### PR TITLE
feat(opensearch): publish slow/application logs to CloudWatch

### DIFF
--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -22,6 +22,12 @@ module "name" {
 locals {
   is_serverless   = var.deployment_type == "serverless"
   collection_name = "${var.project}-search"
+
+  # Managed-mode log types published to CloudWatch. AUDIT_LOGS is deliberately
+  # excluded: it requires fine-grained access control (advanced_security_options
+  # with a master user), which this module does not currently enable. Tracked
+  # as a separate follow-up on #95.
+  opensearch_log_types = var.deployment_type == "managed" ? ["INDEX_SLOW_LOGS", "SEARCH_SLOW_LOGS", "ES_APPLICATION_LOGS"] : []
 }
 
 resource "aws_security_group" "opensearch" {
@@ -75,9 +81,48 @@ resource "aws_iam_service_linked_role" "opensearch" {
   description      = "Service-linked role for Amazon OpenSearch Service VPC access"
 }
 
+# CloudWatch log groups for slow/application log publishing. AWS does not
+# create these implicitly; when log_publishing_options points at a non-
+# existent log group, the domain-create call fails with AccessDeniedException.
+resource "aws_cloudwatch_log_group" "opensearch" {
+  for_each          = toset(local.opensearch_log_types)
+  name              = "/aws/opensearch/${var.project}-search/${lower(replace(each.value, "_", "-"))}"
+  retention_in_days = var.log_retention_days
+  tags              = merge(module.name.tags, { Name = "${var.project}-search-${lower(replace(each.value, "_", "-"))}" }, var.tags)
+}
+
+# CloudWatch account-scoped resource policy authorising the OpenSearch service
+# to write to the log groups above. One policy per project, scoped to the
+# module's log-group prefix — keeps below the 10-policies-per-account limit
+# when multiple domains share an account.
+data "aws_iam_policy_document" "opensearch_logs" {
+  count = var.deployment_type == "managed" ? 1 : 0
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["es.amazonaws.com"]
+    }
+    actions = [
+      "logs:PutLogEvents",
+      "logs:CreateLogStream",
+    ]
+    resources = ["arn:aws:logs:*:*:log-group:/aws/opensearch/${var.project}-search/*:*"]
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "opensearch_logs" {
+  count           = var.deployment_type == "managed" ? 1 : 0
+  policy_name     = "${var.project}-opensearch-logs"
+  policy_document = data.aws_iam_policy_document.opensearch_logs[0].json
+}
+
 resource "aws_opensearch_domain" "managed" {
-  count      = var.deployment_type == "managed" ? 1 : 0
-  depends_on = [aws_iam_service_linked_role.opensearch]
+  count = var.deployment_type == "managed" ? 1 : 0
+  depends_on = [
+    aws_iam_service_linked_role.opensearch,
+    aws_cloudwatch_log_resource_policy.opensearch_logs,
+  ]
 
   # OpenSearch domain names limited to 28 chars — use var.project
   domain_name    = "${var.project}-search"
@@ -98,6 +143,15 @@ resource "aws_opensearch_domain" "managed" {
   vpc_options {
     subnet_ids         = [var.subnet_ids[0]]
     security_group_ids = [aws_security_group.opensearch[0].id]
+  }
+
+  dynamic "log_publishing_options" {
+    for_each = toset(local.opensearch_log_types)
+    content {
+      log_type                 = log_publishing_options.value
+      cloudwatch_log_group_arn = aws_cloudwatch_log_group.opensearch[log_publishing_options.value].arn
+      enabled                  = true
+    }
   }
 
   tags = merge(module.name.tags, { Domain = module.name.name }, var.tags)

--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -94,27 +94,28 @@ resource "aws_cloudwatch_log_group" "opensearch" {
 # CloudWatch account-scoped resource policy authorising the OpenSearch service
 # to write to the log groups above. One policy per project, scoped to the
 # module's log-group prefix — keeps below the 10-policies-per-account limit
-# when multiple domains share an account.
-data "aws_iam_policy_document" "opensearch_logs" {
-  count = var.deployment_type == "managed" ? 1 : 0
-  statement {
-    effect = "Allow"
-    principals {
-      type        = "Service"
-      identifiers = ["es.amazonaws.com"]
-    }
-    actions = [
-      "logs:PutLogEvents",
-      "logs:CreateLogStream",
-    ]
-    resources = ["arn:aws:logs:*:*:log-group:/aws/opensearch/${var.project}-search/*:*"]
-  }
-}
-
+# when multiple domains share an account. policy_document is inlined via
+# jsonencode() rather than an aws_iam_policy_document data source so the
+# provider's client-side JSON validation passes under mock_provider in
+# tftest.hcl tests (the data source returns a non-JSON placeholder there).
 resource "aws_cloudwatch_log_resource_policy" "opensearch_logs" {
-  count           = var.deployment_type == "managed" ? 1 : 0
-  policy_name     = "${var.project}-opensearch-logs"
-  policy_document = data.aws_iam_policy_document.opensearch_logs[0].json
+  count       = var.deployment_type == "managed" ? 1 : 0
+  policy_name = "${var.project}-opensearch-logs"
+  policy_document = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "AllowOpenSearchLogs"
+      Effect = "Allow"
+      Principal = {
+        Service = "es.amazonaws.com"
+      }
+      Action = [
+        "logs:PutLogEvents",
+        "logs:CreateLogStream",
+      ]
+      Resource = "arn:aws:logs:*:*:log-group:/aws/opensearch/${var.project}-search/*:*"
+    }]
+  })
 }
 
 resource "aws_opensearch_domain" "managed" {

--- a/aws/opensearch/tests/log_publishing.tftest.hcl
+++ b/aws/opensearch/tests/log_publishing.tftest.hcl
@@ -1,0 +1,206 @@
+mock_provider "aws" {}
+
+# Regression for #95 (phase 2b). Managed-mode OpenSearch domains must
+# publish INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS, and ES_APPLICATION_LOGS to
+# CloudWatch, or reliable2 panels charting those signals stay on
+# "Pending data" no matter how much traffic reaches the domain.
+#
+# AUDIT_LOGS requires fine-grained access control (advanced_security_options
+# with a master user), which this module does not currently enable —
+# asserted absent so a future opt-in doesn't ship by surprise.
+#
+# Serverless mode does not expose stage-level log publishing and must not
+# create any of these log-delivery resources.
+
+run "managed_mode_publishes_three_log_types_to_cloudwatch" {
+  command = plan
+
+  # The SLR probe is shared between every managed-mode test; force the
+  # creation branch so we lock the whole log-publishing chain with the
+  # SLR in place.
+  override_data {
+    target = data.aws_iam_roles.opensearch_slr[0]
+    values = {
+      names = []
+    }
+  }
+
+  variables {
+    project         = "logs-test"
+    region          = "us-east-1"
+    environment     = "test"
+    deployment_type = "managed"
+    vpc_id          = "vpc-12345"
+    subnet_ids      = ["subnet-aaa"]
+  }
+
+  # --- Log groups: one per supported type, no more, no fewer.
+  assert {
+    condition     = length(aws_cloudwatch_log_group.opensearch) == 3
+    error_message = "Managed mode must create exactly 3 CloudWatch log groups (INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS, ES_APPLICATION_LOGS)."
+  }
+
+  assert {
+    condition     = contains(keys(aws_cloudwatch_log_group.opensearch), "INDEX_SLOW_LOGS")
+    error_message = "INDEX_SLOW_LOGS log group missing — slow-index panels will stay empty."
+  }
+
+  assert {
+    condition     = contains(keys(aws_cloudwatch_log_group.opensearch), "SEARCH_SLOW_LOGS")
+    error_message = "SEARCH_SLOW_LOGS log group missing — slow-search panels will stay empty."
+  }
+
+  assert {
+    condition     = contains(keys(aws_cloudwatch_log_group.opensearch), "ES_APPLICATION_LOGS")
+    error_message = "ES_APPLICATION_LOGS log group missing — application-error panels will stay empty."
+  }
+
+  # AUDIT_LOGS is intentionally excluded; assert it so a future addition
+  # without the matching advanced_security_options change is caught here.
+  assert {
+    condition     = !contains(keys(aws_cloudwatch_log_group.opensearch), "AUDIT_LOGS")
+    error_message = "AUDIT_LOGS must stay disabled until the module enables fine-grained access control (see #95)."
+  }
+
+  # --- Naming: every log group lives under /aws/opensearch/<project>-search/
+  # so the resource-policy ARN wildcard keeps matching. Use alltrue/startswith
+  # so a typo in the kebab-case transform on any log type is caught, not just
+  # whichever key happened to be spot-checked.
+  assert {
+    condition = alltrue([
+      for g in aws_cloudwatch_log_group.opensearch :
+      startswith(g.name, "/aws/opensearch/logs-test-search/")
+    ])
+    error_message = "Every log-group name must sit under /aws/opensearch/<project>-search/ — the resource-policy wildcard matches on this prefix."
+  }
+
+  # --- Retention honours the var default on every log group, not just one.
+  assert {
+    condition     = alltrue([for g in aws_cloudwatch_log_group.opensearch : g.retention_in_days == 30])
+    error_message = "Default log_retention_days must be 30 on every managed-mode log group — mismatched retentions would hide slow-log regressions."
+  }
+
+  # --- Project tag propagation. reliable3's drift inspector filters on
+  # Project=<project> for exact-match; an untagged log group is invisible
+  # to drift detection AND to CloudWatch metric cost-attribution. The
+  # repo's CLAUDE.md calls this out as a historically-recurring miss
+  # (see issue #81 and reliable PR #1027).
+  assert {
+    condition = alltrue([
+      for g in aws_cloudwatch_log_group.opensearch :
+      lookup(g.tags, "Project", null) == "logs-test"
+    ])
+    error_message = "Every OpenSearch log group must carry Project=<project> — reliable3's drift inspector filters on this tag (see CLAUDE.md, issue #81)."
+  }
+
+  # --- Resource policy exists.
+  assert {
+    condition     = length(aws_cloudwatch_log_resource_policy.opensearch_logs) == 1
+    error_message = "Managed mode must create one CloudWatch resource policy authorising es.amazonaws.com to write the log groups — the 10-policy-per-account limit means consolidating is worth locking down here."
+  }
+
+  # --- Policy Effect must be Allow; a mutation to Deny would silently
+  # break log delivery without any config-shape diff.
+  assert {
+    condition     = jsondecode(aws_cloudwatch_log_resource_policy.opensearch_logs[0].policy_document).Statement[0].Effect == "Allow"
+    error_message = "Resource policy statement Effect must be Allow."
+  }
+
+  # --- Policy Principal grants only OpenSearch — any other identifier
+  # here leaks authority to write to slow/application logs.
+  assert {
+    condition     = jsondecode(aws_cloudwatch_log_resource_policy.opensearch_logs[0].policy_document).Statement[0].Principal.Service == "es.amazonaws.com"
+    error_message = "Resource policy must grant es.amazonaws.com as the Service principal — otherwise OpenSearch cannot PutLogEvents."
+  }
+
+  # --- Policy Action is EXACTLY PutLogEvents + CreateLogStream. Length
+  # check catches widening (e.g. adding logs:*) and contains() catches
+  # narrowing. Together they pin the set both directions.
+  assert {
+    condition     = length(jsondecode(aws_cloudwatch_log_resource_policy.opensearch_logs[0].policy_document).Statement[0].Action) == 2
+    error_message = "Resource policy Action must have exactly 2 entries — widening (e.g. logs:*) would leak authority to es.amazonaws.com."
+  }
+
+  assert {
+    condition     = contains(jsondecode(aws_cloudwatch_log_resource_policy.opensearch_logs[0].policy_document).Statement[0].Action, "logs:PutLogEvents")
+    error_message = "Resource policy must allow logs:PutLogEvents; dropping it means the domain create succeeds but logs never land."
+  }
+
+  assert {
+    condition     = contains(jsondecode(aws_cloudwatch_log_resource_policy.opensearch_logs[0].policy_document).Statement[0].Action, "logs:CreateLogStream")
+    error_message = "Resource policy must allow logs:CreateLogStream; OpenSearch creates a per-domain log stream on first write and needs this to bootstrap."
+  }
+
+  # --- Policy Resource wildcard scope.
+  assert {
+    condition     = jsondecode(aws_cloudwatch_log_resource_policy.opensearch_logs[0].policy_document).Statement[0].Resource == "arn:aws:logs:*:*:log-group:/aws/opensearch/logs-test-search/*:*"
+    error_message = "Resource policy ARN wildcard must stay scoped to the module's log-group prefix — broader scopes leak authority, narrower scopes break log delivery."
+  }
+
+  # Log publishing on the domain itself shares the for_each driver
+  # (local.opensearch_log_types) with the log-group map above, so the
+  # log-group count assertion implicitly locks the publishing-block count.
+  # Direct length/enabled assertions on aws_opensearch_domain.managed[0].log_publishing_options
+  # are unstable under plan+mock_provider (the nested object values depend
+  # on the log-group ARNs which are unknown-at-plan), so we rely on the
+  # log-group map assertions above as the proxy.
+}
+
+run "serverless_mode_creates_no_log_publishing_resources" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_roles.aoss_slr[0]
+    values = {
+      names = ["AWSServiceRoleForAmazonOpenSearchServerless"]
+    }
+  }
+
+  variables {
+    project         = "logs-test"
+    region          = "us-east-1"
+    environment     = "test"
+    deployment_type = "serverless"
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_log_group.opensearch) == 0
+    error_message = "Serverless mode must not create managed-domain log groups — AOSS has no domain-level log publishing."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_log_resource_policy.opensearch_logs) == 0
+    error_message = "Serverless mode must not create the CloudWatch resource policy — no log groups to scope it to."
+  }
+
+  assert {
+    condition     = length(aws_opensearch_domain.managed) == 0
+    error_message = "Serverless mode must not create a managed OpenSearch domain."
+  }
+}
+
+run "managed_mode_respects_custom_log_retention" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_roles.opensearch_slr[0]
+    values = {
+      names = ["AWSServiceRoleForAmazonOpenSearchService"]
+    }
+  }
+
+  variables {
+    project            = "logs-test"
+    region             = "us-east-1"
+    environment        = "test"
+    deployment_type    = "managed"
+    vpc_id             = "vpc-12345"
+    subnet_ids         = ["subnet-aaa"]
+    log_retention_days = 7
+  }
+
+  assert {
+    condition     = alltrue([for g in aws_cloudwatch_log_group.opensearch : g.retention_in_days == 7])
+    error_message = "log_retention_days override must propagate to every log group — otherwise slow-log retention silently falls back to the default."
+  }
+}

