### PR TITLE
feat(observability): port did-you-mean hint to UnsupportedActionError (#227)

### DIFF
--- a/pkg/observability/discovery/aws/dispatcher.go
+++ b/pkg/observability/discovery/aws/dispatcher.go
@@ -46,12 +46,15 @@ var ErrUseMetricsPackage = errors.New("get-metrics is handled by pkg/observabili
 
 // ErrUnsupportedService is returned when the service key is not in
 // observability.AWSServiceActions and is not a known alias. Use
-// errors.Is to detect; the wrapped error carries the rejected key, a
+// errors.Is to detect. The wrapped error carries the rejected key, a
 // did-you-mean hint when one is close, and the full list of valid
-// services. The sentinel text matches the prefix of
-// observability.UnsupportedServiceError so the wrapped output reads as
-// `unsupported service: "<svc>" (did you mean "<closest>"?). Supported
-// services: ...` — the format reliable's LLM consumer expects.
+// services in reliable's wire-format (#227). The sentinel text matches
+// the canonical prefix produced by observability.UnsupportedServiceError
+// so unsupportedServiceError can dedupe via strings.TrimPrefix; both
+// halves of that coupling are pinned by tests
+// (pkg/observability/unsupported_test.go::
+// "starts_with_canonical_prefix_for_sentinel_wrapping" and
+// dispatcher_test.go::TestInspectUnsupportedServiceErrorGoldenFormat).
 var ErrUnsupportedService = errors.New("unsupported service")
 
 // Inspect dispatches a single discovery request against the supplied

--- a/pkg/observability/discovery/aws/dispatcher.go
+++ b/pkg/observability/discovery/aws/dispatcher.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 
@@ -45,9 +46,13 @@ var ErrUseMetricsPackage = errors.New("get-metrics is handled by pkg/observabili
 
 // ErrUnsupportedService is returned when the service key is not in
 // observability.AWSServiceActions and is not a known alias. Use
-// errors.Is to detect; the wrapped error carries the rejected key + the
-// list of valid services for callers that want to render a hint.
-var ErrUnsupportedService = errors.New("unsupported aws service")
+// errors.Is to detect; the wrapped error carries the rejected key, a
+// did-you-mean hint when one is close, and the full list of valid
+// services. The sentinel text matches the prefix of
+// observability.UnsupportedServiceError so the wrapped output reads as
+// `unsupported service: "<svc>" (did you mean "<closest>"?). Supported
+// services: ...` — the format reliable's LLM consumer expects.
+var ErrUnsupportedService = errors.New("unsupported service")
 
 // Inspect dispatches a single discovery request against the supplied
 // AWS config. service may be a canonical key (see
@@ -129,7 +134,7 @@ func Inspect(ctx context.Context, cfg aws.Config, service, action, filtersJSON s
 	case "account":
 		return inspectAccount(ctx, cfg, action, filtersJSON)
 	default:
-		return nil, fmt.Errorf("%w: %q (valid: %v)", ErrUnsupportedService, service, observability.AWSServiceNames())
+		return nil, unsupportedServiceError(service)
 	}
 }
 
@@ -140,14 +145,34 @@ func metricsRouted(service string) (any, error) {
 	return nil, fmt.Errorf("%w (service=%s)", ErrUseMetricsPackage, service)
 }
 
-// unsupportedActionError mirrors reliable's
-// inspect_normalize.go:unsupportedActionError but skips the levenshtein
-// "did you mean?" hint to keep this package free of the
-// github.com/agext/levenshtein dependency. The action registry already
-// lives in pkg/observability/service_actions.go; callers that want a
-// hint can compare the rejected action against
-// observability.AWSServiceActions[service] themselves.
+// unsupportedActionError builds the "unsupported <service> action"
+// error including the did-you-mean hint and supported-action list.
+// Thin wrapper over observability.UnsupportedActionError that pulls the
+// per-service action list from the canonical registry. Used by every
+// per-service inspector's default switch arm — they all pass the
+// canonical service key, so registry lookup is the right default.
+//
+// Format matches reliable's inspect_normalize.go::unsupportedActionError
+// byte-for-byte (#227): the string is round-tripped to the LLM as a
+// tool-result envelope, and reliable's consumer tests (and prompts) lock
+// the substring `did you mean "..."`.
 func unsupportedActionError(service, action string) error {
-	valid := observability.AWSServiceActions[service]
-	return fmt.Errorf("unsupported %s action: %q. Supported: %v", service, action, valid)
+	return observability.UnsupportedActionError(service, action, observability.AWSServiceActions[service])
+}
+
+// unsupportedServiceError builds the "unsupported service" error and
+// wraps ErrUnsupportedService so callers can use errors.Is to detect
+// the dispatch fall-through. The message format mirrors reliable's
+// unsupportedServiceError; the sentinel's literal text matches the
+// "unsupported service" prefix so the wrapped output reads cleanly as a
+// single string rather than a sentinel-prefix-plus-message hybrid.
+func unsupportedServiceError(service string) error {
+	valid := observability.AWSServiceNames()
+	body := observability.UnsupportedServiceError(service, valid).Error()
+	// body always starts with "unsupported service" (the literal first
+	// fmt.Fprintf in UnsupportedServiceError); strip it so the wrapped
+	// error reads `unsupported service: "foo" ...` rather than double-
+	// printing the prefix once via %w and once via the body.
+	rest := strings.TrimPrefix(body, "unsupported service")
+	return fmt.Errorf("%w%s", ErrUnsupportedService, rest)
 }

--- a/pkg/observability/discovery/aws/dispatcher_test.go
+++ b/pkg/observability/discovery/aws/dispatcher_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -98,6 +99,33 @@ func TestInspectUnsupportedServiceReturnsSentinel(t *testing.T) {
 	_, err := Inspect(context.Background(), cfg, "definitely-not-a-service", "list-anything", "")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrUnsupportedService))
+}
+
+// TestInspectUnsupportedServiceErrorGoldenFormat pins the wire-format
+// shape of the wrapped sentinel — `errors.Is` only verifies that the
+// sentinel chain is intact, but the rendered string is what reliable's
+// LLM consumer reads as a tool-result envelope (#227). A regression in
+// either half of the dedupe (the sentinel text vs. the upstream
+// observability.UnsupportedServiceError prefix) would silently emit a
+// double-prefixed or partial string while keeping `errors.Is` happy;
+// this assertion fails that loud. The corresponding upstream
+// invariant ("body starts with 'unsupported service'") is locked in
+// pkg/observability/unsupported_test.go.
+func TestInspectUnsupportedServiceErrorGoldenFormat(t *testing.T) {
+	t.Parallel()
+	cfg := aws.Config{Region: "us-east-1"}
+	_, err := Inspect(context.Background(), cfg, "ec3", "list-anything", "")
+	require.Error(t, err)
+
+	// The supported-services list comes straight from the canonical
+	// registry — interpolate it so this golden survives registry
+	// growth without becoming a maintenance burden, while still
+	// pinning every other byte of the wire format.
+	// No trailing period after the services list — pinned by the
+	// upstream golden in pkg/observability/unsupported_test.go.
+	want := `unsupported service: "ec3" (did you mean "ec2"?). Supported services: ` +
+		strings.Join(observability.AWSServiceNames(), ", ")
+	assert.Equal(t, want, err.Error())
 }
 
 func TestInspectGetMetricsRoutesToMetricsPackage(t *testing.T) {

--- a/pkg/observability/discovery/gcp/helpers.go
+++ b/pkg/observability/discovery/gcp/helpers.go
@@ -10,10 +10,13 @@
 // no AWS analogue.
 //
 // Error helpers mirror reliable's inspect_normalize.go::
-// unsupportedActionError / unsupportedServiceError. The "did you mean?"
-// hint is intentionally omitted here — adding the levenshtein dep just
-// for inspector errors isn't worth it; callers see the supported-action
-// list directly.
+// unsupportedActionError / unsupportedServiceError, including the
+// Levenshtein "did you mean?" hint (#227). The hint is consumed by the
+// LLM as part of the tool-result envelope, so the format here matches
+// reliable's byte-for-byte. The actual builders live at
+// observability.UnsupportedActionError /
+// observability.UnsupportedServiceError; these wrappers preserve the
+// per-callsite signatures already in use across this package.
 
 package gcp
 
@@ -21,7 +24,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/observability"
 )
 
 // gcpFilterValueSafe limits caller-supplied label keys/values to a
