### PR TITLE
feat(gcp): flesh out cloud_armor and vertex_ai modules

### DIFF
--- a/gcp/cloud_armor/main.tf
+++ b/gcp/cloud_armor/main.tf
@@ -1,16 +1,100 @@
+# GCP Cloud Armor Security Policy
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_security_policy
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+locals {
+  policy_name = "${var.project}-${var.name}"
+}
+
 resource "google_compute_security_policy" "policy" {
-  name    = "main-policy"
-  project = var.project
+  name        = local.policy_name
+  project     = var.project
+  description = var.description
+
+  # Default rule — priority 2147483647 is required by the API and
+  # functions as the catch-all. Override action via var.default_action.
   rule {
-    action   = "allow"
-    priority = "2147483647"
+    action      = var.default_action
+    priority    = "2147483647"
+    description = "Default ${var.default_action} rule"
     match {
       versioned_expr = "SRC_IPS_V1"
       config {
         src_ip_ranges = ["*"]
       }
     }
-    description = "Default rule"
+  }
+
+  dynamic "rule" {
+    for_each = { for r in var.rules : r.priority => r }
+    content {
+      action      = rule.value.action
+      priority    = rule.value.priority
+      description = rule.value.description
+      match {
+        versioned_expr = "SRC_IPS_V1"
+        config {
+          src_ip_ranges = rule.value.src_ip_ranges
+        }
+      }
+    }
+  }
+
+  dynamic "rule" {
+    for_each = { for r in var.preconfigured_waf_rules : r.priority => r }
+    content {
+      action      = rule.value.action
+      priority    = rule.value.priority
+      description = "WAF: ${rule.value.expression}"
+      match {
+        expr {
+          expression = "evaluatePreconfiguredExpr('${rule.value.expression}')"
+        }
+      }
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.rate_limit == null ? [] : [var.rate_limit]
+    content {
+      action      = "rate_based_ban"
+      priority    = rule.value.priority
+      description = "Rate limit"
+      match {
+        versioned_expr = "SRC_IPS_V1"
+        config {
+          src_ip_ranges = ["*"]
+        }
+      }
+      rate_limit_options {
+        conform_action   = "allow"
+        exceed_action    = rule.value.exceed_action
+        enforce_on_key   = rule.value.enforce_on_key
+        ban_duration_sec = rule.value.ban_duration_sec
+        rate_limit_threshold {
+          count        = rule.value.count
+          interval_sec = rule.value.interval_sec
+        }
+      }
+    }
+  }
+
+  dynamic "adaptive_protection_config" {
+    for_each = var.adaptive_protection_enabled ? [1] : []
+    content {
+      layer_7_ddos_defense_config {
+        enable = true
+      }
+    }
   }
 
   labels = merge(

--- a/gcp/cloud_armor/outputs.tf
+++ b/gcp/cloud_armor/outputs.tf
@@ -1,4 +1,19 @@
 output "security_policy_id" {
   value       = google_compute_security_policy.policy.self_link
-  description = "The self link of the Cloud Armor security policy"
+  description = "DEPRECATED: use self_link. Kept for backward compatibility with existing composer wiring."
+}
+
+output "policy_id" {
+  value       = google_compute_security_policy.policy.id
+  description = "The resource ID of the Cloud Armor security policy"
+}
+
+output "self_link" {
+  value       = google_compute_security_policy.policy.self_link
+  description = "The self link of the Cloud Armor security policy (used to attach to backend services)"
+}
+
+output "name" {
+  value       = google_compute_security_policy.policy.name
+  description = "The fully-qualified name of the Cloud Armor security policy"
 }

--- a/gcp/cloud_armor/variables.tf
+++ b/gcp/cloud_armor/variables.tf
@@ -1,5 +1,91 @@
-variable "project" { type = string }
-variable "region" { type = string }
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region (unused — Cloud Armor policies are global; kept for composer convention)"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "name" {
+  description = "Name suffix for the security policy (prefixed with project)"
+  type        = string
+  default     = "policy"
+}
+
+variable "description" {
+  description = "Description of the security policy"
+  type        = string
+  default     = "Cloud Armor policy managed by Terraform"
+}
+
+variable "default_action" {
+  description = "Action for the default (catch-all) rule. 'allow' or a 'deny(<code>)' variant."
+  type        = string
+  default     = "allow"
+
+  validation {
+    condition     = contains(["allow", "deny(403)", "deny(404)", "deny(502)"], var.default_action)
+    error_message = "default_action must be one of: allow, deny(403), deny(404), deny(502)."
+  }
+}
+
+variable "rules" {
+  description = "Custom IP-range rules. Priorities must be unique and below 2147483647."
+  type = list(object({
+    priority      = number
+    action        = string
+    description   = string
+    src_ip_ranges = list(string)
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for r in var.rules : r.priority < 2147483647 && r.priority >= 0])
+    error_message = "Each rule priority must be in [0, 2147483646]."
+  }
+}
+
+variable "preconfigured_waf_rules" {
+  description = "Google-provided WAF expressions (e.g., 'sqli-v33-stable', 'xss-v33-stable'). See https://cloud.google.com/armor/docs/rule-tuning."
+  type = list(object({
+    priority   = number
+    action     = string
+    expression = string
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for r in var.preconfigured_waf_rules : r.priority < 2147483647 && r.priority >= 0])
+    error_message = "Each preconfigured_waf_rules priority must be in [0, 2147483646]."
+  }
+}
+
+variable "rate_limit" {
+  description = "Optional rate-based ban applied to all source IPs. Null disables rate limiting."
+  type = object({
+    priority         = number
+    count            = number
+    interval_sec     = number
+    enforce_on_key   = string
+    exceed_action    = string
+    ban_duration_sec = number
+  })
+  default = null
+
+  validation {
+    condition     = var.rate_limit == null ? true : contains(["IP", "ALL", "HTTP_HEADER", "XFF_IP", "HTTP_COOKIE", "HTTP_PATH", "SNI", "REGION_CODE"], var.rate_limit.enforce_on_key)
+    error_message = "rate_limit.enforce_on_key must be a valid Cloud Armor enforce key."
+  }
+}
+
+variable "adaptive_protection_enabled" {
+  description = "Enable Layer 7 DDoS adaptive protection"
+  type        = bool
+  default     = false
+}
 
 variable "labels" {
   description = "Labels to apply"

--- a/gcp/vertex_ai/main.tf
+++ b/gcp/vertex_ai/main.tf
@@ -1,8 +1,40 @@
+# GCP Vertex AI Dataset
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_dataset
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+locals {
+  metadata_schemas = {
+    image       = "gs://google-cloud-aiplatform/schema/dataset/metadata/image_1.0.0.yaml"
+    text        = "gs://google-cloud-aiplatform/schema/dataset/metadata/text_1.0.0.yaml"
+    tabular     = "gs://google-cloud-aiplatform/schema/dataset/metadata/tabular_1.0.0.yaml"
+    video       = "gs://google-cloud-aiplatform/schema/dataset/metadata/video_1.0.0.yaml"
+    time_series = "gs://google-cloud-aiplatform/schema/dataset/metadata/time_series_1.0.0.yaml"
+  }
+
+  resolved_schema_uri = coalesce(var.metadata_schema_uri, local.metadata_schemas[var.dataset_type])
+}
+
 resource "google_vertex_ai_dataset" "dataset" {
-  display_name        = "main-dataset"
-  metadata_schema_uri = "gs://google-cloud-aiplatform/schema/dataset/metadata/image_1.0.0.yaml"
+  display_name        = var.dataset_name
+  metadata_schema_uri = local.resolved_schema_uri
   region              = var.region
   project             = var.project
+
+  dynamic "encryption_spec" {
+    for_each = var.encryption_kms_key_name == null ? [] : [var.encryption_kms_key_name]
+    content {
+      kms_key_name = encryption_spec.value
+    }
+  }
 
   labels = merge(
     {

--- a/gcp/vertex_ai/outputs.tf
+++ b/gcp/vertex_ai/outputs.tf
@@ -1,9 +1,19 @@
 output "dataset_id" {
   value       = google_vertex_ai_dataset.dataset.id
-  description = "The ID of the Vertex AI dataset"
+  description = "The resource ID of the Vertex AI dataset"
 }
 
 output "dataset_name" {
   value       = google_vertex_ai_dataset.dataset.display_name
   description = "The display name of the Vertex AI dataset"
+}
+
+output "dataset_resource_name" {
+  value       = google_vertex_ai_dataset.dataset.name
+  description = "The full resource name of the Vertex AI dataset (projects/<n>/locations/<r>/datasets/<id>)"
+}
+
+output "region" {
+  value       = google_vertex_ai_dataset.dataset.region
+  description = "The region of the Vertex AI dataset"
 }

--- a/gcp/vertex_ai/variables.tf
+++ b/gcp/vertex_ai/variables.tf
@@ -1,5 +1,47 @@
-variable "project" { type = string }
-variable "region" { type = string }
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the Vertex AI dataset"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "dataset_name" {
+  description = "Display name of the Vertex AI dataset"
+  type        = string
+  default     = "main-dataset"
+}
+
+variable "dataset_type" {
+  description = "Dataset type. Picks the default metadata_schema_uri. One of: image, text, tabular, video, time_series."
+  type        = string
+  default     = "image"
+
+  validation {
+    condition     = contains(["image", "text", "tabular", "video", "time_series"], var.dataset_type)
+    error_message = "dataset_type must be one of: image, text, tabular, video, time_series."
+  }
+}
+
+variable "metadata_schema_uri" {
+  description = "Override for metadata_schema_uri. Null picks a schema from dataset_type."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.metadata_schema_uri == null ? true : startswith(var.metadata_schema_uri, "gs://google-cloud-aiplatform/schema/dataset/metadata/")
+    error_message = "metadata_schema_uri must be a gs:// URI under gs://google-cloud-aiplatform/schema/dataset/metadata/."
+  }
+}
+
+variable "encryption_kms_key_name" {
+  description = "Fully-qualified KMS CMEK (projects/<p>/locations/<l>/keyRings/<k>/cryptoKeys/<c>) to encrypt the dataset. Null disables CMEK."
+  type        = string
+  default     = null
+}
 
 variable "labels" {
   description = "Labels to apply"


### PR DESCRIPTION
## Summary

Both modules were single-resource stubs with hardcoded names. This parameterizes them per the acceptance criteria in #103.

### cloud_armor
- Parameterize `name`, `description`, and default-rule action (`allow` / `deny(403|404|502)`).
- `var.rules` — list of custom IP-range rules (priority / action / description / src_ip_ranges).
- `var.preconfigured_waf_rules` — OWASP-style rules via `evaluatePreconfiguredExpr()` (e.g. `sqli-v33-stable`, `xss-v33-stable`).
- `var.rate_limit` — optional rate-based ban (threshold / interval / enforce_on_key / exceed_action / ban duration).
- `var.adaptive_protection_enabled` — Layer 7 DDoS toggle.
- New outputs: `policy_id`, `self_link`, `name`. `security_policy_id` kept as a deprecated alias for existing composer wiring.

### vertex_ai
- Parameterize `dataset_name`.
- `var.dataset_type` selects `metadata_schema_uri` from a known set (`image` / `text` / `tabular` / `video` / `time_series`). Override via `var.metadata_schema_uri` (validated against the google-cloud-aiplatform schema bucket).
- Optional CMEK via `var.encryption_kms_key_name`.
- New outputs: `dataset_resource_name`, `region`.

## Breaking change notes

Neither module is referenced by any example in `examples/`, so no downstream wiring breaks. The `security_policy_id` output is preserved as an alias for `self_link` to keep the composer's existing mapping working.

## Test plan

- [x] `terraform validate` — both modules pass
- [x] `terraform fmt -check -recursive` — clean
- [x] `tests/lint-project-tag.sh` — PASS
- [x] `tests/lint-project-label.sh` — PASS
- [ ] CI matrix (validate-presets, lint, format-check) passes on this PR

Closes #103