### PR TITLE
feat(composer): shared-modules framework skeleton (#203)

### DIFF
--- a/.claude/skills/add-aws-module/SKILL.md
+++ b/.claude/skills/add-aws-module/SKILL.md
@@ -87,27 +87,39 @@ output "arn" {
 
 Common wiring outputs: `arn`, `id`, `vpc_id`, `private_subnet_ids`, `security_group_id`, `endpoint`.
 
-### 5. Check Go Embedding
+### 5. Reusing helper logic? Consider a shared module
+
+If your new module needs a small helper that you suspect a second module
+will eventually want too (tag merging, ARN parsing, account ID validation,
+naming-prefix sanitization, an existence-probe pattern, etc.), put the
+helper in `aws/_shared/<helper_name>/` and reference it from your module via
+`source = "../_shared/<helper_name>"`. The composer skips `_`-prefixed dirs
+during preset enumeration and bundles them alongside any preset that
+references them. See `aws/_shared/README.md` and issue #203 for the
+contract; for genuinely cloud-agnostic helpers (severity tagging conventions,
+runbook URL builders), use the top-level `_shared/<name>/` bucket instead.
+
+### 6. Check Go Embedding
 
 Verify the new file patterns are covered by `zz_embed.go`:
 - `.tf` files: already covered by `aws/*/*.tf`
 - `.tmpl` files: already covered by `aws/*/*.tmpl`
 - New extensions: add a `//go:embed` directive to `zz_embed.go`
 
-### 6. Format and Validate
+### 7. Format and Validate
 
 ```bash
 terraform fmt aws/<modulename>/
 cd aws/<modulename> && terraform init -backend=false -input=false && terraform validate
 ```
 
-### 7. Verify Go Embed Compiles
+### 8. Verify Go Embed Compiles
 
 ```bash
 go build ./...
 ```
 
-### 8. Tests (optional but encouraged)
+### 9. Tests (optional but encouraged)
 
 `terraform test` files live in `aws/<modulename>/tests/` and follow a filename convention CI relies on:
 

--- a/.claude/skills/add-gcp-module/SKILL.md
+++ b/.claude/skills/add-gcp-module/SKILL.md
@@ -99,20 +99,32 @@ output "id" {
 
 Common wiring outputs: `id`, `name`, `self_link`, `network_id`, `ip_address`.
 
-### 5. Check Go Embedding
+### 5. Reusing helper logic? Consider a shared module
+
+If your new module needs a small helper that you suspect a second module
+will eventually want too (the singleton existence-probe pattern from #203,
+project-vs-project_id sanitization, label merging variants, etc.), put the
+helper in `gcp/_shared/<helper_name>/` and reference it from your module via
+`source = "../_shared/<helper_name>"`. The composer skips `_`-prefixed dirs
+during preset enumeration and bundles them alongside any preset that
+references them. See `gcp/_shared/README.md` and issue #203 for the
+contract; for genuinely cloud-agnostic helpers (severity tagging conventions,
+runbook URL builders), use the top-level `_shared/<name>/` bucket instead.
+
+### 6. Check Go Embedding
 
 Verify patterns in `zz_embed.go`:
 - `.tf` files: already covered by `gcp/*/*.tf`
 - `.tmpl` files: **NOT covered** — if adding `.tmpl` files, add `//go:embed gcp/*/*.tmpl` to `zz_embed.go`
 
-### 6. Format and Validate
+### 7. Format and Validate
 
 ```bash
 terraform fmt gcp/<module_name>/
 cd gcp/<module_name> && terraform init -backend=false -input=false && terraform validate
 ```
 
-### 7. Verify Go Embed Compiles
+### 8. Verify Go Embed Compiles
 
 ```bash
 go build ./...

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -19,7 +19,13 @@ jobs:
       - id: find-presets
         name: Discover preset modules
         run: |
+          # Skip leading-underscore dirs (e.g. aws/_shared, gcp/_shared) —
+          # they are internal helper buckets bundled by the composer, not
+          # top-level presets. Mirrors composer.isInternalDirName and
+          # tests/validate-as-child.sh::is_shared_path (issue #203).
           dirs=$(find aws gcp -mindepth 1 -maxdepth 1 -type d | sort | while read -r d; do
+            base="$(basename "$d")"
+            case "$base" in _*) continue ;; esac
             [ -f "$d/.validate-skip" ] || echo "$d"
           done | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "dirs=$dirs" >> "$GITHUB_OUTPUT"
@@ -30,7 +36,11 @@ jobs:
           # Only consider modules that have at least one non-integration
           # .tftest.hcl. Files matching *integration* are opt-in: they
           # require live cloud credentials and are skipped in CI.
+          # Skip leading-underscore dirs (issue #203) for the same reason
+          # find-presets does.
           dirs=$(find aws gcp -mindepth 1 -maxdepth 1 -type d | sort | while read -r d; do
+            base="$(basename "$d")"
+            case "$base" in _*) continue ;; esac
             non_integration=$(find "$d" -maxdepth 2 -name '*.tftest.hcl' ! -name '*integration*' 2>/dev/null | head -1)
             if [ -n "$non_integration" ]; then
               echo "$d"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,65 @@ These preset files are embedded at build time into the [reliable](https://github
 - **Root-only blocks are forbidden in presets (issue #199):** Terraform 1.5+ permits `import {}` and `removed {}` blocks **only in the root module**. Every preset in this repo is consumed as a *child* module by the composer (`luthersystems/reliable` emits `module "<key>" { source = "..." }` in a generated root), so any `import {}` or `removed {}` block placed in `aws/<m>/*.tf` or `gcp/<m>/*.tf` will fail `terraform init` with `An import block was detected in "module.<name>". Import blocks are only allowed in the root module.` This regressed v0.7.0 (#199) — standalone `terraform validate` accepted the block because the preset was treated as the root, but the bundle failed init at customer deploy time. Enforced in CI by `tests/lint-no-root-only-blocks.sh` (static grep) and the `validate-presets-as-child` workflow job (wraps each preset and runs `terraform init`). The same rule applies to `provider {}` blocks with arguments — root-only since TF 0.13.
 - **Idempotency contract (issues #197, #199):** every preset must support back-to-back `terraform destroy` → `terraform apply` cycles without manual intervention. Resources backed by cloud-API singletons that can't truly be deleted — Identity Platform, Firestore databases, KMS key rings, project-level service activations — must be modeled as **adoption**, not creation, because the provider's CREATE will reject the second apply with `400 INVALID_*` once the underlying GCP/AWS state survives the destroy. The adoption mechanism is a root-level `import { to = module.<name>.<resource> ... }` block — but per the rule above, the preset itself **cannot** declare it. The composer must emit the import block alongside the module instantiation; until that lands, presets pin `lifecycle { ignore_changes = all }` and document that callers running against pre-existing singletons must `terraform import` out-of-band before the first apply. See `gcp/identity_platform/main.tf` for the current shape (CREATE + `ignore_changes = all`, header comment links #199). For race-prone resources whose CREATE is order-sensitive (e.g. GCP IAM eventual consistency before downstream resource validation), insert an explicit `time_sleep` between the binding and the dependent — see `gcp/cloud_build/main.tf::time_sleep.wait_iam_propagation` (90s covers ~p99 propagation; only fires on creation). Today's known singleton candidates: `gcp_identity_platform` (#197 mitigated, #199 composer-emit-import follow-up). Audit follow-up: `gcp_firestore` (singleton database — once created, the project's default database can't be removed; needs the same adoption treatment, blocked on the same composer change).
 
+## Shared / Helper Modules (issue #203)
+
+Three reserved buckets hold internal helper modules consumed by other presets
+via `source = "../_shared/<name>"` (per-cloud) or
+`source = "../../_shared/<name>"` (cross-cloud). They are NOT top-level
+presets — the composer skips any directory whose name begins with `_` when
+listing preset keys, so they never get a `module "<key>" {}` block in the
+composed root.
+
+| Path | Scope | Examples |
+|---|---|---|
+| `aws/_shared/<name>/` | AWS-only helpers | AWS tag merging, ARN parsing, account-ID validation, S3 bucket-name sanitization |
+| `gcp/_shared/<name>/` | GCP-only helpers | Singleton existence probe (#202 inline precedent), GCP label merging, project / project_id split helpers |
+| `_shared/<name>/` (top-level) | Cloud-agnostic helpers | Severity tagging conventions (#204), runbook URL prefix builders, naming-prefix normalization, time/date utilities |
+
+### Conventions
+
+- **Leading-underscore signals "not a top-level preset."** The composer's
+  `ListPresetKeysForCloud` and `ListClouds` skip `_*` dir entries via
+  `composer.isInternalDirName`. Do not work around this — if a directory
+  needs to be enumerated as a preset, name it without the underscore.
+- **Per-cloud isolation.** GCP-only stacks must not pull AWS helpers into
+  their composed workspace, and vice versa. AWS helpers go in
+  `aws/_shared/`; GCP helpers go in `gcp/_shared/`. Cross-cloud helpers go
+  in top-level `_shared/`.
+- **Cross-cloud helpers MUST NOT declare cloud-specific providers.**
+  Modules under top-level `_shared/` may not declare `aws`, `google`,
+  `google-beta`, `azurerm`, etc. — they ride along with both AWS-only and
+  GCP-only stacks, so dragging in a cloud-specific provider would force
+  every consumer to install it. Enforced by
+  `tests/lint-shared-no-cloud-providers.sh`. If a helper genuinely needs
+  to touch a cloud API, it belongs in a per-cloud bucket.
+- **Plan-time-known outputs.** If a consumer's `count` / `for_each` will
+  depend on a shared-module output, the output must be plan-time-known. The
+  v0.7.2 inline existence-probe (PR #202) is the canonical example —
+  `data.http` of a deterministic-name resource is plan-time-known iff the
+  inputs are plan-time-known.
+- **Module-package boundaries.** Terraform rejects `../` source traversal
+  across module package boundaries with `Local module path escapes module
+  package`. The composer (`luthersystems/reliable`) is responsible for
+  bundling shared modules into the same workspace as their consumers so the
+  relative source path resolves within a single package. For local
+  `tests/validate-as-child.sh` runs, the script auto-detects
+  `source = "../_shared/..."` references and copies the referenced helpers
+  into the synthetic child-module package alongside the wrapped preset.
+- **Embed coverage.** New file extensions in `_shared` buckets need
+  matching `//go:embed` directives in `zz_embed.go` (the existing globs
+  cover `.tf` for all three buckets and `.tmpl` for AWS top-level only —
+  add a glob if a shared module needs other extensions). Each `_shared`
+  glob requires at least one matching file at compile time; the
+  `_smoke` placeholder fixtures in each bucket satisfy this until real
+  shared modules land.
+- **No real shared modules ship in this repo yet.** Issue #203 set up the
+  framework / plumbing only. The `gcp/identity_platform` inline existence
+  probe from PR #202 stays inline for now; conversion to
+  `gcp/_shared/<name>` is a follow-up PR once a second consumer materializes
+  or once the framework is exercised by a real cross-cloud helper (likely
+  the severity-tagging convention from #204).
+
 ## Skills
 
 Before starting a task, check if a matching skill exists and follow its workflow exactly. Multiple skills can chain: e.g., `/pickup-issue` uses the relevant add-module skill for implementation, `/verify` before committing, and `/pr` to ship.

--- a/_shared/README.md
+++ b/_shared/README.md
@@ -1,0 +1,45 @@
+# _shared/
+
+Cross-cloud (cloud-agnostic) internal helper modules consumed by both AWS and
+GCP presets via `source = "../../_shared/<name>"`.
+
+These are NOT top-level presets:
+
+- The composer skips any directory whose name begins with `_` when listing
+  preset keys, so `_shared` modules never get a `module "<key>" {}` block in
+  the composed root.
+- They are bundled into the composed workspace alongside any preset that
+  references them (cross-cloud helpers ride along with both AWS-only and
+  GCP-only stacks; per-cloud helpers do not).
+
+## When to use this bucket
+
+Reach for `_shared/<name>/` when a helper applies equally to both clouds —
+candidates: severity tagging conventions (#204), runbook URL prefix builders,
+naming-prefix normalization, time/date utilities, hash/digest helpers.
+
+If the helper is AWS-only or GCP-only, put it in `aws/_shared/<name>/` or
+`gcp/_shared/<name>/` so the per-cloud workspace stays clean.
+
+## Hard constraint: no cloud-specific providers
+
+Modules under top-level `_shared/` MUST NOT declare any cloud-specific
+provider (`aws`, `google`, `google-beta`, `azurerm`, etc.). They may only use
+provider-agnostic resources / data sources from `null`, `random`, `http`,
+`time`, `local`, `external`, `tls`, etc.
+
+This is enforced by `tests/lint-shared-no-cloud-providers.sh`. If a helper
+needs to touch a cloud API, it belongs in a per-cloud bucket.
+
+## Contract
+
+- Standard module layout: `main.tf` + `variables.tf` + `outputs.tf`.
+- Outputs MUST be plan-time-known if a consumer's `count` / `for_each` will
+  depend on them.
+- Document the helper's contract in the file header — these are part of the
+  internal preset API, not external surface.
+
+## References
+
+- Issue [#203](https://github.com/luthersystems/insideout-terraform-presets/issues/203) — shared-modules framework.
+- Issue [#204](https://github.com/luthersystems/insideout-terraform-presets/issues/204) — observability migration; will need cross-cloud helpers (severity tagging, runbook URLs).

--- a/_shared/_smoke/main.tf
+++ b/_shared/_smoke/main.tf
@@ -1,0 +1,24 @@
+# Placeholder fixture for issue #203 plumbing — DELETE when a real shared
+# module lands in _shared/.
+#
+# This module exists solely so that:
+#   - the embed glob _shared/*/*.tf has at least one matching file (Go's
+#     embed requires every glob to match at least one file at compile time);
+#   - tests/lint-shared-no-cloud-providers.sh has a real cross-cloud module
+#     to scan, satisfying its cardinality floor (>=1 cross-cloud module
+#     scanned per run);
+#   - tests/validate-as-child.sh has a fixture to confirm top-level `_shared/`
+#     is filtered out of preset enumeration.
+#
+# A no-op module: one local, one output. Holds NO cloud-specific providers
+# (no aws, google, google-beta, azurerm) — that constraint is enforced by
+# tests/lint-shared-no-cloud-providers.sh and is the defining contract of
+# this bucket.
+
+terraform {
+  required_version = ">= 1.0"
+}
+
+locals {
+  smoke = "_shared/_smoke"
+}

--- a/_shared/_smoke/outputs.tf
+++ b/_shared/_smoke/outputs.tf
@@ -1,0 +1,7 @@
+# Placeholder fixture for issue #203 plumbing — DELETE when a real shared
+# module lands in _shared/.
+
+output "smoke" {
+  description = "Constant identifier proving the _shared/_smoke (cross-cloud) fixture compiled and was reachable from the composer."
+  value       = local.smoke
+}

--- a/aws/_shared/README.md
+++ b/aws/_shared/README.md
@@ -1,0 +1,40 @@
+# aws/_shared/
+
+AWS-only internal helper modules consumed by other AWS presets via
+`source = "../_shared/<name>"`.
+
+These are NOT top-level presets:
+
+- The composer skips any directory whose name begins with `_` when listing
+  preset keys, so `_shared` modules never get a `module "<key>" {}` block in
+  the composed root.
+- They are bundled into the composed workspace alongside any AWS preset that
+  references them (per-cloud isolation: GCP-only stacks do not pull AWS
+  helpers).
+
+## When to use this bucket
+
+Reach for `aws/_shared/<name>/` when two or more AWS presets need the same
+small piece of logic — typical examples include AWS tag merging, account ID
+parsing, ARN decomposition, S3 bucket name sanitization, or other AWS-specific
+helpers that would otherwise duplicate across modules.
+
+If the helper would also be useful to a GCP preset (severity tagging, runbook
+URL conventions, naming-prefix normalization), put it in the top-level
+`_shared/<name>/` bucket instead — and ensure it declares ZERO cloud-specific
+providers (no `aws`, `google`, `google-beta`, `azurerm`).
+
+## Contract
+
+- Standard module layout: `main.tf` + `variables.tf` + `outputs.tf`.
+- May freely declare the `aws` provider.
+- Subject to AWS lint gates (e.g. `tests/lint-project-tag.sh`).
+- Outputs MUST be plan-time-known if a consumer's `count` / `for_each` will
+  depend on them.
+- Document the helper's contract in the file header — these are part of the
+  internal preset API, not external surface.
+
+## References
+
+- Issue [#203](https://github.com/luthersystems/insideout-terraform-presets/issues/203) — shared-modules framework.
+- PR [#202](https://github.com/luthersystems/insideout-terraform-presets/pull/202) — inline workaround that motivated this bucket.

--- a/aws/_shared/_smoke/main.tf
+++ b/aws/_shared/_smoke/main.tf
@@ -1,0 +1,22 @@
+# Placeholder fixture for issue #203 plumbing — DELETE when a real shared
+# module lands in aws/_shared/.
+#
+# This module exists solely so that:
+#   - the embed glob aws/_shared/*/*.tf has at least one matching file
+#     (Go's embed requires every glob to match at least one file at compile
+#     time);
+#   - tests/validate-as-child.sh has a fixture to exercise the per-cloud
+#     `_shared` filter against;
+#   - the cross-cloud-no-providers lint has a sibling under per-cloud `_shared`
+#     to confirm it does NOT scan AWS-side helpers.
+#
+# A no-op module: one local, one output. Holds no resources, declares no
+# providers.
+
+terraform {
+  required_version = ">= 1.5"
+}
+
+locals {
+  smoke = "aws/_shared/_smoke"
+}

--- a/aws/_shared/_smoke/outputs.tf
+++ b/aws/_shared/_smoke/outputs.tf
@@ -1,0 +1,7 @@
+# Placeholder fixture for issue #203 plumbing — DELETE when a real shared
+# module lands in aws/_shared/.
+
+output "smoke" {
+  description = "Constant identifier proving the aws/_shared/_smoke fixture compiled and was reachable from the composer."
+  value       = local.smoke
+}

--- a/gcp/_shared/README.md
+++ b/gcp/_shared/README.md
@@ -1,0 +1,40 @@
+# gcp/_shared/
+
+GCP-only internal helper modules consumed by other GCP presets via
+`source = "../_shared/<name>"`.
+
+These are NOT top-level presets:
+
+- The composer skips any directory whose name begins with `_` when listing
+  preset keys, so `_shared` modules never get a `module "<key>" {}` block in
+  the composed root.
+- They are bundled into the composed workspace alongside any GCP preset that
+  references them (per-cloud isolation: AWS-only stacks do not pull GCP
+  helpers).
+
+## When to use this bucket
+
+Reach for `gcp/_shared/<name>/` when two or more GCP presets need the same
+small piece of logic — typical examples include the singleton existence
+probe (the v0.7.2 inlined helper that motivated #203), GCP label merging
+helpers, or the `var.project` vs `var.project_id` split (issue #157).
+
+If the helper would also be useful to an AWS preset (severity tagging, runbook
+URL conventions, naming-prefix normalization), put it in the top-level
+`_shared/<name>/` bucket instead — and ensure it declares ZERO cloud-specific
+providers (no `aws`, `google`, `google-beta`, `azurerm`).
+
+## Contract
+
+- Standard module layout: `main.tf` + `variables.tf` + `outputs.tf`.
+- May freely declare the `google` / `google-beta` providers.
+- Subject to GCP lint gates (e.g. `tests/lint-project-label.sh`).
+- Outputs MUST be plan-time-known if a consumer's `count` / `for_each` will
+  depend on them — see the singleton probe shape for the canonical pattern.
+- Document the helper's contract in the file header — these are part of the
+  internal preset API, not external surface.
+
+## References
+
+- Issue [#203](https://github.com/luthersystems/insideout-terraform-presets/issues/203) — shared-modules framework.
+- PR [#202](https://github.com/luthersystems/insideout-terraform-presets/pull/202) — inline workaround that motivated this bucket.

--- a/gcp/_shared/_smoke/main.tf
+++ b/gcp/_shared/_smoke/main.tf
@@ -1,0 +1,22 @@
+# Placeholder fixture for issue #203 plumbing — DELETE when a real shared
+# module lands in gcp/_shared/.
+#
+# This module exists solely so that:
+#   - the embed glob gcp/_shared/*/*.tf has at least one matching file
+#     (Go's embed requires every glob to match at least one file at compile
+#     time);
+#   - tests/validate-as-child.sh has a fixture to exercise the per-cloud
+#     `_shared` filter against;
+#   - the cross-cloud-no-providers lint has a sibling under per-cloud `_shared`
+#     to confirm it does NOT scan GCP-side helpers.
+#
+# A no-op module: one local, one output. Holds no resources, declares no
+# providers.
+
+terraform {
+  required_version = ">= 1.0"
+}
+
+locals {
+  smoke = "gcp/_shared/_smoke"
+}

--- a/gcp/_shared/_smoke/outputs.tf
+++ b/gcp/_shared/_smoke/outputs.tf
@@ -1,0 +1,7 @@
+# Placeholder fixture for issue #203 plumbing — DELETE when a real shared
+# module lands in gcp/_shared/.
+
+output "smoke" {
+  description = "Constant identifier proving the gcp/_shared/_smoke fixture compiled and was reachable from the composer."
+  value       = local.smoke
+}

--- a/pkg/composer/presets.go
+++ b/pkg/composer/presets.go
@@ -16,7 +16,24 @@ var allowedExt = map[string]bool{
 	".tf": true, ".tfvars": true, ".tf.json": true, ".terraform-version": true, ".tmpl": true, ".zip": true,
 }
 
+// isInternalDirName reports whether a preset-FS directory entry is an
+// internal (non-preset) bucket — i.e., shared/helper modules that the
+// composer must NOT enumerate as top-level presets. Issue #203 reserves
+// the leading-underscore convention (e.g. "_shared", "_smoke") for this.
+//
+// Centralised here so every walker (ListClouds, ListPresetKeysForCloud,
+// future callers) shares one definition; if a future PR moves the
+// convention to a different sigil or tightens it (e.g. "_shared" only),
+// this is the single edit site.
+func isInternalDirName(name string) bool {
+	return strings.HasPrefix(name, "_")
+}
+
 // ListClouds returns the available cloud providers (aws, gcp, etc).
+//
+// Top-level directories whose names begin with `_` are treated as internal
+// shared-module buckets (see issue #203 and `_shared/README.md`) and are
+// NOT returned — they are not consumable as standalone clouds.
 func (c *Client) ListClouds() ([]string, error) {
 	if c.presets == nil {
 		return nil, ErrNoPresetFS
@@ -27,9 +44,13 @@ func (c *Client) ListClouds() ([]string, error) {
 	}
 	var clouds []string
 	for _, e := range ents {
-		if e.IsDir() {
-			clouds = append(clouds, e.Name())
+		if !e.IsDir() {
+			continue
 		}
+		if isInternalDirName(e.Name()) {
+			continue
+		}
+		clouds = append(clouds, e.Name())
 	}
 	sort.Strings(clouds)
 	return clouds, nil
@@ -95,6 +116,11 @@ func (c *Client) ListAvailableComponentKeys() ([]string, error) {
 
 // ListPresetKeysForCloud lists module keys for a specific cloud provider.
 // Returns keys like "aws/vpc", "aws/ec2", etc.
+//
+// Sub-directories whose names begin with `_` are treated as internal
+// shared-module buckets (see issue #203 and `<cloud>/_shared/README.md`)
+// and are NOT returned — they are not top-level presets and the composer
+// must not emit `module "<key>" {}` blocks for them.
 func (c *Client) ListPresetKeysForCloud(cloud string) ([]string, error) {
 	if c.presets == nil {
 		return nil, ErrNoPresetFS
@@ -105,9 +131,13 @@ func (c *Client) ListPresetKeysForCloud(cloud string) ([]string, error) {
 	}
 	var keys []string
 	for _, e := range ents {
-		if e.IsDir() {
-			keys = append(keys, cloud+"/"+e.Name())
+		if !e.IsDir() {
+			continue
 		}
+		if isInternalDirName(e.Name()) {
+			continue
+		}
+		keys = append(keys, cloud+"/"+e.Name())
 	}
 	sort.Strings(keys)
 	return keys, nil

--- a/pkg/composer/shared_modules_filter_test.go
+++ b/pkg/composer/shared_modules_filter_test.go
@@ -1,0 +1,85 @@
+package composer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestListPresetKeysForCloud_SkipsSharedBucket pins the issue #203 contract
+// that internal helper buckets under aws/_shared/, gcp/_shared/ are NOT
+// returned as top-level preset keys. The composer must skip any directory
+// whose name begins with `_` so the helper trees never appear as
+// `module "<key>" {}` blocks in the composed root.
+//
+// Mutation coverage: deleting the leading-underscore filter in
+// presets.go::ListPresetKeysForCloud or relaxing it to a different sigil
+// (e.g. `.shared`) would let aws/_shared and gcp/_shared leak through and
+// fail this assertion.
+func TestListPresetKeysForCloud_SkipsSharedBucket(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	for _, cloud := range []string{"aws", "gcp"} {
+		keys, err := c.ListPresetKeysForCloud(cloud)
+		require.NoError(t, err, "ListPresetKeysForCloud(%s)", cloud)
+
+		for _, k := range keys {
+			// keys are returned as "<cloud>/<name>"; strip the cloud prefix
+			// and ensure the leaf does not begin with `_`.
+			name := strings.TrimPrefix(k, cloud+"/")
+			require.False(t, strings.HasPrefix(name, "_"),
+				"%s leaked an internal/_shared key %q — composer must skip leading-underscore dirs (issue #203)",
+				cloud, k)
+		}
+
+		// Cardinality floor: the filter must not eat every preset.
+		require.Greater(t, len(keys), 0,
+			"ListPresetKeysForCloud(%s) returned zero keys; the _shared filter is over-aggressive", cloud)
+	}
+}
+
+// TestListClouds_SkipsSharedBucket pins that the top-level cross-cloud
+// `_shared/` bucket is NOT enumerated as a cloud. Without this guard a
+// caller iterating `ListClouds()` would loop over `_shared` and treat its
+// helper modules as if they were a third cloud.
+func TestListClouds_SkipsSharedBucket(t *testing.T) {
+	t.Parallel()
+
+	clouds, err := newTestClient().ListClouds()
+	require.NoError(t, err)
+	for _, c := range clouds {
+		require.False(t, strings.HasPrefix(c, "_"),
+			"ListClouds returned an internal bucket %q — composer must skip leading-underscore dirs (issue #203)", c)
+	}
+	require.Contains(t, clouds, "aws")
+	require.Contains(t, clouds, "gcp")
+	require.NotContains(t, clouds, "_shared",
+		"top-level _shared/ must not appear in ListClouds (issue #203)")
+}
+
+// TestSharedSmokeFixturesAreEmbedded asserts the placeholder fixtures
+// shipped with the issue #203 plumbing are reachable via the embedded preset
+// FS. If a future PR deletes or moves them, the embed glob in zz_embed.go
+// would silently fail to compile (Go's embed requires every glob to match
+// at least one file) — but if someone adds another file that matches the
+// glob and removes the fixtures without updating the embed line, the
+// fixtures could disappear without alerting anyone. This test pins their
+// presence.
+func TestSharedSmokeFixturesAreEmbedded(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	for _, path := range []string{
+		"aws/_shared/_smoke",
+		"gcp/_shared/_smoke",
+		"_shared/_smoke",
+	} {
+		files, err := c.GetPresetFiles(path)
+		require.NoError(t, err, "GetPresetFiles(%s)", path)
+		require.NotEmpty(t, files, "%s smoke fixture has no embedded files", path)
+		_, hasMain := files["/main.tf"]
+		require.True(t, hasMain, "%s smoke fixture missing main.tf", path)
+	}
+}

--- a/tests/lint-shared-no-cloud-providers.sh
+++ b/tests/lint-shared-no-cloud-providers.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Static analysis: top-level _shared/<name>/ helpers (cross-cloud helpers, see
+# issue #203) MUST NOT declare any cloud-specific provider. Cross-cloud
+# helpers ride along with both AWS-only and GCP-only stacks, so dragging a
+# cloud-specific provider into them would force every consumer to install
+# that provider.
+#
+# Per-cloud helpers under aws/_shared/ and gcp/_shared/ are NOT scanned by
+# this script — they may freely declare their cloud's provider.
+#
+# Forbidden providers: aws, google, google-beta, azurerm, azuread,
+# kubernetes (cluster-specific), helm.
+# Permitted providers: null, random, http, time, local, external, tls,
+# archive, hashicorp/* generic providers.
+#
+# Detection: looks for `<provider> = { ... }` entries inside `required_providers`
+# blocks AND for top-level `provider "<provider>" {}` blocks.
+#
+# Cardinality floor: the script asserts at least one cross-cloud module was
+# scanned per run — silent zero-module passes (e.g. someone deletes the
+# bucket) defeat the test's purpose.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SHARED_DIR="$REPO_ROOT/_shared"
+
+# Cloud-specific providers that cross-cloud helpers must NOT declare.
+# Keep alphabetised.
+FORBIDDEN_PROVIDERS=(
+  aws
+  azuread
+  azurerm
+  google
+  google-beta
+  helm
+  kubernetes
+)
+
+forbidden_alt="$(IFS='|'; echo "${FORBIDDEN_PROVIDERS[*]}")"
+
+echo "=== Checking _shared/ (cross-cloud) helpers for cloud-specific providers ==="
+echo
+
+if [ ! -d "$SHARED_DIR" ]; then
+  echo "FAIL: $SHARED_DIR does not exist; cross-cloud bucket missing."
+  echo "      Issue #203 reserves _shared/ for cloud-agnostic helpers."
+  exit 1
+fi
+
+scanned=0
+any_fail=0
+
+# Iterate every top-level _shared/<name>/ directory (skip files at the bucket root).
+for moddir in "$SHARED_DIR"/*/; do
+  [ -d "$moddir" ] || continue
+  scanned=$((scanned + 1))
+
+  # Scan every .tf file in this module for forbidden provider declarations.
+  for tf in "$moddir"*.tf; do
+    [ -f "$tf" ] || continue
+
+    # Pattern 1: forbidden provider listed in a required_providers block.
+    #   required_providers {
+    #     aws = { source = "hashicorp/aws" ... }
+    #   }
+    # We match a leading-whitespace bare provider name followed by '=' followed by '{'.
+    bad=$(awk -v re="^[[:space:]]+(${forbidden_alt})[[:space:]]*=[[:space:]]*\\{" '
+      $0 ~ re {
+        printf "ERROR: %s:%d: cross-cloud helper declares forbidden provider in required_providers: %s\n", FILENAME, NR, $0
+      }
+    ' "$tf")
+    if [ -n "$bad" ]; then
+      echo "$bad"
+      any_fail=1
+    fi
+
+    # Pattern 2: top-level provider "aws" {}-style block.
+    bad=$(awk -v re="^[[:space:]]*provider[[:space:]]+\"(${forbidden_alt})\"" '
+      $0 ~ re {
+        printf "ERROR: %s:%d: cross-cloud helper declares forbidden top-level provider block: %s\n", FILENAME, NR, $0
+      }
+    ' "$tf")
+    if [ -n "$bad" ]; then
+      echo "$bad"
+      any_fail=1
+    fi
+
+    # Pattern 3: module source references that pull a cloud-specific upstream
+    # registry module (e.g. terraform-aws-modules/*, terraform-google-modules/*).
+    bad=$(awk '
+      /source[[:space:]]*=[[:space:]]*"terraform-(aws|google|azurerm)-modules\// {
+        printf "ERROR: %s:%d: cross-cloud helper sources a cloud-specific registry module: %s\n", FILENAME, NR, $0
+      }
+    ' "$tf")
+    if [ -n "$bad" ]; then
+      echo "$bad"
+      any_fail=1
+    fi
+  done
+done
+
+if (( scanned == 0 )); then
+  echo "FAIL: scanned zero cross-cloud helper modules under $SHARED_DIR/."
+  echo "      Issue #203 requires at least one (the _smoke fixture qualifies)."
+  exit 1
+fi
+
+if (( any_fail )); then
+  echo
+  echo "FAIL: One or more cross-cloud helpers declare a cloud-specific provider."
+  echo "      Cross-cloud helpers ride along with both AWS-only and GCP-only"
+  echo "      stacks; they MUST NOT pull in aws / google / google-beta /"
+  echo "      azurerm. If the helper genuinely needs a cloud API, move it to"
+  echo "      aws/_shared/<name>/ or gcp/_shared/<name>/ instead."
+  exit 1
+fi
+
+echo "PASS: All $scanned cross-cloud helper module(s) under _shared/ are provider-clean."

--- a/tests/validate-as-child.sh
+++ b/tests/validate-as-child.sh
@@ -19,23 +19,54 @@
 # - The synthetic root passes no arguments; Terraform's parser tolerates
 #   missing required variables at init time. Variable validation runs at
 #   plan/apply.
+# - aws/_shared/, gcp/_shared/, _shared/ buckets (issue #203) are NOT
+#   wrapped as standalone presets — they are internal helpers the composer
+#   skips during preset enumeration. They DO get bundled alongside any
+#   wrapped preset that references them via `source = "../_shared/<name>"`
+#   so that path resolves under a single Terraform "module package"
+#   (Terraform rejects `../` source traversal across package boundaries —
+#   `Local module path escapes module package`).
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TARGET="${1:-}"
 
+# is_shared_path returns success (0) iff the given preset path lives under a
+# leading-underscore "_shared" or "_<bucket>" directory anywhere in its
+# ancestry — i.e. it's an internal helper module rather than a top-level
+# preset. Mirrors composer.isInternalDirName in pkg/composer/presets.go.
+is_shared_path() {
+  case "$1" in
+    _*|*/_*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 if [ -n "$TARGET" ]; then
   if [ ! -d "$REPO_ROOT/$TARGET" ]; then
     echo "ERROR: $REPO_ROOT/$TARGET is not a directory" >&2
     exit 2
   fi
+  if is_shared_path "$TARGET"; then
+    echo "ERROR: $TARGET is an internal _shared bucket, not a top-level preset." >&2
+    echo "       Internal helpers are validated transitively when a preset that" >&2
+    echo "       depends on them is wrapped. See issue #203." >&2
+    exit 2
+  fi
   presets=("$TARGET")
 else
   # Avoid mapfile so this runs on macOS bash 3.2 without GNU bash 4+.
+  # find -mindepth 1 -maxdepth 1 enumerates aws/<x> and gcp/<x>; we then
+  # filter out any path whose first component starts with `_` (e.g.
+  # aws/_shared) — those are bundled, not wrapped. The leaf-level
+  # filename-leading-underscore convention (e.g. `_smoke` if it ever
+  # appeared at top level) would also be skipped.
   presets=()
   while IFS= read -r d; do
-    [ -n "$d" ] && presets+=("$d")
+    [ -n "$d" ] || continue
+    is_shared_path "$d" && continue
+    presets+=("$d")
   done < <(find "$REPO_ROOT/aws" "$REPO_ROOT/gcp" -mindepth 1 -maxdepth 1 -type d 2>/dev/null \
     | sort \
     | while read -r dir; do [ -f "$dir/.validate-skip" ] || echo "${dir#"$REPO_ROOT/"}"; done)
@@ -49,11 +80,92 @@ echo
 work="$(mktemp -d -t validate-as-child.XXXXXX)"
 trap 'rm -rf "$work"' EXIT
 
+# bundle_pkg_for_preset stages a preset and any shared modules it references
+# into a single synthetic Terraform "module package" rooted at $pkg_base. The
+# layout mirrors the live repo so the preset's existing `../_shared/<name>`
+# (per-cloud) and `../../_shared/<name>` (cross-cloud) source paths resolve
+# without rewriting:
+#
+#   $pkg_base/<cloud>/<preset_name>/  ← wrapped preset
+#   $pkg_base/<cloud>/_shared/<name>/ ← per-cloud helpers it references
+#   $pkg_base/_shared/<name>/         ← cross-cloud helpers it references
+#
+# From $pkg_base/<cloud>/<preset_name>/main.tf, `../_shared/<name>` resolves
+# to $pkg_base/<cloud>/_shared/<name>/, and `../../_shared/<name>` resolves
+# to $pkg_base/_shared/<name>/ — Terraform treats $pkg_base as a single
+# module package so the `../` traversal stays inside one package, avoiding
+# the "Local module path escapes module package" error that surfaced in #203.
+#
+# Args:
+#   $1 — preset path (e.g. "aws/vpc")
+#   $2 — synthetic package base (e.g. "$work/aws/vpc/pkg")
+bundle_pkg_for_preset() {
+  local preset_path="$1"
+  local pkg_base="$2"
+  local cloud src
+  cloud="${preset_path%%/*}"
+
+  mkdir -p "$pkg_base/$cloud"
+  cp -R "$REPO_ROOT/$preset_path" "$pkg_base/$cloud/"
+
+  # Per-cloud shared refs: `../_shared/<name>` from within aws/<m>/ resolves
+  # to aws/_shared/<name>. Mirror that layout under $pkg_base/<cloud>/.
+  while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    src="$REPO_ROOT/$cloud/_shared/$ref"
+    if [ -d "$src" ]; then
+      mkdir -p "$pkg_base/$cloud/_shared"
+      cp -R "$src" "$pkg_base/$cloud/_shared/"
+    fi
+  done < <(grep -hE 'source[[:space:]]*=[[:space:]]*"\.\./_shared/[^"]+"' \
+             "$REPO_ROOT/$preset_path"/*.tf 2>/dev/null \
+             | sed -E 's|.*"\.\./_shared/([^"]+)".*|\1|' \
+             | sort -u)
+
+  # Cross-cloud shared refs: `../../_shared/<name>` from within aws/<m>/
+  # resolves to ./_shared/<name> at the repo root. Mirror under $pkg_base/.
+  while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    src="$REPO_ROOT/_shared/$ref"
+    if [ -d "$src" ]; then
+      mkdir -p "$pkg_base/_shared"
+      cp -R "$src" "$pkg_base/_shared/"
+    fi
+  done < <(grep -hE 'source[[:space:]]*=[[:space:]]*"\.\./\.\./_shared/[^"]+"' \
+             "$REPO_ROOT/$preset_path"/*.tf 2>/dev/null \
+             | sed -E 's|.*"\.\./\.\./_shared/([^"]+)".*|\1|' \
+             | sort -u)
+}
+
 any_fail=0
 for p in "${presets[@]}"; do
   rootdir="$work/$p"
   mkdir -p "$rootdir"
-  cat > "$rootdir/main.tf" <<EOF
+
+  # Detect whether the preset references any shared modules. If so, build a
+  # synthetic "package" workdir under $rootdir/pkg/ that co-locates the
+  # preset with its shared deps so `../_shared/<name>` resolves within a
+  # single Terraform module package (Terraform rejects `../` source
+  # traversal across package boundaries).
+  needs_pkg=0
+  if grep -qE 'source[[:space:]]*=[[:space:]]*"\.\./(\.\./)?_shared/' "$REPO_ROOT/$p"/*.tf 2>/dev/null; then
+    needs_pkg=1
+  fi
+
+  if (( needs_pkg )); then
+    pkg_base="$rootdir/pkg"
+    bundle_pkg_for_preset "$p" "$pkg_base"
+    cat > "$rootdir/main.tf" <<EOF
+# Auto-generated synthetic root for tests/validate-as-child.sh
+# Wraps $p (with bundled _shared/ deps) as a child module to verify it
+# parses under the actual consumption shape (composer-emitted root +
+# module instantiation + bundled shared helpers; see issue #203).
+module "child" {
+  source = "./pkg/$p"
+}
+EOF
+  else
+    cat > "$rootdir/main.tf" <<EOF
 # Auto-generated synthetic root for tests/validate-as-child.sh
 # Wraps $p as a child module to verify it parses under the actual
 # consumption shape (composer-emitted root + module instantiation).
@@ -61,6 +173,8 @@ module "child" {
   source = "$REPO_ROOT/$p"
 }
 EOF
+  fi
+
   if out=$(terraform -chdir="$rootdir" init -backend=false -input=false -no-color 2>&1); then
     printf "  PASS  %s\n" "$p"
   else

--- a/zz_embed.go
+++ b/zz_embed.go
@@ -4,11 +4,20 @@ import "embed"
 
 // Include all files the composer consumes: .tf, .tmpl, and binary assets (.zip).
 // DO NOT include provider caches, .terraform/*, or lockfiles.
-// Structure: aws/<module>/*.tf and gcp/<module>/*.tf
+// Structure:
+//   aws/<module>/*.tf, gcp/<module>/*.tf — top-level cloud presets
+//   aws/_shared/<name>/*.tf, gcp/_shared/<name>/*.tf — per-cloud helpers (issue #203)
+//   _shared/<name>/*.tf — cross-cloud helpers (issue #203)
 //
 // Note: Go embed requires at least one file to match each pattern.
 // AWS has .tmpl files (bastion/user_data.sh.tmpl), GCP does not yet.
 // We use separate embed lines for optional patterns.
+//
+// The _shared buckets are NOT top-level presets — the composer skips any
+// directory whose name begins with `_` when listing preset keys. Each
+// `_shared` glob has at least one fixture file in this repo to satisfy Go's
+// "every glob must match" rule; see <bucket>/_smoke/ for the placeholders
+// (DELETE them when real shared modules land).
 //
 // IMPORT-CYCLE WARNING: pkg/composer imports this root package to wire
 // its default preset FS. Do not add imports to this file that reach
@@ -16,6 +25,8 @@ import "embed"
 // create a compile-time import cycle. Keep this file a pure leaf.
 //
 //go:embed aws/*/*.tf gcp/*/*.tf
+//go:embed aws/_shared/*/*.tf gcp/_shared/*/*.tf
+//go:embed _shared/*/*.tf
 //go:embed aws/*/*.tmpl
 //go:embed aws/*/*.zip gcp/*/*.zip
 var FS embed.FS


### PR DESCRIPTION
## Summary

Three-bucket framework for internal helper modules so future preset PRs can extract shared logic without re-litigating directory structure, composer awareness, or test gates:

| Path | Scope |
|---|---|
| `aws/_shared/<name>/` | AWS-only helpers |
| `gcp/_shared/<name>/` | GCP-only helpers |
| `_shared/<name>/` (top-level) | Cloud-agnostic helpers (no `aws`/`google`/`google-beta` providers) |

Leading-underscore convention signals "internal, not a top-level preset." The composer skips `_*` directories during preset enumeration; lint gates enforce the cross-cloud no-provider constraint.

## Plumbing

- **`pkg/composer/presets.go`** — `ListClouds` and `ListPresetKeysForCloud` skip leading-underscore directories via a new `isInternalDirName` helper.
- **`zz_embed.go`** — three new `//go:embed` lines covering `aws/_shared/*/*.tf`, `gcp/_shared/*/*.tf`, and `_shared/*/*.tf`.
- **`tests/validate-as-child.sh`** — filters `_*` paths from auto-enumeration, rejects explicit `_shared/...` targets with exit 2, and bundles referenced helpers into a single Terraform module package alongside the wrapped preset (per-cloud `../_shared/<name>` and cross-cloud `../../_shared/<name>` source paths both resolve correctly without the package-boundary error from #203).
- **`tests/lint-shared-no-cloud-providers.sh`** (new) — asserts no module under top-level `_shared/` declares cloud-specific providers (`aws`, `google`, `google-beta`, `azurerm`, `azuread`, `helm`, `kubernetes`). Cardinality floor ≥1.
- **`pkg/composer/shared_modules_filter_test.go`** (new) — three pinning tests covering `ListPresetKeysForCloud`/`ListClouds` skip + embed presence.

## Smoke fixtures (deletable once a real shared module lands)

- `aws/_shared/_smoke/`, `gcp/_shared/_smoke/`, `_shared/_smoke/` each contain a no-op `main.tf` + `outputs.tf` (single output returning a constant string) marked with header comments. They exist to exercise the embed glob, the validate-as-child filter, and the lint gates.

## Docs

- New "Shared / Helper Modules (issue #203)" section in `CLAUDE.md` with the three-bucket convention, when to use which, and the cross-cloud-no-provider constraint.
- One-paragraph addition each in `.claude/skills/add-aws-module/SKILL.md` and `.claude/skills/add-gcp-module/SKILL.md` pointing future preset authors at the shared buckets.

## Verification gauntlet — all green

| Check | Result |
|---|---|
| `terraform fmt -check -recursive` | PASS |
| `tests/validate-as-child.sh` | PASS — 54/54 |
| `tests/lint-no-root-only-blocks.sh` | PASS |
| `tests/lint-project-label.sh` | PASS |
| `tests/lint-foreach-unknown-keys.sh` | PASS |
| `tests/lint-sensitive-for-each.sh` | PASS |
| `tests/lint-project-tag.sh` | PASS |
| `tests/lint-shared-no-cloud-providers.sh` (new) | PASS |
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `go test ./pkg/composer/...` | PASS |
| `go test ./... -count=1` | PASS (root + cmd + 4 composer subpkgs) |
| `TestKnownFieldsNoShrink` | PASS (no re-seed needed) |
| Manual: per-cloud `../_shared/<name>` bundle path | PASS |
| Manual: cross-cloud `../../_shared/<name>` bundle path | PASS |
| Manual: explicit `_shared/...` target rejection | PASS (exit 2) |

## Out of scope (separate PRs)

- Refactoring `gcp/identity_platform`'s inline `data.http` probe (v0.7.2) into a real `gcp/_shared/<name>/` helper — gated on a second consumer or explicit decision.
- First real cross-cloud helper (severity tagging from #204) — gated on the observability migration design landing.
- Composer-side bundling logic in `luthersystems/reliable` for the shared-modules pattern — consumer-side work, separate repo.

Closes #203.