### PR TITLE
feat: add Claude Code skills for standard development operations

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,34 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(terraform init:*)",
+      "Bash(terraform validate:*)",
+      "Bash(terraform fmt:*)",
+      "Bash(terraform version:*)",
+      "Bash(terraform plan:*)",
+      "Bash(git checkout:*)",
+      "Bash(git branch:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git fetch:*)",
+      "Bash(git rebase:*)",
+      "Bash(git tag:*)",
+      "Bash(git merge:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh run:*)",
+      "Bash(gh release:*)",
+      "Bash(gh api:*)",
+      "Bash(find aws:*)",
+      "Bash(find gcp:*)",
+      "Bash(find examples:*)",
+      "Bash(ls:*)",
+      "Bash(mkdir:*)",
+      "Bash(go build:*)"
+    ]
+  }
+}

--- a/.claude/skills/add-aws-module/SKILL.md
+++ b/.claude/skills/add-aws-module/SKILL.md
@@ -1,0 +1,128 @@
+# /add-aws-module — Add New AWS Module Skill
+
+Create a new AWS Terraform preset module following all project conventions.
+
+## Trigger
+
+Use when asked to add a new AWS module, create an AWS preset, or scaffold an AWS Terraform module.
+
+## Workflow
+
+### 1. Name the Module
+
+AWS modules use **camelCase** directory names (e.g., `apigateway`, `cloudwatchlogs`, `secretsmanager`).
+
+```
+aws/<modulename>/
+```
+
+### 2. Create main.tf
+
+Every `main.tf` must include:
+
+```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+data "aws_region" "current" {}
+```
+
+Key rules:
+- Use `data.aws_region.current.region` (not `var.region`) for constructing service names
+- If the module wraps a community module, use `source = "terraform-aws-modules/<name>/aws"` with a version pin
+- If the module needs a provider alias (like WAF needing `aws.us_east_1`), add `configuration_aliases` and create a `.validate-skip` marker file
+- Enable encryption, block public access, enforce least-privilege IAM by default
+
+### 3. Create variables.tf
+
+**Required variables** (every preset must declare these — the composition engine always maps them):
+
+```hcl
+variable "project" {
+  description = "Project name"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,61}[a-z0-9]$", var.project))
+    error_message = "Project must be lowercase alphanumeric with hyphens, 3-63 characters."
+  }
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "tags" {
+  description = "Resource tags"
+  type        = map(string)
+  default     = {}
+}
+```
+
+**Validation patterns:**
+- **Null-safe validation:** Always use ternary: `var.x == null ? true : contains([...], var.x)` — Terraform does NOT short-circuit `||`
+- Use `can()`, `regex()`, `cidrnetmask()`, `trimspace()`, `contains()` as appropriate
+- Variables without defaults become required root variables the mapper MUST provide
+
+### 4. Create outputs.tf
+
+Declare outputs used for cross-module wiring:
+
+```hcl
+output "arn" {
+  description = "ARN of the resource"
+  value       = aws_<resource>.<name>.arn
+}
+```
+
+Common wiring outputs: `arn`, `id`, `vpc_id`, `private_subnet_ids`, `security_group_id`, `endpoint`.
+
+### 5. Check Go Embedding
+
+Verify the new file patterns are covered by `zz_embed.go`:
+- `.tf` files: already covered by `aws/*/*.tf`
+- `.tmpl` files: already covered by `aws/*/*.tmpl`
+- New extensions: add a `//go:embed` directive to `zz_embed.go`
+
+### 6. Format and Validate
+
+```bash
+terraform fmt aws/<modulename>/
+cd aws/<modulename> && terraform init -backend=false -input=false && terraform validate
+```
+
+### 7. Verify Go Embed Compiles
+
+```bash
+go build ./...
+```
+
+## Anti-Patterns
+
+- Using `var.region` instead of `data.aws_region.current.region` in service names
+- Using `var.x == null || condition` in validation (will crash on null)
+- Forgetting `project` or `region` variables
+- Leaving variables without defaults unless intentionally required
+- Public access enabled by default
+
+## Checklist
+
+- [ ] Directory: `aws/<camelCaseName>/`
+- [ ] `main.tf` with `required_providers` (AWS >= 6.0, Terraform >= 1.5)
+- [ ] `variables.tf` with `project`, `region`, `tags` variables
+- [ ] `outputs.tf` with wiring outputs
+- [ ] Null-safe validation (ternary pattern)
+- [ ] Security defaults (encryption, no public access)
+- [ ] `terraform fmt` clean
+- [ ] `terraform validate` passes
+- [ ] `go build ./...` succeeds
+- [ ] `.validate-skip` added if using `configuration_aliases`

