### PR TITLE
feat(composer): cross-tier wiring resolution + union-graph validators (#150)

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -602,6 +602,8 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	issues = append(issues, ValidateValueTypes(moduleToVals, presetPaths)...)
 	issues = append(issues, ValidateModuleWiring(blocks, presetPaths)...)
 	issues = append(issues, ValidateNoModuleCycles(blocks)...)
+	issues = append(issues, ValidateNoUnionCycles(blocks, opts.Imported)...)
+	issues = append(issues, ValidateCrossTierWiring(blocks, opts.Imported)...)
 	issues = append(issues, ValidateProviderConstraints(presetPaths)...)
 	issues = append(issues, ValidateSensitivePropagation(blocks, presetPaths)...)
 	issues = append(issues, ValidateComposedRoot(files)...)

--- a/pkg/composer/imported_compose_test.go
+++ b/pkg/composer/imported_compose_test.go
@@ -417,3 +417,112 @@ func TestEmitImportedTF_ProducesValidHCL(t *testing.T) {
 	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
 	require.False(t, diags.HasErrors(), "EmitImportedTF must produce valid HCL: %s", diags.Error())
 }
+
+// TestComposeStackWithIssues_CrossTierWiring_RoundTrip pins the issue
+// #150 happy path: an imported resource referencing another imported
+// resource via RawExpr round-trips through ComposeStackWithIssues
+// without introducing dangling_resource_ref / wiring_cycle issues
+// and emits the expression text verbatim in /imported.tf.
+func TestComposeStackWithIssues_CrossTierWiring_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-east-1",
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_dynamodb_table",
+					Address:  "aws_dynamodb_table.users",
+					ImportID: "users",
+				},
+				Tier: imported.TierImportedFlat,
+				Attributes: map[string]any{
+					"name":     "users",
+					"hash_key": "id",
+				},
+			},
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_lambda_function",
+					Address:  "aws_lambda_function.api",
+					ImportID: "api",
+				},
+				Tier: imported.TierImportedFlat,
+				Attributes: map[string]any{
+					"function_name": "api",
+					// Cross-tier reference: api Lambda reads users table ARN.
+					"description": RawExpr{Expr: "aws_dynamodb_table.users.arn"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	for _, iss := range res.Issues {
+		require.NotEqual(t, "dangling_resource_ref", iss.Code, "unexpected: %v", iss)
+		require.NotEqual(t, "dangling_module_ref_from_imported", iss.Code, "unexpected: %v", iss)
+		require.NotEqual(t, "unwired_resource_attr", iss.Code, "unexpected: %v", iss)
+		require.NotEqual(t, "wiring_cycle", iss.Code, "unexpected: %v", iss)
+		require.NotEqual(t, "hcl_parse_error", iss.Code, "unexpected: %v", iss)
+	}
+	importedTF := string(res.Files["/imported.tf"])
+	// Assert the *unquoted* form: `description = aws_dynamodb_table.users.arn`,
+	// not `description = "aws_dynamodb_table.users.arn"`. The latter
+	// would still satisfy a substring check while breaking semantics.
+	require.Regexp(t,
+		`description\s*=\s*aws_dynamodb_table\.users\.arn`,
+		importedTF,
+		"RawExpr must round-trip as a Terraform reference, not a quoted string")
+}
+
+// TestComposeStackWithIssues_CrossTierWiring_DanglingFlagged pins the
+// negative path: a module input referencing a flat imported address
+// that isn't in the stack surfaces exactly one dangling_resource_ref
+// issue (and not multiple noisy variants).
+func TestComposeStackWithIssues_CrossTierWiring_DanglingFlagged(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-east-1",
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_lambda_function",
+					Address:  "aws_lambda_function.api",
+					ImportID: "api",
+				},
+				Tier: imported.TierImportedFlat,
+				Attributes: map[string]any{
+					"function_name": "api",
+					"description":   RawExpr{Expr: "aws_dynamodb_table.absent.arn"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Issues, "compose must emit issues for a dangling reference")
+	require.NotEmpty(t, res.Files["/imported.tf"],
+		"compose must still emit /imported.tf even when references dangle")
+	dangling := 0
+	for _, iss := range res.Issues {
+		if iss.Code == "dangling_resource_ref" {
+			dangling++
+			require.Equal(t, "imported.aws_lambda_function.api.description", iss.Field)
+		}
+	}
+	require.Equal(t, 1, dangling, "expected exactly one dangling_resource_ref, got: %v", res.Issues)
+}

--- a/pkg/composer/noselfimport_test.go
+++ b/pkg/composer/noselfimport_test.go
@@ -23,6 +23,10 @@ import (
 //     typed Layer 1 structs that the composer must consume to emit
 //     /imported.tf (issue #148). These are infrastructure owned by the
 //     composer, not downstream consumers.
+//   - github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy
+//     — Phase 2 Layer 2 field-policy registry (issue #147) used by
+//     cross-tier wiring validators (issue #150) to classify
+//     wiring vs scalar attributes.
 //
 // Subpackages outside the allowlist (e.g. an "internal/" helper) must fail
 // so coupling can't accidentally leak in.
@@ -34,6 +38,7 @@ func TestNoForeignLutherImportsInNonTestFiles(t *testing.T) {
 	allowedSubpackages := map[string]struct{}{
 		parentPkg + "/pkg/composer/imported":           {},
 		parentPkg + "/pkg/composer/imported/generated": {},
+		parentPkg + "/pkg/composer/imported/policy":    {},
 	}
 
 	entries, err := os.ReadDir(".")

--- a/pkg/composer/validate_cross_tier.go
+++ b/pkg/composer/validate_cross_tier.go
@@ -1,0 +1,157 @@
+package composer
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// ValidateCrossTierWiring asserts that every cross-tier expression
+// reference resolves to a producer present in the union graph
+// (issue #150). Three issue codes can be produced:
+//
+//   - dangling_resource_ref — a module input or imported attribute
+//     references `<aws_*|google_*>.<label>.<attr>` but no imported
+//     resource at that address is in the stack.
+//   - dangling_module_ref_from_imported — an imported attribute
+//     references `module.X.Y` but module X is not in the stack.
+//     (The module → missing-module case is already covered by
+//     ValidateModuleWiring.)
+//   - unwired_resource_attr — an imported→imported reference whose
+//     producer type is registered in `generated.Lookup` but whose
+//     referenced attribute is not in that schema. Unregistered types
+//     are skipped (Phase 1 wire-compat).
+//
+// Module → missing-module references that originate inside a preset
+// module (the case ValidateModuleWiring already covers) are not
+// re-flagged here.
+func ValidateCrossTierWiring(blocks []ModuleBlock, irs []imported.ImportedResource) []ValidationIssue {
+	moduleNames := map[string]bool{}
+	for _, b := range blocks {
+		moduleNames[b.Name] = true
+	}
+	resourceAddrs := map[string]bool{}
+	for _, ir := range irs {
+		if !isEmitEligibleConsumer(ir) {
+			continue
+		}
+		addr := strings.TrimSpace(ir.Identity.Address)
+		if addr != "" {
+			resourceAddrs[addr] = true
+		}
+	}
+
+	var issues []ValidationIssue
+	for _, edge := range extractUnionEdges(blocks, irs) {
+		switch edge.Producer.Kind {
+		case NodeKindResource:
+			if resourceAddrs[edge.Producer.Addr] {
+				// Producer is in the stack. Cross-check the attribute
+				// against the generated schema if one is registered.
+				if issue := classifyAttrIssue(edge); issue != nil {
+					issues = append(issues, *issue)
+				}
+				continue
+			}
+			issues = append(issues, ValidationIssue{
+				Field:  consumerField(edge),
+				Code:   "dangling_resource_ref",
+				Value:  edge.Producer.Addr + "." + edge.ProducerAttr,
+				Reason: danglingResourceReason(edge),
+			})
+		case NodeKindModule:
+			if moduleNames[edge.Producer.Addr] {
+				continue
+			}
+			// Module → missing module from a preset module consumer is the
+			// existing ValidateModuleWiring surface; only surface
+			// dangling_module_ref_from_imported when the consumer is an
+			// imported resource, which ValidateModuleWiring does not see.
+			if edge.Consumer.Kind != NodeKindResource {
+				continue
+			}
+			issues = append(issues, ValidationIssue{
+				Field:  consumerField(edge),
+				Code:   "dangling_module_ref_from_imported",
+				Value:  "module." + edge.Producer.Addr + "." + edge.ProducerAttr,
+				Reason: fmt.Sprintf("imported resource %s references module.%s.%s, but no module %q is in the stack", edge.Consumer.String(), edge.Producer.Addr, edge.ProducerAttr, edge.Producer.Addr),
+			})
+		}
+	}
+
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].Field != issues[j].Field {
+			return issues[i].Field < issues[j].Field
+		}
+		if issues[i].Code != issues[j].Code {
+			return issues[i].Code < issues[j].Code
+		}
+		return issues[i].Reason < issues[j].Reason
+	})
+	return issues
+}
+
+// classifyAttrIssue reports unwired_resource_attr when the producer is
+// in the stack but its referenced attribute is not in the registered
+// generated schema for the producer's type. Unregistered types skip
+// silently — Phase 1 imports may reference resources whose schema has
+// not been generated yet.
+func classifyAttrIssue(edge UnionEdge) *ValidationIssue {
+	tfType, _, ok := splitAddr(edge.Producer.Addr)
+	if !ok {
+		return nil
+	}
+	_, schema, registered := generated.Lookup(tfType)
+	if !registered {
+		return nil
+	}
+	if _, ok := schema[edge.ProducerAttr]; ok {
+		return nil
+	}
+	return &ValidationIssue{
+		Field:  consumerField(edge),
+		Code:   "unwired_resource_attr",
+		Value:  edge.Producer.Addr + "." + edge.ProducerAttr,
+		Reason: fmt.Sprintf("%s references %s.%s, but %s declares no attribute %q in its provider schema", edge.Consumer.String(), edge.Producer.Addr, edge.ProducerAttr, tfType, edge.ProducerAttr),
+	}
+}
+
+// consumerField builds a stable Field string for an edge. Module
+// consumers use "<name>.<input>"; imported-resource consumers use
+// "imported.<addr>.<input>" so the prefix matches importedField()
+// from imported_validate.go.
+func consumerField(edge UnionEdge) string {
+	if edge.Consumer.Kind == NodeKindResource {
+		return "imported." + edge.Consumer.Addr + "." + edge.ConsumerInput
+	}
+	return edge.Consumer.Addr + "." + edge.ConsumerInput
+}
+
+// danglingResourceReason composes the human-readable reason for
+// dangling_resource_ref, labeling the consuming attribute as a
+// "wiring attribute" when Layer 2 policy curates it that way so
+// reviewers see the field-policy classification.
+func danglingResourceReason(edge UnionEdge) string {
+	classifier := "attribute"
+	if edge.Consumer.Kind == NodeKindResource {
+		tfType, _, ok := splitAddr(edge.Consumer.Addr)
+		if ok && attrIsWiring(tfType, edge.ConsumerInput) {
+			classifier = "wiring attribute"
+		}
+	}
+	return fmt.Sprintf("%s %s %q references %s.%s, but no imported resource at address %q is in the stack",
+		edge.Consumer.String(), classifier, edge.ConsumerInput,
+		edge.Producer.Addr, edge.ProducerAttr, edge.Producer.Addr)
+}
+
+// splitAddr splits "<tf_type>.<label>" into its components.
+func splitAddr(addr string) (tfType, label string, ok bool) {
+	dot := strings.IndexByte(addr, '.')
+	if dot <= 0 || dot == len(addr)-1 {
+		return "", "", false
+	}
+	return addr[:dot], addr[dot+1:], true
+}

