### PR TITLE
feat(observability): pivot EKS metrics onto EC2 InstanceId via cluster tag (#231)

### DIFF
--- a/pkg/observability/component_metrics.go
+++ b/pkg/observability/component_metrics.go
@@ -34,8 +34,15 @@ var ComponentMetricsMapping = map[composer.ComponentKey]ComponentMetricsBinding{
 	// Service-level metrics need a ClusterName+ServiceName dimension join,
 	// which discovery does not resolve. Use list-services via the MCP
 	// inspector directly for a service inventory.
-	composer.KeyAWSECS:                  {Service: "ecs", Action: "list-clusters"},
-	composer.KeyAWSEKS:                  {Service: "eks", Action: "list-clusters"},
+	composer.KeyAWSECS: {Service: "ecs", Action: "list-clusters"},
+	// EKS metrics are pivoted onto EC2 InstanceId via the
+	// `eks:cluster-name` tag (#231 Option A) — list-nodes returns the
+	// cluster's underlying instance IDs so the panel can query AWS/EC2
+	// CPUUtilization per node. The list-clusters action is still
+	// available via the dispatcher for callers that need a cluster
+	// inventory; the panel-default just doesn't use it because the
+	// AWS/EKS namespace publishes nothing usable on stock deployments.
+	composer.KeyAWSEKS:                  {Service: "eks", Action: "list-nodes"},
 	composer.KeyAWSRDS:                  {Service: "rds", Action: "describe-db-instances"},
 	composer.KeyAWSElastiCache:          {Service: "elasticache", Action: "describe-cache-clusters"},
 	composer.KeyAWSS3:                   {Service: "s3", Action: "list-buckets"},

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -237,14 +237,29 @@ var awsServiceMetrics = map[string]AWSObs{
 		},
 	},
 	"eks": {
-		Namespace:     "AWS/EKS",
-		DimensionName: "ClusterName",
+		// EKS metrics are pivoted onto AWS/EC2 InstanceId via the
+		// AWS-managed `eks:cluster-name` tag: the orchestrator's
+		// metrics-discovery action is `list-nodes` (see
+		// ComponentMetricsMapping[KeyAWSEKS] in component_metrics.go),
+		// which returns the cluster's underlying EC2 instance IDs.
+		// Querying CPUUtilization on those instances surfaces real data
+		// on every existing EKS deployment (#231 Option A).
+		//
+		// AWS/EKS itself only publishes a small set of cluster-level
+		// metrics (cluster_failed_node_count, control-plane API server
+		// latency); the node_cpu_utilization / pod_cpu_utilization
+		// names previously listed here are ContainerInsights metrics
+		// that only publish when the amazon-cloudwatch-observability
+		// addon is installed in-cluster — the aws/eks_nodegroup preset
+		// does not install it today, so those queries returned zero
+		// datapoints on every deployment and the panel rendered "no
+		// observable resources". A follow-up issue (#231 Option B)
+		// covers shipping the addon and pivoting back to
+		// ContainerInsights for richer node + pod metrics.
+		Namespace:     "AWS/EC2",
+		DimensionName: "InstanceId",
 		Metrics: []AWSMetricSpec{
-			{Name: "cluster_failed_node_count", Stat: "Maximum"},
-			{Name: "node_cpu_utilization", Stat: "Average"},
-			{Name: "node_memory_utilization", Stat: "Average"},
-			{Name: "pod_cpu_utilization", Stat: "Average"},
-			{Name: "pod_memory_utilization", Stat: "Average"},
+			{Name: "CPUUtilization", Stat: "Average"},
 		},
 	},
 	"elasticache": {

--- a/pkg/observability/discovery/aws/compute.go
+++ b/pkg/observability/discovery/aws/compute.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
@@ -339,6 +340,8 @@ func inspectEKS(ctx context.Context, cfg aws.Config, action, filters string) (an
 		// callers that need a single cluster's details know to call
 		// DescribeCluster directly with the cluster name.
 		return nil, fmt.Errorf("describe-cluster requires a cluster name in filters (not yet implemented)")
+	case "list-nodes":
+		return listEKSNodeInstances(ctx, eks.NewFromConfig(cfg), ec2.NewFromConfig(cfg), project)
 	case "get-metrics":
 		return metricsRouted("eks")
 	default:
@@ -351,6 +354,73 @@ func inspectEKS(ctx context.Context, cfg aws.Config, action, filters string) (an
 		// #204 P2.
 		return nil, unsupportedActionError("eks", action)
 	}
+}
+
+// ec2InstancesClient is the subset of the ec2 SDK used by
+// listEKSNodeInstances. Narrow per-handler interface so test fakes
+// only implement what the helper calls — same pattern used by the
+// other per-service inspector clients in this file.
+type ec2InstancesClient interface {
+	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+}
+
+// listEKSNodeInstances pivots EKS metric discovery from cluster-name
+// to EC2 InstanceId via the AWS-managed `eks:cluster-name` tag, so the
+// observability panel can query AWS/EC2 CPUUtilization per node instead
+// of the unpopulated AWS/EKS namespace (#231 / Option A — works on
+// existing deployments without the amazon-cloudwatch-observability
+// addon).
+//
+// Lists clusters by Project tag, then for each cluster lists EC2
+// instances tagged Project=<project> AND eks:cluster-name=<cluster>
+// (an AWS-managed tag the EKS managed node group attaches to its
+// underlying ASG / EC2 instances), returning the deduped flat list of
+// instance IDs. Per-cluster errors log+skip — partial result beats
+// empty when one cluster has an IAM denial or throttle, matching the
+// contract every other tag-fan-out helper in this package follows.
+//
+// The ContainerInsights namespace would surface richer node + pod
+// metrics but requires the amazon-cloudwatch-observability addon,
+// which our aws/eks_nodegroup preset does not install today (#231
+// follow-up Option B).
+func listEKSNodeInstances(ctx context.Context, eksClient eksClustersClient, ec2Client ec2InstancesClient, project string) ([]string, error) {
+	clusters, err := filterEKSClustersByProjectTag(ctx, eksClient, project)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{})
+	var instances []string
+	for _, cluster := range clusters {
+		filters := []ec2types.Filter{{
+			Name:   aws.String("tag:eks:cluster-name"),
+			Values: []string{cluster},
+		}}
+		if project != "" {
+			filters = append(filters, ec2types.Filter{
+				Name:   aws.String("tag:Project"),
+				Values: []string{project},
+			})
+		}
+		out, descErr := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{Filters: filters})
+		if descErr != nil {
+			log.Printf("[eks list-nodes] cluster=%s DescribeInstances skip: %v", cluster, descErr)
+			continue
+		}
+		for _, res := range out.Reservations {
+			for _, inst := range res.Instances {
+				if inst.InstanceId == nil {
+					continue
+				}
+				id := aws.ToString(inst.InstanceId)
+				if _, dup := seen[id]; dup {
+					continue
+				}
+				seen[id] = struct{}{}
+				instances = append(instances, id)
+			}
+		}
+	}
+	return instances, nil
 }
 
 // filterEKSClustersByProjectTag lists clusters and, when project!="",

