### PR TITLE
fix(tagging): follow-up polish from PR #110 review

### DIFF
--- a/aws/cloudwatchmonitoring/main.tf
+++ b/aws/cloudwatchmonitoring/main.tf
@@ -237,8 +237,8 @@ locals {
 resource "aws_cloudwatch_dashboard" "main" {
   dashboard_name = module.name.name
   dashboard_body = jsonencode({ widgets = local.dash_metrics })
-  # NOTE: aws_cloudwatch_dashboard does not accept a `tags` argument in
-  # the hashicorp/aws provider (as of v6.33.0). CloudWatch dashboards are
+  # NOTE: the hashicorp/aws provider currently does not support the `tags`
+  # argument on `aws_cloudwatch_dashboard`. CloudWatch dashboards are
   # therefore untaggable from Terraform, even though the AWS API supports
   # it. When/if the provider adds the argument, add:
   #   tags = merge(module.name.tags, var.tags)

--- a/examples/cargofit/providers.tf
+++ b/examples/cargofit/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }
@@ -21,6 +22,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/edubot/providers.tf
+++ b/examples/edubot/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }
@@ -21,6 +22,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/gamestudio/providers.tf
+++ b/examples/gamestudio/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-west-2"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/guestbook/providers.tf
+++ b/examples/guestbook/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-west-2"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }
@@ -21,6 +22,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/inboundfund-tf/providers.tf
+++ b/examples/inboundfund-tf/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }
@@ -21,6 +22,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/localbook/providers.tf
+++ b/examples/localbook/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-west-2"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/locallink/providers.tf
+++ b/examples/locallink/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-west-2"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/openclaw/providers.tf
+++ b/examples/openclaw/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-west-2"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/openclaw/variables.tf
+++ b/examples/openclaw/variables.tf
@@ -4,6 +4,12 @@ variable "environment" {
   default     = "sandbox"
 }
 
+variable "project" {
+  description = "Root project name, stamped into the provider default_tags block so every AWS resource carries a Project tag"
+  type        = string
+  default     = "openclaw"
+}
+
 variable "vpc_project" {
   description = "Project name for VPC"
   type        = string

--- a/examples/openclaw/variables.tf
+++ b/examples/openclaw/variables.tf
@@ -11,7 +11,7 @@ variable "project" {
 }
 
 variable "vpc_project" {
-  description = "Project name for VPC"
+  description = "Project name for VPC. Keep in sync with var.project — the Project tag stamped in the provider default_tags block is read from var.project, not var.vpc_project, so a mismatch produces inconsistent tagging."
   type        = string
 }
 
@@ -21,7 +21,7 @@ variable "vpc_region" {
 }
 
 variable "ec2_project" {
-  description = "Project name for EC2 instance"
+  description = "Project name for EC2 instance. Keep in sync with var.project; see vpc_project."
   type        = string
 }
 

--- a/examples/revisionapp/providers.tf
+++ b/examples/revisionapp/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }
@@ -21,6 +22,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/videostreaming/providers.tf
+++ b/examples/videostreaming/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-west-2"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -10,6 +10,12 @@ import (
 	terraformpresets "github.com/luthersystems/insideout-terraform-presets"
 )
 
+// insideoutManagedByValue is the value stamped into the `managed-by` tag on
+// every AWS resource rendered by the composer. Hoisted to a package-level
+// constant so the default_tags emission and any other call sites that care
+// about org identity share a single source of truth.
+const insideoutManagedByValue = "insideout"
+
 // Option configures a Client.
 type Option func(*Client)
 
