### PR TITLE
fix(composer): auto-include EKS node group and auto-derive RDS max_allocated_storage

### DIFF
--- a/aws/eks_nodegroup/variables.tf
+++ b/aws/eks_nodegroup/variables.tf
@@ -57,6 +57,7 @@ variable "subnet_ids" {
 variable "instance_types" {
   description = "Instance types for the node group (e.g., [\"c7i.large\"])"
   type        = list(string)
+  default     = ["c7i.large"]
   validation {
     condition     = length(var.instance_types) >= 1 && alltrue([for t in var.instance_types : length(trimspace(t)) > 0])
     error_message = "instance_types must include at least one non-empty EC2 type (e.g., \"c7i.large\")."
@@ -66,6 +67,7 @@ variable "instance_types" {
 variable "desired_size" {
   description = "Desired number of nodes"
   type        = number
+  default     = 2
   validation {
     condition     = var.desired_size >= 0
     error_message = "desired_size must be >= 0."
@@ -75,6 +77,7 @@ variable "desired_size" {
 variable "min_size" {
   description = "Minimum number of nodes"
   type        = number
+  default     = 1
   validation {
     condition     = var.min_size >= 0
     error_message = "min_size must be >= 0."
@@ -84,6 +87,7 @@ variable "min_size" {
 variable "max_size" {
   description = "Maximum number of nodes"
   type        = number
+  default     = 3
   validation {
     condition     = var.max_size >= 0
     error_message = "max_size must be >= 0."

--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -183,6 +183,18 @@ resource "aws_db_instance" "primary" {
   # NOTE: latest_restorable_time and replicas drift on refresh but are
   # Computed-only, so lifecycle.ignore_changes has no effect. Suppression
   # must happen at the drift-check level — see sandbox-infrastructure-template#93.
+
+  lifecycle {
+    # AWS rejects allocated_storage >= max_allocated_storage with
+    # InvalidParameterCombination at apply time, after a real ENI / subnet
+    # group / IAM has been provisioned. Catch the misconfig at plan time so
+    # callers that bypass the composer's auto-derive (issue #205) still fail
+    # cleanly. max_allocated_storage = 0 disables autoscaling.
+    precondition {
+      condition     = var.max_allocated_storage == 0 || var.max_allocated_storage > var.allocated_storage
+      error_message = "max_allocated_storage (${var.max_allocated_storage}) must be 0 (autoscaling disabled) or strictly greater than allocated_storage (${var.allocated_storage})."
+    }
+  }
 }
 
 # -----------------------------------------------------------------------------

--- a/aws/rds/tests/storage.tftest.hcl
+++ b/aws/rds/tests/storage.tftest.hcl
@@ -1,0 +1,80 @@
+mock_provider "aws" {}
+
+# Regression for #205. AWS rejects the (allocated_storage,
+# max_allocated_storage) combination at apply time with
+# `InvalidParameterCombination: Max storage size must be greater than
+# storage size` whenever max_allocated_storage > 0 AND
+# max_allocated_storage <= allocated_storage. The module's primary
+# aws_db_instance carries a lifecycle.precondition that surfaces this
+# misconfig at plan time so callers that bypass the composer's auto-derive
+# still fail cleanly before any AWS state is provisioned.
+#
+# Note on expect_failures: it matches *any* check failure on
+# resource.aws_db_instance.primary — preconditions, postconditions, or
+# input-variable validation routed to the resource. Today the primary has
+# exactly one precondition (this one) and no postcondition, and the inputs
+# below pass their per-variable validation blocks (allocated_storage >= 20
+# and max_allocated_storage >= 0 always hold). So a failure here pins the
+# precondition specifically. If a future change adds another check on the
+# primary, prefer routing the new rule through a named `check {}` block to
+# preserve this test's specificity.
+
+variables {
+  project     = "rds-storage-test"
+  region      = "us-east-1"
+  environment = "test"
+  vpc_id      = "vpc-12345"
+  subnet_ids  = ["subnet-aaa", "subnet-bbb"]
+}
+
+# Happy path: max_allocated_storage strictly greater than allocated_storage.
+run "max_greater_than_allocated_passes" {
+  command = plan
+
+  variables {
+    allocated_storage     = 200
+    max_allocated_storage = 1000
+  }
+}
+
+# Happy path: max_allocated_storage = 0 disables autoscaling. The
+# precondition's first disjunct allows this regardless of allocated_storage.
+run "max_zero_disables_autoscaling_passes" {
+  command = plan
+
+  variables {
+    allocated_storage     = 200
+    max_allocated_storage = 0
+  }
+}
+
+# Failure path: the issue #205 prod repro — allocated_storage = 2000
+# (storageSize: "2TB") with the module default max_allocated_storage = 1000
+# must fail at plan via the precondition, not at apply.
+run "max_at_module_default_fails_when_allocated_2tb" {
+  command = plan
+
+  variables {
+    allocated_storage     = 2000
+    max_allocated_storage = 1000
+  }
+
+  expect_failures = [
+    resource.aws_db_instance.primary,
+  ]
+}
+
+# Failure path: equal values are also rejected by AWS — guard against the
+# off-by-one where someone might think "max == allocated" is fine.
+run "max_equal_to_allocated_fails" {
+  command = plan
+
+  variables {
+    allocated_storage     = 500
+    max_allocated_storage = 500
+  }
+
+  expect_failures = [
+    resource.aws_db_instance.primary,
+  ]
+}

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -241,7 +241,7 @@ func (c *Client) composeSingleImpl(opts ComposeSingleOpts) (*ComposeSingleResult
 	maybeInjectGCPProjectID(cloud, opts.GCPProjectID, vals)
 
 	// Resolve implicit dependencies so DefaultWiring can connect modules (e.g. Redis -> VPC)
-	expanded := ResolveDependencies([]ComponentKey{opts.Key})
+	expanded := ResolveDependenciesForCompose([]ComponentKey{opts.Key}, opts.Comps)
 	selected := make(map[ComponentKey]bool)
 	for _, k := range expanded {
 		selected[k] = true
@@ -434,8 +434,10 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 		return nil, err
 	}
 
-	// 1. Expand selected keys to include implicit dependencies (e.g. Redis -> VPC)
-	expanded := ResolveDependencies(opts.SelectedKeys)
+	// 1. Expand selected keys to include implicit dependencies (e.g. Redis -> VPC).
+	// Comps-aware so EKS auto-includes the worker node group on non-Lambda
+	// architectures (issue #206) without dragging it into Lambda stacks.
+	expanded := ResolveDependenciesForCompose(opts.SelectedKeys, opts.Comps)
 
 	// If any backup components are selected, ensure the appropriate backup module key is included.
 	if backupsSelected(opts.Comps) {

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -2070,6 +2070,9 @@ func TestComposeStack_AWSECS(t *testing.T) {
 // the implicit-dependency leak where ResolveDependencies would have expanded
 // a polymorphic key to a legacy VPC sibling. A direct Go caller passing only
 // [KeyAWSEKSControlPlane] must still produce a prefixed-only stack.
+//
+// Post-#206: the comps-aware resolver also auto-includes the worker node group
+// (module "ec2") when comps is non-Lambda, so the assertion set covers that.
 func TestComposeStack_PolymorphicKeyPullsInPrefixedVPC(t *testing.T) {
 	c := newTestClient()
 	out, err := c.ComposeStack(ComposeStackOpts{
@@ -2087,6 +2090,127 @@ func TestComposeStack_PolymorphicKeyPullsInPrefixedVPC(t *testing.T) {
 		"implicit dep must render aws_vpc")
 	require.Contains(t, mainTF, `module "resource"`,
 		"polymorphic KeyAWSEKSControlPlane preserves its string value and renders as module.resource")
+	require.Contains(t, mainTF, `module "ec2"`,
+		"non-Lambda EKS must auto-include the worker node group (issue #206)")
+}
+
+// TestComposeStack_EKSAutoIncludesNodeGroup is the issue #206 regression: a
+// caller selecting only KeyAWSEKS (or KeyAWSEKSControlPlane) on a non-Lambda
+// architecture must end up with the worker node group module composed,
+// otherwise EKS addons (coredns, kube-proxy, aws-ebs-csi-driver) have nowhere
+// to schedule and `terraform apply` times out at 20 min in DEGRADED state.
+//
+// The expected cluster-module name depends on which cluster key the caller
+// selected: KeyAWSEKS ("aws_eks") composes module "aws_eks", and
+// KeyAWSEKSControlPlane ("resource") composes module "resource". The
+// auto-include must emit *exactly one* cluster module — not both — so that
+// the prefix-aware key path doesn't drag the legacy polymorphic key in via
+// the node group's static dep.
+func TestComposeStack_EKSAutoIncludesNodeGroup(t *testing.T) {
+	t.Parallel()
+	awsEKSEnabled := true
+	cases := []struct {
+		name        string
+		selected    []ComponentKey
+		comps       *Components
+		wantCluster string // module name expected for the EKS control plane
+		notCluster  string // module name that must NOT be present
+	}{
+		{"OnlyEKS_AutoAddsNodeGroup", []ComponentKey{KeyAWSEKS}, &Components{}, `module "aws_eks"`, `module "resource"`},
+		{"OnlyControlPlane_AutoAddsNodeGroup", []ComponentKey{KeyAWSEKSControlPlane}, &Components{}, `module "resource"`, `module "aws_eks"`},
+		{"EKSPlusVPC_AutoAddsNodeGroup", []ComponentKey{KeyAWSEKS, KeyAWSVPC}, &Components{}, `module "aws_eks"`, `module "resource"`},
+		// Non-empty non-Lambda comps confirms isLambda returns false on a
+		// populated Components{} where AWSLambda is unset — guards against a
+		// regression where isLambda might check non-nil instead of the field.
+		{"EKSWithEnabledFlag_NonEmptyComps", []ComponentKey{KeyAWSEKS}, &Components{AWSEKS: &awsEKSEnabled}, `module "aws_eks"`, `module "resource"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestClient()
+			out, err := c.ComposeStack(ComposeStackOpts{
+				Cloud:        "aws",
+				SelectedKeys: tc.selected,
+				Comps:        tc.comps,
+				Cfg:          &Config{Region: "us-east-1"},
+				Project:      "eks-autoinclude",
+				Region:       "us-east-1",
+			})
+			require.NoError(t, err, "ComposeStack should succeed")
+			mainTF := string(out["/main.tf"])
+			require.Contains(t, mainTF, `module "aws_vpc"`)
+			require.Contains(t, mainTF, tc.wantCluster,
+				"EKS control plane module must compose")
+			require.NotContains(t, mainTF, tc.notCluster,
+				"only one cluster module must compose — the auto-include must not pull in the other polymorphic alias")
+			// Match the block-opening shape, not just a substring, so a
+			// rename of the node-group module wouldn't accidentally credit
+			// (e.g.) a "module \"ec2_legacy_workers\"" occurrence. Pins the
+			// composed name "ec2" and asserts the source path resolves to
+			// the eks_nodegroup preset, which is what actually keeps EKS
+			// schedulable per #206.
+			require.Regexp(t, regexp.MustCompile(`(?m)^module "ec2"\s*\{`), mainTF,
+				"EKS worker node group (polymorphic key 'ec2') must auto-include for non-Lambda EKS (issue #206)")
+			ec2Blocks := regexp.MustCompile(`(?m)^module "ec2"\s*\{`).FindAllStringIndex(mainTF, -1)
+			require.Len(t, ec2Blocks, 1,
+				"node group must compose exactly once — auto-include must not duplicate when user pre-selects KeyAWSEKSNodeGroup")
+			require.Regexp(t, regexp.MustCompile(`source\s*=\s*"\./modules/eks_nodegroup"`), mainTF,
+				"node group module's source must resolve to ./modules/eks_nodegroup")
+		})
+	}
+}
+
+// TestComposeStack_EKSAutoIncludeIdempotent pins ResolveDependenciesForCompose's
+// hasNodeGroup short-circuit: when the caller already selected
+// KeyAWSEKSNodeGroup explicitly, the auto-include must not append a second
+// copy. A mutation removing the hasNodeGroup check would emit two
+// `module "ec2"` blocks, which terraform would reject at init.
+//
+// Note: pre-existing static-map behavior emits two cluster modules
+// (`module "aws_eks"` AND `module "resource"`) when both KeyAWSEKS and
+// KeyAWSEKSNodeGroup are selected explicitly, because the static map declares
+// KeyAWSEKSNodeGroup's dep as KeyAWSEKSControlPlane (the legacy polymorphic
+// alias). That's a separate latent issue outside #206's scope and is not
+// asserted here — this test pins only the node-group-not-doubled invariant.
+func TestComposeStack_EKSAutoIncludeIdempotent(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSEKS, KeyAWSEKSNodeGroup},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "eks-idempotent",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err, "ComposeStack should succeed")
+	mainTF := string(out["/main.tf"])
+	ec2Blocks := regexp.MustCompile(`(?m)^module "ec2"\s*\{`).FindAllStringIndex(mainTF, -1)
+	require.Len(t, ec2Blocks, 1,
+		"node group must compose exactly once even when caller pre-selects KeyAWSEKSNodeGroup — pins the hasNodeGroup short-circuit in ResolveDependenciesForCompose")
+}
+
+// TestComposeStack_EKSControlPlaneLambdaSkipsNodeGroup pins the Lambda gate:
+// when comps.AWSLambda is set, KeyAWSEKSControlPlane routes to the Lambda
+// runtime preset (not EKS), so the auto-include of the worker node group
+// must NOT fire.
+func TestComposeStack_EKSControlPlaneLambdaSkipsNodeGroup(t *testing.T) {
+	t.Parallel()
+	trueVal := true
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSEKSControlPlane},
+		Comps:        &Components{AWSLambda: &trueVal}, // Lambda architecture
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "lambda-no-eks",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err, "ComposeStack(Lambda) should succeed")
+	mainTF := string(out["/main.tf"])
+	require.Contains(t, mainTF, `module "resource"`,
+		"polymorphic KeyAWSEKSControlPlane still composes as module 'resource'")
+	require.NotContains(t, mainTF, `module "ec2"`,
+		"Lambda architecture must NOT auto-include the EKS worker node group (issue #206)")
 }
 
 // TestDefaultWiring_GCPSubnetSelfLinkUsesTryGuard pins the issue #178 fix:

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -242,6 +242,13 @@ var ImplicitDependencies = map[ComponentKey][]ComponentKey{
 }
 
 // ResolveDependencies recursively finds all required components for a given set of keys.
+//
+// This signature is kept stable for downstream callers (e.g. reliable2). For
+// EKS auto-include of the worker node group, callers that have *Components
+// available should use ResolveDependenciesForCompose instead — without comps,
+// we cannot tell EKS-the-Kubernetes-cluster apart from
+// KeyAWSEKSControlPlane-as-Lambda-runtime, and unconditionally adding the node
+// group would produce a stray ec2 module in Lambda stacks.
 func ResolveDependencies(keys []ComponentKey) []ComponentKey {
 	added := make(map[ComponentKey]bool)
 	var final []ComponentKey
@@ -269,6 +276,44 @@ func ResolveDependencies(keys []ComponentKey) []ComponentKey {
 	}
 
 	return final
+}
+
+// ResolveDependenciesForCompose is the comps-aware resolver used by ComposeStack
+// and ComposeSingle. It runs ResolveDependencies first, then auto-includes
+// KeyAWSEKSNodeGroup whenever a non-Lambda EKS cluster is in the resolved set
+// (issue #206). The injection is gated on isLambda(comps) so the polymorphic
+// KeyAWSEKSControlPlane key doesn't drag a worker node group into a Lambda
+// stack. KeyAWSEKS is always Kubernetes (never polymorphic with Lambda), so
+// it always gets the node group.
+func ResolveDependenciesForCompose(keys []ComponentKey, comps *Components) []ComponentKey {
+	resolved := ResolveDependencies(keys)
+	if isLambda(comps) {
+		return resolved
+	}
+	hasEKS := false
+	hasNodeGroup := false
+	for _, k := range resolved {
+		switch k {
+		case KeyAWSEKS, KeyAWSEKSControlPlane:
+			hasEKS = true
+		case KeyAWSEKSNodeGroup:
+			hasNodeGroup = true
+		}
+	}
+	if !hasEKS || hasNodeGroup {
+		return resolved
+	}
+	// Append KeyAWSEKSNodeGroup directly rather than re-resolving via the
+	// static map. The static map declares KeyAWSEKSNodeGroup deps as
+	// {KeyAWSEKSControlPlane, KeyAWSVPC} — re-resolving would force the
+	// legacy polymorphic cluster key into a stack that already has the
+	// prefix-aware KeyAWSEKS, emitting two cluster modules
+	// (module "aws_eks" and module "resource"). Both deps are already
+	// covered: KeyAWSVPC by the cluster key's own dep, and the cluster
+	// itself by the user-selected KeyAWSEKS or KeyAWSEKSControlPlane.
+	// Wiring (resourceRef, contracts.go:528) routes node-group references
+	// to whichever cluster key is present.
+	return append(resolved, KeyAWSEKSNodeGroup)
 }
 
 // GetModuleDir returns the output directory for a key (e.g., "modules/vpc").

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -389,6 +389,15 @@ func (m DefaultMapper) BuildModuleValues(
 					return nil, err
 				}
 				vals["allocated_storage"] = gb
+				// AWS rejects allocated_storage >= max_allocated_storage at
+				// apply time. Auto-derive a 2x autoscaling ceiling, floored at
+				// the module default of 1000 GB so small picks keep the
+				// existing headroom (issue #205). Disabling autoscaling
+				// (max_allocated_storage = 0) is a future opt-in via an IR
+				// field — not user-controllable today.
+				if _, set := vals["max_allocated_storage"]; !set {
+					vals["max_allocated_storage"] = max(gb*2, 1000)
+				}
 			}
 		}
 

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -662,10 +662,77 @@ func TestBuildModuleValues_Postgres_RDSConfig(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "db.m7i.2xlarge", vals["instance_class"])
 		assert.Equal(t, 20, vals["allocated_storage"])
+		// Issue #205: small allocated_storage (20 GB) must still emit a
+		// max_allocated_storage that is strictly greater (else AWS rejects at
+		// apply). Floor is the module default of 1000 GB.
+		assert.Equal(t, 1000, vals["max_allocated_storage"],
+			"max_allocated_storage must default to module floor of 1000 when allocated_storage*2 is below it")
 		_, hasOldCPU := vals["node_cpu_size"]
 		_, hasOldStorage := vals["storage_size"]
 		assert.False(t, hasOldCPU, "node_cpu_size is the pre-fix key — must not be emitted")
 		assert.False(t, hasOldStorage, "storage_size is the pre-fix key — RDS module variable is allocated_storage")
+	})
+
+	// TestBuildModuleValues_RDSStorageSize2TBAutoDerivesMaxAllocatedStorage
+	// is the issue #205 regression. Picking the largest IR storage (2TB →
+	// 2000 GB) emitted allocated_storage=2000 but left max_allocated_storage
+	// at the module default of 1000, which AWS rejects at apply with
+	// "InvalidParameterCombination: Max storage size must be greater than
+	// storage size". The mapper must auto-derive max_allocated_storage as
+	// max(allocated_storage*2, 1000).
+	t.Run("StorageSize 2TB triggers max_allocated_storage = 4000", func(t *testing.T) {
+		cfg := &Config{AWSRDS: &struct {
+			CPUSize      string `json:"cpuSize,omitempty"`
+			ReadReplicas string `json:"readReplicas,omitempty"`
+			StorageSize  string `json:"storageSize,omitempty"`
+		}{StorageSize: "2TB"}}
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, 2000, vals["allocated_storage"])
+		assert.Equal(t, 4000, vals["max_allocated_storage"],
+			"2TB pick must auto-derive max_allocated_storage = 2 * allocated_storage = 4000")
+	})
+
+	t.Run("StorageSize unset leaves max_allocated_storage unset (module default applies)", func(t *testing.T) {
+		cfg := &Config{AWSRDS: &struct {
+			CPUSize      string `json:"cpuSize,omitempty"`
+			ReadReplicas string `json:"readReplicas,omitempty"`
+			StorageSize  string `json:"storageSize,omitempty"`
+		}{CPUSize: "db.m7i.2xlarge"}}
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, cfg, "", "")
+		require.NoError(t, err)
+		_, hasMax := vals["max_allocated_storage"]
+		assert.False(t, hasMax, "without StorageSize, mapper must not override module default")
+	})
+
+	// Boundary cases at the floor: max(gb*2, 1000) flips behavior at gb=500.
+	// These pin the formula against off-by-one mutations
+	// (e.g. max(gb*2+1, 1000) or max(gb*2, 999) would survive only the
+	// 20 / 2000 cases above).
+	t.Run("StorageSize 500GB sits exactly on the floor", func(t *testing.T) {
+		cfg := &Config{AWSRDS: &struct {
+			CPUSize      string `json:"cpuSize,omitempty"`
+			ReadReplicas string `json:"readReplicas,omitempty"`
+			StorageSize  string `json:"storageSize,omitempty"`
+		}{StorageSize: "500"}}
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, 500, vals["allocated_storage"])
+		assert.Equal(t, 1000, vals["max_allocated_storage"],
+			"at allocated=500, gb*2=1000 ties with the floor — must emit 1000 (strictly > 500 satisfies AWS)")
+	})
+
+	t.Run("StorageSize 501GB just above the floor", func(t *testing.T) {
+		cfg := &Config{AWSRDS: &struct {
+			CPUSize      string `json:"cpuSize,omitempty"`
+			ReadReplicas string `json:"readReplicas,omitempty"`
+			StorageSize  string `json:"storageSize,omitempty"`
+		}{StorageSize: "501"}}
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, 501, vals["allocated_storage"])
+		assert.Equal(t, 1002, vals["max_allocated_storage"],
+			"at allocated=501, gb*2=1002 exceeds the floor — must emit 1002, not 1000")
 	})
 }
 


### PR DESCRIPTION
## Summary

- **#206 EKS without a worker node group was unbuildable.** Selecting `KeyAWSEKS` (or polymorphic `KeyAWSEKSControlPlane` on a non-Lambda arch) composed the control plane plus default addons (`coredns`, `kube-proxy`, `aws-ebs-csi-driver`) but never a node group, so addon Deployments stalled `DEGRADED` and apply timed out at 20 min. Fix: a comps-aware `ResolveDependenciesForCompose` that auto-injects `KeyAWSEKSNodeGroup` whenever EKS is selected and `isLambda(comps)` is false. The injection appends directly rather than re-resolving through the static map (which would force the legacy polymorphic key in alongside `KeyAWSEKS`, emitting two cluster modules). HCL defaults added to `aws/eks_nodegroup/variables.tf` for the four previously-required-no-default sizing vars (`instance_types`, `desired_size`, `min_size`, `max_size`) so the implicit-add path works without user-side `AWSEKS` config.

- **#205 RDS rejected `allocated_storage=2000` against the module-default `max_allocated_storage=1000` at apply.** Fix: mapper auto-derives `max_allocated_storage = max(allocated_storage * 2, 1000)` whenever the user supplies `StorageSize`. Module-side `lifecycle.precondition` on `aws_db_instance.primary` catches the bypass case at plan, with a distinctive error message identifying the misconfig.

- **API stability:** `ResolveDependencies` keeps its existing signature so downstream callers (reliable2) build unchanged. Compose-time callers in `compose.go` switch to the new comps-aware variant.

## Test plan

- [x] `go test ./pkg/composer/...` — full suite green (~125s)
- [x] `cd aws/eks_nodegroup && terraform init -backend=false && terraform validate` — clean
- [x] `cd aws/rds && terraform init -backend=false && terraform validate && terraform test` — 5/5 passed (4 storage cases + 1 password)
- [x] `terraform fmt -check -recursive` — clean
- [x] All 5 lint scripts (`lint-project-tag`, `lint-project-label`, `lint-foreach-unknown-keys`, `lint-sensitive-for-each`, `lint-no-root-only-blocks`, `lint-shared-no-cloud-providers`) — pass
- [x] `tests/validate-as-child.sh` for `aws/eks_nodegroup` and `aws/rds` — pass
- [x] `examples/cargofit` and `examples/revisionapp` `terraform validate` — pass

### Specific test additions

- `pkg/composer/compose_stack_test.go`
  - `TestComposeStack_EKSAutoIncludesNodeGroup` (4 sub-cases) — pins each cluster-key path with cluster-exclusivity, source-path resolution, and exactly-one node-group block.
  - `TestComposeStack_EKSAutoIncludeIdempotent` — pins the `hasNodeGroup` short-circuit.
  - `TestComposeStack_EKSControlPlaneLambdaSkipsNodeGroup` — pins the Lambda gate.
  - `TestComposeStack_PolymorphicKeyPullsInPrefixedVPC` extended to assert the auto-include.
- `pkg/composer/mapper_test.go` — three new sub-cases: `2TB → 4000`, `unset preserved`, plus floor-boundary tests at 500 GB / 501 GB.
- `aws/rds/tests/storage.tftest.hcl` — 4 module-level cases: passing `>`, passing `=0`, failing `2TB+default`, failing equal.

## Review notes

- `/review` findings: one P0 caught (auto-include re-resolution emitted duplicate cluster modules when caller used the prefix-aware `KeyAWSEKS` key) — fixed by appending the node group directly rather than re-resolving via the static map. Comment in `contracts.go:296-309` documents the rationale.
- qa-professor findings: addressed P1 floor-boundary test, P1 block-opening regex + source-path assertion, P2 non-empty-non-Lambda comps sub-case, P2 dedicated double-injection test, P2 comment in tftest about `expect_failures` specificity. Deferred: Go-side test asserting composed default sizing values (the `validate-as-child` pass on `aws/eks_nodegroup` already proves the HCL defaults make the implicit path validate).

## Deferred follow-ups

- Composer-level cross-field validation (`validate.go` rule for `aws_rds.maxStorageSize`) — requires extending the IR's `AWSRDS` struct with an explicit `MaxStorageSize` field. Issue #205 lists this as "future IR field"; module-side precondition covers the deploy-blocking case today.
- Static-map dedup for the `[KeyAWSEKS, KeyAWSEKSNodeGroup]` user-preselect path (pre-existing latent issue, surfaces two cluster modules when caller selects both keys explicitly). Out of scope for #206; documented in `TestComposeStack_EKSAutoIncludeIdempotent`'s comment.

Closes #205
Closes #206