### PR TITLE
refactor(composer): Phase 3b Backups consolidation

### DIFF
--- a/pkg/composer/builders_test.go
+++ b/pkg/composer/builders_test.go
@@ -80,11 +80,12 @@ func configWithAWSECS(in awsECSCfgInput) *Config {
 // (un-prefixed) Config names because Config.Normalize() promotes them to
 // the cloud-prefixed equivalents during compose.
 //
-// The split into Base / Legacy / V2 (instead of a single shared builder)
-// preserves a subtle fidelity invariant: the V2 test historically did not
-// set RDS.ReadReplicas, exercising the "unset" branch of the RDS mapper,
-// while the legacy test set it to "2". Collapsing into one shared helper
-// would silently couple the two tests on that branch.
+// The split into Base / WithReadReplicas / V2 (instead of a single shared
+// builder) preserves a subtle fidelity invariant: the V2 variant leaves
+// RDS.ReadReplicas unset, exercising the "unset" branch of the RDS mapper,
+// while the WithReadReplicas variant sets it to "2" so both mapper branches
+// are exercised. Collapsing into one shared helper would silently couple the
+// two tests on that branch.
 func awsKitchenSinkCfgBase() *Config {
 	return &Config{
 		Region: "us-west-2",
@@ -116,9 +117,10 @@ func awsKitchenSinkCfgV2() *Config {
 	return cfg
 }
 
-// awsKitchenSinkCfgLegacy returns the Config for TestComposeStack_KitchenSink.
-// RDS.ReadReplicas is "2" to exercise the read-replicas mapper branch.
-func awsKitchenSinkCfgLegacy() *Config {
+// awsKitchenSinkCfgWithReadReplicas returns the Config for
+// TestComposeStack_KitchenSink. RDS.ReadReplicas is "2" to exercise the
+// read-replicas mapper branch (cfg.RDS.ReadReplicas != "" in mapper.go).
+func awsKitchenSinkCfgWithReadReplicas() *Config {
 	cfg := awsKitchenSinkCfgBase()
 	cfg.RDS = &struct {
 		CPUSize      string `json:"cpuSize,omitempty"`
@@ -128,11 +130,14 @@ func awsKitchenSinkCfgLegacy() *Config {
 	return cfg
 }
 
-// awsKitchenSinkCompsV2 returns the Components shape for the V2-key
-// kitchen-sink: legacy ElastiCache toggle plus AWSBackups (prefixed).
+// awsKitchenSinkCompsV2 returns the Components shape for both kitchen-sink
+// tests: AWSElastiCache toggle plus AWSBackups (prefixed). EC2 and RDS are
+// the only backup targets enabled; DynamoDB and S3 are left unset so
+// boolVal(nil) falls through to false, matching the wiring/backups subtest
+// assertions in both kitchen-sink tests.
 func awsKitchenSinkCompsV2() *Components {
 	return &Components{
-		ElastiCache: ptrBool(true),
+		AWSElastiCache: ptrBool(true),
 		AWSBackups: &struct {
 			EC2         *bool `json:"aws_ec2,omitempty"`
 			RDS         *bool `json:"aws_rds,omitempty"`
@@ -142,30 +147,6 @@ func awsKitchenSinkCompsV2() *Components {
 		}{
 			EC2: ptrBool(true),
 			RDS: ptrBool(true),
-		},
-	}
-}
-
-// awsKitchenSinkCompsLegacy returns the Components shape for the legacy-key
-// kitchen-sink: legacy ElastiCache toggle plus legacy Backups. The explicit
-// DynamoDB=false / S3=false fields are load-bearing — the legacy kitchen-sink
-// "wiring/backups" subtest asserts on `enable_dynamodb = false` and
-// `enable_s3 = false` in the composed main.tf, so dropping them would break
-// that test.
-func awsKitchenSinkCompsLegacy() *Components {
-	return &Components{
-		ElastiCache: ptrBool(true),
-		Backups: &struct {
-			EC2         *bool `json:"ec2,omitempty"`
-			Rds         *bool `json:"rds,omitempty"`
-			ElastiCache *bool `json:"elasticache,omitempty"`
-			DynamoDB    *bool `json:"dynamodb,omitempty"`
-			S3          *bool `json:"s3,omitempty"`
-		}{
-			EC2:      ptrBool(true),
-			Rds:      ptrBool(true),
-			DynamoDB: ptrBool(false),
-			S3:       ptrBool(false),
 		},
 	}
 }

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -366,14 +366,18 @@ func TestDefaultWiring_BackupsDynamoDBS3(t *testing.T) {
 		require.False(t, hasS3, "s3_rule must not be wired when S3 backups are disabled")
 	})
 
-	t.Run("legacy Backups shape wires V2 modules", func(t *testing.T) {
+	t.Run("a legacy Backups session that's been Normalized wires V2 modules", func(t *testing.T) {
 		t.Parallel()
+		// Phase 3b dropped the legacy Backups-field fallback in DefaultWiring.
+		// Legacy sessions must Normalize() before reaching the composer;
+		// reliable's composeradapter does this for us in production.
 		selected := map[ComponentKey]bool{
 			KeyBackups:     true,
 			KeyAWSDynamoDB: true,
 			KeyAWSS3:       true,
 		}
 		comps := &Components{
+			Cloud: "AWS",
 			Backups: &struct {
 				EC2         *bool `json:"ec2,omitempty"`
 				Rds         *bool `json:"rds,omitempty"`
@@ -385,6 +389,7 @@ func TestDefaultWiring_BackupsDynamoDBS3(t *testing.T) {
 				S3:       ptrBool(true),
 			},
 		}
+		comps.Normalize()
 		wi := DefaultWiring(selected, KeyBackups, comps)
 		require.Contains(t, wi.RawHCL["dynamodb_rule"], "module.aws_dynamodb.table_arn")
 		require.Contains(t, wi.RawHCL["s3_rule"], "module.aws_s3.bucket_arn")
@@ -578,9 +583,11 @@ func TestComposeStack_KitchenSink(t *testing.T) {
 		KeyGitHubActions,
 	}
 
-	// Enable backups for EC2/EBS + RDS to trigger wiring.
-	comps := awsKitchenSinkCompsLegacy()
-	cfg := awsKitchenSinkCfgLegacy()
+	// Enable backups for EC2/EBS + RDS to trigger wiring. Cfg sets
+	// RDS.ReadReplicas="2" to exercise the read-replicas mapper branch
+	// that the V2 kitchen-sink leaves unset.
+	comps := awsKitchenSinkCompsV2()
+	cfg := awsKitchenSinkCfgWithReadReplicas()
 
 	c := newTestClient()
 	out, err := c.ComposeStack(ComposeStackOpts{

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -807,17 +807,14 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		}
 
 	case KeyBackups:
+		// Legacy sessions must Normalize before reaching DefaultWiring;
+		// reliable's composeradapter does this for us in production.
 		enableEbs, enableRds, enableDdb, enableS3 := false, false, false, false
 		if comps != nil && comps.AWSBackups != nil {
 			enableEbs = boolVal(comps.AWSBackups.EC2)
 			enableRds = boolVal(comps.AWSBackups.RDS)
 			enableDdb = boolVal(comps.AWSBackups.DynamoDB)
 			enableS3 = boolVal(comps.AWSBackups.S3)
-		} else if comps != nil && comps.Backups != nil {
-			enableEbs = boolVal(comps.Backups.EC2)
-			enableRds = boolVal(comps.Backups.Rds)
-			enableDdb = boolVal(comps.Backups.DynamoDB)
-			enableS3 = boolVal(comps.Backups.S3)
 		}
 		wi.RawHCL["enable_ec2_ebs"] = boolToHCL(enableEbs)
 		wi.RawHCL["enable_rds"] = boolToHCL(enableRds)

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -600,7 +600,8 @@ func (m DefaultMapper) BuildModuleValues(
 		}
 
 		// Only consider details for services that are actually enabled, if we know them.
-		// Check AWSBackups (v2) first, then legacy Backups for backward compatibility.
+		// Legacy sessions must Normalize before reaching BuildModuleValues;
+		// reliable's composeradapter does this for us in production.
 		enabled := map[string]bool{}
 		if comps != nil && comps.AWSBackups != nil {
 			enabled["ec2"] = boolVal(comps.AWSBackups.EC2)
@@ -608,12 +609,6 @@ func (m DefaultMapper) BuildModuleValues(
 			enabled["elasticache"] = boolVal(comps.AWSBackups.ElastiCache)
 			enabled["dynamodb"] = boolVal(comps.AWSBackups.DynamoDB)
 			enabled["s3"] = boolVal(comps.AWSBackups.S3)
-		} else if comps != nil && comps.Backups != nil {
-			enabled["ec2"] = boolVal(comps.Backups.EC2)
-			enabled["rds"] = boolVal(comps.Backups.Rds)
-			enabled["elasticache"] = boolVal(comps.Backups.ElastiCache)
-			enabled["dynamodb"] = boolVal(comps.Backups.DynamoDB)
-			enabled["s3"] = boolVal(comps.Backups.S3)
 		}
 
 		if cfg != nil && cfg.Backups != nil {

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -689,3 +689,46 @@ func TestBuildModuleValues_AWSEC2_CpuArchPrecedence(t *testing.T) {
 		assert.False(t, hasArch, "no arch hint should leave arch unset")
 	})
 }
+
+// TestBuildModuleValues_Postgres_RDSConfig pins the cfg.RDS → module.rds
+// mapping. Previously the kitchen-sink integration test exercised these
+// branches but asserted nothing on the mapper output; the fixture rename
+// in #122 (`awsKitchenSinkCfgWithReadReplicas`) made the gap visible.
+func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
+	m := DefaultMapper{}
+
+	t.Run("ReadReplicas set emits num_read_nodes", func(t *testing.T) {
+		cfg := &Config{RDS: &struct {
+			CPUSize      string `json:"cpuSize,omitempty"`
+			ReadReplicas string `json:"readReplicas,omitempty"`
+			StorageSize  string `json:"storageSize,omitempty"`
+		}{ReadReplicas: "2"}}
+		vals, err := m.BuildModuleValues(KeyPostgres, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "2", vals["num_read_nodes"])
+	})
+
+	t.Run("ReadReplicas unset leaves num_read_nodes unset", func(t *testing.T) {
+		cfg := &Config{RDS: &struct {
+			CPUSize      string `json:"cpuSize,omitempty"`
+			ReadReplicas string `json:"readReplicas,omitempty"`
+			StorageSize  string `json:"storageSize,omitempty"`
+		}{CPUSize: "db.m7i.2xlarge"}}
+		vals, err := m.BuildModuleValues(KeyPostgres, nil, cfg, "", "")
+		require.NoError(t, err)
+		_, hasKey := vals["num_read_nodes"]
+		assert.False(t, hasKey, "unset ReadReplicas should not emit num_read_nodes")
+	})
+
+	t.Run("CPUSize and StorageSize map to node_cpu_size and storage_size", func(t *testing.T) {
+		cfg := &Config{RDS: &struct {
+			CPUSize      string `json:"cpuSize,omitempty"`
+			ReadReplicas string `json:"readReplicas,omitempty"`
+			StorageSize  string `json:"storageSize,omitempty"`
+		}{CPUSize: "db.m7i.2xlarge", StorageSize: "20"}}
+		vals, err := m.BuildModuleValues(KeyPostgres, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "db.m7i.2xlarge", vals["node_cpu_size"])
+		assert.Equal(t, "20", vals["storage_size"])
+	})
+}

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -1078,17 +1078,9 @@ func (c *Components) GCPBackupsSelected() bool {
 }
 
 // BackupsSelected returns true if any backup component is selected (AWS or GCP).
+// Callers with legacy session shapes must Normalize first; see composeradapter.
 func (c *Components) BackupsSelected() bool {
-	return c.AWSBackupsSelected() || c.GCPBackupsSelected() || c.legacyBackupsSelected()
-}
-
-// legacyBackupsSelected checks the old Backups field for backward compatibility.
-func (c *Components) legacyBackupsSelected() bool {
-	if c == nil || c.Backups == nil {
-		return false
-	}
-	b := c.Backups
-	return boolVal(b.EC2) || boolVal(b.Rds) || boolVal(b.ElastiCache) || boolVal(b.DynamoDB) || boolVal(b.S3)
+	return c.AWSBackupsSelected() || c.GCPBackupsSelected()
 }
 
 func (c *Config) Normalize() {


### PR DESCRIPTION
Follow-up to #121 — ships the fixture-coupled Backups half of #118 that PR #121 explicitly deferred. Drops the redundant legacy-`Backups`-field read layer from `pkg/composer`. No rendered `main.tf` changes; deployed stacks keep planning clean.

## Why this is safe to land now

Phase 2 (reliable's composeradapter, reliable#1041) is the single production entry point for legacy-key session JSON. `Components.Normalize` (called on every `ComposeStack` entry at `compose.go:89,240`) also promotes the legacy `Backups` field to `AWSBackups` as a belt-and-braces translation. This PR only drops the *read-time* legacy fallbacks that were a third layer of redundancy — no rendered `module.<name>` paths change, so the `moved {}` automation is not a prerequisite.

## What changes

- `BackupsSelected` (`types.go:1080`) collapses to `AWSBackupsSelected() || GCPBackupsSelected()`; `legacyBackupsSelected` is deleted.
- `DefaultWiring`'s `KeyBackups` arm (`contracts.go:809`) and `BuildModuleValues`'s `KeyBackups` arm (`mapper.go:602`) drop the `else if comps.Backups != nil` branch; godoc points callers with legacy shapes at `Normalize` / composeradapter.
- `awsKitchenSinkCompsLegacy()` is deleted; its sole consumer (`TestComposeStack_KitchenSink`) now uses `awsKitchenSinkCompsV2()`.
- `awsKitchenSinkCfgLegacy()` is renamed to `awsKitchenSinkCfgWithReadReplicas()` — more accurate name for its actual purpose (exercising the `cfg.RDS.ReadReplicas != ""` mapper branch that the V2 kitchen-sink intentionally leaves unset).
- `awsKitchenSinkCompsV2()` switches its ElastiCache toggle from the legacy field to `AWSElastiCache` (prefixed), cleaning the last legacy-field-write from the V2 fixture.

## Test migrations

`TestDefaultWiring_BackupsDynamoDBS3/legacy_Backups_shape_wires_V2_modules` was guarding the removed read path. It's re-scoped as "a legacy Backups session that's been Normalized wires V2 modules" and now calls `Normalize()` first — mirroring the `TestDefaultWiring_LambdaPublicVPC` pattern #121 established. `TestComposeStack_KitchenSink` assertions on `enable_dynamodb = false` / `enable_s3 = false` still pass because `boolVal(nil) == false`; the explicit `false` in the deleted legacy fixture was defensive, not load-bearing.

## What's NOT in this PR (deferred)

Blocked on the `moved {}` automation PR (those changes rename rendered `module.<name>` paths):
- AWS→legacy normalization switches in `DefaultWiring` / `BuildModuleValues`.
- `moduleRef` / `vpcRef` / ... selector simplification.
- 10 `has*` OR pairs in `contracts.go`.
- `TestVpcRef` / `TestV2KeyNormalization` / `TestModuleRefHelpers` / `TestBuildModuleValues_V2KeyNormalization` migrations.

Plan is: ship `moved {}` emitter next, then stack the selector/switch collapse on top as the final Phase 3b PR.

## Test plan
- [x] `go build ./... && go vet ./...` — clean
- [x] `go test -race -count=1 ./pkg/composer/...` — clean (38s)
- [x] `terraform fmt -check -recursive` — clean (no `.tf` changes)
- [x] `grep -rn 'legacyBackupsSelected\|awsKitchenSinkCfgLegacy\|awsKitchenSinkCompsLegacy' pkg/composer/` — zero matches
- [x] `grep -n 'comps.Backups != nil' pkg/composer/contracts.go pkg/composer/mapper.go` — zero matches

Refs #118, #76