### PR TITLE
fix: create default security group for Lambda VPC access

### DIFF
--- a/aws/lambda/outputs.tf
+++ b/aws/lambda/outputs.tf
@@ -1,0 +1,24 @@
+output "function_name" {
+  value       = aws_lambda_function.this.function_name
+  description = "Lambda function name"
+}
+
+output "function_arn" {
+  value       = aws_lambda_function.this.arn
+  description = "Lambda function ARN"
+}
+
+output "invoke_arn" {
+  value       = aws_lambda_function.this.invoke_arn
+  description = "Lambda invoke ARN (for API Gateway integration)"
+}
+
+output "role_arn" {
+  value       = aws_iam_role.lambda_exec.arn
+  description = "Lambda execution role ARN"
+}
+
+output "security_group_id" {
+  value       = local.create_default_sg ? aws_security_group.lambda[0].id : null
+  description = "Default Lambda security group ID (null when security_group_ids provided or VPC disabled)"
+}

--- a/aws/lambda/tests/lambda.tftest.hcl
+++ b/aws/lambda/tests/lambda.tftest.hcl
@@ -44,4 +44,34 @@ run "lambda_with_vpc" {
     condition     = length(aws_iam_role_policy_attachment.lambda_vpc) == 1
     error_message = "Expected one VPC policy attachment when enable_vpc is true"
   }
+
+  assert {
+    condition     = length(aws_security_group.lambda) == 0
+    error_message = "Expected no default security group when security_group_ids provided"
+  }
+}
+
+# Verify that a default security group is created when enable_vpc is true
+# and no security_group_ids are provided.
+run "lambda_with_vpc_default_sg" {
+  command = plan
+
+  variables {
+    project     = "test"
+    region      = "us-east-1"
+    environment = "test"
+    enable_vpc  = true
+    vpc_id      = "vpc-12345"
+    subnet_ids  = ["subnet-aaa", "subnet-bbb"]
+  }
+
+  assert {
+    condition     = length(aws_security_group.lambda) == 1
+    error_message = "Expected a default security group when enable_vpc is true and no security_group_ids"
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.lambda_vpc) == 1
+    error_message = "Expected VPC policy attachment when enable_vpc is true"
+  }
 }

--- a/aws/lambda/variables.tf
+++ b/aws/lambda/variables.tf
@@ -50,19 +50,23 @@ variable "enable_vpc" {
 }
 
 variable "vpc_id" {
-  description = "Optional VPC ID for Lambda VPC access"
+  description = "VPC ID for Lambda VPC access (required when enable_vpc is true)"
   type        = string
   default     = null
+  validation {
+    condition     = var.vpc_id == null ? true : length(trimspace(var.vpc_id)) > 0
+    error_message = "vpc_id must be a non-empty string when provided."
+  }
 }
 
 variable "subnet_ids" {
-  description = "Subnet IDs for VPC access"
+  description = "Subnet IDs for VPC access (required when enable_vpc is true)"
   type        = list(string)
   default     = []
 }
 
 variable "security_group_ids" {
-  description = "Security Group IDs for VPC access"
+  description = "Security Group IDs for VPC access. When empty and enable_vpc is true, a default security group with egress-all is created automatically."
   type        = list(string)
   default     = []
 }

