### PR TITLE
feat(vpc): surface single_nat_gateway as a first-class composer knob

### DIFF
--- a/aws/vpc/variables.tf
+++ b/aws/vpc/variables.tf
@@ -33,7 +33,7 @@ variable "vpc_cidr" {
 }
 
 variable "az_count" {
-  description = "Number of AZs to use for subnets"
+  description = "Number of AZs to span with public+private subnets. Also bounds the number of NAT gateways when single_nat_gateway=false. 2 is recommended for HA."
   type        = number
   default     = 2
 
@@ -45,13 +45,23 @@ variable "az_count" {
 }
 
 variable "enable_nat_gateway" {
-  description = "Enable NAT gateway for private subnets (set false for public-only VPCs)"
+  description = "Enable NAT gateways so private subnets can reach the public internet. Set false only for public-only VPCs (no private workloads). Topology (one vs one-per-AZ) is controlled by single_nat_gateway."
   type        = bool
   default     = true
 }
 
 variable "single_nat_gateway" {
-  description = "Use a single NAT gateway (cost saver) instead of one per AZ"
+  description = <<-EOT
+    Provision exactly one NAT gateway (in the first public subnet / first AZ) shared by all private subnets,
+    instead of one NAT gateway per AZ. Defaults to true for cost.
+
+    - true (default): cheapest, ~1/N the NAT cost, but (a) single point of failure if that AZ goes down
+      and (b) every stack in the account lands its NAT in the first AZ — accounts running multiple stacks
+      can exhaust the per-AZ NAT gateway quota (default 5) before running out of the VPC quota.
+    - false: one NAT gateway per AZ (as bounded by az_count). ~N× cost, no per-AZ SPOF, spreads NAT
+      quota usage across AZs. Recommended once an account runs more than a handful of concurrent VPCs
+      or whenever AZ-level availability is a requirement.
+  EOT
   type        = bool
   default     = true
 }

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -161,6 +161,20 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+		// Topology knobs from Config.AWSVPC override Public-VPC-derived defaults.
+		// Unset pointer fields defer to the HCL default.
+		if cfg != nil && cfg.AWSVPC != nil {
+			if cfg.AWSVPC.SingleNATGateway != nil {
+				vals["single_nat_gateway"] = *cfg.AWSVPC.SingleNATGateway
+			}
+			if cfg.AWSVPC.EnableNATGateway != nil {
+				vals["enable_nat_gateway"] = *cfg.AWSVPC.EnableNATGateway
+			}
+			if cfg.AWSVPC.AZCount != nil {
+				vals["az_count"] = *cfg.AWSVPC.AZCount
+			}
+		}
+
 	case KeyCloud:
 		// Example: cloud/provider selection
 		if comps != nil && comps.Cloud != "" {

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -164,6 +164,26 @@ func (m DefaultMapper) BuildModuleValues(
 		// Topology knobs from Config.AWSVPC override Public-VPC-derived defaults.
 		// Unset pointer fields defer to the HCL default.
 		if cfg != nil && cfg.AWSVPC != nil {
+			// Reject EnableNATGateway=false when the stack has components that
+			// require private subnets with egress (EKS/ECS/RDS/ElastiCache/
+			// OpenSearch/EC2 node groups). Private subnets without NAT can't
+			// pull container images or run package installs, so the apply
+			// would break much later than it needs to. Fail fast here.
+			if cfg.AWSVPC.EnableNATGateway != nil && !*cfg.AWSVPC.EnableNATGateway && stackNeedsPrivateSubnets(comps) {
+				return nil, NewValidationError(
+					"AWSVPC.EnableNATGateway=false is incompatible with components that require private subnets " +
+						"(EKS/ECS/RDS/ElastiCache/OpenSearch/EC2 node groups): private subnets without NAT cannot reach " +
+						"the public internet, breaking image pulls and package installs. Either re-enable NAT or drop " +
+						"the downstream components",
+				)
+			}
+			// AZCount bounds — HCL validation says >= 1; enforce the same at
+			// the mapper so users see a Go-level error before `terraform plan`.
+			if cfg.AWSVPC.AZCount != nil && *cfg.AWSVPC.AZCount < 1 {
+				return nil, NewValidationError(fmt.Sprintf(
+					"AWSVPC.AZCount must be >= 1, got %d", *cfg.AWSVPC.AZCount,
+				))
+			}
 			if cfg.AWSVPC.SingleNATGateway != nil {
 				vals["single_nat_gateway"] = *cfg.AWSVPC.SingleNATGateway
 			}

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -189,80 +189,174 @@ func TestStackNeedsPrivateSubnets(t *testing.T) {
 	assert.True(t, stackNeedsPrivateSubnets(&Components{AWSEC2: "ARM"}), "AWSEC2 ARM")
 }
 
+// cfgWithAWSVPC builds a Config with an AWSVPC sub-config populated from the
+// provided pointer fields. Kills the anonymous-struct literal repetition that
+// would otherwise appear in every subtest below.
+func cfgWithAWSVPC(single, enable *bool, az *int) *Config {
+	c := &Config{}
+	c.AWSVPC = &struct {
+		SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+		EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+		AZCount          *int  `json:"azCount,omitempty"`
+	}{SingleNATGateway: single, EnableNATGateway: enable, AZCount: az}
+	return c
+}
+
 func TestBuildModuleValues_VPC_AWSVPCConfig(t *testing.T) {
 	m := DefaultMapper{}
 	boolPtr := func(v bool) *bool { return &v }
 	intPtr := func(v int) *int { return &v }
 
 	t.Run("SingleNATGateway=false writes single_nat_gateway=false", func(t *testing.T) {
-		cfg := &Config{AWSVPC: &struct {
-			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
-			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
-			AZCount          *int  `json:"azCount,omitempty"`
-		}{SingleNATGateway: boolPtr(false)}}
+		cfg := cfgWithAWSVPC(boolPtr(false), nil, nil)
 		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
 		require.NoError(t, err)
-		assert.Equal(t, false, vals["single_nat_gateway"])
+		// Type-guard the cast so a future mutation writing a stringified bool
+		// would fail the type assertion rather than pass assert.Equal.
+		assert.False(t, vals["single_nat_gateway"].(bool))
 	})
 
-	t.Run("AZCount=3 writes az_count=3", func(t *testing.T) {
-		cfg := &Config{AWSVPC: &struct {
-			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
-			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
-			AZCount          *int  `json:"azCount,omitempty"`
-		}{AZCount: intPtr(3)}}
+	t.Run("AZCount=3 writes az_count=3 as int", func(t *testing.T) {
+		cfg := cfgWithAWSVPC(nil, nil, intPtr(3))
 		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
 		require.NoError(t, err)
-		assert.Equal(t, 3, vals["az_count"])
+		assert.Equal(t, 3, vals["az_count"].(int))
 	})
 
 	t.Run("unset fields do not write to vals (defer to HCL default)", func(t *testing.T) {
-		cfg := &Config{AWSVPC: &struct {
-			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
-			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
-			AZCount          *int  `json:"azCount,omitempty"`
-		}{}}
+		cfg := cfgWithAWSVPC(nil, nil, nil)
 		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
 		require.NoError(t, err)
-		_, hasSingle := vals["single_nat_gateway"]
-		_, hasEnable := vals["enable_nat_gateway"]
-		_, hasAZ := vals["az_count"]
-		assert.False(t, hasSingle, "SingleNATGateway unset should not write single_nat_gateway")
-		assert.False(t, hasEnable, "EnableNATGateway unset should not write enable_nat_gateway")
-		assert.False(t, hasAZ, "AZCount unset should not write az_count")
+		for _, k := range []string{"single_nat_gateway", "enable_nat_gateway", "az_count"} {
+			_, has := vals[k]
+			assert.False(t, has, "unset pointer should not write %q", k)
+		}
 	})
 
-	t.Run("nil cfg.AWSVPC is a no-op", func(t *testing.T) {
+	t.Run("nil cfg.AWSVPC is a no-op — no VPC-topology keys leak", func(t *testing.T) {
 		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, &Config{}, "test", "us-east-1")
 		require.NoError(t, err)
-		_, hasSingle := vals["single_nat_gateway"]
-		assert.False(t, hasSingle)
+		for _, k := range []string{"single_nat_gateway", "enable_nat_gateway", "az_count"} {
+			_, has := vals[k]
+			assert.False(t, has, "nil cfg.AWSVPC should not write %q", k)
+		}
 	})
 
-	t.Run("Public VPC with user SingleNATGateway=false: both apply (enable_nat_gateway=false from Public VPC, single_nat_gateway=false from user)", func(t *testing.T) {
+	t.Run("Public VPC with user SingleNATGateway=false: both apply", func(t *testing.T) {
+		// Public VPC forces enable_nat_gateway=false (no private subnets);
+		// user's SingleNATGateway=false still applies (vestigial but not wrong).
 		comps := &Components{AWSVPC: "Public VPC"}
-		cfg := &Config{AWSVPC: &struct {
-			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
-			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
-			AZCount          *int  `json:"azCount,omitempty"`
-		}{SingleNATGateway: boolPtr(false)}}
+		cfg := cfgWithAWSVPC(boolPtr(false), nil, nil)
 		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
 		require.NoError(t, err)
-		assert.Equal(t, false, vals["enable_nat_gateway"], "Public VPC still wins on enable_nat_gateway")
-		assert.Equal(t, false, vals["single_nat_gateway"], "user config still applies to single_nat_gateway")
+		assert.False(t, vals["enable_nat_gateway"].(bool), "Public VPC sets enable_nat_gateway=false")
+		assert.False(t, vals["single_nat_gateway"].(bool), "user config still applies")
 	})
 
 	t.Run("user EnableNATGateway=true overrides Public-VPC-derived false", func(t *testing.T) {
 		comps := &Components{AWSVPC: "Public VPC"}
-		cfg := &Config{AWSVPC: &struct {
-			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
-			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
-			AZCount          *int  `json:"azCount,omitempty"`
-		}{EnableNATGateway: boolPtr(true)}}
+		cfg := cfgWithAWSVPC(nil, boolPtr(true), nil)
 		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
 		require.NoError(t, err)
-		assert.Equal(t, true, vals["enable_nat_gateway"], "user override wins over Public VPC default")
+		assert.True(t, vals["enable_nat_gateway"].(bool), "user override wins over Public VPC default")
 	})
+}
+
+// TestBuildModuleValues_VPC_AWSVPCConfig_Validation pins the mapper-level
+// validation for invalid Config.AWSVPC combinations that would produce a
+// broken stack (private subnets without egress) or fail at `terraform validate`.
+// Catching these in Go fails fast and gives actionable errors.
+func TestBuildModuleValues_VPC_AWSVPCConfig_Validation(t *testing.T) {
+	m := DefaultMapper{}
+	boolPtr := func(v bool) *bool { return &v }
+	intPtr := func(v int) *int { return &v }
+
+	t.Run("EnableNATGateway=false with EKS returns ValidationError", func(t *testing.T) {
+		comps := &Components{AWSEKS: boolPtr(true)}
+		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
+		_, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.Error(t, err)
+		var verr *ValidationError
+		assert.ErrorAs(t, err, &verr, "should return ValidationError so API-layer can HTTP 400")
+		assert.Contains(t, err.Error(), "EnableNATGateway=false",
+			"error should name the offending knob")
+	})
+
+	t.Run("EnableNATGateway=false with RDS returns ValidationError", func(t *testing.T) {
+		comps := &Components{AWSRDS: boolPtr(true)}
+		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
+		_, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.Error(t, err)
+	})
+
+	t.Run("EnableNATGateway=false with legacy Postgres returns ValidationError", func(t *testing.T) {
+		comps := &Components{Postgres: boolPtr(true)}
+		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
+		_, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.Error(t, err)
+	})
+
+	t.Run("EnableNATGateway=false without downstream components is allowed", func(t *testing.T) {
+		comps := &Components{} // no private-subnet consumers
+		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
+		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.NoError(t, err, "public-only VPC with NAT disabled is valid")
+		assert.False(t, vals["enable_nat_gateway"].(bool))
+	})
+
+	t.Run("AZCount=0 returns ValidationError", func(t *testing.T) {
+		cfg := cfgWithAWSVPC(nil, nil, intPtr(0))
+		_, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "AZCount")
+	})
+
+	t.Run("AZCount=-1 returns ValidationError", func(t *testing.T) {
+		cfg := cfgWithAWSVPC(nil, nil, intPtr(-1))
+		_, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
+		require.Error(t, err)
+	})
+
+	t.Run("AZCount=1 is allowed (HCL default >= 1)", func(t *testing.T) {
+		cfg := cfgWithAWSVPC(nil, nil, intPtr(1))
+		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		assert.Equal(t, 1, vals["az_count"].(int))
+	})
+}
+
+// TestBuildModuleValues_VPC_MapperHCLContract protects against typos in the
+// mapper's output keys. A mutation renaming a vals[...] key in mapper.go to
+// something not declared in aws/vpc/variables.tf previously passed every unit
+// test (the composer's variable-discovery step silently drops unknown keys).
+// Reads the actual preset variables.tf via DiscoverModuleVars and asserts every
+// key the mapper writes for KeyAWSVPC with all AWSVPC knobs set is declared.
+func TestBuildModuleValues_VPC_MapperHCLContract(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+	intPtr := func(v int) *int { return &v }
+
+	presets, err := newTestClient().GetPresetFiles("aws/vpc")
+	require.NoError(t, err)
+	declared, err := DiscoverModuleVars(presets)
+	require.NoError(t, err)
+	declaredSet := make(map[string]bool, len(declared))
+	for _, v := range declared {
+		declaredSet[v.Name] = true
+	}
+
+	// Exercise every AWSVPC knob so the full set of mapper-written keys is
+	// present in vals.
+	cfg := cfgWithAWSVPC(boolPtr(false), boolPtr(true), intPtr(3))
+	vals, err := DefaultMapper{}.BuildModuleValues(
+		KeyAWSVPC, &Components{AWSVPC: "Private VPC"}, cfg, "test", "us-east-1",
+	)
+	require.NoError(t, err)
+
+	for k := range vals {
+		assert.True(t, declaredSet[k],
+			"mapper wrote key %q but aws/vpc/variables.tf does not declare it; the composer would silently drop it",
+			k)
+	}
 }
 
 // TestBuildModuleValues_V2KeyNormalization verifies that calling BuildModuleValues

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -189,6 +189,82 @@ func TestStackNeedsPrivateSubnets(t *testing.T) {
 	assert.True(t, stackNeedsPrivateSubnets(&Components{AWSEC2: "ARM"}), "AWSEC2 ARM")
 }
 
+func TestBuildModuleValues_VPC_AWSVPCConfig(t *testing.T) {
+	m := DefaultMapper{}
+	boolPtr := func(v bool) *bool { return &v }
+	intPtr := func(v int) *int { return &v }
+
+	t.Run("SingleNATGateway=false writes single_nat_gateway=false", func(t *testing.T) {
+		cfg := &Config{AWSVPC: &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{SingleNATGateway: boolPtr(false)}}
+		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		assert.Equal(t, false, vals["single_nat_gateway"])
+	})
+
+	t.Run("AZCount=3 writes az_count=3", func(t *testing.T) {
+		cfg := &Config{AWSVPC: &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{AZCount: intPtr(3)}}
+		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		assert.Equal(t, 3, vals["az_count"])
+	})
+
+	t.Run("unset fields do not write to vals (defer to HCL default)", func(t *testing.T) {
+		cfg := &Config{AWSVPC: &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{}}
+		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		_, hasSingle := vals["single_nat_gateway"]
+		_, hasEnable := vals["enable_nat_gateway"]
+		_, hasAZ := vals["az_count"]
+		assert.False(t, hasSingle, "SingleNATGateway unset should not write single_nat_gateway")
+		assert.False(t, hasEnable, "EnableNATGateway unset should not write enable_nat_gateway")
+		assert.False(t, hasAZ, "AZCount unset should not write az_count")
+	})
+
+	t.Run("nil cfg.AWSVPC is a no-op", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, &Config{}, "test", "us-east-1")
+		require.NoError(t, err)
+		_, hasSingle := vals["single_nat_gateway"]
+		assert.False(t, hasSingle)
+	})
+
+	t.Run("Public VPC with user SingleNATGateway=false: both apply (enable_nat_gateway=false from Public VPC, single_nat_gateway=false from user)", func(t *testing.T) {
+		comps := &Components{AWSVPC: "Public VPC"}
+		cfg := &Config{AWSVPC: &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{SingleNATGateway: boolPtr(false)}}
+		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		assert.Equal(t, false, vals["enable_nat_gateway"], "Public VPC still wins on enable_nat_gateway")
+		assert.Equal(t, false, vals["single_nat_gateway"], "user config still applies to single_nat_gateway")
+	})
+
+	t.Run("user EnableNATGateway=true overrides Public-VPC-derived false", func(t *testing.T) {
+		comps := &Components{AWSVPC: "Public VPC"}
+		cfg := &Config{AWSVPC: &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{EnableNATGateway: boolPtr(true)}}
+		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		assert.Equal(t, true, vals["enable_nat_gateway"], "user override wins over Public VPC default")
+	})
+}
+
 // TestBuildModuleValues_V2KeyNormalization verifies that calling BuildModuleValues
 // with a V2 key (e.g., KeyAWSWAF) produces the same output as calling with the
 // legacy key (e.g., KeyWAF). This catches missing case arms in the normalization switch.

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -192,6 +192,18 @@ type Config struct {
 		EnableServiceConnect    *bool    `json:"enableServiceConnect,omitempty"`
 	} `json:"aws_ecs,omitempty"`
 
+	// AWSVPC surfaces the preset's VPC topology knobs. All fields are pointers
+	// so the zero value means "defer to the module's HCL default" rather than
+	// "force to zero". SingleNATGateway=false spreads NAT gateways across AZs
+	// (one per AZ, bounded by AZCount) — trade higher cost for AZ-level HA and
+	// to avoid exhausting the per-AZ NAT gateway quota when many stacks share
+	// an account.
+	AWSVPC *struct {
+		SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+		EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+		AZCount          *int  `json:"azCount,omitempty"`
+	} `json:"aws_vpc,omitempty"`
+
 	AWSCloudfront *struct {
 		DefaultTtl *string `json:"defaultTtl,omitempty"`
 		OriginPath *string `json:"originPath,omitempty"`


### PR DESCRIPTION
## Summary
- Add `Config.AWSVPC { SingleNATGateway, EnableNATGateway, AZCount }` to `pkg/composer` so sessions can opt into one-NAT-per-AZ topology without touching raw tfvars.
- Extend `DefaultMapper`'s `KeyVPC` branch to overlay those fields onto the module vars. Unset pointer fields defer to the HCL default, so the change is a pure addition for existing callers.
- Tighten `aws/vpc/variables.tf` descriptions on `single_nat_gateway`, `enable_nat_gateway`, and `az_count` so the HA/cost/NAT-quota trade-off is explicit in `terraform-docs`-style surface.

## Why
`single_nat_gateway` default `true` pins every stack's NAT in the first AZ (`us-east-1a`). An account running ~5 stacks hit the per-AZ NAT gateway quota because all five single NATs landed there. Surfacing `SingleNATGateway=false` as a composer-level option lets multi-stack accounts spread NAT across AZs + get genuine AZ HA.

## Test plan
- [x] ` go test ./pkg/composer/... -race ` (all pass; new `TestBuildModuleValues_VPC_AWSVPCConfig` covers set / unset / nil / Public-VPC interplay)
- [x] ` cd aws/vpc && terraform init -backend=false && terraform validate ` (clean)
- [x] ` terraform fmt -check -recursive ` (clean)

Closes #106