### PR TITLE
fix(gcp): kms type mismatch + loadbalancer empty-backends URL map

### DIFF
--- a/gcp/kms/main.tf
+++ b/gcp/kms/main.tf
@@ -14,10 +14,10 @@ module "kms" {
   keyring    = local.keyring_name
 
   keys                 = [for k in var.keys : k.name]
-  key_rotation_period  = { for k in var.keys : k.name => k.rotation_period }
-  key_algorithm        = { for k in var.keys : k.name => k.algorithm }
-  key_protection_level = { for k in var.keys : k.name => k.protection_level }
-  purpose              = { for k in var.keys : k.name => k.purpose }
+  key_rotation_period  = var.keys[0].rotation_period
+  key_algorithm        = var.keys[0].algorithm
+  key_protection_level = var.keys[0].protection_level
+  purpose              = var.keys[0].purpose
 
   prevent_destroy = var.prevent_destroy
 

--- a/gcp/kms/tests/kms.tftest.hcl
+++ b/gcp/kms/tests/kms.tftest.hcl
@@ -1,0 +1,96 @@
+mock_provider "google" {}
+
+# Regression for #141. terraform-google-modules/kms ~> 3.0 declares
+# key_rotation_period / key_algorithm / key_protection_level / purpose as
+# scalar string. A previous revision of main.tf passed map(string) values
+# built from `for k in var.keys : ...`, which the upstream module rejected
+# with `string required` at apply time. The wrapper now passes scalars
+# from var.keys[0] and the variable validates that all keys agree on
+# those four fields — these tests pin both halves.
+
+run "defaults_plan" {
+  command = plan
+
+  variables {
+    project = "test"
+  }
+}
+
+run "multiple_homogeneous_keys" {
+  command = plan
+
+  variables {
+    project = "test"
+    keys = [
+      { name = "data" },
+      { name = "logs" },
+    ]
+  }
+}
+
+run "rejects_heterogeneous_rotation_period" {
+  command = plan
+
+  variables {
+    project = "test"
+    keys = [
+      { name = "a", rotation_period = "7776000s" },
+      { name = "b", rotation_period = "2592000s" },
+    ]
+  }
+
+  expect_failures = [var.keys]
+}
+
+run "rejects_heterogeneous_algorithm" {
+  command = plan
+
+  variables {
+    project = "test"
+    keys = [
+      { name = "a", algorithm = "GOOGLE_SYMMETRIC_ENCRYPTION" },
+      { name = "b", algorithm = "RSA_SIGN_PSS_2048_SHA256" },
+    ]
+  }
+
+  expect_failures = [var.keys]
+}
+
+run "rejects_heterogeneous_protection_level" {
+  command = plan
+
+  variables {
+    project = "test"
+    keys = [
+      { name = "a", protection_level = "SOFTWARE" },
+      { name = "b", protection_level = "HSM" },
+    ]
+  }
+
+  expect_failures = [var.keys]
+}
+
+run "rejects_heterogeneous_purpose" {
+  command = plan
+
+  variables {
+    project = "test"
+    keys = [
+      { name = "a", purpose = "ENCRYPT_DECRYPT" },
+      { name = "b", purpose = "ASYMMETRIC_SIGN" },
+    ]
+  }
+
+  expect_failures = [var.keys]
+}
+
+run "rejects_empty_keys" {
+  command = plan
+
+  variables {
+    project = "test"
+    keys    = []
+  }
+
+  expect_failures = [var.keys]
+}

--- a/gcp/kms/variables.tf
+++ b/gcp/kms/variables.tf
@@ -33,6 +33,27 @@ variable "keys" {
   default = [{
     name = "default"
   }]
+
+  validation {
+    condition     = length(var.keys) > 0
+    error_message = "var.keys must contain at least one entry."
+  }
+  validation {
+    condition     = length(distinct([for k in var.keys : k.rotation_period])) <= 1
+    error_message = "All keys must share the same rotation_period (the upstream KMS module applies one value to every key in the keyring)."
+  }
+  validation {
+    condition     = length(distinct([for k in var.keys : k.algorithm])) <= 1
+    error_message = "All keys must share the same algorithm."
+  }
+  validation {
+    condition     = length(distinct([for k in var.keys : k.protection_level])) <= 1
+    error_message = "All keys must share the same protection_level."
+  }
+  validation {
+    condition     = length(distinct([for k in var.keys : k.purpose])) <= 1
+    error_message = "All keys must share the same purpose."
+  }
 }
 
 variable "prevent_destroy" {

--- a/gcp/loadbalancer/main.tf
+++ b/gcp/loadbalancer/main.tf
@@ -87,6 +87,16 @@ resource "google_compute_url_map" "this" {
   project         = var.project
   default_service = length(var.backends) > 0 ? google_compute_backend_service.this[var.default_backend != "" ? var.default_backend : var.backends[0].name].id : null
 
+  # GCP requires one of default_service / default_url_redirect on every URL map.
+  dynamic "default_url_redirect" {
+    for_each = length(var.backends) == 0 ? [1] : []
+    content {
+      host_redirect          = "placeholder.invalid"
+      strip_query            = false
+      redirect_response_code = "FOUND"
+    }
+  }
+
   dynamic "host_rule" {
     for_each = var.url_map_hosts
     content {

--- a/gcp/loadbalancer/tests/url_map.tftest.hcl
+++ b/gcp/loadbalancer/tests/url_map.tftest.hcl
@@ -1,0 +1,63 @@
+mock_provider "google" {}
+
+# Regression for #141. google_compute_url_map requires exactly one of
+# default_service / default_url_redirect. An earlier revision left both
+# unset when var.backends == [], so the GCP provider rejected the resource
+# at apply time. The wrapper now renders a placeholder default_url_redirect
+# whenever no backends are configured; these tests pin that branch.
+
+run "empty_backends_uses_redirect_placeholder" {
+  command = plan
+
+  variables {
+    project           = "test"
+    network_self_link = "projects/test/global/networks/n"
+    subnet_self_link  = "projects/test/regions/us-central1/subnetworks/s"
+  }
+
+  assert {
+    condition     = google_compute_url_map.this.default_service == null
+    error_message = "default_service must be null when no backends are configured"
+  }
+
+  assert {
+    condition     = length(google_compute_url_map.this.default_url_redirect) == 1
+    error_message = "Expected default_url_redirect block when backends is empty"
+  }
+
+  assert {
+    condition     = google_compute_url_map.this.default_url_redirect[0].host_redirect == "placeholder.invalid"
+    error_message = "Empty-backends URL map must redirect to placeholder.invalid"
+  }
+
+  assert {
+    condition     = google_compute_url_map.this.default_url_redirect[0].redirect_response_code == "FOUND"
+    error_message = "Empty-backends redirect must return 302 FOUND"
+  }
+}
+
+run "with_backends_uses_default_service" {
+  command = plan
+
+  variables {
+    project           = "test"
+    network_self_link = "projects/test/global/networks/n"
+    subnet_self_link  = "projects/test/regions/us-central1/subnetworks/s"
+    backends = [
+      {
+        name           = "api"
+        instance_group = "projects/test/zones/us-central1-a/instanceGroups/api"
+      },
+    ]
+  }
+
+  assert {
+    condition     = length(google_compute_url_map.this.default_url_redirect) == 0
+    error_message = "default_url_redirect must not be set when backends are configured"
+  }
+
+  assert {
+    condition     = length(google_compute_backend_service.this) == 1
+    error_message = "Expected one backend service to be created from var.backends"
+  }
+}


### PR DESCRIPTION
## Summary

Fixes two independent bugs that blocked every prod GCP deploy after `reliable` bumped its presets pin to `v0.5.0` (`luthersystems/reliable#1155`):

1. **`gcp/kms`** — wrapper passed `map(string)` to `terraform-google-modules/kms ~> 3.0`'s `key_rotation_period` / `key_algorithm` / `key_protection_level` / `purpose`, but upstream declares all four as scalar `string`s applied to every key in the keyring. The wrapper has been broken since the initial commit; no example or `terraform validate` test exercised it, so it shipped silently.
2. **`gcp/loadbalancer`** — `google_compute_url_map.this.default_service` resolved to `null` when `var.backends` was empty (the default), and the GCP provider rejects URL maps without one of `default_service` / `default_url_redirect`.

## Changes

### `gcp/kms`
- `main.tf`: pass `var.keys[0].{rotation_period,algorithm,protection_level,purpose}` as scalars instead of building per-key maps the upstream module can't accept.
- `variables.tf`: add validation blocks that reject (a) empty `var.keys` and (b) any `var.keys` entries diverging on rotation/algorithm/protection/purpose — upstream can't deliver per-key heterogeneity in any 3.x release, so divergence becomes a loud error rather than silent value-dropping.

### `gcp/loadbalancer`
- `main.tf`: add `dynamic "default_url_redirect"` to `google_compute_url_map.this` that fires only when `length(var.backends) == 0`, with a placeholder host (`placeholder.invalid`, an RFC 6761 reserved TLD) and a 302 response. Keeps every existing output (`url_map_id`, `external_ip`, `http_proxy_id`, ...) unconditional so the composer's wiring graph stays valid.

## Verification

- `terraform plan` on `gcp/kms` with default vars: 2 resources to add (pre-fix: validate fails with "string required").
- `terraform plan` on `gcp/loadbalancer` with default empty backends: 6 resources to add, URL map renders the `default_url_redirect` block (pre-fix: provider would reject at apply).
- Validation rejects heterogeneous keys: `keys=[{name=a,rotation_period=7776000s},{name=b,rotation_period=2592000s}]` errors at plan time with "All keys must share the same rotation_period".
- `terraform fmt -check -recursive`: clean.
- `go test ./pkg/composer/...`: passing.
- `tests/lint-project-label.sh`: passing.

## Reproduction

Originally surfaced by Oracle prod job `ccs-3d055ba6-qdscd` (Reliable session `sess_v2_jpS77sJekR35`, stack version `sv_eITaQF-DZ-YL`), retried 4× against the same stack version on prod.

## Out of scope

- A repo-wide `terraform validate`-per-module CI gate. The absence of one is what let this regress; worth a follow-up issue but expanding scope here would delay the prod unblock.
- Adding example stacks that exercise `gcp/kms` or `gcp/loadbalancer` end-to-end. Same reasoning.

Fixes #141