### PR TITLE
fix: make OpenSearch SLR creation idempotent on reused accounts

### DIFF
--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -44,9 +44,16 @@ resource "aws_security_group" "opensearch" {
 # VPC-mode managed domains require the account-scoped service-linked role
 # AWSServiceRoleForAmazonOpenSearchService. AWS only auto-creates it on first
 # console use, so Terraform-only deploys into a fresh account fail without
-# this. Set create_service_linked_role = false if the role already exists.
+# it. We probe for the role and create it only when absent, keeping this
+# idempotent across accounts that already have it from a previous deploy.
+data "aws_iam_roles" "opensearch_slr" {
+  count       = var.deployment_type == "managed" ? 1 : 0
+  name_regex  = "^AWSServiceRoleForAmazonOpenSearchService$"
+  path_prefix = "/aws-service-role/opensearchservice.amazonaws.com/"
+}
+
 resource "aws_iam_service_linked_role" "opensearch" {
-  count            = var.deployment_type == "managed" && var.create_service_linked_role ? 1 : 0
+  count            = var.deployment_type == "managed" && length(data.aws_iam_roles.opensearch_slr) > 0 && length(data.aws_iam_roles.opensearch_slr[0].names) == 0 ? 1 : 0
   aws_service_name = "opensearchservice.amazonaws.com"
   description      = "Service-linked role for Amazon OpenSearch Service VPC access"
 }

--- a/aws/opensearch/variables.tf
+++ b/aws/opensearch/variables.tf
@@ -33,18 +33,6 @@ variable "deployment_type" {
   default     = "managed"
 }
 
-variable "create_service_linked_role" {
-  type        = bool
-  description = <<-EOT
-    Whether to create the AWSServiceRoleForAmazonOpenSearchService IAM
-    service-linked role. Required for VPC-mode managed domains on accounts
-    that have never used OpenSearch before. Set to false if the role already
-    exists in the account (e.g. another deploy created it) to avoid a
-    duplicate-resource error.
-  EOT
-  default     = true
-}
-
 variable "instance_type" {
   type        = string
   description = "OpenSearch instance type"


### PR DESCRIPTION
## Summary

Follow-up to #62, which fixed first-deploy into fresh accounts but introduced a regression for accounts where the SLR already exists: the opt-out variable defaulted to `true`, so applying the module on any previously-used account fails with `InvalidInput: Service role name AWSServiceRoleForAmazonOpenSearchService has been taken in this account`. The opt-out required the operator to know about the footgun, which defeats the point.

This PR replaces the opt-out toggle with an `aws_iam_roles` data-source probe (returns an empty set when no matches, no plan-time error) and gates creation on the probe. Apply is now idempotent on both fresh and reused accounts with zero configuration.

The follow-up commit (`5fa0ac2`) existed on the original feature branch but was orphaned — the merge commit's parent was the earlier commit, so only the opt-out variant landed on main.

## Test plan

- [x] `terraform fmt -check -recursive`
- [x] `cd aws/opensearch && terraform init -backend=false && terraform validate`
- [x] Validate `examples/revisionapp`, `examples/edubot`, `examples/gamestudio`
- [x] `go build ./...`

## Reference

- Provider source confirming `aws_iam_roles` returns empty set on no match: https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/iam/roles_data_source.go