--- a/.claude/skills/add-example/SKILL.md
+++ b/.claude/skills/add-example/SKILL.md
@@ -1,0 +1,128 @@
+# /add-example — Add Example Stack Skill
+
+Create a new example composition stack that demonstrates how preset modules wire together.
+
+## Trigger
+
+Use when asked to add an example, create a demo stack, or scaffold an example composition.
+
+## Workflow
+
+### 1. Name the Example
+
+Examples live in `examples/<name>/` with descriptive lowercase names (e.g., `webapp`, `dataplatform`, `microservices`).
+
+### 2. Plan the Composition
+
+Decide which preset modules to compose. Review available modules:
+
+```bash
+ls aws/ gcp/
+```
+
+Identify wiring points: which module outputs feed into other module inputs (e.g., `module.vpc.vpc_id` feeds into ALB/RDS/ECS modules).
+
+### 3. Create main.tf
+
+Define module blocks with relative source paths:
+
+```hcl
+module "vpc" {
+  source = "../../aws/vpc"
+
+  project = var.vpc_project
+  region  = var.vpc_region
+  # ... other variables
+}
+
+module "alb" {
+  source = "../../aws/alb"
+
+  project            = var.alb_project
+  region             = var.alb_region
+  vpc_id             = module.vpc.vpc_id
+  public_subnet_ids  = module.vpc.public_subnet_ids
+  # ... other variables
+}
+```
+
+Key rules:
+- Source paths use `../../aws/<module>` or `../../gcp/<module>` (relative to example dir)
+- Variables are namespaced with `<component>_` prefix (e.g., `vpc_project`, `alb_region`)
+- Cross-module wiring: reference outputs from upstream modules
+
+### 4. Create variables.tf
+
+Declare all namespaced variables:
+
+```hcl
+variable "vpc_project" {
+  description = "Project name for VPC"
+  type        = string
+}
+
+variable "vpc_region" {
+  description = "AWS region for VPC"
+  type        = string
+}
+```
+
+Every module's `project` and `region` become `<component>_project` and `<component>_region`.
+
+### 5. Create providers.tf
+
+Configure provider(s) with region:
+
+```hcl
+provider "aws" {
+  region = var.vpc_region
+}
+```
+
+If using `aws/waf`, add the US East 1 alias:
+
+```hcl
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+```
+
+And pass it to the WAF module:
+
+```hcl
+module "waf" {
+  source = "../../aws/waf"
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+  # ...
+}
+```
+
+### 6. Create .auto.tfvars Files
+
+One file per module component with default values:
+
+```hcl
+# vpc.auto.tfvars
+vpc_project = "example"
+vpc_region  = "us-west-2"
+```
+
+### 7. Validate
+
+```bash
+cd examples/<name> && terraform init -backend=false -input=false && terraform validate
+```
+
+## Checklist
+
+- [ ] Directory: `examples/<name>/`
+- [ ] `main.tf` with module blocks using relative source paths
+- [ ] `variables.tf` with namespaced variables (`<component>_<var>`)
+- [ ] `providers.tf` with provider configuration (including aliases if needed)
+- [ ] `.auto.tfvars` files with example values
+- [ ] Cross-module wiring uses output references
+- [ ] `terraform validate` passes

