### PR TITLE
feat(composer): ResourceDiff + VersionDiff.Resources extension (#151)

### DIFF
--- a/pkg/composer/diff.go
+++ b/pkg/composer/diff.go
@@ -46,7 +46,12 @@ type VersionDiff struct {
 	Components  []ComponentDiff `json:"components"`
 	Metadata    []MetadataDiff  `json:"metadata,omitempty"`
 	Pricing     []PricingDiff   `json:"pricing,omitempty"`
-	Summary     string          `json:"summary"`
+	// Resources carries imported-resource diffs (Phase 2, issue #151).
+	// Populated by DiffImportedResources from the two snapshots'
+	// ImportedResource lists. Empty when both sides have no imported
+	// resources or when the visible diff is a no-op.
+	Resources []ResourceDiff `json:"resources,omitempty"`
+	Summary   string         `json:"summary"`
 }
 
 // JSONTagName extracts the JSON tag name from a struct field, stripping ",omitempty".

--- a/pkg/composer/diff.go
+++ b/pkg/composer/diff.go
@@ -48,9 +48,11 @@ type VersionDiff struct {
 	Pricing     []PricingDiff   `json:"pricing,omitempty"`
 	// Resources carries imported-resource diffs (Phase 2, issue #151).
 	// Populated by DiffImportedResources from the two snapshots'
-	// ImportedResource lists. Empty when both sides have no imported
-	// resources or when the visible diff is a no-op.
-	Resources []ResourceDiff `json:"resources,omitempty"`
+	// ImportedResource lists. Always present in JSON (mirrors Components)
+	// so consumers see a stable shape; an empty array means "no imported
+	// resource changes," distinct from a nil array which would imply the
+	// field is missing.
+	Resources []ResourceDiff `json:"resources"`
 	Summary   string         `json:"summary"`
 }
 

--- a/pkg/composer/imported_diff.go
+++ b/pkg/composer/imported_diff.go
@@ -1,0 +1,425 @@
+package composer
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+)
+
+// Resource diff actions. Mirror the existing component diff vocabulary so
+// downstream renderers can share switch arms.
+const (
+	ResourceActionAdded    = "added"
+	ResourceActionRemoved  = "removed"
+	ResourceActionModified = "modified"
+)
+
+// ResourceDiff describes the change to one imported resource between two
+// stack snapshots. It is the imported-resource analogue of ComponentDiff and
+// rides alongside ComponentDiff inside VersionDiff.Resources.
+//
+// Identity: keyed by Terraform Address (matches the import {} block target
+// and the cross-tier resolver). Type and Cloud are kept on the diff for
+// rendering convenience so consumers don't have to re-derive them.
+//
+// Tier transitions: when the same address moves between Tiers (e.g.
+// ImportedFlat → ImportedConformant, ImportedFlat → ImportedMissing), Action
+// is "modified" and FromTier / ToTier carry the move. Reliable's UI
+// distinguishes a tier move from a field-only modification by checking
+// whether FromTier and ToTier differ.
+//
+// Field changes use ResourceFieldDiff so Reliable can render policy metadata
+// (role, sensitivity, change-risk) without separately querying the policy
+// registry.
+type ResourceDiff struct {
+	Address string `json:"address"`
+	Type    string `json:"type"`
+	Cloud   string `json:"cloud,omitempty"`
+
+	Action string `json:"action"`
+
+	FromTier imported.Tier `json:"from_tier,omitempty"`
+	ToTier   imported.Tier `json:"to_tier,omitempty"`
+
+	// Remediation surfaces the operator-chosen action when the resource
+	// transitioned into TierImportedMissing. Empty otherwise.
+	Remediation imported.MissingAction `json:"remediation,omitempty"`
+
+	Changes []ResourceFieldDiff `json:"changes,omitempty"`
+}
+
+// ResourceFieldDiff describes a per-field change with the policy metadata
+// Reliable needs to group, label, badge, and redact. Policy fields default
+// to the empty string when no curated entry exists for the path or the
+// resource type is unregistered; renderers should treat empty as "no
+// curator opinion" and fall back to a generic display.
+type ResourceFieldDiff struct {
+	Path string `json:"path"`
+	From string `json:"from"`
+	To   string `json:"to"`
+
+	Role        policy.FieldRole         `json:"role,omitempty"`
+	Pillar      policy.FieldPillar       `json:"pillar,omitempty"`
+	Sensitivity policy.SensitivityPolicy `json:"sensitivity,omitempty"`
+	ChangeRisk  policy.ChangeRiskPolicy  `json:"change_risk,omitempty"`
+	EditPolicy  policy.EditPolicy        `json:"edit_policy,omitempty"`
+
+	// Redacted is true when From / To were replaced with placeholders to
+	// honor the field's SensitivityPolicy. Diff JSON, logs, and humanized
+	// text must never contain the original values for redacted fields.
+	Redacted bool `json:"redacted,omitempty"`
+
+	// RelationshipOnly is true when the curated EditPolicy is
+	// EditRelationshipOnly. Reliable uses this to render the change as a
+	// graph relationship, not as an ordinary scalar edit (decisions #30,
+	// #31). The underlying value still diffs so the operator can see the
+	// referenced address; chat-side scalar edits are blocked separately
+	// by ValidateImportedResourceAuthorization.
+	RelationshipOnly bool `json:"relationship_only,omitempty"`
+}
+
+// redactedPlaceholder is the surface form of any field value that the
+// SensitivityPolicy says must not leak. Single shared constant so the wire
+// format never depends on call-site convention.
+const redactedPlaceholder = "***"
+
+// DiffImportedResources compares two slices of ImportedResource and returns
+// one ResourceDiff per address that differs. Resources in old but not new
+// produce Action="removed"; resources in new but not old produce
+// Action="added"; same address on both sides with any Tier or Attributes
+// difference produces Action="modified".
+//
+// Field-level diffs respect the curated Layer 2 policy for the resource
+// type:
+//
+//   - Hidden fields (Visibility=Hidden) are excluded from the diff output
+//     entirely; system-owned attributes (timeouts, tags, internal markers)
+//     should not surface in user-visible diffs.
+//   - RelationshipOnly fields appear with the RelationshipOnly flag set so
+//     renderers can show them as graph references rather than scalar edits.
+//   - Sensitive / Redacted fields have From / To replaced with "***" and
+//     Redacted=true.
+//   - ChangeRisk, Role, Pillar, and EditPolicy are populated from the
+//     curated FieldPolicy so renderers can show plan-tied confirmation
+//     badges and policy grouping without re-querying the registry.
+//
+// When the resource type is not registered in the policy package, fields
+// fall through to a generic diff with empty policy metadata; the safe
+// default redacts nothing because the carrier itself has no curator
+// opinion. (Use ValidateImportedResources for structural checks on
+// uncurated types; this function is render-only.)
+//
+// JSON projections (e.g. redrive_policy.deadLetterTargetArn) are best-
+// effort: when the parent attribute is a JSON-string and a projection is
+// registered, the diff is emitted at the projection path. Parse failures
+// fall back to a raw parent diff so the change is never silently dropped.
+//
+// Output is sorted by Address for stable consumption.
+func DiffImportedResources(old, new []imported.ImportedResource) []ResourceDiff {
+	if len(old) == 0 && len(new) == 0 {
+		return nil
+	}
+	oldByAddr := indexImportedByAddress(old)
+	newByAddr := indexImportedByAddress(new)
+
+	var diffs []ResourceDiff
+	for addr, oldIR := range oldByAddr {
+		newIR, ok := newByAddr[addr]
+		if !ok {
+			diffs = append(diffs, removedResourceDiff(oldIR))
+			continue
+		}
+		if d, ok := modifiedResourceDiff(oldIR, newIR); ok {
+			diffs = append(diffs, d)
+		}
+	}
+	for addr, newIR := range newByAddr {
+		if _, ok := oldByAddr[addr]; ok {
+			continue
+		}
+		diffs = append(diffs, addedResourceDiff(newIR))
+	}
+
+	sort.Slice(diffs, func(i, j int) bool {
+		return diffs[i].Address < diffs[j].Address
+	})
+	return diffs
+}
+
+// indexImportedByAddress builds an Address->ImportedResource map. Resources
+// with empty Address are skipped — DiffImportedResources is render-only and
+// has no way to correlate them; the structural validator surfaces those as
+// imported_resource_missing_address.
+func indexImportedByAddress(irs []imported.ImportedResource) map[string]imported.ImportedResource {
+	out := make(map[string]imported.ImportedResource, len(irs))
+	for _, ir := range irs {
+		addr := strings.TrimSpace(ir.Identity.Address)
+		if addr == "" {
+			continue
+		}
+		out[addr] = ir
+	}
+	return out
+}
+
+// addedResourceDiff renders a "this resource appeared on the new side" diff,
+// listing every visible attribute as an addition (from "" to the new value).
+func addedResourceDiff(ir imported.ImportedResource) ResourceDiff {
+	rd := ResourceDiff{
+		Address: ir.Identity.Address,
+		Type:    ir.Identity.Type,
+		Cloud:   ir.Identity.Cloud,
+		Action:  ResourceActionAdded,
+		ToTier:  ir.Tier,
+	}
+	if ir.Tier == imported.TierImportedMissing {
+		rd.Remediation = ir.Remediation
+	}
+	rd.Changes = diffAttributeMaps(ir.Identity.Type, nil, ir.Attributes)
+	return rd
+}
+
+// removedResourceDiff renders a "this resource went away on the new side"
+// diff, listing every visible attribute as a removal (from the old value to
+// "").
+func removedResourceDiff(ir imported.ImportedResource) ResourceDiff {
+	rd := ResourceDiff{
+		Address:  ir.Identity.Address,
+		Type:     ir.Identity.Type,
+		Cloud:    ir.Identity.Cloud,
+		Action:   ResourceActionRemoved,
+		FromTier: ir.Tier,
+	}
+	rd.Changes = diffAttributeMaps(ir.Identity.Type, ir.Attributes, nil)
+	return rd
+}
+
+// modifiedResourceDiff returns a diff for two snapshots of the same address.
+// ok=false when nothing visible changed (same Tier and no policy-visible
+// attribute deltas) — DiffImportedResources skips no-op modifies entirely.
+func modifiedResourceDiff(oldIR, newIR imported.ImportedResource) (ResourceDiff, bool) {
+	rd := ResourceDiff{
+		Address: newIR.Identity.Address,
+		Type:    newIR.Identity.Type,
+		Cloud:   newIR.Identity.Cloud,
+		Action:  ResourceActionModified,
+	}
+	tierChanged := oldIR.Tier != newIR.Tier
+	if tierChanged {
+		rd.FromTier = oldIR.Tier
+		rd.ToTier = newIR.Tier
+		if newIR.Tier == imported.TierImportedMissing {
+			rd.Remediation = newIR.Remediation
+		}
+	}
+	rd.Changes = diffAttributeMaps(newIR.Identity.Type, oldIR.Attributes, newIR.Attributes)
+	if !tierChanged && len(rd.Changes) == 0 {
+		return ResourceDiff{}, false
+	}
+	return rd, true
+}
+
+// diffAttributeMaps walks the union of keys across old and new and emits
+// ResourceFieldDiff entries for visible (non-Hidden) paths whose stringified
+// values differ. For each top-level path that the curated map declares as a
+// JSON-projection parent, the projection paths are diffed individually
+// rather than as a single raw parent diff (best-effort; parse failures fall
+// back to raw).
+//
+// Output is sorted by Path. Empty old and empty new short-circuit to nil so
+// the caller gets a clean tail.
+func diffAttributeMaps(tfType string, old, new map[string]any) []ResourceFieldDiff {
+	if len(old) == 0 && len(new) == 0 {
+		return nil
+	}
+	polMap, _ := policy.Lookup(tfType)
+	keys := unionKeys(old, new)
+	parents := jsonProjectionParents(polMap)
+
+	var diffs []ResourceFieldDiff
+	for _, key := range keys {
+		if parents[key] {
+			diffs = append(diffs, diffJSONProjection(tfType, key, old[key], new[key], polMap)...)
+			continue
+		}
+		entry, hasEntry := polMap[key]
+		if hasEntry && entry.Visibility == policy.VisibilityHidden {
+			continue
+		}
+		oldStr := stringifyAttr(old[key])
+		newStr := stringifyAttr(new[key])
+		if oldStr == newStr {
+			continue
+		}
+		diffs = append(diffs, makeFieldDiff(key, oldStr, newStr, entry, hasEntry))
+	}
+	sort.Slice(diffs, func(i, j int) bool {
+		return diffs[i].Path < diffs[j].Path
+	})
+	return diffs
+}
+
+// makeFieldDiff applies redaction and policy projection to a raw From/To
+// pair. hasEntry distinguishes "no curator opinion" from "explicit zero
+// values" — without it we couldn't tell apart the empty default and an
+// explicit Visibility=Hidden, but the Hidden case is filtered upstream.
+func makeFieldDiff(path, from, to string, entry policy.FieldPolicy, hasEntry bool) ResourceFieldDiff {
+	d := ResourceFieldDiff{Path: path, From: from, To: to}
+	if !hasEntry {
+		return d
+	}
+	d.Role = entry.Role
+	d.Pillar = entry.Pillar
+	d.Sensitivity = entry.Sensitivity
+	d.ChangeRisk = entry.ChangeRisk
+	d.EditPolicy = entry.Edit
+	d.RelationshipOnly = entry.Edit == policy.EditRelationshipOnly
+	if redactionRequired(entry) {
+		d.From = redactedPlaceholder
+		d.To = redactedPlaceholder
+		d.Redacted = true
+	}
+	return d
+}
+
+// redactionRequired reports whether the curated SensitivityPolicy demands
+// the value be replaced with a placeholder before display.
+func redactionRequired(entry policy.FieldPolicy) bool {
+	switch entry.Sensitivity {
+	case policy.SensitivitySensitive, policy.SensitivityRedacted:
+		return true
+	}
+	return false
+}
+
+// stringifyAttr renders an Attributes value as a stable display string. nil
+// stays as the empty string so the From/To delta correctly shows additions
+// and removals as " → x" / "x → ".
+func stringifyAttr(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	case int, int32, int64, float32, float64, bool:
+		return fmt.Sprintf("%v", t)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}
+
+// unionKeys returns the sorted union of map keys, with nil maps treated as
+// empty. Used to compute the diff coverage for two attribute snapshots.
+func unionKeys(a, b map[string]any) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// jsonProjectionParents returns the set of top-level attribute names that
+// are declared as JSON-projection parents in m. Used by diffAttributeMaps
+// to route those keys through the projection-aware path.
+func jsonProjectionParents(m policy.Map) map[string]bool {
+	parents := map[string]bool{}
+	for path := range m {
+		i := strings.Index(path, ".")
+		if i <= 0 {
+			continue
+		}
+		parents[path[:i]] = true
+	}
+	return parents
+}
+
+// diffJSONProjection renders one or more ResourceFieldDiff entries for a
+// JSON-string parent attribute. Each registered projection gets its own
+// entry when both sides parse cleanly. If either side fails to parse —
+// including the asymmetric case where one snapshot is well-formed JSON and
+// the other is corrupt — the function falls back to a single raw parent
+// diff so the change is never silently dropped and stale projection
+// entries from the parsed half are not emitted.
+func diffJSONProjection(tfType, parent string, oldVal, newVal any, polMap policy.Map) []ResourceFieldDiff {
+	oldMap, oldOK := decodeJSONProjection(oldVal)
+	newMap, newOK := decodeJSONProjection(newVal)
+	if !oldOK || !newOK {
+		oldStr := stringifyAttr(oldVal)
+		newStr := stringifyAttr(newVal)
+		if oldStr == newStr {
+			return nil
+		}
+		entry, hasEntry := polMap[parent]
+		return []ResourceFieldDiff{makeFieldDiff(parent, oldStr, newStr, entry, hasEntry)}
+	}
+	keys := unionKeys(oldMap, newMap)
+	var diffs []ResourceFieldDiff
+	for _, sub := range keys {
+		full := parent + "." + sub
+		entry, hasEntry := polMap[full]
+		if hasEntry && entry.Visibility == policy.VisibilityHidden {
+			continue
+		}
+		oldStr := stringifyAttr(oldMap[sub])
+		newStr := stringifyAttr(newMap[sub])
+		if oldStr == newStr {
+			continue
+		}
+		diffs = append(diffs, makeFieldDiff(full, oldStr, newStr, entry, hasEntry))
+	}
+	return diffs
+}
+
+// decodeJSONProjection accepts either a Go map (Phase 1 typed Attributes)
+// or a JSON-string (Terraform's wire shape for redrive_policy and friends)
+// and returns it as a map[string]any. Returns ok=false on type mismatch or
+// parse failure; callers fall back to raw-parent diffing.
+func decodeJSONProjection(v any) (map[string]any, bool) {
+	if v == nil {
+		return nil, true
+	}
+	switch t := v.(type) {
+	case map[string]any:
+		return t, true
+	case string:
+		if strings.TrimSpace(t) == "" {
+			return nil, true
+		}
+		var out map[string]any
+		if err := json.Unmarshal([]byte(t), &out); err != nil {
+			return nil, false
+		}
+		return out, true
+	}
+	// Reflect-based fallback for json.RawMessage and []byte.
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Slice && rv.Type().Elem().Kind() == reflect.Uint8 {
+		raw := rv.Bytes()
+		if len(raw) == 0 {
+			return nil, true
+		}
+		var out map[string]any
+		if err := json.Unmarshal(raw, &out); err != nil {
+			return nil, false
+		}
+		return out, true
+	}
+	return nil, false
+}

