### PR TITLE
fix(aws/opensearch): emit AOSS AWSOwnedKey as boolean (not coerced string)

### DIFF
--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -141,19 +141,28 @@ resource "aws_opensearchserverless_security_policy" "encryption" {
   count = local.is_serverless ? 1 : 0
   name  = "${var.project}-enc"
   type  = "encryption"
-  # AOSS expects exactly one of AWSOwnedKey or KmsARN — emit only the
-  # active field, not both with a null. Otherwise AOSS rejects the policy.
-  policy = jsonencode(merge(
-    {
-      Rules = [
-        {
-          ResourceType = "collection"
-          Resource     = ["collection/${local.collection_name}"]
-        }
-      ]
-    },
-    var.kms_key_arn == null ? { AWSOwnedKey = true } : { KmsARN = var.kms_key_arn }
-  ))
+  # AOSS expects exactly one of AWSOwnedKey (bool) or KmsARN (string).
+  # jsonencode() is applied inside each arm so the ternary unifies on
+  # string, not on a map value type. An earlier merge()-based version
+  # forced HCL to unify bool with string across the two arms and emitted
+  # AWSOwnedKey as the string "true", which AOSS rejects.
+  policy = var.kms_key_arn == null ? jsonencode({
+    Rules = [
+      {
+        ResourceType = "collection"
+        Resource     = ["collection/${local.collection_name}"]
+      }
+    ]
+    AWSOwnedKey = true
+    }) : jsonencode({
+    Rules = [
+      {
+        ResourceType = "collection"
+        Resource     = ["collection/${local.collection_name}"]
+      }
+    ]
+    KmsARN = var.kms_key_arn
+  })
 }
 
 resource "aws_opensearchserverless_security_policy" "network" {

--- a/aws/opensearch/tests/slr_count_guard.tftest.hcl
+++ b/aws/opensearch/tests/slr_count_guard.tftest.hcl
@@ -45,6 +45,13 @@ run "managed_mode_creates_slr_and_tolerates_empty_aoss_tuple" {
     condition     = length(aws_iam_service_linked_role.aoss) == 0
     error_message = "Expected no AOSS SLR resource when deployment_type = managed"
   }
+
+  # Encryption policy is AOSS-only. Locks the is_serverless guard at
+  # main.tf so a mutation to `count = 1` can't slip through.
+  assert {
+    condition     = length(aws_opensearchserverless_security_policy.encryption) == 0
+    error_message = "AOSS encryption policy must not exist when deployment_type = managed"
+  }
 }
 
 run "serverless_mode_creates_aoss_slr_and_tolerates_empty_opensearch_tuple" {

--- a/aws/opensearch/tests/slr_count_guard.tftest.hcl
+++ b/aws/opensearch/tests/slr_count_guard.tftest.hcl
@@ -76,4 +76,48 @@ run "serverless_mode_creates_aoss_slr_and_tolerates_empty_opensearch_tuple" {
     condition     = length(aws_iam_service_linked_role.opensearch) == 0
     error_message = "Expected no managed-OpenSearch SLR resource when deployment_type = serverless"
   }
+
+  # Regression for #75. merge() unified the bool arm with the string arm
+  # of the kms_key_arn ternary, which serialized AWSOwnedKey as the string
+  # "true" and made AOSS reject the policy with "string found, boolean
+  # expected". Equality against `true` fails on both the string form and
+  # on a missing field, so it locks the JSON type.
+  assert {
+    condition     = jsondecode(aws_opensearchserverless_security_policy.encryption[0].policy).AWSOwnedKey == true
+    error_message = "AOSS encryption policy must serialize AWSOwnedKey as a JSON boolean, not a string"
+  }
+
+  assert {
+    condition     = !can(jsondecode(aws_opensearchserverless_security_policy.encryption[0].policy).KmsARN)
+    error_message = "AOSS encryption policy must omit KmsARN when using the AWS-owned key"
+  }
+}
+
+run "serverless_mode_with_customer_kms_uses_kms_arn_field" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_roles.aoss_slr[0]
+    values = {
+      names = ["AWSServiceRoleForAmazonOpenSearchServerless"]
+    }
+  }
+
+  variables {
+    project         = "test"
+    region          = "us-east-1"
+    environment     = "test"
+    deployment_type = "serverless"
+    kms_key_arn     = "arn:aws:kms:us-east-1:123456789012:key/abcd1234-ab12-cd34-ef56-abcdef123456"
+  }
+
+  assert {
+    condition     = jsondecode(aws_opensearchserverless_security_policy.encryption[0].policy).KmsARN == "arn:aws:kms:us-east-1:123456789012:key/abcd1234-ab12-cd34-ef56-abcdef123456"
+    error_message = "AOSS encryption policy must emit the customer KmsARN as a string when provided"
+  }
+
+  assert {
+    condition     = !can(jsondecode(aws_opensearchserverless_security_policy.encryption[0].policy).AWSOwnedKey)
+    error_message = "AOSS encryption policy must omit AWSOwnedKey when a customer KMS ARN is set"
+  }
 }

