### PR TITLE
fix: emit provider default_tags + tighten preset tagging consistency

### DIFF
--- a/aws/cloudwatchmonitoring/main.tf
+++ b/aws/cloudwatchmonitoring/main.tf
@@ -237,4 +237,9 @@ locals {
 resource "aws_cloudwatch_dashboard" "main" {
   dashboard_name = module.name.name
   dashboard_body = jsonencode({ widgets = local.dash_metrics })
+  # NOTE: aws_cloudwatch_dashboard does not accept a `tags` argument in
+  # the hashicorp/aws provider (as of v6.33.0). CloudWatch dashboards are
+  # therefore untaggable from Terraform, even though the AWS API supports
+  # it. When/if the provider adds the argument, add:
+  #   tags = merge(module.name.tags, var.tags)
 }

--- a/aws/ecs/main.tf
+++ b/aws/ecs/main.tf
@@ -11,7 +11,20 @@ terraform {
   }
 }
 
+module "name" {
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
+  luther_project = var.project
+  aws_region     = var.region
+  luther_env     = var.environment
+  org_name       = "luthersystems"
+  component      = "insideout"
+  subcomponent   = "ecs"
+  resource       = "ecs"
+}
+
 locals {
+  # Cluster name is an immutable ForceNew attribute on aws_ecs_cluster;
+  # preserve the historical format to avoid replacing existing clusters.
   cluster_name = "${var.project}-ecs"
 }
 
@@ -24,11 +37,8 @@ resource "aws_ecs_cluster" "this" {
   }
 
   tags = merge(
-    {
-      Name        = local.cluster_name
-      Project     = var.project
-      Environment = var.environment
-    },
+    module.name.tags,
+    { Name = local.cluster_name },
     var.tags,
   )
 }
@@ -53,11 +63,8 @@ resource "aws_service_discovery_private_dns_namespace" "this" {
   vpc         = var.vpc_id
 
   tags = merge(
-    {
-      Name        = "${local.cluster_name}.local"
-      Project     = var.project
-      Environment = var.environment
-    },
+    module.name.tags,
+    { Name = "${local.cluster_name}.local" },
     var.tags,
   )
 }

