### PR TITLE
fix: create OpenSearch service-linked role for VPC-mode domains

### DIFF
--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -41,8 +41,19 @@ resource "aws_security_group" "opensearch" {
   tags = merge(module.name.tags, { Name = "${module.name.name}-sg" }, var.tags)
 }
 
+# VPC-mode managed domains require the account-scoped service-linked role
+# AWSServiceRoleForAmazonOpenSearchService. AWS only auto-creates it on first
+# console use, so Terraform-only deploys into a fresh account fail without
+# this. Set create_service_linked_role = false if the role already exists.
+resource "aws_iam_service_linked_role" "opensearch" {
+  count            = var.deployment_type == "managed" && var.create_service_linked_role ? 1 : 0
+  aws_service_name = "opensearchservice.amazonaws.com"
+  description      = "Service-linked role for Amazon OpenSearch Service VPC access"
+}
+
 resource "aws_opensearch_domain" "managed" {
-  count = var.deployment_type == "managed" ? 1 : 0
+  count      = var.deployment_type == "managed" ? 1 : 0
+  depends_on = [aws_iam_service_linked_role.opensearch]
 
   # OpenSearch domain names limited to 28 chars — use var.project
   domain_name    = "${var.project}-search"

--- a/aws/opensearch/variables.tf
+++ b/aws/opensearch/variables.tf
@@ -33,6 +33,18 @@ variable "deployment_type" {
   default     = "managed"
 }
 
+variable "create_service_linked_role" {
+  type        = bool
+  description = <<-EOT
+    Whether to create the AWSServiceRoleForAmazonOpenSearchService IAM
+    service-linked role. Required for VPC-mode managed domains on accounts
+    that have never used OpenSearch before. Set to false if the role already
+    exists in the account (e.g. another deploy created it) to avoid a
+    duplicate-resource error.
+  EOT
+  default     = true
+}
+
 variable "instance_type" {
   type        = string
   description = "OpenSearch instance type"


### PR DESCRIPTION
## Summary

- VPC-mode managed OpenSearch domains need the account-scoped IAM SLR `AWSServiceRoleForAmazonOpenSearchService`. AWS auto-creates it on first console use only, so Terraform deploys into fresh accounts failed at apply time with `ValidationException: Before you can proceed, you must enable a service-linked role…`.
- Add `aws_iam_service_linked_role.opensearch` (service principal `opensearchservice.amazonaws.com`) guarded by a new `create_service_linked_role` bool variable (default `true`), and make `aws_opensearch_domain.managed` depend on it.
- Operators re-using an account that already has the role can set `create_service_linked_role = false` to avoid a duplicate-resource error.

## Test plan

- [x] `terraform fmt -check -recursive`
- [x] `cd aws/opensearch && terraform init -backend=false && terraform validate`
- [x] Validate downstream examples that use this module: `examples/revisionapp`, `examples/edubot`, `examples/gamestudio`
- [x] `go build ./...` (embed still compiles)
- [ ] Live apply into a fresh AWS account via Reliable2 succeeds (verified outside this repo once the preset is released)

Fixes #61