### PR TITLE
fix(opensearch): guard SLR count against empty data-source tuples

### DIFF
--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -64,8 +64,13 @@ data "aws_iam_roles" "opensearch_slr" {
   path_prefix = "/aws-service-role/opensearchservice.amazonaws.com/"
 }
 
+# `data.aws_iam_roles.opensearch_slr` is itself count-conditional, so it is a
+# tuple that can be empty. Terraform analyses the `[0]` access statically and
+# rejects it when the tuple is empty — `&&` short-circuit does not help. Wrap
+# the index in try() and default to 1 ("names already present, do nothing") so
+# we never race to create an SLR that may already exist.
 resource "aws_iam_service_linked_role" "opensearch" {
-  count            = var.deployment_type == "managed" && length(data.aws_iam_roles.opensearch_slr) > 0 && length(data.aws_iam_roles.opensearch_slr[0].names) == 0 ? 1 : 0
+  count            = var.deployment_type == "managed" && try(length(data.aws_iam_roles.opensearch_slr[0].names), 1) == 0 ? 1 : 0
   aws_service_name = "opensearchservice.amazonaws.com"
   description      = "Service-linked role for Amazon OpenSearch Service VPC access"
 }
@@ -124,8 +129,10 @@ data "aws_iam_roles" "aoss_slr" {
   path_prefix = "/aws-service-role/observability.aoss.amazonaws.com/"
 }
 
+# Same empty-tuple hazard as aws_iam_service_linked_role.opensearch above —
+# see the comment on that resource for rationale.
 resource "aws_iam_service_linked_role" "aoss" {
-  count            = local.is_serverless && length(data.aws_iam_roles.aoss_slr) > 0 && length(data.aws_iam_roles.aoss_slr[0].names) == 0 ? 1 : 0
+  count            = local.is_serverless && try(length(data.aws_iam_roles.aoss_slr[0].names), 1) == 0 ? 1 : 0
   aws_service_name = "observability.aoss.amazonaws.com"
   description      = "Service-linked role for Amazon OpenSearch Serverless"
 }

--- a/aws/opensearch/tests/slr_count_guard.tftest.hcl
+++ b/aws/opensearch/tests/slr_count_guard.tftest.hcl
@@ -1,0 +1,52 @@
+mock_provider "aws" {}
+
+# Regression for #70. Both service-linked-role data sources are themselves
+# conditional (count = 0 on the "off" deployment_type), producing an empty
+# tuple. Indexing with [0] inside the aws_iam_service_linked_role.count
+# expression previously failed at plan time:
+#
+#   Error: Invalid index — data.aws_iam_roles.opensearch_slr is empty tuple
+#
+# `&&` short-circuit does not prevent Terraform from analysing the [0] access,
+# so the guard must be written with try().
+#
+# Each run below forces one of the two data sources to an empty tuple.
+
+run "managed_mode_plans_with_empty_aoss_slr_tuple" {
+  command = plan
+
+  variables {
+    project         = "test"
+    region          = "us-east-1"
+    environment     = "test"
+    deployment_type = "managed"
+    vpc_id          = "vpc-12345"
+    subnet_ids      = ["subnet-aaa"]
+  }
+
+  # In managed mode, data.aws_iam_roles.aoss_slr has count=0 (empty tuple).
+  # The aws_iam_service_linked_role.aoss count expression must cope.
+  assert {
+    condition     = length(aws_iam_service_linked_role.aoss) == 0
+    error_message = "Expected no AOSS SLR resource when deployment_type = managed"
+  }
+}
+
+run "serverless_mode_plans_with_empty_opensearch_slr_tuple" {
+  command = plan
+
+  variables {
+    project         = "test"
+    region          = "us-east-1"
+    environment     = "test"
+    deployment_type = "serverless"
+  }
+
+  # In serverless mode, data.aws_iam_roles.opensearch_slr has count=0
+  # (empty tuple). The aws_iam_service_linked_role.opensearch count
+  # expression must cope.
+  assert {
+    condition     = length(aws_iam_service_linked_role.opensearch) == 0
+    error_message = "Expected no managed-OpenSearch SLR resource when deployment_type = serverless"
+  }
+}

