### PR TITLE
fix(gcp): cloud_build BYOSA + identity_platform inline adoption (#201)

### DIFF
--- a/gcp/cloud_build/main.tf
+++ b/gcp/cloud_build/main.tf
@@ -9,10 +9,6 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.5"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = ">= 0.9"
-    }
   }
 }
 
@@ -62,13 +58,35 @@ resource "google_secret_manager_secret_version" "webhook" {
   secret_data = random_password.webhook_secret.result
 }
 
+# BYOSA runner SA (issue #201). Cloud Build's regional webhook trigger
+# API rejects CREATE with `400 INVALID_ARGUMENT` (no fieldViolations[])
+# when `service_account` is omitted. Reproducing outside Terraform with
+# `gcloud builds triggers create webhook` confirmed the missing
+# `--service-account` flag is the sole cause; the IAM-propagation
+# hypothesis from #190/#197 was incorrect.
+#
+# account_id has a 4-30 char limit and a `[a-z]([-a-z0-9]*[a-z0-9])`
+# regex. var.project (the stack naming prefix, not the GCP project ID)
+# can be up to ~50 chars and would overflow when combined with the
+# random suffix; the runner SA is project-local so the random suffix
+# alone is enough disambiguation. The display_name carries the project
+# label for human readability.
+resource "google_service_account" "cloudbuild_runner" {
+  project      = var.project_id
+  account_id   = "cb-runner-${random_id.suffix.hex}" # 18 chars, fits the 30-char limit
+  display_name = "Cloud Build webhook trigger runner (project ${var.project})"
+}
+
+resource "google_project_iam_member" "cloudbuild_runner_builds_builder" {
+  project = var.project_id
+  role    = "roles/cloudbuild.builds.builder"
+  member  = "serviceAccount:${google_service_account.cloudbuild_runner.email}"
+}
+
 # The Cloud Build P4SA (service-PROJECT_NUMBER@gcp-sa-cloudbuild) needs
-# roles/secretmanager.secretAccessor on the webhook secret BEFORE the
-# trigger is created — otherwise google_cloudbuild_trigger validates
-# secret access on the create call and rejects with
-# `400 INVALID_ARGUMENT: Request contains an invalid argument` (issue
-# #190). Without this binding the trigger create fails on every
-# fresh-project deploy.
+# roles/secretmanager.secretAccessor on the webhook secret so the trigger
+# can read the webhook secret at runtime. Without this binding the
+# trigger creates but webhook calls fail at invocation time.
 #
 # We resolve the project number from data.google_project rather than
 # adopting the google-beta provider just for `google_project_service_identity`.
@@ -99,25 +117,16 @@ resource "google_secret_manager_secret_iam_member" "cloudbuild_webhook_accessor"
   member = local.cloudbuild_service_agent
 }
 
