### PR TITLE
feat(composer): opt-in remote terraform backend for partial-apply durability

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -346,6 +346,15 @@ type ComposeStackOpts struct {
 	// reported via ValidationIssue codes (imported_resource_*). Nil or
 	// empty preserves the historical no-op behavior.
 	Imported []imported.ImportedResource
+
+	// RemoteBackend, when true, emits an empty `backend "s3" {}` (AWS) or
+	// `backend "gcs" {}` (GCP) sub-block inside the composed providers.tf
+	// terraform { ... } block. The bucket, region, and key/prefix are
+	// supplied at terraform init time via -backend-config=... by the
+	// caller's apply container (HashiCorp partial-configuration pattern).
+	// Default false preserves the historical local-state behavior. See
+	// issue #169.
+	RemoteBackend bool
 }
 
 // ComposeStack preserves the historical (Files, error) signature. It hard-
@@ -577,7 +586,15 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 		files["/imported.tf"] = importedTF
 	}
 
-	files["/providers.tf"] = generateProvidersTF(cloud, reg, opts.GCPProjectID, selected, discoveredProviders, importedClouds)
+	files["/providers.tf"] = generateProvidersTF(providersTFInput{
+		Cloud:          cloud,
+		Region:         reg,
+		GCPProjectID:   opts.GCPProjectID,
+		Selected:       selected,
+		Discovered:     discoveredProviders,
+		ImportedClouds: importedClouds,
+		RemoteBackend:  opts.RemoteBackend,
+	})
 
 	// Validator dispatcher — runs after the stack is fully composed, before
 	// returning. Each validator appends to issues. The missing-required check
@@ -593,28 +610,64 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	return &ComposeStackResult{Files: files, Issues: issues}, nil
 }
 
+// providersTFInput bundles every input needed to render the composed
+// `/providers.tf`. Grouping them in a struct keeps the call sites stable
+// when new optional inputs land — append a field, set it where it
+// matters, leave the rest at their zero values.
+type providersTFInput struct {
+	// Cloud is "aws" or "gcp". Empty defaults to "aws" upstream.
+	Cloud string
+
+	// Region is the cloud region (e.g. "us-east-1", "us-central1").
+	// Empty falls back to a per-cloud default.
+	Region string
+
+	// GCPProjectID is the real GCP project id (matches
+	// ComposeStackOpts.GCPProjectID). Only consumed when emitting the
+	// `google.imported` alias; ignored on AWS.
+	GCPProjectID string
+
+	// Selected is the set of ComponentKeys composed into the stack.
+	// Drives root-level provider aliases that depend on which presets are
+	// present (e.g. the WAF us_east_1 alias for CloudFront cert validation).
+	Selected map[ComponentKey]bool
+
+	// Discovered is the union of every child module's required_providers
+	// declaration (parsed from the preset files). Merged into the
+	// root-level `required_providers` so `terraform init` knows to pull
+	// plugins like `opensearch-project/opensearch` that child modules
+	// reference via their own module-scoped provider blocks.
+	Discovered map[string]*tfconfig.ProviderRequirement
+
+	// ImportedClouds keys ("aws", "gcp") request additional provider
+	// aliases dedicated to imported resources (issue #148). The imported
+	// alias inherits the cloud's region (and assume_role for AWS,
+	// project for GCP) but deliberately omits default_tags /
+	// default_labels — imported resources must not inherit the stack's
+	// Project tag because they may pre-date the InsideOut session.
+	ImportedClouds map[string]bool
+
+	// RemoteBackend opts the composed root into a remote terraform state
+	// backend (issue #169). When true, an empty `backend "s3" {}` (AWS)
+	// or `backend "gcs" {}` (GCP) sub-block is emitted inside the
+	// `terraform { ... }` block; the caller supplies bucket/region/key
+	// at `terraform init -backend-config=...` time. Default false
+	// preserves local-state behavior.
+	RemoteBackend bool
+}
+
 // generateProvidersTF generates cloud-specific provider configuration.
 // For AWS it includes assume_role blocks with bootstrap_role_arn and
 // external_id variables so Oracle can deploy into the customer's account
 // using cross-account role assumption with confused-deputy protection.
