### PR TITLE
feat(composer): provenance tag injector with mutual exclusion (#153)

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 
@@ -135,6 +136,22 @@ type ComposeSingleOpts struct {
 	// the field exists so reliable's adapter can hand the same shape to
 	// either entry point. See ComposeStackOpts.Imported.
 	Imported []imported.ImportedResource
+
+	// ImportProjectID is the logical claim/owner identifier shared across
+	// AWS+GCP for one InsideOut stack/session. It is emitted as
+	// InsideOutImportProject (AWS tag) and insideout-import-project (GCP
+	// label) on every imported resource that supports tags/labels. Empty
+	// disables provenance tagging for backward compatibility with callers
+	// that have not yet adopted issue #153 — a low-severity
+	// imported_resource_provenance_skipped_no_project_id issue is recorded
+	// when Imported is non-empty but ImportProjectID is blank.
+	ImportProjectID string
+
+	// ImportSessionID is the finer-grained importing session identifier.
+	// Emitted as InsideOutImportSession / insideout-import-session.
+	// Optional when ImportProjectID is set; if blank the session tag/label
+	// is omitted and only the project-level claim is enforced.
+	ImportSessionID string
 }
 
 // ComposeSingle preserves the historical (Files, error) signature. It hard-
@@ -346,6 +363,23 @@ type ComposeStackOpts struct {
 	// reported via ValidationIssue codes (imported_resource_*). Nil or
 	// empty preserves the historical no-op behavior.
 	Imported []imported.ImportedResource
+
+	// ImportProjectID is the logical claim/owner identifier shared across
+	// AWS+GCP for one InsideOut stack/session. It is emitted as
+	// InsideOutImportProject (AWS tag) and insideout-import-project (GCP
+	// label) on every imported resource that supports tags/labels, and
+	// drives the mutual-exclusion check (ValidateProvenanceConflicts).
+	// Empty disables provenance tagging for backward compatibility with
+	// callers that have not yet adopted issue #153 — a low-severity
+	// imported_resource_provenance_skipped_no_project_id issue is recorded
+	// when Imported is non-empty but ImportProjectID is blank.
+	ImportProjectID string
+
+	// ImportSessionID is the finer-grained importing session identifier.
+	// Emitted as InsideOutImportSession / insideout-import-session.
+	// Optional when ImportProjectID is set; if blank the session tag/label
+	// is omitted and only the project-level claim is enforced.
+	ImportSessionID string
 }
 
 // ComposeStack preserves the historical (Files, error) signature. It hard-
@@ -572,7 +606,14 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// (issue #148). This must happen before generateProvidersTF so that
 	// importedClouds tells the provider emitter which alias to declare.
 	issues = append(issues, ValidateImportedResources(cloud, opts.Imported)...)
-	importedTF, importedClouds := EmitImportedTF(cloud, opts.Imported)
+	provOpts := ProvenanceOpts{ImportProjectID: opts.ImportProjectID, ImportSessionID: opts.ImportSessionID}
+	issues = append(issues, ValidateProvenanceConflicts(cloud, opts.Imported, provOpts)...)
+	emitOpts := EmitImportedOpts{
+		ImportProjectID: opts.ImportProjectID,
+		ImportSessionID: opts.ImportSessionID,
+		ImportedAt:      time.Now().UTC(),
+	}
+	importedTF, importedClouds := EmitImportedTF(cloud, opts.Imported, emitOpts)
 	if len(importedTF) > 0 {
 		files["/imported.tf"] = importedTF
 	}

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 
@@ -606,12 +605,12 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// (issue #148). This must happen before generateProvidersTF so that
 	// importedClouds tells the provider emitter which alias to declare.
 	issues = append(issues, ValidateImportedResources(cloud, opts.Imported)...)
-	provOpts := ProvenanceOpts{ImportProjectID: opts.ImportProjectID, ImportSessionID: opts.ImportSessionID}
+	provOpts := ProvenanceOpts{ImportProjectID: opts.ImportProjectID}
 	issues = append(issues, ValidateProvenanceConflicts(cloud, opts.Imported, provOpts)...)
 	emitOpts := EmitImportedOpts{
 		ImportProjectID: opts.ImportProjectID,
 		ImportSessionID: opts.ImportSessionID,
-		ImportedAt:      time.Now().UTC(),
+		ImportedAt:      nowFn(),
 	}
 	importedTF, importedClouds := EmitImportedTF(cloud, opts.Imported, emitOpts)
 	if len(importedTF) > 0 {

--- a/pkg/composer/imported/resource.go
+++ b/pkg/composer/imported/resource.go
@@ -68,6 +68,49 @@ type ImportedResource struct {
 	// of a TierImportedMissing resource until Remediation is set. See
 	// docs/managed-resource-tiers.md "ImportedMissing operator actions".
 	Remediation MissingAction `json:"remediation,omitempty"`
+
+	// ForceTakeover is the audited operator override for a provenance
+	// conflict — i.e. the composer observed an InsideOutImportProject /
+	// insideout-import-project tag on this resource that names a different
+	// import project than the current compose pass. Setting this field
+	// suppresses imported_resource_provenance_conflict for this resource and
+	// instructs the provenance injector to overwrite the existing tag value.
+	// All four sub-fields are required. See docs/managed-resource-tiers.md
+	// "Provenance tagging policy" decision #45.
+	ForceTakeover *ForceTakeover `json:"force_takeover,omitempty"`
+
+	// WeakLocked is set by the provenance injector to true when this
+	// resource's Terraform type does not support tags/labels. Mutual
+	// exclusion is then a best-effort check based on ResourceIdentity alone
+	// (see imported_resource_address_collision); the four-key provenance
+	// schema is not emitted. Read-only metadata; callers should not set it.
+	WeakLocked bool `json:"weak_locked,omitempty"`
+}
+
+// ForceTakeover is the audited operator override for a cross-session
+// provenance conflict. Every field is required: a takeover with missing
+// metadata is rejected by ValidateProvenanceConflicts as
+// imported_resource_force_takeover_invalid. ApprovedAt is always serialized
+// as RFC3339Nano UTC regardless of the caller-supplied time.Location;
+// see MarshalJSON.
+type ForceTakeover struct {
+	Actor         string    `json:"actor"`
+	Reason        string    `json:"reason"`
+	PreviousOwner string    `json:"previous_owner"`
+	ApprovedAt    time.Time `json:"approved_at"`
+}
+
+// MarshalJSON enforces RFC3339Nano UTC on ApprovedAt. Mirrors FieldEdit's
+// MarshalJSON — without this, a caller passing a non-UTC time.Time would
+// serialize with a numeric offset (e.g. "-07:00"), which the design contract
+// forbids. The zero value is left untouched so the canonical
+// "0001-01-01T00:00:00Z" form is preserved.
+func (f ForceTakeover) MarshalJSON() ([]byte, error) {
+	type alias ForceTakeover
+	if !f.ApprovedAt.IsZero() {
+		f.ApprovedAt = f.ApprovedAt.UTC()
+	}
+	return json.Marshal(alias(f))
 }
 
 // FieldEdit is audit/conflict metadata for one model-side edit to a single

--- a/pkg/composer/imported_compose_test.go
+++ b/pkg/composer/imported_compose_test.go
@@ -13,6 +13,121 @@ import (
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
+// TestComposeStackWithIssues_ProvenanceTags exercises the issue #153
+// end-to-end path: ImportProjectID + ImportSessionID propagate through
+// composeStackImpl into EmitImportedTF, which writes merge({InsideOut...},
+// {...}) into the body of every taggable imported resource. The composed
+// root must remain HCL-valid.
+func TestComposeStackWithIssues_ProvenanceTags(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:           "aws",
+		SelectedKeys:    []ComponentKey{KeyAWSVPC},
+		Comps:           &Components{Cloud: "AWS"},
+		Cfg:             &Config{},
+		Project:         "demo",
+		Region:          "us-east-1",
+		ImportProjectID: "io-stack-1",
+		ImportSessionID: "sess-9",
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud: "aws", Type: "aws_sqs_queue",
+					Address: "aws_sqs_queue.q", ImportID: "https://sqs/.../q",
+				},
+				Tier:  imported.TierImportedFlat,
+				Attrs: []byte(`{"Name":{"Literal":"q"}}`),
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	importedTF := string(res.Files["/imported.tf"])
+	require.NotEmpty(t, importedTF)
+	assert.Contains(t, importedTF, "tags = merge(")
+	assert.Contains(t, importedTF, `InsideOutImportProject = "io-stack-1"`)
+	assert.Contains(t, importedTF, `InsideOutImportSession = "sess-9"`)
+
+	for _, iss := range res.Issues {
+		require.NotEqualf(t, "hcl_parse_error", iss.Code,
+			"composed root must parse: %+v", iss)
+	}
+}
+
+// TestComposeStackWithIssues_ProvenanceConflict pins that the validator
+// surfaces a structured ValidationIssue when an imported resource's existing
+// InsideOutImportProject tag does not match the composer's ImportProjectID.
+func TestComposeStackWithIssues_ProvenanceConflict(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:           "aws",
+		SelectedKeys:    []ComponentKey{KeyAWSVPC},
+		Comps:           &Components{Cloud: "AWS"},
+		Cfg:             &Config{},
+		Project:         "demo",
+		Region:          "us-east-1",
+		ImportProjectID: "io-stack-1",
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud: "aws", Type: "aws_dynamodb_table",
+					Address: "aws_dynamodb_table.t", ImportID: "t",
+				},
+				Tier: imported.TierImportedFlat,
+				Attributes: map[string]any{
+					"name": "t",
+					"tags": map[string]any{"InsideOutImportProject": "io-other"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	codes := issueCodes(res.Issues)
+	assert.Contains(t, codes, "imported_resource_provenance_conflict")
+}
+
+// TestComposeStackWithIssues_ProvenanceSkippedAdvisory pins the
+// backwards-compat path: when ImportProjectID is empty but Imported is not,
+// the composer surfaces a low-severity advisory issue and does not emit
+// merge() — pre-#153 behavior is preserved.
+func TestComposeStackWithIssues_ProvenanceSkippedAdvisory(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-east-1",
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud: "aws", Type: "aws_sqs_queue",
+					Address: "aws_sqs_queue.q", ImportID: "x",
+				},
+				Tier:  imported.TierImportedFlat,
+				Attrs: []byte(`{"Name":{"Literal":"q"}}`),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	codes := issueCodes(res.Issues)
+	assert.Contains(t, codes, "imported_resource_provenance_skipped_no_project_id")
+
+	importedTF := string(res.Files["/imported.tf"])
+	assert.NotContains(t, importedTF, "tags = merge(", "merge() must not be emitted in pre-#153 mode")
+	assert.NotContains(t, importedTF, "InsideOutImportProject")
+}
+
 // TestComposeStackWithIssues_Imported_AWS exercises the end-to-end path:
 // ComposeStackWithIssues runs the imported validator, emits /imported.tf,
 // and adds the aws.imported provider alias in /providers.tf — alongside an
@@ -284,7 +399,7 @@ func TestImportedResource_EveryTierBranchExercised(t *testing.T) {
 				Tier: tier,
 			}
 			issues := ValidateImportedResources("aws", []imported.ImportedResource{ir})
-			out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir})
+			out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
 
 			// Composer/External tiers are explicitly out of scope for #148:
 			// no validation issues, no emission. Verify both.
@@ -412,7 +527,7 @@ func TestEmitImportedTF_ProducesValidHCL(t *testing.T) {
 			Tier:       imported.TierImportedFlat,
 			Attributes: map[string]any{"name": "x"},
 		},
-	})
+	}, EmitImportedOpts{})
 	require.NotEmpty(t, out)
 	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
 	require.False(t, diags.HasErrors(), "EmitImportedTF must produce valid HCL: %s", diags.Error())

--- a/pkg/composer/imported_compose_test.go
+++ b/pkg/composer/imported_compose_test.go
@@ -59,7 +59,12 @@ func TestComposeStackWithIssues_ProvenanceTags(t *testing.T) {
 
 // TestComposeStackWithIssues_ProvenanceConflict pins that the validator
 // surfaces a structured ValidationIssue when an imported resource's existing
-// InsideOutImportProject tag does not match the composer's ImportProjectID.
+// InsideOutImportProject tag does not match the composer's ImportProjectID,
+// AND that the conflict issue carries the observed prior owner so the caller
+// can render an actionable message. The composer is contracted to surface
+// the issue via Result.Issues; whether the caller hard-fails on it (via
+// StrictValidate) or refuses takeover is the caller's policy, not this
+// layer's. We pin the structured payload so callers can rely on it.
 func TestComposeStackWithIssues_ProvenanceConflict(t *testing.T) {
 	t.Parallel()
 
@@ -88,8 +93,48 @@ func TestComposeStackWithIssues_ProvenanceConflict(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	codes := issueCodes(res.Issues)
-	assert.Contains(t, codes, "imported_resource_provenance_conflict")
+	// Find the conflict issue and pin its structured fields so the caller
+	// can render "claimed by <observed>" UX without re-parsing.
+	var found *ValidationIssue
+	for i := range res.Issues {
+		if res.Issues[i].Code == "imported_resource_provenance_conflict" {
+			found = &res.Issues[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "expected imported_resource_provenance_conflict issue; got %+v", res.Issues)
+	assert.Equal(t, "io-other", found.Value, "Value must carry the observed prior owner")
+	assert.Equal(t, "imported.aws_dynamodb_table.t", found.Field)
+	assert.NotEmpty(t, found.Suggestion, "Suggestion should hint at ForceTakeover")
+
+	// StrictValidate=true must escalate the conflict to an error so callers
+	// that opt in get a hard refusal rather than a silently-overwritten tag.
+	strictRes, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:           "aws",
+		SelectedKeys:    []ComponentKey{KeyAWSVPC},
+		Comps:           &Components{Cloud: "AWS"},
+		Cfg:             &Config{},
+		Project:         "demo",
+		Region:          "us-east-1",
+		ImportProjectID: "io-stack-1",
+		StrictValidate:  true,
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud: "aws", Type: "aws_dynamodb_table",
+					Address: "aws_dynamodb_table.t", ImportID: "t",
+				},
+				Tier: imported.TierImportedFlat,
+				Attributes: map[string]any{
+					"name": "t",
+					"tags": map[string]any{"InsideOutImportProject": "io-other"},
+				},
+			},
+		},
+	})
+	require.Error(t, err, "StrictValidate=true must escalate conflict to error")
+	require.NotNil(t, strictRes)
+	assert.Contains(t, issueCodes(strictRes.Issues), "imported_resource_provenance_conflict")
 }
 
 // TestComposeStackWithIssues_ProvenanceSkippedAdvisory pins the

