### PR TITLE
refactor(composer): polish inherited test-quality issues

### DIFF
--- a/pkg/composer/builders_test.go
+++ b/pkg/composer/builders_test.go
@@ -75,11 +75,17 @@ func configWithAWSECS(in awsECSCfgInput) *Config {
 	}
 }
 
-// awsKitchenSinkCfg returns the Config shared by the two composer
+// awsKitchenSinkCfgBase returns the Config fields shared by the two composer
 // kitchen-sink tests (legacy- and V2-key variants). Fields use the legacy
 // (un-prefixed) Config names because Config.Normalize() promotes them to
 // the cloud-prefixed equivalents during compose.
-func awsKitchenSinkCfg() *Config {
+//
+// The split into Base / Legacy / V2 (instead of a single shared builder)
+// preserves a subtle fidelity invariant: the V2 test historically did not
+// set RDS.ReadReplicas, exercising the "unset" branch of the RDS mapper,
+// while the legacy test set it to "2". Collapsing into one shared helper
+// would silently couple the two tests on that branch.
+func awsKitchenSinkCfgBase() *Config {
 	return &Config{
 		Region: "us-west-2",
 		Cloudfront: &struct {
@@ -87,11 +93,6 @@ func awsKitchenSinkCfg() *Config {
 			OriginPath *string `json:"originPath,omitempty"`
 			CachePaths *string `json:"cachePaths,omitempty"` // DEPRECATED: use OriginPath
 		}{DefaultTtl: ptrString("3600")},
-		RDS: &struct {
-			CPUSize      string `json:"cpuSize,omitempty"`
-			ReadReplicas string `json:"readReplicas,omitempty"`
-			StorageSize  string `json:"storageSize,omitempty"`
-		}{CPUSize: "db.m7i.2xlarge", ReadReplicas: "2", StorageSize: "20"},
 		SQS: &struct {
 			Type              string `json:"type,omitempty"`
 			VisibilityTimeout string `json:"visibilityTimeout,omitempty"`
@@ -100,6 +101,31 @@ func awsKitchenSinkCfg() *Config {
 			RetentionDays int `json:"retentionDays,omitempty"`
 		}{RetentionDays: 90},
 	}
+}
+
+// awsKitchenSinkCfgV2 returns the Config for TestComposeStack_V2KitchenSink.
+// RDS.ReadReplicas is deliberately unset — the test exercises the default
+// (no-read-replicas) mapper branch for that field.
+func awsKitchenSinkCfgV2() *Config {
+	cfg := awsKitchenSinkCfgBase()
+	cfg.RDS = &struct {
+		CPUSize      string `json:"cpuSize,omitempty"`
+		ReadReplicas string `json:"readReplicas,omitempty"`
+		StorageSize  string `json:"storageSize,omitempty"`
+	}{CPUSize: "db.m7i.2xlarge", StorageSize: "20"}
+	return cfg
+}
+
+// awsKitchenSinkCfgLegacy returns the Config for TestComposeStack_KitchenSink.
+// RDS.ReadReplicas is "2" to exercise the read-replicas mapper branch.
+func awsKitchenSinkCfgLegacy() *Config {
+	cfg := awsKitchenSinkCfgBase()
+	cfg.RDS = &struct {
+		CPUSize      string `json:"cpuSize,omitempty"`
+		ReadReplicas string `json:"readReplicas,omitempty"`
+		StorageSize  string `json:"storageSize,omitempty"`
+	}{CPUSize: "db.m7i.2xlarge", ReadReplicas: "2", StorageSize: "20"}
+	return cfg
 }
 
 // awsKitchenSinkCompsV2 returns the Components shape for the V2-key
@@ -122,7 +148,10 @@ func awsKitchenSinkCompsV2() *Components {
 
 // awsKitchenSinkCompsLegacy returns the Components shape for the legacy-key
 // kitchen-sink: legacy ElastiCache toggle plus legacy Backups. The explicit
-// `false` fields exist to prove the test asserts on them; don't shorten.
+// DynamoDB=false / S3=false fields are load-bearing — the legacy kitchen-sink
+// "wiring/backups" subtest asserts on `enable_dynamodb = false` and
+// `enable_s3 = false` in the composed main.tf, so dropping them would break
+// that test.
 func awsKitchenSinkCompsLegacy() *Components {
 	return &Components{
 		ElastiCache: ptrBool(true),

--- a/pkg/composer/builders_test.go
+++ b/pkg/composer/builders_test.go
@@ -1,0 +1,142 @@
+package composer
+
+// Test builders for common Components / Config shapes.
+//
+// Config's sub-configs (AWSEC2, AWSECS, Cloudfront, RDS, SQS, …) are declared
+// as anonymous structs on the Config struct, so every inline literal has to
+// redeclare the full anonymous type — which hides the one or two fields the
+// test actually cares about under ten lines of type boilerplate. The helpers
+// below absorb that boilerplate so test sites read as data, not schema.
+
+// awsEC2CfgInput mirrors the subset of Config.AWSEC2 fields exercised by
+// mapper tests.
+type awsEC2CfgInput struct {
+	InstanceType          string
+	NumServers            string
+	NumCoresPerServer     string
+	DiskSizePerServer     string
+	UserData              string
+	UserDataURL           string
+	CustomIngressPorts    []int
+	SSHPublicKey          string
+	EnableInstanceConnect *bool
+}
+
+// configWithAWSEC2 returns *Config with AWSEC2 populated from input, eliding
+// the ten-line anonymous-struct redeclaration at each call site.
+func configWithAWSEC2(in awsEC2CfgInput) *Config {
+	return &Config{
+		AWSEC2: &struct {
+			InstanceType          string `json:"instanceType,omitempty"`
+			NumServers            string `json:"numServers,omitempty"`
+			NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
+			DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
+			UserData              string `json:"userData,omitempty"`
+			UserDataURL           string `json:"userDataURL,omitempty"`
+			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
+			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
+			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+		}{
+			InstanceType:          in.InstanceType,
+			NumServers:            in.NumServers,
+			NumCoresPerServer:     in.NumCoresPerServer,
+			DiskSizePerServer:     in.DiskSizePerServer,
+			UserData:              in.UserData,
+			UserDataURL:           in.UserDataURL,
+			CustomIngressPorts:    in.CustomIngressPorts,
+			SSHPublicKey:          in.SSHPublicKey,
+			EnableInstanceConnect: in.EnableInstanceConnect,
+		},
+	}
+}
+
+// awsECSCfgInput mirrors Config.AWSECS.
+type awsECSCfgInput struct {
+	EnableContainerInsights *bool
+	CapacityProviders       []string
+	DefaultCapacityProvider string
+	EnableServiceConnect    *bool
+}
+
+// configWithAWSECS returns *Config with AWSECS populated from input.
+func configWithAWSECS(in awsECSCfgInput) *Config {
+	return &Config{
+		AWSECS: &struct {
+			EnableContainerInsights *bool    `json:"enableContainerInsights,omitempty"`
+			CapacityProviders       []string `json:"capacityProviders,omitempty"`
+			DefaultCapacityProvider string   `json:"defaultCapacityProvider,omitempty"`
+			EnableServiceConnect    *bool    `json:"enableServiceConnect,omitempty"`
+		}{
+			EnableContainerInsights: in.EnableContainerInsights,
+			CapacityProviders:       in.CapacityProviders,
+			DefaultCapacityProvider: in.DefaultCapacityProvider,
+			EnableServiceConnect:    in.EnableServiceConnect,
+		},
+	}
+}
+
+// awsKitchenSinkCfg returns the Config shared by the two composer
+// kitchen-sink tests (legacy- and V2-key variants). Fields use the legacy
+// (un-prefixed) Config names because Config.Normalize() promotes them to
+// the cloud-prefixed equivalents during compose.
+func awsKitchenSinkCfg() *Config {
+	return &Config{
+		Region: "us-west-2",
+		Cloudfront: &struct {
+			DefaultTtl *string `json:"defaultTtl,omitempty"`
+			OriginPath *string `json:"originPath,omitempty"`
+			CachePaths *string `json:"cachePaths,omitempty"` // DEPRECATED: use OriginPath
+		}{DefaultTtl: ptrString("3600")},
+		RDS: &struct {
+			CPUSize      string `json:"cpuSize,omitempty"`
+			ReadReplicas string `json:"readReplicas,omitempty"`
+			StorageSize  string `json:"storageSize,omitempty"`
+		}{CPUSize: "db.m7i.2xlarge", ReadReplicas: "2", StorageSize: "20"},
+		SQS: &struct {
+			Type              string `json:"type,omitempty"`
+			VisibilityTimeout string `json:"visibilityTimeout,omitempty"`
+		}{Type: "FIFO", VisibilityTimeout: "600"},
+		CloudWatchLogs: &struct {
+			RetentionDays int `json:"retentionDays,omitempty"`
+		}{RetentionDays: 90},
+	}
+}
+
+// awsKitchenSinkCompsV2 returns the Components shape for the V2-key
+// kitchen-sink: legacy ElastiCache toggle plus AWSBackups (prefixed).
+func awsKitchenSinkCompsV2() *Components {
+	return &Components{
+		ElastiCache: ptrBool(true),
+		AWSBackups: &struct {
+			EC2         *bool `json:"aws_ec2,omitempty"`
+			RDS         *bool `json:"aws_rds,omitempty"`
+			ElastiCache *bool `json:"aws_elasticache,omitempty"`
+			DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+			S3          *bool `json:"aws_s3,omitempty"`
+		}{
+			EC2: ptrBool(true),
+			RDS: ptrBool(true),
+		},
+	}
+}
+
+// awsKitchenSinkCompsLegacy returns the Components shape for the legacy-key
+// kitchen-sink: legacy ElastiCache toggle plus legacy Backups. The explicit
+// `false` fields exist to prove the test asserts on them; don't shorten.
+func awsKitchenSinkCompsLegacy() *Components {
+	return &Components{
+		ElastiCache: ptrBool(true),
+		Backups: &struct {
+			EC2         *bool `json:"ec2,omitempty"`
+			Rds         *bool `json:"rds,omitempty"`
+			ElastiCache *bool `json:"elasticache,omitempty"`
+			DynamoDB    *bool `json:"dynamodb,omitempty"`
+			S3          *bool `json:"s3,omitempty"`
+		}{
+			EC2:      ptrBool(true),
+			Rds:      ptrBool(true),
+			DynamoDB: ptrBool(false),
+			S3:       ptrBool(false),
+		},
+	}
+}

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
@@ -453,40 +454,8 @@ func TestComposeStack_V2KitchenSink(t *testing.T) {
 		KeyAWSGitHubActions,
 	}
 
-	comps := &Components{
-		ElastiCache: ptrBool(true),
-		AWSBackups: &struct {
-			EC2         *bool `json:"aws_ec2,omitempty"`
-			RDS         *bool `json:"aws_rds,omitempty"`
-			ElastiCache *bool `json:"aws_elasticache,omitempty"`
-			DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
-			S3          *bool `json:"aws_s3,omitempty"`
-		}{
-			EC2: ptrBool(true),
-			RDS: ptrBool(true),
-		},
-	}
-
-	cfg := &Config{
-		Region: "us-west-2",
-		Cloudfront: &struct {
-			DefaultTtl *string `json:"defaultTtl,omitempty"`
-			OriginPath *string `json:"originPath,omitempty"`
-			CachePaths *string `json:"cachePaths,omitempty"`
-		}{DefaultTtl: ptrString("3600")},
-		RDS: &struct {
-			CPUSize      string `json:"cpuSize,omitempty"`
-			ReadReplicas string `json:"readReplicas,omitempty"`
-			StorageSize  string `json:"storageSize,omitempty"`
-		}{CPUSize: "db.m7i.2xlarge", StorageSize: "20"},
-		SQS: &struct {
-			Type              string `json:"type,omitempty"`
-			VisibilityTimeout string `json:"visibilityTimeout,omitempty"`
-		}{Type: "FIFO", VisibilityTimeout: "600"},
-		CloudWatchLogs: &struct {
-			RetentionDays int `json:"retentionDays,omitempty"`
-		}{RetentionDays: 90},
-	}
+	comps := awsKitchenSinkCompsV2()
+	cfg := awsKitchenSinkCfg()
 
 	c := newTestClient()
 	out, err := c.ComposeStack(ComposeStackOpts{
@@ -577,49 +546,8 @@ func TestComposeStack_KitchenSink(t *testing.T) {
 	}
 
 	// Enable backups for EC2/EBS + RDS to trigger wiring.
-	comps := &Components{
-		ElastiCache: ptrBool(true),
-		Backups: &struct {
-			EC2         *bool `json:"ec2,omitempty"`
-			Rds         *bool `json:"rds,omitempty"`
-			ElastiCache *bool `json:"elasticache,omitempty"`
-			DynamoDB    *bool `json:"dynamodb,omitempty"`
-			S3          *bool `json:"s3,omitempty"`
-		}{
-			EC2:      ptrBool(true),
-			Rds:      ptrBool(true),
-			DynamoDB: ptrBool(false),
-			S3:       ptrBool(false),
-		},
-	}
-
-	cfg := &Config{
-		Region: "us-west-2",
-		Cloudfront: &struct {
-			DefaultTtl *string `json:"defaultTtl,omitempty"`
-			OriginPath *string `json:"originPath,omitempty"`
-			CachePaths *string `json:"cachePaths,omitempty"`
-		}{DefaultTtl: ptrString("3600")},
-		RDS: &struct {
-			CPUSize      string `json:"cpuSize,omitempty"`
-			ReadReplicas string `json:"readReplicas,omitempty"`
-			StorageSize  string `json:"storageSize,omitempty"`
-		}{
-			CPUSize:      "db.m7i.2xlarge",
-			ReadReplicas: "2",
-			StorageSize:  "20",
-		},
-		SQS: &struct {
-			Type              string `json:"type,omitempty"`
-			VisibilityTimeout string `json:"visibilityTimeout,omitempty"`
-		}{
-			Type:              "FIFO",
-			VisibilityTimeout: "600",
-		},
-		CloudWatchLogs: &struct {
-			RetentionDays int `json:"retentionDays,omitempty"`
-		}{RetentionDays: 90},
-	}
+	comps := awsKitchenSinkCompsLegacy()
+	cfg := awsKitchenSinkCfg()
 
 	c := newTestClient()
 	out, err := c.ComposeStack(ComposeStackOpts{
@@ -968,14 +896,7 @@ func sortedKeys(m map[string]bool) []string {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	// Simple sort
-	for i := 0; i < len(keys)-1; i++ {
-		for j := i + 1; j < len(keys); j++ {
-			if keys[j] < keys[i] {
-				keys[i], keys[j] = keys[j], keys[i]
-			}
-		}
-	}
+	sort.Strings(keys)
 	return keys
 }
 
@@ -1094,13 +1015,6 @@ func TestComposeStack_ConflictingCompute(t *testing.T) {
 			require.Contains(t, err.Error(), tt.errMsg)
 		})
 	}
-}
-
-// TestAllowedExt_IncludesZip verifies that .zip files from presets are included in archives.
-// This is needed for Lambda's placeholder.zip (and any other binary assets in presets).
-func TestAllowedExt_IncludesZip(t *testing.T) {
-	t.Parallel()
-	require.True(t, allowedExt[".zip"], ".zip should be in allowedExt so placeholder.zip is included")
 }
 
 // TestComposeStack_LambdaIncludesPlaceholderZip verifies that a Lambda stack includes

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -455,7 +455,7 @@ func TestComposeStack_V2KitchenSink(t *testing.T) {
 	}
 
 	comps := awsKitchenSinkCompsV2()
-	cfg := awsKitchenSinkCfg()
+	cfg := awsKitchenSinkCfgV2()
 
 	c := newTestClient()
 	out, err := c.ComposeStack(ComposeStackOpts{
@@ -547,7 +547,7 @@ func TestComposeStack_KitchenSink(t *testing.T) {
 
 	// Enable backups for EC2/EBS + RDS to trigger wiring.
 	comps := awsKitchenSinkCompsLegacy()
-	cfg := awsKitchenSinkCfg()
+	cfg := awsKitchenSinkCfgLegacy()
 
 	c := newTestClient()
 	out, err := c.ComposeStack(ComposeStackOpts{

--- a/pkg/composer/discover.go
+++ b/pkg/composer/discover.go
@@ -66,6 +66,12 @@ type OutputMeta struct {
 
 // DiscoverModuleOutputs parses all .tf files in a module preset and returns output metadata
 // including description and sensitive flag.
+//
+// Files whose HCL fails to parse are silently skipped: a composed stack may legitimately
+// include partially-broken preset trees (e.g. a templated file that does not round-trip as
+// HCL on its own), and we want output discovery to reflect what is actually parsable
+// rather than aborting the whole compose. This invariant is locked in by
+// TestDiscoverModuleOutputs_MalformedHCLSkipped.
 func DiscoverModuleOutputs(files map[string][]byte) ([]OutputMeta, error) {
 	var out []OutputMeta
 	for p, b := range files {

--- a/pkg/composer/discover.go
+++ b/pkg/composer/discover.go
@@ -67,11 +67,10 @@ type OutputMeta struct {
 // DiscoverModuleOutputs parses all .tf files in a module preset and returns output metadata
 // including description and sensitive flag.
 //
-// Files whose HCL fails to parse are silently skipped: a composed stack may legitimately
-// include partially-broken preset trees (e.g. a templated file that does not round-trip as
-// HCL on its own), and we want output discovery to reflect what is actually parsable
-// rather than aborting the whole compose. This invariant is locked in by
-// TestDiscoverModuleOutputs_MalformedHCLSkipped.
+// Discovery is best-effort: .tf files whose HCL fails to parse are skipped rather than
+// aborting the whole operation. Callers that need strict validation of every file should
+// run terraform fmt / validate separately. This skip-on-parse-error behaviour is locked in
+// by TestDiscoverModuleOutputs_MalformedHCLSkipped.
 func DiscoverModuleOutputs(files map[string][]byte) ([]OutputMeta, error) {
 	var out []OutputMeta
 	for p, b := range files {

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -30,21 +30,7 @@ func TestBuildModuleValues_AWSEC2_ArchAndInstanceType(t *testing.T) {
 
 	t.Run("explicit instance_type from config overrides default", func(t *testing.T) {
 		comps := &Components{AWSEC2: "ARM"}
-		cfg := &Config{
-			AWSEC2: &struct {
-				InstanceType       string `json:"instanceType,omitempty"`
-				NumServers         string `json:"numServers,omitempty"`
-				NumCoresPerServer  string `json:"numCoresPerServer,omitempty"`
-				DiskSizePerServer  string `json:"diskSizePerServer,omitempty"`
-				UserData           string `json:"userData,omitempty"`
-				UserDataURL        string `json:"userDataURL,omitempty"`
-				CustomIngressPorts []int  `json:"customIngressPorts,omitempty"`
-				SSHPublicKey       string `json:"sshPublicKey,omitempty"`
-				EnableInstanceConnect *bool   `json:"enableInstanceConnect,omitempty"`
-			}{
-				InstanceType: "c7g.large",
-			},
-		}
+		cfg := configWithAWSEC2(awsEC2CfgInput{InstanceType: "c7g.large"})
 		vals, err := m.BuildModuleValues(KeyAWSEC2, comps, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, "arm64", vals["arch"])
@@ -56,40 +42,14 @@ func TestBuildModuleValues_AWSEC2_DiskSize(t *testing.T) {
 	m := DefaultMapper{}
 
 	t.Run("diskSizePerServer maps to root_volume_size as int", func(t *testing.T) {
-		cfg := &Config{
-			AWSEC2: &struct {
-				InstanceType       string `json:"instanceType,omitempty"`
-				NumServers         string `json:"numServers,omitempty"`
-				NumCoresPerServer  string `json:"numCoresPerServer,omitempty"`
-				DiskSizePerServer  string `json:"diskSizePerServer,omitempty"`
-				UserData           string `json:"userData,omitempty"`
-				UserDataURL        string `json:"userDataURL,omitempty"`
-				CustomIngressPorts []int  `json:"customIngressPorts,omitempty"`
-				SSHPublicKey       string `json:"sshPublicKey,omitempty"`
-				EnableInstanceConnect *bool   `json:"enableInstanceConnect,omitempty"`
-			}{
-				DiskSizePerServer: "32",
-			},
-		}
+		cfg := configWithAWSEC2(awsEC2CfgInput{DiskSizePerServer: "32"})
 		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, 32, vals["root_volume_size"], "should convert string to int")
 	})
 
 	t.Run("empty diskSizePerServer does not set root_volume_size", func(t *testing.T) {
-		cfg := &Config{
-			AWSEC2: &struct {
-				InstanceType       string `json:"instanceType,omitempty"`
-				NumServers         string `json:"numServers,omitempty"`
-				NumCoresPerServer  string `json:"numCoresPerServer,omitempty"`
-				DiskSizePerServer  string `json:"diskSizePerServer,omitempty"`
-				UserData           string `json:"userData,omitempty"`
-				UserDataURL        string `json:"userDataURL,omitempty"`
-				CustomIngressPorts []int  `json:"customIngressPorts,omitempty"`
-				SSHPublicKey       string `json:"sshPublicKey,omitempty"`
-				EnableInstanceConnect *bool   `json:"enableInstanceConnect,omitempty"`
-			}{},
-		}
+		cfg := configWithAWSEC2(awsEC2CfgInput{})
 		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
 		require.NoError(t, err)
 		_, hasKey := vals["root_volume_size"]
@@ -103,42 +63,14 @@ func TestBuildModuleValues_AWSEC2_EnableInstanceConnect(t *testing.T) {
 	falseVal := false
 
 	t.Run("enableInstanceConnect maps to enable_instance_connect", func(t *testing.T) {
-		cfg := &Config{
-			AWSEC2: &struct {
-				InstanceType          string `json:"instanceType,omitempty"`
-				NumServers            string `json:"numServers,omitempty"`
-				NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
-				DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
-				UserData              string `json:"userData,omitempty"`
-				UserDataURL           string `json:"userDataURL,omitempty"`
-				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
-				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
-				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
-			}{
-				EnableInstanceConnect: &trueVal,
-			},
-		}
+		cfg := configWithAWSEC2(awsEC2CfgInput{EnableInstanceConnect: &trueVal})
 		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, true, vals["enable_instance_connect"])
 	})
 
 	t.Run("explicit false enableInstanceConnect does not set key", func(t *testing.T) {
-		cfg := &Config{
-			AWSEC2: &struct {
-				InstanceType          string `json:"instanceType,omitempty"`
-				NumServers            string `json:"numServers,omitempty"`
-				NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
-				DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
-				UserData              string `json:"userData,omitempty"`
-				UserDataURL           string `json:"userDataURL,omitempty"`
-				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
-				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
-				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
-			}{
-				EnableInstanceConnect: &falseVal,
-			},
-		}
+		cfg := configWithAWSEC2(awsEC2CfgInput{EnableInstanceConnect: &falseVal})
 		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
 		require.NoError(t, err)
 		_, hasKey := vals["enable_instance_connect"]
@@ -146,19 +78,7 @@ func TestBuildModuleValues_AWSEC2_EnableInstanceConnect(t *testing.T) {
 	})
 
 	t.Run("nil enableInstanceConnect does not set key", func(t *testing.T) {
-		cfg := &Config{
-			AWSEC2: &struct {
-				InstanceType          string `json:"instanceType,omitempty"`
-				NumServers            string `json:"numServers,omitempty"`
-				NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
-				DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
-				UserData              string `json:"userData,omitempty"`
-				UserDataURL           string `json:"userDataURL,omitempty"`
-				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
-				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
-				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
-			}{},
-		}
+		cfg := configWithAWSEC2(awsEC2CfgInput{})
 		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
 		require.NoError(t, err)
 		_, hasKey := vals["enable_instance_connect"]
@@ -468,16 +388,7 @@ func TestBuildModuleValues_AWSECS_Defaults(t *testing.T) {
 
 	t.Run("ECS with config produces ECS-specific values", func(t *testing.T) {
 		comps := &Components{AWSECS: ptrBool(true)}
-		cfg := &Config{
-			AWSECS: &struct {
-				EnableContainerInsights *bool    `json:"enableContainerInsights,omitempty"`
-				CapacityProviders       []string `json:"capacityProviders,omitempty"`
-				DefaultCapacityProvider string   `json:"defaultCapacityProvider,omitempty"`
-				EnableServiceConnect    *bool    `json:"enableServiceConnect,omitempty"`
-			}{
-				EnableContainerInsights: ptrBool(true),
-			},
-		}
+		cfg := configWithAWSECS(awsECSCfgInput{EnableContainerInsights: ptrBool(true)})
 		vals, err := m.BuildModuleValues(KeyAWSECS, comps, cfg, "demo", "us-east-1")
 		require.NoError(t, err)
 
@@ -496,19 +407,12 @@ func TestBuildModuleValues_AWSECS_WithConfig(t *testing.T) {
 	m := DefaultMapper{}
 
 	comps := &Components{AWSECS: ptrBool(true)}
-	cfg := &Config{
-		AWSECS: &struct {
-			EnableContainerInsights *bool    `json:"enableContainerInsights,omitempty"`
-			CapacityProviders       []string `json:"capacityProviders,omitempty"`
-			DefaultCapacityProvider string   `json:"defaultCapacityProvider,omitempty"`
-			EnableServiceConnect    *bool    `json:"enableServiceConnect,omitempty"`
-		}{
-			EnableContainerInsights: ptrBool(true),
-			CapacityProviders:       []string{"FARGATE", "FARGATE_SPOT"},
-			DefaultCapacityProvider: "FARGATE_SPOT",
-			EnableServiceConnect:    ptrBool(false),
-		},
-	}
+	cfg := configWithAWSECS(awsECSCfgInput{
+		EnableContainerInsights: ptrBool(true),
+		CapacityProviders:       []string{"FARGATE", "FARGATE_SPOT"},
+		DefaultCapacityProvider: "FARGATE_SPOT",
+		EnableServiceConnect:    ptrBool(false),
+	})
 
 	vals, err := m.BuildModuleValues(KeyAWSECS, comps, cfg, "demo", "us-east-1")
 	require.NoError(t, err)
@@ -524,16 +428,7 @@ func TestBuildModuleValues_AWSECS_PartialConfig(t *testing.T) {
 
 	// Only CapacityProviders set; bool pointers left nil to exercise nil guards.
 	comps := &Components{AWSECS: ptrBool(true)}
-	cfg := &Config{
-		AWSECS: &struct {
-			EnableContainerInsights *bool    `json:"enableContainerInsights,omitempty"`
-			CapacityProviders       []string `json:"capacityProviders,omitempty"`
-			DefaultCapacityProvider string   `json:"defaultCapacityProvider,omitempty"`
-			EnableServiceConnect    *bool    `json:"enableServiceConnect,omitempty"`
-		}{
-			CapacityProviders: []string{"FARGATE"},
-		},
-	}
+	cfg := configWithAWSECS(awsECSCfgInput{CapacityProviders: []string{"FARGATE"}})
 
 	vals, err := m.BuildModuleValues(KeyAWSECS, comps, cfg, "demo", "us-east-1")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Resolves the remaining P2 polish items from #74 after #73 handled the larger items at port time (tautological Normalize tests, Contains-soup wiring test, monolithic kitchen-sink).

- **Drop `TestAllowedExt_IncludesZip`**: it's a map-literal echo of `allowedExt[".zip"]`, redundant with `TestComposeStack_LambdaIncludesPlaceholderZip` which exercises the same invariant through the real Compose path.
- **Replace `sortedKeys` bubble-sort with `sort.Strings`**.
- **Document the \"silently skip malformed HCL\" invariant on `DiscoverModuleOutputs`** so `TestDiscoverModuleOutputs_MalformedHCLSkipped` locks a documented behaviour.
- **Extract kitchen-sink and sub-config builders** to a new `pkg/composer/builders_test.go`:
  - `awsKitchenSinkCfg()`, `awsKitchenSinkCompsV2()`, `awsKitchenSinkCompsLegacy()` — used by the two `TestComposeStack_*KitchenSink` tests.
  - `configWithAWSEC2(...)` / `configWithAWSECS(...)` — used by the mapper tests for `Config.AWSEC2` / `Config.AWSECS`, eliminating ~10-line anonymous-struct type redeclarations at every call site.
- Same-package `builders_test.go` (not a separate `testutil` package): helpers are composer-internal, and keeping them in-package avoids exporting types that only tests need.

Net ~200 lines of anonymous-struct boilerplate removed from tests.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/composer/...` (all pass, 509s)
- [ ] CI green

Closes #74