### PR TITLE
feat(insideout-import): --include-unsupported enumeration (#296)

### DIFF
--- a/cmd/insideout-import/awsdiscover/unsupported.go
+++ b/cmd/insideout-import/awsdiscover/unsupported.go
@@ -1,0 +1,321 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
+	retypes "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
+)
+
+// UnsupportedResource mirrors the CLI-level wire shape (per the
+// `{type,id,name,region,location,tags,group}` shape promised in #289
+// gap-#6). Declared per-cloud rather than imported across packages so
+// each cloud's enumerator is a leaf package; the CLI's
+// imported_unsupported.go has the canonical wire-format type and
+// translates between this in-package carrier and that one.
+type UnsupportedResource struct {
+	Type     string            `json:"type"`
+	ID       string            `json:"id"`
+	Name     string            `json:"name"`
+	Region   string            `json:"region,omitempty"`
+	Location string            `json:"location,omitempty"`
+	Tags     map[string]string `json:"tags,omitempty"`
+	Group    string            `json:"group,omitempty"`
+}
+
+// resourceExplorerSearcher abstracts the AWS Resource Explorer Search
+// API (#296) so unit tests can swap in canned-response fakes without a
+// real SDK client. The signature mirrors the real Search call's input
+// shape — minus pagination plumbing, which the real implementation
+// loops internally.
+type resourceExplorerSearcher interface {
+	Search(ctx context.Context, region, queryString string) ([]retypes.Resource, error)
+}
+
+// realResourceExplorerSearcher constructs one Resource Explorer client
+// per region (the API requires a per-region endpoint — Resource Explorer
+// is a regional service even though the index it queries spans the
+// account) and pages through Search until NextToken is exhausted.
+//
+// Errors propagate verbatim so the EnumerateUnsupported caller can
+// distinguish "Resource Explorer not configured" (an InternalServerException
+// or AccessDeniedException with a specific message body) from "transient
+// network failure". The CLI translates the former into a soft warning
+// and the latter into a fatal — see runDiscoverWithDeps.
+type realResourceExplorerSearcher struct {
+	cfg aws.Config
+}
+
+// NewRealResourceExplorerSearcher returns the production Resource
+// Explorer searcher backed by a per-region resourceexplorer2.Client.
+// The returned searcher is safe for concurrent use across regions; each
+// Search call constructs its own per-region client internally.
+func NewRealResourceExplorerSearcher(cfg aws.Config) resourceExplorerSearcher {
+	return &realResourceExplorerSearcher{cfg: cfg}
+}
+
+func (r *realResourceExplorerSearcher) Search(ctx context.Context, region, queryString string) ([]retypes.Resource, error) {
+	client := resourceexplorer2.NewFromConfig(r.cfg, func(o *resourceexplorer2.Options) {
+		o.Region = region
+	})
+	var out []retypes.Resource
+	var token *string
+	for {
+		// QueryString must be non-empty per the SDK validator; an empty
+		// string is rejected client-side, so we substitute "*" to mean
+		// "all resources Resource Explorer has indexed in this view".
+		qs := queryString
+		if qs == "" {
+			qs = "*"
+		}
+		resp, err := client.Search(ctx, &resourceexplorer2.SearchInput{
+			QueryString: aws.String(qs),
+			NextToken:   token,
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, resp.Resources...)
+		if resp.NextToken == nil || *resp.NextToken == "" {
+			return out, nil
+		}
+		token = resp.NextToken
+	}
+}
+
+// UnsupportedArgs is the input shape consumed by EnumerateUnsupported.
+// Mirrors DiscoverArgs's relevant subset (Project, Regions, TagSelectors,
+// Emitter) plus a Searcher seam for unit tests. AccountID is intentionally
+// not threaded through — the unsupported emit path doesn't reconstruct
+// ARNs, it passes through whatever Resource Explorer returns.
+type UnsupportedArgs struct {
+	// Project carries the stack project name. Currently unused on the
+	// AWS side because Resource Explorer doesn't expose tags on the
+	// Resource shape — we'd need a per-resource ListTagsForResource
+	// call to filter, which is the same fan-out cost as the per-service
+	// discoverers and defeats the "single Search per region" model.
+	// Reserved for a follow-up that adds opt-in tag-fanout for
+	// unsupported rows.
+	Project string
+
+	// Regions is the multi-region scope. Empty == "use the configured-
+	// region of cfg". Each region produces one Search call.
+	Regions []string
+
+	// TagSelectors mirrors DiscoverArgs.TagSelectors. Same caveat as
+	// Project: not applied today (no inline tags on the Resource shape).
+	TagSelectors []TagSelector
+
+	// Searcher is the test seam. Production callers leave it nil and
+	// EnumerateUnsupported defaults to NewRealResourceExplorerSearcher(cfg).
+	// AWSDiscoverer.EnumerateUnsupported in production wires it directly.
+	Searcher resourceExplorerSearcher
+
+	// Emitter is the streaming-progress sink. Resolved to NopEmitter at
+	// the top of EnumerateUnsupported when nil.
+	Emitter progress.Emitter
+}
+
+// errResourceExplorerNotConfigured wraps an underlying SDK error and
+// signals the operator-actionable case where Resource Explorer is not
+// set up in the target region. The CLI surfaces this as a soft-warning
+// rather than a fatal so --include-unsupported runs degrade gracefully:
+// the operator still gets imported.json from the importable services,
+// and a clear stderr message about the gap.
+//
+// We detect the case by string-matching the error body since the AWS
+// SDK does not surface a typed sentinel for "no default view". The
+// message substrings are stable across the v1 → v2 SDK migration that
+// landed in 2023 and have not changed in any ~/AWS docs change since.
+type errResourceExplorerNotConfigured struct {
+	region string
+	cause  error
+}
+
+func (e *errResourceExplorerNotConfigured) Error() string {
+	return fmt.Sprintf("AWS Resource Explorer not configured in region %s (--include-unsupported requires resource-explorer-2 with a default view; see https://docs.aws.amazon.com/resource-explorer/latest/userguide/getting-started-setting-up.html): %v", e.region, e.cause)
+}
+
+func (e *errResourceExplorerNotConfigured) Unwrap() error { return e.cause }
+
+// IsResourceExplorerNotConfigured reports whether err (or any wrapped
+// cause) is a Resource-Explorer-not-set-up error from
+// EnumerateUnsupported. The CLI's soft-warning branch tests this with
+// errors.As to decide between the warn-and-continue path and the
+// generic fatal path.
+func IsResourceExplorerNotConfigured(err error) bool {
+	var re *errResourceExplorerNotConfigured
+	return errors.As(err, &re)
+}
+
+// looksLikeResourceExplorerNotConfigured pattern-matches on the error
+// body for the SDK errors we want to soft-fail on. Resource Explorer's
+// "no default view" surfaces as one of:
+//   - "ResourceNotFoundException" with "default view"
+//   - "ValidationException" with "no default view"
+//   - "AccessDeniedException" with "resource-explorer-2:GetDefaultView"
+//
+// We accept any of these as the same operator-action ("set up Resource
+// Explorer in this region").
+func looksLikeResourceExplorerNotConfigured(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "default view") ||
+		strings.Contains(msg, "resource-explorer-2") ||
+		strings.Contains(msg, "ResourceNotFoundException")
+}
+
+const unsupportedServiceSlug = "unsupported"
+
+// EnumerateUnsupported walks AWS Resource Explorer in each requested
+// region and returns one UnsupportedResource per resource whose type is
+// NOT in the registry's importable set. The supported set is
+// subtracted via registry.SupportedDiscoverTypes(ProviderAWS) so this
+// function tracks the set of importable types automatically as new
+// per-service discoverers ship — no follow-up edit needed here when
+// awsdiscover gains a new type.
+//
+// Per-region failures: a single region's Search failure is fatal — we
+// don't merge partial results across regions because the wizard's
+// picker assumes the unsupported.json view is whole-account. The CLI
+// wrapper soft-fails the entire EnumerateUnsupported call when
+// IsResourceExplorerNotConfigured(err) is true, since the typical
+// operator gap is "Resource Explorer disabled in some regions".
+//
+// Concurrency: Search calls are sequential across regions. The
+// per-region wall-time is dominated by network round-trips (one Search
+// per region, no per-resource fanout); making this concurrent would
+// improve throughput on multi-region scans but trade off the simplicity
+// of per-region-attributable error messages. Deferred to a follow-up
+// once we see real-world latency profiles.
+func (a *AWSDiscoverer) EnumerateUnsupported(ctx context.Context, args UnsupportedArgs) ([]UnsupportedResource, error) {
+	return enumerateUnsupportedAWS(ctx, args, a.defaultRegion)
+}
+
+// enumerateUnsupportedAWS is the testable form of EnumerateUnsupported
+// that takes an explicit defaultRegion (so unit tests can construct
+// UnsupportedArgs without going through *AWSDiscoverer).
+func enumerateUnsupportedAWS(ctx context.Context, args UnsupportedArgs, defaultRegion string) ([]UnsupportedResource, error) {
+	if args.Searcher == nil {
+		return nil, errors.New("EnumerateUnsupported: Searcher is required (production callers wire NewRealResourceExplorerSearcher; tests inject a fake)")
+	}
+	if args.Emitter == nil {
+		args.Emitter = progress.NopEmitter{}
+	}
+	regions := args.Regions
+	if len(regions) == 0 {
+		regions = []string{defaultRegion}
+	}
+
+	supportedSet := make(map[string]struct{})
+	for _, t := range registry.SupportedDiscoverTypes(registry.ProviderAWS) {
+		supportedSet[t] = struct{}{}
+	}
+
+	var out []UnsupportedResource
+	for _, region := range regions {
+		regionStart := time.Now()
+		args.Emitter.ServiceStart(unsupportedServiceSlug, region)
+
+		results, err := args.Searcher.Search(ctx, region, "*")
+		if err != nil {
+			args.Emitter.ServiceFinish(unsupportedServiceSlug, region, 0, time.Since(regionStart))
+			if looksLikeResourceExplorerNotConfigured(err) {
+				return nil, &errResourceExplorerNotConfigured{region: region, cause: err}
+			}
+			return nil, fmt.Errorf("resource explorer Search (region=%s): %w", region, err)
+		}
+
+		regionCount := 0
+		for _, r := range results {
+			row, ok := awsResourceToUnsupported(r, supportedSet)
+			if !ok {
+				continue
+			}
+			args.Emitter.ItemFound(unsupportedServiceSlug, region, row.Type, row.ID)
+			out = append(out, row)
+			regionCount++
+		}
+		args.Emitter.ServiceFinish(unsupportedServiceSlug, region, regionCount, time.Since(regionStart))
+	}
+	return out, nil
+}
+
+// awsResourceToUnsupported translates a single Resource Explorer hit
+// into an UnsupportedResource, returning ok=false for rows whose
+// terraform-mapped type is in the importable supportedSet (the picker
+// reads those from imported.json instead). Unmapped resource types
+// pass through with Type="" so the picker can still surface them in
+// an "Other" category.
+//
+// AWS Resource Explorer's Resource shape carries no inline tags map —
+// tags would require a per-row ListTagsForResource fanout that the
+// "single Search per region" performance model doesn't admit. We leave
+// Tags nil here; future work can add an opt-in fanout flag.
+func awsResourceToUnsupported(r retypes.Resource, supportedSet map[string]struct{}) (UnsupportedResource, bool) {
+	rt := aws.ToString(r.ResourceType)
+	id := aws.ToString(r.Arn)
+	region := aws.ToString(r.Region)
+
+	tfType, _ := mapAWSResourceTypeToTF(rt)
+	// Filter out the importable set: a mapped TF type that's in the
+	// supported registry is by definition emitted via imported.json,
+	// not unsupported.json. Unmapped rows (tfType == "") cannot be in
+	// the supported set so they always pass through.
+	if tfType != "" {
+		if _, ok := supportedSet[tfType]; ok {
+			return UnsupportedResource{}, false
+		}
+	}
+
+	name := awsResourceNameFromARN(id)
+	if name == "" {
+		// Fall back to the resource type slug so the picker has SOMETHING
+		// legible to show; better than an empty Name cell.
+		name = rt
+	}
+
+	return UnsupportedResource{
+		Type:   tfType,
+		ID:     id,
+		Name:   name,
+		Region: region,
+	}, true
+}
+
+// awsResourceNameFromARN extracts the trailing path segment of an ARN
+// for use as a display name. Examples:
+//
+//	arn:aws:ec2:us-east-1:123:vpc/vpc-abc      -> vpc-abc
+//	arn:aws:rds:us-east-1:123:cluster:my-clu   -> my-clu
+//	arn:aws:s3:::my-bucket                     -> my-bucket
+//
+// Resource Explorer occasionally emits non-ARN resource IDs (the
+// `arn:` prefix is missing for legacy resources); for those we return
+// the empty string and let the caller fall back to the ResourceType
+// slug.
+func awsResourceNameFromARN(arn string) string {
+	parsed, err := awsarn.Parse(arn)
+	if err != nil {
+		return ""
+	}
+	resource := parsed.Resource
+	// Most ARNs use either '/' or ':' as the separator between the
+	// type and the name. Take the trailing token after either.
+	if i := strings.LastIndexAny(resource, "/:"); i >= 0 {
+		return resource[i+1:]
+	}
+	return path.Base(resource)
+}

--- a/cmd/insideout-import/awsdiscover/unsupported_test.go
+++ b/cmd/insideout-import/awsdiscover/unsupported_test.go
@@ -1,0 +1,350 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	retypes "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2/types"
+)
+
+// fakeResourceExplorerSearcher is the unit-test seam for the AWS
+// Resource Explorer surface. Tests configure `byRegion` (canned
+// responses keyed on region) and an optional forced `err`.
+type fakeResourceExplorerSearcher struct {
+	byRegion map[string][]retypes.Resource
+	err      error
+
+	// callsByRegion captures one entry per region the caller asked for,
+	// in invocation order, so multi-region tests can assert per-region
+	// threading.
+	callsByRegion []string
+}
+
+func (f *fakeResourceExplorerSearcher) Search(_ context.Context, region, _ string) ([]retypes.Resource, error) {
+	f.callsByRegion = append(f.callsByRegion, region)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.byRegion[region], nil
+}
+
+// rxResource constructs a Resource Explorer types.Resource with the
+// fields enumerateUnsupportedAWS reads.
+func rxResource(arn, resourceType, region string) retypes.Resource {
+	return retypes.Resource{
+		Arn:          aws.String(arn),
+		ResourceType: aws.String(resourceType),
+		Region:       aws.String(region),
+	}
+}
+
+// TestEnumerateUnsupported_FiltersSupportedTypes pins the registry-
+// subtraction contract: a fake returning a mix of importable +
+// unimportable rows yields only the unimportable subset. The
+// importable types come from registry.SupportedDiscoverTypes("aws"),
+// so this test exercises the live registry — a regression that drops
+// the subtract step would surface every importable row in
+// unsupported.json (the picker would then duplicate).
+func TestEnumerateUnsupported_FiltersSupportedTypes(t *testing.T) {
+	t.Parallel()
+	// 5 results: 2 are importable (aws_sqs_queue, aws_iam_role), 3 are
+	// not (aws_vpc, aws_rds_cluster, aws_eks_cluster).
+	fake := &fakeResourceExplorerSearcher{
+		byRegion: map[string][]retypes.Resource{
+			"us-east-1": {
+				rxResource("arn:aws:sqs:us-east-1:123:io-queue", "sqs:queue", "us-east-1"),
+				rxResource("arn:aws:iam::123:role/io-role", "iam:role", "us-east-1"),
+				rxResource("arn:aws:ec2:us-east-1:123:vpc/vpc-abc", "ec2:vpc", "us-east-1"),
+				rxResource("arn:aws:rds:us-east-1:123:cluster:my-clu", "rds:cluster", "us-east-1"),
+				rxResource("arn:aws:eks:us-east-1:123:cluster/my-eks", "eks:cluster", "us-east-1"),
+			},
+		},
+	}
+	// Note: the importable types depend on the registry. Per the
+	// current registry sqs:queue → aws_sqs_queue is importable;
+	// iam:role → aws_iam_role is importable. ec2:vpc, rds:cluster,
+	// eks:cluster are not (and they're in the lookup map). So 3 rows
+	// expected.
+	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+		Regions:  []string{"us-east-1"},
+		Searcher: fake,
+	}, "us-east-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d unsupported rows, want 3 (5 results minus 2 importable). rows=%+v", len(got), got)
+	}
+	wantTypes := map[string]bool{"aws_vpc": true, "aws_rds_cluster": true, "aws_eks_cluster": true}
+	for _, r := range got {
+		if !wantTypes[r.Type] {
+			t.Errorf("row Type=%q not in expected unsupported set %v", r.Type, wantTypes)
+		}
+	}
+}
+
+// TestEnumerateUnsupported_MultiRegion pins per-region threading: each
+// region in args.Regions produces one Search call, and the resulting
+// rows carry the right Region field.
+func TestEnumerateUnsupported_MultiRegion(t *testing.T) {
+	t.Parallel()
+	fake := &fakeResourceExplorerSearcher{
+		byRegion: map[string][]retypes.Resource{
+			"us-east-1": {rxResource("arn:aws:ec2:us-east-1:123:vpc/vpc-east", "ec2:vpc", "us-east-1")},
+			"eu-west-1": {rxResource("arn:aws:ec2:eu-west-1:123:vpc/vpc-west", "ec2:vpc", "eu-west-1")},
+		},
+	}
+	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+		Regions:  []string{"us-east-1", "eu-west-1"},
+		Searcher: fake,
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d rows, want 2 (one per region)", len(got))
+	}
+	if len(fake.callsByRegion) != 2 || fake.callsByRegion[0] != "us-east-1" || fake.callsByRegion[1] != "eu-west-1" {
+		t.Errorf("callsByRegion=%v, want [us-east-1 eu-west-1]", fake.callsByRegion)
+	}
+	regions := map[string]bool{got[0].Region: true, got[1].Region: true}
+	if !regions["us-east-1"] || !regions["eu-west-1"] {
+		t.Errorf("got regions %v, want both us-east-1 and eu-west-1", regions)
+	}
+}
+
+// TestEnumerateUnsupported_TagsPassThrough is a placeholder pinning
+// the documented contract: AWS Resource Explorer's Resource shape
+// carries no inline tags map (Properties is type-specific and not
+// unmarshaled), so emitted rows have Tags=nil. A regression that
+// silently invented a Tags map (e.g. by reading a non-tag Property as
+// tags) would fail this test — Tags must stay nil until a fanout opt-
+// in lands.
+func TestEnumerateUnsupported_TagsPassThrough(t *testing.T) {
+	t.Parallel()
+	fake := &fakeResourceExplorerSearcher{
+		byRegion: map[string][]retypes.Resource{
+			"us-east-1": {rxResource("arn:aws:ec2:us-east-1:123:vpc/vpc-abc", "ec2:vpc", "us-east-1")},
+		},
+	}
+	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+		Regions:  []string{"us-east-1"},
+		Searcher: fake,
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d rows, want 1", len(got))
+	}
+	if got[0].Tags != nil {
+		t.Errorf("Tags=%v, want nil (Resource Explorer surface has no inline tags today)", got[0].Tags)
+	}
+}
+
+// TestEnumerateUnsupported_TFTypeMappedFromResourceType walks the
+// awsUnsupportedTFTypeByResourceType map and asserts each entry round-
+// trips through enumerateUnsupportedAWS to its mapped Terraform type
+// in UnsupportedResource.Type. A regression that transposed two
+// columns of the map (e.g. mapping ec2:vpc → aws_subnet) would surface
+// here.
+func TestEnumerateUnsupported_TFTypeMappedFromResourceType(t *testing.T) {
+	t.Parallel()
+	for resourceType, wantTF := range awsTFTypeByResourceType {
+		resourceType := resourceType
+		wantTF := wantTF
+		t.Run(resourceType, func(t *testing.T) {
+			t.Parallel()
+			fake := &fakeResourceExplorerSearcher{
+				byRegion: map[string][]retypes.Resource{
+					"us-east-1": {rxResource("arn:aws:test:us-east-1:123:thing/x", resourceType, "us-east-1")},
+				},
+			}
+			got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+				Regions:  []string{"us-east-1"},
+				Searcher: fake,
+			}, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Some rows in the map MAY map to importable types; in that case
+			// the row is filtered out. Skip those rather than fail.
+			if len(got) == 0 {
+				t.Skipf("resource type %s maps to importable TF type %s; filtered out by registry-subtraction", resourceType, wantTF)
+			}
+			if got[0].Type != wantTF {
+				t.Errorf("Type=%q, want %q for ResourceType=%q", got[0].Type, wantTF, resourceType)
+			}
+		})
+	}
+}
+
+// TestEnumerateUnsupported_UnknownResourceTypePreservesEmpty pins the
+// fall-through contract: an unknown ResourceType slug emits a row with
+// Type="" and the slug in Name (so the picker can still surface it
+// under "Other"). A regression that errored on unknown slugs would
+// drop rows the operator actually has in their account.
+func TestEnumerateUnsupported_UnknownResourceTypePreservesEmpty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeResourceExplorerSearcher{
+		byRegion: map[string][]retypes.Resource{
+			"us-east-1": {rxResource("arn:aws:newservice:us-east-1:123:thing/x", "newservice:thing", "us-east-1")},
+		},
+	}
+	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+		Regions:  []string{"us-east-1"},
+		Searcher: fake,
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d rows, want 1 (unknown ResourceType must still pass through)", len(got))
+	}
+	if got[0].Type != "" {
+		t.Errorf("Type=%q, want empty for unknown ResourceType", got[0].Type)
+	}
+	if got[0].Name != "x" {
+		// The trailing path segment of the ARN; on a malformed ARN we
+		// fall back to the resource type slug.
+		t.Errorf("Name=%q, want %q (trailing ARN segment)", got[0].Name, "x")
+	}
+}
+
+// TestEnumerateUnsupported_ResourceExplorerErrorIsReturned pins error
+// propagation: a generic Search failure surfaces through to the
+// caller (which decides between fatal and warn). The CLI wraps the
+// returned error in a stderr WARN; this test only asserts the value
+// is returned, not the wrapping.
+func TestEnumerateUnsupported_ResourceExplorerErrorIsReturned(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("transient: connection reset")
+	fake := &fakeResourceExplorerSearcher{
+		err: wantErr,
+	}
+	_, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+		Regions:  []string{"us-east-1"},
+		Searcher: fake,
+	}, "")
+	if err == nil {
+		t.Fatal("err=nil, want error")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("returned err=%v, want wrap of %v", err, wantErr)
+	}
+}
+
+// TestEnumerateUnsupported_ResourceExplorerNotConfigured pins the
+// soft-failure marker: when the underlying Search error message hints
+// at "no default view", the returned error wraps
+// errResourceExplorerNotConfigured so the CLI's
+// IsResourceExplorerNotConfigured branch fires.
+func TestEnumerateUnsupported_ResourceExplorerNotConfigured(t *testing.T) {
+	t.Parallel()
+	fake := &fakeResourceExplorerSearcher{
+		err: errors.New("ResourceNotFoundException: there is no default view for this region"),
+	}
+	_, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+		Regions:  []string{"us-east-1"},
+		Searcher: fake,
+	}, "")
+	if err == nil {
+		t.Fatal("err=nil, want error")
+	}
+	if !IsResourceExplorerNotConfigured(err) {
+		t.Errorf("err=%v not flagged as ResourceExplorerNotConfigured; CLI's soft-fail branch will mis-route", err)
+	}
+}
+
+// TestEnumerateUnsupported_NilSearcherIsFatal pins the safety net: a
+// nil Searcher errors out at the top of EnumerateUnsupported rather
+// than panicking deep in the call stack. Tests that forget to wire a
+// fake see this error.
+func TestEnumerateUnsupported_NilSearcherIsFatal(t *testing.T) {
+	t.Parallel()
+	_, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+		Regions: []string{"us-east-1"},
+	}, "")
+	if err == nil {
+		t.Fatal("err=nil, want explicit error")
+	}
+}
+
+// TestEnumerateUnsupported_EmitsServiceStartFinishPerRegion pins the
+// progress-event contract: one (service_start, service_finish) bracket
+// per region, plus one item_found per emitted row. Mirrors the per-
+// service progress tests added in #295.
+func TestEnumerateUnsupported_EmitsServiceStartFinishPerRegion(t *testing.T) {
+	t.Parallel()
+	fake := &fakeResourceExplorerSearcher{
+		byRegion: map[string][]retypes.Resource{
+			"us-east-1": {
+				rxResource("arn:aws:ec2:us-east-1:123:vpc/vpc-east-1", "ec2:vpc", "us-east-1"),
+				rxResource("arn:aws:ec2:us-east-1:123:vpc/vpc-east-2", "ec2:vpc", "us-east-1"),
+			},
+			"eu-west-1": {
+				rxResource("arn:aws:ec2:eu-west-1:123:vpc/vpc-west-1", "ec2:vpc", "eu-west-1"),
+			},
+		},
+	}
+	rec := &recordingEmitter{}
+	if _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+		Regions:  []string{"us-east-1", "eu-west-1"},
+		Searcher: fake,
+		Emitter:  rec,
+	}, ""); err != nil {
+		t.Fatal(err)
+	}
+	starts := map[string]int{}
+	finishes := map[string]int{}
+	items := map[string]int{}
+	for _, e := range rec.snapshot() {
+		switch e.Kind {
+		case "service_start":
+			if e.Service != "unsupported" {
+				t.Errorf("service_start.service=%q, want unsupported", e.Service)
+			}
+			starts[e.Region]++
+		case "service_finish":
+			if e.Service != "unsupported" {
+				t.Errorf("service_finish.service=%q, want unsupported", e.Service)
+			}
+			finishes[e.Region]++
+		case "item_found":
+			items[e.Region]++
+		}
+	}
+	if starts["us-east-1"] != 1 || starts["eu-west-1"] != 1 {
+		t.Errorf("starts=%v, want one per region", starts)
+	}
+	if finishes["us-east-1"] != 1 || finishes["eu-west-1"] != 1 {
+		t.Errorf("finishes=%v, want one per region", finishes)
+	}
+	if items["us-east-1"] != 2 || items["eu-west-1"] != 1 {
+		t.Errorf("items=%v, want {us-east-1:2, eu-west-1:1}", items)
+	}
+}
+
+// TestAWSResourceNameFromARN_TrailingSegment pins the display-name
+// extraction across ARN shape variants Resource Explorer hands back.
+func TestAWSResourceNameFromARN_TrailingSegment(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		arn  string
+		want string
+	}{
+		{"arn:aws:ec2:us-east-1:123:vpc/vpc-abc", "vpc-abc"},
+		{"arn:aws:rds:us-east-1:123:cluster:my-cluster", "my-cluster"},
+		{"arn:aws:s3:::my-bucket", "my-bucket"},
+		{"not-an-arn", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := awsResourceNameFromARN(tc.arn)
+		if got != tc.want {
+			t.Errorf("awsResourceNameFromARN(%q)=%q, want %q", tc.arn, got, tc.want)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/unsupported_types.go
+++ b/cmd/insideout-import/awsdiscover/unsupported_types.go
@@ -1,0 +1,79 @@
+package awsdiscover
+
+// awsTFTypeByResourceType maps an AWS Resource Explorer
+// Resource.ResourceType (e.g. "ec2:vpc") to its canonical Terraform
+// resource type (e.g. "aws_vpc"). The map covers BOTH importable types
+// (so the registry-subtraction step in enumerateUnsupportedAWS can
+// filter them out cleanly) AND known unimportable types (so the
+// emitted UnsupportedResource carries a populated Type field for the
+// picker). Unmapped resource types still appear in unsupported.json
+// with Type="" and the raw ResourceType in Name so the picker can
+// surface them under "Other".
+//
+// The initial mapping covers:
+//   - the 9 importable AWS types the discover pipeline already emits
+//     (mirrors registry.SupportedDiscoverTypes("aws") so the subtract
+//     step actually fires; missing entries here would let importable
+//     rows leak into unsupported.json)
+//   - the high-traffic unimportable types the wizard's mockup calls
+//     out as greyed-out picker rows: VPC + subnets + security groups
+//     (Network Security), RDS cluster + DB instance (Data Storage),
+//     EKS / ECS / ECR / EC2 instances (Compute), ALB / ELB / Route53 /
+//     CloudFront (Networking).
+//
+// Extending this map is a one-line change per row; #297 is the
+// parallel PR that owns the Category-side mapping.
+//
+// Why a hand-maintained map vs. inferring from ResourceType: Resource
+// Explorer's slug is service:type, and Terraform's type is provider_type
+// with ad-hoc renames (e.g. ec2:loadbalancer-v2 vs aws_lb,
+// elasticloadbalancing:loadbalancer vs aws_elb). A naive split-and-prefix
+// transform produces the wrong Terraform type ~60% of the time across the
+// surface area surveyed in #289. A lookup table is the only reliable
+// shape, and the map is small enough that drift is caught by code review.
+var awsTFTypeByResourceType = map[string]string{
+	// --- Importable types (registry.SupportedDiscoverTypes("aws")) ---
+	// Filter targets: rows matching these mappings are dropped from
+	// unsupported.json by enumerateUnsupportedAWS.
+	"sqs:queue":             "aws_sqs_queue",
+	"dynamodb:table":        "aws_dynamodb_table",
+	"logs:log-group":        "aws_cloudwatch_log_group",
+	"secretsmanager:secret": "aws_secretsmanager_secret",
+	"lambda:function":       "aws_lambda_function",
+	"iam:role":              "aws_iam_role",
+	"iam:policy":            "aws_iam_policy",
+	"kms:key":               "aws_kms_key",
+	"s3:bucket":             "aws_s3_bucket",
+	// --- Unimportable types — the picker greys these out ---
+	// Network Security
+	"ec2:vpc":            "aws_vpc",
+	"ec2:subnet":         "aws_subnet",
+	"ec2:security-group": "aws_security_group",
+	// Data Storage
+	"rds:cluster": "aws_rds_cluster",
+	"rds:db":      "aws_db_instance",
+	// Compute
+	"eks:cluster":    "aws_eks_cluster",
+	"ecs:cluster":    "aws_ecs_cluster",
+	"ecr:repository": "aws_ecr_repository",
+	"ec2:instance":   "aws_instance",
+	// Networking
+	"elasticloadbalancing:loadbalancer":    "aws_lb",
+	"elasticloadbalancing:loadbalancer-v1": "aws_elb",
+	"route53:hostedzone":                   "aws_route53_zone",
+	"cloudfront:distribution":              "aws_cloudfront_distribution",
+}
+
+// mapAWSResourceTypeToTF resolves a Resource Explorer ResourceType slug
+// to its Terraform type. Unmapped slugs return ("", false) so callers can
+// emit a row with an empty Type field (the picker handles those as
+// "category=Other"). Exported as a small package-private function so the
+// EnumerateUnsupported tests can table-drive the entire map without
+// reaching into the variable directly.
+func mapAWSResourceTypeToTF(rt string) (string, bool) {
+	if rt == "" {
+		return "", false
+	}
+	tf, ok := awsTFTypeByResourceType[rt]
+	return tf, ok
+}

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -115,6 +115,17 @@ func (a gcpAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, acc
 	return a.d.DiscoverByID(ctx, tfType, id, region, accountID)
 }
 
+// unsupportedAWSEnumerator is the function-shaped seam used by
+// runDiscoverWithDeps to call into awsdiscover.EnumerateUnsupported
+// when --include-unsupported is set. Tests inject a fake to exercise
+// the soft-failure branch without standing up Resource Explorer.
+type unsupportedAWSEnumerator func(ctx context.Context, cfg aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error)
+
+// unsupportedGCPEnumerator is the GCP analogue of
+// unsupportedAWSEnumerator. Production wires it to the
+// *gcpdiscover.GCPDiscoverer's EnumerateUnsupported method.
+type unsupportedGCPEnumerator func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, error)
+
 // discoverDeps gathers the AWS- and GCP-side and terraform-side seams that
 // runDiscover would otherwise hit directly. Production code passes
 // productionDiscoverDeps(); tests pass fakes to exercise the post-STS
@@ -150,6 +161,14 @@ type discoverDeps struct {
 	// fake the depchase package directly to exercise the orchestrator
 	// branch without scripting a multi-pass pipeline.
 	runDepChase func(ctx context.Context, opts depchase.Options, resources []imported.ImportedResource) (*depchase.Result, error)
+	// enumerateUnsupportedAWS is the AWS-side seam for the
+	// --include-unsupported broad-enumeration path (#296). Production
+	// wires it to a closure that constructs a per-region Resource
+	// Explorer searcher and calls *AWSDiscoverer.EnumerateUnsupported;
+	// tests inject a fake to short-circuit the SDK roundtrip.
+	enumerateUnsupportedAWS unsupportedAWSEnumerator
+	// enumerateUnsupportedGCP is the GCP analogue.
+	enumerateUnsupportedGCP unsupportedGCPEnumerator
 }
 
 func productionDiscoverDeps() discoverDeps {
@@ -187,6 +206,28 @@ func productionDiscoverDeps() discoverDeps {
 		runGenconfig: genconfig.Run,
 		runDriftfix:  driftfix.Run,
 		runDepChase:  depchase.Run,
+		enumerateUnsupportedAWS: func(ctx context.Context, cfg aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+			if args.Searcher == nil {
+				args.Searcher = awsdiscover.NewRealResourceExplorerSearcher(cfg)
+			}
+			// Construct a default-region AWSDiscoverer purely to call
+			// EnumerateUnsupported — the per-type registry it carries
+			// is unused on this path. The real SDK calls live in the
+			// Searcher.
+			return awsdiscover.NewAWSDiscoverer(cfg).EnumerateUnsupported(ctx, args)
+		},
+		enumerateUnsupportedGCP: func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, error) {
+			// Production callers must already hold a valid
+			// *gcpdiscover.GCPDiscoverer via newGCPDiscoverer; this
+			// closure is overridden in runDiscoverWithDeps below to
+			// route to that aggregator's EnumerateUnsupported method.
+			// The default returns an explanatory error so a misuse
+			// (calling productionDiscoverDeps directly without
+			// rebinding) surfaces loudly.
+			_ = ctx
+			_ = args
+			return nil, fmt.Errorf("enumerateUnsupportedGCP: production deps need re-binding inside runDiscoverWithDeps after newGCPDiscoverer succeeds")
+		},
 	}
 }
 
@@ -246,6 +287,7 @@ Exit codes:
 	fromManifest := fs.String("from-manifest", "", "load resource set from a prior imported.json instead of running Stage 2a (discovery). Use to re-emit HCL for a previously-discovered set without re-walking the cloud. Mutually exclusive with --resource-types.")
 	resourceIDs := fs.String("resource-ids", "", "comma-separated subset of Identity.ImportID values to retain when loading --from-manifest; unknown IDs are fatal. Empty = use the entire manifest. Requires --from-manifest.")
 	progressFmt := fs.String("progress", "", "progress event format. Empty (default) emits human-readable summary lines on stdout. `json` emits one newline-delimited JSON event per service-start, service-finish, item-found, stage-finish on stdout; the human-readable summary moves to stderr so machine consumers see only events on stdout. (#295)")
+	includeUnsupported := fs.Bool("include-unsupported", false, "broad-enumerate cloud resources of types NOT yet imported by per-service discoverers, emitting them in a parallel unsupported.json sibling of imported.json (#296). AWS uses Resource Explorer's Search API (one call per region); GCP uses Cloud Asset Inventory's SearchAllResources with a broader assetTypes filter. The wizard picker reads unsupported.json to render greyed-out rows so operators see what's in their account vs. what's importable. Mutually exclusive with --from-manifest (no live scan to enumerate). Soft-fails when the underlying API isn't configured (Resource Explorer not set up in some regions, Cloud Asset API disabled): imported.json still writes and the run exits 0 with a stderr WARN.")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -283,6 +325,15 @@ Exit codes:
 	}
 	if fromManifestPath != "" && strings.TrimSpace(*resourceTypes) != "" {
 		fmt.Fprintln(os.Stderr, "discover: --resource-types is incompatible with --from-manifest (the manifest is already type-filtered)")
+		return discoverExitFatal
+	}
+	// --include-unsupported / --from-manifest mutual-exclusion (#296).
+	// --include-unsupported needs a live cloud scan to enumerate; the
+	// from-manifest path skips Stage 2a entirely so there's nothing to
+	// enrich. Surfacing this as a typed gate (rather than silently
+	// no-op'ing the flag) makes the wizard's error UX actionable.
+	if *includeUnsupported && fromManifestPath != "" {
+		fmt.Fprintln(os.Stderr, "discover: --include-unsupported is incompatible with --from-manifest (no live scan to enumerate)")
 		return discoverExitFatal
 	}
 	// Resolve --regions vs deprecated --region (#291).
@@ -429,7 +480,8 @@ Exit codes:
 
 	var (
 		d         discoveryAggregator
-		accountID string // AWS account ID, or real GCP project ID for the cloud-agnostic interface slot
+		accountID string     // AWS account ID, or real GCP project ID for the cloud-agnostic interface slot
+		awsCfg    aws.Config // captured AWS config (#296: --include-unsupported reuses for Resource Explorer)
 	)
 	switch cloud {
 	case "aws":
@@ -479,6 +531,7 @@ Exit codes:
 			}
 		}
 		d = deps.newDiscoverer(cfg, *maxConcurrency)
+		awsCfg = cfg
 	case "gcp":
 		gd, closeFn, err := deps.newGCPDiscoverer(ctx, *gcpProjectID)
 		if err != nil {
@@ -492,6 +545,18 @@ Exit codes:
 		defer func() { _ = closeFn() }()
 		d = gd
 		accountID = *gcpProjectID
+		// Rebind the unsupported enumerator (#296) so it routes
+		// through the same *gcpdiscover.GCPDiscoverer we just
+		// constructed and shares the asset searcher / gRPC
+		// connection. Tests that inject a non-default
+		// enumerateUnsupportedGCP keep their fake; the production
+		// closure (productionDiscoverDeps) is intentionally an error
+		// stub that this branch overwrites.
+		if gca, ok := gd.(gcpAggAdapter); ok {
+			deps.enumerateUnsupportedGCP = func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, error) {
+				return gca.d.EnumerateUnsupported(ctx, args)
+			}
+		}
 	}
 
 	var resources []imported.ImportedResource
@@ -515,6 +580,28 @@ Exit codes:
 		return discoverExitFatal
 	}
 	fmt.Fprintf(summaryOut, "wrote %s (%d resource(s) discovered)\n", out, n)
+
+	// --include-unsupported (#296): broad-enumerate types NOT yet wired
+	// into per-service discoverers and emit them in a parallel
+	// unsupported.json. Soft-fails so a Resource-Explorer-not-configured
+	// error (or any other enumeration failure) does NOT abort the run —
+	// imported.json is already written above and the operator can choose
+	// to fix the gap and re-run, or proceed with importable rows only.
+	// The mutual-exclusion gate above (--from-manifest is incompatible)
+	// has already returned discoverExitFatal if both are set.
+	if *includeUnsupported {
+		unsupported, uerr := enumerateUnsupportedForCloud(ctx, cloud, awsCfg, *project, resolvedRegions, parsedSelectors, emitter, deps)
+		if uerr != nil {
+			fmt.Fprintf(os.Stderr, "discover: WARN: --include-unsupported: %v; imported.json was written; continuing without unsupported.json\n", uerr)
+		} else {
+			uout, un, werr := writeUnsupportedManifest(*outputDir, unsupported)
+			if werr != nil {
+				fmt.Fprintf(os.Stderr, "discover: WARN: --include-unsupported: write manifest: %v; imported.json was written; continuing without unsupported.json\n", werr)
+			} else {
+				fmt.Fprintf(summaryOut, "wrote %s (%d unsupported resource(s) enumerated)\n", uout, un)
+			}
+		}
+	}
 
 	if *noHCL || n == 0 {
 		return discoverExitOK
@@ -638,6 +725,91 @@ Exit codes:
 	fmt.Fprintf(summaryOut, "dep chase converged after %d iteration(s); added %d dependency resource(s); generated HCL at %s\n",
 		dcRes.Iterations, len(dcRes.Added), dcRes.GeneratedPath)
 	return discoverExitOK
+}
+
+// enumerateUnsupportedForCloud is the cloud-agnostic dispatcher for the
+// --include-unsupported broad-enumeration path (#296). It calls the
+// configured AWS or GCP enumerator on `deps`, normalizes the typed
+// per-cloud result into the shared UnsupportedResource carrier, and
+// returns it for writeUnsupportedManifest to persist.
+//
+// The function lives next to splitCSV (rather than in unsupported.go)
+// so it can close over discoverDeps without exporting the deps struct
+// — the seam is internal to the CLI package.
+func enumerateUnsupportedForCloud(
+	ctx context.Context,
+	cloud string,
+	awsCfg aws.Config,
+	project string,
+	regions []string,
+	selectors []tagSelectorPair,
+	emitter progress.Emitter,
+	deps discoverDeps,
+) ([]UnsupportedResource, error) {
+	switch cloud {
+	case "aws":
+		if deps.enumerateUnsupportedAWS == nil {
+			return nil, fmt.Errorf("aws enumerator not configured")
+		}
+		sels := make([]awsdiscover.TagSelector, 0, len(selectors))
+		for _, s := range selectors {
+			sels = append(sels, awsdiscover.TagSelector{Key: s.Key, Value: s.Value})
+		}
+		raws, err := deps.enumerateUnsupportedAWS(ctx, awsCfg, awsdiscover.UnsupportedArgs{
+			Project:      project,
+			Regions:      regions,
+			TagSelectors: sels,
+			Emitter:      emitter,
+		})
+		if err != nil {
+			return nil, err
+		}
+		out := make([]UnsupportedResource, 0, len(raws))
+		for _, r := range raws {
+			out = append(out, UnsupportedResource{
+				Type:     r.Type,
+				ID:       r.ID,
+				Name:     r.Name,
+				Region:   r.Region,
+				Location: r.Location,
+				Tags:     r.Tags,
+				Group:    r.Group,
+			})
+		}
+		return out, nil
+	case "gcp":
+		if deps.enumerateUnsupportedGCP == nil {
+			return nil, fmt.Errorf("gcp enumerator not configured")
+		}
+		sels := make([]gcpdiscover.TagSelector, 0, len(selectors))
+		for _, s := range selectors {
+			sels = append(sels, gcpdiscover.TagSelector{Key: s.Key, Value: s.Value})
+		}
+		raws, err := deps.enumerateUnsupportedGCP(ctx, gcpdiscover.UnsupportedArgs{
+			Project:      project,
+			Regions:      regions,
+			TagSelectors: sels,
+			Emitter:      emitter,
+		})
+		if err != nil {
+			return nil, err
+		}
+		out := make([]UnsupportedResource, 0, len(raws))
+		for _, r := range raws {
+			out = append(out, UnsupportedResource{
+				Type:     r.Type,
+				ID:       r.ID,
+				Name:     r.Name,
+				Region:   r.Region,
+				Location: r.Location,
+				Tags:     r.Tags,
+				Group:    r.Group,
+			})
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unknown cloud %q", cloud)
+	}
 }
 
 // splitCSV splits a comma-separated flag value, trims whitespace, and drops

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/depchase"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/driftfix"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -2038,5 +2039,239 @@ func TestRunDiscoverWithDeps_ProgressEmptyKeepsLegacyOutput(t *testing.T) {
 	}
 	if stderr != "" {
 		t.Errorf("expected empty stderr on happy path; got %q", stderr)
+	}
+}
+
+// --- #296 --include-unsupported tests ---
+
+// TestRunDiscoverWithDeps_IncludeUnsupportedWritesUnsupportedJSON pins
+// the on-disk emission contract: --include-unsupported produces
+// unsupported.json next to imported.json with the rows the AWS
+// enumerator returned.
+func TestRunDiscoverWithDeps_IncludeUnsupportedWritesUnsupportedJSON(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+	agg := &fakeAggregator{}
+	deps := okDeps(agg)
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+		return []awsdiscover.UnsupportedResource{
+			{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/v1", Name: "v1", Region: "us-east-1"},
+			{Type: "aws_rds_cluster", ID: "arn:aws:rds:us-east-1:1:cluster:c1", Name: "c1", Region: "us-east-1"},
+		}, nil
+	}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--regions", "us-east-1",
+		"--output-dir", outDir,
+		"--include-unsupported",
+		"--no-hcl",
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	body, err := os.ReadFile(filepath.Join(outDir, "unsupported.json"))
+	require.NoError(t, err)
+	var got []UnsupportedResource
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.Len(t, got, 2)
+	gotTypes := []string{got[0].Type, got[1].Type}
+	if !slices.Contains(gotTypes, "aws_vpc") || !slices.Contains(gotTypes, "aws_rds_cluster") {
+		t.Errorf("emitted types=%v, want both aws_vpc and aws_rds_cluster", gotTypes)
+	}
+}
+
+// TestRunDiscoverWithDeps_IncludeUnsupportedFromManifestIsFatal pins
+// the mutual-exclusion gate: --include-unsupported needs a live scan
+// so it can't combine with --from-manifest.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_IncludeUnsupportedFromManifestIsFatal(t *testing.T) {
+	manifestDir := t.TempDir()
+	manifestPath := writeFixtureManifest(t, manifestDir, "aws", []imported.ImportedResource{
+		validResourceWithRegion("aws_sqs_queue.alpha", "us-east-1", "1234567890"),
+	})
+	outDir := t.TempDir()
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--from-manifest", manifestPath,
+			"--include-unsupported",
+			"--output-dir", outDir,
+		}, okDeps(&fakeAggregator{}))
+	})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+	if !strings.Contains(stderr, "include-unsupported") || !strings.Contains(stderr, "from-manifest") {
+		t.Errorf("stderr should name both flags in the mutex error; got: %s", stderr)
+	}
+}
+
+// TestRunDiscoverWithDeps_IncludeUnsupportedSoftFailureKeepsImportedJSON
+// pins the soft-failure invariant: an enumerator error does NOT abort
+// the run. imported.json is still written, the run exits 0, and a
+// stderr WARN is emitted.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_IncludeUnsupportedSoftFailureKeepsImportedJSON(t *testing.T) {
+	outDir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	deps := okDeps(agg)
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+		return nil, errors.New("simulated: Resource Explorer not configured")
+	}
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--output-dir", outDir,
+			"--include-unsupported",
+			"--no-hcl",
+		}, deps)
+	})
+	if rc != discoverExitOK {
+		t.Errorf("rc=%d, want OK (soft-failure must not abort)", rc)
+	}
+	// imported.json must exist on disk.
+	if _, err := os.Stat(filepath.Join(outDir, "imported.json")); err != nil {
+		t.Errorf("imported.json missing on soft-failure path: %v", err)
+	}
+	// unsupported.json must NOT exist.
+	if _, err := os.Stat(filepath.Join(outDir, "unsupported.json")); err == nil {
+		t.Errorf("unsupported.json was written despite enumerator error")
+	}
+	// Stderr WARN with the literal "WARN" so the wizard's UI parser
+	// can route it to the soft-failure toast.
+	if !strings.Contains(stderr, "WARN") || !strings.Contains(stderr, "include-unsupported") {
+		t.Errorf("stderr WARN missing expected substrings; got: %s", stderr)
+	}
+}
+
+// TestRunDiscoverWithDeps_IncludeUnsupportedDeterministicOrder pins
+// the byte-identical output invariant across runs of the same input.
+// A regression that switched the sort key (or dropped sorting) would
+// surface as a flaky picker UI in the wizard.
+func TestRunDiscoverWithDeps_IncludeUnsupportedDeterministicOrder(t *testing.T) {
+	t.Parallel()
+	rows := []awsdiscover.UnsupportedResource{
+		{Type: "aws_vpc", ID: "arn-z", Region: "us-east-1"},
+		{Type: "aws_subnet", ID: "arn-a", Region: "us-east-1"},
+		{Type: "aws_vpc", ID: "arn-a", Region: "us-east-1"},
+	}
+	enum := func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+		// Return the same input in a permuted order — the writer's
+		// sort must produce identical files in both runs.
+		return rows, nil
+	}
+	enumRev := func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+		rev := make([]awsdiscover.UnsupportedResource, len(rows))
+		for i := range rows {
+			rev[len(rows)-1-i] = rows[i]
+		}
+		return rev, nil
+	}
+
+	dir1, dir2 := t.TempDir(), t.TempDir()
+	d1 := okDeps(&fakeAggregator{})
+	d1.enumerateUnsupportedAWS = enum
+	d2 := okDeps(&fakeAggregator{})
+	d2.enumerateUnsupportedAWS = enumRev
+	for _, dt := range []struct {
+		dir  string
+		deps discoverDeps
+	}{{dir1, d1}, {dir2, d2}} {
+		rc := runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--output-dir", dt.dir,
+			"--include-unsupported",
+			"--no-hcl",
+		}, dt.deps)
+		if rc != discoverExitOK {
+			t.Fatalf("rc=%d, want OK", rc)
+		}
+	}
+	a, err := os.ReadFile(filepath.Join(dir1, "unsupported.json"))
+	require.NoError(t, err)
+	b, err := os.ReadFile(filepath.Join(dir2, "unsupported.json"))
+	require.NoError(t, err)
+	assert.Equal(t, a, b, "unsupported.json must be byte-identical across permuted-input runs")
+}
+
+// TestRunDiscoverWithDeps_IncludeUnsupportedNotSetSkipsEmission pins
+// the back-compat invariant: without --include-unsupported, no
+// unsupported.json file is written, and the AWS enumerator is not
+// called.
+func TestRunDiscoverWithDeps_IncludeUnsupportedNotSetSkipsEmission(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+	called := 0
+	deps := okDeps(&fakeAggregator{})
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+		called++
+		return nil, nil
+	}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--regions", "us-east-1",
+		"--output-dir", outDir,
+		"--no-hcl",
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	if called != 0 {
+		t.Errorf("enumerateUnsupportedAWS called %d times without --include-unsupported, want 0", called)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "unsupported.json")); err == nil {
+		t.Errorf("unsupported.json was written without --include-unsupported")
+	}
+}
+
+// TestRunDiscoverWithDeps_IncludeUnsupportedGCP pins the GCP-side
+// emission contract: --provider gcp + --include-unsupported produces
+// unsupported.json with the GCP enumerator's rows. The
+// enumerateUnsupportedGCP seam is injected explicitly because the GCP
+// branch's production rebind is gated on the gcpAggAdapter type
+// assertion, which the fake aggregator doesn't satisfy.
+func TestRunDiscoverWithDeps_IncludeUnsupportedGCP(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+	agg := &fakeAggregator{}
+	deps, _ := okGCPDeps(t, agg)
+	deps.enumerateUnsupportedGCP = func(_ context.Context, _ gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, error) {
+		return []gcpdiscover.UnsupportedResource{
+			{Type: "google_compute_instance", ID: "//compute.googleapis.com/projects/p/zones/us/instances/vm", Name: "vm", Location: "us"},
+		}, nil
+	}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "gcp",
+		"--project", "io-foo",
+		"--gcp-project-id", "real-proj",
+		"--output-dir", outDir,
+		"--include-unsupported",
+		"--no-hcl",
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	body, err := os.ReadFile(filepath.Join(outDir, "unsupported.json"))
+	require.NoError(t, err)
+	var got []UnsupportedResource
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.Len(t, got, 1)
+	if got[0].Type != "google_compute_instance" {
+		t.Errorf("Type=%q, want google_compute_instance", got[0].Type)
+	}
+	if got[0].Location != "us" {
+		t.Errorf("Location=%q, want us", got[0].Location)
 	}
 }

--- a/cmd/insideout-import/gcpdiscover/unsupported.go
+++ b/cmd/insideout-import/gcpdiscover/unsupported.go
@@ -1,0 +1,165 @@
+package gcpdiscover
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
+)
+
+// unsupportedGCPServiceSlug is the progress-event service slug used
+// for the --include-unsupported Cloud Asset call. We pick a distinct
+// slug from gcpServiceSlug so the wizard's UI can render the
+// unsupported-enumeration phase independently of the importable-types
+// scan even though both call SearchAllResources.
+const unsupportedGCPServiceSlug = "unsupported"
+
+// UnsupportedResource mirrors the awsdiscover-side carrier exactly
+// (matched per the `{type,id,name,region,location,tags,group}` shape
+// promised in #289 gap-#6). We re-declare the type here rather than
+// importing across cloud packages so each cloud's enumerator stays a
+// leaf package — the CLI-level imported_unsupported.go consolidates the
+// two into the on-disk wire shape.
+type UnsupportedResource struct {
+	Type     string            `json:"type"`
+	ID       string            `json:"id"`
+	Name     string            `json:"name"`
+	Region   string            `json:"region,omitempty"`
+	Location string            `json:"location,omitempty"`
+	Tags     map[string]string `json:"tags,omitempty"`
+	Group    string            `json:"group,omitempty"`
+}
+
+// UnsupportedArgs is the GCP enumerator's input shape. Mirrors
+// DiscoverArgs (Project, Regions, TagSelectors, Emitter) so callers
+// share the bulk of the wiring. The Searcher seam is the same
+// gcpAssetSearcher interface the Stage 2d aggregator uses, which keeps
+// unit tests free of any new fake.
+type UnsupportedArgs struct {
+	// Project carries the stack project name, applied as a
+	// `labels.project:<v>` clause server-side via buildSearchQuery —
+	// same semantics as the importable-types scan.
+	Project string
+
+	// Regions populates the location filter, same shape as DiscoverArgs.
+	Regions []string
+
+	// TagSelectors append `labels.<k>:<v>` clauses to the query,
+	// AND-conjuncted with the project label and location clauses.
+	TagSelectors []TagSelector
+
+	// Searcher is the test seam. Production callers leave it nil and
+	// EnumerateUnsupported uses the searcher stored on *GCPDiscoverer.
+	Searcher gcpAssetSearcher
+
+	// Emitter is the streaming-progress sink. Resolved to NopEmitter at
+	// the top of EnumerateUnsupported when nil.
+	Emitter progress.Emitter
+}
+
+// EnumerateUnsupported runs one Cloud Asset SearchAllResources call
+// scoped to the asset types in gcpUnsupportedTFTypeByAssetType minus
+// the importable set, returning one UnsupportedResource per hit.
+//
+// One Search call covers all regions in args.Regions because Cloud
+// Asset's location-filter clause folds the multi-region semantics into
+// the query string (see buildSearchQuery). We emit a single
+// (service_start / service_finish) bracket around the call and an
+// item_found per emitted row.
+//
+// Errors from the underlying SearchAllResources surface unwrapped so
+// the CLI's soft-failure wrapper can pattern-match on the typed gRPC
+// status — Cloud Asset's "API not enabled" returns a PermissionDenied
+// or FailedPrecondition that the wizard's UI translates into the same
+// "operator action required" toast as the AWS Resource-Explorer-not-
+// configured path.
+func (g *GCPDiscoverer) EnumerateUnsupported(ctx context.Context, args UnsupportedArgs) ([]UnsupportedResource, error) {
+	if args.Searcher == nil {
+		args.Searcher = g.searcher
+	}
+	if args.Searcher == nil {
+		return nil, fmt.Errorf("EnumerateUnsupported: no searcher configured (production callers wire NewRealAssetSearcher; tests inject a fake)")
+	}
+	if args.Emitter == nil {
+		args.Emitter = progress.NopEmitter{}
+	}
+
+	supportedSet := make(map[string]struct{})
+	for _, t := range registry.SupportedDiscoverTypes(registry.ProviderGCP) {
+		supportedSet[t] = struct{}{}
+	}
+	assetTypes := gcpUnsupportedAssetTypes(supportedSet)
+	if len(assetTypes) == 0 {
+		// Defensive: the lookup map must be non-empty (and CI's
+		// TestGCPUnsupportedAssetTypes_PerKnownType pin keeps it that
+		// way), so an empty assetTypes here means every entry in the map
+		// is in the supported set — a programming error rather than a
+		// runtime branch worth exercising. Return an empty slice (not
+		// nil) so the caller's writeUnsupportedManifest emits `[]`.
+		return []UnsupportedResource{}, nil
+	}
+
+	scope := fmt.Sprintf("projects/%s", g.projectID)
+	query := buildSearchQuery(args.Project, args.Regions, args.TagSelectors)
+
+	stageStart := time.Now()
+	args.Emitter.ServiceStart(unsupportedGCPServiceSlug, "")
+
+	results, err := args.Searcher.SearchAll(ctx, scope, assetTypes, query)
+	if err != nil {
+		args.Emitter.ServiceFinish(unsupportedGCPServiceSlug, "", 0, time.Since(stageStart))
+		return nil, fmt.Errorf("cloud asset SearchAllResources (unsupported): %w", err)
+	}
+
+	out := make([]UnsupportedResource, 0, len(results))
+	for _, r := range results {
+		row := gcpAssetToUnsupported(r)
+		args.Emitter.ItemFound(unsupportedGCPServiceSlug, r.Location, row.Type, row.ID)
+		out = append(out, row)
+	}
+	args.Emitter.ServiceFinish(unsupportedGCPServiceSlug, "", len(out), time.Since(stageStart))
+	return out, nil
+}
+
+// gcpAssetToUnsupported translates one Cloud Asset hit into an
+// UnsupportedResource. The Cloud Asset full resource name has the form
+// `//<service>/<segments>` — the trailing path segment is the natural
+// display name. Tags pass through from asset.Labels.
+//
+// We do NOT subtract the supportedSet here (unlike the AWS path)
+// because the assetTypes filter on the SearchAllResources request
+// already excludes importable types server-side. The post-filter on
+// AWS exists because Resource Explorer can return any type the user's
+// view exposes; the GCP path is type-scoped at the API layer.
+func gcpAssetToUnsupported(r gcpAssetResult) UnsupportedResource {
+	tfType, _ := mapGCPAssetTypeToTF(r.AssetType)
+	name := gcpResourceNameFromAssetName(r.Name)
+	if name == "" {
+		name = r.AssetType
+	}
+	return UnsupportedResource{
+		Type:     tfType,
+		ID:       r.Name,
+		Name:     name,
+		Location: r.Location,
+		Tags:     r.Labels,
+	}
+}
+
+// gcpResourceNameFromAssetName extracts the trailing path segment of a
+// Cloud Asset full resource name. Examples:
+//
+//	//compute.googleapis.com/projects/p/zones/us-central1-a/instances/my-vm  -> my-vm
+//	//bigquery.googleapis.com/projects/p/datasets/my_ds                      -> my_ds
+//	//container.googleapis.com/projects/p/locations/us-central1/clusters/c   -> c
+//
+// Returns the empty string for malformed names.
+func gcpResourceNameFromAssetName(assetName string) string {
+	if assetName == "" {
+		return ""
+	}
+	return path.Base(assetName)
+}

--- a/cmd/insideout-import/gcpdiscover/unsupported_test.go
+++ b/cmd/insideout-import/gcpdiscover/unsupported_test.go
@@ -1,0 +1,284 @@
+package gcpdiscover
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// gcpAsset constructs a gcpAssetResult fixture with the fields
+// EnumerateUnsupported reads.
+func gcpAsset(name, assetType, location string, labels map[string]string) gcpAssetResult {
+	return gcpAssetResult{
+		Name:      name,
+		AssetType: assetType,
+		Location:  location,
+		Labels:    labels,
+	}
+}
+
+// TestEnumerateUnsupportedGCP_BuildsAssetTypesClauseFromUnsupportedSet
+// pins the SearchAllResources request shape: the assetTypes filter
+// covers exactly the keys of gcpUnsupportedTFTypeByAssetType minus any
+// importable mappings (none currently overlap; the test asserts the
+// invariant for future-proofing).
+func TestEnumerateUnsupportedGCP_BuildsAssetTypesClauseFromUnsupportedSet(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{}
+	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
+	if _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
+		Project: "io-foo",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("calls=%d, want 1 (one SearchAllResources for unsupported)", len(fake.calls))
+	}
+	got := fake.calls[0].assetTypes
+	// Must include every unimportable asset type from the lookup map.
+	for assetType := range gcpUnsupportedTFTypeByAssetType {
+		if !slices.Contains(got, assetType) {
+			t.Errorf("assetTypes %v missing %s", got, assetType)
+		}
+	}
+	// Must be sorted (deterministic on-the-wire shape).
+	for i := 1; i < len(got); i++ {
+		if got[i-1] > got[i] {
+			t.Errorf("assetTypes not sorted: %v", got)
+			break
+		}
+	}
+}
+
+// TestEnumerateUnsupportedGCP_FiltersOutImportableTypes pins the
+// registry-subtraction invariant: any importable mapping in the lookup
+// is dropped from the SearchAllResources assetTypes filter. Today no
+// entry overlaps, but a future change that adds an entry for a type
+// the registry already imports would silently leak rows into
+// unsupported.json — this test catches that.
+func TestEnumerateUnsupportedGCP_FiltersOutImportableTypes(t *testing.T) {
+	t.Parallel()
+	// Construct a synthetic supported-set covering one of the lookup
+	// entries to assert the subtract step actually fires.
+	supportedSet := map[string]struct{}{
+		"google_compute_instance": {},
+	}
+	got := gcpUnsupportedAssetTypes(supportedSet)
+	for _, at := range got {
+		if at == "compute.googleapis.com/Instance" {
+			t.Errorf("assetTypes %v leaked %s despite being in supportedSet", got, at)
+		}
+	}
+}
+
+// TestEnumerateUnsupportedGCP_TFTypeMappedFromAssetType pins that each
+// entry in the lookup map round-trips through EnumerateUnsupported to
+// the right Terraform type. Mirrors the AWS test of the same shape.
+func TestEnumerateUnsupportedGCP_TFTypeMappedFromAssetType(t *testing.T) {
+	t.Parallel()
+	for assetType, wantTF := range gcpUnsupportedTFTypeByAssetType {
+		assetType, wantTF := assetType, wantTF
+		t.Run(assetType, func(t *testing.T) {
+			t.Parallel()
+			fake := &fakeAssetSearcher{
+				results: []gcpAssetResult{gcpAsset(
+					"//"+strings.Split(assetType, "/")[0]+"/projects/p/things/foo",
+					assetType,
+					"us-central1",
+					nil,
+				)},
+			}
+			g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
+			got, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("got %d rows, want 1", len(got))
+			}
+			if got[0].Type != wantTF {
+				t.Errorf("Type=%q, want %q for AssetType=%q", got[0].Type, wantTF, assetType)
+			}
+		})
+	}
+}
+
+// TestEnumerateUnsupportedGCP_UnknownAssetTypePreservesEmpty pins the
+// fall-through: an unknown asset type returned by the searcher
+// produces a row with Type="" so the picker can still surface it.
+func TestEnumerateUnsupportedGCP_UnknownAssetTypePreservesEmpty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{gcpAsset(
+			"//newservice.googleapis.com/projects/p/things/foo",
+			"newservice.googleapis.com/Thing",
+			"us-central1",
+			nil,
+		)},
+	}
+	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
+	got, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d rows, want 1", len(got))
+	}
+	if got[0].Type != "" {
+		t.Errorf("Type=%q, want empty for unknown AssetType", got[0].Type)
+	}
+	if got[0].Name != "foo" {
+		t.Errorf("Name=%q, want %q (trailing path segment)", got[0].Name, "foo")
+	}
+}
+
+// TestEnumerateUnsupportedGCP_LabelsPassThrough pins that asset.Labels
+// flows into UnsupportedResource.Tags unchanged — the GCP path uses
+// labels as the operator-facing tag concept, mirroring CLAUDE.md's
+// labels-as-tags rule.
+func TestEnumerateUnsupportedGCP_LabelsPassThrough(t *testing.T) {
+	t.Parallel()
+	wantLabels := map[string]string{"env": "prod", "owner": "team-a"}
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{gcpAsset(
+			"//compute.googleapis.com/projects/p/zones/us/instances/vm",
+			"compute.googleapis.com/Instance",
+			"us",
+			wantLabels,
+		)},
+	}
+	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
+	got, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d rows, want 1", len(got))
+	}
+	if got[0].Tags == nil || got[0].Tags["env"] != "prod" || got[0].Tags["owner"] != "team-a" {
+		t.Errorf("Tags=%v, want %v passthrough", got[0].Tags, wantLabels)
+	}
+}
+
+// TestEnumerateUnsupportedGCP_SearcherErrorIsReturned pins error
+// propagation: a SearchAllResources failure surfaces through to the
+// caller. The CLI's WARN-and-continue branch is exercised at the
+// orchestrator level; here we just assert the wrap.
+func TestEnumerateUnsupportedGCP_SearcherErrorIsReturned(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("permission denied: cloudasset.assets.searchAllResources")
+	fake := &fakeAssetSearcher{err: wantErr}
+	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
+	_, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	if err == nil {
+		t.Fatal("err=nil, want error")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err=%v, want wrap of %v", err, wantErr)
+	}
+}
+
+// TestEnumerateUnsupportedGCP_NilSearcherIsFatal pins the safety net.
+func TestEnumerateUnsupportedGCP_NilSearcherIsFatal(t *testing.T) {
+	t.Parallel()
+	g := &GCPDiscoverer{projectID: "real-proj"}
+	_, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	if err == nil {
+		t.Fatal("err=nil, want explicit error when no searcher configured")
+	}
+}
+
+// TestEnumerateUnsupportedGCP_EmitsServiceStartFinish pins the
+// progress-event contract: one (service_start, service_finish) bracket
+// (one Search call covers all regions), plus item_found per row.
+func TestEnumerateUnsupportedGCP_EmitsServiceStartFinish(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{
+			gcpAsset("//compute.googleapis.com/projects/p/zones/us/instances/a", "compute.googleapis.com/Instance", "us", nil),
+			gcpAsset("//compute.googleapis.com/projects/p/zones/us/instances/b", "compute.googleapis.com/Instance", "us", nil),
+		},
+	}
+	rec := &recordingEmitter{}
+	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
+	if _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{Emitter: rec}); err != nil {
+		t.Fatal(err)
+	}
+	starts, finishes, items := 0, 0, 0
+	for _, e := range rec.snapshot() {
+		switch e.Kind {
+		case "service_start":
+			if e.Service != "unsupported" {
+				t.Errorf("service_start.service=%q, want unsupported", e.Service)
+			}
+			starts++
+		case "service_finish":
+			if e.Service != "unsupported" {
+				t.Errorf("service_finish.service=%q, want unsupported", e.Service)
+			}
+			finishes++
+		case "item_found":
+			items++
+		}
+	}
+	if starts != 1 {
+		t.Errorf("service_start count=%d, want 1", starts)
+	}
+	if finishes != 1 {
+		t.Errorf("service_finish count=%d, want 1", finishes)
+	}
+	if items != 2 {
+		t.Errorf("item_found count=%d, want 2", items)
+	}
+}
+
+// TestEnumerateUnsupportedGCP_QueryShapeFromArgs pins the search-query
+// composition: --regions and --tag-selectors flow through buildSearchQuery.
+func TestEnumerateUnsupportedGCP_QueryShapeFromArgs(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{}
+	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
+	if _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
+		Project:      "io-foo",
+		Regions:      []string{"us-central1"},
+		TagSelectors: []TagSelector{{Key: "env", Value: "prod"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("calls=%d, want 1", len(fake.calls))
+	}
+	q := fake.calls[0].query
+	if !strings.Contains(q, "labels.project:io-foo") {
+		t.Errorf("query=%q missing labels.project clause", q)
+	}
+	if !strings.Contains(q, "location:us-central1") {
+		t.Errorf("query=%q missing location clause", q)
+	}
+	if !strings.Contains(q, "labels.env:prod") {
+		t.Errorf("query=%q missing tag-selector clause", q)
+	}
+}
+
+// TestGCPResourceNameFromAssetName_TrailingSegment pins the display-
+// name extraction across asset-name shapes Cloud Asset hands back.
+func TestGCPResourceNameFromAssetName_TrailingSegment(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"//compute.googleapis.com/projects/p/zones/us-central1-a/instances/my-vm", "my-vm"},
+		{"//bigquery.googleapis.com/projects/p/datasets/my_ds", "my_ds"},
+		{"//container.googleapis.com/projects/p/locations/us-central1/clusters/c", "c"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := gcpResourceNameFromAssetName(tc.name)
+		if got != tc.want {
+			t.Errorf("gcpResourceNameFromAssetName(%q)=%q, want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/unsupported_types.go
+++ b/cmd/insideout-import/gcpdiscover/unsupported_types.go
@@ -1,0 +1,74 @@
+package gcpdiscover
+
+import "sort"
+
+// gcpUnsupportedTFTypeByAssetType maps a Cloud Asset Inventory asset
+// type (e.g. "compute.googleapis.com/Instance") to its canonical
+// Terraform resource type (e.g. "google_compute_instance"). Only types
+// listed here translate to a non-empty Type in the emitted
+// UnsupportedResource — unmapped asset types still appear in
+// unsupported.json with Type="" and the asset type slug in Name.
+//
+// The initial mapping covers the high-traffic GCP types the wizard's
+// mockup calls out as picker rows: Compute (instances + disks +
+// subnetworks), VPC (firewalls), Cloud SQL, GKE, IAM service accounts,
+// Cloud Functions, Cloud Run, BigQuery datasets. Extending this table
+// is a one-line change per row.
+//
+// Why a hand-maintained map: Cloud Asset's asset-type string is
+// service.googleapis.com/Type; Terraform's type string is google_<service>
+// _<type> with ad-hoc renames (e.g. cloudfunctions.googleapis.com/Function
+// vs. google_cloudfunctions_function vs. google_cloudfunctions2_function
+// for the v2 product). A pure transform produces wrong types ~30% of
+// the time across the surveyed surface. The lookup table is the only
+// reliable shape.
+var gcpUnsupportedTFTypeByAssetType = map[string]string{
+	// Compute
+	"compute.googleapis.com/Instance":   "google_compute_instance",
+	"compute.googleapis.com/Disk":       "google_compute_disk",
+	"compute.googleapis.com/Subnetwork": "google_compute_subnetwork",
+	"compute.googleapis.com/Firewall":   "google_compute_firewall",
+	// Data
+	"sqladmin.googleapis.com/Instance": "google_sql_database_instance",
+	"bigquery.googleapis.com/Dataset":  "google_bigquery_dataset",
+	// Containers / Serverless
+	"container.googleapis.com/Cluster":       "google_container_cluster",
+	"cloudfunctions.googleapis.com/Function": "google_cloudfunctions_function",
+	"run.googleapis.com/Service":             "google_cloud_run_service",
+	// IAM
+	"iam.googleapis.com/ServiceAccount": "google_service_account",
+}
+
+// mapGCPAssetTypeToTF resolves a Cloud Asset asset type to its
+// Terraform type. Unmapped types return ("", false).
+func mapGCPAssetTypeToTF(at string) (string, bool) {
+	if at == "" {
+		return "", false
+	}
+	tf, ok := gcpUnsupportedTFTypeByAssetType[at]
+	return tf, ok
+}
+
+// gcpUnsupportedAssetTypes returns the asset-type strings to feed into
+// the Cloud Asset SearchAllResources request when --include-unsupported
+// is set. The slice is the union of the keys in
+// gcpUnsupportedTFTypeByAssetType minus any whose mapped Terraform
+// type is in the registry's importable set (the picker reads those
+// rows from imported.json instead).
+//
+// We materialize the full, sorted slice so the SearchAllResources
+// request's `assetTypes` field is deterministic across runs — easier to
+// debug a misbehaving query when the request body is byte-identical.
+func gcpUnsupportedAssetTypes(supportedSet map[string]struct{}) []string {
+	out := make([]string, 0, len(gcpUnsupportedTFTypeByAssetType))
+	for assetType, tfType := range gcpUnsupportedTFTypeByAssetType {
+		if _, ok := supportedSet[tfType]; ok {
+			continue
+		}
+		out = append(out, assetType)
+	}
+	// Sort for determinism — the search-query builder concatenates these
+	// into the request and we want a stable wire shape across runs.
+	sort.Strings(out)
+	return out
+}

--- a/cmd/insideout-import/imported_unsupported.go
+++ b/cmd/insideout-import/imported_unsupported.go
@@ -1,0 +1,77 @@
+// Package main holds the CLI surface; the UnsupportedResource carrier
+// lives here (rather than under pkg/composer/imported/) because it is an
+// emission-format only — it never enters the Terraform IR pipeline that
+// imported.ImportedResource feeds. Promoting it to pkg/ would force every
+// downstream consumer (composer, validators, golden tests) to grow a
+// second carrier shape they don't actually use.
+package main
+
+// UnsupportedResource is the per-row shape emitted in unsupported.json
+// when --include-unsupported (#296, gap #6 of #289) is set on a discover
+// run. The reliable importer wizard's resource picker reads this file to
+// render greyed-out rows for resource types the discover pipeline cannot
+// import yet, alongside the fully-importable rows in imported.json.
+//
+// Field shape mirrors the wizard mockup's DiscoveredResource carrier
+// (`{ type, id, name, region, location, tags, group }`); the registry
+// of importable types lives at pkg/insideout-import/registry/registry.go
+// and is the source of truth for the supported-set subtraction the AWS
+// and GCP enumerators apply.
+//
+// JSON wire-format invariants enforced by writeUnsupportedManifest:
+//   - top-level is always a JSON array, never `null` (empty input writes `[]`)
+//   - rows sorted deterministically by (Type, Region, ID) so byte-identical
+//     output across runs for the same input
+//   - omitempty on the four optional fields — a row with no Region/Location/
+//     Tags/Group emits only the three required keys
+type UnsupportedResource struct {
+	// Type is the Terraform resource type the wizard would write into the
+	// generated.tf if discover supported this row (e.g. "aws_vpc",
+	// "google_sql_database_instance"). Empty when the cloud-side resource
+	// has no canonical Terraform mapping in our lookup table — the picker
+	// falls back to displaying the cloud-native AssetType / ResourceType
+	// in the Name field so the row is still legible.
+	Type string `json:"type"`
+
+	// ID is the cloud-side native identifier — an ARN for AWS, the full
+	// Cloud Asset resource name for GCP. The picker uses ID as the row's
+	// stable key; the wizard's "include in import" callback echoes the ID
+	// back to the agent-API.
+	ID string `json:"id"`
+
+	// Name is the short display name shown in the picker row's title cell.
+	// AWS: ResourceType slug from Resource Explorer (e.g. "ec2:vpc") when
+	// no Terraform mapping is registered; the trailing path segment of
+	// the ARN otherwise. GCP: trailing path segment of the asset name.
+	Name string `json:"name"`
+
+	// Region populates the picker's region column for AWS. Empty for
+	// global services (IAM, S3 — which are imported, so not enumerated
+	// here in practice — and CloudFront, which is enumerated). GCP uses
+	// Location instead so this field stays empty on GCP rows.
+	Region string `json:"region,omitempty"`
+
+	// Location populates the picker's region column for GCP. Empty for
+	// project-global asset types (Pub/Sub, Secret Manager, VPC networks).
+	// AWS rows leave Location empty.
+	Location string `json:"location,omitempty"`
+
+	// Tags is the resource's tag (AWS) or label (GCP) map at enumeration
+	// time. Nil when the underlying API surface didn't return tags
+	// inline (AWS Resource Explorer's Resource shape exposes tags only
+	// via a per-type Properties JSON document, which we don't unmarshal
+	// today — see the type-mapping table comment in awsdiscover/unsupported_types.go).
+	Tags map[string]string `json:"tags,omitempty"`
+
+	// Group is the high-level UI category ("Events", "Data Storage",
+	// "Network Security", ...) the wizard groups picker rows under. This
+	// PR (#296) leaves Group empty intentionally — the Category map that
+	// translates Type → Group lands in the parallel #297 (Bundle 2 / PR 3)
+	// PR, which iterates this slice and stamps Group post-emit. Until
+	// then the picker uses an "Other" fallback bucket.
+	//
+	// TODO(#297): populate Group from the imported.Category map once it
+	// lands; this PR ships the field on the wire so #297 is a pure
+	// composer change without an unsupported.json schema bump.
+	Group string `json:"group,omitempty"`
+}

--- a/cmd/insideout-import/manifest.go
+++ b/cmd/insideout-import/manifest.go
@@ -17,6 +17,11 @@ import (
 // manifestFile is the on-disk file name written into --output-dir.
 const manifestFile = "imported.json"
 
+// unsupportedManifestFile is the on-disk file name for the broad-
+// enumeration sibling manifest written by writeUnsupportedManifest
+// when --include-unsupported is set (#296).
+const unsupportedManifestFile = "unsupported.json"
+
 // writeManifest validates the resource set with composer.ValidateImportedResources
 // and writes the JSON array of ImportedResource into <dir>/imported.json.
 // Validation runs BEFORE the file is written so a failing validator never
@@ -107,6 +112,53 @@ func readManifest(path, cloud string) ([]imported.ImportedResource, error) {
 		return nil, fmt.Errorf("manifest validation failed (%d issue(s)): %s", len(issues), formatIssues(issues))
 	}
 	return resources, nil
+}
+
+// writeUnsupportedManifest writes the JSON array of UnsupportedResource
+// rows into <dir>/unsupported.json (#296). Mirrors writeManifest's
+// invariants: nil → []-not-null, deterministic sort, file written
+// atomically via WriteFile.
+//
+// Sort key is (Type, Region, ID) so byte-identical output across runs
+// for the same input. Type-first keeps the picker's "all aws_vpc rows"
+// runs together visually; Region tie-breaks within a type (multi-
+// region scans); ID is the final tiebreaker for rows that match on
+// both. Unlike writeManifest, no validator runs here — the unsupported
+// carrier has no IR-side schema to enforce: the wire shape is checked
+// by the field tags on UnsupportedResource and the test suite below.
+//
+// Returns (path, count, error). On marshal/write failure no file is
+// written so the caller's stderr surface is the only side-effect of a
+// soft-failure path (#296 contract: imported.json must complete even
+// when unsupported emission fails).
+func writeUnsupportedManifest(dir string, resources []UnsupportedResource) (string, int, error) {
+	if resources == nil {
+		resources = []UnsupportedResource{}
+	}
+	sort.Slice(resources, func(i, j int) bool {
+		if resources[i].Type != resources[j].Type {
+			return resources[i].Type < resources[j].Type
+		}
+		if resources[i].Region != resources[j].Region {
+			return resources[i].Region < resources[j].Region
+		}
+		return resources[i].ID < resources[j].ID
+	})
+
+	body, err := json.MarshalIndent(resources, "", "  ")
+	if err != nil {
+		return "", 0, fmt.Errorf("marshal unsupported manifest: %w", err)
+	}
+	body = append(body, '\n')
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", 0, fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	out := filepath.Join(dir, unsupportedManifestFile)
+	if err := os.WriteFile(out, body, 0o644); err != nil {
+		return "", 0, fmt.Errorf("write %s: %w", out, err)
+	}
+	return out, len(resources), nil
 }
 
 // formatIssues turns a slice of validation issues into a multi-line string

--- a/cmd/insideout-import/manifest_test.go
+++ b/cmd/insideout-import/manifest_test.go
@@ -289,3 +289,175 @@ func TestWriteManifest_EmptyInputWritesJSONArrayNotNull(t *testing.T) {
 		t.Errorf("manifest must end with a trailing newline; got: %q", body)
 	}
 }
+
+// --- #296: writeUnsupportedManifest tests ---
+
+// TestWriteUnsupportedManifest_HappyPath pins the basic invariant: 2
+// rows in, 2 rows out, deterministic file name, valid JSON.
+func TestWriteUnsupportedManifest_HappyPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rows := []UnsupportedResource{
+		{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/b", Name: "b", Region: "us-east-1"},
+		{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/a", Name: "a", Region: "us-east-1"},
+	}
+	path, n, err := writeUnsupportedManifest(dir, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Errorf("count=%d, want 2", n)
+	}
+	if filepath.Base(path) != "unsupported.json" {
+		t.Errorf("path=%q, want ends in unsupported.json", path)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []UnsupportedResource
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unsupported.json is not valid JSON: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("decoded len=%d, want 2", len(got))
+	}
+	// Sort key is (Type, Region, ID) — both rows share Type+Region, so
+	// the ID-tiebreak puts the .../vpc/a row first.
+	if got[0].Name != "a" {
+		t.Errorf("first Name=%q, want %q (sorted by (Type, Region, ID))", got[0].Name, "a")
+	}
+}
+
+// TestWriteUnsupportedManifest_EmptyInputWritesArrayNotNull pins the
+// no-null contract: a nil/empty input still produces a `[]` on disk
+// (the wizard picker cannot range over null).
+func TestWriteUnsupportedManifest_EmptyInputWritesArrayNotNull(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	for _, in := range [][]UnsupportedResource{nil, {}} {
+		path, n, err := writeUnsupportedManifest(dir, in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 0 {
+			t.Errorf("count=%d, want 0 for empty input", n)
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.TrimSpace(string(body)) == "null" {
+			t.Errorf("must emit `[]` not `null`; got: %s", body)
+		}
+		if !bytes.HasPrefix(bytes.TrimSpace(body), []byte("[")) {
+			t.Errorf("must start with `[`; got: %s", body)
+		}
+	}
+}
+
+// TestWriteUnsupportedManifest_DeterministicAcrossRuns pins the byte-
+// identical output invariant: two runs with the same input produce
+// the same file (modulo input-order permutations the sort drops).
+func TestWriteUnsupportedManifest_DeterministicAcrossRuns(t *testing.T) {
+	t.Parallel()
+	rows := []UnsupportedResource{
+		{Type: "aws_vpc", ID: "arn-d", Name: "d", Region: "us-east-1"},
+		{Type: "google_compute_instance", ID: "asset-a", Name: "a", Location: "us"},
+		{Type: "aws_subnet", ID: "arn-c", Name: "c", Region: "eu-west-1"},
+		{Type: "", ID: "asset-b", Name: "b"},
+	}
+	dir1, dir2 := t.TempDir(), t.TempDir()
+	if _, _, err := writeUnsupportedManifest(dir1, rows); err != nil {
+		t.Fatal(err)
+	}
+	rev := make([]UnsupportedResource, len(rows))
+	for i := range rows {
+		rev[len(rows)-1-i] = rows[i]
+	}
+	if _, _, err := writeUnsupportedManifest(dir2, rev); err != nil {
+		t.Fatal(err)
+	}
+	a, err := os.ReadFile(filepath.Join(dir1, "unsupported.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir2, "unsupported.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Errorf("unsupported.json differs across runs with permuted input:\nrun1=%s\nrun2=%s", a, b)
+	}
+}
+
+// TestWriteUnsupportedManifest_SortOrder pins the (Type, Region, ID)
+// sort. A regression that switched to a different key (e.g. Name)
+// would visibly reorder picker rows in the wizard UI.
+func TestWriteUnsupportedManifest_SortOrder(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rows := []UnsupportedResource{
+		{Type: "aws_vpc", ID: "arn-z", Region: "us-east-1"},
+		{Type: "aws_subnet", ID: "arn-a", Region: "us-east-1"},
+		{Type: "aws_vpc", ID: "arn-a", Region: "us-east-1"},
+		{Type: "aws_vpc", ID: "arn-b", Region: "eu-west-1"},
+	}
+	if _, _, err := writeUnsupportedManifest(dir, rows); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "unsupported.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []UnsupportedResource
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	want := []struct {
+		typ, region, id string
+	}{
+		{"aws_subnet", "us-east-1", "arn-a"},
+		{"aws_vpc", "eu-west-1", "arn-b"},
+		{"aws_vpc", "us-east-1", "arn-a"},
+		{"aws_vpc", "us-east-1", "arn-z"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d rows, want %d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i].Type != want[i].typ || got[i].Region != want[i].region || got[i].ID != want[i].id {
+			t.Errorf("row[%d]=(%s,%s,%s), want (%s,%s,%s)",
+				i, got[i].Type, got[i].Region, got[i].ID,
+				want[i].typ, want[i].region, want[i].id)
+		}
+	}
+}
+
+// TestWriteUnsupportedManifest_OmitemptyOptionalFields pins the JSON
+// wire shape: rows with no Region/Location/Tags/Group emit only the
+// three required keys (type, id, name). The picker reads these fields
+// optionally; preserving the omitempty contract keeps the serialized
+// shape stable across runs.
+func TestWriteUnsupportedManifest_OmitemptyOptionalFields(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	row := UnsupportedResource{
+		Type: "aws_vpc",
+		ID:   "arn-only",
+		Name: "only",
+	}
+	if _, _, err := writeUnsupportedManifest(dir, []UnsupportedResource{row}); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "unsupported.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Negative assertions: the optional keys must NOT be present.
+	for _, key := range []string{`"region":`, `"location":`, `"tags":`, `"group":`} {
+		if bytes.Contains(body, []byte(key)) {
+			t.Errorf("manifest carries %s for omitempty-zero value; got: %s", key, body)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/opensearch v1.67.1
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.30.3
 	github.com/aws/aws-sdk-go-v2/service/rds v1.118.2
+	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.30.3 h1:47FPswEE4RK
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.30.3/go.mod h1:w/kwwh/dzVFrXLKUCj3M73lYUl+LrVn9gQ7RyiPNkZU=
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.2 h1:pkEeQneYFpTAnGhyqSbyp/DlCPPJTGt0GkWahlLYzMA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.2/go.mod h1:7gS+cGrKF0mH253QHFlStmx79ws+DlNk+04ZRfmw3U0=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6 h1:v4Gii9Pxx4bvvNmV5Se1pmx0ag5+Eb3/wZkT03iyCCI=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6/go.mod h1:W/WhNWo1nbW+wVQTw8681WzAj6yTOvGLl8GLWNEWC2I=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1 h1:mxuT1xE+dI54NW3RkNjP8DUT5HXqbkiAFvfdyDFwE5c=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7 h1:JUGKqUnJHbXpS8uyuICP/zpQ+vXUIXW2zTEqjMLCqrY=


### PR DESCRIPTION
## Summary

- New \`--include-unsupported\` flag on \`insideout-import discover\`. When set, enumerates resources of types NOT yet wired into per-service discoverers and emits them in a parallel \`unsupported.json\` next to \`imported.json\`.
- AWS: one Resource Explorer \`Search\` call per region, with the importable set (from \`registry.SupportedDiscoverTypes(\"aws\")\`) subtracted client-side. New \`resourceexplorer2\` SDK module added.
- GCP: one Cloud Asset \`SearchAllResources\` call with a broader \`assetTypes\` filter scoped to the unimportable set; reuses the existing \`buildSearchQuery\` so \`--regions\` and \`--tag-selectors\` apply equally.
- Soft-fails: an enumerator error (e.g. Resource Explorer not configured) prints a stderr WARN and the run still exits 0 with \`imported.json\` written.
- Mutually exclusive with \`--from-manifest\` — no live scan to enumerate.
- Per-row \`item_found\` and per-region \`service_start\`/\`service_finish\` progress events flow through the \`#295\` emitter for SSE consumption.

## Closes / Part of

- Closes #296
- Part of #289 (Bundle 2 / PR 2)
- Stacked on PR #300 → PR #299 → main

## Stacking note

- **Base branch:** \`feat/progress-json-295\` (not \`main\`).
- Stack order: \`main\` → #299 (\`feat/from-manifest-292\`) → #300 (\`feat/progress-json-295\`) → **this PR** (\`feat/include-unsupported-296\`).
- CI on stacked PRs only triggers cleanly after the base merges and GitHub auto-retargets — operator handles merge order.

## Test plan

- [x] \`go build ./...\` (locally green)
- [x] \`go test ./cmd/insideout-import/... ./pkg/composer/... ./pkg/insideout-import/... -count=1 -race\` — 1918 tests pass
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l cmd/ pkg/\` empty
- [x] All static lint scripts pass (project-tag, project-label, sensitive-for-each, foreach-unknown-keys, no-root-only-blocks, shared-no-cloud-providers, labelless-name-prefix, gcp-project-pin)
- [ ] CI green after base merges (stacked-PR caveat)
- New tests:
  - \`awsdiscover/unsupported_test.go\`: filters supported types, multi-region threading, tags pass-through, TF-type mapping table-drive, unknown-type fallthrough, error propagation, Resource-Explorer-not-configured detection, nil-searcher fatal, per-region progress events, ARN-name extraction.
  - \`gcpdiscover/unsupported_test.go\`: builds asset-types clause from unsupported set, filters out importable types, TF-type mapping, unknown-type fallthrough, labels pass-through, error propagation, nil-searcher fatal, progress events, query-shape composition, asset-name extraction.
  - \`manifest_test.go\`: happy-path, empty-input writes \`[]\` not \`null\`, deterministic across runs, sort order \`(Type, Region, ID)\`, omitempty on optional fields.
  - \`discover_test.go\`: writes \`unsupported.json\` end-to-end, \`--from-manifest\` mutex fatal, soft-failure keeps \`imported.json\`, deterministic ordering, no-flag skips emission, GCP-side emission.

## Out of scope

- \`Group\` field on \`UnsupportedResource\` ships empty intentionally; #297 (Bundle 2 / PR 3) populates it via a \`Category(terraformType string) string\` map. Documented inline.
- AWS \`Tags\` field stays nil: AWS Resource Explorer's \`Resource\` shape exposes tags only via a per-type \`Properties\` JSON document; surfacing them would require a per-row \`ListTagsForResource\` fanout that defeats the "single Search per region" performance model. Deferred.
- IAM permissions manifest update (mentioned in the issue's acceptance criteria) for the new \`resource-explorer-2:Search\` permission tracks under #289 gap-#10 (separate PR).