### PR TITLE
fix(composer): correct mapper key names + value types against module variables

### DIFF
--- a/aws/msk/main.tf
+++ b/aws/msk/main.tf
@@ -89,7 +89,7 @@ resource "aws_msk_configuration" "this" {
   server_properties = <<-PROPS
     auto.create.topics.enable = true
     delete.topic.enable = true
-    log.retention.hours = 168
+    log.retention.hours = ${var.retention_hours}
     default.replication.factor = 3
     min.insync.replicas = 2
   PROPS

--- a/aws/msk/variables.tf
+++ b/aws/msk/variables.tf
@@ -138,6 +138,16 @@ variable "cloudwatch_retention_days" {
   }
 }
 
+variable "retention_hours" {
+  description = "Topic message retention in hours (broker-level log.retention.hours). 168 = 7 days (Kafka default). Translates the IR's \"3 days\" / \"7 days\" / \"14 days\" enum to 72 / 168 / 336."
+  type        = number
+  default     = 168
+  validation {
+    condition     = var.retention_hours >= 1
+    error_message = "retention_hours must be >= 1."
+  }
+}
+
 variable "enhanced_monitoring" {
   description = "MSK enhanced monitoring level: DEFAULT (6 broker metrics) | PER_BROKER (~23 metrics/broker, CPU/memory/network/disk) | PER_TOPIC_PER_BROKER (PER_BROKER + per-topic throughput/lag). Default is PER_BROKER so reliable2 panels charting broker-level AWS/Kafka metrics populate out of the box; override to DEFAULT on large clusters where CloudWatch metric cost (~$0.30/metric/broker/month for the ~17 additional PER_BROKER metrics) matters."
   type        = string

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -1,5 +1,7 @@
 package composer
 
+import "strings"
+
 type ComponentKey string
 
 const (
@@ -342,6 +344,89 @@ func GetPresetPath(cloud string, k ComponentKey, comps *Components) string {
 	}
 
 	return cloud + "/" + presetName
+}
+
+// CloudFor returns the cloud prefix ("aws" or "gcp") for a ComponentKey.
+// Defaults to "aws" for keys whose string value doesn't carry the "gcp_"
+// prefix — covers polymorphic AWS keys (KeyAWSEKSNodeGroup="ec2",
+// KeyAWSEKSControlPlane="resource") whose string identity predates the
+// cloud-prefixed vocabulary.
+func CloudFor(k ComponentKey) string {
+	if strings.HasPrefix(string(k), "gcp_") {
+		return "gcp"
+	}
+	return "aws"
+}
+
+// AllComponentKeys lists every ComponentKey backed by a preset module in
+// this repo. It is the source of truth for tests that need to exercise
+// every component the mapper might touch — TestMapperKeysSubsetOfModule
+// Variables ranges over this list to verify each emitted tfvar matches a
+// declared variable in the corresponding module's variables.tf.
+//
+// Adding a new ComponentKey requires adding it here too:
+// TestAllComponentKeysCoversPresetKeyMap fails on drift between this list
+// and PresetKeyMap.
+//
+// Excluded by design:
+//   - KeyComposer / KeyArch / KeyCloud — conceptual classifiers; no module.
+//   - KeySplunk / KeyDatadog — third-party toggles; no preset in this repo
+//     (consumed directly by reliable's composeradapter).
+var AllComponentKeys = []ComponentKey{
+	// AWS (alphabetical for reviewability)
+	KeyAWSALB,
+	KeyAWSAPIGateway,
+	KeyAWSBackups,
+	KeyAWSBastion,
+	KeyAWSBedrock,
+	KeyAWSCloudWatchLogs,
+	KeyAWSCloudWatchMonitoring,
+	KeyAWSCloudfront,
+	KeyAWSCodePipeline,
+	KeyAWSCognito,
+	KeyAWSDynamoDB,
+	KeyAWSEC2,
+	KeyAWSECS,
+	KeyAWSEKS,
+	KeyAWSEKSControlPlane,
+	KeyAWSEKSNodeGroup,
+	KeyAWSElastiCache,
+	KeyAWSGitHubActions,
+	KeyAWSGrafana,
+	KeyAWSKMS,
+	KeyAWSLambda,
+	KeyAWSMSK,
+	KeyAWSOpenSearch,
+	KeyAWSRDS,
+	KeyAWSS3,
+	KeyAWSSQS,
+	KeyAWSSecretsManager,
+	KeyAWSVPC,
+	KeyAWSWAF,
+	// GCP
+	KeyGCPAPIGateway,
+	KeyGCPBackups,
+	KeyGCPBastion,
+	KeyGCPCloudArmor,
+	KeyGCPCloudBuild,
+	KeyGCPCloudCDN,
+	KeyGCPCloudFunctions,
+	KeyGCPCloudKMS,
+	KeyGCPCloudLogging,
+	KeyGCPCloudMonitoring,
+	KeyGCPCloudRun,
+	KeyGCPCloudSQL,
+	KeyGCPCompute,
+	KeyGCPFirestore,
+	KeyGCPGCS,
+	KeyGCPGKE,
+	KeyGCPIdentityPlatform,
+	KeyGCPLoadbalancer,
+	KeyGCPMemorystore,
+	KeyGCPPubSub,
+	KeyGCPSecretManager,
+	KeyGCPVPC,
+	KeyGCPVertexAI,
 }
 
 func isLambda(comps *Components) bool {

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -328,23 +329,47 @@ func (m DefaultMapper) BuildModuleValues(
 		if _, ok := vals["subnet_ids"]; !ok {
 			vals["subnet_ids"] = []any{}
 		}
-		// Mirror RDS config if provided
+		// Mirror RDS config if provided. Use the module's actual variable
+		// names (instance_class / read_replica_count / allocated_storage)
+		// — earlier versions emitted node_cpu_size / num_read_nodes /
+		// storage_size, none of which the module declares, so user picks
+		// were silently dropped at compose time.
 		if cfg != nil && cfg.AWSRDS != nil {
 			if cfg.AWSRDS.CPUSize != "" {
-				vals["node_cpu_size"] = cfg.AWSRDS.CPUSize
+				cls, err := canonicalRdsInstanceClass(cfg.AWSRDS.CPUSize)
+				if err != nil {
+					return nil, err
+				}
+				vals["instance_class"] = cls
 			}
 			if cfg.AWSRDS.ReadReplicas != "" {
-				vals["num_read_nodes"] = cfg.AWSRDS.ReadReplicas
+				n, err := parseLeadingInt(cfg.AWSRDS.ReadReplicas, "AWSRDS.ReadReplicas")
+				if err != nil {
+					return nil, err
+				}
+				vals["read_replica_count"] = n
 			}
 			if cfg.AWSRDS.StorageSize != "" {
-				vals["storage_size"] = cfg.AWSRDS.StorageSize
+				gb, err := parseStorageSizeGB(cfg.AWSRDS.StorageSize, "AWSRDS.StorageSize")
+				if err != nil {
+					return nil, err
+				}
+				vals["allocated_storage"] = gb
 			}
 		}
 
 	case KeyAWSCloudfront:
 		if cfg != nil && cfg.AWSCloudfront != nil {
 			if cfg.AWSCloudfront.DefaultTtl != nil && *cfg.AWSCloudfront.DefaultTtl != "" {
-				vals["default_ttl"] = *cfg.AWSCloudfront.DefaultTtl
+				// Module variable is default_ttl_seconds (number).
+				// Earlier versions emitted default_ttl (string) which the
+				// module never declared, so the user pick was silently
+				// dropped and the module default of 3600s won.
+				secs, err := parseTTLSeconds(*cfg.AWSCloudfront.DefaultTtl, "AWSCloudfront.DefaultTtl")
+				if err != nil {
+					return nil, err
+				}
+				vals["default_ttl_seconds"] = secs
 			}
 			if cfg.AWSCloudfront.OriginPath != nil && *cfg.AWSCloudfront.OriginPath != "" {
 				vals["origin_path"] = *cfg.AWSCloudfront.OriginPath
@@ -356,14 +381,33 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.AWSElastiCache.HA != nil {
 				vals["ha"] = *cfg.AWSElastiCache.HA
 			}
+			// Module variable is node_type (cache.* string). Earlier
+			// versions emitted node_size, which the module did not
+			// declare, so the value was silently dropped. The IR's
+			// "1 vCPU"/"4 vCPU"/"8 vCPU" enum is translated to a
+			// concrete cache instance type below.
 			if cfg.AWSElastiCache.NodeSize != "" {
-				vals["node_size"] = cfg.AWSElastiCache.NodeSize
+				typ, err := canonicalRedisNodeType(cfg.AWSElastiCache.NodeSize)
+				if err != nil {
+					return nil, err
+				}
+				vals["node_type"] = typ
 			}
-			if cfg.AWSElastiCache.Storage != "" {
-				vals["storage_size"] = cfg.AWSElastiCache.Storage
-			}
+			// Redis is not capacity-priced — sizing is by node_type
+			// alone. The module has no storage_size variable, so any
+			// value emitted here would be silently dropped. Drop the
+			// emission entirely; the IR field is informational only.
+			//
+			// (cfg.AWSElastiCache.Storage is intentionally ignored.)
 			if cfg.AWSElastiCache.Replicas != "" {
-				vals["replicas"] = cfg.AWSElastiCache.Replicas
+				// Module variable is `type = number`. Parse leading
+				// integer from values like "0 read replicas" /
+				// "1 read replica" / "2 read replicas".
+				n, err := parseLeadingInt(cfg.AWSElastiCache.Replicas, "AWSElastiCache.Replicas")
+				if err != nil {
+					return nil, err
+				}
+				vals["replicas"] = n
 			}
 		}
 
@@ -373,23 +417,51 @@ func (m DefaultMapper) BuildModuleValues(
 		}
 
 	case KeyAWSDynamoDB:
+		// The module's variables.tf validates billing_mode is exactly
+		// "PAY_PER_REQUEST" or "PROVISIONED" (uppercase). The IR enum
+		// emits human-friendly values like "On demand" / "provisioned",
+		// and the .or(ZNA) escape hatch in reliable lets users pass the
+		// canonical TF values directly. Translate to canonical here so
+		// every variant validates.
 		if cfg != nil && cfg.AWSDynamoDB != nil && cfg.AWSDynamoDB.Type != "" {
-			vals["billing_mode"] = strings.ToLower(cfg.AWSDynamoDB.Type) // "on demand" | "provisioned"
+			canonical, err := canonicalDdbBillingMode(cfg.AWSDynamoDB.Type)
+			if err != nil {
+				return nil, err
+			}
+			vals["billing_mode"] = canonical
 		}
 
 	case KeyAWSSQS:
+		// Module variables are queue_type ("Standard"|"FIFO") and
+		// visibility_timeout_seconds (number). Earlier versions emitted
+		// type / visibility_timeout, neither of which the module declared,
+		// so the user pick was silently dropped.
 		if cfg != nil && cfg.AWSSQS != nil {
 			if cfg.AWSSQS.Type != "" {
-				vals["type"] = cfg.AWSSQS.Type // "Standard" | "FIFO"
+				vals["queue_type"] = cfg.AWSSQS.Type
 			}
 			if cfg.AWSSQS.VisibilityTimeout != "" {
-				vals["visibility_timeout"] = cfg.AWSSQS.VisibilityTimeout
+				secs, err := parseTTLSeconds(cfg.AWSSQS.VisibilityTimeout, "AWSSQS.VisibilityTimeout")
+				if err != nil {
+					return nil, err
+				}
+				vals["visibility_timeout_seconds"] = secs
 			}
 		}
 
 	case KeyAWSMSK:
+		// Module variable is retention_hours (number). The IR enum emits
+		// "3 days"/"7 days"/"14 days"; translate to integer hours so the
+		// user pick actually takes effect (previously emitted under key
+		// retention_period, which the module never declared, and against
+		// a hardcoded log.retention.hours = 168 that ignored the value
+		// regardless).
 		if cfg != nil && cfg.AWSMSK != nil && cfg.AWSMSK.Retention != "" {
-			vals["retention_period"] = cfg.AWSMSK.Retention
+			hrs, err := parseRetentionHours(cfg.AWSMSK.Retention, "AWSMSK.Retention")
+			if err != nil {
+				return nil, err
+			}
+			vals["retention_hours"] = hrs
 		}
 
 	case KeyAWSCloudWatchLogs:
@@ -440,7 +512,19 @@ func (m DefaultMapper) BuildModuleValues(
 				vals["instance_type"] = cfg.AWSOpenSearch.InstanceType
 			}
 			if cfg.AWSOpenSearch.StorageSize != "" {
-				vals["storage_size"] = cfg.AWSOpenSearch.StorageSize
+				// The OpenSearch module declares storage_size as
+				// `type = string` and does
+				//     volume_size = tonumber(replace(var.storage_size, "GB", ""))
+				// in main.tf, which only handles the "GB" suffix. The
+				// IR enum allows "1TB"; pass that through and tonumber
+				// fails at plan time. Normalise to "<N>GB" form so the
+				// module's existing replace() does the right thing
+				// without changing its declared type.
+				normalized, err := normalizeStorageSizeGBString(cfg.AWSOpenSearch.StorageSize, "AWSOpenSearch.StorageSize")
+				if err != nil {
+					return nil, err
+				}
+				vals["storage_size"] = normalized
 			}
 			if cfg.AWSOpenSearch.MultiAZ != nil {
 				vals["multi_az"] = *cfg.AWSOpenSearch.MultiAZ
@@ -496,22 +580,32 @@ func (m DefaultMapper) BuildModuleValues(
 				vals["runtime"] = cfg.AWSLambda.Runtime
 			}
 			if cfg.AWSLambda.MemorySize != "" {
-				if n, err := strconv.Atoi(cfg.AWSLambda.MemorySize); err == nil {
-					vals["memory_size"] = n
+				// Strict: must be a pure integer (the IR enum is
+				// {"128","512","1024","3072"}). Earlier versions
+				// silently dropped anything Atoi rejected — including
+				// "512MB" / "1GB" — so the user pick was lost without
+				// any signal. Fail fast instead.
+				n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSLambda.MemorySize))
+				if err != nil {
+					return nil, NewValidationError(fmt.Sprintf(
+						"AWSLambda.MemorySize=%q: expected a positive integer (MB), e.g. %q",
+						cfg.AWSLambda.MemorySize, "512",
+					))
 				}
+				vals["memory_size"] = n
 			}
 			if cfg.AWSLambda.Timeout != "" {
-				// Convert "3s", "30s", "15m" to seconds
-				t := cfg.AWSLambda.Timeout
-				if trimmed, ok := strings.CutSuffix(t, "s"); ok {
-					if n, err := strconv.Atoi(trimmed); err == nil {
-						vals["timeout"] = n
-					}
-				} else if trimmed, ok := strings.CutSuffix(t, "m"); ok {
-					if n, err := strconv.Atoi(trimmed); err == nil {
-						vals["timeout"] = n * 60
-					}
+				// Strict: support only "<N>s", "<N>m", "<N>h" — the IR
+				// enum is {"3s","30s","15m"}. Earlier versions dropped
+				// anything that didn't end in s or m (e.g. "1h", bare
+				// "30", "30 s") and produced 0 by accident on a few
+				// malformed shapes. Fail fast on unrecognised format
+				// rather than silently feeding the module its default.
+				secs, err := parseDurationToSeconds(cfg.AWSLambda.Timeout, "AWSLambda.Timeout")
+				if err != nil {
+					return nil, err
 				}
+				vals["timeout"] = secs
 			}
 		}
 
@@ -668,7 +762,15 @@ func (m DefaultMapper) BuildModuleValues(
 	case KeyGCPCloudCDN:
 		if cfg != nil && cfg.GCPCloudCDN != nil {
 			if cfg.GCPCloudCDN.DefaultTtl != "" {
-				vals["default_ttl"] = cfg.GCPCloudCDN.DefaultTtl
+				// Module declares default_ttl as `type = number`
+				// (seconds). The IR enum is "0" / "1h" / "1day";
+				// translate to seconds (0 / 3600 / 86400) so the value
+				// passes Terraform's type check.
+				secs, err := parseTTLSeconds(cfg.GCPCloudCDN.DefaultTtl, "GCPCloudCDN.DefaultTtl")
+				if err != nil {
+					return nil, err
+				}
+				vals["default_ttl"] = secs
 			}
 		}
 
@@ -759,6 +861,260 @@ func (m DefaultMapper) BuildModuleValues(
 	}
 
 	return vals, nil
+}
+
+// ---------------------------------------------------------------------------
+// IR → Terraform value translators.
+//
+// These helpers convert the human-friendly enum values reliable's IR uses
+// (e.g. "On demand", "1h", "8 vCPU") into the canonical TF values the
+// downstream modules' variables.tf declarations expect. They live here
+// because every translation is paired with a specific module variable.
+//
+// Design rules:
+//   - On unrecognised input, return *ValidationError (loud).
+//   - The .or(ZNA) escape hatch in reliable's IR lets users pass a TF-canonical
+//     value directly (e.g. "PAY_PER_REQUEST", "db.m7i.large"). Each helper
+//     accepts those passthrough forms in addition to the enum literals so
+//     advanced users aren't blocked by the translation table.
+// ---------------------------------------------------------------------------
+
+var (
+	ddbOnDemandRe      = regexp.MustCompile(`(?i)^\s*(on[\s_-]*demand|pay[_]?per[_]?request)\s*$`)
+	ddbProvRe          = regexp.MustCompile(`(?i)^\s*provisioned\s*$`)
+	leadingIntRe       = regexp.MustCompile(`^\s*(-?\d+)`)
+	storageSizeRe      = regexp.MustCompile(`^\s*(\d+)\s*(GB|TB|MB)\s*$`)
+	mapperDurationRe   = regexp.MustCompile(`^\s*(\d+)\s*([smh])\s*$`)
+)
+
+// canonicalDdbBillingMode maps IR enum values to the uppercase tokens
+// aws/dynamodb/variables.tf accepts: "PAY_PER_REQUEST" or "PROVISIONED".
+func canonicalDdbBillingMode(s string) (string, error) {
+	switch {
+	case ddbOnDemandRe.MatchString(s):
+		return "PAY_PER_REQUEST", nil
+	case ddbProvRe.MatchString(s):
+		return "PROVISIONED", nil
+	default:
+		return "", NewValidationError(fmt.Sprintf(
+			"AWSDynamoDB.Type=%q: expected one of \"On demand\" / \"PAY_PER_REQUEST\" / \"provisioned\" / \"PROVISIONED\"",
+			s,
+		))
+	}
+}
+
+// canonicalRdsInstanceClass maps the IR vCPU enum ("1 vCPU", "4 vCPU",
+// "8 vCPU") to a concrete RDS db.* class. Pass-through if the input
+// already looks like a db.* class so the .or(ZNA) escape hatch works.
+func canonicalRdsInstanceClass(s string) (string, error) {
+	t := strings.TrimSpace(s)
+	if strings.HasPrefix(t, "db.") {
+		return t, nil
+	}
+	switch strings.ToLower(t) {
+	case "1 vcpu":
+		return "db.t3.medium", nil
+	case "4 vcpu":
+		return "db.m7i.xlarge", nil
+	case "8 vcpu":
+		return "db.m7i.2xlarge", nil
+	default:
+		return "", NewValidationError(fmt.Sprintf(
+			"AWSRDS.CPUSize=%q: expected \"1 vCPU\" / \"4 vCPU\" / \"8 vCPU\" or a concrete db.* instance class (e.g. \"db.m7i.large\")",
+			s,
+		))
+	}
+}
+
+// canonicalRedisNodeType maps the IR vCPU enum to a cache.* node type.
+// Pass-through if the input already starts with "cache.".
+func canonicalRedisNodeType(s string) (string, error) {
+	t := strings.TrimSpace(s)
+	if strings.HasPrefix(t, "cache.") {
+		return t, nil
+	}
+	switch strings.ToLower(t) {
+	case "1 vcpu":
+		return "cache.t3.medium", nil
+	case "4 vcpu":
+		return "cache.r6g.xlarge", nil
+	case "8 vcpu":
+		return "cache.r6g.2xlarge", nil
+	default:
+		return "", NewValidationError(fmt.Sprintf(
+			"AWSElastiCache.NodeSize=%q: expected \"1 vCPU\" / \"4 vCPU\" / \"8 vCPU\" or a concrete cache.* node type (e.g. \"cache.r6g.large\")",
+			s,
+		))
+	}
+}
+
+// parseLeadingInt extracts the leading integer from a string like
+// "0 read replicas" / "1 read replica" / "42". Used for IR enums whose
+// human label embeds a number that the corresponding TF variable expects
+// as `type = number`. fieldName is the IR field name for error context.
+func parseLeadingInt(s, fieldName string) (int, error) {
+	m := leadingIntRe.FindStringSubmatch(s)
+	if m == nil {
+		return 0, NewValidationError(fmt.Sprintf(
+			"%s=%q: expected a value beginning with an integer (e.g. \"2 read replicas\")",
+			fieldName, s,
+		))
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil { // unreachable given the regex but keep the type signature honest
+		return 0, NewValidationError(fmt.Sprintf("%s=%q: cannot parse leading integer", fieldName, s))
+	}
+	return n, nil
+}
+
+// parseStorageSizeGB converts "20GB" / "200GB" / "1TB" / "2TB" / "100GB" to
+// an integer number of GB. Bare integers are accepted and treated as GB
+// (matches the kitchen-sink fixtures and the .or(ZNA) escape hatch where
+// users may enter just a number). fieldName is the IR field name for error
+// context.
+func parseStorageSizeGB(s, fieldName string) (int, error) {
+	t := strings.ToUpper(strings.TrimSpace(s))
+	if n, err := strconv.Atoi(t); err == nil && n >= 0 {
+		return n, nil
+	}
+	m := storageSizeRe.FindStringSubmatch(t)
+	if m == nil {
+		return 0, NewValidationError(fmt.Sprintf(
+			"%s=%q: expected an integer (GB) or \"<N>GB\" / \"<N>TB\" / \"<N>MB\" (e.g. \"200\", \"200GB\", \"2TB\")",
+			fieldName, s,
+		))
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, NewValidationError(fmt.Sprintf("%s=%q: cannot parse number", fieldName, s))
+	}
+	switch m[2] {
+	case "TB":
+		return n * 1000, nil // SI GB to match terraform's allocated_storage convention
+	case "GB":
+		return n, nil
+	case "MB":
+		// Round up to the nearest GB; 0MB stays 0.
+		if n == 0 {
+			return 0, nil
+		}
+		gb := (n + 999) / 1000
+		return gb, nil
+	default: // unreachable
+		return 0, NewValidationError(fmt.Sprintf("%s=%q: unexpected unit", fieldName, s))
+	}
+}
+
+// normalizeStorageSizeGBString returns the input expressed as "<N>GB" so
+// modules that declare storage_size as `type = string` and strip the "GB"
+// suffix internally accept the value. Used for OpenSearch's storage_size.
+func normalizeStorageSizeGBString(s, fieldName string) (string, error) {
+	gb, err := parseStorageSizeGB(s, fieldName)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%dGB", gb), nil
+}
+
+// parseTTLSeconds converts a TTL string to seconds. Accepts:
+//   - "0" / "<N>" — bare integer (already in seconds)
+//   - "<N>s" / "<N>m" / "<N>h" — durations
+//   - "1day" / "<N>day" / "<N>days" — day shorthand the IR uses for CDN TTL
+func parseTTLSeconds(s, fieldName string) (int, error) {
+	t := strings.TrimSpace(s)
+
+	// Bare integer
+	if n, err := strconv.Atoi(t); err == nil {
+		if n < 0 {
+			return 0, NewValidationError(fmt.Sprintf("%s=%q: must be >= 0", fieldName, s))
+		}
+		return n, nil
+	}
+
+	// "1day" / "Nday" / "Ndays"
+	low := strings.ToLower(t)
+	for _, suf := range []string{"days", "day", "d"} {
+		if rest, ok := strings.CutSuffix(low, suf); ok {
+			n, err := strconv.Atoi(strings.TrimSpace(rest))
+			if err == nil && n >= 0 {
+				return n * 86400, nil
+			}
+		}
+	}
+
+	// "<N>s" / "<N>m" / "<N>h"
+	if secs, ok := matchDuration(t); ok {
+		return secs, nil
+	}
+
+	return 0, NewValidationError(fmt.Sprintf(
+		"%s=%q: expected seconds, \"<N>s\" / \"<N>m\" / \"<N>h\", or \"<N>day(s)\"",
+		fieldName, s,
+	))
+}
+
+// parseDurationToSeconds is the strict variant for Lambda timeout: only
+// accepts "<N>s" / "<N>m" / "<N>h" (no bare integers, no day suffix).
+func parseDurationToSeconds(s, fieldName string) (int, error) {
+	if secs, ok := matchDuration(strings.TrimSpace(s)); ok {
+		return secs, nil
+	}
+	return 0, NewValidationError(fmt.Sprintf(
+		"%s=%q: expected \"<N>s\" / \"<N>m\" / \"<N>h\" (e.g. \"30s\", \"15m\")",
+		fieldName, s,
+	))
+}
+
+func matchDuration(t string) (int, bool) {
+	m := mapperDurationRe.FindStringSubmatch(t)
+	if m == nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil { // unreachable
+		return 0, false
+	}
+	switch m[2] {
+	case "s":
+		return n, true
+	case "m":
+		return n * 60, true
+	case "h":
+		return n * 3600, true
+	}
+	return 0, false
+}
+
+// parseRetentionHours converts the IR retention enum ("3 days" / "7 days" /
+// "14 days") to integer hours for MSK's retention_hours variable. Also
+// accepts "<N>h" / "<N>d" passthrough for the .or(ZNA) escape hatch.
+func parseRetentionHours(s, fieldName string) (int, error) {
+	t := strings.TrimSpace(s)
+	low := strings.ToLower(t)
+	for _, suf := range []string{" days", " day", "days", "day", "d"} {
+		if rest, ok := strings.CutSuffix(low, suf); ok {
+			n, err := strconv.Atoi(strings.TrimSpace(rest))
+			if err == nil && n > 0 {
+				return n * 24, nil
+			}
+		}
+	}
+	for _, suf := range []string{" hours", " hour", "hours", "hour", "h"} {
+		if rest, ok := strings.CutSuffix(low, suf); ok {
+			n, err := strconv.Atoi(strings.TrimSpace(rest))
+			if err == nil && n > 0 {
+				return n, nil
+			}
+		}
+	}
+	if n, err := strconv.Atoi(t); err == nil && n > 0 {
+		// Bare integer = hours (matches the module's variable directly).
+		return n, nil
+	}
+	return 0, NewValidationError(fmt.Sprintf(
+		"%s=%q: expected \"<N> days\" or \"<N>h\" / \"<N>d\" (e.g. \"7 days\")",
+		fieldName, s,
+	))
 }
 
 // Helpers for backups default_rule parity with TS

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -825,13 +825,27 @@ func (m DefaultMapper) BuildModuleValues(
 		}
 
 	case KeyGCPSecretManager:
-		vals["secret_id"] = "main-secret"
+		// gcp/secretmanager declares `secrets` (a list of objects) with
+		// default `[]` — module composes cleanly when no secrets are
+		// requested. Earlier mapper versions emitted `secret_id =
+		// "main-secret"` which the module never declared, so the value
+		// was silently dropped (audit class — see issue #131-followup).
+		// Drop the orphan emission; users provide secrets via tfvars
+		// when they need them.
 
 	case KeyGCPCloudKMS:
-		vals["key_ring_name"] = "main-keyring"
+		// Module variable is `keyring_name` (default "main"). Earlier
+		// versions emitted `key_ring_name`, which the module never
+		// declared, so the user's chosen ring name was silently dropped
+		// and the default "main" always won.
+		vals["keyring_name"] = "main-keyring"
 
 	case KeyGCPFirestore:
-		vals["database_id"] = "(default)"
+		// gcp/firestore declares only project/region; the module creates
+		// a single (default) database implicitly. Earlier versions
+		// emitted `database_id = "(default)"` against a non-existent
+		// variable (audit class — see issue #131-followup). No emission
+		// needed; the module's behaviour is correct out of the box.
 
 	case KeyGCPAPIGateway:
 		vals["openapi_spec"] = ""

--- a/pkg/composer/mapper_audit_test.go
+++ b/pkg/composer/mapper_audit_test.go
@@ -1,0 +1,535 @@
+package composer
+
+// Tests for the IR → terraform translation bugs catalogued in
+// luthersystems/insideout-terraform-presets#131 (the upstream audit ticket
+// spawned by reliable#1149).
+//
+// Each Test* function below corresponds to one bug in that audit:
+//   1 — DynamoDB billing_mode lower-case → uppercase validation reject
+//   2 — OpenSearch storage_size "1TB" → tonumber() reject
+//   3 — GCP CloudCDN default_ttl string → number reject
+//   4 — ElastiCache replicas string → number reject
+//   5 — RDS key names (node_cpu_size etc.) didn't match module variables
+//   6 — ElastiCache key names (node_size, orphan storage_size)
+//   7 — CloudFront default_ttl key name + value type
+//   8 — MSK retention_period emitted under non-existent variable
+//   9 — Lambda memory_size / timeout silently dropped on bad input
+//
+// Tests assert on the mapper's *intended output* — i.e., the keys it writes
+// to the returned map. The companion cross-module test in compose_stack_test.go
+// (TestMapperKeysSubsetOfModuleVariables) walks the embedded preset bundle
+// and verifies every key the mapper emits is a declared module variable, so
+// renaming a variable upstream without updating the mapper here fails CI.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Inline-struct builders. Config's sub-configs are anonymous structs, so
+// every test that touches them has to redeclare the full type. These helpers
+// absorb the boilerplate.
+// ---------------------------------------------------------------------------
+
+func ddbCfg(typ string) *Config {
+	return &Config{
+		AWSDynamoDB: &struct {
+			Type string `json:"type,omitempty"`
+		}{Type: typ},
+	}
+}
+
+func openSearchCfg(storage string) *Config {
+	return &Config{
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{StorageSize: storage},
+	}
+}
+
+func gcpCdnCfg(ttl string) *Config {
+	return &Config{
+		GCPCloudCDN: &struct {
+			DefaultTtl string `json:"defaultTtl,omitempty"`
+			OriginPath string `json:"originPath,omitempty"`
+			CachePaths string `json:"cachePaths,omitempty"` // DEPRECATED: use OriginPath
+		}{DefaultTtl: ttl},
+	}
+}
+
+func elasticacheCfg(nodeSize, storage, replicas string) *Config {
+	return &Config{
+		AWSElastiCache: &struct {
+			HA       *bool  `json:"ha,omitempty"`
+			Storage  string `json:"storageSize,omitempty"`
+			NodeSize string `json:"nodeSize,omitempty"`
+			Replicas string `json:"replicas,omitempty"`
+		}{NodeSize: nodeSize, Storage: storage, Replicas: replicas},
+	}
+}
+
+func rdsCfg(cpu, replicas, storage string) *Config {
+	return &Config{
+		AWSRDS: &struct {
+			CPUSize      string `json:"cpuSize,omitempty"`
+			ReadReplicas string `json:"readReplicas,omitempty"`
+			StorageSize  string `json:"storageSize,omitempty"`
+		}{CPUSize: cpu, ReadReplicas: replicas, StorageSize: storage},
+	}
+}
+
+func cloudfrontCfg(ttl, originPath string) *Config {
+	var ttlPtr, opPtr *string
+	if ttl != "" {
+		ttlPtr = &ttl
+	}
+	if originPath != "" {
+		opPtr = &originPath
+	}
+	return &Config{
+		AWSCloudfront: &struct {
+			DefaultTtl *string `json:"defaultTtl,omitempty"`
+			OriginPath *string `json:"originPath,omitempty"`
+			CachePaths *string `json:"cachePaths,omitempty"` // DEPRECATED: use OriginPath
+		}{DefaultTtl: ttlPtr, OriginPath: opPtr},
+	}
+}
+
+func mskCfg(retention string) *Config {
+	return &Config{
+		AWSMSK: &struct {
+			Retention string `json:"retentionPeriod,omitempty"`
+		}{Retention: retention},
+	}
+}
+
+func lambdaCfg(runtime, memory, timeout string) *Config {
+	return &Config{
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Runtime: runtime, MemorySize: memory, Timeout: timeout},
+	}
+}
+
+func assertValidationError(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected *ValidationError, got %T: %v", err, err)
+}
+
+// ---------------------------------------------------------------------------
+// 1. DynamoDB billing_mode — must produce uppercase canonical token.
+// ---------------------------------------------------------------------------
+
+func TestBuildModuleValues_AWSDynamoDB_BillingMode(t *testing.T) {
+	m := DefaultMapper{}
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// IR canonical enum literals
+		{"On demand", "PAY_PER_REQUEST"},
+		{"provisioned", "PROVISIONED"},
+		// Case variants
+		{"on demand", "PAY_PER_REQUEST"},
+		{"On Demand", "PAY_PER_REQUEST"},
+		{"PROVISIONED", "PROVISIONED"},
+		{"Provisioned", "PROVISIONED"},
+		// .or(ZNA) escape-hatch passthrough
+		{"PAY_PER_REQUEST", "PAY_PER_REQUEST"},
+		{"pay_per_request", "PAY_PER_REQUEST"},
+		// Forgiving punctuation
+		{"on-demand", "PAY_PER_REQUEST"},
+		{"on_demand", "PAY_PER_REQUEST"},
+		{"  On demand  ", "PAY_PER_REQUEST"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			vals, err := m.BuildModuleValues(KeyAWSDynamoDB, nil, ddbCfg(tc.in), "", "")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, vals["billing_mode"])
+		})
+	}
+
+	t.Run("rejects garbage with ValidationError", func(t *testing.T) {
+		_, err := m.BuildModuleValues(KeyAWSDynamoDB, nil, ddbCfg("free tier"), "", "")
+		assertValidationError(t, err)
+	})
+
+	t.Run("empty Type is a no-op (module default wins)", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSDynamoDB, nil, ddbCfg(""), "", "")
+		require.NoError(t, err)
+		_, hasKey := vals["billing_mode"]
+		assert.False(t, hasKey)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 2. OpenSearch storage_size — module declares string, strips "GB" before
+//    tonumber(). "1TB" passed through verbatim broke that. Normalise to
+//    "<N>GB" so the module's existing replace() works.
+// ---------------------------------------------------------------------------
+
+func TestBuildModuleValues_AWSOpenSearch_StorageSize(t *testing.T) {
+	m := DefaultMapper{}
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"10GB", "10GB"},
+		{"100GB", "100GB"},
+		{"1TB", "1000GB"},
+		{"2TB", "2000GB"},
+		{"  10GB  ", "10GB"},
+		{"10gb", "10GB"}, // case insensitive
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			vals, err := m.BuildModuleValues(KeyAWSOpenSearch, &Components{}, openSearchCfg(tc.in), "", "")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, vals["storage_size"])
+		})
+	}
+
+	t.Run("rejects garbage with ValidationError", func(t *testing.T) {
+		_, err := m.BuildModuleValues(KeyAWSOpenSearch, &Components{}, openSearchCfg("huge"), "", "")
+		assertValidationError(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 3. GCP CloudCDN default_ttl — module declares type = number; strings like
+//    "1h" / "1day" rejected at plan time. Translate to seconds.
+// ---------------------------------------------------------------------------
+
+func TestBuildModuleValues_GCPCloudCDN_DefaultTTL(t *testing.T) {
+	m := DefaultMapper{}
+
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"0", 0},
+		{"1h", 3600},
+		{"1day", 86400},
+		{"30s", 30},
+		{"5m", 300},
+		{"7days", 7 * 86400},
+		{"3600", 3600}, // bare seconds passthrough
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			vals, err := m.BuildModuleValues(KeyGCPCloudCDN, nil, gcpCdnCfg(tc.in), "", "")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, vals["default_ttl"])
+		})
+	}
+
+	t.Run("rejects garbage with ValidationError", func(t *testing.T) {
+		_, err := m.BuildModuleValues(KeyGCPCloudCDN, nil, gcpCdnCfg("forever"), "", "")
+		assertValidationError(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 4. ElastiCache replicas — module variable is type = number with
+//    validation >= 0. IR enum embeds the integer in a label.
+// ---------------------------------------------------------------------------
+
+func TestBuildModuleValues_AWSElastiCache_Replicas(t *testing.T) {
+	m := DefaultMapper{}
+
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"0 read replicas", 0},
+		{"1 read replica", 1},
+		{"2 read replicas", 2},
+		{"3", 3}, // bare integer passthrough
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			vals, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("", "", tc.in), "", "")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, vals["replicas"])
+		})
+	}
+
+	t.Run("rejects non-numeric replicas with ValidationError", func(t *testing.T) {
+		_, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("", "", "many"), "", "")
+		assertValidationError(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 5. RDS keys — must match the module's actual variables.tf declarations.
+//    instance_class / read_replica_count / allocated_storage. The old
+//    node_cpu_size / num_read_nodes / storage_size keys must NOT be emitted.
+// ---------------------------------------------------------------------------
+
+func TestBuildModuleValues_AWSRDS_VariableNames(t *testing.T) {
+	m := DefaultMapper{}
+
+	t.Run("emits canonical instance_class / read_replica_count / allocated_storage", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("8 vCPU", "2 read replicas", "2TB"), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "db.m7i.2xlarge", vals["instance_class"])
+		assert.Equal(t, 2, vals["read_replica_count"])
+		assert.Equal(t, 2000, vals["allocated_storage"])
+	})
+
+	t.Run("does NOT emit pre-fix key names that the module never declared", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("4 vCPU", "1 read replica", "200GB"), "", "")
+		require.NoError(t, err)
+		_, hasOld1 := vals["node_cpu_size"]
+		_, hasOld2 := vals["num_read_nodes"]
+		// storage_size is the same name on both sides; in RDS we now emit
+		// allocated_storage instead, so check that explicitly.
+		assert.False(t, hasOld1, "node_cpu_size should not be emitted for RDS")
+		assert.False(t, hasOld2, "num_read_nodes should not be emitted for RDS")
+		assert.Equal(t, "db.m7i.xlarge", vals["instance_class"])
+		assert.Equal(t, 1, vals["read_replica_count"])
+		assert.Equal(t, 200, vals["allocated_storage"])
+		_, hasStorageSize := vals["storage_size"]
+		assert.False(t, hasStorageSize, "storage_size should not be emitted for RDS — module variable is allocated_storage")
+	})
+
+	t.Run("1 vCPU maps to db.t3.medium", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("1 vCPU", "", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "db.t3.medium", vals["instance_class"])
+	})
+
+	t.Run("db.* passthrough (escape hatch)", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("db.r6g.4xlarge", "", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "db.r6g.4xlarge", vals["instance_class"])
+	})
+
+	t.Run("rejects unknown CPU label with ValidationError", func(t *testing.T) {
+		_, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("16 vCPU", "", ""), "", "")
+		assertValidationError(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 6. ElastiCache keys — node_type (not node_size); no storage_size.
+// ---------------------------------------------------------------------------
+
+func TestBuildModuleValues_AWSElastiCache_VariableNames(t *testing.T) {
+	m := DefaultMapper{}
+
+	t.Run("emits canonical node_type, drops orphan storage_size", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("8 vCPU", "20GB", "2 read replicas"), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "cache.r6g.2xlarge", vals["node_type"])
+		_, hasNodeSize := vals["node_size"]
+		assert.False(t, hasNodeSize, "node_size should not be emitted — module variable is node_type")
+		_, hasStorage := vals["storage_size"]
+		assert.False(t, hasStorage, "storage_size should not be emitted — Redis is not capacity-priced")
+		assert.Equal(t, 2, vals["replicas"])
+	})
+
+	t.Run("1 vCPU maps to cache.t3.medium", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("1 vCPU", "", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "cache.t3.medium", vals["node_type"])
+	})
+
+	t.Run("4 vCPU maps to cache.r6g.xlarge", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("4 vCPU", "", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "cache.r6g.xlarge", vals["node_type"])
+	})
+
+	t.Run("cache.* passthrough", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("cache.m6g.large", "", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "cache.m6g.large", vals["node_type"])
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 7. CloudFront — module variable is default_ttl_seconds (number), not
+//    default_ttl (string). origin_path is unchanged.
+// ---------------------------------------------------------------------------
+
+func TestBuildModuleValues_AWSCloudfront_VariableNames(t *testing.T) {
+	m := DefaultMapper{}
+
+	t.Run("default_ttl translates to default_ttl_seconds (number)", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSCloudfront, nil, cloudfrontCfg("1h", "/v1"), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, 3600, vals["default_ttl_seconds"])
+		_, hasOld := vals["default_ttl"]
+		assert.False(t, hasOld, "default_ttl (string) should not be emitted — module variable is default_ttl_seconds")
+		assert.Equal(t, "/v1", vals["origin_path"])
+	})
+
+	t.Run("0 stays 0 seconds", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSCloudfront, nil, cloudfrontCfg("0", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, 0, vals["default_ttl_seconds"])
+	})
+
+	t.Run("1day → 86400", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSCloudfront, nil, cloudfrontCfg("1day", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, 86400, vals["default_ttl_seconds"])
+	})
+
+	t.Run("rejects garbage TTL with ValidationError", func(t *testing.T) {
+		_, err := m.BuildModuleValues(KeyAWSCloudfront, nil, cloudfrontCfg("forever", ""), "", "")
+		assertValidationError(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 8. MSK — module now declares retention_hours; mapper translates the IR
+//    enum and emits under that key (was retention_period, undeclared).
+// ---------------------------------------------------------------------------
+
+func TestBuildModuleValues_AWSMSK_RetentionHours(t *testing.T) {
+	m := DefaultMapper{}
+
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"3 days", 72},
+		{"7 days", 168},
+		{"14 days", 336},
+		{"168h", 168}, // escape-hatch passthrough
+		{"7d", 168},
+		{"168", 168}, // bare integer = hours
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			vals, err := m.BuildModuleValues(KeyAWSMSK, nil, mskCfg(tc.in), "", "")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, vals["retention_hours"])
+			_, hasOld := vals["retention_period"]
+			assert.False(t, hasOld, "retention_period should not be emitted — module variable is retention_hours")
+		})
+	}
+
+	t.Run("rejects garbage with ValidationError", func(t *testing.T) {
+		_, err := m.BuildModuleValues(KeyAWSMSK, nil, mskCfg("forever"), "", "")
+		assertValidationError(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 8b. SQS — bonus finding the subset-check test surfaced beyond the audit:
+//     mapper emitted `type` / `visibility_timeout`; module variables are
+//     `queue_type` / `visibility_timeout_seconds`.
+// ---------------------------------------------------------------------------
+
+func sqsCfg(typ, visTimeout string) *Config {
+	return &Config{
+		AWSSQS: &struct {
+			Type              string `json:"type,omitempty"`
+			VisibilityTimeout string `json:"visibilityTimeout,omitempty"`
+		}{Type: typ, VisibilityTimeout: visTimeout},
+	}
+}
+
+func TestBuildModuleValues_AWSSQS_VariableNames(t *testing.T) {
+	m := DefaultMapper{}
+
+	t.Run("emits queue_type / visibility_timeout_seconds (not type / visibility_timeout)", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSSQS, nil, sqsCfg("FIFO", "600"), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "FIFO", vals["queue_type"])
+		assert.Equal(t, 600, vals["visibility_timeout_seconds"])
+		_, hasOldType := vals["type"]
+		_, hasOldVis := vals["visibility_timeout"]
+		assert.False(t, hasOldType, "type is the pre-fix key — module variable is queue_type")
+		assert.False(t, hasOldVis, "visibility_timeout is the pre-fix key — module variable is visibility_timeout_seconds")
+	})
+
+	t.Run("VisibilityTimeout supports duration suffix", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSSQS, nil, sqsCfg("Standard", "10m"), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, 600, vals["visibility_timeout_seconds"])
+	})
+
+	t.Run("rejects garbage VisibilityTimeout with ValidationError", func(t *testing.T) {
+		_, err := m.BuildModuleValues(KeyAWSSQS, nil, sqsCfg("Standard", "soon"), "", "")
+		assertValidationError(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 9. Lambda — strict parsers; loud failure on unrecognised input.
+// ---------------------------------------------------------------------------
+
+func TestBuildModuleValues_AWSLambda_MemoryAndTimeout(t *testing.T) {
+	m := DefaultMapper{}
+
+	t.Run("happy path: IR enum values translate", func(t *testing.T) {
+		cases := []struct {
+			memory string
+			tmout  string
+			wantM  int
+			wantT  int
+		}{
+			{"128", "3s", 128, 3},
+			{"512", "30s", 512, 30},
+			{"1024", "15m", 1024, 900},
+			{"3072", "1h", 3072, 3600},
+		}
+		for _, tc := range cases {
+			t.Run(tc.memory+"/"+tc.tmout, func(t *testing.T) {
+				vals, err := m.BuildModuleValues(KeyAWSLambda, nil, lambdaCfg("", tc.memory, tc.tmout), "", "")
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantM, vals["memory_size"])
+				assert.Equal(t, tc.wantT, vals["timeout"])
+			})
+		}
+	})
+
+	t.Run("rejects non-integer memory_size with ValidationError", func(t *testing.T) {
+		// Previously silently dropped — module default would have won.
+		_, err := m.BuildModuleValues(KeyAWSLambda, nil, lambdaCfg("", "512MB", ""), "", "")
+		assertValidationError(t, err)
+	})
+
+	t.Run("rejects bare-integer timeout (no unit) with ValidationError", func(t *testing.T) {
+		_, err := m.BuildModuleValues(KeyAWSLambda, nil, lambdaCfg("", "", "30"), "", "")
+		assertValidationError(t, err)
+	})
+
+	t.Run("rejects unknown timeout unit with ValidationError", func(t *testing.T) {
+		_, err := m.BuildModuleValues(KeyAWSLambda, nil, lambdaCfg("", "", "5y"), "", "")
+		assertValidationError(t, err)
+	})
+
+	t.Run("runtime defaults still apply when memory/timeout absent", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyAWSLambda, nil, lambdaCfg("", "", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nodejs20.x", vals["runtime"])
+		_, hasMem := vals["memory_size"]
+		_, hasTmout := vals["timeout"]
+		assert.False(t, hasMem)
+		assert.False(t, hasTmout)
+	})
+}

--- a/pkg/composer/mapper_audit_test.go
+++ b/pkg/composer/mapper_audit_test.go
@@ -533,3 +533,50 @@ func TestBuildModuleValues_AWSLambda_MemoryAndTimeout(t *testing.T) {
 		assert.False(t, hasTmout)
 	})
 }
