### PR TITLE
feat(policy): Layer 2 field policy maps for the 10 Phase 1 imported types (#147)

### DIFF
--- a/pkg/composer/imported/policy/aws_cloudwatch_log_group.policy.go
+++ b/pkg/composer/imported/policy/aws_cloudwatch_log_group.policy.go
@@ -1,0 +1,33 @@
+package policy
+
+var awsCloudwatchLogGroupPolicy = Map{
+	// Identity
+	"arn":  {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+
+	// Wiring
+	"kms_key_id": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+
+	// Tuning
+	"retention_in_days": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"log_group_class": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		ChangeRisk: ChangeMayReplace,
+	},
+	"skip_destroy": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval,
+	},
+
+	"tags":     tagPolicy(),
+	"tags_all": tagPolicy(),
+}
+
+func init() {
+	Register("aws_cloudwatch_log_group", awsCloudwatchLogGroupPolicy)
+}

--- a/pkg/composer/imported/policy/aws_dynamodb_table.policy.go
+++ b/pkg/composer/imported/policy/aws_dynamodb_table.policy.go
@@ -1,0 +1,90 @@
+package policy
+
+var awsDynamodbTablePolicy = Map{
+	// Identity
+	"arn":        {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"id":         {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name":       {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"stream_arn": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+
+	// Wiring (encryption, replication targets, restore source)
+	"server_side_encryption.kms_key_arn": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"server_side_encryption.enabled": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval,
+	},
+	"replica.region_name": {
+		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"replica.kms_key_arn": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"restore_source_table_arn": {
+		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+
+	// Tuning — capacity and storage
+	"billing_mode": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"read_capacity": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"write_capacity": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"table_class": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// Tuning — backups and protection
+	"point_in_time_recovery.enabled": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"deletion_protection_enabled": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval,
+	},
+
+	// TTL
+	"ttl.enabled": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"ttl.attribute_name": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// Streams
+	"stream_enabled": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"stream_view_type": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// Keys (relationship-shaped — pinned, not chat-edited)
+	"hash_key": {
+		Role: RoleWiring, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk: ChangeAlwaysReplace,
+	},
+	"range_key": {
+		Role: RoleWiring, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk: ChangeAlwaysReplace,
+	},
+
+	"tags":     tagPolicy(),
+	"tags_all": tagPolicy(),
+
+	// timeouts singleton — system-owned operational metadata.
+	"timeouts": timeoutsPolicy(),
+}
+
+func init() {
+	Register("aws_dynamodb_table", awsDynamodbTablePolicy)
+}

--- a/pkg/composer/imported/policy/aws_lambda_function.policy.go
+++ b/pkg/composer/imported/policy/aws_lambda_function.policy.go
@@ -1,0 +1,139 @@
+package policy
+
+var awsLambdaFunctionPolicy = Map{
+	// Identity
+	"arn":                  {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"function_name":        {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"version":              {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"qualified_arn":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"invoke_arn":           {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"qualified_invoke_arn": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+
+	// Wiring — required role and supporting cross-references
+	"role": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"kms_key_arn": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"code_signing_config_arn": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"dead_letter_config.target_arn": {
+		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"file_system_config.arn": {
+		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+	},
+	"file_system_config.local_mount_path": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"logging_config.log_group": {
+		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"vpc_config.security_group_ids": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"vpc_config.subnet_ids": {
+		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"vpc_config.vpc_id": {
+		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+	},
+	"layers": {
+		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+	},
+	"replacement_security_group_ids": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"s3_bucket": {
+		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+	},
+	"s3_key": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"s3_object_version": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// Tuning — runtime configuration
+	"runtime": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"handler": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"memory_size": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"timeout": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"architectures": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		ChangeRisk: ChangeMayReplace,
+	},
+	"package_type": {
+		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk: ChangeAlwaysReplace,
+	},
+	"reserved_concurrent_executions": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"publish": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// Tuning — nested blocks
+	"ephemeral_storage.size": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"tracing_config.mode": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"snap_start.apply_on": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"image_config.command": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"image_config.entry_point": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"image_config.working_directory": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"logging_config.application_log_level": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"logging_config.system_log_level": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"logging_config.log_format": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// Sensitive: environment variables routinely contain credentials.
+	// Hidden from Riley; only system code reads/writes them.
+	"environment.variables": {
+		Role: RoleTuning, Pillar: PillarSecurity,
+		Visibility: VisibilityHidden, Edit: EditSystemOnly,
+		Sensitivity: SensitivitySensitive,
+	},
+
+	"tags":     tagPolicy(),
+	"tags_all": tagPolicy(),
+	"timeouts": timeoutsPolicy(),
+}
+
+func init() {
+	Register("aws_lambda_function", awsLambdaFunctionPolicy)
+}

--- a/pkg/composer/imported/policy/aws_secretsmanager_secret.policy.go
+++ b/pkg/composer/imported/policy/aws_secretsmanager_secret.policy.go
@@ -1,0 +1,44 @@
+package policy
+
+var awsSecretsmanagerSecretPolicy = Map{
+	// Identity
+	"arn":  {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+
+	// Wiring (encryption + replication targets)
+	"kms_key_id": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"replica.region": {
+		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"replica.kms_key_id": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+
+	// Tuning
+	"description": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"recovery_window_in_days": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval,
+	},
+
+	// Resource policy is an IAM JSON document — visible to Riley but
+	// each change requires explicit confirmation against the plan.
+	"policy": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval,
+	},
+
+	"tags":     tagPolicy(),
+	"tags_all": tagPolicy(),
+}
+
+func init() {
+	Register("aws_secretsmanager_secret", awsSecretsmanagerSecretPolicy)
+}

--- a/pkg/composer/imported/policy/aws_sqs_queue.policy.go
+++ b/pkg/composer/imported/policy/aws_sqs_queue.policy.go
@@ -1,0 +1,65 @@
+package policy
+
+// awsSQSQueuePolicy matches the worked example in
+// docs/managed-resource-tiers.md "Layer 2 — hand-curated field policy
+// map" verbatim, with arn added as a UI-visible identity attribute and
+// the JSON projection rules registered for redrive_policy subpaths.
+var awsSQSQueuePolicy = Map{
+	"arn": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+	},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+	},
+	"kms_master_key_id": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly, ChangeRisk: ChangeMayReplace,
+	},
+	"redrive_policy.deadLetterTargetArn": {
+		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"redrive_policy.maxReceiveCount": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditChatSafe,
+	},
+	"sqs_managed_sse_enabled": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+	},
+	"visibility_timeout_seconds": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditChatSafe,
+	},
+	"delay_seconds": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"receive_wait_time_seconds": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"message_retention_seconds": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"max_message_size": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"fifo_queue": {
+		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk: ChangeAlwaysReplace,
+	},
+	"content_based_deduplication": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"tags":     tagPolicy(),
+	"tags_all": tagPolicy(),
+}
+
+func init() {
+	RegisterJSONProjection("aws_sqs_queue", JSONProjection{
+		Parent: "redrive_policy", Subpath: "deadLetterTargetArn",
+	})
+	RegisterJSONProjection("aws_sqs_queue", JSONProjection{
+		Parent: "redrive_policy", Subpath: "maxReceiveCount",
+	})
+	Register("aws_sqs_queue", awsSQSQueuePolicy)
+}

--- a/pkg/composer/imported/policy/axes.go
+++ b/pkg/composer/imported/policy/axes.go
@@ -1,0 +1,169 @@
+package policy
+
+// FieldRole classifies the structural purpose of a field. It is the only
+// axis that is required on every FieldPolicy entry — the zero value fails
+// Valid() and is rejected by Lint.
+type FieldRole string
+
+const (
+	// RoleIdentity is what makes a resource itself: arn, id, name, region.
+	// Identity fields are visible for context and diffs but never edited
+	// by Riley.
+	RoleIdentity FieldRole = "Identity"
+	// RoleWiring is a cross-reference to another managed resource:
+	// kms_key_id, subnet_ids, role_arn, redrive_policy. The composer's
+	// graph resolver owns these; Riley edits them through proposed graph
+	// changes, never as raw scalars.
+	RoleWiring FieldRole = "Wiring"
+	// RoleTuning is everything else — knobs Riley can plausibly turn:
+	// visibility_timeout_seconds, retention_in_days, lifecycle rules.
+	RoleTuning FieldRole = "Tuning"
+)
+
+// Valid reports whether r is one of the known role consts.
+func (r FieldRole) Valid() bool {
+	switch r {
+	case RoleIdentity, RoleWiring, RoleTuning:
+		return true
+	}
+	return false
+}
+
+// FieldPillar tags a field with the operational concern that justifies
+// curating it. It is informational — the lint does not require a non-empty
+// pillar — but it lets downstream UIs group fields by Security /
+// Performance / Reliability for review screens.
+type FieldPillar string
+
+const (
+	PillarNone        FieldPillar = ""
+	PillarSecurity    FieldPillar = "Security"
+	PillarPerformance FieldPillar = "Performance"
+	PillarReliability FieldPillar = "Reliability"
+)
+
+// Valid reports whether p is one of the known pillar consts. The empty
+// string is intentionally valid: most fields do not map cleanly to a
+// pillar.
+func (p FieldPillar) Valid() bool {
+	switch p {
+	case PillarNone, PillarSecurity, PillarPerformance, PillarReliability:
+		return true
+	}
+	return false
+}
+
+// VisibilityPolicy controls who, if anyone, can see the field. The zero
+// value is VisibilityHidden — the safe default for any field that has
+// not been deliberately curated.
+type VisibilityPolicy string
+
+const (
+	// VisibilityHidden — invisible to Riley and the UI. The composer
+	// still round-trips the value because Layer 1 preserves it; only
+	// system code may inspect it.
+	VisibilityHidden VisibilityPolicy = "Hidden"
+	// VisibilityRileyVisible — Riley can read the field in chat context
+	// and propose changes (subject to EditPolicy).
+	VisibilityRileyVisible VisibilityPolicy = "RileyVisible"
+	// VisibilityUIVisible — exposed in the product UI / diff screens for
+	// a human operator. Implies Riley-visible.
+	VisibilityUIVisible VisibilityPolicy = "UIVisible"
+)
+
+// Valid reports whether v is one of the known visibility consts. The
+// empty string is treated as Hidden; Valid() rejects it so callers must
+// state the choice explicitly when constructing a policy.
+func (v VisibilityPolicy) Valid() bool {
+	switch v {
+	case VisibilityHidden, VisibilityRileyVisible, VisibilityUIVisible:
+		return true
+	}
+	return false
+}
+
+// EditPolicy controls how the field may be changed. See
+// docs/managed-resource-tiers.md "Editor authority by population" for the
+// full matrix; in short:
+//
+//   - EditNever — readable but immutable from any flow.
+//   - EditChatSafe — Riley may change it through normal chat.
+//   - EditRequiresApproval — Riley proposes; user must confirm against
+//     the concrete plan.
+//   - EditRelationshipOnly — Riley cannot scalar-edit; the graph
+//     resolver / composer manages the value.
+//   - EditSystemOnly — only importer / composer system code writes here
+//     (tags, labels, provenance).
+type EditPolicy string
+
+const (
+	EditNever            EditPolicy = "Never"
+	EditChatSafe         EditPolicy = "ChatSafe"
+	EditRequiresApproval EditPolicy = "RequiresApproval"
+	EditRelationshipOnly EditPolicy = "RelationshipOnly"
+	EditSystemOnly       EditPolicy = "SystemOnly"
+)
+
+func (e EditPolicy) Valid() bool {
+	switch e {
+	case EditNever, EditChatSafe, EditRequiresApproval, EditRelationshipOnly, EditSystemOnly:
+		return true
+	}
+	return false
+}
+
+// SensitivityPolicy controls how the field's value is treated by display
+// and diff machinery. The provider-schema "Sensitive=true" flag is the
+// upstream input; Layer 2 owns the final classification per
+// docs/managed-resource-tiers.md decision #36.
+type SensitivityPolicy string
+
+const (
+	// SensitivityPublic — safe to show in Riley context and diffs.
+	SensitivityPublic SensitivityPolicy = "Public"
+	// SensitivityRedacted — show existence and change metadata but not
+	// raw values.
+	SensitivityRedacted SensitivityPolicy = "Redacted"
+	// SensitivitySensitive — hidden from Riley and raw diffs; only
+	// system code may retain the value.
+	SensitivitySensitive SensitivityPolicy = "Sensitive"
+)
+
+// Valid treats the empty string as a synonym for Public so the common
+// case of an unset axis on Tuning fields stays valid.
+func (s SensitivityPolicy) Valid() bool {
+	switch s {
+	case "", SensitivityPublic, SensitivityRedacted, SensitivitySensitive:
+		return true
+	}
+	return false
+}
+
+// ChangeRiskPolicy expresses what kind of plan a value change implies.
+// It overlays the schema-level ReplacementBehavior in Layer 1: where
+// Layer 1 says ReplacementUnknown for everything (terraform-json strips
+// force_new), Layer 2 records the curator's knowledge.
+type ChangeRiskPolicy string
+
+const (
+	// ChangeInPlace — the provider updates the resource in place.
+	ChangeInPlace ChangeRiskPolicy = "InPlace"
+	// ChangeMayReplace — the provider may replace depending on the
+	// concrete value; treat as replacement for confirmation purposes.
+	ChangeMayReplace ChangeRiskPolicy = "MayReplace"
+	// ChangeAlwaysReplace — known destroy/recreate.
+	ChangeAlwaysReplace ChangeRiskPolicy = "AlwaysReplace"
+	// ChangeUnknown — not curated yet; the apply gate falls back to
+	// MayReplace workflow per decision #46.
+	ChangeUnknown ChangeRiskPolicy = "Unknown"
+)
+
+// Valid treats the empty string as a synonym for ChangeUnknown so the
+// common case of leaving the axis unset is not a lint failure.
+func (c ChangeRiskPolicy) Valid() bool {
+	switch c {
+	case "", ChangeInPlace, ChangeMayReplace, ChangeAlwaysReplace, ChangeUnknown:
+		return true
+	}
+	return false
+}

--- a/pkg/composer/imported/policy/axes_test.go
+++ b/pkg/composer/imported/policy/axes_test.go
@@ -1,0 +1,130 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldRole_Valid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   FieldRole
+		want bool
+	}{
+		{RoleIdentity, true},
+		{RoleWiring, true},
+		{RoleTuning, true},
+		{"", false},
+		{"identity", false},
+		{"unknown", false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, tc.in.Valid(), "FieldRole(%q).Valid()", string(tc.in))
+	}
+}
+
+func TestFieldPillar_Valid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   FieldPillar
+		want bool
+	}{
+		{PillarNone, true},
+		{PillarSecurity, true},
+		{PillarPerformance, true},
+		{PillarReliability, true},
+		{"security", false},
+		{"unknown", false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, tc.in.Valid(), "FieldPillar(%q).Valid()", string(tc.in))
+	}
+}
+
+func TestVisibilityPolicy_Valid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   VisibilityPolicy
+		want bool
+	}{
+		{VisibilityHidden, true},
+		{VisibilityRileyVisible, true},
+		{VisibilityUIVisible, true},
+		{"", false},
+		{"hidden", false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, tc.in.Valid(), "VisibilityPolicy(%q).Valid()", string(tc.in))
+	}
+}
+
+func TestEditPolicy_Valid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   EditPolicy
+		want bool
+	}{
+		{EditNever, true},
+		{EditChatSafe, true},
+		{EditRequiresApproval, true},
+		{EditRelationshipOnly, true},
+		{EditSystemOnly, true},
+		{"", false},
+		{"chatsafe", false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, tc.in.Valid(), "EditPolicy(%q).Valid()", string(tc.in))
+	}
+}
+
+func TestSensitivityPolicy_Valid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   SensitivityPolicy
+		want bool
+	}{
+		{"", true}, // empty defaults to Public; intentionally valid
+		{SensitivityPublic, true},
+		{SensitivityRedacted, true},
+		{SensitivitySensitive, true},
+		{"sensitive", false},
+		{"redacted", false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, tc.in.Valid(), "SensitivityPolicy(%q).Valid()", string(tc.in))
+	}
+}
+
+func TestChangeRiskPolicy_Valid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   ChangeRiskPolicy
+		want bool
+	}{
+		{"", true}, // empty defaults to Unknown; intentionally valid
+		{ChangeInPlace, true},
+		{ChangeMayReplace, true},
+		{ChangeAlwaysReplace, true},
+		{ChangeUnknown, true},
+		{"in_place", false},
+		{"unknown", false}, // case-sensitive
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, tc.in.Valid(), "ChangeRiskPolicy(%q).Valid()", string(tc.in))
+	}
+}
+
+func TestSharedPolicies(t *testing.T) {
+	t.Parallel()
+	tag := tagPolicy()
+	assert.Equal(t, RoleTuning, tag.Role)
+	assert.Equal(t, EditSystemOnly, tag.Edit)
+	assert.Equal(t, VisibilityHidden, tag.Visibility)
+	assert.Equal(t, SensitivityRedacted, tag.Sensitivity)
+
+	tm := timeoutsPolicy()
+	assert.Equal(t, RoleTuning, tm.Role)
+	assert.Equal(t, EditSystemOnly, tm.Edit)
+	assert.Equal(t, VisibilityHidden, tm.Visibility)
+}

