### PR TITLE
refactor(composer): drop legacy Config reads from mapper (Phase 3b)

### DIFF
--- a/pkg/composer/builders_test.go
+++ b/pkg/composer/builders_test.go
@@ -76,33 +76,33 @@ func configWithAWSECS(in awsECSCfgInput) *Config {
 }
 
 // awsKitchenSinkCfgBase returns the Config fields shared by the composer
-// kitchen-sink tests. Fields use the legacy (un-prefixed) Config names
-// because Config.Normalize() promotes them to the cloud-prefixed
-// equivalents during compose.
+// kitchen-sink tests. Fields use the AWS-prefixed Config names that the
+// mapper reads directly (Phase 3b).
 func awsKitchenSinkCfgBase() *Config {
 	return &Config{
+		Cloud:  "AWS",
 		Region: "us-west-2",
-		Cloudfront: &struct {
+		AWSCloudfront: &struct {
 			DefaultTtl *string `json:"defaultTtl,omitempty"`
 			OriginPath *string `json:"originPath,omitempty"`
 			CachePaths *string `json:"cachePaths,omitempty"` // DEPRECATED: use OriginPath
 		}{DefaultTtl: ptrString("3600")},
-		SQS: &struct {
+		AWSSQS: &struct {
 			Type              string `json:"type,omitempty"`
 			VisibilityTimeout string `json:"visibilityTimeout,omitempty"`
 		}{Type: "FIFO", VisibilityTimeout: "600"},
-		CloudWatchLogs: &struct {
+		AWSCloudWatchLogs: &struct {
 			RetentionDays int `json:"retentionDays,omitempty"`
 		}{RetentionDays: 90},
 	}
 }
 
 // awsKitchenSinkCfgV2 returns the Config for TestComposeStack_V2KitchenSink.
-// RDS.ReadReplicas is deliberately unset — the test exercises the default
+// AWSRDS.ReadReplicas is deliberately unset — the test exercises the default
 // (no-read-replicas) mapper branch for that field.
 func awsKitchenSinkCfgV2() *Config {
 	cfg := awsKitchenSinkCfgBase()
-	cfg.RDS = &struct {
+	cfg.AWSRDS = &struct {
 		CPUSize      string `json:"cpuSize,omitempty"`
 		ReadReplicas string `json:"readReplicas,omitempty"`
 		StorageSize  string `json:"storageSize,omitempty"`
@@ -111,11 +111,11 @@ func awsKitchenSinkCfgV2() *Config {
 }
 
 // awsKitchenSinkCfgWithReadReplicas returns the Config for
-// TestComposeStack_KitchenSink. RDS.ReadReplicas is "2" to exercise the
-// read-replicas mapper branch (cfg.RDS.ReadReplicas != "" in mapper.go).
+// TestComposeStack_KitchenSink. AWSRDS.ReadReplicas is "2" to exercise the
+// read-replicas mapper branch (cfg.AWSRDS.ReadReplicas != "" in mapper.go).
 func awsKitchenSinkCfgWithReadReplicas() *Config {
 	cfg := awsKitchenSinkCfgBase()
-	cfg.RDS = &struct {
+	cfg.AWSRDS = &struct {
 		CPUSize      string `json:"cpuSize,omitempty"`
 		ReadReplicas string `json:"readReplicas,omitempty"`
 		StorageSize  string `json:"storageSize,omitempty"`

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -100,17 +100,11 @@ func TestMapper_OpenSearchDeploymentTypeOverride(t *testing.T) {
 			"deployment_type must track user config when Bedrock is absent")
 	})
 
-	t.Run("Normalized legacy Bedrock/OpenSearch flags still force serverless", func(t *testing.T) {
-		// Legacy Components fields must Normalize before reaching the mapper;
-		// reliable's composeradapter does this in production. After Normalize
-		// the legacy Bedrock/OpenSearch fields have been promoted to their
-		// AWS-prefixed siblings, so the mapper's V2 code path fires.
-		c := &Components{Cloud: "AWS", Bedrock: ptrBool(true), OpenSearch: ptrBool(true)}
-		c.Normalize()
-		vals, err := m.BuildModuleValues(KeyAWSOpenSearch, c, &Config{}, "demo", "us-east-1")
-		require.NoError(t, err)
-		require.Equal(t, "serverless", vals["deployment_type"])
-	})
+	// Legacy→prefixed Components migration is covered by
+	// TestComponents_Normalize_SyncsLegacyBoolFieldsForAWS (pure Normalize)
+	// and TestBuildModuleValues_IgnoresLegacyBedrockComponent (negative
+	// regression proving unnormalized comps.Bedrock doesn't fire the
+	// serverless override).
 }
 
 // TestMapper_BedrockPreviewStub locks in the preview-safe AOSS ARN stub

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -67,7 +67,7 @@ func TestMapper_OpenSearchDeploymentTypeOverride(t *testing.T) {
 			&Components{AWSBedrock: ptrBool(true), AWSOpenSearch: ptrBool(true)},
 			&Config{
 				// User asks for managed — invariant: Bedrock forces serverless.
-				OpenSearch: &struct {
+				AWSOpenSearch: &struct {
 					DeploymentType string `json:"deploymentType,omitempty"`
 					InstanceType   string `json:"instanceType,omitempty"`
 					StorageSize    string `json:"storageSize,omitempty"`
@@ -86,7 +86,7 @@ func TestMapper_OpenSearchDeploymentTypeOverride(t *testing.T) {
 			KeyAWSOpenSearch,
 			&Components{AWSOpenSearch: ptrBool(true)},
 			&Config{
-				OpenSearch: &struct {
+				AWSOpenSearch: &struct {
 					DeploymentType string `json:"deploymentType,omitempty"`
 					InstanceType   string `json:"instanceType,omitempty"`
 					StorageSize    string `json:"storageSize,omitempty"`
@@ -372,7 +372,7 @@ func TestComposeStack_BedrockOpenSearchAOSSEndToEnd(t *testing.T) {
 		},
 		Cfg: &Config{
 			// User requests managed — composer must force serverless.
-			OpenSearch: &struct {
+			AWSOpenSearch: &struct {
 				DeploymentType string `json:"deploymentType,omitempty"`
 				InstanceType   string `json:"instanceType,omitempty"`
 				StorageSize    string `json:"storageSize,omitempty"`

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -2084,10 +2084,10 @@ func TestComposeSingle_RejectsLegacyKey(t *testing.T) {
 // that ComposeStack (and ComposeSingle) call Config.Normalize() at entry.
 // Phase 3b dropped the mapper's legacy-field reads, so this invariant is
 // what keeps direct Go callers who build a Config with legacy field names
-// (e.g. `cfg.CloudWatchLogs`) working end-to-end. If someone deletes the
-// Normalize() call at compose.go:98 or compose.go:249, the kitchen-sink
-// tests (which populate prefixed fields directly) will still pass — but
-// this test will fail loudly.
+// (e.g. `cfg.CloudWatchLogs`) working end-to-end. If the Normalize() call
+// inside ComposeStack/ComposeSingle is removed, the kitchen-sink tests
+// (which populate prefixed fields directly) will still pass — but this
+// test will fail loudly.
 func TestComposeStack_NormalizesLegacyConfig(t *testing.T) {
 	c := newTestClient()
 

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -2080,6 +2080,69 @@ func TestComposeSingle_RejectsLegacyKey(t *testing.T) {
 		"error must carry the upgrade pair")
 }
 
+// TestComposeStack_NormalizesLegacyConfig pins the load-bearing contract
+// that ComposeStack (and ComposeSingle) call Config.Normalize() at entry.
+// Phase 3b dropped the mapper's legacy-field reads, so this invariant is
+// what keeps direct Go callers who build a Config with legacy field names
+// (e.g. `cfg.CloudWatchLogs`) working end-to-end. If someone deletes the
+// Normalize() call at compose.go:98 or compose.go:249, the kitchen-sink
+// tests (which populate prefixed fields directly) will still pass — but
+// this test will fail loudly.
+func TestComposeStack_NormalizesLegacyConfig(t *testing.T) {
+	c := newTestClient()
+
+	// Legacy Config field populated; AWSCloudWatchLogs left nil. A correct
+	// ComposeStack must call Normalize first so the legacy value reaches
+	// the mapper via its AWS-prefixed sibling.
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSCloudWatchLogs},
+		Comps:        &Components{Cloud: "AWS", AWSCloudWatchLogs: ptrBool(true)},
+		Cfg: &Config{
+			Cloud:  "AWS",
+			Region: "us-east-1",
+			CloudWatchLogs: &struct {
+				RetentionDays int `json:"retentionDays,omitempty"`
+			}{RetentionDays: 180},
+		},
+		Project: "test",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err)
+
+	tfvars := string(out["/aws_cloudwatch_logs.auto.tfvars"])
+	require.Contains(t, tfvars, "aws_cloudwatch_logs_retention_in_days = 180",
+		"legacy cfg.CloudWatchLogs.RetentionDays must be promoted by "+
+			"Config.Normalize during ComposeStack and flow through to the mapper output")
+}
+
+// TestComposeSingle_NormalizesLegacyConfig mirrors the ComposeStack test
+// above for the single-module entry point.
+func TestComposeSingle_NormalizesLegacyConfig(t *testing.T) {
+	c := newTestClient()
+
+	out, err := c.ComposeSingle(ComposeSingleOpts{
+		Cloud: "aws",
+		Key:   KeyAWSCloudWatchLogs,
+		Comps: &Components{Cloud: "AWS", AWSCloudWatchLogs: ptrBool(true)},
+		Cfg: &Config{
+			Cloud:  "AWS",
+			Region: "us-east-1",
+			CloudWatchLogs: &struct {
+				RetentionDays int `json:"retentionDays,omitempty"`
+			}{RetentionDays: 180},
+		},
+		Project: "test",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err)
+
+	tfvars := string(out["/aws_cloudwatch_logs.auto.tfvars"])
+	require.Contains(t, tfvars, "aws_cloudwatch_logs_retention_in_days = 180",
+		"legacy cfg.CloudWatchLogs.RetentionDays must flow through via "+
+			"Config.Normalize in ComposeSingle and reach the preset tfvars")
+}
+
 // TestComposeStack_PolymorphicKeyPullsInPrefixedVPC is a regression test for
 // the implicit-dependency leak where ResolveDependencies expanded a
 // polymorphic key to its legacy VPC sibling. A direct Go caller passing only

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -208,24 +208,24 @@ func (m DefaultMapper) BuildModuleValues(
 		}
 
 		// Use EKS config if available
-		if cfg != nil && cfg.Eks != nil {
-			if cfg.Eks.DesiredSize != "" {
-				if n, err := strconv.Atoi(cfg.Eks.DesiredSize); err == nil {
+		if cfg != nil && cfg.AWSEKS != nil {
+			if cfg.AWSEKS.DesiredSize != "" {
+				if n, err := strconv.Atoi(cfg.AWSEKS.DesiredSize); err == nil {
 					vals["desired_size"] = n
 				}
 			}
-			if cfg.Eks.MinSize != "" {
-				if n, err := strconv.Atoi(cfg.Eks.MinSize); err == nil {
+			if cfg.AWSEKS.MinSize != "" {
+				if n, err := strconv.Atoi(cfg.AWSEKS.MinSize); err == nil {
 					vals["min_size"] = n
 				}
 			}
-			if cfg.Eks.MaxSize != "" {
-				if n, err := strconv.Atoi(cfg.Eks.MaxSize); err == nil {
+			if cfg.AWSEKS.MaxSize != "" {
+				if n, err := strconv.Atoi(cfg.AWSEKS.MaxSize); err == nil {
 					vals["max_size"] = n
 				}
 			}
-			if cfg.Eks.InstanceType != "" {
-				vals["instance_types"] = []any{cfg.Eks.InstanceType}
+			if cfg.AWSEKS.InstanceType != "" {
+				vals["instance_types"] = []any{cfg.AWSEKS.InstanceType}
 			}
 		}
 
@@ -329,131 +329,121 @@ func (m DefaultMapper) BuildModuleValues(
 			vals["subnet_ids"] = []any{}
 		}
 		// Mirror RDS config if provided
-		if cfg != nil && cfg.RDS != nil {
-			if cfg.RDS.CPUSize != "" {
-				vals["node_cpu_size"] = cfg.RDS.CPUSize
+		if cfg != nil && cfg.AWSRDS != nil {
+			if cfg.AWSRDS.CPUSize != "" {
+				vals["node_cpu_size"] = cfg.AWSRDS.CPUSize
 			}
-			if cfg.RDS.ReadReplicas != "" {
-				vals["num_read_nodes"] = cfg.RDS.ReadReplicas
+			if cfg.AWSRDS.ReadReplicas != "" {
+				vals["num_read_nodes"] = cfg.AWSRDS.ReadReplicas
 			}
-			if cfg.RDS.StorageSize != "" {
-				vals["storage_size"] = cfg.RDS.StorageSize
+			if cfg.AWSRDS.StorageSize != "" {
+				vals["storage_size"] = cfg.AWSRDS.StorageSize
 			}
 		}
 
 	case KeyAWSCloudfront:
-		if cfg != nil && cfg.Cloudfront != nil {
-			if cfg.Cloudfront.DefaultTtl != nil && *cfg.Cloudfront.DefaultTtl != "" {
-				vals["default_ttl"] = *cfg.Cloudfront.DefaultTtl
+		if cfg != nil && cfg.AWSCloudfront != nil {
+			if cfg.AWSCloudfront.DefaultTtl != nil && *cfg.AWSCloudfront.DefaultTtl != "" {
+				vals["default_ttl"] = *cfg.AWSCloudfront.DefaultTtl
 			}
-			if cfg.Cloudfront.OriginPath != nil && *cfg.Cloudfront.OriginPath != "" {
-				vals["origin_path"] = *cfg.Cloudfront.OriginPath
-			} else if cfg.Cloudfront.CachePaths != nil && *cfg.Cloudfront.CachePaths != "" {
-				vals["origin_path"] = *cfg.Cloudfront.CachePaths
+			if cfg.AWSCloudfront.OriginPath != nil && *cfg.AWSCloudfront.OriginPath != "" {
+				vals["origin_path"] = *cfg.AWSCloudfront.OriginPath
 			}
 		}
 
 	case KeyAWSElastiCache:
-		if cfg != nil && cfg.ElastiCache != nil {
-			if cfg.ElastiCache.HA != nil {
-				vals["ha"] = *cfg.ElastiCache.HA
+		if cfg != nil && cfg.AWSElastiCache != nil {
+			if cfg.AWSElastiCache.HA != nil {
+				vals["ha"] = *cfg.AWSElastiCache.HA
 			}
-			if cfg.ElastiCache.NodeSize != "" {
-				vals["node_size"] = cfg.ElastiCache.NodeSize
+			if cfg.AWSElastiCache.NodeSize != "" {
+				vals["node_size"] = cfg.AWSElastiCache.NodeSize
 			}
-			if cfg.ElastiCache.Storage != "" {
-				vals["storage_size"] = cfg.ElastiCache.Storage
+			if cfg.AWSElastiCache.Storage != "" {
+				vals["storage_size"] = cfg.AWSElastiCache.Storage
 			}
-			if cfg.ElastiCache.Replicas != "" {
-				vals["replicas"] = cfg.ElastiCache.Replicas
+			if cfg.AWSElastiCache.Replicas != "" {
+				vals["replicas"] = cfg.AWSElastiCache.Replicas
 			}
 		}
 
 	case KeyAWSS3:
-		if cfg != nil && cfg.S3 != nil && cfg.S3.Versioning != nil {
-			vals["versioning"] = *cfg.S3.Versioning
+		if cfg != nil && cfg.AWSS3 != nil && cfg.AWSS3.Versioning != nil {
+			vals["versioning"] = *cfg.AWSS3.Versioning
 		}
 
 	case KeyAWSDynamoDB:
-		if cfg != nil && cfg.DynamoDB != nil && cfg.DynamoDB.Type != "" {
-			vals["billing_mode"] = strings.ToLower(cfg.DynamoDB.Type) // "on demand" | "provisioned"
+		if cfg != nil && cfg.AWSDynamoDB != nil && cfg.AWSDynamoDB.Type != "" {
+			vals["billing_mode"] = strings.ToLower(cfg.AWSDynamoDB.Type) // "on demand" | "provisioned"
 		}
 
 	case KeyAWSSQS:
-		if cfg != nil && cfg.SQS != nil {
-			if cfg.SQS.Type != "" {
-				vals["type"] = cfg.SQS.Type // "Standard" | "FIFO"
+		if cfg != nil && cfg.AWSSQS != nil {
+			if cfg.AWSSQS.Type != "" {
+				vals["type"] = cfg.AWSSQS.Type // "Standard" | "FIFO"
 			}
-			if cfg.SQS.VisibilityTimeout != "" {
-				vals["visibility_timeout"] = cfg.SQS.VisibilityTimeout
+			if cfg.AWSSQS.VisibilityTimeout != "" {
+				vals["visibility_timeout"] = cfg.AWSSQS.VisibilityTimeout
 			}
 		}
 
 	case KeyAWSMSK:
-		if cfg != nil && cfg.MSK != nil && cfg.MSK.Retention != "" {
-			vals["retention_period"] = cfg.MSK.Retention
+		if cfg != nil && cfg.AWSMSK != nil && cfg.AWSMSK.Retention != "" {
+			vals["retention_period"] = cfg.AWSMSK.Retention
 		}
 
 	case KeyAWSCloudWatchLogs:
-		retDays := 0
-		if cfg != nil {
-			if cfg.CloudWatchLogs != nil && cfg.CloudWatchLogs.RetentionDays > 0 {
-				retDays = cfg.CloudWatchLogs.RetentionDays
-			} else if cfg.AWSCloudWatchLogs != nil && cfg.AWSCloudWatchLogs.RetentionDays > 0 {
-				retDays = cfg.AWSCloudWatchLogs.RetentionDays
-			}
-		}
-		if retDays > 0 {
-			vals["retention_in_days"] = retDays
+		if cfg != nil && cfg.AWSCloudWatchLogs != nil && cfg.AWSCloudWatchLogs.RetentionDays > 0 {
+			vals["retention_in_days"] = cfg.AWSCloudWatchLogs.RetentionDays
 		}
 
 	case KeyAWSCognito:
-		if cfg != nil && cfg.Cognito != nil {
-			if cfg.Cognito.SignInType != "" {
-				vals["sign_in_type"] = cfg.Cognito.SignInType
+		if cfg != nil && cfg.AWSCognito != nil {
+			if cfg.AWSCognito.SignInType != "" {
+				vals["sign_in_type"] = cfg.AWSCognito.SignInType
 			}
-			if cfg.Cognito.MFARequired != nil {
-				vals["mfa_required"] = *cfg.Cognito.MFARequired
+			if cfg.AWSCognito.MFARequired != nil {
+				vals["mfa_required"] = *cfg.AWSCognito.MFARequired
 			}
 		}
 
 	case KeyAWSAPIGateway:
-		if cfg != nil && cfg.APIGateway != nil {
-			if cfg.APIGateway.DomainName != "" {
-				vals["domain_name"] = cfg.APIGateway.DomainName
+		if cfg != nil && cfg.AWSAPIGateway != nil {
+			if cfg.AWSAPIGateway.DomainName != "" {
+				vals["domain_name"] = cfg.AWSAPIGateway.DomainName
 			}
-			if cfg.APIGateway.CertificateArn != "" {
-				vals["certificate_arn"] = cfg.APIGateway.CertificateArn
+			if cfg.AWSAPIGateway.CertificateArn != "" {
+				vals["certificate_arn"] = cfg.AWSAPIGateway.CertificateArn
 			}
 		}
 
 	case KeyAWSKMS:
-		if cfg != nil && cfg.KMS != nil && cfg.KMS.NumKeys != "" {
-			if n, err := strconv.Atoi(cfg.KMS.NumKeys); err == nil {
+		if cfg != nil && cfg.AWSKMS != nil && cfg.AWSKMS.NumKeys != "" {
+			if n, err := strconv.Atoi(cfg.AWSKMS.NumKeys); err == nil {
 				vals["num_keys"] = n
 			}
 		}
 
 	case KeyAWSSecretsManager:
-		if cfg != nil && cfg.SecretsManager != nil && cfg.SecretsManager.NumSecrets != "" {
-			if n, err := strconv.Atoi(cfg.SecretsManager.NumSecrets); err == nil {
+		if cfg != nil && cfg.AWSSecretsManager != nil && cfg.AWSSecretsManager.NumSecrets != "" {
+			if n, err := strconv.Atoi(cfg.AWSSecretsManager.NumSecrets); err == nil {
 				vals["num_secrets"] = n
 			}
 		}
 
 	case KeyAWSOpenSearch:
-		if cfg != nil && cfg.OpenSearch != nil {
-			if cfg.OpenSearch.DeploymentType != "" {
-				vals["deployment_type"] = strings.ToLower(cfg.OpenSearch.DeploymentType)
+		if cfg != nil && cfg.AWSOpenSearch != nil {
+			if cfg.AWSOpenSearch.DeploymentType != "" {
+				vals["deployment_type"] = strings.ToLower(cfg.AWSOpenSearch.DeploymentType)
 			}
-			if cfg.OpenSearch.InstanceType != "" {
-				vals["instance_type"] = cfg.OpenSearch.InstanceType
+			if cfg.AWSOpenSearch.InstanceType != "" {
+				vals["instance_type"] = cfg.AWSOpenSearch.InstanceType
 			}
-			if cfg.OpenSearch.StorageSize != "" {
-				vals["storage_size"] = cfg.OpenSearch.StorageSize
+			if cfg.AWSOpenSearch.StorageSize != "" {
+				vals["storage_size"] = cfg.AWSOpenSearch.StorageSize
 			}
-			if cfg.OpenSearch.MultiAZ != nil {
-				vals["multi_az"] = *cfg.OpenSearch.MultiAZ
+			if cfg.AWSOpenSearch.MultiAZ != nil {
+				vals["multi_az"] = *cfg.AWSOpenSearch.MultiAZ
 			}
 		}
 		// Bedrock KB only supports OpenSearch Serverless (AOSS). Managed
@@ -462,7 +452,7 @@ func (m DefaultMapper) BuildModuleValues(
 		// regardless of what the user requested. Data-access policies and
 		// the vector index are an application-layer concern and are
 		// intentionally outside the preset's scope.
-		if boolPtrTrue(comps.Bedrock) || boolPtrTrue(comps.AWSBedrock) {
+		if boolPtrTrue(comps.AWSBedrock) {
 			vals["deployment_type"] = "serverless"
 		}
 		// Preview-safe stubs
@@ -474,15 +464,15 @@ func (m DefaultMapper) BuildModuleValues(
 		}
 
 	case KeyAWSBedrock:
-		if cfg != nil && cfg.Bedrock != nil {
-			if cfg.Bedrock.KnowledgeBaseName != "" {
-				vals["knowledge_base_name"] = cfg.Bedrock.KnowledgeBaseName
+		if cfg != nil && cfg.AWSBedrock != nil {
+			if cfg.AWSBedrock.KnowledgeBaseName != "" {
+				vals["knowledge_base_name"] = cfg.AWSBedrock.KnowledgeBaseName
 			}
-			if cfg.Bedrock.ModelID != "" {
-				vals["model_id"] = cfg.Bedrock.ModelID
+			if cfg.AWSBedrock.ModelID != "" {
+				vals["model_id"] = cfg.AWSBedrock.ModelID
 			}
-			if cfg.Bedrock.EmbeddingModelID != "" {
-				vals["embedding_model_id"] = cfg.Bedrock.EmbeddingModelID
+			if cfg.AWSBedrock.EmbeddingModelID != "" {
+				vals["embedding_model_id"] = cfg.AWSBedrock.EmbeddingModelID
 			}
 		}
 		// In stacks, wiring supplies s3_bucket_arn and opensearch_collection_arn.
@@ -501,18 +491,18 @@ func (m DefaultMapper) BuildModuleValues(
 
 	case KeyAWSLambda:
 		vals["runtime"] = "nodejs20.x" // Default to nodejs
-		if cfg != nil && cfg.Lambda != nil {
-			if cfg.Lambda.Runtime != "" {
-				vals["runtime"] = cfg.Lambda.Runtime
+		if cfg != nil && cfg.AWSLambda != nil {
+			if cfg.AWSLambda.Runtime != "" {
+				vals["runtime"] = cfg.AWSLambda.Runtime
 			}
-			if cfg.Lambda.MemorySize != "" {
-				if n, err := strconv.Atoi(cfg.Lambda.MemorySize); err == nil {
+			if cfg.AWSLambda.MemorySize != "" {
+				if n, err := strconv.Atoi(cfg.AWSLambda.MemorySize); err == nil {
 					vals["memory_size"] = n
 				}
 			}
-			if cfg.Lambda.Timeout != "" {
+			if cfg.AWSLambda.Timeout != "" {
 				// Convert "3s", "30s", "15m" to seconds
-				t := cfg.Lambda.Timeout
+				t := cfg.AWSLambda.Timeout
 				if trimmed, ok := strings.CutSuffix(t, "s"); ok {
 					if n, err := strconv.Atoi(trimmed); err == nil {
 						vals["timeout"] = n
@@ -545,35 +535,36 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
-		// Only consider details for services that are actually enabled, if we know them.
+		// Only consider details for services that are actually enabled.
 		// Legacy sessions must Normalize before reaching BuildModuleValues;
 		// reliable's composeradapter does this for us in production.
-		enabled := map[string]bool{}
-		if comps != nil && comps.AWSBackups != nil {
-			enabled["ec2"] = boolVal(comps.AWSBackups.EC2)
-			enabled["rds"] = boolVal(comps.AWSBackups.RDS)
-			enabled["elasticache"] = boolVal(comps.AWSBackups.ElastiCache)
-			enabled["dynamodb"] = boolVal(comps.AWSBackups.DynamoDB)
-			enabled["s3"] = boolVal(comps.AWSBackups.S3)
+		considerDetail := func(freqHours, retentionDays int) {
+			if freqHours > 0 {
+				if r := rank(freqHours); r > bestRank {
+					bestRank = r
+					bestFreq = freqHours
+				}
+			}
+			if retentionDays > maxRetention {
+				maxRetention = retentionDays
+			}
 		}
 
-		if cfg != nil && cfg.Backups != nil {
-			for svc, det := range cfg.Backups.Details {
-				// svc keys expected like "ec2Ebs", "rds", "dynamodb", "s3"
-				if on, ok := enabled[svc]; ok && !on {
-					continue
-				}
-				if det.FrequencyHours > 0 {
-					if r := rank(det.FrequencyHours); r > bestRank {
-						bestRank = r
-						bestFreq = det.FrequencyHours
-					}
-				}
-				if det.RetentionDays > 0 {
-					if det.RetentionDays > maxRetention {
-						maxRetention = det.RetentionDays
-					}
-				}
+		if cfg != nil && cfg.AWSBackups != nil && comps != nil && comps.AWSBackups != nil {
+			if boolVal(comps.AWSBackups.EC2) && cfg.AWSBackups.EC2 != nil {
+				considerDetail(cfg.AWSBackups.EC2.FrequencyHours, cfg.AWSBackups.EC2.RetentionDays)
+			}
+			if boolVal(comps.AWSBackups.RDS) && cfg.AWSBackups.RDS != nil {
+				considerDetail(cfg.AWSBackups.RDS.FrequencyHours, cfg.AWSBackups.RDS.RetentionDays)
+			}
+			if boolVal(comps.AWSBackups.ElastiCache) && cfg.AWSBackups.ElastiCache != nil {
+				considerDetail(cfg.AWSBackups.ElastiCache.FrequencyHours, cfg.AWSBackups.ElastiCache.RetentionDays)
+			}
+			if boolVal(comps.AWSBackups.DynamoDB) && cfg.AWSBackups.DynamoDB != nil {
+				considerDetail(cfg.AWSBackups.DynamoDB.FrequencyHours, cfg.AWSBackups.DynamoDB.RetentionDays)
+			}
+			if boolVal(comps.AWSBackups.S3) && cfg.AWSBackups.S3 != nil {
+				considerDetail(cfg.AWSBackups.S3.FrequencyHours, cfg.AWSBackups.S3.RetentionDays)
 			}
 		}
 

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -538,6 +538,12 @@ func (m DefaultMapper) BuildModuleValues(
 		// Only consider details for services that are actually enabled.
 		// Legacy sessions must Normalize before reaching BuildModuleValues;
 		// reliable's composeradapter does this for us in production.
+		//
+		// Both comps.AWSBackups and cfg.AWSBackups gates are required: if
+		// no AWSBackups service bool is true there's nothing to back up,
+		// so any cfg details must be ignored (fail-closed). The pre-Phase
+		// 3b map-iteration fell through when comps.AWSBackups was nil,
+		// which was fail-open.
 		considerDetail := func(freqHours, retentionDays int) {
 			if freqHours > 0 {
 				if r := rank(freqHours); r > bestRank {

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -401,7 +401,7 @@ func TestBuildModuleValues_CloudWatchLogs_Retention(t *testing.T) {
 		assert.Equal(t, 90, vals["retention_in_days"])
 	})
 
-	t.Run("365 days retention", func(t *testing.T) {
+	t.Run("AWSCloudWatchLogs RetentionDays maps to retention_in_days", func(t *testing.T) {
 		cfg := &Config{
 			AWSCloudWatchLogs: &struct {
 				RetentionDays int `json:"retentionDays,omitempty"`
@@ -656,6 +656,9 @@ func TestBuildModuleValues_AWSEC2_CpuArchPrecedence(t *testing.T) {
 // mapping. Previously the kitchen-sink integration test exercised these
 // branches but asserted nothing on the mapper output; the fixture rename
 // in #122 (`awsKitchenSinkCfgWithReadReplicas`) made the gap visible.
+// Legacy→prefixed RDS migration is covered by types/Normalize tests and
+// TestComposeSingle_NormalizesLegacyConfig (integration at the compose
+// boundary); this mapper test reads AWS-prefixed fields only.
 func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 	m := DefaultMapper{}
 
@@ -693,10 +696,6 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 		assert.Equal(t, "db.m7i.2xlarge", vals["node_cpu_size"])
 		assert.Equal(t, "20", vals["storage_size"])
 	})
-
-	// Legacy→prefixed RDS migration is covered by types/Normalize tests and
-	// TestComposeSingle_NormalizesLegacyConfig (integration at the compose
-	// boundary). This mapper test reads AWS-prefixed fields only.
 }
 
 // TestBuildModuleValues_IgnoresUnnormalizedLegacyConfig pins the Phase 3b
@@ -718,21 +717,6 @@ func TestBuildModuleValues_IgnoresUnnormalizedLegacyConfig(t *testing.T) {
 		// the legacy Config field this test populates.
 		missing string
 	}{
-		{
-			name: "legacy Eks ignored without Normalize",
-			key:  KeyEC2, // EKS managed node group arm reads cfg.AWSEKS
-			cfg: &Config{Eks: &struct {
-				HaControlPlane         *bool  `json:"haControlPlane,omitempty"`
-				ControlPlaneVisibility string `json:"controlPlaneVisibility,omitempty"`
-				DesiredSize            string `json:"desiredSize,omitempty"`
-				MaxSize                string `json:"maxSize,omitempty"`
-				MinSize                string `json:"minSize,omitempty"`
-				InstanceType           string `json:"instanceType,omitempty"`
-			}{DesiredSize: "9"}},
-			// Mapper falls back to default 3 when AWSEKS is absent; the
-			// legacy field must not bleed through.
-			missing: "", // handled specially below
-		},
 		{
 			name: "legacy RDS ignored without Normalize",
 			key:  KeyAWSRDS,
@@ -893,18 +877,33 @@ func TestBuildModuleValues_IgnoresUnnormalizedLegacyConfig(t *testing.T) {
 			}
 			vals, err := m.BuildModuleValues(tc.key, comps, tc.cfg, "", "")
 			require.NoError(t, err)
-			if tc.missing == "" {
-				// EKS node-group arm: cfg.AWSEKS absent → desired_size default 3
-				assert.Equal(t, 3, vals["desired_size"],
-					"legacy Eks.DesiredSize must not reach mapper output; default 3 should apply")
-				return
-			}
 			_, present := vals[tc.missing]
 			assert.False(t, present,
 				"legacy Config field without Normalize must not produce %q in mapper output",
 				tc.missing)
 		})
 	}
+}
+
+// TestBuildModuleValues_IgnoresUnnormalizedLegacyEksConfig pins the Phase
+// 3b invariant for the EKS node-group arm: unnormalized legacy cfg.Eks is
+// invisible to the mapper, which falls back to its default desired_size.
+// Separate test (not part of the table above) because this arm asserts a
+// positive default rather than the absence of a key.
+func TestBuildModuleValues_IgnoresUnnormalizedLegacyEksConfig(t *testing.T) {
+	m := DefaultMapper{}
+	cfg := &Config{Eks: &struct {
+		HaControlPlane         *bool  `json:"haControlPlane,omitempty"`
+		ControlPlaneVisibility string `json:"controlPlaneVisibility,omitempty"`
+		DesiredSize            string `json:"desiredSize,omitempty"`
+		MaxSize                string `json:"maxSize,omitempty"`
+		MinSize                string `json:"minSize,omitempty"`
+		InstanceType           string `json:"instanceType,omitempty"`
+	}{DesiredSize: "9"}}
+	vals, err := m.BuildModuleValues(KeyEC2, &Components{}, cfg, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, 3, vals["desired_size"],
+		"legacy Eks.DesiredSize must not reach mapper output; default 3 should apply")
 }
 
 // TestBuildModuleValues_IgnoresLegacyBedrockComponent pins the Phase 3b

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -401,19 +401,14 @@ func TestBuildModuleValues_CloudWatchLogs_Retention(t *testing.T) {
 		assert.Equal(t, 90, vals["retention_in_days"])
 	})
 
-	t.Run("legacy CloudWatchLogs config after Normalize is also used", func(t *testing.T) {
-		// Phase 3b: the mapper reads AWSCloudWatchLogs only. Legacy callers
-		// must Normalize() first; reliable's composeradapter does this in
-		// production.
+	t.Run("365 days retention", func(t *testing.T) {
 		cfg := &Config{
-			Cloud: "AWS",
-			CloudWatchLogs: &struct {
+			AWSCloudWatchLogs: &struct {
 				RetentionDays int `json:"retentionDays,omitempty"`
 			}{
 				RetentionDays: 365,
 			},
 		}
-		cfg.Normalize()
 		vals, err := m.BuildModuleValues(KeyAWSCloudWatchLogs, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, 365, vals["retention_in_days"])
@@ -451,41 +446,30 @@ func TestBuildModuleValues_Cloudfront_OriginPath(t *testing.T) {
 		assert.Equal(t, "/assets", vals["origin_path"])
 	})
 
-	t.Run("deprecated cachePaths falls back to origin_path via Normalize", func(t *testing.T) {
-		// Phase 3b: the mapper reads AWSCloudfront.OriginPath only.
-		// Config.Normalize migrates the deprecated CachePaths → OriginPath.
-		path := "/legacy"
+	t.Run("defaultTtl maps to default_ttl", func(t *testing.T) {
+		ttl := "3600"
 		cfg := &Config{
-			Cloud: "AWS",
 			AWSCloudfront: &struct {
 				DefaultTtl *string `json:"defaultTtl,omitempty"`
 				OriginPath *string `json:"originPath,omitempty"`
 				CachePaths *string `json:"cachePaths,omitempty"`
-			}{CachePaths: &path},
+			}{DefaultTtl: &ttl},
 		}
-		cfg.Normalize()
 		vals, err := m.BuildModuleValues(KeyAWSCloudfront, nil, cfg, "", "")
 		require.NoError(t, err)
-		assert.Equal(t, "/legacy", vals["origin_path"])
-	})
-
-	t.Run("originPath takes precedence over cachePaths", func(t *testing.T) {
-		newPath := "/new"
-		oldPath := "/old"
-		cfg := &Config{
-			Cloud: "AWS",
-			AWSCloudfront: &struct {
-				DefaultTtl *string `json:"defaultTtl,omitempty"`
-				OriginPath *string `json:"originPath,omitempty"`
-				CachePaths *string `json:"cachePaths,omitempty"`
-			}{OriginPath: &newPath, CachePaths: &oldPath},
-		}
-		cfg.Normalize()
-		vals, err := m.BuildModuleValues(KeyAWSCloudfront, nil, cfg, "", "")
-		require.NoError(t, err)
-		assert.Equal(t, "/new", vals["origin_path"])
+		assert.Equal(t, "3600", vals["default_ttl"])
 	})
 }
+
+// Legacy→prefixed migration of the AWSCloudfront.CachePaths deprecation
+// and related sub-config field moves is covered by
+// TestConfig_Normalize_CachePathsMigration (pure Normalize) and
+// TestComposeStack_NormalizesLegacyConfig (integration at the compose
+// boundary). The mapper now only reads AWS-prefixed Config fields, so
+// mapper-level coverage is above (direct AWSCloudfront/AWSCloudWatchLogs
+// etc. reads) and in
+// TestBuildModuleValues_IgnoresUnnormalizedLegacyConfig (negative
+// regression).
 
 func TestConfig_Normalize_CachePathsMigration(t *testing.T) {
 	t.Run("legacy Cloudfront CachePaths migrates to AWSCloudfront OriginPath", func(t *testing.T) {
@@ -710,25 +694,9 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 		assert.Equal(t, "20", vals["storage_size"])
 	})
 
-	t.Run("legacy RDS config after Normalize is migrated", func(t *testing.T) {
-		// Phase 3b: the mapper reads AWSRDS only. Legacy callers must
-		// Normalize() first; reliable's composeradapter does this in
-		// production.
-		cfg := &Config{
-			Cloud: "AWS",
-			RDS: &struct {
-				CPUSize      string `json:"cpuSize,omitempty"`
-				ReadReplicas string `json:"readReplicas,omitempty"`
-				StorageSize  string `json:"storageSize,omitempty"`
-			}{CPUSize: "db.m7i.2xlarge", ReadReplicas: "1", StorageSize: "50"},
-		}
-		cfg.Normalize()
-		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, cfg, "", "")
-		require.NoError(t, err)
-		assert.Equal(t, "db.m7i.2xlarge", vals["node_cpu_size"])
-		assert.Equal(t, "1", vals["num_read_nodes"])
-		assert.Equal(t, "50", vals["storage_size"])
-	})
+	// Legacy→prefixed RDS migration is covered by types/Normalize tests and
+	// TestComposeSingle_NormalizesLegacyConfig (integration at the compose
+	// boundary). This mapper test reads AWS-prefixed fields only.
 }
 
 // TestBuildModuleValues_IgnoresUnnormalizedLegacyConfig pins the Phase 3b
@@ -736,6 +704,9 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 // supplied without a prior Normalize() call are invisible. The downstream
 // contract is that callers (reliable's composeradapter in production, the
 // ComposeStack/ComposeSingle entry points elsewhere) always Normalize first.
+//
+// Table covers every migrated legacy Config field so a regression that
+// re-introduces `cfg.Foo` reads in a single arm fails loudly.
 func TestBuildModuleValues_IgnoresUnnormalizedLegacyConfig(t *testing.T) {
 	m := DefaultMapper{}
 
@@ -748,14 +719,90 @@ func TestBuildModuleValues_IgnoresUnnormalizedLegacyConfig(t *testing.T) {
 		missing string
 	}{
 		{
+			name: "legacy Eks ignored without Normalize",
+			key:  KeyEC2, // EKS managed node group arm reads cfg.AWSEKS
+			cfg: &Config{Eks: &struct {
+				HaControlPlane         *bool  `json:"haControlPlane,omitempty"`
+				ControlPlaneVisibility string `json:"controlPlaneVisibility,omitempty"`
+				DesiredSize            string `json:"desiredSize,omitempty"`
+				MaxSize                string `json:"maxSize,omitempty"`
+				MinSize                string `json:"minSize,omitempty"`
+				InstanceType           string `json:"instanceType,omitempty"`
+			}{DesiredSize: "9"}},
+			// Mapper falls back to default 3 when AWSEKS is absent; the
+			// legacy field must not bleed through.
+			missing: "", // handled specially below
+		},
+		{
 			name: "legacy RDS ignored without Normalize",
 			key:  KeyAWSRDS,
 			cfg: &Config{RDS: &struct {
 				CPUSize      string `json:"cpuSize,omitempty"`
 				ReadReplicas string `json:"readReplicas,omitempty"`
 				StorageSize  string `json:"storageSize,omitempty"`
-			}{CPUSize: "db.m7i.2xlarge"}},
+			}{CPUSize: "db.m7i.2xlarge", ReadReplicas: "3", StorageSize: "100"}},
 			missing: "node_cpu_size",
+		},
+		{
+			name: "legacy Cloudfront ignored without Normalize",
+			key:  KeyAWSCloudfront,
+			cfg: func() *Config {
+				ttl := "3600"
+				path := "/legacy"
+				return &Config{Cloudfront: &struct {
+					DefaultTtl *string `json:"defaultTtl,omitempty"`
+					OriginPath *string `json:"originPath,omitempty"`
+					CachePaths *string `json:"cachePaths,omitempty"`
+				}{DefaultTtl: &ttl, OriginPath: &path}}
+			}(),
+			missing: "origin_path",
+		},
+		{
+			name: "legacy ElastiCache ignored without Normalize",
+			key:  KeyAWSElastiCache,
+			cfg: &Config{ElastiCache: &struct {
+				HA       *bool  `json:"ha,omitempty"`
+				Storage  string `json:"storageSize,omitempty"`
+				NodeSize string `json:"nodeSize,omitempty"`
+				Replicas string `json:"replicas,omitempty"`
+			}{NodeSize: "cache.m5.large"}},
+			missing: "node_size",
+		},
+		{
+			name: "legacy S3 ignored without Normalize",
+			key:  KeyAWSS3,
+			cfg: func() *Config {
+				v := true
+				return &Config{S3: &struct {
+					Versioning *bool `json:"versioning,omitempty"`
+				}{Versioning: &v}}
+			}(),
+			missing: "versioning",
+		},
+		{
+			name: "legacy DynamoDB ignored without Normalize",
+			key:  KeyAWSDynamoDB,
+			cfg: &Config{DynamoDB: &struct {
+				Type string `json:"type,omitempty"`
+			}{Type: "On Demand"}},
+			missing: "billing_mode",
+		},
+		{
+			name: "legacy SQS ignored without Normalize",
+			key:  KeyAWSSQS,
+			cfg: &Config{SQS: &struct {
+				Type              string `json:"type,omitempty"`
+				VisibilityTimeout string `json:"visibilityTimeout,omitempty"`
+			}{Type: "FIFO", VisibilityTimeout: "600"}},
+			missing: "type",
+		},
+		{
+			name: "legacy MSK ignored without Normalize",
+			key:  KeyAWSMSK,
+			cfg: &Config{MSK: &struct {
+				Retention string `json:"retentionPeriod,omitempty"`
+			}{Retention: "168"}},
+			missing: "retention_period",
 		},
 		{
 			name: "legacy CloudWatchLogs ignored without Normalize",
@@ -766,23 +813,324 @@ func TestBuildModuleValues_IgnoresUnnormalizedLegacyConfig(t *testing.T) {
 			missing: "retention_in_days",
 		},
 		{
-			name: "legacy SQS ignored without Normalize",
-			key:  KeyAWSSQS,
-			cfg: &Config{SQS: &struct {
-				Type              string `json:"type,omitempty"`
-				VisibilityTimeout string `json:"visibilityTimeout,omitempty"`
-			}{Type: "FIFO"}},
-			missing: "type",
+			name: "legacy Cognito ignored without Normalize",
+			key:  KeyAWSCognito,
+			cfg: &Config{Cognito: &struct {
+				SignInType  string `json:"signInType,omitempty"`
+				MFARequired *bool  `json:"mfaRequired,omitempty"`
+			}{SignInType: "email"}},
+			missing: "sign_in_type",
+		},
+		{
+			name: "legacy APIGateway ignored without Normalize",
+			key:  KeyAWSAPIGateway,
+			cfg: &Config{APIGateway: &struct {
+				DomainName     string `json:"domainName,omitempty"`
+				CertificateArn string `json:"certificateArn,omitempty"`
+			}{DomainName: "api.example.com"}},
+			missing: "domain_name",
+		},
+		{
+			name: "legacy KMS ignored without Normalize",
+			key:  KeyAWSKMS,
+			cfg: &Config{KMS: &struct {
+				NumKeys string `json:"numKeys,omitempty"`
+			}{NumKeys: "3"}},
+			missing: "num_keys",
+		},
+		{
+			name: "legacy SecretsManager ignored without Normalize",
+			key:  KeyAWSSecretsManager,
+			cfg: &Config{SecretsManager: &struct {
+				NumSecrets string `json:"numSecrets,omitempty"`
+			}{NumSecrets: "5"}},
+			missing: "num_secrets",
+		},
+		{
+			name: "legacy OpenSearch ignored without Normalize",
+			key:  KeyAWSOpenSearch,
+			cfg: &Config{OpenSearch: &struct {
+				DeploymentType string `json:"deploymentType,omitempty"`
+				InstanceType   string `json:"instanceType,omitempty"`
+				StorageSize    string `json:"storageSize,omitempty"`
+				MultiAZ        *bool  `json:"multiAz,omitempty"`
+			}{DeploymentType: "managed"}},
+			missing: "deployment_type",
+		},
+		{
+			name: "legacy Bedrock ignored without Normalize",
+			key:  KeyAWSBedrock,
+			cfg: &Config{Bedrock: &struct {
+				KnowledgeBaseName string `json:"knowledgeBaseName,omitempty"`
+				ModelID           string `json:"modelId,omitempty"`
+				EmbeddingModelID  string `json:"embeddingModelId,omitempty"`
+			}{KnowledgeBaseName: "kb"}},
+			missing: "knowledge_base_name",
+		},
+		{
+			name: "legacy Lambda ignored without Normalize",
+			key:  KeyAWSLambda,
+			cfg: &Config{Lambda: &struct {
+				Runtime    string `json:"runtime,omitempty"`
+				MemorySize string `json:"memorySize,omitempty"`
+				Timeout    string `json:"timeout,omitempty"`
+			}{Runtime: "python3.12", MemorySize: "512"}},
+			missing: "memory_size",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			vals, err := m.BuildModuleValues(tc.key, nil, tc.cfg, "", "")
+			comps := &Components{}
+			if tc.key == KeyAWSBedrock {
+				// KeyAWSBedrock arm dereferences comps; give it a non-nil
+				// Components with AWSBedrock flagged so we exercise the Config
+				// read path, not the nil guard.
+				comps.AWSBedrock = ptrBool(true)
+			}
+			if tc.key == KeyAWSOpenSearch {
+				comps.AWSOpenSearch = ptrBool(true)
+			}
+			vals, err := m.BuildModuleValues(tc.key, comps, tc.cfg, "", "")
 			require.NoError(t, err)
+			if tc.missing == "" {
+				// EKS node-group arm: cfg.AWSEKS absent → desired_size default 3
+				assert.Equal(t, 3, vals["desired_size"],
+					"legacy Eks.DesiredSize must not reach mapper output; default 3 should apply")
+				return
+			}
 			_, present := vals[tc.missing]
 			assert.False(t, present,
-				"legacy Config field without Normalize must not reach the mapper output")
+				"legacy Config field without Normalize must not produce %q in mapper output",
+				tc.missing)
 		})
 	}
+}
+
+// TestBuildModuleValues_IgnoresLegacyBedrockComponent pins the Phase 3b
+// invariant that the mapper's Bedrock-forces-AOSS override reads
+// comps.AWSBedrock only. Restoring the dropped comps.Bedrock OR-leg would
+// fail this test.
+func TestBuildModuleValues_IgnoresLegacyBedrockComponent(t *testing.T) {
+	m := DefaultMapper{}
+	// Legacy comps.Bedrock set, AWSBedrock nil. Without Normalize, the
+	// serverless override must NOT fire — user config for managed wins.
+	vals, err := m.BuildModuleValues(
+		KeyAWSOpenSearch,
+		&Components{Bedrock: ptrBool(true), AWSOpenSearch: ptrBool(true)},
+		&Config{
+			AWSOpenSearch: &struct {
+				DeploymentType string `json:"deploymentType,omitempty"`
+				InstanceType   string `json:"instanceType,omitempty"`
+				StorageSize    string `json:"storageSize,omitempty"`
+				MultiAZ        *bool  `json:"multiAz,omitempty"`
+			}{DeploymentType: "managed"},
+		},
+		"demo", "us-east-1",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "managed", vals["deployment_type"],
+		"unnormalized comps.Bedrock must not force serverless")
+}
+
+// TestBuildModuleValues_IgnoresLegacyCachePathsFallback pins the Phase 3b
+// invariant that the mapper does not consult AWSCloudfront.CachePaths. The
+// legacy CachePaths→OriginPath migration lives in Config.Normalize only.
+func TestBuildModuleValues_IgnoresLegacyCachePathsFallback(t *testing.T) {
+	m := DefaultMapper{}
+	path := "/legacy"
+	// AWSCloudfront.CachePaths populated, OriginPath nil, no Normalize call.
+	// The mapper must not emit origin_path.
+	vals, err := m.BuildModuleValues(
+		KeyAWSCloudfront,
+		nil,
+		&Config{AWSCloudfront: &struct {
+			DefaultTtl *string `json:"defaultTtl,omitempty"`
+			OriginPath *string `json:"originPath,omitempty"`
+			CachePaths *string `json:"cachePaths,omitempty"`
+		}{CachePaths: &path}},
+		"", "",
+	)
+	require.NoError(t, err)
+	_, present := vals["origin_path"]
+	assert.False(t, present,
+		"unnormalized AWSCloudfront.CachePaths must not reach mapper output as origin_path")
+}
+
+// TestBuildModuleValues_AWSBackups_DefaultRule pins the mapper's
+// cfg.AWSBackups.{EC2,RDS,ElastiCache,DynamoDB,S3} → default_rule mapping
+// after the Phase 3b rewrite from map-iteration to typed sub-struct reads.
+// Covers: cron rank precedence (1h > 4h > 24h), maxRetention aggregation,
+// comps-gating (cfg detail ignored when component disabled), 30-day
+// retention fallback, and the daily-at-03:00-UTC schedule fallback.
+func TestBuildModuleValues_AWSBackups_DefaultRule(t *testing.T) {
+	m := DefaultMapper{}
+
+	// Local struct-literal helpers keep the table below readable — every
+	// sub-struct on Config.AWSBackups has the same three fields.
+	type det = struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	}
+
+	ec2Det := func(f, r int) *det { return &det{FrequencyHours: f, RetentionDays: r} }
+
+	t.Run("single EC2 detail emits hourly cron and retention", func(t *testing.T) {
+		comps := &Components{AWSBackups: &struct {
+			EC2         *bool `json:"aws_ec2,omitempty"`
+			RDS         *bool `json:"aws_rds,omitempty"`
+			ElastiCache *bool `json:"aws_elasticache,omitempty"`
+			DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+			S3          *bool `json:"aws_s3,omitempty"`
+		}{EC2: ptrBool(true)}}
+		cfg := &Config{AWSBackups: &struct {
+			EC2         *det `json:"aws_ec2,omitempty"`
+			RDS         *det `json:"aws_rds,omitempty"`
+			ElastiCache *det `json:"aws_elasticache,omitempty"`
+			DynamoDB    *det `json:"aws_dynamodb,omitempty"`
+			S3          *det `json:"aws_s3,omitempty"`
+		}{EC2: ec2Det(1, 7)}}
+		vals, err := m.BuildModuleValues(KeyAWSBackups, comps, cfg, "", "")
+		require.NoError(t, err)
+
+		rule, ok := vals["default_rule"].(map[string]any)
+		require.True(t, ok, "default_rule must be a map")
+		assert.Equal(t, "cron(0 0 * * ? *)", rule["schedule_expression"],
+			"frequency=1h must produce hourly cron")
+		assert.Equal(t, 7, rule["retention_days"])
+		assert.Equal(t, 0, rule["cold_storage_after_days"])
+	})
+
+	t.Run("highest-frequency service wins (1h beats 4h beats 24h)", func(t *testing.T) {
+		// Retention is highest on the 24h service; schedule tracks the
+		// 1h service. The test asserts the two reductions are independent.
+		comps := &Components{AWSBackups: &struct {
+			EC2         *bool `json:"aws_ec2,omitempty"`
+			RDS         *bool `json:"aws_rds,omitempty"`
+			ElastiCache *bool `json:"aws_elasticache,omitempty"`
+			DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+			S3          *bool `json:"aws_s3,omitempty"`
+		}{EC2: ptrBool(true), RDS: ptrBool(true), S3: ptrBool(true)}}
+		cfg := &Config{AWSBackups: &struct {
+			EC2         *det `json:"aws_ec2,omitempty"`
+			RDS         *det `json:"aws_rds,omitempty"`
+			ElastiCache *det `json:"aws_elasticache,omitempty"`
+			DynamoDB    *det `json:"aws_dynamodb,omitempty"`
+			S3          *det `json:"aws_s3,omitempty"`
+		}{
+			EC2: ec2Det(1, 7),   // best schedule
+			RDS: ec2Det(4, 14),  // middling
+			S3:  ec2Det(24, 90), // worst schedule, best retention
+		}}
+		vals, err := m.BuildModuleValues(KeyAWSBackups, comps, cfg, "", "")
+		require.NoError(t, err)
+
+		rule := vals["default_rule"].(map[string]any)
+		assert.Equal(t, "cron(0 0 * * ? *)", rule["schedule_expression"],
+			"1h EC2 must win the cron-rank contest")
+		assert.Equal(t, 90, rule["retention_days"],
+			"retention_days must be max across enabled services")
+	})
+
+	t.Run("disabled component with populated detail is ignored", func(t *testing.T) {
+		// RDS detail exists in cfg but comps.AWSBackups.RDS is unset —
+		// the mapper must not let the detail affect default_rule.
+		comps := &Components{AWSBackups: &struct {
+			EC2         *bool `json:"aws_ec2,omitempty"`
+			RDS         *bool `json:"aws_rds,omitempty"`
+			ElastiCache *bool `json:"aws_elasticache,omitempty"`
+			DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+			S3          *bool `json:"aws_s3,omitempty"`
+		}{EC2: ptrBool(true)}} // only EC2 enabled
+		cfg := &Config{AWSBackups: &struct {
+			EC2         *det `json:"aws_ec2,omitempty"`
+			RDS         *det `json:"aws_rds,omitempty"`
+			ElastiCache *det `json:"aws_elasticache,omitempty"`
+			DynamoDB    *det `json:"aws_dynamodb,omitempty"`
+			S3          *det `json:"aws_s3,omitempty"`
+		}{
+			EC2: ec2Det(24, 10),
+			RDS: ec2Det(1, 365), // must be ignored — RDS comp disabled
+		}}
+		vals, err := m.BuildModuleValues(KeyAWSBackups, comps, cfg, "", "")
+		require.NoError(t, err)
+
+		rule := vals["default_rule"].(map[string]any)
+		assert.Equal(t, "cron(0 3 * * ? *)", rule["schedule_expression"],
+			"disabled RDS detail must not influence schedule — expected EC2's 24h cron")
+		assert.Equal(t, 10, rule["retention_days"],
+			"disabled RDS detail must not influence retention")
+	})
+
+	t.Run("no cfg.AWSBackups yields fallback schedule and 30-day retention", func(t *testing.T) {
+		comps := &Components{AWSBackups: &struct {
+			EC2         *bool `json:"aws_ec2,omitempty"`
+			RDS         *bool `json:"aws_rds,omitempty"`
+			ElastiCache *bool `json:"aws_elasticache,omitempty"`
+			DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+			S3          *bool `json:"aws_s3,omitempty"`
+		}{EC2: ptrBool(true)}}
+		vals, err := m.BuildModuleValues(KeyAWSBackups, comps, &Config{}, "", "")
+		require.NoError(t, err)
+
+		rule := vals["default_rule"].(map[string]any)
+		assert.Equal(t, "cron(0 3 * * ? *)", rule["schedule_expression"],
+			"no cfg.AWSBackups must fall back to daily 03:00 UTC cron")
+		assert.Equal(t, 30, rule["retention_days"],
+			"no retention detail must fall back to 30 days")
+	})
+
+	t.Run("all five services covered", func(t *testing.T) {
+		// Mutation guard: ensure each service's detail is read. Assign a
+		// unique frequency to every service (all rank-0 unknowns except
+		// one rank-3 winner per subcase) so a deleted service branch
+		// leaves the wrong retention.
+		for _, svc := range []string{"EC2", "RDS", "ElastiCache", "DynamoDB", "S3"} {
+			t.Run(svc, func(t *testing.T) {
+				b := &struct {
+					EC2         *bool `json:"aws_ec2,omitempty"`
+					RDS         *bool `json:"aws_rds,omitempty"`
+					ElastiCache *bool `json:"aws_elasticache,omitempty"`
+					DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+					S3          *bool `json:"aws_s3,omitempty"`
+				}{}
+				c := &struct {
+					EC2         *det `json:"aws_ec2,omitempty"`
+					RDS         *det `json:"aws_rds,omitempty"`
+					ElastiCache *det `json:"aws_elasticache,omitempty"`
+					DynamoDB    *det `json:"aws_dynamodb,omitempty"`
+					S3          *det `json:"aws_s3,omitempty"`
+				}{}
+				// Assign a distinctive retention (77) to only this service.
+				switch svc {
+				case "EC2":
+					b.EC2 = ptrBool(true)
+					c.EC2 = ec2Det(24, 77)
+				case "RDS":
+					b.RDS = ptrBool(true)
+					c.RDS = ec2Det(24, 77)
+				case "ElastiCache":
+					b.ElastiCache = ptrBool(true)
+					c.ElastiCache = ec2Det(24, 77)
+				case "DynamoDB":
+					b.DynamoDB = ptrBool(true)
+					c.DynamoDB = ec2Det(24, 77)
+				case "S3":
+					b.S3 = ptrBool(true)
+					c.S3 = ec2Det(24, 77)
+				}
+				vals, err := m.BuildModuleValues(
+					KeyAWSBackups,
+					&Components{AWSBackups: b},
+					&Config{AWSBackups: c},
+					"", "",
+				)
+				require.NoError(t, err)
+				rule := vals["default_rule"].(map[string]any)
+				assert.Equal(t, 77, rule["retention_days"],
+					"%s branch of AWSBackups mapper must be live", svc)
+			})
+		}
+	})
 }

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -375,7 +375,7 @@ func TestBuildModuleValues_CloudWatchLogs_Retention(t *testing.T) {
 
 	t.Run("retention days integer set directly", func(t *testing.T) {
 		cfg := &Config{
-			CloudWatchLogs: &struct {
+			AWSCloudWatchLogs: &struct {
 				RetentionDays int `json:"retentionDays,omitempty"`
 			}{
 				RetentionDays: 7,
@@ -390,7 +390,7 @@ func TestBuildModuleValues_CloudWatchLogs_Retention(t *testing.T) {
 
 	t.Run("90 days retention", func(t *testing.T) {
 		cfg := &Config{
-			CloudWatchLogs: &struct {
+			AWSCloudWatchLogs: &struct {
 				RetentionDays int `json:"retentionDays,omitempty"`
 			}{
 				RetentionDays: 90,
@@ -401,14 +401,19 @@ func TestBuildModuleValues_CloudWatchLogs_Retention(t *testing.T) {
 		assert.Equal(t, 90, vals["retention_in_days"])
 	})
 
-	t.Run("V2 AWSCloudWatchLogs config is also used", func(t *testing.T) {
+	t.Run("legacy CloudWatchLogs config after Normalize is also used", func(t *testing.T) {
+		// Phase 3b: the mapper reads AWSCloudWatchLogs only. Legacy callers
+		// must Normalize() first; reliable's composeradapter does this in
+		// production.
 		cfg := &Config{
-			AWSCloudWatchLogs: &struct {
+			Cloud: "AWS",
+			CloudWatchLogs: &struct {
 				RetentionDays int `json:"retentionDays,omitempty"`
 			}{
 				RetentionDays: 365,
 			},
 		}
+		cfg.Normalize()
 		vals, err := m.BuildModuleValues(KeyAWSCloudWatchLogs, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, 365, vals["retention_in_days"])
@@ -416,7 +421,7 @@ func TestBuildModuleValues_CloudWatchLogs_Retention(t *testing.T) {
 
 	t.Run("zero retention does not set key", func(t *testing.T) {
 		cfg := &Config{
-			CloudWatchLogs: &struct {
+			AWSCloudWatchLogs: &struct {
 				RetentionDays int `json:"retentionDays,omitempty"`
 			}{
 				RetentionDays: 0,
@@ -435,7 +440,7 @@ func TestBuildModuleValues_Cloudfront_OriginPath(t *testing.T) {
 	t.Run("originPath maps to origin_path", func(t *testing.T) {
 		path := "/assets"
 		cfg := &Config{
-			Cloudfront: &struct {
+			AWSCloudfront: &struct {
 				DefaultTtl *string `json:"defaultTtl,omitempty"`
 				OriginPath *string `json:"originPath,omitempty"`
 				CachePaths *string `json:"cachePaths,omitempty"`
@@ -446,15 +451,19 @@ func TestBuildModuleValues_Cloudfront_OriginPath(t *testing.T) {
 		assert.Equal(t, "/assets", vals["origin_path"])
 	})
 
-	t.Run("deprecated cachePaths falls back to origin_path", func(t *testing.T) {
+	t.Run("deprecated cachePaths falls back to origin_path via Normalize", func(t *testing.T) {
+		// Phase 3b: the mapper reads AWSCloudfront.OriginPath only.
+		// Config.Normalize migrates the deprecated CachePaths → OriginPath.
 		path := "/legacy"
 		cfg := &Config{
-			Cloudfront: &struct {
+			Cloud: "AWS",
+			AWSCloudfront: &struct {
 				DefaultTtl *string `json:"defaultTtl,omitempty"`
 				OriginPath *string `json:"originPath,omitempty"`
 				CachePaths *string `json:"cachePaths,omitempty"`
 			}{CachePaths: &path},
 		}
+		cfg.Normalize()
 		vals, err := m.BuildModuleValues(KeyAWSCloudfront, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, "/legacy", vals["origin_path"])
@@ -464,12 +473,14 @@ func TestBuildModuleValues_Cloudfront_OriginPath(t *testing.T) {
 		newPath := "/new"
 		oldPath := "/old"
 		cfg := &Config{
-			Cloudfront: &struct {
+			Cloud: "AWS",
+			AWSCloudfront: &struct {
 				DefaultTtl *string `json:"defaultTtl,omitempty"`
 				OriginPath *string `json:"originPath,omitempty"`
 				CachePaths *string `json:"cachePaths,omitempty"`
 			}{OriginPath: &newPath, CachePaths: &oldPath},
 		}
+		cfg.Normalize()
 		vals, err := m.BuildModuleValues(KeyAWSCloudfront, nil, cfg, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, "/new", vals["origin_path"])
@@ -657,7 +668,7 @@ func TestBuildModuleValues_AWSEC2_CpuArchPrecedence(t *testing.T) {
 	})
 }
 
-// TestBuildModuleValues_Postgres_RDSConfig pins the cfg.RDS → module.rds
+// TestBuildModuleValues_Postgres_RDSConfig pins the cfg.AWSRDS → module.rds
 // mapping. Previously the kitchen-sink integration test exercised these
 // branches but asserted nothing on the mapper output; the fixture rename
 // in #122 (`awsKitchenSinkCfgWithReadReplicas`) made the gap visible.
@@ -665,7 +676,7 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 	m := DefaultMapper{}
 
 	t.Run("ReadReplicas set emits num_read_nodes", func(t *testing.T) {
-		cfg := &Config{RDS: &struct {
+		cfg := &Config{AWSRDS: &struct {
 			CPUSize      string `json:"cpuSize,omitempty"`
 			ReadReplicas string `json:"readReplicas,omitempty"`
 			StorageSize  string `json:"storageSize,omitempty"`
@@ -676,7 +687,7 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 	})
 
 	t.Run("ReadReplicas unset leaves num_read_nodes unset", func(t *testing.T) {
-		cfg := &Config{RDS: &struct {
+		cfg := &Config{AWSRDS: &struct {
 			CPUSize      string `json:"cpuSize,omitempty"`
 			ReadReplicas string `json:"readReplicas,omitempty"`
 			StorageSize  string `json:"storageSize,omitempty"`
@@ -688,7 +699,7 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 	})
 
 	t.Run("CPUSize and StorageSize map to node_cpu_size and storage_size", func(t *testing.T) {
-		cfg := &Config{RDS: &struct {
+		cfg := &Config{AWSRDS: &struct {
 			CPUSize      string `json:"cpuSize,omitempty"`
 			ReadReplicas string `json:"readReplicas,omitempty"`
 			StorageSize  string `json:"storageSize,omitempty"`
@@ -698,4 +709,80 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 		assert.Equal(t, "db.m7i.2xlarge", vals["node_cpu_size"])
 		assert.Equal(t, "20", vals["storage_size"])
 	})
+
+	t.Run("legacy RDS config after Normalize is migrated", func(t *testing.T) {
+		// Phase 3b: the mapper reads AWSRDS only. Legacy callers must
+		// Normalize() first; reliable's composeradapter does this in
+		// production.
+		cfg := &Config{
+			Cloud: "AWS",
+			RDS: &struct {
+				CPUSize      string `json:"cpuSize,omitempty"`
+				ReadReplicas string `json:"readReplicas,omitempty"`
+				StorageSize  string `json:"storageSize,omitempty"`
+			}{CPUSize: "db.m7i.2xlarge", ReadReplicas: "1", StorageSize: "50"},
+		}
+		cfg.Normalize()
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "db.m7i.2xlarge", vals["node_cpu_size"])
+		assert.Equal(t, "1", vals["num_read_nodes"])
+		assert.Equal(t, "50", vals["storage_size"])
+	})
+}
+
+// TestBuildModuleValues_IgnoresUnnormalizedLegacyConfig pins the Phase 3b
+// invariant: the mapper reads AWS-prefixed Config fields only. Legacy fields
+// supplied without a prior Normalize() call are invisible. The downstream
+// contract is that callers (reliable's composeradapter in production, the
+// ComposeStack/ComposeSingle entry points elsewhere) always Normalize first.
+func TestBuildModuleValues_IgnoresUnnormalizedLegacyConfig(t *testing.T) {
+	m := DefaultMapper{}
+
+	cases := []struct {
+		name string
+		key  ComponentKey
+		cfg  *Config
+		// key that should NOT appear in vals because the mapper doesn't read
+		// the legacy Config field this test populates.
+		missing string
+	}{
+		{
+			name: "legacy RDS ignored without Normalize",
+			key:  KeyAWSRDS,
+			cfg: &Config{RDS: &struct {
+				CPUSize      string `json:"cpuSize,omitempty"`
+				ReadReplicas string `json:"readReplicas,omitempty"`
+				StorageSize  string `json:"storageSize,omitempty"`
+			}{CPUSize: "db.m7i.2xlarge"}},
+			missing: "node_cpu_size",
+		},
+		{
+			name: "legacy CloudWatchLogs ignored without Normalize",
+			key:  KeyAWSCloudWatchLogs,
+			cfg: &Config{CloudWatchLogs: &struct {
+				RetentionDays int `json:"retentionDays,omitempty"`
+			}{RetentionDays: 42}},
+			missing: "retention_in_days",
+		},
+		{
+			name: "legacy SQS ignored without Normalize",
+			key:  KeyAWSSQS,
+			cfg: &Config{SQS: &struct {
+				Type              string `json:"type,omitempty"`
+				VisibilityTimeout string `json:"visibilityTimeout,omitempty"`
+			}{Type: "FIFO"}},
+			missing: "type",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vals, err := m.BuildModuleValues(tc.key, nil, tc.cfg, "", "")
+			require.NoError(t, err)
+			_, present := vals[tc.missing]
+			assert.False(t, present,
+				"legacy Config field without Normalize must not reach the mapper output")
+		})
+	}
 }

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -1277,6 +1277,194 @@ func (c *Config) Normalize() {
 			c.AWSSQS.Type = c.SQS.Type
 			c.AWSSQS.VisibilityTimeout = c.SQS.VisibilityTimeout
 		}
+		if c.DynamoDB != nil && c.DynamoDB.Type != "" {
+			if c.AWSDynamoDB == nil {
+				c.AWSDynamoDB = &struct {
+					Type string `json:"type,omitempty"`
+				}{}
+			}
+			if c.AWSDynamoDB.Type == "" {
+				c.AWSDynamoDB.Type = c.DynamoDB.Type
+			}
+		}
+		if c.MSK != nil && c.MSK.Retention != "" {
+			if c.AWSMSK == nil {
+				c.AWSMSK = &struct {
+					Retention string `json:"retentionPeriod,omitempty"`
+				}{}
+			}
+			if c.AWSMSK.Retention == "" {
+				c.AWSMSK.Retention = c.MSK.Retention
+			}
+		}
+		if c.APIGateway != nil && (c.APIGateway.DomainName != "" || c.APIGateway.CertificateArn != "") {
+			if c.AWSAPIGateway == nil {
+				c.AWSAPIGateway = &struct {
+					DomainName     string `json:"domainName,omitempty"`
+					CertificateArn string `json:"certificateArn,omitempty"`
+				}{}
+			}
+			if c.AWSAPIGateway.DomainName == "" {
+				c.AWSAPIGateway.DomainName = c.APIGateway.DomainName
+			}
+			if c.AWSAPIGateway.CertificateArn == "" {
+				c.AWSAPIGateway.CertificateArn = c.APIGateway.CertificateArn
+			}
+		}
+		if c.KMS != nil && c.KMS.NumKeys != "" {
+			if c.AWSKMS == nil {
+				c.AWSKMS = &struct {
+					NumKeys string `json:"numKeys,omitempty"`
+				}{}
+			}
+			if c.AWSKMS.NumKeys == "" {
+				c.AWSKMS.NumKeys = c.KMS.NumKeys
+			}
+		}
+		if c.SecretsManager != nil && c.SecretsManager.NumSecrets != "" {
+			if c.AWSSecretsManager == nil {
+				c.AWSSecretsManager = &struct {
+					NumSecrets string `json:"numSecrets,omitempty"`
+				}{}
+			}
+			if c.AWSSecretsManager.NumSecrets == "" {
+				c.AWSSecretsManager.NumSecrets = c.SecretsManager.NumSecrets
+			}
+		}
+		if c.OpenSearch != nil && (c.OpenSearch.DeploymentType != "" || c.OpenSearch.InstanceType != "" || c.OpenSearch.StorageSize != "" || c.OpenSearch.MultiAZ != nil) {
+			if c.AWSOpenSearch == nil {
+				c.AWSOpenSearch = &struct {
+					DeploymentType string `json:"deploymentType,omitempty"`
+					InstanceType   string `json:"instanceType,omitempty"`
+					StorageSize    string `json:"storageSize,omitempty"`
+					MultiAZ        *bool  `json:"multiAz,omitempty"`
+				}{}
+			}
+			if c.AWSOpenSearch.DeploymentType == "" {
+				c.AWSOpenSearch.DeploymentType = c.OpenSearch.DeploymentType
+			}
+			if c.AWSOpenSearch.InstanceType == "" {
+				c.AWSOpenSearch.InstanceType = c.OpenSearch.InstanceType
+			}
+			if c.AWSOpenSearch.StorageSize == "" {
+				c.AWSOpenSearch.StorageSize = c.OpenSearch.StorageSize
+			}
+			if c.AWSOpenSearch.MultiAZ == nil {
+				c.AWSOpenSearch.MultiAZ = c.OpenSearch.MultiAZ
+			}
+		}
+		if c.Bedrock != nil && (c.Bedrock.KnowledgeBaseName != "" || c.Bedrock.ModelID != "" || c.Bedrock.EmbeddingModelID != "") {
+			if c.AWSBedrock == nil {
+				c.AWSBedrock = &struct {
+					KnowledgeBaseName string `json:"knowledgeBaseName,omitempty"`
+					ModelID           string `json:"modelId,omitempty"`
+					EmbeddingModelID  string `json:"embeddingModelId,omitempty"`
+				}{}
+			}
+			if c.AWSBedrock.KnowledgeBaseName == "" {
+				c.AWSBedrock.KnowledgeBaseName = c.Bedrock.KnowledgeBaseName
+			}
+			if c.AWSBedrock.ModelID == "" {
+				c.AWSBedrock.ModelID = c.Bedrock.ModelID
+			}
+			if c.AWSBedrock.EmbeddingModelID == "" {
+				c.AWSBedrock.EmbeddingModelID = c.Bedrock.EmbeddingModelID
+			}
+		}
+		if c.Lambda != nil && (c.Lambda.Runtime != "" || c.Lambda.MemorySize != "" || c.Lambda.Timeout != "") {
+			if c.AWSLambda == nil {
+				c.AWSLambda = &struct {
+					Runtime    string `json:"runtime,omitempty"`
+					MemorySize string `json:"memorySize,omitempty"`
+					Timeout    string `json:"timeout,omitempty"`
+				}{}
+			}
+			if c.AWSLambda.Runtime == "" {
+				c.AWSLambda.Runtime = c.Lambda.Runtime
+			}
+			if c.AWSLambda.MemorySize == "" {
+				c.AWSLambda.MemorySize = c.Lambda.MemorySize
+			}
+			if c.AWSLambda.Timeout == "" {
+				c.AWSLambda.Timeout = c.Lambda.Timeout
+			}
+		}
+		// Backups.Details is a service-keyed map on the legacy shape; promote
+		// each known service key to its typed AWSBackups sub-struct. The
+		// mapper reads AWSBackups directly (Phase 3b) so without this
+		// migration, sessions that carry backup frequencies/retentions under
+		// legacy keys silently stop being honored.
+		if c.Backups != nil && len(c.Backups.Details) > 0 {
+			if c.AWSBackups == nil {
+				c.AWSBackups = &struct {
+					EC2 *struct {
+						FrequencyHours int    `json:"frequencyHours,omitempty"`
+						RetentionDays  int    `json:"retentionDays,omitempty"`
+						Region         string `json:"region,omitempty"`
+					} `json:"aws_ec2,omitempty"`
+					RDS *struct {
+						FrequencyHours int    `json:"frequencyHours,omitempty"`
+						RetentionDays  int    `json:"retentionDays,omitempty"`
+						Region         string `json:"region,omitempty"`
+					} `json:"aws_rds,omitempty"`
+					ElastiCache *struct {
+						FrequencyHours int    `json:"frequencyHours,omitempty"`
+						RetentionDays  int    `json:"retentionDays,omitempty"`
+						Region         string `json:"region,omitempty"`
+					} `json:"aws_elasticache,omitempty"`
+					DynamoDB *struct {
+						FrequencyHours int    `json:"frequencyHours,omitempty"`
+						RetentionDays  int    `json:"retentionDays,omitempty"`
+						Region         string `json:"region,omitempty"`
+					} `json:"aws_dynamodb,omitempty"`
+					S3 *struct {
+						FrequencyHours int    `json:"frequencyHours,omitempty"`
+						RetentionDays  int    `json:"retentionDays,omitempty"`
+						Region         string `json:"region,omitempty"`
+					} `json:"aws_s3,omitempty"`
+				}{}
+			}
+			if det, ok := c.Backups.Details["ec2"]; ok && c.AWSBackups.EC2 == nil {
+				d := det
+				c.AWSBackups.EC2 = &struct {
+					FrequencyHours int    `json:"frequencyHours,omitempty"`
+					RetentionDays  int    `json:"retentionDays,omitempty"`
+					Region         string `json:"region,omitempty"`
+				}{FrequencyHours: d.FrequencyHours, RetentionDays: d.RetentionDays, Region: d.Region}
+			}
+			if det, ok := c.Backups.Details["rds"]; ok && c.AWSBackups.RDS == nil {
+				d := det
+				c.AWSBackups.RDS = &struct {
+					FrequencyHours int    `json:"frequencyHours,omitempty"`
+					RetentionDays  int    `json:"retentionDays,omitempty"`
+					Region         string `json:"region,omitempty"`
+				}{FrequencyHours: d.FrequencyHours, RetentionDays: d.RetentionDays, Region: d.Region}
+			}
+			if det, ok := c.Backups.Details["elasticache"]; ok && c.AWSBackups.ElastiCache == nil {
+				d := det
+				c.AWSBackups.ElastiCache = &struct {
+					FrequencyHours int    `json:"frequencyHours,omitempty"`
+					RetentionDays  int    `json:"retentionDays,omitempty"`
+					Region         string `json:"region,omitempty"`
+				}{FrequencyHours: d.FrequencyHours, RetentionDays: d.RetentionDays, Region: d.Region}
+			}
+			if det, ok := c.Backups.Details["dynamodb"]; ok && c.AWSBackups.DynamoDB == nil {
+				d := det
+				c.AWSBackups.DynamoDB = &struct {
+					FrequencyHours int    `json:"frequencyHours,omitempty"`
+					RetentionDays  int    `json:"retentionDays,omitempty"`
+					Region         string `json:"region,omitempty"`
+				}{FrequencyHours: d.FrequencyHours, RetentionDays: d.RetentionDays, Region: d.Region}
+			}
+			if det, ok := c.Backups.Details["s3"]; ok && c.AWSBackups.S3 == nil {
+				d := det
+				c.AWSBackups.S3 = &struct {
+					FrequencyHours int    `json:"frequencyHours,omitempty"`
+					RetentionDays  int    `json:"retentionDays,omitempty"`
+					Region         string `json:"region,omitempty"`
+				}{FrequencyHours: d.FrequencyHours, RetentionDays: d.RetentionDays, Region: d.Region}
+			}
+		}
 
 		// Then: Migrate cloud-prefixed AWS fields to legacy fields for unified checking
 		// (This is not needed anymore since we clear legacy fields, but keeping for internal logic)

--- a/pkg/composer/types_test.go
+++ b/pkg/composer/types_test.go
@@ -285,3 +285,193 @@ func TestConfig_Normalize_ClearsAWSFieldsForGCP(t *testing.T) {
 func boolPtr(b bool) *bool {
 	return &b
 }
+
+// TestConfig_Normalize_PromotesLegacyAWSSubConfigs pins the AWS-branch
+// legacy → AWS-prefixed migration for the Config sub-configs that Phase 3b
+// added: DynamoDB, MSK, APIGateway, KMS, SecretsManager, OpenSearch,
+// Bedrock, Lambda, and Backups.Details. Composer's mapper (post-Phase 3b)
+// reads only the AWS-prefixed fields, so these migrations are load-bearing
+// for direct Go callers constructing Config from legacy JSON. Reliable's
+// composeradapter emits prefixed-only Config in production, so this test
+// is primarily a contract guard for direct library consumers.
+func TestConfig_Normalize_PromotesLegacyAWSSubConfigs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DynamoDB", func(t *testing.T) {
+		cfg := Config{Cloud: "AWS", DynamoDB: &struct {
+			Type string `json:"type,omitempty"`
+		}{Type: "On Demand"}}
+		cfg.Normalize()
+		if cfg.AWSDynamoDB == nil || cfg.AWSDynamoDB.Type != "On Demand" {
+			t.Fatalf("AWSDynamoDB.Type not promoted; got %#v", cfg.AWSDynamoDB)
+		}
+	})
+
+	t.Run("MSK", func(t *testing.T) {
+		cfg := Config{Cloud: "AWS", MSK: &struct {
+			Retention string `json:"retentionPeriod,omitempty"`
+		}{Retention: "168"}}
+		cfg.Normalize()
+		if cfg.AWSMSK == nil || cfg.AWSMSK.Retention != "168" {
+			t.Fatalf("AWSMSK.Retention not promoted; got %#v", cfg.AWSMSK)
+		}
+	})
+
+	t.Run("APIGateway", func(t *testing.T) {
+		cfg := Config{Cloud: "AWS", APIGateway: &struct {
+			DomainName     string `json:"domainName,omitempty"`
+			CertificateArn string `json:"certificateArn,omitempty"`
+		}{DomainName: "api.example.com", CertificateArn: "arn:aws:acm:us-east-1:123456789012:certificate/abc"}}
+		cfg.Normalize()
+		if cfg.AWSAPIGateway == nil ||
+			cfg.AWSAPIGateway.DomainName != "api.example.com" ||
+			cfg.AWSAPIGateway.CertificateArn != "arn:aws:acm:us-east-1:123456789012:certificate/abc" {
+			t.Fatalf("AWSAPIGateway fields not promoted; got %#v", cfg.AWSAPIGateway)
+		}
+	})
+
+	t.Run("KMS", func(t *testing.T) {
+		cfg := Config{Cloud: "AWS", KMS: &struct {
+			NumKeys string `json:"numKeys,omitempty"`
+		}{NumKeys: "3"}}
+		cfg.Normalize()
+		if cfg.AWSKMS == nil || cfg.AWSKMS.NumKeys != "3" {
+			t.Fatalf("AWSKMS.NumKeys not promoted; got %#v", cfg.AWSKMS)
+		}
+	})
+
+	t.Run("SecretsManager", func(t *testing.T) {
+		cfg := Config{Cloud: "AWS", SecretsManager: &struct {
+			NumSecrets string `json:"numSecrets,omitempty"`
+		}{NumSecrets: "5"}}
+		cfg.Normalize()
+		if cfg.AWSSecretsManager == nil || cfg.AWSSecretsManager.NumSecrets != "5" {
+			t.Fatalf("AWSSecretsManager.NumSecrets not promoted; got %#v", cfg.AWSSecretsManager)
+		}
+	})
+
+	t.Run("OpenSearch", func(t *testing.T) {
+		multi := true
+		cfg := Config{Cloud: "AWS", OpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "serverless", InstanceType: "t3.medium.search", StorageSize: "50", MultiAZ: &multi}}
+		cfg.Normalize()
+		if cfg.AWSOpenSearch == nil ||
+			cfg.AWSOpenSearch.DeploymentType != "serverless" ||
+			cfg.AWSOpenSearch.InstanceType != "t3.medium.search" ||
+			cfg.AWSOpenSearch.StorageSize != "50" ||
+			cfg.AWSOpenSearch.MultiAZ == nil || !*cfg.AWSOpenSearch.MultiAZ {
+			t.Fatalf("AWSOpenSearch fields not promoted; got %#v", cfg.AWSOpenSearch)
+		}
+	})
+
+	t.Run("Bedrock", func(t *testing.T) {
+		cfg := Config{Cloud: "AWS", Bedrock: &struct {
+			KnowledgeBaseName string `json:"knowledgeBaseName,omitempty"`
+			ModelID           string `json:"modelId,omitempty"`
+			EmbeddingModelID  string `json:"embeddingModelId,omitempty"`
+		}{
+			KnowledgeBaseName: "kb-test",
+			ModelID:           "anthropic.claude-3-sonnet-20240229-v1:0",
+			EmbeddingModelID:  "amazon.titan-embed-text-v1",
+		}}
+		cfg.Normalize()
+		if cfg.AWSBedrock == nil ||
+			cfg.AWSBedrock.KnowledgeBaseName != "kb-test" ||
+			cfg.AWSBedrock.ModelID != "anthropic.claude-3-sonnet-20240229-v1:0" ||
+			cfg.AWSBedrock.EmbeddingModelID != "amazon.titan-embed-text-v1" {
+			t.Fatalf("AWSBedrock fields not promoted; got %#v", cfg.AWSBedrock)
+		}
+	})
+
+	t.Run("Lambda", func(t *testing.T) {
+		cfg := Config{Cloud: "AWS", Lambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Runtime: "python3.12", MemorySize: "512", Timeout: "30s"}}
+		cfg.Normalize()
+		if cfg.AWSLambda == nil ||
+			cfg.AWSLambda.Runtime != "python3.12" ||
+			cfg.AWSLambda.MemorySize != "512" ||
+			cfg.AWSLambda.Timeout != "30s" {
+			t.Fatalf("AWSLambda fields not promoted; got %#v", cfg.AWSLambda)
+		}
+	})
+
+	t.Run("Backups.Details map to AWSBackups typed sub-structs", func(t *testing.T) {
+		// Legacy shape: Backups.Details is a service-keyed map. Post-Normalize
+		// each known service key must land on the corresponding typed
+		// sub-struct (AWSBackups.EC2, RDS, ElastiCache, DynamoDB, S3).
+		type det = struct {
+			FrequencyHours int    `json:"frequencyHours,omitempty"`
+			RetentionDays  int    `json:"retentionDays,omitempty"`
+			Region         string `json:"region,omitempty"`
+		}
+		cfg := Config{Cloud: "AWS", Backups: &struct {
+			Details map[string]det `json:"details,omitempty"`
+		}{Details: map[string]det{
+			"ec2":         {FrequencyHours: 1, RetentionDays: 7, Region: "us-east-1"},
+			"rds":         {FrequencyHours: 4, RetentionDays: 14},
+			"elasticache": {FrequencyHours: 24, RetentionDays: 30},
+			"dynamodb":    {FrequencyHours: 24, RetentionDays: 90},
+			"s3":          {FrequencyHours: 24, RetentionDays: 365},
+		}}}
+		cfg.Normalize()
+
+		if cfg.AWSBackups == nil {
+			t.Fatalf("AWSBackups not promoted from Backups.Details map")
+		}
+		if cfg.AWSBackups.EC2 == nil || cfg.AWSBackups.EC2.FrequencyHours != 1 || cfg.AWSBackups.EC2.RetentionDays != 7 || cfg.AWSBackups.EC2.Region != "us-east-1" {
+			t.Errorf("AWSBackups.EC2 mis-promoted: %#v", cfg.AWSBackups.EC2)
+		}
+		if cfg.AWSBackups.RDS == nil || cfg.AWSBackups.RDS.FrequencyHours != 4 || cfg.AWSBackups.RDS.RetentionDays != 14 {
+			t.Errorf("AWSBackups.RDS mis-promoted: %#v", cfg.AWSBackups.RDS)
+		}
+		if cfg.AWSBackups.ElastiCache == nil || cfg.AWSBackups.ElastiCache.RetentionDays != 30 {
+			t.Errorf("AWSBackups.ElastiCache mis-promoted: %#v", cfg.AWSBackups.ElastiCache)
+		}
+		if cfg.AWSBackups.DynamoDB == nil || cfg.AWSBackups.DynamoDB.RetentionDays != 90 {
+			t.Errorf("AWSBackups.DynamoDB mis-promoted: %#v", cfg.AWSBackups.DynamoDB)
+		}
+		if cfg.AWSBackups.S3 == nil || cfg.AWSBackups.S3.RetentionDays != 365 {
+			t.Errorf("AWSBackups.S3 mis-promoted: %#v", cfg.AWSBackups.S3)
+		}
+	})
+
+	t.Run("prefixed wins when both legacy and AWS fields set", func(t *testing.T) {
+		// If a caller supplies both halves, don't overwrite the AWS side.
+		cfg := Config{
+			Cloud:          "AWS",
+			KMS:            &struct{ NumKeys string `json:"numKeys,omitempty"` }{NumKeys: "1"},
+			AWSKMS:         &struct{ NumKeys string `json:"numKeys,omitempty"` }{NumKeys: "99"},
+		}
+		cfg.Normalize()
+		if cfg.AWSKMS.NumKeys != "99" {
+			t.Errorf("pre-set AWSKMS.NumKeys must not be overwritten by legacy KMS; got %q", cfg.AWSKMS.NumKeys)
+		}
+	})
+
+	t.Run("legacy fields are cleared after promotion", func(t *testing.T) {
+		// The post-sync block clears every legacy field; this test pins that
+		// the new migrations don't leave legacy state behind.
+		cfg := Config{Cloud: "AWS",
+			DynamoDB:       &struct{ Type string `json:"type,omitempty"` }{Type: "Provisioned"},
+			Lambda:         &struct {
+				Runtime    string `json:"runtime,omitempty"`
+				MemorySize string `json:"memorySize,omitempty"`
+				Timeout    string `json:"timeout,omitempty"`
+			}{Runtime: "nodejs20.x"},
+		}
+		cfg.Normalize()
+		if cfg.DynamoDB != nil {
+			t.Errorf("legacy DynamoDB should be cleared; got %#v", cfg.DynamoDB)
+		}
+		if cfg.Lambda != nil {
+			t.Errorf("legacy Lambda should be cleared; got %#v", cfg.Lambda)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Collapses `pkg/composer/mapper.go` `BuildModuleValues` Config reads from dual-key (`cfg.<Legacy>` / `cfg.AWS<Legacy>`) to AWS-prefixed only.
- Drops the `comps.Bedrock` leg of the Bedrock-forces-serverless OR in the AWSOpenSearch arm; `comps.AWSBedrock` is now the single source.
- Rewrites the AWSBackups arm to iterate the typed `cfg.AWSBackups.{EC2,RDS,ElastiCache,DynamoDB,S3}` sub-structs instead of the legacy `cfg.Backups.Details` map.
- Drops the inline CachePaths fallback in the AWSCloudfront arm — `Config.Normalize` already migrates `CachePaths` → `OriginPath` and clears the deprecated field before the mapper runs.
- Migrates the kitchen-sink test fixtures and affected unit tests to AWS-prefixed Config fields. Legacy-field payloads remain covered, but via explicit `Normalize()` calls (the documented contract for direct Go callers).
- Adds `TestBuildModuleValues_IgnoresUnnormalizedLegacyConfig` pinning the new invariant: unnormalized legacy Config fields are invisible to the mapper.

## Context

Phase 3a (#116, deprecation markers) and Phase 2 (reliable's `composeradapter`, merged) are both shipped. The Phase 3b scope in #118 is narrower than the issue anticipated — the `DefaultWiring` / `BuildModuleValues` `KeyAWS<X>` key-switch inversion and the `has*` selector collapses were already in main. What remained was the Config-field-read collapse in the mapper, which this PR completes.

Key point: `Config.Normalize()` is called at the entry of `ComposeSingle` (`compose.go:94-99`) and `ComposeStack` (`compose.go:245-250`), so production call sites unconditionally promote legacy → AWS-prefixed before `BuildModuleValues` sees the Config.

## Out of scope (Phase 4)

- Deletion of legacy `ComponentKey` constants and legacy `Components` / `Config` fields.
- `KeyEC2` / `KeyResource` polymorphic rename.
- `Components.Normalize` / `Config.Normalize` refactor.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./pkg/composer/...` passes (includes new regression test)
- [x] `terraform fmt -check -recursive` clean
- [x] Confirmed `grep 'cfg\.(Eks|RDS|Cloudfront|ElastiCache|S3|DynamoDB|SQS|MSK|CloudWatchLogs|Cognito|APIGateway|KMS|SecretsManager|OpenSearch|Bedrock|Lambda|Backups)' pkg/composer/mapper.go` returns zero matches

Closes #118