### PR TITLE
fix(composer): DiffConfigs no longer reports config-only populations as added

### DIFF
--- a/pkg/composer/diff.go
+++ b/pkg/composer/diff.go
@@ -410,6 +410,12 @@ func DiffMetadata(oldComp, newComp Components) []MetadataDiff {
 // this, two consecutive StackVersions that merely populate / clear a config
 // block would both summarize as "Added: <component>." or "Removed:
 // <component>." even though the toggle itself never changed (issue #123).
+//
+// External toggles (splunk / datadog / githubactions) live on Components but
+// never surface in Config, so they can never appear in configDiffs and the
+// demotion branch is a no-op for them by construction. componentEnabled
+// works for them uniformly; this is a latent capability worth preserving if
+// Config ever grows peer structs for those toggles.
 func MergeComponentDiffs(componentDiffs, configDiffs []ComponentDiff, oldComp, newComp Components) []ComponentDiff {
 	seen := make(map[string]bool, len(configDiffs))
 	merged := make([]ComponentDiff, 0, len(configDiffs)+len(componentDiffs))

--- a/pkg/composer/diff.go
+++ b/pkg/composer/diff.go
@@ -290,6 +290,21 @@ func isComponentActive(v reflect.Value) bool {
 	return false
 }
 
+// componentEnabled reports whether the Components field whose JSON tag matches
+// kind is active (non-empty string / non-nil pointer / true bool). Used by
+// MergeComponentDiffs to distinguish a genuine add/remove from a config-only
+// population of an already-enabled component.
+func componentEnabled(c Components, kind string) bool {
+	v := reflect.ValueOf(c)
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		if JSONTagName(t.Field(i)) == kind {
+			return isComponentActive(v.Field(i))
+		}
+	}
+	return false
+}
+
 // DiffComponents compares two Components structs and returns diffs for
 // components that were added or removed. It only looks at toggle fields
 // (cloud-prefixed + external); metadata and legacy fields are skipped.
@@ -388,11 +403,23 @@ func DiffMetadata(oldComp, newComp Components) []MetadataDiff {
 // with config-level diffs (from DiffConfigs) into a single slice. Config diffs
 // take precedence when both sources report the same component key, since they
 // carry richer FieldDiff detail. The result is sorted by component name.
-func MergeComponentDiffs(componentDiffs, configDiffs []ComponentDiff) []ComponentDiff {
+//
+// oldComp / newComp correct a blind spot in DiffConfigs: when a component is
+// active on both sides and only its Config sub-struct flipped nil↔non-nil,
+// the config-origin "added" / "removed" is demoted to "modified". Without
+// this, two consecutive StackVersions that merely populate / clear a config
+// block would both summarize as "Added: <component>." or "Removed:
+// <component>." even though the toggle itself never changed (issue #123).
+func MergeComponentDiffs(componentDiffs, configDiffs []ComponentDiff, oldComp, newComp Components) []ComponentDiff {
 	seen := make(map[string]bool, len(configDiffs))
 	merged := make([]ComponentDiff, 0, len(configDiffs)+len(componentDiffs))
 
 	for _, d := range configDiffs {
+		if (d.Action == "added" || d.Action == "removed") &&
+			componentEnabled(oldComp, d.Component) &&
+			componentEnabled(newComp, d.Component) {
+			d.Action = "modified"
+		}
 		seen[d.Component] = true
 		merged = append(merged, d)
 	}

--- a/pkg/composer/diff.go
+++ b/pkg/composer/diff.go
@@ -160,11 +160,23 @@ func DiffConfigs(oldCfg, newCfg Config) []ComponentDiff {
 			continue
 		}
 		if oldNil && !newNil {
-			diffs = append(diffs, ComponentDiff{Component: tag, Action: "added"})
+			// Diff against a zero-value struct so the diff carries per-field
+			// detail. Surfaces after MergeComponentDiffs demotes this to
+			// "modified" (issue #126 / #123); SummarizeChanges then renders
+			// "Modified: <component> (field: (unset) → <value>, ...)" instead
+			// of a bare "Modified: <component>.".
+			zero := reflect.New(newField.Type().Elem()).Elem()
+			fieldDiffs := diffStructFields(zero, newField.Elem())
+			diffs = append(diffs, ComponentDiff{Component: tag, Action: "added", Changes: fieldDiffs})
 			continue
 		}
 		if !oldNil && newNil {
-			diffs = append(diffs, ComponentDiff{Component: tag, Action: "removed"})
+			// Symmetric to the nil → non-nil branch: diff against a zero-value
+			// struct so the demoted "modified" diff reports which fields were
+			// cleared.
+			zero := reflect.New(oldField.Type().Elem()).Elem()
+			fieldDiffs := diffStructFields(oldField.Elem(), zero)
+			diffs = append(diffs, ComponentDiff{Component: tag, Action: "removed", Changes: fieldDiffs})
 			continue
 		}
 		// Both non-nil: compare sub-struct fields.
@@ -178,6 +190,18 @@ func DiffConfigs(oldCfg, newCfg Config) []ComponentDiff {
 		}
 	}
 	return diffs
+}
+
+// displayFieldValue renders a FieldDiff value for human display. An empty
+// string means the field was absent on that side — often because the diff was
+// taken against a zero-value struct on a nil↔non-nil transition (see
+// DiffConfigs) — and is rendered as "(unset)" so the summary reads naturally.
+// All other values flow through HumanizeFieldValue unchanged.
+func displayFieldValue(field, value string) string {
+	if value == "" {
+		return "(unset)"
+	}
+	return HumanizeFieldValue(field, value)
 }
 
 // SummarizeChanges generates a concise human-readable summary from component diffs.
@@ -199,7 +223,7 @@ func SummarizeChanges(diffs []ComponentDiff) string {
 				limit := min(2, len(d.Changes))
 				var fieldDetails []string
 				for _, c := range d.Changes[:limit] {
-					fieldDetails = append(fieldDetails, fmt.Sprintf("%s: %s \u2192 %s", c.Field, HumanizeFieldValue(c.Field, c.From), HumanizeFieldValue(c.Field, c.To)))
+					fieldDetails = append(fieldDetails, fmt.Sprintf("%s: %s \u2192 %s", c.Field, displayFieldValue(c.Field, c.From), displayFieldValue(c.Field, c.To)))
 				}
 				detail += " (" + strings.Join(fieldDetails, ", ") + ")"
 				if len(d.Changes) > 2 {

--- a/pkg/composer/diff_test.go
+++ b/pkg/composer/diff_test.go
@@ -310,6 +310,34 @@ func TestDiffConfigs_PopulatesChangesOnNonNilToNil(t *testing.T) {
 	}
 }
 
+// TestDiffConfigs_PopulatesChangesForStringPointerField exercises the
+// *string shape of Config sub-struct fields through the zero-value-diff
+// path (aws_cloudfront.defaultTtl is *string). Ensures the reflect.Ptr →
+// reflect.String fallthrough in FormatValue correctly renders a nil
+// *string as "" on the zero side; any regression there would produce
+// garbage From values like "<nil>" or panic on deref.
+func TestDiffConfigs_PopulatesChangesForStringPointerField(t *testing.T) {
+	t.Parallel()
+	oldCfg := cfgFromJSON(t, `{"cloud":"AWS"}`)
+	newCfg := cfgFromJSON(t, `{"cloud":"AWS","aws_cloudfront":{"defaultTtl":"3600"}}`)
+
+	diffs := DiffConfigs(oldCfg, newCfg)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %+v", diffs)
+	}
+	d := diffs[0]
+	if d.Component != "aws_cloudfront" || d.Action != "added" {
+		t.Fatalf("got %+v, want aws_cloudfront/added", d)
+	}
+	if len(d.Changes) != 1 {
+		t.Fatalf("expected 1 change (defaultTtl), got %+v", d.Changes)
+	}
+	c := d.Changes[0]
+	if c.Field != "defaultTtl" || c.From != "" || c.To != "3600" {
+		t.Errorf("got %+v, want {defaultTtl, \"\", 3600}", c)
+	}
+}
+
 func TestDiffConfigs_BoolPointerFields(t *testing.T) {
 	t.Parallel()
 	oldCfg := cfgFromJSON(t, `{"aws_eks": {"haControlPlane": true, "desiredSize": "3"}}`)
@@ -561,22 +589,68 @@ func TestSummarizeChanges_TruncatesFieldDetails(t *testing.T) {
 // contract: empty From/To (the zero-value side of a nil↔non-nil transition)
 // is displayed as "(unset)" rather than an empty string, so the summary
 // reads as "field: (unset) → value" instead of "field:  → value".
+//
+// Also pins displayFieldValue's delegation to HumanizeFieldValue on the
+// populated side — QA review flagged that every prior SummarizeChanges
+// assertion used identity-mapped fields, so a mutation that stopped
+// calling HumanizeFieldValue would have passed. Pair (unset) with:
+//   - versioning (in booleanFields, humanises "true" → "Yes")
+//   - retentionDays (appends " days" suffix)
+// so the delegation contract is enforced both ways.
+//
+// FieldDiff with both sides empty is unreachable from DiffConfigs
+// (diffStructFields only emits when oldStr != newStr), so we don't
+// defend against "(unset) → (unset)" — if a future emitter produces
+// one, the rendering will read exactly that.
 func TestSummarizeChanges_UnsetRenderedForEmptyValues(t *testing.T) {
 	t.Parallel()
-	diffs := []ComponentDiff{
-		{Component: "aws_vpc", Action: "modified", Changes: []FieldDiff{
-			{Field: "azCount", From: "", To: "2"},
-			{Field: "enableNatGateway", From: "true", To: ""},
-		}},
+	// 2-field truncation in SummarizeChanges means only the first two
+	// Changes land in the summary head; sort order follows the slice.
+	// Use one (unset)-on-From + one (unset)-on-To to cover both sides,
+	// and pick humanised fields to lock the HumanizeFieldValue route.
+	tests := []struct {
+		name   string
+		diffs  []ComponentDiff
+		wantIn []string
+	}{
+		{
+			name: "versioning_unset_to_true_humanises_to_Yes",
+			diffs: []ComponentDiff{
+				{Component: "aws_s3", Action: "modified", Changes: []FieldDiff{
+					{Field: "versioning", From: "", To: "true"},
+				}},
+			},
+			wantIn: []string{"versioning: (unset) → Yes"},
+		},
+		{
+			name: "retentionDays_30_to_unset_appends_days_suffix",
+			diffs: []ComponentDiff{
+				{Component: "aws_cloudwatch_logs", Action: "modified", Changes: []FieldDiff{
+					{Field: "retentionDays", From: "30", To: ""},
+				}},
+			},
+			wantIn: []string{"retentionDays: 30 days → (unset)"},
+		},
+		{
+			name: "identity_mapped_field_still_renders_unset",
+			diffs: []ComponentDiff{
+				{Component: "aws_vpc", Action: "modified", Changes: []FieldDiff{
+					{Field: "azCount", From: "", To: "2"},
+				}},
+			},
+			wantIn: []string{"azCount: (unset) → 2"},
+		},
 	}
-	s := SummarizeChanges(diffs)
-	// azCount: nil → populated renders From as "(unset)".
-	if !strings.Contains(s, "azCount: (unset) → 2") {
-		t.Errorf("expected 'azCount: (unset) -> 2' in summary, got %q", s)
-	}
-	// enableNatGateway: populated → nil renders To as "(unset)".
-	if !strings.Contains(s, "enableNatGateway: true → (unset)") {
-		t.Errorf("expected 'enableNatGateway: true -> (unset)' in summary, got %q", s)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := SummarizeChanges(tt.diffs)
+			for _, want := range tt.wantIn {
+				if !strings.Contains(s, want) {
+					t.Errorf("expected %q in summary, got %q", want, s)
+				}
+			}
+		})
 	}
 }
 
@@ -1180,6 +1254,13 @@ func TestMergeComponentDiffs_DemotesAddedWhenComponentAlreadyActive(t *testing.T
 	}
 	if !strings.Contains(summary, "aws_vpc (") {
 		t.Errorf("summary should carry field-level detail in parentheses, got %q", summary)
+	}
+	// Three fields go into DiffConfigs; SummarizeChanges truncates to 2
+	// with a "+1 more" suffix. Pin the truncation end-to-end so a mutation
+	// of the min(2, len(...)) limit surfaces via the real pipeline, not
+	// only via the synthetic TestSummarizeChanges_TruncatesFieldDetails.
+	if !strings.Contains(summary, "+1 more") {
+		t.Errorf("summary should end the aws_vpc detail with '+1 more' (3 fields, 2-field limit), got %q", summary)
 	}
 }
 

--- a/pkg/composer/diff_test.go
+++ b/pkg/composer/diff_test.go
@@ -997,6 +997,13 @@ func TestMergeComponentDiffs_DemotesAddedWhenComponentAlreadyActive(t *testing.T
 	if merged[0].Component != "aws_vpc" || merged[0].Action != "modified" {
 		t.Errorf("expected {aws_vpc, modified}, got %+v", merged[0])
 	}
+	// Pin current behaviour: DiffConfigs emits no Changes on nil→non-nil,
+	// so the demoted "modified" carries no per-field detail. Follow-up
+	// #126 proposes synthesising Changes here; when that lands this
+	// assertion must be updated deliberately.
+	if len(merged[0].Changes) != 0 {
+		t.Errorf("expected no Changes on demoted diff (DiffConfigs emits none on nil→non-nil), got %+v", merged[0].Changes)
+	}
 
 	summary := SummarizeChanges(merged)
 	if strings.HasPrefix(summary, "Added:") {
@@ -1030,6 +1037,11 @@ func TestMergeComponentDiffs_DemotesRemovedWhenComponentStillActive(t *testing.T
 	merged := MergeComponentDiffs(componentDiffs, configDiffs, oldComp, newComp)
 	if len(merged) != 1 || merged[0].Component != "aws_vpc" || merged[0].Action != "modified" {
 		t.Errorf("expected [{aws_vpc, modified}], got %+v", merged)
+	}
+	// Pin current behaviour (see sibling DemotesAdded test): DiffConfigs
+	// emits no Changes on non-nil→nil, so the demoted diff is field-less.
+	if len(merged[0].Changes) != 0 {
+		t.Errorf("expected no Changes on demoted diff (DiffConfigs emits none on non-nil→nil), got %+v", merged[0].Changes)
 	}
 
 	summary := SummarizeChanges(merged)
@@ -1119,5 +1131,11 @@ func TestMergeComponentDiffs_KeepsAddedWhenComponentInactiveOnBothSides(t *testi
 	merged := MergeComponentDiffs(componentDiffs, configDiffs, oldComp, newComp)
 	if len(merged) != 1 || merged[0].Component != "aws_vpc" || merged[0].Action != "added" {
 		t.Errorf("expected [{aws_vpc, added}] (no demotion, component inactive on both sides), got %+v", merged)
+	}
+	// Defend the user-visible label against future SummarizeChanges
+	// refactors that might accidentally lose the distinction between
+	// "component newly enabled" and "config populated while toggle off".
+	if got := SummarizeChanges(merged); !strings.HasPrefix(got, "Added:") {
+		t.Errorf("expected summary to start with 'Added:', got %q", got)
 	}
 }

--- a/pkg/composer/diff_test.go
+++ b/pkg/composer/diff_test.go
@@ -580,6 +580,41 @@ func TestSummarizeChanges_UnsetRenderedForEmptyValues(t *testing.T) {
 	}
 }
 
+// TestDiffConfigs_NativeModifiedRendersUnsetForNilPointerField pins the
+// review-surfaced consequence that displayFieldValue routes ALL modified
+// diffs, not only demoted ones, through the "(unset)" rendering. Here
+// aws_eks stays non-nil on both sides (so the demotion path doesn't apply)
+// but a *bool field inside transitions nil → true — the pre-#126 summary
+// would read "haControlPlane:  → true" (stray blank); after #126 it must
+// read "haControlPlane: (unset) → true". A future refactor that limited
+// displayFieldValue to the demotion path would regress this rendering.
+func TestDiffConfigs_NativeModifiedRendersUnsetForNilPointerField(t *testing.T) {
+	t.Parallel()
+	oldCfg := cfgFromJSON(t, `{"aws_eks":{"desiredSize":"3"}}`)
+	newCfg := cfgFromJSON(t, `{"aws_eks":{"haControlPlane":true,"desiredSize":"3"}}`)
+
+	diffs := DiffConfigs(oldCfg, newCfg)
+	if len(diffs) != 1 || diffs[0].Component != "aws_eks" || diffs[0].Action != "modified" {
+		t.Fatalf("expected [{aws_eks, modified}], got %+v", diffs)
+	}
+	if len(diffs[0].Changes) != 1 {
+		t.Fatalf("expected 1 change, got %+v", diffs[0].Changes)
+	}
+	c := diffs[0].Changes[0]
+	if c.Field != "haControlPlane" || c.From != "" || c.To != "true" {
+		t.Errorf("got %+v, want {haControlPlane, \"\", true}", c)
+	}
+
+	// Summary renders the empty From as "(unset)" and routes the populated
+	// To through HumanizeFieldValue (which humanizes "true" to "Yes" for
+	// boolean-typed fields). Asserts both the (unset) contract and the
+	// HumanizeFieldValue pass-through for non-empty values.
+	summary := SummarizeChanges(diffs)
+	if !strings.Contains(summary, "haControlPlane: (unset) → Yes") {
+		t.Errorf("expected '(unset) → Yes' (HumanizeFieldValue humanizes bool), got %q", summary)
+	}
+}
+
 func TestSummarizeChanges_ModifiedNoChanges(t *testing.T) {
 	t.Parallel()
 	diffs := []ComponentDiff{

--- a/pkg/composer/diff_test.go
+++ b/pkg/composer/diff_test.go
@@ -1028,13 +1028,37 @@ func TestMergeComponentDiffs_DemotesRemovedWhenComponentStillActive(t *testing.T
 	}
 
 	merged := MergeComponentDiffs(componentDiffs, configDiffs, oldComp, newComp)
-	if len(merged) != 1 || merged[0].Action != "modified" {
-		t.Errorf("expected removed → modified demotion, got %+v", merged)
+	if len(merged) != 1 || merged[0].Component != "aws_vpc" || merged[0].Action != "modified" {
+		t.Errorf("expected [{aws_vpc, modified}], got %+v", merged)
 	}
 
 	summary := SummarizeChanges(merged)
 	if strings.HasPrefix(summary, "Removed:") {
 		t.Errorf("summary should not start with 'Removed:' for config-only clear, got %q", summary)
+	}
+}
+
+// TestMergeComponentDiffs_DemotesAddedForBoolToggle exercises the *bool
+// shape of Components fields (aws_rds) — distinct from the string shape
+// (aws_vpc) covered above. Without hitting the reflect.Ptr → reflect.Bool
+// branch of isComponentActive, a future narrowing of componentEnabled to
+// string-only toggles would go unnoticed by the other demotion tests.
+func TestMergeComponentDiffs_DemotesAddedForBoolToggle(t *testing.T) {
+	t.Parallel()
+	oldComp := compFromJSON(t, `{"cloud":"AWS","aws_rds":true}`)
+	newComp := compFromJSON(t, `{"cloud":"AWS","aws_rds":true}`)
+	oldCfg := cfgFromJSON(t, `{"cloud":"AWS"}`)
+	newCfg := cfgFromJSON(t, `{"cloud":"AWS","aws_rds":{"cpuSize":"db.r5.large"}}`)
+
+	componentDiffs := DiffComponents(oldComp, newComp)
+	configDiffs := DiffConfigs(oldCfg, newCfg)
+	if len(configDiffs) != 1 || configDiffs[0].Action != "added" {
+		t.Fatalf("DiffConfigs: expected [{aws_rds, added}], got %+v", configDiffs)
+	}
+
+	merged := MergeComponentDiffs(componentDiffs, configDiffs, oldComp, newComp)
+	if len(merged) != 1 || merged[0].Component != "aws_rds" || merged[0].Action != "modified" {
+		t.Errorf("expected [{aws_rds, modified}] — *bool toggle active on both sides, got %+v", merged)
 	}
 }
 

--- a/pkg/composer/diff_test.go
+++ b/pkg/composer/diff_test.go
@@ -875,7 +875,7 @@ func TestVersionDiff_MetadataOmittedWhenEmpty(t *testing.T) {
 
 func TestMergeComponentDiffs_BothEmpty(t *testing.T) {
 	t.Parallel()
-	merged := MergeComponentDiffs(nil, nil)
+	merged := MergeComponentDiffs(nil, nil, Components{}, Components{})
 	if len(merged) != 0 {
 		t.Errorf("expected empty, got %d", len(merged))
 	}
@@ -886,7 +886,7 @@ func TestMergeComponentDiffs_ConfigOnly(t *testing.T) {
 	cfgDiffs := []ComponentDiff{
 		{Component: "aws_ec2", Action: "modified", Changes: []FieldDiff{{Field: "numServers", From: "2", To: "4"}}},
 	}
-	merged := MergeComponentDiffs(nil, cfgDiffs)
+	merged := MergeComponentDiffs(nil, cfgDiffs, Components{}, Components{})
 	if len(merged) != 1 {
 		t.Fatalf("expected 1, got %d", len(merged))
 	}
@@ -900,7 +900,7 @@ func TestMergeComponentDiffs_ComponentOnly(t *testing.T) {
 	compDiffs := []ComponentDiff{
 		{Component: "aws_waf", Action: "added"},
 	}
-	merged := MergeComponentDiffs(compDiffs, nil)
+	merged := MergeComponentDiffs(compDiffs, nil, Components{}, Components{})
 	if len(merged) != 1 {
 		t.Fatalf("expected 1, got %d", len(merged))
 	}
@@ -917,7 +917,7 @@ func TestMergeComponentDiffs_ConfigTakesPrecedence(t *testing.T) {
 	cfgDiffs := []ComponentDiff{
 		{Component: "aws_rds", Action: "added", Changes: []FieldDiff{{Field: "cpuSize", From: "", To: "db.r5.large"}}},
 	}
-	merged := MergeComponentDiffs(compDiffs, cfgDiffs)
+	merged := MergeComponentDiffs(compDiffs, cfgDiffs, Components{}, Components{})
 	if len(merged) != 1 {
 		t.Fatalf("expected 1, got %d", len(merged))
 	}
@@ -938,7 +938,7 @@ func TestMergeComponentDiffs_Disjoint(t *testing.T) {
 	cfgDiffs := []ComponentDiff{
 		{Component: "aws_ec2", Action: "modified", Changes: []FieldDiff{{Field: "numServers", From: "2", To: "4"}}},
 	}
-	merged := MergeComponentDiffs(compDiffs, cfgDiffs)
+	merged := MergeComponentDiffs(compDiffs, cfgDiffs, Components{}, Components{})
 	if len(merged) != 2 {
 		t.Fatalf("expected 2, got %d", len(merged))
 	}
@@ -957,7 +957,7 @@ func TestMergeComponentDiffs_Sorted(t *testing.T) {
 	cfgDiffs := []ComponentDiff{
 		{Component: "aws_rds", Action: "modified"},
 	}
-	merged := MergeComponentDiffs(compDiffs, cfgDiffs)
+	merged := MergeComponentDiffs(compDiffs, cfgDiffs, Components{}, Components{})
 	if len(merged) != 3 {
 		t.Fatalf("expected 3, got %d", len(merged))
 	}
@@ -965,5 +965,135 @@ func TestMergeComponentDiffs_Sorted(t *testing.T) {
 		if merged[i].Component < merged[i-1].Component {
 			t.Errorf("not sorted: %q < %q at position %d", merged[i].Component, merged[i-1].Component, i)
 		}
+	}
+}
+
+// TestMergeComponentDiffs_DemotesAddedWhenComponentAlreadyActive is the
+// verbatim reproduction from issue #123: two StackVersions with identical
+// Components (aws_vpc already "Private" on both sides) where only the Config
+// sub-struct transitions nil → non-nil. Without the merge-site demotion, the
+// second turn would wrongly summarize as "Added: aws_vpc." even though the
+// toggle never changed.
+func TestMergeComponentDiffs_DemotesAddedWhenComponentAlreadyActive(t *testing.T) {
+	t.Parallel()
+	oldComp := compFromJSON(t, `{"cloud":"AWS","aws_vpc":"Private"}`)
+	newComp := compFromJSON(t, `{"cloud":"AWS","aws_vpc":"Private"}`)
+	oldCfg := cfgFromJSON(t, `{"cloud":"AWS"}`)
+	newCfg := cfgFromJSON(t, `{"cloud":"AWS","aws_vpc":{"azCount":2,"enableNatGateway":true,"singleNatGateway":true}}`)
+
+	componentDiffs := DiffComponents(oldComp, newComp)
+	configDiffs := DiffConfigs(oldCfg, newCfg)
+	if len(componentDiffs) != 0 {
+		t.Fatalf("DiffComponents: expected 0 diffs (toggle unchanged), got %+v", componentDiffs)
+	}
+	if len(configDiffs) != 1 || configDiffs[0].Action != "added" {
+		t.Fatalf("DiffConfigs: expected [{aws_vpc, added}], got %+v", configDiffs)
+	}
+
+	merged := MergeComponentDiffs(componentDiffs, configDiffs, oldComp, newComp)
+	if len(merged) != 1 {
+		t.Fatalf("merged: expected 1 diff, got %+v", merged)
+	}
+	if merged[0].Component != "aws_vpc" || merged[0].Action != "modified" {
+		t.Errorf("expected {aws_vpc, modified}, got %+v", merged[0])
+	}
+
+	summary := SummarizeChanges(merged)
+	if strings.HasPrefix(summary, "Added:") {
+		t.Errorf("summary should not start with 'Added:' for config-only population, got %q", summary)
+	}
+	if !strings.HasPrefix(summary, "Modified:") {
+		t.Errorf("summary should start with 'Modified:', got %q", summary)
+	}
+}
+
+// TestMergeComponentDiffs_DemotesRemovedWhenComponentStillActive is the
+// symmetric case: config transitions non-nil → nil while the component
+// remains enabled. A naive merge would summarize as "Removed: aws_vpc."
+// even though the toggle is unchanged.
+func TestMergeComponentDiffs_DemotesRemovedWhenComponentStillActive(t *testing.T) {
+	t.Parallel()
+	oldComp := compFromJSON(t, `{"cloud":"AWS","aws_vpc":"Private"}`)
+	newComp := compFromJSON(t, `{"cloud":"AWS","aws_vpc":"Private"}`)
+	oldCfg := cfgFromJSON(t, `{"cloud":"AWS","aws_vpc":{"azCount":2}}`)
+	newCfg := cfgFromJSON(t, `{"cloud":"AWS"}`)
+
+	componentDiffs := DiffComponents(oldComp, newComp)
+	configDiffs := DiffConfigs(oldCfg, newCfg)
+	if len(componentDiffs) != 0 {
+		t.Fatalf("DiffComponents: expected 0 diffs, got %+v", componentDiffs)
+	}
+	if len(configDiffs) != 1 || configDiffs[0].Action != "removed" {
+		t.Fatalf("DiffConfigs: expected [{aws_vpc, removed}], got %+v", configDiffs)
+	}
+
+	merged := MergeComponentDiffs(componentDiffs, configDiffs, oldComp, newComp)
+	if len(merged) != 1 || merged[0].Action != "modified" {
+		t.Errorf("expected removed → modified demotion, got %+v", merged)
+	}
+
+	summary := SummarizeChanges(merged)
+	if strings.HasPrefix(summary, "Removed:") {
+		t.Errorf("summary should not start with 'Removed:' for config-only clear, got %q", summary)
+	}
+}
+
+// TestMergeComponentDiffs_KeepsAddedWhenComponentNewlyEnabled guards against
+// over-demoting: when the component genuinely transitioned from off to on,
+// the "added" label must survive. DiffComponents will also emit "added" for
+// aws_vpc but DiffConfigs wins precedence — we assert the surviving diff is
+// still "added".
+func TestMergeComponentDiffs_KeepsAddedWhenComponentNewlyEnabled(t *testing.T) {
+	t.Parallel()
+	oldComp := compFromJSON(t, `{"cloud":"AWS"}`)
+	newComp := compFromJSON(t, `{"cloud":"AWS","aws_vpc":"Private"}`)
+	oldCfg := cfgFromJSON(t, `{"cloud":"AWS"}`)
+	newCfg := cfgFromJSON(t, `{"cloud":"AWS","aws_vpc":{"azCount":2}}`)
+
+	componentDiffs := DiffComponents(oldComp, newComp)
+	configDiffs := DiffConfigs(oldCfg, newCfg)
+
+	merged := MergeComponentDiffs(componentDiffs, configDiffs, oldComp, newComp)
+	if len(merged) != 1 || merged[0].Component != "aws_vpc" || merged[0].Action != "added" {
+		t.Errorf("expected [{aws_vpc, added}], got %+v", merged)
+	}
+}
+
+// TestMergeComponentDiffs_KeepsRemovedWhenComponentFullyRemoved is the mirror
+// regression guard: component toggle went off AND config cleared → must stay
+// "removed".
+func TestMergeComponentDiffs_KeepsRemovedWhenComponentFullyRemoved(t *testing.T) {
+	t.Parallel()
+	oldComp := compFromJSON(t, `{"cloud":"AWS","aws_vpc":"Private"}`)
+	newComp := compFromJSON(t, `{"cloud":"AWS"}`)
+	oldCfg := cfgFromJSON(t, `{"cloud":"AWS","aws_vpc":{"azCount":2}}`)
+	newCfg := cfgFromJSON(t, `{"cloud":"AWS"}`)
+
+	componentDiffs := DiffComponents(oldComp, newComp)
+	configDiffs := DiffConfigs(oldCfg, newCfg)
+
+	merged := MergeComponentDiffs(componentDiffs, configDiffs, oldComp, newComp)
+	if len(merged) != 1 || merged[0].Component != "aws_vpc" || merged[0].Action != "removed" {
+		t.Errorf("expected [{aws_vpc, removed}], got %+v", merged)
+	}
+}
+
+// TestMergeComponentDiffs_KeepsAddedWhenComponentInactiveOnBothSides covers
+// the edge case where config is populated for a component whose toggle is
+// still off on both sides. Unusual in practice, but the merge must not
+// demote — the user surfaced a config block worth reporting.
+func TestMergeComponentDiffs_KeepsAddedWhenComponentInactiveOnBothSides(t *testing.T) {
+	t.Parallel()
+	oldComp := compFromJSON(t, `{"cloud":"AWS"}`)
+	newComp := compFromJSON(t, `{"cloud":"AWS"}`)
+	oldCfg := cfgFromJSON(t, `{"cloud":"AWS"}`)
+	newCfg := cfgFromJSON(t, `{"cloud":"AWS","aws_vpc":{"azCount":2}}`)
+
+	componentDiffs := DiffComponents(oldComp, newComp)
+	configDiffs := DiffConfigs(oldCfg, newCfg)
+
+	merged := MergeComponentDiffs(componentDiffs, configDiffs, oldComp, newComp)
+	if len(merged) != 1 || merged[0].Component != "aws_vpc" || merged[0].Action != "added" {
+		t.Errorf("expected [{aws_vpc, added}] (no demotion, component inactive on both sides), got %+v", merged)
 	}
 }

--- a/pkg/composer/diff_test.go
+++ b/pkg/composer/diff_test.go
@@ -209,6 +209,15 @@ func TestDiffConfigs_ComponentAdded(t *testing.T) {
 	if diffs[0].Component != "gcp_gke" || diffs[0].Action != "added" {
 		t.Errorf("got %+v, want gcp_gke/added", diffs[0])
 	}
+	// Issue #126: nil→non-nil now synthesises Changes against a
+	// zero-value struct so the demoted "modified" diff carries field detail.
+	if len(diffs[0].Changes) != 1 {
+		t.Fatalf("expected 1 change (nodeCount), got %+v", diffs[0].Changes)
+	}
+	c := diffs[0].Changes[0]
+	if c.Field != "nodeCount" || c.From != "" || c.To != "3" {
+		t.Errorf("got %+v, want {nodeCount, \"\", 3}", c)
+	}
 }
 
 func TestDiffConfigs_ComponentRemoved(t *testing.T) {
@@ -225,6 +234,79 @@ func TestDiffConfigs_ComponentRemoved(t *testing.T) {
 	}
 	if diffs[0].Component != "aws_s3" || diffs[0].Action != "removed" {
 		t.Errorf("got %+v, want aws_s3/removed", diffs[0])
+	}
+	// Issue #126 mirror: non-nil→nil now diffs against a zero-value struct
+	// so cleared fields surface on the demoted "modified" diff.
+	if len(diffs[0].Changes) != 1 {
+		t.Fatalf("expected 1 change (versioning), got %+v", diffs[0].Changes)
+	}
+	c := diffs[0].Changes[0]
+	if c.Field != "versioning" || c.From != "true" || c.To != "" {
+		t.Errorf("got %+v, want {versioning, true, \"\"}", c)
+	}
+}
+
+// TestDiffConfigs_PopulatesChangesOnNilToNonNil is the primary #126
+// regression guard: when a component's Config sub-struct transitions nil →
+// non-nil, DiffConfigs must emit Changes by diffing against a zero-value
+// struct. Surfaces after MergeComponentDiffs demotion so SummarizeChanges
+// can render "Modified: aws_vpc (azCount: (unset) → 2, ...)".
+func TestDiffConfigs_PopulatesChangesOnNilToNonNil(t *testing.T) {
+	t.Parallel()
+	oldCfg := cfgFromJSON(t, `{"cloud":"AWS"}`)
+	newCfg := cfgFromJSON(t, `{"cloud":"AWS","aws_vpc":{"azCount":2,"enableNatGateway":true}}`)
+
+	diffs := DiffConfigs(oldCfg, newCfg)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %+v", diffs)
+	}
+	d := diffs[0]
+	if d.Component != "aws_vpc" || d.Action != "added" {
+		t.Fatalf("got %+v, want aws_vpc/added", d)
+	}
+	if len(d.Changes) != 2 {
+		t.Fatalf("expected 2 changes (azCount, enableNatGateway), got %+v", d.Changes)
+	}
+	byField := map[string]FieldDiff{}
+	for _, c := range d.Changes {
+		byField[c.Field] = c
+	}
+	if got, ok := byField["azCount"]; !ok || got.From != "" || got.To != "2" {
+		t.Errorf("azCount: got %+v, want {azCount, \"\", 2}", got)
+	}
+	if got, ok := byField["enableNatGateway"]; !ok || got.From != "" || got.To != "true" {
+		t.Errorf("enableNatGateway: got %+v, want {enableNatGateway, \"\", true}", got)
+	}
+}
+
+// TestDiffConfigs_PopulatesChangesOnNonNilToNil mirrors the nil→non-nil
+// case: cleared fields must surface on the emitted ComponentDiff so a demoted
+// "modified" diff can render which knobs were reset to defaults.
+func TestDiffConfigs_PopulatesChangesOnNonNilToNil(t *testing.T) {
+	t.Parallel()
+	oldCfg := cfgFromJSON(t, `{"cloud":"AWS","aws_vpc":{"azCount":3,"enableNatGateway":true}}`)
+	newCfg := cfgFromJSON(t, `{"cloud":"AWS"}`)
+
+	diffs := DiffConfigs(oldCfg, newCfg)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %+v", diffs)
+	}
+	d := diffs[0]
+	if d.Component != "aws_vpc" || d.Action != "removed" {
+		t.Fatalf("got %+v, want aws_vpc/removed", d)
+	}
+	if len(d.Changes) != 2 {
+		t.Fatalf("expected 2 changes (azCount, enableNatGateway), got %+v", d.Changes)
+	}
+	byField := map[string]FieldDiff{}
+	for _, c := range d.Changes {
+		byField[c.Field] = c
+	}
+	if got, ok := byField["azCount"]; !ok || got.From != "3" || got.To != "" {
+		t.Errorf("azCount: got %+v, want {azCount, 3, \"\"}", got)
+	}
+	if got, ok := byField["enableNatGateway"]; !ok || got.From != "true" || got.To != "" {
+		t.Errorf("enableNatGateway: got %+v, want {enableNatGateway, true, \"\"}", got)
 	}
 }
 
@@ -472,6 +554,29 @@ func TestSummarizeChanges_TruncatesFieldDetails(t *testing.T) {
 	}
 	if strings.Contains(s, "readReplicas:") {
 		t.Error("readReplicas should be truncated, not shown")
+	}
+}
+
+// TestSummarizeChanges_UnsetRenderedForEmptyValues locks the #126 rendering
+// contract: empty From/To (the zero-value side of a nil↔non-nil transition)
+// is displayed as "(unset)" rather than an empty string, so the summary
+// reads as "field: (unset) → value" instead of "field:  → value".
+func TestSummarizeChanges_UnsetRenderedForEmptyValues(t *testing.T) {
+	t.Parallel()
+	diffs := []ComponentDiff{
+		{Component: "aws_vpc", Action: "modified", Changes: []FieldDiff{
+			{Field: "azCount", From: "", To: "2"},
+			{Field: "enableNatGateway", From: "true", To: ""},
+		}},
+	}
+	s := SummarizeChanges(diffs)
+	// azCount: nil → populated renders From as "(unset)".
+	if !strings.Contains(s, "azCount: (unset) → 2") {
+		t.Errorf("expected 'azCount: (unset) -> 2' in summary, got %q", s)
+	}
+	// enableNatGateway: populated → nil renders To as "(unset)".
+	if !strings.Contains(s, "enableNatGateway: true → (unset)") {
+		t.Errorf("expected 'enableNatGateway: true -> (unset)' in summary, got %q", s)
 	}
 }
 
@@ -997,12 +1102,30 @@ func TestMergeComponentDiffs_DemotesAddedWhenComponentAlreadyActive(t *testing.T
 	if merged[0].Component != "aws_vpc" || merged[0].Action != "modified" {
 		t.Errorf("expected {aws_vpc, modified}, got %+v", merged[0])
 	}
-	// Pin current behaviour: DiffConfigs emits no Changes on nil→non-nil,
-	// so the demoted "modified" carries no per-field detail. Follow-up
-	// #126 proposes synthesising Changes here; when that lands this
-	// assertion must be updated deliberately.
-	if len(merged[0].Changes) != 0 {
-		t.Errorf("expected no Changes on demoted diff (DiffConfigs emits none on nil→non-nil), got %+v", merged[0].Changes)
+	// Issue #126: DiffConfigs now synthesises per-field Changes on
+	// nil→non-nil by diffing against a zero-value struct, so the demoted
+	// "modified" carries the populated field detail end-to-end. Each
+	// FieldDiff must record From="" (the zero-value side) and To=<new>.
+	byField := map[string]FieldDiff{}
+	for _, c := range merged[0].Changes {
+		byField[c.Field] = c
+	}
+	for _, want := range []struct {
+		field string
+		to    string
+	}{
+		{"azCount", "2"},
+		{"enableNatGateway", "true"},
+		{"singleNatGateway", "true"},
+	} {
+		got, ok := byField[want.field]
+		if !ok {
+			t.Errorf("expected Changes to include field %q, got %+v", want.field, merged[0].Changes)
+			continue
+		}
+		if got.From != "" || got.To != want.to {
+			t.Errorf("%s: got From=%q To=%q, want From=\"\" To=%q", want.field, got.From, got.To, want.to)
+		}
 	}
 
 	summary := SummarizeChanges(merged)
@@ -1011,6 +1134,17 @@ func TestMergeComponentDiffs_DemotesAddedWhenComponentAlreadyActive(t *testing.T
 	}
 	if !strings.HasPrefix(summary, "Modified:") {
 		t.Errorf("summary should start with 'Modified:', got %q", summary)
+	}
+	// The summary must now carry per-field detail (issue #126) — a bare
+	// "Modified: aws_vpc." was the UX regression this follow-up targets.
+	// (Which specific fields land in the summary head is bounded by the
+	// 2-field truncation limit in SummarizeChanges; we just assert *some*
+	// field detail is present and the (unset) marker surfaces.)
+	if !strings.Contains(summary, "(unset) → ") {
+		t.Errorf("summary should render empty From as (unset), got %q", summary)
+	}
+	if !strings.Contains(summary, "aws_vpc (") {
+		t.Errorf("summary should carry field-level detail in parentheses, got %q", summary)
 	}
 }
 
@@ -1038,15 +1172,27 @@ func TestMergeComponentDiffs_DemotesRemovedWhenComponentStillActive(t *testing.T
 	if len(merged) != 1 || merged[0].Component != "aws_vpc" || merged[0].Action != "modified" {
 		t.Errorf("expected [{aws_vpc, modified}], got %+v", merged)
 	}
-	// Pin current behaviour (see sibling DemotesAdded test): DiffConfigs
-	// emits no Changes on non-nil→nil, so the demoted diff is field-less.
-	if len(merged[0].Changes) != 0 {
-		t.Errorf("expected no Changes on demoted diff (DiffConfigs emits none on non-nil→nil), got %+v", merged[0].Changes)
+	// Issue #126 (symmetric to DemotesAdded): DiffConfigs now diffs
+	// populated→zero to surface which fields were cleared on the demoted
+	// "modified" diff. Each FieldDiff records From=<old> and To="".
+	if len(merged[0].Changes) != 1 {
+		t.Fatalf("expected 1 Change on demoted diff, got %+v", merged[0].Changes)
+	}
+	c := merged[0].Changes[0]
+	if c.Field != "azCount" || c.From != "2" || c.To != "" {
+		t.Errorf("got %+v, want {azCount, 2, \"\"}", c)
 	}
 
 	summary := SummarizeChanges(merged)
 	if strings.HasPrefix(summary, "Removed:") {
 		t.Errorf("summary should not start with 'Removed:' for config-only clear, got %q", summary)
+	}
+	// Per #126 the summary now reports which fields were cleared.
+	if !strings.Contains(summary, "azCount") {
+		t.Errorf("summary should include azCount field detail, got %q", summary)
+	}
+	if !strings.Contains(summary, "(unset)") {
+		t.Errorf("summary should render empty To as (unset), got %q", summary)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #123 and #126.

- **#123 — core bug:** `composer.DiffConfigs` emits `Action: "added"`/`"removed"` for any `nil↔non-nil` transition of a Config sub-struct, without checking whether the corresponding Components toggle changed. When two consecutive StackVersions have identical Components but the agent populates or clears the Config sub-struct on a later turn, `change_summary` wrongly reads `"Added: aws_vpc."` (or `"Removed: ..."`) on back-to-back versions — breaking the Kiro MCP `stackversions` dump and reliable's version grid.
- **Merge-site fix:** `MergeComponentDiffs` now takes `oldComp, newComp Components` and demotes a config-origin `"added"`/`"removed"` to `"modified"` when the component is active on both sides. `DiffConfigs` stays oblivious (structs remain orthogonal).
- **#126 — field-level detail on demoted diffs:** `DiffConfigs` now populates `Changes` on `nil↔non-nil` transitions by diffing against a zero-value struct. `SummarizeChanges` routes through a new `displayFieldValue` shim that renders empty-string sides as `"(unset)"`. A demoted `"modified"` now reads `"Modified: aws_vpc (azCount: (unset) → 2, enableNatGateway: (unset) → true)."` instead of the bare `"Modified: aws_vpc."`.
- **Breaking signature change** on `MergeComponentDiffs` — the only known external caller is `luthersystems/reliable` `reconcileVersions`, which already has both Components in scope; it will get a coordinated follow-up PR.

## Test plan

- [x] `TestMergeComponentDiffs_DemotesAddedWhenComponentAlreadyActive` — verbatim reproduction from #123; after the #126 follow-up, also asserts populated `Changes` (azCount/enableNatGateway/singleNatGateway) and that the summary contains `"(unset) → "` + `"aws_vpc ("` field detail.
- [x] `TestMergeComponentDiffs_DemotesRemovedWhenComponentStillActive` — mirror, asserts `Changes: [{azCount, "2", ""}]` and summary renders `(unset)` on the cleared side.
- [x] `TestMergeComponentDiffs_DemotesAddedForBoolToggle` — `aws_rds` (`*bool`) toggle, pins the `reflect.Ptr → reflect.Bool` branch of `isComponentActive`.
- [x] Regression guards: `KeepsAddedWhenComponentNewlyEnabled`, `KeepsRemovedWhenComponentFullyRemoved`, `KeepsAddedWhenComponentInactiveOnBothSides` (latter asserts summary starts with `"Added:"`).
- [x] `TestDiffConfigs_PopulatesChangesOnNilToNonNil` / `TestDiffConfigs_PopulatesChangesOnNonNilToNil` — primary #126 regressions.
- [x] `TestSummarizeChanges_UnsetRenderedForEmptyValues` — locks the `(unset)` rendering contract.
- [x] Existing `TestDiffConfigs_ComponentAdded` / `TestDiffConfigs_ComponentRemoved` strengthened to assert the new `Changes` shape.
- [x] Six existing `TestMergeComponentDiffs_*` tests updated to pass `Components{}` args for the new signature.
- [x] `go build ./... && go vet ./... && go test -race -count=1 ./pkg/composer/...` — clean (47s).

## Follow-up

- [ ] `luthersystems/reliable` `stack_view_v2.go:reconcileVersions` needs a coordinated PR to pass the two `Components` args — without it this fix does not reach prod summaries.