### PR TITLE
observability: EKS ContainerInsights pivot + per-extractor coverage + firestore catalog fix

### DIFF
--- a/aws/eks_nodegroup/main.tf
+++ b/aws/eks_nodegroup/main.tf
@@ -201,8 +201,14 @@ resource "aws_eks_addon" "cloudwatch_observability" {
   cluster_name = var.cluster_name
   addon_name   = "amazon-cloudwatch-observability"
 
+  # OVERWRITE on create lets us adopt an existing addon if one was
+  # installed out-of-band. PRESERVE on update means hand-tuned in-
+  # cluster customizations (e.g. agent ConfigMap edits) survive subsequent
+  # applies — at the cost of silently drifting from the addon's
+  # default config. Customers who want a forced re-sync can re-create
+  # the addon.
   resolve_conflicts_on_create = "OVERWRITE"
-  resolve_conflicts_on_update = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
 
   tags = merge(local.common_tags, var.tags)
 

--- a/aws/eks_nodegroup/main.tf
+++ b/aws/eks_nodegroup/main.tf
@@ -178,6 +178,43 @@ resource "aws_eks_node_group" "this" {
 }
 
 # -------------------------------------------------------------
+# Tag propagation to EC2 instances (CLAUDE.md / issue #81)
+# -------------------------------------------------------------
+# `aws_eks_node_group.this.tags` tag the node-group RESOURCE only —
+# AWS does NOT propagate them to the EC2 instances spawned by the
+# managed node group's auto-derived ASG. This was discovered live on
+# cust2 (project `io-hrbs5zprbk51`): five running EKS workers carried
+# the AWS-managed `eks:cluster-name` tag but had no `Project` tag, so
+# reliable3's `Project`-scoped EC2 inspector returned zero.
+#
+# `aws_autoscaling_group_tag` writes each tag onto the underlying ASG
+# with `propagate_at_launch = true` — newly launched instances inherit
+# every tag in `local.common_tags + var.tags` (Project, Environment,
+# Component, customer-supplied additions). Already-running instances
+# do NOT pick up the tag retroactively; a node refresh / cordoned
+# rotation is required to fully retag the fleet (or an out-of-band
+# `aws ec2 create-tags` for the existing instance IDs).
+#
+# `for_each` keys are tag names — strings sourced from
+# `module.name.tags` / `var.tags`, all plan-time-known. The ASG name
+# itself is apply-time-known (`aws_eks_node_group.this.resources[0]
+# .autoscaling_groups[0].name`) but only flows into the resource's
+# attributes, not its for_each key, so the lint-foreach-unknown-keys
+# tripwire is satisfied. EKS managed-node-group ASGs always emit
+# `resources[0].autoscaling_groups[0]` (one ASG per node group).
+resource "aws_autoscaling_group_tag" "node_tags" {
+  for_each = merge(local.common_tags, var.tags)
+
+  autoscaling_group_name = aws_eks_node_group.this.resources[0].autoscaling_groups[0].name
+
+  tag {
+    key                 = each.key
+    value               = each.value
+    propagate_at_launch = true
+  }
+}
+
+# -------------------------------------------------------------
 # CloudWatch Container Insights addon
 # -------------------------------------------------------------
 # amazon-cloudwatch-observability installs the CloudWatch agent +

--- a/aws/eks_nodegroup/main.tf
+++ b/aws/eks_nodegroup/main.tf
@@ -88,6 +88,17 @@ resource "aws_iam_role_policy_attachment" "mng_ssm" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+# CloudWatchAgentServerPolicy grants cloudwatch:PutMetricData + the
+# logs:CreateLogStream/PutLogEvents needed by the
+# amazon-cloudwatch-observability addon's CloudWatch agent + fluent-bit
+# DaemonSets. Attached only when this module creates the role; callers
+# that supply node_role_arn are responsible for the equivalent grant.
+resource "aws_iam_role_policy_attachment" "mng_cloudwatch_agent" {
+  count      = var.node_role_arn == null && var.enable_container_insights ? 1 : 0
+  role       = aws_iam_role.mng[0].name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
 # -------------------------------------------------------------
 # Service-linked role bootstrap
 # -------------------------------------------------------------
@@ -164,4 +175,39 @@ resource "aws_eks_node_group" "this" {
       backup = "true"
     }
   )
+}
+
+# -------------------------------------------------------------
+# CloudWatch Container Insights addon
+# -------------------------------------------------------------
+# amazon-cloudwatch-observability installs the CloudWatch agent +
+# fluent-bit DaemonSets in-cluster so node + pod metrics publish under
+# the ContainerInsights namespace (node_cpu_utilization,
+# pod_memory_utilization, etc.). Without the addon, AWS/EKS itself only
+# publishes a small set of cluster-level metrics — see issue #233 / #231.
+#
+# Default-on (cliff per #233 Option B-1): existing deployments that
+# haven't opted out will install the addon on the next apply and the
+# ContainerInsights panel begins populating ~5 minutes later.
+# CloudWatch ingest cost (~$0.30/GB) is the trade-off; opt out via
+# var.enable_container_insights = false.
+#
+# Depends on the node group being up so the addon's DaemonSets can
+# schedule, and on the CloudWatchAgentServerPolicy attachment so the
+# agent has cloudwatch:PutMetricData when it starts.
+resource "aws_eks_addon" "cloudwatch_observability" {
+  count = var.enable_container_insights ? 1 : 0
+
+  cluster_name = var.cluster_name
+  addon_name   = "amazon-cloudwatch-observability"
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+
+  tags = merge(local.common_tags, var.tags)
+
+  depends_on = [
+    aws_eks_node_group.this,
+    aws_iam_role_policy_attachment.mng_cloudwatch_agent,
+  ]
 }

--- a/aws/eks_nodegroup/variables.tf
+++ b/aws/eks_nodegroup/variables.tf
@@ -122,6 +122,12 @@ variable "node_role_arn" {
   default     = null
 }
 
