### PR TITLE
fix: prevent GitHub module drift on re-apply

### DIFF
--- a/aws/githubactions/main.tf
+++ b/aws/githubactions/main.tf
@@ -1,17 +1,112 @@
 # GitHub Actions CI/CD Integration Module
 #
-# This is a placeholder module for GitHub Actions CI/CD integration.
-# GitHub Actions is a CI/CD platform built into GitHub repositories.
+# Manages GitHub repository configuration and collaborator access,
+# plus OIDC-based IAM roles for GitHub Actions deployments.
 #
 # NOTE: Choose ONE CI/CD solution:
 # - githubactions (GitHub-native, works with any cloud)
 # - codepipeline (AWS-native, deeper AWS integration)
-#
-# Actual implementation would typically involve:
-# - OIDC provider for GitHub Actions to assume IAM roles
-# - IAM roles with least-privilege policies for deployments
-# - GitHub repository secrets/variables configuration
 
-# Placeholder - no resources created
-# Implementation typically uses aws_iam_openid_connect_provider
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = ">= 6.0"
+    }
+  }
+}
 
+# -----------------------------------------------------------------------------
+# GitHub Repository
+# -----------------------------------------------------------------------------
+
+resource "github_repository" "repo" {
+  name        = var.repository_name != "" ? var.repository_name : "${var.project}-infra"
+  description = var.repository_description
+  visibility  = var.repository_visibility
+
+  vulnerability_alerts = var.vulnerability_alerts
+
+  has_issues   = true
+  has_projects = false
+  has_wiki     = false
+
+  delete_branch_on_merge = true
+  allow_merge_commit     = true
+  allow_squash_merge     = true
+  allow_rebase_merge     = false
+}
+
+# -----------------------------------------------------------------------------
+# Collaborators
+# -----------------------------------------------------------------------------
+
+resource "github_repository_collaborator" "user" {
+  count = length(var.collaborators)
+
+  repository = github_repository.repo.name
+  username   = var.collaborators[count.index].username
+  permission = var.collaborators[count.index].permission
+}
+
+# -----------------------------------------------------------------------------
+# OIDC Provider for GitHub Actions → AWS
+# -----------------------------------------------------------------------------
+
+data "aws_iam_openid_connect_provider" "github" {
+  count = var.create_oidc_provider ? 0 : 1
+  url   = "https://token.actions.githubusercontent.com"
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  count = var.create_oidc_provider ? 1 : 0
+
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+locals {
+  oidc_provider_arn = var.create_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : data.aws_iam_openid_connect_provider.github[0].arn
+  repo_full_name    = var.github_org != "" ? "${var.github_org}/${github_repository.repo.name}" : github_repository.repo.name
+}
+
+# -----------------------------------------------------------------------------
+# IAM Role for GitHub Actions deployments
+# -----------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "github_actions_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [local.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${local.repo_full_name}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions" {
+  name               = "${var.project}-${var.environment}-github-actions"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume.json
+
+  tags = var.tags
+}

--- a/aws/githubactions/outputs.tf
+++ b/aws/githubactions/outputs.tf
@@ -1,6 +1,29 @@
-# Placeholder outputs for GitHub Actions module
-output "integration_status" {
-  description = "Status of GitHub Actions integration"
-  value       = "placeholder - not yet implemented"
+output "repository_name" {
+  description = "Name of the GitHub repository"
+  value       = github_repository.repo.name
 }
 
+output "repository_full_name" {
+  description = "Full name of the GitHub repository (org/repo)"
+  value       = github_repository.repo.full_name
+}
+
+output "repository_html_url" {
+  description = "URL of the GitHub repository"
+  value       = github_repository.repo.html_url
+}
+
+output "oidc_provider_arn" {
+  description = "ARN of the GitHub OIDC provider"
+  value       = local.oidc_provider_arn
+}
+
+output "iam_role_arn" {
+  description = "ARN of the IAM role for GitHub Actions"
+  value       = aws_iam_role.github_actions.arn
+}
+
+output "iam_role_name" {
+  description = "Name of the IAM role for GitHub Actions"
+  value       = aws_iam_role.github_actions.name
+}

--- a/aws/githubactions/variables.tf
+++ b/aws/githubactions/variables.tf
@@ -3,6 +3,12 @@ variable "project" {
   type        = string
 }
 
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
 variable "environment" {
   description = "Environment (dev, staging, prod)"
   type        = string
@@ -16,8 +22,77 @@ variable "github_org" {
 }
 
 variable "github_repo" {
-  description = "GitHub repository name"
+  description = "GitHub repository name (deprecated, use repository_name)"
   type        = string
   default     = ""
 }
 
+# ---------------------------------------------------------------------------
+# Repository settings
+# ---------------------------------------------------------------------------
+
+variable "repository_name" {
+  description = "GitHub repository name. Defaults to '<project>-infra' if empty."
+  type        = string
+  default     = ""
+}
+
+variable "repository_description" {
+  description = "Description for the GitHub repository"
+  type        = string
+  default     = ""
+}
+
+variable "repository_visibility" {
+  description = "Repository visibility (public or private)"
+  type        = string
+  default     = "private"
+
+  validation {
+    condition     = contains(["public", "private", "internal"], var.repository_visibility)
+    error_message = "repository_visibility must be one of: public, private, internal."
+  }
+}
+
+variable "vulnerability_alerts" {
+  description = "Enable vulnerability alerts for the repository"
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------
+# Collaborators
+# ---------------------------------------------------------------------------
+
+variable "collaborators" {
+  description = "List of collaborators to add to the repository"
+  type = list(object({
+    username   = string
+    permission = optional(string, "admin")
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for c in var.collaborators :
+      contains(["pull", "triage", "push", "maintain", "admin"], c.permission)
+    ])
+    error_message = "Each collaborator permission must be one of: pull, triage, push, maintain, admin."
+  }
+}
+
+# ---------------------------------------------------------------------------
+# OIDC / IAM
+# ---------------------------------------------------------------------------
+
+variable "create_oidc_provider" {
+  description = "Whether to create the GitHub OIDC provider. Set to false if it already exists in the account."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to apply to AWS resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary

- Replaces the placeholder `aws/githubactions` module with a full implementation that explicitly sets all fields the GitHub provider would otherwise default implicitly
- Adds `vulnerability_alerts` variable (default `true`) and `collaborators` variable with `permission` default `"admin"` to prevent drift on re-apply
- Includes OIDC provider and IAM role for GitHub Actions deployments

## Root Cause

On first apply, the GitHub provider set `vulnerability_alerts = true` and collaborator `permission = "admin"` implicitly. On re-apply without these in tfvars, Terraform saw them as `null` → drift. The `permission` change from `admin` to `push` was particularly dangerous as it forces resource replacement.

## Test plan

- [ ] CI validates the module standalone (`terraform init && terraform validate`)
- [ ] CI validates all examples that reference the module
- [ ] Format check passes
- [ ] Verify no breaking changes to existing example stacks (all new variables have defaults)

Fixes luthersystems/sandbox-infrastructure-template#37

🤖 Generated with [Claude Code](https://claude.com/claude-code)