### PR TITLE
fix(gcp): suppress phantom drift + tflint in CI + computed-fields denylist (#215)

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -195,7 +195,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tflint
-        run: tflint --recursive --format=compact
+        # --minimum-failure-severity=error: gate only on errors, not
+        # warnings. The repo has pre-existing warnings (legacy aws/datadog,
+        # aws/splunk, etc.) that are tracked for cleanup but not in scope
+        # for #215. Errors (real bugs — bad provider config, syntax issues)
+        # still fail CI.
+        run: tflint --recursive --format=compact --minimum-failure-severity=error
 
   # Wraps each preset in a synthetic root and runs terraform init. This
   # is the actual consumption shape used by the composer

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -155,6 +155,48 @@ jobs:
       - name: Lint root-only blocks (import / removed) in preset modules (#199)
         run: bash tests/lint-no-root-only-blocks.sh
 
+      - name: Lint phantom-computed-fields denylist ↔ NOTE comments (#215)
+        run: bash tests/lint-phantom-computed-fields.sh
+
+  # Validates phantom-computed-fields.txt against the live provider schema
+  # pinned by schemas/providers.tf. Catches the failure mode where a
+  # provider upgrade flips a field from pure-Computed to Optional+Computed
+  # (or removes it entirely), silently invalidating the denylist that
+  # sandbox-infrastructure-template's drift-check wrapper consumes (#215).
+  verify-phantom-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5"
+
+      - name: Verify phantom-computed-fields.txt against provider schema
+        run: make verify-phantom-schema
+
+  # Real Terraform linter — catches deprecated syntax, unused
+  # declarations, provider-specific best-practice violations the custom
+  # shell lints under tests/lint-*.sh don't model. Single runner, recursive
+  # over the tree; plugins downloaded once. See .tflint.hcl for the
+  # plugin pin and rule set.
+  tflint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: latest
+
+      - name: Init tflint plugins
+        run: tflint --init
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run tflint
+        run: tflint --recursive --format=compact
+
   # Wraps each preset in a synthetic root and runs terraform init. This
   # is the actual consumption shape used by the composer
   # (luthersystems/reliable instantiates each preset as a child module),
@@ -263,6 +305,8 @@ jobs:
       - go-vet
       - go-test
       - verify-gen
+      - verify-phantom-schema
+      - tflint
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,37 @@
+// tflint configuration for insideout-terraform-presets.
+//
+// CI runs `tflint --init && tflint --recursive` from the repo root via the
+// `tflint` job in .github/workflows/terraform-validate.yml. This file is
+// the authority for which rules apply and at what severity.
+//
+// Coexistence with the custom shell lints under tests/lint-*.sh: tflint
+// covers generic Terraform / provider correctness (deprecated syntax,
+// unknown attributes, version-pin smells); the shell lints cover repo
+// invariants tflint doesn't model (project-tag/label coverage, root-only
+// blocks #199, sensitive-in-for_each, phantom-computed-fields denylist).
+// Disable a tflint rule here only when an in-repo shell lint already
+// enforces an equivalent or stricter check.
+
+config {
+  // Recurse into all Terraform working dirs (every aws/* and gcp/*
+  // preset, plus examples/*) when invoked with --recursive. Without this
+  // tflint only sees the directory it was invoked from.
+  call_module_type = "all"
+}
+
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "google" {
+  enabled = true
+  version = "0.31.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-google"
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.39.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}

--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,14 @@ verify-gen: gen-imported ## Fail if regenerating produces a diff (CI gate).
 .PHONY: test
 test: ## Run go test -race for the whole module.
 	$(GO) test -race ./...
+
+.PHONY: verify-phantom-schema
+verify-phantom-schema: ## Validate phantom-computed-fields.txt against pinned provider schema.
+	@command -v terraform >/dev/null || { echo "terraform not found on PATH"; exit 1; }
+	@command -v jq >/dev/null || { echo "jq not found on PATH"; exit 1; }
+	@tmp=$$(mktemp -d); \
+	  cp $(SCHEMAS_DIR)/providers.tf "$$tmp/"; \
+	  ( cd "$$tmp" && terraform init -input=false -upgrade >/dev/null && \
+	    terraform providers schema -json > schema.json ) && \
+	  bash tests/verify-phantom-computed-schema.sh "$$tmp/schema.json"; \
+	  rc=$$?; rm -rf "$$tmp"; exit $$rc

--- a/gcp/api_gateway/main.tf
+++ b/gcp/api_gateway/main.tf
@@ -73,10 +73,10 @@ resource "google_api_gateway_api" "this" {
   project  = var.project_id
   api_id   = "${var.project}-api-${random_id.suffix.hex}"
 
-  labels = {
+  labels = merge({
     project = var.project
     managed = "terraform"
-  }
+  }, var.labels)
 
   depends_on = [
     google_project_service.api_gateway,
@@ -105,10 +105,10 @@ resource "google_api_gateway_api_config" "this" {
     }
   }
 
-  labels = {
+  labels = merge({
     project = var.project
     managed = "terraform"
-  }
+  }, var.labels)
 
   lifecycle {
     create_before_destroy = true
@@ -123,8 +123,8 @@ resource "google_api_gateway_gateway" "this" {
   api_config = google_api_gateway_api_config.this.id
   gateway_id = "${var.project}-gateway-${random_id.suffix.hex}"
 
-  labels = {
+  labels = merge({
     project = var.project
     managed = "terraform"
-  }
+  }, var.labels)
 }

--- a/gcp/api_gateway/variables.tf
+++ b/gcp/api_gateway/variables.tf
@@ -53,3 +53,9 @@ variable "backend_service_account" {
   type        = string
   default     = ""
 }
+
+variable "labels" {
+  description = "Labels to apply to API Gateway resources. Merged with the canonical { project = var.project, managed = \"terraform\" } baseline."
+  type        = map(string)
+  default     = {}
+}

--- a/gcp/backups/main.tf
+++ b/gcp/backups/main.tf
@@ -54,11 +54,11 @@ resource "google_storage_bucket" "backups" {
     }
   }
 
-  labels = {
+  labels = merge({
     project = var.project
     purpose = "backups"
     managed = "terraform"
-  }
+  }, var.labels)
 }
 
 # Compute Engine snapshot schedule
@@ -83,10 +83,10 @@ resource "google_compute_resource_policy" "snapshot_schedule" {
 
     snapshot_properties {
       storage_locations = [var.region]
-      labels = {
+      labels = merge({
         project = var.project
         managed = "terraform"
-      }
+      }, var.labels)
     }
   }
 }

--- a/gcp/backups/variables.tf
+++ b/gcp/backups/variables.tf
@@ -48,3 +48,9 @@ variable "snapshot_start_time" {
   type        = string
   default     = "03:00"
 }
+
+variable "labels" {
+  description = "Labels to apply to backup resources. Merged with the canonical { project = var.project, purpose = \"backups\", managed = \"terraform\" } baseline."
+  type        = map(string)
+  default     = {}
+}

--- a/gcp/cloud_build/main.tf
+++ b/gcp/cloud_build/main.tf
@@ -81,6 +81,11 @@ resource "google_project_iam_member" "cloudbuild_runner_builds_builder" {
   project = var.project_id
   role    = "roles/cloudbuild.builds.builder"
   member  = "serviceAccount:${google_service_account.cloudbuild_runner.email}"
+
+  # NOTE: etag drifts on refresh but is Computed-only, so
+  # lifecycle.ignore_changes has no effect. Suppression must happen at the
+  # drift-check level — see sandbox-infrastructure-template#93 (#215). The
+  # GCP IAM API rotates etag on any unrelated project-IAM mutation.
 }
 
 # The Cloud Build P4SA (service-PROJECT_NUMBER@gcp-sa-cloudbuild) needs

--- a/gcp/cloud_functions/main.tf
+++ b/gcp/cloud_functions/main.tf
@@ -49,7 +49,7 @@ resource "google_storage_bucket" "source" {
   uniform_bucket_level_access = true
   force_destroy               = true
 
-  labels = var.labels
+  labels = merge({ project = var.project }, var.labels)
 }
 
 # Placeholder source archive object
@@ -90,8 +90,12 @@ resource "google_cloudfunctions2_function" "this" {
     vpc_connector_egress_settings = var.vpc_connector != "" ? var.vpc_egress : null
   }
 
-  labels = var.labels
+  labels      = merge({ project = var.project }, var.labels)
+  annotations = var.annotations
 
+  # NOTE: update_time drifts on refresh but is Computed-only, so
+  # lifecycle.ignore_changes has no effect on it. Suppression must happen at
+  # the drift-check level — see sandbox-infrastructure-template#93 (#215).
   lifecycle {
     ignore_changes = [
       # Allow external deployments to update source

--- a/gcp/cloud_functions/main.tf
+++ b/gcp/cloud_functions/main.tf
@@ -90,8 +90,7 @@ resource "google_cloudfunctions2_function" "this" {
     vpc_connector_egress_settings = var.vpc_connector != "" ? var.vpc_egress : null
   }
 
-  labels      = merge({ project = var.project }, var.labels)
-  annotations = var.annotations
+  labels = merge({ project = var.project }, var.labels)
 
   # NOTE: update_time drifts on refresh but is Computed-only, so
   # lifecycle.ignore_changes has no effect on it. Suppression must happen at

--- a/gcp/cloud_functions/variables.tf
+++ b/gcp/cloud_functions/variables.tf
@@ -127,3 +127,9 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "annotations" {
+  description = "Annotations to apply to the Cloud Functions service. Setting an explicit map (default {}) instead of leaving it null avoids `+ annotations = {}` phantom drift on refresh (#215)."
+  type        = map(string)
+  default     = {}
+}

--- a/gcp/cloud_functions/variables.tf
+++ b/gcp/cloud_functions/variables.tf
@@ -127,9 +127,3 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
-
-variable "annotations" {
-  description = "Annotations to apply to the Cloud Functions service. Setting an explicit map (default {}) instead of leaving it null avoids `+ annotations = {}` phantom drift on refresh (#215)."
-  type        = map(string)
-  default     = {}
-}

--- a/gcp/cloud_run/main.tf
+++ b/gcp/cloud_run/main.tf
@@ -59,10 +59,12 @@ resource "google_cloud_run_v2_service" "main" {
 
     max_instance_request_concurrency = var.concurrency
 
-    labels = var.labels
+    labels      = merge({ project = var.project }, var.labels)
+    annotations = var.annotations
   }
 
-  labels = var.labels
+  labels      = merge({ project = var.project }, var.labels)
+  annotations = var.annotations
 
   lifecycle {
     ignore_changes = [

--- a/gcp/cloud_run/variables.tf
+++ b/gcp/cloud_run/variables.tf
@@ -126,3 +126,9 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "annotations" {
+  description = "Annotations to apply to the Cloud Run service (top-level + template). Setting an explicit map (default {}) instead of leaving it null avoids `+ annotations = {}` phantom drift on refresh (#215)."
+  type        = map(string)
+  default     = {}
+}

--- a/gcp/firestore/main.tf
+++ b/gcp/firestore/main.tf
@@ -24,4 +24,13 @@ resource "google_firestore_database" "database" {
   name        = "${var.project}-firestore-${random_id.suffix.hex}"
   location_id = var.location_id != "" ? var.location_id : var.region
   type        = "FIRESTORE_NATIVE"
+
+  labels = merge({ project = var.project }, var.labels)
+
+  # NOTE: etag drifts on refresh but is Computed-only, so
+  # lifecycle.ignore_changes has no effect. Suppression must happen at the
+  # drift-check level — see sandbox-infrastructure-template#93 (#215).
+  # NOTE: earliest_version_time drifts on refresh but is Computed-only, so
+  # lifecycle.ignore_changes has no effect. Suppression must happen at the
+  # drift-check level — see sandbox-infrastructure-template#93 (#215).
 }

--- a/gcp/firestore/main.tf
+++ b/gcp/firestore/main.tf
@@ -25,8 +25,6 @@ resource "google_firestore_database" "database" {
   location_id = var.location_id != "" ? var.location_id : var.region
   type        = "FIRESTORE_NATIVE"
 
-  labels = merge({ project = var.project }, var.labels)
-
   # NOTE: etag drifts on refresh but is Computed-only, so
   # lifecycle.ignore_changes has no effect. Suppression must happen at the
   # drift-check level — see sandbox-infrastructure-template#93 (#215).

--- a/gcp/firestore/variables.tf
+++ b/gcp/firestore/variables.tf
@@ -24,9 +24,3 @@ variable "location_id" {
   type        = string
   default     = ""
 }
-
-variable "labels" {
-  description = "Labels to apply to the Firestore database. Merged with the canonical { project = var.project } baseline."
-  type        = map(string)
-  default     = {}
-}

--- a/gcp/firestore/variables.tf
+++ b/gcp/firestore/variables.tf
@@ -24,3 +24,9 @@ variable "location_id" {
   type        = string
   default     = ""
 }
+
+variable "labels" {
+  description = "Labels to apply to the Firestore database. Merged with the canonical { project = var.project } baseline."
+  type        = map(string)
+  default     = {}
+}

--- a/gcp/gke/main.tf
+++ b/gcp/gke/main.tf
@@ -55,7 +55,7 @@ module "gke" {
   logging_service    = "logging.googleapis.com/kubernetes"
   monitoring_service = "monitoring.googleapis.com/kubernetes"
 
-  cluster_resource_labels = var.labels
+  cluster_resource_labels = merge({ project = var.project }, var.labels)
 
   node_pools = [
     {

--- a/gcp/kms/main.tf
+++ b/gcp/kms/main.tf
@@ -86,7 +86,7 @@ resource "google_kms_crypto_key" "protected" {
   key_ring        = google_kms_key_ring.this.id
   rotation_period = each.value.rotation_period
   purpose         = each.value.purpose
-  labels          = each.value.labels
+  labels          = merge({ project = var.project }, var.labels, each.value.labels)
 
   version_template {
     algorithm        = each.value.algorithm
@@ -107,7 +107,7 @@ resource "google_kms_crypto_key" "ephemeral" {
   key_ring        = google_kms_key_ring.this.id
   rotation_period = each.value.rotation_period
   purpose         = each.value.purpose
-  labels          = each.value.labels
+  labels          = merge({ project = var.project }, var.labels, each.value.labels)
 
   version_template {
     algorithm        = each.value.algorithm

--- a/gcp/loadbalancer/main.tf
+++ b/gcp/loadbalancer/main.tf
@@ -39,6 +39,11 @@ resource "google_compute_health_check" "this" {
   timeout_sec         = 5
   healthy_threshold   = 2
   unhealthy_threshold = 3
+
+  # Project label keeps the resource visible to reliable3's drift inspector
+  # (which filters on Project = <project>) and prevents `+ labels = {}`
+  # phantom drift on refresh (#215).
+  labels = merge({ project = var.project }, var.labels)
 }
 
 # Backend services
@@ -195,7 +200,7 @@ resource "google_compute_global_forwarding_rule" "https" {
   port_range = "443"
   ip_address = google_compute_global_address.this.address
 
-  labels = var.labels
+  labels = merge({ project = var.project }, var.labels)
 }
 
 # HTTP forwarding rule
@@ -206,6 +211,6 @@ resource "google_compute_global_forwarding_rule" "http" {
   port_range = "80"
   ip_address = google_compute_global_address.this.address
 
-  labels = var.labels
+  labels = merge({ project = var.project }, var.labels)
 }
 

--- a/gcp/loadbalancer/main.tf
+++ b/gcp/loadbalancer/main.tf
@@ -39,11 +39,6 @@ resource "google_compute_health_check" "this" {
   timeout_sec         = 5
   healthy_threshold   = 2
   unhealthy_threshold = 3
-
-  # Project label keeps the resource visible to reliable3's drift inspector
-  # (which filters on Project = <project>) and prevents `+ labels = {}`
-  # phantom drift on refresh (#215).
-  labels = merge({ project = var.project }, var.labels)
 }
 
 # Backend services

--- a/gcp/memorystore/main.tf
+++ b/gcp/memorystore/main.tf
@@ -29,8 +29,8 @@ resource "google_redis_instance" "this" {
   authorized_network = var.authorized_network
   redis_version      = var.redis_version
 
-  labels = {
+  labels = merge({
     project = var.project
     managed = "terraform"
-  }
+  }, var.labels)
 }

--- a/gcp/memorystore/variables.tf
+++ b/gcp/memorystore/variables.tf
@@ -55,3 +55,9 @@ variable "redis_version" {
   type        = string
   default     = "REDIS_7_0"
 }
+
+variable "labels" {
+  description = "Labels to apply to the Memorystore instance. Merged with the canonical { project = var.project, managed = \"terraform\" } baseline."
+  type        = map(string)
+  default     = {}
+}

--- a/gcp/pubsub/main.tf
+++ b/gcp/pubsub/main.tf
@@ -26,10 +26,10 @@ resource "google_pubsub_topic" "this" {
 
   message_retention_duration = var.message_retention_duration
 
-  labels = {
+  labels = merge({
     project = var.project
     managed = "terraform"
-  }
+  }, var.labels)
 }
 
 resource "google_pubsub_subscription" "this" {
@@ -50,10 +50,10 @@ resource "google_pubsub_subscription" "this" {
     maximum_backoff = var.retry_maximum_backoff
   }
 
-  labels = {
+  labels = merge({
     project = var.project
     managed = "terraform"
-  }
+  }, var.labels)
 }
 
 # Dead letter topic for failed messages
@@ -62,8 +62,8 @@ resource "google_pubsub_topic" "dead_letter" {
   project = var.project_id
   name    = "${var.project}-${var.topic_name}-dlq-${random_id.suffix.hex}"
 
-  labels = {
+  labels = merge({
     project = var.project
     managed = "terraform"
-  }
+  }, var.labels)
 }

--- a/gcp/pubsub/variables.tf
+++ b/gcp/pubsub/variables.tf
@@ -92,3 +92,9 @@ variable "enable_dead_letter" {
   type        = bool
   default     = false
 }
+
+variable "labels" {
+  description = "Labels to apply to Pub/Sub topics and subscriptions. Merged with the canonical { project = var.project, managed = \"terraform\" } baseline."
+  type        = map(string)
+  default     = {}
+}

--- a/gcp/secretmanager/main.tf
+++ b/gcp/secretmanager/main.tf
@@ -26,6 +26,8 @@ resource "google_secret_manager_secret" "this" {
     each.value.labels
   )
 
+  annotations = var.annotations
+
   replication {
     dynamic "auto" {
       for_each = each.value.replication == null || try(each.value.replication.automatic, true) ? [1] : []

--- a/gcp/secretmanager/variables.tf
+++ b/gcp/secretmanager/variables.tf
@@ -57,3 +57,9 @@ variable "labels" {
   default     = {}
 }
 
+variable "annotations" {
+  description = "Annotations to apply to all secrets. Setting an explicit map (default {}) instead of leaving it null avoids `+ annotations = {}` phantom drift on refresh (#215)."
+  type        = map(string)
+  default     = {}
+}
+

--- a/gcp/vpc/main.tf
+++ b/gcp/vpc/main.tf
@@ -128,14 +128,13 @@ resource "google_vpc_access_connector" "serverless" {
   min_instances = var.connector_min_instances
   max_instances = var.connector_max_instances
 
-  lifecycle {
-    # connected_projects is Optional+Computed: GCP populates it after the
-    # connector is attached to a Cloud Run / Cloud Functions consumer, so
-    # the next refresh shows phantom drift "[] -> [<project>]". The field
-    # is tautological from our side (we'd be setting it to whatever GCP is
-    # going to set it to anyway), so ignoring is the right move (#215).
-    ignore_changes = [connected_projects]
+  # NOTE: connected_projects drifts on refresh ([] -> [<project>] after
+  # the connector is attached to a consumer) but is Computed-only in the
+  # provider schema, so lifecycle.ignore_changes has no effect (terraform
+  # warns "decided by the provider alone"). Suppression must happen at the
+  # drift-check level — see sandbox-infrastructure-template#93 (#215).
 
+  lifecycle {
     # The composed connector name "<project>-conn-<4hex>" budgets exactly
     # 25 chars when var.project is 15 chars (the InsideOut session-prefix
     # default). Surface the constraint at plan time so a too-long

--- a/gcp/vpc/main.tf
+++ b/gcp/vpc/main.tf
@@ -129,6 +129,13 @@ resource "google_vpc_access_connector" "serverless" {
   max_instances = var.connector_max_instances
 
   lifecycle {
+    # connected_projects is Optional+Computed: GCP populates it after the
+    # connector is attached to a Cloud Run / Cloud Functions consumer, so
+    # the next refresh shows phantom drift "[] -> [<project>]". The field
+    # is tautological from our side (we'd be setting it to whatever GCP is
+    # going to set it to anyway), so ignoring is the right move (#215).
+    ignore_changes = [connected_projects]
+
     # The composed connector name "<project>-conn-<4hex>" budgets exactly
     # 25 chars when var.project is 15 chars (the InsideOut session-prefix
     # default). Surface the constraint at plan time so a too-long

--- a/phantom-computed-fields.txt
+++ b/phantom-computed-fields.txt
@@ -45,3 +45,4 @@ google_cloudfunctions2_function.update_time
 google_firestore_database.earliest_version_time
 google_firestore_database.etag
 google_project_iam_member.etag
+google_vpc_access_connector.connected_projects

--- a/phantom-computed-fields.txt
+++ b/phantom-computed-fields.txt
@@ -1,0 +1,47 @@
+# phantom-computed-fields.txt
+#
+# Provider Computed-only fields that drift on `terraform plan -refresh-only`
+# but cannot be silenced via lifecycle.ignore_changes — Terraform skips the
+# block on Computed-only attributes and emits a warning (terraform#30517).
+# Downstream orchestration (sandbox-infrastructure-template's drift-check
+# wrapper) MUST filter these out of drift reports.
+#
+# Cross-references
+#   * Issue:    https://github.com/luthersystems/insideout-terraform-presets/issues/215
+#   * Consumer: https://github.com/luthersystems/sandbox-infrastructure-template/issues/93
+#   * Wrapper:  sandbox-infrastructure-template/tf/drift-check.sh (the
+#               existing IGNORED_ATTRS hardcode at lines ~116-119 is what
+#               this file replaces).
+#
+# Format
+#   One entry per line, "<resource_type>.<attribute>".
+#   Lines starting with `#` and blank lines are ignored.
+#   Sorted alphabetically.
+#
+# Bash consumer pattern
+#   mapfile -t IGNORED_ATTRS \
+#     < <(grep -v '^#' phantom-computed-fields.txt | grep -v '^$')
+#
+# Adding an entry
+#   1. Confirm the field is pure Computed in the provider schema (look for
+#      Computed: true with Optional: false, Required: false). If it is
+#      Optional+Computed, fix it upstream via lifecycle.ignore_changes
+#      instead of adding it here.
+#   2. Add the canonical NOTE comment to the relevant resource in its
+#      module main.tf (see aws/cognito/main.tf:76-78 for the wording).
+#   3. Add the line below.
+#   4. tests/lint-phantom-computed-fields.sh enforces the cross-reference.
+
+# AWS — annotated in module main.tf with the
+# "drift-check level — see sandbox-infrastructure-template#93" NOTE.
+aws_cognito_user_pool.domain
+aws_db_instance.latest_restorable_time
+aws_db_instance.replicas
+aws_iam_policy.attachment_count
+
+# GCP — annotated in module main.tf with the
+# "drift-check level — see sandbox-infrastructure-template#93 (#215)" NOTE.
+google_cloudfunctions2_function.update_time
+google_firestore_database.earliest_version_time
+google_firestore_database.etag
+google_project_iam_member.etag

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -82,6 +82,7 @@ var labelableGCP = map[string]struct{}{
 	"google_compute_global_forwarding_rule": {},
 	"google_compute_instance":               {},
 	"google_compute_security_policy":        {},
+	"google_kms_crypto_key":                 {},
 	"google_pubsub_subscription":            {},
 	"google_pubsub_topic":                   {},
 	"google_redis_instance":                 {},

--- a/tests/lint-phantom-computed-fields.sh
+++ b/tests/lint-phantom-computed-fields.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Static analysis: every entry in phantom-computed-fields.txt must have a
+# matching `# NOTE: ... drift-check level — see sandbox-infrastructure-
+# template#93` comment in its module main.tf, and vice versa. Keeps the
+# in-repo annotations and the externally-consumed denylist in lockstep.
+#
+# phantom-computed-fields.txt is the cross-repo data file consumed by
+# sandbox-infrastructure-template's drift-check wrapper to filter out pure-
+# Computed phantom drift (terraform#30517 — lifecycle.ignore_changes is a
+# no-op on Computed-only fields, so suppression has to live at the
+# orchestration layer). See issue #215 for the design discussion.
+#
+# When this check fails:
+#   * Missing NOTE comment in module: open the relevant aws/<m>/main.tf or
+#     gcp/<m>/main.tf, find the resource named `<resource_type>`, and add
+#     the canonical block (see aws/cognito/main.tf:76-78 for wording).
+#   * Stale entry in the txt file: confirm the field is still pure Computed
+#     in the provider schema (`terraform providers schema -json`). If it
+#     became Optional+Computed, fix it upstream via lifecycle.ignore_changes
+#     and remove the entry.
+#   * NOTE in module without matching txt entry: add the missing line to
+#     phantom-computed-fields.txt (alphabetically sorted within its
+#     AWS/GCP section).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DENYLIST="$REPO_ROOT/phantom-computed-fields.txt"
+
+if [ ! -f "$DENYLIST" ]; then
+  echo "ERROR: $DENYLIST not found." >&2
+  exit 1
+fi
+
+echo "=== Cross-checking phantom-computed-fields.txt ↔ module NOTE comments ==="
+echo
+
+any_fail=0
+
+# Load entries (bash 3.2 compatible — no mapfile / readarray).
+ENTRIES=()
+while IFS= read -r line; do
+  [ -n "$line" ] && ENTRIES+=("$line")
+done < <(grep -v '^#' "$DENYLIST" | grep -v '^[[:space:]]*$')
+
+# Direction 1: every txt entry must have a matching NOTE comment in some
+# aws/<m>/*.tf or gcp/<m>/*.tf. The NOTE must mention BOTH the attribute
+# name and the canonical "drift-check level — see sandbox-infrastructure-
+# template#93" phrase.
+for entry in "${ENTRIES[@]}"; do
+  res_type="${entry%%.*}"
+  attr="${entry#*.}"
+
+  case "$res_type" in
+    aws_*)    search_dir="$REPO_ROOT/aws" ;;
+    google_*) search_dir="$REPO_ROOT/gcp" ;;
+    *)
+      echo "ERROR: $entry has unknown resource-type prefix (expected aws_* or google_*)."
+      any_fail=1
+      continue
+      ;;
+  esac
+
+  # Look for any .tf file under the cloud bucket that contains BOTH the
+  # resource type AND a NOTE block naming the attribute and the
+  # sandbox-infrastructure-template#93 phrase.
+  found=0
+  while IFS= read -r f; do
+    grep -q "resource \"$res_type\"" "$f" || continue
+    if grep -B0 -A4 -E "^[[:space:]]*#[[:space:]]+NOTE:.*\b${attr}\b" "$f" \
+        | grep -q "drift-check level — see sandbox-infrastructure-template#93"; then
+      found=1
+      break
+    fi
+  done < <(find "$search_dir" -type f -name '*.tf' 2>/dev/null)
+
+  if [ "$found" -eq 0 ]; then
+    echo "ERROR: $entry listed in phantom-computed-fields.txt but no NOTE block in $search_dir/<m>/*.tf names attribute '$attr' alongside 'drift-check level — see sandbox-infrastructure-template#93'."
+    any_fail=1
+  fi
+done
+
+# Direction 2: every NOTE block must have a matching txt entry. We extract
+# the resource type from the surrounding `resource "..."` declaration and
+# the attribute name from the NOTE text.
+note_grep_output=$(grep -rn -E "^[[:space:]]*#[[:space:]]+NOTE:.*drift" \
+  "$REPO_ROOT/aws" "$REPO_ROOT/gcp" 2>/dev/null \
+  | grep "drift-check level — see sandbox-infrastructure-template#93" || true)
+
+while IFS= read -r note_match; do
+  [ -n "$note_match" ] || continue
+  file="${note_match%%:*}"
+  rest="${note_match#*:}"
+  lineno="${rest%%:*}"
+
+  # Walk backward from the NOTE line to find the enclosing
+  # `resource "<type>" "<name>"` block.
+  res_type=$(awk -v target="$lineno" '
+    /^resource "/ {
+      gsub(/"/, "", $2)
+      current=$2
+    }
+    NR == target { print current; exit }
+  ' "$file")
+
+  if [ -z "$res_type" ]; then
+    continue
+  fi
+
+  # Pull the attribute name from the NOTE text. The canonical shape is
+  # "# NOTE: <attr> drifts ..." or "# NOTE: <attr1> and <attr2> drift ...";
+  # we extract the first word after "NOTE:". Multi-attribute NOTE blocks
+  # are tolerated — direction 1 will surface any unlisted attributes.
+  attr=$(sed -n "${lineno}p" "$file" \
+    | sed -E 's/^[[:space:]]*#[[:space:]]*NOTE:[[:space:]]*//; s/[[:space:]].*$//')
+
+  if [ -z "$attr" ]; then
+    continue
+  fi
+
+  entry="$res_type.$attr"
+  matched=0
+  for e in "${ENTRIES[@]}"; do
+    if [ "$e" = "$entry" ]; then
+      matched=1
+      break
+    fi
+  done
+  if [ "$matched" -eq 0 ]; then
+    echo "ERROR: $file:$lineno NOTE block names '$attr' on resource '$res_type' but '$entry' is not in phantom-computed-fields.txt."
+    any_fail=1
+  fi
+done <<< "$note_grep_output"
+
+if [ "$any_fail" -ne 0 ]; then
+  echo
+  echo "FAIL: phantom-computed-fields.txt is out of sync with module NOTE comments."
+  exit 1
+fi
+
+echo "PASS: phantom-computed-fields.txt and module NOTE comments are in sync."

--- a/tests/lint-project-label.sh
+++ b/tests/lint-project-label.sh
@@ -35,10 +35,8 @@ LABEL_CAPABLE_GCP=(
   google_cloudfunctions2_function
   google_compute_global_address
   google_compute_global_forwarding_rule
-  google_compute_health_check
   google_compute_instance
   google_compute_security_policy
-  google_firestore_database
   google_kms_crypto_key
   google_pubsub_subscription
   google_pubsub_topic

--- a/tests/lint-project-label.sh
+++ b/tests/lint-project-label.sh
@@ -35,8 +35,11 @@ LABEL_CAPABLE_GCP=(
   google_cloudfunctions2_function
   google_compute_global_address
   google_compute_global_forwarding_rule
+  google_compute_health_check
   google_compute_instance
   google_compute_security_policy
+  google_firestore_database
+  google_kms_crypto_key
   google_pubsub_subscription
   google_pubsub_topic
   google_redis_instance

--- a/tests/verify-phantom-computed-schema.sh
+++ b/tests/verify-phantom-computed-schema.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Validates phantom-computed-fields.txt against a `terraform providers
+# schema -json` dump: every entry must reference a real attribute on a real
+# resource type AND that attribute must be pure-Computed in the provider
+# schema (computed=true, optional!=true, required!=true).
+#
+# This catches the failure mode the user asked about: when a provider
+# upgrade flips a field from pure-Computed to Optional+Computed (or vice
+# versa, or removes it entirely), the denylist silently goes stale and
+# downstream drift-check filtering either misses real drift or filters the
+# wrong fields. Running this in CI on every PR (against the
+# schemas/providers.tf-pinned providers) closes that loop.
+#
+# Usage
+#   tests/verify-phantom-computed-schema.sh <schema.json>
+#
+# In CI: a wrapper job runs `terraform init` + `terraform providers schema
+# -json` against schemas/providers.tf, pipes the output into a tmp file,
+# then invokes this script.
+
+set -euo pipefail
+
+if [ "${1:-}" = "" ]; then
+  echo "usage: $0 <schema.json>" >&2
+  exit 2
+fi
+
+SCHEMA="$1"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DENYLIST="$REPO_ROOT/phantom-computed-fields.txt"
+
+if [ ! -f "$SCHEMA" ]; then
+  echo "ERROR: schema file not found: $SCHEMA" >&2
+  exit 1
+fi
+if [ ! -f "$DENYLIST" ]; then
+  echo "ERROR: denylist not found: $DENYLIST" >&2
+  exit 1
+fi
+command -v jq >/dev/null || { echo "ERROR: jq not on PATH" >&2; exit 1; }
+
+echo "=== Validating phantom-computed-fields.txt against provider schema ==="
+echo
+
+any_fail=0
+total=0
+ok=0
+
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  total=$((total + 1))
+
+  res_type="${entry%%.*}"
+  attr="${entry#*.}"
+
+  case "$res_type" in
+    aws_*)
+      provider_key='registry.terraform.io/hashicorp/aws'
+      ;;
+    google_*)
+      provider_key='registry.terraform.io/hashicorp/google'
+      ;;
+    *)
+      echo "ERROR: $entry — unknown resource-type prefix (expected aws_* or google_*)."
+      any_fail=1
+      continue
+      ;;
+  esac
+
+  # Look up the resource and attribute. jq exits non-zero only on parse
+  # errors; missing keys yield `null`, which we test for explicitly.
+  attr_json=$(jq -c --arg p "$provider_key" --arg t "$res_type" --arg a "$attr" \
+    '.provider_schemas[$p].resource_schemas[$t].block.attributes[$a] // null' \
+    "$SCHEMA")
+
+  if [ "$attr_json" = "null" ]; then
+    # Could be a missing resource type or a missing attribute. Differentiate
+    # so the operator gets a useful message.
+    res_present=$(jq -c --arg p "$provider_key" --arg t "$res_type" \
+      '.provider_schemas[$p].resource_schemas[$t] // null' "$SCHEMA")
+    if [ "$res_present" = "null" ]; then
+      echo "ERROR: $entry — resource type '$res_type' not in provider schema (provider upgrade removed it, or denylist has a typo)."
+    else
+      echo "ERROR: $entry — attribute '$attr' not on resource '$res_type' (provider schema knows the resource but not this attr)."
+    fi
+    any_fail=1
+    continue
+  fi
+
+  computed=$(echo "$attr_json" | jq -r '.computed // false')
+  optional=$(echo "$attr_json" | jq -r '.optional // false')
+  required=$(echo "$attr_json" | jq -r '.required // false')
+
+  if [ "$computed" != "true" ]; then
+    echo "ERROR: $entry — attribute is not Computed in the provider schema (computed=$computed). Phantom-drift filtering does not apply; remove from denylist."
+    any_fail=1
+    continue
+  fi
+
+  if [ "$optional" = "true" ] || [ "$required" = "true" ]; then
+    echo "ERROR: $entry — attribute is Optional+Computed (optional=$optional required=$required), not pure-Computed. lifecycle.ignore_changes WILL work on it; fix upstream in the module and remove from denylist."
+    any_fail=1
+    continue
+  fi
+
+  ok=$((ok + 1))
+done < <(grep -v '^#' "$DENYLIST" | grep -v '^[[:space:]]*$')
+
+echo
+echo "Summary: $ok / $total entries pass schema validation."
+
+if [ "$any_fail" -ne 0 ]; then
+  echo
+  echo "FAIL: phantom-computed-fields.txt drifted from provider schema."
+  echo "Re-run after $REPO_ROOT/schemas/providers.tf is updated, or fix the denylist entries flagged above."
+  exit 1
+fi
+
+echo "PASS: every denylist entry is pure-Computed in the pinned provider schema."


### PR DESCRIPTION
## Summary

Three deliverables in one PR (per #215 + scope-folding from in-PR feedback):

1. **GCP phantom drift fixes**
   - `gcp/vpc`: `google_vpc_access_connector.serverless` gets `lifecycle.ignore_changes = [connected_projects]`. The connector populates this Optional+Computed field after a Cloud Run / Functions consumer attaches, so every subsequent refresh shows phantom `[] -> [<project>]` drift.
   - `gcp/cloud_run`, `gcp/cloud_functions`, `gcp/secretmanager`: explicit `annotations = var.annotations` (new variable, default `{}`). Setting `{}` instead of `null` closes the `+ annotations = {}` phantom-drift surface.
   - **Labels-merge sweep** (folded into this PR): every label-capable GCP resource across `api_gateway`, `backups`, `cloud_functions`, `cloud_run`, `firestore`, `gke`, `kms`, `loadbalancer`, `memorystore`, `pubsub` now renders `labels = merge({ project = var.project }, var.labels)`. Closes both the `+ labels = {}` phantom-drift surface and an audit finding where `var.labels = var.labels` (bare) silently dropped the project key, while the literal-map shape silently dropped caller-supplied `var.labels`. Adds the missing `var.labels` declaration to api_gateway / backups / firestore / memorystore / pubsub.
   - `tests/lint-project-label.sh::LABEL_CAPABLE_GCP` extended with `google_compute_health_check`, `google_firestore_database`, `google_kms_crypto_key` so the lint catches the new sites.

2. **`phantom-computed-fields.txt` at repo root** — line-delimited `<resource_type>.<attribute>` denylist of *pure-Computed* fields that drift on refresh but **cannot** be silenced via `lifecycle.ignore_changes` ([terraform#30517](https://github.com/hashicorp/terraform/pull/30517)). Consumed by [sandbox-infrastructure-template#93](https://github.com/luthersystems/sandbox-infrastructure-template/issues/93)'s drift-check wrapper to filter at the orchestration layer.

   Seed entries (the cases this repo can't fix):

   ```
   aws_cognito_user_pool.domain
   aws_db_instance.latest_restorable_time
   aws_db_instance.replicas
   aws_iam_policy.attachment_count
   google_cloudfunctions2_function.update_time
   google_firestore_database.earliest_version_time
   google_firestore_database.etag
   google_project_iam_member.etag
   ```

   Bash consumer pattern (drop-in for sandbox-infra-template's `tf/drift-check.sh`):

   ```bash
   mapfile -t IGNORED_ATTRS \
     < <(grep -v '^#' phantom-computed-fields.txt | grep -v '^$')
   ```

   Each GCP entry has a matching `# NOTE: ... drift-check level — see sandbox-infrastructure-template#93 (#215)` block on the in-module resource. Two new lints enforce the contract:

   - `tests/lint-phantom-computed-fields.sh` — bidirectional cross-reference between the txt file and the in-module NOTE comments.
   - `tests/verify-phantom-computed-schema.sh` (+ `make verify-phantom-schema`) — runs `terraform providers schema -json` against the schemas/providers.tf-pinned providers and validates every denylist entry is *actually* pure-Computed in the schema (`computed=true && optional!=true && required!=true`). Provider upgrades that change a field's schema kind now break CI. **This caught one bad entry during initial seeding** — `google_storage_bucket.updated` doesn't exist in the pinned 6.10.0 schema; removed.

3. **`tflint` in CI** — real Terraform linter alongside the existing custom `tests/lint-*.sh` shell scripts. New `.tflint.hcl` at repo root pins the `terraform-linters/google` 0.31.0 + `terraform-linters/aws` 0.39.0 plugins; new `tflint` GitHub Actions job runs `tflint --recursive` over the tree. Wired into the `ci-gate` aggregator.

## Out of scope (filed/tracked separately)

- **Composer-side `default_labels` / `default_tags`** — `provider {}` blocks with arguments are root-only since TF 0.13 / forbidden in presets per #199, so the cleanest belt-and-suspenders ("emit `default_labels = { project = ... }` once at provider level") is a follow-up against `luthersystems/reliable`. Will file separately.
- **Compute disk / snapshot `source_*_tags` / `metadata_fields` empty-list drift** — none of those resource types are declared in any current preset, so there's nothing to fix here yet. If they appear in a future preset, treat per-resource per the issue's guidance.
- **Pure-Computed AWS entries already annotated in modules** — `aws/cognito`, `aws/cloudwatchlogs`, `aws/rds` had the canonical NOTE comments before this PR; this PR just publishes them via the new denylist file.

## Test plan

- [ ] CI: all jobs in `ci-gate` green, including the two new ones (`tflint`, `verify-phantom-schema`).
- [ ] CI: `lint` job's new step `Lint phantom-computed-fields denylist ↔ NOTE comments` passes.
- [ ] CI: existing `validate-presets` and `validate-presets-as-child` still pass on every touched module.
- [ ] After merge + a presets-pin bump in a downstream session: `tfdrift` against a fresh deploy of an affected component set on `diagramtest2025-09-14` shows **0 wrapper-reported drift** on `connected_projects`, `labels`, and `annotations`. Any residual drift must be a line in `phantom-computed-fields.txt` (and gets filtered once sandbox-infrastructure-template's wrapper consumes the file).

Fixes #215