### PR TITLE
fix: include placeholder.zip in Go embed for Lambda module

### DIFF
--- a/zz_embed.go
+++ b/zz_embed.go
@@ -2,14 +2,16 @@ package terraformpresets
 
 import "embed"
 
-// Only include the small text files the composer consumes.
-// DO NOT include provider caches, .terraform/*, lockfiles, zips, etc.
+// Include all files the composer consumes: .tf, .tmpl, and binary assets (.zip).
+// DO NOT include provider caches, .terraform/*, or lockfiles.
 // Structure: aws/<module>/*.tf and gcp/<module>/*.tf
 //
 // Note: Go embed requires at least one file to match each pattern.
 // AWS has .tmpl files (bastion/user_data.sh.tmpl), GCP does not yet.
+// AWS has .zip files (lambda/placeholder.zip), GCP does not yet.
 // We use separate embed lines for optional patterns.
 //
 //go:embed aws/*/*.tf gcp/*/*.tf
 //go:embed aws/*/*.tmpl
+//go:embed aws/*/*.zip
 var FS embed.FS


### PR DESCRIPTION
## Summary

- Add `//go:embed aws/*/*.zip` directive to `zz_embed.go` so `aws/lambda/placeholder.zip` is included in the embedded filesystem
- Without this, the composed Lambda module fails at `terraform apply` because the zip file referenced by `aws_lambda_function.this` is missing

## Context

Blocking dependency for [luthersystems/reliable#328](https://github.com/luthersystems/reliable/issues/328). The `reliable` repo already allows `.zip` in its archive walker, but the file was never embedded in the first place.

Fixes #13

## Test plan

- [x] `go build ./...` passes — embed directive compiles with the new pattern
- [x] `terraform fmt -check -recursive` passes
- [ ] CI passes
- [ ] After merge, verify in `reliable` that `GetPresetFiles("aws/lambda")` returns `placeholder.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)