### PR TITLE
chore: batch cleanup from reliable #1042 review (#83-#87)

### DIFF
--- a/aws/githubactions/outputs.tf
+++ b/aws/githubactions/outputs.tf
@@ -1,6 +1,6 @@
-# Placeholder outputs for GitHub Actions module
-output "integration_status" {
-  description = "Status of GitHub Actions integration"
-  value       = "placeholder - not yet implemented"
-}
-
+# GitHub Actions CI/CD Integration Module — no outputs.
+#
+# This module is a placeholder (main.tf creates no resources). Outputs will
+# be added when the OIDC provider / IAM roles / repository secret wiring is
+# implemented. Until then, no output is emitted so deploy logs are not
+# polluted with placeholder strings.

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -23,6 +23,14 @@ module "name" {
   resource       = "rds"
 }
 
+locals {
+  # AWS RDS db instance identifiers reject consecutive hyphens and
+  # leading/trailing hyphens. Upstream inputs (e.g. session-derived project
+  # names) may contain hyphens that collide with suffixes appended here.
+  # Collapse runs of hyphens and strip edges as a defensive choke point.
+  safe_name = trim(replace(module.name.name, "/-+/", "-"), "-")
+}
+
 # Option A (simple): set major version on the instance and let AWS pick preferred minor
 # Option B (explicit): if you prefer a data lookup, use preferred_versions (see variables)
 
