### PR TITLE
feat(insideout-import): --from-manifest targeted-subset re-import (#292)

### DIFF
--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -239,6 +240,8 @@ Exit codes:
 	maxConcurrency := fs.Int("max-concurrency", awsdiscover.DefaultMaxConcurrency, "max in-flight per-resource AWS API calls inside the DynamoDB and Lambda discoverers; raise on accounts with thousands of resources, lower if the SDK retryer keeps tripping. Ignored for --provider gcp (Cloud Asset is a single-call surface).")
 	awsEndpointURL := fs.String("aws-endpoint-url", "", "override the AWS endpoint URL for both SDK and terraform provider; intended for the Stage 2c4 LocalStack-backed CI gate (#272) — pass http://localhost:4566 to retarget every service at LocalStack. Empty (default) uses real AWS. Ignored for --provider gcp.")
 	gcpProjectID := fs.String("gcp-project-id", "", "real GCP project ID (per #157, distinct from --project); required for --provider gcp. The Cloud Asset Inventory scope is `projects/<gcp-project-id>` and Identity.ProjectID on every emitted resource is set to this value.")
+	fromManifest := fs.String("from-manifest", "", "load resource set from a prior imported.json instead of running Stage 2a (discovery). Use to re-emit HCL for a previously-discovered set without re-walking the cloud. Mutually exclusive with --resource-types.")
+	resourceIDs := fs.String("resource-ids", "", "comma-separated subset of Identity.ImportID values to retain when loading --from-manifest; unknown IDs are fatal. Empty = use the entire manifest. Requires --from-manifest.")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -264,6 +267,20 @@ Exit codes:
 		fmt.Fprintln(os.Stderr, "discover: --project is required")
 		return discoverExitFatal
 	}
+	// --from-manifest / --resource-ids mutual-exclusion + dependency
+	// validation (#292). These checks run before the AWS-region requirement
+	// so that --from-manifest can satisfy the region requirement from the
+	// loaded manifest's Identity.Region rather than the CLI flags.
+	fromManifestPath := strings.TrimSpace(*fromManifest)
+	resourceIDsRaw := strings.TrimSpace(*resourceIDs)
+	if resourceIDsRaw != "" && fromManifestPath == "" {
+		fmt.Fprintln(os.Stderr, "discover: --resource-ids requires --from-manifest")
+		return discoverExitFatal
+	}
+	if fromManifestPath != "" && strings.TrimSpace(*resourceTypes) != "" {
+		fmt.Fprintln(os.Stderr, "discover: --resource-types is incompatible with --from-manifest (the manifest is already type-filtered)")
+		return discoverExitFatal
+	}
 	// Resolve --regions vs deprecated --region (#291).
 	regionsRaw := strings.TrimSpace(*regions)
 	regionRaw := strings.TrimSpace(*region)
@@ -276,7 +293,11 @@ Exit codes:
 		fmt.Fprintln(os.Stderr, "discover: WARN: --region is deprecated; use --regions instead")
 		resolvedRegions = []string{regionRaw}
 	}
