### PR TITLE
feat(observability/inspect): jsonschema tags on SubRequest (#280)

### DIFF
--- a/pkg/observability/inspect/types.go
+++ b/pkg/observability/inspect/types.go
@@ -37,10 +37,14 @@ const MaxBatchSubs = 32
 // Detail / raw flags are deliberately NOT exposed: batch always
 // returns summarized results. Callers needing detail or raw output
 // should use the singular awsinspect / gcpinspect tools.
+//
+// The `jsonschema:"..."` tags are read by MCP clients via
+// github.com/google/jsonschema-go reflection to publish per-property
+// descriptions on tools/list. They are inert for encoding/json.
 type SubRequest struct {
-	Service string `json:"service"`
-	Action  string `json:"action"`
-	Filters string `json:"filters,omitempty"`
+	Service string `json:"service" jsonschema:"Cloud service to query (e.g. 'ec2', 'rds', 's3' for AWS; 'compute', 'storage', 'cloudsql' for GCP). Use the singular awsinspect/gcpinspect tool with action='list-actions' to discover supported services."`
+	Action  string `json:"action" jsonschema:"Operation on the service (e.g. 'describe-instances', 'list-buckets', 'list-actions' for discovery, 'list-metrics' / 'get-metrics' for time-series)."`
+	Filters string `json:"filters,omitempty" jsonschema:"Optional JSON-encoded filter object passed through to the underlying API. Examples: '{\"hours\":6}' for metric windows, '{\"days\":7}' for cost queries."`
 }
 
 // SubResult is one probe's outcome. Index pins the result back to the

--- a/pkg/observability/inspect/types_test.go
+++ b/pkg/observability/inspect/types_test.go
@@ -114,17 +114,50 @@ func TestSubRequest_JSONShape(t *testing.T) {
 //
 // Substring-anchored rather than full-string-equal so copy-edits to
 // the description wording don't break the test — the concern is
-// "tag deleted" / "tag truncated to one word", not "wording polished".
+// "tag deleted" / "tag truncated to a stub", not "wording polished".
+//
+// Each field is pinned by:
+//  1. Two distinct semantic anchors — one descriptive lead-in, one
+//     concrete example literal. Single stem-words like "hours" or
+//     "list-actions" alone are too short to defeat a vandalizing
+//     truncation, so the second anchor is a quoted example fragment.
+//  2. A minimum-length floor (60 chars). A regression that replaced
+//     each tag with just the two anchors concatenated would still
+//     fail the floor — the actual tags are >100 chars, so 60 leaves
+//     comfortable room for legitimate copy-edits.
 func TestSubRequest_JSONSchemaTagsPresent(t *testing.T) {
 	t.Parallel()
+	const minTagLen = 60
 	rt := reflect.TypeFor[SubRequest]()
 	cases := []struct {
 		field   string
 		anchors []string
 	}{
-		{"Service", []string{"Cloud service to query", "list-actions"}},
-		{"Action", []string{"Operation on the service", "list-metrics"}},
-		{"Filters", []string{"JSON-encoded filter object", "hours"}},
+		{
+			"Service",
+			[]string{
+				"Cloud service to query",
+				"action='list-actions' to discover",
+			},
+		},
+		{
+			"Action",
+			[]string{
+				"Operation on the service",
+				"'list-metrics' / 'get-metrics'",
+			},
+		},
+		{
+			"Filters",
+			[]string{
+				"JSON-encoded filter object",
+				// reflect.StructTag.Get unescapes \" to " when extracting
+				// the tag value, so the anchor matches the unescaped form
+				// the MCP server actually publishes — not the source-level
+				// escape sequence.
+				`'{"hours":6}'`,
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.field, func(t *testing.T) {
@@ -136,6 +169,9 @@ func TestSubRequest_JSONSchemaTagsPresent(t *testing.T) {
 			tag := f.Tag.Get("jsonschema")
 			if tag == "" {
 				t.Fatalf("SubRequest.%s missing jsonschema tag (#280)", tc.field)
+			}
+			if len(tag) < minTagLen {
+				t.Errorf("SubRequest.%s jsonschema tag is suspiciously short (%d < %d) — likely truncated:\n  got: %q", tc.field, len(tag), minTagLen, tag)
 			}
 			for _, anchor := range tc.anchors {
 				if !strings.Contains(tag, anchor) {

--- a/pkg/observability/inspect/types_test.go
+++ b/pkg/observability/inspect/types_test.go
@@ -2,6 +2,7 @@ package inspect
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -98,6 +99,48 @@ func TestSubRequest_JSONShape(t *testing.T) {
 			}
 			if rt != tc.in {
 				t.Errorf("round-trip mismatch:\n  got = %+v\n want = %+v", rt, tc.in)
+			}
+		})
+	}
+}
+
+// TestSubRequest_JSONSchemaTagsPresent pins that the `jsonschema:"..."`
+// tags on SubRequest are present and carry the load-bearing description
+// content. Reliable's MCP server reads these via
+// github.com/google/jsonschema-go reflection to publish per-property
+// descriptions on tools/list (#280). A regression that deleted or
+// truncated a tag would silently drop the description from the MCP
+// schema and tank the Smithery quality score downstream.
+//
+// Substring-anchored rather than full-string-equal so copy-edits to
+// the description wording don't break the test — the concern is
+// "tag deleted" / "tag truncated to one word", not "wording polished".
+func TestSubRequest_JSONSchemaTagsPresent(t *testing.T) {
+	t.Parallel()
+	rt := reflect.TypeFor[SubRequest]()
+	cases := []struct {
+		field   string
+		anchors []string
+	}{
+		{"Service", []string{"Cloud service to query", "list-actions"}},
+		{"Action", []string{"Operation on the service", "list-metrics"}},
+		{"Filters", []string{"JSON-encoded filter object", "hours"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.field, func(t *testing.T) {
+			t.Parallel()
+			f, ok := rt.FieldByName(tc.field)
+			if !ok {
+				t.Fatalf("SubRequest has no field named %q", tc.field)
+			}
+			tag := f.Tag.Get("jsonschema")
+			if tag == "" {
+				t.Fatalf("SubRequest.%s missing jsonschema tag (#280)", tc.field)
+			}
+			for _, anchor := range tc.anchors {
+				if !strings.Contains(tag, anchor) {
+					t.Errorf("SubRequest.%s jsonschema tag missing anchor %q\n  got: %q", tc.field, anchor, tag)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Add `jsonschema:"..."` tags to `inspect.SubRequest{Service,Action,Filters}` so reliable's MCP server can read per-property descriptions via `google/jsonschema-go` reflection (used by `tools/list` for Claude / Cursor / Smithery quality scorer).
- Tag is inert for `encoding/json` — existing wire-shape tests in `TestSubRequest_JSONShape` still byte-equal, confirming no behavioural change for the dispatcher path.
- Unblocks `luthersystems/reliable#1317`: reliable can drop its parallel tagged copy at `internal/agentapi/inspect_batch_common.go` plus the `toInspectSubs` / `fromInspectSubResults` conversion helpers and import the canonical type directly.

## Out of scope
- `SubResult` — per-property descriptions on output schemas aren't required by Smithery's scorer and reliable's MCP server doesn't currently publish an `OutputSchema` for the batch tools. Defer until reliable adds output schemas.

## Test plan
- [x] `go test ./pkg/observability/inspect/... -count=1` (full inspect package, including new `TestSubRequest_JSONSchemaTagsPresent`)
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `terraform fmt -check -recursive`
- [x] `tests/lint-project-tag.sh` and `tests/lint-project-label.sh` pass
- [x] Existing `TestSubRequest_JSONShape` still byte-equals all four cases — confirms `encoding/json` ignores the new tag

## Review notes
- /review (self-review against P0/P1/P2/P3 rubric): no findings at any level
- qa-professor: flagged two P2s (single stem-word anchors too short to defeat truncation; no minimum-length floor) — both addressed in fixup commit. Anchors now pin distinct semantic chunks (descriptive lead-in + concrete example literal) and a 60-char floor catches "truncate to two anchors" mutations.
- No deferred follow-ups.

Closes #280