### PR TITLE
feat: lift CloudFromKeys + inspect wire types into presets (#276 items 1+2)

### DIFF
--- a/pkg/composer/cloud_test.go
+++ b/pkg/composer/cloud_test.go
@@ -1,0 +1,94 @@
+package composer
+
+import "testing"
+
+// TestCloudFor pins the typed-key cloud derivation. Drive-by addition
+// alongside CloudFromKeys; previously CloudFor's behaviour was only
+// asserted indirectly via iam_actions_test.go, observability_moves_test.go,
+// gcp_services_test.go, and preset_defaults_test.go.
+func TestCloudFor(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		k    ComponentKey
+		want string
+	}{
+		// Standard prefixed keys — the modern naming convention.
+		{"aws_lambda", KeyAWSLambda, "aws"},
+		{"gcp_vpc", KeyGCPVPC, "gcp"},
+		// Legacy polymorphic AWS keys whose string identity predates the
+		// cloud-prefixed vocabulary. The "default-aws" fallback exists
+		// specifically for these — a regression that flipped the default
+		// to "gcp" would mis-route their dispatch.
+		{"legacy resource (EKS control plane / lambda)", KeyAWSEKSControlPlane, "aws"},
+		{"legacy ec2 (EKS node group)", KeyAWSEKSNodeGroup, "aws"},
+		// Empty key — defaults to "aws". Matches the documented behaviour.
+		{"empty key", ComponentKey(""), "aws"},
+		// Adversarial: the contract is "gcp_" prefix INCLUDING the
+		// underscore. A regression flipping the check to `HasPrefix(s,
+		// "gcp")` would mis-route any hypothetical key like "gcps3" or
+		// "gcpus_lambda" to "gcp". No such keys exist today, but the
+		// underscore is part of the wire contract — pin it.
+		{"prefix without underscore is not gcp", ComponentKey("gcps3"), "aws"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := CloudFor(tc.k); got != tc.want {
+				t.Errorf("CloudFor(%q) = %q, want %q", tc.k, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCloudFromKeys pins the slice-shaped sibling of CloudFor used at
+// reliable/mcp-server/server/svc/v2.go:2792 to derive the cloud from a
+// session's selected component-key strings. Covers reliable's
+// TestCloudFromKeys table at v2_test.go:1684 behaviorally — every
+// branch reliable's table exercises (empty, all-aws, all-gcp, mixed,
+// legacy unprefixed) is exercised here too — but is NOT a literal
+// mirror; this table additionally covers nil, the all-empty-strings
+// case, and both mixed-orderings to harden the lifted implementation.
+// The contract pinned is the BEHAVIOR, not the exact fixture set:
+// `gcp` iff any key has the `gcp_` prefix.
+func TestCloudFromKeys(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		keys []string
+		want string
+	}{
+		// Empty / nil — both default to "aws". A regression that returned
+		// "" or "gcp" for the empty case would silently mis-route every
+		// session whose components list is empty.
+		{"nil slice", nil, "aws"},
+		{"empty slice", []string{}, "aws"},
+		// All AWS — uses both the modern "aws_*" prefix and the legacy
+		// "ec2" / "resource" polymorphic keys to confirm neither flips
+		// the cloud.
+		{"all aws prefixed", []string{"aws_lambda", "aws_rds"}, "aws"},
+		{"all aws legacy keys", []string{"resource", "ec2"}, "aws"},
+		// Single GCP key alone or mixed with AWS keys must trigger
+		// "gcp" — the function is "any-gcp wins", not "majority".
+		{"all gcp prefixed", []string{"gcp_vpc", "gcp_cloudsql"}, "gcp"},
+		{"mixed first gcp", []string{"gcp_vpc", "aws_lambda"}, "gcp"},
+		{"mixed first aws then gcp", []string{"aws_lambda", "gcp_vpc"}, "gcp"},
+		// Empty-string key — must not crash; treated as non-gcp so the
+		// slice's other keys decide the cloud.
+		{"empty string key only", []string{""}, "aws"},
+		{"empty string key with gcp", []string{"", "gcp_vpc"}, "gcp"},
+		// Adversarial: the contract is "gcp_" INCLUDING the underscore
+		// (mirror of the TestCloudFor underscore-required row). A
+		// regression flipping the check to `HasPrefix(k, "gcp")` would
+		// mis-route any hypothetical key like "gcps3" to "gcp".
+		{"prefix without underscore is not gcp", []string{"gcps3"}, "aws"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := CloudFromKeys(tc.keys); got != tc.want {
+				t.Errorf("CloudFromKeys(%v) = %q, want %q", tc.keys, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -412,6 +412,22 @@ func CloudFor(k ComponentKey) string {
 	return "aws"
 }
 
+// CloudFromKeys returns the dominant cloud ("aws" or "gcp") for a slice
+// of component keys. Returns "gcp" if any key carries the "gcp_" prefix,
+// otherwise "aws". Mirrors CloudFor's bias toward "aws" for legacy
+// non-prefixed keys (KeyAWSEKSNodeGroup="ec2",
+// KeyAWSEKSControlPlane="resource"). Use this when only string keys are
+// in hand — e.g. derived from a session's selected components — and the
+// typed ComponentKey form isn't available.
+func CloudFromKeys(keys []string) string {
+	for _, k := range keys {
+		if strings.HasPrefix(k, "gcp_") {
+			return "gcp"
+		}
+	}
+	return "aws"
+}
+
 // AllComponentKeys lists every ComponentKey backed by a preset module in
 // this repo. It is the source of truth for tests that need to exercise
 // every component the mapper might touch — TestMapperKeysSubsetOfModule

--- a/pkg/observability/inspect/types.go
+++ b/pkg/observability/inspect/types.go
@@ -1,0 +1,85 @@
+// Package inspect holds the wire envelope types for the
+// /api/v2/aws/inspect/batch and /api/v2/gcp/inspect/batch endpoints.
+// The types are the canonical contract between the Vercel-hosted
+// reliable handlers and the MCP server (currently
+// luthersystems/reliable/mcp-server/, future
+// luthersystems/insideout-agent-skills).
+//
+// JSON shapes are wire-stable. Changing a field name or json tag is a
+// wire-breaking change and requires coordinated rollout across the
+// reliable handler and every MCP-server callsite. Tests in
+// types_test.go pin the exact json tags and `omitempty` semantics so
+// drift surfaces at unit-test time rather than at HTTP-decode time.
+//
+// The dispatcher (InspectAWSBatch / InspectGCPBatch + bounded fan-out)
+// currently lives in reliable/internal/agentapi/ and lifts to
+// pkg/observability/discovery/{aws,gcp}/ in a follow-up PR (#276
+// Item 3). Until then this package owns only the wire types and any
+// constants that are truly part of the wire contract (MaxBatchSubs).
+package inspect
+
+// MaxBatchSubs caps the number of sub-probes per batch request. The
+// dispatcher rejects requests with len(Subs) > MaxBatchSubs. The
+// number is wire-coupled — both the client (MCP server / reliable
+// HTTP handler) and the server (batch dispatcher) read this same
+// constant, so changing it requires coordinated rollout.
+const MaxBatchSubs = 32
+
+// SubRequest is one probe within a batch. Service is a registry name
+// recognized by pkg/observability/service_actions.go's AWSServiceNames
+// or GCPServiceNames; Action is a registry-defined verb. Filters
+// carries arbitrary JSON the per-service handler interprets — left
+// empty for actions that need no filter.
+//
+// Detail / raw flags are deliberately NOT exposed: batch always
+// returns summarized results. Callers needing detail or raw output
+// should use the singular awsinspect / gcpinspect tools.
+type SubRequest struct {
+	Service string `json:"service"`
+	Action  string `json:"action"`
+	Filters string `json:"filters,omitempty"`
+}
+
+// SubResult is one probe's outcome. Index pins the result back to the
+// SubRequest at the same index in the original Subs slice — the
+// fan-out dispatcher may complete out of order. OK is true iff Error
+// is empty; Result is set iff OK is true; Error is set iff OK is
+// false. DurationMS captures the per-probe latency in milliseconds
+// and is always emitted (even when zero) for observability.
+type SubResult struct {
+	Index      int    `json:"index"`
+	Service    string `json:"service"`
+	Action     string `json:"action"`
+	OK         bool   `json:"ok"`
+	Result     any    `json:"result,omitempty"`
+	Error      string `json:"error,omitempty"`
+	DurationMS int64  `json:"duration_ms"`
+}
+
+// BatchRequest is the wire envelope for both
+// POST /api/v2/aws/inspect/batch and POST /api/v2/gcp/inspect/batch.
+// SessionID identifies the calling reliable session; the dispatcher
+// resolves it to credentials + project context (via reliable's
+// session DB + Oracle credential broker today, via injected
+// credential-provider interfaces once #276 Item 3 lifts the
+// dispatcher).
+//
+// A single shape covers both clouds because the request shape is
+// cloud-agnostic — the route the request lands on (`/aws/...` vs
+// `/gcp/...`) carries the cloud selection. Reliable's legacy
+// AWSInspectBatchRequest / GCPInspectBatchRequest are aliases for
+// this same struct shape; the lift to a single canonical type is
+// part of the #276 cleanup.
+type BatchRequest struct {
+	SessionID string       `json:"session_id"`
+	Subs      []SubRequest `json:"subs"`
+}
+
+// BatchResponse is the wire envelope returned by the same two
+// endpoints. OK is the AND of every Result.OK (i.e. true iff every
+// sub-probe succeeded). Results is index-aligned with the original
+// Subs slice: Results[i].Index == i.
+type BatchResponse struct {
+	OK      bool        `json:"ok"`
+	Results []SubResult `json:"results"`
+}

--- a/pkg/observability/inspect/types.go
+++ b/pkg/observability/inspect/types.go
@@ -67,18 +67,28 @@ type SubResult struct {
 // A single shape covers both clouds because the request shape is
 // cloud-agnostic — the route the request lands on (`/aws/...` vs
 // `/gcp/...`) carries the cloud selection. Reliable's legacy
-// AWSInspectBatchRequest / GCPInspectBatchRequest are aliases for
-// this same struct shape; the lift to a single canonical type is
-// part of the #276 cleanup.
+// AWSInspectBatchRequest / GCPInspectBatchRequest are
+// structurally-identical types (NOT Go aliases — separate named
+// declarations with the same fields and json tags); collapsing them
+// into a single canonical BatchRequest is part of the #276 cleanup.
 type BatchRequest struct {
 	SessionID string       `json:"session_id"`
 	Subs      []SubRequest `json:"subs"`
 }
 
 // BatchResponse is the wire envelope returned by the same two
-// endpoints. OK is the AND of every Result.OK (i.e. true iff every
-// sub-probe succeeded). Results is index-aligned with the original
-// Subs slice: Results[i].Index == i.
+// endpoints. OK is the HTTP-envelope success bit — true iff the
+// dispatcher itself ran to completion (HTTP 200 path). Per-sub
+// success/failure is encoded in Results[i].OK and Results[i].Error,
+// NOT aggregated into this outer OK. This matches the legacy
+// reliable dispatcher semantics
+// (reliable/internal/agentapi/{aws,gcp}_inspect_batch.go:
+// `writeJSON(w, http.StatusOK, ...{OK: true, Results: results})`):
+// a partial-failure batch (some Results[i].OK == false) still
+// returns outer OK == true.
+//
+// Results is index-aligned with the original Subs slice:
+// Results[i].Index == i.
 type BatchResponse struct {
 	OK      bool        `json:"ok"`
 	Results []SubResult `json:"results"`

--- a/pkg/observability/inspect/types_test.go
+++ b/pkg/observability/inspect/types_test.go
@@ -1,0 +1,335 @@
+package inspect
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestMaxBatchSubs pins the wire-coupled batch ceiling. Both the MCP
+// client and the reliable batch dispatcher read this constant; a
+// careless edit that desync'd it from the dispatcher's reject-threshold
+// would silently drop or accept oversized batches.
+func TestMaxBatchSubs(t *testing.T) {
+	t.Parallel()
+	if MaxBatchSubs != 32 {
+		t.Errorf("MaxBatchSubs = %d, want 32 (wire-coupled to reliable's batch dispatcher and MCP-server payload check)", MaxBatchSubs)
+	}
+}
+
+// TestSubRequest_JSONShape pins every json tag and `omitempty` rule on
+// SubRequest. Reliable's HTTP handler decodes against this exact shape;
+// any drift here breaks the wire contract.
+func TestSubRequest_JSONShape(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   SubRequest
+		want string
+	}{
+		{
+			name: "every field populated",
+			in:   SubRequest{Service: "lambda", Action: "list-functions", Filters: `{"prefix":"io-"}`},
+			want: `{"service":"lambda","action":"list-functions","filters":"{\"prefix\":\"io-\"}"}`,
+		},
+		{
+			// Filters has `omitempty` — empty string must be omitted, not
+			// serialized as `"filters":""`. A regression dropping the
+			// omitempty would inflate every batch payload by ~14 bytes
+			// per sub and could trip strict-mode JSON decoders.
+			name: "empty filters omitted",
+			in:   SubRequest{Service: "ec2", Action: "list-instances"},
+			want: `{"service":"ec2","action":"list-instances"}`,
+		},
+		{
+			// HTML-significant ASCII (`<`, `>`, `&`) must serialize as
+			// `<` / `>` / `&` — Go's encoding/json
+			// `SetEscapeHTML` defaults to true and reliable's HTTP
+			// handler decodes against the escaped form. A regression
+			// that flipped to `SetEscapeHTML(false)` (e.g. via a
+			// custom encoder) would emit raw `<&>` and break any
+			// downstream consumer that round-trips the payload
+			// through HTML-bearing transports. Pin the escaped form
+			// so the drift surfaces here rather than at the network
+			// layer.
+			name: "html-significant ascii is escaped",
+			in:   SubRequest{Service: "ec2", Action: "list-instances", Filters: `{"q":"a<b&c>d"}`},
+			// The `<` / `&` / `>` literals here are six
+			// real characters each (a backslash + u + 4 hex digits) —
+			// that's what Go's json.Marshal emits when SetEscapeHTML
+			// is true (the default). DO NOT collapse to literal `<` /
+			// `&` / `>` — that's a different wire format.
+			want: "{\"service\":\"ec2\",\"action\":\"list-instances\",\"filters\":\"{\\\"q\\\":\\\"a\\u003cb\\u0026c\\u003ed\\\"}\"}",
+		},
+		{
+			// Non-ASCII codepoints (UTF-8) pass through verbatim — Go
+			// does NOT escape them. Pin so a regression that added a
+			// blanket `\u`-escaping pass would break non-Latin filter
+			// payloads at the wire and surface as a noisy round-trip
+			// equality failure.
+			name: "unicode passes through verbatim",
+			in:   SubRequest{Service: "kms", Action: "list-aliases", Filters: `{"alias":"日本語"}`},
+			want: `{"service":"kms","action":"list-aliases","filters":"{\"alias\":\"日本語\"}"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(tc.in)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("Marshal(%+v)\n  got = %s\n want = %s", tc.in, got, tc.want)
+			}
+			// Round-trip pin: decoding the marshaled bytes must
+			// yield the original struct. NOTE: this catches encoder
+			// drift (a regression that produced output the decoder
+			// can't parse), but it does NOT catch case-only tag
+			// changes — Go's json decoder is case-insensitive by
+			// default, so flipping `json:"service"` to
+			// `json:"Service"` would still round-trip cleanly. The
+			// byte-equal Marshal check above is what guards against
+			// that; the round-trip is supplementary protection
+			// against decoder-side drift.
+			var rt SubRequest
+			if err := json.Unmarshal(got, &rt); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if rt != tc.in {
+				t.Errorf("round-trip mismatch:\n  got = %+v\n want = %+v", rt, tc.in)
+			}
+		})
+	}
+}
+
+// TestSubResult_JSONShape pins the response wire format. The
+// `omitempty` and "always emit" choices here are load-bearing:
+// observability tooling reads `duration_ms` even on healthy zero-ms
+// probes; analytics counts `error` presence to compute success rates.
+func TestSubResult_JSONShape(t *testing.T) {
+	t.Parallel()
+	t.Run("success result with payload", func(t *testing.T) {
+		t.Parallel()
+		// Use a map because SubResult.Result is `any` — Go's MarshalJSON
+		// of a typed struct would serialize differently. The dispatcher
+		// always returns the inner result as decoded JSON (map / slice
+		// / scalar), so map is the realistic shape.
+		in := SubResult{
+			Index:      3,
+			Service:    "lambda",
+			Action:     "list-functions",
+			OK:         true,
+			Result:     map[string]any{"functions": []any{"io-handler"}},
+			DurationMS: 142,
+		}
+		got, err := json.Marshal(in)
+		if err != nil {
+			t.Fatalf("Marshal success path: %v", err)
+		}
+		want := `{"index":3,"service":"lambda","action":"list-functions","ok":true,"result":{"functions":["io-handler"]},"duration_ms":142}`
+		if string(got) != want {
+			t.Errorf("\n  got = %s\n want = %s", got, want)
+		}
+		// "error" must NOT appear when empty — a regression that
+		// dropped omitempty would emit `"error":""` and break analytics
+		// that count error-presence.
+		if strings.Contains(string(got), `"error"`) {
+			t.Errorf("error field must be omitted when empty; got %s", got)
+		}
+	})
+	t.Run("error result without payload", func(t *testing.T) {
+		t.Parallel()
+		in := SubResult{
+			Index:      0,
+			Service:    "ec2",
+			Action:     "list-instances",
+			OK:         false,
+			Error:      "throttling",
+			DurationMS: 5,
+		}
+		got, err := json.Marshal(in)
+		if err != nil {
+			t.Fatalf("Marshal error path: %v", err)
+		}
+		want := `{"index":0,"service":"ec2","action":"list-instances","ok":false,"error":"throttling","duration_ms":5}`
+		if string(got) != want {
+			t.Errorf("\n  got = %s\n want = %s", got, want)
+		}
+		// "result" must NOT appear as `null` — for `Result any`
+		// with `omitempty`, only nil (or unset) collapses to
+		// omitted. NOTE: an empty composite wrapped in `any` (e.g.
+		// `Result: []any{}` or `Result: map[string]any{}`) does
+		// NOT collapse — it serializes as `"result":[]` or
+		// `"result":{}`. The empty-list-success shape is pinned in
+		// the next subtest.
+		if strings.Contains(string(got), `"result"`) {
+			t.Errorf("result field must be omitted on error path; got %s", got)
+		}
+	})
+	t.Run("success result with empty list payload", func(t *testing.T) {
+		t.Parallel()
+		// Pins the empty-list success shape — e.g. `list-buckets`
+		// returning zero buckets. `Result any` with `omitempty`
+		// only omits nil; a non-nil-empty composite must serialize
+		// as `[]` or `{}`. This is the load-bearing wire shape for
+		// the #255 nil-vs-empty-slice rule (see
+		// pkg/observability/discovery/CONTRIBUTING.md): the
+		// dispatcher returns a non-nil empty slice so downstream
+		// consumers can distinguish "no results" from "field
+		// missing".
+		in := SubResult{
+			Index:      2,
+			Service:    "s3",
+			Action:     "list-buckets",
+			OK:         true,
+			Result:     []any{},
+			DurationMS: 8,
+		}
+		got, err := json.Marshal(in)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		want := `{"index":2,"service":"s3","action":"list-buckets","ok":true,"result":[],"duration_ms":8}`
+		if string(got) != want {
+			t.Errorf("\n  got = %s\n want = %s", got, want)
+		}
+	})
+	t.Run("zero duration is emitted", func(t *testing.T) {
+		t.Parallel()
+		// duration_ms is documented as always-emitted (no omitempty).
+		// A fast probe that legitimately measures 0ms must still carry
+		// the field so observability dashboards can distinguish "0ms
+		// fast probe" from "field missing / dispatcher bug." Pin
+		// byte-equal — strictly stronger than `Contains` because it
+		// also catches an accidental `omitempty` on `OK`, a tag
+		// rename anywhere on the success-zero path, or field
+		// reordering.
+		in := SubResult{Index: 1, Service: "s3", Action: "list-buckets", OK: true, DurationMS: 0}
+		got, err := json.Marshal(in)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		want := `{"index":1,"service":"s3","action":"list-buckets","ok":true,"duration_ms":0}`
+		if string(got) != want {
+			t.Errorf("\n  got = %s\n want = %s", got, want)
+		}
+	})
+}
+
+// TestBatchRequest_RoundTripJSON pins the batch request envelope. The
+// outer shape is what the HTTP handler decodes off the request body.
+func TestBatchRequest_RoundTripJSON(t *testing.T) {
+	t.Parallel()
+	in := BatchRequest{
+		SessionID: "sess_abc123",
+		Subs: []SubRequest{
+			{Service: "lambda", Action: "list-functions"},
+			{Service: "ec2", Action: "list-instances", Filters: `{"vpc":"vpc-1"}`},
+		},
+	}
+	first, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("BatchRequest first Marshal: %v", err)
+	}
+	want := `{"session_id":"sess_abc123","subs":[{"service":"lambda","action":"list-functions"},{"service":"ec2","action":"list-instances","filters":"{\"vpc\":\"vpc-1\"}"}]}`
+	if string(first) != want {
+		t.Errorf("first marshal:\n  got = %s\n want = %s", first, want)
+	}
+	// Encode → decode → encode and confirm byte-equal. Catches
+	// regressions where the encoder normalizes representation but the
+	// decoder doesn't reverse it.
+	var rt BatchRequest
+	if err := json.Unmarshal(first, &rt); err != nil {
+		t.Fatalf("BatchRequest Unmarshal: %v", err)
+	}
+	second, err := json.Marshal(rt)
+	if err != nil {
+		t.Fatalf("BatchRequest second Marshal: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("round-trip drift:\n  first  = %s\n second = %s", first, second)
+	}
+}
+
+// TestBatchResponse_RoundTripJSON pins the batch response envelope.
+// MCP-server callers decode against this exact shape; any tag drift
+// would silently break their result rendering.
+func TestBatchResponse_RoundTripJSON(t *testing.T) {
+	t.Parallel()
+	in := BatchResponse{
+		OK: true,
+		Results: []SubResult{
+			{Index: 0, Service: "lambda", Action: "list-functions", OK: true, Result: []any{"io-handler"}, DurationMS: 12},
+			{Index: 1, Service: "ec2", Action: "list-instances", OK: false, Error: "throttling", DurationMS: 5},
+		},
+	}
+	first, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("BatchResponse first Marshal: %v", err)
+	}
+	want := `{"ok":true,"results":[{"index":0,"service":"lambda","action":"list-functions","ok":true,"result":["io-handler"],"duration_ms":12},{"index":1,"service":"ec2","action":"list-instances","ok":false,"error":"throttling","duration_ms":5}]}`
+	if string(first) != want {
+		t.Errorf("first marshal:\n  got = %s\n want = %s", first, want)
+	}
+	var rt BatchResponse
+	if err := json.Unmarshal(first, &rt); err != nil {
+		t.Fatalf("BatchResponse Unmarshal: %v", err)
+	}
+	second, err := json.Marshal(rt)
+	if err != nil {
+		t.Fatalf("BatchResponse second Marshal: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("round-trip drift:\n  first  = %s\n second = %s", first, second)
+	}
+}
+
+// TestBatchResponse_ResultsShape pins both shapes the encoder can emit
+// for the Results field — the safe `[]` (initialized empty slice) and
+// the unsafe `null` (nil slice). The MCP-server renderer iterates
+// Results unconditionally, so a JSON null would cause a nil-deref or
+// silent zero-iteration. The struct field has no `omitempty`, so:
+//
+//	Results: []SubResult{} → "results":[]    (safe)
+//	Results: nil           → "results":null  (unsafe)
+//
+// The dispatcher's contract is to always initialize Results to a
+// non-nil empty slice before responding. This test pins the OUTPUT
+// shapes both paths produce so a future dispatcher author who returns
+// a nil slice sees the unsafe-sentinel case fail and knows to
+// initialize. (Same nil-vs-empty rule the discovery package enforces
+// in pkg/observability/discovery/CONTRIBUTING.md per #255.)
+func TestBatchResponse_ResultsShape(t *testing.T) {
+	t.Parallel()
+	t.Run("empty slice serializes as array", func(t *testing.T) {
+		t.Parallel()
+		in := BatchResponse{OK: true, Results: []SubResult{}}
+		got, err := json.Marshal(in)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		want := `{"ok":true,"results":[]}`
+		if string(got) != want {
+			t.Errorf("\n  got = %s\n want = %s", got, want)
+		}
+	})
+	t.Run("nil slice serializes as null sentinel", func(t *testing.T) {
+		t.Parallel()
+		// SENTINEL — pin the unsafe shape so a future dispatcher
+		// author (or anyone changing the struct definition) sees the
+		// distinction. If we ever add `omitempty` to Results, OR
+		// switch to a slice type that defaults non-nil, this test
+		// fails and forces a deliberate decision rather than a
+		// silent change.
+		in := BatchResponse{OK: true, Results: nil}
+		got, err := json.Marshal(in)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		want := `{"ok":true,"results":null}`
+		if string(got) != want {
+			t.Errorf("\n  got = %s\n want = %s\n  (dispatcher must avoid this shape — initialize Results to []SubResult{} before responding)", got, want)
+		}
+	})
+}

--- a/pkg/observability/inspect/types_test.go
+++ b/pkg/observability/inspect/types_test.go
@@ -111,10 +111,9 @@ func TestSubResult_JSONShape(t *testing.T) {
 	t.Parallel()
 	t.Run("success result with payload", func(t *testing.T) {
 		t.Parallel()
-		// Use a map because SubResult.Result is `any` — Go's MarshalJSON
-		// of a typed struct would serialize differently. The dispatcher
-		// always returns the inner result as decoded JSON (map / slice
-		// / scalar), so map is the realistic shape.
+		// The dispatcher returns inner results as decoded JSON (map /
+		// slice / scalar after `json.Unmarshal` into `any`), so a
+		// map is the realistic shape — not a typed Go struct.
 		in := SubResult{
 			Index:      3,
 			Service:    "lambda",
@@ -282,6 +281,52 @@ func TestBatchResponse_RoundTripJSON(t *testing.T) {
 	}
 	if string(first) != string(second) {
 		t.Errorf("round-trip drift:\n  first  = %s\n second = %s", first, second)
+	}
+}
+
+// TestBatchResponse_OKIsHTTPEnvelopeNotAggregate pins the documented
+// semantics of the outer OK field: it is the HTTP-envelope success
+// bit, not an aggregate over Results[i].OK. Reliable's existing
+// dispatchers (aws_inspect_batch.go:101, gcp_inspect_batch.go:76)
+// always set outer OK=true on HTTP 200 even when some sub-probes
+// failed. The doc on BatchResponse pins this explicitly; this test
+// pins that the struct can in fact represent the
+// "outer-OK-true-with-failed-sub" shape — a regression that flipped
+// outer OK to an aggregate would not break this test directly (the
+// aggregation would happen at the dispatcher), but encoding the
+// shape here documents the contract in code so a future dispatcher
+// author building against this type sees the canonical example.
+func TestBatchResponse_OKIsHTTPEnvelopeNotAggregate(t *testing.T) {
+	t.Parallel()
+	in := BatchResponse{
+		OK: true, // dispatcher ran to completion
+		Results: []SubResult{
+			{Index: 0, Service: "lambda", Action: "list-functions", OK: true, Result: []any{}, DurationMS: 10},
+			{Index: 1, Service: "ec2", Action: "list-instances", OK: false, Error: "throttling", DurationMS: 5},
+		},
+	}
+	got, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// The mixed-success batch must serialize with outer OK=true and
+	// per-sub OK reflecting individual outcomes.
+	want := `{"ok":true,"results":[{"index":0,"service":"lambda","action":"list-functions","ok":true,"result":[],"duration_ms":10},{"index":1,"service":"ec2","action":"list-instances","ok":false,"error":"throttling","duration_ms":5}]}`
+	if string(got) != want {
+		t.Errorf("\n  got = %s\n want = %s", got, want)
+	}
+	// Decode and assert outer OK is independent of inner OKs — pins
+	// that the type does not enforce an aggregate constraint at the
+	// data-model layer.
+	var rt BatchResponse
+	if err := json.Unmarshal(got, &rt); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !rt.OK {
+		t.Error("outer OK must remain true on decode despite a failed sub-probe")
+	}
+	if rt.Results[1].OK {
+		t.Error("Results[1].OK must remain false on decode")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Lifts `models.CloudFromKeys([]string) string` from `reliable/internal/models/` to `composer.CloudFromKeys` in this repo, sitting next to the existing `CloudFor(ComponentKey)`. Verbatim copy; reliable's `mcp-server/server/svc/v2.go` switchover lands in `reliable#1308` Phase 1.
- Adds new `pkg/observability/inspect/` package with the wire envelope types for `/api/v2/{aws,gcp}/inspect/batch`: `SubRequest`, `SubResult`, `BatchRequest`, `BatchResponse`, `MaxBatchSubs`. Byte-equal to reliable's `internal/agentapi/inspect_batch_common.go` + the per-cloud batch envelopes (collapsed to a single cloud-agnostic shape per the issue spec).
- Drive-by: dedicated unit tests for `CloudFor` (previously pinned only indirectly by four other test files).

Item 3 of the Epic (~1500 LOC of dispatcher logic + doc-render) follows in a separate PR with proper interface design (creds-provider / project-resolver / drift-reporter seams) — those are too tangled with reliable's DB / Oracle / drift / auth plumbing for a clean lift today.

Refs #276

## Test plan

- [x] `go test ./pkg/composer/... ./pkg/observability/inspect/... -count=1 -v` — all new tests green; existing composer tests still green
- [x] `go test ./... -count=1` — full repo green, no regressions
- [x] `go build ./...`, `go vet ./...`, `gofmt -l pkg/` — clean
- [ ] Wire format byte-equal verification: capture `curl` output of `/api/v2/aws/inspect/batch` against staging before/after the reliable switchover lands (Acceptance criterion from #276; gated on reliable#1308 Phase 1)

## Review notes

- /review findings: P0 none; P1 (the html-escape rationale comment was wrong; byte-mirror parity claim was overstated; `omitempty` on `any` empty-composite was imprecise) addressed; P2 (zero-duration weak `Contains` → byte-equal; round-trip case-insensitive limitation; underscore-required adversarial coverage on both cloud helpers) addressed; P3 (rename `NilResultsDoesNotEmitNull` → `ResultsShape` with both safe + sentinel subtests; standardize `t.Fatal(err)` → `t.Fatalf` with context) addressed
- qa-professor findings: same as above (the /review pass and qa-professor pass surfaced overlapping findings on the test files)