### PR TITLE
feat: add addressFamily param to ec2_instance_connect_url output

### DIFF
--- a/aws/ec2/outputs.tf
+++ b/aws/ec2/outputs.tf
@@ -31,6 +31,6 @@ output "region" {
 output "ec2_instance_connect_url" {
   description = "AWS Console URL for EC2 Instance Connect browser terminal"
   value = var.associate_public_ip ? (
-    "https://${var.region}.console.aws.amazon.com/ec2-instance-connect/ssh?connType=standard&instanceId=${aws_instance.this.id}&osUser=${var.os_type == "ubuntu" ? "ubuntu" : "ec2-user"}&region=${var.region}&sshPort=22"
+    "https://${var.region}.console.aws.amazon.com/ec2-instance-connect/ssh?connType=standard&instanceId=${aws_instance.this.id}&osUser=${var.os_type == "ubuntu" ? "ubuntu" : "ec2-user"}&region=${var.region}&sshPort=22&addressFamily=${var.ec2_instance_connect_address_family}"
   ) : null
 }

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -145,6 +145,16 @@ variable "enable_instance_connect" {
   default     = false
 }
 
+variable "ec2_instance_connect_address_family" {
+  description = "Address family for EC2 Instance Connect URL (ipv4 or ipv6)"
+  type        = string
+  default     = "ipv4"
+  validation {
+    condition     = contains(["ipv4", "ipv6"], var.ec2_instance_connect_address_family)
+    error_message = "ec2_instance_connect_address_family must be one of: ipv4, ipv6."
+  }
+}
+
 variable "tags" {
   description = "Additional AWS tags applied to created resources"
   type        = map(string)


### PR DESCRIPTION
## Summary
- Adds `ec2_instance_connect_address_family` variable to `aws/ec2` (default: `ipv4`, validates `ipv4`/`ipv6`)
- Appends `&addressFamily=<value>` to the `ec2_instance_connect_url` output
- Prevents connection failures on dual-stack instances where the console defaults to IPv6 but security groups only allow IPv4

Fixes #39

## Test plan
- [ ] CI validates `aws/ec2` module passes `terraform validate`
- [ ] Verify default behavior unchanged (ipv4 appended to URL)
- [ ] Verify `ipv6` can be set for dual-stack instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)