### PR TITLE
chore(composer): resolve golangci-lint nits (mapsloop + stringscutprefix)

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -3,6 +3,7 @@ package composer
 import (
 	"fmt"
 	"io/fs"
+	"maps"
 	"path"
 	"sort"
 	"strings"
@@ -121,9 +122,7 @@ func (c *Client) ComposeSingle(opts ComposeSingleOpts) (Files, error) {
 	wired := DefaultWiring(selected, opts.Key, opts.Comps)
 
 	files := Files{}
-	for p, b := range rebasePresetFiles(leaf, moduleDir) {
-		files[p] = b
-	}
+	maps.Copy(files, rebasePresetFiles(leaf, moduleDir))
 
 	inputs := map[string]any{}
 	rootVars := map[string]any{
@@ -290,9 +289,7 @@ func (c *Client) ComposeStack(opts ComposeStackOpts) (Files, error) {
 			return nil, fmt.Errorf("preset for %s (path %q) returned no files", k, presetPath)
 		}
 
-		for p, b := range rebasePresetFiles(preset, dir) {
-			files[p] = b
-		}
+		maps.Copy(files, rebasePresetFiles(preset, dir))
 
 		vars, err := DiscoverModuleVars(preset)
 		if err != nil {
@@ -306,9 +303,7 @@ func (c *Client) ComposeStack(opts ComposeStackOpts) (Files, error) {
 		if err != nil {
 			return nil, err
 		}
-		for name, rp := range provs {
-			discoveredProviders[name] = rp
-		}
+		maps.Copy(discoveredProviders, provs)
 		if len(outputs) > 0 {
 			moduleOutputs = append(moduleOutputs, ModuleOutputs{
 				Module:  string(k),
@@ -420,9 +415,7 @@ func generateProvidersTF(cloud, region string, selected map[ComponentKey]bool, d
 			region = "us-central1"
 		}
 		required["google"] = RequiredProvider{Source: "hashicorp/google", Version: ">= 5.0"}
-		for name, rp := range discovered {
-			required[name] = rp
-		}
+		maps.Copy(required, discovered)
 		var b strings.Builder
 		b.WriteString("terraform {\n  required_providers {\n")
 		b.WriteString(renderRequiredProviders(required))
@@ -473,9 +466,7 @@ variable "external_id" {
   }`
 
 		required["aws"] = RequiredProvider{Source: "hashicorp/aws", Version: ">= 6.0"}
-		for name, rp := range discovered {
-			required[name] = rp
-		}
+		maps.Copy(required, discovered)
 
 		var b strings.Builder
 		b.WriteString(awsVarDecls)

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -532,12 +532,12 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.Lambda.Timeout != "" {
 				// Convert "3s", "30s", "15m" to seconds
 				t := cfg.Lambda.Timeout
-				if strings.HasSuffix(t, "s") {
-					if n, err := strconv.Atoi(strings.TrimSuffix(t, "s")); err == nil {
+				if trimmed, ok := strings.CutSuffix(t, "s"); ok {
+					if n, err := strconv.Atoi(trimmed); err == nil {
 						vals["timeout"] = n
 					}
-				} else if strings.HasSuffix(t, "m") {
-					if n, err := strconv.Atoi(strings.TrimSuffix(t, "m")); err == nil {
+				} else if trimmed, ok := strings.CutSuffix(t, "m"); ok {
+					if n, err := strconv.Atoi(trimmed); err == nil {
 						vals["timeout"] = n * 60
 					}
 				}


### PR DESCRIPTION
Single bundle PR for the pre-existing golangci-lint nits that surfaced during #113/#114/#116 review. No behaviour change; pure idiom swap.

## Changes

**` pkg/composer/compose.go ` (mapsloop):** five ` for k, v := range src { dst[k] = v } ` loops collapsed to ` maps.Copy(dst, src) `. Adds the ` maps ` stdlib import.

- ` ComposeSingle ` — copying rebased preset files into the root ` files ` map
- ` ComposeStack ` — copying rebased preset files into the root ` files ` map
- ` ComposeStack ` — merging discovered required_providers per child module
- ` generateProvidersTF ` (GCP branch) — merging discovered providers into the root required_providers map
- ` generateProvidersTF ` (AWS branch) — same, for the AWS branch

**` pkg/composer/mapper.go ` (stringscutprefix):** two ` HasSuffix ` + ` TrimSuffix ` pairs in the Lambda timeout parser collapsed to ` strings.CutSuffix `.

## Test plan
- [x] ` go build ./... && go vet ./... && go test -race ./pkg/composer/... ` — clean
- [x] No behaviour change — all test cases (including the Lambda timeout parser tests) pass unchanged

## Go version note
` maps.Copy ` and ` strings.CutSuffix ` are both Go 1.21+. ` go.mod ` is on ` go 1.24.0 `, so no toolchain bump needed.