### PR TITLE
feat(msk): default enhanced_monitoring to PER_BROKER

### DIFF
--- a/aws/msk/tests/enhanced_monitoring.tftest.hcl
+++ b/aws/msk/tests/enhanced_monitoring.tftest.hcl
@@ -1,0 +1,49 @@
+mock_provider "aws" {}
+
+# Regression for #95 (phase 2c). MSK's aws_msk_cluster.enhanced_monitoring
+# maps directly onto AWS/Kafka CloudWatch metric fan-out:
+#
+#   DEFAULT              -> 6 broker-level metrics (cluster aggregates only)
+#   PER_BROKER           -> ~23 broker metrics (CPU/mem/net/disk per broker)
+#   PER_TOPIC_PER_BROKER -> PER_BROKER + per-topic throughput & lag
+#
+# Default must be PER_BROKER so reliable2 panels charting broker-level CPU,
+# memory, network, and disk populate without any override — same "on by
+# default" principle as every other preset in this umbrella. If someone
+# reverts to DEFAULT to trim cost they should do it via an explicit
+# override in the stack config, not by flipping the module default back.
+
+run "default_enhanced_monitoring_is_per_broker" {
+  command = plan
+
+  variables {
+    project     = "test"
+    region      = "us-east-1"
+    environment = "test"
+    vpc_id      = "vpc-12345"
+    subnet_ids  = ["subnet-aaa", "subnet-bbb", "subnet-ccc"]
+  }
+
+  assert {
+    condition     = aws_msk_cluster.this.enhanced_monitoring == "PER_BROKER"
+    error_message = "Default enhanced_monitoring must be PER_BROKER — dropping back to DEFAULT silently loses broker-level CPU/memory/network/disk metrics that reliable2 panels chart."
+  }
+}
+
+run "enhanced_monitoring_override_wins" {
+  command = plan
+
+  variables {
+    project             = "test"
+    region              = "us-east-1"
+    environment         = "test"
+    vpc_id              = "vpc-12345"
+    subnet_ids          = ["subnet-aaa", "subnet-bbb", "subnet-ccc"]
+    enhanced_monitoring = "DEFAULT"
+  }
+
+  assert {
+    condition     = aws_msk_cluster.this.enhanced_monitoring == "DEFAULT"
+    error_message = "Caller override (var.enhanced_monitoring) must reach the cluster — otherwise cost-sensitive callers can't opt out."
+  }
+}

--- a/aws/msk/variables.tf
+++ b/aws/msk/variables.tf
@@ -139,9 +139,9 @@ variable "cloudwatch_retention_days" {
 }
 
 variable "enhanced_monitoring" {
-  description = "MSK enhanced monitoring level: DEFAULT | PER_BROKER | PER_TOPIC_PER_BROKER"
+  description = "MSK enhanced monitoring level: DEFAULT (6 broker metrics) | PER_BROKER (~23 metrics/broker, CPU/memory/network/disk) | PER_TOPIC_PER_BROKER (PER_BROKER + per-topic throughput/lag). Default is PER_BROKER so reliable2 panels charting broker-level AWS/Kafka metrics populate out of the box; override to DEFAULT on large clusters where CloudWatch metric cost (~$0.30/metric/broker/month for the ~17 additional PER_BROKER metrics) matters."
   type        = string
-  default     = "DEFAULT"
+  default     = "PER_BROKER"
   validation {
     condition     = contains(["DEFAULT", "PER_BROKER", "PER_TOPIC_PER_BROKER"], var.enhanced_monitoring)
     error_message = "enhanced_monitoring must be one of: DEFAULT, PER_BROKER, PER_TOPIC_PER_BROKER."


### PR DESCRIPTION
## Summary

Final phase-2c item from #95. MSK's DEFAULT enhanced_monitoring level publishes only 6 cluster-aggregate metrics to \`AWS/Kafka\`; PER_BROKER unlocks ~23 broker-level metrics (CPU / memory / network / disk per broker) that reliable2 panels need to chart per-broker health. Flipping the default aligns with every other preset in the umbrella: on-by-default observability, callers who want to trim cost override via \`var.enhanced_monitoring = \"DEFAULT\"\`.

- \`aws/msk/variables.tf\` — default flipped \`\"DEFAULT\"\` → \`\"PER_BROKER\"\`; description expanded to document the three levels, their metric counts, and the cost trade-off.
- \`aws/msk/tests/enhanced_monitoring.tftest.hcl\` (new) — two plan-mode runs: (1) default lands as PER_BROKER on the cluster resource, (2) caller override to DEFAULT still wins. So a future revert of the default fails loudly instead of silently dropping broker metrics.

## Cost impact

- ~17 additional custom CloudWatch metrics per broker at \$0.30/metric/month.
- 3-broker test cluster: ~\$15/month (negligible).
- 10-broker production cluster: ~\$50/month.
- Callers on large clusters opt out with \`var.enhanced_monitoring = \"DEFAULT\"\` in their stack config; no code change required.

## Non-breaking

- Existing stacks that don't pass \`var.enhanced_monitoring\` pick up PER_BROKER on next apply. AWS plans this as an in-place update (\`UpdateClusterConfiguration\`) — no cluster recreation.
- Existing stacks that explicitly pass \`\"DEFAULT\"\` or any other valid level are unchanged.

## Test plan

- [x] \`terraform fmt -check -recursive\` clean
- [x] \`terraform test\` in \`aws/msk/\` passes (2/2 new runs)
- [x] \`terraform validate\` on \`aws/msk\`
- [x] \`bash tests/lint-project-tag.sh\` passes
- [x] \`go build ./...\` clean
- [ ] CI matrix (presets + examples + tests) delegated to GitHub Actions

Refs #95 (this closes the CloudWatch-surface phase of the umbrella; \`aws/msk\` \`open_monitoring\` / Prometheus and \`aws/opensearch\` \`AUDIT_LOGS\` remain as follow-ups pending downstream scraping and fine-grained-access-control design respectively).