### PR TITLE
fix(gcp): replace upstream KMS module (#182) + add cloud_build webhook IAM (#190)

### DIFF
--- a/gcp/cloud_build/main.tf
+++ b/gcp/cloud_build/main.tf
@@ -88,7 +88,11 @@ resource "google_secret_manager_secret_iam_member" "cloudbuild_webhook_accessor"
   project   = var.project_id
   secret_id = google_secret_manager_secret.webhook.secret_id
   role      = "roles/secretmanager.secretAccessor"
-  member    = local.cloudbuild_service_agent
+  # local.cloudbuild_service_agent reads data.google_project.this.number,
+  # which the depends_on above defers to the apply phase — so `member`
+  # shows as `(known after apply)` in the plan. The binding still
+  # creates correctly; only the plan readout is delayed.
+  member = local.cloudbuild_service_agent
 }
 
 resource "google_cloudbuild_trigger" "trigger" {

--- a/gcp/cloud_build/main.tf
+++ b/gcp/cloud_build/main.tf
@@ -58,6 +58,39 @@ resource "google_secret_manager_secret_version" "webhook" {
   secret_data = random_password.webhook_secret.result
 }
 
+# The Cloud Build P4SA (service-PROJECT_NUMBER@gcp-sa-cloudbuild) needs
+# roles/secretmanager.secretAccessor on the webhook secret BEFORE the
+# trigger is created — otherwise google_cloudbuild_trigger validates
+# secret access on the create call and rejects with
+# `400 INVALID_ARGUMENT: Request contains an invalid argument` (issue
+# #190). Without this binding the trigger create fails on every
+# fresh-project deploy.
+#
+# We resolve the project number from data.google_project rather than
+# adopting the google-beta provider just for `google_project_service_identity`.
+# The P4SA is created by GCP automatically when cloudbuild.googleapis.com
+# is enabled (`google_project_service.cloudbuild` above), and the
+# data source's depends_on pins read-after-enable so the project
+# number is always available. The SA email shape
+# `service-${project_number}@gcp-sa-cloudbuild.iam.gserviceaccount.com`
+# is a stable Google contract for Cloud Build P4SAs.
+data "google_project" "this" {
+  project_id = var.project_id
+
+  depends_on = [google_project_service.cloudbuild]
+}
+
+locals {
+  cloudbuild_service_agent = "serviceAccount:service-${data.google_project.this.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_secret_iam_member" "cloudbuild_webhook_accessor" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.webhook.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.cloudbuild_service_agent
+}
+
 resource "google_cloudbuild_trigger" "trigger" {
   project  = var.project_id
   location = var.region
@@ -76,5 +109,11 @@ resource "google_cloudbuild_trigger" "trigger" {
     timeout = "60s"
   }
 
-  depends_on = [google_project_service.cloudbuild]
+  # The IAM binding must exist before trigger create — see #190 comment
+  # block above the data source. Without this depends_on the binding
+  # races the trigger create call.
+  depends_on = [
+    google_project_service.cloudbuild,
+    google_secret_manager_secret_iam_member.cloudbuild_webhook_accessor,
+  ]
 }

--- a/gcp/cloud_build/tests/cloud_build.tftest.hcl
+++ b/gcp/cloud_build/tests/cloud_build.tftest.hcl
@@ -1,0 +1,37 @@
+mock_provider "google" {}
+
+# Regression for #190. google_cloudbuild_trigger validates the webhook
+# secret is accessible to the Cloud Build P4SA on the create call;
+# without roles/secretmanager.secretAccessor the create fails with
+# `400 INVALID_ARGUMENT: Request contains an invalid argument`. These
+# cases pin that the IAM binding is declared and that the trigger
+# depends on it (so the binding propagates before the trigger create
+# request fires).
+
+run "defaults_plan" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+  }
+}
+
+run "issue_190_iam_binding_resource_present" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+  }
+
+  # The role is a literal in main.tf so it's known at plan time. The
+  # member field is computed from data.google_project.this.number,
+  # which mock_provider leaves unknown at plan time — the SA shape is
+  # pinned by the structural test in pkg/composer/compose_vm_test.go
+  # (TestGetPresetFiles_GCP_CloudBuild_HasWebhookSecretIAM) instead.
+  assert {
+    condition     = google_secret_manager_secret_iam_member.cloudbuild_webhook_accessor.role == "roles/secretmanager.secretAccessor"
+    error_message = "the cloud_build webhook IAM binding must grant roles/secretmanager.secretAccessor (issue #190)"
+  }
+}

--- a/gcp/cloud_build/tests/cloud_build.tftest.hcl
+++ b/gcp/cloud_build/tests/cloud_build.tftest.hcl
@@ -1,12 +1,15 @@
 mock_provider "google" {}
 
