### PR TITLE
feat(composer): emit imported resources as flat HCL (#148)

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -577,7 +577,7 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 		files["/imported.tf"] = importedTF
 	}
 
-	files["/providers.tf"] = generateProvidersTF(cloud, reg, selected, discoveredProviders, importedClouds)
+	files["/providers.tf"] = generateProvidersTF(cloud, reg, opts.GCPProjectID, selected, discoveredProviders, importedClouds)
 
 	// Validator dispatcher — runs after the stack is fully composed, before
 	// returning. Each validator appends to issues. The missing-required check
@@ -604,14 +604,17 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 // plugins like `opensearch-project/opensearch` that child modules reference
 // via their own module-scoped provider blocks.
 //
+// `gcpProjectID` is the real GCP project id (as in ComposeStackOpts) and is
+// only consumed when emitting the google.imported alias; ignored on AWS.
+//
 // `importedClouds` keys ("aws", "gcp") request additional provider aliases
 // dedicated to imported resources (issue #148). The imported alias inherits
-// the cloud's region (and assume_role for AWS, project_id for GCP) but
+// the cloud's region (and assume_role for AWS, project for GCP) but
 // deliberately omits default_tags / default_labels — imported resources
 // must not inherit the stack's Project tag because they may pre-date the
 // InsideOut session. EmitImportedTF returns this map; the wiring is no-op
 // when no imported resources were emitted.