--- a/pkg/composer/imported_compose_test.go
+++ b/pkg/composer/imported_compose_test.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -16,10 +17,15 @@ import (
 // TestComposeStackWithIssues_ProvenanceTags exercises the issue #153
 // end-to-end path: ImportProjectID + ImportSessionID propagate through
 // composeStackImpl into EmitImportedTF, which writes merge({InsideOut...},
-// {...}) into the body of every taggable imported resource. The composed
-// root must remain HCL-valid.
+// {...}) into the body of every taggable imported resource. Pins the
+// imported_at timestamp via withFixedNow so the assertion is exact, not
+// merely "key present". The composed root must remain HCL-valid.
 func TestComposeStackWithIssues_ProvenanceTags(t *testing.T) {
-	t.Parallel()
+	// Pinning nowFn requires serial execution because nowFn is package-
+	// global; t.Parallel() would race with other tests that touch it.
+
+	restore := withFixedNow(time.Date(2026, 4, 29, 14, 30, 0, 0, time.UTC))
+	defer restore()
 
 	c := newTestClient()
 	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
@@ -48,8 +54,12 @@ func TestComposeStackWithIssues_ProvenanceTags(t *testing.T) {
 	importedTF := string(res.Files["/imported.tf"])
 	require.NotEmpty(t, importedTF)
 	assert.Contains(t, importedTF, "tags = merge(")
-	assert.Contains(t, importedTF, `InsideOutImportProject = "io-stack-1"`)
-	assert.Contains(t, importedTF, `InsideOutImportSession = "sess-9"`)
+	assert.True(t, hasAttr(t, importedTF, "InsideOutImportProject", `"io-stack-1"`),
+		"missing InsideOutImportProject in:\n%s", importedTF)
+	assert.True(t, hasAttr(t, importedTF, "InsideOutImportSession", `"sess-9"`),
+		"missing InsideOutImportSession in:\n%s", importedTF)
+	assert.True(t, hasAttr(t, importedTF, "InsideOutImportedAt", `"2026-04-29T14:30:00Z"`),
+		"timestamp must reflect the pinned nowFn value; got:\n%s", importedTF)
 
 	for _, iss := range res.Issues {
 		require.NotEqualf(t, "hcl_parse_error", iss.Code,
@@ -57,16 +67,30 @@ func TestComposeStackWithIssues_ProvenanceTags(t *testing.T) {
 	}
 }
 
-// TestComposeStackWithIssues_ProvenanceConflict pins that the validator
-// surfaces a structured ValidationIssue when an imported resource's existing
-// InsideOutImportProject tag does not match the composer's ImportProjectID,
-// AND that the conflict issue carries the observed prior owner so the caller
-// can render an actionable message. The composer is contracted to surface
-// the issue via Result.Issues; whether the caller hard-fails on it (via
-// StrictValidate) or refuses takeover is the caller's policy, not this
-// layer's. We pin the structured payload so callers can rely on it.
+// TestComposeStackWithIssues_ProvenanceConflict pins three contracts:
+//
+//  1. The validator surfaces imported_resource_provenance_conflict with
+//     the structured payload (Field, Value, Suggestion) callers rely on.
+//  2. The injector does NOT overwrite the existing tag value (the new
+//     project ID must be absent from the emitted HCL; the prior owner
+//     must remain). This is the design's "differs → refuse" rule.
+//  3. StrictValidate=true escalates the conflict to a hard error so
+//     callers that opt in get refusal rather than a silently-emitted
+//     conflict.
 func TestComposeStackWithIssues_ProvenanceConflict(t *testing.T) {
 	t.Parallel()
+
+	conflictIR := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_dynamodb_table",
+			Address: "aws_dynamodb_table.t", ImportID: "t",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"name": "t",
+			"tags": map[string]any{"InsideOutImportProject": "io-other"},
+		},
+	}
 
 	c := newTestClient()
 	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
@@ -77,24 +101,11 @@ func TestComposeStackWithIssues_ProvenanceConflict(t *testing.T) {
 		Project:         "demo",
 		Region:          "us-east-1",
 		ImportProjectID: "io-stack-1",
-		Imported: []imported.ImportedResource{
-			{
-				Identity: imported.ResourceIdentity{
-					Cloud: "aws", Type: "aws_dynamodb_table",
-					Address: "aws_dynamodb_table.t", ImportID: "t",
-				},
-				Tier: imported.TierImportedFlat,
-				Attributes: map[string]any{
-					"name": "t",
-					"tags": map[string]any{"InsideOutImportProject": "io-other"},
-				},
-			},
-		},
+		Imported:        []imported.ImportedResource{conflictIR},
 	})
 	require.NoError(t, err)
 
-	// Find the conflict issue and pin its structured fields so the caller
-	// can render "claimed by <observed>" UX without re-parsing.
+	// (1) Structured issue payload.
 	var found *ValidationIssue
 	for i := range res.Issues {
 		if res.Issues[i].Code == "imported_resource_provenance_conflict" {
@@ -107,8 +118,16 @@ func TestComposeStackWithIssues_ProvenanceConflict(t *testing.T) {
 	assert.Equal(t, "imported.aws_dynamodb_table.t", found.Field)
 	assert.NotEmpty(t, found.Suggestion, "Suggestion should hint at ForceTakeover")
 
-	// StrictValidate=true must escalate the conflict to an error so callers
-	// that opt in get a hard refusal rather than a silently-overwritten tag.
+	// (2) Negative-emission: the new project ID must NOT have replaced the
+	// conflicting tag in /imported.tf, and the prior owner must remain.
+	importedTF := string(res.Files["/imported.tf"])
+	require.NotEmpty(t, importedTF)
+	assert.NotContains(t, importedTF, "io-stack-1",
+		"injector must not silently overwrite conflicting tag without ForceTakeover")
+	assert.Contains(t, importedTF, "io-other",
+		"the existing tag value must remain in the emitted HCL")
+
+	// (3) StrictValidate escalates.
 	strictRes, err := c.ComposeStackWithIssues(ComposeStackOpts{
 		Cloud:           "aws",
 		SelectedKeys:    []ComponentKey{KeyAWSVPC},
@@ -118,6 +137,29 @@ func TestComposeStackWithIssues_ProvenanceConflict(t *testing.T) {
 		Region:          "us-east-1",
 		ImportProjectID: "io-stack-1",
 		StrictValidate:  true,
+		Imported:        []imported.ImportedResource{conflictIR},
+	})
+	require.Error(t, err, "StrictValidate=true must escalate conflict to error")
+	require.NotNil(t, strictRes)
+	assert.Contains(t, issueCodes(strictRes.Issues), "imported_resource_provenance_conflict")
+}
+
+// TestComposeStackWithIssues_ForceTakeoverSuppresses pins the audited-
+// override path at the compose layer: a fully-populated ForceTakeover
+// matching the observed prior owner suppresses the conflict issue AND
+// authorizes the injector to overwrite with the new project ID.
+func TestComposeStackWithIssues_ForceTakeoverSuppresses(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:           "aws",
+		SelectedKeys:    []ComponentKey{KeyAWSVPC},
+		Comps:           &Components{Cloud: "AWS"},
+		Cfg:             &Config{},
+		Project:         "demo",
+		Region:          "us-east-1",
+		ImportProjectID: "io-stack-1",
 		Imported: []imported.ImportedResource{
 			{
 				Identity: imported.ResourceIdentity{
@@ -129,18 +171,36 @@ func TestComposeStackWithIssues_ProvenanceConflict(t *testing.T) {
 					"name": "t",
 					"tags": map[string]any{"InsideOutImportProject": "io-other"},
 				},
+				ForceTakeover: &imported.ForceTakeover{
+					Actor:         "sam@luthersystems.com",
+					Reason:        "session merge after #173 ramp",
+					PreviousOwner: "io-other",
+					ApprovedAt:    time.Date(2026, 4, 29, 14, 30, 0, 0, time.UTC),
+				},
 			},
 		},
 	})
-	require.Error(t, err, "StrictValidate=true must escalate conflict to error")
-	require.NotNil(t, strictRes)
-	assert.Contains(t, issueCodes(strictRes.Issues), "imported_resource_provenance_conflict")
+	require.NoError(t, err)
+
+	codes := issueCodes(res.Issues)
+	assert.NotContains(t, codes, "imported_resource_provenance_conflict",
+		"valid ForceTakeover must suppress the conflict issue")
+	assert.NotContains(t, codes, "imported_resource_force_takeover_invalid")
+
+	importedTF := string(res.Files["/imported.tf"])
+	assert.Contains(t, importedTF, "io-stack-1",
+		"valid ForceTakeover must allow injector to overwrite the conflicting tag")
 }
 
-// TestComposeStackWithIssues_ProvenanceSkippedAdvisory pins the
-// backwards-compat path: when ImportProjectID is empty but Imported is not,
-// the composer surfaces a low-severity advisory issue and does not emit
-// merge() — pre-#153 behavior is preserved.
+// TestComposeStackWithIssues_ProvenanceSkippedAdvisory pins three things:
+//
+//  1. When ImportProjectID is empty and Imported is non-empty, the composer
+//     surfaces the advisory issue.
+//  2. The advisory fires EXACTLY ONCE per compose, not once per resource —
+//     a regression that emitted N copies for N resources would clutter
+//     callers' UX. Multi-resource fixture proves this.
+//  3. Pre-#153 emission shape is preserved: no merge() wrapper, no
+//     provenance keys leak into the HCL.
 func TestComposeStackWithIssues_ProvenanceSkippedAdvisory(t *testing.T) {
 	t.Parallel()
 
@@ -152,14 +212,33 @@ func TestComposeStackWithIssues_ProvenanceSkippedAdvisory(t *testing.T) {
 		Cfg:          &Config{},
 		Project:      "demo",
 		Region:       "us-east-1",
+		// Multi-resource fixture: if the advisory fires per-resource, this
+		// would surface N copies. The validator's break-after-first-eligible
+		// is the contract under test.
 		Imported: []imported.ImportedResource{
 			{
 				Identity: imported.ResourceIdentity{
 					Cloud: "aws", Type: "aws_sqs_queue",
-					Address: "aws_sqs_queue.q", ImportID: "x",
+					Address: "aws_sqs_queue.q1", ImportID: "1",
 				},
 				Tier:  imported.TierImportedFlat,
-				Attrs: []byte(`{"Name":{"Literal":"q"}}`),
+				Attrs: []byte(`{"Name":{"Literal":"q1"}}`),
+			},
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud: "aws", Type: "aws_sqs_queue",
+					Address: "aws_sqs_queue.q2", ImportID: "2",
+				},
+				Tier:  imported.TierImportedFlat,
+				Attrs: []byte(`{"Name":{"Literal":"q2"}}`),
+			},
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud: "aws", Type: "aws_dynamodb_table",
+					Address: "aws_dynamodb_table.t", ImportID: "3",
+				},
+				Tier:       imported.TierImportedFlat,
+				Attributes: map[string]any{"name": "t", "hash_key": "id"},
 			},
 		},
 	})
