### PR TITLE
feat(observability): port account + cost-explorer AWS inspectors (#225)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.72.0
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2
+	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.79.1

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.72.0 h1:yOUKP1aURDdnpgB2W
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.72.0/go.mod h1:MLJu3PUd8fp5Qvj4CiLvyY5H8y7kxHKlTp060Wsd+Vc=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2 h1:pZxE29WAHgnk0jGj1P4UOOJnNPHXfltkfnK4F1Tg8jU=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2/go.mod h1:nbe4Nf/HOY+e54Dl+yjv04scYTGTC+4ZthbfOuPTXQs=
+github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8 h1:rUg81vwoGgCmnQxsVl+B65QF8Qh+zYCluhyAcxsk79o=
+github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8/go.mod h1:V+bKJ05kIC6K0LH8TB3D5boy7F8BhrZeecoXLz1NlB4=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3 h1:XgjzLEE8CrNYnr4Xmi1W5PfKsKMjp4Pu1rWkJNO43JI=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3/go.mod h1:r7sfLXEN8RUA89tAHy1E7lCtVOOWIkqVy/FbnUdxW1E=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.1 h1:gQ9fSyFk3Y9Vm2fVbphBeJfXJlkJvEvC35TszBVjprg=

--- a/pkg/observability/discovery/aws/account.go
+++ b/pkg/observability/discovery/aws/account.go
@@ -1,0 +1,61 @@
+// Account-summary inspector.
+//
+// Ported from reliable internal/agentapi/aws_inspect.go (account:
+// 1774-1812). Issue #225: AWSServiceActions advertised "account" but the
+// discovery dispatcher had no arm — calls fell through to
+// ErrUnsupportedService.
+//
+// The issue text mentions aws-sdk-go-v2/service/account; reliable's real
+// implementation composes sts.GetCallerIdentity + iam.ListAccountAliases +
+// iam.GetAccountSummary. Both SDKs are already in go.mod, and this is the
+// shape reliable's frontend reads, so the port preserves it.
+//
+// Per-call errors log+continue rather than fail — partial answers
+// (AccountId without Aliases, etc.) are more useful in the panel than a
+// 500. Mirrors reliable's behaviour.
+
+package aws
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+func inspectAccount(ctx context.Context, cfg aws.Config, action, _ string) (any, error) {
+	switch action {
+	case "get-info":
+		stsClient := sts.NewFromConfig(cfg)
+		iamClient := iam.NewFromConfig(cfg)
+		info := make(map[string]any)
+
+		identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+		if err == nil {
+			info["AccountId"] = aws.ToString(identity.Account)
+			info["Arn"] = aws.ToString(identity.Arn)
+			info["UserId"] = aws.ToString(identity.UserId)
+		} else {
+			log.Printf("[aws-inspect] account info: sts.GetCallerIdentity failed: %v", err)
+		}
+
+		info["Region"] = cfg.Region
+
+		aliases, err := iamClient.ListAccountAliases(ctx, &iam.ListAccountAliasesInput{})
+		if err == nil && len(aliases.AccountAliases) > 0 {
+			info["AccountAliases"] = aliases.AccountAliases
+		}
+
+		summary, err := iamClient.GetAccountSummary(ctx, &iam.GetAccountSummaryInput{})
+		if err == nil {
+			info["AccountSummary"] = summary.SummaryMap
+		}
+
+		return info, nil
+
+	default:
+		return nil, unsupportedActionError("account", action)
+	}
+}

--- a/pkg/observability/discovery/aws/costexplorer.go
+++ b/pkg/observability/discovery/aws/costexplorer.go
@@ -1,0 +1,295 @@
+// Cost Explorer service inspector.
+//
+// Ported from reliable internal/agentapi/aws_inspect.go (cost-explorer:
+// 1505-1772). Issue #225: AWSServiceActions advertised "cost-explorer" but
+// the discovery dispatcher had no arm — calls fell through to
+// ErrUnsupportedService. This brings the surface back here so reliable's
+// Phase B swap to pkg/observability (reliable#1252 PR 2) doesn't regress
+// production cost reporting.
+//
+// Cost Explorer is a global API: callers should construct cfg in
+// us-east-1 (Cost Explorer doesn't accept other regions). The
+// `DataUnavailable` graceful-degradation path matters for new accounts
+// — billing data lags first usage by 24-48h, and forecasts need at least
+// 14 days of history. Returning a {note, period} map instead of an error
+// keeps the panel rendering instead of showing a wall of red.
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+	cetypes "github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+)
+
+// CostExplorerAPI is the subset of the Cost Explorer SDK used by the
+// inspector. Mirrors reliable's CostExplorerAPI
+// (aws_inspect.go:1505-1509) — exported so tests can inject a mock and
+// callers porting from reliable need no rename.
+type CostExplorerAPI interface {
+	GetCostAndUsage(ctx context.Context, params *costexplorer.GetCostAndUsageInput, optFns ...func(*costexplorer.Options)) (*costexplorer.GetCostAndUsageOutput, error)
+	GetCostForecast(ctx context.Context, params *costexplorer.GetCostForecastInput, optFns ...func(*costexplorer.Options)) (*costexplorer.GetCostForecastOutput, error)
+}
+
+// formatUSD formats a Cost Explorer amount string (e.g. "12.345600") as
+// "$12.35". Returns the input unchanged on parse failure so we surface the
+// raw API response rather than masking it with "$0.00".
+func formatUSD(amount string) string {
+	f := 0.0
+	if _, err := fmt.Sscanf(amount, "%f", &f); err != nil {
+		return amount
+	}
+	return fmt.Sprintf("$%.2f", f)
+}
+
+func inspectCostExplorer(ctx context.Context, cfg aws.Config, action, filters string) (any, error) {
+	return inspectCostExplorerWithDeps(ctx, costexplorer.NewFromConfig(cfg), action, filters)
+}
+
+// inspectCostExplorerWithDeps is the testable core. Accepts an injected
+// [CostExplorerAPI] so unit tests can run against a mock without touching
+// AWS.
+func inspectCostExplorerWithDeps(ctx context.Context, client CostExplorerAPI, action, filters string) (any, error) {
+	var filterMap map[string]string
+	if filters != "" {
+		_ = json.Unmarshal([]byte(filters), &filterMap)
+	}
+
+	switch action {
+	case "get-cost-summary":
+		days := 30
+		if d := filterMap["days"]; d != "" {
+			if _, err := fmt.Sscanf(d, "%d", &days); err != nil || days < 1 {
+				days = 30
+			}
+			if days > 365 {
+				days = 365
+			}
+		}
+
+		granularity := cetypes.GranularityMonthly
+		if g := filterMap["granularity"]; strings.EqualFold(g, "DAILY") {
+			granularity = cetypes.GranularityDaily
+		}
+
+		now := time.Now().UTC()
+		start := now.AddDate(0, 0, -days).Format("2006-01-02")
+		end := now.Format("2006-01-02")
+
+		out, err := client.GetCostAndUsage(ctx, &costexplorer.GetCostAndUsageInput{
+			TimePeriod: &cetypes.DateInterval{
+				Start: aws.String(start),
+				End:   aws.String(end),
+			},
+			Granularity: granularity,
+			Metrics:     []string{"UnblendedCost", "UsageQuantity"},
+			GroupBy: []cetypes.GroupDefinition{
+				{Type: cetypes.GroupDefinitionTypeDimension, Key: aws.String("SERVICE")},
+			},
+		})
+		if err != nil {
+			if strings.Contains(err.Error(), "DataUnavailable") {
+				return map[string]any{
+					"note":   "No billing data available yet. Cost data typically appears 24-48 hours after first usage.",
+					"period": fmt.Sprintf("%s to %s", start, end),
+				}, nil
+			}
+			return nil, err
+		}
+
+		serviceCosts := make(map[string]float64)
+		var totalCost float64
+		for _, result := range out.ResultsByTime {
+			for _, group := range result.Groups {
+				svcName := ""
+				if len(group.Keys) > 0 {
+					svcName = group.Keys[0]
+				}
+				if cost, ok := group.Metrics["UnblendedCost"]; ok && cost.Amount != nil {
+					var amount float64
+					if _, err := fmt.Sscanf(*cost.Amount, "%f", &amount); err == nil {
+						serviceCosts[svcName] += amount
+						totalCost += amount
+					}
+				}
+			}
+		}
+
+		type serviceCostEntry struct {
+			Service string `json:"service"`
+			Cost    string `json:"cost"`
+		}
+		var sorted []serviceCostEntry
+		for svc, cost := range serviceCosts {
+			sorted = append(sorted, serviceCostEntry{Service: svc, Cost: formatUSD(fmt.Sprintf("%f", cost))})
+		}
+		for i := 0; i < len(sorted); i++ {
+			for j := i + 1; j < len(sorted); j++ {
+				if serviceCosts[sorted[j].Service] > serviceCosts[sorted[i].Service] {
+					sorted[i], sorted[j] = sorted[j], sorted[i]
+				}
+			}
+		}
+
+		return map[string]any{
+			"period":        fmt.Sprintf("%s to %s", start, end),
+			"granularity":   string(granularity),
+			"total_cost":    formatUSD(fmt.Sprintf("%f", totalCost)),
+			"by_service":    sorted,
+			"service_count": len(sorted),
+		}, nil
+
+	case "get-cost-forecast":
+		now := time.Now().UTC()
+		start := now.AddDate(0, 0, 1).Format("2006-01-02")
+		endOfMonth := time.Date(now.Year(), now.Month()+1, 1, 0, 0, 0, 0, time.UTC)
+		// If less than 2 days until end of month, forecast next month —
+		// AWS rejects intervals under ~1 day.
+		if endOfMonth.Sub(now).Hours() < 48 {
+			endOfMonth = endOfMonth.AddDate(0, 1, 0)
+		}
+		end := endOfMonth.Format("2006-01-02")
+
+		out, err := client.GetCostForecast(ctx, &costexplorer.GetCostForecastInput{
+			TimePeriod: &cetypes.DateInterval{
+				Start: aws.String(start),
+				End:   aws.String(end),
+			},
+			Granularity: cetypes.GranularityMonthly,
+			Metric:      cetypes.MetricUnblendedCost,
+		})
+		if err != nil {
+			if strings.Contains(err.Error(), "DataUnavailable") || strings.Contains(err.Error(), "not enough data") ||
+				strings.Contains(err.Error(), "BillEstimateLineItemDataUnavailable") {
+				return map[string]any{
+					"note":   "Cost forecast unavailable. AWS requires at least 14 days of billing history to generate forecasts.",
+					"period": fmt.Sprintf("%s to %s", start, end),
+				}, nil
+			}
+			return nil, err
+		}
+
+		result := map[string]any{
+			"period": fmt.Sprintf("%s to %s", start, end),
+		}
+		if out.Total != nil && out.Total.Amount != nil {
+			result["forecast_total"] = formatUSD(*out.Total.Amount)
+			result["unit"] = aws.ToString(out.Total.Unit)
+		}
+		if len(out.ForecastResultsByTime) > 0 {
+			var periods []map[string]string
+			for _, f := range out.ForecastResultsByTime {
+				p := map[string]string{}
+				if f.TimePeriod != nil {
+					p["start"] = aws.ToString(f.TimePeriod.Start)
+					p["end"] = aws.ToString(f.TimePeriod.End)
+				}
+				if f.MeanValue != nil {
+					p["mean_value"] = formatUSD(*f.MeanValue)
+				}
+				periods = append(periods, p)
+			}
+			result["by_period"] = periods
+		}
+		return result, nil
+
+	case "get-cost-by-tag":
+		tagKey := filterMap["tag_key"]
+		if tagKey == "" {
+			return nil, fmt.Errorf("get-cost-by-tag requires tag_key in filters (e.g. {\"tag_key\":\"Environment\"})")
+		}
+
+		days := 30
+		if d := filterMap["days"]; d != "" {
+			if _, err := fmt.Sscanf(d, "%d", &days); err != nil || days < 1 {
+				days = 30
+			}
+			if days > 365 {
+				days = 365
+			}
+		}
+
+		now := time.Now().UTC()
+		start := now.AddDate(0, 0, -days).Format("2006-01-02")
+		end := now.Format("2006-01-02")
+
+		out, err := client.GetCostAndUsage(ctx, &costexplorer.GetCostAndUsageInput{
+			TimePeriod: &cetypes.DateInterval{
+				Start: aws.String(start),
+				End:   aws.String(end),
+			},
+			Granularity: cetypes.GranularityMonthly,
+			Metrics:     []string{"UnblendedCost"},
+			GroupBy: []cetypes.GroupDefinition{
+				{Type: cetypes.GroupDefinitionTypeTag, Key: aws.String(tagKey)},
+			},
+		})
+		if err != nil {
+			if strings.Contains(err.Error(), "DataUnavailable") {
+				return map[string]any{
+					"note":   "No billing data available for the specified tag.",
+					"period": fmt.Sprintf("%s to %s", start, end),
+				}, nil
+			}
+			return nil, err
+		}
+
+		tagCosts := make(map[string]float64)
+		var totalCost float64
+		for _, result := range out.ResultsByTime {
+			for _, group := range result.Groups {
+				tagValue := "(untagged)"
+				if len(group.Keys) > 0 && group.Keys[0] != "" {
+					tagValue = group.Keys[0]
+					// AWS returns "tag_key$tag_value" — split off the
+					// key prefix so the panel shows just the value.
+					if parts := strings.SplitN(tagValue, "$", 2); len(parts) == 2 {
+						tagValue = parts[1]
+						if tagValue == "" {
+							tagValue = "(untagged)"
+						}
+					}
+				}
+				if cost, ok := group.Metrics["UnblendedCost"]; ok && cost.Amount != nil {
+					var amount float64
+					if _, err := fmt.Sscanf(*cost.Amount, "%f", &amount); err == nil {
+						tagCosts[tagValue] += amount
+						totalCost += amount
+					}
+				}
+			}
+		}
+
+		type tagCostEntry struct {
+			TagValue string `json:"tag_value"`
+			Cost     string `json:"cost"`
+		}
+		var sorted []tagCostEntry
+		for tag, cost := range tagCosts {
+			sorted = append(sorted, tagCostEntry{TagValue: tag, Cost: formatUSD(fmt.Sprintf("%f", cost))})
+		}
+		for i := 0; i < len(sorted); i++ {
+			for j := i + 1; j < len(sorted); j++ {
+				if tagCosts[sorted[j].TagValue] > tagCosts[sorted[i].TagValue] {
+					sorted[i], sorted[j] = sorted[j], sorted[i]
+				}
+			}
+		}
+
+		return map[string]any{
+			"period":     fmt.Sprintf("%s to %s", start, end),
+			"tag_key":    tagKey,
+			"total_cost": formatUSD(fmt.Sprintf("%f", totalCost)),
+			"by_tag":     sorted,
+		}, nil
+
+	default:
+		return nil, unsupportedActionError("cost-explorer", action)
+	}
+}

--- a/pkg/observability/discovery/aws/costexplorer_test.go
+++ b/pkg/observability/discovery/aws/costexplorer_test.go
@@ -1,0 +1,443 @@
+// Mock-based unit tests for the Cost Explorer inspector.
+//
+// Ported from reliable internal/agentapi/aws_billing_test.go (1-386).
+// Reliable's integration tests (billingAWSConfig + the live-API tests
+// after line 471) are intentionally NOT ported — they wrap reliable's
+// session/Oracle layer that the issue header for #225 explicitly excludes.
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+	cetypes "github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockCostExplorerClient struct {
+	getCostAndUsageOutput    *costexplorer.GetCostAndUsageOutput
+	getCostAndUsageErr       error
+	getCostForecastOutput    *costexplorer.GetCostForecastOutput
+	getCostForecastErr       error
+	lastGetCostAndUsageInput *costexplorer.GetCostAndUsageInput
+	lastGetCostForecastInput *costexplorer.GetCostForecastInput
+}
+
+func (m *mockCostExplorerClient) GetCostAndUsage(_ context.Context, params *costexplorer.GetCostAndUsageInput, _ ...func(*costexplorer.Options)) (*costexplorer.GetCostAndUsageOutput, error) {
+	m.lastGetCostAndUsageInput = params
+	return m.getCostAndUsageOutput, m.getCostAndUsageErr
+}
+
+func (m *mockCostExplorerClient) GetCostForecast(_ context.Context, params *costexplorer.GetCostForecastInput, _ ...func(*costexplorer.Options)) (*costexplorer.GetCostForecastOutput, error) {
+	m.lastGetCostForecastInput = params
+	return m.getCostForecastOutput, m.getCostForecastErr
+}
+
+func TestFormatUSD(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"zero", "0.000000", "$0.00"},
+		{"whole dollars", "100.000000", "$100.00"},
+		{"cents", "0.123456", "$0.12"},
+		{"large amount", "12345.678900", "$12345.68"},
+		{"negative", "-50.000000", "$-50.00"},
+		{"small fraction", "0.001000", "$0.00"},
+		{"invalid input", "not-a-number", "not-a-number"},
+		{"empty string", "", ""},
+		{"rounds up at 0.005", "0.005", "$0.01"},
+		{"rounds down at 0.004", "0.004", "$0.00"},
+		{"rounds up at 1.995", "1.995", "$2.00"},
+		{"rounds down at 1.994", "1.994", "$1.99"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, formatUSD(tt.input))
+		})
+	}
+}
+
+func TestInspectCostExplorer_UnsupportedAction(t *testing.T) {
+	t.Parallel()
+	mock := &mockCostExplorerClient{}
+	_, err := inspectCostExplorerWithDeps(context.Background(), mock, "nonexistent-action", "")
+	require.Error(t, err)
+	// unsupportedActionError formats as
+	// `unsupported cost-explorer action: %q. Supported: %v`. Assert
+	// substring matches both the verb and at least one canonical action
+	// so a future helper rename surfaces the regression.
+	assert.Contains(t, err.Error(), "unsupported cost-explorer action")
+	assert.Contains(t, err.Error(), "get-cost-summary")
+}
+
+func TestInspectCostExplorer_GetCostByTag_MissingTagKey(t *testing.T) {
+	t.Parallel()
+	mock := &mockCostExplorerClient{}
+	_, err := inspectCostExplorerWithDeps(context.Background(), mock, "get-cost-by-tag", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tag_key")
+}
+
+func TestInspectCostExplorer_GetCostByTag_EmptyFilters(t *testing.T) {
+	t.Parallel()
+	mock := &mockCostExplorerClient{}
+	_, err := inspectCostExplorerWithDeps(context.Background(), mock, "get-cost-by-tag", `{}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tag_key")
+}
+
+func TestCostSummary_AggregationAndSorting(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockCostExplorerClient{
+		getCostAndUsageOutput: &costexplorer.GetCostAndUsageOutput{
+			ResultsByTime: []cetypes.ResultByTime{
+				{
+					Groups: []cetypes.Group{
+						{Keys: []string{"Amazon EC2"}, Metrics: map[string]cetypes.MetricValue{"UnblendedCost": {Amount: aws.String("50.00")}}},
+						{Keys: []string{"Amazon S3"}, Metrics: map[string]cetypes.MetricValue{"UnblendedCost": {Amount: aws.String("10.00")}}},
+						{Keys: []string{"AWS Lambda"}, Metrics: map[string]cetypes.MetricValue{"UnblendedCost": {Amount: aws.String("5.00")}}},
+					},
+				},
+				{
+					Groups: []cetypes.Group{
+						{Keys: []string{"Amazon EC2"}, Metrics: map[string]cetypes.MetricValue{"UnblendedCost": {Amount: aws.String("60.00")}}},
+						{Keys: []string{"Amazon S3"}, Metrics: map[string]cetypes.MetricValue{"UnblendedCost": {Amount: aws.String("15.00")}}},
+						{Keys: []string{"AWS Lambda"}, Metrics: map[string]cetypes.MetricValue{"UnblendedCost": {Amount: aws.String("8.00")}}},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := inspectCostExplorerWithDeps(context.Background(), mock, "get-cost-summary", "")
+	require.NoError(t, err)
+
+	m := jsonRoundTrip(t, result)
+
+	assert.Equal(t, "$148.00", m["total_cost"])
+	assert.Equal(t, float64(3), m["service_count"])
+	assert.Equal(t, "MONTHLY", m["granularity"])
+
+	byService, ok := m["by_service"].([]any)
+	require.True(t, ok, "by_service should be a slice")
+	require.Len(t, byService, 3)
+
+	first := byService[0].(map[string]any)
+	assert.Equal(t, "Amazon EC2", first["service"])
+	assert.Equal(t, "$110.00", first["cost"])
+
+	second := byService[1].(map[string]any)
+	assert.Equal(t, "Amazon S3", second["service"])
+	assert.Equal(t, "$25.00", second["cost"])
+
+	third := byService[2].(map[string]any)
+	assert.Equal(t, "AWS Lambda", third["service"])
+	assert.Equal(t, "$13.00", third["cost"])
+}
+
+func TestCostSummary_DataUnavailable(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockCostExplorerClient{
+		getCostAndUsageErr: fmt.Errorf("DataUnavailable: billing data not yet available"),
+	}
+
+	result, err := inspectCostExplorerWithDeps(context.Background(), mock, "get-cost-summary", "")
+	require.NoError(t, err, "DataUnavailable should be handled gracefully, not returned as error")
+
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, m["note"], "No billing data available")
+	assert.Contains(t, m["period"], " to ")
+}
+
+func TestCostSummary_DaysClamping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filters  string
+		wantDays int
+	}{
+		{"days=0 defaults to 30", `{"days":"0"}`, 30},
+		{"days=500 clamped to 365", `{"days":"500"}`, 365},
+		{"days=7 unchanged", `{"days":"7"}`, 7},
+		{"negative defaults to 30", `{"days":"-5"}`, 30},
+		{"no days defaults to 30", `{}`, 30},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mock := &mockCostExplorerClient{
+				getCostAndUsageOutput: &costexplorer.GetCostAndUsageOutput{},
+			}
+
+			_, err := inspectCostExplorerWithDeps(context.Background(), mock, "get-cost-summary", tt.filters)
+			require.NoError(t, err)
+
+			require.NotNil(t, mock.lastGetCostAndUsageInput)
+			start := aws.ToString(mock.lastGetCostAndUsageInput.TimePeriod.Start)
+			end := aws.ToString(mock.lastGetCostAndUsageInput.TimePeriod.End)
+
+			startTime, err := time.Parse("2006-01-02", start)
+			require.NoError(t, err, "start date should be valid")
+			endTime, err := time.Parse("2006-01-02", end)
+			require.NoError(t, err, "end date should be valid")
+
+			actualDays := int(endTime.Sub(startTime).Hours() / 24)
+			assert.Equal(t, tt.wantDays, actualDays, "date range should span expected days")
+		})
+	}
+}
+
+func TestCostSummary_GranularityMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		filters         string
+		wantGranularity cetypes.Granularity
+	}{
+		{"DAILY maps to GranularityDaily", `{"granularity":"DAILY"}`, cetypes.GranularityDaily},
+		{"daily case insensitive", `{"granularity":"daily"}`, cetypes.GranularityDaily},
+		{"empty defaults to MONTHLY", `{}`, cetypes.GranularityMonthly},
+		{"no filters defaults to MONTHLY", "", cetypes.GranularityMonthly},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mock := &mockCostExplorerClient{
+				getCostAndUsageOutput: &costexplorer.GetCostAndUsageOutput{},
+			}
+
+			_, err := inspectCostExplorerWithDeps(context.Background(), mock, "get-cost-summary", tt.filters)
+			require.NoError(t, err)
+
+			require.NotNil(t, mock.lastGetCostAndUsageInput)
+			assert.Equal(t, tt.wantGranularity, mock.lastGetCostAndUsageInput.Granularity)
+		})
+	}
+}
+
+func TestCostSummary_EmptyResults(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockCostExplorerClient{
+		getCostAndUsageOutput: &costexplorer.GetCostAndUsageOutput{
+			ResultsByTime: []cetypes.ResultByTime{},
+		},
+	}
+
+	result, err := inspectCostExplorerWithDeps(context.Background(), mock, "get-cost-summary", "")
+	require.NoError(t, err)
+
+	m := assertCostSummaryResult(t, result)
+	assert.Equal(t, 0, m["service_count"])
+	assert.Equal(t, "$0.00", m["total_cost"])
+}
+
+func TestCostForecast_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockCostExplorerClient{
+		getCostForecastOutput: &costexplorer.GetCostForecastOutput{
+			Total: &cetypes.MetricValue{
+				Amount: aws.String("250.50"),
+				Unit:   aws.String("USD"),
+			},
+			ForecastResultsByTime: []cetypes.ForecastResult{
+				{
+					TimePeriod: &cetypes.DateInterval{
+						Start: aws.String("2026-02-15"),
+						End:   aws.String("2026-03-01"),
+					},
+					MeanValue: aws.String("250.50"),
+				},
+			},
+		},
+	}
+
+	result, err := inspectCostExplorerWithDeps(context.Background(), mock, "get-cost-forecast", "")
+	require.NoError(t, err)
+
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+
+	assert.Contains(t, m["period"], " to ")
+	assert.Equal(t, "$250.50", m["forecast_total"])
+	assert.Equal(t, "USD", m["unit"])
+
+	periods, ok := m["by_period"].([]map[string]string)
+	require.True(t, ok)
+	require.Len(t, periods, 1)
+	assert.Equal(t, "2026-02-15", periods[0]["start"])
+	assert.Equal(t, "2026-03-01", periods[0]["end"])
+	assert.Equal(t, "$250.50", periods[0]["mean_value"])
+}
+
+func TestCostForecast_InsufficientData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"DataUnavailable", fmt.Errorf("DataUnavailable: no historical data")},
+		{"not enough data", fmt.Errorf("not enough data points available")},
+		{"BillEstimateLineItemDataUnavailable", fmt.Errorf("BillEstimateLineItemDataUnavailable")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mock := &mockCostExplorerClient{
+				getCostForecastErr: tt.err,
+			}
+
+			result, err := inspectCostExplorerWithDeps(context.Background(), mock, "get-cost-forecast", "")
+			require.NoError(t, err, "should handle gracefully")
+
+			m, ok := result.(map[string]any)
+			require.True(t, ok)
+			assert.Contains(t, m["note"], "Cost forecast unavailable")
+			assert.Contains(t, m["period"], " to ")
+		})
+	}
+}
+
+func TestCostForecast_RealError(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockCostExplorerClient{
+		getCostForecastErr: fmt.Errorf("AccessDeniedException: not authorized"),
+	}
+
+	_, err := inspectCostExplorerWithDeps(context.Background(), mock, "get-cost-forecast", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AccessDeniedException")
+}
+
+func TestCostByTag_TagParsing(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockCostExplorerClient{
+		getCostAndUsageOutput: &costexplorer.GetCostAndUsageOutput{
+			ResultsByTime: []cetypes.ResultByTime{
+				{
+					Groups: []cetypes.Group{
+						{Keys: []string{"Environment$production"}, Metrics: map[string]cetypes.MetricValue{"UnblendedCost": {Amount: aws.String("100.00")}}},
+						{Keys: []string{"Environment$staging"}, Metrics: map[string]cetypes.MetricValue{"UnblendedCost": {Amount: aws.String("30.00")}}},
+						{Keys: []string{"Environment$"}, Metrics: map[string]cetypes.MetricValue{"UnblendedCost": {Amount: aws.String("5.00")}}},
+						{Keys: []string{""}, Metrics: map[string]cetypes.MetricValue{"UnblendedCost": {Amount: aws.String("2.00")}}},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := inspectCostExplorerWithDeps(context.Background(), mock, "get-cost-by-tag", `{"tag_key":"Environment"}`)
+	require.NoError(t, err)
+
+	m := jsonRoundTrip(t, result)
+	assert.Equal(t, "Environment", m["tag_key"])
+	assert.Equal(t, "$137.00", m["total_cost"])
+	assert.Contains(t, m["period"], " to ")
+
+	byTag, ok := m["by_tag"].([]any)
+	require.True(t, ok)
+	require.Len(t, byTag, 3)
+
+	first := byTag[0].(map[string]any)
+	assert.Equal(t, "production", first["tag_value"])
+	assert.Equal(t, "$100.00", first["cost"])
+
+	second := byTag[1].(map[string]any)
+	assert.Equal(t, "staging", second["tag_value"])
+	assert.Equal(t, "$30.00", second["cost"])
+
+	third := byTag[2].(map[string]any)
+	assert.Equal(t, "(untagged)", third["tag_value"])
+	assert.Equal(t, "$7.00", third["cost"])
+}
+
+func jsonRoundTrip(t *testing.T, v any) map[string]any {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+	return m
+}
+
+// assertCostSummaryResult validates the full structural contract of a cost
+// summary result. Returns the map for further assertions.
+func assertCostSummaryResult(t *testing.T, result any) map[string]any {
+	t.Helper()
+
+	m, ok := result.(map[string]any)
+	require.True(t, ok, "result should be map[string]any, got %T", result)
+
+	period, ok := m["period"].(string)
+	require.True(t, ok, "period must be a string")
+	assert.Contains(t, period, " to ", "period should be 'start to end' format")
+
+	if _, hasNote := m["note"]; hasNote {
+		t.Logf("Cost API returned note: %v", m["note"])
+		return m
+	}
+
+	totalCost, ok := m["total_cost"].(string)
+	require.True(t, ok, "total_cost must be a string")
+	assert.True(t, strings.HasPrefix(totalCost, "$"), "total_cost should start with $, got %q", totalCost)
+
+	granularity, ok := m["granularity"].(string)
+	require.True(t, ok, "granularity must be a string")
+	assert.NotEmpty(t, granularity)
+
+	var serviceCount int
+	switch sc := m["service_count"].(type) {
+	case int:
+		serviceCount = sc
+	case float64:
+		serviceCount = int(sc)
+	default:
+		require.Fail(t, "service_count must be numeric", "got %T", m["service_count"])
+	}
+	assert.GreaterOrEqual(t, serviceCount, 0)
+
+	byService := m["by_service"]
+	if serviceCount > 0 {
+		require.NotNil(t, byService, "by_service must not be nil when service_count > 0")
+		data, err := json.Marshal(byService)
+		require.NoError(t, err)
+		var entries []map[string]any
+		require.NoError(t, json.Unmarshal(data, &entries))
+		require.Len(t, entries, serviceCount)
+		for _, entry := range entries {
+			svc, ok := entry["service"].(string)
+			require.True(t, ok, "service must be a string")
+			assert.NotEmpty(t, svc)
+			cost, ok := entry["cost"].(string)
+			require.True(t, ok, "cost must be a string")
+			assert.True(t, strings.HasPrefix(cost, "$"), "cost should start with $, got %q", cost)
+		}
+	}
+
+	return m
+}

--- a/pkg/observability/discovery/aws/dispatcher.go
+++ b/pkg/observability/discovery/aws/dispatcher.go
@@ -124,6 +124,10 @@ func Inspect(ctx context.Context, cfg aws.Config, service, action, filtersJSON s
 		return inspectBedrock(ctx, cfg, action, filtersJSON)
 	case "cloudwatchlogs":
 		return inspectCloudWatchLogs(ctx, cfg, action, filtersJSON)
+	case "cost-explorer":
+		return inspectCostExplorer(ctx, cfg, action, filtersJSON)
+	case "account":
+		return inspectAccount(ctx, cfg, action, filtersJSON)
 	default:
 		return nil, fmt.Errorf("%w: %q (valid: %v)", ErrUnsupportedService, service, observability.AWSServiceNames())
 	}

--- a/pkg/observability/discovery/aws/dispatcher_test.go
+++ b/pkg/observability/discovery/aws/dispatcher_test.go
@@ -52,12 +52,6 @@ func TestInspectCoversAllAWSServices(t *testing.T) {
 	for _, svc := range observability.AWSServiceNames() {
 		t.Run(svc, func(t *testing.T) {
 			t.Parallel()
-			// cost-explorer + account aren't ported in C14 — they're
-			// reliable's sts + costexplorer surfaces. Skip so the gate
-			// doesn't false-fail until those land in a follow-up.
-			if svc == "cost-explorer" || svc == "account" {
-				t.Skipf("service %q not yet ported to discovery package (deferred follow-up)", svc)
-			}
 			action := firstAction(svc)
 			_, err := Inspect(context.Background(), cfg, svc, action, "")
 			// The AWS call is expected to fail (no real credentials);
@@ -132,9 +126,6 @@ func TestInspectGetMetricsContractAcrossAllServices(t *testing.T) {
 		}
 		t.Run(svc, func(t *testing.T) {
 			t.Parallel()
-			if svc == "cost-explorer" || svc == "account" {
-				t.Skipf("service %q not yet ported (deferred follow-up)", svc)
-			}
 			_, err := Inspect(context.Background(), cfg, svc, "get-metrics", "")
 			require.Error(t, err, "get-metrics must return an error sentinel, not nil")
 			assert.True(t, errors.Is(err, ErrUseMetricsPackage),


### PR DESCRIPTION
## Summary

- Add `pkg/observability/discovery/aws/{account.go,costexplorer.go}` —
  ports of reliable's `inspectAccount` (sts + iam composition) and
  `inspectCostExplorer` / `inspectCostExplorerWithDeps` (full
  `get-cost-summary` / `get-cost-forecast` / `get-cost-by-tag` surface
  with `DataUnavailable` graceful-degradation).
- Wire two new arms in `discovery/aws/dispatcher.go`; drop the
  `t.Skipf` blocks in `dispatcher_test.go` that deferred this work
  during the C14 consolidation.
- Port the mock-based unit tests from reliable
  `internal/agentapi/aws_billing_test.go` (`TestFormatUSD` +
  cost-summary / forecast / by-tag aggregation, sorting, days clamping,
  granularity mapping, DataUnavailable, real-error). Integration
  tests intentionally not ported — they wrap reliable's session/Oracle
  layer that the issue header explicitly excludes.
- `go.mod`: add `aws-sdk-go-v2/service/costexplorer v1.63.8` (`sts`
  and `iam` already present).

`AWSServiceActions` (`pkg/observability/service_actions.go`) advertised
`account` and `cost-explorer` but the dispatcher had no case arms, so
callers got `ErrUnsupportedService`. Reliable carries the
implementations downstream today (`internal/agentapi/aws_inspect.go`);
this brings them home before reliable#1252 PR 2 swaps to
`pkg/observability` and silently regresses production cost reporting
and account-summary panels.

Closes #225 — release tagging (`v0.8.1` per the issue) is a follow-up
once this merges.

Depends-on: nothing. Unblocks: reliable#1252 PR 2.

## Test plan

- [x] `go build ./...` — clean.
- [x] `gofmt -l pkg/observability/discovery/aws/` — clean.
- [x] `go vet ./...` — clean.
- [x] `go test -race ./pkg/observability/discovery/aws/...` — pass
  (drift gate `TestInspectCoversAllAWSServices` now exercises both new
  services without `ErrUnsupportedService`).
- [x] `go test ./...` — full module green.
- [ ] CI green on PR.