-func generateProvidersTF(cloud, region string, selected map[ComponentKey]bool, discovered map[string]*tfconfig.ProviderRequirement, importedClouds map[string]bool) []byte {
+func generateProvidersTF(cloud, region, gcpProjectID string, selected map[ComponentKey]bool, discovered map[string]*tfconfig.ProviderRequirement, importedClouds map[string]bool) []byte {
 	// Seed required_providers with the cloud's base entry, then union the
 	// child-module discoveries on top. Discovered entries win on conflict.
 	required := map[string]*tfconfig.ProviderRequirement{}
@@ -631,11 +634,14 @@ func generateProvidersTF(cloud, region string, selected map[ComponentKey]bool, d
 		if importedClouds["gcp"] {
 			b.WriteString("\n")
 			// google.imported drives Terraform's import {} for previously
-			// existing GCP resources. project = var.gcp_project_id matches
-			// the default provider's project plumbing so imports land in
-			// the same project. No default_labels: imported resources keep
-			// any pre-existing labels untouched.
-			fmt.Fprintf(&b, "provider \"google\" {\n  alias   = \"imported\"\n  region  = %q\n  project = var.gcp_project_id\n}\n", region)
+			// existing GCP resources. project is rendered as a literal —
+			// the root stack does not declare var.gcp_project_id, and the
+			// project ID is known at compose time. No default_labels:
+			// imported resources keep any pre-existing labels untouched.
+			// An empty gcpProjectID still emits an empty literal: the
+			// gcp_project_id_required ValidationIssue surfaces the real
+			// fix to the caller before apply.
+			fmt.Fprintf(&b, "provider \"google\" {\n  alias   = \"imported\"\n  region  = %q\n  project = %q\n}\n", region, gcpProjectID)
 		}
 		return []byte(b.String())
 

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 
 	terraformpresets "github.com/luthersystems/insideout-terraform-presets"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
 // insideoutManagedByValue is the value stamped into the `managed-by` tag on
@@ -128,6 +129,12 @@ type ComposeSingleOpts struct {
 	// ComposeSingle entry point preserves its historical hard-fail behavior
 	// regardless of this flag.
 	StrictValidate bool
+
+	// Imported is a parity field with ComposeStackOpts.Imported. The
+	// single-module flow does not currently emit imported resources, but
+	// the field exists so reliable's adapter can hand the same shape to
+	// either entry point. See ComposeStackOpts.Imported.
+	Imported []imported.ImportedResource
 }
 
 // ComposeSingle preserves the historical (Files, error) signature. It hard-
@@ -331,6 +338,14 @@ type ComposeStackOpts struct {
 	// ComposeStack entry point preserves its historical hard-fail behavior
 	// regardless of this flag.
 	StrictValidate bool
+
+	// Imported lists resources observed via reverse-Terraform that the
+	// composer must emit as flat HCL alongside the preset module calls. See
+	// pkg/composer/imported and issue #148. Resources whose Identity.Cloud
+	// does not match Cloud are skipped silently; tier-related blockers are
+	// reported via ValidationIssue codes (imported_resource_*). Nil or
+	// empty preserves the historical no-op behavior.
+	Imported []imported.ImportedResource
 }
 
 // ComposeStack preserves the historical (Files, error) signature. It hard-
@@ -553,7 +568,16 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 
 	// Generate cloud-specific providers.tf, merging any child-module
 	// required_providers discovered above.
-	files["/providers.tf"] = generateProvidersTF(cloud, reg, selected, discoveredProviders)
+	// Build /imported.tf for resources observed via reverse-Terraform
+	// (issue #148). This must happen before generateProvidersTF so that
+	// importedClouds tells the provider emitter which alias to declare.
+	issues = append(issues, ValidateImportedResources(cloud, opts.Imported)...)
+	importedTF, importedClouds := EmitImportedTF(cloud, opts.Imported)
+	if len(importedTF) > 0 {
+		files["/imported.tf"] = importedTF
+	}
+
+	files["/providers.tf"] = generateProvidersTF(cloud, reg, selected, discoveredProviders, importedClouds)
 
 	// Validator dispatcher — runs after the stack is fully composed, before
 	// returning. Each validator appends to issues. The missing-required check
@@ -579,7 +603,15 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 // the root-level required_providers block so `terraform init` knows to pull
 // plugins like `opensearch-project/opensearch` that child modules reference
 // via their own module-scoped provider blocks.
-func generateProvidersTF(cloud, region string, selected map[ComponentKey]bool, discovered map[string]*tfconfig.ProviderRequirement) []byte {
+//
+// `importedClouds` keys ("aws", "gcp") request additional provider aliases
+// dedicated to imported resources (issue #148). The imported alias inherits
+// the cloud's region (and assume_role for AWS, project_id for GCP) but
+// deliberately omits default_tags / default_labels — imported resources
+// must not inherit the stack's Project tag because they may pre-date the
+// InsideOut session. EmitImportedTF returns this map; the wiring is no-op
+// when no imported resources were emitted.
+func generateProvidersTF(cloud, region string, selected map[ComponentKey]bool, discovered map[string]*tfconfig.ProviderRequirement, importedClouds map[string]bool) []byte {
 	// Seed required_providers with the cloud's base entry, then union the
 	// child-module discoveries on top. Discovered entries win on conflict.
 	required := map[string]*tfconfig.ProviderRequirement{}
@@ -596,6 +628,15 @@ func generateProvidersTF(cloud, region string, selected map[ComponentKey]bool, d
 		b.WriteString(renderRequiredProviders(required))
 		b.WriteString("  }\n}\n\n")
 		fmt.Fprintf(&b, "provider \"google\" {\n  region = %q\n}\n", region)
+		if importedClouds["gcp"] {
+			b.WriteString("\n")
+			// google.imported drives Terraform's import {} for previously
+			// existing GCP resources. project = var.gcp_project_id matches
+			// the default provider's project plumbing so imports land in
+			// the same project. No default_labels: imported resources keep
+			// any pre-existing labels untouched.
+			fmt.Fprintf(&b, "provider \"google\" {\n  alias   = \"imported\"\n  region  = %q\n  project = var.gcp_project_id\n}\n", region)
+		}
 		return []byte(b.String())
 
 	default: // aws
@@ -656,6 +697,18 @@ variable "external_id" {
 		if selected[KeyAWSWAF] {
 			b.WriteString("\n")
 			fmt.Fprintf(&b, "provider \"aws\" {\n  alias  = \"us_east_1\"\n  region = \"us-east-1\"%s%s\n}\n", awsDefaultTags, awsDynamicAssumeRole)
+		}
+
+		// aws.imported is the dedicated alias for resources discovered via
+		// reverse-Terraform import (issue #148). It carries the same region
+		// and assume_role plumbing as the default provider but deliberately
+		// omits default_tags: imported resources may pre-date the InsideOut
+		// session and must not silently inherit the stack's Project tag.
+		// Provenance tagging is system-owned and re-emitted in the resource
+		// body via merge() instead (issue #153).
+		if importedClouds["aws"] {
+			b.WriteString("\n")
+			fmt.Fprintf(&b, "provider \"aws\" {\n  alias  = \"imported\"\n  region = %q%s\n}\n", region, awsDynamicAssumeRole)
 		}
 
 		return []byte(b.String())

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -202,7 +202,7 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 	}
 
 	t.Run("aws with discovery", func(t *testing.T) {
-		got := string(generateProvidersTF("aws", "us-east-1",
+		got := string(generateProvidersTF("aws", "us-east-1", "",
 			map[ComponentKey]bool{KeyAWSOpenSearch: true}, discovered, nil))
 		require.Contains(t, got, "hashicorp/aws", "base aws provider required")
 		require.Contains(t, got, "opensearch-project/opensearch", "discovered provider required")
@@ -213,7 +213,7 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 	})
 
 	t.Run("aws with WAF + discovery coexist", func(t *testing.T) {
-		got := string(generateProvidersTF("aws", "us-east-1",
+		got := string(generateProvidersTF("aws", "us-east-1", "",
 			map[ComponentKey]bool{KeyAWSWAF: true, KeyAWSOpenSearch: true}, discovered, nil))
 		require.Contains(t, got, `alias  = "us_east_1"`, "WAF us-east-1 alias block")
 		require.Contains(t, got, "opensearch-project/opensearch",
@@ -225,7 +225,7 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 	})
 
 	t.Run("aws with no discovery falls back to aws only", func(t *testing.T) {
-		got := string(generateProvidersTF("aws", "us-east-1",
+		got := string(generateProvidersTF("aws", "us-east-1", "",
 			map[ComponentKey]bool{}, map[string]*tfconfig.ProviderRequirement{}, nil))
 		require.Contains(t, got, "hashicorp/aws")
 		require.Equal(t, 1, strings.Count(got, "source  = "),
@@ -233,7 +233,7 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 	})
 
 	t.Run("gcp base + discovery", func(t *testing.T) {
-		got := string(generateProvidersTF("gcp", "us-central1",
+		got := string(generateProvidersTF("gcp", "us-central1", "demo-project-12345",
 			map[ComponentKey]bool{}, discovered, nil))
 		require.Contains(t, got, "hashicorp/google")
 		require.Contains(t, got, "opensearch-project/opensearch")
@@ -244,16 +244,16 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 		// Use an empty map rather than nil for `selected` — matches the
 		// other subtests in this table and avoids a nil-vs-empty-map
 		// divergence that could hide a real regression.
-		a := string(generateProvidersTF("aws", "us-east-1", map[ComponentKey]bool{}, discovered, nil))
-		b := string(generateProvidersTF("aws", "us-east-1", map[ComponentKey]bool{}, discovered, nil))
+		a := string(generateProvidersTF("aws", "us-east-1", "", map[ComponentKey]bool{}, discovered, nil))
+		b := string(generateProvidersTF("aws", "us-east-1", "", map[ComponentKey]bool{}, discovered, nil))
 		require.Equal(t, a, b, "providers.tf output must be deterministic")
 	})
 
 	t.Run("nil selected is equivalent to empty", func(t *testing.T) {
 		// Defensive: Go map reads of a nil map return the zero value, so
 		// the WAF/OpenSearch guards should treat nil and empty identically.
-		nilOut := string(generateProvidersTF("aws", "us-east-1", nil, discovered, nil))
-		emptyOut := string(generateProvidersTF("aws", "us-east-1", map[ComponentKey]bool{}, discovered, nil))
+		nilOut := string(generateProvidersTF("aws", "us-east-1", "", nil, discovered, nil))
+		emptyOut := string(generateProvidersTF("aws", "us-east-1", "", map[ComponentKey]bool{}, discovered, nil))
 		require.Equal(t, emptyOut, nilOut,
 			"nil and empty `selected` must produce identical providers.tf")
 	})

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -203,7 +203,7 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 
 	t.Run("aws with discovery", func(t *testing.T) {
 		got := string(generateProvidersTF("aws", "us-east-1",
-			map[ComponentKey]bool{KeyAWSOpenSearch: true}, discovered))
+			map[ComponentKey]bool{KeyAWSOpenSearch: true}, discovered, nil))
 		require.Contains(t, got, "hashicorp/aws", "base aws provider required")
 		require.Contains(t, got, "opensearch-project/opensearch", "discovered provider required")
 		require.Contains(t, got, "hashicorp/time", "discovered provider required")
@@ -214,7 +214,7 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 
 	t.Run("aws with WAF + discovery coexist", func(t *testing.T) {
 		got := string(generateProvidersTF("aws", "us-east-1",
-			map[ComponentKey]bool{KeyAWSWAF: true, KeyAWSOpenSearch: true}, discovered))
+			map[ComponentKey]bool{KeyAWSWAF: true, KeyAWSOpenSearch: true}, discovered, nil))
 		require.Contains(t, got, `alias  = "us_east_1"`, "WAF us-east-1 alias block")
 		require.Contains(t, got, "opensearch-project/opensearch",
 			"discovered provider survives the WAF branch")
@@ -226,7 +226,7 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 
 	t.Run("aws with no discovery falls back to aws only", func(t *testing.T) {
 		got := string(generateProvidersTF("aws", "us-east-1",
-			map[ComponentKey]bool{}, map[string]*tfconfig.ProviderRequirement{}))
+			map[ComponentKey]bool{}, map[string]*tfconfig.ProviderRequirement{}, nil))
 		require.Contains(t, got, "hashicorp/aws")
 		require.Equal(t, 1, strings.Count(got, "source  = "),
 			"only aws should be in required_providers")
@@ -234,7 +234,7 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 
 	t.Run("gcp base + discovery", func(t *testing.T) {
 		got := string(generateProvidersTF("gcp", "us-central1",
-			map[ComponentKey]bool{}, discovered))
+			map[ComponentKey]bool{}, discovered, nil))
 		require.Contains(t, got, "hashicorp/google")
 		require.Contains(t, got, "opensearch-project/opensearch")
 	})
@@ -244,16 +244,16 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 		// Use an empty map rather than nil for `selected` — matches the
 		// other subtests in this table and avoids a nil-vs-empty-map
 		// divergence that could hide a real regression.
-		a := string(generateProvidersTF("aws", "us-east-1", map[ComponentKey]bool{}, discovered))
-		b := string(generateProvidersTF("aws", "us-east-1", map[ComponentKey]bool{}, discovered))
+		a := string(generateProvidersTF("aws", "us-east-1", map[ComponentKey]bool{}, discovered, nil))
+		b := string(generateProvidersTF("aws", "us-east-1", map[ComponentKey]bool{}, discovered, nil))
 		require.Equal(t, a, b, "providers.tf output must be deterministic")
 	})
 
 	t.Run("nil selected is equivalent to empty", func(t *testing.T) {
 		// Defensive: Go map reads of a nil map return the zero value, so
 		// the WAF/OpenSearch guards should treat nil and empty identically.
-		nilOut := string(generateProvidersTF("aws", "us-east-1", nil, discovered))
-		emptyOut := string(generateProvidersTF("aws", "us-east-1", map[ComponentKey]bool{}, discovered))
+		nilOut := string(generateProvidersTF("aws", "us-east-1", nil, discovered, nil))
+		emptyOut := string(generateProvidersTF("aws", "us-east-1", map[ComponentKey]bool{}, discovered, nil))
 		require.Equal(t, emptyOut, nilOut,
 			"nil and empty `selected` must produce identical providers.tf")
 	})

--- a/pkg/composer/imported/doc.go
+++ b/pkg/composer/imported/doc.go
@@ -4,9 +4,18 @@
 //
 // This package is the Phase 2 foundation of the imported-resource model. It
 // owns identity, tier classification, desired-state storage, and edit/conflict
-// metadata. It does not generate provider-specific structs (#145/#146), emit
-// HCL (#148), validate the union graph (#150), or extend the diff engine
-// (#151) — those are downstream Phase 2 sub-tickets.
+// metadata. Provider-specific typed structs and HCL marshaling live in
+// pkg/composer/imported/generated (#145/#146); per-resource field policy in
+// pkg/composer/imported/policy (#147); composer emission and validation
+// (EmitImportedTF / ValidateImportedResources, #148) in pkg/composer.
+//
+// Composer/runtime boundary: the composer renders desired state from
+// Attributes/Attrs into flat HCL plus permanent `import {}` blocks (see
+// EmitImportedTF). Confirming that a real `terraform plan` produces only the
+// expected import operations and provenance-tag repairs is a runtime check;
+// it lives in the reliable repo, not in the composer's pre-plan validators.
+// See docs/managed-resource-tiers.md "Composer responsibilities for imported
+// resources" and "Plan acceptance rules".
 //
 // The full model is documented in docs/managed-resource-tiers.md, especially
 // the sections "How this maps to the current pkg/composer IR" (lines 406-544),

--- a/pkg/composer/imported/imported_test.go
+++ b/pkg/composer/imported/imported_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -142,18 +141,45 @@ func TestImportedResource_RoundTrip_Full(t *testing.T) {
 			},
 		},
 		GraduationCandidate: &PresetMatch{
-			PresetKey:  composer.KeyAWSSQS,
+			PresetKey:  "aws_sqs",
 			Confidence: 0.85,
 			MovedBlocks: []MovedBlock{
 				{From: "aws_sqs_queue.dlq", To: "module.aws_sqs.aws_sqs_queue.dlq"},
 			},
-			BlockingDeltas: []composer.FieldDiff{
+			BlockingDeltas: []FieldDelta{
 				{Field: "fifo_queue", From: "false", To: "true"},
 			},
 		},
 	}
 	got := mustRoundTripIdenticalResource(t, r)
 	assert.Equal(t, r, got)
+}
+
+// TestImportedResource_RoundTrip_Missing exercises the TierImportedMissing
+// path with an operator-chosen Remediation. The composer reads Remediation to
+// decide whether to emit a recreate block or block the apply entirely.
+func TestImportedResource_RoundTrip_Missing(t *testing.T) {
+	t.Parallel()
+	for _, action := range []MissingAction{
+		ActionRemoveFromInsideOut,
+		ActionRecreateFromLastImport,
+		ActionReclaimExisting,
+	} {
+		t.Run(string(action), func(t *testing.T) {
+			t.Parallel()
+			r := ImportedResource{
+				Identity:    fullIdentity(),
+				Tier:        TierImportedMissing,
+				Source:      SourceImporter,
+				Remediation: action,
+			}
+			got := mustRoundTripIdenticalResource(t, r)
+			assert.Equal(t, r, got)
+			b, err := json.Marshal(r)
+			require.NoError(t, err)
+			assert.Contains(t, string(b), `"remediation":"`+string(action)+`"`)
+		})
+	}
 }
 
 // TestOmitEmpty pins the exact JSON shape of zero-or-minimal values for every
@@ -243,23 +269,22 @@ func TestFieldEdit_MarshalJSON_ConvertsToUTC(t *testing.T) {
 func TestPresetMatch_RoundTrip(t *testing.T) {
 	t.Parallel()
 	pm := PresetMatch{
-		PresetKey:  composer.KeyAWSVPC,
+		PresetKey:  "aws_vpc",
 		Confidence: 0.42,
 		MovedBlocks: []MovedBlock{
 			{From: "aws_vpc.main", To: "module.aws_vpc.aws_vpc.main"},
 			{From: "aws_subnet.a", To: "module.aws_vpc.aws_subnet.a"},
 		},
-		BlockingDeltas: []composer.FieldDiff{
+		BlockingDeltas: []FieldDelta{
 			{Field: "cidr_block", From: "10.0.0.0/16", To: "10.1.0.0/16"},
 		},
 	}
 	b, err := json.Marshal(pm)
 	require.NoError(t, err)
 
-	// Cross-package byte assertion: catches an upstream rename of
-	// composer.FieldDiff or composer.ComponentKey JSON tags here, in the
-	// package that owns the contract, instead of in some downstream
-	// consumer's failure stack.
+	// Cross-package byte assertion: pins the wire shape of PresetMatch.
+	// FieldDelta's JSON tags match composer.FieldDiff exactly so consumers
+	// reading this envelope across the boundary see no change.
 	s := string(b)
 	assert.Contains(t, s, `"preset_key":"aws_vpc"`)
 	assert.Contains(t, s, `"field":"cidr_block"`)

--- a/pkg/composer/imported/resource.go
+++ b/pkg/composer/imported/resource.go
@@ -3,8 +3,6 @@ package imported
 import (
 	"encoding/json"
 	"time"
-
-	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
 )
 
 // Note on Attrs vs Attributes: ImportedResource carries two attribute
@@ -64,6 +62,12 @@ type ImportedResource struct {
 	// imported graph could be wrapped in a preset module call. Phase 3+;
 	// see decision #16 in the design doc.
 	GraduationCandidate *PresetMatch `json:"graduation_candidate,omitempty"`
+
+	// Remediation is the operator-chosen action for a TierImportedMissing
+	// resource. Empty for non-Missing tiers; the composer blocks emission
+	// of a TierImportedMissing resource until Remediation is set. See
+	// docs/managed-resource-tiers.md "ImportedMissing operator actions".
+	Remediation MissingAction `json:"remediation,omitempty"`
 }
 
 // FieldEdit is audit/conflict metadata for one model-side edit to a single
@@ -91,16 +95,33 @@ func (f FieldEdit) MarshalJSON() ([]byte, error) {
 // PresetMatch is a forward-declared graduation hint. It is populated by the
 // shape-matcher (Phase 3+) when an imported resource could be wrapped in a
 // preset module call. Composer never reads this field today.
+//
+// PresetKey and BlockingDeltas use plain types (string and FieldDelta) rather
+// than composer.ComponentKey / composer.FieldDiff so this package does not
+// import composer. That keeps the dependency direction one-way (composer →
+// imported) and lets the composer call into emission/validation helpers
+// without import cycles. The JSON shape matches composer.FieldDiff exactly,
+// so callers reading or writing JSON across the boundary need no change.
 type PresetMatch struct {
-	// PresetKey identifies the candidate preset module.
-	PresetKey composer.ComponentKey `json:"preset_key,omitempty"`
+	// PresetKey identifies the candidate preset module. Wire format matches
+	// composer.ComponentKey (which is type ComponentKey string).
+	PresetKey string `json:"preset_key,omitempty"`
 	// Confidence is a 0.0-1.0 score from the matcher.
 	Confidence float64 `json:"confidence,omitempty"`
 	// MovedBlocks are the proposed `moved {}` blocks for promotion.
 	MovedBlocks []MovedBlock `json:"moved_blocks,omitempty"`
 	// BlockingDeltas are attributes that would have to change to fit the
-	// preset shape.
-	BlockingDeltas []composer.FieldDiff `json:"blocking_deltas,omitempty"`
+	// preset shape. JSON shape matches composer.FieldDiff.
+	BlockingDeltas []FieldDelta `json:"blocking_deltas,omitempty"`
+}
+
+// FieldDelta is a per-attribute before/after pair for graduation diffs. Its
+// JSON shape matches composer.FieldDiff so consumers that already read those
+// fields by name see no change.
+type FieldDelta struct {
+	Field string `json:"field"`
+	From  string `json:"from"`
+	To    string `json:"to"`
 }
 
 // MovedBlock is the minimal shape of a Terraform `moved {}` block: a from /

--- a/pkg/composer/imported_compose_test.go
+++ b/pkg/composer/imported_compose_test.go
@@ -1,0 +1,336 @@
+package composer
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// TestComposeStackWithIssues_Imported_AWS exercises the end-to-end path:
+// ComposeStackWithIssues runs the imported validator, emits /imported.tf,
+// and adds the aws.imported provider alias in /providers.tf — alongside an
+// unrelated preset module call. The composed root must remain HCL-valid.
+func TestComposeStackWithIssues_Imported_AWS(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-east-1",
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_sqs_queue",
+					Address:  "aws_sqs_queue.orders_dlq",
+					ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders-DLQ",
+				},
+				Tier:  imported.TierImportedFlat,
+				Attrs: []byte(`{"Name":{"Literal":"orders-DLQ"}}`),
+			},
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_dynamodb_table",
+					Address:  "aws_dynamodb_table.users",
+					ImportID: "users",
+				},
+				Tier: imported.TierImportedConformant,
+				Attributes: map[string]any{
+					"name":     "users",
+					"hash_key": "id",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	importedTF := string(res.Files["/imported.tf"])
+	require.NotEmpty(t, importedTF, "/imported.tf must be emitted")
+	assert.Contains(t, importedTF, `resource "aws_sqs_queue" "orders_dlq"`)
+	assert.Contains(t, importedTF, `resource "aws_dynamodb_table" "users"`)
+	assert.Contains(t, importedTF, "import {")
+	assert.Contains(t, importedTF, "to = aws_sqs_queue.orders_dlq")
+	assert.Contains(t, importedTF, "to = aws_dynamodb_table.users")
+
+	providersTF := string(res.Files["/providers.tf"])
+	assert.Contains(t, providersTF, `alias  = "imported"`,
+		"providers.tf must declare the aws.imported alias")
+	assertImportedProviderHasNoDefaultTags(t, providersTF, "aws")
+
+	// Composed root must parse cleanly — ValidateComposedRoot is the
+	// terminal gate. No HCL parse issues should appear in res.Issues.
+	for _, iss := range res.Issues {
+		require.NotEqualf(t, "hcl_parse_error", iss.Code,
+			"composed root must parse: %+v", iss)
+	}
+}
+
+// TestComposeStackWithIssues_Imported_GCP mirrors the AWS case with a GCP
+// selected key and an imported google_pubsub_topic.
+func TestComposeStackWithIssues_Imported_GCP(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPVPC},
+		Comps:        &Components{Cloud: "GCP"},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-central1",
+		GCPProjectID: "demo-project-12345",
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "gcp",
+					Type:     "google_pubsub_topic",
+					Address:  "google_pubsub_topic.events",
+					ImportID: "projects/demo-project-12345/topics/events",
+				},
+				Tier:  imported.TierImportedFlat,
+				Attrs: []byte(`{"Name":{"Literal":"events"}}`),
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	importedTF := string(res.Files["/imported.tf"])
+	require.NotEmpty(t, importedTF)
+	assert.Contains(t, importedTF, `resource "google_pubsub_topic" "events"`)
+	assert.Contains(t, importedTF, "to = google_pubsub_topic.events")
+
+	providersTF := string(res.Files["/providers.tf"])
+	assert.Contains(t, providersTF, `alias   = "imported"`,
+		"providers.tf must declare google.imported alias")
+	assert.Contains(t, providersTF, "project = var.gcp_project_id",
+		"google.imported must inherit the real GCP project ID")
+	assertImportedProviderHasNoDefaultTags(t, providersTF, "gcp")
+
+	for _, iss := range res.Issues {
+		require.NotEqualf(t, "hcl_parse_error", iss.Code,
+			"composed root must parse: %+v", iss)
+	}
+}
+
+// TestComposeStackWithIssues_Imported_MissingBlocksApply pins the safety
+// invariant from issue #148 task #9: TierImportedMissing without an
+// operator-chosen Remediation must surface a validation issue, must NOT
+// emit a resource block, and must NOT declare the imported provider alias.
+func TestComposeStackWithIssues_Imported_MissingBlocksApply(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-east-1",
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_sqs_queue",
+					Address:  "aws_sqs_queue.legacy",
+					ImportID: "https://sqs.us-east-1.amazonaws.com/123/legacy",
+				},
+				Tier: imported.TierImportedMissing,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	codes := make([]string, 0, len(res.Issues))
+	for _, iss := range res.Issues {
+		codes = append(codes, iss.Code)
+	}
+	assert.Contains(t, codes, "imported_resource_missing_remediation",
+		"validator must surface missing-remediation block")
+
+	_, hasImportedTF := res.Files["/imported.tf"]
+	assert.False(t, hasImportedTF,
+		"no imported.tf should be emitted when only blocked records are present")
+
+	providersTF := string(res.Files["/providers.tf"])
+	assert.NotContains(t, providersTF, `alias  = "imported"`,
+		"no aws.imported alias should be declared when nothing emits")
+}
+
+// TestComposeStackWithIssues_Imported_StrictValidateEscalates pins that
+// StrictValidate=true escalates an imported_resource_* issue into the
+// aggregated error from ComposeStackWithIssues. Files are still returned so
+// callers can inspect the partial output.
+func TestComposeStackWithIssues_Imported_StrictValidateEscalates(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	_, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:          "aws",
+		SelectedKeys:   []ComponentKey{KeyAWSVPC},
+		Comps:          &Components{Cloud: "AWS"},
+		Cfg:            &Config{},
+		Project:        "demo",
+		Region:         "us-east-1",
+		StrictValidate: true,
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_sqs_queue",
+					Address:  "aws_sqs_queue.bad",
+					ImportID: "", // missing
+				},
+				Tier: imported.TierImportedFlat,
+			},
+		},
+	})
+	require.Error(t, err, "StrictValidate must escalate validator issues")
+	// summarizeIssues renders "<field>: <reason>"; assert against a stable
+	// substring of the reason copy that names the missing piece.
+	assert.Contains(t, err.Error(), "imported.aws_sqs_queue.bad")
+	assert.Contains(t, err.Error(), "ImportID")
+}
+
+// TestComposeStack_NoImportedKeepsExistingBehavior pins backward
+// compatibility: the historical (Files, error) entry point with no Imported
+// list emits no imported.tf and no aws.imported alias, byte-identical to
+// pre-#148 behavior.
+func TestComposeStack_NoImportedKeepsExistingBehavior(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	files, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+	_, hasImportedTF := files["/imported.tf"]
+	assert.False(t, hasImportedTF,
+		"composes without Imported must not produce imported.tf")
+	providers := string(files["/providers.tf"])
+	assert.NotContains(t, providers, `alias  = "imported"`,
+		"composes without Imported must not declare the aws.imported alias")
+}
+
+// TestImportedResource_EveryTierBranchExercised acts as a CI gate ensuring
+// that adding a new Tier to pkg/composer/imported lights up either the
+// validator or the emitter — no tier may silently fall through both.
+//
+// For every tier value, build a minimal ImportedResource and assert at
+// least one of:
+//   - ValidateImportedResources surfaces an issue, OR
+//   - EmitImportedTF produces non-empty bytes.
+//
+// This catches the case where someone adds Tier "ImportedHybrid" but
+// forgets to wire it into the classifier — without this gate it would
+// silently produce no validation, no emission, and no error.
+func TestImportedResource_EveryTierBranchExercised(t *testing.T) {
+	t.Parallel()
+	allTiers := []imported.Tier{
+		imported.TierComposerNative,
+		imported.TierComposerGraduated,
+		imported.TierImportedFlat,
+		imported.TierImportedConformant,
+		imported.TierImportedMissing,
+		imported.TierExternalByPolicy,
+		imported.TierExternalUnsupported,
+	}
+
+	for _, tier := range allTiers {
+		t.Run(string(tier), func(t *testing.T) {
+			t.Parallel()
+			ir := imported.ImportedResource{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_sqs_queue",
+					Address:  "aws_sqs_queue." + strings.ToLower(string(tier)),
+					ImportID: "test",
+				},
+				Tier: tier,
+			}
+			issues := ValidateImportedResources("aws", []imported.ImportedResource{ir})
+			out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir})
+
+			// Composer/External tiers are explicitly out of scope for #148:
+			// no validation issues, no emission. Verify both.
+			switch tier {
+			case imported.TierComposerNative,
+				imported.TierComposerGraduated,
+				imported.TierExternalByPolicy,
+				imported.TierExternalUnsupported:
+				assert.Empty(t, issues, "tier %q should produce no validation issues", tier)
+				assert.Empty(t, out, "tier %q should produce no emission", tier)
+				return
+			}
+
+			// Imported tiers must be reachable: either validation must
+			// surface an issue (e.g. ImportedMissing without Remediation)
+			// or emission must produce bytes.
+			assert.Truef(t, len(issues) > 0 || len(out) > 0,
+				"tier %q must light up at least one of (validator, emitter)", tier)
+		})
+	}
+}
+
+// assertImportedProviderHasNoDefaultTags asserts the imported provider alias
+// block does not carry default_tags (AWS) / default_labels (GCP). Imported
+// resources may pre-date the InsideOut session and must keep their existing
+// tags untouched.
+func assertImportedProviderHasNoDefaultTags(t *testing.T, providersTF, cloud string) {
+	t.Helper()
+	var blockPattern *regexp.Regexp
+	switch cloud {
+	case "aws":
+		blockPattern = regexp.MustCompile(`(?s)provider\s+"aws"\s*\{[^}]*alias\s*=\s*"imported"[^}]*\}`)
+	case "gcp":
+		blockPattern = regexp.MustCompile(`(?s)provider\s+"google"\s*\{[^}]*alias\s*=\s*"imported"[^}]*\}`)
+	default:
+		t.Fatalf("unsupported cloud %q", cloud)
+	}
+	match := blockPattern.FindString(providersTF)
+	require.NotEmpty(t, match, "imported provider alias block not found in providers.tf:\n%s", providersTF)
+	assert.NotContains(t, match, "default_tags",
+		"imported provider alias must not carry default_tags")
+	assert.NotContains(t, match, "default_labels",
+		"imported provider alias must not carry default_labels")
+}
+
+// pinValidateComposedRootTerminal locks in that EmitImportedTF outputs valid
+// HCL — a regression that makes ValidateComposedRoot fail would surface as
+// an hcl_parse_error issue when ComposeStackWithIssues runs. The earlier
+// integration tests assert this by checking issue codes; this one calls the
+// parser directly for a smaller failure footprint.
+func TestEmitImportedTF_ProducesValidHCL(t *testing.T) {
+	t.Parallel()
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.x", ImportID: "x",
+			},
+			Tier:       imported.TierImportedFlat,
+			Attributes: map[string]any{"name": "x"},
+		},
+	})
+	require.NotEmpty(t, out)
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "EmitImportedTF must produce valid HCL: %s", diags.Error())
+}

