### PR TITLE
fix: preemptively bootstrap SLRs for aws/msk and aws/eks_nodegroup

### DIFF
--- a/aws/eks_nodegroup/main.tf
+++ b/aws/eks_nodegroup/main.tf
@@ -72,9 +72,32 @@ resource "aws_iam_role_policy_attachment" "mng_ssm" {
 }
 
 # -------------------------------------------------------------
+# Service-linked role bootstrap
+# -------------------------------------------------------------
+# EKS managed node groups need AWSServiceRoleForAmazonEKSNodegroup in the
+# account. AWS's CreateNodegroup API is documented to auto-create it, but we
+# bootstrap defensively to avoid IAM-propagation races on brand-new accounts
+# and to survive cases where the nodegroup is created before the cluster has
+# finished materialising its own SLR. Same pattern as aws/opensearch: probe
+# with a plural data source (no error on zero matches) and only create when
+# absent.
+data "aws_iam_roles" "eks_nodegroup_slr" {
+  name_regex  = "^AWSServiceRoleForAmazonEKSNodegroup$"
+  path_prefix = "/aws-service-role/eks-nodegroup.amazonaws.com/"
+}
+
+resource "aws_iam_service_linked_role" "eks_nodegroup" {
+  count            = length(data.aws_iam_roles.eks_nodegroup_slr.names) == 0 ? 1 : 0
+  aws_service_name = "eks-nodegroup.amazonaws.com"
+  description      = "Service-linked role for EKS managed node groups"
+}
+
+# -------------------------------------------------------------
 # EKS Managed Node Group
 # -------------------------------------------------------------
 resource "aws_eks_node_group" "this" {
+  depends_on = [aws_iam_service_linked_role.eks_nodegroup]
+
   cluster_name    = var.cluster_name
   node_group_name = coalesce(var.node_group_name, "default")
 

--- a/aws/msk/main.tf
+++ b/aws/msk/main.tf
@@ -103,8 +103,26 @@ resource "aws_cloudwatch_log_group" "msk" {
   tags              = local.tags
 }
 
+# MSK VPC-attached brokers need AWSServiceRoleForKafka in the account.
+# AWS's CreateCluster API is documented to auto-create it, but we bootstrap
+# defensively to avoid IAM-propagation races on brand-new accounts. Same
+# pattern as aws/opensearch: probe with a plural data source (no error on
+# zero matches) and only create when absent.
+data "aws_iam_roles" "msk_slr" {
+  name_regex  = "^AWSServiceRoleForKafka$"
+  path_prefix = "/aws-service-role/kafka.amazonaws.com/"
+}
+
+resource "aws_iam_service_linked_role" "msk" {
+  count            = length(data.aws_iam_roles.msk_slr.names) == 0 ? 1 : 0
+  aws_service_name = "kafka.amazonaws.com"
+  description      = "Service-linked role for Amazon MSK VPC access"
+}
+
 # The MSK cluster (provisioned)
 resource "aws_msk_cluster" "this" {
+  depends_on = [aws_iam_service_linked_role.msk]
+
   cluster_name           = local.name
   kafka_version          = var.kafka_version
   number_of_broker_nodes = var.number_of_broker_nodes


### PR DESCRIPTION
## Summary

Belt-and-braces follow-up to the aws/opensearch SLR fix (#61 / #62 / #65). Mirrors the same `aws_iam_roles` probe + conditional `aws_iam_service_linked_role` pattern for two more VPC-attached resources:

- `aws/msk` — `AWSServiceRoleForKafka` / `kafka.amazonaws.com`
- `aws/eks_nodegroup` — `AWSServiceRoleForAmazonEKSNodegroup` / `eks-nodegroup.amazonaws.com`

Both `CreateCluster` / `CreateNodegroup` are documented to auto-create the SLR, so this is **not** a confirmed first-apply failure like OpenSearch-in-VPC. It removes a class of rare IAM-propagation races on brand-new accounts and keeps the fleet uniform.

## Test plan

- [x] `terraform fmt -check -recursive`
- [x] Validate `aws/msk` and `aws/eks_nodegroup`
- [x] Validate downstream examples using `aws/eks_nodegroup`: `examples/revisionapp`, `examples/cargofit`
- [x] `go build ./...`
- [x] No changes required to `zz_embed.go`

Fixes #63
Fixes #64