### PR TITLE
fix(gcp/vpc): drop random suffix from subnet/range names to satisfy for_each

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -22,6 +22,20 @@ If formatting issues are found, fix them:
 terraform fmt -recursive
 ```
 
+### 1.5. Static Lints
+
+Run the repo's static analysis scripts. These catch HCL-level patterns that
+`terraform validate` cannot:
+
+```bash
+bash tests/lint-project-tag.sh
+bash tests/lint-project-label.sh
+bash tests/lint-sensitive-for-each.sh
+bash tests/lint-foreach-unknown-keys.sh
+```
+
+Each must print `PASS`. Fail the whole verification if any prints `FAIL`.
+
 ### 2. Discover Modules
 
 Find all preset modules, respecting `.validate-skip` markers:
@@ -70,6 +84,7 @@ grep -rl '<module-dir>' examples/*/main.tf | xargs -I{} dirname {} | sort -u
 ## Checklist
 
 - [ ] `terraform fmt -check -recursive` passes (or issues fixed)
+- [ ] All four static lint scripts pass (`lint-project-tag.sh`, `lint-project-label.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`)
 - [ ] All preset modules validate (excluding `.validate-skip`)
 - [ ] All example stacks validate
 - [ ] Results summarized to user

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Lint sensitive-in-for_each
         run: bash tests/lint-sensitive-for-each.sh
 
+      - name: Lint apply-time-unknown values in for_each map keys (#163)
+        run: bash tests/lint-foreach-unknown-keys.sh
+
       - name: Lint Project-tag coverage (AWS)
         run: bash tests/lint-project-tag.sh
 
@@ -180,6 +183,14 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      # Terraform is required by the integration tests in pkg/composer that
+      # exercise terraform init/plan against composed bundles (e.g.
+      # compose_gcp_vpc_plan_integration_test.go for issue #163). Tests skip
+      # gracefully if it's missing; installing it ensures CI actually runs
+      # them rather than silently skipping.
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5"
       - run: go test -race ./...
 
   # Re-runs cmd/imported-codegen against the committed filtered schemas

--- a/gcp/vpc/main.tf
+++ b/gcp/vpc/main.tf
@@ -9,7 +9,11 @@ resource "random_id" "suffix" {
 
 locals {
   network_name = "${var.project}-${var.network_name}-${random_id.suffix.hex}"
-  subnet_name  = "${var.project}-subnet-${var.region}-${random_id.suffix.hex}"
+  # subnet_name is intentionally suffix-free: it becomes a for_each map key
+  # in the upstream subnets sub-module (which rekeys by subnet_name), and
+  # for_each keys must be plan-time-known. Subnets are network-scoped, so
+  # the suffix on network_name already protects state-loss recovery (#163).
+  subnet_name = "${var.project}-subnet-${var.region}"
 }
 
 module "vpc" {
@@ -33,11 +37,11 @@ module "vpc" {
   secondary_ranges = var.gke_cluster_name != null ? {
     (local.subnet_name) = [
       {
-        range_name    = "${var.project}-pods-${random_id.suffix.hex}"
+        range_name    = "${var.project}-pods"
         ip_cidr_range = var.secondary_ranges.pods_cidr
       },
       {
-        range_name    = "${var.project}-services-${random_id.suffix.hex}"
+        range_name    = "${var.project}-services"
         ip_cidr_range = var.secondary_ranges.services_cidr
       }
     ]

--- a/gcp/vpc/outputs.tf
+++ b/gcp/vpc/outputs.tf
@@ -30,12 +30,12 @@ output "subnet_names" {
 
 output "pods_range_name" {
   description = "Name of the secondary range for GKE pods"
-  value       = var.gke_cluster_name != null ? "${var.project}-pods-${random_id.suffix.hex}" : null
+  value       = var.gke_cluster_name != null ? "${var.project}-pods" : null
 }
 
 output "services_range_name" {
   description = "Name of the secondary range for GKE services"
-  value       = var.gke_cluster_name != null ? "${var.project}-services-${random_id.suffix.hex}" : null
+  value       = var.gke_cluster_name != null ? "${var.project}-services" : null
 }
 
 output "router_name" {

--- a/pkg/composer/compose_gcp_vpc_plan_integration_test.go
+++ b/pkg/composer/compose_gcp_vpc_plan_integration_test.go
@@ -1,0 +1,105 @@
+package composer
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// gkeMapper wraps DefaultMapper to set gke_cluster_name on KeyGCPVPC so the
+// secondary_ranges block (which has its own for_each map-key surface in the
+// upstream wrapper module) is exercised by the regression test below.
+type gkeMapper struct {
+	DefaultMapper
+}
+
+func (m gkeMapper) BuildModuleValues(
+	k ComponentKey,
+	comps *Components,
+	cfg *Config,
+	project, region string,
+) (map[string]any, error) {
+	vals, err := m.DefaultMapper.BuildModuleValues(k, comps, cfg, project, region)
+	if err != nil {
+		return nil, err
+	}
+	if k == KeyGCPVPC {
+		vals["gke_cluster_name"] = "test-cluster"
+	}
+	return vals, nil
+}
+
+// TestComposeGCPVPC_PlanHasNoForEachUnknownKey is the load-bearing regression
+// test for issue #163. It composes the gcp/vpc preset (with gke_cluster_name
+// set so the secondary_ranges block is exercised), writes the bundle to a
+// tempdir, runs `terraform init -backend=false` then `terraform plan
+// -refresh=false`, and asserts the plan output does NOT contain "Invalid
+// for_each argument".
+//
+// This catches the entire family of "apply-time-unknown value flowing into a
+// for_each map key" bugs regardless of which symbol leaks the unknown value
+// (random_id, timestamp, uuid, computed resource attribute, …) — the bug
+// manifests during graph evaluation in `terraform plan`, before any provider
+// API call. Static lints can only flag explicit cases (see
+// tests/lint-foreach-unknown-keys.sh); this test is the verifier.
+//
+// Skipped when -short is set or the `terraform` binary is not on PATH so the
+// core test suite stays hermetic and fast.
+//
+// The plan step does not need real GCP credentials: the for_each error
+// surfaces during graph evaluation, which precedes provider authentication.
+// We tolerate non-regression failures (missing creds, registry hiccups) by
+// only failing the test when the regression-specific error string appears.
+func TestComposeGCPVPC_PlanHasNoForEachUnknownKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in -short mode")
+	}
+	tfBin, err := exec.LookPath("terraform")
+	if err != nil {
+		t.Skipf("terraform binary not on PATH: %v", err)
+	}
+
+	c := New(WithMapper(gkeMapper{}))
+	out, err := c.ComposeSingle(ComposeSingleOpts{
+		Cloud:        "gcp",
+		Key:          KeyGCPVPC,
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-central1"},
+		Project:      "regress163",
+		Region:       "us-central1",
+		GCPProjectID: "regress163-12345",
+	})
+	require.NoError(t, err, "ComposeSingle(gcp_vpc) should succeed")
+	require.NotEmpty(t, out, "composed bundle should not be empty")
+
+	dir := t.TempDir()
+	writeBundle(t, dir, out)
+
+	initCmd := exec.Command(tfBin, "init", "-backend=false", "-input=false", "-no-color")
+	initCmd.Dir = dir
+	if initOut, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("terraform init failed:\n%s", initOut)
+	}
+
+	// Plan with refresh disabled and a fake credential. We don't need real
+	// auth: the for_each evaluation happens before any provider API call.
+	planCmd := exec.Command(tfBin, "plan", "-refresh=false", "-input=false", "-lock=false", "-no-color")
+	planCmd.Dir = dir
+	planCmd.Env = append(os.Environ(), "GOOGLE_OAUTH_ACCESS_TOKEN=fake-regression-test-token")
+	planOut, planErr := planCmd.CombinedOutput()
+	planText := string(planOut)
+
+	if strings.Contains(planText, "Invalid for_each argument") {
+		t.Fatalf("REGRESSION (#163): apply-time-unknown value reached a for_each map key.\nterraform plan output:\n%s", planText)
+	}
+
+	// Plan may still fail for unrelated reasons (no real GCP creds, registry
+	// glitch). Log non-regression failures but don't fail the test — the
+	// regression-specific assertion above is what we care about.
+	if planErr != nil {
+		t.Logf("terraform plan failed for non-regression reason (acceptable):\n%s", planText)
+	}
+}

