### PR TITLE
refactor(composer): Phase 3b final — moved{} emitter + prefixed-only vocabulary

### DIFF
--- a/pkg/composer/builders_test.go
+++ b/pkg/composer/builders_test.go
@@ -75,17 +75,10 @@ func configWithAWSECS(in awsECSCfgInput) *Config {
 	}
 }
 
-// awsKitchenSinkCfgBase returns the Config fields shared by the two composer
-// kitchen-sink tests (legacy- and V2-key variants). Fields use the legacy
-// (un-prefixed) Config names because Config.Normalize() promotes them to
-// the cloud-prefixed equivalents during compose.
-//
-// The split into Base / WithReadReplicas / V2 (instead of a single shared
-// builder) preserves a subtle fidelity invariant: the V2 variant leaves
-// RDS.ReadReplicas unset, exercising the "unset" branch of the RDS mapper,
-// while the WithReadReplicas variant sets it to "2" so both mapper branches
-// are exercised. Collapsing into one shared helper would silently couple the
-// two tests on that branch.
+// awsKitchenSinkCfgBase returns the Config fields shared by the composer
+// kitchen-sink tests. Fields use the legacy (un-prefixed) Config names
+// because Config.Normalize() promotes them to the cloud-prefixed
+// equivalents during compose.
 func awsKitchenSinkCfgBase() *Config {
 	return &Config{
 		Region: "us-west-2",
@@ -130,11 +123,10 @@ func awsKitchenSinkCfgWithReadReplicas() *Config {
 	return cfg
 }
 
-// awsKitchenSinkCompsV2 returns the Components shape for both kitchen-sink
-// tests: AWSElastiCache toggle plus AWSBackups (prefixed). EC2 and RDS are
-// the only backup targets enabled; DynamoDB and S3 are left unset so
-// boolVal(nil) falls through to false, matching the wiring/backups subtest
-// assertions in both kitchen-sink tests.
+// awsKitchenSinkCompsV2 returns the Components shape for the kitchen-sink
+// composer tests: AWSElastiCache toggle plus AWSBackups with EC2 + RDS
+// enabled. DynamoDB and S3 are left unset so boolVal(nil) == false reaches
+// the wiring assertions.
 func awsKitchenSinkCompsV2() *Components {
 	return &Components{
 		AWSElastiCache: ptrBool(true),

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -81,6 +81,12 @@ func (c *Client) ComposeSingle(opts ComposeSingleOpts) (Files, error) {
 		cloud = "aws" // Default to AWS for backward compatibility
 	}
 
+	// Reject legacy ComponentKeys as the compose Key. Phase 3b of #76 made
+	// the composer's selection vocabulary AWS-prefixed-only.
+	if err := ValidateNoLegacyKeys([]ComponentKey{opts.Key}); err != nil {
+		return nil, err
+	}
+
 	// Normalize legacy-key shapes to AWS-prefixed before any helper consumes
 	// Comps/Cfg. Idempotent for already-normalized input (the composeradapter
 	// path) and required for direct Go callers that construct Components from
@@ -243,7 +249,14 @@ func (c *Client) ComposeStack(opts ComposeStackOpts) (Files, error) {
 		opts.Cfg.Normalize()
 	}
 
-	// 0. Validate compute exclusivity before expanding dependencies.
+	// 0a. Reject legacy ComponentKeys in SelectedKeys. Phase 3b of #76 made
+	// the composer's selection vocabulary AWS-prefixed-only; reliable's
+	// composeradapter upgrades legacy session JSON before handing it off.
+	if err := ValidateNoLegacyKeys(opts.SelectedKeys); err != nil {
+		return nil, err
+	}
+
+	// 0b. Validate compute exclusivity before expanding dependencies.
 	if err := ValidateComputeExclusivityWithOpts(opts.SelectedKeys, ComputeExclusivityOpts{
 		AllowLegacyStandaloneEC2Lambda: opts.AllowLegacyMixedCompute,
 	}); err != nil {
@@ -261,13 +274,12 @@ func (c *Client) ComposeStack(opts ComposeStackOpts) (Files, error) {
 		case "gcp":
 			backupKey = KeyGCPBackups
 		default:
-			// For AWS and legacy, use KeyBackups which maps to modules/backups
-			backupKey = KeyBackups
+			backupKey = KeyAWSBackups
 		}
 
 		found := false
 		for _, k := range expanded {
-			if k == KeyBackups || k == KeyAWSBackups || k == KeyGCPBackups {
+			if k == KeyAWSBackups || k == KeyGCPBackups {
 				found = true
 				break
 			}

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -33,58 +33,26 @@ var awsBedrockCollectionArnRegex = regexp.MustCompile(
 //     compose so the preset's regex validation passes.
 
 // TestBedrockWiring_AOSSCollectionArn locks in the rename
-// `opensearch_arn` → `opensearch_collection_arn` and the new
-// `.collection_arn` RHS across both the v2 (aws_-prefixed) and legacy key
-// paths. The `case KeyBedrock:` branch in contracts.go serves both after
-// DefaultWiring's normalization switch, so regressing one silently
-// regresses the other — the legacy subtest prevents that.
+// `opensearch_arn` → `opensearch_collection_arn` and the `.collection_arn`
+// RHS for the AWS-prefixed Bedrock wiring. Legacy unprefixed keys no
+// longer reach the composer after Phase 3b strict validation; the
+// legacy-parity signal now lives in TestComposeStack_RejectsLegacyKeys.
 func TestBedrockWiring_AOSSCollectionArn(t *testing.T) {
-	cases := []struct {
-		name         string
-		selected     map[ComponentKey]bool
-		key          ComponentKey
-		wantRHS      string
-		wantLegacyIn string
-	}{
-		{
-			name: "v2 aws_-prefixed keys",
-			selected: map[ComponentKey]bool{
-				KeyAWSS3:         true,
-				KeyAWSOpenSearch: true,
-				KeyAWSBedrock:    true,
-			},
-			key:          KeyAWSBedrock,
-			wantRHS:      "module.aws_opensearch.collection_arn",
-			wantLegacyIn: "module.aws_opensearch",
-		},
-		{
-			name: "legacy unprefixed keys",
-			selected: map[ComponentKey]bool{
-				KeyS3:         true,
-				KeyOpenSearch: true,
-				KeyBedrock:    true,
-			},
-			key:          KeyBedrock,
-			wantRHS:      "module.opensearch.collection_arn",
-			wantLegacyIn: "module.opensearch",
-		},
+	selected := map[ComponentKey]bool{
+		KeyAWSS3:         true,
+		KeyAWSOpenSearch: true,
+		KeyAWSBedrock:    true,
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			wi := DefaultWiring(tc.selected, tc.key, &Components{})
+	wi := DefaultWiring(selected, KeyAWSBedrock, &Components{})
 
-			require.Equal(t, tc.wantRHS, wi.RawHCL["opensearch_collection_arn"],
-				"bedrock must wire opensearch_collection_arn to the AOSS collection output")
-			require.Contains(t, wi.RawHCL["opensearch_collection_arn"], tc.wantLegacyIn,
-				"wiring must target the correct opensearch module for this key family")
+	require.Equal(t, "module.aws_opensearch.collection_arn", wi.RawHCL["opensearch_collection_arn"],
+		"bedrock must wire opensearch_collection_arn to the AOSS collection output")
 
-			_, hasOldKey := wi.RawHCL["opensearch_arn"]
-			require.False(t, hasOldKey, "legacy opensearch_arn input must not be emitted")
+	_, hasOldKey := wi.RawHCL["opensearch_arn"]
+	require.False(t, hasOldKey, "legacy opensearch_arn input must not be emitted")
 
-			require.Contains(t, wi.Names, "opensearch_collection_arn")
-			require.NotContains(t, wi.Names, "opensearch_arn")
-		})
-	}
+	require.Contains(t, wi.Names, "opensearch_collection_arn")
+	require.NotContains(t, wi.Names, "opensearch_arn")
 }
 
 // TestMapper_OpenSearchDeploymentTypeOverride verifies the mapper
@@ -132,13 +100,14 @@ func TestMapper_OpenSearchDeploymentTypeOverride(t *testing.T) {
 			"deployment_type must track user config when Bedrock is absent")
 	})
 
-	t.Run("legacy Bedrock flag also forces serverless", func(t *testing.T) {
-		vals, err := m.BuildModuleValues(
-			KeyOpenSearch,
-			&Components{Bedrock: ptrBool(true), OpenSearch: ptrBool(true)},
-			&Config{},
-			"demo", "us-east-1",
-		)
+	t.Run("Normalized legacy Bedrock/OpenSearch flags still force serverless", func(t *testing.T) {
+		// Legacy Components fields must Normalize before reaching the mapper;
+		// reliable's composeradapter does this in production. After Normalize
+		// the legacy Bedrock/OpenSearch fields have been promoted to their
+		// AWS-prefixed siblings, so the mapper's V2 code path fires.
+		c := &Components{Cloud: "AWS", Bedrock: ptrBool(true), OpenSearch: ptrBool(true)}
+		c.Normalize()
+		vals, err := m.BuildModuleValues(KeyAWSOpenSearch, c, &Config{}, "demo", "us-east-1")
 		require.NoError(t, err)
 		require.Equal(t, "serverless", vals["deployment_type"])
 	})

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -53,67 +53,13 @@ func TestVpcRef(t *testing.T) {
 	}{
 		{"aws_vpc selected", map[ComponentKey]bool{KeyAWSVPC: true}, "module.aws_vpc"},
 		{"gcp_vpc selected", map[ComponentKey]bool{KeyGCPVPC: true}, "module.gcp_vpc"},
-		{"legacy vpc selected", map[ComponentKey]bool{KeyVPC: true}, "module.vpc"},
-		{"no vpc selected", map[ComponentKey]bool{}, "module.vpc"},
-		{"aws_vpc takes precedence over legacy", map[ComponentKey]bool{KeyAWSVPC: true, KeyVPC: true}, "module.aws_vpc"},
+		{"nothing selected defaults to aws_vpc", map[ComponentKey]bool{}, "module.aws_vpc"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := vpcRef(tt.selected)
 			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
-// TestV2KeyNormalization verifies that every V2 key in LegacyToV2Key is handled
-// by the DefaultWiring normalization switch. This is a structural test that
-// catches missing normalizations when new V2 keys are added.
-func TestV2KeyNormalization(t *testing.T) {
-	t.Parallel()
-	// Build the set of V2 keys that have dedicated case blocks in DefaultWiring
-	// (e.g., KeyAWSEC2 has its own case and should NOT be normalized).
-	// We test normalization by calling DefaultWiring with each V2 key and a
-	// minimal selected set, then verifying it doesn't silently skip wiring.
-	//
-	// Strategy: for each V2→legacy mapping, call DefaultWiring with the V2 key.
-	// If the legacy key has wiring logic (e.g., KeyWAF sets scope/region),
-	// the V2 key should produce the same wiring names.
-	for legacy, v2 := range LegacyToV2Key {
-		t.Run(string(v2), func(t *testing.T) {
-			t.Parallel()
-			// Use a selected set with common dependencies so wiring can fire
-			selected := map[ComponentKey]bool{
-				v2:               true,
-				KeyAWSVPC:        true,
-				KeyAWSALB:        true,
-				KeyAWSWAF:        true,
-				KeyAWSRDS:        true,
-				KeyAWSS3:         true,
-				KeyAWSEKS:        true,
-				KeyAWSBastion:    true,
-				KeyAWSSQS:        true,
-				KeyAWSOpenSearch: true,
-			}
-			legacySelected := map[ComponentKey]bool{
-				legacy:        true,
-				KeyVPC:        true,
-				KeyALB:        true,
-				KeyWAF:        true,
-				KeyPostgres:   true,
-				KeyS3:         true,
-				KeyResource:   true,
-				KeyBastion:    true,
-				KeySQS:        true,
-				KeyOpenSearch: true,
-			}
-
-			wiV2 := DefaultWiring(selected, v2, &Components{})
-			wiLegacy := DefaultWiring(legacySelected, legacy, &Components{})
-
-			// The V2 and legacy keys must produce the same wiring variable names
-			require.ElementsMatch(t, wiLegacy.Names, wiV2.Names,
-				"V2 key %s and legacy key %s should wire the same variable names", v2, legacy)
 		})
 	}
 }
@@ -126,41 +72,17 @@ func TestModuleRefHelpers(t *testing.T) {
 		selected map[ComponentKey]bool
 		want     string
 	}{
-		// ALB
-		{"alb legacy", albRef, map[ComponentKey]bool{KeyALB: true}, "module.alb"},
-		{"alb v2", albRef, map[ComponentKey]bool{KeyAWSALB: true}, "module.aws_alb"},
-		{"alb both prefers v2", albRef, map[ComponentKey]bool{KeyALB: true, KeyAWSALB: true}, "module.aws_alb"},
-		{"alb neither defaults to legacy", albRef, map[ComponentKey]bool{}, "module.alb"},
-		// WAF
-		{"waf legacy", wafRef, map[ComponentKey]bool{KeyWAF: true}, "module.waf"},
-		{"waf v2", wafRef, map[ComponentKey]bool{KeyAWSWAF: true}, "module.aws_waf"},
-		{"waf neither defaults to legacy", wafRef, map[ComponentKey]bool{}, "module.waf"},
-		// Bastion
-		{"bastion legacy", bastionRef, map[ComponentKey]bool{KeyBastion: true}, "module.bastion"},
-		{"bastion v2", bastionRef, map[ComponentKey]bool{KeyAWSBastion: true}, "module.aws_bastion"},
-		{"bastion neither defaults to legacy", bastionRef, map[ComponentKey]bool{}, "module.bastion"},
-		// RDS
-		{"rds legacy", rdsRef, map[ComponentKey]bool{KeyPostgres: true}, "module.rds"},
-		{"rds v2", rdsRef, map[ComponentKey]bool{KeyAWSRDS: true}, "module.aws_rds"},
-		{"rds neither defaults to legacy", rdsRef, map[ComponentKey]bool{}, "module.rds"},
-		// S3
-		{"s3 legacy", s3Ref, map[ComponentKey]bool{KeyS3: true}, "module.s3"},
-		{"s3 v2", s3Ref, map[ComponentKey]bool{KeyAWSS3: true}, "module.aws_s3"},
-		{"s3 neither defaults to legacy", s3Ref, map[ComponentKey]bool{}, "module.s3"},
-		// OpenSearch
-		{"opensearch legacy", opensearchRef, map[ComponentKey]bool{KeyOpenSearch: true}, "module.opensearch"},
-		{"opensearch v2", opensearchRef, map[ComponentKey]bool{KeyAWSOpenSearch: true}, "module.aws_opensearch"},
-		{"opensearch neither defaults to legacy", opensearchRef, map[ComponentKey]bool{}, "module.opensearch"},
-		// SQS
-		{"sqs legacy", sqsRef, map[ComponentKey]bool{KeySQS: true}, "module.sqs"},
-		{"sqs v2", sqsRef, map[ComponentKey]bool{KeyAWSSQS: true}, "module.aws_sqs"},
-		{"sqs neither defaults to legacy", sqsRef, map[ComponentKey]bool{}, "module.sqs"},
-		// Resource (EKS/ECS)
-		{"resource legacy", resourceRef, map[ComponentKey]bool{KeyResource: true}, "module.resource"},
+		{"alb", albRef, map[ComponentKey]bool{KeyAWSALB: true}, "module.aws_alb"},
+		{"waf", wafRef, map[ComponentKey]bool{KeyAWSWAF: true}, "module.aws_waf"},
+		{"bastion", bastionRef, map[ComponentKey]bool{KeyAWSBastion: true}, "module.aws_bastion"},
+		{"rds", rdsRef, map[ComponentKey]bool{KeyAWSRDS: true}, "module.aws_rds"},
+		{"s3", s3Ref, map[ComponentKey]bool{KeyAWSS3: true}, "module.aws_s3"},
+		{"opensearch", opensearchRef, map[ComponentKey]bool{KeyAWSOpenSearch: true}, "module.aws_opensearch"},
+		{"sqs", sqsRef, map[ComponentKey]bool{KeyAWSSQS: true}, "module.aws_sqs"},
 		{"resource eks v2", resourceRef, map[ComponentKey]bool{KeyAWSEKS: true}, "module.aws_eks"},
 		{"resource ecs v2", resourceRef, map[ComponentKey]bool{KeyAWSECS: true}, "module.aws_ecs"},
 		{"resource eks+ecs prefers eks", resourceRef, map[ComponentKey]bool{KeyAWSEKS: true, KeyAWSECS: true}, "module.aws_eks"},
-		{"resource neither defaults to legacy", resourceRef, map[ComponentKey]bool{}, "module.resource"},
+		{"resource neither defaults to eks", resourceRef, map[ComponentKey]bool{}, "module.aws_eks"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -368,11 +290,12 @@ func TestDefaultWiring_BackupsDynamoDBS3(t *testing.T) {
 
 	t.Run("a legacy Backups session that's been Normalized wires V2 modules", func(t *testing.T) {
 		t.Parallel()
-		// Phase 3b dropped the legacy Backups-field fallback in DefaultWiring.
-		// Legacy sessions must Normalize() before reaching the composer;
-		// reliable's composeradapter does this for us in production.
+		// Phase 3b collapsed both the legacy Backups-field fallback and the
+		// AWS→legacy normalization switch. Legacy Components fields must
+		// Normalize before reaching the composer; reliable's composeradapter
+		// does this in production.
 		selected := map[ComponentKey]bool{
-			KeyBackups:     true,
+			KeyAWSBackups:  true,
 			KeyAWSDynamoDB: true,
 			KeyAWSS3:       true,
 		}
@@ -390,7 +313,7 @@ func TestDefaultWiring_BackupsDynamoDBS3(t *testing.T) {
 			},
 		}
 		comps.Normalize()
-		wi := DefaultWiring(selected, KeyBackups, comps)
+		wi := DefaultWiring(selected, KeyAWSBackups, comps)
 		require.Contains(t, wi.RawHCL["dynamodb_rule"], "module.aws_dynamodb.table_arn")
 		require.Contains(t, wi.RawHCL["s3_rule"], "module.aws_s3.bucket_arn")
 	})
@@ -565,22 +488,25 @@ func TestComposeStack_V2KitchenSink(t *testing.T) {
 }
 
 func TestComposeStack_KitchenSink(t *testing.T) {
-	// Select a broad set of modules to exercise wiring.
+	// Select a broad set of modules to exercise wiring. Uses prefixed keys
+	// plus the polymorphic KeyResource (EKS control plane) and KeyEC2 (EKS
+	// managed node group) — those stay until Phase 4 renames them to
+	// unambiguous `KeyAWSEKSControlPlane` / `KeyAWSEKSNodeGroup`.
 	selected := []ComponentKey{
-		KeyVPC,
-		KeyResource, // EKS control plane
-		KeyEC2,      // node group
-		KeyBastion,
-		KeyALB,
-		KeyPostgres,
-		KeyElastiCache,
-		KeyWAF,
-		KeyCloudfront,
-		KeyBackups,
-		KeyCloudWatchLogs,
-		KeySQS,
-		KeyCloudWatchMonitoring,
-		KeyGitHubActions,
+		KeyAWSVPC,
+		KeyAWSEKS, // EKS control plane
+		KeyEC2,    // EKS node group (polymorphic; KeyAWSEKSNodeGroup lands in Phase 4)
+		KeyAWSBastion,
+		KeyAWSALB,
+		KeyAWSRDS,
+		KeyAWSElastiCache,
+		KeyAWSWAF,
+		KeyAWSCloudfront,
+		KeyAWSBackups,
+		KeyAWSCloudWatchLogs,
+		KeyAWSSQS,
+		KeyAWSCloudWatchMonitoring,
+		KeyAWSGitHubActions,
 	}
 
 	// Enable backups for EC2/EBS + RDS to trigger wiring. Cfg sets
@@ -636,29 +562,29 @@ func TestComposeStack_KitchenSink(t *testing.T) {
 	})
 
 	t.Run("wiring/eks", func(t *testing.T) {
-		require.Contains(t, mainTF, `vpc_id                    = module.vpc.vpc_id`)
-		require.Contains(t, mainTF, `private_subnet_ids        = module.vpc.private_subnet_ids`)
-		require.Contains(t, mainTF, `public_subnet_ids         = module.vpc.public_subnet_ids`)
+		require.Contains(t, mainTF, `vpc_id                    = module.aws_vpc.vpc_id`)
+		require.Contains(t, mainTF, `private_subnet_ids        = module.aws_vpc.private_subnet_ids`)
+		require.Contains(t, mainTF, `public_subnet_ids         = module.aws_vpc.public_subnet_ids`)
 		require.Contains(t, mainTF, `cluster_enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]`)
 	})
 
 	t.Run("wiring/nodegroup", func(t *testing.T) {
-		require.Contains(t, mainTF, `cluster_name   = module.resource.cluster_name`)
-		require.Contains(t, mainTF, `subnet_ids     = module.vpc.private_subnet_ids`)
+		require.Contains(t, mainTF, `cluster_name   = module.aws_eks.cluster_name`)
+		require.Contains(t, mainTF, `subnet_ids     = module.aws_vpc.private_subnet_ids`)
 	})
 
 	t.Run("wiring/alb", func(t *testing.T) {
-		require.Contains(t, mainTF, `vpc_id            = module.vpc.vpc_id`)
-		require.Contains(t, mainTF, `public_subnet_ids = module.vpc.public_subnet_ids`)
+		require.Contains(t, mainTF, `vpc_id            = module.aws_vpc.vpc_id`)
+		require.Contains(t, mainTF, `public_subnet_ids = module.aws_vpc.public_subnet_ids`)
 	})
 
 	t.Run("wiring/bastion", func(t *testing.T) {
-		require.Regexp(t, regexp.MustCompile(`(?m)^\s*subnet_id\s+=\s+module\.vpc\.public_subnet_ids\[0\]\s*$`), mainTF)
+		require.Regexp(t, regexp.MustCompile(`(?m)^\s*subnet_id\s+=\s+module\.aws_vpc\.public_subnet_ids\[0\]\s*$`), mainTF)
 	})
 
 	t.Run("wiring/postgres", func(t *testing.T) {
-		require.Contains(t, mainTF, `vpc_id                  = module.vpc.vpc_id`)
-		require.Contains(t, mainTF, `subnet_ids              = module.vpc.private_subnet_ids`)
+		require.Contains(t, mainTF, `vpc_id                  = module.aws_vpc.vpc_id`)
+		require.Contains(t, mainTF, `subnet_ids              = module.aws_vpc.private_subnet_ids`)
 		require.Contains(t, mainTF, `enable_cloudwatch_logs  = true`)
 		require.Contains(t, mainTF, `cloudwatch_logs_exports = ["postgresql", "upgrade"]`)
 		require.Contains(t, mainTF, `skip_final_snapshot     = true`)
@@ -666,14 +592,14 @@ func TestComposeStack_KitchenSink(t *testing.T) {
 	})
 
 	t.Run("wiring/elasticache", func(t *testing.T) {
-		require.Contains(t, mainTF, `vpc_id           = module.vpc.vpc_id`)
-		require.Contains(t, mainTF, `cache_subnet_ids = module.vpc.private_subnet_ids`)
+		require.Contains(t, mainTF, `vpc_id           = module.aws_vpc.vpc_id`)
+		require.Contains(t, mainTF, `cache_subnet_ids = module.aws_vpc.private_subnet_ids`)
 	})
 
 	t.Run("wiring/cloudfront", func(t *testing.T) {
 		require.Contains(t, mainTF, `origin_type          = "http"`)
-		require.Contains(t, mainTF, `custom_origin_domain = module.alb.alb_dns_name`)
-		require.Contains(t, mainTF, `web_acl_id           = module.waf.web_acl_arn`)
+		require.Contains(t, mainTF, `custom_origin_domain = module.aws_alb.alb_dns_name`)
+		require.Contains(t, mainTF, `web_acl_id           = module.aws_waf.web_acl_arn`)
 	})
 
 	t.Run("wiring/waf_providers", func(t *testing.T) {
@@ -685,10 +611,10 @@ func TestComposeStack_KitchenSink(t *testing.T) {
 	})
 
 	t.Run("wiring/monitoring", func(t *testing.T) {
-		require.Contains(t, mainTF, `instance_ids     = [module.bastion.bastion_instance_id]`)
-		require.Contains(t, mainTF, `rds_instance_ids = [module.rds.instance_id]`)
-		require.Contains(t, mainTF, `alb_arn_suffixes = [module.alb.alb_arn_suffix]`)
-		require.Contains(t, mainTF, `sqs_queue_arns   = [module.sqs.queue_arn]`)
+		require.Contains(t, mainTF, `instance_ids     = [module.aws_bastion.bastion_instance_id]`)
+		require.Contains(t, mainTF, `rds_instance_ids = [module.aws_rds.instance_id]`)
+		require.Contains(t, mainTF, `alb_arn_suffixes = [module.aws_alb.alb_arn_suffix]`)
+		require.Contains(t, mainTF, `sqs_queue_arns   = [module.aws_sqs.queue_arn]`)
 	})
 
 	t.Run("wiring/backups", func(t *testing.T) {
@@ -697,8 +623,8 @@ func TestComposeStack_KitchenSink(t *testing.T) {
 		require.Regexp(t, regexp.MustCompile(`(?m)^\s*enable_dynamodb\s*=\s*false\s*$`), mainTF)
 		require.Regexp(t, regexp.MustCompile(`(?m)^\s*enable_s3\s*=\s*false\s*$`), mainTF)
 		require.Contains(t, mainTF, `selection_tags = [{ type = "STRINGEQUALS", key = "backup", value = "true" }]`)
-		require.Contains(t, mainTF, `resource_arns = [module.rds.instance_arn]`)
-		require.Regexp(t, regexp.MustCompile(`(?m)^\s*default_rule\s*=\s*var\.backups_default_rule\s*$`), mainTF)
+		require.Contains(t, mainTF, `resource_arns = [module.aws_rds.instance_arn]`)
+		require.Regexp(t, regexp.MustCompile(`(?m)^\s*default_rule\s*=\s*var\.aws_backups_default_rule\s*$`), mainTF)
 	})
 
 	t.Run("tfvars/ec2_namespacing", func(t *testing.T) {
@@ -740,7 +666,7 @@ func TestDefaultWiring_LambdaPublicVPC(t *testing.T) {
 			KeyAWSLambda: true,
 		}
 		comps := &Components{AWSVPC: "Public VPC", AWSLambda: ptrBool(true)}
-		wi := DefaultWiring(selected, KeyLambda, comps)
+		wi := DefaultWiring(selected, KeyAWSLambda, comps)
 		_, hasEnableVPC := wi.RawHCL["enable_vpc"]
 		_, hasSubnetIDs := wi.RawHCL["subnet_ids"]
 		require.False(t, hasEnableVPC, "Public VPC: Lambda should not have enable_vpc")
@@ -748,16 +674,17 @@ func TestDefaultWiring_LambdaPublicVPC(t *testing.T) {
 	})
 
 	t.Run("Lambda skips VPC wiring for a legacy session that's been Normalized", func(t *testing.T) {
-		// Phase 3b dropped the legacy VPC-string fallback in isPublicVPC.
-		// Legacy sessions must Normalize() before reaching the composer;
-		// reliable's composeradapter does this for us in production.
+		// Legacy Components struct fields must be Normalize()d before reaching
+		// the composer; reliable's composeradapter does this for us in
+		// production. After Normalize, Lambda/VPC live on AWSLambda/AWSVPC
+		// and the selected map uses prefixed keys.
 		selected := map[ComponentKey]bool{
-			KeyVPC:    true,
-			KeyLambda: true,
+			KeyAWSVPC:    true,
+			KeyAWSLambda: true,
 		}
 		comps := &Components{Cloud: "AWS", VPC: "Public VPC", Lambda: ptrBool(true)}
 		comps.Normalize()
-		wi := DefaultWiring(selected, KeyLambda, comps)
+		wi := DefaultWiring(selected, KeyAWSLambda, comps)
 		_, hasEnableVPC := wi.RawHCL["enable_vpc"]
 		require.False(t, hasEnableVPC, "Legacy Public VPC (after Normalize): Lambda should not have enable_vpc")
 	})
@@ -768,7 +695,7 @@ func TestDefaultWiring_LambdaPublicVPC(t *testing.T) {
 			KeyAWSLambda: true,
 		}
 		comps := &Components{AWSVPC: "Private VPC", AWSLambda: ptrBool(true)}
-		wi := DefaultWiring(selected, KeyLambda, comps)
+		wi := DefaultWiring(selected, KeyAWSLambda, comps)
 		require.Equal(t, "true", wi.RawHCL["enable_vpc"])
 		require.Contains(t, wi.RawHCL["subnet_ids"], "private_subnet_ids")
 	})
@@ -779,7 +706,7 @@ func TestDefaultWiring_LambdaPublicVPC(t *testing.T) {
 			KeyAWSLambda: true,
 		}
 		comps := &Components{AWSVPC: "", AWSLambda: ptrBool(true)}
-		wi := DefaultWiring(selected, KeyLambda, comps)
+		wi := DefaultWiring(selected, KeyAWSLambda, comps)
 		require.Equal(t, "true", wi.RawHCL["enable_vpc"])
 		require.Contains(t, wi.RawHCL["subnet_ids"], "private_subnet_ids")
 	})
@@ -842,10 +769,10 @@ func TestComposeStack_LambdaPublicVPC(t *testing.T) {
 // This is a lighter-weight check than running `terraform validate` which requires network access.
 func TestComposeStack_AWS_ValidHCL(t *testing.T) {
 	selected := []ComponentKey{
-		KeyVPC,
-		KeyEC2,
-		KeyPostgres,
-		KeyS3,
+		KeyAWSVPC,
+		KeyEC2, // EKS node group (polymorphic)
+		KeyAWSRDS,
+		KeyAWSS3,
 	}
 
 	c := newTestClient()
@@ -873,20 +800,20 @@ func TestComposeStack_AWS_ValidHCL(t *testing.T) {
 // like writing "project" in .auto.tfvars when variables.tf declares "ec2_project".
 func TestComposeStack_TFVarsMatchVariables(t *testing.T) {
 	selected := []ComponentKey{
-		KeyVPC,
-		KeyResource,
-		KeyEC2,
-		KeyBastion,
-		KeyALB,
-		KeyPostgres,
-		KeyElastiCache,
-		KeyS3,
-		KeyCloudWatchLogs,
-		KeySQS,
+		KeyAWSVPC,
+		KeyAWSEKS,
+		KeyEC2, // EKS node group (polymorphic)
+		KeyAWSBastion,
+		KeyAWSALB,
+		KeyAWSRDS,
+		KeyAWSElastiCache,
+		KeyAWSS3,
+		KeyAWSCloudWatchLogs,
+		KeyAWSSQS,
 	}
 
 	comps := &Components{
-		ElastiCache: ptrBool(true),
+		AWSElastiCache: ptrBool(true),
 	}
 	cfg := &Config{
 		Region: "us-west-2",
@@ -964,12 +891,12 @@ func TestComposeStack_TerraformInit(t *testing.T) {
 	}
 
 	selected := []ComponentKey{
-		KeyVPC,
-		KeyResource,
-		KeyEC2,
-		KeyPostgres,
-		KeyS3,
-		KeyCloudWatchLogs,
+		KeyAWSVPC,
+		KeyAWSEKS,
+		KeyEC2, // EKS node group (polymorphic)
+		KeyAWSRDS,
+		KeyAWSS3,
+		KeyAWSCloudWatchLogs,
 	}
 
 	comps := &Components{}
@@ -1021,21 +948,15 @@ func TestComposeStack_ConflictingCompute(t *testing.T) {
 		errMsg string // cloud-specific error substring
 	}{
 		{
-			name:   "Lambda + EKS (legacy keys)",
-			cloud:  "aws",
-			keys:   []ComponentKey{KeyLambda, KeyResource, KeyVPC},
-			errMsg: "incompatible AWS compute",
-		},
-		{
 			name:   "AWS Lambda + AWS EKS (prefixed)",
 			cloud:  "aws",
 			keys:   []ComponentKey{KeyAWSLambda, KeyAWSEKS, KeyAWSVPC},
 			errMsg: "incompatible AWS compute",
 		},
 		{
-			name:   "Lambda + EC2 (implicit EKS dependency)",
+			name:   "AWS Lambda + EC2 node group (implicit EKS dependency)",
 			cloud:  "aws",
-			keys:   []ComponentKey{KeyLambda, KeyEC2, KeyVPC},
+			keys:   []ComponentKey{KeyAWSLambda, KeyEC2, KeyAWSVPC},
 			errMsg: "incompatible AWS compute",
 		},
 		{
@@ -1073,8 +994,8 @@ func TestComposeStack_LambdaIncludesPlaceholderZip(t *testing.T) {
 	c := newTestClient()
 	out, err := c.ComposeStack(ComposeStackOpts{
 		Cloud:        "aws",
-		SelectedKeys: []ComponentKey{KeyLambda},
-		Comps:        &Components{Lambda: &trueVal},
+		SelectedKeys: []ComponentKey{KeyAWSLambda},
+		Comps:        &Components{AWSLambda: &trueVal},
 		Cfg:          &Config{Region: "us-east-1"},
 		Project:      "test",
 		Region:       "us-east-1",
@@ -1649,11 +1570,11 @@ func TestComposeStack_OutputsTF_KitchenSink(t *testing.T) {
 	t.Parallel()
 
 	selected := []ComponentKey{
-		KeyVPC,
-		KeyResource,
-		KeyEC2,
-		KeyPostgres,
-		KeyS3,
+		KeyAWSVPC,
+		KeyResource, // EKS control plane (polymorphic)
+		KeyEC2,      // EKS node group (polymorphic)
+		KeyAWSRDS,
+		KeyAWSS3,
 	}
 
 	cfg := &Config{
@@ -1683,9 +1604,9 @@ func TestComposeStack_OutputsTF_KitchenSink(t *testing.T) {
 
 	// Structural: verify known outputs map to correct module references
 	knownOutputs := map[string]string{
-		"vpc_vpc_id":     "module.vpc.vpc_id",
-		"rds_db_address": "module.rds.db_address",
-		"s3_bucket_arn":  "module.s3.bucket_arn",
+		"aws_vpc_vpc_id":     "module.aws_vpc.vpc_id",
+		"aws_rds_db_address": "module.aws_rds.db_address",
+		"aws_s3_bucket_arn":  "module.aws_s3.bucket_arn",
 	}
 	for name, valueExpr := range knownOutputs {
 		re := regexp.MustCompile(`(?s)output "` + regexp.QuoteMeta(name) + `"\s*\{[^}]*value\s*=\s*` + regexp.QuoteMeta(valueExpr))
@@ -1857,7 +1778,7 @@ func TestComposeStack_ServerlessLambdaNoDuplicateVPC(t *testing.T) {
 // TestComposeStack_GCP_Provider validates that GCP stacks generate Google provider config.
 func TestComposeStack_GCP_Provider(t *testing.T) {
 	selected := []ComponentKey{
-		KeyVPC,
+		KeyGCPVPC,
 	}
 
 	c := newTestClient()
@@ -2104,4 +2025,26 @@ func TestComposeStack_AWSECS(t *testing.T) {
 	ecsTfStr := string(ecsTfvars)
 	require.Contains(t, ecsTfStr, "aws_ecs_project")
 	require.Contains(t, ecsTfStr, "aws_ecs_region")
+}
+
+// TestComposeStack_RejectsLegacyKeys is the parity test issue #118 calls out:
+// a single end-to-end signal that purely-legacy selections error at the
+// composer entry point, not silently produce un-wired modules. This is the
+// downstream-visible contract reliable's composeradapter upholds — unit
+// coverage of ValidateNoLegacyKeys lives in validate_test.go.
+func TestComposeStack_RejectsLegacyKeys(t *testing.T) {
+	c := newTestClient()
+	_, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyVPC, KeyPostgres, KeyS3},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "test",
+		Region:       "us-east-1",
+	})
+	require.Error(t, err, "ComposeStack must reject purely-legacy SelectedKeys")
+	var ve *ValidationError
+	require.ErrorAs(t, err, &ve, "error must be a ValidationError (HTTP 400, not 500)")
+	require.Contains(t, err.Error(), "legacy ComponentKey",
+		"error must identify legacy-keys as the cause")
 }

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -2045,6 +2045,31 @@ func TestComposeStack_RejectsLegacyKeys(t *testing.T) {
 	require.Error(t, err, "ComposeStack must reject purely-legacy SelectedKeys")
 	var ve *ValidationError
 	require.ErrorAs(t, err, &ve, "error must be a ValidationError (HTTP 400, not 500)")
-	require.Contains(t, err.Error(), "legacy ComponentKey",
+	msg := err.Error()
+	require.Contains(t, msg, "legacy ComponentKey",
 		"error must identify legacy-keys as the cause")
+	require.Contains(t, msg, "vpc → aws_vpc",
+		"error must carry the upgrade pair so callers can fix the selection")
+	require.Contains(t, msg, "composeradapter",
+		"error must point callers at reliable's upgrade path")
+}
+
+// TestComposeSingle_RejectsLegacyKey pins the same contract for the
+// single-module entry point: ComposeSingle validates its Key just like
+// ComposeStack validates its SelectedKeys.
+func TestComposeSingle_RejectsLegacyKey(t *testing.T) {
+	c := newTestClient()
+	_, err := c.ComposeSingle(ComposeSingleOpts{
+		Cloud:   "aws",
+		Key:     KeyVPC,
+		Comps:   &Components{},
+		Cfg:     &Config{},
+		Project: "test",
+		Region:  "us-east-1",
+	})
+	require.Error(t, err, "ComposeSingle must reject a legacy Key")
+	var ve *ValidationError
+	require.ErrorAs(t, err, &ve, "error must be a ValidationError")
+	require.Contains(t, err.Error(), "vpc → aws_vpc",
+		"error must carry the upgrade pair")
 }

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -684,6 +684,12 @@ func TestDefaultWiring_LambdaPublicVPC(t *testing.T) {
 		}
 		comps := &Components{Cloud: "AWS", VPC: "Public VPC", Lambda: ptrBool(true)}
 		comps.Normalize()
+		// Pin that Normalize actually promoted the legacy fields — without
+		// these the assertion below passes vacuously (AWSLambda stays nil →
+		// the KeyAWSLambda wiring arm short-circuits before ever looking at
+		// the VPC).
+		require.Equal(t, "Public VPC", comps.AWSVPC, "Normalize must promote legacy VPC to AWSVPC")
+		require.NotNil(t, comps.AWSLambda, "Normalize must promote legacy Lambda to AWSLambda")
 		wi := DefaultWiring(selected, KeyAWSLambda, comps)
 		_, hasEnableVPC := wi.RawHCL["enable_vpc"]
 		require.False(t, hasEnableVPC, "Legacy Public VPC (after Normalize): Lambda should not have enable_vpc")
@@ -2072,4 +2078,30 @@ func TestComposeSingle_RejectsLegacyKey(t *testing.T) {
 	require.ErrorAs(t, err, &ve, "error must be a ValidationError")
 	require.Contains(t, err.Error(), "vpc → aws_vpc",
 		"error must carry the upgrade pair")
+}
+
+// TestComposeStack_PolymorphicKeyPullsInPrefixedVPC is a regression test for
+// the implicit-dependency leak where ResolveDependencies expanded a
+// polymorphic key to its legacy VPC sibling. A direct Go caller passing only
+// [KeyResource] must still produce a prefixed-only stack: composeradapter
+// upgrades session JSON keys, but in-process callers don't go through it.
+func TestComposeStack_PolymorphicKeyPullsInPrefixedVPC(t *testing.T) {
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyResource}, // polymorphic, pulls VPC via ImplicitDependencies
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err, "ComposeStack with polymorphic KeyResource should succeed")
+
+	mainTF := string(out["/main.tf"])
+	require.Contains(t, mainTF, `module "aws_vpc"`,
+		"implicit dep must render aws_vpc, not legacy vpc")
+	require.NotContains(t, mainTF, `module "vpc"`,
+		"legacy module.vpc must never appear in a prefixed-only stack")
+	require.Contains(t, mainTF, `module "resource"`,
+		"polymorphic KeyResource still renders under its own name until Phase 4")
 }

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -313,14 +313,18 @@ var ImplicitDependencies = map[ComponentKey][]ComponentKey{
 	KeyCloudfront:      {KeyALB},
 	KeyAWSCloudfront:   {KeyAWSALB},
 	KeyGCPCloudCDN:     {KeyGCPLoadbalancer},
-	KeyResource:        {KeyVPC}, // EKS/Lambda both benefit from/require VPC in our presets
-	KeyAWSEKS:          {KeyAWSVPC},
-	KeyAWSECS:          {KeyAWSVPC},
-	KeyGCPGKE:          {KeyGCPVPC},
-	KeyLambda:          {KeyVPC},
-	KeyAWSLambda:       {KeyAWSVPC},
-	KeyEC2:             {KeyResource, KeyVPC},
-	KeyAWSEC2:          {KeyAWSVPC},
+	// KeyResource and KeyEC2 are polymorphic keys that Phase 4 will rename to
+	// unambiguous prefixed names; their implicit deps target KeyAWSVPC (not
+	// legacy KeyVPC) so that a direct caller selecting only a polymorphic key
+	// still produces a prefixed-only stack.
+	KeyResource:       {KeyAWSVPC},
+	KeyAWSEKS:         {KeyAWSVPC},
+	KeyAWSECS:         {KeyAWSVPC},
+	KeyGCPGKE:         {KeyGCPVPC},
+	KeyLambda:         {KeyVPC},
+	KeyAWSLambda:      {KeyAWSVPC},
+	KeyEC2:            {KeyResource, KeyAWSVPC},
+	KeyAWSEC2:         {KeyAWSVPC},
 	KeyGCPCompute:      {KeyGCPVPC},
 }
 
@@ -538,9 +542,11 @@ func opensearchRef(_ map[ComponentKey]bool) string { return "module.aws_opensear
 func sqsRef(_ map[ComponentKey]bool) string       { return "module.aws_sqs" }
 
 // resourceRef returns the EKS/ECS module reference for the selected stack.
-// Prefers the prefixed KeyAWSEKS / KeyAWSECS keys, but falls back to the
-// polymorphic KeyResource ("module.resource") since Phase 4 has not yet
-// split it into unambiguous cloud-prefixed names.
+// Prefers the prefixed KeyAWSEKS / KeyAWSECS keys, with a KeyResource path
+// for the polymorphic selection Phase 4 has not yet renamed. Falls back to
+// module.aws_eks when nothing matches — the final fallback is effectively
+// unreachable (wiring only runs when `hasResource` is true) but picks the
+// prefixed name defensively.
 func resourceRef(selected map[ComponentKey]bool) string {
 	if selected[KeyAWSEKS] {
 		return "module.aws_eks"

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -516,53 +516,31 @@ type WiredInputs struct {
 	RawHCL map[string]string // var name -> raw expression or object literal
 }
 
-// vpcRef returns the correct VPC module reference based on which VPC key is selected.
+// Module-reference helpers return "module.<name>" paths used by wiring to
+// cross-reference resources. Callers with legacy ComponentKey selections
+// must Normalize / use the composeradapter so the `selected` map carries
+// KeyAWS* keys; ComposeStack rejects purely-legacy SelectedKeys at entry.
+// EmitRootMainTF auto-emits `moved {}` blocks for the rename transition.
+
 func vpcRef(selected map[ComponentKey]bool) string {
-	if selected[KeyAWSVPC] {
-		return "module.aws_vpc"
-	}
 	if selected[KeyGCPVPC] {
 		return "module.gcp_vpc"
 	}
-	return "module.vpc"
+	return "module.aws_vpc"
 }
 
-// moduleRef returns "module.<key>" using the V2 key if selected, otherwise the legacy key.
-func moduleRef(selected map[ComponentKey]bool, legacy, v2 ComponentKey) string {
-	if selected[v2] {
-		return "module." + string(v2)
-	}
-	return "module." + string(legacy)
-}
+func albRef(_ map[ComponentKey]bool) string       { return "module.aws_alb" }
+func wafRef(_ map[ComponentKey]bool) string       { return "module.aws_waf" }
+func bastionRef(_ map[ComponentKey]bool) string   { return "module.aws_bastion" }
+func rdsRef(_ map[ComponentKey]bool) string       { return "module.aws_rds" }
+func s3Ref(_ map[ComponentKey]bool) string        { return "module.aws_s3" }
+func opensearchRef(_ map[ComponentKey]bool) string { return "module.aws_opensearch" }
+func sqsRef(_ map[ComponentKey]bool) string       { return "module.aws_sqs" }
 
-func albRef(selected map[ComponentKey]bool) string {
-	return moduleRef(selected, KeyALB, KeyAWSALB)
-}
-
-func wafRef(selected map[ComponentKey]bool) string {
-	return moduleRef(selected, KeyWAF, KeyAWSWAF)
-}
-
-func bastionRef(selected map[ComponentKey]bool) string {
-	return moduleRef(selected, KeyBastion, KeyAWSBastion)
-}
-
-func rdsRef(selected map[ComponentKey]bool) string {
-	return moduleRef(selected, KeyPostgres, KeyAWSRDS)
-}
-
-func s3Ref(selected map[ComponentKey]bool) string {
-	return moduleRef(selected, KeyS3, KeyAWSS3)
-}
-
-func opensearchRef(selected map[ComponentKey]bool) string {
-	return moduleRef(selected, KeyOpenSearch, KeyAWSOpenSearch)
-}
-
-func sqsRef(selected map[ComponentKey]bool) string {
-	return moduleRef(selected, KeySQS, KeyAWSSQS)
-}
-
+// resourceRef returns the EKS/ECS module reference for the selected stack.
+// Prefers the prefixed KeyAWSEKS / KeyAWSECS keys, but falls back to the
+// polymorphic KeyResource ("module.resource") since Phase 4 has not yet
+// split it into unambiguous cloud-prefixed names.
 func resourceRef(selected map[ComponentKey]bool) string {
 	if selected[KeyAWSEKS] {
 		return "module.aws_eks"
@@ -570,82 +548,34 @@ func resourceRef(selected map[ComponentKey]bool) string {
 	if selected[KeyAWSECS] {
 		return "module.aws_ecs"
 	}
-	return "module.resource"
+	if selected[KeyResource] {
+		return "module.resource"
+	}
+	return "module.aws_eks"
 }
 
+// DefaultWiring returns cross-module references for module k. The caller's
+// `selected` map must carry KeyAWS*-prefixed keys; ComposeStack rejects
+// purely-legacy SelectedKeys at entry, and Components.Normalize promotes
+// legacy struct fields before this function is reached.
 func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Components) WiredInputs {
 	wi := WiredInputs{RawHCL: map[string]string{}}
 
-	// Normalize key for switch (handle prefixed names)
-	switch k {
-	case KeyAWSVPC:
-		k = KeyVPC
-	case KeyAWSEKS:
-		k = KeyResource
-	case KeyAWSLambda:
-		k = KeyLambda
-	case KeyAWSALB:
-		k = KeyALB
-	case KeyAWSBastion:
-		k = KeyBastion
-	case KeyAWSRDS:
-		k = KeyPostgres
-	case KeyAWSCloudfront:
-		k = KeyCloudfront
-	case KeyAWSElastiCache:
-		k = KeyElastiCache
-	case KeyAWSS3:
-		k = KeyS3
-	case KeyAWSDynamoDB:
-		k = KeyDynamoDB
-	case KeyAWSSQS:
-		k = KeySQS
-	case KeyAWSMSK:
-		k = KeyMSK
-	case KeyAWSCloudWatchLogs:
-		k = KeyCloudWatchLogs
-	case KeyAWSCloudWatchMonitoring:
-		k = KeyCloudWatchMonitoring
-	case KeyAWSCognito:
-		k = KeyCognito
-	case KeyAWSAPIGateway:
-		k = KeyAPIGateway
-	case KeyAWSKMS:
-		k = KeyKMS
-	case KeyAWSSecretsManager:
-		k = KeySecrets
-	case KeyAWSOpenSearch:
-		k = KeyOpenSearch
-	case KeyAWSBedrock:
-		k = KeyBedrock
-	case KeyAWSWAF:
-		k = KeyWAF
-	case KeyAWSGrafana:
-		k = KeyGrafana
-	case KeyAWSBackups:
-		k = KeyBackups
-	case KeyAWSGitHubActions:
-		k = KeyGitHubActions
-	case KeyAWSCodePipeline:
-		k = KeyCodePipeline
-	}
-
-	// For Wiring dependencies, check both legacy and prefixed keys
-	hasVPC := selected[KeyVPC] || selected[KeyAWSVPC]
-	hasALB := selected[KeyALB] || selected[KeyAWSALB]
-	hasWAF := selected[KeyWAF] || selected[KeyAWSWAF]
-	hasBastion := selected[KeyBastion] || selected[KeyAWSBastion]
-	hasPostgres := selected[KeyPostgres] || selected[KeyAWSRDS]
-	hasS3 := selected[KeyS3] || selected[KeyAWSS3]
-	hasOpenSearch := selected[KeyOpenSearch] || selected[KeyAWSOpenSearch]
-	hasSQS := selected[KeySQS] || selected[KeyAWSSQS]
-	hasResource := selected[KeyResource] || selected[KeyAWSEKS]
+	hasVPC := selected[KeyAWSVPC]
+	hasALB := selected[KeyAWSALB]
+	hasWAF := selected[KeyAWSWAF]
+	hasBastion := selected[KeyAWSBastion]
+	hasPostgres := selected[KeyAWSRDS]
+	hasS3 := selected[KeyAWSS3]
+	hasOpenSearch := selected[KeyAWSOpenSearch]
+	hasSQS := selected[KeyAWSSQS]
+	hasResource := selected[KeyAWSEKS] || selected[KeyResource]
 
 	switch k {
 
 	/* ---------------- VPC fans out ---------------- */
 
-	case KeyALB:
+	case KeyAWSALB:
 		if hasVPC {
 			vpc := vpcRef(selected)
 			wi.RawHCL["vpc_id"] = vpc + ".vpc_id"
@@ -653,7 +583,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.Names = append(wi.Names, "vpc_id", "public_subnet_ids")
 		}
 
-	case KeyResource:
+	case KeyResource, KeyAWSEKS:
 		if isLambda(comps) {
 			// Lambda Wiring
 			if hasVPC {
@@ -686,7 +616,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.Names = append(wi.Names, "vpc_id", "private_subnet_ids", "public_subnet_ids")
 		}
 
-	case KeyLambda:
+	case KeyAWSLambda:
 		// Only wire Lambda to VPC when private subnets are available.
 		// Public VPCs have no private subnets, so Lambda would get empty
 		// subnet_ids which causes AWS API error (SubnetIds and SecurityIds
@@ -725,7 +655,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			}
 		}
 
-	case KeyBastion:
+	case KeyAWSBastion:
 		if hasVPC {
 			vpc := vpcRef(selected)
 			wi.RawHCL["vpc_id"] = vpc + ".vpc_id"
@@ -733,7 +663,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.Names = append(wi.Names, "vpc_id", "subnet_id")
 		}
 
-	case KeyPostgres:
+	case KeyAWSRDS:
 		if hasVPC {
 			vpc := vpcRef(selected)
 			wi.RawHCL["vpc_id"] = vpc + ".vpc_id"
@@ -746,7 +676,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		wi.RawHCL["apply_immediately"] = "true"
 		wi.Names = append(wi.Names, "enable_cloudwatch_logs", "cloudwatch_logs_exports", "skip_final_snapshot", "apply_immediately")
 
-	case KeyElastiCache:
+	case KeyAWSElastiCache:
 		if hasVPC {
 			vpc := vpcRef(selected)
 			wi.RawHCL["vpc_id"] = vpc + ".vpc_id"
@@ -754,7 +684,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.Names = append(wi.Names, "vpc_id", "cache_subnet_ids")
 		}
 
-	case KeyCloudfront:
+	case KeyAWSCloudfront:
 		if hasALB {
 			wi.RawHCL["origin_type"] = `"http"`
 			wi.RawHCL["custom_origin_domain"] = albRef(selected) + ".alb_dns_name"
@@ -765,12 +695,12 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.Names = append(wi.Names, "web_acl_id")
 		}
 
-	case KeyWAF:
+	case KeyAWSWAF:
 		wi.RawHCL["scope"] = `"CLOUDFRONT"`
 		wi.RawHCL["region"] = `"us-east-1"`
 		wi.Names = append(wi.Names, "scope", "region")
 
-	case KeyCloudWatchMonitoring:
+	case KeyAWSCloudWatchMonitoring:
 		if hasBastion {
 			wi.RawHCL["instance_ids"] = "[" + bastionRef(selected) + ".bastion_instance_id]"
 			wi.Names = append(wi.Names, "instance_ids")
@@ -788,7 +718,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.Names = append(wi.Names, "sqs_queue_arns")
 		}
 
-	case KeyOpenSearch:
+	case KeyAWSOpenSearch:
 		if hasVPC {
 			vpc := vpcRef(selected)
 			wi.RawHCL["vpc_id"] = vpc + ".vpc_id"
@@ -796,7 +726,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.Names = append(wi.Names, "vpc_id", "subnet_ids")
 		}
 
-	case KeyBedrock:
+	case KeyAWSBedrock:
 		if hasS3 {
 			wi.RawHCL["s3_bucket_arn"] = s3Ref(selected) + ".bucket_arn"
 			wi.Names = append(wi.Names, "s3_bucket_arn")
@@ -806,7 +736,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.Names = append(wi.Names, "opensearch_collection_arn")
 		}
 
-	case KeyBackups:
+	case KeyAWSBackups:
 		// Legacy sessions must Normalize before reaching DefaultWiring;
 		// reliable's composeradapter does this for us in production.
 		enableEbs, enableRds, enableDdb, enableS3 := false, false, false, false
@@ -832,7 +762,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		// For each enabled service, wire the in-stack module's ARN. If the target
 		// component isn't in the stack, fall back to a backup=true tag selection
 		// so the selection block remains valid.
-		hasDynamoDB := selected[KeyDynamoDB] || selected[KeyAWSDynamoDB]
+		hasDynamoDB := selected[KeyAWSDynamoDB]
 		tagFallback := `{
   selection = {
     resource_arns  = []
@@ -849,7 +779,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		}
 		if enableDdb {
 			if hasDynamoDB {
-				wi.RawHCL["dynamodb_rule"] = "{\n  selection = { resource_arns = [" + moduleRef(selected, KeyDynamoDB, KeyAWSDynamoDB) + ".table_arn], selection_tags = [] }\n}"
+				wi.RawHCL["dynamodb_rule"] = "{\n  selection = { resource_arns = [module.aws_dynamodb.table_arn], selection_tags = [] }\n}"
 			} else {
 				wi.RawHCL["dynamodb_rule"] = tagFallback
 			}

--- a/pkg/composer/emit.go
+++ b/pkg/composer/emit.go
@@ -403,7 +403,36 @@ func EmitRootMainTF(blocks []ModuleBlock) []byte {
 			body.AppendNewline()
 		}
 	}
+	appendMovedBlocks(body, blocks)
 	return doc.Bytes()
+}
+
+// appendMovedBlocks emits `moved { from = module.<legacy> to = module.<v2> }`
+// for every module in blocks whose Name matches a V2 ComponentKey with a
+// legacy sibling in LegacyToV2Key. This auto-migrates stacks previously
+// deployed under the legacy module name without requiring manual
+// `terraform state mv`. On fresh state moved blocks are a no-op — Terraform
+// treats a `from` address that doesn't exist in state as a vacuous move.
+//
+// Iterating `blocks` (not LegacyToV2Key) gives deterministic output order
+// and ensures we only emit moved blocks for modules actually rendered in
+// this main.tf — a stale moved block pointing at a nonexistent `to` would
+// be a Terraform validation error.
+func appendMovedBlocks(body *hclwrite.Body, blocks []ModuleBlock) {
+	v2ToLegacy := make(map[ComponentKey]ComponentKey, len(LegacyToV2Key))
+	for legacy, v2 := range LegacyToV2Key {
+		v2ToLegacy[v2] = legacy
+	}
+	for _, m := range blocks {
+		legacy, ok := v2ToLegacy[ComponentKey(m.Name)]
+		if !ok {
+			continue
+		}
+		body.AppendNewline()
+		mb := body.AppendNewBlock("moved", nil).Body()
+		setRawExpr(mb, "from", "module."+string(legacy))
+		setRawExpr(mb, "to", "module."+m.Name)
+	}
 }
 
 // EmitAutoTFVars writes <key>.auto.tfvars with provided values (skips RawExpr and nil).

--- a/pkg/composer/emit_moved_integration_test.go
+++ b/pkg/composer/emit_moved_integration_test.go
@@ -1,0 +1,55 @@
+package composer
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmitRootMainTF_MovedBlocks_TerraformValidate is a one-shot integration
+// test that writes an emitted main.tf plus a minimal stub module to a tmpdir
+// and runs `terraform init -backend=false && terraform validate` against it.
+// This pins the contract that the emitted `moved {}` blocks are syntactically
+// valid and accepted by terraform's validator — regex assertions elsewhere
+// in this file can't catch subtle HCL-level errors.
+//
+// Skipped when -short is set or the `terraform` binary is not on PATH so the
+// core test suite stays hermetic and fast.
+func TestEmitRootMainTF_MovedBlocks_TerraformValidate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	tfBin, err := exec.LookPath("terraform")
+	if err != nil {
+		t.Skipf("terraform binary not on PATH: %v", err)
+	}
+
+	dir := t.TempDir()
+
+	// Stub module that the root main.tf's module block will point at.
+	// Empty body is a valid Terraform module; `terraform init` accepts it.
+	stubDir := filepath.Join(dir, "modules", "vpc")
+	require.NoError(t, os.MkdirAll(stubDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stubDir, "main.tf"), []byte("# empty stub module\n"), 0o644))
+
+	// Root main.tf with one prefixed module + the auto-emitted moved block.
+	blocks := []ModuleBlock{{Name: "aws_vpc", Source: "./modules/vpc"}}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), EmitRootMainTF(blocks), 0o644))
+
+	// init with -backend=false avoids remote backend setup; no providers are
+	// referenced, so no network round-trip happens.
+	initCmd := exec.Command(tfBin, "init", "-backend=false", "-input=false", "-no-color")
+	initCmd.Dir = dir
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("terraform init failed: %v\n%s", err, out)
+	}
+
+	validateCmd := exec.Command(tfBin, "validate", "-no-color")
+	validateCmd.Dir = dir
+	if out, err := validateCmd.CombinedOutput(); err != nil {
+		t.Fatalf("terraform validate failed on emitted main.tf — moved {} block malformed?\n%s", out)
+	}
+}

--- a/pkg/composer/emit_moved_test.go
+++ b/pkg/composer/emit_moved_test.go
@@ -1,0 +1,125 @@
+package composer
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// movedBlock is a parsed representation of a `moved {}` block.
+type movedBlock struct {
+	from, to string
+}
+
+// parseMovedBlocks extracts every `moved {}` block's from/to expressions
+// from generated HCL. Uses the HCL parser rather than regex matching so a
+// malformed block fails the test with a useful parse error.
+func parseMovedBlocks(t *testing.T, src []byte) []movedBlock {
+	t.Helper()
+	f, diags := hclsyntax.ParseConfig(src, "test.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "parseMovedBlocks: %s", diags.Error())
+
+	body := f.Body.(*hclsyntax.Body)
+	var out []movedBlock
+	for _, blk := range body.Blocks {
+		if blk.Type != "moved" {
+			continue
+		}
+		mb := movedBlock{}
+		if a, ok := blk.Body.Attributes["from"]; ok {
+			mb.from = strings.TrimSpace(string(src[a.Expr.Range().Start.Byte:a.Expr.Range().End.Byte]))
+		}
+		if a, ok := blk.Body.Attributes["to"]; ok {
+			mb.to = strings.TrimSpace(string(src[a.Expr.Range().Start.Byte:a.Expr.Range().End.Byte]))
+		}
+		out = append(out, mb)
+	}
+	return out
+}
+
+func TestEmitRootMainTF_MovedBlocks_PrefixedModulesGetMoves(t *testing.T) {
+	blocks := []ModuleBlock{
+		{Name: "aws_vpc", Source: "./modules/vpc"},
+		{Name: "aws_alb", Source: "./modules/alb"},
+		{Name: "aws_rds", Source: "./modules/rds"},
+	}
+	out := EmitRootMainTF(blocks)
+	moves := parseMovedBlocks(t, out)
+
+	assert.Equal(t, []movedBlock{
+		{from: "module.vpc", to: "module.aws_vpc"},
+		{from: "module.alb", to: "module.aws_alb"},
+		{from: "module.rds", to: "module.aws_rds"},
+	}, moves, "each prefixed module should get a moved block from its legacy name")
+}
+
+func TestEmitRootMainTF_MovedBlocks_LegacyAndPolymorphicModulesSkipped(t *testing.T) {
+	blocks := []ModuleBlock{
+		{Name: "vpc", Source: "./modules/vpc"},      // legacy ComponentKey: no moved block
+		{Name: "resource", Source: "./modules/eks"}, // polymorphic (EKS/Lambda): not in LegacyToV2Key
+		{Name: "ec2", Source: "./modules/eks_nodegroup"},
+		{Name: "splunk", Source: "./modules/splunk"}, // third-party: no AWS-prefixed sibling
+	}
+	out := EmitRootMainTF(blocks)
+	moves := parseMovedBlocks(t, out)
+	assert.Empty(t, moves, "non-V2 module names should not produce moved blocks")
+}
+
+func TestEmitRootMainTF_MovedBlocks_MixedSelection(t *testing.T) {
+	blocks := []ModuleBlock{
+		{Name: "aws_vpc", Source: "./modules/vpc"},       // has moved
+		{Name: "resource", Source: "./modules/eks"},      // skip
+		{Name: "aws_bastion", Source: "./modules/bastion"}, // has moved
+		{Name: "splunk", Source: "./modules/splunk"},     // skip
+	}
+	out := EmitRootMainTF(blocks)
+	moves := parseMovedBlocks(t, out)
+
+	require.Len(t, moves, 2)
+	assert.Equal(t, movedBlock{from: "module.vpc", to: "module.aws_vpc"}, moves[0])
+	assert.Equal(t, movedBlock{from: "module.bastion", to: "module.aws_bastion"}, moves[1])
+}
+
+func TestEmitRootMainTF_MovedBlocks_DeterministicOrder(t *testing.T) {
+	// Iterating LegacyToV2Key directly would give non-deterministic order
+	// (Go map iteration). emitMovedBlocks iterates the input slice, so
+	// running twice must give byte-identical output.
+	blocks := []ModuleBlock{
+		{Name: "aws_s3", Source: "./modules/s3"},
+		{Name: "aws_sqs", Source: "./modules/sqs"},
+		{Name: "aws_dynamodb", Source: "./modules/dynamodb"},
+		{Name: "aws_opensearch", Source: "./modules/opensearch"},
+	}
+	a := EmitRootMainTF(blocks)
+	b := EmitRootMainTF(blocks)
+	assert.Equal(t, a, b, "same inputs must produce identical output")
+
+	// Moves must appear in input order, not map order.
+	moves := parseMovedBlocks(t, a)
+	assert.Equal(t, []movedBlock{
+		{from: "module.s3", to: "module.aws_s3"},
+		{from: "module.sqs", to: "module.aws_sqs"},
+		{from: "module.dynamodb", to: "module.aws_dynamodb"},
+		{from: "module.opensearch", to: "module.aws_opensearch"},
+	}, moves)
+}
+
+func TestEmitRootMainTF_MovedBlocks_EmitsAfterModules(t *testing.T) {
+	// The file layout convention is module blocks first, then moved blocks.
+	// This makes the file readable and keeps moved blocks together.
+	blocks := []ModuleBlock{
+		{Name: "aws_vpc", Source: "./modules/vpc"},
+		{Name: "aws_alb", Source: "./modules/alb"},
+	}
+	out := string(EmitRootMainTF(blocks))
+
+	lastModule := strings.LastIndex(out, `module "aws_alb"`)
+	firstMoved := regexp.MustCompile(`(?m)^moved\s*\{`).FindStringIndex(out)
+	require.NotNil(t, firstMoved, "emitted file should contain at least one moved block")
+	assert.Greater(t, firstMoved[0], lastModule, "moved blocks must appear after the last module block")
+}

--- a/pkg/composer/emit_moved_test.go
+++ b/pkg/composer/emit_moved_test.go
@@ -109,6 +109,19 @@ func TestEmitRootMainTF_MovedBlocks_DeterministicOrder(t *testing.T) {
 	}, moves)
 }
 
+func TestEmitRootMainTF_MovedBlocks_CountMatchesInputPrefixedBlocks(t *testing.T) {
+	// Mutation-resistance: a regression that iterated LegacyToV2Key directly
+	// (instead of iterating `blocks`) would emit moved blocks for every V2
+	// key regardless of whether it was in the rendered stack. That produces
+	// `to = module.aws_foo` references pointing at modules that don't exist,
+	// which `terraform validate` rejects. Pin the count explicitly so the
+	// bug surfaces in unit tests, not just in the integration harness.
+	blocks := []ModuleBlock{{Name: "aws_vpc", Source: "./modules/vpc"}}
+	moves := parseMovedBlocks(t, EmitRootMainTF(blocks))
+	require.Len(t, moves, 1, "exactly one moved block when exactly one prefixed module is emitted")
+	assert.Equal(t, movedBlock{from: "module.vpc", to: "module.aws_vpc"}, moves[0])
+}
+
 func TestEmitRootMainTF_MovedBlocks_EmitsAfterModules(t *testing.T) {
 	// The file layout convention is module blocks first, then moved blocks.
 	// This makes the file readable and keeps moved blocks together.

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -87,63 +87,9 @@ func (m DefaultMapper) BuildModuleValues(
 	// Environment tag used across all modules for resource tagging.
 	vals["environment"] = "prod"
 
-	// Normalize key for switch (handle prefixed names)
 	switch k {
+
 	case KeyAWSVPC:
-		k = KeyVPC
-	case KeyAWSEKS:
-		k = KeyResource
-	case KeyAWSLambda:
-		k = KeyLambda
-	case KeyAWSALB:
-		k = KeyALB
-	case KeyAWSBastion:
-		k = KeyBastion
-	case KeyAWSRDS:
-		k = KeyPostgres
-	case KeyAWSCloudfront:
-		k = KeyCloudfront
-	case KeyAWSElastiCache:
-		k = KeyElastiCache
-	case KeyAWSS3:
-		k = KeyS3
-	case KeyAWSDynamoDB:
-		k = KeyDynamoDB
-	case KeyAWSSQS:
-		k = KeySQS
-	case KeyAWSMSK:
-		k = KeyMSK
-	case KeyAWSCloudWatchLogs:
-		k = KeyCloudWatchLogs
-	case KeyAWSCloudWatchMonitoring:
-		k = KeyCloudWatchMonitoring
-	case KeyAWSCognito:
-		k = KeyCognito
-	case KeyAWSAPIGateway:
-		k = KeyAPIGateway
-	case KeyAWSKMS:
-		k = KeyKMS
-	case KeyAWSSecretsManager:
-		k = KeySecrets
-	case KeyAWSOpenSearch:
-		k = KeyOpenSearch
-	case KeyAWSBedrock:
-		k = KeyBedrock
-	case KeyAWSWAF:
-		k = KeyWAF
-	case KeyAWSGrafana:
-		k = KeyGrafana
-	case KeyAWSBackups:
-		k = KeyBackups
-	case KeyAWSGitHubActions:
-		k = KeyGitHubActions
-	case KeyAWSCodePipeline:
-		k = KeyCodePipeline
-	}
-
-	switch k {
-
-	case KeyVPC:
 		// Map "Public VPC" / "Private VPC" component enum to preset variables.
 		// "Public VPC" = public subnets only, no NAT gateway.
 		// "Private VPC" (or default) = private + public subnets with NAT.
@@ -202,9 +148,9 @@ func (m DefaultMapper) BuildModuleValues(
 			vals["provider"] = strings.ToLower(comps.Cloud) // "aws", "gcp"
 		}
 
-	case KeyResource: // EKS control plane or Lambda
+	case KeyResource, KeyAWSEKS: // EKS control plane or Lambda
 		if isLambda(comps) {
-			return m.BuildModuleValues(KeyLambda, comps, cfg, project, region)
+			return m.BuildModuleValues(KeyAWSLambda, comps, cfg, project, region)
 		}
 		// Preview-safe stubs for required, usually-wired inputs
 		if _, ok := vals["vpc_id"]; !ok {
@@ -356,7 +302,7 @@ func (m DefaultMapper) BuildModuleValues(
 			// Intel defaults handled by preset (t3.medium)
 		}
 
-	case KeyALB:
+	case KeyAWSALB:
 		// ALB needs VPC + public subnets; stub for preview.
 		if _, ok := vals["vpc_id"]; !ok {
 			vals["vpc_id"] = ""
@@ -365,7 +311,7 @@ func (m DefaultMapper) BuildModuleValues(
 			vals["public_subnet_ids"] = []any{}
 		}
 
-	case KeyBastion:
+	case KeyAWSBastion:
 		// Bastion on a public subnet; stub for preview.
 		if _, ok := vals["vpc_id"]; !ok {
 			vals["vpc_id"] = ""
@@ -374,7 +320,7 @@ func (m DefaultMapper) BuildModuleValues(
 			vals["subnet_id"] = ""
 		}
 
-	case KeyPostgres:
+	case KeyAWSRDS:
 		// RDS requires VPC + private subnets; stub for preview.
 		if _, ok := vals["vpc_id"]; !ok {
 			vals["vpc_id"] = ""
@@ -395,7 +341,7 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
-	case KeyCloudfront:
+	case KeyAWSCloudfront:
 		if cfg != nil && cfg.Cloudfront != nil {
 			if cfg.Cloudfront.DefaultTtl != nil && *cfg.Cloudfront.DefaultTtl != "" {
 				vals["default_ttl"] = *cfg.Cloudfront.DefaultTtl
@@ -407,7 +353,7 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
-	case KeyElastiCache:
+	case KeyAWSElastiCache:
 		if cfg != nil && cfg.ElastiCache != nil {
 			if cfg.ElastiCache.HA != nil {
 				vals["ha"] = *cfg.ElastiCache.HA
@@ -423,17 +369,17 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
-	case KeyS3:
+	case KeyAWSS3:
 		if cfg != nil && cfg.S3 != nil && cfg.S3.Versioning != nil {
 			vals["versioning"] = *cfg.S3.Versioning
 		}
 
-	case KeyDynamoDB:
+	case KeyAWSDynamoDB:
 		if cfg != nil && cfg.DynamoDB != nil && cfg.DynamoDB.Type != "" {
 			vals["billing_mode"] = strings.ToLower(cfg.DynamoDB.Type) // "on demand" | "provisioned"
 		}
 
-	case KeySQS:
+	case KeyAWSSQS:
 		if cfg != nil && cfg.SQS != nil {
 			if cfg.SQS.Type != "" {
 				vals["type"] = cfg.SQS.Type // "Standard" | "FIFO"
@@ -443,12 +389,12 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
-	case KeyMSK:
+	case KeyAWSMSK:
 		if cfg != nil && cfg.MSK != nil && cfg.MSK.Retention != "" {
 			vals["retention_period"] = cfg.MSK.Retention
 		}
 
-	case KeyCloudWatchLogs:
+	case KeyAWSCloudWatchLogs:
 		retDays := 0
 		if cfg != nil {
 			if cfg.CloudWatchLogs != nil && cfg.CloudWatchLogs.RetentionDays > 0 {
@@ -461,7 +407,7 @@ func (m DefaultMapper) BuildModuleValues(
 			vals["retention_in_days"] = retDays
 		}
 
-	case KeyCognito:
+	case KeyAWSCognito:
 		if cfg != nil && cfg.Cognito != nil {
 			if cfg.Cognito.SignInType != "" {
 				vals["sign_in_type"] = cfg.Cognito.SignInType
@@ -471,7 +417,7 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
-	case KeyAPIGateway:
+	case KeyAWSAPIGateway:
 		if cfg != nil && cfg.APIGateway != nil {
 			if cfg.APIGateway.DomainName != "" {
 				vals["domain_name"] = cfg.APIGateway.DomainName
@@ -481,21 +427,21 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
-	case KeyKMS:
+	case KeyAWSKMS:
 		if cfg != nil && cfg.KMS != nil && cfg.KMS.NumKeys != "" {
 			if n, err := strconv.Atoi(cfg.KMS.NumKeys); err == nil {
 				vals["num_keys"] = n
 			}
 		}
 
-	case KeySecrets:
+	case KeyAWSSecretsManager:
 		if cfg != nil && cfg.SecretsManager != nil && cfg.SecretsManager.NumSecrets != "" {
 			if n, err := strconv.Atoi(cfg.SecretsManager.NumSecrets); err == nil {
 				vals["num_secrets"] = n
 			}
 		}
 
-	case KeyOpenSearch:
+	case KeyAWSOpenSearch:
 		if cfg != nil && cfg.OpenSearch != nil {
 			if cfg.OpenSearch.DeploymentType != "" {
 				vals["deployment_type"] = strings.ToLower(cfg.OpenSearch.DeploymentType)
@@ -527,7 +473,7 @@ func (m DefaultMapper) BuildModuleValues(
 			vals["subnet_ids"] = []any{}
 		}
 
-	case KeyBedrock:
+	case KeyAWSBedrock:
 		if cfg != nil && cfg.Bedrock != nil {
 			if cfg.Bedrock.KnowledgeBaseName != "" {
 				vals["knowledge_base_name"] = cfg.Bedrock.KnowledgeBaseName
@@ -553,7 +499,7 @@ func (m DefaultMapper) BuildModuleValues(
 			vals["opensearch_collection_arn"] = "arn:aws:aoss:us-east-1:123456789012:collection/composerpreview"
 		}
 
-	case KeyLambda:
+	case KeyAWSLambda:
 		vals["runtime"] = "nodejs20.x" // Default to nodejs
 		if cfg != nil && cfg.Lambda != nil {
 			if cfg.Lambda.Runtime != "" {
@@ -579,7 +525,7 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
-	case KeyBackups:
+	case KeyAWSBackups:
 		// TS parity: provide a sane default_rule (schedule/retention) in addition
 		// to composer-injected enable_* and *_rule raw HCL.
 		bestFreq := 0

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -148,27 +148,13 @@ func TestBuildModuleValues_VPC_PublicPrivateMode(t *testing.T) {
 
 	t.Run("empty AWSVPC uses preset defaults", func(t *testing.T) {
 		comps := &Components{}
-		vals, err := m.BuildModuleValues(KeyVPC, comps, nil, "test", "us-east-1")
+		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, nil, "test", "us-east-1")
 		require.NoError(t, err)
 		assertVPCCaseRan(t, vals)
 		_, hasPrivate := vals["enable_private_subnets"]
 		_, hasNat := vals["enable_nat_gateway"]
 		assert.False(t, hasPrivate)
 		assert.False(t, hasNat)
-	})
-
-	t.Run("KeyVPC (legacy ComponentKey) routes through the same case arm", func(t *testing.T) {
-		// The KeyVPC ComponentKey constant is deprecated (tracked by #76) but
-		// still accepted by the mapper's normalisation switch. This test pins
-		// that accepting the legacy key alongside an AWSVPC string still takes
-		// the Public-VPC branch — regression guard for anyone tempted to drop
-		// legacy-key support before Phase 4.
-		comps := &Components{AWSVPC: "Public VPC"}
-		vals, err := m.BuildModuleValues(KeyVPC, comps, nil, "test", "us-east-1")
-		require.NoError(t, err)
-		assertVPCCaseRan(t, vals)
-		assert.Equal(t, false, vals["enable_private_subnets"])
-		assert.Equal(t, false, vals["enable_nat_gateway"])
 	})
 }
 
@@ -384,25 +370,6 @@ func TestBuildModuleValues_VPC_MapperHCLContract(t *testing.T) {
 	}
 }
 
-// TestBuildModuleValues_V2KeyNormalization verifies that calling BuildModuleValues
-// with a V2 key (e.g., KeyAWSWAF) produces the same output as calling with the
-// legacy key (e.g., KeyWAF). This catches missing case arms in the normalization switch.
-func TestBuildModuleValues_V2KeyNormalization(t *testing.T) {
-	t.Parallel()
-	m := DefaultMapper{}
-	for legacy, v2 := range LegacyToV2Key {
-		t.Run(string(v2), func(t *testing.T) {
-			t.Parallel()
-			valsLegacy, err := m.BuildModuleValues(legacy, &Components{}, &Config{}, "test", "us-east-1")
-			require.NoError(t, err)
-			valsV2, err := m.BuildModuleValues(v2, &Components{}, &Config{}, "test", "us-east-1")
-			require.NoError(t, err)
-			assert.Equal(t, valsLegacy, valsV2,
-				"V2 key %s should produce same values as legacy key %s", v2, legacy)
-		})
-	}
-}
-
 func TestBuildModuleValues_CloudWatchLogs_Retention(t *testing.T) {
 	m := DefaultMapper{}
 
@@ -414,7 +381,7 @@ func TestBuildModuleValues_CloudWatchLogs_Retention(t *testing.T) {
 				RetentionDays: 7,
 			},
 		}
-		vals, err := m.BuildModuleValues(KeyCloudWatchLogs, nil, cfg, "", "")
+		vals, err := m.BuildModuleValues(KeyAWSCloudWatchLogs, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, 7, vals["retention_in_days"])
 		_, hasOldKey := vals["retention"]
@@ -429,7 +396,7 @@ func TestBuildModuleValues_CloudWatchLogs_Retention(t *testing.T) {
 				RetentionDays: 90,
 			},
 		}
-		vals, err := m.BuildModuleValues(KeyCloudWatchLogs, nil, cfg, "", "")
+		vals, err := m.BuildModuleValues(KeyAWSCloudWatchLogs, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, 90, vals["retention_in_days"])
 	})
@@ -442,7 +409,7 @@ func TestBuildModuleValues_CloudWatchLogs_Retention(t *testing.T) {
 				RetentionDays: 365,
 			},
 		}
-		vals, err := m.BuildModuleValues(KeyCloudWatchLogs, nil, cfg, "", "")
+		vals, err := m.BuildModuleValues(KeyAWSCloudWatchLogs, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, 365, vals["retention_in_days"])
 	})
@@ -455,7 +422,7 @@ func TestBuildModuleValues_CloudWatchLogs_Retention(t *testing.T) {
 				RetentionDays: 0,
 			},
 		}
-		vals, err := m.BuildModuleValues(KeyCloudWatchLogs, nil, cfg, "", "")
+		vals, err := m.BuildModuleValues(KeyAWSCloudWatchLogs, nil, cfg, "", "")
 		require.NoError(t, err)
 		_, hasKey := vals["retention_in_days"]
 		assert.False(t, hasKey)
@@ -474,7 +441,7 @@ func TestBuildModuleValues_Cloudfront_OriginPath(t *testing.T) {
 				CachePaths *string `json:"cachePaths,omitempty"`
 			}{OriginPath: &path},
 		}
-		vals, err := m.BuildModuleValues(KeyCloudfront, nil, cfg, "", "")
+		vals, err := m.BuildModuleValues(KeyAWSCloudfront, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, "/assets", vals["origin_path"])
 	})
@@ -488,7 +455,7 @@ func TestBuildModuleValues_Cloudfront_OriginPath(t *testing.T) {
 				CachePaths *string `json:"cachePaths,omitempty"`
 			}{CachePaths: &path},
 		}
-		vals, err := m.BuildModuleValues(KeyCloudfront, nil, cfg, "", "")
+		vals, err := m.BuildModuleValues(KeyAWSCloudfront, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, "/legacy", vals["origin_path"])
 	})
@@ -503,7 +470,7 @@ func TestBuildModuleValues_Cloudfront_OriginPath(t *testing.T) {
 				CachePaths *string `json:"cachePaths,omitempty"`
 			}{OriginPath: &newPath, CachePaths: &oldPath},
 		}
-		vals, err := m.BuildModuleValues(KeyCloudfront, nil, cfg, "", "")
+		vals, err := m.BuildModuleValues(KeyAWSCloudfront, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, "/new", vals["origin_path"])
 	})
@@ -703,7 +670,7 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 			ReadReplicas string `json:"readReplicas,omitempty"`
 			StorageSize  string `json:"storageSize,omitempty"`
 		}{ReadReplicas: "2"}}
-		vals, err := m.BuildModuleValues(KeyPostgres, nil, cfg, "", "")
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, "2", vals["num_read_nodes"])
 	})
@@ -714,7 +681,7 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 			ReadReplicas string `json:"readReplicas,omitempty"`
 			StorageSize  string `json:"storageSize,omitempty"`
 		}{CPUSize: "db.m7i.2xlarge"}}
-		vals, err := m.BuildModuleValues(KeyPostgres, nil, cfg, "", "")
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, cfg, "", "")
 		require.NoError(t, err)
 		_, hasKey := vals["num_read_nodes"]
 		assert.False(t, hasKey, "unset ReadReplicas should not emit num_read_nodes")
@@ -726,7 +693,7 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 			ReadReplicas string `json:"readReplicas,omitempty"`
 			StorageSize  string `json:"storageSize,omitempty"`
 		}{CPUSize: "db.m7i.2xlarge", StorageSize: "20"}}
-		vals, err := m.BuildModuleValues(KeyPostgres, nil, cfg, "", "")
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, "db.m7i.2xlarge", vals["node_cpu_size"])
 		assert.Equal(t, "20", vals["storage_size"])

--- a/pkg/composer/validate.go
+++ b/pkg/composer/validate.go
@@ -101,6 +101,35 @@ func filterPresent(set map[ComponentKey]bool, candidates ...ComponentKey) []Comp
 	return found
 }
 
+// ValidateNoLegacyKeys returns a ValidationError if any of the provided
+// keys are deprecated legacy ComponentKey constants that have been renamed
+// to AWS-prefixed equivalents in LegacyToV2Key. Callers with legacy-shaped
+// session JSON should run reliable's composeradapter (or otherwise upgrade
+// keys) before handing them to ComposeStack. Polymorphic keys that haven't
+// been renamed (KeyResource, KeyEC2) and third-party toggles (KeySplunk,
+// KeyDatadog) pass through — only keys present in LegacyToV2Key are rejected.
+func ValidateNoLegacyKeys(keys []ComponentKey) error {
+	var legacy []ComponentKey
+	for _, k := range keys {
+		if _, isLegacy := LegacyToV2Key[k]; isLegacy {
+			legacy = append(legacy, k)
+		}
+	}
+	if len(legacy) == 0 {
+		return nil
+	}
+	// Build human-readable "legacy → prefixed" pairs so the error points at
+	// the fix, not just the problem.
+	pairs := make([]string, 0, len(legacy))
+	for _, k := range legacy {
+		pairs = append(pairs, fmt.Sprintf("%s → %s", k, LegacyToV2Key[k]))
+	}
+	return &ValidationError{msg: fmt.Sprintf(
+		"legacy ComponentKey(s) in SelectedKeys: %s — composer accepts only AWS-prefixed keys; use reliable's composeradapter to upgrade session JSON",
+		strings.Join(pairs, ", "),
+	)}
+}
+
 // ValidateRemovals checks whether removing the given components would break
 // dependencies of the remaining components. Returns a descriptive error for
 // each problematic removal, or nil if all removals are safe.

--- a/pkg/composer/validate_test.go
+++ b/pkg/composer/validate_test.go
@@ -336,3 +336,48 @@ func TestDiffComponents_SafeRemovalNoWarnings(t *testing.T) {
 	require.Equal(t, "aws_sqs", diffs[0].Component)
 	require.Empty(t, diffs[0].Warnings, "removing SQS should not produce warnings")
 }
+
+// TestValidateNoLegacyKeys locks in the Phase 3b contract that the composer's
+// public surface rejects legacy ComponentKeys. Adapters (reliable
+// composeradapter) must upgrade session JSON before handing it off.
+func TestValidateNoLegacyKeys(t *testing.T) {
+	t.Run("prefixed-only selection passes", func(t *testing.T) {
+		require.NoError(t, ValidateNoLegacyKeys([]ComponentKey{KeyAWSVPC, KeyAWSRDS, KeyAWSS3}))
+	})
+
+	t.Run("polymorphic keys pass", func(t *testing.T) {
+		// KeyResource / KeyEC2 are polymorphic, not renamed in LegacyToV2Key.
+		// Phase 4 renames them to unambiguous prefixed names; until then
+		// they remain valid.
+		require.NoError(t, ValidateNoLegacyKeys([]ComponentKey{KeyAWSVPC, KeyResource, KeyEC2}))
+	})
+
+	t.Run("third-party toggles pass", func(t *testing.T) {
+		// Splunk / Datadog have no AWS-prefixed siblings.
+		require.NoError(t, ValidateNoLegacyKeys([]ComponentKey{KeySplunk, KeyDatadog}))
+	})
+
+	t.Run("empty selection passes", func(t *testing.T) {
+		require.NoError(t, ValidateNoLegacyKeys(nil))
+		require.NoError(t, ValidateNoLegacyKeys([]ComponentKey{}))
+	})
+
+	t.Run("single legacy key fails with actionable pair", func(t *testing.T) {
+		err := ValidateNoLegacyKeys([]ComponentKey{KeyVPC})
+		require.Error(t, err)
+		var ve *ValidationError
+		require.ErrorAs(t, err, &ve, "must return a ValidationError so handlers map to HTTP 400")
+		require.Contains(t, err.Error(), "vpc → aws_vpc")
+		require.Contains(t, err.Error(), "composeradapter",
+			"error must point callers at the upgrade path")
+	})
+
+	t.Run("multiple legacy keys all reported", func(t *testing.T) {
+		err := ValidateNoLegacyKeys([]ComponentKey{KeyVPC, KeyAWSRDS, KeyALB, KeyBackups})
+		require.Error(t, err)
+		msg := err.Error()
+		require.Contains(t, msg, "vpc → aws_vpc")
+		require.Contains(t, msg, "alb → aws_alb")
+		require.Contains(t, msg, "backups → aws_backups")
+	})
+}

--- a/pkg/composer/validate_test.go
+++ b/pkg/composer/validate_test.go
@@ -357,6 +357,16 @@ func TestValidateNoLegacyKeys(t *testing.T) {
 		require.NoError(t, ValidateNoLegacyKeys([]ComponentKey{KeySplunk, KeyDatadog}))
 	})
 
+	t.Run("GCP-only selection passes (validator is cloud-agnostic)", func(t *testing.T) {
+		// LegacyToV2Key only contains AWS pairs; GCP keys are prefixed from
+		// day one. A pure-GCP selection must not trip the validator. Pinning
+		// this as intentional — anyone adding GCP pairs to LegacyToV2Key
+		// should reason about the rejection semantics here.
+		require.NoError(t, ValidateNoLegacyKeys([]ComponentKey{
+			KeyGCPVPC, KeyGCPGKE, KeyGCPCloudSQL, KeyGCPGCS,
+		}))
+	})
+
 	t.Run("empty selection passes", func(t *testing.T) {
 		require.NoError(t, ValidateNoLegacyKeys(nil))
 		require.NoError(t, ValidateNoLegacyKeys([]ComponentKey{}))


### PR DESCRIPTION
Closes the final chunks of Phase 3b from #118 and completes the #76 umbrella through Phase 3. Stacks on top of the moved{} emitter added in the first commit so the selector/switch collapse in the second commit doesn't force a `terraform state mv` migration on any deployed stack.

## Why this is safe to land now

- **Rebase order**: PR #122 (Backups consolidation) is orthogonal and lands first. When this PR rebases, the only overlap is inside the `case KeyAWSBackups:` arm of DefaultWiring / BuildModuleValues — conflicts are small and resolve toward this PR's version.
- **State migrations**: every rendered `module.<legacy>` → `module.aws_<name>` rename ships with a `moved {}` block auto-emitted alongside the module block. On fresh state the block is a no-op; on existing state Terraform rewrites addresses in place with zero API calls (verified via `terraform validate` in `emit_moved_integration_test.go`).
- **Downstream adapter**: reliable#1041's composeradapter is the single production entry point for legacy-key session JSON. It already upgrades legacy keys to AWS-prefixed before handing off to composer. This PR makes that upgrade path *mandatory* at the composer's public API via `ValidateNoLegacyKeys`.

## What changes

### Commit 1 — `feat(composer): auto-emit moved{} blocks for renamed modules`

`EmitRootMainTF` now appends one `moved { from = module.<legacy> to = module.<v2> }` block per rendered module whose name is a V2 ComponentKey in `LegacyToV2Key`. Driven by `LegacyToV2Key` reversed — no parallel hand-maintained name map.

- `pkg/composer/emit.go` — `appendMovedBlocks` helper, iterates input `[]ModuleBlock` (deterministic order, emits only for modules actually rendered).
- `pkg/composer/emit_moved_test.go` — HCL-parser-based unit tests: prefixed-gets-moves, legacy/polymorphic/third-party skipped, mixed selections, deterministic order, post-module placement.
- `pkg/composer/emit_moved_integration_test.go` — writes emitted main.tf to tmpdir + stub module + runs `terraform init -backend=false && terraform validate`. Skips on `-short` and if `terraform` not on PATH.

### Commit 2 — `refactor(composer): Phase 3b Chunk B — prefixed-only selection + wiring`

Flips the composer's public vocabulary to AWS-prefixed only. `ComposeStack` / `ComposeSingle` reject legacy keys at entry with a `ValidationError` that names the prefixed equivalent and points at composeradapter.

- **Selectors** (`contracts.go:519-574`) — `vpcRef` / `albRef` / `wafRef` / `bastionRef` / `rdsRef` / `s3Ref` / `opensearchRef` / `sqsRef` emit `module.aws_*` only. `resourceRef` retains a `KeyResource` fallback since that key is polymorphic (EKS control plane / Lambda), not renamed. `moduleRef` helper removed along with its one caller.
- **27-arm switches** (`contracts.go`, `mapper.go`) — AWS→legacy normalization prelude deleted from both `DefaultWiring` and `BuildModuleValues`. Case labels in the main switch renamed from `case KeyLegacy:` → `case KeyAWS*:`. `KeyResource, KeyAWSEKS` share a case for the EKS path.
- **has* OR pairs** (`contracts.go:607-616, 812`) — 9 `selected[KeyLegacy] || selected[KeyAWS*]` pairs collapsed to single `selected[KeyAWS*]` reads. `hasResource` retains a KeyResource OR for the polymorphic case.
- **Implicit backups-key add** (`compose.go:265`) — now inserts `KeyAWSBackups` instead of legacy `KeyBackups`.
- **Strict validation** (`validate.go` + `validate_test.go`) — new `ValidateNoLegacyKeys` wired into both `ComposeStack` and `ComposeSingle`.
- **Parity test** — `TestComposeStack_RejectsLegacyKeys` in `compose_stack_test.go` pins the end-to-end error contract per #118.
- **Fixture cleanup** — `awsKitchenSinkCompsLegacy` / `awsKitchenSinkCfgLegacy` deleted; `awsKitchenSinkCompsV2` switches to `AWSElastiCache` (prefixed).
- **Test migrations** — ~15 test functions migrated from legacy to prefixed selections, with assertions on `module.*` paths updated. Full list in the commit message. The 4 flipped tests named in #118 — `TestVpcRef`, `TestV2KeyNormalization`, `TestModuleRefHelpers`, `TestBuildModuleValues_V2KeyNormalization` — deleted or trimmed to prefixed-only.

## Dependency order

- Phase 2 (reliable's composeradapter, reliable#1041) — already merged.
- Phase 3a (godoc-only deprecation surface, #116) — already merged.
- Phase 3b safe subset (helper fallback reads, #121) — already merged.
- Phase 3b Backups consolidation (#122) — open; this PR will rebase cleanly on top when #122 merges.
- **This PR** — the final chunk of Phase 3b. Unblocks Phase 4 (umbrella #76): delete legacy `ComponentKey` constants, delete legacy `Components` / `Config` fields, rename polymorphic `KeyResource` / `KeyEC2` to unambiguous prefixed names, cut v0.4.0.

## Test plan

- [x] `go build ./... && go vet ./...` — clean
- [x] `go test -race -count=1 ./pkg/composer/...` — clean (34s)
- [x] `go test -race -v -run TestEmitRootMainTF_MovedBlocks_TerraformValidate ./pkg/composer/...` — `terraform validate` passes on emitted main.tf with moved blocks (0.07s, terraform v1.7.5 on macOS)
- [x] `terraform fmt -check -recursive` — clean (no preset .tf changes)
- [x] Net LOC: -191 (emitter adds 209, Chunk B removes 200 net)

Refs #118, #76