--- a/pkg/composer/validate_cross_tier_test.go
+++ b/pkg/composer/validate_cross_tier_test.go
@@ -1,0 +1,178 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+func TestValidateCrossTierWiring_DanglingResourceRef(t *testing.T) {
+	t.Parallel()
+
+	// Module references a resource address that isn't in the stack.
+	blocks := []ModuleBlock{
+		{Name: "aws_lambda", Raw: map[string]string{"dlq_arn": "aws_sqs_queue.absent.arn"}},
+	}
+	issues := ValidateCrossTierWiring(blocks, nil)
+	require.Len(t, issues, 1)
+	require.Equal(t, "dangling_resource_ref", issues[0].Code)
+	require.Equal(t, "aws_lambda.dlq_arn", issues[0].Field)
+	require.Equal(t, "aws_sqs_queue.absent.arn", issues[0].Value)
+	require.Contains(t, issues[0].Reason, "aws_sqs_queue.absent")
+}
+
+func TestValidateCrossTierWiring_DanglingModuleRefFromImported(t *testing.T) {
+	t.Parallel()
+
+	irs := []imported.ImportedResource{
+		{
+			Identity:   imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.dlq", ImportID: "x"},
+			Tier:       imported.TierImportedFlat,
+			Attributes: map[string]any{"redrive_policy": RawExpr{Expr: "module.absent_mod.topic_arn"}},
+		},
+	}
+	issues := ValidateCrossTierWiring(nil, irs)
+	require.Len(t, issues, 1)
+	require.Equal(t, "dangling_module_ref_from_imported", issues[0].Code)
+	require.Equal(t, "imported.aws_sqs_queue.dlq.redrive_policy", issues[0].Field)
+	require.Equal(t, "module.absent_mod.topic_arn", issues[0].Value)
+}
+
+func TestValidateCrossTierWiring_UnwiredResourceAttr(t *testing.T) {
+	t.Parallel()
+
+	// Both producer and consumer are imported resources of registered
+	// types, but the consumer references an attribute the producer's
+	// generated schema doesn't declare. The producer's address must be
+	// in resourceAddrs, otherwise this falls into dangling_resource_ref
+	// instead. aws_dynamodb_table is registered in generated/.
+	const (
+		producerType  = "aws_dynamodb_table"
+		syntheticAttr = "__qa_synthetic_unwired_attr_v1__"
+	)
+	// Schema-drift defense: assert the synthetic attribute is genuinely
+	// not in the registered schema. A future codegen run that introduces
+	// a real attribute by this exact name would silently flip the test;
+	// the assertion catches that before it confuses CI.
+	_, schema, ok := generated.Lookup(producerType)
+	require.True(t, ok, "%s must be registered in generated/", producerType)
+	_, conflict := schema[syntheticAttr]
+	require.False(t, conflict,
+		"synthetic attr %q must not exist in %s schema (rename if it does)",
+		syntheticAttr, producerType)
+
+	irs := []imported.ImportedResource{
+		{
+			Identity:   imported.ResourceIdentity{Cloud: "aws", Type: producerType, Address: producerType + ".t", ImportID: "x"},
+			Tier:       imported.TierImportedFlat,
+			Attributes: map[string]any{},
+		},
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_lambda_function", Address: "aws_lambda_function.fn", ImportID: "x"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"environment": RawExpr{Expr: producerType + ".t." + syntheticAttr},
+			},
+		},
+	}
+
+	issues := ValidateCrossTierWiring(nil, irs)
+	require.Len(t, issues, 1)
+	require.Equal(t, "unwired_resource_attr", issues[0].Code)
+	require.Equal(t, "imported.aws_lambda_function.fn.environment", issues[0].Field)
+	require.Contains(t, issues[0].Reason, syntheticAttr)
+}
+
+func TestValidateCrossTierWiring_ResolvedRefsAreSilent(t *testing.T) {
+	t.Parallel()
+
+	// A fully wired cross-tier reference: imported Lambda references
+	// imported DynamoDB table's `arn` attribute, which is in the
+	// generated schema for aws_dynamodb_table.
+	irs := []imported.ImportedResource{
+		{
+			Identity:   imported.ResourceIdentity{Cloud: "aws", Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.t", ImportID: "x"},
+			Tier:       imported.TierImportedFlat,
+			Attributes: map[string]any{},
+		},
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_lambda_function", Address: "aws_lambda_function.fn", ImportID: "x"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"environment": RawExpr{Expr: "aws_dynamodb_table.t.arn"},
+			},
+		},
+	}
+
+	require.Empty(t, ValidateCrossTierWiring(nil, irs))
+}
+
+func TestValidateCrossTierWiring_RemovedResourceIsNotProducer(t *testing.T) {
+	t.Parallel()
+
+	// A resource scheduled for `removed {}` emission must not appear as
+	// a producer in resourceAddrs — otherwise references to it would
+	// silently pass instead of being flagged dangling.
+	irs := []imported.ImportedResource{
+		{
+			Identity:    imported.ResourceIdentity{Cloud: "aws", Type: "aws_kms_key", Address: "aws_kms_key.gone", ImportID: "x"},
+			Tier:        imported.TierImportedMissing,
+			Remediation: imported.ActionRemoveFromInsideOut,
+		},
+	}
+	blocks := []ModuleBlock{
+		{Name: "aws_lambda", Raw: map[string]string{"key_arn": "aws_kms_key.gone.arn"}},
+	}
+	issues := ValidateCrossTierWiring(blocks, irs)
+	require.Len(t, issues, 1)
+	require.Equal(t, "dangling_resource_ref", issues[0].Code)
+}
+
+func TestValidateCrossTierWiring_ModuleRefFromModuleNotReReported(t *testing.T) {
+	t.Parallel()
+
+	// Module → missing-module is ValidateModuleWiring's surface (it
+	// emits unwired_output). Don't re-flag the same case here.
+	blocks := []ModuleBlock{
+		{Name: "aws_alb", Raw: map[string]string{"vpc_id": "module.absent_vpc.vpc_id"}},
+	}
+	require.Empty(t, ValidateCrossTierWiring(blocks, nil))
+}
+
+func TestValidateCrossTierWiring_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+
+	// Three issues with overlapping Field values to exercise the
+	// secondary (Code) and tertiary (Reason) sort keys, not just
+	// the primary (Field). aws_dynamodb_table is registered in the
+	// generated schema, so the in-stack producer + bogus attr
+	// triggers `unwired_resource_attr` while a different attr on the
+	// same module input triggers `dangling_resource_ref`.
+	irs := []imported.ImportedResource{
+		{
+			Identity:   imported.ResourceIdentity{Cloud: "aws", Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.t", ImportID: "x"},
+			Tier:       imported.TierImportedFlat,
+			Attributes: map[string]any{},
+		},
+	}
+	blocks := []ModuleBlock{
+		{Name: "aws_lambda", Raw: map[string]string{
+			"a_attr": "aws_sqs_queue.absent.arn",            // dangling_resource_ref
+			"m_attr": "aws_dynamodb_table.t.bogus_attribute", // unwired_resource_attr
+			"z_attr": "aws_iam_role.absent.arn",             // dangling_resource_ref
+		}},
+	}
+	issues := ValidateCrossTierWiring(blocks, irs)
+	require.Len(t, issues, 3)
+	// Primary sort: Field. a_attr < m_attr < z_attr.
+	require.Equal(t, "aws_lambda.a_attr", issues[0].Field)
+	require.Equal(t, "aws_lambda.m_attr", issues[1].Field)
+	require.Equal(t, "aws_lambda.z_attr", issues[2].Field)
+	// Secondary sort observable via Code on the middle row.
+	require.Equal(t, "unwired_resource_attr", issues[1].Code)
+	require.Equal(t, "dangling_resource_ref", issues[0].Code)
+	require.Equal(t, "dangling_resource_ref", issues[2].Code)
+}