-	if cloud == "aws" && len(resolvedRegions) == 0 {
+	// --from-manifest defers the AWS-region requirement: the primary region
+	// is derived from the loaded manifest's first resource's Identity.Region
+	// inside runDiscoverWithDeps. When --from-manifest is empty the legacy
+	// rule applies.
+	if cloud == "aws" && len(resolvedRegions) == 0 && fromManifestPath == "" {
 		fmt.Fprintln(os.Stderr, "discover: --regions is required for --provider aws (or --region for back-compat)")
 		return discoverExitFatal
 	}
@@ -319,6 +340,65 @@ Exit codes:
 	ctx, cancel := context.WithTimeout(context.Background(), discoverTimeout)
 	defer cancel()
 
+	// --from-manifest pre-load (#292): when set, replace Stage 2a
+	// (DiscoverTypes) with a manifest-driven resource set. We still build
+	// the cloud config + discoverer below — Stage 2c3 dep-chase calls
+	// d.DiscoverByID, and Stage 2b/2c1 invoke the terraform binary which
+	// consumes the same provider credentials — but we skip the bulk
+	// DiscoverTypes call.
+	var preloaded []imported.ImportedResource
+	if fromManifestPath != "" {
+		var err error
+		preloaded, err = readManifest(fromManifestPath, cloud)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "discover: load manifest: %v\n", err)
+			return discoverExitFatal
+		}
+		if resourceIDsRaw != "" {
+			wanted := splitCSV(*resourceIDs)
+			wantSet := make(map[string]struct{}, len(wanted))
+			for _, id := range wanted {
+				wantSet[id] = struct{}{}
+			}
+			seen := make(map[string]struct{}, len(preloaded))
+			kept := make([]imported.ImportedResource, 0, len(wanted))
+			for _, r := range preloaded {
+				if _, ok := wantSet[r.Identity.ImportID]; ok {
+					kept = append(kept, r)
+					seen[r.Identity.ImportID] = struct{}{}
+				}
+			}
+			var missing []string
+			for id := range wantSet {
+				if _, ok := seen[id]; !ok {
+					missing = append(missing, id)
+				}
+			}
+			if len(missing) > 0 {
+				sort.Strings(missing)
+				fmt.Fprintf(os.Stderr, "discover: --resource-ids: %d unknown id(s) not present in manifest %s: %s\n",
+					len(missing), fromManifestPath, strings.Join(missing, ", "))
+				return discoverExitFatal
+			}
+			preloaded = kept
+		}
+		// Derive primaryRegion from the loaded manifest when the CLI
+		// flag is empty (the AWS-region-required gate above is bypassed
+		// in this branch). Walk for the first non-empty Region.
+		if cloud == "aws" && primaryRegion == "" {
+			for _, r := range preloaded {
+				if rr := strings.TrimSpace(r.Identity.Region); rr != "" {
+					primaryRegion = rr
+					break
+				}
+			}
+			if primaryRegion == "" {
+				fmt.Fprintf(os.Stderr, "discover: --from-manifest %s: no Identity.Region populated on any resource and --regions is empty; cannot derive primary region for Stage 2b\n", fromManifestPath)
+				return discoverExitFatal
+			}
+		}
+	}
+
 	var (
 		d         discoveryAggregator
 		accountID string // AWS account ID, or real GCP project ID for the cloud-agnostic interface slot
@@ -330,16 +410,45 @@ Exit codes:
 			fmt.Fprintf(os.Stderr, "discover: load AWS config: %v\n", err)
 			return discoverExitFatal
 		}
-		// One STS GetCallerIdentity call per run; the result is threaded into
-		// every per-type discoverer so they don't each re-hit STS. We require
-		// the account ID for ARN construction (DynamoDB) and provenance, so a
-		// failure here is fatal. A nil Account on the STS response is treated
-		// as accountID="" — the DynamoDB discoverer's prefix-only fallback
-		// handles that case (see TestDynamoDBDiscover_PrefixOnlyFallback).
-		accountID, err = deps.getAccount(ctx, cfg)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "discover: STS GetCallerIdentity: %v\n", err)
-			return discoverExitFatal
+		// --from-manifest STS optimization (#292): if every loaded
+		// resource already carries a non-empty Identity.AccountID we
+		// can skip the STS round-trip. Otherwise (any resource missing
+		// AccountID, or no manifest at all) call STS for the
+		// authoritative answer. We also warn-but-don't-fail when the
+		// loaded manifest mixes account IDs — the import path proceeds
+		// with the first one observed.
+		skipSTS := false
+		if fromManifestPath != "" && len(preloaded) > 0 {
+			first := strings.TrimSpace(preloaded[0].Identity.AccountID)
+			if first != "" {
+				skipSTS = true
+				accountID = first
+				for _, r := range preloaded[1:] {
+					rid := strings.TrimSpace(r.Identity.AccountID)
+					if rid == "" {
+						skipSTS = false
+						break
+					}
+					if rid != first {
+						fmt.Fprintf(os.Stderr, "discover: WARN: --from-manifest %s contains mixed Identity.AccountID values (%s vs %s); proceeding with %s from the first record\n",
+							fromManifestPath, first, rid, first)
+					}
+				}
+			}
+		}
+		if !skipSTS {
+			// One STS GetCallerIdentity call per run; the result is threaded
+			// into every per-type discoverer so they don't each re-hit STS.
+			// We require the account ID for ARN construction (DynamoDB) and
+			// provenance, so a failure here is fatal. A nil Account on the
+			// STS response is treated as accountID="" — the DynamoDB
+			// discoverer's prefix-only fallback handles that case (see
+			// TestDynamoDBDiscover_PrefixOnlyFallback).
+			accountID, err = deps.getAccount(ctx, cfg)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "discover: STS GetCallerIdentity: %v\n", err)
+				return discoverExitFatal
+			}
 		}
 		d = deps.newDiscoverer(cfg, *maxConcurrency)
 	case "gcp":
