### PR TITLE
fix(observability/discovery): emit [] not null on empty discoveries (#255)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,37 @@ composed root.
   or once the framework is exercised by a real cross-cloud helper (likely
   the severity-tagging convention from #204).
 
+## Discovery Inspector Constraints (#255)
+
+When you add or modify an inspector under `pkg/observability/discovery/{aws,gcp}/`,
+every slice-shaped return must marshal to a JSON array (`[]` or `[…]`),
+never JSON `null`. The downstream `reliable` UI gates panel rendering on
+that shape; `null` collapses through every empty-state branch onto the
+"Deploy infrastructure first." fallback even on healthy resources whose
+handler legitimately returns zero items.
+
+Rules and the new-inspector checklist live in
+[`pkg/observability/discovery/CONTRIBUTING.md`](pkg/observability/discovery/CONTRIBUTING.md).
+Highlights:
+
+- **Pattern A — loop accumulator:** declare with a non-nil composite
+  literal at the construction site. `collections := []string{}`, NOT
+  `var collections []string`.
+- **Pattern B — direct SDK-slice passthrough (AWS-V2 specifically):**
+  wrap with `nilSliceToEmpty(out.X)` from
+  `pkg/observability/discovery/aws/helpers.go`. AWS SDK V2 emits typed-
+  nil slices on empty list responses; passing them through unchanged
+  reintroduces #255.
+- **Pattern C — wrapped-in-parent:** apply A or B to the inner slice
+  field before stuffing into the parent map.
+- **Test contract pin:** `require.NotNil` + `json.Marshal` ==
+  `"[]"`. `assert.Empty` alone is insufficient — it accepts both nil
+  and `[]`.
+- **Live probes:** `TestLive255_AllInspectorsJSONShape` (GCP) and
+  `TestLive255_AWSInspectorsJSONShape` (AWS) exercise every inspector
+  end-to-end against a real account. Run pre-release with
+  `-tags=integration`.
+
 ## Skills
 
 Before starting a task, check if a matching skill exists and follow its workflow exactly. Multiple skills can chain: e.g., `/pickup-issue` uses the relevant add-module skill for implementation, `/verify` before committing, and `/pr` to ship.

--- a/pkg/observability/discovery/CONTRIBUTING.md
+++ b/pkg/observability/discovery/CONTRIBUTING.md
@@ -1,0 +1,149 @@
+# Discovery inspector contract
+
+When you add or modify a discovery inspector in this package, every
+slice-shaped result MUST marshal to a JSON array (`[]` or `[…]`) — never
+JSON `null`. The downstream `reliable` UI gates panel rendering on the
+result field being a truthy array; `null` collapses through every empty-
+state branch onto the misleading "Deploy infrastructure first." fallback
+even on healthy, deployed resources whose action handler legitimately
+returns zero items.
+
+Issue [#255][issue-255] is the canonical bug. Issue [#256][issue-256]
+tracks the remaining per-inspector unit-test follow-up.
+
+[issue-255]: https://github.com/luthersystems/insideout-terraform-presets/issues/255
+[issue-256]: https://github.com/luthersystems/insideout-terraform-presets/issues/256
+
+## The two patterns that produce JSON `null`
+
+### Pattern A — uninitialized loop accumulator
+
+```go
+// BAD — emits JSON null when the loop body never runs:
+var collections []string
+for {
+    c, err := it.Next()
+    if err == iterator.Done { break }
+    if err != nil { return nil, err }
+    collections = append(collections, c.ID)
+}
+return collections, nil
+```
+
+When the iterator is empty, `collections` stays `nil`. `encoding/json`
+renders a nil slice as the JSON literal `null`.
+
+**Fix:** initialize the accumulator with an empty composite literal at
+the declaration site.
+
+```go
+// GOOD:
+collections := []string{}
+for { ... }
+return collections, nil
+```
+
+### Pattern B — direct SDK-slice passthrough
+
+```go
+// BAD — emits JSON null on empty:
+out, err := client.ListQueues(ctx, &sqs.ListQueuesInput{...})
+if err != nil { return nil, err }
+return out.QueueUrls, nil
+```
+
+AWS SDK V2 list-* responses commonly populate slice fields with typed-
+nil (`[]string(nil)`) when the upstream API returns zero items. Returning
+`out.QueueUrls` directly inherits the nil and JSON-marshals as `null`.
+
+**Fix:** wrap the passthrough in `nilSliceToEmpty` (in
+`pkg/observability/discovery/aws/helpers.go`):
+
+```go
+// GOOD:
+return nilSliceToEmpty(out.QueueUrls), nil
+```
+
+The helper is defined as:
+
+```go
+func nilSliceToEmpty[T any](s []T) []T {
+    if s == nil {
+        return []T{}
+    }
+    return s
+}
+```
+
+GCP inspectors don't generally hit Pattern B because the GCP SDKs use
+iterators that the inspector loops over locally — Pattern A applies
+there. But the rule is the same: any return path that could hold a nil
+slice must be normalized to non-nil at the boundary.
+
+### Pattern C — wrapped-in-parent
+
+```go
+// BAD — inner `null` collapses the same UI render gate:
+return map[string]any{
+    "billing_account": ...,
+    "budgets":         budgetList, // nil → "budgets": null
+}, nil
+```
+
+Apply Pattern A or B's fix to the inner field — declare `budgetList :=
+[]map[string]any{}`, or wrap with `nilSliceToEmpty` if it's a direct
+SDK-slice passthrough.
+
+## Helper choice cheat-sheet
+
+| Helper | When to use | File |
+|---|---|---|
+| `X := []T{}` at declaration | Local accumulator (Pattern A); GCP iterator loops | per-inspector |
+| `nilSliceToEmpty(out.X)` | Direct SDK-slice passthrough (Pattern B); AWS-V2 `ListXxx` results | `aws/helpers.go` |
+| `toSliceOfMaps(out.X)` | Round-trip typed slice → `[]map[string]any` for `filter.Match`; already null-safe post-#255 | `aws/helpers.go` |
+| `filter.Match(...)` | Project-tag filter on `[]map[string]any`; non-nil-empty on no-match (post-#255); nil-passthrough on nil input — keep upstream chained through `toSliceOfMaps` | `pkg/observability/filter` |
+
+## New-inspector checklist
+
+Before merging a new inspector:
+
+1. **Every return path** that has a slice shape — top-level OR wrapped in
+   a parent map/struct — uses one of the helpers above. No
+   `var X []T` followed by `append` and `return X, nil`. No
+   `return out.SliceField, nil` for AWS SDK V2 fields.
+2. **Add a unit test** for the empty-result path. Mutation-resistant pin:
+   ```go
+   require.NotNil(t, got)
+   b, _ := json.Marshal(got)
+   assert.Equal(t, "[]", string(b))
+   ```
+   `assert.Empty` alone is not sufficient — it accepts both nil and
+   empty slices.
+3. **Extend the live probes** in `live_probe_255_test.go` for the cloud
+   you're touching, with an entry for the new (service, action) pair.
+   Run with the `-tags=integration` build tag against a real account
+   before release.
+4. **Audit the audit:** if you ported a helper from the InsideOut backend
+   that returns a slice, check that helper's empty path too — the
+   original #255 audit missed Pattern B because it grepped only for
+   `var X []T`.
+
+## Pre-release verification
+
+```bash
+# GCP — set both vars; the Firestore one exercises the canonical bug:
+LIVE_GCP_PROJECT_ID=<project> \
+LIVE_GCP_FIRESTORE_DB=<db>    \
+  go test -tags=integration ./pkg/observability/discovery/gcp/... \
+    -v -run 'TestLive255|TestLive_InspectFirestore_NamedDB'
+
+# AWS — credentials in env (e.g. via aws_jump <account> <role>):
+go test -tags=integration ./pkg/observability/discovery/aws/... \
+    -v -run TestLive255_AWSInspectorsJSONShape
+```
+
+Both probes run with build tag `integration` so default CI (which has
+no cloud credentials) skips them. The probes auto-Skip on
+SERVICE_DISABLED / OptInRequired / unauthorized errors so partially-
+provisioned test projects produce a clean signal — only genuine
+contract violations turn a subtest red.

--- a/pkg/observability/discovery/aws/auth.go
+++ b/pkg/observability/discovery/aws/auth.go
@@ -54,7 +54,7 @@ func inspectCognito(ctx context.Context, cfg aws.Config, action, filters string)
 // Mirrors the InsideOut backend's filterCognitoUserPoolsByProjectTag
 // (aws_metrics.go:1405).
 func filterCognitoUserPoolsByProjectTag(ctx context.Context, client cognitoUserPoolsClient, project string) ([]cognitoidptypes.UserPoolDescriptionType, error) {
-	var all []cognitoidptypes.UserPoolDescriptionType
+	all := []cognitoidptypes.UserPoolDescriptionType{}
 	paginator := cognitoidentityprovider.NewListUserPoolsPaginator(client, &cognitoidentityprovider.ListUserPoolsInput{
 		// 60 is the ListUserPools MaxResults API max — minimises
 		// round-trips against Cognito's throttle ceiling.

--- a/pkg/observability/discovery/aws/cloudwatchlogs.go
+++ b/pkg/observability/discovery/aws/cloudwatchlogs.go
@@ -69,5 +69,5 @@ func describeProjectLogGroups(ctx context.Context, client cloudWatchLogsClient, 
 	if err != nil {
 		return nil, err
 	}
-	return out.LogGroups, nil
+	return nilSliceToEmpty(out.LogGroups), nil
 }

--- a/pkg/observability/discovery/aws/compute.go
+++ b/pkg/observability/discovery/aws/compute.go
@@ -145,7 +145,7 @@ func inspectLambda(ctx context.Context, cfg aws.Config, action, filters string) 
 //
 // Mirrors the InsideOut backend's filterLambdaFunctionsByProjectTag (aws_metrics.go:899).
 func filterLambdaFunctionsByProjectTag(ctx context.Context, client lambdaFunctionsClient, project string) ([]lambdatypes.FunctionConfiguration, error) {
-	var all []lambdatypes.FunctionConfiguration
+	all := []lambdatypes.FunctionConfiguration{}
 	paginator := lambda.NewListFunctionsPaginator(client, &lambda.ListFunctionsInput{})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
@@ -219,7 +219,7 @@ func filterECSClustersByProjectTag(ctx context.Context, client ecsClient, projec
 	if len(arns) == 0 {
 		return []ecstypes.Cluster{}, nil
 	}
-	var all []ecstypes.Cluster
+	all := []ecstypes.Cluster{}
 	for i := 0; i < len(arns); i += 100 {
 		end := i + 100
 		if end > len(arns) {
@@ -284,7 +284,7 @@ func describeECSServicesAcrossClusters(ctx context.Context, client ecsClient, pr
 	if err != nil {
 		return nil, err
 	}
-	var all []ecstypes.Service
+	all := []ecstypes.Service{}
 	for cluster, arns := range serviceArnsByCluster {
 		for i := 0; i < len(arns); i += 10 {
 			end := i + 10
@@ -389,7 +389,7 @@ func listEKSNodeInstances(ctx context.Context, eksClient eksClustersClient, ec2C
 		return nil, err
 	}
 	seen := make(map[string]struct{})
-	var instances []string
+	instances := []string{}
 	for _, cluster := range clusters {
 		filters := []ec2types.Filter{{
 			Name:   aws.String("tag:eks:cluster-name"),
@@ -430,7 +430,7 @@ func listEKSNodeInstances(ctx context.Context, eksClient eksClustersClient, ec2C
 //
 // Mirrors the InsideOut backend's filterEKSClustersByProjectTag (aws_metrics.go:1668).
 func filterEKSClustersByProjectTag(ctx context.Context, client eksClustersClient, project string) ([]string, error) {
-	var names []string
+	names := []string{}
 	paginator := eks.NewListClustersPaginator(client, &eks.ListClustersInput{})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
@@ -442,7 +442,7 @@ func filterEKSClustersByProjectTag(ctx context.Context, client eksClustersClient
 	if project == "" {
 		return names, nil
 	}
-	var matched []string
+	matched := []string{}
 	for _, name := range names {
 		descOut, descErr := client.DescribeCluster(ctx, &eks.DescribeClusterInput{Name: aws.String(name)})
 		if descErr != nil {

--- a/pkg/observability/discovery/aws/compute.go
+++ b/pkg/observability/discovery/aws/compute.go
@@ -53,7 +53,7 @@ func inspectEC2(ctx context.Context, cfg aws.Config, action, filters string) (an
 		if err != nil {
 			return nil, err
 		}
-		return out.Vpcs, nil
+		return nilSliceToEmpty(out.Vpcs), nil
 	case "describe-subnets":
 		input := &ec2.DescribeSubnetsInput{}
 		if len(tagFilters) > 0 {
@@ -63,7 +63,7 @@ func inspectEC2(ctx context.Context, cfg aws.Config, action, filters string) (an
 		if err != nil {
 			return nil, err
 		}
-		return out.Subnets, nil
+		return nilSliceToEmpty(out.Subnets), nil
 	case "describe-security-groups":
 		input := &ec2.DescribeSecurityGroupsInput{}
 		if len(tagFilters) > 0 {
@@ -73,7 +73,7 @@ func inspectEC2(ctx context.Context, cfg aws.Config, action, filters string) (an
 		if err != nil {
 			return nil, err
 		}
-		return out.SecurityGroups, nil
+		return nilSliceToEmpty(out.SecurityGroups), nil
 	case "get-metrics":
 		return metricsRouted("ec2")
 	default:
@@ -97,7 +97,7 @@ func inspectEBS(ctx context.Context, cfg aws.Config, action, filters string) (an
 		if err != nil {
 			return nil, err
 		}
-		return out.Volumes, nil
+		return nilSliceToEmpty(out.Volumes), nil
 	case "describe-snapshots":
 		// "self" excludes the millions of public/AWS-owned snapshots —
 		// without this the call times out before pagination starts.
@@ -109,7 +109,7 @@ func inspectEBS(ctx context.Context, cfg aws.Config, action, filters string) (an
 		if err != nil {
 			return nil, err
 		}
-		return out.Snapshots, nil
+		return nilSliceToEmpty(out.Snapshots), nil
 	default:
 		return nil, unsupportedActionError("ebs", action)
 	}

--- a/pkg/observability/discovery/aws/connect_info.go
+++ b/pkg/observability/discovery/aws/connect_info.go
@@ -30,7 +30,7 @@ func enrichEC2WithConnectURLs(region string, reservations []ec2types.Reservation
 	if err != nil {
 		return reservations
 	}
-	var enriched []map[string]any
+	enriched := []map[string]any{}
 	if err := json.Unmarshal(raw, &enriched); err != nil {
 		return reservations
 	}

--- a/pkg/observability/discovery/aws/costexplorer.go
+++ b/pkg/observability/discovery/aws/costexplorer.go
@@ -125,7 +125,7 @@ func inspectCostExplorerWithDeps(ctx context.Context, client CostExplorerAPI, ac
 			Service string `json:"service"`
 			Cost    string `json:"cost"`
 		}
-		var sorted []serviceCostEntry
+		sorted := []serviceCostEntry{}
 		for svc, cost := range serviceCosts {
 			sorted = append(sorted, serviceCostEntry{Service: svc, Cost: formatUSD(fmt.Sprintf("%f", cost))})
 		}
@@ -270,7 +270,7 @@ func inspectCostExplorerWithDeps(ctx context.Context, client CostExplorerAPI, ac
 			TagValue string `json:"tag_value"`
 			Cost     string `json:"cost"`
 		}
-		var sorted []tagCostEntry
+		sorted := []tagCostEntry{}
 		for tag, cost := range tagCosts {
 			sorted = append(sorted, tagCostEntry{TagValue: tag, Cost: formatUSD(fmt.Sprintf("%f", cost))})
 		}

--- a/pkg/observability/discovery/aws/data.go
+++ b/pkg/observability/discovery/aws/data.go
@@ -50,7 +50,7 @@ func inspectRDS(ctx context.Context, cfg aws.Config, action, filters string) (an
 		if project != "" {
 			return filter.Match(toSliceOfMaps(out.DBInstances), project, "TagList", filter.FormatKV), nil
 		}
-		return out.DBInstances, nil
+		return nilSliceToEmpty(out.DBInstances), nil
 	case "describe-db-clusters":
 		out, err := client.DescribeDBClusters(ctx, &rds.DescribeDBClustersInput{})
 		if err != nil {
@@ -59,7 +59,7 @@ func inspectRDS(ctx context.Context, cfg aws.Config, action, filters string) (an
 		if project != "" {
 			return filter.Match(toSliceOfMaps(out.DBClusters), project, "TagList", filter.FormatKV), nil
 		}
-		return out.DBClusters, nil
+		return nilSliceToEmpty(out.DBClusters), nil
 	case "get-metrics":
 		return metricsRouted("rds")
 	default:
@@ -277,7 +277,7 @@ func inspectOpenSearch(ctx context.Context, cfg aws.Config, action, filters stri
 		if err != nil {
 			return nil, err
 		}
-		return out.DomainNames, nil
+		return nilSliceToEmpty(out.DomainNames), nil
 	case "describe-domains":
 		// Union discovery: the `aws_opensearch` preset can deploy as
 		// Managed OR Serverless on a single schema node. When a user
@@ -443,7 +443,7 @@ func inspectMSK(ctx context.Context, cfg aws.Config, action, filters string) (an
 		if project != "" {
 			return filter.Match(toSliceOfMaps(out.ClusterInfoList), project, "Tags", filter.FormatMap), nil
 		}
-		return out.ClusterInfoList, nil
+		return nilSliceToEmpty(out.ClusterInfoList), nil
 	case "get-metrics":
 		return metricsRouted("msk")
 	default:

--- a/pkg/observability/discovery/aws/data.go
+++ b/pkg/observability/discovery/aws/data.go
@@ -110,7 +110,7 @@ func inspectDynamoDB(ctx context.Context, cfg aws.Config, action, filters string
 //
 // Mirrors the InsideOut backend's filterDynamoDBTablesByProjectTag (aws_metrics.go:1323).
 func filterDynamoDBTablesByProjectTag(ctx context.Context, client dynamoDBTablesClient, stsClient stsAccountClient, region, project string) ([]string, error) {
-	var all []string
+	all := []string{}
 	paginator := dynamodb.NewListTablesPaginator(client, &dynamodb.ListTablesInput{})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
@@ -174,7 +174,7 @@ func filterElastiCacheCacheClustersByProjectTag(ctx context.Context, client elas
 	return filterElastiCacheByProjectTag(
 		ctx, client, project, "DescribeCacheClusters",
 		func(ctx context.Context) ([]elasticachetypes.CacheCluster, error) {
-			var all []elasticachetypes.CacheCluster
+			all := []elasticachetypes.CacheCluster{}
 			p := elasticache.NewDescribeCacheClustersPaginator(client, &elasticache.DescribeCacheClustersInput{})
 			for p.HasMorePages() {
 				page, err := p.NextPage(ctx)
@@ -193,7 +193,7 @@ func filterElastiCacheReplicationGroupsByProjectTag(ctx context.Context, client 
 	return filterElastiCacheByProjectTag(
 		ctx, client, project, "DescribeReplicationGroups",
 		func(ctx context.Context) ([]elasticachetypes.ReplicationGroup, error) {
-			var all []elasticachetypes.ReplicationGroup
+			all := []elasticachetypes.ReplicationGroup{}
 			p := elasticache.NewDescribeReplicationGroupsPaginator(client, &elasticache.DescribeReplicationGroupsInput{})
 			for p.HasMorePages() {
 				page, err := p.NextPage(ctx)

--- a/pkg/observability/discovery/aws/helpers.go
+++ b/pkg/observability/discovery/aws/helpers.go
@@ -91,3 +91,29 @@ func firstNonEmptyString(s ...string) string {
 	}
 	return ""
 }
+
+// nilSliceToEmpty returns []T{} when s is nil so the JSON wire shape
+// is `[]` not `null` (#255). AWS SDK V2 list-* responses commonly
+// emit typed-nil slices on empty results — a discovery inspector that
+// returns `out.SomeSliceField` directly inherits that nil and json.
+// Marshal renders it as the JSON literal `null`, which the downstream
+// reliable UI gates the panel render on.
+//
+// Wrap every direct SDK-slice passthrough at the inspector boundary:
+//
+//	// Bad — emits JSON null on empty:
+//	return out.QueueUrls, nil
+//
+//	// Good:
+//	return nilSliceToEmpty(out.QueueUrls), nil
+//
+// Loops that build a slice locally should declare it as `X := []T{}`
+// at construction so the nil case never arises (the per-site fix in
+// the original #255 audit). Use this helper when the loop is owned
+// by the AWS SDK and you can't change the construction.
+func nilSliceToEmpty[T any](s []T) []T {
+	if s == nil {
+		return []T{}
+	}
+	return s
+}

--- a/pkg/observability/discovery/aws/helpers.go
+++ b/pkg/observability/discovery/aws/helpers.go
@@ -28,7 +28,7 @@ func toSliceOfMaps(v any) []map[string]any {
 	if err != nil {
 		return nil
 	}
-	var out []map[string]any
+	out := []map[string]any{}
 	if err := json.Unmarshal(raw, &out); err != nil {
 		return nil
 	}

--- a/pkg/observability/discovery/aws/helpers.go
+++ b/pkg/observability/discovery/aws/helpers.go
@@ -18,9 +18,16 @@ import (
 // []map[string]any shape the filter package operates on. Used when an
 // SDK response carries typed structs but the project-tag check needs the
 // reflected map form (filter.Match's tagFieldName lookup works on any
-// JSON-shaped record). Returns nil on marshal/unmarshal failure rather
-// than panicking — callers treat nil as "no records" which yields an
-// empty-but-clean response.
+// JSON-shaped record).
+//
+// Always returns a non-nil slice on the success path so downstream
+// JSON marshaling emits `[]` not `null` (#255). AWS SDK V2 list
+// responses expose empty results as typed-nil slices like
+// `[]bedrockagenttypes.KnowledgeBaseSummary(nil)`, which json.Marshal
+// renders as the JSON literal `null`; unmarshaling that back into
+// `out` would leave it nil, so we restore an empty slice before
+// returning. Returns nil only on marshal/unmarshal failure
+// (fail-closed for shape mismatches).
 //
 // Mirrors the InsideOut backend's toSliceOfMaps (config_extractors.go:172).
 func toSliceOfMaps(v any) []map[string]any {
@@ -31,6 +38,9 @@ func toSliceOfMaps(v any) []map[string]any {
 	out := []map[string]any{}
 	if err := json.Unmarshal(raw, &out); err != nil {
 		return nil
+	}
+	if out == nil {
+		return []map[string]any{}
 	}
 	return out
 }

--- a/pkg/observability/discovery/aws/helpers_test.go
+++ b/pkg/observability/discovery/aws/helpers_test.go
@@ -71,3 +71,45 @@ func TestToSliceOfMaps_UnmarshalFailure_ReturnsNil(t *testing.T) {
 	out := toSliceOfMaps(struct{ X int }{X: 1})
 	assert.Nil(t, out, "shape mismatch must surface as nil (fail-closed)")
 }
+
+// TestNilSliceToEmpty pins the #255 Pattern B fix: AWS SDK V2 list-*
+// responses commonly populate slice fields with typed-nil on empty
+// results. The helper normalizes that nil to []T{} so json.Marshal
+// emits `[]` instead of `null`.
+func TestNilSliceToEmpty(t *testing.T) {
+	t.Parallel()
+
+	t.Run("typed nil []string → non-nil []string{}", func(t *testing.T) {
+		t.Parallel()
+		var in []string
+		got := nilSliceToEmpty(in)
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+		b, err := json.Marshal(got)
+		require.NoError(t, err)
+		assert.Equal(t, "[]", string(b))
+	})
+	t.Run("typed nil []int → non-nil []int{}", func(t *testing.T) {
+		t.Parallel()
+		var in []int
+		got := nilSliceToEmpty(in)
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+		b, err := json.Marshal(got)
+		require.NoError(t, err)
+		assert.Equal(t, "[]", string(b))
+	})
+	t.Run("non-nil empty slice → returned unchanged", func(t *testing.T) {
+		t.Parallel()
+		in := []string{}
+		got := nilSliceToEmpty(in)
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+	t.Run("non-empty slice → returned unchanged", func(t *testing.T) {
+		t.Parallel()
+		in := []string{"a", "b"}
+		got := nilSliceToEmpty(in)
+		assert.Equal(t, []string{"a", "b"}, got)
+	})
+}

--- a/pkg/observability/discovery/aws/helpers_test.go
+++ b/pkg/observability/discovery/aws/helpers_test.go
@@ -1,0 +1,66 @@
+package aws
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToSliceOfMaps_EmptyInput_NotNull pins the #255 contract: a successful
+// empty round-trip yields []map[string]any{} (non-nil) so the JSON wire
+// shape is `[]`, not `null`. This helper is the consolidating fix for the
+// Bedrock list-knowledge-bases / list-agents / list-guardrails callers
+// that previously returned nil top-level slices and surfaced as the
+// reliable UI's "Deploy infrastructure first." fallback.
+func TestToSliceOfMaps_EmptyInput_NotNull(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   any
+	}{
+		{"empty []any", []any{}},
+		{"empty []map[string]any", []map[string]any{}},
+		{"typed empty []string", []string{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := toSliceOfMaps(tc.in)
+			require.NotNil(t, out, "empty input must round-trip to non-nil []")
+			assert.Empty(t, out)
+			b, err := json.Marshal(out)
+			require.NoError(t, err)
+			assert.Equal(t, "[]", string(b),
+				"toSliceOfMaps must marshal empty result as [] not null (#255)")
+		})
+	}
+}
+
+// TestToSliceOfMaps_NilInput preserves the historical fail-closed shape:
+// json.Marshal(nil) -> "null" -> Unmarshal into []map[string]any produces
+// nil. The helper signals upstream-error / unmarshalable shape via nil so
+// callers can differentiate "no records" (success path, post-#255 returns
+// []) from "shape mismatch" (returns nil).
+func TestToSliceOfMaps_NilInput(t *testing.T) {
+	t.Parallel()
+	out := toSliceOfMaps(nil)
+	assert.Nil(t, out, "nil input continues to surface as nil (fail-closed)")
+}
+
+// TestToSliceOfMaps_RoundTripsRecords sanity-checks the success path with
+// real records — guards against regressions to the json round-trip.
+func TestToSliceOfMaps_RoundTripsRecords(t *testing.T) {
+	t.Parallel()
+	type rec struct {
+		Name string `json:"Name"`
+		ARN  string `json:"Arn"`
+	}
+	in := []rec{{Name: "a", ARN: "arn:a"}, {Name: "b", ARN: "arn:b"}}
+	out := toSliceOfMaps(in)
+	require.Len(t, out, 2)
+	assert.Equal(t, "a", out[0]["Name"])
+	assert.Equal(t, "arn:b", out[1]["Arn"])
+}

--- a/pkg/observability/discovery/aws/helpers_test.go
+++ b/pkg/observability/discovery/aws/helpers_test.go
@@ -8,12 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestToSliceOfMaps_EmptyInput_NotNull pins the #255 contract: a successful
-// empty round-trip yields []map[string]any{} (non-nil) so the JSON wire
-// shape is `[]`, not `null`. This helper is the consolidating fix for the
-// Bedrock list-knowledge-bases / list-agents / list-guardrails callers
-// that previously returned nil top-level slices and surfaced as the
-// reliable UI's "Deploy infrastructure first." fallback.
+// TestToSliceOfMaps_EmptyInput_NotNull pins the #255 contract: empty +
+// nil-slice inputs round-trip to []map[string]any{} (non-nil) so the JSON
+// wire shape is `[]`, not `null`. AWS SDK V2 list responses commonly
+// expose empty results as typed-nil slices (e.g.
+// `bedrockagent.ListKnowledgeBasesOutput.KnowledgeBaseSummaries == nil`)
+// — the post-Unmarshal restoration in toSliceOfMaps catches that case.
+// This helper is the consolidating fix for the Bedrock
+// list-knowledge-bases / list-agents / list-guardrails callers that
+// previously returned nil top-level slices and surfaced as the reliable
+// UI's "Deploy infrastructure first." fallback.
 func TestToSliceOfMaps_EmptyInput_NotNull(t *testing.T) {
 	t.Parallel()
 
@@ -21,15 +25,18 @@ func TestToSliceOfMaps_EmptyInput_NotNull(t *testing.T) {
 		name string
 		in   any
 	}{
+		{"untyped nil", nil},
 		{"empty []any", []any{}},
 		{"empty []map[string]any", []map[string]any{}},
 		{"typed empty []string", []string{}},
+		{"typed nil []string", []string(nil)},
+		{"typed nil []map[string]any", []map[string]any(nil)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			out := toSliceOfMaps(tc.in)
-			require.NotNil(t, out, "empty input must round-trip to non-nil []")
+			require.NotNil(t, out, "empty/nil input must round-trip to non-nil []")
 			assert.Empty(t, out)
 			b, err := json.Marshal(out)
 			require.NoError(t, err)
@@ -37,17 +44,6 @@ func TestToSliceOfMaps_EmptyInput_NotNull(t *testing.T) {
 				"toSliceOfMaps must marshal empty result as [] not null (#255)")
 		})
 	}
-}
-
-// TestToSliceOfMaps_NilInput preserves the historical fail-closed shape:
-// json.Marshal(nil) -> "null" -> Unmarshal into []map[string]any produces
-// nil. The helper signals upstream-error / unmarshalable shape via nil so
-// callers can differentiate "no records" (success path, post-#255 returns
-// []) from "shape mismatch" (returns nil).
-func TestToSliceOfMaps_NilInput(t *testing.T) {
-	t.Parallel()
-	out := toSliceOfMaps(nil)
-	assert.Nil(t, out, "nil input continues to surface as nil (fail-closed)")
 }
 
 // TestToSliceOfMaps_RoundTripsRecords sanity-checks the success path with
@@ -63,4 +59,15 @@ func TestToSliceOfMaps_RoundTripsRecords(t *testing.T) {
 	require.Len(t, out, 2)
 	assert.Equal(t, "a", out[0]["Name"])
 	assert.Equal(t, "arn:b", out[1]["Arn"])
+}
+
+// TestToSliceOfMaps_UnmarshalFailure_ReturnsNil pins the documented
+// fail-closed contract: a value that marshals to a JSON object (not an
+// array) cannot be unmarshaled into []map[string]any, and the helper
+// surfaces the shape mismatch as nil rather than [] so callers can
+// distinguish "no records" from "shape error".
+func TestToSliceOfMaps_UnmarshalFailure_ReturnsNil(t *testing.T) {
+	t.Parallel()
+	out := toSliceOfMaps(struct{ X int }{X: 1})
+	assert.Nil(t, out, "shape mismatch must surface as nil (fail-closed)")
 }

--- a/pkg/observability/discovery/aws/live_probe_255_test.go
+++ b/pkg/observability/discovery/aws/live_probe_255_test.go
@@ -1,0 +1,230 @@
+//go:build integration
+
+// One-shot live probe for #255 (AWS side). Hits every AWS inspector
+// action that returns a slice (or wraps one) against a real account
+// and asserts the JSON wire shape is a JSON array (`[…]` / `[]`),
+// never `null`. Pre-fix, the empty-result paths emitted JSON null;
+// post-fix they emit `[]`.
+//
+// Run:
+//
+//	# from a shell where AWS creds are loaded (e.g. aws_jump <acct> <role>):
+//	go test -tags=integration ./pkg/observability/discovery/aws/... \
+//	    -v -run TestLive255_AWSInspectorsJSONShape
+//
+// Calibration: filters are scoped to a project name guaranteed not to
+// match anything (`__live-probe-#255__`) so each inspector exercises
+// the empty-result path that #255 fixed. A handful of services that
+// don't honor server-side project filters return non-empty arrays;
+// either is acceptable — what matters is the wire shape never being
+// `null`.
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	smithy "github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/observability"
+)
+
+func TestLive255_AWSInspectorsJSONShape(t *testing.T) {
+	t.Parallel()
+	cfg := loadOrSkip(t)
+	ctx := context.Background()
+	// Project name guaranteed not to match anything. Restricted to
+	// alphanumeric+dash because Secrets Manager / Backup vault filters
+	// reject `#`, `_`, etc.
+	const noMatchProject = "live-probe-issue-255-no-match"
+	projectFilter := `{"project":"` + noMatchProject + `"}`
+
+	// (service, action) pairs that return slices / wrap them. Pulled
+	// from the issue #255 audit table — every site with a top-level or
+	// wrapped-in-parent slice return that the per-site fix touched.
+	// Probe each service in TWO configurations:
+	//   - with project filter (exercises post-filter / server-side
+	//     filtered paths)
+	//   - WITHOUT a project filter (exercises the no-project early-
+	//     return paths that pass `out.SliceField` straight through —
+	//     AWS SDK V2 emits typed-nil there on empty)
+	type probe struct {
+		service string
+		action  string
+		filters string
+		variant string
+	}
+	mk := func(svc, act string) []probe {
+		return []probe{
+			{svc, act, projectFilter, "filtered"},
+			{svc, act, "", "unfiltered"},
+		}
+	}
+
+	var probes []probe
+	for _, pair := range [][2]string{
+		// Direct top-level slice returns.
+		{"ec2", "describe-instances"},
+		{"lambda", "list-functions"},
+		{"ecs", "list-clusters"},
+		{"ecs", "list-services"},
+		{"ecs", "describe-services"},
+		{"eks", "list-clusters"},
+		{"eks", "list-nodes"},
+		{"dynamodb", "list-tables"},
+		{"elasticache", "describe-cache-clusters"},
+		{"elasticache", "describe-replication-groups"},
+		{"cloudfront", "list-distributions"},
+		{"kms", "list-keys"},
+		{"kms", "list-aliases"},
+		{"backup", "list-backup-vaults"},
+		{"cognito", "list-user-pools"},
+		{"rds", "describe-db-instances"},
+		{"rds", "describe-db-clusters"},
+		{"msk", "list-clusters"},
+		{"alb", "describe-load-balancers"},
+		{"apigateway", "get-apis"},
+		{"apigateway", "get-domain-names"},
+		{"bedrock", "list-knowledge-bases"},
+		{"bedrock", "list-agents"},
+		{"bedrock", "list-guardrails"},
+		{"s3", "list-buckets"},
+		{"vpc", "describe-nat-gateways"},
+		{"secretsmanager", "list-secrets"},
+		{"sqs", "list-queues"},
+		{"opensearch", "list-domains"},
+		{"cloudwatchlogs", "describe-log-groups"},
+		{"waf", "list-web-acls"},
+		{"ec2", "describe-vpcs"},
+		{"ec2", "describe-subnets"},
+		{"ec2", "describe-security-groups"},
+		{"ebs", "describe-volumes"},
+		{"ebs", "describe-snapshots"},
+	} {
+		probes = append(probes, mk(pair[0], pair[1])...)
+	}
+
+	// Wrapped-in-parent (cost-explorer) — needs a days/granularity
+	// envelope; project filter is optional.
+	probes = append(probes, []probe{
+		{"cost-explorer", "get-cost-summary",
+			`{"project":"` + noMatchProject + `","days":7,"granularity":"DAILY"}`, "filtered"},
+		{"cost-explorer", "get-cost-summary",
+			`{"days":7,"granularity":"DAILY"}`, "unfiltered"},
+		{"cost-explorer", "get-cost-by-tag",
+			`{"project":"` + noMatchProject + `","tag_key":"Project","days":7}`, "filtered"},
+		{"cost-explorer", "get-cost-by-tag",
+			`{"tag_key":"Project","days":7}`, "unfiltered"},
+	}...)
+
+	for _, p := range probes {
+		name := p.service + "/" + p.action + "/" + p.variant
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Inspect(ctx, cfg, p.service, p.action, p.filters)
+			if err != nil {
+				if isAWSEnvSkip(err) {
+					t.Skipf("environmental — %s: %v", classifyAWSErr(err),
+						truncate(err.Error(), 200))
+					return
+				}
+				t.Errorf("inspector errored: %v", err)
+				return
+			}
+			b, err := json.Marshal(got)
+			if err != nil {
+				t.Errorf("json.Marshal: %v", err)
+				return
+			}
+			s := string(b)
+			t.Logf("JSON wire (%d bytes): %s", len(s), truncate(s, 240))
+
+			assert.NotEqual(t, "null", s,
+				"#255 regression: empty-result JSON null on %s; expected JSON array", name)
+			if strings.HasPrefix(s, "{") {
+				// Wrapped-in-parent shape (cost-explorer): scan for
+				// `:null` on inner slice fields.
+				assert.NotContains(t, s, `:null`,
+					"#255 regression: inner slice null in %s", name)
+			} else {
+				assert.True(t, strings.HasPrefix(s, "["),
+					"expected JSON array prefix on %s; got: %s",
+					name, truncate(s, 80))
+			}
+		})
+	}
+}
+
+// isAWSEnvSkip returns true when the error indicates an environmental
+// limitation (region not subscribed, opt-in required, service not
+// available) rather than a code-level bug. We Skip these so the
+// suite can run cleanly against any AWS account.
+func isAWSEnvSkip(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "OptInRequired",
+			"UnauthorizedOperation",
+			"AccessDeniedException",
+			"AccessDenied",
+			"InvalidClientTokenId",
+			"AuthFailure",
+			"UnrecognizedClientException",
+			"UnsupportedOperation",
+			"ServiceUnavailableException",
+			"ServiceUnavailable",
+			"InvalidAction":
+			return true
+		}
+	}
+	// String-match fallbacks for SDK errors that don't surface the
+	// canonical code on the smithy.APIError interface.
+	s := err.Error()
+	for _, sub := range []string{
+		"is not subscribed to AWS",
+		"opted in",
+		"is not authorized to perform",
+		"could not be found",
+		"DataUnavailable",
+		"is not enabled in this region",
+		"region is disabled",
+	} {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyAWSErr returns a short label for the t.Skipf line — purely
+// for log-readability when scanning a probe run.
+func classifyAWSErr(err error) string {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode()
+	}
+	return "non-API error"
+}
+
+// (truncate lives in the GCP probe; we redeclare here so this file is
+// self-contained — the AWS package is separate.)
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...(truncated)"
+}
+
+// Compile-time check: Inspect's signature is what we depend on.
+var _ = func() any {
+	_ = observability.AWSServiceActions
+	return nil
+}

