### PR TITLE
feat(composer): export GCP service-enablement preflight maps

### DIFF
--- a/pkg/composer/gcp_services.go
+++ b/pkg/composer/gcp_services.go
@@ -1,0 +1,116 @@
+package composer
+
+import "sort"
+
+// GCPService describes a single GCP service (a.k.a. API) that must be
+// enabled on the target project for a Luther terraform module to apply
+// cleanly. Name is what serviceusage.batchGet expects; Title is the
+// human-readable form rendered in ui-core's "missing APIs" banner.
+type GCPService struct {
+	// Name is the service identifier, e.g. "compute.googleapis.com".
+	Name string
+	// Title is the display label, e.g. "Compute Engine".
+	Title string
+}
+
+// AlwaysRequiredGCPServices are the services every Luther GCP deploy needs,
+// regardless of which composer components the caller selects:
+//   - Service Usage itself (required for the batchGet pre-flight to work).
+//   - Cloud Resource Manager (terraform reads project metadata).
+//   - IAM (every stack mints a service account or IAM binding).
+//   - Compute (we always create at least a VPC).
+//
+// Source of truth ui-core consumes (issue #195). Values are copied verbatim
+// from ui-core's prior alwaysRequiredGCPAPIs.
+var AlwaysRequiredGCPServices = []GCPService{
+	{Name: "serviceusage.googleapis.com", Title: "Service Usage"},
+	{Name: "cloudresourcemanager.googleapis.com", Title: "Cloud Resource Manager"},
+	{Name: "iam.googleapis.com", Title: "Identity and Access Management"},
+	{Name: "compute.googleapis.com", Title: "Compute Engine"},
+}
+
+// GCPServices maps composer ComponentKey to the GCP services the target
+// project must have enabled to apply that component's terraform module.
+// Values are the service names accepted by serviceusage.batchGet plus a
+// human-readable Title for the UI surface that lists missing APIs.
+//
+// Source of truth for ui-core's prior gcpComponentToAPIs (issue #195).
+// Every GCP-backed key in AllComponentKeys must have an entry here; the
+// drift-guard test (TestGCPServices_CoverAllGCPKeys) fails the package
+// build otherwise. nil values are permitted and used for components
+// already covered by AlwaysRequiredGCPServices (e.g. the load balancer is
+// covered by Compute Engine).
+var GCPServices = map[ComponentKey][]GCPService{
+	KeyGCPCloudKMS: {{Name: "cloudkms.googleapis.com", Title: "Cloud KMS"}},
+	KeyGCPCloudSQL: {{Name: "sqladmin.googleapis.com", Title: "Cloud SQL Admin"}},
+	KeyGCPGKE:      {{Name: "container.googleapis.com", Title: "Kubernetes Engine"}},
+	KeyGCPGCS:      {{Name: "storage.googleapis.com", Title: "Cloud Storage"}},
+	KeyGCPCloudRun: {{Name: "run.googleapis.com", Title: "Cloud Run"}},
+	KeyGCPCloudFunctions: {
+		{Name: "cloudfunctions.googleapis.com", Title: "Cloud Functions"},
+		// Cloud Functions Gen 2 builds container images via Cloud Build.
+		{Name: "cloudbuild.googleapis.com", Title: "Cloud Build"},
+		// Serverless VPC Access connectors are required when functions
+		// egress into a VPC.
+		{Name: "vpcaccess.googleapis.com", Title: "Serverless VPC Access"},
+	},
+	KeyGCPPubSub:           {{Name: "pubsub.googleapis.com", Title: "Pub/Sub"}},
+	KeyGCPMemorystore:      {{Name: "redis.googleapis.com", Title: "Memorystore for Redis"}},
+	KeyGCPSecretManager:    {{Name: "secretmanager.googleapis.com", Title: "Secret Manager"}},
+	KeyGCPCloudLogging:     {{Name: "logging.googleapis.com", Title: "Cloud Logging"}},
+	KeyGCPCloudMonitoring:  {{Name: "monitoring.googleapis.com", Title: "Cloud Monitoring"}},
+	KeyGCPIdentityPlatform: {{Name: "identitytoolkit.googleapis.com", Title: "Identity Toolkit"}},
+	KeyGCPCloudBuild:       {{Name: "cloudbuild.googleapis.com", Title: "Cloud Build"}},
+	KeyGCPFirestore:        {{Name: "firestore.googleapis.com", Title: "Cloud Firestore"}},
+	KeyGCPVertexAI:         {{Name: "aiplatform.googleapis.com", Title: "Vertex AI"}},
+	KeyGCPAPIGateway: {
+		{Name: "apigateway.googleapis.com", Title: "API Gateway"},
+		// API Gateway plane requires both Service Control (request
+		// gating) and Service Management (managed-service config push).
+		// Without these enabled, terraform fails on the first
+		// managed-service create.
+		{Name: "servicecontrol.googleapis.com", Title: "Service Control"},
+		{Name: "servicemanagement.googleapis.com", Title: "Service Management"},
+	},
+	KeyGCPBackups: {{Name: "backupdr.googleapis.com", Title: "Backup and DR Service"}},
+	// Components that need no extra service beyond the always-required set
+	// (covered by Compute / always-required entries):
+	KeyGCPVPC:          nil,
+	KeyGCPCompute:      nil,
+	KeyGCPBastion:      nil,
+	KeyGCPLoadbalancer: nil, // covered by always-required Compute Engine.
+	KeyGCPCloudCDN:     nil, // covered by always-required Compute Engine.
+	KeyGCPCloudArmor:   nil, // covered by always-required Compute Engine.
+}
+
+// RequiredGCPServices returns the deduplicated list of GCP services the
+// target project must have enabled to deploy the given components,
+// including AlwaysRequiredGCPServices. Output is sorted by Name so
+// serviceusage.batchGet input is deterministic and test snapshots compare
+// cleanly. Unknown component keys are silently ignored (forward-compat: a
+// presets release introducing a new component shouldn't break in-flight
+// consumers).
+func RequiredGCPServices(components []ComponentKey) []GCPService {
+	want := len(AlwaysRequiredGCPServices) + 2*len(components)
+	seen := make(map[string]bool, want)
+	out := make([]GCPService, 0, want)
+
+	add := func(s GCPService) {
+		if seen[s.Name] {
+			return
+		}
+		seen[s.Name] = true
+		out = append(out, s)
+	}
+
+	for _, s := range AlwaysRequiredGCPServices {
+		add(s)
+	}
+	for _, c := range components {
+		for _, s := range GCPServices[c] {
+			add(s)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/pkg/composer/gcp_services_test.go
+++ b/pkg/composer/gcp_services_test.go
@@ -1,0 +1,144 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGCPServices_CoverAllGCPKeys ensures every GCP-backed ComponentKey in
+// AllComponentKeys has an entry (possibly nil) in GCPServices. New GCP
+// components added without a service entry break this test loudly —
+// without it, ui-core's preflight would silently skip the new component's
+// service-enablement requirements and let terraform apply fail at GCP
+// instead. Mirrors TestGCPIAMPermissions_CoverAllGCPKeys.
+func TestGCPServices_CoverAllGCPKeys(t *testing.T) {
+	for _, k := range AllComponentKeys {
+		if CloudFor(k) != "gcp" {
+			continue
+		}
+		_, ok := GCPServices[k]
+		assert.True(t, ok,
+			"GCPServices is missing %s — preflight will silently skip it; add an entry (nil is permitted) in pkg/composer/gcp_services.go",
+			k)
+	}
+}
+
+// TestGCPServices_NoUnknownKeys ensures every key in GCPServices resolves
+// to a known GCP ComponentKey in AllComponentKeys. Catches typos and
+// stale entries left behind after a key rename or removal. Mirrors
+// TestGCPIAMPermissions_NoUnknownKeys.
+func TestGCPServices_NoUnknownKeys(t *testing.T) {
+	known := allComponentKeysSet()
+	for k := range GCPServices {
+		assert.True(t, known[k],
+			"GCPServices[%s] is not in AllComponentKeys — stale or typo'd key; remove or fix in pkg/composer/gcp_services.go",
+			k)
+		assert.Equal(t, "gcp", CloudFor(k),
+			"GCPServices[%s] resolves to non-gcp cloud — only GCP keys belong here",
+			k)
+	}
+}
+
+// TestGCPServices_EntryHasName ensures every non-nil service entry carries
+// a non-empty Name. A blank Name would silently disable the preflight for
+// that component.
+func TestGCPServices_EntryHasName(t *testing.T) {
+	for k, services := range GCPServices {
+		for i, s := range services {
+			assert.NotEmpty(t, s.Name,
+				"GCPServices[%s][%d].Name is empty; serviceusage.batchGet would skip it",
+				k, i)
+		}
+	}
+	for i, s := range AlwaysRequiredGCPServices {
+		assert.NotEmpty(t, s.Name,
+			"AlwaysRequiredGCPServices[%d].Name is empty; serviceusage.batchGet would skip it",
+			i)
+	}
+}
+
+// TestRequiredGCPServices_AlwaysIncluded confirms the always-required set
+// is returned even when no components are passed.
+func TestRequiredGCPServices_AlwaysIncluded(t *testing.T) {
+	got := RequiredGCPServices(nil)
+	gotNames := make(map[string]bool, len(got))
+	for _, s := range got {
+		gotNames[s.Name] = true
+	}
+	for _, want := range AlwaysRequiredGCPServices {
+		assert.True(t, gotNames[want.Name],
+			"RequiredGCPServices(nil) must include always-required service %q (full output: %v)",
+			want.Name, got)
+	}
+}
+
+// TestRequiredGCPServices_DedupsAcrossComponents verifies overlapping
+// per-component entries collapse to a single output entry.
+// KeyGCPCloudFunctions and KeyGCPCloudBuild both declare
+// "cloudbuild.googleapis.com". Mirrors
+// TestRequiredGCPIAMPermissions_DedupsAcrossComponents and additionally
+// covers duplicate keys in the input slice (caller passes [A, A, B, B]).
+func TestRequiredGCPServices_DedupsAcrossComponents(t *testing.T) {
+	got := RequiredGCPServices([]ComponentKey{
+		KeyGCPCloudFunctions, KeyGCPCloudFunctions,
+		KeyGCPCloudBuild, KeyGCPCloudBuild,
+	})
+	count := 0
+	for _, s := range got {
+		if s.Name == "cloudbuild.googleapis.com" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count,
+		"cloudbuild.googleapis.com should appear exactly once in RequiredGCPServices output, got %d (full output: %v)",
+		count, got)
+}
+
+// TestRequiredGCPServices_DedupPreservesTitle verifies the dedup keeps the
+// declared Title for a service that appears under multiple components.
+// Important because ui-core's missing-APIs banner shows Title to end users
+// — a Title swap (e.g. to the empty string) would silently degrade the UI.
+func TestRequiredGCPServices_DedupPreservesTitle(t *testing.T) {
+	got := RequiredGCPServices([]ComponentKey{KeyGCPCloudFunctions, KeyGCPCloudBuild})
+	for _, s := range got {
+		if s.Name == "cloudbuild.googleapis.com" {
+			assert.Equal(t, "Cloud Build", s.Title,
+				"cloudbuild.googleapis.com Title should be preserved through dedup, got %q (full: %v)",
+				s.Title, got)
+			return
+		}
+	}
+	t.Fatalf("cloudbuild.googleapis.com missing from output: %v", got)
+}
+
+// TestRequiredGCPServices_StableOrder verifies output is sorted by Name
+// so serviceusage.batchGet input is deterministic across runs.
+func TestRequiredGCPServices_StableOrder(t *testing.T) {
+	got := RequiredGCPServices([]ComponentKey{KeyGCPGCS, KeyGCPCloudKMS, KeyGCPGKE, KeyGCPPubSub})
+	for i := 1; i < len(got); i++ {
+		assert.LessOrEqual(t, got[i-1].Name, got[i].Name,
+			"RequiredGCPServices output must be sorted by Name; %q > %q at index %d (full: %v)",
+			got[i-1].Name, got[i].Name, i-1, got)
+	}
+}
+
+// TestRequiredGCPServices_UnknownComponentIgnored verifies forward-compat:
+// a future composer release introducing a new ComponentKey shouldn't break
+// in-flight ui-core deploys that pass that key here.
+func TestRequiredGCPServices_UnknownComponentIgnored(t *testing.T) {
+	const phantom ComponentKey = "gcp_does_not_exist_yet"
+	got := RequiredGCPServices([]ComponentKey{phantom, KeyGCPGCS})
+	gotNames := make(map[string]bool, len(got))
+	for _, s := range got {
+		gotNames[s.Name] = true
+	}
+	assert.True(t, gotNames["storage.googleapis.com"],
+		"RequiredGCPServices should still return known-key services when an unknown key is mixed in: %v",
+		got)
+	for _, want := range AlwaysRequiredGCPServices {
+		assert.True(t, gotNames[want.Name],
+			"RequiredGCPServices should still return always-required services when an unknown key is mixed in: missing %q (full: %v)",
+			want.Name, got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/composer/gcp_services.go` exporting `GCPService`, `AlwaysRequiredGCPServices`, `GCPServices map[ComponentKey][]GCPService`, and `RequiredGCPServices(...)`. These are the per-component GCP API-enablement requirements consumed by `serviceusage.batchGet` in ui-core's pre-flight handler.
- Drift guards in `pkg/composer/gcp_services_test.go` fail the package build if a new GCP-backed `ComponentKey` lands in `AllComponentKeys` without a matching `GCPServices` entry — same structural guarantee that PR #194 introduced for AWS/GCP IAM.
- Completes the relocation begun in #194: AWS IAM and GCP IAM permissions co-located with `ModulePath` already; this PR moves the remaining GCP service-usage data so ui-core's `portal/oracle/gcp_services_apis.go` can be deleted in Phase 3 (ui-core#331).

Values are copied verbatim from ui-core's pre-existing `alwaysRequiredGCPAPIs` / `gcpComponentToAPIs` (single-line entries diff-checked byte-for-byte; multi-entry components `KeyGCPCloudFunctions` and `KeyGCPAPIGateway` reviewed manually). One intentional behavior tightening: `RequiredGCPServices` sorts output by `Name` so `serviceusage.batchGet` input is deterministic — ui-core's prior implementation returned iteration order. The downstream `serviceusage.batchGet` call is order-insensitive, so this is a strict upgrade.

## Test plan

- [x] `go test ./pkg/composer -count=1 -run "TestGCPServices|TestRequiredGCPServices" -v` — all 8 new tests pass
- [x] `go test ./pkg/composer/...` — full package suite green
- [x] `go build ./...` clean
- [x] `gofmt -l pkg/composer/gcp_services.go pkg/composer/gcp_services_test.go` — clean
- [x] `go vet ./pkg/composer/...` — clean
- [x] Drift-guard fault injection: removed `KeyGCPGCS` entry locally, confirmed `TestGCPServices_CoverAllGCPKeys` failed with `"GCPServices is missing gcp_gcs"`, restored

## Review notes

- `/review` findings: 0 P0, 0 P1, 1 P2 addressed (`_DedupPreservesTitle` tightened from `NotEmpty` to `assert.Equal "Cloud Build"`)
- qa-professor findings: 1 P2 deferred (see below), 1 P3 addressed (duplicate-key input now covered in `_DedupsAcrossComponents`, mirroring `iam_actions_test.go:124`'s pattern)
- No security findings — diff is exported static data + one pure function, no untrusted input or secret handling

## Deferred follow-ups

- **`_DedupPreservesTitle` cannot distinguish first-seen-wins from last-seen-wins.** Both colliding `cloudbuild.googleapis.com` declarations share Title `"Cloud Build"`, so a mutation swapping the dedup policy would survive the test. The current assertion does catch the realistic bug class (Title mutated to empty/wrong value); distinguishing the dedup direction would require either a refactor of `RequiredGCPServices` to accept an injected map (API expansion) or extracting the dedup loop into a testable helper. Disproportionate for a 5-line `if seen { return }` whose intent is obvious from the code. Leaving as-is; happy to address if reviewer disagrees.

Closes luthersystems/insideout-terraform-presets#195