-//
-// `discovered` is the union of every child module's required_providers
-// declaration (parsed from the preset files). Those entries are merged into
-// the root-level required_providers block so `terraform init` knows to pull
-// plugins like `opensearch-project/opensearch` that child modules reference
-// via their own module-scoped provider blocks.
-//
-// `gcpProjectID` is the real GCP project id (as in ComposeStackOpts) and is
-// only consumed when emitting the google.imported alias; ignored on AWS.
-//
-// `importedClouds` keys ("aws", "gcp") request additional provider aliases
-// dedicated to imported resources (issue #148). The imported alias inherits
-// the cloud's region (and assume_role for AWS, project for GCP) but
-// deliberately omits default_tags / default_labels — imported resources
-// must not inherit the stack's Project tag because they may pre-date the
-// InsideOut session. EmitImportedTF returns this map; the wiring is no-op
-// when no imported resources were emitted.
-func generateProvidersTF(cloud, region, gcpProjectID string, selected map[ComponentKey]bool, discovered map[string]*tfconfig.ProviderRequirement, importedClouds map[string]bool) []byte {
+func generateProvidersTF(in providersTFInput) []byte {
+	cloud := in.Cloud
+	region := in.Region
+	gcpProjectID := in.GCPProjectID
+	selected := in.Selected
+	discovered := in.Discovered
+	importedClouds := in.ImportedClouds
+	remoteBackend := in.RemoteBackend
 	// Seed required_providers with the cloud's base entry, then union the
 	// child-module discoveries on top. Discovered entries win on conflict.
 	required := map[string]*tfconfig.ProviderRequirement{}
@@ -629,7 +682,11 @@ func generateProvidersTF(cloud, region, gcpProjectID string, selected map[Compon
 		var b strings.Builder
 		b.WriteString("terraform {\n  required_providers {\n")
 		b.WriteString(renderRequiredProviders(required))
-		b.WriteString("  }\n}\n\n")
+		b.WriteString("  }\n")
+		if remoteBackend {
+			b.WriteString("  backend \"gcs\" {}\n")
+		}
+		b.WriteString("}\n\n")
 		fmt.Fprintf(&b, "provider \"google\" {\n  region = %q\n}\n", region)
 		if importedClouds["gcp"] {
 			b.WriteString("\n")
@@ -694,7 +751,11 @@ variable "external_id" {
 		b.WriteString(awsVarDecls)
 		b.WriteString("terraform {\n  required_providers {\n")
 		b.WriteString(renderRequiredProviders(required))
-		b.WriteString("  }\n}\n\n")
+		b.WriteString("  }\n")
+		if remoteBackend {
+			b.WriteString("  backend \"s3\" {}\n")
+		}
+		b.WriteString("}\n\n")
 		fmt.Fprintf(&b, "provider \"aws\" {\n  region = %q%s%s\n}\n", region, awsDefaultTags, awsDynamicAssumeRole)
 
 		// WAF requires an additional us_east_1 provider alias for CloudFront

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -202,8 +202,12 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 	}
 
 	t.Run("aws with discovery", func(t *testing.T) {
-		got := string(generateProvidersTF("aws", "us-east-1", "",
-			map[ComponentKey]bool{KeyAWSOpenSearch: true}, discovered, nil))
+		got := string(generateProvidersTF(providersTFInput{
+			Cloud:      "aws",
+			Region:     "us-east-1",
+			Selected:   map[ComponentKey]bool{KeyAWSOpenSearch: true},
+			Discovered: discovered,
+		}))
 		require.Contains(t, got, "hashicorp/aws", "base aws provider required")
 		require.Contains(t, got, "opensearch-project/opensearch", "discovered provider required")
 		require.Contains(t, got, "hashicorp/time", "discovered provider required")
@@ -213,8 +217,12 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 	})
 
 	t.Run("aws with WAF + discovery coexist", func(t *testing.T) {
-		got := string(generateProvidersTF("aws", "us-east-1", "",
-			map[ComponentKey]bool{KeyAWSWAF: true, KeyAWSOpenSearch: true}, discovered, nil))
+		got := string(generateProvidersTF(providersTFInput{
+			Cloud:      "aws",
+			Region:     "us-east-1",
+			Selected:   map[ComponentKey]bool{KeyAWSWAF: true, KeyAWSOpenSearch: true},
+			Discovered: discovered,
+		}))
 		require.Contains(t, got, `alias  = "us_east_1"`, "WAF us-east-1 alias block")
 		require.Contains(t, got, "opensearch-project/opensearch",
 			"discovered provider survives the WAF branch")
@@ -225,16 +233,25 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 	})
 
 	t.Run("aws with no discovery falls back to aws only", func(t *testing.T) {
-		got := string(generateProvidersTF("aws", "us-east-1", "",
-			map[ComponentKey]bool{}, map[string]*tfconfig.ProviderRequirement{}, nil))
+		got := string(generateProvidersTF(providersTFInput{
+			Cloud:      "aws",
+			Region:     "us-east-1",
+			Selected:   map[ComponentKey]bool{},
+			Discovered: map[string]*tfconfig.ProviderRequirement{},
+		}))
 		require.Contains(t, got, "hashicorp/aws")
 		require.Equal(t, 1, strings.Count(got, "source  = "),
 			"only aws should be in required_providers")
 	})
 
 	t.Run("gcp base + discovery", func(t *testing.T) {
-		got := string(generateProvidersTF("gcp", "us-central1", "demo-project-12345",
-			map[ComponentKey]bool{}, discovered, nil))
+		got := string(generateProvidersTF(providersTFInput{
+			Cloud:        "gcp",
+			Region:       "us-central1",
+			GCPProjectID: "demo-project-12345",
+			Selected:     map[ComponentKey]bool{},
+			Discovered:   discovered,
+		}))
 		require.Contains(t, got, "hashicorp/google")
 		require.Contains(t, got, "opensearch-project/opensearch")
 	})
@@ -244,16 +261,32 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 		// Use an empty map rather than nil for `selected` — matches the
 		// other subtests in this table and avoids a nil-vs-empty-map
 		// divergence that could hide a real regression.
-		a := string(generateProvidersTF("aws", "us-east-1", "", map[ComponentKey]bool{}, discovered, nil))
-		b := string(generateProvidersTF("aws", "us-east-1", "", map[ComponentKey]bool{}, discovered, nil))
+		in := providersTFInput{
+			Cloud:      "aws",
+			Region:     "us-east-1",
+			Selected:   map[ComponentKey]bool{},
+			Discovered: discovered,
+		}
+		a := string(generateProvidersTF(in))
+		b := string(generateProvidersTF(in))
 		require.Equal(t, a, b, "providers.tf output must be deterministic")
 	})
 
 	t.Run("nil selected is equivalent to empty", func(t *testing.T) {
 		// Defensive: Go map reads of a nil map return the zero value, so
 		// the WAF/OpenSearch guards should treat nil and empty identically.
-		nilOut := string(generateProvidersTF("aws", "us-east-1", "", nil, discovered, nil))
-		emptyOut := string(generateProvidersTF("aws", "us-east-1", "", map[ComponentKey]bool{}, discovered, nil))
+		nilOut := string(generateProvidersTF(providersTFInput{
+			Cloud:      "aws",
+			Region:     "us-east-1",
+			Selected:   nil,
+			Discovered: discovered,
+		}))
+		emptyOut := string(generateProvidersTF(providersTFInput{
+			Cloud:      "aws",
+			Region:     "us-east-1",
+			Selected:   map[ComponentKey]bool{},
+			Discovered: discovered,
+		}))
 		require.Equal(t, emptyOut, nilOut,
 			"nil and empty `selected` must produce identical providers.tf")
 	})

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -2089,10 +2089,16 @@ func TestComposeStack_PolymorphicKeyPullsInPrefixedVPC(t *testing.T) {
 }
 
 // TestComposeStack_RemoteBackend_Default is a regression guard: with the
-// default opts (RemoteBackend unset), neither the AWS nor the GCP composed
-// /providers.tf may declare a terraform state backend block. The composer
-// must preserve historical local-state behavior for every existing caller.
-// See issue #169.
+// default opts (RemoteBackend field unset, exercising the zero-value
+// default of false), neither the AWS nor the GCP composed /providers.tf
+// may declare a terraform state backend block. The composer must preserve
+// historical local-state behavior for every existing caller. See issue
+// #169.
+//
+// The test also anchors the composed providers.tf to its expected shape
+// (terraform { required_providers { ... } }) so a regression that
+// silently dropped the entire terraform block — which would also remove
+// any backend declaration — couldn't accidentally satisfy this guard.
 func TestComposeStack_RemoteBackend_Default(t *testing.T) {
 	t.Parallel()
 
@@ -2108,6 +2114,10 @@ func TestComposeStack_RemoteBackend_Default(t *testing.T) {
 	})
 	require.NoError(t, err)
 	awsProv := string(awsOut["/providers.tf"])
+	require.Contains(t, awsProv, "terraform {",
+		"AWS providers.tf must still emit a terraform { ... } block (anchor against accidental whole-block deletion)")
+	require.Contains(t, awsProv, "required_providers",
+		"AWS providers.tf must still emit required_providers (anchor against accidental whole-block deletion)")
 	require.NotContains(t, awsProv, `backend "s3"`,
 		"AWS default opts must not declare an s3 state backend")
 	require.NotContains(t, awsProv, `backend "gcs"`,
@@ -2124,6 +2134,10 @@ func TestComposeStack_RemoteBackend_Default(t *testing.T) {
 	})
 	require.NoError(t, err)
 	gcpProv := string(gcpOut["/providers.tf"])
+	require.Contains(t, gcpProv, "terraform {",
+		"GCP providers.tf must still emit a terraform { ... } block (anchor against accidental whole-block deletion)")
+	require.Contains(t, gcpProv, "required_providers",
+		"GCP providers.tf must still emit required_providers (anchor against accidental whole-block deletion)")
 	require.NotContains(t, gcpProv, `backend "gcs"`,
 		"GCP default opts must not declare a gcs state backend")
 	require.NotContains(t, gcpProv, `backend "s3"`,
@@ -2153,6 +2167,12 @@ func TestComposeStack_RemoteBackend_AWS(t *testing.T) {
 	prov := string(out["/providers.tf"])
 	require.Contains(t, prov, `backend "s3" {}`,
 		"AWS RemoteBackend=true should emit an empty backend \"s3\" {} sub-block")
+
+	// Uniqueness: defend against a copy-paste regression that double-emits
+	// the backend block. terraform rejects duplicate backend blocks at init
+	// time, but a lower-level test that catches it here is cheap insurance.
+	require.Equal(t, 1, strings.Count(prov, `backend "s3"`),
+		"backend \"s3\" block must be emitted exactly once")
 
 	// Lock placement: backend block must live inside the terraform { ... }
 	// block, not as a stray top-level block. The literal we emit puts the
@@ -2192,6 +2212,9 @@ func TestComposeStack_RemoteBackend_GCP(t *testing.T) {
 	require.Contains(t, prov, `backend "gcs" {}`,
 		"GCP RemoteBackend=true should emit an empty backend \"gcs\" {} sub-block")
 
+	require.Equal(t, 1, strings.Count(prov, `backend "gcs"`),
+		"backend \"gcs\" block must be emitted exactly once")
+
 	require.Contains(t, prov, "  }\n  backend \"gcs\" {}\n}\n",
 		"backend \"gcs\" {} must be a sub-block inside terraform { ... } immediately after required_providers")
 
@@ -2202,11 +2225,19 @@ func TestComposeStack_RemoteBackend_GCP(t *testing.T) {
 }
 
 // TestComposeStack_RemoteBackend_TerraformInit writes a RemoteBackend=true
-// composition to a temp dir and runs `terraform init -backend=false +
-// terraform validate` on it. -backend=false skips backend initialization,
-// so the empty backend block remains valid HCL and validation passes —
-// this proves callers can keep using their existing -backend=false test
-// path even when opting into a remote backend at deploy time.
+// composition to a temp dir and runs `terraform init -backend=false` on
+// it for both AWS and GCP. -backend=false skips backend initialization, so
+// the empty backend block remains parseable HCL — this proves callers can
+// keep using their existing -backend=false test path even when opting
+// into a remote backend at deploy time, and exercises both provider
+// plugin download paths (hashicorp/aws, hashicorp/google) with the new
+// terraform { backend ... } sub-block emitted.
+//
+// Note: like the sibling TestComposeStack_TerraformInit, this test
+// deliberately does not run `terraform validate` — preset modules carry
+// known validation-condition issues (contains() with null values etc.)
+// that are out of scope here and would mask the backend-block contract
+// this test exists to lock down.
 //
 // Skipped when terraform CLI is not available.
 func TestComposeStack_RemoteBackend_TerraformInit(t *testing.T) {
@@ -2214,25 +2245,64 @@ func TestComposeStack_RemoteBackend_TerraformInit(t *testing.T) {
 		t.Skip("terraform CLI not available, skipping init test")
 	}
 
+	tests := []struct {
+		name        string
+		opts        ComposeStackOpts
+		backendType string
+	}{
+		{
+			name: "aws emits backend s3",
+			opts: ComposeStackOpts{
+				Cloud:         "aws",
+				SelectedKeys:  []ComponentKey{KeyAWSVPC},
+				Comps:         &Components{},
+				Cfg:           &Config{Region: "us-east-1"},
+				Project:       "test",
+				Region:        "us-east-1",
+				RemoteBackend: true,
+			},
+			backendType: "s3",
+		},
+		{
+			name: "gcp emits backend gcs",
+			opts: ComposeStackOpts{
+				Cloud:         "gcp",
+				SelectedKeys:  []ComponentKey{KeyGCPVPC},
+				Comps:         &Components{},
+				Cfg:           &Config{Region: "us-central1"},
+				Project:       "test-project",
+				GCPProjectID:  "test-project-12345",
+				Region:        "us-central1",
+				RemoteBackend: true,
+			},
+			backendType: "gcs",
+		},
+	}
+
 	c := newTestClient()
-	out, err := c.ComposeStack(ComposeStackOpts{
-		Cloud:         "aws",
-		SelectedKeys:  []ComponentKey{KeyAWSVPC},
-		Comps:         &Components{},
-		Cfg:           &Config{Region: "us-east-1"},
-		Project:       "test",
-		Region:        "us-east-1",
-		RemoteBackend: true,
-	})
-	require.NoError(t, err, "ComposeStack with RemoteBackend should succeed")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := c.ComposeStack(tt.opts)
+			require.NoError(t, err, "ComposeStack with RemoteBackend should succeed")
 
-	dir := t.TempDir()
-	writeBundle(t, dir, out)
+			// Sanity-check the composed providers.tf actually contains the
+			// expected backend block before invoking terraform — if a
+			// regression silently dropped the block, init would still
+			// succeed (no backend == local state == passes -backend=false)
+			// and we'd miss the regression entirely.
+			prov := string(out["/providers.tf"])
+			require.Contains(t, prov, `backend "`+tt.backendType+`" {}`,
+				"composed providers.tf must include the expected empty backend block")
 
-	initCmd := exec.Command("terraform", "init", "-backend=false", "-no-color")
-	initCmd.Dir = dir
-	initOutput, err := initCmd.CombinedOutput()
-	require.NoError(t, err,
-		"terraform init -backend=false should succeed with an empty backend \"s3\" {} block:\n%s",
-		string(initOutput))
+			dir := t.TempDir()
+			writeBundle(t, dir, out)
+
+			initCmd := exec.Command("terraform", "init", "-backend=false", "-no-color")
+			initCmd.Dir = dir
+			initOutput, err := initCmd.CombinedOutput()
+			require.NoError(t, err,
+				"terraform init -backend=false should succeed with an empty backend %q {} block:\n%s",
+				tt.backendType, string(initOutput))
+		})
+	}
 }

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -2087,3 +2087,152 @@ func TestComposeStack_PolymorphicKeyPullsInPrefixedVPC(t *testing.T) {
 	require.Contains(t, mainTF, `module "resource"`,
 		"polymorphic KeyAWSEKSControlPlane preserves its string value and renders as module.resource")
 }
+
+// TestComposeStack_RemoteBackend_Default is a regression guard: with the
+// default opts (RemoteBackend unset), neither the AWS nor the GCP composed
+// /providers.tf may declare a terraform state backend block. The composer
+// must preserve historical local-state behavior for every existing caller.
+// See issue #169.
+func TestComposeStack_RemoteBackend_Default(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+
+	awsOut, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+	awsProv := string(awsOut["/providers.tf"])
+	require.NotContains(t, awsProv, `backend "s3"`,
+		"AWS default opts must not declare an s3 state backend")
+	require.NotContains(t, awsProv, `backend "gcs"`,
+		"AWS providers.tf must never declare a gcs backend")
+
+	gcpOut, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPVPC},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-central1"},
+		Project:      "test-project",
+		GCPProjectID: "test-project-12345",
+		Region:       "us-central1",
+	})
+	require.NoError(t, err)
+	gcpProv := string(gcpOut["/providers.tf"])
+	require.NotContains(t, gcpProv, `backend "gcs"`,
+		"GCP default opts must not declare a gcs state backend")
+	require.NotContains(t, gcpProv, `backend "s3"`,
+		"GCP providers.tf must never declare an s3 backend")
+}
+
+// TestComposeStack_RemoteBackend_AWS verifies that opts.RemoteBackend=true
+// on an AWS stack emits an empty `backend "s3" {}` sub-block inside the
+// composed terraform { ... } block. The bucket is filled in at
+// `terraform init -backend-config=...` time by the apply container —
+// composer does not interpolate it. See issue #169.
+func TestComposeStack_RemoteBackend_AWS(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:         "aws",
+		SelectedKeys:  []ComponentKey{KeyAWSVPC},
+		Comps:         &Components{},
+		Cfg:           &Config{Region: "us-east-1"},
+		Project:       "test",
+		Region:        "us-east-1",
+		RemoteBackend: true,
+	})
+	require.NoError(t, err)
+
+	prov := string(out["/providers.tf"])
+	require.Contains(t, prov, `backend "s3" {}`,
+		"AWS RemoteBackend=true should emit an empty backend \"s3\" {} sub-block")
+
+	// Lock placement: backend block must live inside the terraform { ... }
+	// block, not as a stray top-level block. The literal we emit puts the
+	// backend block right after required_providers closes, then the
+	// terraform block's own closing brace on the next line.
+	require.Contains(t, prov, "  }\n  backend \"s3\" {}\n}\n",
+		"backend \"s3\" {} must be a sub-block inside terraform { ... } immediately after required_providers")
+
+	// No interpolation: the composer must not invent bucket/region/key
+	// values — those are supplied at terraform init time.
+	require.NotRegexp(t,
+		regexp.MustCompile(`backend\s*"s3"\s*\{\s*\w`),
+		prov,
+		"backend \"s3\" block must be empty; bucket/region/key are -backend-config=... at init time")
+}
+
+// TestComposeStack_RemoteBackend_GCP is the GCP counterpart to
+// TestComposeStack_RemoteBackend_AWS — opts.RemoteBackend=true on a GCP
+// stack emits an empty `backend "gcs" {}` sub-block. See issue #169.
+func TestComposeStack_RemoteBackend_GCP(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:         "gcp",
+		SelectedKeys:  []ComponentKey{KeyGCPVPC},
+		Comps:         &Components{},
+		Cfg:           &Config{Region: "us-central1"},
+		Project:       "test-project",
+		GCPProjectID:  "test-project-12345",
+		Region:        "us-central1",
+		RemoteBackend: true,
+	})
+	require.NoError(t, err)
+
+	prov := string(out["/providers.tf"])
+	require.Contains(t, prov, `backend "gcs" {}`,
+		"GCP RemoteBackend=true should emit an empty backend \"gcs\" {} sub-block")
+
+	require.Contains(t, prov, "  }\n  backend \"gcs\" {}\n}\n",
+		"backend \"gcs\" {} must be a sub-block inside terraform { ... } immediately after required_providers")
+
+	require.NotRegexp(t,
+		regexp.MustCompile(`backend\s*"gcs"\s*\{\s*\w`),
+		prov,
+		"backend \"gcs\" block must be empty; bucket/prefix are -backend-config=... at init time")
+}
+
+// TestComposeStack_RemoteBackend_TerraformInit writes a RemoteBackend=true
+// composition to a temp dir and runs `terraform init -backend=false +
+// terraform validate` on it. -backend=false skips backend initialization,
+// so the empty backend block remains valid HCL and validation passes —
+// this proves callers can keep using their existing -backend=false test
+// path even when opting into a remote backend at deploy time.
+//
+// Skipped when terraform CLI is not available.
+func TestComposeStack_RemoteBackend_TerraformInit(t *testing.T) {
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform CLI not available, skipping init test")
+	}
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:         "aws",
+		SelectedKeys:  []ComponentKey{KeyAWSVPC},
+		Comps:         &Components{},
+		Cfg:           &Config{Region: "us-east-1"},
+		Project:       "test",
+		Region:        "us-east-1",
+		RemoteBackend: true,
+	})
+	require.NoError(t, err, "ComposeStack with RemoteBackend should succeed")
+
+	dir := t.TempDir()
+	writeBundle(t, dir, out)
+
+	initCmd := exec.Command("terraform", "init", "-backend=false", "-no-color")
+	initCmd.Dir = dir
+	initOutput, err := initCmd.CombinedOutput()
+	require.NoError(t, err,
+		"terraform init -backend=false should succeed with an empty backend \"s3\" {} block:\n%s",
+		string(initOutput))
+}