--- a/pkg/composer/imported_compose_test.go
+++ b/pkg/composer/imported_compose_test.go
@@ -61,13 +61,22 @@ func TestComposeStackWithIssues_Imported_AWS(t *testing.T) {
 	require.NotEmpty(t, importedTF, "/imported.tf must be emitted")
 	assert.Contains(t, importedTF, `resource "aws_sqs_queue" "orders_dlq"`)
 	assert.Contains(t, importedTF, `resource "aws_dynamodb_table" "users"`)
-	assert.Contains(t, importedTF, "import {")
-	assert.Contains(t, importedTF, "to = aws_sqs_queue.orders_dlq")
-	assert.Contains(t, importedTF, "to = aws_dynamodb_table.users")
+
+	// Each imported resource must have its `import {}` block paired with
+	// the correct id — pin (to, id) jointly so an argument-swap mutation
+	// surfaces. Walking the parsed import blocks rather than substring
+	// matching also catches re-emission of an unrelated id.
+	pairs := parseImportPairs(t, importedTF)
+	assert.Equal(t,
+		map[string]string{
+			"aws_sqs_queue.orders_dlq":   "https://sqs.us-east-1.amazonaws.com/123/orders-DLQ",
+			"aws_dynamodb_table.users":   "users",
+		},
+		pairs,
+		"every imported resource must have a paired import block with the matching id")
 
 	providersTF := string(res.Files["/providers.tf"])
-	assert.Contains(t, providersTF, `alias  = "imported"`,
-		"providers.tf must declare the aws.imported alias")
+	assertImportedAliasDeclared(t, providersTF, "aws")
 	assertImportedProviderHasNoDefaultTags(t, providersTF, "aws")
 
 	// Composed root must parse cleanly — ValidateComposedRoot is the
@@ -111,13 +120,16 @@ func TestComposeStackWithIssues_Imported_GCP(t *testing.T) {
 	importedTF := string(res.Files["/imported.tf"])
 	require.NotEmpty(t, importedTF)
 	assert.Contains(t, importedTF, `resource "google_pubsub_topic" "events"`)
-	assert.Contains(t, importedTF, "to = google_pubsub_topic.events")
+	assert.Equal(t,
+		map[string]string{"google_pubsub_topic.events": "projects/demo-project-12345/topics/events"},
+		parseImportPairs(t, importedTF),
+		"imported google resource must have a paired import block")
 
 	providersTF := string(res.Files["/providers.tf"])
-	assert.Contains(t, providersTF, `alias   = "imported"`,
-		"providers.tf must declare google.imported alias")
-	assert.Contains(t, providersTF, "project = var.gcp_project_id",
-		"google.imported must inherit the real GCP project ID")
+	assertImportedAliasDeclared(t, providersTF, "gcp")
+	assert.True(t, hasProviderAttr(providersTF, "gcp", "project", `"demo-project-12345"`),
+		"google.imported must carry project as a literal (root vars do not declare gcp_project_id):\n%s",
+		providersTF)
 	assertImportedProviderHasNoDefaultTags(t, providersTF, "gcp")
 
 	for _, iss := range res.Issues {
@@ -167,19 +179,21 @@ func TestComposeStackWithIssues_Imported_MissingBlocksApply(t *testing.T) {
 		"no imported.tf should be emitted when only blocked records are present")
 
 	providersTF := string(res.Files["/providers.tf"])
-	assert.NotContains(t, providersTF, `alias  = "imported"`,
-		"no aws.imported alias should be declared when nothing emits")
+	assertImportedAliasNotDeclared(t, providersTF, "aws")
 }
 
 // TestComposeStackWithIssues_Imported_StrictValidateEscalates pins that
 // StrictValidate=true escalates an imported_resource_* issue into the
 // aggregated error from ComposeStackWithIssues. Files are still returned so
-// callers can inspect the partial output.
+// callers can inspect the partial output. We assert by issue *code*, not by
+// error-string substring — substring matching of error messages is fragile
+// and would not catch a refactor that emitted the wrong code with the right
+// reason text.
 func TestComposeStackWithIssues_Imported_StrictValidateEscalates(t *testing.T) {
 	t.Parallel()
 
 	c := newTestClient()
-	_, err := c.ComposeStackWithIssues(ComposeStackOpts{
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
 		Cloud:          "aws",
 		SelectedKeys:   []ComponentKey{KeyAWSVPC},
 		Comps:          &Components{Cloud: "AWS"},
@@ -200,10 +214,13 @@ func TestComposeStackWithIssues_Imported_StrictValidateEscalates(t *testing.T) {
 		},
 	})
 	require.Error(t, err, "StrictValidate must escalate validator issues")
-	// summarizeIssues renders "<field>: <reason>"; assert against a stable
-	// substring of the reason copy that names the missing piece.
-	assert.Contains(t, err.Error(), "imported.aws_sqs_queue.bad")
-	assert.Contains(t, err.Error(), "ImportID")
+	require.NotNil(t, res, "files must still be returned alongside the error")
+	codes := make([]string, 0, len(res.Issues))
+	for _, iss := range res.Issues {
+		codes = append(codes, iss.Code)
+	}
+	assert.Contains(t, codes, "imported_resource_missing_import_id",
+		"the structured issue code must be present in res.Issues")
 }
 
 // TestComposeStack_NoImportedKeepsExistingBehavior pins backward
@@ -227,8 +244,7 @@ func TestComposeStack_NoImportedKeepsExistingBehavior(t *testing.T) {
 	assert.False(t, hasImportedTF,
 		"composes without Imported must not produce imported.tf")
 	providers := string(files["/providers.tf"])
-	assert.NotContains(t, providers, `alias  = "imported"`,
-		"composes without Imported must not declare the aws.imported alias")
+	assertImportedAliasNotDeclared(t, providers, "aws")
 }
 
 // TestImportedResource_EveryTierBranchExercised acts as a CI gate ensuring
@@ -291,27 +307,94 @@ func TestImportedResource_EveryTierBranchExercised(t *testing.T) {
 	}
 }
 
+// providerKindForCloud maps the cloud token to the provider name used in
+// HCL ("aws" or "google"). Centralised so the helpers below stay in sync.
+func providerKindForCloud(cloud string) string {
+	if cloud == "gcp" {
+		return "google"
+	}
+	return "aws"
+}
+
+// importedAliasBlockPattern returns a regex that matches the imported alias
+// block for cloud, tolerant of hclwrite's variable equal-sign alignment.
+func importedAliasBlockPattern(cloud string) *regexp.Regexp {
+	provider := providerKindForCloud(cloud)
+	return regexp.MustCompile(`(?s)provider\s+"` + provider + `"\s*\{[^}]*alias\s*=\s*"imported"[^}]*\}`)
+}
+
+// assertImportedAliasDeclared asserts a `provider "<provider>" { alias =
+// "imported" ... }` block exists in providersTF for cloud. Tolerant of
+// hclwrite's equal-sign alignment so adding sibling attributes doesn't
+// silently break the assertion.
+func assertImportedAliasDeclared(t *testing.T, providersTF, cloud string) {
+	t.Helper()
+	require.Regexp(t, importedAliasBlockPattern(cloud), providersTF,
+		"imported provider alias for %q must be declared:\n%s", cloud, providersTF)
+}
+
+// assertImportedAliasNotDeclared asserts no imported alias block exists.
+func assertImportedAliasNotDeclared(t *testing.T, providersTF, cloud string) {
+	t.Helper()
+	assert.NotRegexp(t, importedAliasBlockPattern(cloud), providersTF,
+		"unexpected imported alias for %q in providers.tf:\n%s", cloud, providersTF)
+}
+
+// hasProviderAttr reports whether the imported alias block for cloud contains
+// `<name> = <value>` (whitespace-tolerant).
+func hasProviderAttr(providersTF, cloud, name, value string) bool {
+	block := importedAliasBlockPattern(cloud).FindString(providersTF)
+	if block == "" {
+		return false
+	}
+	pattern := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(name) + `\s*=\s*` + regexp.QuoteMeta(value) + `\s*$`)
+	return pattern.MatchString(block)
+}
+
 // assertImportedProviderHasNoDefaultTags asserts the imported provider alias
 // block does not carry default_tags (AWS) / default_labels (GCP). Imported
 // resources may pre-date the InsideOut session and must keep their existing
 // tags untouched.
 func assertImportedProviderHasNoDefaultTags(t *testing.T, providersTF, cloud string) {
 	t.Helper()
-	var blockPattern *regexp.Regexp
-	switch cloud {
-	case "aws":
-		blockPattern = regexp.MustCompile(`(?s)provider\s+"aws"\s*\{[^}]*alias\s*=\s*"imported"[^}]*\}`)
-	case "gcp":
-		blockPattern = regexp.MustCompile(`(?s)provider\s+"google"\s*\{[^}]*alias\s*=\s*"imported"[^}]*\}`)
-	default:
-		t.Fatalf("unsupported cloud %q", cloud)
-	}
-	match := blockPattern.FindString(providersTF)
+	match := importedAliasBlockPattern(cloud).FindString(providersTF)
 	require.NotEmpty(t, match, "imported provider alias block not found in providers.tf:\n%s", providersTF)
 	assert.NotContains(t, match, "default_tags",
 		"imported provider alias must not carry default_tags")
 	assert.NotContains(t, match, "default_labels",
 		"imported provider alias must not carry default_labels")
+}
+
+// parseImportPairs walks importedTF and returns map[address]importID for
+// every `import {}` block. Joint extraction defends against argument-swap
+// regressions that would still pass a substring-only assertion.
+func parseImportPairs(t *testing.T, importedTF string) map[string]string {
+	t.Helper()
+	file, diags := hclsyntax.ParseConfig([]byte(importedTF), "imported.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "parseImportPairs: %s", diags.Error())
+	body, ok := file.Body.(*hclsyntax.Body)
+	require.True(t, ok)
+	pairs := map[string]string{}
+	for _, blk := range body.Blocks {
+		if blk.Type != "import" {
+			continue
+		}
+		toAttr, ok := blk.Body.Attributes["to"]
+		require.True(t, ok, "import block missing `to`")
+		idAttr, ok := blk.Body.Attributes["id"]
+		require.True(t, ok, "import block missing `id`")
+
+		// `to` is a traversal expression — capture verbatim source text.
+		toRange := toAttr.Expr.Range()
+		to := strings.TrimSpace(importedTF[toRange.Start.Byte:toRange.End.Byte])
+
+		// `id` is a string literal.
+		idVal, _ := idAttr.Expr.Value(nil)
+		require.True(t, idVal.IsKnown() && idVal.Type().FriendlyName() == "string",
+			"import id must be a string literal")
+		pairs[to] = idVal.AsString()
+	}
+	return pairs
 }
 
 // pinValidateComposedRootTerminal locks in that EmitImportedTF outputs valid

--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -1,0 +1,282 @@
+package composer
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// emitMode classifies how a single ImportedResource is rendered.
+type emitMode int
+
+const (
+	emitModeSkip            emitMode = iota // not rendered (External tiers, Missing without remediation)
+	emitModeResourceImport                  // resource block + import block (Flat / Conformant / Missing+Reclaim)
+	emitModeResourceOnly                    // resource block, no import (Missing+Recreate)
+	emitModeRemovedBlock                    // `removed { from = ... lifecycle { destroy = false } }` only
+)
+
+// EmitImportedTF emits the contents of /imported.tf for the supplied imported
+// resources, restricted to those that match the compose cloud. The returned
+// providersUsed map carries "aws":true and/or "gcp":true to signal which
+// imported provider aliases the caller must declare in providers.tf.
+//
+// Resources whose tier is not emit-eligible are silently skipped — the
+// validator (ValidateImportedResources) is responsible for reporting blocking
+// issues separately. EmitImportedTF returns nil bytes when no resource
+// emits.
+func EmitImportedTF(cloud string, irs []imported.ImportedResource) (out []byte, providersUsed map[string]bool) {
+	if len(irs) == 0 {
+		return nil, nil
+	}
+	wantCloud := strings.ToLower(strings.TrimSpace(cloud))
+	providersUsed = map[string]bool{}
+
+	type entry struct {
+		address  string
+		resource []byte // resource "..." "..." { ... } including provider attr
+		imported []byte // import { to = ...; id = "..." } block
+		removed  []byte // removed { from = ...; lifecycle { destroy = false } }
+	}
+
+	var entries []entry
+	for _, ir := range irs {
+		got := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
+		if got != "aws" && got != "gcp" {
+			continue
+		}
+		if wantCloud != "" && got != wantCloud {
+			continue
+		}
+		mode := classifyEmitMode(ir)
+		if mode == emitModeSkip {
+			continue
+		}
+		addr := strings.TrimSpace(ir.Identity.Address)
+		if addr == "" {
+			continue
+		}
+
+		e := entry{address: addr}
+		switch mode {
+		case emitModeResourceImport, emitModeResourceOnly:
+			body, err := emitImportedResourceBody(ir)
+			if err != nil {
+				continue
+			}
+			e.resource = wrapResourceBlock(ir.Identity.Type, addressLabel(addr), providerAliasFor(got), body)
+			if mode == emitModeResourceImport {
+				e.imported = renderImportBlock(addr, ir.Identity.ImportID)
+			}
+			providersUsed[got] = true
+		case emitModeRemovedBlock:
+			e.removed = renderRemovedBlock(addr)
+		}
+		entries = append(entries, e)
+	}
+
+	if len(entries) == 0 {
+		return nil, providersUsed
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].address < entries[j].address })
+
+	var doc bytes.Buffer
+	// Imports first (sorted), then resources (sorted), then removed blocks
+	// (sorted). Each section separated by a blank line.
+	for _, e := range entries {
+		if len(e.imported) == 0 {
+			continue
+		}
+		doc.Write(e.imported)
+		doc.WriteString("\n\n")
+	}
+	for _, e := range entries {
+		if len(e.resource) == 0 {
+			continue
+		}
+		doc.Write(e.resource)
+		doc.WriteString("\n\n")
+	}
+	for _, e := range entries {
+		if len(e.removed) == 0 {
+			continue
+		}
+		doc.Write(e.removed)
+		doc.WriteString("\n\n")
+	}
+
+	// Round-trip through hclwrite for canonical formatting (mirrors
+	// normalizeTfBytes for module bodies).
+	formatted, diags := hclwrite.ParseConfig(doc.Bytes(), "imported.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		// Fall back to the raw concatenation if parse failed; ValidateComposedRoot
+		// will surface the parse error so the caller still sees the failure.
+		return doc.Bytes(), providersUsed
+	}
+	return formatted.Bytes(), providersUsed
+}
+
+// classifyEmitMode decides what artifact(s) to emit for ir.
+func classifyEmitMode(ir imported.ImportedResource) emitMode {
+	switch ir.Tier {
+	case imported.TierImportedFlat, imported.TierImportedConformant:
+		return emitModeResourceImport
+	case imported.TierImportedMissing:
+		switch ir.Remediation {
+		case imported.ActionReclaimExisting:
+			return emitModeResourceImport
+		case imported.ActionRecreateFromLastImport:
+			return emitModeResourceOnly
+		case imported.ActionRemoveFromInsideOut:
+			return emitModeRemovedBlock
+		}
+	}
+	return emitModeSkip
+}
+
+// emitImportedResourceBody returns the HCL body bytes (no surrounding
+// `resource "..." "..." { ... }` wrapper) for ir. Branches on whether the
+// carrier carries typed Attrs or only opaque Attributes.
+func emitImportedResourceBody(ir imported.ImportedResource) ([]byte, error) {
+	if len(ir.Attrs) > 0 {
+		typed, err := generated.UnmarshalAttrs(ir.Identity.Type, ir.Attrs)
+		if err != nil {
+			return nil, fmt.Errorf("decode typed Attrs for %q: %w", ir.Identity.Type, err)
+		}
+		body, err := generated.MarshalHCL(typed)
+		if err != nil {
+			return nil, fmt.Errorf("marshal typed body for %q: %w", ir.Identity.Type, err)
+		}
+		return body, nil
+	}
+	return emitOpaqueAttrsBody(ir)
+}
+
+// emitOpaqueAttrsBody renders ir.Attributes as HCL body. Skips computed-only
+// fields when a generated schema is registered for ir.Identity.Type;
+// otherwise emits every key (Phase 1 wire-compat fallback).
+func emitOpaqueAttrsBody(ir imported.ImportedResource) ([]byte, error) {
+	if len(ir.Attributes) == 0 {
+		return nil, nil
+	}
+	_, schema, hasSchema := generated.Lookup(ir.Identity.Type)
+
+	keys := make([]string, 0, len(ir.Attributes))
+	for k := range ir.Attributes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	f := hclwrite.NewEmptyFile()
+	body := f.Body()
+
+	for _, k := range keys {
+		if hasSchema {
+			if fs, ok := schema[k]; ok && !fs.Configurable() {
+				continue
+			}
+		}
+		v := ir.Attributes[k]
+		if err := writeOpaqueAttr(body, k, v); err != nil {
+			return nil, fmt.Errorf("attr %q: %w", k, err)
+		}
+	}
+	return bytes.TrimRight(f.Bytes(), "\n"), nil
+}
+
+// writeOpaqueAttr emits one attribute. RawExpr values pass through as raw
+// tokens; everything else converts via toCty.
+func writeOpaqueAttr(body *hclwrite.Body, name string, v any) error {
+	if re, ok := v.(RawExpr); ok {
+		toks, ok := extractExprTokens(name, re.Expr)
+		if !ok {
+			return fmt.Errorf("could not tokenize raw expression %q", re.Expr)
+		}
+		body.SetAttributeRaw(name, toks)
+		return nil
+	}
+	if v == nil {
+		body.SetAttributeValue(name, cty.NullVal(cty.DynamicPseudoType))
+		return nil
+	}
+	cv, err := toCty(v)
+	if err != nil {
+		return err
+	}
+	body.SetAttributeValue(name, cv)
+	return nil
+}
+
+// wrapResourceBlock builds `resource "<type>" "<label>" { provider = <alias>;
+// <body> }` as a byte slice for downstream concatenation. Body bytes are
+// inserted verbatim; the outer hclwrite.ParseConfig pass canonicalises
+// formatting.
+func wrapResourceBlock(tfType, label, providerAlias string, body []byte) []byte {
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "resource %q %q {\n", tfType, label)
+	fmt.Fprintf(&b, "  provider = %s\n", providerAlias)
+	if len(body) > 0 {
+		// Indent each body line by 2 spaces. hclwrite-emitted bodies don't
+		// carry leading indent because they are rooted at column 0; the
+		// outer ParseConfig will re-format anyway, but indenting now keeps
+		// the pre-format intermediate readable in fallback paths.
+		lines := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
+		for _, line := range lines {
+			if line == "" {
+				b.WriteString("\n")
+				continue
+			}
+			b.WriteString("  ")
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("}")
+	return b.Bytes()
+}
+
+// renderImportBlock emits `import { to = <address>; id = "<importID>" }`.
+// The id is always quoted as a string literal (Terraform's import block
+// accepts this for every provider).
+func renderImportBlock(address, importID string) []byte {
+	return fmt.Appendf(nil, "import {\n  to = %s\n  id = %q\n}", address, importID)
+}
+
+// renderRemovedBlock emits the Terraform `removed {}` block used when an
+// imported resource is being detached from InsideOut without being deleted.
+func renderRemovedBlock(address string) []byte {
+	return fmt.Appendf(nil, "removed {\n  from = %s\n  lifecycle {\n    destroy = false\n  }\n}", address)
+}
+
+// providerAliasFor returns the imported provider alias for cloud. Cloud is
+// expected to be lower-cased ("aws" or "gcp"); other inputs fall back to
+// "aws.imported" so the caller still produces valid HCL while the validator
+// surfaces the cloud mismatch.
+func providerAliasFor(cloud string) string {
+	switch cloud {
+	case "gcp":
+		return "google.imported"
+	default:
+		return "aws.imported"
+	}
+}
+
+// addressLabel extracts the Terraform label part of a fully-qualified address
+// like "aws_sqs_queue.orders_dlq" → "orders_dlq". Returns the original input
+// if no separator is found (defensive — the validator rejects empty/malformed
+// addresses).
+func addressLabel(address string) string {
+	if _, label, ok := strings.Cut(address, "."); ok {
+		return label
+	}
+	return address
+}

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
@@ -107,7 +108,11 @@ func TestEmitImportedTF_OpaqueAttributes(t *testing.T) {
 	assert.True(t, hasAttr(t, s, "name", `"users"`), "name attr missing in:\n%s", s)
 	assert.True(t, hasAttr(t, s, "hash_key", `"id"`), "hash_key attr missing in:\n%s", s)
 	assert.Contains(t, s, "tags = {")
-	assert.Contains(t, s, "Project")
+	// Pin tag value with hasAttr so a regression that emits "Project = arn"
+	// or moves the value elsewhere fails this test rather than passing on
+	// a substring of a different attribute.
+	assert.True(t, hasAttr(t, s, "Project", `"demo"`),
+		"tags.Project = \"demo\" attr missing in:\n%s", s)
 	arnPattern := regexp.MustCompile(`(?m)^\s*arn\s*=`)
 	assert.False(t, arnPattern.MatchString(s),
 		"computed-only fields must be skipped when a schema is registered; got:\n%s", s)
@@ -156,7 +161,12 @@ func TestEmitImportedTF_TierGating(t *testing.T) {
 	}
 	out, used := EmitImportedTF("aws", irs)
 	assert.Nil(t, out)
-	assert.Empty(t, used)
+	// Stronger than Empty(used): assert every cloud key is explicitly
+	// false. A regression that flipped used["aws"]=true *before* the skip
+	// filter would be caught here (assert.Empty on map[string]bool returns
+	// true even when keys are present with false values).
+	assert.False(t, used["aws"], "aws alias must not be requested when nothing emits")
+	assert.False(t, used["gcp"], "gcp alias must not be requested when nothing emits")
 }
 
 func TestEmitImportedTF_MissingRemediations(t *testing.T) {
@@ -238,19 +248,49 @@ func TestEmitImportedTF_DeterministicOrder(t *testing.T) {
 			Attrs:    []byte(`{"Name":{"Literal":"x"}}`),
 		}
 	}
-	a, _ := EmitImportedTF("aws", []imported.ImportedResource{
-		mk("aws_sqs_queue.b", "ib"),
-		mk("aws_sqs_queue.a", "ia"),
-	})
-	b, _ := EmitImportedTF("aws", []imported.ImportedResource{
-		mk("aws_sqs_queue.a", "ia"),
-		mk("aws_sqs_queue.b", "ib"),
-	})
-	assert.Equal(t, string(a), string(b), "input order must not change emitted bytes")
+	// Adversarial set: prefix-overlapping addresses ("b", "b_1"),
+	// transposed pairs, and a substring-collider ("a", "aa") to surface
+	// any partial-ordering regression that a 2-element sort could miss.
+	addresses := []string{
+		"aws_sqs_queue.b",
+		"aws_sqs_queue.a",
+		"aws_sqs_queue.aa",
+		"aws_sqs_queue.b_1",
+		"aws_sqs_queue.c",
+	}
+	mkSlice := func(in []string) []imported.ImportedResource {
+		out := make([]imported.ImportedResource, len(in))
+		for i, a := range in {
+			out[i] = mk(a, "i_"+a)
+		}
+		return out
+	}
+	canonical, _ := EmitImportedTF("aws", mkSlice(addresses))
+	// Reverse the input and compare bytes — must be identical.
+	reversed := append([]string(nil), addresses...)
+	for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
+		reversed[i], reversed[j] = reversed[j], reversed[i]
+	}
+	rev, _ := EmitImportedTF("aws", mkSlice(reversed))
+	assert.Equal(t, string(canonical), string(rev),
+		"input order must not change emitted bytes")
 