@@ -32,26 +36,21 @@ import (
 // caller's GCP credentials. #204 P1.
 var gcpFilterValueSafe = regexp.MustCompile(`^[A-Za-z0-9._\-/]{1,128}$`)
 
-// unsupportedActionError builds a descriptive error for an unknown action,
-// listing the supported actions for the service. Mirrors reliable's
-// unsupportedActionError sans the levenshtein "did you mean?" hint.
+// unsupportedActionError builds a descriptive error for an unknown
+// action, listing supported actions and a Levenshtein-based "did you
+// mean?" hint when one is close. Thin wrapper over
+// observability.UnsupportedActionError so per-service callsites can
+// keep passing the human-friendly display name (e.g. "Cloud Run") and
+// their pre-fetched action list without repeating the hint logic.
 func unsupportedActionError(service, action string, validActions []string) error {
-	if len(validActions) == 0 {
-		return fmt.Errorf("unsupported %s action: %q", service, action)
-	}
-	return fmt.Errorf("unsupported %s action: %q. Supported actions: %s",
-		service, action, strings.Join(validActions, ", "))
+	return observability.UnsupportedActionError(service, action, validActions)
 }
 
-// unsupportedServiceError builds a descriptive error for an unknown service,
-// listing the canonical service registry. Mirrors reliable's
-// unsupportedServiceError sans the levenshtein hint.
+// unsupportedServiceError builds a descriptive error for an unknown
+// service, listing the canonical service registry and a "did you mean?"
+// hint. Thin wrapper over observability.UnsupportedServiceError.
 func unsupportedServiceError(service string, validServices []string) error {
-	if len(validServices) == 0 {
-		return fmt.Errorf("unsupported service: %q", service)
-	}
-	return fmt.Errorf("unsupported service: %q. Supported services: %s",
-		service, strings.Join(validServices, ", "))
+	return observability.UnsupportedServiceError(service, validServices)
 }
 
 // parseFilterMap pulls the filter envelope into a map[string]string.

--- a/pkg/observability/unsupported.go
+++ b/pkg/observability/unsupported.go
@@ -1,0 +1,77 @@
+package observability
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/agext/levenshtein"
+)
+
+// didYouMean returns the closest match from valid if the Levenshtein
+// distance is small enough (<=3) to be a plausible typo. Returns "" if
+// nothing is close.
+//
+// We require d > 0 so the helper never suggests the input back at itself
+// — the action / service IS in the valid list, but the dispatcher fell
+// through (a missing switch case is the usual culprit). Without this
+// guard the caller sees `unsupported X action: "foo" (did you mean
+// "foo"?)`, a confusing tell of an internal routing bug rather than a
+// typo. (Ported from reliable internal/agentapi/inspect_normalize.go.)
+func didYouMean(input string, valid []string) string {
+	if len(valid) == 0 {
+		return ""
+	}
+	best := ""
+	bestDist := 4 // threshold: must be <= 3
+	for _, v := range valid {
+		d := levenshtein.Distance(input, v, nil)
+		if d > 0 && d < bestDist {
+			bestDist = d
+			best = v
+		}
+	}
+	return best
+}
+
+// UnsupportedActionError builds the canonical "unsupported X action"
+// error string used by every discovery dispatcher in this package and
+// (post #1252 swap) by reliable. Includes a "did you mean?" hint when a
+// registered action is within Levenshtein distance 3, plus the full list
+// of supported actions and a pointer to the list-actions discovery verb.
+//
+// Format matches reliable's inspect_normalize.go::unsupportedActionError
+// byte-for-byte so tests asserting the hint substring continue to pass
+// once callers swap their local helper for this one. The string is
+// round-tripped to the LLM as a tool-result envelope (see
+// reliable/mcp-server/server/svc/aws_inspect.go and
+// reliable/internal/agentapi/chat_v2.go), so the format is part of the
+// agent-facing contract — don't churn it.
+func UnsupportedActionError(service, action string, validActions []string) error {
+	hint := didYouMean(action, validActions)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "unsupported %s action: %q", service, action)
+	if hint != "" {
+		fmt.Fprintf(&sb, " (did you mean %q?)", hint)
+	}
+	if len(validActions) > 0 {
+		fmt.Fprintf(&sb, ". Supported actions: %s", strings.Join(validActions, ", "))
+	}
+	sb.WriteString(`. Use action "list-actions" to see all supported actions for a service.`)
+	return fmt.Errorf("%s", sb.String())
+}
+
+// UnsupportedServiceError builds the canonical "unsupported service"
+// error string. Same did-you-mean threshold and format conventions as
+// UnsupportedActionError; see that doc comment for the rationale.
+func UnsupportedServiceError(service string, validServices []string) error {
+	hint := didYouMean(service, validServices)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "unsupported service: %q", service)
+	if hint != "" {
+		fmt.Fprintf(&sb, " (did you mean %q?)", hint)
+	}
+	if len(validServices) > 0 {
+		fmt.Fprintf(&sb, ". Supported services: %s", strings.Join(validServices, ", "))
+	}
+	return fmt.Errorf("%s", sb.String())
+}

--- a/pkg/observability/unsupported.go
+++ b/pkg/observability/unsupported.go
@@ -1,6 +1,7 @@
 package observability
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -57,7 +58,11 @@ func UnsupportedActionError(service, action string, validActions []string) error
 		fmt.Fprintf(&sb, ". Supported actions: %s", strings.Join(validActions, ", "))
 	}
 	sb.WriteString(`. Use action "list-actions" to see all supported actions for a service.`)
-	return fmt.Errorf("%s", sb.String())
+	// errors.New (rather than fmt.Errorf with a format string) so the
+	// no-wrap intent is loud: per-cloud dispatchers add their own %w
+	// sentinel wrapping over this body — see
+	// pkg/observability/discovery/aws/dispatcher.go::unsupportedServiceError.
+	return errors.New(sb.String())
 }
 
 // UnsupportedServiceError builds the canonical "unsupported service"
@@ -73,5 +78,5 @@ func UnsupportedServiceError(service string, validServices []string) error {
 	if len(validServices) > 0 {
 		fmt.Fprintf(&sb, ". Supported services: %s", strings.Join(validServices, ", "))
 	}
-	return fmt.Errorf("%s", sb.String())
+	return errors.New(sb.String())
 }

--- a/pkg/observability/unsupported_test.go
+++ b/pkg/observability/unsupported_test.go
@@ -3,6 +3,9 @@ package observability
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDidYouMean(t *testing.T) {
@@ -10,31 +13,44 @@ func TestDidYouMean(t *testing.T) {
 	valid := []string{"describe-instances", "describe-vpcs", "describe-subnets", "get-metrics"}
 
 	tests := []struct {
+		name  string
 		input string
 		want  string
 	}{
-		{"describe-instance", "describe-instances"},  // missing trailing s
-		{"descirbe-instances", "describe-instances"}, // typo
-		{"get-metric", "get-metrics"},                // missing trailing s
-		{"completely-wrong-action", ""},              // too far
-		{"", ""},                                     // empty input
-		{"describe-instances", ""},                   // exact match: d=0 must NOT suggest the input back
+		// Distance-1 boundary (must match) — single-character delete.
+		{"distance_1_drop_trailing_s", "describe-instance", "describe-instances"},
+		{"distance_1_typo_get_metric", "get-metric", "get-metrics"},
+		// Distance-2 (must match) — adjacent transposition.
+		{"distance_2_transposition", "descirbe-instances", "describe-instances"},
+		// Distance-3 boundary (must match). `get-metr` → `get-metrics`
+		// requires inserting "i", "c", "s": exactly 3 edits, all other
+		// candidates are far further.
+		{"distance_3_below_threshold", "get-metr", "get-metrics"},
+		// Distance-4 boundary (must reject). `get-met` → `get-metrics`
+		// requires 4 inserts; all other candidates are >> 4. The
+		// helper's `bestDist := 4; d < bestDist` guard must reject.
+		{"distance_4_above_threshold", "get-met", ""},
+		// Far input: must reject regardless of length.
+		{"far_input_rejects", "completely-wrong-action", ""},
+		// Empty input: trivially d == len(candidate) for every
+		// candidate, so all are >> 3 — must reject.
+		{"empty_input_rejects", "", ""},
+		// d == 0 self-match: the helper MUST NOT suggest the input
+		// back at itself (#227 — confusing tell of an internal
+		// dispatch routing bug, not a typo).
+		{"exact_match_d0_no_self_suggest", "describe-instances", ""},
 	}
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := didYouMean(tt.input, valid)
-			if got != tt.want {
-				t.Errorf("didYouMean(%q, ...) = %q, want %q", tt.input, got, tt.want)
-			}
+			assert.Equal(t, tt.want, got, "didYouMean(%q, ...)", tt.input)
 		})
 	}
 
