### PR TITLE
feat(insideout-import): localstack CI gate proving zero-drift (#272)

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -281,11 +281,12 @@ jobs:
   # End-to-end LocalStack-backed assertion of the discover orchestrator's
   # zero-drift contract (Stage 2c4 / #272). Spins LocalStack as a service
   # container, applies tests/testdata/localstack-seed/ to populate it
-  # with one of each of the 9 supported AWS resource types, then runs
-  # `insideout-import discover --aws-endpoint-url ...` against it and
-  # asserts `terraform plan -detailed-exitcode == 0` on the generated
-  # stack. Without this, the orchestrator's plan-clean exit-code contract
-  # is documented-only — same gap PR #58's QA flagged as P0.
+  # with one of each of 8 supported AWS resource types (SQS is excluded
+  # — see seed's main.tf header for the LocalStack URL-shape reason),
+  # then runs `insideout-import discover --aws-endpoint-url ...` against
+  # it and asserts terraform plan-clean post-import. Without this, the
+  # orchestrator's plan-clean exit-code contract is documented-only —
+  # same gap PR #58's QA flagged as P0.
   localstack-discover-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -278,6 +278,53 @@ jobs:
           terraform_version: "1.7.5"
       - run: go test -race ./...
 
+  # End-to-end LocalStack-backed assertion of the discover orchestrator's
+  # zero-drift contract (Stage 2c4 / #272). Spins LocalStack as a service
+  # container, applies tests/testdata/localstack-seed/ to populate it
+  # with one of each of the 9 supported AWS resource types, then runs
+  # `insideout-import discover --aws-endpoint-url ...` against it and
+  # asserts `terraform plan -detailed-exitcode == 0` on the generated
+  # stack. Without this, the orchestrator's plan-clean exit-code contract
+  # is documented-only — same gap PR #58's QA flagged as P0.
+  localstack-discover-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      localstack:
+        image: localstack/localstack:4
+        ports:
+          - 4566:4566
+        # docker.sock mount is required for the seed's Lambda function:
+        # LocalStack 4 spawns a real Docker container per Lambda runtime
+        # to validate the deployment package, and reaches Docker via the
+        # host socket. Without this mount, terraform apply on the seed
+        # fails with `Error while creating lambda: Docker not available`.
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+        env:
+          SERVICES: lambda,dynamodb,logs,secretsmanager,sqs,iam,kms,s3,sts
+          DEFAULT_REGION: us-east-1
+        options: >-
+          --health-cmd "curl -f http://localhost:4566/_localstack/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 18
+    env:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+      AWS_DEFAULT_REGION: us-east-1
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5"
+      - run: bash tests/localstack-discover-gate.sh
+
   # Re-runs cmd/imported-codegen against the committed filtered schemas
   # and fails if doing so produces a diff in pkg/composer/imported/generated
   # or schemas/. Catches stale generated output from a forgotten regen
@@ -307,6 +354,7 @@ jobs:
       - go-build
       - go-vet
       - go-test
+      - localstack-discover-gate
       - verify-gen
       - verify-phantom-schema
       - tflint

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -152,6 +152,7 @@ Exit codes:
 	noDepChase := fs.Bool("no-depchase", false, "skip Stage 2c3 dependency chase loop after drift fix; leaves dangling external ARN references in generated.tf as drift")
 	maxDepChaseIter := fs.Int("max-depchase-iterations", depchase.DefaultMaxIterations, "max dependency-chase iterations before surfacing the residual unresolved set as a fatal")
 	maxConcurrency := fs.Int("max-concurrency", awsdiscover.DefaultMaxConcurrency, "max in-flight per-resource AWS API calls inside the DynamoDB and Lambda discoverers; raise on accounts with thousands of resources, lower if the SDK retryer keeps tripping")
+	awsEndpointURL := fs.String("aws-endpoint-url", "", "override the AWS endpoint URL for both SDK and terraform provider; intended for the Stage 2c4 LocalStack-backed CI gate (#272) — pass http://localhost:4566 to retarget every service at LocalStack. Empty (default) uses real AWS.")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -198,6 +199,20 @@ Exit codes:
 
 	types := splitCSV(*resourceTypes)
 
+	// SDK side of the LocalStack endpoint override. aws-sdk-go-v2's
+	// LoadDefaultConfig honors AWS_ENDPOINT_URL natively (since v1.27),
+	// and the env-var path covers every per-service client built off the
+	// shared aws.Config without retro-fitting BaseEndpoint into nine
+	// constructors. Set before deps.loadConfig so the production loader
+	// picks it up; tests that inject a fake loadConfig observe the env
+	// var directly.
+	if *awsEndpointURL != "" {
+		if err := os.Setenv("AWS_ENDPOINT_URL", *awsEndpointURL); err != nil {
+			fmt.Fprintf(os.Stderr, "discover: set AWS_ENDPOINT_URL: %v\n", err)
+			return discoverExitFatal
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), discoverTimeout)
 	defer cancel()
 
@@ -242,8 +257,9 @@ Exit codes:
 	// inside output-dir so cleanup is the operator's choice, not ours.
 	gcWorkdir := filepath.Join(*outputDir, "genconfig")
 	res, err := deps.runGenconfig(ctx, genconfig.Options{
-		Workdir: gcWorkdir,
-		Region:  *region,
+		Workdir:        gcWorkdir,
+		Region:         *region,
+		AWSEndpointURL: *awsEndpointURL,
 	}, resources)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "discover: HCL generation: %v\n", err)