-	idxA := strings.Index(string(a), "aws_sqs_queue.a")
-	idxB := strings.Index(string(a), "aws_sqs_queue.b")
-	assert.True(t, idxA < idxB, "alphabetical ordering by address")
+	// Verify each address appears in alphabetical order in the resource
+	// section of the canonical output.
+	canon := string(canonical)
+	want := append([]string(nil), addresses...)
+	sort.Strings(want)
+	last := -1
+	for _, a := range want {
+		// match the resource header for this address: resource "<type>" "<label>"
+		label := strings.TrimPrefix(a, "aws_sqs_queue.")
+		needle := `resource "aws_sqs_queue" "` + label + `"`
+		idx := strings.Index(canon, needle)
+		require.GreaterOrEqualf(t, idx, 0, "address %q must appear", a)
+		assert.Truef(t, idx > last,
+			"address %q at idx %d must appear after the previous (idx=%d)", a, idx, last)
+		last = idx
+	}
 }
 
 func TestProviderAliasFor(t *testing.T) {
@@ -265,4 +305,161 @@ func TestAddressLabel(t *testing.T) {
 	assert.Equal(t, "orders_dlq", addressLabel("aws_sqs_queue.orders_dlq"))
 	assert.Equal(t, "events", addressLabel("google_pubsub_topic.events"))
 	assert.Equal(t, "noop", addressLabel("noop"))
+}
+
+// TestEmitImportedTF_TypedDecodeFailureDropsRecord pins that an
+// ImportedResource whose Attrs cannot be decoded for the registered Type is
+// silently dropped from the output (the validator surfaces the
+// imported_resource_decode_failed code separately). Other records in the
+// same call must survive untouched.
+func TestEmitImportedTF_TypedDecodeFailureDropsRecord(t *testing.T) {
+	t.Parallel()
+	good := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.good", ImportID: "good",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: []byte(`{"Name":{"Literal":"good"}}`),
+	}
+	bad := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_unregistered_xyz", Address: "aws_unregistered_xyz.bad", ImportID: "bad",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: []byte(`{"foo":"bar"}`),
+	}
+	out, used := EmitImportedTF("aws", []imported.ImportedResource{good, bad})
+	require.NotEmpty(t, out)
+	s := string(out)
+	assert.Contains(t, s, `resource "aws_sqs_queue" "good"`,
+		"valid record must survive when a sibling record fails to decode")
+	assert.NotContains(t, s, "aws_unregistered_xyz",
+		"record with undecodable Attrs must be dropped from output entirely")
+	assert.True(t, used["aws"])
+}
+
+// TestEmitImportedTF_OpaqueRawExprMalformedDropsRecord pins that a malformed
+// RawExpr (one that extractExprTokens cannot tokenize) drops the resource
+// from the output rather than emitting broken HCL.
+func TestEmitImportedTF_OpaqueRawExprMalformedDropsRecord(t *testing.T) {
+	t.Parallel()
+	good := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.ok", ImportID: "ok",
+		},
+		Tier:       imported.TierImportedFlat,
+		Attributes: map[string]any{"name": "ok"},
+	}
+	bad := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.bad", ImportID: "bad",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"kms_master_key_id": RawExpr{Expr: "1 +"}, // unterminated expression
+		},
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{good, bad})
+	s := string(out)
+	assert.Contains(t, s, `resource "aws_sqs_queue" "ok"`)
+	assert.NotContains(t, s, "aws_sqs_queue.bad",
+		"resource with malformed RawExpr must be dropped, not partially emitted")
+}
+
+// TestEmitImportedTF_OpaqueValueTypes exercises the toCty conversion paths
+// hit by the opaque-attributes branch — ensures lists, numbers, bools, nil,
+// and nested maps all serialize and the document remains parseable HCL. A
+// regression in any single branch surfaces here rather than only in some
+// downstream consumer's edge case.
+func TestEmitImportedTF_OpaqueValueTypes(t *testing.T) {
+	t.Parallel()
+	// aws_sqs_queue is registered, so computed-only fields would be
+	// filtered. Use only configurable attributes.
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.varied", ImportID: "v",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"name":                       "varied",
+			"fifo_queue":                 true,                // bool
+			"delay_seconds":              int64(45),           // int
+			"visibility_timeout_seconds": float64(30),         // float
+			"kms_master_key_id":          nil,                 // null
+			"tags": map[string]any{ // nested map
+				"Project": "demo",
+				"Owner":   "ops",
+			},
+		},
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir})
+	s := string(out)
+	assert.True(t, hasAttr(t, s, "name", `"varied"`), "string attr in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "fifo_queue", "true"), "bool attr in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "delay_seconds", "45"), "int attr in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "visibility_timeout_seconds", "30"), "float attr in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "kms_master_key_id", "null"), "null attr in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "Project", `"demo"`), "nested map value in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "Owner", `"ops"`), "nested map value in:\n%s", s)
+
+	// Document still parses.
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "varied opaque attrs must parse: %s", diags.Error())
+}
+
+// TestEmitImportedTF_EmptyAttrsEmitsBareResource pins behaviour for a Flat
+// resource with no Attrs and no Attributes: it still gets a resource block
+// (provider attribute only) and a paired import block. The validator
+// surfaces no error because Identity is otherwise complete.
+func TestEmitImportedTF_EmptyAttrsEmitsBareResource(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.bare", ImportID: "bare",
+		},
+		Tier: imported.TierImportedFlat,
+	}
+	out, used := EmitImportedTF("aws", []imported.ImportedResource{ir})
+	s := string(out)
+	assert.Contains(t, s, `resource "aws_sqs_queue" "bare"`)
+	assert.True(t, hasAttr(t, s, "provider", "aws.imported"))
+	assert.Contains(t, s, "to = aws_sqs_queue.bare")
+	assert.True(t, used["aws"])
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors())
+}
+
+// TestEmitImportedTF_SectionOrdering pins that imports come before
+// resources, which come before removed{} blocks. Mixing them would still
+// validate but interleaves cognitive load when reading the file.
+func TestEmitImportedTF_SectionOrdering(t *testing.T) {
+	t.Parallel()
+	irs := []imported.ImportedResource{
+		// Removed block (Missing + ActionRemoveFromInsideOut).
+		{
+			Identity:    imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.gone", ImportID: "g"},
+			Tier:        imported.TierImportedMissing,
+			Remediation: imported.ActionRemoveFromInsideOut,
+		},
+		// Standard imported.
+		{
+			Identity:   imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.live", ImportID: "l"},
+			Tier:       imported.TierImportedFlat,
+			Attributes: map[string]any{"name": "live"},
+		},
+	}
+	out, _ := EmitImportedTF("aws", irs)
+	s := string(out)
+	idxImport := strings.Index(s, "import {")
+	idxResource := strings.Index(s, `resource "aws_sqs_queue"`)
+	idxRemoved := strings.Index(s, "removed {")
+	require.True(t, idxImport >= 0 && idxResource >= 0 && idxRemoved >= 0,
+		"every section must appear; got idxImport=%d idxResource=%d idxRemoved=%d",
+		idxImport, idxResource, idxRemoved)
+	assert.Truef(t, idxImport < idxResource,
+		"imports must precede resources; idxImport=%d idxResource=%d",
+		idxImport, idxResource)
+	assert.Truef(t, idxResource < idxRemoved,
+		"resources must precede removed blocks; idxResource=%d idxRemoved=%d",
+		idxResource, idxRemoved)
 }

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -1,0 +1,268 @@
+package composer
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// hasAttr checks for an HCL attribute named `name` with `value` while
+// tolerating hclwrite's variable equal-sign alignment.
+func hasAttr(t *testing.T, body, name, value string) bool {
+	t.Helper()
+	pattern := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(name) + `\s*=\s*` + regexp.QuoteMeta(value) + `\s*$`)
+	return pattern.MatchString(body)
+}
+
+func TestEmitImportedTF_Empty(t *testing.T) {
+	t.Parallel()
+	out, used := EmitImportedTF("aws", nil)
+	assert.Nil(t, out)
+	assert.Nil(t, used)
+}
+
+func TestEmitImportedTF_TypedAWS(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.orders_dlq",
+			ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders-DLQ",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: []byte(`{"Name":{"Literal":"orders-DLQ"},"FIFOQueue":{"Literal":false}}`),
+	}
+	out, used := EmitImportedTF("aws", []imported.ImportedResource{ir})
+	require.NotNil(t, out)
+	s := string(out)
+	assert.True(t, used["aws"])
+	assert.False(t, used["gcp"])
+	assert.Contains(t, s, `resource "aws_sqs_queue" "orders_dlq"`)
+	assert.True(t, hasAttr(t, s, "provider", "aws.imported"), "provider attribute missing in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "name", `"orders-DLQ"`), "name attr missing in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "fifo_queue", "false"), "fifo_queue attr missing in:\n%s", s)
+	// import block paired with the resource.
+	assert.Contains(t, s, "import {")
+	assert.Contains(t, s, "to = aws_sqs_queue.orders_dlq")
+	assert.Contains(t, s, `id = "https://sqs.us-east-1.amazonaws.com/123/orders-DLQ"`)
+	// Output must parse as valid HCL.
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "imported.tf must parse: %s", diags.Error())
+}
+
+func TestEmitImportedTF_TypedGCP(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "gcp",
+			Type:     "google_pubsub_topic",
+			Address:  "google_pubsub_topic.events",
+			ImportID: "projects/my-project/topics/events",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: []byte(`{"Name":{"Literal":"events"}}`),
+	}
+	out, used := EmitImportedTF("gcp", []imported.ImportedResource{ir})
+	require.NotNil(t, out)
+	s := string(out)
+	assert.True(t, used["gcp"])
+	assert.False(t, used["aws"])
+	assert.Contains(t, s, `resource "google_pubsub_topic" "events"`)
+	assert.True(t, hasAttr(t, s, "provider", "google.imported"), "provider attr missing in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "name", `"events"`), "name attr missing in:\n%s", s)
+	assert.Contains(t, s, "to = google_pubsub_topic.events")
+}
+
+func TestEmitImportedTF_OpaqueAttributes(t *testing.T) {
+	t.Parallel()
+	// aws_dynamodb_table is a registered type; schema lookup applies, so
+	// computed-only fields are filtered. arn is computed; name is optional.
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_dynamodb_table",
+			Address:  "aws_dynamodb_table.users",
+			ImportID: "users",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"name":     "users",
+			"hash_key": "id",
+			"arn":      "arn:aws:dynamodb:us-east-1:123:table/users", // computed-only, must be filtered
+			"tags": map[string]any{
+				"Project": "demo",
+			},
+		},
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir})
+	s := string(out)
+	assert.True(t, hasAttr(t, s, "name", `"users"`), "name attr missing in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "hash_key", `"id"`), "hash_key attr missing in:\n%s", s)
+	assert.Contains(t, s, "tags = {")
+	assert.Contains(t, s, "Project")
+	arnPattern := regexp.MustCompile(`(?m)^\s*arn\s*=`)
+	assert.False(t, arnPattern.MatchString(s),
+		"computed-only fields must be skipped when a schema is registered; got:\n%s", s)
+}
+
+func TestEmitImportedTF_OpaqueWithRawExpr(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.dlq",
+			ImportID: "https://sqs.us-east-1.amazonaws.com/123/dlq",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"name":              "dlq",
+			"kms_master_key_id": RawExpr{Expr: "aws_kms_key.queues.arn"},
+		},
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir})
+	s := string(out)
+	assert.True(t, hasAttr(t, s, "name", `"dlq"`), "name attr missing in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "kms_master_key_id", "aws_kms_key.queues.arn"),
+		"raw expressions must round-trip as Terraform expression text, not quoted strings; got:\n%s", s)
+}
+
+func TestEmitImportedTF_TierGating(t *testing.T) {
+	t.Parallel()
+	// External tiers and Missing-without-remediation must not produce
+	// resource or import blocks.
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_iam_role", Address: "aws_iam_role.bypass", ImportID: "bypass"},
+			Tier:     imported.TierExternalByPolicy,
+		},
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_kms_key", Address: "aws_kms_key.unsupported", ImportID: "unsup"},
+			Tier:     imported.TierExternalUnsupported,
+		},
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.missing", ImportID: "missing"},
+			Tier:     imported.TierImportedMissing,
+			// no Remediation
+		},
+	}
+	out, used := EmitImportedTF("aws", irs)
+	assert.Nil(t, out)
+	assert.Empty(t, used)
+}
+
+func TestEmitImportedTF_MissingRemediations(t *testing.T) {
+	t.Parallel()
+
+	mkResource := func(action imported.MissingAction) imported.ImportedResource {
+		return imported.ImportedResource{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_sqs_queue",
+				Address:  "aws_sqs_queue.legacy",
+				ImportID: "https://sqs.us-east-1.amazonaws.com/123/legacy",
+			},
+			Tier:        imported.TierImportedMissing,
+			Remediation: action,
+			Attributes:  map[string]any{"name": "legacy"},
+		}
+	}
+
+	t.Run("recreate emits resource only", func(t *testing.T) {
+		t.Parallel()
+		out, _ := EmitImportedTF("aws", []imported.ImportedResource{mkResource(imported.ActionRecreateFromLastImport)})
+		s := string(out)
+		assert.Contains(t, s, `resource "aws_sqs_queue" "legacy"`)
+		assert.NotContains(t, s, "import {", "recreate must NOT emit import block (resource is being recreated, not imported)")
+	})
+
+	t.Run("reclaim emits resource and import", func(t *testing.T) {
+		t.Parallel()
+		out, _ := EmitImportedTF("aws", []imported.ImportedResource{mkResource(imported.ActionReclaimExisting)})
+		s := string(out)
+		assert.Contains(t, s, `resource "aws_sqs_queue" "legacy"`)
+		assert.Contains(t, s, "import {")
+		assert.Contains(t, s, "to = aws_sqs_queue.legacy")
+	})
+
+	t.Run("remove emits removed block only", func(t *testing.T) {
+		t.Parallel()
+		out, _ := EmitImportedTF("aws", []imported.ImportedResource{mkResource(imported.ActionRemoveFromInsideOut)})
+		s := string(out)
+		assert.Contains(t, s, "removed {")
+		assert.Contains(t, s, "from = aws_sqs_queue.legacy")
+		assert.Contains(t, s, "destroy = false")
+		assert.NotContains(t, s, `resource "aws_sqs_queue"`)
+		assert.NotContains(t, s, "import {")
+	})
+}
+
+func TestEmitImportedTF_CloudFiltering(t *testing.T) {
+	t.Parallel()
+	// AWS-cloud compose with a stray GCP imported resource: the GCP record
+	// must not contribute to the output and must not flip providersUsed.
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.x", ImportID: "x"},
+			Tier:     imported.TierImportedFlat,
+			Attrs:    []byte(`{"Name":{"Literal":"x"}}`),
+		},
+		{
+			Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_pubsub_topic", Address: "google_pubsub_topic.y", ImportID: "y"},
+			Tier:     imported.TierImportedFlat,
+			Attrs:    []byte(`{"Name":{"Literal":"y"}}`),
+		},
+	}
+	out, used := EmitImportedTF("aws", irs)
+	s := string(out)
+	assert.Contains(t, s, "aws_sqs_queue.x")
+	assert.NotContains(t, s, "google_pubsub_topic.y")
+	assert.True(t, used["aws"])
+	assert.False(t, used["gcp"])
+}
+
+func TestEmitImportedTF_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+	mk := func(addr, importID string) imported.ImportedResource {
+		return imported.ImportedResource{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: addr, ImportID: importID},
+			Tier:     imported.TierImportedFlat,
+			Attrs:    []byte(`{"Name":{"Literal":"x"}}`),
+		}
+	}
+	a, _ := EmitImportedTF("aws", []imported.ImportedResource{
+		mk("aws_sqs_queue.b", "ib"),
+		mk("aws_sqs_queue.a", "ia"),
+	})
+	b, _ := EmitImportedTF("aws", []imported.ImportedResource{
+		mk("aws_sqs_queue.a", "ia"),
+		mk("aws_sqs_queue.b", "ib"),
+	})
+	assert.Equal(t, string(a), string(b), "input order must not change emitted bytes")
+
+	idxA := strings.Index(string(a), "aws_sqs_queue.a")
+	idxB := strings.Index(string(a), "aws_sqs_queue.b")
+	assert.True(t, idxA < idxB, "alphabetical ordering by address")
+}
+
+func TestProviderAliasFor(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "aws.imported", providerAliasFor("aws"))
+	assert.Equal(t, "google.imported", providerAliasFor("gcp"))
+	assert.Equal(t, "aws.imported", providerAliasFor("unknown"))
+}
+
+func TestAddressLabel(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "orders_dlq", addressLabel("aws_sqs_queue.orders_dlq"))
+	assert.Equal(t, "events", addressLabel("google_pubsub_topic.events"))
+	assert.Equal(t, "noop", addressLabel("noop"))
+}