--- a/aws/eks_nodegroup/main.tf
+++ b/aws/eks_nodegroup/main.tf
@@ -42,7 +42,7 @@ resource "aws_iam_role" "mng" {
   count              = var.node_role_arn == null ? 1 : 0
   name               = "${var.cluster_name}-node-role"
   assume_role_policy = data.aws_iam_policy_document.mng_assume.json
-  tags               = local.common_tags
+  tags               = merge(local.common_tags, var.tags)
 }
 
 # Standard policies for EKS worker nodes (only when we created the role)

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -459,6 +459,19 @@ variable "external_id" {
     }
   }`
 
+		// default_tags is a safety net so every AWS resource in the rendered
+		// stack carries the session's Project tag, even if a preset forgets
+		// the `tags = merge(module.name.tags, ...)` convention. The reliable
+		// MCP inspector filters resources by Project to prevent cross-session
+		// data leaks.
+		const awsDefaultTags = `
+  default_tags {
+    tags = {
+      Project    = var.project
+      managed-by = "insideout"
+    }
+  }`
+
 		required["aws"] = RequiredProvider{Source: "hashicorp/aws", Version: ">= 6.0"}
 		for name, rp := range discovered {
 			required[name] = rp
@@ -469,14 +482,14 @@ variable "external_id" {
 		b.WriteString("terraform {\n  required_providers {\n")
 		b.WriteString(renderRequiredProviders(required))
 		b.WriteString("  }\n}\n\n")
-		fmt.Fprintf(&b, "provider \"aws\" {\n  region = %q%s\n}\n", region, awsDynamicAssumeRole)
+		fmt.Fprintf(&b, "provider \"aws\" {\n  region = %q%s%s\n}\n", region, awsDefaultTags, awsDynamicAssumeRole)
 
 		// WAF requires an additional us_east_1 provider alias for CloudFront
 		// certificate validation. This is a root-configuration concern, not a
 		// child-module concern, so it stays cloud-aware here.
 		if selected[KeyWAF] || selected[KeyAWSWAF] {
 			b.WriteString("\n")
-			fmt.Fprintf(&b, "provider \"aws\" {\n  alias  = \"us_east_1\"\n  region = \"us-east-1\"%s\n}\n", awsDynamicAssumeRole)
+			fmt.Fprintf(&b, "provider \"aws\" {\n  alias  = \"us_east_1\"\n  region = \"us-east-1\"%s%s\n}\n", awsDefaultTags, awsDynamicAssumeRole)
 		}
 
 		return []byte(b.String())

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -16,6 +16,32 @@ func writeOutputs(t *testing.T, files Files, dir string) {
 	writeBundle(t, dir, files)
 }
 
+// assertProviderBlocksHaveDefaultTags splits providers.tf by `provider "aws" {`
+// and asserts that (1) exactly wantBlocks provider "aws" blocks exist, and
+// (2) each block contains a default_tags block with Project = var.project and
+// managed-by = "insideout". Split-and-check proves placement per block (a
+// regression dropping default_tags from the alias block would otherwise slip
+// past a global strings.Count), and regex matches tolerate whitespace-only
+// formatting changes from terraform fmt. Locks the safety net for #1112.
+func assertProviderBlocksHaveDefaultTags(t *testing.T, prov string, wantBlocks int) {
+	t.Helper()
+	chunks := strings.Split(prov, `provider "aws" {`)
+	require.Len(t, chunks, wantBlocks+1,
+		"expected %d provider \"aws\" blocks, got %d. prov:\n%s",
+		wantBlocks, len(chunks)-1, prov)
+	defaultTagsRe := regexp.MustCompile(`default_tags\s*\{`)
+	projectRe := regexp.MustCompile(`Project\s*=\s*var\.project`)
+	managedByRe := regexp.MustCompile(`managed-by\s*=\s*"insideout"`)
+	for i, chunk := range chunks[1:] {
+		require.Regexpf(t, defaultTagsRe, chunk,
+			"provider block #%d missing default_tags. chunk:\n%s", i+1, chunk)
+		require.Regexpf(t, projectRe, chunk,
+			"provider block #%d missing Project = var.project. chunk:\n%s", i+1, chunk)
+		require.Regexpf(t, managedByRe, chunk,
+			"provider block #%d missing managed-by tag. chunk:\n%s", i+1, chunk)
+	}
+}
+
 func TestVpcRef(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -510,13 +536,11 @@ func TestComposeStack_V2KitchenSink(t *testing.T) {
 	require.Contains(t, prov, `provider "aws" {`)
 	require.Contains(t, prov, `alias  = "us_east_1"`)
 	require.Contains(t, prov, `region = "us-east-1"`)
-	// default_tags must be present on both provider blocks — this is the
-	// safety net that guarantees every AWS resource carries the Project tag
-	// for cross-session isolation in the reliable inspector (#1112).
-	require.Equal(t, 2, strings.Count(prov, "default_tags {"),
-		"expected default_tags on both default and us_east_1 providers, got prov=\n%s", prov)
-	require.Contains(t, prov, `Project    = var.project`)
-	require.Contains(t, prov, `managed-by = "insideout"`)
+	// Verify each provider block independently carries default_tags with
+	// Project = var.project — the #1112 safety net. Split-per-block proves
+	// placement (a regression dropping default_tags from just one block
+	// would otherwise pass a global substring count).
+	assertProviderBlocksHaveDefaultTags(t, prov, 2)
 
 	// Monitoring ← bastion, RDS, ALB, SQS
 	require.Contains(t, mainTF, "module.aws_bastion.bastion_instance_id")
@@ -691,6 +715,9 @@ func TestComposeStack_KitchenSink(t *testing.T) {
 		require.Contains(t, prov, `provider "aws" {`)
 		require.Contains(t, prov, `alias  = "us_east_1"`)
 		require.Contains(t, prov, `region = "us-east-1"`)
+		// WAF is selected here so both default + us_east_1 blocks render;
+		// each must independently carry the #1112 default_tags safety net.
+		assertProviderBlocksHaveDefaultTags(t, prov, 2)
 	})
 }
 
@@ -1154,6 +1181,14 @@ func TestComposeStack_MonolithEC2(t *testing.T) {
 	varsTF := string(out["/variables.tf"])
 	require.Contains(t, varsTF, `variable "aws_ec2_project"`)
 	require.Contains(t, varsTF, `variable "aws_ec2_region"`)
+
+	// NoWAF path: only the default provider "aws" block should render,
+	// and it must carry the #1112 default_tags safety net. A regression
+	// dropping default_tags from the default block would pass the V2/legacy
+	// WAF tests if inadvertently doubled on the alias — only this NoWAF
+	// assertion catches that directly.
+	require.Contains(t, out, "/providers.tf")
+	assertProviderBlocksHaveDefaultTags(t, string(out["/providers.tf"]), 1)
 
 	// Validate all .tf files parse as valid HCL
 	for name, content := range out {

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -510,6 +510,13 @@ func TestComposeStack_V2KitchenSink(t *testing.T) {
 	require.Contains(t, prov, `provider "aws" {`)
 	require.Contains(t, prov, `alias  = "us_east_1"`)
 	require.Contains(t, prov, `region = "us-east-1"`)
+	// default_tags must be present on both provider blocks — this is the
+	// safety net that guarantees every AWS resource carries the Project tag
+	// for cross-session isolation in the reliable inspector (#1112).
+	require.Equal(t, 2, strings.Count(prov, "default_tags {"),
+		"expected default_tags on both default and us_east_1 providers, got prov=\n%s", prov)
+	require.Contains(t, prov, `Project    = var.project`)
+	require.Contains(t, prov, `managed-by = "insideout"`)
 
 	// Monitoring ← bastion, RDS, ALB, SQS
 	require.Contains(t, mainTF, "module.aws_bastion.bastion_instance_id")


### PR DESCRIPTION
## Summary

Adds `Project` tag as a safety net across every AWS resource rendered by the composer, and cleans up three preset-level tagging inconsistencies discovered during an audit tied to **reliable #1112** (cross-session data leak via name-substring filtering in the MCP inspector).

## Why

Reliable's MCP AWS inspector filters resources by the `Project` tag so a caller only sees their own session's infrastructure. The tag is primarily set per-resource via `merge(module.name.tags, var.tags)` (backed by the `luthername` module). This works, but a single forgotten merge in a new preset silently drops `Project` and reintroduces the class of leak that #1112 is tracking. `default_tags` at the provider level plugs that gap for every current and future resource type.

## Changes

**`pkg/composer/compose.go` — emit `default_tags` on both AWS provider blocks**

`generateProvidersTF` now injects:

```hcl
default_tags {
  tags = {
    Project    = var.project
    managed-by = "insideout"
  }
}
```

into the default `provider "aws"` block and the `aws.us_east_1` alias that gets rendered when WAF is selected. `var.project` is already an emitted root variable (verified in `TestComposeStack_KitchenSink` at `compose_stack_test.go:675`). Per-resource tags still win per AWS provider precedence, so no existing `Project` values drift.

**`aws/ecs/main.tf` — adopt the canonical `module "name"` pattern**

Previously hand-rolled `{ Project = var.project, Environment = var.environment }` directly. Now inherits both via `module.name.tags`, matching every other preset in the repo. Cluster `name` is preserved as `${var.project}-ecs` because `name` is a `ForceNew` attribute on `aws_ecs_cluster` — changing it would replace existing clusters.

> **First-plan tag drift on existing ECS deployments:** switching the cluster tags from `{Name, Project, Environment, <var.tags>}` to `merge(module.name.tags, {Name}, var.tags)` inherits the `luthername` tag set, which adds `Component`, `Subcomponent`, `Resource`, `ID`, and `Organization` keys. The first `terraform plan` after this merges against an existing stack will show these as tag additions on `aws_ecs_cluster.this` and `aws_service_discovery_private_dns_namespace.this`. The change is **non-destructive** (tags on an ECS cluster are not a `ForceNew` attribute) and matches how every other preset in the repo has always tagged its resources. Review plan output on staging (`sess_v2_9Up7YUKIIdjW`) before prod promotion to confirm.

**`aws/eks_nodegroup/main.tf` — merge `var.tags` into the MNG IAM role**

`aws_iam_role.mng` merged `local.common_tags` only. Every other module in the repo merges both `common_tags` and `var.tags`; this was a silent drop of user-supplied tags. Trivial fix at main.tf:45.

**`aws/cloudwatchmonitoring/main.tf` — note the provider-level tagging gap**

Attempted to add `tags = merge(module.name.tags, var.tags)` on `aws_cloudwatch_dashboard`, but the hashicorp/aws provider (v6.33.0, latest) doesn't accept the argument on that resource type despite the AWS API supporting tagging. Left a comment explaining why dashboards remain untagged from Terraform.

**`pkg/composer/compose_stack_test.go` — lock the new behavior**

Adds a `assertProviderBlocksHaveDefaultTags` helper that splits `providers.tf` by `provider "aws" {` and verifies each block independently carries `default_tags` + `Project = var.project` + `managed-by = "insideout"`. Called from both WAF-selected tests (expect 2 blocks) and the NoWAF `TestComposeStack_MonolithEC2` (expect 1 block) so a regression dropping `default_tags` from either site is caught. Regex matches tolerate `terraform fmt` whitespace normalization.

## Audit summary

Every primary inspectable AWS resource across all 23 preset modules is already tagged via the `luthername` pattern. **No other tag gaps were found** — CloudFront, S3, Backup, WAF (both scopes), KMS keys, RDS, Lambda, APIGateway, Cognito user pools, DynamoDB, ElastiCache, EKS node groups are all correctly tagged. Aliases and config sub-resources (e.g. KMS aliases, S3 versioning blocks, Cognito identity providers) are not taggable per AWS API — those gaps are upstream limitations, not preset bugs.

Reliable #1112 is therefore **not blocked** on presets. This PR is pure hardening.

## Test plan

- [x] `go test ./...` passes
- [x] `terraform validate` passes on `aws/cloudwatchmonitoring`, `aws/eks_nodegroup`, `aws/ecs`
- [x] `terraform fmt -recursive` clean
- [x] Composer-rendered `providers.tf` inspected visually — default_tags appears on both provider blocks with correct formatting
- [x] Per-block, per-test (WAF + NoWAF) assertions catch default_tags regressions in isolation
- [ ] After merge: consumer repo (`reliable`) bumps `go.mod` to the new tag; stage a `tfdeploy` on staging (`sess_v2_9Up7YUKIIdjW`) and review the plan output for the expected ECS tag additions (and zero unexpected drift on other resources)
- [ ] Spot-check in AWS Console that a newly-deployed stack has `Project` on a resource that previously relied only on `module.name.tags` (e.g. `aws_ecs_cluster`) and that `Project` is unchanged from pre-PR