### PR TITLE
fix: cap EKS cluster name to 28 chars for IAM name_prefix limit

### DIFF
--- a/aws/resource/main.tf
+++ b/aws/resource/main.tf
@@ -17,6 +17,12 @@ module "name" {
   component      = "insideout"
   subcomponent   = "eks"
   resource       = "eks"
+
+  # AWS IAM name_prefix is limited to 38 characters. The upstream
+  # terraform-aws-modules/eks appends suffixes like "-cluster-" (9 chars)
+  # and "-eks-auto-" (10 chars) as name_prefix values, so the base
+  # cluster name must be ≤ 28 chars to stay within the limit.
+  max_length = 28
 }
 
 locals {


### PR DESCRIPTION
## Summary

- Adds `max_length = 28` to the luthername module call in `aws/resource/main.tf`
- The upstream `terraform-aws-modules/eks` creates IAM roles with `name_prefix` suffixes like `-cluster-` (9 chars) and `-eks-auto-` (10 chars)
- AWS IAM limits `name_prefix` to 38 characters, so the cluster name must be ≤ 28 chars
- luthername's `max_length` truncates the prefix portion while preserving the ID suffix for uniqueness

Without this fix, projects with long names (e.g., `io-vvcarbzn6em1-prod-luthersystems-insideout-eks-eks0` at 56 chars) fail `terraform plan` with:
```
name_prefix "io-vvcarbzn6em1-prod-luthersystems-insideout-eks-eks0-cluster-" cannot be longer than 38 characters
```

## Test plan

- [ ] Verify `terraform validate` passes in `aws/resource/`
- [ ] Run `tfplan` on a session with EKS — should no longer fail on name_prefix length

Fixes luthersystems/reliable#615

🤖 Generated with [Claude Code](https://claude.com/claude-code)