--- a/pkg/composer/validate_module_graph.go
+++ b/pkg/composer/validate_module_graph.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
 // wiringEdge describes a single `module.<consumer>.<input> = module.<producer>.<output>`
@@ -182,6 +185,145 @@ func ValidateNoModuleCycles(blocks []ModuleBlock) []ValidationIssue {
 		Code:   "module_cycle",
 		Reason: fmt.Sprintf("module dependency cycle involving: %v%s", stuck, closing),
 	}}
+}
+
+// ValidateNoUnionCycles topo-sorts the union wiring graph (preset
+// module calls + flat imported resources) and reports cycles that
+// span at least one resource node. Pure module-only cycles are left
+// to ValidateNoModuleCycles so the existing `module_cycle` issue
+// shape is preserved; this validator owns the new `wiring_cycle`
+// code emitted only when an imported resource participates in the
+// cycle.
+//
+// Field stays "module_graph" (matching ValidateNoModuleCycles) so
+// dedupeAndSortIssues groups graph-level issues consistently.
+func ValidateNoUnionCycles(blocks []ModuleBlock, irs []imported.ImportedResource) []ValidationIssue {
+	nodes := map[GraphNode]bool{}
+	for _, b := range blocks {
+		nodes[GraphNode{Kind: NodeKindModule, Addr: b.Name}] = true
+	}
+	for _, ir := range irs {
+		if !isEmitEligibleConsumer(ir) {
+			continue
+		}
+		addr := strings.TrimSpace(ir.Identity.Address)
+		if addr == "" {
+			continue
+		}
+		nodes[GraphNode{Kind: NodeKindResource, Addr: addr}] = true
+	}
+
+	indeg := map[GraphNode]int{}
+	deps := map[GraphNode]map[GraphNode]bool{} // producer -> set(consumers)
+	for n := range nodes {
+		indeg[n] = 0
+		deps[n] = map[GraphNode]bool{}
+	}
+
+	edges := extractUnionEdges(blocks, irs)
+	for _, e := range edges {
+		if !nodes[e.Producer] || !nodes[e.Consumer] {
+			continue
+		}
+		if e.Producer == e.Consumer {
+			continue
+		}
+		if !deps[e.Producer][e.Consumer] {
+			deps[e.Producer][e.Consumer] = true
+			indeg[e.Consumer]++
+		}
+	}
+
+	// Kahn's algorithm. Sort by node string for deterministic queue
+	// ordering (matches ValidateNoModuleCycles).
+	queueKeys := make([]GraphNode, 0, len(indeg))
+	for n, d := range indeg {
+		if d == 0 {
+			queueKeys = append(queueKeys, n)
+		}
+	}
+	sortNodes(queueKeys)
+	visited := map[GraphNode]bool{}
+	for len(queueKeys) > 0 {
+		n := queueKeys[0]
+		queueKeys = queueKeys[1:]
+		visited[n] = true
+		next := make([]GraphNode, 0, len(deps[n]))
+		for d := range deps[n] {
+			indeg[d]--
+			if indeg[d] == 0 {
+				next = append(next, d)
+			}
+		}
+		sortNodes(next)
+		queueKeys = append(queueKeys, next...)
+	}
+
+	var stuck []GraphNode
+	for n := range nodes {
+		if !visited[n] {
+			stuck = append(stuck, n)
+		}
+	}
+	if len(stuck) == 0 {
+		return nil
+	}
+	// Defer to ValidateNoModuleCycles for the pure-module case so the
+	// `module_cycle` code stays canonical and we don't double-report.
+	hasResource := false
+	for _, n := range stuck {
+		if n.Kind == NodeKindResource {
+			hasResource = true
+			break
+		}
+	}
+	if !hasResource {
+		return nil
+	}
+	sortNodes(stuck)
+
+	stuckSet := map[GraphNode]bool{}
+	for _, n := range stuck {
+		stuckSet[n] = true
+	}
+	// Pinpoint at least one closing edge so reviewers can see where to
+	// break the cycle. When the graph contains multiple disjoint
+	// cycles this picks one of them; the full stuck-node list is in
+	// the Reason regardless, so the operator can grep the rendered
+	// composed root for the rest.
+	var closing string
+	for _, e := range edges {
+		if stuckSet[e.Producer] && stuckSet[e.Consumer] && e.Producer != e.Consumer {
+			var consumerSlot string
+			if e.Consumer.Kind == NodeKindResource {
+				consumerSlot = "imported." + e.Consumer.Addr + "." + e.ConsumerInput
+			} else {
+				consumerSlot = e.Consumer.Addr + "." + e.ConsumerInput
+			}
+			closing = fmt.Sprintf(" (e.g. %s -> %s.%s)", consumerSlot, e.Producer.String(), e.ProducerAttr)
+			break
+		}
+	}
+	stuckNames := make([]string, len(stuck))
+	for i, n := range stuck {
+		stuckNames[i] = n.String()
+	}
+	return []ValidationIssue{{
+		Field:  "module_graph",
+		Code:   "wiring_cycle",
+		Reason: fmt.Sprintf("cross-tier wiring cycle involving: %v%s", stuckNames, closing),
+	}}
+}
+
+// sortNodes orders GraphNodes deterministically by Kind then Addr. The
+// kind ordering (module < resource) matches GraphNodeKind iota order.
+func sortNodes(ns []GraphNode) {
+	sort.Slice(ns, func(i, j int) bool {
+		if ns[i].Kind != ns[j].Kind {
+			return ns[i].Kind < ns[j].Kind
+		}
+		return ns[i].Addr < ns[j].Addr
+	})
 }
 
 // ValidateValueTypes asserts each mapped module input value is convertible

