### PR TITLE
fix(observability/gcp): drop labels-filter on regime-(a) Compute v1, Firestore database_name, IDP multi-tenancy envelope (#245)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/stretchr/testify v1.11.1
 	github.com/zclconf/go-cty v1.17.0
+	golang.org/x/oauth2 v0.36.0
 	google.golang.org/api v0.277.0
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
@@ -119,7 +120,6 @@ require (
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/pkg/observability/discovery/gcp/data.go
+++ b/pkg/observability/discovery/gcp/data.go
@@ -16,6 +16,8 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"log"
+	"regexp"
 
 	"cloud.google.com/go/firestore"
 	redis "cloud.google.com/go/redis/apiv1"
@@ -26,6 +28,17 @@ import (
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/observability"
 )
+
+// firestoreDatabaseNameSafe constrains caller-supplied database names
+// before they're passed to firestore.NewClientWithDatabase. The
+// firestore admin spec allows lowercase letters, digits, and hyphens,
+// 4-63 chars, must start with a letter, must end with a letter or
+// digit. We accept that subset plus the literal "(default)" sentinel
+// which is the SDK's symbolic name for the unnamed database. Anything
+// else falls back to the SDK default with a warn log so a malformed
+// caller value doesn't escape into a gRPC target path (#245, defense-
+// in-depth on a string interpolated into the Firestore client target).
+var firestoreDatabaseNameSafe = regexp.MustCompile(`^(\(default\)|[a-z][a-z0-9-]{2,61}[a-z0-9])$`)
 
 func inspectCloudSQL(ctx context.Context, projectID, action, filters string, opts ...option.ClientOption) (any, error) {
 	svc, err := sqladmin.NewService(ctx, opts...)
@@ -125,12 +138,29 @@ func inspectMemorystore(ctx context.Context, projectID, action, filters string, 
 	}
 }
 
-// inspectFirestore — no labels.project filter applies. Firestore
-// exposes a single Database per project, and Collections() returns
-// root collection names. The API is project-scoped; nothing to
-// label-filter against.
-func inspectFirestore(ctx context.Context, projectID, action, _ string, opts ...option.ClientOption) (any, error) {
-	client, err := firestore.NewClient(ctx, projectID, opts...)
+// inspectFirestore — no labels.project filter applies. Firestore is
+// project-scoped at the client level. The preset (gcp/firestore/main.
+// tf, issue #159) deliberately creates a non-default named database
+// so retries after state loss don't 409 on the singleton; callers
+// must thread that name in via filters as `database_name`. When
+// omitted, the SDK falls back to "(default)" — which the preset
+// never creates, so production calls hit `NotFound` (#245). The
+// caller-supplied name is regex-validated before it reaches
+// firestore.NewClientWithDatabase as defense-in-depth.
+func inspectFirestore(ctx context.Context, projectID, action, filters string, opts ...option.ClientOption) (any, error) {
+	dbName := firestoreDatabaseFromFilters(filters)
+	var (
+		client *firestore.Client
+		err    error
+	)
+	if dbName != "" && dbName != "(default)" {
+		client, err = firestore.NewClientWithDatabase(ctx, projectID, dbName, opts...)
+	} else {
+		if dbName == "" {
+			log.Printf("[discovery/gcp firestore] no database_name in filters; falling back to (default) — preset gcp/firestore creates a non-default DB (#159), pass database_name from the preset's database_name output")
+		}
+		client, err = firestore.NewClient(ctx, projectID, opts...)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -155,4 +185,23 @@ func inspectFirestore(ctx context.Context, projectID, action, _ string, opts ...
 	default:
 		return nil, unsupportedActionError("Firestore", action, observability.GCPServiceActions["firestore"])
 	}
+}
+
+// firestoreDatabaseFromFilters extracts and validates the
+// `database_name` filter key. Returns "" when missing, malformed, or
+// unsafe so the caller falls back to the SDK default.
+func firestoreDatabaseFromFilters(filters string) string {
+	m := parseFilterMap(filters)
+	if m == nil {
+		return ""
+	}
+	name := m["database_name"]
+	if name == "" {
+		return ""
+	}
+	if !firestoreDatabaseNameSafe.MatchString(name) {
+		log.Printf("[discovery/gcp firestore] rejected unsafe database_name=%q (must match %s); falling back to default", name, firestoreDatabaseNameSafe.String())
+		return ""
+	}
+	return name
 }

--- a/pkg/observability/discovery/gcp/data_test.go
+++ b/pkg/observability/discovery/gcp/data_test.go
@@ -184,10 +184,30 @@ func TestFirestoreDatabaseFromFilters_Roundtrip(t *testing.T) {
 		{"semicolon injection rejected", `{"database_name":"foo;rm -rf /"}`, ""},
 		{"slash rejected", `{"database_name":"foo/bar"}`, ""},
 		{"quote rejected", `{"database_name":"foo\"bar"}`, ""},
-		{"uppercase rejected", `{"database_name":"FooBar"}`, ""},
-		{"too-short rejected", `{"database_name":"ab"}`, ""},
+		{"uppercase chars rejected", `{"database_name":"FooBar"}`, ""},
 		{"trailing-dash rejected", `{"database_name":"foo-"}`, ""},
 		{"malformed JSON → default", `not-json`, ""},
+
+		// Regex boundaries (qa-professor §5): anchor checks for
+		// length and start/end-char rules — without these a
+		// regex weakening (e.g. dropping the {2,61} bound) would
+		// not be caught by the test suite.
+		{"length-3 rejected (min total length is 4)", `{"database_name":"abc"}`, ""},
+		{"length-2 rejected (under min)", `{"database_name":"ab"}`, ""},
+		{
+			name:    "length-4 minimum accepted",
+			filters: `{"database_name":"abcd"}`,
+			want:    "abcd",
+		},
+		{
+			name:    "length-63 maximum accepted",
+			filters: `{"database_name":"a` + strings.Repeat("b", 61) + `c"}`,
+			want:    "a" + strings.Repeat("b", 61) + "c",
+		},
+		{"length-64 rejected (over max)", `{"database_name":"a` + strings.Repeat("b", 62) + `c"}`, ""},
+		{"leading digit rejected", `{"database_name":"1foo"}`, ""},
+		{"leading hyphen rejected", `{"database_name":"-foo-bar"}`, ""},
+		{"(Default) wrong-case rejected", `{"database_name":"(Default)"}`, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/observability/discovery/gcp/data_test.go
+++ b/pkg/observability/discovery/gcp/data_test.go
@@ -153,3 +153,46 @@ func TestInspectFirestore_UnsupportedAction(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported Firestore action")
 }
+
+// TestFirestoreDatabaseFromFilters_Roundtrip pins the parse + safety-
+// check behavior used by inspectFirestore (#245). Validation is
+// exercised here without spinning up a Firestore client — the
+// happy/sad paths are pure-Go.
+func TestFirestoreDatabaseFromFilters_Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		filters string
+		want    string
+	}{
+		{"empty filters → default", "", ""},
+		{"missing key → default", `{"project":"io-foo"}`, ""},
+		{"empty value → default", `{"database_name":""}`, ""},
+		{
+			name:    "preset-shaped name accepted",
+			filters: `{"database_name":"io-cc7ndmjcolun-firestore-8a3bfd07"}`,
+			want:    "io-cc7ndmjcolun-firestore-8a3bfd07",
+		},
+		{
+			name:    "(default) literal accepted",
+			filters: `{"database_name":"(default)"}`,
+			want:    "(default)",
+		},
+		// Defense-in-depth: anything outside the GCP database-id
+		// charset must NOT reach firestore.NewClientWithDatabase.
+		{"semicolon injection rejected", `{"database_name":"foo;rm -rf /"}`, ""},
+		{"slash rejected", `{"database_name":"foo/bar"}`, ""},
+		{"quote rejected", `{"database_name":"foo\"bar"}`, ""},
+		{"uppercase rejected", `{"database_name":"FooBar"}`, ""},
+		{"too-short rejected", `{"database_name":"ab"}`, ""},
+		{"trailing-dash rejected", `{"database_name":"foo-"}`, ""},
+		{"malformed JSON → default", `not-json`, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := firestoreDatabaseFromFilters(tc.filters)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/observability/discovery/gcp/identity.go
+++ b/pkg/observability/discovery/gcp/identity.go
@@ -22,9 +22,12 @@ package gcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
+	"strings"
 
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/identitytoolkit/v2"
 	"google.golang.org/api/option"
 
@@ -57,6 +60,18 @@ func inspectIdentityPlatform(ctx context.Context, projectID, action, _ string, o
 			}
 			resp, err := call.Do()
 			if err != nil {
+				if isIdentityPlatformMultitenancyDisabled(err) {
+					// Identity Platform multi-tenancy is a per-
+					// project opt-in — the API is enabled but the
+					// /v2/projects/{p}/tenants endpoint returns 400
+					// INVALID_PROJECT_ID until a tenant is first
+					// created via the console or REST. Surface a
+					// structured envelope so the panel renders a
+					// clean "feature not enabled" empty state
+					// instead of leaking the raw 400 (#245).
+					return nil, observability.NewGCPFeatureNotEnabledError(
+						"identity_platform_multitenancy", projectID, err)
+				}
 				return nil, err
 			}
 			tenants = append(tenants, resp.Tenants...)
@@ -108,4 +123,24 @@ func inspectIdentityPlatform(ctx context.Context, projectID, action, _ string, o
 	default:
 		return nil, unsupportedActionError("Identity Platform", action, observability.GCPServiceActions["identityplatform"])
 	}
+}
+
+// isIdentityPlatformMultitenancyDisabled reports whether err is the
+// specific "400 INVALID_PROJECT_ID" signature returned by /v2/
+// projects/{p}/tenants when multi-tenancy hasn't been provisioned.
+// Other Identity Platform endpoints on the same project return 200
+// fine (verified live against diagramtest2025-09-14, #245), so the
+// signature is precise enough to dispatch on without false positives.
+func isIdentityPlatformMultitenancyDisabled(err error) bool {
+	if err == nil {
+		return false
+	}
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		return false
+	}
+	if gerr.Code != 400 {
+		return false
+	}
+	return strings.Contains(gerr.Message, "INVALID_PROJECT_ID")
 }

--- a/pkg/observability/discovery/gcp/identity_test.go
+++ b/pkg/observability/discovery/gcp/identity_test.go
@@ -179,3 +179,40 @@ func TestInspectIdentityPlatform_ListTenants_OtherErrorsPassThrough(t *testing.T
 	var feErr *observability.GCPFeatureNotEnabledError
 	assert.False(t, errors.As(err, &feErr), "5xx errors must NOT be wrapped as feature-not-enabled")
 }
+
+// TestInspectIdentityPlatform_ListProviders_INVALIDPROJECTIDNotWrapped
+// pins the action-scoping contract: the
+// GCPFeatureNotEnabledError wrap is gated to the list-tenants
+// branch only. If an unrelated action (e.g. list-providers) ever
+// returns 400 INVALID_PROJECT_ID, that's a different failure class
+// (truly bad project ID, missing IAM, etc.) and must propagate as
+// the raw error so the caller can diagnose. Without this test, a
+// future refactor that hoisted the wrap to a shared error path
+// would silently swallow real caller bugs as
+// "feature_not_enabled".
+func TestInspectIdentityPlatform_ListProviders_INVALIDPROJECTIDNotWrapped(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeIdentityToolkitREST(t, func(w http.ResponseWriter, r *http.Request) {
+		// Both halves of list-providers (oauthIdpConfigs and
+		// defaultSupportedIdpConfigs) return the same 400 body. The
+		// list-providers handler folds errors into an inline map, so
+		// success of THIS test means the per-half error string lands
+		// inline AND the outer call is not wrapped.
+		_ = r
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":400,"message":"INVALID_PROJECT_ID","status":"INVALID_ARGUMENT"}}`))
+	})
+	defer srv.Close()
+
+	got, err := inspectIdentityPlatform(context.Background(), "diagramtest2025-09-14", "list-providers", "", opts...)
+	// list-providers tolerates per-half failure inline (it does
+	// not surface the call as an error), so err is nil here. The
+	// key invariant is that NO GCPFeatureNotEnabledError is
+	// constructed for list-providers paths.
+	require.NoError(t, err)
+	m, ok := got.(map[string]any)
+	require.True(t, ok)
+	assert.NotNil(t, m["oauth_idp_configs_error"], "OAuth half error must surface inline (not wrapped)")
+	assert.NotNil(t, m["default_supported_idp_configs_error"], "default-supported half error must surface inline (not wrapped)")
+}

--- a/pkg/observability/discovery/gcp/identity_test.go
+++ b/pkg/observability/discovery/gcp/identity_test.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/identitytoolkit/v2"
 	"google.golang.org/api/option"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/observability"
 )
 
 // fakeIdentityToolkitREST stands in for the Identity Toolkit v2 REST
@@ -117,4 +120,62 @@ func TestInspectIdentityPlatform_UnsupportedAction(t *testing.T) {
 	_, err := inspectIdentityPlatform(context.Background(), "demo-proj", "no-such", "", opts...)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported Identity Platform action")
+}
+
+// TestInspectIdentityPlatform_ListTenants_MultitenancyDisabledReturnsStructuredError
+// pins #245: the /v2/projects/{p}/tenants endpoint returns 400
+// INVALID_PROJECT_ID when multi-tenancy hasn't been provisioned on
+// the project (the API IS enabled and other Identity Platform
+// endpoints work fine on the same project). The handler must wrap
+// that signature in observability.GCPFeatureNotEnabledError so
+// reliable's panel renderer can render a clean empty state via
+// errors.As instead of leaking the raw 400 string into the UI.
+func TestInspectIdentityPlatform_ListTenants_MultitenancyDisabledReturnsStructuredError(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeIdentityToolkitREST(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/tenants") {
+			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{
+		  "error": {
+		    "code": 400,
+		    "message": "INVALID_PROJECT_ID",
+		    "status": "INVALID_ARGUMENT"
+		  }
+		}`))
+	})
+	defer srv.Close()
+
+	_, err := inspectIdentityPlatform(context.Background(), "diagramtest2025-09-14", "list-tenants", "", opts...)
+	require.Error(t, err)
+
+	var feErr *observability.GCPFeatureNotEnabledError
+	require.True(t, errors.As(err, &feErr),
+		"err must wrap GCPFeatureNotEnabledError so reliable can errors.As it; got %T (%v)", err, err)
+	assert.Equal(t, "identity_platform_multitenancy", feErr.Feature)
+	assert.Equal(t, "diagramtest2025-09-14", feErr.ProjectID)
+	require.NotNil(t, feErr.Cause, "Cause must preserve the upstream googleapi error for diagnostics")
+}
+
+// TestInspectIdentityPlatform_ListTenants_OtherErrorsPassThrough — the
+// structured envelope is precise: only the INVALID_PROJECT_ID 400
+// from the tenants endpoint gets wrapped. Generic 5xx / 403 errors
+// propagate as-is so callers can distinguish "feature not provisioned"
+// from "transient API failure".
+func TestInspectIdentityPlatform_ListTenants_OtherErrorsPassThrough(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeIdentityToolkitREST(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":500,"message":"backend unavailable","status":"INTERNAL"}}`))
+	})
+	defer srv.Close()
+
+	_, err := inspectIdentityPlatform(context.Background(), "demo-proj", "list-tenants", "", opts...)
+	require.Error(t, err)
+	var feErr *observability.GCPFeatureNotEnabledError
+	assert.False(t, errors.As(err, &feErr), "5xx errors must NOT be wrapped as feature-not-enabled")
 }

--- a/pkg/observability/discovery/gcp/live_integration_test.go
+++ b/pkg/observability/discovery/gcp/live_integration_test.go
@@ -8,28 +8,44 @@
 //   - Application Default Credentials in the environment (e.g.
 //     `gcloud auth application-default login`, or a service-account
 //     key path in GOOGLE_APPLICATION_CREDENTIALS).
-//   - LIVE_GCP_PROJECT_ID set to the Compute project to probe (must
-//     have the Compute API enabled — even if no CDN-enabled backend
-//     services are present).
+//   - LIVE_GCP_PROJECT_ID set to a project where the relevant APIs
+//     are enabled (Compute, API Gateway, Vertex AI, Identity Toolkit,
+//     Firestore — see gcloud services list output).
+//   - Optional: LIVE_GCP_FIRESTORE_DB to probe a named Firestore
+//     database (the gcp/firestore preset uses a non-default name per
+//     issue #159; pass the database_name output of the deployed
+//     stack).
 //
-// Build-tag-gated so CI doesn't exercise these. Used to confirm
-// inspector helpers compose cleanly against the real GCP REST surface.
+// Build-tag-gated so CI doesn't exercise these. The TestLive_*
+// suite is the live-fire confirmation that complements the unit-
+// test pins in network_test.go / data_test.go / identity_test.go.
 //
-// The Cloud CDN test pins #239: backendServices.aggregatedList rejects
-// the GCE legacy filter dialect (`labels.project=<value>`) with HTTP
-// 400 "Invalid list filter expression". The fix flipped the inspector
-// to AIP-160 (`labels.project = "<value>"`); this live probe confirms
-// the call actually returns 200 OK against a real project.
+// History: TestLive_ComputeV1FilterRegimes is the lesson from #245.
+// Both #239 and #245 shipped because we had unit tests pinning a
+// wire format the live API rejected, with no live integration test
+// to cross-check. This file is the cross-check; it must run before
+// every release that touches discovery/gcp.
 
 package gcp
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"net/url"
 	"os"
+	"os/exec"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/observability"
 )
 
 // liveProjectOrSkip returns the project ID from LIVE_GCP_PROJECT_ID or
