### PR TITLE
fix: add Project tag to ALB listeners and IAM instance profiles

### DIFF
--- a/.claude/skills/add-aws-module/SKILL.md
+++ b/.claude/skills/add-aws-module/SKILL.md
@@ -40,6 +40,7 @@ Key rules:
 - If the module wraps a community module, use `source = "terraform-aws-modules/<name>/aws"` with a version pin
 - If the module needs a provider alias (like WAF needing `aws.us_east_1`), add `configuration_aliases` and create a `.validate-skip` marker file
 - Enable encryption, block public access, enforce least-privilege IAM by default
+- **Tag every taggable resource** with `tags = merge(module.name.tags, var.tags)`. Listeners (`aws_lb_listener`), instance profiles (`aws_iam_instance_profile`), and any resource that accepts a `tags` attribute must include it — otherwise the downstream reliable3 inspector's exact-match `Project` tag filter skips them (see issue #81).
 
 ### 3. Create variables.tf
 
@@ -139,6 +140,7 @@ Integration tests should:
 - Forgetting `project` or `region` variables
 - Leaving variables without defaults unless intentionally required
 - Public access enabled by default
+- Creating a taggable resource (e.g. `aws_lb_listener`, `aws_iam_instance_profile`, `aws_iam_role`) without `tags = merge(module.name.tags, var.tags)` — inspector filters by exact `Project` tag and silently drops untagged resources
 
 ## Checklist
 
@@ -148,6 +150,7 @@ Integration tests should:
 - [ ] `outputs.tf` with wiring outputs
 - [ ] Null-safe validation (ternary pattern)
 - [ ] Security defaults (encryption, no public access)
+- [ ] Every taggable resource has `tags = merge(module.name.tags, var.tags)`
 - [ ] `terraform fmt` clean
 - [ ] `terraform validate` passes
 - [ ] `go build ./...` succeeds

--- a/.claude/skills/add-gcp-module/SKILL.md
+++ b/.claude/skills/add-gcp-module/SKILL.md
@@ -38,6 +38,7 @@ Key rules:
 - Otherwise use direct `google_*` resources
 - If the module needs the `random` provider, add it with `>= 3.5`
 - Enable encryption, enforce least-privilege IAM by default
+- **Label every labelable resource** with `labels = merge(..., var.labels)` (merging in module-scoped labels where available) so `Project` identity propagates to the inspector.
 
 ### 3. Create variables.tf
 
@@ -110,6 +111,7 @@ go build ./...
 - Using `var.x == null || condition` in validation
 - Forgetting `project` or `region` variables
 - Adding `.tmpl` files without updating `zz_embed.go`
+- Creating a labelable GCP resource without `labels = merge(..., var.labels)` — inspector drift detection relies on `Project` label propagation (AWS mirror: issue #81)
 
 ## Checklist
 
@@ -119,6 +121,7 @@ go build ./...
 - [ ] `outputs.tf` with wiring outputs
 - [ ] Null-safe validation (ternary pattern)
 - [ ] Security defaults (encryption, least-privilege IAM)
+- [ ] Every labelable resource has `labels = merge(..., var.labels)`
 - [ ] `terraform fmt` clean
 - [ ] `terraform validate` passes
 - [ ] `go build ./...` succeeds

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -69,7 +69,33 @@ grep -rn 'encrypted\s*=\s*false\|encryption\s*=\s*false' aws/ gcp/
 grep -rn '"*"\|"\*"' aws/ gcp/ --include="*.tf"
 ```
 
-### 5. Region Reference Audit (AWS)
+### 5. Tagging Coverage
+
+The downstream reliable3 inspector filters AWS resources by exact `Project = <project>` tag match. Resources without a `tags = merge(module.name.tags, var.tags)` block are invisible to drift detection and CloudWatch metrics. Scan for taggable resources that omit the convention:
+
+```bash
+# AWS — flag resource blocks missing `tags`
+for f in aws/*/main.tf; do
+  awk '
+    /^resource "aws_/ { name=$0; has_tags=0; next }
+    /^  tags[[:space:]]*=/ { has_tags=1 }
+    /^}/ { if (name != "" && !has_tags) print FILENAME": "name; name=""; has_tags=0 }
+  ' "$f"
+done
+
+# GCP — flag resource blocks missing `labels`
+for f in gcp/*/main.tf; do
+  awk '
+    /^resource "google_/ { name=$0; has_labels=0; next }
+    /^  labels[[:space:]]*=/ { has_labels=1 }
+    /^}/ { if (name != "" && !has_labels) print FILENAME": "name; name=""; has_labels=0 }
+  ' "$f"
+done
+```
+
+The heuristic over-reports — some resources are genuinely untaggable (e.g. `aws_iam_role_policy_attachment`, `aws_iam_role_policy`, `aws_route53_record`, `aws_s3_bucket_public_access_block`). Hand-verify each hit against the provider docs before reporting a gap.
+
+### 6. Region Reference Audit (AWS)
 
 Check for direct `var.region` usage in service name construction (should use `data.aws_region.current.region`):
 
@@ -77,7 +103,7 @@ Check for direct `var.region` usage in service name construction (should use `da
 grep -rn 'var\.region' aws/ --include="*.tf" | grep -v 'variables.tf'
 ```
 
-### 6. Cross-Module Wiring
+### 7. Cross-Module Wiring
 
 Verify outputs match what examples expect:
 
@@ -94,7 +120,7 @@ for dir in aws/*/; do
 done
 ```
 
