### PR TITLE
feat(composer): GCP default_labels + tflint warning cleanup

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -195,12 +195,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tflint
-        # --minimum-failure-severity=error: gate only on errors, not
-        # warnings. The repo has pre-existing warnings (legacy aws/datadog,
-        # aws/splunk, etc.) that are tracked for cleanup but not in scope
-        # for #215. Errors (real bugs — bad provider config, syntax issues)
-        # still fail CI.
-        run: tflint --recursive --format=compact --minimum-failure-severity=error
+        run: tflint --recursive --format=compact
 
   # Wraps each preset in a synthetic root and runs terraform init. This
   # is the actual consumption shape used by the composer

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -35,3 +35,9 @@ plugin "aws" {
   version = "0.39.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
+
+// terraform_unused_declarations stays enabled — composer-mandated vars
+// (var.project / var.region / var.environment) that the module body
+// doesn't reference are annotated with `# tflint-ignore:
+// terraform_unused_declarations` directly above the variable block, with
+// a comment explaining why. Genuinely unused declarations still fail.

--- a/aws/codepipeline/main.tf
+++ b/aws/codepipeline/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 1.5"
+}
+
 # AWS CodePipeline CI/CD Module
 #
 # This is a placeholder module for AWS CodePipeline CI/CD.

--- a/aws/codepipeline/variables.tf
+++ b/aws/codepipeline/variables.tf
@@ -1,20 +1,24 @@
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.project at the root (CLAUDE.md mandate)
 variable "project" {
   description = "Project name for resource naming"
   type        = string
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.environment at the root (CLAUDE.md mandate)
 variable "environment" {
   description = "Environment (dev, staging, prod)"
   type        = string
   default     = "dev"
 }
 
+# tflint-ignore: terraform_unused_declarations  # stub module — var.source_repository is reserved for the actual implementation; the module body is currently a placeholder
 variable "source_repository" {
   description = "Source code repository (CodeCommit repo name or GitHub connection)"
   type        = string
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # stub module — var.branch is reserved for the actual implementation; the module body is currently a placeholder
 variable "branch" {
   description = "Branch to build from"
   type        = string

--- a/aws/composer/main.tf
+++ b/aws/composer/main.tf
@@ -1,0 +1,4 @@
+terraform {
+  required_version = ">= 1.5"
+}
+

--- a/aws/datadog/main.tf
+++ b/aws/datadog/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 1.5"
+}
+
 # Datadog Integration Module
 #
 # This is a placeholder module for Datadog observability integration.

--- a/aws/datadog/variables.tf
+++ b/aws/datadog/variables.tf
@@ -1,8 +1,10 @@
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.project at the root (CLAUDE.md mandate)
 variable "project" {
   description = "Project name for resource naming"
   type        = string
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.environment at the root (CLAUDE.md mandate)
 variable "environment" {
   description = "Environment (dev, staging, prod)"
   type        = string
@@ -10,6 +12,7 @@ variable "environment" {
 }
 
 # Datadog-specific variables (placeholders)
+# tflint-ignore: terraform_unused_declarations  # stub module — var.datadog_api_key is reserved for the actual implementation; the module body is currently a placeholder
 variable "datadog_api_key" {
   description = "Datadog API key (should be stored in Secrets Manager)"
   type        = string
@@ -17,6 +20,7 @@ variable "datadog_api_key" {
   sensitive   = true
 }
 
+# tflint-ignore: terraform_unused_declarations  # stub module — var.datadog_site is reserved for the actual implementation; the module body is currently a placeholder
 variable "datadog_site" {
   description = "Datadog site (e.g., datadoghq.com, datadoghq.eu)"
   type        = string

--- a/aws/ecs/variables.tf
+++ b/aws/ecs/variables.tf
@@ -31,6 +31,7 @@ variable "private_subnet_ids" {
   default     = []
 }
 
+# tflint-ignore: terraform_unused_declarations  # reserved for future wiring; kept for API stability across composer revisions
 variable "public_subnet_ids" {
   description = "Public subnet IDs (accepted for wiring compatibility, not used by cluster)"
   type        = list(string)

--- a/aws/githubactions/main.tf
+++ b/aws/githubactions/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 1.5"
+}
+
 # GitHub Actions CI/CD Integration Module
 #
 # This is a placeholder module for GitHub Actions CI/CD integration.

--- a/aws/githubactions/variables.tf
+++ b/aws/githubactions/variables.tf
@@ -1,20 +1,24 @@
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.project at the root (CLAUDE.md mandate)
 variable "project" {
   description = "Project name for resource naming"
   type        = string
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.environment at the root (CLAUDE.md mandate)
 variable "environment" {
   description = "Environment (dev, staging, prod)"
   type        = string
   default     = "dev"
 }
 
+# tflint-ignore: terraform_unused_declarations  # stub module — var.github_org is reserved for the actual implementation; the module body is currently a placeholder
 variable "github_org" {
   description = "GitHub organization or username"
   type        = string
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # stub module — var.github_repo is reserved for the actual implementation; the module body is currently a placeholder
 variable "github_repo" {
   description = "GitHub repository name"
   type        = string

--- a/aws/grafana/main.tf
+++ b/aws/grafana/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 1.5"
+}
+
 # Grafana Integration Module
 #
 # This is a placeholder module for Amazon Managed Grafana (AMG).

--- a/aws/grafana/variables.tf
+++ b/aws/grafana/variables.tf
@@ -1,8 +1,10 @@
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.project at the root (CLAUDE.md mandate)
 variable "project" {
   description = "Project name for resource naming"
   type        = string
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.environment at the root (CLAUDE.md mandate)
 variable "environment" {
   description = "Environment (dev, staging, prod)"
   type        = string
@@ -10,12 +12,14 @@ variable "environment" {
 }
 
 # Grafana-specific variables (placeholders)
+# tflint-ignore: terraform_unused_declarations  # stub module — var.grafana_admin_role_arn is reserved for the actual implementation; the module body is currently a placeholder
 variable "grafana_admin_role_arn" {
   description = "IAM role ARN for Grafana admin access"
   type        = string
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # stub module — var.authentication_providers is reserved for the actual implementation; the module body is currently a placeholder
 variable "authentication_providers" {
   description = "Authentication providers (SAML, AWS_SSO)"
   type        = list(string)

--- a/aws/splunk/main.tf
+++ b/aws/splunk/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 1.5"
+}
+
 # Splunk Integration Module
 #
 # This is a placeholder module for Splunk log forwarding integration.

--- a/aws/splunk/variables.tf
+++ b/aws/splunk/variables.tf
@@ -1,8 +1,10 @@
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.project at the root (CLAUDE.md mandate)
 variable "project" {
   description = "Project name for resource naming"
   type        = string
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.environment at the root (CLAUDE.md mandate)
 variable "environment" {
   description = "Environment (dev, staging, prod)"
   type        = string
@@ -10,12 +12,14 @@ variable "environment" {
 }
 
 # Splunk-specific variables (placeholders)
+# tflint-ignore: terraform_unused_declarations  # stub module — var.splunk_hec_endpoint is reserved for the actual implementation; the module body is currently a placeholder
 variable "splunk_hec_endpoint" {
   description = "Splunk HTTP Event Collector endpoint URL"
   type        = string
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # stub module — var.splunk_hec_token is reserved for the actual implementation; the module body is currently a placeholder
 variable "splunk_hec_token" {
   description = "Splunk HEC token (should be stored in Secrets Manager)"
   type        = string

--- a/examples/cargofit/providers.tf
+++ b/examples/cargofit/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/cargofit/variables.tf
+++ b/examples/cargofit/variables.tf
@@ -110,6 +110,7 @@ variable "project" {
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "AWS region"
   type        = string

--- a/examples/edubot/providers.tf
+++ b/examples/edubot/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/edubot/variables.tf
+++ b/examples/edubot/variables.tf
@@ -114,6 +114,7 @@ variable "project" {
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "AWS region"
   type        = string

--- a/examples/gamestudio/providers.tf
+++ b/examples/gamestudio/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/gamestudio/variables.tf
+++ b/examples/gamestudio/variables.tf
@@ -90,6 +90,7 @@ variable "project" {
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "AWS region"
   type        = string

--- a/examples/guestbook/providers.tf
+++ b/examples/guestbook/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/guestbook/variables.tf
+++ b/examples/guestbook/variables.tf
@@ -74,6 +74,7 @@ variable "project" {
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "AWS region"
   type        = string

--- a/examples/inboundfund-tf/providers.tf
+++ b/examples/inboundfund-tf/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/inboundfund-tf/variables.tf
+++ b/examples/inboundfund-tf/variables.tf
@@ -86,6 +86,7 @@ variable "project" {
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "AWS region"
   type        = string

--- a/examples/localbook/providers.tf
+++ b/examples/localbook/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/localbook/variables.tf
+++ b/examples/localbook/variables.tf
@@ -90,6 +90,7 @@ variable "project" {
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "AWS region"
   type        = string

--- a/examples/locallink/providers.tf
+++ b/examples/locallink/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/locallink/variables.tf
+++ b/examples/locallink/variables.tf
@@ -86,6 +86,7 @@ variable "project" {
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "AWS region"
   type        = string

--- a/examples/mobileapi/providers.tf
+++ b/examples/mobileapi/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/examples/mobileapi/variables.tf
+++ b/examples/mobileapi/variables.tf
@@ -94,12 +94,14 @@ variable "gcp_vpc_region" {
   type = string
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.project at the root (CLAUDE.md mandate)
 variable "project" {
   description = "Project name prefix"
   type        = string
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "GCP region"
   type        = string

--- a/examples/openclaw/providers.tf
+++ b/examples/openclaw/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/revisionapp/providers.tf
+++ b/examples/revisionapp/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/revisionapp/variables.tf
+++ b/examples/revisionapp/variables.tf
@@ -158,6 +158,7 @@ variable "project" {
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "AWS region"
   type        = string

--- a/examples/videostreaming/providers.tf
+++ b/examples/videostreaming/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/examples/videostreaming/variables.tf
+++ b/examples/videostreaming/variables.tf
@@ -58,6 +58,7 @@ variable "project" {
   default     = ""
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "AWS region"
   type        = string

--- a/gcp/backups/main.tf
+++ b/gcp/backups/main.tf
@@ -94,6 +94,7 @@ resource "google_compute_resource_policy" "snapshot_schedule" {
 # Cloud SQL backups are configured on the Cloud SQL instance itself
 # This local captures the backup configuration for reference
 locals {
+  # tflint-ignore: terraform_unused_declarations  # documentation-only: captures the backup configuration for output-by-reference (no resources reference it)
   backup_config = {
     gcs_bucket        = var.enable_gcs_backups ? google_storage_bucket.backups[0].name : null
     snapshot_schedule = var.enable_compute_snapshots ? google_compute_resource_policy.snapshot_schedule[0].name : null

--- a/gcp/bastion/variables.tf
+++ b/gcp/bastion/variables.tf
@@ -18,6 +18,7 @@ variable "project_id" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "GCP region"
   type        = string

--- a/gcp/cloud_armor/variables.tf
+++ b/gcp/cloud_armor/variables.tf
@@ -13,6 +13,7 @@ variable "project_id" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "GCP region (unused — Cloud Armor policies are global; kept for composer convention)"
   type        = string

--- a/gcp/cloud_cdn/main.tf
+++ b/gcp/cloud_cdn/main.tf
@@ -15,6 +15,7 @@ terraform {
 # Cloud CDN cache policy is configured via the load balancer backend service.
 # This local captures the CDN configuration for reference and outputs.
 locals {
+  # tflint-ignore: terraform_unused_declarations  # documentation-only: cloud_cdn is a doc-only preset (no resources); local captures the intended config shape for future implementations
   cdn_config = {
     enabled           = true
     cache_mode        = var.cache_mode

--- a/gcp/cloud_cdn/variables.tf
+++ b/gcp/cloud_cdn/variables.tf
@@ -1,8 +1,10 @@
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.project at the root (CLAUDE.md mandate)
 variable "project" {
   description = "GCP project ID"
   type        = string
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "GCP region"
   type        = string

--- a/gcp/cloud_monitoring/variables.tf
+++ b/gcp/cloud_monitoring/variables.tf
@@ -1,3 +1,4 @@
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.project at the root (CLAUDE.md mandate)
 variable "project" {
   description = "Naming/label prefix for stack resources (NOT a GCP project ID — see var.project_id)."
   type        = string
@@ -18,6 +19,7 @@ variable "project_id" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "GCP region (unused by the dashboard resource but retained for stack-wide composer mapping)"
   type        = string

--- a/gcp/compute/variables.tf
+++ b/gcp/compute/variables.tf
@@ -18,6 +18,7 @@ variable "project_id" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "GCP region"
   type        = string

--- a/gcp/firestore/main.tf
+++ b/gcp/firestore/main.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/gcp/gcs/variables.tf
+++ b/gcp/gcs/variables.tf
@@ -18,6 +18,7 @@ variable "project_id" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "GCP region (for regional buckets)"
   type        = string

--- a/gcp/identity_platform/variables.tf
+++ b/gcp/identity_platform/variables.tf
@@ -1,3 +1,4 @@
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.project at the root (CLAUDE.md mandate)
 variable "project" {
   description = "Naming/label prefix for stack resources (NOT a GCP project ID — see var.project_id)."
   type        = string
@@ -13,6 +14,7 @@ variable "project_id" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "GCP region"
   type        = string

--- a/gcp/loadbalancer/variables.tf
+++ b/gcp/loadbalancer/variables.tf
@@ -18,6 +18,7 @@ variable "project_id" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "GCP region"
   type        = string
@@ -30,11 +31,13 @@ variable "name" {
   default     = "main"
 }
 
+# tflint-ignore: terraform_unused_declarations  # reserved for future wiring; kept for API stability across composer revisions
 variable "network_self_link" {
   description = "VPC network self link"
   type        = string
 }
 
+# tflint-ignore: terraform_unused_declarations  # reserved for future wiring; kept for API stability across composer revisions
 variable "subnet_self_link" {
   description = "Subnet self link"
   type        = string

--- a/gcp/pubsub/variables.tf
+++ b/gcp/pubsub/variables.tf
@@ -13,6 +13,7 @@ variable "project_id" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "GCP region"
   type        = string

--- a/gcp/secretmanager/variables.tf
+++ b/gcp/secretmanager/variables.tf
@@ -18,6 +18,7 @@ variable "project_id" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
 variable "region" {
   description = "GCP region (not used, secrets are global)"
   type        = string

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -703,13 +703,31 @@ func generateProvidersTF(in providersTFInput) []byte {
 		if region == "" {
 			region = "us-central1"
 		}
-		required["google"] = &tfconfig.ProviderRequirement{Source: "hashicorp/google", VersionConstraints: []string{">= 5.0"}}
+		// Provider 5.16+ added default_labels; ">= 5.0" allows older
+		// minors. Hard-bumping to ">= 5.16" guarantees the safety net
+		// emitted below is always honored.
+		required["google"] = &tfconfig.ProviderRequirement{Source: "hashicorp/google", VersionConstraints: []string{">= 5.16"}}
 		maps.Copy(required, discovered)
+
+		// default_labels is a safety net so every GCP resource in the
+		// rendered stack carries the session's project label, even if a
+		// preset forgets the `labels = merge({ project = var.project },
+		// var.labels)` convention. Mirrors the AWS default_tags shape;
+		// reliable3's drift inspector filters resources by exact
+		// `project = <project>` match. Label keys/values must be lowercase
+		// alphanumeric + dash/underscore; both `project` and `managed-by`
+		// satisfy GCP's label-key regex.
+		gcpDefaultLabels := fmt.Sprintf(`
+  default_labels = {
+    project    = var.project
+    managed-by = %q
+  }`, insideoutManagedByValue)
+
 		var b strings.Builder
 		b.WriteString("terraform {\n  required_providers {\n")
 		b.WriteString(renderRequiredProviders(required))
 		b.WriteString("  }\n}\n\n")
-		fmt.Fprintf(&b, "provider \"google\" {\n  region = %q\n}\n", region)
+		fmt.Fprintf(&b, "provider \"google\" {\n  region = %q%s\n}\n", region, gcpDefaultLabels)
 		if importedClouds["gcp"] {
 			b.WriteString("\n")
 			// google.imported drives Terraform's import {} for previously

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -1679,20 +1679,24 @@ func TestComposeStack_GCP_Provider(t *testing.T) {
 	require.Contains(t, provStr, `provider "google"`, "should have google provider block")
 	require.Contains(t, provStr, "us-central1", "should use specified region")
 
-	// GCP intentionally has no default_tags / default_labels safety net: the
-	// google provider has native per-session credential isolation via
-	// creds.ProjectID and Reliable #1112's scope was AWS-only. Guard against
-	// someone adding half-working GCP tagging by accident — if a parity
-	// story ever lands it should be a deliberate feature change that updates
-	// this test, not a drive-by edit.
+	// GCP default_labels safety net: parity with the AWS default_tags shape.
+	// #111 deferred this; the deliberate feature change landed via #215 as
+	// a belt-and-suspenders for the phantom-`+ labels = {}` drift fix
+	// (every preset module is supposed to render
+	// `labels = merge({ project = var.project }, var.labels)`, but a missed
+	// site silently leaves the resource without the project label that
+	// reliable3's drift inspector filters on). default_labels at the
+	// provider level guarantees the project label reaches every label-capable
+	// resource regardless of whether the preset wires labels itself.
 	//
-	// Scope note: provStr is the root /providers.tf only (no preset contents),
-	// so a NotContains on the full string has negligible false-positive risk
-	// from a module name or comment mentioning "default_tags". If the haystack
-	// ever widens to include preset bodies, scope the check to the
-	// `provider "google" { ... }` block.
-	require.NotContains(t, provStr, "default_labels",
-		"GCP provider block should not declare default_labels (see #111; any GCP tagging parity should land via a deliberate feature, not a drive-by edit)")
+	// Requires google provider 5.16+ (default_labels was introduced there);
+	// generateProvidersTF pins the GCP required_providers to ">= 5.16".
+	require.Contains(t, provStr, "default_labels",
+		"GCP provider block should declare default_labels as the project-label safety net (#215)")
+	require.Contains(t, provStr, "project    = var.project",
+		"default_labels should bind project = var.project so reliable3's drift inspector can filter by project")
+	require.Contains(t, provStr, `managed-by = "insideout"`,
+		"default_labels should also carry managed-by = \"insideout\" mirroring the AWS default_tags shape")
 	require.NotContains(t, provStr, "default_tags",
 		"GCP provider block should not borrow AWS-shaped default_tags")
 }

--- a/pkg/composer/imported/generated/testdata/fixtures/terraform.tf
+++ b/pkg/composer/imported/generated/testdata/fixtures/terraform.tf
@@ -1,0 +1,7 @@
+# Test fixtures for the imported-codegen roundtrip tests. Real consumers
+# load specific named files (`<tfType>.tf`, see roundtrip_test.go); this
+# `terraform.tf` exists solely so the directory satisfies tflint's
+# terraform_required_version rule when CI walks the tree with --recursive.
+terraform {
+  required_version = ">= 1.5"
+}

--- a/schemas/providers.tf
+++ b/schemas/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## Summary

Two follow-ups from #215 (merged as #216):

1. **Composer-side `default_labels` for GCP** — the deferred parity from #111. The phantom-drift fix in #215 depends on every preset rendering `labels = merge({ project = var.project }, var.labels)`; a single missed site silently leaves the resource without the project label that reliable3's drift inspector filters on. `default_labels` at the provider level guarantees the project label reaches every label-capable resource even if the preset wires labels itself — mirroring the AWS `default_tags` shape that already lives at `pkg/composer/compose.go`. Required google provider ≥ 5.16; bumps the pin from `>= 5.0`.
2. **tflint warning cleanup** — drops the `--minimum-failure-severity=error` workaround introduced in #216 so warnings now block CI as they should.

## Composer change (deliverable 1)

`pkg/composer/compose.go::generateProvidersTF` now emits:

```hcl
provider "google" {
  region = "us-central1"
  default_labels = {
    project    = var.project
    managed-by = "insideout"
  }
}
```

Mirrors the AWS shape verbatim (same `var.project` source, same `managed-by` constant). Pinned to `hashicorp/google >= 5.16` because `default_labels` was introduced there. Test in `compose_stack_test.go::TestComposeStack_GCP_Provider` was previously a `NotContains` guard against this exact change (per #111's "any GCP tagging parity should land via a deliberate feature, not a drive-by edit"); flipped to `Contains` with a comment explaining that #215 is the deliberate feature.

## tflint cleanup (deliverable 2)

CI's tflint job had `--minimum-failure-severity=error` set in #216 because the repo had 69 pre-existing warnings. This PR clears them and drops the override:

- **`terraform_required_version` (20 sites)** — added `required_version = ">= 1.5"` to every terraform block. Six placeholder modules (`aws/codepipeline`, `aws/composer`, `aws/datadog`, `aws/githubactions`, `aws/grafana`, `aws/splunk`) had no terraform block at all; added a minimal one.
- **`terraform_unused_declarations` (49 sites)** — annotated each with `# tflint-ignore: terraform_unused_declarations` + a per-line explanation. Three categories:
  - **Composer-mandated** (var.project / region / environment, 38 sites): CLAUDE.md mandates these on every preset because the composer namespaces and unconditionally maps them at the root. Many module bodies don't reference them directly (the value reaches the resource via name interpolations or default_tags / default_labels). Annotation reads: `# composer always wires var.X at the root (CLAUDE.md mandate)`.
  - **Stub-module placeholder vars** (9 sites in datadog / grafana / splunk / githubactions / codepipeline): annotated as "stub module — var.X is reserved for the actual implementation".
  - **Vestigial vars** (3 sites in ecs / loadbalancer): annotated as "reserved for future wiring".
  - **Doc-only locals** in `cloud_cdn` and `backups` (2 sites): annotated as "documentation-only".

Rule stays **enabled** — genuinely-unused declarations in future PRs still fail CI.

## Files touched

- `pkg/composer/compose.go` — `generateProvidersTF` GCP branch
- `pkg/composer/compose_stack_test.go` — `TestComposeStack_GCP_Provider` updated
- `.tflint.hcl` — added rule comment block
- `.github/workflows/terraform-validate.yml` — dropped `--minimum-failure-severity=error`
- 20 .tf files: added `required_version`
- ~25 variables.tf and 2 main.tf files: added per-line `# tflint-ignore` annotations

## Test plan

- [ ] CI: all of `ci-gate` green, including `tflint` (now without the severity workaround) and `verify-phantom-schema`.
- [ ] CI: `validate-presets` passes on every module (the required_version additions don't break standalone validate).
- [ ] CI: `validate-presets-as-child` passes (the new GCP `default_labels` block survives child-module wrapping — should be fine since it's emitted at the composed root, not the preset).
- [ ] Local: `go test ./pkg/composer/...` passes (already verified locally; `TestComposeStack_GCP_Provider` updated, `TestUntaggableAllowlistsMatchLintScripts` still passes).