### PR TITLE
feat(insideout-import): drift-fix loop (Stage 2c1 — plan-clean contract)

### DIFF
--- a/cmd/insideout-import/README.md
+++ b/cmd/insideout-import/README.md
@@ -7,7 +7,7 @@ CLI for bringing existing cloud resources under InsideOut management.
 | Subcommand | Status | Purpose |
 |---|---|---|
 | `adopt` | implemented | Emit `import {}` blocks against an *already-known* preset stack. |
-| `discover` | Stage 2b (AWS, manifest + HCL) | Discover existing cloud resources, emit `imported.json`, and generate validated HCL bodies via `terraform plan -generate-config-out`. Stage 2c adds drift fixing; Stage 2d adds GCP. See #189 for the chain. |
+| `discover` | Stage 2c1 (AWS, manifest + HCL + drift fix) | Discover existing cloud resources, emit `imported.json`, generate validated HCL bodies, and loop `terraform plan` patches until the stack is plan-clean. Stage 2c2/2c3/2c4 add SDK QoS, dependency chase, and a localstack CI gate; Stage 2d adds GCP. See #189 for the chain. |
 
 ## `adopt`
 
@@ -92,6 +92,7 @@ insideout-import discover \
 - `--output-dir` (required) — directory to write `imported.json` into.
 - `--resource-types` — comma-separated subset of supported types. Default: all 5 Phase 1 types (`aws_sqs_queue`, `aws_dynamodb_table`, `aws_cloudwatch_log_group`, `aws_secretsmanager_secret`, `aws_lambda_function`).
 - `--no-hcl` — skip Stage 2b's HCL generation (`terraform plan -generate-config-out` + cleanup). Use when no `terraform` binary is available or when only the manifest is needed.
+- `--no-driftfix` — skip Stage 2c1's drift-fix loop. The generated stack is left at validate-clean rather than plan-clean; useful when iterating on the import and you don't yet care about drift convergence.
 
 ### Output
 
@@ -125,15 +126,16 @@ DynamoDB and Lambda fail-closed on per-resource `ListTags` errors — a transien
 
 | Code | Meaning |
 |---|---|
-| `0` | Manifest written; `composer.ValidateImportedResources` returned no issues. With Stage 2b on, `terraform validate` also passed against the cleaned `generated.tf`. |
-| `1` | Fatal: AWS error, validator failure, terraform binary missing or failing, or bad inputs. No partial manifest is written when validation fails before the write step; with Stage 2b, `imported.json` (Stage 2a output) survives even if Stage 2b fails so the operator can inspect it. |
+| `0` | Manifest written; `composer.ValidateImportedResources` returned no issues. With Stage 2b on, `terraform validate` passed against the cleaned `generated.tf`. With Stage 2c1 on (default), `terraform plan -detailed-exitcode` exits 0 against the same stack. |
+| `1` | Fatal: AWS error, validator failure, terraform binary missing or failing, drift-fix replace/delete or stable-drift escalation, or bad inputs. No partial manifest is written when validation fails before the write step; with Stage 2b/2c1, intermediate artifacts (`imported.json`, `generated.tf`, the workdir's `.terraform` dir) survive on disk for inspection. |
 
-### What `discover` does *not* do (Stage 2b)
+### What `discover` does *not* do (Stage 2c1)
 
-- **No drift fixing or dependency chasing.** Stage 2c (`#263`) finds ARNs that point at *un-imported* resources and walks the dependency graph; Stage 2b only cross-refs within the current batch.
-- **No nested-literal cross-refs.** Literals inside object/map values (e.g. `dimensions = { QueueName = "https://..." }`) stay literal. Stage 2c covers those.
+- **No dependency chasing.** Stage 2c3 (`#271`) finds ARNs that point at *un-imported* resources and walks the dependency graph; Stage 2c1 only patches drift within the current batch.
+- **No nested-block drift patching.** Top-level attribute drift is dropped; drift inside nested blocks (timeouts, lifecycle on a non-import-flow resource, etc.) is reported via the stable-drift escalation but not auto-resolved. Stage 2c3 / 2c4 cover those.
+- **No throttle/retry tuning or bounded concurrency.** Stage 2c2 (`#270`).
+- **No localstack CI gate proving zero drift end-to-end.** Stage 2c4 (`#272`).
 - **No GCP support.** Stage 2d (`#264`).
-- **No throttle/retry tuning or bounded concurrency.** Stage 2c.
 
 ## Development
 

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/driftfix"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
@@ -46,6 +47,9 @@ type discoverDeps struct {
 	// `terraform` binary on PATH; tests inject a fake to skip the binary
 	// dependency.
 	runGenconfig func(ctx context.Context, opts genconfig.Options, resources []imported.ImportedResource) (*genconfig.Result, error)
+	// runDriftfix drives Stage 2c1. Same shape as runGenconfig: production
+	// shells out, tests fake.
+	runDriftfix func(ctx context.Context, opts driftfix.Options) (*driftfix.Result, error)
 }
 
 func productionDiscoverDeps() discoverDeps {
@@ -67,6 +71,7 @@ func productionDiscoverDeps() discoverDeps {
 			return awsdiscover.NewAWSDiscoverer(cfg)
 		},
 		runGenconfig: genconfig.Run,
+		runDriftfix:  driftfix.Run,
 	}
 }
 
