### PR TITLE
fix(composer): validate IR values before terraform

### DIFF
--- a/aws/apigateway/variables.tf
+++ b/aws/apigateway/variables.tf
@@ -23,6 +23,10 @@ variable "domain_name" {
 variable "certificate_arn" {
   type    = string
   default = null
+  validation {
+    condition     = var.certificate_arn == null ? true : can(regex("^arn:aws(-[a-z0-9]+)?:acm:[a-z0-9-]+:[0-9]{12}:certificate\\/.+$", var.certificate_arn))
+    error_message = "certificate_arn must be null or a valid ACM certificate ARN."
+  }
 }
 
 variable "throttling_burst_limit" {

--- a/aws/ecs/variables.tf
+++ b/aws/ecs/variables.tf
@@ -49,8 +49,11 @@ variable "capacity_providers" {
   default     = ["FARGATE", "FARGATE_SPOT"]
 
   validation {
-    condition     = length(var.capacity_providers) > 0
-    error_message = "At least one capacity provider must be specified."
+    condition = length(var.capacity_providers) > 0 && length([
+      for p in var.capacity_providers : p
+      if contains(["FARGATE", "FARGATE_SPOT"], p)
+    ]) == length(var.capacity_providers)
+    error_message = "capacity_providers must contain at least one value and every value must be one of: FARGATE, FARGATE_SPOT."
   }
 }
 
@@ -58,6 +61,11 @@ variable "default_capacity_provider" {
   description = "Default capacity provider for the cluster"
   type        = string
   default     = "FARGATE"
+
+  validation {
+    condition     = contains(["FARGATE", "FARGATE_SPOT"], var.default_capacity_provider)
+    error_message = "default_capacity_provider must be one of: FARGATE, FARGATE_SPOT."
+  }
 }
 
 variable "enable_service_connect" {

--- a/aws/kms/variables.tf
+++ b/aws/kms/variables.tf
@@ -18,6 +18,10 @@ variable "environment" {
 variable "num_keys" {
   type    = number
   default = 1
+  validation {
+    condition     = var.num_keys >= 1
+    error_message = "num_keys must be >= 1."
+  }
 }
 
 variable "tags" {

--- a/aws/lambda/variables.tf
+++ b/aws/lambda/variables.tf
@@ -23,18 +23,30 @@ variable "runtime" {
   description = "Lambda runtime (e.g., nodejs20.x, python3.12, go1.x, java21)"
   type        = string
   default     = "nodejs20.x"
+  validation {
+    condition     = length(trimspace(var.runtime)) > 0 && can(regex("^[A-Za-z0-9][A-Za-z0-9_.-]*$", var.runtime))
+    error_message = "runtime must be a non-empty Lambda runtime token (e.g., nodejs20.x, python3.12, go1.x, java21)."
+  }
 }
 
 variable "memory_size" {
   description = "Memory size in MB"
   type        = number
   default     = 128
+  validation {
+    condition     = var.memory_size >= 128 && var.memory_size <= 10240
+    error_message = "memory_size must be between 128 and 10240 MB."
+  }
 }
 
 variable "timeout" {
   description = "Timeout in seconds"
   type        = number
   default     = 3
+  validation {
+    condition     = var.timeout >= 1 && var.timeout <= 900
+    error_message = "timeout must be between 1 and 900 seconds."
+  }
 }
 
 variable "handler" {

--- a/aws/opensearch/variables.tf
+++ b/aws/opensearch/variables.tf
@@ -61,6 +61,10 @@ variable "storage_size" {
   type        = string
   description = "Storage size in GB"
   default     = "10GB"
+  validation {
+    condition     = can(regex("^[0-9]+GB$", var.storage_size))
+    error_message = "storage_size must use whole GB format, e.g. 10GB or 1000GB."
+  }
 }
 
 variable "multi_az" {

--- a/aws/secretsmanager/variables.tf
+++ b/aws/secretsmanager/variables.tf
@@ -18,6 +18,10 @@ variable "environment" {
 variable "num_secrets" {
   type    = number
   default = 1
+  validation {
+    condition     = var.num_secrets >= 1
+    error_message = "num_secrets must be >= 1."
+  }
 }
 
 variable "tags" {

--- a/gcp/cloud_cdn/variables.tf
+++ b/gcp/cloud_cdn/variables.tf
@@ -19,6 +19,10 @@ variable "default_ttl" {
   description = "Default TTL in seconds for cached content"
   type        = number
   default     = 3600
+  validation {
+    condition     = var.default_ttl >= 0
+    error_message = "default_ttl must be >= 0."
+  }
 }
 
 variable "max_ttl" {

--- a/gcp/cloud_run/variables.tf
+++ b/gcp/cloud_run/variables.tf
@@ -30,12 +30,20 @@ variable "memory" {
   description = "Memory allocation (e.g., 512Mi, 1Gi, 2Gi)"
   type        = string
   default     = "512Mi"
+  validation {
+    condition     = can(regex("^[1-9][0-9]*(Mi|Gi)$", var.memory))
+    error_message = "memory must use Kubernetes memory format, e.g. 512Mi, 1Gi, or 2Gi."
+  }
 }
 
 variable "cpu" {
   description = "CPU allocation (e.g., 1, 2, 4)"
   type        = string
   default     = "1"
+  validation {
+    condition     = can(regex("^([1-9][0-9]*|[1-9][0-9]*m)$", var.cpu))
+    error_message = "cpu must be a Kubernetes CPU quantity, e.g. 1, 2, 4, or 1000m."
+  }
 }
 
 variable "min_instances" {

--- a/gcp/gke/variables.tf
+++ b/gcp/gke/variables.tf
@@ -106,6 +106,10 @@ variable "node_count" {
   description = "Initial node count per zone"
   type        = number
   default     = 1
+  validation {
+    condition     = var.node_count >= 1
+    error_message = "node_count must be >= 1."
+  }
 }
 
 variable "min_node_count" {
@@ -155,4 +159,3 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
-

--- a/gcp/memorystore/variables.tf
+++ b/gcp/memorystore/variables.tf
@@ -19,12 +19,20 @@ variable "tier" {
   description = "Tier of the Memorystore instance (BASIC or STANDARD_HA)"
   type        = string
   default     = "BASIC"
+  validation {
+    condition     = contains(["BASIC", "STANDARD_HA"], var.tier)
+    error_message = "tier must be one of: BASIC, STANDARD_HA."
+  }
 }
 
 variable "memory_size_gb" {
   description = "Memory size in GB"
   type        = number
   default     = 1
+  validation {
+    condition     = var.memory_size_gb >= 1
+    error_message = "memory_size_gb must be >= 1."
+  }
 }
 
 variable "authorized_network" {

--- a/gcp/pubsub/variables.tf
+++ b/gcp/pubsub/variables.tf
@@ -19,6 +19,10 @@ variable "message_retention_duration" {
   description = "Message retention duration for the topic"
   type        = string
   default     = "604800s" # 7 days
+  validation {
+    condition     = can(regex("^[0-9]+s$", var.message_retention_duration))
+    error_message = "message_retention_duration must be a duration in whole seconds, e.g. 604800s."
+  }
 }
 
 variable "ack_deadline_seconds" {
@@ -31,6 +35,10 @@ variable "subscription_message_retention" {
   description = "Message retention duration for the subscription"
   type        = string
   default     = "604800s" # 7 days
+  validation {
+    condition     = can(regex("^[0-9]+s$", var.subscription_message_retention))
+    error_message = "subscription_message_retention must be a duration in whole seconds, e.g. 604800s."
+  }
 }
 
 variable "retain_acked_messages" {
@@ -43,18 +51,30 @@ variable "subscription_expiration_ttl" {
   description = "Subscription expiration TTL (empty string for never)"
   type        = string
   default     = "" # Never expire
+  validation {
+    condition     = var.subscription_expiration_ttl == "" ? true : can(regex("^[0-9]+s$", var.subscription_expiration_ttl))
+    error_message = "subscription_expiration_ttl must be empty or a duration in whole seconds, e.g. 86400s."
+  }
 }
 
 variable "retry_minimum_backoff" {
   description = "Minimum retry backoff"
   type        = string
   default     = "10s"
+  validation {
+    condition     = can(regex("^[0-9]+s$", var.retry_minimum_backoff))
+    error_message = "retry_minimum_backoff must be a duration in whole seconds, e.g. 10s."
+  }
 }
 
 variable "retry_maximum_backoff" {
   description = "Maximum retry backoff"
   type        = string
   default     = "600s"
+  validation {
+    condition     = can(regex("^[0-9]+s$", var.retry_maximum_backoff))
+    error_message = "retry_maximum_backoff must be a duration in whole seconds, e.g. 600s."
+  }
 }
 
 variable "enable_dead_letter" {

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/luthersystems/insideout-terraform-presets
 go 1.24.0
 
 require (
+	github.com/agext/levenshtein v1.2.1
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/stretchr/testify v1.11.1
 	github.com/zclconf/go-cty v1.17.0
 )
 
 require (
-	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect

--- a/pkg/composer/hcl_validation.go
+++ b/pkg/composer/hcl_validation.go
@@ -373,42 +373,84 @@ func emptyCollectionForType(target cty.Type) cty.Value {
 }
 
 func extractAllowedValues(expr hcl.Expression, varName string) []string {
+	return extractAllowedValuesWithAliases(expr, varName, nil)
+}
+
+// extractAllowedValuesWithAliases walks an expression looking for the literal
+// set in a `contains([…literals…], <ref>)` call, where <ref> is `var.<varName>`
+// or any name in `aliases`. Aliases handle for-comprehensions:
+// `[for p in var.x : p if contains([…], p)]` binds `p` to elements of `var.x`,
+// so references to `p` inside the comprehension body count as references to
+// `var.x` for allowed-set extraction.
+func extractAllowedValuesWithAliases(expr hcl.Expression, varName string, aliases map[string]bool) []string {
+	if expr == nil {
+		return nil
+	}
 	expr = hcl.UnwrapExpression(expr)
 	switch e := expr.(type) {
 	case *hclsyntax.FunctionCallExpr:
 		var out []string
-		if e.Name == "contains" && len(e.Args) == 2 && exprReferencesVar(e.Args[1], varName) {
+		if e.Name == "contains" && len(e.Args) == 2 && exprReferencesVar(e.Args[1], varName, aliases) {
 			out = append(out, literalTupleValues(e.Args[0])...)
 		}
 		for _, arg := range e.Args {
-			out = appendUniqueStrings(out, extractAllowedValues(arg, varName)...)
+			out = appendUniqueStrings(out, extractAllowedValuesWithAliases(arg, varName, aliases)...)
 		}
 		return out
 	case *hclsyntax.BinaryOpExpr:
 		return appendUniqueStrings(
-			extractAllowedValues(e.LHS, varName),
-			extractAllowedValues(e.RHS, varName)...,
+			extractAllowedValuesWithAliases(e.LHS, varName, aliases),
+			extractAllowedValuesWithAliases(e.RHS, varName, aliases)...,
 		)
 	case *hclsyntax.ConditionalExpr:
-		out := extractAllowedValues(e.Condition, varName)
-		out = appendUniqueStrings(out, extractAllowedValues(e.TrueResult, varName)...)
-		out = appendUniqueStrings(out, extractAllowedValues(e.FalseResult, varName)...)
+		out := extractAllowedValuesWithAliases(e.Condition, varName, aliases)
+		out = appendUniqueStrings(out, extractAllowedValuesWithAliases(e.TrueResult, varName, aliases)...)
+		out = appendUniqueStrings(out, extractAllowedValuesWithAliases(e.FalseResult, varName, aliases)...)
 		return out
 	case *hclsyntax.ForExpr:
-		return extractAllowedValues(e.ValExpr, varName)
+		// Literal sets often live in the comprehension's `if` clause —
+		// e.g. `[for p in var.x : p if contains(["A","B"], p)]` puts the
+		// allowed set in CondExpr, not ValExpr. When the For iterates
+		// `var.<varName>`, the iteration variables alias it inside the body.
+		bodyAliases := aliases
+		if exprReferencesVar(e.CollExpr, varName, aliases) {
+			bodyAliases = make(map[string]bool, len(aliases)+2)
+			for k := range aliases {
+				bodyAliases[k] = true
+			}
+			if e.KeyVar != "" {
+				bodyAliases[e.KeyVar] = true
+			}
+			if e.ValVar != "" {
+				bodyAliases[e.ValVar] = true
+			}
+		}
+		out := extractAllowedValuesWithAliases(e.ValExpr, varName, bodyAliases)
+		out = appendUniqueStrings(out, extractAllowedValuesWithAliases(e.CondExpr, varName, bodyAliases)...)
+		out = appendUniqueStrings(out, extractAllowedValuesWithAliases(e.KeyExpr, varName, bodyAliases)...)
+		return out
 	case *hclsyntax.ParenthesesExpr:
-		return extractAllowedValues(e.Expression, varName)
+		return extractAllowedValuesWithAliases(e.Expression, varName, aliases)
 	default:
 		return nil
 	}
 }
 
-func exprReferencesVar(expr hcl.Expression, varName string) bool {
+func exprReferencesVar(expr hcl.Expression, varName string, aliases map[string]bool) bool {
 	for _, traversal := range expr.Variables() {
-		if len(traversal) < 2 || traversal.RootName() != "var" {
+		if len(traversal) == 0 {
 			continue
 		}
-		if attr, ok := traversal[1].(hcl.TraverseAttr); ok && attr.Name == varName {
+		root := traversal.RootName()
+		if root == "var" {
+			if len(traversal) >= 2 {
+				if attr, ok := traversal[1].(hcl.TraverseAttr); ok && attr.Name == varName {
+					return true
+				}
+			}
+			continue
+		}
+		if aliases[root] {
 			return true
 		}
 	}
@@ -479,7 +521,11 @@ func appendUniqueStrings(dst []string, vals ...string) []string {
 
 func normalizeStringWith(fn func(string) (string, error)) func(any) (any, error) {
 	return func(v any) (any, error) {
-		return fn(v.(string))
+		s, err := requireString(v, "value")
+		if err != nil {
+			return nil, err
+		}
+		return fn(s)
 	}
 }
 
@@ -505,36 +551,60 @@ func normalizeStrictInt(field string) func(any) (any, error) {
 
 func normalizeLeadingInt(field string) func(any) (any, error) {
 	return func(v any) (any, error) {
-		return parseLeadingInt(v.(string), field)
+		s, err := requireString(v, field)
+		if err != nil {
+			return nil, err
+		}
+		return parseLeadingInt(s, field)
 	}
 }
 
 func normalizeStorageGB(field string) func(any) (any, error) {
 	return func(v any) (any, error) {
-		return parseStorageSizeGB(v.(string), field)
+		s, err := requireString(v, field)
+		if err != nil {
+			return nil, err
+		}
+		return parseStorageSizeGB(s, field)
 	}
 }
 
 func normalizeTTLSeconds(field string) func(any) (any, error) {
 	return func(v any) (any, error) {
-		return parseTTLSeconds(v.(string), field)
+		s, err := requireString(v, field)
+		if err != nil {
+			return nil, err
+		}
+		return parseTTLSeconds(s, field)
 	}
 }
 
 func normalizeDurationSeconds(field string) func(any) (any, error) {
 	return func(v any) (any, error) {
-		return parseDurationToSeconds(v.(string), field)
+		s, err := requireString(v, field)
+		if err != nil {
+			return nil, err
+		}
+		return parseDurationToSeconds(s, field)
 	}
 }
 
 func normalizeRetentionHours(field string) func(any) (any, error) {
 	return func(v any) (any, error) {
-		return parseRetentionHours(v.(string), field)
+		s, err := requireString(v, field)
+		if err != nil {
+			return nil, err
+		}
+		return parseRetentionHours(s, field)
 	}
 }
 
 func normalizeEKSControlPlaneVisibility(v any) (any, error) {
-	s := strings.ToLower(strings.TrimSpace(v.(string)))
+	raw, err := requireString(v, "AWSEKS.ControlPlaneVisibility")
+	if err != nil {
+		return nil, err
+	}
+	s := strings.ToLower(strings.TrimSpace(raw))
 	switch s {
 	case "public", "public endpoint", "public control plane":
 		return true, nil
@@ -543,13 +613,19 @@ func normalizeEKSControlPlaneVisibility(v any) (any, error) {
 	default:
 		return nil, NewValidationError(fmt.Sprintf(
 			"AWSEKS.ControlPlaneVisibility=%q: expected \"Public\" or \"Private\"",
-			v.(string),
+			raw,
 		))
 	}
 }
 
 func normalizeECSCapacityProvidersValue(v any) (any, error) {
-	providers := v.([]string)
+	providers, ok := v.([]string)
+	if !ok {
+		return nil, NewValidationError(fmt.Sprintf(
+			"AWSECS.CapacityProviders=%s: expected a list of strings",
+			issueValue(v),
+		))
+	}
 	out := make([]string, len(providers))
 	for i, provider := range providers {
 		canonical, err := canonicalECSCapacityProvider(provider)
@@ -562,7 +638,22 @@ func normalizeECSCapacityProvidersValue(v any) (any, error) {
 }
 
 func normalizeECSCapacityProviderValue(v any) (any, error) {
-	return canonicalECSCapacityProvider(v.(string))
+	s, err := requireString(v, "AWSECS.DefaultCapacityProvider")
+	if err != nil {
+		return nil, err
+	}
+	return canonicalECSCapacityProvider(s)
+}
+
+func requireString(v any, field string) (string, error) {
+	s, ok := v.(string)
+	if !ok {
+		return "", NewValidationError(fmt.Sprintf(
+			"%s=%s: expected a string",
+			field, issueValue(v),
+		))
+	}
+	return s, nil
 }
 
 func canonicalECSCapacityProvider(s string) (string, error) {
@@ -579,7 +670,11 @@ func canonicalECSCapacityProvider(s string) (string, error) {
 }
 
 func normalizeSQSQueueType(v any) (any, error) {
-	switch strings.ToLower(strings.TrimSpace(v.(string))) {
+	raw, err := requireString(v, "AWSSQS.Type")
+	if err != nil {
+		return nil, err
+	}
+	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "standard":
 		return "Standard", nil
 	case "fifo":
@@ -587,59 +682,75 @@ func normalizeSQSQueueType(v any) (any, error) {
 	default:
 		return nil, NewValidationError(fmt.Sprintf(
 			"AWSSQS.Type=%q: expected \"Standard\" or \"FIFO\"",
-			v.(string),
+			raw,
 		))
 	}
 }
 
 func normalizeCognitoSignInType(v any) (any, error) {
-	s := strings.ToLower(strings.TrimSpace(v.(string)))
+	raw, err := requireString(v, "AWSCognito.SignInType")
+	if err != nil {
+		return nil, err
+	}
+	s := strings.ToLower(strings.TrimSpace(raw))
 	switch s {
 	case "email", "username", "both":
 		return s, nil
 	default:
 		return nil, NewValidationError(fmt.Sprintf(
 			"AWSCognito.SignInType=%q: expected \"email\", \"username\", or \"both\"",
-			v.(string),
+			raw,
 		))
 	}
 }
 
 func normalizeOpenSearchDeploymentType(v any) (any, error) {
-	s := strings.ToLower(strings.TrimSpace(v.(string)))
+	raw, err := requireString(v, "AWSOpenSearch.DeploymentType")
+	if err != nil {
+		return nil, err
+	}
+	s := strings.ToLower(strings.TrimSpace(raw))
 	switch s {
 	case "managed", "serverless":
 		return s, nil
 	default:
 		return nil, NewValidationError(fmt.Sprintf(
 			"AWSOpenSearch.DeploymentType=%q: expected \"managed\" or \"serverless\"",
-			v.(string),
+			raw,
 		))
 	}
 }
 
 func normalizeGCPMemorystoreTier(v any) (any, error) {
-	s := strings.ToUpper(strings.TrimSpace(v.(string)))
+	raw, err := requireString(v, "GCPMemorystore.Tier")
+	if err != nil {
+		return nil, err
+	}
+	s := strings.ToUpper(strings.TrimSpace(raw))
 	switch s {
 	case "BASIC", "STANDARD_HA":
 		return s, nil
 	default:
 		return nil, NewValidationError(fmt.Sprintf(
 			"GCPMemorystore.Tier=%q: expected \"BASIC\" or \"STANDARD_HA\"",
-			v.(string),
+			raw,
 		))
 	}
 }
 
 func normalizeGCPStorageClass(v any) (any, error) {
-	s := strings.ToUpper(strings.TrimSpace(v.(string)))
+	raw, err := requireString(v, "GCPGCS.StorageClass")
+	if err != nil {
+		return nil, err
+	}
+	s := strings.ToUpper(strings.TrimSpace(raw))
 	switch s {
 	case "STANDARD", "NEARLINE", "COLDLINE", "ARCHIVE":
 		return s, nil
 	default:
 		return nil, NewValidationError(fmt.Sprintf(
 			"GCPGCS.StorageClass=%q: expected one of STANDARD, NEARLINE, COLDLINE, ARCHIVE",
-			v.(string),
+			raw,
 		))
 	}
 }

--- a/pkg/composer/hcl_validation.go
+++ b/pkg/composer/hcl_validation.go
@@ -1,0 +1,645 @@
+package composer
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/tryfunc"
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	cty "github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+type validationRegistry struct {
+	variables map[moduleVarKey]moduleVariableValidator
+}
+
+type moduleVarKey struct {
+	component ComponentKey
+	variable  string
+}
+
+type moduleVariableValidator struct {
+	name    string
+	typ     cty.Type
+	rules   []moduleValidationRule
+	allowed []string
+}
+
+type moduleValidationRule struct {
+	condition    hcl.Expression
+	errorMessage string
+}
+
+type validationFailure struct {
+	code   string
+	reason string
+}
+
+var (
+	defaultValidationRegistryOnce sync.Once
+	defaultValidationRegistryVal  *validationRegistry
+	defaultValidationRegistryErr  error
+)
+
+func defaultValidationRegistry() (*validationRegistry, error) {
+	defaultValidationRegistryOnce.Do(func() {
+		defaultValidationRegistryVal, defaultValidationRegistryErr = buildDefaultValidationRegistry()
+	})
+	return defaultValidationRegistryVal, defaultValidationRegistryErr
+}
+
+func buildDefaultValidationRegistry() (*validationRegistry, error) {
+	client := New()
+	reg := &validationRegistry{variables: map[moduleVarKey]moduleVariableValidator{}}
+	for _, component := range AllComponentKeys {
+		presetPath := GetPresetPath(CloudFor(component), component, &Components{})
+		files, err := client.GetPresetFiles(presetPath)
+		if err != nil {
+			return nil, fmt.Errorf("load preset %s: %w", presetPath, err)
+		}
+		vars, err := discoverModuleVariableValidators(files)
+		if err != nil {
+			return nil, fmt.Errorf("discover validators for %s: %w", presetPath, err)
+		}
+		for name, validator := range vars {
+			reg.variables[moduleVarKey{component: component, variable: name}] = validator
+		}
+	}
+	return reg, nil
+}
+
+func discoverModuleVariableValidators(files map[string][]byte) (map[string]moduleVariableValidator, error) {
+	out := map[string]moduleVariableValidator{}
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		if strings.HasSuffix(strings.ToLower(p), ".tf") {
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+
+	for _, p := range paths {
+		f, diags := hclsyntax.ParseConfig(files[p], p, hcl.InitialPos)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("%s", diags.Error())
+		}
+		body, ok := f.Body.(*hclsyntax.Body)
+		if !ok {
+			continue
+		}
+		for _, block := range body.Blocks {
+			if block.Type != "variable" || len(block.Labels) != 1 {
+				continue
+			}
+			name := block.Labels[0]
+			validator := moduleVariableValidator{
+				name: name,
+				typ:  cty.DynamicPseudoType,
+			}
+			if attr, ok := block.Body.Attributes["type"]; ok && attr.Expr != nil {
+				typ, typeDiags := typeexpr.TypeConstraint(attr.Expr)
+				if !typeDiags.HasErrors() {
+					validator.typ = typ
+				}
+			}
+
+			for _, inner := range block.Body.Blocks {
+				if inner.Type != "validation" {
+					continue
+				}
+				attr, ok := inner.Body.Attributes["condition"]
+				if !ok || attr.Expr == nil {
+					continue
+				}
+				msg := "validation condition failed"
+				if msgAttr, ok := inner.Body.Attributes["error_message"]; ok && msgAttr.Expr != nil {
+					if literal := literalString(msgAttr.Expr); literal != "" {
+						msg = literal
+					}
+				}
+				validator.rules = append(validator.rules, moduleValidationRule{
+					condition:    attr.Expr,
+					errorMessage: msg,
+				})
+				validator.allowed = appendUniqueStrings(validator.allowed, extractAllowedValues(attr.Expr, name)...)
+			}
+			out[name] = validator
+		}
+	}
+	return out, nil
+}
+
+func (r *validationRegistry) validate(component ComponentKey, variable string, raw any) (validationFailure, bool) {
+	if r == nil {
+		return validationFailure{code: "internal_error", reason: "validation registry is nil"}, false
+	}
+	validator, ok := r.variables[moduleVarKey{component: component, variable: variable}]
+	if !ok || len(validator.rules) == 0 {
+		return validationFailure{}, true
+	}
+
+	value, err := ctyValueForType(raw, validator.typ)
+	if err != nil {
+		return validationFailure{
+			code:   "invalid_type",
+			reason: fmt.Sprintf("%s=%s: %v", variable, issueValue(raw), err),
+		}, false
+	}
+	if !validator.typ.Equals(cty.DynamicPseudoType) {
+		value, err = convert.Convert(value, validator.typ)
+		if err != nil {
+			return validationFailure{
+				code:   "invalid_type",
+				reason: fmt.Sprintf("%s=%s: cannot convert to %s: %v", variable, issueValue(raw), validator.typ.FriendlyNameForConstraint(), err),
+			}, false
+		}
+	}
+
+	ctx := &hcl.EvalContext{
+		Variables: map[string]cty.Value{
+			"var": cty.ObjectVal(map[string]cty.Value{variable: value}),
+		},
+		Functions: validationFunctions(),
+	}
+	for _, rule := range validator.rules {
+		result, diags := rule.condition.Value(ctx)
+		if diags.HasErrors() {
+			return validationFailure{
+				code:   "invalid_value",
+				reason: fmt.Sprintf("%s=%s: %s", variable, issueValue(raw), diags.Error()),
+			}, false
+		}
+		if !result.IsWhollyKnown() || result.IsNull() {
+			return validationFailure{
+				code:   "invalid_value",
+				reason: fmt.Sprintf("%s=%s: validation condition did not produce a known boolean", variable, issueValue(raw)),
+			}, false
+		}
+		if !result.Type().Equals(cty.Bool) {
+			converted, err := convert.Convert(result, cty.Bool)
+			if err != nil {
+				return validationFailure{
+					code:   "invalid_value",
+					reason: fmt.Sprintf("%s=%s: validation condition returned %s, not bool", variable, issueValue(raw), result.Type().FriendlyName()),
+				}, false
+			}
+			result = converted
+		}
+		if !result.True() {
+			return validationFailure{
+				code:   "invalid_value",
+				reason: fmt.Sprintf("%s=%s: %s", variable, issueValue(raw), rule.errorMessage),
+			}, false
+		}
+	}
+	return validationFailure{}, true
+}
+
+func (r *validationRegistry) allowedValues(component ComponentKey, variable string) []string {
+	if r == nil {
+		return nil
+	}
+	validator, ok := r.variables[moduleVarKey{component: component, variable: variable}]
+	if !ok {
+		return nil
+	}
+	return cloneStrings(validator.allowed)
+}
+
+var validationFunctionsOnce sync.Once
+var validationFunctionsMap map[string]function.Function
+
+func validationFunctions() map[string]function.Function {
+	validationFunctionsOnce.Do(func() {
+		validationFunctionsMap = map[string]function.Function{
+			"can":        tryfunc.CanFunc,
+			"contains":   stdlib.ContainsFunc,
+			"length":     lengthFunc(),
+			"lower":      stdlib.LowerFunc,
+			"regex":      stdlib.RegexFunc,
+			"replace":    stdlib.ReplaceFunc,
+			"trimspace":  stdlib.TrimSpaceFunc,
+			"upper":      stdlib.UpperFunc,
+			"alltrue":    allTrueFunc(),
+			"startswith": startsWithFunc(),
+		}
+	})
+	return validationFunctionsMap
+}
+
+func allTrueFunc() function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{{
+			Name:             "collection",
+			Type:             cty.DynamicPseudoType,
+			AllowDynamicType: true,
+		}},
+		Type: function.StaticReturnType(cty.Bool),
+		Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+			collection := args[0]
+			if collection.IsNull() {
+				return cty.False, nil
+			}
+			if !collection.CanIterateElements() {
+				return cty.NilVal, fmt.Errorf("alltrue requires an iterable collection")
+			}
+			it := collection.ElementIterator()
+			for it.Next() {
+				_, elem := it.Element()
+				elem, _ = elem.Unmark()
+				if elem.Type().Equals(cty.String) {
+					elem = cty.BoolVal(strings.EqualFold(elem.AsString(), "true"))
+				}
+				if !elem.Type().Equals(cty.Bool) {
+					return cty.NilVal, fmt.Errorf("alltrue elements must be bool-compatible")
+				}
+				if !elem.True() {
+					return cty.False, nil
+				}
+			}
+			return cty.True, nil
+		},
+	})
+}
+
+func startsWithFunc() function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{
+			{Name: "str", Type: cty.String},
+			{Name: "prefix", Type: cty.String},
+		},
+		Type: function.StaticReturnType(cty.Bool),
+		Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+			return cty.BoolVal(strings.HasPrefix(args[0].AsString(), args[1].AsString())), nil
+		},
+	})
+}
+
+func lengthFunc() function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{{
+			Name: "value",
+			Type: cty.DynamicPseudoType,
+		}},
+		Type: function.StaticReturnType(cty.Number),
+		Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+			value := args[0]
+			value, _ = value.Unmark()
+			if value.Type().Equals(cty.String) {
+				return cty.NumberIntVal(int64(len([]rune(value.AsString())))), nil
+			}
+			if value.CanIterateElements() {
+				return value.Length(), nil
+			}
+			return cty.NilVal, fmt.Errorf("length requires a string or collection")
+		},
+	})
+}
+
+func ctyValueForType(v any, target cty.Type) (cty.Value, error) {
+	if v == nil {
+		if target.Equals(cty.DynamicPseudoType) {
+			return cty.NullVal(cty.DynamicPseudoType), nil
+		}
+		return cty.NullVal(target), nil
+	}
+
+	switch x := v.(type) {
+	case string:
+		return cty.StringVal(x), nil
+	case bool:
+		return cty.BoolVal(x), nil
+	case int:
+		return cty.NumberIntVal(int64(x)), nil
+	case int64:
+		return cty.NumberIntVal(x), nil
+	case float64:
+		return cty.NumberFloatVal(x), nil
+	case []string:
+		if len(x) == 0 {
+			return emptyCollectionForType(target), nil
+		}
+		vals := make([]cty.Value, len(x))
+		for i, s := range x {
+			vals[i] = cty.StringVal(s)
+		}
+		return cty.TupleVal(vals), nil
+	case []any:
+		if len(x) == 0 {
+			return emptyCollectionForType(target), nil
+		}
+		vals := make([]cty.Value, len(x))
+		for i, elem := range x {
+			val, err := ctyValueForType(elem, cty.DynamicPseudoType)
+			if err != nil {
+				return cty.NilVal, err
+			}
+			vals[i] = val
+		}
+		return cty.TupleVal(vals), nil
+	case []int:
+		if len(x) == 0 {
+			return emptyCollectionForType(target), nil
+		}
+		vals := make([]cty.Value, len(x))
+		for i, n := range x {
+			vals[i] = cty.NumberIntVal(int64(n))
+		}
+		return cty.TupleVal(vals), nil
+	default:
+		return cty.NilVal, fmt.Errorf("unsupported Go value type %T", v)
+	}
+}
+
+func emptyCollectionForType(target cty.Type) cty.Value {
+	switch {
+	case target.IsListType():
+		return cty.ListValEmpty(target.ElementType())
+	case target.IsSetType():
+		return cty.SetValEmpty(target.ElementType())
+	case target.IsTupleType():
+		return cty.EmptyTupleVal
+	default:
+		return cty.EmptyTupleVal
+	}
+}
+
+func extractAllowedValues(expr hcl.Expression, varName string) []string {
+	expr = hcl.UnwrapExpression(expr)
+	switch e := expr.(type) {
+	case *hclsyntax.FunctionCallExpr:
+		var out []string
+		if e.Name == "contains" && len(e.Args) == 2 && exprReferencesVar(e.Args[1], varName) {
+			out = append(out, literalTupleValues(e.Args[0])...)
+		}
+		for _, arg := range e.Args {
+			out = appendUniqueStrings(out, extractAllowedValues(arg, varName)...)
+		}
+		return out
+	case *hclsyntax.BinaryOpExpr:
+		return appendUniqueStrings(
+			extractAllowedValues(e.LHS, varName),
+			extractAllowedValues(e.RHS, varName)...,
+		)
+	case *hclsyntax.ConditionalExpr:
+		out := extractAllowedValues(e.Condition, varName)
+		out = appendUniqueStrings(out, extractAllowedValues(e.TrueResult, varName)...)
+		out = appendUniqueStrings(out, extractAllowedValues(e.FalseResult, varName)...)
+		return out
+	case *hclsyntax.ForExpr:
+		return extractAllowedValues(e.ValExpr, varName)
+	case *hclsyntax.ParenthesesExpr:
+		return extractAllowedValues(e.Expression, varName)
+	default:
+		return nil
+	}
+}
+
+func exprReferencesVar(expr hcl.Expression, varName string) bool {
+	for _, traversal := range expr.Variables() {
+		if len(traversal) < 2 || traversal.RootName() != "var" {
+			continue
+		}
+		if attr, ok := traversal[1].(hcl.TraverseAttr); ok && attr.Name == varName {
+			return true
+		}
+	}
+	return false
+}
+
+func literalTupleValues(expr hcl.Expression) []string {
+	expr = hcl.UnwrapExpression(expr)
+	tuple, ok := expr.(*hclsyntax.TupleConsExpr)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, item := range tuple.Exprs {
+		if v, ok := literalCtyValue(item); ok {
+			out = append(out, ctyLiteralString(v))
+		}
+	}
+	return out
+}
+
+func literalCtyValue(expr hcl.Expression) (cty.Value, bool) {
+	expr = hcl.UnwrapExpression(expr)
+	switch e := expr.(type) {
+	case *hclsyntax.LiteralValueExpr:
+		return e.Val, true
+	case *hclsyntax.TemplateExpr:
+		if len(e.Parts) == 1 {
+			if lit, ok := e.Parts[0].(*hclsyntax.LiteralValueExpr); ok {
+				return lit.Val, true
+			}
+		}
+	}
+	return cty.NilVal, false
+}
+
+func ctyLiteralString(v cty.Value) string {
+	v, _ = v.Unmark()
+	switch {
+	case v.Type().Equals(cty.String):
+		return v.AsString()
+	case v.Type().Equals(cty.Number):
+		return v.AsBigFloat().Text('f', -1)
+	case v.Type().Equals(cty.Bool):
+		if v.True() {
+			return "true"
+		}
+		return "false"
+	default:
+		return v.GoString()
+	}
+}
+
+func appendUniqueStrings(dst []string, vals ...string) []string {
+	seen := make(map[string]bool, len(dst)+len(vals))
+	for _, v := range dst {
+		seen[v] = true
+	}
+	for _, v := range vals {
+		if v == "" || seen[v] {
+			continue
+		}
+		dst = append(dst, v)
+		seen[v] = true
+	}
+	return dst
+}
+
+func normalizeStringWith(fn func(string) (string, error)) func(any) (any, error) {
+	return func(v any) (any, error) {
+		return fn(v.(string))
+	}
+}
+
+func normalizeStrictInt(field string) func(any) (any, error) {
+	return func(v any) (any, error) {
+		switch x := v.(type) {
+		case int:
+			return x, nil
+		case string:
+			n, err := strconv.Atoi(strings.TrimSpace(x))
+			if err != nil {
+				return nil, NewValidationError(fmt.Sprintf(
+					"%s=%q: expected an integer",
+					field, x,
+				))
+			}
+			return n, nil
+		default:
+			return nil, NewValidationError(fmt.Sprintf("%s=%s: expected an integer", field, issueValue(v)))
+		}
+	}
+}
+
+func normalizeLeadingInt(field string) func(any) (any, error) {
+	return func(v any) (any, error) {
+		return parseLeadingInt(v.(string), field)
+	}
+}
+
+func normalizeStorageGB(field string) func(any) (any, error) {
+	return func(v any) (any, error) {
+		return parseStorageSizeGB(v.(string), field)
+	}
+}
+
+func normalizeTTLSeconds(field string) func(any) (any, error) {
+	return func(v any) (any, error) {
+		return parseTTLSeconds(v.(string), field)
+	}
+}
+
+func normalizeDurationSeconds(field string) func(any) (any, error) {
+	return func(v any) (any, error) {
+		return parseDurationToSeconds(v.(string), field)
+	}
+}
+
+func normalizeRetentionHours(field string) func(any) (any, error) {
+	return func(v any) (any, error) {
+		return parseRetentionHours(v.(string), field)
+	}
+}
+
+func normalizeEKSControlPlaneVisibility(v any) (any, error) {
+	s := strings.ToLower(strings.TrimSpace(v.(string)))
+	switch s {
+	case "public", "public endpoint", "public control plane":
+		return true, nil
+	case "private", "private endpoint", "private control plane":
+		return false, nil
+	default:
+		return nil, NewValidationError(fmt.Sprintf(
+			"AWSEKS.ControlPlaneVisibility=%q: expected \"Public\" or \"Private\"",
+			v.(string),
+		))
+	}
+}
+
+func normalizeECSCapacityProvidersValue(v any) (any, error) {
+	providers := v.([]string)
+	out := make([]string, len(providers))
+	for i, provider := range providers {
+		canonical, err := canonicalECSCapacityProvider(provider)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = canonical
+	}
+	return out, nil
+}
+
+func normalizeECSCapacityProviderValue(v any) (any, error) {
+	return canonicalECSCapacityProvider(v.(string))
+}
+
+func canonicalECSCapacityProvider(s string) (string, error) {
+	canonical := strings.ToUpper(strings.ReplaceAll(strings.TrimSpace(s), " ", "_"))
+	switch canonical {
+	case "FARGATE", "FARGATE_SPOT":
+		return canonical, nil
+	default:
+		return "", NewValidationError(fmt.Sprintf(
+			"AWSECS.CapacityProvider=%q: expected \"FARGATE\" or \"FARGATE_SPOT\"",
+			s,
+		))
+	}
+}
+
+func normalizeSQSQueueType(v any) (any, error) {
+	switch strings.ToLower(strings.TrimSpace(v.(string))) {
+	case "standard":
+		return "Standard", nil
+	case "fifo":
+		return "FIFO", nil
+	default:
+		return nil, NewValidationError(fmt.Sprintf(
+			"AWSSQS.Type=%q: expected \"Standard\" or \"FIFO\"",
+			v.(string),
+		))
+	}
+}
+
+func normalizeCognitoSignInType(v any) (any, error) {
+	s := strings.ToLower(strings.TrimSpace(v.(string)))
+	switch s {
+	case "email", "username", "both":
+		return s, nil
+	default:
+		return nil, NewValidationError(fmt.Sprintf(
+			"AWSCognito.SignInType=%q: expected \"email\", \"username\", or \"both\"",
+			v.(string),
+		))
+	}
+}
+
+func normalizeOpenSearchDeploymentType(v any) (any, error) {
+	s := strings.ToLower(strings.TrimSpace(v.(string)))
+	switch s {
+	case "managed", "serverless":
+		return s, nil
+	default:
+		return nil, NewValidationError(fmt.Sprintf(
+			"AWSOpenSearch.DeploymentType=%q: expected \"managed\" or \"serverless\"",
+			v.(string),
+		))
+	}
+}
+
+func normalizeGCPMemorystoreTier(v any) (any, error) {
+	s := strings.ToUpper(strings.TrimSpace(v.(string)))
+	switch s {
+	case "BASIC", "STANDARD_HA":
+		return s, nil
+	default:
+		return nil, NewValidationError(fmt.Sprintf(
+			"GCPMemorystore.Tier=%q: expected \"BASIC\" or \"STANDARD_HA\"",
+			v.(string),
+		))
+	}
+}
+
+func normalizeGCPStorageClass(v any) (any, error) {
+	s := strings.ToUpper(strings.TrimSpace(v.(string)))
+	switch s {
+	case "STANDARD", "NEARLINE", "COLDLINE", "ARCHIVE":
+		return s, nil
+	default:
+		return nil, NewValidationError(fmt.Sprintf(
+			"GCPGCS.StorageClass=%q: expected one of STANDARD, NEARLINE, COLDLINE, ARCHIVE",
+			v.(string),
+		))
+	}
+}

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -163,7 +163,13 @@ func (m DefaultMapper) BuildModuleValues(
 		if _, ok := vals["public_subnet_ids"]; !ok {
 			vals["public_subnet_ids"] = []any{}
 		}
-		// Optional: user config could add more later (e.g., visibility)
+		if cfg != nil && cfg.AWSEKS != nil && cfg.AWSEKS.ControlPlaneVisibility != "" {
+			public, err := normalizeEKSControlPlaneVisibility(cfg.AWSEKS.ControlPlaneVisibility)
+			if err != nil {
+				return nil, err
+			}
+			vals["eks_public_control_plane"] = public.(bool)
+		}
 
 	case KeyAWSECS:
 		// Preview-safe stubs for required, usually-wired inputs
@@ -185,12 +191,20 @@ func (m DefaultMapper) BuildModuleValues(
 			if len(ecsCfg.CapacityProviders) > 0 {
 				cp := make([]any, len(ecsCfg.CapacityProviders))
 				for i, p := range ecsCfg.CapacityProviders {
-					cp[i] = p
+					canonical, err := canonicalECSCapacityProvider(p)
+					if err != nil {
+						return nil, err
+					}
+					cp[i] = canonical
 				}
 				vals["capacity_providers"] = cp
 			}
 			if ecsCfg.DefaultCapacityProvider != "" {
-				vals["default_capacity_provider"] = ecsCfg.DefaultCapacityProvider
+				canonical, err := canonicalECSCapacityProvider(ecsCfg.DefaultCapacityProvider)
+				if err != nil {
+					return nil, err
+				}
+				vals["default_capacity_provider"] = canonical
 			}
 			if ecsCfg.EnableServiceConnect != nil {
 				vals["enable_service_connect"] = *ecsCfg.EnableServiceConnect
@@ -211,19 +225,34 @@ func (m DefaultMapper) BuildModuleValues(
 		// Use EKS config if available
 		if cfg != nil && cfg.AWSEKS != nil {
 			if cfg.AWSEKS.DesiredSize != "" {
-				if n, err := strconv.Atoi(cfg.AWSEKS.DesiredSize); err == nil {
-					vals["desired_size"] = n
+				n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSEKS.DesiredSize))
+				if err != nil {
+					return nil, NewValidationError(fmt.Sprintf(
+						"AWSEKS.DesiredSize=%q: expected an integer",
+						cfg.AWSEKS.DesiredSize,
+					))
 				}
+				vals["desired_size"] = n
 			}
 			if cfg.AWSEKS.MinSize != "" {
-				if n, err := strconv.Atoi(cfg.AWSEKS.MinSize); err == nil {
-					vals["min_size"] = n
+				n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSEKS.MinSize))
+				if err != nil {
+					return nil, NewValidationError(fmt.Sprintf(
+						"AWSEKS.MinSize=%q: expected an integer",
+						cfg.AWSEKS.MinSize,
+					))
 				}
+				vals["min_size"] = n
 			}
 			if cfg.AWSEKS.MaxSize != "" {
-				if n, err := strconv.Atoi(cfg.AWSEKS.MaxSize); err == nil {
-					vals["max_size"] = n
+				n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSEKS.MaxSize))
+				if err != nil {
+					return nil, NewValidationError(fmt.Sprintf(
+						"AWSEKS.MaxSize=%q: expected an integer",
+						cfg.AWSEKS.MaxSize,
+					))
 				}
+				vals["max_size"] = n
 			}
 			if cfg.AWSEKS.InstanceType != "" {
 				vals["instance_types"] = []any{cfg.AWSEKS.InstanceType}
@@ -290,9 +319,14 @@ func (m DefaultMapper) BuildModuleValues(
 				vals["enable_instance_connect"] = true
 			}
 			if cfg.AWSEC2.DiskSizePerServer != "" {
-				if n, err := strconv.Atoi(cfg.AWSEC2.DiskSizePerServer); err == nil {
-					vals["root_volume_size"] = n
+				n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSEC2.DiskSizePerServer))
+				if err != nil {
+					return nil, NewValidationError(fmt.Sprintf(
+						"AWSEC2.DiskSizePerServer=%q: expected an integer",
+						cfg.AWSEC2.DiskSizePerServer,
+					))
 				}
+				vals["root_volume_size"] = n
 			}
 		}
 		// Default instance type based on architecture if not explicitly configured
@@ -472,7 +506,11 @@ func (m DefaultMapper) BuildModuleValues(
 	case KeyAWSCognito:
 		if cfg != nil && cfg.AWSCognito != nil {
 			if cfg.AWSCognito.SignInType != "" {
-				vals["sign_in_type"] = cfg.AWSCognito.SignInType
+				signInType, err := normalizeCognitoSignInType(cfg.AWSCognito.SignInType)
+				if err != nil {
+					return nil, err
+				}
+				vals["sign_in_type"] = signInType.(string)
 			}
 			if cfg.AWSCognito.MFARequired != nil {
 				vals["mfa_required"] = *cfg.AWSCognito.MFARequired
@@ -491,22 +529,36 @@ func (m DefaultMapper) BuildModuleValues(
 
 	case KeyAWSKMS:
 		if cfg != nil && cfg.AWSKMS != nil && cfg.AWSKMS.NumKeys != "" {
-			if n, err := strconv.Atoi(cfg.AWSKMS.NumKeys); err == nil {
-				vals["num_keys"] = n
+			n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSKMS.NumKeys))
+			if err != nil {
+				return nil, NewValidationError(fmt.Sprintf(
+					"AWSKMS.NumKeys=%q: expected an integer",
+					cfg.AWSKMS.NumKeys,
+				))
 			}
+			vals["num_keys"] = n
 		}
 
 	case KeyAWSSecretsManager:
 		if cfg != nil && cfg.AWSSecretsManager != nil && cfg.AWSSecretsManager.NumSecrets != "" {
-			if n, err := strconv.Atoi(cfg.AWSSecretsManager.NumSecrets); err == nil {
-				vals["num_secrets"] = n
+			n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSSecretsManager.NumSecrets))
+			if err != nil {
+				return nil, NewValidationError(fmt.Sprintf(
+					"AWSSecretsManager.NumSecrets=%q: expected an integer",
+					cfg.AWSSecretsManager.NumSecrets,
+				))
 			}
+			vals["num_secrets"] = n
 		}
 
 	case KeyAWSOpenSearch:
 		if cfg != nil && cfg.AWSOpenSearch != nil {
 			if cfg.AWSOpenSearch.DeploymentType != "" {
-				vals["deployment_type"] = strings.ToLower(cfg.AWSOpenSearch.DeploymentType)
+				deploymentType, err := normalizeOpenSearchDeploymentType(cfg.AWSOpenSearch.DeploymentType)
+				if err != nil {
+					return nil, err
+				}
+				vals["deployment_type"] = deploymentType.(string)
 			}
 			if cfg.AWSOpenSearch.InstanceType != "" {
 				vals["instance_type"] = cfg.AWSOpenSearch.InstanceType
@@ -698,11 +750,14 @@ func (m DefaultMapper) BuildModuleValues(
 				vals["machine_type"] = cfg.GCPGKE.MachineType
 			}
 			if cfg.GCPGKE.NodeCount != "" {
-				if n, err := strconv.Atoi(cfg.GCPGKE.NodeCount); err == nil {
-					vals["node_count"] = n
-				} else {
-					vals["node_count"] = cfg.GCPGKE.NodeCount // keep as string if not int
+				n, err := strconv.Atoi(strings.TrimSpace(cfg.GCPGKE.NodeCount))
+				if err != nil {
+					return nil, NewValidationError(fmt.Sprintf(
+						"GCPGKE.NodeCount=%q: expected an integer",
+						cfg.GCPGKE.NodeCount,
+					))
 				}
+				vals["node_count"] = n
 			}
 			if cfg.GCPGKE.Regional != nil {
 				vals["regional"] = *cfg.GCPGKE.Regional
@@ -726,7 +781,11 @@ func (m DefaultMapper) BuildModuleValues(
 	case KeyGCPMemorystore:
 		if cfg != nil && cfg.GCPMemorystore != nil {
 			if cfg.GCPMemorystore.Tier != "" {
-				vals["tier"] = cfg.GCPMemorystore.Tier
+				tier, err := normalizeGCPMemorystoreTier(cfg.GCPMemorystore.Tier)
+				if err != nil {
+					return nil, err
+				}
+				vals["tier"] = tier.(string)
 			}
 			if cfg.GCPMemorystore.MemorySizeGb > 0 {
 				vals["memory_size_gb"] = cfg.GCPMemorystore.MemorySizeGb
@@ -737,7 +796,11 @@ func (m DefaultMapper) BuildModuleValues(
 		vals["bucket_name"] = fmt.Sprintf("%s-data", proj)
 		if cfg != nil && cfg.GCPGCS != nil {
 			if cfg.GCPGCS.StorageClass != "" {
-				vals["storage_class"] = cfg.GCPGCS.StorageClass
+				storageClass, err := normalizeGCPStorageClass(cfg.GCPGCS.StorageClass)
+				if err != nil {
+					return nil, err
+				}
+				vals["storage_class"] = storageClass.(string)
 			}
 			if cfg.GCPGCS.Versioning != nil {
 				vals["versioning_enabled"] = *cfg.GCPGCS.Versioning
@@ -781,7 +844,7 @@ func (m DefaultMapper) BuildModuleValues(
 		vals["min_instances"] = 0
 		vals["max_instances"] = 100
 
-		if cfg.GCPCloudRun != nil {
+		if cfg != nil && cfg.GCPCloudRun != nil {
 			if cfg.GCPCloudRun.Memory != "" {
 				vals["memory"] = cfg.GCPCloudRun.Memory
 			}
@@ -800,6 +863,11 @@ func (m DefaultMapper) BuildModuleValues(
 		// Placeholders for now
 		vals["runtime"] = "nodejs20"
 		vals["available_memory_mb"] = 256
+		if cfg != nil && cfg.GCPCloudFunctions != nil {
+			if cfg.GCPCloudFunctions.Runtime != "" {
+				vals["runtime"] = cfg.GCPCloudFunctions.Runtime
+			}
+		}
 
 	case KeyGCPBastion:
 		// Stubs for preview
@@ -894,11 +962,11 @@ func (m DefaultMapper) BuildModuleValues(
 // ---------------------------------------------------------------------------
 
 var (
-	ddbOnDemandRe      = regexp.MustCompile(`(?i)^\s*(on[\s_-]*demand|pay[_]?per[_]?request)\s*$`)
-	ddbProvRe          = regexp.MustCompile(`(?i)^\s*provisioned\s*$`)
-	leadingIntRe       = regexp.MustCompile(`^\s*(-?\d+)`)
-	storageSizeRe      = regexp.MustCompile(`^\s*(\d+)\s*(GB|TB|MB)\s*$`)
-	mapperDurationRe   = regexp.MustCompile(`^\s*(\d+)\s*([smh])\s*$`)
+	ddbOnDemandRe    = regexp.MustCompile(`(?i)^\s*(on[\s_-]*demand|pay[_]?per[_]?request)\s*$`)
+	ddbProvRe        = regexp.MustCompile(`(?i)^\s*provisioned\s*$`)
+	leadingIntRe     = regexp.MustCompile(`^\s*(-?\d+)`)
+	storageSizeRe    = regexp.MustCompile(`^\s*(\d+)\s*(GB|TB|MB)\s*$`)
+	mapperDurationRe = regexp.MustCompile(`^\s*(\d+)\s*([smh])\s*$`)
 )
 
 // canonicalDdbBillingMode maps IR enum values to the uppercase tokens

--- a/pkg/composer/validate.go
+++ b/pkg/composer/validate.go
@@ -1,8 +1,11 @@
 package composer
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/agext/levenshtein"
 )
 
 // ValidationError represents a client input validation failure (e.g., incompatible
@@ -18,6 +21,694 @@ func NewValidationError(msg string) *ValidationError {
 }
 
 func (e *ValidationError) Error() string { return e.msg }
+
+// ValidationIssue describes one field-level input problem in a structured
+// shape callers can use for same-turn AI correction or UI feedback.
+type ValidationIssue struct {
+	Field      string   `json:"field"`
+	Value      string   `json:"value"`
+	Allowed    []string `json:"allowed,omitempty"`
+	Suggestion string   `json:"suggestion,omitempty"`
+	Code       string   `json:"code"`
+	Reason     string   `json:"reason"`
+}
+
+// Validate checks every known IR field in cfg/comps and returns all issues
+// instead of short-circuiting on the first mapper error.
+func Validate(comps *Components, cfg *Config) []ValidationIssue {
+	reg, err := defaultValidationRegistry()
+	if err != nil {
+		return []ValidationIssue{{
+			Field:  "composer.validation_registry",
+			Code:   "internal_error",
+			Reason: err.Error(),
+		}}
+	}
+
+	var issues []ValidationIssue
+	issues = append(issues, validateComponentFields(comps)...)
+	for _, fv := range configFieldValidators {
+		raw, ok := fv.value(cfg)
+		if !ok {
+			continue
+		}
+
+		normalized := raw
+		if fv.normalize != nil {
+			var normErr error
+			normalized, normErr = fv.normalize(raw)
+			if normErr != nil {
+				issues = append(issues, fv.issue(raw, fv.codeForNormalizeError(), normErr.Error()))
+				continue
+			}
+		}
+
+		if fv.component == "" || fv.variable == "" {
+			continue
+		}
+		if failure, ok := reg.validate(fv.component, fv.variable, normalized); !ok {
+			issues = append(issues, fv.issue(raw, fv.codeForValidationFailure(failure), failure.reason))
+		}
+	}
+	return issues
+}
+
+// AllowedValues returns the accepted values known for an IR field path.
+// Closed sets are sourced from the corresponding module validation expression
+// when possible, with IR-facing canonical hints layered on for translated fields.
+func AllowedValues(field string) []string {
+	fv, ok := validatorsByField[field]
+	if !ok {
+		if cv, ok := componentValidatorsByField[field]; ok {
+			return cloneStrings(cv.allowed)
+		}
+		return nil
+	}
+	if len(fv.allowed) > 0 {
+		return cloneStrings(fv.allowed)
+	}
+	reg, err := defaultValidationRegistry()
+	if err != nil {
+		return nil
+	}
+	return cloneStrings(reg.allowedValues(fv.component, fv.variable))
+}
+
+type componentFieldValidator struct {
+	field   string
+	value   func(*Components) (string, bool)
+	allowed []string
+}
+
+var componentFieldValidators = []componentFieldValidator{
+	{
+		field: "cloud",
+		value: func(c *Components) (string, bool) {
+			if c == nil || c.Cloud == "" {
+				return "", false
+			}
+			return c.Cloud, true
+		},
+		allowed: []string{"AWS", "GCP"},
+	},
+	{
+		field: "aws_vpc",
+		value: func(c *Components) (string, bool) {
+			if c == nil || c.AWSVPC == "" {
+				return "", false
+			}
+			return c.AWSVPC, true
+		},
+		allowed: []string{"Private VPC", "Public VPC"},
+	},
+	{
+		field: "aws_ec2",
+		value: func(c *Components) (string, bool) {
+			if c == nil || c.AWSEC2 == "" {
+				return "", false
+			}
+			return c.AWSEC2, true
+		},
+		allowed: []string{"Intel", "ARM"},
+	},
+	{
+		field: "gcp_compute",
+		value: func(c *Components) (string, bool) {
+			if c == nil || c.GCPCompute == "" {
+				return "", false
+			}
+			return c.GCPCompute, true
+		},
+		allowed: []string{"Intel", "ARM"},
+	},
+	{
+		field: "cpu_arch",
+		value: func(c *Components) (string, bool) {
+			if c == nil || c.CpuArch == "" {
+				return "", false
+			}
+			return c.CpuArch, true
+		},
+		allowed: []string{"Intel", "ARM"},
+	},
+}
+
+var componentValidatorsByField = func() map[string]componentFieldValidator {
+	out := make(map[string]componentFieldValidator, len(componentFieldValidators))
+	for _, v := range componentFieldValidators {
+		out[v.field] = v
+	}
+	return out
+}()
+
+func validateComponentFields(comps *Components) []ValidationIssue {
+	var issues []ValidationIssue
+	for _, cv := range componentFieldValidators {
+		value, ok := cv.value(comps)
+		if !ok {
+			continue
+		}
+		if stringInAllowedFold(value, cv.allowed) {
+			continue
+		}
+		issues = append(issues, ValidationIssue{
+			Field:      cv.field,
+			Value:      value,
+			Allowed:    cloneStrings(cv.allowed),
+			Suggestion: nearestSuggestion(value, cv.allowed),
+			Code:       "invalid_enum",
+			Reason:     fmt.Sprintf("%s=%q: expected one of %s", cv.field, value, strings.Join(cv.allowed, ", ")),
+		})
+	}
+	return issues
+}
+
+type configFieldValidator struct {
+	field     string
+	component ComponentKey
+	variable  string
+	value     func(*Config) (any, bool)
+	normalize func(any) (any, error)
+	allowed   []string
+	code      string
+}
+
+func (fv configFieldValidator) issue(raw any, code, reason string) ValidationIssue {
+	allowed := fv.allowed
+	if len(allowed) == 0 {
+		allowed = AllowedValues(fv.field)
+	}
+	return ValidationIssue{
+		Field:      fv.field,
+		Value:      issueValue(raw),
+		Allowed:    cloneStrings(allowed),
+		Suggestion: nearestSuggestion(issueValue(raw), allowed),
+		Code:       code,
+		Reason:     reason,
+	}
+}
+
+func (fv configFieldValidator) codeForNormalizeError() string {
+	if fv.code != "" {
+		return fv.code
+	}
+	if len(fv.allowed) > 0 {
+		return "invalid_enum"
+	}
+	return "unparseable_format"
+}
+
+func (fv configFieldValidator) codeForValidationFailure(f validationFailure) string {
+	if f.code != "" {
+		return f.code
+	}
+	if len(fv.allowed) > 0 || len(AllowedValues(fv.field)) > 0 {
+		return "invalid_enum"
+	}
+	return "invalid_value"
+}
+
+var configFieldValidators = []configFieldValidator{
+	{
+		field:     "aws_ec2.diskSizePerServer",
+		component: KeyAWSEC2,
+		variable:  "root_volume_size",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSEC2 == nil || c.AWSEC2.DiskSizePerServer == "" {
+				return nil, false
+			}
+			return c.AWSEC2.DiskSizePerServer, true
+		},
+		normalize: normalizeStrictInt("AWSEC2.DiskSizePerServer"),
+	},
+	{
+		field:     "aws_eks.controlPlaneVisibility",
+		component: KeyAWSEKS,
+		variable:  "eks_public_control_plane",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSEKS == nil || c.AWSEKS.ControlPlaneVisibility == "" {
+				return nil, false
+			}
+			return c.AWSEKS.ControlPlaneVisibility, true
+		},
+		normalize: normalizeEKSControlPlaneVisibility,
+		allowed:   []string{"Public", "Private"},
+		code:      "invalid_enum",
+	},
+	{
+		field:     "aws_eks.desiredSize",
+		component: KeyAWSEKSNodeGroup,
+		variable:  "desired_size",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSEKS == nil || c.AWSEKS.DesiredSize == "" {
+				return nil, false
+			}
+			return c.AWSEKS.DesiredSize, true
+		},
+		normalize: normalizeStrictInt("AWSEKS.DesiredSize"),
+	},
+	{
+		field:     "aws_eks.minSize",
+		component: KeyAWSEKSNodeGroup,
+		variable:  "min_size",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSEKS == nil || c.AWSEKS.MinSize == "" {
+				return nil, false
+			}
+			return c.AWSEKS.MinSize, true
+		},
+		normalize: normalizeStrictInt("AWSEKS.MinSize"),
+	},
+	{
+		field:     "aws_eks.maxSize",
+		component: KeyAWSEKSNodeGroup,
+		variable:  "max_size",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSEKS == nil || c.AWSEKS.MaxSize == "" {
+				return nil, false
+			}
+			return c.AWSEKS.MaxSize, true
+		},
+		normalize: normalizeStrictInt("AWSEKS.MaxSize"),
+	},
+	{
+		field:     "aws_ecs.capacityProviders",
+		component: KeyAWSECS,
+		variable:  "capacity_providers",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSECS == nil || len(c.AWSECS.CapacityProviders) == 0 {
+				return nil, false
+			}
+			return c.AWSECS.CapacityProviders, true
+		},
+		normalize: normalizeECSCapacityProvidersValue,
+		allowed:   []string{"FARGATE", "FARGATE_SPOT"},
+		code:      "invalid_enum",
+	},
+	{
+		field:     "aws_ecs.defaultCapacityProvider",
+		component: KeyAWSECS,
+		variable:  "default_capacity_provider",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSECS == nil || c.AWSECS.DefaultCapacityProvider == "" {
+				return nil, false
+			}
+			return c.AWSECS.DefaultCapacityProvider, true
+		},
+		normalize: normalizeECSCapacityProviderValue,
+		allowed:   []string{"FARGATE", "FARGATE_SPOT"},
+		code:      "invalid_enum",
+	},
+	{
+		field:     "aws_rds.cpuSize",
+		component: KeyAWSRDS,
+		variable:  "instance_class",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSRDS == nil || c.AWSRDS.CPUSize == "" {
+				return nil, false
+			}
+			return c.AWSRDS.CPUSize, true
+		},
+		normalize: normalizeStringWith(canonicalRdsInstanceClass),
+		allowed:   []string{"1 vCPU", "4 vCPU", "8 vCPU"},
+		code:      "invalid_enum",
+	},
+	{
+		field:     "aws_rds.readReplicas",
+		component: KeyAWSRDS,
+		variable:  "read_replica_count",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSRDS == nil || c.AWSRDS.ReadReplicas == "" {
+				return nil, false
+			}
+			return c.AWSRDS.ReadReplicas, true
+		},
+		normalize: normalizeLeadingInt("AWSRDS.ReadReplicas"),
+	},
+	{
+		field:     "aws_rds.storageSize",
+		component: KeyAWSRDS,
+		variable:  "allocated_storage",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSRDS == nil || c.AWSRDS.StorageSize == "" {
+				return nil, false
+			}
+			return c.AWSRDS.StorageSize, true
+		},
+		normalize: normalizeStorageGB("AWSRDS.StorageSize"),
+	},
+	{
+		field:     "aws_elasticache.nodeSize",
+		component: KeyAWSElastiCache,
+		variable:  "node_type",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSElastiCache == nil || c.AWSElastiCache.NodeSize == "" {
+				return nil, false
+			}
+			return c.AWSElastiCache.NodeSize, true
+		},
+		normalize: normalizeStringWith(canonicalRedisNodeType),
+		allowed:   []string{"1 vCPU", "4 vCPU", "8 vCPU"},
+		code:      "invalid_enum",
+	},
+	{
+		field:     "aws_elasticache.replicas",
+		component: KeyAWSElastiCache,
+		variable:  "replicas",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSElastiCache == nil || c.AWSElastiCache.Replicas == "" {
+				return nil, false
+			}
+			return c.AWSElastiCache.Replicas, true
+		},
+		normalize: normalizeLeadingInt("AWSElastiCache.Replicas"),
+	},
+	{
+		field:     "aws_dynamodb.type",
+		component: KeyAWSDynamoDB,
+		variable:  "billing_mode",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSDynamoDB == nil || c.AWSDynamoDB.Type == "" {
+				return nil, false
+			}
+			return c.AWSDynamoDB.Type, true
+		},
+		normalize: normalizeStringWith(canonicalDdbBillingMode),
+		allowed:   []string{"On demand", "provisioned", "PAY_PER_REQUEST", "PROVISIONED"},
+		code:      "invalid_enum",
+	},
+	{
+		field:     "aws_sqs.type",
+		component: KeyAWSSQS,
+		variable:  "queue_type",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSSQS == nil || c.AWSSQS.Type == "" {
+				return nil, false
+			}
+			return c.AWSSQS.Type, true
+		},
+		normalize: normalizeSQSQueueType,
+		allowed:   []string{"Standard", "FIFO"},
+		code:      "invalid_enum",
+	},
+	{
+		field:     "aws_sqs.visibilityTimeout",
+		component: KeyAWSSQS,
+		variable:  "visibility_timeout_seconds",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSSQS == nil || c.AWSSQS.VisibilityTimeout == "" {
+				return nil, false
+			}
+			return c.AWSSQS.VisibilityTimeout, true
+		},
+		normalize: normalizeTTLSeconds("AWSSQS.VisibilityTimeout"),
+	},
+	{
+		field:     "aws_msk.retentionPeriod",
+		component: KeyAWSMSK,
+		variable:  "retention_hours",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSMSK == nil || c.AWSMSK.Retention == "" {
+				return nil, false
+			}
+			return c.AWSMSK.Retention, true
+		},
+		normalize: normalizeRetentionHours("AWSMSK.Retention"),
+	},
+	{
+		field:     "aws_cloudwatch_logs.retentionDays",
+		component: KeyAWSCloudWatchLogs,
+		variable:  "retention_in_days",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSCloudWatchLogs == nil || c.AWSCloudWatchLogs.RetentionDays == 0 {
+				return nil, false
+			}
+			return c.AWSCloudWatchLogs.RetentionDays, true
+		},
+	},
+	{
+		field:     "aws_cognito.signInType",
+		component: KeyAWSCognito,
+		variable:  "sign_in_type",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSCognito == nil || c.AWSCognito.SignInType == "" {
+				return nil, false
+			}
+			return c.AWSCognito.SignInType, true
+		},
+		normalize: normalizeCognitoSignInType,
+		allowed:   []string{"email", "username", "both"},
+		code:      "invalid_enum",
+	},
+	{
+		field:     "aws_lambda.runtime",
+		component: KeyAWSLambda,
+		variable:  "runtime",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSLambda == nil || c.AWSLambda.Runtime == "" {
+				return nil, false
+			}
+			return c.AWSLambda.Runtime, true
+		},
+	},
+	{
+		field:     "aws_lambda.memorySize",
+		component: KeyAWSLambda,
+		variable:  "memory_size",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSLambda == nil || c.AWSLambda.MemorySize == "" {
+				return nil, false
+			}
+			return c.AWSLambda.MemorySize, true
+		},
+		normalize: normalizeStrictInt("AWSLambda.MemorySize"),
+	},
+	{
+		field:     "aws_lambda.timeout",
+		component: KeyAWSLambda,
+		variable:  "timeout",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSLambda == nil || c.AWSLambda.Timeout == "" {
+				return nil, false
+			}
+			return c.AWSLambda.Timeout, true
+		},
+		normalize: normalizeDurationSeconds("AWSLambda.Timeout"),
+	},
+	{
+		field:     "aws_api_gateway.certificateArn",
+		component: KeyAWSAPIGateway,
+		variable:  "certificate_arn",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSAPIGateway == nil || c.AWSAPIGateway.CertificateArn == "" {
+				return nil, false
+			}
+			return c.AWSAPIGateway.CertificateArn, true
+		},
+	},
+	{
+		field:     "aws_kms.numKeys",
+		component: KeyAWSKMS,
+		variable:  "num_keys",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSKMS == nil || c.AWSKMS.NumKeys == "" {
+				return nil, false
+			}
+			return c.AWSKMS.NumKeys, true
+		},
+		normalize: normalizeStrictInt("AWSKMS.NumKeys"),
+	},
+	{
+		field:     "aws_secretsmanager.numSecrets",
+		component: KeyAWSSecretsManager,
+		variable:  "num_secrets",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSSecretsManager == nil || c.AWSSecretsManager.NumSecrets == "" {
+				return nil, false
+			}
+			return c.AWSSecretsManager.NumSecrets, true
+		},
+		normalize: normalizeStrictInt("AWSSecretsManager.NumSecrets"),
+	},
+	{
+		field:     "aws_opensearch.deploymentType",
+		component: KeyAWSOpenSearch,
+		variable:  "deployment_type",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSOpenSearch == nil || c.AWSOpenSearch.DeploymentType == "" {
+				return nil, false
+			}
+			return c.AWSOpenSearch.DeploymentType, true
+		},
+		normalize: normalizeOpenSearchDeploymentType,
+		allowed:   []string{"managed", "serverless"},
+		code:      "invalid_enum",
+	},
+	{
+		field:     "aws_opensearch.storageSize",
+		component: KeyAWSOpenSearch,
+		variable:  "storage_size",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSOpenSearch == nil || c.AWSOpenSearch.StorageSize == "" {
+				return nil, false
+			}
+			return c.AWSOpenSearch.StorageSize, true
+		},
+		normalize: func(v any) (any, error) {
+			return normalizeStorageSizeGBString(v.(string), "AWSOpenSearch.StorageSize")
+		},
+	},
+	{
+		field:     "gcp_gke.nodeCount",
+		component: KeyGCPGKE,
+		variable:  "node_count",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.GCPGKE == nil || c.GCPGKE.NodeCount == "" {
+				return nil, false
+			}
+			return c.GCPGKE.NodeCount, true
+		},
+		normalize: normalizeStrictInt("GCPGKE.NodeCount"),
+	},
+	{
+		field:     "gcp_memorystore.tier",
+		component: KeyGCPMemorystore,
+		variable:  "tier",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.GCPMemorystore == nil || c.GCPMemorystore.Tier == "" {
+				return nil, false
+			}
+			return c.GCPMemorystore.Tier, true
+		},
+		normalize: normalizeGCPMemorystoreTier,
+		allowed:   []string{"BASIC", "STANDARD_HA"},
+		code:      "invalid_enum",
+	},
+	{
+		field:     "gcp_gcs.storageClass",
+		component: KeyGCPGCS,
+		variable:  "storage_class",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.GCPGCS == nil || c.GCPGCS.StorageClass == "" {
+				return nil, false
+			}
+			return c.GCPGCS.StorageClass, true
+		},
+		normalize: normalizeGCPStorageClass,
+		allowed:   []string{"STANDARD", "NEARLINE", "COLDLINE", "ARCHIVE"},
+		code:      "invalid_enum",
+	},
+	{
+		field:     "gcp_pubsub.messageRetentionDuration",
+		component: KeyGCPPubSub,
+		variable:  "message_retention_duration",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.GCPPubSub == nil || c.GCPPubSub.MessageRetentionDuration == "" {
+				return nil, false
+			}
+			return c.GCPPubSub.MessageRetentionDuration, true
+		},
+	},
+	{
+		field:     "gcp_cloud_run.memory",
+		component: KeyGCPCloudRun,
+		variable:  "memory",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.GCPCloudRun == nil || c.GCPCloudRun.Memory == "" {
+				return nil, false
+			}
+			return c.GCPCloudRun.Memory, true
+		},
+	},
+	{
+		field:     "gcp_cloud_run.cpu",
+		component: KeyGCPCloudRun,
+		variable:  "cpu",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.GCPCloudRun == nil || c.GCPCloudRun.CPU == "" {
+				return nil, false
+			}
+			return c.GCPCloudRun.CPU, true
+		},
+	},
+	{
+		field:     "gcp_cloud_functions.runtime",
+		component: KeyGCPCloudFunctions,
+		variable:  "runtime",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.GCPCloudFunctions == nil || c.GCPCloudFunctions.Runtime == "" {
+				return nil, false
+			}
+			return c.GCPCloudFunctions.Runtime, true
+		},
+	},
+	{
+		field:     "gcp_cloud_cdn.defaultTtl",
+		component: KeyGCPCloudCDN,
+		variable:  "default_ttl",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.GCPCloudCDN == nil || c.GCPCloudCDN.DefaultTtl == "" {
+				return nil, false
+			}
+			return c.GCPCloudCDN.DefaultTtl, true
+		},
+		normalize: normalizeTTLSeconds("GCPCloudCDN.DefaultTtl"),
+	},
+}
+
+var validatorsByField = func() map[string]configFieldValidator {
+	out := make(map[string]configFieldValidator, len(configFieldValidators))
+	for _, v := range configFieldValidators {
+		out[v.field] = v
+	}
+	return out
+}()
+
+func issueValue(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprint(v)
+	}
+	return string(b)
+}
+
+func nearestSuggestion(value string, allowed []string) string {
+	if len(allowed) == 0 || value == "" {
+		return ""
+	}
+	needle := strings.ToLower(strings.TrimSpace(value))
+	best := ""
+	bestDistance := 4
+	for _, candidate := range allowed {
+		d := levenshtein.Distance(needle, strings.ToLower(candidate), nil)
+		if d < bestDistance {
+			bestDistance = d
+			best = candidate
+		}
+	}
+	return best
+}
+
+func cloneStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}
+
+func stringInAllowedFold(value string, allowed []string) bool {
+	for _, a := range allowed {
+		if strings.EqualFold(strings.TrimSpace(value), a) {
+			return true
+		}
+	}
+	return false
+}
 
 // ValidateComputeExclusivity checks that the selected component keys do not
 // contain incompatible compute combinations. For example, Lambda (serverless)

