### PR TITLE
feat(insideout-import): SDK QoS hardening (Stage 2c2 — errgroup + retryer)

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -1,9 +1,14 @@
-// Package awsdiscover holds the AWS-side per-resource-type discoverers used
-// by the insideout-import discover subcommand (Stage 2a of #189). Each
-// discoverer issues read-only AWS SDK calls against the operator's account
-// and returns Phase 2 imported.ImportedResource entries — no terraform-exec,
+// Package awsdiscover holds the AWS-side per-resource-type discoverers
+// used by the insideout-import discover subcommand. Each discoverer
+// issues read-only AWS SDK calls against the operator's account and
+// returns Phase 2 imported.ImportedResource entries — no terraform-exec,
 // no HCL generation. Stage 2b layers `terraform plan -generate-config-out`
 // on top of this manifest to produce the actual .tf files.
+//
+// Originally landed as Stage 2a (#266); Stage 2c2 (#270) added bounded-
+// concurrency errgroup fan-out inside the DynamoDB and Lambda discoverers
+// (the only two with per-item tag API calls), gated by DefaultMaxConcurrency
+// or a caller-supplied override on NewAWSDiscovererWithConcurrency.
 //
 // Discoverers in this package own narrow client interfaces so unit tests
 // can mock the SDK boundary without depending on real AWS credentials.

--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -37,6 +37,14 @@ type Discoverer interface {
 	Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error)
 }
 
+// DefaultMaxConcurrency is the per-discoverer fan-out limit applied when
+// the caller does not request a specific value. 10 is the empirical sweet
+// spot from the audit in #270 — high enough to keep a few-thousand-resource
+// account scan under a minute, low enough that the SDK's adaptive retryer
+// can absorb transient Throttling without exhausting the configured retry
+// budget.
+const DefaultMaxConcurrency = 10
+
 // AWSDiscoverer aggregates the per-type discoverers and fans out a single
 // DiscoverTypes call across all of them. Construct with NewAWSDiscoverer
 // in production; tests can build it directly with mock discoverers.
@@ -44,18 +52,37 @@ type AWSDiscoverer struct {
 	byType map[string]Discoverer
 }
 
-// NewAWSDiscoverer wires up the production set of AWS discoverers (the 5
-// Phase 1 types: SQS, DynamoDB, CloudWatch Logs, Secrets Manager, Lambda).
-// All discoverers share the same aws.Config; per-type SDK clients are
-// constructed inside each discoverer.
+// NewAWSDiscoverer wires up the production set of AWS discoverers with the
+// default per-type fan-out limit. Equivalent to
+// NewAWSDiscovererWithConcurrency(cfg, DefaultMaxConcurrency).
 func NewAWSDiscoverer(cfg aws.Config) *AWSDiscoverer {
+	return NewAWSDiscovererWithConcurrency(cfg, DefaultMaxConcurrency)
+}
+
+// NewAWSDiscovererWithConcurrency wires up the production set of AWS
+// discoverers (the 5 Phase 1 types: SQS, DynamoDB, CloudWatch Logs, Secrets
+// Manager, Lambda). All discoverers share the same aws.Config; per-type SDK
+// clients are constructed inside each discoverer. maxConcurrency is the
+// upper bound on per-resource tag-fanout calls inside the DynamoDB and
+// Lambda discoverers (the only two with per-item API fan-out today). The
+// other three discoverers either filter server-side (SecretsManager) or
+// only issue a single List call (SQS, CloudWatchLogs) and ignore the limit.
+//
+// A non-positive maxConcurrency falls back to DefaultMaxConcurrency rather
+// than serializing — callers should validate flag input upstream and fail
+// loudly there. The fallback exists only as a safety net for direct
+// programmatic callers.
+func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDiscoverer {
+	if maxConcurrency <= 0 {
+		maxConcurrency = DefaultMaxConcurrency
+	}
 	return &AWSDiscoverer{
 		byType: map[string]Discoverer{
 			"aws_sqs_queue":             newSQSDiscoverer(cfg),
-			"aws_dynamodb_table":        newDynamoDBDiscoverer(cfg),
+			"aws_dynamodb_table":        newDynamoDBDiscoverer(cfg, maxConcurrency),
 			"aws_cloudwatch_log_group":  newCloudWatchLogsDiscoverer(cfg),
 			"aws_secretsmanager_secret": newSecretsManagerDiscoverer(cfg),
-			"aws_lambda_function":       newLambdaDiscoverer(cfg),
+			"aws_lambda_function":       newLambdaDiscoverer(cfg, maxConcurrency),
 		},
 	}
 }
