### PR TITLE
feat(insideout-import): add dependency chase loop (Stage 2c3, #271)

### DIFF
--- a/cmd/insideout-import/README.md
+++ b/cmd/insideout-import/README.md
@@ -7,7 +7,7 @@ CLI for bringing existing cloud resources under InsideOut management.
 | Subcommand | Status | Purpose |
 |---|---|---|
 | `adopt` | implemented | Emit `import {}` blocks against an *already-known* preset stack. |
-| `discover` | Stage 2c1 (AWS, manifest + HCL + drift fix) | Discover existing cloud resources, emit `imported.json`, generate validated HCL bodies, and loop `terraform plan` patches until the stack is plan-clean. Stage 2c2/2c3/2c4 add SDK QoS, dependency chase, and a localstack CI gate; Stage 2d adds GCP. See #189 for the chain. |
+| `discover` | Stage 2c3 (AWS, manifest + HCL + drift fix + dep chase) | Discover existing cloud resources, emit `imported.json`, generate validated HCL bodies, loop `terraform plan` patches until plan-clean, then walk the cleaned generated.tf for ARN literals pointing at resources outside the import set and pull them in until the references converge. Stage 2c4 adds the localstack zero-drift CI gate; Stage 2d adds GCP. See #189 for the chain. |
 
 ## `adopt`
 
@@ -72,7 +72,7 @@ These are intentionally out of scope for Stage 1; see #259 for context:
 - **No provenance tag/label injection on the imported resources.** The composer can apply provenance when it composes the stack; `adopt` will not silently mutate user-authored HCL.
 - **No `imported.json` manifest.** That manifest is meaningful only when discovery populates `Identity` and `Tier` from cloud state.
 
-## `discover` (Stage 2a + 2b)
+## `discover` (Stages 2a + 2b + 2c1 + 2c3)
 
 ```
 insideout-import discover \
@@ -81,18 +81,21 @@ insideout-import discover \
   --region us-east-1 \
   --output-dir ./imported \
   [--resource-types aws_sqs_queue,aws_lambda_function,...] \
-  [--no-hcl]
+  [--no-hcl] [--no-driftfix] [--no-depchase] \
+  [--max-depchase-iterations N]
 ```
 
 ### Inputs
 
-- `--provider` (required) — only `aws` is supported in Stages 2a/2b; `gcp` returns a "not yet implemented" error pointing at #264 (Stage 2d).
+- `--provider` (required) — only `aws` is supported in Stages 2a–2c3; `gcp` returns a "not yet implemented" error pointing at #264 (Stage 2d).
 - `--project` (required) — project name used as the prefix / `Project` tag value to filter discovered resources.
 - `--region` (required for AWS) — AWS region to scan.
 - `--output-dir` (required) — directory to write `imported.json` into.
-- `--resource-types` — comma-separated subset of supported types. Default: all 5 Phase 1 types (`aws_sqs_queue`, `aws_dynamodb_table`, `aws_cloudwatch_log_group`, `aws_secretsmanager_secret`, `aws_lambda_function`).
-- `--no-hcl` — skip Stage 2b's HCL generation (`terraform plan -generate-config-out` + cleanup). Use when no `terraform` binary is available or when only the manifest is needed.
-- `--no-driftfix` — skip Stage 2c1's drift-fix loop. The generated stack is left at validate-clean rather than plan-clean; useful when iterating on the import and you don't yet care about drift convergence.
+- `--resource-types` — comma-separated subset of supported types. Default: all 9 supported types (the 5 Phase 1 types plus the 4 dep-chase reference types added by Stage 2c3 — `aws_iam_role`, `aws_iam_policy`, `aws_kms_key`, `aws_s3_bucket`).
+- `--no-hcl` — skip Stage 2b's HCL generation (`terraform plan -generate-config-out` + cleanup). Use when no `terraform` binary is available or when only the manifest is needed. Implies `--no-driftfix` and `--no-depchase`.
+- `--no-driftfix` — skip Stage 2c1's drift-fix loop. The generated stack is left at validate-clean rather than plan-clean; useful when iterating on the import and you don't yet care about drift convergence. Implies `--no-depchase`.
+- `--no-depchase` — skip Stage 2c3's dependency chase. Useful when the operator wants to inspect external ARN references before pulling them in, or when the dep-chase loop is misbehaving. Leaves dangling references in `generated.tf` as drift.
+- `--max-depchase-iterations` — bound on the dep-chase loop (default 5). Raise if the import set has a long dependency chain; lower if cycles are suspected.
 
 ### Output
 
@@ -112,15 +115,21 @@ Records are sorted by `Identity.Address` so `imported.json` is byte-identical ac
 
 ### Per-type SDK calls
 
-| Terraform type | SDK call(s) | Filter | Import ID |
-|---|---|---|---|
-| `aws_sqs_queue` | `ListQueues(QueueNamePrefix)` | server-side prefix | queue URL |
-| `aws_dynamodb_table` | `ListTables` + `ListTagsOfResource(ARN)` | name prefix + Project tag | table name |
-| `aws_cloudwatch_log_group` | `DescribeLogGroups(LogGroupNamePrefix)` | server-side prefix | log group name |
-| `aws_secretsmanager_secret` | `ListSecrets(Filters: tag:Project=<p>)` | server-side tag filter | secret ARN |
-| `aws_lambda_function` | `ListFunctions` + `ListTags(ARN)` | Project tag | function name |
+| Terraform type | Discover SDK call(s) | DiscoverByID SDK call | Filter | Import ID |
+|---|---|---|---|---|
+| `aws_sqs_queue` | `ListQueues(QueueNamePrefix)` | `GetQueueUrl(QueueName)` | server-side prefix | queue URL |
+| `aws_dynamodb_table` | `ListTables` + `ListTagsOfResource(ARN)` | `DescribeTable(TableName)` | name prefix + Project tag | table name |
+| `aws_cloudwatch_log_group` | `DescribeLogGroups(LogGroupNamePrefix)` | `DescribeLogGroups(LogGroupNamePrefix=name, exact match)` | server-side prefix | log group name |
+| `aws_secretsmanager_secret` | `ListSecrets(Filters: tag:Project=<p>)` | `DescribeSecret(SecretId)` | server-side tag filter | secret ARN |
+| `aws_lambda_function` | `ListFunctions` + `ListTags(ARN)` | `GetFunction(FunctionName)` | Project tag | function name |
+| `aws_iam_role` (2c3) | `ListRoles` (paginated) | `GetRole(RoleName)` | name prefix | role name |
+| `aws_iam_policy` (2c3) | `ListPolicies(Scope=Local)` | `GetPolicy(PolicyArn)` | name prefix + scope=Local | policy ARN |
+| `aws_kms_key` (2c3) | `ListAliases` → `TargetKeyId` | `DescribeKey(KeyId)` | alias contains project, skip aws-managed | key UUID |
+| `aws_s3_bucket` (2c3) | `ListBuckets` (account-global) | `HeadBucket(Bucket)` | name prefix (client-side) | bucket name |
 
 DynamoDB and Lambda fail-closed on per-resource `ListTags` errors — a transient throttle skips the resource rather than letting an unverified entry into the manifest. `ListFunctions` / `ListTables` errors abort the whole run.
+
+`DiscoverByID` returns the typed `awsdiscover.ErrNotFound` for valid-but-missing resources and `awsdiscover.ErrNotSupported` for ID shapes the discoverer cannot parse (e.g. an SQS-shape ARN handed to the IAM-role discoverer). Stage 2c3 converts both into operator-facing warnings so the run completes with a documented unresolvable reference rather than a fatal abort.
 
 ### Exit codes
 
@@ -129,11 +138,10 @@ DynamoDB and Lambda fail-closed on per-resource `ListTags` errors — a transien
 | `0` | Manifest written; `composer.ValidateImportedResources` returned no issues. With Stage 2b on, `terraform validate` passed against the cleaned `generated.tf`. With Stage 2c1 on (default), `terraform plan -detailed-exitcode` exits 0 against the same stack. |
 | `1` | Fatal: AWS error, validator failure, terraform binary missing or failing, drift-fix replace/delete or stable-drift escalation, or bad inputs. No partial manifest is written when validation fails before the write step; with Stage 2b/2c1, intermediate artifacts (`imported.json`, `generated.tf`, the workdir's `.terraform` dir) survive on disk for inspection. |
 
-### What `discover` does *not* do (Stage 2c1)
+### What `discover` does *not* do (Stage 2c3)
 
-- **No dependency chasing.** Stage 2c3 (`#271`) finds ARNs that point at *un-imported* resources and walks the dependency graph; Stage 2c1 only patches drift within the current batch.
-- **No nested-block drift patching.** Top-level attribute drift is dropped; drift inside nested blocks (timeouts, lifecycle on a non-import-flow resource, etc.) is reported via the stable-drift escalation but not auto-resolved. Stage 2c3 / 2c4 cover those.
-- **No throttle/retry tuning or bounded concurrency.** Stage 2c2 (`#270`).
+- **No nested-block drift patching.** Top-level attribute drift is dropped; drift inside nested blocks (timeouts, lifecycle on a non-import-flow resource, etc.) is reported via the stable-drift escalation but not auto-resolved. Stage 2c4 covers those.
+- **No nested-block ARN reference detection in dep-chase.** The Stage 2c3 finder walks top-level attribute literals only. ARN-shaped values inside nested blocks (e.g. `environment { variables = { ... } }`) or interpolations are not surfaced. If a real-world stack puts dep-chase-relevant ARNs in nested attributes, the surface can be widened in a follow-up.
 - **No localstack CI gate proving zero drift end-to-end.** Stage 2c4 (`#272`).
 - **No GCP support.** Stage 2d (`#264`).
 

--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -18,6 +18,7 @@ package awsdiscover
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -25,6 +26,20 @@ import (
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
+
+// ErrNotSupported signals that a discoverer cannot resolve a given ID
+// (e.g. an ARN whose service portion does not match this discoverer's
+// resource type, or an ID shape this discoverer does not parse). Stage
+// 2c3's dep-chase loop converts ErrNotSupported into an operator-facing
+// warning rather than a fatal error.
+var ErrNotSupported = errors.New("discoverer does not support this ID")
+
+// ErrNotFound signals that the ID parsed correctly but the resource
+// does not exist in the operator's account / region (or returned a
+// no-such-entity error from the underlying SDK). Stage 2c3 surfaces
+// this as a warning too — the operator can decide whether to remove
+// the dangling reference or rerun once the resource is created.
+var ErrNotFound = errors.New("resource not found")
 
 // Discoverer is the per-resource-type contract. Each implementation handles
 // one Terraform type (e.g. "aws_sqs_queue") and returns []imported.ImportedResource
@@ -40,6 +55,15 @@ type Discoverer interface {
 	// per matched cloud resource. Implementations populate Identity and set
 	// Tier=TierImportedFlat, Source=SourceImporter on each entry.
 	Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error)
+	// DiscoverByID looks up a single resource by its native ID (an ARN or
+	// the natural key the discoverer's Discover method emits — queue URL,
+	// table name, log group name, etc.). Used by Stage 2c3's dep-chase
+	// loop when the generated.tf references a resource not in the
+	// original import set. Returns (zero, ErrNotSupported) for an ID
+	// shape this discoverer does not parse, (zero, ErrNotFound) for a
+	// well-formed ID whose underlying resource does not exist, or any
+	// other error for a real SDK failure.
+	DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error)
 }
 
 // DefaultMaxConcurrency is the per-discoverer fan-out limit applied when
@@ -65,13 +89,15 @@ func NewAWSDiscoverer(cfg aws.Config) *AWSDiscoverer {
 }
 
 // NewAWSDiscovererWithConcurrency wires up the production set of AWS
-// discoverers (the 5 Phase 1 types: SQS, DynamoDB, CloudWatch Logs, Secrets
-// Manager, Lambda). All discoverers share the same aws.Config; per-type SDK
-// clients are constructed inside each discoverer. maxConcurrency is the
-// upper bound on per-resource tag-fanout calls inside the DynamoDB and
-// Lambda discoverers (the only two with per-item API fan-out today). The
-// other three discoverers either filter server-side (SecretsManager) or
-// only issue a single List call (SQS, CloudWatchLogs) and ignore the limit.
+// discoverers — the 5 Phase 1 types (SQS, DynamoDB, CloudWatch Logs,
+// Secrets Manager, Lambda) plus the 4 dep-chase reference types added
+// in Stage 2c3 (#271): IAM role, IAM policy, KMS key, S3 bucket. All
+// discoverers share the same aws.Config; per-type SDK clients are
+// constructed inside each discoverer. maxConcurrency is the upper
+// bound on per-resource tag-fanout calls inside the DynamoDB and
+// Lambda discoverers (the only two with per-item API fan-out today).
+// The other discoverers either filter server-side (SecretsManager) or
+// only issue a single List/page call and ignore the limit.
 //
 // A non-positive maxConcurrency falls back to DefaultMaxConcurrency rather
 // than serializing — callers should validate flag input upstream and fail
@@ -88,6 +114,10 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 			"aws_cloudwatch_log_group":  newCloudWatchLogsDiscoverer(cfg),
 			"aws_secretsmanager_secret": newSecretsManagerDiscoverer(cfg),
 			"aws_lambda_function":       newLambdaDiscoverer(cfg, maxConcurrency),
+			"aws_iam_role":              newIAMRoleDiscoverer(cfg),
+			"aws_iam_policy":            newIAMPolicyDiscoverer(cfg),
+			"aws_kms_key":               newKMSDiscoverer(cfg),
+			"aws_s3_bucket":             newS3Discoverer(cfg),
 		},
 	}
 }
@@ -101,6 +131,20 @@ func (a *AWSDiscoverer) SupportedTypes() []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// DiscoverByID dispatches a per-ID lookup to the discoverer registered
+// for the given Terraform type. Used by Stage 2c3's dep-chase loop.
+// Returns ErrNotSupported if no discoverer is registered for the
+// requested type — dep-chase converts that into a warning so the
+// operator can decide whether to remove the dangling reference or add
+// a discoverer for the missing type.
+func (a *AWSDiscoverer) DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error) {
+	d, ok := a.byType[tfType]
+	if !ok {
+		return imported.ImportedResource{}, fmt.Errorf("no discoverer registered for %q: %w", tfType, ErrNotSupported)
+	}
+	return d.DiscoverByID(ctx, id, region, accountID)
 }
 
 // DiscoverTypes runs each named discoverer in series and concatenates the

--- a/cmd/insideout-import/awsdiscover/awsdiscover_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_test.go
@@ -17,6 +17,12 @@ type fakeDiscoverer struct {
 	gotProj string
 	gotReg  string
 	gotAcct string
+
+	// DiscoverByID wiring (unused by the existing tests, populated by
+	// new tests that exercise the dep-chase aggregator path).
+	byIDOut   imported.ImportedResource
+	byIDErr   error
+	byIDCalls []string
 }
 
 func (f *fakeDiscoverer) ResourceType() string { return f.t }
@@ -24,6 +30,11 @@ func (f *fakeDiscoverer) Discover(_ context.Context, project, region, accountID 
 	f.called++
 	f.gotProj, f.gotReg, f.gotAcct = project, region, accountID
 	return f.out, f.err
+}
+
+func (f *fakeDiscoverer) DiscoverByID(_ context.Context, id, _, _ string) (imported.ImportedResource, error) {
+	f.byIDCalls = append(f.byIDCalls, id)
+	return f.byIDOut, f.byIDErr
 }
 
 func ir(addr string) imported.ImportedResource {
@@ -116,16 +127,22 @@ func TestSupportedTypes_IsSorted(t *testing.T) {
 	}
 }
 
-func TestNewAWSDiscoverer_Registers5PhaseOneTypes(t *testing.T) {
+func TestNewAWSDiscoverer_RegistersAllSupportedTypes(t *testing.T) {
 	t.Parallel()
 	agg := NewAWSDiscoverer(awsDummyConfig())
 	got := agg.SupportedTypes()
 	want := map[string]bool{
+		// Phase 1 (#266).
 		"aws_sqs_queue":             false,
 		"aws_dynamodb_table":        false,
 		"aws_cloudwatch_log_group":  false,
 		"aws_secretsmanager_secret": false,
 		"aws_lambda_function":       false,
+		// Stage 2c3 dep-chase reference types (#271).
+		"aws_iam_role":   false,
+		"aws_iam_policy": false,
+		"aws_kms_key":    false,
+		"aws_s3_bucket":  false,
 	}
 	for _, typ := range got {
 		want[typ] = true
@@ -134,6 +151,27 @@ func TestNewAWSDiscoverer_Registers5PhaseOneTypes(t *testing.T) {
 		if !ok {
 			t.Errorf("expected %q to be registered", k)
 		}
+	}
+}
+
+// TestNewAWSDiscoverer_DiscoverByID_DispatchesAndPropagatesErrNotSupported
+// pins the aggregator's per-type dispatch contract: registered types
+// route to the matching discoverer; unregistered types return
+// ErrNotSupported so dep-chase can convert them to warnings.
+func TestNewAWSDiscoverer_DiscoverByID_DispatchesAndPropagatesErrNotSupported(t *testing.T) {
+	t.Parallel()
+	a := &fakeDiscoverer{t: "type_a"}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a}}
+
+	if _, err := agg.DiscoverByID(context.Background(), "type_a", "id-1", "us-east-1", "123"); err != nil {
+		t.Fatal(err)
+	}
+	if len(a.byIDCalls) != 1 || a.byIDCalls[0] != "id-1" {
+		t.Errorf("expected DiscoverByID to dispatch to type_a; calls=%v", a.byIDCalls)
+	}
+	_, err := agg.DiscoverByID(context.Background(), "type_unknown", "id-1", "us-east-1", "123")
+	if !errors.Is(err, ErrNotSupported) {
+		t.Errorf("err=%v, want ErrNotSupported for unregistered type", err)
 	}
 }
 

--- a/cmd/insideout-import/awsdiscover/cloudwatchlogs.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatchlogs.go
@@ -88,10 +88,15 @@ func (d *cwlDiscoverer) Discover(ctx context.Context, project, region, accountID
 
 // DiscoverByID resolves a CloudWatch Logs log group by ARN
 // (arn:aws:logs:<region>:<account>:log-group:<name>:*) or bare log
-// group name. Issues a single DescribeLogGroups call with an exact-name
-// prefix to verify existence; an empty result page is treated as
-// ErrNotFound (CWL returns a successful empty list rather than a typed
-// error for missing groups).
+// group name. Walks DescribeLogGroups via NextToken until either the
+// exact-name match is found or the prefix iterator is exhausted.
+//
+// Pagination is required because LogGroupNamePrefix returns *every*
+// group whose name starts with the probe; on accounts with many
+// prefix-collision siblings (e.g. `/aws/lambda/svc` and
+// `/aws/lambda/svc-extra`) the exact match can land on page 2+. An
+// empty/exhausted page set is treated as ErrNotFound (CWL returns a
+// successful empty list rather than a typed error for missing groups).
 func (d *cwlDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
 	name, err := cwlNameFromID(id)
 	if err != nil {
@@ -99,27 +104,31 @@ func (d *cwlDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID 
 	}
 
 	client := d.new()
-	out, err := client.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
-		LogGroupNamePrefix: aws.String(name),
-	})
-	if err != nil {
-		return imported.ImportedResource{}, fmt.Errorf("DescribeLogGroups: %w", err)
-	}
-	for _, lg := range out.LogGroups {
-		if aws.ToString(lg.LogGroupName) == name {
-			arn := aws.ToString(lg.Arn)
-			return makeImportedResource(
-				addressBook{},
-				"aws_cloudwatch_log_group",
-				name,
-				name,
-				region,
-				accountID,
-				map[string]string{"arn": arn},
-			), nil
+	input := &cloudwatchlogs.DescribeLogGroupsInput{LogGroupNamePrefix: aws.String(name)}
+	for {
+		out, err := client.DescribeLogGroups(ctx, input)
+		if err != nil {
+			return imported.ImportedResource{}, fmt.Errorf("DescribeLogGroups: %w", err)
 		}
+		for _, lg := range out.LogGroups {
+			if aws.ToString(lg.LogGroupName) == name {
+				arn := aws.ToString(lg.Arn)
+				return makeImportedResource(
+					addressBook{},
+					"aws_cloudwatch_log_group",
+					name,
+					name,
+					region,
+					accountID,
+					map[string]string{"arn": arn},
+				), nil
+			}
+		}
+		if out.NextToken == nil || *out.NextToken == "" {
+			return imported.ImportedResource{}, fmt.Errorf("aws_cloudwatch_log_group %q: %w", name, ErrNotFound)
+		}
+		input.NextToken = out.NextToken
 	}
-	return imported.ImportedResource{}, fmt.Errorf("aws_cloudwatch_log_group %q: %w", name, ErrNotFound)
 }
 
 // cwlNameFromID extracts the log group name from an ARN

--- a/cmd/insideout-import/awsdiscover/cloudwatchlogs.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatchlogs.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -82,4 +84,78 @@ func (d *cwlDiscoverer) Discover(ctx context.Context, project, region, accountID
 		))
 	}
 	return imps, nil
+}
+
+// DiscoverByID resolves a CloudWatch Logs log group by ARN
+// (arn:aws:logs:<region>:<account>:log-group:<name>:*) or bare log
+// group name. Issues a single DescribeLogGroups call with an exact-name
+// prefix to verify existence; an empty result page is treated as
+// ErrNotFound (CWL returns a successful empty list rather than a typed
+// error for missing groups).
+func (d *cwlDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	name, err := cwlNameFromID(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
+
+	client := d.new()
+	out, err := client.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String(name),
+	})
+	if err != nil {
+		return imported.ImportedResource{}, fmt.Errorf("DescribeLogGroups: %w", err)
+	}
+	for _, lg := range out.LogGroups {
+		if aws.ToString(lg.LogGroupName) == name {
+			arn := aws.ToString(lg.Arn)
+			return makeImportedResource(
+				addressBook{},
+				"aws_cloudwatch_log_group",
+				name,
+				name,
+				region,
+				accountID,
+				map[string]string{"arn": arn},
+			), nil
+		}
+	}
+	return imported.ImportedResource{}, fmt.Errorf("aws_cloudwatch_log_group %q: %w", name, ErrNotFound)
+}
+
+// cwlNameFromID extracts the log group name from an ARN
+// (arn:aws:logs:<region>:<account>:log-group:<name>[:*]) or bare name.
+// CWL ARNs use a colon as the separator after "log-group" rather than a
+// slash, and may carry a trailing ":*" wildcard. We normalize both.
+func cwlNameFromID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("cloudwatchlogs: empty id: %w", ErrNotSupported)
+	}
+	if awsarn.IsARN(id) {
+		parsed, err := awsarn.Parse(id)
+		if err != nil {
+			return "", fmt.Errorf("cloudwatchlogs: parse arn: %w", err)
+		}
+		if parsed.Service != "logs" {
+			return "", fmt.Errorf("cloudwatchlogs: not a logs arn (service=%q): %w", parsed.Service, ErrNotSupported)
+		}
+		// CWL log group ARN resource format: log-group:<name>[:*]
+		const prefix = "log-group:"
+		if !strings.HasPrefix(parsed.Resource, prefix) {
+			return "", fmt.Errorf("cloudwatchlogs: arn resource %q is not log-group:<name>: %w", parsed.Resource, ErrNotSupported)
+		}
+		rest := strings.TrimPrefix(parsed.Resource, prefix)
+		// Strip trailing ":*" wildcard if present.
+		rest = strings.TrimSuffix(rest, ":*")
+		if rest == "" {
+			return "", fmt.Errorf("cloudwatchlogs: empty name in arn %q: %w", id, ErrNotSupported)
+		}
+		return rest, nil
+	}
+	// Log group names commonly start with /aws/lambda/... so a leading slash
+	// is allowed; only colons / spaces signal a malformed input.
+	if strings.ContainsAny(id, ": ") {
+		return "", fmt.Errorf("cloudwatchlogs: unrecognized id %q: %w", id, ErrNotSupported)
+	}
+	return id, nil
 }