@@ -357,10 +466,19 @@ Exit codes:
 		accountID = *gcpProjectID
 	}
 
-	resources, err := d.DiscoverTypes(ctx, types, *project, resolvedRegions, parsedSelectors, accountID)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "discover: %v\n", err)
-		return discoverExitFatal
+	var resources []imported.ImportedResource
+	if fromManifestPath != "" {
+		// Skip Stage 2a entirely — the manifest is the source of truth.
+		// The first writeManifest below still runs; it re-validates the
+		// loaded set and re-emits a deterministic file (sorted, []-not-null).
+		resources = preloaded
+	} else {
+		var err error
+		resources, err = d.DiscoverTypes(ctx, types, *project, resolvedRegions, parsedSelectors, accountID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "discover: %v\n", err)
+			return discoverExitFatal
+		}
 	}
 
 	out, n, err := writeManifest(*outputDir, cloud, resources)

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1527,6 +1528,322 @@ func TestRunDiscoverWithDeps_GCPDepChaseConvergesTrivially(t *testing.T) {
 	}, deps)
 	if rc != discoverExitOK {
 		t.Errorf("rc=%d, want OK", rc)
+	}
+}
+
+// --- #292 --from-manifest re-import path ---
+
+// validResourceWithRegion returns a validResource()-shape AWS record with
+// Identity.Region populated. The from-manifest tests assert Stage 2b
+// (genconfig) gets the right Region, and that primaryRegion derives from
+// the loaded manifest when --regions is empty.
+func validResourceWithRegion(addr, region, accountID string) imported.ImportedResource {
+	r := validResource(addr)
+	r.Identity.Region = region
+	r.Identity.AccountID = accountID
+	return r
+}
+
+// writeFixtureManifest is a tiny helper that exercises the production
+// writeManifest in tests so the on-disk fixture matches what a prior
+// discover run would have written. Returns the path to the manifest.
+func writeFixtureManifest(t *testing.T, dir, cloud string, rs []imported.ImportedResource) string {
+	t.Helper()
+	path, _, err := writeManifest(dir, cloud, rs)
+	if err != nil {
+		t.Fatalf("writeManifest fixture: %v", err)
+	}
+	return path
+}
+
+// TestRunDiscoverWithDeps_FromManifestSkipsDiscoverTypes pins the
+// re-import contract: --from-manifest replaces Stage 2a so the
+// aggregator's DiscoverTypes is not called. The downstream Stage 2b
+// (genconfig) must still receive the loaded resources verbatim — a
+// regression that fed an empty slice into genconfig would silently emit
+// an empty generated.tf.
+func TestRunDiscoverWithDeps_FromManifestSkipsDiscoverTypes(t *testing.T) {
+	t.Parallel()
+	manifestDir := t.TempDir()
+	loaded := []imported.ImportedResource{
+		validResourceWithRegion("aws_sqs_queue.alpha", "us-east-1", "1234567890"),
+		validResourceWithRegion("aws_sqs_queue.bravo", "us-east-1", "1234567890"),
+	}
+	manifestPath := writeFixtureManifest(t, manifestDir, "aws", loaded)
+
+	outDir := t.TempDir()
+	gc := &fakeGenconfig{}
+	agg := &fakeAggregator{}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--regions", "us-east-1",
+		"--from-manifest", manifestPath,
+		"--output-dir", outDir,
+	}, okDepsWithGC(agg, gc))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if agg.called != 0 {
+		t.Errorf("DiscoverTypes called %d times with --from-manifest, want 0", agg.called)
+	}
+	if gc.called != 1 {
+		t.Errorf("runGenconfig called %d times, want 1 (Stage 2b must still run)", gc.called)
+	}
+	if gc.gotCount != 2 {
+		t.Errorf("genconfig got %d resources, want 2 (loaded manifest size)", gc.gotCount)
+	}
+}
+
+// TestRunDiscoverWithDeps_FromManifestResourceIDsFiltersToSubset pins the
+// targeted-subset wizard flow: a 3-resource manifest + --resource-ids
+// listing 2 of them yields only those 2 resources downstream.
+func TestRunDiscoverWithDeps_FromManifestResourceIDsFiltersToSubset(t *testing.T) {
+	t.Parallel()
+	manifestDir := t.TempDir()
+	r1 := validResourceWithRegion("aws_sqs_queue.alpha", "us-east-1", "1234567890")
+	r1.Identity.ImportID = "id-alpha"
+	r2 := validResourceWithRegion("aws_sqs_queue.bravo", "us-east-1", "1234567890")
+	r2.Identity.ImportID = "id-bravo"
+	r3 := validResourceWithRegion("aws_sqs_queue.charlie", "us-east-1", "1234567890")
+	r3.Identity.ImportID = "id-charlie"
+	manifestPath := writeFixtureManifest(t, manifestDir, "aws",
+		[]imported.ImportedResource{r1, r2, r3})
+
+	outDir := t.TempDir()
+	gc := &fakeGenconfig{}
+	agg := &fakeAggregator{}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--regions", "us-east-1",
+		"--from-manifest", manifestPath,
+		"--resource-ids", "id-alpha,id-charlie",
+		"--output-dir", outDir,
+	}, okDepsWithGC(agg, gc))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if gc.gotCount != 2 {
+		t.Errorf("genconfig got %d resources, want 2 (subset of 3)", gc.gotCount)
+	}
+	// Re-read on-disk imported.json to confirm only the picked subset
+	// landed (the writeManifest re-emit must not silently include the
+	// dropped resource).
+	body, err := os.ReadFile(filepath.Join(outDir, "imported.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []imported.ImportedResource
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.Len(t, got, 2)
+	gotIDs := []string{got[0].Identity.ImportID, got[1].Identity.ImportID}
+	if !slices.Contains(gotIDs, "id-alpha") || !slices.Contains(gotIDs, "id-charlie") {
+		t.Errorf("emitted manifest IDs=%v, want id-alpha,id-charlie subset", gotIDs)
+	}
+	if slices.Contains(gotIDs, "id-bravo") {
+		t.Errorf("dropped resource id-bravo leaked into emitted manifest: %v", gotIDs)
+	}
+}
+
+// TestRunDiscoverWithDeps_FromManifestUnknownResourceIDIsFatal pins the
+// fail-loud contract: an unknown id in --resource-ids is fatal (no silent
+// drop) and the stderr message names the offending id literal so the
+// wizard's error UX can surface it back to the operator unchanged.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_FromManifestUnknownResourceIDIsFatal(t *testing.T) {
+	manifestDir := t.TempDir()
+	r1 := validResourceWithRegion("aws_sqs_queue.alpha", "us-east-1", "1234567890")
+	r1.Identity.ImportID = "id-alpha"
+	manifestPath := writeFixtureManifest(t, manifestDir, "aws",
+		[]imported.ImportedResource{r1})
+
+	outDir := t.TempDir()
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--from-manifest", manifestPath,
+			"--resource-ids", "id-alpha,id-ghost",
+			"--output-dir", outDir,
+		}, okDeps(&fakeAggregator{}))
+	})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+	if !strings.Contains(stderr, "id-ghost") {
+		t.Errorf("stderr must literal-quote the unknown id; got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "unknown") {
+		t.Errorf("stderr must label the failure as unknown id; got: %s", stderr)
+	}
+}
+
+// TestRunDiscoverWithDeps_FromManifestPopulatedAccountIDSkipsSTS pins the
+// STS optimization (#292): every loaded resource has Identity.AccountID
+// populated, so we don't waste an API call. A regression that always
+// hit STS would still produce a correct manifest but burn the round-trip
+// — the test fails fast on STS being called at all.
+func TestRunDiscoverWithDeps_FromManifestPopulatedAccountIDSkipsSTS(t *testing.T) {
+	t.Parallel()
+	manifestDir := t.TempDir()
+	manifestPath := writeFixtureManifest(t, manifestDir, "aws", []imported.ImportedResource{
+		validResourceWithRegion("aws_sqs_queue.alpha", "us-east-1", "1234567890"),
+		validResourceWithRegion("aws_sqs_queue.bravo", "us-east-1", "1234567890"),
+	})
+
+	outDir := t.TempDir()
+	agg := &fakeAggregator{}
+	stsCalls := 0
+	deps := okDeps(agg)
+	deps.getAccount = func(_ context.Context, _ aws.Config) (string, error) {
+		stsCalls++
+		return "1234567890", nil
+	}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--regions", "us-east-1",
+		"--from-manifest", manifestPath,
+		"--output-dir", outDir,
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if stsCalls != 0 {
+		t.Errorf("getAccount called %d times; --from-manifest with populated AccountID must skip STS", stsCalls)
+	}
+}
+
+// TestRunDiscoverWithDeps_FromManifestEmptyAccountIDStillCallsSTS pins
+// the optimization's correctness fallback: any resource missing
+// Identity.AccountID forces the STS call so the downstream depchase
+// loop has a non-empty account ID for ARN reconstruction.
+func TestRunDiscoverWithDeps_FromManifestEmptyAccountIDStillCallsSTS(t *testing.T) {
+	t.Parallel()
+	manifestDir := t.TempDir()
+	r := validResourceWithRegion("aws_sqs_queue.alpha", "us-east-1", "")
+	manifestPath := writeFixtureManifest(t, manifestDir, "aws",
+		[]imported.ImportedResource{r})
+
+	outDir := t.TempDir()
+	agg := &fakeAggregator{}
+	stsCalls := 0
+	deps := okDeps(agg)
+	deps.getAccount = func(_ context.Context, _ aws.Config) (string, error) {
+		stsCalls++
+		return "1234567890", nil
+	}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--regions", "us-east-1",
+		"--from-manifest", manifestPath,
+		"--output-dir", outDir,
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if stsCalls != 1 {
+		t.Errorf("getAccount called %d times; missing AccountID must force exactly 1 STS call", stsCalls)
+	}
+}
+
+// TestRunDiscoverWithDeps_FromManifestWithResourceTypesIsFatal pins the
+// mutual-exclusion gate: --from-manifest is incompatible with
+// --resource-types because the manifest is already type-filtered.
+// The stderr substring keeps the operator-facing guidance specific.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_FromManifestWithResourceTypesIsFatal(t *testing.T) {
+	manifestDir := t.TempDir()
+	manifestPath := writeFixtureManifest(t, manifestDir, "aws",
+		[]imported.ImportedResource{validResourceWithRegion("aws_sqs_queue.alpha", "us-east-1", "1234567890")})
+
+	outDir := t.TempDir()
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--from-manifest", manifestPath,
+			"--resource-types", "aws_sqs_queue",
+			"--output-dir", outDir,
+		}, okDeps(&fakeAggregator{}))
+	})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+	if !strings.Contains(stderr, "--resource-types") || !strings.Contains(stderr, "--from-manifest") {
+		t.Errorf("stderr must name both flags in the conflict message; got: %s", stderr)
+	}
+}
+
+// TestRunDiscoverWithDeps_ResourceIDsWithoutFromManifestIsFatal pins the
+// dependency direction: --resource-ids only makes sense in the
+// --from-manifest context (a fresh discover run lists every matching
+// resource by definition). Set without the parent and the CLI exits
+// fatal rather than silently ignoring the filter.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_ResourceIDsWithoutFromManifestIsFatal(t *testing.T) {
+	outDir := t.TempDir()
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--resource-ids", "id-alpha",
+			"--output-dir", outDir,
+		}, okDeps(&fakeAggregator{}))
+	})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+	if !strings.Contains(stderr, "--resource-ids") || !strings.Contains(stderr, "--from-manifest") {
+		t.Errorf("stderr must name both flags in the requirement message; got: %s", stderr)
+	}
+}
+
+// TestRunDiscoverWithDeps_FromManifestDerivesPrimaryRegionFromManifest
+// pins that --from-manifest can satisfy the AWS-region requirement on
+// its own: when --regions is empty, primaryRegion is taken from the
+// loaded manifest's first resource's Identity.Region. Threaded into
+// loadConfig + genconfig so Stage 2b operates on the same region the
+// resources were originally discovered in.
+func TestRunDiscoverWithDeps_FromManifestDerivesPrimaryRegionFromManifest(t *testing.T) {
+	t.Parallel()
+	manifestDir := t.TempDir()
+	manifestPath := writeFixtureManifest(t, manifestDir, "aws",
+		[]imported.ImportedResource{validResourceWithRegion("aws_sqs_queue.alpha", "eu-west-1", "1234567890")})
+
+	outDir := t.TempDir()
+	gc := &fakeGenconfig{}
+	var loadRegion string
+	deps := okDepsWithGC(&fakeAggregator{}, gc)
+	deps.loadConfig = func(_ context.Context, region, _ string) (aws.Config, error) {
+		loadRegion = region
+		return aws.Config{}, nil
+	}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--from-manifest", manifestPath,
+		"--output-dir", outDir,
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if loadRegion != "eu-west-1" {
+		t.Errorf("loadConfig region=%q, want eu-west-1 (derived from manifest Identity.Region)", loadRegion)
+	}
+	if gc.gotOpts.Region != "eu-west-1" {
+		t.Errorf("genconfig Region=%q, want eu-west-1 (threaded primaryRegion)", gc.gotOpts.Region)
 	}
 }
 