--- a/.claude/skills/add-gcp-module/SKILL.md
+++ b/.claude/skills/add-gcp-module/SKILL.md
@@ -1,0 +1,125 @@
+# /add-gcp-module — Add New GCP Module Skill
+
+Create a new GCP Terraform preset module following all project conventions.
+
+## Trigger
+
+Use when asked to add a new GCP module, create a GCP preset, or scaffold a GCP Terraform module.
+
+## Workflow
+
+### 1. Name the Module
+
+GCP modules use **snake_case** directory names (e.g., `api_gateway`, `cloud_run`, `cloud_sql`).
+
+```
+gcp/<module_name>/
+```
+
+### 2. Create main.tf
+
+Every `main.tf` must include:
+
+```hcl
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+```
+
+Key rules:
+- If using community modules, source from `terraform-google-modules` with version pin
+- Otherwise use direct `google_*` resources
+- If the module needs the `random` provider, add it with `>= 3.5`
+- Enable encryption, enforce least-privilege IAM by default
+
+### 3. Create variables.tf
+
+**Required variables** (every preset must declare these):
+
+```hcl
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project))
+    error_message = "Project ID must be 6-30 characters, lowercase alphanumeric with hyphens."
+  }
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "labels" {
+  description = "Resource labels"
+  type        = map(string)
+  default     = {}
+}
+```
+
+**Validation patterns:**
+- **Null-safe validation:** Always use ternary: `var.x == null ? true : contains([...], var.x)`
+- Use `can()`, `regex()`, `trimspace()`, `contains()` as appropriate
+- Variables without defaults become required root variables
+
+### 4. Create outputs.tf
+
+Declare outputs for cross-module wiring:
+
+```hcl
+output "id" {
+  description = "Resource ID"
+  value       = google_<resource>.<name>.id
+}
+```
+
+Common wiring outputs: `id`, `name`, `self_link`, `network_id`, `ip_address`.
+
+### 5. Check Go Embedding
+
+Verify patterns in `zz_embed.go`:
+- `.tf` files: already covered by `gcp/*/*.tf`
+- `.tmpl` files: **NOT covered** — if adding `.tmpl` files, add `//go:embed gcp/*/*.tmpl` to `zz_embed.go`
+
+### 6. Format and Validate
+
+```bash
+terraform fmt gcp/<module_name>/
+cd gcp/<module_name> && terraform init -backend=false -input=false && terraform validate
+```
+
+### 7. Verify Go Embed Compiles
+
+```bash
+go build ./...
+```
+
+## Anti-Patterns
+
+- Using camelCase directory names (GCP uses snake_case)
+- Using `tags` instead of `labels` (GCP convention)
+- Using `var.x == null || condition` in validation
+- Forgetting `project` or `region` variables
+- Adding `.tmpl` files without updating `zz_embed.go`
+
+## Checklist
+
+- [ ] Directory: `gcp/<snake_case_name>/`
+- [ ] `main.tf` with `required_providers` (Google >= 5.0, Terraform >= 1.0)
+- [ ] `variables.tf` with `project`, `region`, `labels` variables
+- [ ] `outputs.tf` with wiring outputs
+- [ ] Null-safe validation (ternary pattern)
+- [ ] Security defaults (encryption, least-privilege IAM)
+- [ ] `terraform fmt` clean
+- [ ] `terraform validate` passes
+- [ ] `go build ./...` succeeds
+- [ ] `zz_embed.go` updated if `.tmpl` files added

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,0 +1,137 @@
+# /audit — Terraform Module Audit Skill
+
+Systematic audit of Terraform modules for common issues, security gaps, and convention violations.
+
+## Trigger
+
+Use when asked to audit, review, check quality, or scan the codebase for issues.
+
+## Workflow
+
+### 1. Scope the Audit
+
+Determine what to audit. By default, audit everything. Accept scoped variants:
+
+- `audit aws` — AWS modules only
+- `audit gcp` — GCP modules only
+- `audit security` — security-focused scan
+- `audit conventions` — convention compliance only
+- `audit <module>` — single module deep-dive
+
+### 2. Convention Compliance
+
+For each module, check:
+
+| Convention | AWS | GCP |
+|---|---|---|
+| Directory naming | camelCase | snake_case |
+| Has `main.tf` | Required | Required |
+| Has `variables.tf` | Required | Required |
+| Has `outputs.tf` | Required | Required |
+| Has `project` variable | Required | Required |
+| Has `region` variable | Required | Required |
+| Has `tags`/`labels` variable | `tags` | `labels` |
+| Provider version | AWS >= 6.0, TF >= 1.5 | Google >= 5.0, TF >= 1.0 |
+
+```bash
+# Check all modules have required files
+for dir in aws/*/; do
+  for f in main.tf variables.tf outputs.tf; do
+    [ -f "$dir$f" ] || echo "MISSING: $dir$f"
+  done
+done
+```
+
+### 3. Validation Safety
+
+Scan for unsafe null validation patterns:
+
+```bash
+grep -rn 'var\.\w\+ == null ||' aws/ gcp/
+grep -rn 'var\.\w\+ != null &&' aws/ gcp/
+```
+
+These should use the ternary pattern instead:
+- `var.x == null ? true : condition` (not `var.x == null || condition`)
+
+### 4. Security Audit
+
+Check for common security issues:
+
+```bash
+# Public access enabled
+grep -rn 'public_access\|publicly_accessible\|public = true' aws/ gcp/
+
+# Encryption disabled
+grep -rn 'encrypted\s*=\s*false\|encryption\s*=\s*false' aws/ gcp/
+
+# Overly permissive IAM
+grep -rn '"*"\|"\*"' aws/ gcp/ --include="*.tf"
+```
+
+### 5. Region Reference Audit (AWS)
+
+Check for direct `var.region` usage in service name construction (should use `data.aws_region.current.region`):
+
+```bash
+grep -rn 'var\.region' aws/ --include="*.tf" | grep -v 'variables.tf'
+```
+
+### 6. Cross-Module Wiring
+
+Verify outputs match what examples expect:
+
+```bash
+# List all module output references in examples
+grep -rn 'module\.\w\+\.\w\+' examples/ --include="*.tf"
+
+# Cross-reference with actual outputs
+for dir in aws/*/; do
+  module=$(basename "$dir")
+  grep -l "module\.$module\." examples/*/main.tf 2>/dev/null && \
+    echo "--- $module outputs ---" && \
+    grep 'output "' "$dir/outputs.tf"
+done
+```
+
+### 7. Go Embed Coverage
+
+Verify all file patterns are embedded:
+
+```bash
+# Check for file extensions not covered by embed directives
+find aws gcp -type f | grep -v '\.tf$' | grep -v '\.tmpl$' | grep -v '\.terraform' | grep -v '.validate-skip'
+```
+
+### 8. Report
+
+Produce a structured report:
+
+```
+## Audit Report
+
+### Convention Violations
+- <list>
+
+### Security Issues
+- <list>
+
+### Validation Safety
+- <list>
+
+### Wiring Issues
+- <list>
+
+### Recommendations
+- <prioritized list>
+```
+
+## Checklist
+
+- [ ] Convention compliance checked (file structure, naming, required variables)
+- [ ] Null validation patterns scanned
+- [ ] Security defaults verified
+- [ ] Region references audited (AWS)
+- [ ] Cross-module wiring validated
+- [ ] Go embed coverage confirmed
+- [ ] Report produced with findings and recommendations

