### PR TITLE
feat(insideout-import): add discover subcommand (Stage 2a of #189 split)

### DIFF
--- a/cmd/insideout-import/README.md
+++ b/cmd/insideout-import/README.md
@@ -7,7 +7,7 @@ CLI for bringing existing cloud resources under InsideOut management.
 | Subcommand | Status | Purpose |
 |---|---|---|
 | `adopt` | implemented | Emit `import {}` blocks against an *already-known* preset stack. |
-| `discover` | not yet implemented (#189) | Reverse-Terraform discovery + HCL generation. |
+| `discover` | Stage 2a (AWS, manifest only) | Discover existing cloud resources and emit `imported.json`. Stage 2b layers HCL generation; Stage 2c adds drift fixing; Stage 2d adds GCP. See #189 for the chain. |
 
 ## `adopt`
 
@@ -72,6 +72,61 @@ These are intentionally out of scope for Stage 1; see #259 for context:
 - **No provenance tag/label injection on the imported resources.** The composer can apply provenance when it composes the stack; `adopt` will not silently mutate user-authored HCL.
 - **No `imported.json` manifest.** That manifest is meaningful only when discovery populates `Identity` and `Tier` from cloud state.
 
+## `discover` (Stage 2a)
+
+```
+insideout-import discover \
+  --provider aws \
+  --project io-buqiks112yag \
+  --region us-east-1 \
+  --output-dir ./imported \
+  [--resource-types aws_sqs_queue,aws_lambda_function,...]
+```
+
+### Inputs
+
+- `--provider` (required) — only `aws` is supported in Stage 2a; `gcp` returns a "not yet implemented" error pointing at #264 (Stage 2d).
+- `--project` (required) — project name used as the prefix / `Project` tag value to filter discovered resources.
+- `--region` (required for AWS) — AWS region to scan.
+- `--output-dir` (required) — directory to write `imported.json` into.
+- `--resource-types` — comma-separated subset of supported types. Default: all 5 Phase 1 types (`aws_sqs_queue`, `aws_dynamodb_table`, `aws_cloudwatch_log_group`, `aws_secretsmanager_secret`, `aws_lambda_function`).
+
+### Output
+
+`<output-dir>/imported.json` — JSON array of `imported.ImportedResource` (the Phase 2 carrier defined in `pkg/composer/imported`). Each entry has:
+
+- `Tier = "TierImportedFlat"`, `Source = "importer"`.
+- `Identity.{Cloud, Type, Address, ImportID, NameHint, ProviderSource, AccountID, Region, NativeIDs}` populated.
+- `Attributes` and `Attrs` left empty — Stage 2b populates them via `terraform plan -generate-config-out`.
+
+Records are sorted by `Identity.Address` so the file is byte-identical across runs for the same input.
+
+### Per-type SDK calls
+
+| Terraform type | SDK call(s) | Filter | Import ID |
+|---|---|---|---|
+| `aws_sqs_queue` | `ListQueues(QueueNamePrefix)` | server-side prefix | queue URL |
+| `aws_dynamodb_table` | `ListTables` + `ListTagsOfResource(ARN)` | name prefix + Project tag | table name |
+| `aws_cloudwatch_log_group` | `DescribeLogGroups(LogGroupNamePrefix)` | server-side prefix | log group name |
+| `aws_secretsmanager_secret` | `ListSecrets(Filters: tag:Project=<p>)` | server-side tag filter | secret ARN |
+| `aws_lambda_function` | `ListFunctions` + `ListTags(ARN)` | Project tag | function name |
+
+DynamoDB and Lambda fail-closed on per-resource `ListTags` errors — a transient throttle skips the resource rather than letting an unverified entry into the manifest. `ListFunctions` / `ListTables` errors abort the whole run.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Manifest written; `composer.ValidateImportedResources` returned no issues. |
+| `1` | Fatal: AWS error, validator failure, or bad inputs. No partial manifest written. |
+
+### What `discover` does *not* do (Stage 2a)
+
+- **No HCL generation.** The `imports.tf` / `generated.tf` / `providers.tf` files come from Stage 2b (`#262`).
+- **No drift fixing or dependency chasing.** Stage 2c (`#263`).
+- **No GCP support.** Stage 2d (`#264`).
+- **No throttle/retry tuning or bounded concurrency.** Stage 2c.
+
 ## Development
 
 ```bash
@@ -79,5 +134,4 @@ go build ./cmd/insideout-import
 go test  ./cmd/insideout-import/...
 ```
 
-The `terraform` binary is *not* required for `go test` — the plan-output
-parser is exercised against fixed text fixtures.
+Neither the `terraform` binary nor AWS credentials are required for `go test` — discoverers use mocked SDK clients via narrow client interfaces, and the `adopt` plan-parser runs against fixed text fixtures.

--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -1,0 +1,111 @@
+// Package awsdiscover holds the AWS-side per-resource-type discoverers used
+// by the insideout-import discover subcommand (Stage 2a of #189). Each
+// discoverer issues read-only AWS SDK calls against the operator's account
+// and returns Phase 2 imported.ImportedResource entries — no terraform-exec,
+// no HCL generation. Stage 2b layers `terraform plan -generate-config-out`
+// on top of this manifest to produce the actual .tf files.
+//
+// Discoverers in this package own narrow client interfaces so unit tests
+// can mock the SDK boundary without depending on real AWS credentials.
+// The aggregator (AWSDiscoverer) wires real SDK clients in production and
+// fans out to the registered per-type discoverers.
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// Discoverer is the per-resource-type contract. Each implementation handles
+// one Terraform type (e.g. "aws_sqs_queue") and returns []imported.ImportedResource
+// directly — no intermediate flat shape, per #189.
+//
+// Project, region, and accountID are passed in rather than re-derived per
+// discoverer so the aggregator can call STS GetCallerIdentity once.
+type Discoverer interface {
+	// ResourceType returns the Terraform type this discoverer covers, e.g.
+	// "aws_sqs_queue".
+	ResourceType() string
+	// Discover performs read-only SDK calls and returns one ImportedResource
+	// per matched cloud resource. Implementations populate Identity and set
+	// Tier=TierImportedFlat, Source=SourceImporter on each entry.
+	Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error)
+}
+
+// AWSDiscoverer aggregates the per-type discoverers and fans out a single
+// DiscoverTypes call across all of them. Construct with NewAWSDiscoverer
+// in production; tests can build it directly with mock discoverers.
+type AWSDiscoverer struct {
+	byType map[string]Discoverer
+}
+
+// NewAWSDiscoverer wires up the production set of AWS discoverers (the 5
+// Phase 1 types: SQS, DynamoDB, CloudWatch Logs, Secrets Manager, Lambda).
+// All discoverers share the same aws.Config; per-type SDK clients are
+// constructed inside each discoverer.
+func NewAWSDiscoverer(cfg aws.Config) *AWSDiscoverer {
+	return &AWSDiscoverer{
+		byType: map[string]Discoverer{
+			"aws_sqs_queue":             newSQSDiscoverer(cfg),
+			"aws_dynamodb_table":        newDynamoDBDiscoverer(cfg),
+			"aws_cloudwatch_log_group":  newCloudWatchLogsDiscoverer(cfg),
+			"aws_secretsmanager_secret": newSecretsManagerDiscoverer(cfg),
+			"aws_lambda_function":       newLambdaDiscoverer(cfg),
+		},
+	}
+}
+
+// SupportedTypes returns the registered Terraform types in lexicographic
+// order. Used by the CLI for default --resource-types and validation.
+func (a *AWSDiscoverer) SupportedTypes() []string {
+	out := make([]string, 0, len(a.byType))
+	for t := range a.byType {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// DiscoverTypes runs each named discoverer in series and concatenates the
+// results. Unknown type names are reported as a single error containing all
+// invalid names (not interleaved with partial results) so the operator sees
+// the full set of misspellings in one shot.
+//
+// Concurrency is intentionally serial in Stage 2a — Stage 2c will introduce
+// errgroup with bounded parallelism + the SDK retryer config (per #189's
+// QA carry-forward). Keeping it simple here means deterministic test output
+// and no throttling surprises on small/medium accounts.
+func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, project, region, accountID string) ([]imported.ImportedResource, error) {
+	if len(types) == 0 {
+		types = a.SupportedTypes()
+	}
+
+	var unknown []string
+	selected := make([]Discoverer, 0, len(types))
+	for _, t := range types {
+		d, ok := a.byType[t]
+		if !ok {
+			unknown = append(unknown, t)
+			continue
+		}
+		selected = append(selected, d)
+	}
+	if len(unknown) > 0 {
+		return nil, fmt.Errorf("unknown resource type(s): %v (supported: %v)", unknown, a.SupportedTypes())
+	}
+
+	var all []imported.ImportedResource
+	for _, d := range selected {
+		entries, err := d.Discover(ctx, project, region, accountID)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", d.ResourceType(), err)
+		}
+		all = append(all, entries...)
+	}
+	return all, nil
+}

--- a/cmd/insideout-import/awsdiscover/awsdiscover_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_test.go
@@ -1,0 +1,138 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+type fakeDiscoverer struct {
+	t       string
+	out     []imported.ImportedResource
+	err     error
+	called  int
+	gotProj string
+	gotReg  string
+	gotAcct string
+}
+
+func (f *fakeDiscoverer) ResourceType() string { return f.t }
+func (f *fakeDiscoverer) Discover(_ context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
+	f.called++
+	f.gotProj, f.gotReg, f.gotAcct = project, region, accountID
+	return f.out, f.err
+}
+
+func ir(addr string) imported.ImportedResource {
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: addr, ImportID: addr},
+		Tier:     imported.TierImportedFlat,
+		Source:   imported.SourceImporter,
+	}
+}
+
+func TestDiscoverTypes_DefaultsToAllSupported(t *testing.T) {
+	t.Parallel()
+	a := &fakeDiscoverer{t: "type_a", out: []imported.ImportedResource{ir("a1"), ir("a2")}}
+	b := &fakeDiscoverer{t: "type_b", out: []imported.ImportedResource{ir("b1")}}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a, "type_b": b}}
+
+	got, err := agg.DiscoverTypes(context.Background(), nil, "p", "r", "acc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Errorf("len=%d, want 3", len(got))
+	}
+	if a.called != 1 || b.called != 1 {
+		t.Errorf("each discoverer called once; got a=%d b=%d", a.called, b.called)
+	}
+	if a.gotProj != "p" || a.gotReg != "r" || a.gotAcct != "acc" {
+		t.Errorf("project/region/accountID not threaded; got %q/%q/%q", a.gotProj, a.gotReg, a.gotAcct)
+	}
+}
+
+func TestDiscoverTypes_SelectiveOnlyCallsRequested(t *testing.T) {
+	t.Parallel()
+	a := &fakeDiscoverer{t: "type_a"}
+	b := &fakeDiscoverer{t: "type_b"}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a, "type_b": b}}
+
+	if _, err := agg.DiscoverTypes(context.Background(), []string{"type_b"}, "p", "r", "acc"); err != nil {
+		t.Fatal(err)
+	}
+	if a.called != 0 {
+		t.Errorf("type_a should not have been called; called=%d", a.called)
+	}
+	if b.called != 1 {
+		t.Errorf("type_b should have been called once; called=%d", b.called)
+	}
+}
+
+func TestDiscoverTypes_UnknownTypeAggregatesAllErrorsBeforeRunning(t *testing.T) {
+	t.Parallel()
+	a := &fakeDiscoverer{t: "type_a"}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a}}
+
+	_, err := agg.DiscoverTypes(context.Background(), []string{"type_a", "bogus", "also_bogus"}, "p", "r", "acc")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "bogus") || !strings.Contains(err.Error(), "also_bogus") {
+		t.Errorf("error should list every unknown type; got: %v", err)
+	}
+	if a.called != 0 {
+		t.Errorf("no discoverer should run when any type is unknown; type_a called=%d", a.called)
+	}
+}
+
+func TestDiscoverTypes_PropagatesPerDiscovererError(t *testing.T) {
+	t.Parallel()
+	a := &fakeDiscoverer{t: "type_a", err: errors.New("Throttling")}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a}}
+
+	_, err := agg.DiscoverTypes(context.Background(), nil, "p", "r", "acc")
+	if err == nil || !strings.Contains(err.Error(), "type_a") || !strings.Contains(err.Error(), "Throttling") {
+		t.Errorf("expected wrapped error mentioning resource type and underlying cause; got: %v", err)
+	}
+}
+
+func TestSupportedTypes_IsSorted(t *testing.T) {
+	t.Parallel()
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{
+		"type_z": &fakeDiscoverer{t: "type_z"},
+		"type_a": &fakeDiscoverer{t: "type_a"},
+		"type_m": &fakeDiscoverer{t: "type_m"},
+	}}
+	got := agg.SupportedTypes()
+	want := []string{"type_a", "type_m", "type_z"}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("SupportedTypes()[%d]=%q, want %q (sorted)", i, got[i], w)
+		}
+	}
+}
+
+func TestNewAWSDiscoverer_Registers5PhaseOneTypes(t *testing.T) {
+	t.Parallel()
+	agg := NewAWSDiscoverer(awsDummyConfig())
+	got := agg.SupportedTypes()
+	want := map[string]bool{
+		"aws_sqs_queue":             false,
+		"aws_dynamodb_table":        false,
+		"aws_cloudwatch_log_group":  false,
+		"aws_secretsmanager_secret": false,
+		"aws_lambda_function":       false,
+	}
+	for _, typ := range got {
+		want[typ] = true
+	}
+	for k, ok := range want {
+		if !ok {
+			t.Errorf("expected %q to be registered", k)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudwatchlogs.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatchlogs.go
@@ -26,8 +26,13 @@ func newCloudWatchLogsDiscoverer(cfg aws.Config) Discoverer {
 
 func (d *cwlDiscoverer) ResourceType() string { return "aws_cloudwatch_log_group" }
 
-// Discover finds log groups whose name starts with the project prefix.
-// The CWL API supports server-side LogGroupNamePrefix, so we filter cheaply.
+// Discover finds log groups whose name *contains* the project name. We
+// use the CWL API's LogGroupNamePattern (server-side case-sensitive
+// substring match), not LogGroupNamePrefix — Lambda-emitted log groups
+// are named `/aws/lambda/<fn>` and inspector-style log groups
+// (`/<project>-...`) start with `/`, so a strict prefix match would miss
+// them. Substring match keeps the filter server-side without losing
+// either of those two common shapes.
 //
 // Import ID for aws_cloudwatch_log_group is the log group name.
 func (d *cwlDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
@@ -35,7 +40,7 @@ func (d *cwlDiscoverer) Discover(ctx context.Context, project, region, accountID
 	input := &cloudwatchlogs.DescribeLogGroupsInput{}
 	if project != "" {
 		p := project
-		input.LogGroupNamePrefix = &p
+		input.LogGroupNamePattern = &p
 	}
 
 	type group struct {

--- a/cmd/insideout-import/awsdiscover/cloudwatchlogs.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatchlogs.go
@@ -1,0 +1,80 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// cwlClient is the narrow subset of the CloudWatch Logs SDK we consume.
+type cwlClient interface {
+	DescribeLogGroups(ctx context.Context, in *cloudwatchlogs.DescribeLogGroupsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
+}
+
+type cwlDiscoverer struct {
+	new func() cwlClient
+}
+
+func newCloudWatchLogsDiscoverer(cfg aws.Config) Discoverer {
+	return &cwlDiscoverer{new: func() cwlClient { return cloudwatchlogs.NewFromConfig(cfg) }}
+}
+
+func (d *cwlDiscoverer) ResourceType() string { return "aws_cloudwatch_log_group" }
+
+// Discover finds log groups whose name starts with the project prefix.
+// The CWL API supports server-side LogGroupNamePrefix, so we filter cheaply.
+//
+// Import ID for aws_cloudwatch_log_group is the log group name.
+func (d *cwlDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
+	client := d.new()
+	input := &cloudwatchlogs.DescribeLogGroupsInput{}
+	if project != "" {
+		p := project
+		input.LogGroupNamePrefix = &p
+	}
+
+	type group struct {
+		name string
+		arn  string
+	}
+	var groups []group
+
+	for {
+		out, err := client.DescribeLogGroups(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("DescribeLogGroups: %w", err)
+		}
+		for _, lg := range out.LogGroups {
+			groups = append(groups, group{
+				name: aws.ToString(lg.LogGroupName),
+				arn:  aws.ToString(lg.Arn),
+			})
+		}
+		if out.NextToken == nil || *out.NextToken == "" {
+			break
+		}
+		input.NextToken = out.NextToken
+	}
+
+	sort.Slice(groups, func(i, j int) bool { return groups[i].name < groups[j].name })
+
+	book := addressBook{}
+	imps := make([]imported.ImportedResource, 0, len(groups))
+	for _, g := range groups {
+		imps = append(imps, makeImportedResource(
+			book,
+			"aws_cloudwatch_log_group",
+			g.name,
+			g.name,
+			region,
+			accountID,
+			map[string]string{"arn": g.arn},
+		))
+	}
+	return imps, nil
+}

--- a/cmd/insideout-import/awsdiscover/cloudwatchlogs_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatchlogs_test.go
@@ -57,19 +57,29 @@ func TestCWLDiscover_HappyPath(t *testing.T) {
 	}
 }
 
-func TestCWLDiscover_PassesPrefixServerSide(t *testing.T) {
+func TestCWLDiscover_PassesProjectAsLogGroupNamePattern(t *testing.T) {
 	t.Parallel()
 	fake := &fakeCWLClient{}
 	d := &cwlDiscoverer{new: func() cwlClient { return fake }}
 	if _, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123"); err != nil {
 		t.Fatal(err)
 	}
-	if len(fake.calls) == 0 || fake.calls[0].LogGroupNamePrefix == nil || *fake.calls[0].LogGroupNamePrefix != "io-foo" {
-		t.Errorf("expected LogGroupNamePrefix=io-foo, got %+v", fake.calls)
+	if len(fake.calls) == 0 {
+		t.Fatal("expected at least one DescribeLogGroups call")
+	}
+	in := fake.calls[0]
+	if in.LogGroupNamePattern == nil || *in.LogGroupNamePattern != "io-foo" {
+		t.Errorf("LogGroupNamePattern=%v, want io-foo", in.LogGroupNamePattern)
+	}
+	// Pin: prefix must NOT be set — the two filters are mutually
+	// exclusive at the server. A regression that sends both would fail
+	// at runtime with InvalidParameterException.
+	if in.LogGroupNamePrefix != nil {
+		t.Errorf("LogGroupNamePrefix=%v, must be nil (mutually exclusive with LogGroupNamePattern)", in.LogGroupNamePrefix)
 	}
 }
 
-func TestCWLDiscover_EmptyProjectPassesNoPrefix(t *testing.T) {
+func TestCWLDiscover_EmptyProjectPassesNoFilter(t *testing.T) {
 	t.Parallel()
 	fake := &fakeCWLClient{}
 	d := &cwlDiscoverer{new: func() cwlClient { return fake }}
@@ -79,8 +89,9 @@ func TestCWLDiscover_EmptyProjectPassesNoPrefix(t *testing.T) {
 	if len(fake.calls) == 0 {
 		t.Fatal("expected at least one DescribeLogGroups call")
 	}
-	if fake.calls[0].LogGroupNamePrefix != nil {
-		t.Errorf("LogGroupNamePrefix=%v, want nil for empty project", fake.calls[0].LogGroupNamePrefix)
+	if fake.calls[0].LogGroupNamePattern != nil || fake.calls[0].LogGroupNamePrefix != nil {
+		t.Errorf("expected no filter for empty project; pattern=%v prefix=%v",
+			fake.calls[0].LogGroupNamePattern, fake.calls[0].LogGroupNamePrefix)
 	}
 }
 

--- a/cmd/insideout-import/awsdiscover/cloudwatchlogs_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatchlogs_test.go
@@ -1,0 +1,113 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+)
+
+type fakeCWLClient struct {
+	pages []cloudwatchlogs.DescribeLogGroupsOutput
+	calls []cloudwatchlogs.DescribeLogGroupsInput
+	err   error
+}
+
+func (f *fakeCWLClient) DescribeLogGroups(_ context.Context, in *cloudwatchlogs.DescribeLogGroupsInput, _ ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+	f.calls = append(f.calls, *in)
+	if f.err != nil {
+		return nil, f.err
+	}
+	idx := len(f.calls) - 1
+	if idx >= len(f.pages) {
+		return &cloudwatchlogs.DescribeLogGroupsOutput{}, nil
+	}
+	return &f.pages[idx], nil
+}
+
+func TestCWLDiscover_HappyPath(t *testing.T) {
+	t.Parallel()
+	d := &cwlDiscoverer{new: func() cwlClient {
+		return &fakeCWLClient{
+			pages: []cloudwatchlogs.DescribeLogGroupsOutput{
+				{
+					LogGroups: []cwltypes.LogGroup{
+						{LogGroupName: aws.String("/aws/lambda/io-foo-handler"), Arn: aws.String("arn:aws:logs:us-east-1:123:log-group:/aws/lambda/io-foo-handler:*")},
+						{LogGroupName: aws.String("/aws/lambda/io-foo-worker"), Arn: aws.String("arn:aws:logs:us-east-1:123:log-group:/aws/lambda/io-foo-worker:*")},
+					},
+				},
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+	if got[0].Identity.ImportID != "/aws/lambda/io-foo-handler" {
+		t.Errorf("first ImportID=%q, want log group name (sorted)", got[0].Identity.ImportID)
+	}
+	if got[0].Identity.NativeIDs["arn"] == "" {
+		t.Error("NativeIDs[arn] empty")
+	}
+}
+
+func TestCWLDiscover_PassesPrefixServerSide(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCWLClient{}
+	d := &cwlDiscoverer{new: func() cwlClient { return fake }}
+	if _, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123"); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) == 0 || fake.calls[0].LogGroupNamePrefix == nil || *fake.calls[0].LogGroupNamePrefix != "io-foo" {
+		t.Errorf("expected LogGroupNamePrefix=io-foo, got %+v", fake.calls)
+	}
+}
+
+func TestCWLDiscover_EmptyProjectPassesNoPrefix(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCWLClient{}
+	d := &cwlDiscoverer{new: func() cwlClient { return fake }}
+	if _, err := d.Discover(context.Background(), "", "us-east-1", "123"); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) == 0 {
+		t.Fatal("expected at least one DescribeLogGroups call")
+	}
+	if fake.calls[0].LogGroupNamePrefix != nil {
+		t.Errorf("LogGroupNamePrefix=%v, want nil for empty project", fake.calls[0].LogGroupNamePrefix)
+	}
+}
+
+func TestCWLDiscover_PaginatesUntilNoToken(t *testing.T) {
+	t.Parallel()
+	d := &cwlDiscoverer{new: func() cwlClient {
+		return &fakeCWLClient{
+			pages: []cloudwatchlogs.DescribeLogGroupsOutput{
+				{LogGroups: []cwltypes.LogGroup{{LogGroupName: aws.String("/io-foo-a"), Arn: aws.String("a")}}, NextToken: aws.String("t1")},
+				{LogGroups: []cwltypes.LogGroup{{LogGroupName: aws.String("/io-foo-b"), Arn: aws.String("b")}}}, // terminal
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+}
+
+func TestCWLDiscover_PropagatesError(t *testing.T) {
+	t.Parallel()
+	d := &cwlDiscoverer{new: func() cwlClient { return &fakeCWLClient{err: errors.New("Throttling")} }}
+	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/cmd/insideout-import/awsdiscover/dynamodb.go
+++ b/cmd/insideout-import/awsdiscover/dynamodb.go
@@ -1,0 +1,109 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// dynamoClient is the narrow subset of the DynamoDB SDK we consume.
+type dynamoClient interface {
+	ListTables(ctx context.Context, in *dynamodb.ListTablesInput, opts ...func(*dynamodb.Options)) (*dynamodb.ListTablesOutput, error)
+	ListTagsOfResource(ctx context.Context, in *dynamodb.ListTagsOfResourceInput, opts ...func(*dynamodb.Options)) (*dynamodb.ListTagsOfResourceOutput, error)
+}
+
+type dynamoDiscoverer struct {
+	new func() dynamoClient
+}
+
+func newDynamoDBDiscoverer(cfg aws.Config) Discoverer {
+	return &dynamoDiscoverer{new: func() dynamoClient { return dynamodb.NewFromConfig(cfg) }}
+}
+
+func (d *dynamoDiscoverer) ResourceType() string { return "aws_dynamodb_table" }
+
+// Discover paginates ListTables and filters by name prefix (DynamoDB does
+// not expose server-side filters on ListTables) — then for each candidate
+// runs ListTagsOfResource to confirm the Project tag. The double check
+// (prefix + tag) defends against table names that share the project prefix
+// by accident.
+//
+// Import ID for aws_dynamodb_table is the table name.
+func (d *dynamoDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
+	client := d.new()
+
+	var all []string
+	input := &dynamodb.ListTablesInput{}
+	for {
+		out, err := client.ListTables(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("ListTables: %w", err)
+		}
+		for _, t := range out.TableNames {
+			if project == "" || hasPrefix(t, project) {
+				all = append(all, t)
+			}
+		}
+		if out.LastEvaluatedTableName == nil || *out.LastEvaluatedTableName == "" {
+			break
+		}
+		input.ExclusiveStartTableName = out.LastEvaluatedTableName
+	}
+
+	var matched []string
+	if project == "" || accountID == "" || region == "" {
+		// Without an account ID + region we cannot construct the ARN
+		// ListTagsOfResource needs. Fall back to prefix-only filtering and
+		// trust the operator-supplied scope. Stage 2c will add a hard-fail
+		// when STS lookup is mandatory.
+		matched = all
+	} else {
+		for _, name := range all {
+			arn := fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", region, accountID, name)
+			tagsOut, err := client.ListTagsOfResource(ctx, &dynamodb.ListTagsOfResourceInput{ResourceArn: aws.String(arn)})
+			if err != nil {
+				// Fail-closed; same rationale as Lambda discoverer.
+				continue
+			}
+			for _, tag := range tagsOut.Tags {
+				if aws.ToString(tag.Key) == "Project" && aws.ToString(tag.Value) == project {
+					matched = append(matched, name)
+					break
+				}
+			}
+		}
+	}
+
+	sort.Strings(matched)
+
+	book := addressBook{}
+	imps := make([]imported.ImportedResource, 0, len(matched))
+	for _, name := range matched {
+		var arn string
+		if accountID != "" && region != "" {
+			arn = fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", region, accountID, name)
+		}
+		imps = append(imps, makeImportedResource(
+			book,
+			"aws_dynamodb_table",
+			name,
+			name,
+			region,
+			accountID,
+			map[string]string{"arn": arn},
+		))
+	}
+	return imps, nil
+}
+
+// hasPrefix is a stdlib helper inlined here so the prefix check stays
+// readable next to the ListTables loop. Using strings.HasPrefix would
+// require importing "strings" only for one call.
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}

--- a/cmd/insideout-import/awsdiscover/dynamodb_test.go
+++ b/cmd/insideout-import/awsdiscover/dynamodb_test.go
@@ -1,0 +1,182 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dynamotypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+type fakeDynamoClient struct {
+	pages    []dynamodb.ListTablesOutput
+	tagsByID map[string][]dynamotypes.Tag
+	tagsErr  map[string]error
+
+	listCalls []dynamodb.ListTablesInput
+	tagCalls  []string
+	listErr   error
+}
+
+func (f *fakeDynamoClient) ListTables(_ context.Context, in *dynamodb.ListTablesInput, _ ...func(*dynamodb.Options)) (*dynamodb.ListTablesOutput, error) {
+	f.listCalls = append(f.listCalls, *in)
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	idx := len(f.listCalls) - 1
+	if idx >= len(f.pages) {
+		return &dynamodb.ListTablesOutput{}, nil
+	}
+	return &f.pages[idx], nil
+}
+
+func (f *fakeDynamoClient) ListTagsOfResource(_ context.Context, in *dynamodb.ListTagsOfResourceInput, _ ...func(*dynamodb.Options)) (*dynamodb.ListTagsOfResourceOutput, error) {
+	arn := aws.ToString(in.ResourceArn)
+	f.tagCalls = append(f.tagCalls, arn)
+	if err, ok := f.tagsErr[arn]; ok {
+		return nil, err
+	}
+	return &dynamodb.ListTagsOfResourceOutput{Tags: f.tagsByID[arn]}, nil
+}
+
+func tagPair(k, v string) dynamotypes.Tag {
+	return dynamotypes.Tag{Key: aws.String(k), Value: aws.String(v)}
+}
+
+func TestDynamoDBDiscover_PrefixThenTagFilter(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDynamoClient{
+		pages: []dynamodb.ListTablesOutput{
+			{TableNames: []string{"io-foo-orders", "io-foo-events", "other-table", "io-foo-untagged"}},
+		},
+		tagsByID: map[string][]dynamotypes.Tag{
+			"arn:aws:dynamodb:us-east-1:123:table/io-foo-orders":   {tagPair("Project", "io-foo")},
+			"arn:aws:dynamodb:us-east-1:123:table/io-foo-events":   {tagPair("Project", "io-foo")},
+			"arn:aws:dynamodb:us-east-1:123:table/io-foo-untagged": {tagPair("Owner", "team")},
+		},
+	}
+	d := &dynamoDiscoverer{new: func() dynamoClient { return fake }}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Three names match the prefix; one (untagged) lacks Project tag.
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (prefix + tag filter)", len(got))
+	}
+	for _, ir := range got {
+		if ir.Identity.NativeIDs["arn"] == "" {
+			t.Error("NativeIDs[arn] empty")
+		}
+	}
+	// Prefix is supposed to gate the ARN construction so we don't fan
+	// out ListTagsOfResource on every table in the account. Without this
+	// pin, a mutation that drops the prefix check (`if true {...}`) still
+	// produces len==2 because non-prefix-matching tables get tag-filtered
+	// out — the optimization is silent.
+	if len(fake.tagCalls) != 3 {
+		t.Errorf("expected ListTagsOfResource only on the 3 prefix-matching tables; got %d call(s) on %v", len(fake.tagCalls), fake.tagCalls)
+	}
+}
+
+func TestDynamoDBDiscover_PaginatesUntilNoLastEvaluatedKey(t *testing.T) {
+	t.Parallel()
+	d := &dynamoDiscoverer{new: func() dynamoClient {
+		return &fakeDynamoClient{
+			pages: []dynamodb.ListTablesOutput{
+				{TableNames: []string{"io-foo-a"}, LastEvaluatedTableName: aws.String("io-foo-a")},
+				{TableNames: []string{"io-foo-b"}}, // terminal
+			},
+			tagsByID: map[string][]dynamotypes.Tag{
+				"arn:aws:dynamodb:us-east-1:123:table/io-foo-a": {tagPair("Project", "io-foo")},
+				"arn:aws:dynamodb:us-east-1:123:table/io-foo-b": {tagPair("Project", "io-foo")},
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (paginated)", len(got))
+	}
+}
+
+func TestDynamoDBDiscover_FailClosedOnTagsError(t *testing.T) {
+	t.Parallel()
+	d := &dynamoDiscoverer{new: func() dynamoClient {
+		return &fakeDynamoClient{
+			pages: []dynamodb.ListTablesOutput{
+				{TableNames: []string{"io-foo-good", "io-foo-throttled"}},
+			},
+			tagsByID: map[string][]dynamotypes.Tag{
+				"arn:aws:dynamodb:us-east-1:123:table/io-foo-good": {tagPair("Project", "io-foo")},
+			},
+			tagsErr: map[string]error{
+				"arn:aws:dynamodb:us-east-1:123:table/io-foo-throttled": errors.New("Throttling"),
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (throttled skipped)", len(got))
+	}
+	if got[0].Identity.NameHint != "io-foo-good" {
+		t.Errorf("NameHint=%q, want io-foo-good", got[0].Identity.NameHint)
+	}
+}
+
+func TestDynamoDBDiscover_PrefixOnlyFallback(t *testing.T) {
+	t.Parallel()
+	// dynamodb.go:59 falls back to prefix-only when EITHER accountID OR
+	// region is empty (we cannot construct the ARN ListTagsOfResource
+	// needs). Both legs are exercised below — without both, a mutation
+	// that swaps `||` for `&&` survives.
+	cases := []struct {
+		name      string
+		region    string
+		accountID string
+	}{
+		{name: "empty account id", region: "us-east-1", accountID: ""},
+		{name: "empty region", region: "", accountID: "123"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fake := &fakeDynamoClient{
+				pages: []dynamodb.ListTablesOutput{
+					{TableNames: []string{"io-foo-x", "other-y"}},
+				},
+			}
+			d := &dynamoDiscoverer{new: func() dynamoClient { return fake }}
+			got, err := d.Discover(context.Background(), "io-foo", tc.region, tc.accountID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("len=%d, want 1 (prefix-only fallback)", len(got))
+			}
+			// Pin: no ListTagsOfResource calls happened — the fallback
+			// was reached, not the full filter path.
+			if len(fake.tagCalls) != 0 {
+				t.Errorf("fallback should skip ListTagsOfResource; got %d call(s)", len(fake.tagCalls))
+			}
+		})
+	}
+}
+
+func TestDynamoDBDiscover_PropagatesListTablesError(t *testing.T) {
+	t.Parallel()
+	d := &dynamoDiscoverer{new: func() dynamoClient {
+		return &fakeDynamoClient{listErr: errors.New("AccessDenied")}
+	}}
+	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/cmd/insideout-import/awsdiscover/identity.go
+++ b/cmd/insideout-import/awsdiscover/identity.go
@@ -1,0 +1,75 @@
+package awsdiscover
+
+import (
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// awsProviderSource is the canonical Terraform Registry source for the AWS
+// provider. Hardcoded because Stage 2a does not bind a specific provider
+// version — Stage 2b will set ProviderVersion from the actual terraform
+// init output.
+const awsProviderSource = "registry.terraform.io/hashicorp/aws"
+
+// addressBook is the de-dup state passed to imported.GenerateAddress as the
+// `exists` predicate. Each discoverer's loop seeds the book with addresses
+// it has already produced so collisions within a single resource type, or
+// across types in the same DiscoverTypes call, are resolved with the
+// deterministic _<8hex> suffix.
+type addressBook map[string]struct{}
+
+func (b addressBook) exists(addr string) bool { _, ok := b[addr]; return ok }
+
+func (b addressBook) add(addr string) { b[addr] = struct{}{} }
+
+// makeImportedResource builds a Phase-2 ImportedResource from the common
+// shape every AWS discoverer feeds in. typ is the Terraform type
+// ("aws_sqs_queue"), name is the human-readable name (used as NameHint
+// AND populated into NativeIDs["name"] so GenerateAddress's hint-precedence
+// is consistent), importID is whatever the provider's import {} block
+// expects, and nativeIDs lets a discoverer attach extra cloud-side IDs
+// (arn, url) without mutating the merged map after construction.
+//
+// region and accountID are passed in by the aggregator (one STS call per
+// run); the discoverer does not re-derive them.
+func makeImportedResource(book addressBook, typ, name, importID, region, accountID string, nativeIDs map[string]string) imported.ImportedResource {
+	id := imported.ResourceIdentity{
+		Cloud:          "aws",
+		Type:           typ,
+		NameHint:       name,
+		ProviderSource: awsProviderSource,
+		ProviderConfig: "aws.imported",
+		AccountID:      accountID,
+		Region:         region,
+		ImportID:       importID,
+		NativeIDs:      mergeNativeIDs(name, nativeIDs),
+	}
+	addr := imported.GenerateAddress(id, book.exists)
+	id.Address = addr
+	book.add(addr)
+
+	return imported.ImportedResource{
+		Identity: id,
+		Tier:     imported.TierImportedFlat,
+		Source:   imported.SourceImporter,
+	}
+}
+
+// mergeNativeIDs guarantees the discoverer's NativeIDs map carries the
+// "name" key (used by GenerateAddress's pickNameHint precedence). The
+// caller can pass nil for `extra` when no other IDs are available.
+func mergeNativeIDs(name string, extra map[string]string) map[string]string {
+	out := make(map[string]string, 1+len(extra))
+	if name != "" {
+		out["name"] = name
+	}
+	for k, v := range extra {
+		if v == "" {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/cmd/insideout-import/awsdiscover/identity_test.go
+++ b/cmd/insideout-import/awsdiscover/identity_test.go
@@ -1,0 +1,118 @@
+package awsdiscover
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+func TestMakeImportedResource_PopulatesRequiredFields(t *testing.T) {
+	t.Parallel()
+	book := addressBook{}
+	got := makeImportedResource(book, "aws_sqs_queue", "io-foo-q", "https://sqs.us-east-1.amazonaws.com/123/io-foo-q", "us-east-1", "123", map[string]string{"url": "https://sqs.us-east-1.amazonaws.com/123/io-foo-q"})
+
+	if got.Identity.Cloud != "aws" {
+		t.Errorf("Cloud=%q, want aws", got.Identity.Cloud)
+	}
+	if got.Identity.Type != "aws_sqs_queue" {
+		t.Errorf("Type=%q, want aws_sqs_queue", got.Identity.Type)
+	}
+	if got.Identity.Address == "" {
+		t.Error("Address must be populated by GenerateAddress")
+	}
+	if got.Identity.ImportID == "" {
+		t.Error("ImportID must be populated")
+	}
+	if got.Identity.NameHint != "io-foo-q" {
+		t.Errorf("NameHint=%q, want io-foo-q", got.Identity.NameHint)
+	}
+	if got.Identity.AccountID != "123" {
+		t.Errorf("AccountID=%q, want 123", got.Identity.AccountID)
+	}
+	if got.Identity.Region != "us-east-1" {
+		t.Errorf("Region=%q, want us-east-1", got.Identity.Region)
+	}
+	if got.Identity.ProviderSource != awsProviderSource {
+		t.Errorf("ProviderSource=%q, want %q", got.Identity.ProviderSource, awsProviderSource)
+	}
+	// The composer's emitted HCL references `provider = aws.imported`
+	// for every imported AWS resource (per Phase 2 design decision: see
+	// pkg/composer/imported_emit.go::providerAliasFor). A mutation that
+	// drops or renames this constant breaks every downstream stack.
+	if got.Identity.ProviderConfig != "aws.imported" {
+		t.Errorf("ProviderConfig=%q, want aws.imported", got.Identity.ProviderConfig)
+	}
+	if got.Identity.NativeIDs["name"] != "io-foo-q" {
+		t.Errorf("NativeIDs[name]=%q, want io-foo-q", got.Identity.NativeIDs["name"])
+	}
+	if got.Identity.NativeIDs["url"] == "" {
+		t.Error("NativeIDs[url] should be populated by extra map")
+	}
+	if got.Tier != imported.TierImportedFlat {
+		t.Errorf("Tier=%q, want TierImportedFlat", got.Tier)
+	}
+	if got.Source != imported.SourceImporter {
+		t.Errorf("Source=%q, want SourceImporter", got.Source)
+	}
+}
+
+func TestMakeImportedResource_ResolvesAddressCollisionsWithinBatch(t *testing.T) {
+	t.Parallel()
+	book := addressBook{}
+	a := makeImportedResource(book, "aws_sqs_queue", "io-q", "https://example/io-q-1", "us-east-1", "123", nil)
+	b := makeImportedResource(book, "aws_sqs_queue", "io-q", "https://example/io-q-2", "us-east-1", "123", nil)
+
+	// Identical NameHint but different ImportID → identityHash differs →
+	// GenerateAddress's `_<8hex>` collision suffix should produce
+	// distinct addresses.
+	if a.Identity.Address == b.Identity.Address {
+		t.Errorf("expected distinct addresses for distinct identities; got %q twice", a.Identity.Address)
+	}
+	// Pin the suffix shape: collision-resolved address == base + "_" + 8 hex.
+	// A mutation that shrinks the hash to 4 hex (or shifts to a different
+	// separator) survives the cardinality test alone.
+	if !strings.HasPrefix(b.Identity.Address, a.Identity.Address+"_") {
+		t.Errorf("collision-resolved address %q must start with the original %q + '_'", b.Identity.Address, a.Identity.Address)
+	}
+	suffix := b.Identity.Address[len(a.Identity.Address)+1:]
+	if len(suffix) != 8 {
+		t.Errorf("collision suffix = %q (len=%d), want 8 hex chars", suffix, len(suffix))
+	}
+	for _, r := range suffix {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			t.Errorf("collision suffix %q contains non-hex %q", suffix, r)
+			break
+		}
+	}
+}
+
+func TestMergeNativeIDs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		hint string
+		in   map[string]string
+		want map[string]string
+	}{
+		{name: "name only", hint: "io-q", in: nil, want: map[string]string{"name": "io-q"}},
+		{name: "name plus url", hint: "io-q", in: map[string]string{"url": "u"}, want: map[string]string{"name": "io-q", "url": "u"}},
+		{name: "drops empty values", hint: "io-q", in: map[string]string{"arn": "", "url": "u"}, want: map[string]string{"name": "io-q", "url": "u"}},
+		{name: "empty everything returns nil", hint: "", in: nil, want: nil},
+		{name: "empty hint with extras", hint: "", in: map[string]string{"arn": "a"}, want: map[string]string{"arn": "a"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := mergeNativeIDs(tc.hint, tc.in)
+			if len(got) != len(tc.want) {
+				t.Errorf("len=%d, want %d (%v)", len(got), len(tc.want), got)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("got[%q]=%q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}

--- a/cmd/insideout-import/awsdiscover/lambda.go
+++ b/cmd/insideout-import/awsdiscover/lambda.go
@@ -1,0 +1,98 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// lambdaClient is the narrow subset of the Lambda SDK the discoverer uses.
+// Mirrors pkg/observability/discovery/aws/compute.go:123 (lambdaFunctionsClient).
+type lambdaClient interface {
+	ListFunctions(ctx context.Context, in *lambda.ListFunctionsInput, opts ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error)
+	ListTags(ctx context.Context, in *lambda.ListTagsInput, opts ...func(*lambda.Options)) (*lambda.ListTagsOutput, error)
+}
+
+type lambdaDiscoverer struct {
+	new func() lambdaClient
+}
+
+func newLambdaDiscoverer(cfg aws.Config) Discoverer {
+	return &lambdaDiscoverer{new: func() lambdaClient { return lambda.NewFromConfig(cfg) }}
+}
+
+func (d *lambdaDiscoverer) ResourceType() string { return "aws_lambda_function" }
+
+// Discover paginates ListFunctions then per-function ListTags fan-out to
+// keep functions tagged Project=<project>. Lambda has no server-side tag
+// filter, so this is the cheapest correct shape.
+//
+// ListTags errors per-arn log-and-skip (fail-closed: an unreachable ListTags
+// is treated as "no Project tag", not "include anyway"). ListFunctions
+// errors abort so we never return a silently-truncated account scan.
+//
+// Import ID for aws_lambda_function is the function name.
+func (d *lambdaDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
+	client := d.new()
+
+	type fn struct {
+		name string
+		arn  string
+	}
+	var allFns []fn
+
+	paginator := lambda.NewListFunctionsPaginator(client, &lambda.ListFunctionsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("ListFunctions: %w", err)
+		}
+		for _, f := range page.Functions {
+			allFns = append(allFns, fn{
+				name: aws.ToString(f.FunctionName),
+				arn:  aws.ToString(f.FunctionArn),
+			})
+		}
+	}
+
+	var matched []fn
+	if project == "" {
+		matched = allFns
+	} else {
+		for _, f := range allFns {
+			tagsOut, err := client.ListTags(ctx, &lambda.ListTagsInput{Resource: aws.String(f.arn)})
+			if err != nil {
+				// Fail-closed: a transient ListTags failure should not silently
+				// leak a function into the import set with no proof of project
+				// ownership. Log and skip — the operator sees the gap and can
+				// re-run after the throttle / permission issue resolves.
+				continue
+			}
+			if tagsOut.Tags["Project"] == project {
+				matched = append(matched, f)
+			}
+		}
+	}
+
+	sort.Slice(matched, func(i, j int) bool { return matched[i].name < matched[j].name })
+
+	book := addressBook{}
+	out := make([]imported.ImportedResource, 0, len(matched))
+	for _, f := range matched {
+		out = append(out, makeImportedResource(
+			book,
+			"aws_lambda_function",
+			f.name,
+			f.name,
+			region,
+			accountID,
+			map[string]string{"arn": f.arn},
+		))
+	}
+	return out, nil
+}

--- a/cmd/insideout-import/awsdiscover/lambda_test.go
+++ b/cmd/insideout-import/awsdiscover/lambda_test.go
@@ -1,0 +1,203 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+)
+
+type fakeLambdaClient struct {
+	pages    []lambda.ListFunctionsOutput
+	tagsByID map[string]map[string]string
+	tagsErr  map[string]error // errors keyed by ARN
+
+	listCalls int
+	tagCalls  []string
+}
+
+func (f *fakeLambdaClient) ListFunctions(_ context.Context, _ *lambda.ListFunctionsInput, _ ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error) {
+	idx := f.listCalls
+	f.listCalls++
+	if idx >= len(f.pages) {
+		return &lambda.ListFunctionsOutput{}, nil
+	}
+	return &f.pages[idx], nil
+}
+
+func (f *fakeLambdaClient) ListTags(_ context.Context, in *lambda.ListTagsInput, _ ...func(*lambda.Options)) (*lambda.ListTagsOutput, error) {
+	arn := aws.ToString(in.Resource)
+	f.tagCalls = append(f.tagCalls, arn)
+	if err, ok := f.tagsErr[arn]; ok {
+		return nil, err
+	}
+	return &lambda.ListTagsOutput{Tags: f.tagsByID[arn]}, nil
+}
+
+func fn(name, arn string) lambdatypes.FunctionConfiguration {
+	return lambdatypes.FunctionConfiguration{
+		FunctionName: aws.String(name),
+		FunctionArn:  aws.String(arn),
+	}
+}
+
+func TestLambdaDiscover_FiltersByProjectTag(t *testing.T) {
+	t.Parallel()
+	d := &lambdaDiscoverer{new: func() lambdaClient {
+		return &fakeLambdaClient{
+			pages: []lambda.ListFunctionsOutput{
+				{Functions: []lambdatypes.FunctionConfiguration{
+					fn("io-foo-a", "arn-a"),
+					fn("other-b", "arn-b"),
+					fn("io-foo-c", "arn-c"),
+				}},
+			},
+			tagsByID: map[string]map[string]string{
+				"arn-a": {"Project": "io-foo"},
+				"arn-b": {"Project": "other"},
+				"arn-c": {"Project": "io-foo"},
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (filtered)", len(got))
+	}
+	for _, ir := range got {
+		if ir.Identity.NameHint == "other-b" {
+			t.Error("function with non-matching Project tag leaked through filter")
+		}
+	}
+}
+
+func TestLambdaDiscover_EmptyProjectReturnsAll(t *testing.T) {
+	t.Parallel()
+	d := &lambdaDiscoverer{new: func() lambdaClient {
+		return &fakeLambdaClient{
+			pages: []lambda.ListFunctionsOutput{
+				{Functions: []lambdatypes.FunctionConfiguration{fn("a", "arn-a"), fn("b", "arn-b")}},
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), "", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (all when project empty)", len(got))
+	}
+}
+
+func TestLambdaDiscover_FailClosedOnTagsError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeLambdaClient{
+		pages: []lambda.ListFunctionsOutput{
+			{Functions: []lambdatypes.FunctionConfiguration{
+				fn("io-foo-a", "arn-a"),
+				fn("io-foo-b", "arn-b"),
+			}},
+		},
+		tagsByID: map[string]map[string]string{
+			"arn-b": {"Project": "io-foo"},
+		},
+		tagsErr: map[string]error{"arn-a": errors.New("Throttling")},
+	}
+	d := &lambdaDiscoverer{new: func() lambdaClient { return fake }}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// arn-a's ListTags failed → fail-closed (skip), arn-b matched → include.
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (arn-b only)", len(got))
+	}
+	if got[0].Identity.NameHint != "io-foo-b" {
+		t.Errorf("NameHint=%q, want io-foo-b", got[0].Identity.NameHint)
+	}
+	// Pin that ListTags was *attempted* on arn-a before fail-closed kicked
+	// in — without this assertion a mutation that skipped arn-a entirely
+	// (never even calling ListTags) would still produce len==1 and the
+	// test would silently accept.
+	if !contains(fake.tagCalls, "arn-a") {
+		t.Errorf("ListTags must be attempted on arn-a before fail-closed; tagCalls=%v", fake.tagCalls)
+	}
+	if !contains(fake.tagCalls, "arn-b") {
+		t.Errorf("ListTags must be attempted on arn-b; tagCalls=%v", fake.tagCalls)
+	}
+}
+
+// TestLambdaDiscover_SkipsFunctionWithNoProjectTag pins the empty-tags-but-
+// successful-call branch — distinct from the error branch covered by
+// FailClosedOnTagsError. Without this, a mutation that reads
+// tagsOut.Tags["Project"] from a tag map with no Project key still
+// "succeeds" via the missing-key zero-value path (== "" != project) so
+// it's correctly excluded — we want to make sure that exclusion stays
+// in place if the conditional is altered.
+func TestLambdaDiscover_SkipsFunctionWithNoProjectTag(t *testing.T) {
+	t.Parallel()
+	d := &lambdaDiscoverer{new: func() lambdaClient {
+		return &fakeLambdaClient{
+			pages: []lambda.ListFunctionsOutput{
+				{Functions: []lambdatypes.FunctionConfiguration{
+					fn("io-foo-untagged", "arn-untagged"),
+					fn("io-foo-tagged", "arn-tagged"),
+				}},
+			},
+			tagsByID: map[string]map[string]string{
+				"arn-untagged": {"Owner": "team", "Env": "prod"}, // no Project key
+				"arn-tagged":   {"Project": "io-foo"},
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (untagged excluded)", len(got))
+	}
+	if got[0].Identity.NameHint != "io-foo-tagged" {
+		t.Errorf("wrong function admitted: NameHint=%q", got[0].Identity.NameHint)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestLambdaDiscover_AbortsOnListFunctionsError(t *testing.T) {
+	t.Parallel()
+	// fake that returns an error from ListFunctions: the paginator
+	// surfaces it directly via NextPage. Use an empty fake struct and
+	// inject error via a wrapping client.
+	wrap := &lambdaErrClient{err: errors.New("AccessDenied")}
+	d := &lambdaDiscoverer{new: func() lambdaClient { return wrap }}
+	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err == nil {
+		t.Fatal("expected ListFunctions error to abort")
+	}
+}
+
+// lambdaErrClient is a tiny client whose ListFunctions always errors.
+// ListTags is here only to satisfy the interface — it's never called
+// because ListFunctions aborts the run before any tag fan-out begins.
+type lambdaErrClient struct{ err error }
+
+func (c *lambdaErrClient) ListFunctions(_ context.Context, _ *lambda.ListFunctionsInput, _ ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error) {
+	return nil, c.err
+}
+
+func (c *lambdaErrClient) ListTags(_ context.Context, _ *lambda.ListTagsInput, _ ...func(*lambda.Options)) (*lambda.ListTagsOutput, error) {
+	return nil, c.err
+}

--- a/cmd/insideout-import/awsdiscover/secretsmanager.go
+++ b/cmd/insideout-import/awsdiscover/secretsmanager.go
@@ -1,0 +1,90 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// smClient is the narrow subset of the Secrets Manager SDK we consume.
+type smClient interface {
+	ListSecrets(ctx context.Context, in *secretsmanager.ListSecretsInput, opts ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error)
+}
+
+type secretsManagerDiscoverer struct {
+	new func() smClient
+}
+
+func newSecretsManagerDiscoverer(cfg aws.Config) Discoverer {
+	return &secretsManagerDiscoverer{new: func() smClient { return secretsmanager.NewFromConfig(cfg) }}
+}
+
+func (d *secretsManagerDiscoverer) ResourceType() string { return "aws_secretsmanager_secret" }
+
+// Discover finds secrets tagged Project=<project>. Secrets Manager is the
+// only one of the Phase 1 services that supports server-side tag filtering,
+// so we use it instead of paginate-then-fanout.
+//
+// Import ID for aws_secretsmanager_secret is the secret ARN.
+func (d *secretsManagerDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
+	client := d.new()
+	input := &secretsmanager.ListSecretsInput{}
+	if project != "" {
+		input.Filters = []smtypes.Filter{
+			{
+				Key:    smtypes.FilterNameStringTypeTagKey,
+				Values: []string{"Project"},
+			},
+			{
+				Key:    smtypes.FilterNameStringTypeTagValue,
+				Values: []string{project},
+			},
+		}
+	}
+
+	type secret struct {
+		name string
+		arn  string
+	}
+	var secrets []secret
+
+	for {
+		out, err := client.ListSecrets(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("ListSecrets: %w", err)
+		}
+		for _, s := range out.SecretList {
+			secrets = append(secrets, secret{
+				name: aws.ToString(s.Name),
+				arn:  aws.ToString(s.ARN),
+			})
+		}
+		if out.NextToken == nil || *out.NextToken == "" {
+			break
+		}
+		input.NextToken = out.NextToken
+	}
+
+	sort.Slice(secrets, func(i, j int) bool { return secrets[i].arn < secrets[j].arn })
+
+	book := addressBook{}
+	imps := make([]imported.ImportedResource, 0, len(secrets))
+	for _, s := range secrets {
+		imps = append(imps, makeImportedResource(
+			book,
+			"aws_secretsmanager_secret",
+			s.name,
+			s.arn,
+			region,
+			accountID,
+			map[string]string{"arn": s.arn},
+		))
+	}
+	return imps, nil
+}

--- a/cmd/insideout-import/awsdiscover/secretsmanager_test.go
+++ b/cmd/insideout-import/awsdiscover/secretsmanager_test.go
@@ -1,0 +1,137 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+)
+
+type fakeSMClient struct {
+	pages []secretsmanager.ListSecretsOutput
+	calls []secretsmanager.ListSecretsInput
+	err   error
+}
+
+func (f *fakeSMClient) ListSecrets(_ context.Context, in *secretsmanager.ListSecretsInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
+	f.calls = append(f.calls, *in)
+	if f.err != nil {
+		return nil, f.err
+	}
+	idx := len(f.calls) - 1
+	if idx >= len(f.pages) {
+		return &secretsmanager.ListSecretsOutput{}, nil
+	}
+	return &f.pages[idx], nil
+}
+
+func TestSecretsManagerDiscover_HappyPath(t *testing.T) {
+	t.Parallel()
+	d := &secretsManagerDiscoverer{new: func() smClient {
+		return &fakeSMClient{
+			pages: []secretsmanager.ListSecretsOutput{
+				{
+					SecretList: []smtypes.SecretListEntry{
+						{Name: aws.String("io-foo/db-password"), ARN: aws.String("arn:aws:secretsmanager:us-east-1:123:secret:io-foo/db-password-AbC")},
+						{Name: aws.String("io-foo/api-token"), ARN: aws.String("arn:aws:secretsmanager:us-east-1:123:secret:io-foo/api-token-XyZ")},
+					},
+				},
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+	for _, ir := range got {
+		if ir.Identity.ImportID == "" {
+			t.Error("ImportID empty")
+		}
+		if ir.Identity.NativeIDs["arn"] == "" {
+			t.Error("NativeIDs[arn] empty")
+		}
+	}
+}
+
+func TestSecretsManagerDiscover_UsesServerSideTagFilter(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSMClient{}
+	d := &secretsManagerDiscoverer{new: func() smClient { return fake }}
+	if _, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123"); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) == 0 {
+		t.Fatal("expected at least one ListSecrets call")
+	}
+	// Assert by content, not by index: the discoverer is free to add
+	// further filters later (e.g., DeletionStatus) without breaking this
+	// test as long as the tag-key + tag-value pair is still present.
+	byKey := map[smtypes.FilterNameStringType][]string{}
+	for _, f := range fake.calls[0].Filters {
+		byKey[f.Key] = f.Values
+	}
+	if got, want := byKey[smtypes.FilterNameStringTypeTagKey], []string{"Project"}; !equalStrings(got, want) {
+		t.Errorf("tag-key filter = %v, want %v", got, want)
+	}
+	if got, want := byKey[smtypes.FilterNameStringTypeTagValue], []string{"io-foo"}; !equalStrings(got, want) {
+		t.Errorf("tag-value filter = %v, want %v", got, want)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestSecretsManagerDiscover_EmptyProjectNoFilters(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSMClient{}
+	d := &secretsManagerDiscoverer{new: func() smClient { return fake }}
+	if _, err := d.Discover(context.Background(), "", "us-east-1", "123"); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) == 0 || len(fake.calls[0].Filters) != 0 {
+		t.Errorf("expected no filters for empty project; got %+v", fake.calls)
+	}
+}
+
+func TestSecretsManagerDiscover_PaginatesUntilNoToken(t *testing.T) {
+	t.Parallel()
+	d := &secretsManagerDiscoverer{new: func() smClient {
+		return &fakeSMClient{
+			pages: []secretsmanager.ListSecretsOutput{
+				{SecretList: []smtypes.SecretListEntry{{Name: aws.String("a"), ARN: aws.String("arn-a")}}, NextToken: aws.String("t1")},
+				{SecretList: []smtypes.SecretListEntry{{Name: aws.String("b"), ARN: aws.String("arn-b")}}}, // terminal
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+}
+
+func TestSecretsManagerDiscover_PropagatesError(t *testing.T) {
+	t.Parallel()
+	d := &secretsManagerDiscoverer{new: func() smClient { return &fakeSMClient{err: errors.New("AccessDenied")} }}
+	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/cmd/insideout-import/awsdiscover/sqs.go
+++ b/cmd/insideout-import/awsdiscover/sqs.go
@@ -1,0 +1,87 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// sqsClient is the narrow subset of the SQS SDK the discoverer uses.
+// Mirrors the pattern in pkg/observability/discovery/aws (lambdaFunctionsClient
+// at compute.go:123) so tests can mock without the full SDK surface.
+type sqsClient interface {
+	ListQueues(ctx context.Context, in *sqs.ListQueuesInput, opts ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error)
+}
+
+type sqsDiscoverer struct {
+	new func() sqsClient
+}
+
+func newSQSDiscoverer(cfg aws.Config) Discoverer {
+	return &sqsDiscoverer{new: func() sqsClient { return sqs.NewFromConfig(cfg) }}
+}
+
+func (d *sqsDiscoverer) ResourceType() string { return "aws_sqs_queue" }
+
+// Discover lists queues whose names start with the project prefix. SQS
+// supports a server-side QueueNamePrefix filter, so we never have to
+// download every queue in the account just to filter client-side.
+//
+// Import ID for aws_sqs_queue is the queue URL itself.
+func (d *sqsDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
+	client := d.new()
+	input := &sqs.ListQueuesInput{}
+	if project != "" {
+		p := project
+		input.QueueNamePrefix = &p
+	}
+
+	urls, err := paginateListQueues(ctx, client, input)
+	if err != nil {
+		return nil, fmt.Errorf("ListQueues: %w", err)
+	}
+
+	// Sort URLs so the emitted manifest is deterministic across runs.
+	sort.Strings(urls)
+
+	book := addressBook{}
+	out := make([]imported.ImportedResource, 0, len(urls))
+	for _, url := range urls {
+		// Queue URL: https://sqs.<region>.amazonaws.com/<account>/<name>
+		// The name is the final segment.
+		name := path.Base(url)
+		out = append(out, makeImportedResource(
+			book,
+			"aws_sqs_queue",
+			name,
+			url,
+			region,
+			accountID,
+			map[string]string{"url": url},
+		))
+	}
+	return out, nil
+}
+
+// paginateListQueues walks all NextToken pages. The SDK's ListQueues call
+// returns at most 1000 queues per page, so this matters on large accounts.
+func paginateListQueues(ctx context.Context, client sqsClient, input *sqs.ListQueuesInput) ([]string, error) {
+	var all []string
+	for {
+		out, err := client.ListQueues(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, out.QueueUrls...)
+		if out.NextToken == nil || *out.NextToken == "" {
+			return all, nil
+		}
+		input.NextToken = out.NextToken
+	}
+}

--- a/cmd/insideout-import/awsdiscover/sqs_test.go
+++ b/cmd/insideout-import/awsdiscover/sqs_test.go
@@ -1,0 +1,133 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+type fakeSQSClient struct {
+	pages []sqs.ListQueuesOutput
+	calls []sqs.ListQueuesInput
+	err   error // when non-nil, every ListQueues call returns this
+}
+
+func (f *fakeSQSClient) ListQueues(_ context.Context, in *sqs.ListQueuesInput, _ ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
+	f.calls = append(f.calls, *in)
+	if f.err != nil {
+		return nil, f.err
+	}
+	idx := len(f.calls) - 1
+	if idx >= len(f.pages) {
+		// out of pages; return empty terminal page
+		return &sqs.ListQueuesOutput{}, nil
+	}
+	return &f.pages[idx], nil
+}
+
+func ptr(s string) *string { return &s }
+
+func TestSQSDiscover_HappyPath(t *testing.T) {
+	t.Parallel()
+	d := &sqsDiscoverer{new: func() sqsClient {
+		return &fakeSQSClient{
+			pages: []sqs.ListQueuesOutput{
+				{
+					QueueUrls: []string{
+						"https://sqs.us-east-1.amazonaws.com/123/io-foo-orders",
+						"https://sqs.us-east-1.amazonaws.com/123/io-foo-orders-dlq",
+					},
+				},
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+	for _, ir := range got {
+		if ir.Identity.Type != "aws_sqs_queue" {
+			t.Errorf("Type=%q", ir.Identity.Type)
+		}
+		if ir.Identity.ImportID == "" {
+			t.Error("ImportID empty")
+		}
+		if ir.Identity.NativeIDs["url"] == "" {
+			t.Error("NativeIDs[url] empty")
+		}
+		if ir.Identity.NativeIDs["name"] == "" {
+			t.Error("NativeIDs[name] empty")
+		}
+	}
+	// Output is sorted by URL → addresses are deterministic.
+	if got[0].Identity.NameHint != "io-foo-orders" {
+		t.Errorf("first NameHint=%q, want io-foo-orders (sorted)", got[0].Identity.NameHint)
+	}
+}
+
+func TestSQSDiscover_PaginatesUntilNoToken(t *testing.T) {
+	t.Parallel()
+	d := &sqsDiscoverer{new: func() sqsClient {
+		return &fakeSQSClient{
+			pages: []sqs.ListQueuesOutput{
+				{QueueUrls: []string{"https://example/io-foo-a"}, NextToken: ptr("tok1")},
+				{QueueUrls: []string{"https://example/io-foo-b"}, NextToken: ptr("tok2")},
+				{QueueUrls: []string{"https://example/io-foo-c"}}, // terminal
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len=%d, want 3 (paginated)", len(got))
+	}
+}
+
+func TestSQSDiscover_PassesPrefixServerSide(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSQSClient{}
+	d := &sqsDiscoverer{new: func() sqsClient { return fake }}
+	if _, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123"); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) == 0 {
+		t.Fatal("expected at least one ListQueues call")
+	}
+	in := fake.calls[0]
+	if in.QueueNamePrefix == nil || *in.QueueNamePrefix != "io-foo" {
+		t.Errorf("QueueNamePrefix=%v, want io-foo", in.QueueNamePrefix)
+	}
+}
+
+func TestSQSDiscover_EmptyProjectPassesNoPrefix(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSQSClient{}
+	d := &sqsDiscoverer{new: func() sqsClient { return fake }}
+	if _, err := d.Discover(context.Background(), "", "us-east-1", "123"); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) == 0 {
+		t.Fatal("expected at least one ListQueues call")
+	}
+	if fake.calls[0].QueueNamePrefix != nil {
+		t.Errorf("QueueNamePrefix=%v, want nil for empty project", fake.calls[0].QueueNamePrefix)
+	}
+}
+
+func TestSQSDiscover_PropagatesError(t *testing.T) {
+	t.Parallel()
+	d := &sqsDiscoverer{new: func() sqsClient {
+		return &fakeSQSClient{err: errors.New("AccessDenied")}
+	}}
+	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/cmd/insideout-import/awsdiscover/testhelpers_test.go
+++ b/cmd/insideout-import/awsdiscover/testhelpers_test.go
@@ -1,0 +1,9 @@
+package awsdiscover
+
+import "github.com/aws/aws-sdk-go-v2/aws"
+
+// awsDummyConfig returns an aws.Config with no real credentials. Tests
+// that build the production AWSDiscoverer just to inspect its registry
+// (e.g. TestNewAWSDiscoverer_Registers5PhaseOneTypes) need *some* config
+// to call NewAWSDiscoverer; they do not perform any SDK calls.
+func awsDummyConfig() aws.Config { return aws.Config{Region: "us-east-1"} }

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+const (
+	discoverExitOK    = 0
+	discoverExitFatal = 1
+
+	discoverTimeout = 15 * time.Minute
+)
+
+// discoveryAggregator is the small subset of awsdiscover.AWSDiscoverer the
+// orchestrator needs. Defining the interface in main lets tests inject a
+// fake aggregator without standing up real AWS clients.
+type discoveryAggregator interface {
+	DiscoverTypes(ctx context.Context, types []string, project, region, accountID string) ([]imported.ImportedResource, error)
+}
+
+// discoverDeps gathers the AWS-side seams that runDiscover would otherwise
+// hit directly. Production code passes productionDiscoverDeps(); tests pass
+// fakes to exercise the post-STS branches (validator failure, DiscoverTypes
+// error, nil STS account) without real AWS credentials.
+type discoverDeps struct {
+	loadConfig    func(ctx context.Context, region string) (aws.Config, error)
+	getAccount    func(ctx context.Context, cfg aws.Config) (string, error)
+	newDiscoverer func(cfg aws.Config) discoveryAggregator
+}
+
+func productionDiscoverDeps() discoverDeps {
+	return discoverDeps{
+		loadConfig: func(ctx context.Context, region string) (aws.Config, error) {
+			return config.LoadDefaultConfig(ctx, config.WithRegion(region))
+		},
+		getAccount: func(ctx context.Context, cfg aws.Config) (string, error) {
+			out, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+			if err != nil {
+				return "", err
+			}
+			if out.Account == nil {
+				return "", nil
+			}
+			return *out.Account, nil
+		},
+		newDiscoverer: func(cfg aws.Config) discoveryAggregator {
+			return awsdiscover.NewAWSDiscoverer(cfg)
+		},
+	}
+}
+
+func runDiscover(args []string) int {
+	return runDiscoverWithDeps(args, productionDiscoverDeps())
+}
+
+func runDiscoverWithDeps(args []string, deps discoverDeps) int {
+	fs := flag.NewFlagSet("discover", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, `insideout-import discover — discover existing cloud resources and write imported.json.
+
+Usage:
+  insideout-import discover --provider aws --project P --region R --output-dir DIR [flags]
+
+Stage 2a: AWS only, SDK-driven discovery for the 5 Phase 1 resource types.
+GCP support, terraform-exec HCL generation, drift fixing, and dependency
+chasing land in Stages 2b–2d (see #189 for the chain).
+
+Flags:`)
+		fs.PrintDefaults()
+		fmt.Fprintln(os.Stderr, `
+Exit codes:
+  0  imported.json written and validated
+  1  fatal: bad inputs, AWS errors, or validator failure (no partial manifest written)`)
+	}
+
+	provider := fs.String("provider", "", "cloud provider: aws (gcp lands in Stage 2d) (required)")
+	project := fs.String("project", "", "project name prefix used to filter resources (required)")
+	region := fs.String("region", "", "AWS region to scan (required for --provider aws)")
+	outputDir := fs.String("output-dir", "", "directory to write imported.json into (required)")
+	resourceTypes := fs.String("resource-types", "", "comma-separated subset of types to discover; default: all 5 Phase 1 types")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return discoverExitOK
+		}
+		return discoverExitFatal
+	}
+
+	switch strings.TrimSpace(*provider) {
+	case "aws":
+		// fallthrough to AWS path
+	case "gcp":
+		fmt.Fprintln(os.Stderr, "discover: --provider gcp not yet implemented (tracked in #264 / Stage 2d)")
+		return discoverExitFatal
+	case "":
+		fmt.Fprintln(os.Stderr, "discover: --provider is required (only 'aws' is supported in Stage 2a)")
+		fs.Usage()
+		return discoverExitFatal
+	default:
+		fmt.Fprintf(os.Stderr, "discover: unknown --provider %q (only 'aws' is supported in Stage 2a)\n", *provider)
+		return discoverExitFatal
+	}
+
+	if strings.TrimSpace(*project) == "" {
+		fmt.Fprintln(os.Stderr, "discover: --project is required")
+		return discoverExitFatal
+	}
+	if strings.TrimSpace(*region) == "" {
+		fmt.Fprintln(os.Stderr, "discover: --region is required for --provider aws")
+		return discoverExitFatal
+	}
+	if strings.TrimSpace(*outputDir) == "" {
+		fmt.Fprintln(os.Stderr, "discover: --output-dir is required")
+		return discoverExitFatal
+	}
+
+	types := splitCSV(*resourceTypes)
+
+	ctx, cancel := context.WithTimeout(context.Background(), discoverTimeout)
+	defer cancel()
+
+	cfg, err := deps.loadConfig(ctx, *region)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "discover: load AWS config: %v\n", err)
+		return discoverExitFatal
+	}
+
+	// One STS GetCallerIdentity call per run; the result is threaded into
+	// every per-type discoverer so they don't each re-hit STS. We require
+	// the account ID for ARN construction (DynamoDB) and provenance, so a
+	// failure here is fatal. A nil Account on the STS response is treated
+	// as accountID="" — the DynamoDB discoverer's prefix-only fallback
+	// handles that case (see TestDynamoDBDiscover_PrefixOnlyFallback).
+	accountID, err := deps.getAccount(ctx, cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "discover: STS GetCallerIdentity: %v\n", err)
+		return discoverExitFatal
+	}
+
+	d := deps.newDiscoverer(cfg)
+	resources, err := d.DiscoverTypes(ctx, types, *project, *region, accountID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "discover: %v\n", err)
+		return discoverExitFatal
+	}
+
+	out, n, err := writeManifest(*outputDir, "aws", resources)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "discover: %v\n", err)
+		return discoverExitFatal
+	}
+	fmt.Printf("wrote %s (%d resource(s) discovered)\n", out, n)
+	return discoverExitOK
+}
+
+// splitCSV splits a comma-separated flag value, trims whitespace, and drops
+// empty entries. Returns nil for empty input so DiscoverTypes uses its
+// default (all supported types).
+func splitCSV(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// runDiscover error-path tests. Happy-path requires AWS credentials and
+// is exercised by the live smoke against the io-buqiks112yag test account
+// (see PR description / acceptance criteria) — not in CI.
+
+func TestRunDiscover_MissingProvider(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rc := runDiscover([]string{"--project", "p", "--region", "us-east-1", "--output-dir", dir})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+}
+
+func TestRunDiscover_GCPNotYetImplemented(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rc := runDiscover([]string{"--provider", "gcp", "--project", "p", "--region", "us-east-1", "--output-dir", dir})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal (Stage 2d)", rc)
+	}
+}
+
+func TestRunDiscover_UnknownProvider(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rc := runDiscover([]string{"--provider", "azure", "--project", "p", "--region", "us-east-1", "--output-dir", dir})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+}
+
+func TestRunDiscover_MissingProject(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rc := runDiscover([]string{"--provider", "aws", "--region", "us-east-1", "--output-dir", dir})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+}
+
+func TestRunDiscover_MissingRegion(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rc := runDiscover([]string{"--provider", "aws", "--project", "p", "--output-dir", dir})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+}
+
+func TestRunDiscover_MissingOutputDir(t *testing.T) {
+	t.Parallel()
+	rc := runDiscover([]string{"--provider", "aws", "--project", "p", "--region", "us-east-1"})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+}
+
+// fakeAggregator is a lightweight stand-in for awsdiscover.AWSDiscoverer that
+// captures the inputs DiscoverTypes was called with and returns canned output.
+type fakeAggregator struct {
+	out        []imported.ImportedResource
+	err        error
+	gotProject string
+	gotRegion  string
+	gotAccount string
+	gotTypes   []string
+	called     int
+}
+
+func (f *fakeAggregator) DiscoverTypes(_ context.Context, types []string, project, region, accountID string) ([]imported.ImportedResource, error) {
+	f.called++
+	f.gotProject, f.gotRegion, f.gotAccount, f.gotTypes = project, region, accountID, types
+	return f.out, f.err
+}
+
+func okDeps(agg *fakeAggregator) discoverDeps {
+	return discoverDeps{
+		loadConfig:    func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "1234567890", nil },
+		newDiscoverer: func(_ aws.Config) discoveryAggregator { return agg },
+	}
+}
+
+func validResource(addr string) imported.ImportedResource {
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  addr,
+			ImportID: addr,
+		},
+		Tier:   imported.TierImportedFlat,
+		Source: imported.SourceImporter,
+	}
+}
+
+func TestRunDiscoverWithDeps_HappyPathWritesManifest(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{
+		validResource("aws_sqs_queue.alpha"),
+		validResource("aws_sqs_queue.bravo"),
+	}}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "io-foo", "--region", "us-east-1",
+		"--output-dir", dir,
+	}, okDeps(agg))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want %d", rc, discoverExitOK)
+	}
+	if agg.called != 1 {
+		t.Errorf("DiscoverTypes called %d times, want 1", agg.called)
+	}
+	if agg.gotProject != "io-foo" || agg.gotRegion != "us-east-1" || agg.gotAccount != "1234567890" {
+		t.Errorf("dispatch args = (%q,%q,%q), want (io-foo,us-east-1,1234567890)", agg.gotProject, agg.gotRegion, agg.gotAccount)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "imported.json")); err != nil {
+		t.Errorf("imported.json not written: %v", err)
+	}
+}
+
+func TestRunDiscoverWithDeps_LoadConfigFails(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	deps := discoverDeps{
+		loadConfig: func(_ context.Context, _ string) (aws.Config, error) {
+			return aws.Config{}, errors.New("env unreadable")
+		},
+		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { t.Fatal("should not be called"); return "", nil },
+		newDiscoverer: func(_ aws.Config) discoveryAggregator { t.Fatal("should not be called"); return nil },
+	}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+	}, deps)
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "imported.json")); !os.IsNotExist(err) {
+		t.Errorf("manifest must not be written when LoadConfig fails")
+	}
+}
+
+func TestRunDiscoverWithDeps_STSFails(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	deps := discoverDeps{
+		loadConfig:    func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "", errors.New("AccessDenied") },
+		newDiscoverer: func(_ aws.Config) discoveryAggregator { t.Fatal("should not be called"); return nil },
+	}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+	}, deps)
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+}
+
+// TestRunDiscoverWithDeps_NilSTSAccountThreadsEmpty pins the documented
+// behavior: an STS response with Account=nil is treated as accountID="" and
+// the run continues — the DynamoDB discoverer's prefix-only fallback covers
+// the case downstream. A mutation that hard-fails on empty accountID would
+// silently break STS responses with missing Account fields.
+func TestRunDiscoverWithDeps_NilSTSAccountThreadsEmpty(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	agg := &fakeAggregator{}
+	deps := discoverDeps{
+		loadConfig:    func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "", nil }, // success but empty account
+		newDiscoverer: func(_ aws.Config) discoveryAggregator { return agg },
+	}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+	}, deps)
+	if rc != discoverExitOK {
+		t.Errorf("rc=%d, want OK (nil Account is not fatal)", rc)
+	}
+	if agg.gotAccount != "" {
+		t.Errorf("accountID threaded = %q, want empty", agg.gotAccount)
+	}
+}
+
+func TestRunDiscoverWithDeps_DiscoverTypesFails(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	agg := &fakeAggregator{err: errors.New("Throttling")}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+	}, okDeps(agg))
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "imported.json")); !os.IsNotExist(err) {
+		t.Errorf("manifest must not be written when DiscoverTypes fails")
+	}
+}
+
+// TestRunDiscoverWithDeps_ValidatorFailsExitsFatal pins the validator gate:
+// even if the aggregator returns "successfully", a manifest that fails
+// composer.ValidateImportedResources must produce a fatal exit and no file
+// on disk. The fake here returns a resource missing ImportID — caught by
+// imported_resource_missing_import_id.
+func TestRunDiscoverWithDeps_ValidatorFailsExitsFatal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bad := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.bad"},
+		Tier:     imported.TierImportedFlat,
+		// ImportID intentionally empty.
+	}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+	}, okDeps(&fakeAggregator{out: []imported.ImportedResource{bad}}))
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "imported.json")); !os.IsNotExist(err) {
+		t.Errorf("manifest must not be written when validator fails")
+	}
+}
+
+func TestSplitCSV(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{in: "", want: nil},
+		{in: "  ", want: nil},
+		{in: "a", want: []string{"a"}},
+		{in: "a,b,c", want: []string{"a", "b", "c"}},
+		{in: "  a , b ,c", want: []string{"a", "b", "c"}},
+		{in: "a,,b", want: []string{"a", "b"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			got := splitCSV(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len=%d, want %d (got=%v)", len(got), len(tc.want), got)
+			}
+			for i, w := range tc.want {
+				if got[i] != w {
+					t.Errorf("got[%d]=%q, want %q", i, got[i], w)
+				}
+			}
+		})
+	}
+}

--- a/cmd/insideout-import/main.go
+++ b/cmd/insideout-import/main.go
@@ -9,9 +9,10 @@
 //	          runs `terraform plan -json` to verify the plan is import-only.
 //	          See cmd/insideout-import/README.md.
 //
-//	discover  Reverse-Terraform pipeline (#189). Discovers resources from
-//	          AWS/GCP and generates HCL via `terraform plan -generate-config-out`.
-//	          Stage 2 — not yet implemented.
+//	discover  Discover existing cloud resources and emit imported.json
+//	          (Stage 2a, AWS only). Stage 2b layers `terraform plan
+//	          -generate-config-out` on top to produce HCL; Stage 2c adds
+//	          drift fixing and dependency chasing; Stage 2d adds GCP.
 //
 // Run `insideout-import <subcommand> --help` for subcommand flags.
 package main
@@ -30,8 +31,7 @@ func main() {
 	case "adopt":
 		os.Exit(runAdopt(os.Args[2:]))
 	case "discover":
-		fmt.Fprintln(os.Stderr, "discover: not yet implemented (tracked in #189)")
-		os.Exit(2)
+		os.Exit(runDiscover(os.Args[2:]))
 	case "-h", "--help", "help":
 		usage()
 		os.Exit(0)
@@ -47,7 +47,7 @@ func usage() {
 
 Subcommands:
   adopt     emit import {} blocks against a known preset stack
-  discover  reverse-Terraform discovery (Stage 2 — not yet implemented)
+  discover  discover cloud resources and write imported.json (AWS only — Stage 2a of #189)
 
 Run 'insideout-import <subcommand> --help' for subcommand flags.`)
 }

--- a/cmd/insideout-import/manifest.go
+++ b/cmd/insideout-import/manifest.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// manifestFile is the on-disk file name written into --output-dir.
+const manifestFile = "imported.json"
+
+// writeManifest validates the resource set with composer.ValidateImportedResources
+// and writes the JSON array of ImportedResource into <dir>/imported.json.
+// Validation runs BEFORE the file is written so a failing validator never
+// produces a half-good manifest on disk.
+//
+// Returns (path, count, error). On validator failure, error includes every
+// issue code so the operator can correct in one round-trip rather than
+// running discover repeatedly.
+func writeManifest(dir, cloud string, resources []imported.ImportedResource) (string, int, error) {
+	// json.MarshalIndent of a nil slice writes "null"; downstream
+	// consumers (Reliable, Riley) cannot range over null. Force an empty
+	// slice so the on-disk manifest is always a JSON array.
+	if resources == nil {
+		resources = []imported.ImportedResource{}
+	}
+
+	// Sort by Address so the on-disk file is byte-identical across runs
+	// for the same input. Stage 1's adopt path took the same approach.
+	sort.Slice(resources, func(i, j int) bool {
+		return resources[i].Identity.Address < resources[j].Identity.Address
+	})
+
+	if issues := composer.ValidateImportedResources(cloud, resources); len(issues) > 0 {
+		return "", 0, fmt.Errorf("manifest validation failed (%d issue(s)): %s", len(issues), formatIssues(issues))
+	}
+
+	body, err := json.MarshalIndent(resources, "", "  ")
+	if err != nil {
+		return "", 0, fmt.Errorf("marshal manifest: %w", err)
+	}
+	body = append(body, '\n')
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", 0, fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	out := filepath.Join(dir, manifestFile)
+	if err := os.WriteFile(out, body, 0o644); err != nil {
+		return "", 0, fmt.Errorf("write %s: %w", out, err)
+	}
+	return out, len(resources), nil
+}
+
+// formatIssues turns a slice of validation issues into a multi-line string
+// suitable for an error message. Each line carries the issue code and a
+// short reason — the operator does not need the full ValidationIssue
+// fields (Field, Suggestion, etc.) at the CLI surface; those are for
+// programmatic callers.
+func formatIssues(issues []composer.ValidationIssue) string {
+	out := make([]string, 0, len(issues))
+	for _, i := range issues {
+		line := i.Code
+		if i.Reason != "" {
+			line += ": " + i.Reason
+		}
+		if i.Field != "" {
+			line += " (field=" + i.Field + ")"
+		}
+		out = append(out, line)
+	}
+	// Sorted for deterministic output regardless of validator iteration order.
+	sort.Strings(out)
+	return "\n  " + strings.Join(out, "\n  ")
+}

--- a/cmd/insideout-import/manifest_test.go
+++ b/cmd/insideout-import/manifest_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+func validIR(t, addr, importID string) imported.ImportedResource {
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     t,
+			Address:  addr,
+			ImportID: importID,
+		},
+		Tier:   imported.TierImportedFlat,
+		Source: imported.SourceImporter,
+	}
+}
+
+func TestWriteManifest_HappyPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	resources := []imported.ImportedResource{
+		validIR("aws_sqs_queue", "aws_sqs_queue.b", "https://example/b"),
+		validIR("aws_sqs_queue", "aws_sqs_queue.a", "https://example/a"),
+	}
+	path, n, err := writeManifest(dir, "aws", resources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Errorf("count=%d, want 2", n)
+	}
+	if filepath.Base(path) != "imported.json" {
+		t.Errorf("path=%q, want ends in imported.json", path)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []imported.ImportedResource
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("decoded len=%d, want 2", len(got))
+	}
+	if got[0].Identity.Address != "aws_sqs_queue.a" {
+		t.Errorf("first address=%q, want sorted (aws_sqs_queue.a)", got[0].Identity.Address)
+	}
+}
+
+func TestWriteManifest_DeterministicAcrossRuns(t *testing.T) {
+	t.Parallel()
+	// Use four resources of the same type with non-alphabetic input
+	// order so the sort sees the name suffix as the tiebreaker. A
+	// mutation that drops the sort produces visible drift between runs.
+	resources := []imported.ImportedResource{
+		validIR("aws_sqs_queue", "aws_sqs_queue.delta", "d"),
+		validIR("aws_sqs_queue", "aws_sqs_queue.alpha", "a"),
+		validIR("aws_sqs_queue", "aws_sqs_queue.charlie", "c"),
+		validIR("aws_sqs_queue", "aws_sqs_queue.bravo", "b"),
+	}
+	dir1, dir2 := t.TempDir(), t.TempDir()
+	if _, _, err := writeManifest(dir1, "aws", resources); err != nil {
+		t.Fatal(err)
+	}
+	// Reverse the input order for the second write.
+	rev := make([]imported.ImportedResource, len(resources))
+	for i := range resources {
+		rev[len(resources)-1-i] = resources[i]
+	}
+	if _, _, err := writeManifest(dir2, "aws", rev); err != nil {
+		t.Fatal(err)
+	}
+	a, _ := os.ReadFile(filepath.Join(dir1, "imported.json"))
+	b, _ := os.ReadFile(filepath.Join(dir2, "imported.json"))
+	if string(a) != string(b) {
+		t.Errorf("manifest output depends on input order; must be deterministic\n--- a ---\n%s\n--- b ---\n%s", a, b)
+	}
+	// Pin the ordering: alpha < bravo < charlie < delta in the on-disk
+	// file. Without this, a mutation that emits in a stable-but-wrong
+	// order (e.g. by ImportID) would still produce identical bytes
+	// across the two runs and slip past the cardinality test.
+	got := string(a)
+	if i, j := strings.Index(got, "alpha"), strings.Index(got, "bravo"); i < 0 || j < 0 || i > j {
+		t.Errorf("expected alpha before bravo in sorted manifest; got positions %d,%d", i, j)
+	}
+	if i, j := strings.Index(got, "bravo"), strings.Index(got, "charlie"); i < 0 || j < 0 || i > j {
+		t.Errorf("expected bravo before charlie; got positions %d,%d", i, j)
+	}
+	if i, j := strings.Index(got, "charlie"), strings.Index(got, "delta"); i < 0 || j < 0 || i > j {
+		t.Errorf("expected charlie before delta; got positions %d,%d", i, j)
+	}
+}
+
+func TestWriteManifest_ValidatorFailureNoFileWritten(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bad := []imported.ImportedResource{
+		// Missing ImportID — validator catches it.
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.bad"},
+			Tier:     imported.TierImportedFlat,
+		},
+	}
+	_, _, err := writeManifest(dir, "aws", bad)
+	if err == nil {
+		t.Fatal("expected validator error")
+	}
+	if !strings.Contains(err.Error(), "imported_resource_missing_import_id") {
+		t.Errorf("expected error to mention missing-import-id code; got: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "imported.json")); !os.IsNotExist(statErr) {
+		t.Errorf("imported.json must NOT be written when validation fails; stat err=%v", statErr)
+	}
+}
+
+func TestWriteManifest_AddressCollisionDetectedByValidator(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dup := []imported.ImportedResource{
+		validIR("aws_sqs_queue", "aws_sqs_queue.same", "id-a"),
+		validIR("aws_sqs_queue", "aws_sqs_queue.same", "id-b"),
+	}
+	_, _, err := writeManifest(dir, "aws", dup)
+	if err == nil {
+		t.Fatal("expected collision error")
+	}
+	if !strings.Contains(err.Error(), "imported_resource_address_collision") {
+		t.Errorf("expected address-collision code; got: %v", err)
+	}
+}
+
+func TestWriteManifest_EmptyInputWritesJSONArrayNotNull(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path, n, err := writeManifest(dir, "aws", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("count=%d, want 0", n)
+	}
+	body, _ := os.ReadFile(path)
+	// json.MarshalIndent of a nil slice writes "null", which downstream
+	// consumers (Reliable, Riley) cannot range over. Pin that the writer
+	// emits an empty JSON array even on empty input.
+	if strings.TrimSpace(string(body)) == "null" {
+		t.Errorf("manifest must be `[]` not `null` for empty input; got: %s", body)
+	}
+	if !bytes.HasPrefix(bytes.TrimSpace(body), []byte("[")) {
+		t.Errorf("manifest must start with `[`; got: %s", body)
+	}
+	if !bytes.HasSuffix(body, []byte("\n")) {
+		t.Errorf("manifest must end with a trailing newline; got: %q", body)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `discover` subcommand that scans an AWS account via SDK calls and writes a Phase 2 `imported.ImportedResource[]` manifest into `--output-dir/imported.json`.
- Covers all 5 Phase 1 AWS resource types — SQS, DynamoDB, CloudWatch Logs, Secrets Manager, Lambda — each with a narrow client interface mockable in tests.
- Pre-emit gate via `composer.ValidateImportedResources` (the Phase 2 carrier validator from PR #185). No partial manifest is written on validator failure.
- Manifest sorted by `Identity.Address` so re-runs produce byte-identical output.
- `runDiscover` accepts a `discoverDeps` injection seam — the post-STS branches (validator failure, `DiscoverTypes` error, nil STS account) are unit-testable without AWS credentials.

Stage 2a of the #189 split. See #261 for the full design.

## Why this split (recap of the #189 sub-split)

`#189` was rescoped to umbrella; the four sub-stages now line up against the same fragility seam Stage 1 used:

- **2a (this PR)** — discover skeleton, no terraform-exec → #261.
- **2b** — HCL generation via `terraform plan -generate-config-out` + schema cleanup → #262.
- **2c** — drift fix loop + dependency chase + localstack CI gate → #263.
- **2d** — GCP via Cloud Asset API → #264.

Stage 2a is the high-leverage half: Reliable can already consume `imported.ImportedResource[]` (PR #185), so the manifest path is shippable without taking on the fragile `-generate-config-out` work.

## Per-type SDK strategy

| Type | Filter | Import ID |
|---|---|---|
| `aws_sqs_queue` | server-side `QueueNamePrefix` | queue URL |
| `aws_dynamodb_table` | name prefix + `ListTagsOfResource(arn)` | table name |
| `aws_cloudwatch_log_group` | server-side `LogGroupNamePrefix` | log group name |
| `aws_secretsmanager_secret` | server-side `Filters: tag:Project=<p>` | secret ARN |
| `aws_lambda_function` | paginate + per-arn `ListTags` | function name |

DynamoDB and Lambda fail-closed on per-resource `ListTags` errors — a transient throttle skips the resource rather than admitting an unverified entry. `ListFunctions` / `ListTables` errors abort the run.

## Implementation notes

- `cmd/insideout-import/awsdiscover/` — new package; aggregator + 5 per-type discoverers + `identity.go` helper that wraps `imported.GenerateAddress` for deterministic addressing with `_<8hex>` collision resolution within a discover batch.
- `Discoverer` interface keeps the per-type contract narrow (`ResourceType()` + `Discover(ctx, project, region, accountID)`).
- `AWSDiscoverer.DiscoverTypes` aggregates unknown-type errors before invoking any discoverer (no half-done runs from a typo).
- `manifest.go` forces non-nil slices so empty input emits `[]` not `null` (Reliable / Riley cannot range over null).
- `discover.go` orchestrates: AWS config load → STS GetCallerIdentity (one call per run) → per-type discoverers → `composer.ValidateImportedResources` gate → manifest write. Each step has an injectable seam tested via `discoverDeps`.

## Out of scope (deferred — see #189 children)

- **HCL generation.** `imports.tf` / `generated.tf` come from Stage 2b (#262).
- **Drift fixing, dependency chasing.** Stage 2c (#263).
- **GCP discovery.** Stage 2d (#264) — `--provider gcp` returns "not yet implemented" pointing at #264.
- **Throttle / retry tuning, bounded concurrency.** Stage 2c (per #189's QA carry-forward).
- **Live `terraform plan -detailed-exitcode == 0` zero-drift contract.** Requires HCL generation, so necessarily Stage 2b/2c.

## Test plan

- [x] `go build ./cmd/insideout-import` compiles.
- [x] `go test -race ./cmd/insideout-import/...` passes — 67 unit tests across 11 files; mocks at the SDK boundary so no AWS creds required.
- [x] `go vet ./...`, `gofmt -l`, all 5 lint scripts (`lint-project-tag`, `lint-project-label`, `lint-no-root-only-blocks`, `lint-shared-no-cloud-providers`, `lint-labelless-name-prefix`) clean.
- [x] `terraform fmt -check -recursive` clean.
- [x] qa-professor review on the new test files; P0/P1 findings addressed (mutation-survivor analysis on Lambda/DynamoDB fail-closed, `runDiscover` dep-injection seam for post-STS branches, manifest determinism with non-trivial input order, structural tag-filter assertions in SecretsManager test, etc).
- [x] Local CLI smoke: `discover --help`, `discover --provider gcp`, all error paths exit 1 cleanly. Live AWS path attempted against a non-target account confirms fail-closed wraps the SDK error with the resource type prefix.
- [ ] **Live smoke against the `io-buqiks112yag` test account (AWS account 536892739526) us-east-1 — requires creds I don't have locally.** Reviewer to run before merge or ack via #57's existing test harness.

## Cross-refs

Closes #261.

Sibling stages: #262 (Stage 2b), #263 (Stage 2c), #264 (Stage 2d). Umbrella: #189.

Stage 1 (already merged): #259 / PR #260.

Phase 2 carrier: #143 + closed children #144–#151, #153.
