### PR TITLE
fix(composer): break aws_cloudwatch_monitoring + observability consumer cycle (#285)

### DIFF
--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -153,15 +153,26 @@ func TestDefaultWiring_V2Keys(t *testing.T) {
 			wantNotIn: []string{"module.alb.", "module.waf."},
 		},
 		{
-			name: "cloudwatch monitoring references v2 modules",
+			// #285: when per-component consumers are selected alongside
+			// the aggregator, the back-edge wiring is suppressed (would
+			// otherwise close a 2-cycle with each consumer) and the
+			// disable flag flips so the legacy aggregator-side alarms
+			// retire — per-component observability.tf in each consumer
+			// owns the equivalent alarms. wantNotIn pins both the legacy
+			// module name shape (regression of #283-class drift) and the
+			// V2-prefixed back-edge references (regression of #285).
+			name: "cloudwatch monitoring disables legacy alarms when per-component consumers are present",
 			key:  KeyAWSCloudWatchMonitoring,
 			wantIn: map[string]string{
-				"instance_ids":     "module.aws_bastion.bastion_instance_id",
-				"rds_instance_ids": "module.aws_rds.instance_id",
-				"alb_arn_suffixes": "module.aws_alb.alb_arn_suffix",
-				"sqs_queue_arns":   "module.aws_sqs.queue_arn",
+				"disable_legacy_per_component_alarms": "true",
 			},
-			wantNotIn: []string{"module.bastion.", "module.rds.", "module.alb.", "module.sqs."},
+			wantNotIn: []string{
+				"module.bastion.", "module.rds.", "module.alb.", "module.sqs.",
+				"module.aws_bastion.bastion_instance_id",
+				"module.aws_rds.instance_id",
+				"module.aws_alb.alb_arn_suffix",
+				"module.aws_sqs.queue_arn",
+			},
 		},
 		{
 			name: "bedrock references v2 s3 and opensearch",
@@ -445,11 +456,25 @@ func TestComposeStack_V2KitchenSink(t *testing.T) {
 	// would otherwise pass a global substring count).
 	assertProviderBlocksHaveDefaultTags(t, prov, 2)
 
-	// Monitoring ← bastion, RDS, ALB, SQS
-	require.Contains(t, mainTF, "module.aws_bastion.bastion_instance_id")
-	require.Contains(t, mainTF, "module.aws_rds.instance_id")
-	require.Contains(t, mainTF, "module.aws_alb.alb_arn_suffix")
-	require.Contains(t, mainTF, "module.aws_sqs.queue_arn")
+	// Monitoring: per-component observability is active (consumers selected
+	// alongside cwm), so the legacy aggregator-side back-edges are dropped
+	// and disable_legacy_per_component_alarms flips on (#285). Per-component
+	// alarms still notify via the cwm SNS topic via the post-switch
+	// alarm_topic_arn forward-edge.
+	require.Regexp(t,
+		regexp.MustCompile(`(?m)^\s*disable_legacy_per_component_alarms\s*=\s*true\s*$`),
+		mainTF,
+		"cwm must disable legacy alarms when per-component consumers are present (#285)")
+	require.NotContains(t, mainTF, "module.aws_bastion.bastion_instance_id",
+		"back-edge from cwm to bastion must not render (#285)")
+	require.NotContains(t, mainTF, "module.aws_rds.instance_id",
+		"back-edge from cwm to rds must not render (#285)")
+	require.NotContains(t, mainTF, "module.aws_alb.alb_arn_suffix",
+		"back-edge from cwm to alb must not render (#285)")
+	require.NotContains(t, mainTF, "module.aws_sqs.queue_arn",
+		"back-edge from cwm to sqs must not render (#285)")
+	require.Contains(t, mainTF, "module.aws_cloudwatch_monitoring.sns_topic_arn",
+		"forward-edge alarm_topic_arn must still render so per-component alarms notify")
 
 	// Must NOT contain legacy module references
 	require.NotContains(t, mainTF, "module.alb.")
@@ -591,10 +616,21 @@ func TestComposeStack_KitchenSink(t *testing.T) {
 	})
 
 	t.Run("wiring/monitoring", func(t *testing.T) {
-		require.Contains(t, mainTF, `instance_ids     = [module.aws_bastion.bastion_instance_id]`)
-		require.Contains(t, mainTF, `rds_instance_ids = [module.aws_rds.instance_id]`)
-		require.Contains(t, mainTF, `alb_arn_suffixes = [module.aws_alb.alb_arn_suffix]`)
-		require.Contains(t, mainTF, `sqs_queue_arns   = [module.aws_sqs.queue_arn]`)
+		// #285: when per-component observability consumers are in the
+		// stack, the cwm aggregator drops its back-edge wiring (which
+		// would otherwise close a 2-cycle with each consumer) and flips
+		// disable_legacy_per_component_alarms = true so the legacy
+		// aggregator-side alarms retire — per-component observability.tf
+		// in each consumer module owns the equivalent alarms.
+		require.Regexp(t,
+			regexp.MustCompile(`(?m)^\s*disable_legacy_per_component_alarms\s*=\s*true\s*$`),
+			mainTF,
+			"cwm must disable legacy alarms when per-component observability consumers are in the stack")
+		require.NotContains(t, mainTF, "instance_ids     = [module.aws_bastion.bastion_instance_id]",
+			"back-edge from cwm to bastion must not render once per-component observability is wired (#285)")
+		require.NotContains(t, mainTF, "rds_instance_ids = [module.aws_rds.instance_id]")
+		require.NotContains(t, mainTF, "alb_arn_suffixes = [module.aws_alb.alb_arn_suffix]")
+		require.NotContains(t, mainTF, "sqs_queue_arns   = [module.aws_sqs.queue_arn]")
 	})
 
 	t.Run("wiring/backups", func(t *testing.T) {

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -626,11 +626,21 @@ func TestComposeStack_KitchenSink(t *testing.T) {
 			regexp.MustCompile(`(?m)^\s*disable_legacy_per_component_alarms\s*=\s*true\s*$`),
 			mainTF,
 			"cwm must disable legacy alarms when per-component observability consumers are in the stack")
-		require.NotContains(t, mainTF, "instance_ids     = [module.aws_bastion.bastion_instance_id]",
+		// Bare-RHS substrings: whitespace-independent so a renderer
+		// alignment change can't make these vacuously pass.
+		require.NotContains(t, mainTF, "module.aws_bastion.bastion_instance_id",
 			"back-edge from cwm to bastion must not render once per-component observability is wired (#285)")
-		require.NotContains(t, mainTF, "rds_instance_ids = [module.aws_rds.instance_id]")
-		require.NotContains(t, mainTF, "alb_arn_suffixes = [module.aws_alb.alb_arn_suffix]")
-		require.NotContains(t, mainTF, "sqs_queue_arns   = [module.aws_sqs.queue_arn]")
+		require.NotContains(t, mainTF, "module.aws_rds.instance_id",
+			"back-edge from cwm to rds must not render (#285)")
+		require.NotContains(t, mainTF, "module.aws_alb.alb_arn_suffix",
+			"back-edge from cwm to alb must not render (#285)")
+		require.NotContains(t, mainTF, "module.aws_sqs.queue_arn",
+			"back-edge from cwm to sqs must not render (#285)")
+		// Forward-edge: per-component alarms still notify via the cwm
+		// SNS topic (silent-paging-failure regression net — a mutation
+		// that drops the post-switch wiring is caught here).
+		require.Contains(t, mainTF, "alarm_topic_arn      = module.aws_cloudwatch_monitoring.sns_topic_arn",
+			"forward-edge alarm_topic_arn must still render so per-component alarms notify")
 	})
 
 	t.Run("wiring/backups", func(t *testing.T) {

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -718,6 +718,30 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		wi.Names = append(wi.Names, "scope", "region")
 
 	case KeyAWSCloudWatchMonitoring:
+		// When any per-component observability consumer is in the stack
+		// (issue #204), the per-component observability.tf files own the
+		// CPU/storage/etc. alarms — disable the legacy aggregator-side
+		// alarms and skip the back-edge wiring that would otherwise close
+		// a 2-cycle with each consumer (issue #285). The forward-edge
+		// wiring (alarm_topic_arn = module.aws_cloudwatch_monitoring.sns_topic_arn,
+		// emitted post-switch) keeps per-component alarms notifying via
+		// the shared SNS topic.
+		perComponentActive := false
+		for _, dep := range PricingDependencies[KeyAWSCloudWatchMonitoring] {
+			if selected[dep] {
+				perComponentActive = true
+				break
+			}
+		}
+		if perComponentActive {
+			wi.RawHCL["disable_legacy_per_component_alarms"] = "true"
+			wi.Names = append(wi.Names, "disable_legacy_per_component_alarms")
+			break
+		}
+		// Aggregator-only fall-through: a stack that selects the aggregator
+		// without any per-component consumer (e.g. dashboards over
+		// out-of-stack EC2) keeps the legacy back-edge wiring so dashboard
+		// widgets render per-resource series.
 		if hasBastion {
 			wi.RawHCL["instance_ids"] = "[" + bastionRef(selected) + ".bastion_instance_id]"
 			wi.Names = append(wi.Names, "instance_ids")

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -738,10 +738,15 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.Names = append(wi.Names, "disable_legacy_per_component_alarms")
 			break
 		}
-		// Aggregator-only fall-through: a stack that selects the aggregator
-		// without any per-component consumer (e.g. dashboards over
-		// out-of-stack EC2) keeps the legacy back-edge wiring so dashboard
-		// widgets render per-resource series.
+		// Aggregator-only fall-through. Today every back-edge target
+		// (bastion/rds/alb/sqs) is itself in
+		// PricingDependencies[KeyAWSCloudWatchMonitoring], so the
+		// `if has*` blocks below cannot fire — any stack that selects
+		// one of those keys flips perComponentActive=true above and
+		// breaks first. The blocks remain as defense-in-depth: if a key
+		// is later removed from PricingDependencies (intentional opt-out
+		// of per-component observability), the legacy back-edge wiring
+		// keeps the cwm dashboard widgets rendering per-resource series.
 		if hasBastion {
 			wi.RawHCL["instance_ids"] = "[" + bastionRef(selected) + ".bastion_instance_id]"
 			wi.Names = append(wi.Names, "instance_ids")

--- a/pkg/composer/validate_module_graph_test.go
+++ b/pkg/composer/validate_module_graph_test.go
@@ -1,6 +1,7 @@
 package composer
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -266,4 +267,118 @@ func TestComposeStackWithIssues_GreenStackHasNoGraphIssues(t *testing.T) {
 		require.NotEqual(t, "invalid_type", iss.Code, "unexpected invalid_type: %v", iss)
 		require.NotEqual(t, "dangling_resource_ref", iss.Code, "unexpected dangling_resource_ref: %v", iss)
 	}
+}
+
+// TestComposeStack_NoCycleWithCloudWatchMonitoringAndConsumers regresses
+// the bug surfaced by reliable session sess_v2_T8vvrDtATMBN where
+// ValidateNoModuleCycles reported [aws_alb aws_apigateway aws_cloudfront
+// aws_cloudwatch_monitoring aws_elasticache aws_lambda aws_rds] stuck due
+// to the monitoring<->consumer 2-cycles formed by the legacy aggregator-
+// side wiring (instance_ids/rds_instance_ids/alb_arn_suffixes/sqs_queue_arns)
+// combined with the per-component observability wiring
+// (alarm_topic_arn = module.aws_cloudwatch_monitoring.sns_topic_arn).
+//
+// Fix: when any per-component observability consumer is in the stack,
+// the cwm aggregator drops its back-edge wiring and flips
+// disable_legacy_per_component_alarms = true. The forward-edge stays so
+// per-component alarms continue to notify via the shared SNS topic.
+// Issue #285.
+func TestComposeStack_NoCycleWithCloudWatchMonitoringAndConsumers(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	r, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Project: "demo",
+		Region:  "us-east-1",
+		Cloud:   "aws",
+		SelectedKeys: []ComponentKey{
+			KeyAWSVPC,
+			KeyAWSRDS,
+			KeyAWSALB,
+			KeyAWSLambda,
+			KeyAWSAPIGateway,
+			KeyAWSElastiCache,
+			KeyAWSCloudfront,
+			KeyAWSCloudWatchMonitoring,
+		},
+		Comps: &Components{
+			Cloud:                   "AWS",
+			AWSVPC:                  "Private VPC",
+			AWSRDS:                  ptrBool(true),
+			AWSALB:                  ptrBool(true),
+			AWSLambda:               ptrBool(true),
+			AWSAPIGateway:           ptrBool(true),
+			AWSElastiCache:          ptrBool(true),
+			AWSCloudFront:           ptrBool(true),
+			AWSCloudWatchMonitoring: ptrBool(true),
+		},
+		Cfg: &Config{},
+	})
+	require.NoError(t, err, "compose must succeed for cwm + consumers stack")
+	require.NotNil(t, r)
+
+	for _, iss := range r.Issues {
+		require.NotEqual(t, "module_cycle", iss.Code,
+			"no module_cycle expected for cwm + consumers stack: %v", iss)
+		require.NotEqual(t, "wiring_cycle", iss.Code,
+			"no wiring_cycle expected for cwm + consumers stack: %v", iss)
+	}
+
+	mainTF := string(r.Files["/main.tf"])
+	require.NotEmpty(t, mainTF, "compose must emit /main.tf")
+
+	// Aggregator-side: legacy alarms disabled, back-edges absent.
+	require.Regexp(t,
+		regexp.MustCompile(`(?m)^\s*disable_legacy_per_component_alarms\s*=\s*true\s*$`),
+		mainTF,
+		"legacy alarms must be disabled when per-component observability is wired")
+	require.NotContains(t, mainTF, "instance_ids     = [module.aws_bastion.bastion_instance_id]",
+		"back-edge from cwm to bastion must not render (#285)")
+	require.NotContains(t, mainTF, "rds_instance_ids = [module.aws_rds.instance_id]",
+		"back-edge from cwm to rds must not render (#285)")
+	require.NotContains(t, mainTF, "alb_arn_suffixes = [module.aws_alb.alb_arn_suffix]",
+		"back-edge from cwm to alb must not render (#285)")
+	require.NotContains(t, mainTF, "sqs_queue_arns   = [module.aws_sqs.queue_arn]",
+		"back-edge from cwm to sqs must not render (#285)")
+
+	// Forward-edge: per-component alarms still notify via the cwm SNS topic.
+	require.Contains(t, mainTF, "alarm_topic_arn      = module.aws_cloudwatch_monitoring.sns_topic_arn",
+		"forward-edge alarm_topic_arn must still render so per-component alarms notify")
+	require.Regexp(t,
+		regexp.MustCompile(`(?m)^\s*enable_observability\s*=\s*true\s*$`),
+		mainTF,
+		"forward-edge enable_observability must still render")
+
+	// Cross-check: every emitted module.<X>.… reference resolves to a
+	// declared module block (defense against #283-class regressions).
+	assertComposedRefsResolveToBlocks(t, mainTF, KeyAWSCloudWatchMonitoring)
+}
+
+// TestValidateNoModuleCycles_PinsCWMConsumer2Cycle locks the lower-level
+// validator behavior on the specific 2-cycle shape (cwm <-> rds) so a
+// regression to the wiring layer that re-introduces the back-edge
+// surfaces here as well. Independent of the wiring fix — this is a
+// validator-shape pin. Issue #285.
+func TestValidateNoModuleCycles_PinsCWMConsumer2Cycle(t *testing.T) {
+	t.Parallel()
+
+	blocks := []ModuleBlock{
+		{
+			Name: "aws_cloudwatch_monitoring",
+			Raw: map[string]string{
+				"rds_instance_ids": "[module.aws_rds.instance_id]",
+			},
+		},
+		{
+			Name: "aws_rds",
+			Raw: map[string]string{
+				"alarm_topic_arn": "module.aws_cloudwatch_monitoring.sns_topic_arn",
+			},
+		},
+	}
+	issues := ValidateNoModuleCycles(blocks)
+	require.Len(t, issues, 1)
+	require.Equal(t, "module_cycle", issues[0].Code)
+	require.Contains(t, issues[0].Reason, "[aws_cloudwatch_monitoring aws_rds]",
+		"cycle reason should enumerate the two modules involved")
 }

--- a/pkg/composer/validate_module_graph_test.go
+++ b/pkg/composer/validate_module_graph_test.go
@@ -328,17 +328,19 @@ func TestComposeStack_NoCycleWithCloudWatchMonitoringAndConsumers(t *testing.T) 
 	require.NotEmpty(t, mainTF, "compose must emit /main.tf")
 
 	// Aggregator-side: legacy alarms disabled, back-edges absent.
+	// Bare-RHS substrings (no whitespace alignment) so a renderer alignment
+	// change can't make these checks vacuously pass.
 	require.Regexp(t,
 		regexp.MustCompile(`(?m)^\s*disable_legacy_per_component_alarms\s*=\s*true\s*$`),
 		mainTF,
 		"legacy alarms must be disabled when per-component observability is wired")
-	require.NotContains(t, mainTF, "instance_ids     = [module.aws_bastion.bastion_instance_id]",
+	require.NotContains(t, mainTF, "module.aws_bastion.bastion_instance_id",
 		"back-edge from cwm to bastion must not render (#285)")
-	require.NotContains(t, mainTF, "rds_instance_ids = [module.aws_rds.instance_id]",
+	require.NotContains(t, mainTF, "module.aws_rds.instance_id",
 		"back-edge from cwm to rds must not render (#285)")
-	require.NotContains(t, mainTF, "alb_arn_suffixes = [module.aws_alb.alb_arn_suffix]",
+	require.NotContains(t, mainTF, "module.aws_alb.alb_arn_suffix",
 		"back-edge from cwm to alb must not render (#285)")
-	require.NotContains(t, mainTF, "sqs_queue_arns   = [module.aws_sqs.queue_arn]",
+	require.NotContains(t, mainTF, "module.aws_sqs.queue_arn",
 		"back-edge from cwm to sqs must not render (#285)")
 
 	// Forward-edge: per-component alarms still notify via the cwm SNS topic.
@@ -379,6 +381,11 @@ func TestValidateNoModuleCycles_PinsCWMConsumer2Cycle(t *testing.T) {
 	issues := ValidateNoModuleCycles(blocks)
 	require.Len(t, issues, 1)
 	require.Equal(t, "module_cycle", issues[0].Code)
-	require.Contains(t, issues[0].Reason, "[aws_cloudwatch_monitoring aws_rds]",
-		"cycle reason should enumerate the two modules involved")
+	// Assert each module name independently rather than the bracketed
+	// slice form — decouples this test from Go's default slice-print
+	// formatting so a cosmetic reformatter change doesn't break it.
+	require.Contains(t, issues[0].Reason, "aws_cloudwatch_monitoring",
+		"cycle reason should reference the cwm module")
+	require.Contains(t, issues[0].Reason, "aws_rds",
+		"cycle reason should reference the rds module")
 }


### PR DESCRIPTION
## Summary

Fixes the `module_cycle` validation issue that blocks any AWS stack pairing `aws_cloudwatch_monitoring` with one of its observability consumers (`aws_rds`, `aws_alb`, `aws_sqs`, `aws_bastion`, `aws_elasticache`, `aws_lambda`, `aws_apigateway`, etc.). Production session [`sess_v2_T8vvrDtATMBN`](https://reliable.luthersystemsapp.com/s/sess_v2_T8vvrDtATMBN?tf_console=1&riley=0) cannot deploy without it.

- Gates the legacy aggregator-side back-edge wiring on `PricingDependencies[KeyAWSCloudWatchMonitoring]` membership: when any per-component consumer is in the stack, `disable_legacy_per_component_alarms = true` is emitted on the cwm module and the back-edge wiring (`instance_ids`/`rds_instance_ids`/`alb_arn_suffixes`/`sqs_queue_arns`) is suppressed. The 2-cycle each consumer formed with cwm is broken at the source.
- Forward-edge wiring (`alarm_topic_arn = module.aws_cloudwatch_monitoring.sns_topic_arn`, `enable_observability = true`) is preserved so per-component alarms keep notifying via the shared SNS topic. State preservation is already wired via `pkg/composer/observability_moves.go`.
- The aggregator-only fall-through is retained as defense-in-depth (with a comment noting it is structurally unreachable today since every back-edge target key is itself in `PricingDependencies`).

## Test plan

- [x] `terraform fmt -check -recursive` clean
- [x] All static lint scripts pass (`tests/lint-*.sh`)
- [x] Composer suite green: `go test -count=1 ./pkg/composer/...` (full suite, ~6 min)
- [x] New regression tests pass:
  - `TestComposeStack_NoCycleWithCloudWatchMonitoringAndConsumers` — composes the `sess_v2_T8vvrDtATMBN` shape end-to-end and asserts no `module_cycle`/`wiring_cycle` issue, the disable flag fires, back-edges absent, forward-edge present, and every emitted `module.<X>.…` reference resolves to a declared block (#283 cross-check).
  - `TestValidateNoModuleCycles_PinsCWMConsumer2Cycle` — validator-shape pin on the minimal cwm↔rds 2-cycle.
- [x] Existing affected tests updated and green: `TestComposeStack_KitchenSink`, `TestComposeStack_V2KitchenSink`, `TestDefaultWiring_V2Keys` (cloudwatch_monitoring case rewritten to assert the new shape).
- [ ] Reliable side (post-merge + go.mod bump in `reliable`): retry `sess_v2_T8vvrDtATMBN` per the issue's curl invocation; expect HTTP 200 with a `job_id` instead of the 500 `module dependency cycle`.

## Review notes

- `/review`: P0 none, P1 none, P2 one — fall-through-comment hardening (addressed in commit 2). P3s skipped.
- qa-professor (3 MAJOR findings, all addressed in commit 2):
  1. Whitespace-fragile `NotContains` strings replaced with bare-RHS substrings so a renderer alignment change can't make them vacuously pass.
  2. `TestComposeStack_KitchenSink#wiring/monitoring` had no positive forward-edge assertion — silent-paging-failure mutation could have slipped through. Added.
  3. `TestValidateNoModuleCycles_PinsCWMConsumer2Cycle` decoupled from Go's default slice-print format `[a b]` — asserts each module name independently now.
- Dashboard widgets in `aws/cloudwatchmonitoring/main.tf` get empty input lists when the disable flag fires (per-resource series collapse to baseline metric only). No errors / no plan failures. Migration of widgets to per-component or aggregator-output-aggregation is a separate follow-up.

Fixes #285