### PR TITLE
fix(aws/cognito): emit TOTP MFA factor when mfa_required=true (#208)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 # Claude Code local settings (keep shared .claude/settings.json)
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+.claude/worktrees/

--- a/aws/cognito/main.tf
+++ b/aws/cognito/main.tf
@@ -47,6 +47,16 @@ resource "aws_cognito_user_pool" "this" {
   alias_attributes         = local.alias_attributes
   mfa_configuration        = var.mfa_required ? "ON" : "OFF"
 
+  # MFA factor — required when mfa_configuration = "ON". TOTP is the only
+  # factor that needs no extra wiring (SMS needs SNS origination identity,
+  # Email needs SES domain). #208.
+  dynamic "software_token_mfa_configuration" {
+    for_each = var.mfa_required && var.mfa_factor == "totp" ? [1] : []
+    content {
+      enabled = true
+    }
+  }
+
   email_verification_subject = "${var.project} verification code"
   email_verification_message = "Your verification code is {####}"
 

--- a/aws/cognito/main.tf
+++ b/aws/cognito/main.tf
@@ -50,6 +50,9 @@ resource "aws_cognito_user_pool" "this" {
   # MFA factor — required when mfa_configuration = "ON". TOTP is the only
   # factor that needs no extra wiring (SMS needs SNS origination identity,
   # Email needs SES domain). #208.
+  # TODO(#208): when SMS / Email factors are added to the variable's allowed
+  # set, add the corresponding `dynamic "sms_configuration"` /
+  # `dynamic "email_mfa_configuration"` blocks here, gated on the factor.
   dynamic "software_token_mfa_configuration" {
     for_each = var.mfa_required && var.mfa_factor == "totp" ? [1] : []
     content {

--- a/aws/cognito/tests/mfa.tftest.hcl
+++ b/aws/cognito/tests/mfa.tftest.hcl
@@ -24,6 +24,14 @@ run "cognito_mfa_required_emits_totp_factor" {
     condition     = length(aws_cognito_user_pool.this.software_token_mfa_configuration) == 1
     error_message = "mfa_required=true with default factor should emit exactly one software_token_mfa_configuration block"
   }
+
+  # Pin the inner field — `length == 1` alone would still pass if `enabled`
+  # were silently swapped to false, which AWS would also reject. Close the
+  # weak-assertion gap explicitly.
+  assert {
+    condition     = aws_cognito_user_pool.this.software_token_mfa_configuration[0].enabled == true
+    error_message = "TOTP factor block must have enabled=true"
+  }
 }
 
 run "cognito_mfa_off_omits_factor_block" {

--- a/aws/cognito/tests/mfa.tftest.hcl
+++ b/aws/cognito/tests/mfa.tftest.hcl
@@ -1,0 +1,48 @@
+mock_provider "aws" {}
+
+# Issue #208: Cognito with mfa_required=true must emit a factor sub-block,
+# otherwise AWS rejects the apply with InvalidParameterException. The module
+# defaults mfa_factor to "totp" and emits software_token_mfa_configuration
+# via a dynamic block gated on the factor.
+
+run "cognito_mfa_required_emits_totp_factor" {
+  command = plan
+
+  variables {
+    project      = "test"
+    region       = "us-east-1"
+    environment  = "test"
+    mfa_required = true
+  }
+
+  assert {
+    condition     = aws_cognito_user_pool.this.mfa_configuration == "ON"
+    error_message = "mfa_required=true should set mfa_configuration=ON"
+  }
+
+  assert {
+    condition     = length(aws_cognito_user_pool.this.software_token_mfa_configuration) == 1
+    error_message = "mfa_required=true with default factor should emit exactly one software_token_mfa_configuration block"
+  }
+}
+
+run "cognito_mfa_off_omits_factor_block" {
+  command = plan
+
+  variables {
+    project      = "test"
+    region       = "us-east-1"
+    environment  = "test"
+    mfa_required = false
+  }
+
+  assert {
+    condition     = aws_cognito_user_pool.this.mfa_configuration == "OFF"
+    error_message = "mfa_required=false should set mfa_configuration=OFF"
+  }
+
+  assert {
+    condition     = length(aws_cognito_user_pool.this.software_token_mfa_configuration) == 0
+    error_message = "mfa_required=false should not emit a software_token_mfa_configuration block"
+  }
+}

--- a/aws/cognito/variables.tf
+++ b/aws/cognito/variables.tf
@@ -42,6 +42,16 @@ variable "mfa_required" {
   default     = false
 }
 
+variable "mfa_factor" {
+  description = "MFA factor when mfa_required=true. Currently only 'totp' (Software Token / TOTP) is supported. SMS and Email factors require additional wiring (SNS origination identity / SES domain) and are not yet implemented (#208)."
+  type        = string
+  default     = "totp"
+  validation {
+    condition     = contains(["totp"], var.mfa_factor)
+    error_message = "mfa_factor must be 'totp' (SMS and Email factors are not yet supported — see #208)."
+  }
+}
+
 variable "oauth_callback_urls" {
   description = "Allowed OAuth2 callback URLs for the hosted UI/app client"
   type        = list(string)

--- a/pkg/composer/builders_test.go
+++ b/pkg/composer/builders_test.go
@@ -50,6 +50,35 @@ func configWithAWSEC2(in awsEC2CfgInput) *Config {
 	}
 }
 
+// awsCognitoCfgInput mirrors the subset of Config.AWSCognito fields exercised
+// by mapper / validator tests.
+type awsCognitoCfgInput struct {
+	SignInType  string
+	MFARequired *bool
+	MFAFactor   string
+}
+
+// configWithAWSCognito returns *Config with AWSCognito populated from input.
+func configWithAWSCognito(in awsCognitoCfgInput) *Config {
+	return &Config{
+		AWSCognito: &struct {
+			SignInType  string `json:"signInType,omitempty"`
+			MFARequired *bool  `json:"mfaRequired,omitempty"`
+			MFAFactor   string `json:"mfaFactor,omitempty"`
+			Okta        *struct {
+				SelfSignupAllowed *bool `json:"selfSignupAllowed,omitempty"`
+			} `json:"okta,omitempty"`
+			Auth0 *struct {
+				MFARequired *bool `json:"mfaRequired,omitempty"`
+			} `json:"auth0,omitempty"`
+		}{
+			SignInType:  in.SignInType,
+			MFARequired: in.MFARequired,
+			MFAFactor:   in.MFAFactor,
+		},
+	}
+}
+
 // awsECSCfgInput mirrors Config.AWSECS.
 type awsECSCfgInput struct {
 	EnableContainerInsights *bool

--- a/pkg/composer/hcl_validation.go
+++ b/pkg/composer/hcl_validation.go
@@ -772,6 +772,23 @@ func normalizeCognitoSignInType(v any) (any, error) {
 	}
 }
 
+func normalizeCognitoMFAFactor(v any) (any, error) {
+	raw, err := requireString(v, "AWSCognito.MFAFactor")
+	if err != nil {
+		return nil, err
+	}
+	s := strings.ToLower(strings.TrimSpace(raw))
+	switch s {
+	case "totp":
+		return s, nil
+	default:
+		return nil, NewValidationError(fmt.Sprintf(
+			"AWSCognito.MFAFactor=%q: expected \"totp\" (SMS and Email not yet supported — see #208)",
+			raw,
+		))
+	}
+}
+
 func normalizeOpenSearchDeploymentType(v any) (any, error) {
 	raw, err := requireString(v, "AWSOpenSearch.DeploymentType")
 	if err != nil {

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -515,6 +515,18 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.AWSCognito.MFARequired != nil {
 				vals["mfa_required"] = *cfg.AWSCognito.MFARequired
 			}
+			// Factor — explicit wins. If MFA is on and no factor was given,
+			// back-fill "totp" so the user pool always emits a factor sub-block
+			// (#208: prevents AWS InvalidParameterException at apply time).
+			if cfg.AWSCognito.MFAFactor != "" {
+				factor, err := normalizeCognitoMFAFactor(cfg.AWSCognito.MFAFactor)
+				if err != nil {
+					return nil, err
+				}
+				vals["mfa_factor"] = factor.(string)
+			} else if cfg.AWSCognito.MFARequired != nil && *cfg.AWSCognito.MFARequired {
+				vals["mfa_factor"] = "totp"
+			}
 		}
 
 	case KeyAWSAPIGateway:

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -903,6 +903,17 @@ func TestBuildModuleValues_AWSCognito_MFAFactor(t *testing.T) {
 		require.NoError(t, err)
 		_, hasFactor := vals["mfa_factor"]
 		assert.False(t, hasFactor, "nil MFARequired must not set mfa_factor")
+		_, hasMFARequired := vals["mfa_required"]
+		assert.False(t, hasMFARequired, "nil MFARequired must not set mfa_required")
+	})
+
+	t.Run("sign_in_type passes through normalized", func(t *testing.T) {
+		// Covers the SignInType branch of KeyAWSCognito — otherwise un-exercised
+		// by any test in this package despite the case-statement carrying it.
+		cfg := configWithAWSCognito(awsCognitoCfgInput{SignInType: "EMAIL"})
+		vals, err := m.BuildModuleValues(KeyAWSCognito, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "email", vals["sign_in_type"], "sign_in_type must be normalized to lowercase")
 	})
 
 	t.Run("explicit TOTP passes through lowercased", func(t *testing.T) {
@@ -912,10 +923,24 @@ func TestBuildModuleValues_AWSCognito_MFAFactor(t *testing.T) {
 		assert.Equal(t, "totp", vals["mfa_factor"])
 	})
 
+	t.Run("explicit factor passes through regardless of mfa_required", func(t *testing.T) {
+		// Decouples the explicit-wins branch from the back-fill branch — a
+		// mutation that gates pass-through on MFARequired wouldn't be caught
+		// by the lowercased-pass-through subtest. Use a value that ONLY the
+		// normalize path could produce (mixed case + padding) so a mutation
+		// that drops normalize from the explicit branch is still caught here.
+		cfg := configWithAWSCognito(awsCognitoCfgInput{MFAFactor: "  TOTP  "})
+		vals, err := m.BuildModuleValues(KeyAWSCognito, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "totp", vals["mfa_factor"])
+		_, hasMFARequired := vals["mfa_required"]
+		assert.False(t, hasMFARequired, "nil MFARequired must not set mfa_required")
+	})
+
 	t.Run("unsupported factor returns error", func(t *testing.T) {
 		cfg := configWithAWSCognito(awsCognitoCfgInput{MFARequired: &trueVal, MFAFactor: "sms"})
 		_, err := m.BuildModuleValues(KeyAWSCognito, nil, cfg, "", "")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "expected \"totp\"")
+		assert.ErrorContains(t, err, `expected "totp"`)
 	})
 }

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -869,3 +869,53 @@ func TestBuildModuleValues_AWSBackups_DefaultRule(t *testing.T) {
 		}
 	})
 }
+
+// TestBuildModuleValues_AWSCognito_MFAFactor covers the issue #208 acceptance
+// criteria: when MFA is enabled the mapper must back-fill mfa_factor=totp so
+// the Cognito user pool always has a working factor sub-block; when MFA is
+// off the mapper must not set mfa_factor; an explicit factor passes through
+// (lowercased); an unsupported factor returns an error.
+func TestBuildModuleValues_AWSCognito_MFAFactor(t *testing.T) {
+	m := DefaultMapper{}
+	trueVal := true
+	falseVal := false
+
+	t.Run("mfa_required=true with empty factor back-fills totp", func(t *testing.T) {
+		cfg := configWithAWSCognito(awsCognitoCfgInput{MFARequired: &trueVal})
+		vals, err := m.BuildModuleValues(KeyAWSCognito, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, true, vals["mfa_required"])
+		assert.Equal(t, "totp", vals["mfa_factor"], "MFA on with empty factor must back-fill totp (#208)")
+	})
+
+	t.Run("mfa_required=false does not back-fill factor", func(t *testing.T) {
+		cfg := configWithAWSCognito(awsCognitoCfgInput{MFARequired: &falseVal})
+		vals, err := m.BuildModuleValues(KeyAWSCognito, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, false, vals["mfa_required"])
+		_, hasFactor := vals["mfa_factor"]
+		assert.False(t, hasFactor, "MFA off must not set mfa_factor")
+	})
+
+	t.Run("mfa_required nil does not back-fill factor", func(t *testing.T) {
+		cfg := configWithAWSCognito(awsCognitoCfgInput{})
+		vals, err := m.BuildModuleValues(KeyAWSCognito, nil, cfg, "", "")
+		require.NoError(t, err)
+		_, hasFactor := vals["mfa_factor"]
+		assert.False(t, hasFactor, "nil MFARequired must not set mfa_factor")
+	})
+
+	t.Run("explicit TOTP passes through lowercased", func(t *testing.T) {
+		cfg := configWithAWSCognito(awsCognitoCfgInput{MFARequired: &trueVal, MFAFactor: "TOTP"})
+		vals, err := m.BuildModuleValues(KeyAWSCognito, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "totp", vals["mfa_factor"])
+	})
+
+	t.Run("unsupported factor returns error", func(t *testing.T) {
+		cfg := configWithAWSCognito(awsCognitoCfgInput{MFARequired: &trueVal, MFAFactor: "sms"})
+		_, err := m.BuildModuleValues(KeyAWSCognito, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected \"totp\"")
+	})
+}

--- a/pkg/composer/testdata/known_fields.golden
+++ b/pkg/composer/testdata/known_fields.golden
@@ -1,5 +1,6 @@
 aws_api_gateway.certificateArn
 aws_cloudwatch_logs.retentionDays
+aws_cognito.mfaFactor
 aws_cognito.signInType
 aws_dynamodb.type
 aws_ec2

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -184,6 +184,7 @@ type Config struct {
 	AWSCognito *struct {
 		SignInType  string `json:"signInType,omitempty"`
 		MFARequired *bool  `json:"mfaRequired,omitempty"`
+		MFAFactor   string `json:"mfaFactor,omitempty"`
 		Okta        *struct {
 			SelfSignupAllowed *bool `json:"selfSignupAllowed,omitempty"`
 		} `json:"okta,omitempty"`

--- a/pkg/composer/validate.go
+++ b/pkg/composer/validate.go
@@ -567,6 +567,20 @@ var configFieldValidators = []configFieldValidator{
 		code:      "invalid_enum",
 	},
 	{
+		field:     "aws_cognito.mfaFactor",
+		component: KeyAWSCognito,
+		variable:  "mfa_factor",
+		value: func(c *Config) (any, bool) {
+			if c == nil || c.AWSCognito == nil || c.AWSCognito.MFAFactor == "" {
+				return nil, false
+			}
+			return c.AWSCognito.MFAFactor, true
+		},
+		normalize: normalizeCognitoMFAFactor,
+		allowed:   []string{"totp"},
+		code:      "invalid_enum",
+	},
+	{
 		field:     "aws_lambda.runtime",
 		component: KeyAWSLambda,
 		variable:  "runtime",

--- a/pkg/composer/validate_values_test.go
+++ b/pkg/composer/validate_values_test.go
@@ -94,6 +94,26 @@ func TestValidate_HCLBackedValues_CollectsMultipleIssues(t *testing.T) {
 	require.Contains(t, byField["aws_kms.numKeys"].Reason, "num_keys must be >= 1")
 }
 
+// TestValidate_AWSCognitoMFAFactor_InvalidEnum locks in the issue #208
+// guarantee that an unsupported MFA factor is caught at compose time as a
+// structured ValidationIssue, not at apply time as an AWS API error.
+func TestValidate_AWSCognitoMFAFactor_InvalidEnum(t *testing.T) {
+	t.Parallel()
+
+	cfg := cfgFromJSON(t, `{
+		"aws_cognito": {"mfaRequired": true, "mfaFactor": "sms"}
+	}`)
+
+	issues := Validate(nil, &cfg)
+	byField := issuesByField(issues)
+
+	got, ok := byField["aws_cognito.mfaFactor"]
+	require.True(t, ok, "expected an issue on aws_cognito.mfaFactor; got %+v", issues)
+	require.Equal(t, "invalid_enum", got.Code)
+	require.ElementsMatch(t, []string{"totp"}, got.Allowed,
+		"invalid_enum issues must carry the Allowed set so the AI corrector can suggest the legal value")
+}
+
 func TestAllowedValues(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/composer/validate_values_test.go
+++ b/pkg/composer/validate_values_test.go
@@ -96,12 +96,15 @@ func TestValidate_HCLBackedValues_CollectsMultipleIssues(t *testing.T) {
 
 // TestValidate_AWSCognitoMFAFactor_InvalidEnum locks in the issue #208
 // guarantee that an unsupported MFA factor is caught at compose time as a
-// structured ValidationIssue, not at apply time as an AWS API error.
+// structured ValidationIssue, not at apply time as an AWS API error. Uses a
+// close typo ("totq") so the AI-corrector Suggestion contract is testable —
+// nearestSuggestion caps at edit distance < 4, so far-away strings like "sms"
+// would correctly produce an empty Suggestion.
 func TestValidate_AWSCognitoMFAFactor_InvalidEnum(t *testing.T) {
 	t.Parallel()
 
 	cfg := cfgFromJSON(t, `{
-		"aws_cognito": {"mfaRequired": true, "mfaFactor": "sms"}
+		"aws_cognito": {"mfaRequired": true, "mfaFactor": "totq"}
 	}`)
 
 	issues := Validate(nil, &cfg)
@@ -112,6 +115,10 @@ func TestValidate_AWSCognitoMFAFactor_InvalidEnum(t *testing.T) {
 	require.Equal(t, "invalid_enum", got.Code)
 	require.ElementsMatch(t, []string{"totp"}, got.Allowed,
 		"invalid_enum issues must carry the Allowed set so the AI corrector can suggest the legal value")
+	// Pin Reason and Suggestion so a mutation that empties either field — and
+	// thereby breaks the AI-corrector contract — is caught at compose time.
+	require.NotEmpty(t, got.Reason, "ValidationIssue.Reason must explain why the value is rejected")
+	require.Equal(t, "totp", got.Suggestion, "Suggestion must point the corrector at the legal value")
 }
 
 func TestAllowedValues(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes the AWS apply-time `InvalidParameterException: SMS MFA, Email MFA, or Software Token MFA must be enabled` when a Cognito user pool is composed with `mfaRequired = true`.
- Adds an `mfa_factor` setting (default `"totp"`) plumbed through the composer's type / validate / mapper trio; the module emits a `software_token_mfa_configuration { enabled = true }` sub-block via a `dynamic` gated on the factor.
- The mapper back-fills `mfa_factor = "totp"` whenever `mfa_required = true` and no factor was given, so deploys keep the same one-knob ergonomics they had before — but produce a working AWS user pool now instead of failing apply.
- SMS / Email factors are explicitly out of scope (validator allows `["totp"]` only). They need extra wiring (SNS origination identity / SES domain) and will land in a follow-up.

Repro per the issue: prod session `sess_v2_hrbS5zpRBk51`, deploy job `ccs-6ee757a6-xcp6p`.

## Edit surfaces

- `aws/cognito/variables.tf` — new `mfa_factor` variable + validation (TOTP-only)
- `aws/cognito/main.tf` — `dynamic "software_token_mfa_configuration"` inside `aws_cognito_user_pool.this`
- `pkg/composer/types.go` — `MFAFactor` field on the `AWSCognito` config struct
- `pkg/composer/hcl_validation.go` — `normalizeCognitoMFAFactor` (mirrors `normalizeCognitoSignInType`)
- `pkg/composer/validate.go` — `configFieldValidator` entry for `aws_cognito.mfaFactor`
- `pkg/composer/mapper.go` — `KeyAWSCognito` branch handles MFAFactor + auto-back-fill

## Test plan

- [x] `terraform fmt -check -recursive` clean
- [x] All 6 lint scripts pass (`tests/lint-*.sh`)
- [x] `aws/cognito` validates as a child module (`tests/validate-as-child.sh`)
- [x] `cd aws/cognito && terraform test` — 5/5 pass (2 new MFA + 3 existing OIDC)
- [x] `go test ./pkg/composer/` — full package green (~120s)
- [x] All 7 example stacks that use `aws/cognito` re-validate
- [ ] End-to-end: next `tfdeploy` of a stack with `mfaRequired=true` and no factor input succeeds without the AWS `InvalidParameterException` (deferred — needs `reliable2` IR PR to surface `mfaFactor` first; see Related)

## Review notes

- /review (local diff): no P0/P1; one P2 (drive-by — added decoupling subtest); one P3 (drive-by — switched `assert.Contains(err.Error(), …)` to `assert.ErrorContains`)
- qa-professor: 3 P1s flagged and fixed in `c8150fb`
  - module-level `tftest.hcl` only checked `length == 1` — added `enabled == true` inner-field assertion
  - "explicit factor passes through regardless of mfa_required" used already-lowercase `"totp"` — switched to `"  TOTP  "` so only the normalize path can produce the asserted value, distinguishing it from back-fill
  - validator test pinned only `Code` and `Allowed` — added `Reason`/`Suggestion` assertions and switched the input to a close typo (`"totq"`) so `nearestSuggestion`'s threshold is exercised
- Drive-by P2/P3: SignInType passthrough subtest (closes the previously-untested branch of the same case statement); symmetric `vals["mfa_required"]` absence assertion; `TODO(#208)` on the dynamic block for the SMS/Email follow-up

## Related

- Cross-repo follow-up needed in `luthersystems/reliable2`: extend `ZAwsCognito` in `lib/stack/ir.ts` with `mfaFactor: z.enum(["totp"]).optional()` so the field reaches the composer.

Fixes #208