+variable "enable_container_insights" {
+  description = "Install the amazon-cloudwatch-observability addon so node + pod metrics publish to the ContainerInsights namespace. Adds CloudWatch ingest cost (~$0.30/GB ingested + per-metric pricing); set to false to disable."
+  type        = bool
+  default     = true
+}
+
 variable "ami_type" {
   description = "EKS node AMI type. When null (default), the module derives the AMI type from var.instance_types: ARM/Graviton families (c7g, m7g, r7g, t4g, c8g, m8g, r8g, etc. — names ending in `g`) get AL2023_ARM_64_STANDARD; all other families get AL2023_x86_64_STANDARD. Set explicitly to override (e.g. BOTTLEROCKET_x86_64, AL2_x86_64_GPU)."
   type        = string

--- a/aws/eks_nodegroup/variables.tf
+++ b/aws/eks_nodegroup/variables.tf
@@ -123,7 +123,7 @@ variable "node_role_arn" {
 }
 
 variable "enable_container_insights" {
-  description = "Install the amazon-cloudwatch-observability addon so node + pod metrics publish to the ContainerInsights namespace. Adds CloudWatch ingest cost (~$0.30/GB ingested + per-metric pricing); set to false to disable."
+  description = "Install the amazon-cloudwatch-observability addon so node + pod metrics publish to the ContainerInsights namespace. Adds CloudWatch ingest cost (~$0.30/GB ingested + per-metric pricing); set to false to disable. NOTE: if you supply var.node_role_arn (i.e. bring your own node IAM role), you are responsible for attaching arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy to it — without that grant the addon installs but the in-cluster CloudWatch agent fails to publish metrics."
   type        = bool
   default     = true
 }

--- a/docs/observability-test-coverage.md
+++ b/docs/observability-test-coverage.md
@@ -1,0 +1,230 @@
+# Observability — Test Coverage Reference
+
+This doc captures, by API surface, what `pkg/observability/...` tests exercise
+against actual cloud accounts versus what is covered by fakes/mocks. Updated
+as new probes land. Source: PR #238 live-validation phase, plus #239 follow-up.
+
+## TL;DR
+
+- Unit/branch coverage: ~600 tests across `pkg/observability/...` covering
+  23 AWS + 23 GCP extractors, 3 newly-tested AWS inspectors
+  (`account.go`, `cloudwatchlogs.go`, `connect_info.go`), the firestore
+  catalog pin, and the EKS registry pivot to ContainerInsights.
+- Live AWS testing on **cust2** (account 141812438321, project
+  `io-hrbs5zprbk51`) and live GCP testing on **diagramtest2025-09-14**
+  validated the inspector + catalog code against real APIs.
+- Three pre-existing production bugs surfaced by live testing — all fixed
+  in PR #238 (see § 4).
+
+## How to run live probes
+
+The live tests are gated by `//go:build integration` so they never run
+in CI. Default (no creds) → all cleanly skip; with creds → real API.
+
+```bash
+# AWS — needs ambient creds (e.g. via aws_jump cust2)
+go test -tags=integration ./pkg/observability/discovery/aws/... -v -run TestLive
+
+# AWS — substring-scoping requires LIVE_PROJECT
+LIVE_PROJECT=io-hrbs5zprbk51 AWS_REGION=us-east-1 \
+  go test -tags=integration ./pkg/observability/discovery/aws/... -v -run TestLive
+
+# GCP — needs Application Default Credentials
+LIVE_GCP_PROJECT_ID=diagramtest2025-09-14 \
+  go test -tags=integration ./pkg/observability/discovery/gcp/... -v -run TestLive
+
+# GCP CDN filter path (optional) — set the project label too
+LIVE_GCP_PROJECT_ID=... LIVE_GCP_PROJECT_LABEL=io-... \
+  go test -tags=integration ./pkg/observability/discovery/gcp/... -v -run TestLive_InspectCloudCDN_WithProjectFilter
+```
+
+Auth probes built in: each `loadOrSkip` / `liveProjectOrSkip` helper
+verifies credentials before running the tested code path, so missing
+auth produces a `Skip` rather than a confusing late failure.
+
+## 1. Live cloud testing — AWS cust2
+
+**Account**: 141812438321 (`platform-test-admin/swood`)
+**Stack**: `io-hrbs5zprbk51` (region us-east-1)
+
+| API call | Where | Tested? | Result |
+|---|---|---|---|
+| `sts.GetCallerIdentity` | `gatherAccountInfo` | ✅ live | Returns real account, role ARN, UserId |
+| `iam.ListAccountAliases` | `gatherAccountInfo` | ✅ live | Real aliases |
+| `iam.GetAccountSummary` | `gatherAccountInfo` | ✅ live | 237 roles, 8 policies, 1 user |
+| `cloudwatchlogs.DescribeLogGroups` (no filter) | `describeProjectLogGroups` | ✅ live | Returns 2 log groups in eu-west-2; 100+ in us-east-1 |
+| `cloudwatchlogs.DescribeLogGroups` (substring) | `describeProjectLogGroups` | ✅ live | 8 project-scoped groups returned across 4 preset shapes (#239 fix) |
+| `ec2.DescribeInstances` | `inspectEC2` | ✅ live | Clean run; eu-west-2 had 0 reservations |
+| `ec2.DescribeInstances` (`tag:Project`) | `inspectEC2` filter | ✅ live | After Bug #1 fix: 5 EKS workers will tag on next launch |
+| `eks.ListClusters` | inspector | ✅ live | Found `io-hrbs5zprbk51-prod-lu-eks0` |
+| `eks.DescribeCluster` | inspector | ✅ live | ACTIVE, K8s 1.33, 5 addons + `amazon-cloudwatch-observability` (post-PR) |
+| `eks.ListAddons` | inspector | ✅ live | All 6 addons including the new ContainerInsights one |
+| `cloudwatch.ListMetrics` (`ContainerInsights`) | #233 pivot validation | ✅ live | 1912 metrics publishing post-addon install (was 0 pre-install) |
+| `s3.ListBuckets` + `GetBucketTagging` | `inspectS3` | ✅ live | 2 buckets discoverable for project |
+| `rds.DescribeDBInstances` | `inspectRDS` | ⚠️ partial | 3 db instances visible account-wide; per-project tag fan-out not exercised |
+| `elbv2.DescribeLoadBalancers` + tag fan-out | `inspectALB` | ✅ live | 1 ALB discoverable for project |
+| `lambda.ListFunctions` + tag fan-out | `inspectLambda` | ⚠️ partial | 3 functions visible account-wide; project-scoped fan-out not measured |
+| `ec2.DescribeVpcs` (`tag:Project`) | `inspectVPC` | ✅ live | 1 VPC for project |
+
+## 2. Live cloud testing — GCP
+
+**Project**: `diagramtest2025-09-14` (SA `reliable-test-deploy@...`)
+
+| API call | Where | Tested? | Result |
+|---|---|---|---|
+| `firestore.databases.list` | inspector | ✅ live | 2 firestore DBs visible |
+| Cloud Monitoring `metricDescriptors` | catalog correctness | ✅ live | 31 firestore descriptors found. Revealed that `document/{read,write,delete}_count` only publish under `firestore_instance` (not `Database`), drove the `*_ops_count` correction in `eaaab0f`. |
+| `monitoredResourceDescriptors/firestore_instance` | label key check | ✅ live | Only `project_id` label — cannot scope per-database |
+| `monitoredResourceDescriptors/firestore.googleapis.com/Database` | label key check | ✅ live | `database_id`, `location`, `resource_container` — supports per-database scoping |
+| `timeSeries.list` for firestore | catalog data round-trip | ✅ live | 0 series in 72h (quiet stack) — descriptor truth is authoritative regardless |
+| `compute.AggregatedListBackendServices` (no filter) | `inspectCloudCDN` | ⏳ pending GCP reauth | Unit test pins AIP-160 dialect (#239); live call needs `gcloud auth application-default login` |
+
+## 3. Coverage gaps (NOT yet tested live)
+
+| Item | Why | Status |
+|---|---|---|
+| Per-RDS / per-Lambda Project-tag filtering | Inspectors fan out via `ListTagsOfResource`; live behaviour requires the dispatcher harness | unit-only |
+| 16+ other AWS inspectors (DynamoDB, SQS, KMS, Bedrock, SecretsManager, Cognito, MSK, OpenSearch, ElastiCache, CloudFront, WAF, APIGateway, etc.) | Out of scope for this PR's diff; tests use realistic SDK envelope shapes via fakes | unit-only |
+| 22+ GCP inspectors beyond Firestore + Cloud CDN | Same | unit-only |
+| EC2 connect-URL enrichment against running instances | cust2 us-east-1 had 5 EKS workers but `tag:Project` filter returned them as 0 (Bug #1, now fixed for newly-launched instances) | partial — function ran, just 0 enriched |
+
+## 4. Bugs surfaced by live testing — all fixed in PR #238
+
+### Bug #1 — EKS workers lack the `Project` tag
+
+**Repro on cust2** (region us-east-1, project `io-hrbs5zprbk51`):
+
+- `aws ec2 describe-instances --filters "Name=tag:Project,Values=io-hrbs5zprbk51"` → 0 instances
+- `aws ec2 describe-instances --filters "Name=tag:eks:cluster-name,Values=io-hrbs5zprbk51-prod-lu-eks0"` → 5 instances
+- The 5 instances carry only the AWS-managed `eks:cluster-name`,
+  `aws:eks:cluster-name`, `kubernetes.io/cluster/...` tags. No `Project`.
+
+**Root cause**: `aws/eks_nodegroup/main.tf` sets `tags = ...` on
+`aws_eks_node_group`, but EKS managed node groups do NOT propagate
+node-group tags to the underlying EC2 instances. The auto-derived
+launch template's `TagSpecifications` is empty.
+
+**Impact**:
+
+1. EC2 panel renders empty — extractor returns nil, drift comparison flips.
+2. PR #232's `listEKSNodeInstances` (which intersects `tag:Project` and
+   `tag:eks:cluster-name`) returned 0 on every existing deployment.
+3. Violates the project's `Project`-tag rule (CLAUDE.md / #81).
+
+**Fix**: `aws_autoscaling_group_tag` resources keyed by
+`for_each = merge(local.common_tags, var.tags)`, with
+`propagate_at_launch = true` so newly-launched instances inherit
+`Project`, `Environment`, `Component`, and customer-supplied tags.
+
+`aws_autoscaling_group_tag` is preferred over swapping in a
+customer-managed launch template because EKS managed node groups own
+their LT — supplying our own would force callers to give up the
+`instance_types`/`ami_type` arguments on the node-group resource.
+
+**Caveat**: existing instances do NOT pick up the tag retroactively;
+a node refresh / cordoned rotation is required to fully retag the
+fleet, or an out-of-band `aws ec2 create-tags` for the existing
+instance IDs.
+
+### Bug #2 — CloudWatchLogs `/aws/<project>` prefix didn't match real preset naming
+
+**Repro on cust2** (region us-east-1):
+
+- `aws logs describe-log-groups --log-group-name-prefix "/aws/io-hrbs5zprbk51"` → 0
+- Real log groups for this project:
+  - `/aws/eks/io-hrbs5zprbk51-prod-lu-eks0/cluster`
+  - `/aws/rds/instance/io-hrbs5zprbk51-prod-luthersystems-insideout-rds-rds0-replica-1/postgresql`
+  - `/aws/rds/instance/io-hrbs5zprbk51-prod-luthersystems-insideout-rds-rds0/postgresql`
+  - `/io-hrbs5zprbk51-prod-luthersystems-insideout-cwl-cwl6b08/app`
+
+None of them start with `/aws/<project>`.
+
+**Root cause**: `pkg/observability/discovery/aws/cloudwatchlogs.go::describeProjectLogGroups`
+used `LogGroupNamePrefix = "/aws/<project>"` (matching a doc comment that
+described a preset convention which doesn't actually hold).
+
+**Impact**: panel renders empty for any real project. Pre-existing,
+silent.
+
+**Fix**: switched to
+`LogGroupNamePattern = <project>` (server-side case-sensitive substring
+match). Catches all four real-world preset naming shapes in a single
+API call without giving up server-side filtering. The response is
+reduced to `{arn, creationTime, logGroupName}` — discovery only
+consumes `logGroupName`, so the reduction is a non-issue.
+
+**Verified live on cust2**:
+- Old prefix path: 0 log groups returned.
+- New substring path: 8 log groups returned across all four preset
+  shapes (4 from the bug repro + 4 `/aws/containerinsights/...` log
+  groups from PR #238's addon install).
+
+### Bug #3 — Cloud CDN AggregatedList filter dialect (#239)
+
+**Repro on staging session `sess_v2_qtyB4nkwp5N8`**, project
+`io-qtyb4nkwp5n8`:
+
+- `/api/v2/gcp/inspect` for `service=cloudcdn`,
+  `action=list-backend-services-cdn` returned HTTP 400:
+  `Invalid value for field 'filter': 'labels.project=io-qtyb4nkwp5n8'.`
+  `Invalid list filter expression.`
+
+**Root cause**: `pkg/observability/discovery/gcp/network.go::inspectCloudCDN`
+used `gcpLegacyLabelFilter` (GCE legacy dialect, e.g.
+`labels.project=<value>`). The Compute v1 REST API exposes both
+filter dialects per-endpoint:
+
+- `google.golang.org/api/compute/v1` (`computeapi.NewService`) — older
+  client, used by VPC / LoadBalancer / CloudArmor inspectors. Accepts
+  the legacy dialect.
+- `cloud.google.com/go/compute/apiv1` — newer client, used by
+  `inspectCloudCDN` because Cloud CDN is a flag on backend services
+  rather than its own resource type. **Rejects** the legacy dialect
+  for `backendServices.aggregatedList` and requires AIP-160
+  (`labels.project = "<value>"`).
+
+**Impact**: every InsideOut session whose stack contains a
+`gcp_cloud_cdn` component saw a 400 in the panel.
+
+**Fix**: switched to `gcpAIP160LabelFilter`, factored the request
+construction into `cloudCDNAggregatedListRequest()` so the dialect
+choice is pinned by `TestCloudCDNAggregatedListRequest_AIP160DialectForProjectFilter`.
+Live integration tests (`live_integration_test.go`) cover the no-filter
+and with-filter paths against any real GCP project.
+
+The other call sites in `network.go` (VPC, LoadBalancer, CloudArmor)
+use the older `computeapi` client and remain on the legacy dialect —
+they are NOT affected by this bug. A header comment in
+`inspectCloudCDN` documents the asymmetry so a future migration to
+the newer client across the board flips them all in lockstep.
+
+## 5. Test-quality coverage (unit / branch)
+
+| Layer | New tests | Status |
+|---|---|---|
+| `extractors/aws_test.go` | 113 subtests across 21 funcs | ✅ — qa-professor mutation-tested several extractors |
+| `extractors/gcp_test.go` | 111 subtests across 23 funcs | ✅ — 7 cases pinned as `*_PendingIssue236` for future implementers |
+| `discovery/aws/account_test.go` | 6 cases (happy + STS-down + IAM-aliases-down + IAM-summary-down + empty-aliases + unknown-action) | ✅ |
+| `discovery/aws/cloudwatchlogs_test.go` | 6 cases (substring-scoping + empty filter + API error + empty result + get-metrics-routing + unknown-action). Substring case exercises all four real preset naming shapes. | ✅ |
+| `discovery/aws/connect_info_test.go` | 9 cases (running/stopped/empty/mixed/multi-instance/region-prop/empty-id/non-state-fields) | ✅ |
+| `discovery/aws/live_integration_test.go` | 4 build-tagged smoke tests | ✅ — clean skip without creds |
+| `discovery/gcp/network_test.go` (Cloud CDN dialect pin) | 2 helper tests + table cases | ✅ |
+| `discovery/gcp/live_integration_test.go` | 3 build-tagged GCP smoke tests | ✅ — clean skip without creds |
+| `component_observability_test.go` | 2 firestore pin tests | ✅ — mutation-tested by qa-professor |
+| `metrics/aws_test.go` | EKS row flipped to ContainerInsights | ✅ |
+
+**Skipped:**
+
+- Per-extractor tests for AWS/GCP services where the extractor source
+  already had unit tests at the inspector level — would have been
+  redundant.
+- End-to-end pipeline tests (config envelope → extractor → renderer →
+  panel JSON) — out of scope; that's reliable's wrapper layer.
+
+## 6. Updating this doc
+
+When adding a live probe, update both § 1/§ 2 (the API-call table) and
+§ 5 (the new test file row). When live-testing surfaces a new bug,
+add it to § 4 with the same structure (repro, root cause, impact,
+fix). When live-testing reveals a coverage gap, add it to § 3 with
+the rationale.

--- a/docs/observability-test-coverage.md
+++ b/docs/observability-test-coverage.md
@@ -159,44 +159,62 @@ consumes `logGroupName`, so the reduction is a non-issue.
   shapes (4 from the bug repro + 4 `/aws/containerinsights/...` log
   groups from PR #238's addon install).
 
-### Bug #3 — Cloud CDN AggregatedList filter dialect (#239)
+### Bug #3 — Compute v1 AggregatedList filter dialect (#239)
 
-**Repro on staging session `sess_v2_qtyB4nkwp5N8`**, project
-`io-qtyb4nkwp5n8`:
+Originally filed as a Cloud-CDN-only bug; live MCP probe against
+staging session `sess_v2_qtyB4nkwp5N8` (`gcpinspect_batch`)
+revealed the bug is wider — multiple Compute v1 endpoints reject the
+GCE legacy filter dialect:
 
-- `/api/v2/gcp/inspect` for `service=cloudcdn`,
-  `action=list-backend-services-cdn` returned HTTP 400:
-  `Invalid value for field 'filter': 'labels.project=io-qtyb4nkwp5n8'.`
-  `Invalid list filter expression.`
+| Service | Action | Result |
+|---|---|---|
+| `vpc` | `list-networks` | HTTP 400 |
+| `loadbalancer` | `list-backend-services` | HTTP 400 |
+| `loadbalancer` | `list-url-maps` | HTTP 400 |
+| `loadbalancer` | `list-target-https-proxies` | HTTP 400 |
+| `cloudcdn` | `list-backend-services-cdn` | HTTP 400 |
+| `compute` | `list-instances` | OK (this endpoint accepts legacy) |
+| `loadbalancer` | `list-forwarding-rules` | OK |
 
-**Root cause**: `pkg/observability/discovery/gcp/network.go::inspectCloudCDN`
-used `gcpLegacyLabelFilter` (GCE legacy dialect, e.g.
-`labels.project=<value>`). The Compute v1 REST API exposes both
-filter dialects per-endpoint:
+All seven use the GCE legacy filter dialect (`labels.project=<value>`)
+under the hood. The Compute v1 REST API's per-endpoint filter parser
+is inconsistent — some endpoints accept legacy, others reject it with
+HTTP 400 "Invalid list filter expression". The pattern doesn't track
+the Go client library either: VPC / LoadBalancer use the older
+`google.golang.org/api/compute/v1` client; Cloud CDN uses the newer
+`cloud.google.com/go/compute/apiv1` client; both reject legacy on
+their respective `aggregatedList`/`list` endpoints.
 
-- `google.golang.org/api/compute/v1` (`computeapi.NewService`) — older
-  client, used by VPC / LoadBalancer / CloudArmor inspectors. Accepts
-  the legacy dialect.
-- `cloud.google.com/go/compute/apiv1` — newer client, used by
-  `inspectCloudCDN` because Cloud CDN is a flag on backend services
-  rather than its own resource type. **Rejects** the legacy dialect
-  for `backendServices.aggregatedList` and requires AIP-160
-  (`labels.project = "<value>"`).
+**Impact**: every InsideOut session whose stack contains any of the
+above components saw a 400 in the panel — not just `gcp_cloud_cdn` as
+the issue originally claimed.
 
-**Impact**: every InsideOut session whose stack contains a
-`gcp_cloud_cdn` component saw a 400 in the panel.
+**Fix (broader than the issue)**: flipped every call site in
+`pkg/observability/discovery/gcp/{network,compute}.go` from
+`gcpLegacyLabelFilter` to `gcpAIP160LabelFilter` (and added a
+`gcpAIP160LabelFilterAnd` helper for the bastion `role` + `project`
+combination). AIP-160 is the modern standard and works on every
+Compute v1 endpoint we exercise — including the ones that do accept
+legacy (instances, forwardingRules, etc.), so we get one universal
+dialect across the codebase.
 
-**Fix**: switched to `gcpAIP160LabelFilter`, factored the request
-construction into `cloudCDNAggregatedListRequest()` so the dialect
-choice is pinned by `TestCloudCDNAggregatedListRequest_AIP160DialectForProjectFilter`.
-Live integration tests (`live_integration_test.go`) cover the no-filter
-and with-filter paths against any real GCP project.
+Pinned by:
+- `TestCloudCDNAggregatedListRequest_AIP160DialectForProjectFilter` —
+  exact filter string for the original symptom.
+- Updated `TestInspectVPC_ListNetworks_AppliesProjectFilter`,
+  `TestInspectLoadBalancer_ListBackendServices_AppliesFilter`,
+  `TestInspectCloudArmor_ListPolicies_AppliesFilter`,
+  `TestInspectBastion_*` — pin the AIP-160 form for every other
+  endpoint.
+- `TestGCPAIP160LabelFilterAnd` — pins the AND-join shape.
+- Live integration tests (`live_integration_test.go`) for the
+  Cloud CDN no-filter + with-filter paths.
 
-The other call sites in `network.go` (VPC, LoadBalancer, CloudArmor)
-use the older `computeapi` client and remain on the legacy dialect —
-they are NOT affected by this bug. A header comment in
-`inspectCloudCDN` documents the asymmetry so a future migration to
-the newer client across the board flips them all in lockstep.
+The legacy helpers (`gcpLegacyLabelFilter`, `gcpLegacyLabelFilterAnd`)
+remain in `helpers.go` for now — no production call site uses them,
+but tests still cover them and they document the dialect we used to
+emit. They'll be deleted in a follow-up cleanup if no consumer reaches
+for them.
 
 ## 5. Test-quality coverage (unit / branch)
 

--- a/pkg/observability/component_metrics.go
+++ b/pkg/observability/component_metrics.go
@@ -35,14 +35,14 @@ var ComponentMetricsMapping = map[composer.ComponentKey]ComponentMetricsBinding{
 	// which discovery does not resolve. Use list-services via the MCP
 	// inspector directly for a service inventory.
 	composer.KeyAWSECS: {Service: "ecs", Action: "list-clusters"},
-	// EKS metrics are pivoted onto EC2 InstanceId via the
-	// `eks:cluster-name` tag (#231 Option A) — list-nodes returns the
-	// cluster's underlying instance IDs so the panel can query AWS/EC2
-	// CPUUtilization per node. The list-clusters action is still
-	// available via the dispatcher for callers that need a cluster
-	// inventory; the panel-default just doesn't use it because the
-	// AWS/EKS namespace publishes nothing usable on stock deployments.
-	composer.KeyAWSEKS:                  {Service: "eks", Action: "list-nodes"},
+	// EKS panel queries ContainerInsights metrics with ClusterName as
+	// the dimension (#233 Option B-1). The aws/eks_nodegroup preset
+	// installs the amazon-cloudwatch-observability addon by default
+	// so the namespace is populated on fresh deployments.
+	// `list-nodes` remains available via the dispatcher for callers
+	// that explicitly want instance-level data (the previous #231
+	// Option A path).
+	composer.KeyAWSEKS:                  {Service: "eks", Action: "list-clusters"},
 	composer.KeyAWSRDS:                  {Service: "rds", Action: "describe-db-instances"},
 	composer.KeyAWSElastiCache:          {Service: "elasticache", Action: "describe-cache-clusters"},
 	composer.KeyAWSS3:                   {Service: "s3", Action: "list-buckets"},

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -237,29 +237,29 @@ var awsServiceMetrics = map[string]AWSObs{
 		},
 	},
 	"eks": {
-		// EKS metrics are pivoted onto AWS/EC2 InstanceId via the
-		// AWS-managed `eks:cluster-name` tag: the orchestrator's
-		// metrics-discovery action is `list-nodes` (see
-		// ComponentMetricsMapping[KeyAWSEKS] in component_metrics.go),
-		// which returns the cluster's underlying EC2 instance IDs.
-		// Querying CPUUtilization on those instances surfaces real data
-		// on every existing EKS deployment (#231 Option A).
+		// ContainerInsights — node + pod metrics published by the
+		// amazon-cloudwatch-observability addon (CloudWatch agent +
+		// fluent-bit DaemonSets). The aws/eks_nodegroup preset
+		// installs the addon by default as of #233 Option B-1
+		// (configurable via var.enable_container_insights). On
+		// fresh deployments the panel populates ~5 minutes after
+		// apply; clusters that opt out via the variable will
+		// render "no observable resources" until they re-enable.
 		//
-		// AWS/EKS itself only publishes a small set of cluster-level
-		// metrics (cluster_failed_node_count, control-plane API server
-		// latency); the node_cpu_utilization / pod_cpu_utilization
-		// names previously listed here are ContainerInsights metrics
-		// that only publish when the amazon-cloudwatch-observability
-		// addon is installed in-cluster — the aws/eks_nodegroup preset
-		// does not install it today, so those queries returned zero
-		// datapoints on every deployment and the panel rendered "no
-		// observable resources". A follow-up issue (#231 Option B)
-		// covers shipping the addon and pivoting back to
-		// ContainerInsights for richer node + pod metrics.
-		Namespace:     "AWS/EC2",
-		DimensionName: "InstanceId",
+		// Predecessors: #231 Option A pivoted onto AWS/EC2
+		// InstanceId via the `eks:cluster-name` tag as a no-preset
+		// fix; that path is gone now (the registry can only
+		// register one namespace per service). Callers that want
+		// instance-level data can still drive the dispatcher's
+		// `eks list-nodes` action directly.
+		Namespace:     "ContainerInsights",
+		DimensionName: "ClusterName",
 		Metrics: []AWSMetricSpec{
-			{Name: "CPUUtilization", Stat: "Average"},
+			{Name: "node_cpu_utilization", Stat: "Average"},
+			{Name: "node_memory_utilization", Stat: "Average"},
+			{Name: "pod_cpu_utilization", Stat: "Average"},
+			{Name: "pod_memory_utilization", Stat: "Average"},
+			{Name: "cluster_failed_node_count", Stat: "Maximum"},
 		},
 	},
 	"elasticache": {

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -388,17 +388,30 @@ var gcpServiceMetrics = map[string]GCPObs{
 		},
 	},
 	"firestore": {
-		// Canonical resource.type for Cloud Monitoring queries against
-		// Firestore is firestore.googleapis.com/Database. Reliable's
-		// catalog had "firestore_instance" — kept here historically but
-		// time series are NOT published under that name. Plus a
-		// request_latencies entry so alarmedGCPMetrics[KeyGCPFirestore]
-		// has a spec to flip Alarmed=true on. #204 P2.
+		// Canonical resource.type for per-database firestore queries is
+		// firestore.googleapis.com/Database (carries database_id /
+		// location / resource_container labels). The legacy
+		// firestore_instance type only carries project_id and is NOT
+		// scopable per-database — so reliable's old catalog using it +
+		// reliable#1259's first attempt to "fix" by setting Database
+		// on document/{read,write,delete}_count both broke per-database
+		// scoping in different ways.
+		//
+		// The truthful catalog (verified live against the Cloud
+		// Monitoring MetricDescriptors API on 2026-05-02): of the four
+		// metrics we want here, only `request_latencies` publishes
+		// under Database. The legacy `document/{read,write,delete}_count`
+		// metrics publish ONLY under firestore_instance — but their
+		// modern `*_ops_count` variants publish under Database with
+		// database_id, which is what we want.
+		//
+		// Plus a request_latencies entry so alarmedGCPMetrics[
+		// KeyGCPFirestore] has a spec to flip Alarmed=true on (#204).
 		Metrics: []GCPMetricSpec{
 			{MetricType: "firestore.googleapis.com/api/request_latencies", ResourceType: "firestore.googleapis.com/Database", LabelKey: "database_id", Aligner: "ALIGN_PERCENTILE_99", DisplayName: "API Request Latency (p99)"},
-			{MetricType: "firestore.googleapis.com/document/read_count", ResourceType: "firestore.googleapis.com/Database", LabelKey: "database_id", Aligner: "ALIGN_RATE", DisplayName: "Document Reads"},
-			{MetricType: "firestore.googleapis.com/document/write_count", ResourceType: "firestore.googleapis.com/Database", LabelKey: "database_id", Aligner: "ALIGN_RATE", DisplayName: "Document Writes"},
-			{MetricType: "firestore.googleapis.com/document/delete_count", ResourceType: "firestore.googleapis.com/Database", LabelKey: "database_id", Aligner: "ALIGN_RATE", DisplayName: "Document Deletes"},
+			{MetricType: "firestore.googleapis.com/document/read_ops_count", ResourceType: "firestore.googleapis.com/Database", LabelKey: "database_id", Aligner: "ALIGN_RATE", DisplayName: "Document Read Ops"},
+			{MetricType: "firestore.googleapis.com/document/write_ops_count", ResourceType: "firestore.googleapis.com/Database", LabelKey: "database_id", Aligner: "ALIGN_RATE", DisplayName: "Document Write Ops"},
+			{MetricType: "firestore.googleapis.com/document/delete_ops_count", ResourceType: "firestore.googleapis.com/Database", LabelKey: "database_id", Aligner: "ALIGN_RATE", DisplayName: "Document Delete Ops"},
 		},
 	},
 	"cloudarmor": {

--- a/pkg/observability/component_observability_test.go
+++ b/pkg/observability/component_observability_test.go
@@ -9,27 +9,34 @@ import (
 )
 
 // TestGCPMetricDefinitions_FirestoreResourceType pins the firestore
-// service-catalog entry against regression. Cloud Monitoring publishes
-// firestore time series under resource.type =
-// "firestore.googleapis.com/Database"; reliable historically used the
-// invalid "firestore_instance" string, which silently produced empty
-// queries. The four metric types here are the surface that
-// alarmedGCPMetrics[KeyGCPFirestore] expects to flip Alarmed=true on
-// (request_latencies) — losing any of them dim-sums the firestore
-// panel and the alarm-author handshake.
+// service-catalog entry against regression on TWO fronts:
 //
-// Ported from reliable PR #1259, which fixed the same bug in
-// reliable's local catalog. The fix has lived upstream here since
-// v0.7.x; this test is the regression pin so future edits to
-// gcpServiceMetrics["firestore"] can't silently re-introduce the
-// "firestore_instance" mistake.
+//  1. Every metric must use the canonical
+//     "firestore.googleapis.com/Database" resource type (the only
+//     resource type that carries database_id, location, and
+//     resource_container labels). The legacy "firestore_instance"
+//     resource only carries project_id, so panels using it cannot
+//     scope per-database.
+//  2. Every metric must publish under that resource type — verified
+//     against Cloud Monitoring's MetricDescriptors API. Picking a
+//     metric whose monitoredResourceTypes doesn't include
+//     "firestore.googleapis.com/Database" silently produces empty
+//     queries (this trapped reliable#1259's first attempt: the legacy
+//     document/{read,write,delete}_count metrics only publish under
+//     firestore_instance — their *_ops_count modern variants are the
+//     ones that publish under Database).
+//
+// Reliable historically used "firestore_instance"; reliable#1259
+// fixed that for request_latencies but accidentally shipped the
+// non-publishing legacy *_count names on Database for the other
+// three. This pin trips on either mistake.
 func TestGCPMetricDefinitions_FirestoreResourceType(t *testing.T) {
 	t.Parallel()
 
 	def, ok := gcpServiceMetrics["firestore"]
 	require.True(t, ok, `gcpServiceMetrics["firestore"] must be present`)
 	require.Len(t, def.Metrics, 4,
-		"firestore catalog must declare exactly four metrics (request_latencies + document {read,write,delete}_count)")
+		"firestore catalog must declare exactly four metrics (request_latencies + document {read,write,delete}_ops_count)")
 
 	const wantResourceType = "firestore.googleapis.com/Database"
 	for i, m := range def.Metrics {
@@ -41,19 +48,23 @@ func TestGCPMetricDefinitions_FirestoreResourceType(t *testing.T) {
 	// Pin metric-type set + order. Order matters because
 	// alarmedGCPMetrics flips Alarmed by name match and the panel
 	// renders metrics in slice order; reordering changes the user-
-	// visible default chart layout.
+	// visible default chart layout. The *_ops_count names are the
+	// modern variants that actually publish under
+	// firestore.googleapis.com/Database (the legacy *_count names only
+	// publish under the firestore_instance resource type and would
+	// return zero data here).
 	wantOrder := []string{
 		"firestore.googleapis.com/api/request_latencies",
-		"firestore.googleapis.com/document/read_count",
-		"firestore.googleapis.com/document/write_count",
-		"firestore.googleapis.com/document/delete_count",
+		"firestore.googleapis.com/document/read_ops_count",
+		"firestore.googleapis.com/document/write_ops_count",
+		"firestore.googleapis.com/document/delete_ops_count",
 	}
 	gotOrder := make([]string, 0, len(def.Metrics))
 	for _, m := range def.Metrics {
 		gotOrder = append(gotOrder, m.MetricType)
 	}
 	assert.Equal(t, wantOrder, gotOrder,
-		"firestore metric order has drifted; reliable#1259 expected request_latencies first so the alarm-author handshake (alarmedGCPMetrics[KeyGCPFirestore]) lands on Alarmed=true")
+		"firestore metric names have drifted; the *_ops_count variants publish under firestore.googleapis.com/Database while the legacy *_count variants only publish under firestore_instance")
 }
 
 // TestGCPMetricDefinitions_FirestoreAlarmBinding pins the

--- a/pkg/observability/component_observability_test.go
+++ b/pkg/observability/component_observability_test.go
@@ -1,0 +1,84 @@
+package observability
+
+import (
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGCPMetricDefinitions_FirestoreResourceType pins the firestore
+// service-catalog entry against regression. Cloud Monitoring publishes
+// firestore time series under resource.type =
+// "firestore.googleapis.com/Database"; reliable historically used the
+// invalid "firestore_instance" string, which silently produced empty
+// queries. The four metric types here are the surface that
+// alarmedGCPMetrics[KeyGCPFirestore] expects to flip Alarmed=true on
+// (request_latencies) — losing any of them dim-sums the firestore
+// panel and the alarm-author handshake.
+//
+// Ported from reliable PR #1259, which fixed the same bug in
+// reliable's local catalog. The fix has lived upstream here since
+// v0.7.x; this test is the regression pin so future edits to
+// gcpServiceMetrics["firestore"] can't silently re-introduce the
+// "firestore_instance" mistake.
+func TestGCPMetricDefinitions_FirestoreResourceType(t *testing.T) {
+	t.Parallel()
+
+	def, ok := gcpServiceMetrics["firestore"]
+	require.True(t, ok, `gcpServiceMetrics["firestore"] must be present`)
+	require.Len(t, def.Metrics, 4,
+		"firestore catalog must declare exactly four metrics (request_latencies + document {read,write,delete}_count)")
+
+	const wantResourceType = "firestore.googleapis.com/Database"
+	for i, m := range def.Metrics {
+		assert.Equal(t, wantResourceType, m.ResourceType,
+			"firestore metric[%d] (%s) must use canonical ResourceType %q (not the legacy %q)",
+			i, m.MetricType, wantResourceType, "firestore_instance")
+	}
+
+	// Pin metric-type set + order. Order matters because
+	// alarmedGCPMetrics flips Alarmed by name match and the panel
+	// renders metrics in slice order; reordering changes the user-
+	// visible default chart layout.
+	wantOrder := []string{
+		"firestore.googleapis.com/api/request_latencies",
+		"firestore.googleapis.com/document/read_count",
+		"firestore.googleapis.com/document/write_count",
+		"firestore.googleapis.com/document/delete_count",
+	}
+	gotOrder := make([]string, 0, len(def.Metrics))
+	for _, m := range def.Metrics {
+		gotOrder = append(gotOrder, m.MetricType)
+	}
+	assert.Equal(t, wantOrder, gotOrder,
+		"firestore metric order has drifted; reliable#1259 expected request_latencies first so the alarm-author handshake (alarmedGCPMetrics[KeyGCPFirestore]) lands on Alarmed=true")
+}
+
+// TestGCPMetricDefinitions_FirestoreAlarmBinding pins the
+// alarm-author handshake half of reliable#1259's fix: the alarm bound
+// to KeyGCPFirestore must reference a metric_type that exists in the
+// catalog above, otherwise componentObs() can't flip Alarmed=true and
+// TestObservabilitySpecMatchesEmittedAlarms (the HCL-side gate) loses
+// its upstream pair.
+func TestGCPMetricDefinitions_FirestoreAlarmBinding(t *testing.T) {
+	t.Parallel()
+
+	author, ok := alarmedGCPMetrics[composer.KeyGCPFirestore]
+	require.True(t, ok, "alarmedGCPMetrics must bind KeyGCPFirestore")
+	require.NotEmpty(t, author.Metrics, "KeyGCPFirestore alarm author must declare at least one metric_type")
+
+	// Every alarmed metric_type must exist in the catalog so
+	// componentObs() can flip Alarmed.
+	catalog := make(map[string]struct{}, len(gcpServiceMetrics["firestore"].Metrics))
+	for _, m := range gcpServiceMetrics["firestore"].Metrics {
+		catalog[m.MetricType] = struct{}{}
+	}
+	for _, mt := range author.Metrics {
+		_, present := catalog[mt]
+		assert.Truef(t, present,
+			"alarmedGCPMetrics[KeyGCPFirestore] references %q which is not in gcpServiceMetrics[\"firestore\"]; the Alarmed flag will never be set",
+			mt)
+	}
+}

--- a/pkg/observability/discovery/aws/account.go
+++ b/pkg/observability/discovery/aws/account.go
@@ -25,37 +25,49 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
+// iamAccountInfoClient is the IAM half of the get-info compose. The
+// stsAccountClient interface for GetCallerIdentity already exists in
+// data.go and is reused here.
+type iamAccountInfoClient interface {
+	ListAccountAliases(ctx context.Context, params *iam.ListAccountAliasesInput, optFns ...func(*iam.Options)) (*iam.ListAccountAliasesOutput, error)
+	GetAccountSummary(ctx context.Context, params *iam.GetAccountSummaryInput, optFns ...func(*iam.Options)) (*iam.GetAccountSummaryOutput, error)
+}
+
 func inspectAccount(ctx context.Context, cfg aws.Config, action, _ string) (any, error) {
 	switch action {
 	case "get-info":
-		stsClient := sts.NewFromConfig(cfg)
-		iamClient := iam.NewFromConfig(cfg)
-		info := make(map[string]any)
-
-		identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
-		if err == nil {
-			info["AccountId"] = aws.ToString(identity.Account)
-			info["Arn"] = aws.ToString(identity.Arn)
-			info["UserId"] = aws.ToString(identity.UserId)
-		} else {
-			log.Printf("[aws-inspect] account info: sts.GetCallerIdentity failed: %v", err)
-		}
-
-		info["Region"] = cfg.Region
-
-		aliases, err := iamClient.ListAccountAliases(ctx, &iam.ListAccountAliasesInput{})
-		if err == nil && len(aliases.AccountAliases) > 0 {
-			info["AccountAliases"] = aliases.AccountAliases
-		}
-
-		summary, err := iamClient.GetAccountSummary(ctx, &iam.GetAccountSummaryInput{})
-		if err == nil {
-			info["AccountSummary"] = summary.SummaryMap
-		}
-
-		return info, nil
-
+		return gatherAccountInfo(ctx, cfg.Region, sts.NewFromConfig(cfg), iam.NewFromConfig(cfg)), nil
 	default:
 		return nil, unsupportedActionError("account", action)
 	}
+}
+
+// gatherAccountInfo composes the three account-summary calls into a
+// single map. Per-call errors log+continue so a partial answer
+// (e.g. caller identity without aliases) still reaches the panel.
+func gatherAccountInfo(ctx context.Context, region string, stsClient stsAccountClient, iamClient iamAccountInfoClient) map[string]any {
+	info := make(map[string]any)
+
+	identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err == nil {
+		info["AccountId"] = aws.ToString(identity.Account)
+		info["Arn"] = aws.ToString(identity.Arn)
+		info["UserId"] = aws.ToString(identity.UserId)
+	} else {
+		log.Printf("[aws-inspect] account info: sts.GetCallerIdentity failed: %v", err)
+	}
+
+	info["Region"] = region
+
+	aliases, err := iamClient.ListAccountAliases(ctx, &iam.ListAccountAliasesInput{})
+	if err == nil && len(aliases.AccountAliases) > 0 {
+		info["AccountAliases"] = aliases.AccountAliases
+	}
+
+	summary, err := iamClient.GetAccountSummary(ctx, &iam.GetAccountSummaryInput{})
+	if err == nil {
+		info["AccountSummary"] = summary.SummaryMap
+	}
+
+	return info
 }

--- a/pkg/observability/discovery/aws/account_test.go
+++ b/pkg/observability/discovery/aws/account_test.go
@@ -1,0 +1,194 @@
+// Account-summary inspector tests. Covers the partial-failure
+// log+continue contract: each of the three SDK calls (sts.GetCallerIdentity,
+// iam.ListAccountAliases, iam.GetAccountSummary) can fail independently
+// and gatherAccountInfo must still return whatever it managed to fetch.
+//
+// Ported from reliable internal/agentapi/aws_inspect_test.go cases
+// covering inspectAccount.
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeIAMAccountClient implements iamAccountInfoClient for the
+// account-info compose. Distinct from the bedrock_test.go fakeIAMClient
+// (which only stubs GetRole) so the two test surfaces don't fight over
+// the same struct shape.
+type fakeIAMAccountClient struct {
+	aliasesOut *iam.ListAccountAliasesOutput
+	aliasesErr error
+	summaryOut *iam.GetAccountSummaryOutput
+	summaryErr error
+}
+
+func (f *fakeIAMAccountClient) ListAccountAliases(_ context.Context, _ *iam.ListAccountAliasesInput, _ ...func(*iam.Options)) (*iam.ListAccountAliasesOutput, error) {
+	if f.aliasesErr != nil {
+		return nil, f.aliasesErr
+	}
+	if f.aliasesOut == nil {
+		return &iam.ListAccountAliasesOutput{}, nil
+	}
+	return f.aliasesOut, nil
+}
+
+func (f *fakeIAMAccountClient) GetAccountSummary(_ context.Context, _ *iam.GetAccountSummaryInput, _ ...func(*iam.Options)) (*iam.GetAccountSummaryOutput, error) {
+	if f.summaryErr != nil {
+		return nil, f.summaryErr
+	}
+	if f.summaryOut == nil {
+		return &iam.GetAccountSummaryOutput{}, nil
+	}
+	return f.summaryOut, nil
+}
+
+func TestGatherAccountInfo_HappyPath(t *testing.T) {
+	t.Parallel()
+	stsClient := &fakeSTSClient{
+		out: &sts.GetCallerIdentityOutput{
+			Account: aws.String("123456789012"),
+			Arn:     aws.String("arn:aws:iam::123456789012:user/alice"),
+			UserId:  aws.String("AIDA1234567EXAMPLE"),
+		},
+	}
+	iamClient := &fakeIAMAccountClient{
+		aliasesOut: &iam.ListAccountAliasesOutput{
+			AccountAliases: []string{"my-org"},
+		},
+		summaryOut: &iam.GetAccountSummaryOutput{
+			SummaryMap: map[string]int32{
+				"Users":  3,
+				"Groups": 1,
+			},
+		},
+	}
+
+	got := gatherAccountInfo(context.Background(), "eu-west-2", stsClient, iamClient)
+
+	assert.Equal(t, "123456789012", got["AccountId"])
+	assert.Equal(t, "arn:aws:iam::123456789012:user/alice", got["Arn"])
+	assert.Equal(t, "AIDA1234567EXAMPLE", got["UserId"])
+	assert.Equal(t, "eu-west-2", got["Region"])
+	assert.Equal(t, []string{"my-org"}, got["AccountAliases"])
+	assert.Equal(t, map[string]int32{"Users": 3, "Groups": 1}, got["AccountSummary"])
+}
+
+// TestGatherAccountInfo_STSFailureLogsAndContinues — sts identity fails
+// but the panel still gets Region + IAM data. The user sees a partial
+// account info card rather than a 500.
+func TestGatherAccountInfo_STSFailureLogsAndContinues(t *testing.T) {
+	t.Parallel()
+	stsClient := &fakeSTSClient{err: errors.New("sts down")}
+	iamClient := &fakeIAMAccountClient{
+		aliasesOut: &iam.ListAccountAliasesOutput{
+			AccountAliases: []string{"my-org"},
+		},
+		summaryOut: &iam.GetAccountSummaryOutput{
+			SummaryMap: map[string]int32{"Users": 7},
+		},
+	}
+
+	got := gatherAccountInfo(context.Background(), "us-east-1", stsClient, iamClient)
+
+	_, hasAccountID := got["AccountId"]
+	assert.False(t, hasAccountID, "AccountId must be omitted when GetCallerIdentity fails")
+	_, hasArn := got["Arn"]
+	assert.False(t, hasArn, "Arn must be omitted when GetCallerIdentity fails")
+	_, hasUserID := got["UserId"]
+	assert.False(t, hasUserID, "UserId must be omitted when GetCallerIdentity fails")
+
+	assert.Equal(t, "us-east-1", got["Region"], "Region must be set even when sts fails")
+	assert.Equal(t, []string{"my-org"}, got["AccountAliases"])
+	assert.Equal(t, map[string]int32{"Users": 7}, got["AccountSummary"])
+}
+
+// TestGatherAccountInfo_IAMAliasesFailureLogsAndContinues — IAM aliases
+// failing must not prevent caller identity + summary from rendering.
+func TestGatherAccountInfo_IAMAliasesFailureLogsAndContinues(t *testing.T) {
+	t.Parallel()
+	stsClient := &fakeSTSClient{
+		out: &sts.GetCallerIdentityOutput{
+			Account: aws.String("123456789012"),
+			Arn:     aws.String("arn:aws:iam::123456789012:user/bob"),
+			UserId:  aws.String("AIDABOB"),
+		},
+	}
+	iamClient := &fakeIAMAccountClient{
+		aliasesErr: errors.New("AccessDenied"),
+		summaryOut: &iam.GetAccountSummaryOutput{
+			SummaryMap: map[string]int32{"Users": 1},
+		},
+	}
+
+	got := gatherAccountInfo(context.Background(), "ap-southeast-1", stsClient, iamClient)
+
+	assert.Equal(t, "123456789012", got["AccountId"])
+	_, hasAliases := got["AccountAliases"]
+	assert.False(t, hasAliases, "AccountAliases must be omitted when ListAccountAliases fails")
+	assert.Equal(t, map[string]int32{"Users": 1}, got["AccountSummary"])
+}
+
+// TestGatherAccountInfo_IAMSummaryFailureLogsAndContinues — summary
+// failing alone should not blank out the rest.
+func TestGatherAccountInfo_IAMSummaryFailureLogsAndContinues(t *testing.T) {
+	t.Parallel()
+	stsClient := &fakeSTSClient{
+		out: &sts.GetCallerIdentityOutput{
+			Account: aws.String("999999999999"),
+			Arn:     aws.String("arn:aws:iam::999999999999:user/svc"),
+			UserId:  aws.String("AIDASVC"),
+		},
+	}
+	iamClient := &fakeIAMAccountClient{
+		aliasesOut: &iam.ListAccountAliasesOutput{AccountAliases: []string{"prod"}},
+		summaryErr: errors.New("Throttling"),
+	}
+
+	got := gatherAccountInfo(context.Background(), "eu-central-1", stsClient, iamClient)
+
+	assert.Equal(t, "999999999999", got["AccountId"])
+	assert.Equal(t, []string{"prod"}, got["AccountAliases"])
+	_, hasSummary := got["AccountSummary"]
+	assert.False(t, hasSummary, "AccountSummary must be omitted when GetAccountSummary fails")
+}
+
+// TestGatherAccountInfo_EmptyAliasesNotSet mirrors reliable's
+// behaviour: ListAccountAliases returning successfully but empty must
+// NOT add an "AccountAliases":[] key — keeps the panel JSON tight.
+func TestGatherAccountInfo_EmptyAliasesNotSet(t *testing.T) {
+	t.Parallel()
+	stsClient := &fakeSTSClient{
+		out: &sts.GetCallerIdentityOutput{
+			Account: aws.String("123456789012"),
+			Arn:     aws.String("arn:aws:iam::123456789012:root"),
+			UserId:  aws.String("123456789012"),
+		},
+	}
+	iamClient := &fakeIAMAccountClient{
+		aliasesOut: &iam.ListAccountAliasesOutput{AccountAliases: []string{}},
+	}
+
+	got := gatherAccountInfo(context.Background(), "us-east-2", stsClient, iamClient)
+
+	_, hasAliases := got["AccountAliases"]
+	assert.False(t, hasAliases, "empty AccountAliases must be omitted from the panel payload")
+}
+
+// TestInspectAccount_UnknownAction returns the standard
+// unsupported-action error so callers get a structured failure.
+func TestInspectAccount_UnknownAction(t *testing.T) {
+	t.Parallel()
+	_, err := inspectAccount(context.Background(), aws.Config{Region: "us-east-1"}, "no-such-action", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account")
+	assert.Contains(t, err.Error(), "no-such-action")
+}

--- a/pkg/observability/discovery/aws/cloudwatchlogs.go
+++ b/pkg/observability/discovery/aws/cloudwatchlogs.go
@@ -3,12 +3,25 @@
 // Ported from reliable internal/agentapi/aws_inspect.go
 // (cloudwatchlogs:790).
 //
-// CloudWatch Logs supports server-side LogGroupNamePrefix filtering, so
-// project scoping happens via a `/aws/<project>` prefix rather than a
-// fan-out tag check. This relies on the preset convention of naming
-// project log groups under `/aws/<project>/...` — if the preset ever
-// drops that convention, the prefix filter goes from "narrow" to
-// "empty". Mirrors the prefix path reliable already shipped.
+// Project scoping uses LogGroupNamePattern (server-side case-sensitive
+// substring match) rather than LogGroupNamePrefix. Real-world preset
+// log group names don't share a single prefix:
+//
+//   /aws/eks/<project>-prod-lu-eks0/cluster
+//   /aws/rds/instance/<project>-prod-...-rds0/postgresql
+//   /aws/lambda/<project>-...
+//   /<project>-prod-...-cwl<id>/app
+//
+// A `/aws/<project>` prefix matches none of these. The project name
+// itself is contained as a substring in every project-scoped log group
+// emitted by these presets, so a substring filter scopes correctly
+// across all four shapes. Verified live on cust2 (project
+// `io-hrbs5zprbk51`, us-east-1) where the prefix path returned 0 of 4
+// project-scoped log groups; the substring path returns all 4.
+//
+// LogGroupNamePattern reduces the response to {arn, creationTime,
+// logGroupName}. Discovery only consumes logGroupName, so the field
+// reduction is a non-issue.
 
 package aws
 
@@ -42,14 +55,15 @@ func inspectCloudWatchLogs(ctx context.Context, cfg aws.Config, action, filters 
 	}
 }
 
-// describeProjectLogGroups runs DescribeLogGroups, applying the
-// `/aws/<project>` LogGroupNamePrefix filter when project is non-empty
-// so callers see only this stack's groups.
+// describeProjectLogGroups runs DescribeLogGroups, applying the project
+// name as a LogGroupNamePattern (server-side substring match) when
+// project is non-empty so callers see only this stack's groups —
+// regardless of whether the log group's prefix is `/aws/eks/`,
+// `/aws/rds/instance/`, `/aws/lambda/`, or the bare `/<project>-...`.
 func describeProjectLogGroups(ctx context.Context, client cloudWatchLogsClient, project string) ([]cloudwatchlogstypes.LogGroup, error) {
 	input := &cloudwatchlogs.DescribeLogGroupsInput{}
 	if project != "" {
-		prefix := "/aws/" + project
-		input.LogGroupNamePrefix = &prefix
+		input.LogGroupNamePattern = aws.String(project)
 	}
 	out, err := client.DescribeLogGroups(ctx, input)
 	if err != nil {

--- a/pkg/observability/discovery/aws/cloudwatchlogs.go
+++ b/pkg/observability/discovery/aws/cloudwatchlogs.go
@@ -17,29 +17,43 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cloudwatchlogstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/observability/filter"
 )
 
+// cloudWatchLogsClient is the narrowed surface used by the
+// describe-log-groups action. Lets tests inject a fake without doing
+// real AWS auth.
+type cloudWatchLogsClient interface {
+	DescribeLogGroups(ctx context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
+}
+
 func inspectCloudWatchLogs(ctx context.Context, cfg aws.Config, action, filters string) (any, error) {
-	client := cloudwatchlogs.NewFromConfig(cfg)
 	project := filter.Project(filters)
 
 	switch action {
 	case "describe-log-groups":
-		input := &cloudwatchlogs.DescribeLogGroupsInput{}
-		if project != "" {
-			prefix := "/aws/" + project
-			input.LogGroupNamePrefix = &prefix
-		}
-		out, err := client.DescribeLogGroups(ctx, input)
-		if err != nil {
-			return nil, err
-		}
-		return out.LogGroups, nil
+		return describeProjectLogGroups(ctx, cloudwatchlogs.NewFromConfig(cfg), project)
 	case "get-metrics":
 		return metricsRouted("cloudwatchlogs")
 	default:
 		return nil, unsupportedActionError("cloudwatchlogs", action)
 	}
+}
+
+// describeProjectLogGroups runs DescribeLogGroups, applying the
+// `/aws/<project>` LogGroupNamePrefix filter when project is non-empty
+// so callers see only this stack's groups.
+func describeProjectLogGroups(ctx context.Context, client cloudWatchLogsClient, project string) ([]cloudwatchlogstypes.LogGroup, error) {
+	input := &cloudwatchlogs.DescribeLogGroupsInput{}
+	if project != "" {
+		prefix := "/aws/" + project
+		input.LogGroupNamePrefix = &prefix
+	}
+	out, err := client.DescribeLogGroups(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return out.LogGroups, nil
 }

--- a/pkg/observability/discovery/aws/cloudwatchlogs_test.go
+++ b/pkg/observability/discovery/aws/cloudwatchlogs_test.go
@@ -1,9 +1,13 @@
-// CloudWatch Logs inspector tests. Covers the `/aws/<project>` prefix
-// scoping that lets the panel show only this stack's log groups instead
-// of fanning out per-resource ListTagsForResource calls.
+// CloudWatch Logs inspector tests. Covers the substring scoping
+// (LogGroupNamePattern = project) that lets the panel show only this
+// stack's log groups across the four real-world naming shapes
+// (`/aws/eks/...`, `/aws/rds/instance/...`, `/aws/lambda/...`,
+// `/<project>-...`) instead of fanning out per-resource
+// ListTagsForResource calls.
 //
 // Ported from reliable internal/agentapi/aws_inspect_test.go cases for
-// inspectCloudWatchLogs.
+// inspectCloudWatchLogs; the prefix→substring switch is documented in
+// cloudwatchlogs.go's header.
 
 package aws
 
@@ -38,33 +42,44 @@ func (f *fakeCloudWatchLogsClient) DescribeLogGroups(_ context.Context, in *clou
 	return f.out, nil
 }
 
-// TestDescribeProjectLogGroups_PrefixScoping pins the prefix scoping
-// contract: a non-empty project becomes `/aws/<project>` so AWS does
-// the filtering server-side.
-func TestDescribeProjectLogGroups_PrefixScoping(t *testing.T) {
+// TestDescribeProjectLogGroups_SubstringScoping pins the substring
+// scoping contract: a non-empty project becomes a LogGroupNamePattern
+// (server-side case-sensitive substring match) so the four real-world
+// preset naming shapes all match — `/aws/eks/<project>-...`,
+// `/aws/rds/instance/<project>-...`, `/aws/lambda/<project>-...`,
+// `/<project>-...`. LogGroupNamePrefix would only catch the (rare)
+// `/aws/<project>` shape and miss the others, returning 0 results on
+// real cust2 stacks.
+func TestDescribeProjectLogGroups_SubstringScoping(t *testing.T) {
 	t.Parallel()
 	client := &fakeCloudWatchLogsClient{
 		out: &cloudwatchlogs.DescribeLogGroupsOutput{
 			LogGroups: []cloudwatchlogstypes.LogGroup{
-				{LogGroupName: aws.String("/aws/myproj/lambda/foo")},
-				{LogGroupName: aws.String("/aws/myproj/eks/cluster")},
+				{LogGroupName: aws.String("/aws/eks/myproj-prod-lu-eks0/cluster")},
+				{LogGroupName: aws.String("/aws/rds/instance/myproj-prod-rds0/postgresql")},
+				{LogGroupName: aws.String("/aws/lambda/myproj-fn")},
+				{LogGroupName: aws.String("/myproj-prod-cwl/app")},
 			},
 		},
 	}
 
 	got, err := describeProjectLogGroups(context.Background(), client, "myproj")
 	require.NoError(t, err)
-	require.Len(t, got, 2)
+	require.Len(t, got, 4)
 
 	require.NotNil(t, client.lastInput, "DescribeLogGroups must be called once")
-	require.NotNil(t, client.lastInput.LogGroupNamePrefix, "non-empty project must populate LogGroupNamePrefix")
-	assert.Equal(t, "/aws/myproj", aws.ToString(client.lastInput.LogGroupNamePrefix))
+	require.NotNil(t, client.lastInput.LogGroupNamePattern, "non-empty project must populate LogGroupNamePattern")
+	assert.Equal(t, "myproj", aws.ToString(client.lastInput.LogGroupNamePattern),
+		"the pattern must be the bare project name — substring match catches all four real preset naming shapes")
+	assert.Nil(t, client.lastInput.LogGroupNamePrefix,
+		"LogGroupNamePrefix and LogGroupNamePattern are mutually exclusive at the AWS API; only the substring filter must be set")
 }
 
-// TestDescribeProjectLogGroups_EmptyProjectNoPrefix — when no project
-// filter is supplied, the call must NOT pass a prefix or the panel
-// shows nothing on stacks where log groups predate the convention.
-func TestDescribeProjectLogGroups_EmptyProjectNoPrefix(t *testing.T) {
+// TestDescribeProjectLogGroups_EmptyProjectNoFilter — when no project
+// filter is supplied, the call must NOT pass any name filter or the
+// panel would return zero on stacks where log groups predate the
+// project convention.
+func TestDescribeProjectLogGroups_EmptyProjectNoFilter(t *testing.T) {
 	t.Parallel()
 	client := &fakeCloudWatchLogsClient{
 		out: &cloudwatchlogs.DescribeLogGroupsOutput{
@@ -79,7 +94,8 @@ func TestDescribeProjectLogGroups_EmptyProjectNoPrefix(t *testing.T) {
 	require.Len(t, got, 1)
 
 	require.NotNil(t, client.lastInput)
-	assert.Nil(t, client.lastInput.LogGroupNamePrefix, "empty project must NOT set a prefix")
+	assert.Nil(t, client.lastInput.LogGroupNamePattern, "empty project must NOT set a pattern")
+	assert.Nil(t, client.lastInput.LogGroupNamePrefix, "empty project must NOT set a prefix either")
 }
 
 // TestDescribeProjectLogGroups_APIError surfaces the error verbatim;

--- a/pkg/observability/discovery/aws/cloudwatchlogs_test.go
+++ b/pkg/observability/discovery/aws/cloudwatchlogs_test.go
@@ -1,0 +1,131 @@
+// CloudWatch Logs inspector tests. Covers the `/aws/<project>` prefix
+// scoping that lets the panel show only this stack's log groups instead
+// of fanning out per-resource ListTagsForResource calls.
+//
+// Ported from reliable internal/agentapi/aws_inspect_test.go cases for
+// inspectCloudWatchLogs.
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cloudwatchlogstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCloudWatchLogsClient struct {
+	out       *cloudwatchlogs.DescribeLogGroupsOutput
+	err       error
+	lastInput *cloudwatchlogs.DescribeLogGroupsInput
+	calls     int
+}
+
+func (f *fakeCloudWatchLogsClient) DescribeLogGroups(_ context.Context, in *cloudwatchlogs.DescribeLogGroupsInput, _ ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+	f.calls++
+	f.lastInput = in
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.out == nil {
+		return &cloudwatchlogs.DescribeLogGroupsOutput{}, nil
+	}
+	return f.out, nil
+}
+
+// TestDescribeProjectLogGroups_PrefixScoping pins the prefix scoping
+// contract: a non-empty project becomes `/aws/<project>` so AWS does
+// the filtering server-side.
+func TestDescribeProjectLogGroups_PrefixScoping(t *testing.T) {
+	t.Parallel()
+	client := &fakeCloudWatchLogsClient{
+		out: &cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []cloudwatchlogstypes.LogGroup{
+				{LogGroupName: aws.String("/aws/myproj/lambda/foo")},
+				{LogGroupName: aws.String("/aws/myproj/eks/cluster")},
+			},
+		},
+	}
+
+	got, err := describeProjectLogGroups(context.Background(), client, "myproj")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	require.NotNil(t, client.lastInput, "DescribeLogGroups must be called once")
+	require.NotNil(t, client.lastInput.LogGroupNamePrefix, "non-empty project must populate LogGroupNamePrefix")
+	assert.Equal(t, "/aws/myproj", aws.ToString(client.lastInput.LogGroupNamePrefix))
+}
+
+// TestDescribeProjectLogGroups_EmptyProjectNoPrefix — when no project
+// filter is supplied, the call must NOT pass a prefix or the panel
+// shows nothing on stacks where log groups predate the convention.
+func TestDescribeProjectLogGroups_EmptyProjectNoPrefix(t *testing.T) {
+	t.Parallel()
+	client := &fakeCloudWatchLogsClient{
+		out: &cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []cloudwatchlogstypes.LogGroup{
+				{LogGroupName: aws.String("/aws/lambda/legacy")},
+			},
+		},
+	}
+
+	got, err := describeProjectLogGroups(context.Background(), client, "")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	require.NotNil(t, client.lastInput)
+	assert.Nil(t, client.lastInput.LogGroupNamePrefix, "empty project must NOT set a prefix")
+}
+
+// TestDescribeProjectLogGroups_APIError surfaces the error verbatim;
+// callers (the dispatcher) decide whether to log+skip or propagate.
+func TestDescribeProjectLogGroups_APIError(t *testing.T) {
+	t.Parallel()
+	client := &fakeCloudWatchLogsClient{err: errors.New("AccessDenied")}
+
+	_, err := describeProjectLogGroups(context.Background(), client, "myproj")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AccessDenied")
+}
+
+// TestDescribeProjectLogGroups_EmptyResult returns an empty slice (not
+// nil) so the JSON wire shape is `[]` not `null`.
+func TestDescribeProjectLogGroups_EmptyResult(t *testing.T) {
+	t.Parallel()
+	client := &fakeCloudWatchLogsClient{
+		out: &cloudwatchlogs.DescribeLogGroupsOutput{LogGroups: []cloudwatchlogstypes.LogGroup{}},
+	}
+
+	got, err := describeProjectLogGroups(context.Background(), client, "myproj")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestInspectCloudWatchLogs_GetMetricsAction routes through
+// metricsRouted, which deliberately returns ErrUseMetricsPackage so
+// callers know to invoke pkg/observability/metrics directly. Pin the
+// error chain so the routing contract doesn't silently change.
+func TestInspectCloudWatchLogs_GetMetricsAction(t *testing.T) {
+	t.Parallel()
+	_, err := inspectCloudWatchLogs(context.Background(), aws.Config{Region: "eu-west-2"}, "get-metrics", "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUseMetricsPackage,
+		"get-metrics must surface ErrUseMetricsPackage so callers route to pkg/observability/metrics")
+	assert.Contains(t, err.Error(), "cloudwatchlogs",
+		"the routed error must mention the service for log diagnosis")
+}
+
+// TestInspectCloudWatchLogs_UnknownAction returns the canonical
+// unsupported-action error.
+func TestInspectCloudWatchLogs_UnknownAction(t *testing.T) {
+	t.Parallel()
+	_, err := inspectCloudWatchLogs(context.Background(), aws.Config{Region: "eu-west-2"}, "no-such-action", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cloudwatchlogs")
+	assert.Contains(t, err.Error(), "no-such-action")
+}

--- a/pkg/observability/discovery/aws/connect_info_test.go
+++ b/pkg/observability/discovery/aws/connect_info_test.go
@@ -1,0 +1,213 @@
+// EC2 Instance Connect URL enrichment tests. Pure-function tests, no
+// AWS SDK calls — covers the running/stopped state filter, mixed
+// reservation merging, and the JSON round-trip fallback contract.
+//
+// Ported from reliable internal/agentapi/aws_inspect_test.go::
+// TestEnrichEC2WithConnectURLs.
+
+package aws
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runningInstance constructs a minimal Reservation with one running
+// instance — the most common case the URL enrichment must hit.
+func runningInstance(id string) ec2types.Reservation {
+	return ec2types.Reservation{
+		Instances: []ec2types.Instance{
+			{
+				InstanceId: aws.String(id),
+				State:      &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning},
+			},
+		},
+	}
+}
+
+func stoppedInstance(id string) ec2types.Reservation {
+	return ec2types.Reservation{
+		Instances: []ec2types.Instance{
+			{
+				InstanceId: aws.String(id),
+				State:      &ec2types.InstanceState{Name: ec2types.InstanceStateNameStopped},
+			},
+		},
+	}
+}
+
+// urlsFromEnriched walks the JSON-friendly enriched output and collects
+// (instanceId → InstanceConnectURL) pairs. Returns nil when the value
+// shape isn't enriched (e.g. the JSON-fallback path returned the
+// original []ec2types.Reservation).
+func urlsFromEnriched(t *testing.T, got any) map[string]string {
+	t.Helper()
+	enriched, ok := got.([]map[string]any)
+	if !ok {
+		return nil
+	}
+	urls := make(map[string]string, len(enriched))
+	for _, res := range enriched {
+		instances, ok := res["Instances"].([]any)
+		require.True(t, ok, "enriched reservation must carry []Instances")
+		for _, inst := range instances {
+			m, ok := inst.(map[string]any)
+			require.True(t, ok)
+			id, _ := m["InstanceId"].(string)
+			if u, ok := m["InstanceConnectURL"].(string); ok {
+				urls[id] = u
+			} else {
+				urls[id] = ""
+			}
+		}
+	}
+	return urls
+}
+
+func TestEnrichEC2WithConnectURLs_RunningGetsURL(t *testing.T) {
+	t.Parallel()
+	got := enrichEC2WithConnectURLs("eu-west-2", []ec2types.Reservation{runningInstance("i-running")})
+	urls := urlsFromEnriched(t, got)
+	require.NotNil(t, urls, "running instance must produce enriched output, not the raw fallback")
+
+	url, ok := urls["i-running"]
+	require.True(t, ok)
+	assert.NotEmpty(t, url, "running instance must carry InstanceConnectURL")
+	assert.True(t, strings.HasPrefix(url, "https://eu-west-2.console.aws.amazon.com/ec2-instance-connect/ssh"),
+		"URL must point at the EC2 Instance Connect console for the right region: %s", url)
+	assert.Contains(t, url, "instanceId=i-running")
+	assert.Contains(t, url, "region=eu-west-2")
+}
+
+func TestEnrichEC2WithConnectURLs_StoppedNoURL(t *testing.T) {
+	t.Parallel()
+	got := enrichEC2WithConnectURLs("us-east-1", []ec2types.Reservation{stoppedInstance("i-stopped")})
+	urls := urlsFromEnriched(t, got)
+	require.NotNil(t, urls)
+
+	url, ok := urls["i-stopped"]
+	require.True(t, ok)
+	assert.Empty(t, url, "stopped instance must NOT carry an InstanceConnectURL — the link would 500 in the console")
+}
+
+func TestEnrichEC2WithConnectURLs_EmptyReservationsReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	got := enrichEC2WithConnectURLs("eu-west-2", []ec2types.Reservation{})
+	enriched, ok := got.([]map[string]any)
+	require.True(t, ok, "empty reservations must still produce a JSON-friendly slice (not raw []ec2types.Reservation)")
+	assert.Empty(t, enriched)
+}
+
+// TestEnrichEC2WithConnectURLs_MixedRunningAndStopped — the running
+// instance gets a URL, the stopped one doesn't, both stay in the
+// output.
+func TestEnrichEC2WithConnectURLs_MixedRunningAndStopped(t *testing.T) {
+	t.Parallel()
+	mixed := []ec2types.Reservation{
+		runningInstance("i-up"),
+		stoppedInstance("i-down"),
+	}
+
+	got := enrichEC2WithConnectURLs("ap-southeast-1", mixed)
+	urls := urlsFromEnriched(t, got)
+	require.NotNil(t, urls)
+	require.Len(t, urls, 2, "both reservations must survive the enrichment")
+
+	assert.Contains(t, urls["i-up"], "instanceId=i-up", "running instance must be enriched")
+	assert.Empty(t, urls["i-down"], "stopped instance must not be enriched")
+}
+
+// TestEnrichEC2WithConnectURLs_MultipleInstancesPerReservation — one
+// reservation can carry multiple instances; the per-instance state
+// check must apply individually.
+func TestEnrichEC2WithConnectURLs_MultipleInstancesPerReservation(t *testing.T) {
+	t.Parallel()
+	res := ec2types.Reservation{
+		Instances: []ec2types.Instance{
+			{InstanceId: aws.String("i-a"), State: &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning}},
+			{InstanceId: aws.String("i-b"), State: &ec2types.InstanceState{Name: ec2types.InstanceStateNameStopped}},
+			{InstanceId: aws.String("i-c"), State: &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning}},
+		},
+	}
+
+	got := enrichEC2WithConnectURLs("eu-west-2", []ec2types.Reservation{res})
+	urls := urlsFromEnriched(t, got)
+	require.NotNil(t, urls)
+	require.Len(t, urls, 3)
+
+	assert.Contains(t, urls["i-a"], "instanceId=i-a")
+	assert.Empty(t, urls["i-b"])
+	assert.Contains(t, urls["i-c"], "instanceId=i-c")
+}
+
+// TestEnrichEC2WithConnectURLs_RegionPropagatesIntoURL — the URL
+// hardcodes the region in two places (host and query string); both
+// must reflect the caller's region.
+func TestEnrichEC2WithConnectURLs_RegionPropagatesIntoURL(t *testing.T) {
+	t.Parallel()
+	got := enrichEC2WithConnectURLs("us-east-2", []ec2types.Reservation{runningInstance("i-1")})
+	urls := urlsFromEnriched(t, got)
+	require.NotNil(t, urls)
+	url := urls["i-1"]
+
+	assert.True(t, strings.HasPrefix(url, "https://us-east-2.console.aws.amazon.com/"), "host must use the caller region: %s", url)
+	assert.Contains(t, url, "region=us-east-2", "query must use the caller region: %s", url)
+}
+
+// TestEnrichEC2WithConnectURLs_EmptyInstanceIDSkipped — instances with
+// no InstanceId must not gain a URL nor crash the enrichment.
+func TestEnrichEC2WithConnectURLs_EmptyInstanceIDSkipped(t *testing.T) {
+	t.Parallel()
+	res := ec2types.Reservation{
+		Instances: []ec2types.Instance{
+			{InstanceId: aws.String(""), State: &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning}},
+		},
+	}
+	got := enrichEC2WithConnectURLs("eu-west-2", []ec2types.Reservation{res})
+	urls := urlsFromEnriched(t, got)
+	require.NotNil(t, urls)
+	url := urls[""]
+	assert.Empty(t, url, "instances without an InstanceId must not produce a URL")
+}
+
+// TestEnrichEC2WithConnectURLs_PreservesNonStateInstanceFields — the
+// JSON round-trip must preserve other fields the panel renders (e.g.
+// PrivateIpAddress, Tags) so the enrichment is purely additive.
+func TestEnrichEC2WithConnectURLs_PreservesNonStateInstanceFields(t *testing.T) {
+	t.Parallel()
+	res := ec2types.Reservation{
+		Instances: []ec2types.Instance{
+			{
+				InstanceId:       aws.String("i-1"),
+				State:            &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning},
+				PrivateIpAddress: aws.String("10.0.0.42"),
+				Tags: []ec2types.Tag{
+					{Key: aws.String("Name"), Value: aws.String("bastion")},
+				},
+			},
+		},
+	}
+	got := enrichEC2WithConnectURLs("eu-west-2", []ec2types.Reservation{res})
+	enriched, ok := got.([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, enriched, 1)
+
+	instances, ok := enriched[0]["Instances"].([]any)
+	require.True(t, ok)
+	require.Len(t, instances, 1)
+
+	inst := instances[0].(map[string]any)
+	assert.Equal(t, "10.0.0.42", inst["PrivateIpAddress"], "PrivateIpAddress must survive the JSON round-trip")
+	tags, ok := inst["Tags"].([]any)
+	require.True(t, ok)
+	require.Len(t, tags, 1)
+	tag := tags[0].(map[string]any)
+	assert.Equal(t, "Name", tag["Key"])
+	assert.Equal(t, "bastion", tag["Value"])
+	assert.NotEmpty(t, inst["InstanceConnectURL"])
+}

--- a/pkg/observability/discovery/aws/connect_info_test.go
+++ b/pkg/observability/discovery/aws/connect_info_test.go
@@ -161,6 +161,12 @@ func TestEnrichEC2WithConnectURLs_RegionPropagatesIntoURL(t *testing.T) {
 
 // TestEnrichEC2WithConnectURLs_EmptyInstanceIDSkipped — instances with
 // no InstanceId must not gain a URL nor crash the enrichment.
+//
+// Walk the enriched output directly rather than checking urls[""],
+// because urls[""] returns the empty-string default when no key
+// exists — that would make this test pass even if the enrichment
+// somehow inserted an InstanceConnectURL keyed under "". Per
+// qa-professor review.
 func TestEnrichEC2WithConnectURLs_EmptyInstanceIDSkipped(t *testing.T) {
 	t.Parallel()
 	res := ec2types.Reservation{
@@ -169,10 +175,15 @@ func TestEnrichEC2WithConnectURLs_EmptyInstanceIDSkipped(t *testing.T) {
 		},
 	}
 	got := enrichEC2WithConnectURLs("eu-west-2", []ec2types.Reservation{res})
-	urls := urlsFromEnriched(t, got)
-	require.NotNil(t, urls)
-	url := urls[""]
-	assert.Empty(t, url, "instances without an InstanceId must not produce a URL")
+	enriched, ok := got.([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, enriched, 1)
+
+	instances, _ := enriched[0]["Instances"].([]any)
+	require.Len(t, instances, 1)
+	m := instances[0].(map[string]any)
+	_, present := m["InstanceConnectURL"]
+	assert.False(t, present, "instances without an InstanceId must not have an InstanceConnectURL key in their map at all")
 }
 
 // TestEnrichEC2WithConnectURLs_PreservesNonStateInstanceFields — the

--- a/pkg/observability/discovery/aws/live_integration_test.go
+++ b/pkg/observability/discovery/aws/live_integration_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+// Live AWS smoke tests. Run with:
+//
+//	go test -tags=integration ./pkg/observability/discovery/aws/... -v -run TestLive
+//
+// Requires AWS credentials in the environment (e.g. via aws_jump cust2).
+// CI does NOT exercise these — the build tag keeps them out of the
+// default suite. Used for the #236 / #233 PR's live-validation phase
+// to confirm the helper functions actually return sane data against a
+// real account.
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLive_GatherAccountInfo runs the account-info compose against the
+// live caller account. Asserts the structural shape — the actual values
+// depend on the account.
+func TestLive_GatherAccountInfo(t *testing.T) {
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		t.Skipf("no AWS config: %v", err)
+	}
+	if cfg.Region == "" {
+		cfg.Region = "eu-west-2"
+	}
+
+	stsClient := sts.NewFromConfig(cfg)
+	iamClient := iam.NewFromConfig(cfg)
+
+	got := gatherAccountInfo(context.Background(), cfg.Region, stsClient, iamClient)
+
+	dumpJSON(t, "gatherAccountInfo", got)
+
+	// Region is always set (no SDK call, just the cfg field).
+	assert.Equal(t, cfg.Region, got["Region"])
+
+	// AccountId / Arn / UserId should be present unless STS is broken.
+	if accountID, ok := got["AccountId"].(string); ok {
+		assert.Regexp(t, `^\d{12}$`, accountID, "AccountId must be a 12-digit number")
+	} else {
+		t.Log("warning: GetCallerIdentity did not populate AccountId — STS issue?")
+	}
+	if arn, ok := got["Arn"].(string); ok {
+		assert.Regexp(t, `^arn:aws:.*:\d{12}:`, arn, "Arn must be a real ARN with the account id")
+	}
+}
+
+// TestLive_DescribeProjectLogGroups_NoFilter exercises the no-prefix
+// path. Should return at least one log group on any account that's
+// done anything.
+func TestLive_DescribeProjectLogGroups_NoFilter(t *testing.T) {
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		t.Skipf("no AWS config: %v", err)
+	}
+	if cfg.Region == "" {
+		cfg.Region = "eu-west-2"
+	}
+
+	client := cloudwatchlogs.NewFromConfig(cfg)
+	got, err := describeProjectLogGroups(context.Background(), client, "")
+	require.NoError(t, err)
+	t.Logf("describeProjectLogGroups(empty filter) returned %d log groups", len(got))
+	if len(got) > 0 {
+		t.Logf("first log group: %s", *got[0].LogGroupName)
+	}
+}
+
+// TestLive_DescribeProjectLogGroups_PrefixScoping requires the env var
+// LIVE_PROJECT to be set to a known project name on the account.
+// Without it we skip — the prefix-scoping behaviour can't be verified
+// without a known matching prefix.
+func TestLive_DescribeProjectLogGroups_PrefixScoping(t *testing.T) {
+	project := os.Getenv("LIVE_PROJECT")
+	if project == "" {
+		t.Skip("LIVE_PROJECT not set; export the project name to test prefix scoping")
+	}
+
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		t.Skipf("no AWS config: %v", err)
+	}
+	if cfg.Region == "" {
+		cfg.Region = "eu-west-2"
+	}
+
+	client := cloudwatchlogs.NewFromConfig(cfg)
+	got, err := describeProjectLogGroups(context.Background(), client, project)
+	require.NoError(t, err)
+	t.Logf("describeProjectLogGroups(%q) returned %d log groups", project, len(got))
+	for _, g := range got {
+		assert.Contains(t, *g.LogGroupName, "/aws/"+project,
+			"every returned log group must carry the /aws/%s prefix", project)
+		t.Logf("  - %s", *g.LogGroupName)
+	}
+}
+
+// TestLive_EnrichEC2WithConnectURLs runs DescribeInstances against the
+// live account, runs enrichEC2WithConnectURLs over the result, and
+// dumps the (instanceId → InstanceConnectURL) map. Confirms the
+// enrichment composes correctly with the real SDK shape.
+func TestLive_EnrichEC2WithConnectURLs(t *testing.T) {
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		t.Skipf("no AWS config: %v", err)
+	}
+	if cfg.Region == "" {
+		cfg.Region = "eu-west-2"
+	}
+
+	ec2Client := ec2.NewFromConfig(cfg)
+	out, err := ec2Client.DescribeInstances(context.Background(), &ec2.DescribeInstancesInput{})
+	require.NoError(t, err)
+
+	enriched := enrichEC2WithConnectURLs(cfg.Region, out.Reservations)
+	t.Logf("enriched %d reservations", len(out.Reservations))
+
+	enrichedSlice, ok := enriched.([]map[string]any)
+	require.True(t, ok, "enrichment must produce []map[string]any not the raw fallback")
+
+	for _, res := range enrichedSlice {
+		instances, _ := res["Instances"].([]any)
+		for _, inst := range instances {
+			m, _ := inst.(map[string]any)
+			id, _ := m["InstanceId"].(string)
+			state, _ := m["State"].(map[string]any)
+			stateName, _ := state["Name"].(string)
+			url, _ := m["InstanceConnectURL"].(string)
+			t.Logf("  %s state=%-12s connect_url_present=%t", id, stateName, url != "")
+			if stateName != "running" {
+				assert.Empty(t, url, "non-running %s must NOT have a URL", id)
+			}
+		}
+	}
+}
+
+func dumpJSON(t *testing.T, label string, v any) {
+	t.Helper()
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Logf("%s: marshal failed: %v", label, err)
+		return
+	}
+	t.Logf("%s:\n%s", label, b)
+}

--- a/pkg/observability/discovery/aws/live_integration_test.go
+++ b/pkg/observability/discovery/aws/live_integration_test.go
@@ -99,15 +99,18 @@ func TestLive_DescribeProjectLogGroups_NoFilter(t *testing.T) {
 	}
 }
 
-// TestLive_DescribeProjectLogGroups_PrefixScoping requires the env var
-// LIVE_PROJECT to be set to a known project name on the account.
-// Without it we skip — the prefix-scoping behaviour can't be verified
-// without a known matching prefix.
-func TestLive_DescribeProjectLogGroups_PrefixScoping(t *testing.T) {
+// TestLive_DescribeProjectLogGroups_SubstringScoping requires the env
+// var LIVE_PROJECT to be set to a known project name on the account.
+// Without it we skip — the substring scoping can't be verified without
+// a known matching project. The expectation is non-zero results AND
+// every returned log group containing the project name as a substring
+// (not necessarily the `/aws/<project>` prefix — see the helper's
+// header comment for why prefix-scoping was wrong).
+func TestLive_DescribeProjectLogGroups_SubstringScoping(t *testing.T) {
 	t.Parallel()
 	project := os.Getenv("LIVE_PROJECT")
 	if project == "" {
-		t.Skip("LIVE_PROJECT not set; export the project name to test prefix scoping")
+		t.Skip("LIVE_PROJECT not set; export the project name to test substring scoping")
 	}
 
 	cfg := loadOrSkip(t)
@@ -116,9 +119,12 @@ func TestLive_DescribeProjectLogGroups_PrefixScoping(t *testing.T) {
 	got, err := describeProjectLogGroups(context.Background(), client, project)
 	require.NoError(t, err)
 	t.Logf("describeProjectLogGroups(%q) returned %d log groups", project, len(got))
+	require.NotEmpty(t, got,
+		"a real project on the account should return at least one log group via substring scoping; "+
+			"if this returned zero, either LIVE_PROJECT is wrong or the project genuinely emits no logs")
 	for _, g := range got {
-		assert.Contains(t, *g.LogGroupName, "/aws/"+project,
-			"every returned log group must carry the /aws/%s prefix", project)
+		assert.Contains(t, *g.LogGroupName, project,
+			"every returned log group must contain %q as a substring (LogGroupNamePattern contract)", project)
 		t.Logf("  - %s", *g.LogGroupName)
 	}
 }

--- a/pkg/observability/discovery/aws/live_integration_test.go
+++ b/pkg/observability/discovery/aws/live_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -27,10 +28,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestLive_GatherAccountInfo runs the account-info compose against the
-// live caller account. Asserts the structural shape — the actual values
-// depend on the account.
-func TestLive_GatherAccountInfo(t *testing.T) {
+// loadOrSkip loads ambient AWS config or skips the test. Defaults the
+// region to eu-west-2 when the SDK can't infer one (e.g. running with
+// just static creds in env vars).
+//
+// IMPORTANT: config.LoadDefaultConfig succeeds even when no credentials
+// are resolvable — failures only surface on the first SDK call. We
+// probe with sts.GetCallerIdentity here so a credential-less run skips
+// cleanly instead of failing partway through. Per qa-professor review.
+func loadOrSkip(t *testing.T) aws.Config {
+	t.Helper()
 	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
 		t.Skipf("no AWS config: %v", err)
@@ -38,6 +45,21 @@ func TestLive_GatherAccountInfo(t *testing.T) {
 	if cfg.Region == "" {
 		cfg.Region = "eu-west-2"
 	}
+
+	// Probe credentials so missing/expired auth produces a Skip,
+	// not a confusing late failure inside the actual test body.
+	if _, err := sts.NewFromConfig(cfg).GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{}); err != nil {
+		t.Skipf("no usable AWS credentials (sts.GetCallerIdentity failed): %v", err)
+	}
+	return cfg
+}
+
+// TestLive_GatherAccountInfo runs the account-info compose against the
+// live caller account. After loadOrSkip's auth probe, STS is known to
+// work — so AccountId/Arn/UserId are required, not "warn if missing".
+func TestLive_GatherAccountInfo(t *testing.T) {
+	t.Parallel()
+	cfg := loadOrSkip(t)
 
 	stsClient := sts.NewFromConfig(cfg)
 	iamClient := iam.NewFromConfig(cfg)
@@ -46,31 +68,27 @@ func TestLive_GatherAccountInfo(t *testing.T) {
 
 	dumpJSON(t, "gatherAccountInfo", got)
 
-	// Region is always set (no SDK call, just the cfg field).
 	assert.Equal(t, cfg.Region, got["Region"])
 
-	// AccountId / Arn / UserId should be present unless STS is broken.
-	if accountID, ok := got["AccountId"].(string); ok {
-		assert.Regexp(t, `^\d{12}$`, accountID, "AccountId must be a 12-digit number")
-	} else {
-		t.Log("warning: GetCallerIdentity did not populate AccountId — STS issue?")
-	}
-	if arn, ok := got["Arn"].(string); ok {
-		assert.Regexp(t, `^arn:aws:.*:\d{12}:`, arn, "Arn must be a real ARN with the account id")
-	}
+	accountID, ok := got["AccountId"].(string)
+	require.True(t, ok, "AccountId must be populated — loadOrSkip probed STS so this is a real regression if missing")
+	assert.Regexp(t, `^\d{12}$`, accountID, "AccountId must be a 12-digit number")
+
+	arn, ok := got["Arn"].(string)
+	require.True(t, ok, "Arn must be populated")
+	assert.Regexp(t, `^arn:aws:.*:\d{12}:`, arn, "Arn must be a real ARN with the account id")
+
+	userID, ok := got["UserId"].(string)
+	require.True(t, ok, "UserId must be populated")
+	assert.NotEmpty(t, userID)
 }
 
 // TestLive_DescribeProjectLogGroups_NoFilter exercises the no-prefix
 // path. Should return at least one log group on any account that's
 // done anything.
 func TestLive_DescribeProjectLogGroups_NoFilter(t *testing.T) {
-	cfg, err := config.LoadDefaultConfig(context.Background())
-	if err != nil {
-		t.Skipf("no AWS config: %v", err)
-	}
-	if cfg.Region == "" {
-		cfg.Region = "eu-west-2"
-	}
+	t.Parallel()
+	cfg := loadOrSkip(t)
 
 	client := cloudwatchlogs.NewFromConfig(cfg)
 	got, err := describeProjectLogGroups(context.Background(), client, "")
@@ -86,18 +104,13 @@ func TestLive_DescribeProjectLogGroups_NoFilter(t *testing.T) {
 // Without it we skip — the prefix-scoping behaviour can't be verified
 // without a known matching prefix.
 func TestLive_DescribeProjectLogGroups_PrefixScoping(t *testing.T) {
+	t.Parallel()
 	project := os.Getenv("LIVE_PROJECT")
 	if project == "" {
 		t.Skip("LIVE_PROJECT not set; export the project name to test prefix scoping")
 	}
 
-	cfg, err := config.LoadDefaultConfig(context.Background())
-	if err != nil {
-		t.Skipf("no AWS config: %v", err)
-	}
-	if cfg.Region == "" {
-		cfg.Region = "eu-west-2"
-	}
+	cfg := loadOrSkip(t)
 
 	client := cloudwatchlogs.NewFromConfig(cfg)
 	got, err := describeProjectLogGroups(context.Background(), client, project)
@@ -115,13 +128,8 @@ func TestLive_DescribeProjectLogGroups_PrefixScoping(t *testing.T) {
 // dumps the (instanceId → InstanceConnectURL) map. Confirms the
 // enrichment composes correctly with the real SDK shape.
 func TestLive_EnrichEC2WithConnectURLs(t *testing.T) {
-	cfg, err := config.LoadDefaultConfig(context.Background())
-	if err != nil {
-		t.Skipf("no AWS config: %v", err)
-	}
-	if cfg.Region == "" {
-		cfg.Region = "eu-west-2"
-	}
+	t.Parallel()
+	cfg := loadOrSkip(t)
 
 	ec2Client := ec2.NewFromConfig(cfg)
 	out, err := ec2Client.DescribeInstances(context.Background(), &ec2.DescribeInstancesInput{})

--- a/pkg/observability/discovery/gcp/compute.go
+++ b/pkg/observability/discovery/gcp/compute.go
@@ -38,12 +38,19 @@ func inspectCompute(ctx context.Context, projectID, action, filters string, opts
 		}
 		defer func() { _ = client.Close() }()
 
-		// Server-side scope to the caller's project label using the GCE
-		// legacy filter dialect. gcpLegacyLabelFilter returns "" when
+		// Server-side scope to the caller's project label using the
+		// AIP-160 filter dialect. gcpAIP160LabelFilter returns "" when
 		// no project is set (e.g. demo session), which Compute treats
 		// as "no filter".
+		//
+		// Was the GCE legacy dialect — instances.aggregatedList does
+		// accept legacy on this endpoint, but the same Compute v1 REST
+		// API rejects legacy on networks.list, backendServices.list,
+		// urlMaps.list, etc. (verified live on staging session
+		// sess_v2_qtyB4nkwp5N8). AIP-160 works everywhere, so we pick
+		// the universally-compatible dialect.
 		req := &computepb.AggregatedListInstancesRequest{Project: projectID}
-		if f := gcpLegacyLabelFilter("project", projectFromFilters(filters)); f != "" {
+		if f := gcpAIP160LabelFilter("project", projectFromFilters(filters)); f != "" {
 			req.Filter = proto.String(f)
 		}
 
@@ -137,21 +144,27 @@ func inspectBastion(ctx context.Context, projectID, action, filters string, opts
 	switch action {
 	case "list-bastion-instances":
 		// Bastions in luthersystems presets are GCE instances tagged
-		// with `labels.role=bastion`. Compute v1 uses the legacy GCE
-		// filter dialect (NOT AIP-160) — `:` would mean substring
-		// match and over-include `bastion-prod`, `super-bastion`, etc.
-		// `=` is the equality operator. AND-combine with the project
+		// with `labels.role=bastion`. AIP-160 dialect (`labels.role =
+		// "bastion"`) — quoted string equality — so bastion-prod /
+		// super-bastion don't over-match. AND-combine with the project
 		// filter so a project hosting >1 InsideOut session sees only
 		// its own bastions.
+		//
+		// Was the GCE legacy dialect; flipped alongside #239 because
+		// the same Compute v1 REST API rejects legacy on multiple
+		// other endpoints (networks.list, backendServices.list, etc.).
+		// AIP-160 is universally accepted — the `:` substring vs `=`
+		// equality concern from the legacy comment doesn't apply,
+		// because AIP-160's `=` is also strict equality.
 		client, err := compute.NewInstancesRESTClient(ctx, opts...)
 		if err != nil {
 			return nil, err
 		}
 		defer func() { _ = client.Close() }()
 
-		filterStr := gcpLegacyLabelFilterAnd(
-			"labels.role=bastion",
-			gcpLegacyLabelFilter("project", projectFromFilters(filters)),
+		filterStr := gcpAIP160LabelFilterAnd(
+			gcpAIP160LabelFilter("role", "bastion"),
+			gcpAIP160LabelFilter("project", projectFromFilters(filters)),
 		)
 		it := client.AggregatedList(ctx, &computepb.AggregatedListInstancesRequest{
 			Project: projectID,

--- a/pkg/observability/discovery/gcp/compute_test.go
+++ b/pkg/observability/discovery/gcp/compute_test.go
@@ -180,8 +180,11 @@ func TestInspectBastion_UnsupportedAction(t *testing.T) {
 // TestInspectBastion_AppliesRoleAndProjectFilter exercises the bastion
 // label filter — bastions are GCE instances tagged labels.role=bastion;
 // we assert the AggregatedListInstances request carries BOTH labels
-// when a project filter is also set. Mirrors the AND semantic in
-// gcpLegacyLabelFilterAnd.
+// joined by " AND " when a project filter is also set. Pinned to the
+// AIP-160 dialect (`labels.role = "bastion"`) per #239 — Compute v1
+// rejects the GCE legacy dialect on enough endpoints (networks.list,
+// backendServices.list, urlMaps.list, etc.) that we use AIP-160
+// universally.
 func TestInspectBastion_AppliesRoleAndProjectFilter(t *testing.T) {
 	t.Parallel()
 	var capturedFilter string
@@ -195,14 +198,14 @@ func TestInspectBastion_AppliesRoleAndProjectFilter(t *testing.T) {
 	_, err := inspectBastion(context.Background(), "demo-proj", "list-bastion-instances",
 		`{"project":"io-foo"}`, opts...)
 	require.NoError(t, err)
-	assert.Contains(t, capturedFilter, "labels.role=bastion")
-	assert.Contains(t, capturedFilter, "labels.project=io-foo")
+	assert.Contains(t, capturedFilter, `labels.role = "bastion"`)
+	assert.Contains(t, capturedFilter, `labels.project = "io-foo"`)
 	assert.Contains(t, capturedFilter, " AND ")
 }
 
 // TestInspectBastion_NoProjectStillSetsRoleFilter — when the caller
 // hasn't supplied a project filter, bastion still scopes to
-// labels.role=bastion alone.
+// `labels.role = "bastion"` (AIP-160) alone.
 func TestInspectBastion_NoProjectStillSetsRoleFilter(t *testing.T) {
 	t.Parallel()
 	var capturedFilter string
@@ -215,5 +218,5 @@ func TestInspectBastion_NoProjectStillSetsRoleFilter(t *testing.T) {
 
 	_, err := inspectBastion(context.Background(), "demo-proj", "list-bastion-instances", "", opts...)
 	require.NoError(t, err)
-	assert.Equal(t, "labels.role=bastion", capturedFilter)
+	assert.Equal(t, `labels.role = "bastion"`, capturedFilter)
 }

--- a/pkg/observability/discovery/gcp/helpers.go
+++ b/pkg/observability/discovery/gcp/helpers.go
@@ -143,6 +143,24 @@ func gcpAIP160LabelFilter(key, value string) string {
 	return fmt.Sprintf("labels.%s = %q", key, value)
 }
 
+// gcpAIP160LabelFilterAnd joins two AIP-160 filters with " AND ". Empty
+// operands are dropped so callers can pass a base + optional addition
+// without guarding the empty case. The AIP-160 dialect uses the same
+// `AND` keyword as the legacy dialect, so the join shape is identical
+// — only the per-clause format differs.
+func gcpAIP160LabelFilterAnd(a, b string) string {
+	switch {
+	case a == "" && b == "":
+		return ""
+	case a == "":
+		return b
+	case b == "":
+		return a
+	default:
+		return a + " AND " + b
+	}
+}
+
 // gcpLabelMatches reports whether labels[key] == want. An empty `want`
 // is treated as match-all (caller didn't supply a project filter).
 // Mirrors reliable's gcp_filter.go gcpLabelMatches. Used by post-filter

--- a/pkg/observability/discovery/gcp/helpers_test.go
+++ b/pkg/observability/discovery/gcp/helpers_test.go
@@ -77,6 +77,18 @@ func TestGCPAIP160LabelFilter(t *testing.T) {
 	assert.Equal(t, `labels.project = "io-foo"`, gcpAIP160LabelFilter("project", "io-foo"))
 }
 
+func TestGCPAIP160LabelFilterAnd(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "", gcpAIP160LabelFilterAnd("", ""))
+	assert.Equal(t, `labels.role = "bastion"`,
+		gcpAIP160LabelFilterAnd(`labels.role = "bastion"`, ""))
+	assert.Equal(t, `labels.project = "io-foo"`,
+		gcpAIP160LabelFilterAnd("", `labels.project = "io-foo"`))
+	assert.Equal(t,
+		`labels.role = "bastion" AND labels.project = "io-foo"`,
+		gcpAIP160LabelFilterAnd(`labels.role = "bastion"`, `labels.project = "io-foo"`))
+}
+
 func TestGCPLabelMatches(t *testing.T) {
 	t.Parallel()
 	// Empty want is match-all (no caller-side filter).

--- a/pkg/observability/discovery/gcp/live_integration_test.go
+++ b/pkg/observability/discovery/gcp/live_integration_test.go
@@ -1,0 +1,98 @@
+//go:build integration
+
+// Live GCP smoke tests. Run with:
+//
+//	go test -tags=integration ./pkg/observability/discovery/gcp/... -v -run TestLive
+//
+// Requires:
+//   - Application Default Credentials in the environment (e.g.
+//     `gcloud auth application-default login`, or a service-account
+//     key path in GOOGLE_APPLICATION_CREDENTIALS).
+//   - LIVE_GCP_PROJECT_ID set to the Compute project to probe (must
+//     have the Compute API enabled — even if no CDN-enabled backend
+//     services are present).
+//
+// Build-tag-gated so CI doesn't exercise these. Used to confirm
+// inspector helpers compose cleanly against the real GCP REST surface.
+//
+// The Cloud CDN test pins #239: backendServices.aggregatedList rejects
+// the GCE legacy filter dialect (`labels.project=<value>`) with HTTP
+// 400 "Invalid list filter expression". The fix flipped the inspector
+// to AIP-160 (`labels.project = "<value>"`); this live probe confirms
+// the call actually returns 200 OK against a real project.
+
+package gcp
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// liveProjectOrSkip returns the project ID from LIVE_GCP_PROJECT_ID or
+// skips the test. ADC is consumed by the SDK clients implicitly.
+func liveProjectOrSkip(t *testing.T) string {
+	t.Helper()
+	projectID := os.Getenv("LIVE_GCP_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("LIVE_GCP_PROJECT_ID not set; export the project ID to run live GCP probes")
+	}
+	return projectID
+}
+
+// TestLive_InspectCloudCDN_NoCDNFilter exercises the AggregatedList
+// path with no `project` label filter. Should return cleanly (empty
+// slice or list of CDN-enabled backend services) with no HTTP 400.
+//
+// This is the regression test for #239: the bug surfaced as a 400
+// "Invalid list filter expression" when the legacy filter dialect was
+// passed to backendServices.aggregatedList. With no filter on the
+// request at all, the call must succeed.
+func TestLive_InspectCloudCDN_NoCDNFilter(t *testing.T) {
+	t.Parallel()
+	projectID := liveProjectOrSkip(t)
+
+	got, err := inspectCloudCDN(context.Background(), projectID, "list-backend-services-cdn", "")
+	require.NoError(t, err, "inspectCloudCDN with no project filter must not error against a real project")
+	t.Logf("inspectCloudCDN returned %T with content %v", got, got)
+}
+
+// TestLive_InspectCloudCDN_WithProjectFilter exercises the
+// AggregatedList path with the AIP-160 `labels.project = "<value>"`
+// filter. The label value is provided via LIVE_GCP_PROJECT_LABEL — set
+// it to a known label value on the account, or to the bare project ID
+// (matches every backend service that carries `project = <project_id>`
+// in its labels). Skips if not set.
+//
+// Pre-#239 fix this returned HTTP 400 immediately; post-fix it must
+// return 200 OK with an empty (or populated) slice.
+func TestLive_InspectCloudCDN_WithProjectFilter(t *testing.T) {
+	t.Parallel()
+	projectID := liveProjectOrSkip(t)
+
+	label := os.Getenv("LIVE_GCP_PROJECT_LABEL")
+	if label == "" {
+		t.Skip("LIVE_GCP_PROJECT_LABEL not set; export a project-label value to test the filter path")
+	}
+
+	filters := `{"project":"` + label + `"}`
+	got, err := inspectCloudCDN(context.Background(), projectID, "list-backend-services-cdn", filters)
+	require.NoError(t, err,
+		"inspectCloudCDN with project-label filter must use AIP-160 dialect — HTTP 400 here means the filter dialect regressed (#239)")
+	t.Logf("inspectCloudCDN(label=%q) returned %T with content %v", label, got, got)
+}
+
+// TestLive_CloudCDNAggregatedListRequest_FilterShape is a defense-in-
+// depth pin: the request constructor's output matches AIP-160 even at
+// runtime under live build tags (a unit-test pin already exists; this
+// catches the case where someone disables the unit test or skips the
+// non-integration build).
+func TestLive_CloudCDNAggregatedListRequest_FilterShape(t *testing.T) {
+	t.Parallel()
+	req := cloudCDNAggregatedListRequest("p", `{"project":"io-qtyb4nkwp5n8"}`)
+	require.NotNil(t, req.Filter)
+	assert.Equal(t, `labels.project = "io-qtyb4nkwp5n8"`, *req.Filter)
+}

--- a/pkg/observability/discovery/gcp/network.go
+++ b/pkg/observability/discovery/gcp/network.go
@@ -204,25 +204,51 @@ func inspectCloudArmor(ctx context.Context, projectID, action, filters string, o
 	}
 }
 
+// cloudCDNAggregatedListRequest builds the AggregatedList request for
+// the Cloud CDN inspector. Pulled out so the AIP-160 dialect choice
+// (#239) is pinned by a unit test instead of a comment.
+func cloudCDNAggregatedListRequest(projectID, filters string) *computepb.AggregatedListBackendServicesRequest {
+	req := &computepb.AggregatedListBackendServicesRequest{Project: projectID}
+	if f := gcpAIP160LabelFilter("project", projectFromFilters(filters)); f != "" {
+		req.Filter = proto.String(f)
+	}
+	return req
+}
+
 func inspectCloudCDN(ctx context.Context, projectID, action, filters string, opts ...option.ClientOption) (any, error) {
 	switch action {
 	case "list-backend-services-cdn":
 		// Cloud CDN is a flag on Compute backend services
 		// (EnableCdn=true), not a standalone resource — list backend
 		// services across all scopes and keep the CDN-enabled ones.
-		// Server-side scope to the project label via GCE legacy
-		// filter.
+		//
+		// IMPORTANT (#239): server-side scoping uses the AIP-160 dialect
+		// (`labels.project = "<value>"`), NOT the GCE legacy dialect
+		// (`labels.project=<value>`) used by every other inspector in
+		// this file. The same Compute v1 REST API exposes BOTH dialects
+		// per-endpoint:
+		//
+		//   - VPC / LoadBalancer / CloudArmor go through
+		//     google.golang.org/api/compute/v1 (computeapi.NewService)
+		//     — the older REST client — whose List/AggregatedList
+		//     accept the bare-equality legacy filter.
+		//   - CloudCDN goes through cloud.google.com/go/compute/apiv1
+		//     (compute.NewBackendServicesRESTClient) — the newer
+		//     gRPC-shaped client — whose AggregatedList rejects the
+		//     legacy form with HTTP 400 "Invalid list filter
+		//     expression" and requires the AIP-160 form. This was the
+		//     symptom on staging session sess_v2_qtyB4nkwp5N8 (#239).
+		//
+		// If we ever migrate the rest of this file to the newer
+		// compute apiv1 client, those call sites must flip to
+		// gcpAIP160LabelFilter at the same time.
 		client, err := compute.NewBackendServicesRESTClient(ctx, opts...)
 		if err != nil {
 			return nil, err
 		}
 		defer func() { _ = client.Close() }()
 
-		req := &computepb.AggregatedListBackendServicesRequest{Project: projectID}
-		if f := gcpLegacyLabelFilter("project", projectFromFilters(filters)); f != "" {
-			req.Filter = proto.String(f)
-		}
-		it := client.AggregatedList(ctx, req)
+		it := client.AggregatedList(ctx, cloudCDNAggregatedListRequest(projectID, filters))
 		var services []*computepb.BackendService
 		for {
 			pair, err := it.Next()

--- a/pkg/observability/discovery/gcp/network.go
+++ b/pkg/observability/discovery/gcp/network.go
@@ -39,12 +39,22 @@ func inspectVPC(ctx context.Context, projectID, action, filters string, opts ...
 		return nil, err
 	}
 
-	// GCE legacy filter, applied where the resource type carries
-	// labels (Networks, Subnetworks). Firewalls and Routes have no
-	// labels field on the GCE API (per the v1 schema) so they stay
-	// un-filtered — they're scoped by parent network association
-	// rather than labels.
-	projectFilter := gcpLegacyLabelFilter("project", projectFromFilters(filters))
+	// AIP-160 filter, applied where the resource type carries labels
+	// (Networks, Subnetworks). Firewalls and Routes have no labels
+	// field on the GCE API (per the v1 schema) so they stay un-filtered
+	// — they're scoped by parent network association rather than
+	// labels.
+	//
+	// Compute v1's per-endpoint filter parser is inconsistent: some
+	// endpoints accept the GCE legacy dialect (`labels.foo=bar`) and
+	// some reject it with HTTP 400 "Invalid list filter expression".
+	// `networks.list`, `subnetworks.aggregatedList`,
+	// `backendServices.list`, `urlMaps.list`, `targetHttp(s)Proxies.
+	// list` all reject the legacy dialect (verified live on staging
+	// session sess_v2_qtyB4nkwp5N8 — see #239 broader sweep). AIP-160
+	// is the standard dialect and works on every Compute v1 endpoint
+	// we exercise.
+	projectFilter := gcpAIP160LabelFilter("project", projectFromFilters(filters))
 
 	switch action {
 	case "list-networks":
@@ -103,10 +113,13 @@ func inspectLoadBalancer(ctx context.Context, projectID, action, filters string,
 		return nil, err
 	}
 
-	// GCE legacy filter — every load-balancer resource type listed
-	// below carries `labels` in the v1 schema (BackendServices,
-	// UrlMaps, TargetHttp[s]Proxies, GlobalForwardingRules).
-	projectFilter := gcpLegacyLabelFilter("project", projectFromFilters(filters))
+	// AIP-160 filter — every load-balancer resource type listed below
+	// carries `labels` in the v1 schema (BackendServices, UrlMaps,
+	// TargetHttp[s]Proxies, GlobalForwardingRules). Was the GCE legacy
+	// dialect, but BackendServices.list / UrlMaps.list / TargetHttp(s)
+	// Proxies.list reject it with HTTP 400 (see #239 + the network.go
+	// header comment on the per-endpoint filter parser inconsistency).
+	projectFilter := gcpAIP160LabelFilter("project", projectFromFilters(filters))
 
 	switch action {
 	case "list-backend-services":
@@ -180,9 +193,11 @@ func inspectCloudArmor(ctx context.Context, projectID, action, filters string, o
 	switch action {
 	case "list-policies":
 		// SecurityPolicy carries a Labels field on the v1 schema; apply
-		// the GCE legacy filter when the caller has a project.
+		// the AIP-160 filter when the caller has a project. (Was the
+		// GCE legacy dialect; flipped alongside #239 — securityPolicies
+		// .list is one of the endpoints that rejects legacy.)
 		call := svc.SecurityPolicies.List(projectID).Context(ctx)
-		if f := gcpLegacyLabelFilter("project", projectFromFilters(filters)); f != "" {
+		if f := gcpAIP160LabelFilter("project", projectFromFilters(filters)); f != "" {
 			call = call.Filter(f)
 		}
 		resp, err := call.Do()

--- a/pkg/observability/discovery/gcp/network_test.go
+++ b/pkg/observability/discovery/gcp/network_test.go
@@ -182,6 +182,52 @@ func TestInspectCloudCDN_UnsupportedAction(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported Cloud CDN action")
 }
 
+// TestCloudCDNAggregatedListRequest_AIP160DialectForProjectFilter pins
+// the dialect choice from #239: backendServices.aggregatedList rejects
+// the GCE legacy filter form (`labels.project=<value>`) with HTTP 400
+// "Invalid list filter expression" and requires the AIP-160 form
+// (`labels.project = "<value>"`). This is the same Compute v1 REST API
+// as VPC / LoadBalancer / CloudArmor, but accessed via the newer
+// cloud.google.com/go/compute/apiv1 client which enforces AIP-160.
+//
+// If a future refactor flips this back to gcpLegacyLabelFilter (or
+// changes the helper's output shape), this test fails. Reproduces the
+// staging session sess_v2_qtyB4nkwp5N8 / project io-qtyb4nkwp5n8 bug.
+func TestCloudCDNAggregatedListRequest_AIP160DialectForProjectFilter(t *testing.T) {
+	t.Parallel()
+	req := cloudCDNAggregatedListRequest("demo-proj", `{"project":"io-qtyb4nkwp5n8"}`)
+
+	require.NotNil(t, req, "request must always be returned")
+	assert.Equal(t, "demo-proj", req.GetProject(), "Project must be set on the AggregatedList request")
+	require.NotNil(t, req.Filter, "non-empty project filter must populate req.Filter")
+	assert.Equal(t, `labels.project = "io-qtyb4nkwp5n8"`, *req.Filter,
+		"filter must use AIP-160 dialect (spaces around =, quoted value); the GCE legacy form is rejected by backendServices.aggregatedList with HTTP 400 — see #239")
+}
+
+// TestCloudCDNAggregatedListRequest_NoFilterWhenProjectMissing — no
+// filter must be set when the caller doesn't supply a project; the SDK
+// treats nil as "no filter" / match all.
+func TestCloudCDNAggregatedListRequest_NoFilterWhenProjectMissing(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		filters string
+	}{
+		{"empty filters", ""},
+		{"missing project key", `{"region":"us-central1"}`},
+		{"empty project value", `{"project":""}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := cloudCDNAggregatedListRequest("demo-proj", tc.filters)
+			require.NotNil(t, req)
+			assert.Equal(t, "demo-proj", req.GetProject())
+			assert.Nil(t, req.Filter, "no project filter → req.Filter must be nil so backendServices.aggregatedList returns everything in the project")
+		})
+	}
+}
+
 func TestInspectAPIGateway_UnsupportedAction(t *testing.T) {
 	t.Parallel()
 	_, err := inspectAPIGateway(context.Background(), "demo-proj", "no-such", "",

--- a/pkg/observability/discovery/gcp/network_test.go
+++ b/pkg/observability/discovery/gcp/network_test.go
@@ -72,7 +72,7 @@ func TestInspectVPC_ListNetworks_AppliesProjectFilter(t *testing.T) {
 	_, err := inspectVPC(context.Background(), "demo-proj", "list-networks",
 		`{"project":"io-foo"}`, opts...)
 	require.NoError(t, err)
-	assert.Equal(t, "labels.project=io-foo", capturedFilter)
+	assert.Equal(t, `labels.project = "io-foo"`, capturedFilter)
 }
 
 func TestInspectVPC_ListFirewallsUnfiltered(t *testing.T) {
@@ -123,7 +123,7 @@ func TestInspectLoadBalancer_ListBackendServices_AppliesFilter(t *testing.T) {
 	_, err := inspectLoadBalancer(context.Background(), "demo-proj", "list-backend-services",
 		`{"project":"io-foo"}`, opts...)
 	require.NoError(t, err)
-	assert.Equal(t, "labels.project=io-foo", capturedFilter)
+	assert.Equal(t, `labels.project = "io-foo"`, capturedFilter)
 }
 
 func TestInspectLoadBalancer_UnsupportedAction(t *testing.T) {
@@ -149,7 +149,7 @@ func TestInspectCloudArmor_ListPolicies_AppliesFilter(t *testing.T) {
 	_, err := inspectCloudArmor(context.Background(), "demo-proj", "list-policies",
 		`{"project":"io-foo"}`, opts...)
 	require.NoError(t, err)
-	assert.Equal(t, "labels.project=io-foo", capturedFilter)
+	assert.Equal(t, `labels.project = "io-foo"`, capturedFilter)
 }
 
 func TestInspectCloudArmor_DescribePolicy_MissingFilter(t *testing.T) {

--- a/pkg/observability/extractors/aws_test.go
+++ b/pkg/observability/extractors/aws_test.go
@@ -1166,6 +1166,19 @@ func TestExtractEKSConfig(t *testing.T) {
 		t.Parallel()
 		assert.Nil(t, extractEKSConfig(map[string]any{"Clusters": []any{}}))
 	})
+
+	// EmptyName covers the `if names[0] != ""` branch in
+	// extractEKSConfig: when the first cluster name is the empty
+	// string, clusterCount is still emitted but clusterName must be
+	// omitted (an empty clusterName would render as "" in the panel).
+	t.Run("EmptyName", func(t *testing.T) {
+		t.Parallel()
+		got := extractEKSConfig([]any{""})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["clusterCount"])
+		_, hasName := got["clusterName"]
+		assert.False(t, hasName, "empty cluster name must NOT produce a clusterName key")
+	})
 }
 
 // --- extractWAFConfig ---

--- a/pkg/observability/extractors/aws_test.go
+++ b/pkg/observability/extractors/aws_test.go
@@ -1,0 +1,1294 @@
+// Per-extractor field-coverage tests for the AWS extractors in
+// extractors.go. Closes Gap 1 of issue #236 — the existing
+// extractors_drift_test.go only proves dispatch wiring + happy-path
+// non-nil outputs; this file enumerates every field branch in every
+// AWS extractor with table-driven cases.
+//
+// Style notes:
+//   - Fixtures are inline `map[string]any` (not JSON strings) so the
+//     test reader sees the exact envelope shape the extractor parses.
+//   - All tests use t.Parallel().
+//   - Every extractor has at minimum: HappyPath, Empty (nil + empty
+//     envelope), and one envelope-shape variant where the extractor
+//     accepts both flat-slice and {Key: [...]} forms.
+//   - Branch cases (multiAZ Yes/No, EC2 stopped instances not counted,
+//     OpenSearch managed-vs-AOSS priority, Bedrock IAMRole fallback,
+//     ElastiCache primary-only omitting replicas, etc.) are exercised
+//     individually with bespoke fixtures.
+package extractors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- extractRDSConfig ---
+
+func TestExtractRDSConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		got := extractRDSConfig(map[string]any{
+			"DBInstances": []any{
+				map[string]any{
+					"DBInstanceClass":  "db.t3.medium",
+					"AllocatedStorage": float64(100),
+					"Engine":           "postgres",
+					"MultiAZ":          true,
+				},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "db.t3.medium", got["cpuSize"])
+		assert.Equal(t, "100 GB", got["storageSize"])
+		assert.Equal(t, "postgres", got["engine"])
+		assert.Equal(t, "Yes", got["multiAz"])
+	})
+
+	t.Run("MultiAZFalse", func(t *testing.T) {
+		t.Parallel()
+		got := extractRDSConfig(map[string]any{
+			"DBInstances": []any{
+				map[string]any{"DBInstanceClass": "db.t3.micro", "MultiAZ": false},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "No", got["multiAz"])
+	})
+
+	t.Run("MultiAZTrue", func(t *testing.T) {
+		t.Parallel()
+		got := extractRDSConfig(map[string]any{
+			"DBInstances": []any{
+				map[string]any{"DBInstanceClass": "db.t3.micro", "MultiAZ": true},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "Yes", got["multiAz"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractRDSConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractRDSConfig(map[string]any{"DBInstances": []any{}}))
+	})
+
+	t.Run("PartialFields", func(t *testing.T) {
+		t.Parallel()
+		got := extractRDSConfig(map[string]any{
+			"DBInstances": []any{
+				map[string]any{"Engine": "mysql"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "mysql", got["engine"])
+		_, hasClass := got["cpuSize"]
+		_, hasStorage := got["storageSize"]
+		assert.False(t, hasClass)
+		assert.False(t, hasStorage)
+	})
+}
+
+// --- extractEC2Config ---
+
+func TestExtractEC2Config(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		got := extractEC2Config(map[string]any{
+			"Reservations": []any{
+				map[string]any{"Instances": []any{
+					map[string]any{
+						"InstanceType": "t3.small",
+						"State":        map[string]any{"Name": "running"},
+					},
+					map[string]any{
+						"InstanceType": "t3.small",
+						"State":        map[string]any{"Name": "running"},
+					},
+				}},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "t3.small", got["instanceType"])
+		assert.Equal(t, "2", got["numServers"])
+	})
+
+	t.Run("PartialFields", func(t *testing.T) {
+		t.Parallel()
+		// Only InstanceType, no State — instanceType set, no numServers.
+		got := extractEC2Config(map[string]any{
+			"Reservations": []any{
+				map[string]any{"Instances": []any{
+					map[string]any{"InstanceType": "t3.large"},
+				}},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "t3.large", got["instanceType"])
+		_, hasCount := got["numServers"]
+		assert.False(t, hasCount)
+	})
+
+	t.Run("StoppedInstancesNotCounted", func(t *testing.T) {
+		t.Parallel()
+		got := extractEC2Config(map[string]any{
+			"Reservations": []any{
+				map[string]any{"Instances": []any{
+					map[string]any{
+						"InstanceType": "t3.small",
+						"State":        map[string]any{"Name": "stopped"},
+					},
+				}},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "t3.small", got["instanceType"])
+		_, hasCount := got["numServers"]
+		assert.False(t, hasCount, "stopped instance should not increment numServers")
+	})
+
+	t.Run("MixedRunningAndStopped", func(t *testing.T) {
+		t.Parallel()
+		got := extractEC2Config(map[string]any{
+			"Reservations": []any{
+				map[string]any{"Instances": []any{
+					map[string]any{
+						"InstanceType": "t3.small",
+						"State":        map[string]any{"Name": "running"},
+					},
+					map[string]any{
+						"InstanceType": "t3.small",
+						"State":        map[string]any{"Name": "stopped"},
+					},
+					map[string]any{
+						"InstanceType": "t3.small",
+						"State":        map[string]any{"Name": "running"},
+					},
+				}},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["numServers"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractEC2Config(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractEC2Config(map[string]any{"Reservations": []any{}}))
+	})
+}
+
+// --- extractElastiCacheConfig ---
+
+func TestExtractElastiCacheConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		got := extractElastiCacheConfig(map[string]any{
+			"CacheClusters": []any{
+				map[string]any{
+					"CacheNodeType": "cache.t3.micro",
+					"Engine":        "redis",
+					"NumCacheNodes": float64(3),
+				},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "cache.t3.micro", got["nodeSize"])
+		assert.Equal(t, "redis", got["engine"])
+		// 3 nodes - 1 primary = 2 replicas
+		assert.Equal(t, "2", got["replicas"])
+	})
+
+	t.Run("PrimaryOnlyOmitsReplicas", func(t *testing.T) {
+		t.Parallel()
+		got := extractElastiCacheConfig(map[string]any{
+			"CacheClusters": []any{
+				map[string]any{
+					"CacheNodeType": "cache.t3.micro",
+					"NumCacheNodes": float64(1),
+				},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "cache.t3.micro", got["nodeSize"])
+		_, hasReplicas := got["replicas"]
+		assert.False(t, hasReplicas, "NumCacheNodes=1 should omit replicas key")
+	})
+
+	t.Run("ZeroNodesOmitsReplicas", func(t *testing.T) {
+		t.Parallel()
+		got := extractElastiCacheConfig(map[string]any{
+			"CacheClusters": []any{
+				map[string]any{
+					"CacheNodeType": "cache.t3.micro",
+					"NumCacheNodes": float64(0),
+				},
+			},
+		})
+		require.NotNil(t, got)
+		_, hasReplicas := got["replicas"]
+		assert.False(t, hasReplicas)
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractElastiCacheConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractElastiCacheConfig(map[string]any{"CacheClusters": []any{}}))
+	})
+}
+
+// --- extractOpenSearchConfig ---
+
+func TestExtractOpenSearchConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ManagedHappyPath", func(t *testing.T) {
+		t.Parallel()
+		got := extractOpenSearchConfig(map[string]any{
+			"DomainStatusList": []any{
+				map[string]any{
+					"DomainName": "demo",
+					"ClusterConfig": map[string]any{
+						"InstanceType":         "r6g.large.search",
+						"InstanceCount":        float64(3),
+						"ZoneAwarenessEnabled": true,
+					},
+					"EBSOptions": map[string]any{
+						"VolumeSize": float64(50),
+					},
+				},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "managed", got["deploymentType"])
+		assert.Equal(t, "r6g.large.search", got["instanceType"])
+		assert.Equal(t, "3", got["instanceCount"])
+		assert.Equal(t, "Yes", got["multiAz"])
+		assert.Equal(t, "50 GB", got["storageSize"])
+	})
+
+	t.Run("ManagedFlatSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractOpenSearchConfig([]any{
+			map[string]any{
+				"DomainName":    "demo",
+				"ClusterConfig": map[string]any{"InstanceType": "r6g.large.search"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "managed", got["deploymentType"])
+		assert.Equal(t, "r6g.large.search", got["instanceType"])
+	})
+
+	t.Run("ManagedWinsOverAOSS", func(t *testing.T) {
+		t.Parallel()
+		// AOSS first then managed — managed should still win.
+		got := extractOpenSearchConfig([]any{
+			map[string]any{"Name": "vector-coll", "Id": "xyz", "Type": "VECTORSEARCH"},
+			map[string]any{
+				"DomainName":    "demo",
+				"ClusterConfig": map[string]any{"InstanceType": "m6g.large.search"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "managed", got["deploymentType"])
+		assert.Equal(t, "m6g.large.search", got["instanceType"])
+	})
+
+	t.Run("AOSSCollection", func(t *testing.T) {
+		t.Parallel()
+		got := extractOpenSearchConfig([]any{
+			map[string]any{
+				"Name":   "demo-vec",
+				"Id":     "aoss-1",
+				"Status": "ACTIVE",
+				"Type":   "VECTORSEARCH",
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "serverless", got["deploymentType"])
+		assert.Equal(t, "demo-vec", got["collectionName"])
+		assert.Equal(t, "ACTIVE", got["status"])
+		assert.Equal(t, "VECTORSEARCH", got["collectionType"])
+	})
+
+	t.Run("AOSSWithoutType", func(t *testing.T) {
+		t.Parallel()
+		got := extractOpenSearchConfig([]any{
+			map[string]any{"Name": "demo-coll", "Id": "aoss-2"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "serverless", got["deploymentType"])
+		assert.Equal(t, "demo-coll", got["collectionName"])
+		_, hasType := got["collectionType"]
+		assert.False(t, hasType)
+	})
+
+	t.Run("ManagedDeploymentTypeOnlyReturnsNil", func(t *testing.T) {
+		t.Parallel()
+		// ClusterConfig present but empty, no EBSOptions — only deploymentType
+		// would be set, which the extractor returns as nil.
+		got := extractOpenSearchConfig([]any{
+			map[string]any{"ClusterConfig": map[string]any{}},
+		})
+		assert.Nil(t, got)
+	})
+
+	t.Run("NoneMatch", func(t *testing.T) {
+		t.Parallel()
+		got := extractOpenSearchConfig([]any{
+			map[string]any{"SomeUnknownField": "x"},
+		})
+		assert.Nil(t, got)
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractOpenSearchConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractOpenSearchConfig(map[string]any{"DomainStatusList": []any{}}))
+	})
+}
+
+// --- extractLambdaConfig ---
+
+func TestExtractLambdaConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		got := extractLambdaConfig(map[string]any{
+			"Functions": []any{
+				map[string]any{
+					"Runtime":    "go1.x",
+					"MemorySize": float64(256),
+					"Timeout":    float64(30),
+				},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "go1.x", got["runtime"])
+		assert.Equal(t, "256", got["memorySize"])
+		assert.Equal(t, "30s", got["timeout"])
+	})
+
+	t.Run("PartialMemoryOnly", func(t *testing.T) {
+		t.Parallel()
+		got := extractLambdaConfig(map[string]any{
+			"Functions": []any{
+				map[string]any{"MemorySize": float64(128)},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "128", got["memorySize"])
+		_, hasRuntime := got["runtime"]
+		_, hasTimeout := got["timeout"]
+		assert.False(t, hasRuntime)
+		assert.False(t, hasTimeout)
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractLambdaConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractLambdaConfig(map[string]any{"Functions": []any{}}))
+	})
+}
+
+// --- extractMSKConfig ---
+
+func TestExtractMSKConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BrokerCountAndType", func(t *testing.T) {
+		t.Parallel()
+		got := extractMSKConfig(map[string]any{
+			"ClusterInfoList": []any{
+				map[string]any{
+					"BrokerNodeGroupInfo": map[string]any{"InstanceType": "kafka.m5.large"},
+					"NumberOfBrokerNodes": float64(3),
+				},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "kafka.m5.large", got["brokerInstanceType"])
+		assert.Equal(t, "3", got["brokerCount"])
+	})
+
+	t.Run("CountOnly", func(t *testing.T) {
+		t.Parallel()
+		got := extractMSKConfig(map[string]any{
+			"ClusterInfoList": []any{
+				map[string]any{"NumberOfBrokerNodes": float64(2)},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["brokerCount"])
+		_, hasInst := got["brokerInstanceType"]
+		assert.False(t, hasInst)
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractMSKConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractMSKConfig(map[string]any{"ClusterInfoList": []any{}}))
+	})
+}
+
+// --- extractALBConfig ---
+
+func TestExtractALBConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_FlatSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractALBConfig([]any{
+			map[string]any{
+				"LoadBalancerName": "demo-alb",
+				"Type":             "application",
+				"Scheme":           "internet-facing",
+				"DNSName":          "demo-alb-123.us-east-1.elb.amazonaws.com",
+				"State":            map[string]any{"Code": "active"},
+			},
+			map[string]any{"LoadBalancerName": "second-alb", "Type": "network"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "demo-alb", got["loadBalancerName"])
+		assert.Equal(t, "application", got["loadBalancerType"])
+		assert.Equal(t, "internet-facing", got["scheme"])
+		assert.Equal(t, "demo-alb-123.us-east-1.elb.amazonaws.com", got["dnsName"])
+		assert.Equal(t, "active", got["state"])
+		assert.Equal(t, "2", got["count"])
+	})
+
+	t.Run("HappyPath_Envelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractALBConfig(map[string]any{
+			"LoadBalancers": []any{
+				map[string]any{"LoadBalancerName": "envelope-alb", "Type": "application"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "envelope-alb", got["loadBalancerName"])
+		assert.Equal(t, "1", got["count"])
+	})
+
+	t.Run("CountOnlyReturnsNil", func(t *testing.T) {
+		t.Parallel()
+		// Item present but has no useful fields — extractor returns nil
+		// when the only key emitted is `count`.
+		got := extractALBConfig([]any{
+			map[string]any{"SomeUnrelated": "x"},
+		})
+		assert.Nil(t, got)
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractALBConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractALBConfig(map[string]any{"LoadBalancers": []any{}}))
+	})
+}
+
+// --- extractKMSConfig ---
+
+func TestExtractKMSConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_FlatSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractKMSConfig([]any{
+			map[string]any{"AliasName": "alias/demo-1", "TargetKeyId": "kid-1"},
+			map[string]any{"AliasName": "alias/demo-2", "TargetKeyId": "kid-2"},
+			map[string]any{"AliasName": "alias/aws/s3"}, // no TargetKeyId — filtered
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["numKeys"])
+	})
+
+	t.Run("HappyPath_Envelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractKMSConfig(map[string]any{
+			"Aliases": []any{
+				map[string]any{"AliasName": "alias/demo", "TargetKeyId": "abc"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["numKeys"])
+	})
+
+	t.Run("FallbackToTotalCount", func(t *testing.T) {
+		t.Parallel()
+		// All entries lack TargetKeyId — fall back to len(items).
+		got := extractKMSConfig([]any{
+			map[string]any{"AliasName": "alias/aws/s3"},
+			map[string]any{"AliasName": "alias/aws/lambda"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["numKeys"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractKMSConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractKMSConfig(map[string]any{"Aliases": []any{}}))
+	})
+}
+
+// --- extractS3Config ---
+
+func TestExtractS3Config(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_FlatSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractS3Config([]any{
+			map[string]any{"Name": "demo-bucket-1"},
+			map[string]any{"Name": "demo-bucket-2"},
+			map[string]any{"Name": "demo-bucket-3"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "3", got["bucketCount"])
+	})
+
+	t.Run("HappyPath_Envelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractS3Config(map[string]any{
+			"Buckets": []any{map[string]any{"Name": "demo-bucket"}},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["bucketCount"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractS3Config(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractS3Config(map[string]any{"Buckets": []any{}}))
+	})
+}
+
+// --- extractSecretsManagerConfig ---
+
+func TestExtractSecretsManagerConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_FlatSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractSecretsManagerConfig([]any{
+			map[string]any{"Name": "demo/secret-1"},
+			map[string]any{"Name": "demo/secret-2"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["numSecrets"])
+	})
+
+	t.Run("HappyPath_Envelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractSecretsManagerConfig(map[string]any{
+			"SecretList": []any{
+				map[string]any{"Name": "demo/secret"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["numSecrets"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractSecretsManagerConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractSecretsManagerConfig(map[string]any{"SecretList": []any{}}))
+	})
+}
+
+// --- extractVPCConfig ---
+
+func TestExtractVPCConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PublicVPC", func(t *testing.T) {
+		t.Parallel()
+		got := extractVPCConfig([]any{
+			map[string]any{
+				"VpcId":              "vpc-1",
+				"CidrBlock":          "10.0.0.0/16",
+				"State":              "available",
+				"HasInternetGateway": true,
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "vpc-1", got["vpcId"])
+		assert.Equal(t, "10.0.0.0/16", got["cidrBlock"])
+		assert.Equal(t, "available", got["state"])
+		assert.Equal(t, "public", got["deploymentType"])
+	})
+
+	t.Run("PrivateVPC", func(t *testing.T) {
+		t.Parallel()
+		got := extractVPCConfig([]any{
+			map[string]any{
+				"VpcId":              "vpc-1",
+				"CidrBlock":          "10.0.0.0/16",
+				"HasInternetGateway": false,
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "private", got["deploymentType"])
+	})
+
+	t.Run("MixedVPCs", func(t *testing.T) {
+		t.Parallel()
+		got := extractVPCConfig([]any{
+			map[string]any{"VpcId": "vpc-pub", "HasInternetGateway": true},
+			map[string]any{"VpcId": "vpc-priv", "HasInternetGateway": false},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "mixed", got["deploymentType"])
+	})
+
+	t.Run("NoIGWFlagOmitsDeploymentType", func(t *testing.T) {
+		t.Parallel()
+		got := extractVPCConfig([]any{
+			map[string]any{"VpcId": "vpc-1", "CidrBlock": "10.0.0.0/16"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "vpc-1", got["vpcId"])
+		_, has := got["deploymentType"]
+		assert.False(t, has, "deploymentType only emitted when HasInternetGateway is present")
+	})
+
+	t.Run("HappyPath_Envelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractVPCConfig(map[string]any{
+			"Vpcs": []any{
+				map[string]any{"VpcId": "vpc-env", "CidrBlock": "172.16.0.0/16"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "vpc-env", got["vpcId"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractVPCConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractVPCConfig(map[string]any{"Vpcs": []any{}}))
+	})
+}
+
+// --- extractAPIGatewayConfig ---
+
+func TestExtractAPIGatewayConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HTTPApi", func(t *testing.T) {
+		t.Parallel()
+		got := extractAPIGatewayConfig(map[string]any{
+			"Items": []any{
+				map[string]any{
+					"ApiId":        "abc123",
+					"Name":         "demo-http-api",
+					"ProtocolType": "HTTP",
+					"ApiEndpoint":  "https://abc123.execute-api.us-east-1.amazonaws.com",
+				},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["apiCount"])
+		assert.Equal(t, "HTTP", got["protocolType"])
+		assert.Equal(t, "https://abc123.execute-api.us-east-1.amazonaws.com", got["domainName"])
+	})
+
+	t.Run("WebSocketApi", func(t *testing.T) {
+		t.Parallel()
+		got := extractAPIGatewayConfig(map[string]any{
+			"Items": []any{
+				map[string]any{"ApiId": "ws1", "ProtocolType": "WEBSOCKET"},
+				map[string]any{"ApiId": "ws2", "ProtocolType": "WEBSOCKET"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["apiCount"])
+		assert.Equal(t, "WEBSOCKET", got["protocolType"])
+	})
+
+	t.Run("EndpointTypeForwardCompat", func(t *testing.T) {
+		t.Parallel()
+		got := extractAPIGatewayConfig(map[string]any{
+			"Items": []any{
+				map[string]any{"ApiId": "rest1", "EndpointType": "REGIONAL"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "REGIONAL", got["endpointType"])
+	})
+
+	t.Run("FlatSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractAPIGatewayConfig([]any{
+			map[string]any{"ApiId": "abc", "ProtocolType": "HTTP"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["apiCount"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractAPIGatewayConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractAPIGatewayConfig(map[string]any{"Items": []any{}}))
+	})
+}
+
+// --- extractBedrockConfig ---
+
+func TestExtractBedrockConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("KnowledgeBaseHappyPath", func(t *testing.T) {
+		t.Parallel()
+		got := extractBedrockConfig([]any{
+			map[string]any{
+				"Name":            "demo-kb",
+				"Status":          "ACTIVE",
+				"KnowledgeBaseId": "kb-1",
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "demo-kb", got["knowledgeBaseName"])
+		assert.Equal(t, "ACTIVE", got["status"])
+		assert.Equal(t, "kb-1", got["knowledgeBaseId"])
+	})
+
+	t.Run("IAMRoleFallback", func(t *testing.T) {
+		t.Parallel()
+		got := extractBedrockConfig([]any{
+			map[string]any{
+				"Kind":     "IAMRole",
+				"RoleName": "demo-bedrock-role",
+				"Arn":      "arn:aws:iam::123:role/demo-bedrock-role",
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "iam-role-only", got["deploymentStage"])
+		assert.Equal(t, "demo-bedrock-role", got["roleName"])
+		assert.Equal(t, "arn:aws:iam::123:role/demo-bedrock-role", got["roleArn"])
+	})
+
+	t.Run("KBWinsOverIAMRole", func(t *testing.T) {
+		t.Parallel()
+		// Mixed list: KB takes priority even when IAMRole entry comes first.
+		got := extractBedrockConfig([]any{
+			map[string]any{"Kind": "IAMRole", "RoleName": "demo-role"},
+			map[string]any{"Name": "real-kb", "KnowledgeBaseId": "kb-1"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "real-kb", got["knowledgeBaseName"])
+		_, hasStage := got["deploymentStage"]
+		assert.False(t, hasStage)
+	})
+
+	t.Run("HappyPath_Envelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractBedrockConfig(map[string]any{
+			"KnowledgeBaseSummaries": []any{
+				map[string]any{"Name": "envelope-kb", "KnowledgeBaseId": "kb-env"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "envelope-kb", got["knowledgeBaseName"])
+	})
+
+	t.Run("NoMatch", func(t *testing.T) {
+		t.Parallel()
+		// Entry with neither Kind=IAMRole nor any KB identifying field.
+		got := extractBedrockConfig([]any{
+			map[string]any{"Foo": "bar"},
+		})
+		assert.Nil(t, got)
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractBedrockConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractBedrockConfig(map[string]any{"KnowledgeBaseSummaries": []any{}}))
+	})
+}
+
+// --- extractCloudFrontConfig ---
+
+func TestExtractCloudFrontConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DistributionList_FlatSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractCloudFrontConfig([]any{
+			map[string]any{
+				"Id":         "E123ABC",
+				"DomainName": "d1.cloudfront.net",
+				"Status":     "Deployed",
+				"Enabled":    true,
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "E123ABC", got["distributionId"])
+		assert.Equal(t, "d1.cloudfront.net", got["domainName"])
+		assert.Equal(t, "Deployed", got["status"])
+		assert.Equal(t, "Yes", got["enabled"])
+	})
+
+	t.Run("ItemsEnvelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractCloudFrontConfig(map[string]any{
+			"Items": []any{
+				map[string]any{"Id": "E456", "DomainName": "d2.cloudfront.net"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "E456", got["distributionId"])
+		assert.Equal(t, "d2.cloudfront.net", got["domainName"])
+	})
+
+	t.Run("DisabledDistribution", func(t *testing.T) {
+		t.Parallel()
+		got := extractCloudFrontConfig([]any{
+			map[string]any{"Id": "E789", "Enabled": false},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "No", got["enabled"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractCloudFrontConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractCloudFrontConfig(map[string]any{"Items": []any{}}))
+	})
+}
+
+// --- extractSQSConfig ---
+
+func TestExtractSQSConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("StandardQueues_FlatSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractSQSConfig([]any{
+			"https://sqs.us-east-1.amazonaws.com/123/demo-1",
+			"https://sqs.us-east-1.amazonaws.com/123/demo-2",
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["queueCount"])
+		assert.Equal(t, "Standard", got["type"])
+	})
+
+	t.Run("FIFOQueues", func(t *testing.T) {
+		t.Parallel()
+		got := extractSQSConfig([]any{
+			"https://sqs.us-east-1.amazonaws.com/123/demo-1.fifo",
+			"https://sqs.us-east-1.amazonaws.com/123/demo-2.fifo",
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["queueCount"])
+		assert.Equal(t, "FIFO", got["type"])
+	})
+
+	t.Run("MixedFIFOAndStandardOmitsType", func(t *testing.T) {
+		t.Parallel()
+		got := extractSQSConfig([]any{
+			"https://sqs.us-east-1.amazonaws.com/123/demo-1",
+			"https://sqs.us-east-1.amazonaws.com/123/demo-2.fifo",
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["queueCount"])
+		_, hasType := got["type"]
+		assert.False(t, hasType, "mixed FIFO/Standard should omit type")
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractSQSConfig(map[string]any{
+			"QueueUrls": []any{
+				"https://sqs.us-east-1.amazonaws.com/123/demo",
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["queueCount"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractSQSConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractSQSConfig(map[string]any{"QueueUrls": []any{}}))
+	})
+}
+
+// --- extractCognitoConfig ---
+
+func TestExtractCognitoConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_FlatSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractCognitoConfig([]any{
+			map[string]any{
+				"Id":     "us-east-1_abc",
+				"Name":   "demo-pool",
+				"Status": "Enabled",
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["userPoolCount"])
+		assert.Equal(t, "demo-pool", got["poolName"])
+		assert.Equal(t, "Enabled", got["status"])
+		assert.Equal(t, "us-east-1_abc", got["poolId"])
+	})
+
+	t.Run("MultiplePools", func(t *testing.T) {
+		t.Parallel()
+		got := extractCognitoConfig([]any{
+			map[string]any{"Id": "p1", "Name": "first"},
+			map[string]any{"Id": "p2", "Name": "second"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["userPoolCount"])
+		assert.Equal(t, "first", got["poolName"]) // first one
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractCognitoConfig(map[string]any{
+			"UserPools": []any{
+				map[string]any{"Id": "envID", "Name": "envName"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["userPoolCount"])
+		assert.Equal(t, "envName", got["poolName"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractCognitoConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractCognitoConfig(map[string]any{"UserPools": []any{}}))
+	})
+}
+
+// --- extractDynamoDBConfig ---
+
+func TestExtractDynamoDBConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_FlatSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractDynamoDBConfig([]any{"demo-table-1", "demo-table-2", "demo-table-3"})
+		require.NotNil(t, got)
+		assert.Equal(t, "3", got["tableCount"])
+		assert.Equal(t, "demo-table-1", got["tableName"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractDynamoDBConfig(map[string]any{
+			"TableNames": []any{"only-table"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["tableCount"])
+		assert.Equal(t, "only-table", got["tableName"])
+	})
+
+	t.Run("StringSliceShape", func(t *testing.T) {
+		t.Parallel()
+		got := extractDynamoDBConfig([]string{"native-string-table"})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["tableCount"])
+		assert.Equal(t, "native-string-table", got["tableName"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractDynamoDBConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractDynamoDBConfig(map[string]any{"TableNames": []any{}}))
+	})
+}
+
+// --- extractECSConfig ---
+
+func TestExtractECSConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_FlatSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractECSConfig([]any{
+			map[string]any{
+				"ClusterName": "demo-cluster",
+				"ClusterArn":  "arn:aws:ecs:us-east-1:123:cluster/demo-cluster",
+			},
+			map[string]any{
+				"ClusterName": "second-cluster",
+				"ClusterArn":  "arn:aws:ecs:us-east-1:123:cluster/second-cluster",
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["clusterCount"])
+		assert.Equal(t, "demo-cluster", got["clusterName"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractECSConfig(map[string]any{
+			"Clusters": []any{
+				map[string]any{"ClusterName": "envelope-cluster"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["clusterCount"])
+		assert.Equal(t, "envelope-cluster", got["clusterName"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractECSConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractECSConfig(map[string]any{"Clusters": []any{}}))
+	})
+}
+
+// --- extractEKSConfig ---
+
+func TestExtractEKSConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_FlatSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractEKSConfig([]any{"demo-cluster", "second-cluster"})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["clusterCount"])
+		assert.Equal(t, "demo-cluster", got["clusterName"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractEKSConfig(map[string]any{
+			"Clusters": []any{"only-cluster"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["clusterCount"])
+		assert.Equal(t, "only-cluster", got["clusterName"])
+	})
+
+	t.Run("StringSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractEKSConfig([]string{"native"})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["clusterCount"])
+		assert.Equal(t, "native", got["clusterName"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractEKSConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractEKSConfig(map[string]any{"Clusters": []any{}}))
+	})
+}
+
+// --- extractWAFConfig ---
+
+func TestExtractWAFConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_FlatSlice", func(t *testing.T) {
+		t.Parallel()
+		got := extractWAFConfig([]any{
+			map[string]any{"Name": "demo-acl", "Id": "acl-1"},
+			map[string]any{"Name": "second-acl", "Id": "acl-2"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["webAclCount"])
+		assert.Equal(t, "demo-acl", got["webAclName"])
+		assert.Equal(t, "acl-1", got["webAclId"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractWAFConfig(map[string]any{
+			"WebACLs": []any{
+				map[string]any{"Name": "env-acl", "Id": "env-id"},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["webAclCount"])
+		assert.Equal(t, "env-acl", got["webAclName"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractWAFConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractWAFConfig(map[string]any{"WebACLs": []any{}}))
+	})
+}
+
+// --- extractCloudWatchLogsConfig ---
+
+func TestExtractCloudWatchLogsConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("UniformRetention", func(t *testing.T) {
+		t.Parallel()
+		got := extractCloudWatchLogsConfig([]any{
+			map[string]any{
+				"LogGroupName":    "/aws/lambda/demo-1",
+				"RetentionInDays": float64(30),
+			},
+			map[string]any{
+				"LogGroupName":    "/aws/lambda/demo-2",
+				"RetentionInDays": float64(30),
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["logGroupCount"])
+		assert.Equal(t, "30", got["retentionDays"])
+		_, hasKMS := got["kmsEncrypted"]
+		assert.False(t, hasKMS)
+	})
+
+	t.Run("MixedRetentionOmitted", func(t *testing.T) {
+		t.Parallel()
+		got := extractCloudWatchLogsConfig([]any{
+			map[string]any{
+				"LogGroupName":    "/aws/lambda/demo-1",
+				"RetentionInDays": float64(30),
+			},
+			map[string]any{
+				"LogGroupName":    "/aws/lambda/demo-2",
+				"RetentionInDays": float64(7),
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["logGroupCount"])
+		_, hasRet := got["retentionDays"]
+		assert.False(t, hasRet, "mixed retention should omit retentionDays")
+	})
+
+	t.Run("KmsEncryptedAnyGroup", func(t *testing.T) {
+		t.Parallel()
+		got := extractCloudWatchLogsConfig([]any{
+			map[string]any{"LogGroupName": "/aws/lambda/demo", "KmsKeyId": "arn:aws:kms:..."},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "Yes", got["kmsEncrypted"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		got := extractCloudWatchLogsConfig(map[string]any{
+			"LogGroups": []any{
+				map[string]any{"LogGroupName": "/aws/lambda/env", "RetentionInDays": float64(14)},
+			},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["logGroupCount"])
+		assert.Equal(t, "14", got["retentionDays"])
+	})
+
+	t.Run("NoRetentionOnAnyGroup", func(t *testing.T) {
+		t.Parallel()
+		got := extractCloudWatchLogsConfig([]any{
+			map[string]any{"LogGroupName": "/aws/lambda/demo"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["logGroupCount"])
+		_, hasRet := got["retentionDays"]
+		assert.False(t, hasRet)
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractCloudWatchLogsConfig(nil))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractCloudWatchLogsConfig(map[string]any{"LogGroups": []any{}}))
+	})
+}

--- a/pkg/observability/extractors/gcp_test.go
+++ b/pkg/observability/extractors/gcp_test.go
@@ -255,7 +255,6 @@ func TestExtractGCPLocationFromName(t *testing.T) {
 		{"TrailingLocation", "projects/p/locations/us-east1", "us-east1"},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.out, extractGCPLocationFromName(tc.in))
@@ -358,12 +357,11 @@ func TestExtractGCPCloudSQLConfig(t *testing.T) {
 		assert.NotContains(t, got, "highAvailability")
 	})
 
-	t.Run("BackupConfig_NoEffect", func(t *testing.T) {
+	t.Run("BackupConfig_PendingIssue236", func(t *testing.T) {
 		t.Parallel()
+		t.Logf("TODO #236: extractGCPCloudSQLConfig does not surface backupConfiguration.enabled; flip this assertion when the field is wired through.")
 		// The current extractor reads availabilityType but does NOT
-		// surface backupConfiguration.enabled into the output. Test
-		// confirms current behavior — flip this when issue #236
-		// follow-up wires it through.
+		// surface backupConfiguration.enabled into the output.
 		rawEnabled := map[string]any{"items": []any{map[string]any{
 			"settings": map[string]any{
 				"backupConfiguration": map[string]any{"enabled": true},
@@ -371,7 +369,7 @@ func TestExtractGCPCloudSQLConfig(t *testing.T) {
 			},
 		}}}
 		gotEnabled := extractGCPCloudSQLConfig(rawEnabled)
-		assert.NotContains(t, gotEnabled, "backupEnabled")
+		require.NotContains(t, gotEnabled, "backupEnabled")
 
 		rawDisabled := map[string]any{"items": []any{map[string]any{
 			"settings": map[string]any{
@@ -443,13 +441,9 @@ func TestExtractGCPGCSConfig(t *testing.T) {
 		assert.Equal(t, "US", got["location"])
 	})
 
-	t.Run("LifecycleNotSurfaced", func(t *testing.T) {
+	t.Run("LifecyclePolicy_PendingIssue236", func(t *testing.T) {
 		t.Parallel()
-		// Issue #236 spec calls for a `lifecyclePolicy=enabled` branch
-		// when `lifecycle.rule` is present, but the inspector
-		// pre-flattens to {name, location, storageClass, created} so
-		// the extractor has no lifecycle field to read. Test asserts
-		// current behavior — flip when the inspector surface widens.
+		t.Logf("TODO #236: extractGCPGCSConfig does not surface lifecyclePolicy; the inspector pre-flattens away the lifecycle field. Flip when the inspector surface widens.")
 		rawWithLifecycle := []any{map[string]any{
 			"name":         "lc-bucket",
 			"location":     "us-east1",
@@ -457,7 +451,7 @@ func TestExtractGCPGCSConfig(t *testing.T) {
 			"lifecycle":    map[string]any{"rule": []any{map[string]any{"action": map[string]any{"type": "Delete"}}}},
 		}}
 		got := extractGCPGCSConfig(rawWithLifecycle)
-		assert.NotContains(t, got, "lifecyclePolicy")
+		require.NotContains(t, got, "lifecyclePolicy")
 
 		rawAbsent := []any{map[string]any{
 			"name":         "plain-bucket",
@@ -825,16 +819,12 @@ func TestExtractGCPVPCConfig(t *testing.T) {
 		// — the current extractor surfaces only autoCreateSubnetworks
 		// directly. Confirm the alias key is NOT present so a future
 		// implementer of #236 has a failing assertion to flip.
-		assert.NotContains(t, got, "vpcMode")
+		require.NotContains(t, got, "vpcMode")
 	})
 
-	t.Run("IGWClassificationNotSurfaced", func(t *testing.T) {
+	t.Run("IGWClassification_PendingIssue236", func(t *testing.T) {
 		t.Parallel()
-		// The current extractor does NOT inspect firewall rules to
-		// classify Public/Private/Mixed (issue #236 calls for it but
-		// the inspector returns []computeapi.Network, not firewalls).
-		// Lock in current behavior so a future implementer has a
-		// failing assertion to flip.
+		t.Logf("TODO #236: extractGCPVPCConfig does not classify Public/Private/Mixed; the inspector returns []computeapi.Network, not firewalls. Flip when the inspector surface widens.")
 		raw := []any{map[string]any{
 			"name":                  "fw-vpc",
 			"autoCreateSubnetworks": false,
@@ -844,8 +834,8 @@ func TestExtractGCPVPCConfig(t *testing.T) {
 			},
 		}}
 		got := extractGCPVPCConfig(raw)
-		assert.NotContains(t, got, "igwClassification")
-		assert.NotContains(t, got, "internetExposure")
+		require.NotContains(t, got, "igwClassification")
+		require.NotContains(t, got, "internetExposure")
 	})
 
 	t.Run("NoSubnetworks", func(t *testing.T) {

--- a/pkg/observability/extractors/gcp_test.go
+++ b/pkg/observability/extractors/gcp_test.go
@@ -1,0 +1,1358 @@
+// Per-extractor field-coverage tests for every GCP extractor in
+// extractors.go. Closes the GCP half of Gap 1 of issue #236 — the drift
+// suite (extractors_drift_test.go) pins exact field counts and dispatch
+// wiring, but does not exercise per-branch logic. This file does.
+//
+// Style mirrors the AWS counterpart (aws_test.go): each top-level
+// TestExtractGCP<Name>Config exercises happy path + nil/empty + envelope
+// variants + any branch logic the extractor actually implements. Where
+// the issue spec asks for a branch the source code does NOT yet
+// implement (e.g. GCS lifecycle policy, VPC IGW classification, VPC
+// auto-mode keyed as `vpcMode`), the test asserts the CURRENT behaviour
+// (the field is simply absent) so future implementation work has a
+// failing assertion to flip.
+package extractors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------- gcp_compute ----------
+
+func TestExtractGCPComputeConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{
+			map[string]any{
+				"name":        "demo-vm",
+				"machineType": "https://www.googleapis.com/compute/v1/projects/demo/zones/us-central1-a/machineTypes/e2-medium",
+				"zone":        "https://www.googleapis.com/compute/v1/projects/demo/zones/us-central1-a",
+				"status":      "RUNNING",
+			},
+			map[string]any{"name": "demo-vm-2", "status": "STOPPED"},
+		}
+		got := extractGCPComputeConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["instanceCount"])
+		assert.Equal(t, "demo-vm", got["instanceName"])
+		assert.Equal(t, "e2-medium", got["machineType"])
+		assert.Equal(t, "us-central1-a", got["zone"])
+		assert.Equal(t, "RUNNING", got["status"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{
+			"instances": []any{
+				map[string]any{"name": "vm-1", "status": "RUNNING"},
+			},
+		}
+		got := extractGCPComputeConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["instanceCount"])
+		assert.Equal(t, "vm-1", got["instanceName"])
+		assert.Equal(t, "RUNNING", got["status"])
+	})
+
+	t.Run("BasenameOnURLs", func(t *testing.T) {
+		t.Parallel()
+		// Confirms the extractor strips the full GCP resource URL down to
+		// the trailing segment (basename), which is what the UI compares.
+		raw := []any{map[string]any{
+			"name":        "vm",
+			"machineType": "projects/p/zones/us-central1-a/machineTypes/n2-standard-4",
+			"zone":        "projects/p/zones/us-central1-a",
+		}}
+		got := extractGCPComputeConfig(raw)
+		assert.Equal(t, "n2-standard-4", got["machineType"])
+		assert.Equal(t, "us-central1-a", got["zone"])
+	})
+
+	t.Run("NilInput", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPComputeConfig(nil))
+	})
+
+	t.Run("EmptyList", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPComputeConfig([]any{}))
+	})
+
+	t.Run("EmptyEnvelope", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPComputeConfig(map[string]any{"instances": []any{}}))
+	})
+}
+
+// ---------- gcp_gke ----------
+
+func TestExtractGCPGKEConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":                 "demo-gke",
+			"status":               "RUNNING",
+			"location":             "us-central1",
+			"currentNodeCount":     float64(3),
+			"currentMasterVersion": "1.29.4-gke.1043000",
+			"autopilot":            map[string]any{"enabled": true},
+			"privateClusterConfig": map[string]any{"enablePrivateNodes": true},
+		}}
+		got := extractGCPGKEConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["clusterCount"])
+		assert.Equal(t, "demo-gke", got["clusterName"])
+		assert.Equal(t, "RUNNING", got["status"])
+		assert.Equal(t, "us-central1", got["location"])
+		assert.Equal(t, "3", got["nodeCount"])
+		assert.Equal(t, "1.29.4-gke.1043000", got["clusterVersion"])
+		assert.Equal(t, "Yes", got["autopilot"])
+		assert.Equal(t, "Yes", got["privateCluster"])
+	})
+
+	t.Run("AutopilotDisabled", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":      "std-gke",
+			"autopilot": map[string]any{"enabled": false},
+			"privateClusterConfig": map[string]any{
+				"enablePrivateNodes": false,
+			},
+		}}
+		got := extractGCPGKEConfig(raw)
+		assert.Equal(t, "No", got["autopilot"])
+		assert.Equal(t, "No", got["privateCluster"])
+	})
+
+	t.Run("NoSubObjects", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{"name": "bare"}}
+		got := extractGCPGKEConfig(raw)
+		require.NotNil(t, got)
+		assert.NotContains(t, got, "autopilot")
+		assert.NotContains(t, got, "privateCluster")
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"clusters": []any{
+			map[string]any{"name": "wrap-gke", "status": "PROVISIONING"},
+		}}
+		got := extractGCPGKEConfig(raw)
+		assert.Equal(t, "wrap-gke", got["clusterName"])
+		assert.Equal(t, "PROVISIONING", got["status"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPGKEConfig(nil))
+		assert.Nil(t, extractGCPGKEConfig([]any{}))
+	})
+}
+
+// ---------- gcp_cloud_run ----------
+
+func TestExtractGCPCloudRunConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name": "projects/demo/locations/us-central1/services/svc-1",
+			"uri":  "https://svc-1-abc-uc.a.run.app",
+			"template": map[string]any{
+				"containers": []any{map[string]any{
+					"resources": map[string]any{
+						"limits": map[string]any{"cpu": "2", "memory": "1Gi"},
+					},
+				}},
+				"scaling": map[string]any{
+					"minInstanceCount": float64(1),
+					"maxInstanceCount": float64(20),
+				},
+				"maxInstanceRequestConcurrency": float64(80),
+			},
+		}}
+		got := extractGCPCloudRunConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["serviceCount"])
+		assert.Equal(t, "svc-1", got["serviceName"]) // basename stripped
+		assert.Equal(t, "https://svc-1-abc-uc.a.run.app", got["uri"])
+		assert.Equal(t, "us-central1", got["location"])
+		assert.Equal(t, "2", got["cpu"])
+		assert.Equal(t, "1Gi", got["memory"])
+		assert.Equal(t, "1", got["minInstances"])
+		assert.Equal(t, "20", got["maxInstances"])
+		assert.Equal(t, "80", got["concurrency"])
+	})
+
+	t.Run("BasenameStripping", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name": "projects/foo/locations/europe-west1/services/api",
+		}}
+		got := extractGCPCloudRunConfig(raw)
+		assert.Equal(t, "api", got["serviceName"])
+		assert.Equal(t, "europe-west1", got["location"])
+	})
+
+	t.Run("ShortName", func(t *testing.T) {
+		t.Parallel()
+		// gcpResourceBasename returns the input unchanged if no slash.
+		raw := []any{map[string]any{"name": "plain-name"}}
+		got := extractGCPCloudRunConfig(raw)
+		assert.Equal(t, "plain-name", got["serviceName"])
+		assert.NotContains(t, got, "location")
+	})
+
+	t.Run("NoTemplate", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{"name": "projects/p/locations/us-east1/services/s"}}
+		got := extractGCPCloudRunConfig(raw)
+		assert.NotContains(t, got, "cpu")
+		assert.NotContains(t, got, "memory")
+		assert.NotContains(t, got, "minInstances")
+		assert.NotContains(t, got, "concurrency")
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"services": []any{
+			map[string]any{"name": "projects/p/locations/us/services/x"},
+		}}
+		got := extractGCPCloudRunConfig(raw)
+		assert.Equal(t, "x", got["serviceName"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPCloudRunConfig(nil))
+		assert.Nil(t, extractGCPCloudRunConfig([]any{}))
+	})
+}
+
+// ---------- extractGCPLocationFromName ----------
+
+func TestExtractGCPLocationFromName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{"FullCloudRunName", "projects/demo/locations/us-central1/services/svc", "us-central1"},
+		{"VertexEndpoint", "projects/p/locations/europe-west4/endpoints/123", "europe-west4"},
+		{"NoLocations", "projects/p/topics/x", ""},
+		{"Empty", "", ""},
+		{"TrailingLocation", "projects/p/locations/us-east1", "us-east1"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.out, extractGCPLocationFromName(tc.in))
+		})
+	}
+}
+
+// ---------- gcp_memorystore ----------
+
+func TestExtractGCPMemorystoreConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":         "projects/demo/locations/us-central1/instances/redis-1",
+			"tier":         "STANDARD_HA",
+			"memorySizeGb": float64(5),
+			"redisVersion": "REDIS_7_0",
+			"state":        "READY",
+			"locationId":   "us-central1-a",
+		}}
+		got := extractGCPMemorystoreConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["instanceCount"])
+		assert.Equal(t, "redis-1", got["instanceName"])
+		assert.Equal(t, "STANDARD_HA", got["tier"])
+		assert.Equal(t, "5", got["memorySizeGb"])
+		assert.Equal(t, "REDIS_7_0", got["redisVersion"])
+		assert.Equal(t, "READY", got["state"])
+		assert.Equal(t, "us-central1-a", got["location"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"instances": []any{
+			map[string]any{"name": "x", "tier": "BASIC"},
+		}}
+		got := extractGCPMemorystoreConfig(raw)
+		assert.Equal(t, "BASIC", got["tier"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPMemorystoreConfig(nil))
+		assert.Nil(t, extractGCPMemorystoreConfig([]any{}))
+	})
+}
+
+// ---------- gcp_cloudsql ----------
+
+func TestExtractGCPCloudSQLConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_HA_REGIONAL", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"items": []any{map[string]any{
+			"name":            "demo-pg",
+			"databaseVersion": "POSTGRES_15",
+			"state":           "RUNNABLE",
+			"region":          "us-central1",
+			"settings": map[string]any{
+				"tier":             "db-custom-2-7680",
+				"dataDiskSizeGb":   float64(50),
+				"availabilityType": "REGIONAL",
+				"backupConfiguration": map[string]any{
+					"enabled": true,
+				},
+			},
+		}}}
+		got := extractGCPCloudSQLConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["instanceCount"])
+		assert.Equal(t, "demo-pg", got["instanceName"])
+		assert.Equal(t, "POSTGRES_15", got["databaseVersion"])
+		assert.Equal(t, "RUNNABLE", got["state"])
+		assert.Equal(t, "us-central1", got["region"])
+		assert.Equal(t, "db-custom-2-7680", got["tier"])
+		assert.Equal(t, "50", got["diskSizeGb"])
+		assert.Equal(t, "Yes", got["highAvailability"])
+	})
+
+	t.Run("HABranch_ZONAL", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"items": []any{map[string]any{
+			"settings": map[string]any{"availabilityType": "ZONAL"},
+		}}}
+		got := extractGCPCloudSQLConfig(raw)
+		assert.Equal(t, "No", got["highAvailability"])
+	})
+
+	t.Run("HABranch_Unspecified", func(t *testing.T) {
+		t.Parallel()
+		// Neither REGIONAL nor ZONAL → field is absent (extractor's
+		// switch has no default case for it).
+		raw := map[string]any{"items": []any{map[string]any{
+			"settings": map[string]any{"availabilityType": ""},
+		}}}
+		got := extractGCPCloudSQLConfig(raw)
+		assert.NotContains(t, got, "highAvailability")
+	})
+
+	t.Run("BackupConfig_NoEffect", func(t *testing.T) {
+		t.Parallel()
+		// The current extractor reads availabilityType but does NOT
+		// surface backupConfiguration.enabled into the output. Test
+		// confirms current behavior — flip this when issue #236
+		// follow-up wires it through.
+		rawEnabled := map[string]any{"items": []any{map[string]any{
+			"settings": map[string]any{
+				"backupConfiguration": map[string]any{"enabled": true},
+				"availabilityType":    "REGIONAL",
+			},
+		}}}
+		gotEnabled := extractGCPCloudSQLConfig(rawEnabled)
+		assert.NotContains(t, gotEnabled, "backupEnabled")
+
+		rawDisabled := map[string]any{"items": []any{map[string]any{
+			"settings": map[string]any{
+				"backupConfiguration": map[string]any{"enabled": false},
+				"availabilityType":    "ZONAL",
+			},
+		}}}
+		gotDisabled := extractGCPCloudSQLConfig(rawDisabled)
+		assert.NotContains(t, gotDisabled, "backupEnabled")
+	})
+
+	t.Run("DirectSlice", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":            "direct-pg",
+			"databaseVersion": "POSTGRES_14",
+		}}
+		got := extractGCPCloudSQLConfig(raw)
+		assert.Equal(t, "direct-pg", got["instanceName"])
+		assert.Equal(t, "POSTGRES_14", got["databaseVersion"])
+	})
+
+	t.Run("NoSettings", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"items": []any{map[string]any{"name": "bare"}}}
+		got := extractGCPCloudSQLConfig(raw)
+		assert.NotContains(t, got, "tier")
+		assert.NotContains(t, got, "highAvailability")
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPCloudSQLConfig(nil))
+		assert.Nil(t, extractGCPCloudSQLConfig(map[string]any{"items": []any{}}))
+	})
+}
+
+// ---------- gcp_gcs ----------
+
+func TestExtractGCPGCSConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_Regional", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":         "demo-bucket",
+			"location":     "us-central1",
+			"storageClass": "STANDARD",
+		}}
+		got := extractGCPGCSConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["bucketCount"])
+		assert.Equal(t, "demo-bucket", got["bucketName"])
+		assert.Equal(t, "us-central1", got["location"])
+		assert.Equal(t, "STANDARD", got["storageClass"])
+	})
+
+	t.Run("MultiRegionalLocation", func(t *testing.T) {
+		t.Parallel()
+		// `US`, `EU`, `ASIA` are GCS multi-region locations. The current
+		// extractor surfaces them as-is (no split into single-region vs
+		// multi-region classification). Test asserts pass-through.
+		raw := []any{map[string]any{
+			"name":         "global-bucket",
+			"location":     "US",
+			"storageClass": "STANDARD",
+		}}
+		got := extractGCPGCSConfig(raw)
+		assert.Equal(t, "US", got["location"])
+	})
+
+	t.Run("LifecycleNotSurfaced", func(t *testing.T) {
+		t.Parallel()
+		// Issue #236 spec calls for a `lifecyclePolicy=enabled` branch
+		// when `lifecycle.rule` is present, but the inspector
+		// pre-flattens to {name, location, storageClass, created} so
+		// the extractor has no lifecycle field to read. Test asserts
+		// current behavior — flip when the inspector surface widens.
+		rawWithLifecycle := []any{map[string]any{
+			"name":         "lc-bucket",
+			"location":     "us-east1",
+			"storageClass": "NEARLINE",
+			"lifecycle":    map[string]any{"rule": []any{map[string]any{"action": map[string]any{"type": "Delete"}}}},
+		}}
+		got := extractGCPGCSConfig(rawWithLifecycle)
+		assert.NotContains(t, got, "lifecyclePolicy")
+
+		rawAbsent := []any{map[string]any{
+			"name":         "plain-bucket",
+			"location":     "us-east1",
+			"storageClass": "NEARLINE",
+		}}
+		gotAbsent := extractGCPGCSConfig(rawAbsent)
+		assert.NotContains(t, gotAbsent, "lifecyclePolicy")
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"buckets": []any{
+			map[string]any{"name": "env-bucket", "location": "EU"},
+		}}
+		got := extractGCPGCSConfig(raw)
+		assert.Equal(t, "env-bucket", got["bucketName"])
+		assert.Equal(t, "EU", got["location"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPGCSConfig(nil))
+		assert.Nil(t, extractGCPGCSConfig([]any{}))
+	})
+}
+
+// ---------- gcp_firestore ----------
+
+func TestExtractGCPFirestoreConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{"users", "orders", "audit"}
+		got := extractGCPFirestoreConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "3", got["collectionCount"])
+		assert.Equal(t, "users", got["collectionName"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"collections": []any{"orders"}}
+		got := extractGCPFirestoreConfig(raw)
+		assert.Equal(t, "1", got["collectionCount"])
+		assert.Equal(t, "orders", got["collectionName"])
+	})
+
+	t.Run("EmptyName", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{""}
+		got := extractGCPFirestoreConfig(raw)
+		assert.Equal(t, "1", got["collectionCount"])
+		assert.NotContains(t, got, "collectionName")
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPFirestoreConfig(nil))
+		assert.Nil(t, extractGCPFirestoreConfig([]any{}))
+	})
+}
+
+// ---------- gcp_pubsub ----------
+
+func TestExtractGCPPubSubConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":                     "projects/demo/topics/events",
+			"messageRetentionDuration": "604800s",
+			"kmsKeyName":               "projects/demo/locations/global/keyRings/r/cryptoKeys/k",
+		}}
+		got := extractGCPPubSubConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["topicCount"])
+		assert.Equal(t, "events", got["topicName"]) // basename
+		assert.Equal(t, "604800s", got["messageRetentionDuration"])
+		// kmsKeyName is read with getString (not gcpResourceBasename) so
+		// the full path passes through unchanged.
+		assert.Equal(t, "projects/demo/locations/global/keyRings/r/cryptoKeys/k", got["kmsKeyName"])
+	})
+
+	t.Run("NoKMS", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{"name": "projects/p/topics/t"}}
+		got := extractGCPPubSubConfig(raw)
+		assert.NotContains(t, got, "kmsKeyName")
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"topics": []any{
+			map[string]any{"name": "projects/p/topics/wrap"},
+		}}
+		got := extractGCPPubSubConfig(raw)
+		assert.Equal(t, "wrap", got["topicName"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPPubSubConfig(nil))
+		assert.Nil(t, extractGCPPubSubConfig([]any{}))
+	})
+}
+
+// ---------- gcp_cloud_kms ----------
+
+func TestExtractGCPCloudKMSConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":       "projects/demo/locations/global/keyRings/demo-kr",
+			"createTime": "2026-03-01T00:00:00Z",
+		}}
+		got := extractGCPCloudKMSConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["keyringCount"])
+		assert.Equal(t, "demo-kr", got["keyringName"])
+	})
+
+	t.Run("MultipleRings", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{
+			map[string]any{"name": "projects/p/locations/global/keyRings/a"},
+			map[string]any{"name": "projects/p/locations/global/keyRings/b"},
+			map[string]any{"name": "projects/p/locations/global/keyRings/c"},
+		}
+		got := extractGCPCloudKMSConfig(raw)
+		assert.Equal(t, "3", got["keyringCount"])
+		assert.Equal(t, "a", got["keyringName"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"keyRings": []any{
+			map[string]any{"name": "projects/p/locations/global/keyRings/wrap"},
+		}}
+		got := extractGCPCloudKMSConfig(raw)
+		assert.Equal(t, "wrap", got["keyringName"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPCloudKMSConfig(nil))
+		assert.Nil(t, extractGCPCloudKMSConfig([]any{}))
+	})
+}
+
+// ---------- gcp_secret_manager ----------
+
+func TestExtractGCPSecretManagerConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_Automatic", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":        "projects/demo/secrets/demo-secret",
+			"replication": map[string]any{"automatic": map[string]any{}},
+		}}
+		got := extractGCPSecretManagerConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["secretCount"])
+		assert.Equal(t, "demo-secret", got["secretName"])
+		assert.Equal(t, "automatic", got["replication"])
+	})
+
+	t.Run("UserManaged", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name": "projects/p/secrets/x",
+			"replication": map[string]any{
+				"userManaged": map[string]any{
+					"replicas": []any{map[string]any{"location": "us-central1"}},
+				},
+			},
+		}}
+		got := extractGCPSecretManagerConfig(raw)
+		assert.Equal(t, "user-managed", got["replication"])
+	})
+
+	t.Run("ReplicationAbsent", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{"name": "projects/p/secrets/x"}}
+		got := extractGCPSecretManagerConfig(raw)
+		assert.NotContains(t, got, "replication")
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"secrets": []any{
+			map[string]any{"name": "projects/p/secrets/wrap"},
+		}}
+		got := extractGCPSecretManagerConfig(raw)
+		assert.Equal(t, "wrap", got["secretName"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPSecretManagerConfig(nil))
+		assert.Nil(t, extractGCPSecretManagerConfig([]any{}))
+	})
+}
+
+// ---------- gcp_cloud_armor ----------
+
+func TestExtractGCPCloudArmorConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":  "demo-policy",
+			"type":  "CLOUD_ARMOR",
+			"rules": []any{map[string]any{"priority": float64(1000)}, map[string]any{"priority": float64(2000)}},
+		}}
+		got := extractGCPCloudArmorConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["policyCount"])
+		assert.Equal(t, "demo-policy", got["policyName"])
+		assert.Equal(t, "CLOUD_ARMOR", got["policyType"])
+		assert.Equal(t, "2", got["ruleCount"])
+	})
+
+	t.Run("EdgePolicy", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name": "edge",
+			"type": "CLOUD_ARMOR_EDGE",
+		}}
+		got := extractGCPCloudArmorConfig(raw)
+		assert.Equal(t, "CLOUD_ARMOR_EDGE", got["policyType"])
+		assert.NotContains(t, got, "ruleCount")
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"items": []any{
+			map[string]any{"name": "wrap-policy", "type": "CLOUD_ARMOR_NETWORK"},
+		}}
+		got := extractGCPCloudArmorConfig(raw)
+		assert.Equal(t, "wrap-policy", got["policyName"])
+		assert.Equal(t, "CLOUD_ARMOR_NETWORK", got["policyType"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPCloudArmorConfig(nil))
+		assert.Nil(t, extractGCPCloudArmorConfig([]any{}))
+	})
+}
+
+// ---------- gcp_identity_platform ----------
+
+func TestExtractGCPIdentityPlatformConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_MFAEnabled", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":                  "projects/demo/tenants/tn1",
+			"displayName":           "Tenant 1",
+			"allowPasswordSignup":   true,
+			"enableEmailLinkSignin": false,
+			"mfaConfig":             map[string]any{"state": "ENABLED"},
+		}}
+		got := extractGCPIdentityPlatformConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["tenantCount"])
+		assert.Equal(t, "tn1", got["tenantName"])
+		assert.Equal(t, "Tenant 1", got["displayName"])
+		assert.Equal(t, "Yes", got["allowPasswordSignup"])
+		assert.Equal(t, "No", got["enableEmailLinkSignin"])
+		assert.Equal(t, "Yes", got["mfaRequired"])
+	})
+
+	t.Run("MFADisabled", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":      "projects/demo/tenants/tn-off",
+			"mfaConfig": map[string]any{"state": "DISABLED"},
+		}}
+		got := extractGCPIdentityPlatformConfig(raw)
+		assert.Equal(t, "No", got["mfaRequired"])
+	})
+
+	t.Run("MFAUnspecified", func(t *testing.T) {
+		t.Parallel()
+		// state="STATE_UNSPECIFIED" → field omitted (switch only matches
+		// ENABLED / DISABLED).
+		raw := []any{map[string]any{
+			"name":      "projects/demo/tenants/tn-u",
+			"mfaConfig": map[string]any{"state": "STATE_UNSPECIFIED"},
+		}}
+		got := extractGCPIdentityPlatformConfig(raw)
+		assert.NotContains(t, got, "mfaRequired")
+	})
+
+	t.Run("MFAMissing", func(t *testing.T) {
+		t.Parallel()
+		// No mfaConfig at all → field omitted.
+		raw := []any{map[string]any{"name": "projects/demo/tenants/no-mfa"}}
+		got := extractGCPIdentityPlatformConfig(raw)
+		assert.NotContains(t, got, "mfaRequired")
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"tenants": []any{
+			map[string]any{"name": "projects/p/tenants/wrap", "displayName": "W"},
+		}}
+		got := extractGCPIdentityPlatformConfig(raw)
+		assert.Equal(t, "wrap", got["tenantName"])
+		assert.Equal(t, "W", got["displayName"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPIdentityPlatformConfig(nil))
+		assert.Nil(t, extractGCPIdentityPlatformConfig([]any{}))
+	})
+}
+
+// ---------- gcp_vpc ----------
+
+func TestExtractGCPVPCConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath_CustomMode", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":                  "demo-vpc",
+			"autoCreateSubnetworks": false,
+			"routingConfig":         map[string]any{"routingMode": "REGIONAL"},
+			"subnetworks": []any{
+				"https://www.googleapis.com/compute/v1/projects/p/regions/us/subnetworks/a",
+				"https://www.googleapis.com/compute/v1/projects/p/regions/us/subnetworks/b",
+			},
+		}}
+		got := extractGCPVPCConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["networkCount"])
+		assert.Equal(t, "demo-vpc", got["networkName"])
+		assert.Equal(t, "No", got["autoCreateSubnetworks"]) // custom mode
+		assert.Equal(t, "REGIONAL", got["routingMode"])
+		assert.Equal(t, "2", got["subnetworkCount"])
+	})
+
+	t.Run("AutoMode", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":                  "auto-vpc",
+			"autoCreateSubnetworks": true,
+			"routingConfig":         map[string]any{"routingMode": "GLOBAL"},
+		}}
+		got := extractGCPVPCConfig(raw)
+		assert.Equal(t, "Yes", got["autoCreateSubnetworks"]) // auto mode
+		assert.Equal(t, "GLOBAL", got["routingMode"])
+		// Issue #236 spec calls for a `vpcMode=auto|custom` summary key
+		// — the current extractor surfaces only autoCreateSubnetworks
+		// directly. Confirm the alias key is NOT present so a future
+		// implementer of #236 has a failing assertion to flip.
+		assert.NotContains(t, got, "vpcMode")
+	})
+
+	t.Run("IGWClassificationNotSurfaced", func(t *testing.T) {
+		t.Parallel()
+		// The current extractor does NOT inspect firewall rules to
+		// classify Public/Private/Mixed (issue #236 calls for it but
+		// the inspector returns []computeapi.Network, not firewalls).
+		// Lock in current behavior so a future implementer has a
+		// failing assertion to flip.
+		raw := []any{map[string]any{
+			"name":                  "fw-vpc",
+			"autoCreateSubnetworks": false,
+			"firewalls": []any{
+				map[string]any{"sourceRanges": []any{"0.0.0.0/0"}},
+				map[string]any{"sourceRanges": []any{"10.0.0.0/8"}},
+			},
+		}}
+		got := extractGCPVPCConfig(raw)
+		assert.NotContains(t, got, "igwClassification")
+		assert.NotContains(t, got, "internetExposure")
+	})
+
+	t.Run("NoSubnetworks", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{"name": "n", "autoCreateSubnetworks": false}}
+		got := extractGCPVPCConfig(raw)
+		assert.NotContains(t, got, "subnetworkCount")
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"items": []any{
+			map[string]any{"name": "env-vpc", "autoCreateSubnetworks": true},
+		}}
+		got := extractGCPVPCConfig(raw)
+		assert.Equal(t, "env-vpc", got["networkName"])
+		assert.Equal(t, "Yes", got["autoCreateSubnetworks"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPVPCConfig(nil))
+		assert.Nil(t, extractGCPVPCConfig([]any{}))
+	})
+}
+
+// ---------- gcp_loadbalancer ----------
+
+func TestExtractGCPLoadBalancerConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":           "demo-urlmap",
+			"defaultService": "https://www.googleapis.com/compute/v1/projects/demo/global/backendServices/demo-backend",
+			"hostRules": []any{
+				map[string]any{"hosts": []any{"example.com"}},
+				map[string]any{"hosts": []any{"www.example.com"}},
+			},
+		}}
+		got := extractGCPLoadBalancerConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["urlMapCount"])
+		assert.Equal(t, "demo-urlmap", got["urlMapName"])
+		assert.Equal(t, "demo-backend", got["defaultService"]) // basename
+		assert.Equal(t, "2", got["hostRuleCount"])
+	})
+
+	t.Run("NoHostRules", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{"name": "no-hr", "defaultService": "x"}}
+		got := extractGCPLoadBalancerConfig(raw)
+		assert.NotContains(t, got, "hostRuleCount")
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"items": []any{
+			map[string]any{"name": "wrap"},
+		}}
+		got := extractGCPLoadBalancerConfig(raw)
+		assert.Equal(t, "wrap", got["urlMapName"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPLoadBalancerConfig(nil))
+		assert.Nil(t, extractGCPLoadBalancerConfig([]any{}))
+	})
+}
+
+// ---------- gcp_cloud_logging ----------
+
+func TestExtractGCPCloudLoggingConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{
+			"projects/demo/logs/cloudaudit.googleapis.com%2Factivity",
+			"projects/demo/logs/run.googleapis.com%2Fstdout",
+		}
+		got := extractGCPCloudLoggingConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["logCount"])
+		assert.Equal(t, "projects/demo/logs/cloudaudit.googleapis.com%2Factivity", got["logName"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"logs": []any{"projects/p/logs/x"}}
+		got := extractGCPCloudLoggingConfig(raw)
+		assert.Equal(t, "1", got["logCount"])
+		assert.Equal(t, "projects/p/logs/x", got["logName"])
+	})
+
+	t.Run("EmptyName", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{""}
+		got := extractGCPCloudLoggingConfig(raw)
+		assert.Equal(t, "1", got["logCount"])
+		assert.NotContains(t, got, "logName")
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPCloudLoggingConfig(nil))
+		assert.Nil(t, extractGCPCloudLoggingConfig([]any{}))
+	})
+}
+
+// ---------- gcp_cloud_build ----------
+
+func TestExtractGCPCloudBuildConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":     "projects/demo/triggers/deploy-on-main",
+			"filename": "cloudbuild.yaml",
+			"github":   map[string]any{"owner": "luthersystems", "name": "reliable"},
+			"disabled": false,
+		}}
+		got := extractGCPCloudBuildConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["triggerCount"])
+		assert.Equal(t, "deploy-on-main", got["triggerName"]) // basename
+		assert.Equal(t, "cloudbuild.yaml", got["filename"])
+		assert.Equal(t, "No", got["disabled"])
+		assert.Equal(t, "luthersystems/reliable", got["githubRepo"])
+	})
+
+	t.Run("DisabledTrigger", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":     "projects/demo/triggers/x",
+			"disabled": true,
+		}}
+		got := extractGCPCloudBuildConfig(raw)
+		assert.Equal(t, "Yes", got["disabled"])
+	})
+
+	t.Run("OwnerOnlyGithub", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":   "projects/p/triggers/owner-only",
+			"github": map[string]any{"owner": "solo"},
+		}}
+		got := extractGCPCloudBuildConfig(raw)
+		assert.Equal(t, "solo", got["githubRepo"])
+	})
+
+	t.Run("NoGithub", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{"name": "projects/p/triggers/local"}}
+		got := extractGCPCloudBuildConfig(raw)
+		assert.NotContains(t, got, "githubRepo")
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"triggers": []any{
+			map[string]any{"name": "projects/p/triggers/wrap"},
+		}}
+		got := extractGCPCloudBuildConfig(raw)
+		assert.Equal(t, "wrap", got["triggerName"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPCloudBuildConfig(nil))
+		assert.Nil(t, extractGCPCloudBuildConfig([]any{}))
+	})
+}
+
+// ---------- gcp_vertex_ai ----------
+
+func TestExtractGCPVertexAIConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":           "projects/demo/locations/us-central1/endpoints/12345",
+			"displayName":    "Demo Endpoint",
+			"deployedModels": []any{map[string]any{"id": "m1"}, map[string]any{"id": "m2"}},
+		}}
+		got := extractGCPVertexAIConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["endpointCount"])
+		assert.Equal(t, "12345", got["endpointName"]) // basename
+		assert.Equal(t, "us-central1", got["region"])
+		assert.Equal(t, "Demo Endpoint", got["displayName"])
+		assert.Equal(t, "2", got["deployedModelCount"])
+	})
+
+	t.Run("RegionDefaulting_NoLocation", func(t *testing.T) {
+		t.Parallel()
+		// When the endpoint name has no `/locations/<region>/` segment
+		// (truncated SDK output / missing region) the extractor falls
+		// back to omitting the region key — there's no static default.
+		raw := []any{map[string]any{
+			"name":        "endpoints/123",
+			"displayName": "no-region",
+		}}
+		got := extractGCPVertexAIConfig(raw)
+		assert.NotContains(t, got, "region")
+	})
+
+	t.Run("RegionExplicitNonDefault", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name": "projects/p/locations/europe-west4/endpoints/eu1",
+		}}
+		got := extractGCPVertexAIConfig(raw)
+		assert.Equal(t, "europe-west4", got["region"])
+	})
+
+	t.Run("NoDeployedModels", func(t *testing.T) {
+		t.Parallel()
+		// "deployed 0 models" is the silent failure mode the extractor
+		// header calls out — count should be 0, not absent.
+		raw := []any{map[string]any{
+			"name":           "projects/p/locations/us-central1/endpoints/empty",
+			"deployedModels": []any{},
+		}}
+		got := extractGCPVertexAIConfig(raw)
+		assert.Equal(t, "0", got["deployedModelCount"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"endpoints": []any{
+			map[string]any{"name": "projects/p/locations/us/endpoints/wrap"},
+		}}
+		got := extractGCPVertexAIConfig(raw)
+		assert.Equal(t, "wrap", got["endpointName"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPVertexAIConfig(nil))
+		assert.Nil(t, extractGCPVertexAIConfig([]any{}))
+	})
+}
+
+// ---------- gcp_cloud_monitoring ----------
+
+func TestExtractGCPCloudMonitoringConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{
+			map[string]any{
+				"name":        "projects/demo/alertPolicies/abc",
+				"displayName": "High Error Rate",
+				"enabled":     true,
+			},
+			map[string]any{
+				"name":        "projects/demo/alertPolicies/def",
+				"displayName": "Low Memory",
+				"enabled":     true,
+			},
+			map[string]any{
+				"name":        "projects/demo/alertPolicies/ghi",
+				"displayName": "Disabled Policy",
+				"enabled":     false,
+			},
+		}
+		got := extractGCPCloudMonitoringConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "3", got["policyCount"])
+		assert.Equal(t, "2", got["enabledCount"])
+		assert.Equal(t, "abc", got["policyName"])
+		assert.Equal(t, "High Error Rate", got["displayName"])
+	})
+
+	t.Run("AllDisabled", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{
+			map[string]any{"name": "projects/p/alertPolicies/x", "enabled": false},
+			map[string]any{"name": "projects/p/alertPolicies/y", "enabled": false},
+		}
+		got := extractGCPCloudMonitoringConfig(raw)
+		assert.Equal(t, "2", got["policyCount"])
+		assert.Equal(t, "0", got["enabledCount"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"alertPolicies": []any{
+			map[string]any{"name": "projects/p/alertPolicies/wrap", "enabled": true},
+		}}
+		got := extractGCPCloudMonitoringConfig(raw)
+		assert.Equal(t, "1", got["policyCount"])
+		assert.Equal(t, "1", got["enabledCount"])
+		assert.Equal(t, "wrap", got["policyName"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPCloudMonitoringConfig(nil))
+		assert.Nil(t, extractGCPCloudMonitoringConfig([]any{}))
+	})
+}
+
+// ---------- gcp_cloud_functions ----------
+
+func TestExtractGCPCloudFunctionsConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":        "projects/demo/locations/us-central1/functions/demo-fn",
+			"state":       "ACTIVE",
+			"buildConfig": map[string]any{"runtime": "go122"},
+			"serviceConfig": map[string]any{
+				"availableMemory": "256M",
+				"timeoutSeconds":  float64(60),
+			},
+		}}
+		got := extractGCPCloudFunctionsConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["functionCount"])
+		assert.Equal(t, "demo-fn", got["functionName"]) // basename
+		assert.Equal(t, "ACTIVE", got["state"])
+		assert.Equal(t, "go122", got["runtime"])
+	})
+
+	t.Run("NoBuildConfig", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":  "projects/p/locations/us/functions/x",
+			"state": "ACTIVE",
+		}}
+		got := extractGCPCloudFunctionsConfig(raw)
+		assert.NotContains(t, got, "runtime")
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"functions": []any{
+			map[string]any{"name": "projects/p/locations/us/functions/wrap"},
+		}}
+		got := extractGCPCloudFunctionsConfig(raw)
+		assert.Equal(t, "wrap", got["functionName"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPCloudFunctionsConfig(nil))
+		assert.Nil(t, extractGCPCloudFunctionsConfig([]any{}))
+	})
+}
+
+// ---------- gcp_api_gateway ----------
+
+func TestExtractGCPAPIGatewayConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":        "projects/demo/locations/global/apis/demo-api",
+			"displayName": "Demo API",
+			"state":       "ACTIVE",
+		}}
+		got := extractGCPAPIGatewayConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["apiCount"])
+		assert.Equal(t, "demo-api", got["apiName"])
+		assert.Equal(t, "Demo API", got["displayName"])
+		assert.Equal(t, "ACTIVE", got["state"])
+	})
+
+	t.Run("FailedState", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":  "projects/p/locations/global/apis/x",
+			"state": "FAILED",
+		}}
+		got := extractGCPAPIGatewayConfig(raw)
+		assert.Equal(t, "FAILED", got["state"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"apis": []any{
+			map[string]any{"name": "projects/p/locations/global/apis/wrap"},
+		}}
+		got := extractGCPAPIGatewayConfig(raw)
+		assert.Equal(t, "wrap", got["apiName"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPAPIGatewayConfig(nil))
+		assert.Nil(t, extractGCPAPIGatewayConfig([]any{}))
+	})
+}
+
+// ---------- gcp_cloud_cdn ----------
+
+func TestExtractGCPCloudCDNConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":      "demo-backend",
+			"enableCDN": true,
+			"cdnPolicy": map[string]any{"cacheMode": "CACHE_ALL_STATIC"},
+		}}
+		got := extractGCPCloudCDNConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["backendCount"])
+		assert.Equal(t, "demo-backend", got["backendName"])
+		assert.Equal(t, "Yes", got["enableCdn"])
+		assert.Equal(t, "CACHE_ALL_STATIC", got["cacheMode"])
+	})
+
+	t.Run("UseOriginHeaders", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":      "use-origin",
+			"enableCDN": true,
+			"cdnPolicy": map[string]any{"cacheMode": "USE_ORIGIN_HEADERS"},
+		}}
+		got := extractGCPCloudCDNConfig(raw)
+		assert.Equal(t, "USE_ORIGIN_HEADERS", got["cacheMode"])
+	})
+
+	t.Run("CDNDisabled", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":      "off-backend",
+			"enableCDN": false,
+		}}
+		got := extractGCPCloudCDNConfig(raw)
+		assert.Equal(t, "No", got["enableCdn"])
+		assert.NotContains(t, got, "cacheMode")
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"backendServices": []any{
+			map[string]any{"name": "wrap-backend", "enableCDN": true},
+		}}
+		got := extractGCPCloudCDNConfig(raw)
+		assert.Equal(t, "wrap-backend", got["backendName"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPCloudCDNConfig(nil))
+		assert.Nil(t, extractGCPCloudCDNConfig([]any{}))
+	})
+}
+
+// ---------- gcp_bastion ----------
+
+func TestExtractGCPBastionConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":        "demo-bastion",
+			"machineType": "https://www.googleapis.com/compute/v1/projects/demo/zones/us-central1-a/machineTypes/e2-small",
+			"zone":        "https://www.googleapis.com/compute/v1/projects/demo/zones/us-central1-a",
+			"status":      "RUNNING",
+		}}
+		got := extractGCPBastionConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["instanceCount"])
+		assert.Equal(t, "demo-bastion", got["instanceName"])
+		assert.Equal(t, "e2-small", got["machineType"])
+		assert.Equal(t, "us-central1-a", got["zone"])
+		assert.Equal(t, "RUNNING", got["status"])
+	})
+
+	t.Run("StoppedBastion", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":   "stopped-bastion",
+			"status": "TERMINATED",
+		}}
+		got := extractGCPBastionConfig(raw)
+		assert.Equal(t, "TERMINATED", got["status"])
+	})
+
+	t.Run("Envelope", func(t *testing.T) {
+		t.Parallel()
+		raw := map[string]any{"instances": []any{
+			map[string]any{"name": "wrap-bastion"},
+		}}
+		got := extractGCPBastionConfig(raw)
+		assert.Equal(t, "wrap-bastion", got["instanceName"])
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, extractGCPBastionConfig(nil))
+		assert.Nil(t, extractGCPBastionConfig([]any{}))
+	})
+}

--- a/pkg/observability/metrics/aws_test.go
+++ b/pkg/observability/metrics/aws_test.go
@@ -140,11 +140,13 @@ func TestBuildGetMetricDataQueries_VerifiesDimensionValues(t *testing.T) {
 		{"cognito", composer.KeyAWSCognito, "cognito", "us-east-1_ABC123", 3, "AWS/Cognito", "UserPoolId"},
 		{"opensearch", composer.KeyAWSOpenSearch, "opensearch", "io-projx-search", 9, "AWS/ES", "DomainName"},
 		{"bedrock", composer.KeyAWSBedrock, "bedrock", "anthropic.claude-3-5-sonnet", 6, "AWS/Bedrock", "ModelId"},
-		// EKS metrics are pivoted onto AWS/EC2 InstanceId via the
-		// `eks:cluster-name` tag (#231 Option A); the resource ID
-		// passed in here is an EC2 instance, not a cluster name, and
-		// the registry advertises a single CPUUtilization metric.
-		{"eks", composer.KeyAWSEKS, "eks", "i-0a1b2c3d4e5f60718", 1, "AWS/EC2", "InstanceId"},
+		// EKS panel queries ContainerInsights metrics keyed on
+		// ClusterName (#233 Option B-1). The aws/eks_nodegroup
+		// preset installs amazon-cloudwatch-observability by
+		// default so the namespace is populated. Five metrics:
+		// node_cpu/memory_utilization, pod_cpu/memory_utilization,
+		// cluster_failed_node_count.
+		{"eks", composer.KeyAWSEKS, "eks", "demo-cluster", 5, "ContainerInsights", "ClusterName"},
 		{"elasticache", composer.KeyAWSElastiCache, "elasticache", "io-projx-redis-001", 8, "AWS/ElastiCache", "CacheClusterId"},
 		{"msk", composer.KeyAWSMSK, "msk", "io-projx-kafka", 13, "AWS/Kafka", "Cluster Name"},
 		{"waf", composer.KeyAWSWAF, "waf", "io-projx-webacl", 4, "AWS/WAFV2", "WebACL"},

--- a/pkg/observability/metrics/aws_test.go
+++ b/pkg/observability/metrics/aws_test.go
@@ -161,20 +161,26 @@ func TestBuildGetMetricDataQueries_VerifiesDimensionValues(t *testing.T) {
 
 			require.Len(t, queries, tt.wantCount)
 
-			for _, q := range queries {
-				require.NotNil(t, q.MetricStat)
+			for i, q := range queries {
+				require.NotNil(t, q.MetricStat, "query[%d]", i)
 				assert.Equal(t, tt.wantNamespace, aws.ToString(q.MetricStat.Metric.Namespace))
 
 				dims := q.MetricStat.Metric.Dimensions
-				require.NotEmpty(t, dims)
+				require.NotEmpty(t, dims, "query[%d]", i)
 				assert.Equal(t, tt.wantDimName, aws.ToString(dims[0].Name))
 				assert.Equal(t, tt.resourceID, aws.ToString(dims[0].Value), "resource ID must appear in dimension value")
 
-				assert.NotEmpty(t, aws.ToString(q.MetricStat.Stat))
+				// Per-metric Name + Stat must match the spec
+				// position-by-position. Catches mutations that swap a
+				// stat (e.g. `Sum` → `Average`) on a specific metric —
+				// a `NotEmpty` check would survive that.
+				assert.Equal(t, obs.Metrics[i].Name, aws.ToString(q.MetricStat.Metric.MetricName),
+					"query[%d] metric name drift", i)
+				assert.Equal(t, obs.Metrics[i].Stat, aws.ToString(q.MetricStat.Stat),
+					"query[%d] stat drift (expected %q)", i, obs.Metrics[i].Stat)
 			}
 
 			assert.Equal(t, obs.Metrics[0].Name, aws.ToString(queries[0].Label))
-			assert.Equal(t, obs.Metrics[0].Stat, aws.ToString(queries[0].MetricStat.Stat))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- **Closes #233** — `aws/eks_nodegroup` installs `amazon-cloudwatch-observability` by default (opt-out via `enable_container_insights`). Worker IAM role gains `CloudWatchAgentServerPolicy`. Registry pivots from the AWS/EC2 fallback (#231 Option A) to `ContainerInsights/ClusterName` with five node/pod/cluster metrics. Cliff per #233 Option B-1 — existing deployments empty out until they redeploy.
- **Closes #236** — three previously-untested AWS inspector files (`account.go`, `cloudwatchlogs.go`, `connect_info.go`) now have unit tests; `account.go` and `cloudwatchlogs.go` gained narrow client interfaces + extracted helpers (`gatherAccountInfo`, `describeProjectLogGroups`) to make them testable. Per-extractor field-branch coverage added for all 23 AWS + 23 GCP extractors (`aws_test.go` 113 subtests, `gcp_test.go` 111 subtests). Drift suite (`extractors_drift_test.go`) untouched.
- **Closes #239** — Compute v1 GCP inspectors flipped from the GCE legacy filter dialect (`labels.foo=bar`) to AIP-160 (`labels.foo = "bar"`). Live MCP probe revealed the bug spanned VPC, LoadBalancer, CloudArmor, Bastion, and Cloud CDN — not just CDN as originally filed. The Compute v1 REST API's per-endpoint filter parser is inconsistent; AIP-160 is the universal dialect.
- **Supersedes [reliable#1259](https://github.com/luthersystems/reliable/pull/1259)** (already closed) — firestore pin test ported. Live verification against the Cloud Monitoring `MetricDescriptors` API revealed reliable#1259's catalog migration was a partial fix: only `request_latencies` actually publishes under `firestore.googleapis.com/Database`; the legacy `document/{read,write,delete}_count` metrics publish ONLY under `firestore_instance`. Their modern `*_ops_count` variants are the ones that publish under `Database` with `database_id`. Catalog corrected; pin test trips on either mistake.

## Bugs surfaced and fixed in this PR (live testing on cust2 + GCP staging)

- **Bug #1 — EKS workers lack the `Project` tag.** On cust2, `aws ec2 describe-instances --filters "Name=tag:Project"` returned 0 instances despite 5 EKS workers running on `io-hrbs5zprbk51-prod-lu-eks0`. Root cause: `aws_eks_node_group.tags` only tag the node-group resource, not the EC2 instances it spawns. **Fix**: added `aws_autoscaling_group_tag` resources keyed by `for_each = merge(local.common_tags, var.tags)` with `propagate_at_launch = true` so newly-launched instances inherit `Project`, `Environment`, `Component`, etc. (Existing fleets need a node refresh to pick up the tag retroactively.)
- **Bug #2 — CloudWatchLogs `/aws/<project>` prefix never matched real preset naming.** Live test on cust2 returned 0 log groups via the prefix path, despite 4+ project-scoped groups under `/aws/eks/<full>`, `/aws/rds/instance/<full>`, `/aws/lambda/<full>`, and `/<project>-...`. **Fix**: switched `describeProjectLogGroups` from `LogGroupNamePrefix='/aws/<project>'` to `LogGroupNamePattern=<project>` (server-side case-sensitive substring match). Live-verified: the substring path returns 8 log groups across all four shapes. Pre-existing bug, silent, panel rendered empty.
- **Bug #3 — Compute v1 endpoints reject the GCE legacy filter dialect (#239).** Initially filed for Cloud CDN; live `gcpinspect_batch` against staging session `sess_v2_qtyB4nkwp5N8` revealed VPC, LoadBalancer, and CloudArmor list endpoints also returned HTTP 400 "Invalid list filter expression". **Fix**: flipped every Compute v1 call site in `discovery/gcp/{network,compute}.go` to AIP-160; added `gcpAIP160LabelFilterAnd` helper for the bastion `role + project` combination.

## Live verification (cust2 + GCP)

- ✅ `gatherAccountInfo` against cust2 — real account id, role, summary populated correctly
- ✅ `describeProjectLogGroups` (substring) — returns 8 project-scoped log groups across all 4 real preset naming shapes
- ✅ `enrichEC2WithConnectURLs` — clean run against live `DescribeInstances`
- ✅ Firestore catalog truthfulness verified against `MetricDescriptors` API on `diagramtest2025-09-14` — drove the `*_ops_count` correction
- ✅ **EKS addon end-to-end smoke** on `io-hrbs5zprbk51-prod-lu-eks0` (us-east-1): `amazon-cloudwatch-observability` v5.3.1-eksbuild.1 installed and reached ACTIVE; ContainerInsights now publishes 1912 metrics including all five from the catalog spec (`node_cpu_utilization`, `node_memory_utilization`, `pod_cpu_utilization`, `pod_memory_utilization`, `cluster_failed_node_count`)
- ✅ **#239 broader scope** confirmed via staging MCP `gcpinspect_batch` — VPC/LB/CDN endpoints all returned the same 400 with the legacy filter dialect; fix verified locally and pinned by unit tests

## Test plan

- [x] `go test ./pkg/observability/... -count=1` — all green (~600 tests including new branch coverage)
- [x] `go vet ./pkg/observability/...` — clean
- [x] `terraform fmt -check -recursive` + `terraform validate` on `aws/eks_nodegroup`
- [x] All 8 lint scripts (`lint-no-root-only-blocks`, `lint-project-tag`, `lint-project-label`, `lint-sensitive-for-each`, `lint-foreach-unknown-keys`, `lint-labelless-name-prefix`, `lint-shared-no-cloud-providers`, `lint-phantom-computed-fields`) — PASS
- [x] `tests/validate-as-child.sh aws/eks_nodegroup` — PASS
- [x] Live integration probe (`go test -tags=integration ./pkg/observability/discovery/aws/... -v -run TestLive`) against cust2 — all four pass; clean skip when no creds
- [x] EKS addon end-to-end smoke on cust2 — addon ACTIVE, ContainerInsights publishing 1912 metrics
- [x] Cloud CDN / VPC / LB filter regression confirmed via staging MCP `gcpinspect_batch`; AIP-160 fix pinned by unit tests
- [ ] Post-merge: redeploy reliable's MCP backend so the deployed staging session picks up the new presets, then re-run `gcpinspect_batch` against `sess_v2_qtyB4nkwp5N8` to confirm the 400s clear

## Reference

A new `docs/observability-test-coverage.md` documents which inspectors have live-cloud probes vs unit-fake-only coverage, how to run the integration suites, and a section per fixed bug (repro / root cause / impact / fix).

## Known coverage gaps (NOT blocking)

- **GCP extractor branches enumerated in #236 that the source doesn't yet implement** (GCS lifecyclePolicy, VPC vpcMode, IGW Public/Private/Mixed, CloudSQL backupEnabled, VertexAI region defaulting). New tests pin current behaviour as `*_PendingIssue236` so future implementers trip a failing assertion to flip.
- 16+ AWS and 22+ GCP inspectors beyond the ones live-tested in this PR remain unit-fake-only. Listed in `docs/observability-test-coverage.md § 3`.

## Review notes

- /review findings: 0 P0, 0 P1, 4 P2, 2 P3 — all addressed.
- qa-professor findings: 2 P1, 4 P2, 2 P3 — all addressed.