--- a/cmd/insideout-import/awsdiscover/cloudwatchlogs_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatchlogs_test.go
@@ -122,3 +122,100 @@ func TestCWLDiscover_PropagatesError(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestCWLDiscoverByID_AcceptsARN(t *testing.T) {
+	t.Parallel()
+	name := "/aws/lambda/io-foo-handler"
+	arn := "arn:aws:logs:us-east-1:123:log-group:" + name + ":*"
+	d := &cwlDiscoverer{new: func() cwlClient {
+		return &fakeCWLClient{
+			pages: []cloudwatchlogs.DescribeLogGroupsOutput{
+				{LogGroups: []cwltypes.LogGroup{
+					{LogGroupName: aws.String(name), Arn: aws.String(arn)},
+				}},
+			},
+		}
+	}}
+	got, err := d.DiscoverByID(context.Background(), arn, "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.Type != "aws_cloudwatch_log_group" {
+		t.Errorf("Type=%q", got.Identity.Type)
+	}
+	if got.Identity.NameHint != name {
+		t.Errorf("NameHint=%q, want %q", got.Identity.NameHint, name)
+	}
+	if got.Identity.NativeIDs["arn"] != arn {
+		t.Errorf("NativeIDs[arn]=%q, want %q", got.Identity.NativeIDs["arn"], arn)
+	}
+}
+
+func TestCWLDiscoverByID_AcceptsBareName(t *testing.T) {
+	t.Parallel()
+	name := "/aws/lambda/io-foo-handler"
+	d := &cwlDiscoverer{new: func() cwlClient {
+		return &fakeCWLClient{
+			pages: []cloudwatchlogs.DescribeLogGroupsOutput{
+				{LogGroups: []cwltypes.LogGroup{
+					{LogGroupName: aws.String(name), Arn: aws.String("arn:test")},
+				}},
+			},
+		}
+	}}
+	got, err := d.DiscoverByID(context.Background(), name, "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.NameHint != name {
+		t.Errorf("NameHint=%q", got.Identity.NameHint)
+	}
+}
+
+func TestCWLDiscoverByID_NotFound(t *testing.T) {
+	t.Parallel()
+	d := &cwlDiscoverer{new: func() cwlClient {
+		// Empty pages → CWL returns empty list (no typed not-found error).
+		return &fakeCWLClient{}
+	}}
+	_, err := d.DiscoverByID(context.Background(), "/aws/lambda/missing", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestCWLDiscoverByID_NotFoundOnPrefixMatchOnly(t *testing.T) {
+	t.Parallel()
+	// CWL prefix match returns names that share a prefix; DiscoverByID
+	// must require an exact match.
+	d := &cwlDiscoverer{new: func() cwlClient {
+		return &fakeCWLClient{
+			pages: []cloudwatchlogs.DescribeLogGroupsOutput{
+				{LogGroups: []cwltypes.LogGroup{
+					{LogGroupName: aws.String("/aws/lambda/missing-extended"), Arn: aws.String("arn:test")},
+				}},
+			},
+		}
+	}}
+	_, err := d.DiscoverByID(context.Background(), "/aws/lambda/missing", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestCWLDiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &cwlDiscoverer{new: func() cwlClient { return &fakeCWLClient{} }}
+	cases := []string{
+		"",
+		"arn:aws:s3:::a-bucket", // wrong service
+		"arn:aws:logs:us-east-1:123:metric-filter", // wrong resource type
+		"name with spaces",
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudwatchlogs_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatchlogs_test.go
@@ -184,6 +184,38 @@ func TestCWLDiscoverByID_NotFound(t *testing.T) {
 	}
 }
 
+func TestCWLDiscoverByID_PaginatesToExactMatch(t *testing.T) {
+	t.Parallel()
+	// The exact-name match is on page 2 behind a prefix-collision
+	// sibling on page 1. A non-paginating implementation would
+	// return ErrNotFound spuriously.
+	exact := "/aws/lambda/io-foo"
+	d := &cwlDiscoverer{new: func() cwlClient {
+		return &fakeCWLClient{
+			pages: []cloudwatchlogs.DescribeLogGroupsOutput{
+				{
+					LogGroups: []cwltypes.LogGroup{
+						{LogGroupName: aws.String("/aws/lambda/io-foo-extra"), Arn: aws.String("arn:test:extra")},
+					},
+					NextToken: aws.String("page2"),
+				},
+				{
+					LogGroups: []cwltypes.LogGroup{
+						{LogGroupName: aws.String(exact), Arn: aws.String("arn:test:exact")},
+					},
+				},
+			},
+		}
+	}}
+	got, err := d.DiscoverByID(context.Background(), exact, "us-east-1", "123")
+	if err != nil {
+		t.Fatalf("err=%v (must paginate to exact match)", err)
+	}
+	if got.Identity.NameHint != exact {
+		t.Errorf("NameHint=%q, want %q", got.Identity.NameHint, exact)
+	}
+}
+
 func TestCWLDiscoverByID_NotFoundOnPrefixMatchOnly(t *testing.T) {
 	t.Parallel()
 	// CWL prefix match returns names that share a prefix; DiscoverByID

--- a/cmd/insideout-import/awsdiscover/dynamodb.go
+++ b/cmd/insideout-import/awsdiscover/dynamodb.go
@@ -2,12 +2,16 @@ package awsdiscover
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dynamotypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -17,6 +21,7 @@ import (
 type dynamoClient interface {
 	ListTables(ctx context.Context, in *dynamodb.ListTablesInput, opts ...func(*dynamodb.Options)) (*dynamodb.ListTablesOutput, error)
 	ListTagsOfResource(ctx context.Context, in *dynamodb.ListTagsOfResourceInput, opts ...func(*dynamodb.Options)) (*dynamodb.ListTagsOfResourceOutput, error)
+	DescribeTable(ctx context.Context, in *dynamodb.DescribeTableInput, opts ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error)
 }
 
 type dynamoDiscoverer struct {
@@ -143,8 +148,70 @@ func (d *dynamoDiscoverer) Discover(ctx context.Context, project, region, accoun
 }
 
 // hasPrefix is a stdlib helper inlined here so the prefix check stays
-// readable next to the ListTables loop. Using strings.HasPrefix would
-// require importing "strings" only for one call.
+// readable next to the ListTables loop.
 func hasPrefix(s, prefix string) bool {
 	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+// DiscoverByID resolves a DynamoDB table by ARN
+// (arn:aws:dynamodb:<region>:<account>:table/<name>) or bare table
+// name. Issues a single DescribeTable call to verify existence.
+func (d *dynamoDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	name, err := dynamoNameFromID(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
+	client := d.new()
+	out, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String(name)})
+	if err != nil {
+		var notFound *dynamotypes.ResourceNotFoundException
+		if errors.As(err, &notFound) {
+			return imported.ImportedResource{}, fmt.Errorf("aws_dynamodb_table %q: %w", name, ErrNotFound)
+		}
+		return imported.ImportedResource{}, fmt.Errorf("DescribeTable: %w", err)
+	}
+	arn := ""
+	if out.Table != nil {
+		arn = aws.ToString(out.Table.TableArn)
+	}
+	if arn == "" && accountID != "" && region != "" {
+		arn = fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", region, accountID, name)
+	}
+	return makeImportedResource(
+		addressBook{},
+		"aws_dynamodb_table",
+		name,
+		name,
+		region,
+		accountID,
+		map[string]string{"arn": arn},
+	), nil
+}
+
+// dynamoNameFromID extracts the DynamoDB table name from an ARN
+// (arn:aws:dynamodb:<region>:<account>:table/<name>) or bare name.
+func dynamoNameFromID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("dynamodb: empty id: %w", ErrNotSupported)
+	}
+	if awsarn.IsARN(id) {
+		parsed, err := awsarn.Parse(id)
+		if err != nil {
+			return "", fmt.Errorf("dynamodb: parse arn: %w", err)
+		}
+		if parsed.Service != "dynamodb" {
+			return "", fmt.Errorf("dynamodb: not a dynamodb arn (service=%q): %w", parsed.Service, ErrNotSupported)
+		}
+		// Resource is "table/<name>" — split on first slash.
+		parts := strings.SplitN(parsed.Resource, "/", 2)
+		if len(parts) != 2 || parts[0] != "table" || parts[1] == "" {
+			return "", fmt.Errorf("dynamodb: arn resource %q is not table/<name>: %w", parsed.Resource, ErrNotSupported)
+		}
+		return parts[1], nil
+	}
+	if strings.ContainsAny(id, " :/") {
+		return "", fmt.Errorf("dynamodb: unrecognized id %q: %w", id, ErrNotSupported)
+	}
+	return id, nil
 }

--- a/cmd/insideout-import/awsdiscover/dynamodb_test.go
+++ b/cmd/insideout-import/awsdiscover/dynamodb_test.go
@@ -22,6 +22,12 @@ type fakeDynamoClient struct {
 	listCalls []dynamodb.ListTablesInput
 	tagCalls  []string
 	listErr   error
+
+	// DescribeTable wiring for DiscoverByID tests.
+	describeByName     map[string]*dynamotypes.TableDescription
+	describeErr        error
+	describeCalls      []string
+	describeReturnsErr bool
 }
 
 func (f *fakeDynamoClient) ListTables(_ context.Context, in *dynamodb.ListTablesInput, _ ...func(*dynamodb.Options)) (*dynamodb.ListTablesOutput, error) {
@@ -47,6 +53,20 @@ func (f *fakeDynamoClient) ListTagsOfResource(_ context.Context, in *dynamodb.Li
 		return nil, err
 	}
 	return &dynamodb.ListTagsOfResourceOutput{Tags: f.tagsByID[arn]}, nil
+}
+
+func (f *fakeDynamoClient) DescribeTable(_ context.Context, in *dynamodb.DescribeTableInput, _ ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
+	name := aws.ToString(in.TableName)
+	f.mu.Lock()
+	f.describeCalls = append(f.describeCalls, name)
+	f.mu.Unlock()
+	if f.describeErr != nil {
+		return nil, f.describeErr
+	}
+	if td, ok := f.describeByName[name]; ok {
+		return &dynamodb.DescribeTableOutput{Table: td}, nil
+	}
+	return nil, &dynamotypes.ResourceNotFoundException{}
 }
 
 func tagPair(k, v string) dynamotypes.Tag {
@@ -240,6 +260,13 @@ func (c *blockingDynamoClient) ListTagsOfResource(ctx context.Context, in *dynam
 	}
 }
 
+// DescribeTable is unused by the concurrency tests but required to
+// satisfy the dynamoClient interface; the DiscoverByID code path is
+// covered by fakeDynamoClient.
+func (c *blockingDynamoClient) DescribeTable(_ context.Context, _ *dynamodb.DescribeTableInput, _ ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error) {
+	return nil, errors.New("blockingDynamoClient.DescribeTable: not used in concurrency tests")
+}
+
 // TestDynamoDBDiscover_BoundedConcurrency mirrors the Lambda test for
 // the DynamoDB code path — distinct discoverer, distinct errgroup, so
 // we pin both. Without separate coverage a regression that drops
@@ -356,5 +383,76 @@ func TestDynamoDBDiscover_ContextCancellationUnblocksSiblings(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Discover did not return after parent ctx cancelled — siblings stuck")
+	}
+}
+
+func TestDynamoDBDiscoverByID_AcceptsARN(t *testing.T) {
+	t.Parallel()
+	arn := "arn:aws:dynamodb:us-east-1:123:table/io-foo-orders"
+	fake := &fakeDynamoClient{
+		describeByName: map[string]*dynamotypes.TableDescription{
+			"io-foo-orders": {TableArn: aws.String(arn), TableName: aws.String("io-foo-orders")},
+		},
+	}
+	d := &dynamoDiscoverer{new: func() dynamoClient { return fake }}
+	got, err := d.DiscoverByID(context.Background(), arn, "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.Type != "aws_dynamodb_table" {
+		t.Errorf("Type=%q", got.Identity.Type)
+	}
+	if got.Identity.NameHint != "io-foo-orders" {
+		t.Errorf("NameHint=%q", got.Identity.NameHint)
+	}
+	if got.Identity.NativeIDs["arn"] != arn {
+		t.Errorf("NativeIDs[arn]=%q, want %q", got.Identity.NativeIDs["arn"], arn)
+	}
+}
+
+func TestDynamoDBDiscoverByID_AcceptsBareName(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDynamoClient{
+		describeByName: map[string]*dynamotypes.TableDescription{
+			"orders": {TableName: aws.String("orders")},
+		},
+	}
+	d := &dynamoDiscoverer{new: func() dynamoClient { return fake }}
+	got, err := d.DiscoverByID(context.Background(), "orders", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.NameHint != "orders" {
+		t.Errorf("NameHint=%q", got.Identity.NameHint)
+	}
+	// arn is constructed locally when DescribeTable does not echo it back.
+	if got.Identity.NativeIDs["arn"] != "arn:aws:dynamodb:us-east-1:123:table/orders" {
+		t.Errorf("NativeIDs[arn]=%q (expected synthesized)", got.Identity.NativeIDs["arn"])
+	}
+}
+
+func TestDynamoDBDiscoverByID_NotFound(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDynamoClient{} // empty describeByName triggers ResourceNotFoundException
+	d := &dynamoDiscoverer{new: func() dynamoClient { return fake }}
+	_, err := d.DiscoverByID(context.Background(), "missing", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestDynamoDBDiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &dynamoDiscoverer{new: func() dynamoClient { return &fakeDynamoClient{} }}
+	cases := []string{
+		"",
+		"arn:aws:s3:::a-bucket", // wrong service
+		"arn:aws:dynamodb:us-east-1:123:stream/io-foo/abc", // not a table arn
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
 	}
 }

--- a/cmd/insideout-import/awsdiscover/iam_policy.go
+++ b/cmd/insideout-import/awsdiscover/iam_policy.go
@@ -1,0 +1,137 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// iamPolicyClient is the narrow subset of the IAM SDK the policy
+// discoverer uses. ListPolicies is paginated; GetPolicy resolves a
+// single policy by ARN (no name-only lookup exists for managed
+// policies — the ARN encodes the path that disambiguates same-named
+// policies under different paths).
+type iamPolicyClient interface {
+	ListPolicies(ctx context.Context, in *iam.ListPoliciesInput, opts ...func(*iam.Options)) (*iam.ListPoliciesOutput, error)
+	GetPolicy(ctx context.Context, in *iam.GetPolicyInput, opts ...func(*iam.Options)) (*iam.GetPolicyOutput, error)
+}
+
+type iamPolicyDiscoverer struct {
+	new func() iamPolicyClient
+}
+
+func newIAMPolicyDiscoverer(cfg aws.Config) Discoverer {
+	return &iamPolicyDiscoverer{new: func() iamPolicyClient { return iam.NewFromConfig(cfg) }}
+}
+
+func (d *iamPolicyDiscoverer) ResourceType() string { return "aws_iam_policy" }
+
+// Discover paginates ListPolicies(Scope=Local) and filters by name
+// prefix matching project. Scope=Local restricts the listing to
+// customer-managed policies (the only kind aws_iam_policy creates) and
+// excludes the thousands of AWS-managed policies.
+//
+// Import ID for aws_iam_policy is the policy ARN.
+func (d *iamPolicyDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
+	client := d.new()
+
+	type policy struct {
+		name string
+		arn  string
+	}
+	var policies []policy
+
+	paginator := iam.NewListPoliciesPaginator(client, &iam.ListPoliciesInput{
+		Scope: iamtypes.PolicyScopeTypeLocal,
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("ListPolicies: %w", err)
+		}
+		for _, p := range page.Policies {
+			name := aws.ToString(p.PolicyName)
+			if project != "" && !strings.HasPrefix(name, project) {
+				continue
+			}
+			policies = append(policies, policy{name: name, arn: aws.ToString(p.Arn)})
+		}
+	}
+
+	sort.Slice(policies, func(i, j int) bool { return policies[i].arn < policies[j].arn })
+
+	book := addressBook{}
+	imps := make([]imported.ImportedResource, 0, len(policies))
+	for _, p := range policies {
+		imps = append(imps, makeImportedResource(
+			book,
+			"aws_iam_policy",
+			p.name,
+			p.arn,
+			region,
+			accountID,
+			map[string]string{"arn": p.arn},
+		))
+	}
+	return imps, nil
+}
+
+// DiscoverByID resolves an IAM policy by ARN. Bare names are NOT
+// accepted — IAM does not provide a name-only lookup for managed
+// policies, and the same name can exist under different paths.
+func (d *iamPolicyDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return imported.ImportedResource{}, fmt.Errorf("iam: empty id: %w", ErrNotSupported)
+	}
+	if !awsarn.IsARN(id) {
+		return imported.ImportedResource{}, fmt.Errorf("iam: aws_iam_policy DiscoverByID requires an ARN, got %q: %w", id, ErrNotSupported)
+	}
+	parsed, err := awsarn.Parse(id)
+	if err != nil {
+		return imported.ImportedResource{}, fmt.Errorf("iam: parse arn: %w", err)
+	}
+	if parsed.Service != "iam" {
+		return imported.ImportedResource{}, fmt.Errorf("iam: not an iam arn (service=%q): %w", parsed.Service, ErrNotSupported)
+	}
+	if !strings.HasPrefix(parsed.Resource, "policy/") {
+		return imported.ImportedResource{}, fmt.Errorf("iam: arn resource %q is not policy/<name>: %w", parsed.Resource, ErrNotSupported)
+	}
+
+	client := d.new()
+	out, err := client.GetPolicy(ctx, &iam.GetPolicyInput{PolicyArn: aws.String(id)})
+	if err != nil {
+		var notFound *iamtypes.NoSuchEntityException
+		if errors.As(err, &notFound) {
+			return imported.ImportedResource{}, fmt.Errorf("aws_iam_policy %q: %w", id, ErrNotFound)
+		}
+		return imported.ImportedResource{}, fmt.Errorf("GetPolicy: %w", err)
+	}
+	name := ""
+	if out.Policy != nil {
+		name = aws.ToString(out.Policy.PolicyName)
+	}
+	if name == "" {
+		// Fall back to the last path segment of the ARN's resource portion.
+		segs := strings.Split(parsed.Resource, "/")
+		name = segs[len(segs)-1]
+	}
+	return makeImportedResource(
+		addressBook{},
+		"aws_iam_policy",
+		name,
+		id,
+		region,
+		accountID,
+		map[string]string{"arn": id},
+	), nil
+}

--- a/cmd/insideout-import/awsdiscover/iam_policy_test.go
+++ b/cmd/insideout-import/awsdiscover/iam_policy_test.go
@@ -1,0 +1,138 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+type fakeIAMPolicyClient struct {
+	pages []iam.ListPoliciesOutput
+	err   error
+	calls []iam.ListPoliciesInput
+
+	getByARN map[string]*iamtypes.Policy
+	getErr   error
+	getCalls []string
+}
+
+func (f *fakeIAMPolicyClient) ListPolicies(_ context.Context, in *iam.ListPoliciesInput, _ ...func(*iam.Options)) (*iam.ListPoliciesOutput, error) {
+	f.calls = append(f.calls, *in)
+	if f.err != nil {
+		return nil, f.err
+	}
+	idx := len(f.calls) - 1
+	if idx >= len(f.pages) {
+		return &iam.ListPoliciesOutput{}, nil
+	}
+	return &f.pages[idx], nil
+}
+
+func (f *fakeIAMPolicyClient) GetPolicy(_ context.Context, in *iam.GetPolicyInput, _ ...func(*iam.Options)) (*iam.GetPolicyOutput, error) {
+	arn := aws.ToString(in.PolicyArn)
+	f.getCalls = append(f.getCalls, arn)
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if p, ok := f.getByARN[arn]; ok {
+		return &iam.GetPolicyOutput{Policy: p}, nil
+	}
+	return nil, &iamtypes.NoSuchEntityException{}
+}
+
+func TestIAMPolicyDiscover_FiltersByPrefixAndScope(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMPolicyClient{pages: []iam.ListPoliciesOutput{
+		{Policies: []iamtypes.Policy{
+			{PolicyName: aws.String("io-foo-readonly"), Arn: aws.String("arn:aws:iam::123:policy/io-foo-readonly")},
+			{PolicyName: aws.String("LegacyPolicy"), Arn: aws.String("arn:aws:iam::123:policy/LegacyPolicy")},
+		}},
+	}}
+	d := &iamPolicyDiscoverer{new: func() iamPolicyClient { return fake }}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1", len(got))
+	}
+	if got[0].Identity.NameHint != "io-foo-readonly" {
+		t.Errorf("NameHint=%q", got[0].Identity.NameHint)
+	}
+	if len(fake.calls) == 0 || fake.calls[0].Scope != iamtypes.PolicyScopeTypeLocal {
+		t.Errorf("ListPolicies should pass Scope=Local; got %v", fake.calls)
+	}
+}
+
+func TestIAMPolicyDiscover_PropagatesError(t *testing.T) {
+	t.Parallel()
+	d := &iamPolicyDiscoverer{new: func() iamPolicyClient {
+		return &fakeIAMPolicyClient{err: errors.New("AccessDenied")}
+	}}
+	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestIAMPolicyDiscoverByID_AcceptsARN(t *testing.T) {
+	t.Parallel()
+	arn := "arn:aws:iam::123:policy/io-foo-readonly"
+	d := &iamPolicyDiscoverer{new: func() iamPolicyClient {
+		return &fakeIAMPolicyClient{getByARN: map[string]*iamtypes.Policy{
+			arn: {PolicyName: aws.String("io-foo-readonly"), Arn: aws.String(arn)},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), arn, "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.Type != "aws_iam_policy" {
+		t.Errorf("Type=%q", got.Identity.Type)
+	}
+	if got.Identity.NameHint != "io-foo-readonly" {
+		t.Errorf("NameHint=%q", got.Identity.NameHint)
+	}
+	if got.Identity.ImportID != arn {
+		t.Errorf("ImportID=%q, want %q (policy import id is the arn)", got.Identity.ImportID, arn)
+	}
+}
+
+func TestIAMPolicyDiscoverByID_NotFound(t *testing.T) {
+	t.Parallel()
+	d := &iamPolicyDiscoverer{new: func() iamPolicyClient { return &fakeIAMPolicyClient{} }}
+	_, err := d.DiscoverByID(context.Background(),
+		"arn:aws:iam::123:policy/missing", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestIAMPolicyDiscoverByID_RejectsBareName(t *testing.T) {
+	t.Parallel()
+	d := &iamPolicyDiscoverer{new: func() iamPolicyClient { return &fakeIAMPolicyClient{} }}
+	_, err := d.DiscoverByID(context.Background(), "io-foo-readonly", "us-east-1", "123")
+	if !errors.Is(err, ErrNotSupported) {
+		t.Errorf("err=%v, want ErrNotSupported (bare names not allowed for policies)", err)
+	}
+}
+
+func TestIAMPolicyDiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &iamPolicyDiscoverer{new: func() iamPolicyClient { return &fakeIAMPolicyClient{} }}
+	cases := []string{
+		"",
+		"arn:aws:s3:::a-bucket",
+		"arn:aws:iam::123:role/io-foo",
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/iam_role.go
+++ b/cmd/insideout-import/awsdiscover/iam_role.go
@@ -1,0 +1,145 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// iamRoleClient is the narrow subset of the IAM SDK the role discoverer uses.
+type iamRoleClient interface {
+	ListRoles(ctx context.Context, in *iam.ListRolesInput, opts ...func(*iam.Options)) (*iam.ListRolesOutput, error)
+	GetRole(ctx context.Context, in *iam.GetRoleInput, opts ...func(*iam.Options)) (*iam.GetRoleOutput, error)
+}
+
+type iamRoleDiscoverer struct {
+	new func() iamRoleClient
+}
+
+func newIAMRoleDiscoverer(cfg aws.Config) Discoverer {
+	return &iamRoleDiscoverer{new: func() iamRoleClient { return iam.NewFromConfig(cfg) }}
+}
+
+func (d *iamRoleDiscoverer) ResourceType() string { return "aws_iam_role" }
+
+// Discover paginates ListRoles and filters by name prefix matching
+// project. IAM has no server-side filter on ListRoles, but role names
+// in InsideOut stacks are conventionally prefixed by the project name,
+// so client-side prefix filtering matches the bounded-account
+// assumption already used by the DynamoDB discoverer.
+//
+// Import ID for aws_iam_role is the role name.
+func (d *iamRoleDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
+	client := d.new()
+
+	type role struct {
+		name string
+		arn  string
+	}
+	var roles []role
+
+	paginator := iam.NewListRolesPaginator(client, &iam.ListRolesInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("ListRoles: %w", err)
+		}
+		for _, r := range page.Roles {
+			name := aws.ToString(r.RoleName)
+			if project != "" && !strings.HasPrefix(name, project) {
+				continue
+			}
+			roles = append(roles, role{name: name, arn: aws.ToString(r.Arn)})
+		}
+	}
+
+	sort.Slice(roles, func(i, j int) bool { return roles[i].name < roles[j].name })
+
+	book := addressBook{}
+	imps := make([]imported.ImportedResource, 0, len(roles))
+	for _, r := range roles {
+		imps = append(imps, makeImportedResource(
+			book,
+			"aws_iam_role",
+			r.name,
+			r.name,
+			region,
+			accountID,
+			map[string]string{"arn": r.arn},
+		))
+	}
+	return imps, nil
+}
+
+// DiscoverByID resolves an IAM role by ARN
+// (arn:aws:iam::<account>:role/<name>) or bare role name. Issues a
+// single GetRole call to verify existence.
+func (d *iamRoleDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	name, err := iamRoleNameFromID(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
+	client := d.new()
+	out, err := client.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String(name)})
+	if err != nil {
+		var notFound *iamtypes.NoSuchEntityException
+		if errors.As(err, &notFound) {
+			return imported.ImportedResource{}, fmt.Errorf("aws_iam_role %q: %w", name, ErrNotFound)
+		}
+		return imported.ImportedResource{}, fmt.Errorf("GetRole: %w", err)
+	}
+	arn := ""
+	if out.Role != nil {
+		arn = aws.ToString(out.Role.Arn)
+	}
+	return makeImportedResource(
+		addressBook{},
+		"aws_iam_role",
+		name,
+		name,
+		region,
+		accountID,
+		map[string]string{"arn": arn},
+	), nil
+}
+
+// iamRoleNameFromID extracts the IAM role name from an ARN
+// (arn:aws:iam::<account>:role/<name>) or bare name.
+func iamRoleNameFromID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("iam: empty id: %w", ErrNotSupported)
+	}
+	if awsarn.IsARN(id) {
+		parsed, err := awsarn.Parse(id)
+		if err != nil {
+			return "", fmt.Errorf("iam: parse arn: %w", err)
+		}
+		if parsed.Service != "iam" {
+			return "", fmt.Errorf("iam: not an iam arn (service=%q): %w", parsed.Service, ErrNotSupported)
+		}
+		// Resource is "role/<name>" or "role/<path>/<name>".
+		parts := strings.SplitN(parsed.Resource, "/", 2)
+		if len(parts) != 2 || parts[0] != "role" || parts[1] == "" {
+			return "", fmt.Errorf("iam: arn resource %q is not role/<name>: %w", parsed.Resource, ErrNotSupported)
+		}
+		// IAM role names are the *last* path segment for path-prefixed
+		// roles (arn:...:role/<path>/<name>); GetRole accepts the bare
+		// name without path.
+		segs := strings.Split(parts[1], "/")
+		return segs[len(segs)-1], nil
+	}
+	if strings.ContainsAny(id, " :") {
+		return "", fmt.Errorf("iam: unrecognized id %q: %w", id, ErrNotSupported)
+	}
+	return id, nil
+}

--- a/cmd/insideout-import/awsdiscover/iam_role_test.go
+++ b/cmd/insideout-import/awsdiscover/iam_role_test.go
@@ -1,0 +1,178 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+type fakeIAMRoleClient struct {
+	pages []iam.ListRolesOutput
+	err   error
+	calls []iam.ListRolesInput
+
+	getByName map[string]*iamtypes.Role
+	getErr    error
+	getCalls  []string
+}
+
+func (f *fakeIAMRoleClient) ListRoles(_ context.Context, in *iam.ListRolesInput, _ ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
+	f.calls = append(f.calls, *in)
+	if f.err != nil {
+		return nil, f.err
+	}
+	idx := len(f.calls) - 1
+	if idx >= len(f.pages) {
+		return &iam.ListRolesOutput{}, nil
+	}
+	return &f.pages[idx], nil
+}
+
+func (f *fakeIAMRoleClient) GetRole(_ context.Context, in *iam.GetRoleInput, _ ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
+	name := aws.ToString(in.RoleName)
+	f.getCalls = append(f.getCalls, name)
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if r, ok := f.getByName[name]; ok {
+		return &iam.GetRoleOutput{Role: r}, nil
+	}
+	return nil, &iamtypes.NoSuchEntityException{}
+}
+
+func TestIAMRoleDiscover_FiltersByPrefix(t *testing.T) {
+	t.Parallel()
+	d := &iamRoleDiscoverer{new: func() iamRoleClient {
+		return &fakeIAMRoleClient{pages: []iam.ListRolesOutput{
+			{Roles: []iamtypes.Role{
+				{RoleName: aws.String("io-foo-handler"), Arn: aws.String("arn:aws:iam::123:role/io-foo-handler")},
+				{RoleName: aws.String("OtherTeamRole"), Arn: aws.String("arn:aws:iam::123:role/OtherTeamRole")},
+				{RoleName: aws.String("io-foo-worker"), Arn: aws.String("arn:aws:iam::123:role/io-foo-worker")},
+			}},
+		}}
+	}}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (prefix-filtered)", len(got))
+	}
+	if got[0].Identity.NameHint != "io-foo-handler" {
+		t.Errorf("got[0].NameHint=%q (sort order)", got[0].Identity.NameHint)
+	}
+}
+
+func TestIAMRoleDiscover_EmptyProjectReturnsAll(t *testing.T) {
+	t.Parallel()
+	d := &iamRoleDiscoverer{new: func() iamRoleClient {
+		return &fakeIAMRoleClient{pages: []iam.ListRolesOutput{
+			{Roles: []iamtypes.Role{
+				{RoleName: aws.String("a"), Arn: aws.String("arn:test:a")},
+				{RoleName: aws.String("b"), Arn: aws.String("arn:test:b")},
+			}},
+		}}
+	}}
+	got, err := d.Discover(context.Background(), "", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+}
+
+func TestIAMRoleDiscover_PropagatesError(t *testing.T) {
+	t.Parallel()
+	d := &iamRoleDiscoverer{new: func() iamRoleClient {
+		return &fakeIAMRoleClient{err: errors.New("AccessDenied")}
+	}}
+	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestIAMRoleDiscoverByID_AcceptsARN(t *testing.T) {
+	t.Parallel()
+	arn := "arn:aws:iam::123:role/io-foo-handler"
+	d := &iamRoleDiscoverer{new: func() iamRoleClient {
+		return &fakeIAMRoleClient{getByName: map[string]*iamtypes.Role{
+			"io-foo-handler": {RoleName: aws.String("io-foo-handler"), Arn: aws.String(arn)},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), arn, "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.Type != "aws_iam_role" {
+		t.Errorf("Type=%q", got.Identity.Type)
+	}
+	if got.Identity.NameHint != "io-foo-handler" {
+		t.Errorf("NameHint=%q", got.Identity.NameHint)
+	}
+	if got.Identity.NativeIDs["arn"] != arn {
+		t.Errorf("NativeIDs[arn]=%q, want %q", got.Identity.NativeIDs["arn"], arn)
+	}
+}
+
+func TestIAMRoleDiscoverByID_StripsPathFromARN(t *testing.T) {
+	t.Parallel()
+	d := &iamRoleDiscoverer{new: func() iamRoleClient {
+		return &fakeIAMRoleClient{getByName: map[string]*iamtypes.Role{
+			"my-role": {RoleName: aws.String("my-role"), Arn: aws.String("arn:test")},
+		}}
+	}}
+	// Path-prefixed ARN — GetRole takes the bare name.
+	_, err := d.DiscoverByID(context.Background(),
+		"arn:aws:iam::123:role/service-roles/my-role", "us-east-1", "123")
+	if err != nil {
+		t.Fatalf("expected path stripped to bare name; got %v", err)
+	}
+}
+
+func TestIAMRoleDiscoverByID_AcceptsBareName(t *testing.T) {
+	t.Parallel()
+	d := &iamRoleDiscoverer{new: func() iamRoleClient {
+		return &fakeIAMRoleClient{getByName: map[string]*iamtypes.Role{
+			"io-foo-handler": {RoleName: aws.String("io-foo-handler"), Arn: aws.String("arn:test")},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), "io-foo-handler", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.NameHint != "io-foo-handler" {
+		t.Errorf("NameHint=%q", got.Identity.NameHint)
+	}
+}
+
+func TestIAMRoleDiscoverByID_NotFound(t *testing.T) {
+	t.Parallel()
+	d := &iamRoleDiscoverer{new: func() iamRoleClient { return &fakeIAMRoleClient{} }}
+	_, err := d.DiscoverByID(context.Background(), "missing", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestIAMRoleDiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &iamRoleDiscoverer{new: func() iamRoleClient { return &fakeIAMRoleClient{} }}
+	cases := []string{
+		"",
+		"arn:aws:s3:::a-bucket",
+		"arn:aws:iam::123:user/me", // user, not role
+		"arn:aws:iam::123:policy/ReadOnly",
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/kms.go
+++ b/cmd/insideout-import/awsdiscover/kms.go
@@ -51,7 +51,6 @@ func (d *kmsDiscoverer) Discover(ctx context.Context, project, region, accountID
 
 	type key struct {
 		uuid  string
-		arn   string
 		alias string
 	}
 	var keys []key
@@ -78,9 +77,12 @@ func (d *kmsDiscoverer) Discover(ctx context.Context, project, region, accountID
 			if strings.HasPrefix(alias, "alias/aws/") {
 				continue
 			}
+			// Note: a.AliasArn is the *alias* ARN, not the key ARN we
+			// want for NativeIDs[arn]. The key ARN is synthesized
+			// below from region + accountID + target UUID; alias arn
+			// is intentionally NOT carried into NativeIDs.
 			keys = append(keys, key{
 				uuid:  target,
-				arn:   aws.ToString(a.AliasArn),
 				alias: alias,
 			})
 		}

--- a/cmd/insideout-import/awsdiscover/kms.go
+++ b/cmd/insideout-import/awsdiscover/kms.go
@@ -1,0 +1,183 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// kmsClient is the narrow subset of the KMS SDK the discoverer uses.
+// We probe via aliases (KMS keys are typically referenced by alias in
+// Terraform) and resolve to KeyId via DescribeKey.
+type kmsClient interface {
+	ListAliases(ctx context.Context, in *kms.ListAliasesInput, opts ...func(*kms.Options)) (*kms.ListAliasesOutput, error)
+	DescribeKey(ctx context.Context, in *kms.DescribeKeyInput, opts ...func(*kms.Options)) (*kms.DescribeKeyOutput, error)
+}
+
+type kmsDiscoverer struct {
+	new func() kmsClient
+}
+
+func newKMSDiscoverer(cfg aws.Config) Discoverer {
+	return &kmsDiscoverer{new: func() kmsClient { return kms.NewFromConfig(cfg) }}
+}
+
+func (d *kmsDiscoverer) ResourceType() string { return "aws_kms_key" }
+
+// Discover walks ListAliases and emits one aws_kms_key per alias whose
+// name contains the project string. KMS aliases are the conventional
+// human-readable handle for keys — Terraform stacks set
+// `alias = "alias/<project>-<purpose>"` on aws_kms_alias resources, so
+// the alias name carries the project association even when the
+// underlying key is untagged.
+//
+// Untagged customer-managed keys whose aliases do not contain the
+// project name are skipped. Operators with "naked" keys (no alias)
+// must hand the key UUID to discover via the --resource-types path.
+//
+// Import ID for aws_kms_key is the key UUID (from the alias's
+// TargetKeyId).
+func (d *kmsDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
+	client := d.new()
+
+	type key struct {
+		uuid  string
+		arn   string
+		alias string
+	}
+	var keys []key
+
+	paginator := kms.NewListAliasesPaginator(client, &kms.ListAliasesInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("ListAliases: %w", err)
+		}
+		for _, a := range page.Aliases {
+			alias := aws.ToString(a.AliasName)
+			target := aws.ToString(a.TargetKeyId)
+			if target == "" {
+				// AWS-managed alias with no customer-managed key behind
+				// it; skip — cannot import.
+				continue
+			}
+			if project != "" && !strings.Contains(alias, project) {
+				continue
+			}
+			// Skip AWS-managed aliases (e.g. "alias/aws/...") that may
+			// happen to contain the project name as a substring.
+			if strings.HasPrefix(alias, "alias/aws/") {
+				continue
+			}
+			keys = append(keys, key{
+				uuid:  target,
+				arn:   aws.ToString(a.AliasArn),
+				alias: alias,
+			})
+		}
+	}
+
+	sort.Slice(keys, func(i, j int) bool { return keys[i].alias < keys[j].alias })
+
+	book := addressBook{}
+	imps := make([]imported.ImportedResource, 0, len(keys))
+	for _, k := range keys {
+		var arn string
+		if accountID != "" && region != "" {
+			arn = fmt.Sprintf("arn:aws:kms:%s:%s:key/%s", region, accountID, k.uuid)
+		}
+		// NameHint is the alias (without "alias/" prefix) to keep the
+		// generated Terraform address human-readable.
+		nameHint := strings.TrimPrefix(k.alias, "alias/")
+		imps = append(imps, makeImportedResource(
+			book,
+			"aws_kms_key",
+			nameHint,
+			k.uuid,
+			region,
+			accountID,
+			map[string]string{"arn": arn, "alias": k.alias},
+		))
+	}
+	return imps, nil
+}
+
+// DiscoverByID resolves a KMS key by ARN
+// (arn:aws:kms:<region>:<account>:key/<uuid>), bare key UUID, or alias
+// ARN/name. Issues a single DescribeKey call to verify existence and
+// resolve aliases.
+func (d *kmsDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	probe, err := kmsKeyIDFromInput(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
+	client := d.new()
+	out, err := client.DescribeKey(ctx, &kms.DescribeKeyInput{KeyId: aws.String(probe)})
+	if err != nil {
+		var notFound *kmstypes.NotFoundException
+		if errors.As(err, &notFound) {
+			return imported.ImportedResource{}, fmt.Errorf("aws_kms_key %q: %w", id, ErrNotFound)
+		}
+		return imported.ImportedResource{}, fmt.Errorf("DescribeKey: %w", err)
+	}
+	if out.KeyMetadata == nil {
+		return imported.ImportedResource{}, fmt.Errorf("DescribeKey returned no metadata for %q", id)
+	}
+	uuid := aws.ToString(out.KeyMetadata.KeyId)
+	arn := aws.ToString(out.KeyMetadata.Arn)
+	if arn == "" && accountID != "" && region != "" {
+		arn = fmt.Sprintf("arn:aws:kms:%s:%s:key/%s", region, accountID, uuid)
+	}
+	return makeImportedResource(
+		addressBook{},
+		"aws_kms_key",
+		uuid,
+		uuid,
+		region,
+		accountID,
+		map[string]string{"arn": arn},
+	), nil
+}
+
+// kmsKeyIDFromInput normalizes any of {key UUID, key ARN, alias name,
+// alias ARN} to a probe value DescribeKey accepts (it accepts all four
+// natively, so this function is mainly a validation gate). Returns
+// ErrNotSupported for inputs that obviously can't be a KMS reference.
+func kmsKeyIDFromInput(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("kms: empty id: %w", ErrNotSupported)
+	}
+	if awsarn.IsARN(id) {
+		parsed, err := awsarn.Parse(id)
+		if err != nil {
+			return "", fmt.Errorf("kms: parse arn: %w", err)
+		}
+		if parsed.Service != "kms" {
+			return "", fmt.Errorf("kms: not a kms arn (service=%q): %w", parsed.Service, ErrNotSupported)
+		}
+		// kms ARN resource is "key/<uuid>" or "alias/<name>".
+		if !strings.HasPrefix(parsed.Resource, "key/") && !strings.HasPrefix(parsed.Resource, "alias/") {
+			return "", fmt.Errorf("kms: arn resource %q is not key/<uuid> or alias/<name>: %w", parsed.Resource, ErrNotSupported)
+		}
+		return id, nil
+	}
+	// Allow alias names ("alias/<name>") and bare UUIDs.
+	if strings.HasPrefix(id, "alias/") {
+		return id, nil
+	}
+	if strings.ContainsAny(id, " :") {
+		return "", fmt.Errorf("kms: unrecognized id %q: %w", id, ErrNotSupported)
+	}
+	// Bare UUID — DescribeKey accepts this.
+	return id, nil
+}

--- a/cmd/insideout-import/awsdiscover/kms_test.go
+++ b/cmd/insideout-import/awsdiscover/kms_test.go
@@ -1,0 +1,180 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+)
+
+type fakeKMSClient struct {
+	pages []kms.ListAliasesOutput
+	err   error
+	calls []kms.ListAliasesInput
+
+	describeByID  map[string]*kmstypes.KeyMetadata
+	describeErr   error
+	describeCalls []string
+}
+
+func (f *fakeKMSClient) ListAliases(_ context.Context, in *kms.ListAliasesInput, _ ...func(*kms.Options)) (*kms.ListAliasesOutput, error) {
+	f.calls = append(f.calls, *in)
+	if f.err != nil {
+		return nil, f.err
+	}
+	idx := len(f.calls) - 1
+	if idx >= len(f.pages) {
+		return &kms.ListAliasesOutput{}, nil
+	}
+	return &f.pages[idx], nil
+}
+
+func (f *fakeKMSClient) DescribeKey(_ context.Context, in *kms.DescribeKeyInput, _ ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
+	id := aws.ToString(in.KeyId)
+	f.describeCalls = append(f.describeCalls, id)
+	if f.describeErr != nil {
+		return nil, f.describeErr
+	}
+	if md, ok := f.describeByID[id]; ok {
+		return &kms.DescribeKeyOutput{KeyMetadata: md}, nil
+	}
+	return nil, &kmstypes.NotFoundException{}
+}
+
+func TestKMSDiscover_FiltersByAliasContainsProject(t *testing.T) {
+	t.Parallel()
+	d := &kmsDiscoverer{new: func() kmsClient {
+		return &fakeKMSClient{pages: []kms.ListAliasesOutput{
+			{Aliases: []kmstypes.AliasListEntry{
+				{
+					AliasName:   aws.String("alias/io-foo-data"),
+					TargetKeyId: aws.String("uuid-1"),
+					AliasArn:    aws.String("arn:aws:kms:us-east-1:123:alias/io-foo-data"),
+				},
+				{
+					AliasName:   aws.String("alias/aws/lambda"),
+					TargetKeyId: aws.String("uuid-aws"),
+				},
+				{
+					AliasName:   aws.String("alias/legacy-key"),
+					TargetKeyId: aws.String("uuid-legacy"),
+				},
+				{
+					AliasName: aws.String("alias/io-foo-orphan"),
+					// Missing TargetKeyId — not a real customer-managed key.
+				},
+			}},
+		}}
+	}}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (alias contains project, has TargetKeyId, not aws-managed)", len(got))
+	}
+	if got[0].Identity.NameHint != "io-foo-data" {
+		t.Errorf("NameHint=%q (alias trimmed of 'alias/' prefix)", got[0].Identity.NameHint)
+	}
+	if got[0].Identity.ImportID != "uuid-1" {
+		t.Errorf("ImportID=%q, want uuid-1 (key UUID from TargetKeyId)", got[0].Identity.ImportID)
+	}
+	if got[0].Identity.NativeIDs["arn"] != "arn:aws:kms:us-east-1:123:key/uuid-1" {
+		t.Errorf("NativeIDs[arn]=%q (synthesized from region/accountID)", got[0].Identity.NativeIDs["arn"])
+	}
+}
+
+func TestKMSDiscover_PropagatesError(t *testing.T) {
+	t.Parallel()
+	d := &kmsDiscoverer{new: func() kmsClient {
+		return &fakeKMSClient{err: errors.New("AccessDenied")}
+	}}
+	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestKMSDiscoverByID_AcceptsKeyARN(t *testing.T) {
+	t.Parallel()
+	arn := "arn:aws:kms:us-east-1:123:key/uuid-1"
+	d := &kmsDiscoverer{new: func() kmsClient {
+		return &fakeKMSClient{describeByID: map[string]*kmstypes.KeyMetadata{
+			arn: {KeyId: aws.String("uuid-1"), Arn: aws.String(arn)},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), arn, "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.Type != "aws_kms_key" {
+		t.Errorf("Type=%q", got.Identity.Type)
+	}
+	if got.Identity.ImportID != "uuid-1" {
+		t.Errorf("ImportID=%q, want uuid-1", got.Identity.ImportID)
+	}
+	if got.Identity.NativeIDs["arn"] != arn {
+		t.Errorf("NativeIDs[arn]=%q", got.Identity.NativeIDs["arn"])
+	}
+}
+
+func TestKMSDiscoverByID_AcceptsBareUUID(t *testing.T) {
+	t.Parallel()
+	d := &kmsDiscoverer{new: func() kmsClient {
+		return &fakeKMSClient{describeByID: map[string]*kmstypes.KeyMetadata{
+			"uuid-1": {KeyId: aws.String("uuid-1"), Arn: aws.String("arn:aws:kms:us-east-1:123:key/uuid-1")},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), "uuid-1", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.ImportID != "uuid-1" {
+		t.Errorf("ImportID=%q", got.Identity.ImportID)
+	}
+}
+
+func TestKMSDiscoverByID_AcceptsAliasName(t *testing.T) {
+	t.Parallel()
+	d := &kmsDiscoverer{new: func() kmsClient {
+		return &fakeKMSClient{describeByID: map[string]*kmstypes.KeyMetadata{
+			"alias/io-foo-data": {KeyId: aws.String("uuid-1"), Arn: aws.String("arn:aws:kms:us-east-1:123:key/uuid-1")},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), "alias/io-foo-data", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.ImportID != "uuid-1" {
+		t.Errorf("ImportID=%q (resolved alias to UUID)", got.Identity.ImportID)
+	}
+}
+
+func TestKMSDiscoverByID_NotFound(t *testing.T) {
+	t.Parallel()
+	d := &kmsDiscoverer{new: func() kmsClient { return &fakeKMSClient{} }}
+	_, err := d.DiscoverByID(context.Background(), "uuid-missing", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestKMSDiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &kmsDiscoverer{new: func() kmsClient { return &fakeKMSClient{} }}
+	cases := []string{
+		"",
+		"arn:aws:s3:::a-bucket",
+		"arn:aws:kms:us-east-1:123:grant/abc",
+		"name with spaces",
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/lambda.go
+++ b/cmd/insideout-import/awsdiscover/lambda.go
@@ -2,12 +2,16 @@ package awsdiscover
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -18,6 +22,7 @@ import (
 type lambdaClient interface {
 	ListFunctions(ctx context.Context, in *lambda.ListFunctionsInput, opts ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error)
 	ListTags(ctx context.Context, in *lambda.ListTagsInput, opts ...func(*lambda.Options)) (*lambda.ListTagsOutput, error)
+	GetFunction(ctx context.Context, in *lambda.GetFunctionInput, opts ...func(*lambda.Options)) (*lambda.GetFunctionOutput, error)
 }
 
 type lambdaDiscoverer struct {
@@ -130,4 +135,74 @@ func (d *lambdaDiscoverer) Discover(ctx context.Context, project, region, accoun
 		))
 	}
 	return out, nil
+}
+
+// DiscoverByID resolves a Lambda function by ARN
+// (arn:aws:lambda:<region>:<account>:function:<name>) or bare function
+// name. Issues a single GetFunction call to verify existence.
+func (d *lambdaDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	name, err := lambdaNameFromID(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
+	client := d.new()
+	out, err := client.GetFunction(ctx, &lambda.GetFunctionInput{FunctionName: aws.String(name)})
+	if err != nil {
+		var notFound *lambdatypes.ResourceNotFoundException
+		if errors.As(err, &notFound) {
+			return imported.ImportedResource{}, fmt.Errorf("aws_lambda_function %q: %w", name, ErrNotFound)
+		}
+		return imported.ImportedResource{}, fmt.Errorf("GetFunction: %w", err)
+	}
+	arn := ""
+	if out.Configuration != nil {
+		arn = aws.ToString(out.Configuration.FunctionArn)
+	}
+	return makeImportedResource(
+		addressBook{},
+		"aws_lambda_function",
+		name,
+		name,
+		region,
+		accountID,
+		map[string]string{"arn": arn},
+	), nil
+}
+
+// lambdaNameFromID extracts the function name from an ARN
+// (arn:aws:lambda:<region>:<account>:function:<name>[:<version-or-alias>])
+// or bare name. The function ARN's resource portion uses ":" not "/" as
+// the delimiter, and may carry a version/alias suffix that we strip.
+func lambdaNameFromID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("lambda: empty id: %w", ErrNotSupported)
+	}
+	if awsarn.IsARN(id) {
+		parsed, err := awsarn.Parse(id)
+		if err != nil {
+			return "", fmt.Errorf("lambda: parse arn: %w", err)
+		}
+		if parsed.Service != "lambda" {
+			return "", fmt.Errorf("lambda: not a lambda arn (service=%q): %w", parsed.Service, ErrNotSupported)
+		}
+		// function:<name>[:<qualifier>]
+		const prefix = "function:"
+		if !strings.HasPrefix(parsed.Resource, prefix) {
+			return "", fmt.Errorf("lambda: arn resource %q is not function:<name>: %w", parsed.Resource, ErrNotSupported)
+		}
+		rest := strings.TrimPrefix(parsed.Resource, prefix)
+		// Drop a trailing :version or :alias if present.
+		if i := strings.IndexByte(rest, ':'); i != -1 {
+			rest = rest[:i]
+		}
+		if rest == "" {
+			return "", fmt.Errorf("lambda: empty name in arn %q: %w", id, ErrNotSupported)
+		}
+		return rest, nil
+	}
+	if strings.ContainsAny(id, " :/") {
+		return "", fmt.Errorf("lambda: unrecognized id %q: %w", id, ErrNotSupported)
+	}
+	return id, nil
 }

--- a/cmd/insideout-import/awsdiscover/lambda_test.go
+++ b/cmd/insideout-import/awsdiscover/lambda_test.go
@@ -21,6 +21,12 @@ type fakeLambdaClient struct {
 	mu        sync.Mutex
 	listCalls int
 	tagCalls  []string
+
+	// GetFunction wiring for DiscoverByID tests.
+	getByName    map[string]*lambda.GetFunctionOutput
+	getErr       error
+	getFnCalls   []string
+	getFnCallsMu sync.Mutex
 }
 
 func (f *fakeLambdaClient) ListFunctions(_ context.Context, _ *lambda.ListFunctionsInput, _ ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error) {
@@ -41,6 +47,20 @@ func (f *fakeLambdaClient) ListTags(_ context.Context, in *lambda.ListTagsInput,
 		return nil, err
 	}
 	return &lambda.ListTagsOutput{Tags: f.tagsByID[arn]}, nil
+}
+
+func (f *fakeLambdaClient) GetFunction(_ context.Context, in *lambda.GetFunctionInput, _ ...func(*lambda.Options)) (*lambda.GetFunctionOutput, error) {
+	name := aws.ToString(in.FunctionName)
+	f.getFnCallsMu.Lock()
+	f.getFnCalls = append(f.getFnCalls, name)
+	f.getFnCallsMu.Unlock()
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if out, ok := f.getByName[name]; ok {
+		return out, nil
+	}
+	return nil, &lambdatypes.ResourceNotFoundException{}
 }
 
 func fn(name, arn string) lambdatypes.FunctionConfiguration {
@@ -208,6 +228,10 @@ func (c *lambdaErrClient) ListTags(_ context.Context, _ *lambda.ListTagsInput, _
 	return nil, c.err
 }
 
+func (c *lambdaErrClient) GetFunction(_ context.Context, _ *lambda.GetFunctionInput, _ ...func(*lambda.Options)) (*lambda.GetFunctionOutput, error) {
+	return nil, c.err
+}
+
 // blockingLambdaClient is a fake whose ListTags signals when each call
 // enters and then blocks until release is closed (or ctx is cancelled).
 // Used by the concurrency + cancellation tests to observe peak in-flight
@@ -256,6 +280,13 @@ func (c *blockingLambdaClient) ListTags(ctx context.Context, in *lambda.ListTags
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+// GetFunction is unused by the concurrency tests but required to satisfy
+// the lambdaClient interface; the DiscoverByID path is covered by
+// fakeLambdaClient.
+func (c *blockingLambdaClient) GetFunction(_ context.Context, _ *lambda.GetFunctionInput, _ ...func(*lambda.Options)) (*lambda.GetFunctionOutput, error) {
+	return nil, errors.New("blockingLambdaClient.GetFunction: not used in concurrency tests")
 }
 
 // TestLambdaDiscover_BoundedConcurrency pins g.SetLimit(maxConcurrency).
@@ -381,5 +412,75 @@ func TestLambdaDiscover_ContextCancellationUnblocksSiblings(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Discover did not return after parent ctx cancelled — siblings stuck")
+	}
+}
+
+func TestLambdaDiscoverByID_AcceptsARN(t *testing.T) {
+	t.Parallel()
+	arn := "arn:aws:lambda:us-east-1:123:function:io-foo-handler"
+	d := &lambdaDiscoverer{new: func() lambdaClient {
+		return &fakeLambdaClient{getByName: map[string]*lambda.GetFunctionOutput{
+			"io-foo-handler": {Configuration: &lambdatypes.FunctionConfiguration{
+				FunctionName: aws.String("io-foo-handler"),
+				FunctionArn:  aws.String(arn),
+			}},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), arn, "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.Type != "aws_lambda_function" {
+		t.Errorf("Type=%q", got.Identity.Type)
+	}
+	if got.Identity.NameHint != "io-foo-handler" {
+		t.Errorf("NameHint=%q", got.Identity.NameHint)
+	}
+	if got.Identity.NativeIDs["arn"] != arn {
+		t.Errorf("NativeIDs[arn]=%q, want %q", got.Identity.NativeIDs["arn"], arn)
+	}
+}
+
+func TestLambdaDiscoverByID_StripsVersionFromARN(t *testing.T) {
+	t.Parallel()
+	d := &lambdaDiscoverer{new: func() lambdaClient {
+		return &fakeLambdaClient{getByName: map[string]*lambda.GetFunctionOutput{
+			"io-foo-handler": {Configuration: &lambdatypes.FunctionConfiguration{
+				FunctionName: aws.String("io-foo-handler"),
+				FunctionArn:  aws.String("arn:aws:lambda:us-east-1:123:function:io-foo-handler"),
+			}},
+		}}
+	}}
+	// Versioned/aliased ARN — Lambda's import expects the bare name.
+	_, err := d.DiscoverByID(context.Background(),
+		"arn:aws:lambda:us-east-1:123:function:io-foo-handler:PROD",
+		"us-east-1", "123")
+	if err != nil {
+		t.Fatalf("expected version stripped to bare name; got %v", err)
+	}
+}
+
+func TestLambdaDiscoverByID_NotFound(t *testing.T) {
+	t.Parallel()
+	d := &lambdaDiscoverer{new: func() lambdaClient { return &fakeLambdaClient{} }}
+	_, err := d.DiscoverByID(context.Background(), "missing", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestLambdaDiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &lambdaDiscoverer{new: func() lambdaClient { return &fakeLambdaClient{} }}
+	cases := []string{
+		"",
+		"arn:aws:s3:::a-bucket",
+		"arn:aws:lambda:us-east-1:123:layer:my-layer:1",
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
 	}
 }

--- a/cmd/insideout-import/awsdiscover/s3.go
+++ b/cmd/insideout-import/awsdiscover/s3.go
@@ -1,0 +1,133 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// s3Client is the narrow subset of the S3 SDK the discoverer uses.
+type s3Client interface {
+	ListBuckets(ctx context.Context, in *s3.ListBucketsInput, opts ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
+	HeadBucket(ctx context.Context, in *s3.HeadBucketInput, opts ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
+}
+
+type s3Discoverer struct {
+	new func() s3Client
+}
+
+func newS3Discoverer(cfg aws.Config) Discoverer {
+	return &s3Discoverer{new: func() s3Client { return s3.NewFromConfig(cfg) }}
+}
+
+func (d *s3Discoverer) ResourceType() string { return "aws_s3_bucket" }
+
+// Discover lists buckets and filters by name prefix matching project.
+// S3's ListBuckets is account-global (returns every bucket regardless
+// of region) and unpaginated; the prefix filter is client-side.
+//
+// Import ID for aws_s3_bucket is the bucket name.
+func (d *s3Discoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
+	client := d.new()
+	out, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	if err != nil {
+		return nil, fmt.Errorf("ListBuckets: %w", err)
+	}
+
+	var names []string
+	for _, b := range out.Buckets {
+		name := aws.ToString(b.Name)
+		if project != "" && !strings.HasPrefix(name, project) {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	book := addressBook{}
+	imps := make([]imported.ImportedResource, 0, len(names))
+	for _, name := range names {
+		arn := fmt.Sprintf("arn:aws:s3:::%s", name)
+		imps = append(imps, makeImportedResource(
+			book,
+			"aws_s3_bucket",
+			name,
+			name,
+			region,
+			accountID,
+			map[string]string{"arn": arn},
+		))
+	}
+	return imps, nil
+}
+
+// DiscoverByID resolves an S3 bucket by ARN (arn:aws:s3:::<name>) or
+// bare bucket name. Issues a single HeadBucket call to verify
+// existence; HeadBucket returns *s3types.NotFound for missing buckets
+// in the v2 SDK.
+func (d *s3Discoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	name, err := s3NameFromID(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
+	client := d.new()
+	if _, err := client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(name)}); err != nil {
+		var notFound *s3types.NotFound
+		var noBucket *s3types.NoSuchBucket
+		if errors.As(err, &notFound) || errors.As(err, &noBucket) {
+			return imported.ImportedResource{}, fmt.Errorf("aws_s3_bucket %q: %w", name, ErrNotFound)
+		}
+		return imported.ImportedResource{}, fmt.Errorf("HeadBucket: %w", err)
+	}
+	arn := fmt.Sprintf("arn:aws:s3:::%s", name)
+	return makeImportedResource(
+		addressBook{},
+		"aws_s3_bucket",
+		name,
+		name,
+		region,
+		accountID,
+		map[string]string{"arn": arn},
+	), nil
+}
+
+// s3NameFromID extracts the bucket name from an ARN (arn:aws:s3:::<name>)
+// or bare bucket name. S3 ARNs are unique in that the resource portion
+// is the entire bucket name (no service-region/account scoping).
+func s3NameFromID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("s3: empty id: %w", ErrNotSupported)
+	}
+	if awsarn.IsARN(id) {
+		parsed, err := awsarn.Parse(id)
+		if err != nil {
+			return "", fmt.Errorf("s3: parse arn: %w", err)
+		}
+		if parsed.Service != "s3" {
+			return "", fmt.Errorf("s3: not an s3 arn (service=%q): %w", parsed.Service, ErrNotSupported)
+		}
+		// arn:aws:s3:::<bucket> — Resource = "<bucket>"; reject ARNs
+		// whose Resource carries an object key (contains "/") since
+		// those refer to object identities, not the bucket resource.
+		if parsed.Resource == "" || strings.Contains(parsed.Resource, "/") {
+			return "", fmt.Errorf("s3: arn resource %q is not a bare bucket name: %w", parsed.Resource, ErrNotSupported)
+		}
+		return parsed.Resource, nil
+	}
+	// S3 bucket names: lowercase letters, digits, hyphens, dots; reject
+	// anything obviously malformed.
+	if strings.ContainsAny(id, " :/") {
+		return "", fmt.Errorf("s3: unrecognized id %q: %w", id, ErrNotSupported)
+	}
+	return id, nil
+}

--- a/cmd/insideout-import/awsdiscover/s3_test.go
+++ b/cmd/insideout-import/awsdiscover/s3_test.go
@@ -1,0 +1,152 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+type fakeS3Client struct {
+	listOut *s3.ListBucketsOutput
+	listErr error
+
+	headByName  map[string]bool
+	headErr     error
+	headCalls   []string
+	notFoundTyp string // "NotFound" or "NoSuchBucket" to control which typed error is returned
+}
+
+func (f *fakeS3Client) ListBuckets(_ context.Context, _ *s3.ListBucketsInput, _ ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if f.listOut == nil {
+		return &s3.ListBucketsOutput{}, nil
+	}
+	return f.listOut, nil
+}
+
+func (f *fakeS3Client) HeadBucket(_ context.Context, in *s3.HeadBucketInput, _ ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
+	name := aws.ToString(in.Bucket)
+	f.headCalls = append(f.headCalls, name)
+	if f.headErr != nil {
+		return nil, f.headErr
+	}
+	if f.headByName[name] {
+		return &s3.HeadBucketOutput{}, nil
+	}
+	switch f.notFoundTyp {
+	case "NoSuchBucket":
+		return nil, &s3types.NoSuchBucket{}
+	default:
+		return nil, &s3types.NotFound{}
+	}
+}
+
+func TestS3Discover_FiltersByPrefix(t *testing.T) {
+	t.Parallel()
+	d := &s3Discoverer{new: func() s3Client {
+		return &fakeS3Client{listOut: &s3.ListBucketsOutput{Buckets: []s3types.Bucket{
+			{Name: aws.String("io-foo-uploads")},
+			{Name: aws.String("io-foo-archive")},
+			{Name: aws.String("legacy-data")},
+		}}}
+	}}
+	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (prefix-filtered)", len(got))
+	}
+	if got[0].Identity.NameHint != "io-foo-archive" {
+		t.Errorf("got[0].NameHint=%q (sort order)", got[0].Identity.NameHint)
+	}
+	if got[0].Identity.NativeIDs["arn"] != "arn:aws:s3:::io-foo-archive" {
+		t.Errorf("NativeIDs[arn]=%q", got[0].Identity.NativeIDs["arn"])
+	}
+}
+
+func TestS3Discover_PropagatesError(t *testing.T) {
+	t.Parallel()
+	d := &s3Discoverer{new: func() s3Client {
+		return &fakeS3Client{listErr: errors.New("AccessDenied")}
+	}}
+	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestS3DiscoverByID_AcceptsARN(t *testing.T) {
+	t.Parallel()
+	d := &s3Discoverer{new: func() s3Client {
+		return &fakeS3Client{headByName: map[string]bool{"io-foo-uploads": true}}
+	}}
+	got, err := d.DiscoverByID(context.Background(),
+		"arn:aws:s3:::io-foo-uploads", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.Type != "aws_s3_bucket" {
+		t.Errorf("Type=%q", got.Identity.Type)
+	}
+	if got.Identity.NameHint != "io-foo-uploads" {
+		t.Errorf("NameHint=%q", got.Identity.NameHint)
+	}
+	if got.Identity.NativeIDs["arn"] != "arn:aws:s3:::io-foo-uploads" {
+		t.Errorf("NativeIDs[arn]=%q", got.Identity.NativeIDs["arn"])
+	}
+}
+
+func TestS3DiscoverByID_AcceptsBareName(t *testing.T) {
+	t.Parallel()
+	d := &s3Discoverer{new: func() s3Client {
+		return &fakeS3Client{headByName: map[string]bool{"io-foo-uploads": true}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), "io-foo-uploads", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.NameHint != "io-foo-uploads" {
+		t.Errorf("NameHint=%q", got.Identity.NameHint)
+	}
+}
+
+func TestS3DiscoverByID_NotFoundTyped(t *testing.T) {
+	t.Parallel()
+	for _, typ := range []string{"NotFound", "NoSuchBucket"} {
+		typ := typ
+		t.Run(typ, func(t *testing.T) {
+			t.Parallel()
+			d := &s3Discoverer{new: func() s3Client {
+				return &fakeS3Client{notFoundTyp: typ}
+			}}
+			_, err := d.DiscoverByID(context.Background(), "missing-bucket", "us-east-1", "123")
+			if !errors.Is(err, ErrNotFound) {
+				t.Errorf("typ=%s: err=%v, want ErrNotFound", typ, err)
+			}
+		})
+	}
+}
+
+func TestS3DiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &s3Discoverer{new: func() s3Client { return &fakeS3Client{} }}
+	cases := []string{
+		"",
+		"arn:aws:lambda:us-east-1:123:function:foo",
+		"arn:aws:s3:::a-bucket/object/key",
+		"name with spaces",
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/secretsmanager.go
+++ b/cmd/insideout-import/awsdiscover/secretsmanager.go
@@ -2,10 +2,13 @@ package awsdiscover
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 
@@ -15,6 +18,7 @@ import (
 // smClient is the narrow subset of the Secrets Manager SDK we consume.
 type smClient interface {
 	ListSecrets(ctx context.Context, in *secretsmanager.ListSecretsInput, opts ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error)
+	DescribeSecret(ctx context.Context, in *secretsmanager.DescribeSecretInput, opts ...func(*secretsmanager.Options)) (*secretsmanager.DescribeSecretOutput, error)
 }
 
 type secretsManagerDiscoverer struct {
@@ -87,4 +91,50 @@ func (d *secretsManagerDiscoverer) Discover(ctx context.Context, project, region
 		))
 	}
 	return imps, nil
+}
+
+// DiscoverByID resolves a Secrets Manager secret by ARN or bare name.
+// DescribeSecret accepts either shape natively, so we hand the input to
+// the SDK after a rough validity check.
+func (d *secretsManagerDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return imported.ImportedResource{}, fmt.Errorf("secretsmanager: empty id: %w", ErrNotSupported)
+	}
+	if awsarn.IsARN(id) {
+		parsed, err := awsarn.Parse(id)
+		if err != nil {
+			return imported.ImportedResource{}, fmt.Errorf("secretsmanager: parse arn: %w", err)
+		}
+		if parsed.Service != "secretsmanager" {
+			return imported.ImportedResource{}, fmt.Errorf("secretsmanager: not a secretsmanager arn (service=%q): %w", parsed.Service, ErrNotSupported)
+		}
+		if !strings.HasPrefix(parsed.Resource, "secret:") {
+			return imported.ImportedResource{}, fmt.Errorf("secretsmanager: arn resource %q is not secret:<name>: %w", parsed.Resource, ErrNotSupported)
+		}
+	}
+
+	client := d.new()
+	out, err := client.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{SecretId: aws.String(id)})
+	if err != nil {
+		var notFound *smtypes.ResourceNotFoundException
+		if errors.As(err, &notFound) {
+			return imported.ImportedResource{}, fmt.Errorf("aws_secretsmanager_secret %q: %w", id, ErrNotFound)
+		}
+		return imported.ImportedResource{}, fmt.Errorf("DescribeSecret: %w", err)
+	}
+	name := aws.ToString(out.Name)
+	arn := aws.ToString(out.ARN)
+	if arn == "" && awsarn.IsARN(id) {
+		arn = id
+	}
+	return makeImportedResource(
+		addressBook{},
+		"aws_secretsmanager_secret",
+		name,
+		arn,
+		region,
+		accountID,
+		map[string]string{"arn": arn},
+	), nil
 }

--- a/cmd/insideout-import/awsdiscover/secretsmanager_test.go
+++ b/cmd/insideout-import/awsdiscover/secretsmanager_test.go
@@ -14,6 +14,11 @@ type fakeSMClient struct {
 	pages []secretsmanager.ListSecretsOutput
 	calls []secretsmanager.ListSecretsInput
 	err   error
+
+	// DescribeSecret wiring for DiscoverByID tests.
+	describeByID  map[string]*secretsmanager.DescribeSecretOutput
+	describeErr   error
+	describeCalls []string
 }
 
 func (f *fakeSMClient) ListSecrets(_ context.Context, in *secretsmanager.ListSecretsInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
@@ -26,6 +31,18 @@ func (f *fakeSMClient) ListSecrets(_ context.Context, in *secretsmanager.ListSec
 		return &secretsmanager.ListSecretsOutput{}, nil
 	}
 	return &f.pages[idx], nil
+}
+
+func (f *fakeSMClient) DescribeSecret(_ context.Context, in *secretsmanager.DescribeSecretInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.DescribeSecretOutput, error) {
+	id := aws.ToString(in.SecretId)
+	f.describeCalls = append(f.describeCalls, id)
+	if f.describeErr != nil {
+		return nil, f.describeErr
+	}
+	if out, ok := f.describeByID[id]; ok {
+		return out, nil
+	}
+	return nil, &smtypes.ResourceNotFoundException{}
 }
 
 func TestSecretsManagerDiscover_HappyPath(t *testing.T) {
@@ -133,5 +150,69 @@ func TestSecretsManagerDiscover_PropagatesError(t *testing.T) {
 	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestSecretsManagerDiscoverByID_AcceptsARN(t *testing.T) {
+	t.Parallel()
+	arn := "arn:aws:secretsmanager:us-east-1:123:secret:io-foo/db-AbCdEf"
+	d := &secretsManagerDiscoverer{new: func() smClient {
+		return &fakeSMClient{describeByID: map[string]*secretsmanager.DescribeSecretOutput{
+			arn: {ARN: aws.String(arn), Name: aws.String("io-foo/db")},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), arn, "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.Type != "aws_secretsmanager_secret" {
+		t.Errorf("Type=%q", got.Identity.Type)
+	}
+	if got.Identity.NameHint != "io-foo/db" {
+		t.Errorf("NameHint=%q", got.Identity.NameHint)
+	}
+	if got.Identity.NativeIDs["arn"] != arn {
+		t.Errorf("NativeIDs[arn]=%q, want %q", got.Identity.NativeIDs["arn"], arn)
+	}
+}
+
+func TestSecretsManagerDiscoverByID_AcceptsBareName(t *testing.T) {
+	t.Parallel()
+	d := &secretsManagerDiscoverer{new: func() smClient {
+		return &fakeSMClient{describeByID: map[string]*secretsmanager.DescribeSecretOutput{
+			"io-foo/db": {ARN: aws.String("arn:test"), Name: aws.String("io-foo/db")},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), "io-foo/db", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.NameHint != "io-foo/db" {
+		t.Errorf("NameHint=%q", got.Identity.NameHint)
+	}
+}
+
+func TestSecretsManagerDiscoverByID_NotFound(t *testing.T) {
+	t.Parallel()
+	d := &secretsManagerDiscoverer{new: func() smClient { return &fakeSMClient{} }}
+	_, err := d.DiscoverByID(context.Background(), "missing", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestSecretsManagerDiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &secretsManagerDiscoverer{new: func() smClient { return &fakeSMClient{} }}
+	cases := []string{
+		"",
+		"arn:aws:s3:::a-bucket",
+		"arn:aws:secretsmanager:us-east-1:123:rotation-schedule:io-foo",
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
 	}
 }

--- a/cmd/insideout-import/awsdiscover/sqs.go
+++ b/cmd/insideout-import/awsdiscover/sqs.go
@@ -2,12 +2,16 @@ package awsdiscover
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
@@ -17,6 +21,7 @@ import (
 // at compute.go:123) so tests can mock without the full SDK surface.
 type sqsClient interface {
 	ListQueues(ctx context.Context, in *sqs.ListQueuesInput, opts ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error)
+	GetQueueUrl(ctx context.Context, in *sqs.GetQueueUrlInput, opts ...func(*sqs.Options)) (*sqs.GetQueueUrlOutput, error)
 }
 
 type sqsDiscoverer struct {
@@ -67,6 +72,69 @@ func (d *sqsDiscoverer) Discover(ctx context.Context, project, region, accountID
 		))
 	}
 	return out, nil
+}
+
+// DiscoverByID resolves an SQS queue from a queue URL or ARN. The
+// canonical Terraform import ID for aws_sqs_queue is the queue URL —
+// generated.tf almost always references queues by ARN, so we accept
+// either shape and call GetQueueUrl by name to verify the queue exists.
+func (d *sqsDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	name, err := sqsNameFromID(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
+
+	client := d.new()
+	out, err := client.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{QueueName: aws.String(name)})
+	if err != nil {
+		var notFound *sqstypes.QueueDoesNotExist
+		if errors.As(err, &notFound) {
+			return imported.ImportedResource{}, fmt.Errorf("aws_sqs_queue %q: %w", name, ErrNotFound)
+		}
+		return imported.ImportedResource{}, fmt.Errorf("GetQueueUrl: %w", err)
+	}
+	url := aws.ToString(out.QueueUrl)
+
+	return makeImportedResource(
+		addressBook{},
+		"aws_sqs_queue",
+		name,
+		url,
+		region,
+		accountID,
+		map[string]string{"url": url},
+	), nil
+}
+
+// sqsNameFromID extracts the queue name from one of three accepted inputs:
+// a queue URL (https://sqs.<region>.amazonaws.com/<account>/<name>), an
+// SQS ARN (arn:aws:sqs:<region>:<account>:<name>), or the bare queue
+// name. Anything else returns ErrNotSupported so dep-chase can route it
+// to its unresolvable-warning bucket.
+func sqsNameFromID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("sqs: empty id: %w", ErrNotSupported)
+	}
+	if strings.HasPrefix(id, "https://") || strings.HasPrefix(id, "http://") {
+		return path.Base(id), nil
+	}
+	if awsarn.IsARN(id) {
+		parsed, err := awsarn.Parse(id)
+		if err != nil {
+			return "", fmt.Errorf("sqs: parse arn: %w", err)
+		}
+		if parsed.Service != "sqs" {
+			return "", fmt.Errorf("sqs: not an sqs arn (service=%q): %w", parsed.Service, ErrNotSupported)
+		}
+		// SQS ARN's Resource is the bare queue name (no resource-type prefix).
+		return parsed.Resource, nil
+	}
+	if strings.ContainsAny(id, " :/") {
+		return "", fmt.Errorf("sqs: unrecognized id %q: %w", id, ErrNotSupported)
+	}
+	// Treat as a bare queue name.
+	return id, nil
 }
 
 // paginateListQueues walks all NextToken pages. The SDK's ListQueues call

--- a/cmd/insideout-import/awsdiscover/sqs_test.go
+++ b/cmd/insideout-import/awsdiscover/sqs_test.go
@@ -6,12 +6,18 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 )
 
 type fakeSQSClient struct {
 	pages []sqs.ListQueuesOutput
 	calls []sqs.ListQueuesInput
 	err   error // when non-nil, every ListQueues call returns this
+
+	// GetQueueUrl wiring: tests set getURLByName to control responses.
+	getURLByName map[string]string
+	getURLErr    error // when non-nil, GetQueueUrl returns this
+	getURLCalls  []sqs.GetQueueUrlInput
 }
 
 func (f *fakeSQSClient) ListQueues(_ context.Context, in *sqs.ListQueuesInput, _ ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
@@ -25,6 +31,17 @@ func (f *fakeSQSClient) ListQueues(_ context.Context, in *sqs.ListQueuesInput, _
 		return &sqs.ListQueuesOutput{}, nil
 	}
 	return &f.pages[idx], nil
+}
+
+func (f *fakeSQSClient) GetQueueUrl(_ context.Context, in *sqs.GetQueueUrlInput, _ ...func(*sqs.Options)) (*sqs.GetQueueUrlOutput, error) {
+	f.getURLCalls = append(f.getURLCalls, *in)
+	if f.getURLErr != nil {
+		return nil, f.getURLErr
+	}
+	if url, ok := f.getURLByName[*in.QueueName]; ok {
+		return &sqs.GetQueueUrlOutput{QueueUrl: &url}, nil
+	}
+	return nil, &sqstypes.QueueDoesNotExist{}
 }
 
 func ptr(s string) *string { return &s }
@@ -129,5 +146,72 @@ func TestSQSDiscover_PropagatesError(t *testing.T) {
 	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestSQSDiscoverByID_AcceptsURL(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSQSClient{getURLByName: map[string]string{
+		"io-foo-orders": "https://sqs.us-east-1.amazonaws.com/123/io-foo-orders",
+	}}
+	d := &sqsDiscoverer{new: func() sqsClient { return fake }}
+	got, err := d.DiscoverByID(context.Background(),
+		"https://sqs.us-east-1.amazonaws.com/123/io-foo-orders", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.Type != "aws_sqs_queue" {
+		t.Errorf("Type=%q", got.Identity.Type)
+	}
+	if got.Identity.NameHint != "io-foo-orders" {
+		t.Errorf("NameHint=%q, want io-foo-orders", got.Identity.NameHint)
+	}
+	if got.Identity.NativeIDs["url"] == "" {
+		t.Error("NativeIDs[url] empty")
+	}
+	if len(fake.getURLCalls) != 1 || *fake.getURLCalls[0].QueueName != "io-foo-orders" {
+		t.Errorf("expected one GetQueueUrl call with name=io-foo-orders; got %v", fake.getURLCalls)
+	}
+}
+
+func TestSQSDiscoverByID_AcceptsARN(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSQSClient{getURLByName: map[string]string{
+		"io-foo-orders": "https://sqs.us-east-1.amazonaws.com/123/io-foo-orders",
+	}}
+	d := &sqsDiscoverer{new: func() sqsClient { return fake }}
+	got, err := d.DiscoverByID(context.Background(),
+		"arn:aws:sqs:us-east-1:123:io-foo-orders", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.NameHint != "io-foo-orders" {
+		t.Errorf("NameHint=%q, want io-foo-orders", got.Identity.NameHint)
+	}
+}
+
+func TestSQSDiscoverByID_NotFound(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSQSClient{} // empty getURLByName triggers QueueDoesNotExist
+	d := &sqsDiscoverer{new: func() sqsClient { return fake }}
+	_, err := d.DiscoverByID(context.Background(), "io-foo-missing", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestSQSDiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &sqsDiscoverer{new: func() sqsClient { return &fakeSQSClient{} }}
+	cases := []string{
+		"",
+		"arn:aws:s3:::some-bucket", // wrong service
+		"arn:aws:lambda:us-east-1:123:function:hello", // wrong service
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
 	}
 }

--- a/cmd/insideout-import/depchase/arnparse.go
+++ b/cmd/insideout-import/depchase/arnparse.go
@@ -1,0 +1,111 @@
+// Package depchase walks the cleaned generated.tf, finds ARN-shaped
+// attribute literals that point at resources outside the import set,
+// and re-runs the discover → genconfig → driftfix pipeline over the
+// expanded set until the references converge or a bounded iteration
+// count is hit.
+//
+// Stage 2c3 of the #189 split. Plugs into discover.go between the
+// genconfig and driftfix calls; the orchestrator wraps that pair in
+// the depchase loop so each newly-pulled-in resource is re-processed
+// through the same Stage 2b → Stage 2c1 path as the original import
+// set.
+package depchase
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+)
+
+// ErrUnsupportedType signals an ARN whose service+resource-type does
+// not map to any Terraform type the dep-chase loop knows how to
+// import. The loop converts this into an operator-facing warning so
+// the run can complete with a documented unresolvable reference.
+var ErrUnsupportedType = errors.New("depchase: ARN service/resource-type not mapped to a Terraform type")
+
+// Ref is the resolved (Terraform type, import ID) for an unresolved
+// ARN found in generated.tf. ImportID is the value that aws_<type>'s
+// `terraform import` block expects — typically the raw ARN, sometimes
+// a name or UUID depending on the provider's import semantics.
+type Ref struct {
+	TFType   string
+	ImportID string
+}
+
+// arnKey is the ARN service + leading resource-type segment, e.g.
+// {service: "iam", rtype: "role"} for arn:aws:iam::123:role/foo. S3
+// uses an empty rtype because its ARN format puts the bucket name
+// directly after the third colon (arn:aws:s3:::<bucket>) with no
+// resource-type prefix.
+type arnKey struct {
+	service string
+	rtype   string
+}
+
+// arnTFTypeMap maps ARN service+resource-type to Terraform resource
+// type. The set covers the 9 awsdiscover-supported types (Phase 1 +
+// Stage 2c3). New entries here MUST be paired with a registered
+// discoverer in awsdiscover.NewAWSDiscoverer (the dep-chase loop
+// looks up the discoverer by TFType when a ref is parsed).
+var arnTFTypeMap = map[arnKey]string{
+	// Stage 2c3 reference types (#271).
+	{service: "iam", rtype: "role"}:   "aws_iam_role",
+	{service: "iam", rtype: "policy"}: "aws_iam_policy",
+	{service: "kms", rtype: "key"}:    "aws_kms_key",
+	{service: "kms", rtype: "alias"}:  "aws_kms_key", // alias resolves to underlying key
+	{service: "s3", rtype: ""}:        "aws_s3_bucket",
+	// Phase 1 types (#266) — included so a generated stack referencing
+	// e.g. another lambda's ARN inside a Lambda's destination
+	// configuration can also be chased.
+	{service: "lambda", rtype: "function"}:       "aws_lambda_function",
+	{service: "secretsmanager", rtype: "secret"}: "aws_secretsmanager_secret",
+	{service: "dynamodb", rtype: "table"}:        "aws_dynamodb_table",
+	{service: "logs", rtype: "log-group"}:        "aws_cloudwatch_log_group",
+	{service: "sqs", rtype: ""}:                  "aws_sqs_queue",
+}
+
+// ParseRef extracts the Terraform type and import ID from an ARN
+// string. Returns ErrUnsupportedType for ARN service+resource-type
+// combinations not in arnTFTypeMap (the dep-chase loop converts that
+// into a warning).
+//
+// The input must be a syntactically valid ARN. Non-ARN strings should
+// be filtered out by the finder before reaching ParseRef.
+func ParseRef(s string) (Ref, error) {
+	s = strings.TrimSpace(s)
+	if !awsarn.IsARN(s) {
+		return Ref{}, fmt.Errorf("depchase: %q is not an ARN", s)
+	}
+	parsed, err := awsarn.Parse(s)
+	if err != nil {
+		return Ref{}, fmt.Errorf("depchase: parse arn: %w", err)
+	}
+	rtype, _ := splitResource(parsed.Resource)
+	tf, ok := arnTFTypeMap[arnKey{service: parsed.Service, rtype: rtype}]
+	if !ok {
+		return Ref{}, fmt.Errorf("depchase: %s/%s: %w", parsed.Service, rtype, ErrUnsupportedType)
+	}
+	// Each discoverer's DiscoverByID accepts the raw ARN, so we hand
+	// it through verbatim. Discoverers that need a different shape
+	// (e.g. lambda strips the version qualifier from a function ARN)
+	// do that conversion themselves.
+	return Ref{TFType: tf, ImportID: s}, nil
+}
+
+// splitResource splits an ARN resource portion into a leading
+// resource-type segment and the rest. Three flavors of resource
+// formatting exist in AWS:
+//
+//   - "type/name"     — IAM, S3 (empty type), DynamoDB, KMS
+//   - "type:name"     — Lambda, CloudWatch Logs, Secrets Manager
+//   - bare "name"     — SQS queue name, S3 bucket name
+//
+// Returns ("", resource) when no separator is present.
+func splitResource(resource string) (string, string) {
+	if i := strings.IndexAny(resource, "/:"); i != -1 {
+		return resource[:i], resource[i+1:]
+	}
+	return "", resource
+}

--- a/cmd/insideout-import/depchase/arnparse_test.go
+++ b/cmd/insideout-import/depchase/arnparse_test.go
@@ -1,0 +1,146 @@
+package depchase
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseRef_SupportedTypes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		arn      string
+		wantType string
+	}{
+		{"arn:aws:iam::123:role/io-foo-handler", "aws_iam_role"},
+		{"arn:aws:iam::123:role/service-roles/io-foo", "aws_iam_role"},
+		{"arn:aws:iam::123:policy/io-foo-readonly", "aws_iam_policy"},
+		{"arn:aws:kms:us-east-1:123:key/00000000-0000-0000-0000-000000000000", "aws_kms_key"},
+		{"arn:aws:kms:us-east-1:123:alias/io-foo-data", "aws_kms_key"},
+		{"arn:aws:s3:::io-foo-uploads", "aws_s3_bucket"},
+		{"arn:aws:lambda:us-east-1:123:function:io-foo-handler", "aws_lambda_function"},
+		{"arn:aws:lambda:us-east-1:123:function:io-foo-handler:PROD", "aws_lambda_function"},
+		{"arn:aws:secretsmanager:us-east-1:123:secret:io-foo/db-AbCdEf", "aws_secretsmanager_secret"},
+		{"arn:aws:dynamodb:us-east-1:123:table/io-foo-orders", "aws_dynamodb_table"},
+		{"arn:aws:logs:us-east-1:123:log-group:/aws/lambda/io-foo:*", "aws_cloudwatch_log_group"},
+		{"arn:aws:sqs:us-east-1:123:io-foo-queue", "aws_sqs_queue"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.arn, func(t *testing.T) {
+			t.Parallel()
+			ref, err := ParseRef(tc.arn)
+			if err != nil {
+				t.Fatalf("err=%v", err)
+			}
+			if ref.TFType != tc.wantType {
+				t.Errorf("TFType=%q, want %q", ref.TFType, tc.wantType)
+			}
+			if ref.ImportID != tc.arn {
+				t.Errorf("ImportID=%q, want %q (raw arn)", ref.ImportID, tc.arn)
+			}
+		})
+	}
+}
+
+func TestParseRef_UnsupportedTypes(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"arn:aws:ec2:us-east-1:123:instance/i-abc",      // EC2 not yet supported
+		"arn:aws:rds:us-east-1:123:db:my-db",            // RDS not yet supported
+		"arn:aws:ecs:us-east-1:123:service/cluster/svc", // ECS not yet supported
+		"arn:aws:iam::123:user/me",                      // IAM user not supported
+		"arn:aws:apigateway:us-east-1::/apis/abc",       // API Gateway not supported
+	}
+	for _, arn := range cases {
+		arn := arn
+		t.Run(arn, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseRef(arn)
+			if !errors.Is(err, ErrUnsupportedType) {
+				t.Errorf("err=%v, want ErrUnsupportedType", err)
+			}
+		})
+	}
+}
+
+func TestParseRef_NotAnARN(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"",
+		"not-an-arn",
+		"https://sqs.us-east-1.amazonaws.com/123/io-foo",
+		"io-foo-handler",
+	}
+	for _, s := range cases {
+		s := s
+		t.Run(s, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseRef(s)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			// Non-ARN errors are not ErrUnsupportedType — they're a
+			// bare "not an ARN" string error so the finder can
+			// distinguish them.
+			if errors.Is(err, ErrUnsupportedType) {
+				t.Errorf("err=%v should not match ErrUnsupportedType (non-arn input)", err)
+			}
+		})
+	}
+}
+
+func TestParseRef_PartitionVariants(t *testing.T) {
+	t.Parallel()
+	// Other AWS partitions still parse (gov-cloud, china).
+	cases := []string{
+		"arn:aws-us-gov:iam::123:role/io-foo",
+		"arn:aws-cn:iam::123:role/io-foo",
+	}
+	for _, arn := range cases {
+		ref, err := ParseRef(arn)
+		if err != nil {
+			t.Errorf("arn=%q: err=%v", arn, err)
+			continue
+		}
+		if ref.TFType != "aws_iam_role" {
+			t.Errorf("arn=%q: TFType=%q", arn, ref.TFType)
+		}
+	}
+}
+
+func TestSplitResource(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in       string
+		wantType string
+		wantRest string
+	}{
+		{"role/io-foo", "role", "io-foo"},
+		{"role/service-roles/io-foo", "role", "service-roles/io-foo"},
+		{"function:io-foo:PROD", "function", "io-foo:PROD"},
+		{"log-group:/aws/lambda/io-foo:*", "log-group", "/aws/lambda/io-foo:*"},
+		{"io-foo-bucket", "", "io-foo-bucket"},
+		{"", "", ""},
+	}
+	for _, tc := range cases {
+		gotType, gotRest := splitResource(tc.in)
+		if gotType != tc.wantType || gotRest != tc.wantRest {
+			t.Errorf("splitResource(%q) = (%q, %q); want (%q, %q)",
+				tc.in, gotType, gotRest, tc.wantType, tc.wantRest)
+		}
+	}
+}
+
+// TestArnTFTypeMap_AllValuesNonEmpty pins that no entry in the map
+// accidentally maps to an empty Terraform type. A typo'd entry would
+// silently route ParseRef to a discoverer lookup with empty key and
+// confuse the loop.
+func TestArnTFTypeMap_AllValuesNonEmpty(t *testing.T) {
+	t.Parallel()
+	for k, v := range arnTFTypeMap {
+		if !strings.HasPrefix(v, "aws_") {
+			t.Errorf("key=%v: value=%q does not start with aws_", k, v)
+		}
+	}
+}

--- a/cmd/insideout-import/depchase/depchase.go
+++ b/cmd/insideout-import/depchase/depchase.go
@@ -1,0 +1,289 @@
+package depchase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// DefaultMaxIterations bounds the depchase loop. Five matches
+// driftfix's bound — the realistic case converges in one or two
+// passes (operator's stack references a handful of external IAM/KMS
+// resources; pulling them in produces a stack that's already
+// internally consistent). The bound exists to surface unresolvable
+// configurations as a fatal rather than spinning indefinitely on a
+// reference graph that won't close.
+const DefaultMaxIterations = 5
+
+// ErrCyclicDependency signals that the same set of unresolved
+// references surfaced across two successive iterations after the loop
+// added new resources — i.e. the additions themselves did not change
+// what's unresolved. In a clean stack this never happens; in a
+// pathological one it points at a reference cycle the loop cannot
+// resolve by adding more resources.
+var ErrCyclicDependency = errors.New("depchase: unresolved set stable across iterations (cycle or reference target unreachable via DiscoverByID)")
+
+// ErrMaxIterations signals the bound was hit before the unresolved
+// set drained. The operator-facing message should include the
+// remaining unresolved literals so they can be inspected manually.
+var ErrMaxIterations = errors.New("depchase: max iterations exceeded")
+
+// Discoverer is the per-ID discovery surface depchase needs from the
+// awsdiscover package. The aggregator's DiscoverByID dispatches to
+// the registered per-type discoverer; tests inject a fake.
+type Discoverer interface {
+	DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error)
+}
+
+// PipelineFns are the genconfig + driftfix re-runs depchase calls on
+// each iteration's expanded resource set. The orchestrator passes the
+// production wrappers; tests pass fakes that touch a synthetic
+// generated.tf without standing up terraform.
+type PipelineFns struct {
+	// RunGenconfig regenerates generated.tf from the current resource
+	// set. Receives the current []ImportedResource (the original set
+	// plus everything depchase has added so far) and is expected to
+	// produce the same Workdir+generated.tf shape genconfig.Run would
+	// emit. Returns a Result so the orchestrator can rewrite the
+	// outer manifest with attribute-populated resources.
+	RunGenconfig func(ctx context.Context, resources []imported.ImportedResource) (*GenconfigResult, error)
+	// RunDriftfix runs the drift-fix loop against the regenerated
+	// stack. Receives no input — all state lives in Workdir. Returns
+	// the Iterations count for observability only.
+	RunDriftfix func(ctx context.Context) (*DriftfixResult, error)
+}
+
+// GenconfigResult is the depchase-facing subset of genconfig.Result.
+// Defined here so depchase doesn't import genconfig (which would form
+// a cycle: discover.go imports depchase; depchase would import
+// genconfig; genconfig is also imported by discover.go directly).
+type GenconfigResult struct {
+	GeneratedPath string
+	Resources     []imported.ImportedResource
+}
+
+// DriftfixResult is the depchase-facing subset of driftfix.Result.
+type DriftfixResult struct {
+	GeneratedPath string
+	Iterations    int
+}
+
+// Options is the input to Run. Workdir is the same scratch directory
+// genconfig and driftfix share; depchase reads generated.tf from
+// there and uses Pipeline to regenerate it on each iteration.
+type Options struct {
+	Workdir       string
+	Region        string
+	AccountID     string
+	MaxIterations int
+	Discoverer    Discoverer
+	Pipeline      PipelineFns
+}
+
+// Result is what Run hands back. Resources is the final, expanded
+// set (input + everything pulled in across all iterations).
+// Iterations counts how many times the loop ran the regenerate +
+// re-driftfix cycle (0 means "no unresolved refs on the original
+// stack — nothing to do"). Warnings lists unresolvable / unsupported
+// references the loop chose to surface rather than fail on.
+type Result struct {
+	GeneratedPath string
+	Iterations    int
+	Resources     []imported.ImportedResource
+	Added         []imported.ImportedResource
+	Warnings      []string
+}
+
+// Run is the Stage 2c3 dependency-chase loop:
+//
+//  1. Read the cleaned generated.tf from Workdir.
+//  2. Find ARN-shaped attribute literals not in the resource set.
+//  3. Parse each into (TFType, ImportID); warn on unsupported types.
+//  4. Call Discoverer.DiscoverByID for each new ref; warn on not-found.
+//  5. If anything was added: append to resources, re-run genconfig,
+//     re-run driftfix, GOTO 1.
+//  6. If nothing was added but unresolved set is non-empty: cycle.
+//  7. If unresolved set is empty: return.
+//  8. If iterations exceed MaxIterations: fatal.
+//
+// The "added=0 with unresolved>0" branch is the cycle case. It can
+// fire when (a) the discoverer returns ErrNotSupported / ErrNotFound
+// for every unresolved ref, in which case the loop should warn and
+// not iterate further (we surface this as warnings + clean exit), or
+// (b) the discoverer returns valid resources but their ARN/URL
+// signatures don't match the literals in generated.tf (a cycle in
+// the reference graph). We distinguish (a) from (b) by tracking
+// whether *any* successful discovery happened — if not, every
+// unresolved ref became a warning and the loop exits clean.
+func Run(ctx context.Context, opts Options, resources []imported.ImportedResource) (*Result, error) {
+	if opts.Workdir == "" {
+		return nil, fmt.Errorf("depchase: Workdir required")
+	}
+	if opts.Discoverer == nil {
+		return nil, fmt.Errorf("depchase: Discoverer required")
+	}
+	if opts.Pipeline.RunGenconfig == nil || opts.Pipeline.RunDriftfix == nil {
+		return nil, fmt.Errorf("depchase: Pipeline.RunGenconfig + RunDriftfix required")
+	}
+	if opts.MaxIterations <= 0 {
+		opts.MaxIterations = DefaultMaxIterations
+	}
+
+	abs, err := filepath.Abs(opts.Workdir)
+	if err != nil {
+		return nil, fmt.Errorf("abs workdir: %w", err)
+	}
+	opts.Workdir = abs
+	generatedPath := filepath.Join(opts.Workdir, generatedFile)
+
+	res := &Result{Resources: append([]imported.ImportedResource(nil), resources...)}
+	seenWarning := make(map[string]struct{})
+	var prevUnresolved []string
+
+	for iter := 1; iter <= opts.MaxIterations; iter++ {
+		raw, err := os.ReadFile(generatedPath)
+		if err != nil {
+			return nil, fmt.Errorf("depchase: read generated.tf: %w", err)
+		}
+		unresolved, err := FindUnresolved(raw, res.Resources)
+		if err != nil {
+			return nil, err
+		}
+		if len(unresolved) == 0 {
+			res.GeneratedPath = generatedPath
+			return res, nil
+		}
+
+		// The "no progress" signal: the same unresolved set surfaced
+		// again. We hit this when every ref this iteration's
+		// DiscoverByID call returned ErrNotSupported / ErrNotFound
+		// (i.e. resources is unchanged), or when the loop adds
+		// resources whose ARN signatures don't match the literals.
+		// Either way: warn and stop. (Without this guard the loop
+		// would still terminate via iteration bound, but the error
+		// would be ErrMaxIterations — less actionable than "cycle".)
+		if iter > 1 && reflect.DeepEqual(unresolved, prevUnresolved) {
+			emitUnresolvedAsWarnings(unresolved, res, seenWarning)
+			res.GeneratedPath = generatedPath
+			// If NO resource was ever added and the unresolved set
+			// stabilized at iteration 2, we've simply warned about
+			// every ref — that's a clean exit.
+			if len(res.Added) == 0 {
+				return res, nil
+			}
+			// Otherwise the loop has added resources but the
+			// unresolved set didn't shrink — that's a cycle.
+			return res, fmt.Errorf("%w: %d unresolved refs remain after %d iteration(s) (warnings recorded)",
+				ErrCyclicDependency, len(unresolved), res.Iterations)
+		}
+		prevUnresolved = unresolved
+
+		var newSeeds []seed
+		for _, arn := range unresolved {
+			ref, err := ParseRef(arn)
+			if err != nil {
+				if errors.Is(err, ErrUnsupportedType) {
+					addWarning(res, seenWarning,
+						fmt.Sprintf("unsupported ARN type %q (no Terraform discoverer)", arn))
+					continue
+				}
+				addWarning(res, seenWarning,
+					fmt.Sprintf("could not parse ARN %q: %v", arn, err))
+				continue
+			}
+			newSeeds = append(newSeeds, seed{arn: arn, ref: ref})
+		}
+		// Sort seeds for deterministic discovery order (the discoverer
+		// has no guaranteed ordering on lookups across types/calls).
+		sort.Slice(newSeeds, func(i, j int) bool { return newSeeds[i].arn < newSeeds[j].arn })
+
+		var added []imported.ImportedResource
+		for _, s := range newSeeds {
+			ir, err := opts.Discoverer.DiscoverByID(ctx, s.ref.TFType, s.ref.ImportID, opts.Region, opts.AccountID)
+			if err != nil {
+				switch {
+				case errors.Is(err, awsdiscover.ErrNotFound):
+					addWarning(res, seenWarning,
+						fmt.Sprintf("ARN %q (%s): %v", s.arn, s.ref.TFType, err))
+				case errors.Is(err, awsdiscover.ErrNotSupported):
+					addWarning(res, seenWarning,
+						fmt.Sprintf("ARN %q: %s discoverer rejected ID: %v", s.arn, s.ref.TFType, err))
+				default:
+					return res, fmt.Errorf("DiscoverByID(%s, %s): %w", s.ref.TFType, s.ref.ImportID, err)
+				}
+				continue
+			}
+			added = append(added, ir)
+		}
+
+		if len(added) == 0 {
+			// No new resources — every unresolved ref turned into a
+			// warning. No point regenerating; return clean.
+			res.GeneratedPath = generatedPath
+			return res, nil
+		}
+
+		res.Resources = append(res.Resources, added...)
+		res.Added = append(res.Added, added...)
+		res.Iterations = iter
+
+		gcRes, err := opts.Pipeline.RunGenconfig(ctx, res.Resources)
+		if err != nil {
+			return res, fmt.Errorf("depchase iter %d: regenerate: %w", iter, err)
+		}
+		// Pick up the populated Attributes the regenerate pass wrote
+		// back; the next iteration's FindUnresolved should see them
+		// reflected in the generated.tf re-read.
+		if gcRes != nil && len(gcRes.Resources) > 0 {
+			res.Resources = gcRes.Resources
+		}
+
+		if _, err := opts.Pipeline.RunDriftfix(ctx); err != nil {
+			return res, fmt.Errorf("depchase iter %d: driftfix: %w", iter, err)
+		}
+	}
+
+	// Loop bound exceeded. Surface the residual unresolved set.
+	raw, _ := os.ReadFile(generatedPath)
+	residual, _ := FindUnresolved(raw, res.Resources)
+	res.GeneratedPath = generatedPath
+	return res, fmt.Errorf("%w (%d): %d unresolved ref(s) remain: %v",
+		ErrMaxIterations, opts.MaxIterations, len(residual), residual)
+}
+
+// seed pairs an unresolved ARN string with the parsed Ref so the
+// loop can carry both through to discovery + warning paths.
+type seed struct {
+	arn string
+	ref Ref
+}
+
+// addWarning appends to Warnings if the same message hasn't been
+// emitted before in this run. Dedup is per-message string, not
+// per-ARN, because two ARNs could legitimately produce the same
+// "unsupported ARN type X" warning under their service+rtype.
+func addWarning(res *Result, seen map[string]struct{}, msg string) {
+	if _, ok := seen[msg]; ok {
+		return
+	}
+	seen[msg] = struct{}{}
+	res.Warnings = append(res.Warnings, msg)
+}
+
+// emitUnresolvedAsWarnings is called when the loop detects a stable
+// unresolved set after a no-progress iteration. We surface each
+// remaining literal as a warning so the operator sees what wasn't
+// chased; the caller decides whether to treat the run as success or
+// failure based on whether anything had been successfully added.
+func emitUnresolvedAsWarnings(unresolved []string, res *Result, seen map[string]struct{}) {
+	for _, arn := range unresolved {
+		addWarning(res, seen, fmt.Sprintf("unresolved ARN reference (stable across iterations): %q", arn))
+	}
+}

--- a/cmd/insideout-import/depchase/depchase.go
+++ b/cmd/insideout-import/depchase/depchase.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
+	"slices"
 	"sort"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
@@ -46,13 +46,23 @@ type Discoverer interface {
 // each iteration's expanded resource set. The orchestrator passes the
 // production wrappers; tests pass fakes that touch a synthetic
 // generated.tf without standing up terraform.
+//
+// Contract: RunGenconfig must return a GenconfigResult whose
+// Resources slice is a *superset* of the input — i.e. it may
+// populate Attributes on the input resources or add metadata, but it
+// must not drop entries. Depchase relies on this to keep the
+// resolved-set monotonic across iterations; a regenerate that
+// silently filters resources would let the loop oscillate by
+// re-marking previously resolved ARNs as unresolved.
 type PipelineFns struct {
 	// RunGenconfig regenerates generated.tf from the current resource
 	// set. Receives the current []ImportedResource (the original set
 	// plus everything depchase has added so far) and is expected to
 	// produce the same Workdir+generated.tf shape genconfig.Run would
 	// emit. Returns a Result so the orchestrator can rewrite the
-	// outer manifest with attribute-populated resources.
+	// outer manifest with attribute-populated resources. Per the
+	// PipelineFns contract above, the returned Resources slice must
+	// include every input resource.
 	RunGenconfig func(ctx context.Context, resources []imported.ImportedResource) (*GenconfigResult, error)
 	// RunDriftfix runs the drift-fix loop against the regenerated
 	// stack. Receives no input — all state lives in Workdir. Returns
@@ -129,8 +139,11 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 	if opts.Discoverer == nil {
 		return nil, fmt.Errorf("depchase: Discoverer required")
 	}
-	if opts.Pipeline.RunGenconfig == nil || opts.Pipeline.RunDriftfix == nil {
-		return nil, fmt.Errorf("depchase: Pipeline.RunGenconfig + RunDriftfix required")
+	if opts.Pipeline.RunGenconfig == nil {
+		return nil, fmt.Errorf("depchase: Pipeline.RunGenconfig required")
+	}
+	if opts.Pipeline.RunDriftfix == nil {
+		return nil, fmt.Errorf("depchase: Pipeline.RunDriftfix required")
 	}
 	if opts.MaxIterations <= 0 {
 		opts.MaxIterations = DefaultMaxIterations
@@ -169,7 +182,7 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		// Either way: warn and stop. (Without this guard the loop
 		// would still terminate via iteration bound, but the error
 		// would be ErrMaxIterations — less actionable than "cycle".)
-		if iter > 1 && reflect.DeepEqual(unresolved, prevUnresolved) {
+		if iter > 1 && slices.Equal(unresolved, prevUnresolved) {
 			emitUnresolvedAsWarnings(unresolved, res, seenWarning)
 			res.GeneratedPath = generatedPath
 			// If NO resource was ever added and the unresolved set
@@ -232,7 +245,6 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 
 		res.Resources = append(res.Resources, added...)
 		res.Added = append(res.Added, added...)
-		res.Iterations = iter
 
 		gcRes, err := opts.Pipeline.RunGenconfig(ctx, res.Resources)
 		if err != nil {
@@ -248,6 +260,10 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		if _, err := opts.Pipeline.RunDriftfix(ctx); err != nil {
 			return res, fmt.Errorf("depchase iter %d: driftfix: %w", iter, err)
 		}
+		// Increment only after both pipeline calls succeed so a partial
+		// iteration that fails halfway through doesn't claim a complete
+		// pass to observability output.
+		res.Iterations = iter
 	}
 
 	// Loop bound exceeded. Surface the residual unresolved set.

--- a/cmd/insideout-import/depchase/depchase_test.go
+++ b/cmd/insideout-import/depchase/depchase_test.go
@@ -1,0 +1,397 @@
+package depchase
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// fakeDiscoverer mimics the awsdiscover aggregator's DiscoverByID
+// surface. Callers seed `byID` keyed on tfType|id; `notFound` /
+// `notSupported` slices match against either tfType or id and force
+// the corresponding awsdiscover sentinel error.
+type fakeDiscoverer struct {
+	byID         map[string]imported.ImportedResource
+	notFound     map[string]bool // key = tfType|id
+	notSupported map[string]bool
+	calls        []string
+}
+
+func (f *fakeDiscoverer) DiscoverByID(_ context.Context, tfType, id, _, _ string) (imported.ImportedResource, error) {
+	key := tfType + "|" + id
+	f.calls = append(f.calls, key)
+	if f.notSupported[key] {
+		return imported.ImportedResource{}, awsdiscover.ErrNotSupported
+	}
+	if f.notFound[key] {
+		return imported.ImportedResource{}, awsdiscover.ErrNotFound
+	}
+	if r, ok := f.byID[key]; ok {
+		return r, nil
+	}
+	return imported.ImportedResource{}, awsdiscover.ErrNotFound
+}
+
+func newRes(addr, importID, arn, tfType string) imported.ImportedResource {
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Address:   addr,
+			Type:      tfType,
+			ImportID:  importID,
+			NameHint:  importID,
+			NativeIDs: map[string]string{"arn": arn, "name": importID},
+		},
+	}
+}
+
+// writeGen writes a generated.tf into a temp workdir and returns the
+// directory path. The pipeline fakes use it to model what genconfig
+// would emit on each iteration.
+func writeGen(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, generatedFile), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// scriptedPipeline serves a sequence of generated.tf bodies via
+// RunGenconfig. The first body is the "iteration 0" pre-genconfig
+// state already on disk (written by the test setup); the slice
+// elements correspond to outputs of genconfig.Run AFTER each
+// dep-chase append. The fake updates the workdir's generated.tf so
+// the next FindUnresolved sees it.
+type scriptedPipeline struct {
+	t           *testing.T
+	workdir     string
+	generatedTF []string // slice of generated.tf bodies, one per RunGenconfig call
+	gcCalls     int
+	dfCalls     int
+}
+
+func (p *scriptedPipeline) runGenconfig(_ context.Context, resources []imported.ImportedResource) (*GenconfigResult, error) {
+	if p.gcCalls >= len(p.generatedTF) {
+		p.t.Fatalf("scriptedPipeline: RunGenconfig called %d time(s); only %d body provided", p.gcCalls+1, len(p.generatedTF))
+	}
+	body := p.generatedTF[p.gcCalls]
+	p.gcCalls++
+	if err := os.WriteFile(filepath.Join(p.workdir, generatedFile), []byte(body), 0o644); err != nil {
+		return nil, err
+	}
+	return &GenconfigResult{
+		GeneratedPath: filepath.Join(p.workdir, generatedFile),
+		Resources:     resources,
+	}, nil
+}
+
+func (p *scriptedPipeline) runDriftfix(_ context.Context) (*DriftfixResult, error) {
+	p.dfCalls++
+	return &DriftfixResult{
+		GeneratedPath: filepath.Join(p.workdir, generatedFile),
+		Iterations:    1,
+	}, nil
+}
+
+func (p *scriptedPipeline) fns() PipelineFns {
+	return PipelineFns{RunGenconfig: p.runGenconfig, RunDriftfix: p.runDriftfix}
+}
+
+// TestRun_NoUnresolvedRefsExitsWithoutCallingPipeline pins that the
+// loop is a no-op when generated.tf has no unresolved ARNs — no
+// regenerate, no driftfix, no discover.
+func TestRun_NoUnresolvedRefsExitsWithoutCallingPipeline(t *testing.T) {
+	t.Parallel()
+	dir := writeGen(t, `resource "aws_lambda_function" "h" { function_name = "io-foo-h" }`)
+
+	disc := &fakeDiscoverer{}
+	p := &scriptedPipeline{t: t, workdir: dir} // no scripts — pipeline must not be called
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Discoverer: disc, Pipeline: p.fns(),
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Iterations != 0 {
+		t.Errorf("Iterations=%d, want 0", got.Iterations)
+	}
+	if p.gcCalls != 0 || p.dfCalls != 0 {
+		t.Errorf("pipeline should not be called; gc=%d df=%d", p.gcCalls, p.dfCalls)
+	}
+	if len(disc.calls) != 0 {
+		t.Errorf("discoverer should not be called; got %v", disc.calls)
+	}
+}
+
+// TestRun_SingleDepAddedConvergesAfterOneIteration pins the
+// happy-path: one Lambda references one missing IAM role; iteration
+// 1 pulls in the role, iteration 2 sees the role's ARN in the
+// resolved set and exits clean.
+func TestRun_SingleDepAddedConvergesAfterOneIteration(t *testing.T) {
+	t.Parallel()
+	roleARN := "arn:aws:iam::123:role/io-foo-handler-role"
+	gen0 := `
+resource "aws_lambda_function" "h" {
+  function_name = "io-foo-handler"
+  role          = "` + roleARN + `"
+}`
+	gen1 := gen0 + `
+resource "aws_iam_role" "io_foo_handler_role" {
+  name = "io-foo-handler-role"
+}`
+	dir := writeGen(t, gen0)
+	role := newRes("aws_iam_role.io_foo_handler_role", "io-foo-handler-role", roleARN, "aws_iam_role")
+
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{
+		"aws_iam_role|" + roleARN: role,
+	}}
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{gen1}}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Discoverer: disc, Pipeline: p.fns(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if got.Iterations != 1 {
+		t.Errorf("Iterations=%d, want 1", got.Iterations)
+	}
+	if len(got.Added) != 1 || got.Added[0].Identity.Type != "aws_iam_role" {
+		t.Errorf("Added=%+v, want one aws_iam_role", got.Added)
+	}
+	if len(got.Warnings) != 0 {
+		t.Errorf("Warnings=%v, want none", got.Warnings)
+	}
+}
+
+// TestRun_DepOfDepConvergesAfterTwoIterations pins the chained-dep
+// case: Lambda → IAM role → IAM policy. Three resources end up in
+// the set; the loop converges in 2 iterations.
+func TestRun_DepOfDepConvergesAfterTwoIterations(t *testing.T) {
+	t.Parallel()
+	roleARN := "arn:aws:iam::123:role/io-foo-handler-role"
+	policyARN := "arn:aws:iam::123:policy/io-foo-readonly"
+
+	gen0 := `
+resource "aws_lambda_function" "h" {
+  role = "` + roleARN + `"
+}`
+	gen1 := gen0 + `
+resource "aws_iam_role" "io_foo_handler_role" {
+  name        = "io-foo-handler-role"
+  policy_attr = "` + policyARN + `"
+}`
+	gen2 := gen1 + `
+resource "aws_iam_policy" "io_foo_readonly" {
+  arn = "` + policyARN + `"
+}`
+	dir := writeGen(t, gen0)
+	role := newRes("aws_iam_role.io_foo_handler_role", "io-foo-handler-role", roleARN, "aws_iam_role")
+	policy := newRes("aws_iam_policy.io_foo_readonly", policyARN, policyARN, "aws_iam_policy")
+
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{
+		"aws_iam_role|" + roleARN:     role,
+		"aws_iam_policy|" + policyARN: policy,
+	}}
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{gen1, gen2}}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Discoverer: disc, Pipeline: p.fns(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if got.Iterations != 2 {
+		t.Errorf("Iterations=%d, want 2", got.Iterations)
+	}
+	if len(got.Added) != 2 {
+		t.Errorf("len(Added)=%d, want 2", len(got.Added))
+	}
+}
+
+// TestRun_UnsupportedARNTypeBecomesWarning pins the AC: a generated
+// ARN whose service is not in arnTFTypeMap (e.g. EC2) is surfaced as
+// a warning, not a fatal error, and the loop exits cleanly.
+func TestRun_UnsupportedARNTypeBecomesWarning(t *testing.T) {
+	t.Parallel()
+	gen0 := `
+resource "aws_lambda_function" "h" {
+  vpc_config_subnet = "arn:aws:ec2:us-east-1:123:subnet/subnet-123"
+}`
+	dir := writeGen(t, gen0)
+	disc := &fakeDiscoverer{}
+	p := &scriptedPipeline{t: t, workdir: dir}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Discoverer: disc, Pipeline: p.fns(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("err=%v, want nil (unsupported types are warnings)", err)
+	}
+	if len(got.Warnings) == 0 {
+		t.Error("expected at least one warning for unsupported ARN type")
+	}
+	matched := false
+	for _, w := range got.Warnings {
+		if strings.Contains(w, "unsupported") || strings.Contains(w, "ec2") {
+			matched = true
+		}
+	}
+	if !matched {
+		t.Errorf("Warnings=%v, want one mentioning unsupported / ec2", got.Warnings)
+	}
+}
+
+// TestRun_NotFoundFromDiscovererBecomesWarning pins that a supported
+// ARN whose resource doesn't exist (DiscoverByID returns
+// ErrNotFound) becomes a warning, not a fatal.
+func TestRun_NotFoundFromDiscovererBecomesWarning(t *testing.T) {
+	t.Parallel()
+	roleARN := "arn:aws:iam::123:role/missing-role"
+	gen0 := `
+resource "aws_lambda_function" "h" {
+  role = "` + roleARN + `"
+}`
+	dir := writeGen(t, gen0)
+	disc := &fakeDiscoverer{notFound: map[string]bool{
+		"aws_iam_role|" + roleARN: true,
+	}}
+	p := &scriptedPipeline{t: t, workdir: dir}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Discoverer: disc, Pipeline: p.fns(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("err=%v (ErrNotFound should warn, not fatal)", err)
+	}
+	if len(got.Warnings) == 0 {
+		t.Error("expected warning for ErrNotFound")
+	}
+	if len(got.Added) != 0 {
+		t.Errorf("Added=%+v, want empty", got.Added)
+	}
+}
+
+// TestRun_CyclicDependencyAborts pins the AC cycle case: dep-chase
+// successfully adds a resource, but the unresolved set is identical
+// across iterations because the discovered resource's NativeIDs
+// don't actually cover the literal in generated.tf — adding it
+// didn't shrink what's unresolved. The loop surfaces
+// ErrCyclicDependency rather than spinning to MaxIterations.
+func TestRun_CyclicDependencyAborts(t *testing.T) {
+	t.Parallel()
+	// The literal in generated.tf is `roleARN` but the discoverer
+	// returns a resource whose NativeIDs[arn] is `actualARN` — a
+	// classic ARN-mismatch cycle (alias vs canonical, account-id
+	// disagreement, etc.). Iter 1 adds a resource; iter 2 still
+	// finds the same `roleARN` unresolved, prevUnresolved ==
+	// unresolved, → cycle.
+	roleARN := "arn:aws:iam::123:role/io-foo-handler-role"
+	actualARN := "arn:aws:iam::999:role/io-foo-handler-role" // different account
+	gen0 := `
+resource "aws_lambda_function" "h" {
+  role = "` + roleARN + `"
+}`
+	// Iteration 1 will write gen1 verbatim — the regenerate is a
+	// no-op for the unresolved set since the discovered resource's
+	// arn doesn't match the literal in generated.tf.
+	gen1 := gen0
+	dir := writeGen(t, gen0)
+	role := newRes("aws_iam_role.io_foo_handler_role", "io-foo-handler-role", actualARN, "aws_iam_role")
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{
+		"aws_iam_role|" + roleARN: role, // discoverer keyed on the literal we asked for…
+	}}
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{gen1}}
+
+	res, err := Run(context.Background(), Options{
+		Workdir: dir, Discoverer: disc, Pipeline: p.fns(),
+	}, nil)
+	if !errors.Is(err, ErrCyclicDependency) {
+		t.Fatalf("err=%v, want ErrCyclicDependency", err)
+	}
+	if len(res.Added) == 0 {
+		t.Errorf("Added should be non-empty (the role was successfully pulled in but its arn signature didn't match)")
+	}
+}
+
+// TestRun_MaxIterationsExceeded pins that hitting the iteration
+// bound surfaces ErrMaxIterations when the unresolved set keeps
+// changing (the cycle detector doesn't fire) but never empties.
+func TestRun_MaxIterationsExceeded(t *testing.T) {
+	t.Parallel()
+	// Each iteration introduces a brand-new dangling ARN that the
+	// next iteration's regenerate inherits, so prevUnresolved never
+	// matches curUnresolved and the cycle detector cannot fire — the
+	// MaxIterations bound is the only termination.
+	gen := func(suffix string) string {
+		return `
+resource "aws_lambda_function" "h` + suffix + `" {
+  role = "arn:aws:iam::123:role/role-` + suffix + `"
+}`
+	}
+	dir := writeGen(t, gen("0"))
+
+	// Discoverer returns a synthetic role for every lookup, but the
+	// regenerated stack always has a fresh unresolved ARN.
+	role := func(arn string) imported.ImportedResource {
+		return newRes("aws_iam_role.r", "r", arn, "aws_iam_role")
+	}
+	byID := map[string]imported.ImportedResource{
+		"aws_iam_role|arn:aws:iam::123:role/role-0": role("arn:aws:iam::123:role/role-0"),
+		"aws_iam_role|arn:aws:iam::123:role/role-1": role("arn:aws:iam::123:role/role-1"),
+		"aws_iam_role|arn:aws:iam::123:role/role-2": role("arn:aws:iam::123:role/role-2"),
+		"aws_iam_role|arn:aws:iam::123:role/role-3": role("arn:aws:iam::123:role/role-3"),
+		"aws_iam_role|arn:aws:iam::123:role/role-4": role("arn:aws:iam::123:role/role-4"),
+		"aws_iam_role|arn:aws:iam::123:role/role-5": role("arn:aws:iam::123:role/role-5"),
+		"aws_iam_role|arn:aws:iam::123:role/role-6": role("arn:aws:iam::123:role/role-6"),
+	}
+	disc := &fakeDiscoverer{byID: byID}
+	// Each successive generated.tf points at the next role; because
+	// each new role's NativeIDs[arn] gets added to the resolved set
+	// the previous unresolved ARN goes away — but a NEW one appears
+	// — so prevUnresolved != unresolved each iteration.
+	scripts := []string{gen("1"), gen("2"), gen("3"), gen("4"), gen("5")}
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: scripts}
+
+	_, err := Run(context.Background(), Options{
+		Workdir: dir, Discoverer: disc, Pipeline: p.fns(), MaxIterations: 5,
+	}, nil)
+	if !errors.Is(err, ErrMaxIterations) {
+		t.Errorf("err=%v, want ErrMaxIterations", err)
+	}
+}
+
+// TestRun_RequiresWorkdirAndDeps pins the input validation: missing
+// Workdir, Discoverer, or PipelineFns must fail before any IO.
+func TestRun_RequiresWorkdirAndDeps(t *testing.T) {
+	t.Parallel()
+	disc := &fakeDiscoverer{}
+	good := PipelineFns{
+		RunGenconfig: func(_ context.Context, _ []imported.ImportedResource) (*GenconfigResult, error) { return nil, nil },
+		RunDriftfix:  func(_ context.Context) (*DriftfixResult, error) { return nil, nil },
+	}
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"empty workdir", Options{Discoverer: disc, Pipeline: good}},
+		{"nil discoverer", Options{Workdir: "/tmp", Pipeline: good}},
+		{"nil pipeline runGenconfig", Options{Workdir: "/tmp", Discoverer: disc, Pipeline: PipelineFns{RunDriftfix: good.RunDriftfix}}},
+		{"nil pipeline runDriftfix", Options{Workdir: "/tmp", Discoverer: disc, Pipeline: PipelineFns{RunGenconfig: good.RunGenconfig}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Run(context.Background(), tc.opts, nil)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}

--- a/cmd/insideout-import/depchase/depchase_test.go
+++ b/cmd/insideout-import/depchase/depchase_test.go
@@ -3,6 +3,7 @@ package depchase
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,16 +27,21 @@ type fakeDiscoverer struct {
 func (f *fakeDiscoverer) DiscoverByID(_ context.Context, tfType, id, _, _ string) (imported.ImportedResource, error) {
 	key := tfType + "|" + id
 	f.calls = append(f.calls, key)
+	// Wrap sentinels the same way production discoverers do (e.g.
+	// kms.go, iam_role.go) so the loop's `errors.Is` chain-walk is
+	// exercised — a regression to `err == awsdiscover.ErrNotFound`
+	// would still pass against bare-sentinel returns and silently
+	// break under real wrapped errors.
 	if f.notSupported[key] {
-		return imported.ImportedResource{}, awsdiscover.ErrNotSupported
+		return imported.ImportedResource{}, fmt.Errorf("fake: %s %q rejected: %w", tfType, id, awsdiscover.ErrNotSupported)
 	}
 	if f.notFound[key] {
-		return imported.ImportedResource{}, awsdiscover.ErrNotFound
+		return imported.ImportedResource{}, fmt.Errorf("fake: %s %q: %w", tfType, id, awsdiscover.ErrNotFound)
 	}
 	if r, ok := f.byID[key]; ok {
 		return r, nil
 	}
-	return imported.ImportedResource{}, awsdiscover.ErrNotFound
+	return imported.ImportedResource{}, fmt.Errorf("fake: %s %q: %w", tfType, id, awsdiscover.ErrNotFound)
 }
 
 func newRes(addr, importID, arn, tfType string) imported.ImportedResource {
@@ -221,9 +227,10 @@ resource "aws_iam_policy" "io_foo_readonly" {
 // a warning, not a fatal error, and the loop exits cleanly.
 func TestRun_UnsupportedARNTypeBecomesWarning(t *testing.T) {
 	t.Parallel()
+	subnetARN := "arn:aws:ec2:us-east-1:123:subnet/subnet-123"
 	gen0 := `
 resource "aws_lambda_function" "h" {
-  vpc_config_subnet = "arn:aws:ec2:us-east-1:123:subnet/subnet-123"
+  vpc_config_subnet = "` + subnetARN + `"
 }`
 	dir := writeGen(t, gen0)
 	disc := &fakeDiscoverer{}
@@ -235,23 +242,35 @@ resource "aws_lambda_function" "h" {
 	if err != nil {
 		t.Fatalf("err=%v, want nil (unsupported types are warnings)", err)
 	}
+	if got.Iterations != 0 {
+		t.Errorf("Iterations=%d, want 0 (no resource was added so the regenerate cycle should not run)", got.Iterations)
+	}
+	if len(disc.calls) != 0 {
+		t.Errorf("DiscoverByID should never be called for unsupported ARN types; got calls=%v", disc.calls)
+	}
+	// Strict matcher: production format is "unsupported ARN type %q
+	// (no Terraform discoverer)" — both the ARN literal AND the
+	// "unsupported" word must appear, AND not OR. Loose matcher would
+	// accept "ec2 not yet supported" with no ARN payload.
 	if len(got.Warnings) == 0 {
-		t.Error("expected at least one warning for unsupported ARN type")
+		t.Fatal("expected at least one warning for unsupported ARN type")
 	}
 	matched := false
 	for _, w := range got.Warnings {
-		if strings.Contains(w, "unsupported") || strings.Contains(w, "ec2") {
+		if strings.Contains(w, "unsupported") && strings.Contains(w, subnetARN) {
 			matched = true
 		}
 	}
 	if !matched {
-		t.Errorf("Warnings=%v, want one mentioning unsupported / ec2", got.Warnings)
+		t.Errorf("Warnings=%v, want one containing both \"unsupported\" and the ARN literal %q", got.Warnings, subnetARN)
 	}
 }
 
 // TestRun_NotFoundFromDiscovererBecomesWarning pins that a supported
 // ARN whose resource doesn't exist (DiscoverByID returns
-// ErrNotFound) becomes a warning, not a fatal.
+// ErrNotFound) becomes a warning, not a fatal. The wrapped sentinel
+// must still classify via errors.Is — fakeDiscoverer wraps the
+// sentinel to mirror production discoverers.
 func TestRun_NotFoundFromDiscovererBecomesWarning(t *testing.T) {
 	t.Parallel()
 	roleARN := "arn:aws:iam::123:role/missing-role"
@@ -271,11 +290,73 @@ resource "aws_lambda_function" "h" {
 	if err != nil {
 		t.Fatalf("err=%v (ErrNotFound should warn, not fatal)", err)
 	}
-	if len(got.Warnings) == 0 {
-		t.Error("expected warning for ErrNotFound")
+	if got.Iterations != 0 {
+		t.Errorf("Iterations=%d, want 0 (Added==0, so the regenerate cycle must NOT run)", got.Iterations)
 	}
 	if len(got.Added) != 0 {
 		t.Errorf("Added=%+v, want empty", got.Added)
+	}
+	if len(disc.calls) != 1 || disc.calls[0] != "aws_iam_role|"+roleARN {
+		t.Errorf("DiscoverByID calls=%v, want exactly [aws_iam_role|%s]", disc.calls, roleARN)
+	}
+	// The warning must mention the ARN literal so the operator can
+	// trace it back to generated.tf without grepping. A regression
+	// that emitted a generic "lookup failed" message would survive
+	// without this assertion.
+	if len(got.Warnings) != 1 {
+		t.Fatalf("Warnings=%v, want exactly one", got.Warnings)
+	}
+	w := got.Warnings[0]
+	if !strings.Contains(w, roleARN) {
+		t.Errorf("warning %q must mention the ARN literal %q", w, roleARN)
+	}
+	if !strings.Contains(w, "aws_iam_role") {
+		t.Errorf("warning %q must mention the resource type aws_iam_role", w)
+	}
+}
+
+// TestRun_NotSupportedFromDiscovererBecomesWarning pins the
+// ErrNotSupported branch of DiscoverByID — when the per-type
+// discoverer parses an ARN but rejects the ID shape (e.g. an iam
+// policy ARN whose resource portion is not policy/...), the loop
+// must surface a *distinct* warning vs. ErrNotFound so the operator
+// can tell "the resource doesn't exist" from "the discoverer can't
+// look it up by this ID shape."
+func TestRun_NotSupportedFromDiscovererBecomesWarning(t *testing.T) {
+	t.Parallel()
+	policyARN := "arn:aws:iam::123:policy/io-foo-readonly"
+	gen0 := `
+resource "aws_iam_role" "h" {
+  managed_policy_arns = "` + policyARN + `"
+}`
+	dir := writeGen(t, gen0)
+	disc := &fakeDiscoverer{notSupported: map[string]bool{
+		"aws_iam_policy|" + policyARN: true,
+	}}
+	p := &scriptedPipeline{t: t, workdir: dir}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Discoverer: disc, Pipeline: p.fns(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("err=%v (ErrNotSupported should warn, not fatal)", err)
+	}
+	if got.Iterations != 0 {
+		t.Errorf("Iterations=%d, want 0", got.Iterations)
+	}
+	if len(got.Warnings) != 1 {
+		t.Fatalf("Warnings=%v, want exactly one", got.Warnings)
+	}
+	w := got.Warnings[0]
+	// Production format ("ARN %q: %s discoverer rejected ID: %v") is
+	// distinct from the ErrNotFound format ("ARN %q (%s): %v"). Pin
+	// "rejected" specifically — that's the disambiguator for an
+	// operator triaging an unfamiliar warning.
+	if !strings.Contains(w, "rejected") {
+		t.Errorf("warning %q must contain \"rejected\" to distinguish ErrNotSupported from ErrNotFound", w)
+	}
+	if !strings.Contains(w, policyARN) {
+		t.Errorf("warning %q must mention the ARN literal %q", w, policyARN)
 	}
 }
 
@@ -319,6 +400,22 @@ resource "aws_lambda_function" "h" {
 	if len(res.Added) == 0 {
 		t.Errorf("Added should be non-empty (the role was successfully pulled in but its arn signature didn't match)")
 	}
+	// The cycle-exit branch in depchase.go calls
+	// emitUnresolvedAsWarnings — every remaining literal must surface
+	// so the operator can map the cycle back to generated.tf without
+	// re-reading the on-disk artifact.
+	if len(res.Warnings) == 0 {
+		t.Error("expected at least one warning enumerating the stable unresolved set")
+	}
+	matched := false
+	for _, w := range res.Warnings {
+		if strings.Contains(w, roleARN) {
+			matched = true
+		}
+	}
+	if !matched {
+		t.Errorf("Warnings=%v, want one mentioning the unresolved ARN %q", res.Warnings, roleARN)
+	}
 }
 
 // TestRun_MaxIterationsExceeded pins that hitting the iteration
@@ -360,16 +457,32 @@ resource "aws_lambda_function" "h` + suffix + `" {
 	scripts := []string{gen("1"), gen("2"), gen("3"), gen("4"), gen("5")}
 	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: scripts}
 
-	_, err := Run(context.Background(), Options{
+	res, err := Run(context.Background(), Options{
 		Workdir: dir, Discoverer: disc, Pipeline: p.fns(), MaxIterations: 5,
 	}, nil)
 	if !errors.Is(err, ErrMaxIterations) {
-		t.Errorf("err=%v, want ErrMaxIterations", err)
+		t.Fatalf("err=%v, want ErrMaxIterations", err)
+	}
+	// The bound is 5 → loop must run all 5 iterations, add 5
+	// resources, and call DiscoverByID at least 5 times. A regression
+	// that surfaced ErrMaxIterations on entry without iterating, or
+	// that miscounted res.Iterations, survives without these.
+	if res.Iterations != 5 {
+		t.Errorf("Iterations=%d, want 5 (bound was hit, all iterations should have completed)", res.Iterations)
+	}
+	if len(res.Added) != 5 {
+		t.Errorf("len(Added)=%d, want 5 (one resource added per iteration)", len(res.Added))
+	}
+	if len(disc.calls) < 5 {
+		t.Errorf("DiscoverByID calls=%d, want >= 5 (one lookup per iteration's unresolved ref)", len(disc.calls))
 	}
 }
 
 // TestRun_RequiresWorkdirAndDeps pins the input validation: missing
-// Workdir, Discoverer, or PipelineFns must fail before any IO.
+// Workdir, Discoverer, or PipelineFns must fail before any IO. Each
+// case pins a distinct substring from the error message so a
+// regression that returned the wrong "missing field" name (e.g.
+// reporting "Workdir required" when Discoverer is nil) is caught.
 func TestRun_RequiresWorkdirAndDeps(t *testing.T) {
 	t.Parallel()
 	disc := &fakeDiscoverer{}
@@ -378,19 +491,23 @@ func TestRun_RequiresWorkdirAndDeps(t *testing.T) {
 		RunDriftfix:  func(_ context.Context) (*DriftfixResult, error) { return nil, nil },
 	}
 	cases := []struct {
-		name string
-		opts Options
+		name        string
+		opts        Options
+		errContains string
 	}{
-		{"empty workdir", Options{Discoverer: disc, Pipeline: good}},
-		{"nil discoverer", Options{Workdir: "/tmp", Pipeline: good}},
-		{"nil pipeline runGenconfig", Options{Workdir: "/tmp", Discoverer: disc, Pipeline: PipelineFns{RunDriftfix: good.RunDriftfix}}},
-		{"nil pipeline runDriftfix", Options{Workdir: "/tmp", Discoverer: disc, Pipeline: PipelineFns{RunGenconfig: good.RunGenconfig}}},
+		{"empty workdir", Options{Discoverer: disc, Pipeline: good}, "Workdir"},
+		{"nil discoverer", Options{Workdir: "/tmp", Pipeline: good}, "Discoverer"},
+		{"nil pipeline runGenconfig", Options{Workdir: "/tmp", Discoverer: disc, Pipeline: PipelineFns{RunDriftfix: good.RunDriftfix}}, "RunGenconfig"},
+		{"nil pipeline runDriftfix", Options{Workdir: "/tmp", Discoverer: disc, Pipeline: PipelineFns{RunGenconfig: good.RunGenconfig}}, "RunDriftfix"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := Run(context.Background(), tc.opts, nil)
 			if err == nil {
 				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Errorf("err=%q, want substring %q", err.Error(), tc.errContains)
 			}
 		})
 	}

--- a/cmd/insideout-import/depchase/finder.go
+++ b/cmd/insideout-import/depchase/finder.go
@@ -84,11 +84,22 @@ func collectFromBody(body *hclwrite.Body, resolved map[string]struct{}, out map[
 }
 
 // isARNLiteral is the cheap "is this value worth feeding to ParseRef"
-// test. AWS ARNs always begin with "arn:" — anything else is filtered
-// out before parsing. Trims whitespace defensively but does not
-// validate beyond the prefix; ParseRef does the real validation.
+// test. AWS ARNs are colon-separated and follow
+// `arn:<partition>:<service>:<region>:<account>:<resource>` — six
+// fields, five colons minimum. Pre-filtering to that shape keeps
+// malformed string literals (e.g. `arn:foo`) out of the warnings
+// stream rather than producing a noisy "could not parse ARN"
+// warning per literal per iteration. ParseRef does the real
+// validation; this is just the "worth trying" gate.
 func isARNLiteral(s string) bool {
-	return strings.HasPrefix(strings.TrimSpace(s), "arn:")
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "arn:") {
+		return false
+	}
+	// Count colons cheaply; stdlib `strings.Count` is one allocation-
+	// free pass. The fifth colon may sit inside the resource portion
+	// (e.g. logs `log-group:<name>:*`), so we require AT LEAST 5.
+	return strings.Count(s, ":") >= 5
 }
 
 // buildResolvedSet inverts the in-batch resource list into a set of

--- a/cmd/insideout-import/depchase/finder.go
+++ b/cmd/insideout-import/depchase/finder.go
@@ -1,0 +1,132 @@
+package depchase
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// generatedFile is the conventional filename driftfix and depchase
+// agree on. Mirrors the same constant in genconfig/driftfix so all
+// three subpackages parse the same artifact.
+const generatedFile = "generated.tf"
+
+// FindUnresolved walks the cleaned generated.tf and returns the
+// deterministic-sorted, deduplicated set of ARN-shaped string-literal
+// attribute values that do NOT match any in-batch resource's known
+// identity (ARN/URL/ImportID/NativeIDs).
+//
+// The walker mirrors genconfig/crossref.go's HCL traversal: parse with
+// hclwrite.ParseConfig, iterate `resource` blocks (two-label blocks),
+// inspect each top-level attribute, and consider only pure
+// double-quoted string literals via stringLiteralValue. Anything more
+// complex (interpolations, function calls, lists) is left alone — the
+// dep-chase contract is conservative: only act on values we can be
+// certain are concrete external references.
+//
+// The "resolved set" is built from the same triple that
+// genconfig/crossref.go uses: NativeIDs[arn], NativeIDs[url], and
+// ImportID. A literal that matches any of those is considered
+// in-batch and therefore not unresolved.
+func FindUnresolved(raw []byte, resources []imported.ImportedResource) ([]string, error) {
+	resolved := buildResolvedSet(resources)
+	f, diags := hclwrite.ParseConfig(raw, generatedFile, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("depchase: parse generated.tf: %s", diags.Error())
+	}
+
+	seen := make(map[string]struct{})
+	for _, blk := range f.Body().Blocks() {
+		if blk.Type() != "resource" {
+			continue
+		}
+		if len(blk.Labels()) != 2 {
+			continue
+		}
+		collectFromBody(blk.Body(), resolved, seen)
+	}
+
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// collectFromBody scans every top-level attribute on a body for ARN
+// literals not in the resolved set. Nested blocks (e.g.
+// `environment { variables = {...} }`) are NOT walked: HCL maps and
+// lists of objects rarely contain bare ARN literals at the leaf, and
+// walking them would explode the surface this conservative pass needs
+// to maintain. If a real-world stack lands ARN refs in nested
+// attributes the behavior can be widened in a follow-up.
+func collectFromBody(body *hclwrite.Body, resolved map[string]struct{}, out map[string]struct{}) {
+	for _, attr := range body.Attributes() {
+		lit, ok := stringLiteralValue(attr)
+		if !ok {
+			continue
+		}
+		if !isARNLiteral(lit) {
+			continue
+		}
+		if _, ok := resolved[lit]; ok {
+			continue
+		}
+		out[lit] = struct{}{}
+	}
+}
+
+// isARNLiteral is the cheap "is this value worth feeding to ParseRef"
+// test. AWS ARNs always begin with "arn:" — anything else is filtered
+// out before parsing. Trims whitespace defensively but does not
+// validate beyond the prefix; ParseRef does the real validation.
+func isARNLiteral(s string) bool {
+	return strings.HasPrefix(strings.TrimSpace(s), "arn:")
+}
+
+// buildResolvedSet inverts the in-batch resource list into a set of
+// known identifier strings. Mirrors the inputs to
+// genconfig/crossref.go:buildCrossRefIndex (NativeIDs[arn],
+// NativeIDs[url], ImportID) so dep-chase and crossref agree on what
+// counts as "already in the batch."
+func buildResolvedSet(resources []imported.ImportedResource) map[string]struct{} {
+	set := make(map[string]struct{}, 3*len(resources))
+	for _, r := range resources {
+		if arn := r.Identity.NativeIDs["arn"]; arn != "" {
+			set[arn] = struct{}{}
+		}
+		if url := r.Identity.NativeIDs["url"]; url != "" {
+			set[url] = struct{}{}
+		}
+		if id := r.Identity.ImportID; id != "" {
+			set[id] = struct{}{}
+		}
+	}
+	return set
+}
+
+// stringLiteralValue is a private copy of the helper used in
+// genconfig/crossref.go. Returns the string value of an attribute iff
+// it is a pure double-quoted literal — `"some-value"`. Anything more
+// complex (interpolations, function calls, lists) returns ok=false so
+// the caller leaves it alone.
+func stringLiteralValue(attr *hclwrite.Attribute) (string, bool) {
+	tokens := attr.Expr().BuildTokens(nil)
+	if len(tokens) != 3 {
+		return "", false
+	}
+	if tokens[0].Type != hclsyntax.TokenOQuote || tokens[2].Type != hclsyntax.TokenCQuote {
+		return "", false
+	}
+	if tokens[1].Type != hclsyntax.TokenQuotedLit {
+		return "", false
+	}
+	return string(tokens[1].Bytes), true
+}

--- a/cmd/insideout-import/depchase/finder_test.go
+++ b/cmd/insideout-import/depchase/finder_test.go
@@ -1,0 +1,206 @@
+package depchase
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+func resource(addr, importID string, native map[string]string) imported.ImportedResource {
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Address:   addr,
+			ImportID:  importID,
+			NativeIDs: native,
+		},
+	}
+}
+
+func TestFindUnresolved_ReturnsARNLiteralsNotInBatch(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`
+resource "aws_lambda_function" "io_foo_handler" {
+  function_name = "io-foo-handler"
+  role          = "arn:aws:iam::123:role/io-foo-handler-role"
+  kms_key_arn   = "arn:aws:kms:us-east-1:123:key/uuid-1"
+}
+resource "aws_dynamodb_table" "io_foo_orders" {
+  name = "io-foo-orders"
+}
+`)
+	in := []imported.ImportedResource{
+		resource("aws_lambda_function.io_foo_handler", "io-foo-handler",
+			map[string]string{"arn": "arn:aws:lambda:us-east-1:123:function:io-foo-handler"}),
+		resource("aws_dynamodb_table.io_foo_orders", "io-foo-orders",
+			map[string]string{"arn": "arn:aws:dynamodb:us-east-1:123:table/io-foo-orders"}),
+	}
+	got, err := FindUnresolved(raw, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"arn:aws:iam::123:role/io-foo-handler-role",
+		"arn:aws:kms:us-east-1:123:key/uuid-1",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestFindUnresolved_SkipsResolvedARNs(t *testing.T) {
+	t.Parallel()
+	// Lambda B references Lambda A's ARN — A is in the batch, so the
+	// reference is resolved and not surfaced.
+	raw := []byte(`
+resource "aws_lambda_function" "a" {
+  function_name = "a"
+}
+resource "aws_lambda_function" "b" {
+  function_name = "b"
+  destination   = "arn:aws:lambda:us-east-1:123:function:a"
+}
+`)
+	in := []imported.ImportedResource{
+		resource("aws_lambda_function.a", "a",
+			map[string]string{"arn": "arn:aws:lambda:us-east-1:123:function:a"}),
+		resource("aws_lambda_function.b", "b",
+			map[string]string{"arn": "arn:aws:lambda:us-east-1:123:function:b"}),
+	}
+	got, err := FindUnresolved(raw, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty (Lambda A's ARN is in the resolved set)", got)
+	}
+}
+
+func TestFindUnresolved_DeduplicatesAndSorts(t *testing.T) {
+	t.Parallel()
+	// Two resources both reference the same external IAM role.
+	raw := []byte(`
+resource "aws_lambda_function" "a" {
+  role = "arn:aws:iam::123:role/shared-role"
+}
+resource "aws_lambda_function" "b" {
+  role = "arn:aws:iam::123:role/shared-role"
+}
+resource "aws_lambda_function" "c" {
+  role = "arn:aws:iam::123:role/another-role"
+}
+`)
+	got, err := FindUnresolved(raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"arn:aws:iam::123:role/another-role",
+		"arn:aws:iam::123:role/shared-role",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v (sorted, deduped)", got, want)
+	}
+}
+
+func TestFindUnresolved_IgnoresNonLiteralExpressions(t *testing.T) {
+	t.Parallel()
+	// Interpolations, list values, and references to other resources
+	// should not be treated as unresolved literals — the conservative
+	// finder leaves them alone for genconfig's crossref pass.
+	raw := []byte(`
+resource "aws_lambda_function" "a" {
+  role           = aws_iam_role.handler.arn
+  source_account = "123"
+  layers         = ["arn:aws:lambda:us-east-1:123:layer:x:1"]
+  description    = "see arn:aws:iam::123:role/embedded inside text"
+}
+`)
+	got, err := FindUnresolved(raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty (no top-level pure-literal ARN attrs)", got)
+	}
+}
+
+func TestFindUnresolved_IgnoresNonResourceBlocks(t *testing.T) {
+	t.Parallel()
+	// Provider/terraform/variable blocks must not be walked — only
+	// `resource` blocks. (A `data` block could legitimately reference
+	// an external ARN, but Phase 2 imports do not emit data blocks.)
+	raw := []byte(`
+provider "aws" {
+  region = "arn:aws:iam::123:role/should-not-match"
+}
+data "aws_caller_identity" "current" {}
+variable "external_role" {
+  default = "arn:aws:iam::123:role/from-variable-default"
+}
+`)
+	got, err := FindUnresolved(raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty (only resource blocks are scanned)", got)
+	}
+}
+
+func TestFindUnresolved_NoARNsReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`
+resource "aws_dynamodb_table" "t" {
+  name           = "io-foo-orders"
+  hash_key       = "id"
+  read_capacity  = 5
+  write_capacity = 5
+}
+`)
+	got, err := FindUnresolved(raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func TestFindUnresolved_MalformedHCLErrors(t *testing.T) {
+	t.Parallel()
+	_, err := FindUnresolved([]byte("resource {{{ broken"), nil)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestFindUnresolved_MatchesAgainstURLAndImportID(t *testing.T) {
+	t.Parallel()
+	// SQS queue URL and Lambda function name (ImportID) should also
+	// count as resolved — buildResolvedSet inverts all three (arn,
+	// url, ImportID).
+	raw := []byte(`
+resource "aws_lambda_function" "h" {
+  source = "https://sqs.us-east-1.amazonaws.com/123/io-foo-q"
+  fn     = "io-foo-handler"
+  unresolved = "arn:aws:iam::123:role/external"
+}
+`)
+	in := []imported.ImportedResource{
+		resource("aws_sqs_queue.q", "https://sqs.us-east-1.amazonaws.com/123/io-foo-q",
+			map[string]string{"url": "https://sqs.us-east-1.amazonaws.com/123/io-foo-q"}),
+		resource("aws_lambda_function.h", "io-foo-handler", nil),
+	}
+	got, err := FindUnresolved(raw, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only the IAM role ARN should surface — the URL and bare name
+	// aren't ARN-shaped, so they wouldn't have been collected anyway,
+	// but this test pins the cross-check against the resolved set.
+	want := []string{"arn:aws:iam::123:role/external"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/depchase"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/driftfix"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -40,8 +41,13 @@ const discoverRetryMaxAttempts = 8
 // discoveryAggregator is the small subset of awsdiscover.AWSDiscoverer the
 // orchestrator needs. Defining the interface in main lets tests inject a
 // fake aggregator without standing up real AWS clients.
+//
+// DiscoverByID is part of the contract since Stage 2c3 (#271): the
+// dep-chase loop calls into the aggregator to resolve unresolved ARNs
+// inside generated.tf to fresh ImportedResource entries.
 type discoveryAggregator interface {
 	DiscoverTypes(ctx context.Context, types []string, project, region, accountID string) ([]imported.ImportedResource, error)
+	DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error)
 }
 
 // discoverDeps gathers the AWS-side and terraform-side seams that
@@ -60,6 +66,14 @@ type discoverDeps struct {
 	// runDriftfix drives Stage 2c1. Same shape as runGenconfig: production
 	// shells out, tests fake.
 	runDriftfix func(ctx context.Context, opts driftfix.Options) (*driftfix.Result, error)
+	// runDepChase drives Stage 2c3. Wraps the genconfig→driftfix pair
+	// in a bounded loop that walks the cleaned generated.tf for
+	// unresolved ARNs and pulls them in via the aggregator's
+	// DiscoverByID. Production wires opts.Pipeline to call the same
+	// runGenconfig + runDriftfix functions on each iteration; tests
+	// fake the depchase package directly to exercise the orchestrator
+	// branch without scripting a multi-pass pipeline.
+	runDepChase func(ctx context.Context, opts depchase.Options, resources []imported.ImportedResource) (*depchase.Result, error)
 }
 
 func productionDiscoverDeps() discoverDeps {
@@ -85,6 +99,7 @@ func productionDiscoverDeps() discoverDeps {
 		},
 		runGenconfig: genconfig.Run,
 		runDriftfix:  driftfix.Run,
+		runDepChase:  depchase.Run,
 	}
 }
 
@@ -101,13 +116,23 @@ func runDiscoverWithDeps(args []string, deps discoverDeps) int {
 Usage:
   insideout-import discover --provider aws --project P --region R --output-dir DIR [flags]
 
-Stages 2a + 2b + 2c1 + 2c2: AWS only, SDK-driven discovery for the 5 Phase
-1 resource types (errgroup-bounded fan-out, raised retryer attempt budget),
-terraform plan -generate-config-out + schema cleanup, then a drift-fix loop
-that patches generated.tf until the plan is empty. Pass --no-hcl to skip
-Stage 2b (manifest only) or --no-driftfix to stop after Stage 2b (validate-
-clean but possibly drifting). GCP support, dependency chasing, and a
-localstack CI gate land in Stage 2d (see #189 for the chain).
+Stages 2a + 2b + 2c1–2c3: AWS only, SDK-driven discovery for 9 resource
+types (the 5 Phase 1 types plus IAM role/policy, KMS key, S3 bucket
+added for dep-chase reference resolution), with errgroup-bounded
+fan-out and a raised retryer attempt budget. Stage 2b runs
+terraform plan -generate-config-out + schema cleanup; Stage 2c1
+patches drifting attributes until the plan is empty; Stage 2c3 walks
+the cleaned generated.tf for ARN literals pointing at resources not
+in the import set, pulls those in via per-ID lookups, and re-runs
+the regenerate + drift-fix cycle until the references converge or a
+bounded iteration count is hit.
+
+Pass --no-hcl to skip Stage 2b (manifest only), --no-driftfix to
+stop after Stage 2b (validate-clean but possibly drifting), or
+--no-depchase to stop after Stage 2c1 (drift-fix-converged but
+references to external resources may still drift). GCP support and
+the localstack CI gate land in Stages 2c4 / 2d (see #189 for the
+chain).
 
 Flags:`)
 		fs.PrintDefaults()
@@ -121,9 +146,11 @@ Exit codes:
 	project := fs.String("project", "", "project name prefix used to filter resources (required)")
 	region := fs.String("region", "", "AWS region to scan (required for --provider aws)")
 	outputDir := fs.String("output-dir", "", "directory to write imported.json into (required)")
-	resourceTypes := fs.String("resource-types", "", "comma-separated subset of types to discover; default: all 5 Phase 1 types")
+	resourceTypes := fs.String("resource-types", "", "comma-separated subset of types to discover; default: all 9 supported types")
 	noHCL := fs.Bool("no-hcl", false, "skip Stage 2b HCL generation (terraform plan -generate-config-out + cleanup); leaves imported.json with empty Attributes")
 	noDriftFix := fs.Bool("no-driftfix", false, "skip Stage 2c1 drift fix loop after HCL generation; leaves generated.tf at validate-clean rather than plan-clean")
+	noDepChase := fs.Bool("no-depchase", false, "skip Stage 2c3 dependency chase loop after drift fix; leaves dangling external ARN references in generated.tf as drift")
+	maxDepChaseIter := fs.Int("max-depchase-iterations", depchase.DefaultMaxIterations, "max dependency-chase iterations before surfacing the residual unresolved set as a fatal")
 	maxConcurrency := fs.Int("max-concurrency", awsdiscover.DefaultMaxConcurrency, "max in-flight per-resource AWS API calls inside the DynamoDB and Lambda discoverers; raise on accounts with thousands of resources, lower if the SDK retryer keeps tripping")
 
 	if err := fs.Parse(args); err != nil {
@@ -244,6 +271,81 @@ Exit codes:
 		return discoverExitFatal
 	}
 	fmt.Printf("drift fix converged after %d iteration(s); generated HCL at %s\n", dfRes.Iterations, dfRes.GeneratedPath)
+
+	if *noDepChase {
+		return discoverExitOK
+	}
+
+	// Stage 2c3: walk the cleaned generated.tf for ARN literals
+	// pointing at resources outside the import set; pull each in via
+	// the aggregator's DiscoverByID and re-run genconfig + driftfix
+	// on the expanded set until references converge.
+	//
+	// The pipeline is closed-over here so the depchase package can
+	// invoke the same runGenconfig + runDriftfix functions on each
+	// iteration without taking a dep on either subpackage. After
+	// each successful iteration we rewrite imported.json so the
+	// manifest stays consistent with the on-disk generated.tf.
+	pipeline := depchase.PipelineFns{
+		RunGenconfig: func(ictx context.Context, expanded []imported.ImportedResource) (*depchase.GenconfigResult, error) {
+			r, err := deps.runGenconfig(ictx, genconfig.Options{Workdir: gcWorkdir, Region: *region}, expanded)
+			if err != nil {
+				return nil, err
+			}
+			if _, _, err := writeManifest(*outputDir, "aws", r.Resources); err != nil {
+				return nil, fmt.Errorf("write manifest after depchase regenerate: %w", err)
+			}
+			return &depchase.GenconfigResult{
+				GeneratedPath: r.GeneratedPath,
+				Resources:     r.Resources,
+			}, nil
+		},
+		RunDriftfix: func(ictx context.Context) (*depchase.DriftfixResult, error) {
+			r, err := deps.runDriftfix(ictx, driftfix.Options{Workdir: gcWorkdir})
+			if err != nil {
+				return nil, err
+			}
+			return &depchase.DriftfixResult{
+				GeneratedPath: r.GeneratedPath,
+				Iterations:    r.Iterations,
+			}, nil
+		},
+	}
+	dcRes, err := deps.runDepChase(ctx, depchase.Options{
+		Workdir:       gcWorkdir,
+		Region:        *region,
+		AccountID:     accountID,
+		MaxIterations: *maxDepChaseIter,
+		Discoverer:    d,
+		Pipeline:      pipeline,
+	}, res.Resources)
+	if dcRes != nil {
+		for _, w := range dcRes.Warnings {
+			fmt.Fprintf(os.Stderr, "discover: depchase warning: %s\n", w)
+		}
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "discover: dependency chase: %v\n", err)
+		fmt.Fprintln(os.Stderr, "discover: imported.json + generated.tf are on disk. Re-run with --no-depchase to skip Stage 2c3 explicitly, or raise --max-depchase-iterations and rerun.")
+		return discoverExitFatal
+	}
+	if dcRes == nil {
+		// Defensive: production runDepChase always returns a non-nil
+		// Result on success; a nil-result-with-no-error indicates a
+		// dep injection bug.
+		fmt.Fprintln(os.Stderr, "discover: dep chase returned nil result with no error (programming error)")
+		return discoverExitFatal
+	}
+	if len(dcRes.Added) > 0 {
+		// One last manifest rewrite so any depchase-added resources
+		// land in imported.json with the converged attributes.
+		if _, _, err := writeManifest(*outputDir, "aws", dcRes.Resources); err != nil {
+			fmt.Fprintf(os.Stderr, "discover: write manifest after depchase: %v\n", err)
+			return discoverExitFatal
+		}
+	}
+	fmt.Printf("dep chase converged after %d iteration(s); added %d dependency resource(s); generated HCL at %s\n",
+		dcRes.Iterations, len(dcRes.Added), dcRes.GeneratedPath)
 	return discoverExitOK
 }
 

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -191,6 +191,10 @@ Exit codes:
 		fmt.Fprintf(os.Stderr, "discover: --max-concurrency must be positive (got %d)\n", *maxConcurrency)
 		return discoverExitFatal
 	}
+	if *maxDepChaseIter <= 0 {
+		fmt.Fprintf(os.Stderr, "discover: --max-depchase-iterations must be positive (got %d)\n", *maxDepChaseIter)
+		return discoverExitFatal
+	}
 
 	types := splitCSV(*resourceTypes)
 

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/depchase"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/driftfix"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -83,12 +85,30 @@ type fakeAggregator struct {
 	gotAccount string
 	gotTypes   []string
 	called     int
+
+	// DiscoverByID wiring for Stage 2c3 dep-chase tests. byID is keyed
+	// on tfType|id; missing entries return ErrNotFound.
+	byID      map[string]imported.ImportedResource
+	byIDErr   error
+	byIDCalls []string
 }
 
 func (f *fakeAggregator) DiscoverTypes(_ context.Context, types []string, project, region, accountID string) ([]imported.ImportedResource, error) {
 	f.called++
 	f.gotProject, f.gotRegion, f.gotAccount, f.gotTypes = project, region, accountID, types
 	return f.out, f.err
+}
+
+func (f *fakeAggregator) DiscoverByID(_ context.Context, tfType, id, _, _ string) (imported.ImportedResource, error) {
+	key := tfType + "|" + id
+	f.byIDCalls = append(f.byIDCalls, key)
+	if f.byIDErr != nil {
+		return imported.ImportedResource{}, f.byIDErr
+	}
+	if r, ok := f.byID[key]; ok {
+		return r, nil
+	}
+	return imported.ImportedResource{}, awsdiscover.ErrNotFound
 }
 
 // fakeDriftfix records driftfix invocations so the happy-path tests can
@@ -139,6 +159,17 @@ func (f *fakeGenconfig) Run(_ context.Context, opts genconfig.Options, resources
 	}, nil
 }
 
+// noopDepChase is the test-default for Stage 2c3: returns a clean
+// result with zero iterations and no warnings. Tests that exercise
+// the depchase orchestrator branch override runDepChase directly.
+func noopDepChase(_ context.Context, opts depchase.Options, resources []imported.ImportedResource) (*depchase.Result, error) {
+	return &depchase.Result{
+		GeneratedPath: filepath.Join(opts.Workdir, "generated.tf"),
+		Iterations:    0,
+		Resources:     resources,
+	}, nil
+}
+
 func okDeps(agg *fakeAggregator) discoverDeps {
 	return discoverDeps{
 		loadConfig:    func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
@@ -146,6 +177,7 @@ func okDeps(agg *fakeAggregator) discoverDeps {
 		newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator { return agg },
 		runGenconfig:  (&fakeGenconfig{}).Run,
 		runDriftfix:   (&fakeDriftfix{}).Run,
+		runDepChase:   noopDepChase,
 	}
 }
 
@@ -493,6 +525,210 @@ func TestRunDiscoverWithDeps_NoDriftfixSkipsStage2c(t *testing.T) {
 	}
 	if df.called != 0 {
 		t.Errorf("runDriftfix called %d times with --no-driftfix, want 0", df.called)
+	}
+}
+
+// fakeDepChase records depchase invocations and returns canned
+// results. Mirrors fakeDriftfix's shape — used by tests that need to
+// observe whether Stage 2c3 was reached and how it was invoked.
+type fakeDepChase struct {
+	called  int
+	gotOpts depchase.Options
+	gotIn   []imported.ImportedResource
+	out     *depchase.Result
+	err     error
+}
+
+func (f *fakeDepChase) Run(_ context.Context, opts depchase.Options, resources []imported.ImportedResource) (*depchase.Result, error) {
+	f.called++
+	f.gotOpts = opts
+	f.gotIn = resources
+	if f.err != nil {
+		return f.out, f.err
+	}
+	if f.out != nil {
+		return f.out, nil
+	}
+	return &depchase.Result{
+		GeneratedPath: filepath.Join(opts.Workdir, "generated.tf"),
+		Iterations:    0,
+		Resources:     resources,
+	}, nil
+}
+
+// okDepsWithDC mirrors okDepsWithDF but also lets the caller observe
+// depchase invocations.
+func okDepsWithDC(agg *fakeAggregator, gc *fakeGenconfig, df *fakeDriftfix, dc *fakeDepChase) discoverDeps {
+	d := okDepsWithDF(agg, gc, df)
+	d.runDepChase = dc.Run
+	return d
+}
+
+// TestRunDiscoverWithDeps_DepChaseInvokedAfterDriftfix pins the full
+// Stage 2c1 → 2c3 sequencing on the happy path. Stage 2c3 receives
+// the post-driftfix workdir + the genconfig-attribute-populated
+// resource set + the aggregator (so it can call DiscoverByID on
+// dep-chase iterations).
+func TestRunDiscoverWithDeps_DepChaseInvokedAfterDriftfix(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	gc := &fakeGenconfig{}
+	df := &fakeDriftfix{}
+	dc := &fakeDepChase{}
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+	}, okDepsWithDC(agg, gc, df, dc))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if dc.called != 1 {
+		t.Fatalf("runDepChase called %d times, want 1", dc.called)
+	}
+	if dc.gotOpts.Workdir != filepath.Join(dir, "genconfig") {
+		t.Errorf("depchase Workdir=%q, want <output>/genconfig", dc.gotOpts.Workdir)
+	}
+	if dc.gotOpts.Region != "us-east-1" {
+		t.Errorf("depchase Region=%q, want us-east-1", dc.gotOpts.Region)
+	}
+	if dc.gotOpts.AccountID != "1234567890" {
+		t.Errorf("depchase AccountID=%q", dc.gotOpts.AccountID)
+	}
+	if dc.gotOpts.Discoverer == nil {
+		t.Error("depchase Discoverer must be set (aggregator threaded through)")
+	}
+	if dc.gotOpts.Pipeline.RunGenconfig == nil || dc.gotOpts.Pipeline.RunDriftfix == nil {
+		t.Error("depchase Pipeline.RunGenconfig + RunDriftfix must be set")
+	}
+	if len(dc.gotIn) != 1 || dc.gotIn[0].Identity.Address != "aws_sqs_queue.alpha" {
+		t.Errorf("depchase resources=%+v, want one alpha", dc.gotIn)
+	}
+}
+
+// TestRunDiscoverWithDeps_NoDepChaseSkipsStage2c3 pins --no-depchase.
+// The operator-facing handle to bail out of dep-chase if it's misbehaving.
+func TestRunDiscoverWithDeps_NoDepChaseSkipsStage2c3(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	gc := &fakeGenconfig{}
+	df := &fakeDriftfix{}
+	dc := &fakeDepChase{}
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir, "--no-depchase",
+	}, okDepsWithDC(agg, gc, df, dc))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if dc.called != 0 {
+		t.Errorf("runDepChase called %d times with --no-depchase, want 0", dc.called)
+	}
+	if df.called != 1 {
+		t.Errorf("runDriftfix should still run with --no-depchase; called=%d", df.called)
+	}
+}
+
+// TestRunDiscoverWithDeps_NoDriftfixAlsoSkipsDepChase pins that
+// skipping driftfix necessarily skips dep-chase too — depchase reads
+// the cleaned generated.tf that driftfix produces, so running 2c3
+// without 2c1 would feed it possibly-drifting input.
+func TestRunDiscoverWithDeps_NoDriftfixAlsoSkipsDepChase(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	gc := &fakeGenconfig{}
+	df := &fakeDriftfix{}
+	dc := &fakeDepChase{}
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir, "--no-driftfix",
+	}, okDepsWithDC(agg, gc, df, dc))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if dc.called != 0 {
+		t.Errorf("--no-driftfix must skip dep-chase too; runDepChase called=%d", dc.called)
+	}
+}
+
+// TestRunDiscoverWithDeps_DepChaseFailureExitsFatal pins that a Stage
+// 2c3 failure (cycle, max-iterations exceeded, discoverer SDK error)
+// exits non-zero with a remediation hint pointing at --no-depchase
+// and the on-disk artifacts surviving for inspection.
+func TestRunDiscoverWithDeps_DepChaseFailureExitsFatal(t *testing.T) {
+	dir := t.TempDir()
+	gc := &fakeGenconfig{}
+	df := &fakeDriftfix{}
+	dc := &fakeDepChase{err: depchase.ErrCyclicDependency}
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	stderr := captureStderr(t, func() {
+		rc := runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+		}, okDepsWithDC(agg, gc, df, dc))
+		if rc != discoverExitFatal {
+			t.Errorf("rc=%d, want fatal", rc)
+		}
+	})
+	if !strings.Contains(stderr, "--no-depchase") {
+		t.Errorf("stderr must include the --no-depchase remediation hint; got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "dependency chase") {
+		t.Errorf("stderr must include the failing-stage label; got:\n%s", stderr)
+	}
+}
+
+// TestRunDiscoverWithDeps_DepChaseAddedResourcesRewriteManifest pins
+// that depchase-added resources land in imported.json — without this
+// the manifest would diverge from the on-disk generated.tf.
+func TestRunDiscoverWithDeps_DepChaseAddedResourcesRewriteManifest(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	gc := &fakeGenconfig{}
+	df := &fakeDriftfix{}
+	addedRole := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_iam_role",
+			Address:  "aws_iam_role.dep_role",
+			ImportID: "dep-role",
+			NameHint: "dep-role",
+			NativeIDs: map[string]string{
+				"name": "dep-role",
+				"arn":  "arn:aws:iam::1234567890:role/dep-role",
+			},
+		},
+		Tier:   imported.TierImportedFlat,
+		Source: imported.SourceImporter,
+	}
+	dc := &fakeDepChase{out: &depchase.Result{
+		GeneratedPath: filepath.Join(dir, "genconfig", "generated.tf"),
+		Iterations:    1,
+		Resources:     []imported.ImportedResource{validResource("aws_sqs_queue.alpha"), addedRole},
+		Added:         []imported.ImportedResource{addedRole},
+	}}
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+	}, okDepsWithDC(agg, gc, df, dc))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	// imported.json must include the depchase-added role.
+	body, err := os.ReadFile(filepath.Join(dir, "imported.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []imported.ImportedResource
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	foundRole := false
+	for _, r := range got {
+		if r.Identity.Address == "aws_iam_role.dep_role" {
+			foundRole = true
+		}
+	}
+	if !foundRole {
+		t.Errorf("imported.json should include the depchase-added role; got:\n%s", body)
 	}
 }
 

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -654,6 +654,8 @@ func TestRunDiscoverWithDeps_NoDriftfixAlsoSkipsDepChase(t *testing.T) {
 // 2c3 failure (cycle, max-iterations exceeded, discoverer SDK error)
 // exits non-zero with a remediation hint pointing at --no-depchase
 // and the on-disk artifacts surviving for inspection.
+//
+// NOT t.Parallel(): captures global os.Stderr.
 func TestRunDiscoverWithDeps_DepChaseFailureExitsFatal(t *testing.T) {
 	dir := t.TempDir()
 	gc := &fakeGenconfig{}
@@ -673,6 +675,12 @@ func TestRunDiscoverWithDeps_DepChaseFailureExitsFatal(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "dependency chase") {
 		t.Errorf("stderr must include the failing-stage label; got:\n%s", stderr)
+	}
+	// On-disk artifacts must survive — the docstring contract is
+	// "fail loud, but leave the workdir for inspection." Mirrors the
+	// driftfix-failure test's check of imported.json.
+	if _, err := os.Stat(filepath.Join(dir, "imported.json")); err != nil {
+		t.Errorf("imported.json must survive a depchase failure for inspection: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Stage 2c3 of the `#189` split: closes the gap between "valid HCL" and "zero drift" by walking the cleaned `generated.tf` for ARN literals pointing at resources outside the import set, looking each one up via per-ID discovery, and re-running `genconfig` + `driftfix` until the unresolved set drains, the iteration bound is hit, or a cycle surfaces.
- Extends the `awsdiscover.Discoverer` interface with `DiscoverByID(ctx, id, region, accountID)`. All 5 existing discoverers (sqs, dynamodb, cloudwatchlogs, secretsmanager, lambda) implement it; 4 new discoverers ship in this PR — `aws_iam_role`, `aws_iam_policy`, `aws_kms_key`, `aws_s3_bucket` — bringing the supported set to 9.
- New package `cmd/insideout-import/depchase/` holds the loop (`Run`), the ARN→`(TFType, ImportID)` parser, and the HCL walker that lifts unresolved literals out of `generated.tf`. Sentinel errors `ErrCyclicDependency` and `ErrMaxIterations` distinguish "warn-and-stop" vs "operator must intervene." Sentinels `awsdiscover.ErrNotFound` / `ErrNotSupported` let the loop turn lookup failures into warnings without aborting.
- Wired into `cmd/insideout-import/discover.go` between Stage 2c1 (driftfix) and the manifest write. Two new flags: `--no-depchase` (skip the stage entirely; mirrors `--no-driftfix`) and `--max-depchase-iterations` (default 5).

Closes #271

## Test plan

- [x] `go test ./cmd/insideout-import/depchase/... -count=1` — exercises arnparse (12 supported + 6 unsupported services), finder (HCL walker on 6 generated.tf shapes), loop (no-op / single dep / dep-of-dep / unsupported / not-found / not-supported / cycle / max-iter / option validation)
- [x] `go test ./cmd/insideout-import/awsdiscover/... -count=1` — 9 discoverer types, each with Discover (project-prefix scan) and DiscoverByID (per-ID lookup) green; CWL pagination regression test pins the prefix-collision case
- [x] `go test ./cmd/insideout-import/... -count=1` — full pipeline including the new depchase wrap (success, fatal-exit, --no-depchase, --no-driftfix-implies-no-depchase, manifest-rewrite-with-added-resources)
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- [ ] Manual integration smoke against a dev account (Lambda → IAM role → KMS key dependency chain) — gated on AWS creds, not blocking this PR

## Review notes

- /review findings: P0 none; P1 (CWL DiscoverByID needed pagination) addressed; P2/P3 (alias-arn carryover, isARNLiteral hardening, slices.Equal, Iterations ordering, --max-depchase-iterations validation, PipelineFns contract docs, split nil-checks) addressed
- qa-professor findings: P1 (fakeDiscoverer must wrap sentinels; warning-content + Iterations==0 pins on NotFound/Unsupported branches; MaxIterations test must verify forward progress; RequiresWorkdirAndDeps must distinguish missing fields) addressed; P2 (cycle test must verify warnings emitted; depchase-fatal test must verify on-disk artifacts survive) addressed; P3 promoted (ErrNotSupported DiscoverByID branch was unexercised — added `TestRun_NotSupportedFromDiscovererBecomesWarning`)