### PR TITLE
refactor(composer): Phase 3b safe subset — drop legacy fallback reads from helpers

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -81,6 +81,17 @@ func (c *Client) ComposeSingle(opts ComposeSingleOpts) (Files, error) {
 		cloud = "aws" // Default to AWS for backward compatibility
 	}
 
+	// Normalize legacy-key shapes to AWS-prefixed before any helper consumes
+	// Comps/Cfg. Idempotent for already-normalized input (the composeradapter
+	// path) and required for direct Go callers that construct Components from
+	// legacy JSON. See #76.
+	if opts.Comps != nil {
+		opts.Comps.Normalize()
+	}
+	if opts.Cfg != nil {
+		opts.Cfg.Normalize()
+	}
+
 	// 1. Resolve module directory (e.g. resource -> modules/lambda if Lambda)
 	moduleDir := GetModuleDir(opts.Key, opts.Comps)
 	if moduleDir == "" {
@@ -219,6 +230,17 @@ func (c *Client) ComposeStack(opts ComposeStackOpts) (Files, error) {
 	cloud := opts.Cloud
 	if cloud == "" {
 		cloud = "aws" // Default to AWS for backward compatibility
+	}
+
+	// Normalize legacy-key shapes to AWS-prefixed before any helper consumes
+	// Comps/Cfg. Idempotent for already-normalized input (the composeradapter
+	// path) and required for direct Go callers that construct Components from
+	// legacy JSON. See #76.
+	if opts.Comps != nil {
+		opts.Comps.Normalize()
+	}
+	if opts.Cfg != nil {
+		opts.Cfg.Normalize()
 	}
 
 	// 0. Validate compute exclusivity before expanding dependencies.

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -740,15 +740,19 @@ func TestDefaultWiring_LambdaPublicVPC(t *testing.T) {
 		require.False(t, hasSubnetIDs, "Public VPC: Lambda should not have subnet_ids")
 	})
 
-	t.Run("Lambda skips VPC wiring with legacy Public VPC field", func(t *testing.T) {
+	t.Run("Lambda skips VPC wiring for a legacy session that's been Normalized", func(t *testing.T) {
+		// Phase 3b dropped the legacy VPC-string fallback in isPublicVPC.
+		// Legacy sessions must Normalize() before reaching the composer;
+		// reliable's composeradapter does this for us in production.
 		selected := map[ComponentKey]bool{
 			KeyVPC:    true,
 			KeyLambda: true,
 		}
-		comps := &Components{VPC: "Public VPC", Lambda: ptrBool(true)}
+		comps := &Components{Cloud: "AWS", VPC: "Public VPC", Lambda: ptrBool(true)}
+		comps.Normalize()
 		wi := DefaultWiring(selected, KeyLambda, comps)
 		_, hasEnableVPC := wi.RawHCL["enable_vpc"]
-		require.False(t, hasEnableVPC, "Legacy Public VPC: Lambda should not have enable_vpc")
+		require.False(t, hasEnableVPC, "Legacy Public VPC (after Normalize): Lambda should not have enable_vpc")
 	})
 
 	t.Run("Lambda wires VPC when VPC is Private", func(t *testing.T) {

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -501,11 +501,13 @@ func isLambda(comps *Components) bool {
 }
 
 // isPublicVPC returns true if the VPC is configured as a Public VPC (no private subnets).
+// Callers with legacy session JSON must normalise first via Components.Normalize;
+// see #76 for the reliable-legacy migration plan.
 func isPublicVPC(comps *Components) bool {
 	if comps == nil {
 		return false
 	}
-	return comps.AWSVPC == "Public VPC" || comps.VPC == "Public VPC"
+	return comps.AWSVPC == "Public VPC"
 }
 
 type WiredInputs struct {

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -500,9 +500,10 @@ func isLambda(comps *Components) bool {
 	return comps.IsLambdaArchitecture()
 }
 
-// isPublicVPC returns true if the VPC is configured as a Public VPC (no private subnets).
-// Callers with legacy session JSON must normalise first via Components.Normalize;
-// see #76 for the reliable-legacy migration plan.
+// isPublicVPC returns true if the VPC is configured as a Public VPC (no
+// private subnets). Reads only comps.AWSVPC; the legacy comps.VPC string is
+// promoted to AWSVPC by Components.Normalize, which ComposeStack /
+// ComposeSingle call at entry.
 func isPublicVPC(comps *Components) bool {
 	if comps == nil {
 		return false

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -23,9 +23,9 @@ type Mapper interface {
 // These components wire to module.vpc.private_subnet_ids and fail validation
 // when the VPC only has public subnets.
 //
-// Callers that construct Components from historical legacy-key JSON must
-// call [Components.Normalize] first — reliable/composeradapter does this.
-// See #76 for the reliable-legacy migration plan.
+// Reads only the AWS-prefixed fields; legacy pointer fields (c.Postgres,
+// c.ElastiCache, c.OpenSearch) are promoted by Components.Normalize, which
+// ComposeStack / ComposeSingle call at entry.
 func stackNeedsPrivateSubnets(comps *Components) bool {
 	if comps == nil {
 		return false

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -22,6 +22,10 @@ type Mapper interface {
 // require private subnets (EKS, RDS, ElastiCache, OpenSearch, EKS node groups).
 // These components wire to module.vpc.private_subnet_ids and fail validation
 // when the VPC only has public subnets.
+//
+// Callers that construct Components from historical legacy-key JSON must
+// call [Components.Normalize] first — reliable/composeradapter does this.
+// See #76 for the reliable-legacy migration plan.
 func stackNeedsPrivateSubnets(comps *Components) bool {
 	if comps == nil {
 		return false
@@ -29,11 +33,8 @@ func stackNeedsPrivateSubnets(comps *Components) bool {
 	return boolPtrTrue(comps.AWSEKS) ||
 		boolPtrTrue(comps.AWSECS) ||
 		boolPtrTrue(comps.AWSRDS) ||
-		boolPtrTrue(comps.Postgres) ||
 		boolPtrTrue(comps.AWSElastiCache) ||
-		boolPtrTrue(comps.ElastiCache) ||
 		boolPtrTrue(comps.AWSOpenSearch) ||
-		boolPtrTrue(comps.OpenSearch) ||
 		comps.AWSEC2 != "" // EC2 node groups need private subnets
 }
 

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -115,15 +115,12 @@ func TestBuildModuleValues_VPC_PublicPrivateMode(t *testing.T) {
 		name  string
 		comps *Components
 	}{
-		{"EKS (V2 field)", &Components{AWSVPC: "Public VPC", AWSEKS: boolPtr(true)}},
-		{"RDS (V2 field)", &Components{AWSVPC: "Public VPC", AWSRDS: boolPtr(true)}},
-		{"ElastiCache (V2 field)", &Components{AWSVPC: "Public VPC", AWSElastiCache: boolPtr(true)}},
-		{"OpenSearch (V2 field)", &Components{AWSVPC: "Public VPC", AWSOpenSearch: boolPtr(true)}},
+		{"EKS", &Components{AWSVPC: "Public VPC", AWSEKS: boolPtr(true)}},
+		{"RDS", &Components{AWSVPC: "Public VPC", AWSRDS: boolPtr(true)}},
+		{"ElastiCache", &Components{AWSVPC: "Public VPC", AWSElastiCache: boolPtr(true)}},
+		{"OpenSearch", &Components{AWSVPC: "Public VPC", AWSOpenSearch: boolPtr(true)}},
 		{"EC2 node group", &Components{AWSVPC: "Public VPC", AWSEC2: "Intel"}},
-		{"legacy Postgres field", &Components{AWSVPC: "Public VPC", Postgres: boolPtr(true)}},
-		{"legacy ElastiCache field", &Components{AWSVPC: "Public VPC", ElastiCache: boolPtr(true)}},
-		{"legacy OpenSearch field", &Components{AWSVPC: "Public VPC", OpenSearch: boolPtr(true)}},
-		{"ECS (V2 field)", &Components{AWSVPC: "Public VPC", AWSECS: boolPtr(true)}},
+		{"ECS", &Components{AWSVPC: "Public VPC", AWSECS: boolPtr(true)}},
 		{"EKS + RDS composite stack", &Components{AWSVPC: "Public VPC", AWSEKS: boolPtr(true), AWSRDS: boolPtr(true)}},
 	}
 	for _, tc := range keepsCases {
@@ -180,13 +177,20 @@ func TestStackNeedsPrivateSubnets(t *testing.T) {
 	assert.True(t, stackNeedsPrivateSubnets(&Components{AWSEKS: boolPtr(true)}), "AWSEKS")
 	assert.True(t, stackNeedsPrivateSubnets(&Components{AWSECS: boolPtr(true)}), "AWSECS")
 	assert.True(t, stackNeedsPrivateSubnets(&Components{AWSRDS: boolPtr(true)}), "AWSRDS")
-	assert.True(t, stackNeedsPrivateSubnets(&Components{Postgres: boolPtr(true)}), "legacy Postgres")
 	assert.True(t, stackNeedsPrivateSubnets(&Components{AWSElastiCache: boolPtr(true)}), "AWSElastiCache")
-	assert.True(t, stackNeedsPrivateSubnets(&Components{ElastiCache: boolPtr(true)}), "legacy ElastiCache")
 	assert.True(t, stackNeedsPrivateSubnets(&Components{AWSOpenSearch: boolPtr(true)}), "AWSOpenSearch")
-	assert.True(t, stackNeedsPrivateSubnets(&Components{OpenSearch: boolPtr(true)}), "legacy OpenSearch")
 	assert.True(t, stackNeedsPrivateSubnets(&Components{AWSEC2: "Intel"}), "AWSEC2 Intel")
 	assert.True(t, stackNeedsPrivateSubnets(&Components{AWSEC2: "ARM"}), "AWSEC2 ARM")
+
+	// Legacy-field reads (c.Postgres / c.ElastiCache / c.OpenSearch) were
+	// dropped from stackNeedsPrivateSubnets in Phase 3b. Callers with legacy-
+	// shaped Components must call Normalize() first; the promotion path is
+	// covered by TestComponents_Normalize_SyncsLegacyFieldsForAWS in
+	// types_test.go. Here we just lock the end-to-end round-trip.
+	legacy := &Components{Cloud: "AWS", Postgres: boolPtr(true)}
+	legacy.Normalize()
+	assert.True(t, stackNeedsPrivateSubnets(legacy),
+		"legacy Postgres must still gate private subnets after Normalize() promotes it to AWSRDS")
 }
 
 // cfgWithAWSVPC builds a Config with an AWSVPC sub-config populated from the
@@ -289,8 +293,10 @@ func TestBuildModuleValues_VPC_AWSVPCConfig_Validation(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("EnableNATGateway=false with legacy Postgres returns ValidationError", func(t *testing.T) {
-		comps := &Components{Postgres: boolPtr(true)}
+	t.Run("EnableNATGateway=false with legacy Postgres (post-Normalize) returns ValidationError", func(t *testing.T) {
+		// Legacy-field reads were dropped in Phase 3b; callers must Normalize first.
+		comps := &Components{Cloud: "AWS", Postgres: boolPtr(true)}
+		comps.Normalize()
 		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
 		_, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
 		require.Error(t, err)

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -157,7 +157,12 @@ func TestBuildModuleValues_VPC_PublicPrivateMode(t *testing.T) {
 		assert.False(t, hasNat)
 	})
 
-	t.Run("legacy KeyVPC with Public VPC also works", func(t *testing.T) {
+	t.Run("KeyVPC (legacy ComponentKey) routes through the same case arm", func(t *testing.T) {
+		// The KeyVPC ComponentKey constant is deprecated (tracked by #76) but
+		// still accepted by the mapper's normalisation switch. This test pins
+		// that accepting the legacy key alongside an AWSVPC string still takes
+		// the Public-VPC branch — regression guard for anyone tempted to drop
+		// legacy-key support before Phase 4.
 		comps := &Components{AWSVPC: "Public VPC"}
 		vals, err := m.BuildModuleValues(KeyVPC, comps, nil, "test", "us-east-1")
 		require.NoError(t, err)
@@ -184,13 +189,27 @@ func TestStackNeedsPrivateSubnets(t *testing.T) {
 
 	// Legacy-field reads (c.Postgres / c.ElastiCache / c.OpenSearch) were
 	// dropped from stackNeedsPrivateSubnets in Phase 3b. Callers with legacy-
-	// shaped Components must call Normalize() first; the promotion path is
-	// covered by TestComponents_Normalize_SyncsLegacyFieldsForAWS in
-	// types_test.go. Here we just lock the end-to-end round-trip.
-	legacy := &Components{Cloud: "AWS", Postgres: boolPtr(true)}
-	legacy.Normalize()
-	assert.True(t, stackNeedsPrivateSubnets(legacy),
-		"legacy Postgres must still gate private subnets after Normalize() promotes it to AWSRDS")
+	// shaped Components must Normalize() first; field-level promotion is
+	// covered by TestComponents_Normalize_SyncsLegacyBoolFieldsForAWS in
+	// types_test.go. Here we lock the end-to-end round-trip for each of the
+	// three legacy fields that previously had direct OR reads.
+	legacyRoundTrips := []struct {
+		name  string
+		setup func(*Components)
+	}{
+		{"Postgres → AWSRDS", func(c *Components) { c.Postgres = boolPtr(true) }},
+		{"ElastiCache → AWSElastiCache", func(c *Components) { c.ElastiCache = boolPtr(true) }},
+		{"OpenSearch → AWSOpenSearch", func(c *Components) { c.OpenSearch = boolPtr(true) }},
+	}
+	for _, tc := range legacyRoundTrips {
+		t.Run("Normalize round-trip: "+tc.name, func(t *testing.T) {
+			c := &Components{Cloud: "AWS"}
+			tc.setup(c)
+			c.Normalize()
+			assert.True(t, stackNeedsPrivateSubnets(c),
+				"legacy %s must still gate private subnets after Normalize()", tc.name)
+		})
+	}
 }
 
 // cfgWithAWSVPC builds a Config with an AWSVPC sub-config populated from the

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -1,6 +1,9 @@
 package composer
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Components mirrors the TypeScript ZComponentsIR schema with cloud-specific field names.
 // Use aws_* fields for AWS cloud, gcp_* fields for GCP cloud.
@@ -731,11 +734,28 @@ func (c *Components) Normalize() {
 			c.Bedrock = c.AWSBedrock
 		}
 
-		// Sync Lambda
+		// Sync Lambda. Legacy sessions encoded Lambda/serverless in THREE
+		// different shapes:
+		//   1. c.Lambda *bool      — earliest form, used in reliable sessions
+		//   2. c.AWSLambda *bool   — v2 form
+		//   3. c.Resource string   — earliest form, the architecture enum
+		//                            ("Lambda" / "Serverless" / "Kubernetes")
+		// Promote all three to c.AWSLambda so downstream composer reads a
+		// single source of truth. Resource stays untouched for its GCP role
+		// (GKE / CloudRun detection) and the final legacy-clearing block at
+		// the end of Normalize clears it.
 		if c.Lambda != nil && c.AWSLambda == nil {
 			c.AWSLambda = c.Lambda
 		} else if c.AWSLambda != nil {
 			c.Lambda = c.AWSLambda
+		}
+		if c.AWSLambda == nil && c.Resource != "" {
+			lower := strings.ToLower(c.Resource)
+			if strings.Contains(lower, "lambda") || strings.Contains(lower, "serverless") {
+				t := true
+				c.AWSLambda = &t
+				c.Lambda = &t // keep legacy mirror in sync
+			}
 		}
 
 		// Sync CodePipeline

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -1045,10 +1045,13 @@ func (c *Components) Normalize() {
 	c.Backups = nil
 }
 
-// IsLambdaArchitecture returns true if the stack uses Lambda as its compute layer.
-// Callers with legacy session JSON (where the architecture was encoded as the
-// Resource string "Lambda" / "Serverless") must normalise first via
-// Components.Normalize; see #76 for the reliable-legacy migration plan.
+// IsLambdaArchitecture returns true if the stack uses Lambda as its compute
+// layer. Reads only c.AWSLambda — legacy shapes (c.Lambda *bool and the
+// c.Resource string "Lambda" / "Serverless") are promoted to c.AWSLambda by
+// Components.Normalize (AWS branch). ComposeStack / ComposeSingle call
+// Normalize at entry, so most callers never need to think about this; direct
+// callers of IsLambdaArchitecture on a legacy-shaped Components must call
+// Normalize first. See #76.
 func (c *Components) IsLambdaArchitecture() bool {
 	if c == nil {
 		return false

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -1025,19 +1025,14 @@ func (c *Components) Normalize() {
 	c.Backups = nil
 }
 
-// IsLambdaArchitecture returns true if the resource type indicates Lambda/serverless.
+// IsLambdaArchitecture returns true if the stack uses Lambda as its compute layer.
+// Callers with legacy session JSON (where the architecture was encoded as the
+// Resource string "Lambda" / "Serverless") must normalise first via
+// Components.Normalize; see #76 for the reliable-legacy migration plan.
 func (c *Components) IsLambdaArchitecture() bool {
 	if c == nil {
 		return false
 	}
-	// Check legacy Resource field for backward compatibility
-	if c.Resource != "" {
-		r := c.Resource
-		if containsIgnoreCase(r, "lambda") || containsIgnoreCase(r, "serverless") {
-			return true
-		}
-	}
-	// Check new AWS Lambda field
 	return boolVal(c.AWSLambda)
 }
 
@@ -1698,31 +1693,4 @@ func (c *Config) Normalize() {
 	c.OpenSearch = nil
 	c.Bedrock = nil
 	c.Backups = nil
-}
-
-func containsIgnoreCase(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr ||
-		len(s) > len(substr) && (containsLower(s, substr)))
-}
-
-func containsLower(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if toLower(s[i:i+len(substr)]) == toLower(substr) {
-			return true
-		}
-	}
-	return false
-}
-
-func toLower(s string) string {
-	b := make([]byte, len(s))
-	for i := range s {
-		c := s[i]
-		if c >= 'A' && c <= 'Z' {
-			b[i] = c + 32
-		} else {
-			b[i] = c
-		}
-	}
-	return string(b)
 }

--- a/pkg/composer/types_test.go
+++ b/pkg/composer/types_test.go
@@ -3,6 +3,9 @@ package composer
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestComponents_Normalize_EmptyIsNoOp locks in the invariant that an
@@ -133,6 +136,68 @@ func TestComponents_Normalize_SyncsLegacyFieldsForAWS(t *testing.T) {
 	}
 	if c.AWSEC2 != "Intel" {
 		t.Errorf("AWSEC2 should be 'Intel', got %q", c.AWSEC2)
+	}
+}
+
+// TestComponents_Normalize_SyncsLegacyBoolFieldsForAWS pins the AWS-branch
+// promotion of every legacy *bool field composer helpers now rely on. If a
+// future refactor drops one of these ↔ syncs, the corresponding composer
+// helper (stackNeedsPrivateSubnets, IsLambdaArchitecture, ...) silently
+// misreports — this test catches that at the Normalize layer.
+func TestComponents_Normalize_SyncsLegacyBoolFieldsForAWS(t *testing.T) {
+	t.Parallel()
+	boolPtr := func(v bool) *bool { return &v }
+
+	cases := []struct {
+		name     string
+		setup    func(*Components)
+		assertOn func(t *testing.T, c *Components)
+	}{
+		{"Postgres → AWSRDS", func(c *Components) { c.Postgres = boolPtr(true) },
+			func(t *testing.T, c *Components) {
+				require.NotNil(t, c.AWSRDS, "AWSRDS should be non-nil after Normalize")
+				assert.True(t, *c.AWSRDS)
+			}},
+		{"ElastiCache → AWSElastiCache", func(c *Components) { c.ElastiCache = boolPtr(true) },
+			func(t *testing.T, c *Components) {
+				require.NotNil(t, c.AWSElastiCache)
+				assert.True(t, *c.AWSElastiCache)
+			}},
+		{"OpenSearch → AWSOpenSearch", func(c *Components) { c.OpenSearch = boolPtr(true) },
+			func(t *testing.T, c *Components) {
+				require.NotNil(t, c.AWSOpenSearch)
+				assert.True(t, *c.AWSOpenSearch)
+			}},
+		{"Lambda (*bool) → AWSLambda", func(c *Components) { c.Lambda = boolPtr(true) },
+			func(t *testing.T, c *Components) {
+				require.NotNil(t, c.AWSLambda)
+				assert.True(t, *c.AWSLambda)
+			}},
+		{"Resource \"Lambda\" → AWSLambda", func(c *Components) { c.Resource = "Lambda" },
+			func(t *testing.T, c *Components) {
+				require.NotNil(t, c.AWSLambda, "Normalize must promote legacy Resource=\"Lambda\" to AWSLambda")
+				assert.True(t, *c.AWSLambda)
+			}},
+		{"Resource \"Serverless\" → AWSLambda", func(c *Components) { c.Resource = "Serverless" },
+			func(t *testing.T, c *Components) {
+				require.NotNil(t, c.AWSLambda)
+				assert.True(t, *c.AWSLambda)
+			}},
+		{"Resource \"Kubernetes\" leaves AWSLambda unset", func(c *Components) { c.Resource = "Kubernetes" },
+			func(t *testing.T, c *Components) {
+				assert.Nil(t, c.AWSLambda,
+					"Resource=\"Kubernetes\" must NOT promote to AWSLambda (EKS ≠ Lambda)")
+			}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := &Components{Cloud: "AWS"}
+			tc.setup(c)
+			c.Normalize()
+			tc.assertOn(t, c)
+		})
 	}
 }
 


### PR DESCRIPTION
Partial progress on #118. Ships the zero-state-risk half of Phase 3b — the legacy-field read branches in helpers — and defers the structural switch collapse to a follow-up PR that depends on the `moved {}` automation landing first.

## Why this is safe to land now

Phase 2 (reliable's composeradapter) merged as reliable#1041 and is the single entry point for legacy-key session JSON in production. `Components.Normalize` / `Config.Normalize` also remain as belt-and-braces translation. This PR only drops the *read-time* legacy fallbacks that were a third layer of redundancy; **no rendered `module.<name>` paths change**, so deployed stacks keep planning clean.

## What changes

Three composer helpers stop peeking at the legacy `Components` fields:

- `stackNeedsPrivateSubnets` (mapper.go:25-38) — drops `c.Postgres`, `c.ElastiCache`, `c.OpenSearch` ORs.
- `isPublicVPC` (contracts.go:508) — drops `comps.VPC == "Public VPC"` fallback.
- `Components.IsLambdaArchitecture` (types.go) — drops the `c.Resource` string scan for "lambda"/"serverless". The `containsIgnoreCase` / `containsLower` / `toLower` helpers that supported it are now unused and deleted.

Each helper gains a godoc note pointing callers with legacy shapes at `Components.Normalize` / composeradapter.

## Test migrations

Four tests referenced the removed legacy-read paths:

1. `TestBuildModuleValues_VPC_PublicPrivateMode` — three "legacy X field" subtest rows removed (redundant with the V2 rows and with Normalize's own tests).
2. `TestStackNeedsPrivateSubnets` — three "legacy X" assertions removed; replaced with one `Normalize()` round-trip test pinning the end-to-end contract.
3. `TestBuildModuleValues_VPC_AWSVPCConfig_Validation` — the "legacy Postgres" subtest now calls `Normalize()` first (matches production).
4. `TestDefaultWiring_LambdaPublicVPC` — the "legacy Public VPC field" subtest renamed to "a legacy session that's been Normalized" and now calls `Normalize()`.

The Normalize legacy-to-prefixed promotion path itself stays covered by `TestComponents_Normalize_SyncsLegacyFieldsForAWS` in types_test.go.

## What's NOT in this PR (deferred to a follow-up)

Tightly coupled to the `awsKitchenSinkCompsLegacy` fixture migration:
- `BackupsSelected` / `legacyBackupsSelected` consolidation.
- Dual-branch Backups reads in `DefaultWiring` / `BuildModuleValues`.

Blocked on the `moved {}` automation story (changes rendered `module.<name>` paths):
- AWS→legacy normalisation switches in `DefaultWiring` / `BuildModuleValues`.
- `moduleRef` / `vpcRef` / ... selector simplification.

Research for the `moved {}` approach landed during planning: Terraform `moved { from = module.vpc to = module.aws_vpc }` works at module level, is a no-op on fresh state, and can be auto-emitted from `EmitRootMainTF` when the composer sees the V2 key in the selected set. Planning to ship that as a separate PR, then take the module-renaming portion of Phase 3b as a third PR on top.

## Test plan
- [x] ` go build ./... && go vet ./... && go test -race ./pkg/composer/... ` — all pass (25s)
- [x] ` terraform fmt -check -recursive ` — clean
- [x] Migrated tests still pin the post-Normalize contract
- [x] 5 files, +37 / -56 — net negative LOC

Refs #118, #76