--- a/pkg/composer/validate.go
+++ b/pkg/composer/validate.go
@@ -219,6 +219,14 @@ func (fv configFieldValidator) codeForNormalizeError() string {
 }
 
 func (fv configFieldValidator) codeForValidationFailure(f validationFailure) string {
+	// A registry-side "invalid_value" failure on a field with a known
+	// allowed-set is semantically an enum miss; surface that consistently
+	// regardless of which path (normalize vs HCL eval) caught it.
+	if f.code == "invalid_value" {
+		if len(fv.allowed) > 0 || len(AllowedValues(fv.field)) > 0 {
+			return "invalid_enum"
+		}
+	}
 	if f.code != "" {
 		return f.code
 	}
@@ -242,6 +250,10 @@ var configFieldValidators = []configFieldValidator{
 		normalize: normalizeStrictInt("AWSEC2.DiskSizePerServer"),
 	},
 	{
+		// The module variable is bool, not a closed-set string. Membership is
+		// enforced by normalizeEKSControlPlaneVisibility before HCL ever sees
+		// the value; the exemption in TestConfigFieldValidatorsHaveModuleRulesOrExplicitExemption
+		// matches.
 		field:     "aws_eks.controlPlaneVisibility",
 		component: KeyAWSEKS,
 		variable:  "eks_public_control_plane",
@@ -555,7 +567,11 @@ var configFieldValidators = []configFieldValidator{
 			return c.AWSOpenSearch.StorageSize, true
 		},
 		normalize: func(v any) (any, error) {
-			return normalizeStorageSizeGBString(v.(string), "AWSOpenSearch.StorageSize")
+			s, err := requireString(v, "AWSOpenSearch.StorageSize")
+			if err != nil {
+				return nil, err
+			}
+			return normalizeStorageSizeGBString(s, "AWSOpenSearch.StorageSize")
 		},
 	},
 	{

--- a/pkg/composer/validate_values_test.go
+++ b/pkg/composer/validate_values_test.go
@@ -4,6 +4,8 @@ import (
 	"sort"
 	"testing"
 
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/require"
 )
 
@@ -123,4 +125,74 @@ func issuesByField(issues []ValidationIssue) map[string]ValidationIssue {
 		out[issue.Field] = issue
 	}
 	return out
+}
+
+func TestDefaultValidationRegistry_BuildsForEveryEmbeddedModule(t *testing.T) {
+	t.Parallel()
+
+	reg, err := defaultValidationRegistry()
+	require.NoError(t, err)
+	require.NotNil(t, reg)
+	require.NotEmpty(t, reg.variables, "registry should hold variables for embedded modules")
+}
+
+func TestExtractAllowedValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		varName  string
+		cond     string
+		expected []string
+	}{
+		{
+			name:     "direct contains call",
+			varName:  "tier",
+			cond:     `contains(["BASIC", "STANDARD_HA"], var.tier)`,
+			expected: []string{"BASIC", "STANDARD_HA"},
+		},
+		{
+			name:    "for-comprehension with contains in CondExpr",
+			varName: "capacity_providers",
+			cond: `length([
+				for p in var.capacity_providers : p
+				if contains(["FARGATE", "FARGATE_SPOT"], p)
+			]) == length(var.capacity_providers)`,
+			expected: []string{"FARGATE", "FARGATE_SPOT"},
+		},
+		{
+			name:     "ternary with null escape hatch",
+			varName:  "x",
+			cond:     `var.x == null ? true : contains(["a", "b"], var.x)`,
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "regex condition has no allowed set",
+			varName:  "memory",
+			cond:     `can(regex("^[1-9][0-9]*Mi$", var.memory))`,
+			expected: nil,
+		},
+		{
+			name:     "numeric range has no allowed set",
+			varName:  "memory_size",
+			cond:     `var.memory_size >= 128 && var.memory_size <= 10240`,
+			expected: nil,
+		},
+		{
+			name:     "contains references different var",
+			varName:  "x",
+			cond:     `contains(["a", "b"], var.y)`,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			expr, diags := hclsyntax.ParseExpression([]byte(tc.cond), "test.tf", hcl.InitialPos)
+			require.False(t, diags.HasErrors(), diags.Error())
+			got := extractAllowedValues(expr, tc.varName)
+			require.ElementsMatch(t, tc.expected, got)
+		})
+	}
 }

