### PR TITLE
feat(composer): bundle Phase 2 imported-resource SDK work (#149, #151)

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -605,6 +605,7 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// (issue #148). This must happen before generateProvidersTF so that
 	// importedClouds tells the provider emitter which alias to declare.
 	issues = append(issues, ValidateImportedResources(cloud, opts.Imported)...)
+	issues = append(issues, ValidateImportedResourceAuthorization(cloud, opts.Imported)...)
 	provOpts := ProvenanceOpts{ImportProjectID: opts.ImportProjectID}
 	issues = append(issues, ValidateProvenanceConflicts(cloud, opts.Imported, provOpts)...)
 	emitOpts := EmitImportedOpts{

--- a/pkg/composer/diff.go
+++ b/pkg/composer/diff.go
@@ -46,7 +46,12 @@ type VersionDiff struct {
 	Components  []ComponentDiff `json:"components"`
 	Metadata    []MetadataDiff  `json:"metadata,omitempty"`
 	Pricing     []PricingDiff   `json:"pricing,omitempty"`
-	Summary     string          `json:"summary"`
+	// Resources carries imported-resource diffs (Phase 2, issue #151).
+	// Populated by DiffImportedResources from the two snapshots'
+	// ImportedResource lists. Empty when both sides have no imported
+	// resources or when the visible diff is a no-op.
+	Resources []ResourceDiff `json:"resources,omitempty"`
+	Summary   string         `json:"summary"`
 }
 
 // JSONTagName extracts the JSON tag name from a struct field, stripping ",omitempty".

--- a/pkg/composer/diff.go
+++ b/pkg/composer/diff.go
@@ -48,9 +48,11 @@ type VersionDiff struct {
 	Pricing     []PricingDiff   `json:"pricing,omitempty"`
 	// Resources carries imported-resource diffs (Phase 2, issue #151).
 	// Populated by DiffImportedResources from the two snapshots'
-	// ImportedResource lists. Empty when both sides have no imported
-	// resources or when the visible diff is a no-op.
-	Resources []ResourceDiff `json:"resources,omitempty"`
+	// ImportedResource lists. Always present in JSON (mirrors Components)
+	// so consumers see a stable shape; an empty array means "no imported
+	// resource changes," distinct from a nil array which would imply the
+	// field is missing.
+	Resources []ResourceDiff `json:"resources"`
 	Summary   string         `json:"summary"`
 }
 

--- a/pkg/composer/imported/resource.go
+++ b/pkg/composer/imported/resource.go
@@ -116,11 +116,18 @@ func (f ForceTakeover) MarshalJSON() ([]byte, error) {
 // FieldEdit is audit/conflict metadata for one model-side edit to a single
 // attribute. EditedAt is always serialized as RFC3339Nano UTC regardless of
 // the caller-supplied time.Location; see MarshalJSON.
+//
+// Approval is the optional plan-tied operator confirmation required for edits
+// against fields whose curated FieldPolicy is Edit=RequiresApproval, or whose
+// ChangeRiskPolicy implies a destroy/replace plan (MayReplace, AlwaysReplace,
+// Unknown). Absent for the common Edit=ChatSafe / ChangeInPlace path. See
+// docs/managed-resource-tiers.md decision #42.
 type FieldEdit struct {
-	Source   Source    `json:"source,omitempty"`
-	EditedAt time.Time `json:"edited_at"`
-	OldValue any       `json:"old_value,omitempty"`
-	NewValue any       `json:"new_value,omitempty"`
+	Source   Source             `json:"source,omitempty"`
+	EditedAt time.Time          `json:"edited_at"`
+	OldValue any                `json:"old_value,omitempty"`
+	NewValue any                `json:"new_value,omitempty"`
+	Approval *FieldEditApproval `json:"approval,omitempty"`
 }
 
 // MarshalJSON enforces RFC3339Nano UTC on EditedAt. Without this, a caller
@@ -133,6 +140,33 @@ func (f FieldEdit) MarshalJSON() ([]byte, error) {
 		f.EditedAt = f.EditedAt.UTC()
 	}
 	return json.Marshal(alias(f))
+}
+
+// FieldEditApproval is the plan-tied operator confirmation that authorizes a
+// FieldEdit against an Edit=RequiresApproval policy or a ChangeRisk in
+// {MayReplace, AlwaysReplace, Unknown}. All four required fields must be
+// populated; partial approvals are rejected by the authorization validator
+// (imported_resource_field_edit_approval_invalid). PlanHash binds the
+// approval to a specific Terraform plan run so an approval cannot be
+// silently reused against a different plan output.
+//
+// ApprovedAt is always serialized as RFC3339Nano UTC regardless of the
+// caller-supplied time.Location; see MarshalJSON.
+type FieldEditApproval struct {
+	Approver   string    `json:"approver"`
+	ApprovedAt time.Time `json:"approved_at"`
+	PlanHash   string    `json:"plan_hash"`
+	Note       string    `json:"note,omitempty"`
+}
+
+// MarshalJSON enforces RFC3339Nano UTC on ApprovedAt. Mirrors FieldEdit's
+// MarshalJSON.
+func (a FieldEditApproval) MarshalJSON() ([]byte, error) {
+	type alias FieldEditApproval
+	if !a.ApprovedAt.IsZero() {
+		a.ApprovedAt = a.ApprovedAt.UTC()
+	}
+	return json.Marshal(alias(a))
 }
 
 // PresetMatch is a forward-declared graduation hint. It is populated by the

--- a/pkg/composer/imported_authz_validate.go
+++ b/pkg/composer/imported_authz_validate.go
@@ -1,0 +1,349 @@
+package composer
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+)
+
+// ValidateImportedResourceAuthorization enforces the Layer 2 field policy on
+// model-side write paths to imported resources (chat, API, MCP). It is the
+// Phase 2 server-side write authorization sibling of ValidateImportedResources
+// (which carries Phase 1 structural checks). See
+// docs/managed-resource-tiers.md "Editor authority" section and decisions
+// #7, #8, #14, #19, #30, #31, #33, #36, #37, #42, and #43.
+//
+// For each FieldEdit on an imported resource it produces at most one issue
+// per (resource, path) with a snake_case Code drawn from:
+//
+//   - imported_resource_field_edit_no_policy — the resource type has no
+//     Layer 2 policy registered; per decision #43, every imported field is
+//     hidden / system-owned by default and edits to unregistered types are
+//     rejected.
+//   - imported_resource_field_edit_unknown_path — the path does not resolve
+//     against the Layer 1 generated struct or any registered JSON projection
+//     for the resource type (decision #33).
+//   - imported_resource_field_edit_no_policy_for_path — the path resolves
+//     but is absent from the curated map; default deny per decision #43.
+//   - imported_resource_field_edit_forbidden — Edit=Never. Identity fields
+//     (arn, name, region) live here.
+//   - imported_resource_field_edit_system_only — Edit=SystemOnly. Tags,
+//     labels, and provenance attributes are written by the importer/composer
+//     only.
+//   - imported_resource_field_edit_relationship_only — Edit=RelationshipOnly.
+//     Wiring fields (kms_key_id, redrive_policy.deadLetterTargetArn) cannot
+//     be scalar-edited in Phase 2 (decisions #30, #31).
+//   - imported_resource_field_edit_requires_approval — Edit=RequiresApproval
+//     without an Approval audit record on the FieldEdit.
+//   - imported_resource_field_edit_approval_invalid — Approval is set but
+//     missing one of Approver, ApprovedAt, or PlanHash.
+//   - imported_resource_field_edit_replacement_risk_unconfirmed —
+//     ChangeRisk in {MayReplace, AlwaysReplace, Unknown} without an Approval
+//     record attesting plan review (decision #42; Unknown follows the
+//     MayReplace workflow).
+//   - imported_resource_field_edit_reimport_conflict — the resource's
+//     current desired Attributes value at this path no longer matches the
+//     FieldEdit's NewValue. A re-import or other writer overwrote the
+//     pending edit (decision #19); the operator must accept cloud, keep the
+//     edit, or abort.
+//
+// Sensitive field values (Sensitivity=Sensitive or Sensitivity=Redacted) are
+// redacted to "***" in any ValidationIssue.Value emitted by this function so
+// raw sensitive data cannot escape into validation errors, diffs, or chat
+// correction prompts (decision #36).
+//
+// Resources whose tier is not an imported tier (ComposerNative, External*) or
+// whose Identity.Cloud does not match the compose cloud are skipped silently;
+// those mismatches are surfaced by ValidateImportedResources, not here.
+//
+// The function performs no I/O, has no side effects, and returns a stable
+// per-input slice. Output is fed through dedupeAndSortIssues by ValidateAll
+// like every other validator.
+func ValidateImportedResourceAuthorization(cloud string, irs []imported.ImportedResource) []ValidationIssue {
+	if len(irs) == 0 {
+		return nil
+	}
+	want := strings.ToLower(strings.TrimSpace(cloud))
+	var issues []ValidationIssue
+
+	for i, ir := range irs {
+		if !isImportedTier(ir.Tier) {
+			continue
+		}
+		got := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
+		if got != "aws" && got != "gcp" {
+			continue
+		}
+		if want != "" && got != want {
+			continue
+		}
+		if len(ir.FieldEdits) == 0 {
+			continue
+		}
+
+		polMap, hasPol := policy.Lookup(ir.Identity.Type)
+		field := importedField(ir, i)
+
+		for _, path := range sortedFieldEditPaths(ir.FieldEdits) {
+			edit := ir.FieldEdits[path]
+			issueField := field + "." + path
+
+			if !hasPol {
+				issues = append(issues, ValidationIssue{
+					Field:  issueField,
+					Code:   "imported_resource_field_edit_no_policy",
+					Reason: fmt.Sprintf("imported resource type %q has no Layer 2 field policy registered; edits default to hidden / system-owned per decision #43", ir.Identity.Type),
+				})
+				continue
+			}
+
+			if err := policy.ResolvePath(ir.Identity.Type, path); err != nil {
+				issues = append(issues, ValidationIssue{
+					Field:  issueField,
+					Code:   "imported_resource_field_edit_unknown_path",
+					Reason: fmt.Sprintf("imported resource path %q does not resolve against %s: %s", path, ir.Identity.Type, err.Error()),
+				})
+				continue
+			}
+
+			entry, hasEntry := polMap[path]
+			if !hasEntry {
+				issues = append(issues, ValidationIssue{
+					Field:  issueField,
+					Code:   "imported_resource_field_edit_no_policy_for_path",
+					Reason: fmt.Sprintf("imported resource path %q has no curated FieldPolicy on %s; defaults to hidden / system-owned per decision #43", path, ir.Identity.Type),
+				})
+				continue
+			}
+
+			if iss, ok := evaluateEditPolicy(issueField, ir.Identity.Type, path, edit, entry); ok {
+				issues = append(issues, iss)
+				continue
+			}
+
+			if iss, ok := evaluateApproval(issueField, path, edit, entry); ok {
+				issues = append(issues, iss)
+				continue
+			}
+
+			if iss, ok := evaluateChangeRisk(issueField, path, edit, entry); ok {
+				issues = append(issues, iss)
+				continue
+			}
+
+			if iss, ok := evaluateReimportConflict(issueField, path, edit, ir); ok {
+				issues = append(issues, iss)
+				continue
+			}
+		}
+	}
+
+	return issues
+}
+
+// evaluateEditPolicy returns a non-empty issue when the FieldEdit's target
+// policy forbids the write outright (Never, SystemOnly, RelationshipOnly,
+// RequiresApproval-without-approval, or an unrecognized EditPolicy value).
+func evaluateEditPolicy(issueField, tfType, path string, edit imported.FieldEdit, entry policy.FieldPolicy) (ValidationIssue, bool) {
+	redacted := redactValue(entry, edit.NewValue)
+	switch entry.Edit {
+	case policy.EditNever:
+		reason := fmt.Sprintf("imported resource path %q is Edit=Never on %s; field is read-only from every model write path", path, tfType)
+		if entry.Role == policy.RoleIdentity {
+			reason = fmt.Sprintf("imported resource path %q is an identity field (Edit=Never) on %s; identity is immutable from chat/API/MCP", path, tfType)
+		}
+		return ValidationIssue{
+			Field:  issueField,
+			Value:  redacted,
+			Code:   "imported_resource_field_edit_forbidden",
+			Reason: reason,
+		}, true
+	case policy.EditSystemOnly:
+		return ValidationIssue{
+			Field:  issueField,
+			Value:  redacted,
+			Code:   "imported_resource_field_edit_system_only",
+			Reason: fmt.Sprintf("imported resource path %q is Edit=SystemOnly on %s; only the importer/composer writes here (tags, labels, provenance)", path, tfType),
+		}, true
+	case policy.EditRelationshipOnly:
+		return ValidationIssue{
+			Field:      issueField,
+			Value:      redacted,
+			Code:       "imported_resource_field_edit_relationship_only",
+			Reason:     fmt.Sprintf("imported resource path %q is Edit=RelationshipOnly on %s; raw wiring values are owned by the graph, not scalar-editable in Phase 2 (decision #30)", path, tfType),
+			Suggestion: "use a future graph-editing operation to change the relationship",
+		}, true
+	case policy.EditChatSafe, policy.EditRequiresApproval:
+		return ValidationIssue{}, false
+	default:
+		return ValidationIssue{
+			Field:  issueField,
+			Value:  redacted,
+			Code:   "imported_resource_field_edit_forbidden",
+			Reason: fmt.Sprintf("imported resource path %q on %s has unknown EditPolicy %q", path, tfType, string(entry.Edit)),
+		}, true
+	}
+}
+
+// evaluateApproval returns an issue when Edit=RequiresApproval but the
+// FieldEdit lacks a complete approval audit record. Edits with non-approval
+// EditPolicy values fall through (their gates run elsewhere).
+func evaluateApproval(issueField, path string, edit imported.FieldEdit, entry policy.FieldPolicy) (ValidationIssue, bool) {
+	if entry.Edit != policy.EditRequiresApproval {
+		return ValidationIssue{}, false
+	}
+	if edit.Approval == nil {
+		return ValidationIssue{
+			Field:      issueField,
+			Value:      redactValue(entry, edit.NewValue),
+			Code:       "imported_resource_field_edit_requires_approval",
+			Reason:     fmt.Sprintf("imported resource path %q is Edit=RequiresApproval; FieldEdit must carry plan-tied Approval audit metadata before apply (decision #42)", path),
+			Suggestion: "set FieldEdit.Approval with approver, approved_at, and plan_hash bound to the reviewed plan",
+		}, true
+	}
+	if iss, ok := approvalCompletenessIssue(issueField, path, edit.Approval); ok {
+		return iss, true
+	}
+	return ValidationIssue{}, false
+}
+
+// evaluateChangeRisk returns an issue when the field's ChangeRisk implies a
+// destroy/replace plan and the FieldEdit lacks a complete approval record
+// (per decision #42, Unknown follows the MayReplace workflow). InPlace and
+// the empty default fall through.
+func evaluateChangeRisk(issueField, path string, edit imported.FieldEdit, entry policy.FieldPolicy) (ValidationIssue, bool) {
+	if !requiresPlanConfirmation(entry.ChangeRisk) {
+		return ValidationIssue{}, false
+	}
+	if edit.Approval == nil {
+		return ValidationIssue{
+			Field:      issueField,
+			Value:      redactValue(entry, edit.NewValue),
+			Code:       "imported_resource_field_edit_replacement_risk_unconfirmed",
+			Reason:     fmt.Sprintf("imported resource path %q has ChangeRisk=%s; concrete Terraform plan review and explicit operator confirmation required before apply (decision #42)", path, displayChangeRisk(entry.ChangeRisk)),
+			Suggestion: "review the plan, then set FieldEdit.Approval with the reviewed plan_hash",
+		}, true
+	}
+	if iss, ok := approvalCompletenessIssue(issueField, path, edit.Approval); ok {
+		return iss, true
+	}
+	return ValidationIssue{}, false
+}
+
+// approvalCompletenessIssue checks the four required Approval fields and
+// returns imported_resource_field_edit_approval_invalid if any are missing.
+// PlanHash is required so an approval cannot be silently reused across plans.
+func approvalCompletenessIssue(issueField, path string, ap *imported.FieldEditApproval) (ValidationIssue, bool) {
+	if ap == nil {
+		return ValidationIssue{}, false
+	}
+	missing := []string{}
+	if strings.TrimSpace(ap.Approver) == "" {
+		missing = append(missing, "approver")
+	}
+	if ap.ApprovedAt.IsZero() {
+		missing = append(missing, "approved_at")
+	}
+	if strings.TrimSpace(ap.PlanHash) == "" {
+		missing = append(missing, "plan_hash")
+	}
+	if len(missing) == 0 {
+		return ValidationIssue{}, false
+	}
+	return ValidationIssue{
+		Field:      issueField,
+		Code:       "imported_resource_field_edit_approval_invalid",
+		Reason:     fmt.Sprintf("imported resource path %q FieldEdit.Approval is missing required field(s): %s", path, strings.Join(missing, ", ")),
+		Suggestion: "populate every required Approval field before retrying",
+	}, true
+}
+
+// evaluateReimportConflict checks whether the resource's desired Attributes
+// value at path still matches the FieldEdit's NewValue. A divergence means a
+// re-import (or other writer) clobbered the pending edit; per decision #19
+// the operator must explicitly resolve before apply. Returns no issue when
+// either side cannot be observed deterministically (nested paths, typed-only
+// Attrs, or absent OldValue/NewValue) — the structural Phase 1 validators and
+// Reliable's chat-stream loop carry the rest.
+func evaluateReimportConflict(issueField, path string, edit imported.FieldEdit, ir imported.ImportedResource) (ValidationIssue, bool) {
+	desired, ok := lookupTopLevelAttribute(ir.Attributes, path)
+	if !ok {
+		return ValidationIssue{}, false
+	}
+	if edit.NewValue == nil {
+		return ValidationIssue{}, false
+	}
+	if reflect.DeepEqual(desired, edit.NewValue) {
+		return ValidationIssue{}, false
+	}
+	return ValidationIssue{
+		Field:      issueField,
+		Code:       "imported_resource_field_edit_reimport_conflict",
+		Reason:     fmt.Sprintf("imported resource path %q has a pending FieldEdit but desired state diverged from FieldEdit.NewValue; a re-import or other writer overwrote the edit (decision #19)", path),
+		Suggestion: "operator must accept cloud, keep the edit, or abort",
+	}, true
+}
+
+// lookupTopLevelAttribute returns the value at path in attrs when the path
+// is a single segment with no dotted/bracketed sub-structure. Anything more
+// complex (nested objects, JSON projections) returns ok=false; conflict
+// detection conservatively no-ops on those paths in v1 rather than guessing.
+func lookupTopLevelAttribute(attrs map[string]any, path string) (any, bool) {
+	if len(attrs) == 0 {
+		return nil, false
+	}
+	if strings.ContainsAny(path, ".[") {
+		return nil, false
+	}
+	v, ok := attrs[path]
+	return v, ok
+}
+
+// requiresPlanConfirmation reports whether c demands a plan-tied operator
+// confirmation per decision #42. Only explicit MayReplace, AlwaysReplace, or
+// Unknown trigger the gate; the empty default is treated as implicit InPlace
+// per curator convention (every Phase 1 policy file leaves ChangeRisk unset
+// on safely-edited tuning fields). Decision #42's "Unknown follows MayReplace"
+// means an explicit Unknown gates apply, not that every uncurated field does.
+func requiresPlanConfirmation(c policy.ChangeRiskPolicy) bool {
+	switch c {
+	case policy.ChangeMayReplace, policy.ChangeAlwaysReplace, policy.ChangeUnknown:
+		return true
+	}
+	return false
+}
+
+// displayChangeRisk renders c for human-readable issue Reason strings.
+func displayChangeRisk(c policy.ChangeRiskPolicy) string {
+	return string(c)
+}
+
+// redactValue renders v for ValidationIssue.Value, replacing anything routed
+// through a Sensitive or Redacted policy with "***" so raw sensitive data
+// never escapes into errors, diffs, or chat correction prompts (decision #36).
+func redactValue(p policy.FieldPolicy, v any) string {
+	if v == nil {
+		return ""
+	}
+	switch p.Sensitivity {
+	case policy.SensitivitySensitive, policy.SensitivityRedacted:
+		return "***"
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+// sortedFieldEditPaths returns the keys of edits sorted lexicographically so
+// the per-FieldEdit issue order is stable across runs (Go map iteration is
+// otherwise randomized).
+func sortedFieldEditPaths(edits map[string]imported.FieldEdit) []string {
+	paths := make([]string, 0, len(edits))
+	for p := range edits {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	return paths
+}

--- a/pkg/composer/imported_authz_validate.go
+++ b/pkg/composer/imported_authz_validate.go
@@ -101,17 +101,21 @@ func ValidateImportedResourceAuthorization(cloud string, irs []imported.Imported
 				continue
 			}
 
-			if err := policy.ResolvePath(ir.Identity.Type, path); err != nil {
-				issues = append(issues, ValidationIssue{
-					Field:  issueField,
-					Code:   "imported_resource_field_edit_unknown_path",
-					Reason: fmt.Sprintf("imported resource path %q does not resolve against %s: %s", path, ir.Identity.Type, err.Error()),
-				})
-				continue
-			}
-
+			// Curated paths short-circuit the reflective ResolvePath walk:
+			// presence in the policy map implies resolvability (the lint
+			// rejects unresolvable curated paths). Only run ResolvePath to
+			// disambiguate "unknown path" vs "uncurated path" for paths
+			// the curator hasn't listed.
 			entry, hasEntry := polMap[path]
 			if !hasEntry {
+				if err := policy.ResolvePath(ir.Identity.Type, path); err != nil {
+					issues = append(issues, ValidationIssue{
+						Field:  issueField,
+						Code:   "imported_resource_field_edit_unknown_path",
+						Reason: fmt.Sprintf("imported resource path %q does not resolve against %s: %s", path, ir.Identity.Type, err.Error()),
+					})
+					continue
+				}
 				issues = append(issues, ValidationIssue{
 					Field:  issueField,
 					Code:   "imported_resource_field_edit_no_policy_for_path",

--- a/pkg/composer/imported_authz_validate_test.go
+++ b/pkg/composer/imported_authz_validate_test.go
@@ -59,6 +59,96 @@ func TestValidateImportedResourceAuthorization_NonImportedTiersFiltered(t *testi
 	}
 }
 
+// TestValidateImportedResourceAuthorization_TierImportedMissingFiresAuthzGates
+// pins the current behavior for FieldEdits against a TierImportedMissing
+// resource: authorization gates DO fire (the structural validator reports
+// imported_resource_missing_remediation in parallel via ValidateImportedResources).
+// A future maintainer who decides ImportedMissing should skip authorization
+// must update this test together with the design doc.
+func TestValidateImportedResourceAuthorization_TierImportedMissingFiresAuthzGates(t *testing.T) {
+	t.Parallel()
+	// name is Edit=Never on aws_sqs_queue — a forbidden edit on a missing
+	// resource still produces the forbidden code. The operator sees both
+	// the missing-remediation issue (from the structural validator) AND
+	// the authorization issue (from this validator) so the error message
+	// is coherent: pick a remediation AND don't try to edit identity.
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedMissing,
+		FieldEdits: map[string]imported.FieldEdit{
+			"name": {Source: imported.SourceRiley, NewValue: "rename"},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_forbidden", issues[0].Code,
+		"TierImportedMissing must not silently bypass EditPolicy gates")
+}
+
+// TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPaths
+// pins the current Phase 2 v1 behavior: re-import conflict detection is
+// deliberately conservative and only checks top-level Attribute paths.
+// Dotted (environment.variables) and bracketed (lifecycle_rule[0]) paths
+// no-op the conflict gate to avoid speculating about JSON projections.
+//
+// If a future PR expands lookupTopLevelAttribute to handle nested paths
+// (e.g. via decodeJSONProjection from imported_diff.go), this test must be
+// updated alongside that change so the gap closure is visible.
+func TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPaths(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		path string
+	}{
+		// google_pubsub_subscription has push_config.attributes as a real
+		// curated path. Edit=RequiresApproval, so we supply a complete
+		// approval to bypass that gate; only the conflict gate could fire.
+		{"dotted JSON-projection path", "push_config.attributes"},
+	}
+	approval := &imported.FieldEditApproval{
+		Approver:   "ops@luthersystems.com",
+		ApprovedAt: time.Now(),
+		PlanHash:   "plan-nested",
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// FieldEdit.NewValue diverges from Attributes — would trip the
+			// conflict gate if it ran. The conservative no-op behavior
+			// means no issue surfaces.
+			irs := []imported.ImportedResource{{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "gcp",
+					Type:     "google_pubsub_subscription",
+					Address:  "google_pubsub_subscription.s",
+					ImportID: "s",
+				},
+				Tier: imported.TierImportedFlat,
+				Attributes: map[string]any{
+					"push_config": `{"attributes":{"x-goog-version":"old"}}`,
+				},
+				FieldEdits: map[string]imported.FieldEdit{
+					tc.path: {
+						Source:   imported.SourceRiley,
+						NewValue: "wholly-different",
+						Approval: approval,
+					},
+				},
+			}}
+			issues := ValidateImportedResourceAuthorization("gcp", irs)
+			for _, iss := range issues {
+				assert.NotEqual(t, "imported_resource_field_edit_reimport_conflict", iss.Code,
+					"nested paths currently no-op the conflict gate; if this changed, update TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPaths together with lookupTopLevelAttribute")
+			}
+		})
+	}
+}
+
 func TestValidateImportedResourceAuthorization_CloudMismatch(t *testing.T) {
 	t.Parallel()
 	// Compose cloud differs from the resource's cloud — the structural
@@ -248,6 +338,7 @@ func TestValidateImportedResourceAuthorization_RequiresApprovalIncomplete(t *tes
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ap := tc.ap
 			irs := []imported.ImportedResource{{
 				Identity: imported.ResourceIdentity{

--- a/pkg/composer/imported_authz_validate_test.go
+++ b/pkg/composer/imported_authz_validate_test.go
@@ -762,12 +762,17 @@ func firstUncuratedResolvablePath(tfType string, candidates []string) (string, b
 // premise so a future curator change surfaces as a clear premise failure
 // rather than a confusing test-body assertion drift.
 //
-// PR #151 (ResourceDiff) ships a same-named helper in imported_diff_test.go;
-// when both PRs land, whichever merges second hits a redeclaration error
-// and the duplicate must be deleted as part of that merge. Keeping the
-// names identical (rather than mechanically suffixing one) forces that
-// cleanup to happen rather than leaving two near-identical helpers in the
-// package.
+// PR #151 (ResourceDiff) ships a same-named helper in imported_diff_test.go.
+// Once both PRs merge, the package will contain two definitions of
+// requirePolicyEntry and `go test ./pkg/composer/...` fails to compile
+// with "requirePolicyEntry redeclared." (Note: the text-level git merge
+// itself succeeds — different files, no overlap — so this is NOT caught
+// by `git merge`; the second PR's CI catches it pre-merge only when
+// branch protection requires up-to-date-with-main.) The duplicate must
+// be deleted as part of that second merge. Tracked in #183 so the
+// cleanup doesn't get lost. Keeping the names identical (rather than
+// mechanically suffixing one) forces the consolidation rather than
+// leaving two near-identical helpers in the package permanently.
 func requirePolicyEntry(t *testing.T, tfType, path string, want policy.FieldPolicy) {
 	t.Helper()
 	m, ok := policy.Lookup(tfType)

--- a/pkg/composer/imported_authz_validate_test.go
+++ b/pkg/composer/imported_authz_validate_test.go
@@ -71,7 +71,7 @@ func TestValidateImportedResourceAuthorization_NonImportedTiersFiltered(t *testi
 // structural validator stopped reporting missing_remediation.
 func TestValidateImportedResourceAuthorization_TierImportedMissingFiresBothValidators(t *testing.T) {
 	t.Parallel()
-	requirePolicyEntryAuthz(t, "aws_sqs_queue", "name", policy.FieldPolicy{
+	requirePolicyEntry(t, "aws_sqs_queue", "name", policy.FieldPolicy{
 		Role: policy.RoleIdentity, Edit: policy.EditNever,
 	})
 	irs := []imported.ImportedResource{{
@@ -130,7 +130,15 @@ func TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPath
 			// If the curator removes or downgrades it, this test would
 			// silently pass for the wrong reason (the path would now route
 			// through no_policy_for_path instead of being authorized).
-			requirePolicyEntryAuthz(t, "google_pubsub_subscription", tc.path, policy.FieldPolicy{
+			//
+			// Sensitivity is intentionally NOT pinned here. The curator
+			// has push_config.attributes as Sensitivity=Redacted, but this
+			// test asserts no issue surfaces — so the redaction code path
+			// (which only formats ValidationIssue.Value) never runs.
+			// A curator flipping Sensitivity wouldn't change this test's
+			// outcome; pinning it would couple the premise to detail the
+			// test doesn't depend on.
+			requirePolicyEntry(t, "google_pubsub_subscription", tc.path, policy.FieldPolicy{
 				Edit: policy.EditRequiresApproval,
 			})
 
@@ -749,12 +757,18 @@ func firstUncuratedResolvablePath(tfType string, candidates []string) (string, b
 	return "", false
 }
 
-// requirePolicyEntryAuthz asserts that tfType has a curated FieldPolicy for
-// path matching the non-zero fields of want. Mirrors the same-named helper
-// in imported_diff_test.go (declared separately so the two test files don't
-// depend on each other's build order). Renamed _Authz to dodge the linker
-// collision when both test files are linked into the same package.
-func requirePolicyEntryAuthz(t *testing.T, tfType, path string, want policy.FieldPolicy) {
+// requirePolicyEntry asserts that tfType has a curated FieldPolicy for
+// path matching the non-zero fields of want. Tests use it to pin their
+// premise so a future curator change surfaces as a clear premise failure
+// rather than a confusing test-body assertion drift.
+//
+// PR #151 (ResourceDiff) ships a same-named helper in imported_diff_test.go;
+// when both PRs land, whichever merges second hits a redeclaration error
+// and the duplicate must be deleted as part of that merge. Keeping the
+// names identical (rather than mechanically suffixing one) forces that
+// cleanup to happen rather than leaving two near-identical helpers in the
+// package.
+func requirePolicyEntry(t *testing.T, tfType, path string, want policy.FieldPolicy) {
 	t.Helper()
 	m, ok := policy.Lookup(tfType)
 	require.True(t, ok, "test premise: %q must be a curated type", tfType)

--- a/pkg/composer/imported_authz_validate_test.go
+++ b/pkg/composer/imported_authz_validate_test.go
@@ -59,19 +59,21 @@ func TestValidateImportedResourceAuthorization_NonImportedTiersFiltered(t *testi
 	}
 }
 
-// TestValidateImportedResourceAuthorization_TierImportedMissingFiresAuthzGates
-// pins the current behavior for FieldEdits against a TierImportedMissing
-// resource: authorization gates DO fire (the structural validator reports
-// imported_resource_missing_remediation in parallel via ValidateImportedResources).
-// A future maintainer who decides ImportedMissing should skip authorization
-// must update this test together with the design doc.
-func TestValidateImportedResourceAuthorization_TierImportedMissingFiresAuthzGates(t *testing.T) {
+// TestValidateImportedResourceAuthorization_TierImportedMissingFiresBothValidators
+// pins the dual-issue behavior on TierImportedMissing resources with
+// FieldEdits: ValidateImportedResources reports missing_remediation AND
+// ValidateImportedResourceAuthorization reports the authz gate violation.
+// Both fire from one ValidateAll call so the operator sees a coherent
+// message ("pick a remediation AND don't try to edit identity"). A future
+// maintainer who wants ImportedMissing to skip authorization must update
+// both this test and the design doc — the previous formulation only ran
+// the authz validator and would not have caught a regression where the
+// structural validator stopped reporting missing_remediation.
+func TestValidateImportedResourceAuthorization_TierImportedMissingFiresBothValidators(t *testing.T) {
 	t.Parallel()
-	// name is Edit=Never on aws_sqs_queue — a forbidden edit on a missing
-	// resource still produces the forbidden code. The operator sees both
-	// the missing-remediation issue (from the structural validator) AND
-	// the authorization issue (from this validator) so the error message
-	// is coherent: pick a remediation AND don't try to edit identity.
+	requirePolicyEntryAuthz(t, "aws_sqs_queue", "name", policy.FieldPolicy{
+		Role: policy.RoleIdentity, Edit: policy.EditNever,
+	})
 	irs := []imported.ImportedResource{{
 		Identity: imported.ResourceIdentity{
 			Cloud:    "aws",
@@ -84,10 +86,16 @@ func TestValidateImportedResourceAuthorization_TierImportedMissingFiresAuthzGate
 			"name": {Source: imported.SourceRiley, NewValue: "rename"},
 		},
 	}}
-	issues := ValidateImportedResourceAuthorization("aws", irs)
-	require.Len(t, issues, 1)
-	assert.Equal(t, "imported_resource_field_edit_forbidden", issues[0].Code,
-		"TierImportedMissing must not silently bypass EditPolicy gates")
+
+	all := ValidateAll(nil, nil, nil, nil, nil, nil, ComposeStackOpts{
+		Cloud:    "aws",
+		Imported: irs,
+	})
+	codes := issueCodes(all)
+	assert.Contains(t, codes, "imported_resource_missing_remediation",
+		"structural validator must surface missing_remediation; got codes=%v", codes)
+	assert.Contains(t, codes, "imported_resource_field_edit_forbidden",
+		"authz validator must still gate Edit=Never even on TierImportedMissing; got codes=%v", codes)
 }
 
 // TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPaths
@@ -118,9 +126,18 @@ func TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPath
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			// Premise: the path must be a real curated RequiresApproval entry.
+			// If the curator removes or downgrades it, this test would
+			// silently pass for the wrong reason (the path would now route
+			// through no_policy_for_path instead of being authorized).
+			requirePolicyEntryAuthz(t, "google_pubsub_subscription", tc.path, policy.FieldPolicy{
+				Edit: policy.EditRequiresApproval,
+			})
+
 			// FieldEdit.NewValue diverges from Attributes — would trip the
 			// conflict gate if it ran. The conservative no-op behavior
-			// means no issue surfaces.
+			// means NO issue surfaces (the approval is complete, the path
+			// is curated, the conflict gate skips dotted paths).
 			irs := []imported.ImportedResource{{
 				Identity: imported.ResourceIdentity{
 					Cloud:    "gcp",
@@ -141,10 +158,12 @@ func TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPath
 				},
 			}}
 			issues := ValidateImportedResourceAuthorization("gcp", irs)
-			for _, iss := range issues {
-				assert.NotEqual(t, "imported_resource_field_edit_reimport_conflict", iss.Code,
-					"nested paths currently no-op the conflict gate; if this changed, update TestValidateImportedResourceAuthorization_ReimportConflictNoOpsOnNestedPaths together with lookupTopLevelAttribute")
-			}
+			// Stricter than NotEqual on each code: a regression that
+			// silently masks the conflict gate behind some OTHER gate
+			// (e.g. unknown_path) would have passed the previous
+			// formulation. Require zero issues so any masking surfaces.
+			require.Empty(t, issues,
+				"nested-path conflict gate must no-op AND no other gate may mask it; if this regresses, update lookupTopLevelAttribute together with this test")
 		})
 	}
 }
@@ -728,4 +747,55 @@ func firstUncuratedResolvablePath(tfType string, candidates []string) (string, b
 		return c, true
 	}
 	return "", false
+}
+
+// requirePolicyEntryAuthz asserts that tfType has a curated FieldPolicy for
+// path matching the non-zero fields of want. Mirrors the same-named helper
+// in imported_diff_test.go (declared separately so the two test files don't
+// depend on each other's build order). Renamed _Authz to dodge the linker
+// collision when both test files are linked into the same package.
+func requirePolicyEntryAuthz(t *testing.T, tfType, path string, want policy.FieldPolicy) {
+	t.Helper()
+	m, ok := policy.Lookup(tfType)
+	require.True(t, ok, "test premise: %q must be a curated type", tfType)
+	got, ok := m[path]
+	require.True(t, ok, "test premise: %q must have a curated entry for path %q", tfType, path)
+	if want.Role != "" {
+		assert.Equal(t, want.Role, got.Role, "Role mismatch on %s.%s", tfType, path)
+	}
+	if want.Edit != "" {
+		assert.Equal(t, want.Edit, got.Edit, "Edit mismatch on %s.%s", tfType, path)
+	}
+	if want.Visibility != "" {
+		assert.Equal(t, want.Visibility, got.Visibility, "Visibility mismatch on %s.%s", tfType, path)
+	}
+	if want.Sensitivity != "" {
+		assert.Equal(t, want.Sensitivity, got.Sensitivity, "Sensitivity mismatch on %s.%s", tfType, path)
+	}
+	if want.ChangeRisk != "" {
+		assert.Equal(t, want.ChangeRisk, got.ChangeRisk, "ChangeRisk mismatch on %s.%s", tfType, path)
+	}
+}
+
+// TestEveryCuratedPathResolves makes the curator-lint dependency explicit:
+// every curated path on every registered type must resolve cleanly via
+// policy.ResolvePath against the generated struct (or a registered JSON
+// projection). The authz validator's gate-chain reorder skips ResolvePath on
+// curated paths to avoid the reflective walk on the hot path; that
+// optimization is correct only if EVERY curated path is structurally
+// reachable. Without this test, a curator typo (or a generator-side rename)
+// could bypass the unknown_path diagnostic and emit a confusing
+// forbidden/approval issue against a path that doesn't exist on the struct.
+func TestEveryCuratedPathResolves(t *testing.T) {
+	t.Parallel()
+	for _, tfType := range policy.RegisteredTypes() {
+		m, ok := policy.Lookup(tfType)
+		require.True(t, ok)
+		for path := range m {
+			err := policy.ResolvePath(tfType, path)
+			assert.NoErrorf(t, err,
+				"curated policy %s.%s must resolve via policy.ResolvePath; if this fails, the authz validator's curated-path optimization (imported_authz_validate.go) bypasses the unknown_path diagnostic for this entry",
+				tfType, path)
+		}
+	}
 }

--- a/pkg/composer/imported_authz_validate_test.go
+++ b/pkg/composer/imported_authz_validate_test.go
@@ -1,0 +1,640 @@
+package composer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	_ "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateImportedResourceAuthorization_NoOpInputs(t *testing.T) {
+	t.Parallel()
+	noFieldEdits := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "https://sqs.us-east-1.amazonaws.com/123/q",
+		},
+		Tier: imported.TierImportedFlat,
+	}}
+	cases := map[string][]imported.ImportedResource{
+		"nil slice":              nil,
+		"empty slice":            {},
+		"resources but no edits": noFieldEdits,
+	}
+	for name, irs := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+		})
+	}
+}
+
+func TestValidateImportedResourceAuthorization_NonImportedTiersFiltered(t *testing.T) {
+	t.Parallel()
+	// FieldEdits on every non-imported tier must produce zero issues; this
+	// validator's contract is bounded to imported tiers only. Iterating each
+	// tier explicitly catches a mutation that swaps the tier predicate.
+	nonImportedTiers := []imported.Tier{
+		imported.TierComposerNative,
+		imported.TierComposerGraduated,
+		imported.TierExternalByPolicy,
+		imported.TierExternalUnsupported,
+	}
+	for _, tier := range nonImportedTiers {
+		t.Run(string(tier), func(t *testing.T) {
+			t.Parallel()
+			irs := []imported.ImportedResource{{
+				Identity:   imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.x"},
+				Tier:       tier,
+				FieldEdits: map[string]imported.FieldEdit{"name": {NewValue: "new"}},
+			}}
+			assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+		})
+	}
+}
+
+func TestValidateImportedResourceAuthorization_CloudMismatch(t *testing.T) {
+	t.Parallel()
+	// Compose cloud differs from the resource's cloud — the structural
+	// validator surfaces unsupported_cloud; this validator stays silent so
+	// callers don't double-report.
+	irs := []imported.ImportedResource{{
+		Identity:   imported.ResourceIdentity{Cloud: "gcp", Type: "google_storage_bucket", Address: "google_storage_bucket.b", ImportID: "b"},
+		Tier:       imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{"name": {NewValue: "new"}},
+	}}
+	assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+}
+
+func TestValidateImportedResourceAuthorization_EditPolicyGates(t *testing.T) {
+	t.Parallel()
+	good := imported.ResourceIdentity{
+		Cloud:    "aws",
+		Type:     "aws_sqs_queue",
+		Address:  "aws_sqs_queue.q",
+		ImportID: "https://sqs.us-east-1.amazonaws.com/123/q",
+	}
+
+	cases := []struct {
+		name     string
+		path     string
+		newValue any
+		wantCode string
+	}{
+		{
+			name:     "Edit=Never on identity field",
+			path:     "name",
+			newValue: "renamed",
+			wantCode: "imported_resource_field_edit_forbidden",
+		},
+		{
+			name:     "Edit=SystemOnly on tags",
+			path:     "tags",
+			newValue: map[string]any{"InsideOutImportProject": "io-x"},
+			wantCode: "imported_resource_field_edit_system_only",
+		},
+		{
+			name:     "Edit=RelationshipOnly on wiring field",
+			path:     "kms_master_key_id",
+			newValue: "alias/aws/sqs",
+			wantCode: "imported_resource_field_edit_relationship_only",
+		},
+		{
+			name:     "Edit=ChatSafe on tuning field passes",
+			path:     "visibility_timeout_seconds",
+			newValue: 60,
+			wantCode: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Deliberately do NOT mirror NewValue into Attributes — that
+			// would let a regression in the conflict gate run after the
+			// EditPolicy gate also pass silently. The EditPolicy gate must
+			// fire before any Attributes lookup.
+			irs := []imported.ImportedResource{{
+				Identity: good,
+				Tier:     imported.TierImportedFlat,
+				FieldEdits: map[string]imported.FieldEdit{
+					tc.path: {Source: imported.SourceRiley, NewValue: tc.newValue, EditedAt: time.Now()},
+				},
+			}}
+			issues := ValidateImportedResourceAuthorization("aws", irs)
+			if tc.wantCode == "" {
+				assert.Empty(t, issues)
+				return
+			}
+			require.Len(t, issues, 1)
+			assert.Equal(t, tc.wantCode, issues[0].Code)
+			assert.Equal(t, "imported.aws_sqs_queue.q."+tc.path, issues[0].Field)
+		})
+	}
+}
+
+func TestValidateImportedResourceAuthorization_NoPolicyForType(t *testing.T) {
+	t.Parallel()
+	// aws_iam_role isn't in the Phase 1 ten — no policy registered, so any
+	// FieldEdit defaults to deny.
+	require.False(t, hasPolicyRegistered("aws_iam_role"),
+		"test premise: aws_iam_role should not be in the curated Phase 1 set")
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_iam_role",
+			Address:  "aws_iam_role.r",
+			ImportID: "r",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"description": {Source: imported.SourceRiley, NewValue: "edited"},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_no_policy", issues[0].Code)
+	assert.Equal(t, "imported.aws_iam_role.r.description", issues[0].Field)
+}
+
+func TestValidateImportedResourceAuthorization_UnknownPath(t *testing.T) {
+	t.Parallel()
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"this_field_does_not_exist": {Source: imported.SourceRiley, NewValue: "x"},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_unknown_path", issues[0].Code)
+}
+
+func TestValidateImportedResourceAuthorization_PathWithoutPolicyEntry(t *testing.T) {
+	t.Parallel()
+	// Find a path at runtime that resolves against aws_lambda_function but is
+	// NOT in the curated map. This is mutation-resistant against future
+	// policy growth: as long as some attribute remains uncurated, the test
+	// keeps testing the gate. The skip below documents what to do if the
+	// curated map ever covers the entire schema (unlikely for Phase 2).
+	uncurated, ok := firstUncuratedResolvablePath("aws_lambda_function", []string{
+		"image_uri",
+		"package_type",
+		"publish",
+		"replace_security_groups_on_destroy",
+	})
+	if !ok {
+		t.Skip("no uncurated paths remain on aws_lambda_function — extend the candidate list or accept that the gate is structurally unreachable for this type")
+	}
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.f",
+			ImportID: "f",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			uncurated: {Source: imported.SourceRiley, NewValue: "x"},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_no_policy_for_path", issues[0].Code,
+		"selected path %q should resolve on aws_lambda_function but be absent from the curated map", uncurated)
+}
+
+func TestValidateImportedResourceAuthorization_RequiresApprovalNoApproval(t *testing.T) {
+	t.Parallel()
+	// sqs_managed_sse_enabled is Edit=RequiresApproval on aws_sqs_queue.
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"sqs_managed_sse_enabled": {Source: imported.SourceRiley, NewValue: true},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_requires_approval", issues[0].Code)
+}
+
+func TestValidateImportedResourceAuthorization_RequiresApprovalIncomplete(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		ap   imported.FieldEditApproval
+	}{
+		{"missing approver", imported.FieldEditApproval{ApprovedAt: time.Now(), PlanHash: "h"}},
+		{"zero approved_at", imported.FieldEditApproval{Approver: "a", PlanHash: "h"}},
+		{"missing plan_hash", imported.FieldEditApproval{Approver: "a", ApprovedAt: time.Now()}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ap := tc.ap
+			irs := []imported.ImportedResource{{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_sqs_queue",
+					Address:  "aws_sqs_queue.q",
+					ImportID: "q",
+				},
+				Tier: imported.TierImportedFlat,
+				FieldEdits: map[string]imported.FieldEdit{
+					"sqs_managed_sse_enabled": {
+						Source:   imported.SourceRiley,
+						NewValue: true,
+						Approval: &ap,
+					},
+				},
+			}}
+			issues := ValidateImportedResourceAuthorization("aws", irs)
+			require.Len(t, issues, 1)
+			assert.Equal(t, "imported_resource_field_edit_approval_invalid", issues[0].Code)
+		})
+	}
+}
+
+func TestValidateImportedResourceAuthorization_RequiresApprovalComplete(t *testing.T) {
+	t.Parallel()
+	// recovery_window_in_days on aws_secretsmanager_secret is RequiresApproval
+	// without ChangeRisk metadata, so a complete approval suffices.
+	approval := &imported.FieldEditApproval{
+		Approver:   "ops@luthersystems.com",
+		ApprovedAt: time.Now(),
+		PlanHash:   "abc123",
+	}
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_secretsmanager_secret",
+			Address:  "aws_secretsmanager_secret.s",
+			ImportID: "s",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"recovery_window_in_days": {
+				Source:   imported.SourceRiley,
+				NewValue: 7,
+				Approval: approval,
+			},
+		},
+	}}
+	assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+}
+
+func TestValidateImportedResourceAuthorization_RequiresApprovalAndReplacementRiskBothApproved(t *testing.T) {
+	t.Parallel()
+	// sqs_managed_sse_enabled is RequiresApproval + MayReplace — both gates
+	// must pass with one complete approval. A regression that drops the early
+	// `return` between the two gates would let the second gate (or its
+	// approval-completeness check) reject and would be caught here.
+	approval := &imported.FieldEditApproval{
+		Approver:   "ops@luthersystems.com",
+		ApprovedAt: time.Now(),
+		PlanHash:   "plan-multi",
+	}
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"sqs_managed_sse_enabled": {
+				Source:   imported.SourceRiley,
+				NewValue: true,
+				Approval: approval,
+			},
+		},
+	}}
+	assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+}
+
+func TestValidateImportedResourceAuthorization_ReplacementRiskUnconfirmed(t *testing.T) {
+	t.Parallel()
+	// architectures on aws_lambda_function is ChatSafe + MayReplace — the
+	// EditPolicy gate passes, and the ChangeRisk gate fires when no Approval
+	// is present.
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.f",
+			ImportID: "f",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"architectures": {Source: imported.SourceRiley, NewValue: []any{"arm64"}},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_replacement_risk_unconfirmed", issues[0].Code)
+}
+
+func TestValidateImportedResourceAuthorization_ReplacementRiskApproved(t *testing.T) {
+	t.Parallel()
+	// Same case with a valid Approval — gate is satisfied.
+	approval := &imported.FieldEditApproval{
+		Approver:   "ops@luthersystems.com",
+		ApprovedAt: time.Now(),
+		PlanHash:   "plan-abc",
+	}
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.f",
+			ImportID: "f",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"architectures": {
+				Source:   imported.SourceRiley,
+				NewValue: []any{"arm64"},
+				Approval: approval,
+			},
+		},
+	}}
+	assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+}
+
+func TestValidateImportedResourceAuthorization_ReimportConflict(t *testing.T) {
+	t.Parallel()
+	// FieldEdit recorded NewValue=120, but Attributes shows 30 — a re-import
+	// or other writer overwrote the pending edit. This is the only test that
+	// legitimately mirrors-but-diverges Attributes vs NewValue.
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"visibility_timeout_seconds": 30,
+		},
+		FieldEdits: map[string]imported.FieldEdit{
+			"visibility_timeout_seconds": {
+				Source:   imported.SourceRiley,
+				NewValue: 120,
+				EditedAt: time.Now(),
+			},
+		},
+	}}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_reimport_conflict", issues[0].Code)
+}
+
+func TestValidateImportedResourceAuthorization_ReimportConflictAlignedNoIssue(t *testing.T) {
+	t.Parallel()
+	// Attributes equals NewValue — no conflict.
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"visibility_timeout_seconds": 120,
+		},
+		FieldEdits: map[string]imported.FieldEdit{
+			"visibility_timeout_seconds": {Source: imported.SourceRiley, NewValue: 120},
+		},
+	}}
+	assert.Empty(t, ValidateImportedResourceAuthorization("aws", irs))
+}
+
+func TestValidateImportedResourceAuthorization_RedactsAcrossSeverities(t *testing.T) {
+	t.Parallel()
+
+	const secret = "hunter2-not-public"
+
+	cases := []struct {
+		name     string
+		tfType   string
+		address  string
+		path     string
+		newValue any
+	}{
+		{
+			// tagPolicy() => Sensitivity=Redacted + Edit=SystemOnly.
+			name:     "Redacted via SystemOnly",
+			tfType:   "aws_sqs_queue",
+			address:  "aws_sqs_queue.q",
+			path:     "tags",
+			newValue: map[string]any{"DB_PASSWORD": secret},
+		},
+		{
+			// environment.variables on aws_lambda_function is
+			// Sensitivity=Sensitive + Edit=SystemOnly.
+			name:     "Sensitive via SystemOnly",
+			tfType:   "aws_lambda_function",
+			address:  "aws_lambda_function.f",
+			path:     "environment.variables",
+			newValue: map[string]any{"DB_PASSWORD": secret},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			irs := []imported.ImportedResource{{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     tc.tfType,
+					Address:  tc.address,
+					ImportID: "x",
+				},
+				Tier: imported.TierImportedFlat,
+				FieldEdits: map[string]imported.FieldEdit{
+					tc.path: {Source: imported.SourceRiley, NewValue: tc.newValue},
+				},
+			}}
+			issues := ValidateImportedResourceAuthorization("aws", irs)
+			require.Len(t, issues, 1)
+			iss := issues[0]
+			assert.Equal(t, "***", iss.Value, "Value must be redacted")
+			assert.NotContains(t, iss.Reason, secret, "Reason must not leak the raw value")
+			assert.NotContains(t, iss.Suggestion, secret, "Suggestion must not leak the raw value")
+			assert.NotContains(t, iss.Field, secret, "Field must not leak the raw value")
+		})
+	}
+}
+
+func TestValidateImportedResourceAuthorization_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+	// Two FieldEdits on different paths produce two issues in lexicographic
+	// path order, regardless of map iteration randomness. Iteration count is
+	// high enough to consistently shuffle Go's map randomization in practice.
+	irs := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.q",
+			ImportID: "q",
+		},
+		Tier: imported.TierImportedFlat,
+		FieldEdits: map[string]imported.FieldEdit{
+			"name": {Source: imported.SourceRiley, NewValue: "renamed"},
+			"arn":  {Source: imported.SourceRiley, NewValue: "arn:aws:sqs:..."},
+		},
+	}}
+	for i := range 50 {
+		issues := ValidateImportedResourceAuthorization("aws", irs)
+		require.Len(t, issues, 2)
+		assert.Equal(t, "imported.aws_sqs_queue.q.arn", issues[0].Field, "iteration %d: stable order broken", i)
+		assert.Equal(t, "imported.aws_sqs_queue.q.name", issues[1].Field, "iteration %d: stable order broken", i)
+	}
+}
+
+func TestValidateImportedResourceAuthorization_MultipleResources(t *testing.T) {
+	t.Parallel()
+	// First resource has a clean ChatSafe edit; second has a forbidden one.
+	// Confirms cross-resource iteration includes only the resources with
+	// gated edits and emits per-resource per-path issues independently.
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.a", ImportID: "a",
+			},
+			Tier: imported.TierImportedFlat,
+			FieldEdits: map[string]imported.FieldEdit{
+				"visibility_timeout_seconds": {Source: imported.SourceRiley, NewValue: 60},
+			},
+		},
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.b", ImportID: "b",
+			},
+			Tier: imported.TierImportedFlat,
+			FieldEdits: map[string]imported.FieldEdit{
+				"name": {Source: imported.SourceRiley, NewValue: "rename"},
+			},
+		},
+	}
+	issues := ValidateImportedResourceAuthorization("aws", irs)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_resource_field_edit_forbidden", issues[0].Code)
+	assert.Equal(t, "imported.aws_sqs_queue.b.name", issues[0].Field)
+}
+
+// TestEvaluateEditPolicy_DefaultBranch covers the defensive default branch in
+// evaluateEditPolicy for an EditPolicy value the curated maps cannot
+// legitimately produce (lint enforces Valid()). Direct unit-test on the
+// helper avoids polluting the policy registry with a malformed entry.
+func TestEvaluateEditPolicy_DefaultBranch(t *testing.T) {
+	t.Parallel()
+	entry := policy.FieldPolicy{
+		Role: policy.RoleTuning,
+		Edit: policy.EditPolicy("InvalidValueNotInEnum"),
+	}
+	iss, ok := evaluateEditPolicy("imported.aws_sqs_queue.q.weird", "aws_sqs_queue", "weird", imported.FieldEdit{NewValue: "x"}, entry)
+	require.True(t, ok, "default branch must produce an issue")
+	assert.Equal(t, "imported_resource_field_edit_forbidden", iss.Code)
+	assert.Contains(t, iss.Reason, "InvalidValueNotInEnum",
+		"Reason should name the offending EditPolicy so a curator can fix it")
+}
+
+func TestValidateImportedResourceAuthorization_HookedIntoComposeStack(t *testing.T) {
+	// Sequential: composeStackImpl reads the package-global nowFn (set by
+	// withFixedNow in imported_compose_test.go and imported_provenance_test.go).
+	// Running this test in parallel with those would flake the timestamp those
+	// tests pin via injectProvenance.
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:   "aws",
+		Project: "io-test",
+		Region:  "us-east-1",
+		Imported: []imported.ImportedResource{{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "q",
+			},
+			Tier: imported.TierImportedFlat,
+			FieldEdits: map[string]imported.FieldEdit{
+				"name": {Source: imported.SourceRiley, NewValue: "rename"},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	codes := issueCodes(res.Issues)
+	assert.Contains(t, codes, "imported_resource_field_edit_forbidden",
+		"compose pipeline must surface authorization issues; got codes=%v", codes)
+}
+
+func TestValidateImportedResourceAuthorization_HookedIntoValidateAll(t *testing.T) {
+	t.Parallel()
+	issues := ValidateAll(
+		nil, nil, nil, nil, nil, nil,
+		ComposeStackOpts{
+			Cloud: "aws",
+			Imported: []imported.ImportedResource{{
+				Identity: imported.ResourceIdentity{
+					Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "q",
+				},
+				Tier: imported.TierImportedFlat,
+				FieldEdits: map[string]imported.FieldEdit{
+					"kms_master_key_id": {Source: imported.SourceRiley, NewValue: "alias/foo"},
+				},
+			}},
+		},
+	)
+	codes := issueCodes(issues)
+	assert.Contains(t, codes, "imported_resource_field_edit_relationship_only",
+		"ValidateAll must include the authorization validator; got codes=%v", codes)
+}
+
+// hasPolicyRegistered reports whether tfType is in the curated Layer 2 set.
+// Used by tests that assert their premise (e.g. "this type is uncurated") so
+// a future policy addition surfaces as a clear premise failure rather than a
+// confusing test failure.
+func hasPolicyRegistered(tfType string) bool {
+	_, ok := policy.Lookup(tfType)
+	return ok
+}
+
+// firstUncuratedResolvablePath returns the first candidate path that resolves
+// against tfType's generated struct but is not in the curated policy map.
+// Tests that need a "path-without-policy-entry" example call this with a
+// candidate list so they remain valid as the curated map grows: as long as
+// any candidate is uncurated, the test stays green.
+func firstUncuratedResolvablePath(tfType string, candidates []string) (string, bool) {
+	m, ok := policy.Lookup(tfType)
+	if !ok {
+		return "", false
+	}
+	for _, c := range candidates {
+		if _, curated := m[c]; curated {
+			continue
+		}
+		if err := policy.ResolvePath(tfType, c); err != nil {
+			continue
+		}
+		return c, true
+	}
+	return "", false
+}

--- a/pkg/composer/imported_diff.go
+++ b/pkg/composer/imported_diff.go
@@ -1,0 +1,425 @@
+package composer
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+)
+
+// Resource diff actions. Mirror the existing component diff vocabulary so
+// downstream renderers can share switch arms.
+const (
+	ResourceActionAdded    = "added"
+	ResourceActionRemoved  = "removed"
+	ResourceActionModified = "modified"
+)
+
+// ResourceDiff describes the change to one imported resource between two
+// stack snapshots. It is the imported-resource analogue of ComponentDiff and
+// rides alongside ComponentDiff inside VersionDiff.Resources.
+//
+// Identity: keyed by Terraform Address (matches the import {} block target
+// and the cross-tier resolver). Type and Cloud are kept on the diff for
+// rendering convenience so consumers don't have to re-derive them.
+//
+// Tier transitions: when the same address moves between Tiers (e.g.
+// ImportedFlat → ImportedConformant, ImportedFlat → ImportedMissing), Action
+// is "modified" and FromTier / ToTier carry the move. Reliable's UI
+// distinguishes a tier move from a field-only modification by checking
+// whether FromTier and ToTier differ.
+//
+// Field changes use ResourceFieldDiff so Reliable can render policy metadata
+// (role, sensitivity, change-risk) without separately querying the policy
+// registry.
+type ResourceDiff struct {
+	Address string `json:"address"`
+	Type    string `json:"type"`
+	Cloud   string `json:"cloud,omitempty"`
+
+	Action string `json:"action"`
+
+	FromTier imported.Tier `json:"from_tier,omitempty"`
+	ToTier   imported.Tier `json:"to_tier,omitempty"`
+
+	// Remediation surfaces the operator-chosen action when the resource
+	// transitioned into TierImportedMissing. Empty otherwise.
+	Remediation imported.MissingAction `json:"remediation,omitempty"`
+
+	Changes []ResourceFieldDiff `json:"changes,omitempty"`
+}
+
+// ResourceFieldDiff describes a per-field change with the policy metadata
+// Reliable needs to group, label, badge, and redact. Policy fields default
+// to the empty string when no curated entry exists for the path or the
+// resource type is unregistered; renderers should treat empty as "no
+// curator opinion" and fall back to a generic display.
+type ResourceFieldDiff struct {
+	Path string `json:"path"`
+	From string `json:"from"`
+	To   string `json:"to"`
+
+	Role        policy.FieldRole         `json:"role,omitempty"`
+	Pillar      policy.FieldPillar       `json:"pillar,omitempty"`
+	Sensitivity policy.SensitivityPolicy `json:"sensitivity,omitempty"`
+	ChangeRisk  policy.ChangeRiskPolicy  `json:"change_risk,omitempty"`
+	EditPolicy  policy.EditPolicy        `json:"edit_policy,omitempty"`
+
+	// Redacted is true when From / To were replaced with placeholders to
+	// honor the field's SensitivityPolicy. Diff JSON, logs, and humanized
+	// text must never contain the original values for redacted fields.
+	Redacted bool `json:"redacted,omitempty"`
+
+	// RelationshipOnly is true when the curated EditPolicy is
+	// EditRelationshipOnly. Reliable uses this to render the change as a
+	// graph relationship, not as an ordinary scalar edit (decisions #30,
+	// #31). The underlying value still diffs so the operator can see the
+	// referenced address; chat-side scalar edits are blocked separately
+	// by ValidateImportedResourceAuthorization.
+	RelationshipOnly bool `json:"relationship_only,omitempty"`
+}
+
+// redactedPlaceholder is the surface form of any field value that the
+// SensitivityPolicy says must not leak. Single shared constant so the wire
+// format never depends on call-site convention.
+const redactedPlaceholder = "***"
+
+// DiffImportedResources compares two slices of ImportedResource and returns
+// one ResourceDiff per address that differs. Resources in old but not new
+// produce Action="removed"; resources in new but not old produce
+// Action="added"; same address on both sides with any Tier or Attributes
+// difference produces Action="modified".
+//
+// Field-level diffs respect the curated Layer 2 policy for the resource
+// type:
+//
+//   - Hidden fields (Visibility=Hidden) are excluded from the diff output
+//     entirely; system-owned attributes (timeouts, tags, internal markers)
+//     should not surface in user-visible diffs.
+//   - RelationshipOnly fields appear with the RelationshipOnly flag set so
+//     renderers can show them as graph references rather than scalar edits.
+//   - Sensitive / Redacted fields have From / To replaced with "***" and
+//     Redacted=true.
+//   - ChangeRisk, Role, Pillar, and EditPolicy are populated from the
+//     curated FieldPolicy so renderers can show plan-tied confirmation
+//     badges and policy grouping without re-querying the registry.
+//
+// When the resource type is not registered in the policy package, fields
+// fall through to a generic diff with empty policy metadata; the safe
+// default redacts nothing because the carrier itself has no curator
+// opinion. (Use ValidateImportedResources for structural checks on
+// uncurated types; this function is render-only.)
+//
+// JSON projections (e.g. redrive_policy.deadLetterTargetArn) are best-
+// effort: when the parent attribute is a JSON-string and a projection is
+// registered, the diff is emitted at the projection path. Parse failures
+// fall back to a raw parent diff so the change is never silently dropped.
+//
+// Output is sorted by Address for stable consumption.
+func DiffImportedResources(old, new []imported.ImportedResource) []ResourceDiff {
+	if len(old) == 0 && len(new) == 0 {
+		return nil
+	}
+	oldByAddr := indexImportedByAddress(old)
+	newByAddr := indexImportedByAddress(new)
+
+	var diffs []ResourceDiff
+	for addr, oldIR := range oldByAddr {
+		newIR, ok := newByAddr[addr]
+		if !ok {
+			diffs = append(diffs, removedResourceDiff(oldIR))
+			continue
+		}
+		if d, ok := modifiedResourceDiff(oldIR, newIR); ok {
+			diffs = append(diffs, d)
+		}
+	}
+	for addr, newIR := range newByAddr {
+		if _, ok := oldByAddr[addr]; ok {
+			continue
+		}
+		diffs = append(diffs, addedResourceDiff(newIR))
+	}
+
+	sort.Slice(diffs, func(i, j int) bool {
+		return diffs[i].Address < diffs[j].Address
+	})
+	return diffs
+}
+
+// indexImportedByAddress builds an Address->ImportedResource map. Resources
+// with empty Address are skipped — DiffImportedResources is render-only and
+// has no way to correlate them; the structural validator surfaces those as
+// imported_resource_missing_address.
+func indexImportedByAddress(irs []imported.ImportedResource) map[string]imported.ImportedResource {
+	out := make(map[string]imported.ImportedResource, len(irs))
+	for _, ir := range irs {
+		addr := strings.TrimSpace(ir.Identity.Address)
+		if addr == "" {
+			continue
+		}
+		out[addr] = ir
+	}
+	return out
+}
+
+// addedResourceDiff renders a "this resource appeared on the new side" diff,
+// listing every visible attribute as an addition (from "" to the new value).
+func addedResourceDiff(ir imported.ImportedResource) ResourceDiff {
+	rd := ResourceDiff{
+		Address: ir.Identity.Address,
+		Type:    ir.Identity.Type,
+		Cloud:   ir.Identity.Cloud,
+		Action:  ResourceActionAdded,
+		ToTier:  ir.Tier,
+	}
+	if ir.Tier == imported.TierImportedMissing {
+		rd.Remediation = ir.Remediation
+	}
+	rd.Changes = diffAttributeMaps(ir.Identity.Type, nil, ir.Attributes)
+	return rd
+}
+
+// removedResourceDiff renders a "this resource went away on the new side"
+// diff, listing every visible attribute as a removal (from the old value to
+// "").
+func removedResourceDiff(ir imported.ImportedResource) ResourceDiff {
+	rd := ResourceDiff{
+		Address:  ir.Identity.Address,
+		Type:     ir.Identity.Type,
+		Cloud:    ir.Identity.Cloud,
+		Action:   ResourceActionRemoved,
+		FromTier: ir.Tier,
+	}
+	rd.Changes = diffAttributeMaps(ir.Identity.Type, ir.Attributes, nil)
+	return rd
+}
+
+// modifiedResourceDiff returns a diff for two snapshots of the same address.
+// ok=false when nothing visible changed (same Tier and no policy-visible
+// attribute deltas) — DiffImportedResources skips no-op modifies entirely.
+func modifiedResourceDiff(oldIR, newIR imported.ImportedResource) (ResourceDiff, bool) {
+	rd := ResourceDiff{
+		Address: newIR.Identity.Address,
+		Type:    newIR.Identity.Type,
+		Cloud:   newIR.Identity.Cloud,
+		Action:  ResourceActionModified,
+	}
+	tierChanged := oldIR.Tier != newIR.Tier
+	if tierChanged {
+		rd.FromTier = oldIR.Tier
+		rd.ToTier = newIR.Tier
+		if newIR.Tier == imported.TierImportedMissing {
+			rd.Remediation = newIR.Remediation
+		}
+	}
+	rd.Changes = diffAttributeMaps(newIR.Identity.Type, oldIR.Attributes, newIR.Attributes)
+	if !tierChanged && len(rd.Changes) == 0 {
+		return ResourceDiff{}, false
+	}
+	return rd, true
+}
+
+// diffAttributeMaps walks the union of keys across old and new and emits
+// ResourceFieldDiff entries for visible (non-Hidden) paths whose stringified
+// values differ. For each top-level path that the curated map declares as a
+// JSON-projection parent, the projection paths are diffed individually
+// rather than as a single raw parent diff (best-effort; parse failures fall
+// back to raw).
+//
+// Output is sorted by Path. Empty old and empty new short-circuit to nil so
+// the caller gets a clean tail.
+func diffAttributeMaps(tfType string, old, new map[string]any) []ResourceFieldDiff {
+	if len(old) == 0 && len(new) == 0 {
+		return nil
+	}
+	polMap, _ := policy.Lookup(tfType)
+	keys := unionKeys(old, new)
+	parents := jsonProjectionParents(polMap)
+
+	var diffs []ResourceFieldDiff
+	for _, key := range keys {
+		if parents[key] {
+			diffs = append(diffs, diffJSONProjection(tfType, key, old[key], new[key], polMap)...)
+			continue
+		}
+		entry, hasEntry := polMap[key]
+		if hasEntry && entry.Visibility == policy.VisibilityHidden {
+			continue
+		}
+		oldStr := stringifyAttr(old[key])
+		newStr := stringifyAttr(new[key])
+		if oldStr == newStr {
+			continue
+		}
+		diffs = append(diffs, makeFieldDiff(key, oldStr, newStr, entry, hasEntry))
+	}
+	sort.Slice(diffs, func(i, j int) bool {
+		return diffs[i].Path < diffs[j].Path
+	})
+	return diffs
+}
+
+// makeFieldDiff applies redaction and policy projection to a raw From/To
+// pair. hasEntry distinguishes "no curator opinion" from "explicit zero
+// values" — without it we couldn't tell apart the empty default and an
+// explicit Visibility=Hidden, but the Hidden case is filtered upstream.
+func makeFieldDiff(path, from, to string, entry policy.FieldPolicy, hasEntry bool) ResourceFieldDiff {
+	d := ResourceFieldDiff{Path: path, From: from, To: to}
+	if !hasEntry {
+		return d
+	}
+	d.Role = entry.Role
+	d.Pillar = entry.Pillar
+	d.Sensitivity = entry.Sensitivity
+	d.ChangeRisk = entry.ChangeRisk
+	d.EditPolicy = entry.Edit
+	d.RelationshipOnly = entry.Edit == policy.EditRelationshipOnly
+	if redactionRequired(entry) {
+		d.From = redactedPlaceholder
+		d.To = redactedPlaceholder
+		d.Redacted = true
+	}
+	return d
+}
+
+// redactionRequired reports whether the curated SensitivityPolicy demands
+// the value be replaced with a placeholder before display.
+func redactionRequired(entry policy.FieldPolicy) bool {
+	switch entry.Sensitivity {
+	case policy.SensitivitySensitive, policy.SensitivityRedacted:
+		return true
+	}
+	return false
+}
+
+// stringifyAttr renders an Attributes value as a stable display string. nil
+// stays as the empty string so the From/To delta correctly shows additions
+// and removals as " → x" / "x → ".
+func stringifyAttr(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	case int, int32, int64, float32, float64, bool:
+		return fmt.Sprintf("%v", t)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}
+
+// unionKeys returns the sorted union of map keys, with nil maps treated as
+// empty. Used to compute the diff coverage for two attribute snapshots.
+func unionKeys(a, b map[string]any) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// jsonProjectionParents returns the set of top-level attribute names that
+// are declared as JSON-projection parents in m. Used by diffAttributeMaps
+// to route those keys through the projection-aware path.
+func jsonProjectionParents(m policy.Map) map[string]bool {
+	parents := map[string]bool{}
+	for path := range m {
+		i := strings.Index(path, ".")
+		if i <= 0 {
+			continue
+		}
+		parents[path[:i]] = true
+	}
+	return parents
+}
+
+// diffJSONProjection renders one or more ResourceFieldDiff entries for a
+// JSON-string parent attribute. Each registered projection gets its own
+// entry when both sides parse cleanly. If either side fails to parse —
+// including the asymmetric case where one snapshot is well-formed JSON and
+// the other is corrupt — the function falls back to a single raw parent
+// diff so the change is never silently dropped and stale projection
+// entries from the parsed half are not emitted.
+func diffJSONProjection(tfType, parent string, oldVal, newVal any, polMap policy.Map) []ResourceFieldDiff {
+	oldMap, oldOK := decodeJSONProjection(oldVal)
+	newMap, newOK := decodeJSONProjection(newVal)
+	if !oldOK || !newOK {
+		oldStr := stringifyAttr(oldVal)
+		newStr := stringifyAttr(newVal)
+		if oldStr == newStr {
+			return nil
+		}
+		entry, hasEntry := polMap[parent]
+		return []ResourceFieldDiff{makeFieldDiff(parent, oldStr, newStr, entry, hasEntry)}
+	}
+	keys := unionKeys(oldMap, newMap)
+	var diffs []ResourceFieldDiff
+	for _, sub := range keys {
+		full := parent + "." + sub
+		entry, hasEntry := polMap[full]
+		if hasEntry && entry.Visibility == policy.VisibilityHidden {
+			continue
+		}
+		oldStr := stringifyAttr(oldMap[sub])
+		newStr := stringifyAttr(newMap[sub])
+		if oldStr == newStr {
+			continue
+		}
+		diffs = append(diffs, makeFieldDiff(full, oldStr, newStr, entry, hasEntry))
+	}
+	return diffs
+}
+
+// decodeJSONProjection accepts either a Go map (Phase 1 typed Attributes)
+// or a JSON-string (Terraform's wire shape for redrive_policy and friends)
+// and returns it as a map[string]any. Returns ok=false on type mismatch or
+// parse failure; callers fall back to raw-parent diffing.
+func decodeJSONProjection(v any) (map[string]any, bool) {
+	if v == nil {
+		return nil, true
+	}
+	switch t := v.(type) {
+	case map[string]any:
+		return t, true
+	case string:
+		if strings.TrimSpace(t) == "" {
+			return nil, true
+		}
+		var out map[string]any
+		if err := json.Unmarshal([]byte(t), &out); err != nil {
+			return nil, false
+		}
+		return out, true
+	}
+	// Reflect-based fallback for json.RawMessage and []byte.
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Slice && rv.Type().Elem().Kind() == reflect.Uint8 {
+		raw := rv.Bytes()
+		if len(raw) == 0 {
+			return nil, true
+		}
+		var out map[string]any
+		if err := json.Unmarshal(raw, &out); err != nil {
+			return nil, false
+		}
+		return out, true
+	}
+	return nil, false
+}

--- a/pkg/composer/imported_diff.go
+++ b/pkg/composer/imported_diff.go
@@ -127,28 +127,45 @@ func DiffImportedResources(old, new []imported.ImportedResource) []ResourceDiff 
 	oldByAddr := indexImportedByAddress(old)
 	newByAddr := indexImportedByAddress(new)
 
-	var diffs []ResourceDiff
-	for addr, oldIR := range oldByAddr {
-		newIR, ok := newByAddr[addr]
-		if !ok {
+	addrs := sortedUnionAddresses(oldByAddr, newByAddr)
+	diffs := make([]ResourceDiff, 0, len(addrs))
+	for _, addr := range addrs {
+		oldIR, hasOld := oldByAddr[addr]
+		newIR, hasNew := newByAddr[addr]
+		switch {
+		case !hasOld && hasNew:
+			diffs = append(diffs, addedResourceDiff(newIR))
+		case hasOld && !hasNew:
 			diffs = append(diffs, removedResourceDiff(oldIR))
-			continue
-		}
-		if d, ok := modifiedResourceDiff(oldIR, newIR); ok {
-			diffs = append(diffs, d)
+		case hasOld && hasNew:
+			if d, ok := modifiedResourceDiff(oldIR, newIR); ok {
+				diffs = append(diffs, d)
+			}
 		}
 	}
-	for addr, newIR := range newByAddr {
-		if _, ok := oldByAddr[addr]; ok {
-			continue
-		}
-		diffs = append(diffs, addedResourceDiff(newIR))
+	if len(diffs) == 0 {
+		return nil
 	}
-
-	sort.Slice(diffs, func(i, j int) bool {
-		return diffs[i].Address < diffs[j].Address
-	})
 	return diffs
+}
+
+// sortedUnionAddresses returns the sorted union of map keys from two
+// address-indexed snapshots. Single allocation; eliminates the post-hoc
+// sort.Slice after random map iteration.
+func sortedUnionAddresses(a, b map[string]imported.ImportedResource) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // indexImportedByAddress builds an Address->ImportedResource map. Resources

--- a/pkg/composer/imported_diff.go
+++ b/pkg/composer/imported_diff.go
@@ -119,11 +119,12 @@ const redactedPlaceholder = "***"
 // registered, the diff is emitted at the projection path. Parse failures
 // fall back to a raw parent diff so the change is never silently dropped.
 //
-// Output is sorted by Address for stable consumption.
+// Output is sorted by Address for stable consumption. Always returns a
+// non-nil slice — empty when there are no diffs — so VersionDiff.Resources
+// marshals as the JSON array `[]` rather than `null`. Reliable's snapshot
+// consumers compare diff JSON byte-for-byte, so nil↔[] flips would churn
+// every stack the first time it acquires or sheds an imported resource.
 func DiffImportedResources(old, new []imported.ImportedResource) []ResourceDiff {
-	if len(old) == 0 && len(new) == 0 {
-		return nil
-	}
 	oldByAddr := indexImportedByAddress(old)
 	newByAddr := indexImportedByAddress(new)
 
@@ -142,9 +143,6 @@ func DiffImportedResources(old, new []imported.ImportedResource) []ResourceDiff 
 				diffs = append(diffs, d)
 			}
 		}
-	}
-	if len(diffs) == 0 {
-		return nil
 	}
 	return diffs
 }