### PR DESCRIPTION
## Summary

- Add `ComposeStackOpts.RemoteBackend` (default `false`). When set, composer emits an empty `backend "s3" {}` (AWS) or `backend "gcs" {}` (GCP) sub-block inside the composed `providers.tf` `terraform { ... }` block.
- Bucket, region, and key/prefix are filled in at `terraform init -backend-config=...` time by the apply container (HashiCorp partial-configuration pattern). Composer never interpolates per-project values.
- Refactor `generateProvidersTF` to take a `providersTFInput` struct instead of a positional arg list so future inputs land without breaking call sites.

## Why

A `terraform apply` that fails midway today loses local state if the Argo emissary executor doesn't finalize the failing pod cleanly (OOM, preemption, executor crash). ui-core#314 hardened the artifact-upload path with `Optional:true`, but the dependency on pod-lifecycle finalization remains.

With state on a remote backend, partial mutations are durable by construction (the bucket already exists per-project — `aws_s3_bucket_tfstate` from cloud-provision). A subsequent `terraform plan` recognizes the partial resources instead of trying to recreate them, eliminating the multi-round wedge class of bugs.

## Why opt-in

Default off so existing callers are unchanged. ui-core flips it on per stack once it has plumbed `state_bucket` into the apply container and added `terraform init -backend-config=...` (separate ticket). This keeps roll-forward / roll-back to a single bool flip per call site, with no preset content changes.

