### PR TITLE
fix(aws/eks_nodegroup): auto-derive ami_type from instance family (#207)

### DIFF
--- a/aws/eks_nodegroup/main.tf
+++ b/aws/eks_nodegroup/main.tf
@@ -21,6 +21,23 @@ module "name" {
 
 locals {
   common_tags = module.name.tags
+
+  # Auto-derive ami_type from the first instance type's family so ARM/Graviton
+  # node groups (c7g.large, m7g.xlarge, etc.) don't silently fall back to the
+  # provider's x86 default and produce DEGRADED addons (#207). Graviton/ARM
+  # EC2 families end in `g` (e.g. c7g, m7g, r7g, t4g, c8g, m8g, r8g; with the
+  # optional `d`, `n`, `en`, `ad`, `adn` storage/network suffixes).
+  # Match the family prefix before the size suffix: `c7g.large` → family
+  # `c7g` → ARM. The first instance type drives the choice; mixed-arch
+  # instance lists are not supported by EKS managed node groups (homogeneous
+  # AMI requirement) and are rejected upstream regardless. Caller can
+  # override via var.ami_type.
+  _first_instance_type = length(var.instance_types) > 0 ? var.instance_types[0] : "c7i.large"
+  _instance_family     = split(".", local._first_instance_type)[0]
+  _is_arm_family       = can(regex("^[a-z]+[0-9]+g(d|n|en|ad|adn)?$", local._instance_family))
+
+  derived_ami_type  = local._is_arm_family ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
+  resolved_ami_type = coalesce(var.ami_type, local.derived_ami_type)
 }
 
 # -------------------------------------------------------------
@@ -118,6 +135,12 @@ resource "aws_eks_node_group" "this" {
 
   # Required; use c7i/c7g/etc. passed from root (computed by composer/mapper)
   instance_types = var.instance_types
+
+  # Auto-derived from the first instance type's family unless var.ami_type is
+  # set explicitly. Without this argument the provider defaults to
+  # AL2023_x86_64_STANDARD, which silently breaks ARM instance choices like
+  # c7g.large (#207).
+  ami_type = local.resolved_ami_type
 
   # When null the provider defaults to ON_DEMAND
   capacity_type = var.capacity_type

--- a/aws/eks_nodegroup/outputs.tf
+++ b/aws/eks_nodegroup/outputs.tf
@@ -22,3 +22,8 @@ output "capacity_type" {
   description = "Capacity type for this node group (ON_DEMAND or SPOT)"
   value       = var.capacity_type
 }
+
+output "ami_type" {
+  description = "Resolved AMI type used by the node group (derived from instance_types when var.ami_type is null; #207)."
+  value       = local.resolved_ami_type
+}

--- a/aws/eks_nodegroup/tests/eks_nodegroup.tftest.hcl
+++ b/aws/eks_nodegroup/tests/eks_nodegroup.tftest.hcl
@@ -1,0 +1,122 @@
+# Hermetic plan tests for the AMI-type auto-derive logic added in #207.
+#
+# Failure mode this guards against: when ami_type is omitted on
+# aws_eks_node_group, the AWS provider defaults to AL2023_x86_64_STANDARD.
+# Selecting a Graviton instance (c7g.large, m7g.xlarge, etc.) then produces
+# an arch mismatch — workers never come up and aws-ebs-csi-driver / coredns
+# sit DEGRADED until the addon timeout fires. The auto-derive picks
+# AL2023_ARM_64_STANDARD when the first instance type's family ends in `g`
+# (Graviton convention: c7g, m7g, r7g, t4g, c8g, m8g, r8g, ...) and falls
+# back to AL2023_x86_64_STANDARD otherwise. var.ami_type overrides the
+# derive so callers retain full control (Bottlerocket, GPU, etc.).
+
+mock_provider "aws" {}
+
+variables {
+  project      = "test"
+  region       = "us-east-1"
+  environment  = "test"
+  cluster_name = "test-cluster"
+  subnet_ids   = ["subnet-aaa", "subnet-bbb"]
+  desired_size = 2
+  min_size     = 1
+  max_size     = 3
+  # Pass an existing role ARN so the module's count-gated IAM role + assume
+  # policy resources don't run under mock_provider — the AWS mock returns
+  # a non-JSON value for data.aws_iam_policy_document.mng_assume.json,
+  # which the iam-role validator rejects. The AMI-type derive doesn't
+  # depend on role creation, so this stays orthogonal to what's under test.
+  node_role_arn = "arn:aws:iam::123456789012:role/test-eks-node-role"
+}
+
+run "arm_family_derives_arm_ami" {
+  command = plan
+
+  variables {
+    instance_types = ["c7g.large"]
+  }
+
+  assert {
+    condition     = output.ami_type == "AL2023_ARM_64_STANDARD"
+    error_message = "Graviton family c7g.large must derive AL2023_ARM_64_STANDARD (#207)"
+  }
+  assert {
+    condition     = aws_eks_node_group.this.ami_type == "AL2023_ARM_64_STANDARD"
+    error_message = "node group resource ami_type must be set to AL2023_ARM_64_STANDARD when first instance type is c7g.large (#207)"
+  }
+}
+
+run "x86_intel_family_derives_x86_ami" {
+  command = plan
+
+  variables {
+    instance_types = ["c7i.large"]
+  }
+
+  assert {
+    condition     = output.ami_type == "AL2023_x86_64_STANDARD"
+    error_message = "x86 Intel family c7i.large must derive AL2023_x86_64_STANDARD"
+  }
+  assert {
+    condition     = aws_eks_node_group.this.ami_type == "AL2023_x86_64_STANDARD"
+    error_message = "node group resource ami_type must be set to AL2023_x86_64_STANDARD when first instance type is c7i.large"
+  }
+}
+
+run "x86_general_family_derives_x86_ami" {
+  command = plan
+
+  variables {
+    instance_types = ["m5.xlarge"]
+  }
+
+  assert {
+    condition     = output.ami_type == "AL2023_x86_64_STANDARD"
+    error_message = "x86 general-purpose family m5.xlarge must derive AL2023_x86_64_STANDARD"
+  }
+}
+
+run "explicit_bottlerocket_arm_overrides_derive" {
+  command = plan
+
+  variables {
+    instance_types = ["c7g.large"]
+    ami_type       = "BOTTLEROCKET_ARM_64"
+  }
+
+  assert {
+    condition     = output.ami_type == "BOTTLEROCKET_ARM_64"
+    error_message = "explicit var.ami_type must override the auto-derived value"
+  }
+  assert {
+    condition     = aws_eks_node_group.this.ami_type == "BOTTLEROCKET_ARM_64"
+    error_message = "node group resource ami_type must reflect explicit var.ami_type override"
+  }
+}
+
+run "mixed_family_first_instance_type_drives" {
+  command = plan
+
+  # EKS managed node groups require homogeneous architecture; the first
+  # instance type in the list is the canonical choice. Pin that the
+  # derive uses [0] and not some other heuristic (alphabetical, last, etc.).
+  variables {
+    instance_types = ["c7g.large", "c7g.xlarge", "m7g.large"]
+  }
+
+  assert {
+    condition     = output.ami_type == "AL2023_ARM_64_STANDARD"
+    error_message = "first instance type drives the AMI choice; ARM-led list must derive AL2023_ARM_64_STANDARD"
+  }
+}
+
+run "bogus_ami_type_fails_validation" {
+  command = plan
+
+  variables {
+    instance_types = ["c7i.large"]
+    ami_type       = "FAKE_TYPE"
+  }
+
+  expect_failures = [var.ami_type]
+}

--- a/aws/eks_nodegroup/variables.tf
+++ b/aws/eks_nodegroup/variables.tf
@@ -117,3 +117,19 @@ variable "node_role_arn" {
   type        = string
   default     = null
 }
+
+variable "ami_type" {
+  description = "EKS node AMI type. When null (default), the module derives the AMI type from var.instance_types: ARM/Graviton families (c7g, m7g, r7g, t4g, c8g, m8g, r8g, etc. — names ending in `g`) get AL2023_ARM_64_STANDARD; all other families get AL2023_x86_64_STANDARD. Set explicitly to override (e.g. BOTTLEROCKET_x86_64, AL2_x86_64_GPU)."
+  type        = string
+  default     = null
+
+  validation {
+    condition = var.ami_type == null ? true : contains([
+      "AL2_x86_64", "AL2_x86_64_GPU", "AL2_ARM_64",
+      "AL2023_x86_64_STANDARD", "AL2023_ARM_64_STANDARD", "AL2023_x86_64_NEURON", "AL2023_x86_64_NVIDIA",
+      "BOTTLEROCKET_x86_64", "BOTTLEROCKET_ARM_64", "BOTTLEROCKET_x86_64_NVIDIA", "BOTTLEROCKET_ARM_64_NVIDIA",
+      "WINDOWS_CORE_2019_x86_64", "WINDOWS_FULL_2019_x86_64", "WINDOWS_CORE_2022_x86_64", "WINDOWS_FULL_2022_x86_64",
+    ], var.ami_type)
+    error_message = "ami_type must be a supported EKS-managed AMI type. See https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType."
+  }
+}

--- a/pkg/composer/eks_ami_type_test.go
+++ b/pkg/composer/eks_ami_type_test.go
@@ -1,0 +1,73 @@
+package composer
+
+import (
+	"strings"
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEKSNodeGroupHasAMIType asserts every aws_eks_node_group resource
+// declared anywhere in the preset library sets an ami_type attribute.
+//
+// Without this guard, omitting ami_type causes the AWS provider to default
+// to AL2023_x86_64_STANDARD. Picking a Graviton instance type (c7g.large,
+// m7g.xlarge, etc.) then produces an architecture mismatch: workers never
+// come up, aws-ebs-csi-driver and coredns sit DEGRADED until the 20m addon
+// timeout fires. This was the root cause behind issue #207 (Dario's session
+// sess_v2_hrbS5zpRBk51, job ccs-6ee757a6-mr95b — DEGRADED addons were the
+// downstream symptom of the AMI/instance arch mismatch).
+//
+// Pure structural check — does NOT require AWS credentials, mocks, or real
+// apply. Parses the embedded preset HCL offline.
+func TestEKSNodeGroupHasAMIType(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	keys, err := c.ListPresetKeysForCloud("aws")
+	require.NoError(t, err)
+
+	checked := 0
+	for _, presetPath := range keys {
+		files, err := c.GetPresetFiles(presetPath)
+		require.NoError(t, err, "GetPresetFiles(%s)", presetPath)
+
+		for fileName, content := range files {
+			if !strings.HasSuffix(fileName, ".tf") {
+				continue
+			}
+
+			f, diags := hclsyntax.ParseConfig(content, fileName, hcl.InitialPos)
+			require.False(t, diags.HasErrors(), "parse %s%s: %s", presetPath, fileName, diags.Error())
+
+			body, ok := f.Body.(*hclsyntax.Body)
+			if !ok {
+				continue
+			}
+
+			for _, block := range body.Blocks {
+				if block.Type != "resource" {
+					continue
+				}
+				if len(block.Labels) < 2 || block.Labels[0] != "aws_eks_node_group" {
+					continue
+				}
+				_, hasAMIType := block.Body.Attributes["ami_type"]
+				require.True(t, hasAMIType,
+					"%s%s: resource %q.%q must set ami_type — omitting it lets the provider default to AL2023_x86_64_STANDARD and breaks ARM/Graviton instance choices (issue #207)",
+					presetPath, fileName, block.Labels[0], block.Labels[1])
+				checked++
+			}
+		}
+	}
+
+	// Cardinality floor: the loop has to fire at least once for the guard
+	// to be meaningful. If it falls to 0 (e.g. someone deletes the
+	// eks_nodegroup preset entirely or the iteration shape silently
+	// breaks), this test would otherwise pass vacuously and the
+	// regression returns.
+	require.GreaterOrEqual(t, checked, 1,
+		"expected at least one aws_eks_node_group resource in the preset library; got 0 — test silently passing")
+}


### PR DESCRIPTION
## Summary

Auto-derive `ami_type` on `aws_eks_node_group` from the first instance type's family so ARM/Graviton choices (`c7g.large`, `m7g.xlarge`, ...) don't silently fall back to the provider's `AL2023_x86_64_STANDARD` default and break workers at create time. **Closes #207.**

## Failure mode

Dario's session `sess_v2_hrbS5zpRBk51` hit `JOB_STATUS_FAILURE` on two consecutive applies. Job `ccs-6ee757a6-mr95b` died at 2026-05-01T12:59:50Z after ~36min:

```
Error: waiting for EKS Add-On (...:aws-ebs-csi-driver) create:
  timeout while waiting for state to become 'ACTIVE' (last state: 'DEGRADED', timeout: 20m0s)
Error: waiting for EKS Add-On (...:coredns) create:
  timeout while waiting for state to become 'ACTIVE' (last state: 'DEGRADED', timeout: 20m0s)
```

The DEGRADED addons are a **downstream symptom**, not the root cause. The root cause is upstream:

- `aws/eks_nodegroup/main.tf` declared `aws_eks_node_group.this` with no `ami_type` argument and no `ami_type` variable.
- AWS provider defaults to `AL2023_x86_64_STANDARD` when `ami_type` is omitted.
- Stack chose `instance_types = ["c7g.large"]` (Graviton/ARM). EKS rejects `c7g.large` against an x86 AMI with `InvalidParameterException`. Workers never come up.
- `coredns` and `aws-ebs-csi-driver` (which schedule on workers — unlike `vpc-cni`/`kube-proxy` which set `before_compute = true`) sit DEGRADED until the 20m addon timeout fires.

## Auto-derive logic

Graviton/ARM EC2 families end in `g` — `c7g`, `m7g`, `r7g`, `t4g`, `c8g`, `m8g`, `r8g`, with the optional `d`/`n`/`en`/`ad`/`adn` storage-network suffixes. All other families are x86. Match the family prefix before the size suffix: `c7g.large` -> family `c7g` -> ARM -> `AL2023_ARM_64_STANDARD`.

```hcl
locals {
  _first_instance_type = length(var.instance_types) > 0 ? var.instance_types[0] : "c7i.large"
  _instance_family     = split(".", local._first_instance_type)[0]
  _is_arm_family       = can(regex("^[a-z]+[0-9]+g(d|n|en|ad|adn)?$", local._instance_family))

  derived_ami_type  = local._is_arm_family ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
  resolved_ami_type = coalesce(var.ami_type, local.derived_ami_type)
}
```

The first instance type drives the choice. EKS managed node groups require homogeneous architecture per group, so a mixed-arch list would be rejected upstream regardless. An explicit `var.ami_type` (with validation pinned to the supported EKS API list) overrides the derive so callers retain full control over Bottlerocket / GPU / Windows.

Why preset-only: minimum blast radius. Composer (`pkg/composer/mapper.go`) plumbs `instance_types` straight through; no mapper changes needed. The fix lives entirely in `aws/eks_nodegroup/`.

## Judgment calls

- **Default left as `null`** rather than `AL2023_x86_64_STANDARD`. Null preserves the auto-derive behaviour and makes "I want the safe default for whatever instance I pick" the zero-config path. Explicit override is one variable away.
- **Test fixture sets `node_role_arn`** so the count-gated IAM role + assume-policy resources don't run under `mock_provider`. The AWS mock returns a non-JSON value for `data.aws_iam_policy_document.mng_assume.json`, which the iam-role validator rejects. The AMI-type derive doesn't depend on role creation, so this stays orthogonal to what's under test.
- **Validation list of AMI types**: pulled from the [EKS Nodegroup API reference](https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType). If AWS adds new entries (e.g. AL2024 down the line), this list will need a refresh; alternative would be to skip validation entirely and trust the provider, but the explicit list catches typos at plan time which is the bigger win.
- **No `Co-Authored-By`** per global rules.

## Test matrix

`aws/eks_nodegroup/tests/eks_nodegroup.tftest.hcl` (hermetic, `mock_provider "aws" {}` + `command = plan`):

| Run block | Input | Expected |
|---|---|---|
| `arm_family_derives_arm_ami` | `instance_types = ["c7g.large"]` | `output.ami_type == "AL2023_ARM_64_STANDARD"` and node group resource matches |
| `x86_intel_family_derives_x86_ami` | `instance_types = ["c7i.large"]` | `output.ami_type == "AL2023_x86_64_STANDARD"` |
| `x86_general_family_derives_x86_ami` | `instance_types = ["m5.xlarge"]` | `output.ami_type == "AL2023_x86_64_STANDARD"` |
| `explicit_bottlerocket_arm_overrides_derive` | `c7g.large` + `var.ami_type = "BOTTLEROCKET_ARM_64"` | output equals override |
| `mixed_family_first_instance_type_drives` | `["c7g.large", "c7g.xlarge", "m7g.large"]` | ARM wins (first instance type drives) |
| `bogus_ami_type_fails_validation` | `var.ami_type = "FAKE_TYPE"` | `expect_failures = [var.ami_type]` |

Plus `pkg/composer/eks_ami_type_test.go` — structural pin asserting every `aws_eks_node_group` resource block in the preset library sets `ami_type`. Cardinality floor (`>= 1`) prevents silent vacuous passing if the eks_nodegroup preset is ever deleted or the iteration shape silently breaks.

## Verification gauntlet

```text
$ terraform fmt -check -recursive                                # ---FMT_EXIT: 0
$ ( cd aws/eks_nodegroup && terraform init -backend=false ... )  # ---INIT_EXIT: 0
$ ( cd aws/eks_nodegroup && terraform validate )                 # Success! The configuration is valid.  ---VALIDATE_EXIT: 0
$ ( cd aws/eks_nodegroup && terraform test )
  run "arm_family_derives_arm_ami"... pass
  run "x86_intel_family_derives_x86_ami"... pass
  run "x86_general_family_derives_x86_ami"... pass
  run "explicit_bottlerocket_arm_overrides_derive"... pass
  run "mixed_family_first_instance_type_drives"... pass
  run "bogus_ami_type_fails_validation"... pass
  Success! 6 passed, 0 failed.
$ tests/validate-as-child.sh aws/eks_nodegroup                   # PASS  aws/eks_nodegroup  ---VAC_EXIT: 0
$ tests/lint-no-root-only-blocks.sh                              # PASS: No preset module contains root-only blocks.
$ tests/lint-project-tag.sh                                      # PASS: All taggable AWS resources carry the Project-tag convention.
$ tests/lint-foreach-unknown-keys.sh                             # PASS: No apply-time-unknown values found in for_each map keys.
$ tests/lint-sensitive-for-each.sh                               # PASS: No sensitive variables found in for_each without nonsensitive()
$ go test ./pkg/composer/...                                     # ok  github.com/luthersystems/insideout-terraform-presets/pkg/composer  63.702s
$ go build ./...                                                 # ---GOBUILD_EXIT: 0
$ go test -run "TestKnownFieldsNoShrink|TestPresetDefaultsSatisfyValidations|TestEveryPresetHasResourceOrModuleCall|TestEKSNodeGroupHasAMIType" -v
  --- PASS: TestKnownFieldsNoShrink (0.00s)
  --- PASS: TestEKSNodeGroupHasAMIType (0.04s)
  --- PASS: TestEveryPresetHasResourceOrModuleCall (0.06s)
  --- PASS: TestPresetDefaultsSatisfyValidations (0.06s)
```

`TestKnownFieldsNoShrink` did **not** require a golden re-seed — adding the new `ami_type` variable widens the known-fields set rather than shrinking it, so the "no shrink" guard passes naturally.

## Out of scope (separate follow-ups)

- VPC interface endpoints for fully-private clusters (Explore agent flagged S3 gateway endpoint only; ECR/EKS/STS/EC2/CloudWatch Logs interface endpoints missing). Dario's stack uses NAT so workers reach public ECR — not a blocker today.
- `endpoint_public_access = false` enforcement on `aws/resource/main.tf`.
- Composer-side validation that EKS instance type and architecture agree — defense-in-depth; auto-derive removes the surface entirely so deferring is fine.

## Related

- Closes #207
- Failing job: `ccs-6ee757a6-mr95b` on session `sess_v2_hrbS5zpRBk51` (project `6ee757a6-...`, AWS account `141812438321`)
- Post-merge follow-ups (handled by parent session, not this PR): bump preset version in `reliable`, re-trigger Dario's session re-deploy.