### PR TITLE
feat(observability): add filter.EnsureProject helper

### DIFF
--- a/pkg/observability/filter/project.go
+++ b/pkg/observability/filter/project.go
@@ -34,15 +34,16 @@ func Project(filters string) string {
 // before calling this helper.
 //
 // Behaviour:
-//   - project == ""               → return filters unchanged
-//   - filters already has project → return filters unchanged
-//   - filters == ""               → return {"project":<name>}
-//   - filters has other keys      → merge project=<name> in
-//   - filters is unparseable JSON → return {"project":<name>}
-//
-// The parse contract matches Project(): values are treated as strings,
-// so mixed-type filter JSON round-trips identically to how Project()
-// already (silently) handles it.
+//   - project == ""                   → return filters unchanged
+//   - filters has a non-empty project → return filters unchanged
+//     (an explicit "project":"" is treated as no project set and is
+//     overwritten — Project() reports such filters as having no project)
+//   - filters == ""                   → return {"project":<name>}
+//   - filters is an object of strings → merge project=<name> in
+//   - filters is unparseable, JSON null,
+//     or contains any non-string value → return {"project":<name>}
+//     (the original other-keys are dropped; the parse contract matches
+//     Project(), which treats values as strings)
 func EnsureProject(filters, project string) string {
 	if project == "" {
 		return filters
@@ -52,13 +53,14 @@ func EnsureProject(filters, project string) string {
 	}
 	m := make(map[string]string)
 	if filters != "" {
-		_ = json.Unmarshal([]byte(filters), &m)
+		if err := json.Unmarshal([]byte(filters), &m); err != nil || m == nil {
+			// Drop on any parse failure or JSON null — order-independent
+			// fallback to a fresh map so output is deterministic.
+			m = make(map[string]string)
+		}
 	}
 	m["project"] = project
-	b, err := json.Marshal(m)
-	if err != nil {
-		return filters
-	}
+	b, _ := json.Marshal(m)
 	return string(b)
 }
 

--- a/pkg/observability/filter/project.go
+++ b/pkg/observability/filter/project.go
@@ -3,10 +3,10 @@
 // are scoped via the `Project=<name>` tag (kv- or map-shaped depending
 // on the service); GCP resources via the `project=<name>` label.
 //
-// Ported from reliable internal/agentapi/resource_filter.go (#204).
-// `ensureProjectFilter` is intentionally NOT ported — it depends on
-// reliable's session-ID → project-name translation which has no
-// analogue here. Callers pass the project name directly.
+// Ported from reliable internal/agentapi/resource_filter.go (#204, #228).
+// The session-ID → project-name translation that lives reliable-side
+// is intentionally NOT ported; callers translate session/tenant
+// identifiers into project names before calling EnsureProject.
 package filter
 
 import (
@@ -26,6 +26,40 @@ func Project(filters string) string {
 		return ""
 	}
 	return m["project"]
+}
+
+// EnsureProject injects "project"=<name> into a JSON filters string when
+// no project filter is already set. Pure filter manipulation; callers
+// that translate a session/tenant identifier into a project name do so
+// before calling this helper.
+//
+// Behaviour:
+//   - project == ""               → return filters unchanged
+//   - filters already has project → return filters unchanged
+//   - filters == ""               → return {"project":<name>}
+//   - filters has other keys      → merge project=<name> in
+//   - filters is unparseable JSON → return {"project":<name>}
+//
+// The parse contract matches Project(): values are treated as strings,
+// so mixed-type filter JSON round-trips identically to how Project()
+// already (silently) handles it.
+func EnsureProject(filters, project string) string {
+	if project == "" {
+		return filters
+	}
+	if Project(filters) != "" {
+		return filters
+	}
+	m := make(map[string]string)
+	if filters != "" {
+		_ = json.Unmarshal([]byte(filters), &m)
+	}
+	m["project"] = project
+	b, err := json.Marshal(m)
+	if err != nil {
+		return filters
+	}
+	return string(b)
 }
 
 // ProjectTagFilter returns EC2-style tag filters for the Project tag.

--- a/pkg/observability/filter/project_test.go
+++ b/pkg/observability/filter/project_test.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,75 @@ func TestProject(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.want, Project(tt.filters))
+		})
+	}
+}
+
+func TestEnsureProject(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		filters     string
+		project     string
+		wantProject string            // value Project() should return on the output
+		wantOther   map[string]string // other keys we expect preserved (nil = none)
+		wantSame    bool              // when true, output must equal input verbatim
+	}{
+		{
+			name:     "empty project + empty filters → unchanged",
+			filters:  "",
+			project:  "",
+			wantSame: true,
+		},
+		{
+			name:     "empty project + non-empty filters → unchanged",
+			filters:  `{"zone":"us-east-1a"}`,
+			project:  "",
+			wantSame: true,
+		},
+		{
+			name:        "empty filters + project → fresh JSON",
+			filters:     "",
+			project:     "io-abc123",
+			wantProject: "io-abc123",
+		},
+		{
+			name:        "filters already has project → unchanged",
+			filters:     `{"project":"io-existing"}`,
+			project:     "io-override",
+			wantSame:    true,
+			wantProject: "io-existing",
+		},
+		{
+			name:        "filters with other keys, no project → merge",
+			filters:     `{"zone":"us-east-1a"}`,
+			project:     "io-test",
+			wantProject: "io-test",
+			wantOther:   map[string]string{"zone": "us-east-1a"},
+		},
+		{
+			name:        "unparseable JSON → fresh JSON, dropping bad input",
+			filters:     "not-json",
+			project:     "io-recover",
+			wantProject: "io-recover",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := EnsureProject(tt.filters, tt.project)
+			if tt.wantSame {
+				assert.Equal(t, tt.filters, got)
+			}
+			assert.Equal(t, tt.wantProject, Project(got),
+				"Project() on output should match wantProject")
+			if tt.wantOther != nil {
+				var parsed map[string]string
+				assert.NoError(t, json.Unmarshal([]byte(got), &parsed))
+				for k, v := range tt.wantOther {
+					assert.Equal(t, v, parsed[k], "key %q should be preserved", k)
+				}
+			}
 		})
 	}
 }

