### PR TITLE
fix(composer): align cross-module wire references with declared block labels

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -382,7 +382,7 @@ type ComposeStackOpts struct {
 
 	// EmitObservabilityMoves opts in to emitting `moved {}` blocks that
 	// relocate Terraform state from the legacy aggregator alarms (under
-	// module.aws_cloudwatchmonitoring) to the new per-component alarms
+	// module.aws_cloudwatch_monitoring) to the new per-component alarms
 	// (e.g. module.aws_bastion). Default false: per-component alarms ship
 	// in addition to the aggregator (the documented duplicate-alarm
 	// window). Callers MUST flip this to true in the same apply that
@@ -615,7 +615,7 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 			block.DependsOn = []string{opensearchRef(selected)}
 		}
 		// Observability moves: when both this component and the legacy
-		// aws_cloudwatchmonitoring aggregator are selected AND the caller
+		// aws_cloudwatch_monitoring aggregator are selected AND the caller
 		// has opted in via opts.EmitObservabilityMoves, emit moved {}
 		// blocks relocating the legacy per-component alarms into this
 		// module. Caller opt-in is required because emitting moves while

--- a/pkg/composer/compose_module_refs_test.go
+++ b/pkg/composer/compose_module_refs_test.go
@@ -1,0 +1,120 @@
+package composer
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestComposeStack_AllModuleRefsResolveToDeclaredBlocks is the runtime
+// gate that catches semantic divergence between rendered `module "<X>"
+// {}` block labels and the `module.<X>.…` traversals in argument
+// expressions and `moved.from` attributes (issue #283). Where the static
+// lint test (TestModuleReferenceLiteralsMatchComponentKeys) catches a
+// hand-written literal sneaking back in, this test catches the case
+// where the WireRef helpers themselves render the wrong key.
+//
+// It composes a representative selection (cloudwatch_monitoring + every
+// driver in PricingDependencies[KeyAWSCloudWatchMonitoring] + the
+// observability moves opt-in so `moved.from` references are exercised
+// too), then walks the rendered main.tf and asserts every
+// `module.<X>.` reference resolves to a declared block label. A
+// terraform init against the composed root would fail if this assertion
+// did.
+func TestComposeStack_AllModuleRefsResolveToDeclaredBlocks(t *testing.T) {
+	c := newTestClient()
+
+	enabled := true
+	comps := &Components{
+		AWSVPC:                  "Private",
+		AWSLambda:               &enabled,
+		AWSRDS:                  &enabled,
+		AWSALB:                  &enabled,
+		AWSElastiCache:          &enabled,
+		AWSAPIGateway:           &enabled,
+		AWSSQS:                  &enabled,
+		AWSCloudWatchMonitoring: &enabled,
+	}
+
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud: "aws",
+		SelectedKeys: []ComponentKey{
+			KeyAWSVPC,
+			KeyAWSLambda,
+			KeyAWSRDS,
+			KeyAWSALB,
+			KeyAWSElastiCache,
+			KeyAWSAPIGateway,
+			KeyAWSSQS,
+			KeyAWSCloudWatchMonitoring,
+		},
+		Comps:                  comps,
+		Cfg:                    &Config{Region: "us-east-1"},
+		Project:                "test-283",
+		Region:                 "us-east-1",
+		EmitObservabilityMoves: true,
+	})
+	require.NoError(t, err)
+	mainTF, ok := out["/main.tf"]
+	require.True(t, ok, "expected /main.tf in composed output")
+	body := string(mainTF)
+
+	declRe := regexp.MustCompile(`module\s+"([^"]+)"\s*\{`)
+	declared := map[string]bool{}
+	for _, m := range declRe.FindAllStringSubmatch(body, -1) {
+		declared[m[1]] = true
+	}
+	require.NotEmpty(t, declared, "expected at least one declared module block in:\n%s", body)
+	require.True(t, declared[string(KeyAWSCloudWatchMonitoring)],
+		"sanity: composed root must declare module %q (selection includes the aggregator); declared=%v",
+		KeyAWSCloudWatchMonitoring, declared)
+
+	refRe := regexp.MustCompile(`module\.([a-z][a-z0-9_]*)\.`)
+	for _, m := range refRe.FindAllStringSubmatch(body, -1) {
+		ref := m[1]
+		assert.True(t, declared[ref],
+			"composed main.tf references module.%s.… but no `module \"%s\" {}` block is declared. "+
+				"This is the #283 class of bug — a wire literal or WireRef call rendered an identifier that doesn't match the declared block label. "+
+				"declared=%v",
+			ref, ref, declared)
+	}
+}
+
+// TestComposeStack_ObservabilityWireMatchesAggregatorBlock is the
+// minimal end-to-end repro of issue #283: select the aggregator + one
+// observability driver, render main.tf, and assert the
+// `alarm_topic_arn = module.<X>.sns_topic_arn` reference's <X> matches
+// the rendered `module "<X>" {}` block label. This test fails red on
+// `main` before the WireRef migration and green after.
+func TestComposeStack_ObservabilityWireMatchesAggregatorBlock(t *testing.T) {
+	c := newTestClient()
+	enabled := true
+	comps := &Components{
+		AWSVPC:                  "Private",
+		AWSSQS:                  &enabled,
+		AWSCloudWatchMonitoring: &enabled,
+	}
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud: "aws",
+		SelectedKeys: []ComponentKey{
+			KeyAWSVPC, KeyAWSSQS, KeyAWSCloudWatchMonitoring,
+		},
+		Comps:   comps,
+		Cfg:     &Config{Region: "us-east-1"},
+		Project: "test-283",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err)
+	body := string(out["/main.tf"])
+
+	expectedDecl := `module "` + string(KeyAWSCloudWatchMonitoring) + `"`
+	require.Contains(t, body, expectedDecl,
+		"expected aggregator block %q in composed main.tf", expectedDecl)
+
+	expectedRef := WireRef(KeyAWSCloudWatchMonitoring, "sns_topic_arn")
+	require.Contains(t, body, expectedRef,
+		"expected SQS module to receive alarm_topic_arn = %s; if this fails the wire reference does not match the aggregator's block label (#283)",
+		expectedRef)
+}