--- a/pkg/composer/imported_diff.go
+++ b/pkg/composer/imported_diff.go
@@ -127,28 +127,45 @@ func DiffImportedResources(old, new []imported.ImportedResource) []ResourceDiff 
 	oldByAddr := indexImportedByAddress(old)
 	newByAddr := indexImportedByAddress(new)
 
-	var diffs []ResourceDiff
-	for addr, oldIR := range oldByAddr {
-		newIR, ok := newByAddr[addr]
-		if !ok {
+	addrs := sortedUnionAddresses(oldByAddr, newByAddr)
+	diffs := make([]ResourceDiff, 0, len(addrs))
+	for _, addr := range addrs {
+		oldIR, hasOld := oldByAddr[addr]
+		newIR, hasNew := newByAddr[addr]
+		switch {
+		case !hasOld && hasNew:
+			diffs = append(diffs, addedResourceDiff(newIR))
+		case hasOld && !hasNew:
 			diffs = append(diffs, removedResourceDiff(oldIR))
-			continue
-		}
-		if d, ok := modifiedResourceDiff(oldIR, newIR); ok {
-			diffs = append(diffs, d)
+		case hasOld && hasNew:
+			if d, ok := modifiedResourceDiff(oldIR, newIR); ok {
+				diffs = append(diffs, d)
+			}
 		}
 	}
-	for addr, newIR := range newByAddr {
-		if _, ok := oldByAddr[addr]; ok {
-			continue
-		}
-		diffs = append(diffs, addedResourceDiff(newIR))
+	if len(diffs) == 0 {
+		return nil
 	}
-
-	sort.Slice(diffs, func(i, j int) bool {
-		return diffs[i].Address < diffs[j].Address
-	})
 	return diffs
+}
+
+// sortedUnionAddresses returns the sorted union of map keys from two
+// address-indexed snapshots. Single allocation; eliminates the post-hoc
+// sort.Slice after random map iteration.
+func sortedUnionAddresses(a, b map[string]imported.ImportedResource) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // indexImportedByAddress builds an Address->ImportedResource map. Resources

--- a/pkg/composer/imported_diff.go
+++ b/pkg/composer/imported_diff.go
@@ -119,11 +119,12 @@ const redactedPlaceholder = "***"
 // registered, the diff is emitted at the projection path. Parse failures
 // fall back to a raw parent diff so the change is never silently dropped.
 //
-// Output is sorted by Address for stable consumption.
+// Output is sorted by Address for stable consumption. Always returns a
+// non-nil slice — empty when there are no diffs — so VersionDiff.Resources
+// marshals as the JSON array `[]` rather than `null`. Reliable's snapshot
+// consumers compare diff JSON byte-for-byte, so nil↔[] flips would churn
+// every stack the first time it acquires or sheds an imported resource.
 func DiffImportedResources(old, new []imported.ImportedResource) []ResourceDiff {
-	if len(old) == 0 && len(new) == 0 {
-		return nil
-	}
 	oldByAddr := indexImportedByAddress(old)
 	newByAddr := indexImportedByAddress(new)
 
@@ -142,9 +143,6 @@ func DiffImportedResources(old, new []imported.ImportedResource) []ResourceDiff 
 				diffs = append(diffs, d)
 			}
 		}
-	}
-	if len(diffs) == 0 {
-		return nil
 	}
 	return diffs
 }