--- a/cmd/insideout-import/manifest.go
+++ b/cmd/insideout-import/manifest.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,6 +57,56 @@ func writeManifest(dir, cloud string, resources []imported.ImportedResource) (st
 		return "", 0, fmt.Errorf("write %s: %w", out, err)
 	}
 	return out, len(resources), nil
+}
+
+// readManifest reads <path> from disk, decodes the JSON array of
+// ImportedResource, and re-runs the same composer.ValidateImportedResources
+// gate that writeManifest applied before persisting. It is the inverse of
+// writeManifest, intended for the --from-manifest re-import path (#292) so a
+// previously-discovered set can be replayed through Stage 2b/2c without
+// re-walking the cloud.
+//
+// On malformed JSON the error includes the byte offset surfaced by
+// json.SyntaxError / json.UnmarshalTypeError so an operator editing the
+// file by hand can jump to the failing position. A literal `null` top-level
+// is rejected explicitly: writeManifest's invariant is that an empty
+// resource set serializes as `[]`, never `null`, and downstream consumers
+// (Reliable, Riley, the depchase loop) cannot range over null.
+//
+// Returns ([]ImportedResource, nil) on success — never a nil slice with no
+// error: an empty manifest decodes to a zero-length slice.
+func readManifest(path, cloud string) ([]imported.ImportedResource, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Reject literal "null" before json.Unmarshal — Unmarshal of "null"
+	// into a slice succeeds with a nil slice, which would silently pass
+	// validation (validator returns nil on empty input). Explicit error
+	// references the wire-shape contract that writeManifest enforces.
+	if bytes.Equal(bytes.TrimSpace(body), []byte("null")) {
+		return nil, fmt.Errorf("manifest %s: top-level JSON `null` is not a valid manifest (writeManifest emits `[]` for empty input; refusing to treat null as empty)", path)
+	}
+
+	var resources []imported.ImportedResource
+	if err := json.Unmarshal(body, &resources); err != nil {
+		var syntaxErr *json.SyntaxError
+		var typeErr *json.UnmarshalTypeError
+		switch {
+		case errors.As(err, &syntaxErr):
+			return nil, fmt.Errorf("manifest %s: JSON syntax error at byte offset %d: %w", path, syntaxErr.Offset, err)
+		case errors.As(err, &typeErr):
+			return nil, fmt.Errorf("manifest %s: JSON type mismatch at byte offset %d (field %q, expected %s, got %s): %w", path, typeErr.Offset, typeErr.Field, typeErr.Type, typeErr.Value, err)
+		default:
+			return nil, fmt.Errorf("manifest %s: decode: %w", path, err)
+		}
+	}
+
+	if issues := composer.ValidateImportedResources(cloud, resources); len(issues) > 0 {
+		return nil, fmt.Errorf("manifest validation failed (%d issue(s)): %s", len(issues), formatIssues(issues))
+	}
+	return resources, nil
 }
 
 // formatIssues turns a slice of validation issues into a multi-line string