--- a/pkg/composer/validate_values_test.go
+++ b/pkg/composer/validate_values_test.go
@@ -1,0 +1,126 @@
+package composer
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate_HCLBackedValues_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	cfg := cfgFromJSON(t, `{
+		"aws_dynamodb": {"type": "On demand"},
+		"aws_lambda": {"runtime": "nodejs20.x", "memorySize": "512", "timeout": "30s"},
+		"aws_ecs": {"capacityProviders": ["FARGATE", "FARGATE_SPOT"], "defaultCapacityProvider": "FARGATE"},
+		"gcp_cloud_run": {"memory": "512Mi", "cpu": "1"},
+		"gcp_pubsub": {"messageRetentionDuration": "604800s"},
+		"gcp_gcs": {"storageClass": "STANDARD"}
+	}`)
+
+	require.Empty(t, Validate(nil, &cfg))
+}
+
+func TestValidate_HCLBackedValues_CollectsMultipleIssues(t *testing.T) {
+	t.Parallel()
+
+	cfg := cfgFromJSON(t, `{
+		"aws_dynamodb": {"type": "On demann"},
+		"aws_lambda": {"memorySize": "64", "timeout": "5y"},
+		"aws_ecs": {"capacityProviders": ["FARGATE", "EC2"], "defaultCapacityProvider": "EC2"},
+		"gcp_cloud_run": {"memory": "512MB", "cpu": "half"},
+		"gcp_pubsub": {"messageRetentionDuration": "7 days"},
+		"gcp_gke": {"nodeCount": "0"},
+		"aws_kms": {"numKeys": "0"}
+	}`)
+
+	issues := Validate(nil, &cfg)
+	byField := issuesByField(issues)
+
+	require.Contains(t, byField, "aws_dynamodb.type")
+	require.Equal(t, "invalid_enum", byField["aws_dynamodb.type"].Code)
+	require.Equal(t, "On demand", byField["aws_dynamodb.type"].Suggestion)
+	require.Contains(t, byField["aws_dynamodb.type"].Allowed, "PROVISIONED")
+
+	require.Contains(t, byField, "aws_lambda.memorySize")
+	require.Equal(t, "invalid_value", byField["aws_lambda.memorySize"].Code)
+	require.Contains(t, byField["aws_lambda.memorySize"].Reason, "memory_size must be between 128 and 10240 MB")
+
+	require.Contains(t, byField, "aws_lambda.timeout")
+	require.Equal(t, "unparseable_format", byField["aws_lambda.timeout"].Code)
+
+	require.Contains(t, byField, "aws_ecs.capacityProviders")
+	require.Equal(t, "invalid_enum", byField["aws_ecs.capacityProviders"].Code)
+
+	require.Contains(t, byField, "aws_ecs.defaultCapacityProvider")
+	require.Equal(t, "invalid_enum", byField["aws_ecs.defaultCapacityProvider"].Code)
+
+	require.Contains(t, byField, "gcp_cloud_run.memory")
+	require.Contains(t, byField["gcp_cloud_run.memory"].Reason, "memory must use Kubernetes memory format")
+
+	require.Contains(t, byField, "gcp_cloud_run.cpu")
+	require.Contains(t, byField["gcp_cloud_run.cpu"].Reason, "cpu must be a Kubernetes CPU quantity")
+
+	require.Contains(t, byField, "gcp_pubsub.messageRetentionDuration")
+	require.Contains(t, byField["gcp_pubsub.messageRetentionDuration"].Reason, "message_retention_duration must be a duration")
+
+	require.Contains(t, byField, "gcp_gke.nodeCount")
+	require.Contains(t, byField["gcp_gke.nodeCount"].Reason, "node_count must be >= 1")
+
+	require.Contains(t, byField, "aws_kms.numKeys")
+	require.Contains(t, byField["aws_kms.numKeys"].Reason, "num_keys must be >= 1")
+}
+
+func TestAllowedValues(t *testing.T) {
+	t.Parallel()
+
+	require.ElementsMatch(t,
+		[]string{"On demand", "provisioned", "PAY_PER_REQUEST", "PROVISIONED"},
+		AllowedValues("aws_dynamodb.type"),
+	)
+	require.ElementsMatch(t,
+		[]string{"FARGATE", "FARGATE_SPOT"},
+		AllowedValues("aws_ecs.defaultCapacityProvider"),
+	)
+	require.ElementsMatch(t,
+		[]string{"STANDARD", "NEARLINE", "COLDLINE", "ARCHIVE"},
+		AllowedValues("gcp_gcs.storageClass"),
+	)
+	require.Nil(t, AllowedValues("gcp_pubsub.messageRetentionDuration"))
+}
+
+func TestConfigFieldValidatorsHaveModuleRulesOrExplicitExemption(t *testing.T) {
+	t.Parallel()
+
+	reg, err := defaultValidationRegistry()
+	require.NoError(t, err)
+
+	exempt := map[string]string{
+		"aws_eks.controlPlaneVisibility": "module variable is bool; IR string is validated by the mapper transform before HCL evaluation",
+	}
+
+	var missing []string
+	for _, fv := range configFieldValidators {
+		if fv.component == "" || fv.variable == "" {
+			continue
+		}
+		if _, ok := exempt[fv.field]; ok {
+			continue
+		}
+		mv, ok := reg.variables[moduleVarKey{component: fv.component, variable: fv.variable}]
+		if !ok || len(mv.rules) == 0 {
+			missing = append(missing, fv.field+" -> "+string(fv.component)+"."+fv.variable)
+		}
+	}
+	sort.Strings(missing)
+	require.Empty(t, missing, "mapped IR fields should be backed by module validation blocks")
+}
+
+func issuesByField(issues []ValidationIssue) map[string]ValidationIssue {
+	out := make(map[string]ValidationIssue, len(issues))
+	for _, issue := range issues {
+		out[issue.Field] = issue
+	}
+	return out
+}