--- a/examples/cargofit/main.tf
+++ b/examples/cargofit/main.tf
@@ -6,31 +6,29 @@ module "vpc" {
 }
 
 module "resource" {
-  source             = "../../aws/lambda"
-  enable_vpc         = true
-  subnet_ids         = module.vpc.private_subnet_ids
-  security_group_ids = []
-  vpc_id             = module.vpc.vpc_id
-  region             = var.resource_region
-  runtime            = var.resource_runtime
-  timeout            = var.resource_timeout
-  memory_size        = var.resource_memory_size
-  project            = var.resource_project
-  environment        = var.environment
+  source      = "../../aws/lambda"
+  enable_vpc  = true
+  subnet_ids  = module.vpc.private_subnet_ids
+  vpc_id      = module.vpc.vpc_id
+  region      = var.resource_region
+  runtime     = var.resource_runtime
+  timeout     = var.resource_timeout
+  memory_size = var.resource_memory_size
+  project     = var.resource_project
+  environment = var.environment
 }
 
 module "lambda" {
-  source             = "../../aws/lambda"
-  enable_vpc         = true
-  vpc_id             = module.vpc.vpc_id
-  subnet_ids         = module.vpc.private_subnet_ids
-  security_group_ids = []
-  memory_size        = var.lambda_memory_size
-  project            = var.lambda_project
-  environment        = var.environment
-  region             = var.lambda_region
-  runtime            = var.lambda_runtime
-  timeout            = var.lambda_timeout
+  source      = "../../aws/lambda"
+  enable_vpc  = true
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.private_subnet_ids
+  memory_size = var.lambda_memory_size
+  project     = var.lambda_project
+  environment = var.environment
+  region      = var.lambda_region
+  runtime     = var.lambda_runtime
+  timeout     = var.lambda_timeout
 }
 
 module "ec2" {

--- a/examples/edubot/main.tf
+++ b/examples/edubot/main.tf
@@ -6,15 +6,14 @@ module "vpc" {
 }
 
 module "lambda" {
-  source             = "../../aws/lambda"
-  enable_vpc         = true
-  vpc_id             = module.vpc.vpc_id
-  subnet_ids         = module.vpc.private_subnet_ids
-  security_group_ids = []
-  project            = var.lambda_project
-  region             = var.lambda_region
-  environment        = var.environment
-  runtime            = var.lambda_runtime
+  source      = "../../aws/lambda"
+  enable_vpc  = true
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.private_subnet_ids
+  project     = var.lambda_project
+  region      = var.lambda_region
+  environment = var.environment
+  runtime     = var.lambda_runtime
 }
 
 module "alb" {

--- a/examples/gamestudio/main.tf
+++ b/examples/gamestudio/main.tf
@@ -6,17 +6,16 @@ module "vpc" {
 }
 
 module "lambda" {
-  source             = "../../aws/lambda"
-  enable_vpc         = true
-  vpc_id             = module.vpc.vpc_id
-  subnet_ids         = module.vpc.private_subnet_ids
-  security_group_ids = []
-  memory_size        = var.lambda_memory_size
-  project            = var.lambda_project
-  environment        = var.environment
-  region             = var.lambda_region
-  runtime            = var.lambda_runtime
-  timeout            = var.lambda_timeout
+  source      = "../../aws/lambda"
+  enable_vpc  = true
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.private_subnet_ids
+  memory_size = var.lambda_memory_size
+  project     = var.lambda_project
+  environment = var.environment
+  region      = var.lambda_region
+  runtime     = var.lambda_runtime
+  timeout     = var.lambda_timeout
 }
 
 module "s3" {

--- a/examples/guestbook/main.tf
+++ b/examples/guestbook/main.tf
@@ -6,15 +6,14 @@ module "vpc" {
 }
 
 module "lambda" {
-  source             = "../../aws/lambda"
-  enable_vpc         = true
-  security_group_ids = []
-  vpc_id             = module.vpc.vpc_id
-  subnet_ids         = module.vpc.private_subnet_ids
-  project            = var.lambda_project
-  environment        = var.environment
-  region             = var.lambda_region
-  runtime            = var.lambda_runtime
+  source      = "../../aws/lambda"
+  enable_vpc  = true
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.private_subnet_ids
+  project     = var.lambda_project
+  environment = var.environment
+  region      = var.lambda_region
+  runtime     = var.lambda_runtime
 }
 
 module "alb" {

--- a/examples/inboundfund-tf/main.tf
+++ b/examples/inboundfund-tf/main.tf
@@ -6,15 +6,14 @@ module "vpc" {
 }
 
 module "lambda" {
-  source             = "../../aws/lambda"
-  enable_vpc         = true
-  vpc_id             = module.vpc.vpc_id
-  subnet_ids         = module.vpc.private_subnet_ids
-  security_group_ids = []
-  project            = var.lambda_project
-  environment        = var.environment
-  region             = var.lambda_region
-  runtime            = var.lambda_runtime
+  source      = "../../aws/lambda"
+  enable_vpc  = true
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.private_subnet_ids
+  project     = var.lambda_project
+  environment = var.environment
+  region      = var.lambda_region
+  runtime     = var.lambda_runtime
 }
 
 module "s3" {

--- a/examples/localbook/main.tf
+++ b/examples/localbook/main.tf
@@ -6,17 +6,16 @@ module "vpc" {
 }
 
 module "lambda" {
-  source             = "../../aws/lambda"
-  enable_vpc         = true
-  vpc_id             = module.vpc.vpc_id
-  subnet_ids         = module.vpc.private_subnet_ids
-  security_group_ids = []
-  region             = var.lambda_region
-  runtime            = var.lambda_runtime
-  timeout            = var.lambda_timeout
-  memory_size        = var.lambda_memory_size
-  project            = var.lambda_project
-  environment        = var.environment
+  source      = "../../aws/lambda"
+  enable_vpc  = true
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.private_subnet_ids
+  region      = var.lambda_region
+  runtime     = var.lambda_runtime
+  timeout     = var.lambda_timeout
+  memory_size = var.lambda_memory_size
+  project     = var.lambda_project
+  environment = var.environment
 }
 
 module "alb" {

--- a/examples/locallink/main.tf
+++ b/examples/locallink/main.tf
@@ -6,15 +6,14 @@ module "vpc" {
 }
 
 module "lambda" {
-  source             = "../../aws/lambda"
-  enable_vpc         = true
-  subnet_ids         = module.vpc.private_subnet_ids
-  security_group_ids = []
-  vpc_id             = module.vpc.vpc_id
-  project            = var.lambda_project
-  environment        = var.environment
-  region             = var.lambda_region
-  runtime            = var.lambda_runtime
+  source      = "../../aws/lambda"
+  enable_vpc  = true
+  subnet_ids  = module.vpc.private_subnet_ids
+  vpc_id      = module.vpc.vpc_id
+  project     = var.lambda_project
+  environment = var.environment
+  region      = var.lambda_region
+  runtime     = var.lambda_runtime
 }
 
 module "alb" {

--- a/examples/revisionapp/main.tf
+++ b/examples/revisionapp/main.tf
@@ -17,15 +17,14 @@ module "resource" {
 }
 
 module "lambda" {
-  source             = "../../aws/lambda"
-  enable_vpc         = true
-  vpc_id             = module.vpc.vpc_id
-  subnet_ids         = module.vpc.private_subnet_ids
-  security_group_ids = []
-  project            = var.lambda_project
-  environment        = var.environment
-  region             = var.lambda_region
-  runtime            = var.lambda_runtime
+  source      = "../../aws/lambda"
+  enable_vpc  = true
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.private_subnet_ids
+  project     = var.lambda_project
+  environment = var.environment
+  region      = var.lambda_region
+  runtime     = var.lambda_runtime
 }
 
 module "ec2" {


### PR DESCRIPTION
## Summary

- **Root cause:** AWS Lambda requires `subnet_ids` and `security_group_ids` to both have values or both be empty. The Lambda module allowed `enable_vpc=true` with `security_group_ids=[]`, causing `CreateFunction` to fail with `SubnetIds and SecurityIds must coexist or be both empty list`.
- **Fix:** When `enable_vpc=true` and no `security_group_ids` are provided, the module now auto-creates a default security group with egress-all access — matching the pattern used by `rds`, `opensearch`, `bastion`, `ec2`, and `elasticache` modules. User-provided `security_group_ids` still take precedence.
- Adds `outputs.tf` exporting `function_name`, `function_arn`, `invoke_arn`, `role_arn`, `security_group_id`
- Adds `vpc_id` validation
- Removes `security_group_ids=[]` from all 8 affected examples (no longer needed)
- Adds test case for auto-created security group scenario

Fixes luthersystems/reliable#349

## Test plan

- [x] `terraform validate` passes for `aws/lambda` module
- [x] `terraform test` passes (3/3: without VPC, with VPC + explicit SGs, with VPC + default SG)
- [x] All 51 preset modules validate (1 skipped: waf)
- [x] All 11 example stacks validate
- [x] `terraform fmt -check -recursive` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)