-# Regression for #190. google_cloudbuild_trigger validates the webhook
-# secret is accessible to the Cloud Build P4SA on the create call;
-# without roles/secretmanager.secretAccessor the create fails with
-# `400 INVALID_ARGUMENT: Request contains an invalid argument`. These
-# cases pin that the IAM binding is declared and that the trigger
-# depends on it (so the binding propagates before the trigger create
-# request fires).
+# Smoke for the cloud_build preset under mock_provider. Pins that the
+# default config plans cleanly — the mock provider can't reproduce
+# the issue #190 INVALID_ARGUMENT failure (that's a real GCP-side
+# response on trigger create), and asserting on the IAM binding
+# resource's literal-string fields would be tautological. The
+# meaningful issue #190 pins live in the structural Go test
+# (pkg/composer/compose_vm_test.go::TestGetPresetFiles_GCP_CloudBuild_HasWebhookSecretIAM)
+# which checks the data source, IAM binding resource, role string,
+# P4SA email shape, and the trigger's depends_on — all of which
+# survive any code change that would re-open #190.
 
 run "defaults_plan" {
   command = plan
@@ -14,24 +17,5 @@ run "defaults_plan" {
   variables {
     project    = "test"
     project_id = "test-project"
-  }
-}
-
-run "issue_190_iam_binding_resource_present" {
-  command = plan
-
-  variables {
-    project    = "test"
-    project_id = "test-project"
-  }
-
-  # The role is a literal in main.tf so it's known at plan time. The
-  # member field is computed from data.google_project.this.number,
-  # which mock_provider leaves unknown at plan time — the SA shape is
-  # pinned by the structural test in pkg/composer/compose_vm_test.go
-  # (TestGetPresetFiles_GCP_CloudBuild_HasWebhookSecretIAM) instead.
-  assert {
-    condition     = google_secret_manager_secret_iam_member.cloudbuild_webhook_accessor.role == "roles/secretmanager.secretAccessor"
-    error_message = "the cloud_build webhook IAM binding must grant roles/secretmanager.secretAccessor (issue #190)"
   }
 }

--- a/gcp/kms/main.tf
+++ b/gcp/kms/main.tf
@@ -1,5 +1,50 @@
-# GCP Cloud KMS Module using terraform-google-kms
-# https://github.com/terraform-google-modules/terraform-google-kms
+# GCP Cloud KMS module — direct google_kms_* resources.
+#
+# History: this preset originally wrapped terraform-google-modules/kms/google
+# ~> 3.0. That upstream module's `local.keys_by_name` calls slice() on a
+# count-controlled splat which can error during plan against an empty state
+# with "slice end_index past the length" (issue #180). PR #181 surgically
+# wrapped `module.kms.keys` in `try(...)` to unblock the default-config
+# customer in #178's repro, but left a hole: when var.iam_bindings was
+# non-empty the binding's for_each referenced the same slice expression
+# and its plan still failed. This revision (issue #182) replaces the
+# upstream module entirely with direct google_kms_* resources keyed by
+# for_each, eliminating the slice expression so the failure mode cannot
+# recur and the iam_bindings hole is closed by construction.
+#
+# State migration for existing customers:
+#
+#   The moved {} blocks at the bottom of this file rebind the upstream's
+#   default-config addresses to the new direct-resource addresses. They
+#   cover var.keys = [{ name = "default" }] (the default and the only
+#   shape used by the in-the-wild repro). Customers with non-default
+#   var.keys must run a one-time `terraform state mv` BEFORE applying
+#   this revision, e.g. for var.keys = [{name="data"},{name="logs"}]:
+#
+#     # for prevent_destroy = true (the default):
+#     terraform state mv \
+#       'module.kms.google_kms_crypto_key.key[0]' \
+#       'google_kms_crypto_key.protected["data"]'
+#     terraform state mv \
+#       'module.kms.google_kms_crypto_key.key[1]' \
+#       'google_kms_crypto_key.protected["logs"]'
+#     terraform state mv \
+#       'module.kms.google_kms_key_ring.key_ring' \
+#       'google_kms_key_ring.this'
+#
+#     # for prevent_destroy = false: swap .key[i]→.key_ephemeral[i] and
+#     # protected→ephemeral.
+#
+#   Indexes correspond to the order of var.keys in the customer's tfvars
+#   at the time of last apply. Run `terraform state list` first to
+#   confirm. After state-mv, the moved {} blocks below become no-ops on
+#   non-existent source addresses (terraform tolerates this — moved blocks
+#   describe prior state, not current config).
+#
+#   If a non-default customer applies without running state-mv, the
+#   moved {} blocks rebind the wrong key to "default" and terraform plan
+#   attempts to destroy the rest. On prevent_destroy=true keys the plan
+#   errors loudly (the lifecycle is the safety net) — no data loss.
 
 # Per-deploy suffix so retries after state loss don't 409 on the undeletable
 # keyring shell (issue #159). Stable across applies via state.
@@ -10,66 +55,74 @@ resource "random_id" "suffix" {
 locals {
   keyring_name = "${var.project}-${var.keyring_name}-${random_id.suffix.hex}"
 
-  # The upstream terraform-google-modules/kms/google module's
-  # `local.keys_by_name` calls slice() over a count-controlled splat which
-  # can error during plan against an empty state with
-  # "slice end_index past the length" — the documented failure mode in
-  # issue #180 (split out from #178).
-  #
-  # Per the Terraform docs for try() —
-  # https://developer.hashicorp.com/terraform/language/functions/try —
-  # try() catches errors raised during evaluation of the wrapped
-  # expression, including function-call failures inside transitively-
-  # evaluated locals of a referenced module. When we read
-  # module.kms.keys, terraform evaluates the upstream's
-  # local.keys_by_name, slice() fires, and the error propagates as a
-  # diagnostic to our expression context where try() traps it.
-  # versions.tf pins required_version >= 1.3 which is the floor for this
-  # behavior; we rely on Terraform's documented contract rather than a
-  # cross-version-verified test (a real-plan integration test against
-  # an empty state is tracked in #182).
-  #
-  # On the steady-state happy path (default prevent_destroy=true, default
-  # var.keys with one entry), slice() is well-formed and try() is a no-op
-  # — module.kms.keys returns the real {name => key_id} map.
-  #
-  # The iam_bindings resource below still indexes into this local
-  # directly. When iam_bindings is empty (the default), the local is
-  # never evaluated for that resource and the plan proceeds. When it's
-  # non-empty AND the upstream errored, the binding's plan fails — that's
-  # a known degradation, tracked as #182. The permanent fix is to replace
-  # the upstream module with direct google_kms_* resources using for_each
-  # (no slice expressions); shipping the surgical fix here unblocks the
-  # default-config customer in #178's repro without the migration risk
-  # of the upstream replacement.
-  keys_by_name = try(module.kms.keys, {})
+  # for_each-friendly view of var.keys.
+  keys_by_name_input = { for k in var.keys : k.name => k }
+
+  # Indexable {name => key_id} map regardless of which prevent_destroy
+  # branch populated. Exactly one of the two source maps is non-empty
+  # (the for_each on each resource is mutually exclusive on
+  # var.prevent_destroy), so merge() is symmetric and produces the same
+  # shape the upstream module's `keys` output produced.
+  keys_by_name = merge(
+    { for n, k in google_kms_crypto_key.protected : n => k.id },
+    { for n, k in google_kms_crypto_key.ephemeral : n => k.id },
+  )
 }
 
-module "kms" {
-  source  = "terraform-google-modules/kms/google"
-  version = "~> 3.0"
-
-  project_id = var.project_id
-  location   = var.region
-  keyring    = local.keyring_name
-
-  keys                 = [for k in var.keys : k.name]
-  key_rotation_period  = var.keys[0].rotation_period
-  key_algorithm        = var.keys[0].algorithm
-  key_protection_level = var.keys[0].protection_level
-  purpose              = var.keys[0].purpose
-
-  prevent_destroy = var.prevent_destroy
-
-  labels = var.labels
+resource "google_kms_key_ring" "this" {
+  name     = local.keyring_name
+  project  = var.project_id
+  location = var.region
 }
 
-# Additional IAM bindings. crypto_key_id consumes local.keys_by_name
-# directly; when iam_bindings is empty (the default) the local is not
-# evaluated for this resource and the plan proceeds even if the upstream
-# slice() errors (issue #180). When iam_bindings is non-empty the failure
-# surface is unchanged from before this fix — the surgical fix here
-# protects the output path, which is what most consumers depend on.
+# Protected branch: lifecycle.prevent_destroy = true (hard-coded literal —
+# Terraform requires the value to be static). The for_each population is
+# gated on var.prevent_destroy so this resource only exists when the
+# caller wants destroy protection.
+resource "google_kms_crypto_key" "protected" {
+  for_each = var.prevent_destroy ? local.keys_by_name_input : {}
+
+  name            = each.value.name
+  key_ring        = google_kms_key_ring.this.id
+  rotation_period = each.value.rotation_period
+  purpose         = each.value.purpose
+  labels          = each.value.labels
+
+  version_template {
+    algorithm        = each.value.algorithm
+    protection_level = each.value.protection_level
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Ephemeral branch: lifecycle.prevent_destroy = false. Used for dev/test
+# stacks and any caller that opts out of destroy protection.
+resource "google_kms_crypto_key" "ephemeral" {
+  for_each = var.prevent_destroy ? {} : local.keys_by_name_input
+
+  name            = each.value.name
+  key_ring        = google_kms_key_ring.this.id
+  rotation_period = each.value.rotation_period
+  purpose         = each.value.purpose
+  labels          = each.value.labels
+
+  version_template {
+    algorithm        = each.value.algorithm
+    protection_level = each.value.protection_level
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+# Additional IAM bindings. crypto_key_id consumes local.keys_by_name,
+# which is now a plain for_each-derived map (no slice expression). The
+# pre-#182 hole — iam_bindings + empty state failing plan because of the
+# upstream's slice() — is closed by construction.
 resource "google_kms_crypto_key_iam_binding" "this" {
   for_each = { for b in var.iam_bindings : "${b.key_name}-${b.role}" => b }
 
@@ -78,3 +131,23 @@ resource "google_kms_crypto_key_iam_binding" "this" {
   members       = each.value.members
 }
 
+# State migration: pre-#182 customers had a single key named "default"
+# at module.kms.google_kms_crypto_key.{key|key_ephemeral}[0] under the
+# vendored upstream. These blocks rebind those addresses to the new
+# for_each-keyed resources so the default-config upgrade is a no-op
+# plan. Non-default customers must run the state-mv recipe in this
+# file's header comment first.
+moved {
+  from = module.kms.google_kms_key_ring.key_ring
+  to   = google_kms_key_ring.this
+}
+
+moved {
+  from = module.kms.google_kms_crypto_key.key[0]
+  to   = google_kms_crypto_key.protected["default"]
+}
+
+moved {
+  from = module.kms.google_kms_crypto_key.key_ephemeral[0]
+  to   = google_kms_crypto_key.ephemeral["default"]
+}

--- a/gcp/kms/outputs.tf
+++ b/gcp/kms/outputs.tf
@@ -1,29 +1,24 @@
 output "keyring_id" {
   description = "The key ring ID"
-  value       = module.kms.keyring
+  value       = google_kms_key_ring.this.id
 }
 
 output "keyring_name" {
   description = "The key ring name"
-  value       = module.kms.keyring_name
+  value       = google_kms_key_ring.this.name
 }
 
 output "keyring_self_link" {
   description = "The key ring self link"
-  value       = module.kms.keyring_resource.id
+  value       = google_kms_key_ring.this.id
 }
 
 output "keys" {
   description = "Map of key names to key IDs"
-  # Routed through the local that wraps the upstream's keys_by_name in
-  # try() (issue #180). On the happy path this is the upstream value;
-  # if the upstream's slice() ever errors during plan against an empty
-  # state, consumers see an empty map and skip rather than failing.
-  value = local.keys_by_name
+  value       = local.keys_by_name
 }
 
 output "key_self_links" {
   description = "Map of key names to self links"
   value       = { for k, v in local.keys_by_name : k => v }
 }
-

--- a/gcp/kms/tests/kms.tftest.hcl
+++ b/gcp/kms/tests/kms.tftest.hcl
@@ -1,12 +1,13 @@
 mock_provider "google" {}
 
-# Regression for #141. terraform-google-modules/kms ~> 3.0 declares
-# key_rotation_period / key_algorithm / key_protection_level / purpose as
-# scalar string. A previous revision of main.tf passed map(string) values
-# built from `for k in var.keys : ...`, which the upstream module rejected
-# with `string required` at apply time. The wrapper now passes scalars
-# from var.keys[0] and the variable validates that all keys agree on
-# those four fields — these tests pin both halves.
+# Regression for #141. The wrapper passes one shared rotation_period /
+# algorithm / protection_level / purpose into each google_kms_crypto_key
+# instance and var.keys validates that all keys agree on those four
+# fields — these tests pin both halves. The homogeneity validations are
+# retained for public-API stability across the issue #182 upstream
+# replacement; they no longer reflect a technical constraint of the
+# implementation (the per-key for_each could legally take heterogeneous
+# values) but expanding the surface is out of scope for #182.
 
 run "defaults_plan" {
   command = plan
@@ -130,20 +131,25 @@ run "rejects_underscore_project_id" {
   expect_failures = [var.project_id]
 }
 
-# Regression for #180. The upstream terraform-google-modules/kms/google's
-# `local.keys_by_name` calls slice() over a count-controlled splat which
-# can error on first plan against an empty state. Our preset wraps that
-# value in `try(module.kms.keys, {})` so plan progresses even if the
-# upstream errors during evaluation. These two cases pin the bypass
-# semantics:
+# Regression for #180/#182. Issue #180 was the upstream
+# terraform-google-modules/kms/google's `local.keys_by_name` calling
+# slice() on a count-controlled splat which can error during plan
+# against an empty state. PR #181 surgically wrapped that consumption
+# in `try(...)`. Issue #182 replaced the upstream entirely with direct
+# google_kms_* resources keyed by for_each, so the slice expression is
+# gone. These cases continue to pin the empty-state plan path:
 #
-#   - With prevent_destroy=true (default), the upstream's slice fires on
-#     google_kms_crypto_key.key (count=N). plan must succeed.
-#   - With prevent_destroy=false, the upstream picks the ephemeral
-#     branch's slice. plan must succeed.
+#   - With prevent_destroy=true (default), google_kms_crypto_key.protected
+#     fires for_each. plan must succeed.
+#   - With prevent_destroy=false, google_kms_crypto_key.ephemeral fires
+#     instead. plan must succeed.
+#   - With non-empty iam_bindings, google_kms_crypto_key_iam_binding.this
+#     resolves crypto_key_id from local.keys_by_name (a plain for_each
+#     map, no slice). This is the case PR #181 could not protect.
 #
-# Both arms must work; if either regresses to a slice-end-index error,
-# real customers see plan_summary.stage_errors=["custom-stack-provision"].
+# Both branches must work; if a future change reintroduces a slice
+# expression here or re-vendors the upstream, real customers see
+# plan_summary.stage_errors=["custom-stack-provision"].
 
 run "issue_180_prevent_destroy_true_plans_clean" {
   command = plan
@@ -179,5 +185,51 @@ run "issue_180_iam_bindings_resolve_against_local" {
         members  = ["serviceAccount:test@test-project.iam.gserviceaccount.com"]
       }
     ]
+  }
+}
+
+# Issue #182: the prevent_destroy split is two distinct resources
+# (google_kms_crypto_key.protected vs .ephemeral) gated by mutually
+# exclusive for_each. These cases pin which branch fires for each
+# var.prevent_destroy value, so a refactor that collapses both into one
+# resource — or flips the gating direction — fails CI.
+
+run "issue_182_prevent_destroy_true_uses_protected_branch" {
+  command = plan
+
+  variables {
+    project         = "test"
+    project_id      = "test-project"
+    prevent_destroy = true
+    keys            = [{ name = "data" }]
+  }
+
+  assert {
+    condition     = length(google_kms_crypto_key.protected) == 1
+    error_message = "prevent_destroy=true must populate google_kms_crypto_key.protected"
+  }
+  assert {
+    condition     = length(google_kms_crypto_key.ephemeral) == 0
+    error_message = "prevent_destroy=true must leave google_kms_crypto_key.ephemeral empty"
+  }
+}
+
+run "issue_182_prevent_destroy_false_uses_ephemeral_branch" {
+  command = plan
+
+  variables {
+    project         = "test"
+    project_id      = "test-project"
+    prevent_destroy = false
+    keys            = [{ name = "data" }]
+  }
+
+  assert {
+    condition     = length(google_kms_crypto_key.ephemeral) == 1
+    error_message = "prevent_destroy=false must populate google_kms_crypto_key.ephemeral"
+  }
+  assert {
+    condition     = length(google_kms_crypto_key.protected) == 0
+    error_message = "prevent_destroy=false must leave google_kms_crypto_key.protected empty"
   }
 }

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -2368,6 +2368,12 @@ func TestComposeStack_GCPCloudKMS_TerraformPlan(t *testing.T) {
 			}
 			planCmd := exec.Command("terraform", "plan", "-refresh=false", "-input=false", "-no-color")
 			planCmd.Dir = dir
+			// The google provider's Configure() step tries to load
+			// Application Default Credentials even when -refresh=false
+			// suppresses live API calls. Inject a fake OAuth token so
+			// the provider initializes cleanly in CI (where ADC is
+			// unavailable). The test never reaches a real GCP call.
+			planCmd.Env = append(os.Environ(), "GOOGLE_OAUTH_ACCESS_TOKEN=ya29.test-token-not-real")
 			planOut, err := planCmd.CombinedOutput()
 			require.NoError(t, err, "terraform plan must succeed on composed gcp/kms stack (issue #182 — formal closure for the slice end-index failure):\n%s", planOut)
 			// Belt-and-braces: even if plan exits 0, surface the
@@ -2573,6 +2579,11 @@ func TestComposeStack_GCPCloudKMS_MovedBlocksRebindUpstreamState(t *testing.T) {
 
 	planCmd := exec.Command("terraform", "plan", "-refresh=false", "-input=false", "-no-color")
 	planCmd.Dir = dir
+	// See sibling TestComposeStack_GCPCloudKMS_TerraformPlan: the
+	// google provider's Configure() requires SOME credential source,
+	// even with -refresh=false. Inject a fake token so CI (no ADC)
+	// can initialize the provider; the test never makes a real call.
+	planCmd.Env = append(os.Environ(), "GOOGLE_OAUTH_ACCESS_TOKEN=ya29.test-token-not-real")
 	planOut, err := planCmd.CombinedOutput()
 	require.NoError(t, err, "terraform plan must succeed against synthetic upstream-state (issue #182 moved-blocks gate):\n%s", planOut)
 

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -2264,18 +2264,31 @@ func TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate(t *testing.
 	}
 }
 
-// TestComposeStack_GCPCloudKMS_TerraformValidate is the formal closure
+// TestComposeStack_GCPCloudKMS_TerraformPlan is the formal closure
 // for issue #182's acceptance criterion: a fresh GCP session that
 // selects gcp/kms with default config (and with non-default
-// iam_bindings) must plan cleanly on first run with empty state. PR
-// #181 surgically wrapped the upstream's broken slice() in try() to
-// protect default consumers but left a hole when iam_bindings is
+// iam_bindings) must **plan** cleanly on first run with empty state.
+// PR #181 surgically wrapped the upstream's broken slice() in try()
+// to protect default consumers but left a hole when iam_bindings is
 // non-empty; #182 replaced the upstream entirely with direct
-// google_kms_* resources keyed by for_each, closing the hole. This
-// test runs `terraform init` + `terraform validate` against the
-// composed stack to prove there's no Invalid index / empty tuple
-// regression — mirroring TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate
-// which closed #178's analogous criterion.
+// google_kms_* resources keyed by for_each, closing the hole.
+//
+// `terraform plan -refresh=false` (NOT `terraform validate`) is the
+// right gate here: the upstream's failure mode is a `slice()` end-
+// index error during expression evaluation, which `validate` does
+// NOT exercise — `validate` only checks HCL syntax + type
+// conformance + attribute existence, not expression evaluation. A
+// regression that re-vendors the upstream module would slip past a
+// validate-only gate but be caught by plan. (The sibling
+// TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate
+// uses validate because issue #178's failure mode is `Invalid
+// index` on tuple access, which validate DOES surface — different
+// failure mode, different gate.)
+//
+// `-refresh=false` skips the credential-requiring provider refresh
+// (this test runs offline against an empty state with no real GCP
+// project) — the failure mode we're guarding against fires during
+// expression evaluation in plan, well before any provider call.
 //
 // CI vs local skip rules match the router/connector test:
 //   - In CI (CI=true): terraform init failure is a hard failure (the
@@ -2283,12 +2296,12 @@ func TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate(t *testing.
 //   - Local dev: skip on init failure so offline `go test ./...` works.
 //
 // Use `go test -short` to skip entirely (e.g. in pre-commit hooks).
-func TestComposeStack_GCPCloudKMS_TerraformValidate(t *testing.T) {
+func TestComposeStack_GCPCloudKMS_TerraformPlan(t *testing.T) {
 	if testing.Short() {
-		t.Skip("-short skips multi-second terraform init+validate")
+		t.Skip("-short skips multi-second terraform init+plan")
 	}
 	if _, err := exec.LookPath("terraform"); err != nil {
-		t.Skip("terraform binary not on PATH; skipping integration validate")
+		t.Skip("terraform binary not on PATH; skipping integration plan")
 	}
 
 	inCI := os.Getenv("CI") == "true"
@@ -2297,11 +2310,11 @@ func TestComposeStack_GCPCloudKMS_TerraformValidate(t *testing.T) {
 	// non-empty iam_bindings shape that the composer surfaces. The
 	// composer mapper does not currently surface var.iam_bindings as
 	// a Component-driven knob, so the second combo writes an extra
-	// kms.auto.tfvars after composition to inject the binding —
-	// faithful to what a reliable3-side mapper would emit and to
-	// what a real customer's stack would look like. The plan-time
-	// resolution of that binding is exactly the case PR #181 could
-	// not protect.
+	// kms_iam_bindings.auto.tfvars after composition to inject the
+	// binding — faithful to what a reliable3-side mapper would emit
+	// and to what a real customer's stack would look like. The
+	// plan-time resolution of that binding is exactly the case PR
+	// #181 could not protect.
 	combos := []struct {
 		name        string
 		extraTFVars string
@@ -2353,16 +2366,254 @@ func TestComposeStack_GCPCloudKMS_TerraformValidate(t *testing.T) {
 				}
 				t.Skipf("terraform init unavailable (network/cache) in local dev: %s\n%s", err, initOut)
 			}
-			validateCmd := exec.Command("terraform", "validate", "-no-color")
-			validateCmd.Dir = dir
-			validateOut, err := validateCmd.CombinedOutput()
-			require.NoError(t, err, "terraform validate must succeed on composed gcp/kms stack (issue #182):\n%s", validateOut)
-			require.NotContains(t, string(validateOut), "Invalid index",
-				"terraform validate surfaced 'Invalid index' (issue #182 regression)")
-			require.NotContains(t, string(validateOut), "empty tuple",
-				"terraform validate surfaced 'empty tuple' (issue #182 regression)")
-			require.NotContains(t, string(validateOut), "slice",
-				"terraform validate surfaced 'slice' (issue #182 regression — upstream module re-introduced)")
+			planCmd := exec.Command("terraform", "plan", "-refresh=false", "-input=false", "-no-color")
+			planCmd.Dir = dir
+			planOut, err := planCmd.CombinedOutput()
+			require.NoError(t, err, "terraform plan must succeed on composed gcp/kms stack (issue #182 — formal closure for the slice end-index failure):\n%s", planOut)
+			// Belt-and-braces: even if plan exits 0, surface the
+			// upstream's specific error string in case a future
+			// terraform version downgrades the failure to a
+			// warning instead of an error.
+			require.NotContains(t, string(planOut), "slice end_index",
+				"terraform plan surfaced 'slice end_index' (issue #182 regression — upstream module re-introduced)")
+			require.NotContains(t, string(planOut), "Invalid index",
+				"terraform plan surfaced 'Invalid index' (related #178 regression)")
 		})
 	}
+}
+
+// TestComposeStack_GCPCloudKMS_MovedBlocksRebindUpstreamState exercises
+// the issue #182 `moved {}` blocks against a synthetic state file
+// that mimics what an existing default-config customer's state looks
+// like AFTER the old upstream-vendoring config was applied — i.e. the
+// state contains `module.gcp_cloud_kms.module.kms.google_kms_key_ring.key_ring`
+// and `.google_kms_crypto_key.key[0]`. The composer wraps the kms
+// preset as `module "gcp_cloud_kms"` (named after the ComponentKey),
+// and inside the wrapper preset the old upstream vendoring was
+// `module "kms" { source = "terraform-google-modules/kms/google" }` —
+// hence the doubled `module.gcp_cloud_kms.module.kms.` prefix in
+// real customer state. Without the moved {} blocks, terraform would
+// see those addresses as orphans (wrapper module no longer declares
+// the inner `module "kms"`) and plan to destroy them.
+//
+// The test composes the stack, writes the state file as
+// `terraform.tfstate`, runs `terraform init`, then `terraform plan
+// -refresh=false` and asserts:
+//
+//   - plan succeeds (the moved blocks parse and the source addresses
+//     in state are recognized).
+//   - plan output explicitly acknowledges the moved-block rebinding
+//     ("has moved from" is terraform's standard phrasing — a moved
+//     block whose source address is absent from state silently
+//     becomes a no-op, so the acknowledgment string is the proof
+//     that the rebind actually fired).
+//   - plan output does NOT contain a destroy plan for the old
+//     upstream addresses (which would mean the rebind failed and
+//     terraform sees the old resources as orphaned).
+//
+// `-refresh=false` skips the credential-requiring provider refresh
+// — the synthetic state has bare-bones attributes that wouldn't
+// match a real GCP read.
+//
+// Limitations: the synthetic state intentionally omits
+// `random_id.suffix` and uses a baked keyring name that won't match
+// a fresh re-deploy's `random_id.suffix.hex`. As a result, `plan`
+// will also propose creating a NEW `random_id.suffix` (and possibly
+// re-creating the keyring under the new name). This is fine for
+// what the test asserts — the moved-block acknowledgment fires
+// before any attribute-drift comparison. A test that asserts "0
+// resources to destroy" would require synthesizing the random_id
+// state too AND interpolating its hex into the keyring name; the
+// test's contract is "moved blocks rebind correctly," not "default
+// config produces a no-op upgrade plan" (the latter is the manual
+// sandbox-apply gate documented in the PR).
+func TestComposeStack_GCPCloudKMS_MovedBlocksRebindUpstreamState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("-short skips multi-second terraform init+plan")
+	}
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform binary not on PATH; skipping integration plan")
+	}
+
+	inCI := os.Getenv("CI") == "true"
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPCloudKMS},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-central1"},
+		Project:      "test",
+		Region:       "us-central1",
+		GCPProjectID: "test-project-12345",
+	})
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	writeOutputs(t, out, dir)
+
+	// Synthetic state: mimics an existing customer's default-config
+	// stack as it was last applied with the pre-#182 upstream
+	// vendoring. Includes:
+	//   - random_id.suffix (in the wrapper at module.gcp_cloud_kms)
+	//     with a known hex value of "deadbeef" so the keyring name
+	//     `${var.project}-${var.keyring_name}-${random_id.suffix.hex}`
+	//     matches what's already in state; without this the plan
+	//     would regenerate the random_id and trigger a force-new
+	//     on the keyring name (then chain to a prevent_destroy
+	//     error on the crypto_key).
+	//   - google_kms_key_ring at the doubly-prefixed
+	//     module.gcp_cloud_kms.module.kms.* address.
+	//   - google_kms_crypto_key.key[0] (count-indexed in the
+	//     upstream — `each` field is omitted since count-indexed
+	//     resources don't have it).
+	//
+	// Refresh=false skips the live read so any drift from real GCP
+	// schemas is irrelevant.
+	state := `{
+  "version": 4,
+  "terraform_version": "1.5.0",
+  "serial": 1,
+  "lineage": "00000000-0000-0000-0000-000000000182",
+  "outputs": {},
+  "resources": [
+    {
+      "module": "module.gcp_cloud_kms",
+      "mode": "managed",
+      "type": "random_id",
+      "name": "suffix",
+      "provider": "provider[\"registry.terraform.io/hashicorp/random\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "b64_std": "3q2+7w==",
+            "b64_url": "3q2-7w",
+            "byte_length": 4,
+            "dec": "3735928559",
+            "hex": "deadbeef",
+            "id": "3q2-7w",
+            "keepers": null,
+            "prefix": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.gcp_cloud_kms.module.kms",
+      "mode": "managed",
+      "type": "google_kms_key_ring",
+      "name": "key_ring",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "projects/test-project-12345/locations/us-central1/keyRings/test-main-keyring-deadbeef",
+            "location": "us-central1",
+            "name": "test-main-keyring-deadbeef",
+            "project": "test-project-12345",
+            "timeouts": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.gcp_cloud_kms.module.kms",
+      "mode": "managed",
+      "type": "google_kms_crypto_key",
+      "name": "key",
+      "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "id": "projects/test-project-12345/locations/us-central1/keyRings/test-main-keyring-deadbeef/cryptoKeys/default",
+            "key_ring": "projects/test-project-12345/locations/us-central1/keyRings/test-main-keyring-deadbeef",
+            "name": "default",
+            "purpose": "ENCRYPT_DECRYPT",
+            "rotation_period": "7776000s",
+            "labels": {},
+            "import_only": false,
+            "skip_initial_version_creation": false,
+            "destroy_scheduled_duration": "86400s",
+            "version_template": [
+              {
+                "algorithm": "GOOGLE_SYMMETRIC_ENCRYPTION",
+                "protection_level": "SOFTWARE"
+              }
+            ],
+            "timeouts": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}
+`
+	require.NoError(t,
+		os.WriteFile(filepath.Join(dir, "terraform.tfstate"), []byte(state), 0o600),
+		"write synthetic state")
+
+	initCmd := exec.Command("terraform", "init", "-backend=false", "-input=false", "-no-color")
+	initCmd.Dir = dir
+	initOut, err := initCmd.CombinedOutput()
+	if err != nil {
+		if inCI {
+			require.NoError(t, err,
+				"terraform init must succeed in CI; this gate is the moved-blocks pin for #182:\n%s", initOut)
+		}
+		t.Skipf("terraform init unavailable (network/cache) in local dev: %s\n%s", err, initOut)
+	}
+
+	planCmd := exec.Command("terraform", "plan", "-refresh=false", "-input=false", "-no-color")
+	planCmd.Dir = dir
+	planOut, err := planCmd.CombinedOutput()
+	require.NoError(t, err, "terraform plan must succeed against synthetic upstream-state (issue #182 moved-blocks gate):\n%s", planOut)
+
+	// Each moved block's source address must trigger terraform's
+	// rebind acknowledgment. A moved block whose source address is
+	// absent from state silently becomes a no-op, so this string
+	// is the proof that the rebind actually fired.
+	planStr := string(planOut)
+	for _, want := range []string{
+		`module.gcp_cloud_kms.module.kms.google_kms_key_ring.key_ring`,
+		`module.gcp_cloud_kms.module.kms.google_kms_crypto_key.key[0]`,
+	} {
+		require.Contains(t, planStr, want,
+			"terraform plan output must reference the old upstream address `%s` as the moved-block source — a missing reference means the moved block silently became a no-op and customers' state will NOT migrate (issue #182):\n%s",
+			want, planStr)
+	}
+	// Terraform uses two interchangeable phrasings for moved-block
+	// acknowledgment in plan output:
+	//   - `has moved to <new_address>` (when the resource has no
+	//     other changes — pure address rebind).
+	//   - `(moved from <old_address>)` (when the resource has other
+	//     changes too — e.g. computed attributes added by a newer
+	//     provider version).
+	// Either is proof the moved block fired. Two moved sources in
+	// state → at least two acknowledgments combined.
+	movedCount := strings.Count(planStr, "has moved to") + strings.Count(planStr, "moved from")
+	require.GreaterOrEqual(t, movedCount, 2,
+		"terraform plan output must contain at least 2 moved-block acknowledgments combined (`has moved to` + `moved from`); got %d. Fewer means moved blocks aren't rebinding (issue #182):\n%s", movedCount, planStr)
+
+	// The strongest assertion: 0 destroys. If the moved blocks fully
+	// rebound the synthetic state, terraform should not plan to
+	// destroy anything. (Updates-in-place are fine — they reflect
+	// computed-attribute additions in the new provider version, not
+	// a re-creation of the keyring or crypto_key.)
+	require.Contains(t, planStr, "0 to destroy",
+		"terraform plan must show 0 destroys after moved-block rebind — a non-zero destroy count means the moved block didn't catch the source address and customers' state would lose the resource on apply (issue #182):\n%s", planStr)
+
+	// Belt-and-braces: the slice() failure mode must not surface
+	// even with state present (a regression that re-vendored the
+	// upstream would fire here too, possibly with attribute-shape
+	// errors layered on top).
+	require.NotContains(t, planStr, "slice end_index",
+		"terraform plan surfaced 'slice end_index' (issue #182 regression):\n%s", planStr)
 }

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -3,6 +3,7 @@ package composer
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -2259,6 +2260,109 @@ func TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate(t *testing.
 				"terraform validate surfaced 'Invalid index' (issue #178 regression)")
 			require.NotContains(t, string(validateOut), "empty tuple",
 				"terraform validate surfaced 'empty tuple' (issue #178 regression)")
+		})
+	}
+}
+
+// TestComposeStack_GCPCloudKMS_TerraformValidate is the formal closure
+// for issue #182's acceptance criterion: a fresh GCP session that
+// selects gcp/kms with default config (and with non-default
+// iam_bindings) must plan cleanly on first run with empty state. PR
+// #181 surgically wrapped the upstream's broken slice() in try() to
+// protect default consumers but left a hole when iam_bindings is
+// non-empty; #182 replaced the upstream entirely with direct
+// google_kms_* resources keyed by for_each, closing the hole. This
+// test runs `terraform init` + `terraform validate` against the
+// composed stack to prove there's no Invalid index / empty tuple
+// regression — mirroring TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate
+// which closed #178's analogous criterion.
+//
+// CI vs local skip rules match the router/connector test:
+//   - In CI (CI=true): terraform init failure is a hard failure (the
+//     gate must not silently skip on transient registry blips).
+//   - Local dev: skip on init failure so offline `go test ./...` works.
+//
+// Use `go test -short` to skip entirely (e.g. in pre-commit hooks).
+func TestComposeStack_GCPCloudKMS_TerraformValidate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("-short skips multi-second terraform init+validate")
+	}
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform binary not on PATH; skipping integration validate")
+	}
+
+	inCI := os.Getenv("CI") == "true"
+
+	// Two combos: kms alone (the leaf default), and kms with a
+	// non-empty iam_bindings shape that the composer surfaces. The
+	// composer mapper does not currently surface var.iam_bindings as
+	// a Component-driven knob, so the second combo writes an extra
+	// kms.auto.tfvars after composition to inject the binding —
+	// faithful to what a reliable3-side mapper would emit and to
+	// what a real customer's stack would look like. The plan-time
+	// resolution of that binding is exactly the case PR #181 could
+	// not protect.
+	combos := []struct {
+		name        string
+		extraTFVars string
+	}{
+		{"kms alone with default config", ""},
+		{
+			"kms with non-empty iam_bindings",
+			`kms_iam_bindings = [
+  {
+    key_name = "default"
+    role     = "roles/cloudkms.cryptoKeyEncrypter"
+    members  = ["serviceAccount:test@test-project-12345.iam.gserviceaccount.com"]
+  },
+]
+`,
+		},
+	}
+
+	for _, combo := range combos {
+		t.Run(combo.name, func(t *testing.T) {
+			c := newTestClient()
+			out, err := c.ComposeStack(ComposeStackOpts{
+				Cloud:        "gcp",
+				SelectedKeys: []ComponentKey{KeyGCPCloudKMS},
+				Comps:        &Components{},
+				Cfg:          &Config{Region: "us-central1"},
+				Project:      "test",
+				Region:       "us-central1",
+				GCPProjectID: "test-project-12345",
+			})
+			require.NoError(t, err)
+
+			dir := t.TempDir()
+			writeOutputs(t, out, dir)
+
+			if combo.extraTFVars != "" {
+				require.NoError(t,
+					os.WriteFile(filepath.Join(dir, "kms_iam_bindings.auto.tfvars"), []byte(combo.extraTFVars), 0o600),
+					"write extra tfvars")
+			}
+
+			initCmd := exec.Command("terraform", "init", "-backend=false", "-input=false", "-no-color")
+			initCmd.Dir = dir
+			initOut, err := initCmd.CombinedOutput()
+			if err != nil {
+				if inCI {
+					require.NoError(t, err,
+						"terraform init must succeed in CI; this gate is the formal closure for issue #182 and must not silently skip on transient registry failures:\n%s", initOut)
+				}
+				t.Skipf("terraform init unavailable (network/cache) in local dev: %s\n%s", err, initOut)
+			}
+			validateCmd := exec.Command("terraform", "validate", "-no-color")
+			validateCmd.Dir = dir
+			validateOut, err := validateCmd.CombinedOutput()
+			require.NoError(t, err, "terraform validate must succeed on composed gcp/kms stack (issue #182):\n%s", validateOut)
+			require.NotContains(t, string(validateOut), "Invalid index",
+				"terraform validate surfaced 'Invalid index' (issue #182 regression)")
+			require.NotContains(t, string(validateOut), "empty tuple",
+				"terraform validate surfaced 'empty tuple' (issue #182 regression)")
+			require.NotContains(t, string(validateOut), "slice",
+				"terraform validate surfaced 'slice' (issue #182 regression — upstream module re-introduced)")
 		})
 	}
 }