--- a/pkg/observability/discovery/aws/network.go
+++ b/pkg/observability/discovery/aws/network.go
@@ -351,7 +351,7 @@ func inspectCloudFront(ctx context.Context, cfg aws.Config, action, filters stri
 // Mirrors the InsideOut backend's filterCloudFrontDistributionsByProjectTag
 // (aws_metrics.go:1077).
 func filterCloudFrontDistributionsByProjectTag(ctx context.Context, client cloudFrontDistributionsClient, project string) ([]cloudfronttypes.DistributionSummary, error) {
-	var all []cloudfronttypes.DistributionSummary
+	all := []cloudfronttypes.DistributionSummary{}
 	var marker *string
 	for {
 		out, err := client.ListDistributions(ctx, &cloudfront.ListDistributionsInput{Marker: marker})

--- a/pkg/observability/discovery/aws/network.go
+++ b/pkg/observability/discovery/aws/network.go
@@ -70,7 +70,7 @@ func inspectVPC(ctx context.Context, cfg aws.Config, action, filters string) (an
 		if err != nil {
 			return nil, err
 		}
-		return out.NatGateways, nil
+		return nilSliceToEmpty(out.NatGateways), nil
 	case "describe-vpcs":
 		// Enrich with IGW attachments so extractVPCConfig can report
 		// deploymentType=public|private without a second inspector
@@ -196,7 +196,7 @@ func inspectALB(ctx context.Context, cfg aws.Config, action, filters string) (an
 			}
 			return filtered, nil
 		}
-		return out.LoadBalancers, nil
+		return nilSliceToEmpty(out.LoadBalancers), nil
 	case "get-metrics":
 		return metricsRouted("alb")
 	default:
@@ -290,7 +290,7 @@ func filterWAFWebACLsByScope(ctx context.Context, client wafv2WebACLsClient, sco
 		return nil, fmt.Errorf("wafv2 ListWebACLs scope=%s: %w", scope, err)
 	}
 	if project == "" {
-		return out.WebACLs, nil
+		return nilSliceToEmpty(out.WebACLs), nil
 	}
 	matched := make([]wafv2types.WebACLSummary, 0, len(out.WebACLs))
 	for _, w := range out.WebACLs {
@@ -410,7 +410,7 @@ func inspectAPIGateway(ctx context.Context, cfg aws.Config, action, filters stri
 		if project != "" {
 			return filter.Match(toSliceOfMaps(out.Items), project, "Tags", filter.FormatMap), nil
 		}
-		return out.Items, nil
+		return nilSliceToEmpty(out.Items), nil
 	case "get-domain-names":
 		out, err := client.GetDomainNames(ctx, &apigatewayv2.GetDomainNamesInput{})
 		if err != nil {
@@ -419,7 +419,7 @@ func inspectAPIGateway(ctx context.Context, cfg aws.Config, action, filters stri
 		if project != "" {
 			return filter.Match(toSliceOfMaps(out.Items), project, "Tags", filter.FormatMap), nil
 		}
-		return out.Items, nil
+		return nilSliceToEmpty(out.Items), nil
 	case "get-metrics":
 		return metricsRouted("apigateway")
 	default:

--- a/pkg/observability/discovery/aws/storage.go
+++ b/pkg/observability/discovery/aws/storage.go
@@ -94,7 +94,7 @@ func filterS3BucketsByProjectTag(ctx context.Context, client s3BucketsClient, pr
 		return nil, fmt.Errorf("s3 ListBuckets: %w", err)
 	}
 	if project == "" {
-		return out.Buckets, nil
+		return nilSliceToEmpty(out.Buckets), nil
 	}
 	matched := make([]s3types.Bucket, 0, len(out.Buckets))
 	for _, b := range out.Buckets {
@@ -142,7 +142,7 @@ func inspectSecretsManager(ctx context.Context, cfg aws.Config, action, filters 
 		if err != nil {
 			return nil, err
 		}
-		return out.SecretList, nil
+		return nilSliceToEmpty(out.SecretList), nil
 	case "get-metrics":
 		return metricsRouted("secretsmanager")
 	default:
@@ -340,7 +340,7 @@ func inspectSQS(ctx context.Context, cfg aws.Config, action, filters string) (an
 		if err != nil {
 			return nil, err
 		}
-		return out.QueueUrls, nil
+		return nilSliceToEmpty(out.QueueUrls), nil
 	case "get-metrics":
 		return metricsRouted("sqs")
 	default:

--- a/pkg/observability/discovery/aws/storage.go
+++ b/pkg/observability/discovery/aws/storage.go
@@ -225,7 +225,7 @@ func kmsKeyOwnedByProject(ctx context.Context, client kmsKeysClient, keyID, proj
 //
 // Mirrors the InsideOut backend's filterKMSAliasesByProjectTag (aws_metrics.go:198).
 func filterKMSAliasesByProjectTag(ctx context.Context, client kmsKeysClient, project string) ([]kmstypes.AliasListEntry, error) {
-	var all []kmstypes.AliasListEntry
+	all := []kmstypes.AliasListEntry{}
 	paginator := kms.NewListAliasesPaginator(client, &kms.ListAliasesInput{})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
@@ -294,7 +294,7 @@ func inspectBackup(ctx context.Context, cfg aws.Config, action, filters string) 
 //
 // Mirrors the InsideOut backend's filterBackupVaultsByProjectTag (aws_metrics.go:845).
 func filterBackupVaultsByProjectTag(ctx context.Context, client backupVaultsClient, project string) ([]backuptypes.BackupVaultListMember, error) {
-	var all []backuptypes.BackupVaultListMember
+	all := []backuptypes.BackupVaultListMember{}
 	paginator := backup.NewListBackupVaultsPaginator(client, &backup.ListBackupVaultsInput{})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)

--- a/pkg/observability/discovery/doc.go
+++ b/pkg/observability/discovery/doc.go
@@ -1,0 +1,11 @@
+// Package discovery hosts the AWS- and GCP-side resource enumeration
+// inspectors used by the observability panel and drift detector.
+//
+// Empty-result contract (#255):
+//
+// Every slice-shaped return MUST marshal as a JSON array (`[]` or
+// `[…]`), never JSON `null`. See CONTRIBUTING.md in this directory for
+// the two patterns (uninitialized loop accumulator; direct SDK-slice
+// passthrough), the new-inspector checklist, and the pre-release live
+// probes (TestLive255_*) that pin the contract end-to-end.
+package discovery

--- a/pkg/observability/discovery/gcp/ai.go
+++ b/pkg/observability/discovery/gcp/ai.go
@@ -110,7 +110,7 @@ func inspectVertexAI(ctx context.Context, projectID, action, filters string, opt
 			req.Filter = projectFilter
 		}
 		it := client.ListDatasets(ctx, req)
-		var datasets []*aiplatformpb.Dataset
+		datasets := []*aiplatformpb.Dataset{}
 		for {
 			ds, err := it.Next()
 			if err == iterator.Done {
@@ -136,7 +136,7 @@ func inspectVertexAI(ctx context.Context, projectID, action, filters string, opt
 			req.Filter = projectFilter
 		}
 		it := client.ListEndpoints(ctx, req)
-		var endpoints []*aiplatformpb.Endpoint
+		endpoints := []*aiplatformpb.Endpoint{}
 		for {
 			ep, err := it.Next()
 			if err == iterator.Done {
@@ -162,7 +162,7 @@ func inspectVertexAI(ctx context.Context, projectID, action, filters string, opt
 			req.Filter = projectFilter
 		}
 		it := client.ListModels(ctx, req)
-		var models []*aiplatformpb.Model
+		models := []*aiplatformpb.Model{}
 		for {
 			m, err := it.Next()
 			if err == iterator.Done {

--- a/pkg/observability/discovery/gcp/app.go
+++ b/pkg/observability/discovery/gcp/app.go
@@ -52,7 +52,7 @@ func inspectCloudRun(ctx context.Context, projectID, action, filters string, opt
 			Parent: fmt.Sprintf("projects/%s/locations/-", projectID),
 		})
 		project := projectFromFilters(filters)
-		var services []*runpb.Service
+		services := []*runpb.Service{}
 		for {
 			svc, err := it.Next()
 			if err == iterator.Done {
@@ -101,7 +101,7 @@ func inspectCloudFunctions(ctx context.Context, projectID, action, filters strin
 			req.Filter = f
 		}
 		it := client.ListFunctions(ctx, req)
-		var fns []*functionspb.Function
+		fns := []*functionspb.Function{}
 		for {
 			fn, err := it.Next()
 			if err == iterator.Done {
@@ -136,7 +136,7 @@ func inspectCloudBuild(ctx context.Context, projectID, action, _ string, opts ..
 		it := client.ListBuildTriggers(ctx, &cloudbuildpb.ListBuildTriggersRequest{
 			ProjectId: projectID,
 		})
-		var triggers []*cloudbuildpb.BuildTrigger
+		triggers := []*cloudbuildpb.BuildTrigger{}
 		for {
 			tr, err := it.Next()
 			if err == iterator.Done {
@@ -153,7 +153,7 @@ func inspectCloudBuild(ctx context.Context, projectID, action, _ string, opts ..
 		it := client.ListBuilds(ctx, &cloudbuildpb.ListBuildsRequest{
 			ProjectId: projectID,
 		})
-		var builds []*cloudbuildpb.Build
+		builds := []*cloudbuildpb.Build{}
 		truncated := false
 		for range cloudBuildMaxBuilds {
 			b, err := it.Next()

--- a/pkg/observability/discovery/gcp/billing.go
+++ b/pkg/observability/discovery/gcp/billing.go
@@ -122,7 +122,7 @@ func inspectBillingWithDeps(ctx context.Context, billingClient gcpBillingAPI, bu
 			Scope:  fmt.Sprintf("projects/%s", projectID),
 		})
 
-		var budgetList []map[string]any
+		budgetList := []map[string]any{}
 		for {
 			b, err := it.Next()
 			if err == iterator.Done {

--- a/pkg/observability/discovery/gcp/compute.go
+++ b/pkg/observability/discovery/gcp/compute.go
@@ -55,7 +55,7 @@ func inspectCompute(ctx context.Context, projectID, action, filters string, opts
 		}
 
 		it := client.AggregatedList(ctx, req)
-		var instances []*computepb.Instance
+		instances := []*computepb.Instance{}
 		for {
 			pair, err := it.Next()
 			if err == iterator.Done {
@@ -116,7 +116,7 @@ func inspectGKE(ctx context.Context, projectID, action, filters string, opts ...
 		if project == "" {
 			return resp.Clusters, nil
 		}
-		var clusters []*containerpb.Cluster
+		clusters := []*containerpb.Cluster{}
 		for _, c := range resp.Clusters {
 			if gcpLabelMatches(c.GetResourceLabels(), "project", project) {
 				clusters = append(clusters, c)
@@ -170,7 +170,7 @@ func inspectBastion(ctx context.Context, projectID, action, filters string, opts
 			Project: projectID,
 			Filter:  proto.String(filterStr),
 		})
-		var instances []*computepb.Instance
+		instances := []*computepb.Instance{}
 		for {
 			pair, err := it.Next()
 			if err == iterator.Done {

--- a/pkg/observability/discovery/gcp/data.go
+++ b/pkg/observability/discovery/gcp/data.go
@@ -59,7 +59,7 @@ func inspectCloudSQL(ctx context.Context, projectID, action, filters string, opt
 		if project == "" {
 			return resp.Items, nil
 		}
-		var items []*sqladmin.DatabaseInstance
+		items := []*sqladmin.DatabaseInstance{}
 		for _, inst := range resp.Items {
 			if inst.Settings == nil {
 				continue
@@ -100,7 +100,7 @@ func inspectMemorystore(ctx context.Context, projectID, action, filters string, 
 		// ListInstances has no server-side label filter; post-filter
 		// on Instance.Labels.
 		project := projectFromFilters(filters)
-		var instances []*redispb.Instance
+		instances := []*redispb.Instance{}
 		for {
 			inst, err := it.Next()
 			if err == iterator.Done {
@@ -168,23 +168,38 @@ func inspectFirestore(ctx context.Context, projectID, action, filters string, op
 
 	switch action {
 	case "list-collections":
-		it := client.Collections(ctx)
-		var collections []string
-		for {
-			c, err := it.Next()
-			if err == iterator.Done {
-				break
-			}
-			if err != nil {
-				return nil, err
-			}
-			collections = append(collections, c.ID)
-		}
-		return collections, nil
+		return collectFirestoreCollectionIDs(client.Collections(ctx))
 
 	default:
 		return nil, unsupportedActionError("Firestore", action, observability.GCPServiceActions["firestore"])
 	}
+}
+
+// firestoreCollectionIterator is the minimal slice of
+// *firestore.CollectionIterator that collectFirestoreCollectionIDs
+// consumes, narrow enough to fake in unit tests without a real
+// Firestore client.
+type firestoreCollectionIterator interface {
+	Next() (*firestore.CollectionRef, error)
+}
+
+// collectFirestoreCollectionIDs drains a Firestore collection iterator
+// into a non-nil []string. The empty-iterator path returns [], NOT nil
+// — pinned by TestInspectFirestore_NoCollections_EmptySlice (#255) so
+// downstream JSON marshals as `[]` instead of `null`.
+func collectFirestoreCollectionIDs(it firestoreCollectionIterator) ([]string, error) {
+	collections := []string{}
+	for {
+		c, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		collections = append(collections, c.ID)
+	}
+	return collections, nil
 }
 
 // firestoreDatabaseFromFilters extracts and validates the

--- a/pkg/observability/discovery/gcp/data_test.go
+++ b/pkg/observability/discovery/gcp/data_test.go
@@ -159,6 +159,10 @@ func TestInspectFirestore_UnsupportedAction(t *testing.T) {
 
 // fakeFirestoreIterator stands in for *firestore.CollectionIterator
 // for the empty + happy-path tests of collectFirestoreCollectionIDs.
+//
+// Fidelity note: errors short-circuit on the first Next() call before
+// any data is yielded. For mid-stream-error scenarios (yield N items,
+// then error), extend the fake with a per-call error slice.
 type fakeFirestoreIterator struct {
 	refs []*firestore.CollectionRef
 	idx  int
@@ -215,7 +219,7 @@ func TestInspectFirestore_ListCollections_Error(t *testing.T) {
 	_, err := collectFirestoreCollectionIDs(&fakeFirestoreIterator{
 		err: assert.AnError,
 	})
-	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
 }
 
 // TestFirestoreDatabaseFromFilters_Roundtrip pins the parse + safety-

--- a/pkg/observability/discovery/gcp/data_test.go
+++ b/pkg/observability/discovery/gcp/data_test.go
@@ -2,13 +2,16 @@ package gcp
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"cloud.google.com/go/firestore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	sqladmin "google.golang.org/api/sqladmin/v1"
 )
@@ -152,6 +155,67 @@ func TestInspectFirestore_UnsupportedAction(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported Firestore action")
+}
+
+// fakeFirestoreIterator stands in for *firestore.CollectionIterator
+// for the empty + happy-path tests of collectFirestoreCollectionIDs.
+type fakeFirestoreIterator struct {
+	refs []*firestore.CollectionRef
+	idx  int
+	err  error
+}
+
+func (f *fakeFirestoreIterator) Next() (*firestore.CollectionRef, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.idx >= len(f.refs) {
+		return nil, iterator.Done
+	}
+	r := f.refs[f.idx]
+	f.idx++
+	return r, nil
+}
+
+// TestInspectFirestore_NoCollections_EmptySlice is the canonical #255
+// regression test. A freshly-deployed Firestore database has zero
+// collections (Firestore creates them lazily on first write) so the
+// iterator returns iterator.Done immediately. The pre-fix code declared
+// `var collections []string` which marshaled as `null`, collapsing the
+// reliable UI's `resources` field through every empty-state branch and
+// surfacing the misleading "Deploy infrastructure first." fallback.
+// Post-fix, the empty path returns []string{} which marshals as `[]`.
+func TestInspectFirestore_NoCollections_EmptySlice(t *testing.T) {
+	t.Parallel()
+	got, err := collectFirestoreCollectionIDs(&fakeFirestoreIterator{})
+	require.NoError(t, err)
+	require.NotNil(t, got, "must be non-nil so encoding/json emits [] not null")
+	assert.Empty(t, got)
+
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b),
+		"empty Firestore list-collections must marshal as [] not null (#255)")
+}
+
+func TestInspectFirestore_ListCollections_Happy(t *testing.T) {
+	t.Parallel()
+	got, err := collectFirestoreCollectionIDs(&fakeFirestoreIterator{
+		refs: []*firestore.CollectionRef{
+			{ID: "users"},
+			{ID: "orders"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"users", "orders"}, got)
+}
+
+func TestInspectFirestore_ListCollections_Error(t *testing.T) {
+	t.Parallel()
+	_, err := collectFirestoreCollectionIDs(&fakeFirestoreIterator{
+		err: assert.AnError,
+	})
+	require.Error(t, err)
 }
 
 // TestFirestoreDatabaseFromFilters_Roundtrip pins the parse + safety-

--- a/pkg/observability/discovery/gcp/identity.go
+++ b/pkg/observability/discovery/gcp/identity.go
@@ -50,7 +50,7 @@ func inspectIdentityPlatform(ctx context.Context, projectID, action, _ string, o
 
 	switch action {
 	case "list-tenants":
-		var tenants []*identitytoolkit.GoogleCloudIdentitytoolkitAdminV2Tenant
+		tenants := []*identitytoolkit.GoogleCloudIdentitytoolkitAdminV2Tenant{}
 		var pageToken string
 		truncated := false
 		for {

--- a/pkg/observability/discovery/gcp/live_integration_test.go
+++ b/pkg/observability/discovery/gcp/live_integration_test.go
@@ -30,6 +30,7 @@ package gcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
@@ -411,6 +412,11 @@ func TestLive_InspectFirestore_DefaultDB(t *testing.T) {
 // passthrough works against a real preset-deployed Firestore. Set
 // LIVE_GCP_FIRESTORE_DB to the database_name output of the deployed
 // stack (e.g. io-cc7ndmjcolun-firestore-8a3bfd07).
+//
+// Also pins the #255 wire-shape contract: the result must marshal
+// as a JSON array (`[]` for the empty case, `[…]` for non-empty),
+// never as JSON `null`. The downstream reliable UI gates the panel
+// render on that shape.
 func TestLive_InspectFirestore_NamedDB(t *testing.T) {
 	t.Parallel()
 	projectID := liveProjectOrSkip(t)
@@ -422,7 +428,15 @@ func TestLive_InspectFirestore_NamedDB(t *testing.T) {
 	filters := `{"database_name":"` + dbName + `"}`
 	got, err := inspectFirestore(context.Background(), projectID, "list-collections", filters, liveAuthOpts(t)...)
 	require.NoError(t, err, "inspectFirestore with database_name=%q must succeed against a preset-deployed Firestore (#245)", dbName)
-	t.Logf("list-collections (db=%s) returned %T: %v", dbName, got, got)
+	require.NotNil(t, got, "list-collections must be non-nil so JSON marshals as [] not null (#255)")
+
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.NotEqual(t, "null", string(b),
+		"empty Firestore list-collections must NOT marshal as null — that was the #255 bug")
+	assert.True(t, strings.HasPrefix(string(b), "["),
+		"list-collections must marshal as a JSON array; got %s", string(b))
+	t.Logf("list-collections (db=%s) returned %T: %v; JSON: %s", dbName, got, got, string(b))
 }
 
 // TestLive_InspectIdentityPlatform_TenantsOnUnprovisionedProject

--- a/pkg/observability/discovery/gcp/live_probe_255_test.go
+++ b/pkg/observability/discovery/gcp/live_probe_255_test.go
@@ -1,0 +1,248 @@
+//go:build integration
+
+// One-shot live probe for #255. Hits every GCP inspector action that
+// returns a slice (or wraps one) against a real project and asserts
+// the JSON wire shape is a JSON array (`[…]` / `[]`), never `null`.
+// Pre-fix, the empty-result paths emitted JSON `null`; post-fix they
+// emit `[]`.
+//
+// Run:
+//
+//	LIVE_GCP_PROJECT_ID=<project> [LIVE_GCP_FIRESTORE_DB=<db>] \
+//	  go test -tags=integration ./pkg/observability/discovery/gcp/... \
+//	    -v -run TestLive255_AllInspectorsJSONShape
+//
+// Calibration: most inspectors return empty against a project with no
+// matching resources (the empty-state path the fix targets). For
+// inspectors that need extra context (Firestore database_name; Identity
+// Platform multi-tenancy not provisioned), the probe routes around or
+// asserts the structured error.
+
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/observability"
+)
+
+func TestLive255_AllInspectorsJSONShape(t *testing.T) {
+	t.Parallel()
+	projectID := liveProjectOrSkip(t)
+	ctx := context.Background()
+	opts := liveAuthOpts(t)
+	projectFilter := `{"project":"` + projectID + `"}`
+
+	type probe struct {
+		name    string
+		fn      func() (any, error)
+		filters string // documentation only
+	}
+
+	probes := []probe{
+		// data.go
+		{name: "cloudsql/list-instances (project-filter)",
+			fn: func() (any, error) {
+				return inspectCloudSQL(ctx, projectID, "list-instances", projectFilter, opts...)
+			}, filters: projectFilter},
+		{name: "memorystore/list-instances",
+			fn: func() (any, error) {
+				return inspectMemorystore(ctx, projectID, "list-instances", projectFilter, opts...)
+			}, filters: projectFilter},
+		// firestore/list-collections — covered by TestLive_InspectFirestore_NamedDB
+
+		// compute.go
+		{name: "compute/list-instances",
+			fn: func() (any, error) {
+				return inspectCompute(ctx, projectID, "list-instances", projectFilter, opts...)
+			}, filters: projectFilter},
+		{name: "gke/list-clusters (project-filter)",
+			fn: func() (any, error) {
+				return inspectGKE(ctx, projectID, "list-clusters", projectFilter, opts...)
+			}, filters: projectFilter},
+		{name: "bastion/list-bastion-instances",
+			fn: func() (any, error) {
+				return inspectBastion(ctx, projectID, "list-bastion-instances", projectFilter, opts...)
+			}, filters: projectFilter},
+
+		// app.go
+		{name: "cloudrun/list-services",
+			fn: func() (any, error) {
+				return inspectCloudRun(ctx, projectID, "list-services", projectFilter, opts...)
+			}, filters: projectFilter},
+		{name: "cloudfunctions/list-functions",
+			fn: func() (any, error) {
+				return inspectCloudFunctions(ctx, projectID, "list-functions", projectFilter, opts...)
+			}, filters: projectFilter},
+		{name: "cloudbuild/list-triggers",
+			fn: func() (any, error) {
+				return inspectCloudBuild(ctx, projectID, "list-triggers", "", opts...)
+			}},
+		{name: "cloudbuild/list-builds",
+			fn: func() (any, error) {
+				return inspectCloudBuild(ctx, projectID, "list-builds", "", opts...)
+			}},
+
+		// network.go
+		{name: "vpc/list-subnets",
+			fn: func() (any, error) {
+				return inspectVPC(ctx, projectID, "list-subnets", projectFilter, opts...)
+			}, filters: projectFilter},
+		{name: "cloudcdn/list-backend-services-cdn",
+			fn: func() (any, error) {
+				return inspectCloudCDN(ctx, projectID, "list-backend-services-cdn", "", opts...)
+			}},
+		{name: "apigateway/list-apis",
+			fn: func() (any, error) {
+				return inspectAPIGateway(ctx, projectID, "list-apis", projectFilter, opts...)
+			}, filters: projectFilter},
+
+		// ai.go (Vertex AI — needs region; default us-central1)
+		{name: "vertexai/list-datasets",
+			fn: func() (any, error) {
+				return inspectVertexAI(ctx, projectID, "list-datasets", projectFilter, opts...)
+			}, filters: projectFilter},
+		{name: "vertexai/list-endpoints",
+			fn: func() (any, error) {
+				return inspectVertexAI(ctx, projectID, "list-endpoints", projectFilter, opts...)
+			}, filters: projectFilter},
+		{name: "vertexai/list-models",
+			fn: func() (any, error) {
+				return inspectVertexAI(ctx, projectID, "list-models", projectFilter, opts...)
+			}, filters: projectFilter},
+
+		// ops.go
+		{name: "logging/list-logs",
+			fn: func() (any, error) {
+				return inspectLogging(ctx, projectID, "list-logs", "", opts...)
+			}},
+		{name: "monitoring/list-alert-policies",
+			fn: func() (any, error) {
+				return inspectCloudMonitoring(ctx, projectID, "list-alert-policies", projectFilter, opts...)
+			}, filters: projectFilter},
+		{name: "pubsub/list-topics",
+			fn: func() (any, error) {
+				return inspectPubSub(ctx, projectID, "list-topics", projectFilter, opts...)
+			}, filters: projectFilter},
+		{name: "pubsub/list-subscriptions",
+			fn: func() (any, error) {
+				return inspectPubSub(ctx, projectID, "list-subscriptions", projectFilter, opts...)
+			}, filters: projectFilter},
+
+		// storage.go
+		{name: "gcs/list-buckets",
+			fn: func() (any, error) {
+				return inspectGCS(ctx, projectID, "list-buckets", projectFilter, opts...)
+			}, filters: projectFilter},
+		{name: "secretmanager/list-secrets",
+			fn: func() (any, error) {
+				return inspectSecretManager(ctx, projectID, "list-secrets", projectFilter, opts...)
+			}, filters: projectFilter},
+		{name: "kms/list-keyrings",
+			fn: func() (any, error) {
+				return inspectKMS(ctx, projectID, "list-keyrings", projectFilter, opts...)
+			}, filters: projectFilter},
+
+		// identity.go — list-tenants on a project without multi-tenancy
+		// returns a structured error (TestLive_InspectIdentityPlatform_*).
+		// list-providers is a baseline.
+	}
+
+	for _, p := range probes {
+		t.Run(p.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := p.fn()
+			if err != nil {
+				// Surface FeatureNotEnabledError separately — expected
+				// structured failure, not a #255 issue.
+				var feErr *observability.GCPFeatureNotEnabledError
+				if errors.As(err, &feErr) {
+					t.Logf("FeatureNotEnabled (expected): %v", err)
+					return
+				}
+				// API not enabled in the test project — environmental,
+				// not a fix-quality signal. Surface as Skip so the
+				// suite is green when the project is partially provisioned.
+				if isAPIDisabled(err) {
+					t.Skipf("SERVICE_DISABLED — API not enabled in test project (not a #255 issue): %v",
+						truncate(err.Error(), 200))
+					return
+				}
+				t.Errorf("inspector errored: %v", err)
+				return
+			}
+			b, err := json.Marshal(got)
+			if err != nil {
+				t.Errorf("json.Marshal: %v", err)
+				return
+			}
+			s := string(b)
+			t.Logf("JSON wire (%d bytes): %s", len(s), truncate(s, 240))
+			assert.NotEqual(t, "null", s,
+				"#255 regression: empty-result JSON null on %s; expected JSON array", p.name)
+			// Most inspectors return a top-level array; a few wrap in
+			// {"buckets": [...]} etc. Either is fine — what matters is
+			// no `null` at the top level AND no `null` as the inner
+			// slice value where it's wrapped.
+			if strings.HasPrefix(s, "{") {
+				// Wrapped-in-parent shape: scan for `: null` on slice fields.
+				assert.NotContains(t, s, `:null`, "#255 regression: inner slice null in %s", p.name)
+			} else {
+				assert.True(t, strings.HasPrefix(s, "["),
+					"expected JSON array prefix on %s; got: %s", p.name, truncate(s, 80))
+			}
+		})
+	}
+
+	// Wrapped-in-parent: billing/get-budgets — only meaningful if the
+	// project has a billing account associated, which test projects
+	// usually don't. The handler returns a {"note": ..., "project_id":
+	// ...} envelope when no billing account is linked — which is fine
+	// (no slice null lurking).
+	if os.Getenv("LIVE_GCP_HAS_BILLING") == "1" {
+		t.Run("billing/get-budgets (wrapped)", func(t *testing.T) {
+			t.Parallel()
+			got, err := inspectBilling(ctx, projectID, "get-budgets", "", opts...)
+			if err != nil {
+				t.Logf("billing error (probably permission denied; not a #255 issue): %v", err)
+				return
+			}
+			b, err := json.Marshal(got)
+			if err != nil {
+				t.Errorf("json.Marshal: %v", err)
+				return
+			}
+			s := string(b)
+			t.Logf("JSON wire: %s", truncate(s, 240))
+			assert.NotContains(t, s, `:null`, "#255 regression: inner slice null in billing/get-budgets")
+		})
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...(truncated)"
+}
+
+// isAPIDisabled reports whether the error indicates the underlying
+// Google API is not enabled in the project. Both gRPC (PermissionDenied
+// + SERVICE_DISABLED reason) and REST (HTTP 403 + accessNotConfigured)
+// surface this distinct from genuine permission failures.
+func isAPIDisabled(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "SERVICE_DISABLED") ||
+		strings.Contains(s, "accessNotConfigured") ||
+		strings.Contains(s, "has not been used in project")
+}

--- a/pkg/observability/discovery/gcp/network.go
+++ b/pkg/observability/discovery/gcp/network.go
@@ -87,7 +87,7 @@ func inspectVPC(ctx context.Context, projectID, action, filters string, opts ...
 		if err != nil {
 			return nil, err
 		}
-		var subnets []*computeapi.Subnetwork
+		subnets := []*computeapi.Subnetwork{}
 		for _, item := range resp.Items {
 			subnets = append(subnets, item.Subnetworks...)
 		}
@@ -258,7 +258,7 @@ func inspectCloudCDN(ctx context.Context, projectID, action, filters string, opt
 		defer func() { _ = client.Close() }()
 
 		it := client.AggregatedList(ctx, cloudCDNAggregatedListRequest(projectID, filters))
-		var services []*computepb.BackendService
+		services := []*computepb.BackendService{}
 		for {
 			pair, err := it.Next()
 			if err == iterator.Done {
@@ -298,7 +298,7 @@ func inspectAPIGateway(ctx context.Context, projectID, action, filters string, o
 			req.Filter = f
 		}
 		it := client.ListApis(ctx, req)
-		var apis []*apigatewaypb.Api
+		apis := []*apigatewaypb.Api{}
 		for {
 			api, err := it.Next()
 			if err == iterator.Done {

--- a/pkg/observability/discovery/gcp/ops.go
+++ b/pkg/observability/discovery/gcp/ops.go
@@ -41,7 +41,7 @@ func inspectLogging(ctx context.Context, projectID, action, _ string, opts ...op
 	switch action {
 	case "list-logs":
 		it := client.Logs(ctx)
-		var logs []string
+		logs := []string{}
 		for {
 			l, err := it.Next()
 			if err == iterator.Done {
@@ -76,7 +76,7 @@ func inspectCloudMonitoring(ctx context.Context, projectID, action, _ string, op
 		it := client.ListAlertPolicies(ctx, &monitoringpb.ListAlertPoliciesRequest{
 			Name: fmt.Sprintf("projects/%s", projectID),
 		})
-		var policies []*monitoringpb.AlertPolicy
+		policies := []*monitoringpb.AlertPolicy{}
 		for {
 			p, err := it.Next()
 			if err == iterator.Done {
@@ -110,7 +110,7 @@ func inspectPubSub(ctx context.Context, projectID, action, filters string, opts 
 		it := client.ListTopics(ctx, &pubsubpb.ListTopicsRequest{
 			Project: fmt.Sprintf("projects/%s", projectID),
 		})
-		var topics []*pubsubpb.Topic
+		topics := []*pubsubpb.Topic{}
 		for {
 			t, err := it.Next()
 			if err == iterator.Done {
@@ -136,7 +136,7 @@ func inspectPubSub(ctx context.Context, projectID, action, filters string, opts 
 		it := client.ListSubscriptions(ctx, &pubsubpb.ListSubscriptionsRequest{
 			Project: fmt.Sprintf("projects/%s", projectID),
 		})
-		var subs []*pubsubpb.Subscription
+		subs := []*pubsubpb.Subscription{}
 		for {
 			s, err := it.Next()
 			if err == iterator.Done {

--- a/pkg/observability/discovery/gcp/storage.go
+++ b/pkg/observability/discovery/gcp/storage.go
@@ -40,7 +40,7 @@ func inspectGCS(ctx context.Context, projectID, action, filters string, opts ...
 		// storage.Buckets has no server-side label filter; post-filter
 		// on BucketAttrs.Labels.
 		project := projectFromFilters(filters)
-		var buckets []map[string]any
+		buckets := []map[string]any{}
 		for {
 			b, err := it.Next()
 			if err == iterator.Done {
@@ -81,7 +81,7 @@ func inspectSecretManager(ctx context.Context, projectID, action, filters string
 		// ListSecrets has no server-side label filter; post-filter on
 		// Secret.Labels.
 		project := projectFromFilters(filters)
-		var secrets []*secretmanagerpb.Secret
+		secrets := []*secretmanagerpb.Secret{}
 		for {
 			s, err := it.Next()
 			if err == iterator.Done {
@@ -124,7 +124,7 @@ func inspectKMS(ctx context.Context, projectID, action, filters string, opts ...
 		it := client.ListKeyRings(ctx, &kmspb.ListKeyRingsRequest{
 			Parent: fmt.Sprintf("projects/%s/locations/%s", projectID, location),
 		})
-		var keyRings []*kmspb.KeyRing
+		keyRings := []*kmspb.KeyRing{}
 		for {
 			kr, err := it.Next()
 			if err == iterator.Done {
@@ -151,7 +151,7 @@ func inspectKMS(ctx context.Context, projectID, action, filters string, opts ...
 		// ListCryptoKeys has no server-side label filter; post-filter
 		// on CryptoKey.Labels.
 		project := projectFromFilters(filters)
-		var keys []*kmspb.CryptoKey
+		keys := []*kmspb.CryptoKey{}
 		for {
 			k, err := it.Next()
 			if err == iterator.Done {

--- a/pkg/observability/filter/project.go
+++ b/pkg/observability/filter/project.go
@@ -121,7 +121,7 @@ func Match(resources []map[string]any, project, tagFieldName string, tagFormat T
 	if project == "" || len(resources) == 0 {
 		return resources
 	}
-	var out []map[string]any
+	out := []map[string]any{}
 	for _, r := range resources {
 		tags := r[tagFieldName]
 		if tags == nil {

--- a/pkg/observability/filter/project_test.go
+++ b/pkg/observability/filter/project_test.go
@@ -219,18 +219,25 @@ func TestMatch_KVFormat(t *testing.T) {
 		assert.Len(t, result, 1)
 		assert.Equal(t, "instance-1", result[0]["Name"])
 	})
-	t.Run("no match returns empty", func(t *testing.T) {
+	t.Run("no match returns non-nil empty slice (#255)", func(t *testing.T) {
 		t.Parallel()
 		result := Match(resources, "io-nonexistent", "Tags", FormatKV)
-		assert.Nil(t, result)
+		require.NotNil(t, result, "must be non-nil so encoding/json emits [] not null")
+		assert.Empty(t, result)
+		b, err := json.Marshal(result)
+		require.NoError(t, err)
+		assert.Equal(t, "[]", string(b), "filter.Match no-match must marshal as [] not null (#255)")
 	})
 	t.Run("empty project returns all", func(t *testing.T) {
 		t.Parallel()
 		result := Match(resources, "", "Tags", FormatKV)
 		assert.Len(t, result, 3)
 	})
-	t.Run("nil resources returns nil", func(t *testing.T) {
+	t.Run("nil resources returns nil (passthrough)", func(t *testing.T) {
 		t.Parallel()
+		// Passing nil into Match preserves nil — the per-site fix for
+		// #255 happens at the caller (toSliceOfMaps) which now returns
+		// an empty slice instead of nil for the success path.
 		assert.Nil(t, Match(nil, "io-abc", "Tags", FormatKV))
 	})
 }
@@ -263,9 +270,14 @@ func TestMatch_MapFormat(t *testing.T) {
 		assert.Len(t, result, 1)
 		assert.Equal(t, "cluster-1", result[0]["Name"])
 	})
-	t.Run("no match returns empty", func(t *testing.T) {
+	t.Run("no match returns non-nil empty slice (#255)", func(t *testing.T) {
 		t.Parallel()
-		assert.Nil(t, Match(resources, "io-nonexistent", "Tags", FormatMap))
+		result := Match(resources, "io-nonexistent", "Tags", FormatMap)
+		require.NotNil(t, result)
+		assert.Empty(t, result)
+		b, err := json.Marshal(result)
+		require.NoError(t, err)
+		assert.Equal(t, "[]", string(b))
 	})
 }
 
@@ -282,9 +294,14 @@ func TestMatch_LabelsFormat(t *testing.T) {
 		assert.Len(t, result, 1)
 		assert.Equal(t, "topic-1", result[0]["name"])
 	})
-	t.Run("no match returns empty", func(t *testing.T) {
+	t.Run("no match returns non-nil empty slice (#255)", func(t *testing.T) {
 		t.Parallel()
-		assert.Nil(t, Match(resources, "io-nonexistent", "labels", FormatLabels))
+		result := Match(resources, "io-nonexistent", "labels", FormatLabels)
+		require.NotNil(t, result)
+		assert.Empty(t, result)
+		b, err := json.Marshal(result)
+		require.NoError(t, err)
+		assert.Equal(t, "[]", string(b))
 	})
 	t.Run("empty project returns all", func(t *testing.T) {
 		t.Parallel()
@@ -296,7 +313,9 @@ func TestMatch_LabelsFormat(t *testing.T) {
 		mixed := []map[string]any{
 			{"name": "x", "labels": map[string]any{"Project": "io-abc"}},
 		}
-		assert.Nil(t, Match(mixed, "io-abc", "labels", FormatLabels))
+		result := Match(mixed, "io-abc", "labels", FormatLabels)
+		require.NotNil(t, result)
+		assert.Empty(t, result)
 	})
 	t.Run("typed map[string]string also accepted", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/observability/filter/project_test.go
+++ b/pkg/observability/filter/project_test.go
@@ -308,7 +308,7 @@ func TestMatch_LabelsFormat(t *testing.T) {
 		result := Match(resources, "", "labels", FormatLabels)
 		assert.Len(t, result, 3)
 	})
-	t.Run("uppercase Project does not match — labels key is lowercase", func(t *testing.T) {
+	t.Run("uppercase Project does not match — labels key is lowercase (#255)", func(t *testing.T) {
 		t.Parallel()
 		mixed := []map[string]any{
 			{"name": "x", "labels": map[string]any{"Project": "io-abc"}},
@@ -316,6 +316,9 @@ func TestMatch_LabelsFormat(t *testing.T) {
 		result := Match(mixed, "io-abc", "labels", FormatLabels)
 		require.NotNil(t, result)
 		assert.Empty(t, result)
+		b, err := json.Marshal(result)
+		require.NoError(t, err)
+		assert.Equal(t, "[]", string(b))
 	})
 	t.Run("typed map[string]string also accepted", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
## Summary

- Fixes [#255](https://github.com/luthersystems/insideout-terraform-presets/issues/255): discovery handlers that returned a nil slice (e.g. `gcp_firestore` list-collections on a freshly-deployed DB with zero collections) marshaled as JSON `null`, which the `reliable` UI gates the panel render on — so legitimate empty results surfaced the misleading "Deploy infrastructure first." fallback.
- Mechanical fix at ~45 sites: `var X []T` → `X := []T{}`. 25 GCP top-level returns + 15 AWS top-level returns + 3 wrapped-in-parent (`{"buckets": null, ...}` shape) sites + two consolidating shared helpers (`filter.Match`, `aws.toSliceOfMaps`) that cover RDS / MSK / ALB / APIGateway and Bedrock list-knowledge-bases / list-agents / list-guardrails respectively.
- No central dispatcher fix is viable — both `gcp/dispatcher.go` and `aws/dispatcher.go` route `(any, error)` directly to typed-assertion consumers, so a reflection-based normalizer would change return-shape semantics.

## Implementation notes

- `aws/helpers.go::toSliceOfMaps` needs a post-Unmarshal restoration for typed-nil-slice inputs (the AWS-SDK-V2 empty-list emission pattern). `json.Marshal` of a `[]Foo(nil)` produces the literal `null`, which `json.Unmarshal` reflects back into the destination pointer as nil — undoing the `out := []map[string]any{}` initial value. Test `TestToSliceOfMaps_EmptyInput_NotNull` covers both untyped-nil and typed-nil-slice inputs.
- The canonical Firestore regression test required a small refactor: `inspectFirestore`'s iterator-loop is extracted into `collectFirestoreCollectionIDs` taking a 1-method `firestoreCollectionIterator` interface, so a fake iterator can drive the empty-iterator path without standing up a real Firestore client.
- `filter.Match` keeps its nil-input passthrough (returns nil if caller passes nil) — defense-in-depth happens at `toSliceOfMaps`, the single chokepoint upstream of every `filter.Match` call in production. Documented in the existing test subtest "nil resources returns nil (passthrough)".

## Deferred follow-up

[#256](https://github.com/luthersystems/insideout-terraform-presets/issues/256) tracks per-inspector empty-state regression tests for the remaining ~38 direct-return sites. The acceptance bullet from #255 ("one regression test per inspector that returns `[]` for the empty case") is partially satisfied: the canonical Firestore test ships, plus the two consolidating helpers' tests cover ~10 AWS sites transitively. The remaining gRPC-backed inspectors each need either a fake gRPC server or a per-site refactor like the Firestore one — captured as follow-up rather than blocking this PR.

## Test plan

- [x] `go test ./pkg/observability/...` — full observability suite green
- [x] `TestInspectFirestore_NoCollections_EmptySlice` exists and JSON-marshals to `[]`
- [x] `TestMatch_*_NoMatch_*_NotNull_NotNull` for KV / Map / Labels formats — JSON-marshal contract pinned
- [x] `TestToSliceOfMaps_EmptyInput_NotNull` covers untyped-nil + typed-nil slice + empty-slice cases
- [x] `TestToSliceOfMaps_UnmarshalFailure_ReturnsNil` pins fail-closed contract for shape mismatches
- [x] No new compile/lint warnings introduced by the per-site rewrites
- [ ] Post-merge: tag bump (e.g. v0.10.1 / v0.11.0) so reliable can pin and verify the canonical session `sess_v2_CC7nDMjcOlun` Firestore panel renders the chart instead of the deploy-prompt fallback

## Review notes

- /review (manual review against P0–P3 rubric): one P1 (toSliceOfMaps still emitted null for typed-nil-slice inputs) — fixed in second commit; P2 (uppercase-Project subtest missing JSON-marshal check) and P3s (assert.ErrorIs upgrade, fakeIterator fidelity comment, table-driven coverage) — all addressed.
- qa-professor: noted the same toSliceOfMaps gap, called out the deferred-coverage scope risk (now tracked at #256), and flagged the symmetry / table-driven gaps that the second commit addresses.

Closes #255