-### 7. Go Embed Coverage
+### 8. Go Embed Coverage
 
 Verify all file patterns are embedded:
 
@@ -103,7 +129,7 @@ Verify all file patterns are embedded:
 find aws gcp -type f | grep -v '\.tf$' | grep -v '\.tmpl$' | grep -v '\.terraform' | grep -v '.validate-skip'
 ```
 
-### 8. Report
+### 9. Report
 
 Produce a structured report:
 
@@ -119,6 +145,9 @@ Produce a structured report:
 ### Validation Safety
 - <list>
 
+### Tagging Coverage
+- <list — resources missing `tags`/`labels` per the Project-tag convention>
+
 ### Wiring Issues
 - <list>
 
@@ -131,6 +160,7 @@ Produce a structured report:
 - [ ] Convention compliance checked (file structure, naming, required variables)
 - [ ] Null validation patterns scanned
 - [ ] Security defaults verified
+- [ ] Tagging coverage verified (AWS `tags`, GCP `labels` on every taggable resource)
 - [ ] Region references audited (AWS)
 - [ ] Cross-module wiring validated
 - [ ] Go embed coverage confirmed

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -71,29 +71,30 @@ grep -rn '"*"\|"\*"' aws/ gcp/ --include="*.tf"
 
 ### 5. Tagging Coverage
 
-The downstream reliable3 inspector filters AWS resources by exact `Project = <project>` tag match. Resources without a `tags = merge(module.name.tags, var.tags)` block are invisible to drift detection and CloudWatch metrics. Scan for taggable resources that omit the convention:
+The downstream reliable3 inspector filters AWS resources by exact `Project = <project>` tag match. Resources without a `tags = merge(module.name.tags, var.tags)` block are invisible to drift detection and CloudWatch metrics.
+
+**AWS is enforced in CI** via `tests/lint-project-tag.sh` (wired into the `lint` job in `.github/workflows/terraform-validate.yml`). Run it locally the same way:
 
 ```bash
-# AWS — flag resource blocks missing `tags`
-for f in aws/*/main.tf; do
-  awk '
-    /^resource "aws_/ { name=$0; has_tags=0; next }
-    /^  tags[[:space:]]*=/ { has_tags=1 }
-    /^}/ { if (name != "" && !has_tags) print FILENAME": "name; name=""; has_tags=0 }
-  ' "$f"
-done
+bash tests/lint-project-tag.sh
+```
 
-# GCP — flag resource blocks missing `labels`
+It reports any taggable AWS resource missing the Project-tag convention. The script ships with a `NON_TAGGABLE_AWS` whitelist of resource types that genuinely don't accept tags in AWS provider 6.x; if CI flags a new hit, either add the `tags` line (usual case) or append to the whitelist with a clear rationale.
+
+**GCP** isn't CI-enforced (too many "no labels arg" resources to maintain a clean whitelist). Audit by hand with:
+
+```bash
 for f in gcp/*/main.tf; do
   awk '
     /^resource "google_/ { name=$0; has_labels=0; next }
     /^  labels[[:space:]]*=/ { has_labels=1 }