--- a/pkg/composer/compose_module_refs_test.go
+++ b/pkg/composer/compose_module_refs_test.go
@@ -2,64 +2,30 @@ package composer
 
 import (
 	"regexp"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestComposeStack_AllModuleRefsResolveToDeclaredBlocks is the runtime
-// gate that catches semantic divergence between rendered `module "<X>"
-// {}` block labels and the `module.<X>.…` traversals in argument
-// expressions and `moved.from` attributes (issue #283). Where the static
-// lint test (TestModuleReferenceLiteralsMatchComponentKeys) catches a
-// hand-written literal sneaking back in, this test catches the case
-// where the WireRef helpers themselves render the wrong key.
+// assertComposedRefsResolveToBlocks composes a stack with the given
+// selection and confirms every `module.<X>.…` traversal in the rendered
+// main.tf — both inside argument expressions and inside `moved.from`
+// attributes — resolves to a declared `module "<X>" {}` block.
 //
-// It composes a representative selection (cloudwatch_monitoring + every
-// driver in PricingDependencies[KeyAWSCloudWatchMonitoring] + the
-// observability moves opt-in so `moved.from` references are exercised
-// too), then walks the rendered main.tf and asserts every
-// `module.<X>.` reference resolves to a declared block label. A
-// terraform init against the composed root would fail if this assertion
-// did.
-func TestComposeStack_AllModuleRefsResolveToDeclaredBlocks(t *testing.T) {
-	c := newTestClient()
-
-	enabled := true
-	comps := &Components{
-		AWSVPC:                  "Private",
-		AWSLambda:               &enabled,
-		AWSRDS:                  &enabled,
-		AWSALB:                  &enabled,
-		AWSElastiCache:          &enabled,
-		AWSAPIGateway:           &enabled,
-		AWSSQS:                  &enabled,
-		AWSCloudWatchMonitoring: &enabled,
-	}
-
-	out, err := c.ComposeStack(ComposeStackOpts{
-		Cloud: "aws",
-		SelectedKeys: []ComponentKey{
-			KeyAWSVPC,
-			KeyAWSLambda,
-			KeyAWSRDS,
-			KeyAWSALB,
-			KeyAWSElastiCache,
-			KeyAWSAPIGateway,
-			KeyAWSSQS,
-			KeyAWSCloudWatchMonitoring,
-		},
-		Comps:                  comps,
-		Cfg:                    &Config{Region: "us-east-1"},
-		Project:                "test-283",
-		Region:                 "us-east-1",
-		EmitObservabilityMoves: true,
-	})
-	require.NoError(t, err)
-	mainTF, ok := out["/main.tf"]
-	require.True(t, ok, "expected /main.tf in composed output")
-	body := string(mainTF)
+// This is the load-bearing assertion for the runtime gate against
+// issue #283: where the static lint catches hand-written or
+// dynamically-composed `module.<X>.…` literals at compile time, this
+// catches the case where the WireRef helpers themselves render the
+// wrong key. Either of the two gates in isolation could be evaded;
+// together they close both axes.
+//
+// The test also asserts at least one cross-module wire is present —
+// otherwise a regression that silently deleted DefaultWiring's body
+// would pass via vacuous truth.
+func assertComposedRefsResolveToBlocks(t *testing.T, body string, mustDeclare ComponentKey) {
+	t.Helper()
 
 	declRe := regexp.MustCompile(`module\s+"([^"]+)"\s*\{`)
 	declared := map[string]bool{}
@@ -67,12 +33,17 @@ func TestComposeStack_AllModuleRefsResolveToDeclaredBlocks(t *testing.T) {
 		declared[m[1]] = true
 	}
 	require.NotEmpty(t, declared, "expected at least one declared module block in:\n%s", body)
-	require.True(t, declared[string(KeyAWSCloudWatchMonitoring)],
+	require.True(t, declared[string(mustDeclare)],
 		"sanity: composed root must declare module %q (selection includes the aggregator); declared=%v",
-		KeyAWSCloudWatchMonitoring, declared)
+		mustDeclare, declared)
 
 	refRe := regexp.MustCompile(`module\.([a-z][a-z0-9_]*)\.`)
-	for _, m := range refRe.FindAllStringSubmatch(body, -1) {
+	matches := refRe.FindAllStringSubmatch(body, -1)
+	require.NotEmpty(t, matches,
+		"composed main.tf contains zero `module.<X>.…` references — DefaultWiring may have been silently emptied; declared=%v",
+		declared)
+
+	for _, m := range matches {
 		ref := m[1]
 		assert.True(t, declared[ref],
 			"composed main.tf references module.%s.… but no `module \"%s\" {}` block is declared. "+
@@ -82,12 +53,207 @@ func TestComposeStack_AllModuleRefsResolveToDeclaredBlocks(t *testing.T) {
 	}
 }
 
+// nonComputeDrivers returns drivers that aren't in any of the supplied
+// compute-key registries, so each per-architecture subtest can append
+// its compute keys without conflict with ValidateComputeExclusivity.
+//
+// Reads from the exported AWSServerlessKeys / AWSContainerKeys /
+// GCPServerlessKeys / GCPContainerKeys registries in validate.go so
+// the test stays in lockstep with ValidateComputeExclusivity — adding
+// a new compute key in one place automatically updates the other.
+func nonComputeDrivers(drivers []ComponentKey, registries ...[]ComponentKey) []ComponentKey {
+	out := make([]ComponentKey, 0, len(drivers))
+	for _, k := range drivers {
+		isCompute := false
+		for _, reg := range registries {
+			if slices.Contains(reg, k) {
+				isCompute = true
+				break
+			}
+		}
+		if !isCompute {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// TestComposeStack_AllAWSObservabilityWiresResolveToDeclaredBlocks runs
+// the runtime gate over every AWS observability wire that
+// PricingDependencies[KeyAWSCloudWatchMonitoring] declares. The
+// driver list is iterated mechanically so a new entry there is
+// automatically covered. Compute architectures conflict per
+// ValidateComputeExclusivity, so the test partitions into Lambda /
+// container subtests; together they exercise every PricingDependencies
+// driver plus the EmitObservabilityMoves opt-in (so `moved.from`
+// references are also walked).
+func TestComposeStack_AllAWSObservabilityWiresResolveToDeclaredBlocks(t *testing.T) {
+	c := newTestClient()
+	enabled := true
+	intel := "Intel"
+
+	// Sanity-pin against accidental empty PricingDependencies.
+	require.NotEmpty(t, PricingDependencies[KeyAWSCloudWatchMonitoring],
+		"PricingDependencies[KeyAWSCloudWatchMonitoring] must be non-empty for the runtime gate to exercise any wires")
+
+	nonCompute := nonComputeDrivers(
+		PricingDependencies[KeyAWSCloudWatchMonitoring],
+		AWSServerlessKeys, AWSContainerKeys,
+	)
+
+	type variant struct {
+		name        string
+		computeKeys []ComponentKey
+		comps       func(c *Components)
+	}
+
+	variants := []variant{
+		{
+			name:        "lambda_only",
+			computeKeys: []ComponentKey{KeyAWSLambda},
+			comps:       func(c *Components) { c.AWSLambda = &enabled },
+		},
+		{
+			name:        "eks_ecs_ec2_combo",
+			computeKeys: []ComponentKey{KeyAWSEKS, KeyAWSECS, KeyAWSEC2},
+			comps: func(c *Components) {
+				c.AWSEKS = &enabled
+				c.AWSECS = &enabled
+				c.AWSEC2 = intel
+			},
+		},
+	}
+
+	for _, v := range variants {
+		t.Run(v.name, func(t *testing.T) {
+			comps := &Components{
+				AWSVPC:                  "Private",
+				AWSALB:                  &enabled,
+				AWSAPIGateway:           &enabled,
+				AWSRDS:                  &enabled,
+				AWSElastiCache:          &enabled,
+				AWSDynamoDB:             &enabled,
+				AWSOpenSearch:           &enabled,
+				AWSSQS:                  &enabled,
+				AWSMSK:                  &enabled,
+				AWSBastion:              &enabled,
+				AWSCloudWatchMonitoring: &enabled,
+			}
+			v.comps(comps)
+
+			selected := append([]ComponentKey{KeyAWSVPC, KeyAWSCloudWatchMonitoring}, nonCompute...)
+			selected = append(selected, v.computeKeys...)
+
+			out, err := c.ComposeStack(ComposeStackOpts{
+				Cloud:                  "aws",
+				SelectedKeys:           selected,
+				Comps:                  comps,
+				Cfg:                    &Config{Region: "us-east-1"},
+				Project:                "test-283-aws-" + v.name,
+				Region:                 "us-east-1",
+				EmitObservabilityMoves: true,
+			})
+			require.NoError(t, err)
+			mainTF, ok := out["/main.tf"]
+			require.True(t, ok, "expected /main.tf in composed output")
+
+			assertComposedRefsResolveToBlocks(t, string(mainTF), KeyAWSCloudWatchMonitoring)
+		})
+	}
+}
+
+// TestComposeStack_AllGCPObservabilityWiresResolveToDeclaredBlocks
+// mirrors the AWS gate over the GCP wire surface. DefaultWiring's GCP
+// arm has eight WireRef call sites (network_self_link x6,
+// connector_id x2, security_policy_id, notification_channels) plus the
+// observability bind on every PricingDependencies[KeyGCPCloudMonitoring]
+// driver, none of which were exercised by an end-to-end runtime gate
+// before this test landed. A future typo introducing
+// `WireRef("gcp_cloudmonitoring", ...)` (missing underscore — exactly
+// the #283 shape) would ship green without it. Compute architectures
+// conflict per ValidateComputeExclusivity, so partition into
+// serverless / container subtests.
+func TestComposeStack_AllGCPObservabilityWiresResolveToDeclaredBlocks(t *testing.T) {
+	c := newTestClient()
+	enabled := true
+	intel := "Intel"
+
+	require.NotEmpty(t, PricingDependencies[KeyGCPCloudMonitoring],
+		"PricingDependencies[KeyGCPCloudMonitoring] must be non-empty for the runtime gate to exercise any wires")
+
+	nonCompute := nonComputeDrivers(
+		PricingDependencies[KeyGCPCloudMonitoring],
+		GCPServerlessKeys, GCPContainerKeys,
+	)
+
+	type variant struct {
+		name        string
+		computeKeys []ComponentKey
+		comps       func(c *Components)
+	}
+
+	variants := []variant{
+		{
+			name:        "cloud_run_and_functions",
+			computeKeys: []ComponentKey{KeyGCPCloudFunctions, KeyGCPCloudRun},
+			comps: func(c *Components) {
+				c.GCPCloudFunctions = &enabled
+				c.GCPCloudRun = &enabled
+			},
+		},
+		{
+			name:        "gke_only",
+			computeKeys: []ComponentKey{KeyGCPGKE},
+			comps:       func(c *Components) { c.GCPGKE = &enabled },
+		},
+	}
+
+	for _, v := range variants {
+		t.Run(v.name, func(t *testing.T) {
+			comps := &Components{
+				GCPVPC:             &enabled,
+				GCPCompute:         intel,
+				GCPLoadbalancer:    &enabled,
+				GCPCloudArmor:      &enabled, // exercises security_policy_id wire
+				GCPCloudSQL:        &enabled,
+				GCPMemorystore:     &enabled,
+				GCPAPIGateway:      &enabled,
+				GCPPubSub:          &enabled,
+				GCPFirestore:       &enabled,
+				GCPBastion:         &enabled,
+				GCPCloudMonitoring: &enabled,
+			}
+			v.comps(comps)
+
+			selected := append([]ComponentKey{KeyGCPVPC, KeyGCPCloudArmor, KeyGCPCloudMonitoring}, nonCompute...)
+			selected = append(selected, v.computeKeys...)
+
+			out, err := c.ComposeStack(ComposeStackOpts{
+				Cloud:        "gcp",
+				SelectedKeys: selected,
+				Comps:        comps,
+				Cfg:          &Config{Region: "us-central1"},
+				Project:      "test-283-gcp-" + v.name,
+				Region:       "us-central1",
+				GCPProjectID: "test-283-gcp-projid",
+			})
+			require.NoError(t, err)
+			mainTF, ok := out["/main.tf"]
+			require.True(t, ok, "expected /main.tf in composed output")
+
+			assertComposedRefsResolveToBlocks(t, string(mainTF), KeyGCPCloudMonitoring)
+		})
+	}
+}
+
 // TestComposeStack_ObservabilityWireMatchesAggregatorBlock is the
-// minimal end-to-end repro of issue #283: select the aggregator + one
-// observability driver, render main.tf, and assert the
-// `alarm_topic_arn = module.<X>.sns_topic_arn` reference's <X> matches
-// the rendered `module "<X>" {}` block label. This test fails red on
-// `main` before the WireRef migration and green after.
+// minimal end-to-end repro of issue #283. The expected literal is
+// pinned as a hardcoded string (NOT computed via WireRef) so this
+// assertion is independent of the helper under test — if WireRef ever
+// drifts to render a different identifier, this test catches it. The
+// other runtime gate (assertComposedRefsResolveToBlocks) proves the
+// block-label/ref consistency property; this test pins the canonical
+// rendered value.
 func TestComposeStack_ObservabilityWireMatchesAggregatorBlock(t *testing.T) {
 	c := newTestClient()
 	enabled := true
@@ -107,14 +273,17 @@ func TestComposeStack_ObservabilityWireMatchesAggregatorBlock(t *testing.T) {
 		Region:  "us-east-1",
 	})
 	require.NoError(t, err)
+	require.Contains(t, out, "/main.tf",
+		"composed output must contain /main.tf — check that the composer's emit path hasn't been renamed")
 	body := string(out["/main.tf"])
 
-	expectedDecl := `module "` + string(KeyAWSCloudWatchMonitoring) + `"`
-	require.Contains(t, body, expectedDecl,
-		"expected aggregator block %q in composed main.tf", expectedDecl)
-
-	expectedRef := WireRef(KeyAWSCloudWatchMonitoring, "sns_topic_arn")
-	require.Contains(t, body, expectedRef,
-		"expected SQS module to receive alarm_topic_arn = %s; if this fails the wire reference does not match the aggregator's block label (#283)",
-		expectedRef)
+	// Pinned canonical strings — NOT WireRef-derived. If KeyAWSCloudWatchMonitoring
+	// ever renames or WireRef rewrites identifiers, this test fails red so a
+	// human reviews the change. Both halves of the #283 bug are pinned: the
+	// declared block label AND the wire reference.
+	require.Contains(t, body, `module "aws_cloudwatch_monitoring"`,
+		"composed root must declare `module \"aws_cloudwatch_monitoring\" {}` (the canonical aggregator block label)")
+	require.Contains(t, body, `module.aws_cloudwatch_monitoring.sns_topic_arn`,
+		"composed SQS module must reference the canonical aggregator wire `module.aws_cloudwatch_monitoring.sns_topic_arn`. "+
+			"If this fails, the wire reference does not match the declared block label — the #283 bug shape.")
 }

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -547,7 +547,7 @@ func TestComposeStack_KitchenSink(t *testing.T) {
 		// per-component EKS alarm gets its alarm_topic_arn wired).
 		require.Contains(t, mainTF, `cluster_name         = module.aws_eks.cluster_name`)
 		require.Contains(t, mainTF, `subnet_ids           = module.aws_vpc.private_subnet_ids`)
-		require.Contains(t, mainTF, `alarm_topic_arn      = module.aws_cloudwatchmonitoring.sns_topic_arn`)
+		require.Contains(t, mainTF, `alarm_topic_arn      = module.aws_cloudwatch_monitoring.sns_topic_arn`)
 		require.Contains(t, mainTF, `enable_observability = true`)
 	})
 

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -13,7 +13,10 @@ import (
 // materialized the subnet list, the fallback null lets terraform plan
 // progress without producing the "Invalid index ... empty tuple" stage_error
 // that the custom-stack-provision pipeline previously surfaced.
-const vpcSubnetSelfLinkExpr = "try(module.gcp_vpc.subnet_self_links[0], null)"
+//
+// Built from WireRef so the prefix is guaranteed to match the rendered
+// `module "gcp_vpc" {}` block label (#283).
+var vpcSubnetSelfLinkExpr = "try(" + WireRef(KeyGCPVPC, "subnet_self_links") + "[0], null)"
 
 type ComponentKey string
 
@@ -528,18 +531,18 @@ type WiredInputs struct {
 
 func vpcRef(selected map[ComponentKey]bool) string {
 	if selected[KeyGCPVPC] {
-		return "module.gcp_vpc"
+		return ModuleRef(KeyGCPVPC)
 	}
-	return "module.aws_vpc"
+	return ModuleRef(KeyAWSVPC)
 }
 
-func albRef(_ map[ComponentKey]bool) string        { return "module.aws_alb" }
-func wafRef(_ map[ComponentKey]bool) string        { return "module.aws_waf" }
-func bastionRef(_ map[ComponentKey]bool) string    { return "module.aws_bastion" }
-func rdsRef(_ map[ComponentKey]bool) string        { return "module.aws_rds" }
-func s3Ref(_ map[ComponentKey]bool) string         { return "module.aws_s3" }
-func opensearchRef(_ map[ComponentKey]bool) string { return "module.aws_opensearch" }
-func sqsRef(_ map[ComponentKey]bool) string        { return "module.aws_sqs" }
+func albRef(_ map[ComponentKey]bool) string        { return ModuleRef(KeyAWSALB) }
+func wafRef(_ map[ComponentKey]bool) string        { return ModuleRef(KeyAWSWAF) }
+func bastionRef(_ map[ComponentKey]bool) string    { return ModuleRef(KeyAWSBastion) }
+func rdsRef(_ map[ComponentKey]bool) string        { return ModuleRef(KeyAWSRDS) }
+func s3Ref(_ map[ComponentKey]bool) string         { return ModuleRef(KeyAWSS3) }
+func opensearchRef(_ map[ComponentKey]bool) string { return ModuleRef(KeyAWSOpenSearch) }
+func sqsRef(_ map[ComponentKey]bool) string        { return ModuleRef(KeyAWSSQS) }
 
 // resourceRef returns the EKS/ECS module reference for the selected stack.
 // Prefers the prefixed KeyAWSEKS / KeyAWSECS keys, with a KeyAWSEKSControlPlane path
@@ -549,15 +552,15 @@ func sqsRef(_ map[ComponentKey]bool) string        { return "module.aws_sqs" }
 // prefixed name defensively.
 func resourceRef(selected map[ComponentKey]bool) string {
 	if selected[KeyAWSEKS] {
-		return "module.aws_eks"
+		return ModuleRef(KeyAWSEKS)
 	}
 	if selected[KeyAWSECS] {
-		return "module.aws_ecs"
+		return ModuleRef(KeyAWSECS)
 	}
 	if selected[KeyAWSEKSControlPlane] {
-		return "module.resource"
+		return ModuleRef(KeyAWSEKSControlPlane)
 	}
-	return "module.aws_eks"
+	return ModuleRef(KeyAWSEKS)
 }
 
 // DefaultWiring returns cross-module references for module k. The caller's
@@ -820,59 +823,59 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 
 	case KeyGCPGKE:
 		if selected[KeyGCPVPC] {
-			wi.RawHCL["network_self_link"] = "module.gcp_vpc.network_self_link"
+			wi.RawHCL["network_self_link"] = WireRef(KeyGCPVPC, "network_self_link")
 			wi.RawHCL["subnet_self_link"] = vpcSubnetSelfLinkExpr
-			wi.RawHCL["pods_range_name"] = "module.gcp_vpc.pods_range_name"
-			wi.RawHCL["services_range_name"] = "module.gcp_vpc.services_range_name"
+			wi.RawHCL["pods_range_name"] = WireRef(KeyGCPVPC, "pods_range_name")
+			wi.RawHCL["services_range_name"] = WireRef(KeyGCPVPC, "services_range_name")
 			wi.Names = append(wi.Names, "network_self_link", "subnet_self_link", "pods_range_name", "services_range_name")
 		}
 
 	case KeyGCPLoadbalancer:
 		if selected[KeyGCPVPC] {
-			wi.RawHCL["network_self_link"] = "module.gcp_vpc.network_self_link"
+			wi.RawHCL["network_self_link"] = WireRef(KeyGCPVPC, "network_self_link")
 			wi.RawHCL["subnet_self_link"] = vpcSubnetSelfLinkExpr
 			wi.Names = append(wi.Names, "network_self_link", "subnet_self_link")
 		}
 		if selected[KeyGCPCloudArmor] {
-			wi.RawHCL["security_policy"] = "module.gcp_cloud_armor.security_policy_id"
+			wi.RawHCL["security_policy"] = WireRef(KeyGCPCloudArmor, "security_policy_id")
 			wi.Names = append(wi.Names, "security_policy")
 		}
 
 	case KeyGCPCloudSQL:
 		if selected[KeyGCPVPC] {
-			wi.RawHCL["network_self_link"] = "module.gcp_vpc.network_self_link"
+			wi.RawHCL["network_self_link"] = WireRef(KeyGCPVPC, "network_self_link")
 			wi.Names = append(wi.Names, "network_self_link")
 		}
 
 	case KeyGCPMemorystore:
 		if selected[KeyGCPVPC] {
-			wi.RawHCL["authorized_network"] = "module.gcp_vpc.network_self_link"
+			wi.RawHCL["authorized_network"] = WireRef(KeyGCPVPC, "network_self_link")
 			wi.Names = append(wi.Names, "authorized_network")
 		}
 
 	case KeyGCPCompute:
 		if selected[KeyGCPVPC] {
-			wi.RawHCL["network_self_link"] = "module.gcp_vpc.network_self_link"
+			wi.RawHCL["network_self_link"] = WireRef(KeyGCPVPC, "network_self_link")
 			wi.RawHCL["subnet_self_link"] = vpcSubnetSelfLinkExpr
 			wi.Names = append(wi.Names, "network_self_link", "subnet_self_link")
 		}
 
 	case KeyGCPBastion:
 		if selected[KeyGCPVPC] {
-			wi.RawHCL["network_self_link"] = "module.gcp_vpc.network_self_link"
+			wi.RawHCL["network_self_link"] = WireRef(KeyGCPVPC, "network_self_link")
 			wi.RawHCL["subnet_self_link"] = vpcSubnetSelfLinkExpr
 			wi.Names = append(wi.Names, "network_self_link", "subnet_self_link")
 		}
 
 	case KeyGCPCloudRun:
 		if selected[KeyGCPVPC] {
-			wi.RawHCL["vpc_connector"] = "module.gcp_vpc.connector_id"
+			wi.RawHCL["vpc_connector"] = WireRef(KeyGCPVPC, "connector_id")
 			wi.Names = append(wi.Names, "vpc_connector")
 		}
 
 	case KeyGCPCloudFunctions:
 		if selected[KeyGCPVPC] {
-			wi.RawHCL["vpc_connector"] = "module.gcp_vpc.connector_id"
+			wi.RawHCL["vpc_connector"] = WireRef(KeyGCPVPC, "connector_id")
 			wi.Names = append(wi.Names, "vpc_connector")
 		}
 	}
@@ -880,7 +883,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 	// Observability post-switch wiring (issue #204). Driven off the
 	// PricingDependencies driver lists so a component added there
 	// gets observability wiring "for free." When the matching
-	// aggregator (aws_cloudwatchmonitoring or gcp_cloud_monitoring) is
+	// aggregator (aws_cloudwatch_monitoring or gcp_cloud_monitoring) is
 	// selected, every per-component emitter receives the SNS topic ARN
 	// (AWS) or notification channels (GCP) plus an enable_observability
 	// = true gate. The aggregator itself is excluded.
@@ -899,14 +902,14 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 	// reaches a module that can't consume it.
 	if k != KeyAWSCloudWatchMonitoring && CloudFor(k) == "aws" && selected[KeyAWSCloudWatchMonitoring] {
 		if slices.Contains(PricingDependencies[KeyAWSCloudWatchMonitoring], k) {
-			wi.RawHCL["alarm_topic_arn"] = "module.aws_cloudwatchmonitoring.sns_topic_arn"
+			wi.RawHCL["alarm_topic_arn"] = WireRef(KeyAWSCloudWatchMonitoring, "sns_topic_arn")
 			wi.RawHCL["enable_observability"] = "true"
 			wi.Names = append(wi.Names, "alarm_topic_arn", "enable_observability")
 		}
 	}
 	if k != KeyGCPCloudMonitoring && CloudFor(k) == "gcp" && selected[KeyGCPCloudMonitoring] {
 		if slices.Contains(PricingDependencies[KeyGCPCloudMonitoring], k) {
-			wi.RawHCL["notification_channels"] = "module.gcp_cloud_monitoring.notification_channels"
+			wi.RawHCL["notification_channels"] = WireRef(KeyGCPCloudMonitoring, "notification_channels")
 			wi.RawHCL["enable_observability"] = "true"
 			wi.Names = append(wi.Names, "notification_channels", "enable_observability")
 		}

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -796,7 +796,7 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		}
 		if enableDdb {
 			if hasDynamoDB {
-				wi.RawHCL["dynamodb_rule"] = "{\n  selection = { resource_arns = [module.aws_dynamodb.table_arn], selection_tags = [] }\n}"
+				wi.RawHCL["dynamodb_rule"] = "{\n  selection = { resource_arns = [" + WireRef(KeyAWSDynamoDB, "table_arn") + "], selection_tags = [] }\n}"
 			} else {
 				wi.RawHCL["dynamodb_rule"] = tagFallback
 			}

--- a/pkg/composer/emit.go
+++ b/pkg/composer/emit.go
@@ -522,7 +522,7 @@ func EmitRootOutputsTF(modules []ModuleOutputs) []byte {
 				ob.SetAttributeValue("description", cty.StringVal(o.Description))
 			}
 
-			valueExpr := fmt.Sprintf("module.%s.%s", m.Module, o.Name)
+			valueExpr := WireRef(ComponentKey(m.Module), o.Name)
 			setRawExpr(ob, "value", valueExpr)
 
 			if o.Sensitive {

--- a/pkg/composer/emit.go
+++ b/pkg/composer/emit.go
@@ -362,7 +362,7 @@ type ModuleBlock struct {
 	// Moved emits one or more top-level `moved { from = <expr>; to = <expr> }`
 	// blocks after the module block. Used by the observability migration
 	// (issue #204) to relocate per-component alarms from the
-	// aws_cloudwatchmonitoring aggregator into the per-component modules
+	// aws_cloudwatch_monitoring aggregator into the per-component modules
 	// without forcing destroy+create. The `to` address typically references a
 	// resource in this same module (e.g. module.aws_sqs.aws_cloudwatch_metric_alarm.backlog["0"]).
 	//
@@ -374,12 +374,27 @@ type ModuleBlock struct {
 }
 
 // MovedRef is one source/destination pair for a top-level `moved {}` block.
-// Both addresses are raw HCL expressions — callers are responsible for
-// quoting string keys (`module.foo.aws_x.y["0"]`) since `moved` blocks
-// take resource references, not strings.
+//
+// FromComponent identifies the source module by ComponentKey; the rendered
+// `from = module.<key>.<addr>` is built from `WireRef(FromComponent, FromAddress)`
+// so the prefix is guaranteed to match the composer's emitted block label.
+// FromAddress is the resource address inside the source module, e.g.
+// `aws_cloudwatch_metric_alarm.ec2_cpu_high["0"]`. Callers are responsible
+// for quoting string for_each keys (`["0"]`) since `moved` blocks take
+// resource references, not strings.
+//
+// To is the destination address rendered verbatim — typically a fully
+// qualified `module.<other>.<resource>...` reference produced by the same
+// composer.
 type MovedRef struct {
-	From string
-	To   string
+	FromComponent ComponentKey
+	FromAddress   string
+	To            string
+}
+
+// FromHCL renders the `from = ...` expression for the moved block.
+func (m MovedRef) FromHCL() string {
+	return WireRef(m.FromComponent, m.FromAddress)
 }
 
 func EmitRootMainTF(blocks []ModuleBlock) []byte {
@@ -421,14 +436,17 @@ func EmitRootMainTF(blocks []ModuleBlock) []byte {
 			setRawExpr(mb, "depends_on", "["+strings.Join(m.DependsOn, ", ")+"]")
 		}
 		// Emit any `moved {}` blocks immediately after the module they
-		// relocate into. Source addresses typically reference an old
-		// aggregator module (e.g. module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.foo["0"])
+		// relocate into. Source addresses typically reference the legacy
+		// aggregator module (e.g. module.aws_cloudwatch_monitoring.aws_cloudwatch_metric_alarm.foo["0"])
 		// and destination addresses reference a resource in this module
 		// (e.g. module.aws_sqs.aws_cloudwatch_metric_alarm.backlog["0"]).
+		// FromHCL() renders the source from the typed (FromComponent,
+		// FromAddress) pair, so the prefix matches the declared block
+		// label by construction (#283).
 		for _, mv := range m.Moved {
 			body.AppendNewline()
 			mvBlock := body.AppendNewBlock("moved", nil).Body()
-			setRawExpr(mvBlock, "from", mv.From)
+			setRawExpr(mvBlock, "from", mv.FromHCL())
 			setRawExpr(mvBlock, "to", mv.To)
 		}
 		// Add a blank line between module blocks for readability.

--- a/pkg/composer/emit_moved_test.go
+++ b/pkg/composer/emit_moved_test.go
@@ -31,8 +31,9 @@ func TestEmitRootMainTF_OneMovedBlock(t *testing.T) {
 			Source: "./aws/sqs",
 			Moved: []MovedRef{
 				{
-					From: `module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
-					To:   `module.aws_sqs.aws_cloudwatch_metric_alarm.backlog["0"]`,
+					FromComponent: KeyAWSCloudWatchMonitoring,
+					FromAddress:   `aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
+					To:            `module.aws_sqs.aws_cloudwatch_metric_alarm.backlog["0"]`,
 				},
 			},
 		},
@@ -41,8 +42,8 @@ func TestEmitRootMainTF_OneMovedBlock(t *testing.T) {
 
 	assert.Contains(t, got, `moved {`,
 		"emitted output should contain a moved {} block")
-	assert.Contains(t, got, `from = module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
-		"emitted moved.from should match the source address verbatim")
+	assert.Contains(t, got, `from = module.aws_cloudwatch_monitoring.aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
+		"emitted moved.from should match WireRef(FromComponent, FromAddress) — the prefix matches the declared module block label")
 	assert.Contains(t, got, `to   = module.aws_sqs.aws_cloudwatch_metric_alarm.backlog["0"]`,
 		"emitted moved.to should match the destination address verbatim")
 }
@@ -56,12 +57,14 @@ func TestEmitRootMainTF_MultipleMovedBlocks(t *testing.T) {
 			Source: "./aws/rds",
 			Moved: []MovedRef{
 				{
-					From: `module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.rds_cpu_high["0"]`,
-					To:   `module.aws_rds.aws_cloudwatch_metric_alarm.cpu_high["0"]`,
+					FromComponent: KeyAWSCloudWatchMonitoring,
+					FromAddress:   `aws_cloudwatch_metric_alarm.rds_cpu_high["0"]`,
+					To:            `module.aws_rds.aws_cloudwatch_metric_alarm.cpu_high["0"]`,
 				},
 				{
-					From: `module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.rds_free_storage_low["0"]`,
-					To:   `module.aws_rds.aws_cloudwatch_metric_alarm.free_storage_low["0"]`,
+					FromComponent: KeyAWSCloudWatchMonitoring,
+					FromAddress:   `aws_cloudwatch_metric_alarm.rds_free_storage_low["0"]`,
+					To:            `module.aws_rds.aws_cloudwatch_metric_alarm.free_storage_low["0"]`,
 				},
 			},
 		},
@@ -81,8 +84,9 @@ func TestEmitRootMainTF_MovedBlocksRoundTripParse(t *testing.T) {
 			Name:   "aws_sqs",
 			Source: "./aws/sqs",
 			Moved: []MovedRef{{
-				From: `module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
-				To:   `module.aws_sqs.aws_cloudwatch_metric_alarm.backlog["0"]`,
+				FromComponent: KeyAWSCloudWatchMonitoring,
+				FromAddress:   `aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
+				To:            `module.aws_sqs.aws_cloudwatch_metric_alarm.backlog["0"]`,
 			}},
 		},
 	}
@@ -112,8 +116,9 @@ func TestEmitRootMainTF_MovedFollowsModule(t *testing.T) {
 			Name:   "aws_sqs",
 			Source: "./aws/sqs",
 			Moved: []MovedRef{{
-				From: `module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
-				To:   `module.aws_sqs.aws_cloudwatch_metric_alarm.backlog["0"]`,
+				FromComponent: KeyAWSCloudWatchMonitoring,
+				FromAddress:   `aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
+				To:            `module.aws_sqs.aws_cloudwatch_metric_alarm.backlog["0"]`,
 			}},
 		},
 	}

--- a/pkg/composer/lint_module_refs_test.go
+++ b/pkg/composer/lint_module_refs_test.go
@@ -15,6 +15,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// modRefRe matches `module.<X>.` traversals inside a string literal.
+var modRefRe = regexp.MustCompile(`module\.([a-z][a-z0-9_]*)\.`)
+
+// fmtSprintfModuleRe matches `module.%s` (or `module.%[N]s`) in a format
+// string — the most natural way a developer might recompose a wire
+// reference dynamically and silently bypass the static lint's literal
+// scan. We flag any such format and force the helper.
+var fmtSprintfModuleRe = regexp.MustCompile(`module\.%(\[\d+\])?s\.?`)
+
+// concatStringLiteralValue walks a Go expression and, if it is a chain
+// of `+`-concatenated BasicLit string literals, returns the joined
+// string and true. This unwraps the static-lint evasion case
+// `"module." + "<key>" + ".<output>"` (issue #283 P0-1) so the
+// reference regex can still see the full traversal. Returns "", false
+// for any expression that isn't a pure literal-only concatenation
+// (mixed identifiers, function calls, etc.) — those are handled
+// separately by the fmt.Sprintf detector.
+func concatStringLiteralValue(e ast.Expr) (string, bool) {
+	switch x := e.(type) {
+	case *ast.BasicLit:
+		if x.Kind != token.STRING {
+			return "", false
+		}
+		s, err := strconv.Unquote(x.Value)
+		if err != nil {
+			return "", false
+		}
+		return s, true
+	case *ast.BinaryExpr:
+		if x.Op != token.ADD {
+			return "", false
+		}
+		l, lok := concatStringLiteralValue(x.X)
+		r, rok := concatStringLiteralValue(x.Y)
+		if !lok || !rok {
+			return "", false
+		}
+		return l + r, true
+	case *ast.ParenExpr:
+		return concatStringLiteralValue(x.X)
+	}
+	return "", false
+}
+
 // TestModuleReferenceLiteralsMatchComponentKeys is the static CI gate that
 // prevents the class of bug behind issue #283: any string literal in
 // production code that contains `module.<X>.` must have <X> equal to a
@@ -28,50 +72,115 @@ import (
 // `aws_cloudwatchmonitoring` vs the snake form `aws_cloudwatch_monitoring`)
 // because nothing tied the two together.
 //
-// This test scans every production .go file under the package directory,
-// extracts each string literal via go/parser (so comments are skipped), and
-// fails on any `module.<X>.` whose <X> is not a known ComponentKey rendered
-// as a module. Fix: either use the ComponentKey value (`"module." + string(k)`,
-// preferably via ModuleRef / WireRef) or, if a new identifier really is
-// needed, declare a ComponentKey constant for it first and add it to
-// ModulePath.
+// Three scan modes (each catches an evasion that the previous mode misses):
+//
+//  1. Bare BasicLit string literals — the simplest case.
+//  2. Concatenation chains of BasicLit literals (`"module." + "X" + ".y"`)
+//     — go/parser emits each segment as a separate node, so the bare-lit
+//     scan misses them. Reassembled via concatStringLiteralValue before
+//     applying the regex.
+//  3. fmt.Sprintf calls whose format string contains `module.%s.…` — a
+//     dynamic-substitution form is structurally indistinguishable from
+//     the helper at compile time, so we force the helper to be used
+//     instead. The lint flags any such Sprintf as a hint to call
+//     ModuleRef / WireRef.
+//
+// Fix paths when the lint trips: either use the ComponentKey value via
+// `ModuleRef(KeyXxx)` / `WireRef(KeyXxx, "output")` (the canonical
+// path), or — if a new identifier really is needed — declare a
+// ComponentKey constant for it first and add it to ModulePath.
 func TestModuleReferenceLiteralsMatchComponentKeys(t *testing.T) {
 	valid := map[string]struct{}{}
 	for k := range ModulePath {
 		valid[string(k)] = struct{}{}
 	}
 
-	re := regexp.MustCompile(`module\.([a-z][a-z0-9_]*)\.`)
 	fset := token.NewFileSet()
-
 	entries, err := os.ReadDir(".")
 	require.NoError(t, err, "read pkg/composer directory")
+
+	checkLiteral := func(s string, pos token.Position) {
+		for _, m := range modRefRe.FindAllStringSubmatch(s, -1) {
+			if _, ok := valid[m[1]]; !ok {
+				t.Errorf(
+					"%s: literal %q references module %q which is not a known ComponentKey rendered into a module block. "+
+						"Use ModuleRef(KeyXxx) or WireRef(KeyXxx, \"output\") so ComponentKey is the single source of truth (#283). "+
+						"If the identifier is intentionally new, declare a ComponentKey constant and add it to ModulePath.",
+					pos, s, m[1])
+			}
+		}
+	}
 
 	for _, e := range entries {
 		name := e.Name()
 		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			continue
 		}
+		// Skip wireref.go itself: it is the canonical helper that
+		// builds `module.<key>.<output>` strings via fmt.Sprintf and
+		// concat — flagging its own implementation would defeat the
+		// purpose. The helper is exercised through every consumer in
+		// production code, so any breakage there fails real tests.
+		if name == "wireref.go" {
+			continue
+		}
 		f, perr := parser.ParseFile(fset, name, nil, 0)
 		require.NoError(t, perr, "parse %s", name)
 
 		ast.Inspect(f, func(n ast.Node) bool {
-			lit, ok := n.(*ast.BasicLit)
-			if !ok || lit.Kind != token.STRING {
-				return true
-			}
-			s, uerr := strconv.Unquote(lit.Value)
-			if uerr != nil {
-				return true
-			}
-			for _, m := range re.FindAllStringSubmatch(s, -1) {
-				if _, ok := valid[m[1]]; !ok {
-					pos := fset.Position(lit.Pos())
+			switch x := n.(type) {
+			case *ast.BasicLit:
+				if x.Kind != token.STRING {
+					return true
+				}
+				s, uerr := strconv.Unquote(x.Value)
+				if uerr != nil {
+					return true
+				}
+				checkLiteral(s, fset.Position(x.Pos()))
+			case *ast.BinaryExpr:
+				// Reassemble pure-literal concat chains and check the joined value.
+				// We only inspect ADD nodes whose root has at least one nested ADD,
+				// to avoid double-checking single-literal cases already handled above.
+				if x.Op != token.ADD {
+					return true
+				}
+				if s, ok := concatStringLiteralValue(x); ok {
+					checkLiteral(s, fset.Position(x.Pos()))
+				}
+			case *ast.CallExpr:
+				// Flag fmt.Sprintf("module.%s.…", …) — a structural
+				// evasion of the literal scan. Any such use should
+				// route through ModuleRef / WireRef so ComponentKey
+				// is the only source of truth.
+				sel, ok := x.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				pkg, ok := sel.X.(*ast.Ident)
+				if !ok || pkg.Name != "fmt" {
+					return true
+				}
+				if sel.Sel.Name != "Sprintf" && sel.Sel.Name != "Errorf" && sel.Sel.Name != "Fprintf" {
+					return true
+				}
+				if len(x.Args) == 0 {
+					return true
+				}
+				lit, ok := x.Args[0].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				fmtStr, uerr := strconv.Unquote(lit.Value)
+				if uerr != nil {
+					return true
+				}
+				if fmtSprintfModuleRe.MatchString(fmtStr) {
 					t.Errorf(
-						"%s: literal %q references module %q which is not a known ComponentKey rendered into a module block. "+
-							"Use ModuleRef(KeyXxx) or WireRef(KeyXxx, \"output\") so ComponentKey is the single source of truth (#283). "+
-							"If the identifier is intentionally new, declare a ComponentKey constant and add it to ModulePath.",
-						pos, s, m[1])
+						"%s: fmt.%s format string %q dynamically composes a `module.<X>.…` reference. "+
+							"This bypasses the literal scan and reintroduces the #283 class of bug. "+
+							"Use ModuleRef(KeyXxx) or WireRef(KeyXxx, \"output\") instead so ComponentKey is the single source of truth.",
+						fset.Position(lit.Pos()), sel.Sel.Name, fmtStr)
 				}
 			}
 			return true
@@ -86,22 +195,38 @@ func TestModuleReferenceLiteralsMatchComponentKeys(t *testing.T) {
 // Without this gate, a dir rename produces "preset for X (path %q)
 // returned no files" only at compose time, after the customer has
 // selected the affected component.
+//
+// Also exercises the polymorphic Lambda branch: GetPresetPath of
+// KeyAWSEKSControlPlane with comps.AWSLambda = true returns
+// `aws/lambda` instead of the default `aws/resource`, and that
+// resolved path must also exist on disk.
 func TestComponentKeyResolvesToExistingPreset(t *testing.T) {
 	repoRootDir := repoRoot(t)
-	for _, k := range AllComponentKeys {
+
+	check := func(t *testing.T, k ComponentKey, comps *Components) {
+		t.Helper()
 		cloud := CloudFor(k)
 		if cloud == "" {
-			continue // non-physical keys
+			return // non-physical key
 		}
-		presetPath := GetPresetPath(cloud, k, nil)
+		presetPath := GetPresetPath(cloud, k, comps)
 		full := filepath.Join(repoRootDir, presetPath)
 		info, err := os.Stat(full)
 		if !assert.NoError(t, err,
-			"ComponentKey %q resolves to GetPresetPath=%q which does not exist on disk. "+
-				"Did the preset directory get renamed without updating PresetKeyMap?", k, presetPath) {
-			continue
+			"ComponentKey %q (comps=%v) resolves to GetPresetPath=%q which does not exist on disk. "+
+				"Did the preset directory get renamed without updating PresetKeyMap?", k, comps, presetPath) {
+			return
 		}
 		assert.True(t, info.IsDir(),
 			"ComponentKey %q GetPresetPath=%q is not a directory", k, presetPath)
 	}
+
+	for _, k := range AllComponentKeys {
+		check(t, k, nil)
+	}
+
+	// Polymorphic-Lambda variant: KeyAWSEKSControlPlane resolves to
+	// the lambda preset when comps signals a Lambda architecture.
+	enabled := true
+	check(t, KeyAWSEKSControlPlane, &Components{AWSLambda: &enabled})
 }

--- a/pkg/composer/lint_module_refs_test.go
+++ b/pkg/composer/lint_module_refs_test.go
@@ -1,0 +1,107 @@
+package composer
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestModuleReferenceLiteralsMatchComponentKeys is the static CI gate that
+// prevents the class of bug behind issue #283: any string literal in
+// production code that contains `module.<X>.` must have <X> equal to a
+// ComponentKey rendered as a Terraform module block.
+//
+// The composer emits each `module "<X>" {}` block label from a ComponentKey
+// (compose.go's `block.Name = string(k)` and emit.go's
+// `body.AppendNewBlock("module", []string{m.Name})`), so any cross-module
+// reference must use the same value. Hand-written `"module.…"` literals in
+// the past drifted from the ComponentKey value (e.g. the bare-dir form
+// `aws_cloudwatchmonitoring` vs the snake form `aws_cloudwatch_monitoring`)
+// because nothing tied the two together.
+//
+// This test scans every production .go file under the package directory,
+// extracts each string literal via go/parser (so comments are skipped), and
+// fails on any `module.<X>.` whose <X> is not a known ComponentKey rendered
+// as a module. Fix: either use the ComponentKey value (`"module." + string(k)`,
+// preferably via ModuleRef / WireRef) or, if a new identifier really is
+// needed, declare a ComponentKey constant for it first and add it to
+// ModulePath.
+func TestModuleReferenceLiteralsMatchComponentKeys(t *testing.T) {
+	valid := map[string]struct{}{}
+	for k := range ModulePath {
+		valid[string(k)] = struct{}{}
+	}
+
+	re := regexp.MustCompile(`module\.([a-z][a-z0-9_]*)\.`)
+	fset := token.NewFileSet()
+
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err, "read pkg/composer directory")
+
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, perr := parser.ParseFile(fset, name, nil, 0)
+		require.NoError(t, perr, "parse %s", name)
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			s, uerr := strconv.Unquote(lit.Value)
+			if uerr != nil {
+				return true
+			}
+			for _, m := range re.FindAllStringSubmatch(s, -1) {
+				if _, ok := valid[m[1]]; !ok {
+					pos := fset.Position(lit.Pos())
+					t.Errorf(
+						"%s: literal %q references module %q which is not a known ComponentKey rendered into a module block. "+
+							"Use ModuleRef(KeyXxx) or WireRef(KeyXxx, \"output\") so ComponentKey is the single source of truth (#283). "+
+							"If the identifier is intentionally new, declare a ComponentKey constant and add it to ModulePath.",
+						pos, s, m[1])
+				}
+			}
+			return true
+		})
+	}
+}
+
+// TestComponentKeyResolvesToExistingPreset cross-checks that every
+// AllComponentKeys entry's source path (via GetPresetPath) points at a
+// directory that actually exists in the repo. Catches a preset directory
+// rename that didn't update PresetKeyMap — the symmetric class to #283.
+// Without this gate, a dir rename produces "preset for X (path %q)
+// returned no files" only at compose time, after the customer has
+// selected the affected component.
+func TestComponentKeyResolvesToExistingPreset(t *testing.T) {
+	repoRootDir := repoRoot(t)
+	for _, k := range AllComponentKeys {
+		cloud := CloudFor(k)
+		if cloud == "" {
+			continue // non-physical keys
+		}
+		presetPath := GetPresetPath(cloud, k, nil)
+		full := filepath.Join(repoRootDir, presetPath)
+		info, err := os.Stat(full)
+		if !assert.NoError(t, err,
+			"ComponentKey %q resolves to GetPresetPath=%q which does not exist on disk. "+
+				"Did the preset directory get renamed without updating PresetKeyMap?", k, presetPath) {
+			continue
+		}
+		assert.True(t, info.IsDir(),
+			"ComponentKey %q GetPresetPath=%q is not a directory", k, presetPath)
+	}
+}

--- a/pkg/composer/observability_moves.go
+++ b/pkg/composer/observability_moves.go
@@ -2,9 +2,9 @@ package composer
 
 // observabilityMoves declares the moved {} block address pairs the
 // composer emits when a per-component module that owns observability
-// alarms is selected alongside aws_cloudwatchmonitoring. Each entry
+// alarms is selected alongside aws_cloudwatch_monitoring. Each entry
 // relocates a legacy aggregator-side alarm (in module
-// "aws_cloudwatchmonitoring") into the per-component module's own
+// "aws_cloudwatch_monitoring") into the per-component module's own
 // observability.tf so existing customer state continues to refer to a
 // real resource without forcing destroy+create.
 //
@@ -42,26 +42,31 @@ package composer
 // lookup.
 var observabilityMoves = map[ComponentKey][]MovedRef{
 	KeyAWSBastion: {{
-		From: `module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.ec2_cpu_high["0"]`,
-		To:   `module.aws_bastion.aws_cloudwatch_metric_alarm.cpu_high["0"]`,
+		FromComponent: KeyAWSCloudWatchMonitoring,
+		FromAddress:   `aws_cloudwatch_metric_alarm.ec2_cpu_high["0"]`,
+		To:            `module.aws_bastion.aws_cloudwatch_metric_alarm.cpu_high["0"]`,
 	}},
 	KeyAWSRDS: {
 		{
-			From: `module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.rds_cpu_high["0"]`,
-			To:   `module.aws_rds.aws_cloudwatch_metric_alarm.cpu_high["0"]`,
+			FromComponent: KeyAWSCloudWatchMonitoring,
+			FromAddress:   `aws_cloudwatch_metric_alarm.rds_cpu_high["0"]`,
+			To:            `module.aws_rds.aws_cloudwatch_metric_alarm.cpu_high["0"]`,
 		},
 		{
-			From: `module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.rds_free_storage_low["0"]`,
-			To:   `module.aws_rds.aws_cloudwatch_metric_alarm.free_storage_low["0"]`,
+			FromComponent: KeyAWSCloudWatchMonitoring,
+			FromAddress:   `aws_cloudwatch_metric_alarm.rds_free_storage_low["0"]`,
+			To:            `module.aws_rds.aws_cloudwatch_metric_alarm.free_storage_low["0"]`,
 		},
 	},
 	KeyAWSElastiCache: {{
-		From: `module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.redis_cpu_high["0"]`,
-		To:   `module.aws_elasticache.aws_cloudwatch_metric_alarm.cpu_high["0"]`,
+		FromComponent: KeyAWSCloudWatchMonitoring,
+		FromAddress:   `aws_cloudwatch_metric_alarm.redis_cpu_high["0"]`,
+		To:            `module.aws_elasticache.aws_cloudwatch_metric_alarm.cpu_high["0"]`,
 	}},
 	KeyAWSSQS: {{
-		From: `module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
-		To:   `module.aws_sqs.aws_cloudwatch_metric_alarm.backlog["0"]`,
+		FromComponent: KeyAWSCloudWatchMonitoring,
+		FromAddress:   `aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
+		To:            `module.aws_sqs.aws_cloudwatch_metric_alarm.backlog["0"]`,
 	}},
 }
 

--- a/pkg/composer/observability_moves_test.go
+++ b/pkg/composer/observability_moves_test.go
@@ -23,9 +23,10 @@ import (
 func TestObservabilityMoves_KeyShapeIsZero(t *testing.T) {
 	for k, refs := range observabilityMoves {
 		for i, mv := range refs {
-			assert.Contains(t, mv.From, `["0"]`,
-				"observabilityMoves[%s][%d].From=%q must contain string-keyed [\"0\"] (matches the legacy for_each = { for i in tolist(range(...)) : i => true } shape)",
-				k, i, mv.From)
+			from := mv.FromHCL()
+			assert.Contains(t, from, `["0"]`,
+				"observabilityMoves[%s][%d].FromHCL()=%q must contain string-keyed [\"0\"] (matches the legacy for_each = { for i in tolist(range(...)) : i => true } shape)",
+				k, i, from)
 			assert.Contains(t, mv.To, `["0"]`,
 				"observabilityMoves[%s][%d].To=%q must contain string-keyed [\"0\"] (matches the per-component for_each = var.enable_observability ? { \"0\" = true } : {} shape)",
 				k, i, mv.To)
@@ -39,8 +40,22 @@ func TestObservabilityMoves_KeyShapeIsZero(t *testing.T) {
 func TestObservabilityMoves_DestinationCloudIsAWS(t *testing.T) {
 	for k := range observabilityMoves {
 		assert.Equal(t, "aws", CloudFor(k),
-			"observabilityMoves[%s] destination component is non-AWS; only AWS keys belong here (legacy aggregator is aws_cloudwatchmonitoring)",
+			"observabilityMoves[%s] destination component is non-AWS; only AWS keys belong here (legacy aggregator is aws_cloudwatch_monitoring)",
 			k)
+	}
+}
+
+// TestObservabilityMoves_FromComponentIsAggregator asserts every move
+// entry's source component is the legacy aggregator KeyAWSCloudWatchMonitoring.
+// Catches a future entry that accidentally points at a different source
+// module (which would silently fail to relocate the legacy alarm).
+func TestObservabilityMoves_FromComponentIsAggregator(t *testing.T) {
+	for k, refs := range observabilityMoves {
+		for i, mv := range refs {
+			assert.Equal(t, KeyAWSCloudWatchMonitoring, mv.FromComponent,
+				"observabilityMoves[%s][%d].FromComponent=%q must be KeyAWSCloudWatchMonitoring (legacy aggregator)",
+				k, i, mv.FromComponent)
+		}
 	}
 }
 
@@ -74,14 +89,14 @@ func TestObservabilityMovesCoversAllAggregatorAlarms(t *testing.T) {
 	froms := make(map[string]bool)
 	for _, refs := range observabilityMoves {
 		for _, mv := range refs {
-			froms[mv.From] = true
+			froms[mv.FromHCL()] = true
 		}
 	}
 
 	for _, res := range resources {
-		expected := `module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.` + res + `["0"]`
+		expected := WireRef(KeyAWSCloudWatchMonitoring, `aws_cloudwatch_metric_alarm.`+res+`["0"]`)
 		assert.True(t, froms[expected],
-			"aws_cloudwatch_metric_alarm.%s in aws/cloudwatchmonitoring/main.tf has no matching observabilityMoves From=%q — add an entry to pkg/composer/observability_moves.go so the relocation is wired",
+			"aws_cloudwatch_metric_alarm.%s in aws/cloudwatchmonitoring/main.tf has no matching observabilityMoves entry rendering as %q — add an entry to pkg/composer/observability_moves.go so the relocation is wired",
 			res, expected)
 	}
 }
@@ -100,15 +115,18 @@ func TestObservabilityMoves_NoUnknownAggregatorAlarms(t *testing.T) {
 	for k, refs := range observabilityMoves {
 		for i, mv := range refs {
 			// Extract resource name between `aws_cloudwatch_metric_alarm.` and `[`.
-			const prefix = `module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.`
+			require.Equal(t, KeyAWSCloudWatchMonitoring, mv.FromComponent,
+				"observabilityMoves[%s][%d].FromComponent=%q does not match the legacy aggregator (KeyAWSCloudWatchMonitoring)",
+				k, i, mv.FromComponent)
+			const prefix = `aws_cloudwatch_metric_alarm.`
 			require.True(t,
-				strings.HasPrefix(mv.From, prefix),
-				"observabilityMoves[%s][%d].From=%q does not match the legacy aggregator address shape (prefix=%q)",
-				k, i, mv.From, prefix)
-			rest := strings.TrimPrefix(mv.From, prefix)
+				strings.HasPrefix(mv.FromAddress, prefix),
+				"observabilityMoves[%s][%d].FromAddress=%q does not match the legacy aggregator address shape (prefix=%q)",
+				k, i, mv.FromAddress, prefix)
+			rest := strings.TrimPrefix(mv.FromAddress, prefix)
 			name := rest[:strings.IndexByte(rest, '[')]
 			assert.True(t, known[name],
-				"observabilityMoves[%s][%d].From references aggregator alarm %q which does not exist in aws/cloudwatchmonitoring/main.tf — stale entry, remove it",
+				"observabilityMoves[%s][%d].FromAddress references aggregator alarm %q which does not exist in aws/cloudwatchmonitoring/main.tf — stale entry, remove it",
 				k, i, name)
 		}
 	}
@@ -120,14 +138,18 @@ func TestObservabilityMoves_NoUnknownAggregatorAlarms(t *testing.T) {
 func TestObservabilityMoves_PublicAccessor(t *testing.T) {
 	got := ObservabilityMoves(KeyAWSSQS)
 	require.Len(t, got, 1, "KeyAWSSQS should have exactly one move")
+	assert.Equal(t, KeyAWSCloudWatchMonitoring, got[0].FromComponent)
 	assert.Equal(t,
-		`module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
-		got[0].From)
+		`aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
+		got[0].FromAddress)
+	assert.Equal(t,
+		`module.aws_cloudwatch_monitoring.aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
+		got[0].FromHCL())
 
 	// Mutate the returned slice and verify the package map is unchanged.
-	got[0].From = "phantom"
+	got[0].FromAddress = "phantom"
 	got2 := ObservabilityMoves(KeyAWSSQS)
-	assert.NotEqual(t, "phantom", got2[0].From,
+	assert.NotEqual(t, "phantom", got2[0].FromAddress,
 		"ObservabilityMoves must return a defensive copy")
 }
 

--- a/pkg/composer/observability_moves_test.go
+++ b/pkg/composer/observability_moves_test.go
@@ -21,6 +21,8 @@ import (
 // destroy+create. The drift design discussion is in
 // docs/observability-consolidation.md (Risks).
 func TestObservabilityMoves_KeyShapeIsZero(t *testing.T) {
+	require.NotEmpty(t, observabilityMoves,
+		"observabilityMoves must declare at least one entry — empty map would make every loop assertion vacuously pass")
 	for k, refs := range observabilityMoves {
 		for i, mv := range refs {
 			from := mv.FromHCL()
@@ -62,6 +64,8 @@ func TestObservabilityMoves_FromComponentIsAggregator(t *testing.T) {
 // TestObservabilityMoves_DestinationsAreKnownComponentKeys catches
 // typos / stale destination keys after a key rename or removal.
 func TestObservabilityMoves_DestinationsAreKnownComponentKeys(t *testing.T) {
+	require.NotEmpty(t, observabilityMoves,
+		"observabilityMoves must declare at least one entry — empty map would make every assertion vacuously pass")
 	known := make(map[ComponentKey]bool, len(AllComponentKeys))
 	for _, k := range AllComponentKeys {
 		known[k] = true
@@ -94,10 +98,15 @@ func TestObservabilityMovesCoversAllAggregatorAlarms(t *testing.T) {
 	}
 
 	for _, res := range resources {
-		expected := WireRef(KeyAWSCloudWatchMonitoring, `aws_cloudwatch_metric_alarm.`+res+`["0"]`)
+		// Expected literal is pinned (NOT WireRef-derived) so this
+		// assertion catches helper drift independent of the production
+		// rendering. If WireRef ever rewrites the prefix, both sides
+		// of a WireRef-vs-WireRef comparison would move together and
+		// silently pass.
+		expected := `module.aws_cloudwatch_monitoring.aws_cloudwatch_metric_alarm.` + res + `["0"]`
 		assert.True(t, froms[expected],
-			"aws_cloudwatch_metric_alarm.%s in aws/cloudwatchmonitoring/main.tf has no matching observabilityMoves entry rendering as %q — add an entry to pkg/composer/observability_moves.go so the relocation is wired",
-			res, expected)
+			"aws_cloudwatch_metric_alarm.%s in aws/cloudwatchmonitoring/main.tf has no matching observabilityMoves entry rendering as %q — add an entry to pkg/composer/observability_moves.go so the relocation is wired (%v)",
+			res, expected, froms)
 	}
 }
 

--- a/pkg/composer/observability_wiring_test.go
+++ b/pkg/composer/observability_wiring_test.go
@@ -30,9 +30,9 @@ func TestDefaultWiring_ObservabilityAWS_SelectedDriver(t *testing.T) {
 		KeyAWSSQS:                  true,
 	}
 	wi := DefaultWiring(selected, KeyAWSSQS, &Components{})
-	assert.Equal(t, "module.aws_cloudwatchmonitoring.sns_topic_arn",
+	assert.Equal(t, "module.aws_cloudwatch_monitoring.sns_topic_arn",
 		wi.RawHCL["alarm_topic_arn"],
-		"SQS should receive the SNS topic ARN from the aggregator when both are selected")
+		"SQS should receive the SNS topic ARN from the aggregator when both are selected; the prefix must match the rendered `module \"aws_cloudwatch_monitoring\"` block label (#283)")
 	assert.Equal(t, "true", wi.RawHCL["enable_observability"],
 		"SQS should be opted into observability by default when the aggregator is selected")
 }
@@ -113,8 +113,8 @@ func TestComposeStack_EmitsObservabilityMovedBlocks_AWS(t *testing.T) {
 
 	body := string(mainTF)
 	assert.Contains(t, body,
-		`from = module.aws_cloudwatchmonitoring.aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
-		"composed root main.tf must contain SQS-source moved.from")
+		`from = module.aws_cloudwatch_monitoring.aws_cloudwatch_metric_alarm.sqs_backlog["0"]`,
+		"composed root main.tf must contain SQS-source moved.from (rendered via WireRef from KeyAWSCloudWatchMonitoring; #283)")
 	assert.Contains(t, body,
 		`to   = module.aws_sqs.aws_cloudwatch_metric_alarm.backlog["0"]`,
 		"composed root main.tf must contain SQS-destination moved.to")
@@ -211,7 +211,7 @@ func TestComposeStack_FilteredWiring_PassThroughForKnownVars(t *testing.T) {
 	sqsBlock := rest[:end]
 	assert.Contains(t, sqsBlock, "alarm_topic_arn",
 		"aws_sqs module block must contain alarm_topic_arn after C7 — variable is declared and aggregator wires it")
-	assert.Contains(t, sqsBlock, "module.aws_cloudwatchmonitoring.sns_topic_arn",
+	assert.Contains(t, sqsBlock, "module.aws_cloudwatch_monitoring.sns_topic_arn",
 		"alarm_topic_arn must reference the aggregator's SNS topic ARN")
 }
 

--- a/pkg/composer/validate.go
+++ b/pkg/composer/validate.go
@@ -822,6 +822,33 @@ func stringInAllowedFold(value string, allowed []string) bool {
 	return false
 }
 
+// AWSServerlessKeys lists every AWS ComponentKey that
+// ValidateComputeExclusivity classifies as serverless. Exported so
+// tests can iterate without re-listing (and so changes here are
+// automatically picked up by the runtime gate in
+// compose_module_refs_test.go).
+var AWSServerlessKeys = []ComponentKey{
+	KeyAWSLambda,
+}
+
+// AWSContainerKeys lists every AWS ComponentKey that
+// ValidateComputeExclusivity classifies as container/VM compute.
+var AWSContainerKeys = []ComponentKey{
+	KeyAWSEKSControlPlane, KeyAWSEKS, KeyAWSECS,
+	KeyAWSEKSNodeGroup, KeyAWSEC2,
+}
+
+// GCPServerlessKeys is the GCP equivalent of AWSServerlessKeys.
+var GCPServerlessKeys = []ComponentKey{
+	KeyGCPCloudFunctions,
+	KeyGCPCloudRun,
+}
+
+// GCPContainerKeys is the GCP equivalent of AWSContainerKeys.
+var GCPContainerKeys = []ComponentKey{
+	KeyGCPGKE,
+}
+
 // ValidateComputeExclusivity checks that the selected component keys do not
 // contain incompatible compute combinations. For example, Lambda (serverless)
 // and EKS (container orchestration) cannot coexist in the same stack.
@@ -833,15 +860,8 @@ func ValidateComputeExclusivity(keys []ComponentKey) error {
 		set[k] = true
 	}
 
-	// AWS serverless keys
-	awsServerless := filterPresent(set,
-		KeyAWSLambda,
-	)
-	// AWS container/VM keys
-	awsContainer := filterPresent(set,
-		KeyAWSEKSControlPlane, KeyAWSEKS, KeyAWSECS,
-		KeyAWSEKSNodeGroup, KeyAWSEC2,
-	)
+	awsServerless := filterPresent(set, AWSServerlessKeys...)
+	awsContainer := filterPresent(set, AWSContainerKeys...)
 
 	if len(awsServerless) > 0 && len(awsContainer) > 0 {
 		return &ValidationError{msg: fmt.Sprintf(
@@ -850,15 +870,8 @@ func ValidateComputeExclusivity(keys []ComponentKey) error {
 		)}
 	}
 
-	// GCP serverless keys
-	gcpServerless := filterPresent(set,
-		KeyGCPCloudFunctions,
-		KeyGCPCloudRun,
-	)
-	// GCP container keys
-	gcpContainer := filterPresent(set,
-		KeyGCPGKE,
-	)
+	gcpServerless := filterPresent(set, GCPServerlessKeys...)
+	gcpContainer := filterPresent(set, GCPContainerKeys...)
 
 	if len(gcpServerless) > 0 && len(gcpContainer) > 0 {
 		return &ValidationError{msg: fmt.Sprintf(

--- a/pkg/composer/validate_cross_tier.go
+++ b/pkg/composer/validate_cross_tier.go
@@ -73,11 +73,12 @@ func ValidateCrossTierWiring(blocks []ModuleBlock, irs []imported.ImportedResour
 			if edge.Consumer.Kind != NodeKindResource {
 				continue
 			}
+			ref := WireRef(ComponentKey(edge.Producer.Addr), edge.ProducerAttr)
 			issues = append(issues, ValidationIssue{
 				Field:  consumerField(edge),
 				Code:   "dangling_module_ref_from_imported",
-				Value:  "module." + edge.Producer.Addr + "." + edge.ProducerAttr,
-				Reason: fmt.Sprintf("imported resource %s references module.%s.%s, but no module %q is in the stack", edge.Consumer.String(), edge.Producer.Addr, edge.ProducerAttr, edge.Producer.Addr),
+				Value:  ref,
+				Reason: fmt.Sprintf("imported resource %s references %s, but no module %q is in the stack", edge.Consumer.String(), ref, edge.Producer.Addr),
 			})
 		}
 	}

--- a/pkg/composer/validate_module_graph.go
+++ b/pkg/composer/validate_module_graph.go
@@ -92,8 +92,8 @@ func ValidateModuleWiring(blocks []ModuleBlock, presetPaths map[string]string) [
 			issues = append(issues, ValidationIssue{
 				Field: edge.Consumer + "." + edge.Input,
 				Code:  "unwired_output",
-				Reason: fmt.Sprintf("module %q references module.%s.%s, but %s declares no output %q",
-					edge.Consumer, edge.Producer, edge.Output, edge.Producer, edge.Output),
+				Reason: fmt.Sprintf("module %q references %s, but %s declares no output %q",
+					edge.Consumer, WireRef(ComponentKey(edge.Producer), edge.Output), edge.Producer, edge.Output),
 			})
 		}
 	}
@@ -176,7 +176,7 @@ func ValidateNoModuleCycles(blocks []ModuleBlock) []ValidationIssue {
 	var closing string
 	for _, edge := range extractWiringEdges(blocks) {
 		if stuckSet[edge.Producer] && stuckSet[edge.Consumer] && edge.Producer != edge.Consumer {
-			closing = fmt.Sprintf(" (e.g. %s.%s -> module.%s.%s)", edge.Consumer, edge.Input, edge.Producer, edge.Output)
+			closing = fmt.Sprintf(" (e.g. %s.%s -> %s)", edge.Consumer, edge.Input, WireRef(ComponentKey(edge.Producer), edge.Output))
 			break
 		}
 	}

--- a/pkg/composer/validate_providers.go
+++ b/pkg/composer/validate_providers.go
@@ -176,8 +176,8 @@ func ValidateSensitivePropagation(blocks []ModuleBlock, presetPaths map[string]s
 		issues = append(issues, ValidationIssue{
 			Field: edge.Consumer + "." + edge.Input,
 			Code:  "sensitive_propagation",
-			Reason: fmt.Sprintf("module.%s.%s is sensitive; ensure %s.%s is declared with sensitive = true",
-				edge.Producer, edge.Output, edge.Consumer, edge.Input),
+			Reason: fmt.Sprintf("%s is sensitive; ensure %s.%s is declared with sensitive = true",
+				WireRef(ComponentKey(edge.Producer), edge.Output), edge.Consumer, edge.Input),
 		})
 	}
 	return issues

--- a/pkg/composer/wireref.go
+++ b/pkg/composer/wireref.go
@@ -1,0 +1,25 @@
+package composer
+
+import "fmt"
+
+// ModuleRef returns the canonical HCL `module.<key>` prefix for a
+// ComponentKey. Use this when wiring a module reference whose attribute
+// is appended later (e.g. `ModuleRef(k) + ".vpc_id"`). For full
+// traversals, prefer WireRef.
+//
+// ComponentKey is the single source of truth for the rendered identifier
+// — the composer emits `module "<key>" {}` from the same value, so this
+// helper guarantees the prefix matches the declared block label.
+func ModuleRef(k ComponentKey) string {
+	return "module." + string(k)
+}
+
+// WireRef returns the canonical HCL traversal `module.<key>.<output>`
+// for a ComponentKey and an output / resource address. Use this for
+// every cross-module wire instead of hand-written `"module.…"` string
+// literals — drift between the rendered block label and the reference
+// then becomes a compile error rather than a terraform-init failure
+// (issue #283).
+func WireRef(k ComponentKey, output string) string {
+	return fmt.Sprintf("module.%s.%s", k, output)
+}


### PR DESCRIPTION
## Summary

- Composed stacks selecting `aws_cloudwatch_monitoring` with any observability driver were failing at `terraform init` because the rendered `module "aws_cloudwatch_monitoring" {}` block label and the wire reference `module.aws_cloudwatchmonitoring.sns_topic_arn` disagreed (extra underscore in the snake-cased ComponentKey vs the bare-dir form in five hand-coded literals).
- Migrate every `module.<X>.<y>` string literal in `pkg/composer/` to a new `WireRef(ComponentKey, output)` helper plus a typed `MovedRef` (`FromComponent ComponentKey, FromAddress string` with a `FromHCL()` method) so `ComponentKey` is the only source of truth for the rendered identifier — drift becomes a Go compile error rather than a runtime terraform-init failure.
- Add three CI gates so the class can't recur: a static go/parser lint that catches both bare literals and concat-evasion (`"module." + key + ".y"`) plus `fmt.Sprintf("module.%s.…")` substitution; an alignment test that asserts every `AllComponentKeys` entry's `GetPresetPath` resolves to a real on-disk dir (also exercises the polymorphic Lambda branch); and a runtime regression gate that `ComposeStack`s mechanically over `PricingDependencies` (AWS lambda-only + eks/ecs/ec2-combo + GCP cloud-run-and-functions + gke-only subtests) and asserts every `module.<X>.…` traversal resolves to a declared block.

## Test plan

- [x] `go test ./pkg/composer/... -count=1` — green (88s).
- [x] `go test ./... -count=1` — green across composer, observability, drift, discover, genconfig, etc.
- [x] Static lint fires red and pinpoints `contracts.go:905` on the synthetic regression `"module." + "aws_cloudwatchmonitoring" + ".sns_topic_arn"` (concat-evasion case).
- [x] GCP runtime gate fires red on synthetic `"module.gcp_cloudmonitoring.notification_channels"` typo (missing underscore — exact #283 shape).
- [x] AWS observability driver list iterated mechanically from `PricingDependencies[KeyAWSCloudWatchMonitoring]`; new entries are auto-covered.

## Review notes

- /review findings: all P0/P1 resolved on local branch before push.
- qa-professor findings (round 1: P0×3, P1×5): all addressed in the second commit. New rev confirmed all prior findings closed.
- qa-professor findings (round 2: P1×2 follow-on): P1 #1 (test-side compute-key registry was paralleling validate.go by hand) closed by exporting `AWSServerlessKeys` / `AWSContainerKeys` / `GCPServerlessKeys` / `GCPContainerKeys` from validate.go and reading them in tests. P1 #2 (regex blind spot for nested module refs) reviewed and confirmed false-positive — `FindAllStringSubmatch` walks every match in the body, not just the first leading segment. P2/P3 nits (subtest naming, `repoRoot` walk depth, `require.True` in loops) noted as follow-ups; not blocking.

## Audit (not blocking)

Four other ComponentKeys have the same key-vs-dir divergence shape but aren't currently wired across modules: `aws_cloudwatch_logs`, `aws_github_actions`, `gcp_secret_manager`, `gcp_cloud_kms`. The new gates cover them automatically the moment any future wiring touches them.

## Breaking change note

`MovedRef` shape changed from `(From string, To string)` to `(FromComponent ComponentKey, FromAddress string, To string)` — fully migrated within this repo. The InsideOut backend's only documented public-API path is the `ObservabilityMoves(k)` accessor (returns `[]MovedRef`), not direct struct construction; if downstream constructs `MovedRef` directly anywhere, that is a compile-time break and the new typed shape is the safer construction.

## Deferred follow-ups

- Migrate `MovedRef.To` to a typed `(ToComponent, ToAddress)` shape symmetric with `From`. Today `To` is a verbatim HCL expression to handle resource-address subscripts cleanly, but the same drift class applies.
- Tighten `fmtSprintfModuleRe` to scope only to calls whose result feeds `setRawExpr` / `RawHCL[…] =`, or add a fixture+exemption mechanism. Today the rule is "any `module.%s.…` format must use `WireRef`," which doubles as a style invariant for diagnostics.
- `repoRoot` walks three `filepath.Dir` calls; switch to walking upward looking for `go.mod` so moving the test file doesn't break it silently.

Fixes #283