--- a/pkg/observability/discovery/aws/compute_test.go
+++ b/pkg/observability/discovery/aws/compute_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
@@ -245,6 +246,201 @@ func TestFilterEKSClustersByProjectTag_DescribeErrorSkips(t *testing.T) {
 	got, err := filterEKSClustersByProjectTag(context.Background(), client, "my-stack")
 	require.NoError(t, err)
 	assert.Empty(t, got)
+}
+
+// --- EC2 fake (for EKS list-nodes fan-out) ---
+
+// fakeEC2InstancesClient records the filters it observes so tests can
+// assert per-cluster filter shape, and returns per-cluster
+// DescribeInstances results keyed off the `tag:eks:cluster-name`
+// filter value. errByCluster lets a test simulate IAM denials /
+// throttles on a subset of clusters to exercise the log+skip path.
+type fakeEC2InstancesClient struct {
+	reservationsByCluster map[string][]ec2types.Reservation
+	errByCluster          map[string]error
+	calls                 []ec2.DescribeInstancesInput
+}
+
+func (f *fakeEC2InstancesClient) DescribeInstances(_ context.Context, in *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	if in != nil {
+		f.calls = append(f.calls, *in)
+	}
+	cluster := ""
+	for _, ft := range in.Filters {
+		if aws.ToString(ft.Name) == "tag:eks:cluster-name" && len(ft.Values) > 0 {
+			cluster = ft.Values[0]
+			break
+		}
+	}
+	if err, ok := f.errByCluster[cluster]; ok {
+		return nil, err
+	}
+	return &ec2.DescribeInstancesOutput{Reservations: f.reservationsByCluster[cluster]}, nil
+}
+
+// instanceReservation builds the [Reservation{Instance{InstanceId}}]
+// shape the EC2 SDK returns for the test fakes.
+func instanceReservation(ids ...string) []ec2types.Reservation {
+	res := ec2types.Reservation{}
+	for _, id := range ids {
+		res.Instances = append(res.Instances, ec2types.Instance{InstanceId: aws.String(id)})
+	}
+	return []ec2types.Reservation{res}
+}
+
+func TestListEKSNodeInstances_ScopedByProjectAndClusterTag(t *testing.T) {
+	t.Parallel()
+	// Two clusters; only foo carries the matching Project tag, so
+	// filterEKSClustersByProjectTag prunes bar before the EC2 fan-out
+	// even gets a chance to ask. The EC2 fake then returns foo's two
+	// node instances scoped by the eks:cluster-name=foo tag.
+	eksFake := &fakeEKSClient{
+		listClustersOut: &eks.ListClustersOutput{Clusters: []string{"foo", "bar"}},
+		describeByName: map[string]*eks.DescribeClusterOutput{
+			"foo": {Cluster: &ekstypes.Cluster{
+				Name: aws.String("foo"),
+				Tags: map[string]string{"Project": "my-stack"},
+			}},
+			"bar": {Cluster: &ekstypes.Cluster{
+				Name: aws.String("bar"),
+				Tags: map[string]string{"Project": "other"},
+			}},
+		},
+	}
+	ec2Fake := &fakeEC2InstancesClient{
+		reservationsByCluster: map[string][]ec2types.Reservation{
+			"foo": instanceReservation("i-aaaa", "i-bbbb"),
+			"bar": instanceReservation("i-cccc"), // must NOT appear: cluster pruned upstream
+		},
+	}
+
+	got, err := listEKSNodeInstances(context.Background(), eksFake, ec2Fake, "my-stack")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"i-aaaa", "i-bbbb"}, got)
+
+	// Filter-shape assertion: every EC2 call must carry both
+	// tag:eks:cluster-name AND tag:Project so the EC2 API enforces the
+	// project scope server-side (defense in depth — the EKS-side
+	// project filter could be bypassed if a cluster is mis-tagged).
+	require.Len(t, ec2Fake.calls, 1, "bar must be pruned upstream so EC2 is only called once")
+	filters := ec2Fake.calls[0].Filters
+	require.Len(t, filters, 2)
+	assert.Equal(t, "tag:eks:cluster-name", aws.ToString(filters[0].Name))
+	assert.Equal(t, []string{"foo"}, filters[0].Values)
+	assert.Equal(t, "tag:Project", aws.ToString(filters[1].Name))
+	assert.Equal(t, []string{"my-stack"}, filters[1].Values)
+}
+
+func TestListEKSNodeInstances_EmptyProjectFansOutWithoutProjectFilter(t *testing.T) {
+	t.Parallel()
+	// Empty project: every cluster passes the EKS-side filter, and the
+	// EC2 fan-out only carries the tag:eks:cluster-name filter (no
+	// project clause). Mirrors the contract used by every other
+	// per-service inspector — empty filter means "everything visible
+	// to the credentials".
+	eksFake := &fakeEKSClient{
+		listClustersOut: &eks.ListClustersOutput{Clusters: []string{"foo"}},
+	}
+	ec2Fake := &fakeEC2InstancesClient{
+		reservationsByCluster: map[string][]ec2types.Reservation{
+			"foo": instanceReservation("i-1234"),
+		},
+	}
+	got, err := listEKSNodeInstances(context.Background(), eksFake, ec2Fake, "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"i-1234"}, got)
+
+	require.Len(t, ec2Fake.calls, 1)
+	filters := ec2Fake.calls[0].Filters
+	require.Len(t, filters, 1, "no project → no tag:Project filter")
+	assert.Equal(t, "tag:eks:cluster-name", aws.ToString(filters[0].Name))
+}
+
+func TestListEKSNodeInstances_PerClusterErrorLogsAndSkips(t *testing.T) {
+	t.Parallel()
+	// Two project-matched clusters; EC2 denies one. The helper logs
+	// and continues — partial result beats empty when one cluster has
+	// an IAM denial or throttle, matching every other tag-fan-out
+	// helper in this package.
+	eksFake := &fakeEKSClient{
+		listClustersOut: &eks.ListClustersOutput{Clusters: []string{"foo", "bar"}},
+		describeByName: map[string]*eks.DescribeClusterOutput{
+			"foo": {Cluster: &ekstypes.Cluster{
+				Name: aws.String("foo"),
+				Tags: map[string]string{"Project": "my-stack"},
+			}},
+			"bar": {Cluster: &ekstypes.Cluster{
+				Name: aws.String("bar"),
+				Tags: map[string]string{"Project": "my-stack"},
+			}},
+		},
+	}
+	ec2Fake := &fakeEC2InstancesClient{
+		reservationsByCluster: map[string][]ec2types.Reservation{
+			"foo": instanceReservation("i-aaaa"),
+		},
+		errByCluster: map[string]error{
+			"bar": errors.New("denied"),
+		},
+	}
+
+	got, err := listEKSNodeInstances(context.Background(), eksFake, ec2Fake, "my-stack")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"i-aaaa"}, got)
+}
+
+func TestListEKSNodeInstances_DedupesInstanceIDsAcrossClusters(t *testing.T) {
+	t.Parallel()
+	// Same instance reported under two clusters. Doesn't happen in
+	// practice (an EC2 instance carries exactly one
+	// eks:cluster-name=...) but pin the contract so a future refactor
+	// that, e.g., joins the result of two queries doesn't
+	// double-count.
+	eksFake := &fakeEKSClient{
+		listClustersOut: &eks.ListClustersOutput{Clusters: []string{"foo", "bar"}},
+		describeByName: map[string]*eks.DescribeClusterOutput{
+			"foo": {Cluster: &ekstypes.Cluster{Name: aws.String("foo"), Tags: map[string]string{"Project": "my-stack"}}},
+			"bar": {Cluster: &ekstypes.Cluster{Name: aws.String("bar"), Tags: map[string]string{"Project": "my-stack"}}},
+		},
+	}
+	ec2Fake := &fakeEC2InstancesClient{
+		reservationsByCluster: map[string][]ec2types.Reservation{
+			"foo": instanceReservation("i-shared", "i-foo-only"),
+			"bar": instanceReservation("i-shared", "i-bar-only"),
+		},
+	}
+	got, err := listEKSNodeInstances(context.Background(), eksFake, ec2Fake, "my-stack")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"i-shared", "i-foo-only", "i-bar-only"}, got)
+}
+
+func TestListEKSNodeInstances_NoClustersReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	// filterEKSClustersByProjectTag returning an empty list short-
+	// circuits the fan-out — the helper must not call EC2 once.
+	eksFake := &fakeEKSClient{
+		listClustersOut: &eks.ListClustersOutput{},
+	}
+	ec2Fake := &fakeEC2InstancesClient{}
+
+	got, err := listEKSNodeInstances(context.Background(), eksFake, ec2Fake, "my-stack")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	assert.Empty(t, ec2Fake.calls, "no clusters → no EC2 calls")
+}
+
+func TestListEKSNodeInstances_ListClustersErrorPropagates(t *testing.T) {
+	t.Parallel()
+	// EKS ListClusters failure is fatal — there's nothing to fan out
+	// from and the caller needs to know the discovery side broke.
+	// This mirrors filterEKSClustersByProjectTag's contract; we just
+	// confirm listEKSNodeInstances propagates instead of swallowing.
+	eksFake := &fakeEKSClient{
+		listClustersErr: errors.New("denied"),
+	}
+	_, err := listEKSNodeInstances(context.Background(), eksFake, &fakeEC2InstancesClient{}, "")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "ListClusters")
 }
 
 // --- Lambda fake ---

