### PR TITLE
feat(drift): consumer-method API for centralized drift questions

### DIFF
--- a/pkg/drift/doc.go
+++ b/pkg/drift/doc.go
@@ -13,9 +13,43 @@
 // (tests/verify-phantom-computed-schema.sh) extends naturally to keep
 // the Go classifier and the embedded denylist in sync.
 //
+// # Canonical entry point
+//
+// Consumers parse and classify in one step via [ClassifyJSON]:
+//
+//	v, err := drift.ClassifyJSON(driftJSONBytes)
+//	switch {
+//	case errors.Is(err, drift.ErrNoClassifiableDetail):
+//	    // Producer wrote pre-#105 schema. Treat as input error.
+//	case err != nil:
+//	    // Malformed JSON.
+//	default:
+//	    if v.ShouldBlockApply() { /* apply gate fires */ }
+//	    if v.IsInformationalOnly() { /* non-blocking notice */ }
+//	    log.Printf("drift: %s template=%s presets=%s",
+//	        v.Result, v.TemplateVersion(), v.PresetsVersion())
+//	}
+//
+// All consumer questions — "any drift?", "block apply?", "informational
+// only?", "what versions produced this?", "resources grouped by class?"
+// — have method answers on [Verdict] / [Result] / [Class]. New consumer
+// code should call those methods rather than reach into struct fields,
+// so the wire format can evolve without churning call sites.
+//
+// # Persistence
+//
+// [Verdict] is the canonical hand-off shape. Persistence layers should
+// store the original drift.json bytes (in a DB column, opaque protobuf
+// Struct, session metadata, etc.) and re-derive [Verdict] via
+// [ClassifyJSON] on read. The classifier is pure and inexpensive;
+// storing only the input means the classifier version can change
+// without invalidating cached rows.
+//
 // # Parse / classify split
 //
-// The package is split deliberately:
+// The package keeps the parse and classify steps separately reachable
+// for the rule-test suite, which constructs [Drift] literals directly
+// in Go and skips the JSON layer entirely:
 //
 //   - [UnmarshalJSON] (in unmarshal.go) parses the drift.json bytes
 //     written by sandbox-infrastructure-template/tf/drift-check.sh into
@@ -23,13 +57,18 @@
 //     the new (post-#105 additive) schema; missing fields decode to
 //     zero values without error.
 //   - [Classify] (in classify.go) runs the rule chain over a [Drift]
-//     and returns a [Result]. Tests for individual rules construct
-//     [Drift] literals directly in Go and skip the JSON layer entirely.
+//     and returns a [Result].
+//   - [HasClassifiableDetail] is the precondition gate [ClassifyJSON]
+//     uses internally; exported so callers can assert it on a [Drift]
+//     they assembled some other way.
 //
-// Callers that get a Drift with insufficient detail (see
-// [HasClassifiableDetail]) should fall back to whatever coarse signal
-// they had before. Today that's reliable's existing trust-the-boolean
-// path against Job.drift_actionable.
+// Callers that get [ErrNoClassifiableDetail] from [ClassifyJSON]
+// should treat it as an input error from an out-of-date producer, not
+// silently fall back to a coarser drift signal — there is no longer
+// any "coarse signal" path to fall back to. The producer pipeline has
+// emitted the post-#105 schema since 2026-04, and the legacy schema is
+// not classifiable: a Drift with addresses but no per-resource detail
+// gives the rules engine nothing to match on.
 //
 // # Versioning
 //