--- a/aws/opensearch/tests/slr_count_guard.tftest.hcl
+++ b/aws/opensearch/tests/slr_count_guard.tftest.hcl
@@ -10,10 +10,21 @@ mock_provider "aws" {}
 # `&&` short-circuit does not prevent Terraform from analysing the [0] access,
 # so the guard must be written with try().
 #
-# Each run below forces one of the two data sources to an empty tuple.
+# Each run pins one direction of the hazard and also exercises the positive
+# "create when names is empty" branch by overriding the non-empty probe —
+# otherwise a mutation that replaced the try() with a constant would slip past.
 
-run "managed_mode_plans_with_empty_aoss_slr_tuple" {
+run "managed_mode_creates_slr_and_tolerates_empty_aoss_tuple" {
   command = plan
+
+  # Force the managed-SLR probe to report "role absent" so the try() guard's
+  # creation branch runs — asserting count == 1 pins that branch.
+  override_data {
+    target = data.aws_iam_roles.opensearch_slr[0]
+    values = {
+      names = []
+    }
+  }
 
   variables {
     project         = "test"
@@ -24,16 +35,29 @@ run "managed_mode_plans_with_empty_aoss_slr_tuple" {
     subnet_ids      = ["subnet-aaa"]
   }
 
-  # In managed mode, data.aws_iam_roles.aoss_slr has count=0 (empty tuple).
-  # The aws_iam_service_linked_role.aoss count expression must cope.
+  assert {
+    condition     = length(aws_iam_service_linked_role.opensearch) == 1
+    error_message = "Expected the managed-OpenSearch SLR to be created when the probe returns no matching role"
+  }
+
+  # data.aws_iam_roles.aoss_slr has count = 0 here — empty tuple.
   assert {
     condition     = length(aws_iam_service_linked_role.aoss) == 0
     error_message = "Expected no AOSS SLR resource when deployment_type = managed"
   }
 }
 
-run "serverless_mode_plans_with_empty_opensearch_slr_tuple" {
+run "serverless_mode_creates_aoss_slr_and_tolerates_empty_opensearch_tuple" {
   command = plan
+
+  # Mirror of the managed run: force the AOSS probe to report "role absent"
+  # so the try() creation branch is exercised.
+  override_data {
+    target = data.aws_iam_roles.aoss_slr[0]
+    values = {
+      names = []
+    }
+  }
 
   variables {
     project         = "test"
@@ -42,9 +66,12 @@ run "serverless_mode_plans_with_empty_opensearch_slr_tuple" {
     deployment_type = "serverless"
   }
 
-  # In serverless mode, data.aws_iam_roles.opensearch_slr has count=0
-  # (empty tuple). The aws_iam_service_linked_role.opensearch count
-  # expression must cope.
+  assert {
+    condition     = length(aws_iam_service_linked_role.aoss) == 1
+    error_message = "Expected the AOSS SLR to be created when the probe returns no matching role"
+  }
+
+  # data.aws_iam_roles.opensearch_slr has count = 0 here — empty tuple.
   assert {
     condition     = length(aws_iam_service_linked_role.opensearch) == 0
     error_message = "Expected no managed-OpenSearch SLR resource when deployment_type = serverless"


### PR DESCRIPTION
## Summary

- Both `aws_iam_service_linked_role.{opensearch,aoss}` count expressions indexed `data.aws_iam_roles.*_slr[0]` directly. When the data source's own count resolves to 0 (the \"other\" deployment_type), the tuple is empty and Terraform rejects the [0] access at plan time — `&&` short-circuit doesn't prevent the static index check.
- Replaced the unsafe index with `try(length(... [0].names), 1) == 0`. Default of 1 means \"names already present, do nothing\", so a probe that can't resolve causes us to skip creating the SLR — the safe direction, since `aws_iam_service_linked_role` fails hard when the role already exists.
- Added `aws/opensearch/tests/slr_count_guard.tftest.hcl` with one plan-level run per `deployment_type` to exercise the empty-tuple path on each side. Both runs fail on `main` with the exact error quoted in the issue; both pass after the fix.

## Test plan

- [x] `terraform test` in `aws/opensearch` — 2 passed, 0 failed
- [x] `terraform validate` in `aws/opensearch`
- [x] `terraform validate` in the three examples that pull in `aws/opensearch` (`edubot`, `gamestudio`, `revisionapp`)
- [x] `terraform fmt -check -recursive`

Fixes #70