+
+// ---------------------------------------------------------------------------
+// 10–12. Audit-class follow-ups surfaced when the subset test was refactored
+//        to range over the full ComponentKey registry instead of a static
+//        13-entry allowlist. Each is the same shape as findings 5–8: mapper
+//        emitted under a key the module never declared, so the value was
+//        silently dropped at compose time.
+// ---------------------------------------------------------------------------
+
+// 10. GCP Cloud KMS — module variable is `keyring_name` (one word), not
+//     `key_ring_name` (two). Pre-fix mapper emitted the latter, silently
+//     dropped, and the module default "main" always won.
+func TestBuildModuleValues_GCPCloudKMS_KeyringName(t *testing.T) {
+	m := DefaultMapper{}
+
+	vals, err := m.BuildModuleValues(KeyGCPCloudKMS, nil, nil, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, "main-keyring", vals["keyring_name"])
+	_, hasOld := vals["key_ring_name"]
+	assert.False(t, hasOld, "key_ring_name is the pre-fix key — module variable is keyring_name")
+}
+
+// 11. GCP Secret Manager — module variable is `secrets` (list of objects)
+//     with default `[]`. Pre-fix mapper emitted `secret_id = "main-secret"`
+//     against a non-existent variable; value silently dropped. Drop the
+//     orphan emission so the mapper's output is honest about what it can
+//     actually configure.
+func TestBuildModuleValues_GCPSecretManager_NoOrphanSecretID(t *testing.T) {
+	m := DefaultMapper{}
+
+	vals, err := m.BuildModuleValues(KeyGCPSecretManager, nil, nil, "", "")
+	require.NoError(t, err)
+	_, hasOld := vals["secret_id"]
+	assert.False(t, hasOld, "secret_id is the pre-fix orphan key — gcp/secretmanager declares `secrets` (list); leave it to user tfvars")
+}
+
+// 12. GCP Firestore — module declares only project/region; the (default)
+//     database is created implicitly. Pre-fix mapper emitted
+//     `database_id = "(default)"` against a non-existent variable.
+func TestBuildModuleValues_GCPFirestore_NoOrphanDatabaseID(t *testing.T) {
+	m := DefaultMapper{}
+
+	vals, err := m.BuildModuleValues(KeyGCPFirestore, nil, nil, "", "")
+	require.NoError(t, err)
+	_, hasOld := vals["database_id"]
+	assert.False(t, hasOld, "database_id is the pre-fix orphan key — gcp/firestore declares no such variable")
+}

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -1,0 +1,163 @@
+package composer
+
+// TestMapperKeysSubsetOfModuleVariables is the generic safety net for the
+// upstream issue #131 audit — it verifies that every key the mapper writes
+// for a given component is a declared variable in that module's
+// variables.tf. The existing TestComposeStack_TFVarsMatchVariables only
+// checks the *root* variables.tf the composer assembles, which means it
+// can't catch mapper bugs where compose.go silently filters out tfvars
+// whose key isn't a declared module variable (the most common shape of
+// audit findings 5–8).
+//
+// Adding a new mapper case that writes a key the target module didn't
+// declare will fail this test. Renaming a module variable upstream
+// without updating the mapper will fail this test.
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// kitchenSinkConfig populates every cfg sub-struct the mapper reads with
+// values that exercise each mapper branch. Used to drive a single mapper
+// invocation per ComponentKey for the cross-module check below.
+func kitchenSinkConfig() *Config {
+	ttl := "1h"
+	op := "/v1"
+	t := true
+
+	return &Config{
+		Cloud:  "aws",
+		Region: "us-east-1",
+		AWSCloudfront: &struct {
+			DefaultTtl *string `json:"defaultTtl,omitempty"`
+			OriginPath *string `json:"originPath,omitempty"`
+			CachePaths *string `json:"cachePaths,omitempty"` // DEPRECATED: use OriginPath
+		}{DefaultTtl: &ttl, OriginPath: &op},
+		AWSRDS: &struct {
+			CPUSize      string `json:"cpuSize,omitempty"`
+			ReadReplicas string `json:"readReplicas,omitempty"`
+			StorageSize  string `json:"storageSize,omitempty"`
+		}{CPUSize: "8 vCPU", ReadReplicas: "2 read replicas", StorageSize: "200GB"},
+		AWSElastiCache: &struct {
+			HA       *bool  `json:"ha,omitempty"`
+			Storage  string `json:"storageSize,omitempty"`
+			NodeSize string `json:"nodeSize,omitempty"`
+			Replicas string `json:"replicas,omitempty"`
+		}{HA: &t, Storage: "20GB", NodeSize: "8 vCPU", Replicas: "2 read replicas"},
+		AWSS3: &struct {
+			Versioning *bool `json:"versioning,omitempty"`
+		}{Versioning: &t},
+		AWSDynamoDB: &struct {
+			Type string `json:"type,omitempty"`
+		}{Type: "On demand"},
+		AWSSQS: &struct {
+			Type              string `json:"type,omitempty"`
+			VisibilityTimeout string `json:"visibilityTimeout,omitempty"`
+		}{Type: "FIFO", VisibilityTimeout: "600"},
+		AWSMSK: &struct {
+			Retention string `json:"retentionPeriod,omitempty"`
+		}{Retention: "7 days"},
+		AWSCloudWatchLogs: &struct {
+			RetentionDays int `json:"retentionDays,omitempty"`
+		}{RetentionDays: 90},
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Runtime: "nodejs20.x", MemorySize: "512", Timeout: "30s"},
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "managed", InstanceType: "t3.medium.search", StorageSize: "1TB", MultiAZ: &t},
+		AWSKMS: &struct {
+			NumKeys string `json:"numKeys,omitempty"`
+		}{NumKeys: "1"},
+		AWSSecretsManager: &struct {
+			NumSecrets string `json:"numSecrets,omitempty"`
+		}{NumSecrets: "1"},
+		GCPCloudCDN: &struct {
+			DefaultTtl string `json:"defaultTtl,omitempty"`
+			OriginPath string `json:"originPath,omitempty"`
+			CachePaths string `json:"cachePaths,omitempty"` // DEPRECATED: use OriginPath
+		}{DefaultTtl: "1h"},
+	}
+}
+
+// keysToCheck enumerates the ComponentKeys whose mapper cases write
+// component-specific tfvars (i.e., where a stale key name silently
+// drops the user's choice). Common keys (project / region / environment)
+// and preview-stub keys (vpc_id / subnet_ids / cluster_name) are read
+// from this same list because every module that uses them declares them.
+//
+// Each entry is paired with the cloud prefix used by GetPresetPath.
+var mapperKeyCheckTargets = []struct {
+	key   ComponentKey
+	cloud string
+}{
+	{KeyAWSDynamoDB, "aws"},
+	{KeyAWSOpenSearch, "aws"},
+	{KeyAWSElastiCache, "aws"},
+	{KeyAWSRDS, "aws"},
+	{KeyAWSCloudfront, "aws"},
+	{KeyAWSMSK, "aws"},
+	{KeyAWSLambda, "aws"},
+	{KeyAWSSQS, "aws"},
+	{KeyAWSCloudWatchLogs, "aws"},
+	{KeyAWSKMS, "aws"},
+	{KeyAWSSecretsManager, "aws"},
+	{KeyAWSS3, "aws"},
+	{KeyGCPCloudCDN, "gcp"},
+}
+
+func TestMapperKeysSubsetOfModuleVariables(t *testing.T) {
+	m := DefaultMapper{}
+	cfg := kitchenSinkConfig()
+	c := newTestClient()
+
+	varDeclRe := regexp.MustCompile(`variable\s+"([^"]+)"`)
+
+	for _, tt := range mapperKeyCheckTargets {
+		t.Run(string(tt.key), func(t *testing.T) {
+			vals, err := m.BuildModuleValues(tt.key, &Components{}, cfg, "test", "us-east-1")
+			require.NoError(t, err, "mapper should not fail with the kitchen-sink config")
+
+			presetPath := GetPresetPath(tt.cloud, tt.key, &Components{})
+			files, err := c.GetPresetFiles(presetPath)
+			require.NoError(t, err, "GetPresetFiles(%s)", presetPath)
+			varsTF, ok := files["/variables.tf"]
+			require.True(t, ok, "%s should have a /variables.tf", presetPath)
+
+			declared := map[string]bool{}
+			for _, m := range varDeclRe.FindAllStringSubmatch(string(varsTF), -1) {
+				declared[m[1]] = true
+			}
+
+			// Common keys that DefaultMapper unconditionally sets for every
+			// component. AWS modules consistently declare all three; some
+			// GCP modules don't declare environment yet (tracked separately
+			// from this audit). The mismatch isn't an audit-class user-data
+			// bug — it's a metadata default that just gets dropped — so
+			// exempt these from the strict subset check.
+			commonDefaults := map[string]bool{
+				"project":     true,
+				"region":      true,
+				"environment": true,
+			}
+
+			for k := range vals {
+				if commonDefaults[k] {
+					continue
+				}
+				assert.True(t, declared[k],
+					"mapper for %s emits key %q which is not declared in %s/variables.tf — declared: %v",
+					tt.key, k, presetPath, sortedKeys(declared))
+			}
+		})
+	}
+}

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -89,32 +89,6 @@ func kitchenSinkConfig() *Config {
 	}
 }
 
