### PR TITLE
fix: remove redundant base64encode on EC2 user_data

### DIFF
--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -118,7 +118,7 @@ resource "aws_instance" "this" {
   iam_instance_profile        = aws_iam_instance_profile.this.name
   key_name                    = var.ssh_public_key != "" ? aws_key_pair.this[0].key_name : var.key_name
 
-  user_data = var.user_data != "" ? base64encode(var.user_data) : null
+  user_data = var.user_data != "" ? var.user_data : null
 
   metadata_options {
     http_tokens = "required"

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -88,7 +88,7 @@ variable "associate_public_ip" {
 }
 
 variable "user_data" {
-  description = "User data script to run on instance launch (plain text, will be base64-encoded)"
+  description = "User data script to run on instance launch (plain text, provider handles encoding)"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary
- Remove manual `base64encode()` on `var.user_data` in EC2 module — AWS provider >= 6.0 handles encoding automatically
- Update variable description to reflect this

The `base64encode()` was triggering a Terraform warning on every apply:
```
Warning: Value is base64 encoded. If you want to use base64 encoding,
please use the user_data_base64 argument.
```

Aligns with how the bastion module already handles user_data (passes plain text directly).

## Test plan
- [ ] `terraform plan` on an EC2 stack with `user_data` set — no warning
- [ ] Existing deploys unaffected (user_data value is the same, just encoded by provider instead of manually)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>