--- a/.claude/skills/pickup-issue/SKILL.md
+++ b/.claude/skills/pickup-issue/SKILL.md
@@ -1,0 +1,98 @@
+# /pickup-issue — Issue to PR Lifecycle Skill
+
+Take a GitHub issue from assignment through to a merged PR.
+
+## Trigger
+
+Use when asked to pick up an issue, work on issue #N, fix a bug from an issue, or implement a feature from an issue.
+
+## Workflow
+
+### 1. Fetch the Issue
+
+```bash
+gh issue view <number>
+```
+
+Read the issue title, description, labels, and any linked discussion.
+
+### 2. Classify the Change
+
+| Type | Branch prefix | Commit prefix |
+|------|--------------|---------------|
+| Bug fix | `fix/` | `fix:` |
+| New module | `feature/` | `feat:` |
+| Enhancement | `feature/` | `feat:` |
+| Refactor | `refactor/` | `refactor:` |
+| CI/CD | `feature/` | `ci:` |
+| Documentation | `feature/` | `docs:` |
+
+### 3. Create Branch
+
+```bash
+git checkout main && git pull origin main
+git checkout -b <prefix><short-description>
+```
+
+Use a descriptive kebab-case name derived from the issue (e.g., `fix/ec2-capacity-type-validation`).
+
+### 4. Investigate
+
+Read the relevant module files to understand the current state:
+
+- `<module>/main.tf` — resource definitions
+- `<module>/variables.tf` — variable declarations and validations
+- `<module>/outputs.tf` — output declarations
+
+For bug fixes, identify root cause before writing code.
+
+### 5. Implement
+
+Make the code changes. Follow the relevant skill for the type of change:
+
+- Adding a module: follow `/add-aws-module` or `/add-gcp-module`
+- Adding an example: follow `/add-example`
+- Modifying a module: apply the fix directly, respecting all conventions in CLAUDE.md
+
+**Breaking change awareness:**
+- Renaming a variable is breaking (downstream composer namespaces them)
+- Adding a variable without a default is breaking (becomes required root variable)
+- Removing an output is breaking (may be used for cross-module wiring)
+
+### 6. Verify
+
+Follow the `/verify` skill. At minimum, validate the changed module(s) and any examples that reference them.
+
+### 7. Commit
+
+Use conventional commit format referencing the issue:
+
+```bash
+git add <files>
+git commit -m "$(cat <<'EOF'
+<type>: <description>
+
+<optional body explaining why>
+
+Fixes #<N>
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 8. Create PR
+
+Follow the `/pr` skill. Ensure the PR body includes `Fixes #<N>` or `Closes #<N>` to auto-close the issue on merge.
+
+## Checklist
+
+- [ ] Issue fetched and understood
+- [ ] Branch created with correct prefix
+- [ ] Root cause identified (for bugs)
+- [ ] Changes implemented following project conventions
+- [ ] No unintended breaking changes
+- [ ] `/verify` passes
+- [ ] Committed with conventional commit and issue reference
+- [ ] PR created with `Fixes #N` / `Closes #N`
+- [ ] CI passing

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,110 @@
+# /pr — Pull Request Creation Skill
+
+Create a pull request targeting main with proper formatting and verification.
+
+## Trigger
+
+Use when asked to create a PR, open a pull request, submit changes for review, or ship changes.
+
+## Workflow
+
+### 1. Pre-flight Checks
+
+Verify you're on a feature branch (not `main`):
+
+```bash
+git branch --show-current
+```
+
+If on `main`, stop and ask the user to create a feature branch first.
+
+### 2. Run Verification
+
+Follow the `/verify` skill to ensure all modules validate and formatting is clean. Fix any issues before proceeding.
+
+### 3. Stage and Commit
+
+If there are uncommitted changes, stage and commit them using conventional commit format:
+
+- `feat:` — new module or feature
+- `fix:` — bug fix
+- `chore:` — maintenance, deps
+- `ci:` — CI/CD changes
+- `style:` — formatting only
+- `docs:` — documentation
+
+### 4. Determine Base Branch
+
+The base branch is always `main`:
+
+```bash
+git fetch origin main
+```
+
+### 5. Rebase on Base
+
+Rebase the feature branch onto the latest main:
+
+```bash
+git rebase origin/main
+```
+
+If conflicts arise, resolve them and continue.
+
+### 6. Push
+
+Push the branch to the remote:
+
+```bash
+git push -u origin HEAD
+```
+
+### 7. Create PR
+
+Create the PR with a structured body:
+
+```bash
+gh pr create --title "<type>: <short description>" --body "$(cat <<'EOF'
+## Summary
+- <bullet points describing what changed and why>
+
+## Test plan
+- [ ] `terraform fmt -check -recursive` passes
+- [ ] All preset modules validate
+- [ ] All example stacks validate
+- [ ] <additional manual checks if applicable>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Title guidelines:**
+- Use conventional commit prefix: `feat:`, `fix:`, `chore:`, `ci:`, `style:`, `docs:`
+- Keep under 70 characters
+- Describe the outcome, not the process
+
+**Body guidelines:**
+- Summary bullets: what changed and why (not how)
+- Reference issues with `Fixes #N` or `Closes #N` when applicable
+- Test plan should list all verification steps performed
+
+### 8. Verify CI
+
+After PR creation, check that CI passes:
+
+```bash
+gh pr checks
+```
+
+If CI fails, fix the issues, push, and re-check.
+
+## Checklist
+
+- [ ] On a feature branch (not main)
+- [ ] `/verify` passes
+- [ ] All changes committed with conventional commit messages
+- [ ] Rebased on latest main
+- [ ] Pushed to remote
+- [ ] PR created with Summary + Test plan
+- [ ] CI checks passing

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,105 @@
+# /release — Tag and Release Skill
+
+Create a semver-tagged release for the Go module.
+
+## Trigger
+
+Use when asked to cut a release, tag a version, create a release, or publish a new version.
+
+## Workflow
+
+### 1. Determine Version
+
+Check the latest existing tag:
+
+```bash
+git tag --sort=-v:refname | head -5
+```
+
+If no tags exist, start with `v0.1.0`.
+
+Follow semantic versioning:
+- **Patch** (`v0.1.1`): bug fixes, formatting, documentation
+- **Minor** (`v0.2.0`): new modules, new features, non-breaking enhancements
+- **Major** (`v1.0.0` / `v2.0.0`): breaking changes (variable renames, removed outputs, changed defaults)
+
+### 2. Review Changes Since Last Release
+
+```bash
+git log $(git describe --tags --abbrev=0 2>/dev/null || echo "HEAD~20")..HEAD --oneline
+```
+
+Classify each commit to determine the appropriate version bump.
+
+### 3. Verify
+
+Follow the `/verify` skill to ensure everything passes before tagging.
+
+### 4. Verify Go Module
+
+Ensure the Go embed compiles cleanly:
+
+```bash
+go build ./...
+```
+
+### 5. Create the Tag
+
+```bash
+git tag -a v<X.Y.Z> -m "v<X.Y.Z>: <summary of changes>"
+```
+
+### 6. Push the Tag
+
+```bash
+git push origin v<X.Y.Z>
+```
+
+### 7. Create GitHub Release
+
+```bash
+gh release create v<X.Y.Z> --title "v<X.Y.Z>" --notes "$(cat <<'EOF'
+## What's Changed
+
+- <bullet points of notable changes>
+
+## Module Changes
+
+- <new/modified/removed modules>
+
+**Full Changelog**: https://github.com/luthersystems/insideout-terraform-presets/compare/<prev-tag>...v<X.Y.Z>
+EOF
+)"
+```
+
+### 8. Verify Downstream Consumption
+
+After release, the downstream `reliable` repo can update its `go.mod`:
+
+```bash
+go get github.com/luthersystems/insideout-terraform-presets@v<X.Y.Z>
+```
+
+Remind the user to update the downstream dependency.
+
+## Version Decision Guide
+
+| Change Type | Examples | Bump |
+|---|---|---|
+| Bug fix in existing module | Fix validation, wire variable | Patch |
+| New module added | `aws/newservice`, `gcp/new_service` | Minor |
+| New example added | `examples/newstack` | Minor |
+| CI/tooling changes | Workflow updates, Claude skills | Patch |
+| Variable renamed | `instance_type` → `node_type` | Major |
+| Output removed | Removed `vpc_id` output | Major |
+| Default changed (breaking) | Changed default from `null` to `"value"` | Major |
+
+## Checklist
+
+- [ ] Latest tag identified (or starting from v0.1.0)
+- [ ] Changes reviewed and version bump determined
+- [ ] `/verify` passes
+- [ ] `go build ./...` succeeds
+- [ ] Tag created and pushed
+- [ ] GitHub release created with changelog
+- [ ] User reminded to update downstream `go.mod`

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,75 @@
+# /verify — Local CI Gate Skill
+
+Run the same validation pipeline that GitHub Actions runs, locally.
+
+## Trigger
+
+Use when asked to verify, validate, check, or run CI locally — or before creating a PR.
+
+## Workflow
+
+### 1. Format Check
+
+Run the Terraform format check across the entire repo:
+
+```bash
+terraform fmt -check -recursive
+```
+
+If formatting issues are found, fix them:
+
+```bash
+terraform fmt -recursive
+```
+
+### 2. Discover Modules
+
+Find all preset modules, respecting `.validate-skip` markers:
+
+```bash
+find aws gcp -mindepth 1 -maxdepth 1 -type d | sort | while read -r d; do
+  [ -f "$d/.validate-skip" ] && echo "SKIP: $d" && continue
+  echo "$d"
+done
+```
+
+### 3. Validate Preset Modules
+
+For each discovered module (not skipped), run init + validate:
+
+```bash
+cd <module-dir> && terraform init -backend=false -input=false && terraform validate
+```
+
+Run modules in parallel where possible. On failure, record the module and error but continue validating remaining modules.
+
+### 4. Discover and Validate Examples
+
+Find and validate all example stacks:
+
+```bash
+find examples -mindepth 1 -maxdepth 1 -type d | sort | while read -r d; do
+  echo "Validating $d..."
+  (cd "$d" && terraform init -backend=false -input=false && terraform validate)
+done
+```
+
+### 5. Report Results
+
+Summarize: total modules checked, skipped, passed, failed. List any failures with their error messages.
+
+## Quick Mode
+
+If only a single module was changed, validate just that module and any examples that reference it:
+
+```bash
+cd <module-dir> && terraform init -backend=false -input=false && terraform validate
+grep -rl '<module-dir>' examples/*/main.tf | xargs -I{} dirname {} | sort -u
+```
+
+## Checklist
+
+- [ ] `terraform fmt -check -recursive` passes (or issues fixed)
+- [ ] All preset modules validate (excluding `.validate-skip`)
+- [ ] All example stacks validate
+- [ ] Results summarized to user

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # Temporary files
 .tmp/
