### PR TITLE
feat(telemetry): enable CloudWatch toggles on rds, dynamodb, cloudfront (phase 1)

### DIFF
--- a/aws/cloudfront/main.tf
+++ b/aws/cloudfront/main.tf
@@ -182,3 +182,17 @@ resource "aws_cloudfront_distribution" "this" {
     }
   }
 }
+
+# Enables the "additional CloudFront metrics" (cache-hit rate, origin latency,
+# error-rate-by-status). Without this subscription only the 6 default metrics
+# publish, so reliable2 panels on those additional signals stay on "Pending
+# data" indefinitely.
+resource "aws_cloudfront_monitoring_subscription" "this" {
+  distribution_id = aws_cloudfront_distribution.this.id
+
+  monitoring_subscription {
+    realtime_metrics_subscription_config {
+      realtime_metrics_subscription_status = "Enabled"
+    }
+  }
+}

--- a/aws/dynamodb/main.tf
+++ b/aws/dynamodb/main.tf
@@ -90,3 +90,17 @@ resource "aws_dynamodb_table" "this" {
 
   tags = local.tags
 }
+
+# CloudWatch Contributor Insights — exposes hot-partition / most-accessed-key
+# analytics on the table and each GSI. Required for reliable2 panels that chart
+# key-level access patterns; without it CI is disabled and those panels stay on
+# "Pending data".
+resource "aws_dynamodb_contributor_insights" "table" {
+  table_name = aws_dynamodb_table.this.name
+}
+
+resource "aws_dynamodb_contributor_insights" "gsi" {
+  for_each   = { for idx in var.global_secondary_indexes : idx.name => idx }
+  table_name = aws_dynamodb_table.this.name
+  index_name = each.value.name
+}

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -120,6 +120,8 @@ resource "aws_db_instance" "primary" {
 
   enabled_cloudwatch_logs_exports = var.enable_cloudwatch_logs ? var.cloudwatch_logs_exports : []
 
+  performance_insights_enabled = true
+
   auto_minor_version_upgrade = true
 
   tags = merge(module.name.tags, var.tags)
@@ -153,6 +155,10 @@ resource "aws_db_instance" "replica" {
   max_allocated_storage = var.max_allocated_storage
 
   skip_final_snapshot = true
+
+  enabled_cloudwatch_logs_exports = var.enable_cloudwatch_logs ? var.cloudwatch_logs_exports : []
+
+  performance_insights_enabled = true
 
   tags = merge(module.name.tags, var.tags)
 }

--- a/tests/lint-project-tag.sh
+++ b/tests/lint-project-tag.sh
@@ -27,12 +27,14 @@ NON_TAGGABLE_AWS=(
   aws_apigatewayv2_api_mapping
   aws_backup_selection
   aws_bedrock_model_invocation_logging_configuration
+  aws_cloudfront_monitoring_subscription
   aws_cloudfront_origin_access_identity
   aws_cloudwatch_dashboard
   aws_cloudwatch_log_stream
   aws_cognito_identity_provider
   aws_cognito_user_pool_client
   aws_cognito_user_pool_domain
+  aws_dynamodb_contributor_insights
   aws_ecs_cluster_capacity_providers
   aws_iam_role_policy
   aws_iam_role_policy_attachment


### PR DESCRIPTION
## Summary

Same class of bug as #93 / #94. Several AWS resources default telemetry toggles to OFF, so AWS publishes nothing and reliable2's `component-metrics` view stays on "Pending data" no matter how much traffic or load hits them. This is the **phase-1 batch from #95** — flip-the-flag fixes that introduce no new IAM roles, S3 buckets, or CW log groups.

- **`aws/rds`**: `performance_insights_enabled = true` on `aws_db_instance.primary` and `.replica`. PI retention defaults to 7 days (free tier) and uses the AWS-managed `aws/rds` KMS key when no override is set.
- **`aws/rds`**: replica now carries the same `enabled_cloudwatch_logs_exports` gate the primary has. The primary was already wired; the replica was silently missing the same line. Parity fix.
- **`aws/dynamodb`**: new `aws_dynamodb_contributor_insights` resources — one for the table and one per GSI (`for_each` keyed by GSI name). CI is a standalone resource, not an inline attribute, so this is the correct shape.
- **`aws/cloudfront`**: new `aws_cloudfront_monitoring_subscription` resource with `realtime_metrics_subscription_status = "Enabled"`. Unlocks cache-hit rate, origin latency, and error-rate-by-status (only the 6 default metrics publish without it).
- **`tests/lint-project-tag.sh`**: allowlist `aws_cloudfront_monitoring_subscription` and `aws_dynamodb_contributor_insights`. Neither accepts a `tags` attribute in AWS provider 6.x.

## Non-breaking

- No renamed/removed variables. Two new sibling resources, both standalone (no output dependencies from consumers). PI / Contributor Insights / CloudFront real-time metrics are plan-as-in-place-enable on existing deployed stacks — no resource recreation.

## Test plan

- [x] `terraform fmt -check -recursive` clean
- [x] `terraform validate` passes on `aws/rds`, `aws/dynamodb`, `aws/cloudfront`
- [x] All 8 example stacks that consume these modules validate (cargofit, edubot, gamestudio, guestbook, localbook, locallink, revisionapp, videostreaming)
- [x] `go build ./...` clean (embed intact, no new file patterns)
- [x] `bash tests/lint-project-tag.sh` passes after allowlist update
- [ ] Post-release: redeploy a test session with an RDS instance, a DynamoDB table with a GSI, and a CloudFront distribution. Fire traffic. Within ~5 min: Performance Insights populates in the RDS console; `aws dynamodb describe-contributor-insights` returns `ENABLED` for both table and GSI; CloudFront `AWS/CloudFront` additional metrics (`CacheHitRate`, `OriginLatency`) return non-null datapoints.

Refs #95 (not `Closes` — phase-2 items in #95 still pending)