--- a/tests/lint-foreach-unknown-keys.sh
+++ b/tests/lint-foreach-unknown-keys.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Static analysis: detect apply-time-unknown values flowing into for_each map
+# keys.
+#
+# Terraform requires for_each map keys to be plan-time-known. Values derived
+# from random_id, random_uuid, timestamp(), uuid(), or any computed resource
+# attribute (e.g. the .hex of a random_id) are only known after apply, so
+# using them as a key fails apply with "Invalid for_each argument" — invisible
+# to `terraform validate` and `terraform plan` against a non-GKE state.
+#
+# This is a tripwire (catches the explicit cases). The load-bearing check is
+# pkg/composer/compose_gcp_vpc_plan_integration_test.go, which actually runs
+# `terraform plan` and catches every variant of this bug regardless of which
+# symbol leaks the unknown value.
+#
+# Patterns flagged:
+#   1. (local.X) = ...  used as a map key, where local.X's RHS contains an
+#      apply-time-unknown ref (random_id., random_uuid., timestamp(, uuid().
+#   2. for_each = local.X where X is similarly tainted.
+#   3. for_each = { ... } where the map-literal line itself directly references
+#      an apply-time-unknown value.
+#
+# The list-of-objects upstream-rekey case (a name field that becomes a
+# downstream module's for_each key) is not statically detectable here — the
+# integration test covers it dynamically.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ERRORS_FILE=$(mktemp)
+trap 'rm -f "$ERRORS_FILE"' EXIT
+
+# Pattern matching apply-time-unknown references. Uses character classes for
+# parens so it parses identically under BSD awk and GNU awk (BSD awk treats a
+# bare "(" as the start of a regex group and rejects an unbalanced one).
+UNKNOWN_REGEX='random_id\.|random_uuid\.|timestamp[(]|uuid[(]'
+
+echo "=== Checking for apply-time-unknown values in for_each map keys ==="
+echo
+
+for mainfile in "$REPO_ROOT"/{aws,gcp}/*/main.tf; do
+  [ -f "$mainfile" ] || continue
+
+  # Extract names of locals whose single-line RHS contains a tainted ref.
+  # Presets use one-local-per-line exclusively (verified across the repo); a
+  # multi-line scan is unnecessary.
+  tainted=$(awk -v re="$UNKNOWN_REGEX" '
+    /^locals[ \t]*\{/ { in_locals=1; next }
+    in_locals && /^\}/ { in_locals=0; next }
+    in_locals && /^[ \t]*[A-Za-z_][A-Za-z0-9_]*[ \t]*=/ {
+      if ($0 ~ re) {
+        line = $0
+        sub(/^[ \t]+/, "", line)
+        sub(/[ \t]*=.*$/, "", line)
+        print line
+      }
+    }
+  ' "$mainfile")
+
+  # Pattern 1 + 2 per tainted local.
+  while read -r name; do
+    [ -z "$name" ] && continue
+
+    matches=$(grep -nE "\(local\.${name}\)[ \t]*=" "$mainfile" || true)
+    if [ -n "$matches" ]; then
+      while IFS=: read -r lineno content; do
+        echo "ERROR: $mainfile:$lineno: tainted local.$name used as map key (RHS contains apply-time-unknown ref)" | tee -a "$ERRORS_FILE"
+        echo "  $(echo "$content" | sed 's/^[[:space:]]*//')"
+      done <<< "$matches"
+    fi
+
+    matches=$(grep -nE "for_each[ \t]*=[ \t]*local\.${name}\b" "$mainfile" || true)
+    if [ -n "$matches" ]; then
+      while IFS=: read -r lineno content; do
+        echo "ERROR: $mainfile:$lineno: for_each consumes tainted local.$name (RHS contains apply-time-unknown ref)" | tee -a "$ERRORS_FILE"
+        echo "  $(echo "$content" | sed 's/^[[:space:]]*//')"
+      done <<< "$matches"
+    fi
+  done <<< "$tainted"
+
+  # Pattern 3: for_each line itself directly references an apply-time-unknown value.
+  matches=$(grep -nE "for_each[ \t]*=" "$mainfile" | grep -E "$UNKNOWN_REGEX" || true)
+  if [ -n "$matches" ]; then
+    while IFS=: read -r lineno content; do
+      echo "ERROR: $mainfile:$lineno: for_each line directly references apply-time-unknown value" | tee -a "$ERRORS_FILE"
+      echo "  $(echo "$content" | sed 's/^[[:space:]]*//')"
+    done <<< "$matches"
+  fi
+done
+
+if [ -s "$ERRORS_FILE" ]; then
+  echo
+  echo "FAIL: Apply-time-unknown values found in for_each map keys."
+  echo "      These break apply with 'Invalid for_each argument' and are"
+  echo "      invisible to 'terraform validate'. See issue #163 for context."
+  exit 1
+fi
+
+echo "PASS: No apply-time-unknown values found in for_each map keys."


