### PR TITLE
fix(examples/mobileapi): replace AWS us-west-2 with GCP us-west1 region

### DIFF
--- a/examples/mobileapi/gcp_cloud_logging.auto.tfvars
+++ b/examples/mobileapi/gcp_cloud_logging.auto.tfvars
@@ -1,2 +1,2 @@
 project = "demo"
-region  = "us-west-2"
+region  = "us-west1"

--- a/examples/mobileapi/gcp_cloud_run.auto.tfvars
+++ b/examples/mobileapi/gcp_cloud_run.auto.tfvars
@@ -3,4 +3,4 @@ max_instances = 100
 memory        = "512Mi"
 min_instances = 0
 project       = "demo"
-region        = "us-west-2"
+region        = "us-west1"

--- a/examples/mobileapi/gcp_cloudsql.auto.tfvars
+++ b/examples/mobileapi/gcp_cloudsql.auto.tfvars
@@ -1,4 +1,4 @@
 availability_type = "ZONAL"
 project           = "demo"
-region            = "us-west-2"
+region            = "us-west1"
 tier              = "db-f1-micro"

--- a/examples/mobileapi/gcp_gcs.auto.tfvars
+++ b/examples/mobileapi/gcp_gcs.auto.tfvars
@@ -1,5 +1,5 @@
 bucket_name        = "demo-data"
 project            = "demo"
-region             = "us-west-2"
+region             = "us-west1"
 storage_class      = "STANDARD"
 versioning_enabled = false

--- a/examples/mobileapi/gcp_vpc.auto.tfvars
+++ b/examples/mobileapi/gcp_vpc.auto.tfvars
@@ -1,2 +1,2 @@
 project = "demo"
-region  = "us-west-2"
+region  = "us-west1"

--- a/examples/mobileapi/providers.tf
+++ b/examples/mobileapi/providers.tf
@@ -8,5 +8,5 @@ terraform {
 }
 
 provider "google" {
-  region = "us-west-2"
+  region = "us-west1"
 }

--- a/examples/mobileapi/variables.tf
+++ b/examples/mobileapi/variables.tf
@@ -81,7 +81,7 @@ variable "project" {
 }
 
 variable "region" {
-  description = "AWS region"
+  description = "GCP region"
   type        = string
-  default     = "us-west-2"
+  default     = "us-west1"
 }


### PR DESCRIPTION
Small leftover bundle addressing the one tractable follow-up from the previous session — the mobileapi example's GCP stack had AWS region strings throughout.

## Scope

Seven files in ` examples/mobileapi/ ` had ` region = "us-west-2" ` (an AWS region) or the "AWS region" description, even though the stack's ` providers.tf ` declares ` provider "google" `:

- ` providers.tf ` — ` region = "us-west-2" ` → ` "us-west1" `
- ` variables.tf ` — top-level ` variable "region" ` default ` "us-west-2" ` → ` "us-west1" `; description ` "AWS region" ` → ` "GCP region" `
- ` gcp_cloud_logging.auto.tfvars ` — ` region = "us-west-2" ` → ` "us-west1" `
- ` gcp_cloud_run.auto.tfvars ` — same
- ` gcp_cloudsql.auto.tfvars ` — same
- ` gcp_vpc.auto.tfvars ` — same
- ` gcp_gcs.auto.tfvars ` — same

Picked ` us-west1 ` as the closest geographic equivalent to AWS ` us-west-2 ` (both Oregon). Composer's default GCP region elsewhere is ` us-central1 ` (compose.go) — left mobileapi on ` us-west1 ` since the original intent appears to have been "west coast".

## Test plan
- [x] ` cd examples/mobileapi && terraform init -backend=false && terraform validate ` — valid
- [x] ` terraform fmt -check -recursive ` — clean
- [x] ` grep -rn us-west-2 examples/mobileapi/ ` — no residual matches (excluding .terraform/ caches)

## Remaining leftovers (not in this PR)

- **#118** (Phase 3b composer structural collapse) — explicitly requires ops coordination per its PR body (changes rendered ` module.<name> ` paths and needs a ` terraform state mv ` migration story). Not autonomous-safe.

Closes #115