### PR TITLE
refactor(composer): deprecate legacy keys and fields on public surface

### DIFF
--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -3,37 +3,69 @@ package composer
 type ComponentKey string
 
 const (
-	KeyComposer             ComponentKey = "composer"
-	KeyArch                 ComponentKey = "architecture"
-	KeyCloud                ComponentKey = "cloud"
-	KeyEC2                  ComponentKey = "ec2"
-	KeyResource             ComponentKey = "resource"
-	KeyVPC                  ComponentKey = "vpc"
-	KeyBastion              ComponentKey = "bastion"
-	KeyALB                  ComponentKey = "alb"
-	KeyCloudfront           ComponentKey = "cloudfront"
-	KeyWAF                  ComponentKey = "waf"
-	KeyPostgres             ComponentKey = "rds"
-	KeyElastiCache          ComponentKey = "elasticache"
-	KeyS3                   ComponentKey = "s3"
-	KeyDynamoDB             ComponentKey = "dynamodb"
-	KeySQS                  ComponentKey = "sqs"
-	KeyMSK                  ComponentKey = "msk"
-	KeyCloudWatchLogs       ComponentKey = "cloudwatchlogs"
+	KeyComposer ComponentKey = "composer"
+	KeyArch     ComponentKey = "architecture"
+	KeyCloud    ComponentKey = "cloud"
+
+	// KeyEC2 is the polymorphic EKS node-group / Lambda compute key.
+	// Distinct from KeyAWSEC2 (EKS node group only); see GetModuleDir.
+	KeyEC2 ComponentKey = "ec2"
+	// KeyResource is the polymorphic EKS control plane / Lambda runtime key;
+	// see GetModuleDir.
+	KeyResource ComponentKey = "resource"
+
+	// Deprecated: Use KeyAWSVPC.
+	KeyVPC ComponentKey = "vpc"
+	// Deprecated: Use KeyAWSBastion.
+	KeyBastion ComponentKey = "bastion"
+	// Deprecated: Use KeyAWSALB.
+	KeyALB ComponentKey = "alb"
+	// Deprecated: Use KeyAWSCloudfront.
+	KeyCloudfront ComponentKey = "cloudfront"
+	// Deprecated: Use KeyAWSWAF.
+	KeyWAF ComponentKey = "waf"
+	// Deprecated: Use KeyAWSRDS.
+	KeyPostgres ComponentKey = "rds"
+	// Deprecated: Use KeyAWSElastiCache.
+	KeyElastiCache ComponentKey = "elasticache"
+	// Deprecated: Use KeyAWSS3.
+	KeyS3 ComponentKey = "s3"
+	// Deprecated: Use KeyAWSDynamoDB.
+	KeyDynamoDB ComponentKey = "dynamodb"
+	// Deprecated: Use KeyAWSSQS.
+	KeySQS ComponentKey = "sqs"
+	// Deprecated: Use KeyAWSMSK.
+	KeyMSK ComponentKey = "msk"
+	// Deprecated: Use KeyAWSCloudWatchLogs.
+	KeyCloudWatchLogs ComponentKey = "cloudwatchlogs"
+	// Deprecated: Use KeyAWSCloudWatchMonitoring.
 	KeyCloudWatchMonitoring ComponentKey = "cloudwatchmonitoring"
-	KeySplunk               ComponentKey = "splunk"
-	KeyDatadog              ComponentKey = "datadog"
-	KeyGrafana              ComponentKey = "grafana"
-	KeyCognito              ComponentKey = "cognito"
-	KeyBackups              ComponentKey = "backups"
-	KeyGitHubActions        ComponentKey = "githubactions"
-	KeyCodePipeline         ComponentKey = "codepipeline"
-	KeyLambda               ComponentKey = "lambda"
-	KeyAPIGateway           ComponentKey = "apigateway"
-	KeyKMS                  ComponentKey = "kms"
-	KeySecrets              ComponentKey = "secretsmanager"
-	KeyOpenSearch           ComponentKey = "opensearch"
-	KeyBedrock              ComponentKey = "bedrock"
+
+	KeySplunk  ComponentKey = "splunk"
+	KeyDatadog ComponentKey = "datadog"
+
+	// Deprecated: Use KeyAWSGrafana.
+	KeyGrafana ComponentKey = "grafana"
+	// Deprecated: Use KeyAWSCognito.
+	KeyCognito ComponentKey = "cognito"
+	// Deprecated: Use KeyAWSBackups.
+	KeyBackups ComponentKey = "backups"
+	// Deprecated: Use KeyAWSGitHubActions.
+	KeyGitHubActions ComponentKey = "githubactions"
+	// Deprecated: Use KeyAWSCodePipeline.
+	KeyCodePipeline ComponentKey = "codepipeline"
+	// Deprecated: Use KeyAWSLambda.
+	KeyLambda ComponentKey = "lambda"
+	// Deprecated: Use KeyAWSAPIGateway.
+	KeyAPIGateway ComponentKey = "apigateway"
+	// Deprecated: Use KeyAWSKMS.
+	KeyKMS ComponentKey = "kms"
+	// Deprecated: Use KeyAWSSecretsManager.
+	KeySecrets ComponentKey = "secretsmanager"
+	// Deprecated: Use KeyAWSOpenSearch.
+	KeyOpenSearch ComponentKey = "opensearch"
+	// Deprecated: Use KeyAWSBedrock.
+	KeyBedrock ComponentKey = "bedrock"
 
 	// AWS components (new prefixed names for v2)
 	KeyAWSVPC                  ComponentKey = "aws_vpc"

--- a/pkg/composer/doc.go
+++ b/pkg/composer/doc.go
@@ -1,0 +1,30 @@
+// Package composer turns a declarative "components + config" session into a
+// ready-to-deploy Terraform stack by wiring together preset modules from
+// insideout-terraform-presets.
+//
+// # Canonical key vocabulary
+//
+// The public API uses cloud-prefixed [ComponentKey] values:
+//
+//   - AWS: KeyAWSVPC, KeyAWSBastion, KeyAWSEKS, KeyAWSRDS, KeyAWSS3, …
+//   - GCP: KeyGCPVPC, KeyGCPGKE, KeyGCPCloudSQL, KeyGCPGCS, …
+//   - Third-party (not cloud-specific): KeySplunk, KeyDatadog.
+//
+// New callers should select and wire modules exclusively in this vocabulary,
+// and should populate the AWS*/GCP* fields on [Components] and [Config].
+//
+// # Legacy (deprecated) surface
+//
+// The un-prefixed [ComponentKey] constants (KeyVPC, KeyALB, KeyBastion,
+// KeyCloudfront, KeyPostgres, KeyS3, …) and the matching un-prefixed fields
+// on [Components] and [Config] exist solely to parse historical session JSON
+// from reliable. They are deprecated and will be removed in a future release.
+//
+// These symbols are not part of composer's supported public contract. If you
+// need to consume historical session payloads, use reliable's composeradapter
+// package (see luthersystems/reliable#998), which normalises legacy shapes to
+// the prefixed vocabulary before handing them to composer.
+//
+// See luthersystems/insideout-terraform-presets#76 for the phased removal
+// plan.
+package composer

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -81,32 +81,63 @@ type Components struct {
 
 	// ==================== Legacy Fields (backward compatibility) ====================
 	// These are kept for backward compatibility when parsing old JSON.
-	// They will be phased out as the codebase migrates to cloud-specific fields.
-	EC2                  string `json:"ec2,omitempty"`
-	Resource             string `json:"resource,omitempty"`
-	VPC                  string `json:"vpc,omitempty"`
-	Bastion              *bool  `json:"bastion,omitempty"`
-	ALB                  *bool  `json:"alb,omitempty"`
-	CloudFront           *bool  `json:"cloudfront,omitempty"`
-	WAF                  *bool  `json:"waf,omitempty"`
-	Postgres             *bool  `json:"postgres,omitempty"`
-	ElastiCache          *bool  `json:"elasticache,omitempty"`
-	S3                   *bool  `json:"s3,omitempty"`
-	DynamoDB             *bool  `json:"dynamodb,omitempty"`
-	SQS                  *bool  `json:"sqs,omitempty"`
-	MSK                  *bool  `json:"msk,omitempty"`
-	CloudWatchLogs       *bool  `json:"cloudwatchlogs,omitempty"`
-	CloudWatchMonitoring *bool  `json:"cloudwatchmonitoring,omitempty"`
-	Grafana              *bool  `json:"grafana,omitempty"`
-	Cognito              *bool  `json:"cognito,omitempty"`
-	APIGateway           *bool  `json:"apigateway,omitempty"`
-	KMS                  *bool  `json:"kms,omitempty"`
-	SecretsManager       *bool  `json:"secretsmanager,omitempty"`
-	OpenSearch           *bool  `json:"opensearch,omitempty"`
-	Bedrock              *bool  `json:"bedrock,omitempty"`
-	Lambda               *bool  `json:"lambda,omitempty"`
-	CodePipeline         *bool  `json:"codepipeline,omitempty"`
-	Backups              *struct {
+	// Deprecated as a group: use the AWS*-prefixed fields above. See doc.go
+	// and insideout-terraform-presets#76 for the removal plan; historical
+	// session JSON should be normalised by reliable's composeradapter before
+	// reaching composer.
+	//
+	// Deprecated: Use AWSEC2 (node-group flavour) or the polymorphic AWS
+	// compute keys. Retained for legacy session JSON parsing only.
+	EC2 string `json:"ec2,omitempty"`
+	// Deprecated: Polymorphic EKS/Lambda indicator kept for legacy session
+	// parsing. Use the prefixed keys on Components directly.
+	Resource string `json:"resource,omitempty"`
+	// Deprecated: Use AWSVPC.
+	VPC string `json:"vpc,omitempty"`
+	// Deprecated: Use AWSBastion.
+	Bastion *bool `json:"bastion,omitempty"`
+	// Deprecated: Use AWSALB.
+	ALB *bool `json:"alb,omitempty"`
+	// Deprecated: Use AWSCloudFront.
+	CloudFront *bool `json:"cloudfront,omitempty"`
+	// Deprecated: Use AWSWAF.
+	WAF *bool `json:"waf,omitempty"`
+	// Deprecated: Use AWSRDS.
+	Postgres *bool `json:"postgres,omitempty"`
+	// Deprecated: Use AWSElastiCache.
+	ElastiCache *bool `json:"elasticache,omitempty"`
+	// Deprecated: Use AWSS3.
+	S3 *bool `json:"s3,omitempty"`
+	// Deprecated: Use AWSDynamoDB.
+	DynamoDB *bool `json:"dynamodb,omitempty"`
+	// Deprecated: Use AWSSQS.
+	SQS *bool `json:"sqs,omitempty"`
+	// Deprecated: Use AWSMSK.
+	MSK *bool `json:"msk,omitempty"`
+	// Deprecated: Use AWSCloudWatchLogs.
+	CloudWatchLogs *bool `json:"cloudwatchlogs,omitempty"`
+	// Deprecated: Use AWSCloudWatchMonitoring.
+	CloudWatchMonitoring *bool `json:"cloudwatchmonitoring,omitempty"`
+	// Deprecated: Use AWSGrafana.
+	Grafana *bool `json:"grafana,omitempty"`
+	// Deprecated: Use AWSCognito.
+	Cognito *bool `json:"cognito,omitempty"`
+	// Deprecated: Use AWSAPIGateway.
+	APIGateway *bool `json:"apigateway,omitempty"`
+	// Deprecated: Use AWSKMS.
+	KMS *bool `json:"kms,omitempty"`
+	// Deprecated: Use AWSSecretsManager.
+	SecretsManager *bool `json:"secretsmanager,omitempty"`
+	// Deprecated: Use AWSOpenSearch.
+	OpenSearch *bool `json:"opensearch,omitempty"`
+	// Deprecated: Use AWSBedrock.
+	Bedrock *bool `json:"bedrock,omitempty"`
+	// Deprecated: Use AWSLambda.
+	Lambda *bool `json:"lambda,omitempty"`
+	// Deprecated: Use AWSCodePipeline.
+	CodePipeline *bool `json:"codepipeline,omitempty"`
+	// Deprecated: Use AWSBackups.
+	Backups *struct {
 		EC2         *bool `json:"ec2,omitempty"`
 		Rds         *bool `json:"rds,omitempty"`
 		ElastiCache *bool `json:"elasticache,omitempty"`
@@ -352,12 +383,19 @@ type Config struct {
 	} `json:"gcp_backups,omitempty"`
 
 	// ==================== Legacy Fields (backward compatibility) ====================
+	// Deprecated as a group: use the AWS*-prefixed fields above. See doc.go
+	// and insideout-terraform-presets#76 for the removal plan; historical
+	// session JSON should be normalised by reliable's composeradapter before
+	// reaching composer.
+	//
+	// Deprecated: Use AWSEC2.
 	EC2 *struct {
 		NumServers        string `json:"numServers,omitempty"`
 		NumCoresPerServer string `json:"numCoresPerServer,omitempty"`
 		DiskSizePerServer string `json:"diskSizePerServer,omitempty"`
 	} `json:"ec2,omitempty"`
 
+	// Deprecated: Use AWSEKS.
 	Eks *struct {
 		HaControlPlane         *bool  `json:"haControlPlane,omitempty"`
 		ControlPlaneVisibility string `json:"controlPlaneVisibility,omitempty"`
@@ -367,18 +405,21 @@ type Config struct {
 		InstanceType           string `json:"instanceType,omitempty"`
 	} `json:"eks,omitempty"`
 
+	// Deprecated: Use AWSCloudfront.
 	Cloudfront *struct {
 		DefaultTtl *string `json:"defaultTtl,omitempty"`
 		OriginPath *string `json:"originPath,omitempty"`
 		CachePaths *string `json:"cachePaths,omitempty"` // DEPRECATED: use OriginPath
 	} `json:"cloudfront,omitempty"`
 
+	// Deprecated: Use AWSRDS.
 	RDS *struct {
 		CPUSize      string `json:"cpuSize,omitempty"`
 		ReadReplicas string `json:"readReplicas,omitempty"`
 		StorageSize  string `json:"storageSize,omitempty"`
 	} `json:"rds,omitempty"`
 
+	// Deprecated: Use AWSElastiCache.
 	ElastiCache *struct {
 		HA       *bool  `json:"ha,omitempty"`
 		Storage  string `json:"storageSize,omitempty"`
@@ -386,51 +427,63 @@ type Config struct {
 		Replicas string `json:"replicas,omitempty"`
 	} `json:"elasticache,omitempty"`
 
+	// Deprecated: Use AWSS3.
 	S3 *struct {
 		Versioning *bool `json:"versioning,omitempty"`
 	} `json:"s3,omitempty"`
+	// Deprecated: Use AWSDynamoDB.
 	DynamoDB *struct {
 		Type string `json:"type,omitempty"`
 	} `json:"dynamodb,omitempty"`
 
+	// Deprecated: Use AWSSQS.
 	SQS *struct {
 		Type              string `json:"type,omitempty"`
 		VisibilityTimeout string `json:"visibilityTimeout,omitempty"`
 	} `json:"sqs,omitempty"`
 
+	// Deprecated: Use AWSMSK.
 	MSK *struct {
 		Retention string `json:"retentionPeriod,omitempty"`
 	} `json:"msk,omitempty"`
+	// Deprecated: Use AWSCloudWatchLogs.
 	CloudWatchLogs *struct {
 		RetentionDays int `json:"retentionDays,omitempty"`
 	} `json:"cloudwatchlogs,omitempty"`
+	// Deprecated: Use AWSCloudWatchMonitoring.
 	CloudWatchMonitoring *struct {
 		RetentionDays int `json:"retentionDays,omitempty"`
 	} `json:"cloudwatchmonitoring,omitempty"`
 
+	// Deprecated: Use AWSCognito.
 	Cognito *struct {
 		SignInType  string `json:"signInType,omitempty"`
 		MFARequired *bool  `json:"mfaRequired,omitempty"`
 	} `json:"cognito,omitempty"`
 
+	// Deprecated: Use AWSLambda.
 	Lambda *struct {
 		Runtime    string `json:"runtime,omitempty"`
 		MemorySize string `json:"memorySize,omitempty"`
 		Timeout    string `json:"timeout,omitempty"`
 	} `json:"lambda,omitempty"`
 
+	// Deprecated: Use AWSAPIGateway.
 	APIGateway *struct {
 		DomainName     string `json:"domainName,omitempty"`
 		CertificateArn string `json:"certificateArn,omitempty"`
 	} `json:"apigateway,omitempty"`
 
+	// Deprecated: Use AWSKMS.
 	KMS *struct {
 		NumKeys string `json:"numKeys,omitempty"`
 	} `json:"kms,omitempty"`
 
+	// Deprecated: Use AWSSecretsManager.
 	SecretsManager *struct {
 		NumSecrets string `json:"numSecrets,omitempty"`
 	} `json:"secretsmanager,omitempty"`
+	// Deprecated: Use AWSOpenSearch.
 	OpenSearch *struct {
 		DeploymentType string `json:"deploymentType,omitempty"`
 		InstanceType   string `json:"instanceType,omitempty"`
@@ -438,12 +491,14 @@ type Config struct {
 		MultiAZ        *bool  `json:"multiAz,omitempty"`
 	} `json:"opensearch,omitempty"`
 
+	// Deprecated: Use AWSBedrock.
 	Bedrock *struct {
 		KnowledgeBaseName string `json:"knowledgeBaseName,omitempty"`
 		ModelID           string `json:"modelId,omitempty"`
 		EmbeddingModelID  string `json:"embeddingModelId,omitempty"`
 	} `json:"bedrock,omitempty"`
 
+	// Deprecated: Use AWSBackups.
 	Backups *struct {
 		Details map[string]struct {
 			FrequencyHours int    `json:"frequencyHours,omitempty"`


### PR DESCRIPTION
## Summary

Phase 1 of the [phased plan in #76](https://github.com/luthersystems/insideout-terraform-presets/issues/76) to shed reliable-specific legacy keys from the `pkg/composer` public surface.

- Adds `// Deprecated: Use KeyAWS<X>` godoc to the 24 un-prefixed `ComponentKey` constants in `contracts.go`. `KeyEC2` and `KeyResource` get expository comments instead of deprecation (they're polymorphic across EKS/Lambda — a Phase-4 rename). `KeySplunk`/`KeyDatadog` are untouched (not legacy).
- Adds `// Deprecated: Use AWS<X>` godoc to each legacy field on `Components` and `Config` in `types.go`.
- Adds new package doc file `pkg/composer/doc.go` describing the canonical AWS-prefixed / GCP-prefixed vocabulary and pointing historical-session callers at reliable's adapter.

Non-breaking: nothing is renamed or removed. `Normalize()` and the compat translation machinery continue to execute. Static analysers (staticcheck, golint) will now signal downstream consumers that still reference the legacy symbols.

## Sequencing

- **This PR:** Phase 1 (deprecation godoc only).
- **Phase 2 (reliable-side):** tracked in luthersystems/reliable#998 — add a `composeradapter` that normalises historical session JSON to the prefixed vocabulary.
- **Phase 3:** collapse the dual-key switches in `DefaultWiring` / `BuildModuleValues`. Gated on the reliable adapter landing.
- **Phase 4:** delete the legacy symbols. Cuts v0.4.0.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/composer/...`
- [x] `terraform fmt -check -recursive` (no `.tf` files touched)
- [ ] CI green

Refs #76