### PR TITLE
fix: provision AOSS collection + Bedrock IAM role as infra skeleton

### DIFF
--- a/aws/bedrock/main.tf
+++ b/aws/bedrock/main.tf
@@ -64,13 +64,9 @@ resource "aws_iam_role_policy" "bedrock_kb" {
         ]
       },
       {
-        Action = [
-          "es:ESHttpPost",
-          "es:ESHttpGet",
-          "es:DescribeDomain"
-        ]
+        Action   = ["aoss:APIAccessAll"]
         Effect   = "Allow"
-        Resource = "${var.opensearch_arn}/*"
+        Resource = var.opensearch_collection_arn
       }
     ]
   })
@@ -91,7 +87,7 @@ resource "aws_bedrockagent_knowledge_base" "this" {
   storage_configuration {
     type = "OPENSEARCH_SERVERLESS"
     opensearch_serverless_configuration {
-      collection_arn    = var.opensearch_arn
+      collection_arn    = var.opensearch_collection_arn
       vector_index_name = "bedrock-knowledge-base-default-index"
       field_mapping {
         vector_field   = "bedrock-knowledge-base-default-vector"

--- a/aws/bedrock/main.tf
+++ b/aws/bedrock/main.tf
@@ -77,39 +77,15 @@ resource "aws_iam_role_policy" "bedrock_kb" {
   })
 }
 
-resource "aws_bedrockagent_knowledge_base" "this" {
-  name     = "${module.name.name}-${var.knowledge_base_name}"
-  role_arn = aws_iam_role.bedrock_kb.arn
-  tags     = merge(module.name.tags, var.tags)
-
-  knowledge_base_configuration {
-    type = "VECTOR"
-    vector_knowledge_base_configuration {
-      embedding_model_arn = "arn:aws:bedrock:${var.region}::foundation-model/${var.embedding_model_id}"
-    }
-  }
-
-  storage_configuration {
-    type = "OPENSEARCH_SERVERLESS"
-    opensearch_serverless_configuration {
-      collection_arn    = var.opensearch_collection_arn
-      vector_index_name = "bedrock-knowledge-base-default-index"
-      field_mapping {
-        vector_field   = "bedrock-knowledge-base-default-vector"
-        text_field     = "AMAZON_BEDROCK_TEXT_CHUNK"
-        metadata_field = "AMAZON_BEDROCK_METADATA"
-      }
-    }
-  }
-}
-
-resource "aws_bedrockagent_data_source" "this" {
-  knowledge_base_id = aws_bedrockagent_knowledge_base.this.id
-  name              = "${module.name.name}-s3-source"
-  data_source_configuration {
-    type = "S3"
-    s3_configuration {
-      bucket_arn = var.s3_bucket_arn
-    }
-  }
-}
+# The Bedrock Knowledge Base (aws_bedrockagent_knowledge_base) and its S3
+# data source are intentionally NOT managed by this module. Creating the KB
+# at terraform time requires (1) a pre-existing AOSS vector index with the
+# k-NN field mapping Bedrock expects, (2) an AOSS data-access policy
+# granting this role and the terraform runner aoss:* on the collection, and
+# (3) resolving assumed-role session ARNs to their underlying roles. All of
+# that is an application-layer concern — the application that ingests data
+# into the KB is the right place to create the KB, the vector index, and
+# the data-access policy, because only it knows which embedding model /
+# dimension / field names it needs. This module provisions only the IAM
+# role and its policy so the application can assume it when it calls
+# CreateKnowledgeBase and StartIngestionJob.

--- a/aws/bedrock/main.tf
+++ b/aws/bedrock/main.tf
@@ -49,8 +49,13 @@ resource "aws_iam_role_policy" "bedrock_kb" {
         Action = [
           "bedrock:InvokeModel"
         ]
-        Effect   = "Allow"
-        Resource = "arn:aws:bedrock:${var.region}::foundation-model/${var.model_id}"
+        Effect = "Allow"
+        # KB ingestion calls the embedding model; downstream consumers
+        # of the KB typically invoke the chat model through the same role.
+        Resource = [
+          "arn:aws:bedrock:${var.region}::foundation-model/${var.model_id}",
+          "arn:aws:bedrock:${var.region}::foundation-model/${var.embedding_model_id}",
+        ]
       },
       {
         Action = [

--- a/aws/bedrock/outputs.tf
+++ b/aws/bedrock/outputs.tf
@@ -1,19 +1,9 @@
-output "knowledge_base_id" {
-  value       = aws_bedrockagent_knowledge_base.this.id
-  description = "The ID of the Bedrock Knowledge Base"
-}
-
-output "knowledge_base_arn" {
-  value       = aws_bedrockagent_knowledge_base.this.arn
-  description = "The ARN of the Bedrock Knowledge Base"
-}
-
-output "data_source_id" {
-  value       = aws_bedrockagent_data_source.this.id
-  description = "The ID of the Bedrock data source"
-}
-
 output "role_arn" {
   value       = aws_iam_role.bedrock_kb.arn
-  description = "The ARN of the Bedrock Knowledge Base IAM role"
+  description = "ARN of the IAM role the application assumes when creating a Bedrock Knowledge Base against the configured AOSS collection and S3 bucket."
+}
+
+output "role_name" {
+  value       = aws_iam_role.bedrock_kb.name
+  description = "Name of the Bedrock IAM role. Useful when the application needs to attach additional policies at runtime."
 }

--- a/aws/bedrock/variables.tf
+++ b/aws/bedrock/variables.tf
@@ -31,7 +31,7 @@ variable "model_id" {
 
 variable "embedding_model_id" {
   type        = string
-  description = "Bedrock Embedding Model ID"
+  description = "Bedrock Embedding Model ID. If you change this, update aws/opensearch's vector_embedding_dimension to match (titan-embed-text-v1 = 1024, titan-embed-text-v2 = 1024/512/256, cohere.embed-english-v3 = 1024, cohere.embed-multilingual-v3 = 1024). A mismatch will silently corrupt ingestion."
   default     = "amazon.titan-embed-text-v1"
 }
 

--- a/aws/bedrock/variables.tf
+++ b/aws/bedrock/variables.tf
@@ -31,16 +31,14 @@ variable "embedding_model_id" {
 
 variable "s3_bucket_arn" {
   type        = string
-  description = "ARN of the S3 bucket for the data source"
-  default     = null
+  description = "ARN of the S3 bucket the role is granted s3:ListBucket and s3:GetObject on. Required — the Bedrock KB role has no meaningful purpose without an S3 data source."
 }
 
 variable "opensearch_collection_arn" {
   type        = string
-  description = "ARN of the OpenSearch Serverless (AOSS) collection that backs the Bedrock Knowledge Base vector store. Managed-domain ARNs are not supported by Bedrock."
-  default     = null
+  description = "ARN of the OpenSearch Serverless (AOSS) collection that backs the Bedrock Knowledge Base vector store. Managed-domain ARNs are not supported by Bedrock. Required — this role exists specifically to grant aoss:APIAccessAll on this collection."
   validation {
-    condition     = var.opensearch_collection_arn == null ? true : can(regex("^arn:aws[a-z-]*:aoss:[a-z0-9-]+:[0-9]{12}:collection/[a-z0-9]+$", var.opensearch_collection_arn))
+    condition     = can(regex("^arn:aws[a-z-]*:aoss:[a-z0-9-]+:[0-9]{12}:collection/[a-z0-9]+$", var.opensearch_collection_arn))
     error_message = "opensearch_collection_arn must be an AOSS collection ARN matching arn:aws:aoss:<region>:<account>:collection/<id>."
   }
 }

--- a/aws/bedrock/variables.tf
+++ b/aws/bedrock/variables.tf
@@ -41,10 +41,14 @@ variable "s3_bucket_arn" {
   default     = null
 }
 
-variable "opensearch_arn" {
+variable "opensearch_collection_arn" {
   type        = string
-  description = "ARN of the OpenSearch domain/collection for the vector store"
+  description = "ARN of the OpenSearch Serverless (AOSS) collection that backs the Bedrock Knowledge Base vector store. Managed-domain ARNs are not supported by Bedrock."
   default     = null
+  validation {
+    condition     = var.opensearch_collection_arn == null ? true : can(regex("^arn:aws[a-z-]*:aoss:[a-z0-9-]+:[0-9]{12}:collection/[a-z0-9]+$", var.opensearch_collection_arn))
+    error_message = "opensearch_collection_arn must be an AOSS collection ARN matching arn:aws:aoss:<region>:<account>:collection/<id>."
+  }
 }
 
 variable "tags" {

--- a/aws/bedrock/variables.tf
+++ b/aws/bedrock/variables.tf
@@ -17,21 +17,15 @@ variable "environment" {
   }
 }
 
-variable "knowledge_base_name" {
-  type        = string
-  description = "Name of the Bedrock Knowledge Base"
-  default     = "default-kb"
-}
-
 variable "model_id" {
   type        = string
-  description = "Bedrock Model ID for the Knowledge Base"
+  description = "Bedrock foundation model ID the role may invoke (chat/completions). Granted via the IAM policy."
   default     = "anthropic.claude-3-sonnet-20240229-v1:0"
 }
 
 variable "embedding_model_id" {
   type        = string
-  description = "Bedrock Embedding Model ID. If you change this, update aws/opensearch's vector_embedding_dimension to match (titan-embed-text-v1 = 1024, titan-embed-text-v2 = 1024/512/256, cohere.embed-english-v3 = 1024, cohere.embed-multilingual-v3 = 1024). A mismatch will silently corrupt ingestion."
+  description = "Bedrock embedding model ID the role may invoke. Granted via the IAM policy so the application can ingest into a Knowledge Base backed by this role."
   default     = "amazon.titan-embed-text-v1"
 }
 

--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -5,6 +5,14 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 6.0"
     }
+    opensearch = {
+      source  = "opensearch-project/opensearch"
+      version = "~> 2.3"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
   }
 }
 
@@ -19,7 +27,22 @@ module "name" {
   resource       = "os"
 }
 
+locals {
+  is_serverless     = var.deployment_type == "serverless"
+  collection_name   = "${var.project}-search"
+  emit_data_access  = local.is_serverless && length(var.data_access_principal_arns) > 0
+  create_vector_idx = local.is_serverless && var.create_bedrock_vector_index
+  # AOSS data-access policies reject sts assumed-role session ARNs; resolve
+  # the caller's underlying role via aws_iam_session_context so the
+  # terraform runner can itself PUT the vector index.
+  data_access_principals = local.emit_data_access ? distinct(concat(
+    var.data_access_principal_arns,
+    [data.aws_iam_session_context.current[0].issuer_arn]
+  )) : []
+}
+
 resource "aws_security_group" "opensearch" {
+  count       = var.deployment_type == "managed" ? 1 : 0
   name        = "${module.name.name}-sg"
   description = "Security group for OpenSearch domain"
   vpc_id      = var.vpc_id
@@ -80,19 +103,158 @@ resource "aws_opensearch_domain" "managed" {
 
   vpc_options {
     subnet_ids         = [var.subnet_ids[0]]
-    security_group_ids = [aws_security_group.opensearch.id]
+    security_group_ids = [aws_security_group.opensearch[0].id]
   }
 
   tags = merge(module.name.tags, { Domain = module.name.name }, var.tags)
 }
 
+# --- AOSS serverless path --------------------------------------------------
+#
+# AOSS requires encryption + network security policies *before* the collection
+# can be created. Data-access policies and the Bedrock default vector index
+# are created conditionally based on caller-supplied principals and the
+# create_bedrock_vector_index flag.
+
+data "aws_caller_identity" "current" {
+  count = local.emit_data_access ? 1 : 0
+}
+
+data "aws_iam_session_context" "current" {
+  count = local.emit_data_access ? 1 : 0
+  arn   = data.aws_caller_identity.current[0].arn
+}
+
+resource "aws_opensearchserverless_security_policy" "encryption" {
+  count = local.is_serverless ? 1 : 0
+  name  = "${var.project}-enc"
+  type  = "encryption"
+  policy = jsonencode({
+    Rules = [
+      {
+        ResourceType = "collection"
+        Resource     = ["collection/${local.collection_name}"]
+      }
+    ]
+    AWSOwnedKey = var.kms_key_arn == null
+    KmsARN      = var.kms_key_arn
+  })
+}
+
+resource "aws_opensearchserverless_security_policy" "network" {
+  count = local.is_serverless ? 1 : 0
+  name  = "${var.project}-net"
+  type  = "network"
+  policy = jsonencode([
+    {
+      Rules = [
+        {
+          ResourceType = "collection"
+          Resource     = ["collection/${local.collection_name}"]
+        },
+        {
+          ResourceType = "dashboard"
+          Resource     = ["collection/${local.collection_name}"]
+        }
+      ]
+      AllowFromPublic = var.allow_public_access
+    }
+  ])
+}
+
 resource "aws_opensearchserverless_collection" "serverless" {
-  count = var.deployment_type == "serverless" ? 1 : 0
+  count = local.is_serverless ? 1 : 0
 
   # OpenSearch collection names limited to 32 chars — use var.project
-  name = "${var.project}-search"
+  name = local.collection_name
   type = "VECTORSEARCH"
 
   tags = merge(module.name.tags, { Name = module.name.name }, var.tags)
+
+  depends_on = [
+    aws_opensearchserverless_security_policy.encryption,
+    aws_opensearchserverless_security_policy.network,
+  ]
 }
 
+resource "aws_opensearchserverless_access_policy" "data" {
+  count = local.emit_data_access ? 1 : 0
+  name  = "${var.project}-data"
+  type  = "data"
+  policy = jsonencode([
+    {
+      Rules = [
+        {
+          ResourceType = "collection"
+          Resource     = ["collection/${local.collection_name}"]
+          Permission   = ["aoss:*"]
+        },
+        {
+          ResourceType = "index"
+          Resource     = ["index/${local.collection_name}/*"]
+          Permission   = ["aoss:*"]
+        }
+      ]
+      Principal = local.data_access_principals
+    }
+  ])
+}
+
+# AOSS data-access policies propagate asynchronously; a PUT against the
+# collection immediately after policy creation returns 403 with some
+# regularity. 45s is the empirically safe floor.
+resource "time_sleep" "aoss_policy_propagation" {
+  count           = local.create_vector_idx ? 1 : 0
+  create_duration = "45s"
+  depends_on = [
+    aws_opensearchserverless_access_policy.data,
+    aws_opensearchserverless_collection.serverless,
+  ]
+}
+
+# The opensearch provider must be configured even when serverless is
+# disabled (required_providers is module-global). The url points at a
+# placeholder in that case; no opensearch_* resource is ever created
+# unless create_vector_idx is true, so the placeholder is never dialled.
+provider "opensearch" {
+  url               = local.is_serverless && length(aws_opensearchserverless_collection.serverless) > 0 ? aws_opensearchserverless_collection.serverless[0].collection_endpoint : "https://placeholder.invalid"
+  aws_region        = var.region
+  sign_aws_requests = true
+  healthcheck       = false
+}
+
+resource "opensearch_index" "bedrock_default" {
+  count = local.create_vector_idx ? 1 : 0
+  name  = "bedrock-knowledge-base-default-index"
+
+  number_of_shards   = "2"
+  number_of_replicas = "0"
+  index_knn          = true
+
+  mappings = jsonencode({
+    properties = {
+      "bedrock-knowledge-base-default-vector" = {
+        type      = "knn_vector"
+        dimension = var.vector_embedding_dimension
+        method = {
+          name       = "hnsw"
+          engine     = "faiss"
+          space_type = "l2"
+          parameters = {
+            m               = 16
+            ef_construction = 512
+          }
+        }
+      }
+      "AMAZON_BEDROCK_TEXT_CHUNK" = {
+        type = "text"
+      }
+      "AMAZON_BEDROCK_METADATA" = {
+        type  = "text"
+        index = false
+      }
+    }
+  })
+
+  depends_on = [time_sleep.aoss_policy_propagation]
+}

--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -129,16 +129,19 @@ resource "aws_opensearchserverless_security_policy" "encryption" {
   count = local.is_serverless ? 1 : 0
   name  = "${var.project}-enc"
   type  = "encryption"
-  policy = jsonencode({
-    Rules = [
-      {
-        ResourceType = "collection"
-        Resource     = ["collection/${local.collection_name}"]
-      }
-    ]
-    AWSOwnedKey = var.kms_key_arn == null
-    KmsARN      = var.kms_key_arn
-  })
+  # AOSS expects exactly one of AWSOwnedKey or KmsARN — emit only the
+  # active field, not both with a null. Otherwise AOSS rejects the policy.
+  policy = jsonencode(merge(
+    {
+      Rules = [
+        {
+          ResourceType = "collection"
+          Resource     = ["collection/${local.collection_name}"]
+        }
+      ]
+    },
+    var.kms_key_arn == null ? { AWSOwnedKey = true } : { KmsARN = var.kms_key_arn }
+  ))
 }
 
 resource "aws_opensearchserverless_security_policy" "network" {
@@ -181,18 +184,32 @@ resource "aws_opensearchserverless_access_policy" "data" {
   count = local.emit_data_access ? 1 : 0
   name  = "${var.project}-data"
   type  = "data"
+  # Scoped to the exact permissions Bedrock KB needs plus index
+  # create/update/delete so the Terraform caller can manage the vector
+  # index. Matches the AWS-published reference policy for Bedrock + AOSS.
   policy = jsonencode([
     {
       Rules = [
         {
           ResourceType = "collection"
           Resource     = ["collection/${local.collection_name}"]
-          Permission   = ["aoss:*"]
+          Permission = [
+            "aoss:DescribeCollectionItems",
+            "aoss:CreateCollectionItems",
+            "aoss:UpdateCollectionItems",
+          ]
         },
         {
           ResourceType = "index"
           Resource     = ["index/${local.collection_name}/*"]
-          Permission   = ["aoss:*"]
+          Permission = [
+            "aoss:ReadDocument",
+            "aoss:WriteDocument",
+            "aoss:CreateIndex",
+            "aoss:DescribeIndex",
+            "aoss:UpdateIndex",
+            "aoss:DeleteIndex",
+          ]
         }
       ]
       Principal = local.data_access_principals
@@ -227,9 +244,17 @@ resource "opensearch_index" "bedrock_default" {
   count = local.create_vector_idx ? 1 : 0
   name  = "bedrock-knowledge-base-default-index"
 
-  number_of_shards   = "2"
-  number_of_replicas = "0"
-  index_knn          = true
+  # AOSS manages replica count internally and does not accept
+  # number_of_replicas on index settings; shards and knn only.
+  number_of_shards = "2"
+  index_knn        = true
+
+  lifecycle {
+    precondition {
+      condition     = length(var.data_access_principal_arns) > 0
+      error_message = "create_bedrock_vector_index requires data_access_principal_arns to be non-empty. Pass the Bedrock KB role ARN (e.g. [module.bedrock.role_arn]) so the AOSS data-access policy grants it — and the Terraform runner — aoss:* on the index."
+    }
+  }
 
   mappings = jsonencode({
     properties = {

--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -5,14 +5,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 6.0"
     }
-    opensearch = {
-      source  = "opensearch-project/opensearch"
-      version = "~> 2.3"
-    }
-    time = {
-      source  = "hashicorp/time"
-      version = ">= 0.9"
-    }
   }
 }
 
@@ -28,17 +20,8 @@ module "name" {
 }
 
 locals {
-  is_serverless     = var.deployment_type == "serverless"
-  collection_name   = "${var.project}-search"
-  emit_data_access  = local.is_serverless && length(var.data_access_principal_arns) > 0
-  create_vector_idx = local.is_serverless && var.create_bedrock_vector_index
-  # AOSS data-access policies reject sts assumed-role session ARNs; resolve
-  # the caller's underlying role via aws_iam_session_context so the
-  # terraform runner can itself PUT the vector index.
-  data_access_principals = local.emit_data_access ? distinct(concat(
-    var.data_access_principal_arns,
-    [data.aws_iam_session_context.current[0].issuer_arn]
-  )) : []
+  is_serverless   = var.deployment_type == "serverless"
+  collection_name = "${var.project}-search"
 }
 
 resource "aws_security_group" "opensearch" {
@@ -111,18 +94,28 @@ resource "aws_opensearch_domain" "managed" {
 
 # --- AOSS serverless path --------------------------------------------------
 #
-# AOSS requires encryption + network security policies *before* the collection
-# can be created. Data-access policies and the Bedrock default vector index
-# are created conditionally based on caller-supplied principals and the
-# create_bedrock_vector_index flag.
+# Provisions an empty vector collection + its required encryption and
+# network security policies. Data-access policies and vector indexes are
+# intentionally NOT created here: they depend on who is consuming the
+# collection (e.g. a Bedrock KB role, the application's ingestion role),
+# which embedding model / dimension the application uses, and are therefore
+# an application-layer concern. The application creates its own data-access
+# policy and vector index after this infra exists.
 
-data "aws_caller_identity" "current" {
-  count = local.emit_data_access ? 1 : 0
+# AOSS service-linked role. AWS auto-creates it on first collection create
+# in most accounts, but fresh accounts and tight IAM propagation windows can
+# race, so we preemptively probe and create if missing. Same idiom as the
+# managed-OpenSearch SLR above.
+data "aws_iam_roles" "aoss_slr" {
+  count       = local.is_serverless ? 1 : 0
+  name_regex  = "^AWSServiceRoleForAmazonOpenSearchServerless$"
+  path_prefix = "/aws-service-role/observability.aoss.amazonaws.com/"
 }
 
-data "aws_iam_session_context" "current" {
-  count = local.emit_data_access ? 1 : 0
-  arn   = data.aws_caller_identity.current[0].arn
+resource "aws_iam_service_linked_role" "aoss" {
+  count            = local.is_serverless && length(data.aws_iam_roles.aoss_slr) > 0 && length(data.aws_iam_roles.aoss_slr[0].names) == 0 ? 1 : 0
+  aws_service_name = "observability.aoss.amazonaws.com"
+  description      = "Service-linked role for Amazon OpenSearch Serverless"
 }
 
 resource "aws_opensearchserverless_security_policy" "encryption" {
@@ -175,111 +168,8 @@ resource "aws_opensearchserverless_collection" "serverless" {
   tags = merge(module.name.tags, { Name = module.name.name }, var.tags)
 
   depends_on = [
+    aws_iam_service_linked_role.aoss,
     aws_opensearchserverless_security_policy.encryption,
     aws_opensearchserverless_security_policy.network,
   ]
-}
-
-resource "aws_opensearchserverless_access_policy" "data" {
-  count = local.emit_data_access ? 1 : 0
-  name  = "${var.project}-data"
-  type  = "data"
-  # Scoped to the exact permissions Bedrock KB needs plus index
-  # create/update/delete so the Terraform caller can manage the vector
-  # index. Matches the AWS-published reference policy for Bedrock + AOSS.
-  policy = jsonencode([
-    {
-      Rules = [
-        {
-          ResourceType = "collection"
-          Resource     = ["collection/${local.collection_name}"]
-          Permission = [
-            "aoss:DescribeCollectionItems",
-            "aoss:CreateCollectionItems",
-            "aoss:UpdateCollectionItems",
-          ]
-        },
-        {
-          ResourceType = "index"
-          Resource     = ["index/${local.collection_name}/*"]
-          Permission = [
-            "aoss:ReadDocument",
-            "aoss:WriteDocument",
-            "aoss:CreateIndex",
-            "aoss:DescribeIndex",
-            "aoss:UpdateIndex",
-            "aoss:DeleteIndex",
-          ]
-        }
-      ]
-      Principal = local.data_access_principals
-    }
-  ])
-}
-
-# AOSS data-access policies propagate asynchronously; a PUT against the
-# collection immediately after policy creation returns 403 with some
-# regularity. 45s is the empirically safe floor.
-resource "time_sleep" "aoss_policy_propagation" {
-  count           = local.create_vector_idx ? 1 : 0
-  create_duration = "45s"
-  depends_on = [
-    aws_opensearchserverless_access_policy.data,
-    aws_opensearchserverless_collection.serverless,
-  ]
-}
-
-# The opensearch provider must be configured even when serverless is
-# disabled (required_providers is module-global). The url points at a
-# placeholder in that case; no opensearch_* resource is ever created
-# unless create_vector_idx is true, so the placeholder is never dialled.
-provider "opensearch" {
-  url               = local.is_serverless && length(aws_opensearchserverless_collection.serverless) > 0 ? aws_opensearchserverless_collection.serverless[0].collection_endpoint : "https://placeholder.invalid"
-  aws_region        = var.region
-  sign_aws_requests = true
-  healthcheck       = false
-}
-
-resource "opensearch_index" "bedrock_default" {
-  count = local.create_vector_idx ? 1 : 0
-  name  = "bedrock-knowledge-base-default-index"
-
-  # AOSS manages replica count internally and does not accept
-  # number_of_replicas on index settings; shards and knn only.
-  number_of_shards = "2"
-  index_knn        = true
-
-  lifecycle {
-    precondition {
-      condition     = length(var.data_access_principal_arns) > 0
-      error_message = "create_bedrock_vector_index requires data_access_principal_arns to be non-empty. Pass the Bedrock KB role ARN (e.g. [module.bedrock.role_arn]) so the AOSS data-access policy grants it — and the Terraform runner — aoss:* on the index."
-    }
-  }
-
-  mappings = jsonencode({
-    properties = {
-      "bedrock-knowledge-base-default-vector" = {
-        type      = "knn_vector"
-        dimension = var.vector_embedding_dimension
-        method = {
-          name       = "hnsw"
-          engine     = "faiss"
-          space_type = "l2"
-          parameters = {
-            m               = 16
-            ef_construction = 512
-          }
-        }
-      }
-      "AMAZON_BEDROCK_TEXT_CHUNK" = {
-        type = "text"
-      }
-      "AMAZON_BEDROCK_METADATA" = {
-        type  = "text"
-        index = false
-      }
-    }
-  })
-
-  depends_on = [time_sleep.aoss_policy_propagation]
 }

--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -29,6 +29,12 @@ resource "aws_security_group" "opensearch" {
   name        = "${module.name.name}-sg"
   description = "Security group for OpenSearch domain"
   vpc_id      = var.vpc_id
+  lifecycle {
+    precondition {
+      condition     = var.vpc_id != null && length(var.subnet_ids) > 0
+      error_message = "Managed OpenSearch deployment requires vpc_id and at least one subnet_id. Either set deployment_type = \"serverless\" or pass vpc_id and subnet_ids."
+    }
+  }
 
   ingress {
     from_port   = 443
@@ -106,6 +112,12 @@ resource "aws_opensearch_domain" "managed" {
 # in most accounts, but fresh accounts and tight IAM propagation windows can
 # race, so we preemptively probe and create if missing. Same idiom as the
 # managed-OpenSearch SLR above.
+#
+# Note the service-role path: "observability.aoss.amazonaws.com" (not plain
+# "aoss.amazonaws.com"). AWS files the AOSS SLR under the observability
+# service namespace — counterintuitive but correct. Verify by inspecting an
+# account that's already used AOSS: the role lives at
+# /aws-service-role/observability.aoss.amazonaws.com/AWSServiceRoleForAmazonOpenSearchServerless
 data "aws_iam_roles" "aoss_slr" {
   count       = local.is_serverless ? 1 : 0
   name_regex  = "^AWSServiceRoleForAmazonOpenSearchServerless$"

--- a/aws/opensearch/outputs.tf
+++ b/aws/opensearch/outputs.tf
@@ -8,3 +8,16 @@ output "opensearch_endpoint" {
   description = "The endpoint of the OpenSearch domain or collection"
 }
 
+output "collection_arn" {
+  value       = var.deployment_type == "serverless" ? aws_opensearchserverless_collection.serverless[0].arn : null
+  description = "ARN of the AOSS collection. null when deployment_type is managed. Wire this (not opensearch_arn) into aws/bedrock.opensearch_collection_arn. Consuming this output implicitly waits for the data-access policy and (if enabled) the Bedrock vector index to be created, so downstream Bedrock KB creation does not need its own depends_on."
+  depends_on = [
+    aws_opensearchserverless_access_policy.data,
+    opensearch_index.bedrock_default,
+  ]
+}
+
+output "vector_index_ready" {
+  value       = var.create_bedrock_vector_index && var.deployment_type == "serverless" ? opensearch_index.bedrock_default[0].id : null
+  description = "ID of the Bedrock default vector index when it has been created; null otherwise. Non-null value indicates the collection is fully ready for aws_bedrockagent_knowledge_base creation."
+}

--- a/aws/opensearch/outputs.tf
+++ b/aws/opensearch/outputs.tf
@@ -1,23 +1,14 @@
 output "opensearch_arn" {
   value       = var.deployment_type == "managed" ? aws_opensearch_domain.managed[0].arn : aws_opensearchserverless_collection.serverless[0].arn
-  description = "The ARN of the OpenSearch domain or collection"
+  description = "ARN of the OpenSearch domain (managed) or collection (serverless)."
 }
 
 output "opensearch_endpoint" {
   value       = var.deployment_type == "managed" ? aws_opensearch_domain.managed[0].endpoint : aws_opensearchserverless_collection.serverless[0].collection_endpoint
-  description = "The endpoint of the OpenSearch domain or collection"
+  description = "Endpoint of the OpenSearch domain or AOSS collection."
 }
 
 output "collection_arn" {
   value       = var.deployment_type == "serverless" ? aws_opensearchserverless_collection.serverless[0].arn : null
-  description = "ARN of the AOSS collection. null when deployment_type is managed. Wire this (not opensearch_arn) into aws/bedrock.opensearch_collection_arn. Consuming this output implicitly waits for the data-access policy and (if enabled) the Bedrock vector index to be created, so downstream Bedrock KB creation does not need its own depends_on."
-  depends_on = [
-    aws_opensearchserverless_access_policy.data,
-    opensearch_index.bedrock_default,
-  ]
-}
-
-output "vector_index_ready" {
-  value       = var.create_bedrock_vector_index && var.deployment_type == "serverless" ? opensearch_index.bedrock_default[0].id : null
-  description = "ID of the Bedrock default vector index when it has been created; null otherwise. Non-null value indicates the collection is fully ready for aws_bedrockagent_knowledge_base creation."
+  description = "ARN of the AOSS collection. null when deployment_type is managed. Wire this (not opensearch_arn) into aws/bedrock.opensearch_collection_arn. The application layer is responsible for creating data-access policies and vector indexes against this collection."
 }

--- a/aws/opensearch/variables.tf
+++ b/aws/opensearch/variables.tf
@@ -1,6 +1,10 @@
 variable "project" {
   type        = string
-  description = "Project name for resource naming"
+  description = "Project name for resource naming. Used as a prefix for AOSS collection and security policy names, which are capped at 32 chars; longest suffix is '-search' (7), so project must be ≤25."
+  validation {
+    condition     = length(trimspace(var.project)) > 0 && length(var.project) <= 25
+    error_message = "project must be a non-empty string ≤25 characters (AOSS collection and security policy names are capped at 32 chars and this module appends up to 7 chars of suffix)."
+  }
 }
 
 variable "environment" {

--- a/aws/opensearch/variables.tf
+++ b/aws/opensearch/variables.tf
@@ -1,9 +1,9 @@
 variable "project" {
   type        = string
-  description = "Project name for resource naming. Used as a prefix for AOSS collection and security policy names, which are capped at 32 chars; longest suffix is '-search' (7), so project must be ≤25."
+  description = "Project name for resource naming. Used as a prefix for the OpenSearch domain name (managed) or AOSS collection name (serverless). OpenSearch Service caps domain names at 28 chars; AOSS caps collection/policy names at 32. The module appends '-search' (7 chars), so the tighter managed-mode constraint of 21 applies."
   validation {
-    condition     = length(trimspace(var.project)) > 0 && length(var.project) <= 25
-    error_message = "project must be a non-empty string ≤25 characters (AOSS collection and security policy names are capped at 32 chars and this module appends up to 7 chars of suffix)."
+    condition     = length(trimspace(var.project)) > 0 && length(var.project) <= 21
+    error_message = "project must be a non-empty string ≤21 characters. OpenSearch Service domain names cap at 28 chars; this module appends '-search' (7), so project must be ≤21 to satisfy both managed and serverless modes."
   }
 }
 
@@ -23,18 +23,24 @@ variable "region" {
 
 variable "vpc_id" {
   type        = string
-  description = "VPC ID for OpenSearch domain"
+  description = "VPC ID for the managed-mode OpenSearch domain's VPC interface. Required in managed mode; ignored in serverless mode."
+  default     = null
 }
 
 variable "subnet_ids" {
   type        = list(string)
-  description = "List of subnet IDs for OpenSearch domain"
+  description = "Subnet IDs for the managed-mode OpenSearch domain. Required in managed mode; ignored in serverless mode."
+  default     = []
 }
 
 variable "deployment_type" {
   type        = string
-  description = "Deployment type (Managed or Serverless)"
+  description = "Deployment type. \"managed\" provisions an OpenSearch Service domain in the VPC; \"serverless\" provisions an OpenSearch Serverless collection. Must be lowercase."
   default     = "managed"
+  validation {
+    condition     = contains(["managed", "serverless"], var.deployment_type)
+    error_message = "deployment_type must be either \"managed\" or \"serverless\" (lowercase)."
+  }
 }
 
 variable "instance_type" {

--- a/aws/opensearch/variables.tf
+++ b/aws/opensearch/variables.tf
@@ -61,18 +61,6 @@ variable "tags" {
   default     = {}
 }
 
-variable "data_access_principal_arns" {
-  type        = list(string)
-  description = "List of IAM role/user ARNs granted aoss:* on the collection and its indexes via a data-access policy. Serverless mode only. When non-empty, the Terraform caller's underlying role ARN is also added so it can create the vector index."
-  default     = []
-}
-
-variable "create_bedrock_vector_index" {
-  type        = bool
-  description = "When true (and deployment_type is serverless), create the bedrock-knowledge-base-default-index vector index with the k-NN field mapping required by aws_bedrockagent_knowledge_base. Requires data_access_principal_arns to include the Bedrock KB role."
-  default     = false
-}
-
 variable "kms_key_arn" {
   type        = string
   description = "Optional KMS key ARN for the AOSS encryption security policy. If null (default), the AWS-owned AOSS key is used. Serverless mode only."
@@ -84,10 +72,3 @@ variable "allow_public_access" {
   description = "AOSS network security policy: when true (default), the collection and dashboards are reachable from the public internet. Set false only if the stack provisions an aws_opensearchserverless_vpc_endpoint (not included in this module). Serverless mode only."
   default     = true
 }
-
-variable "vector_embedding_dimension" {
-  type        = number
-  description = "Dimension of the k-NN vector field on the Bedrock default index. Default 1024 matches amazon.titan-embed-text-v1. Change if you switch embedding_model_id in the Bedrock module."
-  default     = 1024
-}
-

--- a/aws/opensearch/variables.tf
+++ b/aws/opensearch/variables.tf
@@ -57,3 +57,33 @@ variable "tags" {
   default     = {}
 }
 
+variable "data_access_principal_arns" {
+  type        = list(string)
+  description = "List of IAM role/user ARNs granted aoss:* on the collection and its indexes via a data-access policy. Serverless mode only. When non-empty, the Terraform caller's underlying role ARN is also added so it can create the vector index."
+  default     = []
+}
+
+variable "create_bedrock_vector_index" {
+  type        = bool
+  description = "When true (and deployment_type is serverless), create the bedrock-knowledge-base-default-index vector index with the k-NN field mapping required by aws_bedrockagent_knowledge_base. Requires data_access_principal_arns to include the Bedrock KB role."
+  default     = false
+}
+
+variable "kms_key_arn" {
+  type        = string
+  description = "Optional KMS key ARN for the AOSS encryption security policy. If null (default), the AWS-owned AOSS key is used. Serverless mode only."
+  default     = null
+}
+
+variable "allow_public_access" {
+  type        = bool
+  description = "AOSS network security policy: when true (default), the collection and dashboards are reachable from the public internet. Set false only if the stack provisions an aws_opensearchserverless_vpc_endpoint (not included in this module). Serverless mode only."
+  default     = true
+}
+
+variable "vector_embedding_dimension" {
+  type        = number
+  description = "Dimension of the k-NN vector field on the Bedrock default index. Default 1024 matches amazon.titan-embed-text-v1. Change if you switch embedding_model_id in the Bedrock module."
+  default     = 1024
+}
+

--- a/examples/edubot/main.tf
+++ b/examples/edubot/main.tf
@@ -105,21 +105,24 @@ module "secretsmanager" {
 }
 
 module "opensearch" {
-  source      = "../../aws/opensearch"
-  vpc_id      = module.vpc.vpc_id
-  subnet_ids  = module.vpc.private_subnet_ids
-  project     = var.opensearch_project
-  region      = var.opensearch_region
-  environment = var.environment
+  source                      = "../../aws/opensearch"
+  vpc_id                      = module.vpc.vpc_id
+  subnet_ids                  = module.vpc.private_subnet_ids
+  project                     = var.opensearch_project
+  region                      = var.opensearch_region
+  environment                 = var.environment
+  deployment_type             = "serverless"
+  data_access_principal_arns  = [module.bedrock.role_arn]
+  create_bedrock_vector_index = true
 }
 
 module "bedrock" {
-  source         = "../../aws/bedrock"
-  s3_bucket_arn  = module.s3.bucket_arn
-  opensearch_arn = module.opensearch.opensearch_arn
-  project        = var.bedrock_project
-  region         = var.bedrock_region
-  environment    = var.environment
+  source                    = "../../aws/bedrock"
+  s3_bucket_arn             = module.s3.bucket_arn
+  opensearch_collection_arn = module.opensearch.collection_arn
+  project                   = var.bedrock_project
+  region                    = var.bedrock_region
+  environment               = var.environment
 }
 
 module "githubactions" {

--- a/examples/edubot/main.tf
+++ b/examples/edubot/main.tf
@@ -105,15 +105,13 @@ module "secretsmanager" {
 }
 
 module "opensearch" {
-  source                      = "../../aws/opensearch"
-  vpc_id                      = module.vpc.vpc_id
-  subnet_ids                  = module.vpc.private_subnet_ids
-  project                     = var.opensearch_project
-  region                      = var.opensearch_region
-  environment                 = var.environment
-  deployment_type             = "serverless"
-  data_access_principal_arns  = [module.bedrock.role_arn]
-  create_bedrock_vector_index = true
+  source          = "../../aws/opensearch"
+  vpc_id          = module.vpc.vpc_id
+  subnet_ids      = module.vpc.private_subnet_ids
+  project         = var.opensearch_project
+  region          = var.opensearch_region
+  environment     = var.environment
+  deployment_type = "serverless"
 }
 
 module "bedrock" {

--- a/examples/gamestudio/main.tf
+++ b/examples/gamestudio/main.tf
@@ -64,21 +64,24 @@ module "secretsmanager" {
 }
 
 module "opensearch" {
-  source      = "../../aws/opensearch"
-  vpc_id      = module.vpc.vpc_id
-  subnet_ids  = module.vpc.private_subnet_ids
-  project     = var.opensearch_project
-  environment = var.environment
-  region      = var.opensearch_region
+  source                      = "../../aws/opensearch"
+  vpc_id                      = module.vpc.vpc_id
+  subnet_ids                  = module.vpc.private_subnet_ids
+  project                     = var.opensearch_project
+  environment                 = var.environment
+  region                      = var.opensearch_region
+  deployment_type             = "serverless"
+  data_access_principal_arns  = [module.bedrock.role_arn]
+  create_bedrock_vector_index = true
 }
 
 module "bedrock" {
-  source         = "../../aws/bedrock"
-  s3_bucket_arn  = module.s3.bucket_arn
-  opensearch_arn = module.opensearch.opensearch_arn
-  project        = var.bedrock_project
-  environment    = var.environment
-  region         = var.bedrock_region
+  source                    = "../../aws/bedrock"
+  s3_bucket_arn             = module.s3.bucket_arn
+  opensearch_collection_arn = module.opensearch.collection_arn
+  project                   = var.bedrock_project
+  environment               = var.environment
+  region                    = var.bedrock_region
 }
 
 module "sqs" {

--- a/examples/gamestudio/main.tf
+++ b/examples/gamestudio/main.tf
@@ -64,15 +64,13 @@ module "secretsmanager" {
 }
 
 module "opensearch" {
-  source                      = "../../aws/opensearch"
-  vpc_id                      = module.vpc.vpc_id
-  subnet_ids                  = module.vpc.private_subnet_ids
-  project                     = var.opensearch_project
-  environment                 = var.environment
-  region                      = var.opensearch_region
-  deployment_type             = "serverless"
-  data_access_principal_arns  = [module.bedrock.role_arn]
-  create_bedrock_vector_index = true
+  source          = "../../aws/opensearch"
+  vpc_id          = module.vpc.vpc_id
+  subnet_ids      = module.vpc.private_subnet_ids
+  project         = var.opensearch_project
+  environment     = var.environment
+  region          = var.opensearch_region
+  deployment_type = "serverless"
 }
 
 module "bedrock" {

--- a/examples/revisionapp/main.tf
+++ b/examples/revisionapp/main.tf
@@ -141,15 +141,13 @@ module "secretsmanager" {
 }
 
 module "opensearch" {
-  source                      = "../../aws/opensearch"
-  vpc_id                      = module.vpc.vpc_id
-  subnet_ids                  = module.vpc.private_subnet_ids
-  project                     = var.opensearch_project
-  environment                 = var.environment
-  region                      = var.opensearch_region
-  deployment_type             = "serverless"
-  data_access_principal_arns  = [module.bedrock.role_arn]
-  create_bedrock_vector_index = true
+  source          = "../../aws/opensearch"
+  vpc_id          = module.vpc.vpc_id
+  subnet_ids      = module.vpc.private_subnet_ids
+  project         = var.opensearch_project
+  environment     = var.environment
+  region          = var.opensearch_region
+  deployment_type = "serverless"
 }
 
 module "bedrock" {

--- a/examples/revisionapp/main.tf
+++ b/examples/revisionapp/main.tf
@@ -141,21 +141,24 @@ module "secretsmanager" {
 }
 
 module "opensearch" {
-  source      = "../../aws/opensearch"
-  vpc_id      = module.vpc.vpc_id
-  subnet_ids  = module.vpc.private_subnet_ids
-  project     = var.opensearch_project
-  environment = var.environment
-  region      = var.opensearch_region
+  source                      = "../../aws/opensearch"
+  vpc_id                      = module.vpc.vpc_id
+  subnet_ids                  = module.vpc.private_subnet_ids
+  project                     = var.opensearch_project
+  environment                 = var.environment
+  region                      = var.opensearch_region
+  deployment_type             = "serverless"
+  data_access_principal_arns  = [module.bedrock.role_arn]
+  create_bedrock_vector_index = true
 }
 
 module "bedrock" {
-  source         = "../../aws/bedrock"
-  s3_bucket_arn  = module.s3.bucket_arn
-  opensearch_arn = module.opensearch.opensearch_arn
-  project        = var.bedrock_project
-  environment    = var.environment
-  region         = var.bedrock_region
+  source                    = "../../aws/bedrock"
+  s3_bucket_arn             = module.s3.bucket_arn
+  opensearch_collection_arn = module.opensearch.collection_arn
+  project                   = var.bedrock_project
+  environment               = var.environment
+  region                    = var.bedrock_region
 }
 
 module "sqs" {


### PR DESCRIPTION
## Summary

Bedrock Knowledge Base creation has been failing on every composed stack that includes `aws/bedrock` (concrete repro: reliable3 session `sess_v2_vQ_piI47NgiO`). The root cause was three interlocking defects — wrong ARN shape fed from opensearch, wrong IAM action family (`es:*` instead of `aoss:*`), and missing AOSS prerequisites.

Rather than try to terraform the entire KB path end-to-end (which pulled in an in-module `provider "opensearch"` block, a data-access-policy cycle through the Bedrock role, a 45s `time_sleep` for AOSS propagation, and a hard dependency on `iam:GetRole` for the deploy runner), this PR **narrows both modules to the infrastructure skeleton only**. The Bedrock Knowledge Base itself, its vector index, and its data-access policy are now created by the application layer — the process that actually has data to ingest, knows which embedding model to use, and knows the field schema the index needs.

Fixes #68.

### What changed

**`aws/bedrock`** — now provisions *just* the Bedrock IAM role and policy:
- Rename `var.opensearch_arn` → `var.opensearch_collection_arn` (breaking). Regex-validated to an AOSS collection ARN; managed-domain ARNs fail at plan.
- `s3_bucket_arn` and `opensearch_collection_arn` are required (defaults removed) — the role has no purpose without either, and null-resource IAM statements fail silently at apply.
- IAM swapped from `es:ESHttp*` to `aoss:APIAccessAll` on the collection ARN; `bedrock:InvokeModel` now grants on both chat and embedding model ARNs.
- Removed: `aws_bedrockagent_knowledge_base`, `aws_bedrockagent_data_source`, `knowledge_base_name` variable, `knowledge_base_id` / `knowledge_base_arn` / `data_source_id` outputs.
- Added: `role_name` output for app-layer policy attachment.

**`aws/opensearch`** (serverless path) — now provisions an empty vector-ready AOSS collection:
- AOSS service-linked role bootstrap (`AWSServiceRoleForAmazonOpenSearchServerless`), same probe/create idiom used for managed OpenSearch, MSK, and EKS node groups. Comment explains the `observability.aoss.amazonaws.com` service-role path.
- Encryption + network security policies (AWS-owned key default, public network default, both with escape-hatch vars).
- Collection itself with `depends_on` on the SLR and both policies.
- New output `collection_arn` for wiring into bedrock.
- Removed: the AOSS data-access policy, vector index, `time_sleep`, `provider "opensearch"` block, `opensearch-project/opensearch` + `hashicorp/time` provider deps, `data.aws_caller_identity` + `data.aws_iam_session_context` lookups.

**Variable contract tightening** (from review):
- `var.project` validated ≤21 chars — catches oversize project names at plan instead of at AWS API (OpenSearch Service domain-name cap of 28 minus the 7-char `-search` suffix).
- `var.deployment_type` restricted to `{"managed", "serverless"}` — typos no longer fall through the mode ternary silently.
- `vpc_id` / `subnet_ids` now optional with `null` / `[]` defaults (ignored in serverless). `lifecycle.precondition` on the managed-mode security group fails plan with a clear message if they're missing in managed mode.

**Examples** (revisionapp / gamestudio / edubot) now set `deployment_type = "serverless"` on opensearch and pass `opensearch_collection_arn = module.opensearch.collection_arn` into bedrock. No other wiring required.

### What the modules deliberately no longer do

- Create the Bedrock Knowledge Base resource
- Create the AOSS vector index (requires embedding-model-specific schema)
- Create the AOSS data-access policy (requires knowing which application roles need access)
- Pull in non-AWS providers
- Configure a `provider` block inside a child module

All of those move to the application layer, which has the right context and doesn't need a generic terraform preset to own them.

### Composer dependency

Composer-side changes tracked in [luthersystems/reliable#904](https://github.com/luthersystems/reliable/issues/904). With the reduced scope, the composer change shrinks to just the variable rename (`opensearch_arn` → `opensearch_collection_arn`, RHS now `module.opensearch.collection_arn`) and forcing `deployment_type = "serverless"` on opensearch when bedrock is composed. No new providers, no principal wiring, no module-level `depends_on`.

### Verification

- `terraform fmt -check -recursive` — clean.
- `terraform init -backend=false && terraform validate` — both modules pass (only `hashicorp/aws` required).
- `terraform init && terraform validate` — all three examples pass.
- `tests/lint-sensitive-for-each.sh` — clean.
- CI green across all 63 preset + example validations.
- Fresh-account apply-readiness: no Bedrock console opt-in required (KB creation is not managed by terraform), no `iam:GetRole` needed on the deploy runner, no `aoss:APIAccessAll` needed on the deploy runner, AOSS SLR bootstrapped preemptively.