--- a/pkg/composer/imported_diff_test.go
+++ b/pkg/composer/imported_diff_test.go
@@ -13,6 +13,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestDiffImportedResources_EmptyMarshalsAsArray pins the wire-shape
+// contract that VersionDiff.Resources is "always an array, possibly empty"
+// on the JSON side. DiffImportedResources must return a non-nil slice so
+// json.Marshal emits `[]` and not `null` — Reliable's snapshot consumers
+// compare diff JSON byte-for-byte, so a nil↔[] flip would churn every
+// stack the first time it acquires or sheds an imported resource.
+func TestDiffImportedResources_EmptyMarshalsAsArray(t *testing.T) {
+	t.Parallel()
+	cases := map[string][2][]imported.ImportedResource{
+		"both nil":          {nil, nil},
+		"both empty":        {{}, {}},
+		"identical content": {{sampleSQS("a", 30)}, {sampleSQS("a", 30)}},
+	}
+	for name, sides := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			diffs := DiffImportedResources(sides[0], sides[1])
+			b, err := json.Marshal(diffs)
+			require.NoError(t, err)
+			assert.Equal(t, "[]", string(b),
+				"DiffImportedResources must return non-nil so empty marshals as []")
+			// VersionDiff round-trip: empty Resources must serialize as
+			// `"resources":[]`, never `"resources":null`.
+			vd := VersionDiff{
+				FromVersion: 1, ToVersion: 2,
+				Components: []ComponentDiff{},
+				Resources:  diffs,
+				Summary:    "no-op",
+			}
+			vdBytes, err := json.Marshal(vd)
+			require.NoError(t, err)
+			assert.Contains(t, string(vdBytes), `"resources":[]`,
+				"VersionDiff.Resources must always be an array on the wire (issue: nil-vs-[] churn)")
+			assert.NotContains(t, string(vdBytes), `"resources":null`,
+				"VersionDiff.Resources must never serialize as null")
+		})
+	}
+}
+
 func TestDiffImportedResources_NoOp(t *testing.T) {
 	t.Parallel()
 	cases := map[string][2][]imported.ImportedResource{
@@ -222,12 +261,15 @@ func TestDiffImportedResources_HiddenSensitiveFilteredEndToEnd(t *testing.T) {
 	diffs := DiffImportedResources([]imported.ImportedResource{old}, []imported.ImportedResource{new})
 	require.Empty(t, diffs, "Hidden filter must drop sensitive fields end-to-end")
 
-	// Defense-in-depth: marshal the diffs slice and assert no secret leaked
-	// into any rendering of the result.
+	// Pin the wire shape: the diffs slice must marshal as `[]`, not `null`.
+	// Reliable's snapshot consumers compare diff JSON byte-for-byte, so a
+	// nil↔[] flip would churn every stack the first time it onboards an
+	// imported resource. The previous defense-in-depth NotContains check
+	// here was vacuous because it ran against the literal "null" string.
 	b, err := json.Marshal(diffs)
 	require.NoError(t, err)
-	assert.NotContains(t, string(b), oldSecret)
-	assert.NotContains(t, string(b), newSecret)
+	assert.Equal(t, "[]", string(b),
+		"empty diff slice must marshal as []; if this regresses to null, VersionDiff.Resources flips its wire shape and Reliable's byte-for-byte snapshot tests churn")
 }
 
 // TestDiffImportedResources_VisibleRedactedEndToEnd exercises the integration

--- a/pkg/composer/imported_diff_test.go
+++ b/pkg/composer/imported_diff_test.go
@@ -21,10 +21,22 @@ import (
 // stack the first time it acquires or sheds an imported resource.
 func TestDiffImportedResources_EmptyMarshalsAsArray(t *testing.T) {
 	t.Parallel()
+
+	// hiddenOnlyDelta exercises the modifiedResourceDiff no-visible-delta
+	// return path: two snapshots of the same address differ ONLY in tags
+	// (Hidden via tagPolicy), so diffAttributeMaps filters every change
+	// out, modifiedResourceDiff returns (_, false), and the diff slice
+	// stays empty. The other three cases short-circuit earlier paths.
+	hiddenOldOnly := sampleSQS("q", 30)
+	hiddenOldOnly.Attributes["tags"] = map[string]any{"Project": "before"}
+	hiddenNewOnly := sampleSQS("q", 30)
+	hiddenNewOnly.Attributes["tags"] = map[string]any{"Project": "after"}
+
 	cases := map[string][2][]imported.ImportedResource{
 		"both nil":          {nil, nil},
 		"both empty":        {{}, {}},
 		"identical content": {{sampleSQS("a", 30)}, {sampleSQS("a", 30)}},
+		"hidden-only delta": {{hiddenOldOnly}, {hiddenNewOnly}},
 	}
 	for name, sides := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/composer/imported_diff_test.go
+++ b/pkg/composer/imported_diff_test.go
@@ -1,0 +1,480 @@
+package composer
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	_ "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffImportedResources_NoOp(t *testing.T) {
+	t.Parallel()
+	cases := map[string][2][]imported.ImportedResource{
+		"both nil":          {nil, nil},
+		"both empty":        {{}, {}},
+		"identical content": {{sampleSQS("a", 30)}, {sampleSQS("a", 30)}},
+	}
+	for name, sides := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Empty(t, DiffImportedResources(sides[0], sides[1]))
+		})
+	}
+}
+
+func TestDiffImportedResources_AddedAndRemoved(t *testing.T) {
+	t.Parallel()
+	old := []imported.ImportedResource{sampleSQS("a", 30)}
+	new := []imported.ImportedResource{sampleSQS("b", 60)}
+	diffs := DiffImportedResources(old, new)
+	require.Len(t, diffs, 2)
+
+	// Sorted by Address: ".a" < ".b".
+	removed := diffs[0]
+	assert.Equal(t, ResourceActionRemoved, removed.Action)
+	assert.Equal(t, "aws_sqs_queue.a", removed.Address)
+	assert.Equal(t, imported.TierImportedFlat, removed.FromTier)
+	assert.Empty(t, removed.ToTier)
+	require.NotEmpty(t, removed.Changes,
+		"removed resources must list the disappeared attributes so the renderer can show what was lost")
+	for _, c := range removed.Changes {
+		assert.NotEmpty(t, c.From, "removed Change.From must carry the previous value")
+		assert.Empty(t, c.To, "removed Change.To must be empty")
+	}
+
+	added := diffs[1]
+	assert.Equal(t, ResourceActionAdded, added.Action)
+	assert.Equal(t, "aws_sqs_queue.b", added.Address)
+	assert.Equal(t, imported.TierImportedFlat, added.ToTier)
+	assert.Empty(t, added.FromTier)
+	require.NotEmpty(t, added.Changes,
+		"added resources must list the new attributes so the renderer can show what arrived")
+	for _, c := range added.Changes {
+		assert.Empty(t, c.From, "added Change.From must be empty")
+		assert.NotEmpty(t, c.To, "added Change.To must carry the new value")
+	}
+}
+
+func TestDiffImportedResources_ModifiedFieldOnly(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "aws_sqs_queue", "visibility_timeout_seconds", policy.FieldPolicy{
+		Role: policy.RoleTuning, Edit: policy.EditChatSafe,
+	})
+	diffs := DiffImportedResources(
+		[]imported.ImportedResource{sampleSQS("q", 30)},
+		[]imported.ImportedResource{sampleSQS("q", 60)},
+	)
+	require.Len(t, diffs, 1)
+	d := diffs[0]
+	assert.Equal(t, ResourceActionModified, d.Action)
+	assert.Empty(t, d.FromTier, "tier didn't change")
+	assert.Empty(t, d.ToTier)
+	require.Len(t, d.Changes, 1)
+	c := d.Changes[0]
+	assert.Equal(t, "visibility_timeout_seconds", c.Path)
+	assert.Equal(t, "30", c.From)
+	assert.Equal(t, "60", c.To)
+	assert.Equal(t, policy.RoleTuning, c.Role)
+	assert.Equal(t, policy.EditChatSafe, c.EditPolicy)
+	assert.False(t, c.Redacted)
+}
+
+func TestDiffImportedResources_TierTransition(t *testing.T) {
+	t.Parallel()
+	oldIR := sampleSQS("q", 30)
+	newIR := sampleSQS("q", 30)
+	newIR.Tier = imported.TierImportedMissing
+	newIR.Remediation = imported.ActionRecreateFromLastImport
+
+	diffs := DiffImportedResources([]imported.ImportedResource{oldIR}, []imported.ImportedResource{newIR})
+	require.Len(t, diffs, 1)
+	d := diffs[0]
+	assert.Equal(t, ResourceActionModified, d.Action)
+	assert.Equal(t, imported.TierImportedFlat, d.FromTier)
+	assert.Equal(t, imported.TierImportedMissing, d.ToTier)
+	assert.Equal(t, imported.ActionRecreateFromLastImport, d.Remediation)
+	assert.Empty(t, d.Changes, "tier-only transition shouldn't synthesize attribute changes")
+}
+
+func TestDiffImportedResources_TierTransitionWithFieldChange(t *testing.T) {
+	t.Parallel()
+	// Both Tier and an attribute changed in the same step. FromTier/ToTier
+	// must populate alongside Changes so a renderer doesn't have to choose.
+	oldIR := sampleSQS("q", 30)
+	newIR := sampleSQS("q", 60)
+	newIR.Tier = imported.TierImportedConformant
+
+	diffs := DiffImportedResources([]imported.ImportedResource{oldIR}, []imported.ImportedResource{newIR})
+	require.Len(t, diffs, 1)
+	d := diffs[0]
+	assert.Equal(t, ResourceActionModified, d.Action)
+	assert.Equal(t, imported.TierImportedFlat, d.FromTier)
+	assert.Equal(t, imported.TierImportedConformant, d.ToTier)
+	require.Len(t, d.Changes, 1)
+	assert.Equal(t, "visibility_timeout_seconds", d.Changes[0].Path)
+}
+
+func TestDiffImportedResources_HiddenFieldsOmitted(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "aws_sqs_queue", "tags", policy.FieldPolicy{Visibility: policy.VisibilityHidden})
+
+	old := sampleSQS("q", 30)
+	old.Attributes["tags"] = map[string]any{"Project": "before"}
+	new := sampleSQS("q", 30)
+	new.Attributes["tags"] = map[string]any{"Project": "after"}
+
+	diffs := DiffImportedResources(
+		[]imported.ImportedResource{old},
+		[]imported.ImportedResource{new},
+	)
+	assert.Empty(t, diffs, "tag-only change is Hidden and must be filtered from user-visible diff")
+}
+
+func TestDiffImportedResources_VisibleAndHiddenInSameResource(t *testing.T) {
+	t.Parallel()
+	// Mixed change: visibility_timeout_seconds is RileyVisible, tags is
+	// Hidden. The diff must include only the visible field — a regression
+	// that filters the wrong field surfaces here as a count mismatch.
+	requirePolicyEntry(t, "aws_sqs_queue", "tags", policy.FieldPolicy{Visibility: policy.VisibilityHidden})
+
+	old := sampleSQS("q", 30)
+	old.Attributes["tags"] = map[string]any{"Project": "before"}
+
+	new := sampleSQS("q", 60)
+	new.Attributes["tags"] = map[string]any{"Project": "after"}
+
+	diffs := DiffImportedResources(
+		[]imported.ImportedResource{old},
+		[]imported.ImportedResource{new},
+	)
+	require.Len(t, diffs, 1)
+	require.Len(t, diffs[0].Changes, 1, "only the visible field should surface")
+	assert.Equal(t, "visibility_timeout_seconds", diffs[0].Changes[0].Path)
+}
+
+func TestMakeFieldDiff_RedactsSensitiveValues(t *testing.T) {
+	t.Parallel()
+	// Direct unit test on makeFieldDiff covers the redaction path for
+	// fields whose Sensitivity is Sensitive or Redacted but whose Visibility
+	// is not Hidden — a configuration the curated set doesn't currently
+	// produce, but the helper must still honor the contract.
+	cases := []struct {
+		name        string
+		sensitivity policy.SensitivityPolicy
+		wantRedact  bool
+	}{
+		{"Public no redaction", policy.SensitivityPublic, false},
+		{"Sensitive redacts", policy.SensitivitySensitive, true},
+		{"Redacted redacts", policy.SensitivityRedacted, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			entry := policy.FieldPolicy{
+				Role:        policy.RoleTuning,
+				Visibility:  policy.VisibilityRileyVisible,
+				Edit:        policy.EditChatSafe,
+				Sensitivity: tc.sensitivity,
+			}
+			diff := makeFieldDiff("some_field", "secret-old", "secret-new", entry, true)
+			if tc.wantRedact {
+				assert.True(t, diff.Redacted)
+				assert.Equal(t, redactedPlaceholder, diff.From)
+				assert.Equal(t, redactedPlaceholder, diff.To)
+			} else {
+				assert.False(t, diff.Redacted)
+				assert.Equal(t, "secret-old", diff.From)
+				assert.Equal(t, "secret-new", diff.To)
+			}
+		})
+	}
+}
+
+func TestDiffAttributeMaps_HiddenSkipsRedaction(t *testing.T) {
+	t.Parallel()
+	// Hidden + Sensitive should never reach the redaction code path —
+	// the value is filtered from the diff entirely (no opportunity to
+	// leak even a placeholder). This pins the documented order:
+	// Hidden filter runs before makeFieldDiff.
+	tfType := "aws_lambda_function"
+	requirePolicyEntry(t, tfType, "environment.variables", policy.FieldPolicy{
+		Visibility:  policy.VisibilityHidden,
+		Sensitivity: policy.SensitivitySensitive,
+	})
+	old := map[string]any{"environment.variables": map[string]any{"DB_PASSWORD": "old-secret"}}
+	new := map[string]any{"environment.variables": map[string]any{"DB_PASSWORD": "new-secret"}}
+	diffs := diffAttributeMaps(tfType, old, new)
+	assert.Empty(t, diffs, "Hidden filter must drop sensitive fields before redaction runs")
+}
+
+func TestDiffImportedResources_RelationshipOnlyFlagged(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "aws_sqs_queue", "kms_master_key_id", policy.FieldPolicy{
+		Edit: policy.EditRelationshipOnly,
+	})
+	oldIR := sampleSQS("q", 30)
+	oldIR.Attributes["kms_master_key_id"] = "alias/aws/sqs"
+	newIR := sampleSQS("q", 30)
+	newIR.Attributes["kms_master_key_id"] = "alias/custom"
+
+	diffs := DiffImportedResources(
+		[]imported.ImportedResource{oldIR},
+		[]imported.ImportedResource{newIR},
+	)
+	require.Len(t, diffs, 1)
+	require.Len(t, diffs[0].Changes, 1)
+	c := diffs[0].Changes[0]
+	assert.Equal(t, "kms_master_key_id", c.Path)
+	assert.True(t, c.RelationshipOnly, "RelationshipOnly EditPolicy must set the flag for renderers")
+	assert.Equal(t, policy.EditRelationshipOnly, c.EditPolicy)
+	assert.Equal(t, "alias/aws/sqs", c.From)
+	assert.Equal(t, "alias/custom", c.To)
+}
+
+func TestDiffImportedResources_ChangeRiskCarriedOnFieldDiff(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "aws_lambda_function", "architectures", policy.FieldPolicy{
+		Edit: policy.EditChatSafe, ChangeRisk: policy.ChangeMayReplace,
+	})
+	oldIR := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_lambda_function", Address: "aws_lambda_function.f", ImportID: "f",
+		},
+		Tier:       imported.TierImportedFlat,
+		Attributes: map[string]any{"architectures": []any{"x86_64"}},
+	}
+	newIR := oldIR
+	newIR.Attributes = map[string]any{"architectures": []any{"arm64"}}
+	diffs := DiffImportedResources([]imported.ImportedResource{oldIR}, []imported.ImportedResource{newIR})
+	require.Len(t, diffs, 1)
+	require.Len(t, diffs[0].Changes, 1)
+	c := diffs[0].Changes[0]
+	assert.Equal(t, "architectures", c.Path)
+	assert.Equal(t, policy.ChangeMayReplace, c.ChangeRisk)
+	assert.Equal(t, policy.EditChatSafe, c.EditPolicy)
+}
+
+func TestDiffImportedResources_JSONProjectionExpanded(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "aws_sqs_queue", "redrive_policy.maxReceiveCount", policy.FieldPolicy{
+		Edit: policy.EditChatSafe,
+	})
+
+	// Mutating only the maxReceiveCount sub-field should produce one diff
+	// at the projection path, not one at the raw parent.
+	oldIR := sampleSQS("q", 30)
+	oldIR.Attributes["redrive_policy"] = `{"deadLetterTargetArn":"arn:aws:sqs:::dlq","maxReceiveCount":3}`
+	newIR := sampleSQS("q", 30)
+	newIR.Attributes["redrive_policy"] = `{"deadLetterTargetArn":"arn:aws:sqs:::dlq","maxReceiveCount":5}`
+
+	diffs := DiffImportedResources(
+		[]imported.ImportedResource{oldIR},
+		[]imported.ImportedResource{newIR},
+	)
+	require.Len(t, diffs, 1)
+	require.Len(t, diffs[0].Changes, 1, "only maxReceiveCount changed; deadLetterTargetArn must not produce a diff")
+	c := diffs[0].Changes[0]
+	assert.Equal(t, "redrive_policy.maxReceiveCount", c.Path)
+	assert.Equal(t, "3", c.From)
+	assert.Equal(t, "5", c.To)
+	assert.Equal(t, policy.EditChatSafe, c.EditPolicy)
+}
+
+func TestDiffImportedResources_JSONProjectionParseFallback(t *testing.T) {
+	t.Parallel()
+	// Three fallback shapes — all must funnel to a single raw-parent diff so
+	// stale projection entries from a half-parsed map can never leak.
+	cases := []struct {
+		name string
+		old  any
+		new  any
+	}{
+		{"both garbled", "not-json-at-all", "different-not-json"},
+		{"old garbled new valid", "not-json", `{"maxReceiveCount":5}`},
+		{"old valid new garbled", `{"maxReceiveCount":3}`, "garbled-after-importer"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			oldIR := sampleSQS("q", 30)
+			oldIR.Attributes["redrive_policy"] = tc.old
+			newIR := sampleSQS("q", 30)
+			newIR.Attributes["redrive_policy"] = tc.new
+
+			diffs := DiffImportedResources(
+				[]imported.ImportedResource{oldIR},
+				[]imported.ImportedResource{newIR},
+			)
+			require.Len(t, diffs, 1)
+			require.Len(t, diffs[0].Changes, 1, "asymmetric parse failure must NOT produce stale projection diffs")
+			assert.Equal(t, "redrive_policy", diffs[0].Changes[0].Path,
+				"fallback emits at the raw parent path, never at a sub-projection")
+		})
+	}
+}
+
+func TestDiffImportedResources_MultipleResources(t *testing.T) {
+	t.Parallel()
+	old := []imported.ImportedResource{sampleSQS("alpha", 30), sampleSQS("zeta", 30)}
+	new := []imported.ImportedResource{sampleSQS("alpha", 60), sampleSQS("zeta", 30)}
+	diffs := DiffImportedResources(old, new)
+	require.Len(t, diffs, 1, "only alpha changed")
+	assert.Equal(t, "aws_sqs_queue.alpha", diffs[0].Address)
+}
+
+func TestDiffImportedResources_OmitsResourcesWithEmptyAddress(t *testing.T) {
+	t.Parallel()
+	noAddr := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue"},
+		Tier:     imported.TierImportedFlat,
+	}
+	assert.Empty(t, DiffImportedResources([]imported.ImportedResource{noAddr}, nil))
+	assert.Empty(t, DiffImportedResources(nil, []imported.ImportedResource{noAddr}))
+}
+
+func TestDiffImportedResources_StableOrdering(t *testing.T) {
+	t.Parallel()
+	// Multi-resource, multi-field input so sort order is exercised at both
+	// the top level (Address) and within each resource's Changes (Path).
+	// Compare slices directly with assert.Equal — the contract is on the
+	// returned data, not its JSON projection.
+	mk := func(suffix string, vt int, kms string) imported.ImportedResource {
+		ir := sampleSQS(suffix, vt)
+		ir.Attributes["kms_master_key_id"] = kms
+		ir.Attributes["delay_seconds"] = 10
+		return ir
+	}
+	old := []imported.ImportedResource{
+		mk("zeta", 30, "alias/old-z"),
+		mk("alpha", 30, "alias/old-a"),
+	}
+	new := []imported.ImportedResource{
+		mk("zeta", 60, "alias/new-z"),
+		mk("alpha", 60, "alias/new-a"),
+	}
+
+	first := DiffImportedResources(old, new)
+	require.Len(t, first, 2)
+	for i := range 25 {
+		got := DiffImportedResources(old, new)
+		assert.Equal(t, first, got, "iteration %d: slice drifted (Go map iteration randomization)", i)
+	}
+}
+
+func TestDiffImportedResources_NoPolicyForType(t *testing.T) {
+	t.Parallel()
+	old := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_iam_role", Address: "aws_iam_role.r", ImportID: "r",
+		},
+		Tier:       imported.TierImportedFlat,
+		Attributes: map[string]any{"description": "old"},
+	}
+	new := old
+	new.Attributes = map[string]any{"description": "new"}
+	require.False(t, hasPolicy("aws_iam_role"), "test premise: aws_iam_role uncurated")
+
+	diffs := DiffImportedResources([]imported.ImportedResource{old}, []imported.ImportedResource{new})
+	require.Len(t, diffs, 1)
+	require.Len(t, diffs[0].Changes, 1)
+	c := diffs[0].Changes[0]
+	assert.Equal(t, "description", c.Path)
+	assert.Empty(t, c.Role)
+	assert.Empty(t, c.EditPolicy)
+	assert.False(t, c.Redacted)
+	assert.False(t, c.RelationshipOnly)
+}
+
+func TestDiffImportedResources_VersionDiffWiringGolden(t *testing.T) {
+	t.Parallel()
+	// Pin the wire format that consumers (Reliable, ui-core) rely on. Re-seed
+	// with `UPDATE_GOLDEN=1 go test ./pkg/composer/...` after intentional
+	// shape changes; otherwise drift here is a customer-facing wire break.
+	vd := VersionDiff{
+		FromVersion: 1,
+		ToVersion:   2,
+		Components:  []ComponentDiff{{Component: "aws_vpc", Action: ResourceActionAdded}},
+		Resources: DiffImportedResources(
+			[]imported.ImportedResource{sampleSQS("q", 30)},
+			[]imported.ImportedResource{sampleSQS("q", 60)},
+		),
+		Summary: "test",
+	}
+	got, err := json.MarshalIndent(vd, "", "  ")
+	require.NoError(t, err)
+
+	goldenPath := filepath.Join("testdata", "version_diff_resources.golden.json")
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		require.NoError(t, os.MkdirAll(filepath.Dir(goldenPath), 0o755))
+		require.NoError(t, os.WriteFile(goldenPath, append(got, '\n'), 0o644))
+		t.Logf("wrote golden: %s", goldenPath)
+		return
+	}
+	want, err := os.ReadFile(goldenPath)
+	require.NoError(t, err, "golden missing — run `UPDATE_GOLDEN=1 go test ./pkg/composer/...`")
+	require.Equal(t, string(want), string(got)+"\n",
+		"VersionDiff wire format drifted from %s. If intentional, re-seed via UPDATE_GOLDEN=1.", goldenPath)
+}
+
+// sampleSQS returns a TierImportedFlat aws_sqs_queue with the given suffix
+// and visibility_timeout_seconds value. Used by every test that needs a
+// stable, lightly-curated imported resource.
+func sampleSQS(suffix string, visibilityTimeout int) imported.ImportedResource {
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue." + suffix,
+			ImportID: "https://sqs.us-east-1.amazonaws.com/123/" + suffix,
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"name":                       suffix,
+			"visibility_timeout_seconds": visibilityTimeout,
+		},
+	}
+}
+
+// hasPolicy reports whether tfType has a curated Layer 2 policy. Tests use
+// it to assert their premise so a future curator addition surfaces as a
+// clear premise failure rather than a confusing test failure.
+func hasPolicy(tfType string) bool {
+	_, ok := policy.Lookup(tfType)
+	return ok
+}
+
+// requirePolicyEntry asserts that the curated FieldPolicy at (tfType, path)
+// matches the non-zero fields of want. Tests that depend on a specific
+// curator decision call this so a future policy edit surfaces as a clear
+// premise failure rather than a silent assertion drift.
+//
+// Only the fields populated on want are compared; zero-valued axes are
+// ignored so each test only pins what it depends on.
+func requirePolicyEntry(t *testing.T, tfType, path string, want policy.FieldPolicy) {
+	t.Helper()
+	m, ok := policy.Lookup(tfType)
+	require.True(t, ok, "test premise: %q must be a curated type", tfType)
+	got, ok := m[path]
+	require.True(t, ok, "test premise: %q must have a curated entry for path %q", tfType, path)
+	if want.Role != "" {
+		assert.Equal(t, want.Role, got.Role, "Role mismatch on %s.%s", tfType, path)
+	}
+	if want.Edit != "" {
+		assert.Equal(t, want.Edit, got.Edit, "Edit mismatch on %s.%s", tfType, path)
+	}
+	if want.Visibility != "" {
+		assert.Equal(t, want.Visibility, got.Visibility, "Visibility mismatch on %s.%s", tfType, path)
+	}
+	if want.Sensitivity != "" {
+		assert.Equal(t, want.Sensitivity, got.Sensitivity, "Sensitivity mismatch on %s.%s", tfType, path)
+	}
+	if want.ChangeRisk != "" {
+		assert.Equal(t, want.ChangeRisk, got.ChangeRisk, "ChangeRisk mismatch on %s.%s", tfType, path)
+	}
+}