--- a/pkg/composer/validate_module_graph_test.go
+++ b/pkg/composer/validate_module_graph_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
 func TestExtractWiringEdges_BasicAndDeterministic(t *testing.T) {
@@ -166,6 +168,75 @@ func TestValidateValueTypes_AcceptsValidValues(t *testing.T) {
 	require.Empty(t, ValidateValueTypes(moduleToVals, presetPaths))
 }
 
+// TestValidateNoUnionCycles_DetectsCrossTierCycle pins that a cycle
+// spanning a preset module and a flat imported resource is reported
+// as wiring_cycle (not module_cycle), with the closing-edge hint
+// rendered in module/resource form so reviewers can break the cycle.
+func TestValidateNoUnionCycles_DetectsCrossTierCycle(t *testing.T) {
+	t.Parallel()
+
+	// Module aws_lambda consumes resource aws_sqs_queue.dlq.arn;
+	// resource aws_sqs_queue.dlq consumes module.aws_lambda.role_arn.
+	blocks := []ModuleBlock{
+		{Name: "aws_lambda", Raw: map[string]string{"dlq_arn": "aws_sqs_queue.dlq.arn"}},
+	}
+	irs := []imported.ImportedResource{
+		{
+			Identity:   imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.dlq", ImportID: "x"},
+			Tier:       imported.TierImportedFlat,
+			Attributes: map[string]any{"redrive_role_arn": RawExpr{Expr: "module.aws_lambda.role_arn"}},
+		},
+	}
+
+	issues := ValidateNoUnionCycles(blocks, irs)
+	require.Len(t, issues, 1)
+	require.Equal(t, "wiring_cycle", issues[0].Code)
+	require.Equal(t, "module_graph", issues[0].Field)
+	require.Contains(t, issues[0].Reason, "module.aws_lambda")
+	require.Contains(t, issues[0].Reason, "aws_sqs_queue.dlq")
+	// Closing-edge hint locks the rendering format `(e.g. <consumerSlot>
+	// -> <producer>.<attr>)`. Either edge of the 2-cycle qualifies; both
+	// shapes are pinned so an argument-swap mutation surfaces.
+	require.Regexp(t,
+		`\(e\.g\. (imported\.aws_sqs_queue\.dlq\.redrive_role_arn -> module\.aws_lambda\.role_arn|aws_lambda\.dlq_arn -> aws_sqs_queue\.dlq\.arn)\)`,
+		issues[0].Reason,
+		"closing-edge hint must reference both nodes with kind-specific prefixes")
+}
+
+// TestValidateNoUnionCycles_PureModuleCycleSkipped pins the deferral
+// contract: a pure-module cycle is left to ValidateNoModuleCycles so
+// the canonical `module_cycle` code is emitted exactly once instead
+// of double-reporting.
+func TestValidateNoUnionCycles_PureModuleCycleSkipped(t *testing.T) {
+	t.Parallel()
+
+	blocks := []ModuleBlock{
+		{Name: "a", Raw: map[string]string{"x": "module.b.x"}},
+		{Name: "b", Raw: map[string]string{"y": "module.a.y"}},
+	}
+	require.Empty(t, ValidateNoUnionCycles(blocks, nil),
+		"pure-module cycle must be deferred to ValidateNoModuleCycles")
+}
+
+// TestValidateNoUnionCycles_DAGNoIssue guards the happy path: a mixed
+// module + imported-resource graph with a strict topological order
+// produces no cycles.
+func TestValidateNoUnionCycles_DAGNoIssue(t *testing.T) {
+	t.Parallel()
+
+	blocks := []ModuleBlock{
+		{Name: "aws_lambda", Raw: map[string]string{"dlq_arn": "aws_sqs_queue.dlq.arn"}},
+	}
+	irs := []imported.ImportedResource{
+		{
+			Identity:   imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.dlq", ImportID: "x"},
+			Tier:       imported.TierImportedFlat,
+			Attributes: map[string]any{},
+		},
+	}
+	require.Empty(t, ValidateNoUnionCycles(blocks, irs))
+}
+
 // TestComposeStackWithIssues_GreenStackHasNoGraphIssues pins the contract
 // that a real-world stack composes cleanly under all module-graph
 // validators. If a future preset rename or output removal slips through,
@@ -183,9 +254,16 @@ func TestComposeStackWithIssues_GreenStackHasNoGraphIssues(t *testing.T) {
 		Region:       "us-east-1",
 	})
 	require.NoError(t, err)
+	// Positive guard: the compose actually produced the root files we
+	// expect — a "Liar Test" where the validators silently no-op'd
+	// would yield empty Files and no bad codes, falsely passing.
+	require.NotEmpty(t, r.Files["/main.tf"], "compose must emit /main.tf")
+	require.NotEmpty(t, r.Files["/variables.tf"], "compose must emit /variables.tf")
 	for _, iss := range r.Issues {
 		require.NotEqual(t, "unwired_output", iss.Code, "unexpected unwired_output: %v", iss)
 		require.NotEqual(t, "module_cycle", iss.Code, "unexpected module_cycle: %v", iss)
+		require.NotEqual(t, "wiring_cycle", iss.Code, "unexpected wiring_cycle: %v", iss)
 		require.NotEqual(t, "invalid_type", iss.Code, "unexpected invalid_type: %v", iss)
+		require.NotEqual(t, "dangling_resource_ref", iss.Code, "unexpected dangling_resource_ref: %v", iss)
 	}
 }

--- a/pkg/composer/validate_providers.go
+++ b/pkg/composer/validate_providers.go
@@ -17,6 +17,11 @@ import (
 //
 // Mirror these constants on any change to the seeds in generateProvidersTF
 // (compose.go).
+//
+// The imported provider aliases (`aws.imported` / `google.imported`,
+// emitted by generateProvidersTF when ComposeStackOpts.Imported is
+// non-empty) share the same provider source/version as the default
+// alias; they introduce no new entry here.
 var providerSeeds = map[string]string{
 	"aws":    ">= 6.0",
 	"google": ">= 5.0",

--- a/pkg/composer/validate_providers_test.go
+++ b/pkg/composer/validate_providers_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
 // TestFindProviderConflicts_FlagsImpossibleUnion exercises the conflict-
@@ -256,5 +258,40 @@ func TestComposeStackWithIssues_GreenStackHasNoCommit3Issues(t *testing.T) {
 		// stay clean.
 		require.NotEqual(t, "provider_version_conflict", iss.Code, "unexpected: %v", iss)
 		require.NotEqual(t, "hcl_parse_error", iss.Code, "unexpected: %v", iss)
+	}
+}
+
+// TestValidateProviderConstraints_ImportedAliasNoOp pins that adding
+// imported resources to a compose run does not introduce a
+// provider_version_conflict — the aws.imported / google.imported
+// aliases share the same provider source/version as the default
+// alias, so the version-constraint aggregation must remain a no-op.
+func TestValidateProviderConstraints_ImportedAliasNoOp(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	r, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "p",
+		Region:       "us-east-1",
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_sqs_queue",
+					Address:  "aws_sqs_queue.dlq",
+					ImportID: "https://sqs.us-east-1.amazonaws.com/123/dlq",
+				},
+				Tier: imported.TierImportedFlat,
+			},
+		},
+	})
+	require.NoError(t, err)
+	for _, iss := range r.Issues {
+		require.NotEqual(t, "provider_version_conflict", iss.Code,
+			"imported alias must not introduce a version conflict: %v", iss)
 	}
 }

