### PR TITLE
refactor(composer): Phase 3a — deprecate remaining reliable-legacy exports

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -199,10 +199,13 @@ func (c *Client) ComposeSingle(opts ComposeSingleOpts) (Files, error) {
 /* ---------- Stack ---------- */
 
 type ComposeStackOpts struct {
-	Cloud                   string // "aws" or "gcp" (defaults to "aws" if empty)
-	SelectedKeys            []ComponentKey
-	Comps                   *Components
-	Cfg                     *Config
+	Cloud        string // "aws" or "gcp" (defaults to "aws" if empty)
+	SelectedKeys []ComponentKey
+	Comps        *Components
+	Cfg          *Config
+	// Deprecated: legacy compute-exclusivity escape hatch tracked by issue #76.
+	// Historical sessions that mixed standalone EC2 with Lambda relied on this;
+	// new callers should not set it.
 	AllowLegacyMixedCompute bool
 	Project, Region         string
 }

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -326,6 +326,11 @@ var ImplicitDependencies = map[ComponentKey][]ComponentKey{
 
 // LegacyToV2Key maps legacy (unprefixed) component keys to their V2 (aws_-prefixed) equivalents.
 // Used by DeduplicateKeys to remove legacy duplicates when both forms are present.
+//
+// Deprecated: part of the reliable-legacy compat layer tracked by issue #76.
+// New code should work with KeyAWS*-prefixed keys directly; legacy session
+// payloads should be normalised by reliable's composeradapter before reaching
+// composer.
 var LegacyToV2Key = map[ComponentKey]ComponentKey{
 	KeyVPC:                  KeyAWSVPC,
 	KeyALB:                  KeyAWSALB,
@@ -355,6 +360,9 @@ var LegacyToV2Key = map[ComponentKey]ComponentKey{
 // DeduplicateKeys removes legacy keys when their V2 equivalent is also present.
 // For example, if both KeyVPC and KeyAWSVPC are in keys, only KeyAWSVPC is kept.
 // This prevents duplicate Terraform module blocks for the same infrastructure.
+//
+// Deprecated: part of the reliable-legacy compat layer tracked by issue #76.
+// Callers that already produce AWS-prefixed keys should not need this.
 func DeduplicateKeys(keys []ComponentKey) []ComponentKey {
 	present := make(map[ComponentKey]bool, len(keys))
 	for _, k := range keys {

--- a/pkg/composer/doc.go
+++ b/pkg/composer/doc.go
@@ -22,8 +22,8 @@
 //
 // These symbols are not part of composer's supported public contract. If you
 // need to consume historical session payloads, use reliable's composeradapter
-// package (see luthersystems/reliable#998), which normalises legacy shapes to
-// the prefixed vocabulary before handing them to composer.
+// package (landed via luthersystems/reliable#1041), which normalises legacy
+// shapes to the prefixed vocabulary before handing them to composer.
 //
 // See luthersystems/insideout-terraform-presets#76 for the phased removal
 // plan.

--- a/pkg/composer/validate.go
+++ b/pkg/composer/validate.go
@@ -20,6 +20,9 @@ func NewValidationError(msg string) *ValidationError {
 func (e *ValidationError) Error() string { return e.msg }
 
 type ComputeExclusivityOpts struct {
+	// Deprecated: legacy compute-exclusivity escape hatch tracked by issue #76.
+	// Historical sessions that mixed standalone EC2 with Lambda relied on this;
+	// new callers should not set it.
 	AllowLegacyStandaloneEC2Lambda bool
 }
 


### PR DESCRIPTION
Partial progress on #76 Phase 3. Scoped intentionally small — just the deprecation-surface work. Structural collapse (Phase 3b) is a separate follow-up PR because it's coupled to test-fixture migration and changes rendered module paths.

## What this ships (safe, zero behaviour change)
- **doc.go:** bump the reliable adapter reference from the original draft (#998) to the merged PR (#1041).
- ` // Deprecated: ` godoc on the last four reliable-legacy exports that didn't already carry one:
  - ` LegacyToV2Key `
  - ` DeduplicateKeys `
  - ` ComposeStackOpts.AllowLegacyMixedCompute `
  - ` ComputeExclusivityOpts.AllowLegacyStandaloneEC2Lambda `

After this lands, golangci-lint's SA1019 rule flags any new reliable-side use of these symbols — matching the invariant established by reliable#1041.

## Deferred to Phase 3b (new PR)
Tightly coupled, higher-risk work that needs its own review:

- Collapse AWS→legacy normalisation switches in ` DefaultWiring ` (contracts.go) and ` BuildModuleValues ` (mapper.go).
- Simplify ` moduleRef ` / ` vpcRef ` / ... selectors to emit ` KeyAWS* `-only module references. **Note**: this changes rendered ` module."<name>" ` paths in ` main.tf ` (e.g. ` module.vpc ` → ` module.aws_vpc `) — any existing deployed stacks would need a ` terraform state mv ` migration. Worth a coordination note with operations before landing.
- Drop legacy ORs in ` isPublicVPC `, ` stackNeedsPrivateSubnets `, ` IsLambdaArchitecture `, ` BackupsSelected ` / ` legacyBackupsSelected `.
- Migrate ` builders_test.go ` kitchen-sink fixtures off legacy fields.

## Test plan
- [x] ` go build ./... && go vet ./... && go test -race ./pkg/composer/... ` — all pass
- [x] No behaviour change — pure godoc / reference string edits

Refs #76