### PR TITLE
Add GCP project-label CI lint mirroring AWS Project-tag

### DIFF
--- a/.claude/skills/add-gcp-module/SKILL.md
+++ b/.claude/skills/add-gcp-module/SKILL.md
@@ -38,7 +38,7 @@ Key rules:
 - Otherwise use direct `google_*` resources
 - If the module needs the `random` provider, add it with `>= 3.5`
 - Enable encryption, enforce least-privilege IAM by default
-- **Label every labelable resource** with `labels = merge(..., var.labels)` (merging in module-scoped labels where available) so `Project` identity propagates to the inspector.
+- **Label every labelable resource** with `labels = merge({ project = var.project }, var.labels)` so `Project` identity propagates to the inspector. Coverage is CI-enforced by `tests/lint-project-label.sh` — if you add a new label-capable resource type, add it to the `LABEL_CAPABLE_GCP` allowlist in that script.
 
 ### 3. Create variables.tf
 

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -81,20 +81,16 @@ bash tests/lint-project-tag.sh
 
 It reports any taggable AWS resource missing the Project-tag convention. The script ships with a `NON_TAGGABLE_AWS` whitelist of resource types that genuinely don't accept tags in AWS provider 6.x; if CI flags a new hit, either add the `tags` line (usual case) or append to the whitelist with a clear rationale.
 
-**GCP** isn't CI-enforced (too many "no labels arg" resources to maintain a clean whitelist). Audit by hand with:
+**GCP is enforced in CI** via `tests/lint-project-label.sh` (wired into the `lint` job alongside the AWS script). Run it locally the same way:
 
 ```bash
-for f in gcp/*/main.tf; do
-  awk '
-    /^resource "google_/ { name=$0; has_labels=0; next }
-    /^  labels[[:space:]]*=/ { has_labels=1 }
-    /^  user_labels[[:space:]]*=/ { has_labels=1 }
-    /^}/ { if (name != "" && !has_labels) print FILENAME": "name; name=""; has_labels=0 }
-  ' "$f"
-done
+bash tests/lint-project-label.sh
 ```
 
-Hand-verify each hit against the provider docs before reporting a gap.
+Unlike AWS (where most resources accept tags), the GCP script uses an ALLOWLIST of resource types known to support `labels` in the Google provider v5.x/v6.x. When adding a new GCP resource type:
+
+- If the [provider docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/) show a `labels` attribute, add the type to `LABEL_CAPABLE_GCP` in `tests/lint-project-label.sh` (alphabetically) and set `labels = merge({ project = var.project }, var.labels)` on the resource.
+- If the resource does not accept labels, no action is needed — the script ignores it.
 
 ### 6. Region Reference Audit (AWS)
 

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Lint Project-tag coverage (AWS)
         run: bash tests/lint-project-tag.sh
 
