### PR TITLE
fix(composer): guard [0] indices on count-controlled resources (#178)

### DIFF
--- a/gcp/vpc/main.tf
+++ b/gcp/vpc/main.tf
@@ -63,9 +63,13 @@ module "cloud_nat" {
   source  = "terraform-google-modules/cloud-nat/google"
   version = "~> 5.0"
 
-  project_id    = var.project_id
-  region        = var.region
-  router        = google_compute_router.router[0].name
+  project_id = var.project_id
+  region     = var.region
+  # try() defends against empty-tuple errors when terraform evaluates the
+  # router reference during validation/plan against an empty state (issue
+  # #178). count gates instantiation; try() guarantees the expression itself
+  # never errors.
+  router        = try(google_compute_router.router[0].name, null)
   name          = "${var.project}-nat-${random_id.suffix.hex}"
   network       = module.vpc.network_id
   create_router = false

--- a/gcp/vpc/outputs.tf
+++ b/gcp/vpc/outputs.tf
@@ -40,7 +40,10 @@ output "services_range_name" {
 
 output "router_name" {
   description = "Cloud Router name (if Cloud NAT enabled)"
-  value       = var.enable_cloud_nat ? google_compute_router.router[0].name : null
+  # try() defends against empty-tuple errors on first plan with empty state
+  # (issue #178). The ternary alone is correct in steady state; try() adds
+  # belt-and-braces for the unmaterialized first-plan case.
+  value = try(google_compute_router.router[0].name, null)
 }
 
 output "region" {
@@ -50,6 +53,7 @@ output "region" {
 
 output "connector_id" {
   description = "Serverless VPC Access Connector ID (null if disabled)"
-  value       = var.enable_serverless_connector ? google_vpc_access_connector.serverless[0].id : null
+  # try() — see router_name above (issue #178).
+  value = try(google_vpc_access_connector.serverless[0].id, null)
 }
 

--- a/gcp/vpc/outputs.tf
+++ b/gcp/vpc/outputs.tf
@@ -40,10 +40,12 @@ output "services_range_name" {
 
 output "router_name" {
   description = "Cloud Router name (if Cloud NAT enabled)"
-  # try() defends against empty-tuple errors on first plan with empty state
-  # (issue #178). The ternary alone is correct in steady state; try() adds
-  # belt-and-braces for the unmaterialized first-plan case.
-  value = try(google_compute_router.router[0].name, null)
+  # The ternary preserves the deterministic disabled-by-config contract
+  # (router_name=null when var.enable_cloud_nat=false). The inner try()
+  # defends against the empty-tuple plan-time error on first plan with
+  # empty state (issue #178). Layered: ternary picks the branch
+  # statically, try() makes the picked branch never error.
+  value = var.enable_cloud_nat ? try(google_compute_router.router[0].name, null) : null
 }
 
 output "region" {
@@ -53,7 +55,7 @@ output "region" {
 
 output "connector_id" {
   description = "Serverless VPC Access Connector ID (null if disabled)"
-  # try() — see router_name above (issue #178).
-  value = try(google_vpc_access_connector.serverless[0].id, null)
+  # Layered ternary + try(): see router_name above (issue #178).
+  value = var.enable_serverless_connector ? try(google_vpc_access_connector.serverless[0].id, null) : null
 }
 

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -2087,3 +2087,94 @@ func TestComposeStack_PolymorphicKeyPullsInPrefixedVPC(t *testing.T) {
 	require.Contains(t, mainTF, `module "resource"`,
 		"polymorphic KeyAWSEKSControlPlane preserves its string value and renders as module.resource")
 }
+
+// TestDefaultWiring_GCPSubnetSelfLinkUsesTryGuard pins the issue #178 fix:
+// every GCP module that consumes the VPC's subnets_self_links output must do
+// so via try(module.gcp_vpc.subnet_self_links[0], null), not the raw [0]
+// index. The raw form errors with "Invalid index ... empty tuple" on first
+// terraform plan against an empty state and surfaces as a stage_error in
+// Oracle's custom-stack-provision pipeline.
+//
+// This test exercises every module that consumes subnet_self_link as a
+// scalar wiring input; if a future caller is added without the try() guard
+// the test fails before the regression reaches a customer.
+func TestDefaultWiring_GCPSubnetSelfLinkUsesTryGuard(t *testing.T) {
+	t.Parallel()
+	const wantExpr = "try(module.gcp_vpc.subnet_self_links[0], null)"
+	const rawForm = "module.gcp_vpc.subnet_self_links[0]"
+
+	selected := map[ComponentKey]bool{
+		KeyGCPVPC:          true,
+		KeyGCPGKE:          true,
+		KeyGCPLoadbalancer: true,
+		KeyGCPCompute:      true,
+		KeyGCPBastion:      true,
+	}
+	consumers := []ComponentKey{
+		KeyGCPGKE, KeyGCPLoadbalancer, KeyGCPCompute, KeyGCPBastion,
+	}
+	for _, key := range consumers {
+		t.Run(string(key), func(t *testing.T) {
+			t.Parallel()
+			wi := DefaultWiring(selected, key, &Components{})
+			got, ok := wi.RawHCL["subnet_self_link"]
+			require.True(t, ok, "%s must wire subnet_self_link from gcp_vpc", key)
+			require.Equal(t, wantExpr, got,
+				"%s subnet_self_link must use try() guard (issue #178); raw [0] errors on first plan with empty state", key)
+			require.NotContains(t, got, rawForm+"\n",
+				"%s must not emit unguarded [0] index", key)
+		})
+	}
+}
+
+// TestComposeStack_GCPSubnetSelfLinkInGeneratedHCL is the integration check:
+// a real ComposeStack run against a GCP+VPC+GKE stack must emit the try()
+// expression in the composed main.tf — not the raw [0] form. Mirrors
+// TestComposeStack_AWS_ValidHCL's structural HCL check but targets the
+// specific issue #178 string.
+func TestComposeStack_GCPSubnetSelfLinkInGeneratedHCL(t *testing.T) {
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPVPC, KeyGCPGKE},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-central1"},
+		Project:      "test",
+		Region:       "us-central1",
+		GCPProjectID: "test-project-12345",
+	})
+	require.NoError(t, err)
+
+	mainTF := string(out["/main.tf"])
+	require.Contains(t, mainTF, "try(module.gcp_vpc.subnet_self_links[0], null)",
+		"composed main.tf must use try() guard on subnet_self_links (issue #178)")
+	// Defense: scan every .tf file for the unguarded form.
+	for name, body := range out {
+		if !strings.HasSuffix(name, ".tf") {
+			continue
+		}
+		// The unguarded "module.gcp_vpc.subnet_self_links[0]" substring will
+		// appear inside the try() expression too; the check below ensures
+		// it never appears WITHOUT the surrounding try(...).
+		s := string(body)
+		idx := 0
+		for {
+			at := strings.Index(s[idx:], "module.gcp_vpc.subnet_self_links[0]")
+			if at < 0 {
+				break
+			}
+			start := idx + at
+			prefix := s[max0(start-len("try(")):start]
+			require.Contains(t, prefix, "try(",
+				"%s contains unguarded module.gcp_vpc.subnet_self_links[0] near offset %d", name, start)
+			idx = start + 1
+		}
+	}
+}
+
+func max0(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -2128,15 +2128,78 @@ func TestDefaultWiring_GCPSubnetSelfLinkUsesTryGuard(t *testing.T) {
 }
 
 // TestComposeStack_GCPSubnetSelfLinkInGeneratedHCL is the integration check:
-// a real ComposeStack run against a GCP+VPC+GKE stack must emit the try()
-// expression in the composed main.tf — not the raw [0] form. Mirrors
-// TestComposeStack_AWS_ValidHCL's structural HCL check but targets the
-// specific issue #178 string.
+// a real ComposeStack run against each GCP+VPC consumer combo must emit the
+// try() expression in the composed main.tf and never the raw [0] form
+// outside that try(). Targets issue #178 acceptance criteria: composed HCL
+// against an empty state must not contain unguarded [0] indices on the
+// VPC's subnets_self_links output.
 func TestComposeStack_GCPSubnetSelfLinkInGeneratedHCL(t *testing.T) {
+	// Match `try(module.gcp_vpc.subnet_self_links[0], null)` exactly.
+	guardedRE := regexp.MustCompile(`try\(\s*module\.gcp_vpc\.subnet_self_links\[0\]\s*,\s*null\s*\)`)
+	// Match the unguarded substring (with bracketed [0]). Used to count
+	// raw occurrences and subtract guarded matches; any leftover is an
+	// unguarded bug.
+	rawSubstr := "module.gcp_vpc.subnet_self_links[0]"
+
+	consumerCombos := []struct {
+		name string
+		keys []ComponentKey
+	}{
+		{"gke", []ComponentKey{KeyGCPVPC, KeyGCPGKE}},
+		{"loadbalancer", []ComponentKey{KeyGCPVPC, KeyGCPLoadbalancer}},
+		{"compute", []ComponentKey{KeyGCPVPC, KeyGCPCompute}},
+		{"bastion", []ComponentKey{KeyGCPVPC, KeyGCPBastion}},
+	}
+	for _, combo := range consumerCombos {
+		t.Run(combo.name, func(t *testing.T) {
+			c := newTestClient()
+			out, err := c.ComposeStack(ComposeStackOpts{
+				Cloud:        "gcp",
+				SelectedKeys: combo.keys,
+				Comps:        &Components{},
+				Cfg:          &Config{Region: "us-central1"},
+				Project:      "test",
+				Region:       "us-central1",
+				GCPProjectID: "test-project-12345",
+			})
+			require.NoError(t, err)
+
+			mainTF := string(out["/main.tf"])
+			require.True(t, guardedRE.MatchString(mainTF),
+				"%s: composed main.tf must contain try(module.gcp_vpc.subnet_self_links[0], null) (issue #178)", combo.name)
+
+			for name, body := range out {
+				if !strings.HasSuffix(name, ".tf") {
+					continue
+				}
+				s := string(body)
+				rawCount := strings.Count(s, rawSubstr)
+				guardedCount := len(guardedRE.FindAllString(s, -1))
+				require.Equal(t, rawCount, guardedCount,
+					"%s/%s: every occurrence of %q must be inside try(..., null); raw=%d guarded=%d (issue #178)",
+					combo.name, name, rawSubstr, rawCount, guardedCount)
+			}
+		})
+	}
+}
+
+// TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate runs
+// `terraform validate` on a freshly composed GCP+VPC stack to formally
+// close issue #178's acceptance criterion: composed HCL must validate
+// against an empty state (no plan errors on first run). Skips when the
+// terraform binary isn't installed or when network access (for `init`) is
+// unavailable.
+func TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate(t *testing.T) {
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform binary not on PATH; skipping integration validate")
+	}
+	if os.Getenv("CI_OFFLINE") == "1" {
+		t.Skip("CI_OFFLINE=1 skips terraform init network calls")
+	}
 	c := newTestClient()
 	out, err := c.ComposeStack(ComposeStackOpts{
 		Cloud:        "gcp",
-		SelectedKeys: []ComponentKey{KeyGCPVPC, KeyGCPGKE},
+		SelectedKeys: []ComponentKey{KeyGCPVPC, KeyGCPGKE, KeyGCPLoadbalancer, KeyGCPCompute, KeyGCPBastion},
 		Comps:        &Components{},
 		Cfg:          &Config{Region: "us-central1"},
 		Project:      "test",
@@ -2145,36 +2208,24 @@ func TestComposeStack_GCPSubnetSelfLinkInGeneratedHCL(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	mainTF := string(out["/main.tf"])
-	require.Contains(t, mainTF, "try(module.gcp_vpc.subnet_self_links[0], null)",
-		"composed main.tf must use try() guard on subnet_self_links (issue #178)")
-	// Defense: scan every .tf file for the unguarded form.
-	for name, body := range out {
-		if !strings.HasSuffix(name, ".tf") {
-			continue
-		}
-		// The unguarded "module.gcp_vpc.subnet_self_links[0]" substring will
-		// appear inside the try() expression too; the check below ensures
-		// it never appears WITHOUT the surrounding try(...).
-		s := string(body)
-		idx := 0
-		for {
-			at := strings.Index(s[idx:], "module.gcp_vpc.subnet_self_links[0]")
-			if at < 0 {
-				break
-			}
-			start := idx + at
-			prefix := s[max0(start-len("try(")):start]
-			require.Contains(t, prefix, "try(",
-				"%s contains unguarded module.gcp_vpc.subnet_self_links[0] near offset %d", name, start)
-			idx = start + 1
-		}
-	}
-}
+	dir := t.TempDir()
+	writeOutputs(t, out, dir)
 
-func max0(n int) int {
-	if n < 0 {
-		return 0
+	initCmd := exec.Command("terraform", "init", "-backend=false", "-input=false", "-no-color")
+	initCmd.Dir = dir
+	initOut, err := initCmd.CombinedOutput()
+	if err != nil {
+		t.Skipf("terraform init unavailable (network/cache): %s\n%s", err, initOut)
 	}
-	return n
+	validateCmd := exec.Command("terraform", "validate", "-no-color")
+	validateCmd.Dir = dir
+	validateOut, err := validateCmd.CombinedOutput()
+	require.NoError(t, err, "terraform validate must succeed on composed stack (issue #178):\n%s", validateOut)
+	// Empty-tuple errors and slice errors are the two specific failure
+	// modes from issue #178. If they reappear, fail loud with the
+	// terraform output so a human can see exactly what regressed.
+	require.NotContains(t, string(validateOut), "Invalid index",
+		"terraform validate surfaced 'Invalid index' (issue #178 regression)")
+	require.NotContains(t, string(validateOut), "empty tuple",
+		"terraform validate surfaced 'empty tuple' (issue #178 regression)")
 }

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -2184,48 +2184,81 @@ func TestComposeStack_GCPSubnetSelfLinkInGeneratedHCL(t *testing.T) {
 }
 
 // TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate runs
-// `terraform validate` on a freshly composed GCP+VPC stack to formally
-// close issue #178's acceptance criterion: composed HCL must validate
-// against an empty state (no plan errors on first run). Skips when the
-// terraform binary isn't installed or when network access (for `init`) is
-// unavailable.
+// `terraform validate` on freshly composed GCP+VPC stacks (multiple
+// consumer combos) to formally close issue #178's acceptance criterion:
+// composed HCL must validate against an empty state with no
+// "Invalid index" / "empty tuple" errors.
+//
+// Behavior on init failure differs by environment:
+//
+//   - In CI (env CI=true, set by GitHub Actions): require the test runs.
+//     A `terraform init` failure is a hard test failure so a transient
+//     registry blip can never silently skip the gate that's the formal
+//     closure for #178.
+//   - Local dev (no CI env): skip on init failure so a developer offline
+//     can still run `go test ./...` without the gate forcing a network
+//     round-trip for every test invocation.
+//
+// Use `go test -short` to skip the test entirely (e.g. in pre-commit
+// hooks where the multi-second init+validate is too costly).
 func TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("-short skips multi-second terraform init+validate")
+	}
 	if _, err := exec.LookPath("terraform"); err != nil {
 		t.Skip("terraform binary not on PATH; skipping integration validate")
 	}
-	if os.Getenv("CI_OFFLINE") == "1" {
-		t.Skip("CI_OFFLINE=1 skips terraform init network calls")
-	}
-	c := newTestClient()
-	out, err := c.ComposeStack(ComposeStackOpts{
-		Cloud:        "gcp",
-		SelectedKeys: []ComponentKey{KeyGCPVPC, KeyGCPGKE, KeyGCPLoadbalancer, KeyGCPCompute, KeyGCPBastion},
-		Comps:        &Components{},
-		Cfg:          &Config{Region: "us-central1"},
-		Project:      "test",
-		Region:       "us-central1",
-		GCPProjectID: "test-project-12345",
-	})
-	require.NoError(t, err)
 
-	dir := t.TempDir()
-	writeOutputs(t, out, dir)
+	inCI := os.Getenv("CI") == "true"
 
-	initCmd := exec.Command("terraform", "init", "-backend=false", "-input=false", "-no-color")
-	initCmd.Dir = dir
-	initOut, err := initCmd.CombinedOutput()
-	if err != nil {
-		t.Skipf("terraform init unavailable (network/cache): %s\n%s", err, initOut)
+	// Multiple subset combos catch a regression that only manifests
+	// outside the kitchen-sink stack — e.g. a wiring rule that fires
+	// only when one consumer is paired with the VPC. The subset combos
+	// also exercise enable_cloud_nat / enable_serverless_connector
+	// independently across stacks.
+	combos := []struct {
+		name string
+		keys []ComponentKey
+	}{
+		{"vpc+compute alone", []ComponentKey{KeyGCPVPC, KeyGCPCompute}},
+		{"vpc+gke+loadbalancer+compute+bastion", []ComponentKey{KeyGCPVPC, KeyGCPGKE, KeyGCPLoadbalancer, KeyGCPCompute, KeyGCPBastion}},
 	}
-	validateCmd := exec.Command("terraform", "validate", "-no-color")
-	validateCmd.Dir = dir
-	validateOut, err := validateCmd.CombinedOutput()
-	require.NoError(t, err, "terraform validate must succeed on composed stack (issue #178):\n%s", validateOut)
-	// Empty-tuple errors and slice errors are the two specific failure
-	// modes from issue #178. If they reappear, fail loud with the
-	// terraform output so a human can see exactly what regressed.
-	require.NotContains(t, string(validateOut), "Invalid index",
-		"terraform validate surfaced 'Invalid index' (issue #178 regression)")
-	require.NotContains(t, string(validateOut), "empty tuple",
-		"terraform validate surfaced 'empty tuple' (issue #178 regression)")
+
+	for _, combo := range combos {
+		t.Run(combo.name, func(t *testing.T) {
+			c := newTestClient()
+			out, err := c.ComposeStack(ComposeStackOpts{
+				Cloud:        "gcp",
+				SelectedKeys: combo.keys,
+				Comps:        &Components{},
+				Cfg:          &Config{Region: "us-central1"},
+				Project:      "test",
+				Region:       "us-central1",
+				GCPProjectID: "test-project-12345",
+			})
+			require.NoError(t, err)
+
+			dir := t.TempDir()
+			writeOutputs(t, out, dir)
+
+			initCmd := exec.Command("terraform", "init", "-backend=false", "-input=false", "-no-color")
+			initCmd.Dir = dir
+			initOut, err := initCmd.CombinedOutput()
+			if err != nil {
+				if inCI {
+					require.NoError(t, err,
+						"terraform init must succeed in CI; this gate is the formal closure for issue #178 and must not silently skip on transient registry failures:\n%s", initOut)
+				}
+				t.Skipf("terraform init unavailable (network/cache) in local dev: %s\n%s", err, initOut)
+			}
+			validateCmd := exec.Command("terraform", "validate", "-no-color")
+			validateCmd.Dir = dir
+			validateOut, err := validateCmd.CombinedOutput()
+			require.NoError(t, err, "terraform validate must succeed on composed stack (issue #178):\n%s", validateOut)
+			require.NotContains(t, string(validateOut), "Invalid index",
+				"terraform validate surfaced 'Invalid index' (issue #178 regression)")
+			require.NotContains(t, string(validateOut), "empty tuple",
+				"terraform validate surfaced 'empty tuple' (issue #178 regression)")
+		})
+	}
 }

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -2,6 +2,16 @@ package composer
 
 import "strings"
 
+// vpcSubnetSelfLinkExpr is the wiring expression for any module that consumes
+// gcp_vpc's subnets_self_links output as a single value. It uses try() so
+// terraform plan succeeds against an empty state on the first run (issue
+// #178). On steady state subnet_self_links has length 1 and the [0] index
+// resolves; on first plan when the upstream VPC module hasn't yet
+// materialized the subnet list, the fallback null lets terraform plan
+// progress without producing the "Invalid index ... empty tuple" stage_error
+// that the custom-stack-provision pipeline previously surfaced.
+const vpcSubnetSelfLinkExpr = "try(module.gcp_vpc.subnet_self_links[0], null)"
+
 type ComponentKey string
 
 const (
@@ -745,7 +755,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 	case KeyGCPGKE:
 		if selected[KeyGCPVPC] {
 			wi.RawHCL["network_self_link"] = "module.gcp_vpc.network_self_link"
-			wi.RawHCL["subnet_self_link"] = "module.gcp_vpc.subnet_self_links[0]"
+			wi.RawHCL["subnet_self_link"] = vpcSubnetSelfLinkExpr
 			wi.RawHCL["pods_range_name"] = "module.gcp_vpc.pods_range_name"
 			wi.RawHCL["services_range_name"] = "module.gcp_vpc.services_range_name"
 			wi.Names = append(wi.Names, "network_self_link", "subnet_self_link", "pods_range_name", "services_range_name")
@@ -754,7 +764,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 	case KeyGCPLoadbalancer:
 		if selected[KeyGCPVPC] {
 			wi.RawHCL["network_self_link"] = "module.gcp_vpc.network_self_link"
-			wi.RawHCL["subnet_self_link"] = "module.gcp_vpc.subnet_self_links[0]"
+			wi.RawHCL["subnet_self_link"] = vpcSubnetSelfLinkExpr
 			wi.Names = append(wi.Names, "network_self_link", "subnet_self_link")
 		}
 		if selected[KeyGCPCloudCDN] {
@@ -781,14 +791,14 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 	case KeyGCPCompute:
 		if selected[KeyGCPVPC] {
 			wi.RawHCL["network_self_link"] = "module.gcp_vpc.network_self_link"
-			wi.RawHCL["subnet_self_link"] = "module.gcp_vpc.subnet_self_links[0]"
+			wi.RawHCL["subnet_self_link"] = vpcSubnetSelfLinkExpr
 			wi.Names = append(wi.Names, "network_self_link", "subnet_self_link")
 		}
 
 	case KeyGCPBastion:
 		if selected[KeyGCPVPC] {
 			wi.RawHCL["network_self_link"] = "module.gcp_vpc.network_self_link"
-			wi.RawHCL["subnet_self_link"] = "module.gcp_vpc.subnet_self_links[0]"
+			wi.RawHCL["subnet_self_link"] = vpcSubnetSelfLinkExpr
 			wi.Names = append(wi.Names, "network_self_link", "subnet_self_link")
 		}
 


### PR DESCRIPTION
## Summary

**Customer-blocking.** First `terraform plan` against an empty state errored with `Invalid index ... is empty tuple` on multiple count-controlled resource references in the composer-generated stack. The failure cascaded through Oracle's `custom-stack-provision` pipeline and surfaced as `plan_summary.stage_errors=["custom-stack-provision"]`, visible to operators on every fresh GCP session.

[reliable#1202](https://github.com/luthersystems/reliable/pull/1202) (already merged) maps the wrapper status correctly to `SUCCESS` so user-facing job status is now right. This PR is the upstream fix: stop emitting the spurious diagnostic.

### Repro evidence (from #178)

5 / 20 sampled non-test sessions on staging Neon (last 90 days) hit this stage_error on first GCP plan with empty state. Sample: `sess_v2_h3667DwrK9yb`, `sess_v2_C7-f33hb9ww6`, `sess_v2_xtgvPbQK8lIf`, `sess_v2_oYGVtPx9A_1o`, `sess_v2_6tG2hBH-NFHq`.

## Fixes

- **`pkg/composer/contracts.go`** — every wiring emission of `module.gcp_vpc.subnet_self_links[0]` (4 sites: GKE, Loadbalancer, Compute, Bastion) now uses `try(module.gcp_vpc.subnet_self_links[0], null)` via a single `vpcSubnetSelfLinkExpr` constant. On steady state the `[0]` index resolves; on first plan with empty state, `try()` returns null and lets the plan progress.
- **`gcp/vpc/outputs.tf`** — `router_name` and `connector_id` outputs use `var.enable_X ? try(resource[0].field, null) : null` (layered ternary + try). The outer ternary preserves the disabled-by-config contract; the inner try() defends against the empty-tuple plan-time error. Restored after a QA round flagged the bare `try(...)` form as semantically not-equivalent (it collapses "disabled by config" with "indexing failed").
- **`gcp/vpc/main.tf`** — `module.cloud_nat`'s `router` argument wraps the count-controlled router reference in `try()`.

## Tests

- **`TestDefaultWiring_GCPSubnetSelfLinkUsesTryGuard`** pins the wiring expression for every consumer (gcp_gke, gcp_loadbalancer, gcp_compute, gcp_bastion). Adding a future consumer without the `try()` guard fails this test.
- **`TestComposeStack_GCPSubnetSelfLinkInGeneratedHCL`** parameterized across all 4 consumer combos. Replaces the fragile byte-scan with a regex-anchored count check: `rawCount == guardedCount` per file.
- **`TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate`** runs `terraform init && terraform validate` on freshly composed stacks (two subset combos). Hard-fails in CI on init failure (the formal closure for #178 must not silently skip on a transient registry blip); skips locally for offline dev. `-short` opts out for pre-commit speed.

## Out of scope (tracked elsewhere)

- The KMS upstream module's `slice end_index` error from `terraform-google-modules/kms/google` — opened as follow-up **#180**.
- Reliable-side reconciliation — already shipped in luthersystems/reliable#1202.

## Test plan

- [x] `go test ./pkg/composer/...` passes (full suite, 4 new tests pinning the fix)
- [x] `terraform validate` passes end-to-end on both subset and full-stack combos
- [x] `terraform fmt -check -recursive` passes
- [x] All four static lint scripts pass
- [x] Composer wiring constant `vpcSubnetSelfLinkExpr` consolidates 4 emission sites — single source of truth
- [ ] CI checks pass on this PR
- [ ] **Post-merge**: bump preset version downstream so reliable's embedded composer picks up the fix

## Closes

Closes #178