--- a/pkg/composer/imported_diff_test.go
+++ b/pkg/composer/imported_diff_test.go
@@ -13,6 +13,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestDiffImportedResources_EmptyMarshalsAsArray pins the wire-shape
+// contract that VersionDiff.Resources is "always an array, possibly empty"
+// on the JSON side. DiffImportedResources must return a non-nil slice so
+// json.Marshal emits `[]` and not `null` — Reliable's snapshot consumers
+// compare diff JSON byte-for-byte, so a nil↔[] flip would churn every
+// stack the first time it acquires or sheds an imported resource.
+func TestDiffImportedResources_EmptyMarshalsAsArray(t *testing.T) {
+	t.Parallel()
+	cases := map[string][2][]imported.ImportedResource{
+		"both nil":          {nil, nil},
+		"both empty":        {{}, {}},
+		"identical content": {{sampleSQS("a", 30)}, {sampleSQS("a", 30)}},
+	}
+	for name, sides := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			diffs := DiffImportedResources(sides[0], sides[1])
+			b, err := json.Marshal(diffs)
+			require.NoError(t, err)
+			assert.Equal(t, "[]", string(b),
+				"DiffImportedResources must return non-nil so empty marshals as []")
+			// VersionDiff round-trip: empty Resources must serialize as
+			// `"resources":[]`, never `"resources":null`.
+			vd := VersionDiff{
+				FromVersion: 1, ToVersion: 2,
+				Components: []ComponentDiff{},
+				Resources:  diffs,
+				Summary:    "no-op",
+			}
+			vdBytes, err := json.Marshal(vd)
+			require.NoError(t, err)
+			assert.Contains(t, string(vdBytes), `"resources":[]`,
+				"VersionDiff.Resources must always be an array on the wire (issue: nil-vs-[] churn)")
+			assert.NotContains(t, string(vdBytes), `"resources":null`,
+				"VersionDiff.Resources must never serialize as null")
+		})
+	}
+}
+
 func TestDiffImportedResources_NoOp(t *testing.T) {
 	t.Parallel()
 	cases := map[string][2][]imported.ImportedResource{
@@ -222,12 +261,15 @@ func TestDiffImportedResources_HiddenSensitiveFilteredEndToEnd(t *testing.T) {
 	diffs := DiffImportedResources([]imported.ImportedResource{old}, []imported.ImportedResource{new})
 	require.Empty(t, diffs, "Hidden filter must drop sensitive fields end-to-end")
 
-	// Defense-in-depth: marshal the diffs slice and assert no secret leaked
-	// into any rendering of the result.
+	// Pin the wire shape: the diffs slice must marshal as `[]`, not `null`.
+	// Reliable's snapshot consumers compare diff JSON byte-for-byte, so a
+	// nil↔[] flip would churn every stack the first time it onboards an
+	// imported resource. The previous defense-in-depth NotContains check
+	// here was vacuous because it ran against the literal "null" string.
 	b, err := json.Marshal(diffs)
 	require.NoError(t, err)
-	assert.NotContains(t, string(b), oldSecret)
-	assert.NotContains(t, string(b), newSecret)
+	assert.Equal(t, "[]", string(b),
+		"empty diff slice must marshal as []; if this regresses to null, VersionDiff.Resources flips its wire shape and Reliable's byte-for-byte snapshot tests churn")
 }
 
 // TestDiffImportedResources_VisibleRedactedEndToEnd exercises the integration

--- a/pkg/composer/imported_diff_test.go
+++ b/pkg/composer/imported_diff_test.go
@@ -609,32 +609,7 @@ func hasPolicy(tfType string) bool {
 	return ok
 }
 
-// requirePolicyEntry asserts that the curated FieldPolicy at (tfType, path)
-// matches the non-zero fields of want. Tests that depend on a specific
-// curator decision call this so a future policy edit surfaces as a clear
-// premise failure rather than a silent assertion drift.
-//
-// Only the fields populated on want are compared; zero-valued axes are
-// ignored so each test only pins what it depends on.
-func requirePolicyEntry(t *testing.T, tfType, path string, want policy.FieldPolicy) {
-	t.Helper()
-	m, ok := policy.Lookup(tfType)
-	require.True(t, ok, "test premise: %q must be a curated type", tfType)
-	got, ok := m[path]
-	require.True(t, ok, "test premise: %q must have a curated entry for path %q", tfType, path)
-	if want.Role != "" {
-		assert.Equal(t, want.Role, got.Role, "Role mismatch on %s.%s", tfType, path)
-	}
-	if want.Edit != "" {
-		assert.Equal(t, want.Edit, got.Edit, "Edit mismatch on %s.%s", tfType, path)
-	}
-	if want.Visibility != "" {
-		assert.Equal(t, want.Visibility, got.Visibility, "Visibility mismatch on %s.%s", tfType, path)
-	}
-	if want.Sensitivity != "" {
-		assert.Equal(t, want.Sensitivity, got.Sensitivity, "Sensitivity mismatch on %s.%s", tfType, path)
-	}
-	if want.ChangeRisk != "" {
-		assert.Equal(t, want.ChangeRisk, got.ChangeRisk, "ChangeRisk mismatch on %s.%s", tfType, path)
-	}
-}
+// requirePolicyEntry is defined in imported_authz_validate_test.go (the
+// other test file in this package). Both PRs (#149 / authz validator and
+// #151 / ResourceDiff) shipped identical helpers; per #183 the duplicate
+// in this file is dropped on bundle-merge so the package compiles.

--- a/pkg/composer/imported_diff_test.go
+++ b/pkg/composer/imported_diff_test.go
@@ -21,10 +21,22 @@ import (
 // stack the first time it acquires or sheds an imported resource.
 func TestDiffImportedResources_EmptyMarshalsAsArray(t *testing.T) {
 	t.Parallel()
+
+	// hiddenOnlyDelta exercises the modifiedResourceDiff no-visible-delta
+	// return path: two snapshots of the same address differ ONLY in tags
+	// (Hidden via tagPolicy), so diffAttributeMaps filters every change
+	// out, modifiedResourceDiff returns (_, false), and the diff slice
+	// stays empty. The other three cases short-circuit earlier paths.
+	hiddenOldOnly := sampleSQS("q", 30)
+	hiddenOldOnly.Attributes["tags"] = map[string]any{"Project": "before"}
+	hiddenNewOnly := sampleSQS("q", 30)
+	hiddenNewOnly.Attributes["tags"] = map[string]any{"Project": "after"}
+
 	cases := map[string][2][]imported.ImportedResource{
 		"both nil":          {nil, nil},
 		"both empty":        {{}, {}},
 		"identical content": {{sampleSQS("a", 30)}, {sampleSQS("a", 30)}},
+		"hidden-only delta": {{hiddenOldOnly}, {hiddenNewOnly}},
 	}
 	for name, sides := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/composer/imported_diff_test.go
+++ b/pkg/composer/imported_diff_test.go
@@ -1,0 +1,480 @@
+package composer
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	_ "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffImportedResources_NoOp(t *testing.T) {
+	t.Parallel()
+	cases := map[string][2][]imported.ImportedResource{
+		"both nil":          {nil, nil},
+		"both empty":        {{}, {}},
+		"identical content": {{sampleSQS("a", 30)}, {sampleSQS("a", 30)}},
+	}
+	for name, sides := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Empty(t, DiffImportedResources(sides[0], sides[1]))
+		})
+	}
+}
+
+func TestDiffImportedResources_AddedAndRemoved(t *testing.T) {
+	t.Parallel()
+	old := []imported.ImportedResource{sampleSQS("a", 30)}
+	new := []imported.ImportedResource{sampleSQS("b", 60)}
+	diffs := DiffImportedResources(old, new)
+	require.Len(t, diffs, 2)
+
+	// Sorted by Address: ".a" < ".b".
+	removed := diffs[0]
+	assert.Equal(t, ResourceActionRemoved, removed.Action)
+	assert.Equal(t, "aws_sqs_queue.a", removed.Address)
+	assert.Equal(t, imported.TierImportedFlat, removed.FromTier)
+	assert.Empty(t, removed.ToTier)
+	require.NotEmpty(t, removed.Changes,
+		"removed resources must list the disappeared attributes so the renderer can show what was lost")
+	for _, c := range removed.Changes {
+		assert.NotEmpty(t, c.From, "removed Change.From must carry the previous value")
+		assert.Empty(t, c.To, "removed Change.To must be empty")
+	}
+
+	added := diffs[1]
+	assert.Equal(t, ResourceActionAdded, added.Action)
+	assert.Equal(t, "aws_sqs_queue.b", added.Address)
+	assert.Equal(t, imported.TierImportedFlat, added.ToTier)
+	assert.Empty(t, added.FromTier)
+	require.NotEmpty(t, added.Changes,
+		"added resources must list the new attributes so the renderer can show what arrived")
+	for _, c := range added.Changes {
+		assert.Empty(t, c.From, "added Change.From must be empty")
+		assert.NotEmpty(t, c.To, "added Change.To must carry the new value")
+	}
+}
+
+func TestDiffImportedResources_ModifiedFieldOnly(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "aws_sqs_queue", "visibility_timeout_seconds", policy.FieldPolicy{
+		Role: policy.RoleTuning, Edit: policy.EditChatSafe,
+	})
+	diffs := DiffImportedResources(
+		[]imported.ImportedResource{sampleSQS("q", 30)},
+		[]imported.ImportedResource{sampleSQS("q", 60)},
+	)
+	require.Len(t, diffs, 1)
+	d := diffs[0]
+	assert.Equal(t, ResourceActionModified, d.Action)
+	assert.Empty(t, d.FromTier, "tier didn't change")
+	assert.Empty(t, d.ToTier)
+	require.Len(t, d.Changes, 1)
+	c := d.Changes[0]
+	assert.Equal(t, "visibility_timeout_seconds", c.Path)
+	assert.Equal(t, "30", c.From)
+	assert.Equal(t, "60", c.To)
+	assert.Equal(t, policy.RoleTuning, c.Role)
+	assert.Equal(t, policy.EditChatSafe, c.EditPolicy)
+	assert.False(t, c.Redacted)
+}
+
+func TestDiffImportedResources_TierTransition(t *testing.T) {
+	t.Parallel()
+	oldIR := sampleSQS("q", 30)
+	newIR := sampleSQS("q", 30)
+	newIR.Tier = imported.TierImportedMissing
+	newIR.Remediation = imported.ActionRecreateFromLastImport
+
+	diffs := DiffImportedResources([]imported.ImportedResource{oldIR}, []imported.ImportedResource{newIR})
+	require.Len(t, diffs, 1)
+	d := diffs[0]
+	assert.Equal(t, ResourceActionModified, d.Action)
+	assert.Equal(t, imported.TierImportedFlat, d.FromTier)
+	assert.Equal(t, imported.TierImportedMissing, d.ToTier)
+	assert.Equal(t, imported.ActionRecreateFromLastImport, d.Remediation)
+	assert.Empty(t, d.Changes, "tier-only transition shouldn't synthesize attribute changes")
+}
+
+func TestDiffImportedResources_TierTransitionWithFieldChange(t *testing.T) {
+	t.Parallel()
+	// Both Tier and an attribute changed in the same step. FromTier/ToTier
+	// must populate alongside Changes so a renderer doesn't have to choose.
+	oldIR := sampleSQS("q", 30)
+	newIR := sampleSQS("q", 60)
+	newIR.Tier = imported.TierImportedConformant
+
+	diffs := DiffImportedResources([]imported.ImportedResource{oldIR}, []imported.ImportedResource{newIR})
+	require.Len(t, diffs, 1)
+	d := diffs[0]
+	assert.Equal(t, ResourceActionModified, d.Action)
+	assert.Equal(t, imported.TierImportedFlat, d.FromTier)
+	assert.Equal(t, imported.TierImportedConformant, d.ToTier)
+	require.Len(t, d.Changes, 1)
+	assert.Equal(t, "visibility_timeout_seconds", d.Changes[0].Path)
+}
+
+func TestDiffImportedResources_HiddenFieldsOmitted(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "aws_sqs_queue", "tags", policy.FieldPolicy{Visibility: policy.VisibilityHidden})
+
+	old := sampleSQS("q", 30)
+	old.Attributes["tags"] = map[string]any{"Project": "before"}
+	new := sampleSQS("q", 30)
+	new.Attributes["tags"] = map[string]any{"Project": "after"}
+
+	diffs := DiffImportedResources(
+		[]imported.ImportedResource{old},
+		[]imported.ImportedResource{new},
+	)
+	assert.Empty(t, diffs, "tag-only change is Hidden and must be filtered from user-visible diff")
+}
+
+func TestDiffImportedResources_VisibleAndHiddenInSameResource(t *testing.T) {
+	t.Parallel()
+	// Mixed change: visibility_timeout_seconds is RileyVisible, tags is
+	// Hidden. The diff must include only the visible field — a regression
+	// that filters the wrong field surfaces here as a count mismatch.
+	requirePolicyEntry(t, "aws_sqs_queue", "tags", policy.FieldPolicy{Visibility: policy.VisibilityHidden})
+
+	old := sampleSQS("q", 30)
+	old.Attributes["tags"] = map[string]any{"Project": "before"}
+
+	new := sampleSQS("q", 60)
+	new.Attributes["tags"] = map[string]any{"Project": "after"}
+
+	diffs := DiffImportedResources(
+		[]imported.ImportedResource{old},
+		[]imported.ImportedResource{new},
+	)
+	require.Len(t, diffs, 1)
+	require.Len(t, diffs[0].Changes, 1, "only the visible field should surface")
+	assert.Equal(t, "visibility_timeout_seconds", diffs[0].Changes[0].Path)
+}
+
+func TestMakeFieldDiff_RedactsSensitiveValues(t *testing.T) {
+	t.Parallel()
+	// Direct unit test on makeFieldDiff covers the redaction path for
+	// fields whose Sensitivity is Sensitive or Redacted but whose Visibility
+	// is not Hidden — a configuration the curated set doesn't currently
+	// produce, but the helper must still honor the contract.
+	cases := []struct {
+		name        string
+		sensitivity policy.SensitivityPolicy
+		wantRedact  bool
+	}{
+		{"Public no redaction", policy.SensitivityPublic, false},
+		{"Sensitive redacts", policy.SensitivitySensitive, true},
+		{"Redacted redacts", policy.SensitivityRedacted, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			entry := policy.FieldPolicy{
+				Role:        policy.RoleTuning,
+				Visibility:  policy.VisibilityRileyVisible,
+				Edit:        policy.EditChatSafe,
+				Sensitivity: tc.sensitivity,
+			}
+			diff := makeFieldDiff("some_field", "secret-old", "secret-new", entry, true)
+			if tc.wantRedact {
+				assert.True(t, diff.Redacted)
+				assert.Equal(t, redactedPlaceholder, diff.From)
+				assert.Equal(t, redactedPlaceholder, diff.To)
+			} else {
+				assert.False(t, diff.Redacted)
+				assert.Equal(t, "secret-old", diff.From)
+				assert.Equal(t, "secret-new", diff.To)
+			}
+		})
+	}
+}
+
+func TestDiffAttributeMaps_HiddenSkipsRedaction(t *testing.T) {
+	t.Parallel()
+	// Hidden + Sensitive should never reach the redaction code path —
+	// the value is filtered from the diff entirely (no opportunity to
+	// leak even a placeholder). This pins the documented order:
+	// Hidden filter runs before makeFieldDiff.
+	tfType := "aws_lambda_function"
+	requirePolicyEntry(t, tfType, "environment.variables", policy.FieldPolicy{
+		Visibility:  policy.VisibilityHidden,
+		Sensitivity: policy.SensitivitySensitive,
+	})
+	old := map[string]any{"environment.variables": map[string]any{"DB_PASSWORD": "old-secret"}}
+	new := map[string]any{"environment.variables": map[string]any{"DB_PASSWORD": "new-secret"}}
+	diffs := diffAttributeMaps(tfType, old, new)
+	assert.Empty(t, diffs, "Hidden filter must drop sensitive fields before redaction runs")
+}
+
+func TestDiffImportedResources_RelationshipOnlyFlagged(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "aws_sqs_queue", "kms_master_key_id", policy.FieldPolicy{
+		Edit: policy.EditRelationshipOnly,
+	})
+	oldIR := sampleSQS("q", 30)
+	oldIR.Attributes["kms_master_key_id"] = "alias/aws/sqs"
+	newIR := sampleSQS("q", 30)
+	newIR.Attributes["kms_master_key_id"] = "alias/custom"
+
+	diffs := DiffImportedResources(
+		[]imported.ImportedResource{oldIR},
+		[]imported.ImportedResource{newIR},
+	)
+	require.Len(t, diffs, 1)
+	require.Len(t, diffs[0].Changes, 1)
+	c := diffs[0].Changes[0]
+	assert.Equal(t, "kms_master_key_id", c.Path)
+	assert.True(t, c.RelationshipOnly, "RelationshipOnly EditPolicy must set the flag for renderers")
+	assert.Equal(t, policy.EditRelationshipOnly, c.EditPolicy)
+	assert.Equal(t, "alias/aws/sqs", c.From)
+	assert.Equal(t, "alias/custom", c.To)
+}
+
+func TestDiffImportedResources_ChangeRiskCarriedOnFieldDiff(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "aws_lambda_function", "architectures", policy.FieldPolicy{
+		Edit: policy.EditChatSafe, ChangeRisk: policy.ChangeMayReplace,
+	})
+	oldIR := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_lambda_function", Address: "aws_lambda_function.f", ImportID: "f",
+		},
+		Tier:       imported.TierImportedFlat,
+		Attributes: map[string]any{"architectures": []any{"x86_64"}},
+	}
+	newIR := oldIR
+	newIR.Attributes = map[string]any{"architectures": []any{"arm64"}}
+	diffs := DiffImportedResources([]imported.ImportedResource{oldIR}, []imported.ImportedResource{newIR})
+	require.Len(t, diffs, 1)
+	require.Len(t, diffs[0].Changes, 1)
+	c := diffs[0].Changes[0]
+	assert.Equal(t, "architectures", c.Path)
+	assert.Equal(t, policy.ChangeMayReplace, c.ChangeRisk)
+	assert.Equal(t, policy.EditChatSafe, c.EditPolicy)
+}
+
+func TestDiffImportedResources_JSONProjectionExpanded(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "aws_sqs_queue", "redrive_policy.maxReceiveCount", policy.FieldPolicy{
+		Edit: policy.EditChatSafe,
+	})
+
+	// Mutating only the maxReceiveCount sub-field should produce one diff
+	// at the projection path, not one at the raw parent.
+	oldIR := sampleSQS("q", 30)
+	oldIR.Attributes["redrive_policy"] = `{"deadLetterTargetArn":"arn:aws:sqs:::dlq","maxReceiveCount":3}`
+	newIR := sampleSQS("q", 30)
+	newIR.Attributes["redrive_policy"] = `{"deadLetterTargetArn":"arn:aws:sqs:::dlq","maxReceiveCount":5}`
+
+	diffs := DiffImportedResources(
+		[]imported.ImportedResource{oldIR},
+		[]imported.ImportedResource{newIR},
+	)
+	require.Len(t, diffs, 1)
+	require.Len(t, diffs[0].Changes, 1, "only maxReceiveCount changed; deadLetterTargetArn must not produce a diff")
+	c := diffs[0].Changes[0]
+	assert.Equal(t, "redrive_policy.maxReceiveCount", c.Path)
+	assert.Equal(t, "3", c.From)
+	assert.Equal(t, "5", c.To)
+	assert.Equal(t, policy.EditChatSafe, c.EditPolicy)
+}
+
+func TestDiffImportedResources_JSONProjectionParseFallback(t *testing.T) {
+	t.Parallel()
+	// Three fallback shapes — all must funnel to a single raw-parent diff so
+	// stale projection entries from a half-parsed map can never leak.
+	cases := []struct {
+		name string
+		old  any
+		new  any
+	}{
+		{"both garbled", "not-json-at-all", "different-not-json"},
+		{"old garbled new valid", "not-json", `{"maxReceiveCount":5}`},
+		{"old valid new garbled", `{"maxReceiveCount":3}`, "garbled-after-importer"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			oldIR := sampleSQS("q", 30)
+			oldIR.Attributes["redrive_policy"] = tc.old
+			newIR := sampleSQS("q", 30)
+			newIR.Attributes["redrive_policy"] = tc.new
+
+			diffs := DiffImportedResources(
+				[]imported.ImportedResource{oldIR},
+				[]imported.ImportedResource{newIR},
+			)
+			require.Len(t, diffs, 1)
+			require.Len(t, diffs[0].Changes, 1, "asymmetric parse failure must NOT produce stale projection diffs")
+			assert.Equal(t, "redrive_policy", diffs[0].Changes[0].Path,
+				"fallback emits at the raw parent path, never at a sub-projection")
+		})
+	}
+}
+
+func TestDiffImportedResources_MultipleResources(t *testing.T) {
+	t.Parallel()
+	old := []imported.ImportedResource{sampleSQS("alpha", 30), sampleSQS("zeta", 30)}
+	new := []imported.ImportedResource{sampleSQS("alpha", 60), sampleSQS("zeta", 30)}
+	diffs := DiffImportedResources(old, new)
+	require.Len(t, diffs, 1, "only alpha changed")
+	assert.Equal(t, "aws_sqs_queue.alpha", diffs[0].Address)
+}
+
+func TestDiffImportedResources_OmitsResourcesWithEmptyAddress(t *testing.T) {
+	t.Parallel()
+	noAddr := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue"},
+		Tier:     imported.TierImportedFlat,
+	}
+	assert.Empty(t, DiffImportedResources([]imported.ImportedResource{noAddr}, nil))
+	assert.Empty(t, DiffImportedResources(nil, []imported.ImportedResource{noAddr}))
+}
+
+func TestDiffImportedResources_StableOrdering(t *testing.T) {
+	t.Parallel()
+	// Multi-resource, multi-field input so sort order is exercised at both
+	// the top level (Address) and within each resource's Changes (Path).
+	// Compare slices directly with assert.Equal — the contract is on the
+	// returned data, not its JSON projection.
+	mk := func(suffix string, vt int, kms string) imported.ImportedResource {
+		ir := sampleSQS(suffix, vt)
+		ir.Attributes["kms_master_key_id"] = kms
+		ir.Attributes["delay_seconds"] = 10
+		return ir
+	}
+	old := []imported.ImportedResource{
+		mk("zeta", 30, "alias/old-z"),
+		mk("alpha", 30, "alias/old-a"),
+	}
+	new := []imported.ImportedResource{
+		mk("zeta", 60, "alias/new-z"),
+		mk("alpha", 60, "alias/new-a"),
+	}
+
+	first := DiffImportedResources(old, new)
+	require.Len(t, first, 2)
+	for i := range 25 {
+		got := DiffImportedResources(old, new)
+		assert.Equal(t, first, got, "iteration %d: slice drifted (Go map iteration randomization)", i)
+	}
+}
+
+func TestDiffImportedResources_NoPolicyForType(t *testing.T) {
+	t.Parallel()
+	old := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_iam_role", Address: "aws_iam_role.r", ImportID: "r",
+		},
+		Tier:       imported.TierImportedFlat,
+		Attributes: map[string]any{"description": "old"},
+	}
+	new := old
+	new.Attributes = map[string]any{"description": "new"}
+	require.False(t, hasPolicy("aws_iam_role"), "test premise: aws_iam_role uncurated")
+
+	diffs := DiffImportedResources([]imported.ImportedResource{old}, []imported.ImportedResource{new})
+	require.Len(t, diffs, 1)
+	require.Len(t, diffs[0].Changes, 1)
+	c := diffs[0].Changes[0]
+	assert.Equal(t, "description", c.Path)
+	assert.Empty(t, c.Role)
+	assert.Empty(t, c.EditPolicy)
+	assert.False(t, c.Redacted)
+	assert.False(t, c.RelationshipOnly)
+}
+
+func TestDiffImportedResources_VersionDiffWiringGolden(t *testing.T) {
+	t.Parallel()
+	// Pin the wire format that consumers (Reliable, ui-core) rely on. Re-seed
+	// with `UPDATE_GOLDEN=1 go test ./pkg/composer/...` after intentional
+	// shape changes; otherwise drift here is a customer-facing wire break.
+	vd := VersionDiff{
+		FromVersion: 1,
+		ToVersion:   2,
+		Components:  []ComponentDiff{{Component: "aws_vpc", Action: ResourceActionAdded}},
+		Resources: DiffImportedResources(
+			[]imported.ImportedResource{sampleSQS("q", 30)},
+			[]imported.ImportedResource{sampleSQS("q", 60)},
+		),
+		Summary: "test",
+	}
+	got, err := json.MarshalIndent(vd, "", "  ")
+	require.NoError(t, err)
+
+	goldenPath := filepath.Join("testdata", "version_diff_resources.golden.json")
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		require.NoError(t, os.MkdirAll(filepath.Dir(goldenPath), 0o755))
+		require.NoError(t, os.WriteFile(goldenPath, append(got, '\n'), 0o644))
+		t.Logf("wrote golden: %s", goldenPath)
+		return
+	}
+	want, err := os.ReadFile(goldenPath)
+	require.NoError(t, err, "golden missing — run `UPDATE_GOLDEN=1 go test ./pkg/composer/...`")
+	require.Equal(t, string(want), string(got)+"\n",
+		"VersionDiff wire format drifted from %s. If intentional, re-seed via UPDATE_GOLDEN=1.", goldenPath)
+}
+
+// sampleSQS returns a TierImportedFlat aws_sqs_queue with the given suffix
+// and visibility_timeout_seconds value. Used by every test that needs a
+// stable, lightly-curated imported resource.
+func sampleSQS(suffix string, visibilityTimeout int) imported.ImportedResource {
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue." + suffix,
+			ImportID: "https://sqs.us-east-1.amazonaws.com/123/" + suffix,
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"name":                       suffix,
+			"visibility_timeout_seconds": visibilityTimeout,
+		},
+	}
+}
+
+// hasPolicy reports whether tfType has a curated Layer 2 policy. Tests use
+// it to assert their premise so a future curator addition surfaces as a
+// clear premise failure rather than a confusing test failure.
+func hasPolicy(tfType string) bool {
+	_, ok := policy.Lookup(tfType)
+	return ok
+}
+
+// requirePolicyEntry asserts that the curated FieldPolicy at (tfType, path)
+// matches the non-zero fields of want. Tests that depend on a specific
+// curator decision call this so a future policy edit surfaces as a clear
+// premise failure rather than a silent assertion drift.
+//
+// Only the fields populated on want are compared; zero-valued axes are
+// ignored so each test only pins what it depends on.
+func requirePolicyEntry(t *testing.T, tfType, path string, want policy.FieldPolicy) {
+	t.Helper()
+	m, ok := policy.Lookup(tfType)
+	require.True(t, ok, "test premise: %q must be a curated type", tfType)
+	got, ok := m[path]
+	require.True(t, ok, "test premise: %q must have a curated entry for path %q", tfType, path)
+	if want.Role != "" {
+		assert.Equal(t, want.Role, got.Role, "Role mismatch on %s.%s", tfType, path)
+	}
+	if want.Edit != "" {
+		assert.Equal(t, want.Edit, got.Edit, "Edit mismatch on %s.%s", tfType, path)
+	}
+	if want.Visibility != "" {
+		assert.Equal(t, want.Visibility, got.Visibility, "Visibility mismatch on %s.%s", tfType, path)
+	}
+	if want.Sensitivity != "" {
+		assert.Equal(t, want.Sensitivity, got.Sensitivity, "Sensitivity mismatch on %s.%s", tfType, path)
+	}
+	if want.ChangeRisk != "" {
+		assert.Equal(t, want.ChangeRisk, got.ChangeRisk, "ChangeRisk mismatch on %s.%s", tfType, path)
+	}
+}