--- a/pkg/composer/validate_values_test.go
+++ b/pkg/composer/validate_values_test.go
@@ -12,6 +12,13 @@ import (
 func TestValidate_HCLBackedValues_HappyPath(t *testing.T) {
 	t.Parallel()
 
+	// Exercise the component-aware path so a future component-scoped
+	// pre-filter in Validate cannot silently turn this into a no-op.
+	comps := &Components{
+		Cloud:  "AWS",
+		AWSVPC: "Private VPC",
+		AWSEC2: "Intel",
+	}
 	cfg := cfgFromJSON(t, `{
 		"aws_dynamodb": {"type": "On demand"},
 		"aws_lambda": {"runtime": "nodejs20.x", "memorySize": "512", "timeout": "30s"},
@@ -21,6 +28,7 @@ func TestValidate_HCLBackedValues_HappyPath(t *testing.T) {
 		"gcp_gcs": {"storageClass": "STANDARD"}
 	}`)
 
+	require.Empty(t, Validate(comps, &cfg))
 	require.Empty(t, Validate(nil, &cfg))
 }
 
@@ -38,39 +46,51 @@ func TestValidate_HCLBackedValues_CollectsMultipleIssues(t *testing.T) {
 	}`)
 
 	issues := Validate(nil, &cfg)
+
+	// Cardinality + uniqueness: exactly one issue per field, ten in total.
+	expectedFields := []string{
+		"aws_dynamodb.type",
+		"aws_lambda.memorySize",
+		"aws_lambda.timeout",
+		"aws_ecs.capacityProviders",
+		"aws_ecs.defaultCapacityProvider",
+		"gcp_cloud_run.memory",
+		"gcp_cloud_run.cpu",
+		"gcp_pubsub.messageRetentionDuration",
+		"gcp_gke.nodeCount",
+		"aws_kms.numKeys",
+	}
+	require.Len(t, issues, len(expectedFields))
+	seen := map[string]int{}
+	for _, issue := range issues {
+		seen[issue.Field]++
+	}
+	for _, f := range expectedFields {
+		require.Equal(t, 1, seen[f], "exactly one issue expected for %s, got %d", f, seen[f])
+	}
 	byField := issuesByField(issues)
 
-	require.Contains(t, byField, "aws_dynamodb.type")
 	require.Equal(t, "invalid_enum", byField["aws_dynamodb.type"].Code)
 	require.Equal(t, "On demand", byField["aws_dynamodb.type"].Suggestion)
 	require.Contains(t, byField["aws_dynamodb.type"].Allowed, "PROVISIONED")
 
-	require.Contains(t, byField, "aws_lambda.memorySize")
 	require.Equal(t, "invalid_value", byField["aws_lambda.memorySize"].Code)
 	require.Contains(t, byField["aws_lambda.memorySize"].Reason, "memory_size must be between 128 and 10240 MB")
 
-	require.Contains(t, byField, "aws_lambda.timeout")
 	require.Equal(t, "unparseable_format", byField["aws_lambda.timeout"].Code)
 
-	require.Contains(t, byField, "aws_ecs.capacityProviders")
+	// invalid_enum cases must always carry Allowed — that's the field the
+	// AI corrector consumes for same-turn correction.
 	require.Equal(t, "invalid_enum", byField["aws_ecs.capacityProviders"].Code)
+	require.ElementsMatch(t, []string{"FARGATE", "FARGATE_SPOT"}, byField["aws_ecs.capacityProviders"].Allowed)
 
-	require.Contains(t, byField, "aws_ecs.defaultCapacityProvider")
 	require.Equal(t, "invalid_enum", byField["aws_ecs.defaultCapacityProvider"].Code)
+	require.ElementsMatch(t, []string{"FARGATE", "FARGATE_SPOT"}, byField["aws_ecs.defaultCapacityProvider"].Allowed)
 
-	require.Contains(t, byField, "gcp_cloud_run.memory")
 	require.Contains(t, byField["gcp_cloud_run.memory"].Reason, "memory must use Kubernetes memory format")
-
-	require.Contains(t, byField, "gcp_cloud_run.cpu")
 	require.Contains(t, byField["gcp_cloud_run.cpu"].Reason, "cpu must be a Kubernetes CPU quantity")
-
-	require.Contains(t, byField, "gcp_pubsub.messageRetentionDuration")
 	require.Contains(t, byField["gcp_pubsub.messageRetentionDuration"].Reason, "message_retention_duration must be a duration")
-
-	require.Contains(t, byField, "gcp_gke.nodeCount")
 	require.Contains(t, byField["gcp_gke.nodeCount"].Reason, "node_count must be >= 1")
-
-	require.Contains(t, byField, "aws_kms.numKeys")
 	require.Contains(t, byField["aws_kms.numKeys"].Reason, "num_keys must be >= 1")
 }
 
@@ -100,6 +120,20 @@ func TestConfigFieldValidatorsHaveModuleRulesOrExplicitExemption(t *testing.T) {
 
 	exempt := map[string]string{
 		"aws_eks.controlPlaneVisibility": "module variable is bool; IR string is validated by the mapper transform before HCL evaluation",
+	}
+
+	// The exempt list is an escape hatch — keep it small and require a
+	// rationale string. Bumping this floor demands re-justifying every entry.
+	require.LessOrEqual(t, len(exempt), 1, "exempt list should stay minimal; justify any addition")
+
+	// Stale exempt entries silently mask future drift — guard against a
+	// rename/removal in configFieldValidators leaving an obsolete exemption.
+	knownFields := map[string]bool{}
+	for _, fv := range configFieldValidators {
+		knownFields[fv.field] = true
+	}
+	for k := range exempt {
+		require.True(t, knownFields[k], "exempt entry %q does not match any configFieldValidators field", k)
 	}
 
 	var missing []string
@@ -133,7 +167,34 @@ func TestDefaultValidationRegistry_BuildsForEveryEmbeddedModule(t *testing.T) {
 	reg, err := defaultValidationRegistry()
 	require.NoError(t, err)
 	require.NotNil(t, reg)
-	require.NotEmpty(t, reg.variables, "registry should hold variables for embedded modules")
+
+	// One representative variable from each cloud — proves both walks ran
+	// (deleting the AWS or GCP loop in buildDefaultValidationRegistry would
+	// otherwise survive a NotEmpty check).
+	pinned := []moduleVarKey{
+		{component: KeyAWSDynamoDB, variable: "billing_mode"},
+		{component: KeyAWSLambda, variable: "memory_size"},
+		{component: KeyGCPGCS, variable: "storage_class"},
+		{component: KeyGCPMemorystore, variable: "tier"},
+	}
+	for _, key := range pinned {
+		mv, ok := reg.variables[key]
+		require.True(t, ok, "missing %s.%s in registry", key.component, key.variable)
+		require.NotEmpty(t, mv.rules, "expected %s.%s to have at least one validation rule", key.component, key.variable)
+	}
+
+	// Floor: at least every component the validator wires up must be reachable.
+	covered := map[ComponentKey]bool{}
+	for k := range reg.variables {
+		covered[k.component] = true
+	}
+	for _, fv := range configFieldValidators {
+		if fv.component == "" {
+			continue
+		}
+		require.True(t, covered[fv.component],
+			"registry has no entries for %s — its variables.tf was not parsed", fv.component)
+	}
 }
 
 func TestExtractAllowedValues(t *testing.T) {
@@ -183,6 +244,25 @@ func TestExtractAllowedValues(t *testing.T) {
 			varName:  "x",
 			cond:     `contains(["a", "b"], var.y)`,
 			expected: nil,
+		},
+		{
+			// Negation: a denylist is NOT an allowlist. Walker must return
+			// nil so the AI corrector doesn't suggest forbidden values.
+			name:     "negated contains is not an allowlist",
+			varName:  "x",
+			cond:     `!contains(["a", "b"], var.x)`,
+			expected: nil,
+		},
+		{
+			// alltrue(for-comprehension) is the canonical Terraform idiom
+			// for per-element validation; walker should reach the inner
+			// contains via the for's iteration alias.
+			name:    "alltrue with per-element contains",
+			varName: "items",
+			cond: `alltrue([
+				for item in var.items : contains(["x", "y", "z"], item)
+			])`,
+			expected: []string{"x", "y", "z"},
 		},
 	}
 


### PR DESCRIPTION
## Summary

Closes #134.

Lifts every embedded module's `variables.tf` `validation { condition = ... }` blocks into a Go-level `composer.Validate(comps, cfg) []ValidationIssue` so the per-turn AI correction loop sees the same failure surface terraform reports at plan time — without shelling out to the terraform binary. Adds the 11 module-side validation blocks needed for the IR fields the mapper passed through verbatim or silently dropped on parse error (Lambda runtime/memory/timeout, ECS capacity providers, KMS num_keys, OpenSearch storage_size, GKE node_count, Cloud Run cpu/memory, PubSub durations, GCS storage_class, Memorystore tier, CloudCDN default_ttl, ApiGateway certificate_arn).

- `pkg/composer/hcl_validation.go` (new) — parses every embedded module's `variables.tf` once at first call, builds a registry keyed by `(component, variable)`, and re-evaluates each `validation` block against runtime values via `hcl/v2` + `cty`. `extractAllowedValues` walks the AST for the `contains([…literals…], var.x)` shape including for-comprehensions where the literal set lives in the `if` clause.
- `pkg/composer/validate.go` — adds `Validate`, `AllowedValues`, `ValidationIssue`, and the field→variable wiring for ~35 IR fields. Levenshtein-based `Suggestion` for typos.
- `pkg/composer/mapper.go` — converts ~9 silent `if n, err := strconv.Atoi(...); err == nil` parse-or-drop sites to `*ValidationError` returns; routes ECS capacity providers, Cognito sign-in, OpenSearch deployment type, GCP storage class, and Memorystore tier through canonical normalizers.

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] All 11 modified preset modules validate (`terraform init -backend=false && terraform validate`)
- [x] `go test ./pkg/composer/` (≈44s) green, including the four new tests:
  - `TestValidate_HCLBackedValues_HappyPath` (6 IR families)
  - `TestValidate_HCLBackedValues_CollectsMultipleIssues` (10 fields, 5 distinct codes)
  - `TestAllowedValues` regression
  - `TestConfigFieldValidatorsHaveModuleRulesOrExplicitExemption` (cross-module drift guard)
  - `TestExtractAllowedValues` (6 AST shapes)
  - `TestDefaultValidationRegistry_BuildsForEveryEmbeddedModule` (init-time smoke)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean