### PR TITLE
feat(insideout-import): streaming progress events via --progress=json (#295)

### DIFF
--- a/cmd/insideout-import/awsdiscover/args.go
+++ b/cmd/insideout-import/awsdiscover/args.go
@@ -1,5 +1,7 @@
 package awsdiscover
 
+import "github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+
 // DiscoverArgs is the per-call input shape consumed by the aggregator's
 // DiscoverTypes and every per-service Discoverer.Discover. Bundling the
 // inputs into a struct (instead of positional args) keeps the per-service
@@ -14,6 +16,11 @@ package awsdiscover
 // AccountID (one STS GetCallerIdentity per run, threaded through so
 // per-service code can stamp Identity.AccountID without re-deriving).
 //
+// Emitter (#295) carries the streaming-progress sink. Per-service code
+// always calls methods on a non-nil Emitter; the aggregator resolves a
+// nil Emitter to progress.NopEmitter{} once at the top of DiscoverTypes
+// so per-service code never has to nil-check.
+//
 // DiscoverArgs is intentionally NOT exported via pkg/insideout-import/...
 // — it lives in the cloud-specific aggregator package so the public
 // registry surface stays dep-free for downstream consumers (reliable
@@ -23,6 +30,7 @@ type DiscoverArgs struct {
 	Regions      []string
 	TagSelectors []TagSelector
 	AccountID    string
+	Emitter      progress.Emitter
 }
 
 // TagSelector is a single operator-supplied tag-equality clause. The
@@ -62,4 +70,18 @@ func MatchesAll(tags map[string]string, selectors []TagSelector) bool {
 		}
 	}
 	return true
+}
+
+// emitterOrNop returns args.Emitter when non-nil, otherwise a NopEmitter
+// (#295). Per-service Discover bodies call this once at the top to avoid
+// nil-checking in every emit call site. The aggregator
+// (AWSDiscoverer.DiscoverTypes) already defaults a nil Emitter to NopEmitter
+// before fanning out, but per-service unit tests construct DiscoverArgs
+// directly and won't go through the aggregator — without this fallback
+// every existing test would have to set Emitter explicitly.
+func emitterOrNop(e progress.Emitter) progress.Emitter {
+	if e == nil {
+		return progress.NopEmitter{}
+	}
+	return e
 }

--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -21,9 +21,11 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
@@ -135,6 +137,39 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 	}
 }
 
+// serviceSlugByTFType maps a Terraform resource type to the short,
+// stable progress-event service slug (#295). The slug appears in the
+// `service` field of every progress.Event emitted by the per-service
+// discoverer; downstream consumers (reliable agent-API SSE translator)
+// pivot UI rows on these strings, so they're locked here as a single
+// source of truth. The names match the package directory / file
+// convention already used in this package (sqs.go, dynamodb.go,
+// cloudwatchlogs.go, etc.) so a regression that switches a per-service
+// file's slug will diverge from the file name and be obvious in review.
+var serviceSlugByTFType = map[string]string{
+	"aws_sqs_queue":             "sqs",
+	"aws_dynamodb_table":        "dynamodb",
+	"aws_cloudwatch_log_group":  "cloudwatchlogs",
+	"aws_secretsmanager_secret": "secretsmanager",
+	"aws_lambda_function":       "lambda",
+	"aws_iam_role":              "iam_role",
+	"aws_iam_policy":            "iam_policy",
+	"aws_kms_key":               "kms",
+	"aws_s3_bucket":             "s3",
+}
+
+// ServiceSlug returns the progress-event slug for a Terraform resource
+// type, falling back to the type itself when no slug is registered.
+// Falling back (rather than panicking) keeps the Emitter safe to call
+// from any Discoverer, including test-only ones a future contributor
+// might register without updating the slug map.
+func ServiceSlug(tfType string) string {
+	if s, ok := serviceSlugByTFType[tfType]; ok {
+		return s
+	}
+	return tfType
+}
+
 // SupportedTypes returns the registered Terraform types in lexicographic
 // order. Used by the CLI for default --resource-types and validation.
 func (a *AWSDiscoverer) SupportedTypes() []string {
@@ -184,6 +219,12 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	if len(args.Regions) == 0 {
 		args.Regions = []string{a.defaultRegion}
 	}
+	// Resolve a nil Emitter once here so per-service Discover bodies
+	// can call args.Emitter.* unconditionally. The progress package's
+	// NopEmitter is zero-overhead.
+	if args.Emitter == nil {
+		args.Emitter = progress.NopEmitter{}
+	}
 
 	var unknown []string
 	selected := make([]Discoverer, 0, len(types))
@@ -199,6 +240,7 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 		return nil, fmt.Errorf("unknown resource type(s): %v (supported: %v)", unknown, a.SupportedTypes())
 	}
 
+	stageStart := time.Now()
 	var all []imported.ImportedResource
 	for _, d := range selected {
 		entries, err := d.Discover(ctx, args)
@@ -207,5 +249,6 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 		}
 		all = append(all, entries...)
 	}
+	args.Emitter.StageFinish("discover", len(all), time.Since(stageStart))
 	return all, nil
 }

--- a/cmd/insideout-import/awsdiscover/cloudwatchlogs.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatchlogs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -49,10 +50,15 @@ func (d *cwlDiscoverer) ResourceType() string { return "aws_cloudwatch_log_group
 //
 // Import ID for aws_cloudwatch_log_group is the log group name.
 func (d *cwlDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
 	book := addressBook{}
+	const slug = "cloudwatchlogs"
 	var imps []imported.ImportedResource
 
 	for _, region := range args.Regions {
+		regionStart := time.Now()
+		args.Emitter.ServiceStart(slug, region)
+		regionCount := 0
 		client := d.new(region)
 		input := &cloudwatchlogs.DescribeLogGroupsInput{}
 		if args.Project != "" {
@@ -69,6 +75,7 @@ func (d *cwlDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]impo
 		for {
 			out, err := client.DescribeLogGroups(ctx, input)
 			if err != nil {
+				args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 				return nil, fmt.Errorf("DescribeLogGroups (region=%s): %w", region, err)
 			}
 			for _, lg := range out.LogGroups {
@@ -92,6 +99,7 @@ func (d *cwlDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]impo
 			tagARN := strings.TrimSuffix(g.arn, ":*")
 			tags, err := fetchCWLTags(ctx, client, tagARN)
 			if err != nil {
+				args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 				return nil, fmt.Errorf("ListTagsForResource (region=%s, log_group=%s): %w", region, g.name, err)
 			}
 			if !MatchesAll(tags, args.TagSelectors) {
@@ -107,7 +115,10 @@ func (d *cwlDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]impo
 				map[string]string{"arn": g.arn},
 				tags,
 			))
+			args.Emitter.ItemFound(slug, region, "aws_cloudwatch_log_group", g.name)
+			regionCount++
 		}
+		args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 	}
 	return imps, nil
 }

--- a/cmd/insideout-import/awsdiscover/dynamodb.go
+++ b/cmd/insideout-import/awsdiscover/dynamodb.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -68,9 +69,14 @@ func (d *dynamoDiscoverer) ResourceType() string { return "aws_dynamodb_table" }
 //
 // Import ID for aws_dynamodb_table is the table name.
 func (d *dynamoDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
 	book := addressBook{}
+	const slug = "dynamodb"
 	var imps []imported.ImportedResource
 	for _, region := range args.Regions {
+		regionStart := time.Now()
+		args.Emitter.ServiceStart(slug, region)
+		regionCount := 0
 		client := d.new(region)
 
 		var all []string
@@ -78,6 +84,7 @@ func (d *dynamoDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]i
 		for {
 			out, err := client.ListTables(ctx, input)
 			if err != nil {
+				args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 				return nil, fmt.Errorf("ListTables (region=%s): %w", region, err)
 			}
 			for _, t := range out.TableNames {
@@ -141,6 +148,7 @@ func (d *dynamoDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]i
 				})
 			}
 			if err := g.Wait(); err != nil {
+				args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 				return nil, fmt.Errorf("ListTagsOfResource (region=%s): %w", region, err)
 			}
 			entries = ok
@@ -175,7 +183,10 @@ func (d *dynamoDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]i
 				map[string]string{"arn": arn},
 				e.tags,
 			))
+			args.Emitter.ItemFound(slug, region, "aws_dynamodb_table", e.name)
+			regionCount++
 		}
+		args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 	}
 	return imps, nil
 }

--- a/cmd/insideout-import/awsdiscover/dynamodb_test.go
+++ b/cmd/insideout-import/awsdiscover/dynamodb_test.go
@@ -441,6 +441,117 @@ func TestDynamoDBDiscoverByID_NotFound(t *testing.T) {
 	}
 }
 
+// TestDynamoDBDiscover_EmitsServiceStartFinish_PerRegion (#295) is the
+// dynamodb mirror of TestSQSDiscover_EmitsServiceStartFinish_PerRegion.
+// DynamoDB is the most operationally significant per-service emitter test
+// because the discoverer fans out per-table tag fetches under an
+// errgroup — concurrent ItemFound emits race with one another, and the
+// progress.JSONEmitter mutex is the only thing keeping the on-the-wire
+// output line-safe. Asserting the per-region brackets here keeps that
+// path covered by a unit test (the live race-detector run on
+// progress.JSONEmitter covers the line-safety side).
+func TestDynamoDBDiscover_EmitsServiceStartFinish_PerRegion(t *testing.T) {
+	t.Parallel()
+	fakes := map[string]*fakeDynamoClient{
+		"us-east-1": {
+			pages: []dynamodb.ListTablesOutput{{TableNames: []string{"io-foo-east"}}},
+			tagsByID: map[string][]dynamotypes.Tag{
+				"arn:aws:dynamodb:us-east-1:123:table/io-foo-east": {tagPair("Project", "io-foo")},
+			},
+		},
+		"eu-west-1": {
+			pages: []dynamodb.ListTablesOutput{{TableNames: []string{"io-foo-west"}}},
+			tagsByID: map[string][]dynamotypes.Tag{
+				"arn:aws:dynamodb:eu-west-1:123:table/io-foo-west": {tagPair("Project", "io-foo")},
+			},
+		},
+	}
+	d := &dynamoDiscoverer{new: func(region string) dynamoClient { return fakes[region] }, maxConcurrency: 4}
+	rec := &recordingEmitter{}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	starts := map[string]int{}
+	finishes := map[string]int{}
+	for _, e := range rec.snapshot() {
+		switch e.Kind {
+		case "service_start":
+			if e.Service != "dynamodb" {
+				t.Errorf("service_start.service=%q, want dynamodb", e.Service)
+			}
+			starts[e.Region]++
+		case "service_finish":
+			if e.Service != "dynamodb" {
+				t.Errorf("service_finish.service=%q, want dynamodb", e.Service)
+			}
+			finishes[e.Region]++
+		}
+	}
+	for _, region := range []string{"us-east-1", "eu-west-1"} {
+		if starts[region] != 1 {
+			t.Errorf("region=%s: service_start count=%d, want 1", region, starts[region])
+		}
+		if finishes[region] != 1 {
+			t.Errorf("region=%s: service_finish count=%d, want 1", region, finishes[region])
+		}
+	}
+}
+
+// TestDynamoDBDiscover_EmitsItemFound_PerTable (#295) pins one
+// item_found per emitted ImportedResource. Tables that fail the
+// Project=<project> back-compat tag check (TestDynamoDBDiscover_PrefixThenTagFilter
+// pattern) must not emit item_found.
+func TestDynamoDBDiscover_EmitsItemFound_PerTable(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDynamoClient{
+		pages: []dynamodb.ListTablesOutput{
+			{TableNames: []string{"io-foo-a", "io-foo-b", "io-foo-untagged"}},
+		},
+		tagsByID: map[string][]dynamotypes.Tag{
+			"arn:aws:dynamodb:us-east-1:123:table/io-foo-a":        {tagPair("Project", "io-foo")},
+			"arn:aws:dynamodb:us-east-1:123:table/io-foo-b":        {tagPair("Project", "io-foo")},
+			"arn:aws:dynamodb:us-east-1:123:table/io-foo-untagged": {tagPair("Owner", "team")},
+		},
+	}
+	d := &dynamoDiscoverer{new: func(_ string) dynamoClient { return fake }, maxConcurrency: 4}
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var items []recordedEvent
+	for _, e := range rec.snapshot() {
+		if e.Kind == "item_found" {
+			items = append(items, e)
+		}
+	}
+	if len(items) != len(got) {
+		t.Errorf("item_found count=%d, want %d (one per emitted resource)", len(items), len(got))
+	}
+	wantNames := map[string]bool{"io-foo-a": true, "io-foo-b": true}
+	for _, it := range items {
+		if it.Service != "dynamodb" {
+			t.Errorf("item.service=%q, want dynamodb", it.Service)
+		}
+		if it.TFType != "aws_dynamodb_table" {
+			t.Errorf("item.tf_type=%q, want aws_dynamodb_table", it.TFType)
+		}
+		if !wantNames[it.ImportID] {
+			t.Errorf("item.import_id=%q not in expected set", it.ImportID)
+		}
+	}
+}
+
 func TestDynamoDBDiscoverByID_UnsupportedID(t *testing.T) {
 	t.Parallel()
 	d := &dynamoDiscoverer{new: func(_ string) dynamoClient { return &fakeDynamoClient{} }}

--- a/cmd/insideout-import/awsdiscover/iam_policy.go
+++ b/cmd/insideout-import/awsdiscover/iam_policy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -53,6 +54,11 @@ func (d *iamPolicyDiscoverer) ResourceType() string { return "aws_iam_policy" }
 //
 // Import ID for aws_iam_policy is the policy ARN.
 func (d *iamPolicyDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
+	const slug = "iam_policy"
+	regionStart := time.Now()
+	args.Emitter.ServiceStart(slug, "")
+	regionCount := 0
 	client := d.new("")
 
 	type policy struct {
@@ -67,6 +73,7 @@ func (d *iamPolicyDiscoverer) Discover(ctx context.Context, args DiscoverArgs) (
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
+			args.Emitter.ServiceFinish(slug, "", regionCount, time.Since(regionStart))
 			return nil, fmt.Errorf("ListPolicies: %w", err)
 		}
 		for _, p := range page.Policies {
@@ -85,6 +92,7 @@ func (d *iamPolicyDiscoverer) Discover(ctx context.Context, args DiscoverArgs) (
 	for _, p := range policies {
 		tags, err := fetchIAMPolicyTags(ctx, client, p.arn)
 		if err != nil {
+			args.Emitter.ServiceFinish(slug, "", regionCount, time.Since(regionStart))
 			return nil, fmt.Errorf("ListPolicyTags (policy=%s): %w", p.name, err)
 		}
 		if !MatchesAll(tags, args.TagSelectors) {
@@ -100,7 +108,10 @@ func (d *iamPolicyDiscoverer) Discover(ctx context.Context, args DiscoverArgs) (
 			map[string]string{"arn": p.arn},
 			tags,
 		))
+		args.Emitter.ItemFound(slug, "", "aws_iam_policy", p.arn)
+		regionCount++
 	}
+	args.Emitter.ServiceFinish(slug, "", regionCount, time.Since(regionStart))
 	return imps, nil
 }
 

--- a/cmd/insideout-import/awsdiscover/iam_role.go
+++ b/cmd/insideout-import/awsdiscover/iam_role.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -51,6 +52,14 @@ func (d *iamRoleDiscoverer) ResourceType() string { return "aws_iam_role" }
 //
 // Import ID for aws_iam_role is the role name.
 func (d *iamRoleDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
+	const slug = "iam_role"
+	// IAM is account-global; emit a single (svc,"") scope per run. Empty
+	// region in the event matches the empty Identity.Region the per-role
+	// stamp uses.
+	regionStart := time.Now()
+	args.Emitter.ServiceStart(slug, "")
+	regionCount := 0
 	client := d.new("")
 
 	type role struct {
@@ -63,6 +72,7 @@ func (d *iamRoleDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
+			args.Emitter.ServiceFinish(slug, "", regionCount, time.Since(regionStart))
 			return nil, fmt.Errorf("ListRoles: %w", err)
 		}
 		for _, r := range page.Roles {
@@ -81,6 +91,7 @@ func (d *iamRoleDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]
 	for _, r := range roles {
 		tags, err := fetchIAMRoleTags(ctx, client, r.name)
 		if err != nil {
+			args.Emitter.ServiceFinish(slug, "", regionCount, time.Since(regionStart))
 			return nil, fmt.Errorf("ListRoleTags (role=%s): %w", r.name, err)
 		}
 		if !MatchesAll(tags, args.TagSelectors) {
@@ -96,7 +107,10 @@ func (d *iamRoleDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]
 			map[string]string{"arn": r.arn},
 			tags,
 		))
+		args.Emitter.ItemFound(slug, "", "aws_iam_role", r.name)
+		regionCount++
 	}
+	args.Emitter.ServiceFinish(slug, "", regionCount, time.Since(regionStart))
 	return imps, nil
 }
 

--- a/cmd/insideout-import/awsdiscover/kms.go
+++ b/cmd/insideout-import/awsdiscover/kms.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -58,10 +59,15 @@ func (d *kmsDiscoverer) ResourceType() string { return "aws_kms_key" }
 // Import ID for aws_kms_key is the key UUID (from the alias's
 // TargetKeyId).
 func (d *kmsDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
 	book := addressBook{}
+	const slug = "kms"
 	var imps []imported.ImportedResource
 
 	for _, region := range args.Regions {
+		regionStart := time.Now()
+		args.Emitter.ServiceStart(slug, region)
+		regionCount := 0
 		client := d.new(region)
 
 		type key struct {
@@ -74,6 +80,7 @@ func (d *kmsDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]impo
 		for paginator.HasMorePages() {
 			page, err := paginator.NextPage(ctx)
 			if err != nil {
+				args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 				return nil, fmt.Errorf("ListAliases (region=%s): %w", region, err)
 			}
 			for _, a := range page.Aliases {
@@ -104,6 +111,7 @@ func (d *kmsDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]impo
 		for _, k := range keys {
 			tags, err := fetchKMSTags(ctx, client, k.uuid)
 			if err != nil {
+				args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 				return nil, fmt.Errorf("ListResourceTags (region=%s, key=%s): %w", region, k.uuid, err)
 			}
 			if !MatchesAll(tags, args.TagSelectors) {
@@ -126,7 +134,10 @@ func (d *kmsDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]impo
 				map[string]string{"arn": arn, "alias": k.alias},
 				tags,
 			))
+			args.Emitter.ItemFound(slug, region, "aws_kms_key", k.uuid)
+			regionCount++
 		}
+		args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 	}
 	return imps, nil
 }

--- a/cmd/insideout-import/awsdiscover/lambda.go
+++ b/cmd/insideout-import/awsdiscover/lambda.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -69,10 +70,15 @@ func (d *lambdaDiscoverer) ResourceType() string { return "aws_lambda_function" 
 //
 // Import ID for aws_lambda_function is the function name.
 func (d *lambdaDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
 	book := addressBook{}
+	const slug = "lambda"
 	var out []imported.ImportedResource
 
 	for _, region := range args.Regions {
+		regionStart := time.Now()
+		args.Emitter.ServiceStart(slug, region)
+		regionCount := 0
 		client := d.new(region)
 
 		type fn struct {
@@ -86,6 +92,7 @@ func (d *lambdaDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]i
 		for paginator.HasMorePages() {
 			page, err := paginator.NextPage(ctx)
 			if err != nil {
+				args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 				return nil, fmt.Errorf("ListFunctions (region=%s): %w", region, err)
 			}
 			for _, f := range page.Functions {
@@ -136,6 +143,7 @@ func (d *lambdaDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]i
 			})
 		}
 		if err := g.Wait(); err != nil {
+			args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 			return nil, fmt.Errorf("ListTags (region=%s): %w", region, err)
 		}
 
@@ -159,7 +167,10 @@ func (d *lambdaDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]i
 				map[string]string{"arn": f.arn},
 				f.tags,
 			))
+			args.Emitter.ItemFound(slug, region, "aws_lambda_function", f.name)
+			regionCount++
 		}
+		args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 	}
 	return out, nil
 }

--- a/cmd/insideout-import/awsdiscover/s3.go
+++ b/cmd/insideout-import/awsdiscover/s3.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -56,13 +57,19 @@ func (d *s3Discoverer) ResourceType() string { return "aws_s3_bucket" }
 //
 // Import ID for aws_s3_bucket is the bucket name.
 func (d *s3Discoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
+	const slug = "s3"
 	stampRegion := ""
 	if len(args.Regions) > 0 {
 		stampRegion = args.Regions[0]
 	}
+	regionStart := time.Now()
+	args.Emitter.ServiceStart(slug, stampRegion)
+	regionCount := 0
 	client := d.new(stampRegion)
 	out, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
 	if err != nil {
+		args.Emitter.ServiceFinish(slug, stampRegion, regionCount, time.Since(regionStart))
 		return nil, fmt.Errorf("ListBuckets: %w", err)
 	}
 
@@ -81,6 +88,7 @@ func (d *s3Discoverer) Discover(ctx context.Context, args DiscoverArgs) ([]impor
 	for _, name := range names {
 		tags, err := fetchS3BucketTags(ctx, client, name)
 		if err != nil {
+			args.Emitter.ServiceFinish(slug, stampRegion, regionCount, time.Since(regionStart))
 			return nil, fmt.Errorf("GetBucketTagging (bucket=%s): %w", name, err)
 		}
 		if !MatchesAll(tags, args.TagSelectors) {
@@ -97,7 +105,10 @@ func (d *s3Discoverer) Discover(ctx context.Context, args DiscoverArgs) ([]impor
 			map[string]string{"arn": arn},
 			tags,
 		))
+		args.Emitter.ItemFound(slug, stampRegion, "aws_s3_bucket", name)
+		regionCount++
 	}
+	args.Emitter.ServiceFinish(slug, stampRegion, regionCount, time.Since(regionStart))
 	return imps, nil
 }
 

--- a/cmd/insideout-import/awsdiscover/secretsmanager.go
+++ b/cmd/insideout-import/awsdiscover/secretsmanager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -48,10 +49,15 @@ func (d *secretsManagerDiscoverer) ResourceType() string { return "aws_secretsma
 //
 // Import ID for aws_secretsmanager_secret is the secret ARN.
 func (d *secretsManagerDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
 	book := addressBook{}
+	const slug = "secretsmanager"
 	var imps []imported.ImportedResource
 
 	for _, region := range args.Regions {
+		regionStart := time.Now()
+		args.Emitter.ServiceStart(slug, region)
+		regionCount := 0
 		client := d.new(region)
 		input := &secretsmanager.ListSecretsInput{}
 		if args.Project != "" {
@@ -77,6 +83,7 @@ func (d *secretsManagerDiscoverer) Discover(ctx context.Context, args DiscoverAr
 		for {
 			out, err := client.ListSecrets(ctx, input)
 			if err != nil {
+				args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 				return nil, fmt.Errorf("ListSecrets (region=%s): %w", region, err)
 			}
 			for _, s := range out.SecretList {
@@ -112,7 +119,10 @@ func (d *secretsManagerDiscoverer) Discover(ctx context.Context, args DiscoverAr
 				map[string]string{"arn": s.arn},
 				s.tags,
 			))
+			args.Emitter.ItemFound(slug, region, "aws_secretsmanager_secret", s.arn)
+			regionCount++
 		}
+		args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 	}
 	return imps, nil
 }

--- a/cmd/insideout-import/awsdiscover/sqs.go
+++ b/cmd/insideout-import/awsdiscover/sqs.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -51,9 +52,14 @@ func (d *sqsDiscoverer) ResourceType() string { return "aws_sqs_queue" }
 //
 // Import ID for aws_sqs_queue is the queue URL itself.
 func (d *sqsDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
 	book := addressBook{}
+	const slug = "sqs"
 	var out []imported.ImportedResource
 	for _, region := range args.Regions {
+		regionStart := time.Now()
+		args.Emitter.ServiceStart(slug, region)
+		regionCount := 0
 		client := d.new(region)
 		input := &sqs.ListQueuesInput{}
 		if args.Project != "" {
@@ -63,6 +69,7 @@ func (d *sqsDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]impo
 
 		urls, err := paginateListQueues(ctx, client, input)
 		if err != nil {
+			args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 			return nil, fmt.Errorf("ListQueues (region=%s): %w", region, err)
 		}
 
@@ -75,6 +82,7 @@ func (d *sqsDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]impo
 			name := path.Base(url)
 			tags, err := fetchSQSTags(ctx, client, url)
 			if err != nil {
+				args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 				return nil, fmt.Errorf("ListQueueTags (region=%s, queue=%s): %w", region, name, err)
 			}
 			if !MatchesAll(tags, args.TagSelectors) {
@@ -90,7 +98,10 @@ func (d *sqsDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]impo
 				map[string]string{"url": url},
 				tags,
 			))
+			args.Emitter.ItemFound(slug, region, "aws_sqs_queue", url)
+			regionCount++
 		}
+		args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
 	}
 	return out, nil
 }

--- a/cmd/insideout-import/awsdiscover/sqs_test.go
+++ b/cmd/insideout-import/awsdiscover/sqs_test.go
@@ -320,6 +320,124 @@ func TestSQSDiscover_TagSelectorAppliedAsFilter(t *testing.T) {
 	}
 }
 
+// TestSQSDiscover_EmitsServiceStartFinish_PerRegion (#295) pins the
+// per-service progress contract: each region in args.Regions gets one
+// service_start + one service_finish event, in that order, with the
+// correct slug ("sqs") and region. A regression that emits at the
+// aggregator level instead of per-region — or skips Regions[1] — would
+// surface here as a missing or misordered event.
+func TestSQSDiscover_EmitsServiceStartFinish_PerRegion(t *testing.T) {
+	t.Parallel()
+	fakes := map[string]*fakeSQSClient{
+		"us-east-1": {
+			pages: []sqs.ListQueuesOutput{{QueueUrls: []string{"https://sqs.us-east-1.amazonaws.com/123/io-foo-east"}}},
+		},
+		"eu-west-1": {
+			pages: []sqs.ListQueuesOutput{{QueueUrls: []string{"https://sqs.eu-west-1.amazonaws.com/123/io-foo-west"}}},
+		},
+	}
+	d := &sqsDiscoverer{new: func(region string) sqsClient { return fakes[region] }}
+	rec := &recordingEmitter{}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	events := rec.snapshot()
+
+	// Pull out the service-scope brackets only.
+	type bracket struct{ start, finish int }
+	got := map[string]bracket{}
+	for i, e := range events {
+		switch e.Kind {
+		case "service_start":
+			b := got[e.Region]
+			b.start = i + 1 // +1 so zero-value disambiguates "not seen"
+			got[e.Region] = b
+		case "service_finish":
+			b := got[e.Region]
+			b.finish = i + 1
+			got[e.Region] = b
+		}
+		if e.Kind == "service_start" || e.Kind == "service_finish" {
+			if e.Service != "sqs" {
+				t.Errorf("event %d: service=%q, want sqs", i, e.Service)
+			}
+		}
+	}
+	if got["us-east-1"].start == 0 || got["us-east-1"].finish == 0 {
+		t.Errorf("us-east-1: missing service_start or service_finish: %+v", got["us-east-1"])
+	}
+	if got["eu-west-1"].start == 0 || got["eu-west-1"].finish == 0 {
+		t.Errorf("eu-west-1: missing service_start or service_finish: %+v", got["eu-west-1"])
+	}
+	if got["us-east-1"].start >= got["us-east-1"].finish {
+		t.Errorf("us-east-1: start at index %d >= finish at index %d", got["us-east-1"].start, got["us-east-1"].finish)
+	}
+}
+
+// TestSQSDiscover_EmitsItemFound_PerQueue (#295) pins that one
+// item_found event is emitted per emitted ImportedResource, carrying the
+// resource's TF type and import ID. A regression that emits one event
+// per ListQueues page (rather than per resolved queue) would surface
+// here as a count mismatch.
+func TestSQSDiscover_EmitsItemFound_PerQueue(t *testing.T) {
+	t.Parallel()
+	urls := []string{
+		"https://sqs.us-east-1.amazonaws.com/123/io-foo-a",
+		"https://sqs.us-east-1.amazonaws.com/123/io-foo-b",
+		"https://sqs.us-east-1.amazonaws.com/123/io-foo-c",
+	}
+	fake := &fakeSQSClient{
+		pages: []sqs.ListQueuesOutput{{QueueUrls: urls}},
+	}
+	d := &sqsDiscoverer{new: func(_ string) sqsClient { return fake }}
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var items []recordedEvent
+	for _, e := range rec.snapshot() {
+		if e.Kind == "item_found" {
+			items = append(items, e)
+		}
+	}
+	if len(items) != len(got) {
+		t.Errorf("item_found count = %d, want %d (one per emitted resource)", len(items), len(got))
+	}
+	wantIDs := map[string]bool{urls[0]: true, urls[1]: true, urls[2]: true}
+	for i, it := range items {
+		if it.Service != "sqs" {
+			t.Errorf("item %d: service=%q, want sqs", i, it.Service)
+		}
+		if it.Region != "us-east-1" {
+			t.Errorf("item %d: region=%q, want us-east-1", i, it.Region)
+		}
+		if it.TFType != "aws_sqs_queue" {
+			t.Errorf("item %d: tf_type=%q, want aws_sqs_queue", i, it.TFType)
+		}
+		if !wantIDs[it.ImportID] {
+			t.Errorf("item %d: import_id=%q not in expected URLs", i, it.ImportID)
+		}
+	}
+	// service_finish.count should match the number of items emitted.
+	for _, e := range rec.snapshot() {
+		if e.Kind == "service_finish" && e.Count != len(got) {
+			t.Errorf("service_finish.count=%d, want %d", e.Count, len(got))
+		}
+	}
+}
+
 func TestSQSDiscoverByID_UnsupportedID(t *testing.T) {
 	t.Parallel()
 	d := &sqsDiscoverer{new: func(_ string) sqsClient { return &fakeSQSClient{} }}

--- a/cmd/insideout-import/awsdiscover/testhelpers_test.go
+++ b/cmd/insideout-import/awsdiscover/testhelpers_test.go
@@ -1,9 +1,77 @@
 package awsdiscover
 
-import "github.com/aws/aws-sdk-go-v2/aws"
+import (
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
 
 // awsDummyConfig returns an aws.Config with no real credentials. Tests
 // that build the production AWSDiscoverer just to inspect its registry
 // (e.g. TestNewAWSDiscoverer_Registers5PhaseOneTypes) need *some* config
 // to call NewAWSDiscoverer; they do not perform any SDK calls.
 func awsDummyConfig() aws.Config { return aws.Config{Region: "us-east-1"} }
+
+// recordedEvent is a single emit observed by recordingEmitter (#295). The
+// fields cover every progress.Emitter method's load-bearing arguments;
+// per-method tests pin the relevant subset.
+type recordedEvent struct {
+	Kind     string // "service_start" | "service_finish" | "item_found" | "stage_finish"
+	Service  string
+	Region   string
+	TFType   string
+	ImportID string
+	Stage    string
+	Count    int
+	Total    int
+	Dur      time.Duration
+}
+
+// recordingEmitter is a test-only progress.Emitter that captures every
+// emit into an in-memory slice. It mirrors the semantics of
+// progress.NopEmitter for the per-service Discover code path (Emitter is
+// always non-nil after the emitterOrNop fallback) but lets tests assert
+// the sequence and field values of emitted events.
+//
+// Concurrent emissions are guarded by mu — DynamoDB and Lambda discoverers
+// fan out per-item tag fetches under an errgroup, so item_found events
+// can race.
+type recordingEmitter struct {
+	mu     sync.Mutex
+	events []recordedEvent
+}
+
+func (r *recordingEmitter) ServiceStart(service, region string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, recordedEvent{Kind: "service_start", Service: service, Region: region})
+}
+
+func (r *recordingEmitter) ServiceFinish(service, region string, count int, dur time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, recordedEvent{Kind: "service_finish", Service: service, Region: region, Count: count, Dur: dur})
+}
+
+func (r *recordingEmitter) ItemFound(service, region, tfType, importID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, recordedEvent{Kind: "item_found", Service: service, Region: region, TFType: tfType, ImportID: importID})
+}
+
+func (r *recordingEmitter) StageFinish(stage string, total int, dur time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, recordedEvent{Kind: "stage_finish", Stage: stage, Total: total, Count: total, Dur: dur})
+}
+
+// snapshot returns a copy of the event slice under lock so test
+// assertions don't race with any concurrent emits still in flight.
+func (r *recordingEmitter) snapshot() []recordedEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -20,6 +20,7 @@ import (
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/driftfix"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
@@ -55,7 +56,7 @@ const discoverRetryMaxAttempts = 8
 // selectors flow through as the CLI-package tagSelectorPair so the
 // interface stays decoupled from awsdiscover/gcpdiscover.
 type discoveryAggregator interface {
-	DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string) ([]imported.ImportedResource, error)
+	DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error)
 	DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error)
 }
 
@@ -69,7 +70,7 @@ type awsAggAdapter struct {
 	d *awsdiscover.AWSDiscoverer
 }
 
-func (a awsAggAdapter) DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string) ([]imported.ImportedResource, error) {
+func (a awsAggAdapter) DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error) {
 	sel := make([]awsdiscover.TagSelector, 0, len(tagSelectors))
 	for _, p := range tagSelectors {
 		sel = append(sel, awsdiscover.TagSelector{Key: p.Key, Value: p.Value})
@@ -79,6 +80,7 @@ func (a awsAggAdapter) DiscoverTypes(ctx context.Context, types []string, projec
 		Regions:      regions,
 		TagSelectors: sel,
 		AccountID:    accountID,
+		Emitter:      emitter,
 	})
 }
 
@@ -93,7 +95,7 @@ type gcpAggAdapter struct {
 	d *gcpdiscover.GCPDiscoverer
 }
 
-func (a gcpAggAdapter) DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string) ([]imported.ImportedResource, error) {
+func (a gcpAggAdapter) DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error) {
 	sel := make([]gcpdiscover.TagSelector, 0, len(tagSelectors))
 	for _, p := range tagSelectors {
 		sel = append(sel, gcpdiscover.TagSelector{Key: p.Key, Value: p.Value})
@@ -105,6 +107,7 @@ func (a gcpAggAdapter) DiscoverTypes(ctx context.Context, types []string, projec
 		Project:      project,
 		Regions:      regions,
 		TagSelectors: sel,
+		Emitter:      emitter,
 	})
 }
 
@@ -242,6 +245,7 @@ Exit codes:
 	gcpProjectID := fs.String("gcp-project-id", "", "real GCP project ID (per #157, distinct from --project); required for --provider gcp. The Cloud Asset Inventory scope is `projects/<gcp-project-id>` and Identity.ProjectID on every emitted resource is set to this value.")
 	fromManifest := fs.String("from-manifest", "", "load resource set from a prior imported.json instead of running Stage 2a (discovery). Use to re-emit HCL for a previously-discovered set without re-walking the cloud. Mutually exclusive with --resource-types.")
 	resourceIDs := fs.String("resource-ids", "", "comma-separated subset of Identity.ImportID values to retain when loading --from-manifest; unknown IDs are fatal. Empty = use the entire manifest. Requires --from-manifest.")
+	progressFmt := fs.String("progress", "", "progress event format. Empty (default) emits human-readable summary lines on stdout. `json` emits one newline-delimited JSON event per service-start, service-finish, item-found, stage-finish on stdout; the human-readable summary moves to stderr so machine consumers see only events on stdout. (#295)")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -332,6 +336,30 @@ Exit codes:
 	}
 	if *maxDepChaseIter <= 0 {
 		fmt.Fprintf(os.Stderr, "discover: --max-depchase-iterations must be positive (got %d)\n", *maxDepChaseIter)
+		return discoverExitFatal
+	}
+
+	// --progress=<fmt> validation + emitter wiring (#295).
+	//
+	// Empty   ⇒ NopEmitter; the existing fmt.Printf summary lines stay on stdout.
+	// "json"  ⇒ JSONEmitter writing newline-delimited Events to stdout; the
+	//           summary lines move to stderr so machine consumers see only
+	//           events on stdout (the SSE-translator-friendly contract).
+	//
+	// summaryOut is the writer the post-discovery summary lines target. We
+	// derive it from the chosen format here so the rest of runDiscoverWithDeps
+	// can use a single fmt.Fprintf(summaryOut, ...) without re-checking the
+	// flag at every call site.
+	var emitter progress.Emitter
+	summaryOut := os.Stdout
+	switch *progressFmt {
+	case "":
+		emitter = progress.NopEmitter{}
+	case "json":
+		emitter = progress.NewJSONEmitter(os.Stdout)
+		summaryOut = os.Stderr
+	default:
+		fmt.Fprintf(os.Stderr, "discover: --progress: unknown format %q (one of: json)\n", *progressFmt)
 		return discoverExitFatal
 	}
 
@@ -474,7 +502,7 @@ Exit codes:
 		resources = preloaded
 	} else {
 		var err error
-		resources, err = d.DiscoverTypes(ctx, types, *project, resolvedRegions, parsedSelectors, accountID)
+		resources, err = d.DiscoverTypes(ctx, types, *project, resolvedRegions, parsedSelectors, accountID, emitter)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "discover: %v\n", err)
 			return discoverExitFatal
@@ -486,7 +514,7 @@ Exit codes:
 		fmt.Fprintf(os.Stderr, "discover: %v\n", err)
 		return discoverExitFatal
 	}
-	fmt.Printf("wrote %s (%d resource(s) discovered)\n", out, n)
+	fmt.Fprintf(summaryOut, "wrote %s (%d resource(s) discovered)\n", out, n)
 
 	if *noHCL || n == 0 {
 		return discoverExitOK
@@ -518,7 +546,7 @@ Exit codes:
 		fmt.Fprintf(os.Stderr, "discover: %v\n", err)
 		return discoverExitFatal
 	}
-	fmt.Printf("wrote %s (%d resource(s) with Attributes); generated HCL at %s\n", out, n, res.GeneratedPath)
+	fmt.Fprintf(summaryOut, "wrote %s (%d resource(s) with Attributes); generated HCL at %s\n", out, n, res.GeneratedPath)
 
 	if *noDriftFix {
 		return discoverExitOK
@@ -533,7 +561,7 @@ Exit codes:
 		fmt.Fprintln(os.Stderr, "discover: imported.json + generated.tf are on disk. Re-run with --no-driftfix to skip Stage 2c1 explicitly, or inspect the workdir to fix manually.")
 		return discoverExitFatal
 	}
-	fmt.Printf("drift fix converged after %d iteration(s); generated HCL at %s\n", dfRes.Iterations, dfRes.GeneratedPath)
+	fmt.Fprintf(summaryOut, "drift fix converged after %d iteration(s); generated HCL at %s\n", dfRes.Iterations, dfRes.GeneratedPath)
 
 	if *noDepChase {
 		return discoverExitOK
@@ -607,7 +635,7 @@ Exit codes:
 			return discoverExitFatal
 		}
 	}
-	fmt.Printf("dep chase converged after %d iteration(s); added %d dependency resource(s); generated HCL at %s\n",
+	fmt.Fprintf(summaryOut, "dep chase converged after %d iteration(s); added %d dependency resource(s); generated HCL at %s\n",
 		dcRes.Iterations, len(dcRes.Added), dcRes.GeneratedPath)
 	return discoverExitOK
 }

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/depchase"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/driftfix"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
@@ -277,6 +278,7 @@ type fakeAggregator struct {
 	gotSelectors []tagSelectorPair
 	gotAccount   string
 	gotTypes     []string
+	gotEmitter   progress.Emitter
 	called       int
 
 	// DiscoverByID wiring for Stage 2c3 dep-chase tests. byID is keyed
@@ -295,9 +297,10 @@ func (f *fakeAggregator) gotRegion() string {
 	return f.gotRegions[0]
 }
 
-func (f *fakeAggregator) DiscoverTypes(_ context.Context, types []string, project string, regions []string, selectors []tagSelectorPair, accountID string) ([]imported.ImportedResource, error) {
+func (f *fakeAggregator) DiscoverTypes(_ context.Context, types []string, project string, regions []string, selectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error) {
 	f.called++
 	f.gotProject, f.gotRegions, f.gotSelectors, f.gotAccount, f.gotTypes = project, regions, selectors, accountID, types
+	f.gotEmitter = emitter
 	return f.out, f.err
 }
 
@@ -1040,6 +1043,67 @@ func TestRunDiscoverWithDeps_DriftfixFailureExitsFatal(t *testing.T) {
 	if !strings.Contains(stderr, "drift fix") {
 		t.Errorf("stderr must include the failing-stage label; got:\n%s", stderr)
 	}
+}
+
+// captureStdoutStderr swaps both os.Stdout and os.Stderr for pipes,
+// runs fn, and returns the captured (stdout, stderr) output. Used by
+// the --progress=json tests (#295) where the contract is "events on
+// stdout, summary on stderr" — asserting one without the other would
+// miss half the regression. Callers must NOT mark the test parallel —
+// os.Stdout / os.Stderr are global state.
+func captureStdoutStderr(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stdout: %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stderr: %v", err)
+	}
+	origOut, origErr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = wOut, wErr
+	t.Cleanup(func() { os.Stdout, os.Stderr = origOut, origErr })
+
+	doneOut := make(chan string, 1)
+	doneErr := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 0, 4096)
+		tmp := make([]byte, 1024)
+		for {
+			n, err := rOut.Read(tmp)
+			if n > 0 {
+				buf = append(buf, tmp[:n]...)
+			}
+			if err != nil {
+				break
+			}
+		}
+		doneOut <- string(buf)
+	}()
+	go func() {
+		buf := make([]byte, 0, 4096)
+		tmp := make([]byte, 1024)
+		for {
+			n, err := rErr.Read(tmp)
+			if n > 0 {
+				buf = append(buf, tmp[:n]...)
+			}
+			if err != nil {
+				break
+			}
+		}
+		doneErr <- string(buf)
+	}()
+
+	func() {
+		defer func() {
+			_ = wOut.Close()
+			_ = wErr.Close()
+		}()
+		fn()
+	}()
+	return <-doneOut, <-doneErr
 }
 
 // captureStderr swaps os.Stderr for a pipe, runs fn, and returns the
@@ -1873,5 +1937,106 @@ func TestSplitCSV(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestRunDiscoverWithDeps_ProgressJSONMovesSummaryToStderr (#295) is
+// the canonical contract pin for --progress=json: stdout carries only
+// JSON event lines, stderr carries the human-readable "wrote …"
+// summary. The reliable agent-API will Reader-tail stdout; non-event
+// lines on stdout would corrupt the SSE stream.
+//
+// Not t.Parallel(): the test rebinds os.Stdout / os.Stderr globally and
+// must own them for its run.
+func TestRunDiscoverWithDeps_ProgressJSONMovesSummaryToStderr(t *testing.T) {
+	dir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{
+		validResource("aws_sqs_queue.alpha"),
+	}}
+	stdout, stderr := captureStdoutStderr(t, func() {
+		rc := runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "io-foo", "--region", "us-east-1",
+			"--output-dir", dir, "--no-hcl", "--progress", "json",
+		}, okDeps(agg))
+		if rc != discoverExitOK {
+			t.Errorf("rc=%d, want %d", rc, discoverExitOK)
+		}
+	})
+
+	// stdout: every non-empty line must parse as a JSON Event. The
+	// fakeAggregator does not actually emit events (it bypasses the
+	// per-service code), but the orchestrator passes the JSONEmitter
+	// through; if the summary "wrote ..." line bled onto stdout the
+	// JSON parse would fail.
+	for i, line := range strings.Split(strings.TrimRight(stdout, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var evt map[string]any
+		if err := json.Unmarshal([]byte(line), &evt); err != nil {
+			t.Errorf("stdout line %d not JSON: %v\n  raw: %q", i, err, line)
+		}
+	}
+	// stderr: the post-discovery summary line must land here.
+	if !strings.Contains(stderr, "wrote ") || !strings.Contains(stderr, "imported.json") {
+		t.Errorf("expected summary 'wrote ... imported.json' on stderr; got stderr=%q", stderr)
+	}
+	if strings.Contains(stdout, "wrote ") {
+		t.Errorf("summary line bled onto stdout; got stdout=%q", stdout)
+	}
+}
+
+// TestRunDiscoverWithDeps_ProgressUnknownFormatIsFatal (#295) pins the
+// validation error message exactly so the operator-facing string is
+// covered (a reliable wizard surfaces this verbatim if the user
+// misconfigures the agent-API call).
+func TestRunDiscoverWithDeps_ProgressUnknownFormatIsFatal(t *testing.T) {
+	dir := t.TempDir()
+	stderr := captureStderr(t, func() {
+		rc := runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "io-foo", "--region", "us-east-1",
+			"--output-dir", dir, "--progress", "yaml",
+		}, okDeps(&fakeAggregator{}))
+		if rc != discoverExitFatal {
+			t.Errorf("rc=%d, want fatal", rc)
+		}
+	})
+	if !strings.Contains(stderr, "--progress: unknown format \"yaml\"") {
+		t.Errorf("stderr=%q, want it to mention `--progress: unknown format \"yaml\"`", stderr)
+	}
+	if !strings.Contains(stderr, "(one of: json)") {
+		t.Errorf("stderr=%q, want it to enumerate the supported formats", stderr)
+	}
+}
+
+// TestRunDiscoverWithDeps_ProgressEmptyKeepsLegacyOutput (#295) is the
+// back-compat pin: when --progress is unset the existing stdout summary
+// stays exactly as it was, and stderr stays empty for the happy path.
+// A regression that defaults --progress=json (or otherwise reroutes
+// the summary) would surface here as a stdout-empty / stderr-non-empty
+// flip.
+//
+// We pass --regions (not the deprecated --region) so the deprecation
+// warning #291 emits to stderr does NOT pollute the stderr-empty
+// assertion below.
+func TestRunDiscoverWithDeps_ProgressEmptyKeepsLegacyOutput(t *testing.T) {
+	dir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{
+		validResource("aws_sqs_queue.alpha"),
+	}}
+	stdout, stderr := captureStdoutStderr(t, func() {
+		rc := runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "io-foo", "--regions", "us-east-1",
+			"--output-dir", dir, "--no-hcl",
+		}, okDeps(agg))
+		if rc != discoverExitOK {
+			t.Errorf("rc=%d, want %d", rc, discoverExitOK)
+		}
+	})
+	if !strings.Contains(stdout, "wrote ") || !strings.Contains(stdout, "imported.json") {
+		t.Errorf("expected legacy summary on stdout; got stdout=%q", stdout)
+	}
+	if stderr != "" {
+		t.Errorf("expected empty stderr on happy path; got %q", stderr)
 	}
 }

--- a/cmd/insideout-import/gcpdiscover/args.go
+++ b/cmd/insideout-import/gcpdiscover/args.go
@@ -1,5 +1,7 @@
 package gcpdiscover
 
+import "github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+
 // DiscoverArgs is the per-call input shape consumed by the aggregator's
 // DiscoverTypes. Mirrors awsdiscover.DiscoverArgs minus AccountID
 // (GCP uses the projectID stored on the *GCPDiscoverer; the GCP path
@@ -13,10 +15,15 @@ package gcpdiscover
 // the asset query language the `:` operator is substring-match, not
 // strict equality — same caveat as the existing labels.project:<v>
 // filter the aggregator already emits.
+//
+// Emitter (#295) carries the streaming-progress sink. The aggregator
+// resolves a nil Emitter to progress.NopEmitter{} once at the top of
+// DiscoverTypes so per-asset translation never has to nil-check.
 type DiscoverArgs struct {
 	Project      string
 	Regions      []string
 	TagSelectors []TagSelector
+	Emitter      progress.Emitter
 }
 
 // TagSelector is a single operator-supplied label-equality clause. See

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -29,9 +29,20 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
+
+// gcpServiceSlug is the progress-event service slug used for the
+// single Cloud Asset Inventory call that powers GCP discovery (#295).
+// One CAI SearchAllResources covers every requested asset type for a
+// project, so we emit one (service_start/service_finish) pair around
+// it rather than per-asset-type. The slug name matches the Cloud
+// Asset API's product naming so consumers know what the events
+// represent.
+const gcpServiceSlug = "cloud_asset_inventory"
 
 // ErrNotSupported signals that a discoverer cannot resolve a given ID
 // (e.g. a Terraform type for which no discoverer is registered, or a GCP
@@ -151,6 +162,11 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	if len(types) == 0 {
 		types = g.SupportedTypes()
 	}
+	// Resolve a nil Emitter once here so per-asset translation can call
+	// args.Emitter.* unconditionally (#295).
+	if args.Emitter == nil {
+		args.Emitter = progress.NopEmitter{}
+	}
 
 	var unknown []string
 	selected := make([]Discoverer, 0, len(types))
@@ -171,8 +187,11 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	scope := fmt.Sprintf("projects/%s", g.projectID)
 	query := buildSearchQuery(args.Project, args.Regions, args.TagSelectors)
 
+	stageStart := time.Now()
+	args.Emitter.ServiceStart(gcpServiceSlug, "")
 	results, err := g.searcher.SearchAll(ctx, scope, assetTypes, query)
 	if err != nil {
+		args.Emitter.ServiceFinish(gcpServiceSlug, "", 0, time.Since(stageStart))
 		return nil, fmt.Errorf("cloud asset SearchAllResources: %w", err)
 	}
 
@@ -190,9 +209,13 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 		bucket := byAsset[d.AssetType()]
 		sort.SliceStable(bucket, func(i, j int) bool { return bucket[i].Name < bucket[j].Name })
 		for _, r := range bucket {
-			out = append(out, d.FromAsset(book, r, g.projectID))
+			imp := d.FromAsset(book, r, g.projectID)
+			args.Emitter.ItemFound(gcpServiceSlug, r.Location, imp.Identity.Type, imp.Identity.ImportID)
+			out = append(out, imp)
 		}
 	}
+	args.Emitter.ServiceFinish(gcpServiceSlug, "", len(out), time.Since(stageStart))
+	args.Emitter.StageFinish("discover", len(out), time.Since(stageStart))
 	return out, nil
 }
 

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
@@ -399,3 +399,144 @@ func TestRegistryParity_GCP_LiveMatchesRegistry(t *testing.T) {
 		t.Errorf("registry drift: gcpdiscover=%v, registry=%v", live, pub)
 	}
 }
+
+// TestGCPDiscoverTypes_EmitsServiceStartFinish_OnceForCloudAssetInventory
+// (#295) pins the GCP-side contract: Cloud Asset is a single discovery
+// surface (one SearchAllResources call covers every asset type for a
+// project) so we emit one service_start + one service_finish per run,
+// regardless of how many resource types or regions were requested. The
+// service slug is "cloud_asset_inventory" — the API's product name —
+// and matches what the reliable agent-API SSE translator routes on.
+func TestGCPDiscoverTypes_EmitsServiceStartFinish_OnceForCloudAssetInventory(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{
+			{Name: "//pubsub.googleapis.com/projects/real-proj/topics/alpha", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+		},
+	}
+	g := NewGCPDiscoverer(fake, "real-proj")
+	rec := &recordingEmitter{}
+	if _, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic", "google_storage_bucket"}, DiscoverArgs{
+		Project: "io-foo",
+		Regions: []string{"us-central1", "europe-west1"},
+		Emitter: rec,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	starts := 0
+	finishes := 0
+	for _, e := range rec.snapshot() {
+		switch e.Kind {
+		case "service_start":
+			starts++
+			if e.Service != "cloud_asset_inventory" {
+				t.Errorf("service_start.service=%q, want cloud_asset_inventory", e.Service)
+			}
+		case "service_finish":
+			finishes++
+			if e.Service != "cloud_asset_inventory" {
+				t.Errorf("service_finish.service=%q, want cloud_asset_inventory", e.Service)
+			}
+		}
+	}
+	if starts != 1 {
+		t.Errorf("service_start count=%d, want 1 (Cloud Asset is single-call)", starts)
+	}
+	if finishes != 1 {
+		t.Errorf("service_finish count=%d, want 1", finishes)
+	}
+}
+
+// TestGCPDiscoverTypes_EmitsItemFound_PerAsset (#295) pins one
+// item_found per emitted ImportedResource, with the asset's Location
+// stamped into the event so consumers can attribute multi-region
+// scans correctly. The TF type matches the per-discoverer
+// ResourceType().
+func TestGCPDiscoverTypes_EmitsItemFound_PerAsset(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{
+			{Name: "//pubsub.googleapis.com/projects/real-proj/topics/alpha", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+			{Name: "//pubsub.googleapis.com/projects/real-proj/topics/zeta", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+			{Name: "//storage.googleapis.com/io-foo-bucket", AssetType: "storage.googleapis.com/Bucket", Project: "real-proj", Location: "us-central1"},
+		},
+	}
+	g := NewGCPDiscoverer(fake, "real-proj")
+	rec := &recordingEmitter{}
+	got, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic", "google_storage_bucket"}, DiscoverArgs{
+		Project: "io-foo",
+		Emitter: rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var items []recordedEvent
+	for _, e := range rec.snapshot() {
+		if e.Kind == "item_found" {
+			items = append(items, e)
+		}
+	}
+	if len(items) != len(got) {
+		t.Errorf("item_found count=%d, want %d (one per emitted resource)", len(items), len(got))
+	}
+	// At least one item should carry a non-empty Location (the storage
+	// bucket); pubsub topics are project-global and may have empty
+	// Location on the asset.
+	sawLoc := false
+	for _, it := range items {
+		if it.Service != "cloud_asset_inventory" {
+			t.Errorf("item.service=%q, want cloud_asset_inventory", it.Service)
+		}
+		if it.TFType == "" {
+			t.Errorf("item.tf_type empty: %+v", it)
+		}
+		if it.ImportID == "" {
+			t.Errorf("item.import_id empty: %+v", it)
+		}
+		if it.Region == "us-central1" {
+			sawLoc = true
+		}
+	}
+	if !sawLoc {
+		t.Errorf("expected at least one item_found with region=us-central1; got %d items", len(items))
+	}
+}
+
+// TestGCPDiscoverTypes_EmitsStageFinish (#295) pins that DiscoverTypes
+// closes the stage with one stage_finish event whose total matches the
+// emitted resource count. The orchestrator-level test in the main
+// package asserts the same property at the runDiscoverWithDeps boundary;
+// this test pins it inside the aggregator so a regression that moves
+// the StageFinish out of DiscoverTypes (e.g. into the per-type loop)
+// surfaces here first.
+func TestGCPDiscoverTypes_EmitsStageFinish(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{
+			{Name: "//pubsub.googleapis.com/projects/real-proj/topics/a", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+		},
+	}
+	g := NewGCPDiscoverer(fake, "real-proj")
+	rec := &recordingEmitter{}
+	if _, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic"}, DiscoverArgs{
+		Project: "io-foo",
+		Emitter: rec,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stageEvents := 0
+	for _, e := range rec.snapshot() {
+		if e.Kind == "stage_finish" {
+			stageEvents++
+			if e.Stage != "discover" {
+				t.Errorf("stage_finish.stage=%q, want discover", e.Stage)
+			}
+			if e.Total != 1 {
+				t.Errorf("stage_finish.total=%d, want 1", e.Total)
+			}
+		}
+	}
+	if stageEvents != 1 {
+		t.Errorf("stage_finish count=%d, want 1", stageEvents)
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/testhelpers_test.go
+++ b/cmd/insideout-import/gcpdiscover/testhelpers_test.go
@@ -1,6 +1,66 @@
 package gcpdiscover
 
-import "context"
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// recordedEvent is a single emit observed by recordingEmitter (#295).
+// Mirrors the awsdiscover-package helper of the same name; kept
+// per-package so each cloud's test suite can assert independently.
+type recordedEvent struct {
+	Kind     string
+	Service  string
+	Region   string
+	TFType   string
+	ImportID string
+	Stage    string
+	Count    int
+	Total    int
+	Dur      time.Duration
+}
+
+// recordingEmitter is a test-only progress.Emitter that captures every
+// emit. Concurrent emissions are guarded by mu (Cloud Asset's per-asset
+// translation is sequential today, but the helper stays lock-safe so
+// regressions that introduce parallelism don't silently race).
+type recordingEmitter struct {
+	mu     sync.Mutex
+	events []recordedEvent
+}
+
+func (r *recordingEmitter) ServiceStart(service, region string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, recordedEvent{Kind: "service_start", Service: service, Region: region})
+}
+
+func (r *recordingEmitter) ServiceFinish(service, region string, count int, dur time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, recordedEvent{Kind: "service_finish", Service: service, Region: region, Count: count, Dur: dur})
+}
+
+func (r *recordingEmitter) ItemFound(service, region, tfType, importID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, recordedEvent{Kind: "item_found", Service: service, Region: region, TFType: tfType, ImportID: importID})
+}
+
+func (r *recordingEmitter) StageFinish(stage string, total int, dur time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, recordedEvent{Kind: "stage_finish", Stage: stage, Total: total, Count: total, Dur: dur})
+}
+
+func (r *recordingEmitter) snapshot() []recordedEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}
 
 // fakeAssetSearcher is the unit-test seam that replaces RealAssetSearcher.
 // Tests configure `pages` (the canned response slice) and `err` (forced