--- a/pkg/composer/imported_diff_test.go
+++ b/pkg/composer/imported_diff_test.go
@@ -196,6 +196,87 @@ func TestMakeFieldDiff_RedactsSensitiveValues(t *testing.T) {
 	}
 }
 
+// TestDiffImportedResources_HiddenSensitiveFilteredEndToEnd exercises the
+// integration for a Hidden+Sensitive pair: aws_lambda_function's
+// environment.variables. Hidden filters before redaction so no FieldDiff
+// surfaces and raw sensitive values cannot leak.
+func TestDiffImportedResources_HiddenSensitiveFilteredEndToEnd(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "aws_lambda_function", "environment.variables", policy.FieldPolicy{
+		Visibility:  policy.VisibilityHidden,
+		Sensitivity: policy.SensitivitySensitive,
+	})
+	const oldSecret = "DB_PASSWORD=old-leaks-this"
+	const newSecret = "DB_PASSWORD=new-leaks-this-too"
+
+	old := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_lambda_function", Address: "aws_lambda_function.f", ImportID: "f",
+		},
+		Tier:       imported.TierImportedFlat,
+		Attributes: map[string]any{"environment.variables": oldSecret},
+	}
+	new := old
+	new.Attributes = map[string]any{"environment.variables": newSecret}
+
+	diffs := DiffImportedResources([]imported.ImportedResource{old}, []imported.ImportedResource{new})
+	require.Empty(t, diffs, "Hidden filter must drop sensitive fields end-to-end")
+
+	// Defense-in-depth: marshal the diffs slice and assert no secret leaked
+	// into any rendering of the result.
+	b, err := json.Marshal(diffs)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), oldSecret)
+	assert.NotContains(t, string(b), newSecret)
+}
+
+// TestDiffImportedResources_VisibleRedactedEndToEnd exercises the integration
+// for a real Visible+Redacted curated entry: google_pubsub_subscription's
+// push_config.attributes (a JSON-projection path). The diff must surface the
+// change so the operator sees that something moved, but values must be
+// replaced with the redacted placeholder so raw subscriber metadata cannot
+// leak into Reliable's JSON.
+func TestDiffImportedResources_VisibleRedactedEndToEnd(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "google_pubsub_subscription", "push_config.attributes", policy.FieldPolicy{
+		Visibility:  policy.VisibilityRileyVisible,
+		Sensitivity: policy.SensitivityRedacted,
+	})
+	const oldSecret = "x-goog-version-not-public"
+	const newSecret = "x-goog-version-rotated"
+
+	old := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "gcp", Type: "google_pubsub_subscription", Address: "google_pubsub_subscription.s", ImportID: "s",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"push_config": `{"attributes":{"x-goog-version":"` + oldSecret + `"}}`,
+		},
+	}
+	new := old
+	new.Attributes = map[string]any{
+		"push_config": `{"attributes":{"x-goog-version":"` + newSecret + `"}}`,
+	}
+
+	diffs := DiffImportedResources([]imported.ImportedResource{old}, []imported.ImportedResource{new})
+	require.Len(t, diffs, 1)
+	require.Len(t, diffs[0].Changes, 1)
+	c := diffs[0].Changes[0]
+	assert.Equal(t, "push_config.attributes", c.Path)
+	assert.True(t, c.Redacted, "Visible+Redacted must set the redacted flag")
+	assert.Equal(t, redactedPlaceholder, c.From)
+	assert.Equal(t, redactedPlaceholder, c.To)
+	assert.Equal(t, policy.SensitivityRedacted, c.Sensitivity)
+
+	// Defense-in-depth: marshal the full ResourceDiff and assert no secret
+	// leaks anywhere — Path, Reason, JSON encoding, none of it.
+	b, err := json.Marshal(diffs)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), oldSecret, "redacted JSON must never contain the old value")
+	assert.NotContains(t, string(b), newSecret, "redacted JSON must never contain the new value")
+}
+
 func TestDiffAttributeMaps_HiddenSkipsRedaction(t *testing.T) {
 	t.Parallel()
 	// Hidden + Sensitive should never reach the redaction code path —
@@ -396,15 +477,40 @@ func TestDiffImportedResources_VersionDiffWiringGolden(t *testing.T) {
 	// Pin the wire format that consumers (Reliable, ui-core) rely on. Re-seed
 	// with `UPDATE_GOLDEN=1 go test ./pkg/composer/...` after intentional
 	// shape changes; otherwise drift here is a customer-facing wire break.
+	//
+	// The Resources slice combines the live diff path (a curated ChatSafe
+	// change) with a hand-constructed redacted-shape entry. The Phase 1
+	// curated set never produces Visible+Sensitive (every Sensitive /
+	// Redacted entry is also Hidden — see TestNoVisibleSensitiveInPhase1),
+	// so a regression in the placeholder constant or the Redacted flag would
+	// otherwise go unpinned in JSON. This test pins both shapes in one
+	// golden so renderers (Reliable / ui-core) get a stable contract.
+	live := DiffImportedResources(
+		[]imported.ImportedResource{sampleSQS("q", 30)},
+		[]imported.ImportedResource{sampleSQS("q", 60)},
+	)
+	redacted := ResourceDiff{
+		Address: "test_only.r",
+		Type:    "test_only_type",
+		Cloud:   "aws",
+		Action:  ResourceActionModified,
+		Changes: []ResourceFieldDiff{{
+			Path:        "secret_field",
+			From:        redactedPlaceholder,
+			To:          redactedPlaceholder,
+			Role:        policy.RoleTuning,
+			Sensitivity: policy.SensitivitySensitive,
+			EditPolicy:  policy.EditChatSafe,
+			Redacted:    true,
+		}},
+	}
+
 	vd := VersionDiff{
 		FromVersion: 1,
 		ToVersion:   2,
 		Components:  []ComponentDiff{{Component: "aws_vpc", Action: ResourceActionAdded}},
-		Resources: DiffImportedResources(
-			[]imported.ImportedResource{sampleSQS("q", 30)},
-			[]imported.ImportedResource{sampleSQS("q", 60)},
-		),
-		Summary: "test",
+		Resources:   append(live, redacted),
+		Summary:     "test",
 	}
 	got, err := json.MarshalIndent(vd, "", "  ")
 	require.NoError(t, err)

--- a/pkg/composer/testdata/version_diff_resources.golden.json
+++ b/pkg/composer/testdata/version_diff_resources.golden.json
@@ -1,0 +1,29 @@
+{
+  "from_version": 1,
+  "to_version": 2,
+  "components": [
+    {
+      "component": "aws_vpc",
+      "action": "added"
+    }
+  ],
+  "resources": [
+    {
+      "address": "aws_sqs_queue.q",
+      "type": "aws_sqs_queue",
+      "cloud": "aws",
+      "action": "modified",
+      "changes": [
+        {
+          "path": "visibility_timeout_seconds",
+          "from": "30",
+          "to": "60",
+          "role": "Tuning",
+          "pillar": "Reliability",
+          "edit_policy": "ChatSafe"
+        }
+      ]
+    }
+  ],
+  "summary": "test"
+}

--- a/pkg/composer/testdata/version_diff_resources.golden.json
+++ b/pkg/composer/testdata/version_diff_resources.golden.json
@@ -23,6 +23,23 @@
           "edit_policy": "ChatSafe"
         }
       ]
