### PR TITLE
feat(insideout-import): public SupportedDiscoverTypes registry (#290)

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_test.go
@@ -237,14 +237,23 @@ func TestNewAWSDiscovererWithConcurrency_NonPositiveFallsBackToDefault(t *testin
 	}
 }
 
-// TestRegistryParity_AWS guards against drift between this package's live
-// constructor map and the public list in pkg/insideout-import/registry. If a
-// new type is registered here without updating the registry (or vice versa),
-// the reliable-side wizard will silently disagree with what the CLI actually
-// supports — this test fails first instead.
-func TestRegistryParity_AWS(t *testing.T) {
+// TestRegistryParity_AWS_LiveMatchesRegistry guards against drift between
+// this package's live constructor map and the public list in
+// pkg/insideout-import/registry. If a new type is registered here without
+// updating the registry (or vice versa), the reliable-side wizard will
+// silently disagree with what the CLI actually supports — this test fails
+// first instead.
+//
+// Note this only pins drift between the two sources of truth. Literal-value
+// pinning (the contract reliable consumers depend on) lives in the registry
+// package's own tests; we don't reach across the import boundary to assert
+// it twice.
+func TestRegistryParity_AWS_LiveMatchesRegistry(t *testing.T) {
 	t.Parallel()
 	live := NewAWSDiscoverer(awsDummyConfig()).SupportedTypes()
+	if len(live) == 0 {
+		t.Fatal("awsdiscover registered no types — registry parity check would be tautologically empty")
+	}
 	pub := registry.SupportedDiscoverTypes(registry.ProviderAWS)
 	if !reflect.DeepEqual(live, pub) {
 		t.Errorf("registry drift: awsdiscover=%v, registry=%v", live, pub)

--- a/cmd/insideout-import/awsdiscover/awsdiscover_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_test.go
@@ -3,10 +3,12 @@ package awsdiscover
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
 )
 
 type fakeDiscoverer struct {
@@ -232,5 +234,19 @@ func TestNewAWSDiscovererWithConcurrency_NonPositiveFallsBackToDefault(t *testin
 		if l := agg.byType["aws_lambda_function"].(*lambdaDiscoverer); l.maxConcurrency != DefaultMaxConcurrency {
 			t.Errorf("n=%d: lambda maxConcurrency=%d, want %d", n, l.maxConcurrency, DefaultMaxConcurrency)
 		}
+	}
+}
+
+// TestRegistryParity_AWS guards against drift between this package's live
+// constructor map and the public list in pkg/insideout-import/registry. If a
+// new type is registered here without updating the registry (or vice versa),
+// the reliable-side wizard will silently disagree with what the CLI actually
+// supports — this test fails first instead.
+func TestRegistryParity_AWS(t *testing.T) {
+	t.Parallel()
+	live := NewAWSDiscoverer(awsDummyConfig()).SupportedTypes()
+	pub := registry.SupportedDiscoverTypes(registry.ProviderAWS)
+	if !reflect.DeepEqual(live, pub) {
+		t.Errorf("registry drift: awsdiscover=%v, registry=%v", live, pub)
 	}
 }

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
@@ -315,14 +315,23 @@ func TestBuildSearchQuery_Composition(t *testing.T) {
 	}
 }
 
-// TestRegistryParity_GCP guards against drift between this package's live
-// constructor map and the public list in pkg/insideout-import/registry. If a
-// new type is registered here without updating the registry (or vice versa),
-// the reliable-side wizard will silently disagree with what the CLI actually
-// supports — this test fails first instead.
-func TestRegistryParity_GCP(t *testing.T) {
+// TestRegistryParity_GCP_LiveMatchesRegistry guards against drift between
+// this package's live constructor map and the public list in
+// pkg/insideout-import/registry. If a new type is registered here without
+// updating the registry (or vice versa), the reliable-side wizard will
+// silently disagree with what the CLI actually supports — this test fails
+// first instead.
+//
+// Note this only pins drift between the two sources of truth. Literal-value
+// pinning (the contract reliable consumers depend on) lives in the registry
+// package's own tests; we don't reach across the import boundary to assert
+// it twice.
+func TestRegistryParity_GCP_LiveMatchesRegistry(t *testing.T) {
 	t.Parallel()
 	live := NewGCPDiscoverer(&fakeAssetSearcher{}, "p").SupportedTypes()
+	if len(live) == 0 {
+		t.Fatal("gcpdiscover registered no types — registry parity check would be tautologically empty")
+	}
 	pub := registry.SupportedDiscoverTypes(registry.ProviderGCP)
 	if !reflect.DeepEqual(live, pub) {
 		t.Errorf("registry drift: gcpdiscover=%v, registry=%v", live, pub)

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
@@ -3,10 +3,12 @@ package gcpdiscover
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
 )
 
 func TestNewGCPDiscoverer_RegistersPhase1Types(t *testing.T) {
@@ -310,5 +312,19 @@ func TestBuildSearchQuery_Composition(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestRegistryParity_GCP guards against drift between this package's live
+// constructor map and the public list in pkg/insideout-import/registry. If a
+// new type is registered here without updating the registry (or vice versa),
+// the reliable-side wizard will silently disagree with what the CLI actually
+// supports — this test fails first instead.
+func TestRegistryParity_GCP(t *testing.T) {
+	t.Parallel()
+	live := NewGCPDiscoverer(&fakeAssetSearcher{}, "p").SupportedTypes()
+	pub := registry.SupportedDiscoverTypes(registry.ProviderGCP)
+	if !reflect.DeepEqual(live, pub) {
+		t.Errorf("registry drift: gcpdiscover=%v, registry=%v", live, pub)
 	}
 }

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -12,6 +12,8 @@
 // TestRegistryParity_GCP.
 package registry
 
+import "slices"
+
 const (
 	ProviderAWS = "aws"
 	ProviderGCP = "gcp"
@@ -45,15 +47,19 @@ var gcpTypes = []string{
 
 // SupportedDiscoverTypes returns the sorted, deterministic list of Terraform
 // resource types that the discover pipeline can emit clean HCL for, for the
-// given provider. Returns nil for unrecognized provider strings.
+// given provider. Returns nil (not an empty slice) for unrecognized provider
+// strings — downstream consumers may distinguish "unknown provider" from
+// "known provider with zero supported types" via that nil-vs-non-nil signal,
+// and JSON marshaling renders them differently (`null` vs `[]`).
 //
-// The returned slice is a fresh copy; callers may mutate it freely.
+// The returned slice is a fresh copy; callers may mutate it freely without
+// affecting subsequent calls or the package's internal state.
 func SupportedDiscoverTypes(provider string) []string {
 	switch provider {
 	case ProviderAWS:
-		return cloneStrings(awsTypes)
+		return slices.Clone(awsTypes)
 	case ProviderGCP:
-		return cloneStrings(gcpTypes)
+		return slices.Clone(gcpTypes)
 	default:
 		return nil
 	}
@@ -61,13 +67,9 @@ func SupportedDiscoverTypes(provider string) []string {
 
 // SupportedProviders returns the sorted list of provider keys recognized by
 // SupportedDiscoverTypes. Useful for UIs enumerating providers without
-// hardcoding the set.
+// hardcoding the set. Every entry returned here is guaranteed to map to a
+// non-empty SupportedDiscoverTypes result; the round-trip invariant is
+// pinned by TestSupportedProviders_RoundTripsThroughSupportedDiscoverTypes.
 func SupportedProviders() []string {
 	return []string{ProviderAWS, ProviderGCP}
-}
-
-func cloneStrings(in []string) []string {
-	out := make([]string, len(in))
-	copy(out, in)
-	return out
 }

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -1,0 +1,73 @@
+// Package registry exposes the public, dependency-free list of Terraform
+// resource types that `insideout-import discover` supports for each cloud
+// provider.
+//
+// The reliable repo's importer wizard imports this package to render picker
+// and address-mapping rows without referencing CLI source lines. Consumers
+// must treat the returned slices as opaque, sorted lists keyed by provider.
+//
+// Drift between this registry and the live discoverer constructor maps in
+// cmd/insideout-import/awsdiscover and cmd/insideout-import/gcpdiscover is
+// guarded by parity tests in those packages — see TestRegistryParity_AWS /
+// TestRegistryParity_GCP.
+package registry
+
+const (
+	ProviderAWS = "aws"
+	ProviderGCP = "gcp"
+)
+
+// awsTypes is the canonical, sorted list of AWS Terraform resource types the
+// discover pipeline emits clean HCL for. Keep sorted lexicographically; the
+// awsdiscover parity test will fail if this drifts from the live constructor.
+var awsTypes = []string{
+	"aws_cloudwatch_log_group",
+	"aws_dynamodb_table",
+	"aws_iam_policy",
+	"aws_iam_role",
+	"aws_kms_key",
+	"aws_lambda_function",
+	"aws_s3_bucket",
+	"aws_secretsmanager_secret",
+	"aws_sqs_queue",
+}
+
+// gcpTypes is the canonical, sorted list of GCP Terraform resource types the
+// discover pipeline emits clean HCL for. Keep sorted lexicographically; the
+// gcpdiscover parity test will fail if this drifts from the live constructor.
+var gcpTypes = []string{
+	"google_compute_network",
+	"google_pubsub_subscription",
+	"google_pubsub_topic",
+	"google_secret_manager_secret",
+	"google_storage_bucket",
+}
+
+// SupportedDiscoverTypes returns the sorted, deterministic list of Terraform
+// resource types that the discover pipeline can emit clean HCL for, for the
+// given provider. Returns nil for unrecognized provider strings.
+//
+// The returned slice is a fresh copy; callers may mutate it freely.
+func SupportedDiscoverTypes(provider string) []string {
+	switch provider {
+	case ProviderAWS:
+		return cloneStrings(awsTypes)
+	case ProviderGCP:
+		return cloneStrings(gcpTypes)
+	default:
+		return nil
+	}
+}
+
+// SupportedProviders returns the sorted list of provider keys recognized by
+// SupportedDiscoverTypes. Useful for UIs enumerating providers without
+// hardcoding the set.
+func SupportedProviders() []string {
+	return []string{ProviderAWS, ProviderGCP}
+}
+
+func cloneStrings(in []string) []string {
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -1,0 +1,101 @@
+package registry
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestSupportedDiscoverTypes_AWS(t *testing.T) {
+	t.Parallel()
+	want := []string{
+		"aws_cloudwatch_log_group",
+		"aws_dynamodb_table",
+		"aws_iam_policy",
+		"aws_iam_role",
+		"aws_kms_key",
+		"aws_lambda_function",
+		"aws_s3_bucket",
+		"aws_secretsmanager_secret",
+		"aws_sqs_queue",
+	}
+	got := SupportedDiscoverTypes(ProviderAWS)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SupportedDiscoverTypes(%q) = %v, want %v", ProviderAWS, got, want)
+	}
+}
+
+func TestSupportedDiscoverTypes_GCP(t *testing.T) {
+	t.Parallel()
+	want := []string{
+		"google_compute_network",
+		"google_pubsub_subscription",
+		"google_pubsub_topic",
+		"google_secret_manager_secret",
+		"google_storage_bucket",
+	}
+	got := SupportedDiscoverTypes(ProviderGCP)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SupportedDiscoverTypes(%q) = %v, want %v", ProviderGCP, got, want)
+	}
+}
+
+func TestSupportedDiscoverTypes_Unknown(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		provider string
+	}{
+		{name: "empty", provider: ""},
+		{name: "azure", provider: "azure"},
+		{name: "AWS_uppercase", provider: "AWS"},
+		{name: "whitespace", provider: " aws "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := SupportedDiscoverTypes(tc.provider); got != nil {
+				t.Errorf("SupportedDiscoverTypes(%q) = %v, want nil", tc.provider, got)
+			}
+		})
+	}
+}
+
+func TestSupportedDiscoverTypes_ReturnsCopy(t *testing.T) {
+	t.Parallel()
+	first := SupportedDiscoverTypes(ProviderAWS)
+	if len(first) == 0 {
+		t.Fatal("expected non-empty AWS type list")
+	}
+	first[0] = "MUTATED"
+
+	second := SupportedDiscoverTypes(ProviderAWS)
+	if second[0] == "MUTATED" {
+		t.Errorf("mutating returned slice leaked into the package; second call returned %v", second)
+	}
+}
+
+func TestSupportedDiscoverTypes_Sorted(t *testing.T) {
+	t.Parallel()
+	for _, provider := range SupportedProviders() {
+		t.Run(provider, func(t *testing.T) {
+			t.Parallel()
+			got := SupportedDiscoverTypes(provider)
+			if !sort.StringsAreSorted(got) {
+				t.Errorf("SupportedDiscoverTypes(%q) not sorted: %v", provider, got)
+			}
+		})
+	}
+}
+
+func TestSupportedProviders(t *testing.T) {
+	t.Parallel()
+	want := []string{ProviderAWS, ProviderGCP}
+	got := SupportedProviders()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SupportedProviders() = %v, want %v", got, want)
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Errorf("SupportedProviders() not sorted: %v", got)
+	}
+}

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -1,12 +1,21 @@
+// The literal expected slices in TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList
+// and TestSupportedDiscoverTypes_GCP_ReturnsCanonicalSortedList are the
+// authoritative pin for the public-API contract: any change to the supported
+// type set must be reflected here. The parity tests in
+// cmd/insideout-import/awsdiscover and cmd/insideout-import/gcpdiscover only
+// guard drift between the two sources of truth — they do not pin literal
+// values, by design (we don't want the awsdiscover/gcpdiscover packages to
+// reach across the import boundary to assert what reliable should expect).
 package registry
 
 import (
 	"reflect"
 	"sort"
+	"sync"
 	"testing"
 )
 
-func TestSupportedDiscoverTypes_AWS(t *testing.T) {
+func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 	t.Parallel()
 	want := []string{
 		"aws_cloudwatch_log_group",
@@ -25,7 +34,7 @@ func TestSupportedDiscoverTypes_AWS(t *testing.T) {
 	}
 }
 
-func TestSupportedDiscoverTypes_GCP(t *testing.T) {
+func TestSupportedDiscoverTypes_GCP_ReturnsCanonicalSortedList(t *testing.T) {
 	t.Parallel()
 	want := []string{
 		"google_compute_network",
@@ -40,7 +49,11 @@ func TestSupportedDiscoverTypes_GCP(t *testing.T) {
 	}
 }
 
-func TestSupportedDiscoverTypes_Unknown(t *testing.T) {
+// TestSupportedDiscoverTypes_UnknownProvider_ReturnsNil pins the nil (vs
+// empty-slice) contract documented on SupportedDiscoverTypes. JSON consumers
+// rely on this — `null` and `[]` are not interchangeable in the reliable
+// wizard's payloads.
+func TestSupportedDiscoverTypes_UnknownProvider_ReturnsNil(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name     string
@@ -54,28 +67,56 @@ func TestSupportedDiscoverTypes_Unknown(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := SupportedDiscoverTypes(tc.provider); got != nil {
-				t.Errorf("SupportedDiscoverTypes(%q) = %v, want nil", tc.provider, got)
+			got := SupportedDiscoverTypes(tc.provider)
+			if got != nil {
+				t.Errorf("SupportedDiscoverTypes(%q) = %v, want nil (not empty slice)", tc.provider, got)
 			}
 		})
 	}
 }
 
-func TestSupportedDiscoverTypes_ReturnsCopy(t *testing.T) {
+// TestSupportedDiscoverTypes_ReturnsCopy_PackageStateUnchanged proves the
+// stronger invariant that callers cannot mutate the package's internal slice
+// through the returned value. Asserting against literal first elements + a
+// pointer-identity check is mutation-resistant against subtle implementation
+// regressions like `return s[:len(s):len(s)]` (which would share the backing
+// array even though the slice headers differ).
+func TestSupportedDiscoverTypes_ReturnsCopy_PackageStateUnchanged(t *testing.T) {
 	t.Parallel()
-	first := SupportedDiscoverTypes(ProviderAWS)
-	if len(first) == 0 {
-		t.Fatal("expected non-empty AWS type list")
+	cases := []struct {
+		provider string
+		// firstLiteral is the canonical first element of the sorted list.
+		// If a mutation leaks back into the package, a subsequent call's
+		// [0] no longer matches.
+		firstLiteral string
+	}{
+		{provider: ProviderAWS, firstLiteral: "aws_cloudwatch_log_group"},
+		{provider: ProviderGCP, firstLiteral: "google_compute_network"},
 	}
-	first[0] = "MUTATED"
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			t.Parallel()
+			first := SupportedDiscoverTypes(tc.provider)
+			if len(first) == 0 {
+				t.Fatalf("expected non-empty list for provider %q", tc.provider)
+			}
+			if first[0] != tc.firstLiteral {
+				t.Fatalf("first element drift: got %q, want %q (test data needs updating)", first[0], tc.firstLiteral)
+			}
+			first[0] = "MUTATED"
 
-	second := SupportedDiscoverTypes(ProviderAWS)
-	if second[0] == "MUTATED" {
-		t.Errorf("mutating returned slice leaked into the package; second call returned %v", second)
+			second := SupportedDiscoverTypes(tc.provider)
+			if second[0] != tc.firstLiteral {
+				t.Errorf("mutation leaked into package state: second call [0] = %q, want %q", second[0], tc.firstLiteral)
+			}
+			if &first[0] == &second[0] {
+				t.Error("returned slices share backing array; not a real copy")
+			}
+		})
 	}
 }
 
-func TestSupportedDiscoverTypes_Sorted(t *testing.T) {
+func TestSupportedDiscoverTypes_AllProviders_AreSorted(t *testing.T) {
 	t.Parallel()
 	for _, provider := range SupportedProviders() {
 		t.Run(provider, func(t *testing.T) {
@@ -88,7 +129,30 @@ func TestSupportedDiscoverTypes_Sorted(t *testing.T) {
 	}
 }
 
-func TestSupportedProviders(t *testing.T) {
+// TestSupportedProviders_RoundTripsThroughSupportedDiscoverTypes guards the
+// invariant promised in SupportedProviders' doc comment: every provider key
+// it advertises must map to a non-empty SupportedDiscoverTypes result. A new
+// provider added to the SupportedDiscoverTypes switch but missed in
+// SupportedProviders (or vice versa) fails here instead of silently breaking
+// downstream UIs that enumerate providers via SupportedProviders().
+func TestSupportedProviders_RoundTripsThroughSupportedDiscoverTypes(t *testing.T) {
+	t.Parallel()
+	providers := SupportedProviders()
+	if len(providers) == 0 {
+		t.Fatal("SupportedProviders returned empty list — registry would be unusable")
+	}
+	for _, p := range providers {
+		t.Run(p, func(t *testing.T) {
+			t.Parallel()
+			got := SupportedDiscoverTypes(p)
+			if len(got) == 0 {
+				t.Errorf("SupportedProviders advertises %q but SupportedDiscoverTypes(%q) returned no types", p, p)
+			}
+		})
+	}
+}
+
+func TestSupportedProviders_ReturnsBothCloudKeysSorted(t *testing.T) {
 	t.Parallel()
 	want := []string{ProviderAWS, ProviderGCP}
 	got := SupportedProviders()
@@ -97,5 +161,41 @@ func TestSupportedProviders(t *testing.T) {
 	}
 	if !sort.StringsAreSorted(got) {
 		t.Errorf("SupportedProviders() not sorted: %v", got)
+	}
+}
+
+// TestSupportedDiscoverTypes_ConcurrentAccess_IsRaceFree pins the documented
+// goroutine-safety contract by running concurrent callers under -race. The
+// package is safe by construction today (only stateless reads + per-call
+// allocation), but a future "optimization" that caches the slice and returns
+// the cached copy directly would silently break this — and surface as a race
+// here. Each goroutine mutates its own returned slice to maximize the chance
+// that a buggy shared-state implementation trips the race detector.
+func TestSupportedDiscoverTypes_ConcurrentAccess_IsRaceFree(t *testing.T) {
+	t.Parallel()
+	const goroutines = 64
+	providers := SupportedProviders()
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for _, p := range providers {
+				got := SupportedDiscoverTypes(p)
+				if len(got) == 0 {
+					t.Errorf("concurrent caller got empty list for %q", p)
+					return
+				}
+				got[0] = "MUTATED-BY-GOROUTINE"
+			}
+		}()
+	}
+	wg.Wait()
+
+	for _, p := range providers {
+		got := SupportedDiscoverTypes(p)
+		if len(got) > 0 && got[0] == "MUTATED-BY-GOROUTINE" {
+			t.Errorf("concurrent mutation leaked into package state for provider %q", p)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `pkg/insideout-import/registry` — dependency-free public Go package that exposes the supported Terraform resource types for `insideout-import discover`, per cloud provider.
- Replaces the implicit contract that today forces the reliable importer wizard to mirror the list in `mock-ui/components/import/mockData.ts` with pinned source-line references.
- Parity tests in `cmd/insideout-import/awsdiscover` and `cmd/insideout-import/gcpdiscover` guard against drift between the public registry and the live constructor maps.

## Why dependency-free

The reliable repo will import this package. If the registry depended on `awsdiscover` / `gcpdiscover`, reliable's transitive deps would balloon to include `aws-sdk-go-v2` and the GCP `cloud.google.com/go/asset` modules for no reason — these are CLI implementation. So the registry owns its own canonical sorted slices, and the discoverer-package parity tests catch any drift between the two sources of truth.

## API

```go
package registry

const (
    ProviderAWS = "aws"
    ProviderGCP = "gcp"
)

func SupportedDiscoverTypes(provider string) []string  // sorted, copy, nil for unknown
func SupportedProviders() []string
```

## Bundle context

Part of #289 (Bundle 1, gap #5). PR 1 of three; PRs 2 (#291) and 3 (#292) follow.

## Test plan

- [x] `go test ./pkg/insideout-import/registry/...` — 8 tests pass.
- [x] `go test ./cmd/insideout-import/awsdiscover/... ./cmd/insideout-import/gcpdiscover/...` — parity tests pass alongside existing suites.
- [x] `go test ./...` — full repo suite green (3112 tests).
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `gofmt -l` clean.
- [x] Repo lint suite (project-tag, project-label, sensitive-for-each, foreach-unknown-keys) clean.

Closes #290.