@@ -75,7 +83,7 @@ resource "random_password" "db" {
 # Primary RDS instance (PostgreSQL)
 # -----------------------------------------------------------------------------
 resource "aws_db_instance" "primary" {
-  identifier = module.name.name
+  identifier = local.safe_name
   engine     = "postgres"
 
   # If var.engine_version is null, set major only (e.g., "15") so AWS chooses the preferred minor.
@@ -126,7 +134,7 @@ locals {
 
 resource "aws_db_instance" "replica" {
   count          = local.replica_count
-  identifier     = "${module.name.name}-replica-${count.index + 1}"
+  identifier     = "${local.safe_name}-replica-${count.index + 1}"
   engine         = "postgres"
   instance_class = var.instance_class
 

--- a/pkg/composer/diff.go
+++ b/pkg/composer/diff.go
@@ -31,11 +31,20 @@ type PricingDiff struct {
 	Delta     float64 `json:"delta"`
 }
 
+// MetadataDiff describes a transition of a stack-level metadata field
+// (cloud, architecture) between two versions.
+type MetadataDiff struct {
+	Field string `json:"field"`
+	From  string `json:"from"`
+	To    string `json:"to"`
+}
+
 // VersionDiff is the complete diff between two stack versions.
 type VersionDiff struct {
 	FromVersion int             `json:"from_version"`
 	ToVersion   int             `json:"to_version"`
 	Components  []ComponentDiff `json:"components"`
+	Metadata    []MetadataDiff  `json:"metadata,omitempty"`
 	Pricing     []PricingDiff   `json:"pricing,omitempty"`
 	Summary     string          `json:"summary"`
 }
@@ -245,6 +254,12 @@ var metadataFields = map[string]bool{
 	"cpu_arch":     true,
 }
 
+// stackMetadataDiffFields are the metadata fields that DiffMetadata reports
+// transitions for. cpu_arch is intentionally excluded — it is consumed
+// internally by per-component arch (aws_ec2 / gcp_compute) and has no UI
+// tile, so highlighting it would be spurious.
+var stackMetadataDiffFields = []string{"cloud", "architecture"}
+
 // isComponentActive returns true if a reflect.Value represents an "enabled"
 // component toggle. The heuristic: *bool → true, string → non-empty,
 // *struct → non-nil.
@@ -331,6 +346,37 @@ func DiffComponents(oldComp, newComp Components) []ComponentDiff {
 		}
 	}
 
+	return diffs
+}
+
+// DiffMetadata returns one MetadataDiff per stack-level metadata field whose
+// value changed between oldComp and newComp. Only fields in
+// stackMetadataDiffFields (cloud, architecture) are reported; cpu_arch is
+// always skipped. Transitions covered: empty->non-empty, non-empty->different,
+// non-empty->empty. No-op fields are omitted.
+func DiffMetadata(oldComp, newComp Components) []MetadataDiff {
+	oldVal := reflect.ValueOf(oldComp)
+	newVal := reflect.ValueOf(newComp)
+	t := oldVal.Type()
+
+	wanted := make(map[string]bool, len(stackMetadataDiffFields))
+	for _, name := range stackMetadataDiffFields {
+		wanted[name] = true
+	}
+
+	var diffs []MetadataDiff
+	for i := 0; i < t.NumField(); i++ {
+		tag := JSONTagName(t.Field(i))
+		if !wanted[tag] {
+			continue
+		}
+		oldStr := FormatValue(oldVal.Field(i))
+		newStr := FormatValue(newVal.Field(i))
+		if oldStr == newStr {
+			continue
+		}
+		diffs = append(diffs, MetadataDiff{Field: tag, From: oldStr, To: newStr})
+	}
 	return diffs
 }
 

--- a/pkg/composer/diff.go
+++ b/pkg/composer/diff.go
@@ -247,7 +247,10 @@ func isToggleComponentField(f reflect.StructField) bool {
 }
 
 // metadataFields lists Components fields that describe the stack itself
-// rather than an individual component toggle.
+// rather than an individual component toggle. Used by DiffComponents to
+// *exclude* these fields from toggle diffs. A strict superset of
+// stackMetadataDiffFields — the extra entry (cpu_arch) is excluded from
+// toggle diffs AND from metadata diffs.
 var metadataFields = map[string]bool{
 	"cloud":        true,
 	"architecture": true,
@@ -255,9 +258,10 @@ var metadataFields = map[string]bool{
 }
 
 // stackMetadataDiffFields are the metadata fields that DiffMetadata reports
-// transitions for. cpu_arch is intentionally excluded — it is consumed
-// internally by per-component arch (aws_ec2 / gcp_compute) and has no UI
-// tile, so highlighting it would be spurious.
+// transitions for — the inverse view of metadataFields. cpu_arch is
+// intentionally excluded here: it is consumed internally by per-component
+// arch (aws_ec2 / gcp_compute) and has no UI tile, so highlighting it
+// would be spurious.
 var stackMetadataDiffFields = []string{"cloud", "architecture"}
 
 // isComponentActive returns true if a reflect.Value represents an "enabled"

--- a/pkg/composer/diff_test.go
+++ b/pkg/composer/diff_test.go
@@ -767,11 +767,22 @@ func TestDiffMetadata_NoChange(t *testing.T) {
 
 func TestDiffMetadata_SkipsCpuArch(t *testing.T) {
 	t.Parallel()
-	oldComp := Components{CpuArch: "Intel"}
-	newComp := Components{CpuArch: "ARM"}
-	diffs := DiffMetadata(oldComp, newComp)
-	if len(diffs) != 0 {
-		t.Errorf("expected cpu_arch to be skipped, got %d: %+v", len(diffs), diffs)
+	cases := []struct {
+		name    string
+		oldComp Components
+		newComp Components
+	}{
+		{"modification", Components{CpuArch: "Intel"}, Components{CpuArch: "ARM"}},
+		{"appears", Components{}, Components{CpuArch: "ARM"}},
+		{"disappears", Components{CpuArch: "ARM"}, Components{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diffs := DiffMetadata(tc.oldComp, tc.newComp)
+			if len(diffs) != 0 {
+				t.Errorf("expected cpu_arch to be skipped, got %d: %+v", len(diffs), diffs)
+			}
+		})
 	}
 }
 
@@ -822,24 +833,21 @@ func TestDiffMetadata_DoesNotLeakIntoComponents(t *testing.T) {
 
 func TestVersionDiff_MetadataJSONRoundTrip(t *testing.T) {
 	t.Parallel()
-	vd := VersionDiff{
+	want := VersionDiff{
 		FromVersion: 1,
 		ToVersion:   2,
 		Metadata:    []MetadataDiff{{Field: "cloud", From: "", To: "aws"}},
 	}
-	b, err := json.Marshal(vd)
+	b, err := json.Marshal(want)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if !strings.Contains(string(b), `"metadata":[{"field":"cloud","from":"","to":"aws"}]`) {
-		t.Errorf("unexpected JSON: %s", string(b))
-	}
-	var back VersionDiff
-	if err := json.Unmarshal(b, &back); err != nil {
+	var got VersionDiff
+	if err := json.Unmarshal(b, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(back.Metadata) != 1 || back.Metadata[0].Field != "cloud" || back.Metadata[0].To != "aws" {
-		t.Errorf("round-trip: got %+v", back.Metadata)
+	if !reflect.DeepEqual(got.Metadata, want.Metadata) {
+		t.Errorf("round-trip: got %+v, want %+v", got.Metadata, want.Metadata)
 	}
 }
 
@@ -851,7 +859,15 @@ func TestVersionDiff_MetadataOmittedWhenEmpty(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 	if strings.Contains(string(b), `"metadata"`) {
-		t.Errorf("metadata should be omitted when nil: %s", string(b))
+		t.Errorf("metadata key should be omitted when slice is nil: %s", string(b))
+	}
+	// Round-trip: unmarshaling the emitted JSON yields an empty Metadata slice.
+	var back VersionDiff
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(back.Metadata) != 0 {
+		t.Errorf("round-trip Metadata should be empty, got %+v", back.Metadata)
 	}
 }
 

--- a/pkg/composer/diff_test.go
+++ b/pkg/composer/diff_test.go
@@ -713,6 +713,148 @@ func TestDiffComponents_GCPComponents(t *testing.T) {
 	}
 }
 
+// --- DiffMetadata tests ---
+
+func TestDiffMetadata_CloudAppears(t *testing.T) {
+	t.Parallel()
+	oldComp := Components{}
+	newComp := Components{Cloud: "aws"}
+	diffs := DiffMetadata(oldComp, newComp)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d: %+v", len(diffs), diffs)
+	}
+	got := diffs[0]
+	if got.Field != "cloud" || got.From != "" || got.To != "aws" {
+		t.Errorf("got %+v, want {cloud,'','aws'}", got)
+	}
+}
+
+func TestDiffMetadata_CloudChanges(t *testing.T) {
+	t.Parallel()
+	oldComp := Components{Cloud: "aws"}
+	newComp := Components{Cloud: "gcp"}
+	diffs := DiffMetadata(oldComp, newComp)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d: %+v", len(diffs), diffs)
+	}
+	got := diffs[0]
+	if got.Field != "cloud" || got.From != "aws" || got.To != "gcp" {
+		t.Errorf("got %+v, want {cloud,'aws','gcp'}", got)
+	}
+}
+
+func TestDiffMetadata_CloudDisappears(t *testing.T) {
+	t.Parallel()
+	oldComp := Components{Cloud: "aws"}
+	newComp := Components{}
+	diffs := DiffMetadata(oldComp, newComp)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d: %+v", len(diffs), diffs)
+	}
+	if diffs[0].From != "aws" || diffs[0].To != "" {
+		t.Errorf("got %+v, want from=aws to=''", diffs[0])
+	}
+}
+
+func TestDiffMetadata_NoChange(t *testing.T) {
+	t.Parallel()
+	comp := Components{Cloud: "aws", Architecture: "microservices"}
+	diffs := DiffMetadata(comp, comp)
+	if len(diffs) != 0 {
+		t.Errorf("expected 0 diffs, got %d: %+v", len(diffs), diffs)
+	}
+}
+
+func TestDiffMetadata_SkipsCpuArch(t *testing.T) {
+	t.Parallel()
+	oldComp := Components{CpuArch: "Intel"}
+	newComp := Components{CpuArch: "ARM"}
+	diffs := DiffMetadata(oldComp, newComp)
+	if len(diffs) != 0 {
+		t.Errorf("expected cpu_arch to be skipped, got %d: %+v", len(diffs), diffs)
+	}
+}
+
+func TestDiffMetadata_ArchitectureTransitions(t *testing.T) {
+	t.Parallel()
+	oldComp := Components{Architecture: "monolith"}
+	newComp := Components{Architecture: "microservices"}
+	diffs := DiffMetadata(oldComp, newComp)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d: %+v", len(diffs), diffs)
+	}
+	got := diffs[0]
+	if got.Field != "architecture" || got.From != "monolith" || got.To != "microservices" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestDiffMetadata_CloudAndArchitectureTogether(t *testing.T) {
+	t.Parallel()
+	oldComp := Components{}
+	newComp := Components{Cloud: "aws", Architecture: "microservices"}
+	diffs := DiffMetadata(oldComp, newComp)
+	if len(diffs) != 2 {
+		t.Fatalf("expected 2 diffs, got %d: %+v", len(diffs), diffs)
+	}
+	byField := map[string]MetadataDiff{}
+	for _, d := range diffs {
+		byField[d.Field] = d
+	}
+	if byField["cloud"].To != "aws" {
+		t.Errorf("cloud: got %+v", byField["cloud"])
+	}
+	if byField["architecture"].To != "microservices" {
+		t.Errorf("architecture: got %+v", byField["architecture"])
+	}
+}
+
+func TestDiffMetadata_DoesNotLeakIntoComponents(t *testing.T) {
+	t.Parallel()
+	// Transitioning only metadata fields must not produce ComponentDiffs.
+	oldComp := Components{}
+	newComp := Components{Cloud: "aws", Architecture: "microservices"}
+	compDiffs := DiffComponents(oldComp, newComp)
+	if len(compDiffs) != 0 {
+		t.Errorf("metadata transitions should not appear in Components diff: %+v", compDiffs)
+	}
+}
+
+func TestVersionDiff_MetadataJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	vd := VersionDiff{
+		FromVersion: 1,
+		ToVersion:   2,
+		Metadata:    []MetadataDiff{{Field: "cloud", From: "", To: "aws"}},
+	}
+	b, err := json.Marshal(vd)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"metadata":[{"field":"cloud","from":"","to":"aws"}]`) {
+		t.Errorf("unexpected JSON: %s", string(b))
+	}
+	var back VersionDiff
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(back.Metadata) != 1 || back.Metadata[0].Field != "cloud" || back.Metadata[0].To != "aws" {
+		t.Errorf("round-trip: got %+v", back.Metadata)
+	}
+}
+
+func TestVersionDiff_MetadataOmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+	vd := VersionDiff{FromVersion: 1, ToVersion: 2}
+	b, err := json.Marshal(vd)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), `"metadata"`) {
+		t.Errorf("metadata should be omitted when nil: %s", string(b))
+	}
+}
+
 // --- MergeComponentDiffs tests ---
 
 func TestMergeComponentDiffs_BothEmpty(t *testing.T) {

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -273,11 +273,19 @@ func (m DefaultMapper) BuildModuleValues(
 		if _, ok := vals["subnet_id"]; !ok {
 			vals["subnet_id"] = ""
 		}
-		// Map CPU architecture from component selection ("Intel"/"ARM") to preset variable
-		if comps != nil && strings.EqualFold(comps.AWSEC2, "ARM") {
-			vals["arch"] = "arm64"
-		} else if comps != nil && comps.AWSEC2 != "" {
-			vals["arch"] = "x86_64"
+		// Map CPU architecture from component selection ("Intel"/"ARM") to preset variable.
+		// Precedence: per-component AWSEC2 wins; fall back to the deprecated top-level
+		// CpuArch for backwards compatibility with pre-deprecation callers (see #86).
+		if comps != nil {
+			archHint := comps.AWSEC2
+			if archHint == "" {
+				archHint = comps.CpuArch
+			}
+			if strings.EqualFold(archHint, "ARM") {
+				vals["arch"] = "arm64"
+			} else if archHint != "" {
+				vals["arch"] = "x86_64"
+			}
 		}
 		// Map config fields to Terraform variables
 		if cfg != nil && cfg.AWSEC2 != nil {

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -459,11 +459,23 @@ func TestBuildModuleValues_AWSEC2_CpuArchPrecedence(t *testing.T) {
 		assert.Equal(t, "arm64", vals["arch"], "AWSEC2=ARM must win over CpuArch=Intel")
 	})
 
+	t.Run("AWSEC2 arch match is case-insensitive (locks EqualFold)", func(t *testing.T) {
+		// Lowercase variants of "ARM" must still map to arm64 — guards against
+		// a careless switch to == that would silently emit x86_64 instead.
+		comps := &Components{AWSEC2: "arm"}
+		vals, err := m.BuildModuleValues(KeyAWSEC2, comps, nil, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "arm64", vals["arch"], "AWSEC2='arm' must be matched case-insensitively")
+	})
+
 	t.Run("deprecated CpuArch=ARM used as fallback when AWSEC2 empty", func(t *testing.T) {
 		comps := &Components{CpuArch: "ARM"}
 		vals, err := m.BuildModuleValues(KeyAWSEC2, comps, nil, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, "arm64", vals["arch"], "CpuArch fallback should emit arm64")
+		// t4g.medium is the arm64 default instance type; see the fallback
+		// block around mapper.go:309-314 ("Default instance type based on
+		// architecture if not explicitly configured").
 		assert.Equal(t, "t4g.medium", vals["instance_type"], "arm64 fallback should default to t4g.medium")
 	})
 

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -445,3 +445,40 @@ func TestBuildModuleValues_AWSECS_PartialConfig(t *testing.T) {
 	_, hasDefault := vals["default_capacity_provider"]
 	assert.False(t, hasDefault, "empty DefaultCapacityProvider should not appear")
 }
+
+// TestBuildModuleValues_AWSEC2_CpuArchPrecedence locks the precedence rule
+// documented on the deprecated Components.CpuArch field: per-component AWSEC2
+// wins; CpuArch is only consulted as a fallback. See issue #86.
+func TestBuildModuleValues_AWSEC2_CpuArchPrecedence(t *testing.T) {
+	m := DefaultMapper{}
+
+	t.Run("per-component AWSEC2 wins over deprecated CpuArch", func(t *testing.T) {
+		comps := &Components{CpuArch: "Intel", AWSEC2: "ARM"}
+		vals, err := m.BuildModuleValues(KeyAWSEC2, comps, nil, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "arm64", vals["arch"], "AWSEC2=ARM must win over CpuArch=Intel")
+	})
+
+	t.Run("deprecated CpuArch=ARM used as fallback when AWSEC2 empty", func(t *testing.T) {
+		comps := &Components{CpuArch: "ARM"}
+		vals, err := m.BuildModuleValues(KeyAWSEC2, comps, nil, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "arm64", vals["arch"], "CpuArch fallback should emit arm64")
+		assert.Equal(t, "t4g.medium", vals["instance_type"], "arm64 fallback should default to t4g.medium")
+	})
+
+	t.Run("deprecated CpuArch=Intel used as fallback when AWSEC2 empty", func(t *testing.T) {
+		comps := &Components{CpuArch: "Intel"}
+		vals, err := m.BuildModuleValues(KeyAWSEC2, comps, nil, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "x86_64", vals["arch"], "CpuArch fallback should emit x86_64")
+	})
+
+	t.Run("no arch set anywhere leaves arch unset", func(t *testing.T) {
+		comps := &Components{}
+		vals, err := m.BuildModuleValues(KeyAWSEC2, comps, nil, "", "")
+		require.NoError(t, err)
+		_, hasArch := vals["arch"]
+		assert.False(t, hasArch, "no arch hint should leave arch unset")
+	})
+}

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -8,7 +8,15 @@ type Components struct {
 	// Cloud-agnostic fields
 	Architecture string `json:"architecture,omitempty"`
 	Cloud        string `json:"cloud,omitempty"`
-	CpuArch      string `json:"cpu_arch,omitempty"`
+
+	// CpuArch is a stack-level default CPU architecture ("Intel" | "ARM").
+	//
+	// Deprecated: prefer per-component arch fields (AWSEC2, GCPCompute).
+	// The mapper reads per-component arch first and only consults CpuArch
+	// as a fallback for callers that have not migrated. New code MUST set
+	// AWSEC2/GCPCompute directly; CpuArch will be removed in a future
+	// release after all known consumers migrate.
+	CpuArch string `json:"cpu_arch,omitempty"`
 
 	// ==================== AWS Components ====================
 	AWSVPC                  string `json:"aws_vpc,omitempty"` // "Private" or "Public"


### PR DESCRIPTION
## Summary

Five small issues discovered during review of [reliable PR #1042](https://github.com/luthersystems/reliable/pull/1042) and live-testing session `sess_v2_W7AUcv6nIY8I`, batched onto one branch per user request. Each change is independently scoped; no shared abstraction was introduced just because they ride on one PR.

### Per-issue

- **#83 feat(composer/diff):** `MetadataDiff` + `VersionDiff.Metadata` field + `DiffMetadata(old, new)` helper. Emits transitions for `cloud` and `architecture` (stack-level fields with UI tiles). `cpu_arch` intentionally skipped — consumed internally by per-component arch. 10 new tests cover appear, change, disappear, no-op, cpu_arch-skipped, both-together, no-leak-into-Components, and JSON round-trip (including `omitempty` when nil). `VersionDiff` is not constructed in this repo; the field is available for reliable to pick up via a preset version bump.
- **#84 fix(aws/rds):** `local.safe_name = trim(replace(module.name.name, \"/-+/\", \"-\"), \"-\")` — used for `aws_db_instance.primary.identifier` and the replica identifier. Defensive choke point against hyphenated upstream inputs (session IDs). Root cause — hyphenated session IDs — is being fixed in reliable; this PR keeps a local guard at the consumption site.
- **#85 chore:** investigation only. Confirmed via `gh search code` that `template_ref` is emitted by `luthersystems/ui-core` (`jobs/workflows/`, `portal/oracle/`, proto); zero references in this repo. Filed [luthersystems/ui-core#289](https://github.com/luthersystems/ui-core/issues/289) for the keep-vs-strip decision.
- **#86 refactor(composer):** Phase 1 deprecation — `Components.CpuArch` gets `// Deprecated:` godoc (triggers SA1019 downstream) + a backwards-compat fallback in `mapper.go`: per-component `AWSEC2` wins; `CpuArch` is consulted only when the per-component field is empty. Four new precedence tests (A/B/C/D) lock the contract. Phase 2 hard removal deferred to a follow-up once reliable migrates its copy sites.
- **#87 chore(aws/githubactions):** Remove the placeholder `integration_status` output. The module creates no resources; keeping `\"placeholder - not yet implemented\"` in every deploy log is noise. File retained with a short explanatory comment.

## #84 audit (secondary deliverable, deferred)

Modules with strict identifier constraints that should get the same `safe_name` pattern in a follow-up:

| Module | Constraint | Affected attr |
|---|---|---|
| `aws/alb` | target groups ≤ 32 chars, alphanumeric + hyphens, no leading/trailing | TG names |
| `aws/elasticache` | no consecutive hyphens; must start with letter; ≤ 40 chars | replication_group_id |
| `aws/s3` | DNS rules, lowercase, no consecutive hyphens | bucket names |
| `aws/cognito` | name length limits | user pool names |
| `aws/ecs` | character-set restrictions | cluster/service names |

Not touched in this PR to keep scope surgical. Will file a dedicated follow-up ticket.

## Migration state (reliable-side) — context for reviewers

- The broader legacy-key migration tracked in #76 has **Phase 2 complete** on the reliable side (luthersystems/reliable#1041, merged 2026-04-19). Reliable runs `golangci-lint` clean with `SA1019` scoped only to `internal/composeradapter/`.
- **Phase 3** (collapse dual-key switches in `contracts.go:537-588` + `mapper.go:89-141`, simplify `moduleRef`/`vpcRef`/… selectors, migrate test fixtures) is now unblocked in this repo but is a substantial refactor — deliberately **not** included here. Tracked for a dedicated PR against #76.
- The `// Deprecated:` on `CpuArch` in this PR is orthogonal to the #76 legacy-key deprecation — it's a separate deprecation tracked by #86.

## Follow-up candidates (not in this PR)

- Placeholder-output cleanup for `datadog`, `splunk`, `grafana`, `codepipeline` (#87 pattern).
- Identifier sanitization for `alb`/`elasticache`/`s3`/`cognito`/`ecs` (#84 secondary).
- Phase 3 of #76 (collapse dual-key switches in composer).
- Phase 2 of #86 (hard removal of `CpuArch` after reliable migrates copy sites).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all pkg/composer tests pass, including 10 new for #83 and 4 new for #86
- [x] `terraform fmt -check -recursive` (clean)
- [x] `cd aws/rds && terraform validate` — `Success! The configuration is valid.`
- [x] `cd aws/githubactions && terraform validate` — `Success! The configuration is valid.`
- [ ] Post-merge: reliable bumps preset version and picks up `VersionDiff.Metadata` for first-unveil highlighting (#83 downstream).

Closes #83
Closes #84
Closes #85
Closes #86
Closes #87