### PR TITLE
feat: add inspector IAM role (AWS) and service account (GCP) modules

### DIFF
--- a/aws/inspector/main.tf
+++ b/aws/inspector/main.tf
@@ -1,0 +1,53 @@
+# Inspector IAM Role
+# Creates an IAM role that the InsideOut inspector pipeline assumes
+# to perform read-only inspection of AWS resources.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+module "name" {
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
+  luther_project = var.project
+  aws_region     = var.region
+  luther_env     = var.environment
+  org_name       = "luthersystems"
+  component      = "insideout"
+  subcomponent   = "inspector"
+  resource       = "inspector"
+}
+
+# -----------------------------------------------------------------------------
+# Trust policy: allows the Terraform SA role to assume this inspector role
+# -----------------------------------------------------------------------------
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.terraform_sa_role_arn]
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Inspector IAM Role
+# -----------------------------------------------------------------------------
+resource "aws_iam_role" "inspector" {
+  name               = "insideout-inspector-${var.insideout_project_id}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  tags               = merge(module.name.tags, var.tags)
+}
+
+resource "aws_iam_role_policy_attachment" "readonly" {
+  role       = aws_iam_role.inspector.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}

--- a/aws/inspector/outputs.tf
+++ b/aws/inspector/outputs.tf
@@ -1,0 +1,9 @@
+output "role_arn" {
+  description = "Inspector IAM role ARN"
+  value       = aws_iam_role.inspector.arn
+}
+
+output "role_name" {
+  description = "Inspector IAM role name"
+  value       = aws_iam_role.inspector.name
+}

--- a/aws/inspector/variables.tf
+++ b/aws/inspector/variables.tf
@@ -1,0 +1,47 @@
+variable "project" {
+  description = "Name prefix for resources"
+  type        = string
+  default     = "demo"
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g. production, staging, sandbox)"
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.environment)) > 0
+    error_message = "environment must be a non-empty string."
+  }
+}
+
+variable "insideout_project_id" {
+  description = "InsideOut project UUID used to construct the deterministic role name (e.g. 78476478-06ca-4f4b-a325-3128a966df42)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", var.insideout_project_id))
+    error_message = "insideout_project_id must be a valid UUID."
+  }
+}
+
+variable "terraform_sa_role_arn" {
+  description = "ARN of the Terraform service account role trusted to assume this inspector role"
+  type        = string
+
+  validation {
+    condition     = can(regex("^arn:aws:iam::", var.terraform_sa_role_arn))
+    error_message = "terraform_sa_role_arn must be a valid IAM role ARN."
+  }
+}
+
+variable "tags" {
+  description = "Extra resource tags"
+  type        = map(string)
+  default     = {}
+}

--- a/gcp/inspector/main.tf
+++ b/gcp/inspector/main.tf
@@ -1,0 +1,32 @@
+# Inspector Service Account
+# Creates a GCP service account that the InsideOut inspector pipeline
+# uses to perform read-only inspection of GCP resources.
+
+# -----------------------------------------------------------------------------
+# Inspector Service Account
+# -----------------------------------------------------------------------------
+resource "google_service_account" "inspector" {
+  project      = var.project
+  account_id   = "insideout-inspector-${var.short_project_id}"
+  display_name = "InsideOut Inspector (${var.short_project_id})"
+}
+
+# -----------------------------------------------------------------------------
+# Viewer roles for the inspector SA at project level
+# -----------------------------------------------------------------------------
+resource "google_project_iam_member" "inspector" {
+  for_each = toset(var.inspector_roles)
+
+  project = var.project
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.inspector.email}"
+}
+
+# -----------------------------------------------------------------------------
+# Allow the deployment SA to generate access tokens for the inspector SA
+# -----------------------------------------------------------------------------
+resource "google_service_account_iam_member" "token_creator" {
+  service_account_id = google_service_account.inspector.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${var.deployment_sa_email}"
+}

--- a/gcp/inspector/outputs.tf
+++ b/gcp/inspector/outputs.tf
@@ -1,0 +1,9 @@
+output "service_account_email" {
+  description = "Inspector service account email"
+  value       = google_service_account.inspector.email
+}
+
+output "service_account_id" {
+  description = "Inspector service account ID"
+  value       = google_service_account.inspector.id
+}

--- a/gcp/inspector/variables.tf
+++ b/gcp/inspector/variables.tf
@@ -1,0 +1,70 @@
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g. production, staging, sandbox)"
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.environment)) > 0
+    error_message = "environment must be a non-empty string."
+  }
+}
+
+variable "short_project_id" {
+  description = "Short InsideOut project ID (first segment of UUID, e.g. 78476478) used for SA naming"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{8}$", var.short_project_id))
+    error_message = "short_project_id must be an 8-character hex string (first segment of a UUID)."
+  }
+}
+
+variable "deployment_sa_email" {
+  description = "Deployment service account email that needs token creator permission on the inspector SA"
+  type        = string
+
+  validation {
+    condition     = can(regex("@.*\\.iam\\.gserviceaccount\\.com$", var.deployment_sa_email))
+    error_message = "deployment_sa_email must be a valid GCP service account email."
+  }
+}
+
+variable "inspector_roles" {
+  description = "Viewer roles to grant to the inspector service account"
+  type        = list(string)
+  default = [
+    "roles/compute.viewer",
+    "roles/container.viewer",
+    "roles/run.viewer",
+    "roles/cloudsql.viewer",
+    "roles/storage.objectViewer",
+    "roles/cloudkms.viewer",
+    "roles/secretmanager.viewer",
+    "roles/pubsub.viewer",
+    "roles/logging.viewer",
+    "roles/datastore.viewer",
+    "roles/monitoring.viewer",
+    "roles/iam.serviceAccountViewer",
+  ]
+}
+
+variable "labels" {
+  description = "Labels to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/gcp/inspector/versions.tf
+++ b/gcp/inspector/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **`aws/inspector`**: IAM role (`insideout-inspector-{project_uuid}`) with `ReadOnlyAccess` policy, trusted by the Terraform SA role via STS AssumeRole. Enables the 2-hop credential chain Oracle uses for AWS inspection.
- **`gcp/inspector`**: Service account (`insideout-inspector-{short_id}`) with configurable viewer roles, plus `serviceAccountTokenCreator` grant for the deployment SA. Enables Oracle to mint access tokens for GCP inspection.

Both modules follow existing conventions (luthername tags for AWS, `versions.tf` for GCP, standard variable validation patterns).

Closes #43, closes #44

## Upstream follow-up

After merging, the `reliable` composition engine needs to wire these modules into stack generation (auto-injected like backups, not user-selectable). Tracked separately.

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false && terraform validate` passes for both modules
- [x] All 53 existing preset modules still validate
- [x] All 11 example stacks still validate
- [x] `zz_embed.go` patterns (`aws/*/*.tf`, `gcp/*/*.tf`) already cover new modules — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)