--- a/pkg/drift/methods.go
+++ b/pkg/drift/methods.go
@@ -1,0 +1,81 @@
+package drift
+
+// Methods on Result, Verdict, and Class that answer the questions
+// downstream consumers ask. Field-based access still works; methods
+// exist so the wire format and internal counts can evolve without
+// churning every consumer call site.
+
+// HasDrift reports whether the producer detected any drifted resources.
+// Equivalent to r.TotalCount > 0; preferred over the field read for new
+// call sites so the predicate name carries intent.
+func (r Result) HasDrift() bool {
+	return r.TotalCount > 0
+}
+
+// ShouldBlockApply reports whether the apply gate should fire. True iff
+// the classifier marked at least one resource as [ClassActionable].
+// Single canonical predicate replacing the row.DriftActionable.Bool /
+// result.ActionableCount > 0 reach-throughs scattered across consumers.
+func (r Result) ShouldBlockApply() bool {
+	return r.ActionableCount > 0
+}
+
+// IsInformationalOnly reports whether drift was detected but no
+// resource is actionable — the UI should render a non-blocking notice
+// rather than a failure banner. Equivalent to
+// r.HasDrift() && !r.ShouldBlockApply().
+func (r Result) IsInformationalOnly() bool {
+	return r.HasDrift() && !r.ShouldBlockApply()
+}
+
+// ResourcesByClass returns the per-resource verdicts grouped by
+// [Class]. The returned map omits classes with zero entries; within
+// each slice, resources keep their input order so consumers rendering
+// per-class sub-lists get stable output.
+//
+// The map is freshly allocated on each call; callers may mutate it
+// without affecting the underlying [Result].
+func (r Result) ResourcesByClass() map[Class][]Resource {
+	if len(r.Resources) == 0 {
+		return map[Class][]Resource{}
+	}
+	out := make(map[Class][]Resource)
+	for _, res := range r.Resources {
+		out[res.Class] = append(out[res.Class], res)
+	}
+	return out
+}
+
+// String satisfies fmt.Stringer; returns r.Summary so log lines and
+// chat-tool result formatting can pass a Result directly.
+func (r Result) String() string {
+	return r.Summary
+}
+
+// TemplateVersion returns the sandbox-infrastructure-template version
+// stamped onto the underlying [Drift]; "" when the producer omitted
+// it. Method (rather than direct field read on Verdict.Drift) so
+// callers can stay stable if the wire format evolves.
+func (v *Verdict) TemplateVersion() string {
+	if v == nil {
+		return ""
+	}
+	return v.Drift.TemplateVersion
+}
+
+// PresetsVersion returns the insideout-terraform-presets version
+// stamped onto the underlying [Drift]; "" when the producer omitted
+// it. Same rationale as [Verdict.TemplateVersion].
+func (v *Verdict) PresetsVersion() string {
+	if v == nil {
+		return ""
+	}
+	return v.Drift.PresetsVersion
+}
+
+// IsActionable reports whether resources of this Class block apply.
+// Today only [ClassActionable] is gating; the method form lets the
+// rule set grow new gating classes without churning every consumer.
+func (c Class) IsActionable() bool {
+	return c == ClassActionable
+}