@@ -43,56 +59,341 @@ func liveProjectOrSkip(t *testing.T) string {
 	return projectID
 }
 
-// TestLive_InspectCloudCDN_NoCDNFilter exercises the AggregatedList
-// path with no `project` label filter. Should return cleanly (empty
-// slice or list of CDN-enabled backend services) with no HTTP 400.
+// gcloudTokenSource returns an oauth2.TokenSource that shells out to
+// `gcloud auth print-access-token`. Used as a fallback when ADC is in
+// an invalid_rapt / invalid_grant state — common for human accounts
+// after the reauth window expires. The active gcloud account
+// (`gcloud auth list`) is the source of truth; for service-account
+// runs (e.g. CI), prefer GOOGLE_APPLICATION_CREDENTIALS pointing at a
+// SA JSON key file, which the Google SDK picks up automatically and
+// makes this helper unnecessary.
+type gcloudTokenSource struct{}
+
+// Token shells out to gcloud and parses the resulting access token.
+// The lifetime is conservative — gcloud-issued tokens are typically
+// 1 hour, but we don't trust the lifetime metadata across versions.
+func (gcloudTokenSource) Token() (*oauth2.Token, error) {
+	cmd := exec.Command("gcloud", "auth", "print-access-token")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	tok := strings.TrimSpace(string(out))
+	if tok == "" {
+		return nil, errors.New("gcloud auth print-access-token returned an empty token")
+	}
+	return &oauth2.Token{AccessToken: tok, Expiry: time.Now().Add(30 * time.Minute)}, nil
+}
+
+// liveAuthOpts returns option.ClientOption(s) suitable for the SDK
+// clients used by the inspectors. It tries ADC first; on failure,
+// falls back to a `gcloud auth print-access-token` token source so a
+// developer with `gcloud auth login` (active account or impersonated
+// service account) can run the suite without needing to refresh
+// application-default credentials separately.
 //
-// This is the regression test for #239: the bug surfaced as a 400
-// "Invalid list filter expression" when the legacy filter dialect was
-// passed to backendServices.aggregatedList. With no filter on the
-// request at all, the call must succeed.
+// Critical: ADC's "find" can succeed even when the cached refresh
+// token is in invalid_grant / invalid_rapt state — so we MUST issue
+// a real token via TokenSource.Token() to confirm before letting
+// the SDK use it. Otherwise the per-inspector tests below would
+// silently inherit broken ADC even though the regime probe (which
+// uses liveHTTPClient with the same check) works fine.
+func liveAuthOpts(t *testing.T) []option.ClientOption {
+	t.Helper()
+	creds, err := google.FindDefaultCredentials(context.Background(), "https://www.googleapis.com/auth/cloud-platform")
+	if err == nil && creds != nil {
+		if _, terr := creds.TokenSource.Token(); terr == nil {
+			return nil
+		}
+	}
+	t.Logf("ADC unavailable or token fetch failed; falling back to `gcloud auth print-access-token`")
+	return []option.ClientOption{option.WithTokenSource(gcloudTokenSource{})}
+}
+
+// liveHTTPClient returns an http.Client backed by the same auth
+// resolution as liveAuthOpts. Used for the direct REST probes in
+// TestLive_ComputeV1FilterRegimes (which bypass the SDK to assert
+// per-endpoint server-side dialect behavior).
+func liveHTTPClient(t *testing.T) *http.Client {
+	t.Helper()
+	ctx := context.Background()
+	if c, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform"); err == nil {
+		// Smoke-check by issuing a token; if invalid_grant fires here,
+		// fall through to the gcloud fallback below.
+		creds, _ := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+		if creds != nil {
+			if _, terr := creds.TokenSource.Token(); terr == nil {
+				return c
+			}
+		}
+	}
+	t.Logf("ADC unavailable; falling back to `gcloud auth print-access-token` for direct REST probes")
+	return oauth2.NewClient(ctx, gcloudTokenSource{})
+}
+
+// TestLive_InspectCloudCDN_NoCDNFilter exercises the AggregatedList
+// path with no `project` label filter. Must return cleanly (empty
+// slice or list of CDN-enabled backend services) with no HTTP 400.
 func TestLive_InspectCloudCDN_NoCDNFilter(t *testing.T) {
 	t.Parallel()
 	projectID := liveProjectOrSkip(t)
 
-	got, err := inspectCloudCDN(context.Background(), projectID, "list-backend-services-cdn", "")
+	got, err := inspectCloudCDN(context.Background(), projectID, "list-backend-services-cdn", "", liveAuthOpts(t)...)
 	require.NoError(t, err, "inspectCloudCDN with no project filter must not error against a real project")
 	t.Logf("inspectCloudCDN returned %T with content %v", got, got)
 }
 
 // TestLive_InspectCloudCDN_WithProjectFilter exercises the
