### PR TITLE
feat(gcp): per-deploy random_id suffix for state-loss recovery (#159)

### DIFF
--- a/examples/mobileapi/main.tf
+++ b/examples/mobileapi/main.tf
@@ -39,7 +39,8 @@ module "gcp_gcs" {
 }
 
 module "gcp_cloud_logging" {
-  source  = "../../gcp/cloud_logging"
-  project = var.gcp_cloud_logging_project
-  region  = var.gcp_cloud_logging_region
+  source     = "../../gcp/cloud_logging"
+  project    = var.gcp_cloud_logging_project
+  project_id = var.gcp_cloud_logging_project_id
+  region     = var.gcp_cloud_logging_region
 }

--- a/examples/mobileapi/providers.tf
+++ b/examples/mobileapi/providers.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
 

--- a/examples/mobileapi/variables.tf
+++ b/examples/mobileapi/variables.tf
@@ -2,6 +2,10 @@ variable "gcp_cloud_logging_project" {
   type = string
 }
 
+variable "gcp_cloud_logging_project_id" {
+  type = string
+}
+
 variable "gcp_cloud_logging_region" {
   type = string
 }

--- a/gcp/api_gateway/main.tf
+++ b/gcp/api_gateway/main.tf
@@ -11,7 +11,17 @@ terraform {
       source  = "hashicorp/google-beta"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
+}
+
+# Per-deploy suffix so retries after state loss don't 409 on the api / gateway
+# IDs (issue #159). The api_config_id already rotates per-apply via timestamp().
+resource "random_id" "suffix" {
+  byte_length = 4
 }
 
 # Enable API Gateway API
@@ -40,7 +50,7 @@ resource "google_project_service" "service_control" {
 resource "google_api_gateway_api" "this" {
   provider = google-beta
   project  = var.project_id
-  api_id   = "${var.project}-api"
+  api_id   = "${var.project}-api-${random_id.suffix.hex}"
 
   labels = {
     project = var.project
@@ -59,7 +69,7 @@ resource "google_api_gateway_api_config" "this" {
   provider      = google-beta
   project       = var.project_id
   api           = google_api_gateway_api.this.api_id
-  api_config_id = "${var.project}-api-config-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  api_config_id = "${var.project}-api-config-${random_id.suffix.hex}-${formatdate("YYYYMMDDhhmmss", timestamp())}"
 
   openapi_documents {
     document {
@@ -90,7 +100,7 @@ resource "google_api_gateway_gateway" "this" {
   project    = var.project_id
   region     = var.region
   api_config = google_api_gateway_api_config.this.id
-  gateway_id = "${var.project}-gateway"
+  gateway_id = "${var.project}-gateway-${random_id.suffix.hex}"
 
   labels = {
     project = var.project

--- a/gcp/api_gateway/main.tf
+++ b/gcp/api_gateway/main.tf
@@ -19,9 +19,30 @@ terraform {
 }
 
 # Per-deploy suffix so retries after state loss don't 409 on the api / gateway
-# IDs (issue #159). The api_config_id already rotates per-apply via timestamp().
+# IDs (issue #159).
 resource "random_id" "suffix" {
   byte_length = 4
+}
+
+# Rotate api_config_id only when the OpenAPI spec actually changes.
+# Previously this used formatdate(timestamp()) which forced replacement
+# on every apply — functionally fine (api configs are versioned and
+# immutable by design, so the intended deployment model IS create + swap)
+# but surfaces as drift_detected=true on every plan even when the spec
+# hasn't changed. Reliable's tfstatus flow then shows a false drift
+# signal on otherwise-quiescent stacks.
+#
+# Using random_id with keepers tied to md5(var.openapi_spec):
+#   - same spec → same hex → same config_id → no churn → no drift
+#   - spec change → new hex → new config created, gateway switches
+#     (create_before_destroy on the api_config below makes this safe)
+#   - state loss → random_id regenerates → fresh config (the operator
+#     cleans up the orphan in GCP — config_ids don't 409 on retry)
+resource "random_id" "config_version" {
+  byte_length = 4
+  keepers = {
+    spec_hash = md5(var.openapi_spec)
+  }
 }
 
 # Enable API Gateway API
@@ -66,14 +87,10 @@ resource "google_api_gateway_api" "this" {
 
 # API Config (OpenAPI spec)
 resource "google_api_gateway_api_config" "this" {
-  provider = google-beta
-  project  = var.project_id
-  api      = google_api_gateway_api.this.api_id
-  # timestamp() already changes every apply (and survives state loss — a
-  # fresh apply just gets a fresh timestamp), so the random_id suffix is
-  # redundant here. Kept on api_id and gateway_id where there's no
-  # timestamp to fall back on.
-  api_config_id = "${var.project}-api-config-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  provider      = google-beta
+  project       = var.project_id
+  api           = google_api_gateway_api.this.api_id
+  api_config_id = "${var.project}-api-config-${random_id.config_version.hex}"
 
   openapi_documents {
     document {

--- a/gcp/api_gateway/main.tf
+++ b/gcp/api_gateway/main.tf
@@ -66,10 +66,14 @@ resource "google_api_gateway_api" "this" {
 
 # API Config (OpenAPI spec)
 resource "google_api_gateway_api_config" "this" {
-  provider      = google-beta
-  project       = var.project_id
-  api           = google_api_gateway_api.this.api_id
-  api_config_id = "${var.project}-api-config-${random_id.suffix.hex}-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  provider = google-beta
+  project  = var.project_id
+  api      = google_api_gateway_api.this.api_id
+  # timestamp() already changes every apply (and survives state loss — a
+  # fresh apply just gets a fresh timestamp), so the random_id suffix is
+  # redundant here. Kept on api_id and gateway_id where there's no
+  # timestamp to fall back on.
+  api_config_id = "${var.project}-api-config-${formatdate("YYYYMMDDhhmmss", timestamp())}"
 
   openapi_documents {
     document {

--- a/gcp/backups/main.tf
+++ b/gcp/backups/main.tf
@@ -8,14 +8,24 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
+}
+
+# Per-deploy suffix so retries after state loss dodge the 7-day soft-delete
+# name reservation on the backups bucket and the snapshot policy name (issue #159).
+resource "random_id" "suffix" {
+  byte_length = 4
 }
 
 # GCS bucket for backups
 resource "google_storage_bucket" "backups" {
   count    = var.enable_gcs_backups ? 1 : 0
   project  = var.project_id
-  name     = "${var.project}-backups-${var.region}"
+  name     = "${var.project}-backups-${var.region}-${random_id.suffix.hex}"
   location = var.region
 
   uniform_bucket_level_access = true
@@ -55,7 +65,7 @@ resource "google_storage_bucket" "backups" {
 resource "google_compute_resource_policy" "snapshot_schedule" {
   count   = var.enable_compute_snapshots ? 1 : 0
   project = var.project_id
-  name    = "${var.project}-snapshot-schedule"
+  name    = "${var.project}-snapshot-schedule-${random_id.suffix.hex}"
   region  = var.region
 
   snapshot_schedule_policy {

--- a/gcp/bastion/main.tf
+++ b/gcp/bastion/main.tf
@@ -8,16 +8,27 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
 
+# Per-deploy suffix so retries after state loss don't 409 on the existing
+# instance / service account / firewall names (issue #159). Service account
+# IDs are capped at 30 chars, so the SA uses a 4-char suffix slice.
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 locals {
-  instance_name = "${var.project}-bastion"
+  instance_name = "${var.project}-bastion-${random_id.suffix.hex}"
 }
 
 # Dedicated service account for the bastion
 resource "google_service_account" "bastion" {
-  account_id   = "${var.project}-bastion"
+  account_id   = "${var.project}-bastion-${substr(random_id.suffix.hex, 0, 4)}"
   display_name = "${var.project} Bastion Host"
   project      = var.project_id
 }

--- a/gcp/cloud_armor/main.tf
+++ b/gcp/cloud_armor/main.tf
@@ -8,11 +8,21 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
 
+# Per-deploy suffix so retries after state loss don't 409 on the security
+# policy name (issue #159).
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 locals {
-  policy_name = "${var.project}-${var.name}"
+  policy_name = "${var.project}-${var.name}-${random_id.suffix.hex}"
 }
 
 resource "google_compute_security_policy" "policy" {

--- a/gcp/cloud_build/main.tf
+++ b/gcp/cloud_build/main.tf
@@ -19,6 +19,7 @@ resource "random_id" "suffix" {
 }
 
 resource "google_cloudbuild_trigger" "trigger" {
+  project  = var.project_id
   name     = "${var.project}-trigger-${random_id.suffix.hex}"
   filename = "cloudbuild.yaml"
   trigger_template {

--- a/gcp/cloud_build/main.tf
+++ b/gcp/cloud_build/main.tf
@@ -1,5 +1,25 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
+  }
+}
+
+# Per-deploy suffix so retries after state loss don't 409 on the trigger
+# name (issue #159).
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 resource "google_cloudbuild_trigger" "trigger" {
-  name     = "main-trigger"
+  name     = "${var.project}-trigger-${random_id.suffix.hex}"
   filename = "cloudbuild.yaml"
   trigger_template {
     branch_name = "main"

--- a/gcp/cloud_build/variables.tf
+++ b/gcp/cloud_build/variables.tf
@@ -1,2 +1,21 @@
-variable "project" { type = string }
+variable "project" {
+  description = "Naming/label prefix for stack resources (NOT a GCP project ID — see var.project_id)."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+}
+
+variable "project_id" {
+  description = "Real GCP project ID where resources are created (e.g. \"my-prod-12345\"). Distinct from var.project, which is the naming/label prefix and need not be a valid GCP project ID."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "project_id must be a valid GCP project ID: 6–30 chars, lowercase letters/digits/hyphens, start with a letter, end alphanumeric."
+  }
+}
+
 variable "region" { type = string }

--- a/gcp/cloud_functions/main.tf
+++ b/gcp/cloud_functions/main.tf
@@ -15,15 +15,16 @@ terraform {
   }
 }
 
-locals {
-  function_name = "${var.project}-${var.function_name}"
-  bucket_name   = var.source_archive_bucket != "" ? var.source_archive_bucket : "${var.project}-gcf-source-${random_id.bucket_suffix[0].hex}"
+# Per-deploy suffix for the function name so retries after state loss don't
+# 409 on the existing function (issue #159). Reused for the auto-created
+# source bucket so both rotate together.
+resource "random_id" "suffix" {
+  byte_length = 4
 }
 
-# Random suffix for auto-created source bucket
-resource "random_id" "bucket_suffix" {
-  count       = var.source_archive_bucket == "" ? 1 : 0
-  byte_length = 4
+locals {
+  function_name = "${var.project}-${var.function_name}-${random_id.suffix.hex}"
+  bucket_name   = var.source_archive_bucket != "" ? var.source_archive_bucket : "${var.project}-gcf-source-${random_id.suffix.hex}"
 }
 
 # Source code bucket (created only if not provided)

--- a/gcp/cloud_functions/main.tf
+++ b/gcp/cloud_functions/main.tf
@@ -22,6 +22,18 @@ resource "random_id" "suffix" {
   byte_length = 4
 }
 
+# Migrate state from the pre-#159 conditional `random_id.bucket_suffix[0]`
+# resource to the unconditional `random_id.suffix` resource. For stacks
+# that were deployed with source_archive_bucket = "" (the prior count = 1
+# case), this preserves the existing hex value so the auto-created source
+# bucket name does not change on first apply after upgrade. For stacks
+# deployed with a caller-supplied bucket (prior count = 0), the moved
+# block is a no-op and `random_id.suffix` is created fresh.
+moved {
+  from = random_id.bucket_suffix[0]
+  to   = random_id.suffix
+}
+
 locals {
   function_name = "${var.project}-${var.function_name}-${random_id.suffix.hex}"
   bucket_name   = var.source_archive_bucket != "" ? var.source_archive_bucket : "${var.project}-gcf-source-${random_id.suffix.hex}"

--- a/gcp/cloud_logging/main.tf
+++ b/gcp/cloud_logging/main.tf
@@ -19,6 +19,7 @@ resource "random_id" "suffix" {
 }
 
 resource "google_logging_project_sink" "sink" {
+  project     = var.project_id
   name        = "${var.project}-sink-${random_id.suffix.hex}"
   destination = "storage.googleapis.com/${var.project}-logs"
   filter      = "severity >= ERROR"

--- a/gcp/cloud_logging/main.tf
+++ b/gcp/cloud_logging/main.tf
@@ -1,5 +1,25 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
+  }
+}
+
+# Per-deploy suffix so retries after state loss don't 409 on the sink name
+# (issue #159).
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 resource "google_logging_project_sink" "sink" {
-  name        = "main-sink"
+  name        = "${var.project}-sink-${random_id.suffix.hex}"
   destination = "storage.googleapis.com/${var.project}-logs"
   filter      = "severity >= ERROR"
 }

--- a/gcp/cloud_logging/variables.tf
+++ b/gcp/cloud_logging/variables.tf
@@ -1,2 +1,21 @@
-variable "project" { type = string }
+variable "project" {
+  description = "Naming/label prefix for stack resources (NOT a GCP project ID — see var.project_id)."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+}
+
+variable "project_id" {
+  description = "Real GCP project ID where resources are created (e.g. \"my-prod-12345\"). Distinct from var.project, which is the naming/label prefix and need not be a valid GCP project ID."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "project_id must be a valid GCP project ID: 6–30 chars, lowercase letters/digits/hyphens, start with a letter, end alphanumeric."
+  }
+}
+
 variable "region" { type = string }

--- a/gcp/cloud_run/main.tf
+++ b/gcp/cloud_run/main.tf
@@ -1,8 +1,14 @@
 # Cloud Run Service
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service
 
+# Per-deploy suffix so retries after state loss don't 409 on the existing
+# Cloud Run service name (issue #159).
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 locals {
-  service_name = "${var.project}-${var.service_name}"
+  service_name = "${var.project}-${var.service_name}-${random_id.suffix.hex}"
 }
 
 resource "google_cloud_run_v2_service" "main" {

--- a/gcp/cloud_run/versions.tf
+++ b/gcp/cloud_run/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }

--- a/gcp/cloudsql/main.tf
+++ b/gcp/cloudsql/main.tf
@@ -1,8 +1,15 @@
 # Cloud SQL Module using terraform-google-sql-db
 # https://github.com/terraform-google-modules/terraform-google-sql-db
 
+# Per-deploy suffix so retries after state loss dodge Cloud SQL's 7-day
+# instance-name reservation after delete (issue #159). Stable across applies
+# via state.
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 locals {
-  instance_name = "${var.project}-${var.instance_name}"
+  instance_name = "${var.project}-${var.instance_name}-${random_id.suffix.hex}"
   is_postgres   = startswith(var.database_version, "POSTGRES")
 }
 

--- a/gcp/cloudsql/versions.tf
+++ b/gcp/cloudsql/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = ">= 3.5"
     }
   }
 }

--- a/gcp/compute/main.tf
+++ b/gcp/compute/main.tf
@@ -1,8 +1,14 @@
 # GCP Compute Engine Instance Module
 # https://github.com/terraform-google-modules/terraform-google-vm
 
+# Per-deploy suffix so retries after state loss don't 409 on existing
+# compute instance names (issue #159).
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 locals {
-  instance_name = "${var.project}-${var.instance_name}"
+  instance_name = "${var.project}-${var.instance_name}-${random_id.suffix.hex}"
 }
 
 data "google_compute_image" "this" {

--- a/gcp/compute/versions.tf
+++ b/gcp/compute/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
 

--- a/gcp/firestore/main.tf
+++ b/gcp/firestore/main.tf
@@ -1,6 +1,27 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
+  }
+}
+
+# Per-deploy suffix so retries after state loss don't 409 on the singleton
+# database (issue #159). Switching off "(default)" is a deliberate breaking
+# change: client SDKs no longer infer the database name — read the
+# `database_name` output and pass it explicitly.
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 resource "google_firestore_database" "database" {
   project     = var.project_id
-  name        = "(default)"
+  name        = "${var.project}-firestore-${random_id.suffix.hex}"
   location_id = var.region
   type        = "FIRESTORE_NATIVE"
 }

--- a/gcp/firestore/outputs.tf
+++ b/gcp/firestore/outputs.tf
@@ -5,5 +5,5 @@ output "database_id" {
 
 output "database_name" {
   value       = google_firestore_database.database.name
-  description = "The name of the Firestore database"
+  description = "The name of the Firestore database. As of issue #159 this is no longer \"(default)\" — application code must read this output and pass it to the Firestore client SDK (e.g. firestore.Client(database=<name>)) instead of relying on the SDK default."
 }

--- a/gcp/gcs/main.tf
+++ b/gcp/gcs/main.tf
@@ -1,8 +1,15 @@
 # GCS Bucket Module
 # Using native google_storage_bucket resource
 
+# Per-deploy suffix so retries after state loss dodge the 7-day soft-delete
+# name reservation on globally-unique bucket names (issue #159). Stable
+# across applies via state.
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 resource "google_storage_bucket" "this" {
-  name     = var.bucket_name
+  name     = "${var.bucket_name}-${random_id.suffix.hex}"
   project  = var.project_id
   location = var.location
 

--- a/gcp/gcs/variables.tf
+++ b/gcp/gcs/variables.tf
@@ -25,8 +25,13 @@ variable "region" {
 }
 
 variable "bucket_name" {
-  description = "Name of the bucket (must be globally unique)"
+  description = "Name of the bucket (must be globally unique). The module appends a 9-char random suffix, so this value must be ≤ 54 chars to stay within GCS's 63-char ceiling."
   type        = string
+
+  validation {
+    condition     = length(var.bucket_name) <= 54
+    error_message = "bucket_name must be ≤ 54 chars (the module appends a 9-char '-<8hex>' suffix; GCS bucket names are limited to 63 chars)."
+  }
 }
 
 variable "location" {

--- a/gcp/gcs/versions.tf
+++ b/gcp/gcs/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
 

--- a/gcp/gke/main.tf
+++ b/gcp/gke/main.tf
@@ -1,8 +1,14 @@
 # GKE Cluster Module using terraform-google-kubernetes-engine
 # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine
 
+# Per-deploy suffix so retries after state loss don't 409 on the GKE
+# cluster name (issue #159). GKE cluster names are limited to 40 chars.
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 locals {
-  cluster_name = "${var.project}-${var.cluster_name}"
+  cluster_name = "${var.project}-${var.cluster_name}-${random_id.suffix.hex}"
 }
 
 module "gke" {

--- a/gcp/gke/variables.tf
+++ b/gcp/gke/variables.tf
@@ -25,9 +25,14 @@ variable "region" {
 }
 
 variable "cluster_name" {
-  description = "Name of the GKE cluster"
+  description = "Name of the GKE cluster (without project prefix or random suffix). The composed name is <project>-<cluster_name>-<8hex>; GKE caps cluster names at 40 chars total, so cluster_name must leave room for the project prefix and the 9-char suffix."
   type        = string
   default     = "main"
+
+  validation {
+    condition     = length(var.cluster_name) <= 14
+    error_message = "cluster_name must be ≤ 14 chars. GKE caps cluster names at 40 chars; the module composes <project>-<cluster_name>-<8hex>. Assuming a 15-char project prefix (typical InsideOut session ID), 14 chars here keeps the total at 40."
+  }
 }
 
 variable "network_self_link" {

--- a/gcp/gke/versions.tf
+++ b/gcp/gke/versions.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 2.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
 

--- a/gcp/kms/main.tf
+++ b/gcp/kms/main.tf
@@ -1,8 +1,14 @@
 # GCP Cloud KMS Module using terraform-google-kms
 # https://github.com/terraform-google-modules/terraform-google-kms
 
+# Per-deploy suffix so retries after state loss don't 409 on the undeletable
+# keyring shell (issue #159). Stable across applies via state.
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 locals {
-  keyring_name = "${var.project}-${var.keyring_name}"
+  keyring_name = "${var.project}-${var.keyring_name}-${random_id.suffix.hex}"
 }
 
 module "kms" {

--- a/gcp/kms/versions.tf
+++ b/gcp/kms/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
 

--- a/gcp/loadbalancer/main.tf
+++ b/gcp/loadbalancer/main.tf
@@ -1,8 +1,16 @@
 # GCP HTTP(S) Load Balancer Module using terraform-google-lb-http
 # https://github.com/terraform-google-modules/terraform-google-lb-http
 
+# Per-deploy suffix so retries after state loss don't 409 on the load
+# balancer's named compute resources (issue #159). The suffix flows through
+# local.name_prefix to every backend / health check / URL map / proxy /
+# certificate / forwarding rule.
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 locals {
-  name_prefix = "${var.project}-${var.name}"
+  name_prefix = "${var.project}-${var.name}-${random_id.suffix.hex}"
 }
 
 # Health checks for backends

--- a/gcp/loadbalancer/versions.tf
+++ b/gcp/loadbalancer/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
 

--- a/gcp/memorystore/main.tf
+++ b/gcp/memorystore/main.tf
@@ -7,12 +7,22 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
+}
+
+# Per-deploy suffix so retries after state loss don't 409 on the existing
+# Redis instance name (issue #159).
+resource "random_id" "suffix" {
+  byte_length = 4
 }
 
 resource "google_redis_instance" "this" {
   project            = var.project_id
-  name               = "${var.project}-${var.name}"
+  name               = "${var.project}-${var.name}-${random_id.suffix.hex}"
   tier               = var.tier
   memory_size_gb     = var.memory_size_gb
   region             = var.region

--- a/gcp/pubsub/main.tf
+++ b/gcp/pubsub/main.tf
@@ -7,12 +7,22 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
+}
+
+# Per-deploy suffix so retries after state loss don't 409 on the topic /
+# subscription / dead-letter-topic names (issue #159).
+resource "random_id" "suffix" {
+  byte_length = 4
 }
 
 resource "google_pubsub_topic" "this" {
   project = var.project_id
-  name    = "${var.project}-${var.topic_name}"
+  name    = "${var.project}-${var.topic_name}-${random_id.suffix.hex}"
 
   message_retention_duration = var.message_retention_duration
 
@@ -24,7 +34,7 @@ resource "google_pubsub_topic" "this" {
 
 resource "google_pubsub_subscription" "this" {
   project = var.project_id
-  name    = "${var.project}-${var.topic_name}-sub"
+  name    = "${var.project}-${var.topic_name}-sub-${random_id.suffix.hex}"
   topic   = google_pubsub_topic.this.id
 
   ack_deadline_seconds       = var.ack_deadline_seconds
@@ -50,7 +60,7 @@ resource "google_pubsub_subscription" "this" {
 resource "google_pubsub_topic" "dead_letter" {
   count   = var.enable_dead_letter ? 1 : 0
   project = var.project_id
-  name    = "${var.project}-${var.topic_name}-dlq"
+  name    = "${var.project}-${var.topic_name}-dlq-${random_id.suffix.hex}"
 
   labels = {
     project = var.project

--- a/gcp/secretmanager/main.tf
+++ b/gcp/secretmanager/main.tf
@@ -1,6 +1,12 @@
 # GCP Secret Manager Module
 # Using native google_secret_manager_secret resources
 
+# Per-deploy suffix so retries after state loss dodge the 30-day soft-delete
+# name reservation on Secret Manager secret IDs (issue #159).
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 locals {
   secrets_map = { for s in var.secrets : s.name => s }
 }
@@ -9,7 +15,7 @@ locals {
 resource "google_secret_manager_secret" "this" {
   for_each = local.secrets_map
 
-  secret_id = "${var.project}-${each.key}"
+  secret_id = "${var.project}-${each.key}-${random_id.suffix.hex}"
   project   = var.project_id
 
   labels = merge(

--- a/gcp/secretmanager/versions.tf
+++ b/gcp/secretmanager/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
 

--- a/gcp/vpc/main.tf
+++ b/gcp/vpc/main.tf
@@ -113,5 +113,17 @@ resource "google_vpc_access_connector" "serverless" {
   region        = var.region
   network       = module.vpc.network_self_link
   ip_cidr_range = var.connector_cidr
+
+  lifecycle {
+    # The composed connector name "<project>-conn-<4hex>" budgets exactly
+    # 25 chars when var.project is 15 chars (the InsideOut session-prefix
+    # default). Surface the constraint at plan time so a too-long
+    # var.project fails fast with a clear message instead of erroring at
+    # apply when the GCP API rejects the name.
+    precondition {
+      condition     = length(var.project) <= 15
+      error_message = "var.project must be ≤ 15 chars when enable_serverless_connector = true. The composed connector name is \"<project>-conn-<4hex>\" (project + 10 chars), and the VPC connector API caps names at 25 chars. Either disable enable_serverless_connector or shorten var.project."
+    }
+  }
 }
 

--- a/gcp/vpc/main.tf
+++ b/gcp/vpc/main.tf
@@ -1,9 +1,15 @@
 # GCP VPC Module using terraform-google-network
 # https://github.com/terraform-google-modules/terraform-google-network
 
+# Per-deploy suffix so retries after state loss don't 409 on existing
+# network/subnet/firewall/router/connector names (issue #159).
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 locals {
-  network_name = "${var.project}-${var.network_name}"
-  subnet_name  = "${var.project}-subnet-${var.region}"
+  network_name = "${var.project}-${var.network_name}-${random_id.suffix.hex}"
+  subnet_name  = "${var.project}-subnet-${var.region}-${random_id.suffix.hex}"
 }
 
 module "vpc" {
@@ -27,11 +33,11 @@ module "vpc" {
   secondary_ranges = var.gke_cluster_name != null ? {
     (local.subnet_name) = [
       {
-        range_name    = "${var.project}-pods"
+        range_name    = "${var.project}-pods-${random_id.suffix.hex}"
         ip_cidr_range = var.secondary_ranges.pods_cidr
       },
       {
-        range_name    = "${var.project}-services"
+        range_name    = "${var.project}-services-${random_id.suffix.hex}"
         ip_cidr_range = var.secondary_ranges.services_cidr
       }
     ]
@@ -41,7 +47,7 @@ module "vpc" {
 # Cloud Router for NAT
 resource "google_compute_router" "router" {
   count   = var.enable_cloud_nat ? 1 : 0
-  name    = "${var.project}-router"
+  name    = "${var.project}-router-${random_id.suffix.hex}"
   project = var.project_id
   region  = var.region
   network = module.vpc.network_id
@@ -56,7 +62,7 @@ module "cloud_nat" {
   project_id    = var.project_id
   region        = var.region
   router        = google_compute_router.router[0].name
-  name          = "${var.project}-nat"
+  name          = "${var.project}-nat-${random_id.suffix.hex}"
   network       = module.vpc.network_id
   create_router = false
 }
@@ -100,7 +106,9 @@ resource "google_compute_firewall" "allow_ssh_iap" {
 resource "google_vpc_access_connector" "serverless" {
   count = var.enable_serverless_connector ? 1 : 0
 
-  name          = "${var.project}-connector"
+  # Connector names are limited to 25 chars total. Use a 4-char suffix slice
+  # to keep within budget while still cycling on state-loss recovery.
+  name          = "${var.project}-conn-${substr(random_id.suffix.hex, 0, 4)}"
   project       = var.project_id
   region        = var.region
   network       = module.vpc.network_self_link

--- a/gcp/vpc/outputs.tf
+++ b/gcp/vpc/outputs.tf
@@ -30,12 +30,12 @@ output "subnet_names" {
 
 output "pods_range_name" {
   description = "Name of the secondary range for GKE pods"
-  value       = var.gke_cluster_name != null ? "${var.project}-pods" : null
+  value       = var.gke_cluster_name != null ? "${var.project}-pods-${random_id.suffix.hex}" : null
 }
 
 output "services_range_name" {
   description = "Name of the secondary range for GKE services"
-  value       = var.gke_cluster_name != null ? "${var.project}-services" : null
+  value       = var.gke_cluster_name != null ? "${var.project}-services-${random_id.suffix.hex}" : null
 }
 
 output "router_name" {

--- a/gcp/vpc/versions.tf
+++ b/gcp/vpc/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
 

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	terraformpresets "github.com/luthersystems/insideout-terraform-presets"
 )
 
 // shim so this test can reuse the helper defined in compose_vm_test.go
@@ -1731,6 +1733,56 @@ func TestComposeStack_DiscoveredProvidersReachRoot(t *testing.T) {
 	// not a stray substring in a comment or module name).
 	require.Regexp(t, regexp.MustCompile(`(?s)random\s*=\s*\{[^}]*hashicorp/random`), prov,
 		"hashicorp/random should be attached to a random = {...} entry in required_providers, not just appear as a substring")
+}
+
+// TestComposeStack_GCPRandomIDSuffix locks in the issue #159 contract: every
+// GCP module that creates a named cloud resource declares a random_id
+// "suffix" and appends its hex to the resource name, and the random
+// provider lifts into the root providers.tf so a `terraform init` on the
+// composed stack succeeds. State-loss recovery (re-applying after losing
+// state on a project that already has e.g. an undeletable KMS keyring)
+// depends on this end-to-end.
+//
+// The test exercises KMS specifically because it's the customer-incident
+// driver (reliable #1167 → #1168 — a prior keyring 409'd every retry on
+// the same project, requiring a fresh GCP project to recover).
+func TestComposeStack_GCPRandomIDSuffix(t *testing.T) {
+	c := newTestClient()
+
+	// Precondition 1: the kms preset declares random in required_providers.
+	// If a future edit drops it, this assertion fails first with a clearer
+	// signal than the indirect "hashicorp/random missing from providers.tf".
+	kmsMod, err := InspectPreset("gcp/kms")
+	require.NoError(t, err)
+	require.Contains(t, kmsMod.RequiredProviders, "random",
+		"precondition: gcp/kms preset must declare a random = {...} required_provider for the suffix pattern to work")
+
+	// Precondition 2: the kms preset's main.tf actually interpolates
+	// random_id.suffix.hex into the keyring name. A passing
+	// required_providers assertion alone doesn't prove the suffix wires up.
+	kmsBytes, err := terraformpresets.FS.ReadFile("gcp/kms/main.tf")
+	require.NoError(t, err)
+	require.Contains(t, string(kmsBytes), "random_id.suffix.hex",
+		"gcp/kms/main.tf must interpolate random_id.suffix.hex (issue #159 — keyrings are undeletable, so name reuse blocks every retry)")
+
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPVPC, KeyGCPCloudKMS},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-central1"},
+		Project:      "suffix-test",
+		GCPProjectID: "suffix-test-12345",
+		Region:       "us-central1",
+	})
+	require.NoError(t, err, "ComposeStack(gcp) with KMS+VPC should succeed")
+
+	// Root providers.tf must include the random provider so terraform init
+	// can resolve it.
+	prov := string(out["/providers.tf"])
+	require.Contains(t, prov, "hashicorp/random",
+		"root providers.tf should include the random provider lifted from the kms preset's required_providers")
+	require.Regexp(t, regexp.MustCompile(`(?s)random\s*=\s*\{[^}]*hashicorp/random`), prov,
+		"hashicorp/random should be attached to a random = {...} entry, not just appear as a substring")
 }
 
 // TestComposeStack_ProjectRoundTrip renders with a distinctive Project value

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -1735,36 +1735,147 @@ func TestComposeStack_DiscoveredProvidersReachRoot(t *testing.T) {
 		"hashicorp/random should be attached to a random = {...} entry in required_providers, not just appear as a substring")
 }
 
-// TestComposeStack_GCPRandomIDSuffix locks in the issue #159 contract: every
-// GCP module that creates a named cloud resource declares a random_id
-// "suffix" and appends its hex to the resource name, and the random
-// provider lifts into the root providers.tf so a `terraform init` on the
-// composed stack succeeds. State-loss recovery (re-applying after losing
-// state on a project that already has e.g. an undeletable KMS keyring)
-// depends on this end-to-end.
+// TestGCPPresets_AllSuffixedResourceNames pins the issue #159 contract
+// across every GCP module that creates a named cloud resource: each must
+// (a) declare hashicorp/random in required_providers, (b) declare a
+// resource "random_id" "suffix" block, and (c) interpolate
+// ${random_id.suffix.hex} as a real HCL expression somewhere in the
+// preset's source.
 //
-// The test exercises KMS specifically because it's the customer-incident
-// driver (reliable #1167 → #1168 — a prior keyring 409'd every retry on
-// the same project, requiring a fresh GCP project to recover).
+// Why a table sweep, not a single-instance smoke test:
+// the customer incident chain that motivated #159 (reliable #1167 → #1168)
+// hit *three* dead-ends — the KMS keyring (undeletable), the Firestore
+// (default) database (singleton), and a GCS bucket (7-day soft-delete name
+// reservation). A KMS-only assertion would let a future edit silently
+// revert gcp/firestore/main.tf back to "(default)" with green CI and
+// reproduce the original incident. Enumerating every in-scope module here
+// makes "remove the suffix from any one preset" fail loudly.
+//
+// The skip allowlist captures the four GCP modules that the PR
+// intentionally left untouched: cloud_cdn (config-only, no cloud
+// resources), cloud_monitoring (only a non-unique displayName JSON),
+// identity_platform (singleton per project, no name field), vertex_ai
+// (display_name is non-unique server-side; the resource ID is
+// server-assigned). New GCP modules must either land on the suffix list
+// or be added to the skip allowlist with a justification.
+func TestGCPPresets_AllSuffixedResourceNames(t *testing.T) {
+	// In-scope modules — every named cloud resource must carry the suffix.
+	suffixedPresets := []string{
+		"gcp/api_gateway",
+		"gcp/backups",
+		"gcp/bastion",
+		"gcp/cloud_armor",
+		"gcp/cloud_build",
+		"gcp/cloud_functions",
+		"gcp/cloud_logging",
+		"gcp/cloud_run",
+		"gcp/cloudsql",
+		"gcp/compute",
+		"gcp/firestore",
+		"gcp/gcs",
+		"gcp/gke",
+		"gcp/kms",
+		"gcp/loadbalancer",
+		"gcp/memorystore",
+		"gcp/pubsub",
+		"gcp/secretmanager",
+		"gcp/vpc",
+	}
+
+	// Pre-anchored regexes — declared once so test-loop hot path stays cheap.
+	// randomIDBlockRe: a real `resource "random_id" "suffix" { ... }` block
+	//   (not just the substring random_id.suffix in a comment or string).
+	// suffixInterpRe: ${random_id.suffix.hex} as an HCL interpolation —
+	//   the dollar+brace anchors it to a real expression. Matches both
+	//   the bare form and the substr() slice form (vpc connector / bastion
+	//   service account budget cases) since both contain
+	//   `random_id.suffix.hex` inside a `${...}` interpolation.
+	randomIDBlockRe := regexp.MustCompile(`(?m)^\s*resource\s+"random_id"\s+"suffix"\s*\{`)
+	suffixInterpRe := regexp.MustCompile(`\$\{[^}]*random_id\.suffix\.hex[^}]*\}`)
+
+	for _, preset := range suffixedPresets {
+		t.Run(preset, func(t *testing.T) {
+			// (a) The preset declares the random required_provider. Use
+			//     InspectPreset (not raw string match) so this fails with
+			//     a clear "missing provider" diagnostic if versions.tf is
+			//     malformed.
+			mod, err := InspectPreset(preset)
+			require.NoError(t, err, "InspectPreset(%q) failed", preset)
+			require.Contains(t, mod.RequiredProviders, "random",
+				"%s must declare a random = {...} required_provider (issue #159)", preset)
+
+			// (b)+(c): read every .tf file in the preset and assert at
+			// least one carries the random_id "suffix" block, and at least
+			// one carries a ${random_id.suffix.hex} HCL interpolation.
+			// Splitting (b)/(c) across files is fine — most modules keep
+			// the resource block in main.tf; some keep providers in
+			// versions.tf.
+			entries, err := terraformpresets.FS.ReadDir(preset)
+			require.NoError(t, err, "ReadDir(%q) failed", preset)
+
+			var concatenated []byte
+			for _, e := range entries {
+				if e.IsDir() || !strings.HasSuffix(e.Name(), ".tf") {
+					continue
+				}
+				b, readErr := terraformpresets.FS.ReadFile(preset + "/" + e.Name())
+				require.NoError(t, readErr, "ReadFile(%q/%q) failed", preset, e.Name())
+				concatenated = append(concatenated, b...)
+				concatenated = append(concatenated, '\n')
+			}
+
+			require.Regexp(t, randomIDBlockRe, string(concatenated),
+				`%s must declare a top-level resource "random_id" "suffix" {} block (issue #159 — without it, retries after state loss 409 on the existing resource name)`,
+				preset)
+			require.Regexp(t, suffixInterpRe, string(concatenated),
+				`%s must interpolate ${random_id.suffix.hex} into at least one HCL expression (issue #159 — a comment-only reference does not propagate the suffix to a resource name and would silently allow the original customer incident to recur)`,
+				preset)
+		})
+	}
+}
+
+// TestGCPPresets_NoSharedRootRandomID pins the per-module-suffix design
+// decision from issue #159: each GCP module declares its OWN random_id
+// "suffix", rather than the composer hoisting a single shared random_id
+// into the composed root. This matches the existing AWS convention (each
+// AWS module that needs uniqueness declares its own random_id "suffix")
+// and avoids requiring composer changes.
+//
+// If a future change hoists random_id into the composed root, suffix
+// collisions and rotation semantics change in ways callers may not
+// expect. That's a deliberate decision worth a separate review, not a
+// drive-by edit.
+func TestGCPPresets_NoSharedRootRandomID(t *testing.T) {
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud: "gcp",
+		// VPC + KMS + Firestore — three of the four customer-incident
+		// modules in one composition (GCS isn't selectable as a default
+		// component the same way; the per-module assertion in the sister
+		// test above already covers it).
+		SelectedKeys: []ComponentKey{KeyGCPVPC, KeyGCPCloudKMS, KeyGCPFirestore},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-central1"},
+		Project:      "suffix-test",
+		GCPProjectID: "suffix-test-12345",
+		Region:       "us-central1",
+	})
+	require.NoError(t, err)
+
+	rootMain := string(out["/main.tf"])
+	require.NotEmpty(t, rootMain, "composed root main.tf must exist")
+	require.NotRegexp(t, regexp.MustCompile(`(?m)^\s*resource\s+"random_id"`), rootMain,
+		"composed root main.tf must NOT declare a top-level random_id resource (issue #159: per-module suffix, not shared root). Each preset declares its own resource \"random_id\" \"suffix\" block; hoisting one to the root changes collision and rotation semantics.")
+}
+
+// TestComposeStack_GCPRandomIDSuffix smoke-tests the end-to-end provider
+// merge path for the GCP/random case: composing a GCP stack with KMS
+// must lift hashicorp/random into the composed root providers.tf so a
+// `terraform init` on the result succeeds. The wider per-module contract
+// is enforced by TestGCPPresets_AllSuffixedResourceNames; this test only
+// covers the composer's role in stitching the modules together.
 func TestComposeStack_GCPRandomIDSuffix(t *testing.T) {
 	c := newTestClient()
-
-	// Precondition 1: the kms preset declares random in required_providers.
-	// If a future edit drops it, this assertion fails first with a clearer
-	// signal than the indirect "hashicorp/random missing from providers.tf".
-	kmsMod, err := InspectPreset("gcp/kms")
-	require.NoError(t, err)
-	require.Contains(t, kmsMod.RequiredProviders, "random",
-		"precondition: gcp/kms preset must declare a random = {...} required_provider for the suffix pattern to work")
-
-	// Precondition 2: the kms preset's main.tf actually interpolates
-	// random_id.suffix.hex into the keyring name. A passing
-	// required_providers assertion alone doesn't prove the suffix wires up.
-	kmsBytes, err := terraformpresets.FS.ReadFile("gcp/kms/main.tf")
-	require.NoError(t, err)
-	require.Contains(t, string(kmsBytes), "random_id.suffix.hex",
-		"gcp/kms/main.tf must interpolate random_id.suffix.hex (issue #159 — keyrings are undeletable, so name reuse blocks every retry)")
-
 	out, err := c.ComposeStack(ComposeStackOpts{
 		Cloud:        "gcp",
 		SelectedKeys: []ComponentKey{KeyGCPVPC, KeyGCPCloudKMS},
@@ -1777,7 +1888,9 @@ func TestComposeStack_GCPRandomIDSuffix(t *testing.T) {
 	require.NoError(t, err, "ComposeStack(gcp) with KMS+VPC should succeed")
 
 	// Root providers.tf must include the random provider so terraform init
-	// can resolve it.
+	// can resolve it. Lock the merge location: hashicorp/random must
+	// appear inside a `random = {...}` entry, not as a stray substring in
+	// a comment or module name.
 	prov := string(out["/providers.tf"])
 	require.Contains(t, prov, "hashicorp/random",
 		"root providers.tf should include the random provider lifted from the kms preset's required_providers")

--- a/pkg/composer/gcp_project_split_invariants_test.go
+++ b/pkg/composer/gcp_project_split_invariants_test.go
@@ -189,11 +189,16 @@ func TestGCPModules_ProjectIDDeclaredAndUsed(t *testing.T) {
 	// therefore don't declare project_id. Listed explicitly so a future
 	// addition of project-scoped resources to one of these surfaces as a
 	// test failure rather than silent miss.
+	//
+	// cloud_build and cloud_logging were on this list as "skeletons", but
+	// the project_id-less form was a latent bug — both create real
+	// project-scoped resources (a build trigger and a logging sink) that
+	// would land in whatever default project the provider was configured
+	// with. Issue #159's self-review fixed that and they are now full
+	// project-scoped modules.
 	exempt := map[string]bool{
-		"cloud_build":      true, // skeleton, no project-scoped resources
 		"cloud_monitoring": true, // single hardcoded dashboard
 		"cloud_cdn":        true, // locals-only stub
-		"cloud_logging":    true, // sink uses bucket name only, no project arg
 	}
 
 	consumesPattern := regexp.MustCompile(`var\.project_id`)


### PR DESCRIPTION
## Summary

- Add `random_id "suffix" { byte_length = 4 }` to 19 GCP modules and append `${random_id.suffix.hex}` to every named cloud resource — destroy + redeploy now cycles cleanly even when state is lost mid-apply.
- Switch `gcp/firestore` off the `(default)` magic database to a real named database (breaking change — see Migration Impact).
- Fix two outliers (`gcp/cloud_build`, `gcp/cloud_logging`) that hardcoded names with no project prefix.

Closes #159.

## Why

A customer's GCP deploy hit 14 orphan resources after a state-loss event ([reliable #1167](https://github.com/luthersystems/reliable/issues/1167) → [#1168](https://github.com/luthersystems/reliable/issues/1168)). The KMS keyring is undeletable per GCP policy, so every retry on the same project 409'd forever — only recovery was a fresh GCP project. Two other resource families had similar dead-ends: Firestore `(default)` (magic singleton) and GCS buckets (7-day soft-delete name reservation).

AWS modules already solve this — 10 AWS modules use the per-module `random_id "suffix"` + `luthername` pattern. GCP modules previously had only one (`gcp/cloud_functions` for the auto-created source bucket). This PR brings GCP to parity.

## Decisions

- **Per-module `random_id`, not shared root**: matches the existing AWS convention exactly, requires zero composer changes. The `random` provider auto-aggregates into root `providers.tf` via the existing `compose.go:469` discovery (proven by `TestComposeStack_DiscoveredProvidersReachRoot`).
- **Default `byte_length = 4`** (8 hex chars) for ample uniqueness; tight name budgets use `substr(random_id.suffix.hex, 0, 4)`:
  - bastion service account (30-char limit) → 4-char slice
  - VPC connector (25-char limit) → role shortened to `conn` + 4-char slice
- **Firestore default flipped to named DB**: deliberate breaking change. `(default)` cannot be deleted, so a stack stuck on a 409 needs a way out.
- **GKE cluster_name validation added**: caps `var.cluster_name` at 14 chars to keep the composed name (project + cluster_name + 9-char suffix) within GKE's 40-char limit.

## Migration Impact (existing deployed stacks)

**Per the issue, migrating existing deployed stacks is out of scope.** This PR's naming changes apply only to fresh deploys. Operators upgrading existing stacks should expect the following on `terraform plan`:

| Resource family | Plan behavior on upgrade | Recommended action |
|---|---|---|
| **Firestore `(default)`** | `terraform plan` proposes destroy + recreate. **`(default)` cannot be destroyed by GCP** → `terraform apply` will error. | `terraform state rm 'module.<X>.google_firestore_database.database'` before applying; or pin the firestore module to its prior version for existing stacks. |
| **GCS buckets** | `terraform plan` proposes destroy + recreate (name change). With `force_destroy = false` (default), apply errors if the bucket has objects. With `force_destroy = true`, **buckets and their contents are deleted**. | For buckets with data, do **not** apply on existing stacks; pin the gcs module or use `terraform state mv` after manually creating the new-name bucket. |
| **Cloud SQL instances** | Destroy + recreate (7-day name reuse delay). | Pin the cloudsql module on existing stacks. |
| **KMS keyrings** | Destroy + recreate. **Keyrings cannot be destroyed.** Apply errors. | The new keyring lands cleanly; the old one becomes a tombstone. Use `terraform state rm` on the old keyring + manual `gcloud` cleanup of crypto keys. |
| **Most other resources** (compute, load balancer, Cloud Run, Cloud Functions, GKE, secrets, pubsub, redis, etc.) | Destroy + recreate at apply time. | Same caveat — do not apply on existing stacks without a planned migration. |

**Mitigation pattern for stacks already in production**: pin the preset version and migrate one module at a time using `terraform state rm` + manual GCP cleanup. The reliable repo's stack-version migration tooling can sequence this.

## Breaking change — Firestore SDK contract

`gcp/firestore` no longer creates a `"(default)"` database. The new name is `"${var.project}-firestore-${random_id.suffix.hex}"`. **Application code that uses Firebase/Firestore client SDKs must read the new `database_name` output and pass it explicitly**:

```python
# Before
client = firestore.Client(project="my-project")  # implicit (default)

# After
client = firestore.Client(project="my-project", database="my-prefix-firestore-a1b2c3d4")
```

## Modules touched

| Module | Change |
|---|---|
| api_gateway, backups, bastion, cloud_armor, cloud_functions, cloud_run, cloudsql, compute, gcs, gke, kms, loadbalancer, memorystore, pubsub, secretmanager, vpc | random_id + name suffix |
| firestore | random_id + named DB (breaking) + output description update |
| cloud_build, cloud_logging | Outlier rewrite — were bare `"main-trigger"` / `"main-sink"` with no project prefix |
| gke | + cluster_name length validation (≤ 14 chars) |

Skipped (no named cloud resources to suffix): `cloud_cdn`, `cloud_monitoring`, `identity_platform`, `vertex_ai`.

## Verification

- All 73 CI checks pass: every `validate-presets`, `validate-examples`, `test-presets`, `go-build`, `go-test`, `go-vet`, `lint`, `format-check`, `verify-gen`, `discover`, `ci-gate`.
- `terraform fmt -check -recursive` clean.
- All three lint scripts pass: `lint-project-label.sh`, `lint-project-tag.sh`, `lint-sensitive-for-each.sh`.
- New regression test `TestComposeStack_GCPRandomIDSuffix` pins the contract: precondition asserts `gcp/kms` declares `random` in `required_providers` and interpolates `random_id.suffix.hex` in `main.tf`; end-to-end assertion verifies `hashicorp/random` lifts into the composed root `providers.tf`.

## Test plan

- [x] Wait for CI to validate every `gcp/*` module via `terraform init -backend=false && terraform validate`
- [x] Wait for CI to run the full `go test ./pkg/composer/...` suite (including the AWS `TestComposeStack_TerraformInit` end-to-end)
- [x] Manually confirm `examples/mobileapi` composes and validates with the new providers
- [ ] Sandbox project: state-loss recovery validation — apply → delete state → re-apply → confirm no 409s, fresh suffix

## Coordination

- Reliable companion change ([reliable repo](https://github.com/luthersystems/reliable)): downstream consumers that read stack outputs may want to surface `database_name` for Firestore-using stacks. Outputs are just strings; this should be backwards-compatible — a separate PR can lift the value into the deploy schema if useful.