### PR TITLE
feat(metrics): add NewClientsFromConfig for already-resolved aws.Config

### DIFF
--- a/pkg/observability/metrics/client.go
+++ b/pkg/observability/metrics/client.go
@@ -55,12 +55,13 @@ type Clients struct {
 	cloudFrontCW CloudWatchAPI
 }
 
-// NewClients builds a Clients value bound to region. Mirrors the
-// LoadDefaultConfig path used by reliable's getServiceMetrics
-// (aws_metrics.go:614) — ambient credentials only. STS-AssumeRole
-// machinery in reliable is integration-test scaffolding (see
-// aws_metrics_test.go:125 integrationAWSConfig); not part of the
-// metric-fetch production path, so not ported.
+// NewClients builds a Clients value bound to region. Loads ambient
+// credentials via config.LoadDefaultConfig — appropriate for callers
+// that run inside the same trust boundary as the resources they're
+// fetching metrics for. Callers that already hold a resolved aws.Config
+// (reliable's broker-issued assumed-role config, integration-test
+// configs built via STS AssumeRole, etc.) should use NewClientsFromConfig
+// instead so the resolved credentials flow through unchanged.
 func NewClients(ctx context.Context, region string) (*Clients, error) {
 	if region == "" {
 		return nil, fmt.Errorf("metrics: region is required")
@@ -71,6 +72,28 @@ func NewClients(ctx context.Context, region string) (*Clients, error) {
 	}
 	return &Clients{
 		Region:     region,
+		CloudWatch: cloudwatch.NewFromConfig(cfg),
+		baseCfg:    cfg,
+	}, nil
+}
+
+// NewClientsFromConfig builds a Clients value from an already-resolved
+// aws.Config. Use this when the caller has obtained credentials through
+// a path other than ambient default-config resolution — e.g. reliable's
+// Oracle credential-broker assumed-role flow, or an integration test
+// that built a config via sts.AssumeRole.
+//
+// Region is taken from cfg.Region; if cfg.Region is empty an error is
+// returned (the caller should set it explicitly via
+// config.WithRegion(...) when building cfg). The supplied cfg is also
+// retained as baseCfg so the lazy CloudFront us-east-1 client can clone
+// the resolved credentials without reissuing them.
+func NewClientsFromConfig(cfg aws.Config) (*Clients, error) {
+	if cfg.Region == "" {
+		return nil, fmt.Errorf("metrics: cfg.Region is required")
+	}
+	return &Clients{
+		Region:     cfg.Region,
 		CloudWatch: cloudwatch.NewFromConfig(cfg),
 		baseCfg:    cfg,
 	}, nil

--- a/pkg/observability/metrics/client_test.go
+++ b/pkg/observability/metrics/client_test.go
@@ -1,0 +1,44 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewClientsFromConfig_PreservesResolvedCredentials covers the
+// motivating use case: a caller (reliable's Oracle credential broker,
+// integration tests building configs via STS AssumeRole) hands in an
+// already-resolved aws.Config, and the resulting Clients carries that
+// exact config — no re-resolution against ambient defaults.
+func TestNewClientsFromConfig_PreservesResolvedCredentials(t *testing.T) {
+	t.Parallel()
+
+	provider := credentials.NewStaticCredentialsProvider("AKIATESTKEYID", "test-secret", "test-token")
+	cfg := aws.Config{
+		Region:      "eu-west-2",
+		Credentials: provider,
+	}
+
+	c, err := NewClientsFromConfig(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	assert.Equal(t, "eu-west-2", c.Region)
+	require.NotNil(t, c.CloudWatch)
+	assert.NotNil(t, c.baseCfg.Credentials, "baseCfg credentials must flow through for the lazy CloudFront client")
+	assert.Equal(t, "eu-west-2", c.baseCfg.Region)
+}
+
+func TestNewClientsFromConfig_RejectsEmptyRegion(t *testing.T) {
+	t.Parallel()
+
+	cfg := aws.Config{Credentials: credentials.NewStaticCredentialsProvider("k", "s", "")}
+
+	_, err := NewClientsFromConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cfg.Region is required")
+}


### PR DESCRIPTION
## Summary

Add `metrics.NewClientsFromConfig(cfg aws.Config) (*Clients, error)` so
callers that already hold a resolved `aws.Config` can build a Clients
value without going through `config.LoadDefaultConfig`.

## Why

Reliable obtains AWS credentials through an Oracle credential broker
that returns an assumed-role `aws.Config`. The existing
`NewClients(ctx, region)` constructor calls `config.LoadDefaultConfig` —
which re-resolves ambient credentials and ignores the broker creds.
Result: reliable can't currently call `metrics.Fetch` with its
production credentials, and has to keep the per-service CloudWatch +
discovery code reliable-side. Same blocker hits any caller that builds
configs via STS AssumeRole or other non-default-chain paths.

## Changes

- `pkg/observability/metrics/client.go`: add `NewClientsFromConfig`.
  Region is read from `cfg.Region`; supplied cfg is retained as
  `baseCfg` so the lazy CloudFront us-east-1 client can clone the
  resolved credentials.
- `pkg/observability/metrics/client_test.go`: new file. Two tests:
  - `TestNewClientsFromConfig_PreservesResolvedCredentials` — happy
    path, asserts the supplied creds + region land on `baseCfg`.
  - `TestNewClientsFromConfig_RejectsEmptyRegion` — error path.
- Existing `NewClients` doc updated to point callers with resolved
  configs at the new constructor.

GCP needs no parallel addition — `NewGCPClients` already accepts
variadic `option.ClientOption`, so reliable's broker-issued creds flow
through.

## Unblocks

Reliable Phase F (luthersystems/reliable#1273 audit items 3 full + 5 + 6
+ 8 + 9): swap `getServiceMetricsWithDeps` body to call `metrics.Fetch`
and delete the per-service AWS discoverers (`discoverEC2Instances`,
`discoverLambdaFunctions`, …, ~700 LOC).

## Test plan
- [x] `go test ./pkg/observability/...` — all pass
- [x] New tests cover both success and error paths
- [ ] CI green