-	t.Run("nil_valid", func(t *testing.T) {
+	t.Run("nil_valid_returns_empty", func(t *testing.T) {
 		t.Parallel()
-		if got := didYouMean("foo", nil); got != "" {
-			t.Errorf("didYouMean with nil valid = %q, want empty", got)
-		}
+		assert.Equal(t, "", didYouMean("foo", nil))
 	})
 }
 
@@ -42,49 +58,44 @@ func TestUnsupportedActionError(t *testing.T) {
 	t.Parallel()
 	validActions := []string{"describe-instances", "describe-vpcs", "get-metrics"}
 
-	t.Run("with_hint", func(t *testing.T) {
+	// Golden full-string assertions: this string is the wire contract
+	// round-tripped to the LLM as a tool-result envelope. Substring
+	// checks miss byte-level mutations (drop `?`, drop parens, reorder
+	// hint vs supported list, truncate the list-actions pointer to a
+	// bare token). Lock the literal here.
+	t.Run("golden_with_hint", func(t *testing.T) {
 		t.Parallel()
 		err := UnsupportedActionError("EC2", "describe-instance", validActions)
-		msg := err.Error()
-		if !strings.Contains(msg, `unsupported EC2 action: "describe-instance"`) {
-			t.Errorf("expected action in error, got: %s", msg)
-		}
-		if !strings.Contains(msg, `did you mean "describe-instances"`) {
-			t.Errorf("expected did-you-mean hint, got: %s", msg)
-		}
-		if !strings.Contains(msg, "Supported actions:") {
-			t.Errorf("expected supported actions list, got: %s", msg)
-		}
-		if !strings.Contains(msg, "list-actions") {
-			t.Errorf("expected list-actions hint, got: %s", msg)
-		}
+		require.Error(t, err)
+		want := `unsupported EC2 action: "describe-instance" (did you mean "describe-instances"?). Supported actions: describe-instances, describe-vpcs, get-metrics. Use action "list-actions" to see all supported actions for a service.`
+		assert.Equal(t, want, err.Error())
 	})
 
-	t.Run("without_hint", func(t *testing.T) {
+	t.Run("golden_without_hint", func(t *testing.T) {
 		t.Parallel()
 		err := UnsupportedActionError("EC2", "zzzzz-totally-wrong", validActions)
-		msg := err.Error()
-		if strings.Contains(msg, "did you mean") {
-			t.Errorf("should not have did-you-mean for distant input, got: %s", msg)
-		}
-		if !strings.Contains(msg, "Supported actions:") {
-			t.Errorf("expected supported actions list, got: %s", msg)
-		}
+		require.Error(t, err)
+		want := `unsupported EC2 action: "zzzzz-totally-wrong". Supported actions: describe-instances, describe-vpcs, get-metrics. Use action "list-actions" to see all supported actions for a service.`
+		assert.Equal(t, want, err.Error())
 	})
 
-	t.Run("empty_actions", func(t *testing.T) {
+	t.Run("golden_empty_actions", func(t *testing.T) {
 		t.Parallel()
 		err := UnsupportedActionError("EC2", "foo", nil)
-		msg := err.Error()
-		if !strings.Contains(msg, `unsupported EC2 action: "foo"`) {
-			t.Errorf("expected action in error, got: %s", msg)
-		}
-		if strings.Contains(msg, "Supported actions:") {
-			t.Errorf("should not list supported actions when none given, got: %s", msg)
-		}
-		if !strings.Contains(msg, "list-actions") {
-			t.Errorf("list-actions pointer must always be present, got: %s", msg)
-		}
+		require.Error(t, err)
+		want := `unsupported EC2 action: "foo". Use action "list-actions" to see all supported actions for a service.`
+		assert.Equal(t, want, err.Error())
+	})
+
+	// Public-API exercise of the d>0 self-suggest guard: feeding an
+	// exact-match action through the user-facing builder must NOT
+	// produce a `(did you mean "<same>"?)` hint. A regression dropping
+	// the d>0 guard surfaces here as an unexpected hint substring.
+	t.Run("exact_match_no_self_hint", func(t *testing.T) {
+		t.Parallel()
+		err := UnsupportedActionError("EC2", "describe-instances", validActions)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "did you mean")
 	})
 }
 
@@ -92,39 +103,71 @@ func TestUnsupportedServiceError(t *testing.T) {
 	t.Parallel()
 	validServices := []string{"ec2", "rds", "s3", "vpc"}
 
-	t.Run("with_hint", func(t *testing.T) {
+	t.Run("golden_with_hint", func(t *testing.T) {
 		t.Parallel()
 		err := UnsupportedServiceError("ec3", validServices)
-		msg := err.Error()
-		if !strings.Contains(msg, `unsupported service: "ec3"`) {
-			t.Errorf("expected service in error, got: %s", msg)
-		}
-		if !strings.Contains(msg, `did you mean "ec2"`) {
-			t.Errorf("expected did-you-mean hint, got: %s", msg)
-		}
+		require.Error(t, err)
+		// Note: the service builder does NOT append a trailing period
+		// after the supported-services list (reliable's reference
+		// behavior — pin it here so a future "tidiness" tweak doesn't
+		// silently change the wire format).
+		want := `unsupported service: "ec3" (did you mean "ec2"?). Supported services: ec2, rds, s3, vpc`
+		assert.Equal(t, want, err.Error())
 	})
 
-	t.Run("without_hint", func(t *testing.T) {
+	t.Run("golden_without_hint", func(t *testing.T) {
 		t.Parallel()
 		err := UnsupportedServiceError("zzznotaservice", validServices)
-		msg := err.Error()
-		if strings.Contains(msg, "did you mean") {
-			t.Errorf("should not have did-you-mean for distant input, got: %s", msg)
-		}
-		if !strings.Contains(msg, "Supported services:") {
-			t.Errorf("expected supported services list, got: %s", msg)
-		}
+		require.Error(t, err)
+		want := `unsupported service: "zzznotaservice". Supported services: ec2, rds, s3, vpc`
+		assert.Equal(t, want, err.Error())
 	})
 
-	t.Run("empty_services", func(t *testing.T) {
+	t.Run("golden_empty_services", func(t *testing.T) {
 		t.Parallel()
 		err := UnsupportedServiceError("foo", nil)
-		msg := err.Error()
-		if !strings.Contains(msg, `unsupported service: "foo"`) {
-			t.Errorf("expected service in error, got: %s", msg)
-		}
-		if strings.Contains(msg, "Supported services:") {
-			t.Errorf("should not list supported services when none given, got: %s", msg)
+		require.Error(t, err)
+		want := `unsupported service: "foo"`
+		assert.Equal(t, want, err.Error())
+	})
+
+	// Pass a single-candidate list so the only possible match is the
+	// input itself; the d>0 guard must fire and produce no hint. Using
+	// the broader validServices set wouldn't isolate the guard because
+	// "ec2" is within d=3 of "rds"/"s3"/"vpc" (3-char strings of low
+	// alphabet overlap), so a regression dropping `d > 0` would still
+	// emit *some* hint via a non-self candidate.
+	t.Run("exact_match_no_self_hint", func(t *testing.T) {
+		t.Parallel()
+		err := UnsupportedServiceError("ec2", []string{"ec2"})
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "did you mean")
+	})
+
+	// Cross-package invariant: pkg/observability/discovery/aws/
+	// dispatcher.go::unsupportedServiceError relies on the literal
+	// "unsupported service" prefix to dedupe the sentinel + body via
+	// strings.TrimPrefix. If this prefix changes, the wrapped AWS
+	// sentinel error silently emits a malformed string (sentinel
+	// errors.Is keeps working; substring tests keep passing). Pin the
+	// prefix here so the cross-package coupling fails loudly instead.
+	t.Run("starts_with_canonical_prefix_for_sentinel_wrapping", func(t *testing.T) {
+		t.Parallel()
+		for _, sample := range []struct {
+			service string
+			valid   []string
+		}{
+			{"ec3", validServices},
+			{"zzznotaservice", validServices},
+			{"foo", nil},
+		} {
+			err := UnsupportedServiceError(sample.service, sample.valid)
+			require.Error(t, err)
+			assert.True(t,
+				strings.HasPrefix(err.Error(), "unsupported service"),
+				"discovery/aws/dispatcher.go::unsupportedServiceError relies on this exact prefix; got: %q",
+				err.Error(),
+			)
 		}
 	})
 }

--- a/pkg/observability/unsupported_test.go
+++ b/pkg/observability/unsupported_test.go
@@ -1,0 +1,130 @@
+package observability
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDidYouMean(t *testing.T) {
+	t.Parallel()
+	valid := []string{"describe-instances", "describe-vpcs", "describe-subnets", "get-metrics"}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"describe-instance", "describe-instances"},  // missing trailing s
+		{"descirbe-instances", "describe-instances"}, // typo
+		{"get-metric", "get-metrics"},                // missing trailing s
+		{"completely-wrong-action", ""},              // too far
+		{"", ""},                                     // empty input
+		{"describe-instances", ""},                   // exact match: d=0 must NOT suggest the input back
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			got := didYouMean(tt.input, valid)
+			if got != tt.want {
+				t.Errorf("didYouMean(%q, ...) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("nil_valid", func(t *testing.T) {
+		t.Parallel()
+		if got := didYouMean("foo", nil); got != "" {
+			t.Errorf("didYouMean with nil valid = %q, want empty", got)
+		}
+	})
+}
+
+func TestUnsupportedActionError(t *testing.T) {
+	t.Parallel()
+	validActions := []string{"describe-instances", "describe-vpcs", "get-metrics"}
+
+	t.Run("with_hint", func(t *testing.T) {
+		t.Parallel()
+		err := UnsupportedActionError("EC2", "describe-instance", validActions)
+		msg := err.Error()
+		if !strings.Contains(msg, `unsupported EC2 action: "describe-instance"`) {
+			t.Errorf("expected action in error, got: %s", msg)
+		}
+		if !strings.Contains(msg, `did you mean "describe-instances"`) {
+			t.Errorf("expected did-you-mean hint, got: %s", msg)
+		}
+		if !strings.Contains(msg, "Supported actions:") {
+			t.Errorf("expected supported actions list, got: %s", msg)
+		}
+		if !strings.Contains(msg, "list-actions") {
+			t.Errorf("expected list-actions hint, got: %s", msg)
+		}
+	})
+
+	t.Run("without_hint", func(t *testing.T) {
+		t.Parallel()
+		err := UnsupportedActionError("EC2", "zzzzz-totally-wrong", validActions)
+		msg := err.Error()
+		if strings.Contains(msg, "did you mean") {
+			t.Errorf("should not have did-you-mean for distant input, got: %s", msg)
+		}
+		if !strings.Contains(msg, "Supported actions:") {
+			t.Errorf("expected supported actions list, got: %s", msg)
+		}
+	})
+
+	t.Run("empty_actions", func(t *testing.T) {
+		t.Parallel()
+		err := UnsupportedActionError("EC2", "foo", nil)
+		msg := err.Error()
+		if !strings.Contains(msg, `unsupported EC2 action: "foo"`) {
+			t.Errorf("expected action in error, got: %s", msg)
+		}
+		if strings.Contains(msg, "Supported actions:") {
+			t.Errorf("should not list supported actions when none given, got: %s", msg)
+		}
+		if !strings.Contains(msg, "list-actions") {
+			t.Errorf("list-actions pointer must always be present, got: %s", msg)
+		}
+	})
+}
+
+func TestUnsupportedServiceError(t *testing.T) {
+	t.Parallel()
+	validServices := []string{"ec2", "rds", "s3", "vpc"}
+
+	t.Run("with_hint", func(t *testing.T) {
+		t.Parallel()
+		err := UnsupportedServiceError("ec3", validServices)
+		msg := err.Error()
+		if !strings.Contains(msg, `unsupported service: "ec3"`) {
+			t.Errorf("expected service in error, got: %s", msg)
+		}
+		if !strings.Contains(msg, `did you mean "ec2"`) {
+			t.Errorf("expected did-you-mean hint, got: %s", msg)
+		}
+	})
+
+	t.Run("without_hint", func(t *testing.T) {
+		t.Parallel()
+		err := UnsupportedServiceError("zzznotaservice", validServices)
+		msg := err.Error()
+		if strings.Contains(msg, "did you mean") {
+			t.Errorf("should not have did-you-mean for distant input, got: %s", msg)
+		}
+		if !strings.Contains(msg, "Supported services:") {
+			t.Errorf("expected supported services list, got: %s", msg)
+		}
+	})
+
+	t.Run("empty_services", func(t *testing.T) {
+		t.Parallel()
+		err := UnsupportedServiceError("foo", nil)
+		msg := err.Error()
+		if !strings.Contains(msg, `unsupported service: "foo"`) {
+			t.Errorf("expected service in error, got: %s", msg)
+		}
+		if strings.Contains(msg, "Supported services:") {
+			t.Errorf("should not list supported services when none given, got: %s", msg)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Port reliable's Levenshtein \"did you mean?\" hint from `internal/agentapi/inspect_normalize.go` into `pkg/observability` (#227). The hint is consumed by the LLM as a tool-result envelope (see `reliable/mcp-server/server/svc/aws_inspect.go` and `reliable/internal/agentapi/chat_v2.go`) and locked by reliable's tests at `internal/agentapi/inspect_normalize_test.go:54-198` — when reliable bumps presets and swaps to the upstream helpers as part of #1252 Phase B, the hint had to be there or agent self-correction after typo'd actions silently regressed.

- New exported `observability.UnsupportedActionError` / `observability.UnsupportedServiceError` whose rendered strings match reliable's byte-for-byte (so reliable's existing tests pass when retargeted upstream).
- AWS dispatcher: `ErrUnsupportedService` text changes from `\"unsupported aws service\"` to `\"unsupported service\"` so the wrapped output reads cleanly via `%w`. The local `unsupportedActionError` and a new `unsupportedServiceError` delegate to the upstream builders.
- GCP helpers: thin wrappers that delegate; per-callsite signatures unchanged so no per-service inspector touched.
- `agext/levenshtein` was already a direct dep (used by `pkg/composer/validate.go`), so no `go.mod` / `go.sum` churn.

The wire format is locked by full-string golden assertions in `pkg/observability/unsupported_test.go` and the wrapped-sentinel form is locked in `dispatcher_test.go::TestInspectUnsupportedServiceErrorGoldenFormat`. The `bestDist` threshold gets explicit d=3 (must match) / d=4 (must reject) boundary cases.

## Heads-up

The AWS sentinel text change (`\"unsupported aws service\"` → `\"unsupported service\"`) is technically observable to anyone string-matching the sentinel. In-repo only `errors.Is` is used; if any external consumer (dashboards, alerts) does literal-text matching, they'll need to update.

## Test plan

- [x] `go test -count=1 ./pkg/observability/...` — green
- [x] `go vet ./...` and `go build ./...` — green
- [x] All 8 lint scripts under `tests/lint-*.sh` — PASS
- [x] `terraform fmt -check -recursive` — clean
- [x] Golden assertions exercise: with-hint, without-hint, empty list, exact-match no-self-suggest
- [x] Threshold boundary: d=1, d=2, d=3 (match), d=4 (reject), empty, far input
- [ ] CI green on this PR
- [ ] Follow-up: tag `v0.8.2` so reliable can bump for #1252 PR 2 (out of scope for this PR — use `/release` after merge)

## Review notes

- `/review` findings: all P1s resolved (golden full-string lock, d=3/d=4 boundaries, cross-package prefix invariant). Drive-by P2/P3s addressed: `errors.New` for no-wrap intent, named subtests, testify, tighter doc comment.
- `qa-professor` findings: all P0/P1 addressed in the second commit; the wire contract is now locked via goldens, the d>0 self-suggest guard is exercised at the public API surface with single-candidate lists (so the guard is isolated rather than masked by a near-by non-self candidate).

Closes #227
Refs reliable#1252 (Phase B drift audit)