-// AggregatedList path with the AIP-160 `labels.project = "<value>"`
-// filter. The label value is provided via LIVE_GCP_PROJECT_LABEL — set
-// it to a known label value on the account, or to the bare project ID
-// (matches every backend service that carries `project = <project_id>`
-// in its labels). Skips if not set.
-//
-// Pre-#239 fix this returned HTTP 400 immediately; post-fix it must
-// return 200 OK with an empty (or populated) slice.
+// AggregatedList path with a project-label filter envelope. Per #245
+// the handler MUST drop the labels filter server-side (the endpoint
+// rejects it with HTTP 400 in both dialects). The call should
+// succeed regardless of the filter envelope.
 func TestLive_InspectCloudCDN_WithProjectFilter(t *testing.T) {
 	t.Parallel()
 	projectID := liveProjectOrSkip(t)
 
 	label := os.Getenv("LIVE_GCP_PROJECT_LABEL")
 	if label == "" {
-		t.Skip("LIVE_GCP_PROJECT_LABEL not set; export a project-label value to test the filter path")
+		// Default to the project ID so the test runs against any
+		// configured LIVE_GCP_PROJECT_ID without the operator having
+		// to know an existing label value.
+		label = projectID
 	}
 
 	filters := `{"project":"` + label + `"}`
-	got, err := inspectCloudCDN(context.Background(), projectID, "list-backend-services-cdn", filters)
+	got, err := inspectCloudCDN(context.Background(), projectID, "list-backend-services-cdn", filters, liveAuthOpts(t)...)
 	require.NoError(t, err,
-		"inspectCloudCDN with project-label filter must use AIP-160 dialect — HTTP 400 here means the filter dialect regressed (#239)")
+		"inspectCloudCDN with project-label filter must succeed — HTTP 400 here means the labels filter is being sent server-side (#245 regression)")
 	t.Logf("inspectCloudCDN(label=%q) returned %T with content %v", label, got, got)
 }
 
-// TestLive_CloudCDNAggregatedListRequest_FilterShape is a defense-in-
-// depth pin: the request constructor's output matches AIP-160 even at
-// runtime under live build tags (a unit-test pin already exists; this
-// catches the case where someone disables the unit test or skips the
-// non-integration build).
-func TestLive_CloudCDNAggregatedListRequest_FilterShape(t *testing.T) {
+// TestLive_CloudCDNAggregatedListRequest_NoFilter is a defense-in-
+// depth pin (mirrors the unit test under live build tags): the
+// request constructor never sets req.Filter regardless of inputs.
+func TestLive_CloudCDNAggregatedListRequest_NoFilter(t *testing.T) {
 	t.Parallel()
 	req := cloudCDNAggregatedListRequest("p", `{"project":"io-qtyb4nkwp5n8"}`)
-	require.NotNil(t, req.Filter)
-	assert.Equal(t, `labels.project = "io-qtyb4nkwp5n8"`, *req.Filter)
+	require.NotNil(t, req)
+	assert.Nil(t, req.Filter,
+		"req.Filter must be nil — backendServices.aggregatedList rejects labels filters server-side (#245)")
+}
+
+// TestLive_ComputeV1FilterRegimes is the canary against future
+// Google-side parser changes. It probes each Compute v1 list
+// endpoint with both filter dialects and asserts the regime hasn't
+// shifted (regime-(a) endpoints stay 400, regime-(b) endpoints stay
+// 200, regime-(c) endpoints stay 200 with no filter).
+//
+// If this test fails after a SDK upgrade or a Google-side change,
+// the per-handler dispatch in network.go MUST be re-audited
+// before the next release. The bug history (#239, #245) shows that
+// silent regressions here ship straight to customers without a live
+// gate.
+func TestLive_ComputeV1FilterRegimes(t *testing.T) {
+	t.Parallel()
+	projectID := liveProjectOrSkip(t)
+
+	client := liveHTTPClient(t)
+
+	const (
+		regimeA  = "rejects all labels filters (HTTP 400)"
+		regimeB  = "accepts AIP-160 labels filter (HTTP 200)"
+		regimeAB = "accepts both dialects (HTTP 200)"
+		regimeC  = "no labels field; only no-filter probe (HTTP 200)"
+	)
+
+	type probe struct {
+		name        string
+		url         string // without ?filter=...
+		regime      string
+		legacyCode  int    // expected status with the legacy dialect
+		aip160Code  int    // expected status with the AIP-160 dialect
+		noFilterOK  bool   // expected to return 200 with no filter
+	}
+
+	probes := []probe{
+		// Regime (a) — both dialects 400
+		{"networks.list", "https://compute.googleapis.com/compute/v1/projects/" + projectID + "/global/networks", regimeA, 400, 400, true},
+		{"subnetworks.aggregatedList", "https://compute.googleapis.com/compute/v1/projects/" + projectID + "/aggregated/subnetworks", regimeA, 400, 400, true},
+		{"backendServices.list", "https://compute.googleapis.com/compute/v1/projects/" + projectID + "/global/backendServices", regimeA, 400, 400, true},
+		{"backendServices.aggregatedList", "https://compute.googleapis.com/compute/v1/projects/" + projectID + "/aggregated/backendServices", regimeA, 400, 400, true},
+		{"urlMaps.list", "https://compute.googleapis.com/compute/v1/projects/" + projectID + "/global/urlMaps", regimeA, 400, 400, true},
+		{"targetHttpProxies.list", "https://compute.googleapis.com/compute/v1/projects/" + projectID + "/global/targetHttpProxies", regimeA, 400, 400, true},
+		{"targetHttpsProxies.list", "https://compute.googleapis.com/compute/v1/projects/" + projectID + "/global/targetHttpsProxies", regimeA, 400, 400, true},
+
+		// Regime (b)/(ab) — accept AIP-160 (and most accept legacy too)
+		{"globalForwardingRules.list", "https://compute.googleapis.com/compute/v1/projects/" + projectID + "/global/forwardingRules", regimeAB, 200, 200, true},
+		{"securityPolicies.list", "https://compute.googleapis.com/compute/v1/projects/" + projectID + "/global/securityPolicies", regimeAB, 200, 200, true},
+		{"instances.aggregatedList", "https://compute.googleapis.com/compute/v1/projects/" + projectID + "/aggregated/instances", regimeAB, 200, 200, true},
+
+		// Regime (c) — no labels field
+		{"firewalls.list", "https://compute.googleapis.com/compute/v1/projects/" + projectID + "/global/firewalls", regimeC, 0, 0, true},
+		{"routes.list", "https://compute.googleapis.com/compute/v1/projects/" + projectID + "/global/routes", regimeC, 0, 0, true},
+	}
+
+	probeOnce := func(t *testing.T, baseURL, filter string) int {
+		t.Helper()
+		u := baseURL
+		if filter != "" {
+			u = baseURL + "?filter=" + url.QueryEscape(filter)
+		}
+		resp, err := client.Get(u)
+		require.NoError(t, err, "GET %s", u)
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	for _, p := range probes {
+		t.Run(p.name, func(t *testing.T) {
+			t.Parallel()
+			t.Logf("regime: %s", p.regime)
+
+			if p.noFilterOK {
+				code := probeOnce(t, p.url, "")
+				assert.Equal(t, http.StatusOK, code, "no-filter probe must succeed; sanity-check that the project + auth + endpoint are reachable")
+			}
+
+			if p.regime == regimeC {
+				return // no labels-filter probes for regime (c)
+			}
+
+			legacyCode := probeOnce(t, p.url, `labels.project=io-foo`)
+			aip160Code := probeOnce(t, p.url, `labels.project = "io-foo"`)
+			t.Logf("legacy → HTTP %d, AIP-160 → HTTP %d", legacyCode, aip160Code)
+
+			assert.Equal(t, p.legacyCode, legacyCode, "legacy dialect regime drift on %s — re-audit the per-handler dispatch in network.go (#245)", p.name)
+			assert.Equal(t, p.aip160Code, aip160Code, "AIP-160 dialect regime drift on %s — re-audit the per-handler dispatch in network.go (#245)", p.name)
+		})
+	}
+}
+
+// TestLive_InspectVPC exercises every VPC action against a real
+// project. None should error.
+func TestLive_InspectVPC(t *testing.T) {
+	t.Parallel()
+	projectID := liveProjectOrSkip(t)
+	ctx := context.Background()
+
+	for _, action := range []string{"list-networks", "list-subnets", "list-firewalls", "list-routes"} {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
+			got, err := inspectVPC(ctx, projectID, action, `{"project":"`+projectID+`"}`, liveAuthOpts(t)...)
+			require.NoError(t, err, "inspectVPC %s must succeed against a real project (#245)", action)
+			t.Logf("%s returned %T", action, got)
+		})
+	}
+}
+
+// TestLive_InspectLoadBalancer exercises every load-balancer action.
+func TestLive_InspectLoadBalancer(t *testing.T) {
+	t.Parallel()
+	projectID := liveProjectOrSkip(t)
+	ctx := context.Background()
+
+	for _, action := range []string{
+		"list-backend-services", "list-url-maps",
+		"list-target-http-proxies", "list-target-https-proxies",
+		"list-forwarding-rules",
+	} {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
+			got, err := inspectLoadBalancer(ctx, projectID, action, `{"project":"`+projectID+`"}`, liveAuthOpts(t)...)
+			require.NoError(t, err, "inspectLoadBalancer %s must succeed (#245)", action)
+			t.Logf("%s returned %T", action, got)
+		})
+	}
+}
+
+// TestLive_InspectAPIGateway: list-apis must succeed with the AIP-160
+// project filter.
+func TestLive_InspectAPIGateway(t *testing.T) {
+	t.Parallel()
+	projectID := liveProjectOrSkip(t)
+	got, err := inspectAPIGateway(context.Background(), projectID, "list-apis", `{"project":"`+projectID+`"}`, liveAuthOpts(t)...)
+	require.NoError(t, err, "inspectAPIGateway list-apis must succeed (#245)")
+	t.Logf("list-apis returned %T", got)
+}
+
+// TestLive_InspectCloudFunctions: gen2 ListFunctions accepts AIP-160
+// labels filter (verified live #245). The handler filters server-side.
+func TestLive_InspectCloudFunctions(t *testing.T) {
+	t.Parallel()
+	projectID := liveProjectOrSkip(t)
+	got, err := inspectCloudFunctions(context.Background(), projectID, "list-functions", `{"project":"`+projectID+`"}`, liveAuthOpts(t)...)
+	require.NoError(t, err, "inspectCloudFunctions list-functions must succeed (#245)")
+	t.Logf("list-functions returned %T", got)
+}
+
+// TestLive_InspectVertexAI: list-endpoints in the default region.
+func TestLive_InspectVertexAI(t *testing.T) {
+	t.Parallel()
+	projectID := liveProjectOrSkip(t)
+	got, err := inspectVertexAI(context.Background(), projectID, "list-endpoints", `{"project":"`+projectID+`"}`, liveAuthOpts(t)...)
+	require.NoError(t, err, "inspectVertexAI list-endpoints must succeed (#245)")
+	t.Logf("list-endpoints returned %T", got)
+}
+
+// TestLive_InspectFirestore_DefaultDB exercises the fallback path —
+// when database_name is omitted, the inspector uses (default). Most
+// projects don't have a (default) database (the preset uses a named
+// DB per #159), so this is allowed to surface a NotFound; the call
+// itself must not be silently swallowed.
+func TestLive_InspectFirestore_DefaultDB(t *testing.T) {
+	t.Parallel()
+	projectID := liveProjectOrSkip(t)
+	_, err := inspectFirestore(context.Background(), projectID, "list-collections", "", liveAuthOpts(t)...)
+	if err != nil {
+		t.Logf("inspectFirestore (default) returned (expected on preset-deployed projects): %v", err)
+	}
+}
+
+// TestLive_InspectFirestore_NamedDB confirms the database_name
+// passthrough works against a real preset-deployed Firestore. Set
+// LIVE_GCP_FIRESTORE_DB to the database_name output of the deployed
+// stack (e.g. io-cc7ndmjcolun-firestore-8a3bfd07).
+func TestLive_InspectFirestore_NamedDB(t *testing.T) {
+	t.Parallel()
+	projectID := liveProjectOrSkip(t)
+	dbName := os.Getenv("LIVE_GCP_FIRESTORE_DB")
+	if dbName == "" {
+		t.Skip("LIVE_GCP_FIRESTORE_DB not set; export the database_name output of a deployed gcp/firestore preset to exercise the named-DB path (#245)")
+	}
+
+	filters := `{"database_name":"` + dbName + `"}`
+	got, err := inspectFirestore(context.Background(), projectID, "list-collections", filters, liveAuthOpts(t)...)
+	require.NoError(t, err, "inspectFirestore with database_name=%q must succeed against a preset-deployed Firestore (#245)", dbName)
+	t.Logf("list-collections (db=%s) returned %T: %v", dbName, got, got)
+}
+
+// TestLive_InspectIdentityPlatform_TenantsOnUnprovisionedProject
+// confirms the structured-error envelope on a project that has the
+// API enabled but multi-tenancy not provisioned. By default this
+// runs against LIVE_GCP_PROJECT_ID; skip with LIVE_GCP_IDP_HAS_MULTITENANCY=1
+// when the project DOES have tenants (in which case it would 200).
+func TestLive_InspectIdentityPlatform_TenantsOnUnprovisionedProject(t *testing.T) {
+	t.Parallel()
+	projectID := liveProjectOrSkip(t)
+	if os.Getenv("LIVE_GCP_IDP_HAS_MULTITENANCY") == "1" {
+		t.Skip("LIVE_GCP_IDP_HAS_MULTITENANCY=1; project has multi-tenancy provisioned, skipping the structured-error probe")
+	}
+
+	_, err := inspectIdentityPlatform(context.Background(), projectID, "list-tenants", "", liveAuthOpts(t)...)
+	require.Error(t, err, "list-tenants on a project without provisioned multi-tenancy must error")
+
+	var feErr *observability.GCPFeatureNotEnabledError
+	require.True(t, errors.As(err, &feErr),
+		"err must be wrapped as GCPFeatureNotEnabledError so reliable's panel renderer can errors.As it (#245); got %T (%v)", err, err)
+	assert.Equal(t, "identity_platform_multitenancy", feErr.Feature)
+	assert.Equal(t, projectID, feErr.ProjectID)
+}
+
+// TestLive_InspectIdentityPlatform_ListProviders — list-providers
+// works on every project with the Identity Toolkit API enabled, so
+// it's a baseline sanity check that the project + creds are right.
+func TestLive_InspectIdentityPlatform_ListProviders(t *testing.T) {
+	t.Parallel()
+	projectID := liveProjectOrSkip(t)
+	got, err := inspectIdentityPlatform(context.Background(), projectID, "list-providers", "", liveAuthOpts(t)...)
+	require.NoError(t, err)
+	t.Logf("list-providers returned %T: %v", got, got)
 }