--- a/pkg/drift/verdict.go
+++ b/pkg/drift/verdict.go
@@ -1,0 +1,63 @@
+package drift
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNoClassifiableDetail is returned by [ClassifyJSON] when the parsed
+// drift carries no per-resource detail (pre-#105 schema). Callers that
+// want to distinguish "input was malformed" from "input was the legacy
+// schema we no longer accept" should errors.Is against this sentinel.
+//
+// Empty drift reports — drift_detected:false with an empty resources
+// slice — do NOT trip this error: an empty Drift is classifiable as
+// "no drift," which is a valid verdict.
+var ErrNoClassifiableDetail = errors.New("drift: input has no classifiable per-resource detail")
+
+// Verdict bundles a parsed [Drift] with its classifier [Result]. It is
+// the canonical hand-off shape for consumers: a single value that
+// answers every drift question via methods on the embedded fields.
+//
+// Persistence pattern: round-trip the drift.json bytes through whatever
+// store fits (DB column, opaque protobuf Struct, session metadata)
+// and re-derive Verdict via [ClassifyJSON] on read. The classifier is
+// pure and inexpensive; storing only the input means the classifier
+// version can change without invalidating cached rows.
+type Verdict struct {
+	// Drift is the parsed drift.json — the producer's input.
+	Drift Drift
+	// Result is the classifier's verdict over Drift.
+	Result Result
+}
+
+// ClassifyJSON is the canonical entry point for consumers: parse
+// drift.json bytes, validate that they carry per-resource detail, run
+// [Classify], and return the bundled [Verdict].
+//
+// Error paths:
+//
+//   - JSON parse failure: returns a wrapped error from
+//     [UnmarshalJSON]. Distinguish via errors.As against a
+//     *json.SyntaxError or by checking the wrapped error's text.
+//   - Missing per-resource detail: returns [ErrNoClassifiableDetail].
+//     The caller has parsed JSON that decoded into a [Drift] but lacks
+//     the post-#105 schema fields the rules need. Treat as an input
+//     error from an out-of-date producer; do NOT silently fall back to
+//     a coarser drift signal.
+//   - Success: returns a non-nil *Verdict and nil error.
+//
+// Options are forwarded to [Classify] unchanged.
+func ClassifyJSON(b []byte, opts ...Option) (*Verdict, error) {
+	d, err := UnmarshalJSON(b)
+	if err != nil {
+		return nil, fmt.Errorf("drift: classify: %w", err)
+	}
+	if !HasClassifiableDetail(d) {
+		return nil, ErrNoClassifiableDetail
+	}
+	return &Verdict{
+		Drift:  d,
+		Result: Classify(d, opts...),
+	}, nil
+}

