### PR TITLE
feat: add root_volume_size variable for EC2 disk size

### DIFF
--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -151,6 +151,13 @@ resource "aws_instance" "this" {
     }
   }
 
+  root_block_device {
+    volume_size           = var.root_volume_size
+    volume_type           = "gp3"
+    delete_on_termination = true
+    encrypted             = true
+  }
+
   metadata_options {
     http_tokens = "required"
   }

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -129,6 +129,16 @@ variable "ingress_cidr_blocks" {
   }
 }
 
+variable "root_volume_size" {
+  description = "Root EBS volume size in GB"
+  type        = number
+  default     = 32
+  validation {
+    condition     = var.root_volume_size >= 8 && var.root_volume_size <= 16384
+    error_message = "root_volume_size must be between 8 and 16384 GB."
+  }
+}
+
 variable "tags" {
   description = "Additional AWS tags applied to created resources"
   type        = map(string)


### PR DESCRIPTION
## Summary

PR #29 was accidentally merged into the feature branch instead of `main`. This PR brings the `root_volume_size` changes to `main`.

- Adds `root_volume_size` variable (default 32 GB, range 8-16384 GB)
- Adds `root_block_device` block with gp3 volume type, encryption enabled, delete-on-termination

Ref: #28