### PR TITLE
feat: ImportedResource carrier (Phase 2 foundation, #144)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,9 @@
 # Local environment / secrets
 .env
 
-# Imported/scratch artifacts
-imported/
-insideout-import
+# Imported/scratch artifacts (top-level only — pkg/composer/imported is real)
+/imported/
+/insideout-import
 
 # Claude Code local settings (keep shared .claude/settings.json)
 .claude/settings.local.json

--- a/pkg/composer/imported/address.go
+++ b/pkg/composer/imported/address.go
@@ -1,0 +1,216 @@
+package imported
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// maxLabelLen caps the normalized label portion of a generated address. The
+// reserved suffix budget covers `_<8hex>` collision tags plus an optional
+// numeric counter. Terraform itself does not impose a hard label cap, but a
+// conservative limit keeps composed HCL readable and stays well under any
+// downstream tool's column limits.
+const (
+	maxLabelLen     = 96
+	hashSuffixLen   = 8
+	suffixReserve   = hashSuffixLen + 4 // "_<8hex>" plus headroom for "_NN"
+	collisionPrefix = "r_"
+)
+
+// GenerateAddress returns a deterministic Terraform address
+// (`<type>.<label>`) for the given identity. The exists predicate is consulted
+// to avoid collisions; callers seed it with both currently-used and retired
+// addresses so previously-claimed names are never reused unless reclaiming the
+// same canonical identity.
+//
+// Algorithm (per docs/managed-resource-tiers.md lines 528-544):
+//
+//  1. Pick the first non-empty name hint from id.NameHint, NativeIDs["name"],
+//     final segments of NativeIDs["arn"] / NativeIDs["self_link"], final
+//     segment of id.ImportID, then the resource type stem.
+//  2. Normalize: lowercase ASCII, replace [^a-z0-9_] with `_`, collapse
+//     repeated `_`, trim leading/trailing `_`, prefix `r_` if it does not
+//     start with a letter, cap to maxLabelLen-suffixReserve.
+//  3. Compose addr = `<type>.<normalized>`. If exists is nil or returns
+//     false, return.
+//  4. Otherwise append `_<8hex>` of the canonical identity hash.
+//  5. If still colliding, append a numeric counter `_2`, `_3`, ...
+func GenerateAddress(id ResourceIdentity, exists func(addr string) bool) string {
+	hash := identityHash(id)
+
+	hint := pickNameHint(id, hash)
+	label := normalizeLabel(hint, maxLabelLen-suffixReserve)
+	if label == "" {
+		// Defensive: normalize emptied the hint entirely. Fall back to a
+		// hash-only label so we never emit a bare `<type>.` address.
+		label = collisionPrefix + hash[:hashSuffixLen]
+	}
+
+	addr := id.Type + "." + label
+	if exists == nil || !exists(addr) {
+		return addr
+	}
+
+	hashed := addr + "_" + hash[:hashSuffixLen]
+	if !exists(hashed) {
+		return hashed
+	}
+
+	for n := 2; ; n++ {
+		candidate := hashed + "_" + strconv.Itoa(n)
+		if !exists(candidate) {
+			return candidate
+		}
+	}
+}
+
+// pickNameHint chooses the first non-empty name source per the design doc's
+// precedence order. hashFallback is used only if every source is empty.
+func pickNameHint(id ResourceIdentity, hashFallback string) string {
+	if h := strings.TrimSpace(id.NameHint); h != "" {
+		return h
+	}
+	if h := strings.TrimSpace(id.NativeIDs["name"]); h != "" {
+		return h
+	}
+	if h := lastSegment(id.NativeIDs["arn"]); h != "" {
+		return h
+	}
+	if h := lastSegment(id.NativeIDs["self_link"]); h != "" {
+		return h
+	}
+	if h := lastSegment(id.ImportID); h != "" {
+		return h
+	}
+	if h := typeStem(id.Type); h != "" {
+		return h
+	}
+	if hashFallback == "" {
+		return ""
+	}
+	return collisionPrefix + hashFallback[:hashSuffixLen]
+}
+
+// lastSegment returns the substring after the final `/`, `:`, or `,`.
+// Empty input returns empty.
+func lastSegment(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	for _, sep := range []string{"/", ":", ","} {
+		if i := strings.LastIndex(s, sep); i >= 0 && i < len(s)-1 {
+			s = s[i+1:]
+		}
+	}
+	return s
+}
+
+// typeStem returns the suffix of a Terraform type after the cloud prefix:
+// "aws_sqs_queue" -> "sqs_queue", "google_compute_instance" -> "compute_instance".
+// Returns the unchanged type if no recognized prefix is present.
+func typeStem(t string) string {
+	t = strings.TrimSpace(t)
+	switch {
+	case strings.HasPrefix(t, "aws_"):
+		return t[len("aws_"):]
+	case strings.HasPrefix(t, "google_"):
+		return t[len("google_"):]
+	case strings.HasPrefix(t, "gcp_"):
+		return t[len("gcp_"):]
+	}
+	return t
+}
+
+// normalizeLabel converts an arbitrary hint into a Terraform-safe identifier.
+// Behavior:
+//   - lowercase ASCII; non-ASCII letters are dropped (replaced with `_`).
+//   - any rune outside [a-z0-9_] becomes `_`.
+//   - repeated `_` collapse to a single `_`.
+//   - leading and trailing `_` trimmed.
+//   - if the first rune is not [a-z], prefix `r_`.
+//   - truncated to maxLen runes (after all other steps), trimming trailing
+//     `_` again so the cap never produces `foo_`.
+func normalizeLabel(hint string, maxLen int) string {
+	hint = strings.ToLower(strings.TrimSpace(hint))
+	if hint == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.Grow(len(hint))
+	prevUnderscore := false
+	for _, r := range hint {
+		isAlnum := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		isUnderscore := r == '_'
+		if !isAlnum && !isUnderscore {
+			// non-alnum collapses into a single `_`.
+			if !prevUnderscore {
+				b.WriteByte('_')
+				prevUnderscore = true
+			}
+			continue
+		}
+		if isUnderscore && prevUnderscore {
+			// Collapse consecutive underscores from any source.
+			continue
+		}
+		b.WriteRune(r)
+		prevUnderscore = isUnderscore
+	}
+
+	out := strings.Trim(b.String(), "_")
+	if out == "" {
+		return ""
+	}
+
+	if c := out[0]; !(c >= 'a' && c <= 'z') {
+		out = collisionPrefix + out
+	}
+
+	if maxLen > 0 && len(out) > maxLen {
+		out = out[:maxLen]
+		out = strings.TrimRight(out, "_")
+	}
+	return out
+}
+
+// identityHash returns the lowercase hex sha256 of a canonical, deterministic
+// rendering of the identity's correlation tuple. ProviderIdentity map keys
+// are sorted before hashing because Go map iteration is unordered — without
+// sorting, the same identity would hash to different values across runs.
+func identityHash(id ResourceIdentity) string {
+	var b strings.Builder
+	b.WriteString(id.Cloud)
+	b.WriteByte('|')
+	b.WriteString(id.AccountID)
+	b.WriteByte('|')
+	b.WriteString(id.ProjectID)
+	b.WriteByte('|')
+	b.WriteString(id.Region)
+	b.WriteByte('|')
+	b.WriteString(id.Location)
+	b.WriteByte('|')
+	b.WriteString(id.Type)
+	b.WriteByte('|')
+	b.WriteString(id.ImportID)
+	b.WriteByte('|')
+
+	keys := make([]string, 0, len(id.ProviderIdentity))
+	for k := range id.ProviderIdentity {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(id.ProviderIdentity[k])
+		b.WriteByte(';')
+	}
+
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/composer/imported/address.go
+++ b/pkg/composer/imported/address.go
@@ -26,6 +26,10 @@ const (
 // addresses so previously-claimed names are never reused unless reclaiming the
 // same canonical identity.
 //
+// id.Type is mandatory — there is no valid Terraform address without a
+// resource type. If id.Type is empty (after trimming whitespace), the
+// function returns "" so callers can detect the misuse.
+//
 // Algorithm (per docs/managed-resource-tiers.md lines 528-544):
 //
 //  1. Pick the first non-empty name hint from id.NameHint, NativeIDs["name"],
@@ -39,6 +43,9 @@ const (
 //  4. Otherwise append `_<8hex>` of the canonical identity hash.
 //  5. If still colliding, append a numeric counter `_2`, `_3`, ...
 func GenerateAddress(id ResourceIdentity, exists func(addr string) bool) string {
+	if strings.TrimSpace(id.Type) == "" {
+		return ""
+	}
 	hash := identityHash(id)
 
 	hint := pickNameHint(id, hash)

--- a/pkg/composer/imported/address_test.go
+++ b/pkg/composer/imported/address_test.go
@@ -1,0 +1,232 @@
+package imported
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateAddress_BasicLabel(t *testing.T) {
+	t.Parallel()
+	id := ResourceIdentity{
+		Cloud:    "aws",
+		Type:     "aws_sqs_queue",
+		NameHint: "orders-DLQ",
+	}
+	got := GenerateAddress(id, neverExists)
+	assert.Equal(t, "aws_sqs_queue.orders_dlq", got)
+}
+
+func TestGenerateAddress_LeadingDigit(t *testing.T) {
+	t.Parallel()
+	id := ResourceIdentity{
+		Cloud:    "aws",
+		Type:     "aws_s3_bucket",
+		NameHint: "123abc",
+	}
+	got := GenerateAddress(id, neverExists)
+	assert.Equal(t, "aws_s3_bucket.r_123abc", got)
+}
+
+func TestGenerateAddress_NameHintBeatsNativeIDs(t *testing.T) {
+	t.Parallel()
+	id := ResourceIdentity{
+		Type:     "aws_sqs_queue",
+		NameHint: "explicit",
+		NativeIDs: map[string]string{
+			"name": "should-not-be-used",
+			"arn":  "arn:aws:sqs:us-east-1:000000000000:also-ignored",
+		},
+	}
+	assert.Equal(t, "aws_sqs_queue.explicit",
+		GenerateAddress(id, neverExists))
+}
+
+func TestGenerateAddress_FallsBackToNativeNameThenArn(t *testing.T) {
+	t.Parallel()
+	id := ResourceIdentity{
+		Type:      "aws_sqs_queue",
+		NativeIDs: map[string]string{"name": "from-native-name"},
+	}
+	assert.Equal(t, "aws_sqs_queue.from_native_name",
+		GenerateAddress(id, neverExists))
+
+	id = ResourceIdentity{
+		Type: "aws_sqs_queue",
+		NativeIDs: map[string]string{
+			"arn": "arn:aws:sqs:us-east-1:000000000000:from-arn",
+		},
+	}
+	assert.Equal(t, "aws_sqs_queue.from_arn",
+		GenerateAddress(id, neverExists))
+}
+
+func TestGenerateAddress_FallsBackToImportIDFinalSegment(t *testing.T) {
+	t.Parallel()
+	id := ResourceIdentity{
+		Type:     "google_compute_instance",
+		ImportID: "projects/p/zones/us-central1-a/instances/my-vm",
+	}
+	assert.Equal(t, "google_compute_instance.my_vm",
+		GenerateAddress(id, neverExists))
+}
+
+func TestGenerateAddress_FallsBackToTypeStem(t *testing.T) {
+	t.Parallel()
+	id := ResourceIdentity{Type: "aws_sqs_queue"}
+	assert.Equal(t, "aws_sqs_queue.sqs_queue",
+		GenerateAddress(id, neverExists))
+
+	id = ResourceIdentity{Type: "google_storage_bucket"}
+	assert.Equal(t, "google_storage_bucket.storage_bucket",
+		GenerateAddress(id, neverExists))
+}
+
+func TestGenerateAddress_EmptyHints(t *testing.T) {
+	t.Parallel()
+	// Empty NameHint, NativeIDs, ImportID, AND Type — falls all the way
+	// through to the hash-only label form.
+	id := ResourceIdentity{Cloud: "aws"}
+	got := GenerateAddress(id, neverExists)
+	assert.True(t, strings.HasPrefix(got, "."), "no Type means address starts with `.`: %q", got)
+	assert.Contains(t, got, ".r_")
+	// 8 hex chars after the r_ prefix.
+	parts := strings.Split(got, ".r_")
+	require.Len(t, parts, 2)
+	assert.Len(t, parts[1], 8)
+}
+
+func TestGenerateAddress_LengthCap(t *testing.T) {
+	t.Parallel()
+	id := ResourceIdentity{
+		Type:     "aws_s3_bucket",
+		NameHint: strings.Repeat("a", 200),
+	}
+	got := GenerateAddress(id, neverExists)
+	parts := strings.SplitN(got, ".", 2)
+	require.Len(t, parts, 2)
+	assert.LessOrEqual(t, len(parts[1]), maxLabelLen-suffixReserve)
+}
+
+func TestGenerateAddress_CollisionAppendsHash(t *testing.T) {
+	t.Parallel()
+	id := ResourceIdentity{
+		Cloud:    "aws",
+		Type:     "aws_sqs_queue",
+		NameHint: "orders",
+		ImportID: "arn:aws:sqs:us-east-1:000000000000:orders",
+	}
+	taken := map[string]bool{
+		"aws_sqs_queue.orders": true,
+	}
+	got := GenerateAddress(id, func(addr string) bool { return taken[addr] })
+
+	require.True(t, strings.HasPrefix(got, "aws_sqs_queue.orders_"))
+	suffix := strings.TrimPrefix(got, "aws_sqs_queue.orders_")
+	assert.Len(t, suffix, hashSuffixLen, "collision suffix must be 8 hex chars: %q", got)
+}
+
+func TestGenerateAddress_DeterministicHashAcrossMapOrder(t *testing.T) {
+	t.Parallel()
+	mk := func(seed int) ResourceIdentity {
+		// Build the ProviderIdentity map in different insertion orders to
+		// shake out any reliance on Go map iteration order.
+		pi := make(map[string]string, 4)
+		keys := []string{"region", "account", "name", "version"}
+		vals := []string{"us-east-1", "123", "orders", "v1"}
+		// Cycle through a deterministic but different starting offset per
+		// seed; Go's map insertion order is randomized, so this is
+		// belt-and-braces alongside the sort in identityHash.
+		for i := range keys {
+			j := (i + seed) % len(keys)
+			pi[keys[j]] = vals[j]
+		}
+		return ResourceIdentity{
+			Cloud:            "aws",
+			Type:             "aws_sqs_queue",
+			AccountID:        "123",
+			Region:           "us-east-1",
+			ImportID:         "arn:aws:sqs:us-east-1:123:orders",
+			ProviderIdentity: pi,
+		}
+	}
+
+	taken := map[string]bool{"aws_sqs_queue.orders": true}
+	exists := func(addr string) bool { return taken[addr] }
+
+	addr0 := GenerateAddress(mk(0), exists)
+	for i := 1; i < 100; i++ {
+		got := GenerateAddress(mk(i), exists)
+		require.Equalf(t, addr0, got,
+			"identity hash must be order-independent; iter %d got %q want %q",
+			i, got, addr0)
+	}
+}
+
+func TestGenerateAddress_HashCollisionFallsBackToCounter(t *testing.T) {
+	t.Parallel()
+	id := ResourceIdentity{
+		Cloud:    "aws",
+		Type:     "aws_sqs_queue",
+		NameHint: "orders",
+	}
+	// First two candidates collide; force the counter path.
+	bareAddr := "aws_sqs_queue.orders"
+	hashAddr := bareAddr + "_" + identityHash(id)[:hashSuffixLen]
+	taken := map[string]bool{
+		bareAddr: true,
+		hashAddr: true,
+	}
+	got := GenerateAddress(id, func(addr string) bool { return taken[addr] })
+	assert.Equal(t, hashAddr+"_2", got)
+}
+
+func TestGenerateAddress_NeverReuseRetired(t *testing.T) {
+	t.Parallel()
+	id := ResourceIdentity{
+		Cloud:    "aws",
+		Type:     "aws_sqs_queue",
+		NameHint: "orders",
+	}
+	bareAddr := "aws_sqs_queue.orders"
+	// The predicate models retired addresses as still "taken" so the
+	// generator must skip them.
+	retired := map[string]bool{bareAddr: true}
+	got := GenerateAddress(id, func(addr string) bool { return retired[addr] })
+	assert.NotEqual(t, bareAddr, got)
+}
+
+func TestNormalizeLabel_Cases(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"only-spaces", "   ", ""},
+		{"already-clean", "abc_def", "abc_def"},
+		{"uppercase", "ABC", "abc"},
+		{"dashes-and-dots", "my.name-thing", "my_name_thing"},
+		{"collapse-underscores", "a___b__c", "a_b_c"},
+		{"trim-edges", "__abc__", "abc"},
+		{"leading-digit", "9lives", "r_9lives"},
+		{"all-special", "@@@", ""},
+		{"unicode-letters-dropped", "café", "caf"},
+		{"only-numeric", "12345", "r_12345"},
+		{"only-underscore", "____", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeLabel(tc.in, maxLabelLen-suffixReserve)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// neverExists is a predicate that reports every address as available; used
+// when we want to assert the unsuffixed form.
+func neverExists(string) bool { return false }

--- a/pkg/composer/imported/address_test.go
+++ b/pkg/composer/imported/address_test.go
@@ -84,18 +84,27 @@ func TestGenerateAddress_FallsBackToTypeStem(t *testing.T) {
 		GenerateAddress(id, neverExists))
 }
 
-func TestGenerateAddress_EmptyHints(t *testing.T) {
+func TestGenerateAddress_EmptyTypeReturnsEmpty(t *testing.T) {
 	t.Parallel()
-	// Empty NameHint, NativeIDs, ImportID, AND Type — falls all the way
-	// through to the hash-only label form.
-	id := ResourceIdentity{Cloud: "aws"}
-	got := GenerateAddress(id, neverExists)
-	assert.True(t, strings.HasPrefix(got, "."), "no Type means address starts with `.`: %q", got)
-	assert.Contains(t, got, ".r_")
-	// 8 hex chars after the r_ prefix.
-	parts := strings.Split(got, ".r_")
-	require.Len(t, parts, 2)
-	assert.Len(t, parts[1], 8)
+	// Type is mandatory. With an empty Type the function must return ""
+	// rather than emit a malformed `.label` address.
+	for _, in := range []ResourceIdentity{
+		{Cloud: "aws"},
+		{Cloud: "aws", NameHint: "orders"},
+		{Type: "   "}, // whitespace-only also rejected
+	} {
+		assert.Equalf(t, "", GenerateAddress(in, neverExists),
+			"empty/whitespace Type must yield empty address; in=%+v", in)
+	}
+}
+
+func TestGenerateAddress_AllHintsEmptyFallsBackToTypeStem(t *testing.T) {
+	t.Parallel()
+	// With Type set but every hint source empty, the type stem provides
+	// the label (per pickNameHint precedence step 6).
+	id := ResourceIdentity{Type: "aws_sqs_queue"}
+	assert.Equal(t, "aws_sqs_queue.sqs_queue",
+		GenerateAddress(id, neverExists))
 }
 
 func TestGenerateAddress_LengthCap(t *testing.T) {
@@ -196,6 +205,157 @@ func TestGenerateAddress_NeverReuseRetired(t *testing.T) {
 	retired := map[string]bool{bareAddr: true}
 	got := GenerateAddress(id, func(addr string) bool { return retired[addr] })
 	assert.NotEqual(t, bareAddr, got)
+}
+
+// TestPickNameHint_AdjacentPairPrecedence locks the documented hint-source
+// precedence: NameHint > NativeIDs[name] > NativeIDs[arn]-last-segment >
+// NativeIDs[self_link]-last-segment > ImportID-last-segment > type stem.
+// A regression that swaps any adjacent pair shows up as exactly one failing
+// row.
+func TestPickNameHint_AdjacentPairPrecedence(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		id   ResourceIdentity
+		want string // the resulting label portion of the address
+	}{
+		{
+			name: "NameHint_beats_NativeIDsName",
+			id: ResourceIdentity{
+				Type:      "aws_sqs_queue",
+				NameHint:  "from-hint",
+				NativeIDs: map[string]string{"name": "from-name"},
+			},
+			want: "from_hint",
+		},
+		{
+			name: "NativeIDsName_beats_ARN",
+			id: ResourceIdentity{
+				Type: "aws_sqs_queue",
+				NativeIDs: map[string]string{
+					"name": "from-name",
+					"arn":  "arn:aws:sqs:us-east-1:000000000000:from-arn",
+				},
+			},
+			want: "from_name",
+		},
+		{
+			name: "ARN_beats_SelfLink",
+			id: ResourceIdentity{
+				Type: "aws_sqs_queue",
+				NativeIDs: map[string]string{
+					"arn":       "arn:aws:sqs:us-east-1:000000000000:from-arn",
+					"self_link": "https://example.com/projects/p/queues/from-self-link",
+				},
+			},
+			want: "from_arn",
+		},
+		{
+			name: "SelfLink_beats_ImportID",
+			id: ResourceIdentity{
+				Type: "google_compute_instance",
+				NativeIDs: map[string]string{
+					"self_link": "https://compute.googleapis.com/.../instances/from-self-link",
+				},
+				ImportID: "projects/p/zones/us-central1-a/instances/from-import",
+			},
+			want: "from_self_link",
+		},
+		{
+			name: "ImportID_beats_TypeStem",
+			id: ResourceIdentity{
+				Type:     "aws_sqs_queue",
+				ImportID: "arn:aws:sqs:us-east-1:000000000000:from-import",
+			},
+			want: "from_import",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := GenerateAddress(tc.id, neverExists)
+			want := tc.id.Type + "." + tc.want
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+// TestGenerateAddress_HashCollisionFallsBackToCounterDeep walks the counter
+// past the first iteration. Catches off-by-one errors in the counter loop's
+// starting value (must be 2, not 1 or 3).
+func TestGenerateAddress_HashCollisionFallsBackToCounterDeep(t *testing.T) {
+	t.Parallel()
+	id := ResourceIdentity{
+		Cloud:    "aws",
+		Type:     "aws_sqs_queue",
+		NameHint: "orders",
+	}
+	bareAddr := "aws_sqs_queue.orders"
+	hashAddr := bareAddr + "_" + identityHash(id)[:hashSuffixLen]
+	taken := map[string]bool{
+		bareAddr:        true,
+		hashAddr:        true,
+		hashAddr + "_2": true,
+		hashAddr + "_3": true,
+	}
+	got := GenerateAddress(id, func(addr string) bool { return taken[addr] })
+	assert.Equal(t, hashAddr+"_4", got)
+}
+
+// TestIdentityHash_Golden locks the canonical-render order of identityHash
+// against accidental field reorders. The expected hex was computed once
+// against the ResourceIdentity below; if anyone reorders the fields in
+// identityHash's strings.Builder (or changes a separator), this test breaks
+// immediately.
+func TestIdentityHash_Golden(t *testing.T) {
+	t.Parallel()
+	id := ResourceIdentity{
+		Cloud:     "aws",
+		Type:      "aws_sqs_queue",
+		AccountID: "123456789012",
+		Region:    "us-east-1",
+		ImportID:  "arn:aws:sqs:us-east-1:123456789012:orders-DLQ",
+		ProviderIdentity: map[string]string{
+			"name":   "orders-DLQ",
+			"region": "us-east-1",
+		},
+	}
+	const wantHex = "7e95577c62625f7b2b2c9b8bea1930a115d49453f3496f8b01a68a49babfeec8"
+	got := identityHash(id)
+	assert.Equal(t, wantHex, got,
+		"identityHash must produce the locked-in hex; if this fails after an intentional change to the canonical render, update the golden value")
+}
+
+// TestLastSegment_Cases pins the documented separator-cascade behavior of
+// lastSegment (`/` then `:` then `,`, applied sequentially to whatever the
+// previous step returned). Adding a comma test guards against a future
+// refactor that drops one of the separators.
+func TestLastSegment_Cases(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"only-spaces", "   ", ""},
+		{"no-separator", "foo", "foo"},
+		{"slash", "a/b/c", "c"},
+		{"colon", "a:b:c", "c"},
+		{"comma", "a,b,c", "c"},
+		{"slash-then-colon", "foo:bar/baz", "baz"},
+		{"colon-then-slash-then-comma", "a/b:c,d", "d"},
+		{"trailing-separator-ignored", "a/b/", "a/b/"},
+		{"arn-style", "arn:aws:sqs:us-east-1:000000000000:orders-DLQ", "orders-DLQ"},
+		{"url-style", "https://sqs.us-east-1.amazonaws.com/000000000000/orders-DLQ", "orders-DLQ"},
+		{"gcp-self-link-style", "https://compute.googleapis.com/projects/p/zones/z/instances/my-vm", "my-vm"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, lastSegment(tc.in))
+		})
+	}
 }
 
 func TestNormalizeLabel_Cases(t *testing.T) {

--- a/pkg/composer/imported/doc.go
+++ b/pkg/composer/imported/doc.go
@@ -1,0 +1,20 @@
+// Package imported defines the typed carrier for resources discovered by the
+// reverse-Terraform importer (or otherwise observed in the cloud) so the
+// composer's IR can describe them alongside preset-managed Components.
+//
+// This package is the Phase 2 foundation of the imported-resource model. It
+// owns identity, tier classification, desired-state storage, and edit/conflict
+// metadata. It does not generate provider-specific structs (#145/#146), emit
+// HCL (#148), validate the union graph (#150), or extend the diff engine
+// (#151) — those are downstream Phase 2 sub-tickets.
+//
+// The full model is documented in docs/managed-resource-tiers.md, especially
+// the sections "How this maps to the current pkg/composer IR" (lines 406-544),
+// "ImportedMissing operator actions" (lines 642-665), and "Decisions captured"
+// (lines 726+).
+//
+// Wire format: snake_case JSON keys with omitempty, matching the convention in
+// pkg/composer/types.go. Tier values are CamelCase strings ("ComposerNative",
+// "ImportedFlat", ...) to match the design contract; MissingAction values are
+// snake_case ("remove_from_insideout", ...). Times are RFC3339Nano UTC.
+package imported

--- a/pkg/composer/imported/identity.go
+++ b/pkg/composer/imported/identity.go
@@ -1,0 +1,48 @@
+package imported
+
+// ResourceIdentity separates Terraform's stable address from cloud-side
+// correlation identifiers. Address is immutable after import; renaming is a
+// future explicit migration operation using `moved {}` blocks, not an ordinary
+// edit. See docs/managed-resource-tiers.md lines 456-475 for the canonical
+// shape and lines 517-544 for the address generation algorithm.
+//
+// Use ImportID and ProviderIdentity for Terraform import; use NativeIDs for
+// lookup, dedupe, and cross-reference resolution.
+type ResourceIdentity struct {
+	// Cloud is the platform identifier: "aws" or "gcp".
+	Cloud string `json:"cloud,omitempty"`
+	// Type is the Terraform resource type, e.g. "aws_sqs_queue".
+	Type string `json:"type,omitempty"`
+	// Address is the immutable Terraform resource address (e.g.
+	// "aws_sqs_queue.dlq"). Generated once via GenerateAddress and frozen.
+	Address string `json:"address,omitempty"`
+	// NameHint is the original human-readable name source preserved for
+	// audit and display.
+	NameHint string `json:"name_hint,omitempty"`
+	// ProviderConfig identifies the provider alias used by emitted HCL,
+	// e.g. "aws.imported" or "google.imported".
+	ProviderConfig string `json:"provider_config,omitempty"`
+	// ProviderSource is the registry source, e.g.
+	// "registry.terraform.io/hashicorp/aws".
+	ProviderSource string `json:"provider_source,omitempty"`
+	// ProviderVersion is the exact provider version used at import time.
+	ProviderVersion string `json:"provider_version,omitempty"`
+	// SchemaVersion is the generated-schema / codegen version that produced
+	// any associated typed Attrs. Empty for opaque-bag-only carriers.
+	SchemaVersion string `json:"schema_version,omitempty"`
+
+	// AccountID is the AWS account ID when applicable.
+	AccountID string `json:"account_id,omitempty"`
+	// ProjectID is the GCP project ID when applicable.
+	ProjectID string `json:"project_id,omitempty"`
+	// Region is the AWS region or GCP region when applicable.
+	Region string `json:"region,omitempty"`
+	// Location is the GCP zone/location when region is not enough.
+	Location string `json:"location,omitempty"`
+	// ImportID is the provider import ID: URL, ARN, name, self-link, etc.
+	ImportID string `json:"import_id,omitempty"`
+	// ProviderIdentity is the Terraform identity object when supported.
+	ProviderIdentity map[string]string `json:"provider_identity,omitempty"`
+	// NativeIDs holds cloud-side identifiers (arn, url, self_link, name).
+	NativeIDs map[string]string `json:"native_ids,omitempty"`
+}

--- a/pkg/composer/imported/imported_test.go
+++ b/pkg/composer/imported/imported_test.go
@@ -156,40 +156,85 @@ func TestImportedResource_RoundTrip_Full(t *testing.T) {
 	assert.Equal(t, r, got)
 }
 
-func TestImportedResource_OmitEmpty(t *testing.T) {
+// TestOmitEmpty pins the exact JSON shape of zero-or-minimal values for every
+// type in this package that uses json:"...,omitempty" tags. Stronger than
+// "key X is absent" — any change to which fields are omitempty (including
+// accidental removal) shows up as an exact-string diff.
+//
+// FieldEdit.EditedAt intentionally has no omitempty: a missing edit_at
+// timestamp on an audit record would silently lose information, so the zero
+// value is preserved on the wire.
+func TestOmitEmpty(t *testing.T) {
 	t.Parallel()
-	r := ImportedResource{
-		Identity: ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue"},
-		Tier:     TierImportedFlat,
-		Source:   SourceImporter,
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{
+			name: "ResourceIdentity_zero",
+			in:   ResourceIdentity{},
+			want: `{}`,
+		},
+		{
+			name: "PresetMatch_zero",
+			in:   PresetMatch{},
+			want: `{}`,
+		},
+		{
+			name: "FieldEdit_zero",
+			in:   FieldEdit{},
+			want: `{"edited_at":"0001-01-01T00:00:00Z"}`,
+		},
+		{
+			name: "ImportedResource_minimal",
+			in: ImportedResource{
+				Identity: ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue"},
+				Tier:     TierImportedFlat,
+				Source:   SourceImporter,
+			},
+			want: `{"identity":{"cloud":"aws","type":"aws_sqs_queue"},"tier":"ImportedFlat","source":"importer"}`,
+		},
 	}
-	b, err := json.Marshal(r)
-	require.NoError(t, err)
-	s := string(b)
-	for _, key := range []string{"attributes", "field_edits", "graduation_candidate"} {
-		assert.NotContainsf(t, s, key, "empty %s must be omitted; got %s", key, s)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b, err := json.Marshal(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, string(b))
+		})
 	}
 }
 
-func TestFieldEdit_RoundTrip_UTC(t *testing.T) {
+// TestFieldEdit_MarshalJSON_ConvertsToUTC proves that FieldEdit.MarshalJSON
+// converts a non-UTC time.Time to UTC before serialization. Without the
+// custom MarshalJSON, encoding/json would emit a numeric offset (e.g.
+// "-07:00") that violates the RFC3339Nano UTC contract.
+func TestFieldEdit_MarshalJSON_ConvertsToUTC(t *testing.T) {
 	t.Parallel()
-	loc, err := time.LoadLocation("America/Los_Angeles")
+	la, err := time.LoadLocation("America/Los_Angeles")
 	require.NoError(t, err)
-	original := time.Date(2026, 4, 27, 7, 30, 15, 123_456_789, loc)
+	// Same instant as 2026-04-27T14:30:15.123456789Z, but expressed in
+	// LA local time. The serializer must convert this back to UTC.
+	laTime := time.Date(2026, 4, 27, 7, 30, 15, 123_456_789, la)
 	fe := FieldEdit{
 		Source:   SourceRiley,
-		EditedAt: original.UTC(),
+		EditedAt: laTime,
 		OldValue: "before",
 		NewValue: "after",
 	}
 	b, err := json.Marshal(fe)
 	require.NoError(t, err)
 	assert.Contains(t, string(b), `"edited_at":"2026-04-27T14:30:15.123456789Z"`,
-		"FieldEdit.EditedAt must serialize as RFC3339Nano UTC with Z suffix")
+		"non-UTC EditedAt must be converted to UTC at marshal time; got %s", string(b))
+	assert.NotContains(t, string(b), "-07:00",
+		"serialized output must not retain the source time zone offset")
 
 	var got FieldEdit
 	require.NoError(t, json.Unmarshal(b, &got))
 	assert.True(t, got.EditedAt.Equal(fe.EditedAt))
+	assert.Equal(t, time.UTC, got.EditedAt.Location(),
+		"unmarshalled EditedAt must be in UTC")
 	assert.Equal(t, fe.Source, got.Source)
 	assert.Equal(t, fe.OldValue, got.OldValue)
 	assert.Equal(t, fe.NewValue, got.NewValue)
@@ -210,6 +255,15 @@ func TestPresetMatch_RoundTrip(t *testing.T) {
 	}
 	b, err := json.Marshal(pm)
 	require.NoError(t, err)
+
+	// Cross-package byte assertion: catches an upstream rename of
+	// composer.FieldDiff or composer.ComponentKey JSON tags here, in the
+	// package that owns the contract, instead of in some downstream
+	// consumer's failure stack.
+	s := string(b)
+	assert.Contains(t, s, `"preset_key":"aws_vpc"`)
+	assert.Contains(t, s, `"field":"cidr_block"`)
+	assert.Contains(t, s, `"from":"10.0.0.0/16"`)
 
 	var got PresetMatch
 	require.NoError(t, json.Unmarshal(b, &got))

--- a/pkg/composer/imported/imported_test.go
+++ b/pkg/composer/imported/imported_test.go
@@ -1,0 +1,283 @@
+package imported
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTier_RoundTrip(t *testing.T) {
+	t.Parallel()
+	tiers := []Tier{
+		TierComposerNative,
+		TierComposerGraduated,
+		TierImportedFlat,
+		TierImportedConformant,
+		TierImportedMissing,
+		TierExternalByPolicy,
+		TierExternalUnsupported,
+	}
+	for _, tier := range tiers {
+		t.Run(string(tier), func(t *testing.T) {
+			t.Parallel()
+			require.True(t, tier.Valid(), "valid tier const must report Valid()=true")
+			b, err := json.Marshal(tier)
+			require.NoError(t, err)
+			assert.Equal(t, `"`+string(tier)+`"`, string(b))
+
+			var got Tier
+			require.NoError(t, json.Unmarshal(b, &got))
+			assert.Equal(t, tier, got)
+		})
+	}
+}
+
+func TestTier_ValidRejectsUnknown(t *testing.T) {
+	t.Parallel()
+	for _, v := range []Tier{"", "Composer", "imported_flat", "Unknown"} {
+		assert.Falsef(t, v.Valid(), "%q must not Valid()", v)
+	}
+}
+
+func TestSource_RoundTrip(t *testing.T) {
+	t.Parallel()
+	sources := []Source{
+		SourceComposer, SourceImporter, SourceInspector,
+		SourceRiley, SourceAPI, SourceMCP,
+	}
+	for _, s := range sources {
+		t.Run(string(s), func(t *testing.T) {
+			t.Parallel()
+			require.True(t, s.Valid(), "valid source const must report Valid()=true")
+			b, err := json.Marshal(s)
+			require.NoError(t, err)
+			assert.Equal(t, `"`+string(s)+`"`, string(b))
+
+			var got Source
+			require.NoError(t, json.Unmarshal(b, &got))
+			assert.Equal(t, s, got)
+		})
+	}
+}
+
+func TestSource_ValidRejectsUnknown(t *testing.T) {
+	t.Parallel()
+	for _, v := range []Source{"", "RILEY", "user", "unknown"} {
+		assert.Falsef(t, v.Valid(), "%q must not Valid()", v)
+	}
+}
+
+func TestMissingAction_RoundTrip(t *testing.T) {
+	t.Parallel()
+	actions := []MissingAction{
+		ActionRemoveFromInsideOut,
+		ActionRecreateFromLastImport,
+		ActionReclaimExisting,
+	}
+	for _, a := range actions {
+		t.Run(string(a), func(t *testing.T) {
+			t.Parallel()
+			require.True(t, a.Valid())
+			b, err := json.Marshal(a)
+			require.NoError(t, err)
+			assert.Equal(t, `"`+string(a)+`"`, string(b))
+
+			var got MissingAction
+			require.NoError(t, json.Unmarshal(b, &got))
+			assert.Equal(t, a, got)
+		})
+	}
+}
+
+func TestMissingAction_ValidRejectsUnknown(t *testing.T) {
+	t.Parallel()
+	for _, v := range []MissingAction{"", "remove", "RECREATE_FROM_LAST_IMPORT"} {
+		assert.Falsef(t, v.Valid(), "%q must not Valid()", v)
+	}
+}
+
+func TestResourceIdentity_RoundTrip_Empty(t *testing.T) {
+	t.Parallel()
+	b, err := json.Marshal(ResourceIdentity{})
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(b), "zero identity must marshal to {}")
+
+	var got ResourceIdentity
+	require.NoError(t, json.Unmarshal(b, &got))
+	assert.Equal(t, ResourceIdentity{}, got)
+}
+
+func TestResourceIdentity_RoundTrip_Full(t *testing.T) {
+	t.Parallel()
+	id := fullIdentity()
+	got := mustRoundTripIdentical(t, id)
+	assert.Equal(t, id, got)
+}
+
+func TestImportedResource_RoundTrip_Full(t *testing.T) {
+	t.Parallel()
+	r := ImportedResource{
+		Identity: fullIdentity(),
+		Tier:     TierImportedFlat,
+		Source:   SourceImporter,
+		Attributes: map[string]any{
+			"name":                       "orders-dlq",
+			"fifo_queue":                 false,
+			"visibility_timeout_seconds": float64(30),
+			"tags": map[string]any{
+				"managed_by": "external",
+			},
+		},
+		FieldEdits: map[string]FieldEdit{
+			"visibility_timeout_seconds": {
+				Source:   SourceRiley,
+				EditedAt: time.Date(2026, 4, 27, 14, 30, 0, 0, time.UTC),
+				OldValue: float64(30),
+				NewValue: float64(60),
+			},
+		},
+		GraduationCandidate: &PresetMatch{
+			PresetKey:  composer.KeyAWSSQS,
+			Confidence: 0.85,
+			MovedBlocks: []MovedBlock{
+				{From: "aws_sqs_queue.dlq", To: "module.aws_sqs.aws_sqs_queue.dlq"},
+			},
+			BlockingDeltas: []composer.FieldDiff{
+				{Field: "fifo_queue", From: "false", To: "true"},
+			},
+		},
+	}
+	got := mustRoundTripIdenticalResource(t, r)
+	assert.Equal(t, r, got)
+}
+
+func TestImportedResource_OmitEmpty(t *testing.T) {
+	t.Parallel()
+	r := ImportedResource{
+		Identity: ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue"},
+		Tier:     TierImportedFlat,
+		Source:   SourceImporter,
+	}
+	b, err := json.Marshal(r)
+	require.NoError(t, err)
+	s := string(b)
+	for _, key := range []string{"attributes", "field_edits", "graduation_candidate"} {
+		assert.NotContainsf(t, s, key, "empty %s must be omitted; got %s", key, s)
+	}
+}
+
+func TestFieldEdit_RoundTrip_UTC(t *testing.T) {
+	t.Parallel()
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+	original := time.Date(2026, 4, 27, 7, 30, 15, 123_456_789, loc)
+	fe := FieldEdit{
+		Source:   SourceRiley,
+		EditedAt: original.UTC(),
+		OldValue: "before",
+		NewValue: "after",
+	}
+	b, err := json.Marshal(fe)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"edited_at":"2026-04-27T14:30:15.123456789Z"`,
+		"FieldEdit.EditedAt must serialize as RFC3339Nano UTC with Z suffix")
+
+	var got FieldEdit
+	require.NoError(t, json.Unmarshal(b, &got))
+	assert.True(t, got.EditedAt.Equal(fe.EditedAt))
+	assert.Equal(t, fe.Source, got.Source)
+	assert.Equal(t, fe.OldValue, got.OldValue)
+	assert.Equal(t, fe.NewValue, got.NewValue)
+}
+
+func TestPresetMatch_RoundTrip(t *testing.T) {
+	t.Parallel()
+	pm := PresetMatch{
+		PresetKey:  composer.KeyAWSVPC,
+		Confidence: 0.42,
+		MovedBlocks: []MovedBlock{
+			{From: "aws_vpc.main", To: "module.aws_vpc.aws_vpc.main"},
+			{From: "aws_subnet.a", To: "module.aws_vpc.aws_subnet.a"},
+		},
+		BlockingDeltas: []composer.FieldDiff{
+			{Field: "cidr_block", From: "10.0.0.0/16", To: "10.1.0.0/16"},
+		},
+	}
+	b, err := json.Marshal(pm)
+	require.NoError(t, err)
+
+	var got PresetMatch
+	require.NoError(t, json.Unmarshal(b, &got))
+	assert.Equal(t, pm, got)
+}
+
+// fullIdentity returns a ResourceIdentity with every field populated. Reused
+// by several tests.
+func fullIdentity() ResourceIdentity {
+	return ResourceIdentity{
+		Cloud:           "aws",
+		Type:            "aws_sqs_queue",
+		Address:         "aws_sqs_queue.orders_dlq",
+		NameHint:        "orders-DLQ",
+		ProviderConfig:  "aws.imported",
+		ProviderSource:  "registry.terraform.io/hashicorp/aws",
+		ProviderVersion: "6.7.0",
+		SchemaVersion:   "v1",
+		AccountID:       "123456789012",
+		ProjectID:       "",
+		Region:          "us-east-1",
+		Location:        "",
+		ImportID:        "https://sqs.us-east-1.amazonaws.com/123456789012/orders-DLQ",
+		ProviderIdentity: map[string]string{
+			"region": "us-east-1",
+			"name":   "orders-DLQ",
+		},
+		NativeIDs: map[string]string{
+			"arn":  "arn:aws:sqs:us-east-1:123456789012:orders-DLQ",
+			"name": "orders-DLQ",
+			"url":  "https://sqs.us-east-1.amazonaws.com/123456789012/orders-DLQ",
+		},
+	}
+}
+
+// mustRoundTripIdentical marshals v, asserts a second marshal of the
+// unmarshalled value produces byte-identical output, and returns the
+// unmarshalled value.
+func mustRoundTripIdentical(t *testing.T, v ResourceIdentity) ResourceIdentity {
+	t.Helper()
+	first, err := json.Marshal(v)
+	require.NoError(t, err)
+
+	var got ResourceIdentity
+	require.NoError(t, json.Unmarshal(first, &got))
+
+	second, err := json.Marshal(got)
+	require.NoError(t, err)
+	require.Equalf(t, string(first), string(second),
+		"identity must round-trip byte-identically; first=%s second=%s",
+		first, second)
+	require.False(t, strings.Contains(string(first), `"":`),
+		"empty JSON keys must not appear: %s", first)
+	return got
+}
+
+func mustRoundTripIdenticalResource(t *testing.T, v ImportedResource) ImportedResource {
+	t.Helper()
+	first, err := json.Marshal(v)
+	require.NoError(t, err)
+
+	var got ImportedResource
+	require.NoError(t, json.Unmarshal(first, &got))
+
+	second, err := json.Marshal(got)
+	require.NoError(t, err)
+	require.Equalf(t, string(first), string(second),
+		"resource must round-trip byte-identically; first=%s second=%s",
+		first, second)
+	return got
+}

--- a/pkg/composer/imported/resource.go
+++ b/pkg/composer/imported/resource.go
@@ -1,0 +1,82 @@
+package imported
+
+import (
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+)
+
+// ImportedResource is the IR carrier for one cloud resource that lives outside
+// the preset module call space — either imported via reverse-Terraform or
+// observed by the inspector. It rides alongside composer.Components in the
+// stack snapshot. See docs/managed-resource-tiers.md lines 477-500.
+//
+// Phase 2 stores desired provider attributes in the opaque Attributes bag for
+// wire-compatibility with the Phase 1 importer. A future ticket (#145) will
+// add a sibling typed Attrs field backed by per-resource-type generated
+// structs; the JSON key for that typed shape will differ from "attributes"
+// so both can coexist.
+type ImportedResource struct {
+	// Identity carries the immutable Terraform address and cloud-side
+	// correlation identifiers.
+	Identity ResourceIdentity `json:"identity"`
+
+	// Tier classifies how InsideOut treats the resource. See Tier consts.
+	Tier Tier `json:"tier,omitempty"`
+
+	// Source records who created the resource record (composer | importer
+	// | inspector).
+	Source Source `json:"source,omitempty"`
+
+	// Attributes is the current desired provider attributes as an opaque
+	// bag (Phase 1 / wire-compatible shape). The composer emits HCL from
+	// this state. Riley's chat edits update the values here through the
+	// model write path; FieldEdits records audit/conflict metadata only —
+	// the composer does not emit from FieldEdits.
+	Attributes map[string]any `json:"attributes,omitempty"`
+
+	// FieldEdits is audit/conflict metadata for changes made via the model
+	// write path since the last successful `terraform apply`. The edited
+	// values are already reflected in Attributes; this map exists to detect
+	// conflicts between Riley's pending edits and independent cloud changes
+	// at re-import time. Cleared when an apply succeeds.
+	FieldEdits map[string]FieldEdit `json:"field_edits,omitempty"`
+
+	// GraduationCandidate is populated by the shape-matcher when the
+	// imported graph could be wrapped in a preset module call. Phase 3+;
+	// see decision #16 in the design doc.
+	GraduationCandidate *PresetMatch `json:"graduation_candidate,omitempty"`
+}
+
+// FieldEdit is audit/conflict metadata for one model-side edit to a single
+// attribute. EditedAt is RFC3339Nano UTC.
+type FieldEdit struct {
+	Source   Source    `json:"source,omitempty"`
+	EditedAt time.Time `json:"edited_at"`
+	OldValue any       `json:"old_value,omitempty"`
+	NewValue any       `json:"new_value,omitempty"`
+}
+
+// PresetMatch is a forward-declared graduation hint. It is populated by the
+// shape-matcher (Phase 3+) when an imported resource could be wrapped in a
+// preset module call. Composer never reads this field today.
+type PresetMatch struct {
+	// PresetKey identifies the candidate preset module.
+	PresetKey composer.ComponentKey `json:"preset_key,omitempty"`
+	// Confidence is a 0.0-1.0 score from the matcher.
+	Confidence float64 `json:"confidence,omitempty"`
+	// MovedBlocks are the proposed `moved {}` blocks for promotion.
+	MovedBlocks []MovedBlock `json:"moved_blocks,omitempty"`
+	// BlockingDeltas are attributes that would have to change to fit the
+	// preset shape.
+	BlockingDeltas []composer.FieldDiff `json:"blocking_deltas,omitempty"`
+}
+
+// MovedBlock is the minimal shape of a Terraform `moved {}` block: a from /
+// to address pair. Declared locally because pkg/composer does not yet expose
+// an equivalent type (only an unexported test helper). When #147 lands the
+// composer-side emission, it can promote this to pkg/composer if useful.
+type MovedBlock struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}

--- a/pkg/composer/imported/resource.go
+++ b/pkg/composer/imported/resource.go
@@ -1,6 +1,7 @@
 package imported
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
@@ -49,12 +50,25 @@ type ImportedResource struct {
 }
 
 // FieldEdit is audit/conflict metadata for one model-side edit to a single
-// attribute. EditedAt is RFC3339Nano UTC.
+// attribute. EditedAt is always serialized as RFC3339Nano UTC regardless of
+// the caller-supplied time.Location; see MarshalJSON.
 type FieldEdit struct {
 	Source   Source    `json:"source,omitempty"`
 	EditedAt time.Time `json:"edited_at"`
 	OldValue any       `json:"old_value,omitempty"`
 	NewValue any       `json:"new_value,omitempty"`
+}
+
+// MarshalJSON enforces RFC3339Nano UTC on EditedAt. Without this, a caller
+// passing a non-UTC time.Time would serialize with a numeric offset (e.g.
+// "-07:00"), which the design contract forbids. The zero value is left
+// untouched so the canonical "0001-01-01T00:00:00Z" form is preserved.
+func (f FieldEdit) MarshalJSON() ([]byte, error) {
+	type alias FieldEdit
+	if !f.EditedAt.IsZero() {
+		f.EditedAt = f.EditedAt.UTC()
+	}
+	return json.Marshal(alias(f))
 }
 
 // PresetMatch is a forward-declared graduation hint. It is populated by the

--- a/pkg/composer/imported/snapshot_envelope_test.go
+++ b/pkg/composer/imported/snapshot_envelope_test.go
@@ -1,0 +1,147 @@
+package imported
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSnapshotEnvelope_RoundTrip locks in the issue #144 acceptance criterion:
+// a synthetic stack-snapshot JSON envelope carrying both the existing preset
+// shape (components, config, pricing — modeled here as opaque RawMessage) and
+// a populated imported list round-trips byte-identically.
+//
+// The real envelope is owned by the reliable repo's stack_versions row; this
+// test does not attempt to mirror it field-by-field. It only proves that
+// adding "imported" alongside the existing keys does not lose semantic data.
+func TestSnapshotEnvelope_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	resources := []ImportedResource{
+		{
+			Identity: ResourceIdentity{
+				Cloud:           "aws",
+				Type:            "aws_sqs_queue",
+				Address:         "aws_sqs_queue.orders_dlq",
+				NameHint:        "orders-DLQ",
+				ProviderConfig:  "aws.imported",
+				ProviderSource:  "registry.terraform.io/hashicorp/aws",
+				ProviderVersion: "6.7.0",
+				SchemaVersion:   "v1",
+				AccountID:       "123456789012",
+				Region:          "us-east-1",
+				ImportID:        "arn:aws:sqs:us-east-1:123456789012:orders-DLQ",
+				NativeIDs: map[string]string{
+					"arn":  "arn:aws:sqs:us-east-1:123456789012:orders-DLQ",
+					"name": "orders-DLQ",
+				},
+			},
+			Tier:   TierImportedFlat,
+			Source: SourceImporter,
+			Attributes: map[string]any{
+				"name":       "orders-DLQ",
+				"fifo_queue": false,
+			},
+			FieldEdits: map[string]FieldEdit{
+				"visibility_timeout_seconds": {
+					Source:   SourceRiley,
+					EditedAt: time.Date(2026, 4, 27, 14, 30, 0, 0, time.UTC),
+					OldValue: float64(30),
+					NewValue: float64(60),
+				},
+			},
+		},
+		{
+			Identity: ResourceIdentity{
+				Cloud:           "gcp",
+				Type:            "google_storage_bucket",
+				Address:         "google_storage_bucket.assets",
+				NameHint:        "assets",
+				ProviderConfig:  "google.imported",
+				ProviderSource:  "registry.terraform.io/hashicorp/google",
+				ProviderVersion: "5.40.0",
+				ProjectID:       "my-project",
+				Location:        "US",
+				ImportID:        "my-project/assets",
+			},
+			Tier:   TierImportedConformant,
+			Source: SourceImporter,
+		},
+		{
+			Identity: ResourceIdentity{
+				Cloud:   "aws",
+				Type:    "aws_kms_key",
+				Address: "aws_kms_key.legacy",
+			},
+			Tier:   TierImportedMissing,
+			Source: SourceInspector,
+		},
+	}
+
+	envelope := map[string]json.RawMessage{
+		"components": json.RawMessage(`{"cloud":"AWS","aws_vpc":"Private"}`),
+		"config":     json.RawMessage(`{"environment":"staging"}`),
+		"pricing":    json.RawMessage(`{"monthly_total":42.5}`),
+		"imported":   mustMarshal(t, resources),
+	}
+
+	first, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	var got map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(first, &got))
+
+	second, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(first), string(second),
+		"envelope must round-trip without semantic loss")
+
+	// And the imported slice itself must round-trip back to the same Go
+	// value.
+	var rt []ImportedResource
+	require.NoError(t, json.Unmarshal(got["imported"], &rt))
+	require.Len(t, rt, len(resources))
+	for i, want := range resources {
+		assert.Truef(t, equalIdentity(want.Identity, rt[i].Identity),
+			"identity[%d] mismatch", i)
+		assert.Equal(t, want.Tier, rt[i].Tier)
+		assert.Equal(t, want.Source, rt[i].Source)
+		assert.Equal(t, want.Attributes, rt[i].Attributes)
+	}
+}
+
+// equalIdentity compares two identities without relying on map ordering.
+func equalIdentity(a, b ResourceIdentity) bool {
+	if a.Cloud != b.Cloud || a.Type != b.Type || a.Address != b.Address ||
+		a.NameHint != b.NameHint || a.ProviderConfig != b.ProviderConfig ||
+		a.ProviderSource != b.ProviderSource || a.ProviderVersion != b.ProviderVersion ||
+		a.SchemaVersion != b.SchemaVersion || a.AccountID != b.AccountID ||
+		a.ProjectID != b.ProjectID || a.Region != b.Region ||
+		a.Location != b.Location || a.ImportID != b.ImportID {
+		return false
+	}
+	return mapsEqual(a.ProviderIdentity, b.ProviderIdentity) &&
+		mapsEqual(a.NativeIDs, b.NativeIDs)
+}
+
+func mapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func mustMarshal(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/pkg/composer/imported/snapshot_envelope_test.go
+++ b/pkg/composer/imported/snapshot_envelope_test.go
@@ -96,8 +96,11 @@ func TestSnapshotEnvelope_RoundTrip(t *testing.T) {
 
 	second, err := json.Marshal(got)
 	require.NoError(t, err)
-	assert.JSONEq(t, string(first), string(second),
-		"envelope must round-trip without semantic loss")
+	// Byte-identical round trip: encoding/json sorts map keys alphabetically
+	// on both passes, so any drift indicates a real serialization bug
+	// (re-ordered struct fields, hand-rolled MarshalJSON misbehavior, etc.).
+	require.Equal(t, string(first), string(second),
+		"envelope must round-trip byte-identically")
 
 	// And the imported slice itself must round-trip back to the same Go
 	// value.

--- a/pkg/composer/imported/tier.go
+++ b/pkg/composer/imported/tier.go
@@ -1,0 +1,101 @@
+package imported
+
+// Tier classifies how InsideOut treats a resource: composer-managed,
+// imported-and-managed, or externally observed. Values are stable identifiers
+// — adding or removing tiers does not renumber existing ones. The wire format
+// is the CamelCase string literal (e.g. "ComposerNative"); see
+// docs/managed-resource-tiers.md "A note on naming" for rationale.
+type Tier string
+
+const (
+	TierComposerNative      Tier = "ComposerNative"
+	TierComposerGraduated   Tier = "ComposerGraduated"
+	TierImportedFlat        Tier = "ImportedFlat"
+	TierImportedConformant  Tier = "ImportedConformant"
+	TierImportedMissing     Tier = "ImportedMissing"
+	TierExternalByPolicy    Tier = "ExternalByPolicy"
+	TierExternalUnsupported Tier = "ExternalUnsupported"
+)
+
+// Valid reports whether t is one of the known tier consts.
+func (t Tier) Valid() bool {
+	switch t {
+	case TierComposerNative,
+		TierComposerGraduated,
+		TierImportedFlat,
+		TierImportedConformant,
+		TierImportedMissing,
+		TierExternalByPolicy,
+		TierExternalUnsupported:
+		return true
+	}
+	return false
+}
+
+// Source identifies which actor produced or last touched a record. The same
+// type is used in two contexts:
+//
+//   - ImportedResource.Source: who created the resource record. Valid values
+//     are SourceComposer, SourceImporter, SourceInspector.
+//   - FieldEdit.Source: who authored a pending model-side edit. Valid values
+//     are SourceRiley, SourceAPI, SourceMCP.
+//
+// One typed string keeps the wire format simple and matches the single Source
+// symbol used throughout docs/managed-resource-tiers.md.
+type Source string
+
+const (
+	SourceComposer  Source = "composer"
+	SourceImporter  Source = "importer"
+	SourceInspector Source = "inspector"
+
+	SourceRiley Source = "riley"
+	SourceAPI   Source = "api"
+	SourceMCP   Source = "mcp"
+)
+
+// Valid reports whether s is one of the known source consts.
+func (s Source) Valid() bool {
+	switch s {
+	case SourceComposer, SourceImporter, SourceInspector,
+		SourceRiley, SourceAPI, SourceMCP:
+		return true
+	}
+	return false
+}
+
+// MissingAction is the operator-chosen remediation when a previously imported
+// resource is no longer present in cloud (Tier == TierImportedMissing). The
+// composer blocks apply until one of these actions is selected. See
+// docs/managed-resource-tiers.md "ImportedMissing operator actions"
+// (lines 642-665).
+type MissingAction string
+
+const (
+	// ActionRemoveFromInsideOut detaches the resource from InsideOut
+	// management. The composer may emit a `removed { from = ... lifecycle {
+	// destroy = false } }` block to release Terraform state without deleting
+	// cloud infrastructure.
+	ActionRemoveFromInsideOut MissingAction = "remove_from_insideout"
+
+	// ActionRecreateFromLastImport rolls the resource back to TierImportedFlat
+	// using the last desired Attributes. The composer emits the resource block
+	// so Terraform recreates it.
+	ActionRecreateFromLastImport MissingAction = "recreate_from_last_import"
+
+	// ActionReclaimExisting re-runs discovery for the same ResourceIdentity.
+	// If the cloud object exists with matching ownership tags, the resource
+	// returns to TierImportedFlat without recreation.
+	ActionReclaimExisting MissingAction = "reclaim_existing"
+)
+
+// Valid reports whether a is one of the known action consts.
+func (a MissingAction) Valid() bool {
+	switch a {
+	case ActionRemoveFromInsideOut,
+		ActionRecreateFromLastImport,
+		ActionReclaimExisting:
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/composer/imported` — the typed-carrier foundation that every later Phase 2 imported-resource ticket (codegen, field policy, composer emission, validators, diff) depends on.
- No existing composer files are modified. The package is consumed only by future Phase 2 PRs.
- Anchors top-level scratch ignore patterns in `.gitignore` so the unanchored `imported/` does not match the new package directory.

## What's in the package

| File | Contents |
|------|----------|
| `tier.go` | `Tier`, `Source`, `MissingAction` typed-string enums + consts + `Valid()` helpers. Tier wire values are CamelCase per the design doc; action values are snake_case. |
| `identity.go` | `ResourceIdentity` with immutable `Address`, cloud correlation IDs (`AccountID`/`ProjectID`/`Region`/`Location`/`ImportID`/`ProviderIdentity`/`NativeIDs`), and provider/schema versioning. |
| `resource.go` | `ImportedResource` (Identity + Tier + Source + opaque `Attributes` + `FieldEdits` audit metadata + forward-declared `GraduationCandidate`), `FieldEdit`, and `PresetMatch` (Phase 3+ hint). |
| `address.go` | Deterministic `GenerateAddress(id, exists)` — name-hint precedence chain (`NameHint` → `NativeIDs` → `ImportID` → type stem), normalization, sha256 collision suffix over a sorted-key canonical identity tuple, then a numeric counter as final fallback. |

## Plan reference

Implements [issue #144](https://github.com/luthersystems/insideout-terraform-presets/issues/144) under epic [#143](https://github.com/luthersystems/insideout-terraform-presets/issues/143). The full design lives in [`docs/managed-resource-tiers.md`](https://github.com/luthersystems/insideout-terraform-presets/blob/main/docs/managed-resource-tiers.md).

## Acceptance criterion check

`TestSnapshotEnvelope_RoundTrip` builds a synthetic `{components, config, pricing, imported}` JSON envelope carrying three imported resources spanning AWS / GCP / `ImportedMissing`, marshals → unmarshals → re-marshals, and asserts both byte-identical envelope round-trip and structural equality of the imported slice. This matches issue #144's acceptance language: *"a stack snapshot can carry both preset Components and imported resources, JSON-serialize through the expected stack-version shape, and round-trip without losing identity, provider/schema versioning, attributes, tier, or edit/conflict metadata."*

## Notable plan deviations

- `composer.MovedBlock` does not exist as an exported type today (only an unexported test helper), so `PresetMatch.MovedBlocks` uses a minimal local `MovedBlock` struct. #147 / #148 can promote it to `pkg/composer` if that helps the composer-side emission.
- Total LoC ~1130 (567 implementation, 562 tests) — over the 800 plan budget. Test density is justified because the issue's whole acceptance criterion is *"JSON round-trips with no semantic loss"*; test coverage is the deliverable.

## Out of scope (deferred to other Phase 2 sub-tickets)

- `ComposeStackOpts.Imported` plumbing and HCL emission → #148
- Codegen pipeline + Layer 1 typed structs → #146 / #145
- Layer 2 field policy maps → #147
- Provenance tag injector + `aws.imported` / `google.imported` aliases → #153
- Union-graph validator extensions → #150
- `validateImportedResources` server-side authorization → #149
- `ResourceDiff` / `VersionDiff.Resources` extension → #151
- Cross-repo Reliable inspector filter + Riley import context → #152

## Test plan

- [x] `go build ./...` clean (no import cycles)
- [x] `go test ./pkg/composer/imported/...` passes — covers all enum round-trips, OmitEmpty, RFC3339Nano UTC for `FieldEdit.EditedAt`, `ResourceIdentity` zero+full round-trip, `ImportedResource` round-trip with nested Attributes, address generator (name-hint precedence, normalization edge cases, collision → hash, hash-collision → counter, retired-address avoidance, 100-iteration shuffle for hash determinism), and the snapshot envelope acceptance test
- [x] `go test ./pkg/composer/...` passes — no regressions in the existing composer package
- [x] `go vet ./pkg/composer/imported/...` clean; `gofmt -l pkg/composer/imported/` empty
- [x] `terraform fmt -check -recursive` clean (no `.tf` changes)
- [ ] CI green on PR

Fixes #144
Refs #143