--- a/pkg/composer/imported_validate.go
+++ b/pkg/composer/imported_validate.go
@@ -1,0 +1,180 @@
+package composer
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// ValidateImportedResources runs structural pre-emission checks on irs in the
+// context of a compose for cloud. Issues use snake_case codes matching the
+// rest of the composer:
+//
+//   - imported_resource_unknown_tier — Identity.Tier not in the known set.
+//   - imported_resource_unsupported_cloud — Identity.Cloud empty, not in
+//     {aws, gcp}, or mismatched against the compose cloud.
+//   - imported_resource_missing_address — Identity.Address empty.
+//   - imported_resource_missing_import_id — Identity.ImportID empty for an
+//     emit-eligible tier (ImportedFlat, ImportedConformant, or
+//     ImportedMissing). Phase 1 import requires a non-empty id.
+//   - imported_resource_address_collision — two resources resolve to the
+//     same Identity.Address.
+//   - imported_resource_missing_remediation — TierImportedMissing without
+//     Remediation set; the composer blocks emission until the operator picks
+//     an action.
+//   - imported_resource_decode_failed — Attrs is non-empty but
+//     generated.UnmarshalAttrs(Identity.Type, Attrs) returns an error or the
+//     type is not in the registry.
+//
+// External tiers (ExternalByPolicy, ExternalUnsupported) and ComposerNative /
+// ComposerGraduated are out of scope here — they are not emitted as flat
+// imported HCL.
+func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []ValidationIssue {
+	if len(irs) == 0 {
+		return nil
+	}
+	want := strings.ToLower(strings.TrimSpace(cloud))
+	var issues []ValidationIssue
+	addressIndex := map[string][]int{}
+
+	for i, ir := range irs {
+		field := importedField(ir, i)
+
+		if !ir.Tier.Valid() {
+			issues = append(issues, ValidationIssue{
+				Field:  field,
+				Value:  string(ir.Tier),
+				Code:   "imported_resource_unknown_tier",
+				Reason: fmt.Sprintf("imported resource has unknown tier %q; expected one of %s", string(ir.Tier), strings.Join(knownTierNames(), ", ")),
+			})
+			continue
+		}
+
+		// Tiers the composer does not emit as imported HCL skip the
+		// per-record structural checks. Out-of-scope for #148.
+		if !isImportedTier(ir.Tier) {
+			continue
+		}
+
+		got := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
+		switch {
+		case got == "":
+			issues = append(issues, ValidationIssue{
+				Field:  field,
+				Code:   "imported_resource_unsupported_cloud",
+				Reason: "imported resource has empty Identity.Cloud; expected \"aws\" or \"gcp\"",
+			})
+		case got != "aws" && got != "gcp":
+			issues = append(issues, ValidationIssue{
+				Field:   field,
+				Value:   ir.Identity.Cloud,
+				Allowed: []string{"aws", "gcp"},
+				Code:    "imported_resource_unsupported_cloud",
+				Reason:  fmt.Sprintf("imported resource has unsupported Identity.Cloud %q; expected \"aws\" or \"gcp\"", ir.Identity.Cloud),
+			})
+		case want != "" && got != want:
+			issues = append(issues, ValidationIssue{
+				Field:  field,
+				Value:  ir.Identity.Cloud,
+				Code:   "imported_resource_unsupported_cloud",
+				Reason: fmt.Sprintf("imported resource cloud %q does not match the compose cloud %q; one stack composes a single cloud", ir.Identity.Cloud, want),
+			})
+		}
+
+		addr := strings.TrimSpace(ir.Identity.Address)
+		if addr == "" {
+			issues = append(issues, ValidationIssue{
+				Field:  field,
+				Code:   "imported_resource_missing_address",
+				Reason: "imported resource has empty Identity.Address; the importer must populate it via imported.GenerateAddress before composing",
+			})
+		} else {
+			addressIndex[addr] = append(addressIndex[addr], i)
+		}
+
+		if strings.TrimSpace(ir.Identity.ImportID) == "" {
+			issues = append(issues, ValidationIssue{
+				Field:  field,
+				Code:   "imported_resource_missing_import_id",
+				Reason: "imported resource has empty Identity.ImportID; cannot emit a Terraform import {} block without a provider import id",
+			})
+		}
+
+		if ir.Tier == imported.TierImportedMissing && !ir.Remediation.Valid() {
+			issues = append(issues, ValidationIssue{
+				Field:      field,
+				Value:      string(ir.Remediation),
+				Allowed:    []string{string(imported.ActionRemoveFromInsideOut), string(imported.ActionRecreateFromLastImport), string(imported.ActionReclaimExisting)},
+				Code:       "imported_resource_missing_remediation",
+				Reason:     "TierImportedMissing requires Remediation; the composer blocks emission until an operator picks an action",
+				Suggestion: "set ImportedResource.Remediation to remove_from_insideout, recreate_from_last_import, or reclaim_existing",
+			})
+		}
+
+		if len(ir.Attrs) > 0 {
+			if _, err := generated.UnmarshalAttrs(ir.Identity.Type, ir.Attrs); err != nil {
+				issues = append(issues, ValidationIssue{
+					Field:  field,
+					Value:  ir.Identity.Type,
+					Code:   "imported_resource_decode_failed",
+					Reason: fmt.Sprintf("decode typed Attrs for %q failed: %s", ir.Identity.Type, err.Error()),
+				})
+			}
+		}
+	}
+
+	for addr, idxs := range addressIndex {
+		if len(idxs) < 2 {
+			continue
+		}
+		issues = append(issues, ValidationIssue{
+			Field:  "imported." + addr,
+			Value:  fmt.Sprintf("%d resources", len(idxs)),
+			Code:   "imported_resource_address_collision",
+			Reason: fmt.Sprintf("Terraform address %q is claimed by %d imported resources; addresses must be unique within a stack", addr, len(idxs)),
+		})
+	}
+
+	return issues
+}
+
+// isImportedTier reports whether t is a tier that the composer emits as flat
+// imported HCL (or, for ImportedMissing, would emit once Remediation is set).
+func isImportedTier(t imported.Tier) bool {
+	switch t {
+	case imported.TierImportedFlat,
+		imported.TierImportedConformant,
+		imported.TierImportedMissing:
+		return true
+	}
+	return false
+}
+
+// importedField builds the Field value for a ValidationIssue describing ir.
+// Falls back to a stable index-based identifier when Address is empty so
+// dedupeAndSortIssues still produces deterministic output.
+func importedField(ir imported.ImportedResource, idx int) string {
+	if a := strings.TrimSpace(ir.Identity.Address); a != "" {
+		return "imported." + a
+	}
+	return fmt.Sprintf("imported.[%d]", idx)
+}
+
+// knownTierNames returns the string forms of every defined Tier in stable
+// order for use in error messages.
+func knownTierNames() []string {
+	names := []string{
+		string(imported.TierComposerNative),
+		string(imported.TierComposerGraduated),
+		string(imported.TierImportedFlat),
+		string(imported.TierImportedConformant),
+		string(imported.TierImportedMissing),
+		string(imported.TierExternalByPolicy),
+		string(imported.TierExternalUnsupported),
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/composer/imported_validate_test.go
+++ b/pkg/composer/imported_validate_test.go
@@ -1,0 +1,227 @@
+package composer
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateImportedResources_Empty(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, ValidateImportedResources("aws", nil))
+	assert.Nil(t, ValidateImportedResources("aws", []imported.ImportedResource{}))
+}
+
+func TestValidateImportedResources_Codes(t *testing.T) {
+	t.Parallel()
+
+	good := imported.ResourceIdentity{
+		Cloud:    "aws",
+		Type:     "aws_sqs_queue",
+		Address:  "aws_sqs_queue.dlq",
+		ImportID: "https://sqs.us-east-1.amazonaws.com/123/dlq",
+	}
+
+	cases := []struct {
+		name       string
+		cloud      string
+		irs        []imported.ImportedResource
+		wantCodes  []string
+		denyCodes  []string
+		wantField  string
+		mustReason string
+	}{
+		{
+			name:  "happy path no issues",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{Identity: good, Tier: imported.TierImportedFlat},
+			},
+			wantCodes: nil,
+		},
+		{
+			name:  "unknown tier short-circuits per-record checks",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{Identity: good, Tier: imported.Tier("Bogus")},
+			},
+			wantCodes: []string{"imported_resource_unknown_tier"},
+			denyCodes: []string{
+				"imported_resource_missing_address",
+				"imported_resource_missing_import_id",
+			},
+		},
+		{
+			name:  "external tiers skip structural checks",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{
+					Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_iam_role"},
+					Tier:     imported.TierExternalByPolicy,
+				},
+				{
+					Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_billing_account"},
+					Tier:     imported.TierExternalUnsupported,
+				},
+			},
+			wantCodes: nil,
+			denyCodes: []string{
+				"imported_resource_missing_address",
+				"imported_resource_unsupported_cloud",
+			},
+		},
+		{
+			name:  "empty cloud surfaces unsupported_cloud",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{
+					Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.x", ImportID: "x"},
+					Tier:     imported.TierImportedFlat,
+				},
+			},
+			wantCodes: []string{"imported_resource_unsupported_cloud"},
+		},
+		{
+			name:  "azure unsupported",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{
+					Identity: imported.ResourceIdentity{Cloud: "azure", Type: "azurerm_storage", Address: "azurerm_storage.x", ImportID: "x"},
+					Tier:     imported.TierImportedFlat,
+				},
+			},
+			wantCodes: []string{"imported_resource_unsupported_cloud"},
+		},
+		{
+			name:  "cloud mismatch",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{
+					Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_storage_bucket", Address: "google_storage_bucket.x", ImportID: "x"},
+					Tier:     imported.TierImportedFlat,
+				},
+			},
+			wantCodes: []string{"imported_resource_unsupported_cloud"},
+		},
+		{
+			name:  "missing address",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{
+					Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", ImportID: "x"},
+					Tier:     imported.TierImportedFlat,
+				},
+			},
+			wantCodes: []string{"imported_resource_missing_address"},
+		},
+		{
+			name:  "missing import id",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{
+					Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.x"},
+					Tier:     imported.TierImportedFlat,
+				},
+			},
+			wantCodes: []string{"imported_resource_missing_import_id"},
+		},
+		{
+			name:  "address collision",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{Identity: good, Tier: imported.TierImportedFlat},
+				{Identity: good, Tier: imported.TierImportedFlat},
+			},
+			wantCodes: []string{"imported_resource_address_collision"},
+		},
+		{
+			name:  "missing tier blocks without remediation",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{Identity: good, Tier: imported.TierImportedMissing},
+			},
+			wantCodes: []string{"imported_resource_missing_remediation"},
+		},
+		{
+			name:  "missing tier with valid remediation passes",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{Identity: good, Tier: imported.TierImportedMissing, Remediation: imported.ActionRecreateFromLastImport},
+			},
+			wantCodes: nil,
+			denyCodes: []string{"imported_resource_missing_remediation"},
+		},
+		{
+			name:  "decode failed for unknown type with non-empty Attrs",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{
+					Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_unregistered_xyz", Address: "aws_unregistered_xyz.x", ImportID: "x"},
+					Tier:     imported.TierImportedFlat,
+					Attrs:    []byte(`{"foo":"bar"}`),
+				},
+			},
+			wantCodes: []string{"imported_resource_decode_failed"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			issues := ValidateImportedResources(tc.cloud, tc.irs)
+			got := issueCodes(issues)
+			sort.Strings(got)
+
+			want := append([]string(nil), tc.wantCodes...)
+			sort.Strings(want)
+			if len(want) == 0 {
+				assert.Empty(t, got, "codes mismatch; issues=%+v", issues)
+			} else {
+				assert.Equal(t, want, got, "codes mismatch; issues=%+v", issues)
+			}
+
+			for _, denied := range tc.denyCodes {
+				assert.NotContainsf(t, got, denied, "did not expect code %q; issues=%+v", denied, issues)
+			}
+		})
+	}
+}
+
+func TestValidateImportedResources_FieldFormat(t *testing.T) {
+	t.Parallel()
+	// Address-bearing record uses imported.<address>; address-less record
+	// falls back to imported.[<index>] so dedupeAndSortIssues is stable.
+	issues := ValidateImportedResources("aws", []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.dlq"},
+			Tier:     imported.TierImportedFlat,
+		},
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", ImportID: "x"},
+			Tier:     imported.TierImportedFlat,
+		},
+	})
+	require.NotEmpty(t, issues)
+	fields := issueFields(issues)
+	assert.Contains(t, fields, "imported.aws_sqs_queue.dlq")
+	assert.Contains(t, fields, "imported.[1]")
+}
+
+func issueCodes(issues []ValidationIssue) []string {
+	out := make([]string, 0, len(issues))
+	for _, i := range issues {
+		out = append(out, i.Code)
+	}
+	return out
+}
+
+func issueFields(issues []ValidationIssue) []string {
+	out := make([]string, 0, len(issues))
+	for _, i := range issues {
+		out = append(out, i.Field)
+	}
+	return out
+}

