### PR TITLE
fix(observability): EnsureProject preserves non-string sibling fields

### DIFF
--- a/pkg/observability/filter/project.go
+++ b/pkg/observability/filter/project.go
@@ -16,16 +16,28 @@ import (
 )
 
 // Project extracts the "project" value from a JSON filters string.
-// Returns "" if not present or unparseable.
+// Returns "" if not present, the project value is not a string, or the
+// envelope is unparseable. Sibling fields with non-string values
+// (numbers, bools, arrays, nested objects) do not affect extraction —
+// the envelope is parsed as map[string]json.RawMessage and only the
+// "project" key is decoded as a string.
 func Project(filters string) string {
 	if filters == "" {
 		return ""
 	}
-	var m map[string]string
+	var m map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(filters), &m); err != nil {
 		return ""
 	}
-	return m["project"]
+	raw, ok := m["project"]
+	if !ok {
+		return ""
+	}
+	var p string
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return ""
+	}
+	return p
 }
 
 // EnsureProject injects "project"=<name> into a JSON filters string when
@@ -39,11 +51,12 @@ func Project(filters string) string {
 //     (an explicit "project":"" is treated as no project set and is
 //     overwritten — Project() reports such filters as having no project)
 //   - filters == ""                   → return {"project":<name>}
-//   - filters is an object of strings → merge project=<name> in
-//   - filters is unparseable, JSON null,
-//     or contains any non-string value → return {"project":<name>}
-//     (the original other-keys are dropped; the parse contract matches
-//     Project(), which treats values as strings)
+//   - filters is a JSON object        → merge project=<name> in;
+//     sibling fields of any JSON type (strings, numbers, bools, arrays,
+//     nested objects) are preserved byte-exact via json.RawMessage
+//   - filters is unparseable, JSON null, or a non-object →
+//     return {"project":<name>} (the original input is dropped; the
+//     fallback is order-independent so output is deterministic)
 func EnsureProject(filters, project string) string {
 	if project == "" {
 		return filters
@@ -51,15 +64,16 @@ func EnsureProject(filters, project string) string {
 	if Project(filters) != "" {
 		return filters
 	}
-	m := make(map[string]string)
+	m := make(map[string]json.RawMessage)
 	if filters != "" {
 		if err := json.Unmarshal([]byte(filters), &m); err != nil || m == nil {
 			// Drop on any parse failure or JSON null — order-independent
 			// fallback to a fresh map so output is deterministic.
-			m = make(map[string]string)
+			m = make(map[string]json.RawMessage)
 		}
 	}
-	m["project"] = project
+	pj, _ := json.Marshal(project)
+	m["project"] = pj
 	b, _ := json.Marshal(m)
 	return string(b)
 }

--- a/pkg/observability/filter/project_test.go
+++ b/pkg/observability/filter/project_test.go
@@ -17,9 +17,15 @@ func TestProject(t *testing.T) {
 	}{
 		{name: "empty string", filters: "", want: ""},
 		{name: "invalid JSON", filters: "not-json", want: ""},
+		{name: "literal JSON null", filters: "null", want: ""},
+		{name: "non-object JSON (array)", filters: `[1,2,3]`, want: ""},
 		{name: "no project key", filters: `{"foo":"bar"}`, want: ""},
 		{name: "valid project", filters: `{"project":"io-abc123"}`, want: "io-abc123"},
 		{name: "project with other keys", filters: `{"project":"io-test","zone":"us-east-1a"}`, want: "io-test"},
+		{name: "project with numeric sibling", filters: `{"hours":6,"project":"io-test"}`, want: "io-test"},
+		{name: "project with array sibling", filters: `{"groupBy":["a","b"],"project":"io-test"}`, want: "io-test"},
+		{name: "project with nested-object sibling", filters: `{"nested":{"k":"v"},"project":"io-test"}`, want: "io-test"},
+		{name: "non-string project value treated as absent", filters: `{"project":42}`, want: ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -37,13 +43,12 @@ func TestEnsureProject(t *testing.T) {
 		filters string
 		project string
 		// Exactly one of the assertion modes below applies per row:
-		// - wantSame=true asserts byte-equality with `filters`; wantProject
-		//   and wantOther are ignored.
-		// - otherwise wantProject is the expected Project(out), and the
-		//   parsed output map must equal {project:<wantProject>} ∪ wantOther.
-		wantSame    bool
-		wantProject string
-		wantOther   map[string]string
+		// - wantSame=true asserts byte-equality with `filters`; wantJSON
+		//   is ignored.
+		// - otherwise wantJSON is the expected output, compared via
+		//   assert.JSONEq so key order doesn't matter.
+		wantSame bool
+		wantJSON string
 	}{
 		{
 			name:     "empty project + empty filters → unchanged",
@@ -58,10 +63,10 @@ func TestEnsureProject(t *testing.T) {
 			wantSame: true,
 		},
 		{
-			name:        "empty filters + project → fresh JSON",
-			filters:     "",
-			project:     "io-abc123",
-			wantProject: "io-abc123",
+			name:     "empty filters + project → fresh JSON",
+			filters:  "",
+			project:  "io-abc123",
+			wantJSON: `{"project":"io-abc123"}`,
 		},
 		{
 			name:     "filters already has project → unchanged (single key)",
@@ -76,38 +81,77 @@ func TestEnsureProject(t *testing.T) {
 			wantSame: true,
 		},
 		{
-			name:        "filters with other keys, no project → merge",
-			filters:     `{"zone":"us-east-1a"}`,
-			project:     "io-test",
-			wantProject: "io-test",
-			wantOther:   map[string]string{"zone": "us-east-1a"},
+			name:     "filters already has project → unchanged (with numeric sibling)",
+			filters:  `{"hours":6,"project":"io-existing"}`,
+			project:  "io-override",
+			wantSame: true,
 		},
 		{
-			name:        "explicit empty project value → overwrite",
-			filters:     `{"project":"","zone":"us-east-1a"}`,
-			project:     "io-real",
-			wantProject: "io-real",
-			wantOther:   map[string]string{"zone": "us-east-1a"},
+			name:     "filters with other keys, no project → merge",
+			filters:  `{"zone":"us-east-1a"}`,
+			project:  "io-test",
+			wantJSON: `{"zone":"us-east-1a","project":"io-test"}`,
 		},
 		{
-			name:        "unparseable JSON → fresh JSON, drop bad input",
-			filters:     "not-json",
-			project:     "io-recover",
-			wantProject: "io-recover",
+			name:     "explicit empty project value → overwrite, preserve siblings",
+			filters:  `{"project":"","zone":"us-east-1a"}`,
+			project:  "io-real",
+			wantJSON: `{"zone":"us-east-1a","project":"io-real"}`,
 		},
 		{
-			name:        "literal JSON null → fresh JSON (no panic)",
-			filters:     "null",
-			project:     "io-recover",
-			wantProject: "io-recover",
+			name:     "unparseable JSON → fresh JSON, drop bad input",
+			filters:  "not-json",
+			project:  "io-recover",
+			wantJSON: `{"project":"io-recover"}`,
 		},
 		{
-			name:        "mixed-type values → fresh JSON, all original keys dropped",
-			filters:     `{"zone":"us-east-1a","limit":10}`,
-			project:     "io-test",
-			wantProject: "io-test",
-			// wantOther nil: the contract is order-independent reset on
-			// any parse failure, so "zone" is dropped along with "limit".
+			name:     "literal JSON null → fresh JSON (no panic)",
+			filters:  "null",
+			project:  "io-recover",
+			wantJSON: `{"project":"io-recover"}`,
+		},
+		{
+			name:     "non-object JSON (array) → fresh JSON, drop bad input",
+			filters:  `[1,2,3]`,
+			project:  "io-recover",
+			wantJSON: `{"project":"io-recover"}`,
+		},
+		// Issue #234: non-string sibling fields must be preserved.
+		{
+			name:     "numeric sibling preserved (hours)",
+			filters:  `{"hours":6}`,
+			project:  "io-test",
+			wantJSON: `{"hours":6,"project":"io-test"}`,
+		},
+		{
+			name:     "numeric + string siblings preserved (cost-summary shape)",
+			filters:  `{"days":7,"granularity":"DAILY"}`,
+			project:  "io-test",
+			wantJSON: `{"days":7,"granularity":"DAILY","project":"io-test"}`,
+		},
+		{
+			name:     "string + numeric siblings preserved (cost-by-tag shape)",
+			filters:  `{"tag_key":"Environment","days":30}`,
+			project:  "io-test",
+			wantJSON: `{"tag_key":"Environment","days":30,"project":"io-test"}`,
+		},
+		{
+			name:     "array sibling preserved",
+			filters:  `{"groupBy":["a","b"]}`,
+			project:  "io-test",
+			wantJSON: `{"groupBy":["a","b"],"project":"io-test"}`,
+		},
+		{
+			name:     "nested-object sibling preserved",
+			filters:  `{"nested":{"k":"v"}}`,
+			project:  "io-test",
+			wantJSON: `{"nested":{"k":"v"},"project":"io-test"}`,
+		},
+		{
+			name:     "mixed string + numeric siblings preserved",
+			filters:  `{"zone":"us-east-1a","limit":10}`,
+			project:  "io-test",
+			wantJSON: `{"zone":"us-east-1a","limit":10,"project":"io-test"}`,
 		},
 	}
 	for _, tt := range tests {
@@ -118,17 +162,16 @@ func TestEnsureProject(t *testing.T) {
 				assert.Equal(t, tt.filters, got)
 				return
 			}
-			assert.Equal(t, tt.wantProject, Project(got),
-				"Project() on output should match wantProject")
-			var parsed map[string]string
-			require.NoError(t, json.Unmarshal([]byte(got), &parsed),
-				"output must be parseable as map[string]string")
-			// Output must contain exactly project + wantOther — no
-			// stray injected keys, no missing ones.
-			assert.Len(t, parsed, len(tt.wantOther)+1,
-				"output map should have exactly len(wantOther)+1 keys")
-			for k, v := range tt.wantOther {
-				assert.Equal(t, v, parsed[k], "key %q should be preserved", k)
+			assert.JSONEq(t, tt.wantJSON, got,
+				"output JSON should match wantJSON ignoring key order")
+			// Cross-check: Project() on the output should agree with the
+			// project field embedded in wantJSON, exercising the early-
+			// return guard inside EnsureProject for any future calls.
+			var expected map[string]any
+			require.NoError(t, json.Unmarshal([]byte(tt.wantJSON), &expected))
+			if want, ok := expected["project"].(string); ok {
+				assert.Equal(t, want, Project(got),
+					"Project() on output should equal wantJSON.project")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`filter.EnsureProject` (v0.8.2) parsed the filters envelope as
`map[string]string`. Any sibling field with a non-string JSON value
(numbers, bools, arrays, nested objects) made `json.Unmarshal` error,
and the fallback silently reset to a fresh empty map — so every
non-project key was dropped on the merge path.

Why this matters: reliable's MCP `awsinspect` / `gcpinspect` tool docs
explicitly tell the LLM to pass numeric filter values like
`{"hours":6,"period":300}` and `{"days":7,"granularity":"DAILY"}`.
`ensureProjectFilter` runs at the entry of every inspector, so those
numeric fields were stripped before downstream parsers
(`metricFilters{Hours,Period}`, cost-explorer parsers) saw them —
silently narrowing the metric lookback window and reverting CloudWatch
period to defaults.

## Fix

Switch both `Project()` and `EnsureProject()` to parse the envelope as
`map[string]json.RawMessage` so unknown values round-trip byte-exact.

- `Project()` decodes only the `"project"` key as a string; non-string
  project values are treated as absent (matches today's contract).
- `EnsureProject` marshals the new project value via `json.Marshal` and
  inserts it under `"project"`, leaving every other key untouched.
- Fallback for unparseable / null / non-object input is unchanged.

The 25 `filter.Project(filters)` call sites under
`pkg/observability/discovery/aws/*.go` get the same fix automatically —
they now correctly extract the project from filters that carry numeric
siblings (previously every such call returned `""` and the inspector
treated the request as unscoped).

## Test plan

- [x] `go test -race ./pkg/observability/filter/...` passes locally
  (added cases for numeric, array, nested-object, mixed siblings, and
  the existing-project early-return path with a numeric sibling)
- [ ] Full Go test + Terraform validate suite via CI
- [ ] After merge + `v0.8.3` tag, reliable bumps the presets dep and
      its `TestEnsureProjectFilter/merges_into_existing_filters` passes
      with the local workaround replaced by `return filter.EnsureProject(...)`
      (tracked in reliable #1252; out of scope for this PR)

Fixes #234