+      - name: Lint project-label coverage (GCP)
+        run: bash tests/lint-project-label.sh
+
   format-check:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ These preset files are embedded at build time into the [reliable](https://github
 - **Defaults matter:** Variables without defaults become required root variables — the mapper MUST provide values or deploy fails
 - **Wiring outputs:** Outputs used for cross-module wiring (e.g., `vpc_id`, `private_subnet_ids`) must be declared in `outputs.tf`
 - **Project tag is required on every taggable AWS resource.** Use `tags = merge(module.name.tags, var.tags)` so the `Project` tag emitted by `module.name.tags` reaches the resource. The downstream reliable3 inspector filters on exact `Project = <project>` match, so untagged resources are invisible to drift detection and CloudWatch metrics (see issue #81, [reliable PR #1027](https://github.com/luthersystems/reliable/pull/1027)). If a resource accepts any tag-shaped attribute (including listeners, instance profiles, and IAM roles/policies in provider 5.x+), tag it.
-- **GCP mirror:** every labelable GCP resource must set `labels = merge(<module-labels>, var.labels)` (or equivalent) so project identity propagates.
+- **GCP mirror:** every labelable GCP resource must set `labels = merge({ project = var.project }, var.labels)` (or equivalent) so project identity propagates. Enforced in CI by `tests/lint-project-label.sh` using an allowlist of label-capable resource types (see script header for how to extend).
 
 ## Skills
 

--- a/gcp/cloud_armor/main.tf
+++ b/gcp/cloud_armor/main.tf
@@ -1,5 +1,6 @@
 resource "google_compute_security_policy" "policy" {
-  name = "main-policy"
+  name    = "main-policy"
+  project = var.project
   rule {
     action   = "allow"
     priority = "2147483647"
@@ -11,4 +12,11 @@ resource "google_compute_security_policy" "policy" {
     }
     description = "Default rule"
   }
+
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
 }

--- a/gcp/cloud_armor/variables.tf
+++ b/gcp/cloud_armor/variables.tf
@@ -1,2 +1,8 @@
 variable "project" { type = string }
 variable "region" { type = string }
+
+variable "labels" {
+  description = "Labels to apply"
+  type        = map(string)
+  default     = {}
+}

--- a/gcp/cloudsql/main.tf
+++ b/gcp/cloudsql/main.tf
@@ -22,6 +22,13 @@ resource "google_compute_global_address" "private_ip_address" {
   address_type  = "INTERNAL"
   prefix_length = 16
   network       = var.network_self_link
+
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
 }
 
 resource "google_service_networking_connection" "private_vpc_connection" {

--- a/gcp/loadbalancer/main.tf
+++ b/gcp/loadbalancer/main.tf
@@ -148,6 +148,13 @@ resource "google_compute_target_http_proxy" "this" {
 resource "google_compute_global_address" "this" {
   name    = "${local.name_prefix}-ip"
   project = var.project
+
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
 }
 
 # HTTPS forwarding rule

--- a/gcp/vertex_ai/main.tf
+++ b/gcp/vertex_ai/main.tf
@@ -2,4 +2,12 @@ resource "google_vertex_ai_dataset" "dataset" {
   display_name        = "main-dataset"
   metadata_schema_uri = "gs://google-cloud-aiplatform/schema/dataset/metadata/image_1.0.0.yaml"
   region              = var.region
+  project             = var.project
+
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
 }

--- a/gcp/vertex_ai/variables.tf
+++ b/gcp/vertex_ai/variables.tf
@@ -1,2 +1,8 @@
 variable "project" { type = string }
 variable "region" { type = string }
+
+variable "labels" {
+  description = "Labels to apply"
+  type        = map(string)
+  default     = {}
+}

--- a/tests/lint-project-label.sh
+++ b/tests/lint-project-label.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Static analysis: every GCP resource that SUPPORTS labels must carry
+#   labels = merge({ project = var.project }, var.labels)
+# (or an equivalent merge containing the module's project-bearing labels) so
+# the Project label emitted by the module reaches the resource. This mirrors
+# the AWS Project-tag convention enforced by lint-project-tag.sh — the
+# downstream reliable3 inspector filters GCP resources by exact
+# project = <project> label match.
+#
+# Unlike AWS (where most resources accept tags), the majority of GCP
+# resources DO NOT accept a labels attribute. This script uses an ALLOWLIST
+# of resource types that are known to support `labels` in the Google
+# provider v5.x/v6.x. If you add a new GCP resource type and CI flags it as
+# not on the allowlist, verify against the provider docs
+# (registry.terraform.io/providers/hashicorp/google/latest/docs/resources/<name>):
+#   - If the resource supports labels: add the type to LABEL_CAPABLE_GCP
+#     below and set labels = merge(...) on the resource.
+#   - If the resource does NOT support labels: no action needed; the script
+#     ignores it.
+#
+# Scope: GCP only. See tests/lint-project-tag.sh for the AWS companion.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# GCP resource types that accept a `labels` attribute in the Google provider
+# v5.x/v6.x. Verified against registry.terraform.io provider docs.
+# Keep sorted alphabetically.
+LABEL_CAPABLE_GCP=(
+  google_api_gateway_api
+  google_api_gateway_api_config
+  google_api_gateway_gateway
+  google_cloud_run_v2_service
+  google_cloudfunctions2_function
+  google_compute_global_address
+  google_compute_global_forwarding_rule
+  google_compute_instance
+  google_compute_security_policy
+  google_pubsub_subscription
+  google_pubsub_topic
+  google_redis_instance
+  google_secret_manager_secret
+  google_storage_bucket
+  google_vertex_ai_dataset
+)
+
+allow_pattern="^($(IFS='|'; echo "${LABEL_CAPABLE_GCP[*]}"))$"
+
+echo "=== Checking GCP resources for project label (labels = merge({ project = var.project }, var.labels)) ==="
+echo
+
+any_fail=0
+for f in "$REPO_ROOT"/gcp/*/main.tf; do
+  [ -f "$f" ] || continue
+  awk -v allow_pattern="$allow_pattern" '
+    BEGIN { in_res=0; failed=0 }
+    /^resource "google_/ {
+      in_res=1
+      res=$2; gsub(/"/, "", res)
+      start=NR
+      has_labels=0
+      check_this=(res ~ allow_pattern)
+      next
+    }
+    in_res && /^  labels[[:space:]]*=/ { has_labels=1 }
+    in_res && /^}/ {
+      if (check_this && !has_labels) {
+        printf "ERROR: %s:%d: resource %s missing labels = merge({ project = var.project }, var.labels)\n", FILENAME, start, res
+        failed=1
+      }
+      in_res=0
+    }
+    END { exit (failed ? 1 : 0) }
+  ' "$f" || any_fail=1
+done
+
+if (( any_fail )); then
+  echo
+  echo "FAIL: One or more label-capable GCP resources are missing the project-label convention."
+  echo "Fix: add  labels = merge({ project = var.project }, var.labels)  to each resource."
+  echo "If you've added a new label-capable GCP resource type, also add it to"
+  echo "LABEL_CAPABLE_GCP in tests/lint-project-label.sh (alphabetically)."
+  exit 1
+fi
+
+echo "PASS: All label-capable GCP resources carry the project-label convention."


### PR DESCRIPTION
## Summary

- Adds `tests/lint-project-label.sh` — GCP mirror of the AWS Project-tag lint. Uses an allowlist of resource types known to support `labels` in Google provider v5.x/v6.x and enforces `labels = merge({ project = var.project }, var.labels)` on each.
- Wires it into the CI `lint` job alongside the existing `lint-project-tag.sh`.
- Fixes four real gaps found during the audit: `google_compute_global_address` in `cloudsql` and `loadbalancer`, `google_compute_security_policy` in `cloud_armor`, and `google_vertex_ai_dataset` in `vertex_ai`. The last two also needed `var.labels` added and `project` bound.
- Updates `/audit`, `/add-gcp-module`, and `CLAUDE.md` to document the lint and how to extend its allowlist.

## Why now

AWS tagging has been CI-enforced for a while, but GCP was hand-audited only. The audit skill said GCP had "too many no-labels resources to maintain a clean whitelist" — that's backwards for GCP: because so few resources support labels, an **allowlist** of label-capable types stays small and stable. 15 resource types covers every GCP resource currently in the repo that actually accepts labels.

Followup: #103 tracks fleshing out the `cloud_armor` and `vertex_ai` modules, which today are thin stubs.

## Test plan

- [x] `bash tests/lint-project-tag.sh` — PASS (no AWS regression)
- [x] `bash tests/lint-project-label.sh` — PASS on current tree
- [x] Negative test: injected a `google_compute_global_address` without `labels` into a throwaway file — script correctly reports `ERROR: ... missing labels = merge(...)`
- [x] `terraform fmt -check -recursive` — clean
- [x] `terraform validate` on all modified modules — clean
- [ ] GitHub Actions `lint` job runs both scripts and passes