--- a/pkg/composer/wiring_graph.go
+++ b/pkg/composer/wiring_graph.go
@@ -1,0 +1,303 @@
+package composer
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+)
+
+// GraphNodeKind tags a wiring-graph node as either a preset module call or
+// a flat imported resource. The composer treats both as first-class
+// producers/consumers when reasoning about cross-tier expression
+// references (issue #150).
+type GraphNodeKind int
+
+const (
+	// NodeKindModule is a preset module call (root-level `module "<name>"`).
+	NodeKindModule GraphNodeKind = iota
+	// NodeKindResource is a flat imported resource (root-level
+	// `resource "<tf_type>" "<label>"`). Address is "<tf_type>.<label>".
+	NodeKindResource
+)
+
+func (k GraphNodeKind) String() string {
+	switch k {
+	case NodeKindModule:
+		return "module"
+	case NodeKindResource:
+		return "resource"
+	}
+	return "unknown"
+}
+
+// GraphNode identifies one node in the union wiring graph. Addr is either
+// a module name (e.g. "aws_vpc") or a flat-resource address
+// (e.g. "aws_sqs_queue.dlq"). The pair (Kind, Addr) is unique per node.
+type GraphNode struct {
+	Kind GraphNodeKind
+	Addr string
+}
+
+// String renders the node in the form Terraform itself uses ("module.X"
+// or "<type>.<label>") so issue Reason text is copy-pastable.
+func (n GraphNode) String() string {
+	if n.Kind == NodeKindModule {
+		return "module." + n.Addr
+	}
+	return n.Addr
+}
+
+// UnionEdge is a single producer→consumer reference in the union graph.
+// ProducerAttr is the field of the producer that the consumer reads
+// ("arn", "vpc_id"); ConsumerInput is the slot on the consumer the
+// reference appears in ("kms_master_key_id", "subnet_ids").
+type UnionEdge struct {
+	Producer      GraphNode
+	ProducerAttr  string
+	Consumer      GraphNode
+	ConsumerInput string
+}
+
+// resourceRefPattern matches a `(aws_|google_)<type>.<label>.<attr>`
+// traversal. Used as a fallback for ModuleBlock.Raw values that may
+// reference flat imported resources directly. Callers must strip
+// `module\.<name>\.<attr>` matches first to avoid false-positives
+// against substrings like "module.aws_vpc.vpc_id".
+var resourceRefPattern = regexp.MustCompile(`(aws_|google_)[A-Za-z0-9_]+\.[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*`)
+
+// extractImportedEdges walks every emit-eligible imported resource and
+// returns the cross-tier references its Attributes carry as RawExpr
+// values. The producer of each edge is whatever the RawExpr names
+// (a module call or another flat resource); the consumer is the imported
+// resource itself.
+//
+// Tier filtering matches isImportedTier plus the
+// ImportedMissing+ActionRemoveFromInsideOut exclusion: a `removed {}`
+// block does not consume any references, so its Attributes are ignored.
+//
+// The function is deterministic: Attribute keys are walked in sorted
+// order and within each value the parser yields traversals in source
+// order.
+func extractImportedEdges(irs []imported.ImportedResource) []UnionEdge {
+	var edges []UnionEdge
+	for _, ir := range irs {
+		if !isEmitEligibleConsumer(ir) {
+			continue
+		}
+		consumer := GraphNode{Kind: NodeKindResource, Addr: strings.TrimSpace(ir.Identity.Address)}
+		if consumer.Addr == "" {
+			continue
+		}
+		keys := make([]string, 0, len(ir.Attributes))
+		for k := range ir.Attributes {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			re, ok := ir.Attributes[k].(RawExpr)
+			if !ok {
+				continue
+			}
+			edges = append(edges, traversalEdges(re.Expr, consumer, k)...)
+		}
+	}
+	return edges
+}
+
+// extractModuleToResourceEdges scans ModuleBlock.Raw values for direct
+// references to flat imported resources (e.g. a preset that wires
+// `dlq_arn = aws_sqs_queue.orders_dlq.arn`). It runs after the existing
+// `module.X.Y` matches are stripped from the value, so substrings like
+// "module.aws_vpc.private_subnet_ids" do not yield a phantom
+// `aws_vpc.private_subnet_ids` edge.
+func extractModuleToResourceEdges(blocks []ModuleBlock) []UnionEdge {
+	var edges []UnionEdge
+	for _, b := range blocks {
+		consumer := GraphNode{Kind: NodeKindModule, Addr: b.Name}
+		keys := make([]string, 0, len(b.Raw))
+		for k := range b.Raw {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, input := range keys {
+			expr := b.Raw[input]
+			// Strip every module.X.Y match before scanning for resource
+			// refs. moduleRefPattern is defined in validate_module_graph.go
+			// and has matched expressions like "module.aws_vpc.vpc_id"
+			// since its introduction.
+			stripped := moduleRefPattern.ReplaceAllString(expr, "")
+			for _, m := range resourceRefPattern.FindAllStringSubmatch(stripped, -1) {
+				addr, attr := splitResourceRef(m[0])
+				if addr == "" || attr == "" {
+					continue
+				}
+				edges = append(edges, UnionEdge{
+					Producer:      GraphNode{Kind: NodeKindResource, Addr: addr},
+					ProducerAttr:  attr,
+					Consumer:      consumer,
+					ConsumerInput: input,
+				})
+			}
+		}
+	}
+	return edges
+}
+
+// extractUnionEdges concatenates module→module edges (from the legacy
+// extractWiringEdges), imported→{module,resource} edges, and
+// module→resource edges into a single deterministic slice.
+//
+// Sort key: (Consumer.Kind, Consumer.Addr, ConsumerInput, Producer.Kind,
+// Producer.Addr, ProducerAttr). Stable ordering matters because
+// downstream validators emit one issue per edge.
+func extractUnionEdges(blocks []ModuleBlock, irs []imported.ImportedResource) []UnionEdge {
+	var edges []UnionEdge
+	for _, e := range extractWiringEdges(blocks) {
+		edges = append(edges, UnionEdge{
+			Producer:      GraphNode{Kind: NodeKindModule, Addr: e.Producer},
+			ProducerAttr:  e.Output,
+			Consumer:      GraphNode{Kind: NodeKindModule, Addr: e.Consumer},
+			ConsumerInput: e.Input,
+		})
+	}
+	edges = append(edges, extractImportedEdges(irs)...)
+	edges = append(edges, extractModuleToResourceEdges(blocks)...)
+	sort.Slice(edges, func(i, j int) bool {
+		a, b := edges[i], edges[j]
+		if a.Consumer.Kind != b.Consumer.Kind {
+			return a.Consumer.Kind < b.Consumer.Kind
+		}
+		if a.Consumer.Addr != b.Consumer.Addr {
+			return a.Consumer.Addr < b.Consumer.Addr
+		}
+		if a.ConsumerInput != b.ConsumerInput {
+			return a.ConsumerInput < b.ConsumerInput
+		}
+		if a.Producer.Kind != b.Producer.Kind {
+			return a.Producer.Kind < b.Producer.Kind
+		}
+		if a.Producer.Addr != b.Producer.Addr {
+			return a.Producer.Addr < b.Producer.Addr
+		}
+		return a.ProducerAttr < b.ProducerAttr
+	})
+	return edges
+}
+
+// attrIsWiring reports whether the (tfType, attrPath) pair is curated
+// as a relationship-only wiring slot in the Layer 2 field policy
+// (Role=Wiring, Edit=RelationshipOnly). Validators use this as a
+// classification hint in issue Reason text — never as a gate on
+// extraction, since dangling-reference reports must surface even when
+// the attr is absent from the policy map.
+func attrIsWiring(tfType, attrPath string) bool {
+	m, ok := policy.Lookup(tfType)
+	if !ok {
+		return false
+	}
+	p, ok := m[attrPath]
+	if !ok {
+		return false
+	}
+	return p.Role == policy.RoleWiring && p.Edit == policy.EditRelationshipOnly
+}
+
+// isEmitEligibleConsumer reports whether ir is composed into the
+// /imported.tf union document as a resource block. Resources with
+// remediation `remove_from_insideout` emit only a `removed {}` block
+// (no body), so they do not consume references.
+func isEmitEligibleConsumer(ir imported.ImportedResource) bool {
+	if !isImportedTier(ir.Tier) {
+		return false
+	}
+	if ir.Tier == imported.TierImportedMissing && ir.Remediation == imported.ActionRemoveFromInsideOut {
+		return false
+	}
+	return true
+}
+
+// traversalEdges parses expr as an HCL expression and yields one
+// UnionEdge per top-level traversal recognised as a module reference
+// (module.X.Y) or a flat-resource reference (<type>.<label>.<attr>).
+// Other traversals (input variables, locals, function calls without
+// recognised arguments) are silently dropped — they are not cross-tier
+// references the composer needs to validate.
+//
+// The leading "<name> = " wrapper trick mirrors extractExprTokens
+// (emit.go:159): hclsyntax.ParseExpression accepts a bare expression,
+// so we don't need it. The traversal walk goes through Variables(),
+// which returns each independent root traversal exactly once even when
+// the expression composes them (e.g. `concat(module.X.Y, [Z])`).
+func traversalEdges(expr string, consumer GraphNode, consumerInput string) []UnionEdge {
+	parsed, diags := hclsyntax.ParseExpression([]byte(expr), "imported.attr", hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil
+	}
+	var edges []UnionEdge
+	for _, tr := range parsed.Variables() {
+		producer, attr, ok := classifyTraversal(tr)
+		if !ok {
+			continue
+		}
+		edges = append(edges, UnionEdge{
+			Producer:      producer,
+			ProducerAttr:  attr,
+			Consumer:      consumer,
+			ConsumerInput: consumerInput,
+		})
+	}
+	return edges
+}
+
+// classifyTraversal inspects a parsed hcl.Traversal and returns the
+// referenced producer node + producer attribute. The two recognised
+// shapes are:
+//
+//   - module.<name>.<attr>[...]     → NodeKindModule{<name>}, attr
+//   - <tf_type>.<label>.<attr>[...] → NodeKindResource{<tf_type>.<label>}, attr
+//     where tf_type starts with "aws_" or "google_".
+//
+// Anything else (single-segment traversals like `var.foo` or
+// `each.value`, traversals into unknown roots) yields ok=false.
+func classifyTraversal(tr hcl.Traversal) (GraphNode, string, bool) {
+	if len(tr) < 3 {
+		return GraphNode{}, "", false
+	}
+	root, ok := tr[0].(hcl.TraverseRoot)
+	if !ok {
+		return GraphNode{}, "", false
+	}
+	step1, ok := tr[1].(hcl.TraverseAttr)
+	if !ok {
+		return GraphNode{}, "", false
+	}
+	step2, ok := tr[2].(hcl.TraverseAttr)
+	if !ok {
+		return GraphNode{}, "", false
+	}
+	if root.Name == "module" {
+		return GraphNode{Kind: NodeKindModule, Addr: step1.Name}, step2.Name, true
+	}
+	if strings.HasPrefix(root.Name, "aws_") || strings.HasPrefix(root.Name, "google_") {
+		return GraphNode{Kind: NodeKindResource, Addr: root.Name + "." + step1.Name}, step2.Name, true
+	}
+	return GraphNode{}, "", false
+}
+
+// splitResourceRef splits a "<type>.<label>.<attr>" string from
+// resourceRefPattern.FindAll into ("<type>.<label>", "<attr>"). Returns
+// empty strings if the input does not contain three dot-separated
+// segments.
+func splitResourceRef(ref string) (addr, attr string) {
+	parts := strings.SplitN(ref, ".", 3)
+	if len(parts) != 3 {
+		return "", ""
+	}
+	return parts[0] + "." + parts[1], parts[2]
+}

--- a/pkg/composer/wiring_graph_test.go
+++ b/pkg/composer/wiring_graph_test.go
@@ -1,0 +1,409 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+func TestExtractImportedEdges_ResourceToResource(t *testing.T) {
+	t.Parallel()
+
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.dlq", ImportID: "https://sqs.example/dlq",
+			},
+			Tier: imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"kms_master_key_id": RawExpr{Expr: "aws_kms_key.queues.arn"},
+				"name":              "dlq",
+			},
+		},
+	}
+
+	edges := extractImportedEdges(irs)
+	require.Len(t, edges, 1, "expected exactly one cross-tier edge from the RawExpr value")
+	e := edges[0]
+	require.Equal(t, NodeKindResource, e.Producer.Kind)
+	require.Equal(t, "aws_kms_key.queues", e.Producer.Addr)
+	require.Equal(t, "arn", e.ProducerAttr)
+	require.Equal(t, NodeKindResource, e.Consumer.Kind)
+	require.Equal(t, "aws_sqs_queue.dlq", e.Consumer.Addr)
+	require.Equal(t, "kms_master_key_id", e.ConsumerInput)
+}
+
+func TestExtractImportedEdges_ImportedToModule(t *testing.T) {
+	t.Parallel()
+
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.dlq", ImportID: "https://sqs.example/dlq",
+			},
+			Tier: imported.TierImportedFlat,
+			Attributes: map[string]any{
+				// Index access on a module list output — Variables() yields
+				// the root traversal once.
+				"redrive_policy": RawExpr{Expr: "module.aws_sns.topic_arn"},
+			},
+		},
+	}
+
+	edges := extractImportedEdges(irs)
+	require.Len(t, edges, 1)
+	e := edges[0]
+	require.Equal(t, NodeKindModule, e.Producer.Kind)
+	require.Equal(t, "aws_sns", e.Producer.Addr)
+	require.Equal(t, "topic_arn", e.ProducerAttr)
+}
+
+func TestExtractImportedEdges_PlainScalarsIgnored(t *testing.T) {
+	t.Parallel()
+
+	// Non-RawExpr Attributes values must not produce edges across the
+	// full range of plain-Go scalar/collection types the carrier might
+	// carry. Locking the type-switch on RawExpr against accidental
+	// widening (e.g. matching a Stringer interface).
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.dlq", ImportID: "x",
+			},
+			Tier: imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"str_attr":   "aws_kms_key.queues.arn", // plain string, not RawExpr
+				"int_attr":   42,
+				"bool_attr":  true,
+				"nil_attr":   nil,
+				"slice_attr": []string{"aws_kms_key.queues.arn"},
+				"map_attr":   map[string]any{"nested": "aws_kms_key.queues.arn"},
+			},
+		},
+	}
+
+	require.Empty(t, extractImportedEdges(irs))
+}
+
+// TestExtractImportedEdges_MultiSegmentTraversals pins the Variables()
+// contract for non-bare traversals: index access, deep attribute chains,
+// and repeated references. Each shape is what Riley wiring is allowed
+// to emit through a RawExpr value — a regression in classifyTraversal's
+// `len(tr) < 3` early-return or in HCL's traversal classification would
+// silently drop edges otherwise.
+func TestExtractImportedEdges_MultiSegmentTraversals(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		expr        string
+		wantProd    GraphNode
+		wantAttr    string
+		wantCount   int
+	}{
+		{
+			name:      "index access on module list output",
+			expr:      "module.aws_vpc.private_subnet_ids[0]",
+			wantProd:  GraphNode{Kind: NodeKindModule, Addr: "aws_vpc"},
+			wantAttr:  "private_subnet_ids",
+			wantCount: 1,
+		},
+		{
+			name:      "deep attribute on resource",
+			expr:      "aws_kms_key.k.tags.Project",
+			wantProd:  GraphNode{Kind: NodeKindResource, Addr: "aws_kms_key.k"},
+			wantAttr:  "tags",
+			wantCount: 1,
+		},
+		{
+			name:      "splat on resource list output",
+			expr:      "module.aws_vpc.subnet_ids[*]",
+			wantProd:  GraphNode{Kind: NodeKindModule, Addr: "aws_vpc"},
+			wantAttr:  "subnet_ids",
+			wantCount: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			irs := []imported.ImportedResource{
+				{
+					Identity:   imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "x"},
+					Tier:       imported.TierImportedFlat,
+					Attributes: map[string]any{"a": RawExpr{Expr: tc.expr}},
+				},
+			}
+			edges := extractImportedEdges(irs)
+			require.Len(t, edges, tc.wantCount, "expr=%q", tc.expr)
+			require.Equal(t, tc.wantProd, edges[0].Producer)
+			require.Equal(t, tc.wantAttr, edges[0].ProducerAttr)
+		})
+	}
+}
+
+// TestExtractImportedEdges_RepeatedProducerInExpr pins the dedup
+// contract for hcl.Variables() when the same producer appears twice
+// inside a single RawExpr. Variables() returns each independent root
+// traversal; identical traversals are NOT deduped at the AST level —
+// each occurrence yields its own edge. This may surprise readers, so
+// we lock it here.
+func TestExtractImportedEdges_RepeatedProducerInExpr(t *testing.T) {
+	t.Parallel()
+
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "x"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				// concat(...) — both traversals reach the same producer
+				// but to different attributes.
+				"merged": RawExpr{Expr: "concat([aws_kms_key.k.arn], [aws_kms_key.k.id])"},
+			},
+		},
+	}
+	edges := extractImportedEdges(irs)
+	require.Len(t, edges, 2, "two distinct attribute traversals must yield two edges")
+	attrs := []string{edges[0].ProducerAttr, edges[1].ProducerAttr}
+	require.ElementsMatch(t, []string{"arn", "id"}, attrs)
+}
+
+// TestExtractImportedEdges_MalformedRawExprDropped pins the parse-
+// error contract: an unparseable RawExpr yields zero edges and never
+// panics. Validators upstream are responsible for surfacing parse
+// errors via other channels (e.g. emit-time decode_failed); the
+// edge extractor must fail closed.
+func TestExtractImportedEdges_MalformedRawExprDropped(t *testing.T) {
+	t.Parallel()
+
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "x"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"a": RawExpr{Expr: "this is not (((( hcl"},
+			},
+		},
+	}
+	require.NotPanics(t, func() {
+		require.Empty(t, extractImportedEdges(irs))
+	})
+}
+
+// TestExtractImportedEdges_UnsupportedCloudIgnored pins that traversals
+// to azurerm_* or other unsupported-cloud resource types do not produce
+// edges — classifyTraversal only recognises aws_/google_ roots.
+func TestExtractImportedEdges_UnsupportedCloudIgnored(t *testing.T) {
+	t.Parallel()
+
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "x"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"a": RawExpr{Expr: "azurerm_storage_account.s.id"},
+				"b": RawExpr{Expr: "kubernetes_namespace.ns.metadata"},
+			},
+		},
+	}
+	require.Empty(t, extractImportedEdges(irs))
+}
+
+func TestExtractImportedEdges_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.b", ImportID: "x",
+			},
+			Tier: imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"z_attr": RawExpr{Expr: "aws_kms_key.k.arn"},
+				"a_attr": RawExpr{Expr: "aws_iam_role.r.arn"},
+			},
+		},
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.a", ImportID: "x",
+			},
+			Tier: imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"m_attr": RawExpr{Expr: "aws_kms_key.k.arn"},
+			},
+		},
+	}
+
+	edges := extractImportedEdges(irs)
+	require.Len(t, edges, 3)
+
+	// Edges are emitted per-IR in source order, with sorted attribute keys.
+	require.Equal(t, "aws_sqs_queue.b", edges[0].Consumer.Addr)
+	require.Equal(t, "a_attr", edges[0].ConsumerInput)
+	require.Equal(t, "aws_sqs_queue.b", edges[1].Consumer.Addr)
+	require.Equal(t, "z_attr", edges[1].ConsumerInput)
+	require.Equal(t, "aws_sqs_queue.a", edges[2].Consumer.Addr)
+}
+
+func TestExtractImportedEdges_TierFilter(t *testing.T) {
+	t.Parallel()
+
+	// External tiers and Missing+Remove are not consumers in the union
+	// graph; their RawExpr values must be ignored.
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_kms_key", Address: "aws_kms_key.gone", ImportID: "x",
+			},
+			Tier:        imported.TierImportedMissing,
+			Remediation: imported.ActionRemoveFromInsideOut,
+			Attributes: map[string]any{
+				"description": RawExpr{Expr: "aws_iam_role.bypass.arn"},
+			},
+		},
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_iam_role", Address: "aws_iam_role.bypass", ImportID: "x",
+			},
+			Tier: imported.TierExternalByPolicy,
+			Attributes: map[string]any{
+				"role_arn": RawExpr{Expr: "aws_iam_policy.p.arn"},
+			},
+		},
+	}
+
+	require.Empty(t, extractImportedEdges(irs),
+		"removed and external-tier resources must not produce edges")
+}
+
+func TestExtractModuleToResourceEdges_StripsModulePrefix(t *testing.T) {
+	t.Parallel()
+
+	// `module.aws_vpc.private_subnet_ids` contains the substring
+	// "aws_vpc.private_subnet_ids" which would match the resource regex
+	// if the module-prefix strip is omitted. Guard against that
+	// regression here.
+	blocks := []ModuleBlock{
+		{
+			Name: "aws_alb",
+			Raw: map[string]string{
+				"vpc_id":  "module.aws_vpc.vpc_id",
+				"subnets": "module.aws_vpc.private_subnet_ids",
+			},
+		},
+	}
+	require.Empty(t, extractModuleToResourceEdges(blocks),
+		"module.<name>.<attr> traversals must be stripped before resource regex runs")
+}
+
+// TestExtractModuleToResourceEdges_PhantomEdgesGuarded pins the
+// documented risk surface: a Raw value that interleaves a real
+// `module.X.Y` traversal with a sibling resource-shaped *literal*
+// substring must not produce a phantom edge. The strip-first rule
+// in extractModuleToResourceEdges removes module.X.Y matches before
+// running the resource regex, so embedded text resembling
+// `aws_kms_key.k.arn` *as part of* the module reference is gone.
+// However, a free-standing real resource reference adjacent to the
+// module reference must still surface.
+func TestExtractModuleToResourceEdges_PhantomEdgesGuarded(t *testing.T) {
+	t.Parallel()
+
+	blocks := []ModuleBlock{
+		{
+			Name: "aws_lambda",
+			Raw: map[string]string{
+				// A description-literal containing module-shaped text;
+				// stripping module.X.Y leaves no resource-shaped residue.
+				"description_with_quoted_module_ref": `"see module.aws_vpc.vpc_id docs"`,
+				// Real composition: a concat of a module ref and a real
+				// resource ref. After stripping the module match, the
+				// resource regex must still match on the free-standing
+				// resource reference.
+				"sg_ids": "concat(module.aws_vpc.default_sg, [aws_security_group.extra.id])",
+				// Unsupported cloud — must be ignored.
+				"azurerm_ref": "azurerm_storage_account.s.id",
+			},
+		},
+	}
+	edges := extractModuleToResourceEdges(blocks)
+	require.Len(t, edges, 1, "only the genuine resource ref must surface; got %v", edges)
+	require.Equal(t, NodeKindResource, edges[0].Producer.Kind)
+	require.Equal(t, "aws_security_group.extra", edges[0].Producer.Addr)
+	require.Equal(t, "id", edges[0].ProducerAttr)
+	require.Equal(t, "sg_ids", edges[0].ConsumerInput)
+}
+
+func TestExtractModuleToResourceEdges_RealResourceRef(t *testing.T) {
+	t.Parallel()
+
+	// Direct resource references in a module input do produce edges.
+	// This case is rare today (Riley wiring uses module outputs), but
+	// the validator must not regress when typed-wiring edits land.
+	blocks := []ModuleBlock{
+		{
+			Name: "aws_lambda",
+			Raw: map[string]string{
+				"dlq_arn": "aws_sqs_queue.orders_dlq.arn",
+			},
+		},
+	}
+	edges := extractModuleToResourceEdges(blocks)
+	require.Len(t, edges, 1)
+	require.Equal(t, NodeKindResource, edges[0].Producer.Kind)
+	require.Equal(t, "aws_sqs_queue.orders_dlq", edges[0].Producer.Addr)
+	require.Equal(t, "arn", edges[0].ProducerAttr)
+	require.Equal(t, NodeKindModule, edges[0].Consumer.Kind)
+	require.Equal(t, "aws_lambda", edges[0].Consumer.Addr)
+}
+
+func TestExtractUnionEdges_DeterministicSort(t *testing.T) {
+	t.Parallel()
+
+	// Exercise every level of the 6-tuple sort key
+	// (Consumer.Kind, Consumer.Addr, ConsumerInput, Producer.Kind,
+	// Producer.Addr, ProducerAttr). Each pair of consecutive edges
+	// differs at exactly one level so a single misplaced compare
+	// surfaces.
+	blocks := []ModuleBlock{
+		// Same module-consumer, two inputs → exercises ConsumerInput sort.
+		{Name: "z_mod", Raw: map[string]string{
+			"a_input": "module.a_mod.x",
+			"b_input": "module.b_mod.x",
+		}},
+		{Name: "a_mod", Raw: map[string]string{}},
+		{Name: "b_mod", Raw: map[string]string{}},
+	}
+	irs := []imported.ImportedResource{
+		// Same resource-consumer, two attrs → exercises ConsumerInput sort.
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "x"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"a_kms":  RawExpr{Expr: "aws_kms_key.alpha.arn"},
+				"z_kms":  RawExpr{Expr: "aws_kms_key.beta.arn"},
+			},
+		},
+	}
+
+	edges := extractUnionEdges(blocks, irs)
+	require.Len(t, edges, 4)
+
+	// Kind=Module first (iota=0), addr=z_mod (only consumer of that
+	// kind), inputs sorted a_input < b_input.
+	require.Equal(t, NodeKindModule, edges[0].Consumer.Kind)
+	require.Equal(t, "z_mod", edges[0].Consumer.Addr)
+	require.Equal(t, "a_input", edges[0].ConsumerInput)
+	require.Equal(t, "z_mod", edges[1].Consumer.Addr)
+	require.Equal(t, "b_input", edges[1].ConsumerInput)
+
+	// Kind=Resource second, addr=aws_sqs_queue.q, inputs sorted
+	// a_kms < z_kms.
+	require.Equal(t, NodeKindResource, edges[2].Consumer.Kind)
+	require.Equal(t, "aws_sqs_queue.q", edges[2].Consumer.Addr)
+	require.Equal(t, "a_kms", edges[2].ConsumerInput)
+	require.Equal(t, "z_kms", edges[3].ConsumerInput)
+	// Producer.Addr level: alpha precedes beta.
+	require.Equal(t, "aws_kms_key.alpha", edges[2].Producer.Addr)
+	require.Equal(t, "aws_kms_key.beta", edges[3].Producer.Addr)
+}


