### PR TITLE
fix: resolve EKS addon timeout and add version management

### DIFF
--- a/aws/resource/main.tf
+++ b/aws/resource/main.tf
@@ -22,12 +22,109 @@ module "name" {
 locals {
   cluster_name = "${var.project}-eks"
   common_tags  = merge(module.name.tags, var.tags)
+
+  # ---------------------------------------------------------------------------
+  # Addon version maps — pinned per Kubernetes minor version.
+  # Override any individual addon version via var.addon_*_version.
+  # ---------------------------------------------------------------------------
+  vpc_cni_versions = {
+    "1.28" = "v1.17.1-eksbuild.1"
+    "1.29" = "v1.18.2-eksbuild.1"
+    "1.30" = "v1.18.3-eksbuild.1"
+    "1.31" = "v1.18.3-eksbuild.3"
+    "1.32" = "v1.19.2-eksbuild.1"
+    "1.33" = "v1.19.5-eksbuild.3"
+  }
+
+  kube_proxy_versions = {
+    "1.28" = "v1.28.1-eksbuild.1"
+    "1.29" = "v1.29.0-eksbuild.2"
+    "1.30" = "v1.30.0-eksbuild.3"
+    "1.31" = "v1.31.0-eksbuild.5"
+    "1.32" = "v1.32.0-eksbuild.2"
+    "1.33" = "v1.33.0-eksbuild.2"
+  }
+
+  coredns_versions = {
+    "1.28" = "v1.10.1-eksbuild.4"
+    "1.29" = "v1.11.1-eksbuild.4"
+    "1.30" = "v1.11.1-eksbuild.9"
+    "1.31" = "v1.11.3-eksbuild.1"
+    "1.32" = "v1.11.4-eksbuild.2"
+    "1.33" = "v1.12.1-eksbuild.2"
+  }
+
+  ebs_csi_versions = {
+    "1.28" = "v1.28.0-eksbuild.1"
+    "1.29" = "v1.31.0-eksbuild.1"
+    "1.30" = "v1.31.0-eksbuild.1"
+    "1.31" = "v1.35.0-eksbuild.1"
+    "1.32" = "v1.45.0-eksbuild.2"
+    "1.33" = "v1.45.0-eksbuild.2"
+  }
+
+  # Effective versions: user override takes precedence over version map lookup.
+  effective_vpc_cni_version    = coalesce(var.addon_vpc_cni_version, local.vpc_cni_versions[var.cluster_version])
+  effective_kube_proxy_version = coalesce(var.addon_kube_proxy_version, local.kube_proxy_versions[var.cluster_version])
+  effective_coredns_version    = coalesce(var.addon_coredns_version, local.coredns_versions[var.cluster_version])
+  effective_ebs_csi_version    = coalesce(var.addon_ebs_csi_version, local.ebs_csi_versions[var.cluster_version])
+
+  # EBS CSI driver configuration values.
+  ebs_csi_configuration_values = var.enable_ebs_csi_volume_modification ? jsonencode({
+    controller = {
+      volumeModificationFeature = { enabled = true }
+    }
+  }) : null
+
+  # ---------------------------------------------------------------------------
+  # Addon map — built conditionally so toggles actually remove addons.
+  # Pod identity for EBS CSI is declared inline to fix ordering: the upstream
+  # module creates the association BEFORE the addon, ensuring IAM permissions
+  # are in place when the driver pods start.
+  # ---------------------------------------------------------------------------
+  addons = merge(
+    {
+      vpc-cni = {
+        addon_version  = local.effective_vpc_cni_version
+        before_compute = true
+        most_recent    = false
+      }
+      eks-pod-identity-agent = {
+        before_compute = true
+      }
+    },
+    var.enable_kube_proxy ? {
+      kube-proxy = {
+        addon_version = local.effective_kube_proxy_version
+        most_recent   = false
+      }
+    } : {},
+    var.enable_coredns ? {
+      coredns = {
+        addon_version = local.effective_coredns_version
+        most_recent   = false
+      }
+    } : {},
+    var.enable_ebs_csi_driver ? {
+      aws-ebs-csi-driver = {
+        addon_version        = local.effective_ebs_csi_version
+        most_recent          = false
+        configuration_values = local.ebs_csi_configuration_values
+        pod_identity_association = [{
+          role_arn        = aws_iam_role.ebs_csi[0].arn
+          service_account = "ebs-csi-controller-sa"
+        }]
+      }
+    } : {},
+  )
 }
 
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 data "aws_iam_policy_document" "ebs_csi_pod_identity_trust" {
+  count = var.enable_ebs_csi_driver ? 1 : 0
+
   statement {
     effect = "Allow"
 
@@ -58,13 +155,15 @@ data "aws_iam_policy_document" "ebs_csi_pod_identity_trust" {
 }
 
 resource "aws_iam_role" "ebs_csi" {
+  count              = var.enable_ebs_csi_driver ? 1 : 0
   name               = "${local.cluster_name}-ebs-csi"
-  assume_role_policy = data.aws_iam_policy_document.ebs_csi_pod_identity_trust.json
+  assume_role_policy = data.aws_iam_policy_document.ebs_csi_pod_identity_trust[0].json
   tags               = local.common_tags
 }
 
 resource "aws_iam_role_policy_attachment" "ebs_csi" {
-  role       = aws_iam_role.ebs_csi.name
+  count      = var.enable_ebs_csi_driver ? 1 : 0
+  role       = aws_iam_role.ebs_csi[0].name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
 }
 
@@ -75,13 +174,9 @@ module "eks" {
   name               = local.cluster_name
   kubernetes_version = var.cluster_version
 
-  addons = {
-    vpc-cni                = { before_compute = true }
-    eks-pod-identity-agent = { before_compute = true }
-    coredns                = {}
-    kube-proxy             = {}
-    aws-ebs-csi-driver     = {}
-  }
+  addons = local.addons
+
+  addons_timeouts = var.addons_timeouts
 
   endpoint_public_access  = var.eks_public_control_plane
   endpoint_private_access = true
@@ -94,14 +189,5 @@ module "eks" {
 
   enable_cluster_creator_admin_permissions = true
 
-  # NOTE: No eks_managed_node_groups here anymore.
   tags = local.common_tags
-}
-
-resource "aws_eks_pod_identity_association" "ebs_csi" {
-  cluster_name    = module.eks.cluster_name
-  namespace       = "kube-system"
-  service_account = "ebs-csi-controller-sa"
-  role_arn        = aws_iam_role.ebs_csi.arn
-  depends_on      = [module.eks]
 }

--- a/aws/resource/outputs.tf
+++ b/aws/resource/outputs.tf
@@ -43,3 +43,8 @@ output "cluster_arn" {
   description = "EKS cluster ARN"
   value       = module.eks.cluster_arn
 }
+
+output "ebs_csi_role_arn" {
+  description = "IAM role ARN for the EBS CSI driver"
+  value       = var.enable_ebs_csi_driver ? aws_iam_role.ebs_csi[0].arn : null
+}

--- a/aws/resource/variables.tf
+++ b/aws/resource/variables.tf
@@ -94,3 +94,73 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+# ---------------------------------------------------------------------------
+# Addon toggles
+# ---------------------------------------------------------------------------
+
+variable "enable_coredns" {
+  description = "Whether to install the CoreDNS addon"
+  type        = bool
+  default     = true
+}
+
+variable "enable_kube_proxy" {
+  description = "Whether to install the kube-proxy addon"
+  type        = bool
+  default     = true
+}
+
+variable "enable_ebs_csi_driver" {
+  description = "Whether to install the EBS CSI driver addon"
+  type        = bool
+  default     = true
+}
+
+variable "enable_ebs_csi_volume_modification" {
+  description = "Enable the EBS CSI volume modification feature on the controller"
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------
+# Addon version overrides (null = use built-in version map for cluster_version)
+# ---------------------------------------------------------------------------
+
+variable "addon_vpc_cni_version" {
+  description = "Override VPC CNI addon version (null = auto-select for cluster_version)"
+  type        = string
+  default     = null
+}
+
+variable "addon_kube_proxy_version" {
+  description = "Override kube-proxy addon version (null = auto-select for cluster_version)"
+  type        = string
+  default     = null
+}
+
+variable "addon_coredns_version" {
+  description = "Override CoreDNS addon version (null = auto-select for cluster_version)"
+  type        = string
+  default     = null
+}
+
+variable "addon_ebs_csi_version" {
+  description = "Override EBS CSI driver addon version (null = auto-select for cluster_version)"
+  type        = string
+  default     = null
+}
+
+# ---------------------------------------------------------------------------
+# Addon timeouts
+# ---------------------------------------------------------------------------
+
+variable "addons_timeouts" {
+  description = "Timeout configuration for EKS addon create/update/delete operations"
+  type = object({
+    create = optional(string)
+    update = optional(string)
+    delete = optional(string)
+  })
+  default = {}
+}


### PR DESCRIPTION
## Summary
- **Fix pod identity ordering bug**: move EBS CSI pod identity association inline into the addon config so IAM permissions are established *before* the driver starts (root cause of #18 timeout)
- **Pin addon versions**: add per-Kubernetes-version maps (1.28–1.33) for vpc-cni, kube-proxy, coredns, and ebs-csi-driver instead of `most_recent = true`
- **Add addon toggles & overrides**: new variables to enable/disable individual addons, override versions, configure timeouts, and enable EBS CSI volume modification

## Test plan
- [x] `terraform fmt -check -recursive` — passes
- [x] All 51 preset modules validate (1 skipped: `aws/waf`)
- [x] All 11 example stacks validate
- [ ] Deploy to staging and verify EBS CSI driver starts without timeout

Closes #18

---
*Local tests passed. Security review completed (IAM policy scoped to cluster ARN + account, least-privilege EBS CSI policy only).*

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>