### PR TITLE
fix(apigateway): enable detailed CloudWatch metrics on $default stage

### DIFF
--- a/aws/apigateway/main.tf
+++ b/aws/apigateway/main.tf
@@ -31,6 +31,12 @@ resource "aws_apigatewayv2_stage" "default" {
   name        = "$default"
   auto_deploy = true
 
+  default_route_settings {
+    detailed_metrics_enabled = true
+    throttling_burst_limit   = var.throttling_burst_limit
+    throttling_rate_limit    = var.throttling_rate_limit
+  }
+
   tags = merge(module.name.tags, { Name = "${module.name.prefix}-default" }, var.tags)
 }
 

--- a/aws/apigateway/variables.tf
+++ b/aws/apigateway/variables.tf
@@ -25,6 +25,26 @@ variable "certificate_arn" {
   default = null
 }
 
+variable "throttling_burst_limit" {
+  description = "Optional override for the $default stage's burst limit (requests). When null, inherits the AWS account-level default."
+  type        = number
+  default     = null
+  validation {
+    condition     = var.throttling_burst_limit == null ? true : var.throttling_burst_limit >= 0
+    error_message = "throttling_burst_limit must be null or a non-negative integer."
+  }
+}
+
+variable "throttling_rate_limit" {
+  description = "Optional override for the $default stage's steady-state rate limit (requests per second). When null, inherits the AWS account-level default."
+  type        = number
+  default     = null
+  validation {
+    condition     = var.throttling_rate_limit == null ? true : var.throttling_rate_limit >= 0
+    error_message = "throttling_rate_limit must be null or a non-negative number."
+  }
+}
+
 variable "tags" {
   type    = map(string)
   default = {}


### PR DESCRIPTION
## Summary
- `aws_apigatewayv2_stage.default` in `aws/apigateway` had no `default_route_settings`, so `detailed_metrics_enabled` defaulted to `false` and AWS published **no** CloudWatch metrics for the stage — reliable2's component-metrics view stayed on "Pending data" for 4xx / 5xx / Latency / Count regardless of traffic (repro'd on prod session `sess_v2_YqoemAQOXiqU`, API id `dkl4xhcu46`).
- Set `detailed_metrics_enabled = true` on the stage's `default_route_settings`; AWS applies this as an in-place UpdateStage — no stage recreation.
- Expose `throttling_burst_limit` and `throttling_rate_limit` as optional `number` variables (default `null` → inherit account-level throttle), per the issue's optional follow-up. Both use the `var.x == null ? true : ...` validation pattern.
- Additive change only: no renamed/removed variables, no output changes — non-breaking for the composer and downstream `reliable2` pins.

## Test plan
- [x] `terraform fmt -check -recursive` passes
- [x] `aws/apigateway` module validates (`terraform init -backend=false && terraform validate`)
- [x] All seven example stacks that consume `aws/apigateway` validate (edubot, gamestudio, guestbook, inboundfund-tf, localbook, locallink, revisionapp)
- [x] `go build ./...` clean (embed intact)
- [x] `bash tests/lint-project-tag.sh` passes
- [ ] Post-release: redeploy a test session, fire traffic, confirm `/api/v2/component/metrics?key=aws_apigateway` returns non-null datapoints for `Count` / `Latency` within ~5 minutes. (4xx / 5xx remain empty until the separate reliable2 metric-name rename lands — called out in the issue as out-of-scope for this repo.)

Fixes #93