--- a/pkg/observability/discovery/gcp/live_integration_test.go
+++ b/pkg/observability/discovery/gcp/live_integration_test.go
@@ -39,10 +39,14 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/aiplatform/apiv1/aiplatformpb"
+	"cloud.google.com/go/apigateway/apiv1/apigatewaypb"
+	"cloud.google.com/go/functions/apiv2/functionspb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	computeapi "google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/observability"
@@ -85,29 +89,56 @@ func (gcloudTokenSource) Token() (*oauth2.Token, error) {
 	return &oauth2.Token{AccessToken: tok, Expiry: time.Now().Add(30 * time.Minute)}, nil
 }
 
-// liveAuthOpts returns option.ClientOption(s) suitable for the SDK
-// clients used by the inspectors. It tries ADC first; on failure,
-// falls back to a `gcloud auth print-access-token` token source so a
-// developer with `gcloud auth login` (active account or impersonated
-// service account) can run the suite without needing to refresh
-// application-default credentials separately.
+// gcloudReusableTokenSource caches the gcloud-issued access token
+// across calls so the SDK's per-RPC token fetch doesn't shell out
+// to `gcloud auth print-access-token` every time. The wrapped
+// gcloudTokenSource{} sets a 30-minute Expiry; ReuseTokenSource
+// honors that and re-fetches only when the cache expires.
+func gcloudReusableTokenSource() oauth2.TokenSource {
+	return oauth2.ReuseTokenSource(nil, gcloudTokenSource{})
+}
+
+// resolveLiveAuth returns the credentials we should use for live
+// probes, picking ADC when usable and falling back to gcloud-CLI
+// when allowed. Critical: ADC's "find" can succeed even when the
+// cached refresh token is in invalid_grant / invalid_rapt state —
+// so we MUST issue a real token via TokenSource.Token() to confirm
+// before letting the SDK use it.
 //