--- a/cmd/insideout-import/manifest_test.go
+++ b/cmd/insideout-import/manifest_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -137,6 +138,130 @@ func TestWriteManifest_AddressCollisionDetectedByValidator(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "imported_resource_address_collision") {
 		t.Errorf("expected address-collision code; got: %v", err)
+	}
+}
+
+// readManifest is the inverse of writeManifest: writes-then-reads round
+// trip pins the wire-shape contract end-to-end. A regression that drops
+// the validator (or runs only one direction) would still pass the
+// individual write/read tests but fail this one.
+func TestReadManifest_HappyPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	want := []imported.ImportedResource{
+		validIR("aws_sqs_queue", "aws_sqs_queue.b", "https://example/b"),
+		validIR("aws_sqs_queue", "aws_sqs_queue.a", "https://example/a"),
+	}
+	path, _, err := writeManifest(dir, "aws", want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := readManifest(path, "aws")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+	// writeManifest sorts by Address, so the round-trip yields the
+	// sorted order regardless of input order.
+	if got[0].Identity.Address != "aws_sqs_queue.a" || got[1].Identity.Address != "aws_sqs_queue.b" {
+		t.Errorf("addresses=%q,%q want a,b (sort preserved through round-trip)",
+			got[0].Identity.Address, got[1].Identity.Address)
+	}
+}
+
+// TestReadManifest_MalformedJSONIncludesOffset pins that a syntactically
+// invalid manifest surfaces a json.SyntaxError offset in the error message.
+// Operators editing the file by hand need a position pointer; without it
+// the only recourse is bisection.
+func TestReadManifest_MalformedJSONIncludesOffset(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "imported.json")
+	if err := os.WriteFile(path, []byte("{ not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := readManifest(path, "aws")
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	// Either "offset" or "position" — the assertion is loose to permit a
+	// future swap to wrap a different error type as long as the position
+	// pointer survives. Asserting an offset substring keeps the contract
+	// human-debuggable without pinning the literal phrasing.
+	msg := err.Error()
+	if !strings.Contains(msg, "offset") && !strings.Contains(msg, "position") {
+		t.Errorf("error must include byte-offset/position hint; got: %v", err)
+	}
+}
+
+func TestReadManifest_MissingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, err := readManifest(filepath.Join(dir, "does-not-exist.json"), "aws")
+	if err == nil {
+		t.Fatal("expected ENOENT-shaped error")
+	}
+	// Either errors.Is(err, os.ErrNotExist) (preferred — preserves the
+	// sentinel chain when readManifest wraps) or the substring fallback
+	// for a future refactor that wraps with %v rather than %w.
+	if !os.IsNotExist(err) && !errors.Is(err, os.ErrNotExist) && !strings.Contains(err.Error(), "no such file") {
+		t.Errorf("error must wrap ErrNotExist or mention missing file; got: %v", err)
+	}
+}
+
+// TestReadManifest_NullTopLevelRejected pins the writeManifest invariant:
+// an empty manifest is `[]`, never `null`. Decoding `null` into a slice
+// succeeds with a nil slice (validator returns nil → silent pass), so the
+// reader must reject `null` explicitly.
+func TestReadManifest_NullTopLevelRejected(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "imported.json")
+	if err := os.WriteFile(path, []byte("null\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := readManifest(path, "aws")
+	if err == nil {
+		t.Fatal("expected null-top-level error; readManifest must not silently treat null as empty")
+	}
+	if !strings.Contains(err.Error(), "null") {
+		t.Errorf("error must reference the null contract; got: %v", err)
+	}
+}
+
+// TestReadManifest_ValidatorFailureSurfacesIssueCode pins that
+// readManifest reuses composer.ValidateImportedResources — the same
+// gate writeManifest applies — so a tampered manifest can't slip past.
+// The issue-code substring keeps the error operator-actionable.
+func TestReadManifest_ValidatorFailureSurfacesIssueCode(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bad := []imported.ImportedResource{
+		// Missing ImportID — same shape as
+		// TestWriteManifest_ValidatorFailureNoFileWritten but read-side.
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.bad"},
+			Tier:     imported.TierImportedFlat,
+			Source:   imported.SourceImporter,
+		},
+	}
+	body, err := json.MarshalIndent(bad, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body = append(body, '\n')
+	path := filepath.Join(dir, "imported.json")
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, rerr := readManifest(path, "aws")
+	if rerr == nil {
+		t.Fatal("expected validator error")
+	}
+	if !strings.Contains(rerr.Error(), "imported_resource_missing_import_id") {
+		t.Errorf("expected error to mention missing-import-id code; got: %v", rerr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `--from-manifest <path>` and `--resource-ids id1,id2,...` to `insideout-import discover`, replacing Stage 2a (cloud walk) with a manifest-driven resource set so the wizard's apply step can re-emit `generated.tf` for a previously-discovered subset without re-scanning the cloud.
- Skips the STS `GetCallerIdentity` round-trip when every loaded resource has `Identity.AccountID` populated; falls back to the call when any resource is missing it. Builds the cloud config + discoverer in both branches — Stage 2c3 (depchase) and Stage 2b/2c1 still need them.
- New `readManifest` mirrors `writeManifest`: same validator gate, same `[]`-not-`null` wire-shape contract. JSON syntax errors include a byte-offset hint; literal `null` top-level is rejected explicitly.

## Design notes

- `--resource-types` is rejected with `--from-manifest` (the manifest is already type-filtered); `--resource-ids` requires `--from-manifest`. Both mutual-exclusion errors name both flag literals in stderr so the wizard's error UX can render them verbatim.
- Unknown IDs in `--resource-ids` are a fatal error listing every offending id (sorted) — operators don't get a silent drop, which would surprise the wizard's apply path.
- `--from-manifest` defers the AWS-region requirement: `primaryRegion` derives from the loaded manifest's first non-empty `Identity.Region` if `--regions` is omitted, so the wizard payload doesn't need to duplicate region data.

## Closes

Closes #292
Part of #289 (Bundle 1 / PR 3)

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/insideout-import/... ./pkg/composer/... -count=1` (1829 passing including 12 new)
- [x] `go vet ./...`, `gofmt -l cmd/ pkg/` clean
- [x] All eight static lint scripts pass (project-tag, project-label, sensitive-for-each, foreach-unknown-keys, no-root-only-blocks, shared-no-cloud-providers, labelless-name-prefix, gcp-project-pin)
- [ ] CI green