### PR DESCRIPTION
## Summary

Phase 2 of the imported-resource model: teach the composer's wiring resolver and validators to operate on the **union graph** of preset module calls + flat imported resources emitted in #148. Cross-tier expression references survive composition unchanged, dangling references in either direction are caught at compose time as structured ValidationIssues, and cycles spanning module ↔ resource nodes are detected before `terraform plan`.

- New `pkg/composer/wiring_graph.go` — `GraphNode`/`UnionEdge` types; `extractImportedEdges` (HCL-parsed `RawExpr` traversals via `hclsyntax.ParseExpression`); `extractModuleToResourceEdges` (regex with strip-first `module.X.Y` rule to suppress phantom edges); `extractUnionEdges` (deterministic 6-tuple sort).
- New `ValidateCrossTierWiring` emitting three issue codes:
  - `dangling_resource_ref` — module input or imported attr references `<aws_*|google_*>.<label>.<attr>` not in the stack.
  - `dangling_module_ref_from_imported` — imported attr references `module.X.Y` not in the stack.
  - `unwired_resource_attr` — imported→imported reference whose producer schema (via `generated.Lookup`) doesn't declare the attr.
- New `ValidateNoUnionCycles` emits `wiring_cycle` only when ≥1 stuck node is a resource — defers pure-module cycles to `ValidateNoModuleCycles` to avoid double-reporting; closing-edge hint mirrors the existing format with kind-specific prefixes (`module.X` vs `imported.X.attr`).
- Field-policy classification: `attrIsWiring` consults Layer 2 policy (`Role=Wiring`, `Edit=RelationshipOnly`) for issue Reason text only — extraction stays exhaustive so dangling refs surface even when policy is unknown.
- `noselfimport_test.go` allowlist extended for `imported/policy` (composer-owned subpackage from #147).
- Imported aliases continue to share `aws`/`google` provider source/version; comment added to `providerSeeds` documenting the no-op.

## Out of scope (sibling tickets)

- **Provenance tag schema constants** (#153) — composer emits whatever tags/labels are already in the carrier.
- **ResourceDiff / VersionDiff.Resources** (#151) — separate sibling.
- **Relationship *editing* operations** — Phase 2 preserves and displays only.

## Test plan

- [x] `go test ./pkg/composer ./pkg/composer/imported/... -count=1` — full repo green.
- [x] `go vet ./...` clean; `terraform fmt -check -recursive` clean.
- [x] New `wiring_graph_test.go` covers: ResourceToResource, ImportedToModule, multi-segment traversals (`[0]`, `.foo`, splat), repeated producer in same expr, malformed RawExpr (parse-error path), unsupported-cloud (azurerm) ignored, plain-scalar/nil/slice/map ignored, full 6-tuple sort exercised.
- [x] New `validate_cross_tier_test.go` covers: every issue code, removed-resource-not-producer guard, module-from-module not re-reported, deterministic order across all three sort keys, schema-drift defense via `generated.Lookup` precondition.
- [x] `TestValidateNoUnionCycles_DetectsCrossTierCycle` pins the closing-edge hint with kind-specific regex; `_PureModuleCycleSkipped` and `_DAGNoIssue` pin the deferral contract and happy path.
- [x] Integration: `TestComposeStackWithIssues_CrossTierWiring_RoundTrip` asserts unquoted `description = aws_dynamodb_table.users.arn` round-trips through `/imported.tf`; `_DanglingFlagged` asserts exactly one `dangling_resource_ref` plus positive `Files["/imported.tf"]` non-empty assertion.
- [x] Surface-lock: `TestKnownFieldsNoShrink` clean (new validators consume `[]ImportedResource`/`[]ModuleBlock`, not IR field paths — golden untouched).
- [ ] CI: `gh pr checks` after this lands.

Closes #150.