### PR TITLE
feat: support Ubuntu AMI selection for EC2 instances

### DIFF
--- a/aws/ec2/outputs.tf
+++ b/aws/ec2/outputs.tf
@@ -20,5 +20,5 @@ output "security_group_id" {
 
 output "ssh_command" {
   description = "SSH command to connect to the instance"
-  value       = var.associate_public_ip ? "ssh ubuntu@${aws_instance.this.public_ip}" : null
+  value       = var.associate_public_ip ? "ssh ${var.os_type == "ubuntu" ? "ubuntu" : "ec2-user"}@${aws_instance.this.public_ip}" : null
 }

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -54,9 +54,19 @@ variable "instance_type" {
 }
 
 variable "ami_id" {
-  description = "Specific AMI ID to use. If null, the latest Amazon Linux 2023 AMI for the given arch is selected."
+  description = "Specific AMI ID to use. If null, an AMI is selected automatically based on os_type and arch."
   type        = string
   default     = null
+}
+
+variable "os_type" {
+  description = "Operating system for AMI selection when ami_id is null"
+  type        = string
+  default     = "ubuntu"
+  validation {
+    condition     = contains(["amazon-linux", "ubuntu"], var.os_type)
+    error_message = "os_type must be one of: amazon-linux, ubuntu."
+  }
 }
 
 variable "arch" {


### PR DESCRIPTION
## Summary

- Add `os_type` variable (`"ubuntu"` | `"amazon-linux"`, default `"ubuntu"`) for automatic AMI selection when `ami_id` is null
- Add Ubuntu 24.04 LTS (Noble) AMI data source from Canonical, with arch-aware naming (`amd64` / `arm64`)
- Update `ssh_command` output to use correct default username per OS (`ubuntu` vs `ec2-user`)
- Amazon Linux 2023 AMI lookup is now conditional on `os_type = "amazon-linux"` (was unconditional)

## Downstream changes needed

Once merged, the `reliable` repo should:
1. Pass `os_type = "ubuntu"` (or rely on the new default) in the EC2 variable mapper
2. Update the preset ref to the new version

See: luthersystems/reliable#356

Fixes #26

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform validate` passes on `aws/ec2` module
- [x] `terraform validate` passes on `examples/openclaw` (references `aws/ec2`)
- [ ] CI validation workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)