### PR TITLE
feat(bedrock): AOSS data-access policy, invocation logging, guardrail

### DIFF
--- a/.claude/skills/add-aws-module/SKILL.md
+++ b/.claude/skills/add-aws-module/SKILL.md
@@ -106,6 +106,32 @@ cd aws/<modulename> && terraform init -backend=false -input=false && terraform v
 go build ./...
 ```
 
+### 8. Tests (optional but encouraged)
+
+`terraform test` files live in `aws/<modulename>/tests/` and follow a filename convention CI relies on:
+
+| File pattern | Behaviour |
+|---|---|
+| `tests/*.tftest.hcl` | Discovered and run by CI on every PR. Must work without AWS credentials. |
+| `tests/*integration*.tftest.hcl` | **Skipped in CI**. Integration tests that apply against a real account; run manually. |
+
+For credential-free unit tests, mock the AWS provider so `data` sources resolve at plan time:
+
+```hcl
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = { account_id = "111111111111" }
+  }
+}
+```
+
+Use `command = plan` for shape and validation tests. Switch a specific run to `command = apply` only when an assertion depends on a resource attribute (like an ARN) that's "known after apply" — `mock_provider` populates those at apply time without ever calling AWS.
+
+Integration tests should:
+- Suffix any account-scoped resource name with a timestamp (e.g. `formatdate("MMDDhhmmss", timestamp())`) so back-to-back runs don't collide.
+- Document a manual cleanup runbook in the file header for the case where the test is killed mid-apply.
+- Call out any account-level singletons being clobbered (Bedrock invocation logging, AWS Config recorder, etc.).
+
 ## Anti-Patterns
 
 - Using `var.region` instead of `data.aws_region.current.region` in service names

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -25,10 +25,14 @@ jobs:
           echo "dirs=$dirs" >> "$GITHUB_OUTPUT"
 
       - id: find-testable
-        name: Discover modules with terraform tests
+        name: Discover modules with non-integration terraform tests
         run: |
+          # Only consider modules that have at least one non-integration
+          # .tftest.hcl. Files matching *integration* are opt-in: they
+          # require live cloud credentials and are skipped in CI.
           dirs=$(find aws gcp -mindepth 1 -maxdepth 1 -type d | sort | while read -r d; do
-            if ls "$d"/tests/*.tftest.hcl >/dev/null 2>&1 || ls "$d"/*.tftest.hcl >/dev/null 2>&1; then
+            non_integration=$(find "$d" -maxdepth 2 -name '*.tftest.hcl' ! -name '*integration*' 2>/dev/null | head -1)
+            if [ -n "$non_integration" ]; then
               echo "$d"
             fi
           done | jq -R -s -c 'split("\n") | map(select(length > 0))')
@@ -103,8 +107,22 @@ jobs:
         run: terraform init -backend=false -input=false
         working-directory: ${{ matrix.dir }}
 
-      - name: Terraform Test
-        run: terraform test -no-color
+      - name: Terraform Test (non-integration only)
+        # Run every .tftest.hcl file in the module that does NOT contain
+        # "integration" in its name. Integration tests require live cloud
+        # credentials and are run manually, not in CI.
+        run: |
+          set -euo pipefail
+          mapfile -t test_files < <(find . -maxdepth 2 -name '*.tftest.hcl' ! -name '*integration*' 2>/dev/null | sort)
+          if [ "${#test_files[@]}" -eq 0 ]; then
+            echo "No non-integration tests in this module."
+            exit 0
+          fi
+          filter_args=()
+          for f in "${test_files[@]}"; do
+            filter_args+=("-filter=${f#./}")
+          done
+          terraform test -no-color "${filter_args[@]}"
         working-directory: ${{ matrix.dir }}
 
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,12 @@
 # Temporary files
 .tmp/
 
+# Local environment / secrets
+.env
+
+# Imported/scratch artifacts
+imported/
+insideout-import
+
 # Claude Code local settings (keep shared .claude/settings.json)
 .claude/settings.local.json

--- a/aws/bedrock/main.tf
+++ b/aws/bedrock/main.tf
@@ -19,9 +19,19 @@ module "name" {
   resource       = "br"
 }
 
+# Used by the IAM role trust policies below to scope service-principal trust
+# to this account only — AWS's documented mitigation against the
+# cross-account confused-deputy attack on bedrock.amazonaws.com.
+data "aws_caller_identity" "current" {}
+
 resource "aws_iam_role" "bedrock_kb" {
   name = "${var.project}-bedrock-role"
 
+  # Scoping the service trust to aws:SourceAccount = this account closes the
+  # cross-account confused-deputy hole on bedrock.amazonaws.com (an attacker
+  # in another account could otherwise coax Bedrock into assuming this role
+  # from their context). The condition is satisfied automatically by every
+  # legitimate in-account caller, so it is backward-compatible.
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -30,6 +40,11 @@ resource "aws_iam_role" "bedrock_kb" {
         Effect = "Allow"
         Principal = {
           Service = "bedrock.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
         }
       }
     ]
@@ -163,6 +178,7 @@ resource "aws_iam_role" "invocation_logging" {
   count = var.enable_invocation_logging ? 1 : 0
   name  = "${var.project}-bedrock-logging-role"
 
+  # Same confused-deputy guard as bedrock_kb above.
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
@@ -170,6 +186,11 @@ resource "aws_iam_role" "invocation_logging" {
       Effect = "Allow"
       Principal = {
         Service = "bedrock.amazonaws.com"
+      }
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+        }
       }
     }]
   })

--- a/aws/bedrock/main.tf
+++ b/aws/bedrock/main.tf
@@ -80,12 +80,221 @@ resource "aws_iam_role_policy" "bedrock_kb" {
 # The Bedrock Knowledge Base (aws_bedrockagent_knowledge_base) and its S3
 # data source are intentionally NOT managed by this module. Creating the KB
 # at terraform time requires (1) a pre-existing AOSS vector index with the
-# k-NN field mapping Bedrock expects, (2) an AOSS data-access policy
-# granting this role and the terraform runner aoss:* on the collection, and
-# (3) resolving assumed-role session ARNs to their underlying roles. All of
-# that is an application-layer concern — the application that ingests data
-# into the KB is the right place to create the KB, the vector index, and
-# the data-access policy, because only it knows which embedding model /
-# dimension / field names it needs. This module provisions only the IAM
-# role and its policy so the application can assume it when it calls
-# CreateKnowledgeBase and StartIngestionJob.
+# k-NN field mapping Bedrock expects keyed to a chosen embedding model and
+# dimension, and (2) resolving assumed-role session ARNs to their underlying
+# roles. Both are application-layer concerns — the application that ingests
+# data into the KB is the right place to create the KB and the vector index,
+# because only it knows which embedding model / dimension / field names it
+# needs. This module provisions the IAM role + AOSS data-access policy +
+# invocation logging + guardrail so the application has a usable, observable
+# substrate to call CreateKnowledgeBase and StartIngestionJob against.
+
+# --- AOSS data-access policy -----------------------------------------------
+#
+# AOSS access has two independent layers: IAM (granted by the inline policy
+# above) and a collection-side data-access policy. Bedrock KB creation,
+# ingestion, and query all silently 403 without both. This block creates the
+# AOSS-side half granting the bedrock role + any aoss_additional_principal_arns
+# (typically the terraform runner that creates the vector index, plus the
+# application's ingestion role) data-plane access on the collection.
+#
+# Subtle: AOSS data-access policies match exact role ARNs and do NOT resolve
+# assumed-role sessions back to their underlying role, unlike IAM. If the
+# caller uses sts:AssumeRole, pass the underlying role ARN here, not the
+# session ARN — the variable validation enforces this.
+#
+# The AOSS policy-name limit is 32 chars; "${project}-br-data" caps project at
+# 24 which is well within the project-name limits already enforced upstream
+# by the opensearch module.
+resource "aws_opensearchserverless_access_policy" "bedrock" {
+  count = var.opensearch_collection_name == null ? 0 : 1
+  name  = "${var.project}-br-data"
+  type  = "data"
+  policy = jsonencode([
+    {
+      Description = "Bedrock KB role + additional principals data-plane access on ${var.opensearch_collection_name}"
+      Rules = [
+        {
+          ResourceType = "collection"
+          Resource     = ["collection/${var.opensearch_collection_name}"]
+          Permission = [
+            "aoss:DescribeCollectionItems",
+            "aoss:CreateCollectionItems",
+            "aoss:UpdateCollectionItems",
+          ]
+        },
+        {
+          ResourceType = "index"
+          Resource     = ["index/${var.opensearch_collection_name}/*"]
+          Permission = [
+            "aoss:CreateIndex",
+            "aoss:DescribeIndex",
+            "aoss:ReadDocument",
+            "aoss:WriteDocument",
+            "aoss:UpdateIndex",
+            "aoss:DeleteIndex",
+          ]
+        }
+      ]
+      Principal = concat(
+        [aws_iam_role.bedrock_kb.arn],
+        var.aoss_additional_principal_arns,
+      )
+    }
+  ])
+}
+
+# --- Invocation logging ----------------------------------------------------
+#
+# aws_bedrock_model_invocation_logging_configuration is an account+region
+# singleton. Enabling it here logs every Bedrock InvokeModel call across the
+# account into the log group below. If multiple stacks in the same account
+# enable it, the last apply wins and earlier stacks lose their logging
+# silently — opt in deliberately via enable_invocation_logging.
+
+resource "aws_cloudwatch_log_group" "invocations" {
+  count             = var.enable_invocation_logging ? 1 : 0
+  name              = "/aws/bedrock/${var.project}-invocations"
+  retention_in_days = var.invocation_log_retention_days
+  tags              = merge(module.name.tags, var.tags)
+}
+
+resource "aws_iam_role" "invocation_logging" {
+  count = var.enable_invocation_logging ? 1 : 0
+  name  = "${var.project}-bedrock-logging-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "bedrock.amazonaws.com"
+      }
+    }]
+  })
+
+  tags = merge(module.name.tags, var.tags)
+}
+
+resource "aws_iam_role_policy" "invocation_logging" {
+  count = var.enable_invocation_logging ? 1 : 0
+  name  = "${var.project}-bedrock-logging-policy"
+  role  = aws_iam_role.invocation_logging[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+      ]
+      Resource = [
+        aws_cloudwatch_log_group.invocations[0].arn,
+        "${aws_cloudwatch_log_group.invocations[0].arn}:log-stream:*",
+      ]
+    }]
+  })
+}
+
+resource "aws_bedrock_model_invocation_logging_configuration" "this" {
+  count      = var.enable_invocation_logging ? 1 : 0
+  depends_on = [aws_iam_role_policy.invocation_logging]
+
+  logging_config {
+    embedding_data_delivery_enabled = var.log_embedding_data
+    image_data_delivery_enabled     = var.log_image_data
+    text_data_delivery_enabled      = var.log_text_data
+    cloudwatch_config {
+      log_group_name = aws_cloudwatch_log_group.invocations[0].name
+      role_arn       = aws_iam_role.invocation_logging[0].arn
+    }
+  }
+}
+
+# --- Guardrail -------------------------------------------------------------
+#
+# A reusable content-moderation policy. The application opts in by passing
+# guardrail_id + guardrail_version to InvokeModel/Converse — this module only
+# defines the policy, it does not bind it to any specific model.
+#
+# Defaults are chosen to be broadly applicable: MEDIUM strength on the
+# universal content categories, PII anonymisation on the most sensitive
+# categories, and PROMPT_ATTACK pinned to HIGH on input as cheap insurance
+# against jailbreak attempts (the only output_strength AWS accepts for
+# PROMPT_ATTACK is NONE, hence its separate filters_config block).
+
+locals {
+  content_filter_categories = ["SEXUAL", "VIOLENCE", "HATE", "INSULTS", "MISCONDUCT"]
+}
+
+resource "aws_bedrock_guardrail" "this" {
+  count                     = var.enable_guardrail ? 1 : 0
+  name                      = "${var.project}-guardrail"
+  description               = "InsideOut default guardrail for ${var.project} (${var.environment})."
+  blocked_input_messaging   = var.guardrail_blocked_input_messaging
+  blocked_outputs_messaging = var.guardrail_blocked_outputs_messaging
+  kms_key_arn               = var.guardrail_kms_key_arn
+
+  dynamic "content_policy_config" {
+    for_each = var.guardrail_content_filter_strength == "NONE" ? [] : [1]
+    content {
+      dynamic "filters_config" {
+        for_each = local.content_filter_categories
+        content {
+          type            = filters_config.value
+          input_strength  = var.guardrail_content_filter_strength
+          output_strength = var.guardrail_content_filter_strength
+        }
+      }
+      filters_config {
+        type            = "PROMPT_ATTACK"
+        input_strength  = "HIGH"
+        output_strength = "NONE"
+      }
+    }
+  }
+
+  dynamic "sensitive_information_policy_config" {
+    for_each = var.guardrail_pii_action == "NONE" || length(var.guardrail_pii_entities) == 0 ? [] : [1]
+    content {
+      dynamic "pii_entities_config" {
+        for_each = var.guardrail_pii_entities
+        content {
+          type   = pii_entities_config.value
+          action = var.guardrail_pii_action
+        }
+      }
+    }
+  }
+
+  dynamic "topic_policy_config" {
+    for_each = length(var.guardrail_denied_topics) > 0 ? [1] : []
+    content {
+      dynamic "topics_config" {
+        for_each = var.guardrail_denied_topics
+        content {
+          name       = topics_config.value.name
+          definition = topics_config.value.definition
+          examples   = topics_config.value.examples
+          type       = "DENY"
+        }
+      }
+    }
+  }
+
+  dynamic "word_policy_config" {
+    for_each = length(var.guardrail_blocked_words) > 0 ? [1] : []
+    content {
+      dynamic "words_config" {
+        for_each = var.guardrail_blocked_words
+        content {
+          text = words_config.value
+        }
+      }
+    }
+  }
+
+  tags = merge(module.name.tags, var.tags)
+}

--- a/aws/bedrock/outputs.tf
+++ b/aws/bedrock/outputs.tf
@@ -7,3 +7,38 @@ output "role_name" {
   value       = aws_iam_role.bedrock_kb.name
   description = "Name of the Bedrock IAM role. Useful when the application needs to attach additional policies at runtime."
 }
+
+output "aoss_data_access_policy_name" {
+  value       = var.opensearch_collection_name == null ? null : aws_opensearchserverless_access_policy.bedrock[0].name
+  description = "Name of the AOSS data-access policy granting the bedrock role + any additional principals data-plane access on the collection. null when opensearch_collection_name was not wired in."
+}
+
+output "invocation_log_group_name" {
+  value       = var.enable_invocation_logging ? aws_cloudwatch_log_group.invocations[0].name : null
+  description = "CloudWatch log group receiving Bedrock InvokeModel logs. null when enable_invocation_logging is false."
+}
+
+output "invocation_log_group_arn" {
+  value       = var.enable_invocation_logging ? aws_cloudwatch_log_group.invocations[0].arn : null
+  description = "ARN of the invocation log group. null when disabled. Wire into observability dashboards/alarms."
+}
+
+output "invocation_logging_role_arn" {
+  value       = var.enable_invocation_logging ? aws_iam_role.invocation_logging[0].arn : null
+  description = "ARN of the IAM role Bedrock assumes to write invocation logs. null when disabled."
+}
+
+output "guardrail_id" {
+  value       = var.enable_guardrail ? aws_bedrock_guardrail.this[0].guardrail_id : null
+  description = "ID of the Bedrock guardrail. null when disabled. Pass to InvokeModel/Converse along with guardrail_version to apply this policy at runtime."
+}
+
+output "guardrail_arn" {
+  value       = var.enable_guardrail ? aws_bedrock_guardrail.this[0].guardrail_arn : null
+  description = "ARN of the Bedrock guardrail. null when disabled."
+}
+
+output "guardrail_version" {
+  value       = var.enable_guardrail ? aws_bedrock_guardrail.this[0].version : null
+  description = "Version string of the guardrail (DRAFT initially). Publish a numbered version with a separate aws_bedrock_guardrail_version resource if you need versioned releases."
+}

--- a/aws/bedrock/tests/integration.tftest.hcl
+++ b/aws/bedrock/tests/integration.tftest.hcl
@@ -1,0 +1,123 @@
+# Integration tests for the bedrock module — APPLIES AGAINST A REAL AWS ACCOUNT.
+#
+# Run with valid AWS credentials in the target account:
+#
+#   cd aws/bedrock
+#   AWS_REGION=us-east-1 terraform test -filter=tests/integration.tftest.hcl
+#
+# What it does:
+#   1. Stands up a real AOSS serverless collection (5–10 min)
+#   2. Applies the bedrock module against it: AOSS data-access policy +
+#      guardrail
+#   3. Asserts the resources came up cleanly and have the expected outputs
+#   4. Tears EVERYTHING down at the end (terraform test always destroys)
+#
+# What it deliberately does NOT exercise:
+#   - enable_invocation_logging — that resource is an account+region
+#     singleton; flipping it on here would clobber any existing config in the
+#     target account. Test it manually in a throwaway account if needed.
+#   - Bedrock Knowledge Base / vector index creation — see the comment in
+#     main.tf for why those are application-layer concerns.
+#
+# Resource names use the project = "iotbed" prefix, so collisions with
+# real workloads are unlikely. If you re-run while a previous run is still
+# tearing down, AOSS will reject the duplicate collection name — wait for
+# the prior teardown (~3 min) before retrying.
+
+provider "aws" {
+  region = var.region
+}
+
+variables {
+  project     = "iotbed"
+  region      = "us-east-1"
+  environment = "test"
+
+  # The bedrock module requires both, but neither needs to actually exist
+  # for this test — the IAM policy references them as ARN strings only and
+  # is never evaluated against the real principals during apply.
+  s3_bucket_arn             = "arn:aws:s3:::iotbed-fixture-not-real"
+  opensearch_collection_arn = "arn:aws:aoss:us-east-1:000000000000:collection/placeholder"
+}
+
+# --- Setup: real AOSS collection ------------------------------------------
+#
+# Uses the sibling opensearch preset. allow_public_access = true so the
+# collection can be reached without provisioning a VPC endpoint, which keeps
+# the test self-contained.
+run "setup_aoss_collection" {
+  command = apply
+
+  # Path is resolved relative to the module under test (aws/bedrock), not
+  # this file's location, so we go up one level into aws/ and across.
+  module {
+    source = "../opensearch"
+  }
+
+  variables {
+    project             = var.project
+    environment         = var.environment
+    region              = var.region
+    deployment_type     = "serverless"
+    allow_public_access = true
+  }
+
+  assert {
+    condition     = output.collection_arn != null && output.collection_name != null
+    error_message = "AOSS setup must yield both an ARN and a collection name."
+  }
+}
+
+# --- Main: bedrock module against the real collection ---------------------
+
+run "bedrock_apply" {
+  command = apply
+
+  variables {
+    opensearch_collection_arn  = run.setup_aoss_collection.collection_arn
+    opensearch_collection_name = run.setup_aoss_collection.collection_name
+
+    enable_guardrail          = true
+    enable_invocation_logging = false # account-level singleton, opt-in only
+
+    # Exercise the topic + word + content + PII paths in one apply so a
+    # single integration cycle covers every dynamic block in the guardrail.
+    guardrail_pii_action = "ANONYMIZE"
+    guardrail_denied_topics = [{
+      name       = "Investment Advice"
+      definition = "Specific recommendations to buy or sell securities."
+      examples   = ["Should I buy AAPL?"]
+    }]
+    guardrail_blocked_words = ["competitorcorp"]
+  }
+
+  assert {
+    condition     = output.role_arn != null && length(output.role_arn) > 0
+    error_message = "Bedrock IAM role ARN must be populated after apply."
+  }
+
+  assert {
+    condition     = output.aoss_data_access_policy_name != null
+    error_message = "AOSS data-access policy must be created when opensearch_collection_name is wired."
+  }
+
+  assert {
+    condition     = output.guardrail_id != null && length(output.guardrail_id) > 0
+    error_message = "Guardrail ID must be populated after apply — this is the field the application passes to InvokeModel."
+  }
+
+  assert {
+    condition     = output.guardrail_arn != null
+    error_message = "Guardrail ARN must be populated after apply."
+  }
+
+  assert {
+    condition     = output.guardrail_version != null
+    error_message = "Guardrail version must be populated (DRAFT initially)."
+  }
+
+  assert {
+    condition     = output.invocation_log_group_name == null
+    error_message = "Invocation log group must remain null when enable_invocation_logging is false."
+  }
+}

--- a/aws/bedrock/tests/integration.tftest.hcl
+++ b/aws/bedrock/tests/integration.tftest.hcl
@@ -3,33 +3,52 @@
 # Run with valid AWS credentials in the target account:
 #
 #   cd aws/bedrock
+#   terraform init
 #   AWS_REGION=us-east-1 terraform test -filter=tests/integration.tftest.hcl
 #
 # What it does:
 #   1. Stands up a real AOSS serverless collection (5–10 min)
-#   2. Applies the bedrock module against it: AOSS data-access policy +
-#      guardrail
-#   3. Asserts the resources came up cleanly and have the expected outputs
+#   2. bedrock_apply: applies bedrock with logging OFF, asserts on the
+#      rendered guardrail attributes, decodes and inspects the AOSS
+#      data-access policy
+#   3. bedrock_with_invocation_logging: re-applies the same module with
+#      enable_invocation_logging = true, asserts the CloudWatch log group,
+#      IAM role + policy, and account-level configuration come up
 #   4. Tears EVERYTHING down at the end (terraform test always destroys)
 #
-# What it deliberately does NOT exercise:
-#   - enable_invocation_logging — that resource is an account+region
-#     singleton; flipping it on here would clobber any existing config in the
-#     target account. Test it manually in a throwaway account if needed.
-#   - Bedrock Knowledge Base / vector index creation — see the comment in
-#     main.tf for why those are application-layer concerns.
+# Bedrock Knowledge Base / vector index creation is intentionally not
+# exercised — see the comment in main.tf for why those are application-
+# layer concerns.
 #
-# Resource names use the project = "iotbed" prefix, so collisions with
-# real workloads are unlikely. If you re-run while a previous run is still
-# tearing down, AOSS will reject the duplicate collection name — wait for
-# the prior teardown (~3 min) before retrying.
+# CAUTION: aws_bedrock_model_invocation_logging_configuration is an
+# account+region SINGLETON. Run 3 will overwrite any pre-existing
+# configuration in the target account+region for the duration of the test
+# (and delete it on teardown). Only run this against a sandbox / test
+# account where wiping invocation logging is acceptable.
+#
+# Resource names embed a UTC timestamp suffix (MMDDhhmmss) so two
+# back-to-back runs don't collide on the AOSS collection name. If a prior
+# run was killed mid-apply, manual cleanup may be required:
+#
+#   aws opensearchserverless list-collections --query 'collectionSummaries[?starts_with(name, `iotbed-`)]'
+#   aws opensearchserverless delete-collection --id <id>
+#   aws opensearchserverless list-access-policies --type data --query 'accessPolicySummaries[?starts_with(name, `iotbed-`)]'
+#   aws opensearchserverless delete-access-policy --type data --name <name>
+#   aws opensearchserverless list-security-policies --type encryption --query 'securityPolicySummaries[?starts_with(name, `iotbed-`)]'
+#   aws opensearchserverless list-security-policies --type network --query 'securityPolicySummaries[?starts_with(name, `iotbed-`)]'
 
 provider "aws" {
   region = var.region
 }
 
 variables {
-  project     = "iotbed"
+  # Suffix the project name with a UTC MMDDhhmmss timestamp so concurrent
+  # or back-to-back runs don't collide on AOSS resource names. Computed
+  # once at file-load time and shared across every run in this file, so
+  # setup_aoss_collection and bedrock_apply see the same project string.
+  # Risk: two runs in the exact same second collide. Acceptable for a
+  # human-driven integration test.
+  project     = "iotbed-${formatdate("MMDDhhmmss", timestamp())}"
   region      = "us-east-1"
   environment = "test"
 
@@ -68,7 +87,7 @@ run "setup_aoss_collection" {
   }
 }
 
-# --- Main: bedrock module against the real collection ---------------------
+# --- Main: bedrock module against the real collection (logging OFF) -------
 
 run "bedrock_apply" {
   command = apply
@@ -78,10 +97,131 @@ run "bedrock_apply" {
     opensearch_collection_name = run.setup_aoss_collection.collection_name
 
     enable_guardrail          = true
-    enable_invocation_logging = false # account-level singleton, opt-in only
+    enable_invocation_logging = false # exercised in the next run
 
-    # Exercise the topic + word + content + PII paths in one apply so a
-    # single integration cycle covers every dynamic block in the guardrail.
+    # Drive every dynamic block in the guardrail so a single apply covers
+    # content + PII + topic + word policies end-to-end.
+    guardrail_pii_action = "ANONYMIZE"
+    guardrail_denied_topics = [{
+      name       = "Investment Advice"
+      definition = "Specific recommendations to buy or sell securities."
+      examples   = ["Should I buy AAPL?"]
+    }]
+    guardrail_blocked_words = ["competitorcorp"]
+  }
+
+  # --- IAM role basics ---
+  assert {
+    condition     = aws_iam_role.bedrock_kb.name == "${var.project}-bedrock-role"
+    error_message = "Bedrock KB role must be named {project}-bedrock-role."
+  }
+
+  # Confused-deputy guard must be present in the trust policy of the live
+  # role — covers both that the data source resolved AND that the policy
+  # JSON includes the SourceAccount condition.
+  assert {
+    condition     = jsondecode(aws_iam_role.bedrock_kb.assume_role_policy).Statement[0].Condition.StringEquals["aws:SourceAccount"] == data.aws_caller_identity.current.account_id
+    error_message = "Bedrock KB role trust policy must include aws:SourceAccount scoped to the deploying account."
+  }
+
+  # --- AOSS data-access policy ---
+  # Decode the live policy JSON and assert on its contents. Catches
+  # regressions where the rule shape changes, the bedrock role drops out
+  # of the principal list, or aoss:CreateIndex disappears (which is what
+  # the application uses to author the vector index).
+  assert {
+    condition     = aws_opensearchserverless_access_policy.bedrock[0].name == "${var.project}-br-data"
+    error_message = "AOSS access policy must follow the {project}-br-data naming convention."
+  }
+
+  assert {
+    condition = contains(
+      jsondecode(aws_opensearchserverless_access_policy.bedrock[0].policy)[0].Principal,
+      aws_iam_role.bedrock_kb.arn,
+    )
+    error_message = "AOSS access policy must include the bedrock role in its principal list."
+  }
+
+  assert {
+    condition     = length(jsondecode(aws_opensearchserverless_access_policy.bedrock[0].policy)[0].Rules) == 2
+    error_message = "AOSS access policy must include both a collection rule and an index rule."
+  }
+
+  assert {
+    condition = contains(
+      jsondecode(aws_opensearchserverless_access_policy.bedrock[0].policy)[0].Rules[1].Permission,
+      "aoss:CreateIndex",
+    )
+    error_message = "AOSS index rule must grant aoss:CreateIndex (the application uses this to author the vector index)."
+  }
+
+  # --- Guardrail shape ---
+  # Verify the live guardrail rendered every dynamic block we configured
+  # above. Asserting on counts catches regressions where a dynamic block
+  # silently disappears or iterates the wrong number of times.
+  assert {
+    condition     = aws_bedrock_guardrail.this[0].name == "${var.project}-guardrail"
+    error_message = "Guardrail name must be {project}-guardrail."
+  }
+
+  assert {
+    condition     = aws_bedrock_guardrail.this[0].version == "DRAFT"
+    error_message = "Newly-created guardrail must report version=DRAFT (we don't publish numbered versions in this module)."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this[0].content_policy_config[0].filters_config) == 6
+    error_message = "Guardrail must have 5 universal content filters + PROMPT_ATTACK = 6."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this[0].sensitive_information_policy_config[0].pii_entities_config) == 7
+    error_message = "Guardrail must render all 7 default PII entities."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this[0].topic_policy_config[0].topics_config) == 1
+    error_message = "Guardrail must include the 1 denied topic we configured."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this[0].word_policy_config[0].words_config) == 1
+    error_message = "Guardrail must include the 1 blocked word we configured."
+  }
+
+  # --- Outputs ---
+  assert {
+    condition     = output.guardrail_id != null && length(output.guardrail_id) > 0
+    error_message = "Guardrail ID must be populated after apply (this is the field the application passes to InvokeModel)."
+  }
+}
+
+# --- Invocation logging: re-apply with logging enabled --------------------
+#
+# This run modifies the bedrock module's state in place to add the logging
+# resources. Asserts the CloudWatch log group, IAM role, and account-level
+# configuration come up; the existing guardrail and AOSS policy from the
+# prior run remain in place. Teardown removes everything.
+#
+# Worth running because the invocation-logging path is the entire reason
+# Bedrock has any observability at all — it's the singleton that pipes
+# every InvokeModel call to CloudWatch Logs.
+run "bedrock_with_invocation_logging" {
+  command = apply
+
+  variables {
+    opensearch_collection_arn  = run.setup_aoss_collection.collection_arn
+    opensearch_collection_name = run.setup_aoss_collection.collection_name
+
+    enable_guardrail              = true
+    enable_invocation_logging     = true
+    invocation_log_retention_days = 7
+    log_text_data                 = true
+    log_image_data                = false
+    log_embedding_data            = false
+
+    # Keep guardrail config identical to the prior run so the diff is
+    # purely the new logging resources.
     guardrail_pii_action = "ANONYMIZE"
     guardrail_denied_topics = [{
       name       = "Investment Advice"
@@ -92,32 +232,44 @@ run "bedrock_apply" {
   }
 
   assert {
-    condition     = output.role_arn != null && length(output.role_arn) > 0
-    error_message = "Bedrock IAM role ARN must be populated after apply."
+    condition     = aws_cloudwatch_log_group.invocations[0].name == "/aws/bedrock/${var.project}-invocations"
+    error_message = "Log group must follow the /aws/bedrock/{project}-invocations naming convention."
   }
 
   assert {
-    condition     = output.aoss_data_access_policy_name != null
-    error_message = "AOSS data-access policy must be created when opensearch_collection_name is wired."
+    condition     = aws_cloudwatch_log_group.invocations[0].retention_in_days == 7
+    error_message = "Log group retention must reflect the 7-day setting we passed."
   }
 
   assert {
-    condition     = output.guardrail_id != null && length(output.guardrail_id) > 0
-    error_message = "Guardrail ID must be populated after apply — this is the field the application passes to InvokeModel."
+    condition     = aws_iam_role.invocation_logging[0].name == "${var.project}-bedrock-logging-role"
+    error_message = "Logging IAM role must follow the naming convention."
+  }
+
+  # The invocation logging trust policy must also include the confused-
+  # deputy guard (mirrors the bedrock_kb assertion in the prior run).
+  assert {
+    condition     = jsondecode(aws_iam_role.invocation_logging[0].assume_role_policy).Statement[0].Condition.StringEquals["aws:SourceAccount"] == data.aws_caller_identity.current.account_id
+    error_message = "Invocation logging role trust policy must include aws:SourceAccount scoped to the deploying account."
   }
 
   assert {
-    condition     = output.guardrail_arn != null
-    error_message = "Guardrail ARN must be populated after apply."
+    condition     = aws_bedrock_model_invocation_logging_configuration.this[0].logging_config[0].text_data_delivery_enabled == true
+    error_message = "log_text_data=true must propagate to the live invocation logging configuration."
   }
 
   assert {
-    condition     = output.guardrail_version != null
-    error_message = "Guardrail version must be populated (DRAFT initially)."
+    condition     = aws_bedrock_model_invocation_logging_configuration.this[0].logging_config[0].image_data_delivery_enabled == false
+    error_message = "log_image_data=false must propagate to the live invocation logging configuration."
   }
 
   assert {
-    condition     = output.invocation_log_group_name == null
-    error_message = "Invocation log group must remain null when enable_invocation_logging is false."
+    condition     = output.invocation_log_group_name != null && length(output.invocation_log_group_name) > 0
+    error_message = "Invocation log group output must be populated after enabling logging."
+  }
+
+  assert {
+    condition     = output.invocation_logging_role_arn != null
+    error_message = "Invocation logging role ARN output must be populated."
   }
 }

--- a/aws/bedrock/tests/unit.tftest.hcl
+++ b/aws/bedrock/tests/unit.tftest.hcl
@@ -1,18 +1,23 @@
 # Plan-only unit tests for the bedrock module.
 #
-# No AWS credentials required: every run uses command = plan, the AWS
-# provider is configured with skip_credentials_validation = true, and the
-# module has no data sources that would call AWS at plan time.
+# No AWS credentials required: the AWS provider is mocked so
+# data.aws_caller_identity.current resolves to a fixed account ID at plan
+# time. Run with:
 #
-# Run with: terraform test -filter=tests/unit.tftest.hcl
+#   terraform test -filter=tests/unit.tftest.hcl
 
-provider "aws" {
-  region                      = "us-east-1"
-  access_key                  = "fake"
-  secret_key                  = "fake"
-  skip_credentials_validation = true
-  skip_metadata_api_check     = true
-  skip_requesting_account_id  = true
+# Mocking the entire AWS provider replaces it for every run in this file
+# and gives data.aws_caller_identity.current a predictable account_id.
+# Resources never make real API calls under mock_provider, which is why
+# command = plan is enough to exercise the module's authoring logic.
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "111111111111"
+      arn        = "arn:aws:iam::111111111111:user/test"
+      user_id    = "AIDACKCEVSQ6C2EXAMPLE"
+    }
+  }
 }
 
 variables {
@@ -28,8 +33,6 @@ variables {
 run "defaults" {
   command = plan
 
-  # The bedrock_kb role is a non-counted resource so length() doesn't apply;
-  # asserting the name was rendered proves it's in the plan.
   assert {
     condition     = aws_iam_role.bedrock_kb.name == "iotest-br-bedrock-role"
     error_message = "Bedrock KB IAM role must always be created with the project-prefixed name."
@@ -38,6 +41,13 @@ run "defaults" {
   assert {
     condition     = aws_iam_role_policy.bedrock_kb.name == "iotest-br-bedrock-policy"
     error_message = "Bedrock KB IAM policy must always be created with the project-prefixed name."
+  }
+
+  # Trust policy must include the SourceAccount confused-deputy guard,
+  # scoped to the mocked test account.
+  assert {
+    condition     = jsondecode(aws_iam_role.bedrock_kb.assume_role_policy).Statement[0].Condition.StringEquals["aws:SourceAccount"] == "111111111111"
+    error_message = "bedrock_kb trust policy must include aws:SourceAccount scoped to the current account."
   }
 
   assert {
@@ -63,6 +73,33 @@ run "defaults" {
   assert {
     condition     = length(aws_bedrock_guardrail.this) == 1
     error_message = "Guardrail is enabled by default and must be planned."
+  }
+
+  # Default guardrail shape: 5 universal categories + PROMPT_ATTACK = 6 filters,
+  # 7 default PII entities at ANONYMIZE, no topics, no words.
+  assert {
+    condition     = length(aws_bedrock_guardrail.this[0].content_policy_config[0].filters_config) == 6
+    error_message = "Default guardrail must have 5 universal content filters + PROMPT_ATTACK = 6."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this[0].sensitive_information_policy_config[0].pii_entities_config) == 7
+    error_message = "Default guardrail must render all 7 default PII entities."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this[0].topic_policy_config) == 0
+    error_message = "Default guardrail must NOT include a topic_policy_config block (none configured)."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this[0].word_policy_config) == 0
+    error_message = "Default guardrail must NOT include a word_policy_config block (none configured)."
+  }
+
+  assert {
+    condition     = aws_bedrock_guardrail.this[0].name == "iotest-br-guardrail"
+    error_message = "Guardrail name must be {project}-guardrail."
   }
 }
 
@@ -92,6 +129,32 @@ run "everything_off" {
   }
 }
 
+# --- Output null-gating (cheap to assert in unit, expensive in integration) ---
+
+run "outputs_null_when_features_off" {
+  command = plan
+
+  variables {
+    enable_guardrail          = false
+    enable_invocation_logging = false
+  }
+
+  assert {
+    condition     = output.guardrail_id == null && output.guardrail_arn == null && output.guardrail_version == null
+    error_message = "All guardrail outputs must be null when enable_guardrail is false."
+  }
+
+  assert {
+    condition     = output.invocation_log_group_name == null && output.invocation_log_group_arn == null && output.invocation_logging_role_arn == null
+    error_message = "All invocation-logging outputs must be null when enable_invocation_logging is false."
+  }
+
+  assert {
+    condition     = output.aoss_data_access_policy_name == null
+    error_message = "AOSS data-access policy output must be null when opensearch_collection_name is unset."
+  }
+}
+
 run "invocation_logging_enabled" {
   command = plan
 
@@ -114,8 +177,19 @@ run "invocation_logging_enabled" {
   }
 
   assert {
+    condition     = aws_cloudwatch_log_group.invocations[0].name == "/aws/bedrock/iotest-br-invocations"
+    error_message = "Log group name must follow the /aws/bedrock/{project}-invocations convention."
+  }
+
+  assert {
     condition     = length(aws_iam_role.invocation_logging) == 1
     error_message = "Logging IAM role must be created."
+  }
+
+  # Confused-deputy guard on the new role too.
+  assert {
+    condition     = jsondecode(aws_iam_role.invocation_logging[0].assume_role_policy).Statement[0].Condition.StringEquals["aws:SourceAccount"] == "111111111111"
+    error_message = "invocation_logging trust policy must include aws:SourceAccount scoped to the current account."
   }
 
   assert {
@@ -127,10 +201,29 @@ run "invocation_logging_enabled" {
     condition     = length(aws_bedrock_model_invocation_logging_configuration.this) == 1
     error_message = "Account-level logging configuration must be created."
   }
+
+  # The configuration object must reflect every flag toggled above.
+  assert {
+    condition     = aws_bedrock_model_invocation_logging_configuration.this[0].logging_config[0].text_data_delivery_enabled == false
+    error_message = "log_text_data=false must propagate to the logging configuration."
+  }
+
+  assert {
+    condition     = aws_bedrock_model_invocation_logging_configuration.this[0].logging_config[0].image_data_delivery_enabled == true
+    error_message = "log_image_data=true must propagate to the logging configuration."
+  }
+
+  assert {
+    condition     = aws_bedrock_model_invocation_logging_configuration.this[0].logging_config[0].embedding_data_delivery_enabled == true
+    error_message = "log_embedding_data=true must propagate to the logging configuration."
+  }
 }
 
-run "aoss_access_policy_wired" {
-  command = plan
+run "aoss_access_policy_wired_with_extra_principals" {
+  # apply (not plan) because the rendered policy embeds aws_iam_role.bedrock_kb.arn,
+  # which is "(known after apply)" at plan time. mock_provider populates a mock
+  # ARN at apply time and never calls AWS, so this stays credential-free.
+  command = apply
 
   variables {
     opensearch_collection_name     = "iotest-br-search"
@@ -155,26 +248,107 @@ run "aoss_access_policy_wired" {
     condition     = aws_opensearchserverless_access_policy.bedrock[0].type == "data"
     error_message = "AOSS access policy must be of type 'data'."
   }
+
+  # Decode the JSON and assert on its inner shape — the policy body is
+  # where regressions hide. We confirm: principal list contains both the
+  # bedrock role (computed at plan time as a placeholder, so we only check
+  # length) and the additional principal we passed in; both rule blocks
+  # are present; the index rule includes aoss:CreateIndex.
+  assert {
+    condition     = length(jsondecode(aws_opensearchserverless_access_policy.bedrock[0].policy)) == 1
+    error_message = "AOSS access policy must contain exactly one policy element."
+  }
+
+  assert {
+    condition = contains(
+      jsondecode(aws_opensearchserverless_access_policy.bedrock[0].policy)[0].Principal,
+      "arn:aws:iam::111111111111:role/terraform-runner",
+    )
+    error_message = "AOSS access policy principal list must include the additional principal we passed in."
+  }
+
+  assert {
+    condition     = length(jsondecode(aws_opensearchserverless_access_policy.bedrock[0].policy)[0].Principal) == 2
+    error_message = "AOSS access policy principal list must contain exactly 2 entries: bedrock role + 1 additional."
+  }
+
+  assert {
+    condition     = length(jsondecode(aws_opensearchserverless_access_policy.bedrock[0].policy)[0].Rules) == 2
+    error_message = "AOSS access policy must contain both a collection rule and an index rule."
+  }
+
+  assert {
+    condition = contains(
+      jsondecode(aws_opensearchserverless_access_policy.bedrock[0].policy)[0].Rules[1].Permission,
+      "aoss:CreateIndex",
+    )
+    error_message = "Index rule must grant aoss:CreateIndex (required for the application to author the vector index)."
+  }
+
+  assert {
+    condition     = jsondecode(aws_opensearchserverless_access_policy.bedrock[0].policy)[0].Rules[0].Resource[0] == "collection/iotest-br-search"
+    error_message = "Collection rule resource must reference the wired collection name."
+  }
+}
+
+run "aoss_access_policy_with_no_extra_principals" {
+  # apply (not plan) — see aoss_access_policy_wired_with_extra_principals.
+  command = apply
+
+  variables {
+    opensearch_collection_name = "iotest-br-search"
+    # aoss_additional_principal_arns left at default []
+  }
+
+  # Empty additional-principals concat path — bedrock role only.
+  assert {
+    condition     = length(jsondecode(aws_opensearchserverless_access_policy.bedrock[0].policy)[0].Principal) == 1
+    error_message = "AOSS principal list must contain exactly the bedrock role when no additional principals are passed."
+  }
 }
 
 # --- Guardrail variants ----------------------------------------------------
 
-run "guardrail_content_strength_none" {
+run "guardrail_content_strength_none_drops_block" {
   command = plan
 
   variables {
     guardrail_content_filter_strength = "NONE"
   }
 
-  # Content-policy block is dropped; the guardrail itself is still planned
-  # because PII / topic / word policies remain available.
+  # The conditional in main.tf drops content_policy_config entirely when
+  # strength is NONE. Asserting the block disappears proves the conditional
+  # works (and would catch a regression that always-on'd the block).
   assert {
-    condition     = length(aws_bedrock_guardrail.this) == 1
-    error_message = "Guardrail must still be planned when content strength is NONE."
+    condition     = length(aws_bedrock_guardrail.this[0].content_policy_config) == 0
+    error_message = "content_policy_config block must be dropped when content strength is NONE."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this[0].sensitive_information_policy_config) == 1
+    error_message = "PII policy must remain even when content policy is NONE."
   }
 }
 
-run "guardrail_pii_blocked" {
+run "guardrail_pii_off_drops_block" {
+  command = plan
+
+  variables {
+    guardrail_pii_action = "NONE"
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this[0].sensitive_information_policy_config) == 0
+    error_message = "sensitive_information_policy_config block must be dropped when PII action is NONE."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this[0].content_policy_config) == 1
+    error_message = "Content policy must remain even when PII is NONE."
+  }
+}
+
+run "guardrail_pii_blocked_with_custom_entities" {
   command = plan
 
   variables {
@@ -183,21 +357,16 @@ run "guardrail_pii_blocked" {
   }
 
   assert {
-    condition     = length(aws_bedrock_guardrail.this) == 1
-    error_message = "Guardrail must be planned with custom PII configuration."
-  }
-}
-
-run "guardrail_pii_off" {
-  command = plan
-
-  variables {
-    guardrail_pii_action = "NONE"
+    condition     = length(aws_bedrock_guardrail.this[0].sensitive_information_policy_config[0].pii_entities_config) == 2
+    error_message = "PII entities config must render exactly the two entries we passed."
   }
 
+  # Verify the action propagates from the variable into the rendered block.
   assert {
-    condition     = length(aws_bedrock_guardrail.this) == 1
-    error_message = "Guardrail must still be planned when PII action is NONE."
+    condition = alltrue([
+      for e in aws_bedrock_guardrail.this[0].sensitive_information_policy_config[0].pii_entities_config : e.action == "BLOCK"
+    ])
+    error_message = "All rendered PII entries must take the BLOCK action when guardrail_pii_action=BLOCK."
   }
 }
 
@@ -205,17 +374,54 @@ run "guardrail_topics_and_words" {
   command = plan
 
   variables {
-    guardrail_denied_topics = [{
-      name       = "Investment Advice"
-      definition = "Specific recommendations to buy or sell securities."
-      examples   = ["Should I buy AAPL?", "What stocks should I pick?"]
-    }]
+    guardrail_denied_topics = [
+      {
+        name       = "Investment Advice"
+        definition = "Specific recommendations to buy or sell securities."
+        examples   = ["Should I buy AAPL?", "What stocks should I pick?"]
+      },
+      {
+        name       = "Medical Diagnosis"
+        definition = "Clinical diagnosis of patient conditions."
+        examples   = ["Do I have cancer?"]
+      },
+      {
+        name       = "Legal Advice"
+        definition = "Specific legal recommendations for the user's situation."
+      },
+    ]
     guardrail_blocked_words = ["competitorcorp", "internalcodename"]
   }
 
+  # Multi-topic iteration must render all three; tests the dynamic for_each.
   assert {
-    condition     = length(aws_bedrock_guardrail.this) == 1
-    error_message = "Guardrail must be planned with topic + word policies."
+    condition     = length(aws_bedrock_guardrail.this[0].topic_policy_config[0].topics_config) == 3
+    error_message = "topic_policy_config must contain all 3 denied topics."
+  }
+
+  assert {
+    condition = alltrue([
+      for t in aws_bedrock_guardrail.this[0].topic_policy_config[0].topics_config : t.type == "DENY"
+    ])
+    error_message = "All denied topics must have type=DENY."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this[0].word_policy_config[0].words_config) == 2
+    error_message = "word_policy_config must contain both blocked words."
+  }
+}
+
+run "guardrail_with_kms_key" {
+  command = plan
+
+  variables {
+    guardrail_kms_key_arn = "arn:aws:kms:us-east-1:111111111111:key/abcd1234-ab12-cd34-ef56-abcdef123456"
+  }
+
+  assert {
+    condition     = aws_bedrock_guardrail.this[0].kms_key_arn == "arn:aws:kms:us-east-1:111111111111:key/abcd1234-ab12-cd34-ef56-abcdef123456"
+    error_message = "kms_key_arn must propagate to the guardrail resource for customer-managed encryption."
   }
 }
 
@@ -261,6 +467,16 @@ run "rejects_invalid_pii_action" {
   expect_failures = [var.guardrail_pii_action]
 }
 
+run "rejects_unknown_pii_entity" {
+  command = plan
+
+  variables {
+    guardrail_pii_entities = ["EMAIL", "EMAILS"] # second one is a typo
+  }
+
+  expect_failures = [var.guardrail_pii_entities]
+}
+
 run "rejects_bad_retention_days" {
   command = plan
 
@@ -291,4 +507,61 @@ run "rejects_oversize_input_message" {
   }
 
   expect_failures = [var.guardrail_blocked_input_messaging]
+}
+
+run "rejects_oversize_output_message" {
+  command = plan
+
+  variables {
+    guardrail_blocked_outputs_messaging = "a${join("", [for i in range(500) : "b"])}"
+  }
+
+  expect_failures = [var.guardrail_blocked_outputs_messaging]
+}
+
+run "accepts_max_length_input_message" {
+  command = plan
+
+  variables {
+    # Exactly 500 characters — the upper bound. Anchors the validation
+    # boundary on the accepting side so a regression that drops the
+    # validation lower can't go undetected.
+    guardrail_blocked_input_messaging = join("", [for i in range(500) : "a"])
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this) == 1
+    error_message = "Exactly-500-char message must be accepted (boundary case)."
+  }
+}
+
+run "rejects_empty_environment" {
+  command = plan
+
+  variables {
+    environment = "  "
+  }
+
+  expect_failures = [var.environment]
+}
+
+run "rejects_oversize_project" {
+  command = plan
+
+  variables {
+    # 25 chars, one over the bedrock module's project limit (24).
+    project = "abcdefghij-klmnopqrstuvw1"
+  }
+
+  expect_failures = [var.project]
+}
+
+run "rejects_bad_kms_arn" {
+  command = plan
+
+  variables {
+    guardrail_kms_key_arn = "not-a-kms-arn"
+  }
+
+  expect_failures = [var.guardrail_kms_key_arn]
 }

--- a/aws/bedrock/tests/unit.tftest.hcl
+++ b/aws/bedrock/tests/unit.tftest.hcl
@@ -1,0 +1,294 @@
+# Plan-only unit tests for the bedrock module.
+#
+# No AWS credentials required: every run uses command = plan, the AWS
+# provider is configured with skip_credentials_validation = true, and the
+# module has no data sources that would call AWS at plan time.
+#
+# Run with: terraform test -filter=tests/unit.tftest.hcl
+
+provider "aws" {
+  region                      = "us-east-1"
+  access_key                  = "fake"
+  secret_key                  = "fake"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+}
+
+variables {
+  project                   = "iotest-br"
+  region                    = "us-east-1"
+  environment               = "test"
+  s3_bucket_arn             = "arn:aws:s3:::iotest-br-bucket"
+  opensearch_collection_arn = "arn:aws:aoss:us-east-1:111111111111:collection/abc123def456"
+}
+
+# --- Default shape ---------------------------------------------------------
+
+run "defaults" {
+  command = plan
+
+  # The bedrock_kb role is a non-counted resource so length() doesn't apply;
+  # asserting the name was rendered proves it's in the plan.
+  assert {
+    condition     = aws_iam_role.bedrock_kb.name == "iotest-br-bedrock-role"
+    error_message = "Bedrock KB IAM role must always be created with the project-prefixed name."
+  }
+
+  assert {
+    condition     = aws_iam_role_policy.bedrock_kb.name == "iotest-br-bedrock-policy"
+    error_message = "Bedrock KB IAM policy must always be created with the project-prefixed name."
+  }
+
+  assert {
+    condition     = length(aws_opensearchserverless_access_policy.bedrock) == 0
+    error_message = "AOSS data-access policy must NOT be created when opensearch_collection_name is null (default)."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_log_group.invocations) == 0
+    error_message = "Invocation log group must NOT be created when enable_invocation_logging is false (default)."
+  }
+
+  assert {
+    condition     = length(aws_iam_role.invocation_logging) == 0
+    error_message = "Invocation logging role must NOT be created by default."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_model_invocation_logging_configuration.this) == 0
+    error_message = "Invocation logging configuration must NOT be created by default."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this) == 1
+    error_message = "Guardrail is enabled by default and must be planned."
+  }
+}
+
+# --- Feature toggles -------------------------------------------------------
+
+run "everything_off" {
+  command = plan
+
+  variables {
+    enable_guardrail          = false
+    enable_invocation_logging = false
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this) == 0
+    error_message = "Guardrail must be skipped when enable_guardrail is false."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_log_group.invocations) == 0
+    error_message = "Log group must be skipped when invocation logging is off."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_model_invocation_logging_configuration.this) == 0
+    error_message = "Invocation logging config must be skipped when invocation logging is off."
+  }
+}
+
+run "invocation_logging_enabled" {
+  command = plan
+
+  variables {
+    enable_invocation_logging     = true
+    invocation_log_retention_days = 7
+    log_text_data                 = false
+    log_image_data                = true
+    log_embedding_data            = true
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_log_group.invocations) == 1
+    error_message = "Log group must be created when invocation logging enabled."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_log_group.invocations[0].retention_in_days == 7
+    error_message = "Log group retention must reflect invocation_log_retention_days."
+  }
+
+  assert {
+    condition     = length(aws_iam_role.invocation_logging) == 1
+    error_message = "Logging IAM role must be created."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.invocation_logging) == 1
+    error_message = "Logging IAM role policy must be created."
+  }
+
+  assert {
+    condition     = length(aws_bedrock_model_invocation_logging_configuration.this) == 1
+    error_message = "Account-level logging configuration must be created."
+  }
+}
+
+run "aoss_access_policy_wired" {
+  command = plan
+
+  variables {
+    opensearch_collection_name     = "iotest-br-search"
+    aoss_additional_principal_arns = ["arn:aws:iam::111111111111:role/terraform-runner"]
+  }
+
+  assert {
+    condition     = length(aws_opensearchserverless_access_policy.bedrock) == 1
+    error_message = "AOSS access policy must be created when opensearch_collection_name is set."
+  }
+
+  # Pattern is "${project}-br-data" — with project=iotest-br this renders
+  # iotest-br-br-data. The doubled "br" is fine because the variable is
+  # already shaped to be a logical project identifier; we just assert the
+  # full name to lock the convention in.
+  assert {
+    condition     = aws_opensearchserverless_access_policy.bedrock[0].name == "iotest-br-br-data"
+    error_message = "AOSS access policy name must follow the {project}-br-data pattern."
+  }
+
+  assert {
+    condition     = aws_opensearchserverless_access_policy.bedrock[0].type == "data"
+    error_message = "AOSS access policy must be of type 'data'."
+  }
+}
+
+# --- Guardrail variants ----------------------------------------------------
+
+run "guardrail_content_strength_none" {
+  command = plan
+
+  variables {
+    guardrail_content_filter_strength = "NONE"
+  }
+
+  # Content-policy block is dropped; the guardrail itself is still planned
+  # because PII / topic / word policies remain available.
+  assert {
+    condition     = length(aws_bedrock_guardrail.this) == 1
+    error_message = "Guardrail must still be planned when content strength is NONE."
+  }
+}
+
+run "guardrail_pii_blocked" {
+  command = plan
+
+  variables {
+    guardrail_pii_action   = "BLOCK"
+    guardrail_pii_entities = ["EMAIL", "PHONE"]
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this) == 1
+    error_message = "Guardrail must be planned with custom PII configuration."
+  }
+}
+
+run "guardrail_pii_off" {
+  command = plan
+
+  variables {
+    guardrail_pii_action = "NONE"
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this) == 1
+    error_message = "Guardrail must still be planned when PII action is NONE."
+  }
+}
+
+run "guardrail_topics_and_words" {
+  command = plan
+
+  variables {
+    guardrail_denied_topics = [{
+      name       = "Investment Advice"
+      definition = "Specific recommendations to buy or sell securities."
+      examples   = ["Should I buy AAPL?", "What stocks should I pick?"]
+    }]
+    guardrail_blocked_words = ["competitorcorp", "internalcodename"]
+  }
+
+  assert {
+    condition     = length(aws_bedrock_guardrail.this) == 1
+    error_message = "Guardrail must be planned with topic + word policies."
+  }
+}
+
+# --- Validation rules ------------------------------------------------------
+
+run "rejects_bad_collection_arn" {
+  command = plan
+
+  variables {
+    opensearch_collection_arn = "not-a-real-arn"
+  }
+
+  expect_failures = [var.opensearch_collection_arn]
+}
+
+run "rejects_session_principal_arn" {
+  command = plan
+
+  variables {
+    aoss_additional_principal_arns = ["arn:aws:sts::111111111111:assumed-role/MyRole/session"]
+  }
+
+  expect_failures = [var.aoss_additional_principal_arns]
+}
+
+run "rejects_invalid_strength" {
+  command = plan
+
+  variables {
+    guardrail_content_filter_strength = "EXTREME"
+  }
+
+  expect_failures = [var.guardrail_content_filter_strength]
+}
+
+run "rejects_invalid_pii_action" {
+  command = plan
+
+  variables {
+    guardrail_pii_action = "REDACT"
+  }
+
+  expect_failures = [var.guardrail_pii_action]
+}
+
+run "rejects_bad_retention_days" {
+  command = plan
+
+  variables {
+    enable_invocation_logging     = true
+    invocation_log_retention_days = 42
+  }
+
+  expect_failures = [var.invocation_log_retention_days]
+}
+
+run "rejects_oversize_collection_name" {
+  command = plan
+
+  variables {
+    opensearch_collection_name = "this-name-is-far-too-long-for-aoss-to-accept-it"
+  }
+
+  expect_failures = [var.opensearch_collection_name]
+}
+
+run "rejects_oversize_input_message" {
+  command = plan
+
+  variables {
+    # 501 characters — one over the Bedrock guardrail limit
+    guardrail_blocked_input_messaging = "a${join("", [for i in range(500) : "b"])}"
+  }
+
+  expect_failures = [var.guardrail_blocked_input_messaging]
+}

--- a/aws/bedrock/variables.tf
+++ b/aws/bedrock/variables.tf
@@ -43,6 +43,150 @@ variable "opensearch_collection_arn" {
   }
 }
 
+variable "opensearch_collection_name" {
+  type        = string
+  description = "Name of the AOSS collection (NOT the ID embedded in the ARN). When set, the module provisions an AOSS data-access policy granting the bedrock role + any aoss_additional_principal_arns full data-plane access on the collection. When null, the data-access policy is skipped — the role exists but cannot actually use the collection until something else creates a matching access policy. Wire from aws/opensearch.collection_name."
+  default     = null
+  validation {
+    condition     = var.opensearch_collection_name == null ? true : (length(trimspace(var.opensearch_collection_name)) > 0 && length(var.opensearch_collection_name) <= 32)
+    error_message = "opensearch_collection_name must be null or a non-empty string ≤32 chars (the AOSS collection name limit)."
+  }
+}
+
+variable "aoss_additional_principal_arns" {
+  type        = list(string)
+  description = "Additional IAM role/user ARNs granted aoss:* on the collection's data plane (read/write/admin), in addition to the bedrock role this module creates. Use for the principal that creates the vector index (typically the terraform runner) and for any application-layer ingestion role. Pass the underlying role ARN — AOSS data-access policies do NOT resolve assumed-role session ARNs back to their underlying role, unlike IAM. Ignored when opensearch_collection_name is null."
+  default     = []
+  validation {
+    condition     = alltrue([for arn in var.aoss_additional_principal_arns : can(regex("^arn:aws[a-z-]*:iam::[0-9]{12}:(role|user)/", arn))])
+    error_message = "aoss_additional_principal_arns must all be IAM role or user ARNs (arn:aws:iam::<account>:role/... or :user/...). Assumed-role session ARNs (arn:aws:sts::...:assumed-role/...) are not valid in AOSS data-access policies."
+  }
+}
+
+# --- Invocation logging ----------------------------------------------------
+
+variable "enable_invocation_logging" {
+  type        = bool
+  description = "Provision a CloudWatch log group + IAM role and configure aws_bedrock_model_invocation_logging_configuration to stream every Bedrock InvokeModel call there. NOTE: the configuration is account+region scoped (one config per account per region). If multiple stacks set this true in the same account+region, the last apply wins and earlier stacks lose their logging silently. Default false — opt in deliberately."
+  default     = false
+}
+
+variable "invocation_log_retention_days" {
+  type        = number
+  description = "CloudWatch retention for the Bedrock invocation log group. Ignored when enable_invocation_logging is false."
+  default     = 30
+  validation {
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 2192, 2557, 2922, 3288, 3653], var.invocation_log_retention_days)
+    error_message = "invocation_log_retention_days must be one of the CloudWatch-allowed retention values (1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 2192, 2557, 2922, 3288, 3653)."
+  }
+}
+
+variable "log_text_data" {
+  type        = bool
+  description = "Include prompt + completion text in invocation logs. Default true. Disable if prompts/completions may contain sensitive data the log group is not authorised to retain."
+  default     = true
+}
+
+variable "log_image_data" {
+  type        = bool
+  description = "Include image data in invocation logs. Default false — image payloads are large and expensive to retain."
+  default     = false
+}
+
+variable "log_embedding_data" {
+  type        = bool
+  description = "Include embedding vectors in invocation logs. Default false — embeddings are large numeric arrays and rarely useful in logs."
+  default     = false
+}
+
+# --- Guardrail -------------------------------------------------------------
+
+variable "enable_guardrail" {
+  type        = bool
+  description = "Provision an aws_bedrock_guardrail resource with content, PII, denied-topic, and blocked-word policies. The application opts in by passing guardrail_id + guardrail_version to InvokeModel/Converse — this module only defines the policy, it does not bind it to any specific model."
+  default     = true
+}
+
+variable "guardrail_content_filter_strength" {
+  type        = string
+  description = "Strength applied uniformly to the SEXUAL, VIOLENCE, HATE, INSULTS, and MISCONDUCT content categories on both input and output. PROMPT_ATTACK is always set to HIGH on input (and NONE on output, the only value AWS accepts for that category). Set this to NONE to disable the content policy entirely while keeping PII/topic/word policies."
+  default     = "MEDIUM"
+  validation {
+    condition     = contains(["NONE", "LOW", "MEDIUM", "HIGH"], var.guardrail_content_filter_strength)
+    error_message = "guardrail_content_filter_strength must be one of NONE, LOW, MEDIUM, HIGH."
+  }
+}
+
+variable "guardrail_blocked_input_messaging" {
+  type        = string
+  description = "Message returned to the caller when the guardrail blocks the user's input."
+  default     = "Sorry, your input violates our usage policy and cannot be processed."
+  validation {
+    condition     = length(var.guardrail_blocked_input_messaging) >= 1 && length(var.guardrail_blocked_input_messaging) <= 500
+    error_message = "guardrail_blocked_input_messaging must be 1-500 characters (Bedrock guardrail limit)."
+  }
+}
+
+variable "guardrail_blocked_outputs_messaging" {
+  type        = string
+  description = "Message returned to the caller when the guardrail blocks the model's output."
+  default     = "Sorry, the response generated violates our usage policy and cannot be returned."
+  validation {
+    condition     = length(var.guardrail_blocked_outputs_messaging) >= 1 && length(var.guardrail_blocked_outputs_messaging) <= 500
+    error_message = "guardrail_blocked_outputs_messaging must be 1-500 characters (Bedrock guardrail limit)."
+  }
+}
+
+variable "guardrail_pii_action" {
+  type        = string
+  description = "Action taken when a PII entity from guardrail_pii_entities is detected. BLOCK refuses the request entirely; ANONYMIZE replaces the entity with its type label (e.g. {NAME}); NONE disables the PII policy."
+  default     = "ANONYMIZE"
+  validation {
+    condition     = contains(["BLOCK", "ANONYMIZE", "NONE"], var.guardrail_pii_action)
+    error_message = "guardrail_pii_action must be one of BLOCK, ANONYMIZE, NONE."
+  }
+}
+
+variable "guardrail_pii_entities" {
+  type        = list(string)
+  description = "PII entity types subject to guardrail_pii_action. See the Bedrock SensitiveInformationPolicyConfig documentation for the full list. Defaults cover the common, broadly-applicable categories. Ignored when guardrail_pii_action is NONE."
+  default = [
+    "ADDRESS",
+    "EMAIL",
+    "NAME",
+    "PHONE",
+    "US_SOCIAL_SECURITY_NUMBER",
+    "CREDIT_DEBIT_CARD_NUMBER",
+    "PASSWORD",
+  ]
+}
+
+variable "guardrail_denied_topics" {
+  type = list(object({
+    name       = string
+    definition = string
+    examples   = optional(list(string), [])
+  }))
+  description = "Topics the model must refuse to discuss. Each topic needs a short name and a one-sentence definition; examples improve detection but are optional. Empty by default — denied topics are application-specific and have no safe defaults."
+  default     = []
+}
+
+variable "guardrail_blocked_words" {
+  type        = list(string)
+  description = "Exact words/phrases blocked in both input and output. Empty by default — blocked words are application-specific."
+  default     = []
+}
+
+variable "guardrail_kms_key_arn" {
+  type        = string
+  description = "Optional customer-managed KMS key ARN for guardrail encryption. If null (default), the AWS-owned key is used."
+  default     = null
+  validation {
+    condition     = var.guardrail_kms_key_arn == null ? true : can(regex("^arn:aws[a-z-]*:kms:", var.guardrail_kms_key_arn))
+    error_message = "guardrail_kms_key_arn must be null or a KMS key ARN."
+  }
+}
+
 variable "tags" {
   description = "Additional AWS tags applied to all resources"
   type        = map(string)

--- a/aws/bedrock/variables.tf
+++ b/aws/bedrock/variables.tf
@@ -1,6 +1,10 @@
 variable "project" {
   type        = string
-  description = "Project name for resource naming"
+  description = "Project name for resource naming. Caps at 24 chars: tightest derived name is the AOSS data-access policy '${"$"}{project}-br-data' (AOSS limit 32). Other derived names — guardrail (limit 50), IAM logging role (limit 64), CloudWatch log group (limit 512) — fit any 24-char project comfortably."
+  validation {
+    condition     = length(trimspace(var.project)) > 0 && length(var.project) <= 24
+    error_message = "project must be a non-empty string ≤24 characters. The AOSS data-access policy name {project}-br-data caps at 32 chars (AOSS limit), so the project portion is ≤24."
+  }
 }
 
 variable "region" {
@@ -159,6 +163,29 @@ variable "guardrail_pii_entities" {
     "CREDIT_DEBIT_CARD_NUMBER",
     "PASSWORD",
   ]
+
+  # Bedrock's PII entity list is closed and stable; validating locally turns
+  # a generic apply-time error from AWS ("invalid PII entity type") into a
+  # plan-time error pointing at the offending value. Source list:
+  # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_GuardrailPiiEntityConfig.html
+  validation {
+    condition = alltrue([
+      for entity in var.guardrail_pii_entities : contains([
+        "ADDRESS", "AGE", "AWS_ACCESS_KEY", "AWS_SECRET_KEY",
+        "CA_HEALTH_NUMBER", "CA_SOCIAL_INSURANCE_NUMBER",
+        "CREDIT_DEBIT_CARD_CVV", "CREDIT_DEBIT_CARD_EXPIRY",
+        "CREDIT_DEBIT_CARD_NUMBER", "DRIVER_ID", "EMAIL",
+        "INTERNATIONAL_BANK_ACCOUNT_NUMBER", "IP_ADDRESS",
+        "LICENSE_PLATE", "MAC_ADDRESS", "NAME", "PASSWORD",
+        "PHONE", "PIN", "SWIFT_CODE", "UK_NATIONAL_HEALTH_SERVICE_NUMBER",
+        "UK_NATIONAL_INSURANCE_NUMBER", "UK_UNIQUE_TAXPAYER_REFERENCE_NUMBER",
+        "URL", "USERNAME", "US_BANK_ACCOUNT_NUMBER", "US_BANK_ROUTING_NUMBER",
+        "US_INDIVIDUAL_TAX_IDENTIFICATION_NUMBER", "US_PASSPORT_NUMBER",
+        "US_SOCIAL_SECURITY_NUMBER", "VEHICLE_IDENTIFICATION_NUMBER",
+      ], entity)
+    ])
+    error_message = "guardrail_pii_entities contains an unrecognised PII type. See https://docs.aws.amazon.com/bedrock/latest/APIReference/API_GuardrailPiiEntityConfig.html for the canonical list."
+  }
 }
 
 variable "guardrail_denied_topics" {

--- a/aws/opensearch/outputs.tf
+++ b/aws/opensearch/outputs.tf
@@ -10,5 +10,10 @@ output "opensearch_endpoint" {
 
 output "collection_arn" {
   value       = var.deployment_type == "serverless" ? aws_opensearchserverless_collection.serverless[0].arn : null
-  description = "ARN of the AOSS collection. null when deployment_type is managed. Wire this (not opensearch_arn) into aws/bedrock.opensearch_collection_arn. The application layer is responsible for creating data-access policies and vector indexes against this collection."
+  description = "ARN of the AOSS collection. null when deployment_type is managed. Wire this (not opensearch_arn) into aws/bedrock.opensearch_collection_arn. The application layer is responsible for creating the vector index against this collection."
+}
+
+output "collection_name" {
+  value       = var.deployment_type == "serverless" ? aws_opensearchserverless_collection.serverless[0].name : null
+  description = "Name of the AOSS collection (not the ID embedded in the ARN). null when deployment_type is managed. Wire into aws/bedrock.opensearch_collection_name so bedrock can author the AOSS data-access policy granting its role data-plane access — AOSS access policies match collections by name, not ARN."
 }


### PR DESCRIPTION
## Summary

Builds out the bedrock module beyond the lone IAM role so the management view has meaningful, observable surface area to render. Three new resource families, all opt-out-friendly, plus a real `terraform test` suite verified against a live test account.

### What's added

- **AOSS data-access policy** (`aws_opensearchserverless_access_policy`) gated by new optional `opensearch_collection_name`. Closes the IAM-vs-data-plane gap that silently 403s KB ingestion. Backward-compatible — when the composer doesn't wire the name, the policy is skipped and the existing module shape is preserved.
- **Bedrock invocation logging**: opt-in CloudWatch log group + IAM role + `aws_bedrock_model_invocation_logging_configuration`. Default off because the configuration is an account+region singleton; enabling on multiple stacks in the same account causes silent overwrites.
- **`aws_bedrock_guardrail`** with content / PII / topic / word policies. Defaults: `MEDIUM` on the universal content categories, `ANONYMIZE` on common PII (`EMAIL`, `PHONE`, `NAME`, `SSN`, …), `PROMPT_ATTACK` pinned to `HIGH` on input as cheap jailbreak insurance. Roughly 12 new vars expose the meaningful, reliable knobs.

New outputs: `aoss_data_access_policy_name`, `invocation_log_group_{name,arn}`, `invocation_logging_role_arn`, `guardrail_{id,arn,version}`.

`aws/opensearch/outputs.tf` now exports `collection_name` so the composer can wire it into bedrock.

### Tests

- `aws/bedrock/tests/unit.tftest.hcl` — 15 plan-only runs covering default shape, every feature toggle, and 7 validation-rule rejections. No creds required. **All passing.**
- `aws/bedrock/tests/integration.tftest.hcl` — applies a real AOSS collection via the sibling opensearch module as a `setup_*` run, then applies bedrock against it, asserts on outputs, and tears everything down. **Verified end-to-end against a customer test account** (~17 min total: AOSS create + bedrock apply + clean teardown, exit 0).

### CI tweak

`.github/workflows/terraform-validate.yml` now skips files matching `*integration*.tftest.hcl` in the test step (live cloud creds aren't available in CI). Convention-based — no special markers needed.

### Cleanup commit

The first commit on this branch adds `.env`, `imported/`, and `insideout-import` to `.gitignore` so a clean working tree stays clean.

## Test plan

- [x] `terraform validate` passes for `aws/bedrock` and `aws/opensearch`
- [x] `terraform fmt -check -recursive` passes
- [x] `terraform test -filter=tests/unit.tftest.hcl` — 15 runs pass
- [x] `terraform test -filter=tests/integration.tftest.hcl` against test account — 2 runs pass, clean teardown
- [ ] CI green