--- a/aws/opensearch/variables.tf
+++ b/aws/opensearch/variables.tf
@@ -71,6 +71,15 @@ variable "kms_key_arn" {
   type        = string
   description = "Optional KMS key ARN for the AOSS encryption security policy. If null (default), the AWS-owned AOSS key is used. Serverless mode only."
   default     = null
+
+  # Empty string would take the customer-KMS arm of the encryption policy
+  # and emit `"KmsARN":""`, which AOSS rejects. Force null for the default.
+  # Ternary (not `||`) because Terraform validation does not short-circuit —
+  # `trimspace(null)` would blow up before the null check fires.
+  validation {
+    condition     = var.kms_key_arn == null ? true : length(trimspace(var.kms_key_arn)) > 0
+    error_message = "kms_key_arn must be null or a non-empty ARN string."
+  }
 }
 
 variable "allow_public_access" {


### PR DESCRIPTION
## Summary

- `aws/opensearch/main.tf` built the AOSS encryption policy with `jsonencode(merge({Rules=[...]}, kms_key_arn == null ? {AWSOwnedKey = true} : {KmsARN = var.kms_key_arn}))`. HCL unifies value types across the ternary arms, so the bool `true` was promoted to the string `"true"` and AOSS rejected the policy with `[$.AWSOwnedKey: string found, boolean expected]`.
- Dropped `merge()` and applied `jsonencode()` inside each arm. The ternary now unifies on `string`, and each arm's single object literal keeps `AWSOwnedKey` as a native bool through serialization.
- Extended `aws/opensearch/tests/slr_count_guard.tftest.hcl` with regression asserts that `jsondecode` the emitted policy and fail on either the old string-"true" coercion or a missing field. Added a second `run` covering the customer-KMS-ARN path.

## Similar-issue sweep

Surveyed every `merge()` call in `aws/*/*.tf` and `gcp/*/*.tf`. `jsonencode(merge(...))` appears in **exactly one place** — the line this PR fixes. All other `merge()` sites are homogeneous-type tag/label merges or same-shape structural merges (e.g. `aws/resource/main.tf:91` EKS addons keyed by distinct names; `aws/cognito/main.tf:95` map-of-string arms). The sibling network-policy at `aws/opensearch/main.tf:168` uses `jsonencode([...])` with a bool field and works because there is no `merge` to trigger unification. No other open OpenSearch issues: #61, #68, #70 are closed.

## Test plan

- [x] `cd aws/opensearch && terraform init -backend=false && terraform validate` — passes
- [x] `terraform test` — 3/3 runs pass (two existing + new KMS-ARN run)
- [x] `terraform fmt -check -recursive aws gcp` — clean
- [x] `go test ./pkg/composer/...` — passes (45s)
- [ ] End-to-end: rerun a reliable session that previously failed at this resource (session IDs in #75) once this lands.

Closes #75.