### PR TITLE
feat(composer): export preset defaults from embedded HCL (#89)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ insideout-import
 
 # Claude Code local settings (keep shared .claude/settings.json)
 .claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/pkg/composer/defaults.go
+++ b/pkg/composer/defaults.go
@@ -1,7 +1,9 @@
 package composer
 
 import (
+	"fmt"
 	"math/big"
+	"reflect"
 	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
@@ -97,6 +99,262 @@ func (c *Client) PresetDefaults() (map[string]map[string]any, error) {
 		}
 	}
 	return out, nil
+}
+
+// ApplyPresetDefaults backfills cfg with statically-resolvable HCL defaults
+// for every key in `selected` that has a preset module under the cloud
+// indicated by comps.Cloud (defaulting to "aws"). It is the typed-Config
+// counterpart to PresetDefaults: where PresetDefaults returns a raw
+// "preset path → variable → value" map, this function lifts those values into
+// the matching nested *struct fields of Config, performing snake_case ↔
+// camelCase JSON-tag matching and per-field type coercion.
+//
+// Backfill semantics — a Config field is filled ONLY when its current value
+// is the zero value for its type (per reflect.Value.IsZero):
+//   - "" for strings, 0 for numerics, false for bools.
+//   - nil for pointers / slices / maps / interfaces.
+//
+// This means a non-nil empty slice (e.g. []int{} the user set explicitly) is
+// preserved, and a *bool set to &false is preserved. The intent is "fill in
+// the blanks the user hasn't filled yet," matching reliable's apply-start
+// flow for materialising defaults into session state.
+//
+// A nested struct field is allocated on demand: if cfg.AWSEC2 is nil and at
+// least one HCL default is statically resolvable for aws/ec2, AWSEC2 is
+// allocated and populated. If no defaults resolve (or the preset has no
+// `default = ...` clauses at all), the nested field stays nil.
+//
+// Type coercion table (HCL value → Go field type):
+//   - HCL string  → string field          : direct
+//   - HCL number  → string field          : fmt.Sprint(v)  ("2", not 2)
+//   - HCL number  → int / int64 / float64 : numeric cast
+//   - HCL bool    → bool field            : direct
+//   - HCL bool    → *bool field           : pointer to value
+//   - HCL string  → *string field         : pointer to value
+//   - HCL list    → []string / []int      : element-wise coerce
+//   - HCL null    → any                   : skipped (treated as "no static default")
+//
+// HCL variables that don't correspond to any Config field, and Config fields
+// without a matching HCL variable, are silently ignored — that's expected,
+// since some Config fields are reliable-side-only (e.g. AWSEC2.NumServers)
+// and many HCL variables are stack-wired (vpc_id, subnet_ids).
+//
+// Returns an error only on HCL-parse / FS failures; missing presets or
+// unmappable values are silently skipped.
+func (c *Client) ApplyPresetDefaults(cfg *Config, comps *Components, selected []ComponentKey) error {
+	if c.presets == nil {
+		return ErrNoPresetFS
+	}
+	if cfg == nil {
+		return fmt.Errorf("composer: ApplyPresetDefaults requires a non-nil *Config")
+	}
+	cloud := "aws"
+	if comps != nil && comps.Cloud != "" {
+		cloud = strings.ToLower(comps.Cloud)
+	}
+
+	// Build a JSON-tag → struct-field-index map for Config's nested *struct
+	// fields, so we can look up which Config field matches a given
+	// ComponentKey (whose string form equals the JSON tag, e.g. "aws_ec2").
+	cfgVal := reflect.ValueOf(cfg).Elem()
+	cfgType := cfgVal.Type()
+	tagIndex := map[string]int{}
+	for i := 0; i < cfgType.NumField(); i++ {
+		ft := cfgType.Field(i)
+		if ft.Type.Kind() != reflect.Ptr || ft.Type.Elem().Kind() != reflect.Struct {
+			continue
+		}
+		tag := jsonTagName(ft.Tag.Get("json"))
+		if tag != "" {
+			tagIndex[tag] = i
+		}
+	}
+
+	for _, key := range selected {
+		fieldIdx, ok := tagIndex[string(key)]
+		if !ok {
+			continue
+		}
+		path := GetPresetPath(cloud, key, comps)
+		files, err := c.GetPresetFiles(path)
+		if err != nil {
+			// Missing preset module: not an error, just nothing to fill.
+			continue
+		}
+		defaults, err := ModuleDefaults(files)
+		if err != nil {
+			return fmt.Errorf("composer: reading defaults for %s: %w", path, err)
+		}
+		if len(defaults) == 0 {
+			continue
+		}
+
+		fieldVal := cfgVal.Field(fieldIdx)
+		// Allocate the inner struct on demand.
+		allocated := false
+		if fieldVal.IsNil() {
+			fieldVal.Set(reflect.New(fieldVal.Type().Elem()))
+			allocated = true
+		}
+		filled := backfillStruct(fieldVal.Elem(), defaults)
+		if allocated && !filled {
+			// Nothing landed; revert to nil so the field stays omitempty.
+			fieldVal.Set(reflect.Zero(fieldVal.Type()))
+		}
+	}
+	return nil
+}
+
+// backfillStruct walks fields of dst (which must be a struct value) and for
+// each zero-valued field looks up the HCL default by snake_case-ified JSON
+// tag. Returns true if at least one field was successfully set.
+func backfillStruct(dst reflect.Value, defaults map[string]any) bool {
+	t := dst.Type()
+	filled := false
+	for i := 0; i < t.NumField(); i++ {
+		ft := t.Field(i)
+		fv := dst.Field(i)
+		if !fv.CanSet() || !fv.IsZero() {
+			continue
+		}
+		tag := jsonTagName(ft.Tag.Get("json"))
+		if tag == "" {
+			continue
+		}
+		hclName := camelToSnake(tag)
+		raw, ok := defaults[hclName]
+		if !ok || raw == nil {
+			continue
+		}
+		coerced, ok := coerceToFieldType(raw, ft.Type)
+		if !ok {
+			continue
+		}
+		fv.Set(coerced)
+		filled = true
+	}
+	return filled
+}
+
+// coerceToFieldType converts a Go value produced by ctyValueToGo into a
+// reflect.Value of the requested destination type, applying the coercion
+// table documented on ApplyPresetDefaults. Returns (zero, false) when the
+// source type cannot be coerced into dst.
+func coerceToFieldType(src any, dst reflect.Type) (reflect.Value, bool) {
+	// Pointer destinations: produce *T from T (one level of indirection).
+	if dst.Kind() == reflect.Ptr {
+		inner, ok := coerceToFieldType(src, dst.Elem())
+		if !ok {
+			return reflect.Value{}, false
+		}
+		ptr := reflect.New(dst.Elem())
+		ptr.Elem().Set(inner)
+		return ptr, true
+	}
+
+	switch dst.Kind() {
+	case reflect.String:
+		switch v := src.(type) {
+		case string:
+			return reflect.ValueOf(v), true
+		case int64:
+			return reflect.ValueOf(fmt.Sprint(v)), true
+		case float64:
+			return reflect.ValueOf(fmt.Sprint(v)), true
+		case bool:
+			return reflect.ValueOf(fmt.Sprint(v)), true
+		}
+	case reflect.Bool:
+		if v, ok := src.(bool); ok {
+			return reflect.ValueOf(v), true
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		switch v := src.(type) {
+		case int64:
+			rv := reflect.New(dst).Elem()
+			rv.SetInt(v)
+			return rv, true
+		case float64:
+			rv := reflect.New(dst).Elem()
+			rv.SetInt(int64(v))
+			return rv, true
+		}
+	case reflect.Float32, reflect.Float64:
+		switch v := src.(type) {
+		case float64:
+			rv := reflect.New(dst).Elem()
+			rv.SetFloat(v)
+			return rv, true
+		case int64:
+			rv := reflect.New(dst).Elem()
+			rv.SetFloat(float64(v))
+			return rv, true
+		}
+	case reflect.Slice:
+		srcSlice, ok := src.([]any)
+		if !ok {
+			return reflect.Value{}, false
+		}
+		out := reflect.MakeSlice(dst, len(srcSlice), len(srcSlice))
+		for i, e := range srcSlice {
+			ev, ok := coerceToFieldType(e, dst.Elem())
+			if !ok {
+				return reflect.Value{}, false
+			}
+			out.Index(i).Set(ev)
+		}
+		return out, true
+	case reflect.Map:
+		srcMap, ok := src.(map[string]any)
+		if !ok || dst.Key().Kind() != reflect.String {
+			return reflect.Value{}, false
+		}
+		out := reflect.MakeMapWithSize(dst, len(srcMap))
+		for k, v := range srcMap {
+			vv, ok := coerceToFieldType(v, dst.Elem())
+			if !ok {
+				return reflect.Value{}, false
+			}
+			out.SetMapIndex(reflect.ValueOf(k), vv)
+		}
+		return out, true
+	}
+	return reflect.Value{}, false
+}
+
+// jsonTagName extracts just the name portion of a `json:"name,omitempty"` tag.
+func jsonTagName(raw string) string {
+	if raw == "" || raw == "-" {
+		return ""
+	}
+	name, _, _ := strings.Cut(raw, ",")
+	return name
+}
+
+// camelToSnake converts a camelCase JSON tag to its snake_case HCL equivalent.
+// Initialism runs (URL, URI, MFA, CPU, HA, AZ) are preserved as a single
+// underscore-bounded token: userDataURL → user_data_url, multiAz → multi_az,
+// haControlPlane → ha_control_plane. This matches the convention used in
+// Config's JSON tags vs. each preset's variables.tf.
+func camelToSnake(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 4)
+	for i, r := range s {
+		isUpper := r >= 'A' && r <= 'Z'
+		if isUpper && i > 0 {
+			prev := rune(s[i-1])
+			prevLowerOrDigit := (prev >= 'a' && prev <= 'z') || (prev >= '0' && prev <= '9')
+			if prevLowerOrDigit {
+				b.WriteByte('_')
+			}
+		}
+		if isUpper {
+			b.WriteRune(r + ('a' - 'A'))
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // ctyValueToGo converts a fully-known cty.Value to a JSON-marshalable Go

--- a/pkg/composer/defaults.go
+++ b/pkg/composer/defaults.go
@@ -1,0 +1,157 @@
+package composer
+
+import (
+	"math/big"
+	"strings"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	cty "github.com/zclconf/go-cty/cty"
+)
+
+// ModuleDefaults parses every .tf file in a preset module and returns the
+// statically-resolvable default values declared in `variable { default = ... }`
+// blocks, keyed by HCL variable name.
+//
+// HCL is the single source of truth: defaults are extracted by parsing each
+// variables.tf and evaluating the default expression in an empty EvalContext.
+// As a result:
+//   - Variables without a `default = ...` clause are omitted.
+//   - Variables whose default is `null` are included with value `nil`.
+//   - Variables whose default expression references other vars, locals, or
+//     impure functions cannot be evaluated and are omitted. Callers needing
+//     dynamic defaults must fall back to `terraform plan`.
+//
+// Returned values are JSON-marshalable Go primitives:
+// string, int64, float64, bool, nil, []any, map[string]any.
+func ModuleDefaults(files map[string][]byte) (map[string]any, error) {
+	out := map[string]any{}
+	for p, b := range files {
+		if !strings.HasSuffix(strings.ToLower(p), ".tf") {
+			continue
+		}
+		f, diags := hclsyntax.ParseConfig(b, p, hcl.InitialPos)
+		if diags.HasErrors() {
+			continue
+		}
+		body, ok := f.Body.(*hclsyntax.Body)
+		if !ok {
+			continue
+		}
+		for _, blk := range body.Blocks {
+			if blk.Type != "variable" || len(blk.Labels) != 1 {
+				continue
+			}
+			attr, ok := blk.Body.Attributes["default"]
+			if !ok || attr == nil || attr.Expr == nil {
+				continue
+			}
+			v, ediags := attr.Expr.Value(nil)
+			if ediags.HasErrors() {
+				continue
+			}
+			g, ok := ctyValueToGo(v)
+			if !ok {
+				continue
+			}
+			out[blk.Labels[0]] = g
+		}
+	}
+	return out, nil
+}
+
+// PresetDefaults walks every embedded preset under every cloud and returns the
+// static defaults declared in each module's variables.tf.
+//
+// Keys are cloud-prefixed preset paths matching what GetPresetPath returns
+// (e.g. "aws/vpc", "gcp/cloudsql"); inner keys are HCL variable names.
+// Modules with no statically-resolvable defaults are omitted.
+//
+// Source-of-truth contract: see ModuleDefaults.
+func (c *Client) PresetDefaults() (map[string]map[string]any, error) {
+	if c.presets == nil {
+		return nil, ErrNoPresetFS
+	}
+	clouds, err := c.ListClouds()
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]map[string]any{}
+	for _, cloud := range clouds {
+		keys, err := c.ListPresetKeysForCloud(cloud)
+		if err != nil {
+			return nil, err
+		}
+		for _, key := range keys {
+			files, err := c.GetPresetFiles(key)
+			if err != nil {
+				return nil, err
+			}
+			defaults, err := ModuleDefaults(files)
+			if err != nil {
+				return nil, err
+			}
+			if len(defaults) > 0 {
+				out[key] = defaults
+			}
+		}
+	}
+	return out, nil
+}
+
+// ctyValueToGo converts a fully-known cty.Value to a JSON-marshalable Go
+// primitive. Returns (nil, false) for unknown values, marked values, or
+// composite values containing a non-convertible element.
+//
+// Whole numbers that fit in int64 are returned as int64 so authored defaults
+// like `default = 2` round-trip without becoming `2.0`.
+func ctyValueToGo(v cty.Value) (any, bool) {
+	if !v.IsKnown() {
+		return nil, false
+	}
+	if v.IsNull() {
+		return nil, true
+	}
+	t := v.Type()
+	switch {
+	case t == cty.String:
+		return v.AsString(), true
+	case t == cty.Bool:
+		return v.True(), true
+	case t == cty.Number:
+		bf := v.AsBigFloat()
+		if i, acc := bf.Int64(); acc == big.Exact {
+			return i, true
+		}
+		f, _ := bf.Float64()
+		return f, true
+	case t.IsListType(), t.IsSetType(), t.IsTupleType():
+		out := []any{}
+		it := v.ElementIterator()
+		for it.Next() {
+			_, ev := it.Element()
+			g, ok := ctyValueToGo(ev)
+			if !ok {
+				return nil, false
+			}
+			out = append(out, g)
+		}
+		return out, true
+	case t.IsMapType(), t.IsObjectType():
+		out := map[string]any{}
+		it := v.ElementIterator()
+		for it.Next() {
+			kv, ev := it.Element()
+			if kv.Type() != cty.String {
+				return nil, false
+			}
+			g, ok := ctyValueToGo(ev)
+			if !ok {
+				return nil, false
+			}
+			out[kv.AsString()] = g
+		}
+		return out, true
+	}
+	return nil, false
+}

--- a/pkg/composer/defaults_test.go
+++ b/pkg/composer/defaults_test.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -215,4 +216,171 @@ func TestPresetDefaults_NoPresetFS(t *testing.T) {
 	c := &Client{} // bypass New(); presets remains nil
 	_, err := c.PresetDefaults()
 	assert.ErrorIs(t, err, ErrNoPresetFS)
+}
+
+func TestCamelToSnake(t *testing.T) {
+	cases := map[string]string{
+		"instanceType":          "instance_type",
+		"numServers":            "num_servers",
+		"userDataURL":           "user_data_url",
+		"multiAz":               "multi_az",
+		"haControlPlane":        "ha_control_plane",
+		"enableInstanceConnect": "enable_instance_connect",
+		"customIngressPorts":    "custom_ingress_ports",
+		"sshPublicKey":          "ssh_public_key",
+		"mfaRequired":           "mfa_required",
+		"cpuSize":               "cpu_size",
+		"ha":                    "ha",
+		"region":                "region",
+		"URL":                   "url",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, camelToSnake(in), "input=%q", in)
+	}
+}
+
+func TestApplyPresetDefaults_FillsZeroFieldsOnly(t *testing.T) {
+	c := New()
+	cfg := &Config{
+		AWSEC2: &struct {
+			InstanceType          string `json:"instanceType,omitempty"`
+			NumServers            string `json:"numServers,omitempty"`
+			NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
+			DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
+			UserData              string `json:"userData,omitempty"`
+			UserDataURL           string `json:"userDataURL,omitempty"`
+			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
+			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
+			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+		}{
+			InstanceType: "m6i.large",                   // user-set: must be preserved
+			UserData:     "echo configured by the user", // user-set: must be preserved
+		},
+	}
+
+	err := c.ApplyPresetDefaults(cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+	require.NoError(t, err)
+	require.NotNil(t, cfg.AWSEC2)
+
+	// User-set fields preserved.
+	assert.Equal(t, "m6i.large", cfg.AWSEC2.InstanceType, "non-zero user value must NOT be overwritten")
+	assert.Equal(t, "echo configured by the user", cfg.AWSEC2.UserData)
+
+	// Zero-valued fields backfilled from aws/ec2/variables.tf.
+	assert.Equal(t, "", cfg.AWSEC2.UserDataURL, "HCL default of \"\" leaves field at zero (still treated as filled)")
+	assert.Equal(t, "", cfg.AWSEC2.SSHPublicKey)
+	require.NotNil(t, cfg.AWSEC2.EnableInstanceConnect, "*bool field with HCL default = false must be a non-nil pointer")
+	assert.False(t, *cfg.AWSEC2.EnableInstanceConnect)
+
+	// Empty list default → []int{} via element-wise coercion.
+	assert.NotNil(t, cfg.AWSEC2.CustomIngressPorts, "list default of [] must produce a non-nil empty slice")
+	assert.Equal(t, []int{}, cfg.AWSEC2.CustomIngressPorts)
+
+	// Fields with no HCL backer (NumServers etc.) stay zero.
+	assert.Empty(t, cfg.AWSEC2.NumServers, "Config fields without an HCL counterpart stay at zero value")
+	assert.Empty(t, cfg.AWSEC2.NumCoresPerServer)
+}
+
+func TestApplyPresetDefaults_AllocatesNilNestedStruct(t *testing.T) {
+	c := New()
+	cfg := &Config{} // AWSEC2 is nil
+
+	err := c.ApplyPresetDefaults(cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+	require.NoError(t, err)
+	require.NotNil(t, cfg.AWSEC2, "selected component with at least one resolvable default must allocate the nested struct")
+	assert.Equal(t, "t3.medium", cfg.AWSEC2.InstanceType)
+}
+
+func TestCoerceToFieldType(t *testing.T) {
+	cases := []struct {
+		name string
+		src  any
+		dst  reflect.Type
+		want any
+		ok   bool
+	}{
+		// String-typed targets cover the fmt.Sprint coercion paths used for
+		// Config fields like NumServers (HCL number → Go string).
+		{"string→string", "demo", reflect.TypeFor[string](), "demo", true},
+		{"int64→string", int64(2), reflect.TypeFor[string](), "2", true},
+		{"float64→string", 0.25, reflect.TypeFor[string](), "0.25", true},
+		{"bool→string", true, reflect.TypeFor[string](), "true", true},
+
+		// Numeric-typed targets cover RetentionDays-style int fields and
+		// EstimatedMonthlyRequests-style int64 fields.
+		{"int64→int", int64(7), reflect.TypeFor[int](), int(7), true},
+		{"int64→int64", int64(7), reflect.TypeFor[int64](), int64(7), true},
+		{"float64→int", 7.0, reflect.TypeFor[int](), int(7), true},
+		{"int64→float64", int64(7), reflect.TypeFor[float64](), float64(7), true},
+		{"float64→float64", 0.5, reflect.TypeFor[float64](), 0.5, true},
+
+		// Bool target.
+		{"bool→bool", true, reflect.TypeFor[bool](), true, true},
+
+		// Pointer targets — exercise the recursive *T branch used for
+		// Config fields like EnableInstanceConnect (*bool) and CachePaths (*string).
+		{"bool→*bool", false, reflect.TypeFor[*bool](), false, true},
+		{"string→*string", "x", reflect.TypeFor[*string](), "x", true},
+
+		// Slice elementwise coercion: HCL list(number) → Go []int (used for
+		// CustomIngressPorts).
+		{"[]any{int64,int64}→[]int", []any{int64(80), int64(443)}, reflect.TypeFor[[]int](), []int{80, 443}, true},
+		{"[]any{string}→[]string", []any{"a", "b"}, reflect.TypeFor[[]string](), []string{"a", "b"}, true},
+		{"empty []any→[]int", []any{}, reflect.TypeFor[[]int](), []int{}, true},
+
+		// Refusals: type combinations we explicitly do NOT coerce so callers
+		// know to leave the field at zero rather than apply a wrong value.
+		{"string→int (refused)", "7", reflect.TypeFor[int](), nil, false},
+		{"string→bool (refused)", "true", reflect.TypeFor[bool](), nil, false},
+		{"map→string (refused)", map[string]any{"a": "b"}, reflect.TypeFor[string](), nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := coerceToFieldType(tc.src, tc.dst)
+			require.Equal(t, tc.ok, ok)
+			if !tc.ok {
+				return
+			}
+			// Pointer comparisons need to deref to the underlying value.
+			if got.Kind() == reflect.Ptr {
+				assert.Equal(t, tc.want, got.Elem().Interface())
+			} else {
+				assert.Equal(t, tc.want, got.Interface())
+			}
+		})
+	}
+}
+
+func TestApplyPresetDefaults_UnselectedComponentsUntouched(t *testing.T) {
+	c := New()
+	cfg := &Config{} // AWSEC2 nil, AWSRDS nil
+
+	err := c.ApplyPresetDefaults(cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+	require.NoError(t, err)
+	assert.NotNil(t, cfg.AWSEC2, "selected component is allocated")
+	assert.Nil(t, cfg.AWSRDS, "unselected component must remain nil — no spurious allocation")
+	assert.Nil(t, cfg.AWSS3)
+}
+
+func TestApplyPresetDefaults_NilCfgErrors(t *testing.T) {
+	c := New()
+	err := c.ApplyPresetDefaults(nil, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+	require.Error(t, err, "nil cfg must error rather than panic")
+}
+
+func TestApplyPresetDefaults_NoPresetFS(t *testing.T) {
+	c := &Client{} // presets nil
+	err := c.ApplyPresetDefaults(&Config{}, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+	assert.ErrorIs(t, err, ErrNoPresetFS)
+}
+
+func TestApplyPresetDefaults_GCPRoute(t *testing.T) {
+	c := New()
+	cfg := &Config{}
+	err := c.ApplyPresetDefaults(cfg, &Components{Cloud: "gcp"}, []ComponentKey{KeyGCPCloudSQL})
+	require.NoError(t, err)
+	// We don't pin a specific GCP value here (GCP preset Configs are sparser);
+	// the assertion is just that selecting a GCP key with cloud=gcp doesn't
+	// route to the AWS preset tree or panic.
+	_ = cfg
 }

--- a/pkg/composer/defaults_test.go
+++ b/pkg/composer/defaults_test.go
@@ -1,0 +1,183 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModuleDefaults_PrimitiveShapes(t *testing.T) {
+	files := map[string][]byte{
+		"variables.tf": []byte(`
+variable "name" {
+  type    = string
+  default = "demo"
+}
+variable "count" {
+  type    = number
+  default = 2
+}
+variable "ratio" {
+  type    = number
+  default = 0.25
+}
+variable "enabled" {
+  type    = bool
+  default = true
+}
+variable "nullable" {
+  type    = string
+  default = null
+}
+variable "ports" {
+  type    = list(number)
+  default = [80, 443]
+}
+variable "cidrs" {
+  type    = list(string)
+  default = ["0.0.0.0/0"]
+}
+variable "tags" {
+  type    = map(string)
+  default = { Env = "prod", Team = "core" }
+}
+variable "empty_list" {
+  type    = list(string)
+  default = []
+}
+variable "empty_map" {
+  type    = map(string)
+  default = {}
+}
+variable "required" {
+  type = string
+}
+`),
+	}
+
+	got, err := ModuleDefaults(files)
+	require.NoError(t, err)
+
+	require.Contains(t, got, "nullable", "default = null must be present in the map")
+	assert.Nil(t, got["nullable"], "default = null must round-trip as Go nil")
+
+	assert.Equal(t, "demo", got["name"])
+	assert.Equal(t, int64(2), got["count"], "whole numbers must stay int64, not float64")
+	assert.Equal(t, 0.25, got["ratio"])
+	assert.Equal(t, true, got["enabled"])
+	assert.Equal(t, []any{int64(80), int64(443)}, got["ports"])
+	assert.Equal(t, []any{"0.0.0.0/0"}, got["cidrs"])
+	assert.Equal(t, map[string]any{"Env": "prod", "Team": "core"}, got["tags"])
+	assert.Equal(t, []any{}, got["empty_list"])
+	assert.Equal(t, map[string]any{}, got["empty_map"])
+	assert.NotContains(t, got, "required", "variables without `default = ...` must be omitted")
+}
+
+func TestModuleDefaults_OmitsDynamicDefaults(t *testing.T) {
+	files := map[string][]byte{
+		"variables.tf": []byte(`
+variable "base" {
+  default = "x"
+}
+variable "ref" {
+  # references another variable
+  default = var.base
+}
+variable "loc" {
+  # references a local
+  default = local.something
+}
+variable "fn" {
+  # function calls without an EvalContext also fail
+  default = lookup({ a = 1 }, "a", 0)
+}
+`),
+	}
+
+	got, err := ModuleDefaults(files)
+	require.NoError(t, err)
+
+	assert.Contains(t, got, "base")
+	assert.NotContains(t, got, "ref", "references to other variables must be omitted")
+	assert.NotContains(t, got, "loc", "references to locals must be omitted")
+	// "fn" uses lookup() which actually IS pure-stdlib but we evaluate with nil ctx;
+	// hcl.Expression.Value(nil) refuses unknown function calls. Treat that as "non-static".
+	assert.NotContains(t, got, "fn", "function calls without an EvalContext must be omitted")
+}
+
+func TestModuleDefaults_SkipsNonTFFiles(t *testing.T) {
+	files := map[string][]byte{
+		"variables.tf":      []byte(`variable "kept" { default = "yes" }`),
+		"user_data.sh.tmpl": []byte(`#!/bin/bash\nvariable "noise" { default = "ignored" }`),
+		"providers.tfstate": []byte(`{"definitely": "not HCL"}`),
+		"unparseable.tf":    []byte(`variable "broken" { default = ` + "`bad`" + `}`),
+		"with_outputs.tf": []byte(`
+variable "second" {
+  default = 42
+}
+output "irrelevant" {
+  value = "ignored"
+}
+`),
+	}
+
+	got, err := ModuleDefaults(files)
+	require.NoError(t, err)
+	assert.Equal(t, "yes", got["kept"])
+	assert.Equal(t, int64(42), got["second"])
+	assert.NotContains(t, got, "noise")
+	assert.NotContains(t, got, "broken", "unparseable .tf files must be skipped, not error")
+}
+
+func TestPresetDefaults_EmbeddedFS_KnownVPCSamples(t *testing.T) {
+	c := New() // uses embedded preset FS
+	all, err := c.PresetDefaults()
+	require.NoError(t, err)
+
+	// aws/vpc must be present and carry the known authored defaults from
+	// aws/vpc/variables.tf. If a future PR changes those defaults, this test
+	// fails — that's the contract: HCL is the source of truth, the Go export
+	// reflects it automatically, and a behavioural change is visible.
+	vpc, ok := all["aws/vpc"]
+	require.True(t, ok, "aws/vpc must appear in PresetDefaults()")
+
+	assert.Equal(t, "demo", vpc["project"])
+	assert.Equal(t, "us-east-1", vpc["region"])
+	assert.Equal(t, "10.1.0.0/16", vpc["vpc_cidr"])
+	assert.Equal(t, int64(2), vpc["az_count"])
+	assert.Equal(t, true, vpc["enable_nat_gateway"])
+	assert.Equal(t, true, vpc["single_nat_gateway"])
+	assert.Equal(t, true, vpc["enable_private_subnets"])
+
+	// `environment` has no default in aws/vpc — must be absent.
+	assert.NotContains(t, vpc, "environment")
+
+	// `eks_cluster_name` has `default = null` — must be present and nil.
+	require.Contains(t, vpc, "eks_cluster_name")
+	assert.Nil(t, vpc["eks_cluster_name"])
+}
+
+func TestPresetDefaults_EmbeddedFS_CoversBothClouds(t *testing.T) {
+	c := New()
+	all, err := c.PresetDefaults()
+	require.NoError(t, err)
+
+	var awsCount, gcpCount int
+	for k := range all {
+		switch {
+		case len(k) >= 4 && k[:4] == "aws/":
+			awsCount++
+		case len(k) >= 4 && k[:4] == "gcp/":
+			gcpCount++
+		}
+	}
+	assert.Greater(t, awsCount, 0, "must surface AWS preset defaults")
+	assert.Greater(t, gcpCount, 0, "must surface GCP preset defaults")
+}
+
+func TestPresetDefaults_NoPresetFS(t *testing.T) {
+	c := &Client{} // bypass New(); presets remains nil
+	_, err := c.PresetDefaults()
+	assert.ErrorIs(t, err, ErrNoPresetFS)
+}

--- a/pkg/composer/defaults_test.go
+++ b/pkg/composer/defaults_test.go
@@ -233,6 +233,12 @@ func TestCamelToSnake(t *testing.T) {
 		"ha":                    "ha",
 		"region":                "region",
 		"URL":                   "url",
+		// Digit-bearing identifiers (real cases from Config: diskSizeGb,
+		// embeddingModelId, modelId, auth0). Digits don't trigger boundaries.
+		"diskSizeGb":       "disk_size_gb",
+		"embeddingModelId": "embedding_model_id",
+		"modelId":          "model_id",
+		"auth0":            "auth0",
 	}
 	for in, want := range cases {
 		assert.Equal(t, want, camelToSnake(in), "input=%q", in)
@@ -328,11 +334,16 @@ func TestCoerceToFieldType(t *testing.T) {
 		{"[]any{string}→[]string", []any{"a", "b"}, reflect.TypeFor[[]string](), []string{"a", "b"}, true},
 		{"empty []any→[]int", []any{}, reflect.TypeFor[[]int](), []int{}, true},
 
+		// Map elementwise coercion (rare in Config but exercises the
+		// reflect.Map branch).
+		{"map[string]any→map[string]string", map[string]any{"k": "v"}, reflect.TypeFor[map[string]string](), map[string]string{"k": "v"}, true},
+
 		// Refusals: type combinations we explicitly do NOT coerce so callers
 		// know to leave the field at zero rather than apply a wrong value.
 		{"string→int (refused)", "7", reflect.TypeFor[int](), nil, false},
 		{"string→bool (refused)", "true", reflect.TypeFor[bool](), nil, false},
 		{"map→string (refused)", map[string]any{"a": "b"}, reflect.TypeFor[string](), nil, false},
+		{"[]any{string}→[]int (refused, element fails)", []any{"x"}, reflect.TypeFor[[]int](), nil, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -372,6 +383,29 @@ func TestApplyPresetDefaults_NoPresetFS(t *testing.T) {
 	c := &Client{} // presets nil
 	err := c.ApplyPresetDefaults(&Config{}, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
 	assert.ErrorIs(t, err, ErrNoPresetFS)
+}
+
+// TestApplyPresetDefaults_NamingMismatch_LeavesNilAndZero locks in two
+// related contracts in one test:
+//
+//  1. Silent ignore on snake↔camel mismatch. aws/cloudwatchlogs/variables.tf
+//     declares `retention_in_days` (HCL) but Config.AWSCloudWatchLogs's only
+//     field is RetentionDays with JSON tag `retentionDays` → snake form
+//     `retention_days`. The names don't align, so the field MUST stay zero.
+//     If a future refactor switches to fuzzy matching (or panics on miss)
+//     this test fails and forces an explicit decision.
+//  2. Allocated-but-empty revert. Because no Config field successfully
+//     backfills, the inner *struct that ApplyPresetDefaults allocated must
+//     be reverted to nil so omitempty works downstream. A regression that
+//     leaves the empty inner struct allocated would surface here.
+func TestApplyPresetDefaults_NamingMismatch_LeavesNilAndZero(t *testing.T) {
+	c := New()
+	cfg := &Config{} // AWSCloudWatchLogs is nil
+
+	err := c.ApplyPresetDefaults(cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSCloudWatchLogs})
+	require.NoError(t, err, "naming mismatch must not error")
+	assert.Nil(t, cfg.AWSCloudWatchLogs,
+		"selected component whose preset declares no fields matching any Config tag must leave the inner struct nil (allocated-but-empty revert)")
 }
 
 func TestApplyPresetDefaults_GCPRoute(t *testing.T) {

--- a/pkg/composer/defaults_test.go
+++ b/pkg/composer/defaults_test.go
@@ -1,6 +1,8 @@
 package composer
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,6 +52,10 @@ variable "empty_map" {
   type    = map(string)
   default = {}
 }
+variable "obj" {
+  type    = object({ name = string, port = number })
+  default = { name = "x", port = 80 }
+}
 variable "required" {
   type = string
 }
@@ -71,7 +77,23 @@ variable "required" {
 	assert.Equal(t, map[string]any{"Env": "prod", "Team": "core"}, got["tags"])
 	assert.Equal(t, []any{}, got["empty_list"])
 	assert.Equal(t, map[string]any{}, got["empty_map"])
+	assert.Equal(t, map[string]any{"name": "x", "port": int64(80)}, got["obj"],
+		"object({...}) defaults must round-trip via the IsObjectType branch with int-preservation inside")
 	assert.NotContains(t, got, "required", "variables without `default = ...` must be omitted")
+
+	// JSON round-trip: ModuleDefaults claims to return JSON-marshalable Go
+	// primitives. A regression returning cty.Value, big.Float, or other
+	// non-marshalable types would slip through if we never marshalled.
+	// json.Marshal promotes int64→float64, so we re-assert post-promotion shapes
+	// to document the actual on-the-wire form reliable will see.
+	b, err := json.Marshal(got)
+	require.NoError(t, err, "PresetDefaults output must be JSON-marshalable")
+	var rt map[string]any
+	require.NoError(t, json.Unmarshal(b, &rt))
+	assert.Equal(t, "demo", rt["name"])
+	assert.Equal(t, float64(2), rt["count"], "JSON round-trip promotes int64 to float64; downstream callers see this shape")
+	assert.Equal(t, []any{float64(80), float64(443)}, rt["ports"])
+	assert.Nil(t, rt["nullable"])
 }
 
 func TestModuleDefaults_OmitsDynamicDefaults(t *testing.T) {
@@ -166,14 +188,27 @@ func TestPresetDefaults_EmbeddedFS_CoversBothClouds(t *testing.T) {
 	var awsCount, gcpCount int
 	for k := range all {
 		switch {
-		case len(k) >= 4 && k[:4] == "aws/":
+		case strings.HasPrefix(k, "aws/"):
 			awsCount++
-		case len(k) >= 4 && k[:4] == "gcp/":
+		case strings.HasPrefix(k, "gcp/"):
 			gcpCount++
 		}
 	}
 	assert.Greater(t, awsCount, 0, "must surface AWS preset defaults")
 	assert.Greater(t, gcpCount, 0, "must surface GCP preset defaults")
+
+	// Cross-contamination guard: gcp/vpc::region is "us-central1" in HCL.
+	// aws/vpc::region is "us-east-1". A bug that stuffed AWS defaults under
+	// gcp/ keys (or vice versa) would survive a count-only check, so pin
+	// the actual values per cloud.
+	gcpVPC, ok := all["gcp/vpc"]
+	require.True(t, ok, "gcp/vpc must appear in PresetDefaults()")
+	assert.Equal(t, "us-central1", gcpVPC["region"],
+		"gcp/vpc::region must be the GCP-authored default, not the aws/vpc default")
+
+	awsVPC := all["aws/vpc"]
+	assert.Equal(t, "us-east-1", awsVPC["region"],
+		"aws/vpc::region must be the AWS-authored default, not the gcp/vpc default")
 }
 
 func TestPresetDefaults_NoPresetFS(t *testing.T) {


### PR DESCRIPTION
## Summary

Two layers landing together so reliable can consume defaults end-to-end without writing its own snake↔camel mapper:

**1. Primitive layer** — `ModuleDefaults()` and `(*Client).PresetDefaults()`.
Extracts statically-resolvable HCL `default = ...` values from embedded `variables.tf` files via the existing `hcl/v2` + `cty` deps. Returns JSON-marshalable Go primitives keyed by HCL variable name. HCL stays the **single source of truth** — no parity test, no code generation.

**2. Typed-Config layer** — `(*Client).ApplyPresetDefaults(cfg, comps, selected)`.
Backfills `cfg` with the primitive layer's values lifted into Config's nested `*struct` fields, doing snake↔camel JSON-tag matching and per-field type coercion. **Only zero-valued fields are filled** (per `reflect.Value.IsZero`), so user-set values are preserved — matches reliable's apply-start need to "fill in the blanks the user hasn't filled yet" without overwriting explicit configuration.

Closes #89.

## API surface

```go
// Primitives
func ModuleDefaults(files map[string][]byte) (map[string]any, error)
func (c *Client) PresetDefaults() (map[string]map[string]any, error)

// Typed Config backfill (the one reliable will call at apply-start)
func (c *Client) ApplyPresetDefaults(cfg *Config, comps *Components, selected []ComponentKey) error
```

## Coercion table (HCL → Go field type)

| HCL value | Go field type | Result |
|-----------|--------------|--------|
| string    | string        | direct |
| number    | string        | `fmt.Sprint(v)` ("2", not 2) |
| number    | int / int64 / float64 | numeric cast |
| bool      | bool          | direct |
| bool      | *bool         | pointer to value |
| string    | *string       | pointer to value |
| list      | []string / []int | element-wise coerce |
| null      | any           | skipped (treated as no static default) |

Refusals (string→int, string→bool, map→string, etc.) leave the field at zero rather than guess. HCL variables with no matching Config field, and Config fields with no matching HCL variable, are silently ignored — covers reliable-side-only fields like `AWSEC2.NumServers` and stack-wired vars like `vpc_id`.

## Design rationale (per #89 discussion)

The three sync strategies in the original ticket all assume two representations of defaults exist. We don't have to. We already embed the HCL via `embed.FS` and already pull `hcl/v2` + `cty` for variable discovery — so the primitive layer just extends the existing HCL pass to evaluate `attr.Expr.Value(nil)`. Drift is mathematically impossible because there is only one representation. The typed layer is a pure reflection-based lift over that primitive, using Config's existing JSON tags as the field-name source of truth.

## Test plan

- [x] `go test ./pkg/composer/` — full suite passes locally (~20s)
- [x] Primitive layer: every value shape (string/number/bool/null/list/map/object), int-preserving for whole numbers, omission of `default`-less vars, omission of dynamic defaults, unparseable-file skip, JSON round-trip, embedded-FS smoke against `aws/vpc`, cross-cloud isolation pinning `aws/vpc::region="us-east-1"` vs `gcp/vpc::region="us-central1"`, `ErrNoPresetFS` for unconfigured Client.
- [x] `ApplyPresetDefaults`: user-set fields preserved, zero fields filled, nested struct allocated on demand, `*bool` for HCL bool, `[]int{}` from empty HCL list, unselected components untouched, nil-cfg errors, no-FS errors, GCP cloud route.
- [x] `coerceToFieldType` direct unit tests covering 18 type combinations including refusals.
- [x] `camelToSnake` covers initialism runs (URL, AZ, MFA, CPU, HA).
- [x] `terraform fmt -check -recursive` clean
- [x] `gofmt -l` clean, `go vet ./...` clean

## Out of scope

- Renaming HCL variables to align with Config JSON tags (e.g. `retention_in_days` → `retention_days`). The current implementation silently leaves mismatched fields at zero, which is the safe behavior; a future PR can rename HCL vars and the typed layer will start populating those fields automatically.
- Evaluating dynamic defaults (those that reference other vars). Requires a real HCL `EvalContext`; explicitly out of scope per the ticket.