### PR TITLE
fix(insideout-import): loud-fail plan errors + cover replace drift (review #58)

### DIFF
--- a/internal/cleanup/driftfix.go
+++ b/internal/cleanup/driftfix.go
@@ -17,9 +17,18 @@ import (
 //
 // The approach:
 //  1. Parse the plan's ResourceChanges
-//  2. For each resource with action "update", diff Before/After
+//  2. For each resource with a drift-bearing action (update OR replace),
+//     diff Before/After
 //  3. Identify which attributes changed
 //  4. Add those attributes to lifecycle { ignore_changes } in the HCL
+//
+// Both "update" and "replace" actions carry meaningful drift. An "update"
+// is a single-step change; a "replace" (delete+create or create+delete)
+// fires when terraform detects a change that the provider deems
+// non-modifiable in place. For an imported resource, BOTH cases mean
+// "the desired state diverged from the cloud state" — adding
+// ignore_changes on the drifting attribute is the right cleanup for
+// either action so the imported config produces a clean plan.
 //
 // This replaces hardcoded per-resource-type ignore_changes lists with
 // a data-driven approach that works for any provider and resource type.
@@ -34,8 +43,7 @@ func FixDriftFromPlan(src []byte, plan *tfjson.Plan) ([]byte, error) {
 		if rc.Change == nil {
 			continue
 		}
-		// Only care about "update" actions (drift on import)
-		if !containsAction(rc.Change.Actions, "update") {
+		if !isDriftAction(rc.Change.Actions) {
 			continue
 		}
 
@@ -106,6 +114,29 @@ func containsAction(actions tfjson.Actions, action string) bool {
 		}
 	}
 	return false
+}
+
+// isDriftAction reports whether a ResourceChange's actions indicate
+// drift-on-import that ignore_changes can suppress. Two action shapes
+// qualify:
+//
+//   - {"update"} — the provider can adjust in place.
+//   - {"delete","create"} or {"create","delete"} — terraform's "replace"
+//     encoding; fires when the provider deems the changed attribute
+//     non-modifiable in place. For imported resources, replace usually
+//     means "your config has a different value than the cloud reality"
+//     and the cleanup is the same as update: add the drifting attribute
+//     to ignore_changes so the next plan is clean.
+//
+// "no-op" and pure-create / pure-delete actions are excluded; those
+// don't represent drift on the imported resource.
+func isDriftAction(actions tfjson.Actions) bool {
+	if containsAction(actions, "update") {
+		return true
+	}
+	hasCreate := containsAction(actions, "create")
+	hasDelete := containsAction(actions, "delete")
+	return hasCreate && hasDelete
 }
 
 // addLifecycleIgnoreChanges adds or merges a lifecycle block with

--- a/internal/cleanup/driftfix_test.go
+++ b/internal/cleanup/driftfix_test.go
@@ -231,3 +231,87 @@ func TestFixDriftFromPlan_ImportOnly(t *testing.T) {
 		t.Error("import-only action should not add lifecycle")
 	}
 }
+
+// TestFixDriftFromPlan_ReplaceAction pins the new behavior: replace
+// actions ({delete, create}) carry meaningful drift on imported
+// resources and must produce ignore_changes the same way update
+// actions do. Pre-fix, FixDriftFromPlan only filtered on "update" so
+// replace-action drift slipped through silently and the next plan
+// would still show the replace.
+func TestFixDriftFromPlan_ReplaceAction(t *testing.T) {
+	hcl := `resource "aws_lambda_function" "f" {
+  function_name = "my-fn"
+  architectures = ["x86_64"]
+}
+`
+	cases := []struct {
+		name    string
+		actions tfjson.Actions
+	}{
+		{"delete then create", tfjson.Actions{"delete", "create"}},
+		{"create then delete", tfjson.Actions{"create", "delete"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := &tfjson.Plan{
+				ResourceChanges: []*tfjson.ResourceChange{
+					{
+						Address: "aws_lambda_function.f",
+						Type:    "aws_lambda_function",
+						Name:    "f",
+						Change: &tfjson.Change{
+							Actions: tc.actions,
+							Before: map[string]interface{}{
+								"function_name": "my-fn",
+								"architectures": []interface{}{"x86_64"},
+							},
+							After: map[string]interface{}{
+								"function_name": "my-fn",
+								"architectures": []interface{}{"arm64"},
+							},
+						},
+					},
+				},
+			}
+
+			got, err := FixDriftFromPlan([]byte(hcl), plan)
+			if err != nil {
+				t.Fatalf("error = %v", err)
+			}
+			output := string(got)
+			if !strings.Contains(output, "lifecycle") {
+				t.Fatalf("replace action must add lifecycle block; got %s", output)
+			}
+			if !strings.Contains(output, "architectures") {
+				t.Errorf("ignore_changes must contain architectures (drifting attr); got %s", output)
+			}
+		})
+	}
+}
+
+// TestIsDriftAction covers the action-classifier edge cases. Update is
+// the original baseline; replace-as-{delete,create} or {create,delete}
+// is the new coverage; pure create / pure delete / no-op must NOT
+// trigger ignore_changes synthesis (those aren't drift).
+func TestIsDriftAction(t *testing.T) {
+	cases := []struct {
+		name    string
+		actions tfjson.Actions
+		want    bool
+	}{
+		{"update only", tfjson.Actions{"update"}, true},
+		{"delete then create (replace)", tfjson.Actions{"delete", "create"}, true},
+		{"create then delete (replace)", tfjson.Actions{"create", "delete"}, true},
+		{"create only (import / new)", tfjson.Actions{"create"}, false},
+		{"delete only", tfjson.Actions{"delete"}, false},
+		{"no-op", tfjson.Actions{"no-op"}, false},
+		{"empty actions", tfjson.Actions{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDriftAction(tc.actions); got != tc.want {
+				t.Errorf("isDriftAction(%v) = %v, want %v", tc.actions, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -441,7 +441,7 @@ func (r *Runner) getTerraformRunner(ctx context.Context, workDir string) (terraf
 		}
 		return r.tfRunner, nil
 	}
-	return NewTerraformExecutor(ctx, workDir, r.config.TFBinary)
+	return NewTerraformExecutor(ctx, workDir, r.config.TFBinary, r.logger)
 }
 
 func (r *Runner) copyOutput(workDir string) error {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -226,8 +226,16 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 		// import blocks without corresponding resource blocks.
 		depGeneratedFile := fmt.Sprintf("generated_dep_%d.tf", iteration)
 		if err := tfExec.PlanGenerateConfig(ctx, depGeneratedFile); err != nil {
-			r.logger.Warn("terraform plan failed during dep chase, stopping", "error", err)
-			break
+			// PlanGenerateConfig only returns non-nil when the file was NOT
+			// written (the post-#187 contract; the Lambda-style validation
+			// gap is logged at Warn and returns nil). A real terraform
+			// failure here means the dep-chase iteration produced no HCL
+			// while the accumulated cleanedHCL references its ARN — silent
+			// break would leave the output internally inconsistent with
+			// orphaned references that pass validate but fail apply
+			// (issue #58 review). Escalate so the operator sees the
+			// failure and can re-run.
+			return nil, fmt.Errorf("terraform plan failed during dep chase iteration %d: %w", iteration, err)
 		}
 
 		depGeneratedPath := filepath.Join(workDir, depGeneratedFile)
@@ -331,14 +339,23 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 	for driftIter := 0; driftIter < 3; driftIter++ {
 		plan, err := validateExec.PlanJSON(ctx)
 		if err != nil {
-			r.logger.Warn("drift-fix plan failed, skipping", "error", err)
-			break
+			// The drift-fix plan IS the input to drift detection; if it
+			// fails, we cannot honor the "0 changes plan" contract from
+			// the design doc ("drift is a bug, not a limitation"). The
+			// pre-#187 silent break marked the run ValidationOK against
+			// HCL with un-fixed drift — a customer would then see drift
+			// on their NEXT plan and report a false positive. Escalate
+			// instead so the operator re-runs and the contract holds.
+			return nil, fmt.Errorf("drift-fix plan failed at iteration %d: %w", driftIter, err)
 		}
 
 		fixedHCL, err := cleanup.FixDriftFromPlan(cleanedHCL, plan)
 		if err != nil {
-			r.logger.Warn("drift-fix failed, skipping", "error", err)
-			break
+			// FixDriftFromPlan parses HCL and rewrites lifecycle blocks.
+			// A failure here means we have a partial rewrite or invalid
+			// HCL output. Escalating ensures the operator sees the issue
+			// rather than getting a "successful" run with broken output.
+			return nil, fmt.Errorf("drift-fix HCL rewrite failed at iteration %d: %w", driftIter, err)
 		}
 
 		if string(fixedHCL) == string(cleanedHCL) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -32,6 +33,12 @@ type mockTF struct {
 	validateErr    error
 	generatedPages []string // HCL to write on successive PlanGenerateConfig calls
 	planCallCount  int
+
+	// Error injection for the loud-failure tests (issue #58 review):
+	// planErrAtCall fails PlanGenerateConfig on the nth call (1-indexed,
+	// 0 = never). planJSONErr fails every PlanJSON call.
+	planErrAtCall int
+	planJSONErr   error
 }
 
 func (m *mockTF) SetWorkDir(dir string) { m.workDir = dir }
@@ -41,11 +48,15 @@ func (m *mockTF) Init(_ context.Context) error {
 }
 
 func (m *mockTF) PlanGenerateConfig(_ context.Context, outFile string) error {
-	if m.planCallCount >= len(m.generatedPages) {
+	m.planCallCount++
+	if m.planErrAtCall != 0 && m.planCallCount == m.planErrAtCall {
+		return errors.New("simulated terraform plan failure")
+	}
+	idx := m.planCallCount - 1
+	if idx >= len(m.generatedPages) {
 		return nil
 	}
-	hcl := m.generatedPages[m.planCallCount]
-	m.planCallCount++
+	hcl := m.generatedPages[idx]
 	return os.WriteFile(filepath.Join(m.workDir, outFile), []byte(hcl), 0644)
 }
 
@@ -58,6 +69,9 @@ func (m *mockTF) ProvidersSchema(_ context.Context) (*tfjson.ProviderSchemas, er
 }
 
 func (m *mockTF) PlanJSON(_ context.Context) (*tfjson.Plan, error) {
+	if m.planJSONErr != nil {
+		return nil, m.planJSONErr
+	}
 	// Return empty plan (no drift) — drift-fix pass sees no changes
 	return &tfjson.Plan{}, nil
 }
@@ -414,5 +428,89 @@ resource "aws_iam_role" "my_project_lambda_exec" {
 	// --- Verify validation ran ---
 	if !result.ValidationOK {
 		t.Error("ValidationOK should be true (mock returns no error)")
+	}
+}
+
+// TestRunner_DepChasePlanError_Escalates pins the issue #58 review fix:
+// when the dep-chase iteration's PlanGenerateConfig fails (the real
+// terraform-failure path, post-#187 — the Lambda-style validation gap is
+// returned as nil + Warn from PlanGenerateConfig itself), the runner
+// must escalate the error so the operator sees a non-zero exit instead
+// of a "successful" run with internally-inconsistent HCL referencing
+// dependencies that were never imported.
+func TestRunner_DepChasePlanError_Escalates(t *testing.T) {
+	// Use the iteration1HCL shape from TestRunner_DependencyChase: it
+	// contains a hardcoded IAM role ARN that the dep chaser will detect
+	// as an unresolved reference, triggering a second PlanGenerateConfig
+	// call. We fail that second call to exercise the escalation path.
+	iteration1HCL := `# __generated__ by Terraform
+resource "aws_lambda_function" "fn" {
+  function_name = "my-project-fn"
+  role          = "arn:aws:iam::123456789012:role/my-project-lambda-exec"
+  runtime       = "nodejs20.x"
+  handler       = "index.handler"
+}
+`
+	mock := &mockTF{
+		generatedPages: []string{iteration1HCL},
+		planErrAtCall:  2, // initial plan succeeds; dep-chase plan fails
+	}
+	r := New(Config{
+		Project:   "my-project",
+		Region:    "us-east-1",
+		OutputDir: filepath.Join(t.TempDir(), "output"),
+	}, testLogger())
+	r.discoverer = &mockDiscoverer{
+		resources: []discovery.DiscoveredResource{{
+			TerraformType: "aws_lambda_function",
+			ImportID:      "my-project-fn",
+			Name:          "my-project-fn",
+		}},
+	}
+	r.tfRunner = mock
+
+	_, err := r.Run(context.Background())
+	if err == nil {
+		t.Fatal("dep-chase plan failure must propagate; got nil error")
+	}
+	if !strings.Contains(err.Error(), "dep chase") {
+		t.Errorf("error must name the failing phase; got %v", err)
+	}
+}
+
+// TestRunner_DriftFixPlanError_Escalates pins the issue #58 review fix:
+// when the drift-fix loop's PlanJSON fails, the runner must escalate
+// instead of silently breaking and reporting ValidationOK against HCL
+// that may still have un-fixed drift.
+func TestRunner_DriftFixPlanError_Escalates(t *testing.T) {
+	iteration1HCL := `# __generated__ by Terraform
+resource "aws_sqs_queue" "q" {
+  name = "my-project-queue"
+}
+`
+	mock := &mockTF{
+		generatedPages: []string{iteration1HCL},
+		planJSONErr:    errors.New("simulated drift-fix plan failure"),
+	}
+	r := New(Config{
+		Project:   "my-project",
+		Region:    "us-east-1",
+		OutputDir: filepath.Join(t.TempDir(), "output"),
+	}, testLogger())
+	r.discoverer = &mockDiscoverer{
+		resources: []discovery.DiscoveredResource{{
+			TerraformType: "aws_sqs_queue",
+			ImportID:      "https://sqs.us-east-1.amazonaws.com/123/my-project-queue",
+			Name:          "my-project-queue",
+		}},
+	}
+	r.tfRunner = mock
+
+	_, err := r.Run(context.Background())
+	if err == nil {
+		t.Fatal("drift-fix plan failure must propagate; got nil error")
+	}
+	if !strings.Contains(err.Error(), "drift-fix") {
+		t.Errorf("error must name the failing phase; got %v", err)
 	}
 }

--- a/internal/runner/terraform.go
+++ b/internal/runner/terraform.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -17,11 +18,17 @@ import (
 type TerraformExecutor struct {
 	tf      *tfexec.Terraform
 	workDir string
+	logger  *slog.Logger
 }
 
 // NewTerraformExecutor creates a new executor. If tfBinary is empty, it uses
-// the system terraform or installs one.
-func NewTerraformExecutor(ctx context.Context, workDir, tfBinary string) (*TerraformExecutor, error) {
+// the system terraform or installs one. logger is used to surface non-fatal
+// terraform diagnostics that would otherwise be silently swallowed (e.g.
+// PlanGenerateConfig generating HCL successfully despite a validation
+// error — the caller still gets nil but the underlying error is logged at
+// Warn so operators can spot real failures vs the documented Lambda case).
+// A nil logger defaults to slog.Default() so existing callers don't change.
+func NewTerraformExecutor(ctx context.Context, workDir, tfBinary string, logger *slog.Logger) (*TerraformExecutor, error) {
 	if tfBinary == "" {
 		installer := &releases.ExactVersion{
 			Product: product.Terraform,
@@ -39,7 +46,10 @@ func NewTerraformExecutor(ctx context.Context, workDir, tfBinary string) (*Terra
 		return nil, fmt.Errorf("create terraform executor: %w", err)
 	}
 
-	return &TerraformExecutor{tf: tf, workDir: workDir}, nil
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &TerraformExecutor{tf: tf, workDir: workDir, logger: logger}, nil
 }
 
 // Init runs terraform init in the working directory.
@@ -50,23 +60,53 @@ func (t *TerraformExecutor) Init(ctx context.Context) error {
 // PlanGenerateConfig runs terraform plan with -generate-config-out to produce
 // HCL configuration from import blocks. The generated file may be written even
 // if plan returns an error (e.g., validation errors on generated resources).
-// Returns nil if the output file was produced, regardless of plan outcome.
+// Returns nil if the output file was produced, regardless of plan outcome —
+// downstream cleanup phases fix common validation gaps like the Lambda
+// "requires one of filename/image_uri/s3_bucket" case.
+//
+// When swallowing the plan error, the underlying diagnostic is logged at
+// Warn so an operator running `insideout-import` can distinguish the
+// expected Lambda-style validation gap from a real terraform failure (auth
+// expiry, state corruption, provider crash) that left a partial file. The
+// previous implementation returned nil silently in both cases — see
+// PR review on #58. If the file was NOT written, the original error
+// propagates.
 func (t *TerraformExecutor) PlanGenerateConfig(ctx context.Context, outFile string) error {
-	_, err := t.tf.Plan(ctx, tfexec.GenerateConfigOut(outFile))
-	if err != nil {
-		// Check if the generated file was written despite the error.
-		// terraform plan -generate-config-out writes the file before validation,
-		// so it may exist even when the plan fails (e.g., Lambda requires
-		// one of filename/image_uri/s3_bucket).
-		outPath := filepath.Join(t.workDir, outFile)
-		if _, statErr := os.Stat(outPath); statErr == nil {
-			// File exists — the generation succeeded, even if plan didn't.
-			// Our cleanup phase will fix the validation issues.
-			return nil
-		}
-		return fmt.Errorf("terraform plan: %w", err)
+	_, planErr := t.tf.Plan(ctx, tfexec.GenerateConfigOut(outFile))
+	outPath := filepath.Join(t.workDir, outFile)
+	_, statErr := os.Stat(outPath)
+	return classifyPlanGenerateConfigError(t.logger, planErr, statErr == nil, outFile)
+}
+
+// classifyPlanGenerateConfigError encodes the swallow-or-propagate decision
+// for a `terraform plan -generate-config-out` invocation. It is extracted
+// so the policy can be unit-tested without spinning up terraform — the
+// only state it inspects is the plan error, the file-exists flag, and the
+// supplied logger.
+//
+// Decision matrix:
+//
+//	planErr=nil               -> nil (happy path)
+//	planErr!=nil, file exists -> nil + Warn (terraform generated HCL but
+//	                              tripped a post-generation diagnostic;
+//	                              cleanup phases will fix common gaps
+//	                              like the Lambda required-arg case)
+//	planErr!=nil, no file     -> propagate (plan executor itself failed
+//	                              before writing anything; cleanup cannot
+//	                              salvage)
+func classifyPlanGenerateConfigError(logger *slog.Logger, planErr error, outFileExists bool, outFile string) error {
+	if planErr == nil {
+		return nil
 	}
-	return nil
+	if outFileExists {
+		logger.Warn(
+			"terraform plan -generate-config-out wrote the output file but plan returned an error; proceeding to cleanup phase",
+			slog.String("out_file", outFile),
+			slog.String("plan_err", planErr.Error()),
+		)
+		return nil
+	}
+	return fmt.Errorf("terraform plan: %w", planErr)
 }
 
 // Validate runs terraform validate.
@@ -90,7 +130,6 @@ func (t *TerraformExecutor) PlanJSON(ctx context.Context) (*tfjson.Plan, error) 
 	}
 	return t.tf.ShowPlanFile(ctx, planFile)
 }
-
 
 // ProvidersTF returns the provider configuration HCL for the given provider.
 func ProvidersTF(provider, project, region string) []byte {

--- a/internal/runner/terraform_test.go
+++ b/internal/runner/terraform_test.go
@@ -1,6 +1,10 @@
 package runner
 
 import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -100,4 +104,92 @@ func TestCopyOutput_CreatesOutputDir(t *testing.T) {
 	if _, err := os.Stat(dstDir); err != nil {
 		t.Errorf("output dir should be created: %v", err)
 	}
+}
+
+// TestClassifyPlanGenerateConfigError covers the decision matrix for
+// PlanGenerateConfig's swallow-or-propagate behavior. The key contract:
+// errors are only swallowed when terraform DID write the output file —
+// indicating the plan tripped a post-generation diagnostic that the
+// cleanup phase can fix (e.g. the Lambda required-arg case). Errors
+// without a written file propagate so the runner doesn't continue with
+// garbage HCL.
+func TestClassifyPlanGenerateConfigError(t *testing.T) {
+	cases := []struct {
+		name      string
+		planErr   error
+		fileExist bool
+		wantNil   bool
+		wantWarn  bool
+	}{
+		{
+			name:      "happy path: no plan error",
+			planErr:   nil,
+			fileExist: true,
+			wantNil:   true,
+			wantWarn:  false,
+		},
+		{
+			name:      "happy path: no plan error and no file (caller decides)",
+			planErr:   nil,
+			fileExist: false,
+			wantNil:   true,
+			wantWarn:  false,
+		},
+		{
+			name:      "post-generation validation error: file written, error swallowed with warn",
+			planErr:   errors.New("Error: Missing required argument"),
+			fileExist: true,
+			wantNil:   true,
+			wantWarn:  true,
+		},
+		{
+			name:      "executor failure: no file, error propagates",
+			planErr:   errors.New("Error: NoCredentialProviders"),
+			fileExist: false,
+			wantNil:   false,
+			wantWarn:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			got := classifyPlanGenerateConfigError(logger, tc.planErr, tc.fileExist, "generated.tf")
+
+			if tc.wantNil && got != nil {
+				t.Errorf("expected nil, got %v", got)
+			}
+			if !tc.wantNil && got == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.wantNil && got != nil && !errors.Is(got, tc.planErr) {
+				t.Errorf("returned error must wrap the plan error; got %v", got)
+			}
+			gotWarn := strings.Contains(buf.String(), "level=WARN")
+			if tc.wantWarn != gotWarn {
+				t.Errorf("warn=%v, log output=%q", gotWarn, buf.String())
+			}
+			// When swallowing, the warn must include the plan error
+			// string so an operator can spot real failures vs the
+			// documented Lambda case.
+			if tc.wantWarn && !strings.Contains(buf.String(), tc.planErr.Error()) {
+				t.Errorf("warn must include plan error text; got %q", buf.String())
+			}
+		})
+	}
+}
+
+// TestClassifyPlanGenerateConfigError_NilLoggerSafe ensures the helper
+// doesn't panic on a nil logger — the constructor defaults to
+// slog.Default(), but a future caller bypassing the constructor must not
+// crash the runner.
+func TestClassifyPlanGenerateConfigError_NilLoggerSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("nil-logger path must not panic; got %v", r)
+		}
+	}()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	_ = classifyPlanGenerateConfigError(logger, errors.New("x"), true, "generated.tf")
 }


### PR DESCRIPTION
## Summary

Stacked on **PR #58** (\`feature/insideout-import-phase1\`). Surgical fixes for the highest-impact silent-failure findings from qa-professor review of #58. Targets that branch directly so the fixes land **with** PR #58 when the maintainer merges.

Three commits, all themed "no silent state":

### 1. \`PlanGenerateConfig\` no longer silently swallows real terraform errors [P0]

The previous implementation returned \`nil\` whenever the output file existed, regardless of plan outcome. The cited rationale (Lambda's "requires one of filename/image_uri/s3_bucket" case) is real, but the side effect was that **any** plan failure that left a partial file — provider auth error, state corruption, provider crash — became silently "successful" and the runner marched on with garbage HCL.

Fix: extracted \`classifyPlanGenerateConfigError\` helper. Decision matrix is now testable without spinning up terraform:
- no error → nil
- error + file written → nil + Warn (operator can spot real failures vs the documented Lambda case)
- error + no file → propagate

### 2. Dep-chase and drift-fix loops escalate plan errors [P1]

Two parallel silent-break-on-plan-error sites:

- **runner.go:228** (dep chase) — silent break left \`cleanedHCL\` referencing un-imported deps. \`FilterImportBlocks\` would strip the orphaned import entries and validate would pass against the half-imported config; apply would fail.
- **runner.go:332** (drift fix) — silent break reported \`ValidationOK=true\` against HCL with un-fixed drift. The customer's NEXT plan would show drift, and the design doc's "drift is a bug, not a limitation" contract couldn't hold.

Both now return wrapped errors that name the failing phase. With #1 in place, \`PlanGenerateConfig\` only returns non-nil when the file was NOT written (real terraform failure), so escalating those is the right call — the Lambda-style validation gap is no longer in the error path.

### 3. \`FixDriftFromPlan\` covers replace actions [P1]

The drift-fix pass added \`ignore_changes\` only for resources whose plan showed \`action="update"\`. Resources whose plan showed \`replace\` (\`{delete,create}\` or \`{create,delete}\`) — terraform's encoding for "this attribute can't be modified in place" — slipped through silently. For an imported resource, replace usually means "your config diverged from cloud reality" and the right cleanup is the same as update: add the drifting attribute to \`ignore_changes\`.

Fix: \`isDriftAction(actions)\` helper covers both update and replace shapes.

## Tests

- **\`TestClassifyPlanGenerateConfigError\`** — 4 cases pinning every branch of the swallow-or-propagate matrix; asserts the warn fires only on the swallow path and the warn message contains the underlying plan error.
- **\`TestClassifyPlanGenerateConfigError_NilLoggerSafe\`** — guard against panic on a nil logger from a future caller bypassing the constructor.
- **\`TestRunner_DepChasePlanError_Escalates\`** — fixture forces dep-chase iteration; second \`PlanGenerateConfig\` fails; asserts \`Run\` returns an error naming the dep-chase phase.
- **\`TestRunner_DriftFixPlanError_Escalates\`** — injects a \`PlanJSON\` failure; asserts \`Run\` returns an error naming the drift-fix phase.
- **\`TestFixDriftFromPlan_ReplaceAction\`** — parameterized over \`{delete,create}\` and \`{create,delete}\`; verifies the resource gets a \`lifecycle\` block with \`ignore_changes\` containing the drifting attr.
- **\`TestIsDriftAction\`** — unit pin covering create-only / delete-only / no-op / empty as negatives.

## Out of scope (tracked elsewhere)

- **#186** — Phase-2 carrier emitter (\`DiscoveredResource → imported.ImportedResource\`). Flagged as P0 in the QA review but can't land in this stacked PR — \`pkg/composer/imported\` doesn't exist on PR #58's branch. Will land cleanly after #58 merges to main.
- Retry/backoff/rate-limiting in AWS discovery, asymmetric tag-error policy, \`FilterImportBlocks\` warn-on-drop, and the "0 changes plan" CI gate — separate workstreams; tracked in the QA review thread.

## Review trail

- qa-professor review on PR #58 surfaced 10+ P0/P1 findings (the full review is in the parent PR's discussion).
- This stacked PR addresses the four highest-impact fixes that don't require Phase 2 carrier types.
- The remaining findings have tracking issues or are out of scope per the bullet above.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` passes (full suite, all new tests)
- [x] \`gofmt -l\` clean on modified files
- [ ] CI checks pass (workflow only triggers on PRs into \`main\`; this PR targets PR #58's branch — local signals above are the gate)

## Closes / refs

- Refs PR #58
- Refs #186 (follow-up after #58 merges)