-// keysToCheck enumerates the ComponentKeys whose mapper cases write
-// component-specific tfvars (i.e., where a stale key name silently
-// drops the user's choice). Common keys (project / region / environment)
-// and preview-stub keys (vpc_id / subnet_ids / cluster_name) are read
-// from this same list because every module that uses them declares them.
-//
-// Each entry is paired with the cloud prefix used by GetPresetPath.
-var mapperKeyCheckTargets = []struct {
-	key   ComponentKey
-	cloud string
-}{
-	{KeyAWSDynamoDB, "aws"},
-	{KeyAWSOpenSearch, "aws"},
-	{KeyAWSElastiCache, "aws"},
-	{KeyAWSRDS, "aws"},
-	{KeyAWSCloudfront, "aws"},
-	{KeyAWSMSK, "aws"},
-	{KeyAWSLambda, "aws"},
-	{KeyAWSSQS, "aws"},
-	{KeyAWSCloudWatchLogs, "aws"},
-	{KeyAWSKMS, "aws"},
-	{KeyAWSSecretsManager, "aws"},
-	{KeyAWSS3, "aws"},
-	{KeyGCPCloudCDN, "gcp"},
-}
-
 func TestMapperKeysSubsetOfModuleVariables(t *testing.T) {
 	m := DefaultMapper{}
 	cfg := kitchenSinkConfig()
@@ -122,12 +96,23 @@ func TestMapperKeysSubsetOfModuleVariables(t *testing.T) {
 
 	varDeclRe := regexp.MustCompile(`variable\s+"([^"]+)"`)
 
-	for _, tt := range mapperKeyCheckTargets {
-		t.Run(string(tt.key), func(t *testing.T) {
-			vals, err := m.BuildModuleValues(tt.key, &Components{}, cfg, "test", "us-east-1")
+	// Common keys DefaultMapper unconditionally sets for every component.
+	// AWS modules consistently declare all three; most GCP modules don't
+	// declare environment yet — that's a metadata-default mismatch the
+	// composer drops, not an audit-class user-data bug. Exempt them so
+	// this test stays focused on the audit class.
+	commonDefaults := map[string]bool{
+		"project":     true,
+		"region":      true,
+		"environment": true,
+	}
+
+	for _, key := range AllComponentKeys {
+		t.Run(string(key), func(t *testing.T) {
+			vals, err := m.BuildModuleValues(key, &Components{}, cfg, "test", "us-east-1")
 			require.NoError(t, err, "mapper should not fail with the kitchen-sink config")
 
-			presetPath := GetPresetPath(tt.cloud, tt.key, &Components{})
+			presetPath := GetPresetPath(CloudFor(key), key, &Components{})
 			files, err := c.GetPresetFiles(presetPath)
 			require.NoError(t, err, "GetPresetFiles(%s)", presetPath)
 			varsTF, ok := files["/variables.tf"]
@@ -138,26 +123,56 @@ func TestMapperKeysSubsetOfModuleVariables(t *testing.T) {
 				declared[m[1]] = true
 			}
 
-			// Common keys that DefaultMapper unconditionally sets for every
-			// component. AWS modules consistently declare all three; some
-			// GCP modules don't declare environment yet (tracked separately
-			// from this audit). The mismatch isn't an audit-class user-data
-			// bug — it's a metadata default that just gets dropped — so
-			// exempt these from the strict subset check.
-			commonDefaults := map[string]bool{
-				"project":     true,
-				"region":      true,
-				"environment": true,
-			}
-
 			for k := range vals {
 				if commonDefaults[k] {
 					continue
 				}
 				assert.True(t, declared[k],
 					"mapper for %s emits key %q which is not declared in %s/variables.tf — declared: %v",
-					tt.key, k, presetPath, sortedKeys(declared))
+					key, k, presetPath, sortedKeys(declared))
 			}
 		})
+	}
+}
+
+// TestAllComponentKeysCoversPresetKeyMap is the registry-consistency
+// guard. AllComponentKeys is the source of truth for which keys back a
+// preset module; PresetKeyMap is the source of truth for the preset
+// directory name. Every key in PresetKeyMap (minus KeySplunk/KeyDatadog,
+// which are toggles with no in-repo preset) must appear in
+// AllComponentKeys, and vice versa. Adding a new component key without
+// updating both lists breaks this test loudly rather than silently
+// dropping the new component from the subset-check coverage.
+func TestAllComponentKeysCoversPresetKeyMap(t *testing.T) {
+	registry := map[ComponentKey]bool{}
+	for _, k := range AllComponentKeys {
+		registry[k] = true
+	}
+
+	// Keys present in PresetKeyMap but intentionally excluded from
+	// AllComponentKeys (no in-repo preset; consumed elsewhere).
+	exempt := map[ComponentKey]bool{
+		KeySplunk:  true,
+		KeyDatadog: true,
+	}
+
+	for k := range PresetKeyMap {
+		if exempt[k] {
+			continue
+		}
+		assert.True(t, registry[k],
+			"PresetKeyMap[%s] is set but AllComponentKeys is missing it — every preset-backed key must be in the registry so the subset test exercises it",
+			k)
+	}
+
+	// And the reverse: every registry entry must resolve to a preset
+	// path. KeyAWSEKSControlPlane is the special case — it isn't in
+	// PresetKeyMap (GetPresetPath uses string(k)="resource" for it) but
+	// does back the aws/resource module.
+	for _, k := range AllComponentKeys {
+		_, inMap := PresetKeyMap[k]
+		if !inMap && k != KeyAWSEKSControlPlane {
+			t.Errorf("AllComponentKeys[%s] is registered but has no PresetKeyMap entry", k)
+		}
 	}
 }

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -416,7 +416,11 @@ func TestBuildModuleValues_Cloudfront_OriginPath(t *testing.T) {
 		assert.Equal(t, "/assets", vals["origin_path"])
 	})
 
-	t.Run("defaultTtl maps to default_ttl", func(t *testing.T) {
+	t.Run("defaultTtl maps to default_ttl_seconds (number)", func(t *testing.T) {
+		// The CloudFront module variable is default_ttl_seconds (number).
+		// Earlier mapper versions emitted default_ttl (string), which the
+		// module never declared, so the user pick was silently dropped.
+		// See upstream issue #131.
 		ttl := "3600"
 		cfg := &Config{
 			AWSCloudfront: &struct {
@@ -427,7 +431,9 @@ func TestBuildModuleValues_Cloudfront_OriginPath(t *testing.T) {
 		}
 		vals, err := m.BuildModuleValues(KeyAWSCloudfront, nil, cfg, "", "")
 		require.NoError(t, err)
-		assert.Equal(t, "3600", vals["default_ttl"])
+		assert.Equal(t, 3600, vals["default_ttl_seconds"])
+		_, hasOld := vals["default_ttl"]
+		assert.False(t, hasOld, "default_ttl (string) is the pre-fix key — must not be emitted")
 	})
 }
 
@@ -617,7 +623,13 @@ func TestBuildModuleValues_AWSEC2_CpuArchPrecedence(t *testing.T) {
 func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 	m := DefaultMapper{}
 
-	t.Run("ReadReplicas set emits num_read_nodes", func(t *testing.T) {
+	// The RDS module's actual variable names are instance_class /
+	// read_replica_count / allocated_storage. Earlier versions emitted
+	// node_cpu_size / num_read_nodes / storage_size — none of which the
+	// module declared, so user picks were silently dropped. See upstream
+	// issue #131.
+
+	t.Run("ReadReplicas set emits read_replica_count (number)", func(t *testing.T) {
 		cfg := &Config{AWSRDS: &struct {
 			CPUSize      string `json:"cpuSize,omitempty"`
 			ReadReplicas string `json:"readReplicas,omitempty"`
@@ -625,10 +637,12 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 		}{ReadReplicas: "2"}}
 		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, cfg, "", "")
 		require.NoError(t, err)
-		assert.Equal(t, "2", vals["num_read_nodes"])
+		assert.Equal(t, 2, vals["read_replica_count"])
+		_, hasOld := vals["num_read_nodes"]
+		assert.False(t, hasOld, "num_read_nodes is the pre-fix key — must not be emitted")
 	})
 
-	t.Run("ReadReplicas unset leaves num_read_nodes unset", func(t *testing.T) {
+	t.Run("ReadReplicas unset leaves read_replica_count unset", func(t *testing.T) {
 		cfg := &Config{AWSRDS: &struct {
 			CPUSize      string `json:"cpuSize,omitempty"`
 			ReadReplicas string `json:"readReplicas,omitempty"`
@@ -636,11 +650,11 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 		}{CPUSize: "db.m7i.2xlarge"}}
 		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, cfg, "", "")
 		require.NoError(t, err)
-		_, hasKey := vals["num_read_nodes"]
-		assert.False(t, hasKey, "unset ReadReplicas should not emit num_read_nodes")
+		_, hasKey := vals["read_replica_count"]
+		assert.False(t, hasKey, "unset ReadReplicas should not emit read_replica_count")
 	})
 
-	t.Run("CPUSize and StorageSize map to node_cpu_size and storage_size", func(t *testing.T) {
+	t.Run("CPUSize and StorageSize map to instance_class and allocated_storage", func(t *testing.T) {
 		cfg := &Config{AWSRDS: &struct {
 			CPUSize      string `json:"cpuSize,omitempty"`
 			ReadReplicas string `json:"readReplicas,omitempty"`
@@ -648,8 +662,12 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 		}{CPUSize: "db.m7i.2xlarge", StorageSize: "20"}}
 		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, cfg, "", "")
 		require.NoError(t, err)
-		assert.Equal(t, "db.m7i.2xlarge", vals["node_cpu_size"])
-		assert.Equal(t, "20", vals["storage_size"])
+		assert.Equal(t, "db.m7i.2xlarge", vals["instance_class"])
+		assert.Equal(t, 20, vals["allocated_storage"])
+		_, hasOldCPU := vals["node_cpu_size"]
+		_, hasOldStorage := vals["storage_size"]
+		assert.False(t, hasOldCPU, "node_cpu_size is the pre-fix key — must not be emitted")
+		assert.False(t, hasOldStorage, "storage_size is the pre-fix key — RDS module variable is allocated_storage")
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes the eight composer-mapper bugs catalogued in #131 plus three additional bugs of the same audit class (12 total) and refactors the cross-module test from a 13-entry static allowlist to a registry over all 52 component keys so this class of bug fails CI loudly going forward.

The shape: `pkg/composer/mapper.go` emitted tfvars under keys the corresponding module's `variables.tf` didn't declare, or sent string values where the module declared `type = number`. The composer's `compose.go` silently filters out tfvars with undeclared keys, so for half the bugs the user's pick was just lost (module default won at deploy time). The other half hit `tonumber()` casts or `validation { … }` blocks and rejected at plan time.

## What changed

**`pkg/composer/mapper.go` per-field fixes** (one helper `var` block + a section of canonicalising helpers; all branches now route through the helpers and return `*ValidationError` on garbage):

| # | Component | Old emit (broken) | New emit |
|---|---|---|---|
| 1 | AWS DynamoDB | `billing_mode = strings.ToLower(...)` (lowercase) | uppercase canonical via regex |
| 2 | AWS OpenSearch | `storage_size = "1TB"` (verbatim) | `storage_size = "1000GB"` (normalised) |
| 3 | GCP CloudCDN | `default_ttl = "1h"` (string) | `default_ttl = 3600` (number) |
| 4 | AWS ElastiCache | `replicas = "2 read replicas"` (string) | `replicas = 2` (number) |
| 5 | AWS RDS | `node_cpu_size` / `num_read_nodes` / `storage_size` | `instance_class` / `read_replica_count` (number) / `allocated_storage` (number) |
| 6 | AWS ElastiCache | `node_size` / `storage_size` (orphan) | `node_type`; storage_size dropped (Redis isn't capacity-priced) |
| 7 | AWS CloudFront | `default_ttl = "3600"` (string under wrong key) | `default_ttl_seconds = 3600` (number, correct key) |
| 8 | AWS MSK | `retention_period` (under non-existent var) | `retention_hours = 168` against new module var |
| 9 | AWS Lambda | silent drop on unrecognised memory/timeout format | `*ValidationError` |
| — | AWS SQS *(bonus from subset test)* | `type` / `visibility_timeout` | `queue_type` / `visibility_timeout_seconds` (number) |
| 10 | GCP Cloud KMS *(surfaced by registry refactor)* | `key_ring_name` (under non-existent var) | `keyring_name` |
| 11 | GCP Secret Manager *(surfaced by registry refactor)* | `secret_id = "main-secret"` (under non-existent var; module declares `secrets`) | drop emit; module default `secrets = []` composes cleanly |
| 12 | GCP Firestore *(surfaced by registry refactor)* | `database_id = "(default)"` (under non-existent var) | drop emit; (default) database created implicitly |

**`aws/msk/`** gains a real `retention_hours` variable; `aws/msk/main.tf:92`'s hardcoded `log.retention.hours = 168` becomes `${var.retention_hours}`.

**`pkg/composer/contracts.go`** gains `AllComponentKeys` (registry of all 52 preset-backed component keys) and `CloudFor(key)` so the subset test can range over the full surface programmatically instead of an allowlist.

The `.or(ZNA)` escape hatch in reliable's IR is preserved end-to-end — passing `"PAY_PER_REQUEST"`, `"db.m7i.large"`, `"cache.r6g.large"`, or a TF-canonical number bypasses the translation table cleanly.

## Tests

- **`pkg/composer/mapper_audit_test.go`** — table-driven assertions on every emitted key and value for each of the 12 bugs, including `.or(ZNA)` passthrough and `*ValidationError` on garbage. ~300 LOC, 12 `Test*` functions, ~55 subcases.
- **`pkg/composer/mapper_keys_subset_test.go`** — the generic safety net, refactored. Ranges over `AllComponentKeys` (52 entries; up from 13) and asserts every emitted key is a declared module variable. Adding a new mapper case that writes a key the target module didn't declare fails this test in CI.
- **`pkg/composer/mapper_keys_subset_test.go::TestAllComponentKeysCoversPresetKeyMap`** — registry-consistency guard. Adding a new component key without updating both `PresetKeyMap` and `AllComponentKeys` fails CI loudly.
- **`pkg/composer/mapper_test.go`** — updated two existing tests (`TestBuildModuleValues_Postgres_RDSConfig`, `TestBuildModuleValues_Cloudfront_OriginPath/defaultTtl_maps_to_default_ttl`) that were locking in the buggy behaviour by asserting on the old key names.

`go test ./...` passes; existing integration tests (`TestComposeStack_TerraformInit`, `TestComposeStack_OutputsTF_KitchenSink`, `TestComposeStack_TFVarsMatchVariables`) continue to pass.

## Test plan

- [x] `go test ./pkg/composer/... -count=1` — all green
- [x] `go test ./pkg/composer/ -run TestMapperKeysSubsetOfModuleVariables -v` — all 52 components pass
- [x] `go test ./pkg/composer/ -run TestAllComponentKeysCoversPresetKeyMap -v` — registry consistent
- [x] CI: 78/78 checks pass on the latest commit
- [ ] Reviewer sanity check: revert any single fix line in `mapper.go` and confirm a test in `mapper_audit_test.go` and the subset test both fail (the tests assert exact key names and values, so reversion is locked-in by construction)
- [ ] After merge: cut `v0.4.1` so reliable can bump

## Out of scope (deferred follow-ups)

- 23 GCP modules don't declare `environment`; the mapper unconditionally sets it and the composer drops it for those. Pre-existing metadata inconsistency, not user-data corruption — exempted from the subset check with a comment. Worth a follow-up to add `environment` to GCP modules for tagging parity.
- Kitchen-sink config in the subset test exercises cfg branches for ~17 components. Other components are tested only against their unconditional-emit paths (preview stubs etc.), which is fine for catching key-name bugs but doesn't catch cfg-branch bugs in untested components. Worth a follow-up to extend the kitchen-sink to populate every cfg sub-struct the mapper reads.
- The full IR canonicalisation refactor (move `lib/stack/ir.ts` to TF-canonical values, eliminating the translation table entirely) is tracked in reliable separately. This PR keeps the translation layer; it just makes it correct.

Closes #131
Refs luthersystems/reliable#1149