+    /^  user_labels[[:space:]]*=/ { has_labels=1 }
     /^}/ { if (name != "" && !has_labels) print FILENAME": "name; name=""; has_labels=0 }
   ' "$f"
 done
 ```
 
-The heuristic over-reports — some resources are genuinely untaggable (e.g. `aws_iam_role_policy_attachment`, `aws_iam_role_policy`, `aws_route53_record`, `aws_s3_bucket_public_access_block`). Hand-verify each hit against the provider docs before reporting a gap.
+Hand-verify each hit against the provider docs before reporting a gap.
 
 ### 6. Region Reference Audit (AWS)
 

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Lint sensitive-in-for_each
         run: bash tests/lint-sensitive-for-each.sh
 
+      - name: Lint Project-tag coverage (AWS)
+        run: bash tests/lint-project-tag.sh
+
   format-check:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,8 @@ These preset files are embedded at build time into the [reliable](https://github
 - **Required variables:** Every preset should declare `project` and `region` variables — the composer always maps these
 - **Defaults matter:** Variables without defaults become required root variables — the mapper MUST provide values or deploy fails
 - **Wiring outputs:** Outputs used for cross-module wiring (e.g., `vpc_id`, `private_subnet_ids`) must be declared in `outputs.tf`
+- **Project tag is required on every taggable AWS resource.** Use `tags = merge(module.name.tags, var.tags)` so the `Project` tag emitted by `module.name.tags` reaches the resource. The downstream reliable3 inspector filters on exact `Project = <project>` match, so untagged resources are invisible to drift detection and CloudWatch metrics (see issue #81, [reliable PR #1027](https://github.com/luthersystems/reliable/pull/1027)). If a resource accepts any tag-shaped attribute (including listeners, instance profiles, and IAM roles/policies in provider 5.x+), tag it.
+- **GCP mirror:** every labelable GCP resource must set `labels = merge(<module-labels>, var.labels)` (or equivalent) so project identity propagates.
 
 ## Skills
 

--- a/aws/alb/main.tf
+++ b/aws/alb/main.tf
@@ -102,6 +102,8 @@ resource "aws_lb_listener" "http_forward" {
     type             = "forward"
     target_group_arn = aws_lb_target_group.app.arn
   }
+
+  tags = merge(module.name.tags, var.tags)
 }
 
 # HTTP listener → redirect to HTTPS (when cert provided)
@@ -120,6 +122,8 @@ resource "aws_lb_listener" "http_redirect" {
       status_code = "HTTP_301"
     }
   }
+
+  tags = merge(module.name.tags, var.tags)
 }
 
 # HTTPS listener (when cert provided)
@@ -135,4 +139,6 @@ resource "aws_lb_listener" "https" {
     type             = "forward"
     target_group_arn = aws_lb_target_group.app.arn
   }
+
+  tags = merge(module.name.tags, var.tags)
 }

--- a/aws/bastion/main.tf
+++ b/aws/bastion/main.tf
@@ -80,6 +80,7 @@ resource "aws_iam_role_policy_attachment" "ssm_core" {
 resource "aws_iam_instance_profile" "bastion_profile" {
   name = "${var.project}-bastion-profile"
   role = aws_iam_role.bastion_role.name
+  tags = merge(module.name.tags, var.tags)
 }
 
 # locals for template vars

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -135,6 +135,7 @@ resource "aws_iam_role_policy_attachment" "ssm_core" {
 resource "aws_iam_instance_profile" "this" {
   name = "${var.project}-ec2-profile"
   role = aws_iam_role.this.name
+  tags = merge(module.name.tags, var.tags)
 }
 
 # -------------------------------------------------------------

--- a/tests/lint-project-tag.sh
+++ b/tests/lint-project-tag.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Static analysis: every taggable AWS resource must carry
+#   tags = merge(module.name.tags, var.tags)
+# (or an equivalent merge containing module.name.tags) so the Project tag
+# emitted by module.name.tags reaches the resource. The downstream reliable3
+# inspector filters AWS resources by exact Project = <project> match —
+# untagged resources are invisible to drift detection and CloudWatch metrics.
+# See issue #81 and https://github.com/luthersystems/reliable/pull/1027.
+#
+# When this check fails, the fix is almost always:
+#   tags = merge(module.name.tags, var.tags)
+# Only add a resource type to NON_TAGGABLE_AWS below if the AWS provider
+# genuinely doesn't accept a tags block on it (confirmed against the
+# hashicorp/aws provider 6.x docs).
+#
+# Scope: AWS only. GCP labels have too many "not supported" resources to
+# enforce cleanly; the /audit skill's Tagging Coverage step covers GCP by
+# review.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Resource types that do NOT accept a tags attribute in AWS provider 6.x.
+# Keep sorted alphabetically.
+NON_TAGGABLE_AWS=(
+  aws_apigatewayv2_api_mapping
+  aws_backup_selection
+  aws_bedrock_model_invocation_logging_configuration
+  aws_cloudfront_origin_access_identity
+  aws_cloudwatch_dashboard
+  aws_cloudwatch_log_stream
+  aws_cognito_identity_provider
+  aws_cognito_user_pool_client
+  aws_cognito_user_pool_domain
+  aws_ecs_cluster_capacity_providers
+  aws_iam_role_policy
+  aws_iam_role_policy_attachment
+  aws_iam_service_linked_role
+  aws_kms_alias
+  aws_msk_configuration
+  aws_opensearchserverless_access_policy
+  aws_opensearchserverless_security_policy
+  aws_s3_bucket_lifecycle_configuration
+  aws_s3_bucket_ownership_controls
+  aws_s3_bucket_policy
+  aws_s3_bucket_public_access_block
+  aws_s3_bucket_server_side_encryption_configuration
+  aws_s3_bucket_versioning
+  aws_security_group_rule
+  aws_sns_topic_subscription
+  aws_wafv2_web_acl_association
+)
+
+skip_pattern="^($(IFS='|'; echo "${NON_TAGGABLE_AWS[*]}"))$"
+
+echo "=== Checking AWS resources for Project tag (tags = merge(module.name.tags, var.tags)) ==="
+echo
+
+any_fail=0
+for f in "$REPO_ROOT"/aws/*/main.tf; do
+  [ -f "$f" ] || continue
+  awk -v skip_pattern="$skip_pattern" '
+    BEGIN { in_res=0; failed=0 }
+    /^resource "aws_/ {
+      in_res=1
+      res=$2; gsub(/"/, "", res)
+      start=NR
+      has_tags=0
+      has_tag_block=0
+      skip_this=(res ~ skip_pattern)
+      next
+    }
+    in_res && /^  tags[[:space:]]*=/ { has_tags=1 }
+    in_res && /^  tag[[:space:]]*\{/ { has_tag_block=1 }
+    in_res && /^}/ {
+      if (!has_tags && !has_tag_block && !skip_this) {
+        printf "ERROR: %s:%d: resource %s missing tags = merge(module.name.tags, var.tags)\n", FILENAME, start, res
+        failed=1
+      }
+      in_res=0
+    }
+    END { exit (failed ? 1 : 0) }
+  ' "$f" || any_fail=1
+done
+
+if (( any_fail )); then
+  echo
+  echo "FAIL: One or more taggable AWS resources are missing the Project-tag convention."
+  echo "Fix: add  tags = merge(module.name.tags, var.tags)  to each resource."
+  echo "If the resource genuinely doesn't accept tags in AWS provider 6.x,"
+  echo "add it to NON_TAGGABLE_AWS in tests/lint-project-tag.sh (alphabetically)."
+  exit 1
+fi
+
+echo "PASS: All taggable AWS resources carry the Project-tag convention."


### PR DESCRIPTION
## Summary

- **Fix (5 resources):** adds `tags = merge(module.name.tags, var.tags)` to five taggable AWS resources that were missing it: `aws_lb_listener.{http_forward,http_redirect,https}` in `aws/alb`, `aws_iam_instance_profile.bastion_profile` in `aws/bastion`, and `aws_iam_instance_profile.this` in `aws/ec2`.
- **CI enforcement:** adds `tests/lint-project-tag.sh` (patterned after the existing `lint-sensitive-for-each.sh`) and wires it into the existing `lint` job. The script fails CI if any taggable AWS resource is missing the Project-tag convention, and ships with a `NON_TAGGABLE_AWS` whitelist of 26 resource types that genuinely don't accept tags in AWS provider 6.x.
- **Documentation guardrails:** CLAUDE.md Project-tag invariant, plus key-rule + anti-pattern + checklist entries in `/add-aws-module`, `/add-gcp-module`, and `/audit` skills. `/audit` now references the lint script as the canonical enforcement.

Without the `Project` tag, the downstream reliable3 inspector ([PR #1027](https://github.com/luthersystems/reliable/pull/1027)) cannot see these resources — its drift detection and CloudWatch metrics queries both filter by exact `Project = <project>` match.

**Scope note:** CI enforcement is AWS-only. GCP has too many `google_*` resources with no `labels` argument to maintain a clean whitelist, so GCP remains a manual audit step (heuristic documented in `/audit`).

Fixes #81

## Test plan

- [x] `terraform fmt -check -recursive` clean on changed modules
- [x] `terraform validate` passes for `aws/alb`, `aws/bastion`, `aws/ec2`
- [x] `terraform validate` passes for representative downstream examples (`examples/guestbook`, `examples/revisionapp`)
- [x] `bash tests/lint-project-tag.sh` passes locally on the fixed tree
- [x] Verified the lint script catches failures via synthetic fixture (untagged `aws_lb` flagged; whitelisted `aws_iam_role_policy_attachment` ignored; tagged `aws_lb_target_group` accepted)
- [x] CI green — all 76 checks, including new `lint` step