### PR TITLE
Bundle: VPC NAT knob + tagging follow-ups + composer Phase 3a + lint cleanup + docs (#106 #111 #76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ InsideOut is a streamlined platform to build, configure, deploy, and manage your
 *   **Agent Prototype**: [insideout.luthersystemsapp.com](https://insideout.luthersystemsapp.com)
 *   **Discord Community**: [insideout.luthersystems.com/discord](https://insideout.luthersystems.com/discord)
 *   **Subreddit**: [r/luthersystems](https://www.reddit.com/r/luthersystems/)
+*   **Kiro IDE Power**: [insideout-power](https://github.com/luthersystems/insideout-power) — Kiro IDE Power for AI-powered cloud infrastructure design
 
 ## About These Presets
 

--- a/aws/cloudwatchmonitoring/main.tf
+++ b/aws/cloudwatchmonitoring/main.tf
@@ -237,8 +237,8 @@ locals {
 resource "aws_cloudwatch_dashboard" "main" {
   dashboard_name = module.name.name
   dashboard_body = jsonencode({ widgets = local.dash_metrics })
-  # NOTE: aws_cloudwatch_dashboard does not accept a `tags` argument in
-  # the hashicorp/aws provider (as of v6.33.0). CloudWatch dashboards are
+  # NOTE: the hashicorp/aws provider currently does not support the `tags`
+  # argument on `aws_cloudwatch_dashboard`. CloudWatch dashboards are
   # therefore untaggable from Terraform, even though the AWS API supports
   # it. When/if the provider adds the argument, add:
   #   tags = merge(module.name.tags, var.tags)

--- a/aws/vpc/variables.tf
+++ b/aws/vpc/variables.tf
@@ -33,7 +33,7 @@ variable "vpc_cidr" {
 }
 
 variable "az_count" {
-  description = "Number of AZs to use for subnets"
+  description = "Number of AZs to span with public+private subnets. Also bounds the number of NAT gateways when single_nat_gateway=false. 2 is recommended for HA."
   type        = number
   default     = 2
 
@@ -45,13 +45,23 @@ variable "az_count" {
 }
 
 variable "enable_nat_gateway" {
-  description = "Enable NAT gateway for private subnets (set false for public-only VPCs)"
+  description = "Enable NAT gateways so private subnets can reach the public internet. Set false only for public-only VPCs (no private workloads). Topology (one vs one-per-AZ) is controlled by single_nat_gateway."
   type        = bool
   default     = true
 }
 
 variable "single_nat_gateway" {
-  description = "Use a single NAT gateway (cost saver) instead of one per AZ"
+  description = <<-EOT
+    Provision exactly one NAT gateway (in the first public subnet / first AZ) shared by all private subnets,
+    instead of one NAT gateway per AZ. Defaults to true for cost.
+
+    - true (default): cheapest, ~1/N the NAT cost, but (a) single point of failure if that AZ goes down
+      and (b) every stack in the account lands its NAT in the first AZ — accounts running multiple stacks
+      can exhaust the per-AZ NAT gateway quota (default 5) before running out of the VPC quota.
+    - false: one NAT gateway per AZ (as bounded by az_count). ~N× cost, no per-AZ SPOF, spreads NAT
+      quota usage across AZs. Recommended once an account runs more than a handful of concurrent VPCs
+      or whenever AZ-level availability is a requirement.
+  EOT
   type        = bool
   default     = true
 }

--- a/examples/cargofit/providers.tf
+++ b/examples/cargofit/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }
@@ -21,6 +22,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/edubot/providers.tf
+++ b/examples/edubot/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }
@@ -21,6 +22,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/gamestudio/providers.tf
+++ b/examples/gamestudio/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-west-2"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/guestbook/providers.tf
+++ b/examples/guestbook/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-west-2"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }
@@ -21,6 +22,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/inboundfund-tf/providers.tf
+++ b/examples/inboundfund-tf/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }
@@ -21,6 +22,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/localbook/providers.tf
+++ b/examples/localbook/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-west-2"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/locallink/providers.tf
+++ b/examples/locallink/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-west-2"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/openclaw/providers.tf
+++ b/examples/openclaw/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-west-2"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/openclaw/variables.tf
+++ b/examples/openclaw/variables.tf
@@ -4,6 +4,12 @@ variable "environment" {
   default     = "sandbox"
 }
 
+variable "project" {
+  description = "Root project name, stamped into the provider default_tags block so every AWS resource carries a Project tag"
+  type        = string
+  default     = "openclaw"
+}
+
 variable "vpc_project" {
   description = "Project name for VPC"
   type        = string

--- a/examples/openclaw/variables.tf
+++ b/examples/openclaw/variables.tf
@@ -11,7 +11,7 @@ variable "project" {
 }
 
 variable "vpc_project" {
-  description = "Project name for VPC"
+  description = "Project name for VPC. Keep in sync with var.project — the Project tag stamped in the provider default_tags block is read from var.project, not var.vpc_project, so a mismatch produces inconsistent tagging."
   type        = string
 }
 
@@ -21,7 +21,7 @@ variable "vpc_region" {
 }
 
 variable "ec2_project" {
-  description = "Project name for EC2 instance"
+  description = "Project name for EC2 instance. Keep in sync with var.project; see vpc_project."
   type        = string
 }
 

--- a/examples/revisionapp/providers.tf
+++ b/examples/revisionapp/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }
@@ -21,6 +22,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/examples/videostreaming/providers.tf
+++ b/examples/videostreaming/providers.tf
@@ -11,6 +11,7 @@ provider "aws" {
   region = "us-west-2"
   default_tags {
     tags = {
+      Project    = var.project
       managed-by = "insideout"
     }
   }

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -10,6 +10,12 @@ import (
 	terraformpresets "github.com/luthersystems/insideout-terraform-presets"
 )
 
+// insideoutManagedByValue is the value stamped into the `managed-by` tag on
+// every AWS resource rendered by the composer. Hoisted to a package-level
+// constant so the default_tags emission and any other call sites that care
+// about org identity share a single source of truth.
+const insideoutManagedByValue = "insideout"
+
 // Option configures a Client.
 type Option func(*Client)
 
@@ -464,13 +470,13 @@ variable "external_id" {
 		// the `tags = merge(module.name.tags, ...)` convention. The reliable
 		// MCP inspector filters resources by Project to prevent cross-session
 		// data leaks.
-		const awsDefaultTags = `
+		awsDefaultTags := fmt.Sprintf(`
   default_tags {
     tags = {
       Project    = var.project
-      managed-by = "insideout"
+      managed-by = %q
     }
-  }`
+  }`, insideoutManagedByValue)
 
 		required["aws"] = RequiredProvider{Source: "hashicorp/aws", Version: ">= 6.0"}
 		for name, rp := range discovered {

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -199,10 +199,13 @@ func (c *Client) ComposeSingle(opts ComposeSingleOpts) (Files, error) {
 /* ---------- Stack ---------- */
 
 type ComposeStackOpts struct {
-	Cloud                   string // "aws" or "gcp" (defaults to "aws" if empty)
-	SelectedKeys            []ComponentKey
-	Comps                   *Components
-	Cfg                     *Config
+	Cloud        string // "aws" or "gcp" (defaults to "aws" if empty)
+	SelectedKeys []ComponentKey
+	Comps        *Components
+	Cfg          *Config
+	// Deprecated: legacy compute-exclusivity escape hatch tracked by issue #76.
+	// Historical sessions that mixed standalone EC2 with Lambda relied on this;
+	// new callers should not set it.
 	AllowLegacyMixedCompute bool
 	Project, Region         string
 }

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -3,6 +3,7 @@ package composer
 import (
 	"fmt"
 	"io/fs"
+	"maps"
 	"path"
 	"sort"
 	"strings"
@@ -121,9 +122,7 @@ func (c *Client) ComposeSingle(opts ComposeSingleOpts) (Files, error) {
 	wired := DefaultWiring(selected, opts.Key, opts.Comps)
 
 	files := Files{}
-	for p, b := range rebasePresetFiles(leaf, moduleDir) {
-		files[p] = b
-	}
+	maps.Copy(files, rebasePresetFiles(leaf, moduleDir))
 
 	inputs := map[string]any{}
 	rootVars := map[string]any{
@@ -290,9 +289,7 @@ func (c *Client) ComposeStack(opts ComposeStackOpts) (Files, error) {
 			return nil, fmt.Errorf("preset for %s (path %q) returned no files", k, presetPath)
 		}
 
-		for p, b := range rebasePresetFiles(preset, dir) {
-			files[p] = b
-		}
+		maps.Copy(files, rebasePresetFiles(preset, dir))
 
 		vars, err := DiscoverModuleVars(preset)
 		if err != nil {
@@ -306,9 +303,7 @@ func (c *Client) ComposeStack(opts ComposeStackOpts) (Files, error) {
 		if err != nil {
 			return nil, err
 		}
-		for name, rp := range provs {
-			discoveredProviders[name] = rp
-		}
+		maps.Copy(discoveredProviders, provs)
 		if len(outputs) > 0 {
 			moduleOutputs = append(moduleOutputs, ModuleOutputs{
 				Module:  string(k),
@@ -420,9 +415,7 @@ func generateProvidersTF(cloud, region string, selected map[ComponentKey]bool, d
 			region = "us-central1"
 		}
 		required["google"] = RequiredProvider{Source: "hashicorp/google", Version: ">= 5.0"}
-		for name, rp := range discovered {
-			required[name] = rp
-		}
+		maps.Copy(required, discovered)
 		var b strings.Builder
 		b.WriteString("terraform {\n  required_providers {\n")
 		b.WriteString(renderRequiredProviders(required))
@@ -473,9 +466,7 @@ variable "external_id" {
   }`
 
 		required["aws"] = RequiredProvider{Source: "hashicorp/aws", Version: ">= 6.0"}
-		for name, rp := range discovered {
-			required[name] = rp
-		}
+		maps.Copy(required, discovered)
 
 		var b strings.Builder
 		b.WriteString(awsVarDecls)

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -1875,6 +1875,12 @@ func TestComposeStack_GCP_Provider(t *testing.T) {
 	// someone adding half-working GCP tagging by accident — if a parity
 	// story ever lands it should be a deliberate feature change that updates
 	// this test, not a drive-by edit.
+	//
+	// Scope note: provStr is the root /providers.tf only (no preset contents),
+	// so a NotContains on the full string has negligible false-positive risk
+	// from a module name or comment mentioning "default_tags". If the haystack
+	// ever widens to include preset bodies, scope the check to the
+	// `provider "google" { ... }` block.
 	require.NotContains(t, provStr, "default_labels",
 		"GCP provider block should not declare default_labels (see #111; any GCP tagging parity should land via a deliberate feature, not a drive-by edit)")
 	require.NotContains(t, provStr, "default_tags",
@@ -1888,6 +1894,18 @@ func TestComposeStack_GCP_Provider(t *testing.T) {
 // DiscoverRequiredProviders alone don't cover the merge in generateProvidersTF.
 func TestComposeStack_DiscoveredProvidersReachRoot(t *testing.T) {
 	c := newTestClient()
+
+	// Precondition: the ALB preset really does declare hashicorp/random in
+	// its required_providers. If this test silently becomes a no-op because
+	// the ALB module dropped the provider, the precondition fails first —
+	// much clearer diagnostic than a passing assertion on an absent string.
+	albFiles, err := c.GetPresetFiles("aws/alb")
+	require.NoError(t, err)
+	albProvs, err := DiscoverRequiredProviders(albFiles)
+	require.NoError(t, err)
+	require.Contains(t, albProvs, "random",
+		"precondition: aws/alb preset should declare a random = {...} required_provider; if this fails, pick a different preset to exercise the discovered-providers merge")
+
 	out, err := c.ComposeStack(ComposeStackOpts{
 		Cloud:        "aws",
 		SelectedKeys: []ComponentKey{KeyAWSVPC, KeyAWSALB},
@@ -1903,12 +1921,19 @@ func TestComposeStack_DiscoveredProvidersReachRoot(t *testing.T) {
 		"root providers.tf should include the ALB module's discovered hashicorp/random required_providers entry")
 	require.Contains(t, prov, "hashicorp/aws",
 		"root providers.tf should keep the cloud's base required_provider entry")
+	// Lock the merge location: hashicorp/random must appear inside a
+	// `random = { ... }` entry (i.e. it's a keyed required_providers block,
+	// not a stray substring in a comment or module name).
+	require.Regexp(t, regexp.MustCompile(`(?s)random\s*=\s*\{[^}]*hashicorp/random`), prov,
+		"hashicorp/random should be attached to a random = {...} entry in required_providers, not just appear as a substring")
 }
 
 // TestComposeStack_ProjectRoundTrip renders with a distinctive Project value
-// and asserts that value flows through to both the root variables.tf default
-// and per-module .auto.tfvars. Guards against a refactor replacing var.project
-// with a hardcoded literal (which would defeat cross-session isolation).
+// and asserts that value flows through to the root variables.tf default, the
+// per-module .auto.tfvars, and the provider default_tags block. Each
+// assertion binds the sentinel to the specific variable/declaration it
+// belongs to — a bare substring match would pass even if the sentinel landed
+// in an unrelated comment or the wrong variable.
 func TestComposeStack_ProjectRoundTrip(t *testing.T) {
 	const sentinel = "demo-xyz-round-trip"
 	c := newTestClient()
@@ -1922,20 +1947,32 @@ func TestComposeStack_ProjectRoundTrip(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Root variables.tf: the sentinel must appear as the default of the
+	// `variable "project"` block, not somewhere else (a module name, a
+	// comment, another variable's default).
 	varsTF := string(out["/variables.tf"])
-	require.Contains(t, varsTF, `variable "project"`,
-		"root variables.tf should declare variable project")
-	require.Contains(t, varsTF, sentinel,
-		"root variables.tf should carry ComposeStackOpts.Project as the project default")
+	require.Regexp(t,
+		regexp.MustCompile(`(?s)variable "project"\s*\{[^}]*default\s*=\s*"`+regexp.QuoteMeta(sentinel)+`"`),
+		varsTF,
+		"root variables.tf should carry ComposeStackOpts.Project as the default of variable \"project\"")
 
+	// Per-module .auto.tfvars: sentinel must be bound to aws_vpc_project
+	// specifically, not aws_vpc_region or any other key.
 	require.Contains(t, out, "/aws_vpc.auto.tfvars")
 	vpcTf := string(out["/aws_vpc.auto.tfvars"])
-	require.Contains(t, vpcTf, sentinel,
-		"per-module .auto.tfvars should carry the Project value through the namespaced aws_vpc_project binding")
+	require.Regexp(t,
+		regexp.MustCompile(`(?m)^\s*aws_vpc_project\s*=\s*"`+regexp.QuoteMeta(sentinel)+`"\s*$`),
+		vpcTf,
+		"aws_vpc.auto.tfvars should bind aws_vpc_project to the sentinel, not leak it into another key")
 
+	// Provider default_tags: `Project = var.project` must appear (the binding
+	// is what makes the round-trip work at apply time). Whitespace-tolerant
+	// regex matches terraform fmt output.
 	prov := string(out["/providers.tf"])
-	require.Contains(t, prov, "Project    = var.project",
-		"provider block should bind Project to var.project (not a hardcoded literal)")
+	require.Regexp(t,
+		regexp.MustCompile(`Project\s*=\s*var\.project`),
+		prov,
+		"provider default_tags should bind Project to var.project (not a hardcoded literal)")
 }
 
 func TestDefaultWiring_AWSECS(t *testing.T) {

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -18,11 +18,13 @@ func writeOutputs(t *testing.T, files Files, dir string) {
 
 // assertProviderBlocksHaveDefaultTags splits providers.tf by `provider "aws" {`
 // and asserts that (1) exactly wantBlocks provider "aws" blocks exist, and
-// (2) each block contains a default_tags block with Project = var.project and
+// (2) each block declares a default_tags block with Project = var.project and
 // managed-by = "insideout". Split-and-check proves placement per block (a
 // regression dropping default_tags from the alias block would otherwise slip
 // past a global strings.Count), and regex matches tolerate whitespace-only
-// formatting changes from terraform fmt. Locks the safety net for #1112.
+// formatting changes from terraform fmt. Note this locks the HCL surface of
+// the provider blocks — it does not prove rendered resources inherit the tag
+// at terraform apply, which requires a plan-json round-trip.
 func assertProviderBlocksHaveDefaultTags(t *testing.T, prov string, wantBlocks int) {
 	t.Helper()
 	chunks := strings.Split(prov, `provider "aws" {`)
@@ -1866,6 +1868,74 @@ func TestComposeStack_GCP_Provider(t *testing.T) {
 	require.Contains(t, provStr, "hashicorp/google", "should use Google provider")
 	require.Contains(t, provStr, `provider "google"`, "should have google provider block")
 	require.Contains(t, provStr, "us-central1", "should use specified region")
+
+	// GCP intentionally has no default_tags / default_labels safety net: the
+	// google provider has native per-session credential isolation via
+	// creds.ProjectID and Reliable #1112's scope was AWS-only. Guard against
+	// someone adding half-working GCP tagging by accident — if a parity
+	// story ever lands it should be a deliberate feature change that updates
+	// this test, not a drive-by edit.
+	require.NotContains(t, provStr, "default_labels",
+		"GCP provider block should not declare default_labels (see #111; any GCP tagging parity should land via a deliberate feature, not a drive-by edit)")
+	require.NotContains(t, provStr, "default_tags",
+		"GCP provider block should not borrow AWS-shaped default_tags")
+}
+
+// TestComposeStack_DiscoveredProvidersReachRoot exercises the end-to-end path
+// where a child module's non-AWS `required_providers` declaration (e.g. ALB
+// declaring hashicorp/random) is discovered via DiscoverRequiredProviders
+// and merged into the root providers.tf. Unit tests on
+// DiscoverRequiredProviders alone don't cover the merge in generateProvidersTF.
+func TestComposeStack_DiscoveredProvidersReachRoot(t *testing.T) {
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC, KeyAWSALB},
+		Comps:        &Components{AWSVPC: "Private VPC", AWSALB: ptrBool(true)},
+		Cfg:          &Config{},
+		Project:      "discovered-test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	prov := string(out["/providers.tf"])
+	require.Contains(t, prov, "hashicorp/random",
+		"root providers.tf should include the ALB module's discovered hashicorp/random required_providers entry")
+	require.Contains(t, prov, "hashicorp/aws",
+		"root providers.tf should keep the cloud's base required_provider entry")
+}
+
+// TestComposeStack_ProjectRoundTrip renders with a distinctive Project value
+// and asserts that value flows through to both the root variables.tf default
+// and per-module .auto.tfvars. Guards against a refactor replacing var.project
+// with a hardcoded literal (which would defeat cross-session isolation).
+func TestComposeStack_ProjectRoundTrip(t *testing.T) {
+	const sentinel = "demo-xyz-round-trip"
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{AWSVPC: "Private VPC"},
+		Cfg:          &Config{},
+		Project:      sentinel,
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	varsTF := string(out["/variables.tf"])
+	require.Contains(t, varsTF, `variable "project"`,
+		"root variables.tf should declare variable project")
+	require.Contains(t, varsTF, sentinel,
+		"root variables.tf should carry ComposeStackOpts.Project as the project default")
+
+	require.Contains(t, out, "/aws_vpc.auto.tfvars")
+	vpcTf := string(out["/aws_vpc.auto.tfvars"])
+	require.Contains(t, vpcTf, sentinel,
+		"per-module .auto.tfvars should carry the Project value through the namespaced aws_vpc_project binding")
+
+	prov := string(out["/providers.tf"])
+	require.Contains(t, prov, "Project    = var.project",
+		"provider block should bind Project to var.project (not a hardcoded literal)")
 }
 
 func TestDefaultWiring_AWSECS(t *testing.T) {

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -326,6 +326,11 @@ var ImplicitDependencies = map[ComponentKey][]ComponentKey{
 
 // LegacyToV2Key maps legacy (unprefixed) component keys to their V2 (aws_-prefixed) equivalents.
 // Used by DeduplicateKeys to remove legacy duplicates when both forms are present.
+//
+// Deprecated: part of the reliable-legacy compat layer tracked by issue #76.
+// New code should work with KeyAWS*-prefixed keys directly; legacy session
+// payloads should be normalised by reliable's composeradapter before reaching
+// composer.
 var LegacyToV2Key = map[ComponentKey]ComponentKey{
 	KeyVPC:                  KeyAWSVPC,
 	KeyALB:                  KeyAWSALB,
@@ -355,6 +360,9 @@ var LegacyToV2Key = map[ComponentKey]ComponentKey{
 // DeduplicateKeys removes legacy keys when their V2 equivalent is also present.
 // For example, if both KeyVPC and KeyAWSVPC are in keys, only KeyAWSVPC is kept.
 // This prevents duplicate Terraform module blocks for the same infrastructure.
+//
+// Deprecated: part of the reliable-legacy compat layer tracked by issue #76.
+// Callers that already produce AWS-prefixed keys should not need this.
 func DeduplicateKeys(keys []ComponentKey) []ComponentKey {
 	present := make(map[ComponentKey]bool, len(keys))
 	for _, k := range keys {

--- a/pkg/composer/doc.go
+++ b/pkg/composer/doc.go
@@ -22,8 +22,8 @@
 //
 // These symbols are not part of composer's supported public contract. If you
 // need to consume historical session payloads, use reliable's composeradapter
-// package (see luthersystems/reliable#998), which normalises legacy shapes to
-// the prefixed vocabulary before handing them to composer.
+// package (landed via luthersystems/reliable#1041), which normalises legacy
+// shapes to the prefixed vocabulary before handing them to composer.
 //
 // See luthersystems/insideout-terraform-presets#76 for the phased removal
 // plan.

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -532,12 +532,12 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.Lambda.Timeout != "" {
 				// Convert "3s", "30s", "15m" to seconds
 				t := cfg.Lambda.Timeout
-				if strings.HasSuffix(t, "s") {
-					if n, err := strconv.Atoi(strings.TrimSuffix(t, "s")); err == nil {
+				if trimmed, ok := strings.CutSuffix(t, "s"); ok {
+					if n, err := strconv.Atoi(trimmed); err == nil {
 						vals["timeout"] = n
 					}
-				} else if strings.HasSuffix(t, "m") {
-					if n, err := strconv.Atoi(strings.TrimSuffix(t, "m")); err == nil {
+				} else if trimmed, ok := strings.CutSuffix(t, "m"); ok {
+					if n, err := strconv.Atoi(trimmed); err == nil {
 						vals["timeout"] = n * 60
 					}
 				}

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -161,6 +161,20 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+		// Topology knobs from Config.AWSVPC override Public-VPC-derived defaults.
+		// Unset pointer fields defer to the HCL default.
+		if cfg != nil && cfg.AWSVPC != nil {
+			if cfg.AWSVPC.SingleNATGateway != nil {
+				vals["single_nat_gateway"] = *cfg.AWSVPC.SingleNATGateway
+			}
+			if cfg.AWSVPC.EnableNATGateway != nil {
+				vals["enable_nat_gateway"] = *cfg.AWSVPC.EnableNATGateway
+			}
+			if cfg.AWSVPC.AZCount != nil {
+				vals["az_count"] = *cfg.AWSVPC.AZCount
+			}
+		}
+
 	case KeyCloud:
 		// Example: cloud/provider selection
 		if comps != nil && comps.Cloud != "" {

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -164,6 +164,26 @@ func (m DefaultMapper) BuildModuleValues(
 		// Topology knobs from Config.AWSVPC override Public-VPC-derived defaults.
 		// Unset pointer fields defer to the HCL default.
 		if cfg != nil && cfg.AWSVPC != nil {
+			// Reject EnableNATGateway=false when the stack has components that
+			// require private subnets with egress (EKS/ECS/RDS/ElastiCache/
+			// OpenSearch/EC2 node groups). Private subnets without NAT can't
+			// pull container images or run package installs, so the apply
+			// would break much later than it needs to. Fail fast here.
+			if cfg.AWSVPC.EnableNATGateway != nil && !*cfg.AWSVPC.EnableNATGateway && stackNeedsPrivateSubnets(comps) {
+				return nil, NewValidationError(
+					"AWSVPC.EnableNATGateway=false is incompatible with components that require private subnets " +
+						"(EKS/ECS/RDS/ElastiCache/OpenSearch/EC2 node groups): private subnets without NAT cannot reach " +
+						"the public internet, breaking image pulls and package installs. Either re-enable NAT or drop " +
+						"the downstream components",
+				)
+			}
+			// AZCount bounds — HCL validation says >= 1; enforce the same at
+			// the mapper so users see a Go-level error before `terraform plan`.
+			if cfg.AWSVPC.AZCount != nil && *cfg.AWSVPC.AZCount < 1 {
+				return nil, NewValidationError(fmt.Sprintf(
+					"AWSVPC.AZCount must be >= 1, got %d", *cfg.AWSVPC.AZCount,
+				))
+			}
 			if cfg.AWSVPC.SingleNATGateway != nil {
 				vals["single_nat_gateway"] = *cfg.AWSVPC.SingleNATGateway
 			}

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -189,80 +189,174 @@ func TestStackNeedsPrivateSubnets(t *testing.T) {
 	assert.True(t, stackNeedsPrivateSubnets(&Components{AWSEC2: "ARM"}), "AWSEC2 ARM")
 }
 
+// cfgWithAWSVPC builds a Config with an AWSVPC sub-config populated from the
+// provided pointer fields. Kills the anonymous-struct literal repetition that
+// would otherwise appear in every subtest below.
+func cfgWithAWSVPC(single, enable *bool, az *int) *Config {
+	c := &Config{}
+	c.AWSVPC = &struct {
+		SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+		EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+		AZCount          *int  `json:"azCount,omitempty"`
+	}{SingleNATGateway: single, EnableNATGateway: enable, AZCount: az}
+	return c
+}
+
 func TestBuildModuleValues_VPC_AWSVPCConfig(t *testing.T) {
 	m := DefaultMapper{}
 	boolPtr := func(v bool) *bool { return &v }
 	intPtr := func(v int) *int { return &v }
 
 	t.Run("SingleNATGateway=false writes single_nat_gateway=false", func(t *testing.T) {
-		cfg := &Config{AWSVPC: &struct {
-			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
-			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
-			AZCount          *int  `json:"azCount,omitempty"`
-		}{SingleNATGateway: boolPtr(false)}}
+		cfg := cfgWithAWSVPC(boolPtr(false), nil, nil)
 		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
 		require.NoError(t, err)
-		assert.Equal(t, false, vals["single_nat_gateway"])
+		// Type-guard the cast so a future mutation writing a stringified bool
+		// would fail the type assertion rather than pass assert.Equal.
+		assert.False(t, vals["single_nat_gateway"].(bool))
 	})
 
-	t.Run("AZCount=3 writes az_count=3", func(t *testing.T) {
-		cfg := &Config{AWSVPC: &struct {
-			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
-			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
-			AZCount          *int  `json:"azCount,omitempty"`
-		}{AZCount: intPtr(3)}}
+	t.Run("AZCount=3 writes az_count=3 as int", func(t *testing.T) {
+		cfg := cfgWithAWSVPC(nil, nil, intPtr(3))
 		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
 		require.NoError(t, err)
-		assert.Equal(t, 3, vals["az_count"])
+		assert.Equal(t, 3, vals["az_count"].(int))
 	})
 
 	t.Run("unset fields do not write to vals (defer to HCL default)", func(t *testing.T) {
-		cfg := &Config{AWSVPC: &struct {
-			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
-			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
-			AZCount          *int  `json:"azCount,omitempty"`
-		}{}}
+		cfg := cfgWithAWSVPC(nil, nil, nil)
 		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
 		require.NoError(t, err)
-		_, hasSingle := vals["single_nat_gateway"]
-		_, hasEnable := vals["enable_nat_gateway"]
-		_, hasAZ := vals["az_count"]
-		assert.False(t, hasSingle, "SingleNATGateway unset should not write single_nat_gateway")
-		assert.False(t, hasEnable, "EnableNATGateway unset should not write enable_nat_gateway")
-		assert.False(t, hasAZ, "AZCount unset should not write az_count")
+		for _, k := range []string{"single_nat_gateway", "enable_nat_gateway", "az_count"} {
+			_, has := vals[k]
+			assert.False(t, has, "unset pointer should not write %q", k)
+		}
 	})
 
-	t.Run("nil cfg.AWSVPC is a no-op", func(t *testing.T) {
+	t.Run("nil cfg.AWSVPC is a no-op — no VPC-topology keys leak", func(t *testing.T) {
 		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, &Config{}, "test", "us-east-1")
 		require.NoError(t, err)
-		_, hasSingle := vals["single_nat_gateway"]
-		assert.False(t, hasSingle)
+		for _, k := range []string{"single_nat_gateway", "enable_nat_gateway", "az_count"} {
+			_, has := vals[k]
+			assert.False(t, has, "nil cfg.AWSVPC should not write %q", k)
+		}
 	})
 
-	t.Run("Public VPC with user SingleNATGateway=false: both apply (enable_nat_gateway=false from Public VPC, single_nat_gateway=false from user)", func(t *testing.T) {
+	t.Run("Public VPC with user SingleNATGateway=false: both apply", func(t *testing.T) {
+		// Public VPC forces enable_nat_gateway=false (no private subnets);
+		// user's SingleNATGateway=false still applies (vestigial but not wrong).
 		comps := &Components{AWSVPC: "Public VPC"}
-		cfg := &Config{AWSVPC: &struct {
-			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
-			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
-			AZCount          *int  `json:"azCount,omitempty"`
-		}{SingleNATGateway: boolPtr(false)}}
+		cfg := cfgWithAWSVPC(boolPtr(false), nil, nil)
 		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
 		require.NoError(t, err)
-		assert.Equal(t, false, vals["enable_nat_gateway"], "Public VPC still wins on enable_nat_gateway")
-		assert.Equal(t, false, vals["single_nat_gateway"], "user config still applies to single_nat_gateway")
+		assert.False(t, vals["enable_nat_gateway"].(bool), "Public VPC sets enable_nat_gateway=false")
+		assert.False(t, vals["single_nat_gateway"].(bool), "user config still applies")
 	})
 
 	t.Run("user EnableNATGateway=true overrides Public-VPC-derived false", func(t *testing.T) {
 		comps := &Components{AWSVPC: "Public VPC"}
-		cfg := &Config{AWSVPC: &struct {
-			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
-			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
-			AZCount          *int  `json:"azCount,omitempty"`
-		}{EnableNATGateway: boolPtr(true)}}
+		cfg := cfgWithAWSVPC(nil, boolPtr(true), nil)
 		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
 		require.NoError(t, err)
-		assert.Equal(t, true, vals["enable_nat_gateway"], "user override wins over Public VPC default")
+		assert.True(t, vals["enable_nat_gateway"].(bool), "user override wins over Public VPC default")
 	})
+}
+
+// TestBuildModuleValues_VPC_AWSVPCConfig_Validation pins the mapper-level
+// validation for invalid Config.AWSVPC combinations that would produce a
+// broken stack (private subnets without egress) or fail at `terraform validate`.
+// Catching these in Go fails fast and gives actionable errors.
+func TestBuildModuleValues_VPC_AWSVPCConfig_Validation(t *testing.T) {
+	m := DefaultMapper{}
+	boolPtr := func(v bool) *bool { return &v }
+	intPtr := func(v int) *int { return &v }
+
+	t.Run("EnableNATGateway=false with EKS returns ValidationError", func(t *testing.T) {
+		comps := &Components{AWSEKS: boolPtr(true)}
+		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
+		_, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.Error(t, err)
+		var verr *ValidationError
+		assert.ErrorAs(t, err, &verr, "should return ValidationError so API-layer can HTTP 400")
+		assert.Contains(t, err.Error(), "EnableNATGateway=false",
+			"error should name the offending knob")
+	})
+
+	t.Run("EnableNATGateway=false with RDS returns ValidationError", func(t *testing.T) {
+		comps := &Components{AWSRDS: boolPtr(true)}
+		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
+		_, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.Error(t, err)
+	})
+
+	t.Run("EnableNATGateway=false with legacy Postgres returns ValidationError", func(t *testing.T) {
+		comps := &Components{Postgres: boolPtr(true)}
+		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
+		_, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.Error(t, err)
+	})
+
+	t.Run("EnableNATGateway=false without downstream components is allowed", func(t *testing.T) {
+		comps := &Components{} // no private-subnet consumers
+		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
+		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.NoError(t, err, "public-only VPC with NAT disabled is valid")
+		assert.False(t, vals["enable_nat_gateway"].(bool))
+	})
+
+	t.Run("AZCount=0 returns ValidationError", func(t *testing.T) {
+		cfg := cfgWithAWSVPC(nil, nil, intPtr(0))
+		_, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "AZCount")
+	})
+
+	t.Run("AZCount=-1 returns ValidationError", func(t *testing.T) {
+		cfg := cfgWithAWSVPC(nil, nil, intPtr(-1))
+		_, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
+		require.Error(t, err)
+	})
+
+	t.Run("AZCount=1 is allowed (HCL default >= 1)", func(t *testing.T) {
+		cfg := cfgWithAWSVPC(nil, nil, intPtr(1))
+		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		assert.Equal(t, 1, vals["az_count"].(int))
+	})
+}
+
+// TestBuildModuleValues_VPC_MapperHCLContract protects against typos in the
+// mapper's output keys. A mutation renaming a vals[...] key in mapper.go to
+// something not declared in aws/vpc/variables.tf previously passed every unit
+// test (the composer's variable-discovery step silently drops unknown keys).
+// Reads the actual preset variables.tf via DiscoverModuleVars and asserts every
+// key the mapper writes for KeyAWSVPC with all AWSVPC knobs set is declared.
+func TestBuildModuleValues_VPC_MapperHCLContract(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+	intPtr := func(v int) *int { return &v }
+
+	presets, err := newTestClient().GetPresetFiles("aws/vpc")
+	require.NoError(t, err)
+	declared, err := DiscoverModuleVars(presets)
+	require.NoError(t, err)
+	declaredSet := make(map[string]bool, len(declared))
+	for _, v := range declared {
+		declaredSet[v.Name] = true
+	}
+
+	// Exercise every AWSVPC knob so the full set of mapper-written keys is
+	// present in vals.
+	cfg := cfgWithAWSVPC(boolPtr(false), boolPtr(true), intPtr(3))
+	vals, err := DefaultMapper{}.BuildModuleValues(
+		KeyAWSVPC, &Components{AWSVPC: "Private VPC"}, cfg, "test", "us-east-1",
+	)
+	require.NoError(t, err)
+
+	for k := range vals {
+		assert.True(t, declaredSet[k],
+			"mapper wrote key %q but aws/vpc/variables.tf does not declare it; the composer would silently drop it",
+			k)
+	}
 }
 
 // TestBuildModuleValues_V2KeyNormalization verifies that calling BuildModuleValues

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -189,6 +189,82 @@ func TestStackNeedsPrivateSubnets(t *testing.T) {
 	assert.True(t, stackNeedsPrivateSubnets(&Components{AWSEC2: "ARM"}), "AWSEC2 ARM")
 }
 
+func TestBuildModuleValues_VPC_AWSVPCConfig(t *testing.T) {
+	m := DefaultMapper{}
+	boolPtr := func(v bool) *bool { return &v }
+	intPtr := func(v int) *int { return &v }
+
+	t.Run("SingleNATGateway=false writes single_nat_gateway=false", func(t *testing.T) {
+		cfg := &Config{AWSVPC: &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{SingleNATGateway: boolPtr(false)}}
+		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		assert.Equal(t, false, vals["single_nat_gateway"])
+	})
+
+	t.Run("AZCount=3 writes az_count=3", func(t *testing.T) {
+		cfg := &Config{AWSVPC: &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{AZCount: intPtr(3)}}
+		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		assert.Equal(t, 3, vals["az_count"])
+	})
+
+	t.Run("unset fields do not write to vals (defer to HCL default)", func(t *testing.T) {
+		cfg := &Config{AWSVPC: &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{}}
+		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		_, hasSingle := vals["single_nat_gateway"]
+		_, hasEnable := vals["enable_nat_gateway"]
+		_, hasAZ := vals["az_count"]
+		assert.False(t, hasSingle, "SingleNATGateway unset should not write single_nat_gateway")
+		assert.False(t, hasEnable, "EnableNATGateway unset should not write enable_nat_gateway")
+		assert.False(t, hasAZ, "AZCount unset should not write az_count")
+	})
+
+	t.Run("nil cfg.AWSVPC is a no-op", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSVPC, &Components{}, &Config{}, "test", "us-east-1")
+		require.NoError(t, err)
+		_, hasSingle := vals["single_nat_gateway"]
+		assert.False(t, hasSingle)
+	})
+
+	t.Run("Public VPC with user SingleNATGateway=false: both apply (enable_nat_gateway=false from Public VPC, single_nat_gateway=false from user)", func(t *testing.T) {
+		comps := &Components{AWSVPC: "Public VPC"}
+		cfg := &Config{AWSVPC: &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{SingleNATGateway: boolPtr(false)}}
+		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		assert.Equal(t, false, vals["enable_nat_gateway"], "Public VPC still wins on enable_nat_gateway")
+		assert.Equal(t, false, vals["single_nat_gateway"], "user config still applies to single_nat_gateway")
+	})
+
+	t.Run("user EnableNATGateway=true overrides Public-VPC-derived false", func(t *testing.T) {
+		comps := &Components{AWSVPC: "Public VPC"}
+		cfg := &Config{AWSVPC: &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{EnableNATGateway: boolPtr(true)}}
+		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		assert.Equal(t, true, vals["enable_nat_gateway"], "user override wins over Public VPC default")
+	})
+}
+
 // TestBuildModuleValues_V2KeyNormalization verifies that calling BuildModuleValues
 // with a V2 key (e.g., KeyAWSWAF) produces the same output as calling with the
 // legacy key (e.g., KeyWAF). This catches missing case arms in the normalization switch.

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -192,6 +192,18 @@ type Config struct {
 		EnableServiceConnect    *bool    `json:"enableServiceConnect,omitempty"`
 	} `json:"aws_ecs,omitempty"`
 
+	// AWSVPC surfaces the preset's VPC topology knobs. All fields are pointers
+	// so the zero value means "defer to the module's HCL default" rather than
+	// "force to zero". SingleNATGateway=false spreads NAT gateways across AZs
+	// (one per AZ, bounded by AZCount) — trade higher cost for AZ-level HA and
+	// to avoid exhausting the per-AZ NAT gateway quota when many stacks share
+	// an account.
+	AWSVPC *struct {
+		SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+		EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+		AZCount          *int  `json:"azCount,omitempty"`
+	} `json:"aws_vpc,omitempty"`
+
 	AWSCloudfront *struct {
 		DefaultTtl *string `json:"defaultTtl,omitempty"`
 		OriginPath *string `json:"originPath,omitempty"`

--- a/pkg/composer/validate.go
+++ b/pkg/composer/validate.go
@@ -20,6 +20,9 @@ func NewValidationError(msg string) *ValidationError {
 func (e *ValidationError) Error() string { return e.msg }
 
 type ComputeExclusivityOpts struct {
+	// Deprecated: legacy compute-exclusivity escape hatch tracked by issue #76.
+	// Historical sessions that mixed standalone EC2 with Lambda relied on this;
+	// new callers should not set it.
 	AllowLegacyStandaloneEC2Lambda bool
 }
 


### PR DESCRIPTION
Bundle PR consolidating five related changes from a single working session for easier review/merge. Each underlying branch/PR remains open (can be merged standalone if preferred); this bundle merges them via `--no-ff` so individual commit histories are preserved.

## What's included

| Source PR | Branch | Scope | Closes |
|-----------|--------|-------|--------|
| #112 | `docs/link-insideout-power` | README bullet pointing at the Kiro IDE Power | — |
| #113 | `feat/vpc-single-nat-gateway-knob` | `Config.AWSVPC { SingleNATGateway, EnableNATGateway, AZCount }` + HCL description tightening + mapper validation + HCL-contract test | #106 |
| #114 | `fix/tagging-followups-111` | `"insideout"` const hoist; GCP regression guard; discovered-providers test; Project round-trip test; 10 examples updated; cloudwatchmonitoring comment version-independent | #111 |
| #116 | `refactor/composer-phase3-prefixed-only` | Phase 3a — `// Deprecated:` godoc on LegacyToV2Key / DeduplicateKeys / AllowLegacyMixedCompute / AllowLegacyStandaloneEC2Lambda; `doc.go` reliable ref bump #998 → #1041 | refs #76 |
| #117 | `chore/composer-lint-nits` | golangci-lint cleanup — 5× `maps.Copy` in compose.go + 2× `strings.CutSuffix` in mapper.go | — |

## Review hardening applied (post qa-professor)

The #113 and #114 branches each carry a follow-up commit addressing qa-professor findings:

- **#113** (`b48786e`): mapper-level ValidationError when `EnableNATGateway=false` + downstream needs private subnets; `AZCount < 1` validation; mapper→HCL contract test via `DiscoverModuleVars`; `cfgWithAWSVPC` helper; type-guarded assertions.
- **#114** (`9f563d6`): whitespace-tolerant regex for `Project = var.project`; sentinel anchored to `variable "project" { default = ... }` block in the root `variables.tf` and to `aws_vpc_project = "…"` line in tfvars; discovered-providers precondition check; GCP scope comment.

## Test plan
- [x] `go build ./... && go vet ./... && go test -race ./pkg/composer/...` — all pass (25s, no new warnings)
- [x] `terraform fmt -check -recursive` — clean
- [x] Individual PR CI on #113 already green (ci-gate, go-test, go-vet, lint, format-check, discover, test-presets)

## Follow-ups filed this session
- **#115** — examples/mobileapi GCP region bug
- **#118** — composer Phase 3b (structural collapse; blocked on ops coordination for the `module.<name>` rename migration)

## Merge guidance
- **Squash** loses the 7 individual commits + 5 merge commits but produces a single clean main-line commit.
- **Rebase-and-merge** keeps the 7 feature commits (drops the merge commits), linear history.
- **Merge commit** preserves everything as-is.

If bundle is preferred, the 5 source PRs (#112/#113/#114/#116/#117) can be closed without merging. If individual review is preferred, close this bundle and land the sources one at a time.

Closes #106, #111. Refs #76.