### PR TITLE
feat(insideout-import): multi-region scan + tag/label selectors (#291)

### DIFF
--- a/cmd/insideout-import/awsdiscover/args.go
+++ b/cmd/insideout-import/awsdiscover/args.go
@@ -1,0 +1,65 @@
+package awsdiscover
+
+// DiscoverArgs is the per-call input shape consumed by the aggregator's
+// DiscoverTypes and every per-service Discoverer.Discover. Bundling the
+// inputs into a struct (instead of positional args) keeps the per-service
+// signature stable when future fields land — e.g. #289 gap-#6 may add
+// IncludeUnsupported, #289 gap-#10 may add a permissions probe handle.
+//
+// Callers populate Project (the stack project tag/label prefix passed to
+// every per-service prefix or label filter), Regions (zero-or-more AWS
+// regions; empty means "use the configured-region of the aws.Config"
+// for back-compat with single --region invocations), TagSelectors (the
+// operator-supplied AND-conjunction filter — see TagSelector), and
+// AccountID (one STS GetCallerIdentity per run, threaded through so
+// per-service code can stamp Identity.AccountID without re-deriving).
+//
+// DiscoverArgs is intentionally NOT exported via pkg/insideout-import/...
+// — it lives in the cloud-specific aggregator package so the public
+// registry surface stays dep-free for downstream consumers (reliable
+// repo's importer wizard).
+type DiscoverArgs struct {
+	Project      string
+	Regions      []string
+	TagSelectors []TagSelector
+	AccountID    string
+}
+
+// TagSelector is a single operator-supplied tag-equality clause. The
+// match semantics are case-sensitive equality on both Key and Value;
+// substring / prefix / regex variants are deliberately not supported
+// (the reliable wizard's mockup at components/import/types.ts:69
+// presents tag selectors as `key=value` strings and the
+// case-equality model is the simplest contract that matches that UX).
+//
+// Multiple TagSelectors form an AND conjunction — see MatchesAll.
+type TagSelector struct {
+	Key   string
+	Value string
+}
+
+// Matches reports whether the given tag map contains a key-value pair
+// that exactly matches this selector. A nil tag map never matches.
+func (s TagSelector) Matches(tags map[string]string) bool {
+	if tags == nil {
+		return false
+	}
+	v, ok := tags[s.Key]
+	return ok && v == s.Value
+}
+
+// MatchesAll reports whether the given tag map satisfies every selector
+// (AND conjunction). An empty selectors slice always matches — used by
+// per-service discoverers as the no-filter fast path. A nil tag map
+// matches only when selectors is empty.
+func MatchesAll(tags map[string]string, selectors []TagSelector) bool {
+	if len(selectors) == 0 {
+		return true
+	}
+	for _, s := range selectors {
+		if !s.Matches(tags) {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/insideout-import/awsdiscover/args_test.go
+++ b/cmd/insideout-import/awsdiscover/args_test.go
@@ -1,0 +1,75 @@
+package awsdiscover
+
+import "testing"
+
+// TestTagSelector_Matches_CaseSensitiveEquality pins both legs of the
+// match contract: the same-key/same-value pair matches; differing
+// case fails (the asset stores tag values verbatim and the reliable
+// wizard's `key=value` UX implies case-sensitive equality).
+func TestTagSelector_Matches_CaseSensitiveEquality(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		tags     map[string]string
+		selector TagSelector
+		want     bool
+	}{
+		{name: "exact match", tags: map[string]string{"env": "prod"}, selector: TagSelector{Key: "env", Value: "prod"}, want: true},
+		{name: "missing key", tags: map[string]string{"team": "growth"}, selector: TagSelector{Key: "env", Value: "prod"}, want: false},
+		{name: "wrong value", tags: map[string]string{"env": "staging"}, selector: TagSelector{Key: "env", Value: "prod"}, want: false},
+		{name: "key case mismatch", tags: map[string]string{"ENV": "prod"}, selector: TagSelector{Key: "env", Value: "prod"}, want: false},
+		{name: "value case mismatch", tags: map[string]string{"env": "PROD"}, selector: TagSelector{Key: "env", Value: "prod"}, want: false},
+		{name: "nil tag map", tags: nil, selector: TagSelector{Key: "env", Value: "prod"}, want: false},
+		{name: "empty value matches empty selector value", tags: map[string]string{"env": ""}, selector: TagSelector{Key: "env", Value: ""}, want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.selector.Matches(tc.tags); got != tc.want {
+				t.Errorf("Matches(%v) for %v = %v, want %v", tc.tags, tc.selector, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMatchesAll_AllOfSemantics pins the AND-conjunction — every
+// selector must match for the resource to pass. Empty selector slice
+// is the no-filter fast path and matches anything (including a nil
+// tag map). One mismatched selector in a multi-selector set rejects
+// the resource even when every other selector matches.
+func TestMatchesAll_AllOfSemantics(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		tags      map[string]string
+		selectors []TagSelector
+		want      bool
+	}{
+		{name: "empty selectors match anything", tags: nil, selectors: nil, want: true},
+		{name: "empty selectors match populated tags", tags: map[string]string{"env": "prod"}, selectors: nil, want: true},
+		{name: "single selector hit", tags: map[string]string{"env": "prod"}, selectors: []TagSelector{{Key: "env", Value: "prod"}}, want: true},
+		{name: "single selector miss", tags: map[string]string{"env": "staging"}, selectors: []TagSelector{{Key: "env", Value: "prod"}}, want: false},
+		{name: "multi-selector all hit", tags: map[string]string{"env": "prod", "team": "growth"}, selectors: []TagSelector{{Key: "env", Value: "prod"}, {Key: "team", Value: "growth"}}, want: true},
+		{name: "multi-selector last miss rejects", tags: map[string]string{"env": "prod", "team": "infra"}, selectors: []TagSelector{{Key: "env", Value: "prod"}, {Key: "team", Value: "growth"}}, want: false},
+		// Symmetric to "last miss" — kills the "first-selector-only"
+		// mutant (a buggy implementation that returns true after the
+		// first hit without checking the rest, OR returns false only
+		// when the first selector misses).
+		{name: "multi-selector first miss rejects", tags: map[string]string{"env": "staging", "team": "growth"}, selectors: []TagSelector{{Key: "env", Value: "prod"}, {Key: "team", Value: "growth"}}, want: false},
+		// Programmatic callers can hand MatchesAll a duplicate-key
+		// selector slice (the CLI parser rejects it, but Go callers
+		// have no such gate). The AND-conjunction makes the conflict
+		// unsatisfiable; the function must report false regardless of
+		// which value the tag map carries.
+		{name: "duplicate key conflicting values", tags: map[string]string{"env": "prod"}, selectors: []TagSelector{{Key: "env", Value: "prod"}, {Key: "env", Value: "staging"}}, want: false},
+		{name: "nil tags with non-empty selectors fails", tags: nil, selectors: []TagSelector{{Key: "env", Value: "prod"}}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := MatchesAll(tc.tags, tc.selectors); got != tc.want {
+				t.Errorf("MatchesAll(%v, %v) = %v, want %v", tc.tags, tc.selectors, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -45,8 +45,14 @@ var ErrNotFound = errors.New("resource not found")
 // one Terraform type (e.g. "aws_sqs_queue") and returns []imported.ImportedResource
 // directly — no intermediate flat shape, per #189.
 //
-// Project, region, and accountID are passed in rather than re-derived per
-// discoverer so the aggregator can call STS GetCallerIdentity once.
+// The bulk Discover takes a DiscoverArgs struct (#291): Project, Regions,
+// TagSelectors, AccountID. Per-region SDK clients are constructed inside
+// each implementation so global services (IAM, S3) can ignore Regions
+// without polluting the aggregator with per-cloud branching.
+//
+// DiscoverByID stays on the legacy 4-arg shape because single-resource
+// lookups have no meaningful multi-region or tag-selector semantics —
+// dep-chase resolves one ID at a time, in one region, with no filters.
 type Discoverer interface {
 	// ResourceType returns the Terraform type this discoverer covers, e.g.
 	// "aws_sqs_queue".
@@ -54,7 +60,7 @@ type Discoverer interface {
 	// Discover performs read-only SDK calls and returns one ImportedResource
 	// per matched cloud resource. Implementations populate Identity and set
 	// Tier=TierImportedFlat, Source=SourceImporter on each entry.
-	Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error)
+	Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error)
 	// DiscoverByID looks up a single resource by its native ID (an ARN or
 	// the natural key the discoverer's Discover method emits — queue URL,
 	// table name, log group name, etc.). Used by Stage 2c3's dep-chase
@@ -77,8 +83,14 @@ const DefaultMaxConcurrency = 10
 // AWSDiscoverer aggregates the per-type discoverers and fans out a single
 // DiscoverTypes call across all of them. Construct with NewAWSDiscoverer
 // in production; tests can build it directly with mock discoverers.
+//
+// defaultRegion is captured from the construction-time aws.Config and
+// substituted into args.Regions when the operator passes none —
+// preserves the pre-#291 single-region behavior so callers that haven't
+// migrated to --regions still scan the configured-region.
 type AWSDiscoverer struct {
-	byType map[string]Discoverer
+	byType        map[string]Discoverer
+	defaultRegion string
 }
 
 // NewAWSDiscoverer wires up the production set of AWS discoverers with the
@@ -108,6 +120,7 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 		maxConcurrency = DefaultMaxConcurrency
 	}
 	return &AWSDiscoverer{
+		defaultRegion: cfg.Region,
 		byType: map[string]Discoverer{
 			"aws_sqs_queue":             newSQSDiscoverer(cfg),
 			"aws_dynamodb_table":        newDynamoDBDiscoverer(cfg, maxConcurrency),
@@ -157,9 +170,19 @@ func (a *AWSDiscoverer) DiscoverByID(ctx context.Context, tfType, id, region, ac
 // tag-fanout dominates wall time. Stage 2c2 (#270) bounded that fanout via
 // errgroup; the SDK retryer config in cmd/insideout-import/discover.go
 // raises maxAttempts so transient Throttling no longer aborts a run.
-func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, project, region, accountID string) ([]imported.ImportedResource, error) {
+//
+// Multi-region (#291): each per-service Discover loops args.Regions
+// internally and builds per-region SDK clients via the configured
+// aws.Config; global services (IAM role/policy, S3) ignore Regions. An
+// empty args.Regions defaults to the configured-region of the
+// aws.Config inside each per-service implementation, preserving the
+// pre-#291 single-region behavior.
+func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args DiscoverArgs) ([]imported.ImportedResource, error) {
 	if len(types) == 0 {
 		types = a.SupportedTypes()
+	}
+	if len(args.Regions) == 0 {
+		args.Regions = []string{a.defaultRegion}
 	}
 
 	var unknown []string
@@ -178,7 +201,7 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, proje
 
 	var all []imported.ImportedResource
 	for _, d := range selected {
-		entries, err := d.Discover(ctx, project, region, accountID)
+		entries, err := d.Discover(ctx, args)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", d.ResourceType(), err)
 		}

--- a/cmd/insideout-import/awsdiscover/awsdiscover_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_test.go
@@ -16,9 +16,7 @@ type fakeDiscoverer struct {
 	out     []imported.ImportedResource
 	err     error
 	called  int
-	gotProj string
-	gotReg  string
-	gotAcct string
+	gotArgs DiscoverArgs
 
 	// DiscoverByID wiring (unused by the existing tests, populated by
 	// new tests that exercise the dep-chase aggregator path).
@@ -28,9 +26,9 @@ type fakeDiscoverer struct {
 }
 
 func (f *fakeDiscoverer) ResourceType() string { return f.t }
-func (f *fakeDiscoverer) Discover(_ context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
+func (f *fakeDiscoverer) Discover(_ context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
 	f.called++
-	f.gotProj, f.gotReg, f.gotAcct = project, region, accountID
+	f.gotArgs = args
 	return f.out, f.err
 }
 
@@ -47,13 +45,17 @@ func ir(addr string) imported.ImportedResource {
 	}
 }
 
+func argsBasic() DiscoverArgs {
+	return DiscoverArgs{Project: "p", Regions: []string{"r"}, AccountID: "acc"}
+}
+
 func TestDiscoverTypes_DefaultsToAllSupported(t *testing.T) {
 	t.Parallel()
 	a := &fakeDiscoverer{t: "type_a", out: []imported.ImportedResource{ir("a1"), ir("a2")}}
 	b := &fakeDiscoverer{t: "type_b", out: []imported.ImportedResource{ir("b1")}}
 	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a, "type_b": b}}
 
-	got, err := agg.DiscoverTypes(context.Background(), nil, "p", "r", "acc")
+	got, err := agg.DiscoverTypes(context.Background(), nil, argsBasic())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,8 +65,70 @@ func TestDiscoverTypes_DefaultsToAllSupported(t *testing.T) {
 	if a.called != 1 || b.called != 1 {
 		t.Errorf("each discoverer called once; got a=%d b=%d", a.called, b.called)
 	}
-	if a.gotProj != "p" || a.gotReg != "r" || a.gotAcct != "acc" {
-		t.Errorf("project/region/accountID not threaded; got %q/%q/%q", a.gotProj, a.gotReg, a.gotAcct)
+	if a.gotArgs.Project != "p" || a.gotArgs.AccountID != "acc" {
+		t.Errorf("project/accountID not threaded; got %+v", a.gotArgs)
+	}
+	if !reflect.DeepEqual(a.gotArgs.Regions, []string{"r"}) {
+		t.Errorf("regions not threaded; got %v, want [r]", a.gotArgs.Regions)
+	}
+}
+
+// TestDiscoverTypes_EmptyRegionsDefaultsToConfiguredRegion pins the
+// back-compat behavior introduced in #291: callers that pass no Regions
+// (today's pre-#291 single-region invocation, which sees an empty
+// Regions slice) get the AWSDiscoverer's stored defaultRegion threaded
+// through. Callers pre-migration to --regions still scan one region.
+func TestDiscoverTypes_EmptyRegionsDefaultsToConfiguredRegion(t *testing.T) {
+	t.Parallel()
+	a := &fakeDiscoverer{t: "type_a"}
+	agg := &AWSDiscoverer{
+		byType:        map[string]Discoverer{"type_a": a},
+		defaultRegion: "us-east-1",
+	}
+	if _, err := agg.DiscoverTypes(context.Background(), nil, DiscoverArgs{Project: "p", AccountID: "acc"}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(a.gotArgs.Regions, []string{"us-east-1"}) {
+		t.Errorf("empty Regions should default to the configured region; got %v", a.gotArgs.Regions)
+	}
+}
+
+// TestDiscoverTypes_MultiRegionThreadsAllRegionsToEachDiscoverer pins
+// that multi-region inputs flow verbatim (no aggregator-side fan-out)
+// — per-service Discover loops Regions internally.
+func TestDiscoverTypes_MultiRegionThreadsAllRegionsToEachDiscoverer(t *testing.T) {
+	t.Parallel()
+	a := &fakeDiscoverer{t: "type_a"}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a}}
+	args := DiscoverArgs{Project: "p", Regions: []string{"us-east-1", "eu-west-1"}, AccountID: "acc"}
+	if _, err := agg.DiscoverTypes(context.Background(), nil, args); err != nil {
+		t.Fatal(err)
+	}
+	if a.called != 1 {
+		t.Errorf("aggregator must call each discoverer once; got %d", a.called)
+	}
+	if !reflect.DeepEqual(a.gotArgs.Regions, []string{"us-east-1", "eu-west-1"}) {
+		t.Errorf("regions not passed verbatim; got %v", a.gotArgs.Regions)
+	}
+}
+
+// TestDiscoverTypes_TagSelectorsThreadedToEachDiscoverer pins that
+// operator-supplied selectors flow through the aggregator unchanged.
+func TestDiscoverTypes_TagSelectorsThreadedToEachDiscoverer(t *testing.T) {
+	t.Parallel()
+	a := &fakeDiscoverer{t: "type_a"}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a}}
+	args := DiscoverArgs{
+		Project:      "p",
+		Regions:      []string{"r"},
+		AccountID:    "acc",
+		TagSelectors: []TagSelector{{Key: "env", Value: "prod"}, {Key: "team", Value: "growth"}},
+	}
+	if _, err := agg.DiscoverTypes(context.Background(), nil, args); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(a.gotArgs.TagSelectors, args.TagSelectors) {
+		t.Errorf("selectors not threaded; got %v, want %v", a.gotArgs.TagSelectors, args.TagSelectors)
 	}
 }
 
@@ -74,7 +138,7 @@ func TestDiscoverTypes_SelectiveOnlyCallsRequested(t *testing.T) {
 	b := &fakeDiscoverer{t: "type_b"}
 	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a, "type_b": b}}
 
-	if _, err := agg.DiscoverTypes(context.Background(), []string{"type_b"}, "p", "r", "acc"); err != nil {
+	if _, err := agg.DiscoverTypes(context.Background(), []string{"type_b"}, argsBasic()); err != nil {
 		t.Fatal(err)
 	}
 	if a.called != 0 {
@@ -90,7 +154,7 @@ func TestDiscoverTypes_UnknownTypeAggregatesAllErrorsBeforeRunning(t *testing.T)
 	a := &fakeDiscoverer{t: "type_a"}
 	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a}}
 
-	_, err := agg.DiscoverTypes(context.Background(), []string{"type_a", "bogus", "also_bogus"}, "p", "r", "acc")
+	_, err := agg.DiscoverTypes(context.Background(), []string{"type_a", "bogus", "also_bogus"}, argsBasic())
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -107,7 +171,7 @@ func TestDiscoverTypes_PropagatesPerDiscovererError(t *testing.T) {
 	a := &fakeDiscoverer{t: "type_a", err: errors.New("Throttling")}
 	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a}}
 
-	_, err := agg.DiscoverTypes(context.Background(), nil, "p", "r", "acc")
+	_, err := agg.DiscoverTypes(context.Background(), nil, argsBasic())
 	if err == nil || !strings.Contains(err.Error(), "type_a") || !strings.Contains(err.Error(), "Throttling") {
 		t.Errorf("expected wrapped error mentioning resource type and underlying cause; got: %v", err)
 	}

--- a/cmd/insideout-import/awsdiscover/cloudwatchlogs.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatchlogs.go
@@ -16,14 +16,21 @@ import (
 // cwlClient is the narrow subset of the CloudWatch Logs SDK we consume.
 type cwlClient interface {
 	DescribeLogGroups(ctx context.Context, in *cloudwatchlogs.DescribeLogGroupsInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
+	ListTagsForResource(ctx context.Context, in *cloudwatchlogs.ListTagsForResourceInput, opts ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.ListTagsForResourceOutput, error)
 }
 
 type cwlDiscoverer struct {
-	new func() cwlClient
+	new func(region string) cwlClient
 }
 
 func newCloudWatchLogsDiscoverer(cfg aws.Config) Discoverer {
-	return &cwlDiscoverer{new: func() cwlClient { return cloudwatchlogs.NewFromConfig(cfg) }}
+	return &cwlDiscoverer{new: func(region string) cwlClient {
+		return cloudwatchlogs.NewFromConfig(cfg, func(o *cloudwatchlogs.Options) {
+			if region != "" {
+				o.Region = region
+			}
+		})
+	}}
 }
 
 func (d *cwlDiscoverer) ResourceType() string { return "aws_cloudwatch_log_group" }
@@ -36,54 +43,89 @@ func (d *cwlDiscoverer) ResourceType() string { return "aws_cloudwatch_log_group
 // them. Substring match keeps the filter server-side without losing
 // either of those two common shapes.
 //
+// Multi-region (#291): outer loop walks args.Regions, building a per-
+// region SDK client. Per-group ListTagsForResource fetches the tag map
+// for tag-selector post-filtering and tag persistence onto Identity.Tags.
+//
 // Import ID for aws_cloudwatch_log_group is the log group name.
-func (d *cwlDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
-	client := d.new()
-	input := &cloudwatchlogs.DescribeLogGroupsInput{}
-	if project != "" {
-		p := project
-		input.LogGroupNamePattern = &p
-	}
-
-	type group struct {
-		name string
-		arn  string
-	}
-	var groups []group
-
-	for {
-		out, err := client.DescribeLogGroups(ctx, input)
-		if err != nil {
-			return nil, fmt.Errorf("DescribeLogGroups: %w", err)
-		}
-		for _, lg := range out.LogGroups {
-			groups = append(groups, group{
-				name: aws.ToString(lg.LogGroupName),
-				arn:  aws.ToString(lg.Arn),
-			})
-		}
-		if out.NextToken == nil || *out.NextToken == "" {
-			break
-		}
-		input.NextToken = out.NextToken
-	}
-
-	sort.Slice(groups, func(i, j int) bool { return groups[i].name < groups[j].name })
-
+func (d *cwlDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
 	book := addressBook{}
-	imps := make([]imported.ImportedResource, 0, len(groups))
-	for _, g := range groups {
-		imps = append(imps, makeImportedResource(
-			book,
-			"aws_cloudwatch_log_group",
-			g.name,
-			g.name,
-			region,
-			accountID,
-			map[string]string{"arn": g.arn},
-		))
+	var imps []imported.ImportedResource
+
+	for _, region := range args.Regions {
+		client := d.new(region)
+		input := &cloudwatchlogs.DescribeLogGroupsInput{}
+		if args.Project != "" {
+			p := args.Project
+			input.LogGroupNamePattern = &p
+		}
+
+		type group struct {
+			name string
+			arn  string
+		}
+		var groups []group
+
+		for {
+			out, err := client.DescribeLogGroups(ctx, input)
+			if err != nil {
+				return nil, fmt.Errorf("DescribeLogGroups (region=%s): %w", region, err)
+			}
+			for _, lg := range out.LogGroups {
+				groups = append(groups, group{
+					name: aws.ToString(lg.LogGroupName),
+					arn:  aws.ToString(lg.Arn),
+				})
+			}
+			if out.NextToken == nil || *out.NextToken == "" {
+				break
+			}
+			input.NextToken = out.NextToken
+		}
+
+		sort.Slice(groups, func(i, j int) bool { return groups[i].name < groups[j].name })
+
+		for _, g := range groups {
+			// ListTagsForResource takes the log group ARN, not the
+			// name. Strip the trailing ":*" wildcard CWL ARNs carry —
+			// the API rejects ARNs containing it.
+			tagARN := strings.TrimSuffix(g.arn, ":*")
+			tags, err := fetchCWLTags(ctx, client, tagARN)
+			if err != nil {
+				return nil, fmt.Errorf("ListTagsForResource (region=%s, log_group=%s): %w", region, g.name, err)
+			}
+			if !MatchesAll(tags, args.TagSelectors) {
+				continue
+			}
+			imps = append(imps, makeImportedResource(
+				book,
+				"aws_cloudwatch_log_group",
+				g.name,
+				g.name,
+				region,
+				args.AccountID,
+				map[string]string{"arn": g.arn},
+				tags,
+			))
+		}
 	}
 	return imps, nil
+}
+
+// fetchCWLTags returns the log group's tag map. CWL's
+// ListTagsForResource returns a `Tags map[string]string` directly; we
+// normalize the SDK's nil-on-empty into an empty map so the
+// nil-vs-empty distinction is preserved (nil ⇒ "didn't fetch", empty
+// ⇒ "no tags").
+func fetchCWLTags(ctx context.Context, client cwlClient, logGroupName string) (map[string]string, error) {
+	out, err := client.ListTagsForResource(ctx, &cloudwatchlogs.ListTagsForResourceInput{ResourceArn: aws.String(logGroupName)})
+	if err != nil {
+		return nil, err
+	}
+	if out.Tags == nil {
+		return map[string]string{}, nil
+	}
+	return out.Tags, nil
 }
 
 // DiscoverByID resolves a CloudWatch Logs log group by ARN
@@ -103,7 +145,7 @@ func (d *cwlDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID 
 		return imported.ImportedResource{}, err
 	}
 
-	client := d.new()
+	client := d.new(region)
 	input := &cloudwatchlogs.DescribeLogGroupsInput{LogGroupNamePrefix: aws.String(name)}
 	for {
 		out, err := client.DescribeLogGroups(ctx, input)
@@ -121,6 +163,7 @@ func (d *cwlDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID 
 					region,
 					accountID,
 					map[string]string{"arn": arn},
+					nil,
 				), nil
 			}
 		}

--- a/cmd/insideout-import/awsdiscover/cloudwatchlogs_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatchlogs_test.go
@@ -14,6 +14,14 @@ type fakeCWLClient struct {
 	pages []cloudwatchlogs.DescribeLogGroupsOutput
 	calls []cloudwatchlogs.DescribeLogGroupsInput
 	err   error
+
+	// ListTagsForResource wiring (#291). tagsByARN maps log-group ARN →
+	// tag map. Empty map for groups without tags. tagsErr is returned
+	// for every ListTagsForResource call when set. tagsCalls records
+	// the ARN observed for assertions.
+	tagsByARN map[string]map[string]string
+	tagsErr   error
+	tagsCalls []string
 }
 
 func (f *fakeCWLClient) DescribeLogGroups(_ context.Context, in *cloudwatchlogs.DescribeLogGroupsInput, _ ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
@@ -28,9 +36,20 @@ func (f *fakeCWLClient) DescribeLogGroups(_ context.Context, in *cloudwatchlogs.
 	return &f.pages[idx], nil
 }
 
+func (f *fakeCWLClient) ListTagsForResource(_ context.Context, in *cloudwatchlogs.ListTagsForResourceInput, _ ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.ListTagsForResourceOutput, error) {
+	f.tagsCalls = append(f.tagsCalls, *in.ResourceArn)
+	if f.tagsErr != nil {
+		return nil, f.tagsErr
+	}
+	if tags, ok := f.tagsByARN[*in.ResourceArn]; ok {
+		return &cloudwatchlogs.ListTagsForResourceOutput{Tags: tags}, nil
+	}
+	return &cloudwatchlogs.ListTagsForResourceOutput{}, nil
+}
+
 func TestCWLDiscover_HappyPath(t *testing.T) {
 	t.Parallel()
-	d := &cwlDiscoverer{new: func() cwlClient {
+	d := &cwlDiscoverer{new: func(_ string) cwlClient {
 		return &fakeCWLClient{
 			pages: []cloudwatchlogs.DescribeLogGroupsOutput{
 				{
@@ -42,7 +61,7 @@ func TestCWLDiscover_HappyPath(t *testing.T) {
 			},
 		}
 	}}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,8 +79,8 @@ func TestCWLDiscover_HappyPath(t *testing.T) {
 func TestCWLDiscover_PassesProjectAsLogGroupNamePattern(t *testing.T) {
 	t.Parallel()
 	fake := &fakeCWLClient{}
-	d := &cwlDiscoverer{new: func() cwlClient { return fake }}
-	if _, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123"); err != nil {
+	d := &cwlDiscoverer{new: func(_ string) cwlClient { return fake }}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.calls) == 0 {
@@ -82,8 +101,8 @@ func TestCWLDiscover_PassesProjectAsLogGroupNamePattern(t *testing.T) {
 func TestCWLDiscover_EmptyProjectPassesNoFilter(t *testing.T) {
 	t.Parallel()
 	fake := &fakeCWLClient{}
-	d := &cwlDiscoverer{new: func() cwlClient { return fake }}
-	if _, err := d.Discover(context.Background(), "", "us-east-1", "123"); err != nil {
+	d := &cwlDiscoverer{new: func(_ string) cwlClient { return fake }}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{Project: "", Regions: []string{"us-east-1"}, AccountID: "123"}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.calls) == 0 {
@@ -97,7 +116,7 @@ func TestCWLDiscover_EmptyProjectPassesNoFilter(t *testing.T) {
 
 func TestCWLDiscover_PaginatesUntilNoToken(t *testing.T) {
 	t.Parallel()
-	d := &cwlDiscoverer{new: func() cwlClient {
+	d := &cwlDiscoverer{new: func(_ string) cwlClient {
 		return &fakeCWLClient{
 			pages: []cloudwatchlogs.DescribeLogGroupsOutput{
 				{LogGroups: []cwltypes.LogGroup{{LogGroupName: aws.String("/io-foo-a"), Arn: aws.String("a")}}, NextToken: aws.String("t1")},
@@ -105,7 +124,7 @@ func TestCWLDiscover_PaginatesUntilNoToken(t *testing.T) {
 			},
 		}
 	}}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,8 +135,8 @@ func TestCWLDiscover_PaginatesUntilNoToken(t *testing.T) {
 
 func TestCWLDiscover_PropagatesError(t *testing.T) {
 	t.Parallel()
-	d := &cwlDiscoverer{new: func() cwlClient { return &fakeCWLClient{err: errors.New("Throttling")} }}
-	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	d := &cwlDiscoverer{new: func(_ string) cwlClient { return &fakeCWLClient{err: errors.New("Throttling")} }}
+	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -127,7 +146,7 @@ func TestCWLDiscoverByID_AcceptsARN(t *testing.T) {
 	t.Parallel()
 	name := "/aws/lambda/io-foo-handler"
 	arn := "arn:aws:logs:us-east-1:123:log-group:" + name + ":*"
-	d := &cwlDiscoverer{new: func() cwlClient {
+	d := &cwlDiscoverer{new: func(_ string) cwlClient {
 		return &fakeCWLClient{
 			pages: []cloudwatchlogs.DescribeLogGroupsOutput{
 				{LogGroups: []cwltypes.LogGroup{
@@ -154,7 +173,7 @@ func TestCWLDiscoverByID_AcceptsARN(t *testing.T) {
 func TestCWLDiscoverByID_AcceptsBareName(t *testing.T) {
 	t.Parallel()
 	name := "/aws/lambda/io-foo-handler"
-	d := &cwlDiscoverer{new: func() cwlClient {
+	d := &cwlDiscoverer{new: func(_ string) cwlClient {
 		return &fakeCWLClient{
 			pages: []cloudwatchlogs.DescribeLogGroupsOutput{
 				{LogGroups: []cwltypes.LogGroup{
@@ -174,7 +193,7 @@ func TestCWLDiscoverByID_AcceptsBareName(t *testing.T) {
 
 func TestCWLDiscoverByID_NotFound(t *testing.T) {
 	t.Parallel()
-	d := &cwlDiscoverer{new: func() cwlClient {
+	d := &cwlDiscoverer{new: func(_ string) cwlClient {
 		// Empty pages → CWL returns empty list (no typed not-found error).
 		return &fakeCWLClient{}
 	}}
@@ -190,7 +209,7 @@ func TestCWLDiscoverByID_PaginatesToExactMatch(t *testing.T) {
 	// sibling on page 1. A non-paginating implementation would
 	// return ErrNotFound spuriously.
 	exact := "/aws/lambda/io-foo"
-	d := &cwlDiscoverer{new: func() cwlClient {
+	d := &cwlDiscoverer{new: func(_ string) cwlClient {
 		return &fakeCWLClient{
 			pages: []cloudwatchlogs.DescribeLogGroupsOutput{
 				{
@@ -220,7 +239,7 @@ func TestCWLDiscoverByID_NotFoundOnPrefixMatchOnly(t *testing.T) {
 	t.Parallel()
 	// CWL prefix match returns names that share a prefix; DiscoverByID
 	// must require an exact match.
-	d := &cwlDiscoverer{new: func() cwlClient {
+	d := &cwlDiscoverer{new: func(_ string) cwlClient {
 		return &fakeCWLClient{
 			pages: []cloudwatchlogs.DescribeLogGroupsOutput{
 				{LogGroups: []cwltypes.LogGroup{
@@ -237,7 +256,7 @@ func TestCWLDiscoverByID_NotFoundOnPrefixMatchOnly(t *testing.T) {
 
 func TestCWLDiscoverByID_UnsupportedID(t *testing.T) {
 	t.Parallel()
-	d := &cwlDiscoverer{new: func() cwlClient { return &fakeCWLClient{} }}
+	d := &cwlDiscoverer{new: func(_ string) cwlClient { return &fakeCWLClient{} }}
 	cases := []string{
 		"",
 		"arn:aws:s3:::a-bucket", // wrong service

--- a/cmd/insideout-import/awsdiscover/dynamodb.go
+++ b/cmd/insideout-import/awsdiscover/dynamodb.go
@@ -25,7 +25,7 @@ type dynamoClient interface {
 }
 
 type dynamoDiscoverer struct {
-	new            func() dynamoClient
+	new            func(region string) dynamoClient
 	maxConcurrency int
 }
 
@@ -34,7 +34,13 @@ func newDynamoDBDiscoverer(cfg aws.Config, maxConcurrency int) Discoverer {
 		maxConcurrency = DefaultMaxConcurrency
 	}
 	return &dynamoDiscoverer{
-		new:            func() dynamoClient { return dynamodb.NewFromConfig(cfg) },
+		new: func(region string) dynamoClient {
+			return dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+				if region != "" {
+					o.Region = region
+				}
+			})
+		},
 		maxConcurrency: maxConcurrency,
 	}
 }
@@ -43,9 +49,8 @@ func (d *dynamoDiscoverer) ResourceType() string { return "aws_dynamodb_table" }
 
 // Discover paginates ListTables and filters by name prefix (DynamoDB does
 // not expose server-side filters on ListTables) — then for each candidate
-// runs ListTagsOfResource to confirm the Project tag. The double check
-// (prefix + tag) defends against table names that share the project prefix
-// by accident.
+// runs ListTagsOfResource to fetch the table's tag map. The fetched map
+// is matched against args.TagSelectors and persisted onto Identity.Tags.
 //
 // Per-table tag lookups fan out under a bounded errgroup so a few-thousand
 // table account does not serialize into a multi-minute wall-time. Per-item
@@ -55,94 +60,122 @@ func (d *dynamoDiscoverer) ResourceType() string { return "aws_dynamodb_table" }
 // propagated: gctx unblocks any in-flight goroutines and Discover returns
 // ctx.Err() rather than a silently-truncated set.
 //
+// Multi-region (#291): outer loop walks args.Regions building a per-region
+// SDK client. The legacy "Project=<project>" tag check is preserved as a
+// back-compat implicit filter when args.Project is non-empty — operators
+// that scan composer-emitted stacks rely on this dual (name-prefix +
+// Project-tag) defense. Operator-supplied selectors are AND'd on top.
+//
 // Import ID for aws_dynamodb_table is the table name.
-func (d *dynamoDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
-	client := d.new()
+func (d *dynamoDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	book := addressBook{}
+	var imps []imported.ImportedResource
+	for _, region := range args.Regions {
+		client := d.new(region)
 
-	var all []string
-	input := &dynamodb.ListTablesInput{}
-	for {
-		out, err := client.ListTables(ctx, input)
-		if err != nil {
-			return nil, fmt.Errorf("ListTables: %w", err)
-		}
-		for _, t := range out.TableNames {
-			if project == "" || hasPrefix(t, project) {
-				all = append(all, t)
+		var all []string
+		input := &dynamodb.ListTablesInput{}
+		for {
+			out, err := client.ListTables(ctx, input)
+			if err != nil {
+				return nil, fmt.Errorf("ListTables (region=%s): %w", region, err)
 			}
+			for _, t := range out.TableNames {
+				if args.Project == "" || hasPrefix(t, args.Project) {
+					all = append(all, t)
+				}
+			}
+			if out.LastEvaluatedTableName == nil || *out.LastEvaluatedTableName == "" {
+				break
+			}
+			input.ExclusiveStartTableName = out.LastEvaluatedTableName
 		}
-		if out.LastEvaluatedTableName == nil || *out.LastEvaluatedTableName == "" {
-			break
-		}
-		input.ExclusiveStartTableName = out.LastEvaluatedTableName
-	}
 
-	var matched []string
-	if project == "" || accountID == "" || region == "" {
-		// Without an account ID + region we cannot construct the ARN
-		// ListTagsOfResource needs. Fall back to prefix-only filtering and
-		// trust the operator-supplied scope.
-		matched = all
-	} else {
-		var (
-			mu sync.Mutex
-			ok []string
-		)
-		limit := d.maxConcurrency
-		if limit <= 0 {
-			limit = DefaultMaxConcurrency
+		// Per-table tag map fetched once, reused for selector match + persistence.
+		type tableEntry struct {
+			name string
+			tags map[string]string
+			arn  string
 		}
-		g, gctx := errgroup.WithContext(ctx)
-		g.SetLimit(limit)
-		for _, name := range all {
-			name := name
-			g.Go(func() error {
-				if err := gctx.Err(); err != nil {
-					return err
-				}
-				arn := fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", region, accountID, name)
-				tagsOut, err := client.ListTagsOfResource(gctx, &dynamodb.ListTagsOfResourceInput{ResourceArn: aws.String(arn)})
-				if err != nil {
-					if cerr := gctx.Err(); cerr != nil {
-						return cerr
+		entries := make([]tableEntry, 0, len(all))
+		canFetchTags := args.AccountID != "" && region != ""
+		if !canFetchTags {
+			// Without an account ID + region we cannot construct the ARN
+			// ListTagsOfResource needs. Fall back to prefix-only filtering and
+			// trust the operator-supplied scope; tags stay nil to signal
+			// "didn't fetch."
+			for _, name := range all {
+				entries = append(entries, tableEntry{name: name})
+			}
+		} else {
+			var mu sync.Mutex
+			ok := make([]tableEntry, 0, len(all))
+			limit := d.maxConcurrency
+			if limit <= 0 {
+				limit = DefaultMaxConcurrency
+			}
+			g, gctx := errgroup.WithContext(ctx)
+			g.SetLimit(limit)
+			for _, name := range all {
+				name := name
+				g.Go(func() error {
+					if err := gctx.Err(); err != nil {
+						return err
 					}
-					return nil
-				}
-				for _, tag := range tagsOut.Tags {
-					if aws.ToString(tag.Key) == "Project" && aws.ToString(tag.Value) == project {
-						mu.Lock()
-						ok = append(ok, name)
-						mu.Unlock()
+					arn := fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", region, args.AccountID, name)
+					tagsOut, err := client.ListTagsOfResource(gctx, &dynamodb.ListTagsOfResourceInput{ResourceArn: aws.String(arn)})
+					if err != nil {
+						if cerr := gctx.Err(); cerr != nil {
+							return cerr
+						}
 						return nil
 					}
-				}
-				return nil
-			})
+					tags := make(map[string]string, len(tagsOut.Tags))
+					for _, tag := range tagsOut.Tags {
+						tags[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+					}
+					mu.Lock()
+					ok = append(ok, tableEntry{name: name, tags: tags, arn: arn})
+					mu.Unlock()
+					return nil
+				})
+			}
+			if err := g.Wait(); err != nil {
+				return nil, fmt.Errorf("ListTagsOfResource (region=%s): %w", region, err)
+			}
+			entries = ok
 		}
-		if err := g.Wait(); err != nil {
-			return nil, fmt.Errorf("ListTagsOfResource: %w", err)
-		}
-		matched = ok
-	}
 
-	sort.Strings(matched)
+		sort.Slice(entries, func(i, j int) bool { return entries[i].name < entries[j].name })
 
-	book := addressBook{}
-	imps := make([]imported.ImportedResource, 0, len(matched))
-	for _, name := range matched {
-		var arn string
-		if accountID != "" && region != "" {
-			arn = fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", region, accountID, name)
+		for _, e := range entries {
+			// Legacy back-compat: when project is non-empty AND we
+			// successfully fetched tags, require the Project=<project>
+			// tag. Composer-emitted stacks rely on this dual-check; we
+			// skip it on the prefix-only fallback path (canFetchTags
+			// false) to preserve that path's existing behavior. Tags
+			// nil ⇒ "didn't fetch" ⇒ skip the Project check.
+			if canFetchTags && args.Project != "" && e.tags != nil && e.tags["Project"] != args.Project {
+				continue
+			}
+			if !MatchesAll(e.tags, args.TagSelectors) {
+				continue
+			}
+			arn := e.arn
+			if arn == "" && args.AccountID != "" && region != "" {
+				arn = fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", region, args.AccountID, e.name)
+			}
+			imps = append(imps, makeImportedResource(
+				book,
+				"aws_dynamodb_table",
+				e.name,
+				e.name,
+				region,
+				args.AccountID,
+				map[string]string{"arn": arn},
+				e.tags,
+			))
 		}
-		imps = append(imps, makeImportedResource(
-			book,
-			"aws_dynamodb_table",
-			name,
-			name,
-			region,
-			accountID,
-			map[string]string{"arn": arn},
-		))
 	}
 	return imps, nil
 }
@@ -161,7 +194,7 @@ func (d *dynamoDiscoverer) DiscoverByID(ctx context.Context, id, region, account
 	if err != nil {
 		return imported.ImportedResource{}, err
 	}
-	client := d.new()
+	client := d.new(region)
 	out, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String(name)})
 	if err != nil {
 		var notFound *dynamotypes.ResourceNotFoundException
@@ -177,6 +210,8 @@ func (d *dynamoDiscoverer) DiscoverByID(ctx context.Context, id, region, account
 	if arn == "" && accountID != "" && region != "" {
 		arn = fmt.Sprintf("arn:aws:dynamodb:%s:%s:table/%s", region, accountID, name)
 	}
+	// DiscoverByID does not fetch tags — dep-chase only needs the
+	// resource's address/import-ID resolution, not its tag map.
 	return makeImportedResource(
 		addressBook{},
 		"aws_dynamodb_table",
@@ -185,6 +220,7 @@ func (d *dynamoDiscoverer) DiscoverByID(ctx context.Context, id, region, account
 		region,
 		accountID,
 		map[string]string{"arn": arn},
+		nil,
 	), nil
 }
 

--- a/cmd/insideout-import/awsdiscover/dynamodb_test.go
+++ b/cmd/insideout-import/awsdiscover/dynamodb_test.go
@@ -85,8 +85,8 @@ func TestDynamoDBDiscover_PrefixThenTagFilter(t *testing.T) {
 			"arn:aws:dynamodb:us-east-1:123:table/io-foo-untagged": {tagPair("Owner", "team")},
 		},
 	}
-	d := &dynamoDiscoverer{new: func() dynamoClient { return fake }}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	d := &dynamoDiscoverer{new: func(_ string) dynamoClient { return fake }}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestDynamoDBDiscover_PrefixThenTagFilter(t *testing.T) {
 
 func TestDynamoDBDiscover_PaginatesUntilNoLastEvaluatedKey(t *testing.T) {
 	t.Parallel()
-	d := &dynamoDiscoverer{new: func() dynamoClient {
+	d := &dynamoDiscoverer{new: func(_ string) dynamoClient {
 		return &fakeDynamoClient{
 			pages: []dynamodb.ListTablesOutput{
 				{TableNames: []string{"io-foo-a"}, LastEvaluatedTableName: aws.String("io-foo-a")},
@@ -123,7 +123,7 @@ func TestDynamoDBDiscover_PaginatesUntilNoLastEvaluatedKey(t *testing.T) {
 			},
 		}
 	}}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestDynamoDBDiscover_PaginatesUntilNoLastEvaluatedKey(t *testing.T) {
 
 func TestDynamoDBDiscover_FailClosedOnTagsError(t *testing.T) {
 	t.Parallel()
-	d := &dynamoDiscoverer{new: func() dynamoClient {
+	d := &dynamoDiscoverer{new: func(_ string) dynamoClient {
 		return &fakeDynamoClient{
 			pages: []dynamodb.ListTablesOutput{
 				{TableNames: []string{"io-foo-good", "io-foo-throttled"}},
@@ -147,7 +147,7 @@ func TestDynamoDBDiscover_FailClosedOnTagsError(t *testing.T) {
 			},
 		}
 	}}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,8 +181,8 @@ func TestDynamoDBDiscover_PrefixOnlyFallback(t *testing.T) {
 					{TableNames: []string{"io-foo-x", "other-y"}},
 				},
 			}
-			d := &dynamoDiscoverer{new: func() dynamoClient { return fake }}
-			got, err := d.Discover(context.Background(), "io-foo", tc.region, tc.accountID)
+			d := &dynamoDiscoverer{new: func(_ string) dynamoClient { return fake }}
+			got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{tc.region}, AccountID: tc.accountID})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -200,10 +200,10 @@ func TestDynamoDBDiscover_PrefixOnlyFallback(t *testing.T) {
 
 func TestDynamoDBDiscover_PropagatesListTablesError(t *testing.T) {
 	t.Parallel()
-	d := &dynamoDiscoverer{new: func() dynamoClient {
+	d := &dynamoDiscoverer{new: func(_ string) dynamoClient {
 		return &fakeDynamoClient{listErr: errors.New("AccessDenied")}
 	}}
-	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -291,13 +291,13 @@ func TestDynamoDBDiscover_BoundedConcurrency(t *testing.T) {
 		release: release,
 	}
 	d := &dynamoDiscoverer{
-		new:            func() dynamoClient { return bc },
+		new:            func(_ string) dynamoClient { return bc },
 		maxConcurrency: limit,
 	}
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+		_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 		done <- err
 	}()
 
@@ -353,14 +353,14 @@ func TestDynamoDBDiscover_ContextCancellationUnblocksSiblings(t *testing.T) {
 		starts:  starts,
 	}
 	d := &dynamoDiscoverer{
-		new:            func() dynamoClient { return bc },
+		new:            func(_ string) dynamoClient { return bc },
 		maxConcurrency: total,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		_, err := d.Discover(ctx, "io-foo", "us-east-1", "123")
+		_, err := d.Discover(ctx, DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 		done <- err
 	}()
 
@@ -394,7 +394,7 @@ func TestDynamoDBDiscoverByID_AcceptsARN(t *testing.T) {
 			"io-foo-orders": {TableArn: aws.String(arn), TableName: aws.String("io-foo-orders")},
 		},
 	}
-	d := &dynamoDiscoverer{new: func() dynamoClient { return fake }}
+	d := &dynamoDiscoverer{new: func(_ string) dynamoClient { return fake }}
 	got, err := d.DiscoverByID(context.Background(), arn, "us-east-1", "123")
 	if err != nil {
 		t.Fatal(err)
@@ -417,7 +417,7 @@ func TestDynamoDBDiscoverByID_AcceptsBareName(t *testing.T) {
 			"orders": {TableName: aws.String("orders")},
 		},
 	}
-	d := &dynamoDiscoverer{new: func() dynamoClient { return fake }}
+	d := &dynamoDiscoverer{new: func(_ string) dynamoClient { return fake }}
 	got, err := d.DiscoverByID(context.Background(), "orders", "us-east-1", "123")
 	if err != nil {
 		t.Fatal(err)
@@ -434,7 +434,7 @@ func TestDynamoDBDiscoverByID_AcceptsBareName(t *testing.T) {
 func TestDynamoDBDiscoverByID_NotFound(t *testing.T) {
 	t.Parallel()
 	fake := &fakeDynamoClient{} // empty describeByName triggers ResourceNotFoundException
-	d := &dynamoDiscoverer{new: func() dynamoClient { return fake }}
+	d := &dynamoDiscoverer{new: func(_ string) dynamoClient { return fake }}
 	_, err := d.DiscoverByID(context.Background(), "missing", "us-east-1", "123")
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("err=%v, want ErrNotFound", err)
@@ -443,7 +443,7 @@ func TestDynamoDBDiscoverByID_NotFound(t *testing.T) {
 
 func TestDynamoDBDiscoverByID_UnsupportedID(t *testing.T) {
 	t.Parallel()
-	d := &dynamoDiscoverer{new: func() dynamoClient { return &fakeDynamoClient{} }}
+	d := &dynamoDiscoverer{new: func(_ string) dynamoClient { return &fakeDynamoClient{} }}
 	cases := []string{
 		"",
 		"arn:aws:s3:::a-bucket", // wrong service

--- a/cmd/insideout-import/awsdiscover/iam_policy.go
+++ b/cmd/insideout-import/awsdiscover/iam_policy.go
@@ -23,14 +23,21 @@ import (
 type iamPolicyClient interface {
 	ListPolicies(ctx context.Context, in *iam.ListPoliciesInput, opts ...func(*iam.Options)) (*iam.ListPoliciesOutput, error)
 	GetPolicy(ctx context.Context, in *iam.GetPolicyInput, opts ...func(*iam.Options)) (*iam.GetPolicyOutput, error)
+	ListPolicyTags(ctx context.Context, in *iam.ListPolicyTagsInput, opts ...func(*iam.Options)) (*iam.ListPolicyTagsOutput, error)
 }
 
 type iamPolicyDiscoverer struct {
-	new func() iamPolicyClient
+	new func(region string) iamPolicyClient
 }
 
 func newIAMPolicyDiscoverer(cfg aws.Config) Discoverer {
-	return &iamPolicyDiscoverer{new: func() iamPolicyClient { return iam.NewFromConfig(cfg) }}
+	return &iamPolicyDiscoverer{new: func(region string) iamPolicyClient {
+		return iam.NewFromConfig(cfg, func(o *iam.Options) {
+			if region != "" {
+				o.Region = region
+			}
+		})
+	}}
 }
 
 func (d *iamPolicyDiscoverer) ResourceType() string { return "aws_iam_policy" }
@@ -40,9 +47,13 @@ func (d *iamPolicyDiscoverer) ResourceType() string { return "aws_iam_policy" }
 // customer-managed policies (the only kind aws_iam_policy creates) and
 // excludes the thousands of AWS-managed policies.
 //
+// IAM is account-global — args.Regions is ignored; Identity.Region is
+// stamped empty. Per-policy ListPolicyTags fetches the tag map for
+// tag-selector post-filtering and tag persistence onto Identity.Tags.
+//
 // Import ID for aws_iam_policy is the policy ARN.
-func (d *iamPolicyDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
-	client := d.new()
+func (d *iamPolicyDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	client := d.new("")
 
 	type policy struct {
 		name string
@@ -60,7 +71,7 @@ func (d *iamPolicyDiscoverer) Discover(ctx context.Context, project, region, acc
 		}
 		for _, p := range page.Policies {
 			name := aws.ToString(p.PolicyName)
-			if project != "" && !strings.HasPrefix(name, project) {
+			if args.Project != "" && !strings.HasPrefix(name, args.Project) {
 				continue
 			}
 			policies = append(policies, policy{name: name, arn: aws.ToString(p.Arn)})
@@ -72,17 +83,46 @@ func (d *iamPolicyDiscoverer) Discover(ctx context.Context, project, region, acc
 	book := addressBook{}
 	imps := make([]imported.ImportedResource, 0, len(policies))
 	for _, p := range policies {
+		tags, err := fetchIAMPolicyTags(ctx, client, p.arn)
+		if err != nil {
+			return nil, fmt.Errorf("ListPolicyTags (policy=%s): %w", p.name, err)
+		}
+		if !MatchesAll(tags, args.TagSelectors) {
+			continue
+		}
 		imps = append(imps, makeImportedResource(
 			book,
 			"aws_iam_policy",
 			p.name,
 			p.arn,
-			region,
-			accountID,
+			"", // IAM is global; do not stamp a region.
+			args.AccountID,
 			map[string]string{"arn": p.arn},
+			tags,
 		))
 	}
 	return imps, nil
+}
+
+// fetchIAMPolicyTags returns the policy's tag map. ListPolicyTags
+// returns a `Tags []iamtypes.Tag` we transcribe into a string-keyed
+// map. Empty (non-nil) map for "fetched, but the policy has no tags."
+func fetchIAMPolicyTags(ctx context.Context, client iamPolicyClient, policyArn string) (map[string]string, error) {
+	tags := map[string]string{}
+	input := &iam.ListPolicyTagsInput{PolicyArn: aws.String(policyArn)}
+	for {
+		out, err := client.ListPolicyTags(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range out.Tags {
+			tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+		}
+		if !out.IsTruncated {
+			return tags, nil
+		}
+		input.Marker = out.Marker
+	}
 }
 
 // DiscoverByID resolves an IAM policy by ARN. Bare names are NOT
@@ -107,7 +147,7 @@ func (d *iamPolicyDiscoverer) DiscoverByID(ctx context.Context, id, region, acco
 		return imported.ImportedResource{}, fmt.Errorf("iam: arn resource %q is not policy/<name>: %w", parsed.Resource, ErrNotSupported)
 	}
 
-	client := d.new()
+	client := d.new(region)
 	out, err := client.GetPolicy(ctx, &iam.GetPolicyInput{PolicyArn: aws.String(id)})
 	if err != nil {
 		var notFound *iamtypes.NoSuchEntityException
@@ -133,5 +173,6 @@ func (d *iamPolicyDiscoverer) DiscoverByID(ctx context.Context, id, region, acco
 		region,
 		accountID,
 		map[string]string{"arn": id},
+		nil,
 	), nil
 }

--- a/cmd/insideout-import/awsdiscover/iam_policy_test.go
+++ b/cmd/insideout-import/awsdiscover/iam_policy_test.go
@@ -18,6 +18,11 @@ type fakeIAMPolicyClient struct {
 	getByARN map[string]*iamtypes.Policy
 	getErr   error
 	getCalls []string
+
+	// ListPolicyTags wiring (#291).
+	tagsByARN map[string][]iamtypes.Tag
+	tagsErr   error
+	tagsCalls []string
 }
 
 func (f *fakeIAMPolicyClient) ListPolicies(_ context.Context, in *iam.ListPoliciesInput, _ ...func(*iam.Options)) (*iam.ListPoliciesOutput, error) {
@@ -44,6 +49,18 @@ func (f *fakeIAMPolicyClient) GetPolicy(_ context.Context, in *iam.GetPolicyInpu
 	return nil, &iamtypes.NoSuchEntityException{}
 }
 
+func (f *fakeIAMPolicyClient) ListPolicyTags(_ context.Context, in *iam.ListPolicyTagsInput, _ ...func(*iam.Options)) (*iam.ListPolicyTagsOutput, error) {
+	arn := aws.ToString(in.PolicyArn)
+	f.tagsCalls = append(f.tagsCalls, arn)
+	if f.tagsErr != nil {
+		return nil, f.tagsErr
+	}
+	if t, ok := f.tagsByARN[arn]; ok {
+		return &iam.ListPolicyTagsOutput{Tags: t}, nil
+	}
+	return &iam.ListPolicyTagsOutput{}, nil
+}
+
 func TestIAMPolicyDiscover_FiltersByPrefixAndScope(t *testing.T) {
 	t.Parallel()
 	fake := &fakeIAMPolicyClient{pages: []iam.ListPoliciesOutput{
@@ -52,8 +69,8 @@ func TestIAMPolicyDiscover_FiltersByPrefixAndScope(t *testing.T) {
 			{PolicyName: aws.String("LegacyPolicy"), Arn: aws.String("arn:aws:iam::123:policy/LegacyPolicy")},
 		}},
 	}}
-	d := &iamPolicyDiscoverer{new: func() iamPolicyClient { return fake }}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	d := &iamPolicyDiscoverer{new: func(_ string) iamPolicyClient { return fake }}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,10 +87,10 @@ func TestIAMPolicyDiscover_FiltersByPrefixAndScope(t *testing.T) {
 
 func TestIAMPolicyDiscover_PropagatesError(t *testing.T) {
 	t.Parallel()
-	d := &iamPolicyDiscoverer{new: func() iamPolicyClient {
+	d := &iamPolicyDiscoverer{new: func(_ string) iamPolicyClient {
 		return &fakeIAMPolicyClient{err: errors.New("AccessDenied")}
 	}}
-	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -82,7 +99,7 @@ func TestIAMPolicyDiscover_PropagatesError(t *testing.T) {
 func TestIAMPolicyDiscoverByID_AcceptsARN(t *testing.T) {
 	t.Parallel()
 	arn := "arn:aws:iam::123:policy/io-foo-readonly"
-	d := &iamPolicyDiscoverer{new: func() iamPolicyClient {
+	d := &iamPolicyDiscoverer{new: func(_ string) iamPolicyClient {
 		return &fakeIAMPolicyClient{getByARN: map[string]*iamtypes.Policy{
 			arn: {PolicyName: aws.String("io-foo-readonly"), Arn: aws.String(arn)},
 		}}
@@ -104,7 +121,7 @@ func TestIAMPolicyDiscoverByID_AcceptsARN(t *testing.T) {
 
 func TestIAMPolicyDiscoverByID_NotFound(t *testing.T) {
 	t.Parallel()
-	d := &iamPolicyDiscoverer{new: func() iamPolicyClient { return &fakeIAMPolicyClient{} }}
+	d := &iamPolicyDiscoverer{new: func(_ string) iamPolicyClient { return &fakeIAMPolicyClient{} }}
 	_, err := d.DiscoverByID(context.Background(),
 		"arn:aws:iam::123:policy/missing", "us-east-1", "123")
 	if !errors.Is(err, ErrNotFound) {
@@ -114,7 +131,7 @@ func TestIAMPolicyDiscoverByID_NotFound(t *testing.T) {
 
 func TestIAMPolicyDiscoverByID_RejectsBareName(t *testing.T) {
 	t.Parallel()
-	d := &iamPolicyDiscoverer{new: func() iamPolicyClient { return &fakeIAMPolicyClient{} }}
+	d := &iamPolicyDiscoverer{new: func(_ string) iamPolicyClient { return &fakeIAMPolicyClient{} }}
 	_, err := d.DiscoverByID(context.Background(), "io-foo-readonly", "us-east-1", "123")
 	if !errors.Is(err, ErrNotSupported) {
 		t.Errorf("err=%v, want ErrNotSupported (bare names not allowed for policies)", err)
@@ -123,7 +140,7 @@ func TestIAMPolicyDiscoverByID_RejectsBareName(t *testing.T) {
 
 func TestIAMPolicyDiscoverByID_UnsupportedID(t *testing.T) {
 	t.Parallel()
-	d := &iamPolicyDiscoverer{new: func() iamPolicyClient { return &fakeIAMPolicyClient{} }}
+	d := &iamPolicyDiscoverer{new: func(_ string) iamPolicyClient { return &fakeIAMPolicyClient{} }}
 	cases := []string{
 		"",
 		"arn:aws:s3:::a-bucket",

--- a/cmd/insideout-import/awsdiscover/iam_role.go
+++ b/cmd/insideout-import/awsdiscover/iam_role.go
@@ -19,14 +19,21 @@ import (
 type iamRoleClient interface {
 	ListRoles(ctx context.Context, in *iam.ListRolesInput, opts ...func(*iam.Options)) (*iam.ListRolesOutput, error)
 	GetRole(ctx context.Context, in *iam.GetRoleInput, opts ...func(*iam.Options)) (*iam.GetRoleOutput, error)
+	ListRoleTags(ctx context.Context, in *iam.ListRoleTagsInput, opts ...func(*iam.Options)) (*iam.ListRoleTagsOutput, error)
 }
 
 type iamRoleDiscoverer struct {
-	new func() iamRoleClient
+	new func(region string) iamRoleClient
 }
 
 func newIAMRoleDiscoverer(cfg aws.Config) Discoverer {
-	return &iamRoleDiscoverer{new: func() iamRoleClient { return iam.NewFromConfig(cfg) }}
+	return &iamRoleDiscoverer{new: func(region string) iamRoleClient {
+		return iam.NewFromConfig(cfg, func(o *iam.Options) {
+			if region != "" {
+				o.Region = region
+			}
+		})
+	}}
 }
 
 func (d *iamRoleDiscoverer) ResourceType() string { return "aws_iam_role" }
@@ -37,9 +44,14 @@ func (d *iamRoleDiscoverer) ResourceType() string { return "aws_iam_role" }
 // so client-side prefix filtering matches the bounded-account
 // assumption already used by the DynamoDB discoverer.
 //
+// IAM is account-global — args.Regions is ignored. The Identity.Region
+// stamp is left empty for IAM resources to reflect that. Per-role
+// ListRoleTags fetches the tag map for tag-selector post-filtering and
+// tag persistence onto Identity.Tags.
+//
 // Import ID for aws_iam_role is the role name.
-func (d *iamRoleDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
-	client := d.new()
+func (d *iamRoleDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	client := d.new("")
 
 	type role struct {
 		name string
@@ -55,7 +67,7 @@ func (d *iamRoleDiscoverer) Discover(ctx context.Context, project, region, accou
 		}
 		for _, r := range page.Roles {
 			name := aws.ToString(r.RoleName)
-			if project != "" && !strings.HasPrefix(name, project) {
+			if args.Project != "" && !strings.HasPrefix(name, args.Project) {
 				continue
 			}
 			roles = append(roles, role{name: name, arn: aws.ToString(r.Arn)})
@@ -67,17 +79,46 @@ func (d *iamRoleDiscoverer) Discover(ctx context.Context, project, region, accou
 	book := addressBook{}
 	imps := make([]imported.ImportedResource, 0, len(roles))
 	for _, r := range roles {
+		tags, err := fetchIAMRoleTags(ctx, client, r.name)
+		if err != nil {
+			return nil, fmt.Errorf("ListRoleTags (role=%s): %w", r.name, err)
+		}
+		if !MatchesAll(tags, args.TagSelectors) {
+			continue
+		}
 		imps = append(imps, makeImportedResource(
 			book,
 			"aws_iam_role",
 			r.name,
 			r.name,
-			region,
-			accountID,
+			"", // IAM is global; do not stamp a region.
+			args.AccountID,
 			map[string]string{"arn": r.arn},
+			tags,
 		))
 	}
 	return imps, nil
+}
+
+// fetchIAMRoleTags returns the role's tag map. ListRoleTags returns a
+// `Tags []iamtypes.Tag` we transcribe into a string-keyed map. Empty
+// (non-nil) map for "fetched, but the role has no tags."
+func fetchIAMRoleTags(ctx context.Context, client iamRoleClient, roleName string) (map[string]string, error) {
+	tags := map[string]string{}
+	input := &iam.ListRoleTagsInput{RoleName: aws.String(roleName)}
+	for {
+		out, err := client.ListRoleTags(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range out.Tags {
+			tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+		}
+		if !out.IsTruncated {
+			return tags, nil
+		}
+		input.Marker = out.Marker
+	}
 }
 
 // DiscoverByID resolves an IAM role by ARN
@@ -88,7 +129,7 @@ func (d *iamRoleDiscoverer) DiscoverByID(ctx context.Context, id, region, accoun
 	if err != nil {
 		return imported.ImportedResource{}, err
 	}
-	client := d.new()
+	client := d.new(region)
 	out, err := client.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String(name)})
 	if err != nil {
 		var notFound *iamtypes.NoSuchEntityException
@@ -109,6 +150,7 @@ func (d *iamRoleDiscoverer) DiscoverByID(ctx context.Context, id, region, accoun
 		region,
 		accountID,
 		map[string]string{"arn": arn},
+		nil,
 	), nil
 }
 

--- a/cmd/insideout-import/awsdiscover/iam_role_test.go
+++ b/cmd/insideout-import/awsdiscover/iam_role_test.go
@@ -18,6 +18,11 @@ type fakeIAMRoleClient struct {
 	getByName map[string]*iamtypes.Role
 	getErr    error
 	getCalls  []string
+
+	// ListRoleTags wiring (#291).
+	tagsByRole map[string][]iamtypes.Tag
+	tagsErr    error
+	tagsCalls  []string
 }
 
 func (f *fakeIAMRoleClient) ListRoles(_ context.Context, in *iam.ListRolesInput, _ ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
@@ -44,9 +49,21 @@ func (f *fakeIAMRoleClient) GetRole(_ context.Context, in *iam.GetRoleInput, _ .
 	return nil, &iamtypes.NoSuchEntityException{}
 }
 
+func (f *fakeIAMRoleClient) ListRoleTags(_ context.Context, in *iam.ListRoleTagsInput, _ ...func(*iam.Options)) (*iam.ListRoleTagsOutput, error) {
+	name := aws.ToString(in.RoleName)
+	f.tagsCalls = append(f.tagsCalls, name)
+	if f.tagsErr != nil {
+		return nil, f.tagsErr
+	}
+	if t, ok := f.tagsByRole[name]; ok {
+		return &iam.ListRoleTagsOutput{Tags: t}, nil
+	}
+	return &iam.ListRoleTagsOutput{}, nil
+}
+
 func TestIAMRoleDiscover_FiltersByPrefix(t *testing.T) {
 	t.Parallel()
-	d := &iamRoleDiscoverer{new: func() iamRoleClient {
+	d := &iamRoleDiscoverer{new: func(_ string) iamRoleClient {
 		return &fakeIAMRoleClient{pages: []iam.ListRolesOutput{
 			{Roles: []iamtypes.Role{
 				{RoleName: aws.String("io-foo-handler"), Arn: aws.String("arn:aws:iam::123:role/io-foo-handler")},
@@ -55,7 +72,7 @@ func TestIAMRoleDiscover_FiltersByPrefix(t *testing.T) {
 			}},
 		}}
 	}}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +86,7 @@ func TestIAMRoleDiscover_FiltersByPrefix(t *testing.T) {
 
 func TestIAMRoleDiscover_EmptyProjectReturnsAll(t *testing.T) {
 	t.Parallel()
-	d := &iamRoleDiscoverer{new: func() iamRoleClient {
+	d := &iamRoleDiscoverer{new: func(_ string) iamRoleClient {
 		return &fakeIAMRoleClient{pages: []iam.ListRolesOutput{
 			{Roles: []iamtypes.Role{
 				{RoleName: aws.String("a"), Arn: aws.String("arn:test:a")},
@@ -77,7 +94,7 @@ func TestIAMRoleDiscover_EmptyProjectReturnsAll(t *testing.T) {
 			}},
 		}}
 	}}
-	got, err := d.Discover(context.Background(), "", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,10 +105,10 @@ func TestIAMRoleDiscover_EmptyProjectReturnsAll(t *testing.T) {
 
 func TestIAMRoleDiscover_PropagatesError(t *testing.T) {
 	t.Parallel()
-	d := &iamRoleDiscoverer{new: func() iamRoleClient {
+	d := &iamRoleDiscoverer{new: func(_ string) iamRoleClient {
 		return &fakeIAMRoleClient{err: errors.New("AccessDenied")}
 	}}
-	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -100,7 +117,7 @@ func TestIAMRoleDiscover_PropagatesError(t *testing.T) {
 func TestIAMRoleDiscoverByID_AcceptsARN(t *testing.T) {
 	t.Parallel()
 	arn := "arn:aws:iam::123:role/io-foo-handler"
-	d := &iamRoleDiscoverer{new: func() iamRoleClient {
+	d := &iamRoleDiscoverer{new: func(_ string) iamRoleClient {
 		return &fakeIAMRoleClient{getByName: map[string]*iamtypes.Role{
 			"io-foo-handler": {RoleName: aws.String("io-foo-handler"), Arn: aws.String(arn)},
 		}}
@@ -122,7 +139,7 @@ func TestIAMRoleDiscoverByID_AcceptsARN(t *testing.T) {
 
 func TestIAMRoleDiscoverByID_StripsPathFromARN(t *testing.T) {
 	t.Parallel()
-	d := &iamRoleDiscoverer{new: func() iamRoleClient {
+	d := &iamRoleDiscoverer{new: func(_ string) iamRoleClient {
 		return &fakeIAMRoleClient{getByName: map[string]*iamtypes.Role{
 			"my-role": {RoleName: aws.String("my-role"), Arn: aws.String("arn:test")},
 		}}
@@ -137,7 +154,7 @@ func TestIAMRoleDiscoverByID_StripsPathFromARN(t *testing.T) {
 
 func TestIAMRoleDiscoverByID_AcceptsBareName(t *testing.T) {
 	t.Parallel()
-	d := &iamRoleDiscoverer{new: func() iamRoleClient {
+	d := &iamRoleDiscoverer{new: func(_ string) iamRoleClient {
 		return &fakeIAMRoleClient{getByName: map[string]*iamtypes.Role{
 			"io-foo-handler": {RoleName: aws.String("io-foo-handler"), Arn: aws.String("arn:test")},
 		}}
@@ -153,7 +170,7 @@ func TestIAMRoleDiscoverByID_AcceptsBareName(t *testing.T) {
 
 func TestIAMRoleDiscoverByID_NotFound(t *testing.T) {
 	t.Parallel()
-	d := &iamRoleDiscoverer{new: func() iamRoleClient { return &fakeIAMRoleClient{} }}
+	d := &iamRoleDiscoverer{new: func(_ string) iamRoleClient { return &fakeIAMRoleClient{} }}
 	_, err := d.DiscoverByID(context.Background(), "missing", "us-east-1", "123")
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("err=%v, want ErrNotFound", err)
@@ -162,7 +179,7 @@ func TestIAMRoleDiscoverByID_NotFound(t *testing.T) {
 
 func TestIAMRoleDiscoverByID_UnsupportedID(t *testing.T) {
 	t.Parallel()
-	d := &iamRoleDiscoverer{new: func() iamRoleClient { return &fakeIAMRoleClient{} }}
+	d := &iamRoleDiscoverer{new: func(_ string) iamRoleClient { return &fakeIAMRoleClient{} }}
 	cases := []string{
 		"",
 		"arn:aws:s3:::a-bucket",

--- a/cmd/insideout-import/awsdiscover/identity.go
+++ b/cmd/insideout-import/awsdiscover/identity.go
@@ -30,8 +30,12 @@ func (b addressBook) add(addr string) { b[addr] = struct{}{} }
 // (arn, url) without mutating the merged map after construction.
 //
 // region and accountID are passed in by the aggregator (one STS call per
-// run); the discoverer does not re-derive them.
-func makeImportedResource(book addressBook, typ, name, importID, region, accountID string, nativeIDs map[string]string) imported.ImportedResource {
+// run); the discoverer does not re-derive them. tags is the cloud-side
+// tag map captured at discover time — pass nil if the discoverer did not
+// fetch tags, or an empty (non-nil) map for "fetched, but the resource
+// has no tags." The nil-vs-empty distinction is load-bearing for
+// downstream tag-selector and summary consumers (#291, #289 gap-#6).
+func makeImportedResource(book addressBook, typ, name, importID, region, accountID string, nativeIDs, tags map[string]string) imported.ImportedResource {
 	id := imported.ResourceIdentity{
 		Cloud:          "aws",
 		Type:           typ,
@@ -42,6 +46,7 @@ func makeImportedResource(book addressBook, typ, name, importID, region, account
 		Region:         region,
 		ImportID:       importID,
 		NativeIDs:      mergeNativeIDs(name, nativeIDs),
+		Tags:           tags,
 	}
 	addr := imported.GenerateAddress(id, book.exists)
 	id.Address = addr

--- a/cmd/insideout-import/awsdiscover/identity_test.go
+++ b/cmd/insideout-import/awsdiscover/identity_test.go
@@ -10,7 +10,21 @@ import (
 func TestMakeImportedResource_PopulatesRequiredFields(t *testing.T) {
 	t.Parallel()
 	book := addressBook{}
-	got := makeImportedResource(book, "aws_sqs_queue", "io-foo-q", "https://sqs.us-east-1.amazonaws.com/123/io-foo-q", "us-east-1", "123", map[string]string{"url": "https://sqs.us-east-1.amazonaws.com/123/io-foo-q"})
+	wantTags := map[string]string{"Project": "io-foo", "env": "prod"}
+	got := makeImportedResource(book, "aws_sqs_queue", "io-foo-q", "https://sqs.us-east-1.amazonaws.com/123/io-foo-q", "us-east-1", "123",
+		map[string]string{"url": "https://sqs.us-east-1.amazonaws.com/123/io-foo-q"},
+		wantTags,
+	)
+
+	// Tags carrier (#291) — pin both presence and shape. A regression
+	// that drops the field would surface here before any downstream
+	// consumer (selector-filter, summary builder) silently breaks.
+	if got.Identity.Tags == nil {
+		t.Error("Tags must be populated when discoverer fetched a tag map")
+	}
+	if got.Identity.Tags["Project"] != "io-foo" || got.Identity.Tags["env"] != "prod" {
+		t.Errorf("Tags=%v, want %v", got.Identity.Tags, wantTags)
+	}
 
 	if got.Identity.Cloud != "aws" {
 		t.Errorf("Cloud=%q, want aws", got.Identity.Cloud)
@@ -60,8 +74,8 @@ func TestMakeImportedResource_PopulatesRequiredFields(t *testing.T) {
 func TestMakeImportedResource_ResolvesAddressCollisionsWithinBatch(t *testing.T) {
 	t.Parallel()
 	book := addressBook{}
-	a := makeImportedResource(book, "aws_sqs_queue", "io-q", "https://example/io-q-1", "us-east-1", "123", nil)
-	b := makeImportedResource(book, "aws_sqs_queue", "io-q", "https://example/io-q-2", "us-east-1", "123", nil)
+	a := makeImportedResource(book, "aws_sqs_queue", "io-q", "https://example/io-q-1", "us-east-1", "123", nil, nil)
+	b := makeImportedResource(book, "aws_sqs_queue", "io-q", "https://example/io-q-2", "us-east-1", "123", nil, nil)
 
 	// Identical NameHint but different ImportID → identityHash differs →
 	// GenerateAddress's `_<8hex>` collision suffix should produce

--- a/cmd/insideout-import/awsdiscover/kms.go
+++ b/cmd/insideout-import/awsdiscover/kms.go
@@ -21,14 +21,21 @@ import (
 type kmsClient interface {
 	ListAliases(ctx context.Context, in *kms.ListAliasesInput, opts ...func(*kms.Options)) (*kms.ListAliasesOutput, error)
 	DescribeKey(ctx context.Context, in *kms.DescribeKeyInput, opts ...func(*kms.Options)) (*kms.DescribeKeyOutput, error)
+	ListResourceTags(ctx context.Context, in *kms.ListResourceTagsInput, opts ...func(*kms.Options)) (*kms.ListResourceTagsOutput, error)
 }
 
 type kmsDiscoverer struct {
-	new func() kmsClient
+	new func(region string) kmsClient
 }
 
 func newKMSDiscoverer(cfg aws.Config) Discoverer {
-	return &kmsDiscoverer{new: func() kmsClient { return kms.NewFromConfig(cfg) }}
+	return &kmsDiscoverer{new: func(region string) kmsClient {
+		return kms.NewFromConfig(cfg, func(o *kms.Options) {
+			if region != "" {
+				o.Region = region
+			}
+		})
+	}}
 }
 
 func (d *kmsDiscoverer) ResourceType() string { return "aws_kms_key" }
@@ -44,73 +51,105 @@ func (d *kmsDiscoverer) ResourceType() string { return "aws_kms_key" }
 // project name are skipped. Operators with "naked" keys (no alias)
 // must hand the key UUID to discover via the --resource-types path.
 //
+// Multi-region (#291): outer loop walks args.Regions, building a per-
+// region SDK client. Per-key ListResourceTags fetches the key tag map
+// for tag-selector post-filtering and tag persistence onto Identity.Tags.
+//
 // Import ID for aws_kms_key is the key UUID (from the alias's
 // TargetKeyId).
-func (d *kmsDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
-	client := d.new()
-
-	type key struct {
-		uuid  string
-		alias string
-	}
-	var keys []key
-
-	paginator := kms.NewListAliasesPaginator(client, &kms.ListAliasesInput{})
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("ListAliases: %w", err)
-		}
-		for _, a := range page.Aliases {
-			alias := aws.ToString(a.AliasName)
-			target := aws.ToString(a.TargetKeyId)
-			if target == "" {
-				// AWS-managed alias with no customer-managed key behind
-				// it; skip — cannot import.
-				continue
-			}
-			if project != "" && !strings.Contains(alias, project) {
-				continue
-			}
-			// Skip AWS-managed aliases (e.g. "alias/aws/...") that may
-			// happen to contain the project name as a substring.
-			if strings.HasPrefix(alias, "alias/aws/") {
-				continue
-			}
-			// Note: a.AliasArn is the *alias* ARN, not the key ARN we
-			// want for NativeIDs[arn]. The key ARN is synthesized
-			// below from region + accountID + target UUID; alias arn
-			// is intentionally NOT carried into NativeIDs.
-			keys = append(keys, key{
-				uuid:  target,
-				alias: alias,
-			})
-		}
-	}
-
-	sort.Slice(keys, func(i, j int) bool { return keys[i].alias < keys[j].alias })
-
+func (d *kmsDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
 	book := addressBook{}
-	imps := make([]imported.ImportedResource, 0, len(keys))
-	for _, k := range keys {
-		var arn string
-		if accountID != "" && region != "" {
-			arn = fmt.Sprintf("arn:aws:kms:%s:%s:key/%s", region, accountID, k.uuid)
+	var imps []imported.ImportedResource
+
+	for _, region := range args.Regions {
+		client := d.new(region)
+
+		type key struct {
+			uuid  string
+			alias string
 		}
-		// NameHint is the alias (without "alias/" prefix) to keep the
-		// generated Terraform address human-readable.
-		nameHint := strings.TrimPrefix(k.alias, "alias/")
-		imps = append(imps, makeImportedResource(
-			book,
-			"aws_kms_key",
-			nameHint,
-			k.uuid,
-			region,
-			accountID,
-			map[string]string{"arn": arn, "alias": k.alias},
-		))
+		var keys []key
+
+		paginator := kms.NewListAliasesPaginator(client, &kms.ListAliasesInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("ListAliases (region=%s): %w", region, err)
+			}
+			for _, a := range page.Aliases {
+				alias := aws.ToString(a.AliasName)
+				target := aws.ToString(a.TargetKeyId)
+				if target == "" {
+					// AWS-managed alias with no customer-managed key behind
+					// it; skip — cannot import.
+					continue
+				}
+				if args.Project != "" && !strings.Contains(alias, args.Project) {
+					continue
+				}
+				// Skip AWS-managed aliases (e.g. "alias/aws/...") that may
+				// happen to contain the project name as a substring.
+				if strings.HasPrefix(alias, "alias/aws/") {
+					continue
+				}
+				keys = append(keys, key{
+					uuid:  target,
+					alias: alias,
+				})
+			}
+		}
+
+		sort.Slice(keys, func(i, j int) bool { return keys[i].alias < keys[j].alias })
+
+		for _, k := range keys {
+			tags, err := fetchKMSTags(ctx, client, k.uuid)
+			if err != nil {
+				return nil, fmt.Errorf("ListResourceTags (region=%s, key=%s): %w", region, k.uuid, err)
+			}
+			if !MatchesAll(tags, args.TagSelectors) {
+				continue
+			}
+			var arn string
+			if args.AccountID != "" && region != "" {
+				arn = fmt.Sprintf("arn:aws:kms:%s:%s:key/%s", region, args.AccountID, k.uuid)
+			}
+			// NameHint is the alias (without "alias/" prefix) to keep the
+			// generated Terraform address human-readable.
+			nameHint := strings.TrimPrefix(k.alias, "alias/")
+			imps = append(imps, makeImportedResource(
+				book,
+				"aws_kms_key",
+				nameHint,
+				k.uuid,
+				region,
+				args.AccountID,
+				map[string]string{"arn": arn, "alias": k.alias},
+				tags,
+			))
+		}
 	}
 	return imps, nil
+}
+
+// fetchKMSTags returns the key's tag map. KMS's ListResourceTags
+// returns `Tags []TagListEntry` (TagKey + TagValue). Empty (non-nil)
+// map for "fetched, but the key has no tags."
+func fetchKMSTags(ctx context.Context, client kmsClient, keyID string) (map[string]string, error) {
+	tags := map[string]string{}
+	input := &kms.ListResourceTagsInput{KeyId: aws.String(keyID)}
+	for {
+		out, err := client.ListResourceTags(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range out.Tags {
+			tags[aws.ToString(t.TagKey)] = aws.ToString(t.TagValue)
+		}
+		if !out.Truncated {
+			return tags, nil
+		}
+		input.Marker = out.NextMarker
+	}
 }
 
 // DiscoverByID resolves a KMS key by ARN
@@ -122,7 +161,7 @@ func (d *kmsDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID 
 	if err != nil {
 		return imported.ImportedResource{}, err
 	}
-	client := d.new()
+	client := d.new(region)
 	out, err := client.DescribeKey(ctx, &kms.DescribeKeyInput{KeyId: aws.String(probe)})
 	if err != nil {
 		var notFound *kmstypes.NotFoundException
@@ -147,6 +186,7 @@ func (d *kmsDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID 
 		region,
 		accountID,
 		map[string]string{"arn": arn},
+		nil,
 	), nil
 }
 

--- a/cmd/insideout-import/awsdiscover/kms_test.go
+++ b/cmd/insideout-import/awsdiscover/kms_test.go
@@ -18,6 +18,11 @@ type fakeKMSClient struct {
 	describeByID  map[string]*kmstypes.KeyMetadata
 	describeErr   error
 	describeCalls []string
+
+	// ListResourceTags wiring (#291).
+	tagsByKey map[string][]kmstypes.Tag
+	tagsErr   error
+	tagsCalls []string
 }
 
 func (f *fakeKMSClient) ListAliases(_ context.Context, in *kms.ListAliasesInput, _ ...func(*kms.Options)) (*kms.ListAliasesOutput, error) {
@@ -44,9 +49,21 @@ func (f *fakeKMSClient) DescribeKey(_ context.Context, in *kms.DescribeKeyInput,
 	return nil, &kmstypes.NotFoundException{}
 }
 
+func (f *fakeKMSClient) ListResourceTags(_ context.Context, in *kms.ListResourceTagsInput, _ ...func(*kms.Options)) (*kms.ListResourceTagsOutput, error) {
+	id := aws.ToString(in.KeyId)
+	f.tagsCalls = append(f.tagsCalls, id)
+	if f.tagsErr != nil {
+		return nil, f.tagsErr
+	}
+	if t, ok := f.tagsByKey[id]; ok {
+		return &kms.ListResourceTagsOutput{Tags: t}, nil
+	}
+	return &kms.ListResourceTagsOutput{}, nil
+}
+
 func TestKMSDiscover_FiltersByAliasContainsProject(t *testing.T) {
 	t.Parallel()
-	d := &kmsDiscoverer{new: func() kmsClient {
+	d := &kmsDiscoverer{new: func(_ string) kmsClient {
 		return &fakeKMSClient{pages: []kms.ListAliasesOutput{
 			{Aliases: []kmstypes.AliasListEntry{
 				{
@@ -69,7 +86,7 @@ func TestKMSDiscover_FiltersByAliasContainsProject(t *testing.T) {
 			}},
 		}}
 	}}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,10 +106,10 @@ func TestKMSDiscover_FiltersByAliasContainsProject(t *testing.T) {
 
 func TestKMSDiscover_PropagatesError(t *testing.T) {
 	t.Parallel()
-	d := &kmsDiscoverer{new: func() kmsClient {
+	d := &kmsDiscoverer{new: func(_ string) kmsClient {
 		return &fakeKMSClient{err: errors.New("AccessDenied")}
 	}}
-	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -101,7 +118,7 @@ func TestKMSDiscover_PropagatesError(t *testing.T) {
 func TestKMSDiscoverByID_AcceptsKeyARN(t *testing.T) {
 	t.Parallel()
 	arn := "arn:aws:kms:us-east-1:123:key/uuid-1"
-	d := &kmsDiscoverer{new: func() kmsClient {
+	d := &kmsDiscoverer{new: func(_ string) kmsClient {
 		return &fakeKMSClient{describeByID: map[string]*kmstypes.KeyMetadata{
 			arn: {KeyId: aws.String("uuid-1"), Arn: aws.String(arn)},
 		}}
@@ -123,7 +140,7 @@ func TestKMSDiscoverByID_AcceptsKeyARN(t *testing.T) {
 
 func TestKMSDiscoverByID_AcceptsBareUUID(t *testing.T) {
 	t.Parallel()
-	d := &kmsDiscoverer{new: func() kmsClient {
+	d := &kmsDiscoverer{new: func(_ string) kmsClient {
 		return &fakeKMSClient{describeByID: map[string]*kmstypes.KeyMetadata{
 			"uuid-1": {KeyId: aws.String("uuid-1"), Arn: aws.String("arn:aws:kms:us-east-1:123:key/uuid-1")},
 		}}
@@ -139,7 +156,7 @@ func TestKMSDiscoverByID_AcceptsBareUUID(t *testing.T) {
 
 func TestKMSDiscoverByID_AcceptsAliasName(t *testing.T) {
 	t.Parallel()
-	d := &kmsDiscoverer{new: func() kmsClient {
+	d := &kmsDiscoverer{new: func(_ string) kmsClient {
 		return &fakeKMSClient{describeByID: map[string]*kmstypes.KeyMetadata{
 			"alias/io-foo-data": {KeyId: aws.String("uuid-1"), Arn: aws.String("arn:aws:kms:us-east-1:123:key/uuid-1")},
 		}}
@@ -155,7 +172,7 @@ func TestKMSDiscoverByID_AcceptsAliasName(t *testing.T) {
 
 func TestKMSDiscoverByID_NotFound(t *testing.T) {
 	t.Parallel()
-	d := &kmsDiscoverer{new: func() kmsClient { return &fakeKMSClient{} }}
+	d := &kmsDiscoverer{new: func(_ string) kmsClient { return &fakeKMSClient{} }}
 	_, err := d.DiscoverByID(context.Background(), "uuid-missing", "us-east-1", "123")
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("err=%v, want ErrNotFound", err)
@@ -164,7 +181,7 @@ func TestKMSDiscoverByID_NotFound(t *testing.T) {
 
 func TestKMSDiscoverByID_UnsupportedID(t *testing.T) {
 	t.Parallel()
-	d := &kmsDiscoverer{new: func() kmsClient { return &fakeKMSClient{} }}
+	d := &kmsDiscoverer{new: func(_ string) kmsClient { return &fakeKMSClient{} }}
 	cases := []string{
 		"",
 		"arn:aws:s3:::a-bucket",

--- a/cmd/insideout-import/awsdiscover/lambda.go
+++ b/cmd/insideout-import/awsdiscover/lambda.go
@@ -26,7 +26,7 @@ type lambdaClient interface {
 }
 
 type lambdaDiscoverer struct {
-	new            func() lambdaClient
+	new            func(region string) lambdaClient
 	maxConcurrency int
 }
 
@@ -35,53 +35,70 @@ func newLambdaDiscoverer(cfg aws.Config, maxConcurrency int) Discoverer {
 		maxConcurrency = DefaultMaxConcurrency
 	}
 	return &lambdaDiscoverer{
-		new:            func() lambdaClient { return lambda.NewFromConfig(cfg) },
+		new: func(region string) lambdaClient {
+			return lambda.NewFromConfig(cfg, func(o *lambda.Options) {
+				if region != "" {
+					o.Region = region
+				}
+			})
+		},
 		maxConcurrency: maxConcurrency,
 	}
 }
 
 func (d *lambdaDiscoverer) ResourceType() string { return "aws_lambda_function" }
 
-// Discover paginates ListFunctions then per-function ListTags fan-out to
-// keep functions tagged Project=<project>. Lambda has no server-side tag
-// filter, so this is the cheapest correct shape.
+// Discover paginates ListFunctions then fans out per-function ListTags to
+// fetch each function's tag map. Lambda has no server-side tag filter,
+// so this is the cheapest correct shape.
 //
 // Per-function ListTags calls run under a bounded errgroup so a thousand-
 // function account does not serialize into a multi-minute wall-time.
 // Per-item SDK errors are fail-closed (an unreachable ListTags is treated
-// as "no Project tag", not "include anyway") since the SDK retryer has
-// already exhausted its budget. Parent-context cancellation IS propagated:
-// gctx unblocks any in-flight goroutines and Discover returns ctx.Err()
-// rather than a silently-truncated set. ListFunctions errors abort.
+// as nil tags, which fails any selector that requires a key) since the
+// SDK retryer has already exhausted its budget. Parent-context
+// cancellation IS propagated: gctx unblocks any in-flight goroutines
+// and Discover returns ctx.Err() rather than a silently-truncated set.
+// ListFunctions errors abort.
+//
+// Multi-region (#291): outer loop walks args.Regions, building a per-
+// region SDK client. The legacy "Project=<project>" tag check is
+// preserved as a back-compat implicit filter when args.Project is
+// non-empty (composer-emitted stacks rely on it). Operator selectors
+// AND on top.
 //
 // Import ID for aws_lambda_function is the function name.
-func (d *lambdaDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
-	client := d.new()
+func (d *lambdaDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	book := addressBook{}
+	var out []imported.ImportedResource
 
-	type fn struct {
-		name string
-		arn  string
-	}
-	var allFns []fn
+	for _, region := range args.Regions {
+		client := d.new(region)
 
-	paginator := lambda.NewListFunctionsPaginator(client, &lambda.ListFunctionsInput{})
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("ListFunctions: %w", err)
+		type fn struct {
+			name string
+			arn  string
+			tags map[string]string
 		}
-		for _, f := range page.Functions {
-			allFns = append(allFns, fn{
-				name: aws.ToString(f.FunctionName),
-				arn:  aws.ToString(f.FunctionArn),
-			})
-		}
-	}
+		var allFns []fn
 
-	var matched []fn
-	if project == "" {
-		matched = allFns
-	} else {
+		paginator := lambda.NewListFunctionsPaginator(client, &lambda.ListFunctionsInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("ListFunctions (region=%s): %w", region, err)
+			}
+			for _, f := range page.Functions {
+				allFns = append(allFns, fn{
+					name: aws.ToString(f.FunctionName),
+					arn:  aws.ToString(f.FunctionArn),
+				})
+			}
+		}
+
+		// Per-function tag fetch fan-out. We always fetch (PR 2 #291)
+		// — the tag map is needed for selector matching AND for
+		// persistence onto Identity.Tags.
 		var (
 			mu sync.Mutex
 			ok []fn
@@ -103,36 +120,46 @@ func (d *lambdaDiscoverer) Discover(ctx context.Context, project, region, accoun
 					if cerr := gctx.Err(); cerr != nil {
 						return cerr
 					}
+					// Transient ListTags failure: skip the function.
+					// Pre-#291 dropped the row when the Project check
+					// could not run; we keep that posture for back-compat.
 					return nil
 				}
-				if tagsOut.Tags["Project"] == project {
-					mu.Lock()
-					ok = append(ok, f)
-					mu.Unlock()
+				tags := tagsOut.Tags
+				if tags == nil {
+					tags = map[string]string{}
 				}
+				mu.Lock()
+				ok = append(ok, fn{name: f.name, arn: f.arn, tags: tags})
+				mu.Unlock()
 				return nil
 			})
 		}
 		if err := g.Wait(); err != nil {
-			return nil, fmt.Errorf("ListTags: %w", err)
+			return nil, fmt.Errorf("ListTags (region=%s): %w", region, err)
 		}
-		matched = ok
-	}
 
-	sort.Slice(matched, func(i, j int) bool { return matched[i].name < matched[j].name })
+		sort.Slice(ok, func(i, j int) bool { return ok[i].name < ok[j].name })
 
-	book := addressBook{}
-	out := make([]imported.ImportedResource, 0, len(matched))
-	for _, f := range matched {
-		out = append(out, makeImportedResource(
-			book,
-			"aws_lambda_function",
-			f.name,
-			f.name,
-			region,
-			accountID,
-			map[string]string{"arn": f.arn},
-		))
+		for _, f := range ok {
+			// Legacy Project=<project> back-compat filter.
+			if args.Project != "" && f.tags["Project"] != args.Project {
+				continue
+			}
+			if !MatchesAll(f.tags, args.TagSelectors) {
+				continue
+			}
+			out = append(out, makeImportedResource(
+				book,
+				"aws_lambda_function",
+				f.name,
+				f.name,
+				region,
+				args.AccountID,
+				map[string]string{"arn": f.arn},
+				f.tags,
+			))
+		}
 	}
 	return out, nil
 }
@@ -145,7 +172,7 @@ func (d *lambdaDiscoverer) DiscoverByID(ctx context.Context, id, region, account
 	if err != nil {
 		return imported.ImportedResource{}, err
 	}
-	client := d.new()
+	client := d.new(region)
 	out, err := client.GetFunction(ctx, &lambda.GetFunctionInput{FunctionName: aws.String(name)})
 	if err != nil {
 		var notFound *lambdatypes.ResourceNotFoundException
@@ -166,6 +193,7 @@ func (d *lambdaDiscoverer) DiscoverByID(ctx context.Context, id, region, account
 		region,
 		accountID,
 		map[string]string{"arn": arn},
+		nil,
 	), nil
 }
 

--- a/cmd/insideout-import/awsdiscover/lambda_test.go
+++ b/cmd/insideout-import/awsdiscover/lambda_test.go
@@ -72,7 +72,7 @@ func fn(name, arn string) lambdatypes.FunctionConfiguration {
 
 func TestLambdaDiscover_FiltersByProjectTag(t *testing.T) {
 	t.Parallel()
-	d := &lambdaDiscoverer{new: func() lambdaClient {
+	d := &lambdaDiscoverer{new: func(_ string) lambdaClient {
 		return &fakeLambdaClient{
 			pages: []lambda.ListFunctionsOutput{
 				{Functions: []lambdatypes.FunctionConfiguration{
@@ -88,7 +88,7 @@ func TestLambdaDiscover_FiltersByProjectTag(t *testing.T) {
 			},
 		}
 	}}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,14 +104,14 @@ func TestLambdaDiscover_FiltersByProjectTag(t *testing.T) {
 
 func TestLambdaDiscover_EmptyProjectReturnsAll(t *testing.T) {
 	t.Parallel()
-	d := &lambdaDiscoverer{new: func() lambdaClient {
+	d := &lambdaDiscoverer{new: func(_ string) lambdaClient {
 		return &fakeLambdaClient{
 			pages: []lambda.ListFunctionsOutput{
 				{Functions: []lambdatypes.FunctionConfiguration{fn("a", "arn-a"), fn("b", "arn-b")}},
 			},
 		}
 	}}
-	got, err := d.Discover(context.Background(), "", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,8 +134,8 @@ func TestLambdaDiscover_FailClosedOnTagsError(t *testing.T) {
 		},
 		tagsErr: map[string]error{"arn-a": errors.New("Throttling")},
 	}
-	d := &lambdaDiscoverer{new: func() lambdaClient { return fake }}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	d := &lambdaDiscoverer{new: func(_ string) lambdaClient { return fake }}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestLambdaDiscover_FailClosedOnTagsError(t *testing.T) {
 // in place if the conditional is altered.
 func TestLambdaDiscover_SkipsFunctionWithNoProjectTag(t *testing.T) {
 	t.Parallel()
-	d := &lambdaDiscoverer{new: func() lambdaClient {
+	d := &lambdaDiscoverer{new: func(_ string) lambdaClient {
 		return &fakeLambdaClient{
 			pages: []lambda.ListFunctionsOutput{
 				{Functions: []lambdatypes.FunctionConfiguration{
@@ -181,7 +181,7 @@ func TestLambdaDiscover_SkipsFunctionWithNoProjectTag(t *testing.T) {
 			},
 		}
 	}}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,8 +208,8 @@ func TestLambdaDiscover_AbortsOnListFunctionsError(t *testing.T) {
 	// surfaces it directly via NextPage. Use an empty fake struct and
 	// inject error via a wrapping client.
 	wrap := &lambdaErrClient{err: errors.New("AccessDenied")}
-	d := &lambdaDiscoverer{new: func() lambdaClient { return wrap }}
-	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	d := &lambdaDiscoverer{new: func(_ string) lambdaClient { return wrap }}
+	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err == nil {
 		t.Fatal("expected ListFunctions error to abort")
 	}
@@ -311,12 +311,12 @@ func TestLambdaDiscover_BoundedConcurrency(t *testing.T) {
 	bc := &blockingLambdaClient{pages: pages, release: release, tags: tags}
 
 	d := &lambdaDiscoverer{
-		new:            func() lambdaClient { return bc },
+		new:            func(_ string) lambdaClient { return bc },
 		maxConcurrency: limit,
 	}
 	done := make(chan error, 1)
 	go func() {
-		_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+		_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 		done <- err
 	}()
 
@@ -380,13 +380,13 @@ func TestLambdaDiscover_ContextCancellationUnblocksSiblings(t *testing.T) {
 	bc := &blockingLambdaClient{pages: pages, release: release, tags: tags, starts: starts}
 
 	d := &lambdaDiscoverer{
-		new:            func() lambdaClient { return bc },
+		new:            func(_ string) lambdaClient { return bc },
 		maxConcurrency: total, // allow all to dispatch at once
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		_, err := d.Discover(ctx, "io-foo", "us-east-1", "123")
+		_, err := d.Discover(ctx, DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 		done <- err
 	}()
 
@@ -418,7 +418,7 @@ func TestLambdaDiscover_ContextCancellationUnblocksSiblings(t *testing.T) {
 func TestLambdaDiscoverByID_AcceptsARN(t *testing.T) {
 	t.Parallel()
 	arn := "arn:aws:lambda:us-east-1:123:function:io-foo-handler"
-	d := &lambdaDiscoverer{new: func() lambdaClient {
+	d := &lambdaDiscoverer{new: func(_ string) lambdaClient {
 		return &fakeLambdaClient{getByName: map[string]*lambda.GetFunctionOutput{
 			"io-foo-handler": {Configuration: &lambdatypes.FunctionConfiguration{
 				FunctionName: aws.String("io-foo-handler"),
@@ -443,7 +443,7 @@ func TestLambdaDiscoverByID_AcceptsARN(t *testing.T) {
 
 func TestLambdaDiscoverByID_StripsVersionFromARN(t *testing.T) {
 	t.Parallel()
-	d := &lambdaDiscoverer{new: func() lambdaClient {
+	d := &lambdaDiscoverer{new: func(_ string) lambdaClient {
 		return &fakeLambdaClient{getByName: map[string]*lambda.GetFunctionOutput{
 			"io-foo-handler": {Configuration: &lambdatypes.FunctionConfiguration{
 				FunctionName: aws.String("io-foo-handler"),
@@ -462,7 +462,7 @@ func TestLambdaDiscoverByID_StripsVersionFromARN(t *testing.T) {
 
 func TestLambdaDiscoverByID_NotFound(t *testing.T) {
 	t.Parallel()
-	d := &lambdaDiscoverer{new: func() lambdaClient { return &fakeLambdaClient{} }}
+	d := &lambdaDiscoverer{new: func(_ string) lambdaClient { return &fakeLambdaClient{} }}
 	_, err := d.DiscoverByID(context.Background(), "missing", "us-east-1", "123")
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("err=%v, want ErrNotFound", err)
@@ -471,7 +471,7 @@ func TestLambdaDiscoverByID_NotFound(t *testing.T) {
 
 func TestLambdaDiscoverByID_UnsupportedID(t *testing.T) {
 	t.Parallel()
-	d := &lambdaDiscoverer{new: func() lambdaClient { return &fakeLambdaClient{} }}
+	d := &lambdaDiscoverer{new: func(_ string) lambdaClient { return &fakeLambdaClient{} }}
 	cases := []string{
 		"",
 		"arn:aws:s3:::a-bucket",

--- a/cmd/insideout-import/awsdiscover/s3.go
+++ b/cmd/insideout-import/awsdiscover/s3.go
@@ -19,14 +19,21 @@ import (
 type s3Client interface {
 	ListBuckets(ctx context.Context, in *s3.ListBucketsInput, opts ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
 	HeadBucket(ctx context.Context, in *s3.HeadBucketInput, opts ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
+	GetBucketTagging(ctx context.Context, in *s3.GetBucketTaggingInput, opts ...func(*s3.Options)) (*s3.GetBucketTaggingOutput, error)
 }
 
 type s3Discoverer struct {
-	new func() s3Client
+	new func(region string) s3Client
 }
 
 func newS3Discoverer(cfg aws.Config) Discoverer {
-	return &s3Discoverer{new: func() s3Client { return s3.NewFromConfig(cfg) }}
+	return &s3Discoverer{new: func(region string) s3Client {
+		return s3.NewFromConfig(cfg, func(o *s3.Options) {
+			if region != "" {
+				o.Region = region
+			}
+		})
+	}}
 }
 
 func (d *s3Discoverer) ResourceType() string { return "aws_s3_bucket" }
@@ -35,9 +42,25 @@ func (d *s3Discoverer) ResourceType() string { return "aws_s3_bucket" }
 // S3's ListBuckets is account-global (returns every bucket regardless
 // of region) and unpaginated; the prefix filter is client-side.
 //
+// S3 buckets have a real home region, but ListBuckets does not return
+// it inline. PR 2 stamps Identity.Region with args.Regions[0] (the
+// operator's first --regions value, or the configured cfg.Region for
+// back-compat). Per-bucket GetBucketLocation is a follow-up to get the
+// accurate stamp; the operator-supplied region carries forward as
+// today.
+//
+// Per-bucket GetBucketTagging fetches the tag map for tag-selector
+// post-filtering and tag persistence onto Identity.Tags. S3 returns
+// NoSuchTagSet for buckets without any tags — we normalize that into
+// an empty map so the nil-vs-empty distinction holds.
+//
 // Import ID for aws_s3_bucket is the bucket name.
-func (d *s3Discoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
-	client := d.new()
+func (d *s3Discoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	stampRegion := ""
+	if len(args.Regions) > 0 {
+		stampRegion = args.Regions[0]
+	}
+	client := d.new(stampRegion)
 	out, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
 	if err != nil {
 		return nil, fmt.Errorf("ListBuckets: %w", err)
@@ -46,7 +69,7 @@ func (d *s3Discoverer) Discover(ctx context.Context, project, region, accountID 
 	var names []string
 	for _, b := range out.Buckets {
 		name := aws.ToString(b.Name)
-		if project != "" && !strings.HasPrefix(name, project) {
+		if args.Project != "" && !strings.HasPrefix(name, args.Project) {
 			continue
 		}
 		names = append(names, name)
@@ -56,18 +79,50 @@ func (d *s3Discoverer) Discover(ctx context.Context, project, region, accountID 
 	book := addressBook{}
 	imps := make([]imported.ImportedResource, 0, len(names))
 	for _, name := range names {
+		tags, err := fetchS3BucketTags(ctx, client, name)
+		if err != nil {
+			return nil, fmt.Errorf("GetBucketTagging (bucket=%s): %w", name, err)
+		}
+		if !MatchesAll(tags, args.TagSelectors) {
+			continue
+		}
 		arn := fmt.Sprintf("arn:aws:s3:::%s", name)
 		imps = append(imps, makeImportedResource(
 			book,
 			"aws_s3_bucket",
 			name,
 			name,
-			region,
-			accountID,
+			stampRegion,
+			args.AccountID,
 			map[string]string{"arn": arn},
+			tags,
 		))
 	}
 	return imps, nil
+}
+
+// fetchS3BucketTags returns the bucket's tag map. S3's GetBucketTagging
+// returns NoSuchTagSet (typed *s3types.NoSuchBucket is rare here; the
+// real error code is "NoSuchTagSet" surfaced as a generic API error
+// with that code) for buckets that have never had tags applied; we
+// normalize that into an empty map so the nil-vs-empty distinction
+// (nil ⇒ "didn't fetch", empty ⇒ "no tags") holds.
+func fetchS3BucketTags(ctx context.Context, client s3Client, bucket string) (map[string]string, error) {
+	out, err := client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		// Match by error-code string — S3 surfaces NoSuchTagSet as a
+		// generic *smithy.GenericAPIError (no typed shape); using
+		// strings.Contains keeps us decoupled from the smithy package.
+		if strings.Contains(err.Error(), "NoSuchTagSet") {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	tags := make(map[string]string, len(out.TagSet))
+	for _, t := range out.TagSet {
+		tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+	}
+	return tags, nil
 }
 
 // DiscoverByID resolves an S3 bucket by ARN (arn:aws:s3:::<name>) or
@@ -79,7 +134,7 @@ func (d *s3Discoverer) DiscoverByID(ctx context.Context, id, region, accountID s
 	if err != nil {
 		return imported.ImportedResource{}, err
 	}
-	client := d.new()
+	client := d.new(region)
 	if _, err := client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(name)}); err != nil {
 		var notFound *s3types.NotFound
 		var noBucket *s3types.NoSuchBucket
@@ -97,6 +152,7 @@ func (d *s3Discoverer) DiscoverByID(ctx context.Context, id, region, accountID s
 		region,
 		accountID,
 		map[string]string{"arn": arn},
+		nil,
 	), nil
 }
 

--- a/cmd/insideout-import/awsdiscover/s3_test.go
+++ b/cmd/insideout-import/awsdiscover/s3_test.go
@@ -18,6 +18,14 @@ type fakeS3Client struct {
 	headErr     error
 	headCalls   []string
 	notFoundTyp string // "NotFound" or "NoSuchBucket" to control which typed error is returned
+
+	// GetBucketTagging wiring (#291). tagsByName maps bucket name → tag
+	// pairs (S3 stores tags as TagSet entries). tagsErr is returned for
+	// every call when set; if it stringifies "NoSuchTagSet" the
+	// discoverer normalizes it into an empty map.
+	tagsByName map[string][]s3types.Tag
+	tagsErr    error
+	tagsCalls  []string
 }
 
 func (f *fakeS3Client) ListBuckets(_ context.Context, _ *s3.ListBucketsInput, _ ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
@@ -47,16 +55,28 @@ func (f *fakeS3Client) HeadBucket(_ context.Context, in *s3.HeadBucketInput, _ .
 	}
 }
 
+func (f *fakeS3Client) GetBucketTagging(_ context.Context, in *s3.GetBucketTaggingInput, _ ...func(*s3.Options)) (*s3.GetBucketTaggingOutput, error) {
+	name := aws.ToString(in.Bucket)
+	f.tagsCalls = append(f.tagsCalls, name)
+	if f.tagsErr != nil {
+		return nil, f.tagsErr
+	}
+	if t, ok := f.tagsByName[name]; ok {
+		return &s3.GetBucketTaggingOutput{TagSet: t}, nil
+	}
+	return &s3.GetBucketTaggingOutput{}, nil
+}
+
 func TestS3Discover_FiltersByPrefix(t *testing.T) {
 	t.Parallel()
-	d := &s3Discoverer{new: func() s3Client {
+	d := &s3Discoverer{new: func(_ string) s3Client {
 		return &fakeS3Client{listOut: &s3.ListBucketsOutput{Buckets: []s3types.Bucket{
 			{Name: aws.String("io-foo-uploads")},
 			{Name: aws.String("io-foo-archive")},
 			{Name: aws.String("legacy-data")},
 		}}}
 	}}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,10 +93,10 @@ func TestS3Discover_FiltersByPrefix(t *testing.T) {
 
 func TestS3Discover_PropagatesError(t *testing.T) {
 	t.Parallel()
-	d := &s3Discoverer{new: func() s3Client {
+	d := &s3Discoverer{new: func(_ string) s3Client {
 		return &fakeS3Client{listErr: errors.New("AccessDenied")}
 	}}
-	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -84,7 +104,7 @@ func TestS3Discover_PropagatesError(t *testing.T) {
 
 func TestS3DiscoverByID_AcceptsARN(t *testing.T) {
 	t.Parallel()
-	d := &s3Discoverer{new: func() s3Client {
+	d := &s3Discoverer{new: func(_ string) s3Client {
 		return &fakeS3Client{headByName: map[string]bool{"io-foo-uploads": true}}
 	}}
 	got, err := d.DiscoverByID(context.Background(),
@@ -105,7 +125,7 @@ func TestS3DiscoverByID_AcceptsARN(t *testing.T) {
 
 func TestS3DiscoverByID_AcceptsBareName(t *testing.T) {
 	t.Parallel()
-	d := &s3Discoverer{new: func() s3Client {
+	d := &s3Discoverer{new: func(_ string) s3Client {
 		return &fakeS3Client{headByName: map[string]bool{"io-foo-uploads": true}}
 	}}
 	got, err := d.DiscoverByID(context.Background(), "io-foo-uploads", "us-east-1", "123")
@@ -123,7 +143,7 @@ func TestS3DiscoverByID_NotFoundTyped(t *testing.T) {
 		typ := typ
 		t.Run(typ, func(t *testing.T) {
 			t.Parallel()
-			d := &s3Discoverer{new: func() s3Client {
+			d := &s3Discoverer{new: func(_ string) s3Client {
 				return &fakeS3Client{notFoundTyp: typ}
 			}}
 			_, err := d.DiscoverByID(context.Background(), "missing-bucket", "us-east-1", "123")
@@ -136,7 +156,7 @@ func TestS3DiscoverByID_NotFoundTyped(t *testing.T) {
 
 func TestS3DiscoverByID_UnsupportedID(t *testing.T) {
 	t.Parallel()
-	d := &s3Discoverer{new: func() s3Client { return &fakeS3Client{} }}
+	d := &s3Discoverer{new: func(_ string) s3Client { return &fakeS3Client{} }}
 	cases := []string{
 		"",
 		"arn:aws:lambda:us-east-1:123:function:foo",

--- a/cmd/insideout-import/awsdiscover/secretsmanager.go
+++ b/cmd/insideout-import/awsdiscover/secretsmanager.go
@@ -22,73 +22,97 @@ type smClient interface {
 }
 
 type secretsManagerDiscoverer struct {
-	new func() smClient
+	new func(region string) smClient
 }
 
 func newSecretsManagerDiscoverer(cfg aws.Config) Discoverer {
-	return &secretsManagerDiscoverer{new: func() smClient { return secretsmanager.NewFromConfig(cfg) }}
+	return &secretsManagerDiscoverer{new: func(region string) smClient {
+		return secretsmanager.NewFromConfig(cfg, func(o *secretsmanager.Options) {
+			if region != "" {
+				o.Region = region
+			}
+		})
+	}}
 }
 
 func (d *secretsManagerDiscoverer) ResourceType() string { return "aws_secretsmanager_secret" }
 
 // Discover finds secrets tagged Project=<project>. Secrets Manager is the
 // only one of the Phase 1 services that supports server-side tag filtering,
-// so we use it instead of paginate-then-fanout.
+// so we keep that filter (back-compat) and apply operator-supplied tag
+// selectors as an additional client-side AND-conjunction over the inline
+// Tags returned by ListSecrets.
+//
+// Multi-region (#291): outer loop walks args.Regions, building a per-
+// region SDK client.
 //
 // Import ID for aws_secretsmanager_secret is the secret ARN.
-func (d *secretsManagerDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
-	client := d.new()
-	input := &secretsmanager.ListSecretsInput{}
-	if project != "" {
-		input.Filters = []smtypes.Filter{
-			{
-				Key:    smtypes.FilterNameStringTypeTagKey,
-				Values: []string{"Project"},
-			},
-			{
-				Key:    smtypes.FilterNameStringTypeTagValue,
-				Values: []string{project},
-			},
-		}
-	}
-
-	type secret struct {
-		name string
-		arn  string
-	}
-	var secrets []secret
-
-	for {
-		out, err := client.ListSecrets(ctx, input)
-		if err != nil {
-			return nil, fmt.Errorf("ListSecrets: %w", err)
-		}
-		for _, s := range out.SecretList {
-			secrets = append(secrets, secret{
-				name: aws.ToString(s.Name),
-				arn:  aws.ToString(s.ARN),
-			})
-		}
-		if out.NextToken == nil || *out.NextToken == "" {
-			break
-		}
-		input.NextToken = out.NextToken
-	}
-
-	sort.Slice(secrets, func(i, j int) bool { return secrets[i].arn < secrets[j].arn })
-
+func (d *secretsManagerDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
 	book := addressBook{}
-	imps := make([]imported.ImportedResource, 0, len(secrets))
-	for _, s := range secrets {
-		imps = append(imps, makeImportedResource(
-			book,
-			"aws_secretsmanager_secret",
-			s.name,
-			s.arn,
-			region,
-			accountID,
-			map[string]string{"arn": s.arn},
-		))
+	var imps []imported.ImportedResource
+
+	for _, region := range args.Regions {
+		client := d.new(region)
+		input := &secretsmanager.ListSecretsInput{}
+		if args.Project != "" {
+			input.Filters = []smtypes.Filter{
+				{
+					Key:    smtypes.FilterNameStringTypeTagKey,
+					Values: []string{"Project"},
+				},
+				{
+					Key:    smtypes.FilterNameStringTypeTagValue,
+					Values: []string{args.Project},
+				},
+			}
+		}
+
+		type secret struct {
+			name string
+			arn  string
+			tags map[string]string
+		}
+		var secrets []secret
+
+		for {
+			out, err := client.ListSecrets(ctx, input)
+			if err != nil {
+				return nil, fmt.Errorf("ListSecrets (region=%s): %w", region, err)
+			}
+			for _, s := range out.SecretList {
+				tags := make(map[string]string, len(s.Tags))
+				for _, t := range s.Tags {
+					tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+				}
+				secrets = append(secrets, secret{
+					name: aws.ToString(s.Name),
+					arn:  aws.ToString(s.ARN),
+					tags: tags,
+				})
+			}
+			if out.NextToken == nil || *out.NextToken == "" {
+				break
+			}
+			input.NextToken = out.NextToken
+		}
+
+		sort.Slice(secrets, func(i, j int) bool { return secrets[i].arn < secrets[j].arn })
+
+		for _, s := range secrets {
+			if !MatchesAll(s.tags, args.TagSelectors) {
+				continue
+			}
+			imps = append(imps, makeImportedResource(
+				book,
+				"aws_secretsmanager_secret",
+				s.name,
+				s.arn,
+				region,
+				args.AccountID,
+				map[string]string{"arn": s.arn},
+				s.tags,
+			))
+		}
 	}
 	return imps, nil
 }
@@ -114,7 +138,7 @@ func (d *secretsManagerDiscoverer) DiscoverByID(ctx context.Context, id, region,
 		}
 	}
 
-	client := d.new()
+	client := d.new(region)
 	out, err := client.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{SecretId: aws.String(id)})
 	if err != nil {
 		var notFound *smtypes.ResourceNotFoundException
@@ -136,5 +160,6 @@ func (d *secretsManagerDiscoverer) DiscoverByID(ctx context.Context, id, region,
 		region,
 		accountID,
 		map[string]string{"arn": arn},
+		nil,
 	), nil
 }

--- a/cmd/insideout-import/awsdiscover/secretsmanager_test.go
+++ b/cmd/insideout-import/awsdiscover/secretsmanager_test.go
@@ -47,7 +47,7 @@ func (f *fakeSMClient) DescribeSecret(_ context.Context, in *secretsmanager.Desc
 
 func TestSecretsManagerDiscover_HappyPath(t *testing.T) {
 	t.Parallel()
-	d := &secretsManagerDiscoverer{new: func() smClient {
+	d := &secretsManagerDiscoverer{new: func(_ string) smClient {
 		return &fakeSMClient{
 			pages: []secretsmanager.ListSecretsOutput{
 				{
@@ -59,7 +59,7 @@ func TestSecretsManagerDiscover_HappyPath(t *testing.T) {
 			},
 		}
 	}}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,8 +79,8 @@ func TestSecretsManagerDiscover_HappyPath(t *testing.T) {
 func TestSecretsManagerDiscover_UsesServerSideTagFilter(t *testing.T) {
 	t.Parallel()
 	fake := &fakeSMClient{}
-	d := &secretsManagerDiscoverer{new: func() smClient { return fake }}
-	if _, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123"); err != nil {
+	d := &secretsManagerDiscoverer{new: func(_ string) smClient { return fake }}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.calls) == 0 {
@@ -116,8 +116,8 @@ func equalStrings(a, b []string) bool {
 func TestSecretsManagerDiscover_EmptyProjectNoFilters(t *testing.T) {
 	t.Parallel()
 	fake := &fakeSMClient{}
-	d := &secretsManagerDiscoverer{new: func() smClient { return fake }}
-	if _, err := d.Discover(context.Background(), "", "us-east-1", "123"); err != nil {
+	d := &secretsManagerDiscoverer{new: func(_ string) smClient { return fake }}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{Project: "", Regions: []string{"us-east-1"}, AccountID: "123"}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.calls) == 0 || len(fake.calls[0].Filters) != 0 {
@@ -127,7 +127,7 @@ func TestSecretsManagerDiscover_EmptyProjectNoFilters(t *testing.T) {
 
 func TestSecretsManagerDiscover_PaginatesUntilNoToken(t *testing.T) {
 	t.Parallel()
-	d := &secretsManagerDiscoverer{new: func() smClient {
+	d := &secretsManagerDiscoverer{new: func(_ string) smClient {
 		return &fakeSMClient{
 			pages: []secretsmanager.ListSecretsOutput{
 				{SecretList: []smtypes.SecretListEntry{{Name: aws.String("a"), ARN: aws.String("arn-a")}}, NextToken: aws.String("t1")},
@@ -135,7 +135,7 @@ func TestSecretsManagerDiscover_PaginatesUntilNoToken(t *testing.T) {
 			},
 		}
 	}}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,8 +146,8 @@ func TestSecretsManagerDiscover_PaginatesUntilNoToken(t *testing.T) {
 
 func TestSecretsManagerDiscover_PropagatesError(t *testing.T) {
 	t.Parallel()
-	d := &secretsManagerDiscoverer{new: func() smClient { return &fakeSMClient{err: errors.New("AccessDenied")} }}
-	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	d := &secretsManagerDiscoverer{new: func(_ string) smClient { return &fakeSMClient{err: errors.New("AccessDenied")} }}
+	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -156,7 +156,7 @@ func TestSecretsManagerDiscover_PropagatesError(t *testing.T) {
 func TestSecretsManagerDiscoverByID_AcceptsARN(t *testing.T) {
 	t.Parallel()
 	arn := "arn:aws:secretsmanager:us-east-1:123:secret:io-foo/db-AbCdEf"
-	d := &secretsManagerDiscoverer{new: func() smClient {
+	d := &secretsManagerDiscoverer{new: func(_ string) smClient {
 		return &fakeSMClient{describeByID: map[string]*secretsmanager.DescribeSecretOutput{
 			arn: {ARN: aws.String(arn), Name: aws.String("io-foo/db")},
 		}}
@@ -178,7 +178,7 @@ func TestSecretsManagerDiscoverByID_AcceptsARN(t *testing.T) {
 
 func TestSecretsManagerDiscoverByID_AcceptsBareName(t *testing.T) {
 	t.Parallel()
-	d := &secretsManagerDiscoverer{new: func() smClient {
+	d := &secretsManagerDiscoverer{new: func(_ string) smClient {
 		return &fakeSMClient{describeByID: map[string]*secretsmanager.DescribeSecretOutput{
 			"io-foo/db": {ARN: aws.String("arn:test"), Name: aws.String("io-foo/db")},
 		}}
@@ -194,7 +194,7 @@ func TestSecretsManagerDiscoverByID_AcceptsBareName(t *testing.T) {
 
 func TestSecretsManagerDiscoverByID_NotFound(t *testing.T) {
 	t.Parallel()
-	d := &secretsManagerDiscoverer{new: func() smClient { return &fakeSMClient{} }}
+	d := &secretsManagerDiscoverer{new: func(_ string) smClient { return &fakeSMClient{} }}
 	_, err := d.DiscoverByID(context.Background(), "missing", "us-east-1", "123")
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("err=%v, want ErrNotFound", err)
@@ -203,7 +203,7 @@ func TestSecretsManagerDiscoverByID_NotFound(t *testing.T) {
 
 func TestSecretsManagerDiscoverByID_UnsupportedID(t *testing.T) {
 	t.Parallel()
-	d := &secretsManagerDiscoverer{new: func() smClient { return &fakeSMClient{} }}
+	d := &secretsManagerDiscoverer{new: func(_ string) smClient { return &fakeSMClient{} }}
 	cases := []string{
 		"",
 		"arn:aws:s3:::a-bucket",

--- a/cmd/insideout-import/awsdiscover/sqs.go
+++ b/cmd/insideout-import/awsdiscover/sqs.go
@@ -22,14 +22,21 @@ import (
 type sqsClient interface {
 	ListQueues(ctx context.Context, in *sqs.ListQueuesInput, opts ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error)
 	GetQueueUrl(ctx context.Context, in *sqs.GetQueueUrlInput, opts ...func(*sqs.Options)) (*sqs.GetQueueUrlOutput, error)
+	ListQueueTags(ctx context.Context, in *sqs.ListQueueTagsInput, opts ...func(*sqs.Options)) (*sqs.ListQueueTagsOutput, error)
 }
 
 type sqsDiscoverer struct {
-	new func() sqsClient
+	new func(region string) sqsClient
 }
 
 func newSQSDiscoverer(cfg aws.Config) Discoverer {
-	return &sqsDiscoverer{new: func() sqsClient { return sqs.NewFromConfig(cfg) }}
+	return &sqsDiscoverer{new: func(region string) sqsClient {
+		return sqs.NewFromConfig(cfg, func(o *sqs.Options) {
+			if region != "" {
+				o.Region = region
+			}
+		})
+	}}
 }
 
 func (d *sqsDiscoverer) ResourceType() string { return "aws_sqs_queue" }
@@ -38,40 +45,68 @@ func (d *sqsDiscoverer) ResourceType() string { return "aws_sqs_queue" }
 // supports a server-side QueueNamePrefix filter, so we never have to
 // download every queue in the account just to filter client-side.
 //
+// Multi-region (#291): loops args.Regions, building a per-region SDK
+// client. Per-queue ListQueueTags fetches the tag map for tag-selector
+// post-filtering and tag persistence onto Identity.Tags.
+//
 // Import ID for aws_sqs_queue is the queue URL itself.
-func (d *sqsDiscoverer) Discover(ctx context.Context, project, region, accountID string) ([]imported.ImportedResource, error) {
-	client := d.new()
-	input := &sqs.ListQueuesInput{}
-	if project != "" {
-		p := project
-		input.QueueNamePrefix = &p
-	}
-
-	urls, err := paginateListQueues(ctx, client, input)
-	if err != nil {
-		return nil, fmt.Errorf("ListQueues: %w", err)
-	}
-
-	// Sort URLs so the emitted manifest is deterministic across runs.
-	sort.Strings(urls)
-
+func (d *sqsDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
 	book := addressBook{}
-	out := make([]imported.ImportedResource, 0, len(urls))
-	for _, url := range urls {
-		// Queue URL: https://sqs.<region>.amazonaws.com/<account>/<name>
-		// The name is the final segment.
-		name := path.Base(url)
-		out = append(out, makeImportedResource(
-			book,
-			"aws_sqs_queue",
-			name,
-			url,
-			region,
-			accountID,
-			map[string]string{"url": url},
-		))
+	var out []imported.ImportedResource
+	for _, region := range args.Regions {
+		client := d.new(region)
+		input := &sqs.ListQueuesInput{}
+		if args.Project != "" {
+			p := args.Project
+			input.QueueNamePrefix = &p
+		}
+
+		urls, err := paginateListQueues(ctx, client, input)
+		if err != nil {
+			return nil, fmt.Errorf("ListQueues (region=%s): %w", region, err)
+		}
+
+		// Sort URLs so the emitted manifest is deterministic across runs.
+		sort.Strings(urls)
+
+		for _, url := range urls {
+			// Queue URL: https://sqs.<region>.amazonaws.com/<account>/<name>
+			// The name is the final segment.
+			name := path.Base(url)
+			tags, err := fetchSQSTags(ctx, client, url)
+			if err != nil {
+				return nil, fmt.Errorf("ListQueueTags (region=%s, queue=%s): %w", region, name, err)
+			}
+			if !MatchesAll(tags, args.TagSelectors) {
+				continue
+			}
+			out = append(out, makeImportedResource(
+				book,
+				"aws_sqs_queue",
+				name,
+				url,
+				region,
+				args.AccountID,
+				map[string]string{"url": url},
+				tags,
+			))
+		}
 	}
 	return out, nil
+}
+
+// fetchSQSTags returns the queue's tag map, normalizing a nil-result
+// from the SDK into an empty (non-nil) map so the filter+persist
+// contract is preserved (nil ⇒ "didn't fetch", empty ⇒ "no tags").
+func fetchSQSTags(ctx context.Context, client sqsClient, queueURL string) (map[string]string, error) {
+	out, err := client.ListQueueTags(ctx, &sqs.ListQueueTagsInput{QueueUrl: aws.String(queueURL)})
+	if err != nil {
+		return nil, err
+	}
+	if out.Tags == nil {
+		return map[string]string{}, nil
+	}
+	return out.Tags, nil
 }
 
 // DiscoverByID resolves an SQS queue from a queue URL or ARN. The
@@ -84,7 +119,7 @@ func (d *sqsDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID 
 		return imported.ImportedResource{}, err
 	}
 
-	client := d.new()
+	client := d.new(region)
 	out, err := client.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{QueueName: aws.String(name)})
 	if err != nil {
 		var notFound *sqstypes.QueueDoesNotExist
@@ -95,6 +130,10 @@ func (d *sqsDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID 
 	}
 	url := aws.ToString(out.QueueUrl)
 
+	tags, err := fetchSQSTags(ctx, client, url)
+	if err != nil {
+		return imported.ImportedResource{}, fmt.Errorf("ListQueueTags (queue=%s): %w", name, err)
+	}
 	return makeImportedResource(
 		addressBook{},
 		"aws_sqs_queue",
@@ -103,6 +142,7 @@ func (d *sqsDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID 
 		region,
 		accountID,
 		map[string]string{"url": url},
+		tags,
 	), nil
 }
 

--- a/cmd/insideout-import/awsdiscover/sqs_test.go
+++ b/cmd/insideout-import/awsdiscover/sqs_test.go
@@ -18,6 +18,14 @@ type fakeSQSClient struct {
 	getURLByName map[string]string
 	getURLErr    error // when non-nil, GetQueueUrl returns this
 	getURLCalls  []sqs.GetQueueUrlInput
+
+	// ListQueueTags wiring (#291): tagsByURL maps queue URL → tag map.
+	// Empty/nil for queues without tags. tagsErr is returned for every
+	// ListQueueTags call when set.
+	tagsByURL  map[string]map[string]string
+	tagsErr    error
+	tagsCalls  []string // observed queue URLs
+	regionSeen []string // every region the new(...) closure observed
 }
 
 func (f *fakeSQSClient) ListQueues(_ context.Context, in *sqs.ListQueuesInput, _ ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
@@ -44,11 +52,22 @@ func (f *fakeSQSClient) GetQueueUrl(_ context.Context, in *sqs.GetQueueUrlInput,
 	return nil, &sqstypes.QueueDoesNotExist{}
 }
 
+func (f *fakeSQSClient) ListQueueTags(_ context.Context, in *sqs.ListQueueTagsInput, _ ...func(*sqs.Options)) (*sqs.ListQueueTagsOutput, error) {
+	f.tagsCalls = append(f.tagsCalls, *in.QueueUrl)
+	if f.tagsErr != nil {
+		return nil, f.tagsErr
+	}
+	if tags, ok := f.tagsByURL[*in.QueueUrl]; ok {
+		return &sqs.ListQueueTagsOutput{Tags: tags}, nil
+	}
+	return &sqs.ListQueueTagsOutput{}, nil
+}
+
 func ptr(s string) *string { return &s }
 
 func TestSQSDiscover_HappyPath(t *testing.T) {
 	t.Parallel()
-	d := &sqsDiscoverer{new: func() sqsClient {
+	d := &sqsDiscoverer{new: func(_ string) sqsClient {
 		return &fakeSQSClient{
 			pages: []sqs.ListQueuesOutput{
 				{
@@ -60,7 +79,7 @@ func TestSQSDiscover_HappyPath(t *testing.T) {
 			},
 		}
 	}}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +108,7 @@ func TestSQSDiscover_HappyPath(t *testing.T) {
 
 func TestSQSDiscover_PaginatesUntilNoToken(t *testing.T) {
 	t.Parallel()
-	d := &sqsDiscoverer{new: func() sqsClient {
+	d := &sqsDiscoverer{new: func(_ string) sqsClient {
 		return &fakeSQSClient{
 			pages: []sqs.ListQueuesOutput{
 				{QueueUrls: []string{"https://example/io-foo-a"}, NextToken: ptr("tok1")},
@@ -98,7 +117,7 @@ func TestSQSDiscover_PaginatesUntilNoToken(t *testing.T) {
 			},
 		}
 	}}
-	got, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,8 +129,8 @@ func TestSQSDiscover_PaginatesUntilNoToken(t *testing.T) {
 func TestSQSDiscover_PassesPrefixServerSide(t *testing.T) {
 	t.Parallel()
 	fake := &fakeSQSClient{}
-	d := &sqsDiscoverer{new: func() sqsClient { return fake }}
-	if _, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123"); err != nil {
+	d := &sqsDiscoverer{new: func(_ string) sqsClient { return fake }}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.calls) == 0 {
@@ -126,8 +145,8 @@ func TestSQSDiscover_PassesPrefixServerSide(t *testing.T) {
 func TestSQSDiscover_EmptyProjectPassesNoPrefix(t *testing.T) {
 	t.Parallel()
 	fake := &fakeSQSClient{}
-	d := &sqsDiscoverer{new: func() sqsClient { return fake }}
-	if _, err := d.Discover(context.Background(), "", "us-east-1", "123"); err != nil {
+	d := &sqsDiscoverer{new: func(_ string) sqsClient { return fake }}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{Project: "", Regions: []string{"us-east-1"}, AccountID: "123"}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.calls) == 0 {
@@ -140,10 +159,10 @@ func TestSQSDiscover_EmptyProjectPassesNoPrefix(t *testing.T) {
 
 func TestSQSDiscover_PropagatesError(t *testing.T) {
 	t.Parallel()
-	d := &sqsDiscoverer{new: func() sqsClient {
+	d := &sqsDiscoverer{new: func(_ string) sqsClient {
 		return &fakeSQSClient{err: errors.New("AccessDenied")}
 	}}
-	_, err := d.Discover(context.Background(), "io-foo", "us-east-1", "123")
+	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -154,7 +173,7 @@ func TestSQSDiscoverByID_AcceptsURL(t *testing.T) {
 	fake := &fakeSQSClient{getURLByName: map[string]string{
 		"io-foo-orders": "https://sqs.us-east-1.amazonaws.com/123/io-foo-orders",
 	}}
-	d := &sqsDiscoverer{new: func() sqsClient { return fake }}
+	d := &sqsDiscoverer{new: func(_ string) sqsClient { return fake }}
 	got, err := d.DiscoverByID(context.Background(),
 		"https://sqs.us-east-1.amazonaws.com/123/io-foo-orders", "us-east-1", "123")
 	if err != nil {
@@ -179,7 +198,7 @@ func TestSQSDiscoverByID_AcceptsARN(t *testing.T) {
 	fake := &fakeSQSClient{getURLByName: map[string]string{
 		"io-foo-orders": "https://sqs.us-east-1.amazonaws.com/123/io-foo-orders",
 	}}
-	d := &sqsDiscoverer{new: func() sqsClient { return fake }}
+	d := &sqsDiscoverer{new: func(_ string) sqsClient { return fake }}
 	got, err := d.DiscoverByID(context.Background(),
 		"arn:aws:sqs:us-east-1:123:io-foo-orders", "us-east-1", "123")
 	if err != nil {
@@ -193,16 +212,117 @@ func TestSQSDiscoverByID_AcceptsARN(t *testing.T) {
 func TestSQSDiscoverByID_NotFound(t *testing.T) {
 	t.Parallel()
 	fake := &fakeSQSClient{} // empty getURLByName triggers QueueDoesNotExist
-	d := &sqsDiscoverer{new: func() sqsClient { return fake }}
+	d := &sqsDiscoverer{new: func(_ string) sqsClient { return fake }}
 	_, err := d.DiscoverByID(context.Background(), "io-foo-missing", "us-east-1", "123")
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("err=%v, want ErrNotFound", err)
 	}
 }
 
+// TestSQSDiscover_MultiRegionTriggersOneSDKCallPerRegion (#291) is the
+// pattern-pin for every per-service Discover's `for _, region := range
+// args.Regions` loop. The aggregator-level test only proves the slice
+// is threaded; this test proves it is *iterated*. A regression that
+// drops the inner loop in any per-service file (e.g. ignores Regions[1]
+// and only scans Regions[0]) survives every other pin.
+//
+// Strategy: hand the closure a per-region fake so the test can assert
+// (a) both regions trigger a ListQueues call, and (b) the manifest
+// contains entries from both regions. The same shape generalizes to
+// every other regional service — this serves as the canonical example.
+func TestSQSDiscover_MultiRegionTriggersOneSDKCallPerRegion(t *testing.T) {
+	t.Parallel()
+	fakes := map[string]*fakeSQSClient{
+		"us-east-1": {
+			pages: []sqs.ListQueuesOutput{{QueueUrls: []string{"https://sqs.us-east-1.amazonaws.com/123/io-foo-east"}}},
+		},
+		"eu-west-1": {
+			pages: []sqs.ListQueuesOutput{{QueueUrls: []string{"https://sqs.eu-west-1.amazonaws.com/123/io-foo-west"}}},
+		},
+	}
+	var seenRegions []string
+	d := &sqsDiscoverer{new: func(region string) sqsClient {
+		seenRegions = append(seenRegions, region)
+		f, ok := fakes[region]
+		if !ok {
+			t.Fatalf("closure called with unexpected region %q", region)
+		}
+		return f
+	}}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// (a) closure invoked once per region.
+	if len(seenRegions) != 2 || seenRegions[0] != "us-east-1" || seenRegions[1] != "eu-west-1" {
+		t.Errorf("region closure invocations = %v, want [us-east-1 eu-west-1]", seenRegions)
+	}
+	// (b) each region's fake saw a ListQueues call.
+	if len(fakes["us-east-1"].calls) == 0 {
+		t.Error("us-east-1 fake never received ListQueues; per-region loop dropped the first region")
+	}
+	if len(fakes["eu-west-1"].calls) == 0 {
+		t.Error("eu-west-1 fake never received ListQueues; per-region loop dropped the second region")
+	}
+	// (c) manifest carries entries from both regions.
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (one per region)", len(got))
+	}
+	gotNames := map[string]bool{}
+	for _, ir := range got {
+		gotNames[ir.Identity.NameHint] = true
+	}
+	if !gotNames["io-foo-east"] || !gotNames["io-foo-west"] {
+		t.Errorf("manifest names = %v, want both io-foo-east and io-foo-west", gotNames)
+	}
+}
+
+// TestSQSDiscover_TagSelectorAppliedAsFilter (#291) is the pattern-pin
+// for the per-service Discover's `if !MatchesAll(...) { continue }`
+// in-loop filter. The aggregator-level test only proves selectors are
+// threaded; this test proves they are *applied*. A regression that
+// drops the MatchesAll call in any per-service file (or inverts the
+// condition) survives every other pin.
+func TestSQSDiscover_TagSelectorAppliedAsFilter(t *testing.T) {
+	t.Parallel()
+	urlProd := "https://sqs.us-east-1.amazonaws.com/123/io-foo-prod"
+	urlStaging := "https://sqs.us-east-1.amazonaws.com/123/io-foo-staging"
+	fake := &fakeSQSClient{
+		pages: []sqs.ListQueuesOutput{{QueueUrls: []string{urlProd, urlStaging}}},
+		tagsByURL: map[string]map[string]string{
+			urlProd:    {"env": "prod"},
+			urlStaging: {"env": "staging"},
+		},
+	}
+	d := &sqsDiscoverer{new: func(_ string) sqsClient { return fake }}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:      "io-foo",
+		Regions:      []string{"us-east-1"},
+		AccountID:    "123",
+		TagSelectors: []TagSelector{{Key: "env", Value: "prod"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (only env=prod queue should pass)", len(got))
+	}
+	if got[0].Identity.NameHint != "io-foo-prod" {
+		t.Errorf("NameHint=%q, want io-foo-prod", got[0].Identity.NameHint)
+	}
+	if got[0].Identity.Tags["env"] != "prod" {
+		t.Errorf("Tags[env]=%q, want prod (filter+persist contract)", got[0].Identity.Tags["env"])
+	}
+}
+
 func TestSQSDiscoverByID_UnsupportedID(t *testing.T) {
 	t.Parallel()
-	d := &sqsDiscoverer{new: func() sqsClient { return &fakeSQSClient{} }}
+	d := &sqsDiscoverer{new: func(_ string) sqsClient { return &fakeSQSClient{} }}
 	cases := []string{
 		"",
 		"arn:aws:s3:::some-bucket", // wrong service

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -39,16 +39,76 @@ const (
 // 15-minute discoverTimeout can absorb.
 const discoverRetryMaxAttempts = 8
 
-// discoveryAggregator is the small subset of awsdiscover.AWSDiscoverer the
-// orchestrator needs. Defining the interface in main lets tests inject a
-// fake aggregator without standing up real AWS clients.
+// discoveryAggregator is the small subset of awsdiscover.AWSDiscoverer
+// (and gcpdiscover.GCPDiscoverer) the orchestrator needs. Defining the
+// interface in main lets tests inject a fake aggregator without standing
+// up real AWS / GCP clients.
 //
 // DiscoverByID is part of the contract since Stage 2c3 (#271): the
 // dep-chase loop calls into the aggregator to resolve unresolved ARNs
 // inside generated.tf to fresh ImportedResource entries.
+//
+// DiscoverTypes uses positional args (rather than a struct) so neither
+// cloud's package-local DiscoverArgs type (#291) leaks into the CLI's
+// shared interface — adapters in productionDiscoverDeps convert. Tag
+// selectors flow through as the CLI-package tagSelectorPair so the
+// interface stays decoupled from awsdiscover/gcpdiscover.
 type discoveryAggregator interface {
-	DiscoverTypes(ctx context.Context, types []string, project, region, accountID string) ([]imported.ImportedResource, error)
+	DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string) ([]imported.ImportedResource, error)
 	DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error)
+}
+
+// awsAggAdapter wraps *awsdiscover.AWSDiscoverer to satisfy
+// discoveryAggregator's positional DiscoverTypes signature, converting
+// the CLI's tagSelectorPair into awsdiscover.TagSelector at the
+// boundary. Mirrors gcpAggAdapter; both adapters are intentionally
+// thin so the cloud-specific type doesn't bleed into discover.go's
+// orchestrator code.
+type awsAggAdapter struct {
+	d *awsdiscover.AWSDiscoverer
+}
+
+func (a awsAggAdapter) DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string) ([]imported.ImportedResource, error) {
+	sel := make([]awsdiscover.TagSelector, 0, len(tagSelectors))
+	for _, p := range tagSelectors {
+		sel = append(sel, awsdiscover.TagSelector{Key: p.Key, Value: p.Value})
+	}
+	return a.d.DiscoverTypes(ctx, types, awsdiscover.DiscoverArgs{
+		Project:      project,
+		Regions:      regions,
+		TagSelectors: sel,
+		AccountID:    accountID,
+	})
+}
+
+func (a awsAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error) {
+	return a.d.DiscoverByID(ctx, tfType, id, region, accountID)
+}
+
+// gcpAggAdapter wraps *gcpdiscover.GCPDiscoverer to satisfy
+// discoveryAggregator. Converts tagSelectorPair → gcpdiscover.TagSelector;
+// otherwise mirrors awsAggAdapter.
+type gcpAggAdapter struct {
+	d *gcpdiscover.GCPDiscoverer
+}
+
+func (a gcpAggAdapter) DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string) ([]imported.ImportedResource, error) {
+	sel := make([]gcpdiscover.TagSelector, 0, len(tagSelectors))
+	for _, p := range tagSelectors {
+		sel = append(sel, gcpdiscover.TagSelector{Key: p.Key, Value: p.Value})
+	}
+	// accountID is unused on GCP — the project ID lives on the
+	// *gcpdiscover.GCPDiscoverer struct (set at construction).
+	_ = accountID
+	return a.d.DiscoverTypes(ctx, types, gcpdiscover.DiscoverArgs{
+		Project:      project,
+		Regions:      regions,
+		TagSelectors: sel,
+	})
+}
+
+func (a gcpAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error) {
+	return a.d.DiscoverByID(ctx, tfType, id, region, accountID)
 }
 
 // discoverDeps gathers the AWS- and GCP-side and terraform-side seams that
@@ -111,14 +171,14 @@ func productionDiscoverDeps() discoverDeps {
 			return *out.Account, nil
 		},
 		newDiscoverer: func(cfg aws.Config, maxConcurrency int) discoveryAggregator {
-			return awsdiscover.NewAWSDiscovererWithConcurrency(cfg, maxConcurrency)
+			return awsAggAdapter{d: awsdiscover.NewAWSDiscovererWithConcurrency(cfg, maxConcurrency)}
 		},
 		newGCPDiscoverer: func(ctx context.Context, gcpProjectID string) (discoveryAggregator, func() error, error) {
 			s, err := gcpdiscover.NewRealAssetSearcher(ctx)
 			if err != nil {
 				return nil, func() error { return nil }, err
 			}
-			return gcpdiscover.NewGCPDiscoverer(s, gcpProjectID), s.Close, nil
+			return gcpAggAdapter{d: gcpdiscover.NewGCPDiscoverer(s, gcpProjectID)}, s.Close, nil
 		},
 		runGenconfig: genconfig.Run,
 		runDriftfix:  driftfix.Run,
@@ -167,7 +227,9 @@ Exit codes:
 
 	provider := fs.String("provider", "", "cloud provider: aws or gcp (required)")
 	project := fs.String("project", "", "project name prefix used to filter resources (required)")
-	region := fs.String("region", "", "AWS region (required for --provider aws); GCP location filter (optional for --provider gcp)")
+	region := fs.String("region", "", "DEPRECATED (#291): use --regions instead. Single AWS region or GCP location filter; emits a deprecation warning when set.")
+	regions := fs.String("regions", "", "comma-separated AWS regions (or GCP locations) to scan in one invocation (required for --provider aws unless --region is set; optional for --provider gcp). Multi-region scans use the same per-service tag-selector filter across every region. Note: GCP project-global asset types (Pub/Sub, VPC networks, secrets) are excluded by any non-empty --regions; this is a known asset-API limitation.")
+	tagSelectors := fs.String("tag-selectors", "", "comma-separated tag/label selectors of the form key=value, AND-conjuncted across the list. AWS: applied client-side over each per-service tag fetch. GCP: appended as `labels.<k>:<v>` clauses to the Cloud Asset query (server-side AND).")
 	outputDir := fs.String("output-dir", "", "directory to write imported.json into (required)")
 	resourceTypes := fs.String("resource-types", "", "comma-separated subset of types to discover; default: all supported types for the chosen provider")
 	noHCL := fs.Bool("no-hcl", false, "skip Stage 2b HCL generation (terraform plan -generate-config-out + cleanup); leaves imported.json with empty Attributes")
@@ -202,9 +264,38 @@ Exit codes:
 		fmt.Fprintln(os.Stderr, "discover: --project is required")
 		return discoverExitFatal
 	}
-	if cloud == "aws" && strings.TrimSpace(*region) == "" {
-		fmt.Fprintln(os.Stderr, "discover: --region is required for --provider aws")
+	// Resolve --regions vs deprecated --region (#291).
+	regionsRaw := strings.TrimSpace(*regions)
+	regionRaw := strings.TrimSpace(*region)
+	if regionsRaw != "" && regionRaw != "" {
+		fmt.Fprintln(os.Stderr, "discover: --regions and --region are mutually exclusive; --region is deprecated, prefer --regions")
 		return discoverExitFatal
+	}
+	resolvedRegions := splitCSV(*regions)
+	if len(resolvedRegions) == 0 && regionRaw != "" {
+		fmt.Fprintln(os.Stderr, "discover: WARN: --region is deprecated; use --regions instead")
+		resolvedRegions = []string{regionRaw}
+	}
+	if cloud == "aws" && len(resolvedRegions) == 0 {
+		fmt.Fprintln(os.Stderr, "discover: --regions is required for --provider aws (or --region for back-compat)")
+		return discoverExitFatal
+	}
+	// Tag selectors apply equally to AWS and GCP.
+	parsedSelectors, err := parseTagSelectors(*tagSelectors)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "discover: %v\n", err)
+		return discoverExitFatal
+	}
+	// primaryRegion is the single region threaded into downstream Stage 2b
+	// (genconfig), Stage 2c1 (driftfix), and Stage 2c3 (depchase) — those
+	// stages operate on a single Terraform workspace per run. With a
+	// multi-region --regions, this is the first listed region; the
+	// remaining regions still feed the bulk DiscoverTypes scan, but the
+	// generated.tf stack is rooted in the primary. Multi-region stack
+	// emission is a follow-up — see PR description.
+	var primaryRegion string
+	if len(resolvedRegions) > 0 {
+		primaryRegion = resolvedRegions[0]
 	}
 	if cloud == "gcp" && strings.TrimSpace(*gcpProjectID) == "" {
 		fmt.Fprintln(os.Stderr, "discover: --gcp-project-id is required for --provider gcp (per #157, distinct from --project)")
@@ -234,7 +325,7 @@ Exit codes:
 	)
 	switch cloud {
 	case "aws":
-		cfg, err := deps.loadConfig(ctx, *region, *awsEndpointURL)
+		cfg, err := deps.loadConfig(ctx, primaryRegion, *awsEndpointURL)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "discover: load AWS config: %v\n", err)
 			return discoverExitFatal
@@ -266,7 +357,7 @@ Exit codes:
 		accountID = *gcpProjectID
 	}
 
-	resources, err := d.DiscoverTypes(ctx, types, *project, *region, accountID)
+	resources, err := d.DiscoverTypes(ctx, types, *project, resolvedRegions, parsedSelectors, accountID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "discover: %v\n", err)
 		return discoverExitFatal
@@ -290,7 +381,7 @@ Exit codes:
 	gcOptsBase := genconfig.Options{
 		Workdir:        gcWorkdir,
 		Provider:       cloud,
-		Region:         *region,
+		Region:         primaryRegion,
 		GCPProjectID:   *gcpProjectID,
 		AWSEndpointURL: *awsEndpointURL,
 	}
@@ -367,7 +458,7 @@ Exit codes:
 	}
 	dcRes, err := deps.runDepChase(ctx, depchase.Options{
 		Workdir:       gcWorkdir,
-		Region:        *region,
+		Region:        primaryRegion,
 		AccountID:     accountID,
 		MaxIterations: *maxDepChaseIter,
 		Discoverer:    d,

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -80,16 +80,203 @@ func TestRunDiscover_MissingOutputDir(t *testing.T) {
 	}
 }
 
+// TestRunDiscover_RegionAndRegionsConflictIsFatal pins the #291
+// migration ergonomics: passing both --region (deprecated) and
+// --regions in the same invocation is an error rather than silently
+// ignoring one. The deprecation pathway prefers an explicit-failure
+// shape so operators don't get surprised by which value won.
+//
+// The stderr substring pin guarantees the operator-facing guidance
+// stays specific. A regression that swaps the message for a generic
+// "bad flags" error would survive a `rc != discoverExitFatal` check
+// but fail this assertion.
+func TestRunDiscover_RegionAndRegionsConflictIsFatal(t *testing.T) {
+	dir := t.TempDir()
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscover([]string{
+			"--provider", "aws",
+			"--project", "p",
+			"--region", "us-east-1",
+			"--regions", "us-east-1,eu-west-1",
+			"--output-dir", dir,
+		})
+	})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+	if !strings.Contains(stderr, "mutually exclusive") {
+		t.Errorf("stderr=%q, want substring %q", stderr, "mutually exclusive")
+	}
+}
+
+// TestRunDiscover_MissingRegionsForAWSIsFatal pins that AWS still
+// requires at least one region (--regions or the deprecated --region).
+// The "back-compat" hint in the message points operators that haven't
+// migrated to --regions yet at the legacy alias; pinning it keeps the
+// hint from rotting.
+func TestRunDiscover_MissingRegionsForAWSIsFatal(t *testing.T) {
+	dir := t.TempDir()
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscover([]string{"--provider", "aws", "--project", "p", "--output-dir", dir})
+	})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+	if !strings.Contains(stderr, "--regions is required") || !strings.Contains(stderr, "back-compat") {
+		t.Errorf("stderr=%q, want substrings %q and %q", stderr, "--regions is required", "back-compat")
+	}
+}
+
+// TestRunDiscoverWithDeps_MultiRegionThreadsAllRegionsToAggregator pins
+// that --regions r1,r2 surfaces as a 2-element slice on the aggregator
+// (not an aggregator-side fan-out — the per-service Discover loops
+// internally). Plus, primaryRegion (the first listed) is what
+// load-config receives so Stage 2b/2c1 still operate on a single TF
+// workspace.
+func TestRunDiscoverWithDeps_MultiRegionThreadsAllRegionsToAggregator(t *testing.T) {
+	t.Parallel()
+	agg := &fakeAggregator{}
+	deps := okDeps(agg)
+	loadCalls := 0
+	var lastLoadRegion string
+	deps.loadConfig = func(_ context.Context, region, _ string) (aws.Config, error) {
+		loadCalls++
+		lastLoadRegion = region
+		return aws.Config{}, nil
+	}
+	dir := t.TempDir()
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--regions", "us-east-1,eu-west-1",
+		"--output-dir", dir,
+		"--no-hcl",
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want ok", rc)
+	}
+	if loadCalls != 1 {
+		t.Errorf("loadConfig called %d times, want 1", loadCalls)
+	}
+	if lastLoadRegion != "us-east-1" {
+		t.Errorf("loadConfig got region=%q, want us-east-1 (primaryRegion = first --regions value)", lastLoadRegion)
+	}
+	if got, want := agg.gotRegions, []string{"us-east-1", "eu-west-1"}; !equalSlices(got, want) {
+		t.Errorf("Regions threaded = %v, want %v", got, want)
+	}
+}
+
+// TestRunDiscoverWithDeps_DeprecatedRegionStillThreadsAsRegions pins
+// the back-compat alias: --region us-east-1 (no --regions) populates
+// the aggregator's Regions slice with [us-east-1] and emits a stderr
+// deprecation warning. We assert the warning substring "deprecated"
+// (not the full message) so the migration signal stays loud while
+// leaving the exact phrasing free to evolve.
+func TestRunDiscoverWithDeps_DeprecatedRegionStillThreadsAsRegions(t *testing.T) {
+	agg := &fakeAggregator{}
+	deps := okDeps(agg)
+	dir := t.TempDir()
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--region", "us-east-1",
+			"--output-dir", dir,
+			"--no-hcl",
+		}, deps)
+	})
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want ok", rc)
+	}
+	if got, want := agg.gotRegions, []string{"us-east-1"}; !equalSlices(got, want) {
+		t.Errorf("Regions threaded = %v, want [us-east-1] (deprecated --region alias)", got)
+	}
+	if !strings.Contains(stderr, "deprecated") {
+		t.Errorf("stderr=%q, want substring %q (deprecation warning must be loud)", stderr, "deprecated")
+	}
+}
+
+// TestRunDiscoverWithDeps_TagSelectorsThreadedToAggregator pins that
+// --tag-selectors flow through the parser into the aggregator's
+// observed gotSelectors slice. The CLI parser produces tagSelectorPair
+// entries; the aggregator adapter converts them per-cloud.
+func TestRunDiscoverWithDeps_TagSelectorsThreadedToAggregator(t *testing.T) {
+	t.Parallel()
+	agg := &fakeAggregator{}
+	deps := okDeps(agg)
+	dir := t.TempDir()
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--regions", "us-east-1",
+		"--tag-selectors", "env=prod,team=growth",
+		"--output-dir", dir,
+		"--no-hcl",
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want ok", rc)
+	}
+	want := []tagSelectorPair{{Key: "env", Value: "prod"}, {Key: "team", Value: "growth"}}
+	if len(agg.gotSelectors) != len(want) {
+		t.Fatalf("selectors len=%d, want %d", len(agg.gotSelectors), len(want))
+	}
+	for i, w := range want {
+		if agg.gotSelectors[i] != w {
+			t.Errorf("selector[%d]=%+v, want %+v", i, agg.gotSelectors[i], w)
+		}
+	}
+}
+
+// TestRunDiscoverWithDeps_MalformedTagSelectorIsFatal pins that the
+// parser's error surface (missing '=', empty key, duplicate keys)
+// translates to exit-fatal at the orchestrator level — operators
+// don't get a partial scan with quietly-dropped selectors.
+func TestRunDiscoverWithDeps_MalformedTagSelectorIsFatal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--regions", "us-east-1",
+		"--tag-selectors", "missing-equals",
+		"--output-dir", dir,
+		"--no-hcl",
+	}, okDeps(&fakeAggregator{}))
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal (malformed selector)", rc)
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // fakeAggregator is a lightweight stand-in for awsdiscover.AWSDiscoverer that
 // captures the inputs DiscoverTypes was called with and returns canned output.
 type fakeAggregator struct {
 	out        []imported.ImportedResource
 	err        error
 	gotProject string
-	gotRegion  string
-	gotAccount string
-	gotTypes   []string
-	called     int
+	// gotRegions captures the full Regions slice (#291). gotRegion is
+	// the legacy single-region accessor, kept as the first element of
+	// Regions so existing test assertions continue to match for the
+	// pre-#291 single-region happy path.
+	gotRegions   []string
+	gotSelectors []tagSelectorPair
+	gotAccount   string
+	gotTypes     []string
+	called       int
 
 	// DiscoverByID wiring for Stage 2c3 dep-chase tests. byID is keyed
 	// on tfType|id; missing entries return ErrNotFound.
@@ -98,9 +285,18 @@ type fakeAggregator struct {
 	byIDCalls []string
 }
 
-func (f *fakeAggregator) DiscoverTypes(_ context.Context, types []string, project, region, accountID string) ([]imported.ImportedResource, error) {
+// gotRegion returns the first captured region for back-compat with
+// pre-#291 single-region test assertions.
+func (f *fakeAggregator) gotRegion() string {
+	if len(f.gotRegions) == 0 {
+		return ""
+	}
+	return f.gotRegions[0]
+}
+
+func (f *fakeAggregator) DiscoverTypes(_ context.Context, types []string, project string, regions []string, selectors []tagSelectorPair, accountID string) ([]imported.ImportedResource, error) {
 	f.called++
-	f.gotProject, f.gotRegion, f.gotAccount, f.gotTypes = project, region, accountID, types
+	f.gotProject, f.gotRegions, f.gotSelectors, f.gotAccount, f.gotTypes = project, regions, selectors, accountID, types
 	return f.out, f.err
 }
 
@@ -278,8 +474,8 @@ func TestRunDiscoverWithDeps_HappyPathWritesManifest(t *testing.T) {
 	if agg.called != 1 {
 		t.Errorf("DiscoverTypes called %d times, want 1", agg.called)
 	}
-	if agg.gotProject != "io-foo" || agg.gotRegion != "us-east-1" || agg.gotAccount != "1234567890" {
-		t.Errorf("dispatch args = (%q,%q,%q), want (io-foo,us-east-1,1234567890)", agg.gotProject, agg.gotRegion, agg.gotAccount)
+	if agg.gotProject != "io-foo" || agg.gotRegion() != "us-east-1" || agg.gotAccount != "1234567890" {
+		t.Errorf("dispatch args = (%q,%q,%q), want (io-foo,us-east-1,1234567890)", agg.gotProject, agg.gotRegion(), agg.gotAccount)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "imported.json")); err != nil {
 		t.Errorf("imported.json not written: %v", err)
@@ -1173,7 +1369,7 @@ func TestRunDiscoverWithDeps_GCPHappyPathWritesManifest(t *testing.T) {
 		t.Errorf("DiscoverTypes called %d times, want 1", agg.called)
 	}
 	if agg.gotProject != "io-foo" || agg.gotAccount != "real-proj" {
-		t.Errorf("dispatch args = (%q,%q,%q), want (io-foo, *, real-proj)", agg.gotProject, agg.gotRegion, agg.gotAccount)
+		t.Errorf("dispatch args = (%q,%q,%q), want (io-foo, *, real-proj)", agg.gotProject, agg.gotRegion(), agg.gotAccount)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, "imported.json"))
 	if err != nil {
@@ -1205,8 +1401,8 @@ func TestRunDiscoverWithDeps_GCPRegionThreadsToAggregator(t *testing.T) {
 	if rc != discoverExitOK {
 		t.Fatalf("rc=%d, want OK", rc)
 	}
-	if agg.gotRegion != "us-central1" {
-		t.Errorf("region threaded = %q, want us-central1", agg.gotRegion)
+	if agg.gotRegion() != "us-central1" {
+		t.Errorf("region threaded = %q, want us-central1", agg.gotRegion())
 	}
 }
 

--- a/cmd/insideout-import/gcpdiscover/args.go
+++ b/cmd/insideout-import/gcpdiscover/args.go
@@ -1,0 +1,30 @@
+package gcpdiscover
+
+// DiscoverArgs is the per-call input shape consumed by the aggregator's
+// DiscoverTypes. Mirrors awsdiscover.DiscoverArgs minus AccountID
+// (GCP uses the projectID stored on the *GCPDiscoverer; the GCP path
+// has no equivalent of an STS GetCallerIdentity round-trip per run).
+//
+// Regions populates the Cloud Asset query's location filter. Zero
+// regions ⇒ no location clause (asset-API "all locations"). One ⇒
+// "location:r1". Two or more ⇒ "(location:r1 OR location:r2 OR ...)".
+//
+// TagSelectors append `labels.<k>:<v>` clauses to the asset query. Per
+// the asset query language the `:` operator is substring-match, not
+// strict equality — same caveat as the existing labels.project:<v>
+// filter the aggregator already emits.
+type DiscoverArgs struct {
+	Project      string
+	Regions      []string
+	TagSelectors []TagSelector
+}
+
+// TagSelector is a single operator-supplied label-equality clause. See
+// awsdiscover.TagSelector for the conjunction semantics; the GCP path
+// applies selectors at query-time (server-side via Cloud Asset) rather
+// than as a post-filter, so the AND of multiple clauses is the asset
+// API's responsibility.
+type TagSelector struct {
+	Key   string
+	Value string
+}

--- a/cmd/insideout-import/gcpdiscover/compute_network.go
+++ b/cmd/insideout-import/gcpdiscover/compute_network.go
@@ -38,7 +38,7 @@ func (computeNetworkDiscoverer) FromAsset(book addressBook, a gcpAssetResult, pr
 	return makeImportedResource(book, computeNetworkTFType, name, importID, projectID, "", map[string]string{
 		"asset_name": a.Name,
 		"self_link":  fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/%s", projectID, name),
-	})
+	}, a.Labels)
 }
 
 func (computeNetworkDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, id, projectID string) (imported.ImportedResource, error) {
@@ -50,7 +50,7 @@ func (computeNetworkDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearch
 	return makeImportedResource(addressBook{}, computeNetworkTFType, name, importID, projectID, "", map[string]string{
 		"asset_name": fmt.Sprintf("//%s/projects/%s/global/networks/%s", computeAssetHost, projectID, name),
 		"self_link":  fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/%s", projectID, name),
-	}), nil
+	}, nil), nil
 }
 
 // computeNetworkNameFromID extracts the network name from one of three

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
@@ -72,8 +73,11 @@ type Discoverer interface {
 	// FromAsset translates a single Cloud Asset SearchAllResources result
 	// (already filtered to this discoverer's AssetType) into an
 	// ImportedResource. Implementations populate Identity (Cloud, Type,
-	// Address, ImportID, NameHint, ProjectID, Location, NativeIDs) and
-	// set Tier=TierImportedFlat, Source=SourceImporter on each entry.
+	// Address, ImportID, NameHint, ProjectID, Location, NativeIDs, Tags)
+	// and set Tier=TierImportedFlat, Source=SourceImporter on each entry.
+	// asset.Labels (#291 tag-persist) is the asset's labels map — pass
+	// it through to makeImportedResource so the manifest carries the
+	// tag/label values for downstream selectors and summary consumers.
 	FromAsset(book addressBook, asset gcpAssetResult, projectID string) imported.ImportedResource
 	// DiscoverByID looks up a single resource by its Cloud Asset full
 	// resource name (// host / path / segments), used by the dep-chase
@@ -134,16 +138,16 @@ func (g *GCPDiscoverer) SupportedTypes() []string {
 // Terraform type, then fans out per-asset translation across the registered
 // discoverers. Unknown type names are reported as a single error containing
 // all invalid names so the operator sees the full set of misspellings in
-// one shot. The accountID parameter is unused on GCP — the project ID lives
-// on the GCPDiscoverer struct (set at construction); the parameter exists
-// only to satisfy the orchestrator's discoveryAggregator interface that the
-// AWS path also implements.
+// one shot.
 //
-// region is treated as an optional asset-location filter. Cloud Asset's
-// SearchAllResources accepts a `location:<region>` qualifier; an empty
-// region means search all locations (the default for project-global
-// resource types like Pub/Sub topics and VPC networks).
-func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, project, region, accountID string) ([]imported.ImportedResource, error) {
+// args.Regions populates the Cloud Asset query's `location:` filter. Zero
+// regions ⇒ no location clause (asset-API "all locations"). One ⇒
+// `location:r1`. Two or more ⇒ `(location:r1 OR location:r2 OR ...)`.
+// args.TagSelectors append `labels.<k>:<v>` clauses to the asset query
+// (server-side AND-conjunction). The legacy implicit
+// `labels.project:<project>` clause is preserved when args.Project is
+// non-empty.
+func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args DiscoverArgs) ([]imported.ImportedResource, error) {
 	if len(types) == 0 {
 		types = g.SupportedTypes()
 	}
@@ -165,7 +169,7 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, proje
 	}
 
 	scope := fmt.Sprintf("projects/%s", g.projectID)
-	query := buildSearchQuery(project, region)
+	query := buildSearchQuery(args.Project, args.Regions, args.TagSelectors)
 
 	results, err := g.searcher.SearchAll(ctx, scope, assetTypes, query)
 	if err != nil {
@@ -216,30 +220,57 @@ func (g *GCPDiscoverer) DiscoverByID(ctx context.Context, tfType, id, region, ac
 	return d.DiscoverByID(ctx, g.searcher, id, projectID)
 }
 
-// buildSearchQuery composes the SearchAllResources `query` string from the
-// stack project name (label-filter) and the optional region. Returns "" when
-// neither is set so the search is unfiltered.
+// buildSearchQuery composes the SearchAllResources `query` string from
+// the stack project name (label-filter), zero-or-more locations, and
+// zero-or-more operator-supplied label selectors. Returns "" when none
+// are set so the search is unfiltered.
 //
-// Cloud Asset query syntax: `labels.<key>:<value>` and `location:<region>`,
-// AND-combined with whitespace. The `:` operator is a substring match on
-// values; for our project label values that's identical to equality (the
-// label isn't a substring of any other valid project name), but if a future
-// stack project shadows another's label-prefix this will need an explicit
-// `=` operator.
-func buildSearchQuery(stackProject, region string) string {
-	parts := make([]string, 0, 2)
+// Cloud Asset query syntax: `labels.<key>:<value>` and `location:<l>`,
+// AND-combined with whitespace. The `:` operator is a substring match
+// on values; for our project label values that's identical to equality
+// (the label isn't a substring of any other valid project name), but a
+// future stack project shadowing another's label-prefix would need an
+// explicit `=` operator.
+//
+// Multi-region (#291): two-or-more locations emit a parenthesized
+// `(location:l1 OR location:l2)` clause. Implicit precedence — `AND`
+// binds tighter than `OR` — is the reason the parens are non-optional.
+//
+// Known surprise (carried forward from pre-#291): four of five Phase-1
+// GCP types are project-global (their asset-side `location` is empty),
+// so any non-empty Regions will exclude them. A fix that auto-includes
+// `(location:l1 OR location:l2 OR NOT location:*)` is a follow-up.
+func buildSearchQuery(stackProject string, locations []string, selectors []TagSelector) string {
+	// Filter empty location strings so callers can pass a single-element
+	// `[]string{""}` (the natural shape when --regions is unset and we
+	// fall through the GCP no-default path) without producing the
+	// invalid `location:` clause.
+	nonEmpty := make([]string, 0, len(locations))
+	for _, l := range locations {
+		if l != "" {
+			nonEmpty = append(nonEmpty, l)
+		}
+	}
+	locations = nonEmpty
+
+	var clauses []string
 	if stackProject != "" {
-		parts = append(parts, "labels.project:"+stackProject)
+		clauses = append(clauses, "labels.project:"+stackProject)
 	}
-	if region != "" {
-		parts = append(parts, "location:"+region)
-	}
-	switch len(parts) {
+	switch len(locations) {
 	case 0:
-		return ""
+		// no location clause
 	case 1:
-		return parts[0]
+		clauses = append(clauses, "location:"+locations[0])
 	default:
-		return parts[0] + " AND " + parts[1]
+		locClauses := make([]string, 0, len(locations))
+		for _, l := range locations {
+			locClauses = append(locClauses, "location:"+l)
+		}
+		clauses = append(clauses, "("+strings.Join(locClauses, " OR ")+")")
 	}
+	for _, s := range selectors {
+		clauses = append(clauses, "labels."+s.Key+":"+s.Value)
+	}
+	return strings.Join(clauses, " AND ")
 }

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
@@ -51,7 +51,7 @@ func TestDiscoverTypes_ScopesToProjectAndPassesAssetTypes(t *testing.T) {
 	fake := &fakeAssetSearcher{}
 	g := NewGCPDiscoverer(fake, "real-proj")
 
-	if _, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic"}, "io-foo", "us-central1", ""); err != nil {
+	if _, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic"}, DiscoverArgs{Project: "io-foo", Regions: []string{"us-central1"}}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.calls) != 1 {
@@ -76,7 +76,7 @@ func TestDiscoverTypes_DefaultsToAllSupported(t *testing.T) {
 	t.Parallel()
 	fake := &fakeAssetSearcher{}
 	g := NewGCPDiscoverer(fake, "real-proj")
-	if _, err := g.DiscoverTypes(context.Background(), nil, "io-foo", "", ""); err != nil {
+	if _, err := g.DiscoverTypes(context.Background(), nil, DiscoverArgs{Project: "io-foo", Regions: []string{""}}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.calls) != 1 {
@@ -92,7 +92,7 @@ func TestDiscoverTypes_EmptyProjectAndRegionEmptyQuery(t *testing.T) {
 	t.Parallel()
 	fake := &fakeAssetSearcher{}
 	g := NewGCPDiscoverer(fake, "real-proj")
-	if _, err := g.DiscoverTypes(context.Background(), []string{"google_storage_bucket"}, "", "", ""); err != nil {
+	if _, err := g.DiscoverTypes(context.Background(), []string{"google_storage_bucket"}, DiscoverArgs{Project: "", Regions: []string{""}}); err != nil {
 		t.Fatal(err)
 	}
 	if fake.calls[0].query != "" {
@@ -103,7 +103,7 @@ func TestDiscoverTypes_EmptyProjectAndRegionEmptyQuery(t *testing.T) {
 func TestDiscoverTypes_UnknownTypeAggregatesError(t *testing.T) {
 	t.Parallel()
 	g := NewGCPDiscoverer(&fakeAssetSearcher{}, "p")
-	_, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic", "bogus", "also_bogus"}, "io-foo", "", "")
+	_, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic", "bogus", "also_bogus"}, DiscoverArgs{Project: "io-foo"})
 	if err == nil {
 		t.Fatal("expected error for unknown types")
 	}
@@ -115,7 +115,7 @@ func TestDiscoverTypes_UnknownTypeAggregatesError(t *testing.T) {
 func TestDiscoverTypes_PropagatesSearcherError(t *testing.T) {
 	t.Parallel()
 	g := NewGCPDiscoverer(&fakeAssetSearcher{err: errors.New("PermissionDenied")}, "p")
-	_, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic"}, "io-foo", "", "")
+	_, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic"}, DiscoverArgs{Project: "io-foo", Regions: []string{""}})
 	if err == nil || !strings.Contains(err.Error(), "PermissionDenied") {
 		t.Errorf("err=%v, want wrap of PermissionDenied", err)
 	}
@@ -131,7 +131,7 @@ func TestDiscoverTypes_TranslatesAndSortsByName(t *testing.T) {
 		},
 	}
 	g := NewGCPDiscoverer(fake, "real-proj")
-	got, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic", "google_storage_bucket"}, "io-foo", "", "")
+	got, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic", "google_storage_bucket"}, DiscoverArgs{Project: "io-foo"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +188,7 @@ func TestDiscoverTypes_SkipsAssetsForUnsupportedTypes(t *testing.T) {
 		},
 	}
 	g := NewGCPDiscoverer(fake, "real-proj")
-	got, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic"}, "io-foo", "", "")
+	got, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic"}, DiscoverArgs{Project: "io-foo", Regions: []string{""}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,24 +291,86 @@ func TestFromAsset_ProjectIDArgWinsOverAssetField(t *testing.T) {
 	}
 }
 
-// TestBuildSearchQuery_Composition pins the AND-join and the kept-empty
-// branches. A mutation that emitted `labels.project = io-foo` (with `=`
-// instead of `:`) or that included the empty terms anyway would produce
-// invalid Cloud Asset queries; this test catches both shapes.
+// TestBuildSearchQuery_Composition pins the AND-join, the kept-empty
+// branches, the multi-region OR-clause shape (#291), and operator-
+// supplied tag-selector clauses. A mutation that emitted
+// `labels.project = io-foo` (with `=` instead of `:`) or that
+// included the empty terms anyway would produce invalid Cloud Asset
+// queries; the literal-string assertions catch both shapes.
 func TestBuildSearchQuery_Composition(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name, project, region, want string
+		name      string
+		project   string
+		locations []string
+		selectors []TagSelector
+		want      string
 	}{
-		{name: "both", project: "io-foo", region: "us-east1", want: "labels.project:io-foo AND location:us-east1"},
-		{name: "project only", project: "io-foo", region: "", want: "labels.project:io-foo"},
-		{name: "region only", project: "", region: "us-east1", want: "location:us-east1"},
-		{name: "neither", project: "", region: "", want: ""},
+		// Pre-#291 baseline cases (no selectors, single or zero region).
+		{name: "both project and single region", project: "io-foo", locations: []string{"us-east1"}, want: "labels.project:io-foo AND location:us-east1"},
+		{name: "project only", project: "io-foo", want: "labels.project:io-foo"},
+		{name: "single region only", locations: []string{"us-east1"}, want: "location:us-east1"},
+		{name: "neither", want: ""},
+
+		// Empty-string-filtering cases (#291). The natural shape from
+		// a no-default GCP path is a single-element slice containing
+		// the empty string; that must NOT produce the invalid
+		// "location:" clause. Mixed empty + non-empty must fall
+		// through to the single-region branch (one cleaned location).
+		{name: "single empty location stripped", locations: []string{""}, want: ""},
+		{name: "mixed empty + valid falls through to single", locations: []string{"", "us-east1"}, want: "location:us-east1"},
+
+		// #291 multi-region cases. Two-or-more locations emit a
+		// parenthesized `(location:l1 OR location:l2 OR ...)` clause —
+		// parens are non-optional because Cloud Asset's implicit `AND`
+		// binds tighter than `OR`.
+		{
+			name:      "multi-region only",
+			locations: []string{"us-east1", "us-central1"},
+			want:      "(location:us-east1 OR location:us-central1)",
+		},
+		{
+			name:      "project and multi-region",
+			project:   "io-foo",
+			locations: []string{"us-east1", "eu-west1"},
+			want:      "labels.project:io-foo AND (location:us-east1 OR location:eu-west1)",
+		},
+		{
+			name:      "multi-region OR ordering pin",
+			locations: []string{"a", "b", "c"},
+			want:      "(location:a OR location:b OR location:c)",
+		},
+
+		// #291 selector cases.
+		{
+			name:      "selector only",
+			selectors: []TagSelector{{Key: "env", Value: "prod"}},
+			want:      "labels.env:prod",
+		},
+		{
+			name:      "project and selector",
+			project:   "io-foo",
+			selectors: []TagSelector{{Key: "env", Value: "prod"}},
+			want:      "labels.project:io-foo AND labels.env:prod",
+		},
+		{
+			name:      "multi-region and selector",
+			project:   "io-foo",
+			locations: []string{"us-east1", "us-central1"},
+			selectors: []TagSelector{{Key: "env", Value: "prod"}},
+			want:      "labels.project:io-foo AND (location:us-east1 OR location:us-central1) AND labels.env:prod",
+		},
+		{
+			name:      "multi-selector ordering pin",
+			project:   "io-foo",
+			selectors: []TagSelector{{Key: "env", Value: "prod"}, {Key: "team", Value: "growth"}},
+			want:      "labels.project:io-foo AND labels.env:prod AND labels.team:growth",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := buildSearchQuery(tc.project, tc.region); got != tc.want {
+			if got := buildSearchQuery(tc.project, tc.locations, tc.selectors); got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})

--- a/cmd/insideout-import/gcpdiscover/identity.go
+++ b/cmd/insideout-import/gcpdiscover/identity.go
@@ -37,10 +37,13 @@ func (b addressBook) add(addr string) { b[addr] = struct{}{} }
 // hint precedence matches the AWS path), importID is the per-type
 // terraform-side import ID (see each discoverer file for the shape),
 // projectID is the real GCP project ID, location is the GCP location
-// (empty for project-global types), and nativeIDs lets a discoverer
-// attach extra cloud-side IDs (self-link, asset name) without mutating
-// the merged map after construction.
-func makeImportedResource(book addressBook, typ, name, importID, projectID, location string, nativeIDs map[string]string) imported.ImportedResource {
+// (empty for project-global types), nativeIDs lets a discoverer attach
+// extra cloud-side IDs (self-link, asset name) without mutating the
+// merged map after construction, and tags is the asset's labels map
+// captured at discover time. Pass nil for tags if the asset had no
+// labels field; the nil-vs-empty distinction is load-bearing for the
+// downstream tag-selector and summary consumers (#291, #289 gap-#6).
+func makeImportedResource(book addressBook, typ, name, importID, projectID, location string, nativeIDs, tags map[string]string) imported.ImportedResource {
 	id := imported.ResourceIdentity{
 		Cloud:          "gcp",
 		Type:           typ,
@@ -51,6 +54,7 @@ func makeImportedResource(book addressBook, typ, name, importID, projectID, loca
 		Location:       location,
 		ImportID:       importID,
 		NativeIDs:      mergeNativeIDs(name, nativeIDs),
+		Tags:           tags,
 	}
 	addr := imported.GenerateAddress(id, book.exists)
 	id.Address = addr

--- a/cmd/insideout-import/gcpdiscover/identity_test.go
+++ b/cmd/insideout-import/gcpdiscover/identity_test.go
@@ -10,9 +10,20 @@ import (
 func TestMakeImportedResource_PopulatesRequiredFields(t *testing.T) {
 	t.Parallel()
 	book := addressBook{}
+	wantTags := map[string]string{"project": "io-foo", "env": "prod"}
 	got := makeImportedResource(book, "google_pubsub_topic", "io-foo-events",
 		"projects/real-proj/topics/io-foo-events", "real-proj", "",
-		map[string]string{"asset_name": "//pubsub.googleapis.com/projects/real-proj/topics/io-foo-events"})
+		map[string]string{"asset_name": "//pubsub.googleapis.com/projects/real-proj/topics/io-foo-events"},
+		wantTags)
+
+	// Tags carrier (#291) — pin both presence and shape. Mirrors the
+	// AWS-side pin so a regression on either side is caught here.
+	if got.Identity.Tags == nil {
+		t.Error("Tags must be populated when discoverer fetched a label map")
+	}
+	if got.Identity.Tags["project"] != "io-foo" || got.Identity.Tags["env"] != "prod" {
+		t.Errorf("Tags=%v, want %v", got.Identity.Tags, wantTags)
+	}
 
 	if got.Identity.Cloud != "gcp" {
 		t.Errorf("Cloud=%q, want gcp", got.Identity.Cloud)
@@ -60,9 +71,9 @@ func TestMakeImportedResource_ResolvesAddressCollisionsWithinBatch(t *testing.T)
 	t.Parallel()
 	book := addressBook{}
 	a := makeImportedResource(book, "google_pubsub_topic", "events",
-		"projects/p1/topics/events", "p1", "", nil)
+		"projects/p1/topics/events", "p1", "", nil, nil)
 	b := makeImportedResource(book, "google_pubsub_topic", "events",
-		"projects/p1/topics/events-also", "p1", "", nil)
+		"projects/p1/topics/events-also", "p1", "", nil, nil)
 
 	if a.Identity.Address == b.Identity.Address {
 		t.Errorf("expected distinct addresses for distinct identities; got %q twice", a.Identity.Address)
@@ -79,7 +90,7 @@ func TestMakeImportedResource_ResolvesAddressCollisionsWithinBatch(t *testing.T)
 func TestMakeImportedResource_EmptyLocationLeftEmpty(t *testing.T) {
 	t.Parallel()
 	got := makeImportedResource(addressBook{}, "google_pubsub_topic", "events",
-		"projects/p/topics/events", "p", "", nil)
+		"projects/p/topics/events", "p", "", nil, nil)
 	if got.Identity.Location != "" {
 		t.Errorf("Location=%q, want empty for project-global resource", got.Identity.Location)
 	}
@@ -88,7 +99,7 @@ func TestMakeImportedResource_EmptyLocationLeftEmpty(t *testing.T) {
 func TestMakeImportedResource_PropagatesLocationForRegionalResource(t *testing.T) {
 	t.Parallel()
 	got := makeImportedResource(addressBook{}, "google_storage_bucket", "io-bucket",
-		"io-bucket", "real-proj", "us-central1", nil)
+		"io-bucket", "real-proj", "us-central1", nil, nil)
 	if got.Identity.Location != "us-central1" {
 		t.Errorf("Location=%q, want us-central1", got.Identity.Location)
 	}

--- a/cmd/insideout-import/gcpdiscover/pubsub_subscription.go
+++ b/cmd/insideout-import/gcpdiscover/pubsub_subscription.go
@@ -31,7 +31,7 @@ func (pubsubSubscriptionDiscoverer) FromAsset(book addressBook, a gcpAssetResult
 	importID := fmt.Sprintf("projects/%s/subscriptions/%s", projectID, name)
 	return makeImportedResource(book, pubsubSubscriptionTFType, name, importID, projectID, "", map[string]string{
 		"asset_name": a.Name,
-	})
+	}, a.Labels)
 }
 
 func (pubsubSubscriptionDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, id, projectID string) (imported.ImportedResource, error) {
@@ -42,7 +42,7 @@ func (pubsubSubscriptionDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSe
 	importID := fmt.Sprintf("projects/%s/subscriptions/%s", projectID, name)
 	return makeImportedResource(addressBook{}, pubsubSubscriptionTFType, name, importID, projectID, "", map[string]string{
 		"asset_name": fmt.Sprintf("//%s/projects/%s/subscriptions/%s", pubsubAssetHost, projectID, name),
-	}), nil
+	}, nil), nil
 }
 
 func pubsubSubscriptionNameFromID(id string) (string, error) {

--- a/cmd/insideout-import/gcpdiscover/pubsub_topic.go
+++ b/cmd/insideout-import/gcpdiscover/pubsub_topic.go
@@ -38,7 +38,7 @@ func (pubsubTopicDiscoverer) FromAsset(book addressBook, a gcpAssetResult, proje
 	importID := fmt.Sprintf("projects/%s/topics/%s", projectID, name)
 	return makeImportedResource(book, pubsubTopicTFType, name, importID, projectID, "", map[string]string{
 		"asset_name": a.Name,
-	})
+	}, a.Labels)
 }
 
 func (pubsubTopicDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, id, projectID string) (imported.ImportedResource, error) {
@@ -49,7 +49,7 @@ func (pubsubTopicDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher,
 	importID := fmt.Sprintf("projects/%s/topics/%s", projectID, name)
 	return makeImportedResource(addressBook{}, pubsubTopicTFType, name, importID, projectID, "", map[string]string{
 		"asset_name": fmt.Sprintf("//%s/projects/%s/topics/%s", pubsubAssetHost, projectID, name),
-	}), nil
+	}, nil), nil
 }
 
 const pubsubAssetHost = "pubsub.googleapis.com"

--- a/cmd/insideout-import/gcpdiscover/secret_manager_secret.go
+++ b/cmd/insideout-import/gcpdiscover/secret_manager_secret.go
@@ -38,7 +38,7 @@ func (secretManagerSecretDiscoverer) FromAsset(book addressBook, a gcpAssetResul
 	importID := fmt.Sprintf("projects/%s/secrets/%s", projectID, name)
 	return makeImportedResource(book, secretManagerSecretTFType, name, importID, projectID, "", map[string]string{
 		"asset_name": a.Name,
-	})
+	}, a.Labels)
 }
 
 func (secretManagerSecretDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, id, projectID string) (imported.ImportedResource, error) {
@@ -49,7 +49,7 @@ func (secretManagerSecretDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetS
 	importID := fmt.Sprintf("projects/%s/secrets/%s", projectID, name)
 	return makeImportedResource(addressBook{}, secretManagerSecretTFType, name, importID, projectID, "", map[string]string{
 		"asset_name": fmt.Sprintf("//%s/projects/%s/secrets/%s", secretManagerAssetHost, projectID, name),
-	}), nil
+	}, nil), nil
 }
 
 func secretManagerSecretNameFromID(id string) (string, error) {

--- a/cmd/insideout-import/gcpdiscover/storage_bucket.go
+++ b/cmd/insideout-import/gcpdiscover/storage_bucket.go
@@ -39,7 +39,7 @@ func (storageBucketDiscoverer) FromAsset(book addressBook, a gcpAssetResult, pro
 	return makeImportedResource(book, storageBucketTFType, name, name, projectID, a.Location, map[string]string{
 		"asset_name": a.Name,
 		"self_link":  fmt.Sprintf("https://www.googleapis.com/storage/v1/b/%s", name),
-	})
+	}, a.Labels)
 }
 
 func (storageBucketDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, id, projectID string) (imported.ImportedResource, error) {
@@ -49,11 +49,12 @@ func (storageBucketDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearche
 	}
 	// Location is unknown without a re-query; leave empty rather than
 	// guessing. The driftfix loop will surface it via terraform plan
-	// if downstream resources reference it.
+	// if downstream resources reference it. Tags are nil — DiscoverByID
+	// does not re-fetch labels from Cloud Asset.
 	return makeImportedResource(addressBook{}, storageBucketTFType, name, name, projectID, "", map[string]string{
 		"asset_name": fmt.Sprintf("//%s/%s", storageAssetHost, name),
 		"self_link":  fmt.Sprintf("https://www.googleapis.com/storage/v1/b/%s", name),
-	}), nil
+	}, nil), nil
 }
 
 // storageBucketNameFromID extracts the bucket name from one of three

--- a/cmd/insideout-import/tag_selectors.go
+++ b/cmd/insideout-import/tag_selectors.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// tagSelectorPair is a single parsed --tag-selectors entry. Lives in the
+// CLI package (rather than awsdiscover/gcpdiscover) so the parser stays
+// cloud-agnostic; the AWS and GCP RunE handlers convert the slice to
+// their respective discoverer-package TagSelector type when threading
+// the args. The two-package conversion is one for-loop on each side and
+// keeps the CLI free of cloud-specific types.
+type tagSelectorPair struct {
+	Key   string
+	Value string
+}
+
+// parseTagSelectors parses the --tag-selectors flag value. The expected
+// format is a comma-separated list of `key=value` pairs; whitespace
+// around keys and values is trimmed. Empty input returns nil (no
+// selectors). Tag values may contain `=` (uncommon but legal in cloud
+// tag stores), so we split on the first `=` only.
+//
+// Returns an error on:
+//   - any pair missing the `=` separator;
+//   - empty key after trimming;
+//   - duplicate keys (operator-supplied conflict — silently dropping
+//     the earlier one would surprise the operator and an AND-conjunction
+//     of `env=prod` AND `env=staging` is unsatisfiable).
+//
+// Empty values are permitted: matches resources whose tag key is
+// present and equals the empty string. This is rare but legal in AWS
+// (a tag with empty value) and GCP (a label with no value).
+func parseTagSelectors(raw string) ([]tagSelectorPair, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]tagSelectorPair, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		idx := strings.Index(p, "=")
+		if idx < 0 {
+			return nil, fmt.Errorf("tag selector %q: missing '=' separator (expected key=value)", p)
+		}
+		key := strings.TrimSpace(p[:idx])
+		val := strings.TrimSpace(p[idx+1:])
+		if key == "" {
+			return nil, fmt.Errorf("tag selector %q: empty key", p)
+		}
+		if _, dup := seen[key]; dup {
+			return nil, fmt.Errorf("tag selector %q: duplicate key %q (an AND-conjunction with conflicting values for the same key cannot match any resource)", p, key)
+		}
+		seen[key] = struct{}{}
+		out = append(out, tagSelectorPair{Key: key, Value: val})
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}

--- a/cmd/insideout-import/tag_selectors_test.go
+++ b/cmd/insideout-import/tag_selectors_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestParseTagSelectors_ValidShapes pins the happy paths — single
+// selector, multiple selectors, whitespace tolerance, and the
+// empty-input return (nil rather than empty slice; consistent with
+// splitCSV's contract).
+func TestParseTagSelectors_ValidShapes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		raw  string
+		want []tagSelectorPair
+	}{
+		{name: "empty input returns nil", raw: "", want: nil},
+		{name: "whitespace input returns nil", raw: "   ", want: nil},
+		{name: "single selector", raw: "env=prod", want: []tagSelectorPair{{Key: "env", Value: "prod"}}},
+		{name: "two selectors", raw: "env=prod,team=growth", want: []tagSelectorPair{{Key: "env", Value: "prod"}, {Key: "team", Value: "growth"}}},
+		{name: "trims whitespace around pair", raw: " env = prod , team = growth ", want: []tagSelectorPair{{Key: "env", Value: "prod"}, {Key: "team", Value: "growth"}}},
+		{name: "value with embedded equals", raw: "url=https://example.com/?x=1", want: []tagSelectorPair{{Key: "url", Value: "https://example.com/?x=1"}}},
+		{name: "empty value permitted", raw: "env=", want: []tagSelectorPair{{Key: "env", Value: ""}}},
+		{name: "trailing comma is tolerated", raw: "env=prod,", want: []tagSelectorPair{{Key: "env", Value: "prod"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseTagSelectors(tc.raw)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseTagSelectors_RejectsMalformed pins each error path
+// individually so a regression on one branch (e.g. silently dropping
+// the missing-equals check) surfaces specifically rather than via a
+// generic "no error returned" failure. Substring assertion on the
+// error string keeps the messages owner-friendly without overfitting.
+func TestParseTagSelectors_RejectsMalformed(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		raw         string
+		wantErrSubs string
+	}{
+		{name: "missing equals", raw: "env-prod", wantErrSubs: "missing '=' separator"},
+		{name: "empty key", raw: "=prod", wantErrSubs: "empty key"},
+		{name: "duplicate key", raw: "env=prod,env=staging", wantErrSubs: "duplicate key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseTagSelectors(tc.raw)
+			if err == nil {
+				t.Fatalf("expected error for %q", tc.raw)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubs) {
+				t.Errorf("err=%q, want substring %q", err.Error(), tc.wantErrSubs)
+			}
+		})
+	}
+}

--- a/pkg/composer/imported/identity.go
+++ b/pkg/composer/imported/identity.go
@@ -45,4 +45,10 @@ type ResourceIdentity struct {
 	ProviderIdentity map[string]string `json:"provider_identity,omitempty"`
 	// NativeIDs holds cloud-side identifiers (arn, url, self_link, name).
 	NativeIDs map[string]string `json:"native_ids,omitempty"`
+	// Tags is the cloud-side tag (AWS) or label (GCP) map captured at
+	// discover time. Empty map (not nil) when the resource genuinely has
+	// no tags; nil when the discoverer didn't fetch tags. Downstream
+	// consumers (#291 tag selectors, #289 gap-#6 DiscoverySummary.byTag)
+	// rely on the nil-vs-empty distinction.
+	Tags map[string]string `json:"tags,omitempty"`
 }


### PR DESCRIPTION
Closes #291. Bundle 1 / PR 2 of the reverse-Terraform import surface (umbrella #289).

## Summary

Multi-region AWS scanning and operator-supplied tag/label selectors for `insideout-import discover`, with full tag persistence onto the manifest.

- **`DiscoverArgs` migration**: per-service `Discoverer.Discover` accepts a `DiscoverArgs{Project, Regions, TagSelectors, AccountID}` struct. `DiscoverByID` stays on its legacy 4-arg shape — single-resource lookups have no multi-region or selector semantics. AWS aggregator pre-resolves empty `Regions` to the configured-region for back-compat.
- **Per-region scan (AWS)**: each per-service `Discover` loops `args.Regions` with a per-region SDK client (`WithRegion` option override). IAM (role/policy) and S3 are global and ignore `Regions`.
- **Tag selectors + persistence**: every per-service discoverer now fetches tags (net-new in SQS, CloudWatch Logs, IAM role, IAM policy, KMS, S3) and persists them onto a new `ResourceIdentity.Tags` field. Operator selectors apply via shared `MatchesAll` (AND-conjunction). The legacy implicit `Project=<project>` filter on DynamoDB / Lambda / SecretsManager is preserved as back-compat.
- **GCP query (Cloud Asset)**: `buildSearchQuery(stackProject, locations, selectors)` emits `(location:l1 OR location:l2)` for multi-location and `labels.<k>:<v>` per selector, AND-joined. Empty-string locations are filtered (the natural shape from a no-default GCP path).
- **CLI**: `--regions r1,r2,...` replaces `--region` (which stays as a deprecation alias with a stderr warning). `--tag-selectors env=prod,team=growth`. Conflict between `--region` and `--regions` is a fatal error with operator-facing guidance.

## Behavior changes

- `ResourceIdentity` gains a `Tags map[string]string` field. Persisted on every emitted resource. nil ⇒ "didn't fetch", empty ⇒ "no tags."
- Five AWS services now issue an extra per-resource tag fetch on every scan. Bounded by the resources already discovered; cost is acceptable.
- Stage 2b/2c1/2c3 (genconfig, driftfix, depchase) thread `primaryRegion` (the first listed in `--regions`) — multi-region stack emission is a follow-up.

## Known surprises (carried forward, documented in code)

- GCP project-global asset types (Pub/Sub, VPC networks, secrets) are excluded by any non-empty `--regions` value. The Cloud Asset API treats their location as empty; a `(location:a OR location:b)` clause excludes them. Header comment on `buildSearchQuery` calls this out.
- S3 buckets stamp `Identity.Region` with the operator's first `--regions` value. `GetBucketLocation` for accurate per-bucket stamps is a follow-up.
- IAM resources stamp `Identity.Region` empty (IAM is account-global).

## Test surface

50+ new tests:

- **Aggregator level** (`awsdiscover_test.go`): empty-Regions defaulting, multi-region threading, tag-selector threading.
- **Per-service pattern pins** (`sqs_test.go`): multi-region triggers one SDK call per region (P0 mutation-resistance for the inner loop), tag selectors actually filter (P1 mutation-resistance for the `MatchesAll` continue).
- **GCP query builder** (`gcpdiscover_test.go::TestBuildSearchQuery_Composition`): 13 cases — pre-#291 baselines + multi-region OR + selectors + ordering pins + empty-string filter rows.
- **Tag persistence**: `identity_test.go` (both AWS and GCP) pin specific Tags values, not just non-nil.
- **CLI flag validation** (`discover_test.go`): conflict detection, missing-regions fatal, deprecation alias works, malformed-selector fatal — all with stderr substring pins on operator-facing guidance.
- **`MatchesAll` semantics** (`args_test.go`): AND-conjunction, first-miss / last-miss / duplicate-key cases (mutation-resistant).
- **`parseTagSelectors`** (`tag_selectors_test.go`): valid shapes + each malformed-input branch.

## Tracked elsewhere

- True \"all regions\" mode for AWS — needs an EC2 DescribeRegions source. Not in this PR.
- S3 `GetBucketLocation` for accurate `Identity.Region` stamps — follow-up.
- GCP global-resource exclusion when `--regions` is set — follow-up.
- PR 3 / Bundle 1 — `--from-manifest` re-import → #292.
- Bundle 2 candidates → tracked under #289 (gaps 4, 6, 7, 8, 9, 10).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` (3169 passed)
- [x] `go vet ./...` clean
- [x] `gofmt -l cmd/ pkg/` empty
- [x] `terraform fmt -check -recursive` clean
- [x] Static lint scripts (lint-project-tag, lint-project-label, lint-sensitive-for-each, lint-foreach-unknown-keys) all PASS
- [x] qa-professor review of new tests — P0/P1/P2 findings all addressed