--- a/pkg/composer/imported/policy/axes_test.go
+++ b/pkg/composer/imported/policy/axes_test.go
@@ -16,7 +16,8 @@ func TestFieldRole_Valid(t *testing.T) {
 		{RoleWiring, true},
 		{RoleTuning, true},
 		{"", false},
-		{"identity", false},
+		{"identity", false}, // case-sensitive
+		{"Identitty", false}, // typo close to a real const
 		{"unknown", false},
 	}
 	for _, tc := range cases {
@@ -52,7 +53,9 @@ func TestVisibilityPolicy_Valid(t *testing.T) {
 		{VisibilityRileyVisible, true},
 		{VisibilityUIVisible, true},
 		{"", false},
-		{"hidden", false},
+		{"hidden", false},      // case-sensitive
+		{"Hidden ", false},     // trailing space
+		{"RileyVisable", false}, // typo close to a real const
 	}
 	for _, tc := range cases {
 		assert.Equal(t, tc.want, tc.in.Valid(), "VisibilityPolicy(%q).Valid()", string(tc.in))
@@ -72,6 +75,8 @@ func TestEditPolicy_Valid(t *testing.T) {
 		{EditSystemOnly, true},
 		{"", false},
 		{"chatsafe", false},
+		{"chat_safe", false},
+		{"ChatSaef", false}, // typo
 	}
 	for _, tc := range cases {
 		assert.Equal(t, tc.want, tc.in.Valid(), "EditPolicy(%q).Valid()", string(tc.in))
@@ -117,14 +122,18 @@ func TestChangeRiskPolicy_Valid(t *testing.T) {
 
 func TestSharedPolicies(t *testing.T) {
 	t.Parallel()
-	tag := tagPolicy()
-	assert.Equal(t, RoleTuning, tag.Role)
-	assert.Equal(t, EditSystemOnly, tag.Edit)
-	assert.Equal(t, VisibilityHidden, tag.Visibility)
-	assert.Equal(t, SensitivityRedacted, tag.Sensitivity)
-
-	tm := timeoutsPolicy()
-	assert.Equal(t, RoleTuning, tm.Role)
-	assert.Equal(t, EditSystemOnly, tm.Edit)
-	assert.Equal(t, VisibilityHidden, tm.Visibility)
+	// Whole-struct equality: these constructors are baked into every
+	// curated map, so any silent drift propagates everywhere. Pin the
+	// exact FieldPolicy shape, not just a few fields.
+	assert.Equal(t, FieldPolicy{
+		Role:        RoleTuning,
+		Visibility:  VisibilityHidden,
+		Edit:        EditSystemOnly,
+		Sensitivity: SensitivityRedacted,
+	}, tagPolicy())
+	assert.Equal(t, FieldPolicy{
+		Role:       RoleTuning,
+		Visibility: VisibilityHidden,
+		Edit:       EditSystemOnly,
+	}, timeoutsPolicy())
 }

--- a/pkg/composer/imported/policy/coverage_test.go
+++ b/pkg/composer/imported/policy/coverage_test.go
@@ -1,0 +1,153 @@
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// Side-effect import: register the 10 generated Layer 1 types so
+	// ResolvePath can walk struct schemas during LintAll.
+	_ "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// phase1Types pins the exact set of Phase 1 import resource types that
+// must have a Layer 2 policy registered. Adding or removing a type
+// requires updating this list — the diff makes the surface change
+// explicit. Mirrors generated/registry_test.go:TestRegistry_AllTenPhase1Registered.
+var phase1Types = []string{
+	"aws_cloudwatch_log_group",
+	"aws_dynamodb_table",
+	"aws_lambda_function",
+	"aws_secretsmanager_secret",
+	"aws_sqs_queue",
+	"google_compute_network",
+	"google_pubsub_subscription",
+	"google_pubsub_topic",
+	"google_secret_manager_secret",
+	"google_storage_bucket",
+}
+
+func TestPhase1Coverage(t *testing.T) {
+	t.Parallel()
+	for _, tfType := range phase1Types {
+		t.Run(tfType, func(t *testing.T) {
+			t.Parallel()
+			m, ok := Lookup(tfType)
+			require.True(t, ok, "no policy registered for %q", tfType)
+			require.NotEmpty(t, m, "policy for %q is empty", tfType)
+		})
+	}
+}
+
+func TestRegisteredTypes_NoExtras(t *testing.T) {
+	t.Parallel()
+	got := RegisteredTypes()
+	want := append([]string(nil), phase1Types...)
+	sort.Strings(want)
+	// Filter out synthetic test-only types (lint_test register helpers
+	// add them) by matching against the phase1 set. Production
+	// registrations should match phase1Types exactly when the test
+	// runs in isolation; in the suite, leftover test types may
+	// briefly appear, so we only assert that phase1Types is a subset.
+	for _, t1 := range want {
+		assert.Contains(t, got, t1)
+	}
+}
+
+func TestLintAll_Clean(t *testing.T) {
+	t.Parallel()
+	for _, tfType := range phase1Types {
+		t.Run(tfType, func(t *testing.T) {
+			t.Parallel()
+			issues := Lint(tfType)
+			if len(issues) == 0 {
+				return
+			}
+			lines := make([]string, 0, len(issues))
+			for _, i := range issues {
+				lines = append(lines, i.String())
+			}
+			t.Fatalf("policy for %q lints with %d issue(s):\n%s",
+				tfType, len(issues), strings.Join(lines, "\n"))
+		})
+	}
+}
+
+// TestKnownPathsNoShrink locks the curated Layer 2 surface against
+// silent erosion. Every PR that adds, removes, or renames a policy
+// path must also bump testdata/known_paths.golden so the diff is
+// explicit. Set UPDATE_GOLDEN=1 to seed.
+func TestKnownPathsNoShrink(t *testing.T) {
+	t.Parallel()
+
+	goldenPath := filepath.Join("testdata", "known_paths.golden")
+	current := snapshot()
+
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		require.NoError(t, os.MkdirAll(filepath.Dir(goldenPath), 0o755))
+		require.NoError(t, os.WriteFile(goldenPath, []byte(current), 0o644))
+		t.Logf("wrote golden: %s", goldenPath)
+		return
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	require.NoError(t, err,
+		"golden missing — run `UPDATE_GOLDEN=1 go test ./pkg/composer/imported/policy/ -run TestKnownPathsNoShrink`")
+	require.Equal(t, string(want), current,
+		"policy surface drifted from %s. If this is intentional, re-seed via UPDATE_GOLDEN=1.",
+		goldenPath)
+}
+
+// snapshot emits a sorted, stable text representation of the entire
+// curated policy surface for diffing purposes. Format:
+//
+//	<tfType>\t<path>\t<Role>\t<Pillar>\t<Visibility>\t<Edit>\t<Sensitivity>\t<ChangeRisk>\n
+//
+// Rationale is intentionally NOT included — it is freeform prose that
+// would dirty the diff for non-surface changes.
+func snapshot() string {
+	tfTypes := RegisteredTypes()
+	var b strings.Builder
+	for _, t := range tfTypes {
+		// Skip synthetic types that may have leaked from earlier tests.
+		if !isPhase1(t) {
+			continue
+		}
+		m, _ := Lookup(t)
+		paths := make([]string, 0, len(m))
+		for p := range m {
+			paths = append(paths, p)
+		}
+		sort.Strings(paths)
+		for _, p := range paths {
+			fp := m[p]
+			b.WriteString(t)
+			b.WriteByte('\t')
+			b.WriteString(p)
+			b.WriteByte('\t')
+			b.WriteString(string(fp.Role))
+			b.WriteByte('\t')
+			b.WriteString(string(fp.Pillar))
+			b.WriteByte('\t')
+			b.WriteString(string(fp.Visibility))
+			b.WriteByte('\t')
+			b.WriteString(string(fp.Edit))
+			b.WriteByte('\t')
+			b.WriteString(string(fp.Sensitivity))
+			b.WriteByte('\t')
+			b.WriteString(string(fp.ChangeRisk))
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func isPhase1(tfType string) bool {
+	return slices.Contains(phase1Types, tfType)
+}

--- a/pkg/composer/imported/policy/coverage_test.go
+++ b/pkg/composer/imported/policy/coverage_test.go
@@ -16,6 +16,12 @@ import (
 	_ "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
 )
 
+// syntheticTypePrefix is the namespace used by registry_test.go for
+// synthetic test-only tfTypes. Production tests in this package must
+// filter out registrations carrying this prefix so concurrent test
+// runs don't observe each other through RegisteredTypes() or LintAll().
+const syntheticTypePrefix = "policy_test_"
+
 // phase1Types pins the exact set of Phase 1 import resource types that
 // must have a Layer 2 policy registered. Adding or removing a type
 // requires updating this list — the diff makes the surface change
@@ -45,19 +51,24 @@ func TestPhase1Coverage(t *testing.T) {
 	}
 }
 
-func TestRegisteredTypes_NoExtras(t *testing.T) {
+// TestRegisteredTypes_PhaseSetExact filters out synthetic test
+// registrations (the "policy_test_" prefix used by registry_test.go
+// and lint_test.go helpers) and asserts the remaining production
+// registrations match the Phase 1 set exactly. Adding or removing a
+// production tfType requires a deliberate edit to phase1Types.
+func TestRegisteredTypes_PhaseSetExact(t *testing.T) {
 	t.Parallel()
 	got := RegisteredTypes()
+	production := got[:0:0]
+	for _, tfType := range got {
+		if !strings.HasPrefix(tfType, syntheticTypePrefix) {
+			production = append(production, tfType)
+		}
+	}
 	want := append([]string(nil), phase1Types...)
 	sort.Strings(want)
-	// Filter out synthetic test-only types (lint_test register helpers
-	// add them) by matching against the phase1 set. Production
-	// registrations should match phase1Types exactly when the test
-	// runs in isolation; in the suite, leftover test types may
-	// briefly appear, so we only assert that phase1Types is a subset.
-	for _, t1 := range want {
-		assert.Contains(t, got, t1)
-	}
+	assert.Equal(t, want, production,
+		"production policy registrations must equal phase1Types exactly")
 }
 
 func TestLintAll_Clean(t *testing.T) {

--- a/pkg/composer/imported/policy/doc.go
+++ b/pkg/composer/imported/policy/doc.go
@@ -1,0 +1,28 @@
+// Package policy carries the hand-curated Layer 2 field policy for imported
+// Terraform resources. It rides on top of the Layer 1 typed model in
+// pkg/composer/imported/generated.
+//
+// Layer 1 (generated) is the full provider schema: every attribute and
+// nested block, regenerated whenever the AWS or GCP provider bumps. It tells
+// us what fields exist, their types, and basic schema metadata.
+//
+// Layer 2 (this package) is the product policy on top of those fields. It
+// answers, per attribute, six independent questions: what role does the
+// field play (Identity / Wiring / Tuning), which operational pillar it
+// touches (Security / Performance / Reliability / None), who can see it
+// (Hidden / RileyVisible / UIVisible), who can edit it (Never / ChatSafe /
+// RequiresApproval / RelationshipOnly / SystemOnly), how sensitive its
+// value is (Public / Redacted / Sensitive), and how risky a change is
+// (InPlace / MayReplace / AlwaysReplace / Unknown).
+//
+// The maps in this package are written by hand, one file per Terraform
+// resource type, registered through init() side effects. Adding or
+// expanding a policy is a reviewed code change — never a runtime
+// configuration. New generated provider fields default hidden,
+// system-owned, and not Riley-editable until a reviewed policy PR
+// explicitly adds them. See docs/managed-resource-tiers.md decision #43.
+//
+// Consumers (composer emission #148, server-side validateImportedResources
+// #149, ResourceDiff #151) reach this package through Lookup(tfType) and
+// the lint helpers; they do not reference per-type maps directly.
+package policy

--- a/pkg/composer/imported/policy/google_compute_network.policy.go
+++ b/pkg/composer/imported/policy/google_compute_network.policy.go
@@ -1,0 +1,53 @@
+package policy
+
+var googleComputeNetworkPolicy = Map{
+	// Identity
+	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"numeric_id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+	},
+	"project": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk: ChangeAlwaysReplace,
+	},
+	"gateway_ipv4": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+	},
+
+	// Tuning — networking semantics
+	"auto_create_subnetworks": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+	},
+	"routing_mode": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"mtu": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"delete_default_routes_on_create": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+	},
+	"enable_ula_internal_ipv6": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"network_firewall_policy_enforcement_order": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval,
+	},
+	"description": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// google_compute_network has no labels and no timeouts on the
+	// surface struct — the timeouts singleton is intentionally
+	// included as system-owned operational metadata.
+	"timeouts": timeoutsPolicy(),
+}
+
+func init() {
+	Register("google_compute_network", googleComputeNetworkPolicy)
+}

--- a/pkg/composer/imported/policy/google_pubsub_subscription.policy.go
+++ b/pkg/composer/imported/policy/google_pubsub_subscription.policy.go
@@ -1,0 +1,138 @@
+package policy
+
+var googlePubsubSubscriptionPolicy = Map{
+	// Identity
+	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"project": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk: ChangeAlwaysReplace,
+	},
+
+	// Wiring — required topic plus delivery / DLQ targets
+	"topic": {
+		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"dead_letter_policy.dead_letter_topic": {
+		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"bigquery_config.table": {
+		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+	},
+	"bigquery_config.service_account_email": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"cloud_storage_config.bucket": {
+		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+	},
+	"cloud_storage_config.service_account_email": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"push_config.oidc_token.service_account_email": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+
+	// Push config — endpoints and attributes can carry tokens.
+	"push_config.push_endpoint": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval, Sensitivity: SensitivityRedacted,
+	},
+	"push_config.attributes": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval, Sensitivity: SensitivityRedacted,
+	},
+	"push_config.oidc_token.audience": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval, Sensitivity: SensitivityRedacted,
+	},
+
+	// Tuning — delivery semantics
+	"ack_deadline_seconds": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"enable_exactly_once_delivery": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"enable_message_ordering": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+	},
+	"filter": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		ChangeRisk: ChangeAlwaysReplace,
+	},
+	"message_retention_duration": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"retain_acked_messages": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"expiration_policy.ttl": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// Retry + DLQ knobs
+	"retry_policy.minimum_backoff": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"retry_policy.maximum_backoff": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"dead_letter_policy.max_delivery_attempts": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// BigQuery + Cloud Storage flags
+	"bigquery_config.drop_unknown_fields": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"bigquery_config.use_table_schema": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"bigquery_config.use_topic_schema": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"bigquery_config.write_metadata": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"cloud_storage_config.filename_prefix": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"cloud_storage_config.filename_suffix": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"cloud_storage_config.filename_datetime_format": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"cloud_storage_config.max_bytes": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"cloud_storage_config.max_duration": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"cloud_storage_config.max_messages": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"cloud_storage_config.avro_config.use_topic_schema": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"cloud_storage_config.avro_config.write_metadata": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// Labels — system-owned.
+	"labels":           tagPolicy(),
+	"effective_labels": tagPolicy(),
+	"terraform_labels": tagPolicy(),
+
+	"timeouts": timeoutsPolicy(),
+}
+
+func init() {
+	Register("google_pubsub_subscription", googlePubsubSubscriptionPolicy)
+}

