### PR TITLE
fix(insideout-import): symmetric tag-error policy + escalate dropped imports (review #58)

### DIFF
--- a/internal/cleanup/filterimports.go
+++ b/internal/cleanup/filterimports.go
@@ -1,6 +1,8 @@
 package cleanup
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -12,17 +14,25 @@ import (
 //
 // Returns:
 //   - filtered: the imports HCL with un-importable blocks removed.
-//   - dropped: the list of "to" addresses that were filtered out. Callers
-//     should surface this list at Warn so the operator sees that the tool
-//     dropped imports — silently dropping them produces a stack that
-//     references resources outside its own state, validates clean, but
-//     fails on apply (issue #58 review).
+//   - dropped: well-formed "to" addresses that were filtered because the
+//     generated HCL didn't declare a matching resource (e.g. cross-account
+//     IAM roles, denied IAM, depth-limited chase). Callers must surface
+//     these — silently dropping produces a stack that references resources
+//     outside its own state, validates clean, but fails on apply (issue
+//     #58 review).
+//   - malformed: import blocks whose `to` attribute couldn't be parsed
+//     into a resource address. These are anomalies (parse failure, missing
+//     `to`, exotic traversal shape) — distinct from `dropped` which is the
+//     legitimate "dep chase missed the target" case. Tracked separately so
+//     a regression in extractTraversalAddress doesn't masquerade as a
+//     dep-chase miss. The slice contains a stable token-shape descriptor
+//     for diagnostic logging; see filterimports.go for the encoding.
 //   - err: HCL parse errors.
-func FilterImportBlocks(importsSrc, generatedSrc []byte) (filtered []byte, dropped []string, err error) {
+func FilterImportBlocks(importsSrc, generatedSrc []byte) (filtered []byte, dropped, malformed []string, err error) {
 	// Parse generated HCL to find declared resource addresses
 	genFile, diags := hclwrite.ParseConfig(generatedSrc, "generated.tf", hcl.Pos{})
 	if diags.HasErrors() {
-		return nil, nil, diags
+		return nil, nil, nil, diags
 	}
 
 	declared := make(map[string]bool)
@@ -38,24 +48,26 @@ func FilterImportBlocks(importsSrc, generatedSrc []byte) (filtered []byte, dropp
 	// Parse import blocks and keep only those with declared targets
 	impFile, diags := hclwrite.ParseConfig(importsSrc, "imports.tf", hcl.Pos{})
 	if diags.HasErrors() {
-		return nil, nil, diags
+		return nil, nil, nil, diags
 	}
 
 	outFile := hclwrite.NewEmptyFile()
 	outBody := outFile.Body()
 
-	for _, block := range impFile.Body().Blocks() {
+	for i, block := range impFile.Body().Blocks() {
 		if block.Type() != "import" {
 			continue
 		}
 		toAttr := block.Body().GetAttribute("to")
 		if toAttr == nil {
+			malformed = append(malformed, fmt.Sprintf("import[%d]: no `to` attribute", i))
 			continue
 		}
 
 		// Extract the traversal target (e.g., "aws_sqs_queue.my_queue")
 		target := extractTraversalAddress(toAttr.Expr().BuildTokens(nil))
 		if target == "" {
+			malformed = append(malformed, fmt.Sprintf("import[%d]: unparseable `to` traversal", i))
 			continue
 		}
 		if !declared[target] {
@@ -71,7 +83,7 @@ func FilterImportBlocks(importsSrc, generatedSrc []byte) (filtered []byte, dropp
 		outBody.AppendNewline()
 	}
 
-	return outFile.Bytes(), dropped, nil
+	return outFile.Bytes(), dropped, malformed, nil
 }
 
 // extractTraversalAddress extracts a resource address like "aws_sqs_queue.name"

--- a/internal/cleanup/filterimports.go
+++ b/internal/cleanup/filterimports.go
@@ -9,11 +9,20 @@ import (
 // FilterImportBlocks removes import blocks whose target resource doesn't exist
 // in the generated HCL. This prevents "Configuration for import target does
 // not exist" errors when a dependency chase fails to import a resource.
-func FilterImportBlocks(importsSrc, generatedSrc []byte) ([]byte, error) {
+//
+// Returns:
+//   - filtered: the imports HCL with un-importable blocks removed.
+//   - dropped: the list of "to" addresses that were filtered out. Callers
+//     should surface this list at Warn so the operator sees that the tool
+//     dropped imports — silently dropping them produces a stack that
+//     references resources outside its own state, validates clean, but
+//     fails on apply (issue #58 review).
+//   - err: HCL parse errors.
+func FilterImportBlocks(importsSrc, generatedSrc []byte) (filtered []byte, dropped []string, err error) {
 	// Parse generated HCL to find declared resource addresses
 	genFile, diags := hclwrite.ParseConfig(generatedSrc, "generated.tf", hcl.Pos{})
 	if diags.HasErrors() {
-		return nil, diags
+		return nil, nil, diags
 	}
 
 	declared := make(map[string]bool)
@@ -29,7 +38,7 @@ func FilterImportBlocks(importsSrc, generatedSrc []byte) ([]byte, error) {
 	// Parse import blocks and keep only those with declared targets
 	impFile, diags := hclwrite.ParseConfig(importsSrc, "imports.tf", hcl.Pos{})
 	if diags.HasErrors() {
-		return nil, diags
+		return nil, nil, diags
 	}
 
 	outFile := hclwrite.NewEmptyFile()
@@ -46,7 +55,11 @@ func FilterImportBlocks(importsSrc, generatedSrc []byte) ([]byte, error) {
 
 		// Extract the traversal target (e.g., "aws_sqs_queue.my_queue")
 		target := extractTraversalAddress(toAttr.Expr().BuildTokens(nil))
-		if target == "" || !declared[target] {
+		if target == "" {
+			continue
+		}
+		if !declared[target] {
+			dropped = append(dropped, target)
 			continue
 		}
 
@@ -58,7 +71,7 @@ func FilterImportBlocks(importsSrc, generatedSrc []byte) ([]byte, error) {
 		outBody.AppendNewline()
 	}
 
-	return outFile.Bytes(), nil
+	return outFile.Bytes(), dropped, nil
 }
 
 // extractTraversalAddress extracts a resource address like "aws_sqs_queue.name"

--- a/internal/cleanup/filterimports_test.go
+++ b/internal/cleanup/filterimports_test.go
@@ -1,0 +1,104 @@
+package cleanup
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFilterImportBlocks_DroppedList pins the dropped-targets contract.
+// FilterImportBlocks now returns the list of "to" addresses that were
+// filtered out so the runner can surface them at Warn. Before this
+// change, un-importable references were silently dropped and the
+// consuming HCL still referenced them as literal ARNs — terraform
+// validate passed against a stack that referenced resources outside
+// its own state, and apply failed at runtime (issue #58 review).
+func TestFilterImportBlocks_DroppedList(t *testing.T) {
+	cases := []struct {
+		name        string
+		imports     string
+		generated   string
+		wantKept    []string
+		wantDropped []string
+	}{
+		{
+			name: "all imports have matching resources",
+			imports: `
+import {
+  to = aws_sqs_queue.q
+  id = "https://sqs.us-east-1.amazonaws.com/123/q"
+}
+`,
+			generated: `
+resource "aws_sqs_queue" "q" {
+  name = "q"
+}
+`,
+			wantKept:    []string{"aws_sqs_queue.q"},
+			wantDropped: nil,
+		},
+		{
+			name: "import without matching resource is dropped and reported",
+			imports: `
+import {
+  to = aws_sqs_queue.kept
+  id = "kept-id"
+}
+import {
+  to = aws_iam_role.missing
+  id = "arn:aws:iam::123:role/missing"
+}
+`,
+			generated: `
+resource "aws_sqs_queue" "kept" {
+  name = "kept"
+}
+`,
+			wantKept:    []string{"aws_sqs_queue.kept"},
+			wantDropped: []string{"aws_iam_role.missing"},
+		},
+		{
+			name: "every import dropped (worst case for silent-failure bug)",
+			imports: `
+import {
+  to = aws_iam_role.cross_account
+  id = "arn:aws:iam::999:role/cross-account"
+}
+`,
+			generated: `
+resource "aws_sqs_queue" "q" {
+  name = "q"
+}
+`,
+			wantKept:    nil,
+			wantDropped: []string{"aws_iam_role.cross_account"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			filtered, dropped, err := FilterImportBlocks([]byte(tc.imports), []byte(tc.generated))
+			if err != nil {
+				t.Fatalf("FilterImportBlocks error: %v", err)
+			}
+			gotKept := []string{}
+			for _, addr := range tc.wantKept {
+				if !strings.Contains(string(filtered), "to = "+addr) {
+					t.Errorf("expected filtered output to keep %q; got\n%s", addr, filtered)
+				}
+				gotKept = append(gotKept, addr)
+			}
+			for _, addr := range tc.wantDropped {
+				if strings.Contains(string(filtered), "to = "+addr) {
+					t.Errorf("expected filtered output to NOT contain dropped target %q; got\n%s", addr, filtered)
+				}
+			}
+			if len(dropped) != len(tc.wantDropped) {
+				t.Fatalf("dropped len = %d, want %d (got %v)", len(dropped), len(tc.wantDropped), dropped)
+			}
+			for i, want := range tc.wantDropped {
+				if dropped[i] != want {
+					t.Errorf("dropped[%d] = %q, want %q", i, dropped[i], want)
+				}
+			}
+		})
+	}
+}

--- a/internal/cleanup/filterimports_test.go
+++ b/internal/cleanup/filterimports_test.go
@@ -1,24 +1,30 @@
 package cleanup
 
 import (
-	"strings"
+	"sort"
 	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
-// TestFilterImportBlocks_DroppedList pins the dropped-targets contract.
-// FilterImportBlocks now returns the list of "to" addresses that were
-// filtered out so the runner can surface them at Warn. Before this
-// change, un-importable references were silently dropped and the
-// consuming HCL still referenced them as literal ARNs — terraform
-// validate passed against a stack that referenced resources outside
-// its own state, and apply failed at runtime (issue #58 review).
-func TestFilterImportBlocks_DroppedList(t *testing.T) {
+// TestFilterImportBlocks_DroppedAndMalformed pins the three-bucket
+// contract: kept imports, dropped well-formed targets, and malformed
+// blocks. Pre-#58-review FilterImportBlocks silently dropped both kinds
+// and the runner reported success against incomplete HCL — terraform
+// validate would pass but apply would fail at runtime when the unresolved
+// reference hit the provider.
+//
+// Test parses the filtered HCL with hclwrite (rather than substring-
+// matching) so future formatting changes from hclwrite don't false-fail.
+func TestFilterImportBlocks_DroppedAndMalformed(t *testing.T) {
 	cases := []struct {
-		name        string
-		imports     string
-		generated   string
-		wantKept    []string
-		wantDropped []string
+		name          string
+		imports       string
+		generated     string
+		wantKept      []string
+		wantDropped   []string
+		wantMalformed int
 	}{
 		{
 			name: "all imports have matching resources",
@@ -72,33 +78,93 @@ resource "aws_sqs_queue" "q" {
 			wantKept:    nil,
 			wantDropped: []string{"aws_iam_role.cross_account"},
 		},
+		{
+			name: "import with missing `to` is malformed, not dropped",
+			imports: `
+import {
+  id = "no-target"
+}
+import {
+  to = aws_sqs_queue.kept
+  id = "kept-id"
+}
+`,
+			generated: `
+resource "aws_sqs_queue" "kept" {
+  name = "kept"
+}
+`,
+			wantKept:      []string{"aws_sqs_queue.kept"},
+			wantMalformed: 1,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			filtered, dropped, err := FilterImportBlocks([]byte(tc.imports), []byte(tc.generated))
+			filtered, dropped, malformed, err := FilterImportBlocks([]byte(tc.imports), []byte(tc.generated))
 			if err != nil {
 				t.Fatalf("FilterImportBlocks error: %v", err)
 			}
-			gotKept := []string{}
-			for _, addr := range tc.wantKept {
-				if !strings.Contains(string(filtered), "to = "+addr) {
-					t.Errorf("expected filtered output to keep %q; got\n%s", addr, filtered)
-				}
-				gotKept = append(gotKept, addr)
+
+			gotKept := parseImportTargets(t, filtered)
+			sortStrings(gotKept)
+			sortStrings(tc.wantKept)
+			if !equalStrings(gotKept, tc.wantKept) {
+				t.Errorf("filtered kept = %v, want %v", gotKept, tc.wantKept)
 			}
-			for _, addr := range tc.wantDropped {
-				if strings.Contains(string(filtered), "to = "+addr) {
-					t.Errorf("expected filtered output to NOT contain dropped target %q; got\n%s", addr, filtered)
-				}
+
+			sortStrings(dropped)
+			sortStrings(tc.wantDropped)
+			if !equalStrings(dropped, tc.wantDropped) {
+				t.Errorf("dropped = %v, want %v", dropped, tc.wantDropped)
 			}
-			if len(dropped) != len(tc.wantDropped) {
-				t.Fatalf("dropped len = %d, want %d (got %v)", len(dropped), len(tc.wantDropped), dropped)
-			}
-			for i, want := range tc.wantDropped {
-				if dropped[i] != want {
-					t.Errorf("dropped[%d] = %q, want %q", i, dropped[i], want)
-				}
+
+			if len(malformed) != tc.wantMalformed {
+				t.Errorf("malformed len = %d, want %d (got %v)", len(malformed), tc.wantMalformed, malformed)
 			}
 		})
 	}
+}
+
+// parseImportTargets returns the `to` addresses from an imports.tf body,
+// using hclwrite + the production extractTraversalAddress helper. The
+// test deliberately reuses the same helper the production code uses so
+// a regression there fails BOTH the production behavior and the test —
+// not just the test's substring expectation.
+func parseImportTargets(t *testing.T, src []byte) []string {
+	t.Helper()
+	if len(src) == 0 {
+		return nil
+	}
+	f, diags := hclwrite.ParseConfig(src, "filtered.tf", hcl.Pos{})
+	if diags.HasErrors() {
+		t.Fatalf("parse filtered HCL: %v", diags)
+	}
+	var out []string
+	for _, block := range f.Body().Blocks() {
+		if block.Type() != "import" {
+			continue
+		}
+		toAttr := block.Body().GetAttribute("to")
+		if toAttr == nil {
+			continue
+		}
+		if addr := extractTraversalAddress(toAttr.Expr().BuildTokens(nil)); addr != "" {
+			out = append(out, addr)
+		}
+	}
+	return out
+}
+
+func sortStrings(s []string) { sort.Strings(s) }
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/cleanup/validate_test.go
+++ b/internal/cleanup/validate_test.go
@@ -236,12 +236,15 @@ import {
   id = "missing-role"
 }
 `
-	filtered, dropped, err := FilterImportBlocks([]byte(imports), []byte(generated))
+	filtered, dropped, malformed, err := FilterImportBlocks([]byte(imports), []byte(generated))
 	if err != nil {
 		t.Fatalf("FilterImportBlocks error: %v", err)
 	}
 	if len(dropped) != 1 || dropped[0] != "aws_iam_role.missing_role" {
 		t.Errorf("expected dropped=[aws_iam_role.missing_role], got %v", dropped)
+	}
+	if len(malformed) != 0 {
+		t.Errorf("expected no malformed imports, got %v", malformed)
 	}
 
 	// Write both to a dir and validate

--- a/internal/cleanup/validate_test.go
+++ b/internal/cleanup/validate_test.go
@@ -236,9 +236,12 @@ import {
   id = "missing-role"
 }
 `
-	filtered, err := FilterImportBlocks([]byte(imports), []byte(generated))
+	filtered, dropped, err := FilterImportBlocks([]byte(imports), []byte(generated))
 	if err != nil {
 		t.Fatalf("FilterImportBlocks error: %v", err)
+	}
+	if len(dropped) != 1 || dropped[0] != "aws_iam_role.missing_role" {
+		t.Errorf("expected dropped=[aws_iam_role.missing_role], got %v", dropped)
 	}
 
 	// Write both to a dir and validate

--- a/internal/discovery/cloudwatchlogs.go
+++ b/internal/discovery/cloudwatchlogs.go
@@ -62,15 +62,18 @@ func (d *CloudWatchLogsDiscoverer) Discover(ctx context.Context, filter Filter) 
 					ResourceArn: aws.String(arn),
 				})
 				if err != nil {
-					// Match the Lambda / SQS / DynamoDB / SecretsManager
-					// policy: tag-fetch errors abort discovery (issue #58
-					// review). The previous behavior swallowed the error
-					// and treated the resource as untagged, which (a)
-					// silently dropped resources from --tags filtering
-					// and (b) emitted a misleading "no tags" report for
-					// resources whose tags were inaccessible. Both
-					// outcomes are wrong for a security-relevant tool;
-					// fail-loud is the symmetric policy.
+					// Match the Lambda / SQS / DynamoDB policy: tag-fetch
+					// errors abort discovery (issue #58 review).
+					// SecretsManager has no separate tag call — its tags
+					// are inline in ListSecrets — so it has no tag-step
+					// to fail-loud on. The previous CWL behavior
+					// swallowed the error and treated the resource as
+					// untagged, which (a) silently dropped resources
+					// from --tags filtering and (b) emitted a misleading
+					// "no tags" report for resources whose tags were
+					// inaccessible. Both outcomes are wrong for a
+					// security-relevant tool; fail-loud is the symmetric
+					// policy.
 					return nil, fmt.Errorf("cloudwatchlogs list tags for %s: %w", name, err)
 				}
 

--- a/internal/discovery/cloudwatchlogs.go
+++ b/internal/discovery/cloudwatchlogs.go
@@ -62,10 +62,16 @@ func (d *CloudWatchLogsDiscoverer) Discover(ctx context.Context, filter Filter) 
 					ResourceArn: aws.String(arn),
 				})
 				if err != nil {
-					// ListTagsForResource requires a proper ARN. If the ARN is malformed
-					// or the API returns an access error, return empty tags rather than
-					// blocking discovery entirely. Tags are used for optional filtering only.
-					tags = &cloudwatchlogs.ListTagsForResourceOutput{}
+					// Match the Lambda / SQS / DynamoDB / SecretsManager
+					// policy: tag-fetch errors abort discovery (issue #58
+					// review). The previous behavior swallowed the error
+					// and treated the resource as untagged, which (a)
+					// silently dropped resources from --tags filtering
+					// and (b) emitted a misleading "no tags" report for
+					// resources whose tags were inaccessible. Both
+					// outcomes are wrong for a security-relevant tool;
+					// fail-loud is the symmetric policy.
+					return nil, fmt.Errorf("cloudwatchlogs list tags for %s: %w", name, err)
 				}
 
 				if len(filter.Tags) > 0 && !MatchesTags(tags.Tags, filter.Tags) {

--- a/internal/discovery/cloudwatchlogs_test.go
+++ b/internal/discovery/cloudwatchlogs_test.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -118,26 +119,33 @@ func TestCloudWatchLogsDiscoverer_Deduplication(t *testing.T) {
 	}
 }
 
-func TestCloudWatchLogsDiscoverer_TagErrorGraceful(t *testing.T) {
+// TestCloudWatchLogsDiscoverer_TagErrorFailsLoud pins the symmetric tag-
+// error policy. Pre-#58-review CWL silently swallowed ListTagsForResource
+// errors and emitted the resource with empty tags — which (a) silently
+// dropped resources from --tags filtering and (b) emitted a misleading
+// "no tags" report for resources whose tags were inaccessible. Both
+// outcomes are wrong for a security-relevant tool. Lambda / SQS /
+// DynamoDB / SecretsManager already failed-loud on tag errors; CWL now
+// matches them.
+func TestCloudWatchLogsDiscoverer_TagErrorFailsLoud(t *testing.T) {
 	mock := &mockCWL{
 		describeLogGroupsPages: map[string][]cloudwatchlogs.DescribeLogGroupsOutput{
 			"/my-project": {
 				{LogGroups: []cwltypes.LogGroup{
-					{LogGroupName: aws.String("/my-project-logs"), Arn: aws.String("arn:invalid")},
+					{LogGroupName: aws.String("/my-project-logs"), Arn: aws.String("arn:aws:logs:us-east-1:123456789012:log-group:/my-project-logs")},
 				}},
 			},
 			"/aws/lambda/my-project": {},
 		},
-		// Tag listing fails — should not block discovery
 		listTagsErr: fmt.Errorf("access denied"),
 	}
 
 	d := &CloudWatchLogsDiscoverer{client: mock}
-	resources, err := d.Discover(context.Background(), Filter{Project: "my-project"})
-	if err != nil {
-		t.Fatalf("Discover() should not fail when tag listing fails: %v", err)
+	_, err := d.Discover(context.Background(), Filter{Project: "my-project"})
+	if err == nil {
+		t.Fatal("Discover() must fail loud on tag-listing error (symmetric with Lambda / SQS / DynamoDB / SecretsManager)")
 	}
-	if len(resources) != 1 {
-		t.Errorf("expected 1 resource even with tag errors, got %d", len(resources))
+	if !strings.Contains(err.Error(), "list tags for /my-project-logs") {
+		t.Errorf("error must name the log group whose tags failed; got %v", err)
 	}
 }

--- a/internal/discovery/cloudwatchlogs_test.go
+++ b/internal/discovery/cloudwatchlogs_test.go
@@ -125,8 +125,9 @@ func TestCloudWatchLogsDiscoverer_Deduplication(t *testing.T) {
 // dropped resources from --tags filtering and (b) emitted a misleading
 // "no tags" report for resources whose tags were inaccessible. Both
 // outcomes are wrong for a security-relevant tool. Lambda / SQS /
-// DynamoDB / SecretsManager already failed-loud on tag errors; CWL now
-// matches them.
+// DynamoDB already failed-loud on tag errors; CWL now matches them.
+// (SecretsManager has no separate tag call — tags are inline in
+// ListSecrets — so it has no tag-step to fail-loud on.)
 func TestCloudWatchLogsDiscoverer_TagErrorFailsLoud(t *testing.T) {
 	mock := &mockCWL{
 		describeLogGroupsPages: map[string][]cloudwatchlogs.DescribeLogGroupsOutput{

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -289,9 +289,22 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read merged imports: %w", err)
 	}
-	filteredImports, err := cleanup.FilterImportBlocks(mergedImports, cleanedHCL)
+	filteredImports, droppedImports, err := cleanup.FilterImportBlocks(mergedImports, cleanedHCL)
 	if err != nil {
 		return nil, fmt.Errorf("filter import blocks: %w", err)
+	}
+	// Surface dropped import targets at Warn so the operator sees that
+	// the tool removed un-importable references (e.g. cross-account IAM
+	// roles that the dep chaser couldn't resolve). Pre-#58-review these
+	// were silently filtered and the consuming HCL still referenced
+	// them as literal ARNs — terraform validate passed against a stack
+	// that referenced resources outside its own state, and apply failed
+	// at runtime.
+	for _, target := range droppedImports {
+		r.logger.Warn(
+			"dropped un-importable reference; consuming HCL still references it as a literal value and may fail at terraform apply (issue #58 review)",
+			"target", target,
+		)
 	}
 	if err := os.WriteFile(importsPath, filteredImports, 0644); err != nil {
 		return nil, fmt.Errorf("write filtered imports: %w", err)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -34,6 +34,23 @@ type Result struct {
 	GeneratedFiles  []string
 	ValidationOK    bool
 	Errors          []error
+
+	// DroppedImports lists the Terraform addresses (e.g. "aws_iam_role.x")
+	// whose import blocks were filtered out because the dependency chase
+	// couldn't generate a matching resource block (e.g. cross-account IAM
+	// roles, denied IAM permissions, depth-limited chase). The consuming
+	// HCL still references these as literal ARNs, so terraform plan/apply
+	// will fail at runtime. Surfaced in Result so callers / CI can fail
+	// loud rather than relying on log scraping (issue #58 review).
+	DroppedImports []string
+
+	// MalformedImports lists import blocks whose `to` attribute couldn't
+	// be parsed into a resource address. These are anomalies (parse
+	// failures, malformed HCL) — distinct from DroppedImports which are
+	// well-formed but missing a target. Tracked separately so a regression
+	// in extractTraversalAddress doesn't masquerade as "dep chase did its
+	// job and dropped some references."
+	MalformedImports []string
 }
 
 // resourceDiscoverer abstracts AWS resource discovery for testing.
@@ -289,21 +306,40 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read merged imports: %w", err)
 	}
-	filteredImports, droppedImports, err := cleanup.FilterImportBlocks(mergedImports, cleanedHCL)
+	filteredImports, droppedImports, malformedImports, err := cleanup.FilterImportBlocks(mergedImports, cleanedHCL)
 	if err != nil {
 		return nil, fmt.Errorf("filter import blocks: %w", err)
 	}
-	// Surface dropped import targets at Warn so the operator sees that
-	// the tool removed un-importable references (e.g. cross-account IAM
-	// roles that the dep chaser couldn't resolve). Pre-#58-review these
-	// were silently filtered and the consuming HCL still referenced
-	// them as literal ARNs — terraform validate passed against a stack
-	// that referenced resources outside its own state, and apply failed
-	// at runtime.
+	result.DroppedImports = droppedImports
+	result.MalformedImports = malformedImports
+
+	// Surface dropped imports at Warn with cause classes + remediation so
+	// an operator at 2am has a starting point. Common causes for a
+	// well-formed import target that's missing from the generated HCL:
+	//
+	//   - The target is in another AWS account (dep chase can't reach it).
+	//   - IAM denies the permission needed to import (terraform plan
+	//     -generate-config-out gave up on it).
+	//   - The dep chase ran out of iterations before reaching the target.
+	//
+	// Remediation: re-run with broader IAM, mark the target as expected-
+	// external in your stack docs, or accept the warning if the literal
+	// ARN reference is intentional (e.g. a customer-owned KMS key shared
+	// with this account). Run is escalated to an error at the end of
+	// Run() because the resulting HCL won't satisfy the "0 changes plan"
+	// contract — see end of Run().
 	for _, target := range droppedImports {
 		r.logger.Warn(
-			"dropped un-importable reference; consuming HCL still references it as a literal value and may fail at terraform apply (issue #58 review)",
+			"dropped un-importable reference; the consuming HCL still references it as a literal value, so terraform apply may fail at runtime (issue #58 review)",
 			"target", target,
+			"likely_causes", "cross-account resource | denied IAM permission | dep chase depth limit",
+			"remediation", "broaden IAM, accept the literal reference if intentional, or extend dep chase depth",
+		)
+	}
+	for _, anomaly := range malformedImports {
+		r.logger.Warn(
+			"malformed import block in generated imports.tf; this is a parse-level anomaly, not a dep-chase miss — likely a regression in extractTraversalAddress",
+			"detail", anomaly,
 		)
 	}
 	if err := os.WriteFile(importsPath, filteredImports, 0644); err != nil {
@@ -406,6 +442,18 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 		filepath.Join(r.config.OutputDir, "providers.tf"),
 		filepath.Join(r.config.OutputDir, "imports.tf"),
 		filepath.Join(r.config.OutputDir, "generated.tf"),
+	}
+
+	// Escalate dropped or malformed imports to a non-zero exit. The Warn
+	// logs above carry the actionable detail; this gate ensures CI / shell
+	// scripts wrapping the CLI see a non-zero status code rather than
+	// having to scrape logs. The "0 changes plan" contract from the design
+	// doc cannot hold when imports were filtered out — the consuming HCL
+	// still references those targets as literal values and apply fails
+	// at runtime (issue #58 review).
+	if len(result.DroppedImports) > 0 || len(result.MalformedImports) > 0 {
+		return result, fmt.Errorf("import generation produced an incomplete stack: %d dropped reference(s), %d malformed import block(s); see Warn logs for details and remediation",
+			len(result.DroppedImports), len(result.MalformedImports))
 	}
 
 	return result, nil

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -514,3 +514,75 @@ resource "aws_sqs_queue" "q" {
 		t.Errorf("error must name the failing phase; got %v", err)
 	}
 }
+
+// TestRunner_DroppedImports_Escalates pins the issue #58 review fix:
+// when FilterImportBlocks drops un-importable references (e.g. cross-
+// account IAM roles the dep chaser can't reach), the runner must escalate
+// to a non-zero exit AND surface the dropped list in the Result. Pre-fix
+// the runner returned ValidationOK=true silently while the consuming HCL
+// still referenced the un-importable target as a literal ARN — terraform
+// validate would pass and apply would fail at runtime.
+//
+// The fixture: an iteration-1 HCL that references an IAM role ARN.
+// Discovery only knows about the SQS queue, so the dep chase generates
+// import blocks for the role but never produces a matching resource
+// (we don't extend planErrAtCall — the dep-chase plan succeeds with no
+// new resources, and FilterImportBlocks then has an orphan import).
+func TestRunner_DroppedImports_Escalates(t *testing.T) {
+	// iteration1 declares a Lambda referencing an IAM role.
+	iteration1HCL := `# __generated__ by Terraform
+resource "aws_lambda_function" "fn" {
+  function_name = "my-project-fn"
+  role          = "arn:aws:iam::123456789012:role/my-project-lambda-exec"
+  runtime       = "nodejs20.x"
+  handler       = "index.handler"
+}
+`
+	// iteration2 (the dep-chase pass) returns the SAME body — no new
+	// resource for the IAM role. The dep chaser will still emit an
+	// import block for the role; FilterImportBlocks drops it because
+	// no resource matches.
+	iteration2HCL := iteration1HCL
+
+	mock := &mockTF{
+		generatedPages: []string{iteration1HCL, iteration2HCL},
+	}
+	r := New(Config{
+		Project:   "my-project",
+		Region:    "us-east-1",
+		OutputDir: filepath.Join(t.TempDir(), "output"),
+	}, testLogger())
+	r.discoverer = &mockDiscoverer{
+		resources: []discovery.DiscoveredResource{{
+			TerraformType: "aws_lambda_function",
+			ImportID:      "my-project-fn",
+			Name:          "my-project-fn",
+		}},
+	}
+	r.tfRunner = mock
+
+	result, err := r.Run(context.Background())
+	if err == nil {
+		t.Fatal("dropped imports must escalate to a non-zero exit (issue #58 review)")
+	}
+	if !strings.Contains(err.Error(), "incomplete stack") {
+		t.Errorf("error must name the incomplete-stack contract; got %v", err)
+	}
+	if result == nil {
+		t.Fatal("Result must be returned even when escalating so callers see the dropped list")
+	}
+	if len(result.DroppedImports) == 0 {
+		t.Errorf("Result.DroppedImports must list the un-importable targets; got %v", result.DroppedImports)
+	}
+	// The IAM role is the realistic target the dep chase can't import.
+	found := false
+	for _, addr := range result.DroppedImports {
+		if strings.HasPrefix(addr, "aws_iam_role.") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected an aws_iam_role.* in DroppedImports, got %v", result.DroppedImports)
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on **PR #58** (\`feature/insideout-import-phase1\`). Two surgical P1 fixes from the qa-professor review of #58, plus a follow-up round addressing the QA review of this PR. Targets PR #58's branch directly so the fixes land **with** PR #58 when the maintainer merges.

Same theme as #187: \"no silent state.\" Two related changes:

### 1. Symmetric tag-error policy across discoverers [P1]

CloudWatchLogs swallowed \`ListTagsForResource\` errors and emitted the resource with empty tags. Lambda / SQS / DynamoDB all fail-loud (SecretsManager has no separate tag call — its tags are inline). The asymmetry produced two real bugs:

1. **With \`--tags\` filtering**: a resource whose tags couldn't be fetched silently dropped from the output, giving a false-negative on tag-based scoping.
2. **Without \`--tags\` filtering**: the resource emitted with empty tags, giving a misleading "no tags" report when tags were just inaccessible.

CWL now matches its siblings: tag-fetch errors abort discovery with a wrapped error that names the failing log group.

### 2. \`FilterImportBlocks\` escalates dropped + tracks malformed [P1]

\`FilterImportBlocks\` silently dropped import blocks whose target resource didn't exist in the generated HCL. The cited rationale was real ("prevents 'Configuration for import target does not exist' errors"), but silent drops produced a stack where:

- The consuming HCL still referenced the un-importable target as a literal ARN.
- \`imports.tf\` no longer had the corresponding import block.
- \`terraform validate\` passed.
- \`terraform apply\` failed at runtime.

Fix:

- \`FilterImportBlocks\` returns \`(filtered, dropped, malformed, err)\`. \`dropped\` is well-formed targets the dep chase missed; \`malformed\` is parse-level anomalies (missing \`to\` attr, unparseable traversal). Tracked separately so a regression in extractTraversalAddress doesn't masquerade as "dep chase did its job."
- \`Result\` gains \`DroppedImports\` and \`MalformedImports\` so callers / CI see them programmatically.
- The runner Warn-logs each entry at the time of filtering (with cause classes + remediation), then **escalates** to a wrapped error at the end of \`Run()\` if either list is non-empty. Wrappers and CI scripts now see a non-zero exit instead of having to log-scrape.
- HCL behavior unchanged.

## QA-pass-2 fixes (commit \`ee89c5e\`)

A second qa-professor review on the first version of this PR caught:

- **[P1]** Warn-only was "logged into the void" — runner now escalates.
- **[P2]** Malformed \`to\` was lumped in with dropped targets — now tracked separately.
- **[P2]** SecretsManager symmetry claim was wrong (no separate tag call) — corrected in code comments and PR body.
- **[P2]** Test used substring matching against \`hclwrite\` output — now parses HCL with the production helper.
- **[P2]** Warn message lacked actionability — added cause classes + remediation steps.

## Tests

- **\`TestCloudWatchLogsDiscoverer_TagErrorFailsLoud\`** — asserts the new contract and that the error wraps the log group name.
- **\`TestFilterImportBlocks_DroppedAndMalformed\`** — table-driven over four cases (kept-only, partial drop, full drop, malformed). Asserts via HCL re-parse, not substring matching.
- **\`TestValidate_FilteredImports\`** — extended to assert dropped and malformed lists.
- **\`TestRunner_DroppedImports_Escalates\`** — pins the new escalation contract end-to-end: Run() returns a wrapped error AND populates \`Result.DroppedImports\`.

## Out of scope (still tracked)

- AWS SDK retries / backoff / bounded concurrency (P1 in the QA review) — substantial, separate PR.
- "0 changes plan" CI gate (P0) — needs localstack / Cloud Asset emulator, separate workstream.
- Carrier emitter (**#186**) — blocked on PR #58 merging to main.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` passes (full suite, all new tests)
- [x] \`gofmt -l\` clean on modified files
- [x] qa-professor review run twice (caught the warn-only-too-soft P1 → escalation; SecretsManager symmetry P2; substring-match P2; etc.)
- [ ] CI checks pass (workflow only triggers on PRs into \`main\`; this PR targets PR #58's branch — local signals above are the gate)

## Closes / refs

- Refs PR #58
- Refs #186 (follow-up after #58 merges)