--- a/pkg/observability/filter/project_test.go
+++ b/pkg/observability/filter/project_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProject(t *testing.T) {
@@ -31,12 +32,18 @@ func TestProject(t *testing.T) {
 func TestEnsureProject(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name        string
-		filters     string
-		project     string
-		wantProject string            // value Project() should return on the output
-		wantOther   map[string]string // other keys we expect preserved (nil = none)
-		wantSame    bool              // when true, output must equal input verbatim
+		name string
+		// Inputs.
+		filters string
+		project string
+		// Exactly one of the assertion modes below applies per row:
+		// - wantSame=true asserts byte-equality with `filters`; wantProject
+		//   and wantOther are ignored.
+		// - otherwise wantProject is the expected Project(out), and the
+		//   parsed output map must equal {project:<wantProject>} ∪ wantOther.
+		wantSame    bool
+		wantProject string
+		wantOther   map[string]string
 	}{
 		{
 			name:     "empty project + empty filters → unchanged",
@@ -57,11 +64,16 @@ func TestEnsureProject(t *testing.T) {
 			wantProject: "io-abc123",
 		},
 		{
-			name:        "filters already has project → unchanged",
-			filters:     `{"project":"io-existing"}`,
-			project:     "io-override",
-			wantSame:    true,
-			wantProject: "io-existing",
+			name:     "filters already has project → unchanged (single key)",
+			filters:  `{"project":"io-existing"}`,
+			project:  "io-override",
+			wantSame: true,
+		},
+		{
+			name:     "filters already has project → unchanged (with extra keys)",
+			filters:  `{"project":"io-existing","zone":"us-east-1a"}`,
+			project:  "io-override",
+			wantSame: true,
 		},
 		{
 			name:        "filters with other keys, no project → merge",
@@ -71,10 +83,31 @@ func TestEnsureProject(t *testing.T) {
 			wantOther:   map[string]string{"zone": "us-east-1a"},
 		},
 		{
-			name:        "unparseable JSON → fresh JSON, dropping bad input",
+			name:        "explicit empty project value → overwrite",
+			filters:     `{"project":"","zone":"us-east-1a"}`,
+			project:     "io-real",
+			wantProject: "io-real",
+			wantOther:   map[string]string{"zone": "us-east-1a"},
+		},
+		{
+			name:        "unparseable JSON → fresh JSON, drop bad input",
 			filters:     "not-json",
 			project:     "io-recover",
 			wantProject: "io-recover",
+		},
+		{
+			name:        "literal JSON null → fresh JSON (no panic)",
+			filters:     "null",
+			project:     "io-recover",
+			wantProject: "io-recover",
+		},
+		{
+			name:        "mixed-type values → fresh JSON, all original keys dropped",
+			filters:     `{"zone":"us-east-1a","limit":10}`,
+			project:     "io-test",
+			wantProject: "io-test",
+			// wantOther nil: the contract is order-independent reset on
+			// any parse failure, so "zone" is dropped along with "limit".
 		},
 	}
 	for _, tt := range tests {
@@ -83,15 +116,19 @@ func TestEnsureProject(t *testing.T) {
 			got := EnsureProject(tt.filters, tt.project)
 			if tt.wantSame {
 				assert.Equal(t, tt.filters, got)
+				return
 			}
 			assert.Equal(t, tt.wantProject, Project(got),
 				"Project() on output should match wantProject")
-			if tt.wantOther != nil {
-				var parsed map[string]string
-				assert.NoError(t, json.Unmarshal([]byte(got), &parsed))
-				for k, v := range tt.wantOther {
-					assert.Equal(t, v, parsed[k], "key %q should be preserved", k)
-				}
+			var parsed map[string]string
+			require.NoError(t, json.Unmarshal([]byte(got), &parsed),
+				"output must be parseable as map[string]string")
+			// Output must contain exactly project + wantOther — no
+			// stray injected keys, no missing ones.
+			assert.Len(t, parsed, len(tt.wantOther)+1,
+				"output map should have exactly len(wantOther)+1 keys")
+			for k, v := range tt.wantOther {
+				assert.Equal(t, v, parsed[k], "key %q should be preserved", k)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Adds `filter.EnsureProject(filters, project string) string` to `pkg/observability/filter` — pure JSON manipulation that injects `"project":<name>` into a filters string when none is set.
- Lifts the JSON half of reliable's `ensureProjectFilter` (`internal/agentapi/resource_filter.go:120-146`) upstream so every cloud inspector + metric-fetch wrapper can share one project-injection codepath. Reliable keeps the session-ID → project-name translation reliable-side; once a presets release with this helper is cut, reliable's wrapper drops to ~3 lines (resolve → skip demo → delegate).
- Parse contract uses `map[string]string` (matching the existing `Project()` extractor) rather than the issue body's `map[string]any` — keeping the two helpers' parse contracts aligned. Mixed-type or unparseable JSON falls back to a fresh `{"project":<name>}` so output is order-independent and never panics on `"null"` input.

## Test plan

- [x] `go test ./pkg/observability/filter/... -count=1` — 10 `TestEnsureProject` subtests pass; existing `TestProject` and the AWS-shape gate remain green.
- [x] `go vet ./pkg/observability/...` clean.
- [x] `gofmt -l pkg/observability/filter/` clean.
- [x] `terraform fmt -check -recursive` clean (no Terraform touched, sanity check).
- [x] All 4 static lint scripts (`lint-project-tag.sh`, `lint-project-label.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`) PASS.

## Review notes

- `/review` findings: 1 P1 (panic on `"null"`), 3 P2 (silent unmarshal drop without comment, `assert.NoError`→`require.NoError`, missing edge-case tests), 1 P3 (dead `json.Marshal` error branch). All resolved on this branch.
- `qa-professor` findings: critical "no length invariant" gap, major "missing project + extra-keys row" mutation gap, major "order-dependent partial-unmarshal" contract issue, missing `{"project":""}` edge case. All resolved by tightening the contract (any parse error → fresh map) and adding `assert.Len` plus three new test rows.
- Deferred follow-ups (out of scope here):
  - Replacing reliable's `ensureProjectFilter` body with a call to this helper — separate downstream PR after a presets release tag.
  - Tagging `v0.8.2` (or higher) so reliable can bump — `/release` skill, separate PR.
  - Auditing `assert.Len` → `require.Len` in the rest of `project_test.go` (qa-professor noted a few existing spots that index after a length assertion; pre-existing, not part of this change).

Fixes #228