--- a/pkg/drift/verdict_test.go
+++ b/pkg/drift/verdict_test.go
@@ -1,0 +1,264 @@
+package drift
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// --- Result method tests ---
+
+func TestResult_HasDrift(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		r    Result
+		want bool
+	}{
+		{"empty", Result{}, false},
+		{"single_actionable", Result{TotalCount: 1, ActionableCount: 1}, true},
+		{"single_filtered", Result{TotalCount: 1, FilteredCount: 1}, true},
+		{"unknown_only", Result{TotalCount: 1}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.r.HasDrift(); got != tt.want {
+				t.Errorf("HasDrift() = %v; want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResult_ShouldBlockApply(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		r    Result
+		want bool
+	}{
+		{"empty", Result{}, false},
+		{"all_filtered", Result{TotalCount: 3, FilteredCount: 3}, false},
+		{"one_actionable", Result{TotalCount: 3, ActionableCount: 1, FilteredCount: 2}, true},
+		{"all_actionable", Result{TotalCount: 2, ActionableCount: 2}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.r.ShouldBlockApply(); got != tt.want {
+				t.Errorf("ShouldBlockApply() = %v; want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResult_IsInformationalOnly(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		r    Result
+		want bool
+	}{
+		{"empty_no_drift", Result{}, false},
+		{"single_actionable", Result{TotalCount: 1, ActionableCount: 1}, false},
+		{"single_filtered_only", Result{TotalCount: 1, FilteredCount: 1}, true},
+		{"mixed_actionable_plus_filtered", Result{TotalCount: 3, ActionableCount: 1, FilteredCount: 2}, false},
+		{"unknown_only", Result{TotalCount: 1}, true}, // drift seen but unclassified-and-not-actionable
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.r.IsInformationalOnly(); got != tt.want {
+				t.Errorf("IsInformationalOnly() = %v; want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResult_ResourcesByClass_HeterogeneousMixPreservesOrder(t *testing.T) {
+	t.Parallel()
+	r := Result{
+		TotalCount:      4,
+		ActionableCount: 2,
+		FilteredCount:   2,
+		Resources: []Resource{
+			{Address: "a1", Class: ClassActionable},
+			{Address: "p1", Class: ClassPhantomComputed},
+			{Address: "a2", Class: ClassActionable},
+			{Address: "n1", Class: ClassProviderNoise},
+		},
+	}
+	got := r.ResourcesByClass()
+	if len(got) != 3 {
+		t.Fatalf("ResourcesByClass() returned %d classes; want 3", len(got))
+	}
+	if as := got[ClassActionable]; len(as) != 2 || as[0].Address != "a1" || as[1].Address != "a2" {
+		t.Errorf("ClassActionable order = %+v; want [a1, a2]", as)
+	}
+	if ps := got[ClassPhantomComputed]; len(ps) != 1 || ps[0].Address != "p1" {
+		t.Errorf("ClassPhantomComputed = %+v; want [p1]", ps)
+	}
+	if ns := got[ClassProviderNoise]; len(ns) != 1 || ns[0].Address != "n1" {
+		t.Errorf("ClassProviderNoise = %+v; want [n1]", ns)
+	}
+	if _, found := got[ClassReconverge]; found {
+		t.Error("ClassReconverge should be absent (zero entries omitted)")
+	}
+}
+
+func TestResult_ResourcesByClass_EmptyResultReturnsEmptyMap(t *testing.T) {
+	t.Parallel()
+	got := Result{}.ResourcesByClass()
+	if got == nil {
+		t.Fatal("ResourcesByClass() returned nil; want non-nil empty map")
+	}
+	if len(got) != 0 {
+		t.Errorf("len = %d; want 0", len(got))
+	}
+}
+
+func TestResult_ResourcesByClass_FreshlyAllocated(t *testing.T) {
+	t.Parallel()
+	r := Result{Resources: []Resource{{Class: ClassActionable, Address: "x"}}}
+	first := r.ResourcesByClass()
+	first[ClassActionable] = append(first[ClassActionable], Resource{Address: "leak"})
+	second := r.ResourcesByClass()
+	if got := len(second[ClassActionable]); got != 1 {
+		t.Errorf("second.ResourcesByClass()[ClassActionable] len = %d; want 1 (mutation leaked)", got)
+	}
+}
+
+func TestResult_String_ReturnsSummary(t *testing.T) {
+	t.Parallel()
+	r := Result{Summary: "1 drift events: 0 actionable, 1 phantom_computed"}
+	if got := r.String(); got != r.Summary {
+		t.Errorf("String() = %q; Summary = %q", got, r.Summary)
+	}
+}
+
+// --- Class method tests ---
+
+func TestClass_IsActionable(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		c    Class
+		want bool
+	}{
+		{ClassActionable, true},
+		{ClassPhantomComputed, false},
+		{ClassProviderNoise, false},
+		{ClassReconverge, false},
+		{ClassUnknown, false},
+		{Class("future_class"), false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.c), func(t *testing.T) {
+			t.Parallel()
+			if got := tt.c.IsActionable(); got != tt.want {
+				t.Errorf("Class(%q).IsActionable() = %v; want %v", tt.c, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Verdict / ClassifyJSON tests ---
+
+func TestClassifyJSON_OK_MixedFixture(t *testing.T) {
+	t.Parallel()
+	v, err := ClassifyJSON(readFixture(t, "mixed.drift.json"))
+	if err != nil {
+		t.Fatalf("ClassifyJSON: unexpected error: %v", err)
+	}
+	if v == nil {
+		t.Fatal("ClassifyJSON: nil verdict on success")
+	}
+	if !v.Result.HasDrift() {
+		t.Error("HasDrift() = false; mixed fixture has 4 drift events")
+	}
+	if !v.Result.ShouldBlockApply() {
+		t.Error("ShouldBlockApply() = false; mixed fixture has one actionable resource")
+	}
+	if v.Result.IsInformationalOnly() {
+		t.Error("IsInformationalOnly() = true; mixed fixture has actionable drift")
+	}
+	if got, want := v.TemplateVersion(), "v0.7.0"; got != want {
+		t.Errorf("TemplateVersion() = %q; want %q", got, want)
+	}
+	if got, want := v.PresetsVersion(), "v0.7.3"; got != want {
+		t.Errorf("PresetsVersion() = %q; want %q", got, want)
+	}
+}
+
+func TestClassifyJSON_OK_PhantomOnlyIsInformational(t *testing.T) {
+	t.Parallel()
+	v, err := ClassifyJSON(readFixture(t, "phantom_only.drift.json"))
+	if err != nil {
+		t.Fatalf("ClassifyJSON: unexpected error: %v", err)
+	}
+	if !v.Result.HasDrift() {
+		t.Error("HasDrift() = false; phantom_only fixture has drift")
+	}
+	if v.Result.ShouldBlockApply() {
+		t.Error("ShouldBlockApply() = true; phantom_only fixture should be filtered")
+	}
+	if !v.Result.IsInformationalOnly() {
+		t.Error("IsInformationalOnly() = false; phantom_only fixture is exactly that case")
+	}
+}
+
+func TestClassifyJSON_OK_EmptyDriftIsClassifiable(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"drift_detected": false, "drift_count": 0, "resources": []}`)
+	v, err := ClassifyJSON(body)
+	if err != nil {
+		t.Fatalf("ClassifyJSON: empty drift should classify cleanly: %v", err)
+	}
+	if v.Result.HasDrift() {
+		t.Error("HasDrift() = true on empty drift report")
+	}
+	if v.Result.ShouldBlockApply() {
+		t.Error("ShouldBlockApply() = true on empty drift report")
+	}
+	if v.Result.IsInformationalOnly() {
+		t.Error("IsInformationalOnly() = true on empty drift report; should be false")
+	}
+}
+
+func TestClassifyJSON_ParseError_OnMalformedJSON(t *testing.T) {
+	t.Parallel()
+	v, err := ClassifyJSON([]byte("not-json"))
+	if err == nil {
+		t.Fatal("ClassifyJSON: expected parse error, got nil")
+	}
+	if v != nil {
+		t.Errorf("ClassifyJSON: verdict should be nil on error, got %+v", v)
+	}
+	if errors.Is(err, ErrNoClassifiableDetail) {
+		t.Errorf("malformed JSON should not be reported as ErrNoClassifiableDetail; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "drift: classify") {
+		t.Errorf("error %q missing wrap prefix 'drift: classify'", err.Error())
+	}
+}
+
+func TestClassifyJSON_NoDetail_OldSchemaFixture(t *testing.T) {
+	t.Parallel()
+	v, err := ClassifyJSON(readFixture(t, "old_schema.drift.json"))
+	if !errors.Is(err, ErrNoClassifiableDetail) {
+		t.Fatalf("ClassifyJSON: want ErrNoClassifiableDetail, got %v", err)
+	}
+	if v != nil {
+		t.Errorf("verdict should be nil on no-detail error, got %+v", v)
+	}
+}
+
+func TestVerdict_VersionAccessors_NilSafe(t *testing.T) {
+	t.Parallel()
+	var v *Verdict
+	if got := v.TemplateVersion(); got != "" {
+		t.Errorf("nil Verdict TemplateVersion() = %q; want \"\"", got)
+	}
+	if got := v.PresetsVersion(); got != "" {
+		t.Errorf("nil Verdict PresetsVersion() = %q; want \"\"", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a consumer-method API to `pkg/drift` so downstream consumers (reliable, ui-core) can ask drift questions via methods on a single deserialized struct, rather than reaching into typed booleans / status-string-checks scattered across ~25 call sites. Closes #248. Unblocks #242 (Phase 3 cleanup).

## What's new

- **`Verdict` struct** — bundles parsed `Drift` + classifier `Result`. Canonical hand-off shape.
- **`ClassifyJSON([]byte) (*Verdict, error)`** — one-shot entry point that subsumes the `UnmarshalJSON` → `HasClassifiableDetail` → `Classify` pattern at `reliable/internal/agentapi/tf_status.go:1151-1167`. Returns typed `ErrNoClassifiableDetail` for legacy-schema input.
- **Methods on `Result`** — `HasDrift`, `ShouldBlockApply`, `IsInformationalOnly`, `ResourcesByClass`, `String` (fmt.Stringer).
- **Methods on `Verdict`** — `TemplateVersion`, `PresetsVersion` (nil-safe).
- **`Class.IsActionable`** — single predicate that lets the rule chain grow new gating classes without churning consumers.
- **`doc.go` rewritten** — drops the "fall back to a coarser signal" guidance from the original PR #222; documents `ClassifyJSON` as the canonical entry point. (Absorbs Phase 3 step 3d from #242.)

Existing public API (`Classify`, `UnmarshalJSON`, `HasClassifiableDetail`) is unchanged — purely additive.

## Why

Cross-repo audit (reliable, reliable3, ui-core, sandbox-infrastructure-template) showed the same handful of questions answered in 25+ places with subtly different OR-fallbacks, status-string back-compat, and tri-state nullable bools:

- `drift_detected` — 9 sites
- `drift_actionable` — 8 sites
- "informational drift" predicate — 5 sites
- "prefer custom_*_version over runtime" — 3 sites

This is the sprawl Phase 3 cleanup needs to delete, but you can't delete the deprecated typed fields (`Job.drift_detected`, `Job.drift_actionable`, `Job.template_version`, `Job.presets_version`, etc.) until consumers have an ergonomic API to migrate to. This PR ships that API.

## Test plan

- [x] `go test ./pkg/drift/... -count=1 -race` — all green (existing 30+ tests + 14 new method tests)
- [x] `go vet ./...` — clean
- [x] `gofmt -l pkg/drift/` — clean
- [x] `go build ./...` — clean

New test coverage:

- `TestResult_HasDrift` — empty / single-actionable / single-filtered / unknown-only
- `TestResult_ShouldBlockApply` — empty / all-filtered / one-actionable / all-actionable
- `TestResult_IsInformationalOnly` — empty / single-actionable / single-filtered-only / mixed / unknown-only
- `TestResult_ResourcesByClass` — heterogeneous-mix order preservation, empty result returns non-nil empty map, freshly allocated (mutation isolation)
- `TestResult_String` — equals `Summary`
- `TestClass_IsActionable` — all 5 known classes + a `Class("future_class")` to lock down the contract
- `TestClassifyJSON_OK_MixedFixture` — full happy path through fixtures
- `TestClassifyJSON_OK_PhantomOnlyIsInformational` — drift+filtered, no actionable
- `TestClassifyJSON_OK_EmptyDriftIsClassifiable` — `drift_detected:false` returns OK Verdict
- `TestClassifyJSON_ParseError_OnMalformedJSON` — typed parse error path, distinguishable from `ErrNoClassifiableDetail`
- `TestClassifyJSON_NoDetail_OldSchemaFixture` — `errors.Is(err, ErrNoClassifiableDetail)` on legacy fixture
- `TestVerdict_VersionAccessors_NilSafe` — `(*Verdict)(nil).TemplateVersion()` returns ""

## Out of scope (follow-ups, separate PRs)

1. Reliable migration of ~25 call sites in `tf_status.go`, `chat_v2.go`, `tf_runs.go`, `db.go`, `session_bundle/*` to call `*Verdict` methods. ~1-2 days.
2. ui-core: stop populating typed `Job.{drift_detected,drift_actionable,template_version,presets_version,custom_*}` writes; populate `Job.drift = google.protobuf.Struct` only.
3. ui-core proto: `reserved` deprecated tag numbers, remove fields. Ships after #1 + #2.
4. Reliable DB migration: drop the 6 typed columns on `tf_runs`. Half day + stage soak.
5. sandbox-infra: drop top-level `actionable` rollup in `drift-check.sh`. Keep `--ignore-drift` (orthogonal — caller intent).

These five complete the spirit of #242 without the multi-week soak, since each becomes a mechanical migration once this API exists.

## Refs

- Closes #248
- Unblocks #242 (Phase 3 cleanup)
- Builds on #222 (Phase 1 classifier)