-# IAM propagation wait (issue #197). PR #191 added the secretAccessor
-# binding above and a `depends_on` from the trigger to it, but the
-# trigger create still hit `400 INVALID_ARGUMENT` on the customer's
-# repro. Root cause: GCP IAM is eventually consistent. `depends_on`
-# orders the create call but not the propagation of the binding to
-# the Cloud Build trigger validator. Resource-level Secret Manager
-# bindings have observed propagation of ~60s p50 / ~120s p99, so 90s
-# covers the long tail. `time_sleep` only fires on creation — no
-# penalty on subsequent applies (and no penalty on destroy/apply
-# cycles where this resource is re-created from scratch each time).
-resource "time_sleep" "wait_iam_propagation" {
-  depends_on      = [google_secret_manager_secret_iam_member.cloudbuild_webhook_accessor]
-  create_duration = "90s"
-}
-
 resource "google_cloudbuild_trigger" "trigger" {
   project  = var.project_id
   location = var.region
   name     = "${var.project}-trigger-${random_id.suffix.hex}"
+
+  # BYOSA: Cloud Build's regional webhook trigger API rejects CREATE
+  # with `400 INVALID_ARGUMENT` (no fieldViolations[]) when
+  # service_account is omitted. See header comment on
+  # google_service_account.cloudbuild_runner above (#201).
+  service_account = google_service_account.cloudbuild_runner.id
 
   webhook_config {
     secret = google_secret_manager_secret_version.webhook.id
@@ -132,12 +141,9 @@ resource "google_cloudbuild_trigger" "trigger" {
     timeout = "60s"
   }
 
-  # Wait for IAM propagation before issuing the trigger create — see
-  # `time_sleep.wait_iam_propagation` comment above (#197). The
-  # `time_sleep` itself depends on the IAM binding, so this single
-  # depends_on transitively orders binding → propagation → create.
   depends_on = [
     google_project_service.cloudbuild,
-    time_sleep.wait_iam_propagation,
+    google_secret_manager_secret_iam_member.cloudbuild_webhook_accessor,
+    google_project_iam_member.cloudbuild_runner_builds_builder,
   ]
 }

--- a/gcp/cloud_build/outputs.tf
+++ b/gcp/cloud_build/outputs.tf
@@ -12,3 +12,8 @@ output "webhook_secret_name" {
   value       = google_secret_manager_secret.webhook.secret_id
   description = "Secret Manager secret holding the webhook trigger token. Retrieve with: gcloud secrets versions access latest --secret=<this>"
 }
+
+output "cloudbuild_runner_service_account_email" {
+  value       = google_service_account.cloudbuild_runner.email
+  description = "Email of the BYOSA runner SA the Cloud Build trigger executes as. Grant additional roles here for downstream resources the trigger's build steps must touch."
+}

--- a/gcp/cloud_build/tests/cloud_build.tftest.hcl
+++ b/gcp/cloud_build/tests/cloud_build.tftest.hcl
@@ -1,16 +1,15 @@
 mock_provider "google" {}
-mock_provider "time" {}
 
 # Smoke for the cloud_build preset under mock_provider. Pins that the
 # default config plans cleanly — the mock provider can't reproduce
-# the issue #190 INVALID_ARGUMENT failure (that's a real GCP-side
-# response on trigger create), and asserting on the IAM binding
-# resource's literal-string fields would be tautological. The
-# meaningful issue #190 pins live in the structural Go test
-# (pkg/composer/compose_vm_test.go::TestGetPresetFiles_GCP_CloudBuild_HasWebhookSecretIAM)
-# which checks the data source, IAM binding resource, role string,
-# P4SA email shape, and the trigger's depends_on — all of which
-# survive any code change that would re-open #190.
+# the issue #190 / #201 INVALID_ARGUMENT failures (those are real
+# GCP-side responses on trigger create). The meaningful issue-#190
+# and issue-#201 pins live in the structural Go test
+# (pkg/composer/compose_vm_test.go::TestGetPresetFiles_GCP_CloudBuild_HasWebhookSecretIAM
+# and pkg/composer/cloud_build_byosa_test.go::TestCloudBuildTriggerHasServiceAccount)
+# which check IAM binding shape and the BYOSA service_account argument
+# on every google_cloudbuild_trigger in the preset library — all of
+# which survive any code change that would re-open the regressions.
 
 run "defaults_plan" {
   command = plan

--- a/gcp/identity_platform/main.tf
+++ b/gcp/identity_platform/main.tf
@@ -1,37 +1,37 @@
 # GCP Identity Platform Configuration
 #
-# Idempotency contract (issues #197, #199): Identity Platform is a GCP
-# singleton — once enabled on a project, the API has no way to disable
-# it. `terraform destroy` cannot truly remove the underlying state, so
-# the next `terraform apply` would issue a CREATE that GCP rejects with
+# Singleton adoption (issues #197, #199, #201): Identity Platform's
+# `projects/<id>/config` resource is a true GCP singleton — once
+# enabled, the API has no way to disable it, and CREATE rejects with
 # `400 INVALID_PROJECT_ID: Identity Platform has already been enabled
-# for this project`. This breaks back-to-back destroy/apply cycles and
-# also fails on shared/test projects where IP was previously enabled.
+# for this project` on previously-enabled projects.
 #
-# v0.7.0 attempted to fix this with a child-module `import {}` block.
-# That regressed harder: TF 1.5+ only permits `import {}` blocks in the
-# root module, so `terraform init` rejected the bundle outright (#199,
-# "An import block was detected in 'module.gcp_identity_platform'.
-# Import blocks are only allowed in the root module."). Same constraint
-# applies to `removed {}` blocks — both are root-only.
+# v0.7.0 attempted a child-module `import {}` block (rejected by TF 1.5+
+# root-only rule, #199); v0.7.1 reverted to plain CREATE + lifecycle.
+# v0.7.2 lands the canonical fix in-tree: data.google_client_config
+# pulls the OAuth2 token the google provider already minted, and
+# data.http issues a plan-time REST GET against
+# `https://identitytoolkit.googleapis.com/v2/projects/<id>/config`. If
+# the GET returns 200, the config already exists and `count = 0` skips
+# the CREATE; if 404 (or any other non-2xx — 403 from missing API
+# enablement, etc.), `count = 1` proceeds with the CREATE on greenfield.
+# No cross-repo coupling, no out-of-band `terraform import` step, no
+# gcloud-on-deploy-container assumption.
 #
-# Current state (v0.7.1+): the module CREATEs the resource normally and
-# pins `lifecycle { ignore_changes = all }` so that once it lands in
-# state, subsequent applies don't fight customer-side tweaks made via
-# the GCP console. The first-apply-on-previously-enabled-project failure
-# is a known limitation tracked in #199 — the proper fix lives in the
-# composer (`luthersystems/reliable`), which must emit a root-level
-# `import { to = module.gcp_identity_platform.google_identity_platform_config.this ... }`
-# alongside the module instantiation. Until that lands, callers running
-# against pre-existing IP projects must `terraform import` the resource
-# into state out-of-band before the first apply.
+# Trade-off on adopted projects: the module's input variables (sign_in,
+# mfa, etc.) are NOT applied to a pre-existing config — `count = 0`
+# means the variables seed nothing, and `lifecycle.ignore_changes = all`
+# remains as a belt-and-suspenders against any future apply-time drift
+# fights on the greenfield path. Ongoing config changes go through the
+# GCP console or out-of-band tooling. Matches the singleton semantics
+# of the underlying API.
 #
-# Trade-off: module variables (sign_in, mfa, etc.) ARE applied on
-# greenfield projects but are NOT enforced on subsequent applies (per
-# `ignore_changes = all`). They document intent and seed the initial
-# config; ongoing config changes go through the GCP console or out-of-
-# band tooling. This matches the singleton semantics of the underlying
-# API.
+# Outputs: `config_name` returns the canonical path
+# `projects/<id>/config` regardless of greenfield-vs-adopt. The
+# `authorized_domains` output is null on adopted projects since we
+# don't have the resource's attribute readout — callers needing this
+# on adopted projects must query the IP REST API directly. The
+# `adopted` output exposes which path was taken.
 
 terraform {
   required_version = ">= 1.5"
@@ -39,6 +39,10 @@ terraform {
     google = {
       source  = "hashicorp/google"
       version = ">= 5.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.4"
     }
   }
 }
@@ -51,11 +55,48 @@ resource "google_project_service" "identity_platform" {
   disable_on_destroy = false
 }
 
-# Identity Platform configuration. CREATEd on greenfield projects;
-# `lifecycle.ignore_changes = all` prevents drift fights once in state.
-# See header comment for the singleton semantics and the follow-up
-# composer change tracked in #199.
+# Singleton existence probe (issue #201). Pull the OAuth2 token the
+# google provider already minted via data.google_client_config, then
+# issue a single REST GET against the IP config endpoint via
+# data.http. The hashicorp/http provider returns status_code without
+# erroring on non-2xx responses (a 404 from a missing config is the
+# expected greenfield case), so status_code is plan-time-known and
+# safe to gate the resource's count on.
+#
+# No depends_on on google_project_service.identity_platform: that
+# would defer status_code to apply time and break the count expression.
+# The probe is safe pre-API-enable —
+#   greenfield, API disabled: probe returns 403/404 → count=1 → CREATE
+#     fires after the API enable lands in apply order
+#   previously enabled, API enabled: probe returns 200 → count=0 →
+#     SKIP, which is the correct outcome
+# The exotic case (API disabled but config already exists from a prior
+# session) is outside this module's contract.
+data "google_client_config" "current" {}
+
+data "http" "ip_existence_check" {
+  url = "https://identitytoolkit.googleapis.com/v2/projects/${var.project_id}/config"
+  request_headers = {
+    Authorization = "Bearer ${data.google_client_config.current.access_token}"
+    Accept        = "application/json"
+  }
+}
+
+locals {
+  # True when CREATE should fire: probe returned anything other than
+  # 200 (404 = config doesn't exist yet, 403 = API not enabled, etc.).
+  ip_should_create = data.http.ip_existence_check.status_code != 200
+}
+
+# Identity Platform configuration. CREATEd on greenfield projects
+# (count=1 when the probe returned non-200); SKIPPED on previously-
+# enabled projects (count=0 when the probe returned 200).
+# `lifecycle.ignore_changes = all` is retained as a defensive pin
+# against any future apply-time drift on the greenfield path. See
+# header comment for the full adoption rationale (#201).
 resource "google_identity_platform_config" "this" {
+  count = local.ip_should_create ? 1 : 0
+
   project = var.project_id
 
   sign_in {
@@ -92,9 +133,12 @@ resource "google_identity_platform_config" "this" {
   depends_on = [google_project_service.identity_platform]
 }
 
-# OAuth client for web applications
+# OAuth client for web applications. Gated on both var.enable_google_signin
+# and module.adopt.should_create — on adopted projects we don't manage
+# the IdP config either, matching the parent's stance of leaving
+# pre-existing IP state alone.
 resource "google_identity_platform_default_supported_idp_config" "google" {
-  count   = var.enable_google_signin ? 1 : 0
+  count   = var.enable_google_signin && local.ip_should_create ? 1 : 0
   project = var.project_id
 
   idp_id        = "google.com"

--- a/gcp/identity_platform/outputs.tf
+++ b/gcp/identity_platform/outputs.tf
@@ -1,9 +1,14 @@
 output "config_name" {
-  description = "The name of the Identity Platform config"
-  value       = google_identity_platform_config.this.name
+  description = "Canonical name of the Identity Platform config. Stable for both created and adopted configs since the API path is deterministic per project."
+  value       = "projects/${var.project_id}/config"
 }
 
 output "authorized_domains" {
-  description = "List of authorized domains"
-  value       = google_identity_platform_config.this.authorized_domains
+  description = "List of authorized domains. Populated only when this module CREATEd the config (greenfield); null when the config was adopted. Callers needing this on adopted projects must query the IP REST API directly."
+  value       = try(google_identity_platform_config.this[0].authorized_domains, null)
+}
+
+output "adopted" {
+  description = "True if this module skipped CREATE because the Identity Platform config already existed on the project (existence probe returned 200)."
+  value       = !local.ip_should_create
 }

--- a/gcp/identity_platform/tests/identity_platform.tftest.hcl
+++ b/gcp/identity_platform/tests/identity_platform.tftest.hcl
@@ -1,22 +1,90 @@
-# Smoke for the identity_platform preset under mock_provider. Pins that
-# the default config plans cleanly on a greenfield project (CREATE path).
-# The singleton "already enabled" failure is a real GCP-side response on
-# CREATE against a previously-enabled project and cannot be reproduced
-# under mock_provider — that path is exercised by the manual real-cloud
-# repro on issues #197 / #199.
+# Smoke for the identity_platform preset under mock_provider, exercising
+# both branches of the v0.7.2 adoption logic (issue #201): greenfield
+# (helper returns 404 → count=1, CREATE) and adopted (helper returns
+# 200 → count=0, SKIP). override_data pins the helper's data.http
+# status_code so the test does not need real GCP credentials.
 #
-# v0.7.0 attempted child-module `import {}` adoption; v0.7.1 reverts
+# v0.7.0 attempted child-module `import {}` adoption; v0.7.1 reverted
 # that since TF 1.5+ allows `import {}` blocks only in the root module
-# (see #199). The structural pin that this module contains NO top-level
+# (#199). The structural pin that this module contains NO top-level
 # `import {}` block lives in the Go test
 # (pkg/composer/compose_vm_test.go::TestGetPresetFiles_GCP_IdentityPlatform_NoRootOnlyBlocks).
-mock_provider "google" {}
 
-run "defaults_plan" {
+mock_provider "google" {}
+mock_provider "http" {}
+
+variables {
+  project    = "test"
+  project_id = "test-project"
+}
+
+run "greenfield_creates_config" {
+  command = plan
+
+  override_data {
+    target = data.http.ip_existence_check
+    values = {
+      status_code = 404
+    }
+  }
+
+  assert {
+    condition     = length(google_identity_platform_config.this) == 1
+    error_message = "On greenfield (404) the IP config must be CREATEd (count == 1)"
+  }
+  assert {
+    condition     = output.adopted == false
+    error_message = "adopted output must be false when the existence probe returned 404"
+  }
+}
+
+run "previously_enabled_skips_create" {
+  command = plan
+
+  override_data {
+    target = data.http.ip_existence_check
+    values = {
+      status_code = 200
+    }
+  }
+
+  assert {
+    condition     = length(google_identity_platform_config.this) == 0
+    error_message = "On previously-enabled (200) the IP config must be SKIPPED (count == 0)"
+  }
+  assert {
+    condition     = output.adopted == true
+    error_message = "adopted output must be true when the existence probe returned 200"
+  }
+  assert {
+    condition     = output.config_name == "projects/test-project/config"
+    error_message = "config_name must always return the canonical path regardless of greenfield-vs-adopt"
+  }
+}
+
+# IdP config is also gated on module.adopt.should_create — on adopted
+# projects we don't manage Google sign-in either, matching the parent's
+# stance of leaving pre-existing IP state alone.
+run "google_signin_skipped_when_adopted" {
   command = plan
 
   variables {
-    project    = "test"
-    project_id = "test-project"
+    project              = "test"
+    project_id           = "test-project"
+    enable_google_signin = true
+    google_client_id     = "test-client-id"
+    google_client_secret = "test-client-secret"
+  }
+
+  override_data {
+    target = data.http.ip_existence_check
+    values = {
+      status_code = 200
+    }
+  }
+
+  assert {
+    condition     = length(google_identity_platform_default_supported_idp_config.google) == 0
+    error_message = "Google sign-in IdP config must be SKIPPED on adopted projects (count == 0)"
   }
 }

--- a/pkg/composer/cloud_build_byosa_test.go
+++ b/pkg/composer/cloud_build_byosa_test.go
@@ -1,0 +1,117 @@
+package composer
+
+import (
+	"strings"
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCloudBuildTriggerHasServiceAccount asserts every
+// google_cloudbuild_trigger resource declared anywhere in the preset
+// library sets a service_account attribute. Cloud Build's regional /
+// 2nd-gen webhook trigger API requires a BYOSA service account on
+// create; omitting it surfaces as `400 INVALID_ARGUMENT` with no
+// fieldViolations[] (issue #201). This guard would have caught the
+// regression at publish time.
+//
+// Pure structural check — does NOT require GCP credentials, mocks, or
+// real apply. Parses the embedded preset HCL offline.
+func TestCloudBuildTriggerHasServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	keys, err := c.ListPresetKeysForCloud("gcp")
+	require.NoError(t, err)
+
+	checked := 0
+	for _, presetPath := range keys {
+		files, err := c.GetPresetFiles(presetPath)
+		require.NoError(t, err, "GetPresetFiles(%s)", presetPath)
+
+		for fileName, content := range files {
+			if !strings.HasSuffix(fileName, ".tf") {
+				continue
+			}
+
+			f, diags := hclsyntax.ParseConfig(content, fileName, hcl.InitialPos)
+			require.False(t, diags.HasErrors(), "parse %s%s: %s", presetPath, fileName, diags.Error())
+
+			body, ok := f.Body.(*hclsyntax.Body)
+			if !ok {
+				continue
+			}
+
+			for _, block := range body.Blocks {
+				if block.Type != "resource" {
+					continue
+				}
+				if len(block.Labels) < 2 || block.Labels[0] != "google_cloudbuild_trigger" {
+					continue
+				}
+				_, hasServiceAccount := block.Body.Attributes["service_account"]
+				require.True(t, hasServiceAccount,
+					"%s%s: resource %q.%q must set service_account (BYOSA, issue #201)",
+					presetPath, fileName, block.Labels[0], block.Labels[1])
+				checked++
+			}
+		}
+	}
+
+	// Cardinality floor: the loop has to fire at least once for the
+	// guard to be meaningful. If it falls to 0 (e.g. someone deletes the
+	// cloud_build preset entirely or the iteration shape silently
+	// breaks), this test would otherwise pass vacuously and the
+	// regression returns.
+	require.GreaterOrEqual(t, checked, 1,
+		"expected at least one google_cloudbuild_trigger in the preset library; got 0 — test silently passing")
+}
+
+// TestGetPresetFiles_GCP_CloudBuild_HasBYOSARunner pins the v0.7.2
+// BYOSA-runner shape at the embedded-FS layer. Companion to
+// TestCloudBuildTriggerHasServiceAccount (which asserts every trigger
+// has *some* service_account); this test pins the specific shape
+// gcp/cloud_build emits — a dedicated runner SA + cloudbuild.builds.builder
+// project IAM binding, with the trigger's depends_on transitively
+// ordered runner-SA → IAM-binding → trigger-create.
+//
+// A regression that drops the runner SA, the builds.builder grant, or
+// the trigger's service_account argument re-opens issue #201:
+// `400 INVALID_ARGUMENT` on every webhook trigger create.
+func TestGetPresetFiles_GCP_CloudBuild_HasBYOSARunner(t *testing.T) {
+	t.Parallel()
+	files, err := newTestClient().GetPresetFiles("gcp/cloud_build")
+	require.NoError(t, err)
+
+	mainTF, ok := files["/main.tf"]
+	require.True(t, ok, "gcp/cloud_build must include main.tf")
+	body := string(mainTF)
+
+	// (1) Dedicated runner SA exists.
+	require.Contains(t, body, `resource "google_service_account" "cloudbuild_runner"`,
+		"gcp/cloud_build/main.tf must declare the BYOSA runner SA google_service_account.cloudbuild_runner (issue #201)")
+
+	// (2) Project-level cloudbuild.builds.builder grant on the runner SA.
+	require.Contains(t, body, `resource "google_project_iam_member" "cloudbuild_runner_builds_builder"`,
+		"gcp/cloud_build/main.tf must bind roles/cloudbuild.builds.builder to the runner SA (issue #201)")
+	require.Contains(t, body, `roles/cloudbuild.builds.builder`,
+		"gcp/cloud_build/main.tf must grant roles/cloudbuild.builds.builder so the runner SA can execute builds (issue #201)")
+
+	// (3) Trigger consumes the runner SA via service_account.
+	require.Contains(t, body, `service_account = google_service_account.cloudbuild_runner.id`,
+		"gcp/cloud_build/main.tf trigger must set service_account = google_service_account.cloudbuild_runner.id (BYOSA, issue #201)")
+
+	// (4) Trigger depends_on the IAM binding so create fires post-grant.
+	require.Contains(t, body, `google_project_iam_member.cloudbuild_runner_builds_builder`,
+		"gcp/cloud_build/main.tf trigger depends_on must include the runner SA's IAM binding (issue #201)")
+
+	// (5) Counter-pin: the v0.7.0/v0.7.1 IAM-propagation theater code
+	// must be gone. The 90s time_sleep was solving the wrong problem —
+	// the real issue was missing service_account, not propagation.
+	require.NotContains(t, body, `resource "time_sleep" "wait_iam_propagation"`,
+		"gcp/cloud_build/main.tf must not retain the v0.7.1 time_sleep.wait_iam_propagation block — root cause was BYOSA, not IAM propagation (issue #201)")
+	require.NotContains(t, body, `source  = "hashicorp/time"`,
+		"gcp/cloud_build/main.tf must not declare hashicorp/time once time_sleep is removed (issue #201)")
+}

--- a/pkg/composer/compose_vm_test.go
+++ b/pkg/composer/compose_vm_test.go
@@ -390,31 +390,23 @@ func TestGetPresetFiles_GCP_KMS_NoUpstreamModule(t *testing.T) {
 }
 
 // TestGetPresetFiles_GCP_CloudBuild_HasWebhookSecretIAM pins the
-// issue #190 + #197 fixes at the embedded-FS layer.
+// issue #190 webhook-secret IAM binding shape at the embedded-FS
+// layer. (#197's time_sleep mitigation was retired in v0.7.2 once the
+// real root cause — missing BYOSA on the trigger — was isolated; see
+// pkg/composer/cloud_build_byosa_test.go for the BYOSA pins.)
 //
-// google_cloudbuild_trigger validates webhook secret access on the
-// create call. Without an IAM binding granting
-// roles/secretmanager.secretAccessor on the webhook secret to the
-// Cloud Build P4SA (service-PROJECT_NUMBER@gcp-sa-cloudbuild) the
-// create fails with `400 INVALID_ARGUMENT: Request contains an
-// invalid argument`. The fix:
+// The Cloud Build P4SA (service-PROJECT_NUMBER@gcp-sa-cloudbuild)
+// needs roles/secretmanager.secretAccessor on the webhook secret so
+// the trigger can read the secret at invocation time. Without the
+// binding, webhook calls fail at runtime even if the trigger creates
+// successfully:
 //
 //   1. data.google_project.this resolves the project number
 //      after-enable.
 //   2. google_secret_manager_secret_iam_member.cloudbuild_webhook_accessor
 //      grants secretAccessor on the webhook secret to the P4SA.
-//   3. time_sleep.wait_iam_propagation defers the trigger create by
-//      90s after the IAM binding (issue #197). depends_on alone
-//      orders the create CALL but not GCP IAM propagation, which is
-//      eventually consistent (~60s p50 / ~120s p99 for resource-level
-//      Secret Manager bindings); without the sleep, the trigger
-//      validator may not see the binding and rejects with 400.
-//   4. The trigger depends_on the time_sleep, which itself depends_on
-//      the IAM binding — transitive ordering binding → propagation →
-//      create.
-//
-// A regression that drops any of those four pieces leaves customers
-// hitting INVALID_ARGUMENT on every fresh-project deploy.
+//   3. The trigger depends_on the IAM binding so the binding lands
+//      before the trigger is created.
 func TestGetPresetFiles_GCP_CloudBuild_HasWebhookSecretIAM(t *testing.T) {
 	t.Parallel()
 	files, err := newTestClient().GetPresetFiles("gcp/cloud_build")
@@ -436,23 +428,9 @@ func TestGetPresetFiles_GCP_CloudBuild_HasWebhookSecretIAM(t *testing.T) {
 	require.Contains(t, body, `gcp-sa-cloudbuild.iam.gserviceaccount.com`,
 		"gcp/cloud_build/main.tf must target the Cloud Build P4SA service-{PROJECT_NUMBER}@gcp-sa-cloudbuild (issue #190)")
 
-	// (3) time_sleep absorbs IAM propagation latency before trigger create
-	// fires (issue #197). The hashicorp/time provider must be declared,
-	// the resource must exist, and the duration must be at least 60s to
-	// cover the documented p99 propagation tail.
-	require.Contains(t, body, `source  = "hashicorp/time"`,
-		"gcp/cloud_build/main.tf must declare hashicorp/time provider for time_sleep (issue #197)")
-	require.Contains(t, body, `resource "time_sleep" "wait_iam_propagation"`,
-		"gcp/cloud_build/main.tf must declare time_sleep.wait_iam_propagation between IAM binding and trigger (issue #197)")
-	require.Contains(t, body, `create_duration = "90s"`,
-		"gcp/cloud_build/main.tf time_sleep must wait 90s for IAM propagation (issue #197)")
-
-	// (4) The substring asserts both: the resource declaration AND the
-	// time_sleep's depends_on on it (transitive trigger ordering).
+	// (3) Trigger depends_on the IAM binding (transitive ordering).
 	require.Contains(t, body, "google_secret_manager_secret_iam_member.cloudbuild_webhook_accessor",
-		"gcp/cloud_build/main.tf must reference the IAM binding (issue #190; transitive ordering via time_sleep #197)")
-	require.Contains(t, body, "time_sleep.wait_iam_propagation",
-		"gcp/cloud_build/main.tf trigger must depend_on time_sleep.wait_iam_propagation (issue #197)")
+		"gcp/cloud_build/main.tf trigger depends_on must reference the webhook-secret IAM binding (issue #190)")
 }
 
 // TestGetPresetFiles_GCP_IdentityPlatform_NoRootOnlyBlocks pins the
@@ -467,11 +445,11 @@ func TestGetPresetFiles_GCP_CloudBuild_HasWebhookSecretIAM(t *testing.T) {
 // Import blocks are only allowed in the root module." That regressed
 // harder than #197: hard fail at init, before apply could even start.
 //
-// The proper adoption fix lives in the composer (root module emits
-// `import { to = module.gcp_identity_platform.google_identity_platform_config.this ... }`).
-// Until that lands, this preset CREATEs the resource normally and
-// keeps `lifecycle { ignore_changes = all }` so subsequent applies
-// don't fight console edits.
+// v0.7.2 (#201) lands the proper adoption fix in-tree via the
+// gcp/adopt_singleton helper module: `module "adopt"` issues a
+// plan-time REST GET against the IP config endpoint and outputs a
+// plan-time-known should_create boolean that gates `count` on the
+// singleton resource. No cross-module `import {}` block needed.
 //
 // A regression that re-introduces `import {}` (or `removed {}`) inside
 // this child module reopens #199 — every customer deploy hits the init


### PR DESCRIPTION
## Summary

Two distinct apply-time 400s that v0.7.1 didn't resolve:

1. **`gcp/cloud_build`** — Cloud Build's regional webhook trigger API now requires a user-supplied (BYOSA) `service_account`. Adds a dedicated runner SA, binds `roles/cloudbuild.builds.builder`, sets `service_account` on the trigger, and drops the v0.7.1 90s `time_sleep` (it was solving the wrong problem; root cause was missing BYOSA, not IAM propagation).
2. **`gcp/identity_platform`** — singleton at `projects/<id>/config` 400s on previously-enabled projects. v0.7.2 lands an in-tree, pure-TF probe via `data.google_client_config` + `data.http` → plan-time-known `status_code` → `count = (status_code != 200) ? 1 : 0` gates the resource. No cross-repo coupling, no `terraform import` step. (Investigation of cleaner alternatives confirmed no first-class answer exists in the provider — see https://github.com/luthersystems/insideout-terraform-presets/pull/202#issuecomment-4359712898.)

## Architectural pivot worth flagging

Originally built as a reusable `gcp/adopt_singleton` helper module, but Terraform's "package" model rejects `source = "../adopt_singleton"` from inside a child module — the path escapes the package boundary. This would have broken `tests/validate-as-child.sh` AND the composer's consumption shape. Inlined the probe directly in the IP module. Follow-up issue #203 tracks the pattern for shared/common modules the composer auto-bundles.

## CI guards added

- `pkg/composer/cloud_build_byosa_test.go::TestCloudBuildTriggerHasServiceAccount` — walks every preset, asserts each `google_cloudbuild_trigger` sets `service_account`. Fast, hermetic, would have caught the regression at publish time.
- `pkg/composer/cloud_build_byosa_test.go::TestGetPresetFiles_GCP_CloudBuild_HasBYOSARunner` — pins the runner SA + IAM binding shape; counter-pins absence of the time_sleep.
- Updated existing `TestGetPresetFiles_GCP_CloudBuild_HasWebhookSecretIAM` to drop obsolete `time_sleep` / `hashicorp/time` assertions.
- Hermetic `terraform test` runs in `gcp/identity_platform/tests/identity_platform.tftest.hcl` cover both greenfield (404 → CREATE, count=1) and adopted (200 → SKIP, count=0) paths via `override_data`.

## Scope correction

Original Q3 scope was "IP + Firestore + KMS" but Firestore/KMS already use random suffixes from #159 (`<project>-firestore-<8hex>`, `<project>-<keyring>-<8hex>`) which both sidesteps the singleton class AND breaks the plan-time-known requirement of `count = (status_code != 200) ? ...` (random suffix isn't known on first apply). v0.7.2 adoption is IP-only.

## Test plan

Local verification (all green):
- [x] `terraform fmt -check -recursive`
- [x] `terraform init/validate` per module (`gcp/cloud_build`, `gcp/identity_platform`)
- [x] `tests/validate-as-child.sh` — all 14 GCP + AWS presets PASS
- [x] `tests/lint-no-root-only-blocks.sh`, `lint-project-label.sh`, `lint-foreach-unknown-keys.sh`, `lint-sensitive-for-each.sh`
- [x] `terraform test ./gcp/identity_platform` — 3/3 pass
- [x] `terraform test ./gcp/cloud_build` — 1/1 pass
- [x] `go test ./pkg/composer/...` — all pass

CI (fully green): `ci-gate`, `discover`, `format-check`, `go-build`, `go-test`, `go-vet`, `lint`, all `test-presets`, all `validate-examples`, all `validate-presets`, all `validate-presets-as-child`.

Real-cloud smoke against `diagramtest2025-09-14` (the project from the original #201 repro):
- [x] Applied `gcp/identity_platform` standalone — probe returned 200, `count=0`, no IP CREATE in plan, `adopted=true`, `config_name=projects/diagramtest2025-09-14/config`. The v0.7.1 `400 INVALID_PROJECT_ID` is gone.
- [x] Applied `gcp/cloud_build` standalone — `google_cloudbuild_trigger.trigger` **creation complete after 1s** (was 400-ing in v0.7.1). Total apply time ~40s. `cloudbuild_runner_service_account_email = "cb-runner-c742c255@diagramtest2025-09-14.iam.gserviceaccount.com"`. `terraform destroy` cleaned up the test resources cleanly.

## Release note (v0.7.2)

**State-migration heads-up for customers upgrading IP from a pre-v0.7.x preset:** the IP config resource address changes from `module.<key>.google_identity_platform_config.this` (unindexed) to `module.<key>.google_identity_platform_config.this[0]` (indexed via `count`). Combined with the new probe-gates-count behavior, two scenarios land cleanly and one needs a manual step:

| Scenario | State has IP entry? | v0.7.2 plan | Action |
|---|---|---|---|
| Greenfield (IP never enabled) | No | `count=1`, CREATE fires | None — just works |
| Failed v0.7.0/v0.7.1 deploy (CREATE never succeeded) | No | `count=0`, no resource in plan, state already matches | None — just works (this is Dario's session) |
| Successful pre-v0.7.x deploy (IP applied via TF) | Yes, at unindexed `this` | Terraform plans `destroy` of unindexed entry; the provider's Delete resets config fields | **Run `terraform state rm 'module.<key>.google_identity_platform_config.this'` before bumping**, so v0.7.2 sees a clean state for the count-gated probe to take over |

The third row is the only customer-facing manual step. Cloud Build BYOSA has no state-migration concerns — the new `google_service_account.cloudbuild_runner` and `google_project_iam_member.cloudbuild_runner_builds_builder` are pure adds, and the existing trigger keeps the same address.

## Issue references

Closes #201. Subsumes #197 (real cloud_build root cause was BYOSA, not IAM propagation; #190's hypothesis was wrong). Spawns follow-up #203 (shared/common modules pattern for composer) and #204 (observability migration design).