### PR TITLE
fix: backups module fails with zero rule blocks when no services enabled

### DIFF
--- a/aws/backups/tests/backups.tftest.hcl
+++ b/aws/backups/tests/backups.tftest.hcl
@@ -1,0 +1,69 @@
+mock_provider "aws" {}
+mock_provider "time" {}
+
+# Verify that enabling a single service plans successfully.
+run "backups_single_service_enabled" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.backup_assume
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  variables {
+    project    = "test"
+    region     = "us-east-1"
+    enable_rds = true
+  }
+
+  assert {
+    condition     = aws_backup_plan.this.name == "test-plan"
+    error_message = "Expected backup plan name to be 'test-plan'"
+  }
+}
+
+# Verify that enabling all services plans successfully.
+run "backups_all_services_enabled" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.backup_assume
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  variables {
+    project         = "test"
+    region          = "us-east-1"
+    enable_ec2_ebs  = true
+    enable_rds      = true
+    enable_dynamodb = true
+    enable_s3       = true
+  }
+
+  assert {
+    condition     = aws_backup_plan.this.name == "test-plan"
+    error_message = "Expected backup plan name to be 'test-plan'"
+  }
+}
+
+# Verify that zero services enabled fails the precondition at plan time.
+run "backups_no_services_fails_precondition" {
+  command         = plan
+  expect_failures = [aws_backup_plan.this]
+
+  override_data {
+    target = data.aws_iam_policy_document.backup_assume
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  variables {
+    project = "test"
+    region  = "us-east-1"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `local.any_service_enabled` and a `lifecycle { precondition }` on `aws_backup_plan.this` so the module fails fast at plan time with a clear message instead of a cryptic AWS API error when all four service flags are `false`
- Add `aws/backups/tests/backups.tftest.hcl` with three test cases: single service enabled, all services enabled, and the zero-services precondition failure path

## Test plan

- [x] `terraform validate` passes
- [x] `terraform test` passes all 3 new test cases (single service, all services, zero services)
- [x] Existing cognito tests still pass (no regression)
- [ ] CI passes

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)