+
+# Claude Code local settings (keep shared .claude/settings.json)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,3 +80,18 @@ These preset files are embedded at build time into the [reliable](https://github
 - **Required variables:** Every preset should declare `project` and `region` variables — the composer always maps these
 - **Defaults matter:** Variables without defaults become required root variables — the mapper MUST provide values or deploy fails
 - **Wiring outputs:** Outputs used for cross-module wiring (e.g., `vpc_id`, `private_subnet_ids`) must be declared in `outputs.tf`
+
+## Skills
+
+Before starting a task, check if a matching skill exists and follow its workflow exactly. Multiple skills can chain: e.g., `/pickup-issue` uses the relevant add-module skill for implementation, `/verify` before committing, and `/pr` to ship.
+
+| Task | Skill | File |
+|------|-------|------|
+| Run local CI validation | `/verify` | `.claude/skills/verify/SKILL.md` |
+| Create a pull request | `/pr` | `.claude/skills/pr/SKILL.md` |
+| Add a new AWS module | `/add-aws-module` | `.claude/skills/add-aws-module/SKILL.md` |
+| Add a new GCP module | `/add-gcp-module` | `.claude/skills/add-gcp-module/SKILL.md` |
+| Add an example stack | `/add-example` | `.claude/skills/add-example/SKILL.md` |
+| Work on a GitHub issue | `/pickup-issue` | `.claude/skills/pickup-issue/SKILL.md` |
+| Tag and release a version | `/release` | `.claude/skills/release/SKILL.md` |
+| Audit modules for issues | `/audit` | `.claude/skills/audit/SKILL.md` |


### PR DESCRIPTION
## Summary

- Adds 8 Claude Code skill files (`.claude/skills/*/SKILL.md`) covering the full SDLC and routine development operations for this repo
- Adds shared `.claude/settings.json` with pre-approved Bash permissions for terraform, git, gh, and other tools used by skills — eliminates permission prompts during skill execution
- Updates `CLAUDE.md` with a skills discovery table so Claude Code auto-matches tasks to the correct skill
- Updates `.gitignore` to exclude `.claude/settings.local.json` (personal overrides)

### Skills Added

| Skill | Purpose |
|-------|---------|
| `/verify` | Local CI gate — validate all modules + format check (mirrors GitHub Actions) |
| `/pr` | Pull request creation with conventional commits, rebasing, and CI verification |
| `/add-aws-module` | Scaffold new AWS preset modules with all conventions (camelCase, provider >= 6.0, security defaults) |
| `/add-gcp-module` | Scaffold new GCP preset modules with all conventions (snake_case, provider >= 5.0, labels) |
| `/add-example` | Create example composition stacks with cross-module wiring and namespaced variables |
| `/pickup-issue` | Full issue-to-PR lifecycle: fetch issue → classify → branch → implement → verify → PR |
| `/release` | Semver tagging, GitHub release creation, downstream dependency guidance |
| `/audit` | Systematic module audit: conventions, security, null validation, region refs, wiring, embed coverage |

Skills are composable — `/pickup-issue` chains into the relevant add-module skill, `/verify`, and `/pr`. Inspired by the skills structure in [elps#78](https://github.com/luthersystems/elps/pull/78) and [elps#77](https://github.com/luthersystems/elps/pull/77).

## Test plan

- [x] All skill files follow consistent format (title, trigger, workflow, checklist)
- [x] `CLAUDE.md` skills table links to correct file paths
- [x] `.claude/settings.json` covers all Bash commands referenced in skills
- [x] `.gitignore` excludes `.claude/settings.local.json`
- [ ] Verify skills trigger correctly via `/skill-name` in Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)