### PR TITLE
chore: bump luthername to v55.15.0 across all AWS modules

### DIFF
--- a/aws/alb/main.tf
+++ b/aws/alb/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/apigateway/main.tf
+++ b/aws/apigateway/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/backups/main.tf
+++ b/aws/backups/main.tf
@@ -13,7 +13,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/bastion/main.tf
+++ b/aws/bastion/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/bedrock/main.tf
+++ b/aws/bedrock/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/cloudfront/main.tf
+++ b/aws/cloudfront/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/cloudwatchlogs/main.tf
+++ b/aws/cloudwatchlogs/main.tf
@@ -18,7 +18,7 @@ resource "random_id" "suffix" {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/cloudwatchmonitoring/main.tf
+++ b/aws/cloudwatchmonitoring/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/cognito/main.tf
+++ b/aws/cognito/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/dynamodb/main.tf
+++ b/aws/dynamodb/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/eks_nodegroup/main.tf
+++ b/aws/eks_nodegroup/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/elasticache/main.tf
+++ b/aws/elasticache/main.tf
@@ -18,7 +18,7 @@ resource "random_id" "suffix" {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/kms/main.tf
+++ b/aws/kms/main.tf
@@ -18,7 +18,7 @@ resource "random_id" "suffix" {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/lambda/main.tf
+++ b/aws/lambda/main.tf
@@ -18,7 +18,7 @@ resource "random_id" "suffix" {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/msk/main.tf
+++ b/aws/msk/main.tf
@@ -18,7 +18,7 @@ resource "random_id" "suffix" {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -13,7 +13,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/resource/main.tf
+++ b/aws/resource/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/s3/main.tf
+++ b/aws/s3/main.tf
@@ -13,7 +13,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/secretsmanager/main.tf
+++ b/aws/secretsmanager/main.tf
@@ -18,7 +18,7 @@ resource "random_id" "suffix" {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/sqs/main.tf
+++ b/aws/sqs/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment

--- a/aws/waf/main.tf
+++ b/aws/waf/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 module "name" {
-  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.13.4"
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
   luther_project = var.project
   aws_region     = var.region
   luther_env     = var.environment


### PR DESCRIPTION
## Summary
- Upgrade all 24 AWS modules from tf-modules v55.13.4 to v55.15.0
- This version adds the optional `max_length` variable for name truncation (luthersystems/tf-modules#56)
- No functional changes — `max_length` defaults to `0` (no limit), so existing behavior is preserved

This was part of PR #37 but was pushed after the merge, so it didn't make it in.

## Test plan
- [ ] CI validates all modules + examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)