### PR TITLE
feat(composer): expose known validation fields

### DIFF
--- a/pkg/composer/validate.go
+++ b/pkg/composer/validate.go
@@ -3,6 +3,7 @@ package composer
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/agext/levenshtein"
@@ -92,6 +93,29 @@ func AllowedValues(field string) []string {
 		return nil
 	}
 	return cloneStrings(reg.allowedValues(fv.component, fv.variable))
+}
+
+// KnownFields returns the dotted IR field paths covered by the validator.
+//
+// The returned order is deterministic for stable consumer contract-test
+// output. Callers that only care about closed-enum drift should pair this with
+// AllowedValues(field): fields with no allowed values may still be validated by
+// regex, numeric range, or other module validation logic.
+func KnownFields() []string {
+	seen := make(map[string]bool, len(componentFieldValidators)+len(configFieldValidators))
+	for _, cv := range componentFieldValidators {
+		seen[cv.field] = true
+	}
+	for _, fv := range configFieldValidators {
+		seen[fv.field] = true
+	}
+
+	fields := make([]string, 0, len(seen))
+	for field := range seen {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	return fields
 }
 
 type componentFieldValidator struct {

--- a/pkg/composer/validate_values_test.go
+++ b/pkg/composer/validate_values_test.go
@@ -112,6 +112,34 @@ func TestAllowedValues(t *testing.T) {
 	require.Nil(t, AllowedValues("gcp_pubsub.messageRetentionDuration"))
 }
 
+func TestKnownFields(t *testing.T) {
+	t.Parallel()
+
+	fields := KnownFields()
+	require.NotEmpty(t, fields)
+	require.True(t, sort.StringsAreSorted(fields), "KnownFields should be deterministic")
+
+	seen := map[string]bool{}
+	for _, field := range fields {
+		require.NotEmpty(t, field)
+		require.False(t, seen[field], "KnownFields returned duplicate %q", field)
+		seen[field] = true
+	}
+
+	for _, field := range []string{
+		"cloud",
+		"aws_dynamodb.type",
+		"aws_eks.controlPlaneVisibility",
+		"gcp_cloud_run.memory",
+	} {
+		require.Contains(t, fields, field)
+	}
+
+	require.NotContains(t, fields, "region", "unvalidated config fields should not appear")
+	require.NotEmpty(t, AllowedValues("aws_dynamodb.type"), "enum fields should still be discoverable via AllowedValues")
+	require.Nil(t, AllowedValues("gcp_cloud_run.memory"), "KnownFields includes non-enum validators; consumers should filter with AllowedValues for enum-only contracts")
+}
+
 func TestConfigFieldValidatorsHaveModuleRulesOrExplicitExemption(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/composer/validate_values_test.go
+++ b/pkg/composer/validate_values_test.go
@@ -115,24 +115,32 @@ func TestAllowedValues(t *testing.T) {
 func TestKnownFields(t *testing.T) {
 	t.Parallel()
 
-	expected := make([]string, 0, len(componentFieldValidators)+len(configFieldValidators))
+	// Build expected as a set so the assertion mirrors the production
+	// dedupe contract: a field appearing in both validator slices must
+	// surface exactly once, not twice.
+	expected := map[string]struct{}{}
 	for _, cv := range componentFieldValidators {
-		expected = append(expected, cv.field)
+		expected[cv.field] = struct{}{}
 	}
 	for _, fv := range configFieldValidators {
-		expected = append(expected, fv.field)
+		expected[fv.field] = struct{}{}
 	}
 
 	fields := KnownFields()
 	require.NotEmpty(t, fields)
 	require.True(t, sort.StringsAreSorted(fields), "KnownFields should be deterministic")
-	require.ElementsMatch(t, expected, fields)
+	require.Len(t, fields, len(expected), "KnownFields should be deduped to the set of distinct validator fields")
 
 	seen := map[string]bool{}
 	for _, field := range fields {
 		require.NotEmpty(t, field)
 		require.False(t, seen[field], "KnownFields returned duplicate %q", field)
 		seen[field] = true
+		_, ok := expected[field]
+		require.True(t, ok, "KnownFields returned %q which is not declared in any validator slice", field)
+	}
+	for field := range expected {
+		require.True(t, seen[field], "KnownFields missing declared validator field %q", field)
 	}
 
 	for _, field := range []string{

--- a/pkg/composer/validate_values_test.go
+++ b/pkg/composer/validate_values_test.go
@@ -115,9 +115,18 @@ func TestAllowedValues(t *testing.T) {
 func TestKnownFields(t *testing.T) {
 	t.Parallel()
 
+	expected := make([]string, 0, len(componentFieldValidators)+len(configFieldValidators))
+	for _, cv := range componentFieldValidators {
+		expected = append(expected, cv.field)
+	}
+	for _, fv := range configFieldValidators {
+		expected = append(expected, fv.field)
+	}
+
 	fields := KnownFields()
 	require.NotEmpty(t, fields)
 	require.True(t, sort.StringsAreSorted(fields), "KnownFields should be deterministic")
+	require.ElementsMatch(t, expected, fields)
 
 	seen := map[string]bool{}
 	for _, field := range fields {


### PR DESCRIPTION
## Summary
- Add composer.KnownFields() to enumerate validator-covered IR field paths in deterministic order.
- Document the intended consumer pattern: use KnownFields for coverage and AllowedValues(field) to isolate closed-enum fields.
- Add unit coverage for stable fields, ordering, dedupe, and non-enum validator behavior.

## Test plan
- [x] go test ./pkg/composer
- [x] go test ./...
- [x] git diff --check

Fixes #136