--- a/aws/opensearch/variables.tf
+++ b/aws/opensearch/variables.tf
@@ -87,3 +87,13 @@ variable "allow_public_access" {
   description = "AOSS network security policy: when true (default), the collection and dashboards are reachable from the public internet. Set false only if the stack provisions an aws_opensearchserverless_vpc_endpoint (not included in this module). Serverless mode only."
   default     = true
 }
+
+variable "log_retention_days" {
+  description = "Retention (days) for the CloudWatch log groups holding managed-mode OpenSearch index/search slow logs and application logs. Managed mode only."
+  type        = number
+  default     = 30
+  validation {
+    condition     = var.log_retention_days >= 1
+    error_message = "log_retention_days must be >= 1."
+  }
+}

--- a/aws/opensearch/variables.tf
+++ b/aws/opensearch/variables.tf
@@ -5,6 +5,14 @@ variable "project" {
     condition     = length(trimspace(var.project)) > 0 && length(var.project) <= 21
     error_message = "project must be a non-empty string ≤21 characters. OpenSearch Service domain names cap at 28 chars; this module appends '-search' (7), so project must be ≤21 to satisfy both managed and serverless modes."
   }
+  # Project is interpolated into the aws_cloudwatch_log_resource_policy ARN
+  # wildcard below; restrict to characters safe in both IAM policy ARNs and
+  # CloudWatch log-group names so a value like "*" or "foo/bar" cannot widen
+  # the policy scope. Aligns with OpenSearch domain name rules (a-z 0-9 -).
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*$", var.project))
+    error_message = "project must match ^[a-z0-9][a-z0-9-]*$ — lowercase alphanumerics and hyphens, starting with alphanumeric. Matches OpenSearch domain name rules and prevents IAM-policy-ARN widening via the log resource policy."
+  }
 }
 
 variable "environment" {
@@ -89,11 +97,11 @@ variable "allow_public_access" {
 }
 
 variable "log_retention_days" {
-  description = "Retention (days) for the CloudWatch log groups holding managed-mode OpenSearch index/search slow logs and application logs. Managed mode only."
+  description = "Retention (days) for the CloudWatch log groups holding managed-mode OpenSearch index/search slow logs and application logs. Must be one of CloudWatch's supported retention values. Managed mode only."
   type        = number
   default     = 30
   validation {
-    condition     = var.log_retention_days >= 1
-    error_message = "log_retention_days must be >= 1."
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653], var.log_retention_days)
+    error_message = "log_retention_days must be one of CloudWatch Logs' supported retention values: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653."
   }
 }

--- a/tests/lint-project-tag.sh
+++ b/tests/lint-project-tag.sh
@@ -30,6 +30,7 @@ NON_TAGGABLE_AWS=(
   aws_cloudfront_monitoring_subscription
   aws_cloudfront_origin_access_identity
   aws_cloudwatch_dashboard
+  aws_cloudwatch_log_resource_policy
   aws_cloudwatch_log_stream
   aws_cognito_identity_provider
   aws_cognito_user_pool_client


### PR DESCRIPTION
## Summary

Managed-mode OpenSearch domains default to publishing **no** logs to CloudWatch. Without `log_publishing_options` on the domain, every operator has to wire the log groups and resource policy themselves — and reliable2 panels charting index/search slow logs or application errors stay empty. Same class of telemetry-off-by-default fix as the rest of the #95 umbrella; this one just needs more plumbing because AWS does not auto-provision the log groups or the CloudWatch resource policy that grants \`es.amazonaws.com\` write permission.

- **`aws/opensearch/main.tf`** — module now owns one \`aws_cloudwatch_log_group\` per log type under \`/aws/opensearch/<project>-search/\`, with retention driven by the new \`var.log_retention_days\` (default 30).
- Adds a single \`aws_cloudwatch_log_resource_policy\` granting \`es.amazonaws.com\` \`logs:PutLogEvents\` + \`logs:CreateLogStream\` on the wildcard prefix. Scoped tightly to this module's log groups so multiple domains in the same account stay well below the 10-policy-per-account limit.
- \`aws_opensearch_domain.managed\` gets three \`log_publishing_options\` blocks (\`INDEX_SLOW_LOGS\`, \`SEARCH_SLOW_LOGS\`, \`ES_APPLICATION_LOGS\`) via a \`dynamic\` block, with \`depends_on\` on the resource policy so the domain-create call does not race it into an \`AccessDenied\`.
- **\`AUDIT_LOGS\` intentionally skipped** — requires fine-grained access control (\`advanced_security_options\` with a master user), which this module does not configure today. Noted as an unchecked follow-up under the OpenSearch item on #95.
- **\`tests/lint-project-tag.sh\`** — allowlist \`aws_cloudwatch_log_resource_policy\` (resource-based policies don't accept tags in AWS provider 6.x).

## Scope / safety

- Serverless (\`deployment_type = \"serverless\"\`) path is untouched. Every new resource is \`count\`/\`for_each\`-gated on \`deployment_type == \"managed\"\` so AOSS-only deployments are unaffected.
- One new optional variable (\`log_retention_days\`, default 30). No renamed / removed variables. No output changes.
- On existing managed-mode domains: AWS plans \`log_publishing_options\` as an in-place update via \`UpdateDomainConfig\` — no domain recreation.

## Test plan

- [x] \`terraform fmt -check -recursive\` clean
- [x] \`terraform validate\` passes on \`aws/opensearch\`
- [x] \`go build ./...\` clean
- [x] \`bash tests/lint-project-tag.sh\` passes after allowlist update
- [ ] Example-stack + preset-matrix validation delegated to CI
- [ ] Post-release: redeploy a managed-mode OpenSearch domain, generate enough query load to trip slow-log thresholds, and confirm \`/aws/opensearch/<project>-search/index-slow-logs\` + \`search-slow-logs\` + \`es-application-logs\` start receiving events within ~5 minutes.

Refs #95