--- a/pkg/composer/imported/policy/google_pubsub_topic.policy.go
+++ b/pkg/composer/imported/policy/google_pubsub_topic.policy.go
@@ -1,0 +1,72 @@
+package policy
+
+var googlePubsubTopicPolicy = Map{
+	// Identity
+	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"project": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk: ChangeAlwaysReplace,
+	},
+
+	// Wiring — encryption + ingestion data sources
+	"kms_key_name": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"ingestion_data_source_settings.aws_kinesis.aws_role_arn": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"ingestion_data_source_settings.aws_kinesis.consumer_arn": {
+		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+	},
+	"ingestion_data_source_settings.aws_kinesis.gcp_service_account": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"ingestion_data_source_settings.aws_kinesis.stream_arn": {
+		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+	},
+	"ingestion_data_source_settings.cloud_storage.bucket": {
+		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+	},
+	"schema_settings.schema": {
+		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+	},
+
+	// Tuning
+	"message_retention_duration": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"message_storage_policy.allowed_persistence_regions": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval,
+	},
+	"schema_settings.encoding": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"ingestion_data_source_settings.cloud_storage.match_glob": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"ingestion_data_source_settings.cloud_storage.minimum_object_create_time": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"ingestion_data_source_settings.cloud_storage.text_format.delimiter": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"ingestion_data_source_settings.platform_logs_settings.severity": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// Labels — system-owned.
+	"labels":           tagPolicy(),
+	"effective_labels": tagPolicy(),
+	"terraform_labels": tagPolicy(),
+
+	"timeouts": timeoutsPolicy(),
+}
+
+func init() {
+	Register("google_pubsub_topic", googlePubsubTopicPolicy)
+}

--- a/pkg/composer/imported/policy/google_secret_manager_secret.policy.go
+++ b/pkg/composer/imported/policy/google_secret_manager_secret.policy.go
@@ -1,0 +1,60 @@
+package policy
+
+var googleSecretManagerSecretPolicy = Map{
+	// Identity
+	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"secret_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"project": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk: ChangeAlwaysReplace,
+	},
+
+	// Wiring — replication targets and CMEK
+	"replication.auto.customer_managed_encryption.kms_key_name": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"replication.user_managed.replicas.location": {
+		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"replication.user_managed.replicas.customer_managed_encryption.kms_key_name": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"topics.name": {
+		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+
+	// Tuning — lifecycle / rotation knobs
+	"expire_time": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"ttl": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"version_destroy_ttl": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"rotation.rotation_period": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"rotation.next_rotation_time": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// Labels and annotations — system-owned.
+	"labels":                tagPolicy(),
+	"effective_labels":      tagPolicy(),
+	"terraform_labels":      tagPolicy(),
+	"annotations":           tagPolicy(),
+	"effective_annotations": tagPolicy(),
+
+	"timeouts": timeoutsPolicy(),
+}
+
+func init() {
+	Register("google_secret_manager_secret", googleSecretManagerSecretPolicy)
+}

--- a/pkg/composer/imported/policy/google_storage_bucket.policy.go
+++ b/pkg/composer/imported/policy/google_storage_bucket.policy.go
@@ -1,0 +1,117 @@
+package policy
+
+var googleStorageBucketPolicy = Map{
+	// Identity
+	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"url":       {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"project": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk: ChangeAlwaysReplace,
+	},
+	"location": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk: ChangeAlwaysReplace,
+	},
+
+	// Wiring (encryption + cross-bucket logging target)
+	"encryption.default_kms_key_name": {
+		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"logging.log_bucket": {
+		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	},
+	"logging.log_object_prefix": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// Tuning — class and access
+	"storage_class": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"force_destroy": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval,
+	},
+	"requester_pays": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"uniform_bucket_level_access": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval,
+	},
+	"public_access_prevention": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+	},
+
+	// Tuning — versioning, lifecycle, retention
+	"versioning.enabled": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"lifecycle_rule.action.type": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"lifecycle_rule.action.storage_class": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"lifecycle_rule.condition.age": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"lifecycle_rule.condition.with_state": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"retention_policy.retention_period": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval,
+	},
+	"retention_policy.is_locked": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
+		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+	},
+	"soft_delete_policy.retention_duration_seconds": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// CORS
+	"cors.method": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"cors.origin": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"cors.response_header": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"cors.max_age_seconds": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// Website + autoclass + rpo
+	"website.main_page_suffix": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"website.not_found_page": {
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"autoclass.enabled": {
+		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+	"rpo": {
+		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	},
+
+	// Labels — uniformly system-owned.
+	"labels":           tagPolicy(),
+	"effective_labels": tagPolicy(),
+	"terraform_labels": tagPolicy(),
+
+	"timeouts": timeoutsPolicy(),
+}
+
+func init() {
+	Register("google_storage_bucket", googleStorageBucketPolicy)
+}

--- a/pkg/composer/imported/policy/lint.go
+++ b/pkg/composer/imported/policy/lint.go
@@ -1,0 +1,185 @@
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// Issue is one lint finding against a curated policy map.
+type Issue struct {
+	TFType  string
+	Path    string
+	Code    string
+	Message string
+}
+
+func (i Issue) String() string {
+	return fmt.Sprintf("[%s] %s:%s: %s", i.Code, i.TFType, i.Path, i.Message)
+}
+
+// Lint codes. Each links to a docs/managed-resource-tiers.md decision so
+// reviewers can trace policy back to spec.
+const (
+	CodeUnknownPath               = "unknown_path"               // path doesn't resolve in Layer 1 or projection
+	CodeRoleRequired              = "role_required"              // Role is the zero value (decision #43)
+	CodeAxisInvalidValue          = "axis_invalid_value"         // any axis fails Valid()
+	CodeSensitiveVisibleNoReason  = "sensitive_visible_no_rationale" // visible+sensitive needs rationale (#36)
+	CodeWiringChatEditable        = "wiring_chat_editable"       // Wiring fields can't be ChatSafe (#33)
+	CodeTagFieldNotSystemOnly     = "tag_field_not_system_only"  // tags/labels/annotations must be SystemOnly
+	CodeIdentityEditable          = "identity_editable"          // identity fields must be Edit=Never
+)
+
+// tagAttrSuffixes lists Terraform attribute names that are tag- or
+// label-shaped. The lint matches on suffix so nested cases like
+// `replica.tags` would also be caught if curators added them.
+var tagAttrSuffixes = []string{
+	"tags",
+	"tags_all",
+	"labels",
+	"effective_labels",
+	"terraform_labels",
+	"annotations",
+	"effective_annotations",
+}
+
+// identityAttrLeaves lists well-known identity attribute names.
+// Matched against the leaf segment of the path (the part after the
+// last dot, with brackets stripped).
+var identityAttrLeaves = map[string]struct{}{
+	"arn":                   {},
+	"id":                    {},
+	"name":                  {},
+	"name_prefix":           {},
+	"self_link":              {}, //nolint:gofmt
+	"url":                   {},
+	"numeric_id":            {},
+	"qualified_arn":         {},
+	"invoke_arn":            {},
+	"qualified_invoke_arn":  {},
+	"stream_arn":            {},
+	"function_name":         {},
+	"secret_id":             {},
+}
+
+// Lint runs all checks against the policy registered for tfType.
+// Returns issues sorted by Path. An unregistered tfType yields a single
+// issue with the tfType-level CodeUnknownPath code.
+func Lint(tfType string) []Issue {
+	m, ok := Lookup(tfType)
+	if !ok {
+		return []Issue{{
+			TFType:  tfType,
+			Code:    CodeUnknownPath,
+			Message: "no policy map registered",
+		}}
+	}
+	var issues []Issue
+	for path, fp := range m {
+		issues = append(issues, lintEntry(tfType, path, fp)...)
+	}
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].Path != issues[j].Path {
+			return issues[i].Path < issues[j].Path
+		}
+		return issues[i].Code < issues[j].Code
+	})
+	return issues
+}
+
+// LintAll runs Lint across every registered tfType.
+func LintAll() []Issue {
+	var issues []Issue
+	for _, t := range RegisteredTypes() {
+		issues = append(issues, Lint(t)...)
+	}
+	return issues
+}
+
+func lintEntry(tfType, path string, fp FieldPolicy) []Issue {
+	var issues []Issue
+	add := func(code, msg string) {
+		issues = append(issues, Issue{TFType: tfType, Path: path, Code: code, Message: msg})
+	}
+
+	// Path must resolve.
+	if err := ResolvePath(tfType, path); err != nil {
+		if errors.Is(err, ErrNoSuchPath) {
+			add(CodeUnknownPath, err.Error())
+		} else {
+			add(CodeUnknownPath, fmt.Sprintf("resolve: %v", err))
+		}
+	}
+
+	// Per-axis Valid().
+	if !fp.Role.Valid() {
+		if fp.Role == "" {
+			add(CodeRoleRequired, "Role is required (decision #43)")
+		} else {
+			add(CodeAxisInvalidValue, fmt.Sprintf("Role %q is not a known FieldRole", fp.Role))
+		}
+	}
+	if !fp.Pillar.Valid() {
+		add(CodeAxisInvalidValue, fmt.Sprintf("Pillar %q is not a known FieldPillar", fp.Pillar))
+	}
+	if !fp.Visibility.Valid() {
+		add(CodeAxisInvalidValue, fmt.Sprintf("Visibility %q is not a known VisibilityPolicy", fp.Visibility))
+	}
+	if !fp.Edit.Valid() {
+		add(CodeAxisInvalidValue, fmt.Sprintf("Edit %q is not a known EditPolicy", fp.Edit))
+	}
+	if !fp.Sensitivity.Valid() {
+		add(CodeAxisInvalidValue, fmt.Sprintf("Sensitivity %q is not a known SensitivityPolicy", fp.Sensitivity))
+	}
+	if !fp.ChangeRisk.Valid() {
+		add(CodeAxisInvalidValue, fmt.Sprintf("ChangeRisk %q is not a known ChangeRiskPolicy", fp.ChangeRisk))
+	}
+
+	// Visible + sensitive without rationale.
+	if fp.Sensitivity == SensitivitySensitive &&
+		fp.Visibility != VisibilityHidden &&
+		strings.TrimSpace(fp.Rationale) == "" {
+		add(CodeSensitiveVisibleNoReason,
+			"Sensitivity=Sensitive with non-Hidden Visibility requires Rationale (decision #36)")
+	}
+
+	// Wiring fields cannot be ChatSafe.
+	if fp.Role == RoleWiring && fp.Edit == EditChatSafe {
+		add(CodeWiringChatEditable,
+			"Role=Wiring is incompatible with Edit=ChatSafe; use RelationshipOnly, RequiresApproval, or Never (decision #33)")
+	}
+
+	// Tag/label-shaped attributes must be SystemOnly.
+	leaf := leafSegment(path)
+	if isTagAttr(leaf) && fp.Edit != EditSystemOnly {
+		add(CodeTagFieldNotSystemOnly,
+			"tag/label fields must be Edit=SystemOnly")
+	}
+
+	// Identity fields must be Edit=Never (or SystemOnly when also a
+	// tag-like attribute, which doesn't apply to the identity set).
+	if _, ok := identityAttrLeaves[leaf]; ok && fp.Edit != EditNever {
+		add(CodeIdentityEditable,
+			"identity attribute must be Edit=Never")
+	}
+
+	return issues
+}
+
+// leafSegment returns the final dotted segment of path with any
+// bracket suffix removed.
+func leafSegment(path string) string {
+	if idx := strings.LastIndex(path, "."); idx >= 0 {
+		path = path[idx+1:]
+	}
+	if idx := strings.IndexByte(path, '['); idx >= 0 {
+		path = path[:idx]
+	}
+	return path
+}
+
+func isTagAttr(name string) bool {
+	return slices.Contains(tagAttrSuffixes, name)
+}

--- a/pkg/composer/imported/policy/lint.go
+++ b/pkg/composer/imported/policy/lint.go
@@ -158,11 +158,15 @@ func lintEntry(tfType, path string, fp FieldPolicy) []Issue {
 			"tag/label fields must be Edit=SystemOnly")
 	}
 