@@ -76,10 +103,11 @@ func (a *AWSDiscoverer) SupportedTypes() []string {
 // invalid names (not interleaved with partial results) so the operator sees
 // the full set of misspellings in one shot.
 //
-// Concurrency is intentionally serial in Stage 2a — Stage 2c will introduce
-// errgroup with bounded parallelism + the SDK retryer config (per #189's
-// QA carry-forward). Keeping it simple here means deterministic test output
-// and no throttling surprises on small/medium accounts.
+// The aggregator itself is sequential across resource types — concurrency
+// lives inside individual discoverers (DynamoDB, Lambda) where per-item
+// tag-fanout dominates wall time. Stage 2c2 (#270) bounded that fanout via
+// errgroup; the SDK retryer config in cmd/insideout-import/discover.go
+// raises maxAttempts so transient Throttling no longer aborts a run.
 func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, project, region, accountID string) ([]imported.ImportedResource, error) {
 	if len(types) == 0 {
 		types = a.SupportedTypes()

--- a/cmd/insideout-import/awsdiscover/awsdiscover_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_test.go
@@ -139,9 +139,14 @@ func TestNewAWSDiscoverer_Registers5PhaseOneTypes(t *testing.T) {
 
 // TestNewAWSDiscoverer_AppliesDefaultMaxConcurrency pins that the legacy
 // single-arg constructor delegates with DefaultMaxConcurrency rather than
-// silently serializing (which would defeat the point of #270).
+// silently serializing (which would defeat the point of #270). The
+// literal-value pin guards the audit-grounded constant: a refactor that
+// re-points DefaultMaxConcurrency to 1 must fail this test.
 func TestNewAWSDiscoverer_AppliesDefaultMaxConcurrency(t *testing.T) {
 	t.Parallel()
+	if DefaultMaxConcurrency != 10 {
+		t.Errorf("DefaultMaxConcurrency=%d, want 10 (audit-grounded sweet spot per #270 — change requires updating both the constant doc and this pin)", DefaultMaxConcurrency)
+	}
 	agg := NewAWSDiscoverer(awsDummyConfig())
 	dyn, ok := agg.byType["aws_dynamodb_table"].(*dynamoDiscoverer)
 	if !ok {

--- a/cmd/insideout-import/awsdiscover/awsdiscover_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_test.go
@@ -136,3 +136,58 @@ func TestNewAWSDiscoverer_Registers5PhaseOneTypes(t *testing.T) {
 		}
 	}
 }
+
+// TestNewAWSDiscoverer_AppliesDefaultMaxConcurrency pins that the legacy
+// single-arg constructor delegates with DefaultMaxConcurrency rather than
+// silently serializing (which would defeat the point of #270).
+func TestNewAWSDiscoverer_AppliesDefaultMaxConcurrency(t *testing.T) {
+	t.Parallel()
+	agg := NewAWSDiscoverer(awsDummyConfig())
+	dyn, ok := agg.byType["aws_dynamodb_table"].(*dynamoDiscoverer)
+	if !ok {
+		t.Fatalf("dynamodb discoverer is not *dynamoDiscoverer (got %T)", agg.byType["aws_dynamodb_table"])
+	}
+	if dyn.maxConcurrency != DefaultMaxConcurrency {
+		t.Errorf("dynamo maxConcurrency=%d, want %d", dyn.maxConcurrency, DefaultMaxConcurrency)
+	}
+	lam, ok := agg.byType["aws_lambda_function"].(*lambdaDiscoverer)
+	if !ok {
+		t.Fatalf("lambda discoverer is not *lambdaDiscoverer (got %T)", agg.byType["aws_lambda_function"])
+	}
+	if lam.maxConcurrency != DefaultMaxConcurrency {
+		t.Errorf("lambda maxConcurrency=%d, want %d", lam.maxConcurrency, DefaultMaxConcurrency)
+	}
+}
+
+// TestNewAWSDiscovererWithConcurrency_ThreadsValueToFanoutDiscoverers
+// pins that an explicit concurrency value reaches both per-item-fanout
+// discoverers (DynamoDB and Lambda). The single-call discoverers (SQS,
+// CloudWatch Logs, SecretsManager) ignore the value by design.
+func TestNewAWSDiscovererWithConcurrency_ThreadsValueToFanoutDiscoverers(t *testing.T) {
+	t.Parallel()
+	agg := NewAWSDiscovererWithConcurrency(awsDummyConfig(), 25)
+	if d := agg.byType["aws_dynamodb_table"].(*dynamoDiscoverer); d.maxConcurrency != 25 {
+		t.Errorf("dynamo maxConcurrency=%d, want 25", d.maxConcurrency)
+	}
+	if l := agg.byType["aws_lambda_function"].(*lambdaDiscoverer); l.maxConcurrency != 25 {
+		t.Errorf("lambda maxConcurrency=%d, want 25", l.maxConcurrency)
+	}
+}
+
+// TestNewAWSDiscovererWithConcurrency_NonPositiveFallsBackToDefault
+// is the safety net for direct programmatic callers. The CLI rejects
+// non-positive --max-concurrency upstream, but a Go caller using this
+// constructor directly should not get a deadlocked errgroup
+// (g.SetLimit(0) blocks forever).
+func TestNewAWSDiscovererWithConcurrency_NonPositiveFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+	for _, n := range []int{0, -1, -100} {
+		agg := NewAWSDiscovererWithConcurrency(awsDummyConfig(), n)
+		if d := agg.byType["aws_dynamodb_table"].(*dynamoDiscoverer); d.maxConcurrency != DefaultMaxConcurrency {
+			t.Errorf("n=%d: dynamo maxConcurrency=%d, want %d", n, d.maxConcurrency, DefaultMaxConcurrency)
+		}
+		if l := agg.byType["aws_lambda_function"].(*lambdaDiscoverer); l.maxConcurrency != DefaultMaxConcurrency {
+			t.Errorf("n=%d: lambda maxConcurrency=%d, want %d", n, l.maxConcurrency, DefaultMaxConcurrency)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/dynamodb.go
+++ b/cmd/insideout-import/awsdiscover/dynamodb.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
@@ -18,11 +20,18 @@ type dynamoClient interface {
 }
 
 type dynamoDiscoverer struct {
-	new func() dynamoClient
+	new            func() dynamoClient
+	maxConcurrency int
 }
 
-func newDynamoDBDiscoverer(cfg aws.Config) Discoverer {
-	return &dynamoDiscoverer{new: func() dynamoClient { return dynamodb.NewFromConfig(cfg) }}
+func newDynamoDBDiscoverer(cfg aws.Config, maxConcurrency int) Discoverer {
+	if maxConcurrency <= 0 {
+		maxConcurrency = DefaultMaxConcurrency
+	}
+	return &dynamoDiscoverer{
+		new:            func() dynamoClient { return dynamodb.NewFromConfig(cfg) },
+		maxConcurrency: maxConcurrency,
+	}
 }
 
 func (d *dynamoDiscoverer) ResourceType() string { return "aws_dynamodb_table" }
@@ -32,6 +41,14 @@ func (d *dynamoDiscoverer) ResourceType() string { return "aws_dynamodb_table" }
 // runs ListTagsOfResource to confirm the Project tag. The double check
 // (prefix + tag) defends against table names that share the project prefix
 // by accident.
+//
+// Per-table tag lookups fan out under a bounded errgroup so a few-thousand
+// table account does not serialize into a multi-minute wall-time. Per-item
+// SDK errors stay fail-closed (transient ListTagsOfResource failures skip
+// the table rather than aborting the run, since the SDK retryer has
+// already exhausted its budget by then). Parent-context cancellation IS
+// propagated: gctx unblocks any in-flight goroutines and Discover returns
+// ctx.Err() rather than a silently-truncated set.
 //
 // Import ID for aws_dynamodb_table is the table name.
 func (d *dynamoDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
@@ -59,24 +76,48 @@ func (d *dynamoDiscoverer) Discover(ctx context.Context, project, region, accoun
 	if project == "" || accountID == "" || region == "" {
 		// Without an account ID + region we cannot construct the ARN
 		// ListTagsOfResource needs. Fall back to prefix-only filtering and
-		// trust the operator-supplied scope. Stage 2c will add a hard-fail
-		// when STS lookup is mandatory.
+		// trust the operator-supplied scope.
 		matched = all
 	} else {
-		for _, name := range all {
-			arn := fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", region, accountID, name)
-			tagsOut, err := client.ListTagsOfResource(ctx, &dynamodb.ListTagsOfResourceInput{ResourceArn: aws.String(arn)})
-			if err != nil {
-				// Fail-closed; same rationale as Lambda discoverer.
-				continue
-			}
-			for _, tag := range tagsOut.Tags {
-				if aws.ToString(tag.Key) == "Project" && aws.ToString(tag.Value) == project {
-					matched = append(matched, name)
-					break
-				}
-			}
+		var (
+			mu sync.Mutex
+			ok []string
+		)
+		limit := d.maxConcurrency
+		if limit <= 0 {
+			limit = DefaultMaxConcurrency
 		}
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(limit)
+		for _, name := range all {
+			name := name
+			g.Go(func() error {
+				if err := gctx.Err(); err != nil {
+					return err
+				}
+				arn := fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", region, accountID, name)
+				tagsOut, err := client.ListTagsOfResource(gctx, &dynamodb.ListTagsOfResourceInput{ResourceArn: aws.String(arn)})
+				if err != nil {
+					if cerr := gctx.Err(); cerr != nil {
+						return cerr
+					}
+					return nil
+				}
+				for _, tag := range tagsOut.Tags {
+					if aws.ToString(tag.Key) == "Project" && aws.ToString(tag.Value) == project {
+						mu.Lock()
+						ok = append(ok, name)
+						mu.Unlock()
+						return nil
+					}
+				}
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return nil, fmt.Errorf("ListTagsOfResource: %w", err)
+		}
+		matched = ok
 	}
 
 	sort.Strings(matched)

--- a/cmd/insideout-import/awsdiscover/dynamodb_test.go
+++ b/cmd/insideout-import/awsdiscover/dynamodb_test.go
@@ -3,7 +3,10 @@ package awsdiscover
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -15,6 +18,7 @@ type fakeDynamoClient struct {
 	tagsByID map[string][]dynamotypes.Tag
 	tagsErr  map[string]error
 
+	mu        sync.Mutex
 	listCalls []dynamodb.ListTablesInput
 	tagCalls  []string
 	listErr   error
@@ -34,7 +38,9 @@ func (f *fakeDynamoClient) ListTables(_ context.Context, in *dynamodb.ListTables
 
 func (f *fakeDynamoClient) ListTagsOfResource(_ context.Context, in *dynamodb.ListTagsOfResourceInput, _ ...func(*dynamodb.Options)) (*dynamodb.ListTagsOfResourceOutput, error) {
 	arn := aws.ToString(in.ResourceArn)
+	f.mu.Lock()
 	f.tagCalls = append(f.tagCalls, arn)
+	f.mu.Unlock()
 	if err, ok := f.tagsErr[arn]; ok {
 		return nil, err
 	}
@@ -178,5 +184,175 @@ func TestDynamoDBDiscover_PropagatesListTablesError(t *testing.T) {
 	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+// blockingDynamoClient is a fake whose ListTagsOfResource signals when
+// each call enters and then blocks until release is closed (or ctx is
+// cancelled). Used by the concurrency + cancellation tests.
+type blockingDynamoClient struct {
+	pages []dynamodb.ListTablesOutput
+	tags  map[string][]dynamotypes.Tag
+
+	release chan struct{}
+
+	mu          sync.Mutex
+	inflight    int
+	maxInflight int
+	starts      chan string
+
+	listIdx int
+}
+
+func (c *blockingDynamoClient) ListTables(_ context.Context, _ *dynamodb.ListTablesInput, _ ...func(*dynamodb.Options)) (*dynamodb.ListTablesOutput, error) {
+	if c.listIdx >= len(c.pages) {
+		return &dynamodb.ListTablesOutput{}, nil
+	}
+	out := c.pages[c.listIdx]
+	c.listIdx++
+	return &out, nil
+}
+
+func (c *blockingDynamoClient) ListTagsOfResource(ctx context.Context, in *dynamodb.ListTagsOfResourceInput, _ ...func(*dynamodb.Options)) (*dynamodb.ListTagsOfResourceOutput, error) {
+	arn := aws.ToString(in.ResourceArn)
+	c.mu.Lock()
+	c.inflight++
+	if c.inflight > c.maxInflight {
+		c.maxInflight = c.inflight
+	}
+	c.mu.Unlock()
+	if c.starts != nil {
+		c.starts <- arn
+	}
+	defer func() {
+		c.mu.Lock()
+		c.inflight--
+		c.mu.Unlock()
+	}()
+
+	select {
+	case <-c.release:
+		return &dynamodb.ListTagsOfResourceOutput{Tags: c.tags[arn]}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// TestDynamoDBDiscover_BoundedConcurrency mirrors the Lambda test for
+// the DynamoDB code path — distinct discoverer, distinct errgroup, so
+// we pin both. Without separate coverage a regression that drops
+// SetLimit on dynamodb.go but keeps it on lambda.go would slip through.
+func TestDynamoDBDiscover_BoundedConcurrency(t *testing.T) {
+	t.Parallel()
+	const total = 30
+	const limit = 4
+
+	names := make([]string, total)
+	tags := make(map[string][]dynamotypes.Tag, total)
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("io-foo-%d", i)
+		names[i] = name
+		arn := fmt.Sprintf("arn:aws:dynamodb:us-east-1:123:table/%s", name)
+		tags[arn] = []dynamotypes.Tag{tagPair("Project", "io-foo")}
+	}
+	release := make(chan struct{})
+	bc := &blockingDynamoClient{
+		pages:   []dynamodb.ListTablesOutput{{TableNames: names}},
+		tags:    tags,
+		release: release,
+	}
+	d := &dynamoDiscoverer{
+		new:            func() dynamoClient { return bc },
+		maxConcurrency: limit,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+		done <- err
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		bc.mu.Lock()
+		got := bc.inflight
+		bc.mu.Unlock()
+		if got >= limit {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("never reached %d in-flight; saw %d", limit, got)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	time.Sleep(50 * time.Millisecond)
+	bc.mu.Lock()
+	peak := bc.maxInflight
+	bc.mu.Unlock()
+	if peak > limit {
+		t.Errorf("peak in-flight=%d exceeded limit=%d", peak, limit)
+	}
+
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+}
+
+// TestDynamoDBDiscover_ContextCancellationUnblocksSiblings mirrors the
+// lambda test — pins the same gctx-propagation contract on the DynamoDB
+// errgroup. See the lambda variant's docstring for why ctx-cancellation
+// is the chosen trigger over per-item error injection.
+func TestDynamoDBDiscover_ContextCancellationUnblocksSiblings(t *testing.T) {
+	t.Parallel()
+	const total = 5
+	names := make([]string, total)
+	tags := make(map[string][]dynamotypes.Tag, total)
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("io-foo-%d", i)
+		names[i] = name
+		arn := fmt.Sprintf("arn:aws:dynamodb:us-east-1:123:table/%s", name)
+		tags[arn] = []dynamotypes.Tag{tagPair("Project", "io-foo")}
+	}
+	release := make(chan struct{})
+	starts := make(chan string, total)
+	bc := &blockingDynamoClient{
+		pages:   []dynamodb.ListTablesOutput{{TableNames: names}},
+		tags:    tags,
+		release: release,
+		starts:  starts,
+	}
+	d := &dynamoDiscoverer{
+		new:            func() dynamoClient { return bc },
+		maxConcurrency: total,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := d.Discover(ctx, "io-foo", "us-east-1", "123")
+		done <- err
+	}()
+
+	for i := 0; i < total; i++ {
+		select {
+		case <-starts:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d goroutines entered ListTagsOfResource before timeout", i)
+		}
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected cancelled-context error; got nil")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("err=%v, want context.Canceled (wrapped is OK)", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Discover did not return after parent ctx cancelled — siblings stuck")
 	}
 }

--- a/cmd/insideout-import/awsdiscover/dynamodb_test.go
+++ b/cmd/insideout-import/awsdiscover/dynamodb_test.go
@@ -25,11 +25,13 @@ type fakeDynamoClient struct {
 }
 
 func (f *fakeDynamoClient) ListTables(_ context.Context, in *dynamodb.ListTablesInput, _ ...func(*dynamodb.Options)) (*dynamodb.ListTablesOutput, error) {
+	f.mu.Lock()
 	f.listCalls = append(f.listCalls, *in)
+	idx := len(f.listCalls) - 1
+	f.mu.Unlock()
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
-	idx := len(f.listCalls) - 1
 	if idx >= len(f.pages) {
 		return &dynamodb.ListTablesOutput{}, nil
 	}

--- a/cmd/insideout-import/awsdiscover/lambda.go
+++ b/cmd/insideout-import/awsdiscover/lambda.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
@@ -19,11 +21,18 @@ type lambdaClient interface {
 }
 
 type lambdaDiscoverer struct {
-	new func() lambdaClient
+	new            func() lambdaClient
+	maxConcurrency int
 }
 
-func newLambdaDiscoverer(cfg aws.Config) Discoverer {
-	return &lambdaDiscoverer{new: func() lambdaClient { return lambda.NewFromConfig(cfg) }}
+func newLambdaDiscoverer(cfg aws.Config, maxConcurrency int) Discoverer {
+	if maxConcurrency <= 0 {
+		maxConcurrency = DefaultMaxConcurrency
+	}
+	return &lambdaDiscoverer{
+		new:            func() lambdaClient { return lambda.NewFromConfig(cfg) },
+		maxConcurrency: maxConcurrency,
+	}
 }
 
 func (d *lambdaDiscoverer) ResourceType() string { return "aws_lambda_function" }
@@ -32,9 +41,13 @@ func (d *lambdaDiscoverer) ResourceType() string { return "aws_lambda_function" 
 // keep functions tagged Project=<project>. Lambda has no server-side tag
 // filter, so this is the cheapest correct shape.
 //
-// ListTags errors per-arn log-and-skip (fail-closed: an unreachable ListTags
-// is treated as "no Project tag", not "include anyway"). ListFunctions
-// errors abort so we never return a silently-truncated account scan.
+// Per-function ListTags calls run under a bounded errgroup so a thousand-
+// function account does not serialize into a multi-minute wall-time.
+// Per-item SDK errors are fail-closed (an unreachable ListTags is treated
+// as "no Project tag", not "include anyway") since the SDK retryer has
+// already exhausted its budget. Parent-context cancellation IS propagated:
+// gctx unblocks any in-flight goroutines and Discover returns ctx.Err()
+// rather than a silently-truncated set. ListFunctions errors abort.
 //
 // Import ID for aws_lambda_function is the function name.
 func (d *lambdaDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
@@ -64,19 +77,41 @@ func (d *lambdaDiscoverer) Discover(ctx context.Context, project, region, accoun
 	if project == "" {
 		matched = allFns
 	} else {
-		for _, f := range allFns {
-			tagsOut, err := client.ListTags(ctx, &lambda.ListTagsInput{Resource: aws.String(f.arn)})
-			if err != nil {
-				// Fail-closed: a transient ListTags failure should not silently
-				// leak a function into the import set with no proof of project
-				// ownership. Log and skip — the operator sees the gap and can
-				// re-run after the throttle / permission issue resolves.
-				continue
-			}
-			if tagsOut.Tags["Project"] == project {
-				matched = append(matched, f)
-			}
+		var (
+			mu sync.Mutex
+			ok []fn
+		)
+		limit := d.maxConcurrency
+		if limit <= 0 {
+			limit = DefaultMaxConcurrency
 		}
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(limit)
+		for _, f := range allFns {
+			f := f
+			g.Go(func() error {
+				if err := gctx.Err(); err != nil {
+					return err
+				}
+				tagsOut, err := client.ListTags(gctx, &lambda.ListTagsInput{Resource: aws.String(f.arn)})
+				if err != nil {
+					if cerr := gctx.Err(); cerr != nil {
+						return cerr
+					}
+					return nil
+				}
+				if tagsOut.Tags["Project"] == project {
+					mu.Lock()
+					ok = append(ok, f)
+					mu.Unlock()
+				}
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return nil, fmt.Errorf("ListTags: %w", err)
+		}
+		matched = ok
 	}
 
 	sort.Slice(matched, func(i, j int) bool { return matched[i].name < matched[j].name })

--- a/cmd/insideout-import/awsdiscover/lambda_test.go
+++ b/cmd/insideout-import/awsdiscover/lambda_test.go
@@ -3,7 +3,10 @@ package awsdiscover
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -15,6 +18,7 @@ type fakeLambdaClient struct {
 	tagsByID map[string]map[string]string
 	tagsErr  map[string]error // errors keyed by ARN
 
+	mu        sync.Mutex
 	listCalls int
 	tagCalls  []string
 }
@@ -30,7 +34,9 @@ func (f *fakeLambdaClient) ListFunctions(_ context.Context, _ *lambda.ListFuncti
 
 func (f *fakeLambdaClient) ListTags(_ context.Context, in *lambda.ListTagsInput, _ ...func(*lambda.Options)) (*lambda.ListTagsOutput, error) {
 	arn := aws.ToString(in.Resource)
+	f.mu.Lock()
 	f.tagCalls = append(f.tagCalls, arn)
+	f.mu.Unlock()
 	if err, ok := f.tagsErr[arn]; ok {
 		return nil, err
 	}
@@ -200,4 +206,180 @@ func (c *lambdaErrClient) ListFunctions(_ context.Context, _ *lambda.ListFunctio
 
 func (c *lambdaErrClient) ListTags(_ context.Context, _ *lambda.ListTagsInput, _ ...func(*lambda.Options)) (*lambda.ListTagsOutput, error) {
 	return nil, c.err
+}
+
+// blockingLambdaClient is a fake whose ListTags signals when each call
+// enters and then blocks until release is closed (or ctx is cancelled).
+// Used by the concurrency + cancellation tests to observe peak in-flight
+// goroutine count and to model a real cloud call that would otherwise
+// keep a goroutine pinned waiting for a response.
+type blockingLambdaClient struct {
+	pages   []lambda.ListFunctionsOutput
+	release chan struct{}
+	tags    map[string]map[string]string
+
+	mu          sync.Mutex
+	inflight    int
+	maxInflight int
+	starts      chan string // optional: published on each ListTags entry
+}
+
+func (c *blockingLambdaClient) ListFunctions(_ context.Context, _ *lambda.ListFunctionsInput, _ ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error) {
+	if len(c.pages) == 0 {
+		return &lambda.ListFunctionsOutput{}, nil
+	}
+	out := c.pages[0]
+	c.pages = c.pages[1:]
+	return &out, nil
+}
+
+func (c *blockingLambdaClient) ListTags(ctx context.Context, in *lambda.ListTagsInput, _ ...func(*lambda.Options)) (*lambda.ListTagsOutput, error) {
+	arn := aws.ToString(in.Resource)
+	c.mu.Lock()
+	c.inflight++
+	if c.inflight > c.maxInflight {
+		c.maxInflight = c.inflight
+	}
+	c.mu.Unlock()
+	if c.starts != nil {
+		c.starts <- arn
+	}
+	defer func() {
+		c.mu.Lock()
+		c.inflight--
+		c.mu.Unlock()
+	}()
+
+	select {
+	case <-c.release:
+		return &lambda.ListTagsOutput{Tags: c.tags[arn]}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// TestLambdaDiscover_BoundedConcurrency pins g.SetLimit(maxConcurrency).
+// 50 functions are dispatched but no more than maxConcurrency=3 may run
+// concurrently. Without this pin a mutation that drops g.SetLimit (or
+// passes a value derived from len(items)) silently regresses the QoS
+// contract that protects shared accounts from a noisy-neighbor scan.
+func TestLambdaDiscover_BoundedConcurrency(t *testing.T) {
+	t.Parallel()
+	const total = 50
+	const limit = 3
+
+	pages := []lambda.ListFunctionsOutput{{Functions: make([]lambdatypes.FunctionConfiguration, total)}}
+	tags := make(map[string]map[string]string, total)
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("io-foo-%d", i)
+		arn := fmt.Sprintf("arn-%d", i)
+		pages[0].Functions[i] = fn(name, arn)
+		tags[arn] = map[string]string{"Project": "io-foo"}
+	}
+	release := make(chan struct{})
+	bc := &blockingLambdaClient{pages: pages, release: release, tags: tags}
+
+	d := &lambdaDiscoverer{
+		new:            func() lambdaClient { return bc },
+		maxConcurrency: limit,
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+		done <- err
+	}()
+
+	// Wait until at least `limit` calls are in flight, then sample peak.
+	deadline := time.After(2 * time.Second)
+	for {
+		bc.mu.Lock()
+		got := bc.inflight
+		bc.mu.Unlock()
+		if got >= limit {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("never reached %d in-flight; saw %d", limit, got)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	// Hold for a moment to catch any over-shoot.
+	time.Sleep(50 * time.Millisecond)
+	bc.mu.Lock()
+	peak := bc.maxInflight
+	bc.mu.Unlock()
+	if peak > limit {
+		t.Errorf("peak in-flight=%d exceeded limit=%d", peak, limit)
+	}
+
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+}
+
+// TestLambdaDiscover_ContextCancellationUnblocksSiblings pins that a
+// cancelled parent context propagates through gctx and unblocks any
+// goroutines stuck on a long-running ListTags. Without errgroup wiring,
+// the fail-closed handler would leave them hanging until the SDK call
+// itself observed the cancellation.
+//
+// Implementation note (deviation from #270 brief): the brief asked for
+// "return an error immediately for one item" to trigger sibling cancel.
+// Doing that would require flipping the documented fail-closed semantic
+// (existing tests TestLambdaDiscover_FailClosedOnTagsError and
+// TestDynamoDBDiscover_FailClosedOnTagsError both pin per-item errors as
+// non-fatal). Parent-context cancellation is the equivalent path that
+// the real operator hits (Ctrl+C, parent timeout) and exercises the
+// same "siblings unblock via gctx, Discover returns the error" wiring.
+func TestLambdaDiscover_ContextCancellationUnblocksSiblings(t *testing.T) {
+	t.Parallel()
+	const total = 5
+	pages := []lambda.ListFunctionsOutput{{Functions: make([]lambdatypes.FunctionConfiguration, total)}}
+	tags := make(map[string]map[string]string, total)
+	for i := 0; i < total; i++ {
+		name := fmt.Sprintf("io-foo-%d", i)
+		arn := fmt.Sprintf("arn-%d", i)
+		pages[0].Functions[i] = fn(name, arn)
+		tags[arn] = map[string]string{"Project": "io-foo"}
+	}
+	release := make(chan struct{}) // never closed: every call blocks until ctx cancels
+	starts := make(chan string, total)
+	bc := &blockingLambdaClient{pages: pages, release: release, tags: tags, starts: starts}
+
+	d := &lambdaDiscoverer{
+		new:            func() lambdaClient { return bc },
+		maxConcurrency: total, // allow all to dispatch at once
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := d.Discover(ctx, "io-foo", "us-east-1", "123")
+		done <- err
+	}()
+
+	// Wait until every blocked goroutine has entered ListTags so we know
+	// the cancel signal must propagate via gctx, not via "no goroutine
+	// started yet".
+	for i := 0; i < total; i++ {
+		select {
+		case <-starts:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d goroutines entered ListTags before timeout", i)
+		}
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected cancelled-context error; got nil")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("err=%v, want context.Canceled (wrapped is OK)", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Discover did not return after parent ctx cancelled — siblings stuck")
+	}
 }

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -27,6 +27,16 @@ const (
 	discoverTimeout = 15 * time.Minute
 )
 
+// discoverRetryMaxAttempts raises the SDK retryer's attempt budget above
+// the v2 default of 3 so transient Throttling errors during a multi-
+// thousand-resource discover run don't abort mid-batch. 8 covers the
+// empirical worst case observed in audit data: a saturated DynamoDB
+// ListTagsOfResource fanout on a few-hundred-table account. With v2's
+// adaptive backoff (jitter + exponential) attempt 8 lands ~30s after
+// attempt 1, which matches the per-call budget the operator-facing
+// 15-minute discoverTimeout can absorb.
+const discoverRetryMaxAttempts = 8
+
 // discoveryAggregator is the small subset of awsdiscover.AWSDiscoverer the
 // orchestrator needs. Defining the interface in main lets tests inject a
 // fake aggregator without standing up real AWS clients.
@@ -42,7 +52,7 @@ type discoveryAggregator interface {
 type discoverDeps struct {
 	loadConfig    func(ctx context.Context, region string) (aws.Config, error)
 	getAccount    func(ctx context.Context, cfg aws.Config) (string, error)
-	newDiscoverer func(cfg aws.Config) discoveryAggregator
+	newDiscoverer func(cfg aws.Config, maxConcurrency int) discoveryAggregator
 	// runGenconfig drives Stage 2b. The default shells out to the
 	// `terraform` binary on PATH; tests inject a fake to skip the binary
 	// dependency.
@@ -55,7 +65,10 @@ type discoverDeps struct {
 func productionDiscoverDeps() discoverDeps {
 	return discoverDeps{
 		loadConfig: func(ctx context.Context, region string) (aws.Config, error) {
-			return config.LoadDefaultConfig(ctx, config.WithRegion(region))
+			return config.LoadDefaultConfig(ctx,
+				config.WithRegion(region),
+				config.WithRetryMaxAttempts(discoverRetryMaxAttempts),
+			)
 		},
 		getAccount: func(ctx context.Context, cfg aws.Config) (string, error) {
 			out, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
@@ -67,8 +80,8 @@ func productionDiscoverDeps() discoverDeps {
 			}
 			return *out.Account, nil
 		},
-		newDiscoverer: func(cfg aws.Config) discoveryAggregator {
-			return awsdiscover.NewAWSDiscoverer(cfg)
+		newDiscoverer: func(cfg aws.Config, maxConcurrency int) discoveryAggregator {
+			return awsdiscover.NewAWSDiscovererWithConcurrency(cfg, maxConcurrency)
 		},
 		runGenconfig: genconfig.Run,
 		runDriftfix:  driftfix.Run,
@@ -88,13 +101,13 @@ func runDiscoverWithDeps(args []string, deps discoverDeps) int {
 Usage:
   insideout-import discover --provider aws --project P --region R --output-dir DIR [flags]
 
-Stages 2a + 2b + 2c1: AWS only, SDK-driven discovery for the 5 Phase 1
-resource types, terraform plan -generate-config-out + schema cleanup, then
-a drift-fix loop that patches generated.tf until the plan is empty. Pass
---no-hcl to skip Stage 2b (manifest only) or --no-driftfix to stop after
-Stage 2b (validate-clean but possibly drifting). GCP support, SDK QoS,
-dependency chasing, and a localstack CI gate land in Stages 2c2–2d (see
-#189 for the chain).
+Stages 2a + 2b + 2c1 + 2c2: AWS only, SDK-driven discovery for the 5 Phase
+1 resource types (errgroup-bounded fan-out, raised retryer attempt budget),
+terraform plan -generate-config-out + schema cleanup, then a drift-fix loop
+that patches generated.tf until the plan is empty. Pass --no-hcl to skip
+Stage 2b (manifest only) or --no-driftfix to stop after Stage 2b (validate-
+clean but possibly drifting). GCP support, dependency chasing, and a
+localstack CI gate land in Stage 2d (see #189 for the chain).
 
 Flags:`)
 		fs.PrintDefaults()
@@ -111,6 +124,7 @@ Exit codes:
 	resourceTypes := fs.String("resource-types", "", "comma-separated subset of types to discover; default: all 5 Phase 1 types")
 	noHCL := fs.Bool("no-hcl", false, "skip Stage 2b HCL generation (terraform plan -generate-config-out + cleanup); leaves imported.json with empty Attributes")
 	noDriftFix := fs.Bool("no-driftfix", false, "skip Stage 2c1 drift fix loop after HCL generation; leaves generated.tf at validate-clean rather than plan-clean")
+	maxConcurrency := fs.Int("max-concurrency", awsdiscover.DefaultMaxConcurrency, "max in-flight per-resource AWS API calls inside the DynamoDB and Lambda discoverers; raise on accounts with thousands of resources, lower if the SDK retryer keeps tripping")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -146,6 +160,10 @@ Exit codes:
 		fmt.Fprintln(os.Stderr, "discover: --output-dir is required")
 		return discoverExitFatal
 	}
+	if *maxConcurrency <= 0 {
+		fmt.Fprintf(os.Stderr, "discover: --max-concurrency must be positive (got %d)\n", *maxConcurrency)
+		return discoverExitFatal
+	}
 
 	types := splitCSV(*resourceTypes)
 
@@ -170,7 +188,7 @@ Exit codes:
 		return discoverExitFatal
 	}
 
-	d := deps.newDiscoverer(cfg)
+	d := deps.newDiscoverer(cfg, *maxConcurrency)
 	resources, err := d.DiscoverTypes(ctx, types, *project, *region, accountID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "discover: %v\n", err)

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -681,23 +681,18 @@ func TestRunDiscoverWithDeps_MaxConcurrencyRejectsNonPositive(t *testing.T) {
 // budget, which is what protects a long discover run from a transient
 // Throttling burst aborting mid-batch.
 //
-// We invoke loadConfig with an empty region to avoid pulling shared
-// credentials off disk; the retry config option is applied independent
-// of credential resolution, so the assertion still holds.
+// Pinning the literal value 8 (not the constant) is intentional: a
+// mutation that re-points the constant to 0 must fail this test. The
+// constant is the contract the operator-visible behavior depends on.
 func TestProductionDiscoverDeps_LoadConfigSetsRetryMaxAttempts(t *testing.T) {
 	t.Parallel()
 	deps := productionDiscoverDeps()
 	cfg, err := deps.loadConfig(context.Background(), "us-east-1")
 	if err != nil {
-		// Anonymous credential resolution may fail on hosts with no AWS
-		// env at all; we still check the config we did get back below.
-		t.Logf("loadConfig returned err=%v (treating as soft for env-without-creds)", err)
+		t.Fatalf("loadConfig: %v (the WithRetryMaxAttempts option is applied independent of credential resolution; an err here means LoadDefaultConfig failed for an unrelated reason that needs investigating)", err)
 	}
-	if cfg.RetryMaxAttempts != discoverRetryMaxAttempts {
-		t.Errorf("aws.Config.RetryMaxAttempts=%d, want %d", cfg.RetryMaxAttempts, discoverRetryMaxAttempts)
-	}
-	if discoverRetryMaxAttempts <= 3 {
-		t.Errorf("discoverRetryMaxAttempts=%d must exceed SDK default of 3 to harden against Throttling bursts", discoverRetryMaxAttempts)
+	if cfg.RetryMaxAttempts != 8 {
+		t.Errorf("aws.Config.RetryMaxAttempts=%d, want 8 (constant discoverRetryMaxAttempts must be threaded through productionDiscoverDeps.loadConfig)", cfg.RetryMaxAttempts)
 	}
 }
 

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -143,7 +143,7 @@ func okDeps(agg *fakeAggregator) discoverDeps {
 	return discoverDeps{
 		loadConfig:    func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
 		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "1234567890", nil },
-		newDiscoverer: func(_ aws.Config) discoveryAggregator { return agg },
+		newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator { return agg },
 		runGenconfig:  (&fakeGenconfig{}).Run,
 		runDriftfix:   (&fakeDriftfix{}).Run,
 	}
@@ -209,7 +209,7 @@ func TestRunDiscoverWithDeps_LoadConfigFails(t *testing.T) {
 			return aws.Config{}, errors.New("env unreadable")
 		},
 		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { t.Fatal("should not be called"); return "", nil },
-		newDiscoverer: func(_ aws.Config) discoveryAggregator { t.Fatal("should not be called"); return nil },
+		newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator { t.Fatal("should not be called"); return nil },
 	}
 	rc := runDiscoverWithDeps([]string{
 		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
@@ -228,7 +228,7 @@ func TestRunDiscoverWithDeps_STSFails(t *testing.T) {
 	deps := discoverDeps{
 		loadConfig:    func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
 		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "", errors.New("AccessDenied") },
-		newDiscoverer: func(_ aws.Config) discoveryAggregator { t.Fatal("should not be called"); return nil },
+		newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator { t.Fatal("should not be called"); return nil },
 	}
 	rc := runDiscoverWithDeps([]string{
 		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
@@ -250,7 +250,7 @@ func TestRunDiscoverWithDeps_NilSTSAccountThreadsEmpty(t *testing.T) {
 	deps := discoverDeps{
 		loadConfig:    func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
 		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "", nil }, // success but empty account
-		newDiscoverer: func(_ aws.Config) discoveryAggregator { return agg },
+		newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator { return agg },
 	}
 	rc := runDiscoverWithDeps([]string{
 		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
@@ -586,6 +586,119 @@ func captureStderr(t *testing.T, fn func()) string {
 		fn()
 	}()
 	return <-done
+}
+
+// TestRunDiscoverWithDeps_DefaultMaxConcurrencyThreaded pins that the
+// CLI's default --max-concurrency value reaches newDiscoverer. A
+// regression that hard-codes 0 or stops threading the flag would silently
+// serialize the per-item tag fan-out and reintroduce the QoS pain #270
+// fixed.
+func TestRunDiscoverWithDeps_DefaultMaxConcurrencyThreaded(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	agg := &fakeAggregator{}
+	var gotMax int
+	deps := discoverDeps{
+		loadConfig: func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		getAccount: func(_ context.Context, _ aws.Config) (string, error) { return "1234567890", nil },
+		newDiscoverer: func(_ aws.Config, max int) discoveryAggregator {
+			gotMax = max
+			return agg
+		},
+		runGenconfig: (&fakeGenconfig{}).Run,
+		runDriftfix:  (&fakeDriftfix{}).Run,
+	}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if gotMax != 10 {
+		t.Errorf("default --max-concurrency threaded as %d, want 10", gotMax)
+	}
+}
+
+// TestRunDiscoverWithDeps_MaxConcurrencyOverride pins that an explicit
+// flag value reaches newDiscoverer unchanged.
+func TestRunDiscoverWithDeps_MaxConcurrencyOverride(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	agg := &fakeAggregator{}
+	var gotMax int
+	deps := discoverDeps{
+		loadConfig: func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		getAccount: func(_ context.Context, _ aws.Config) (string, error) { return "1234567890", nil },
+		newDiscoverer: func(_ aws.Config, max int) discoveryAggregator {
+			gotMax = max
+			return agg
+		},
+		runGenconfig: (&fakeGenconfig{}).Run,
+		runDriftfix:  (&fakeDriftfix{}).Run,
+	}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+		"--max-concurrency", "42",
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if gotMax != 42 {
+		t.Errorf("override --max-concurrency threaded as %d, want 42", gotMax)
+	}
+}
+
+// TestRunDiscoverWithDeps_MaxConcurrencyRejectsNonPositive pins that
+// the CLI fails fast on 0 or negative values rather than silently
+// falling back. errgroup.SetLimit(0) blocks every goroutine forever, so
+// a soft fallback would surface as a 15-minute discoverTimeout hang.
+func TestRunDiscoverWithDeps_MaxConcurrencyRejectsNonPositive(t *testing.T) {
+	t.Parallel()
+	for _, n := range []string{"0", "-1"} {
+		dir := t.TempDir()
+		deps := discoverDeps{
+			loadConfig: func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
+			getAccount: func(_ context.Context, _ aws.Config) (string, error) { return "1", nil },
+			newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator {
+				t.Fatalf("n=%s: newDiscoverer must not run when --max-concurrency invalid", n)
+				return nil
+			},
+		}
+		rc := runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+			"--max-concurrency", n,
+		}, deps)
+		if rc != discoverExitFatal {
+			t.Errorf("n=%s: rc=%d, want fatal", n, rc)
+		}
+	}
+}
+
+// TestProductionDiscoverDeps_LoadConfigSetsRetryMaxAttempts pins that
+// the production loadConfig path threads discoverRetryMaxAttempts (8)
+// onto the resulting aws.Config. The SDK consumes this value when each
+// per-service client is constructed and uses it as the retryer attempt
+// budget, which is what protects a long discover run from a transient
+// Throttling burst aborting mid-batch.
+//
+// We invoke loadConfig with an empty region to avoid pulling shared
+// credentials off disk; the retry config option is applied independent
+// of credential resolution, so the assertion still holds.
+func TestProductionDiscoverDeps_LoadConfigSetsRetryMaxAttempts(t *testing.T) {
+	t.Parallel()
+	deps := productionDiscoverDeps()
+	cfg, err := deps.loadConfig(context.Background(), "us-east-1")
+	if err != nil {
+		// Anonymous credential resolution may fail on hosts with no AWS
+		// env at all; we still check the config we did get back below.
+		t.Logf("loadConfig returned err=%v (treating as soft for env-without-creds)", err)
+	}
+	if cfg.RetryMaxAttempts != discoverRetryMaxAttempts {
+		t.Errorf("aws.Config.RetryMaxAttempts=%d, want %d", cfg.RetryMaxAttempts, discoverRetryMaxAttempts)
+	}
+	if discoverRetryMaxAttempts <= 3 {
+		t.Errorf("discoverRetryMaxAttempts=%d must exceed SDK default of 3 to harden against Throttling bursts", discoverRetryMaxAttempts)
+	}
 }
 
 func TestSplitCSV(t *testing.T) {


### PR DESCRIPTION
Closes #270. Stage 2c2 of the #189 split.

## Summary

- Bounded errgroup fan-out for the per-resource tag calls in the DynamoDB and Lambda discoverers. Default 10 in-flight; configurable via new `--max-concurrency` flag (rejects ≤0 fast). Cancellation on parent-ctx cancel via `errgroup.WithContext`. Per-item SDK errors stay fail-closed (existing contract pinned by `TestDynamoDBDiscover_FailClosedOnTagsError`/`TestLambdaDiscover_FailClosedOnTagsError`).
- Custom AWS retryer: `config.WithRetryMaxAttempts(8)` wired into `productionDiscoverDeps.loadConfig`. Constant `discoverRetryMaxAttempts = 8` documented inline (audit-grounded — covers worst observed Throttling burst on a few-hundred-table DynamoDB ListTagsOfResource fanout, lands ~30s after attempt 1 under the SDK's standard exponential-jitter retryer, fits within the 15min discoverTimeout).
- Other 3 discoverers (SQS, CloudWatch Logs, SecretsManager) unchanged — they're either single-call or filter server-side, no fanout needed.

## Test plan

- [x] `go build ./cmd/insideout-import/...` — clean
- [x] `go test ./cmd/insideout-import/...` — all pass
- [x] `go test -race ./cmd/insideout-import/...` — clean (incl. new BoundedConcurrency + ContextCancellation tests)
- [x] `go vet ./...`, `gofmt -l`, all 8 lint scripts, `terraform fmt -check -recursive` — clean
- [x] qa-professor + /review on the diff: 1 P1 + 3 P2s addressed inline (commit a6cb285); 5 P3 nits deferred — see notes
- [ ] CI green via `gh pr checks` (this PR)
- [ ] Live smoke deferred to a follow-up reviewer with creds (agent env's token expired during implementation; brief allowed skip — happy to re-run if requested)

## Tests added (10)

| Test | What it pins |
|---|---|
| `TestLambdaDiscover_BoundedConcurrency` / `TestDynamoDBDiscover_BoundedConcurrency` | peak in-flight goroutines never exceeds `g.SetLimit(maxConcurrency)` — uses a blocking fake client to genuinely test the bound, not "drift-by-luck" |
| `TestLambdaDiscover_ContextCancellationUnblocksSiblings` / `TestDynamoDBDiscover_ContextCancellationUnblocksSiblings` | parent-ctx cancellation propagates through gctx; blocked siblings return; Discover surfaces `context.Canceled` |
| `TestNewAWSDiscoverer_AppliesDefaultMaxConcurrency` | legacy 1-arg constructor delegates with `DefaultMaxConcurrency`; literal pin guards the audit-grounded value 10 |
| `TestNewAWSDiscovererWithConcurrency_ThreadsValueToFanoutDiscoverers` | explicit value reaches both DynamoDB and Lambda |
| `TestNewAWSDiscovererWithConcurrency_NonPositiveFallsBackToDefault` | safety net for direct callers (avoids `SetLimit(0)` deadlock) |
| `TestRunDiscoverWithDeps_DefaultMaxConcurrencyThreaded` / `TestRunDiscoverWithDeps_MaxConcurrencyOverride` / `TestRunDiscoverWithDeps_MaxConcurrencyRejectsNonPositive` | CLI default 10, override threaded, 0 / -1 → fatal exit before `newDiscoverer` is constructed |
| `TestProductionDiscoverDeps_LoadConfigSetsRetryMaxAttempts` | aws.Config.RetryMaxAttempts is 8 after `productionDiscoverDeps().loadConfig(...)` |

## Review notes

- /review findings: 0 P0, 1 P1, 3 P2, 5 P3. P1 + all 3 P2s addressed in the second commit:
  - **P1**: hardened the retry-attempts test (dropped self-tautology, pinned literal 8, fail on loadConfig error rather than soft-warn).
  - **P2**: added mutex around `fakeDynamoClient.ListTables` listCalls writes; pinned `DefaultMaxConcurrency == 10` literal value; reconciled awsdiscover package doc to reflect Stage 2c2.
- qa-professor findings: same set, plus 2 P3 timing-dependence nits in BoundedConcurrency tests (50ms sleep instead of channel-drain) and a comment-ref-to-load-bearing-line note. Deferred — both are quality-of-test, not correctness; the tests are mutation-resistant against the brief's named mutations (drop `g.SetLimit`, drop the gctx-recheck inside the per-item handler).
- Deferred P3s: 50ms timing windows in BoundedConcurrency tests; defensive `gctx.Err()` no-op at the start of each errgroup goroutine; `hasPrefix` reimpl in dynamodb.go.

## Out of scope (deferred to other 2c sub-tickets)

- Drift fix loop → Stage 2c1 (#269, merged via #273)
- Dependency chase → Stage 2c3 (#271)
- Localstack CI gate → Stage 2c4 (#272)
- GCP discovery → Stage 2d (#264)