@@ -464,13 +470,13 @@ variable "external_id" {
 		// the `tags = merge(module.name.tags, ...)` convention. The reliable
 		// MCP inspector filters resources by Project to prevent cross-session
 		// data leaks.
-		const awsDefaultTags = `
+		awsDefaultTags := fmt.Sprintf(`
   default_tags {
     tags = {
       Project    = var.project
-      managed-by = "insideout"
+      managed-by = %q
     }
-  }`
+  }`, insideoutManagedByValue)
 
 		required["aws"] = RequiredProvider{Source: "hashicorp/aws", Version: ">= 6.0"}
 		for name, rp := range discovered {

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -1875,6 +1875,12 @@ func TestComposeStack_GCP_Provider(t *testing.T) {
 	// someone adding half-working GCP tagging by accident — if a parity
 	// story ever lands it should be a deliberate feature change that updates
 	// this test, not a drive-by edit.
+	//
+	// Scope note: provStr is the root /providers.tf only (no preset contents),
+	// so a NotContains on the full string has negligible false-positive risk
+	// from a module name or comment mentioning "default_tags". If the haystack
+	// ever widens to include preset bodies, scope the check to the
+	// `provider "google" { ... }` block.
 	require.NotContains(t, provStr, "default_labels",
 		"GCP provider block should not declare default_labels (see #111; any GCP tagging parity should land via a deliberate feature, not a drive-by edit)")
 	require.NotContains(t, provStr, "default_tags",
@@ -1888,6 +1894,18 @@ func TestComposeStack_GCP_Provider(t *testing.T) {
 // DiscoverRequiredProviders alone don't cover the merge in generateProvidersTF.
 func TestComposeStack_DiscoveredProvidersReachRoot(t *testing.T) {
 	c := newTestClient()
+
+	// Precondition: the ALB preset really does declare hashicorp/random in
+	// its required_providers. If this test silently becomes a no-op because
+	// the ALB module dropped the provider, the precondition fails first —
+	// much clearer diagnostic than a passing assertion on an absent string.
+	albFiles, err := c.GetPresetFiles("aws/alb")
+	require.NoError(t, err)
+	albProvs, err := DiscoverRequiredProviders(albFiles)
+	require.NoError(t, err)
+	require.Contains(t, albProvs, "random",
+		"precondition: aws/alb preset should declare a random = {...} required_provider; if this fails, pick a different preset to exercise the discovered-providers merge")
+
 	out, err := c.ComposeStack(ComposeStackOpts{
 		Cloud:        "aws",
 		SelectedKeys: []ComponentKey{KeyAWSVPC, KeyAWSALB},
@@ -1903,12 +1921,19 @@ func TestComposeStack_DiscoveredProvidersReachRoot(t *testing.T) {
 		"root providers.tf should include the ALB module's discovered hashicorp/random required_providers entry")
 	require.Contains(t, prov, "hashicorp/aws",
 		"root providers.tf should keep the cloud's base required_provider entry")
+	// Lock the merge location: hashicorp/random must appear inside a
+	// `random = { ... }` entry (i.e. it's a keyed required_providers block,
+	// not a stray substring in a comment or module name).
+	require.Regexp(t, regexp.MustCompile(`(?s)random\s*=\s*\{[^}]*hashicorp/random`), prov,
+		"hashicorp/random should be attached to a random = {...} entry in required_providers, not just appear as a substring")
 }
 
 // TestComposeStack_ProjectRoundTrip renders with a distinctive Project value
-// and asserts that value flows through to both the root variables.tf default
-// and per-module .auto.tfvars. Guards against a refactor replacing var.project
-// with a hardcoded literal (which would defeat cross-session isolation).
+// and asserts that value flows through to the root variables.tf default, the
+// per-module .auto.tfvars, and the provider default_tags block. Each
+// assertion binds the sentinel to the specific variable/declaration it
+// belongs to — a bare substring match would pass even if the sentinel landed
+// in an unrelated comment or the wrong variable.
 func TestComposeStack_ProjectRoundTrip(t *testing.T) {
 	const sentinel = "demo-xyz-round-trip"
 	c := newTestClient()
@@ -1922,20 +1947,32 @@ func TestComposeStack_ProjectRoundTrip(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Root variables.tf: the sentinel must appear as the default of the
+	// `variable "project"` block, not somewhere else (a module name, a
+	// comment, another variable's default).
 	varsTF := string(out["/variables.tf"])
-	require.Contains(t, varsTF, `variable "project"`,
-		"root variables.tf should declare variable project")
-	require.Contains(t, varsTF, sentinel,
-		"root variables.tf should carry ComposeStackOpts.Project as the project default")
+	require.Regexp(t,
+		regexp.MustCompile(`(?s)variable "project"\s*\{[^}]*default\s*=\s*"`+regexp.QuoteMeta(sentinel)+`"`),
+		varsTF,
+		"root variables.tf should carry ComposeStackOpts.Project as the default of variable \"project\"")
 
+	// Per-module .auto.tfvars: sentinel must be bound to aws_vpc_project
+	// specifically, not aws_vpc_region or any other key.
 	require.Contains(t, out, "/aws_vpc.auto.tfvars")
 	vpcTf := string(out["/aws_vpc.auto.tfvars"])
-	require.Contains(t, vpcTf, sentinel,
-		"per-module .auto.tfvars should carry the Project value through the namespaced aws_vpc_project binding")
+	require.Regexp(t,
+		regexp.MustCompile(`(?m)^\s*aws_vpc_project\s*=\s*"`+regexp.QuoteMeta(sentinel)+`"\s*$`),
+		vpcTf,
+		"aws_vpc.auto.tfvars should bind aws_vpc_project to the sentinel, not leak it into another key")
 
+	// Provider default_tags: `Project = var.project` must appear (the binding
+	// is what makes the round-trip work at apply time). Whitespace-tolerant
+	// regex matches terraform fmt output.
 	prov := string(out["/providers.tf"])
-	require.Contains(t, prov, "Project    = var.project",
-		"provider block should bind Project to var.project (not a hardcoded literal)")
+	require.Regexp(t,
+		regexp.MustCompile(`Project\s*=\s*var\.project`),
+		prov,
+		"provider default_tags should bind Project to var.project (not a hardcoded literal)")
 }
 
 func TestDefaultWiring_AWSECS(t *testing.T) {

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -18,11 +18,13 @@ func writeOutputs(t *testing.T, files Files, dir string) {
 
 // assertProviderBlocksHaveDefaultTags splits providers.tf by `provider "aws" {`
 // and asserts that (1) exactly wantBlocks provider "aws" blocks exist, and
-// (2) each block contains a default_tags block with Project = var.project and
+// (2) each block declares a default_tags block with Project = var.project and
 // managed-by = "insideout". Split-and-check proves placement per block (a
 // regression dropping default_tags from the alias block would otherwise slip
 // past a global strings.Count), and regex matches tolerate whitespace-only
-// formatting changes from terraform fmt. Locks the safety net for #1112.
+// formatting changes from terraform fmt. Note this locks the HCL surface of
+// the provider blocks — it does not prove rendered resources inherit the tag
+// at terraform apply, which requires a plan-json round-trip.
 func assertProviderBlocksHaveDefaultTags(t *testing.T, prov string, wantBlocks int) {
 	t.Helper()
 	chunks := strings.Split(prov, `provider "aws" {`)
@@ -1866,6 +1868,74 @@ func TestComposeStack_GCP_Provider(t *testing.T) {
 	require.Contains(t, provStr, "hashicorp/google", "should use Google provider")
 	require.Contains(t, provStr, `provider "google"`, "should have google provider block")
 	require.Contains(t, provStr, "us-central1", "should use specified region")
+
+	// GCP intentionally has no default_tags / default_labels safety net: the
+	// google provider has native per-session credential isolation via
+	// creds.ProjectID and Reliable #1112's scope was AWS-only. Guard against
+	// someone adding half-working GCP tagging by accident — if a parity
+	// story ever lands it should be a deliberate feature change that updates
+	// this test, not a drive-by edit.
+	require.NotContains(t, provStr, "default_labels",
+		"GCP provider block should not declare default_labels (see #111; any GCP tagging parity should land via a deliberate feature, not a drive-by edit)")
+	require.NotContains(t, provStr, "default_tags",
+		"GCP provider block should not borrow AWS-shaped default_tags")
+}
+
+// TestComposeStack_DiscoveredProvidersReachRoot exercises the end-to-end path
+// where a child module's non-AWS `required_providers` declaration (e.g. ALB
+// declaring hashicorp/random) is discovered via DiscoverRequiredProviders
+// and merged into the root providers.tf. Unit tests on
+// DiscoverRequiredProviders alone don't cover the merge in generateProvidersTF.
+func TestComposeStack_DiscoveredProvidersReachRoot(t *testing.T) {
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC, KeyAWSALB},
+		Comps:        &Components{AWSVPC: "Private VPC", AWSALB: ptrBool(true)},
+		Cfg:          &Config{},
+		Project:      "discovered-test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	prov := string(out["/providers.tf"])
+	require.Contains(t, prov, "hashicorp/random",
+		"root providers.tf should include the ALB module's discovered hashicorp/random required_providers entry")
+	require.Contains(t, prov, "hashicorp/aws",
+		"root providers.tf should keep the cloud's base required_provider entry")
+}
+
+// TestComposeStack_ProjectRoundTrip renders with a distinctive Project value
+// and asserts that value flows through to both the root variables.tf default
+// and per-module .auto.tfvars. Guards against a refactor replacing var.project
+// with a hardcoded literal (which would defeat cross-session isolation).
+func TestComposeStack_ProjectRoundTrip(t *testing.T) {
+	const sentinel = "demo-xyz-round-trip"
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{AWSVPC: "Private VPC"},
+		Cfg:          &Config{},
+		Project:      sentinel,
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	varsTF := string(out["/variables.tf"])
+	require.Contains(t, varsTF, `variable "project"`,
+		"root variables.tf should declare variable project")
+	require.Contains(t, varsTF, sentinel,
+		"root variables.tf should carry ComposeStackOpts.Project as the project default")
+
+	require.Contains(t, out, "/aws_vpc.auto.tfvars")
+	vpcTf := string(out["/aws_vpc.auto.tfvars"])
+	require.Contains(t, vpcTf, sentinel,
+		"per-module .auto.tfvars should carry the Project value through the namespaced aws_vpc_project binding")
+
+	prov := string(out["/providers.tf"])
+	require.Contains(t, prov, "Project    = var.project",
+		"provider block should bind Project to var.project (not a hardcoded literal)")
 }
 
 func TestDefaultWiring_AWSECS(t *testing.T) {


### PR DESCRIPTION
Addresses every P2/P3 item from #111 in one shot — each is small and the story is more coherent when shipped together.

## Summary
- **Hoist `"insideout"` literal** to `insideoutManagedByValue` const in `pkg/composer/compose.go`, shared by default + `us_east_1` alias provider blocks.
- **GCP regression guard** in `TestComposeStack_GCP_Provider`: asserts absence of `default_tags` / `default_labels` (GCP has native per-session credential isolation; half-working AWS-shaped tagging should require a deliberate feature change, not a drive-by).
- **`TestComposeStack_DiscoveredProvidersReachRoot`**: new end-to-end test covering the `discovered` merge path in `generateProvidersTF` — selects `KeyAWSALB` (which declares `hashicorp/random`) and asserts the child provider reaches the root `providers.tf`.
- **`TestComposeStack_ProjectRoundTrip`**: new test rendering with `Project: "demo-xyz-round-trip"` and asserting the sentinel appears in root `variables.tf` default, per-module `.auto.tfvars`, and the provider `default_tags` binds `Project = var.project` (not a hardcoded literal).
- **Soften the #1112 comment** on `assertProviderBlocksHaveDefaultTags` — be explicit that it locks the HCL surface, not post-apply tag inheritance.
- **Version-independent comment** on `aws_cloudwatch_dashboard` tagging — drop the `v6.33.0` pin.
- **Examples `providers.tf` alignment**: all 10 AWS examples now declare `Project = var.project` in their `default_tags` block (Option (a) from #111; more honest if the examples are meant to be runnable). Added `variable "project"` to `examples/openclaw/variables.tf` which didn't already declare it.

## Drive-by spotted, not fixed
- `examples/mobileapi/providers.tf` (GCP) uses `region = "us-west-2"` which is not a GCP region. Filing as a separate issue.
- Pre-existing golangci-lint nits (`mapsloop` on `pkg/composer/compose.go:131/300/316/430/483`, `stringscutprefix` on `mapper.go:549/553`). Out of scope here.

## Test plan
- [x] ` go test ./pkg/composer/... -race ` — all pass
- [x] ` terraform fmt -check -recursive ` — clean
- [x] ` cd examples/<each> && terraform init -backend=false && terraform validate ` — all 10 AWS examples validate

Closes #111