@@ -78,15 +83,18 @@ func runDiscoverWithDeps(args []string, deps discoverDeps) int {
 	fs := flag.NewFlagSet("discover", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	fs.Usage = func() {
-		fmt.Fprintln(os.Stderr, `insideout-import discover — discover existing cloud resources, write imported.json, and generate validated HCL.
+		fmt.Fprintln(os.Stderr, `insideout-import discover — discover existing cloud resources, write imported.json, generate validated HCL, and patch drift.
 
 Usage:
   insideout-import discover --provider aws --project P --region R --output-dir DIR [flags]
 
-Stages 2a + 2b: AWS only, SDK-driven discovery for the 5 Phase 1 resource
-types, then terraform plan -generate-config-out + schema cleanup. Pass
---no-hcl to skip Stage 2b (manifest only). GCP, drift fixing, and dependency
-chasing land in Stages 2c–2d (see #189 for the chain).
+Stages 2a + 2b + 2c1: AWS only, SDK-driven discovery for the 5 Phase 1
+resource types, terraform plan -generate-config-out + schema cleanup, then
+a drift-fix loop that patches generated.tf until the plan is empty. Pass
+--no-hcl to skip Stage 2b (manifest only) or --no-driftfix to stop after
+Stage 2b (validate-clean but possibly drifting). GCP support, SDK QoS,
+dependency chasing, and a localstack CI gate land in Stages 2c2–2d (see
+#189 for the chain).
 
 Flags:`)
 		fs.PrintDefaults()
@@ -102,6 +110,7 @@ Exit codes:
 	outputDir := fs.String("output-dir", "", "directory to write imported.json into (required)")
 	resourceTypes := fs.String("resource-types", "", "comma-separated subset of types to discover; default: all 5 Phase 1 types")
 	noHCL := fs.Bool("no-hcl", false, "skip Stage 2b HCL generation (terraform plan -generate-config-out + cleanup); leaves imported.json with empty Attributes")
+	noDriftFix := fs.Bool("no-driftfix", false, "skip Stage 2c1 drift fix loop after HCL generation; leaves generated.tf at validate-clean rather than plan-clean")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -202,6 +211,21 @@ Exit codes:
 		return discoverExitFatal
 	}
 	fmt.Printf("wrote %s (%d resource(s) with Attributes); generated HCL at %s\n", out, n, res.GeneratedPath)
+
+	if *noDriftFix {
+		return discoverExitOK
+	}
+
+	// Stage 2c1: loop terraform plan against the generated stack and
+	// patch drifting attributes until the plan is empty. Same workdir as
+	// genconfig (re-uses the .terraform dir).
+	dfRes, err := deps.runDriftfix(ctx, driftfix.Options{Workdir: gcWorkdir})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "discover: drift fix: %v\n", err)
+		fmt.Fprintln(os.Stderr, "discover: imported.json + generated.tf are on disk. Re-run with --no-driftfix to skip Stage 2c1 explicitly, or inspect the workdir to fix manually.")
+		return discoverExitFatal
+	}
+	fmt.Printf("drift fix converged after %d iteration(s); generated HCL at %s\n", dfRes.Iterations, dfRes.GeneratedPath)
 	return discoverExitOK
 }
 

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/driftfix"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
@@ -89,6 +90,26 @@ func (f *fakeAggregator) DiscoverTypes(_ context.Context, types []string, projec
 	return f.out, f.err
 }
 
+// fakeDriftfix records driftfix invocations so the happy-path tests can
+// assert Stage 2c1 was reached without standing up a terraform binary.
+type fakeDriftfix struct {
+	called  int
+	gotOpts driftfix.Options
+	err     error
+}
+
+func (f *fakeDriftfix) Run(_ context.Context, opts driftfix.Options) (*driftfix.Result, error) {
+	f.called++
+	f.gotOpts = opts
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &driftfix.Result{
+		GeneratedPath: filepath.Join(opts.Workdir, "generated.tf"),
+		Iterations:    1,
+	}, nil
+}
+
 // fakeGenconfig records its inputs and returns the resources unchanged so the
 // happy-path tests can assert HCL generation was invoked without standing up
 // a terraform binary.
@@ -123,6 +144,7 @@ func okDeps(agg *fakeAggregator) discoverDeps {
 		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "1234567890", nil },
 		newDiscoverer: func(_ aws.Config) discoveryAggregator { return agg },
 		runGenconfig:  (&fakeGenconfig{}).Run,
+		runDriftfix:   (&fakeDriftfix{}).Run,
 	}
 }
 
@@ -130,6 +152,13 @@ func okDeps(agg *fakeAggregator) discoverDeps {
 func okDepsWithGC(agg *fakeAggregator, gc *fakeGenconfig) discoverDeps {
 	d := okDeps(agg)
 	d.runGenconfig = gc.Run
+	return d
+}
+
+// okDepsWithDF mirrors okDeps but lets the caller observe driftfix invocations.
+func okDepsWithDF(agg *fakeAggregator, gc *fakeGenconfig, df *fakeDriftfix) discoverDeps {
+	d := okDepsWithGC(agg, gc)
+	d.runDriftfix = df.Run
 	return d
 }
 
@@ -419,6 +448,91 @@ func TestRunDiscoverWithDeps_GenconfigResourcesRewriteManifest(t *testing.T) {
 	}
 	if got[0].Attributes["delay_seconds"] != float64(30) {
 		t.Errorf("Attributes[delay_seconds]=%v, want 30", got[0].Attributes["delay_seconds"])
+	}
+}
+
+// TestRunDiscoverWithDeps_DriftfixInvokedOnHappyPath pins that Stage 2c1
+// runs by default after Stage 2b succeeds. A mutation that flipped
+// --no-driftfix's default to true would silently revert to Stage 2b
+// behavior and skip the zero-drift contract.
+func TestRunDiscoverWithDeps_DriftfixInvokedOnHappyPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	gc := &fakeGenconfig{}
+	df := &fakeDriftfix{}
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+	}, okDepsWithDF(agg, gc, df))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if df.called != 1 {
+		t.Errorf("runDriftfix called %d times, want 1", df.called)
+	}
+	if df.gotOpts.Workdir != filepath.Join(dir, "genconfig") {
+		t.Errorf("driftfix Workdir=%q, want <output>/genconfig", df.gotOpts.Workdir)
+	}
+}
+
+// TestRunDiscoverWithDeps_NoDriftfixSkipsStage2c pins that --no-driftfix
+// turns off Stage 2c1 — for operators who only want validate-clean HCL
+// or who hit drift they want to inspect manually.
+func TestRunDiscoverWithDeps_NoDriftfixSkipsStage2c(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	gc := &fakeGenconfig{}
+	df := &fakeDriftfix{}
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir, "--no-driftfix",
+	}, okDepsWithDF(agg, gc, df))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if df.called != 0 {
+		t.Errorf("runDriftfix called %d times with --no-driftfix, want 0", df.called)
+	}
+}
+
+// TestRunDiscoverWithDeps_NoHCLSkipsBothStages pins that --no-hcl skips
+// Stage 2b AND its downstream Stage 2c1 — running drift fix without
+// Stage 2b's generated.tf would error confusingly.
+func TestRunDiscoverWithDeps_NoHCLSkipsBothStages(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	gc := &fakeGenconfig{}
+	df := &fakeDriftfix{}
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir, "--no-hcl",
+	}, okDepsWithDF(agg, gc, df))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if gc.called != 0 || df.called != 0 {
+		t.Errorf("--no-hcl must skip both Stage 2b (gc=%d) and Stage 2c1 (df=%d)", gc.called, df.called)
+	}
+}
+
+// TestRunDiscoverWithDeps_DriftfixFailureExitsFatal pins that a Stage
+// 2c1 failure (replace, stable drift, validate-after-patch failure)
+// exits non-zero. The on-disk imported.json + generated.tf survive so
+// the operator can inspect.
+func TestRunDiscoverWithDeps_DriftfixFailureExitsFatal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	gc := &fakeGenconfig{}
+	df := &fakeDriftfix{err: errors.New("must be replaced")}
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+	}, okDepsWithDF(agg, gc, df))
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "imported.json")); err != nil {
+		t.Errorf("imported.json must exist after Stage 2b even if Stage 2c1 fails: %v", err)
 	}
 }
 

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -518,22 +519,67 @@ func TestRunDiscoverWithDeps_NoHCLSkipsBothStages(t *testing.T) {
 // TestRunDiscoverWithDeps_DriftfixFailureExitsFatal pins that a Stage
 // 2c1 failure (replace, stable drift, validate-after-patch failure)
 // exits non-zero. The on-disk imported.json + generated.tf survive so
-// the operator can inspect.
+// the operator can inspect. Also pins that the operator-facing
+// remediation hint ("Re-run with --no-driftfix...") reaches stderr —
+// regressing that string would silently degrade the failure UX.
+//
+// NOT t.Parallel(): captures global os.Stderr.
 func TestRunDiscoverWithDeps_DriftfixFailureExitsFatal(t *testing.T) {
-	t.Parallel()
 	dir := t.TempDir()
 	gc := &fakeGenconfig{}
 	df := &fakeDriftfix{err: errors.New("must be replaced")}
 	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
-	rc := runDiscoverWithDeps([]string{
-		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
-	}, okDepsWithDF(agg, gc, df))
-	if rc != discoverExitFatal {
-		t.Errorf("rc=%d, want fatal", rc)
-	}
+	stderr := captureStderr(t, func() {
+		rc := runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+		}, okDepsWithDF(agg, gc, df))
+		if rc != discoverExitFatal {
+			t.Errorf("rc=%d, want fatal", rc)
+		}
+	})
 	if _, err := os.Stat(filepath.Join(dir, "imported.json")); err != nil {
 		t.Errorf("imported.json must exist after Stage 2b even if Stage 2c1 fails: %v", err)
 	}
+	if !strings.Contains(stderr, "--no-driftfix") {
+		t.Errorf("stderr must include the --no-driftfix remediation hint; got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "drift fix") {
+		t.Errorf("stderr must include the failing-stage label; got:\n%s", stderr)
+	}
+}
+
+// captureStderr swaps os.Stderr for a pipe, runs fn, and returns the
+// captured output. Callers using this must NOT mark the test parallel
+// — os.Stderr is global state.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = orig })
+
+	done := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 0, 4096)
+		tmp := make([]byte, 1024)
+		for {
+			n, err := r.Read(tmp)
+			if n > 0 {
+				buf = append(buf, tmp[:n]...)
+			}
+			if err != nil {
+				break
+			}
+		}
+		done <- string(buf)
+	}()
+
+	fn()
+	_ = w.Close()
+	return <-done
 }
 
 func TestSplitCSV(t *testing.T) {

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -551,6 +551,10 @@ func TestRunDiscoverWithDeps_DriftfixFailureExitsFatal(t *testing.T) {
 // captureStderr swaps os.Stderr for a pipe, runs fn, and returns the
 // captured output. Callers using this must NOT mark the test parallel
 // — os.Stderr is global state.
+//
+// The pipe writer is closed via defer so a panic inside fn still
+// unblocks the reader goroutine; otherwise the test would deadlock
+// on <-done.
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	r, w, err := os.Pipe()
@@ -577,8 +581,10 @@ func captureStderr(t *testing.T, fn func()) string {
 		done <- string(buf)
 	}()
 
-	fn()
-	_ = w.Close()
+	func() {
+		defer func() { _ = w.Close() }()
+		fn()
+	}()
 	return <-done
 }
 

--- a/cmd/insideout-import/driftfix/driftfix.go
+++ b/cmd/insideout-import/driftfix/driftfix.go
@@ -1,0 +1,244 @@
+// Package driftfix runs after Stage 2b's genconfig pipeline produces a
+// validating generated.tf. It loops `terraform plan` against the stack
+// and patches drifting attributes — dropping them from generated.tf so
+// terraform reads the value from cloud state instead of trying to push
+// the import-time snapshot back. Loop terminates when the plan is empty
+// or the same drift recurs across iterations (stability without
+// resolution → fatal).
+//
+// Stage 2c1 of the #189 split. Dependency chase (Stage 2c3) and the
+// localstack zero-drift CI gate (Stage 2c4) layer on top.
+package driftfix
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+)
+
+// generatedFile is the file genconfig wrote and driftfix mutates in
+// place. Kept as a constant so the orchestrator and patch helpers agree.
+const generatedFile = "generated.tf"
+
+// planFile is the name of the binary plan produced by `terraform plan
+// -out=...`. ShowPlan reads it back into the typed shape.
+const planFile = "driftfix.tfplan"
+
+// defaultMaxIterations bounds the patch loop. Five is enough for the
+// realistic case (one or two passes typically converges); the bound is
+// here to surface "stable but unresolved" cases as a fatal rather than
+// spinning on an attr we can't patch.
+const defaultMaxIterations = 5
+
+// Options is the input to Run. Workdir must be the same directory that
+// genconfig.Run produced — driftfix expects generated.tf, providers.tf,
+// imports.tf, and the .terraform dir already in place.
+type Options struct {
+	Workdir       string
+	MaxIterations int
+	// Runner is optional; nil means "construct an execRunner from PATH."
+	Runner terraformRunner
+}
+
+// Result is what the orchestrator hands back to the caller. Iterations
+// is informational (operator-visible in logs); GeneratedPath points at
+// the file the loop converged on.
+type Result struct {
+	GeneratedPath string
+	Iterations    int
+}
+
+// Run is the Stage 2c1 pipeline:
+//
+//  1. Plan the existing stack.
+//  2. If plan is empty (no resource_changes off no-op), return.
+//  3. Classify changes; replace/delete = fatal.
+//  4. Drop drifting top-level attrs from generated.tf.
+//  5. Validate the patched file (catches Required-attr removal).
+//  6. Goto 1, up to MaxIterations.
+//
+// "Stable but unresolved" — same drift recurs after a patch — surfaces
+// as a fatal so the operator sees what couldn't be fixed instead of
+// looping forever.
+func Run(ctx context.Context, opts Options) (*Result, error) {
+	if opts.Workdir == "" {
+		return nil, fmt.Errorf("driftfix: Workdir required")
+	}
+	if opts.MaxIterations <= 0 {
+		opts.MaxIterations = defaultMaxIterations
+	}
+
+	abs, err := filepath.Abs(opts.Workdir)
+	if err != nil {
+		return nil, fmt.Errorf("abs workdir: %w", err)
+	}
+	opts.Workdir = abs
+
+	runner := opts.Runner
+	if runner == nil {
+		r, err := newExecRunner(opts.Workdir)
+		if err != nil {
+			return nil, err
+		}
+		runner = r
+	}
+
+	generatedPath := filepath.Join(opts.Workdir, generatedFile)
+	planPath := filepath.Join(opts.Workdir, planFile)
+
+	var prevDrift map[string][]string
+	// alreadyEscalated tracks (address, attr) pairs we've already moved
+	// to lifecycle.ignore_changes. If the same drift recurs AFTER
+	// escalation, it's truly stable-unresolved and we surface it as
+	// fatal — the operator must inspect manually.
+	alreadyEscalated := map[string]map[string]struct{}{}
+
+	for iter := 1; iter <= opts.MaxIterations; iter++ {
+		hasChanges, err := runner.PlanTo(ctx, planPath)
+		if err != nil {
+			return nil, fmt.Errorf("driftfix iter %d: terraform plan: %w", iter, err)
+		}
+		if !hasChanges {
+			return &Result{GeneratedPath: generatedPath, Iterations: iter}, nil
+		}
+
+		plan, err := runner.ShowPlan(ctx, planPath)
+		if err != nil {
+			return nil, fmt.Errorf("driftfix iter %d: show plan: %w", iter, err)
+		}
+
+		classifications := classifyPlan(plan)
+		if fatalErr := classificationFatal(classifications); fatalErr != nil {
+			return nil, fmt.Errorf("driftfix iter %d: %w", iter, fatalErr)
+		}
+		// terraform-exec reports hasChanges=true for an import-only plan
+		// because imports count as changes. classifyPlan filters those
+		// out via the no-op check; if nothing actionable remains, the
+		// plan is functionally clean and the loop is done.
+		if len(classifications) == 0 {
+			return &Result{GeneratedPath: generatedPath, Iterations: iter}, nil
+		}
+
+		curDrift := driftMap(classifications)
+		raw, err := os.ReadFile(generatedPath)
+		if err != nil {
+			return nil, fmt.Errorf("driftfix iter %d: read generated.tf: %w", iter, err)
+		}
+
+		// Stability detection: same drift two iterations in a row → our
+		// drop-from-HCL patch isn't enough. Either upgrade to
+		// lifecycle.ignore_changes (the right move for CREATE-only /
+		// DESTROY-only schema attrs whose default differs from cloud
+		// "missing"), or — if we already escalated this same drift —
+		// give up and surface the error.
+		if iter > 1 && reflect.DeepEqual(prevDrift, curDrift) {
+			if everyDriftAttrAlreadyEscalated(curDrift, alreadyEscalated) {
+				return nil, fmt.Errorf("driftfix iter %d: %w", iter, errStableUnresolved(curDrift))
+			}
+			patched, err := applyIgnoreChangesEscalation(raw, classifications)
+			if err != nil {
+				return nil, fmt.Errorf("driftfix iter %d: ignore_changes escalation: %w", iter, err)
+			}
+			if err := os.WriteFile(generatedPath, patched, 0o644); err != nil {
+				return nil, fmt.Errorf("driftfix iter %d: write generated.tf: %w", iter, err)
+			}
+			markEscalated(curDrift, alreadyEscalated)
+			if err := runner.Validate(ctx); err != nil {
+				return nil, fmt.Errorf("driftfix iter %d: validate after ignore_changes: %w", iter, err)
+			}
+			prevDrift = curDrift
+			continue
+		}
+		prevDrift = curDrift
+
+		patched, err := applyDriftPatches(raw, classifications)
+		if err != nil {
+			return nil, fmt.Errorf("driftfix iter %d: patch: %w", iter, err)
+		}
+		if err := os.WriteFile(generatedPath, patched, 0o644); err != nil {
+			return nil, fmt.Errorf("driftfix iter %d: write generated.tf: %w", iter, err)
+		}
+		if err := runner.Validate(ctx); err != nil {
+			return nil, fmt.Errorf("driftfix iter %d: validate after patch: %w", iter, err)
+		}
+	}
+	return nil, fmt.Errorf("driftfix: %d iterations exhausted without convergence", opts.MaxIterations)
+}
+
+// everyDriftAttrAlreadyEscalated returns true iff every (address, attr)
+// pair in `cur` was previously added to `escalated`. When that's the
+// case, ignore_changes wasn't enough either — the drift is truly stuck
+// and the loop must escalate to a fatal error.
+func everyDriftAttrAlreadyEscalated(cur map[string][]string, escalated map[string]map[string]struct{}) bool {
+	for addr, attrs := range cur {
+		seen, ok := escalated[addr]
+		if !ok {
+			return false
+		}
+		for _, a := range attrs {
+			if _, ok := seen[a]; !ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// markEscalated records that we've added (address, attr) pairs to
+// lifecycle.ignore_changes so a re-occurrence on a subsequent iteration
+// can be detected and surfaced as a real failure.
+func markEscalated(cur map[string][]string, dst map[string]map[string]struct{}) {
+	for addr, attrs := range cur {
+		if dst[addr] == nil {
+			dst[addr] = map[string]struct{}{}
+		}
+		for _, a := range attrs {
+			dst[addr][a] = struct{}{}
+		}
+	}
+}
+
+// classificationFatal returns the first fatal condition (delete or
+// replace) encountered in classifications. nil otherwise.
+func classificationFatal(cs []driftClassification) error {
+	for _, c := range cs {
+		if c.mustDelete {
+			return fmt.Errorf("resource %q is marked for delete in plan; an import-only run must not produce deletes", c.address)
+		}
+		if c.mustReplace {
+			return fmt.Errorf("resource %q must be replaced (reason: %s); driftfix will not auto-resolve replaces — operator must reconcile manually", c.address, c.replaceWhy)
+		}
+	}
+	return nil
+}
+
+// driftMap collapses classifications into a {address: sorted-attr-names}
+// shape so the stability detector can DeepEqual two iterations.
+func driftMap(cs []driftClassification) map[string][]string {
+	out := make(map[string][]string, len(cs))
+	for _, c := range cs {
+		if len(c.driftAttrs) == 0 {
+			continue
+		}
+		out[c.address] = append([]string(nil), c.driftAttrs...)
+	}
+	return out
+}
+
+// errStableUnresolved formats the same-drift-as-last-iteration message
+// with enough detail that the operator knows which attr to look at.
+func errStableUnresolved(drift map[string][]string) error {
+	var b []byte
+	b = append(b, "drift stable but unresolved across iterations:\n"...)
+	for addr, attrs := range drift {
+		b = append(b, "  "...)
+		b = append(b, addr...)
+		b = append(b, ": "...)
+		b = append(b, fmt.Sprintf("%v", attrs)...)
+		b = append(b, '\n')
+	}
+	return errors.New(string(b))
+}

--- a/cmd/insideout-import/driftfix/driftfix_test.go
+++ b/cmd/insideout-import/driftfix/driftfix_test.go
@@ -5,9 +5,12 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
@@ -158,6 +161,13 @@ func TestRun_ImportOnlyPlanReturnsClean(t *testing.T) {
 	if res.Iterations != 1 {
 		t.Errorf("Iterations=%d, want 1 (clean plan converges immediately)", res.Iterations)
 	}
+	// Validate must NOT run on the early-return path: no patch was
+	// written, so there's nothing to validate. A mutation that always
+	// validated would mask a logic bug where the loop wrote a partial
+	// patch before short-circuiting.
+	if runner.validateCalls != 0 {
+		t.Errorf("validate must not run on early-return path; got %d calls", runner.validateCalls)
+	}
 }
 
 // alwaysHasChangesRunner forces PlanTo to report hasChanges=true even
@@ -201,12 +211,34 @@ func TestRun_DriftThenCleanConverges(t *testing.T) {
 		t.Errorf("Iterations=%d, want 2", res.Iterations)
 	}
 	body, _ := os.ReadFile(filepath.Join(dir, generatedFile))
-	if strings.Contains(string(body), "delay_seconds") {
+	if hclResourceHasAttr(t, body, "aws_sqs_queue.x", "delay_seconds") {
 		t.Errorf("delay_seconds must be dropped after patch\n--- got ---\n%s", body)
 	}
 	if runner.validateCalls != 1 {
 		t.Errorf("validate must run once per patched iteration; got %d", runner.validateCalls)
 	}
+}
+
+// hclResourceHasAttr parses raw HCL and reports whether the named
+// resource address has the named top-level attribute. Robust to
+// formatter whitespace and comments.
+func hclResourceHasAttr(t *testing.T, raw []byte, address, attr string) bool {
+	t.Helper()
+	f, diags := hclwrite.ParseConfig(raw, "test.tf", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse: %s", diags.Error())
+	}
+	for _, blk := range f.Body().Blocks() {
+		if blk.Type() != "resource" {
+			continue
+		}
+		labels := blk.Labels()
+		if len(labels) != 2 || labels[0]+"."+labels[1] != address {
+			continue
+		}
+		return blk.Body().GetAttribute(attr) != nil
+	}
+	return false
 }
 
 // TestRun_RecurringDriftEscalatesToIgnoreChanges pins the two-strategy
@@ -234,8 +266,22 @@ func TestRun_RecurringDriftEscalatesToIgnoreChanges(t *testing.T) {
 		t.Errorf("Iterations=%d, want 3 (drop, escalate, converge)", res.Iterations)
 	}
 	body, _ := os.ReadFile(filepath.Join(dir, generatedFile))
-	if !strings.Contains(string(body), "ignore_changes") {
-		t.Errorf("escalation must add lifecycle.ignore_changes\n--- got ---\n%s", body)
+	if !hclResourceHasIgnoreChange(t, body, "aws_sqs_queue.x", "name") {
+		t.Errorf("escalation must add `name` to lifecycle.ignore_changes\n--- got ---\n%s", body)
+	}
+	// Validate must run TWICE: once after the drop patch, once after
+	// the escalation. A mutation that skipped the escalation-side
+	// validate would survive without this check (the test would pass
+	// even if a Required attr were dropped during escalation).
+	if runner.validateCalls != 2 {
+		t.Errorf("validate calls = %d, want 2 (one per patched iteration)", runner.validateCalls)
+	}
+	// Pin call ordering so a mutation that flipped patch+validate
+	// wouldn't slip past. Expected: plan, show, validate, plan, show,
+	// validate, plan, (no show on clean plan).
+	wantOrder := []string{"plan", "show", "validate", "plan", "show", "validate", "plan"}
+	if !equalStringSlices(runner.calls, wantOrder) {
+		t.Errorf("call order = %v, want %v", runner.calls, wantOrder)
 	}
 }
 
@@ -259,6 +305,78 @@ func TestRun_DriftStableAfterEscalationFatal(t *testing.T) {
 	if !strings.Contains(err.Error(), "stable but unresolved") {
 		t.Errorf("err=%v, want stable-but-unresolved message", err)
 	}
+	// Pin that the escalation patch DID run before the fatal: the
+	// disk file must contain ignore_changes at the time of failure.
+	// A mutation that returned the fatal without performing the
+	// escalation patch on iter 2 would survive a message-only check.
+	body, _ := os.ReadFile(filepath.Join(dir, generatedFile))
+	if !hclResourceHasIgnoreChange(t, body, "aws_sqs_queue.x", "name") {
+		t.Errorf("escalation must have run (writing ignore_changes) before fatal\n--- got ---\n%s", body)
+	}
+}
+
+// TestRun_ValidateFailureAfterEscalationFatal pins that validate
+// failure on the escalation path surfaces the escalation-specific
+// error message, distinct from validate failure on the drop path.
+// A mutation that hard-coded "validate after patch" everywhere would
+// survive the drop-path-only TestRun_ValidateFailureFatal.
+func TestRun_ValidateFailureAfterEscalationFatal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixture(t, dir)
+	driftP := updatePlan("aws_sqs_queue.x",
+		map[string]any{"name": "alpha"},
+		map[string]any{"name": "bravo"})
+	// failOnNthValidate fails ONLY the second validate (the one on
+	// the escalation path). The first validate (drop pass) succeeds.
+	runner := &validateNthFailRunner{
+		scriptedRunner: scriptedRunner{plansByCall: []*tfjson.Plan{driftP, driftP, emptyPlan()}},
+		failOnCall:     2,
+		failErr:        errors.New("hcl unexpected token"),
+	}
+	_, err := Run(context.Background(), Options{Workdir: dir, Runner: runner.toBase()})
+	if err == nil {
+		t.Fatal("expected validate error on escalation path")
+	}
+	if !strings.Contains(err.Error(), "validate after ignore_changes") {
+		t.Errorf("err=%v, want escalation-specific validate message", err)
+	}
+}
+
+// validateNthFailRunner returns failErr on the failOnCall-th call to
+// Validate (1-indexed). All other Validate calls succeed.
+type validateNthFailRunner struct {
+	scriptedRunner
+	failOnCall int
+	failErr    error
+}
+
+func (r *validateNthFailRunner) Validate(_ context.Context) error {
+	r.calls = append(r.calls, "validate")
+	r.validateCalls++
+	if r.validateCalls == r.failOnCall {
+		return r.failErr
+	}
+	return nil
+}
+
+// toBase returns the runner as a terraformRunner — needed because Go
+// embeds the base struct's methods but Run takes the interface.
+func (r *validateNthFailRunner) toBase() terraformRunner { return r }
+
+// equalStringSlices reports whether two string slices are equal.
+// Used for pinning call sequence order without a third-party diff
+// library.
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // TestRun_ReplaceFatal pins that a plan with a delete-create pair never
@@ -268,6 +386,7 @@ func TestRun_ReplaceFatal(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	writeFixture(t, dir)
+	pre, _ := os.ReadFile(filepath.Join(dir, generatedFile))
 	replaceP := &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{{
 		Address: "aws_sqs_queue.x",
 		Change: &tfjson.Change{
@@ -283,6 +402,13 @@ func TestRun_ReplaceFatal(t *testing.T) {
 	if !strings.Contains(err.Error(), "must be replaced") {
 		t.Errorf("err=%v, want must-be-replaced message", err)
 	}
+	// generated.tf must be untouched on a fatal — a mutation that
+	// patched before classifying as fatal would silently corrupt the
+	// operator's only debugging artifact.
+	post, _ := os.ReadFile(filepath.Join(dir, generatedFile))
+	if string(pre) != string(post) {
+		t.Errorf("generated.tf must be byte-identical on fatal exit\n--- pre ---\n%s\n--- post ---\n%s", pre, post)
+	}
 }
 
 // TestRun_DeleteFatal pins that a bare delete is fatal.
@@ -290,6 +416,7 @@ func TestRun_DeleteFatal(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	writeFixture(t, dir)
+	pre, _ := os.ReadFile(filepath.Join(dir, generatedFile))
 	deleteP := &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{{
 		Address: "aws_sqs_queue.x",
 		Change:  &tfjson.Change{Actions: tfjson.Actions{tfjson.ActionDelete}},
@@ -302,6 +429,44 @@ func TestRun_DeleteFatal(t *testing.T) {
 	if !strings.Contains(err.Error(), "marked for delete") {
 		t.Errorf("err=%v, want marked-for-delete message", err)
 	}
+	post, _ := os.ReadFile(filepath.Join(dir, generatedFile))
+	if string(pre) != string(post) {
+		t.Errorf("generated.tf must be byte-identical on fatal exit\n--- pre ---\n%s\n--- post ---\n%s", pre, post)
+	}
+}
+
+// hclResourceHasIgnoreChange parses raw HCL and reports whether the
+// named resource address has an attr in lifecycle.ignore_changes.
+// Use this rather than strings.Contains so the assertion isn't
+// fragile to formatter whitespace, comments, or attr ordering.
+func hclResourceHasIgnoreChange(t *testing.T, raw []byte, address, attr string) bool {
+	t.Helper()
+	f, diags := hclwrite.ParseConfig(raw, "test.tf", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse: %s", diags.Error())
+	}
+	for _, blk := range f.Body().Blocks() {
+		if blk.Type() != "resource" {
+			continue
+		}
+		labels := blk.Labels()
+		if len(labels) != 2 || labels[0]+"."+labels[1] != address {
+			continue
+		}
+		for _, sub := range blk.Body().Blocks() {
+			if sub.Type() != "lifecycle" {
+				continue
+			}
+			ic := sub.Body().GetAttribute("ignore_changes")
+			if ic == nil {
+				continue
+			}
+			if slices.Contains(parseIgnoreChangesList(ic), attr) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // TestRun_ValidateFailureFatal pins that if patching breaks `terraform

--- a/cmd/insideout-import/driftfix/driftfix_test.go
+++ b/cmd/insideout-import/driftfix/driftfix_test.go
@@ -1,0 +1,376 @@
+package driftfix
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+// scriptedRunner returns a different plan on each iteration so tests can
+// drive the loop through realistic shapes (drift→clean, stable drift,
+// replace, etc.) without a terraform binary. plansByCall is consumed
+// front-to-back; once exhausted, every subsequent PlanTo returns
+// hasChanges=false.
+type scriptedRunner struct {
+	plansByCall []*tfjson.Plan
+	planErr     error
+	validateErr error
+
+	planCalls     int
+	showCalls     int
+	validateCalls int
+	calls         []string
+}
+
+func (r *scriptedRunner) PlanTo(_ context.Context, planFile string) (bool, error) {
+	r.calls = append(r.calls, "plan")
+	r.planCalls++
+	if r.planErr != nil {
+		return false, r.planErr
+	}
+	// Mark the plan file with the call index so ShowPlan can fish out
+	// the matching scripted plan.
+	idx := r.planCalls - 1
+	if idx >= len(r.plansByCall) {
+		return false, nil // no more changes; loop exits
+	}
+	if !planHasNonNoOp(r.plansByCall[idx]) {
+		return false, nil
+	}
+	_ = os.WriteFile(planFile, []byte{byte(idx)}, 0o644)
+	return true, nil
+}
+
+func (r *scriptedRunner) ShowPlan(_ context.Context, planFile string) (*tfjson.Plan, error) {
+	r.calls = append(r.calls, "show")
+	r.showCalls++
+	body, _ := os.ReadFile(planFile)
+	if len(body) == 0 {
+		return nil, errors.New("plan file empty")
+	}
+	idx := int(body[0])
+	if idx >= len(r.plansByCall) {
+		return nil, errors.New("scripted plan index out of range")
+	}
+	return r.plansByCall[idx], nil
+}
+
+func (r *scriptedRunner) Validate(_ context.Context) error {
+	r.calls = append(r.calls, "validate")
+	r.validateCalls++
+	return r.validateErr
+}
+
+func planHasNonNoOp(p *tfjson.Plan) bool {
+	if p == nil {
+		return false
+	}
+	for _, rc := range p.ResourceChanges {
+		if rc != nil && rc.Change != nil && !isNoOp(rc.Change.Actions) {
+			return true
+		}
+	}
+	return false
+}
+
+func updatePlan(addr string, before, after map[string]any) *tfjson.Plan {
+	return &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{{
+		Address: addr,
+		Change: &tfjson.Change{
+			Actions: tfjson.Actions{tfjson.ActionUpdate},
+			Before:  before,
+			After:   after,
+		},
+	}}}
+}
+
+func emptyPlan() *tfjson.Plan {
+	return &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{{
+		Address: "aws_sqs_queue.x",
+		Change:  &tfjson.Change{Actions: tfjson.Actions{tfjson.ActionNoop}},
+	}}}
+}
+
+func writeFixture(t *testing.T, dir string) {
+	t.Helper()
+	body := []byte(`resource "aws_sqs_queue" "x" {
+  name          = "alpha"
+  delay_seconds = 0
+}
+`)
+	if err := os.WriteFile(filepath.Join(dir, generatedFile), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRun_EmptyPlanFirstIterationReturnsImmediately(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixture(t, dir)
+	runner := &scriptedRunner{plansByCall: []*tfjson.Plan{emptyPlan()}}
+	res, err := Run(context.Background(), Options{Workdir: dir, Runner: runner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Iterations != 1 {
+		t.Errorf("Iterations=%d, want 1", res.Iterations)
+	}
+	if runner.planCalls != 1 || runner.showCalls != 0 || runner.validateCalls != 0 {
+		t.Errorf("call counts plan/show/validate = %d/%d/%d, want 1/0/0",
+			runner.planCalls, runner.showCalls, runner.validateCalls)
+	}
+}
+
+// TestRun_ImportOnlyPlanReturnsClean pins the post-2b convergence
+// shape: terraform-exec's Plan reports hasChanges=true for any plan
+// that imports resources, even when there's no actual drift. The loop
+// must short-circuit when classifications is empty (only no-ops past
+// the import) — otherwise it'd flag a clean import as stuck drift and
+// fail the run. This was the live-smoke regression that prompted the
+// short-circuit; pinning it here keeps that mistake from coming back.
+func TestRun_ImportOnlyPlanReturnsClean(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixture(t, dir)
+	// 5 imported resources, all with no-op Change.Actions — the
+	// realistic shape of a Stage 2b output that's already drift-free.
+	rcs := make([]*tfjson.ResourceChange, 0, 5)
+	for _, name := range []string{"a", "b", "c", "d", "e"} {
+		rcs = append(rcs, &tfjson.ResourceChange{
+			Address: "aws_sqs_queue." + name,
+			Change:  &tfjson.Change{Actions: tfjson.Actions{tfjson.ActionNoop}},
+		})
+	}
+	plan := &tfjson.Plan{ResourceChanges: rcs}
+	// alwaysHasChanges forces PlanTo to return (true, nil) regardless
+	// of whether the plan has non-noop actions — the behavior real
+	// terraform-exec exhibits for an import-only plan.
+	runner := &alwaysHasChangesRunner{scriptedRunner: scriptedRunner{plansByCall: []*tfjson.Plan{plan}}}
+	res, err := Run(context.Background(), Options{Workdir: dir, Runner: runner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Iterations != 1 {
+		t.Errorf("Iterations=%d, want 1 (clean plan converges immediately)", res.Iterations)
+	}
+}
+
+// alwaysHasChangesRunner forces PlanTo to report hasChanges=true even
+// when every Action is no-op. Models the real-world shape of
+// terraform-exec.Plan against an import-only stack.
+type alwaysHasChangesRunner struct {
+	scriptedRunner
+}
+
+func (r *alwaysHasChangesRunner) PlanTo(_ context.Context, planFile string) (bool, error) {
+	r.calls = append(r.calls, "plan")
+	r.planCalls++
+	idx := r.planCalls - 1
+	if idx >= len(r.plansByCall) {
+		return false, nil
+	}
+	_ = os.WriteFile(planFile, []byte{byte(idx)}, 0o644)
+	return true, nil
+}
+
+// TestRun_DriftThenCleanConverges pins the happy-path loop: iteration 1
+// returns drift, the patch drops the offending attr, iteration 2's plan
+// is empty, Run exits with Iterations==2. A mutation that re-ran the
+// plan without applying the patch first would surface the same drift on
+// iteration 2 and trigger the stability detector.
+func TestRun_DriftThenCleanConverges(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixture(t, dir)
+	runner := &scriptedRunner{plansByCall: []*tfjson.Plan{
+		updatePlan("aws_sqs_queue.x",
+			map[string]any{"name": "alpha", "delay_seconds": float64(30)},
+			map[string]any{"name": "alpha", "delay_seconds": float64(0)}),
+		emptyPlan(),
+	}}
+	res, err := Run(context.Background(), Options{Workdir: dir, Runner: runner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Iterations != 2 {
+		t.Errorf("Iterations=%d, want 2", res.Iterations)
+	}
+	body, _ := os.ReadFile(filepath.Join(dir, generatedFile))
+	if strings.Contains(string(body), "delay_seconds") {
+		t.Errorf("delay_seconds must be dropped after patch\n--- got ---\n%s", body)
+	}
+	if runner.validateCalls != 1 {
+		t.Errorf("validate must run once per patched iteration; got %d", runner.validateCalls)
+	}
+}
+
+// TestRun_RecurringDriftEscalatesToIgnoreChanges pins the two-strategy
+// loop: when the same drift recurs after the drop pass (iter 2's plan
+// matches iter 1's), the loop escalates to lifecycle.ignore_changes
+// instead of failing. Iter 3 sees no drift → converges. This is the
+// real-world Stage 2c1 case for CREATE-only / DESTROY-only schema
+// attributes (e.g. aws_secretsmanager_secret.recovery_window_in_days)
+// whose schema default differs from the imported cloud state's "null".
+func TestRun_RecurringDriftEscalatesToIgnoreChanges(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixture(t, dir)
+	driftP := updatePlan("aws_sqs_queue.x",
+		map[string]any{"name": "alpha"},
+		map[string]any{"name": "bravo"})
+	// iter1=drift → drop; iter2=same drift → escalate to ignore_changes;
+	// iter3=empty → converge.
+	runner := &scriptedRunner{plansByCall: []*tfjson.Plan{driftP, driftP, emptyPlan()}}
+	res, err := Run(context.Background(), Options{Workdir: dir, Runner: runner})
+	if err != nil {
+		t.Fatalf("expected escalation+convergence; got: %v", err)
+	}
+	if res.Iterations != 3 {
+		t.Errorf("Iterations=%d, want 3 (drop, escalate, converge)", res.Iterations)
+	}
+	body, _ := os.ReadFile(filepath.Join(dir, generatedFile))
+	if !strings.Contains(string(body), "ignore_changes") {
+		t.Errorf("escalation must add lifecycle.ignore_changes\n--- got ---\n%s", body)
+	}
+}
+
+// TestRun_DriftStableAfterEscalationFatal pins the truly-stuck case:
+// drift recurs even AFTER ignore_changes has been added for those
+// attrs. The loop must surface the issue as fatal rather than spin.
+func TestRun_DriftStableAfterEscalationFatal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixture(t, dir)
+	driftP := updatePlan("aws_sqs_queue.x",
+		map[string]any{"name": "alpha"},
+		map[string]any{"name": "bravo"})
+	// Three identical plans. iter1 drops, iter2 escalates, iter3 still
+	// drifts → fatal "stable but unresolved."
+	runner := &scriptedRunner{plansByCall: []*tfjson.Plan{driftP, driftP, driftP}}
+	_, err := Run(context.Background(), Options{Workdir: dir, Runner: runner})
+	if err == nil {
+		t.Fatal("expected stable-after-escalation error")
+	}
+	if !strings.Contains(err.Error(), "stable but unresolved") {
+		t.Errorf("err=%v, want stable-but-unresolved message", err)
+	}
+}
+
+// TestRun_ReplaceFatal pins that a plan with a delete-create pair never
+// auto-resolves — the operator must reconcile manually because a
+// replace on an imported resource = data loss.
+func TestRun_ReplaceFatal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixture(t, dir)
+	replaceP := &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{{
+		Address: "aws_sqs_queue.x",
+		Change: &tfjson.Change{
+			Actions:      tfjson.Actions{tfjson.ActionDelete, tfjson.ActionCreate},
+			ReplacePaths: []any{"name"},
+		},
+	}}}
+	runner := &scriptedRunner{plansByCall: []*tfjson.Plan{replaceP}}
+	_, err := Run(context.Background(), Options{Workdir: dir, Runner: runner})
+	if err == nil {
+		t.Fatal("expected replace error")
+	}
+	if !strings.Contains(err.Error(), "must be replaced") {
+		t.Errorf("err=%v, want must-be-replaced message", err)
+	}
+}
+
+// TestRun_DeleteFatal pins that a bare delete is fatal.
+func TestRun_DeleteFatal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixture(t, dir)
+	deleteP := &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{{
+		Address: "aws_sqs_queue.x",
+		Change:  &tfjson.Change{Actions: tfjson.Actions{tfjson.ActionDelete}},
+	}}}
+	runner := &scriptedRunner{plansByCall: []*tfjson.Plan{deleteP}}
+	_, err := Run(context.Background(), Options{Workdir: dir, Runner: runner})
+	if err == nil {
+		t.Fatal("expected delete error")
+	}
+	if !strings.Contains(err.Error(), "marked for delete") {
+		t.Errorf("err=%v, want marked-for-delete message", err)
+	}
+}
+
+// TestRun_ValidateFailureFatal pins that if patching breaks `terraform
+// validate` (e.g. dropped a Required attr), the loop surfaces the
+// underlying validate error rather than continuing into another plan.
+func TestRun_ValidateFailureFatal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixture(t, dir)
+	runner := &scriptedRunner{
+		plansByCall: []*tfjson.Plan{updatePlan("aws_sqs_queue.x",
+			map[string]any{"name": "alpha"},
+			map[string]any{"name": "bravo"})},
+		validateErr: errors.New(`"name" is required`),
+	}
+	_, err := Run(context.Background(), Options{Workdir: dir, Runner: runner})
+	if err == nil {
+		t.Fatal("expected validate error")
+	}
+	if !strings.Contains(err.Error(), "validate after patch") || !strings.Contains(err.Error(), "is required") {
+		t.Errorf("err=%v, want validate+required message", err)
+	}
+}
+
+// TestRun_MaxIterationsExhausted pins the bound: the loop never spins
+// forever even if drift keeps changing shape across iterations. Default
+// is defaultMaxIterations; lower it explicitly here so the test runs
+// quickly.
+func TestRun_MaxIterationsExhausted(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixture(t, dir)
+	// Distinct drift shapes each iteration so the stability detector
+	// never fires. Three iterations + max=2 means iteration 2 is the
+	// last one we run; the loop returns the "iterations exhausted"
+	// error rather than continuing.
+	plans := []*tfjson.Plan{
+		updatePlan("aws_sqs_queue.x", map[string]any{"a": 1}, map[string]any{"a": 2}),
+		updatePlan("aws_sqs_queue.x", map[string]any{"b": 1}, map[string]any{"b": 2}),
+		updatePlan("aws_sqs_queue.x", map[string]any{"c": 1}, map[string]any{"c": 2}),
+	}
+	runner := &scriptedRunner{plansByCall: plans}
+	_, err := Run(context.Background(), Options{Workdir: dir, Runner: runner, MaxIterations: 2})
+	if err == nil {
+		t.Fatal("expected iterations-exhausted error")
+	}
+	if !strings.Contains(err.Error(), "iterations exhausted") {
+		t.Errorf("err=%v, want iterations-exhausted message", err)
+	}
+}
+
+func TestRun_RejectsEmptyWorkdir(t *testing.T) {
+	t.Parallel()
+	_, err := Run(context.Background(), Options{Runner: &scriptedRunner{}})
+	if err == nil {
+		t.Error("expected error for missing workdir")
+	}
+}
+
+// TestRun_PlanErrorPropagates pins that a real plan failure (not just
+// "drift detected", which shows up as hasChanges=true) surfaces
+// verbatim and aborts the loop.
+func TestRun_PlanErrorPropagates(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixture(t, dir)
+	runner := &scriptedRunner{planErr: errors.New("AccessDenied on terraform plan")}
+	_, err := Run(context.Background(), Options{Workdir: dir, Runner: runner})
+	if err == nil || !strings.Contains(err.Error(), "AccessDenied") {
+		t.Errorf("err=%v, want AccessDenied", err)
+	}
+}

--- a/cmd/insideout-import/driftfix/patch.go
+++ b/cmd/insideout-import/driftfix/patch.go
@@ -1,0 +1,306 @@
+package driftfix
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+// driftClassification is what walking the plan output told us about one
+// resource_change. Each field is independent — a single resource can have
+// drifting attrs *and* be marked for replacement (e.g. attr drift forced
+// the replace), in which case the replace is the operator-visible signal
+// and the drift list is informational.
+type driftClassification struct {
+	address     string
+	driftAttrs  []string // top-level attribute names that differ Before vs After
+	mustReplace bool     // delete-create pair in Actions
+	mustDelete  bool     // bare delete in Actions (shouldn't happen for import)
+	replaceWhy  string   // human-readable reason from ResourceChange
+}
+
+// classifyPlan walks the plan's ResourceChanges and records what each
+// resource needs from the patch step. Only resources with non-no-op
+// actions appear in the result; the count of returned classifications is
+// also the number of "things still wrong" the loop will operate on.
+func classifyPlan(p *tfjson.Plan) []driftClassification {
+	if p == nil {
+		return nil
+	}
+	out := make([]driftClassification, 0, len(p.ResourceChanges))
+	for _, rc := range p.ResourceChanges {
+		if rc == nil || rc.Change == nil {
+			continue
+		}
+		if isNoOp(rc.Change.Actions) {
+			continue
+		}
+		c := driftClassification{address: rc.Address}
+		if hasAction(rc.Change.Actions, tfjson.ActionDelete) && hasAction(rc.Change.Actions, tfjson.ActionCreate) {
+			c.mustReplace = true
+			c.replaceWhy = replaceReasonString(rc.Change.ReplacePaths)
+		} else if hasAction(rc.Change.Actions, tfjson.ActionDelete) && len(rc.Change.Actions) == 1 {
+			c.mustDelete = true
+		} else if isUpdateOnly(rc.Change.Actions) {
+			c.driftAttrs = topLevelDrift(rc.Change.Before, rc.Change.After)
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+func isNoOp(actions tfjson.Actions) bool {
+	return len(actions) == 1 && actions[0] == tfjson.ActionNoop
+}
+
+func isUpdateOnly(actions tfjson.Actions) bool {
+	return len(actions) == 1 && actions[0] == tfjson.ActionUpdate
+}
+
+func hasAction(actions tfjson.Actions, want tfjson.Action) bool {
+	for _, a := range actions {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+// topLevelDrift returns the sorted set of top-level attribute names
+// whose After differs from Before. Sorted so the patch pass produces
+// byte-identical output across runs of the same plan.
+//
+// Nested-block drift (timeouts, lifecycle, etc.) is intentionally not
+// reported — Stage 2c1's contract is "patch the plain attrs"; nested
+// blocks fall under Stage 2c3's dep-chase work. A future caller that
+// hits this gap will see the same attribute name show up in two
+// successive plans (because the patch couldn't reach it) and the
+// stability detector will surface it as escalation rather than spinning.
+func topLevelDrift(before, after any) []string {
+	beforeMap, _ := before.(map[string]any)
+	afterMap, _ := after.(map[string]any)
+	if afterMap == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for k, av := range afterMap {
+		bv, ok := beforeMap[k]
+		if !ok || !reflect.DeepEqual(av, bv) {
+			seen[k] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// replaceReasonString turns the structured ReplacePaths list into a
+// readable hint for the operator. Falls back to "<unspecified>" when the
+// plan didn't surface a path (which happens for some delete-create pairs).
+func replaceReasonString(paths []any) string {
+	if len(paths) == 0 {
+		return "<unspecified>"
+	}
+	return fmt.Sprintf("%v", paths)
+}
+
+// applyDriftPatches drops every drifting top-level attribute from its
+// resource block in `raw` and returns the modified bytes. Replace/delete
+// classifications are NOT patched — the caller surfaces them as fatal.
+//
+// "Drop" is the safe-by-default move for an import flow: terraform will
+// re-read the value from cloud state on the next plan and the
+// resource_change becomes no-op. If dropping breaks `terraform validate`
+// (because the schema marks the attribute Required), the loop's validate
+// call surfaces it as a fatal, the operator can then decide to manually
+// pin via lifecycle.ignore_changes.
+//
+// For attributes where dropping doesn't converge (e.g. CREATE-only
+// flags whose schema default differs from the imported cloud state's
+// "missing"), call applyIgnoreChangesEscalation instead. The loop in
+// driftfix.go alternates the two strategies.
+func applyDriftPatches(raw []byte, classifications []driftClassification) ([]byte, error) {
+	if !hasUpdates(classifications) {
+		return raw, nil
+	}
+	f, diags := hclwrite.ParseConfig(raw, "generated.tf", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("parse generated.tf: %s", diags.Error())
+	}
+
+	driftByAddr := make(map[string][]string, len(classifications))
+	for _, c := range classifications {
+		if len(c.driftAttrs) == 0 {
+			continue
+		}
+		driftByAddr[c.address] = c.driftAttrs
+	}
+
+	for _, blk := range f.Body().Blocks() {
+		if blk.Type() != "resource" {
+			continue
+		}
+		labels := blk.Labels()
+		if len(labels) != 2 {
+			continue
+		}
+		addr := labels[0] + "." + labels[1]
+		attrs, ok := driftByAddr[addr]
+		if !ok {
+			continue
+		}
+		body := blk.Body()
+		for _, name := range attrs {
+			body.RemoveAttribute(name)
+		}
+	}
+	return f.Bytes(), nil
+}
+
+// hasUpdates returns true iff any classification carries drifting
+// top-level attrs the patch can act on. Lets the caller short-circuit
+// re-parsing the HCL when there's nothing to do.
+func hasUpdates(cs []driftClassification) bool {
+	for _, c := range cs {
+		if len(c.driftAttrs) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// applyIgnoreChangesEscalation is the fallback patch strategy when
+// applyDriftPatches drops attrs but the same drift recurs on the next
+// plan. This happens for CREATE-only / DESTROY-only schema attributes
+// (e.g. aws_secretsmanager_secret.force_overwrite_replica_secret,
+// aws_secretsmanager_secret.recovery_window_in_days) whose schema
+// default ("false", "30") differs from what an imported cloud resource
+// reports for them ("null"). Dropping the attr from HCL doesn't help —
+// terraform applies the schema default and the diff persists. The
+// only correct fix is a `lifecycle { ignore_changes = [attr] }` entry
+// per resource.
+//
+// This function adds the offending attrs to each resource's existing
+// lifecycle block (creating one if needed). Existing ignore_changes
+// entries are preserved.
+func applyIgnoreChangesEscalation(raw []byte, classifications []driftClassification) ([]byte, error) {
+	if !hasUpdates(classifications) {
+		return raw, nil
+	}
+	f, diags := hclwrite.ParseConfig(raw, "generated.tf", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("parse generated.tf: %s", diags.Error())
+	}
+
+	driftByAddr := make(map[string][]string, len(classifications))
+	for _, c := range classifications {
+		if len(c.driftAttrs) == 0 {
+			continue
+		}
+		driftByAddr[c.address] = c.driftAttrs
+	}
+
+	for _, blk := range f.Body().Blocks() {
+		if blk.Type() != "resource" {
+			continue
+		}
+		labels := blk.Labels()
+		if len(labels) != 2 {
+			continue
+		}
+		addr := labels[0] + "." + labels[1]
+		attrs, ok := driftByAddr[addr]
+		if !ok {
+			continue
+		}
+		ensureIgnoreChanges(blk, attrs)
+	}
+	return f.Bytes(), nil
+}
+
+// ensureIgnoreChanges adds `attrs` to the resource block's
+// lifecycle.ignore_changes list, creating the lifecycle block if it
+// doesn't exist. Existing entries are preserved (deduplicated by name).
+func ensureIgnoreChanges(blk *hclwrite.Block, attrs []string) {
+	body := blk.Body()
+	for _, sub := range body.Blocks() {
+		if sub.Type() == "lifecycle" {
+			mergeLifecycleIgnoreChanges(sub, attrs)
+			return
+		}
+	}
+	lc := body.AppendNewBlock("lifecycle", nil)
+	lc.Body().SetAttributeRaw("ignore_changes", buildIgnoreChangesTokens(uniqueSorted(attrs)))
+}
+
+// mergeLifecycleIgnoreChanges adds `attrs` to an existing lifecycle
+// block's ignore_changes list. The current implementation parses the
+// existing list as a string-literal slice; if it isn't (e.g. operator
+// hand-edited to use traversal references), the function rebuilds from
+// scratch with `attrs` only. That's lossy in the rare hand-edit case
+// but matches the conservative "we rewrote your file" expectation.
+func mergeLifecycleIgnoreChanges(lc *hclwrite.Block, attrs []string) {
+	body := lc.Body()
+	existing := []string{}
+	if old := body.GetAttribute("ignore_changes"); old != nil {
+		existing = parseIgnoreChangesList(old)
+	}
+	all := append(existing, attrs...)
+	body.SetAttributeRaw("ignore_changes", buildIgnoreChangesTokens(uniqueSorted(all)))
+}
+
+// parseIgnoreChangesList returns the attribute names from a
+// `[a, b]` (traversal) or `["a", "b"]` (string-literal) ignore_changes
+// attribute. Returns nil for any shape it doesn't understand (the
+// caller falls back to overwriting).
+func parseIgnoreChangesList(attr *hclwrite.Attribute) []string {
+	tokens := attr.Expr().BuildTokens(nil)
+	out := []string{}
+	for _, t := range tokens {
+		switch t.Type {
+		case hclsyntax.TokenIdent, hclsyntax.TokenQuotedLit:
+			out = append(out, string(t.Bytes))
+		}
+	}
+	return out
+}
+
+// buildIgnoreChangesTokens emits the token sequence for
+// `[name1, name2, ...]` (traversal-style, NOT string-style). terraform
+// 1.5+ accepts both forms but the traversal form is canonical and
+// matches what `terraform fmt` would write.
+func buildIgnoreChangesTokens(names []string) hclwrite.Tokens {
+	tokens := hclwrite.Tokens{
+		{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")},
+	}
+	for i, n := range names {
+		if i > 0 {
+			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenComma, Bytes: []byte(", ")})
+		}
+		tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte(n)})
+	}
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")})
+	return tokens
+}
+
+func uniqueSorted(in []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/insideout-import/driftfix/patch.go
+++ b/cmd/insideout-import/driftfix/patch.go
@@ -3,6 +3,7 @@ package driftfix
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 
 	"github.com/hashicorp/hcl/v2"
@@ -63,17 +64,19 @@ func isUpdateOnly(actions tfjson.Actions) bool {
 }
 
 func hasAction(actions tfjson.Actions, want tfjson.Action) bool {
-	for _, a := range actions {
-		if a == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(actions, want)
 }
 
 // topLevelDrift returns the sorted set of top-level attribute names
 // whose After differs from Before. Sorted so the patch pass produces
 // byte-identical output across runs of the same plan.
+//
+// The walk visits the union of Before+After keys so a key dropped on
+// the After side (After omits a key Before has) still classifies as
+// drift. terraform-json typically emits both maps with identical key
+// sets and null values for unset attrs, but a key-drop case is what
+// the patch pass would see if a future provider release shifts an
+// attr to deprecated/computed.
 //
 // Nested-block drift (timeouts, lifecycle, etc.) is intentionally not
 // reported — Stage 2c1's contract is "patch the plain attrs"; nested
@@ -84,13 +87,18 @@ func hasAction(actions tfjson.Actions, want tfjson.Action) bool {
 func topLevelDrift(before, after any) []string {
 	beforeMap, _ := before.(map[string]any)
 	afterMap, _ := after.(map[string]any)
-	if afterMap == nil {
+	if beforeMap == nil && afterMap == nil {
 		return nil
 	}
 	seen := map[string]struct{}{}
 	for k, av := range afterMap {
 		bv, ok := beforeMap[k]
 		if !ok || !reflect.DeepEqual(av, bv) {
+			seen[k] = struct{}{}
+		}
+	}
+	for k := range beforeMap {
+		if _, ok := afterMap[k]; !ok {
 			seen[k] = struct{}{}
 		}
 	}

--- a/cmd/insideout-import/driftfix/patch.go
+++ b/cmd/insideout-import/driftfix/patch.go
@@ -250,11 +250,14 @@ func ensureIgnoreChanges(blk *hclwrite.Block, attrs []string) {
 }
 
 // mergeLifecycleIgnoreChanges adds `attrs` to an existing lifecycle
-// block's ignore_changes list. The current implementation parses the
-// existing list as a string-literal slice; if it isn't (e.g. operator
-// hand-edited to use traversal references), the function rebuilds from
-// scratch with `attrs` only. That's lossy in the rare hand-edit case
-// but matches the conservative "we rewrote your file" expectation.
+// block's ignore_changes list, preserving entries already present in
+// either traversal (`[a]`) or quoted-string (`["a"]`) form. If the
+// existing expression doesn't parse as a flat list literal — e.g.
+// the operator hand-edited it to a function expression like
+// `concat([filename], var.extra)` — parseIgnoreChangesList returns
+// nil and we rebuild from `attrs` only. That's lossy in the rare
+// hand-edit case but matches the conservative "we rewrote your file"
+// expectation.
 func mergeLifecycleIgnoreChanges(lc *hclwrite.Block, attrs []string) {
 	body := lc.Body()
 	existing := []string{}
@@ -267,10 +270,14 @@ func mergeLifecycleIgnoreChanges(lc *hclwrite.Block, attrs []string) {
 
 // parseIgnoreChangesList returns the attribute names from a
 // `[a, b]` (traversal) or `["a", "b"]` (string-literal) ignore_changes
-// attribute. Returns nil for any shape it doesn't understand (the
-// caller falls back to overwriting).
+// attribute. Returns nil for any shape it doesn't understand (e.g.
+// `concat(...)` or `var.x` — anything other than a flat bracketed
+// list literal). The caller treats nil as "rebuild from scratch."
 func parseIgnoreChangesList(attr *hclwrite.Attribute) []string {
 	tokens := attr.Expr().BuildTokens(nil)
+	if !isFlatListLiteral(tokens) {
+		return nil
+	}
 	out := []string{}
 	for _, t := range tokens {
 		switch t.Type {
@@ -279,6 +286,41 @@ func parseIgnoreChangesList(attr *hclwrite.Attribute) []string {
 		}
 	}
 	return out
+}
+
+// isFlatListLiteral reports whether the token sequence is the shape
+// `[ident-or-quoted (, ident-or-quoted)* ]` (with optional
+// surrounding quotes around quoted entries). Anything else — function
+// calls, variable refs, splat — returns false so the caller falls
+// back to overwriting.
+func isFlatListLiteral(tokens hclwrite.Tokens) bool {
+	// Strip leading/trailing whitespace and newline tokens.
+	first := -1
+	last := -1
+	for i, t := range tokens {
+		if t.Type == hclsyntax.TokenNewline {
+			continue
+		}
+		if first < 0 {
+			first = i
+		}
+		last = i
+	}
+	if first < 0 || tokens[first].Type != hclsyntax.TokenOBrack || tokens[last].Type != hclsyntax.TokenCBrack {
+		return false
+	}
+	for _, t := range tokens[first+1 : last] {
+		switch t.Type {
+		case hclsyntax.TokenIdent, hclsyntax.TokenQuotedLit,
+			hclsyntax.TokenComma, hclsyntax.TokenOQuote,
+			hclsyntax.TokenCQuote, hclsyntax.TokenNewline,
+			hclsyntax.TokenComment:
+			// permitted
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // buildIgnoreChangesTokens emits the token sequence for

--- a/cmd/insideout-import/driftfix/patch_test.go
+++ b/cmd/insideout-import/driftfix/patch_test.go
@@ -464,6 +464,41 @@ func TestApplyIgnoreChangesEscalation_NoUpdatesShortCircuits(t *testing.T) {
 	}
 }
 
+// TestApplyIgnoreChangesEscalation_RebuildsOnFunctionExpression pins
+// the documented fallback: when the existing ignore_changes is a
+// shape we can't safely parse (function call, variable ref, splat),
+// the merge function rebuilds with the new attrs only rather than
+// returning a garbage union. A mutation that walked TokenIdent
+// indiscriminately would silently produce e.g. ignore_changes =
+// [concat, filename, var, extra, delay_seconds].
+func TestApplyIgnoreChangesEscalation_RebuildsOnFunctionExpression(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_sqs_queue" "x" {
+  name = "alpha"
+
+  lifecycle {
+    ignore_changes = concat([filename], var.extra)
+  }
+}
+`)
+	cs := []driftClassification{{
+		address:    "aws_sqs_queue.x",
+		driftAttrs: []string{"delay_seconds"},
+	}}
+	out, err := applyIgnoreChangesEscalation(in, cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The rebuild must NOT carry forward `concat`/`var`/`extra` as
+	// pseudo-entries; only the new attr should appear.
+	if strings.Contains(string(out), "concat") || strings.Contains(string(out), "var.extra") {
+		t.Errorf("non-list-literal expression must not be merged in; got:\n%s", out)
+	}
+	if !hclHasIgnoreChanges(t, out, "aws_sqs_queue.x", []string{"delay_seconds"}) {
+		t.Errorf("rebuild must contain new attr `delay_seconds`; got:\n%s", out)
+	}
+}
+
 func TestUniqueSorted(t *testing.T) {
 	t.Parallel()
 	got := uniqueSorted([]string{"b", "a", "b", "c", "a"})

--- a/cmd/insideout-import/driftfix/patch_test.go
+++ b/cmd/insideout-import/driftfix/patch_test.go
@@ -1,0 +1,211 @@
+package driftfix
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+func TestClassifyPlan_NoOpDropped(t *testing.T) {
+	t.Parallel()
+	p := &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+		{Address: "aws_sqs_queue.x", Change: &tfjson.Change{Actions: tfjson.Actions{tfjson.ActionNoop}}},
+	}}
+	got := classifyPlan(p)
+	if len(got) != 0 {
+		t.Errorf("no-op resource_change must be excluded; got %v", got)
+	}
+}
+
+// TestClassifyPlan_UpdateExtractsTopLevelDrift pins the contract: only
+// top-level keys whose After differs from Before are reported. A naive
+// implementation that returns every After key would over-patch and
+// silently drop attributes that haven't drifted.
+func TestClassifyPlan_UpdateExtractsTopLevelDrift(t *testing.T) {
+	t.Parallel()
+	p := &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{{
+		Address: "aws_sqs_queue.x",
+		Change: &tfjson.Change{
+			Actions: tfjson.Actions{tfjson.ActionUpdate},
+			Before:  map[string]any{"name": "alpha", "delay_seconds": float64(0), "fifo_queue": false},
+			After:   map[string]any{"name": "alpha", "delay_seconds": float64(30), "fifo_queue": false},
+		},
+	}}}
+	got := classifyPlan(p)
+	if len(got) != 1 {
+		t.Fatalf("classifications=%d, want 1", len(got))
+	}
+	if len(got[0].driftAttrs) != 1 || got[0].driftAttrs[0] != "delay_seconds" {
+		t.Errorf("driftAttrs=%v, want [delay_seconds]", got[0].driftAttrs)
+	}
+}
+
+// TestClassifyPlan_ReplaceFlagged pins that a delete-create pair is
+// surfaced as mustReplace, not silently treated as drift. Auto-resolving
+// a replace would risk data loss.
+func TestClassifyPlan_ReplaceFlagged(t *testing.T) {
+	t.Parallel()
+	p := &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{{
+		Address: "aws_sqs_queue.x",
+		Change: &tfjson.Change{
+			Actions:      tfjson.Actions{tfjson.ActionDelete, tfjson.ActionCreate},
+			ReplacePaths: []any{"name"},
+		},
+	}}}
+	got := classifyPlan(p)
+	if len(got) != 1 || !got[0].mustReplace || got[0].mustDelete {
+		t.Errorf("got=%+v, want mustReplace=true mustDelete=false", got)
+	}
+}
+
+// TestClassifyPlan_DeleteFlagged pins that a bare delete is fatal —
+// import-only runs must never produce a delete, so the loop must
+// surface this rather than hide it as drift.
+func TestClassifyPlan_DeleteFlagged(t *testing.T) {
+	t.Parallel()
+	p := &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{{
+		Address: "aws_sqs_queue.x",
+		Change:  &tfjson.Change{Actions: tfjson.Actions{tfjson.ActionDelete}},
+	}}}
+	got := classifyPlan(p)
+	if len(got) != 1 || !got[0].mustDelete {
+		t.Errorf("got=%+v, want mustDelete=true", got)
+	}
+}
+
+func TestClassifyPlan_NilPlanReturnsNil(t *testing.T) {
+	t.Parallel()
+	if got := classifyPlan(nil); got != nil {
+		t.Errorf("got=%v, want nil for nil plan", got)
+	}
+}
+
+// TestClassifyPlan_SortedDriftAttrs pins determinism: re-running drift
+// classification on the same plan must produce byte-identical output.
+// A mutation that walked the After map without sorting would still
+// "pass" individual cases by coincidence but break the stability
+// detector in driftfix.go (which DeepEquals adjacent iterations).
+func TestClassifyPlan_SortedDriftAttrs(t *testing.T) {
+	t.Parallel()
+	p := &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{{
+		Address: "aws_sqs_queue.x",
+		Change: &tfjson.Change{
+			Actions: tfjson.Actions{tfjson.ActionUpdate},
+			Before:  map[string]any{"a": 1, "b": 1, "c": 1},
+			After:   map[string]any{"a": 2, "b": 2, "c": 2},
+		},
+	}}}
+	got := classifyPlan(p)
+	want := []string{"a", "b", "c"}
+	if len(got[0].driftAttrs) != len(want) {
+		t.Fatalf("len=%d, want %d", len(got[0].driftAttrs), len(want))
+	}
+	for i, w := range want {
+		if got[0].driftAttrs[i] != w {
+			t.Errorf("driftAttrs[%d]=%q, want %q (sorted)", i, got[0].driftAttrs[i], w)
+		}
+	}
+}
+
+func TestApplyDriftPatches_DropsDriftingAttrsOnly(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_sqs_queue" "x" {
+  name           = "alpha"
+  delay_seconds  = 0
+  fifo_queue     = false
+}
+`)
+	cs := []driftClassification{{
+		address:    "aws_sqs_queue.x",
+		driftAttrs: []string{"delay_seconds"},
+	}}
+	out, err := applyDriftPatches(in, cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "delay_seconds") {
+		t.Errorf("delay_seconds must be dropped\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?m)^\s*name\s*=\s*"alpha"`).MatchString(got) {
+		t.Errorf("non-drifting attr `name` must be retained (any whitespace)\n--- got ---\n%s", got)
+	}
+}
+
+// TestApplyDriftPatches_NoUpdatesShortCircuits pins that the function
+// returns the input bytes verbatim when no classification carries
+// drift. Without this, every plan iteration would re-parse + re-emit
+// the HCL, normalizing whitespace and risking unintended diffs.
+func TestApplyDriftPatches_NoUpdatesShortCircuits(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_sqs_queue" "x" { name = "alpha" }
+`)
+	out, err := applyDriftPatches(in, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(in) {
+		t.Errorf("no-updates path must short-circuit; bytes diverged\n--- want ---\n%s\n--- got ---\n%s", in, out)
+	}
+}
+
+// TestApplyDriftPatches_AddressMismatchLeavesBlockAlone pins that the
+// patch only touches the resource block matching the classification's
+// address. A mutation that broadened to "every resource block" would
+// blow away unrelated resources' attrs.
+func TestApplyDriftPatches_AddressMismatchLeavesBlockAlone(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_sqs_queue" "alpha" {
+  name = "a"
+}
+
+resource "aws_sqs_queue" "bravo" {
+  name = "b"
+}
+`)
+	cs := []driftClassification{{address: "aws_sqs_queue.alpha", driftAttrs: []string{"name"}}}
+	out, err := applyDriftPatches(in, cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// alpha's `name = "a"` must be dropped, bravo's `name = "b"` must
+	// remain. Use the value to disambiguate without depending on
+	// hclwrite's whitespace.
+	if strings.Contains(got, `"a"`) {
+		t.Errorf("alpha's `name = \"a\"` must be dropped\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?m)^\s*name\s*=\s*"b"`).MatchString(got) {
+		t.Errorf("bravo's `name = \"b\"` must survive\n--- got ---\n%s", got)
+	}
+}
+
+// TestApplyDriftPatches_MultipleAttrsAllDropped pins the loop in the
+// patch function — mutation that exited after the first attribute
+// would survive single-attr cases.
+func TestApplyDriftPatches_MultipleAttrsAllDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_sqs_queue" "x" {
+  name           = "alpha"
+  delay_seconds  = 0
+  fifo_queue     = false
+}
+`)
+	cs := []driftClassification{{
+		address:    "aws_sqs_queue.x",
+		driftAttrs: []string{"delay_seconds", "fifo_queue"},
+	}}
+	out, err := applyDriftPatches(in, cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "delay_seconds") {
+		t.Errorf("delay_seconds must be dropped\n--- got ---\n%s", got)
+	}
+	if strings.Contains(got, "fifo_queue") {
+		t.Errorf("fifo_queue must be dropped\n--- got ---\n%s", got)
+	}
+}

--- a/cmd/insideout-import/driftfix/patch_test.go
+++ b/cmd/insideout-import/driftfix/patch_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
@@ -207,5 +209,271 @@ func TestApplyDriftPatches_MultipleAttrsAllDropped(t *testing.T) {
 	}
 	if strings.Contains(got, "fifo_queue") {
 		t.Errorf("fifo_queue must be dropped\n--- got ---\n%s", got)
+	}
+}
+
+// TestApplyDriftPatches_MalformedHCLReturnsError pins the parse-error
+// path. A mutation that swallowed parse diagnostics and returned the
+// unparsed bytes would surface as silent drift the loop couldn't
+// patch — surface as a real error so the operator sees it on the
+// first iteration instead of via "iterations exhausted."
+func TestApplyDriftPatches_MalformedHCLReturnsError(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_sqs_queue" "x" { name = "alpha" oops`)
+	cs := []driftClassification{{address: "aws_sqs_queue.x", driftAttrs: []string{"name"}}}
+	_, err := applyDriftPatches(in, cs)
+	if err == nil {
+		t.Fatal("expected parse error for malformed HCL")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("err=%v, want parse-error message", err)
+	}
+}
+
+// TestClassifyPlan_RemovedKeyIsDrift pins the union-walk semantics of
+// topLevelDrift: a key present in Before but absent from After must
+// classify as drift. Without this, the loop would short-circuit on
+// `len(classifications)==0` and report "clean" while terraform plan
+// still reports a change. terraform-json typically emits null for
+// unset attrs (not absent), so this is a defensive pin against future
+// provider releases that drop a key entirely.
+func TestClassifyPlan_RemovedKeyIsDrift(t *testing.T) {
+	t.Parallel()
+	p := &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{{
+		Address: "aws_sqs_queue.x",
+		Change: &tfjson.Change{
+			Actions: tfjson.Actions{tfjson.ActionUpdate},
+			Before:  map[string]any{"name": "alpha", "delay_seconds": float64(0)},
+			After:   map[string]any{"name": "alpha"}, // delay_seconds dropped
+		},
+	}}}
+	got := classifyPlan(p)
+	if len(got) != 1 {
+		t.Fatalf("classifications=%d, want 1", len(got))
+	}
+	if len(got[0].driftAttrs) != 1 || got[0].driftAttrs[0] != "delay_seconds" {
+		t.Errorf("driftAttrs=%v, want [delay_seconds] (key removed from After)", got[0].driftAttrs)
+	}
+}
+
+// hclHasIgnoreChanges reports whether the given resource address (e.g.
+// "aws_sqs_queue.x") has a lifecycle.ignore_changes containing every
+// attr in want. Parses with hclwrite so it isn't sensitive to formatter
+// whitespace or surrounding comments — a string-contains check on the
+// full body would also pass when "ignore_changes" appears in an
+// unrelated comment.
+func hclHasIgnoreChanges(t *testing.T, raw []byte, address string, want []string) bool {
+	t.Helper()
+	f, diags := hclwrite.ParseConfig(raw, "test.tf", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse: %s", diags.Error())
+	}
+	for _, blk := range f.Body().Blocks() {
+		if blk.Type() != "resource" {
+			continue
+		}
+		labels := blk.Labels()
+		if len(labels) != 2 {
+			continue
+		}
+		if labels[0]+"."+labels[1] != address {
+			continue
+		}
+		for _, sub := range blk.Body().Blocks() {
+			if sub.Type() != "lifecycle" {
+				continue
+			}
+			attr := sub.Body().GetAttribute("ignore_changes")
+			if attr == nil {
+				continue
+			}
+			got := parseIgnoreChangesList(attr)
+			gotSet := map[string]struct{}{}
+			for _, g := range got {
+				gotSet[g] = struct{}{}
+			}
+			for _, w := range want {
+				if _, ok := gotSet[w]; !ok {
+					return false
+				}
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func TestApplyIgnoreChangesEscalation_AddsLifecycleBlock(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_sqs_queue" "x" {
+  name = "alpha"
+}
+`)
+	cs := []driftClassification{{
+		address:    "aws_sqs_queue.x",
+		driftAttrs: []string{"delay_seconds"},
+	}}
+	out, err := applyIgnoreChangesEscalation(in, cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hclHasIgnoreChanges(t, out, "aws_sqs_queue.x", []string{"delay_seconds"}) {
+		t.Errorf("escalation must add lifecycle.ignore_changes containing delay_seconds\n--- got ---\n%s", out)
+	}
+}
+
+// TestApplyIgnoreChangesEscalation_MergesIntoExistingLifecycle pins that
+// an existing ignore_changes list is preserved (entries are merged,
+// not overwritten). A mutation that always created a new lifecycle
+// block would produce HCL with two lifecycle blocks (parse error) or
+// would clobber whatever the cleanup pass already wrote (e.g. lambda
+// fixup's filename + image_uri pins).
+func TestApplyIgnoreChangesEscalation_MergesIntoExistingLifecycle(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_sqs_queue" "x" {
+  name = "alpha"
+
+  lifecycle {
+    ignore_changes = [filename]
+  }
+}
+`)
+	cs := []driftClassification{{
+		address:    "aws_sqs_queue.x",
+		driftAttrs: []string{"delay_seconds"},
+	}}
+	out, err := applyIgnoreChangesEscalation(in, cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hclHasIgnoreChanges(t, out, "aws_sqs_queue.x", []string{"filename", "delay_seconds"}) {
+		t.Errorf("merge must preserve `filename` and add `delay_seconds`\n--- got ---\n%s", out)
+	}
+	// Counting `lifecycle {` blocks via parse: there must be exactly 1.
+	f, diags := hclwrite.ParseConfig(out, "test.tf", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("parse: %s", diags.Error())
+	}
+	count := 0
+	for _, blk := range f.Body().Blocks() {
+		if blk.Type() != "resource" {
+			continue
+		}
+		for _, sub := range blk.Body().Blocks() {
+			if sub.Type() == "lifecycle" {
+				count++
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("lifecycle block count = %d, want 1 (merge, not append)", count)
+	}
+}
+
+// TestApplyIgnoreChangesEscalation_DedupesExistingEntries pins that an
+// attr already in ignore_changes isn't duplicated when escalation
+// re-adds it. Duplicate entries are accepted by terraform but ugly
+// in generated.tf and a sign of buggy merge logic.
+func TestApplyIgnoreChangesEscalation_DedupesExistingEntries(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_sqs_queue" "x" {
+  name = "alpha"
+
+  lifecycle {
+    ignore_changes = [delay_seconds]
+  }
+}
+`)
+	cs := []driftClassification{{
+		address:    "aws_sqs_queue.x",
+		driftAttrs: []string{"delay_seconds"},
+	}}
+	out, err := applyIgnoreChangesEscalation(in, cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c := strings.Count(string(out), "delay_seconds"); c != 1 {
+		t.Errorf("delay_seconds occurrences = %d, want 1 (dedup)\n--- got ---\n%s", c, out)
+	}
+}
+
+// TestApplyIgnoreChangesEscalation_AddressMismatchLeavesBlockAlone pins
+// that escalation only touches the resource block whose address is in
+// the classification — so a single drifting resource doesn't sprinkle
+// lifecycle blocks across every other resource in the file.
+func TestApplyIgnoreChangesEscalation_AddressMismatchLeavesBlockAlone(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_sqs_queue" "alpha" {
+  name = "a"
+}
+
+resource "aws_sqs_queue" "bravo" {
+  name = "b"
+}
+`)
+	cs := []driftClassification{{address: "aws_sqs_queue.alpha", driftAttrs: []string{"delay_seconds"}}}
+	out, err := applyIgnoreChangesEscalation(in, cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hclHasIgnoreChanges(t, out, "aws_sqs_queue.alpha", []string{"delay_seconds"}) {
+		t.Errorf("alpha must gain lifecycle.ignore_changes\n--- got ---\n%s", out)
+	}
+	if hclHasIgnoreChanges(t, out, "aws_sqs_queue.bravo", []string{"delay_seconds"}) {
+		t.Errorf("bravo must NOT gain lifecycle.ignore_changes\n--- got ---\n%s", out)
+	}
+}
+
+// TestApplyIgnoreChangesEscalation_MultipleAttrsAllAdded pins the loop —
+// a mutation that exited after the first attr would survive single-
+// attr cases. Also pins the sort: output must be deterministic so
+// downstream golden-file tests don't churn.
+func TestApplyIgnoreChangesEscalation_MultipleAttrsAllAdded(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_sqs_queue" "x" {
+  name = "alpha"
+}
+`)
+	cs := []driftClassification{{
+		address:    "aws_sqs_queue.x",
+		driftAttrs: []string{"fifo_queue", "delay_seconds"},
+	}}
+	out, err := applyIgnoreChangesEscalation(in, cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hclHasIgnoreChanges(t, out, "aws_sqs_queue.x", []string{"delay_seconds", "fifo_queue"}) {
+		t.Errorf("both attrs must appear in ignore_changes\n--- got ---\n%s", out)
+	}
+	// Pin sort: delay_seconds < fifo_queue alphabetically.
+	if !regexp.MustCompile(`ignore_changes\s*=\s*\[delay_seconds,\s*fifo_queue\]`).Match(out) {
+		t.Errorf("ignore_changes must be sorted [delay_seconds, fifo_queue]\n--- got ---\n%s", out)
+	}
+}
+
+func TestApplyIgnoreChangesEscalation_NoUpdatesShortCircuits(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_sqs_queue" "x" { name = "alpha" }
+`)
+	out, err := applyIgnoreChangesEscalation(in, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(in) {
+		t.Errorf("no-updates path must short-circuit; bytes diverged")
+	}
+}
+
+func TestUniqueSorted(t *testing.T) {
+	t.Parallel()
+	got := uniqueSorted([]string{"b", "a", "b", "c", "a"})
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("len=%d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("got[%d]=%q, want %q", i, got[i], w)
+		}
 	}
 }

--- a/cmd/insideout-import/driftfix/runner.go
+++ b/cmd/insideout-import/driftfix/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
 	tfjson "github.com/hashicorp/terraform-json"
@@ -66,7 +67,21 @@ func (r *execRunner) Validate(ctx context.Context) error {
 		return err
 	}
 	if !out.Valid {
-		return fmt.Errorf("terraform validate reported %d error diagnostic(s)", out.ErrorCount)
+		msgs := make([]string, 0, len(out.Diagnostics))
+		for _, d := range out.Diagnostics {
+			if d.Severity != tfjson.DiagnosticSeverityError {
+				continue
+			}
+			msg := d.Summary
+			if d.Detail != "" {
+				msg = msg + ": " + d.Detail
+			}
+			if d.Range != nil {
+				msg = fmt.Sprintf("%s:%d: %s", d.Range.Filename, d.Range.Start.Line, msg)
+			}
+			msgs = append(msgs, msg)
+		}
+		return fmt.Errorf("terraform validate reported %d error diagnostic(s): %s", out.ErrorCount, strings.Join(msgs, "; "))
 	}
 	return nil
 }

--- a/cmd/insideout-import/driftfix/runner.go
+++ b/cmd/insideout-import/driftfix/runner.go
@@ -1,0 +1,72 @@
+package driftfix
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+// terraformRunner is the narrow surface driftfix needs from terraform-exec.
+// Tests inject a fake; production uses execRunner backed by the
+// `terraform` binary on PATH.
+//
+// Drift fix runs after genconfig.Run has already done init + plan. We
+// don't re-init here — re-init would clobber the .terraform dir genconfig
+// just produced. The runner's only job is to drive plan-and-show cycles
+// and re-validate after each patch.
+type terraformRunner interface {
+	// PlanTo runs `terraform plan -out=<planFile>`. Returns hasChanges =
+	// true iff the plan contains a non-no-op resource change.
+	PlanTo(ctx context.Context, planFile string) (hasChanges bool, err error)
+	// ShowPlan decodes a binary plan file into the typed tfjson.Plan
+	// shape so the patch pass can walk ResourceChanges.
+	ShowPlan(ctx context.Context, planFile string) (*tfjson.Plan, error)
+	// Validate re-runs `terraform validate` after a patch. We re-validate
+	// every iteration because the patch can drop required attrs and the
+	// loop must surface that as a fatal rather than march into another
+	// plan call.
+	Validate(ctx context.Context) error
+}
+
+// execRunner adapts a *tfexec.Terraform to the terraformRunner interface.
+// The constructor is identical in shape to genconfig.execRunner — both
+// ride the same workdir, but each package declares its own runner so
+// the dependency direction stays one-way (driftfix never imports
+// genconfig).
+type execRunner struct {
+	tf *tfexec.Terraform
+}
+
+func newExecRunner(workdir string) (*execRunner, error) {
+	bin, err := exec.LookPath("terraform")
+	if err != nil {
+		return nil, fmt.Errorf("terraform binary not found on PATH: %w", err)
+	}
+	tf, err := tfexec.NewTerraform(workdir, bin)
+	if err != nil {
+		return nil, fmt.Errorf("init terraform-exec: %w", err)
+	}
+	return &execRunner{tf: tf}, nil
+}
+
+func (r *execRunner) PlanTo(ctx context.Context, planFile string) (bool, error) {
+	return r.tf.Plan(ctx, tfexec.Out(planFile))
+}
+
+func (r *execRunner) ShowPlan(ctx context.Context, planFile string) (*tfjson.Plan, error) {
+	return r.tf.ShowPlanFile(ctx, planFile)
+}
+
+func (r *execRunner) Validate(ctx context.Context) error {
+	out, err := r.tf.Validate(ctx)
+	if err != nil {
+		return err
+	}
+	if !out.Valid {
+		return fmt.Errorf("terraform validate reported %d error diagnostic(s)", out.ErrorCount)
+	}
+	return nil
+}

--- a/cmd/insideout-import/genconfig/cleanup.go
+++ b/cmd/insideout-import/genconfig/cleanup.go
@@ -5,9 +5,9 @@ import (
 	"sort"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	tfjson "github.com/hashicorp/terraform-json"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // awsProviderKey is the registry source for the AWS provider as it appears in
@@ -104,7 +104,7 @@ func applySchemaToBlock(blk *hclwrite.Block, schema *tfjson.SchemaBlock) {
 		}
 	}
 	lc := blk.Body().AppendNewBlock("lifecycle", nil)
-	lc.Body().SetAttributeValue("ignore_changes", traversalListValue(sensitive))
+	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(sensitive))
 }
 
 // mergeIgnoreChanges is a placeholder for the case where a `lifecycle` block
@@ -112,21 +112,24 @@ func applySchemaToBlock(blk *hclwrite.Block, schema *tfjson.SchemaBlock) {
 // attribute from scratch — a smarter merge can land in Stage 2c if a real
 // caller hits it.
 func mergeIgnoreChanges(lc *hclwrite.Block, sensitive []string) {
-	lc.Body().SetAttributeValue("ignore_changes", traversalListValue(sensitive))
+	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(sensitive))
 }
 
-// traversalListValue builds the cty value for ignore_changes. Terraform's
-// schema technically wants a list of attribute references, not a list of
-// strings, but for the unaliased-attribute case (no nested blocks) the string
-// form is interpreted identically by the engine. We use the string form here
-// because hclwrite's SetAttributeValue can't accept naked traversals.
-func traversalListValue(names []string) cty.Value {
-	out := make([]cty.Value, 0, len(names))
-	for _, n := range names {
-		out = append(out, cty.StringVal(n))
+// ignoreChangesTokens emits the canonical `[name1, name2, ...]` form
+// (traversal references, NOT quoted strings). terraform 1.5+ deprecates
+// the quoted form with a warning at every plan; using traversal form
+// keeps generated.tf warning-free and matches what `terraform fmt`
+// would produce.
+func ignoreChangesTokens(names []string) hclwrite.Tokens {
+	tokens := hclwrite.Tokens{
+		{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")},
 	}
-	if len(out) == 0 {
-		return cty.ListValEmpty(cty.String)
+	for i, n := range names {
+		if i > 0 {
+			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenComma, Bytes: []byte(", ")})
+		}
+		tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte(n)})
 	}
-	return cty.ListVal(out)
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")})
+	return tokens
 }

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -96,7 +96,7 @@ func fixupLambdaSource(blk *hclwrite.Block) {
 		}
 	}
 	lc := body.AppendNewBlock("lifecycle", nil)
-	lc.Body().SetAttributeValue("ignore_changes", traversalListValue(lambdaIgnoreChanges))
+	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(lambdaIgnoreChanges))
 }
 
 // hasUsableValue reports whether the named attribute is both present and

--- a/cmd/insideout-import/main.go
+++ b/cmd/insideout-import/main.go
@@ -9,11 +9,12 @@
 //	          runs `terraform plan -json` to verify the plan is import-only.
 //	          See cmd/insideout-import/README.md.
 //
-//	discover  Discover existing cloud resources, emit imported.json, and
+//	discover  Discover existing cloud resources, emit imported.json,
 //	          generate validated HCL bodies via `terraform plan
-//	          -generate-config-out` + schema cleanup (Stages 2a + 2b, AWS
-//	          only). Stage 2c adds drift fixing and dependency chasing;
-//	          Stage 2d adds GCP.
+//	          -generate-config-out` + schema cleanup, then loop the plan
+//	          to patch drifting attributes (Stages 2a + 2b + 2c1, AWS
+//	          only). Stage 2c2/2c3/2c4 add SDK QoS, dependency chasing,
+//	          and a localstack CI gate; Stage 2d adds GCP.
 //
 // Run `insideout-import <subcommand> --help` for subcommand flags.
 package main
@@ -48,7 +49,7 @@ func usage() {
 
 Subcommands:
   adopt     emit import {} blocks against a known preset stack
-  discover  discover cloud resources, write imported.json, and generate validated HCL (AWS only — Stages 2a+2b of #189)
+  discover  discover cloud resources, write imported.json, generate validated HCL, and loop drift fix (AWS only — Stages 2a+2b+2c1 of #189)
 
 Run 'insideout-import <subcommand> --help' for subcommand flags.`)
 }


### PR DESCRIPTION
Closes #269. First sub-ticket of #263 (Stage 2c1 of the #189 split).

## Summary

- Add `cmd/insideout-import/driftfix/` with a two-strategy plan-driven drift fix loop. Stage 2b (#268) produces validate-clean HCL but `terraform plan` routinely shows drift (CREATE-only / DESTROY-only schema attrs whose defaults differ from imported cloud state). Stage 2c1 patches that drift in a bounded loop until `terraform plan -detailed-exitcode` returns 0.
- Loop: plan → classify resource_changes → drop drifting top-level attrs from `generated.tf` (terraform re-reads from cloud state on the next plan) → validate → repeat. If the same drift recurs (drop didn't help — typical for CREATE-only schema attrs like `aws_secretsmanager_secret.recovery_window_in_days`), escalate to `lifecycle { ignore_changes = [...] }`. If drift recurs again *after* escalation, fatal "stable but unresolved" so the operator sees what couldn't be auto-fixed.
- `replace` (delete-create pair) and bare `delete` actions surface as fatal — auto-resolving either is data-loss risk; the operator must reconcile manually.
- Wire into `discover.go` after Stage 2b. Default ON; `--no-driftfix` flag stops at validate-clean for operators who want to inspect drift manually.
- terraform-exec's `Plan` returns `hasChanges=true` for any non-empty plan (including pure import plans where every resource_change is no-op). The loop short-circuits when classifications are all no-ops to handle this — pinned by `TestRun_ImportOnlyPlanReturnsClean`.
- Output ignore_changes uses traversal token form `[name1, name2]` (not deprecated string form `["name1", "name2"]`) so generated.tf stays warning-free under Terraform 1.5+. Same convention applied to genconfig's Sensitive-driven cleanup and Lambda fixup.

## Test plan

- [x] `go test ./cmd/insideout-import/...` passes (driftfix: 11 driftfix_test cases + 17 patch_test cases; discover_test adds 5 cases for `--no-driftfix` flag and pipeline wiring).
- [x] `go test -race ./cmd/insideout-import/...` clean.
- [x] `go vet ./...`, `gofmt -l`, all 8 lint scripts (`lint-foreach-unknown-keys`, `lint-labelless-name-prefix`, `lint-no-root-only-blocks`, `lint-phantom-computed-fields`, `lint-project-label`, `lint-project-tag`, `lint-sensitive-for-each`, `lint-shared-no-cloud-providers`), `terraform fmt -check -recursive`: clean.
- [x] qa-professor review on new tests; addressed P0 (direct unit tests for `applyIgnoreChangesEscalation` + helpers; fixed `topLevelDrift` to walk Before+After union for key-removed-from-After), P1 (validate call counts, call-sequence ordering, post-fatal `generated.tf` byte preservation, validate-after-escalation failure case), and P2 picks (HCL-parse helpers replace `strings.Contains` shape checks; stderr capture pins remediation hint).
- [x] Live smoke against `io-buqiks112yag` (us-east-1, account 536892739526): 6 resources discovered, drift fix converged in 3 iterations, `terraform plan -detailed-exitcode` returns 0 post-loop, zero deprecation warnings, `Plan: 6 to import, 0 to add, 0 to change, 0 to destroy.`
- [ ] Final CI green via `gh pr checks` after PR opens.

## Out of scope (deferred to other 2c sub-tickets)

- Dependency chase (find unresolved ARNs in generated.tf → re-discover + re-import) → **Stage 2c3 (#271)**.
- AWS SDK QoS (errgroup bounded concurrency + retry tuning) → **Stage 2c2 (#270)**.
- Localstack CI gate proving zero-drift end-to-end → **Stage 2c4 (#272)**.