### PR TITLE
feat(composer): co-locate per-component IAM maps with ModulePath

### DIFF
--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -1,0 +1,178 @@
+package composer
+
+import "sort"
+
+// AlwaysRequiredAWSIAMActions are the IAM actions every AWS deploy needs,
+// regardless of which composer components the caller selects.
+//   - sts:GetCallerIdentity — terraform's AWS provider calls this on init.
+//   - iam:CreateRole / iam:PassRole — every stack provisions at least one
+//     service-linked role and passes it to a downstream resource.
+//   - iam:CreatePolicy / iam:AttachRolePolicy — paired with CreateRole
+//     for the policies the role consumes.
+//
+// Source of truth ui-core consumes (issue #192). Sorted output from
+// RequiredAWSIAMActions keeps SimulatePrincipalPolicy input deterministic.
+var AlwaysRequiredAWSIAMActions = []string{
+	"iam:AttachRolePolicy",
+	"iam:CreatePolicy",
+	"iam:CreateRole",
+	"iam:PassRole",
+	"sts:GetCallerIdentity",
+}
+
+// AWSIAMActions maps composer ComponentKey to the IAM actions the caller's
+// principal needs to apply that component's terraform module on AWS. Values
+// are representative create-time actions — SimulatePrincipalPolicy returns
+// DENIED if the caller can't perform any one of them, which is sufficient
+// to fail fast before terraform apply.
+//
+// Source of truth for ui-core's awsComponentToIAMActions (issue #192).
+// Every AWS-backed key in AllComponentKeys must have an entry here; the
+// drift-guard test (TestAWSIAMActions_CoverAllAWSKeys) fails the package
+// build otherwise. nil values are permitted for forward-compat.
+//
+// Polymorphic keys: KeyAWSEKSNodeGroup ("ec2") and KeyAWSEKSControlPlane
+// ("resource") share their cloud-prefixed siblings' actions. The
+// EKSControlPlane entry lists eks:CreateCluster (its default route); the
+// Lambda runtime variant is covered separately by KeyAWSLambda — caller
+// resolution happens in GetModuleDir, but IAM is declared per-key here.
+var AWSIAMActions = map[ComponentKey][]string{
+	KeyAWSVPC:                  {"ec2:AllocateAddress", "ec2:CreateInternetGateway", "ec2:CreateNatGateway", "ec2:CreateRouteTable", "ec2:CreateSubnet", "ec2:CreateVpc"},
+	KeyAWSBastion:              {"ec2:RunInstances"},
+	KeyAWSEC2:                  {"ec2:RunInstances"},
+	KeyAWSEKS:                  {"eks:CreateCluster", "eks:CreateNodegroup"},
+	KeyAWSEKSControlPlane:      {"eks:CreateCluster"},   // polymorphic; Lambda variant via KeyAWSLambda
+	KeyAWSEKSNodeGroup:         {"eks:CreateNodegroup"}, // polymorphic
+	KeyAWSECS:                  {"ecs:CreateCluster", "ecs:CreateService"},
+	KeyAWSLambda:               {"lambda:CreateFunction"},
+	KeyAWSALB:                  {"elasticloadbalancing:CreateLoadBalancer", "elasticloadbalancing:CreateTargetGroup"},
+	KeyAWSCloudfront:           {"cloudfront:CreateDistribution"},
+	KeyAWSWAF:                  {"wafv2:CreateWebACL"},
+	KeyAWSAPIGateway:           {"apigateway:POST"},
+	KeyAWSRDS:                  {"rds:CreateDBInstance", "rds:CreateDBSubnetGroup"},
+	KeyAWSElastiCache:          {"elasticache:CreateCacheCluster"},
+	KeyAWSDynamoDB:             {"dynamodb:CreateTable"},
+	KeyAWSS3:                   {"s3:CreateBucket"},
+	KeyAWSKMS:                  {"kms:CreateAlias", "kms:CreateKey"},
+	KeyAWSSecretsManager:       {"secretsmanager:CreateSecret"},
+	KeyAWSOpenSearch:           {"es:CreateDomain"},
+	KeyAWSBedrock:              {"bedrock:GetFoundationModel"},
+	KeyAWSSQS:                  {"sqs:CreateQueue"},
+	KeyAWSMSK:                  {"kafka:CreateClusterV2"},
+	KeyAWSCloudWatchLogs:       {"logs:CreateLogGroup"},
+	KeyAWSCloudWatchMonitoring: {"cloudwatch:PutMetricAlarm"},
+	KeyAWSGrafana:              {"grafana:CreateWorkspace"},
+	KeyAWSCognito:              {"cognito-idp:CreateUserPool"},
+	KeyAWSBackups:              {"backup:CreateBackupPlan", "backup:CreateBackupVault"},
+	KeyAWSGitHubActions:        {"iam:CreateOpenIDConnectProvider"},
+	KeyAWSCodePipeline:         {"codepipeline:CreatePipeline"},
+}
+
+// RequiredAWSIAMActions returns the deduplicated, sorted list of IAM
+// actions the caller's principal needs on the target account to deploy the
+// given components, including AlwaysRequiredAWSIAMActions. Stable order
+// keeps SimulatePrincipalPolicy input deterministic and lets test
+// snapshots compare cleanly. Unknown component keys are silently ignored
+// (forward-compat: a presets release introducing a new component shouldn't
+// break in-flight deploys here).
+func RequiredAWSIAMActions(components []ComponentKey) []string {
+	want := len(AlwaysRequiredAWSIAMActions) + len(components)
+	seen := make(map[string]bool, want)
+	out := make([]string, 0, want)
+	add := func(a string) {
+		if seen[a] {
+			return
+		}
+		seen[a] = true
+		out = append(out, a)
+	}
+	for _, a := range AlwaysRequiredAWSIAMActions {
+		add(a)
+	}
+	for _, c := range components {
+		for _, a := range AWSIAMActions[c] {
+			add(a)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// AlwaysRequiredGCPIAMPermissions are the IAM permissions the SA needs on
+// the target project for any Luther GCP deploy:
+//   - resourcemanager.projects.get — read project metadata.
+//   - iam.serviceAccounts.actAs — terraform impersonates SAs it creates.
+//   - compute.networks.create — every stack creates at least a VPC.
+//
+// Source of truth ui-core consumes (issue #192).
+var AlwaysRequiredGCPIAMPermissions = []string{
+	"compute.networks.create",
+	"iam.serviceAccounts.actAs",
+	"resourcemanager.projects.get",
+}
+
+// GCPIAMPermissions maps composer ComponentKey to the IAM permissions the
+// SA needs on the target project to apply each component's terraform
+// module. Values are representative create-permissions — testIamPermissions
+// checks the SA has at least the create capability, which is sufficient to
+// fail fast before terraform apply.
+//
+// Source of truth for ui-core's gcpComponentToIAMPermissions (issue #192).
+// Every GCP-backed key in AllComponentKeys must have an entry here; the
+// drift-guard test (TestGCPIAMPermissions_CoverAllGCPKeys) fails the
+// package build otherwise. nil values are permitted and used for
+// components already covered by AlwaysRequiredGCPIAMPermissions.
+var GCPIAMPermissions = map[ComponentKey][]string{
+	KeyGCPCloudKMS:         {"cloudkms.keyRings.create"},
+	KeyGCPCloudSQL:         {"cloudsql.instances.create"},
+	KeyGCPGKE:              {"container.clusters.create"},
+	KeyGCPGCS:              {"storage.buckets.create"},
+	KeyGCPCloudRun:         {"run.services.create"},
+	KeyGCPCloudFunctions:   {"cloudfunctions.functions.create"},
+	KeyGCPPubSub:           {"pubsub.topics.create"},
+	KeyGCPMemorystore:      {"redis.instances.create"},
+	KeyGCPSecretManager:    {"secretmanager.secrets.create"},
+	KeyGCPCloudLogging:     {"logging.logEntries.create"},
+	KeyGCPCloudMonitoring:  {"monitoring.alertPolicies.create"},
+	KeyGCPIdentityPlatform: {"identityplatform.config.update"},
+	KeyGCPCloudBuild:       {"cloudbuild.builds.create"},
+	KeyGCPFirestore:        {"datastore.databases.create"},
+	KeyGCPVertexAI:         {"aiplatform.endpoints.create"},
+	KeyGCPAPIGateway:       {"apigateway.gateways.create"},
+	KeyGCPBackups:          {"backupdr.managementServers.create"},
+	// Components that need no extra permission beyond the always-required set:
+	KeyGCPVPC:          nil,
+	KeyGCPCompute:      nil,
+	KeyGCPBastion:      nil,
+	KeyGCPLoadbalancer: nil, // covered by always-required compute.networks.create.
+	KeyGCPCloudCDN:     nil, // covered by always-required compute.networks.create.
+	KeyGCPCloudArmor:   nil, // covered by always-required compute.networks.create.
+}
+
+// RequiredGCPIAMPermissions returns the deduplicated, sorted list of IAM
+// permissions the SA needs on the target project to deploy the given
+// components, including AlwaysRequiredGCPIAMPermissions. Stable order
+// keeps testIamPermissions input deterministic. Unknown component keys
+// are silently ignored (forward-compat).
+func RequiredGCPIAMPermissions(components []ComponentKey) []string {
+	want := len(AlwaysRequiredGCPIAMPermissions) + len(components)
+	seen := make(map[string]bool, want)
+	out := make([]string, 0, want)
+	add := func(p string) {
+		if seen[p] {
+			return
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	for _, p := range AlwaysRequiredGCPIAMPermissions {
+		add(p)
+	}
+	for _, c := range components {
+		for _, p := range GCPIAMPermissions[c] {
+			add(p)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/composer/iam_actions_test.go
+++ b/pkg/composer/iam_actions_test.go
@@ -1,0 +1,186 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAWSIAMActions_CoverAllAWSKeys ensures every AWS-backed ComponentKey
+// in AllComponentKeys has an entry (possibly nil) in AWSIAMActions. New AWS
+// components added without an IAM entry break this test loudly — without
+// it, ui-core's preflight would silently skip the new component's IAM
+// requirements and let terraform apply fail at AWS instead.
+//
+// We walk AllComponentKeys rather than ModulePath because the former is
+// the canonical "user-selectable component" registry: it includes the
+// polymorphic KeyAWSEKSControlPlane / KeyAWSEKSNodeGroup keys (so
+// preflight covers them), and excludes third-party toggles like
+// KeySplunk / KeyDatadog that have no Luther-managed AWS IAM surface.
+func TestAWSIAMActions_CoverAllAWSKeys(t *testing.T) {
+	for _, k := range AllComponentKeys {
+		if CloudFor(k) != "aws" {
+			continue
+		}
+		_, ok := AWSIAMActions[k]
+		assert.True(t, ok,
+			"AWSIAMActions is missing %s — preflight will silently skip it; add an entry (nil is permitted) in pkg/composer/iam_actions.go",
+			k)
+	}
+}
+
+// TestAWSIAMActions_NoUnknownKeys ensures every key in AWSIAMActions
+// resolves to a known AWS ComponentKey in AllComponentKeys. Catches typos
+// and stale entries left behind after a key rename or removal.
+func TestAWSIAMActions_NoUnknownKeys(t *testing.T) {
+	known := allComponentKeysSet()
+	for k := range AWSIAMActions {
+		assert.True(t, known[k],
+			"AWSIAMActions[%s] is not in AllComponentKeys — stale or typo'd key; remove or fix in pkg/composer/iam_actions.go",
+			k)
+		assert.Equal(t, "aws", CloudFor(k),
+			"AWSIAMActions[%s] resolves to non-aws cloud — only AWS keys belong here",
+			k)
+	}
+}
+
+// TestGCPIAMPermissions_CoverAllGCPKeys is the GCP analog of
+// TestAWSIAMActions_CoverAllAWSKeys.
+func TestGCPIAMPermissions_CoverAllGCPKeys(t *testing.T) {
+	for _, k := range AllComponentKeys {
+		if CloudFor(k) != "gcp" {
+			continue
+		}
+		_, ok := GCPIAMPermissions[k]
+		assert.True(t, ok,
+			"GCPIAMPermissions is missing %s — preflight will silently skip it; add an entry (nil is permitted) in pkg/composer/iam_actions.go",
+			k)
+	}
+}
+
+// TestGCPIAMPermissions_NoUnknownKeys is the GCP analog of
+// TestAWSIAMActions_NoUnknownKeys.
+func TestGCPIAMPermissions_NoUnknownKeys(t *testing.T) {
+	known := allComponentKeysSet()
+	for k := range GCPIAMPermissions {
+		assert.True(t, known[k],
+			"GCPIAMPermissions[%s] is not in AllComponentKeys — stale or typo'd key; remove or fix in pkg/composer/iam_actions.go",
+			k)
+		assert.Equal(t, "gcp", CloudFor(k),
+			"GCPIAMPermissions[%s] resolves to non-gcp cloud — only GCP keys belong here",
+			k)
+	}
+}
+
+// allComponentKeysSet returns AllComponentKeys as a presence map for the
+// reverse-direction drift-guard tests.
+func allComponentKeysSet() map[ComponentKey]bool {
+	out := make(map[ComponentKey]bool, len(AllComponentKeys))
+	for _, k := range AllComponentKeys {
+		out[k] = true
+	}
+	return out
+}
+
+// TestRequiredAWSIAMActions_AlwaysIncluded confirms the always-required set
+// is returned even when no components are passed.
+func TestRequiredAWSIAMActions_AlwaysIncluded(t *testing.T) {
+	got := RequiredAWSIAMActions(nil)
+	for _, want := range AlwaysRequiredAWSIAMActions {
+		assert.Contains(t, got, want,
+			"RequiredAWSIAMActions(nil) must include always-required action %q", want)
+	}
+}
+
+// TestRequiredGCPIAMPermissions_AlwaysIncluded confirms the always-required
+// set is returned even when no components are passed.
+func TestRequiredGCPIAMPermissions_AlwaysIncluded(t *testing.T) {
+	got := RequiredGCPIAMPermissions(nil)
+	for _, want := range AlwaysRequiredGCPIAMPermissions {
+		assert.Contains(t, got, want,
+			"RequiredGCPIAMPermissions(nil) must include always-required permission %q", want)
+	}
+}
+
+// TestRequiredAWSIAMActions_DedupsAcrossComponents verifies overlapping
+// per-component entries collapse to a single output entry. KeyAWSBastion
+// and KeyAWSEC2 both declare "ec2:RunInstances".
+func TestRequiredAWSIAMActions_DedupsAcrossComponents(t *testing.T) {
+	got := RequiredAWSIAMActions([]ComponentKey{KeyAWSBastion, KeyAWSEC2})
+	count := 0
+	for _, a := range got {
+		if a == "ec2:RunInstances" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count,
+		"ec2:RunInstances should appear exactly once in RequiredAWSIAMActions output, got %d (full output: %v)",
+		count, got)
+}
+
+// TestRequiredGCPIAMPermissions_DedupsAcrossComponents verifies overlapping
+// per-component entries collapse to a single output entry.
+func TestRequiredGCPIAMPermissions_DedupsAcrossComponents(t *testing.T) {
+	got := RequiredGCPIAMPermissions([]ComponentKey{KeyGCPVPC, KeyGCPVPC, KeyGCPCloudKMS, KeyGCPCloudKMS})
+	count := 0
+	for _, p := range got {
+		if p == "cloudkms.keyRings.create" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count,
+		"cloudkms.keyRings.create should appear exactly once in RequiredGCPIAMPermissions output, got %d (full output: %v)",
+		count, got)
+}
+
+// TestRequiredAWSIAMActions_StableOrder verifies output is sorted, so
+// SimulatePrincipalPolicy input is deterministic across runs.
+func TestRequiredAWSIAMActions_StableOrder(t *testing.T) {
+	got := RequiredAWSIAMActions([]ComponentKey{KeyAWSS3, KeyAWSVPC, KeyAWSKMS, KeyAWSALB})
+	for i := 1; i < len(got); i++ {
+		assert.LessOrEqual(t, got[i-1], got[i],
+			"RequiredAWSIAMActions output must be sorted; %q > %q at index %d (full: %v)",
+			got[i-1], got[i], i-1, got)
+	}
+}
+
+// TestRequiredGCPIAMPermissions_StableOrder verifies output is sorted, so
+// testIamPermissions input is deterministic across runs.
+func TestRequiredGCPIAMPermissions_StableOrder(t *testing.T) {
+	got := RequiredGCPIAMPermissions([]ComponentKey{KeyGCPGCS, KeyGCPCloudKMS, KeyGCPGKE, KeyGCPPubSub})
+	for i := 1; i < len(got); i++ {
+		assert.LessOrEqual(t, got[i-1], got[i],
+			"RequiredGCPIAMPermissions output must be sorted; %q > %q at index %d (full: %v)",
+			got[i-1], got[i], i-1, got)
+	}
+}
+
+// TestRequiredAWSIAMActions_UnknownComponentIgnored verifies forward-compat:
+// a future composer release introducing a new ComponentKey shouldn't break
+// in-flight ui-core deploys that pass that key here.
+func TestRequiredAWSIAMActions_UnknownComponentIgnored(t *testing.T) {
+	const phantom ComponentKey = "aws_does_not_exist_yet"
+	got := RequiredAWSIAMActions([]ComponentKey{phantom, KeyAWSS3})
+	assert.Contains(t, got, "s3:CreateBucket",
+		"RequiredAWSIAMActions should still return known-key actions when an unknown key is mixed in: %v",
+		got)
+	for _, a := range AlwaysRequiredAWSIAMActions {
+		assert.Contains(t, got, a,
+			"RequiredAWSIAMActions should still return always-required actions when an unknown key is mixed in: missing %q (full: %v)",
+			a, got)
+	}
+}
+
+// TestRequiredGCPIAMPermissions_UnknownComponentIgnored is the GCP analog.
+func TestRequiredGCPIAMPermissions_UnknownComponentIgnored(t *testing.T) {
+	const phantom ComponentKey = "gcp_does_not_exist_yet"
+	got := RequiredGCPIAMPermissions([]ComponentKey{phantom, KeyGCPGCS})
+	assert.Contains(t, got, "storage.buckets.create",
+		"RequiredGCPIAMPermissions should still return known-key permissions when an unknown key is mixed in: %v",
+		got)
+	for _, p := range AlwaysRequiredGCPIAMPermissions {
+		assert.Contains(t, got, p,
+			"RequiredGCPIAMPermissions should still return always-required permissions when an unknown key is mixed in: missing %q (full: %v)",
+			p, got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add exported `AWSIAMActions` and `GCPIAMPermissions` (typed `map[ComponentKey][]string`), their always-required slices, and dedup+sort aggregator funcs (`RequiredAWSIAMActions` / `RequiredGCPIAMPermissions`) to `pkg/composer/iam_actions.go`. Source of truth ui-core consumes via its preflight (issue #192).
- Drift guards (`pkg/composer/iam_actions_test.go`, 12 tests) walk `AllComponentKeys` filtered by `CloudFor`: every selectable component must have an entry (nil permitted), every map key must round-trip back to `AllComponentKeys` to catch typos. Adding a new component without an IAM entry now fails this package's own tests.
- Polymorphic AWS keys (`KeyAWSEKSControlPlane="resource"`, `KeyAWSEKSNodeGroup="ec2"`) get explicit IAM entries — stronger invariant than ui-core's existing `aws_`-prefix filter, which silently skipped them.
- GCP aggregator now sorts its output (small change vs. ui-core's GCP variant; matches AWS variant for deterministic `testIamPermissions` input).
- Pure additive change. No existing composer file modified, no API breaks. ui-core consumes the new symbols in a follow-up PR (bumps the dep, swaps in `composer.AWSIAMActions` / `composer.GCPIAMPermissions` / `composer.Required*`, retires the local maps and the weak `*KeysAreKnownComposerKeys` drift guards).

Closes #192

## Test plan

- [x] `go vet ./pkg/composer/...` clean
- [x] `go test ./pkg/composer/...` (full package, 82s) — passes
- [x] 12 new tests pass: `TestAWSIAMActions_*`, `TestGCPIAMPermissions_*`, `TestRequired{AWS,GCP}IAMActions/Permissions_*`
- [x] `terraform fmt -check -recursive` clean
- [x] All four static lint scripts (`lint-project-tag.sh`, `lint-project-label.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`) — PASS