### PR TITLE
feat(telemetry): phase-2a self-contained fixes — rds EM, alb access logs, lambda xray, ec2 monitoring, elasticache logs

### DIFF
--- a/aws/alb/main.tf
+++ b/aws/alb/main.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 6.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
 
@@ -54,6 +58,65 @@ resource "aws_security_group" "alb_sg" {
   tags = merge(module.name.tags, { Name = "${module.name.prefix}-sg" }, var.tags)
 }
 
+# -----------------------------------------------------------------------------
+# Access-logs S3 bucket (owned by this module)
+# -----------------------------------------------------------------------------
+# ALB access logs unlock per-path / per-status / target-response-time analysis
+# that the CloudWatch metric surface alone cannot provide. AWS delivers access
+# logs to S3, so we own a dedicated bucket here (one per ALB) with the
+# service-principal PutObject grant recommended for all regions — including
+# opt-in / post-August-2022 regions where the historical ELB account-ID
+# approach does not work.
+resource "random_id" "alb_logs_suffix" {
+  byte_length = 3
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "alb_logs" {
+  bucket        = "${var.project}-alb-logs-${random_id.alb_logs_suffix.hex}"
+  force_destroy = true
+  tags          = merge(module.name.tags, { Name = "${module.name.prefix}-alb-logs" }, var.tags)
+}
+
+resource "aws_s3_bucket_public_access_block" "alb_logs" {
+  bucket                  = aws_s3_bucket.alb_logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+data "aws_iam_policy_document" "alb_logs" {
+  statement {
+    sid       = "AllowELBAccessLogDelivery"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.alb_logs.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
+    principals {
+      type        = "Service"
+      identifiers = ["logdelivery.elasticloadbalancing.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+  policy = data.aws_iam_policy_document.alb_logs.json
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+  rule {
+    id     = "expire-access-logs"
+    status = "Enabled"
+    filter {}
+    expiration {
+      days = var.access_logs_retention_days
+    }
+  }
+}
+
 # Internet-facing ALB
 resource "aws_lb" "alb" {
   # ALB names limited to 32 chars — use var.project
@@ -65,7 +128,14 @@ resource "aws_lb" "alb" {
 
   enable_deletion_protection = var.enable_deletion_protection
 
+  access_logs {
+    bucket  = aws_s3_bucket.alb_logs.bucket
+    enabled = true
+  }
+
   tags = merge(module.name.tags, var.tags)
+
+  depends_on = [aws_s3_bucket_policy.alb_logs]
 }
 
 # Default target group (attach ECS/EKS/instances later)

--- a/aws/alb/variables.tf
+++ b/aws/alb/variables.tf
@@ -80,6 +80,16 @@ variable "enable_deletion_protection" {
   default     = false
 }
 
+variable "access_logs_retention_days" {
+  description = "Days to retain ALB access logs in the in-module S3 bucket before expiration."
+  type        = number
+  default     = 90
+  validation {
+    condition     = var.access_logs_retention_days >= 1
+    error_message = "access_logs_retention_days must be >= 1."
+  }
+}
+
 variable "tags" {
   description = "Common resource tags"
   type        = map(string)

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -160,6 +160,10 @@ resource "aws_instance" "this" {
   iam_instance_profile        = aws_iam_instance_profile.this.name
   key_name                    = var.ssh_public_key != "" ? aws_key_pair.this[0].key_name : var.key_name
 
+  # 1-minute CloudWatch metrics (default 5-minute). Required for any reliable2
+  # chart that samples CPU/net/disk at sub-5-minute granularity.
+  monitoring = true
+
   user_data = local.effective_user_data != "" ? local.effective_user_data : null
 
   lifecycle {

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -130,9 +130,9 @@ variable "apply_immediately" {
 }
 
 variable "enable_cloudwatch_logs" {
-  description = "Enable Redis log delivery to CloudWatch Logs"
+  description = "Enable Redis log delivery to CloudWatch Logs (engine + slow logs)"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "tags" {

--- a/aws/lambda/main.tf
+++ b/aws/lambda/main.tf
@@ -62,6 +62,13 @@ resource "aws_iam_role_policy_attachment" "lambda_vpc" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
+# Active X-Ray tracing is enabled on the function below; the exec role needs
+# PutTraceSegments / PutTelemetryRecords, which AWSXRayDaemonWriteAccess grants.
+resource "aws_iam_role_policy_attachment" "lambda_xray" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
 # -----------------------------------------------------------------------------
 # Default Security Group (created when VPC-enabled and no SGs provided)
 # -----------------------------------------------------------------------------
@@ -123,10 +130,15 @@ resource "aws_lambda_function" "this" {
     variables = var.environment_variables
   }
 
+  tracing_config {
+    mode = "Active"
+  }
+
   tags = merge(module.name.tags, var.tags)
 
   depends_on = [
     aws_iam_role_policy_attachment.lambda_basic,
+    aws_iam_role_policy_attachment.lambda_xray,
     aws_cloudwatch_log_group.lambda,
   ]
 }

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -67,6 +67,38 @@ resource "aws_db_subnet_group" "this" {
 }
 
 # -----------------------------------------------------------------------------
+# Enhanced Monitoring IAM role (gated on var.monitoring_interval)
+# -----------------------------------------------------------------------------
+# RDS Enhanced Monitoring publishes OS-level metrics (CPU / memory / disk / net
+# per-process) to CloudWatch. It is disabled by default in the provider; leaving
+# it off means the reliable2 monitoring surface cannot chart anything below the
+# DB-engine layer. The service assumes this role to write to CW Logs in the
+# RDSOSMetrics log group.
+data "aws_iam_policy_document" "rds_monitoring_assume" {
+  count = var.monitoring_interval > 0 ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["monitoring.rds.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "rds_monitoring" {
+  count              = var.monitoring_interval > 0 ? 1 : 0
+  name               = "${module.name.name}-em"
+  assume_role_policy = data.aws_iam_policy_document.rds_monitoring_assume[0].json
+  tags               = merge(module.name.tags, var.tags)
+}
+
+resource "aws_iam_role_policy_attachment" "rds_monitoring" {
+  count      = var.monitoring_interval > 0 ? 1 : 0
+  role       = aws_iam_role.rds_monitoring[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+# -----------------------------------------------------------------------------
 # Credentials
 # -----------------------------------------------------------------------------
 resource "random_password" "db" {
@@ -122,6 +154,9 @@ resource "aws_db_instance" "primary" {
 
   performance_insights_enabled = true
 
+  monitoring_interval = var.monitoring_interval
+  monitoring_role_arn = var.monitoring_interval > 0 ? aws_iam_role.rds_monitoring[0].arn : null
+
   auto_minor_version_upgrade = true
 
   tags = merge(module.name.tags, var.tags)
@@ -159,6 +194,9 @@ resource "aws_db_instance" "replica" {
   enabled_cloudwatch_logs_exports = var.enable_cloudwatch_logs ? var.cloudwatch_logs_exports : []
 
   performance_insights_enabled = true
+
+  monitoring_interval = var.monitoring_interval
+  monitoring_role_arn = var.monitoring_interval > 0 ? aws_iam_role.rds_monitoring[0].arn : null
 
   tags = merge(module.name.tags, var.tags)
 }

--- a/aws/rds/variables.tf
+++ b/aws/rds/variables.tf
@@ -229,3 +229,13 @@ variable "cloudwatch_logs_exports" {
     error_message = "cloudwatch_logs_exports must be a list (use empty to disable)."
   }
 }
+
+variable "monitoring_interval" {
+  description = "RDS Enhanced Monitoring sampling interval in seconds. 0 disables Enhanced Monitoring; valid non-zero values are 1, 5, 10, 15, 30, 60."
+  type        = number
+  default     = 60
+  validation {
+    condition     = contains([0, 1, 5, 10, 15, 30, 60], var.monitoring_interval)
+    error_message = "monitoring_interval must be one of: 0, 1, 5, 10, 15, 30, 60."
+  }
+}


### PR DESCRIPTION
## Summary

Fifth batch of the #95 umbrella. Every fix is a module-local flip of a provider-default-off telemetry toggle, and each stays self-contained (no external IAM role, S3 bucket, or log group wiring required from callers).

- **`aws/rds`** — Enhanced Monitoring wired to `aws_db_instance.{primary,replica}` via an in-module `aws_iam_role` (trust: `monitoring.rds.amazonaws.com`, `AmazonRDSEnhancedMonitoringRole` managed policy). New `var.monitoring_interval` (default `60`s; `0` disables and skips the role entirely via `count`).
- **`aws/alb`** — New in-module S3 bucket for access logs (`random_id` suffix, 90-day lifecycle expiration, public-access-blocked) + bucket policy granting `s3:PutObject` to `logdelivery.elasticloadbalancing.amazonaws.com` on the account-scoped `AWSLogs/` prefix (portable across opt-in / post-August-2022 regions, where the historical `aws_elb_service_account` approach no longer works). ALB gets `access_logs { enabled = true }`. New `var.access_logs_retention_days` (default `90`).
- **`aws/elasticache`** — `var.enable_cloudwatch_logs` default flipped `false` → `true`. One-character change; the module already owned the log group and `log_delivery_configuration` wiring for engine + slow logs.
- **`aws/lambda`** — `tracing_config { mode = \"Active\" }` on `aws_lambda_function.this` + new `aws_iam_role_policy_attachment.lambda_xray` attaching `AWSXRayDaemonWriteAccess`. The existing `AWSLambdaBasicExecutionRole` does not grant X-Ray permissions on its own.
- **`aws/ec2`** — `monitoring = true` on `aws_instance.this` for 1-minute CW metrics (default is 5-minute), required for any reliable2 chart at sub-5-min granularity.

## Non-breaking

No renamed / removed variables. Two new optional vars, both with defaults:
- `aws/rds` \`monitoring_interval\` → 60
- `aws/alb` \`access_logs_retention_days\` → 90

All other changes flip defaults or add sibling resources. AWS plans each as an in-place update on existing deployed stacks — no recreation of the ALB, RDS instance, Lambda function, EC2 instance, or Redis replication group.

## Test plan

- [x] `terraform fmt -check -recursive` clean
- [x] `terraform validate` passes on `aws/rds`, `aws/alb`, `aws/elasticache`, `aws/lambda`, `aws/ec2`
- [x] `go build ./...` clean
- [x] `bash tests/lint-project-tag.sh` passes (every new taggable AWS resource carries \`merge(module.name.tags, ..., var.tags)\`; no new entries needed in \`NON_TAGGABLE_AWS\`)
- [ ] Example-stack validation delegated to CI (same matrix that green-lit #94 and #96)
- [ ] Post-release: redeploy a test session; confirm (a) Enhanced Monitoring OS-level metrics populate in the RDS console, (b) new ALB access logs appear in \`s3://<project>-alb-logs-<suffix>/AWSLogs/<acct>/...\`, (c) Lambda shows X-Ray segments, (d) EC2 CloudWatch graphs switch to 1-minute resolution, (e) Redis engine + slow log groups receive data.

Refs #95 (phase-2b: OpenSearch \`log_publishing_options\` and MSK \`enhanced_monitoring\` / \`open_monitoring\` still open)