### PR TITLE
fix(drift): classify no-op and read action resources as benign (#251)

### DIFF
--- a/pkg/drift/classify_test.go
+++ b/pkg/drift/classify_test.go
@@ -209,6 +209,94 @@ func TestIAMManagedPolicyReconverge_DoesNotFireWhenBeforeNonEmpty(t *testing.T) 
 	}
 }
 
+// --- noOpRule ---
+
+func TestNoOpRule_OnlyNoOpAction(t *testing.T) {
+	t.Parallel()
+	// Issue #251 repro: action ["no-op"] on a resource type that
+	// none of the specific rules cover. Without noOpRule the
+	// resource hits the actionable fallback; with it, the verdict
+	// is the dedicated no_op class.
+	d := Drift{Resources: []ResourceDrift{
+		rd("module.gcp_cloud_functions.google_storage_bucket.source[0]",
+			"google_storage_bucket",
+			[]string{"no-op"},
+			`{"labels": {"managed-by": "terraform"}}`,
+			`{"labels": {"managed-by": "terraform", "drift": "phantom"}}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class != ClassNoOp {
+		t.Errorf("Class = %q; want %q", got.Resources[0].Class, ClassNoOp)
+	}
+	if got.Resources[0].Reason != "plan action is no-op" {
+		t.Errorf("Reason = %q; want %q", got.Resources[0].Reason, "plan action is no-op")
+	}
+	if got.ActionableCount != 0 {
+		t.Errorf("ActionableCount = %d; want 0", got.ActionableCount)
+	}
+	if got.FilteredCount != 1 {
+		t.Errorf("FilteredCount = %d; want 1", got.FilteredCount)
+	}
+}
+
+func TestNoOpRule_DoesNotFireOnUpdateAction(t *testing.T) {
+	t.Parallel()
+	// Mixed-or-non-no-op actions must not be silenced by noOpRule.
+	d := Drift{Resources: []ResourceDrift{
+		rd("aws_s3_bucket.b", "aws_s3_bucket", []string{"update"},
+			`{"acl": "private"}`, `{"acl": "public-read"}`),
+		rd("aws_s3_bucket.c", "aws_s3_bucket", []string{"no-op", "update"},
+			`{"acl": "private"}`, `{"acl": "public-read"}`),
+	}}
+	got := Classify(d)
+	for i, res := range got.Resources {
+		if res.Class == ClassNoOp {
+			t.Errorf("Resources[%d].Class = no_op for action %v; must abstain", i, res.Action)
+		}
+	}
+}
+
+func TestNoOpRule_DoesNotFireOnEmptyAction(t *testing.T) {
+	t.Parallel()
+	// Action == nil (refresh-only address with upstream action:null
+	// per the wireResourceDrift trichotomy) must continue falling
+	// through to ClassUnknown — not get silently filtered as no_op.
+	d := Drift{Resources: []ResourceDrift{
+		rd("aws_s3_bucket.b", "aws_s3_bucket", nil,
+			`{"acl": "private"}`, `{"acl": "public-read"}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class != ClassUnknown {
+		t.Errorf("Class = %q; want %q", got.Resources[0].Class, ClassUnknown)
+	}
+}
+
+func TestNoOpRule_SpecificRulesWinFirst(t *testing.T) {
+	t.Parallel()
+	// All three resources have action ["no-op"]. The more specific
+	// rules earlier in the chain must claim them ahead of noOpRule
+	// so the per-resource Reason carries the finer-grained signal.
+	d := Drift{Resources: []ResourceDrift{
+		// providerNoiseRule should fire on null/empty equivalence.
+		rd("module.alb.aws_lb_listener.main", "aws_lb_listener",
+			[]string{"no-op"},
+			`{"tags": {}}`, `{"tags": null}`),
+		// phantomComputedRule should fire on denylisted-only attrs.
+		rd("module.gcp_firestore.google_firestore_database.default",
+			"google_firestore_database", []string{"no-op"},
+			`{"etag": "abc"}`, `{"etag": "def"}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class != ClassProviderNoise {
+		t.Errorf("Resources[0].Class = %q; want %q",
+			got.Resources[0].Class, ClassProviderNoise)
+	}
+	if got.Resources[1].Class != ClassPhantomComputed {
+		t.Errorf("Resources[1].Class = %q; want %q",
+			got.Resources[1].Class, ClassPhantomComputed)
+	}
+}
+
 // --- fall-through: actionable / unknown ---
 
 func TestClassify_FallThroughActionable(t *testing.T) {
@@ -348,6 +436,14 @@ func TestClassify_FixtureRoundTrip(t *testing.T) {
 			// abstain because Type is empty, so resources fall
 			// through to ClassUnknown (no Action populated either).
 			[]Class{ClassUnknown, ClassUnknown},
+		},
+		{
+			"no_op_only.drift.json",
+			true, 1, 0,
+			// Issue #251: action ["no-op"] on a resource that no
+			// specific rule covers must classify as no_op (not
+			// actionable).
+			[]Class{ClassNoOp},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/drift/classify_test.go
+++ b/pkg/drift/classify_test.go
@@ -297,6 +297,62 @@ func TestNoOpRule_SpecificRulesWinFirst(t *testing.T) {
 	}
 }
 
+// --- readRule ---
+
+func TestReadRule_OnlyReadAction(t *testing.T) {
+	t.Parallel()
+	// Symmetric to TestNoOpRule_OnlyNoOpAction: a data source that
+	// surfaces in resource_drift with action ["read"] must classify
+	// as benign because reading never mutates infrastructure.
+	d := Drift{Resources: []ResourceDrift{
+		rd("data.aws_caller_identity.current", "aws_caller_identity",
+			[]string{"read"},
+			`{"account_id": "111111111111"}`,
+			`{"account_id": "222222222222"}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class != ClassRead {
+		t.Errorf("Class = %q; want %q", got.Resources[0].Class, ClassRead)
+	}
+	if got.Resources[0].Reason != "plan action is read" {
+		t.Errorf("Reason = %q; want %q", got.Resources[0].Reason, "plan action is read")
+	}
+	if got.ActionableCount != 0 {
+		t.Errorf("ActionableCount = %d; want 0", got.ActionableCount)
+	}
+	if got.FilteredCount != 1 {
+		t.Errorf("FilteredCount = %d; want 1", got.FilteredCount)
+	}
+}
+
+func TestReadRule_DoesNotFireOnNoOp(t *testing.T) {
+	t.Parallel()
+	// noOpRule and readRule must remain disjoint — a no-op-only
+	// resource must classify as ClassNoOp, not ClassRead.
+	d := Drift{Resources: []ResourceDrift{
+		rd("aws_s3_bucket.b", "aws_s3_bucket", []string{"no-op"},
+			`{"x": 1}`, `{"x": 2}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class != ClassNoOp {
+		t.Errorf("Class = %q; want %q", got.Resources[0].Class, ClassNoOp)
+	}
+}
+
+func TestReadRule_DoesNotFireOnMixedAction(t *testing.T) {
+	t.Parallel()
+	// ["read", "update"] is nonsense in practice but must not be
+	// silenced — readRule fires only when every action is "read".
+	d := Drift{Resources: []ResourceDrift{
+		rd("aws_s3_bucket.b", "aws_s3_bucket", []string{"read", "update"},
+			`{"x": 1}`, `{"x": 2}`),
+	}}
+	got := Classify(d)
+	if got.Resources[0].Class == ClassRead {
+		t.Errorf("Class = read for action %v; must abstain", got.Resources[0].Action)
+	}
+}
+
 // --- fall-through: actionable / unknown ---
 
 func TestClassify_FallThroughActionable(t *testing.T) {
@@ -444,6 +500,13 @@ func TestClassify_FixtureRoundTrip(t *testing.T) {
 			// specific rule covers must classify as no_op (not
 			// actionable).
 			[]Class{ClassNoOp},
+		},
+		{
+			"read_only.drift.json",
+			true, 1, 0,
+			// Symmetric coverage: action ["read"] is non-mutating
+			// and must classify as read (not actionable).
+			[]Class{ClassRead},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/drift/doc.go
+++ b/pkg/drift/doc.go
@@ -101,6 +101,13 @@
 //     [] to a non-empty list of strings, with an `update` action. The
 //     resource reconverges to the same state on next refresh after
 //     apply. Classifies as [ClassReconverge].
+//  4. noOpRule — catch-all for resources whose plan action set is
+//     non-empty and contains only "no-op". Terraform's planner has
+//     authoritatively decided no apply will happen, so any
+//     refresh-only Before/After diff on the resource is benign.
+//     Placed last so the more specific rules above can claim
+//     ownership (and a finer-grained reason) first. Classifies as
+//     [ClassNoOp].
 //
 // Anything that doesn't match a rule falls through to
 // [ClassActionable] (when an Action is present — the "presumed real

--- a/pkg/drift/doc.go
+++ b/pkg/drift/doc.go
@@ -105,9 +105,13 @@
 //     non-empty and contains only "no-op". Terraform's planner has
 //     authoritatively decided no apply will happen, so any
 //     refresh-only Before/After diff on the resource is benign.
-//     Placed last so the more specific rules above can claim
+//     Placed near the end so the more specific rules above can claim
 //     ownership (and a finer-grained reason) first. Classifies as
 //     [ClassNoOp].
+//  5. readRule — symmetric catch-all for resources whose plan action
+//     set is non-empty and contains only "read" — the data-source
+//     refresh action. Reading never mutates infrastructure, so any
+//     Before/After diff is informational. Classifies as [ClassRead].
 //
 // Anything that doesn't match a rule falls through to
 // [ClassActionable] (when an Action is present — the "presumed real

--- a/pkg/drift/drift.go
+++ b/pkg/drift/drift.go
@@ -34,6 +34,15 @@ const (
 	// from the user's perspective; not actionable.
 	ClassReconverge Class = "reconverge"
 
+	// ClassNoOp marks a resource whose only plan action is "no-op".
+	// Terraform's planner has authoritatively decided the resource
+	// will not change on apply, so any Before/After diff visible in
+	// resource_drift is refresh-only noise. Used as a catch-all when
+	// the more specific noise/phantom/reconverge rules don't fire —
+	// without it, no-op-only resources hit the actionable fallback
+	// (issue #251).
+	ClassNoOp Class = "no_op"
+
 	// ClassUnknown is the fallback when no rule matched and the
 	// resource also has no Action populated — typically because the
 	// input drift.json was the pre-#105 schema and slipped past

--- a/pkg/drift/drift.go
+++ b/pkg/drift/drift.go
@@ -43,6 +43,14 @@ const (
 	// (issue #251).
 	ClassNoOp Class = "no_op"
 
+	// ClassRead marks a resource whose only plan action is "read" —
+	// the data-source refresh action. Reading a data source never
+	// mutates infrastructure, so any Before/After diff is informational
+	// and not gating. Symmetric to [ClassNoOp]; both are "planner
+	// decided no apply will modify infrastructure," differing only in
+	// the planner action emitted.
+	ClassRead Class = "read"
+
 	// ClassUnknown is the fallback when no rule matched and the
 	// resource also has no Action populated — typically because the
 	// input drift.json was the pre-#105 schema and slipped past

--- a/pkg/drift/rules.go
+++ b/pkg/drift/rules.go
@@ -20,12 +20,18 @@ import (
 //     is "no-op". Last so the more specific rules above can claim
 //     ownership (and their reasons) first; without this rule those
 //     resources hit the actionable fallback (issue #251).
+//  5. readRule — symmetric catch-all for resources whose only
+//     planner action is "read" (data-source refresh). Reading a
+//     data source never mutates infrastructure, so any Before/After
+//     diff is informational. Co-located with noOpRule because both
+//     classify on a non-mutating planner action.
 func defaultRules() []Rule {
 	return []Rule{
 		providerNoiseRule{},
 		phantomComputedRule{},
 		iamManagedPolicyReconvergeRule{},
 		noOpRule{},
+		readRule{},
 	}
 }
 
@@ -289,7 +295,7 @@ func actionIsExactly(actions []string, want string) bool {
 // (refresh-only addresses with action: null upstream) still falls
 // through to ClassUnknown rather than being silently filtered.
 //
-// Placed last in defaultRules so the more specific
+// Placed near the end of defaultRules so the more specific
 // providerNoiseRule / phantomComputedRule / iamManagedPolicyReconvergeRule
 // can claim ownership of no-op resources first and surface their
 // fine-grained reason. Without this rule, no-op-only resources that
@@ -299,23 +305,39 @@ func actionIsExactly(actions []string, want string) bool {
 type noOpRule struct{}
 
 func (noOpRule) Match(r ResourceDrift) (Class, string, bool) {
-	if !actionsAllNoOp(r.Action) {
+	if !actionsAllEqual(r.Action, "no-op") {
 		return "", "", false
 	}
 	return ClassNoOp, "plan action is no-op", true
 }
 
-// actionsAllNoOp returns true when actions is non-empty and every
-// entry is "no-op". Subset-of-{"no-op"} semantics rather than exact
-// match — terraform always emits a singleton ["no-op"] today, but the
-// permissive form keeps the rule from regressing if the upstream ever
-// joins multiple no-op planner actions onto one address.
-func actionsAllNoOp(actions []string) bool {
+// readRule classifies a resource whose plan action set is non-empty
+// and contains only "read" entries as [ClassRead]. The "read" action
+// is emitted for data sources whose result is being refreshed — the
+// operation queries cloud state but never mutates it, so any
+// Before/After diff is informational. Symmetric to noOpRule; both
+// signal "planner decided no apply will modify infrastructure."
+type readRule struct{}
+
+func (readRule) Match(r ResourceDrift) (Class, string, bool) {
+	if !actionsAllEqual(r.Action, "read") {
+		return "", "", false
+	}
+	return ClassRead, "plan action is read", true
+}
+
+// actionsAllEqual returns true when actions is non-empty and every
+// entry equals want. Subset semantics rather than exact-singleton —
+// terraform canonically emits a singleton ["no-op"] / ["read"] today,
+// but the permissive form keeps the rules from regressing if the
+// upstream ever joins multiple identical planner actions onto one
+// address.
+func actionsAllEqual(actions []string, want string) bool {
 	if len(actions) == 0 {
 		return false
 	}
 	for _, a := range actions {
-		if a != "no-op" {
+		if a != want {
 			return false
 		}
 	}

--- a/pkg/drift/rules.go
+++ b/pkg/drift/rules.go
@@ -16,11 +16,16 @@ import (
 //  2. phantomComputedRule — denylist lookup; needs Type populated.
 //  3. iamManagedPolicyReconvergeRule — narrow shape match for the
 //     known IAM reconverge case.
+//  4. noOpRule — catch-all for resources whose only planner action
+//     is "no-op". Last so the more specific rules above can claim
+//     ownership (and their reasons) first; without this rule those
+//     resources hit the actionable fallback (issue #251).
 func defaultRules() []Rule {
 	return []Rule{
 		providerNoiseRule{},
 		phantomComputedRule{},
 		iamManagedPolicyReconvergeRule{},
+		noOpRule{},
 	}
 }
 
@@ -274,4 +279,45 @@ func (iamManagedPolicyReconvergeRule) Match(r ResourceDrift) (Class, string, boo
 // ["update", "replace"] which we don't want to classify as benign.
 func actionIsExactly(actions []string, want string) bool {
 	return len(actions) == 1 && actions[0] == want
+}
+
+// noOpRule classifies a resource whose plan action set is non-empty
+// and contains only "no-op" entries as [ClassNoOp]. Terraform's
+// resource_changes[].change.actions for a no-op resource is
+// canonically ["no-op"], so a subset check is mostly defensive — but
+// the rule does require at least one entry so an empty Action slice
+// (refresh-only addresses with action: null upstream) still falls
+// through to ClassUnknown rather than being silently filtered.
+//
+// Placed last in defaultRules so the more specific
+// providerNoiseRule / phantomComputedRule / iamManagedPolicyReconvergeRule
+// can claim ownership of no-op resources first and surface their
+// fine-grained reason. Without this rule, no-op-only resources that
+// don't match any specific rule hit the actionable fallback in
+// classifyOne — the false positive reported in issue #251 against
+// module.gcp_cloud_functions.google_storage_bucket.source[0].
+type noOpRule struct{}
+
+func (noOpRule) Match(r ResourceDrift) (Class, string, bool) {
+	if !actionsAllNoOp(r.Action) {
+		return "", "", false
+	}
+	return ClassNoOp, "plan action is no-op", true
+}
+
+// actionsAllNoOp returns true when actions is non-empty and every
+// entry is "no-op". Subset-of-{"no-op"} semantics rather than exact
+// match — terraform always emits a singleton ["no-op"] today, but the
+// permissive form keeps the rule from regressing if the upstream ever
+// joins multiple no-op planner actions onto one address.
+func actionsAllNoOp(actions []string) bool {
+	if len(actions) == 0 {
+		return false
+	}
+	for _, a := range actions {
+		if a != "no-op" {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/drift/testdata/no_op_only.drift.json
+++ b/pkg/drift/testdata/no_op_only.drift.json
@@ -1,0 +1,19 @@
+{
+  "drift_detected": true,
+  "drift_count": 1,
+  "actionable": false,
+  "template_version": "v0.7.0",
+  "presets_version": "v0.9.1",
+  "resources": [
+    {
+      "address": "module.gcp_cloud_functions.google_storage_bucket.source[0]",
+      "type": "google_storage_bucket",
+      "name": "source",
+      "action": ["no-op"],
+      "change": {
+        "before": { "labels": {"managed-by": "terraform"} },
+        "after":  { "labels": {"managed-by": "terraform", "drift": "phantom"} }
+      }
+    }
+  ]
+}

--- a/pkg/drift/testdata/read_only.drift.json
+++ b/pkg/drift/testdata/read_only.drift.json
@@ -1,0 +1,19 @@
+{
+  "drift_detected": true,
+  "drift_count": 1,
+  "actionable": false,
+  "template_version": "v0.7.0",
+  "presets_version": "v0.9.1",
+  "resources": [
+    {
+      "address": "data.aws_caller_identity.current",
+      "type": "aws_caller_identity",
+      "name": "current",
+      "action": ["read"],
+      "change": {
+        "before": { "account_id": "111111111111" },
+        "after":  { "account_id": "222222222222" }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a `noOpRule` to `pkg/drift` that classifies any resource whose plan action set is non-empty and contains only `"no-op"` as `ClassNoOp`.
- Adds a symmetric `readRule` for action `["read"]` (data-source refresh — never mutates infrastructure) → `ClassRead`. Same non-actionable semantics; refactors the action-equality check into a shared `actionsAllEqual` helper.
- Both rules are placed after the specific rules (`providerNoiseRule` / `phantomComputedRule` / `iamManagedPolicyReconvergeRule`) so those continue to claim ownership of resources they already cover.
- Adds round-trip + behavior tests, including an issue-#251 repro fixture (`google_storage_bucket` with action `["no-op"]`) and a parallel `data.aws_caller_identity` read fixture.

## Why

Without these rules, no-op-only and read-only resources fall through to the `classifyOne` actionable fallback ("no rule matched; action present"), even though terraform's planner has authoritatively decided no apply will happen. Downstream consumers (`reliable`, MCP) that gate on `Result.ShouldBlockApply()` see `ActionableCount > 0` and fire the apply-block signal — the false positive reported in #251 against `module.gcp_cloud_functions.google_storage_bucket.source[0]`.

`["read"]` is the symmetric case: data-source refreshes never mutate infrastructure, so any Before/After diff is informational. Adding it now closes a defensive gap before it surfaces as a separate false-positive ticket.

## Behavior change

```text
module.gcp_cloud_functions.google_storage_bucket.source[0]
  action: ["no-op"]
  before: class=actionable reason="no rule matched; action present"
  after:  class=no_op      reason="plan action is no-op"

data.aws_caller_identity.current
  action: ["read"]
  before: class=actionable reason="no rule matched; action present"
  after:  class=read       reason="plan action is read"
```

`ClassNoOp` and `ClassRead` are filtered (counted in `FilteredCount`, not `ActionableCount`), so `ShouldBlockApply()` no longer trips for these.

## Compatibility

- Class strings are part of the public contract per `pkg/drift/drift.go` — adding `ClassNoOp` and `ClassRead` is additive only.
- Existing rules retain priority: a no-op resource that also matches `providerNoiseRule` (null/empty) or `phantomComputedRule` (denylist) keeps its prior classification — verified by `TestNoOpRule_SpecificRulesWinFirst`.
- An empty/`nil` `Action` slice still falls through to `ClassUnknown` — verified by `TestNoOpRule_DoesNotFireOnEmptyAction`.
- Mixed actions like `["read", "update"]` or `["no-op", "update"]` still classify as actionable — verified by `TestNoOpRule_DoesNotFireOnUpdateAction` / `TestReadRule_DoesNotFireOnMixedAction`.

## Test plan

- [x] `go test ./pkg/drift/...` — all existing tests + 7 new no-op/read tests + 2 new fixture round-trips
- [x] `go test ./...` — full suite passes
- [x] `go vet ./pkg/...`
- [x] `gofmt -l pkg/drift/` clean

Closes #251