--- a/pkg/observability/metrics/aws_test.go
+++ b/pkg/observability/metrics/aws_test.go
@@ -140,7 +140,11 @@ func TestBuildGetMetricDataQueries_VerifiesDimensionValues(t *testing.T) {
 		{"cognito", composer.KeyAWSCognito, "cognito", "us-east-1_ABC123", 3, "AWS/Cognito", "UserPoolId"},
 		{"opensearch", composer.KeyAWSOpenSearch, "opensearch", "io-projx-search", 9, "AWS/ES", "DomainName"},
 		{"bedrock", composer.KeyAWSBedrock, "bedrock", "anthropic.claude-3-5-sonnet", 6, "AWS/Bedrock", "ModelId"},
-		{"eks", composer.KeyAWSEKS, "eks", "io-projx-cluster", 5, "AWS/EKS", "ClusterName"},
+		// EKS metrics are pivoted onto AWS/EC2 InstanceId via the
+		// `eks:cluster-name` tag (#231 Option A); the resource ID
+		// passed in here is an EC2 instance, not a cluster name, and
+		// the registry advertises a single CPUUtilization metric.
+		{"eks", composer.KeyAWSEKS, "eks", "i-0a1b2c3d4e5f60718", 1, "AWS/EC2", "InstanceId"},
 		{"elasticache", composer.KeyAWSElastiCache, "elasticache", "io-projx-redis-001", 8, "AWS/ElastiCache", "CacheClusterId"},
 		{"msk", composer.KeyAWSMSK, "msk", "io-projx-kafka", 13, "AWS/Kafka", "Cluster Name"},
 		{"waf", composer.KeyAWSWAF, "waf", "io-projx-webacl", 4, "AWS/WAFV2", "WebACL"},

--- a/pkg/observability/service_actions.go
+++ b/pkg/observability/service_actions.go
@@ -23,7 +23,11 @@ var AWSServiceActions = map[string][]string{
 	"kms":            {"list-keys", "list-aliases", "get-metrics"},
 	"secretsmanager": {"list-secrets", "get-metrics"},
 	"ecs":            {"list-clusters", "list-services", "describe-services", "get-metrics"},
-	"eks":            {"list-clusters", "describe-cluster", "get-metrics"},
+	// list-nodes pivots EKS metric discovery from cluster-name to EC2
+	// InstanceId via the AWS-managed `eks:cluster-name` tag, so the
+	// observability panel queries AWS/EC2 CPUUtilization per node
+	// instead of the unpopulated AWS/EKS namespace (#231 / Option A).
+	"eks":            {"list-clusters", "describe-cluster", "list-nodes", "get-metrics"},
 	"cloudfront":     {"list-distributions", "get-metrics"},
 	"cloudwatchlogs": {"describe-log-groups", "get-metrics"},
 	"alb":            {"describe-load-balancers", "get-metrics"},


### PR DESCRIPTION
## Summary

The EKS observability card has been rendering \"No live observable resources were found\" on every existing deployment. Root cause: `pkg/observability/component_observability.go` registered EKS under namespace `AWS/EKS` with metric names (`node_cpu_utilization`, `pod_cpu_utilization`, etc.) that actually live in `ContainerInsights`, which only publishes when the `amazon-cloudwatch-observability` addon is installed in-cluster — which our `aws/eks_nodegroup` preset does not install today. Result: zero datapoints on every query.

This PR ships **Option A** from #231: pivot EKS metric discovery from cluster-name to EC2 `InstanceId` via the AWS-managed `eks:cluster-name` tag the EKS managed node group attaches to its underlying ASG / EC2 instances. Query `AWS/EC2 CPUUtilization` per node — a path the codebase already exercises for the EC2 component — so the panel works on every existing deployment immediately, without any preset change.

- New EKS action `list-nodes` and helper `listEKSNodeInstances`: lists clusters via the existing `filterEKSClustersByProjectTag`, then for each cluster lists EC2 instances filtered by `Project=<project>` AND `eks:cluster-name=<cluster>`. Per-cluster errors log+skip; the Project filter is applied at both the EKS and EC2 layer for defense in depth.
- `ComponentObservability[\"eks\"]` repointed to `AWS/EC2 + InstanceId + CPUUtilization`.
- `ComponentMetricsMapping[KeyAWSEKS]` repointed to `list-nodes` so the orchestrator's metric-discovery action returns instance IDs that match the new namespace + dimension. (Reliable consumes `ComponentObservability` at runtime via `metricDefinitions`, so no reliable-side change is required.)
- Six new unit tests cover the fan-out semantics: project + cluster tag scoping, empty-project fan-out, per-cluster error skipping, instance-id dedup across clusters, empty-cluster-list short-circuit, and ListClusters error propagation.

## Heads-up

`ComponentMetricsMapping[KeyAWSEKS]` action change (`list-clusters` → `list-nodes`) means the EKS panel's resource summary now shows EC2 instance IDs instead of cluster names. That's strictly better than rendering empty, and instance-level is what the metrics need anyway. The `list-clusters` action is still available via the dispatcher for callers that need a cluster inventory (the action is still in `AWSServiceActions[\"eks\"]`).

## Test plan

- [x] `go test -count=1 ./pkg/observability/...` — green
- [x] `go vet ./...` and `go build ./...` — green
- [x] `terraform fmt -check -recursive` — clean
- [x] All 8 lint scripts under `tests/lint-*.sh` — PASS
- [x] Six new tests for `listEKSNodeInstances` (filter shape + error semantics)
- [x] Existing `TestInspectCoversAllAWSServices` drift gate passes (firstAction is still `list-clusters`)
- [x] Existing `TestBuildGetMetricDataQueries_AllServices` updated EKS row passes
- [ ] CI green on this PR
- [ ] Live verification on a deployed EKS session post-merge

## Out of scope (separate follow-ups, see #231)

- **Option B (Container Insights):** bump `aws/eks_nodegroup` to install `amazon-cloudwatch-observability` and pivot back to `ContainerInsights` for richer node + pod metrics.
- Memory / disk / network metrics for EKS via `AWS/EC2` (extend the metric list once Option A is verified live).
- The `describe-cluster` action is still stubbed at `compute.go:341`.

Closes #231
Refs reliable#1260 (closed; redirected here)