### PR TITLE
feat(drift): pkg/drift classifier — phase 1 of #219

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/phantom_computed_fields_embed.go
+++ b/phantom_computed_fields_embed.go
@@ -1,0 +1,21 @@
+package terraformpresets
+
+import _ "embed"
+
+// PhantomComputedFieldsTXT is the contents of phantom-computed-fields.txt
+// at repo root, exposed as a package-level variable so subpackages
+// (notably pkg/drift) can consume the denylist without traversing upward
+// in the source tree (go:embed forbids `..` paths).
+//
+// The file is the canonical list of pure-Computed provider attributes
+// that drift on `terraform plan -refresh-only` but cannot be silenced
+// via lifecycle.ignore_changes (terraform#30517). Format and ownership
+// are documented in the file itself; CI gates
+// (tests/verify-phantom-computed-schema.sh,
+// tests/lint-phantom-computed-fields.sh) keep it in sync with provider
+// schemas and module NOTE comments. The pkg/drift classifier parses
+// this content into a resource-type → attribute denylist used by the
+// phantomComputedRule (see pkg/drift/rules.go).
+//
+//go:embed phantom-computed-fields.txt
+var PhantomComputedFieldsTXT []byte

--- a/pkg/drift/classify.go
+++ b/pkg/drift/classify.go
@@ -2,7 +2,7 @@ package drift
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -92,7 +92,7 @@ func summarize(r Result) string {
 	for c := range classCounts {
 		classes = append(classes, c)
 	}
-	sort.Slice(classes, func(i, j int) bool { return classes[i] < classes[j] })
+	slices.Sort(classes)
 	for _, c := range classes {
 		fmt.Fprintf(&sb, ", %d %s", classCounts[c], c)
 	}

--- a/pkg/drift/classify.go
+++ b/pkg/drift/classify.go
@@ -1,0 +1,100 @@
+package drift
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Classify runs the rule chain against d and returns aggregate
+// findings. The rule chain is: defaultRules() in order, then any
+// extras passed via [WithExtraRules], then a fall-through that
+// classifies a resource with a non-empty Action as [ClassActionable]
+// (presumed real drift) or, lacking an Action, as [ClassUnknown].
+//
+// First match wins: once a rule returns true for a resource, no later
+// rule sees it. Resources is the per-resource verdict list, in input
+// order. Summary is a one-line human-readable roll-up suitable for
+// logs and downstream UI text.
+func Classify(d Drift, opts ...Option) Result {
+	cfg := config{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	rules := append(defaultRules(), cfg.extraRules...)
+
+	out := Result{
+		TotalCount: len(d.Resources),
+		Resources:  make([]Resource, 0, len(d.Resources)),
+	}
+
+	for _, rd := range d.Resources {
+		class, reason := classifyOne(rd, rules)
+		out.Resources = append(out.Resources, Resource{
+			Address: rd.Address,
+			Type:    rd.Type,
+			Name:    rd.Name,
+			Action:  rd.Action,
+			Class:   class,
+			Reason:  reason,
+		})
+		switch class {
+		case ClassActionable:
+			out.ActionableCount++
+		case ClassUnknown:
+			// Unknown isn't a "filtered out" win — it's just
+			// "not enough info to decide." Don't count it as
+			// filtered, don't count it as actionable.
+		default:
+			out.FilteredCount++
+		}
+	}
+
+	out.Summary = summarize(out)
+	return out
+}
+
+// classifyOne walks the rule chain for a single resource. Returns the
+// fall-through verdict (ClassActionable when Action is set,
+// ClassUnknown otherwise) when no rule matches.
+func classifyOne(rd ResourceDrift, rules []Rule) (Class, string) {
+	for _, rule := range rules {
+		if class, reason, ok := rule.Match(rd); ok {
+			return class, reason
+		}
+	}
+	if len(rd.Action) > 0 {
+		return ClassActionable, "no rule matched; action present"
+	}
+	return ClassUnknown, "no rule matched; no action present"
+}
+
+// summarize renders a one-line summary of a [Result], formatted as:
+//
+//	"<n> drift events: <m> actionable[, <k> <class>]..."
+//
+// Class roll-ups appear in deterministic alphabetical order so log
+// scrapers and golden tests are stable. Zero-count classes are
+// omitted.
+func summarize(r Result) string {
+	classCounts := make(map[Class]int)
+	for _, res := range r.Resources {
+		if res.Class == ClassActionable {
+			continue
+		}
+		classCounts[res.Class]++
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d drift events: %d actionable", r.TotalCount, r.ActionableCount)
+
+	classes := make([]Class, 0, len(classCounts))
+	for c := range classCounts {
+		classes = append(classes, c)
+	}
+	sort.Slice(classes, func(i, j int) bool { return classes[i] < classes[j] })
+	for _, c := range classes {
+		fmt.Fprintf(&sb, ", %d %s", classCounts[c], c)
+	}
+	return sb.String()
+}

--- a/pkg/drift/classify_test.go
+++ b/pkg/drift/classify_test.go
@@ -1,0 +1,433 @@
+package drift
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// rd is a tiny helper to keep ResourceDrift literals readable in test
+// tables. before/after are passed as raw JSON strings, parsed once.
+func rd(addr, typ string, action []string, before, after string) ResourceDrift {
+	return ResourceDrift{
+		Address: addr,
+		Type:    typ,
+		Action:  action,
+		Change: Change{
+			Before: json.RawMessage(before),
+			After:  json.RawMessage(after),
+		},
+	}
+}
+
+// --- providerNoiseRule ---
+
+func TestProviderNoiseRule_NullEmptyEquivalence(t *testing.T) {
+	t.Parallel()
+	d := Drift{Resources: []ResourceDrift{
+		rd("module.alb.aws_lb_listener.main", "aws_lb_listener",
+			[]string{"no-op"},
+			`{"tags": {}, "tags_all": {}, "ssl_policy": ""}`,
+			`{"tags": null, "tags_all": null, "ssl_policy": null}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class != ClassProviderNoise {
+		t.Errorf("Class = %q; want %q", got.Resources[0].Class, ClassProviderNoise)
+	}
+	if got.ActionableCount != 0 {
+		t.Errorf("ActionableCount = %d; want 0", got.ActionableCount)
+	}
+	if got.FilteredCount != 1 {
+		t.Errorf("FilteredCount = %d; want 1", got.FilteredCount)
+	}
+}
+
+func TestProviderNoiseRule_DoesNotFireOnRealDiff(t *testing.T) {
+	t.Parallel()
+	d := Drift{Resources: []ResourceDrift{
+		rd("aws_db.main", "aws_db_instance", []string{"update"},
+			`{"engine_version": "16.1"}`,
+			`{"engine_version": "16.3"}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class == ClassProviderNoise {
+		t.Errorf("provider_noise should not fire on real value change")
+	}
+}
+
+func TestNormalizeEmpty_ZeroValues(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   any
+		want any
+	}{
+		{"nil", nil, nil},
+		{"empty_string", "", nil},
+		{"zero_int", float64(0), nil},
+		{"false", false, nil},
+		{"empty_array", []any{}, nil},
+		{"empty_object", map[string]any{}, nil},
+		{"nonzero_int", float64(1), float64(1)},
+		{"nonempty_string", "x", "x"},
+		{"true", true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeEmpty(tt.in)
+			if !equalAny(got, tt.want) {
+				t.Errorf("normalizeEmpty(%v) = %v; want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func equalAny(a, b any) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	return a == b
+}
+
+// --- phantomComputedRule ---
+
+func TestPhantomComputedRule_AllAttrsOnDenylist(t *testing.T) {
+	t.Parallel()
+	// google_firestore_database.{etag,earliest_version_time} are
+	// both on the denylist; classification should be phantom.
+	d := Drift{Resources: []ResourceDrift{
+		rd("module.gcp_firestore.google_firestore_database.default",
+			"google_firestore_database",
+			[]string{"no-op"},
+			`{"etag": "abc", "earliest_version_time": "2026-04-30T18:00:00Z"}`,
+			`{"etag": "def", "earliest_version_time": "2026-05-01T18:00:00Z"}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class != ClassPhantomComputed {
+		t.Errorf("Class = %q; want %q", got.Resources[0].Class, ClassPhantomComputed)
+	}
+	if got.ActionableCount != 0 {
+		t.Errorf("ActionableCount = %d; want 0", got.ActionableCount)
+	}
+}
+
+func TestPhantomComputedRule_MixedDenylistedAndRealDrift(t *testing.T) {
+	t.Parallel()
+	// etag is on denylist, but engine_version is not — the resource
+	// has real drift in addition to phantom drift, must NOT be
+	// silenced. (Engine_version isn't an aws_db_instance attribute on
+	// the denylist, but use a clearly-not-listed key for the test.)
+	d := Drift{Resources: []ResourceDrift{
+		rd("aws_db.main", "aws_db_instance", []string{"update"},
+			`{"latest_restorable_time": "2026-04-30T18:00:00Z", "engine_version": "16.1"}`,
+			`{"latest_restorable_time": "2026-05-01T18:00:00Z", "engine_version": "16.3"}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class == ClassPhantomComputed {
+		t.Errorf("phantom_computed should not fire when non-denylisted attribute also changed")
+	}
+}
+
+func TestPhantomComputedRule_TypeNotInDenylist(t *testing.T) {
+	t.Parallel()
+	d := Drift{Resources: []ResourceDrift{
+		rd("aws_s3_bucket.b", "aws_s3_bucket", []string{"update"},
+			`{"acl": "private"}`,
+			`{"acl": "public-read"}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class == ClassPhantomComputed {
+		t.Errorf("phantom_computed fired on resource type not in denylist")
+	}
+}
+
+// --- iamManagedPolicyReconvergeRule ---
+
+func TestIAMManagedPolicyReconverge(t *testing.T) {
+	t.Parallel()
+	// Direct port of the example from issue #219.
+	d := Drift{
+		Detected: true,
+		Resources: []ResourceDrift{{
+			Address: "module.iam.aws_iam_role.inspector[0]",
+			Type:    "aws_iam_role",
+			Action:  []string{"update"},
+			Change: Change{
+				Before: json.RawMessage(`{"managed_policy_arns":[]}`),
+				After:  json.RawMessage(`{"managed_policy_arns":["arn:aws:iam::aws:policy/ReadOnlyAccess"]}`),
+			},
+		}},
+	}
+	got := Classify(d)
+	if got.ActionableCount != 0 {
+		t.Errorf("ActionableCount = %d; want 0", got.ActionableCount)
+	}
+	if got.Resources[0].Class != ClassReconverge {
+		t.Errorf("Class = %q; want %q", got.Resources[0].Class, ClassReconverge)
+	}
+}
+
+func TestIAMManagedPolicyReconverge_DoesNotFireOnNonRole(t *testing.T) {
+	t.Parallel()
+	d := Drift{Resources: []ResourceDrift{
+		rd("aws_iam_policy.p", "aws_iam_policy", []string{"update"},
+			`{"managed_policy_arns": []}`,
+			`{"managed_policy_arns": ["arn:aws:iam::aws:policy/ReadOnlyAccess"]}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class == ClassReconverge {
+		t.Errorf("reconverge fired on aws_iam_policy; rule must be aws_iam_role-only")
+	}
+}
+
+func TestIAMManagedPolicyReconverge_DoesNotFireOnReplace(t *testing.T) {
+	t.Parallel()
+	// Mixed actions ("delete" + "create") indicate a real replace,
+	// not a reconverge. Rule must abstain.
+	d := Drift{Resources: []ResourceDrift{
+		rd("aws_iam_role.r", "aws_iam_role", []string{"delete", "create"},
+			`{"managed_policy_arns": []}`,
+			`{"managed_policy_arns": ["arn:aws:iam::aws:policy/ReadOnlyAccess"]}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class == ClassReconverge {
+		t.Errorf("reconverge fired on replace action; must require update only")
+	}
+}
+
+func TestIAMManagedPolicyReconverge_DoesNotFireWhenBeforeNonEmpty(t *testing.T) {
+	t.Parallel()
+	d := Drift{Resources: []ResourceDrift{
+		rd("aws_iam_role.r", "aws_iam_role", []string{"update"},
+			`{"managed_policy_arns": ["arn:aws:iam::aws:policy/A"]}`,
+			`{"managed_policy_arns": ["arn:aws:iam::aws:policy/B"]}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class == ClassReconverge {
+		t.Errorf("reconverge fired when before was non-empty; rule requires before == []")
+	}
+}
+
+// --- fall-through: actionable / unknown ---
+
+func TestClassify_FallThroughActionable(t *testing.T) {
+	t.Parallel()
+	// Action present, no rule matches. Verdict: actionable.
+	d := Drift{Resources: []ResourceDrift{
+		rd("aws_s3_bucket.b", "aws_s3_bucket", []string{"update"},
+			`{"acl": "private"}`,
+			`{"acl": "public-read"}`),
+	}}
+	got := Classify(d)
+	if got.ActionableCount != 1 {
+		t.Errorf("ActionableCount = %d; want 1", got.ActionableCount)
+	}
+	if got.Resources[0].Class != ClassActionable {
+		t.Errorf("Class = %q; want %q", got.Resources[0].Class, ClassActionable)
+	}
+}
+
+func TestClassify_FallThroughUnknown(t *testing.T) {
+	t.Parallel()
+	// No Action, no rule matches. Verdict: unknown (not counted as
+	// actionable, not counted as filtered).
+	d := Drift{Resources: []ResourceDrift{
+		rd("aws_s3_bucket.b", "aws_s3_bucket", nil,
+			`{"acl": "private"}`,
+			`{"acl": "public-read"}`),
+	}}
+	got := Classify(d)
+	if got.ActionableCount != 0 {
+		t.Errorf("ActionableCount = %d; want 0", got.ActionableCount)
+	}
+	if got.FilteredCount != 0 {
+		t.Errorf("FilteredCount = %d; want 0", got.FilteredCount)
+	}
+	if got.Resources[0].Class != ClassUnknown {
+		t.Errorf("Class = %q; want %q", got.Resources[0].Class, ClassUnknown)
+	}
+}
+
+// --- Result.Summary shape ---
+
+func TestSummaryShape(t *testing.T) {
+	t.Parallel()
+	d := Drift{Resources: []ResourceDrift{
+		// reconverge
+		rd("aws_iam_role.a", "aws_iam_role", []string{"update"},
+			`{"managed_policy_arns": []}`,
+			`{"managed_policy_arns": ["arn:aws:iam::aws:policy/A"]}`),
+		// phantom_computed
+		rd("google_firestore_database.b", "google_firestore_database",
+			[]string{"no-op"},
+			`{"etag": "x"}`, `{"etag": "y"}`),
+		// actionable fallthrough
+		rd("aws_s3_bucket.c", "aws_s3_bucket", []string{"update"},
+			`{"acl": "private"}`, `{"acl": "public-read"}`),
+	}}
+	got := Classify(d)
+	want := "3 drift events: 1 actionable, 1 phantom_computed, 1 reconverge"
+	if got.Summary != want {
+		t.Errorf("Summary = %q; want %q", got.Summary, want)
+	}
+}
+
+// --- WithExtraRules option ---
+
+type alwaysReconverge struct{}
+
+func (alwaysReconverge) Match(_ ResourceDrift) (Class, string, bool) {
+	return ClassReconverge, "test extra", true
+}
+
+func TestWithExtraRules_RunsAfterDefaults(t *testing.T) {
+	t.Parallel()
+	// Default rules wouldn't match this resource; the extra rule
+	// should turn the actionable-fallthrough into reconverge.
+	d := Drift{Resources: []ResourceDrift{
+		rd("aws_s3_bucket.b", "aws_s3_bucket", []string{"update"},
+			`{"acl": "private"}`, `{"acl": "public-read"}`),
+	}}
+
+	// Without extras: actionable.
+	if got := Classify(d); got.Resources[0].Class != ClassActionable {
+		t.Fatalf("baseline Class = %q; want %q", got.Resources[0].Class, ClassActionable)
+	}
+
+	// With the always-reconverge extra: reconverge.
+	got := Classify(d, WithExtraRules(alwaysReconverge{}))
+	if got.Resources[0].Class != ClassReconverge {
+		t.Errorf("with extra Class = %q; want %q", got.Resources[0].Class, ClassReconverge)
+	}
+	if got.Resources[0].Reason != "test extra" {
+		t.Errorf("Reason = %q; want %q", got.Resources[0].Reason, "test extra")
+	}
+}
+
+// --- end-to-end fixture round-trip ---
+
+func TestClassify_FixtureRoundTrip(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		fixture          string
+		wantClassifiable bool
+		wantTotal        int
+		wantActionable   int
+		wantClasses      []Class // per-resource, in input order
+	}{
+		{
+			"phantom_only.drift.json",
+			true, 1, 0,
+			[]Class{ClassPhantomComputed},
+		},
+		{
+			"actionable.drift.json",
+			true, 1, 1,
+			[]Class{ClassActionable},
+		},
+		{
+			"iam_managed_policy_reconverge.drift.json",
+			true, 1, 0,
+			[]Class{ClassReconverge},
+		},
+		{
+			"mixed.drift.json",
+			true, 4, 1,
+			[]Class{
+				ClassReconverge,      // aws_iam_role managed_policy_arns
+				ClassPhantomComputed, // google_firestore_database etag
+				ClassProviderNoise,   // aws_lb_listener tags {} -> null
+				ClassActionable,      // aws_db_instance engine_version
+			},
+		},
+		{
+			"old_schema.drift.json",
+			false, 2, 0,
+			// Old-schema input still goes through Classify; rules
+			// abstain because Type is empty, so resources fall
+			// through to ClassUnknown (no Action populated either).
+			[]Class{ClassUnknown, ClassUnknown},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fixture, func(t *testing.T) {
+			t.Parallel()
+			d, err := UnmarshalJSON(readFixture(t, tt.fixture))
+			if err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := HasClassifiableDetail(d); got != tt.wantClassifiable {
+				t.Errorf("HasClassifiableDetail = %v; want %v", got, tt.wantClassifiable)
+			}
+			r := Classify(d)
+			if r.TotalCount != tt.wantTotal {
+				t.Errorf("TotalCount = %d; want %d", r.TotalCount, tt.wantTotal)
+			}
+			if r.ActionableCount != tt.wantActionable {
+				t.Errorf("ActionableCount = %d; want %d", r.ActionableCount, tt.wantActionable)
+			}
+			if len(r.Resources) != len(tt.wantClasses) {
+				t.Fatalf("len(Resources) = %d; want %d", len(r.Resources), len(tt.wantClasses))
+			}
+			for i, want := range tt.wantClasses {
+				if r.Resources[i].Class != want {
+					t.Errorf("Resources[%d].Class = %q; want %q (addr=%s type=%s)",
+						i, r.Resources[i].Class, want,
+						r.Resources[i].Address, r.Resources[i].Type)
+				}
+			}
+		})
+	}
+}
+
+// --- denylist parser ---
+
+func TestParsePhantomDenylist(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`# header comment
+# blank below
+
+aws_db_instance.latest_restorable_time
+aws_db_instance.replicas
+
+# new section
+google_firestore_database.etag
+malformed_no_dot
+.malformed_leading_dot
+trailing_dot.
+`)
+	got := parsePhantomDenylist(raw)
+
+	if _, ok := got["aws_db_instance"]["latest_restorable_time"]; !ok {
+		t.Errorf("missing aws_db_instance.latest_restorable_time")
+	}
+	if _, ok := got["aws_db_instance"]["replicas"]; !ok {
+		t.Errorf("missing aws_db_instance.replicas")
+	}
+	if _, ok := got["google_firestore_database"]["etag"]; !ok {
+		t.Errorf("missing google_firestore_database.etag")
+	}
+	// Malformed entries dropped silently.
+	for k := range got {
+		if strings.HasPrefix(k, ".") || strings.HasSuffix(k, ".") || k == "malformed_no_dot" {
+			t.Errorf("malformed entry leaked through as resource type: %q", k)
+		}
+	}
+}
+
+func TestEmbeddedPhantomDenylistNonEmpty(t *testing.T) {
+	t.Parallel()
+	// Smoke test: the embedded phantom-computed-fields.txt at repo
+	// root reaches pkg/drift via the top-level
+	// PhantomComputedFieldsTXT variable. If this fails, the embed
+	// wiring is broken.
+	got := phantomDenylist()
+	if len(got) == 0 {
+		t.Fatalf("phantomDenylist() empty; embed wiring broken")
+	}
+	// Spot-check a known entry.
+	if _, ok := got["aws_db_instance"]["latest_restorable_time"]; !ok {
+		t.Errorf("expected entry aws_db_instance.latest_restorable_time not in denylist")
+	}
+}

--- a/pkg/drift/doc.go
+++ b/pkg/drift/doc.go
@@ -1,0 +1,79 @@
+// Package drift owns the data + rules that decide whether a
+// terraform-detected drift event is actionable, benign provider noise, a
+// pure-Computed phantom, or an idempotent reconverge.
+//
+// # Why this lives here
+//
+// The rules describe provider behavior — which attributes auto-advance,
+// which resource types reconverge on next apply, what null/empty
+// equivalences exist. That data lives next to the modules that declare
+// these resources, so a new module with a noisy computed field can land
+// the module + its denylist entry + its rule in one PR in this repo.
+// The existing schema-verification CI gate
+// (tests/verify-phantom-computed-schema.sh) extends naturally to keep
+// the Go classifier and the embedded denylist in sync.
+//
+// # Parse / classify split
+//
+// The package is split deliberately:
+//
+//   - [UnmarshalJSON] (in unmarshal.go) parses the drift.json bytes
+//     written by sandbox-infrastructure-template/tf/drift-check.sh into
+//     a typed [Drift]. It is tolerant of both the old (pre-#105) and
+//     the new (post-#105 additive) schema; missing fields decode to
+//     zero values without error.
+//   - [Classify] (in classify.go) runs the rule chain over a [Drift]
+//     and returns a [Result]. Tests for individual rules construct
+//     [Drift] literals directly in Go and skip the JSON layer entirely.
+//
+// Callers that get a Drift with insufficient detail (see
+// [HasClassifiableDetail]) should fall back to whatever coarse signal
+// they had before. Today that's reliable's existing trust-the-boolean
+// path against Job.drift_actionable.
+//
+// # Versioning
+//
+// reliable's classifier uses *its own* embedded denylist + rules
+// (whatever pkg/drift version reliable was built against), regardless
+// of the customer's pinned custom_presets_version. Rationale:
+//
+//   - Forward-compatible. Newer reliable can correctly classify phantom
+//     drift on stacks composed before the denylist existed.
+//   - Never escalates anything to actionable that older sandbox-infra
+//     would have ignored — only ever filters more. A presets release
+//     that adds a denylist entry can't make a previously-passing
+//     deployment start failing on the reliable side.
+//
+// # Default rule chain
+//
+// First match wins. The default order is:
+//
+//  1. providerNoiseRule — cheapest, runs first. Recursively maps
+//     null/[]/{}/false/0/"" to null in both Before and After; if the
+//     normalized values are equal, classifies the resource as
+//     [ClassProviderNoise]. This is the Go port of the jq _normalize
+//     filter in sandbox-infrastructure-template/tf/drift-check.sh.
+//  2. phantomComputedRule — consults the embedded
+//     phantom-computed-fields.txt denylist. If every changed attribute
+//     on the resource is on the denylist for that resource type,
+//     classifies as [ClassPhantomComputed].
+//  3. iamManagedPolicyReconvergeRule — narrowly matches the canonical
+//     reconverge case: aws_iam_role with managed_policy_arns going from
+//     [] to a non-empty list of strings, with an `update` action. The
+//     resource reconverges to the same state on next refresh after
+//     apply. Classifies as [ClassReconverge].
+//
+// Anything that doesn't match a rule falls through to
+// [ClassActionable] (when an Action is present — the "presumed real
+// drift" fallback) or [ClassUnknown] (when no Action is set, e.g. an
+// old-schema input that snuck past [HasClassifiableDetail]).
+//
+// # Adding a rule
+//
+// New false-drift cases land as new [Rule] implementations alongside
+// the affected modules. Add the implementation to rules.go, register
+// it in defaultRules in evaluation order, and add a focused unit test
+// to classify_test.go that constructs a [Drift] literal exhibiting the
+// case. Callers that want to extend the default set without forking
+// the package use [WithExtraRules].
+package drift

--- a/pkg/drift/drift.go
+++ b/pkg/drift/drift.go
@@ -1,0 +1,185 @@
+package drift
+
+import "encoding/json"
+
+// Class is the verdict the classifier assigns to a drifted resource (or to
+// an individual attribute within a resource). Persisted into JSON output
+// of downstream consumers; values are part of the public contract — only
+// add new constants, do not rename existing ones.
+type Class string
+
+const (
+	// ClassActionable is "presumed real drift": the resource has a
+	// non-empty Action and no rule recognized it as benign. Reaches
+	// the user as a blocking signal in downstream UIs.
+	ClassActionable Class = "actionable"
+
+	// ClassPhantomComputed marks a resource whose changed attributes
+	// are all on the embedded phantom-computed-fields.txt denylist —
+	// pure-Computed provider attributes that drift on refresh-only
+	// plans and cannot be silenced via lifecycle.ignore_changes
+	// (terraform#30517).
+	ClassPhantomComputed Class = "phantom_computed"
+
+	// ClassProviderNoise marks a resource whose Before/After become
+	// equal under null/empty normalization (null ↔ [] ↔ {} ↔ false
+	// ↔ 0 ↔ ""). Mirrors the jq _normalize filter in
+	// sandbox-infrastructure-template/tf/drift-check.sh.
+	ClassProviderNoise Class = "provider_noise"
+
+	// ClassReconverge marks a resource whose action is non-trivial
+	// but whose post-apply state will reconverge to the same drift
+	// on the next refresh — e.g. aws_iam_role with
+	// managed_policy_arns moving from [] → [arn:...]. Idempotent
+	// from the user's perspective; not actionable.
+	ClassReconverge Class = "reconverge"
+
+	// ClassUnknown is the fallback when no rule matched and the
+	// resource also has no Action populated — typically because the
+	// input drift.json was the pre-#105 schema and slipped past
+	// HasClassifiableDetail. Treated as not-actionable.
+	ClassUnknown Class = "unknown"
+)
+
+// Drift is the parsed shape of drift.json as written by
+// sandbox-infrastructure-template/tf/drift-check.sh. The schema is
+// additive: pre-#105 inputs populate only the top-level fields and
+// Resources[i].Address; post-#105 inputs additionally populate Type,
+// Name, Action, and Change on each entry. UnmarshalJSON tolerates both.
+type Drift struct {
+	// Detected is true when terraform reported any resource_drift
+	// entries. Top-level field; populated in both schema versions.
+	Detected bool
+
+	// Count is the total number of drifted resources (post-normalize).
+	// Top-level field; populated in both schema versions.
+	Count int
+
+	// TemplateVersion is the sandbox-infrastructure-template version
+	// stamped onto the report. May be empty.
+	TemplateVersion string
+
+	// PresetsVersion is the customer's pinned
+	// insideout-terraform-presets version stamped onto the report.
+	// May be empty. NOTE: the classifier deliberately does NOT use
+	// this field — it always uses its own embedded denylist + rules,
+	// regardless of which preset version produced the drift. See
+	// the package doc for the rationale.
+	PresetsVersion string
+
+	// Resources is one entry per drifted resource address. The
+	// per-entry detail (Type, Name, Action, Change) is populated by
+	// the post-#105 schema only.
+	Resources []ResourceDrift
+}
+
+// ResourceDrift is a single drifted resource. Fields beyond Address are
+// populated only by the post-#105 additive schema; old-schema decodes
+// leave them at their zero values.
+type ResourceDrift struct {
+	// Address is the canonical Terraform address
+	// ("module.foo.aws_iam_role.bar[0]"). Populated in both schema
+	// versions.
+	Address string
+
+	// Type is the resource type ("aws_iam_role"). Post-#105 schema
+	// only.
+	Type string
+
+	// Name is the resource local name ("bar"). Post-#105 schema only.
+	Name string
+
+	// Action is the join result against resource_changes[]: the
+	// terraform-plan actions for this resource (e.g. ["update"], or
+	// ["no-op"]). nil when the address wasn't in resource_changes
+	// (e.g. refresh-only plans). Post-#105 schema only.
+	Action []string
+
+	// Change is the raw resource_drift change (before/after). Post-#105
+	// schema only. Stored as RawMessage so rules can match on shape
+	// without the package knowing the universe of provider attributes.
+	Change Change
+}
+
+// Change carries the resource_drift change.before / change.after blobs.
+// Both are raw JSON to keep the package agnostic of provider schemas;
+// rules unmarshal selectively as they need to.
+type Change struct {
+	Before json.RawMessage
+	After  json.RawMessage
+}
+
+// Result is the aggregate output of [Classify]. ActionableCount is the
+// number of resources classified as [ClassActionable]; FilteredCount is
+// the count of resources rules pulled out of "actionable" (i.e.
+// classified as anything other than ClassActionable / ClassUnknown).
+// TotalCount is len(Resources).
+type Result struct {
+	TotalCount      int
+	ActionableCount int
+	FilteredCount   int
+	Resources       []Resource
+	// Summary is a one-line human-readable roll-up of classifications,
+	// e.g. "3 drift events: 0 actionable, 2 phantom_computed, 1 reconverge".
+	Summary string
+}
+
+// Resource is the per-resource verdict in a [Result]. Class is the
+// worst-case roll-up across the resource's attributes (i.e. once a rule
+// fires, the whole resource carries that class — consistent with the
+// "first match wins" rule chain). Reason is a short string identifying
+// which rule fired.
+type Resource struct {
+	Address    string
+	Type       string
+	Name       string
+	Action     []string
+	Class      Class
+	Reason     string
+	Attributes []Attribute
+}
+
+// Attribute is reserved for future per-attribute classification. The
+// Phase 1 rule set classifies at the resource level only, so Attributes
+// is unpopulated today. Kept on the public type so consumers' code
+// doesn't need to change when per-attribute classification lands.
+type Attribute struct {
+	Path   string
+	Before json.RawMessage
+	After  json.RawMessage
+	Class  Class
+	Reason string
+}
+
+// Rule decides whether a resource-level drift event matches its
+// criterion. Match returns the verdict (Class), a short Reason
+// identifying the rule (rendered in [Resource].Reason and surfaced to
+// downstream UIs), and a bool that's true when the rule applies. When
+// false, the second class/reason are ignored and the chain advances.
+//
+// Rules are pluggable via [WithExtraRules]. The default chain is
+// constructed by defaultRules(); see the package doc for the order
+// and rationale. Rules MUST NOT mutate the ResourceDrift they receive.
+type Rule interface {
+	Match(r ResourceDrift) (Class, string, bool)
+}
+
+// Option configures [Classify]. The zero set of options uses the
+// default rule chain.
+type Option func(*config)
+
+// config is the internal struct populated by Options. Kept private so
+// the option-setter shape can evolve without breaking callers.
+type config struct {
+	extraRules []Rule
+}
+
+// WithExtraRules appends caller-supplied rules to the default rule
+// chain. Extras run AFTER the default rules (so default rules continue
+// to classify the cases they cover) but BEFORE the actionable/unknown
+// fallback. Extras are evaluated in argument order.
+func WithExtraRules(rs ...Rule) Option {
+	return func(c *config) {
+		c.extraRules = append(c.extraRules, rs...)
+	}
+}

--- a/pkg/drift/phantomfields.go
+++ b/pkg/drift/phantomfields.go
@@ -1,0 +1,71 @@
+package drift
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"sync"
+
+	terraformpresets "github.com/luthersystems/insideout-terraform-presets"
+)
+
+// phantomDenylist returns the parsed phantom-computed-fields.txt as a
+// nested map keyed by resource_type → attribute → present. The map is
+// built once at first use and cached for the life of the process.
+//
+// Entries are sourced from the top-level repo file via the embedded
+// [terraformpresets.PhantomComputedFieldsTXT] byte slice. Single
+// source of truth: the same bytes that
+// tests/verify-phantom-computed-schema.sh validates against the pinned
+// provider schema.
+//
+// Format (one entry per line, "<resource_type>.<attribute>") matches
+// what the bash consumer `grep -v '^#' phantom-computed-fields.txt`
+// pattern expects — comments (#) and blank lines are skipped.
+// Malformed entries (no dot, empty type, empty attr) are tolerated
+// and silently dropped; a malformed entry can't pass
+// tests/verify-phantom-computed-schema.sh, so reaching parsing here
+// implies the file already passed CI.
+func phantomDenylist() map[string]map[string]struct{} {
+	phantomDenylistOnce.Do(func() {
+		phantomDenylistCache = parsePhantomDenylist(terraformpresets.PhantomComputedFieldsTXT)
+	})
+	return phantomDenylistCache
+}
+
+var (
+	phantomDenylistOnce  sync.Once
+	phantomDenylistCache map[string]map[string]struct{}
+)
+
+// parsePhantomDenylist is the parser, isolated for direct test access
+// (so tests can exercise edge cases without touching package-level
+// caches).
+func parsePhantomDenylist(raw []byte) map[string]map[string]struct{} {
+	out := make(map[string]map[string]struct{})
+	sc := bufio.NewScanner(bytes.NewReader(raw))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		dot := strings.IndexByte(line, '.')
+		if dot <= 0 || dot == len(line)-1 {
+			// Malformed; skip silently. CI lints catch real
+			// drift before it reaches a user.
+			continue
+		}
+		resType := line[:dot]
+		attr := line[dot+1:]
+		if resType == "" || attr == "" {
+			continue
+		}
+		attrs, ok := out[resType]
+		if !ok {
+			attrs = make(map[string]struct{})
+			out[resType] = attrs
+		}
+		attrs[attr] = struct{}{}
+	}
+	return out
+}

--- a/pkg/drift/rules.go
+++ b/pkg/drift/rules.go
@@ -1,0 +1,277 @@
+package drift
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+// defaultRules returns the rule chain Classify uses when no extras are
+// supplied. Order matters: cheaper / more general rules come first so
+// that more specific ones don't have to defensively re-implement the
+// "trivial cases" check.
+//
+//  1. providerNoiseRule — null/empty normalization. Cheapest because
+//     it's a recursive walk of the change blobs and doesn't need any
+//     resource-type knowledge.
+//  2. phantomComputedRule — denylist lookup; needs Type populated.
+//  3. iamManagedPolicyReconvergeRule — narrow shape match for the
+//     known IAM reconverge case.
+func defaultRules() []Rule {
+	return []Rule{
+		providerNoiseRule{},
+		phantomComputedRule{},
+		iamManagedPolicyReconvergeRule{},
+	}
+}
+
+// providerNoiseRule implements the null/empty equivalence
+// classification. It is the Go port of the jq _normalize filter in
+// sandbox-infrastructure-template/tf/drift-check.sh:77-89.
+//
+//	def normalize_empty:
+//	  if . == null then null
+//	  elif . == [] then null
+//	  elif . == {} then null
+//	  elif . == false then null
+//	  elif . == 0 then null
+//	  elif . == "" then null
+//	  elif type == "array" then map(normalize_empty)
+//	  elif type == "object" then with_entries(.value |= normalize_empty)
+//	  else .
+//	  end;
+//
+// If the normalized Before and After are deep-equal, the diff was
+// purely null/empty noise and the resource is classified as
+// [ClassProviderNoise].
+type providerNoiseRule struct{}
+
+func (providerNoiseRule) Match(r ResourceDrift) (Class, string, bool) {
+	// Need both sides to compare. Either side missing is something a
+	// later rule may understand; this rule abstains.
+	if len(r.Change.Before) == 0 || len(r.Change.After) == 0 {
+		return "", "", false
+	}
+	var before, after any
+	if err := json.Unmarshal(r.Change.Before, &before); err != nil {
+		return "", "", false
+	}
+	if err := json.Unmarshal(r.Change.After, &after); err != nil {
+		return "", "", false
+	}
+	nb := normalizeEmpty(before)
+	na := normalizeEmpty(after)
+	if reflect.DeepEqual(nb, na) {
+		return ClassProviderNoise, "null/empty equivalence", true
+	}
+	return "", "", false
+}
+
+// normalizeEmpty maps null-equivalent leaf values (null, [], {},
+// false, 0, "") to nil and recurses into arrays / objects. It exists
+// at package-level (rather than inline in the rule) so unit tests can
+// pin the behavior without going through the full rule path.
+func normalizeEmpty(v any) any {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case bool:
+		if !t {
+			return nil
+		}
+		return t
+	case string:
+		if t == "" {
+			return nil
+		}
+		return t
+	case float64: // encoding/json default for numbers into any
+		if t == 0 {
+			return nil
+		}
+		return t
+	case json.Number:
+		if t == "" || t == "0" {
+			return nil
+		}
+		return t
+	case []any:
+		if len(t) == 0 {
+			return nil
+		}
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = normalizeEmpty(e)
+		}
+		return out
+	case map[string]any:
+		if len(t) == 0 {
+			return nil
+		}
+		out := make(map[string]any, len(t))
+		for k, e := range t {
+			out[k] = normalizeEmpty(e)
+		}
+		return out
+	default:
+		return t
+	}
+}
+
+// phantomComputedRule classifies a resource as [ClassPhantomComputed]
+// when every attribute that actually changed between Before and After
+// is on the embedded phantom-computed-fields.txt denylist for the
+// resource's Type.
+//
+// The match is "every changed attribute," not "any changed attribute"
+// — if a resource's drift includes one denylisted attribute alongside
+// a non-denylisted one, the non-denylisted change is real and the
+// resource shouldn't be silenced. Real-world example: an
+// aws_db_instance whose latest_restorable_time advanced (denylisted)
+// AND whose engine_version got bumped (real drift) — the engine
+// version bump is actionable.
+type phantomComputedRule struct{}
+
+func (phantomComputedRule) Match(r ResourceDrift) (Class, string, bool) {
+	if r.Type == "" {
+		return "", "", false
+	}
+	denylist := phantomDenylist()
+	allowedAttrs, ok := denylist[r.Type]
+	if !ok {
+		return "", "", false
+	}
+	if len(r.Change.Before) == 0 || len(r.Change.After) == 0 {
+		return "", "", false
+	}
+	var before, after map[string]json.RawMessage
+	if err := json.Unmarshal(r.Change.Before, &before); err != nil {
+		return "", "", false
+	}
+	if err := json.Unmarshal(r.Change.After, &after); err != nil {
+		return "", "", false
+	}
+	changed := changedTopLevelKeys(before, after)
+	if len(changed) == 0 {
+		// Nothing changed at the top level; abstain — not our case.
+		return "", "", false
+	}
+	for _, k := range changed {
+		if _, allowed := allowedAttrs[k]; !allowed {
+			return "", "", false
+		}
+	}
+	return ClassPhantomComputed, "phantom-computed-fields denylist", true
+}
+
+// changedTopLevelKeys returns the set of keys whose value differs
+// (raw-bytes-different is "different enough" — keys that decode to the
+// same JSON value but were re-serialized with different whitespace will
+// flag as changed, but Terraform's drift output is canonicalized so
+// this is fine in practice). Keys missing on one side are also
+// considered changed.
+func changedTopLevelKeys(a, b map[string]json.RawMessage) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+	var out []string
+	for k := range seen {
+		av, aok := a[k]
+		bv, bok := b[k]
+		if aok != bok {
+			out = append(out, k)
+			continue
+		}
+		if !rawJSONEqual(av, bv) {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// rawJSONEqual compares two json.RawMessage values by decoding them
+// into any and deep-equaling — this makes formatting-only differences
+// (whitespace, key ordering in objects) compare equal, which matches
+// the user's mental model of "what changed."
+func rawJSONEqual(a, b json.RawMessage) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	var av, bv any
+	if err := json.Unmarshal(a, &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(b, &bv); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(av, bv)
+}
+
+// iamManagedPolicyReconvergeRule classifies aws_iam_role drift where
+// managed_policy_arns goes from [] to a non-empty list of strings
+// with action "update". This is the canonical reconverge case
+// surfaced by sandbox-infrastructure-template's .tmp/drift.json
+// (issue #219 background): the role exists with attached managed
+// policies, terraform plan shows the attachment as drift, after the
+// next apply the same drift reappears because terraform's view of
+// managed_policy_arns is built from a side-channel API and it
+// reconverges on every plan.
+//
+// Match conditions (all required):
+//   - Type == "aws_iam_role"
+//   - Action contains exactly "update" (no destroy / replace mixed in)
+//   - Before.managed_policy_arns is an empty array []
+//   - After.managed_policy_arns is a non-empty array of strings
+//
+// Permissive on the array shape — JSON arrays of strings is the only
+// sane shape for managed_policy_arns; we don't require literal byte
+// equality with `[]`.
+type iamManagedPolicyReconvergeRule struct{}
+
+func (iamManagedPolicyReconvergeRule) Match(r ResourceDrift) (Class, string, bool) {
+	if r.Type != "aws_iam_role" {
+		return "", "", false
+	}
+	if !actionIsExactly(r.Action, "update") {
+		return "", "", false
+	}
+	if len(r.Change.Before) == 0 || len(r.Change.After) == 0 {
+		return "", "", false
+	}
+	var before, after map[string]json.RawMessage
+	if err := json.Unmarshal(r.Change.Before, &before); err != nil {
+		return "", "", false
+	}
+	if err := json.Unmarshal(r.Change.After, &after); err != nil {
+		return "", "", false
+	}
+	beforeRaw, hasBefore := before["managed_policy_arns"]
+	afterRaw, hasAfter := after["managed_policy_arns"]
+	if !hasBefore || !hasAfter {
+		return "", "", false
+	}
+	var beforeArr, afterArr []string
+	if err := json.Unmarshal(beforeRaw, &beforeArr); err != nil {
+		return "", "", false
+	}
+	if err := json.Unmarshal(afterRaw, &afterArr); err != nil {
+		return "", "", false
+	}
+	if len(beforeArr) != 0 {
+		return "", "", false
+	}
+	if len(afterArr) == 0 {
+		return "", "", false
+	}
+	return ClassReconverge, "aws_iam_role managed_policy_arns reconverge", true
+}
+
+// actionIsExactly returns true when actions is a single-element slice
+// containing want. Used to guard against mixed actions like
+// ["update", "replace"] which we don't want to classify as benign.
+func actionIsExactly(actions []string, want string) bool {
+	return len(actions) == 1 && actions[0] == want
+}

--- a/pkg/drift/testdata/actionable.drift.json
+++ b/pkg/drift/testdata/actionable.drift.json
@@ -1,0 +1,25 @@
+{
+  "drift_detected": true,
+  "drift_count": 1,
+  "actionable": true,
+  "template_version": "v0.7.0",
+  "presets_version": "v0.7.3",
+  "resources": [
+    {
+      "address": "module.aws_rds.aws_db_instance.main",
+      "type": "aws_db_instance",
+      "name": "main",
+      "action": ["update"],
+      "change": {
+        "before": {
+          "engine_version": "16.1",
+          "instance_class": "db.t3.medium"
+        },
+        "after": {
+          "engine_version": "16.3",
+          "instance_class": "db.t3.large"
+        }
+      }
+    }
+  ]
+}

--- a/pkg/drift/testdata/iam_managed_policy_reconverge.drift.json
+++ b/pkg/drift/testdata/iam_managed_policy_reconverge.drift.json
@@ -7,10 +7,13 @@
   "resources": [
     {
       "address": "aws_iam_role.insideout_inspector[0]",
+      "module_address": "module.iam",
+      "mode": "managed",
       "type": "aws_iam_role",
       "name": "insideout_inspector",
-      "action": ["update"],
+      "provider_name": "registry.terraform.io/hashicorp/aws",
       "change": {
+        "actions": ["update"],
         "before": {
           "name": "insideout-inspector-de9def7c",
           "managed_policy_arns": [],
@@ -20,8 +23,16 @@
           "name": "insideout-inspector-de9def7c",
           "managed_policy_arns": ["arn:aws:iam::aws:policy/ReadOnlyAccess"],
           "inline_policy": []
+        },
+        "after_unknown": {
+          "managed_policy_arns": [false]
+        },
+        "before_sensitive": {},
+        "after_sensitive": {
+          "managed_policy_arns": [false]
         }
-      }
+      },
+      "action": ["update"]
     }
   ]
 }

--- a/pkg/drift/testdata/iam_managed_policy_reconverge.drift.json
+++ b/pkg/drift/testdata/iam_managed_policy_reconverge.drift.json
@@ -1,0 +1,27 @@
+{
+  "drift_detected": true,
+  "drift_count": 1,
+  "actionable": true,
+  "template_version": "v0.7.0",
+  "presets_version": "v0.7.3",
+  "resources": [
+    {
+      "address": "aws_iam_role.insideout_inspector[0]",
+      "type": "aws_iam_role",
+      "name": "insideout_inspector",
+      "action": ["update"],
+      "change": {
+        "before": {
+          "name": "insideout-inspector-de9def7c",
+          "managed_policy_arns": [],
+          "inline_policy": []
+        },
+        "after": {
+          "name": "insideout-inspector-de9def7c",
+          "managed_policy_arns": ["arn:aws:iam::aws:policy/ReadOnlyAccess"],
+          "inline_policy": []
+        }
+      }
+    }
+  ]
+}

--- a/pkg/drift/testdata/mixed.drift.json
+++ b/pkg/drift/testdata/mixed.drift.json
@@ -1,0 +1,49 @@
+{
+  "drift_detected": true,
+  "drift_count": 4,
+  "actionable": true,
+  "template_version": "v0.7.0",
+  "presets_version": "v0.7.3",
+  "resources": [
+    {
+      "address": "aws_iam_role.inspector[0]",
+      "type": "aws_iam_role",
+      "name": "inspector",
+      "action": ["update"],
+      "change": {
+        "before": { "managed_policy_arns": [] },
+        "after": { "managed_policy_arns": ["arn:aws:iam::aws:policy/ReadOnlyAccess"] }
+      }
+    },
+    {
+      "address": "module.gcp_firestore.google_firestore_database.default",
+      "type": "google_firestore_database",
+      "name": "default",
+      "action": ["no-op"],
+      "change": {
+        "before": { "etag": "abc" },
+        "after": { "etag": "def" }
+      }
+    },
+    {
+      "address": "module.aws_alb.aws_lb_listener.main",
+      "type": "aws_lb_listener",
+      "name": "main",
+      "action": ["no-op"],
+      "change": {
+        "before": { "tags": {}, "tags_all": {} },
+        "after": { "tags": null, "tags_all": null }
+      }
+    },
+    {
+      "address": "module.aws_rds.aws_db_instance.main",
+      "type": "aws_db_instance",
+      "name": "main",
+      "action": ["update"],
+      "change": {
+        "before": { "engine_version": "16.1" },
+        "after": { "engine_version": "16.3" }
+      }
+    }
+  ]
+}

--- a/pkg/drift/testdata/old_schema.drift.json
+++ b/pkg/drift/testdata/old_schema.drift.json
@@ -1,0 +1,11 @@
+{
+  "drift_detected": true,
+  "drift_count": 2,
+  "actionable": false,
+  "template_version": "v0.5.0",
+  "presets_version": "v0.6.0",
+  "resources": [
+    { "address": "aws_iam_role.legacy_role" },
+    { "address": "google_firestore_database.default" }
+  ]
+}

--- a/pkg/drift/testdata/phantom_only.drift.json
+++ b/pkg/drift/testdata/phantom_only.drift.json
@@ -1,0 +1,27 @@
+{
+  "drift_detected": true,
+  "drift_count": 1,
+  "actionable": false,
+  "template_version": "v0.7.0",
+  "presets_version": "v0.7.3",
+  "resources": [
+    {
+      "address": "module.gcp_firestore.google_firestore_database.default",
+      "type": "google_firestore_database",
+      "name": "default",
+      "action": ["no-op"],
+      "change": {
+        "before": {
+          "name": "(default)",
+          "earliest_version_time": "2026-04-30T18:00:00Z",
+          "etag": "abc123"
+        },
+        "after": {
+          "name": "(default)",
+          "earliest_version_time": "2026-05-01T18:00:00Z",
+          "etag": "def456"
+        }
+      }
+    }
+  ]
+}

--- a/pkg/drift/unmarshal.go
+++ b/pkg/drift/unmarshal.go
@@ -1,0 +1,135 @@
+package drift
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// wireDrift is the on-the-wire shape of drift.json. It mirrors the
+// schema in sandbox-infrastructure-template/tf/drift-check.sh — both
+// the pre-#105 fields (drift_detected, drift_count, actionable,
+// template_version, presets_version, resources[].address) and the
+// post-#105 additive per-resource fields (type, name, action, change).
+//
+// Any unknown JSON keys are ignored; missing keys decode to zero
+// values without error. This keeps the parser tolerant of both schema
+// versions and forward-compatible if the upstream wrapper later adds
+// further fields.
+type wireDrift struct {
+	DriftDetected   bool                `json:"drift_detected"`
+	DriftCount      int                 `json:"drift_count"`
+	TemplateVersion string              `json:"template_version"`
+	PresetsVersion  string              `json:"presets_version"`
+	Resources       []wireResourceDrift `json:"resources"`
+	// Note: top-level "actionable" is intentionally ignored here —
+	// reliable's classifier owns that verdict now via Classify(). The
+	// field is still emitted by sandbox-infra for the
+	// trust-the-boolean fallback path that callers take when
+	// HasClassifiableDetail returns false; that fallback reads from
+	// Oracle's typed Job.drift_actionable, not from this struct.
+}
+
+// wireResourceDrift carries both old and new schema fields. Top-level
+// "action" is the post-#105 enrichment (the address-join result from
+// resource_changes[]); change.actions is the pre-#105 nested location
+// (terraform's own resource_changes[].change.actions). We accept both
+// — when only the nested form is present we lift it onto Action so
+// rules don't need to special-case schema versions.
+type wireResourceDrift struct {
+	Address string     `json:"address"`
+	Type    string     `json:"type"`
+	Name    string     `json:"name"`
+	Action  []string   `json:"action"`
+	Change  wireChange `json:"change"`
+}
+
+type wireChange struct {
+	Before json.RawMessage `json:"before"`
+	After  json.RawMessage `json:"after"`
+	// Actions is the pre-#105 nested location of the action list.
+	// Only consulted as a fallback when the top-level Action field
+	// isn't populated.
+	Actions []string `json:"actions"`
+}
+
+// UnmarshalJSON parses drift.json bytes into a typed [Drift]. The
+// parser is tolerant: missing post-#105 fields (Type, Name, Action,
+// Change.Before, Change.After) decode to zero values without error so
+// pre-#105 inputs flow through cleanly. Old- and new-schema inputs
+// both produce a valid Drift; whether the result has enough detail
+// for [Classify] to do useful work is a separate question — see
+// [HasClassifiableDetail].
+//
+// Returns an error only when data is not valid JSON or doesn't decode
+// into the expected top-level shape (e.g. resources is a number, not
+// an array).
+func UnmarshalJSON(data []byte) (Drift, error) {
+	var w wireDrift
+	if err := json.Unmarshal(data, &w); err != nil {
+		return Drift{}, fmt.Errorf("drift: parse drift.json: %w", err)
+	}
+
+	d := Drift{
+		Detected:        w.DriftDetected,
+		Count:           w.DriftCount,
+		TemplateVersion: w.TemplateVersion,
+		PresetsVersion:  w.PresetsVersion,
+	}
+	if len(w.Resources) > 0 {
+		d.Resources = make([]ResourceDrift, len(w.Resources))
+		for i, wr := range w.Resources {
+			action := wr.Action
+			// Fall back to the nested change.actions location for
+			// inputs written by older drift-check.sh versions that
+			// haven't been updated to project Action onto the
+			// top-level. Both fields together are a no-op (we
+			// prefer the top-level when populated).
+			if len(action) == 0 && len(wr.Change.Actions) > 0 {
+				action = wr.Change.Actions
+			}
+			d.Resources[i] = ResourceDrift{
+				Address: wr.Address,
+				Type:    wr.Type,
+				Name:    wr.Name,
+				Action:  action,
+				Change: Change{
+					Before: wr.Change.Before,
+					After:  wr.Change.After,
+				},
+			}
+		}
+	}
+	return d, nil
+}
+
+// HasClassifiableDetail returns true iff d carries enough per-resource
+// detail for the rules engine to produce useful verdicts. The
+// heuristic is conservative: every entry in d.Resources must have a
+// populated Type AND at least one of Change.Before or Change.After
+// non-empty. Callers that get false should fall back to whatever
+// coarse signal they had before (e.g. Oracle's drift_actionable).
+//
+// Rationale:
+//
+//   - Type is the post-#105 schema marker the address-only old
+//     schema doesn't populate; presence of Type on every resource is
+//     a strong signal that this is the additive-schema shape.
+//   - Change.Before / Change.After are what every rule's match logic
+//     needs to do anything useful. A drift entry without either
+//     gives rules nothing to work with.
+//
+// Empty resource lists return true: the report says "no drift," and
+// Classify will produce an empty Result, which is the correct
+// not-actionable verdict. There's no useful "fall back" to escalate
+// to in that case.
+func HasClassifiableDetail(d Drift) bool {
+	for _, r := range d.Resources {
+		if r.Type == "" {
+			return false
+		}
+		if len(r.Change.Before) == 0 && len(r.Change.After) == 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/drift/unmarshal.go
+++ b/pkg/drift/unmarshal.go
@@ -1,6 +1,7 @@
 package drift
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -33,14 +34,95 @@ type wireDrift struct {
 // "action" is the post-#105 enrichment (the address-join result from
 // resource_changes[]); change.actions is the pre-#105 nested location
 // (terraform's own resource_changes[].change.actions). We accept both
-// — when only the nested form is present we lift it onto Action so
-// rules don't need to special-case schema versions.
+// — when the top-level field is absent we lift the nested form onto
+// Action so rules don't need to special-case schema versions.
+//
+// actionState records the three states the post-#107 schema cares
+// about (encoding/json on its own can't disambiguate them, since both
+// "missing key" and "key with null value" decode to a nil slice):
+//
+//	actionAbsent → top-level "action" key not present in the JSON
+//	               object (pre-#105 input). Falls back to
+//	               change.actions for the Action slice.
+//	actionNull   → top-level "action" key present and explicitly
+//	               null (post-#107 refresh-only / no-op address).
+//	               Action stays nil — the upstream's join already
+//	               decided null is the correct value, do NOT fall
+//	               back to change.actions.
+//	actionList   → top-level "action" key present with a JSON array
+//	               value; Action = the list, change.actions is
+//	               ignored.
+//
+// Populated by wireResourceDrift.UnmarshalJSON so it can inspect raw
+// key presence; the field tags on this struct are advisory.
 type wireResourceDrift struct {
-	Address string     `json:"address"`
-	Type    string     `json:"type"`
-	Name    string     `json:"name"`
-	Action  []string   `json:"action"`
-	Change  wireChange `json:"change"`
+	Address     string     `json:"address"`
+	Type        string     `json:"type"`
+	Name        string     `json:"name"`
+	Change      wireChange `json:"change"`
+	Action      []string   `json:"-"`
+	actionState actionState
+}
+
+// actionState is the trichotomy described on wireResourceDrift.
+type actionState int
+
+const (
+	actionAbsent actionState = iota
+	actionNull
+	actionList
+)
+
+// UnmarshalJSON decodes a single resource entry, distinguishing
+// "action key absent" from "action key present with null value." We
+// can't get this distinction from struct-field tags alone — both decode
+// to a nil slice — so we route through a map[string]json.RawMessage
+// intermediate and inspect key presence directly.
+//
+// Unknown JSON keys (e.g. mode, module_address, provider_name, the
+// post-#107 enrichment fields the classifier doesn't read) are
+// silently dropped — same as the default behavior of encoding/json.
+func (w *wireResourceDrift) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	// Decode the simple fields directly. A missing key leaves the
+	// field at its zero value, matching encoding/json's default.
+	if raw, ok := fields["address"]; ok {
+		if err := json.Unmarshal(raw, &w.Address); err != nil {
+			return fmt.Errorf("address: %w", err)
+		}
+	}
+	if raw, ok := fields["type"]; ok {
+		if err := json.Unmarshal(raw, &w.Type); err != nil {
+			return fmt.Errorf("type: %w", err)
+		}
+	}
+	if raw, ok := fields["name"]; ok {
+		if err := json.Unmarshal(raw, &w.Name); err != nil {
+			return fmt.Errorf("name: %w", err)
+		}
+	}
+	if raw, ok := fields["change"]; ok && len(raw) > 0 && !bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		if err := json.Unmarshal(raw, &w.Change); err != nil {
+			return fmt.Errorf("change: %w", err)
+		}
+	}
+	// Action: the trichotomy lives here.
+	raw, ok := fields["action"]
+	switch {
+	case !ok:
+		w.actionState = actionAbsent
+	case len(bytes.TrimSpace(raw)) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")):
+		w.actionState = actionNull
+	default:
+		if err := json.Unmarshal(raw, &w.Action); err != nil {
+			return fmt.Errorf("action: %w", err)
+		}
+		w.actionState = actionList
+	}
+	return nil
 }
 
 type wireChange struct {
@@ -78,20 +160,11 @@ func UnmarshalJSON(data []byte) (Drift, error) {
 	if len(w.Resources) > 0 {
 		d.Resources = make([]ResourceDrift, len(w.Resources))
 		for i, wr := range w.Resources {
-			action := wr.Action
-			// Fall back to the nested change.actions location for
-			// inputs written by older drift-check.sh versions that
-			// haven't been updated to project Action onto the
-			// top-level. Both fields together are a no-op (we
-			// prefer the top-level when populated).
-			if len(action) == 0 && len(wr.Change.Actions) > 0 {
-				action = wr.Change.Actions
-			}
 			d.Resources[i] = ResourceDrift{
 				Address: wr.Address,
 				Type:    wr.Type,
 				Name:    wr.Name,
-				Action:  action,
+				Action:  resolveAction(wr),
 				Change: Change{
 					Before: wr.Change.Before,
 					After:  wr.Change.After,
@@ -100,6 +173,30 @@ func UnmarshalJSON(data []byte) (Drift, error) {
 		}
 	}
 	return d, nil
+}
+
+// resolveAction implements the schema-tolerant action resolution
+// documented on wireResourceDrift. State machine:
+//
+//	actionAbsent → fall back to change.actions (pre-#105 input).
+//	actionNull   → return nil (post-#107 refresh-only / no-op join
+//	               result; preserve the upstream signal — do NOT
+//	               fall back to change.actions).
+//	actionList   → return the parsed list; change.actions ignored.
+func resolveAction(wr wireResourceDrift) []string {
+	switch wr.actionState {
+	case actionAbsent:
+		if len(wr.Change.Actions) > 0 {
+			return wr.Change.Actions
+		}
+		return nil
+	case actionNull:
+		return nil
+	case actionList:
+		return wr.Action
+	default:
+		return nil
+	}
 }
 
 // HasClassifiableDetail returns true iff d carries enough per-resource

--- a/pkg/drift/unmarshal_test.go
+++ b/pkg/drift/unmarshal_test.go
@@ -188,3 +188,118 @@ func TestUnmarshalJSON_EmptyDriftIsClassifiable(t *testing.T) {
 		t.Errorf("HasClassifiableDetail = false on empty-resources input; want true")
 	}
 }
+
+// TestUnmarshalJSON_PostEnrichmentNoOpFields verifies the decoder
+// tolerates the full real-world post-#107 emitted shape: top-level
+// "mode", "module_address", "provider_name" alongside in-change
+// "actions", "after_unknown", "before_sensitive", "after_sensitive".
+// None of these are decoded into Drift / ResourceDrift / Change today
+// (we only need address/type/name/action + before/after); this test
+// pins the "ignore unknown fields" contract so a future schema bump
+// upstream doesn't break parsing.
+func TestUnmarshalJSON_PostEnrichmentNoOpFields(t *testing.T) {
+	t.Parallel()
+	d, err := UnmarshalJSON(readFixture(t, "iam_managed_policy_reconverge.drift.json"))
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := len(d.Resources); got != 1 {
+		t.Fatalf("len(Resources) = %d; want 1", got)
+	}
+	r := d.Resources[0]
+	// Top-level "action" — the post-#107 enrichment field — wins over
+	// nested change.actions when both are present.
+	if len(r.Action) != 1 || r.Action[0] != "update" {
+		t.Errorf("Action = %v; want [update] (top-level field)", r.Action)
+	}
+	// Sanity: classification succeeds end-to-end on the enriched
+	// shape — the decoder fed Change.Before / Change.After through
+	// cleanly despite the surrounding noise fields.
+	if !HasClassifiableDetail(d) {
+		t.Errorf("HasClassifiableDetail = false on enriched input; want true")
+	}
+}
+
+// TestUnmarshalJSON_ActionNullFromRefreshOnly captures the post-#107
+// case where the join against resource_changes[] yielded null because
+// terraform isn't planning anything for this address (refresh-only
+// plans, or addresses outside the plan's actionable set). The decoder
+// must accept this and leave Action nil. The new Action field being
+// nil is NOT disqualifying for HasClassifiableDetail — phantom drift
+// legitimately has null action — Type + Change.{Before,After} are the
+// classifiable-detail markers.
+func TestUnmarshalJSON_ActionNullFromRefreshOnly(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{
+		"drift_detected": true,
+		"drift_count": 1,
+		"resources": [
+			{
+				"address": "module.firestore.google_firestore_database.default",
+				"mode": "managed",
+				"type": "google_firestore_database",
+				"name": "default",
+				"provider_name": "registry.terraform.io/hashicorp/google",
+				"change": {
+					"actions": ["no-op"],
+					"before": {"etag": "abc"},
+					"after":  {"etag": "def"},
+					"after_unknown": {},
+					"before_sensitive": {},
+					"after_sensitive": {}
+				},
+				"action": null
+			}
+		]
+	}`)
+	d, err := UnmarshalJSON(raw)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	r := d.Resources[0]
+	// action: null at the top level — Action must be nil. The nested
+	// change.actions fallback should NOT apply here (top-level field
+	// is present and explicitly null, indicating "no plan action,"
+	// not "older schema").
+	if r.Action != nil {
+		t.Errorf("Action = %v; want nil for top-level action: null", r.Action)
+	}
+	// HasClassifiableDetail must still return true: Type and
+	// Change.Before/After are populated, which is the contract.
+	if !HasClassifiableDetail(d) {
+		t.Errorf("HasClassifiableDetail = false with action: null; want true (Action nil is not disqualifying)")
+	}
+}
+
+// TestUnmarshalJSON_MissingChangeFieldDoesNotError defends against
+// drift-check.sh's `if ($entry.change == null) then $entry` branch —
+// a resource entry whose change key is absent (or null) must decode
+// to a zero Change struct without erroring.
+func TestUnmarshalJSON_MissingChangeFieldDoesNotError(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{
+		"drift_detected": true,
+		"drift_count": 1,
+		"resources": [
+			{
+				"address": "aws_s3_bucket.b",
+				"type": "aws_s3_bucket",
+				"name": "b"
+			}
+		]
+	}`)
+	d, err := UnmarshalJSON(raw)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	r := d.Resources[0]
+	if len(r.Change.Before) != 0 || len(r.Change.After) != 0 {
+		t.Errorf("Change populated despite missing change key; want zero")
+	}
+	// HasClassifiableDetail must return false: even though Type is
+	// populated, neither Before nor After is, so rules have nothing
+	// to match against.
+	if HasClassifiableDetail(d) {
+		t.Errorf("HasClassifiableDetail = true with missing change; want false")
+	}
+}

--- a/pkg/drift/unmarshal_test.go
+++ b/pkg/drift/unmarshal_test.go
@@ -1,0 +1,190 @@
+package drift
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// readFixture reads a file from testdata/, failing the test on I/O
+// error so callers can stay in the happy path.
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %q: %v", name, err)
+	}
+	return b
+}
+
+func TestUnmarshalJSON_OldSchema(t *testing.T) {
+	t.Parallel()
+	d, err := UnmarshalJSON(readFixture(t, "old_schema.drift.json"))
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !d.Detected {
+		t.Errorf("Detected = false; want true")
+	}
+	if d.Count != 2 {
+		t.Errorf("Count = %d; want 2", d.Count)
+	}
+	if d.TemplateVersion != "v0.5.0" {
+		t.Errorf("TemplateVersion = %q; want %q", d.TemplateVersion, "v0.5.0")
+	}
+	if d.PresetsVersion != "v0.6.0" {
+		t.Errorf("PresetsVersion = %q; want %q", d.PresetsVersion, "v0.6.0")
+	}
+	if got := len(d.Resources); got != 2 {
+		t.Fatalf("len(Resources) = %d; want 2", got)
+	}
+	if d.Resources[0].Address != "aws_iam_role.legacy_role" {
+		t.Errorf("Resources[0].Address = %q; want %q",
+			d.Resources[0].Address, "aws_iam_role.legacy_role")
+	}
+	// Old-schema fields beyond Address must decode to zero.
+	if d.Resources[0].Type != "" {
+		t.Errorf("Resources[0].Type = %q; want \"\"", d.Resources[0].Type)
+	}
+	if len(d.Resources[0].Action) != 0 {
+		t.Errorf("Resources[0].Action = %v; want nil", d.Resources[0].Action)
+	}
+	if len(d.Resources[0].Change.Before) != 0 || len(d.Resources[0].Change.After) != 0 {
+		t.Errorf("Resources[0].Change populated; want zero")
+	}
+	if HasClassifiableDetail(d) {
+		t.Errorf("HasClassifiableDetail = true on old-schema input; want false")
+	}
+}
+
+func TestUnmarshalJSON_NewSchema(t *testing.T) {
+	t.Parallel()
+	d, err := UnmarshalJSON(readFixture(t, "iam_managed_policy_reconverge.drift.json"))
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !d.Detected {
+		t.Errorf("Detected = false; want true")
+	}
+	if got := len(d.Resources); got != 1 {
+		t.Fatalf("len(Resources) = %d; want 1", got)
+	}
+	r := d.Resources[0]
+	if r.Type != "aws_iam_role" {
+		t.Errorf("Type = %q; want aws_iam_role", r.Type)
+	}
+	if r.Name != "insideout_inspector" {
+		t.Errorf("Name = %q; want insideout_inspector", r.Name)
+	}
+	if len(r.Action) != 1 || r.Action[0] != "update" {
+		t.Errorf("Action = %v; want [update]", r.Action)
+	}
+	if len(r.Change.Before) == 0 || len(r.Change.After) == 0 {
+		t.Errorf("Change.Before/After empty; want populated")
+	}
+	if !HasClassifiableDetail(d) {
+		t.Errorf("HasClassifiableDetail = false on fully-populated new-schema input; want true")
+	}
+}
+
+func TestUnmarshalJSON_PartialNewSchema(t *testing.T) {
+	t.Parallel()
+	// Mixed: one resource has full new-schema detail, another has
+	// only Address. HasClassifiableDetail should return false because
+	// at least one resource lacks Type.
+	raw := []byte(`{
+		"drift_detected": true,
+		"drift_count": 2,
+		"resources": [
+			{
+				"address": "aws_iam_role.full",
+				"type": "aws_iam_role",
+				"name": "full",
+				"action": ["update"],
+				"change": {
+					"before": {"a": 1},
+					"after":  {"a": 2}
+				}
+			},
+			{ "address": "aws_iam_role.partial" }
+		]
+	}`)
+	d, err := UnmarshalJSON(raw)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if HasClassifiableDetail(d) {
+		t.Errorf("HasClassifiableDetail = true with partial-schema input; want false")
+	}
+	// Sanity: the populated resource's fields decoded.
+	if d.Resources[0].Type != "aws_iam_role" {
+		t.Errorf("Resources[0].Type = %q; want aws_iam_role", d.Resources[0].Type)
+	}
+	if d.Resources[1].Type != "" {
+		t.Errorf("Resources[1].Type = %q; want \"\"", d.Resources[1].Type)
+	}
+}
+
+func TestUnmarshalJSON_NestedActionsFallback(t *testing.T) {
+	t.Parallel()
+	// Pre-#105 form where action lives at change.actions rather than
+	// at the top level. UnmarshalJSON should lift it onto Action so
+	// rule code doesn't have to special-case the schema.
+	raw := []byte(`{
+		"drift_detected": true,
+		"drift_count": 1,
+		"resources": [
+			{
+				"address": "aws_iam_role.r",
+				"type": "aws_iam_role",
+				"change": {
+					"before": {"a": 1},
+					"after":  {"a": 2},
+					"actions": ["update"]
+				}
+			}
+		]
+	}`)
+	d, err := UnmarshalJSON(raw)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := d.Resources[0].Action
+	if len(got) != 1 || got[0] != "update" {
+		t.Errorf("Action = %v; want [update] (fallback from change.actions)", got)
+	}
+}
+
+func TestUnmarshalJSON_MalformedReturnsError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"not_json", "this is not json"},
+		{"resources_wrong_type", `{"resources": 7}`},
+		{"truncated", `{"drift_detected":`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := UnmarshalJSON([]byte(tt.data)); err == nil {
+				t.Errorf("UnmarshalJSON(%q) = nil err; want error", tt.data)
+			}
+		})
+	}
+}
+
+func TestUnmarshalJSON_EmptyDriftIsClassifiable(t *testing.T) {
+	t.Parallel()
+	// "No drift" reports must be classifiable: HasClassifiableDetail
+	// returns true so callers don't fall back to a coarse signal when
+	// there's nothing to classify in the first place.
+	d, err := UnmarshalJSON([]byte(`{"drift_detected": false, "drift_count": 0, "resources": []}`))
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !HasClassifiableDetail(d) {
+		t.Errorf("HasClassifiableDetail = false on empty-resources input; want true")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `pkg/drift` — a Go package that owns drift.json parse + classification. This is **phase 1** of the design in #219 (presets-side scope only); it has no callers in this repo. Companion follow-ups land in `luthersystems/reliable#1251` (consumes `pkg/drift`), `luthersystems/sandbox-infrastructure-template#105` (additive `drift.json` schema extension), and `luthersystems/ui-core#336` (UI surfacing of per-class verdicts).

**This is partial work on #219 — please do NOT auto-close that issue.**

### What's in this PR

- **Public API** (`pkg/drift/drift.go`): `Drift`, `ResourceDrift`, `Change`, `Result`, `Resource`, `Attribute`, `Class` constants, `Rule` interface, `Option` / `WithExtraRules`. Signatures match the spec in #219 verbatim so reliable#1251 can pin against them.
- **Tolerant parser** (`unmarshal.go`): `UnmarshalJSON` decodes pre-#105 (address-only), post-#105 (additive `type`/`name`/`action`/`change`), and post-#107 enriched (`mode`/`module_address`/`provider_name` + `change.before_sensitive`/`after_sensitive`/`after_unknown`) drift.json shapes. Distinguishes `action` absent vs `action: null` via a trichotomy state machine so refresh-only signals don't get clobbered by the nested `change.actions` fallback. `HasClassifiableDetail` flags inputs rich enough for the rule chain to run.
- **Default rule chain** (`rules.go`), in evaluation order:
  1. `providerNoiseRule` — Go port of sandbox-infra's jq `_normalize` null/[]/{}/false/0/`""` equivalence
  2. `phantomComputedRule` — consults the embedded `phantom-computed-fields.txt` denylist; classifies only when *every* changed top-level attribute is on the list
  3. `iamManagedPolicyReconvergeRule` — narrow shape-match for `aws_iam_role.managed_policy_arns` going `[] → [arn:...]` with action `update`
- **Embed wiring** (`phantom_computed_fields_embed.go` at repo root): exposes `phantom-computed-fields.txt` as `PhantomComputedFieldsTXT` so `pkg/drift` can read it without traversing upward (`go:embed` forbids `..`). Single source of truth — same bytes the schema-verification CI gate validates.
- **Versioning rule** documented in package doc: reliable's classifier always uses its *own* embedded denylist, regardless of the customer's pinned `custom_presets_version`. Forward-compatible; never escalates anything to actionable that older sandbox-infra would have ignored.
- **Tests**: per-rule positive + negative cases, fall-through to actionable / unknown, fixture round-trips (5 hand-written JSON fixtures under `testdata/`), Summary shape, embed wiring smoke. Reconverge fixture mirrors the real post-#107 emitted shape so the decoder is exercised against production-shaped JSON.

**Schema confirmed against `luthersystems/sandbox-infrastructure-template` commit `3f74f4b`** — the post-#107 emitted JSON shape is what the decoder is hardened against.

### Out of scope here (per #219)

- No `tfplan.json` parser / `Input.Plan` / second-input infrastructure (deferred to a follow-up rule that needs cross-resource context).
- No new rules beyond the three specified — additional false-drift cases land in their own PRs alongside the affected modules.
- No reliable / ui-core / sandbox-infra changes — those are separate PRs.
- Pod-side apply-gate semantics unchanged — phase 2.

## Drive-by

Closes #220 — bump `github.com/go-jose/go-jose/v4` from 4.1.3 to 4.1.4 (cherry-picked from the dependabot branch).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` all packages pass (including pkg/drift)
- [x] `terraform fmt -check -recursive` passes
- [x] `tests/lint-phantom-computed-fields.sh` PASS (denylist still in sync with module NOTE comments)
- [x] `tests/lint-project-tag.sh`, `lint-project-label.sh`, `lint-labelless-name-prefix.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`, `lint-no-root-only-blocks.sh`, `lint-shared-no-cloud-providers.sh` all PASS
- [x] `make verify-gen` clean (no generated-code drift)
- [ ] CI on this PR is green