--- a/pkg/composer/noselfimport_test.go
+++ b/pkg/composer/noselfimport_test.go
@@ -11,16 +11,30 @@ import (
 // TestNoForeignLutherImportsInNonTestFiles guards the invariant that
 // pkg/composer's non-test code has zero luthersystems/* imports *other
 // than* its own parent package root (which is how composer discovers the
-// bundled preset FS). Any foreign luthersystems import — including any
-// subpackage of insideout-terraform-presets other than the root — would
-// couple composer to downstream consumers and block extraction. Only
-// the exact parent path is permitted; subpackage imports must fail so
-// that e.g. an "internal/" helper cannot accidentally leak in.
+// bundled preset FS) and the explicit allowlist of composer-owned
+// subpackages. Any foreign luthersystems import would couple composer to
+// downstream consumers and block extraction.
+//
+// Allowlist:
+//   - github.com/luthersystems/insideout-terraform-presets — parent root
+//     (preset filesystem).
+//   - github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported
+//     and ...imported/generated — Phase 2 imported-resource carriers and
+//     typed Layer 1 structs that the composer must consume to emit
+//     /imported.tf (issue #148). These are infrastructure owned by the
+//     composer, not downstream consumers.
+//
+// Subpackages outside the allowlist (e.g. an "internal/" helper) must fail
+// so coupling can't accidentally leak in.
 func TestNoForeignLutherImportsInNonTestFiles(t *testing.T) {
 	const (
 		parentPkg    = "github.com/luthersystems/insideout-terraform-presets"
 		lutherPrefix = "github.com/luthersystems/"
 	)
+	allowedSubpackages := map[string]struct{}{
+		parentPkg + "/pkg/composer/imported":           {},
+		parentPkg + "/pkg/composer/imported/generated": {},
+	}
 
 	entries, err := os.ReadDir(".")
 	if err != nil {
@@ -45,7 +59,10 @@ func TestNoForeignLutherImportsInNonTestFiles(t *testing.T) {
 			if path == parentPkg {
 				continue // parent package is the permitted exception
 			}
-			t.Errorf("%s imports %q — pkg/composer non-test code may not import luthersystems/* other than the parent package %q", name, path, parentPkg)
+			if _, ok := allowedSubpackages[path]; ok {
+				continue // explicit composer-owned subpackage allowlist
+			}
+			t.Errorf("%s imports %q — pkg/composer non-test code may not import luthersystems/* other than the parent package %q or composer-owned subpackages", name, path, parentPkg)
 		}
 	}
 }

--- a/pkg/composer/validate.go
+++ b/pkg/composer/validate.go
@@ -130,6 +130,7 @@ func ValidateAll(
 	all = append(all, ValidateComposedRoot(files)...)
 	if len(opts) > 0 {
 		all = append(all, ValidateOpts(opts[0])...)
+		all = append(all, ValidateImportedResources(opts[0].Cloud, opts[0].Imported)...)
 	}
 	return dedupeAndSortIssues(all)
 }


### PR DESCRIPTION
## Summary

Phase 2 of the imported-resource model: extend the composer to emit resources discovered via reverse-Terraform as flat HCL alongside preset module calls.

- New `ComposeStackOpts.Imported []imported.ImportedResource` accepted on every compose entry point.
- New `/imported.tf` with sorted `import {}` blocks + sorted `resource` blocks. Typed (`Attrs` via `generated.UnmarshalAttrs`/`MarshalHCL`) and opaque (`Attributes` map) paths both supported; computed-only fields filtered when a generated `FieldSchema` is available; `RawExpr` round-trips.
- New provider aliases `aws.imported` / `google.imported`. Imported aliases inherit region (and assume_role / project) but deliberately omit `default_tags` / `default_labels` — imported resources may pre-date the InsideOut session and must keep their existing tags.
- New validator `ValidateImportedResources` with seven snake_case codes (`imported_resource_unknown_tier`, `unsupported_cloud`, `missing_address`, `missing_import_id`, `address_collision`, `missing_remediation`, `decode_failed`).
- `TierImportedMissing` remediations honored: `recreate` emits resource only, `reclaim` emits resource + import, `remove` emits `removed {}`, missing remediation blocks emission and surfaces a validation issue.

## Carrier additions

- `ImportedResource.Remediation MissingAction` (omitempty) — operator-chosen Missing-tier action.
- `PresetMatch.PresetKey` / `BlockingDeltas` now use plain `string` / local `FieldDelta`, breaking the `imported -> composer` import dependency so the composer can import `pkg/composer/imported` without a cycle. JSON shape unchanged.

## Out of scope (follow-ups to file)

- **Runtime first-adoption plan-diff validation** — `terraform plan -json` against a real provider belongs in reliable, not the composer's pre-plan validators.
- **Provenance tag schema constants** (#153) — composer emits whatever tags/labels are already in the carrier; the schema and injector are #153.
- **Cross-tier wiring resolution** (#150) and **ResourceDiff / VersionDiff.Resources** (#151) — separate sibling tickets.

Closes #148.

## Test plan

- [x] `go test ./...` — full repo green.
- [x] `go vet ./...` clean.
- [x] `terraform fmt -check -recursive` clean.
- [x] `TestValidateImportedResources_Codes` — table-driven coverage of every new validation code.
- [x] `TestEmitImportedTF_*` — typed AWS, typed GCP, opaque AWS, opaque + RawExpr, tier gating, remediation modes, cloud filtering, deterministic ordering, valid-HCL output.
- [x] `TestComposeStackWithIssues_Imported_AWS|GCP` — end-to-end through `ComposeStackWithIssues` alongside a real preset module call.
- [x] `TestComposeStackWithIssues_Imported_MissingBlocksApply` — `TierImportedMissing` without `Remediation` surfaces issue, no `/imported.tf`, no alias.
- [x] `TestComposeStackWithIssues_Imported_StrictValidateEscalates` — `StrictValidate=true` aggregates new codes into the error.
- [x] `TestComposeStack_NoImportedKeepsExistingBehavior` — backward compat: stacks without imports produce no `/imported.tf` and no `aws.imported` alias.
- [x] `TestImportedResource_EveryTierBranchExercised` — CI gate; every `Tier` lights up validator or emitter so future tier additions don't fall through silently.