--- a/pkg/composer/imported_diff_test.go
+++ b/pkg/composer/imported_diff_test.go
@@ -196,6 +196,87 @@ func TestMakeFieldDiff_RedactsSensitiveValues(t *testing.T) {
 	}
 }
 
+// TestDiffImportedResources_HiddenSensitiveFilteredEndToEnd exercises the
+// integration for a Hidden+Sensitive pair: aws_lambda_function's
+// environment.variables. Hidden filters before redaction so no FieldDiff
+// surfaces and raw sensitive values cannot leak.
+func TestDiffImportedResources_HiddenSensitiveFilteredEndToEnd(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "aws_lambda_function", "environment.variables", policy.FieldPolicy{
+		Visibility:  policy.VisibilityHidden,
+		Sensitivity: policy.SensitivitySensitive,
+	})
+	const oldSecret = "DB_PASSWORD=old-leaks-this"
+	const newSecret = "DB_PASSWORD=new-leaks-this-too"
+
+	old := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_lambda_function", Address: "aws_lambda_function.f", ImportID: "f",
+		},
+		Tier:       imported.TierImportedFlat,
+		Attributes: map[string]any{"environment.variables": oldSecret},
+	}
+	new := old
+	new.Attributes = map[string]any{"environment.variables": newSecret}
+
+	diffs := DiffImportedResources([]imported.ImportedResource{old}, []imported.ImportedResource{new})
+	require.Empty(t, diffs, "Hidden filter must drop sensitive fields end-to-end")
+
+	// Defense-in-depth: marshal the diffs slice and assert no secret leaked
+	// into any rendering of the result.
+	b, err := json.Marshal(diffs)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), oldSecret)
+	assert.NotContains(t, string(b), newSecret)
+}
+
+// TestDiffImportedResources_VisibleRedactedEndToEnd exercises the integration
+// for a real Visible+Redacted curated entry: google_pubsub_subscription's
+// push_config.attributes (a JSON-projection path). The diff must surface the
+// change so the operator sees that something moved, but values must be
+// replaced with the redacted placeholder so raw subscriber metadata cannot
+// leak into Reliable's JSON.
+func TestDiffImportedResources_VisibleRedactedEndToEnd(t *testing.T) {
+	t.Parallel()
+	requirePolicyEntry(t, "google_pubsub_subscription", "push_config.attributes", policy.FieldPolicy{
+		Visibility:  policy.VisibilityRileyVisible,
+		Sensitivity: policy.SensitivityRedacted,
+	})
+	const oldSecret = "x-goog-version-not-public"
+	const newSecret = "x-goog-version-rotated"
+
+	old := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "gcp", Type: "google_pubsub_subscription", Address: "google_pubsub_subscription.s", ImportID: "s",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"push_config": `{"attributes":{"x-goog-version":"` + oldSecret + `"}}`,
+		},
+	}
+	new := old
+	new.Attributes = map[string]any{
+		"push_config": `{"attributes":{"x-goog-version":"` + newSecret + `"}}`,
+	}
+
+	diffs := DiffImportedResources([]imported.ImportedResource{old}, []imported.ImportedResource{new})
+	require.Len(t, diffs, 1)
+	require.Len(t, diffs[0].Changes, 1)
+	c := diffs[0].Changes[0]
+	assert.Equal(t, "push_config.attributes", c.Path)
+	assert.True(t, c.Redacted, "Visible+Redacted must set the redacted flag")
+	assert.Equal(t, redactedPlaceholder, c.From)
+	assert.Equal(t, redactedPlaceholder, c.To)
+	assert.Equal(t, policy.SensitivityRedacted, c.Sensitivity)
+
+	// Defense-in-depth: marshal the full ResourceDiff and assert no secret
+	// leaks anywhere — Path, Reason, JSON encoding, none of it.
+	b, err := json.Marshal(diffs)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), oldSecret, "redacted JSON must never contain the old value")
+	assert.NotContains(t, string(b), newSecret, "redacted JSON must never contain the new value")
+}
+
 func TestDiffAttributeMaps_HiddenSkipsRedaction(t *testing.T) {
 	t.Parallel()
 	// Hidden + Sensitive should never reach the redaction code path —
@@ -396,15 +477,40 @@ func TestDiffImportedResources_VersionDiffWiringGolden(t *testing.T) {
 	// Pin the wire format that consumers (Reliable, ui-core) rely on. Re-seed
 	// with `UPDATE_GOLDEN=1 go test ./pkg/composer/...` after intentional
 	// shape changes; otherwise drift here is a customer-facing wire break.
+	//
+	// The Resources slice combines the live diff path (a curated ChatSafe
+	// change) with a hand-constructed redacted-shape entry. The Phase 1
+	// curated set never produces Visible+Sensitive (every Sensitive /
+	// Redacted entry is also Hidden — see TestNoVisibleSensitiveInPhase1),
+	// so a regression in the placeholder constant or the Redacted flag would
+	// otherwise go unpinned in JSON. This test pins both shapes in one
+	// golden so renderers (Reliable / ui-core) get a stable contract.
+	live := DiffImportedResources(
+		[]imported.ImportedResource{sampleSQS("q", 30)},
+		[]imported.ImportedResource{sampleSQS("q", 60)},
+	)
+	redacted := ResourceDiff{
+		Address: "test_only.r",
+		Type:    "test_only_type",
+		Cloud:   "aws",
+		Action:  ResourceActionModified,
+		Changes: []ResourceFieldDiff{{
+			Path:        "secret_field",
+			From:        redactedPlaceholder,
+			To:          redactedPlaceholder,
+			Role:        policy.RoleTuning,
+			Sensitivity: policy.SensitivitySensitive,
+			EditPolicy:  policy.EditChatSafe,
+			Redacted:    true,
+		}},
+	}
+
 	vd := VersionDiff{
 		FromVersion: 1,
 		ToVersion:   2,
 		Components:  []ComponentDiff{{Component: "aws_vpc", Action: ResourceActionAdded}},
-		Resources: DiffImportedResources(
-			[]imported.ImportedResource{sampleSQS("q", 30)},
-			[]imported.ImportedResource{sampleSQS("q", 60)},
-		),
-		Summary: "test",
+		Resources:   append(live, redacted),
+		Summary:     "test",
 	}
 	got, err := json.MarshalIndent(vd, "", "  ")
 	require.NoError(t, err)

--- a/pkg/composer/testdata/version_diff_resources.golden.json
+++ b/pkg/composer/testdata/version_diff_resources.golden.json
@@ -1,0 +1,29 @@
+{
+  "from_version": 1,
+  "to_version": 2,
+  "components": [
+    {
+      "component": "aws_vpc",
+      "action": "added"
+    }
+  ],
+  "resources": [
+    {
+      "address": "aws_sqs_queue.q",
+      "type": "aws_sqs_queue",
+      "cloud": "aws",
+      "action": "modified",
+      "changes": [
+        {
+          "path": "visibility_timeout_seconds",
+          "from": "30",
+          "to": "60",
+          "role": "Tuning",
+          "pillar": "Reliability",
+          "edit_policy": "ChatSafe"
+        }
+      ]
+    }
+  ],
+  "summary": "test"
+}

--- a/pkg/composer/testdata/version_diff_resources.golden.json
+++ b/pkg/composer/testdata/version_diff_resources.golden.json
@@ -23,6 +23,23 @@
           "edit_policy": "ChatSafe"
         }
       ]