--- a/cmd/insideout-import/progress/progress.go
+++ b/cmd/insideout-import/progress/progress.go
@@ -1,0 +1,195 @@
+// Package progress emits structured discovery progress events from the
+// insideout-import discover subcommand. It powers the streaming
+// `--progress=json` flag added in #295 (Bundle 2 / PR 1 of #289) so the
+// reliable agent-API can translate per-service phase events into SSE for
+// the v2 importer wizard's DiscoveryScreen ("SSE streams resource events").
+//
+// The contract is intentionally small: four event types
+// (service_start, service_finish, item_found, stage_finish), each carrying
+// the fields the downstream UI needs to render per-service progress bars
+// and per-item rows. The Emitter interface is implemented by JSONEmitter
+// (newline-delimited JSON to a writer) and NopEmitter (zero overhead when
+// the flag is unset). Per-service discoverers always call methods on a
+// non-nil Emitter — the orchestrator resolves nil to NopEmitter once at
+// the top of DiscoverTypes so the per-service code never nil-checks.
+//
+// JSONEmitter serializes concurrent emissions through a sync.Mutex: the
+// AWS DynamoDB and Lambda discoverers run per-item tag fetches under a
+// bounded errgroup, so item_found events from those goroutines can race
+// with one another and with parallel ServiceStart/ServiceFinish from the
+// orchestrator. The lock guarantees each newline-delimited line is a
+// complete JSON object and that the single Encode-then-flush write is
+// not interleaved with another goroutine's write.
+package progress
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// Event is the on-the-wire shape produced by JSONEmitter. Field order in
+// the JSON output is determined by the struct layout (Go's encoding/json
+// emits in declaration order); we keep the most-discriminating fields
+// first so a streaming consumer can route on `event` without reading the
+// rest of the line.
+//
+// Optional fields use `omitempty` so each event type carries only the
+// fields that apply to it — service_start has no Count/DurationMs, etc.
+// The Timestamp field is always present; tests inject a fixed clock via
+// JSONEmitter.WithNow so golden output is deterministic.
+type Event struct {
+	Event      string    `json:"event"`                 // service_start | service_finish | item_found | stage_finish
+	Service    string    `json:"service,omitempty"`     // AWS service slug (sqs, dynamodb, ...) or GCP asset_type slug (cloud_asset_inventory)
+	Region     string    `json:"region,omitempty"`      // AWS region; empty for global services (IAM, S3) and GCP
+	Location   string    `json:"location,omitempty"`    // GCP location; empty for project-global types and AWS
+	TFType     string    `json:"tf_type,omitempty"`     // Terraform resource type for item_found
+	ImportID   string    `json:"import_id,omitempty"`   // Terraform import ID for item_found
+	Stage      string    `json:"stage,omitempty"`       // discover for stage_finish (room for future stages: hcl_gen, drift_fix, dep_chase)
+	Count      int       `json:"count,omitempty"`       // service_finish, stage_finish — items emitted in scope
+	Total      int       `json:"total,omitempty"`       // stage_finish — total items across the stage (==Count today, separate field for future fan-in)
+	DurationMs int64     `json:"duration_ms,omitempty"` // service_finish, stage_finish — wall-time spent in the scope
+	Timestamp  time.Time `json:"ts"`                    // every event; injectable for deterministic tests via WithNow
+}
+
+// Emitter is the per-service progress contract. Default implementation
+// (NopEmitter) is a no-op; JSONEmitter writes one newline-delimited JSON
+// event per call. Method names mirror the issue body: ServiceStart and
+// ServiceFinish bracket each (service, region) discovery scope;
+// ItemFound fires once per ImportedResource the discoverer emits;
+// StageFinish fires once at the end of DiscoverTypes with the total
+// item count and wall-time.
+type Emitter interface {
+	ServiceStart(service, region string)
+	ServiceFinish(service, region string, count int, dur time.Duration)
+	ItemFound(service, region, tfType, importID string)
+	StageFinish(stage string, total int, dur time.Duration)
+}
+
+// NopEmitter is a zero-overhead Emitter that swallows every call. The
+// orchestrator substitutes NopEmitter{} when the operator did not pass
+// --progress=json, so per-service discoverers always have a non-nil
+// Emitter to call.
+type NopEmitter struct{}
+
+// ServiceStart is a no-op.
+func (NopEmitter) ServiceStart(string, string) {}
+
+// ServiceFinish is a no-op.
+func (NopEmitter) ServiceFinish(string, string, int, time.Duration) {}
+
+// ItemFound is a no-op.
+func (NopEmitter) ItemFound(string, string, string, string) {}
+
+// StageFinish is a no-op.
+func (NopEmitter) StageFinish(string, int, time.Duration) {}
+
+// JSONEmitter writes one newline-delimited JSON Event per call to an
+// io.Writer. Concurrent emissions are serialized through mu so each
+// line in the output stream is a complete JSON object.
+//
+// Construct with NewJSONEmitter; the zero value is not usable (the
+// internal clock would emit the zero time on every event).
+type JSONEmitter struct {
+	out io.Writer
+	now func() time.Time
+	mu  sync.Mutex
+}
+
+// NewJSONEmitter constructs a JSONEmitter that writes to out and
+// timestamps events with time.Now. Tests that need deterministic
+// timestamps should call WithNow on the returned emitter.
+func NewJSONEmitter(out io.Writer) *JSONEmitter {
+	return &JSONEmitter{
+		out: out,
+		now: time.Now,
+	}
+}
+
+// WithNow overrides the clock used to stamp Event.Timestamp. Returns
+// the receiver so callers can chain. Test-only path: production code
+// constructs with NewJSONEmitter and never calls WithNow.
+func (e *JSONEmitter) WithNow(now func() time.Time) *JSONEmitter {
+	e.now = now
+	return e
+}
+
+// ServiceStart emits one service_start event. Errors writing to the
+// underlying io.Writer are silently dropped: a failed progress emit
+// must never abort the discovery run, since the caller (reliable
+// agent-API) is consuming a best-effort stream and the discovery
+// stages own their own error reporting.
+func (e *JSONEmitter) ServiceStart(service, region string) {
+	e.write(Event{
+		Event:     "service_start",
+		Service:   service,
+		Region:    region,
+		Timestamp: e.now(),
+	})
+}
+
+// ServiceFinish emits one service_finish event with the final item
+// count for the (service, region) scope and the wall-time spent in
+// that scope.
+func (e *JSONEmitter) ServiceFinish(service, region string, count int, dur time.Duration) {
+	e.write(Event{
+		Event:      "service_finish",
+		Service:    service,
+		Region:     region,
+		Count:      count,
+		DurationMs: dur.Milliseconds(),
+		Timestamp:  e.now(),
+	})
+}
+
+// ItemFound emits one item_found event per ImportedResource. tfType
+// and importID match the Identity.Type and Identity.ImportID stamped
+// onto the resource by makeImportedResource.
+func (e *JSONEmitter) ItemFound(service, region, tfType, importID string) {
+	e.write(Event{
+		Event:     "item_found",
+		Service:   service,
+		Region:    region,
+		TFType:    tfType,
+		ImportID:  importID,
+		Timestamp: e.now(),
+	})
+}
+
+// StageFinish emits one stage_finish event at the end of DiscoverTypes
+// with the aggregate count + wall-time across every (service, region)
+// scope. The Stage field is "discover" today; reserved as a discriminator
+// for future per-stage events (Stage 2b genconfig, Stage 2c1 driftfix,
+// Stage 2c3 depchase).
+func (e *JSONEmitter) StageFinish(stage string, total int, dur time.Duration) {
+	e.write(Event{
+		Event:      "stage_finish",
+		Stage:      stage,
+		Count:      total,
+		Total:      total,
+		DurationMs: dur.Milliseconds(),
+		Timestamp:  e.now(),
+	})
+}
+
+// write encodes evt as a single JSON object followed by a newline and
+// writes it to e.out under the lock. Encoding errors are silently
+// dropped (best-effort stream — see ServiceStart docs).
+//
+// We use json.Marshal + a single Write rather than json.NewEncoder
+// because the Encoder writes the trailing newline as a separate Write
+// call, which under contention can interleave with another goroutine's
+// next event payload even with the mutex held — Encoder's two writes
+// would atomically span the lock-and-release boundary. Marshal +
+// fmt.Fprintln is one Write to e.out, one byte sequence.
+func (e *JSONEmitter) write(evt Event) {
+	buf, err := json.Marshal(evt)
+	if err != nil {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	_, _ = fmt.Fprintln(e.out, string(buf))
+}

--- a/cmd/insideout-import/progress/progress_test.go
+++ b/cmd/insideout-import/progress/progress_test.go
@@ -1,0 +1,193 @@
+package progress
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fixedNow returns a deterministic clock for golden assertions. The
+// timestamp matches the example in the issue body (#295) so the JSON
+// shape lines up 1:1 with the documented contract.
+func fixedNow() func() time.Time {
+	t, _ := time.Parse(time.RFC3339Nano, "2026-05-07T12:00:00Z")
+	return func() time.Time { return t }
+}
+
+func TestJSONEmitter_ServiceStartShape(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.ServiceStart("sqs", "us-east-1")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	want := `{"event":"service_start","service":"sqs","region":"us-east-1","ts":"2026-05-07T12:00:00Z"}`
+	if got != want {
+		t.Errorf("ServiceStart line mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestJSONEmitter_ItemFoundShape(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.ItemFound("sqs", "us-east-1", "aws_sqs_queue", "https://sqs.us-east-1.amazonaws.com/123/q1")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	want := `{"event":"item_found","service":"sqs","region":"us-east-1","tf_type":"aws_sqs_queue","import_id":"https://sqs.us-east-1.amazonaws.com/123/q1","ts":"2026-05-07T12:00:00Z"}`
+	if got != want {
+		t.Errorf("ItemFound line mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestJSONEmitter_ServiceFinishShape pins the service_finish JSON shape
+// AND asserts that DurationMs comes through as the integer milliseconds
+// of the supplied time.Duration (1.234s → 1234). A regression that
+// switched to Nanoseconds() / Seconds() would silently shift the units
+// the downstream UI reads.
+func TestJSONEmitter_ServiceFinishShape(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.ServiceFinish("sqs", "us-east-1", 42, 1234*time.Millisecond)
+
+	got := strings.TrimRight(buf.String(), "\n")
+	want := `{"event":"service_finish","service":"sqs","region":"us-east-1","count":42,"duration_ms":1234,"ts":"2026-05-07T12:00:00Z"}`
+	if got != want {
+		t.Errorf("ServiceFinish line mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestJSONEmitter_StageFinishShape(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.StageFinish("discover", 7, 5*time.Second)
+
+	got := strings.TrimRight(buf.String(), "\n")
+	want := `{"event":"stage_finish","stage":"discover","count":7,"total":7,"duration_ms":5000,"ts":"2026-05-07T12:00:00Z"}`
+	if got != want {
+		t.Errorf("StageFinish line mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestJSONEmitter_ConcurrentEmissionIsLineSafe runs N goroutines
+// emitting ItemFound concurrently and asserts every output line is
+// valid JSON with the expected event type. A regression that drops
+// the mutex would produce interleaved bytes and at least one
+// json.Unmarshal failure under -race.
+//
+// Not t.Parallel(): the test exercises shared-resource scheduling
+// behavior and we want it to dominate its own goroutine pool, not
+// share with sibling tests.
+func TestJSONEmitter_ConcurrentEmissionIsLineSafe(t *testing.T) {
+	const goroutines = 16
+	const perG = 64
+	var buf bytes.Buffer
+	// Wrap buf in a synchronizing writer so we don't conflate the
+	// emitter's serialization with bytes.Buffer's per-write copy.
+	sw := &syncWriter{w: &buf}
+	e := NewJSONEmitter(sw).WithNow(fixedNow())
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perG; j++ {
+				e.ItemFound("sqs", "us-east-1", "aws_sqs_queue", "id")
+			}
+		}()
+	}
+	wg.Wait()
+
+	scanner := bufio.NewScanner(strings.NewReader(buf.String()))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lines := 0
+	for scanner.Scan() {
+		lines++
+		var evt Event
+		if err := json.Unmarshal(scanner.Bytes(), &evt); err != nil {
+			t.Fatalf("line %d not valid JSON: %v\n  raw: %q", lines, err, scanner.Text())
+		}
+		if evt.Event != "item_found" {
+			t.Errorf("line %d: event=%q, want item_found", lines, evt.Event)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if want := goroutines * perG; lines != want {
+		t.Errorf("got %d lines, want %d", lines, want)
+	}
+}
+
+func TestNopEmitter_AllMethodsAreNoOps(t *testing.T) {
+	t.Parallel()
+	// The contract: NopEmitter never writes to anything. We verify by
+	// confirming the methods are callable without panic and their
+	// signatures satisfy the Emitter interface.
+	var e Emitter = NopEmitter{}
+	e.ServiceStart("sqs", "us-east-1")
+	e.ServiceFinish("sqs", "us-east-1", 5, time.Second)
+	e.ItemFound("sqs", "us-east-1", "aws_sqs_queue", "id")
+	e.StageFinish("discover", 5, time.Second)
+
+	// Belt-and-suspenders: a counting writer wrapped around any future
+	// fields would catch a regression that introduces a hidden write.
+	// NopEmitter has no fields today; this asserts that property at
+	// construction (zero-value usable, no internal state).
+	var zero NopEmitter
+	zero.ServiceStart("", "")
+	zero.ServiceFinish("", "", 0, 0)
+	zero.ItemFound("", "", "", "")
+	zero.StageFinish("", 0, 0)
+}
+
+// TestJSONEmitter_FlowOrderingDocumentedExample assembles a realistic
+// per-service event sequence and asserts the on-the-wire output matches
+// the example block in the issue body (#295). This is the canonical
+// integration shape downstream consumers (reliable agent-API SSE
+// translator) read against.
+func TestJSONEmitter_FlowOrderingDocumentedExample(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.ServiceStart("sqs", "us-east-1")
+	e.ItemFound("sqs", "us-east-1", "aws_sqs_queue", "https://sqs.us-east-1.amazonaws.com/1/q")
+	e.ServiceFinish("sqs", "us-east-1", 1, 100*time.Millisecond)
+	e.StageFinish("discover", 1, 200*time.Millisecond)
+
+	want := strings.Join([]string{
+		`{"event":"service_start","service":"sqs","region":"us-east-1","ts":"2026-05-07T12:00:00Z"}`,
+		`{"event":"item_found","service":"sqs","region":"us-east-1","tf_type":"aws_sqs_queue","import_id":"https://sqs.us-east-1.amazonaws.com/1/q","ts":"2026-05-07T12:00:00Z"}`,
+		`{"event":"service_finish","service":"sqs","region":"us-east-1","count":1,"duration_ms":100,"ts":"2026-05-07T12:00:00Z"}`,
+		`{"event":"stage_finish","stage":"discover","count":1,"total":1,"duration_ms":200,"ts":"2026-05-07T12:00:00Z"}`,
+		"",
+	}, "\n")
+	if buf.String() != want {
+		t.Errorf("documented flow output mismatch:\n got: %q\nwant: %q", buf.String(), want)
+	}
+}
+
+// syncWriter wraps an io.Writer with an atomic counter so the
+// concurrent-emission test can assert that every emit produced exactly
+// one Write call (no torn writes) without depending on bytes.Buffer's
+// internal locking semantics.
+type syncWriter struct {
+	mu     sync.Mutex
+	w      *bytes.Buffer
+	writes atomic.Int64
+}
+
+func (s *syncWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.writes.Add(1)
+	return s.w.Write(p)
+}


### PR DESCRIPTION
## Summary

- Adds a `--progress=json` flag to `insideout-import discover` that emits newline-delimited JSON events (`service_start`, `service_finish`, `item_found`, `stage_finish`) on stdout. The human-readable `wrote …` / `drift fix converged …` / `dep chase converged …` summary lines move to stderr so machine consumers (reliable agent-API SSE translator) see only events on stdout.
- New `cmd/insideout-import/progress/` package: `Emitter` interface + `JSONEmitter` (concurrent-safe, mutex-serialized so per-item DynamoDB/Lambda errgroup goroutines don't tear lines) + `NopEmitter` (zero-overhead default when the flag is absent).
- AWS per-service `Discover` emits one `service_start`/`service_finish` per `(service, region)` scope (IAM and S3 emit a single global-region scope) and one `item_found` per emitted `ImportedResource`. GCP wraps the single Cloud Asset Inventory call with one bracket and emits per-asset `item_found` (slug `cloud_asset_inventory`).
- Empty `--progress` is back-compat: legacy stdout summary stays as today; unknown formats are fatal with a stable error string `discover: --progress: unknown format "<x>" (one of: json)`.

## Closes / Part of

- Closes #295
- Part of #289 (Bundle 2 / PR 1)
- Stacked on PR #299 (#292 / Bundle 1 / PR 3) — `feat/from-manifest-292`

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1 -race` — 3199 passed
- [x] `go vet ./...`
- [x] `gofmt -l cmd/ pkg/` empty
- [x] All 8 lint scripts (`lint-project-tag`, `lint-project-label`, `lint-sensitive-for-each`, `lint-foreach-unknown-keys`, `lint-no-root-only-blocks`, `lint-shared-no-cloud-providers`, `lint-labelless-name-prefix`, `lint-gcp-project-pin`) pass
- [x] `go test ./cmd/insideout-import/progress/... -count=10 -race` (stress concurrent JSONEmitter)
- [x] CI green (TBD until pipeline runs)

## Self-review notes

- New stderr/stdout-capture tests are NOT `t.Parallel()` (codebase convention; rebinding global `os.Stdout`/`os.Stderr`).
- New per-service emitter tests use `t.Parallel()` (no global state).
- `JSONEmitter.write` uses a single `Marshal` + `Fprintln` rather than `json.Encoder` because the encoder writes payload + newline as two `Write` calls; under contention even a mutex-bracketed two-call sequence can interleave with another goroutine's payload — single Write keeps each line atomic.
- `IAM` (role + policy) and `S3` are global services — they emit one `(service, "")` (or `(service, stampRegion)` for S3) scope rather than iterating Regions, mirroring the existing region-stamping behavior.
- Per-service `Discover` defensively re-defaults a nil `Emitter` to `NopEmitter` (helper `emitterOrNop`) so unit tests that bypass the aggregator and pass `DiscoverArgs{}` directly don't NPE; the aggregator already defaults at its entry too.

## Stacking note

- Base branch: `feat/from-manifest-292` (PR #299), not `main`. After #299 merges, GitHub will auto-rebase this PR onto main; the operator handles merge order.
- Conflicts at rebase time should be limited to `discover.go` (the orchestrator file both PRs touch) — additive shape kept that surface area minimal.