## Test plan

- [x] `go test ./pkg/composer/...` — full suite passes (~100s)
- [x] `TestComposeStack_RemoteBackend_Default` — regression guard: default opts (zero-value `RemoteBackend`) emit no backend block on AWS or GCP; anchored to `terraform {` / `required_providers` so an accidental whole-block deletion can't satisfy the guard
- [x] `TestComposeStack_RemoteBackend_AWS` — opt-in emits `backend "s3" {}` exactly once, inside the `terraform { ... }` block, with no interpolated values
- [x] `TestComposeStack_RemoteBackend_GCP` — opt-in emits `backend "gcs" {}` with the same uniqueness, placement, and emptiness checks
- [x] `TestComposeStack_RemoteBackend_TerraformInit` — table-driven across **both AWS and GCP**: composes a stack with `RemoteBackend: true`, sanity-checks the composed `providers.tf` contains the expected backend block (guards against silent-drop regressions that `init` alone wouldn't catch), then runs `terraform init -backend=false` against a temp dir. Both subtests pass — proves the empty backend block is parseable HCL and exercises both provider plugin download paths (hashicorp/aws, hashicorp/google)
- [x] `terraform fmt -check -recursive` — clean
- [x] All 4 static lint scripts (`lint-project-tag`, `lint-project-label`, `lint-sensitive-for-each`, `lint-foreach-unknown-keys`) — PASS
- [x] QA professor review — PASS (5 issues from first pass all addressed in second commit)
- [ ] **Out of scope (separate tickets):** ui-core wiring of `state_bucket` into custom-stack auto-vars; `prepare-custom-stack.sh` / `apply-with-outputs.sh` updates to call `terraform init -backend-config=...` when the opt-in flag is set; eventual default flip once ui-core has rolled it out.

Closes #169