### PR DESCRIPTION
## Summary

- v0.6.0 (#161) inlined `random_id.suffix.hex` into `local.subnet_name` and the secondary `range_name` strings in `gcp/vpc`. The upstream `terraform-google-modules/network` wrapper rekeys its subnets list by `subnet_name` and runs `for_each` on the result, so the suffix made those keys apply-time-unknown and blocked apply with `Error: Invalid for_each argument`.
- This patch drops the suffix from `subnet_name` and from the two secondary `range_name` strings (and matches the change in `pods_range_name` / `services_range_name` outputs that downstream GKE wiring consumes). The suffix on `network_name` still cycles on state-loss recovery — and since subnets/ranges are scoped under the VPC network, a fresh suffixed network on retry gets fresh nested resources in its own namespace, so the recovery property #161 was designed for is preserved.
- Audit of every other `random_id.suffix`-using GCP module (`loadbalancer`, `cloud_functions`, `cloud_logging`, `api_gateway`, `firestore`, `gcs`, `cloud_cdn`, `vertex_ai`, `cloud_monitoring`) confirmed none exhibit the same anti-pattern — `gcp/vpc` was the only affected module.

**Migration safety:** verified by `git show eabc457:gcp/vpc/main.tf` (commit before #161, i.e. v0.5.x). The pre-v0.6.0 form was **exactly** `subnet_name = "${var.project}-subnet-${var.region}"` and `range_name = "${var.project}-pods"` / `"${var.project}-services"`. This PR reverts to that form precisely, so v0.5.x state sees zero diff on these names. v0.6.0 state does not exist (apply blocked on every attempt).

## Regression coverage (added per QA review)

- **Plan-time verifier** (`pkg/composer/compose_gcp_vpc_plan_integration_test.go`) — composes `gcp/vpc` with `gke_cluster_name` set, runs `terraform init -backend=false` + `terraform plan -refresh=false`, asserts plan output does NOT contain `Invalid for_each argument`. Mutation-resistant: catches the entire family of "apply-time-unknown value flowing into a for_each map key" bugs regardless of symbol (random_id, timestamp, uuid, computed attrs). Skips on `-short` or missing terraform binary. Reproduces #163 against the v0.6.0 form of `main.tf:34` and passes on the fix.
- **Static tripwire** (`tests/lint-foreach-unknown-keys.sh`) — flags explicit `(local.X) = ...` map keys and `for_each = local.X` where local X's RHS contains `random_id.`/`timestamp(`/`uuid(`/`random_uuid.`. Catches the bug at PR-review time, before terraform plan runs. Wired into the existing CI `lint` job and `/verify` skill. Reproduces #163 against the v0.6.0 form of `main.tf:34`.
- **CI wiring** — `.github/workflows/terraform-validate.yml` now installs terraform in the `go-test` job so the integration test actually runs (rather than silently skipping). New lint added to the `lint` job. `/verify` skill updated to gate locally on all four lint scripts.

Closes #163. Closes #165 (regression coverage now in this PR rather than deferred).

## Test plan

- [x] `cd gcp/vpc && terraform init -backend=false && terraform validate` — passes
- [x] `terraform fmt -check -recursive` — clean
- [x] `tests/lint-{sensitive-for-each,project-label,project-tag,foreach-unknown-keys}.sh` — all PASS
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — all pass (composer suite ~26s, new integration test ~12.5s)
- [x] `examples/mobileapi` (consumes `gcp/vpc`) `terraform init && terraform validate` — passes
- [x] **Mutation test**: reverted `main.tf` to v0.6.0 form locally — both the integration test and `lint-foreach-unknown-keys.sh` FAIL with the expected #163 error, confirming the verifier and tripwire actually catch the regression. Restored after.
- [ ] Post-merge: cut `v0.6.1`, then bump dep in `reliable` so Dario's GCP retry on `ai-notes-494612` unblocks.