### PR TITLE
feat(composer): validateImportedResources server-side authorization (#149)

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -605,6 +605,7 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// (issue #148). This must happen before generateProvidersTF so that
 	// importedClouds tells the provider emitter which alias to declare.
 	issues = append(issues, ValidateImportedResources(cloud, opts.Imported)...)
+	issues = append(issues, ValidateImportedResourceAuthorization(cloud, opts.Imported)...)
 	provOpts := ProvenanceOpts{ImportProjectID: opts.ImportProjectID}
 	issues = append(issues, ValidateProvenanceConflicts(cloud, opts.Imported, provOpts)...)
 	emitOpts := EmitImportedOpts{

--- a/pkg/composer/imported/resource.go
+++ b/pkg/composer/imported/resource.go
@@ -116,11 +116,18 @@ func (f ForceTakeover) MarshalJSON() ([]byte, error) {
 // FieldEdit is audit/conflict metadata for one model-side edit to a single
 // attribute. EditedAt is always serialized as RFC3339Nano UTC regardless of
 // the caller-supplied time.Location; see MarshalJSON.
+//
+// Approval is the optional plan-tied operator confirmation required for edits
+// against fields whose curated FieldPolicy is Edit=RequiresApproval, or whose
+// ChangeRiskPolicy implies a destroy/replace plan (MayReplace, AlwaysReplace,
+// Unknown). Absent for the common Edit=ChatSafe / ChangeInPlace path. See
+// docs/managed-resource-tiers.md decision #42.
 type FieldEdit struct {
-	Source   Source    `json:"source,omitempty"`
-	EditedAt time.Time `json:"edited_at"`
-	OldValue any       `json:"old_value,omitempty"`
-	NewValue any       `json:"new_value,omitempty"`
+	Source   Source             `json:"source,omitempty"`
+	EditedAt time.Time          `json:"edited_at"`
+	OldValue any                `json:"old_value,omitempty"`
+	NewValue any                `json:"new_value,omitempty"`
+	Approval *FieldEditApproval `json:"approval,omitempty"`
 }
 
 // MarshalJSON enforces RFC3339Nano UTC on EditedAt. Without this, a caller
@@ -133,6 +140,33 @@ func (f FieldEdit) MarshalJSON() ([]byte, error) {
 		f.EditedAt = f.EditedAt.UTC()
 	}
 	return json.Marshal(alias(f))
+}
+
+// FieldEditApproval is the plan-tied operator confirmation that authorizes a
+// FieldEdit against an Edit=RequiresApproval policy or a ChangeRisk in
+// {MayReplace, AlwaysReplace, Unknown}. All four required fields must be
+// populated; partial approvals are rejected by the authorization validator
+// (imported_resource_field_edit_approval_invalid). PlanHash binds the
+// approval to a specific Terraform plan run so an approval cannot be
+// silently reused against a different plan output.
+//
+// ApprovedAt is always serialized as RFC3339Nano UTC regardless of the
+// caller-supplied time.Location; see MarshalJSON.
+type FieldEditApproval struct {
+	Approver   string    `json:"approver"`
+	ApprovedAt time.Time `json:"approved_at"`
+	PlanHash   string    `json:"plan_hash"`
+	Note       string    `json:"note,omitempty"`
+}
+
+// MarshalJSON enforces RFC3339Nano UTC on ApprovedAt. Mirrors FieldEdit's
+// MarshalJSON.
+func (a FieldEditApproval) MarshalJSON() ([]byte, error) {
+	type alias FieldEditApproval
+	if !a.ApprovedAt.IsZero() {
+		a.ApprovedAt = a.ApprovedAt.UTC()
+	}
+	return json.Marshal(alias(a))
 }
 
 // PresetMatch is a forward-declared graduation hint. It is populated by the

--- a/pkg/composer/imported_authz_validate.go
+++ b/pkg/composer/imported_authz_validate.go
@@ -1,0 +1,349 @@
+package composer
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+)
+
+// ValidateImportedResourceAuthorization enforces the Layer 2 field policy on
+// model-side write paths to imported resources (chat, API, MCP). It is the
+// Phase 2 server-side write authorization sibling of ValidateImportedResources
+// (which carries Phase 1 structural checks). See
+// docs/managed-resource-tiers.md "Editor authority" section and decisions
+// #7, #8, #14, #19, #30, #31, #33, #36, #37, #42, and #43.
+//
+// For each FieldEdit on an imported resource it produces at most one issue
+// per (resource, path) with a snake_case Code drawn from:
+//
+//   - imported_resource_field_edit_no_policy — the resource type has no
+//     Layer 2 policy registered; per decision #43, every imported field is
+//     hidden / system-owned by default and edits to unregistered types are
+//     rejected.
+//   - imported_resource_field_edit_unknown_path — the path does not resolve
+//     against the Layer 1 generated struct or any registered JSON projection
+//     for the resource type (decision #33).
+//   - imported_resource_field_edit_no_policy_for_path — the path resolves
+//     but is absent from the curated map; default deny per decision #43.
+//   - imported_resource_field_edit_forbidden — Edit=Never. Identity fields
+//     (arn, name, region) live here.
+//   - imported_resource_field_edit_system_only — Edit=SystemOnly. Tags,
+//     labels, and provenance attributes are written by the importer/composer
+//     only.
+//   - imported_resource_field_edit_relationship_only — Edit=RelationshipOnly.
+//     Wiring fields (kms_key_id, redrive_policy.deadLetterTargetArn) cannot
+//     be scalar-edited in Phase 2 (decisions #30, #31).
+//   - imported_resource_field_edit_requires_approval — Edit=RequiresApproval
+//     without an Approval audit record on the FieldEdit.
+//   - imported_resource_field_edit_approval_invalid — Approval is set but
+//     missing one of Approver, ApprovedAt, or PlanHash.
+//   - imported_resource_field_edit_replacement_risk_unconfirmed —
+//     ChangeRisk in {MayReplace, AlwaysReplace, Unknown} without an Approval
+//     record attesting plan review (decision #42; Unknown follows the
+//     MayReplace workflow).
+//   - imported_resource_field_edit_reimport_conflict — the resource's
+//     current desired Attributes value at this path no longer matches the
+//     FieldEdit's NewValue. A re-import or other writer overwrote the
+//     pending edit (decision #19); the operator must accept cloud, keep the
+//     edit, or abort.
+//
+// Sensitive field values (Sensitivity=Sensitive or Sensitivity=Redacted) are
+// redacted to "***" in any ValidationIssue.Value emitted by this function so
+// raw sensitive data cannot escape into validation errors, diffs, or chat
+// correction prompts (decision #36).
+//
+// Resources whose tier is not an imported tier (ComposerNative, External*) or
+// whose Identity.Cloud does not match the compose cloud are skipped silently;
+// those mismatches are surfaced by ValidateImportedResources, not here.
+//
+// The function performs no I/O, has no side effects, and returns a stable
+// per-input slice. Output is fed through dedupeAndSortIssues by ValidateAll
+// like every other validator.
+func ValidateImportedResourceAuthorization(cloud string, irs []imported.ImportedResource) []ValidationIssue {
+	if len(irs) == 0 {
+		return nil
+	}
+	want := strings.ToLower(strings.TrimSpace(cloud))
+	var issues []ValidationIssue
+
+	for i, ir := range irs {
+		if !isImportedTier(ir.Tier) {
+			continue
+		}
+		got := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
+		if got != "aws" && got != "gcp" {
+			continue
+		}
+		if want != "" && got != want {
+			continue
+		}
+		if len(ir.FieldEdits) == 0 {
+			continue
+		}
+
+		polMap, hasPol := policy.Lookup(ir.Identity.Type)
+		field := importedField(ir, i)
+
+		for _, path := range sortedFieldEditPaths(ir.FieldEdits) {
+			edit := ir.FieldEdits[path]
+			issueField := field + "." + path
+
+			if !hasPol {
+				issues = append(issues, ValidationIssue{
+					Field:  issueField,
+					Code:   "imported_resource_field_edit_no_policy",
+					Reason: fmt.Sprintf("imported resource type %q has no Layer 2 field policy registered; edits default to hidden / system-owned per decision #43", ir.Identity.Type),
+				})
+				continue
+			}
+
+			if err := policy.ResolvePath(ir.Identity.Type, path); err != nil {
+				issues = append(issues, ValidationIssue{
+					Field:  issueField,
+					Code:   "imported_resource_field_edit_unknown_path",
+					Reason: fmt.Sprintf("imported resource path %q does not resolve against %s: %s", path, ir.Identity.Type, err.Error()),
+				})
+				continue
+			}
+
+			entry, hasEntry := polMap[path]
+			if !hasEntry {
+				issues = append(issues, ValidationIssue{
+					Field:  issueField,
+					Code:   "imported_resource_field_edit_no_policy_for_path",
+					Reason: fmt.Sprintf("imported resource path %q has no curated FieldPolicy on %s; defaults to hidden / system-owned per decision #43", path, ir.Identity.Type),
+				})
+				continue
+			}
+
+			if iss, ok := evaluateEditPolicy(issueField, ir.Identity.Type, path, edit, entry); ok {
+				issues = append(issues, iss)
+				continue
+			}
+
+			if iss, ok := evaluateApproval(issueField, path, edit, entry); ok {
+				issues = append(issues, iss)
+				continue
+			}
+
+			if iss, ok := evaluateChangeRisk(issueField, path, edit, entry); ok {
+				issues = append(issues, iss)
+				continue
+			}
+
+			if iss, ok := evaluateReimportConflict(issueField, path, edit, ir); ok {
+				issues = append(issues, iss)
+				continue
+			}
+		}
+	}
+
+	return issues
+}
+
+// evaluateEditPolicy returns a non-empty issue when the FieldEdit's target
+// policy forbids the write outright (Never, SystemOnly, RelationshipOnly,
+// RequiresApproval-without-approval, or an unrecognized EditPolicy value).
+func evaluateEditPolicy(issueField, tfType, path string, edit imported.FieldEdit, entry policy.FieldPolicy) (ValidationIssue, bool) {
+	redacted := redactValue(entry, edit.NewValue)
+	switch entry.Edit {
+	case policy.EditNever:
+		reason := fmt.Sprintf("imported resource path %q is Edit=Never on %s; field is read-only from every model write path", path, tfType)
+		if entry.Role == policy.RoleIdentity {
+			reason = fmt.Sprintf("imported resource path %q is an identity field (Edit=Never) on %s; identity is immutable from chat/API/MCP", path, tfType)
+		}
+		return ValidationIssue{
+			Field:  issueField,
+			Value:  redacted,
+			Code:   "imported_resource_field_edit_forbidden",
+			Reason: reason,
+		}, true
+	case policy.EditSystemOnly:
+		return ValidationIssue{
+			Field:  issueField,
+			Value:  redacted,
+			Code:   "imported_resource_field_edit_system_only",
+			Reason: fmt.Sprintf("imported resource path %q is Edit=SystemOnly on %s; only the importer/composer writes here (tags, labels, provenance)", path, tfType),
+		}, true
+	case policy.EditRelationshipOnly:
+		return ValidationIssue{
+			Field:      issueField,
+			Value:      redacted,
+			Code:       "imported_resource_field_edit_relationship_only",
+			Reason:     fmt.Sprintf("imported resource path %q is Edit=RelationshipOnly on %s; raw wiring values are owned by the graph, not scalar-editable in Phase 2 (decision #30)", path, tfType),
+			Suggestion: "use a future graph-editing operation to change the relationship",
+		}, true
+	case policy.EditChatSafe, policy.EditRequiresApproval:
+		return ValidationIssue{}, false
+	default:
+		return ValidationIssue{
+			Field:  issueField,
+			Value:  redacted,
+			Code:   "imported_resource_field_edit_forbidden",
+			Reason: fmt.Sprintf("imported resource path %q on %s has unknown EditPolicy %q", path, tfType, string(entry.Edit)),
+		}, true
+	}
+}
+
+// evaluateApproval returns an issue when Edit=RequiresApproval but the
+// FieldEdit lacks a complete approval audit record. Edits with non-approval
+// EditPolicy values fall through (their gates run elsewhere).
+func evaluateApproval(issueField, path string, edit imported.FieldEdit, entry policy.FieldPolicy) (ValidationIssue, bool) {
+	if entry.Edit != policy.EditRequiresApproval {
+		return ValidationIssue{}, false
+	}
+	if edit.Approval == nil {
+		return ValidationIssue{
+			Field:      issueField,
+			Value:      redactValue(entry, edit.NewValue),
+			Code:       "imported_resource_field_edit_requires_approval",
+			Reason:     fmt.Sprintf("imported resource path %q is Edit=RequiresApproval; FieldEdit must carry plan-tied Approval audit metadata before apply (decision #42)", path),
+			Suggestion: "set FieldEdit.Approval with approver, approved_at, and plan_hash bound to the reviewed plan",
+		}, true
+	}
+	if iss, ok := approvalCompletenessIssue(issueField, path, edit.Approval); ok {
+		return iss, true
+	}
+	return ValidationIssue{}, false
+}
+
+// evaluateChangeRisk returns an issue when the field's ChangeRisk implies a
+// destroy/replace plan and the FieldEdit lacks a complete approval record
+// (per decision #42, Unknown follows the MayReplace workflow). InPlace and
+// the empty default fall through.
+func evaluateChangeRisk(issueField, path string, edit imported.FieldEdit, entry policy.FieldPolicy) (ValidationIssue, bool) {
+	if !requiresPlanConfirmation(entry.ChangeRisk) {
+		return ValidationIssue{}, false
+	}
+	if edit.Approval == nil {
+		return ValidationIssue{
+			Field:      issueField,
+			Value:      redactValue(entry, edit.NewValue),
+			Code:       "imported_resource_field_edit_replacement_risk_unconfirmed",
+			Reason:     fmt.Sprintf("imported resource path %q has ChangeRisk=%s; concrete Terraform plan review and explicit operator confirmation required before apply (decision #42)", path, displayChangeRisk(entry.ChangeRisk)),
+			Suggestion: "review the plan, then set FieldEdit.Approval with the reviewed plan_hash",
+		}, true
+	}
+	if iss, ok := approvalCompletenessIssue(issueField, path, edit.Approval); ok {
+		return iss, true
+	}
+	return ValidationIssue{}, false
+}
+
+// approvalCompletenessIssue checks the four required Approval fields and
+// returns imported_resource_field_edit_approval_invalid if any are missing.
+// PlanHash is required so an approval cannot be silently reused across plans.
+func approvalCompletenessIssue(issueField, path string, ap *imported.FieldEditApproval) (ValidationIssue, bool) {
+	if ap == nil {
+		return ValidationIssue{}, false
+	}
+	missing := []string{}
+	if strings.TrimSpace(ap.Approver) == "" {
+		missing = append(missing, "approver")
+	}
+	if ap.ApprovedAt.IsZero() {
+		missing = append(missing, "approved_at")
+	}
+	if strings.TrimSpace(ap.PlanHash) == "" {
+		missing = append(missing, "plan_hash")
+	}
+	if len(missing) == 0 {
+		return ValidationIssue{}, false
+	}
+	return ValidationIssue{
+		Field:      issueField,
+		Code:       "imported_resource_field_edit_approval_invalid",
+		Reason:     fmt.Sprintf("imported resource path %q FieldEdit.Approval is missing required field(s): %s", path, strings.Join(missing, ", ")),
+		Suggestion: "populate every required Approval field before retrying",
+	}, true
+}
+
+// evaluateReimportConflict checks whether the resource's desired Attributes
+// value at path still matches the FieldEdit's NewValue. A divergence means a
+// re-import (or other writer) clobbered the pending edit; per decision #19
+// the operator must explicitly resolve before apply. Returns no issue when
+// either side cannot be observed deterministically (nested paths, typed-only
+// Attrs, or absent OldValue/NewValue) — the structural Phase 1 validators and
+// Reliable's chat-stream loop carry the rest.
+func evaluateReimportConflict(issueField, path string, edit imported.FieldEdit, ir imported.ImportedResource) (ValidationIssue, bool) {
+	desired, ok := lookupTopLevelAttribute(ir.Attributes, path)
+	if !ok {
+		return ValidationIssue{}, false
+	}
+	if edit.NewValue == nil {
+		return ValidationIssue{}, false
+	}
+	if reflect.DeepEqual(desired, edit.NewValue) {
+		return ValidationIssue{}, false
+	}
+	return ValidationIssue{
+		Field:      issueField,
+		Code:       "imported_resource_field_edit_reimport_conflict",
+		Reason:     fmt.Sprintf("imported resource path %q has a pending FieldEdit but desired state diverged from FieldEdit.NewValue; a re-import or other writer overwrote the edit (decision #19)", path),
+		Suggestion: "operator must accept cloud, keep the edit, or abort",
+	}, true
+}
+
+// lookupTopLevelAttribute returns the value at path in attrs when the path
+// is a single segment with no dotted/bracketed sub-structure. Anything more
+// complex (nested objects, JSON projections) returns ok=false; conflict
+// detection conservatively no-ops on those paths in v1 rather than guessing.
+func lookupTopLevelAttribute(attrs map[string]any, path string) (any, bool) {
+	if len(attrs) == 0 {
+		return nil, false
+	}
+	if strings.ContainsAny(path, ".[") {
+		return nil, false
+	}
+	v, ok := attrs[path]
+	return v, ok
+}
+
+// requiresPlanConfirmation reports whether c demands a plan-tied operator
+// confirmation per decision #42. Only explicit MayReplace, AlwaysReplace, or
+// Unknown trigger the gate; the empty default is treated as implicit InPlace
+// per curator convention (every Phase 1 policy file leaves ChangeRisk unset
+// on safely-edited tuning fields). Decision #42's "Unknown follows MayReplace"
+// means an explicit Unknown gates apply, not that every uncurated field does.
+func requiresPlanConfirmation(c policy.ChangeRiskPolicy) bool {
+	switch c {
+	case policy.ChangeMayReplace, policy.ChangeAlwaysReplace, policy.ChangeUnknown:
+		return true
+	}
+	return false
+}
+
+// displayChangeRisk renders c for human-readable issue Reason strings.
+func displayChangeRisk(c policy.ChangeRiskPolicy) string {
+	return string(c)
+}
+
+// redactValue renders v for ValidationIssue.Value, replacing anything routed
+// through a Sensitive or Redacted policy with "***" so raw sensitive data
+// never escapes into errors, diffs, or chat correction prompts (decision #36).
+func redactValue(p policy.FieldPolicy, v any) string {
+	if v == nil {
+		return ""
+	}
+	switch p.Sensitivity {
+	case policy.SensitivitySensitive, policy.SensitivityRedacted:
+		return "***"
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+// sortedFieldEditPaths returns the keys of edits sorted lexicographically so
+// the per-FieldEdit issue order is stable across runs (Go map iteration is
+// otherwise randomized).
+func sortedFieldEditPaths(edits map[string]imported.FieldEdit) []string {
+	paths := make([]string, 0, len(edits))
+	for p := range edits {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	return paths
+}

--- a/pkg/composer/imported_authz_validate.go
+++ b/pkg/composer/imported_authz_validate.go
@@ -101,17 +101,21 @@ func ValidateImportedResourceAuthorization(cloud string, irs []imported.Imported
 				continue
 			}
 
-			if err := policy.ResolvePath(ir.Identity.Type, path); err != nil {
-				issues = append(issues, ValidationIssue{
-					Field:  issueField,
-					Code:   "imported_resource_field_edit_unknown_path",
-					Reason: fmt.Sprintf("imported resource path %q does not resolve against %s: %s", path, ir.Identity.Type, err.Error()),
-				})
-				continue
-			}
-
+			// Curated paths short-circuit the reflective ResolvePath walk:
+			// presence in the policy map implies resolvability (the lint
+			// rejects unresolvable curated paths). Only run ResolvePath to
+			// disambiguate "unknown path" vs "uncurated path" for paths
+			// the curator hasn't listed.
 			entry, hasEntry := polMap[path]
 			if !hasEntry {
+				if err := policy.ResolvePath(ir.Identity.Type, path); err != nil {
+					issues = append(issues, ValidationIssue{
+						Field:  issueField,
+						Code:   "imported_resource_field_edit_unknown_path",
+						Reason: fmt.Sprintf("imported resource path %q does not resolve against %s: %s", path, ir.Identity.Type, err.Error()),
+					})
+					continue
+				}
 				issues = append(issues, ValidationIssue{
 					Field:  issueField,
 					Code:   "imported_resource_field_edit_no_policy_for_path",

--- a/pkg/composer/imported_authz_validate_test.go
+++ b/pkg/composer/imported_authz_validate_test.go
@@ -59,6 +59,96 @@ func TestValidateImportedResourceAuthorization_NonImportedTiersFiltered(t *testi
 	}
 }
 
+// TestValidateImportedResourceAuthorization_TierImportedMissingFiresAuthzGates
+// pins the current behavior for FieldEdits against a TierImportedMissing
+// resource: authorization gates DO fire (the structural validator reports
+// imported_resource_missing_remediation in parallel via ValidateImportedResources).
+// A future maintainer who decides ImportedMissing should skip authorization
+// must update this test together with the design doc.
+func TestValidateImportedResourceAuthorization_TierImportedMissingFiresAuthzGates(t *testing.T) {
+	t.Parallel()
+	// name is Edit=Never on aws_sqs_queue — a forbidden edit on a missing
+	// resource still produces the forbidden code. The operator sees both
+	// the missing-remediation issue (from the structural validator) AND
+	// the authorization issue (from this validator) so the error message
+	// is coherent: pick a remediation AND don't try to edit identity.
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedMissing,
+		FieldEdits: map[string]imported.FieldEdit{
+			"name": {Source: imported.SourceRiley, NewValue: "rename"},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_forbidden", issues[0].Code,
+		"TierImportedMissing must not silently bypass EditPolicy gates")
+}
+
+// TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPaths
+// pins the current Phase 2 v1 behavior: re-import conflict detection is
+// deliberately conservative and only checks top-level Attribute paths.
+// Dotted (environment.variables) and bracketed (lifecycle_rule[0]) paths
+// no-op the conflict gate to avoid speculating about JSON projections.
+//
+// If a future PR expands lookupTopLevelAttribute to handle nested paths
+// (e.g. via decodeJSONProjection from imported_diff.go), this test must be
+// updated alongside that change so the gap closure is visible.
+func TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPaths(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		path string
+	}{
+		// google_pubsub_subscription has push_config.attributes as a real
+		// curated path. Edit=RequiresApproval, so we supply a complete
+		// approval to bypass that gate; only the conflict gate could fire.
+		{"dotted JSON-projection path", "push_config.attributes"},
+	}
+	approval := &imported.FieldEditApproval{
+		Approver:   "ops@luthersystems.com",
+		ApprovedAt: time.Now(),
+		PlanHash:   "plan-nested",
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// FieldEdit.NewValue diverges from Attributes — would trip the
+			// conflict gate if it ran. The conservative no-op behavior
+			// means no issue surfaces.
+			irs := []imported.ImportedResource{{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "gcp",
+					Type:     "google_pubsub_subscription",
+					Address:  "google_pubsub_subscription.s",
+					ImportID: "s",
+				},
+				Tier: imported.TierImportedFlat,
+				Attributes: map[string]any{
+					"push_config": `{"attributes":{"x-goog-version":"old"}}`,
+				},
+				FieldEdits: map[string]imported.FieldEdit{
+					tc.path: {
+						Source:   imported.SourceRiley,
+						NewValue: "wholly-different",
+						Approval: approval,
+					},
+				},
+			}}
+			issues := ValidateImportedResourceAuthorization("gcp", irs)
+			for _, iss := range issues {
+				assert.NotEqual(t, "imported_resource_field_edit_reimport_conflict", iss.Code,
+					"nested paths currently no-op the conflict gate; if this changed, update TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPaths together with lookupTopLevelAttribute")
+			}
+		})
+	}
+}
+
 func TestValidateImportedResourceAuthorization_CloudMismatch(t *testing.T) {
 	t.Parallel()
 	// Compose cloud differs from the resource's cloud — the structural
@@ -248,6 +338,7 @@ func TestValidateImportedResourceAuthorization_RequiresApprovalIncomplete(t *tes
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ap := tc.ap
 			irs := []imported.ImportedResource{{
 				Identity: imported.ResourceIdentity{

--- a/pkg/composer/imported_authz_validate_test.go
+++ b/pkg/composer/imported_authz_validate_test.go
@@ -762,12 +762,17 @@ func firstUncuratedResolvablePath(tfType string, candidates []string) (string, b
 // premise so a future curator change surfaces as a clear premise failure
 // rather than a confusing test-body assertion drift.
 //
-// PR #151 (ResourceDiff) ships a same-named helper in imported_diff_test.go;
-// when both PRs land, whichever merges second hits a redeclaration error
-// and the duplicate must be deleted as part of that merge. Keeping the
-// names identical (rather than mechanically suffixing one) forces that
-// cleanup to happen rather than leaving two near-identical helpers in the
-// package.
+// PR #151 (ResourceDiff) ships a same-named helper in imported_diff_test.go.
+// Once both PRs merge, the package will contain two definitions of
+// requirePolicyEntry and `go test ./pkg/composer/...` fails to compile
+// with "requirePolicyEntry redeclared." (Note: the text-level git merge
+// itself succeeds — different files, no overlap — so this is NOT caught
+// by `git merge`; the second PR's CI catches it pre-merge only when
+// branch protection requires up-to-date-with-main.) The duplicate must
+// be deleted as part of that second merge. Tracked in #183 so the
+// cleanup doesn't get lost. Keeping the names identical (rather than
+// mechanically suffixing one) forces the consolidation rather than
+// leaving two near-identical helpers in the package permanently.
 func requirePolicyEntry(t *testing.T, tfType, path string, want policy.FieldPolicy) {
 	t.Helper()
 	m, ok := policy.Lookup(tfType)

--- a/pkg/composer/imported_authz_validate_test.go
+++ b/pkg/composer/imported_authz_validate_test.go
@@ -71,7 +71,7 @@ func TestValidateImportedResourceAuthorization_NonImportedTiersFiltered(t *testi
 // structural validator stopped reporting missing_remediation.
 func TestValidateImportedResourceAuthorization_TierImportedMissingFiresBothValidators(t *testing.T) {
 	t.Parallel()
-	requirePolicyEntryAuthz(t, "aws_sqs_queue", "name", policy.FieldPolicy{
+	requirePolicyEntry(t, "aws_sqs_queue", "name", policy.FieldPolicy{
 		Role: policy.RoleIdentity, Edit: policy.EditNever,
 	})
 	irs := []imported.ImportedResource{{
@@ -130,7 +130,15 @@ func TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPath
 			// If the curator removes or downgrades it, this test would
 			// silently pass for the wrong reason (the path would now route
 			// through no_policy_for_path instead of being authorized).
-			requirePolicyEntryAuthz(t, "google_pubsub_subscription", tc.path, policy.FieldPolicy{
+			//
+			// Sensitivity is intentionally NOT pinned here. The curator
+			// has push_config.attributes as Sensitivity=Redacted, but this
+			// test asserts no issue surfaces — so the redaction code path
+			// (which only formats ValidationIssue.Value) never runs.
+			// A curator flipping Sensitivity wouldn't change this test's
+			// outcome; pinning it would couple the premise to detail the
+			// test doesn't depend on.
+			requirePolicyEntry(t, "google_pubsub_subscription", tc.path, policy.FieldPolicy{
 				Edit: policy.EditRequiresApproval,
 			})
 
@@ -749,12 +757,18 @@ func firstUncuratedResolvablePath(tfType string, candidates []string) (string, b
 	return "", false
 }
 
-// requirePolicyEntryAuthz asserts that tfType has a curated FieldPolicy for
-// path matching the non-zero fields of want. Mirrors the same-named helper
-// in imported_diff_test.go (declared separately so the two test files don't
-// depend on each other's build order). Renamed _Authz to dodge the linker
-// collision when both test files are linked into the same package.
-func requirePolicyEntryAuthz(t *testing.T, tfType, path string, want policy.FieldPolicy) {
+// requirePolicyEntry asserts that tfType has a curated FieldPolicy for
+// path matching the non-zero fields of want. Tests use it to pin their
+// premise so a future curator change surfaces as a clear premise failure
+// rather than a confusing test-body assertion drift.
+//
+// PR #151 (ResourceDiff) ships a same-named helper in imported_diff_test.go;
+// when both PRs land, whichever merges second hits a redeclaration error
+// and the duplicate must be deleted as part of that merge. Keeping the
+// names identical (rather than mechanically suffixing one) forces that
+// cleanup to happen rather than leaving two near-identical helpers in the
+// package.
+func requirePolicyEntry(t *testing.T, tfType, path string, want policy.FieldPolicy) {
 	t.Helper()
 	m, ok := policy.Lookup(tfType)
 	require.True(t, ok, "test premise: %q must be a curated type", tfType)

--- a/pkg/composer/imported_authz_validate_test.go
+++ b/pkg/composer/imported_authz_validate_test.go
@@ -59,19 +59,21 @@ func TestValidateImportedResourceAuthorization_NonImportedTiersFiltered(t *testi
 	}
 }
 
-// TestValidateImportedResourceAuthorization_TierImportedMissingFiresAuthzGates
-// pins the current behavior for FieldEdits against a TierImportedMissing
-// resource: authorization gates DO fire (the structural validator reports
-// imported_resource_missing_remediation in parallel via ValidateImportedResources).
-// A future maintainer who decides ImportedMissing should skip authorization
-// must update this test together with the design doc.
-func TestValidateImportedResourceAuthorization_TierImportedMissingFiresAuthzGates(t *testing.T) {
+// TestValidateImportedResourceAuthorization_TierImportedMissingFiresBothValidators
+// pins the dual-issue behavior on TierImportedMissing resources with
+// FieldEdits: ValidateImportedResources reports missing_remediation AND
+// ValidateImportedResourceAuthorization reports the authz gate violation.
+// Both fire from one ValidateAll call so the operator sees a coherent
+// message ("pick a remediation AND don't try to edit identity"). A future
+// maintainer who wants ImportedMissing to skip authorization must update
+// both this test and the design doc — the previous formulation only ran
+// the authz validator and would not have caught a regression where the
+// structural validator stopped reporting missing_remediation.
+func TestValidateImportedResourceAuthorization_TierImportedMissingFiresBothValidators(t *testing.T) {
 	t.Parallel()
-	// name is Edit=Never on aws_sqs_queue — a forbidden edit on a missing
-	// resource still produces the forbidden code. The operator sees both
-	// the missing-remediation issue (from the structural validator) AND
-	// the authorization issue (from this validator) so the error message
-	// is coherent: pick a remediation AND don't try to edit identity.
+	requirePolicyEntryAuthz(t, "aws_sqs_queue", "name", policy.FieldPolicy{
+		Role: policy.RoleIdentity, Edit: policy.EditNever,
+	})
 	irs := []imported.ImportedResource{{
 		Identity: imported.ResourceIdentity{
 			Cloud:    "aws",
@@ -84,10 +86,16 @@ func TestValidateImportedResourceAuthorization_TierImportedMissingFiresAuthzGate
 			"name": {Source: imported.SourceRiley, NewValue: "rename"},
 		},
 	}}
-	issues := ValidateImportedResourceAuthorization("aws", irs)
-	require.Len(t, issues, 1)
-	assert.Equal(t, "imported_resource_field_edit_forbidden", issues[0].Code,
-		"TierImportedMissing must not silently bypass EditPolicy gates")
+
+	all := ValidateAll(nil, nil, nil, nil, nil, nil, ComposeStackOpts{
+		Cloud:    "aws",
+		Imported: irs,
+	})
+	codes := issueCodes(all)
+	assert.Contains(t, codes, "imported_resource_missing_remediation",
+		"structural validator must surface missing_remediation; got codes=%v", codes)
+	assert.Contains(t, codes, "imported_resource_field_edit_forbidden",
+		"authz validator must still gate Edit=Never even on TierImportedMissing; got codes=%v", codes)
 }
 
 // TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPaths
@@ -118,9 +126,18 @@ func TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPath
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			// Premise: the path must be a real curated RequiresApproval entry.
+			// If the curator removes or downgrades it, this test would
+			// silently pass for the wrong reason (the path would now route
+			// through no_policy_for_path instead of being authorized).
+			requirePolicyEntryAuthz(t, "google_pubsub_subscription", tc.path, policy.FieldPolicy{
+				Edit: policy.EditRequiresApproval,
+			})
+
 			// FieldEdit.NewValue diverges from Attributes — would trip the
 			// conflict gate if it ran. The conservative no-op behavior
-			// means no issue surfaces.
+			// means NO issue surfaces (the approval is complete, the path
+			// is curated, the conflict gate skips dotted paths).
 			irs := []imported.ImportedResource{{
 				Identity: imported.ResourceIdentity{
 					Cloud:    "gcp",
@@ -141,10 +158,12 @@ func TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPath
 				},
 			}}
 			issues := ValidateImportedResourceAuthorization("gcp", irs)
-			for _, iss := range issues {
-				assert.NotEqual(t, "imported_resource_field_edit_reimport_conflict", iss.Code,
-					"nested paths currently no-op the conflict gate; if this changed, update TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPaths together with lookupTopLevelAttribute")
-			}
+			// Stricter than NotEqual on each code: a regression that
+			// silently masks the conflict gate behind some OTHER gate
+			// (e.g. unknown_path) would have passed the previous
+			// formulation. Require zero issues so any masking surfaces.
+			require.Empty(t, issues,
+				"nested-path conflict gate must no-op AND no other gate may mask it; if this regresses, update lookupTopLevelAttribute together with this test")
 		})
 	}
 }
@@ -728,4 +747,55 @@ func firstUncuratedResolvablePath(tfType string, candidates []string) (string, b
 		return c, true
 	}
 	return "", false
+}
+
+// requirePolicyEntryAuthz asserts that tfType has a curated FieldPolicy for
+// path matching the non-zero fields of want. Mirrors the same-named helper
+// in imported_diff_test.go (declared separately so the two test files don't
+// depend on each other's build order). Renamed _Authz to dodge the linker
+// collision when both test files are linked into the same package.
+func requirePolicyEntryAuthz(t *testing.T, tfType, path string, want policy.FieldPolicy) {
+	t.Helper()
+	m, ok := policy.Lookup(tfType)
+	require.True(t, ok, "test premise: %q must be a curated type", tfType)
+	got, ok := m[path]
+	require.True(t, ok, "test premise: %q must have a curated entry for path %q", tfType, path)
+	if want.Role != "" {
+		assert.Equal(t, want.Role, got.Role, "Role mismatch on %s.%s", tfType, path)
+	}
+	if want.Edit != "" {
+		assert.Equal(t, want.Edit, got.Edit, "Edit mismatch on %s.%s", tfType, path)
+	}
+	if want.Visibility != "" {
+		assert.Equal(t, want.Visibility, got.Visibility, "Visibility mismatch on %s.%s", tfType, path)
+	}
+	if want.Sensitivity != "" {
+		assert.Equal(t, want.Sensitivity, got.Sensitivity, "Sensitivity mismatch on %s.%s", tfType, path)
+	}
+	if want.ChangeRisk != "" {
+		assert.Equal(t, want.ChangeRisk, got.ChangeRisk, "ChangeRisk mismatch on %s.%s", tfType, path)
+	}
+}
+
+// TestEveryCuratedPathResolves makes the curator-lint dependency explicit:
+// every curated path on every registered type must resolve cleanly via
+// policy.ResolvePath against the generated struct (or a registered JSON
+// projection). The authz validator's gate-chain reorder skips ResolvePath on
+// curated paths to avoid the reflective walk on the hot path; that
+// optimization is correct only if EVERY curated path is structurally
+// reachable. Without this test, a curator typo (or a generator-side rename)
+// could bypass the unknown_path diagnostic and emit a confusing
+// forbidden/approval issue against a path that doesn't exist on the struct.
+func TestEveryCuratedPathResolves(t *testing.T) {
+	t.Parallel()
+	for _, tfType := range policy.RegisteredTypes() {
+		m, ok := policy.Lookup(tfType)
+		require.True(t, ok)
+		for path := range m {
+			err := policy.ResolvePath(tfType, path)
+			assert.NoErrorf(t, err,
+				"curated policy %s.%s must resolve via policy.ResolvePath; if this fails, the authz validator's curated-path optimization (imported_authz_validate.go) bypasses the unknown_path diagnostic for this entry",
+				tfType, path)
+		}
+	}
 }

--- a/pkg/composer/imported_authz_validate_test.go
+++ b/pkg/composer/imported_authz_validate_test.go
@@ -1,0 +1,640 @@
+package composer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	_ "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateImportedResourceAuthorization_NoOpInputs(t *testing.T) {
+	t.Parallel()
+	noFieldEdits := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "https://sqs.us-east-1.amazonaws.com/123/q",
+		},
+		Tier: imported.TierImportedFlat,
+	}}
+	cases := map[string][]imported.ImportedResource{
+		"nil slice":              nil,
+		"empty slice":            {},
+		"resources but no edits": noFieldEdits,
+	}
+	for name, irs := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+		})
+	}
+}
+
+func TestValidateImportedResourceAuthorization_NonImportedTiersFiltered(t *testing.T) {
+	t.Parallel()
+	// FieldEdits on every non-imported tier must produce zero issues; this
+	// validator's contract is bounded to imported tiers only. Iterating each
+	// tier explicitly catches a mutation that swaps the tier predicate.
+	nonImportedTiers := []imported.Tier{
+		imported.TierComposerNative,
+		imported.TierComposerGraduated,
+		imported.TierExternalByPolicy,
+		imported.TierExternalUnsupported,
+	}
+	for _, tier := range nonImportedTiers {
+		t.Run(string(tier), func(t *testing.T) {
+			t.Parallel()
+			irs := []imported.ImportedResource{{
+				Identity:   imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.x"},
+				Tier:       tier,
+				FieldEdits: map[string]imported.FieldEdit{"name": {NewValue: "new"}},
+			}}
+			assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+		})
+	}
+}
+
+func TestValidateImportedResourceAuthorization_CloudMismatch(t *testing.T) {
+	t.Parallel()
+	// Compose cloud differs from the resource's cloud — the structural
+	// validator surfaces unsupported_cloud; this validator stays silent so
+	// callers don't double-report.
+	irs := []imported.ImportedResource{{
+		Identity:   imported.ResourceIdentity{Cloud: "gcp", Type: "google_storage_bucket", Address: "google_storage_bucket.b", ImportID: "b"},
+		Tier:       imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{"name": {NewValue: "new"}},
+	}}
+	assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+}
+
+func TestValidateImportedResourceAuthorization_EditPolicyGates(t *testing.T) {
+	t.Parallel()
+	good := imported.ResourceIdentity{
+		Cloud:    "aws",
+		Type:     "aws_sqs_queue",
+		Address:  "aws_sqs_queue.q",
+		ImportID: "https://sqs.us-east-1.amazonaws.com/123/q",
+	}
+
+	cases := []struct {
+		name     string
+		path     string
+		newValue any
+		wantCode string
+	}{
+		{
+			name:     "Edit=Never on identity field",
+			path:     "name",
+			newValue: "renamed",
+			wantCode: "imported_resource_field_edit_forbidden",
+		},
+		{
+			name:     "Edit=SystemOnly on tags",
+			path:     "tags",
+			newValue: map[string]any{"InsideOutImportProject": "io-x"},
+			wantCode: "imported_resource_field_edit_system_only",
+		},
+		{
+			name:     "Edit=RelationshipOnly on wiring field",
+			path:     "kms_master_key_id",
+			newValue: "alias/aws/sqs",
+			wantCode: "imported_resource_field_edit_relationship_only",
+		},
+		{
+			name:     "Edit=ChatSafe on tuning field passes",
+			path:     "visibility_timeout_seconds",
+			newValue: 60,
+			wantCode: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Deliberately do NOT mirror NewValue into Attributes — that
+			// would let a regression in the conflict gate run after the
+			// EditPolicy gate also pass silently. The EditPolicy gate must
+			// fire before any Attributes lookup.
+			irs := []imported.ImportedResource{{
+				Identity: good,
+				Tier:     imported.TierImportedFlat,
+				FieldEdits: map[string]imported.FieldEdit{
+					tc.path: {Source: imported.SourceRiley, NewValue: tc.newValue, EditedAt: time.Now()},
+				},
+			}}
+			issues := ValidateImportedResourceAuthorization("aws", irs)
+			if tc.wantCode == "" {
+				assert.Empty(t, issues)
+				return
+			}
+			require.Len(t, issues, 1)
+			assert.Equal(t, tc.wantCode, issues[0].Code)
+			assert.Equal(t, "imported.aws_sqs_queue.q."+tc.path, issues[0].Field)
+		})
+	}
+}
+
+func TestValidateImportedResourceAuthorization_NoPolicyForType(t *testing.T) {
+	t.Parallel()
+	// aws_iam_role isn't in the Phase 1 ten — no policy registered, so any
+	// FieldEdit defaults to deny.
+	require.False(t, hasPolicyRegistered("aws_iam_role"),
+		"test premise: aws_iam_role should not be in the curated Phase 1 set")
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_iam_role",
+			Address:  "aws_iam_role.r",
+			ImportID: "r",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"description": {Source: imported.SourceRiley, NewValue: "edited"},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_no_policy", issues[0].Code)
+	assert.Equal(t, "imported.aws_iam_role.r.description", issues[0].Field)
+}
+
+func TestValidateImportedResourceAuthorization_UnknownPath(t *testing.T) {
+	t.Parallel()
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"this_field_does_not_exist": {Source: imported.SourceRiley, NewValue: "x"},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_unknown_path", issues[0].Code)
+}
+
+func TestValidateImportedResourceAuthorization_PathWithoutPolicyEntry(t *testing.T) {
+	t.Parallel()
+	// Find a path at runtime that resolves against aws_lambda_function but is
+	// NOT in the curated map. This is mutation-resistant against future
+	// policy growth: as long as some attribute remains uncurated, the test
+	// keeps testing the gate. The skip below documents what to do if the
+	// curated map ever covers the entire schema (unlikely for Phase 2).
+	uncurated, ok := firstUncuratedResolvablePath("aws_lambda_function", []string{
+		"image_uri",
+		"package_type",
+		"publish",
+		"replace_security_groups_on_destroy",
+	})
+	if !ok {
+		t.Skip("no uncurated paths remain on aws_lambda_function — extend the candidate list or accept that the gate is structurally unreachable for this type")
+	}
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.f",
+			ImportID: "f",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			uncurated: {Source: imported.SourceRiley, NewValue: "x"},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_no_policy_for_path", issues[0].Code,
+		"selected path %q should resolve on aws_lambda_function but be absent from the curated map", uncurated)
+}
+
+func TestValidateImportedResourceAuthorization_RequiresApprovalNoApproval(t *testing.T) {
+	t.Parallel()
+	// sqs_managed_sse_enabled is Edit=RequiresApproval on aws_sqs_queue.
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"sqs_managed_sse_enabled": {Source: imported.SourceRiley, NewValue: true},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_requires_approval", issues[0].Code)
+}
+
+func TestValidateImportedResourceAuthorization_RequiresApprovalIncomplete(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		ap   imported.FieldEditApproval
+	}{
+		{"missing approver", imported.FieldEditApproval{ApprovedAt: time.Now(), PlanHash: "h"}},
+		{"zero approved_at", imported.FieldEditApproval{Approver: "a", PlanHash: "h"}},
+		{"missing plan_hash", imported.FieldEditApproval{Approver: "a", ApprovedAt: time.Now()}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ap := tc.ap
+			irs := []imported.ImportedResource{{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_sqs_queue",
+					Address:  "aws_sqs_queue.q",
+					ImportID: "q",
+				},
+				Tier: imported.TierImportedFlat,
+				FieldEdits: map[string]imported.FieldEdit{
+					"sqs_managed_sse_enabled": {
+						Source:   imported.SourceRiley,
+						NewValue: true,
+						Approval: &ap,
+					},
+				},
+			}}
+			issues := ValidateImportedResourceAuthorization("aws", irs)
+			require.Len(t, issues, 1)
+			assert.Equal(t, "imported_resource_field_edit_approval_invalid", issues[0].Code)
+		})
+	}
+}
+
+func TestValidateImportedResourceAuthorization_RequiresApprovalComplete(t *testing.T) {
+	t.Parallel()
+	// recovery_window_in_days on aws_secretsmanager_secret is RequiresApproval
+	// without ChangeRisk metadata, so a complete approval suffices.
+	approval := &imported.FieldEditApproval{
+		Approver:   "ops@luthersystems.com",
+		ApprovedAt: time.Now(),
+		PlanHash:   "abc123",
+	}
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_secretsmanager_secret",
+			Address:  "aws_secretsmanager_secret.s",
+			ImportID: "s",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"recovery_window_in_days": {
+				Source:   imported.SourceRiley,
+				NewValue: 7,
+				Approval: approval,
+			},
+		},
+	}}
+	assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+}
+
+func TestValidateImportedResourceAuthorization_RequiresApprovalAndReplacementRiskBothApproved(t *testing.T) {
+	t.Parallel()
+	// sqs_managed_sse_enabled is RequiresApproval + MayReplace — both gates
+	// must pass with one complete approval. A regression that drops the early
+	// `return` between the two gates would let the second gate (or its
+	// approval-completeness check) reject and would be caught here.
+	approval := &imported.FieldEditApproval{
+		Approver:   "ops@luthersystems.com",
+		ApprovedAt: time.Now(),
+		PlanHash:   "plan-multi",
+	}
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"sqs_managed_sse_enabled": {
+				Source:   imported.SourceRiley,
+				NewValue: true,
+				Approval: approval,
+			},
+		},
+	}}
+	assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+}
+
+func TestValidateImportedResourceAuthorization_ReplacementRiskUnconfirmed(t *testing.T) {
+	t.Parallel()
+	// architectures on aws_lambda_function is ChatSafe + MayReplace — the
+	// EditPolicy gate passes, and the ChangeRisk gate fires when no Approval
+	// is present.
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.f",
+			ImportID: "f",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"architectures": {Source: imported.SourceRiley, NewValue: []any{"arm64"}},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_replacement_risk_unconfirmed", issues[0].Code)
+}
+
+func TestValidateImportedResourceAuthorization_ReplacementRiskApproved(t *testing.T) {
+	t.Parallel()
+	// Same case with a valid Approval — gate is satisfied.
+	approval := &imported.FieldEditApproval{
+		Approver:   "ops@luthersystems.com",
+		ApprovedAt: time.Now(),
+		PlanHash:   "plan-abc",
+	}
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.f",
+			ImportID: "f",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"architectures": {
+				Source:   imported.SourceRiley,
+				NewValue: []any{"arm64"},
+				Approval: approval,
+			},
+		},
+	}}
+	assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+}
+
+func TestValidateImportedResourceAuthorization_ReimportConflict(t *testing.T) {
+	t.Parallel()
+	// FieldEdit recorded NewValue=120, but Attributes shows 30 — a re-import
+	// or other writer overwrote the pending edit. This is the only test that
+	// legitimately mirrors-but-diverges Attributes vs NewValue.
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"visibility_timeout_seconds": 30,
+		},
+		FieldEdits: map[string]imported.FieldEdit{
+			"visibility_timeout_seconds": {
+				Source:   imported.SourceRiley,
+				NewValue: 120,
+				EditedAt: time.Now(),
+			},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_reimport_conflict", issues[0].Code)
+}
+
+func TestValidateImportedResourceAuthorization_ReimportConflictAlignedNoIssue(t *testing.T) {
+	t.Parallel()
+	// Attributes equals NewValue — no conflict.
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"visibility_timeout_seconds": 120,
+		},
+		FieldEdits: map[string]imported.FieldEdit{
+			"visibility_timeout_seconds": {Source: imported.SourceRiley, NewValue: 120},
+		},
+	}}
+	assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+}
+
+func TestValidateImportedResourceAuthorization_RedactsAcrossSeverities(t *testing.T) {
+	t.Parallel()
+
+	const secret = "hunter2-not-public"
+
+	cases := []struct {
+		name     string
+		tfType   string
+		address  string
+		path     string
+		newValue any
+	}{
+		{
+			// tagPolicy() => Sensitivity=Redacted + Edit=SystemOnly.
+			name:     "Redacted via SystemOnly",
+			tfType:   "aws_sqs_queue",
+			address:  "aws_sqs_queue.q",
+			path:     "tags",
+			newValue: map[string]any{"DB_PASSWORD": secret},
+		},
+		{
+			// environment.variables on aws_lambda_function is
+			// Sensitivity=Sensitive + Edit=SystemOnly.
+			name:     "Sensitive via SystemOnly",
+			tfType:   "aws_lambda_function",
+			address:  "aws_lambda_function.f",
+			path:     "environment.variables",
+			newValue: map[string]any{"DB_PASSWORD": secret},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			irs := []imported.ImportedResource{{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     tc.tfType,
+					Address:  tc.address,
+					ImportID: "x",
+				},
+				Tier: imported.TierImportedFlat,
+				FieldEdits: map[string]imported.FieldEdit{
+					tc.path: {Source: imported.SourceRiley, NewValue: tc.newValue},
+				},
+			}}
+			issues := ValidateImportedResourceAuthorization("aws", irs)
+			require.Len(t, issues, 1)
+			iss := issues[0]
+			assert.Equal(t, "***", iss.Value, "Value must be redacted")
+			assert.NotContains(t, iss.Reason, secret, "Reason must not leak the raw value")
+			assert.NotContains(t, iss.Suggestion, secret, "Suggestion must not leak the raw value")
+			assert.NotContains(t, iss.Field, secret, "Field must not leak the raw value")
+		})
+	}
+}
+
+func TestValidateImportedResourceAuthorization_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+	// Two FieldEdits on different paths produce two issues in lexicographic
+	// path order, regardless of map iteration randomness. Iteration count is
+	// high enough to consistently shuffle Go's map randomization in practice.
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"name": {Source: imported.SourceRiley, NewValue: "renamed"},
+			"arn":  {Source: imported.SourceRiley, NewValue: "arn:aws:sqs:..."},
+		},
+	}}
+	for i := range 50 {
+		issues := ValidateImportedResourceAuthorization("aws", irs)
+		require.Len(t, issues, 2)
+		assert.Equal(t, "imported.aws_sqs_queue.q.arn", issues[0].Field, "iteration %d: stable order broken", i)
+		assert.Equal(t, "imported.aws_sqs_queue.q.name", issues[1].Field, "iteration %d: stable order broken", i)
+	}
+}
+
+func TestValidateImportedResourceAuthorization_MultipleResources(t *testing.T) {
+	t.Parallel()
+	// First resource has a clean ChatSafe edit; second has a forbidden one.
+	// Confirms cross-resource iteration includes only the resources with
+	// gated edits and emits per-resource per-path issues independently.
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.a", ImportID: "a",
+			},
+			Tier: imported.TierImportedFlat,
+			FieldEdits: map[string]imported.FieldEdit{
+				"visibility_timeout_seconds": {Source: imported.SourceRiley, NewValue: 60},
+			},
+		},
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.b", ImportID: "b",
+			},
+			Tier: imported.TierImportedFlat,
+			FieldEdits: map[string]imported.FieldEdit{
+				"name": {Source: imported.SourceRiley, NewValue: "rename"},
+			},
+		},
+	}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_forbidden", issues[0].Code)
+	assert.Equal(t, "imported.aws_sqs_queue.b.name", issues[0].Field)
+}
+
+// TestEvaluateEditPolicy_DefaultBranch covers the defensive default branch in
+// evaluateEditPolicy for an EditPolicy value the curated maps cannot
+// legitimately produce (lint enforces Valid()). Direct unit-test on the
+// helper avoids polluting the policy registry with a malformed entry.
+func TestEvaluateEditPolicy_DefaultBranch(t *testing.T) {
+	t.Parallel()
+	entry := policy.FieldPolicy{
+		Role: policy.RoleTuning,
+		Edit: policy.EditPolicy("InvalidValueNotInEnum"),
+	}
+	iss, ok := evaluateEditPolicy("imported.aws_sqs_queue.q.weird", "aws_sqs_queue", "weird", imported.FieldEdit{NewValue: "x"}, entry)
+	require.True(t, ok, "default branch must produce an issue")
+	assert.Equal(t, "imported_resource_field_edit_forbidden", iss.Code)
+	assert.Contains(t, iss.Reason, "InvalidValueNotInEnum",
+		"Reason should name the offending EditPolicy so a curator can fix it")
+}
+
+func TestValidateImportedResourceAuthorization_HookedIntoComposeStack(t *testing.T) {
+	// Sequential: composeStackImpl reads the package-global nowFn (set by
+	// withFixedNow in imported_compose_test.go and imported_provenance_test.go).
+	// Running this test in parallel with those would flake the timestamp those
+	// tests pin via injectProvenance.
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:   "aws",
+		Project: "io-test",
+		Region:  "us-east-1",
+		Imported: []imported.ImportedResource{{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "q",
+			},
+			Tier: imported.TierImportedFlat,
+			FieldEdits: map[string]imported.FieldEdit{
+				"name": {Source: imported.SourceRiley, NewValue: "rename"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	codes := issueCodes(res.Issues)
+	assert.Contains(t, codes, "imported_resource_field_edit_forbidden",
+		"compose pipeline must surface authorization issues; got codes=%v", codes)
+}
+
+func TestValidateImportedResourceAuthorization_HookedIntoValidateAll(t *testing.T) {
+	t.Parallel()
+	issues := ValidateAll(
+		nil, nil, nil, nil, nil, nil,
+		ComposeStackOpts{
+			Cloud: "aws",
+			Imported: []imported.ImportedResource{{
+				Identity: imported.ResourceIdentity{
+					Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "q",
+				},
+				Tier: imported.TierImportedFlat,
+				FieldEdits: map[string]imported.FieldEdit{
+					"kms_master_key_id": {Source: imported.SourceRiley, NewValue: "alias/foo"},
+				},
+			}},
+		},
+	)
+	codes := issueCodes(issues)
+	assert.Contains(t, codes, "imported_resource_field_edit_relationship_only",
+		"ValidateAll must include the authorization validator; got codes=%v", codes)
+}
+
+// hasPolicyRegistered reports whether tfType is in the curated Layer 2 set.
+// Used by tests that assert their premise (e.g. "this type is uncurated") so
+// a future policy addition surfaces as a clear premise failure rather than a
+// confusing test failure.
+func hasPolicyRegistered(tfType string) bool {
+	_, ok := policy.Lookup(tfType)
+	return ok
+}
+
+// firstUncuratedResolvablePath returns the first candidate path that resolves
+// against tfType's generated struct but is not in the curated policy map.
+// Tests that need a "path-without-policy-entry" example call this with a
+// candidate list so they remain valid as the curated map grows: as long as
+// any candidate is uncurated, the test stays green.
+func firstUncuratedResolvablePath(tfType string, candidates []string) (string, bool) {
+	m, ok := policy.Lookup(tfType)
+	if !ok {
+		return "", false
+	}
+	for _, c := range candidates {
+		if _, curated := m[c]; curated {
+			continue
+		}
+		if err := policy.ResolvePath(tfType, c); err != nil {
+			continue
+		}
+		return c, true
+	}
+	return "", false
+}

--- a/pkg/composer/validate.go
+++ b/pkg/composer/validate.go
@@ -131,6 +131,7 @@ func ValidateAll(
 	if len(opts) > 0 {
 		all = append(all, ValidateOpts(opts[0])...)
 		all = append(all, ValidateImportedResources(opts[0].Cloud, opts[0].Imported)...)
+		all = append(all, ValidateImportedResourceAuthorization(opts[0].Cloud, opts[0].Imported)...)
 	}
 	return dedupeAndSortIssues(all)
 }


### PR DESCRIPTION
## Summary

Phase 2 sibling to `ValidateImportedResources` that enforces the Layer 2 field policy on imported-resource model writes (chat, API, MCP). Closes #149 and is part of the Phase 2 epic #143.

Per FieldEdit it produces at most one issue with a snake_case Code:

- `imported_resource_field_edit_no_policy` / `_no_policy_for_path` / `_unknown_path` — default-deny for unregistered types and uncurated paths (decision #43).
- `imported_resource_field_edit_forbidden` / `_system_only` / `_relationship_only` — EditPolicy gates (Never / SystemOnly / RelationshipOnly per decisions #14, #30).
- `imported_resource_field_edit_requires_approval` / `_approval_invalid` — RequiresApproval edits without complete plan-tied approval metadata (decision #42).
- `imported_resource_field_edit_replacement_risk_unconfirmed` — ChangeRisk in {MayReplace, AlwaysReplace, Unknown} without an approval record attesting plan review.
- `imported_resource_field_edit_reimport_conflict` — desired Attributes diverged from FieldEdit.NewValue, indicating a re-import overwrote the pending edit (decision #19).

Sensitive (or Redacted) field values are redacted to `***` in any emitted ValidationIssue so raw sensitive data never escapes into errors, diffs, or chat correction prompts (decision #36).

Adds `FieldEditApproval` to `pkg/composer/imported` with the four-field plan-tied audit record (Approver, ApprovedAt, PlanHash, Note), exposed as an optional pointer on FieldEdit. Wires the new validator into `composeStackImpl` and `ValidateAll` alongside the existing imported-resource validators.

## Test plan

- [x] Unit tests cover every documented gate code (both positive and negative cases)
- [x] RequiresApproval + MayReplace combinatorial gate (both halves: rejected without approval, accepted with one complete approval)
- [x] Redaction across both `Sensitivity=Redacted` (tags) and `Sensitivity=Sensitive` (lambda environment.variables) — asserts Value, Reason, Suggestion, and Field do not leak
- [x] `evaluateEditPolicy` defensive default branch for unrecognized EditPolicy values
- [x] Deterministic per-FieldEdit ordering across 50 iterations (Go map randomization)
- [x] Tier filter covers every non-imported tier explicitly (ComposerNative, ComposerGraduated, ExternalByPolicy, ExternalUnsupported)
- [x] Integration through `ComposeStackWithIssues` and `ValidateAll`
- [x] `firstUncuratedResolvablePath` test helper makes the path-without-policy test mutation-resistant against future curated-map growth
- [x] Full composer test suite passes (`go test ./pkg/composer/...`)
- [x] All four static lints pass (`lint-project-tag.sh`, `lint-project-label.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`)
- [x] `terraform fmt -check -recursive` passes

## Closes

Closes #149