@@ -292,7 +308,11 @@ Exit codes:
 	// manifest stays consistent with the on-disk generated.tf.
 	pipeline := depchase.PipelineFns{
 		RunGenconfig: func(ictx context.Context, expanded []imported.ImportedResource) (*depchase.GenconfigResult, error) {
-			r, err := deps.runGenconfig(ictx, genconfig.Options{Workdir: gcWorkdir, Region: *region}, expanded)
+			r, err := deps.runGenconfig(ictx, genconfig.Options{
+				Workdir:        gcWorkdir,
+				Region:         *region,
+				AWSEndpointURL: *awsEndpointURL,
+			}, expanded)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -56,7 +56,14 @@ type discoveryAggregator interface {
 // branches (validator failure, DiscoverTypes error, nil STS account, HCL
 // generation failure) without real AWS credentials or a terraform binary.
 type discoverDeps struct {
-	loadConfig    func(ctx context.Context, region string) (aws.Config, error)
+	// loadConfig builds the aws.Config the orchestrator hands to every
+	// per-service discoverer. The endpointURL parameter is the
+	// --aws-endpoint-url flag value: empty for real AWS, non-empty to
+	// route every SDK client at LocalStack (Stage 2c4 / #272). Empty
+	// preserves whatever AWS_ENDPOINT_URL the caller's shell has set, so
+	// operators using AWS-compatible endpoints unrelated to this gate
+	// keep working unchanged.
+	loadConfig    func(ctx context.Context, region, endpointURL string) (aws.Config, error)
 	getAccount    func(ctx context.Context, cfg aws.Config) (string, error)
 	newDiscoverer func(cfg aws.Config, maxConcurrency int) discoveryAggregator
 	// runGenconfig drives Stage 2b. The default shells out to the
@@ -78,11 +85,15 @@ type discoverDeps struct {
 
 func productionDiscoverDeps() discoverDeps {
 	return discoverDeps{
-		loadConfig: func(ctx context.Context, region string) (aws.Config, error) {
-			return config.LoadDefaultConfig(ctx,
+		loadConfig: func(ctx context.Context, region, endpointURL string) (aws.Config, error) {
+			opts := []func(*config.LoadOptions) error{
 				config.WithRegion(region),
 				config.WithRetryMaxAttempts(discoverRetryMaxAttempts),
-			)
+			}
+			if endpointURL != "" {
+				opts = append(opts, config.WithBaseEndpoint(endpointURL))
+			}
+			return config.LoadDefaultConfig(ctx, opts...)
 		},
 		getAccount: func(ctx context.Context, cfg aws.Config) (string, error) {
 			out, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
@@ -199,24 +210,10 @@ Exit codes:
 
 	types := splitCSV(*resourceTypes)
 
-	// SDK side of the LocalStack endpoint override. aws-sdk-go-v2's
-	// LoadDefaultConfig honors AWS_ENDPOINT_URL natively (since v1.27),
-	// and the env-var path covers every per-service client built off the
-	// shared aws.Config without retro-fitting BaseEndpoint into nine
-	// constructors. Set before deps.loadConfig so the production loader
-	// picks it up; tests that inject a fake loadConfig observe the env
-	// var directly.
-	if *awsEndpointURL != "" {
-		if err := os.Setenv("AWS_ENDPOINT_URL", *awsEndpointURL); err != nil {
-			fmt.Fprintf(os.Stderr, "discover: set AWS_ENDPOINT_URL: %v\n", err)
-			return discoverExitFatal
-		}
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), discoverTimeout)
 	defer cancel()
 
-	cfg, err := deps.loadConfig(ctx, *region)
+	cfg, err := deps.loadConfig(ctx, *region, *awsEndpointURL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "discover: load AWS config: %v\n", err)
 		return discoverExitFatal

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/depchase"
@@ -172,7 +174,7 @@ func noopDepChase(_ context.Context, opts depchase.Options, resources []imported
 
 func okDeps(agg *fakeAggregator) discoverDeps {
 	return discoverDeps{
-		loadConfig:    func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		loadConfig:    func(_ context.Context, _, _ string) (aws.Config, error) { return aws.Config{}, nil },
 		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "1234567890", nil },
 		newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator { return agg },
 		runGenconfig:  (&fakeGenconfig{}).Run,
@@ -237,7 +239,7 @@ func TestRunDiscoverWithDeps_LoadConfigFails(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	deps := discoverDeps{
-		loadConfig: func(_ context.Context, _ string) (aws.Config, error) {
+		loadConfig: func(_ context.Context, _, _ string) (aws.Config, error) {
 			return aws.Config{}, errors.New("env unreadable")
 		},
 		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { t.Fatal("should not be called"); return "", nil },
@@ -258,7 +260,7 @@ func TestRunDiscoverWithDeps_STSFails(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	deps := discoverDeps{
-		loadConfig:    func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		loadConfig:    func(_ context.Context, _, _ string) (aws.Config, error) { return aws.Config{}, nil },
 		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "", errors.New("AccessDenied") },
 		newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator { t.Fatal("should not be called"); return nil },
 	}
@@ -280,7 +282,7 @@ func TestRunDiscoverWithDeps_NilSTSAccountThreadsEmpty(t *testing.T) {
 	dir := t.TempDir()
 	agg := &fakeAggregator{}
 	deps := discoverDeps{
-		loadConfig:    func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		loadConfig:    func(_ context.Context, _, _ string) (aws.Config, error) { return aws.Config{}, nil },
 		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "", nil }, // success but empty account
 		newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator { return agg },
 	}
@@ -843,7 +845,7 @@ func TestRunDiscoverWithDeps_DefaultMaxConcurrencyThreaded(t *testing.T) {
 	agg := &fakeAggregator{}
 	var gotMax int
 	deps := discoverDeps{
-		loadConfig: func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		loadConfig: func(_ context.Context, _, _ string) (aws.Config, error) { return aws.Config{}, nil },
 		getAccount: func(_ context.Context, _ aws.Config) (string, error) { return "1234567890", nil },
 		newDiscoverer: func(_ aws.Config, max int) discoveryAggregator {
 			gotMax = max
@@ -871,7 +873,7 @@ func TestRunDiscoverWithDeps_MaxConcurrencyOverride(t *testing.T) {
 	agg := &fakeAggregator{}
 	var gotMax int
 	deps := discoverDeps{
-		loadConfig: func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		loadConfig: func(_ context.Context, _, _ string) (aws.Config, error) { return aws.Config{}, nil },
 		getAccount: func(_ context.Context, _ aws.Config) (string, error) { return "1234567890", nil },
 		newDiscoverer: func(_ aws.Config, max int) discoveryAggregator {
 			gotMax = max
@@ -901,7 +903,7 @@ func TestRunDiscoverWithDeps_MaxConcurrencyRejectsNonPositive(t *testing.T) {
 	for _, n := range []string{"0", "-1"} {
 		dir := t.TempDir()
 		deps := discoverDeps{
-			loadConfig: func(_ context.Context, _ string) (aws.Config, error) { return aws.Config{}, nil },
+			loadConfig: func(_ context.Context, _, _ string) (aws.Config, error) { return aws.Config{}, nil },
 			getAccount: func(_ context.Context, _ aws.Config) (string, error) { return "1", nil },
 			newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator {
 				t.Fatalf("n=%s: newDiscoverer must not run when --max-concurrency invalid", n)
@@ -931,7 +933,7 @@ func TestRunDiscoverWithDeps_MaxConcurrencyRejectsNonPositive(t *testing.T) {
 func TestProductionDiscoverDeps_LoadConfigSetsRetryMaxAttempts(t *testing.T) {
 	t.Parallel()
 	deps := productionDiscoverDeps()
-	cfg, err := deps.loadConfig(context.Background(), "us-east-1")
+	cfg, err := deps.loadConfig(context.Background(), "us-east-1", "")
 	if err != nil {
 		t.Fatalf("loadConfig: %v (the WithRetryMaxAttempts option is applied independent of credential resolution; an err here means LoadDefaultConfig failed for an unrelated reason that needs investigating)", err)
 	}
@@ -940,83 +942,161 @@ func TestProductionDiscoverDeps_LoadConfigSetsRetryMaxAttempts(t *testing.T) {
 	}
 }
 
-// TestRunDiscoverWithDeps_AWSEndpointURLThreaded pins the Stage 2c4 (#272)
-// LocalStack flag wiring on both sides of the seam:
-//   - genconfig.Options.AWSEndpointURL receives the flag value (so the
-//     emitted providers.tf points at LocalStack via emitProviders).
-//   - The AWS_ENDPOINT_URL env var is set before deps.loadConfig fires,
-//     so production loadConfig (and every per-service SDK client built
-//     off the resulting aws.Config) routes API calls to the same URL.
+// TestProductionDiscoverDeps_LoadConfigBaseEndpoint pins how the
+// endpointURL parameter reaches aws.Config.BaseEndpoint across the
+// flag/env precedence matrix that the orchestrator-level table test
+// (TestRunDiscoverWithDeps_AWSEndpointURLWiresFlagToBothSeams) only
+// exercises with a fake loader. The Stage 2c4 LocalStack gate (#272)
+// depends on this being threaded through every per-service SDK client
+// built off the shared aws.Config.
 //
-// Both branches matter: a regression that drops env-var setting would
-// produce HCL pointing at LocalStack while the discoverers still hit
-// real AWS, silently emptying the manifest. The reverse breaks
-// terraform plan against an unmocked endpoint.
-func TestRunDiscoverWithDeps_AWSEndpointURLThreaded(t *testing.T) {
-	dir := t.TempDir()
-	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.q")}}
-	gc := &fakeGenconfig{}
-
-	// Snapshot the env var observed at loadConfig time. t.Setenv handles
-	// cleanup so the value doesn't leak into other tests; production
-	// loadConfig fires only after runDiscoverWithDeps's setenv, so an
-	// initial value of "" is the contract under test.
-	t.Setenv("AWS_ENDPOINT_URL", "")
-	var loadConfigSawEnv string
-	deps := discoverDeps{
-		loadConfig: func(_ context.Context, _ string) (aws.Config, error) {
-			loadConfigSawEnv = os.Getenv("AWS_ENDPOINT_URL")
-			return aws.Config{}, nil
+// The "garbage URL" case is intentional: this layer is a thin wrapper
+// over LoadDefaultConfig and inherits its threading semantics — it
+// does NOT validate the URL. That contract is locked here so a future
+// "helpful" refactor that adds URL validation (and silently drops
+// unrecognized schemes) is caught.
+//
+// NOT t.Parallel(): t.Setenv calls on AWS_ENDPOINT_URL would race
+// with sibling tests using the same var.
+func TestProductionDiscoverDeps_LoadConfigBaseEndpoint(t *testing.T) {
+	cases := []struct {
+		name        string
+		shellEnv    string
+		endpointURL string
+		want        string // expected aws.Config.BaseEndpoint after load; "" means BaseEndpoint must be nil
+	}{
+		{
+			name:        "param empty, env empty → BaseEndpoint nil",
+			shellEnv:    "",
+			endpointURL: "",
+			want:        "",
 		},
-		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "1234567890", nil },
-		newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator { return agg },
-		runGenconfig:  gc.Run,
-		runDriftfix:   (&fakeDriftfix{}).Run,
-		runDepChase:   noopDepChase,
+		{
+			name:        "param set, env empty → param threaded to BaseEndpoint",
+			shellEnv:    "",
+			endpointURL: "http://localhost:4566",
+			want:        "http://localhost:4566",
+		},
+		{
+			name:        "param empty, env set → SDK fallback resolves env into BaseEndpoint",
+			shellEnv:    "http://from-env.example",
+			endpointURL: "",
+			want:        "http://from-env.example",
+		},
+		{
+			name:        "param set, env set → param wins (WithBaseEndpoint overrides env)",
+			shellEnv:    "http://from-env.example",
+			endpointURL: "http://localhost:4566",
+			want:        "http://localhost:4566",
+		},
+		{
+			name:        "garbage URL passed through verbatim (no validation at this layer)",
+			shellEnv:    "",
+			endpointURL: "://broken-scheme",
+			want:        "://broken-scheme",
+		},
 	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AWS_ENDPOINT_URL", tc.shellEnv)
+			deps := productionDiscoverDeps()
+			cfg, err := deps.loadConfig(context.Background(), "us-east-1", tc.endpointURL)
+			require.NoError(t, err, "loadConfig must not fail on the WithRetryMaxAttempts/WithBaseEndpoint composition")
 
-	rc := runDiscoverWithDeps([]string{
-		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
-		"--aws-endpoint-url", "http://localhost:4566",
-	}, deps)
-	if rc != discoverExitOK {
-		t.Fatalf("rc=%d, want OK", rc)
-	}
-	if loadConfigSawEnv != "http://localhost:4566" {
-		t.Errorf("loadConfig saw AWS_ENDPOINT_URL=%q, want %q (env var must be set BEFORE loadConfig)", loadConfigSawEnv, "http://localhost:4566")
-	}
-	if gc.gotOpts.AWSEndpointURL != "http://localhost:4566" {
-		t.Errorf("genconfig.Options.AWSEndpointURL=%q, want %q (flag must propagate to providers.tf emitter)", gc.gotOpts.AWSEndpointURL, "http://localhost:4566")
+			var got string
+			if cfg.BaseEndpoint != nil {
+				got = *cfg.BaseEndpoint
+			}
+			assert.Equal(t, tc.want, got, "aws.Config.BaseEndpoint")
+			if tc.want == "" {
+				assert.Nil(t, cfg.BaseEndpoint, "empty want must yield nil BaseEndpoint, not empty string")
+			}
+		})
 	}
 }
 
-// TestRunDiscoverWithDeps_AWSEndpointURLDefaultsEmpty pins that omitting
-// --aws-endpoint-url leaves the env var alone (real AWS behavior) and
-// passes "" to genconfig (standard provider block). Without this, a
-// loose default that pre-set AWS_ENDPOINT_URL="" would still mutate
-// inherited env in unrelated test runs.
-func TestRunDiscoverWithDeps_AWSEndpointURLDefaultsEmpty(t *testing.T) {
-	dir := t.TempDir()
-	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.q")}}
-	gc := &fakeGenconfig{}
-
-	// Pre-set a sentinel that must NOT be overwritten when the flag is
-	// absent. (Real-world analogue: an operator already exported
-	// AWS_ENDPOINT_URL for another tool — discover should not clobber it.)
-	t.Setenv("AWS_ENDPOINT_URL", "http://preexisting.invalid")
-	deps := okDepsWithGC(agg, gc)
-
-	rc := runDiscoverWithDeps([]string{
-		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
-	}, deps)
-	if rc != discoverExitOK {
-		t.Fatalf("rc=%d, want OK", rc)
+// TestRunDiscoverWithDeps_AWSEndpointURLWiresFlagToBothSeams pins the
+// Stage 2c4 (#272) LocalStack flag wiring on both sides of the seam,
+// table-driven:
+//   - loadConfig receives the flag value as its third arg (so production
+//     loadConfig threads it onto aws.Config.BaseEndpoint, retargeting
+//     every per-service SDK client built off it).
+//   - genconfig.Options.AWSEndpointURL receives the same flag value (so
+//     the emitted providers.tf points at LocalStack via emitProviders).
+//
+// Both branches matter: a regression that drops the loadConfig threading
+// would produce HCL pointing at LocalStack while the discoverers still
+// hit real AWS, silently emptying the manifest. The reverse breaks
+// terraform plan against an unmocked endpoint.
+//
+// Precedence is pinned in both directions:
+//   - flag set + env set: flag wins at the orchestrator seam (the SDK
+//     never sees env when WithBaseEndpoint is applied).
+//   - flag empty + env set: orchestrator threads "" through to
+//     loadConfig; the production loader then defers to the SDK's own
+//     env-fallback (covered by TestProductionDiscoverDeps_LoadConfigBaseEndpoint).
+func TestRunDiscoverWithDeps_AWSEndpointURLWiresFlagToBothSeams(t *testing.T) {
+	cases := []struct {
+		name      string
+		shellEnv  string // AWS_ENDPOINT_URL pre-set at test start
+		flagValue string // value passed to --aws-endpoint-url, or "" to omit the flag
+		wantArg   string // expected third arg to loadConfig + genconfig.Options.AWSEndpointURL
+	}{
+		{
+			name:      "flag set, shell env empty → flag value at both seams",
+			shellEnv:  "",
+			flagValue: "http://localhost:4566",
+			wantArg:   "http://localhost:4566",
+		},
+		{
+			name:      "flag omitted, shell env empty → empty at both seams",
+			shellEnv:  "",
+			flagValue: "",
+			wantArg:   "",
+		},
+		{
+			name:      "flag set, shell env set to different value → flag wins",
+			shellEnv:  "http://preexisting.invalid",
+			flagValue: "http://localhost:4566",
+			wantArg:   "http://localhost:4566",
+		},
+		{
+			name:      "flag omitted, shell env set → orchestrator threads \"\" (env handled by SDK, not us)",
+			shellEnv:  "http://from-env.example",
+			flagValue: "",
+			wantArg:   "",
+		},
 	}
-	if got := os.Getenv("AWS_ENDPOINT_URL"); got != "http://preexisting.invalid" {
-		t.Errorf("AWS_ENDPOINT_URL mutated to %q without --aws-endpoint-url; pre-existing env must be preserved", got)
-	}
-	if gc.gotOpts.AWSEndpointURL != "" {
-		t.Errorf("genconfig.Options.AWSEndpointURL=%q, want empty (flag default)", gc.gotOpts.AWSEndpointURL)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AWS_ENDPOINT_URL", tc.shellEnv)
+
+			dir := t.TempDir()
+			agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.q")}}
+			gc := &fakeGenconfig{}
+
+			var loadConfigSawArg string
+			deps := discoverDeps{
+				loadConfig: func(_ context.Context, _, endpointURL string) (aws.Config, error) {
+					loadConfigSawArg = endpointURL
+					return aws.Config{}, nil
+				},
+				getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "1234567890", nil },
+				newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator { return agg },
+				runGenconfig:  gc.Run,
+				runDriftfix:   (&fakeDriftfix{}).Run,
+				runDepChase:   noopDepChase,
+			}
+
+			args := []string{"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir}
+			if tc.flagValue != "" {
+				args = append(args, "--aws-endpoint-url", tc.flagValue)
+			}
+			rc := runDiscoverWithDeps(args, deps)
+			require.Equal(t, discoverExitOK, rc)
+			assert.Equal(t, tc.wantArg, loadConfigSawArg, "loadConfig third arg")
+			assert.Equal(t, tc.wantArg, gc.gotOpts.AWSEndpointURL, "genconfig.Options.AWSEndpointURL")
+		})
 	}
 }
 

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -940,6 +940,86 @@ func TestProductionDiscoverDeps_LoadConfigSetsRetryMaxAttempts(t *testing.T) {
 	}
 }
 
+// TestRunDiscoverWithDeps_AWSEndpointURLThreaded pins the Stage 2c4 (#272)
+// LocalStack flag wiring on both sides of the seam:
+//   - genconfig.Options.AWSEndpointURL receives the flag value (so the
+//     emitted providers.tf points at LocalStack via emitProviders).
+//   - The AWS_ENDPOINT_URL env var is set before deps.loadConfig fires,
+//     so production loadConfig (and every per-service SDK client built
+//     off the resulting aws.Config) routes API calls to the same URL.
+//
+// Both branches matter: a regression that drops env-var setting would
+// produce HCL pointing at LocalStack while the discoverers still hit
+// real AWS, silently emptying the manifest. The reverse breaks
+// terraform plan against an unmocked endpoint.
+func TestRunDiscoverWithDeps_AWSEndpointURLThreaded(t *testing.T) {
+	dir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.q")}}
+	gc := &fakeGenconfig{}
+
+	// Snapshot the env var observed at loadConfig time. t.Setenv handles
+	// cleanup so the value doesn't leak into other tests; production
+	// loadConfig fires only after runDiscoverWithDeps's setenv, so an
+	// initial value of "" is the contract under test.
+	t.Setenv("AWS_ENDPOINT_URL", "")
+	var loadConfigSawEnv string
+	deps := discoverDeps{
+		loadConfig: func(_ context.Context, _ string) (aws.Config, error) {
+			loadConfigSawEnv = os.Getenv("AWS_ENDPOINT_URL")
+			return aws.Config{}, nil
+		},
+		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "1234567890", nil },
+		newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator { return agg },
+		runGenconfig:  gc.Run,
+		runDriftfix:   (&fakeDriftfix{}).Run,
+		runDepChase:   noopDepChase,
+	}
+
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+		"--aws-endpoint-url", "http://localhost:4566",
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if loadConfigSawEnv != "http://localhost:4566" {
+		t.Errorf("loadConfig saw AWS_ENDPOINT_URL=%q, want %q (env var must be set BEFORE loadConfig)", loadConfigSawEnv, "http://localhost:4566")
+	}
+	if gc.gotOpts.AWSEndpointURL != "http://localhost:4566" {
+		t.Errorf("genconfig.Options.AWSEndpointURL=%q, want %q (flag must propagate to providers.tf emitter)", gc.gotOpts.AWSEndpointURL, "http://localhost:4566")
+	}
+}
+
+// TestRunDiscoverWithDeps_AWSEndpointURLDefaultsEmpty pins that omitting
+// --aws-endpoint-url leaves the env var alone (real AWS behavior) and
+// passes "" to genconfig (standard provider block). Without this, a
+// loose default that pre-set AWS_ENDPOINT_URL="" would still mutate
+// inherited env in unrelated test runs.
+func TestRunDiscoverWithDeps_AWSEndpointURLDefaultsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.q")}}
+	gc := &fakeGenconfig{}
+
+	// Pre-set a sentinel that must NOT be overwritten when the flag is
+	// absent. (Real-world analogue: an operator already exported
+	// AWS_ENDPOINT_URL for another tool — discover should not clobber it.)
+	t.Setenv("AWS_ENDPOINT_URL", "http://preexisting.invalid")
+	deps := okDepsWithGC(agg, gc)
+
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if got := os.Getenv("AWS_ENDPOINT_URL"); got != "http://preexisting.invalid" {
+		t.Errorf("AWS_ENDPOINT_URL mutated to %q without --aws-endpoint-url; pre-existing env must be preserved", got)
+	}
+	if gc.gotOpts.AWSEndpointURL != "" {
+		t.Errorf("genconfig.Options.AWSEndpointURL=%q, want empty (flag default)", gc.gotOpts.AWSEndpointURL)
+	}
+}
+
 func TestSplitCSV(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/cmd/insideout-import/genconfig/emit.go
+++ b/cmd/insideout-import/genconfig/emit.go
@@ -45,10 +45,35 @@ func emitImports(dir string, resources []imported.ImportedResource) error {
 	return os.WriteFile(filepath.Join(dir, importsFile), f.Bytes(), 0o644)
 }
 
+// localstackEndpointServices is the set of TF AWS provider `endpoints {}`
+// keys we retarget when emitting a LocalStack-backed providers.tf. It's the
+// union of services every discoverer in awsdiscover/ touches plus `sts`
+// (called by the orchestrator's getAccount).
+//
+// Order is fixed so the emitted HCL is byte-stable across runs (golden-file
+// friendly).
+var localstackEndpointServices = []string{
+	"cloudwatchlogs",
+	"dynamodb",
+	"iam",
+	"kms",
+	"lambda",
+	"s3",
+	"secretsmanager",
+	"sqs",
+	"sts",
+}
+
 // emitProviders writes <dir>/providers.tf with the AWS provider pinned to the
 // same major as the rest of the repo (>= 6.0). The provider block is
 // unaliased — see emitImports for why.
-func emitProviders(dir, region string) error {
+//
+// If endpointURL is non-empty (set via --aws-endpoint-url, used by the
+// Stage 2c4 LocalStack CI gate #272), the block is augmented with the
+// LocalStack attribute set: `endpoints {}` map covering every service the
+// discoverers + STS touch, plus dummy creds and the four `skip_*`/path-
+// style flags that LocalStack's documentation requires for v3+.
+func emitProviders(dir, region, endpointURL string) error {
 	f := hclwrite.NewEmptyFile()
 	body := f.Body()
 
@@ -62,6 +87,19 @@ func emitProviders(dir, region string) error {
 	body.AppendNewline()
 	prov := body.AppendNewBlock("provider", []string{"aws"})
 	prov.Body().SetAttributeValue("region", cty.StringVal(region))
+
+	if endpointURL != "" {
+		prov.Body().SetAttributeValue("access_key", cty.StringVal("test"))
+		prov.Body().SetAttributeValue("secret_key", cty.StringVal("test"))
+		prov.Body().SetAttributeValue("skip_credentials_validation", cty.True)
+		prov.Body().SetAttributeValue("skip_metadata_api_check", cty.True)
+		prov.Body().SetAttributeValue("skip_requesting_account_id", cty.True)
+		prov.Body().SetAttributeValue("s3_use_path_style", cty.True)
+		ep := prov.Body().AppendNewBlock("endpoints", nil)
+		for _, svc := range localstackEndpointServices {
+			ep.Body().SetAttributeValue(svc, cty.StringVal(endpointURL))
+		}
+	}
 
 	return os.WriteFile(filepath.Join(dir, providersFile), f.Bytes(), 0o644)
 }

--- a/cmd/insideout-import/genconfig/emit_test.go
+++ b/cmd/insideout-import/genconfig/emit_test.go
@@ -90,7 +90,7 @@ func TestEmitImports_RejectsBadAddress(t *testing.T) {
 func TestEmitProviders_HappyPath(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	if err := emitProviders(dir, "us-west-2"); err != nil {
+	if err := emitProviders(dir, "us-west-2", ""); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, providersFile))
@@ -106,6 +106,59 @@ func TestEmitProviders_HappyPath(t *testing.T) {
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("providers.tf missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+	// LocalStack-only attrs must NOT appear when endpointURL is "".
+	for _, banned := range []string{"endpoints", "access_key", "skip_credentials_validation", "s3_use_path_style"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("providers.tf must not contain %q when endpointURL is empty\n--- got ---\n%s", banned, got)
+		}
+	}
+}
+
+// TestEmitProviders_LocalStackEndpoint pins the Stage 2c4 (#272) shape:
+// when endpointURL is set, the emitted providers.tf carries the LocalStack
+// attribute set the gate's seed and the discover-generated stack both share.
+// One canonical shape across both consumers means a future change to the
+// LocalStack contract lands in exactly one place.
+//
+// Assertions are presence-only (no column alignment pinning) so a change
+// to hclwrite's whitespace rules doesn't flake the test.
+func TestEmitProviders_LocalStackEndpoint(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := emitProviders(dir, "us-east-1", "http://localhost:4566"); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, providersFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(body)
+
+	// Auth + skip flags. Match attribute name + `= <value>` with arbitrary
+	// inter-token whitespace so the test survives hclwrite alignment.
+	authPatterns := []string{
+		`region\s*=\s*"us-east-1"`,
+		`access_key\s*=\s*"test"`,
+		`secret_key\s*=\s*"test"`,
+		`skip_credentials_validation\s*=\s*true`,
+		`skip_metadata_api_check\s*=\s*true`,
+		`skip_requesting_account_id\s*=\s*true`,
+		`s3_use_path_style\s*=\s*true`,
+		`endpoints\s*\{`,
+	}
+	for _, pat := range authPatterns {
+		if !regexp.MustCompile(pat).MatchString(got) {
+			t.Errorf("providers.tf missing pattern %q\n--- got ---\n%s", pat, got)
+		}
+	}
+
+	// Every service in localstackEndpointServices must point at the URL.
+	for _, svc := range localstackEndpointServices {
+		pat := svc + `\s*=\s*"http://localhost:4566"`
+		if !regexp.MustCompile(pat).MatchString(got) {
+			t.Errorf("providers.tf missing endpoint mapping for %q (pattern %q)\n--- got ---\n%s", svc, pat, got)
 		}
 	}
 }

--- a/cmd/insideout-import/genconfig/emit_test.go
+++ b/cmd/insideout-import/genconfig/emit_test.go
@@ -109,9 +109,18 @@ func TestEmitProviders_HappyPath(t *testing.T) {
 		}
 	}
 	// LocalStack-only attrs must NOT appear when endpointURL is "".
-	for _, banned := range []string{"endpoints", "access_key", "skip_credentials_validation", "s3_use_path_style"} {
-		if strings.Contains(got, banned) {
-			t.Errorf("providers.tf must not contain %q when endpointURL is empty\n--- got ---\n%s", banned, got)
+	// Use anchored attribute/block-start patterns rather than substring
+	// blocklists so a future header comment that mentions one of these
+	// words doesn't trip the check.
+	bannedPatterns := []string{
+		`(?m)^\s*endpoints\s*\{`,
+		`(?m)^\s*access_key\s*=`,
+		`(?m)^\s*skip_credentials_validation\s*=`,
+		`(?m)^\s*s3_use_path_style\s*=`,
+	}
+	for _, pat := range bannedPatterns {
+		if regexp.MustCompile(pat).MatchString(got) {
+			t.Errorf("providers.tf must not contain pattern %q when endpointURL is empty\n--- got ---\n%s", pat, got)
 		}
 	}
 }
@@ -154,11 +163,60 @@ func TestEmitProviders_LocalStackEndpoint(t *testing.T) {
 		}
 	}
 
-	// Every service in localstackEndpointServices must point at the URL.
-	for _, svc := range localstackEndpointServices {
-		pat := svc + `\s*=\s*"http://localhost:4566"`
-		if !regexp.MustCompile(pat).MatchString(got) {
-			t.Errorf("providers.tf missing endpoint mapping for %q (pattern %q)\n--- got ---\n%s", svc, pat, got)
+	// Extract the body of the `endpoints { ... }` block and assert
+	// service mappings against THAT scope only — a mutation that
+	// emitted, say, `sqs = "..."` at provider scope (outside endpoints)
+	// would not get a regex match on the slice contents alone.
+	endpointsBody := extractEndpointsBlock(t, got)
+
+	// Hardcode a load-bearing subset that the LocalStack gate's seed
+	// depends on directly (not derived from the production slice). A
+	// teammate shrinking localstackEndpointServices and dropping any of
+	// these would now fail this test rather than silently skipping
+	// coverage. Symmetric with the seed's main.tf which exercises these
+	// services end-to-end.
+	loadBearing := []string{"s3", "dynamodb", "lambda", "iam", "sts"}
+	for _, svc := range loadBearing {
+		pat := `(?m)^\s*` + svc + `\s*=\s*"http://localhost:4566"`
+		if !regexp.MustCompile(pat).MatchString(endpointsBody) {
+			t.Errorf("endpoints {} block missing hardcoded mapping for %q (pattern %q)\n--- endpoints block ---\n%s", svc, pat, endpointsBody)
 		}
 	}
+
+	// Then every service in the production slice must also appear,
+	// inside the endpoints block.
+	for _, svc := range localstackEndpointServices {
+		pat := `(?m)^\s*` + svc + `\s*=\s*"http://localhost:4566"`
+		if !regexp.MustCompile(pat).MatchString(endpointsBody) {
+			t.Errorf("endpoints {} block missing mapping for %q (pattern %q)\n--- endpoints block ---\n%s", svc, pat, endpointsBody)
+		}
+	}
+}
+
+// extractEndpointsBlock pulls the contents of the first `endpoints {
+// ... }` block out of an HCL providers.tf body. Naive brace-balance
+// scan is fine here because the emit path doesn't nest blocks under
+// `endpoints {}`; if that ever changes the test will see it as a
+// false positive on the first inner closing brace.
+func extractEndpointsBlock(t *testing.T, hcl string) string {
+	t.Helper()
+	loc := regexp.MustCompile(`(?s)endpoints\s*\{`).FindStringIndex(hcl)
+	if loc == nil {
+		t.Fatalf("no endpoints {} block in providers.tf\n--- hcl ---\n%s", hcl)
+	}
+	rest := hcl[loc[1]:]
+	depth := 1
+	for i, r := range rest {
+		switch r {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return rest[:i]
+			}
+		}
+	}
+	t.Fatalf("unbalanced braces inside endpoints {} block\n--- hcl ---\n%s", hcl)
+	return ""
 }

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -51,6 +51,8 @@ func applyResourceTypeFixups(raw []byte) ([]byte, error) {
 // by cleanGenerated.
 var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_lambda_function": fixupLambdaSource,
+	"aws_kms_key":         fixupKMSRotationPeriodZero,
+	"aws_dynamodb_table":  fixupDynamoDBPITRRecoveryPeriodZero,
 }
 
 // lambdaPlaceholderFile is what we set `filename` to so the block
@@ -97,6 +99,57 @@ func fixupLambdaSource(blk *hclwrite.Block) {
 	}
 	lc := body.AppendNewBlock("lifecycle", nil)
 	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(lambdaIgnoreChanges))
+}
+
+// fixupKMSRotationPeriodZero drops aws_kms_key.rotation_period_in_days
+// when its emitted value is the literal `0`. Real AWS DescribeKey leaves
+// the field absent when key rotation isn't enabled (the provider's
+// validator pins it to 90-2560), so generate-config-out wouldn't emit
+// the line in the first place. LocalStack 4.x returns 0 instead of
+// leaving the field unset, which makes the import bundle fail
+// `terraform validate` with `expected rotation_period_in_days to be in
+// the range (90 - 2560), got 0`.
+//
+// The fixup is conservative — it only touches the literal `0`, so a
+// real value coming back from AWS (e.g. 365) is preserved. No-op
+// against real AWS.
+func fixupKMSRotationPeriodZero(blk *hclwrite.Block) {
+	if isAttrLiteralZero(blk.Body(), "rotation_period_in_days") {
+		blk.Body().RemoveAttribute("rotation_period_in_days")
+	}
+}
+
+// fixupDynamoDBPITRRecoveryPeriodZero drops the analogous LocalStack 0
+// for aws_dynamodb_table.point_in_time_recovery.recovery_period_in_days
+// (validator: 1-35). Same conservative shape as fixupKMSRotationPeriodZero;
+// only the literal `0` is removed.
+func fixupDynamoDBPITRRecoveryPeriodZero(blk *hclwrite.Block) {
+	for _, sub := range blk.Body().Blocks() {
+		if sub.Type() != "point_in_time_recovery" {
+			continue
+		}
+		if isAttrLiteralZero(sub.Body(), "recovery_period_in_days") {
+			sub.Body().RemoveAttribute("recovery_period_in_days")
+		}
+	}
+}
+
+// isAttrLiteralZero reports whether the named attribute exists and its
+// expression is exactly the literal `0` (after whitespace trimming).
+// It does NOT match `0.0`, `00`, or any computed expression that
+// happens to evaluate to zero — only the raw literal terraform plan
+// -generate-config-out would emit for an int-shaped field.
+func isAttrLiteralZero(body *hclwrite.Body, name string) bool {
+	attr := body.GetAttribute(name)
+	if attr == nil {
+		return false
+	}
+	tokens := attr.Expr().BuildTokens(nil)
+	var sb strings.Builder
+	for _, t := range tokens {
+		sb.Write(t.Bytes)
+	}
+	return strings.TrimSpace(sb.String()) == "0"
 }
 
 // hasUsableValue reports whether the named attribute is both present and

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -171,20 +171,41 @@ func TestFixupKMS_RotationPeriodZeroDropped(t *testing.T) {
 // real AWS returning a meaningful 365-day rotation must NOT have its
 // value silently dropped. Only the literal 0 from LocalStack triggers
 // the fixup.
+//
+// Table-driven so the carve-outs documented on isAttrLiteralZero
+// ("does NOT match `0.0`, `00`, or any computed expression") are
+// pinned by tests, not just docstrings. A mutation broadening the
+// trigger to `strings.HasPrefix(s, "0")` or `== "00"` would now fail
+// these cases.
 func TestFixupKMS_RotationPeriodNonZeroPreserved(t *testing.T) {
 	t.Parallel()
-	in := []byte(`resource "aws_kms_key" "main" {
+	cases := []struct {
+		name, value string
+	}{
+		{name: "real AWS value", value: "365"},
+		{name: "minimum valid", value: "90"},
+		{name: "maximum valid", value: "2560"},
+		{name: "leading-zero literal (carve-out: not the LocalStack shape)", value: "00"},
+		{name: "float-zero literal (carve-out: not the LocalStack shape)", value: "0.0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := []byte(`resource "aws_kms_key" "main" {
   description             = "x"
-  rotation_period_in_days = 365
+  rotation_period_in_days = ` + tc.value + `
 }
 `)
-	out, err := applyResourceTypeFixups(in)
-	if err != nil {
-		t.Fatal(err)
-	}
-	got := string(out)
-	if !regexp.MustCompile(`rotation_period_in_days\s*=\s*365`).MatchString(got) {
-		t.Errorf("non-zero rotation_period_in_days must be preserved\n--- got ---\n%s", got)
+			out, err := applyResourceTypeFixups(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(out)
+			pat := `rotation_period_in_days\s*=\s*` + regexp.QuoteMeta(tc.value)
+			if !regexp.MustCompile(pat).MatchString(got) {
+				t.Errorf("value %q must be preserved (only literal `0` is dropped)\n--- got ---\n%s", tc.value, got)
+			}
+		})
 	}
 }
 
@@ -218,15 +239,79 @@ func TestFixupDynamoDB_PITRRecoveryPeriodZeroDropped(t *testing.T) {
 }
 
 // TestFixupDynamoDB_PITRRecoveryPeriodNonZeroPreserved is the symmetric
-// non-zero case — a real PITR window of 14 days must reach the emitted
-// HCL untouched.
+// non-zero case — a real PITR window must reach the emitted HCL
+// untouched. Table-driven to also pin the literal-zero carve-outs
+// documented on isAttrLiteralZero.
 func TestFixupDynamoDB_PITRRecoveryPeriodNonZeroPreserved(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, value string
+	}{
+		{name: "real AWS value", value: "14"},
+		{name: "minimum valid", value: "1"},
+		{name: "maximum valid", value: "35"},
+		{name: "leading-zero literal (carve-out)", value: "00"},
+		{name: "float-zero literal (carve-out)", value: "0.0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := []byte(`resource "aws_dynamodb_table" "main" {
+  name = "x"
+  point_in_time_recovery {
+    enabled                 = true
+    recovery_period_in_days = ` + tc.value + `
+  }
+}
+`)
+			out, err := applyResourceTypeFixups(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(out)
+			pat := `recovery_period_in_days\s*=\s*` + regexp.QuoteMeta(tc.value)
+			if !regexp.MustCompile(pat).MatchString(got) {
+				t.Errorf("value %q must be preserved (only literal `0` is dropped)\n--- got ---\n%s", tc.value, got)
+			}
+		})
+	}
+}
+
+// TestFixupDynamoDB_NoPITRBlockNoOp pins the canonical real-AWS shape:
+// when point_in_time_recovery isn't even present, the fixup must be a
+// pure no-op. A mutation that "helpfully" injected a PITR block or
+// touched other sub-blocks would fail this.
+func TestFixupDynamoDB_NoPITRBlockNoOp(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_dynamodb_table" "main" {
+  name     = "x"
+  hash_key = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(in) {
+		t.Errorf("absent point_in_time_recovery must yield identical output\n--- in ---\n%s\n--- out ---\n%s", in, out)
+	}
+}
+
+// TestFixupDynamoDB_PITRBlockPresentAttrAbsentNoOp pins that a PITR
+// block carrying only `enabled = false` (no recovery_period_in_days)
+// is also a no-op. A mutation that always added or removed
+// recovery_period_in_days regardless of presence would fail.
+func TestFixupDynamoDB_PITRBlockPresentAttrAbsentNoOp(t *testing.T) {
 	t.Parallel()
 	in := []byte(`resource "aws_dynamodb_table" "main" {
   name = "x"
   point_in_time_recovery {
-    enabled                 = true
-    recovery_period_in_days = 14
+    enabled = false
   }
 }
 `)
@@ -235,8 +320,43 @@ func TestFixupDynamoDB_PITRRecoveryPeriodNonZeroPreserved(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := string(out)
-	if !regexp.MustCompile(`recovery_period_in_days\s*=\s*14`).MatchString(got) {
-		t.Errorf("non-zero recovery_period_in_days must be preserved\n--- got ---\n%s", got)
+	if !regexp.MustCompile(`(?m)^\s*enabled\s*=\s*false`).MatchString(got) {
+		t.Errorf("enabled=false must be preserved\n--- got ---\n%s", got)
+	}
+	if regexp.MustCompile(`recovery_period_in_days`).MatchString(got) {
+		t.Errorf("absent recovery_period_in_days must NOT appear after fixup\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupDynamoDB_MultiplePITRBlocksAllZerosDropped pins iteration:
+// if a (hypothetical) DynamoDB resource has multiple
+// point_in_time_recovery sub-blocks (Terraform doesn't support this in
+// reality, but `terraform plan -generate-config-out` has emitted
+// duplicate blocks before for other types), the fixup must process
+// all of them — not break after the first match. A mutation
+// substituting `break` for `continue` after the inner remove would
+// survive single-block tests but fail this.
+func TestFixupDynamoDB_MultiplePITRBlocksAllZerosDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_dynamodb_table" "main" {
+  name = "x"
+  point_in_time_recovery {
+    enabled                 = false
+    recovery_period_in_days = 0
+  }
+  point_in_time_recovery {
+    enabled                 = false
+    recovery_period_in_days = 0
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`recovery_period_in_days`).MatchString(got) {
+		t.Errorf("all zero-valued recovery_period_in_days must be dropped, even across multiple PITR blocks\n--- got ---\n%s", got)
 	}
 }
 

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -144,6 +144,102 @@ func TestFixupLambda_NonLambdaResourceUntouched(t *testing.T) {
 	}
 }
 
+// TestFixupKMS_RotationPeriodZeroDropped pins the LocalStack 4.x
+// fidelity workaround for #272: DescribeKey returns
+// rotation_period_in_days=0 for keys without rotation enabled, but the
+// AWS provider's validator rejects 0 (range 90-2560). Real AWS leaves
+// the field absent, so the fixup normalizes LocalStack output to the
+// AWS-shaped output that schema cleanup is built around.
+func TestFixupKMS_RotationPeriodZeroDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_kms_key" "main" {
+  description             = "x"
+  rotation_period_in_days = 0
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "rotation_period_in_days") {
+		t.Errorf("rotation_period_in_days = 0 must be dropped\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupKMS_RotationPeriodNonZeroPreserved pins conservative scope:
+// real AWS returning a meaningful 365-day rotation must NOT have its
+// value silently dropped. Only the literal 0 from LocalStack triggers
+// the fixup.
+func TestFixupKMS_RotationPeriodNonZeroPreserved(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_kms_key" "main" {
+  description             = "x"
+  rotation_period_in_days = 365
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`rotation_period_in_days\s*=\s*365`).MatchString(got) {
+		t.Errorf("non-zero rotation_period_in_days must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupDynamoDB_PITRRecoveryPeriodZeroDropped is the DynamoDB twin
+// of the KMS rotation fixup — same LocalStack 4.x quirk, different
+// resource type. Validator range is 1-35; LocalStack returns 0 when
+// PITR is disabled.
+func TestFixupDynamoDB_PITRRecoveryPeriodZeroDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_dynamodb_table" "main" {
+  name = "x"
+  point_in_time_recovery {
+    enabled                 = false
+    recovery_period_in_days = 0
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "recovery_period_in_days") {
+		t.Errorf("recovery_period_in_days = 0 must be dropped from point_in_time_recovery block\n--- got ---\n%s", got)
+	}
+	// The enclosing block must remain so other PITR fields (enabled)
+	// stay intact.
+	if !strings.Contains(got, "point_in_time_recovery {") {
+		t.Errorf("point_in_time_recovery block must not be removed wholesale\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupDynamoDB_PITRRecoveryPeriodNonZeroPreserved is the symmetric
+// non-zero case — a real PITR window of 14 days must reach the emitted
+// HCL untouched.
+func TestFixupDynamoDB_PITRRecoveryPeriodNonZeroPreserved(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_dynamodb_table" "main" {
+  name = "x"
+  point_in_time_recovery {
+    enabled                 = true
+    recovery_period_in_days = 14
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`recovery_period_in_days\s*=\s*14`).MatchString(got) {
+		t.Errorf("non-zero recovery_period_in_days must be preserved\n--- got ---\n%s", got)
+	}
+}
+
 // TestFixupLambda_MultipleLambdasBothFixed pins iteration: two Lambda
 // blocks in input order both get the placeholder + ignore_changes
 // treatment. A mutation that exited after the first block would survive

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -28,6 +28,14 @@ type Options struct {
 	Workdir string
 	Region  string
 
+	// AWSEndpointURL, when non-empty, retargets the emitted providers.tf
+	// at a single URL (LocalStack) for every AWS service the discoverers
+	// touch, plus the LocalStack auth/skip attribute set. Empty means
+	// emit the standard provider block (region only). Set by the
+	// --aws-endpoint-url discover flag, intended for the Stage 2c4 CI
+	// gate (#272).
+	AWSEndpointURL string
+
 	// Runner is optional. If nil, Run constructs an execRunner that shells
 	// out to the `terraform` binary on PATH. Tests inject a fake here to
 	// avoid the binary dependency.
@@ -84,7 +92,7 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 	if err := emitImports(opts.Workdir, resources); err != nil {
 		return nil, fmt.Errorf("emit imports.tf: %w", err)
 	}
-	if err := emitProviders(opts.Workdir, opts.Region); err != nil {
+	if err := emitProviders(opts.Workdir, opts.Region, opts.AWSEndpointURL); err != nil {
 		return nil, fmt.Errorf("emit providers.tf: %w", err)
 	}
 

--- a/tests/localstack-discover-gate.sh
+++ b/tests/localstack-discover-gate.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Stage 2c4 LocalStack discover gate (#272).
+#
+# End-to-end zero-drift assertion for `insideout-import discover`:
+#   1. Wait for LocalStack to report healthy on http://localhost:4566.
+#   2. terraform apply the seed stack at tests/testdata/localstack-seed/
+#      (creates one of each of 8 supported AWS resource types — SQS is
+#      excluded; see seed's main.tf header for the LocalStack URL-shape
+#      reason).
+#   3. Run `insideout-import discover --aws-endpoint-url …` against
+#      LocalStack. The orchestrator's exit-code contract is: 0 iff the
+#      generated stack would `terraform plan` clean.
+#   4. Defense-in-depth: independently run
+#      `terraform plan -detailed-exitcode` against the discover-generated
+#      genconfig workdir and assert exit 0.
+#   5. Sanity-check the manifest contains at least the seeded resources.
+#
+# Local invocation:
+#   docker run --rm -d -p 4566:4566 \
+#     -v /var/run/docker.sock:/var/run/docker.sock \
+#     -e SERVICES=lambda,dynamodb,logs,secretsmanager,sqs,iam,kms,s3,sts \
+#     -e DEFAULT_REGION=us-east-1 \
+#     --name localstack-272 localstack/localstack:4
+#   bash tests/localstack-discover-gate.sh
+#   docker rm -f localstack-272
+#
+# Notes:
+#   - LocalStack 4 (not 3) is required: Lambda + DynamoDB seed apply
+#     fail on 3.x with state-poll / Docker-availability gaps.
+#   - docker.sock mount is required so LocalStack 4 can spawn the
+#     Lambda runtime container for deployment-package validation.
+#
+# CI invocation: as a step inside the localstack-discover-gate job, with
+# LocalStack as a `services:` container on the same network.
+
+set -euo pipefail
+
+readonly LOCALSTACK_URL="${LOCALSTACK_URL:-http://localhost:4566}"
+readonly REGION="${AWS_REGION:-us-east-1}"
+readonly PROJECT="localstack-seed-272"
+readonly REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly SEED_DIR="${REPO_ROOT}/tests/testdata/localstack-seed"
+readonly OUT_DIR="${REPO_ROOT}/.tmp/discover-272"
+
+# CI exports these via the job env. Local invocations may not, so set
+# placeholders; LocalStack ignores credential values when
+# skip_credentials_validation is true on the provider.
+export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-test}"
+export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-test}"
+export AWS_REGION="${REGION}"
+export AWS_DEFAULT_REGION="${REGION}"
+
+log() { printf '\n>>> %s\n' "$*" >&2; }
+fail() { printf '\nFAIL: %s\n' "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 1. LocalStack health.
+# ---------------------------------------------------------------------------
+
+log "Waiting for LocalStack at ${LOCALSTACK_URL}/_localstack/health"
+for i in $(seq 1 60); do
+  if curl --silent --fail "${LOCALSTACK_URL}/_localstack/health" >/dev/null 2>&1; then
+    log "LocalStack ready (took ${i}s)"
+    break
+  fi
+  if [[ "${i}" == "60" ]]; then
+    fail "LocalStack did not become healthy within 60s"
+  fi
+  sleep 1
+done
+
+# ---------------------------------------------------------------------------
+# 2. Apply the seed stack.
+# ---------------------------------------------------------------------------
+
+log "Applying seed stack at ${SEED_DIR}"
+( cd "${SEED_DIR}" && terraform init -input=false -no-color )
+( cd "${SEED_DIR}" && terraform apply -auto-approve -input=false -no-color )
+
+# ---------------------------------------------------------------------------
+# 3. Run insideout-import discover against LocalStack.
+# ---------------------------------------------------------------------------
+
+mkdir -p "${OUT_DIR}"
+rm -rf "${OUT_DIR:?}"/*
+
+log "Running insideout-import discover against ${LOCALSTACK_URL}"
+( cd "${REPO_ROOT}" && go run ./cmd/insideout-import discover \
+    --provider aws \
+    --project "${PROJECT}" \
+    --region "${REGION}" \
+    --output-dir "${OUT_DIR}" \
+    --aws-endpoint-url "${LOCALSTACK_URL}" )
+
+# ---------------------------------------------------------------------------
+# 4. Apply the import blocks, then assert plan is empty.
+#
+# After discover the genconfig workdir contains import {} blocks plus
+# generated.tf, but state is empty. A naked `terraform plan -detailed-
+# exitcode` legitimately reports `N to import` (rc=2) — that's the
+# imports waiting to happen, not drift. The zero-drift contract is:
+# once the imports are applied (state hydrated from cloud), the next
+# plan must be empty.
+#
+# `terraform apply -auto-approve` executes the imports against
+# LocalStack. If the orchestrator's drift-fix loop didn't fully
+# converge, the apply itself will fail (an attribute mismatch surfaces
+# as a plan diff during apply's pre-check). Then we re-plan with
+# -detailed-exitcode and require 0.
+# ---------------------------------------------------------------------------
+
+GENCONFIG_DIR="${OUT_DIR}/genconfig"
+if [[ ! -d "${GENCONFIG_DIR}" ]]; then
+  fail "expected ${GENCONFIG_DIR} to exist after discover"
+fi
+
+log "Applying import blocks against LocalStack to hydrate state"
+( cd "${GENCONFIG_DIR}" && terraform apply -auto-approve -input=false -no-color )
+
+log "Re-asserting plan-clean with terraform plan -detailed-exitcode"
+# -detailed-exitcode codes: 0 = no diff, 1 = error, 2 = diff.
+set +e
+( cd "${GENCONFIG_DIR}" && terraform plan -detailed-exitcode -input=false -no-color )
+plan_rc=$?
+set -e
+case "${plan_rc}" in
+  0) log "plan: no changes — zero-drift contract holds" ;;
+  1) fail "plan errored (rc=1)" ;;
+  2) fail "plan shows changes (rc=2) — post-import drift" ;;
+  *) fail "plan unexpected rc=${plan_rc}" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 5. Manifest sanity check. Each of the 9 seeded types must appear.
+# ---------------------------------------------------------------------------
+
+MANIFEST="${OUT_DIR}/imported.json"
+[[ -s "${MANIFEST}" ]] || fail "manifest ${MANIFEST} missing or empty"
+
+required_types=(
+  aws_cloudwatch_log_group
+  aws_dynamodb_table
+  aws_iam_policy
+  aws_iam_role
+  aws_kms_key
+  aws_lambda_function
+  aws_s3_bucket
+  aws_secretsmanager_secret
+)
+for t in "${required_types[@]}"; do
+  if ! jq -e --arg t "${t}" 'any(.[]; .identity.type == $t)' "${MANIFEST}" >/dev/null; then
+    fail "manifest missing resource of type ${t}"
+  fi
+done
+log "manifest contains all 8 required resource types"
+
+log "OK — Stage 2c4 zero-drift gate passed"

--- a/tests/localstack-discover-gate.sh
+++ b/tests/localstack-discover-gate.sh
@@ -132,7 +132,7 @@ case "${plan_rc}" in
 esac
 
 # ---------------------------------------------------------------------------
-# 5. Manifest sanity check. Each of the 9 seeded types must appear.
+# 5. Manifest sanity check. Each of the 8 seeded types must appear.
 # ---------------------------------------------------------------------------
 
 MANIFEST="${OUT_DIR}/imported.json"

--- a/tests/testdata/localstack-seed/main.tf
+++ b/tests/testdata/localstack-seed/main.tf
@@ -1,0 +1,146 @@
+# Seed resources for the Stage 2c4 LocalStack discover gate (#272).
+#
+# One of each of the 8 supported AWS resource types covered by the gate.
+# Naming + tagging follows what the awsdiscover/* per-type filters expect:
+#   - IAM role/policy, S3:       name prefix == project
+#   - DynamoDB:                  name prefix + Project tag
+#   - Secrets Manager, Lambda:   Project tag
+#   - KMS:                       aws_kms_alias name contains project
+#   - CloudWatch Logs:           name contains project (substring)
+#
+# All taggable resources also carry Project=<project> for symmetry with
+# how downstream discovery expects to attribute them (issue #81 / #255).
+#
+# **SQS is intentionally excluded from this seed.** LocalStack 4.x emits
+# queue URLs of the form `http://sqs.<region>.localhost.localstack.cloud:4566/...`
+# regardless of `SQS_ENDPOINT_STRATEGY`, and the AWS provider's SQS import
+# parser only accepts `sqs.<region>.amazonaws.com` / `<region>.queue.amazonaws.com`
+# hostnames. The discover code is correct against real AWS — this is purely
+# a LocalStack hostname-shape gap. Tracked as a follow-up so SQS coverage
+# rejoins the gate once LocalStack offers an AWS-shaped SQS endpoint or
+# we add a queue-name-keyed import path.
+#
+# This stack is **never composed by InsideOut** — it's a CI fixture
+# applied directly against LocalStack (http://localhost:4566) by
+# tests/localstack-discover-gate.sh. The lint scripts that target
+# InsideOut presets do not scan tests/testdata/.
+
+locals {
+  project = "localstack-seed-272"
+  tags = {
+    Project = local.project
+  }
+}
+
+# ---------------------------------------------------------------------------
+# IAM — execution role + a separate standalone policy.
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "lambda_exec" {
+  name = "${local.project}-lambda-exec"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+  tags = local.tags
+}
+
+resource "aws_iam_policy" "read_only" {
+  name = "${local.project}-read-only"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action   = ["s3:GetObject"]
+      Effect   = "Allow"
+      Resource = "*"
+    }]
+  })
+  tags = local.tags
+}
+
+# ---------------------------------------------------------------------------
+# KMS — a CMK plus an alias whose name contains the project, so the
+# alias-driven kmsDiscoverer pulls the key in.
+# ---------------------------------------------------------------------------
+
+resource "aws_kms_key" "main" {
+  description             = "${local.project} CMK"
+  deletion_window_in_days = 7
+  tags                    = local.tags
+}
+
+resource "aws_kms_alias" "main" {
+  name          = "alias/${local.project}-cmk"
+  target_key_id = aws_kms_key.main.key_id
+}
+
+# ---------------------------------------------------------------------------
+# S3, SQS, DynamoDB, Secrets Manager, CloudWatch Logs.
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "main" {
+  bucket = "${local.project}-bucket"
+  tags   = local.tags
+}
+
+# aws_sqs_queue intentionally omitted — see file-header note.
+
+resource "aws_dynamodb_table" "main" {
+  name         = "${local.project}-table"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret" "main" {
+  name = "${local.project}-secret"
+  # Immediate destroy — the gate's terraform destroy must not leave the
+  # secret in scheduled-for-deletion state, otherwise the very next
+  # apply blows up on `secret with this name is already scheduled for
+  # deletion`. Real AWS honors this, LocalStack honors this; the gate
+  # is the only environment where back-to-back create/destroy cycles
+  # are routine.
+  recovery_window_in_days = 0
+  tags                    = local.tags
+}
+
+resource "aws_cloudwatch_log_group" "main" {
+  name              = "/${local.project}/logs"
+  retention_in_days = 7
+  tags              = local.tags
+}
+
+# ---------------------------------------------------------------------------
+# Lambda — needs a deployment package on disk. Build one inline via
+# archive_file so the seed has zero external file dependencies.
+# ---------------------------------------------------------------------------
+
+data "archive_file" "lambda_stub" {
+  type        = "zip"
+  output_path = "${path.module}/.tmp/lambda_stub.zip"
+
+  source {
+    filename = "index.py"
+    content  = "def handler(event, context):\n    return {'statusCode': 200}\n"
+  }
+}
+
+resource "aws_lambda_function" "main" {
+  function_name    = "${local.project}-fn"
+  role             = aws_iam_role.lambda_exec.arn
+  filename         = data.archive_file.lambda_stub.output_path
+  source_code_hash = data.archive_file.lambda_stub.output_base64sha256
+  handler          = "index.handler"
+  runtime          = "python3.11"
+  tags             = local.tags
+}

--- a/tests/testdata/localstack-seed/providers.tf
+++ b/tests/testdata/localstack-seed/providers.tf
@@ -1,0 +1,43 @@
+# Seed stack provider — points the AWS provider at LocalStack
+# (http://localhost:4566). The attribute set must stay in sync with
+# cmd/insideout-import/genconfig/emit.go::emitProviders' LocalStack branch
+# so the seed and the discover-generated stack speak the same dialect.
+#
+# Used only by tests/localstack-discover-gate.sh (Stage 2c4 / #272).
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    # archive is local-only — used to build the inline Lambda zip in
+    # main.tf without committing a binary fixture to the repo.
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-east-1"
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  s3_use_path_style           = true
+
+  endpoints {
+    cloudwatchlogs = "http://localhost:4566"
+    dynamodb       = "http://localhost:4566"
+    iam            = "http://localhost:4566"
+    kms            = "http://localhost:4566"
+    lambda         = "http://localhost:4566"
+    s3             = "http://localhost:4566"
+    secretsmanager = "http://localhost:4566"
+    sqs            = "http://localhost:4566"
+    sts            = "http://localhost:4566"
+  }
+}

--- a/tests/testdata/localstack-seed/providers.tf
+++ b/tests/testdata/localstack-seed/providers.tf
@@ -6,6 +6,7 @@
 # Used only by tests/localstack-discover-gate.sh (Stage 2c4 / #272).
 
 terraform {
+  required_version = ">= 1.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## Summary

- Stage 2c4 of the reverse-Terraform discover pipeline: spins LocalStack 4 as a CI service container, applies a seed stack covering 8 of the 9 supported AWS resource types, runs `insideout-import discover --aws-endpoint-url ...` end-to-end, then asserts post-import `terraform plan -detailed-exitcode == 0`.
- Turns the orchestrator's plan-clean exit-code contract from documented-only into CI-enforced, closing the dominant P0 from PR #58's QA review.
- Endpoint plumbing rides `aws.Config.BaseEndpoint` via `config.WithBaseEndpoint`, threaded through `discoverDeps.loadConfig`. The Terraform AWS provider gets the same target via `genconfig`'s expanded `providers.tf` block (LocalStack attribute set: dummy creds, `skip_*` flags, `s3_use_path_style`, full `endpoints {}` map).
- Two narrow fixups (`fixupKMSRotationPeriodZero`, `fixupDynamoDBPITRRecoveryPeriodZero`) handle LocalStack-specific `0`-instead-of-absent gaps. Scoped to the literal `0` so genuine real-AWS values pass through unchanged. Docstrings document why; tests pin the carve-outs (`0.0`, `00`) the trigger explicitly does NOT match.

## Test plan

- [x] `go test -race -count=1 ./cmd/insideout-import/...` — green
- [x] `go vet ./cmd/insideout-import/...` — clean
- [x] `terraform fmt -check -recursive` — clean
- [x] `bash tests/lint-no-root-only-blocks.sh` and `bash tests/lint-project-tag.sh` — pass
- [x] End-to-end LocalStack 4 gate run locally (8 resources discovered, imported cleanly, post-import plan empty)
- [ ] CI: new `localstack-discover-gate` job (wired into `ci-gate` aggregator's `needs:`)
- [ ] CI: existing matrix jobs unaffected by the workflow change

## Review notes

- /review findings: P0/P1: 0. P2: 3, all addressed (refactored env-var to BaseEndpoint plumbing, added flag-vs-env precedence test, fixed doc-drift). P3: drive-by fixes for absence-pattern regex and adversarial URL handling.
- qa-professor findings: all addressed — added `0.0`/`00` carve-out tests on both fixups, multiple-PITR-block iteration test, attribute-absent-but-block-present no-op test, fourth diagonal (flag empty + env set) on the orchestrator table, env-fallback + garbage-URL cases on the production loadConfig table, hardcoded load-bearing service names + `endpoints {}` block extraction in the providers.tf shape test.

## Deferred follow-ups

- **SQS coverage** (excluded from seed): LocalStack 4 emits queue URLs the AWS provider's import parser rejects regardless of `SQS_ENDPOINT_STRATEGY`. Discover code is correct against real AWS — pure LocalStack hostname-shape gap. Will rejoin the gate once LocalStack ships AWS-shaped SQS endpoints or the provider widens its parser.
- **Reuse for `pkg/observability/discovery/aws/` metrics-shape contracts** (#255 regression class): the LocalStack scaffolding from this PR is the prerequisite. Worth a follow-up issue once this lands.

Closes #272.