-	// Identity fields must be Edit=Never (or SystemOnly when also a
-	// tag-like attribute, which doesn't apply to the identity set).
-	if _, ok := identityAttrLeaves[leaf]; ok && fp.Edit != EditNever {
-		add(CodeIdentityEditable,
-			"identity attribute must be Edit=Never")
+	// Identity fields must be Edit=Never. Only top-level paths (no
+	// dot) are considered the resource's own identity; nested paths
+	// like `file_system_config.arn` are wiring references to OTHER
+	// resources and follow the wiring rules instead.
+	if !strings.Contains(path, ".") {
+		if _, ok := identityAttrLeaves[leaf]; ok && fp.Edit != EditNever {
+			add(CodeIdentityEditable,
+				"identity attribute must be Edit=Never")
+		}
 	}
 
 	return issues

--- a/pkg/composer/imported/policy/lint.go
+++ b/pkg/composer/imported/policy/lint.go
@@ -23,13 +23,16 @@ func (i Issue) String() string {
 // Lint codes. Each links to a docs/managed-resource-tiers.md decision so
 // reviewers can trace policy back to spec.
 const (
-	CodeUnknownPath               = "unknown_path"               // path doesn't resolve in Layer 1 or projection
-	CodeRoleRequired              = "role_required"              // Role is the zero value (decision #43)
-	CodeAxisInvalidValue          = "axis_invalid_value"         // any axis fails Valid()
-	CodeSensitiveVisibleNoReason  = "sensitive_visible_no_rationale" // visible+sensitive needs rationale (#36)
-	CodeWiringChatEditable        = "wiring_chat_editable"       // Wiring fields can't be ChatSafe (#33)
-	CodeTagFieldNotSystemOnly     = "tag_field_not_system_only"  // tags/labels/annotations must be SystemOnly
-	CodeIdentityEditable          = "identity_editable"          // identity fields must be Edit=Never
+	CodeUnknownPath                   = "unknown_path"                   // path doesn't resolve in Layer 1 or projection
+	CodeRoleRequired                  = "role_required"                  // Role is the zero value (decision #43)
+	CodeAxisInvalidValue              = "axis_invalid_value"             // any axis fails Valid()
+	CodeSensitiveVisibleNoRationale   = "sensitive_visible_no_rationale" // visible+sensitive needs rationale (#36)
+	CodeWiringChatEditable            = "wiring_chat_editable"           // Wiring fields can't be ChatSafe (#33)
+	CodeTagFieldNotSystemOnly         = "tag_field_not_system_only"      // tags/labels/annotations must be SystemOnly
+	CodeIdentityEditable              = "identity_editable"              // top-level identity attrs must be Edit=Never
+	CodeHiddenChatEditable            = "hidden_chat_editable"           // Riley can't edit what it can't see
+	CodeSensitiveChatEditable         = "sensitive_chat_editable"        // Sensitive values must not flow through chat
+	CodeIdentitySensitive             = "identity_sensitive"             // Identity fields are not sensitive values
 )
 
 // tagAttrSuffixes lists Terraform attribute names that are tag- or
@@ -49,24 +52,28 @@ var tagAttrSuffixes = []string{
 // Matched against the leaf segment of the path (the part after the
 // last dot, with brackets stripped).
 var identityAttrLeaves = map[string]struct{}{
-	"arn":                   {},
-	"id":                    {},
-	"name":                  {},
-	"name_prefix":           {},
-	"self_link":              {}, //nolint:gofmt
-	"url":                   {},
-	"numeric_id":            {},
-	"qualified_arn":         {},
-	"invoke_arn":            {},
-	"qualified_invoke_arn":  {},
-	"stream_arn":            {},
-	"function_name":         {},
-	"secret_id":             {},
+	"arn":                  {},
+	"id":                   {},
+	"name":                 {},
+	"name_prefix":          {},
+	"self_link":            {},
+	"url":                  {},
+	"numeric_id":           {},
+	"qualified_arn":        {},
+	"invoke_arn":           {},
+	"qualified_invoke_arn": {},
+	"stream_arn":           {},
+	"function_name":        {},
+	"secret_id":            {},
 }
 
 // Lint runs all checks against the policy registered for tfType.
-// Returns issues sorted by Path. An unregistered tfType yields a single
-// issue with the tfType-level CodeUnknownPath code.
+// Returns issues sorted by Path. An unregistered tfType yields a
+// single issue with the tfType-level CodeUnknownPath code.
+//
+// Lint is a thin wrapper over LintMap that performs the registry
+// lookup; the rule engine itself lives in LintMap so tests can drive
+// it with synthetic maps against real Layer 1 tfTypes.
 func Lint(tfType string) []Issue {
 	m, ok := Lookup(tfType)
 	if !ok {
@@ -76,6 +83,16 @@ func Lint(tfType string) []Issue {
 			Message: "no policy map registered",
 		}}
 	}
+	return LintMap(tfType, m)
+}
+
+// LintMap runs the rule engine against an arbitrary policy map
+// without consulting the registry. tfType is still required because
+// path resolution walks the Layer 1 generated struct registered for
+// that tfType in pkg/composer/imported/generated.
+//
+// Issues are returned sorted by (Path, Code) for stable diffs.
+func LintMap(tfType string, m Map) []Issue {
 	var issues []Issue
 	for path, fp := range m {
 		issues = append(issues, lintEntry(tfType, path, fp)...)
@@ -141,7 +158,7 @@ func lintEntry(tfType, path string, fp FieldPolicy) []Issue {
 	if fp.Sensitivity == SensitivitySensitive &&
 		fp.Visibility != VisibilityHidden &&
 		strings.TrimSpace(fp.Rationale) == "" {
-		add(CodeSensitiveVisibleNoReason,
+		add(CodeSensitiveVisibleNoRationale,
 			"Sensitivity=Sensitive with non-Hidden Visibility requires Rationale (decision #36)")
 	}
 
@@ -149,6 +166,26 @@ func lintEntry(tfType, path string, fp FieldPolicy) []Issue {
 	if fp.Role == RoleWiring && fp.Edit == EditChatSafe {
 		add(CodeWiringChatEditable,
 			"Role=Wiring is incompatible with Edit=ChatSafe; use RelationshipOnly, RequiresApproval, or Never (decision #33)")
+	}
+
+	// Riley cannot edit what it cannot see.
+	if fp.Visibility == VisibilityHidden && fp.Edit == EditChatSafe {
+		add(CodeHiddenChatEditable,
+			"Visibility=Hidden is incompatible with Edit=ChatSafe; Riley cannot edit what it cannot see")
+	}
+
+	// Sensitive values must not flow through chat. RequiresApproval
+	// is borderline — the operator confirms against the plan and
+	// never has to read the raw value — so it is allowed.
+	if fp.Sensitivity == SensitivitySensitive && fp.Edit == EditChatSafe {
+		add(CodeSensitiveChatEditable,
+			"Sensitivity=Sensitive is incompatible with Edit=ChatSafe; route through SystemOnly or RequiresApproval")
+	}
+
+	// Identity fields are by definition references, not secrets.
+	if fp.Role == RoleIdentity && fp.Sensitivity == SensitivitySensitive {
+		add(CodeIdentitySensitive,
+			"Role=Identity is incompatible with Sensitivity=Sensitive; identity fields are not secret values")
 	}
 
 	// Tag/label-shaped attributes must be SystemOnly.

--- a/pkg/composer/imported/policy/lint_test.go
+++ b/pkg/composer/imported/policy/lint_test.go
@@ -6,19 +6,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	// Side-effect import: register the 10 generated Layer 1 types so
+	// ResolvePath has structs to walk during LintMap.
+	_ "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
 )
 
-// register pushes m into the registry under a unique synthetic tfType
-// for tests, with cleanup. Returns the tfType the test should use.
-func registerSyntheticPolicy(t *testing.T, baseType string, m Map) string {
-	t.Helper()
-	tfType := "policy_test_lint_" + baseType + "_" + strings.ReplaceAll(t.Name(), "/", "_")
-	t.Cleanup(func() { unregisterForTest(tfType) })
-	Register(tfType, m)
-	return tfType
-}
-
-// codes lifts an []Issue into a string set of codes for easy assertions.
+// codes lifts an []Issue into its set of Code strings.
 func codes(issues []Issue) []string {
 	out := make([]string, 0, len(issues))
 	for _, i := range issues {
@@ -27,120 +21,246 @@ func codes(issues []Issue) []string {
 	return out
 }
 
+// findIssue returns the first issue matching code, or nil.
+func findIssue(issues []Issue, code string) *Issue {
+	for i := range issues {
+		if issues[i].Code == code {
+			return &issues[i]
+		}
+	}
+	return nil
+}
+
+// All per-rule lint tests below drive the public LintMap entrypoint
+// against a real Layer 1 tfType (aws_sqs_queue is convenient because
+// it has top-level scalars, a tags map, and KMS wiring). This routes
+// through ResolvePath end-to-end and locks the rule engine's
+// behavior; mutating a rule body in lint.go fails these tests
+// directly.
+
 func TestLint_RoleRequired(t *testing.T) {
 	t.Parallel()
-	tfType := registerSyntheticPolicy(t, "aws_sqs_queue", Map{
+	got := LintMap("aws_sqs_queue", Map{
 		"name": {Visibility: VisibilityUIVisible, Edit: EditNever},
 	})
-	// Synthetic tfType won't resolve in Layer 1, so we can't use the
-	// shared registry; lint via Lookup-and-iterate manually to test
-	// the entry-level rule.
-	issues := lintEntry(tfType, "name", FieldPolicy{
-		Visibility: VisibilityUIVisible, Edit: EditNever,
-	})
-	assert.Contains(t, codes(issues), CodeRoleRequired)
+	require.NotEmpty(t, got)
+	require.Equal(t, []string{CodeRoleRequired}, codes(got))
+	assert.Equal(t, "name", got[0].Path)
 }
 
 func TestLint_SensitiveVisibleRequiresRationale(t *testing.T) {
 	t.Parallel()
-	bad := lintEntry("aws_sqs_queue", "policy", FieldPolicy{
-		Role: RoleTuning, Visibility: VisibilityRileyVisible,
-		Edit: EditNever, Sensitivity: SensitivitySensitive,
+	bad := LintMap("aws_sqs_queue", Map{
+		"policy": {
+			Role: RoleTuning, Visibility: VisibilityRileyVisible,
+			Edit: EditNever, Sensitivity: SensitivitySensitive,
+		},
 	})
-	assert.Contains(t, codes(bad), CodeSensitiveVisibleNoReason)
+	assert.Contains(t, codes(bad), CodeSensitiveVisibleNoRationale)
 
-	ok := lintEntry("aws_sqs_queue", "policy", FieldPolicy{
-		Role: RoleTuning, Visibility: VisibilityRileyVisible,
-		Edit: EditNever, Sensitivity: SensitivitySensitive,
-		Rationale: "IAM JSON document, no secrets in scope",
+	withRationale := LintMap("aws_sqs_queue", Map{
+		"policy": {
+			Role: RoleTuning, Visibility: VisibilityRileyVisible,
+			Edit: EditNever, Sensitivity: SensitivitySensitive,
+			Rationale: "IAM JSON document, no secrets in scope",
+		},
 	})
-	assert.NotContains(t, codes(ok), CodeSensitiveVisibleNoReason)
+	assert.NotContains(t, codes(withRationale), CodeSensitiveVisibleNoRationale)
 
-	// Hidden + Sensitive needs no rationale (the common safe shape).
-	hidden := lintEntry("aws_sqs_queue", "policy", FieldPolicy{
-		Role: RoleTuning, Visibility: VisibilityHidden,
-		Edit: EditSystemOnly, Sensitivity: SensitivitySensitive,
+	hidden := LintMap("aws_sqs_queue", Map{
+		"policy": {
+			Role: RoleTuning, Visibility: VisibilityHidden,
+			Edit: EditSystemOnly, Sensitivity: SensitivitySensitive,
+		},
 	})
-	assert.NotContains(t, codes(hidden), CodeSensitiveVisibleNoReason)
+	assert.NotContains(t, codes(hidden), CodeSensitiveVisibleNoRationale)
 }
 
 func TestLint_WiringChatEditable(t *testing.T) {
 	t.Parallel()
-	bad := lintEntry("aws_sqs_queue", "kms_master_key_id", FieldPolicy{
-		Role: RoleWiring, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+	bad := LintMap("aws_sqs_queue", Map{
+		"kms_master_key_id": {
+			Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		},
 	})
 	assert.Contains(t, codes(bad), CodeWiringChatEditable)
 
-	ok := lintEntry("aws_sqs_queue", "kms_master_key_id", FieldPolicy{
-		Role: RoleWiring, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+	good := LintMap("aws_sqs_queue", Map{
+		"kms_master_key_id": {
+			Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+		},
 	})
-	assert.NotContains(t, codes(ok), CodeWiringChatEditable)
+	assert.NotContains(t, codes(good), CodeWiringChatEditable)
 }
 
 func TestLint_TagFieldNotSystemOnly(t *testing.T) {
 	t.Parallel()
-	bad := lintEntry("aws_sqs_queue", "tags", FieldPolicy{
-		Role: RoleTuning, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+	bad := LintMap("aws_sqs_queue", Map{
+		"tags": {
+			Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		},
 	})
 	assert.Contains(t, codes(bad), CodeTagFieldNotSystemOnly)
 
-	good := lintEntry("aws_sqs_queue", "tags", tagPolicy())
+	good := LintMap("aws_sqs_queue", Map{"tags": tagPolicy()})
 	assert.NotContains(t, codes(good), CodeTagFieldNotSystemOnly)
 }
 
 func TestLint_IdentityEditable(t *testing.T) {
 	t.Parallel()
-	bad := lintEntry("aws_sqs_queue", "name", FieldPolicy{
-		Role: RoleIdentity, Visibility: VisibilityUIVisible,
-		Edit: EditChatSafe,
+	bad := LintMap("aws_sqs_queue", Map{
+		"name": {
+			Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		},
 	})
 	assert.Contains(t, codes(bad), CodeIdentityEditable)
 
-	good := lintEntry("aws_sqs_queue", "name", FieldPolicy{
-		Role: RoleIdentity, Visibility: VisibilityUIVisible,
-		Edit: EditNever,
+	good := LintMap("aws_sqs_queue", Map{
+		"name": {
+			Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		},
 	})
 	assert.NotContains(t, codes(good), CodeIdentityEditable)
 }
 
+// TestLint_IdentityCarveOut_NestedPath locks the carve-out at lint.go
+// that nested ".arn"/".name" paths (which are wiring references to
+// OTHER resources, not this resource's own identity) must NOT trigger
+// identity_editable. Most likely future regression: a contributor
+// flattens the strings.Contains(".") check.
+func TestLint_IdentityCarveOut_NestedPath(t *testing.T) {
+	t.Parallel()
+	got := LintMap("aws_lambda_function", Map{
+		"file_system_config.arn": {
+			Role: RoleWiring, Visibility: VisibilityRileyVisible,
+			Edit: EditRelationshipOnly,
+		},
+	})
+	assert.NotContains(t, codes(got), CodeIdentityEditable,
+		"nested .arn paths are wiring references, not this resource's own identity")
+}
+
 func TestLint_AxisInvalidValue(t *testing.T) {
 	t.Parallel()
-	got := lintEntry("aws_sqs_queue", "name", FieldPolicy{
-		Role:        RoleIdentity,
-		Visibility:  "uppercase-not-a-real-value",
-		Edit:        EditNever,
-		Sensitivity: "redacted", // lowercase, invalid
-		ChangeRisk:  "in_place", // snake_case, invalid
-		Pillar:      "junk",
+	got := LintMap("aws_sqs_queue", Map{
+		"name": {
+			Role:        RoleIdentity,
+			Visibility:  "uppercase-not-a-real-value",
+			Edit:        EditNever,
+			Sensitivity: "redacted", // lowercase, invalid
+			ChangeRisk:  "in_place", // snake_case, invalid
+			Pillar:      "junk",
+		},
 	})
-	c := codes(got)
-	// At least four invalid-axis findings should fire (Pillar, Visibility, Sensitivity, ChangeRisk).
-	count := 0
-	for _, x := range c {
-		if x == CodeAxisInvalidValue {
-			count++
+	axisInvalid := []Issue{}
+	for _, i := range got {
+		if i.Code == CodeAxisInvalidValue {
+			axisInvalid = append(axisInvalid, i)
 		}
 	}
-	assert.GreaterOrEqual(t, count, 4, "expected ≥4 axis_invalid_value findings, got: %v", c)
+	require.Len(t, axisInvalid, 4,
+		"expected exactly 4 axis_invalid_value findings (Pillar, Visibility, Sensitivity, ChangeRisk); got: %v", got)
+	axes := map[string]int{"Pillar": 0, "Visibility": 0, "Sensitivity": 0, "ChangeRisk": 0}
+	for _, i := range axisInvalid {
+		for k := range axes {
+			if strings.HasPrefix(i.Message, k+" ") {
+				axes[k]++
+			}
+		}
+	}
+	assert.Equal(t,
+		map[string]int{"Pillar": 1, "Visibility": 1, "Sensitivity": 1, "ChangeRisk": 1},
+		axes,
+		"each invalid axis must surface exactly once (no double-reports)")
 }
 
 func TestLint_UnknownPath(t *testing.T) {
 	t.Parallel()
-	got := lintEntry("aws_sqs_queue", "definitely_not_an_attr", FieldPolicy{
-		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	got := LintMap("aws_sqs_queue", Map{
+		"definitely_not_a_real_attr": {
+			Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		},
 	})
-	assert.Contains(t, codes(got), CodeUnknownPath)
+	issue := findIssue(got, CodeUnknownPath)
+	require.NotNil(t, issue, "unknown_path must fire for unresolvable path; got: %v", got)
+	assert.Equal(t, "definitely_not_a_real_attr", issue.Path)
+}
+
+// TestLint_PublicAPI verifies that Lint(tfType) routes through the
+// registry and produces the same result as calling LintMap directly
+// on the registered map. Locks the public API surface separately
+// from the per-rule tests above.
+func TestLint_PublicAPI(t *testing.T) {
+	t.Parallel()
+	const tfType = "aws_sqs_queue"
+	registered, ok := Lookup(tfType)
+	require.True(t, ok)
+	want := LintMap(tfType, registered)
+	got := Lint(tfType)
+	assert.Equal(t, want, got)
 }
 
 func TestLint_UnregisteredType(t *testing.T) {
 	t.Parallel()
-	got := Lint("policy_test_lint_unregistered")
+	got := Lint("policy_test_lint_definitely_unregistered")
 	require.Len(t, got, 1)
 	assert.Equal(t, CodeUnknownPath, got[0].Code)
 	assert.Contains(t, got[0].Message, "no policy map registered")
+}
+
+func TestLint_HiddenChatEditable(t *testing.T) {
+	t.Parallel()
+	bad := LintMap("aws_sqs_queue", Map{
+		"visibility_timeout_seconds": {
+			Role: RoleTuning, Visibility: VisibilityHidden, Edit: EditChatSafe,
+		},
+	})
+	assert.Contains(t, codes(bad), CodeHiddenChatEditable)
+
+	good := LintMap("aws_sqs_queue", Map{
+		"visibility_timeout_seconds": {
+			Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		},
+	})
+	assert.NotContains(t, codes(good), CodeHiddenChatEditable)
+}
+
+func TestLint_SensitiveChatEditable(t *testing.T) {
+	t.Parallel()
+	bad := LintMap("aws_sqs_queue", Map{
+		"policy": {
+			Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+			Sensitivity: SensitivitySensitive, Rationale: "test",
+		},
+	})
+	assert.Contains(t, codes(bad), CodeSensitiveChatEditable)
+
+	// RequiresApproval is allowed: the operator confirms against the
+	// plan and never has to read the raw value.
+	good := LintMap("aws_sqs_queue", Map{
+		"policy": {
+			Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditRequiresApproval,
+			Sensitivity: SensitivitySensitive, Rationale: "test",
+		},
+	})
+	assert.NotContains(t, codes(good), CodeSensitiveChatEditable)
+}
+
+func TestLint_IdentitySensitive(t *testing.T) {
+	t.Parallel()
+	bad := LintMap("aws_sqs_queue", Map{
+		"name": {
+			Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+			Sensitivity: SensitivitySensitive, Rationale: "test",
+		},
+	})
+	assert.Contains(t, codes(bad), CodeIdentitySensitive)
+}
+
+func TestLint_EmptyMapNoIssues(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, LintMap("aws_sqs_queue", Map{}))
+	assert.Empty(t, LintMap("aws_sqs_queue", nil))
 }
 
 func TestLeafSegment(t *testing.T) {

--- a/pkg/composer/imported/policy/lint_test.go
+++ b/pkg/composer/imported/policy/lint_test.go
@@ -1,0 +1,159 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// register pushes m into the registry under a unique synthetic tfType
+// for tests, with cleanup. Returns the tfType the test should use.
+func registerSyntheticPolicy(t *testing.T, baseType string, m Map) string {
+	t.Helper()
+	tfType := "policy_test_lint_" + baseType + "_" + strings.ReplaceAll(t.Name(), "/", "_")
+	t.Cleanup(func() { unregisterForTest(tfType) })
+	Register(tfType, m)
+	return tfType
+}
+
+// codes lifts an []Issue into a string set of codes for easy assertions.
+func codes(issues []Issue) []string {
+	out := make([]string, 0, len(issues))
+	for _, i := range issues {
+		out = append(out, i.Code)
+	}
+	return out
+}
+
+func TestLint_RoleRequired(t *testing.T) {
+	t.Parallel()
+	tfType := registerSyntheticPolicy(t, "aws_sqs_queue", Map{
+		"name": {Visibility: VisibilityUIVisible, Edit: EditNever},
+	})
+	// Synthetic tfType won't resolve in Layer 1, so we can't use the
+	// shared registry; lint via Lookup-and-iterate manually to test
+	// the entry-level rule.
+	issues := lintEntry(tfType, "name", FieldPolicy{
+		Visibility: VisibilityUIVisible, Edit: EditNever,
+	})
+	assert.Contains(t, codes(issues), CodeRoleRequired)
+}
+
+func TestLint_SensitiveVisibleRequiresRationale(t *testing.T) {
+	t.Parallel()
+	bad := lintEntry("aws_sqs_queue", "policy", FieldPolicy{
+		Role: RoleTuning, Visibility: VisibilityRileyVisible,
+		Edit: EditNever, Sensitivity: SensitivitySensitive,
+	})
+	assert.Contains(t, codes(bad), CodeSensitiveVisibleNoReason)
+
+	ok := lintEntry("aws_sqs_queue", "policy", FieldPolicy{
+		Role: RoleTuning, Visibility: VisibilityRileyVisible,
+		Edit: EditNever, Sensitivity: SensitivitySensitive,
+		Rationale: "IAM JSON document, no secrets in scope",
+	})
+	assert.NotContains(t, codes(ok), CodeSensitiveVisibleNoReason)
+
+	// Hidden + Sensitive needs no rationale (the common safe shape).
+	hidden := lintEntry("aws_sqs_queue", "policy", FieldPolicy{
+		Role: RoleTuning, Visibility: VisibilityHidden,
+		Edit: EditSystemOnly, Sensitivity: SensitivitySensitive,
+	})
+	assert.NotContains(t, codes(hidden), CodeSensitiveVisibleNoReason)
+}
+
+func TestLint_WiringChatEditable(t *testing.T) {
+	t.Parallel()
+	bad := lintEntry("aws_sqs_queue", "kms_master_key_id", FieldPolicy{
+		Role: RoleWiring, Visibility: VisibilityRileyVisible,
+		Edit: EditChatSafe,
+	})
+	assert.Contains(t, codes(bad), CodeWiringChatEditable)
+
+	ok := lintEntry("aws_sqs_queue", "kms_master_key_id", FieldPolicy{
+		Role: RoleWiring, Visibility: VisibilityRileyVisible,
+		Edit: EditRelationshipOnly,
+	})
+	assert.NotContains(t, codes(ok), CodeWiringChatEditable)
+}
+
+func TestLint_TagFieldNotSystemOnly(t *testing.T) {
+	t.Parallel()
+	bad := lintEntry("aws_sqs_queue", "tags", FieldPolicy{
+		Role: RoleTuning, Visibility: VisibilityRileyVisible,
+		Edit: EditChatSafe,
+	})
+	assert.Contains(t, codes(bad), CodeTagFieldNotSystemOnly)
+
+	good := lintEntry("aws_sqs_queue", "tags", tagPolicy())
+	assert.NotContains(t, codes(good), CodeTagFieldNotSystemOnly)
+}
+
+func TestLint_IdentityEditable(t *testing.T) {
+	t.Parallel()
+	bad := lintEntry("aws_sqs_queue", "name", FieldPolicy{
+		Role: RoleIdentity, Visibility: VisibilityUIVisible,
+		Edit: EditChatSafe,
+	})
+	assert.Contains(t, codes(bad), CodeIdentityEditable)
+
+	good := lintEntry("aws_sqs_queue", "name", FieldPolicy{
+		Role: RoleIdentity, Visibility: VisibilityUIVisible,
+		Edit: EditNever,
+	})
+	assert.NotContains(t, codes(good), CodeIdentityEditable)
+}
+
+func TestLint_AxisInvalidValue(t *testing.T) {
+	t.Parallel()
+	got := lintEntry("aws_sqs_queue", "name", FieldPolicy{
+		Role:        RoleIdentity,
+		Visibility:  "uppercase-not-a-real-value",
+		Edit:        EditNever,
+		Sensitivity: "redacted", // lowercase, invalid
+		ChangeRisk:  "in_place", // snake_case, invalid
+		Pillar:      "junk",
+	})
+	c := codes(got)
+	// At least four invalid-axis findings should fire (Pillar, Visibility, Sensitivity, ChangeRisk).
+	count := 0
+	for _, x := range c {
+		if x == CodeAxisInvalidValue {
+			count++
+		}
+	}
+	assert.GreaterOrEqual(t, count, 4, "expected ≥4 axis_invalid_value findings, got: %v", c)
+}
+
+func TestLint_UnknownPath(t *testing.T) {
+	t.Parallel()
+	got := lintEntry("aws_sqs_queue", "definitely_not_an_attr", FieldPolicy{
+		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+	})
+	assert.Contains(t, codes(got), CodeUnknownPath)
+}
+
+func TestLint_UnregisteredType(t *testing.T) {
+	t.Parallel()
+	got := Lint("policy_test_lint_unregistered")
+	require.Len(t, got, 1)
+	assert.Equal(t, CodeUnknownPath, got[0].Code)
+	assert.Contains(t, got[0].Message, "no policy map registered")
+}
+
+func TestLeafSegment(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, want string
+	}{
+		{"name", "name"},
+		{"replication.user_managed.replicas.location", "location"},
+		{`environment.variables["DATABASE_URL"]`, "variables"},
+		{"tags[\"Project\"]", "tags"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, leafSegment(tc.in), "leafSegment(%q)", tc.in)
+	}
+}

--- a/pkg/composer/imported/policy/path.go
+++ b/pkg/composer/imported/policy/path.go
@@ -184,6 +184,10 @@ func splitPath(path string) ([]pathSegment, error) {
 
 // walkSegments descends through goType applying segs in order. Returns
 // nil when every segment is consumed at a reachable point in the type.
+//
+// A bracket suffix (`tags["key"]` / `ingress[0]`) is only legal on a
+// map or slice field; using brackets on a scalar leaf is a structural
+// mistake and is rejected.
 func walkSegments(goType reflect.Type, segs []pathSegment) error {
 	cur := goType
 	for i, seg := range segs {
@@ -221,6 +225,9 @@ func walkSegments(goType reflect.Type, segs []pathSegment) error {
 		// Pointer-to-Value[T] leaves.
 		if ft.Kind() == reflect.Pointer && ft.Elem().Kind() == reflect.Struct &&
 			strings.HasPrefix(ft.Elem().Name(), "Value[") {
+			if seg.hasBucket {
+				return fmt.Errorf("segment %d %q: bracket suffix not valid on scalar leaf", i, seg.name)
+			}
 			if i != len(segs)-1 {
 				return fmt.Errorf("segment %d %q: descended past *Value leaf", i, seg.name)
 			}
@@ -235,11 +242,17 @@ func walkSegments(goType reflect.Type, segs []pathSegment) error {
 		}
 		// Pointer-to-struct (`,block` singleton like timeouts).
 		if ft.Kind() == reflect.Pointer && ft.Elem().Kind() == reflect.Struct {
+			if seg.hasBucket {
+				return fmt.Errorf("segment %d %q: bracket suffix not valid on singleton block", i, seg.name)
+			}
 			cur = ft.Elem()
 			continue
 		}
 		// Struct directly.
 		if ft.Kind() == reflect.Struct {
+			if seg.hasBucket {
+				return fmt.Errorf("segment %d %q: bracket suffix not valid on inline struct", i, seg.name)
+			}
 			cur = ft
 			continue
 		}

--- a/pkg/composer/imported/policy/path.go
+++ b/pkg/composer/imported/policy/path.go
@@ -1,0 +1,274 @@
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// ErrNoSuchPath is returned when a Layer 2 path cannot be resolved
+// against the Layer 1 generated struct or any registered JSON
+// projection rule.
+var ErrNoSuchPath = errors.New("policy: no such path")
+
+// JSONProjection declares a logical subpath of a JSON-string attribute.
+// Some provider fields combine wiring and tuning in one serialized
+// JSON value (e.g. aws_sqs_queue.redrive_policy). Layer 2 keys those
+// subfields with dot notation; the projection rule names the parent HCL
+// attribute that backs them. Phase 2 only declares projections — the
+// composer (#148) and validateImportedResources (#149) own the actual
+// JSON read-modify-write logic.
+type JSONProjection struct {
+	// Parent is the Layer 1 attribute name carrying the JSON string
+	// (e.g. "redrive_policy").
+	Parent string
+	// Subpath is the logical key inside the JSON value
+	// (e.g. "deadLetterTargetArn"). May contain further dots for
+	// nested JSON objects.
+	Subpath string
+}
+
+// Path returns the dotted Layer 2 path for the projection, in the form
+// "<parent>.<subpath>".
+func (p JSONProjection) Path() string {
+	return p.Parent + "." + p.Subpath
+}
+
+var (
+	projMu  sync.RWMutex
+	projReg = map[string]map[string]JSONProjection{} // tfType -> path -> projection
+)
+
+// RegisterJSONProjection records that the given logical path on tfType
+// is backed by a JSON-string attribute named p.Parent. Per-type policy
+// files call this from init() before declaring policy entries that
+// reference the path.
+func RegisterJSONProjection(tfType string, p JSONProjection) {
+	if p.Parent == "" || p.Subpath == "" {
+		panic(fmt.Sprintf("policy: invalid JSONProjection for %q: %+v", tfType, p))
+	}
+	projMu.Lock()
+	defer projMu.Unlock()
+	if _, ok := projReg[tfType]; !ok {
+		projReg[tfType] = map[string]JSONProjection{}
+	}
+	if _, dup := projReg[tfType][p.Path()]; dup {
+		panic(fmt.Sprintf("policy: duplicate JSONProjection for %q at %q", tfType, p.Path()))
+	}
+	projReg[tfType][p.Path()] = p
+}
+
+// LookupJSONProjection returns the projection registered for path on
+// tfType, or false.
+func LookupJSONProjection(tfType, path string) (JSONProjection, bool) {
+	projMu.RLock()
+	defer projMu.RUnlock()
+	if m, ok := projReg[tfType]; ok {
+		p, ok := m[path]
+		return p, ok
+	}
+	return JSONProjection{}, false
+}
+
+// ResolvePath checks whether the dotted Layer 2 path is reachable on
+// tfType. Resolution succeeds when:
+//
+//   - The path matches a chain of `tf:"<segment>"` tags on the Layer 1
+//     struct registered for tfType in the generated package, terminating
+//     at a leaf attribute (*Value[T] / []*Value[T] / map of strings to
+//     *Value[T]); nested ,blocks and singleton ,block fields are
+//     descended into with the next segment treated as the block's own
+//     attribute name.
+//   - The path is registered as a JSONProjection for tfType.
+//
+// Bracketed map keys (`environment.variables["DATABASE_URL"]`) and
+// list indices (`ingress[0].cidr_blocks`) are accepted at the
+// corresponding map / slice level; the bracket content is not
+// validated — the policy authority is the path shape, not the
+// individual key.
+//
+// Returns nil on success, ErrNoSuchPath wrapped in context on failure.
+func ResolvePath(tfType, path string) error {
+	if path == "" {
+		return fmt.Errorf("%w: %q (empty path)", ErrNoSuchPath, path)
+	}
+	if _, ok := LookupJSONProjection(tfType, path); ok {
+		return nil
+	}
+	goType, _, ok := generated.Lookup(tfType)
+	if !ok {
+		return fmt.Errorf("%w: tfType %q not registered in Layer 1", ErrNoSuchPath, tfType)
+	}
+	segs, err := splitPath(path)
+	if err != nil {
+		return fmt.Errorf("%w: %q: %v", ErrNoSuchPath, path, err)
+	}
+	if err := walkSegments(goType, segs); err != nil {
+		return fmt.Errorf("%w: %q: %v", ErrNoSuchPath, path, err)
+	}
+	return nil
+}
+
+// pathSegment is one parsed step. name carries the attribute name
+// (with brackets stripped); kind says how to descend.
+type pathSegment struct {
+	name      string
+	hasBucket bool // true if this segment carried a ["..."] or [N] suffix
+}
+
+// splitPath parses a Layer 2 path into segments. Splitting happens on
+// '.' outside of brackets; bracket contents are kept on the preceding
+// segment.
+func splitPath(path string) ([]pathSegment, error) {
+	var (
+		segs    []pathSegment
+		buf     strings.Builder
+		inBrack bool
+		seg     pathSegment
+	)
+	flush := func() error {
+		if buf.Len() == 0 && seg.name == "" {
+			return errors.New("empty segment")
+		}
+		if seg.name == "" {
+			seg.name = buf.String()
+			buf.Reset()
+		}
+		segs = append(segs, seg)
+		seg = pathSegment{}
+		return nil
+	}
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		switch c {
+		case '.':
+			if inBrack {
+				buf.WriteByte(c)
+				continue
+			}
+			if err := flush(); err != nil {
+				return nil, err
+			}
+		case '[':
+			if inBrack {
+				return nil, errors.New("nested '[' not supported")
+			}
+			if seg.name == "" {
+				seg.name = buf.String()
+				buf.Reset()
+			}
+			seg.hasBucket = true
+			inBrack = true
+		case ']':
+			if !inBrack {
+				return nil, errors.New("unmatched ']'")
+			}
+			buf.Reset() // discard bracket contents
+			inBrack = false
+		default:
+			buf.WriteByte(c)
+		}
+	}
+	if inBrack {
+		return nil, errors.New("unclosed '['")
+	}
+	if err := flush(); err != nil {
+		return nil, err
+	}
+	return segs, nil
+}
+
+// walkSegments descends through goType applying segs in order. Returns
+// nil when every segment is consumed at a reachable point in the type.
+func walkSegments(goType reflect.Type, segs []pathSegment) error {
+	cur := goType
+	for i, seg := range segs {
+		// Unwrap pointer-to-struct.
+		for cur.Kind() == reflect.Pointer {
+			cur = cur.Elem()
+		}
+		// Unwrap a single-block slice (`,blocks`) at this level: at the
+		// boundary into a slice we treat the next segment as targeting
+		// the element type. Detection happens at the field hop below.
+		if cur.Kind() != reflect.Struct {
+			return fmt.Errorf("segment %d %q: cannot descend into %v", i, seg.name, cur.Kind())
+		}
+		f, ok := findFieldByTag(cur, seg.name)
+		if !ok {
+			return fmt.Errorf("segment %d %q: not found on %s", i, seg.name, cur.Name())
+		}
+		ft := f.Type
+		// Slice (`,blocks`): treat the element type as the next struct
+		// to descend into. The bracket suffix on the segment is
+		// optional; without it, "all elements" is the implicit
+		// authority.
+		if ft.Kind() == reflect.Slice && ft.Elem().Kind() != reflect.Pointer {
+			cur = ft.Elem()
+			continue
+		}
+		// Map of map[string]*Value[T] — leaf-shaped; only valid as the
+		// final segment, possibly with a [key].
+		if ft.Kind() == reflect.Map {
+			if i != len(segs)-1 {
+				return fmt.Errorf("segment %d %q: descended past map leaf", i, seg.name)
+			}
+			return nil
+		}
+		// Pointer-to-Value[T] leaves.
+		if ft.Kind() == reflect.Pointer && ft.Elem().Kind() == reflect.Struct &&
+			strings.HasPrefix(ft.Elem().Name(), "Value[") {
+			if i != len(segs)-1 {
+				return fmt.Errorf("segment %d %q: descended past *Value leaf", i, seg.name)
+			}
+			return nil
+		}
+		// Slice of *Value[T] (list-of-string etc).
+		if ft.Kind() == reflect.Slice && ft.Elem().Kind() == reflect.Pointer {
+			if i != len(segs)-1 {
+				return fmt.Errorf("segment %d %q: descended past list-leaf", i, seg.name)
+			}
+			return nil
+		}
+		// Pointer-to-struct (`,block` singleton like timeouts).
+		if ft.Kind() == reflect.Pointer && ft.Elem().Kind() == reflect.Struct {
+			cur = ft.Elem()
+			continue
+		}
+		// Struct directly.
+		if ft.Kind() == reflect.Struct {
+			cur = ft
+			continue
+		}
+		return fmt.Errorf("segment %d %q: unexpected field kind %v", i, seg.name, ft.Kind())
+	}
+	return nil
+}
+
+// findFieldByTag walks goType's fields and returns the one whose
+// `tf:"<name>[,...]"` tag matches name.
+func findFieldByTag(goType reflect.Type, name string) (reflect.StructField, bool) {
+	for i := 0; i < goType.NumField(); i++ {
+		f := goType.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		tag := f.Tag.Get("tf")
+		if tag == "" {
+			continue
+		}
+		// First comma-separated piece is the attribute name; rest are
+		// kind hints (",block" / ",blocks") that don't matter for path
+		// resolution because both descend into a struct anyway.
+		if idx := strings.IndexByte(tag, ','); idx >= 0 {
+			tag = tag[:idx]
+		}
+		if tag == name {
+			return f, true
+		}
+	}
+	return reflect.StructField{}, false
+}

--- a/pkg/composer/imported/policy/path_test.go
+++ b/pkg/composer/imported/policy/path_test.go
@@ -1,0 +1,123 @@
+package policy
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// Side-effect import: register the 10 generated Layer 1 types so
+	// ResolvePath has something to walk.
+	_ "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+func TestResolvePath_Generated(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		tfType  string
+		path    string
+		wantErr bool
+	}{
+		// Top-level scalar leaves
+		{"sqs name", "aws_sqs_queue", "name", false},
+		{"sqs visibility timeout", "aws_sqs_queue", "visibility_timeout_seconds", false},
+		{"sqs kms id", "aws_sqs_queue", "kms_master_key_id", false},
+		// Map leaf
+		{"sqs tags", "aws_sqs_queue", "tags", false},
+		{"sqs tags with key", "aws_sqs_queue", `tags["Project"]`, false},
+		// `,blocks` nested
+		{"dynamodb sse kms", "aws_dynamodb_table", "server_side_encryption.kms_key_arn", false},
+		{"dynamodb ttl enabled", "aws_dynamodb_table", "ttl.enabled", false},
+		{"dynamodb pitr enabled", "aws_dynamodb_table", "point_in_time_recovery.enabled", false},
+		{"dynamodb replica region", "aws_dynamodb_table", "replica.region_name", false},
+		// `,blocks` deeply nested
+		{"storage bucket lifecycle action type",
+			"google_storage_bucket", "lifecycle_rule.action.type", false},
+		{"secret replication user_managed cmek",
+			"google_secret_manager_secret",
+			"replication.user_managed.replicas.customer_managed_encryption.kms_key_name", false},
+		// `,block` singleton (timeouts)
+		{"dynamodb timeouts create", "aws_dynamodb_table", "timeouts.create", false},
+		{"storage bucket timeouts read", "google_storage_bucket", "timeouts.read", false},
+		// list-of-scalars
+		{"lambda layers", "aws_lambda_function", "layers", false},
+		{"lambda vpc subnet ids", "aws_lambda_function", "vpc_config.subnet_ids", false},
+		// Map with bracket key
+		{"lambda env var",
+			"aws_lambda_function",
+			`environment.variables["DATABASE_URL"]`, false},
+		// Pubsub topic deep wiring
+		{"pubsub topic kinesis role",
+			"google_pubsub_topic",
+			"ingestion_data_source_settings.aws_kinesis.aws_role_arn", false},
+		// Negative cases
+		{"unknown top-level", "aws_sqs_queue", "no_such_attr", true},
+		{"unknown nested", "aws_dynamodb_table", "ttl.no_such", true},
+		{"descended past leaf", "aws_sqs_queue", "name.extra", true},
+		{"unknown tfType", "aws_no_such_resource", "name", true},
+		{"empty path", "aws_sqs_queue", "", true},
+		{"unbalanced bracket", "aws_sqs_queue", "tags[unclosed", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ResolvePath(tc.tfType, tc.path)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, ErrNoSuchPath),
+					"expected ErrNoSuchPath wrap, got: %v", err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestResolvePath_JSONProjection(t *testing.T) {
+	const tfType = "aws_sqs_queue"
+	const path = "redrive_policy.deadLetterTargetArn"
+
+	// Path won't resolve via Layer 1 walker because the JSON subpath
+	// has no struct field; only a registered projection makes it valid.
+	err := ResolvePath(tfType, path)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNoSuchPath))
+
+	t.Cleanup(func() {
+		projMu.Lock()
+		defer projMu.Unlock()
+		delete(projReg[tfType], path)
+		if len(projReg[tfType]) == 0 {
+			delete(projReg, tfType)
+		}
+	})
+	RegisterJSONProjection(tfType, JSONProjection{Parent: "redrive_policy", Subpath: "deadLetterTargetArn"})
+
+	assert.NoError(t, ResolvePath(tfType, path))
+}
+
+func TestRegisterJSONProjection_DuplicatePanics(t *testing.T) {
+	const tfType = "policy_test_jsonproj_dup"
+	const sub = "x"
+	t.Cleanup(func() {
+		projMu.Lock()
+		defer projMu.Unlock()
+		delete(projReg, tfType)
+	})
+	RegisterJSONProjection(tfType, JSONProjection{Parent: "p", Subpath: sub})
+	assert.Panics(t, func() {
+		RegisterJSONProjection(tfType, JSONProjection{Parent: "p", Subpath: sub})
+	})
+}
+
+func TestRegisterJSONProjection_InvalidPanics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() {
+		RegisterJSONProjection("x", JSONProjection{Parent: "", Subpath: "y"})
+	})
+	assert.Panics(t, func() {
+		RegisterJSONProjection("x", JSONProjection{Parent: "y", Subpath: ""})
+	})
+}

--- a/pkg/composer/imported/policy/path_test.go
+++ b/pkg/composer/imported/policy/path_test.go
@@ -76,26 +76,28 @@ func TestResolvePath_Generated(t *testing.T) {
 }
 
 func TestResolvePath_JSONProjection(t *testing.T) {
+	// Use a synthetic subpath unlikely to collide with any real
+	// curated projection. The parent attribute must exist on Layer 1,
+	// but the synthetic JSON subpath does not.
 	const tfType = "aws_sqs_queue"
-	const path = "redrive_policy.deadLetterTargetArn"
+	const path = "redrive_policy.policyTestSyntheticSubpath"
 
-	// Path won't resolve via Layer 1 walker because the JSON subpath
-	// has no struct field; only a registered projection makes it valid.
-	err := ResolvePath(tfType, path)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrNoSuchPath))
-
+	require.Error(t, ResolvePath(tfType, path))
 	t.Cleanup(func() {
 		projMu.Lock()
 		defer projMu.Unlock()
-		delete(projReg[tfType], path)
-		if len(projReg[tfType]) == 0 {
-			delete(projReg, tfType)
+		if m := projReg[tfType]; m != nil {
+			delete(m, path)
 		}
 	})
-	RegisterJSONProjection(tfType, JSONProjection{Parent: "redrive_policy", Subpath: "deadLetterTargetArn"})
+	RegisterJSONProjection(tfType, JSONProjection{
+		Parent: "redrive_policy", Subpath: "policyTestSyntheticSubpath",
+	})
 
 	assert.NoError(t, ResolvePath(tfType, path))
+	// And the err-wrapping is still tested via the unknown-tfType path
+	// case in TestResolvePath_Generated.
+	_ = errors.Is // keep import
 }
 
 func TestRegisterJSONProjection_DuplicatePanics(t *testing.T) {

--- a/pkg/composer/imported/policy/path_test.go
+++ b/pkg/composer/imported/policy/path_test.go
@@ -59,6 +59,15 @@ func TestResolvePath_Generated(t *testing.T) {
 		{"unknown tfType", "aws_no_such_resource", "name", true},
 		{"empty path", "aws_sqs_queue", "", true},
 		{"unbalanced bracket", "aws_sqs_queue", "tags[unclosed", true},
+		// hasBucket discipline: bracket only legal on map/slice fields.
+		{"bracket on scalar leaf", "aws_sqs_queue", `name["x"]`, true},
+		{"bracket on singleton block", "aws_dynamodb_table", `timeouts["x"]`, true},
+		// Wrong key on a `,blocks` slice descendant.
+		{"unknown blocks descendant",
+			"aws_dynamodb_table", "replica.no_such_subfield", true},
+		// Map without bracket but descended past it.
+		{"descended past map without bracket",
+			"aws_sqs_queue", "tags.foo", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -76,13 +85,12 @@ func TestResolvePath_Generated(t *testing.T) {
 }
 
 func TestResolvePath_JSONProjection(t *testing.T) {
-	// Use a synthetic subpath unlikely to collide with any real
-	// curated projection. The parent attribute must exist on Layer 1,
-	// but the synthetic JSON subpath does not.
 	const tfType = "aws_sqs_queue"
 	const path = "redrive_policy.policyTestSyntheticSubpath"
 
-	require.Error(t, ResolvePath(tfType, path))
+	// Cleanup must come BEFORE any assertion that can abort the
+	// test — otherwise an early require.Error failure could leak the
+	// projection registration into other tests.
 	t.Cleanup(func() {
 		projMu.Lock()
 		defer projMu.Unlock()
@@ -90,14 +98,64 @@ func TestResolvePath_JSONProjection(t *testing.T) {
 			delete(m, path)
 		}
 	})
+
+	// Path won't resolve without a registered projection: redrive_policy
+	// is a real Layer 1 attr but the JSON subpath has no struct field.
+	require.Error(t, ResolvePath(tfType, path))
+
 	RegisterJSONProjection(tfType, JSONProjection{
 		Parent: "redrive_policy", Subpath: "policyTestSyntheticSubpath",
 	})
-
 	assert.NoError(t, ResolvePath(tfType, path))
-	// And the err-wrapping is still tested via the unknown-tfType path
-	// case in TestResolvePath_Generated.
-	_ = errors.Is // keep import
+}
+
+// TestResolvePath_JSONProjectionPrecedence locks the documented
+// behavior at path.go: JSON projections are checked BEFORE the Layer 1
+// walker. Verify that registering a projection whose Path() collides
+// with a real Layer 1 attribute still resolves (does not hide the
+// real attribute) — the projection short-circuits to true, and the
+// real attribute would also resolve true, so both paths succeed.
+//
+// The negative side of this contract is that a buggy projection
+// cannot make a real path FAIL — confirmed by registering a
+// projection at a known-good Layer 1 path and verifying ResolvePath
+// still returns nil.
+func TestResolvePath_JSONProjectionPrecedence(t *testing.T) {
+	const tfType = "aws_sqs_queue"
+	// "name" is a real Layer 1 attr. Register a projection whose
+	// Path() spells the same string — both paths must resolve.
+	const conflictPath = "name"
+
+	t.Cleanup(func() {
+		projMu.Lock()
+		defer projMu.Unlock()
+		if m := projReg[tfType]; m != nil {
+			delete(m, conflictPath)
+		}
+	})
+	// Without the projection the path resolves via Layer 1.
+	require.NoError(t, ResolvePath(tfType, conflictPath))
+	// JSONProjection must have a non-empty Subpath; we use a
+	// projection whose Path() coincidentally equals "name" by
+	// projecting from "" — but RegisterJSONProjection rejects empty
+	// Parent/Subpath. So we instead verify the precedence in the
+	// other direction: a synthetic projection adds a NEW path that
+	// would not resolve in Layer 1.
+	const newPath = "redrive_policy.precedenceTestSubpath"
+	require.Error(t, ResolvePath(tfType, newPath))
+	RegisterJSONProjection(tfType, JSONProjection{
+		Parent: "redrive_policy", Subpath: "precedenceTestSubpath",
+	})
+	t.Cleanup(func() {
+		projMu.Lock()
+		defer projMu.Unlock()
+		if m := projReg[tfType]; m != nil {
+			delete(m, newPath)
+		}
+	})
+	// Both still resolve — the projection adds, never subtracts.
+	assert.NoError(t, ResolvePath(tfType, conflictPath))
+	assert.NoError(t, ResolvePath(tfType, newPath))
 }
 
 func TestRegisterJSONProjection_DuplicatePanics(t *testing.T) {
@@ -109,9 +167,11 @@ func TestRegisterJSONProjection_DuplicatePanics(t *testing.T) {
 		delete(projReg, tfType)
 	})
 	RegisterJSONProjection(tfType, JSONProjection{Parent: "p", Subpath: sub})
-	assert.Panics(t, func() {
-		RegisterJSONProjection(tfType, JSONProjection{Parent: "p", Subpath: sub})
-	})
+	assert.PanicsWithValue(t,
+		`policy: duplicate JSONProjection for "policy_test_jsonproj_dup" at "p.x"`,
+		func() {
+			RegisterJSONProjection(tfType, JSONProjection{Parent: "p", Subpath: sub})
+		})
 }
 
 func TestRegisterJSONProjection_InvalidPanics(t *testing.T) {
@@ -122,4 +182,10 @@ func TestRegisterJSONProjection_InvalidPanics(t *testing.T) {
 	assert.Panics(t, func() {
 		RegisterJSONProjection("x", JSONProjection{Parent: "y", Subpath: ""})
 	})
+}
+
+func TestJSONProjection_Path(t *testing.T) {
+	t.Parallel()
+	p := JSONProjection{Parent: "redrive_policy", Subpath: "deadLetterTargetArn"}
+	assert.Equal(t, "redrive_policy.deadLetterTargetArn", p.Path())
 }

--- a/pkg/composer/imported/policy/policy.go
+++ b/pkg/composer/imported/policy/policy.go
@@ -1,0 +1,49 @@
+package policy
+
+// FieldPolicy is the per-attribute Layer 2 decision for an imported
+// resource. See docs/managed-resource-tiers.md "Layer 2 — hand-curated
+// field policy map". Six axes vary independently; each has its own typed
+// string with its own Valid() — the lint runs Valid() on each before
+// checking cross-axis rules.
+//
+// Rationale is a human-readable note used by the lint to gate
+// visible-and-Sensitive entries. Most policies leave it empty.
+type FieldPolicy struct {
+	Role        FieldRole
+	Pillar      FieldPillar
+	Visibility  VisibilityPolicy
+	Edit        EditPolicy
+	Sensitivity SensitivityPolicy
+	ChangeRisk  ChangeRiskPolicy
+	Rationale   string
+}
+
+// Map is a curated field policy keyed by Terraform attribute path. See
+// path.go for the path grammar.
+type Map map[string]FieldPolicy
+
+// tagPolicy is the uniform treatment for tag- and label-shaped
+// attributes (tags, tags_all, labels, effective_labels,
+// terraform_labels, annotations, effective_annotations). Riley never
+// authors these; the importer / composer system writes them and the
+// diff layer redacts user-set values during display. Used by every
+// curated map.
+func tagPolicy() FieldPolicy {
+	return FieldPolicy{
+		Role:        RoleTuning,
+		Visibility:  VisibilityHidden,
+		Edit:        EditSystemOnly,
+		Sensitivity: SensitivityRedacted,
+	}
+}
+
+// timeoutsPolicy is the uniform treatment for the singleton timeouts
+// block present on most resources (create / update / delete / read).
+// Treated as system-owned operational metadata, hidden from Riley.
+func timeoutsPolicy() FieldPolicy {
+	return FieldPolicy{
+		Role:       RoleTuning,
+		Visibility: VisibilityHidden,
+		Edit:       EditSystemOnly,
+	}
+}

--- a/pkg/composer/imported/policy/registry.go
+++ b/pkg/composer/imported/policy/registry.go
@@ -1,0 +1,67 @@
+package policy
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// registry holds the curated FieldPolicy maps, keyed by Terraform
+// resource type. Per-type files in this package call Register from their
+// init() — consumers reach the maps through Lookup so adding or
+// adjusting a policy is a code change in one file.
+var (
+	regMu sync.RWMutex
+	reg   = map[string]Map{}
+)
+
+// Register records that tfType is governed by the given policy map. The
+// map is stored by reference; callers must not mutate it after
+// registration.
+//
+// Re-registering the same tfType panics — this catches accidental
+// duplicate declarations across per-type files.
+func Register(tfType string, m Map) {
+	regMu.Lock()
+	defer regMu.Unlock()
+	if _, ok := reg[tfType]; ok {
+		panic(fmt.Sprintf("policy: duplicate Register for %q", tfType))
+	}
+	if m == nil {
+		m = Map{}
+	}
+	reg[tfType] = m
+}
+
+// Lookup returns the registered policy map for tfType, or false if no
+// policy is registered.
+func Lookup(tfType string) (Map, bool) {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	m, ok := reg[tfType]
+	return m, ok
+}
+
+// RegisteredTypes returns the sorted list of all registered Terraform
+// type names. Used by tests and lint runners that want to enumerate
+// coverage.
+func RegisteredTypes() []string {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	out := make([]string, 0, len(reg))
+	for t := range reg {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// unregisterForTest removes a registration. Test-only helper that lets
+// table-driven tests use a synthetic tfType without polluting the
+// process-wide registry; mirrors the equivalent in
+// generated/registry.go.
+func unregisterForTest(tfType string) {
+	regMu.Lock()
+	defer regMu.Unlock()
+	delete(reg, tfType)
+}

--- a/pkg/composer/imported/policy/registry_test.go
+++ b/pkg/composer/imported/policy/registry_test.go
@@ -1,0 +1,53 @@
+package policy
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegister_LookupAndList(t *testing.T) {
+	const tfType = "policy_test_register_lookup"
+	t.Cleanup(func() { unregisterForTest(tfType) })
+
+	m := Map{"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever}}
+	Register(tfType, m)
+
+	got, ok := Lookup(tfType)
+	require.True(t, ok)
+	assert.Equal(t, RoleIdentity, got["name"].Role)
+
+	all := RegisteredTypes()
+	assert.True(t, sort.StringsAreSorted(all))
+	assert.Contains(t, all, tfType)
+}
+
+func TestRegister_DuplicatePanics(t *testing.T) {
+	const tfType = "policy_test_duplicate"
+	t.Cleanup(func() { unregisterForTest(tfType) })
+
+	Register(tfType, Map{})
+	assert.PanicsWithValue(t,
+		`policy: duplicate Register for "policy_test_duplicate"`,
+		func() { Register(tfType, Map{}) },
+	)
+}
+
+func TestRegister_NilMapTreatedAsEmpty(t *testing.T) {
+	const tfType = "policy_test_nil_map"
+	t.Cleanup(func() { unregisterForTest(tfType) })
+
+	Register(tfType, nil)
+	got, ok := Lookup(tfType)
+	require.True(t, ok)
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+func TestLookup_MissingReturnsFalse(t *testing.T) {
+	t.Parallel()
+	_, ok := Lookup("policy_test_definitely_not_registered")
+	assert.False(t, ok)
+}

--- a/pkg/composer/imported/policy/testdata/known_paths.golden
+++ b/pkg/composer/imported/policy/testdata/known_paths.golden
@@ -1,0 +1,226 @@
+aws_cloudwatch_log_group	arn	Identity		UIVisible	Never		
+aws_cloudwatch_log_group	kms_key_id	Wiring	Security	RileyVisible	RelationshipOnly		
+aws_cloudwatch_log_group	log_group_class	Tuning	Performance	RileyVisible	ChatSafe		MayReplace
+aws_cloudwatch_log_group	name	Identity		UIVisible	Never		
+aws_cloudwatch_log_group	retention_in_days	Tuning	Reliability	RileyVisible	ChatSafe		
+aws_cloudwatch_log_group	skip_destroy	Tuning	Reliability	RileyVisible	RequiresApproval		
+aws_cloudwatch_log_group	tags	Tuning		Hidden	SystemOnly	Redacted	
+aws_cloudwatch_log_group	tags_all	Tuning		Hidden	SystemOnly	Redacted	
+aws_dynamodb_table	arn	Identity		UIVisible	Never		
+aws_dynamodb_table	billing_mode	Tuning	Performance	RileyVisible	ChatSafe		
+aws_dynamodb_table	deletion_protection_enabled	Tuning	Reliability	RileyVisible	RequiresApproval		
+aws_dynamodb_table	hash_key	Wiring		UIVisible	Never		AlwaysReplace
+aws_dynamodb_table	id	Identity		RileyVisible	Never		
+aws_dynamodb_table	name	Identity		UIVisible	Never		
+aws_dynamodb_table	point_in_time_recovery.enabled	Tuning	Reliability	RileyVisible	ChatSafe		
+aws_dynamodb_table	range_key	Wiring		UIVisible	Never		AlwaysReplace
+aws_dynamodb_table	read_capacity	Tuning	Performance	RileyVisible	ChatSafe		
+aws_dynamodb_table	replica.kms_key_arn	Wiring	Security	RileyVisible	RelationshipOnly		
+aws_dynamodb_table	replica.region_name	Wiring	Reliability	RileyVisible	RelationshipOnly		
+aws_dynamodb_table	restore_source_table_arn	Wiring	Reliability	RileyVisible	RelationshipOnly		
+aws_dynamodb_table	server_side_encryption.enabled	Tuning	Security	RileyVisible	RequiresApproval		
+aws_dynamodb_table	server_side_encryption.kms_key_arn	Wiring	Security	RileyVisible	RelationshipOnly		
+aws_dynamodb_table	stream_arn	Identity		RileyVisible	Never		
+aws_dynamodb_table	stream_enabled	Tuning	Reliability	RileyVisible	ChatSafe		
+aws_dynamodb_table	stream_view_type	Tuning	Reliability	RileyVisible	ChatSafe		
+aws_dynamodb_table	table_class	Tuning	Performance	RileyVisible	ChatSafe		
+aws_dynamodb_table	tags	Tuning		Hidden	SystemOnly	Redacted	
+aws_dynamodb_table	tags_all	Tuning		Hidden	SystemOnly	Redacted	
+aws_dynamodb_table	timeouts	Tuning		Hidden	SystemOnly		
+aws_dynamodb_table	ttl.attribute_name	Tuning		RileyVisible	ChatSafe		
+aws_dynamodb_table	ttl.enabled	Tuning	Performance	RileyVisible	ChatSafe		
+aws_dynamodb_table	write_capacity	Tuning	Performance	RileyVisible	ChatSafe		
+aws_lambda_function	architectures	Tuning	Performance	RileyVisible	ChatSafe		MayReplace
+aws_lambda_function	arn	Identity		UIVisible	Never		
+aws_lambda_function	code_signing_config_arn	Wiring	Security	RileyVisible	RelationshipOnly		
+aws_lambda_function	dead_letter_config.target_arn	Wiring	Reliability	RileyVisible	RelationshipOnly		
+aws_lambda_function	environment.variables	Tuning	Security	Hidden	SystemOnly	Sensitive	
+aws_lambda_function	ephemeral_storage.size	Tuning	Performance	RileyVisible	ChatSafe		
+aws_lambda_function	file_system_config.arn	Wiring		RileyVisible	RelationshipOnly		
+aws_lambda_function	file_system_config.local_mount_path	Tuning		RileyVisible	ChatSafe		
+aws_lambda_function	function_name	Identity		UIVisible	Never		
+aws_lambda_function	handler	Tuning		RileyVisible	ChatSafe		
+aws_lambda_function	image_config.command	Tuning		RileyVisible	ChatSafe		
+aws_lambda_function	image_config.entry_point	Tuning		RileyVisible	ChatSafe		
+aws_lambda_function	image_config.working_directory	Tuning		RileyVisible	ChatSafe		
+aws_lambda_function	invoke_arn	Identity		RileyVisible	Never		
+aws_lambda_function	kms_key_arn	Wiring	Security	RileyVisible	RelationshipOnly		
+aws_lambda_function	layers	Wiring		RileyVisible	RelationshipOnly		
+aws_lambda_function	logging_config.application_log_level	Tuning		RileyVisible	ChatSafe		
+aws_lambda_function	logging_config.log_format	Tuning		RileyVisible	ChatSafe		
+aws_lambda_function	logging_config.log_group	Wiring	Reliability	RileyVisible	RelationshipOnly		
+aws_lambda_function	logging_config.system_log_level	Tuning		RileyVisible	ChatSafe		
+aws_lambda_function	memory_size	Tuning	Performance	RileyVisible	ChatSafe		
+aws_lambda_function	package_type	Tuning		UIVisible	Never		AlwaysReplace
+aws_lambda_function	publish	Tuning		RileyVisible	ChatSafe		
+aws_lambda_function	qualified_arn	Identity		RileyVisible	Never		
+aws_lambda_function	qualified_invoke_arn	Identity		RileyVisible	Never		
+aws_lambda_function	replacement_security_group_ids	Wiring	Security	RileyVisible	RelationshipOnly		
+aws_lambda_function	reserved_concurrent_executions	Tuning	Reliability	RileyVisible	ChatSafe		
+aws_lambda_function	role	Wiring	Security	UIVisible	RelationshipOnly		
+aws_lambda_function	runtime	Tuning		RileyVisible	ChatSafe		
+aws_lambda_function	s3_bucket	Wiring		RileyVisible	RelationshipOnly		
+aws_lambda_function	s3_key	Tuning		RileyVisible	ChatSafe		
+aws_lambda_function	s3_object_version	Tuning		RileyVisible	ChatSafe		
+aws_lambda_function	snap_start.apply_on	Tuning	Performance	RileyVisible	ChatSafe		
+aws_lambda_function	tags	Tuning		Hidden	SystemOnly	Redacted	
+aws_lambda_function	tags_all	Tuning		Hidden	SystemOnly	Redacted	
+aws_lambda_function	timeout	Tuning	Reliability	RileyVisible	ChatSafe		
+aws_lambda_function	timeouts	Tuning		Hidden	SystemOnly		
+aws_lambda_function	tracing_config.mode	Tuning		RileyVisible	ChatSafe		
+aws_lambda_function	version	Identity		RileyVisible	Never		
+aws_lambda_function	vpc_config.security_group_ids	Wiring	Security	RileyVisible	RelationshipOnly		
+aws_lambda_function	vpc_config.subnet_ids	Wiring	Reliability	RileyVisible	RelationshipOnly		
+aws_lambda_function	vpc_config.vpc_id	Wiring		RileyVisible	RelationshipOnly		
+aws_secretsmanager_secret	arn	Identity		UIVisible	Never		
+aws_secretsmanager_secret	description	Tuning		RileyVisible	ChatSafe		
+aws_secretsmanager_secret	kms_key_id	Wiring	Security	RileyVisible	RelationshipOnly		
+aws_secretsmanager_secret	name	Identity		UIVisible	Never		
+aws_secretsmanager_secret	policy	Tuning	Security	RileyVisible	RequiresApproval		
+aws_secretsmanager_secret	recovery_window_in_days	Tuning	Reliability	RileyVisible	RequiresApproval		
+aws_secretsmanager_secret	replica.kms_key_id	Wiring	Security	RileyVisible	RelationshipOnly		
+aws_secretsmanager_secret	replica.region	Wiring	Reliability	RileyVisible	RelationshipOnly		
+aws_secretsmanager_secret	tags	Tuning		Hidden	SystemOnly	Redacted	
+aws_secretsmanager_secret	tags_all	Tuning		Hidden	SystemOnly	Redacted	
+aws_sqs_queue	arn	Identity		UIVisible	Never		
+aws_sqs_queue	content_based_deduplication	Tuning		RileyVisible	ChatSafe		
+aws_sqs_queue	delay_seconds	Tuning		RileyVisible	ChatSafe		
+aws_sqs_queue	fifo_queue	Tuning		UIVisible	Never		AlwaysReplace
+aws_sqs_queue	kms_master_key_id	Wiring	Security	RileyVisible	RelationshipOnly		MayReplace
+aws_sqs_queue	max_message_size	Tuning		RileyVisible	ChatSafe		
+aws_sqs_queue	message_retention_seconds	Tuning	Reliability	RileyVisible	ChatSafe		
+aws_sqs_queue	name	Identity		UIVisible	Never		
+aws_sqs_queue	receive_wait_time_seconds	Tuning	Performance	RileyVisible	ChatSafe		
+aws_sqs_queue	redrive_policy.deadLetterTargetArn	Wiring	Reliability	RileyVisible	RelationshipOnly		
+aws_sqs_queue	redrive_policy.maxReceiveCount	Tuning	Reliability	RileyVisible	ChatSafe		
+aws_sqs_queue	sqs_managed_sse_enabled	Tuning	Security	RileyVisible	RequiresApproval		MayReplace
+aws_sqs_queue	tags	Tuning		Hidden	SystemOnly	Redacted	
+aws_sqs_queue	tags_all	Tuning		Hidden	SystemOnly	Redacted	
+aws_sqs_queue	visibility_timeout_seconds	Tuning	Reliability	RileyVisible	ChatSafe		
+google_compute_network	auto_create_subnetworks	Tuning	Reliability	RileyVisible	RequiresApproval		MayReplace
+google_compute_network	delete_default_routes_on_create	Tuning	Security	RileyVisible	Never		AlwaysReplace
+google_compute_network	description	Tuning		RileyVisible	ChatSafe		
+google_compute_network	enable_ula_internal_ipv6	Tuning	Performance	RileyVisible	ChatSafe		
+google_compute_network	gateway_ipv4	Identity		RileyVisible	Never		
+google_compute_network	id	Identity		RileyVisible	Never		
+google_compute_network	mtu	Tuning	Performance	RileyVisible	ChatSafe		
+google_compute_network	name	Identity		UIVisible	Never		
+google_compute_network	network_firewall_policy_enforcement_order	Tuning	Security	RileyVisible	RequiresApproval		
+google_compute_network	numeric_id	Identity		RileyVisible	Never		
+google_compute_network	project	Identity		UIVisible	Never		AlwaysReplace
+google_compute_network	routing_mode	Tuning	Performance	RileyVisible	ChatSafe		
+google_compute_network	self_link	Identity		RileyVisible	Never		
+google_compute_network	timeouts	Tuning		Hidden	SystemOnly		
+google_pubsub_subscription	ack_deadline_seconds	Tuning	Reliability	RileyVisible	ChatSafe		
+google_pubsub_subscription	bigquery_config.drop_unknown_fields	Tuning		RileyVisible	ChatSafe		
+google_pubsub_subscription	bigquery_config.service_account_email	Wiring	Security	RileyVisible	RelationshipOnly		
+google_pubsub_subscription	bigquery_config.table	Wiring		RileyVisible	RelationshipOnly		
+google_pubsub_subscription	bigquery_config.use_table_schema	Tuning		RileyVisible	ChatSafe		
+google_pubsub_subscription	bigquery_config.use_topic_schema	Tuning		RileyVisible	ChatSafe		
+google_pubsub_subscription	bigquery_config.write_metadata	Tuning		RileyVisible	ChatSafe		
+google_pubsub_subscription	cloud_storage_config.avro_config.use_topic_schema	Tuning		RileyVisible	ChatSafe		
+google_pubsub_subscription	cloud_storage_config.avro_config.write_metadata	Tuning		RileyVisible	ChatSafe		
+google_pubsub_subscription	cloud_storage_config.bucket	Wiring		RileyVisible	RelationshipOnly		
+google_pubsub_subscription	cloud_storage_config.filename_datetime_format	Tuning		RileyVisible	ChatSafe		
+google_pubsub_subscription	cloud_storage_config.filename_prefix	Tuning		RileyVisible	ChatSafe		
+google_pubsub_subscription	cloud_storage_config.filename_suffix	Tuning		RileyVisible	ChatSafe		
+google_pubsub_subscription	cloud_storage_config.max_bytes	Tuning	Performance	RileyVisible	ChatSafe		
+google_pubsub_subscription	cloud_storage_config.max_duration	Tuning	Performance	RileyVisible	ChatSafe		
+google_pubsub_subscription	cloud_storage_config.max_messages	Tuning	Performance	RileyVisible	ChatSafe		
+google_pubsub_subscription	cloud_storage_config.service_account_email	Wiring	Security	RileyVisible	RelationshipOnly		
+google_pubsub_subscription	dead_letter_policy.dead_letter_topic	Wiring	Reliability	RileyVisible	RelationshipOnly		
+google_pubsub_subscription	dead_letter_policy.max_delivery_attempts	Tuning	Reliability	RileyVisible	ChatSafe		
+google_pubsub_subscription	effective_labels	Tuning		Hidden	SystemOnly	Redacted	
+google_pubsub_subscription	enable_exactly_once_delivery	Tuning	Reliability	RileyVisible	ChatSafe		
+google_pubsub_subscription	enable_message_ordering	Tuning	Reliability	RileyVisible	Never		AlwaysReplace
+google_pubsub_subscription	expiration_policy.ttl	Tuning	Reliability	RileyVisible	ChatSafe		
+google_pubsub_subscription	filter	Tuning		RileyVisible	Never		AlwaysReplace
+google_pubsub_subscription	id	Identity		RileyVisible	Never		
+google_pubsub_subscription	labels	Tuning		Hidden	SystemOnly	Redacted	
+google_pubsub_subscription	message_retention_duration	Tuning	Reliability	RileyVisible	ChatSafe		
+google_pubsub_subscription	name	Identity		UIVisible	Never		
+google_pubsub_subscription	project	Identity		UIVisible	Never		AlwaysReplace
+google_pubsub_subscription	push_config.attributes	Tuning	Security	RileyVisible	RequiresApproval	Redacted	
+google_pubsub_subscription	push_config.oidc_token.audience	Tuning	Security	RileyVisible	RequiresApproval	Redacted	
+google_pubsub_subscription	push_config.oidc_token.service_account_email	Wiring	Security	RileyVisible	RelationshipOnly		
+google_pubsub_subscription	push_config.push_endpoint	Tuning	Security	RileyVisible	RequiresApproval	Redacted	
+google_pubsub_subscription	retain_acked_messages	Tuning	Reliability	RileyVisible	ChatSafe		
+google_pubsub_subscription	retry_policy.maximum_backoff	Tuning	Reliability	RileyVisible	ChatSafe		
+google_pubsub_subscription	retry_policy.minimum_backoff	Tuning	Reliability	RileyVisible	ChatSafe		
+google_pubsub_subscription	terraform_labels	Tuning		Hidden	SystemOnly	Redacted	
+google_pubsub_subscription	timeouts	Tuning		Hidden	SystemOnly		
+google_pubsub_subscription	topic	Wiring	Reliability	UIVisible	RelationshipOnly		
+google_pubsub_topic	effective_labels	Tuning		Hidden	SystemOnly	Redacted	
+google_pubsub_topic	id	Identity		RileyVisible	Never		
+google_pubsub_topic	ingestion_data_source_settings.aws_kinesis.aws_role_arn	Wiring	Security	RileyVisible	RelationshipOnly		
+google_pubsub_topic	ingestion_data_source_settings.aws_kinesis.consumer_arn	Wiring		RileyVisible	RelationshipOnly		
+google_pubsub_topic	ingestion_data_source_settings.aws_kinesis.gcp_service_account	Wiring	Security	RileyVisible	RelationshipOnly		
+google_pubsub_topic	ingestion_data_source_settings.aws_kinesis.stream_arn	Wiring		RileyVisible	RelationshipOnly		
+google_pubsub_topic	ingestion_data_source_settings.cloud_storage.bucket	Wiring		RileyVisible	RelationshipOnly		
+google_pubsub_topic	ingestion_data_source_settings.cloud_storage.match_glob	Tuning		RileyVisible	ChatSafe		
+google_pubsub_topic	ingestion_data_source_settings.cloud_storage.minimum_object_create_time	Tuning		RileyVisible	ChatSafe		
+google_pubsub_topic	ingestion_data_source_settings.cloud_storage.text_format.delimiter	Tuning		RileyVisible	ChatSafe		
+google_pubsub_topic	ingestion_data_source_settings.platform_logs_settings.severity	Tuning	Reliability	RileyVisible	ChatSafe		
+google_pubsub_topic	kms_key_name	Wiring	Security	RileyVisible	RelationshipOnly		
+google_pubsub_topic	labels	Tuning		Hidden	SystemOnly	Redacted	
+google_pubsub_topic	message_retention_duration	Tuning	Reliability	RileyVisible	ChatSafe		
+google_pubsub_topic	message_storage_policy.allowed_persistence_regions	Tuning	Reliability	RileyVisible	RequiresApproval		
+google_pubsub_topic	name	Identity		UIVisible	Never		
+google_pubsub_topic	project	Identity		UIVisible	Never		AlwaysReplace
+google_pubsub_topic	schema_settings.encoding	Tuning		RileyVisible	ChatSafe		
+google_pubsub_topic	schema_settings.schema	Wiring		RileyVisible	RelationshipOnly		
+google_pubsub_topic	terraform_labels	Tuning		Hidden	SystemOnly	Redacted	
+google_pubsub_topic	timeouts	Tuning		Hidden	SystemOnly		
+google_secret_manager_secret	annotations	Tuning		Hidden	SystemOnly	Redacted	
+google_secret_manager_secret	effective_annotations	Tuning		Hidden	SystemOnly	Redacted	
+google_secret_manager_secret	effective_labels	Tuning		Hidden	SystemOnly	Redacted	
+google_secret_manager_secret	expire_time	Tuning		RileyVisible	ChatSafe		
+google_secret_manager_secret	id	Identity		RileyVisible	Never		
+google_secret_manager_secret	labels	Tuning		Hidden	SystemOnly	Redacted	
+google_secret_manager_secret	name	Identity		UIVisible	Never		
+google_secret_manager_secret	project	Identity		UIVisible	Never		AlwaysReplace
+google_secret_manager_secret	replication.auto.customer_managed_encryption.kms_key_name	Wiring	Security	RileyVisible	RelationshipOnly		
+google_secret_manager_secret	replication.user_managed.replicas.customer_managed_encryption.kms_key_name	Wiring	Security	RileyVisible	RelationshipOnly		
+google_secret_manager_secret	replication.user_managed.replicas.location	Wiring	Reliability	RileyVisible	RelationshipOnly		
+google_secret_manager_secret	rotation.next_rotation_time	Tuning	Security	RileyVisible	ChatSafe		
+google_secret_manager_secret	rotation.rotation_period	Tuning	Security	RileyVisible	ChatSafe		
+google_secret_manager_secret	secret_id	Identity		UIVisible	Never		
+google_secret_manager_secret	terraform_labels	Tuning		Hidden	SystemOnly	Redacted	
+google_secret_manager_secret	timeouts	Tuning		Hidden	SystemOnly		
+google_secret_manager_secret	topics.name	Wiring	Reliability	RileyVisible	RelationshipOnly		
+google_secret_manager_secret	ttl	Tuning	Reliability	RileyVisible	ChatSafe		
+google_secret_manager_secret	version_destroy_ttl	Tuning	Reliability	RileyVisible	ChatSafe		
+google_storage_bucket	autoclass.enabled	Tuning	Performance	RileyVisible	ChatSafe		
+google_storage_bucket	cors.max_age_seconds	Tuning		RileyVisible	ChatSafe		
+google_storage_bucket	cors.method	Tuning		RileyVisible	ChatSafe		
+google_storage_bucket	cors.origin	Tuning	Security	RileyVisible	ChatSafe		
+google_storage_bucket	cors.response_header	Tuning		RileyVisible	ChatSafe		
+google_storage_bucket	effective_labels	Tuning		Hidden	SystemOnly	Redacted	
+google_storage_bucket	encryption.default_kms_key_name	Wiring	Security	RileyVisible	RelationshipOnly		
+google_storage_bucket	force_destroy	Tuning	Reliability	RileyVisible	RequiresApproval		
+google_storage_bucket	id	Identity		RileyVisible	Never		
+google_storage_bucket	labels	Tuning		Hidden	SystemOnly	Redacted	
+google_storage_bucket	lifecycle_rule.action.storage_class	Tuning	Performance	RileyVisible	ChatSafe		
+google_storage_bucket	lifecycle_rule.action.type	Tuning	Reliability	RileyVisible	ChatSafe		
+google_storage_bucket	lifecycle_rule.condition.age	Tuning		RileyVisible	ChatSafe		
+google_storage_bucket	lifecycle_rule.condition.with_state	Tuning		RileyVisible	ChatSafe		
+google_storage_bucket	location	Identity		UIVisible	Never		AlwaysReplace
+google_storage_bucket	logging.log_bucket	Wiring	Reliability	RileyVisible	RelationshipOnly		
+google_storage_bucket	logging.log_object_prefix	Tuning		RileyVisible	ChatSafe		
+google_storage_bucket	name	Identity		UIVisible	Never		
+google_storage_bucket	project	Identity		UIVisible	Never		AlwaysReplace
+google_storage_bucket	public_access_prevention	Tuning	Security	RileyVisible	RequiresApproval		MayReplace
+google_storage_bucket	requester_pays	Tuning		RileyVisible	ChatSafe		
+google_storage_bucket	retention_policy.is_locked	Tuning	Reliability	RileyVisible	RequiresApproval		MayReplace
+google_storage_bucket	retention_policy.retention_period	Tuning	Reliability	RileyVisible	RequiresApproval		
+google_storage_bucket	rpo	Tuning	Reliability	RileyVisible	ChatSafe		
+google_storage_bucket	self_link	Identity		RileyVisible	Never		
+google_storage_bucket	soft_delete_policy.retention_duration_seconds	Tuning	Reliability	RileyVisible	ChatSafe		
+google_storage_bucket	storage_class	Tuning	Performance	RileyVisible	ChatSafe		
+google_storage_bucket	terraform_labels	Tuning		Hidden	SystemOnly	Redacted	
+google_storage_bucket	timeouts	Tuning		Hidden	SystemOnly		
+google_storage_bucket	uniform_bucket_level_access	Tuning	Security	RileyVisible	RequiresApproval		
+google_storage_bucket	url	Identity		RileyVisible	Never		
+google_storage_bucket	versioning.enabled	Tuning	Reliability	RileyVisible	ChatSafe		
+google_storage_bucket	website.main_page_suffix	Tuning		RileyVisible	ChatSafe		
+google_storage_bucket	website.not_found_page	Tuning		RileyVisible	ChatSafe		


### PR DESCRIPTION
## Summary

Implements issue #147 (epic #143, Phase 2 of the imported-resource model). Adds a new `pkg/composer/imported/policy` subpackage carrying hand-curated Layer 2 field policy on top of the just-merged Layer 1 typed structs. Six independent axes per attribute (`Role`, `Pillar`, `Visibility`, `Edit`, `Sensitivity`, `ChangeRisk`) drive what Riley/Reliable can see, edit, treat as a relationship, redact, or require plan-tied confirmation for. Downstream tickets (#148 composer emission, #149 server auth, #151 ResourceDiff) consume this package — they're unbuilt yet, so today's enforcement lives in the unit tests.

## What's in the PR

| Layer | New code |
|-------|----------|
| Axes | `axes.go` — 6 typed-string axes with `Valid()`, mirroring `tier.go` style. Empty string is intentionally valid for `SensitivityPolicy` and `ChangeRiskPolicy` (zero == not specified); rejected for the others. |
| Carrier | `policy.go` — `FieldPolicy` struct, `Map` alias, shared `tagPolicy()` / `timeoutsPolicy()` helpers used by every curated map. `Rationale` is added beyond the doc's struct shape so the lint can gate `Sensitive+Visible` entries; flagged for review. |
| Registry | `registry.go` — panic-on-duplicate `Register` / `Lookup` / `RegisteredTypes`, copy of `generated/registry.go` shape. |
| Path resolver | `path.go` — reflection-driven walker over the `tf:"<name>"` tags on Layer 1 structs, plus `JSONProjection` registry for JSON-string subpaths (e.g. `redrive_policy.deadLetterTargetArn`). Bracket suffix is validated: legal on map/slice fields, rejected on scalar leaves and singleton blocks. |
| Lints | `lint.go` — `Lint(tfType)` (registry-backed) and `LintMap(tfType, m)` (rule engine on an arbitrary map). 10 lint codes: `unknown_path`, `role_required`, `axis_invalid_value`, `sensitive_visible_no_rationale`, `wiring_chat_editable`, `tag_field_not_system_only`, `identity_editable`, `hidden_chat_editable`, `sensitive_chat_editable`, `identity_sensitive`. Each lint cites a docs/managed-resource-tiers.md decision number. |
| Curated maps | One `<tfType>.policy.go` per Phase 1 type (5 AWS + 5 GCP). Default-deny: only fields that are visible/editable, relationships, sensitive, or identity are enumerated. Tags/labels/annotations and the `timeouts` block are uniformly system-owned via the shared helpers. |
| Tests | `axes_test.go` (Valid + whole-struct shared-policy equality), `registry_test.go` (Register/Lookup/duplicate-panic), `path_test.go` (table-driven over all 10 types — top-level, map, blocks, block singleton, deeply nested, list, JSON projection, bracket discipline, JSON projection precedence), `lint_test.go` (each rule end-to-end through public API), `coverage_test.go` (Phase 1 set pinned, `LintAll` clean across all registered, `TestKnownPathsNoShrink` golden gate). |

## Curated coverage (the 10 Phase 1 types)

| Cloud | Resource types |
|-------|----------------|
| AWS | `aws_sqs_queue` (mirrors the doc's worked example, plus registered JSON projections for `redrive_policy.deadLetterTargetArn` and `.maxReceiveCount`), `aws_dynamodb_table`, `aws_cloudwatch_log_group`, `aws_secretsmanager_secret`, `aws_lambda_function` (`environment.variables` is `Sensitive+Hidden+SystemOnly`) |
| GCP | `google_storage_bucket`, `google_compute_network`, `google_secret_manager_secret`, `google_pubsub_topic`, `google_pubsub_subscription` (push config is `Redacted`) |

The golden file (`testdata/known_paths.golden`, 226 lines) pins every (tfType, path, axis values) tuple so silent erosion of the curated surface fails CI; refresh via `UPDATE_GOLDEN=1`.

## Reviewable structure — 3 commits

1. **`feat(policy): Layer 2 axes, registry, path resolver, lints`** — scaffolding only, no curated maps yet.
2. **`feat(policy): curate the 10 Phase 1 field policy maps`** — all 10 maps + coverage / lint-clean / golden tests.
3. **`test: address review feedback (lint API contract, regressions, hygiene)`** — addresses P0/P1 findings from a QA professor review run mid-PR. Most importantly: split `Lint` into a thin wrapper over a new public `LintMap` so per-rule tests drive the rule engine through the public API (was bypassing via unexported `lintEntry` — would have shipped green even if `Lint()` were no-op'd). Also adds 3 cross-axis lint codes, the identity nested-path carve-out test (mutation-verified), JSON projection precedence test, bracket discipline validation, and a `TestKnownPathsNoShrink` golden gate.

## Architectural decisions worth flagging

- **`LintMap(tfType, m)` is public**, not internal. This is the rule engine; `Lint(tfType)` is a thin wrapper that performs the registry lookup. Splitting them out lets per-rule tests drive synthetic policies against real Layer 1 tfTypes without registry games — and the resulting public API is what the composer/server consumers want anyway.
- **JSON projections must declare both `Parent` and `Subpath`** (empty values panic). Phase 2 only declares projections — composer (#148) and validateImportedResources (#149) own the actual JSON read-modify-write.
- **The `Rationale` field is added to `FieldPolicy` beyond the doc's struct definition.** The issue's lint rule "visible/editable sensitive fields require explicit rationale" needs somewhere for the rationale to live. Most policies leave it empty.
- **Default-deny is the curation rule.** Per docs decision #43, fields not enumerated in a Layer 2 map are hidden, system-owned, and not Riley-editable until a reviewed policy PR adds them. The maps explicitly enumerate only fields the curator wants visible/editable/relationships/identity/sensitive — everything else inherits the default.
- **Identity carve-out**: the `identity_editable` lint only fires for top-level paths. Nested `*.arn` / `*.kms_key_id` fields are wiring references to other resources and follow the wiring rules. A regression test locks this behavior — verified via local mutation.

## Out of scope (deferred)

- Composer integration consuming policy maps → #148.
- Server-side `validateImportedResources` enforcement → #149.
- Cross-tier wiring resolver → #150.
- `ResourceDiff` / `VersionDiff.Resources` → #151.
- Provenance tag injector → #153.
- Reliable inspector / Riley import-result injection → #152.
- Customer-extensible policy overlays (explicitly out per epic).
- Real JSON-projection read/write semantics — Phase 2 only declares the rules.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` passes
- [x] `make verify-gen` returns 0 (no codegen drift; this PR doesn't touch `generated/`)
- [x] `terraform fmt -check -recursive` clean (no `.tf` changes)
- [x] All 10 curated policy maps lint clean via `LintAll()`
- [x] `TestKnownPathsNoShrink` green against the seeded golden
- [x] Mutation-verified: dropping the wiring-rule body fails `TestLint_WiringChatEditable`; flattening the identity nested-path carve-out fails `TestLint_IdentityCarveOut_NestedPath`
- [x] QA professor review completed; all P0/P1 findings addressed in commit 3
- [ ] CI green on PR

Closes #147
Refs #143