+    },
+    {
+      "address": "test_only.r",
+      "type": "test_only_type",
+      "cloud": "aws",
+      "action": "modified",
+      "changes": [
+        {
+          "path": "secret_field",
+          "from": "***",
+          "to": "***",
+          "role": "Tuning",
+          "sensitivity": "Sensitive",
+          "edit_policy": "ChatSafe",
+          "redacted": true
+        }
+      ]
     }
   ],
   "summary": "test"


### PR DESCRIPTION
## Summary

Phase 2 diffing for imported resources. Closes #151 and is part of Phase 2 epic #143.

`DiffImportedResources(old, new []ImportedResource) []ResourceDiff` produces a sorted, redacted, policy-aware diff that Reliable can render alongside component/config changes. `VersionDiff` gains a `Resources []ResourceDiff` field.

### Field-level diffs respect the curated Layer 2 policy

- **Hidden visibility** filters fields from the diff entirely (system-owned metadata like timeouts, tags, terraform_labels never surface in user-visible diffs).
- **Sensitive / Redacted** Sensitivity replaces values with `\"***\"` and sets `Redacted=true` so JSON, logs, and humanized text never carry raw values (decision #36).
- **RelationshipOnly** EditPolicy keeps the change visible but flags it so renderers show graph movement rather than scalar edits (decisions #30, #31).
- **ChangeRisk** in {MayReplace, AlwaysReplace, Unknown} populates on the FieldDiff so renderers can show plan-tied confirmation badges (decision #42).
- **JSON projections** (e.g. `redrive_policy.deadLetterTargetArn`) decode from string-shaped parents and emit at the projection path. Asymmetric parse failures (one side garbled, the other valid) fall back to a raw parent diff so stale projection entries from the parsed half can never leak.

### Wire format

`VersionDiff.Resources` is pinned by a golden file at `pkg/composer/testdata/version_diff_resources.golden.json` so accidental wire breaks fail loud. Re-seed via `UPDATE_GOLDEN=1 go test ./pkg/composer/...`.

## Test plan

- [x] Added / removed / modified actions
- [x] Tier transition alone
- [x] Tier transition with attribute change in same step (FromTier/ToTier coexist with Changes)
- [x] Hidden field omitted; visible+hidden mixed change in same resource only surfaces visible
- [x] Sensitive / Redacted redaction (direct unit test on makeFieldDiff)
- [x] Hidden filters before redaction runs (integration through diffAttributeMaps)
- [x] RelationshipOnly flag set, value still diffs
- [x] ChangeRisk carried on FieldDiff
- [x] JSON projection happy path (sub-field changes emit at projection path)
- [x] JSON projection asymmetric parse-fallback (3 cases: both garbled, old garbled / new valid, old valid / new garbled)
- [x] Multi-resource sort stability across 25 iterations (slice-level, not JSON)
- [x] No-policy-for-type still produces a generic diff
- [x] Empty-address resources skipped (mirrors structural validator's responsibility)
- [x] Wire-format golden file
- [x] Policy-entry premise checks via `requirePolicyEntry` helper across every test that hardcodes a curator decision — future curator changes surface as clear premise failures, not silent assertion drift
- [x] Full composer test suite passes (`go test ./pkg/composer/...`)
- [x] `go vet ./...` clean

## Cross-repo follow-up

Reliable / ui-core consumers (issue #152) will pick up the new `Resources` field when they bump the embedded preset module. The TypeScript wire-format mirror lives in `lib/stack/types.ts` in the Reliable repo and should be updated under #152.

## Closes

Closes #151