@@ -167,6 +246,8 @@ func TestComposeStackWithIssues_ProvenanceSkippedAdvisory(t *testing.T) {
 
 	codes := issueCodes(res.Issues)
 	assert.Contains(t, codes, "imported_resource_provenance_skipped_no_project_id")
+	assert.Equal(t, 1, countCode(res.Issues, "imported_resource_provenance_skipped_no_project_id"),
+		"advisory must fire exactly once per compose, not once per resource")
 
 	importedTF := string(res.Files["/imported.tf"])
 	assert.NotContains(t, importedTF, "tags = merge(", "merge() must not be emitted in pre-#153 mode")

--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -13,6 +14,26 @@ import (
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
 )
+
+// EmitImportedOpts bundles the provenance inputs threaded into EmitImportedTF
+// (issue #153). Zero-valued opts disables provenance injection entirely; the
+// composer surfaces this via imported_resource_provenance_skipped_no_project_id
+// from ValidateProvenanceConflicts so callers know they're running in
+// pre-#153 mode.
+type EmitImportedOpts struct {
+	ImportProjectID string
+	ImportSessionID string
+	ImportedAt      time.Time
+}
+
+// shouldInject reports whether the opts carry enough state for the injector
+// to produce a merge() wrapper. Empty ProjectID disables; everything else
+// (including a zero ImportedAt) is treated as "go" — the injector will use
+// time.Time zero, which the caller can replace with time.Now() before
+// passing.
+func (o EmitImportedOpts) shouldInject() bool {
+	return strings.TrimSpace(o.ImportProjectID) != ""
+}
 
 // emitMode classifies how a single ImportedResource is rendered.
 type emitMode int
@@ -33,7 +54,14 @@ const (
 // validator (ValidateImportedResources) is responsible for reporting blocking
 // issues separately. EmitImportedTF returns nil bytes when no resource
 // emits.
-func EmitImportedTF(cloud string, irs []imported.ImportedResource) (out []byte, providersUsed map[string]bool) {
+//
+// opts threads provenance state into the per-resource body via
+// injectProvenance (issue #153). When opts.ImportProjectID is empty
+// provenance is disabled and bodies emit unchanged for backwards
+// compatibility. EmitImportedTF mutates ir.WeakLocked in irs to record the
+// provenance decision per resource — callers that need the original slice
+// untouched should pass a copy.
+func EmitImportedTF(cloud string, irs []imported.ImportedResource, opts EmitImportedOpts) (out []byte, providersUsed map[string]bool) {
 	if len(irs) == 0 {
 		return nil, nil
 	}
@@ -48,7 +76,8 @@ func EmitImportedTF(cloud string, irs []imported.ImportedResource) (out []byte, 
 	}
 
 	var entries []entry
-	for _, ir := range irs {
+	for i := range irs {
+		ir := &irs[i]
 		got := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
 		if got != "aws" && got != "gcp" {
 			continue
@@ -56,7 +85,7 @@ func EmitImportedTF(cloud string, irs []imported.ImportedResource) (out []byte, 
 		if wantCloud != "" && got != wantCloud {
 			continue
 		}
-		mode := classifyEmitMode(ir)
+		mode := classifyEmitMode(*ir)
 		if mode == emitModeSkip {
 			continue
 		}
@@ -68,9 +97,15 @@ func EmitImportedTF(cloud string, irs []imported.ImportedResource) (out []byte, 
 		e := entry{address: addr}
 		switch mode {
 		case emitModeResourceImport, emitModeResourceOnly:
-			body, err := emitImportedResourceBody(ir)
+			body, err := emitImportedResourceBody(*ir)
 			if err != nil {
 				continue
+			}
+			if opts.shouldInject() {
+				body, err = injectProvenance(body, ir, opts.ImportProjectID, opts.ImportSessionID, opts.ImportedAt)
+				if err != nil {
+					continue
+				}
 			}
 			e.resource = wrapResourceBlock(ir.Identity.Type, addressLabel(addr), providerAliasFor(got), body)
 			if mode == emitModeResourceImport {

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -24,7 +24,7 @@ func hasAttr(t *testing.T, body, name, value string) bool {
 
 func TestEmitImportedTF_Empty(t *testing.T) {
 	t.Parallel()
-	out, used := EmitImportedTF("aws", nil)
+	out, used := EmitImportedTF("aws", nil, EmitImportedOpts{})
 	assert.Nil(t, out)
 	assert.Nil(t, used)
 }
@@ -41,7 +41,7 @@ func TestEmitImportedTF_TypedAWS(t *testing.T) {
 		Tier:  imported.TierImportedFlat,
 		Attrs: []byte(`{"Name":{"Literal":"orders-DLQ"},"FIFOQueue":{"Literal":false}}`),
 	}
-	out, used := EmitImportedTF("aws", []imported.ImportedResource{ir})
+	out, used := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
 	require.NotNil(t, out)
 	s := string(out)
 	assert.True(t, used["aws"])
@@ -71,7 +71,7 @@ func TestEmitImportedTF_TypedGCP(t *testing.T) {
 		Tier:  imported.TierImportedFlat,
 		Attrs: []byte(`{"Name":{"Literal":"events"}}`),
 	}
-	out, used := EmitImportedTF("gcp", []imported.ImportedResource{ir})
+	out, used := EmitImportedTF("gcp", []imported.ImportedResource{ir}, EmitImportedOpts{})
 	require.NotNil(t, out)
 	s := string(out)
 	assert.True(t, used["gcp"])
@@ -103,7 +103,7 @@ func TestEmitImportedTF_OpaqueAttributes(t *testing.T) {
 			},
 		},
 	}
-	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir})
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
 	s := string(out)
 	assert.True(t, hasAttr(t, s, "name", `"users"`), "name attr missing in:\n%s", s)
 	assert.True(t, hasAttr(t, s, "hash_key", `"id"`), "hash_key attr missing in:\n%s", s)
@@ -133,7 +133,7 @@ func TestEmitImportedTF_OpaqueWithRawExpr(t *testing.T) {
 			"kms_master_key_id": RawExpr{Expr: "aws_kms_key.queues.arn"},
 		},
 	}
-	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir})
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
 	s := string(out)
 	assert.True(t, hasAttr(t, s, "name", `"dlq"`), "name attr missing in:\n%s", s)
 	assert.True(t, hasAttr(t, s, "kms_master_key_id", "aws_kms_key.queues.arn"),
@@ -159,7 +159,7 @@ func TestEmitImportedTF_TierGating(t *testing.T) {
 			// no Remediation
 		},
 	}
-	out, used := EmitImportedTF("aws", irs)
+	out, used := EmitImportedTF("aws", irs, EmitImportedOpts{})
 	assert.Nil(t, out)
 	// Stronger than Empty(used): assert every cloud key is explicitly
 	// false. A regression that flipped used["aws"]=true *before* the skip
@@ -188,7 +188,7 @@ func TestEmitImportedTF_MissingRemediations(t *testing.T) {
 
 	t.Run("recreate emits resource only", func(t *testing.T) {
 		t.Parallel()
-		out, _ := EmitImportedTF("aws", []imported.ImportedResource{mkResource(imported.ActionRecreateFromLastImport)})
+		out, _ := EmitImportedTF("aws", []imported.ImportedResource{mkResource(imported.ActionRecreateFromLastImport)}, EmitImportedOpts{})
 		s := string(out)
 		assert.Contains(t, s, `resource "aws_sqs_queue" "legacy"`)
 		assert.NotContains(t, s, "import {", "recreate must NOT emit import block (resource is being recreated, not imported)")
@@ -196,7 +196,7 @@ func TestEmitImportedTF_MissingRemediations(t *testing.T) {
 
 	t.Run("reclaim emits resource and import", func(t *testing.T) {
 		t.Parallel()
-		out, _ := EmitImportedTF("aws", []imported.ImportedResource{mkResource(imported.ActionReclaimExisting)})
+		out, _ := EmitImportedTF("aws", []imported.ImportedResource{mkResource(imported.ActionReclaimExisting)}, EmitImportedOpts{})
 		s := string(out)
 		assert.Contains(t, s, `resource "aws_sqs_queue" "legacy"`)
 		assert.Contains(t, s, "import {")
@@ -205,7 +205,7 @@ func TestEmitImportedTF_MissingRemediations(t *testing.T) {
 
 	t.Run("remove emits removed block only", func(t *testing.T) {
 		t.Parallel()
-		out, _ := EmitImportedTF("aws", []imported.ImportedResource{mkResource(imported.ActionRemoveFromInsideOut)})
+		out, _ := EmitImportedTF("aws", []imported.ImportedResource{mkResource(imported.ActionRemoveFromInsideOut)}, EmitImportedOpts{})
 		s := string(out)
 		assert.Contains(t, s, "removed {")
 		assert.Contains(t, s, "from = aws_sqs_queue.legacy")
@@ -231,7 +231,7 @@ func TestEmitImportedTF_CloudFiltering(t *testing.T) {
 			Attrs:    []byte(`{"Name":{"Literal":"y"}}`),
 		},
 	}
-	out, used := EmitImportedTF("aws", irs)
+	out, used := EmitImportedTF("aws", irs, EmitImportedOpts{})
 	s := string(out)
 	assert.Contains(t, s, "aws_sqs_queue.x")
 	assert.NotContains(t, s, "google_pubsub_topic.y")
@@ -265,13 +265,13 @@ func TestEmitImportedTF_DeterministicOrder(t *testing.T) {
 		}
 		return out
 	}
-	canonical, _ := EmitImportedTF("aws", mkSlice(addresses))
+	canonical, _ := EmitImportedTF("aws", mkSlice(addresses), EmitImportedOpts{})
 	// Reverse the input and compare bytes — must be identical.
 	reversed := append([]string(nil), addresses...)
 	for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
 		reversed[i], reversed[j] = reversed[j], reversed[i]
 	}
-	rev, _ := EmitImportedTF("aws", mkSlice(reversed))
+	rev, _ := EmitImportedTF("aws", mkSlice(reversed), EmitImportedOpts{})
 	assert.Equal(t, string(canonical), string(rev),
 		"input order must not change emitted bytes")
 
@@ -328,7 +328,7 @@ func TestEmitImportedTF_TypedDecodeFailureDropsRecord(t *testing.T) {
 		Tier:  imported.TierImportedFlat,
 		Attrs: []byte(`{"foo":"bar"}`),
 	}
-	out, used := EmitImportedTF("aws", []imported.ImportedResource{good, bad})
+	out, used := EmitImportedTF("aws", []imported.ImportedResource{good, bad}, EmitImportedOpts{})
 	require.NotEmpty(t, out)
 	s := string(out)
 	assert.Contains(t, s, `resource "aws_sqs_queue" "good"`,
@@ -359,7 +359,7 @@ func TestEmitImportedTF_OpaqueRawExprMalformedDropsRecord(t *testing.T) {
 			"kms_master_key_id": RawExpr{Expr: "1 +"}, // unterminated expression
 		},
 	}
-	out, _ := EmitImportedTF("aws", []imported.ImportedResource{good, bad})
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{good, bad}, EmitImportedOpts{})
 	s := string(out)
 	assert.Contains(t, s, `resource "aws_sqs_queue" "ok"`)
 	assert.NotContains(t, s, "aws_sqs_queue.bad",
@@ -392,7 +392,7 @@ func TestEmitImportedTF_OpaqueValueTypes(t *testing.T) {
 			},
 		},
 	}
-	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir})
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
 	s := string(out)
 	assert.True(t, hasAttr(t, s, "name", `"varied"`), "string attr in:\n%s", s)
 	assert.True(t, hasAttr(t, s, "fifo_queue", "true"), "bool attr in:\n%s", s)
@@ -419,7 +419,7 @@ func TestEmitImportedTF_EmptyAttrsEmitsBareResource(t *testing.T) {
 		},
 		Tier: imported.TierImportedFlat,
 	}
-	out, used := EmitImportedTF("aws", []imported.ImportedResource{ir})
+	out, used := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
 	s := string(out)
 	assert.Contains(t, s, `resource "aws_sqs_queue" "bare"`)
 	assert.True(t, hasAttr(t, s, "provider", "aws.imported"))
@@ -448,7 +448,7 @@ func TestEmitImportedTF_SectionOrdering(t *testing.T) {
 			Attributes: map[string]any{"name": "live"},
 		},
 	}
-	out, _ := EmitImportedTF("aws", irs)
+	out, _ := EmitImportedTF("aws", irs, EmitImportedOpts{})
 	s := string(out)
 	idxImport := strings.Index(s, "import {")
 	idxResource := strings.Index(s, `resource "aws_sqs_queue"`)
@@ -462,4 +462,95 @@ func TestEmitImportedTF_SectionOrdering(t *testing.T) {
 	assert.Truef(t, idxResource < idxRemoved,
 		"resources must precede removed blocks; idxResource=%d idxRemoved=%d",
 		idxResource, idxRemoved)
+}
+
+// TestEmitImportedTF_ProvenanceTags pins the end-to-end provenance shape:
+// taggable imported resources get tags = merge({InsideOutImport...}, {...}),
+// labelable GCP resources get the lower-cased hyphenated equivalent, and
+// untaggable types (google_compute_network) emit unchanged.
+func TestEmitImportedTF_ProvenanceTags(t *testing.T) {
+	t.Parallel()
+	awsIR := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "x"},
+		Tier:     imported.TierImportedFlat,
+		Attrs:    []byte(`{"Name":{"Literal":"q"}}`),
+	}
+	gcpIR := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_storage_bucket", Address: "google_storage_bucket.b", ImportID: "b"},
+		Tier:     imported.TierImportedFlat,
+		Attrs:    []byte(`{"Name":{"Literal":"b"}}`),
+	}
+	gcpVPC := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_compute_network", Address: "google_compute_network.vpc", ImportID: "vpc"},
+		Tier:     imported.TierImportedFlat,
+		Attrs:    []byte(`{"Name":{"Literal":"vpc"}}`),
+	}
+
+	opts := EmitImportedOpts{
+		ImportProjectID: "io-stack-1",
+		ImportSessionID: "sess-9",
+		ImportedAt:      fixedTime(),
+	}
+
+	awsIRs := []imported.ImportedResource{awsIR}
+	awsOut, _ := EmitImportedTF("aws", awsIRs, opts)
+	awsStr := string(awsOut)
+	assert.Contains(t, awsStr, `tags = merge(`)
+	assert.Contains(t, awsStr, `InsideOutImportProject = "io-stack-1"`)
+	assert.Contains(t, awsStr, `InsideOutImportSession = "sess-9"`)
+	assert.Contains(t, awsStr, `InsideOutImported`)
+	assert.Contains(t, awsStr, `InsideOutImportedAt`)
+	assert.False(t, awsIRs[0].WeakLocked)
+
+	gcpIRs := []imported.ImportedResource{gcpIR, gcpVPC}
+	gcpOut, _ := EmitImportedTF("gcp", gcpIRs, opts)
+	gcpStr := string(gcpOut)
+	assert.Contains(t, gcpStr, `labels = merge(`)
+	assert.Contains(t, gcpStr, `"insideout-import-project" = "io-stack-1"`)
+	assert.Contains(t, gcpStr, `"insideout-imported-at"    = "2026-04-29t14-30-00z"`)
+	// The VPC body must NOT have a labels merge.
+	vpcBlock := extractResourceBlock(t, gcpStr, "google_compute_network", "vpc")
+	assert.NotContains(t, vpcBlock, "labels = merge(",
+		"google_compute_network is untaggable; provenance must not be injected")
+	assert.True(t, gcpIRs[1].WeakLocked, "google_compute_network must be flagged WeakLocked")
+}
+
+// TestEmitImportedTF_ProvenanceDisabled confirms the backwards-compat path:
+// when EmitImportedOpts.ImportProjectID is empty, no merge() is emitted and
+// existing behavior (issue #148) is preserved bit-for-bit.
+func TestEmitImportedTF_ProvenanceDisabled(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "x"},
+		Tier:     imported.TierImportedFlat,
+		Attrs:    []byte(`{"Name":{"Literal":"q"}}`),
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	s := string(out)
+	assert.NotContains(t, s, "tags = merge(")
+	assert.NotContains(t, s, "InsideOutImportProject")
+}
+
+// extractResourceBlock returns the bytes between the `resource "<type>"
+// "<label>"` line and the matching closing `}` brace. Used to scope an
+// assertion to one resource's body inside a multi-resource emission.
+func extractResourceBlock(t *testing.T, hcl, tfType, label string) string {
+	t.Helper()
+	header := `resource "` + tfType + `" "` + label + `"`
+	start := strings.Index(hcl, header)
+	require.GreaterOrEqual(t, start, 0, "resource %s.%s not found in:\n%s", tfType, label, hcl)
+	depth := 0
+	for i := start; i < len(hcl); i++ {
+		switch hcl[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return hcl[start : i+1]
+			}
+		}
+	}
+	t.Fatalf("unterminated resource block for %s.%s", tfType, label)
+	return ""
 }

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -1,0 +1,429 @@
+package composer
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// Provenance tag/label key names emitted on every taggable imported resource.
+// Decision #46 in docs/managed-resource-tiers.md: the same logical
+// <import-project-id> is used across AWS+GCP for one InsideOut stack/session.
+const (
+	awsTagImportProject = "InsideOutImportProject"
+	awsTagImportSession = "InsideOutImportSession"
+	awsTagImported      = "InsideOutImported"
+	awsTagImportedAt    = "InsideOutImportedAt"
+	awsTagImportedTrue  = "true"
+
+	gcpLabelImportProject = "insideout-import-project"
+	gcpLabelImportSession = "insideout-import-session"
+	gcpLabelImported      = "insideout-imported"
+	gcpLabelImportedAt    = "insideout-imported-at"
+	gcpLabelImportedTrue  = "true"
+)
+
+// untaggableAWS mirrors the canonical NON_TAGGABLE_AWS array in
+// tests/lint-project-tag.sh. Resource types in this set do NOT accept a tags
+// attribute in AWS provider 6.x; the provenance injector skips them and marks
+// the resource WeakLocked. TestUntaggableAllowlistsMatchLintScripts ensures
+// this list stays in sync with the bash array.
+var untaggableAWS = map[string]struct{}{
+	"aws_apigatewayv2_api_mapping":                       {},
+	"aws_backup_selection":                               {},
+	"aws_bedrock_model_invocation_logging_configuration": {},
+	"aws_cloudfront_monitoring_subscription":             {},
+	"aws_cloudfront_origin_access_identity":              {},
+	"aws_cloudwatch_dashboard":                           {},
+	"aws_cloudwatch_log_resource_policy":                 {},
+	"aws_cloudwatch_log_stream":                          {},
+	"aws_cognito_identity_provider":                      {},
+	"aws_cognito_user_pool_client":                       {},
+	"aws_cognito_user_pool_domain":                       {},
+	"aws_dynamodb_contributor_insights":                  {},
+	"aws_ecs_cluster_capacity_providers":                 {},
+	"aws_iam_role_policy":                                {},
+	"aws_iam_role_policy_attachment":                     {},
+	"aws_iam_service_linked_role":                        {},
+	"aws_kms_alias":                                      {},
+	"aws_msk_configuration":                              {},
+	"aws_opensearchserverless_access_policy":             {},
+	"aws_opensearchserverless_security_policy":           {},
+	"aws_s3_bucket_lifecycle_configuration":              {},
+	"aws_s3_bucket_ownership_controls":                   {},
+	"aws_s3_bucket_policy":                               {},
+	"aws_s3_bucket_public_access_block":                  {},
+	"aws_s3_bucket_server_side_encryption_configuration": {},
+	"aws_s3_bucket_versioning":                           {},
+	"aws_security_group_rule":                            {},
+	"aws_sns_topic_subscription":                         {},
+	"aws_wafv2_web_acl_association":                      {},
+}
+
+// labelableGCP mirrors the canonical LABEL_CAPABLE_GCP array in
+// tests/lint-project-label.sh. Unlike AWS where most resources accept tags,
+// GCP labelability is an allowlist: a type is labelable only if it appears
+// here. Types not in this list are weak-locked.
+var labelableGCP = map[string]struct{}{
+	"google_api_gateway_api":                {},
+	"google_api_gateway_api_config":         {},
+	"google_api_gateway_gateway":            {},
+	"google_cloud_run_v2_service":           {},
+	"google_cloudfunctions2_function":       {},
+	"google_compute_global_address":         {},
+	"google_compute_global_forwarding_rule": {},
+	"google_compute_instance":               {},
+	"google_compute_security_policy":        {},
+	"google_pubsub_subscription":            {},
+	"google_pubsub_topic":                   {},
+	"google_redis_instance":                 {},
+	"google_secret_manager_secret":          {},
+	"google_storage_bucket":                 {},
+	"google_vertex_ai_dataset":              {},
+}
+
+// taggable returns the HCL attribute name ("tags" for AWS, "labels" for GCP)
+// to inject provenance into for ir, or ("", false) if the resource type does
+// not support tag/label-based mutual exclusion (weak lock).
+//
+// Decision order:
+//  1. Layer 1 generated schema (authoritative when registered): the schema
+//     map indicates whether the type carries a "tags" or "labels" key.
+//  2. Static allowlists mirroring the lint scripts for types outside Phase 1.
+//  3. Default: AWS unknown types are taggable; GCP unknown types are NOT
+//     labelable (matches the lint script's allowlist semantics).
+func taggable(ir imported.ImportedResource) (attr string, ok bool) {
+	cloud := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
+	tfType := strings.TrimSpace(ir.Identity.Type)
+	if cloud == "" || tfType == "" {
+		return "", false
+	}
+
+	if _, schema, registered := generated.Lookup(tfType); registered {
+		switch cloud {
+		case "aws":
+			if _, has := schema["tags"]; has {
+				return "tags", true
+			}
+			return "", false
+		case "gcp":
+			if _, has := schema["labels"]; has {
+				return "labels", true
+			}
+			return "", false
+		}
+	}
+
+	switch cloud {
+	case "aws":
+		if _, blocked := untaggableAWS[tfType]; blocked {
+			return "", false
+		}
+		return "tags", true
+	case "gcp":
+		if _, allowed := labelableGCP[tfType]; allowed {
+			return "labels", true
+		}
+		return "", false
+	}
+	return "", false
+}
+
+// provenanceEntry is a single key/value pair to emit into the provenance
+// map literal. Order matters at emission time so the output HCL is
+// deterministic; callers receive entries in the canonical order.
+type provenanceEntry struct {
+	Key   string
+	Value string
+}
+
+// provenanceKeysFor builds the provenance entry list for cloud. Always
+// includes the project marker (`InsideOutImportProject` / equivalent), the
+// `Imported = "true"` flag, and the imported-at timestamp; the session entry
+// is included only when sessionID is non-empty.
+func provenanceKeysFor(cloud, projectID, sessionID string, importedAt time.Time) []provenanceEntry {
+	switch strings.ToLower(strings.TrimSpace(cloud)) {
+	case "aws":
+		entries := []provenanceEntry{
+			{Key: awsTagImportProject, Value: projectID},
+		}
+		if sessionID != "" {
+			entries = append(entries, provenanceEntry{Key: awsTagImportSession, Value: sessionID})
+		}
+		entries = append(entries,
+			provenanceEntry{Key: awsTagImported, Value: awsTagImportedTrue},
+			provenanceEntry{Key: awsTagImportedAt, Value: importedAt.UTC().Format(time.RFC3339)},
+		)
+		return entries
+	case "gcp":
+		entries := []provenanceEntry{
+			{Key: gcpLabelImportProject, Value: projectID},
+		}
+		if sessionID != "" {
+			entries = append(entries, provenanceEntry{Key: gcpLabelImportSession, Value: sessionID})
+		}
+		entries = append(entries,
+			provenanceEntry{Key: gcpLabelImported, Value: gcpLabelImportedTrue},
+			provenanceEntry{Key: gcpLabelImportedAt, Value: gcpLabelTimestamp(importedAt)},
+		)
+		return entries
+	}
+	return nil
+}
+
+// gcpLabelTimestamp returns t formatted to satisfy the GCP label charset
+// (lowercase letters, digits, `-`, `_`; no `:` or `.`). RFC3339 has both `:`
+// (between H:M:S and the timezone) and `.` (in fractional seconds), so we
+// downcase, strip fractional seconds, and replace `:` with `-`.
+func gcpLabelTimestamp(t time.Time) string {
+	s := t.UTC().Format("2006-01-02T15:04:05Z")
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, ":", "-")
+	s = strings.ReplaceAll(s, ".", "-")
+	return s
+}
+
+// existingProvenanceProject reads the InsideOutImportProject (AWS) or
+// insideout-import-project (GCP) value from ir's desired state, preferring
+// the typed Attrs over the opaque Attributes bag. Returns ("", false) when
+// the resource does not advertise a prior owner. Used by the validator to
+// detect cross-session ownership conflicts.
+func existingProvenanceProject(ir imported.ImportedResource) (string, bool) {
+	attrName, ok := taggable(ir)
+	if !ok {
+		return "", false
+	}
+	key := awsTagImportProject
+	if attrName == "labels" {
+		key = gcpLabelImportProject
+	}
+
+	if len(ir.Attrs) > 0 {
+		if v, found := readTypedTagLiteral(ir.Identity.Type, ir.Attrs, attrName, key); found {
+			return v, true
+		}
+	}
+	if len(ir.Attributes) > 0 {
+		if v, found := readOpaqueTagLiteral(ir.Attributes, attrName, key); found {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// readTypedTagLiteral decodes typed Attrs and reads the literal string value
+// at <Tags|Labels>[key]. Returns ok=false when the typed model has no
+// matching field, the entry is missing, or the entry's state is anything
+// other than a string literal (Expr / Null / Absent).
+//
+// Implementation: reflect into the decoded struct and find the field whose
+// `tf:"tags"` / `tf:"labels"` tag matches attrName. The map element type is
+// always *generated.Value[string] for tag/label maps, so the Literal pointer
+// gives us the string directly.
+func readTypedTagLiteral(tfType string, raw []byte, attrName, key string) (string, bool) {
+	decoded, err := generated.UnmarshalAttrs(tfType, raw)
+	if err != nil {
+		return "", false
+	}
+	v := reflect.ValueOf(decoded)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return "", false
+	}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		fld := t.Field(i)
+		tag := strings.Split(fld.Tag.Get("tf"), ",")[0]
+		if tag != attrName {
+			continue
+		}
+		fv := v.Field(i)
+		if fv.Kind() != reflect.Map || fv.IsNil() {
+			return "", false
+		}
+		entry := fv.MapIndex(reflect.ValueOf(key))
+		if !entry.IsValid() {
+			return "", false
+		}
+		if entry.Kind() == reflect.Pointer {
+			if entry.IsNil() {
+				return "", false
+			}
+			entry = entry.Elem()
+		}
+		if entry.Kind() != reflect.Struct {
+			return "", false
+		}
+		lit := entry.FieldByName("Literal")
+		if !lit.IsValid() || lit.IsNil() {
+			return "", false
+		}
+		s, ok := lit.Elem().Interface().(string)
+		if !ok {
+			return "", false
+		}
+		return s, true
+	}
+	return "", false
+}
+
+// readOpaqueTagLiteral reads attrs[attrName][key] from the Phase 1 opaque
+// attribute bag. Returns ok=false on any type mismatch.
+func readOpaqueTagLiteral(attrs map[string]any, attrName, key string) (string, bool) {
+	raw, ok := attrs[attrName]
+	if !ok {
+		return "", false
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	v, has := m[key]
+	if !has {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
+}
+
+// injectProvenance rewrites the tags/labels attribute in body so it carries
+// the provenance entries for the configured project/session. The resulting
+// attribute value is `merge({InsideOutImport... = "..."}, <existing>)`.
+// When body has no existing tags/labels attribute the second merge argument
+// becomes `{}`.
+//
+// If ir's Terraform type is not taggable/labelable, body is returned
+// unchanged and ir.WeakLocked is set to true.
+//
+// projectID must be non-empty; the caller (composeStackImpl) gates the call
+// when ImportProjectID is empty so this function can assume it has work to
+// do once it's reached.
+func injectProvenance(body []byte, ir *imported.ImportedResource, projectID, sessionID string, importedAt time.Time) ([]byte, error) {
+	attrName, ok := taggable(*ir)
+	if !ok {
+		ir.WeakLocked = true
+		return body, nil
+	}
+
+	cloud := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
+	entries := provenanceKeysFor(cloud, projectID, sessionID, importedAt)
+	if len(entries) == 0 {
+		return body, nil
+	}
+
+	// emitImportedResourceBody trims trailing newlines; without one, hclwrite
+	// appends a new attribute on the same line as the previous one. Restore
+	// the newline before parsing so SetAttributeRaw lays the merge() down on
+	// its own line.
+	parsed := body
+	if len(parsed) > 0 && parsed[len(parsed)-1] != '\n' {
+		parsed = append(append([]byte{}, parsed...), '\n')
+	}
+	f, diags := hclwrite.ParseConfig(parsed, "imported_body.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("parse imported body for provenance injection: %s", diags.Error())
+	}
+	bodyW := f.Body()
+
+	existingExprText := "{}"
+	if existing := bodyW.GetAttribute(attrName); existing != nil {
+		raw := strings.TrimSpace(string(existing.Expr().BuildTokens(nil).Bytes()))
+		if raw != "" {
+			existingExprText = raw
+		}
+		bodyW.RemoveAttribute(attrName)
+	}
+
+	mergeExpr := buildMergeExpression(entries, existingExprText)
+	tokens, err := tokenizeExpression(mergeExpr)
+	if err != nil {
+		return nil, fmt.Errorf("tokenize provenance merge expression: %w", err)
+	}
+	bodyW.SetAttributeRaw(attrName, tokens)
+
+	return f.Bytes(), nil
+}
+
+// buildMergeExpression formats `merge({ <provenance> }, <existingExpr>)` as
+// a string suitable for re-parsing via hclwrite. Provenance keys are emitted
+// in the order returned by provenanceKeysFor.
+func buildMergeExpression(entries []provenanceEntry, existingExpr string) string {
+	var b strings.Builder
+	b.WriteString("merge(\n  {\n")
+	for _, e := range entries {
+		fmt.Fprintf(&b, "    %s = %q\n", quoteKeyIfNeeded(e.Key), e.Value)
+	}
+	b.WriteString("  },\n  ")
+	b.WriteString(existingExpr)
+	b.WriteString(",\n)")
+	return b.String()
+}
+
+// quoteKeyIfNeeded wraps key in double quotes when it is not a legal HCL
+// identifier. GCP labels use hyphens and require quoting; AWS provenance
+// tags use CamelCase and don't need quoting.
+func quoteKeyIfNeeded(key string) string {
+	for i := 0; i < len(key); i++ {
+		c := key[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9' && i > 0:
+		case c == '_':
+		default:
+			return fmt.Sprintf("%q", key)
+		}
+	}
+	return key
+}
+
+// tokenizeExpression takes an HCL expression (e.g. "merge({...}, {...})")
+// and returns hclwrite tokens that emit it verbatim. Round-trips through a
+// throw-away `__expr = ...` attribute so hclwrite tokenizes for us.
+func tokenizeExpression(expr string) (hclwrite.Tokens, error) {
+	src := fmt.Appendf(nil, "__expr = %s\n", expr)
+	f, diags := hclwrite.ParseConfig(src, "expr.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("%s", diags.Error())
+	}
+	attr := f.Body().GetAttribute("__expr")
+	if attr == nil {
+		return nil, fmt.Errorf("internal: expected __expr attribute")
+	}
+	return attr.Expr().BuildTokens(nil), nil
+}
+
+// untaggableAWSSlice returns the sorted untaggable AWS resource type list
+// for cross-checking against the lint script. The slice is a stable copy.
+func untaggableAWSSlice() []string {
+	out := make([]string, 0, len(untaggableAWS))
+	for k := range untaggableAWS {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// labelableGCPSlice returns the sorted labelable GCP resource type list for
+// cross-checking against the lint script.
+func labelableGCPSlice() []string {
+	out := make([]string, 0, len(labelableGCP))
+	for k := range labelableGCP {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -277,6 +277,21 @@ func readTypedTagLiteral(tfType string, raw []byte, attrName, key string) (strin
 	return "", false
 }
 
+// validForceTakeover reports whether ft is non-nil, fully-populated, and
+// whose PreviousOwner matches the value observed on the resource. The
+// validator uses this to decide between imported_resource_provenance_conflict
+// vs imported_resource_force_takeover_invalid; the injector uses it to
+// decide whether overwriting is authorized.
+func validForceTakeover(ft *imported.ForceTakeover, observed string) bool {
+	if ft == nil {
+		return false
+	}
+	if strings.TrimSpace(ft.Actor) == "" || strings.TrimSpace(ft.Reason) == "" || strings.TrimSpace(ft.PreviousOwner) == "" || ft.ApprovedAt.IsZero() {
+		return false
+	}
+	return ft.PreviousOwner == observed
+}
+
 // readOpaqueTagLiteral reads attrs[attrName][key] from the Phase 1 opaque
 // attribute bag. Returns ok=false on any type mismatch.
 func readOpaqueTagLiteral(attrs map[string]any, attrName, key string) (string, bool) {
@@ -308,6 +323,14 @@ func readOpaqueTagLiteral(attrs map[string]any, attrName, key string) (string, b
 // If ir's Terraform type is not taggable/labelable, body is returned
 // unchanged and ir.WeakLocked is set to true.
 //
+// If the resource already advertises a different InsideOutImportProject /
+// insideout-import-project value AND no valid ForceTakeover is supplied,
+// the body is returned unchanged — refusing to silently overwrite the
+// conflicting tag (design decision #45). The validator
+// (ValidateProvenanceConflicts) is responsible for surfacing the
+// imported_resource_provenance_conflict issue separately; this arm just
+// keeps the injector from racing past it.
+//
 // projectID must be non-empty; the caller (composeStackImpl) gates the call
 // when ImportProjectID is empty so this function can assume it has work to
 // do once it's reached.
@@ -315,6 +338,14 @@ func injectProvenance(body []byte, ir *imported.ImportedResource, projectID, ses
 	attrName, ok := taggable(*ir)
 	if !ok {
 		ir.WeakLocked = true
+		return body, nil
+	}
+
+	// Refuse to overwrite a conflicting prior owner without a valid force-
+	// takeover. Mirrors the validator's branching: any existing owner that
+	// is neither equal to projectID nor accompanied by a valid ForceTakeover
+	// blocks the rewrite.
+	if existing, has := existingProvenanceProject(*ir); has && existing != projectID && !validForceTakeover(ir.ForceTakeover, existing) {
 		return body, nil
 	}
 
@@ -404,6 +435,20 @@ func tokenizeExpression(expr string) (hclwrite.Tokens, error) {
 		return nil, fmt.Errorf("internal: expected __expr attribute")
 	}
 	return attr.Expr().BuildTokens(nil), nil
+}
+
+// nowFn is the package-private clock seam used by composeStackImpl to
+// stamp the imported_at timestamp. Tests override it via withFixedNow to
+// pin the value across a compose pass.
+var nowFn = func() time.Time { return time.Now().UTC() }
+
+// withFixedNow temporarily replaces nowFn with a fixed value for the
+// duration of the returned restore func; intended for tests that need to
+// pin imported_at across a compose call.
+func withFixedNow(t time.Time) (restore func()) {
+	prev := nowFn
+	nowFn = func() time.Time { return t }
+	return func() { nowFn = prev }
 }
 
 // untaggableAWSSlice returns the sorted untaggable AWS resource type list

--- a/pkg/composer/imported_provenance_test.go
+++ b/pkg/composer/imported_provenance_test.go
@@ -3,7 +3,9 @@ package composer
 import (
 	"bufio"
 	"os"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -134,12 +136,15 @@ func TestInjectProvenance_AWSTypedAttrsExisting(t *testing.T) {
 	s := string(got)
 	assert.False(t, ir.WeakLocked, "AWS taggable resource must not be weak-locked")
 	assert.Contains(t, s, "tags = merge(")
-	assert.Contains(t, s, `InsideOutImportProject = "io-stack-1"`)
-	assert.Contains(t, s, `InsideOutImportSession = "sess-9"`)
-	assert.Contains(t, s, `InsideOutImported      = "true"`)
-	assert.Contains(t, s, `InsideOutImportedAt    = "2026-04-29T14:30:00Z"`)
+	// hasAttr tolerates the column-alignment padding hclwrite applies, so
+	// these assertions don't break when a future change shifts the longest
+	// key.
+	assert.True(t, hasAttr(t, s, "InsideOutImportProject", `"io-stack-1"`), "missing InsideOutImportProject in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "InsideOutImportSession", `"sess-9"`), "missing InsideOutImportSession in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "InsideOutImported", `"true"`), "missing InsideOutImported in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "InsideOutImportedAt", `"2026-04-29T14:30:00Z"`), "missing InsideOutImportedAt in:\n%s", s)
 	// Existing user tag preserved verbatim in the second merge argument.
-	assert.Contains(t, s, `Owner = "team-payments"`)
+	assert.True(t, hasAttr(t, s, "Owner", `"team-payments"`), "user-supplied Owner tag missing in:\n%s", s)
 }
 
 func TestInjectProvenance_GCPTypedAttrsExisting(t *testing.T) {
@@ -157,11 +162,157 @@ func TestInjectProvenance_GCPTypedAttrsExisting(t *testing.T) {
 	s := string(got)
 	assert.False(t, ir.WeakLocked)
 	assert.Contains(t, s, "labels = merge(")
-	assert.Contains(t, s, `"insideout-import-project" = "io-stack-1"`)
-	assert.Contains(t, s, `"insideout-import-session" = "sess-9"`)
-	assert.Contains(t, s, `"insideout-imported"       = "true"`)
-	assert.Contains(t, s, `"insideout-imported-at"    = "2026-04-29t14-30-00z"`)
-	assert.Contains(t, s, `team = "docs"`)
+	// GCP label keys are hyphenated and so emit quoted; hasAttr handles the
+	// quoted-key regex. The key argument includes the surrounding quotes.
+	assert.True(t, hasAttr(t, s, `"insideout-import-project"`, `"io-stack-1"`), "missing insideout-import-project in:\n%s", s)
+	assert.True(t, hasAttr(t, s, `"insideout-import-session"`, `"sess-9"`), "missing insideout-import-session in:\n%s", s)
+	assert.True(t, hasAttr(t, s, `"insideout-imported"`, `"true"`), "missing insideout-imported in:\n%s", s)
+	assert.True(t, hasAttr(t, s, `"insideout-imported-at"`, `"2026-04-29t14-30-00z"`), "missing insideout-imported-at in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "team", `"docs"`), "user-supplied team label missing in:\n%s", s)
+}
+
+// TestInjectProvenance_GCPAllowlistFallback exercises the labelableGCP
+// allowlist fallback for resource types that are NOT in the Phase 1
+// generated registry. google_redis_instance is on the allowlist (in
+// labelableGCP) but has no .gen.go schema; google_kms_key_ring is neither
+// registered nor on the allowlist and should weak-lock. Both paths exist
+// in taggable() but were only covered at the predicate level by
+// TestTaggable_AllowlistFallback — this test pins the end-to-end emit.
+func TestInjectProvenance_GCPAllowlistFallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allowlisted but unregistered → labels emitted", func(t *testing.T) {
+		ir := imported.ImportedResource{
+			Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_redis_instance", Address: "google_redis_instance.cache"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"name": "cache",
+			},
+		}
+		body, _, err := emitTestBody(t, ir)
+		require.NoError(t, err)
+		got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+		require.NoError(t, err)
+		s := string(got)
+		assert.False(t, ir.WeakLocked, "allowlisted GCP type must not be weak-locked")
+		assert.Contains(t, s, "labels = merge(")
+		assert.True(t, hasAttr(t, s, `"insideout-import-project"`, `"io-stack-1"`),
+			"missing insideout-import-project in fallback emit:\n%s", s)
+	})
+
+	t.Run("not allowlisted and not registered → weak-lock, no labels", func(t *testing.T) {
+		ir := imported.ImportedResource{
+			Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_kms_key_ring", Address: "google_kms_key_ring.r"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"name": "r",
+			},
+		}
+		body, _, err := emitTestBody(t, ir)
+		require.NoError(t, err)
+		got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+		require.NoError(t, err)
+		assert.True(t, ir.WeakLocked, "non-allowlisted unregistered GCP type must weak-lock")
+		assert.Equal(t, string(body), string(got), "weak-lock body must be returned unchanged")
+		assert.NotContains(t, string(got), "labels = merge(")
+	})
+}
+
+// TestInjectProvenance_AWSAllowlistFallback mirrors the GCP fallback test
+// for the AWS side: an unregistered type that is not on the
+// untaggableAWS block-list should get tags injected; one that is should
+// weak-lock.
+func TestInjectProvenance_AWSAllowlistFallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unregistered and not blocked → tags emitted", func(t *testing.T) {
+		ir := imported.ImportedResource{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_kinesis_stream", Address: "aws_kinesis_stream.events"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"name": "events",
+			},
+		}
+		body, _, err := emitTestBody(t, ir)
+		require.NoError(t, err)
+		got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+		require.NoError(t, err)
+		s := string(got)
+		assert.False(t, ir.WeakLocked)
+		assert.Contains(t, s, "tags = merge(")
+		assert.True(t, hasAttr(t, s, "InsideOutImportProject", `"io-stack-1"`),
+			"missing InsideOutImportProject in fallback emit:\n%s", s)
+	})
+
+	t.Run("blocklisted → weak-lock, no tags", func(t *testing.T) {
+		ir := imported.ImportedResource{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_iam_role_policy", Address: "aws_iam_role_policy.p"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"name": "p",
+			},
+		}
+		body, _, err := emitTestBody(t, ir)
+		require.NoError(t, err)
+		got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+		require.NoError(t, err)
+		assert.True(t, ir.WeakLocked)
+		assert.Equal(t, string(body), string(got))
+	})
+}
+
+// TestInjectProvenance_ConflictRefusesOverwrite pins the design contract
+// that the injector does NOT overwrite a conflicting prior owner without a
+// valid ForceTakeover. The validator surfaces the issue separately; this
+// test only verifies the injector's emit-side guard.
+func TestInjectProvenance_ConflictRefusesOverwrite(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.t"},
+		Tier:     imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"name": "t",
+			"tags": map[string]any{"InsideOutImportProject": "io-other"},
+		},
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+	assert.NotContains(t, s, "io-stack-1", "injector must not overwrite conflicting tag without ForceTakeover")
+	assert.Contains(t, s, "io-other", "the existing owner tag must remain")
+}
+
+// TestInjectProvenance_ValidForceTakeoverOverwrites pins the inverse: a
+// fully-populated ForceTakeover with matching PreviousOwner authorizes the
+// injector to overwrite the conflicting tag.
+func TestInjectProvenance_ValidForceTakeoverOverwrites(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.t"},
+		Tier:     imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"name": "t",
+			"tags": map[string]any{"InsideOutImportProject": "io-other"},
+		},
+		ForceTakeover: &imported.ForceTakeover{
+			Actor:         "sam@luthersystems.com",
+			Reason:        "session merge after #173 ramp",
+			PreviousOwner: "io-other",
+			ApprovedAt:    fixedTime(),
+		},
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+	assert.Contains(t, s, "tags = merge(")
+	assert.True(t, hasAttr(t, s, "InsideOutImportProject", `"io-stack-1"`),
+		"valid ForceTakeover must allow overwrite; got:\n%s", s)
 }
 
 func TestInjectProvenance_GCPUntaggableType(t *testing.T) {
@@ -362,33 +513,15 @@ func TestUntaggableAllowlistsMatchLintScripts(t *testing.T) {
 	assert.Equal(t, gcpLint, gotGCP, "labelableGCP drift vs lint-project-label.sh")
 }
 
-// findRepoRoot walks up from the current package directory until it finds a
-// .git directory, then returns the absolute path. Tests use this to locate
-// the bash lint scripts.
+// findRepoRoot returns the repository root by walking up from this test
+// file's own location, which is `<repo>/pkg/composer/imported_provenance_test.go`.
+// Using runtime.Caller is deterministic across worktrees and CI sandboxes
+// and does not depend on the test process's working directory.
 func findRepoRoot(t *testing.T) string {
 	t.Helper()
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-	for cur := wd; cur != "/" && cur != ""; {
-		if _, err := os.Stat(cur + "/.git"); err == nil {
-			return cur
-		}
-		parent := strings.TrimSuffix(cur, "/"+lastDir(cur))
-		if parent == cur {
-			break
-		}
-		cur = parent
-	}
-	t.Fatalf("could not find repo root from %s", wd)
-	return ""
-}
-
-func lastDir(p string) string {
-	idx := strings.LastIndex(p, "/")
-	if idx < 0 {
-		return p
-	}
-	return p[idx+1:]
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
 }
 
 // parseBashArray extracts a bash array assignment of the form

--- a/pkg/composer/imported_provenance_test.go
+++ b/pkg/composer/imported_provenance_test.go
@@ -1,0 +1,344 @@
+package composer
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// fixedTime returns a stable timestamp used by the provenance tests so output
+// HCL is deterministic across runs.
+func fixedTime() time.Time {
+	return time.Date(2026, 4, 29, 14, 30, 0, 0, time.UTC)
+}
+
+func TestGCPLabelTimestamp(t *testing.T) {
+	t.Parallel()
+	got := gcpLabelTimestamp(fixedTime())
+	// Charset constraint: lowercase letters, digits, hyphens, underscores;
+	// no `:`, `.`, or uppercase letters.
+	require.Equal(t, "2026-04-29t14-30-00z", got)
+}
+
+func TestTaggable_RegisteredTypes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		cloud, tfType, attr string
+		ok                  bool
+	}{
+		// All 5 AWS Phase 1 types support tags.
+		{"aws", "aws_sqs_queue", "tags", true},
+		{"aws", "aws_dynamodb_table", "tags", true},
+		{"aws", "aws_cloudwatch_log_group", "tags", true},
+		{"aws", "aws_secretsmanager_secret", "tags", true},
+		{"aws", "aws_lambda_function", "tags", true},
+		// 4 of 5 GCP Phase 1 types support labels.
+		{"gcp", "google_pubsub_topic", "labels", true},
+		{"gcp", "google_pubsub_subscription", "labels", true},
+		{"gcp", "google_storage_bucket", "labels", true},
+		{"gcp", "google_secret_manager_secret", "labels", true},
+		// google_compute_network is the one Phase 1 type that has no labels.
+		{"gcp", "google_compute_network", "", false},
+	}
+	for _, tc := range cases {
+		ir := imported.ImportedResource{
+			Identity: imported.ResourceIdentity{Cloud: tc.cloud, Type: tc.tfType},
+		}
+		attr, ok := taggable(ir)
+		assert.Equal(t, tc.ok, ok, "%s/%s ok mismatch", tc.cloud, tc.tfType)
+		assert.Equal(t, tc.attr, attr, "%s/%s attr mismatch", tc.cloud, tc.tfType)
+	}
+}
+
+func TestTaggable_AllowlistFallback(t *testing.T) {
+	t.Parallel()
+	// AWS unregistered type defaults taggable unless in untaggableAWS.
+	awsTaggable := imported.ImportedResource{Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_kinesis_stream"}}
+	attr, ok := taggable(awsTaggable)
+	assert.True(t, ok)
+	assert.Equal(t, "tags", attr)
+
+	awsBlocked := imported.ImportedResource{Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_iam_role_policy"}}
+	_, ok = taggable(awsBlocked)
+	assert.False(t, ok)
+
+	// GCP unregistered type defaults to NOT labelable unless in labelableGCP.
+	gcpAllowed := imported.ImportedResource{Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_redis_instance"}}
+	attr, ok = taggable(gcpAllowed)
+	assert.True(t, ok)
+	assert.Equal(t, "labels", attr)
+
+	gcpDisallowed := imported.ImportedResource{Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_kms_key_ring"}}
+	_, ok = taggable(gcpDisallowed)
+	assert.False(t, ok)
+}
+
+func TestProvenanceKeysFor_AWS(t *testing.T) {
+	t.Parallel()
+	entries := provenanceKeysFor("aws", "io-stack-1", "sess-9", fixedTime())
+	require.Len(t, entries, 4)
+	assert.Equal(t, awsTagImportProject, entries[0].Key)
+	assert.Equal(t, "io-stack-1", entries[0].Value)
+	assert.Equal(t, awsTagImportSession, entries[1].Key)
+	assert.Equal(t, "sess-9", entries[1].Value)
+	assert.Equal(t, awsTagImported, entries[2].Key)
+	assert.Equal(t, "true", entries[2].Value)
+	assert.Equal(t, awsTagImportedAt, entries[3].Key)
+	assert.Equal(t, "2026-04-29T14:30:00Z", entries[3].Value)
+}
+
+func TestProvenanceKeysFor_GCP(t *testing.T) {
+	t.Parallel()
+	entries := provenanceKeysFor("gcp", "io-stack-1", "sess-9", fixedTime())
+	require.Len(t, entries, 4)
+	assert.Equal(t, gcpLabelImportProject, entries[0].Key)
+	assert.Equal(t, gcpLabelImportSession, entries[1].Key)
+	assert.Equal(t, gcpLabelImportedAt, entries[3].Key)
+	assert.Equal(t, "2026-04-29t14-30-00z", entries[3].Value)
+}
+
+func TestProvenanceKeysFor_OmitSession(t *testing.T) {
+	t.Parallel()
+	entries := provenanceKeysFor("aws", "io-stack-1", "", fixedTime())
+	require.Len(t, entries, 3)
+	for _, e := range entries {
+		assert.NotEqual(t, awsTagImportSession, e.Key, "session entry must be omitted when sessionID is empty")
+	}
+}
+
+func TestInjectProvenance_AWSTypedAttrsExisting(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q"},
+		Tier:     imported.TierImportedFlat,
+		Attrs:    []byte(`{"Name":{"Literal":"q"},"Tags":{"Owner":{"Literal":"team-payments"}}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+	assert.False(t, ir.WeakLocked, "AWS taggable resource must not be weak-locked")
+	assert.Contains(t, s, "tags = merge(")
+	assert.Contains(t, s, `InsideOutImportProject = "io-stack-1"`)
+	assert.Contains(t, s, `InsideOutImportSession = "sess-9"`)
+	assert.Contains(t, s, `InsideOutImported      = "true"`)
+	assert.Contains(t, s, `InsideOutImportedAt    = "2026-04-29T14:30:00Z"`)
+	// Existing user tag preserved verbatim in the second merge argument.
+	assert.Contains(t, s, `Owner = "team-payments"`)
+}
+
+func TestInjectProvenance_GCPTypedAttrsExisting(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_storage_bucket", Address: "google_storage_bucket.docs"},
+		Tier:     imported.TierImportedFlat,
+		Attrs:    []byte(`{"Name":{"Literal":"docs"},"Labels":{"team":{"Literal":"docs"}}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+	assert.False(t, ir.WeakLocked)
+	assert.Contains(t, s, "labels = merge(")
+	assert.Contains(t, s, `"insideout-import-project" = "io-stack-1"`)
+	assert.Contains(t, s, `"insideout-import-session" = "sess-9"`)
+	assert.Contains(t, s, `"insideout-imported"       = "true"`)
+	assert.Contains(t, s, `"insideout-imported-at"    = "2026-04-29t14-30-00z"`)
+	assert.Contains(t, s, `team = "docs"`)
+}
+
+func TestInjectProvenance_GCPUntaggableType(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_compute_network", Address: "google_compute_network.vpc"},
+		Tier:     imported.TierImportedFlat,
+		Attrs:    []byte(`{"Name":{"Literal":"vpc"}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	assert.True(t, ir.WeakLocked, "untaggable resource must be weak-locked")
+	assert.Equal(t, string(body), string(got), "weak-locked body must be returned unchanged")
+}
+
+func TestInjectProvenance_NoExistingTags(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q"},
+		Tier:     imported.TierImportedFlat,
+		Attrs:    []byte(`{"Name":{"Literal":"q"}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+	got, err := injectProvenance(body, &ir, "io-stack-1", "", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+	assert.Contains(t, s, "tags = merge(")
+	// Second argument is `{}` when there were no existing tags.
+	mergeArgs := regexp.MustCompile(`(?s)merge\(\s*\{[^{}]*\},\s*(\{[^{}]*\}|\{\s*\}),\s*\)`)
+	require.True(t, mergeArgs.MatchString(s), "merge call shape mismatch in:\n%s", s)
+}
+
+func TestInjectProvenance_OpaqueAttributes(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.t"},
+		Tier:     imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"name":     "t",
+			"hash_key": "id",
+			"tags":     map[string]any{"Project": "demo"},
+		},
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+	assert.Contains(t, s, "tags = merge(")
+	assert.Contains(t, s, `Project = "demo"`)
+	assert.Contains(t, s, `InsideOutImportProject = "io-stack-1"`)
+}
+
+func TestInjectProvenance_Idempotent(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q"},
+		Tier:     imported.TierImportedFlat,
+		Attrs:    []byte(`{"Name":{"Literal":"q"}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+	first, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	second, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	assert.Equal(t, string(first), string(second), "two injections with same opts must be byte-identical")
+}
+
+// emitTestBody is a small helper that runs the same body-emission path as
+// EmitImportedTF (typed Attrs → MarshalHCL, opaque → emitOpaqueAttrsBody) so
+// the injector tests get a realistic input.
+func emitTestBody(t *testing.T, ir imported.ImportedResource) ([]byte, string, error) {
+	t.Helper()
+	body, err := emitImportedResourceBody(ir)
+	return body, "", err
+}
+
+// TestUntaggableAllowlistsMatchLintScripts cross-checks that the Go-side
+// allowlists in imported_provenance.go stay in sync with the bash arrays in
+// tests/lint-project-tag.sh and tests/lint-project-label.sh. Drift here
+// silently breaks provenance enforcement, so this test exists to fail fast
+// rather than wait for a downstream surprise.
+func TestUntaggableAllowlistsMatchLintScripts(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := findRepoRoot(t)
+
+	awsLint, err := parseBashArray(repoRoot+"/tests/lint-project-tag.sh", "NON_TAGGABLE_AWS")
+	require.NoError(t, err)
+	gcpLint, err := parseBashArray(repoRoot+"/tests/lint-project-label.sh", "LABEL_CAPABLE_GCP")
+	require.NoError(t, err)
+
+	gotAWS := untaggableAWSSlice()
+	gotGCP := labelableGCPSlice()
+	sort.Strings(awsLint)
+	sort.Strings(gcpLint)
+
+	assert.Equal(t, awsLint, gotAWS, "untaggableAWS drift vs lint-project-tag.sh")
+	assert.Equal(t, gcpLint, gotGCP, "labelableGCP drift vs lint-project-label.sh")
+}
+
+// findRepoRoot walks up from the current package directory until it finds a
+// .git directory, then returns the absolute path. Tests use this to locate
+// the bash lint scripts.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	for cur := wd; cur != "/" && cur != ""; {
+		if _, err := os.Stat(cur + "/.git"); err == nil {
+			return cur
+		}
+		parent := strings.TrimSuffix(cur, "/"+lastDir(cur))
+		if parent == cur {
+			break
+		}
+		cur = parent
+	}
+	t.Fatalf("could not find repo root from %s", wd)
+	return ""
+}
+
+func lastDir(p string) string {
+	idx := strings.LastIndex(p, "/")
+	if idx < 0 {
+		return p
+	}
+	return p[idx+1:]
+}
+
+// parseBashArray extracts a bash array assignment of the form
+// `NAME=( a b c )` from a script. Lines inside the parentheses may carry
+// `#` comments (stripped) and arbitrary whitespace. Returns the unsorted
+// list of unquoted entries.
+func parseBashArray(path, name string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var out []string
+	scanner := bufio.NewScanner(f)
+	state := 0 // 0 = looking for "NAME=(", 1 = inside the array
+	header := name + "=("
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch state {
+		case 0:
+			if strings.Contains(line, header) {
+				state = 1
+			}
+		case 1:
+			if strings.Contains(line, ")") {
+				state = 2
+			}
+			// Strip comments and whitespace, then parse one entry per token.
+			if i := strings.Index(line, "#"); i >= 0 {
+				line = line[:i]
+			}
+			line = strings.TrimSpace(line)
+			line = strings.TrimSuffix(line, ")")
+			line = strings.TrimSpace(line)
+			for _, tok := range strings.Fields(line) {
+				if tok == "(" || tok == "" {
+					continue
+				}
+				tok = strings.Trim(tok, `"'`)
+				out = append(out, tok)
+			}
+		}
+		if state == 2 {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/pkg/composer/imported_provenance_test.go
+++ b/pkg/composer/imported_provenance_test.go
@@ -101,7 +101,11 @@ func TestProvenanceKeysFor_GCP(t *testing.T) {
 	entries := provenanceKeysFor("gcp", "io-stack-1", "sess-9", fixedTime())
 	require.Len(t, entries, 4)
 	assert.Equal(t, gcpLabelImportProject, entries[0].Key)
+	assert.Equal(t, "io-stack-1", entries[0].Value)
 	assert.Equal(t, gcpLabelImportSession, entries[1].Key)
+	assert.Equal(t, "sess-9", entries[1].Value)
+	assert.Equal(t, gcpLabelImported, entries[2].Key)
+	assert.Equal(t, "true", entries[2].Value)
 	assert.Equal(t, gcpLabelImportedAt, entries[3].Key)
 	assert.Equal(t, "2026-04-29t14-30-00z", entries[3].Value)
 }
@@ -214,7 +218,13 @@ func TestInjectProvenance_OpaqueAttributes(t *testing.T) {
 	assert.Contains(t, s, `InsideOutImportProject = "io-stack-1"`)
 }
 
-func TestInjectProvenance_Idempotent(t *testing.T) {
+// TestInjectProvenance_Deterministic confirms two independent injection
+// passes over the same fresh body produce byte-identical output. This is
+// determinism, not idempotency: injectProvenance is contracted to run on
+// the IR's desired-state body (Attrs / Attributes), never on previously-
+// injected HCL. EmitImportedTF guarantees this by always rebuilding the
+// body via emitImportedResourceBody before calling the injector.
+func TestInjectProvenance_Deterministic(t *testing.T) {
 	t.Parallel()
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q"},
@@ -230,6 +240,32 @@ func TestInjectProvenance_Idempotent(t *testing.T) {
 	assert.Equal(t, string(first), string(second), "two injections with same opts must be byte-identical")
 }
 
+// TestInjectProvenance_DoubleInjectionNests pins the contract that
+// injectProvenance is NOT idempotent on already-injected output: a second
+// pass treats the existing merge() expression as the user's prior tags and
+// nests it. This is not a defect — the function is contracted to run only
+// on fresh bodies — but capturing the behavior here means a future caller
+// that mistakenly re-runs the injector on emitted HCL will get a clear
+// signal about what is happening.
+func TestInjectProvenance_DoubleInjectionNests(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q"},
+		Tier:     imported.TierImportedFlat,
+		Attrs:    []byte(`{"Name":{"Literal":"q"}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+	first, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	second, err := injectProvenance(first, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	// Two `merge(` substrings means we nested. Single-pass output has only
+	// one. The bytes should differ.
+	assert.NotEqual(t, string(first), string(second), "double injection must differ from single injection (non-idempotent contract)")
+	assert.Equal(t, 2, strings.Count(string(second), "merge("), "second pass nests merge() inside the existing one")
+}
+
 // emitTestBody is a small helper that runs the same body-emission path as
 // EmitImportedTF (typed Attrs → MarshalHCL, opaque → emitOpaqueAttrsBody) so
 // the injector tests get a realistic input.
@@ -237,6 +273,69 @@ func emitTestBody(t *testing.T, ir imported.ImportedResource) ([]byte, string, e
 	t.Helper()
 	body, err := emitImportedResourceBody(ir)
 	return body, "", err
+}
+
+// TestParseBashArray pins the parser's edge cases so a regression here
+// can't quietly mask drift between the Go allowlists and the bash lint
+// scripts. Without these the cross-check test below could pass on a
+// truncated parse.
+func TestParseBashArray(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "multi-line plain",
+			src: `LIST=(
+  a
+  b
+  c
+)`,
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "comment containing close paren must not terminate parse",
+			src: `LIST=(
+  a
+  b  # see ticket (#42)
+  c
+)`,
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "single-line array",
+			src:  `LIST=( a b c )`,
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "header with trailing comment",
+			src: `LIST=(  # ordered
+  a
+  b
+)`,
+			want: []string{"a", "b"},
+		},
+		{
+			name: "quoted entries are unquoted",
+			src: `LIST=(
+  "a"
+  'b'
+)`,
+			want: []string{"a", "b"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir() + "/script.sh"
+			require.NoError(t, os.WriteFile(tmp, []byte(tc.src), 0o644))
+			got, err := parseBashArray(tmp, "LIST")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }
 
 // TestUntaggableAllowlistsMatchLintScripts cross-checks that the Go-side
@@ -294,8 +393,11 @@ func lastDir(p string) string {
 
 // parseBashArray extracts a bash array assignment of the form
 // `NAME=( a b c )` from a script. Lines inside the parentheses may carry
-// `#` comments (stripped) and arbitrary whitespace. Returns the unsorted
-// list of unquoted entries.
+// `#` comments (stripped first, then closing `)` is detected) and arbitrary
+// whitespace. The header (`NAME=(`) and closing `)` may occur on separate
+// lines or on the same line.
+//
+// Returns the unsorted list of unquoted entries.
 func parseBashArray(path, name string) ([]string, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -305,23 +407,36 @@ func parseBashArray(path, name string) ([]string, error) {
 
 	var out []string
 	scanner := bufio.NewScanner(f)
-	state := 0 // 0 = looking for "NAME=(", 1 = inside the array
+	state := 0 // 0 = looking for "NAME=(", 1 = inside the array, 2 = done
 	header := name + "=("
 	for scanner.Scan() {
-		line := scanner.Text()
+		raw := scanner.Text()
+
+		// Strip line comments first so a `# … (…)` annotation cannot fool
+		// either the header or close detector. Comments must be in
+		// unquoted context — the lint scripts don't use embedded `#` in
+		// quoted entries today, so a naive split is sufficient.
+		line := raw
+		if i := strings.Index(line, "#"); i >= 0 {
+			line = line[:i]
+		}
+
 		switch state {
 		case 0:
 			if strings.Contains(line, header) {
 				state = 1
+				// Trim everything up to and including the header so a
+				// single-line `NAME=( a b c )` parses correctly.
+				if i := strings.Index(line, header); i >= 0 {
+					line = line[i+len(header):]
+				}
+				// Fall through to state-1 parsing on the remainder.
+			} else {
+				continue
 			}
+			fallthrough
 		case 1:
-			if strings.Contains(line, ")") {
-				state = 2
-			}
-			// Strip comments and whitespace, then parse one entry per token.
-			if i := strings.Index(line, "#"); i >= 0 {
-				line = line[:i]
-			}
+			closed := strings.Contains(line, ")")
 			line = strings.TrimSpace(line)
 			line = strings.TrimSuffix(line, ")")
 			line = strings.TrimSpace(line)
@@ -331,6 +446,9 @@ func parseBashArray(path, name string) ([]string, error) {
 				}
 				tok = strings.Trim(tok, `"'`)
 				out = append(out, tok)
+			}
+			if closed {
+				state = 2
 			}
 		}
 		if state == 2 {

--- a/pkg/composer/imported_validate.go
+++ b/pkg/composer/imported_validate.go
@@ -141,6 +141,132 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 	return issues
 }
 
+// ProvenanceOpts carries the per-compose context needed by
+// ValidateProvenanceConflicts. ImportProjectID is the logical claim/owner ID
+// used cross-cloud (decision #46 in docs/managed-resource-tiers.md);
+// ImportSessionID is unused for the conflict check itself but lives on the
+// struct so the same opts value can be threaded into the injector.
+type ProvenanceOpts struct {
+	ImportProjectID string
+	ImportSessionID string
+}
+
+// ValidateProvenanceConflicts enforces cross-session mutual exclusion on
+// imported resources. Issues:
+//
+//   - imported_resource_provenance_skipped_no_project_id — emitted once when
+//     opts.ImportProjectID is empty but irs is non-empty. Indicates the
+//     composer is running in pre-#153 backwards-compatible mode and no
+//     provenance tags will be written.
+//   - imported_resource_provenance_conflict — the resource already advertises
+//     a different InsideOutImportProject / insideout-import-project value and
+//     no ForceTakeover is supplied. Hard-fails per design decision #45.
+//   - imported_resource_force_takeover_invalid — ForceTakeover is set but
+//     missing required audit metadata, or its PreviousOwner does not match
+//     the value observed on the resource.
+//
+// Resources that do not support tags/labels (taggable returns false) are
+// skipped silently — they fall back to weak-lock semantics, which rely on
+// ResourceIdentity uniqueness already enforced by
+// imported_resource_address_collision in ValidateImportedResources.
+func ValidateProvenanceConflicts(cloud string, irs []imported.ImportedResource, opts ProvenanceOpts) []ValidationIssue {
+	if len(irs) == 0 {
+		return nil
+	}
+	want := strings.ToLower(strings.TrimSpace(cloud))
+	var issues []ValidationIssue
+
+	if strings.TrimSpace(opts.ImportProjectID) == "" {
+		// Backwards-compat path: surface a single advisory issue so the
+		// caller knows provenance is disabled, then skip per-resource
+		// checks.
+		hasEligible := false
+		for _, ir := range irs {
+			got := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
+			if got != "aws" && got != "gcp" {
+				continue
+			}
+			if want != "" && got != want {
+				continue
+			}
+			if !isImportedTier(ir.Tier) {
+				continue
+			}
+			hasEligible = true
+			break
+		}
+		if hasEligible {
+			issues = append(issues, ValidationIssue{
+				Field:      "imported",
+				Code:       "imported_resource_provenance_skipped_no_project_id",
+				Reason:     "ComposeStackOpts.ImportProjectID is empty; provenance tags will not be emitted and cross-session mutual exclusion is disabled",
+				Suggestion: "set opts.ImportProjectID to the InsideOut stack/session import-project identifier (issue #153)",
+			})
+		}
+		return issues
+	}
+
+	for i, ir := range irs {
+		got := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
+		if got != "aws" && got != "gcp" {
+			continue
+		}
+		if want != "" && got != want {
+			continue
+		}
+		if !isImportedTier(ir.Tier) {
+			continue
+		}
+		// Resources without tag/label support are weak-locked; mutual
+		// exclusion falls back to address-uniqueness only.
+		if _, ok := taggable(ir); !ok {
+			continue
+		}
+
+		observed, hasOwner := existingProvenanceProject(ir)
+		if !hasOwner {
+			continue
+		}
+		if observed == opts.ImportProjectID {
+			continue
+		}
+
+		field := importedField(ir, i)
+		if ir.ForceTakeover == nil {
+			issues = append(issues, ValidationIssue{
+				Field:   field,
+				Value:   observed,
+				Code:    "imported_resource_provenance_conflict",
+				Reason:  fmt.Sprintf("imported resource %q is already claimed by import project %q; refusing to overwrite without an audited force-takeover", ir.Identity.Address, observed),
+				Suggestion: "set ImportedResource.ForceTakeover with actor, reason, previous_owner, and approved_at to override (audited)",
+			})
+			continue
+		}
+		ft := ir.ForceTakeover
+		if strings.TrimSpace(ft.Actor) == "" || strings.TrimSpace(ft.Reason) == "" || strings.TrimSpace(ft.PreviousOwner) == "" || ft.ApprovedAt.IsZero() {
+			issues = append(issues, ValidationIssue{
+				Field:      field,
+				Value:      observed,
+				Code:       "imported_resource_force_takeover_invalid",
+				Reason:     "ForceTakeover requires non-empty Actor, Reason, PreviousOwner, and a non-zero ApprovedAt timestamp",
+				Suggestion: "populate every audit field on ImportedResource.ForceTakeover before retrying",
+			})
+			continue
+		}
+		if ft.PreviousOwner != observed {
+			issues = append(issues, ValidationIssue{
+				Field:      field,
+				Value:      observed,
+				Code:       "imported_resource_force_takeover_invalid",
+				Reason:     fmt.Sprintf("ForceTakeover.PreviousOwner %q does not match the observed import project %q on the resource", ft.PreviousOwner, observed),
+				Suggestion: "ensure ForceTakeover.PreviousOwner matches the InsideOutImportProject value currently on the cloud resource",
+			})
+		}
+	}
+
+	return issues
+}
+
 // isImportedTier reports whether t is a tier that the composer emits as flat
 // imported HCL (or, for ImportedMissing, would emit once Remediation is set).
 func isImportedTier(t imported.Tier) bool {

--- a/pkg/composer/imported_validate.go
+++ b/pkg/composer/imported_validate.go
@@ -143,12 +143,11 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 
 // ProvenanceOpts carries the per-compose context needed by
 // ValidateProvenanceConflicts. ImportProjectID is the logical claim/owner ID
-// used cross-cloud (decision #46 in docs/managed-resource-tiers.md);
-// ImportSessionID is unused for the conflict check itself but lives on the
-// struct so the same opts value can be threaded into the injector.
+// used cross-cloud (decision #46 in docs/managed-resource-tiers.md). The
+// session ID is not relevant to the conflict check (sessions are advisory)
+// and is omitted from this struct deliberately.
 type ProvenanceOpts struct {
 	ImportProjectID string
-	ImportSessionID string
 }
 
 // ValidateProvenanceConflicts enforces cross-session mutual exclusion on

--- a/pkg/composer/imported_validate_test.go
+++ b/pkg/composer/imported_validate_test.go
@@ -401,6 +401,17 @@ func issueCodes(issues []ValidationIssue) []string {
 	return out
 }
 
+// countCode returns the number of issues whose Code equals code.
+func countCode(issues []ValidationIssue, code string) int {
+	n := 0
+	for _, i := range issues {
+		if i.Code == code {
+			n++
+		}
+	}
+	return n
+}
+
 func issueFields(issues []ValidationIssue) []string {
 	out := make([]string, 0, len(issues))
 	for _, i := range issues {

--- a/pkg/composer/imported_validate_test.go
+++ b/pkg/composer/imported_validate_test.go
@@ -210,6 +210,189 @@ func TestValidateImportedResources_FieldFormat(t *testing.T) {
 	assert.Contains(t, fields, "imported.[1]")
 }
 
+func TestValidateProvenanceConflicts_Empty(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, ValidateProvenanceConflicts("aws", nil, ProvenanceOpts{ImportProjectID: "io-1"}))
+	assert.Nil(t, ValidateProvenanceConflicts("aws", []imported.ImportedResource{}, ProvenanceOpts{ImportProjectID: "io-1"}))
+}
+
+func TestValidateProvenanceConflicts_NoProjectIDAdvisory(t *testing.T) {
+	t.Parallel()
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "x"},
+			Tier:     imported.TierImportedFlat,
+		},
+	}
+	issues := ValidateProvenanceConflicts("aws", irs, ProvenanceOpts{})
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_provenance_skipped_no_project_id", issues[0].Code)
+}
+
+func TestValidateProvenanceConflicts_AbsentTagOK(t *testing.T) {
+	t.Parallel()
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "x"},
+			Tier:     imported.TierImportedFlat,
+		},
+	}
+	issues := ValidateProvenanceConflicts("aws", irs, ProvenanceOpts{ImportProjectID: "io-1"})
+	assert.Empty(t, issues)
+}
+
+func TestValidateProvenanceConflicts_MatchingTagOK(t *testing.T) {
+	t.Parallel()
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.t", ImportID: "t"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"name": "t",
+				"tags": map[string]any{
+					"InsideOutImportProject": "io-1",
+				},
+			},
+		},
+	}
+	issues := ValidateProvenanceConflicts("aws", irs, ProvenanceOpts{ImportProjectID: "io-1"})
+	assert.Empty(t, issues)
+}
+
+func TestValidateProvenanceConflicts_DifferentTagFails(t *testing.T) {
+	t.Parallel()
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.t", ImportID: "t"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"name": "t",
+				"tags": map[string]any{
+					"InsideOutImportProject": "io-other",
+				},
+			},
+		},
+	}
+	issues := ValidateProvenanceConflicts("aws", irs, ProvenanceOpts{ImportProjectID: "io-1"})
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_provenance_conflict", issues[0].Code)
+	assert.Equal(t, "io-other", issues[0].Value)
+	assert.Equal(t, "imported.aws_dynamodb_table.t", issues[0].Field)
+}
+
+func TestValidateProvenanceConflicts_ForceTakeoverValid(t *testing.T) {
+	t.Parallel()
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.t", ImportID: "t"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"name": "t",
+				"tags": map[string]any{
+					"InsideOutImportProject": "io-other",
+				},
+			},
+			ForceTakeover: &imported.ForceTakeover{
+				Actor:         "sam@luthersystems.com",
+				Reason:        "merging environments after #173 ramp",
+				PreviousOwner: "io-other",
+				ApprovedAt:    fixedTime(),
+			},
+		},
+	}
+	issues := ValidateProvenanceConflicts("aws", irs, ProvenanceOpts{ImportProjectID: "io-1"})
+	assert.Empty(t, issues, "valid ForceTakeover suppresses the conflict")
+}
+
+func TestValidateProvenanceConflicts_ForceTakeoverIncomplete(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		ft   imported.ForceTakeover
+	}{
+		{"missing Actor", imported.ForceTakeover{Reason: "r", PreviousOwner: "io-other", ApprovedAt: fixedTime()}},
+		{"missing Reason", imported.ForceTakeover{Actor: "a", PreviousOwner: "io-other", ApprovedAt: fixedTime()}},
+		{"missing PreviousOwner", imported.ForceTakeover{Actor: "a", Reason: "r", ApprovedAt: fixedTime()}},
+		{"zero ApprovedAt", imported.ForceTakeover{Actor: "a", Reason: "r", PreviousOwner: "io-other"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ft := tc.ft
+			irs := []imported.ImportedResource{
+				{
+					Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.t", ImportID: "t"},
+					Tier:     imported.TierImportedFlat,
+					Attributes: map[string]any{
+						"name": "t",
+						"tags": map[string]any{"InsideOutImportProject": "io-other"},
+					},
+					ForceTakeover: &ft,
+				},
+			}
+			issues := ValidateProvenanceConflicts("aws", irs, ProvenanceOpts{ImportProjectID: "io-1"})
+			require.Len(t, issues, 1)
+			assert.Equal(t, "imported_resource_force_takeover_invalid", issues[0].Code)
+		})
+	}
+}
+
+func TestValidateProvenanceConflicts_ForceTakeoverWrongPreviousOwner(t *testing.T) {
+	t.Parallel()
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.t", ImportID: "t"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"name": "t",
+				"tags": map[string]any{"InsideOutImportProject": "io-other"},
+			},
+			ForceTakeover: &imported.ForceTakeover{
+				Actor:         "a",
+				Reason:        "r",
+				PreviousOwner: "io-someone-else", // mismatch with observed
+				ApprovedAt:    fixedTime(),
+			},
+		},
+	}
+	issues := ValidateProvenanceConflicts("aws", irs, ProvenanceOpts{ImportProjectID: "io-1"})
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_force_takeover_invalid", issues[0].Code)
+}
+
+func TestValidateProvenanceConflicts_UntaggableSkipsCheck(t *testing.T) {
+	t.Parallel()
+	// google_compute_network has no Labels field — weak-lock fallback. Even
+	// if Attributes carry a labels map (which the schema would reject), the
+	// validator must not raise a conflict.
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_compute_network", Address: "google_compute_network.vpc", ImportID: "vpc"},
+			Tier:     imported.TierImportedFlat,
+			Attributes: map[string]any{
+				"name":   "vpc",
+				"labels": map[string]any{"insideout-import-project": "io-other"},
+			},
+		},
+	}
+	issues := ValidateProvenanceConflicts("gcp", irs, ProvenanceOpts{ImportProjectID: "io-1"})
+	assert.Empty(t, issues, "weak-lock resources must skip mutual-exclusion check")
+}
+
+func TestValidateProvenanceConflicts_GCPTagFromTypedAttrs(t *testing.T) {
+	t.Parallel()
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_storage_bucket", Address: "google_storage_bucket.b", ImportID: "b"},
+			Tier:     imported.TierImportedFlat,
+			Attrs:    []byte(`{"Name":{"Literal":"b"},"Labels":{"insideout-import-project":{"Literal":"io-other"}}}`),
+		},
+	}
+	issues := ValidateProvenanceConflicts("gcp", irs, ProvenanceOpts{ImportProjectID: "io-1"})
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_provenance_conflict", issues[0].Code)
+	assert.Equal(t, "io-other", issues[0].Value)
+}
+
 func issueCodes(issues []ValidationIssue) []string {
 	out := make([]string, 0, len(issues))
 	for _, i := range issues {


### PR DESCRIPTION
## Summary

- The composer now stamps namespaced provenance tags/labels on imported resources so two InsideOut sessions cannot silently claim the same cloud resource.
- A new pre-emission validator (`ValidateProvenanceConflicts`) refuses cross-session ownership conflicts and recognizes an audited `ForceTakeover` override.
- Untaggable resources (e.g. `google_compute_network`, the `NON_TAGGABLE_AWS` block-list) fall through to weak-lock semantics, where mutual exclusion relies on the existing `imported_resource_address_collision` check.

Implements work package #153 in epic #143 (Imported Resource Model — Phase 2). Closes #153.

## What changes

- `ImportedResource` gains `ForceTakeover` (audit metadata: actor / reason / previous_owner / approved_at, UTC-enforcing `MarshalJSON`) and `WeakLocked bool` set by the injector.
- `ComposeStackOpts` / `ComposeSingleOpts` gain `ImportProjectID` and `ImportSessionID`; empty `ImportProjectID` disables provenance entirely (backwards-compat with pre-#153 callers) and surfaces a single advisory issue `imported_resource_provenance_skipped_no_project_id` so the caller knows.
- New `pkg/composer/imported_provenance.go`:
  - `taggable(ir)` — Layer 1 schema + lint-script-derived allowlists (`untaggableAWS`, `labelableGCP`) decide whether to inject.
  - `provenanceKeysFor(cloud, ...)` — emits `InsideOutImport*` (AWS) or `insideout-import-*` (GCP) entries; session entry is omitted when `ImportSessionID` is blank.
  - `gcpLabelTimestamp` — encodes RFC3339 to satisfy the GCP label charset (`2026-04-29t14-30-00z`).
  - `injectProvenance(body, ir, ...)` — parses the body via `hclwrite`, rewrites the tags/labels attribute as `merge({provenance}, <existing>)`. Marks `WeakLocked` and returns the body unchanged when the resource type does not support tags/labels.
- `EmitImportedTF` takes a new `EmitImportedOpts` struct and threads provenance into per-resource body emission.
- `ValidateProvenanceConflicts` emits three structured `ValidationIssue` codes:
  - `imported_resource_provenance_skipped_no_project_id`
  - `imported_resource_provenance_conflict`
  - `imported_resource_force_takeover_invalid`
- `composeStackImpl` runs the new validator after `ValidateImportedResources` and threads the opts into `EmitImportedTF`.

## HCL shape

```hcl
resource \"aws_sqs_queue\" \"q\" {
  provider = aws.imported
  name     = \"q\"
  tags = merge(
    {
      InsideOutImportProject = \"io-stack-1\"
      InsideOutImportSession = \"sess-9\"
      InsideOutImported      = \"true\"
      InsideOutImportedAt    = \"2026-04-29T14:30:00Z\"
    },
    { Owner = \"team-payments\" },
  )
}
```

GCP mirrors this with `labels = merge({...}, {...})` using lowercase hyphenated keys (`insideout-import-project`, etc.) and the GCP-charset-safe timestamp (`2026-04-29t14-30-00z`).

## Allowlist drift guard

`TestUntaggableAllowlistsMatchLintScripts` parses `tests/lint-project-tag.sh::NON_TAGGABLE_AWS` and `tests/lint-project-label.sh::LABEL_CAPABLE_GCP` at test time and asserts the Go-side maps match. Drift fails fast.

## Test plan

- [x] `go test ./pkg/composer/... -short`
- [x] `bash tests/lint-project-tag.sh` and `lint-project-label.sh` (PASS)
- [x] New tests:
  - `TestInjectProvenance_AWSTypedAttrsExisting`, `_GCPTypedAttrsExisting`, `_GCPUntaggableType`, `_NoExistingTags`, `_OpaqueAttributes`, `_Idempotent`
  - `TestTaggable_RegisteredTypes`, `_AllowlistFallback`
  - `TestProvenanceKeysFor_{AWS,GCP,OmitSession}`, `TestGCPLabelTimestamp`
  - `TestValidateProvenanceConflicts_{Empty,NoProjectIDAdvisory,AbsentTagOK,MatchingTagOK,DifferentTagFails,ForceTakeoverValid,ForceTakeoverIncomplete,ForceTakeoverWrongPreviousOwner,UntaggableSkipsCheck,GCPTagFromTypedAttrs}`
  - `TestEmitImportedTF_{ProvenanceTags,ProvenanceDisabled}`
  - `TestComposeStackWithIssues_{ProvenanceTags,ProvenanceConflict,ProvenanceSkippedAdvisory}`
  - `TestUntaggableAllowlistsMatchLintScripts`
- [x] Existing emit tests still pass with empty `EmitImportedOpts{}` (default behavior preserved).

## Out of scope

- Cross-repo Reliable inspector + Riley import-result hookup (#152) — separate ticket.
- Resource-diff support for provenance changes (#151) — separate ticket.
- Server-side authorization (#149) — separate ticket; this PR only handles the mutual-exclusion gate, not the broader edit-policy enforcement.