### PR TITLE
ci: add ci-gate aggregator check for branch protection

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -126,3 +126,24 @@ jobs:
 
       - name: Terraform Format Check
         run: terraform fmt -check -recursive
+
+  # Single aggregator status for branch protection to require. Lets the
+  # matrix jobs above grow/shrink without updating the protection rule.
+  ci-gate:
+    needs:
+      - discover
+      - validate-presets
+      - validate-examples
+      - test-presets
+      - lint
+      - format-check
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all required jobs succeeded
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required CI jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required CI jobs passed."


### PR DESCRIPTION
## Summary

Add a single `ci-gate` job that `needs:` every other CI job and fails on any failure/cancellation. Branch-protection on `main` can require just this one check and stay stable as the matrix (`validate-presets`, `validate-examples`, `test-presets`) grows.

This also closes the auto-merge footgun that bit PR #62: with a required status check, GitHub auto-merge waits for the latest commit's checks rather than merging on the first-commit CI pass.

## Follow-up

Once merged, enable branch protection on `main` with:
- Require status checks to pass: `ci-gate`
- Require branches to be up to date before merging
- Forbid force-pushes and branch deletion