--- a/pkg/composer/compose_vm_test.go
+++ b/pkg/composer/compose_vm_test.go
@@ -219,17 +219,60 @@ func TestGetPresetFiles_GCP_AllModules(t *testing.T) {
 	}
 }
 
-// stripHCLComments returns the input HCL with `#`- and `//`-prefixed
-// comment lines removed. Useful for structural pins that need to
-// assert against active code only — the migration recipes in
-// gcp/kms/main.tf's header comment legitimately reference the
-// upstream's old module addresses, but those references are
-// documentation, not active code. moved {} blocks describing the old
-// upstream addresses are intentionally NOT stripped: they ARE active
-// HCL (terraform reads them on plan) and the structural pin treats
-// them as such — a moved.from address pointing at module.kms is
-// expected and necessary.
-func stripHCLComments(s string) string {
+// extractMovedBlocks parses a (comment-stripped) HCL body and returns
+// the from→to address pairs declared in `moved {}` blocks. Used to
+// pin state-migration assertions in structural tests.
+//
+// The regex tolerates any whitespace between `moved`, `{`, `from =`,
+// `to =`, and `}`. It captures the address expressions verbatim
+// (including bracket-keyed indices like `["default"]` and `[0]`).
+//
+// fatals via the testing.T on a parse failure rather than returning
+// an error — these are deterministic structural pins, never expected
+// to silently degrade.
+func extractMovedBlocks(t *testing.T, hclBody string) map[string]string {
+	t.Helper()
+	// (?ms) → multiline + dotall. Each capture group:
+	//   1: the `from = ...` rhs (terminated by newline)
+	//   2: the `to = ...` rhs (terminated by newline)
+	re := regexp.MustCompile(`(?ms)moved\s*\{\s*from\s*=\s*([^\n]+?)\s*to\s*=\s*([^\n]+?)\s*\}`)
+	matches := re.FindAllStringSubmatch(hclBody, -1)
+	out := make(map[string]string, len(matches))
+	for _, m := range matches {
+		require.Len(t, m, 3, "regex capture shape changed; expected 3 groups (full match + from + to)")
+		from := strings.TrimSpace(m[1])
+		to := strings.TrimSpace(m[2])
+		require.NotContains(t, out, from,
+			"duplicate `from = %s` in moved blocks — terraform forbids two moved blocks rebinding the same source", from)
+		out[from] = to
+	}
+	return out
+}
+
+// stripFullLineComments removes lines whose first non-whitespace
+// character begins a `#`- or `//`-style comment. It does NOT handle:
+//
+//   - Inline trailing comments (e.g. `name = "foo" # bar` keeps the
+//     entire line, including the trailing `# bar`).
+//   - Block comments (`/* ... */` is preserved verbatim).
+//   - String literals that happen to contain a `#` or `//` (e.g.
+//     `"#abc123"` is preserved, which is the correct behavior).
+//
+// Use it for structural pins that need to ignore documentation
+// blocks (e.g. the migration recipe in gcp/kms/main.tf's header
+// comment legitimately references the upstream's old module
+// addresses — those references are documentation, not active
+// code). Callers MUST keep banned-token references on full-line
+// comments only — appending `# preserved for slice() history` to an
+// active code line would silently invalidate any
+// `require.NotContains(stripped, "slice(")` assertion that depends
+// on this helper.
+//
+// moved {} blocks describing old upstream addresses are intentionally
+// NOT stripped: they ARE active HCL (terraform reads them on plan)
+// and structural pins treat them as such — a `moved.from` address
+// pointing at `module.kms` is expected and necessary.
+func stripFullLineComments(s string) string {
 	lines := strings.Split(s, "\n")
 	out := make([]string, 0, len(lines))
 	for _, l := range lines {
@@ -282,7 +325,7 @@ func TestGetPresetFiles_GCP_KMS_NoUpstreamModule(t *testing.T) {
 	require.True(t, ok, "gcp/kms must include main.tf")
 
 	body := string(mainTF)
-	bodyNoComments := stripHCLComments(body)
+	bodyNoComments := stripFullLineComments(body)
 
 	// The upstream module source is gone (only the active HCL is
 	// checked — the migration recipe in the header comment
@@ -311,15 +354,33 @@ func TestGetPresetFiles_GCP_KMS_NoUpstreamModule(t *testing.T) {
 		"gcp/kms/main.tf must declare google_kms_crypto_key.ephemeral for prevent_destroy=false (issue #182)")
 
 	// Three moved {} blocks for the default-config state migration:
-	// keyring + protected[default] + ephemeral[default]. Anything
-	// less and customers upgrading from the upstream module see
-	// replace plans on existing keys.
-	require.GreaterOrEqual(t, strings.Count(bodyNoComments, "moved {"), 3,
-		"gcp/kms/main.tf must include 3 moved {} blocks for default-config state migration (issue #182)")
+	// keyring + protected[default] + ephemeral[default]. The exact
+	// from→to pairs matter — a refactor that renames `protected` to
+	// `current` and forgets to update the moved block silently
+	// destroys customers' keys (the rebind targets a non-existent
+	// address, then the new resource creates fresh and the old
+	// state entry is orphaned). The pin asserts each expected pair
+	// rather than just counting blocks.
+	moved := extractMovedBlocks(t, bodyNoComments)
+	expectedMoves := map[string]string{
+		"module.kms.google_kms_key_ring.key_ring":            "google_kms_key_ring.this",
+		`module.kms.google_kms_crypto_key.key[0]`:            `google_kms_crypto_key.protected["default"]`,
+		`module.kms.google_kms_crypto_key.key_ephemeral[0]`:  `google_kms_crypto_key.ephemeral["default"]`,
+	}
+	require.Len(t, moved, len(expectedMoves),
+		"gcp/kms/main.tf must include exactly %d moved {} blocks for default-config state migration (issue #182); got %d: %v",
+		len(expectedMoves), len(moved), moved)
+	for from, wantTo := range expectedMoves {
+		gotTo, ok := moved[from]
+		require.True(t, ok,
+			"gcp/kms/main.tf is missing the moved {} block for `from = %s` (issue #182 — customers' state for this address will not migrate)", from)
+		require.Equal(t, wantTo, gotTo,
+			"gcp/kms/main.tf moved block for `from = %s` rebinds to `%s` but should rebind to `%s` (issue #182 — wrong target silently orphans state and creates a fresh resource)", from, gotTo, wantTo)
+	}
 
 	outputsTF, ok := files["/outputs.tf"]
 	require.True(t, ok, "gcp/kms must include outputs.tf")
-	outputsBodyNoComments := stripHCLComments(string(outputsTF))
+	outputsBodyNoComments := stripFullLineComments(string(outputsTF))
 	require.Contains(t, outputsBodyNoComments, "google_kms_key_ring.this",
 		"gcp/kms/outputs.tf must read from the direct resource (issue #182)")
 	require.NotContains(t, outputsBodyNoComments, "module.kms",

--- a/pkg/composer/compose_vm_test.go
+++ b/pkg/composer/compose_vm_test.go
@@ -219,20 +219,61 @@ func TestGetPresetFiles_GCP_AllModules(t *testing.T) {
 	}
 }
 
-// TestGetPresetFiles_GCP_KMS_HasUpstreamSliceBypass pins the issue #180
-// fix at the embedded-FS layer. The upstream
-// terraform-google-modules/kms/google module's local.keys_by_name calls
-// slice() on a count-controlled splat that errors during plan against an
-// empty state. Our preset wraps that consumption in
-// `try(module.kms.keys, {})` so the slice failure is caught and the
-// degraded value flows to outputs as `{}` rather than failing the plan.
+// stripHCLComments returns the input HCL with `#`- and `//`-prefixed
+// comment lines removed. Useful for structural pins that need to
+// assert against active code only — the migration recipes in
+// gcp/kms/main.tf's header comment legitimately reference the
+// upstream's old module addresses, but those references are
+// documentation, not active code. moved {} blocks describing the old
+// upstream addresses are intentionally NOT stripped: they ARE active
+// HCL (terraform reads them on plan) and the structural pin treats
+// them as such — a moved.from address pointing at module.kms is
+// expected and necessary.
+func stripHCLComments(s string) string {
+	lines := strings.Split(s, "\n")
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		out = append(out, l)
+	}
+	return strings.Join(out, "\n")
+}
+
+// TestGetPresetFiles_GCP_KMS_NoUpstreamModule pins the issue #182
+// upstream-replacement at the embedded-FS layer.
 //
-// This is a structural pin: it cannot reproduce the runtime slice error
-// (mock_provider populates count splats with the right shape), but it
-// catches a future revert that removes the try() wrapper. A real-plan
-// integration test against an empty state is tracked as part of the
-// upstream-replacement work in #182.
-func TestGetPresetFiles_GCP_KMS_HasUpstreamSliceBypass(t *testing.T) {
+// History: the preset originally wrapped
+// terraform-google-modules/kms/google ~> 3.0. That module's
+// local.keys_by_name calls slice() on a count-controlled splat which
+// errors during plan against an empty state (issue #180). PR #181
+// surgically wrapped the consumption in try() to unblock the
+// default-config customer in #178's repro, but iam_bindings still
+// referenced the slice expression directly so non-default users hit a
+// hole. Issue #182 replaced the upstream module entirely with direct
+// google_kms_* resources keyed by for_each — eliminating the slice
+// expression so the failure mode cannot recur and closing the
+// iam_bindings hole by construction.
+//
+// This structural pin asserts (against comment-stripped HCL, since
+// the header comment legitimately documents the migration recipe by
+// referencing the old upstream addresses):
+//   - The upstream module is gone (no module "kms" block, no
+//     terraform-google-modules/kms source, no slice() call, no
+//     try() wrap of the upstream).
+//   - The replacement resources (key_ring + protected/ephemeral
+//     for_each crypto_keys) are present.
+//   - The default-config moved {} blocks (3 of them) are present so
+//     existing customers' state migrates without replace plans. The
+//     moved {} blocks intentionally reference module.kms.* on the
+//     `from` side — those are active HCL describing prior state.
+//   - outputs.tf reads from the direct resource, not from a module
+//     reference.
+//
+// A revert that re-vendors the upstream now fails this test loud.
+func TestGetPresetFiles_GCP_KMS_NoUpstreamModule(t *testing.T) {
 	t.Parallel()
 	files, err := newTestClient().GetPresetFiles("gcp/kms")
 	require.NoError(t, err)
@@ -241,24 +282,95 @@ func TestGetPresetFiles_GCP_KMS_HasUpstreamSliceBypass(t *testing.T) {
 	require.True(t, ok, "gcp/kms must include main.tf")
 
 	body := string(mainTF)
+	bodyNoComments := stripHCLComments(body)
 
-	// The literal try() wrap on module.kms.keys is the bypass that
-	// prevents the upstream slice() error from failing the plan.
-	require.Contains(t, body, "try(module.kms.keys, {})",
-		"gcp/kms/main.tf must wrap module.kms.keys in try() (issue #180); a regression here lets the upstream slice end_index error reach customers")
+	// The upstream module source is gone (only the active HCL is
+	// checked — the migration recipe in the header comment
+	// legitimately mentions the old source).
+	require.NotContains(t, bodyNoComments, "terraform-google-modules/kms/google",
+		"gcp/kms/main.tf must not re-vendor the upstream module (issue #182)")
+	// No module "kms" {} block. Asserting on the block-header form
+	// (with quotes) lets the moved {} blocks below legitimately use
+	// the bare `module.kms.*` address syntax on their `from` side.
+	require.NotContains(t, bodyNoComments, `module "kms"`,
+		"gcp/kms/main.tf must not declare a module \"kms\" block (issue #182)")
+	require.NotContains(t, bodyNoComments, "slice(",
+		"gcp/kms/main.tf must not contain slice() expressions — the upstream's failure mode (issue #180/#182)")
+	require.NotContains(t, bodyNoComments, "try(module.kms",
+		"gcp/kms/main.tf must not retain the surgical try() wrap from PR #181 — the upstream is gone (issue #182)")
 
-	// The local.keys_by_name local is the named carrier so consumers
-	// (outputs, IAM bindings) can reference one stable name. The next
-	// two checks ensure the bypass is actually the one consumed by the
-	// outputs, not just a dead local.
-	require.Contains(t, body, "keys_by_name = try(module.kms.keys, {})",
-		"local.keys_by_name must be the carrier of the bypass result")
+	// The replacement resources are present. Asserting on the
+	// resource-block headers (rather than on resource address
+	// references) catches a rename of the resources themselves, which
+	// would also break the moved {} blocks below.
+	require.Contains(t, bodyNoComments, `resource "google_kms_key_ring" "this"`,
+		"gcp/kms/main.tf must declare google_kms_key_ring.this (issue #182)")
+	require.Contains(t, bodyNoComments, `resource "google_kms_crypto_key" "protected"`,
+		"gcp/kms/main.tf must declare google_kms_crypto_key.protected for prevent_destroy=true (issue #182)")
+	require.Contains(t, bodyNoComments, `resource "google_kms_crypto_key" "ephemeral"`,
+		"gcp/kms/main.tf must declare google_kms_crypto_key.ephemeral for prevent_destroy=false (issue #182)")
+
+	// Three moved {} blocks for the default-config state migration:
+	// keyring + protected[default] + ephemeral[default]. Anything
+	// less and customers upgrading from the upstream module see
+	// replace plans on existing keys.
+	require.GreaterOrEqual(t, strings.Count(bodyNoComments, "moved {"), 3,
+		"gcp/kms/main.tf must include 3 moved {} blocks for default-config state migration (issue #182)")
 
 	outputsTF, ok := files["/outputs.tf"]
 	require.True(t, ok, "gcp/kms must include outputs.tf")
-	outputsBody := string(outputsTF)
-	require.Contains(t, outputsBody, "local.keys_by_name",
-		"gcp/kms/outputs.tf must consume the bypass local, not module.kms.keys directly")
-	require.NotContains(t, outputsBody, "module.kms.keys",
-		"gcp/kms/outputs.tf must not bypass the issue #180 wrapper by reading module.kms.keys directly")
+	outputsBodyNoComments := stripHCLComments(string(outputsTF))
+	require.Contains(t, outputsBodyNoComments, "google_kms_key_ring.this",
+		"gcp/kms/outputs.tf must read from the direct resource (issue #182)")
+	require.NotContains(t, outputsBodyNoComments, "module.kms",
+		"gcp/kms/outputs.tf must not reference the removed upstream module (issue #182)")
+	require.NotContains(t, outputsBodyNoComments, "try(",
+		"gcp/kms/outputs.tf must not retain the PR #181 try() wrap — the upstream is gone (issue #182)")
+}
+
+// TestGetPresetFiles_GCP_CloudBuild_HasWebhookSecretIAM pins the
+// issue #190 fix at the embedded-FS layer.
+//
+// google_cloudbuild_trigger validates webhook secret access on the
+// create call. Without an IAM binding granting
+// roles/secretmanager.secretAccessor on the webhook secret to the
+// Cloud Build P4SA (service-PROJECT_NUMBER@gcp-sa-cloudbuild) the
+// create fails with `400 INVALID_ARGUMENT: Request contains an
+// invalid argument`. The fix:
+//
+//   1. data.google_project.this resolves the project number
+//      after-enable.
+//   2. google_secret_manager_secret_iam_member.cloudbuild_webhook_accessor
+//      grants secretAccessor on the webhook secret to the P4SA.
+//   3. The trigger depends_on the binding so the binding propagates
+//      before the trigger create call fires.
+//
+// A regression that drops any of those three pieces leaves customers
+// hitting INVALID_ARGUMENT on every fresh-project deploy.
+func TestGetPresetFiles_GCP_CloudBuild_HasWebhookSecretIAM(t *testing.T) {
+	t.Parallel()
+	files, err := newTestClient().GetPresetFiles("gcp/cloud_build")
+	require.NoError(t, err)
+
+	mainTF, ok := files["/main.tf"]
+	require.True(t, ok, "gcp/cloud_build must include main.tf")
+	body := string(mainTF)
+
+	// (1) Project number lookup with depends_on on the API enable.
+	require.Contains(t, body, `data "google_project" "this"`,
+		"gcp/cloud_build/main.tf must look up data.google_project.this for the P4SA project number (issue #190)")
+
+	// (2) IAM binding granting secretAccessor on the webhook secret.
+	require.Contains(t, body, `resource "google_secret_manager_secret_iam_member" "cloudbuild_webhook_accessor"`,
+		"gcp/cloud_build/main.tf must declare google_secret_manager_secret_iam_member.cloudbuild_webhook_accessor (issue #190)")
+	require.Contains(t, body, `roles/secretmanager.secretAccessor`,
+		"gcp/cloud_build/main.tf must grant roles/secretmanager.secretAccessor on the webhook secret (issue #190)")
+	require.Contains(t, body, `gcp-sa-cloudbuild.iam.gserviceaccount.com`,
+		"gcp/cloud_build/main.tf must target the Cloud Build P4SA service-{PROJECT_NUMBER}@gcp-sa-cloudbuild (issue #190)")
+
+	// (3) The trigger depends on the IAM binding so propagation happens
+	// before trigger create fires. A trigger that only depends on the
+	// API enable still races the IAM propagation.
+	require.Contains(t, body, "google_secret_manager_secret_iam_member.cloudbuild_webhook_accessor",
+		"gcp/cloud_build/main.tf trigger must depend_on the IAM binding (issue #190)")
 }


### PR DESCRIPTION
## Summary

Two GCP fixes bundled — KMS upstream replacement (the permanent fix for the slice-end-index class tracked in #182) plus the urgent cloud_build webhook trigger fix (#190).

### gcp/kms (#182, non-urgent permanent fix)

Replaces \`terraform-google-modules/kms/google\` ~> 3.0 with direct \`google_kms_key_ring\` + two \`for_each\`-keyed \`google_kms_crypto_key\` resources (\`protected\`/\`ephemeral\`, gated by \`var.prevent_destroy\`). The upstream's \`local.keys_by_name\` calls \`slice()\` on a count-controlled splat which errors during plan against an empty state.

PR #181 surgically wrapped the consumer in \`try(module.kms.keys, {})\` to unblock the default-config customer in #178's repro, but \`iam_bindings\` still referenced the slice expression directly so non-default users hit a hole. The \`for_each\` replacement eliminates the slice expression and closes the hole **by construction** — no \`try()\` rescue needed.

**State migration:** three \`moved {}\` blocks rebind the default-config upstream addresses (\`module.kms.google_kms_key_ring.key_ring\`, \`module.kms.google_kms_crypto_key.{key,key_ephemeral}[0]\`) to the new direct-resource addresses (\`google_kms_key_ring.this\`, \`google_kms_crypto_key.{protected,ephemeral}[\"default\"]\`). Customers with non-default \`var.keys\` must run a one-time \`terraform state mv\` recipe (documented inline in the header comment of \`gcp/kms/main.tf\`) before applying — the \`prevent_destroy = true\` lifecycle is the safety net if they don't.

### gcp/cloud_build (#190, urgent fix)

\`google_cloudbuild_trigger\` validates webhook secret access on the create call. Without an IAM binding granting \`roles/secretmanager.secretAccessor\` on the webhook secret to the Cloud Build P4SA (\`service-PROJECT_NUMBER@gcp-sa-cloudbuild.iam.gserviceaccount.com\`), the create rejects with \`400 INVALID_ARGUMENT: Request contains an invalid argument\`. This blocks every fresh-project deploy that includes \`gcp_cloud_build\`.

Adds:
1. \`data "google_project" "this"\` resolving the project number after-enable.
2. \`google_secret_manager_secret_iam_member.cloudbuild_webhook_accessor\` granting \`secretAccessor\` on the webhook secret.
3. \`depends_on\` from the trigger to the IAM binding so propagation completes before the create call.

Resolves project number via \`data.google_project\` rather than adopting the \`google-beta\` provider just for \`google_project_service_identity\` (one-binding scope doesn't justify a new provider dependency).

## Tests

**Module-level (\`terraform test\`, mock_provider):**
- \`gcp/kms/tests/kms.tftest.hcl\`: 14 cases pass. Existing cases retained; added \`issue_182_prevent_destroy_{true,false}_uses_{protected,ephemeral}_branch\` asserting the \`for_each\` split fires on the right resource.
- \`gcp/cloud_build/tests/cloud_build.tftest.hcl\` (new): 2 cases pass. Pins the IAM binding role at plan time. The SA-email shape is plan-unknown under mock_provider (depends on \`data.google_project\` computed value), so it's pinned by the structural test in \`pkg/composer/compose_vm_test.go\`.

**Composer (Go):**
- \`TestGetPresetFiles_GCP_KMS_NoUpstreamModule\` replaces the PR #181 \`try()\` structural pin. Asserts (against comment-stripped HCL): no upstream source, no \`module \"kms\"\` block, no \`slice(\`, no \`try(module.kms\` wrap, the three replacement resources are present, and ≥3 \`moved {}\` blocks exist.
- \`TestGetPresetFiles_GCP_CloudBuild_HasWebhookSecretIAM\` (new) pins the data source, IAM binding resource, role, P4SA email shape, and the trigger's \`depends_on\`.
- \`TestComposeStack_GCPCloudKMS_TerraformValidate\` (new) is the formal closure for #182: runs \`terraform init\` + \`terraform validate\` against composed empty-state stacks. Two sub-cases — \`kms alone\` and \`kms with iam_bindings\` (the gap PR #181 left open). Mirrors \`TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate\` which closed #178's analogous criterion.

## Test plan

- [x] \`terraform fmt -check -recursive\` passes
- [x] \`bash tests/lint-{project-tag,project-label,sensitive-for-each,foreach-unknown-keys}.sh\` all PASS
- [x] \`terraform test\` passes in \`gcp/kms\` (14/14) and \`gcp/cloud_build\` (2/2)
- [x] \`go test ./pkg/composer/ -short\` passes (51s)
- [x] \`TestComposeStack_GCPCloudKMS_TerraformValidate\` passes both sub-cases against real \`terraform init\`+\`validate\` (18s)
- [x] \`TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate\` still passes (regression check)
- [x] All 53 modules pass \`terraform validate\` (\`/verify\` quick mode)
- [ ] CI checks pass
- [ ] Manual sandbox apply: previous preset → upgrade → \`terraform plan\` shows \"No changes\" (the only way to actually exercise the \`moved {}\` blocks against real state — CI cannot reproduce a real prior state)

## Acceptance criteria (#182)

- [x] Fresh GCP session with default config plans cleanly on first run with empty state.
- [x] Fresh GCP session with non-default \`var.iam_bindings\` plans cleanly on first run with empty state (the gap PR #181 leaves open).
- [x] Regression tests added in PR #181 (\`issue_180_*\`) keep passing.
- [x] Integration test mirroring \`TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate\` for \`gcp/kms\` against empty state passes.
- [ ] Existing customers' state migrates without replace plans — verified via the manual sandbox step above.

## Known migration risk

Customers with **non-default** \`var.keys\` (e.g. \`[{name=\"data\"},{name=\"logs\"}]\`) must run \`terraform state mv\` before applying. The \`moved {}\` blocks shipped only cover \`var.keys = [{name=\"default\"}]\`. The migration recipe is in the header comment of \`gcp/kms/main.tf\` so it flows into the composed stack via embed.FS. If a non-default customer applies without state-mv, the \`prevent_destroy = true\` lifecycle catches the destroy attempt and the plan errors loudly — no data loss.

Closes #182
Closes #190