-// Critical: ADC's "find" can succeed even when the cached refresh
-// token is in invalid_grant / invalid_rapt state — so we MUST issue
-// a real token via TokenSource.Token() to confirm before letting
-// the SDK use it. Otherwise the per-inspector tests below would
-// silently inherit broken ADC even though the regime probe (which
-// uses liveHTTPClient with the same check) works fine.
-func liveAuthOpts(t *testing.T) []option.ClientOption {
+// Set LIVE_GCP_REQUIRE_ADC=1 to disable the gcloud fallback (CI mode
+// + paranoid local runs); the test fatals instead of falling back.
+// Without that env var, the fallback is enabled by default for local
+// developer ergonomics — broken ADC otherwise blocks every test run
+// until the operator runs `gcloud auth application-default login`,
+// which is friction without much defensive value (the next gcloud
+// command would have surfaced it anyway).
+//
+// Returns the chosen TokenSource and a bool indicating whether the
+// fallback was taken (purely for the t.Logf line at the call site).
+func resolveLiveAuth(t *testing.T, ctx context.Context) (ts oauth2.TokenSource, viaGcloud bool) {
 	t.Helper()
-	creds, err := google.FindDefaultCredentials(context.Background(), "https://www.googleapis.com/auth/cloud-platform")
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
 	if err == nil && creds != nil {
 		if _, terr := creds.TokenSource.Token(); terr == nil {
-			return nil
+			return creds.TokenSource, false
 		}
 	}
-	t.Logf("ADC unavailable or token fetch failed; falling back to `gcloud auth print-access-token`")
-	return []option.ClientOption{option.WithTokenSource(gcloudTokenSource{})}
+	if os.Getenv("LIVE_GCP_REQUIRE_ADC") == "1" {
+		t.Fatalf("ADC unavailable or token fetch failed and LIVE_GCP_REQUIRE_ADC=1; refresh ADC with `gcloud auth application-default login` or unset the env var to allow the gcloud-CLI fallback")
+	}
+	return gcloudReusableTokenSource(), true
+}
+
+// liveAuthOpts returns option.ClientOption(s) suitable for the SDK
+// clients used by the inspectors. ADC first; gcloud fallback when
+// ADC is broken (see resolveLiveAuth).
+func liveAuthOpts(t *testing.T) []option.ClientOption {
+	t.Helper()
+	ts, viaGcloud := resolveLiveAuth(t, context.Background())
+	if viaGcloud {
+		t.Logf("WARN: ADC unavailable or token fetch failed; falling back to `gcloud auth print-access-token`. Set LIVE_GCP_REQUIRE_ADC=1 to fatal instead.")
+	}
+	return []option.ClientOption{option.WithTokenSource(ts)}
 }
 
 // liveHTTPClient returns an http.Client backed by the same auth
@@ -117,18 +148,11 @@ func liveAuthOpts(t *testing.T) []option.ClientOption {
 func liveHTTPClient(t *testing.T) *http.Client {
 	t.Helper()
 	ctx := context.Background()
-	if c, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform"); err == nil {
-		// Smoke-check by issuing a token; if invalid_grant fires here,
-		// fall through to the gcloud fallback below.
-		creds, _ := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
-		if creds != nil {
-			if _, terr := creds.TokenSource.Token(); terr == nil {
-				return c
-			}
-		}
+	ts, viaGcloud := resolveLiveAuth(t, ctx)
+	if viaGcloud {
+		t.Logf("WARN: ADC unavailable or token fetch failed; falling back to `gcloud auth print-access-token` for direct REST probes. Set LIVE_GCP_REQUIRE_ADC=1 to fatal instead.")
 	}
-	t.Logf("ADC unavailable; falling back to `gcloud auth print-access-token` for direct REST probes")
-	return oauth2.NewClient(ctx, gcloudTokenSource{})
+	return oauth2.NewClient(ctx, ts)
 }
 
 // TestLive_InspectCloudCDN_NoCDNFilter exercises the AggregatedList
@@ -268,38 +292,60 @@ func TestLive_ComputeV1FilterRegimes(t *testing.T) {
 }
 
 // TestLive_InspectVPC exercises every VPC action against a real
-// project. None should error.
+// project. Asserts the concrete return type per action so a
+// switch-case fallthrough (e.g. list-subnets returning []*Network)
+// would fail loudly (qa-professor §P1.3) instead of slipping through
+// as a no-error result.
 func TestLive_InspectVPC(t *testing.T) {
 	t.Parallel()
 	projectID := liveProjectOrSkip(t)
 	ctx := context.Background()
 
-	for _, action := range []string{"list-networks", "list-subnets", "list-firewalls", "list-routes"} {
-		t.Run(action, func(t *testing.T) {
+	cases := []struct {
+		action   string
+		wantType any
+	}{
+		{"list-networks", []*computeapi.Network(nil)},
+		{"list-subnets", []*computeapi.Subnetwork(nil)},
+		{"list-firewalls", []*computeapi.Firewall(nil)},
+		{"list-routes", []*computeapi.Route(nil)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.action, func(t *testing.T) {
 			t.Parallel()
-			got, err := inspectVPC(ctx, projectID, action, `{"project":"`+projectID+`"}`, liveAuthOpts(t)...)
-			require.NoError(t, err, "inspectVPC %s must succeed against a real project (#245)", action)
-			t.Logf("%s returned %T", action, got)
+			got, err := inspectVPC(ctx, projectID, tc.action, `{"project":"`+projectID+`"}`, liveAuthOpts(t)...)
+			require.NoError(t, err, "inspectVPC %s must succeed against a real project (#245)", tc.action)
+			require.IsType(t, tc.wantType, got, "concrete return type drift on %s — switch-case fallthrough?", tc.action)
+			t.Logf("%s returned %T", tc.action, got)
 		})
 	}
 }
 
 // TestLive_InspectLoadBalancer exercises every load-balancer action.
+// Same return-type assertion as TestLive_InspectVPC (qa-professor
+// §P1.3).
 func TestLive_InspectLoadBalancer(t *testing.T) {
 	t.Parallel()
 	projectID := liveProjectOrSkip(t)
 	ctx := context.Background()
 
-	for _, action := range []string{
-		"list-backend-services", "list-url-maps",
-		"list-target-http-proxies", "list-target-https-proxies",
-		"list-forwarding-rules",
-	} {
-		t.Run(action, func(t *testing.T) {
+	cases := []struct {
+		action   string
+		wantType any
+	}{
+		{"list-backend-services", []*computeapi.BackendService(nil)},
+		{"list-url-maps", []*computeapi.UrlMap(nil)},
+		{"list-target-http-proxies", []*computeapi.TargetHttpProxy(nil)},
+		{"list-target-https-proxies", []*computeapi.TargetHttpsProxy(nil)},
+		{"list-forwarding-rules", []*computeapi.ForwardingRule(nil)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.action, func(t *testing.T) {
 			t.Parallel()
-			got, err := inspectLoadBalancer(ctx, projectID, action, `{"project":"`+projectID+`"}`, liveAuthOpts(t)...)
-			require.NoError(t, err, "inspectLoadBalancer %s must succeed (#245)", action)
-			t.Logf("%s returned %T", action, got)
+			got, err := inspectLoadBalancer(ctx, projectID, tc.action, `{"project":"`+projectID+`"}`, liveAuthOpts(t)...)
+			require.NoError(t, err, "inspectLoadBalancer %s must succeed (#245)", tc.action)
+			require.IsType(t, tc.wantType, got, "concrete return type drift on %s — switch-case fallthrough?", tc.action)
+			t.Logf("%s returned %T", tc.action, got)
 		})
 	}
 }
@@ -311,6 +357,7 @@ func TestLive_InspectAPIGateway(t *testing.T) {
 	projectID := liveProjectOrSkip(t)
 	got, err := inspectAPIGateway(context.Background(), projectID, "list-apis", `{"project":"`+projectID+`"}`, liveAuthOpts(t)...)
 	require.NoError(t, err, "inspectAPIGateway list-apis must succeed (#245)")
+	require.IsType(t, []*apigatewaypb.Api(nil), got, "concrete return type drift on list-apis")
 	t.Logf("list-apis returned %T", got)
 }
 
@@ -321,6 +368,7 @@ func TestLive_InspectCloudFunctions(t *testing.T) {
 	projectID := liveProjectOrSkip(t)
 	got, err := inspectCloudFunctions(context.Background(), projectID, "list-functions", `{"project":"`+projectID+`"}`, liveAuthOpts(t)...)
 	require.NoError(t, err, "inspectCloudFunctions list-functions must succeed (#245)")
+	require.IsType(t, []*functionspb.Function(nil), got, "concrete return type drift on list-functions")
 	t.Logf("list-functions returned %T", got)
 }
 
@@ -330,21 +378,33 @@ func TestLive_InspectVertexAI(t *testing.T) {
 	projectID := liveProjectOrSkip(t)
 	got, err := inspectVertexAI(context.Background(), projectID, "list-endpoints", `{"project":"`+projectID+`"}`, liveAuthOpts(t)...)
 	require.NoError(t, err, "inspectVertexAI list-endpoints must succeed (#245)")
+	require.IsType(t, []*aiplatformpb.Endpoint(nil), got, "concrete return type drift on list-endpoints")
 	t.Logf("list-endpoints returned %T", got)
 }
 
 // TestLive_InspectFirestore_DefaultDB exercises the fallback path —
 // when database_name is omitted, the inspector uses (default). Most
-// projects don't have a (default) database (the preset uses a named
-// DB per #159), so this is allowed to surface a NotFound; the call
-// itself must not be silently swallowed.
+// preset-deployed projects don't have a (default) database (#159 —
+// the preset deliberately uses a named DB), so the call must surface
+// either a successful empty-list OR a clear NotFound from the
+// gRPC layer. A no-op implementation that returned nil/nil would
+// pass the previous version of this test (qa-professor §P3.2);
+// this version asserts we got *some* meaningful response.
 func TestLive_InspectFirestore_DefaultDB(t *testing.T) {
 	t.Parallel()
 	projectID := liveProjectOrSkip(t)
-	_, err := inspectFirestore(context.Background(), projectID, "list-collections", "", liveAuthOpts(t)...)
-	if err != nil {
-		t.Logf("inspectFirestore (default) returned (expected on preset-deployed projects): %v", err)
+	got, err := inspectFirestore(context.Background(), projectID, "list-collections", "", liveAuthOpts(t)...)
+	if err == nil {
+		// Default DB exists on this project — happy path.
+		require.IsType(t, []string(nil), got, "list-collections must return []string, not nil-pretending-to-be-anything")
+		t.Logf("inspectFirestore (default) succeeded: %T = %v", got, got)
+		return
 	}
+	// Default DB missing — must be the explicit gRPC NotFound, not a
+	// silently-swallowed wrong-shape error.
+	assert.Contains(t, err.Error(), "NotFound",
+		"expected explicit gRPC NotFound on default-DB-missing projects (the preset uses a non-default name per #159); got %v", err)
+	t.Logf("inspectFirestore (default) NotFound (expected on preset-deployed projects): %v", err)
 }
 
 // TestLive_InspectFirestore_NamedDB confirms the database_name

--- a/pkg/observability/discovery/gcp/live_integration_test.go
+++ b/pkg/observability/discovery/gcp/live_integration_test.go
@@ -203,12 +203,12 @@ func TestLive_ComputeV1FilterRegimes(t *testing.T) {
 	)
 
 	type probe struct {
-		name        string
-		url         string // without ?filter=...
-		regime      string
-		legacyCode  int    // expected status with the legacy dialect
-		aip160Code  int    // expected status with the AIP-160 dialect
-		noFilterOK  bool   // expected to return 200 with no filter
+		name       string
+		url        string // without ?filter=...
+		regime     string
+		legacyCode int  // expected status with the legacy dialect
+		aip160Code int  // expected status with the AIP-160 dialect
+		noFilterOK bool // expected to return 200 with no filter
 	}
 
 	probes := []probe{

--- a/pkg/observability/discovery/gcp/network.go
+++ b/pkg/observability/discovery/gcp/network.go
@@ -28,7 +28,6 @@ import (
 	computeapi "google.golang.org/api/compute/v1"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/observability"
 )
@@ -39,42 +38,49 @@ func inspectVPC(ctx context.Context, projectID, action, filters string, opts ...
 		return nil, err
 	}
 
-	// AIP-160 filter, applied where the resource type carries labels
-	// (Networks, Subnetworks). Firewalls and Routes have no labels
-	// field on the GCE API (per the v1 schema) so they stay un-filtered
-	// — they're scoped by parent network association rather than
-	// labels.
+	// Compute v1 list endpoints split into THREE filter regimes
+	// (verified live against project diagramtest2025-09-14, #245):
 	//
-	// Compute v1's per-endpoint filter parser is inconsistent: some
-	// endpoints accept the GCE legacy dialect (`labels.foo=bar`) and
-	// some reject it with HTTP 400 "Invalid list filter expression".
-	// `networks.list`, `subnetworks.aggregatedList`,
-	// `backendServices.list`, `urlMaps.list`, `targetHttp(s)Proxies.
-	// list` all reject the legacy dialect (verified live on staging
-	// session sess_v2_qtyB4nkwp5N8 — see #239 broader sweep). AIP-160
-	// is the standard dialect and works on every Compute v1 endpoint
-	// we exercise.
-	projectFilter := gcpAIP160LabelFilter("project", projectFromFilters(filters))
+	//   (a) Resource type has no `labels` field at the API surface:
+	//       networks, subnetworks, backendServices, urlMaps,
+	//       targetHttp(s)Proxies, firewalls, routes. The server
+	//       rejects `labels.*` filters with HTTP 400 "Invalid list
+	//       filter expression"; post-filtering is impossible too
+	//       because the SDK's struct has no Labels field. Return
+	//       everything in the project.
+	//   (b) Resource type carries `labels` and accepts the AIP-160
+	//       server-side filter dialect: globalForwardingRules,
+	//       securityPolicies, instances.aggregatedList. Filter
+	//       server-side via gcpAIP160LabelFilter.
+	//
+	// The earlier #239 fix unilaterally flipped every Compute v1
+	// call site to AIP-160 thinking that was the universal answer.
+	// Live probing showed AIP-160 fails just as hard as the legacy
+	// dialect on regime-(a) endpoints, including the original
+	// backendServices.aggregatedList that #239 patched. The fix
+	// here drops the labels filter on regime-(a) endpoints
+	// entirely. Project-level attribution for those resource types
+	// happens via Project tag on the GCP project itself, not via
+	// per-resource labels.
+	//
+	// TestLive_ComputeV1FilterRegimes in live_integration_test.go
+	// pins the regime table against the real API so future
+	// Google-side parser changes are caught immediately.
 
 	switch action {
 	case "list-networks":
-		call := svc.Networks.List(projectID).Context(ctx)
-		if projectFilter != "" {
-			call = call.Filter(projectFilter)
-		}
-		resp, err := call.Do()
+		// Regime (a) — Network has no Labels field; drop filter;
+		// return everything in the project.
+		resp, err := svc.Networks.List(projectID).Context(ctx).Do()
 		if err != nil {
 			return nil, err
 		}
 		return resp.Items, nil
 
 	case "list-subnets":
+		// Regime (a) — Subnetwork has no Labels field; drop filter;
 		// AggregatedList covers every region.
-		call := svc.Subnetworks.AggregatedList(projectID).Context(ctx)
-		if projectFilter != "" {
-			call = call.Filter(projectFilter)
-		}
-		resp, err := call.Do()
+		resp, err := svc.Subnetworks.AggregatedList(projectID).Context(ctx).Do()
 		if err != nil {
 			return nil, err
 		}
@@ -113,65 +119,56 @@ func inspectLoadBalancer(ctx context.Context, projectID, action, filters string,
 		return nil, err
 	}
 
-	// AIP-160 filter — every load-balancer resource type listed below
-	// carries `labels` in the v1 schema (BackendServices, UrlMaps,
-	// TargetHttp[s]Proxies, GlobalForwardingRules). Was the GCE legacy
-	// dialect, but BackendServices.list / UrlMaps.list / TargetHttp(s)
-	// Proxies.list reject it with HTTP 400 (see #239 + the network.go
-	// header comment on the per-endpoint filter parser inconsistency).
-	projectFilter := gcpAIP160LabelFilter("project", projectFromFilters(filters))
+	// Filter regime per endpoint — see the network.go inspectVPC
+	// header comment for the full table. Summary for the load-
+	// balancer resource family:
+	//   - backendServices, urlMaps, targetHttp(s)Proxies — regime
+	//     (a): no Labels on the resource type. Drop the filter;
+	//     return everything.
+	//   - globalForwardingRules — regime (b): AIP-160 works.
+	aip160 := gcpAIP160LabelFilter("project", projectFromFilters(filters))
 
 	switch action {
 	case "list-backend-services":
-		// Global backend services.
-		call := svc.BackendServices.List(projectID).Context(ctx)
-		if projectFilter != "" {
-			call = call.Filter(projectFilter)
-		}
-		resp, err := call.Do()
+		// Regime (a) — BackendService has no Labels field; drop
+		// filter.
+		resp, err := svc.BackendServices.List(projectID).Context(ctx).Do()
 		if err != nil {
 			return nil, err
 		}
 		return resp.Items, nil
 
 	case "list-url-maps":
-		call := svc.UrlMaps.List(projectID).Context(ctx)
-		if projectFilter != "" {
-			call = call.Filter(projectFilter)
-		}
-		resp, err := call.Do()
+		// Regime (a) — UrlMap has no Labels field; drop filter.
+		resp, err := svc.UrlMaps.List(projectID).Context(ctx).Do()
 		if err != nil {
 			return nil, err
 		}
 		return resp.Items, nil
 
 	case "list-target-http-proxies":
-		call := svc.TargetHttpProxies.List(projectID).Context(ctx)
-		if projectFilter != "" {
-			call = call.Filter(projectFilter)
-		}
-		resp, err := call.Do()
+		// Regime (a) — TargetHttpProxy has no Labels field; drop
+		// filter. The reliable side attributes ownership via the
+		// URL-map → backend-service chain when needed.
+		resp, err := svc.TargetHttpProxies.List(projectID).Context(ctx).Do()
 		if err != nil {
 			return nil, err
 		}
 		return resp.Items, nil
 
 	case "list-target-https-proxies":
-		call := svc.TargetHttpsProxies.List(projectID).Context(ctx)
-		if projectFilter != "" {
-			call = call.Filter(projectFilter)
-		}
-		resp, err := call.Do()
+		// Regime (a) — same as list-target-http-proxies.
+		resp, err := svc.TargetHttpsProxies.List(projectID).Context(ctx).Do()
 		if err != nil {
 			return nil, err
 		}
 		return resp.Items, nil
 
 	case "list-forwarding-rules":
-		// Global forwarding rules.
+		// Regime (b) — AIP-160 server-side filter accepted.
 		call := svc.GlobalForwardingRules.List(projectID).Context(ctx)
-		if projectFilter != "" {
-			call = call.Filter(projectFilter)
+		if aip160 != "" {
+			call = call.Filter(aip160)
 		}
 		resp, err := call.Do()
 		if err != nil {
@@ -220,14 +217,16 @@ func inspectCloudArmor(ctx context.Context, projectID, action, filters string, o
 }
 
 // cloudCDNAggregatedListRequest builds the AggregatedList request for
-// the Cloud CDN inspector. Pulled out so the AIP-160 dialect choice
-// (#239) is pinned by a unit test instead of a comment.
-func cloudCDNAggregatedListRequest(projectID, filters string) *computepb.AggregatedListBackendServicesRequest {
-	req := &computepb.AggregatedListBackendServicesRequest{Project: projectID}
-	if f := gcpAIP160LabelFilter("project", projectFromFilters(filters)); f != "" {
-		req.Filter = proto.String(f)
-	}
-	return req
+// the Cloud CDN inspector. Pulled out so the no-filter contract (#245)
+// is pinned by a unit test.
+//
+// `filters` is accepted for forward compatibility but currently
+// unused: BackendService has no Labels field on either the legacy
+// (computeapi) or gapic (computepb) representation, so there's nothing
+// to attribute by even client-side. Project-level scoping is enforced
+// at the project boundary (caller controls projectID).
+func cloudCDNAggregatedListRequest(projectID string, _ string) *computepb.AggregatedListBackendServicesRequest {
+	return &computepb.AggregatedListBackendServicesRequest{Project: projectID}
 }
 
 func inspectCloudCDN(ctx context.Context, projectID, action, filters string, opts ...option.ClientOption) (any, error) {
@@ -237,26 +236,18 @@ func inspectCloudCDN(ctx context.Context, projectID, action, filters string, opt
 		// (EnableCdn=true), not a standalone resource — list backend
 		// services across all scopes and keep the CDN-enabled ones.
 		//
-		// IMPORTANT (#239): server-side scoping uses the AIP-160 dialect
-		// (`labels.project = "<value>"`), NOT the GCE legacy dialect
-		// (`labels.project=<value>`) used by every other inspector in
-		// this file. The same Compute v1 REST API exposes BOTH dialects
-		// per-endpoint:
-		//
-		//   - VPC / LoadBalancer / CloudArmor go through
-		//     google.golang.org/api/compute/v1 (computeapi.NewService)
-		//     — the older REST client — whose List/AggregatedList
-		//     accept the bare-equality legacy filter.
-		//   - CloudCDN goes through cloud.google.com/go/compute/apiv1
-		//     (compute.NewBackendServicesRESTClient) — the newer
-		//     gRPC-shaped client — whose AggregatedList rejects the
-		//     legacy form with HTTP 400 "Invalid list filter
-		//     expression" and requires the AIP-160 form. This was the
-		//     symptom on staging session sess_v2_qtyB4nkwp5N8 (#239).
-		//
-		// If we ever migrate the rest of this file to the newer
-		// compute apiv1 client, those call sites must flip to
-		// gcpAIP160LabelFilter at the same time.
+		// CORRECTION (#245): the previous #239 fix passed the
+		// AIP-160 `labels.project = "<value>"` server-side filter,
+		// claiming backendServices.aggregatedList accepted it. Live
+		// probing against project diagramtest2025-09-14 showed the
+		// endpoint REJECTS labels filters in BOTH dialects with
+		// HTTP 400 "Invalid list filter expression" — BackendService
+		// has no `labels` field on the v1 schema. The earlier unit
+		// test `TestCloudCDNAggregatedListRequest_AIP160DialectFor
+		// ProjectFilter` pinned a wire format the server actually
+		// rejects; without a live integration test, the bug shipped
+		// to v0.9.0. Fix: drop the labels filter; the EnableCDN
+		// post-filter on returned services already scopes correctly.
 		client, err := compute.NewBackendServicesRESTClient(ctx, opts...)
 		if err != nil {
 			return nil, err

--- a/pkg/observability/discovery/gcp/network_test.go
+++ b/pkg/observability/discovery/gcp/network_test.go
@@ -127,10 +127,19 @@ func TestInspectVPC_UnsupportedAction(t *testing.T) {
 // schema. Same regime applies to UrlMaps, TargetHttp(s)Proxies — all
 // covered by the regime-(a) live-probe table in network.go. Handler
 // MUST not send a filter query param.
+//
+// The fake handler asserts the URL path so a future switch-case
+// crossing (e.g. list-backend-services accidentally calling
+// UrlMaps.List) is caught by the path guard, not silently passed as
+// "filter param empty" (qa-professor §P2.4).
 func TestInspectLoadBalancer_ListBackendServices_NoServerSideLabelsFilter(t *testing.T) {
 	t.Parallel()
 	var capturedFilter string
 	srv, opts := fakeComputeAPIREST(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/backendServices") {
+			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
 		capturedFilter = r.URL.Query().Get("filter")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"items":[{"name":"bs-a"}]}`))
@@ -150,6 +159,10 @@ func TestInspectLoadBalancer_ListUrlMaps_NoServerSideLabelsFilter(t *testing.T) 
 	t.Parallel()
 	var capturedFilter string
 	srv, opts := fakeComputeAPIREST(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/urlMaps") {
+			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
 		capturedFilter = r.URL.Query().Get("filter")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"items":[{"name":"um-a"}]}`))
@@ -169,6 +182,13 @@ func TestInspectLoadBalancer_ListTargetHttpProxies_NoServerSideLabelsFilter(t *t
 	t.Parallel()
 	var capturedFilter string
 	srv, opts := fakeComputeAPIREST(t, func(w http.ResponseWriter, r *http.Request) {
+		// Note the trailing-slash-resistant guard: targetHttpProxies
+		// has a longer cousin (targetHttpsProxies) — match on the
+		// exact path segment.
+		if !strings.Contains(r.URL.Path, "/targetHttpProxies") || strings.Contains(r.URL.Path, "/targetHttpsProxies") {
+			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
 		capturedFilter = r.URL.Query().Get("filter")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"items":[{"name":"thp-a"}]}`))
@@ -185,6 +205,10 @@ func TestInspectLoadBalancer_ListTargetHttpsProxies_NoServerSideLabelsFilter(t *
 	t.Parallel()
 	var capturedFilter string
 	srv, opts := fakeComputeAPIREST(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/targetHttpsProxies") {
+			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
 		capturedFilter = r.URL.Query().Get("filter")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"items":[{"name":"thsp-a"}]}`))
@@ -205,6 +229,10 @@ func TestInspectLoadBalancer_ListForwardingRules_AppliesAIP160Filter(t *testing.
 	t.Parallel()
 	var capturedFilter string
 	srv, opts := fakeComputeAPIREST(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/forwardingRules") {
+			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
 		capturedFilter = r.URL.Query().Get("filter")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"items":[]}`))
@@ -288,28 +316,19 @@ func TestInspectCloudCDN_UnsupportedAction(t *testing.T) {
 // Without a live integration test, the bug shipped to v0.9.0; the
 // new TestLive_ComputeV1FilterRegimes integration test in
 // live_integration_test.go closes that loop.
+//
+// One row is enough — the constructor's signature ignores `filters`
+// (`_ string`), so iterating over many rows would be tautological
+// (qa-professor §6). The behavioral pin against `inspectCloudCDN` +
+// fakeComputeAPIREST in TestInspectCloudCDN_NoLabelsFilter exercises
+// the live wire path.
 func TestCloudCDNAggregatedListRequest_NoServerSideLabelsFilter(t *testing.T) {
 	t.Parallel()
-
-	for _, tc := range []struct {
-		name    string
-		filters string
-	}{
-		{"empty filters", ""},
-		{"missing project key", `{"region":"us-central1"}`},
-		{"empty project value", `{"project":""}`},
-		{"populated project", `{"project":"io-qtyb4nkwp5n8"}`},
-		{"populated project + extra", `{"project":"io-foo","region":"us-central1"}`},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			req := cloudCDNAggregatedListRequest("demo-proj", tc.filters)
-			require.NotNil(t, req)
-			assert.Equal(t, "demo-proj", req.GetProject())
-			assert.Nil(t, req.Filter,
-				"req.Filter must be nil — backendServices.aggregatedList rejects labels filters server-side regardless of dialect (#245)")
-		})
-	}
+	req := cloudCDNAggregatedListRequest("demo-proj", `{"project":"io-qtyb4nkwp5n8"}`)
+	require.NotNil(t, req)
+	assert.Equal(t, "demo-proj", req.GetProject())
+	assert.Nil(t, req.Filter,
+		"req.Filter must be nil — backendServices.aggregatedList rejects labels filters server-side regardless of dialect (#245)")
 }
 
 func TestInspectAPIGateway_UnsupportedAction(t *testing.T) {

--- a/pkg/observability/discovery/gcp/network_test.go
+++ b/pkg/observability/discovery/gcp/network_test.go
@@ -59,20 +59,31 @@ func TestInspectVPC_ListNetworks(t *testing.T) {
 	assert.Empty(t, capturedFilter)
 }
 
-func TestInspectVPC_ListNetworks_AppliesProjectFilter(t *testing.T) {
+// TestInspectVPC_ListNetworks_NoServerSideLabelsFilter pins #245:
+// networks.list rejects ALL labels filters with HTTP 400 ("Invalid
+// list filter expression") because Network has no `labels` field on
+// the v1 schema. The handler MUST send no `filter` query parameter
+// even when the caller passes a project filter; project-scoping
+// happens at the GCP project boundary, not via per-resource labels.
+//
+// If a future refactor re-introduces gcpAIP160LabelFilter or
+// gcpLegacyLabelFilter on this call site, this test fails. Reverses
+// the previous (broken) #239 broadening (commit 8465e59).
+func TestInspectVPC_ListNetworks_NoServerSideLabelsFilter(t *testing.T) {
 	t.Parallel()
 	var capturedFilter string
 	srv, opts := fakeComputeAPIREST(t, func(w http.ResponseWriter, r *http.Request) {
 		capturedFilter = r.URL.Query().Get("filter")
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"items":[]}`))
+		_, _ = w.Write([]byte(`{"items":[{"name":"net-a"}]}`))
 	})
 	defer srv.Close()
 
 	_, err := inspectVPC(context.Background(), "demo-proj", "list-networks",
 		`{"project":"io-foo"}`, opts...)
 	require.NoError(t, err)
-	assert.Equal(t, `labels.project = "io-foo"`, capturedFilter)
+	assert.Empty(t, capturedFilter,
+		"networks.list rejects labels filters server-side; handler must send no filter param (#245)")
 }
 
 func TestInspectVPC_ListFirewallsUnfiltered(t *testing.T) {
@@ -110,7 +121,87 @@ func TestInspectVPC_UnsupportedAction(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported VPC action")
 }
 
-func TestInspectLoadBalancer_ListBackendServices_AppliesFilter(t *testing.T) {
+// TestInspectLoadBalancer_ListBackendServices_NoServerSideLabelsFilter
+// pins #245: backendServices.list rejects ALL labels filters with
+// HTTP 400 because BackendService has no `labels` field on the v1
+// schema. Same regime applies to UrlMaps, TargetHttp(s)Proxies — all
+// covered by the regime-(a) live-probe table in network.go. Handler
+// MUST not send a filter query param.
+func TestInspectLoadBalancer_ListBackendServices_NoServerSideLabelsFilter(t *testing.T) {
+	t.Parallel()
+	var capturedFilter string
+	srv, opts := fakeComputeAPIREST(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedFilter = r.URL.Query().Get("filter")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"name":"bs-a"}]}`))
+	})
+	defer srv.Close()
+
+	_, err := inspectLoadBalancer(context.Background(), "demo-proj", "list-backend-services",
+		`{"project":"io-foo"}`, opts...)
+	require.NoError(t, err)
+	assert.Empty(t, capturedFilter,
+		"backendServices.list rejects labels filters server-side; handler must send no filter param (#245)")
+}
+
+// TestInspectLoadBalancer_ListUrlMaps_NoServerSideLabelsFilter — same
+// regime as backend-services per the network.go header comment.
+func TestInspectLoadBalancer_ListUrlMaps_NoServerSideLabelsFilter(t *testing.T) {
+	t.Parallel()
+	var capturedFilter string
+	srv, opts := fakeComputeAPIREST(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedFilter = r.URL.Query().Get("filter")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"name":"um-a"}]}`))
+	})
+	defer srv.Close()
+
+	_, err := inspectLoadBalancer(context.Background(), "demo-proj", "list-url-maps",
+		`{"project":"io-foo"}`, opts...)
+	require.NoError(t, err)
+	assert.Empty(t, capturedFilter,
+		"urlMaps.list rejects labels filters server-side; handler must send no filter param (#245)")
+}
+
+// TestInspectLoadBalancer_ListTargetHttp{,s}Proxies_NoServerSideLabelsFilter
+// — same regime.
+func TestInspectLoadBalancer_ListTargetHttpProxies_NoServerSideLabelsFilter(t *testing.T) {
+	t.Parallel()
+	var capturedFilter string
+	srv, opts := fakeComputeAPIREST(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedFilter = r.URL.Query().Get("filter")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"name":"thp-a"}]}`))
+	})
+	defer srv.Close()
+
+	_, err := inspectLoadBalancer(context.Background(), "demo-proj", "list-target-http-proxies",
+		`{"project":"io-foo"}`, opts...)
+	require.NoError(t, err)
+	assert.Empty(t, capturedFilter)
+}
+
+func TestInspectLoadBalancer_ListTargetHttpsProxies_NoServerSideLabelsFilter(t *testing.T) {
+	t.Parallel()
+	var capturedFilter string
+	srv, opts := fakeComputeAPIREST(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedFilter = r.URL.Query().Get("filter")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"name":"thsp-a"}]}`))
+	})
+	defer srv.Close()
+
+	_, err := inspectLoadBalancer(context.Background(), "demo-proj", "list-target-https-proxies",
+		`{"project":"io-foo"}`, opts...)
+	require.NoError(t, err)
+	assert.Empty(t, capturedFilter)
+}
+
+// TestInspectLoadBalancer_ListForwardingRules_AppliesAIP160Filter
+// pins #245 regime (b): globalForwardingRules.list accepts the
+// AIP-160 server-side label filter. ForwardingRule carries `labels`
+// on the v1 schema, so the handler keeps the original behavior.
+func TestInspectLoadBalancer_ListForwardingRules_AppliesAIP160Filter(t *testing.T) {
 	t.Parallel()
 	var capturedFilter string
 	srv, opts := fakeComputeAPIREST(t, func(w http.ResponseWriter, r *http.Request) {
@@ -120,10 +211,11 @@ func TestInspectLoadBalancer_ListBackendServices_AppliesFilter(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := inspectLoadBalancer(context.Background(), "demo-proj", "list-backend-services",
+	_, err := inspectLoadBalancer(context.Background(), "demo-proj", "list-forwarding-rules",
 		`{"project":"io-foo"}`, opts...)
 	require.NoError(t, err)
-	assert.Equal(t, `labels.project = "io-foo"`, capturedFilter)
+	assert.Equal(t, `labels.project = "io-foo"`, capturedFilter,
+		"globalForwardingRules.list accepts AIP-160; handler must keep server-side filter (#245)")
 }
 
 func TestInspectLoadBalancer_UnsupportedAction(t *testing.T) {
@@ -182,32 +274,21 @@ func TestInspectCloudCDN_UnsupportedAction(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported Cloud CDN action")
 }
 
-// TestCloudCDNAggregatedListRequest_AIP160DialectForProjectFilter pins
-// the dialect choice from #239: backendServices.aggregatedList rejects
-// the GCE legacy filter form (`labels.project=<value>`) with HTTP 400
-// "Invalid list filter expression" and requires the AIP-160 form
-// (`labels.project = "<value>"`). This is the same Compute v1 REST API
-// as VPC / LoadBalancer / CloudArmor, but accessed via the newer
-// cloud.google.com/go/compute/apiv1 client which enforces AIP-160.
+// TestCloudCDNAggregatedListRequest_NoServerSideLabelsFilter pins
+// the corrected #245 contract: backendServices.aggregatedList rejects
+// labels filters in BOTH dialects (legacy AND AIP-160) with HTTP 400
+// "Invalid list filter expression". BackendService has no `labels`
+// field on the v1 schema, so server-side label filtering is
+// impossible regardless of dialect. The constructor MUST NOT set
+// req.Filter.
 //
-// If a future refactor flips this back to gcpLegacyLabelFilter (or
-// changes the helper's output shape), this test fails. Reproduces the
-// staging session sess_v2_qtyB4nkwp5N8 / project io-qtyb4nkwp5n8 bug.
-func TestCloudCDNAggregatedListRequest_AIP160DialectForProjectFilter(t *testing.T) {
-	t.Parallel()
-	req := cloudCDNAggregatedListRequest("demo-proj", `{"project":"io-qtyb4nkwp5n8"}`)
-
-	require.NotNil(t, req, "request must always be returned")
-	assert.Equal(t, "demo-proj", req.GetProject(), "Project must be set on the AggregatedList request")
-	require.NotNil(t, req.Filter, "non-empty project filter must populate req.Filter")
-	assert.Equal(t, `labels.project = "io-qtyb4nkwp5n8"`, *req.Filter,
-		"filter must use AIP-160 dialect (spaces around =, quoted value); the GCE legacy form is rejected by backendServices.aggregatedList with HTTP 400 — see #239")
-}
-
-// TestCloudCDNAggregatedListRequest_NoFilterWhenProjectMissing — no
-// filter must be set when the caller doesn't supply a project; the SDK
-// treats nil as "no filter" / match all.
-func TestCloudCDNAggregatedListRequest_NoFilterWhenProjectMissing(t *testing.T) {
+// This reverses the (broken) #239 unit test
+// `TestCloudCDNAggregatedListRequest_AIP160DialectForProjectFilter`
+// — that test pinned a wire format the live server actually rejects.
+// Without a live integration test, the bug shipped to v0.9.0; the
+// new TestLive_ComputeV1FilterRegimes integration test in
+// live_integration_test.go closes that loop.
+func TestCloudCDNAggregatedListRequest_NoServerSideLabelsFilter(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -217,13 +298,16 @@ func TestCloudCDNAggregatedListRequest_NoFilterWhenProjectMissing(t *testing.T) 
 		{"empty filters", ""},
 		{"missing project key", `{"region":"us-central1"}`},
 		{"empty project value", `{"project":""}`},
+		{"populated project", `{"project":"io-qtyb4nkwp5n8"}`},
+		{"populated project + extra", `{"project":"io-foo","region":"us-central1"}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			req := cloudCDNAggregatedListRequest("demo-proj", tc.filters)
 			require.NotNil(t, req)
 			assert.Equal(t, "demo-proj", req.GetProject())
-			assert.Nil(t, req.Filter, "no project filter → req.Filter must be nil so backendServices.aggregatedList returns everything in the project")
+			assert.Nil(t, req.Filter,
+				"req.Filter must be nil — backendServices.aggregatedList rejects labels filters server-side regardless of dialect (#245)")
 		})
 	}
 }

--- a/pkg/observability/unsupported.go
+++ b/pkg/observability/unsupported.go
@@ -80,3 +80,51 @@ func UnsupportedServiceError(service string, validServices []string) error {
 	}
 	return errors.New(sb.String())
 }
+
+// GCPFeatureNotEnabledError signals that a per-project GCP feature is
+// not provisioned even though the underlying API is enabled — for
+// example, Identity Platform multi-tenancy on a project that has
+// `identitytoolkit.googleapis.com` enabled but never opted in to
+// multi-tenancy. The discovery layer wraps the upstream 4xx in this
+// type so callers (reliable's panel renderer) can render a clean
+// "feature not enabled" empty state via errors.As instead of leaking
+// a raw `400 INVALID_PROJECT_ID` string into the UI (#245).
+//
+// Feature is a stable identifier (snake_case) — reliable matches on
+// it without parsing the human-readable Error() string. ProjectID is
+// the GCP project the call was made against.
+type GCPFeatureNotEnabledError struct {
+	Feature   string
+	ProjectID string
+	Cause     error
+}
+
+// Error renders a human-readable form. The Feature identifier is the
+// machine-checkable contract — callers should use errors.As, not
+// string matching.
+func (e *GCPFeatureNotEnabledError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Cause != nil {
+		return fmt.Sprintf("gcp_feature_not_enabled[%s] project=%s: %v", e.Feature, e.ProjectID, e.Cause)
+	}
+	return fmt.Sprintf("gcp_feature_not_enabled[%s] project=%s", e.Feature, e.ProjectID)
+}
+
+// Unwrap exposes the upstream googleapi.Error / wrapped error so
+// callers can inspect status codes if they need to.
+func (e *GCPFeatureNotEnabledError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+// NewGCPFeatureNotEnabledError constructs the typed envelope. Use
+// from per-service inspectors when an upstream 4xx specifically
+// signals "feature not provisioned on this project" rather than a
+// generic API or auth failure.
+func NewGCPFeatureNotEnabledError(feature, projectID string, cause error) error {
+	return &GCPFeatureNotEnabledError{Feature: feature, ProjectID: projectID, Cause: cause}
+}


### PR DESCRIPTION
## Summary

Fixes the GCP component panel outage on staging session [`sess_v2_qtyB4nkwp5N8`](https://reliable.luthersystemsapp.com/s/sess_v2_qtyB4nkwp5N8) (issue #245). Live probing against the same project the bug was filed on (`diagramtest2025-09-14`) revealed that the previous #239 fix and its broadening commit `8465e59` were based on a wrong premise: most Compute v1 list endpoints reject `labels.project` filters in **both** dialects, not just the legacy one.

### Cause A — Compute v1 dialect (reverses #239 + closes the broader sweep)

Live-probed each Compute v1 list endpoint with both filter dialects against `diagramtest2025-09-14`:

| Endpoint | AIP-160 | Legacy | Required action |
|---|---|---|---|
| `networks.list` | 400 | 400 | **Drop server-side filter** |
| `subnetworks.aggregatedList` | 400 | 400 | **Drop** |
| `backendServices.list` | 400 | 400 | **Drop** |
| `backendServices.aggregatedList` (Cloud CDN) | **400** | 400 | **Drop** *(reverses #239's fix)* |
| `urlMaps.list` | 400 | 400 | **Drop** |
| `targetHttp(s)Proxies.list` | 400 | 400 | **Drop** |
| `globalForwardingRules.list` | 200 | 200 | Keep AIP-160 |
| `securityPolicies.list` | 200 | 200 | Keep AIP-160 |
| `instances.aggregatedList` | 200 | 200 | Keep AIP-160 |
| `apigateway apis.list` | 200 | 400 | Keep AIP-160 |

The regime-(a) endpoints' resource types have no `labels` field on the v1 schema (verified by compiler — `*compute.Network` etc. have no Labels field), so server-side filtering is impossible regardless of dialect, and post-filtering is impossible too. Project-scoping happens at the GCP project boundary.

The misleading `network.go:48-56` header comment claiming "AIP-160 is the standard dialect and works on every Compute v1 endpoint we exercise" is rewritten with the actual three-regime ground truth.

### Cause B — Firestore `database_name` passthrough

`inspectFirestore` was hardcoded to `firestore.NewClient(ctx, projectID, opts...)` which connects to `(default)`. The `gcp/firestore` preset deliberately uses a non-default named DB (issue #159: "Switching off `(default)` is a deliberate breaking change"). Inspector now reads `database_name` from filters and uses `firestore.NewClientWithDatabase` when supplied; falls back to `(default)` with a warn log when omitted. Database name is regex-validated as defense-in-depth.

### Cause C — Identity Platform multi-tenancy structured-error envelope

The `/v2/projects/{p}/tenants` endpoint returns 400 `INVALID_PROJECT_ID` when multi-tenancy isn't provisioned on the project — even though the API IS enabled and other Identity Platform endpoints (`oauthIdpConfigs`, `defaultSupportedIdpConfigs`, `config`) work fine. New typed `observability.GCPFeatureNotEnabledError` envelope wraps the specific 400 signature so reliable's panel renderer can `errors.As` it and render a clean empty state instead of leaking the raw 400 string.

The issue's hypothesis was "API not enabled"; live `gcloud services list --enabled` and direct REST probe disprove that — the Service Usage pre-flight check it suggested would be a false negative.

### Drive-by audit (`ComponentMetricsMapping`)

Walked every GCP entry. All other inspectors (compute, gke, cloudsql, gcs, cloudrun, secretmanager, cloudkms, pubsub, memorystore, cloudarmor, cloudbuild, cloudfunctions, vertexai, bastion, cloudlogging, cloudmonitoring) use the correct dialect or post-filter pattern for their endpoint. Confirmed live for cloudfunctions gen2 (HTTP 200 with AIP-160).

## Files changed

| File | Change |
|---|---|
| `pkg/observability/discovery/gcp/network.go` | Per-handler regime fix; rewrite header comment |
| `pkg/observability/discovery/gcp/data.go` | Firestore `database_name` passthrough; defense-in-depth regex |
| `pkg/observability/discovery/gcp/identity.go` | Wrap multi-tenancy 400 in structured envelope |
| `pkg/observability/unsupported.go` | New `GCPFeatureNotEnabledError` typed error |
| `pkg/observability/discovery/gcp/network_test.go` | Per-handler dialect pins; reverses #239's broken pin |
| `pkg/observability/discovery/gcp/data_test.go` | Firestore `database_name` parse + safety tests |
| `pkg/observability/discovery/gcp/identity_test.go` | Structured envelope + 5xx pass-through tests |
| `pkg/observability/discovery/gcp/live_integration_test.go` | `TestLive_ComputeV1FilterRegimes` canary + per-inspector smoke tests |
| `go.mod` | Promote `golang.org/x/oauth2` to direct (live test gcloud-token fallback) |

## Test plan

- [x] `go test -race ./...` passes (full repo)
- [x] `go vet ./...` clean
- [x] `terraform fmt -check -recursive` clean
- [x] `lint-project-tag.sh`, `lint-project-label.sh`, `lint-sensitive-for-each.sh` pass
- [x] **Live integration suite passes against `diagramtest2025-09-14`** (the same project the bug was filed on):
  ```
  LIVE_GCP_PROJECT_ID=diagramtest2025-09-14 \
  LIVE_GCP_FIRESTORE_DB=io-cc7ndmjcolun-firestore-8a3bfd07 \
    go test -tags=integration ./pkg/observability/discovery/gcp/...
  ```
  All `TestLive_*` pass: VPC, LoadBalancer (all 5 actions), APIGateway, VertexAI, CloudFunctions, CloudCDN (with + without project filter), Firestore (default returns expected NotFound; named-DB returns clean), IdentityPlatform (tenants returns wrapped envelope, providers returns 200), and the regime canary `TestLive_ComputeV1FilterRegimes` matches the live API.
- [x] Three-regime table verified by direct REST probe with `gcloud auth print-access-token`.

## CI gate

The user requested "if we can do any kind of CI check to stop this in future is good, if applicable". The catch-rate for this class of bug (#239 + #245 both shipped because unit tests pinned a wire format the live API rejected) is the live integration suite — it asserts the actual server behavior, not the developer's belief about it. The suite is build-tag-gated (`integration`) and runs locally before each release. Wiring it into a scheduled GitHub Actions job behind Workload Identity Federation is left as a follow-up issue to keep this PR scoped to the bug fix.

Fixes #245