+    },
+    {
+      "address": "test_only.r",
+      "type": "test_only_type",
+      "cloud": "aws",
+      "action": "modified",
+      "changes": [
+        {
+          "path": "secret_field",
+          "from": "***",
+          "to": "***",
+          "role": "Tuning",
+          "sensitivity": "Sensitive",
+          "edit_policy": "ChatSafe",
+          "redacted": true
+        }
+      ]
     }
   ],
   "summary": "test"

--- a/pkg/composer/validate.go
+++ b/pkg/composer/validate.go
@@ -131,6 +131,7 @@ func ValidateAll(
 	if len(opts) > 0 {
 		all = append(all, ValidateOpts(opts[0])...)
 		all = append(all, ValidateImportedResources(opts[0].Cloud, opts[0].Imported)...)
+		all = append(all, ValidateImportedResourceAuthorization(opts[0].Cloud, opts[0].Imported)...)
 	}
 	return dedupeAndSortIssues(all)
 }


### PR DESCRIPTION
## Summary

Bundles the two Phase 2 imported-resource SDK PRs into a single shipping unit. These are SDK-level changes consumed by Reliable / ui-core (cross-repo via the embedded \`embed.FS\`); shipping them together makes the downstream preset version bump cover both. Also resolves the duplicate test-helper that would have caused a compile error if the two PRs had been merged independently.

Original individual PRs (kept open as alternatives — close once this bundle merges):
- PR #176 → issue #149 (server-side authorization)
- PR #177 → issue #151 (ResourceDiff + VersionDiff.Resources)

## What's in it

### 1. \`ValidateImportedResourceAuthorization\` (#149)

Phase 2 sibling to \`ValidateImportedResources\`. Enforces the Layer 2 field policy on chat / API / MCP write paths to imported resources. Per FieldEdit, produces at most one issue with a snake_case Code:

- \`imported_resource_field_edit_no_policy\` / \`_no_policy_for_path\` / \`_unknown_path\` — default-deny for unregistered types and uncurated paths (decision #43).
- \`imported_resource_field_edit_forbidden\` / \`_system_only\` / \`_relationship_only\` — EditPolicy gates (Never / SystemOnly / RelationshipOnly per decisions #14, #30).
- \`imported_resource_field_edit_requires_approval\` / \`_approval_invalid\` — RequiresApproval edits without complete plan-tied approval metadata (decision #42).
- \`imported_resource_field_edit_replacement_risk_unconfirmed\` — ChangeRisk in {MayReplace, AlwaysReplace, Unknown} without approval (decision #42).
- \`imported_resource_field_edit_reimport_conflict\` — desired Attributes diverged from FieldEdit.NewValue (decision #19).

Sensitive (or Redacted) field values are redacted to \`***\` in any emitted ValidationIssue (decision #36). Adds \`FieldEditApproval\` to \`pkg/composer/imported\`. Wired into \`composeStackImpl\` and \`ValidateAll\`.

### 2. \`DiffImportedResources\` + \`VersionDiff.Resources\` (#151)

Sorted, redacted, policy-aware diff that Reliable can render alongside component/config changes. \`VersionDiff\` gains a \`Resources []ResourceDiff\` field (always-non-nil; serializes as \`[]\` not \`null\`).

- **Hidden** filters fields out entirely (system-owned metadata never surfaces).
- **Sensitive / Redacted** replaces values with \`***\` and sets \`Redacted=true\`.
- **RelationshipOnly** is flagged but still diffs (renderers show graph movement, not scalar edits).
- **ChangeRisk** populates so renderers show plan-tied confirmation badges.
- **JSON projections** decode from string-shaped parents and emit at the projection path; asymmetric parse failures fall back to raw parent diff.

### 3. \`requirePolicyEntry\` consolidation (#183)

Both #176 and #177 shipped identical \`requirePolicyEntry\` test helpers in different files in the same package. Landing them independently would compile-error in main with \`requirePolicyEntry redeclared\`. The text-level git merge succeeds cleanly so it's not caught by \`git merge\` itself — only by CI on the second PR if branch protection requires up-to-date-with-main. Bundling them is the natural place to consolidate; the duplicate in \`imported_diff_test.go\` is dropped, the \`imported_authz_validate_test.go\` version is canonical.

## QA

Both halves went through 4 rounds of qa-professor + /review with severity tags. Net findings caught and fixed:
- 1 P0 wire-format break (\`Resources\` would have marshaled as \`null\` after \`omitempty\` removal).
- ~10 P1s across both PRs (semantic divergence, missing premise checks, stale rationale, missing curator-lint dependency test, etc.).
- Multiple P2/P3 polish items.

## Tests

**#149 authz:**
- Every documented gate code (positive + negative).
- RequiresApproval + MayReplace combinatorial gate (both halves).
- Redaction across both \`SensitivityRedacted\` (tags) and \`SensitivitySensitive\` (lambda environment.variables) — asserts Value, Reason, Suggestion, AND Field don't leak.
- \`evaluateEditPolicy\` defensive default branch.
- Deterministic per-FieldEdit ordering across 50 iterations.
- Tier filter covers every non-imported tier explicitly.
- Integration through \`ComposeStackWithIssues\` and \`ValidateAll\`.
- \`firstUncuratedResolvablePath\` test helper makes the path-without-policy test mutation-resistant.
- \`TestEveryCuratedPathResolves\` makes the curator-lint dependency explicit (the perf reorder relies on it).
- TierImportedMissing dual-validator pinning.
- Nested-path conflict-gate no-op pinning.

**#151 diff:**
- Added / removed / modified actions.
- Tier transition alone + tier-transition-with-field-change (FromTier/ToTier coexist with Changes).
- Hidden field omitted; visible+hidden mixed change in same resource.
- Sensitive / Redacted redaction (direct unit test on makeFieldDiff + integration via real curated entry).
- Hidden-Sensitive end-to-end on \`aws_lambda_function.environment.variables\`.
- Visible-Redacted end-to-end on \`google_pubsub_subscription.push_config.attributes\` (real curated JSON-projection entry).
- RelationshipOnly flag set, value still diffs.
- ChangeRisk carried on FieldDiff.
- JSON projection happy path + 3 asymmetric parse-fallback cases.
- Multi-resource sort stability across 25 iterations (slice-level).
- No-policy-for-type generic diff.
- Wire-format golden file (\`testdata/version_diff_resources.golden.json\`); pinned for both live diff entries AND the redacted shape.
- \`Resources\` always-non-nil contract: \`TestDiffImportedResources_EmptyMarshalsAsArray\` covers nil, empty, identical-content, AND hidden-only-delta cases.

**Repo:**
- \`go test ./pkg/composer/...\` passes (full suite).
- \`go vet ./...\` clean.
- \`terraform fmt -check -recursive\` passes.
- All four static lint scripts pass.

## Closes

- Closes #149
- Closes #151
- Closes #183 (helper consolidation done as part of this bundle)

## Cross-repo follow-up

Reliable / ui-core consumers will pick up both new APIs (\`ValidateImportedResourceAuthorization\` + \`VersionDiff.Resources\`) on next preset bump. The TypeScript wire-format mirror in Reliable's \`lib/stack/types.ts\` should be updated to match the \`ResourceDiff\` shape as part of issue **#152** (cross-repo Reliable inspector filter + Riley import-result injection).

## Out of scope

- #152 — cross-repo Reliable integration (tracked separately on the Reliable side).
- The remaining open items on the Phase 2 epic (#143) — see the epic for status.