### PR TITLE
fix(gcp): unblock Dario's stack — 4 mid-apply bugs (#166)

### DIFF
--- a/gcp/api_gateway/variables.tf
+++ b/gcp/api_gateway/variables.tf
@@ -20,13 +20,15 @@ variable "region" {
 }
 
 variable "openapi_spec" {
-  description = "OpenAPI specification for the API"
+  description = "OpenAPI 2.0 specification for the API. The default is a minimal spec that satisfies GCP API Gateway's validator (host + x-google-backend on each operation) so the module composes and applies cleanly out of the box; override it with your real spec."
   type        = string
   default     = <<-EOT
     swagger: '2.0'
     info:
       title: API
+      description: Placeholder API. Override var.openapi_spec to publish your own.
       version: '1.0'
+    host: example.com
     schemes:
       - https
     produces:
@@ -36,9 +38,13 @@ variable "openapi_spec" {
         get:
           summary: Health check
           operationId: healthCheck
+          x-google-backend:
+            address: https://example.com/health
           responses:
             '200':
               description: OK
+              schema:
+                type: string
   EOT
 }
 

--- a/gcp/cloud_logging/main.tf
+++ b/gcp/cloud_logging/main.tf
@@ -13,14 +13,52 @@ terraform {
 }
 
 # Per-deploy suffix so retries after state loss don't 409 on the sink name
-# (issue #159).
+# or bucket name (issue #159).
 resource "random_id" "suffix" {
   byte_length = 4
+}
+
+# Log archive bucket — sink destination. Created inside this module so the
+# preset is batteries-included; the sink had previously referenced
+# ${var.project}-logs which no module ever created (issue #166).
+resource "google_storage_bucket" "logs" {
+  name                        = "${var.project}-logs-${random_id.suffix.hex}"
+  project                     = var.project_id
+  location                    = var.region
+  force_destroy               = true
+  uniform_bucket_level_access = true
+
+  lifecycle_rule {
+    condition {
+      age = var.retention_days
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  labels = merge(
+    {
+      project = var.project
+      managed = "terraform"
+    },
+    var.labels,
+  )
 }
 
 resource "google_logging_project_sink" "sink" {
   project     = var.project_id
   name        = "${var.project}-sink-${random_id.suffix.hex}"
-  destination = "storage.googleapis.com/${var.project}-logs"
+  destination = "storage.googleapis.com/${google_storage_bucket.logs.name}"
   filter      = "severity >= ERROR"
+
+  unique_writer_identity = true
+}
+
+# Grant the sink's writer identity permission to write to the bucket.
+# Without this the sink silently drops every log entry.
+resource "google_storage_bucket_iam_member" "sink_writer" {
+  bucket = google_storage_bucket.logs.name
+  role   = "roles/storage.objectCreator"
+  member = google_logging_project_sink.sink.writer_identity
 }

--- a/gcp/cloud_logging/outputs.tf
+++ b/gcp/cloud_logging/outputs.tf
@@ -7,3 +7,13 @@ output "sink_writer_identity" {
   value       = google_logging_project_sink.sink.writer_identity
   description = "The writer identity of the logging sink for granting destination permissions"
 }
+
+output "logs_bucket_name" {
+  value       = google_storage_bucket.logs.name
+  description = "The GCS bucket that holds archived logs."
+}
+
+output "logs_bucket_url" {
+  value       = google_storage_bucket.logs.url
+  description = "The gs:// URL for the logs bucket."
+}

--- a/gcp/cloud_logging/variables.tf
+++ b/gcp/cloud_logging/variables.tf
@@ -19,3 +19,20 @@ variable "project_id" {
 }
 
 variable "region" { type = string }
+
+variable "retention_days" {
+  description = "Number of days to retain archived log objects in the logs bucket before deletion."
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.retention_days >= 1
+    error_message = "retention_days must be >= 1."
+  }
+}
+
+variable "labels" {
+  description = "Additional labels to apply to module resources. Merged with module-managed labels."
+  type        = map(string)
+  default     = {}
+}

--- a/gcp/loadbalancer/main.tf
+++ b/gcp/loadbalancer/main.tf
@@ -11,6 +11,16 @@ resource "random_id" "suffix" {
 
 locals {
   name_prefix = "${var.project}-${var.name}-${random_id.suffix.hex}"
+
+  # HTTPS proxy + forwarding rule are only created when SSL is requested
+  # AND a cert source is supplied. Without this guard, default settings
+  # (var.enable_ssl = true, no certs) produce a target_https_proxy with an
+  # empty ssl_certificates list, which GCP rejects with HTTP 412 at apply
+  # (issue #166 part 3). With the guard, default settings yield an HTTP-only
+  # LB; supplying ssl_certificates or managed_ssl_domains opts into HTTPS.
+  https_enabled = var.enable_ssl && (
+    length(var.ssl_certificates) > 0 || length(var.managed_ssl_domains) > 0
+  )
 }
 
 # Health checks for backends
@@ -144,7 +154,7 @@ resource "google_compute_managed_ssl_certificate" "this" {
 
 # HTTPS proxy
 resource "google_compute_target_https_proxy" "this" {
-  count = var.enable_ssl ? 1 : 0
+  count = local.https_enabled ? 1 : 0
 
   name    = "${local.name_prefix}-https-proxy"
   project = var.project_id
@@ -177,7 +187,7 @@ resource "google_compute_global_address" "this" {
 
 # HTTPS forwarding rule
 resource "google_compute_global_forwarding_rule" "https" {
-  count = var.enable_ssl ? 1 : 0
+  count = local.https_enabled ? 1 : 0
 
   name       = "${local.name_prefix}-https"
   project    = var.project_id

--- a/gcp/loadbalancer/outputs.tf
+++ b/gcp/loadbalancer/outputs.tf
@@ -24,8 +24,10 @@ output "http_proxy_id" {
 }
 
 output "https_proxy_id" {
-  description = "The HTTPS proxy ID (if SSL enabled)"
-  value       = var.enable_ssl ? google_compute_target_https_proxy.this[0].id : null
+  description = "The HTTPS proxy ID, or null when no SSL cert / managed domain was supplied (issue #166)."
+  value = length(google_compute_target_https_proxy.this) > 0 ? (
+    google_compute_target_https_proxy.this[0].id
+  ) : null
 }
 
 output "backend_service_ids" {

--- a/gcp/vpc/main.tf
+++ b/gcp/vpc/main.tf
@@ -118,6 +118,12 @@ resource "google_vpc_access_connector" "serverless" {
   network       = module.vpc.network_self_link
   ip_cidr_range = var.connector_cidr
 
+  # GCP requires at least one of max_throughput / max_instances; the API
+  # rejects creation outright otherwise (issue #166 part 4). Use the modern
+  # *_instances form — max_throughput is being phased out by the provider.
+  min_instances = var.connector_min_instances
+  max_instances = var.connector_max_instances
+
   lifecycle {
     # The composed connector name "<project>-conn-<4hex>" budgets exactly
     # 25 chars when var.project is 15 chars (the InsideOut session-prefix
@@ -127,6 +133,12 @@ resource "google_vpc_access_connector" "serverless" {
     precondition {
       condition     = length(var.project) <= 15
       error_message = "var.project must be ≤ 15 chars when enable_serverless_connector = true. The composed connector name is \"<project>-conn-<4hex>\" (project + 10 chars), and the VPC connector API caps names at 25 chars. Either disable enable_serverless_connector or shorten var.project."
+    }
+    # Cross-variable check: max must exceed min (single-variable validation
+    # blocks can't see another variable, so this lives on the resource).
+    precondition {
+      condition     = var.connector_max_instances > var.connector_min_instances
+      error_message = "connector_max_instances (${var.connector_max_instances}) must be > connector_min_instances (${var.connector_min_instances})."
     }
   }
 }

--- a/gcp/vpc/variables.tf
+++ b/gcp/vpc/variables.tf
@@ -92,3 +92,25 @@ variable "connector_cidr" {
   }
 }
 
+variable "connector_min_instances" {
+  description = "Minimum instances for the Serverless VPC Access Connector. GCP requires >= 2."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.connector_min_instances >= 2
+    error_message = "connector_min_instances must be >= 2 (GCP minimum)."
+  }
+}
+
+variable "connector_max_instances" {
+  description = "Maximum instances for the Serverless VPC Access Connector. GCP allows 3..10 and requires it (or max_throughput) to be set."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.connector_max_instances >= 3 && var.connector_max_instances <= 10
+    error_message = "connector_max_instances must be between 3 and 10."
+  }
+}
+

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -916,7 +916,10 @@ func (m DefaultMapper) BuildModuleValues(
 		// needed; the module's behaviour is correct out of the box.
 
 	case KeyGCPAPIGateway:
-		vals["openapi_spec"] = ""
+		// Don't emit openapi_spec when the caller didn't supply one — the
+		// module's variables.tf default is a minimal-but-GCP-valid spec
+		// (issue #166). Emitting "" here previously sabotaged that default
+		// and produced a 400 from API Gateway's spec validator at apply.
 		if cfg != nil && cfg.GCPAPIGateway != nil {
 			if cfg.GCPAPIGateway.DomainName != "" {
 				vals["domain_name"] = cfg.GCPAPIGateway.DomainName


### PR DESCRIPTION
## Summary

Fixes the four orthogonal mid-apply failures Dario hit on a clean GCP project (Closes #166). After v0.6.1 landed, plan succeeds and 25/40 resources apply, then four separate preset modules break apply. Each fix is small, independent, and gets its own commit on this branch for clean bisect.

| # | Module | Fix | Commit |
|---|--------|-----|--------|
| 1 | `gcp/api_gateway` | Replace broken Swagger 2.0 default with a GCP-validator-compliant spec (adds `host:` + `x-google-backend`); drop `vals["openapi_spec"] = ""` mapper override that was sabotaging the default. | 720b7fd |
| 2 | `gcp/cloud_logging` | Create the log archive bucket inside the module (sink had been writing to `${var.project}-logs`, which nothing created); add `retention_days` + `labels` variables; grant the sink writer `roles/storage.objectCreator`. | 65f1e70 |
| 3 | `gcp/loadbalancer` | Gate `target_https_proxy` + HTTPS forwarding rule on `local.https_enabled = enable_ssl AND (certs OR domains)` so default settings yield a working HTTP-only LB instead of a 412 at apply. | 25dd86e |
| 4 | `gcp/vpc` | Add `min_instances` / `max_instances` (defaults 2/3) to the serverless VPC connector so GCP no longer rejects creation for missing scaling input. | 9cf733c |

The umbrella issue suggested either one v0.6.2 covering all four or four small PRs; opted for one PR with four commits to unblock the downstream reliable bump in a single round-trip while keeping each fix independently revertable.

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `bash tests/lint-project-tag.sh` PASS
- [x] `bash tests/lint-project-label.sh` PASS
- [x] `bash tests/lint-sensitive-for-each.sh` PASS
- [x] `bash tests/lint-foreach-unknown-keys.sh` PASS
- [x] `terraform init -backend=false && terraform validate` passes for `gcp/api_gateway`, `gcp/cloud_logging`, `gcp/loadbalancer`, `gcp/vpc`
- [x] `terraform validate` passes for all 11 examples (mobileapi exercises `gcp/vpc` + `gcp/cloud_logging`)
- [x] `go test ./pkg/composer/...` passes (incl. `TestPresetDefaultsSatisfyValidations`, `TestKnownFieldsNoShrink`, `TestComposeGCPVPC_PlanHasNoForEachUnknownKey`)
- [ ] End-to-end smoke: re-run Dario's 12-component stack against a fresh GCP project once v0.6.2 ships and reliable bumps. Expect all 40 resources to apply.

## Out of scope

- The `presets_version=v0.3.1-…` reporting bug noted at the bottom of #166 — separate follow-up.
- Plan-time integration tests for the four modules. All four bugs surface at apply, not plan, so plan-time tests would not catch them; end-to-end smoke against real GCP is the verifier.