### PR TITLE
feat(insideout-import): DiscoverySummary aggregate summary.json (#298)

### DIFF
--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -419,6 +419,56 @@ Exit codes:
 	ctx, cancel := context.WithTimeout(context.Background(), discoverTimeout)
 	defer cancel()
 
+	// summaryStart is the wall-clock anchor for ScanSummary.duration_ms
+	// in summary.json (#298). We capture it here — after argument
+	// parsing, before any cloud config / STS / discovery — so the
+	// duration measures the discovery + HCL pipeline scope, not the
+	// CLI argv parse latency. Used by writeSummary at every success
+	// exit below.
+	summaryStart := time.Now()
+	// summaryResources holds the final resource set the summary should
+	// reflect. It evolves as the pipeline progresses (Stage 2a output
+	// → Stage 2b enriched → Stage 2c3 expanded). We re-assign it after
+	// each writeManifest so the on-disk imported.json and the
+	// in-memory summary stay aligned. The deferred summary writer
+	// reads this slice last, after every other exit-path mutation.
+	var summaryResources []imported.ImportedResource
+	// summaryUnsupportedCount is set when --include-unsupported runs
+	// to completion (soft-failures leave it at 0 — the WARN'd
+	// unsupported.json was never written, so the summary's
+	// `unsupported` count must not lie about its existence).
+	summaryUnsupportedCount := 0
+	// summaryShouldEmit gates the deferred writer. Argument-validation
+	// fatals exit before the function gets far enough to be useful;
+	// we flip this to true once we've established a valid output dir
+	// + cloud + scope so the summary is only attempted on runs that
+	// would have produced an imported.json. The defer re-reads this
+	// flag at exit to decide whether to emit.
+	summaryShouldEmit := false
+	defer func() {
+		if !summaryShouldEmit {
+			return
+		}
+		summary := imported.SummarizeResources(summaryResources, imported.SummaryOpts{
+			Cloud:            cloud,
+			UnsupportedCount: summaryUnsupportedCount,
+			Duration:         time.Since(summaryStart),
+			Regions:          resolvedRegions,
+			TagSelectors:     toSummaryTagSelectors(parsedSelectors),
+		})
+		if path, err := writeSummary(*outputDir, summary); err != nil {
+			// Best-effort: a write failure must not flip an
+			// otherwise-OK run to fatal — imported.json is the
+			// source of truth. Log to stderr (not summaryOut, so
+			// a JSON-progress consumer doesn't see this on
+			// stdout) and continue.
+			fmt.Fprintf(os.Stderr, "discover: write summary.json: %v (continuing)\n", err)
+		} else {
+			fmt.Fprintf(summaryOut, "wrote %s (%d importable + %d unsupported = %d total)\n",
+				path, summary.Importable, summary.Unsupported, summary.Total)
+		}
+	}()
+
 	// --from-manifest pre-load (#292): when set, replace Stage 2a
 	// (DiscoverTypes) with a manifest-driven resource set. We still build
 	// the cloud config + discoverer below — Stage 2c3 dep-chase calls
@@ -579,6 +629,12 @@ Exit codes:
 		fmt.Fprintf(os.Stderr, "discover: %v\n", err)
 		return discoverExitFatal
 	}
+	// First successful imported.json write — flip the summary deferred
+	// emitter on. From here every successful exit (including soft
+	// failures of optional stages) lands in the deferred writer with
+	// a coherent summary.
+	summaryShouldEmit = true
+	summaryResources = resources
 	fmt.Fprintf(summaryOut, "wrote %s (%d resource(s) discovered)\n", out, n)
 
 	// --include-unsupported (#296): broad-enumerate types NOT yet wired
@@ -598,6 +654,10 @@ Exit codes:
 			if werr != nil {
 				fmt.Fprintf(os.Stderr, "discover: WARN: --include-unsupported: write manifest: %v; imported.json was written; continuing without unsupported.json\n", werr)
 			} else {
+				// Update the summary's unsupported count to
+				// match unsupported.json on disk; soft-failures
+				// above leave it at 0.
+				summaryUnsupportedCount = un
 				fmt.Fprintf(summaryOut, "wrote %s (%d unsupported resource(s) enumerated)\n", uout, un)
 			}
 		}
@@ -633,6 +693,7 @@ Exit codes:
 		fmt.Fprintf(os.Stderr, "discover: %v\n", err)
 		return discoverExitFatal
 	}
+	summaryResources = res.Resources
 	fmt.Fprintf(summaryOut, "wrote %s (%d resource(s) with Attributes); generated HCL at %s\n", out, n, res.GeneratedPath)
 
 	if *noDriftFix {
@@ -721,6 +782,7 @@ Exit codes:
 			fmt.Fprintf(os.Stderr, "discover: write manifest after depchase: %v\n", err)
 			return discoverExitFatal
 		}
+		summaryResources = dcRes.Resources
 	}
 	// Persist the dependency-graph edges next to imported.json (#297).
 	// Best-effort: a write failure does NOT abort the run — imported.json
@@ -822,6 +884,20 @@ func enumerateUnsupportedForCloud(
 	default:
 		return nil, fmt.Errorf("unknown cloud %q", cloud)
 	}
+}
+
+// toSummaryTagSelectors converts the CLI-package tagSelectorPair slice
+// into the cloud-agnostic imported.SummaryTagSelector slice that
+// SummarizeResources accepts. Keeps pkg/composer/imported decoupled
+// from the CLI package's parser shape. One-for-one copy; nil in →
+// empty slice out so the downstream Summary's TagSelectors field is
+// always a valid (non-nil) slice.
+func toSummaryTagSelectors(in []tagSelectorPair) []imported.SummaryTagSelector {
+	out := make([]imported.SummaryTagSelector, 0, len(in))
+	for _, p := range in {
+		out = append(out, imported.SummaryTagSelector{Key: p.Key, Value: p.Value})
+	}
+	return out
 }
 
 // splitCSV splits a comma-separated flag value, trims whitespace, and drops

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -2392,3 +2392,250 @@ func TestRunDiscoverWithDeps_IncludeUnsupportedGCP(t *testing.T) {
 		t.Errorf("Location=%q, want us", got[0].Location)
 	}
 }
+
+// --- #298 summary.json emission tests ---
+
+// TestRunDiscoverWithDeps_WritesSummaryJSON pins the always-on emission
+// contract: summary.json sits next to imported.json on every successful
+// discover run. The discovery-review screen reads summary.json directly;
+// a regression that gated emission on a flag would silently break the
+// wizard's review panel.
+func TestRunDiscoverWithDeps_WritesSummaryJSON(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{
+		validResource("aws_sqs_queue.alpha"),
+		validResource("aws_sqs_queue.bravo"),
+	}}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--regions", "us-east-1",
+		"--output-dir", outDir,
+		"--no-hcl",
+	}, okDeps(agg))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	path := filepath.Join(outDir, "summary.json")
+	body, err := os.ReadFile(path)
+	require.NoError(t, err, "summary.json must exist next to imported.json")
+	var got imported.DiscoverySummary
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Equal(t, 2, got.Total, "Total")
+	assert.Equal(t, 2, got.Importable, "Importable")
+	assert.Equal(t, 0, got.Unsupported, "Unsupported (no --include-unsupported)")
+	assert.Equal(t, 2, got.ByType["aws_sqs_queue"], "ByType bucket count")
+	assert.Equal(t, "aws", got.ScanSummary.Cloud)
+	assert.Equal(t, []string{"us-east-1"}, got.ScanSummary.RegionsScanned)
+}
+
+// TestRunDiscoverWithDeps_SummaryFromManifestStillEmitted pins that
+// the --from-manifest re-import path also emits summary.json — the
+// wizard's review panel must not lose its data source when an
+// operator replays a previously-discovered set.
+func TestRunDiscoverWithDeps_SummaryFromManifestStillEmitted(t *testing.T) {
+	t.Parallel()
+	manifestDir := t.TempDir()
+	loaded := []imported.ImportedResource{
+		validResourceWithRegion("aws_sqs_queue.alpha", "us-east-1", "1234567890"),
+		validResourceWithRegion("aws_sqs_queue.bravo", "us-east-1", "1234567890"),
+	}
+	manifestPath := writeFixtureManifest(t, manifestDir, "aws", loaded)
+
+	outDir := t.TempDir()
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--regions", "us-east-1",
+		"--from-manifest", manifestPath,
+		"--output-dir", outDir,
+		"--no-hcl",
+	}, okDepsWithGC(&fakeAggregator{}, &fakeGenconfig{}))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	body, err := os.ReadFile(filepath.Join(outDir, "summary.json"))
+	require.NoError(t, err, "summary.json must be emitted on --from-manifest path")
+	var got imported.DiscoverySummary
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Equal(t, 2, got.Importable, "Importable mirrors loaded manifest size")
+}
+
+// TestRunDiscoverWithDeps_SummaryIncludeUnsupportedReflectsCount pins
+// that the unsupported count from --include-unsupported propagates into
+// summary.json's `unsupported` and `total` fields. A regression that
+// computed Total from len(resources) only would diverge from the wire
+// shape the discovery-review screen expects.
+func TestRunDiscoverWithDeps_SummaryIncludeUnsupportedReflectsCount(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{
+		validResource("aws_sqs_queue.alpha"),
+	}}
+	deps := okDeps(agg)
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+		return []awsdiscover.UnsupportedResource{
+			{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/v1", Region: "us-east-1"},
+			{Type: "aws_rds_cluster", ID: "arn:aws:rds:us-east-1:1:cluster:c1", Region: "us-east-1"},
+			{Type: "aws_iam_role", ID: "arn:aws:iam::1:role/r1"},
+		}, nil
+	}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--regions", "us-east-1",
+		"--output-dir", outDir,
+		"--include-unsupported",
+		"--no-hcl",
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	body, err := os.ReadFile(filepath.Join(outDir, "summary.json"))
+	require.NoError(t, err)
+	var got imported.DiscoverySummary
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Equal(t, 1, got.Importable, "Importable (1 fake aggregator row)")
+	assert.Equal(t, 3, got.Unsupported, "Unsupported count from unsupported.json")
+	assert.Equal(t, 4, got.Total, "Total = Importable + Unsupported")
+}
+
+// TestRunDiscoverWithDeps_SummaryIncludeUnsupportedSoftFailureZeroCount
+// pins the soft-failure invariant: when the unsupported enumerator
+// errors and unsupported.json is NOT written, summary.json's
+// `unsupported` count must remain 0 — the summary cannot lie about
+// rows that aren't on disk.
+func TestRunDiscoverWithDeps_SummaryIncludeUnsupportedSoftFailureZeroCount(t *testing.T) {
+	outDir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	deps := okDeps(agg)
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+		return nil, errors.New("simulated: Resource Explorer not configured")
+	}
+	var rc int
+	captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--output-dir", outDir,
+			"--include-unsupported",
+			"--no-hcl",
+		}, deps)
+	})
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	body, err := os.ReadFile(filepath.Join(outDir, "summary.json"))
+	require.NoError(t, err)
+	var got imported.DiscoverySummary
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Equal(t, 0, got.Unsupported, "soft-failure must leave Unsupported at 0")
+	assert.Equal(t, 1, got.Total, "Total mirrors Importable when no unsupported.json was written")
+}
+
+// TestRunDiscoverWithDeps_SummaryRegionsAndTagSelectorsReflectInputs
+// pins that the operator-supplied scope round-trips into ScanSummary.
+// Multi-region + multi-selector inputs must surface verbatim; a
+// regression that dropped the deprecated --region alias resolution
+// would surface as a missing region in summary.json.
+func TestRunDiscoverWithDeps_SummaryRegionsAndTagSelectorsReflectInputs(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "io-foo",
+		"--regions", "us-east-1,eu-west-1",
+		"--tag-selectors", "env=prod,team=growth",
+		"--output-dir", outDir,
+		"--no-hcl",
+	}, okDeps(agg))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	body, err := os.ReadFile(filepath.Join(outDir, "summary.json"))
+	require.NoError(t, err)
+	var got imported.DiscoverySummary
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Equal(t, []string{"us-east-1", "eu-west-1"}, got.ScanSummary.RegionsScanned)
+	// TagSelectors are sorted in the summary's wire shape.
+	assert.Equal(t, []string{"env=prod", "team=growth"}, got.ScanSummary.TagSelectors)
+}
+
+// TestRunDiscoverWithDeps_SummaryNotEmittedOnEarlyValidationFailure
+// pins that argument-validation fatals (which exit before any
+// imported.json could be written) do not produce a stray summary.json.
+// A regression that emitted summary.json on every defer-fired exit —
+// even the bad-argv ones — would leave behind a "ghost" file the
+// wizard could mistake for a successful run.
+//
+// NOT t.Parallel(): some early-validation paths capture stderr; this
+// test doesn't, but co-locating with the rest of the summary tests
+// keeps the suite cohesive.
+func TestRunDiscoverWithDeps_SummaryNotEmittedOnEarlyValidationFailure(t *testing.T) {
+	t.Parallel()
+	outDir := t.TempDir()
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "p",
+		// no --regions — fatal pre-discovery
+		"--output-dir", outDir,
+	}, okDeps(&fakeAggregator{}))
+	if rc != discoverExitFatal {
+		t.Fatalf("rc=%d, want fatal", rc)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "summary.json")); err == nil {
+		t.Errorf("summary.json was emitted on early-validation failure")
+	}
+}
+
+// TestRunDiscoverWithDeps_SummaryDeterministicAcrossRuns pins that two
+// discover invocations with the same input produce byte-identical
+// summary.json. The discovery-review screen hashes summary.json bytes
+// to invalidate cached panel renders; non-deterministic output would
+// invalidate the cache on every idempotent re-run.
+func TestRunDiscoverWithDeps_SummaryDeterministicAcrossRuns(t *testing.T) {
+	t.Parallel()
+	rs := []imported.ImportedResource{
+		validResource("aws_sqs_queue.alpha"),
+		validResource("aws_sqs_queue.bravo"),
+		validResource("aws_sqs_queue.charlie"),
+	}
+	dirA, dirB := t.TempDir(), t.TempDir()
+	for _, dir := range []string{dirA, dirB} {
+		agg := &fakeAggregator{out: rs}
+		rc := runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--output-dir", dir,
+			"--no-hcl",
+		}, okDeps(agg))
+		if rc != discoverExitOK {
+			t.Fatalf("rc=%d (dir=%s), want OK", rc, dir)
+		}
+	}
+	// We compare body bytes minus the duration_ms field, which is
+	// the only legitimately-non-deterministic value in the summary
+	// (wall-time of the run varies). Every other byte must match.
+	a := readSummaryWithoutDuration(t, filepath.Join(dirA, "summary.json"))
+	b := readSummaryWithoutDuration(t, filepath.Join(dirB, "summary.json"))
+	assert.Equal(t, a, b, "summary.json (modulo duration_ms) must be byte-identical across runs")
+}
+
+// readSummaryWithoutDuration loads a summary.json and zeros out
+// ScanSummary.duration_ms before re-marshalling so the deterministic
+// comparison ignores wall-time jitter.
+func readSummaryWithoutDuration(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var s imported.DiscoverySummary
+	require.NoError(t, json.Unmarshal(body, &s))
+	s.ScanSummary.DurationMs = 0
+	out, err := json.MarshalIndent(s, "", "  ")
+	require.NoError(t, err)
+	return string(out)
+}

--- a/cmd/insideout-import/manifest.go
+++ b/cmd/insideout-import/manifest.go
@@ -32,6 +32,14 @@ const unsupportedManifestFile = "unsupported.json"
 // never has to special-case missing/empty file.
 const graphManifestFile = "graph.json"
 
+// summaryManifestFile is the on-disk file name for the DiscoverySummary
+// aggregate written by writeSummary at the end of every discover run
+// (#298). The reliable wizard's discovery-review screen reads this file
+// directly rather than recomputing the buckets client-side over a
+// potentially large imported.json. Always emitted (no flag); empty
+// input still produces a valid `{ total: 0, by_type: {}, ... }` body.
+const summaryManifestFile = "summary.json"
+
 // writeManifest validates the resource set with composer.ValidateImportedResources
 // and writes the JSON array of ImportedResource into <dir>/imported.json.
 // Validation runs BEFORE the file is written so a failing validator never
@@ -217,6 +225,44 @@ func writeGraphManifest(dir string, edges []depchase.GraphEdge) (string, int, er
 		return "", 0, fmt.Errorf("write %s: %w", out, err)
 	}
 	return out, len(edges), nil
+}
+
+// writeSummary writes the DiscoverySummary aggregate into
+// <dir>/summary.json (#298). Mirrors writeGraphManifest's invariants:
+// nil/empty input still produces a structurally valid body (Total=0,
+// every map serialized as `{}` not `null`, every slice serialized as
+// `[]` not `null`); the file is written via WriteFile (no temp+rename);
+// determinism comes from Go's encoding/json marshalling map keys in
+// sorted order plus the SummarizeResources caller's deterministic
+// inputs.
+//
+// Returns (path, error). The CLI treats summary.json as best-effort UI
+// metadata: a write failure surfaces as a stderr WARN and does not
+// abort the run (imported.json is the source of truth). The discovery-
+// review screen falls back to client-side computation over
+// imported.json if summary.json is missing.
+//
+// Why summary.json is a sibling of imported.json (rather than embedded):
+// the aggregate's wire shape evolves independently of the per-resource
+// IR — adding a new aggregate bucket (e.g. byCloud) shouldn't require
+// every imported.json reader (composer, validators, riley) to know the
+// summary schema. Keeping it as a sibling matches the same rationale
+// behind unsupported.json (#296) and graph.json (#297).
+func writeSummary(dir string, summary imported.DiscoverySummary) (string, error) {
+	body, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal summary: %w", err)
+	}
+	body = append(body, '\n')
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	out := filepath.Join(dir, summaryManifestFile)
+	if err := os.WriteFile(out, body, 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", out, err)
+	}
+	return out, nil
 }
 
 // formatIssues turns a slice of validation issues into a multi-line string

--- a/cmd/insideout-import/manifest_test.go
+++ b/cmd/insideout-import/manifest_test.go
@@ -604,3 +604,136 @@ func TestWriteGraphManifest_SortOrder(t *testing.T) {
 		}
 	}
 }
+
+// --- #298 writeSummary tests ---
+
+// TestWriteSummary_HappyPath pins the round-trip: a populated
+// DiscoverySummary is written to <dir>/summary.json and decodes back
+// to an equal value.
+func TestWriteSummary_HappyPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	resources := []imported.ImportedResource{
+		validIR("aws_sqs_queue", "aws_sqs_queue.alpha", "id-alpha"),
+		validIR("aws_lambda_function", "aws_lambda_function.beta", "id-beta"),
+	}
+	summary := imported.SummarizeResources(resources, imported.SummaryOpts{
+		Cloud:   "aws",
+		Regions: []string{"us-east-1"},
+	})
+	path, err := writeSummary(dir, summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(path) != "summary.json" {
+		t.Errorf("path=%q, want ends in summary.json", path)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got imported.DiscoverySummary
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("summary.json is not valid JSON: %v", err)
+	}
+	if got.Total != 2 {
+		t.Errorf("Total=%d, want 2", got.Total)
+	}
+	if got.Importable != 2 {
+		t.Errorf("Importable=%d, want 2", got.Importable)
+	}
+	if got.ByType["aws_sqs_queue"] != 1 || got.ByType["aws_lambda_function"] != 1 {
+		t.Errorf("ByType=%v, want one of each type", got.ByType)
+	}
+	if got.ScanSummary.Cloud != "aws" {
+		t.Errorf("Cloud=%q, want aws", got.ScanSummary.Cloud)
+	}
+}
+
+// TestWriteSummary_EmptyInputWritesValidShape pins the no-null
+// contract for the on-disk summary. The discovery-review screen reads
+// summary.json on every load and cannot distinguish "no resources"
+// from "missing/unparseable file" if the maps are `null`. Empty
+// resources must still produce well-shaped JSON.
+func TestWriteSummary_EmptyInputWritesValidShape(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	summary := imported.SummarizeResources(nil, imported.SummaryOpts{Cloud: "aws"})
+	path, err := writeSummary(dir, summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A regression that emitted nil maps would surface as `"by_type":null`
+	// here. Spot-check every map and slice.
+	for _, want := range []string{
+		`"total": 0`,
+		`"by_type": {}`,
+		`"by_region": {}`,
+		`"by_tag": {}`,
+		`"by_group": {}`,
+		`"regions_scanned": []`,
+		`"tag_selectors": []`,
+	} {
+		if !bytes.Contains(body, []byte(want)) {
+			t.Errorf("summary.json missing %q\nbody=%s", want, body)
+		}
+	}
+	// Round-trip: the body must decode back into a valid struct with
+	// non-nil maps.
+	var got imported.DiscoverySummary
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("summary.json is not valid JSON: %v", err)
+	}
+	if got.ByType == nil || got.ByRegion == nil || got.ByTag == nil || got.ByGroup == nil {
+		t.Errorf("decoded summary has nil map(s); ByType=%v ByRegion=%v ByTag=%v ByGroup=%v",
+			got.ByType, got.ByRegion, got.ByTag, got.ByGroup)
+	}
+}
+
+// TestWriteSummary_DeterministicAcrossRuns pins byte-identical output
+// across two writes of the same summary input. The discovery-review
+// screen hashes summary.json contents to invalidate cached panel
+// renders; non-deterministic byte output would invalidate the cache
+// on every idempotent re-run.
+func TestWriteSummary_DeterministicAcrossRuns(t *testing.T) {
+	t.Parallel()
+	resources := []imported.ImportedResource{
+		validIR("aws_sqs_queue", "aws_sqs_queue.delta", "d"),
+		validIR("aws_sqs_queue", "aws_sqs_queue.alpha", "a"),
+		validIR("aws_lambda_function", "aws_lambda_function.charlie", "c"),
+		validIR("aws_lambda_function", "aws_lambda_function.bravo", "b"),
+	}
+	opts := imported.SummaryOpts{
+		Cloud:   "aws",
+		Regions: []string{"us-east-1", "eu-west-1"},
+	}
+	dir1, dir2 := t.TempDir(), t.TempDir()
+	if _, err := writeSummary(dir1, imported.SummarizeResources(resources, opts)); err != nil {
+		t.Fatal(err)
+	}
+	// Reverse the input order on the second pass — Go's map iteration
+	// is unordered, so a regression that pulled the buckets through
+	// without a sort would flake here.
+	rev := make([]imported.ImportedResource, len(resources))
+	for i := range resources {
+		rev[len(resources)-1-i] = resources[i]
+	}
+	if _, err := writeSummary(dir2, imported.SummarizeResources(rev, opts)); err != nil {
+		t.Fatal(err)
+	}
+	a, err := os.ReadFile(filepath.Join(dir1, "summary.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir2, "summary.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Errorf("summary.json differs across runs with permuted input:\nrun1=%s\nrun2=%s", a, b)
+	}
+}

--- a/pkg/composer/imported/summary.go
+++ b/pkg/composer/imported/summary.go
@@ -1,0 +1,189 @@
+package imported
+
+import (
+	"sort"
+	"time"
+)
+
+// DiscoverySummary is the on-the-wire shape persisted next to imported.json
+// (and unsupported.json + graph.json) by `insideout-import discover`. The
+// reliable importer wizard's discovery-review screen reads it directly,
+// rather than computing the per-bucket counts client-side over a potentially
+// large imported.json. Always emitted (no flag); see writeSummary in
+// cmd/insideout-import/manifest.go for the persistence half.
+//
+// Wire-format invariants:
+//
+//   - Total / Importable / Unsupported are always present (omitempty is NOT
+//     set on these three; an absent zero is wire-distinguishable from the
+//     "no resources discovered" case).
+//   - All four map fields default to map[string]int{} (NOT nil) so the
+//     persisted summary.json marshals empty buckets as `{}` not `null`.
+//     The discovery-review screen iterates the maps unconditionally and
+//     a `null` body would crash the iterator.
+//   - ScanSummary.RegionsScanned and TagSelectors default to []string{}
+//     (NOT nil) for the same reason.
+//   - Map keys are emitted by Go's encoding/json in sorted order, so
+//     summary.json is byte-deterministic across runs of the same input.
+//
+// See issue #298 (gap #8 of #289).
+type DiscoverySummary struct {
+	// Total is the count of resources visible to the discover run —
+	// importable + unsupported. When --include-unsupported is unset,
+	// Total == Importable.
+	Total int `json:"total"`
+	// Importable is the count of rows in the companion imported.json
+	// (i.e. resources the discover pipeline can drive end-to-end).
+	Importable int `json:"importable"`
+	// Unsupported is the count of rows in the companion unsupported.json,
+	// 0 when --include-unsupported was not set on the run.
+	Unsupported int `json:"unsupported"`
+	// ByType buckets the importable set by Identity.Type (e.g.
+	// "aws_sqs_queue" → 5). Empty input → {}.
+	ByType map[string]int `json:"by_type"`
+	// ByRegion buckets the importable set by Identity.Region. Resources
+	// with an empty Region land in the "" bucket so the count totals
+	// match Importable.
+	ByRegion map[string]int `json:"by_region"`
+	// ByTag buckets the importable set by `<key>=<value>` strings drawn
+	// from Identity.Tags. A single resource with two tag pairs
+	// contributes to two ByTag entries. Resources with nil Tags
+	// contribute nothing — there is no synthetic empty entry.
+	ByTag map[string]int `json:"by_tag"`
+	// ByGroup buckets the importable set by the high-level UI category
+	// returned by Category(Identity.Type). Types with no Category mapping
+	// land in the "" bucket so the picker can show them under "Other".
+	// Useful for the discovery-review screen's group toggles.
+	ByGroup map[string]int `json:"by_group"`
+	// ScanSummary records the scope and wall-time of the discover run.
+	ScanSummary ScanSummary `json:"scan_summary"`
+}
+
+// ScanSummary captures the operator-supplied scope (regions + tag
+// selectors) and the observed wall-time of the discover stage.
+//
+// Cloud is always populated to "aws" or "gcp"; the omitempty avoids
+// emitting an empty string when the caller misuses SummarizeResources
+// with an empty SummaryOpts.Cloud (the test suite pins the expected
+// non-empty value).
+type ScanSummary struct {
+	// DurationMs is the total wall-time of the discover run in
+	// milliseconds. Zero when the caller did not supply a duration.
+	DurationMs int64 `json:"duration_ms,omitempty"`
+	// RegionsScanned is the resolved --regions list (after deprecated
+	// --region alias resolution). Defaulted to []string{} so the field
+	// always serializes as `[]` rather than `null`.
+	RegionsScanned []string `json:"regions_scanned"`
+	// TagSelectors is the parsed --tag-selectors list, in `key=value`
+	// string form. Defaulted to []string{} for the same reason.
+	TagSelectors []string `json:"tag_selectors"`
+	// Cloud is "aws" or "gcp". omitempty covers misuse but the discover
+	// wiring always supplies a value.
+	Cloud string `json:"cloud,omitempty"`
+}
+
+// SummaryTagSelector is a single parsed tag-selector pair. Declared in
+// this package so callers (cmd/insideout-import) can convert their
+// CLI-level tagSelectorPair into something SummarizeResources accepts
+// without coupling pkg/composer/imported to the CLI package.
+type SummaryTagSelector struct {
+	Key   string
+	Value string
+}
+
+// SummaryOpts is the non-resource scope SummarizeResources needs to
+// populate ScanSummary and the Total / Unsupported counts. The struct
+// is value-typed (not a pointer) to keep the call site obvious — there
+// is no "no opts" mode, every field is explicitly set by the caller.
+type SummaryOpts struct {
+	// Cloud is "aws" or "gcp"; threaded into ScanSummary.Cloud.
+	Cloud string
+	// UnsupportedCount is the row count from unsupported.json when
+	// --include-unsupported was set; 0 otherwise. Total =
+	// len(resources) + UnsupportedCount.
+	UnsupportedCount int
+	// Duration is the wall-time of the discover stage. Zero is permitted
+	// and serializes as omitempty.
+	Duration time.Duration
+	// Regions is the resolved --regions list.
+	Regions []string
+	// TagSelectors is the parsed --tag-selectors list. Cloud-agnostic
+	// shape; the CLI's tagSelectorPair maps trivially onto this.
+	TagSelectors []SummaryTagSelector
+}
+
+// SummarizeResources computes the DiscoverySummary aggregate from a
+// resource set + scope opts. Pure function: no globals, no I/O, no
+// time.Now (the caller passes Duration). Determinism comes from the
+// caller-supplied input order being irrelevant — every output bucket
+// is a map (Go's encoding/json marshals sorted) or an explicitly
+// sorted slice.
+//
+// Empty input is valid and produces a summary with Total=0, all maps
+// non-nil-empty, RegionsScanned and TagSelectors echoed back from
+// opts (still defaulted to []string{} when the caller passes nil).
+//
+// Region-vs-Location: ScanSummary tracks Regions but ByRegion buckets
+// by Identity.Region. When a GCP resource carries both Region and
+// Location populated, Region wins (per the SummaryOpts/SummaryOpts
+// design contract — the discovery-review screen surfaces Region
+// uniformly across both clouds).
+func SummarizeResources(resources []ImportedResource, opts SummaryOpts) DiscoverySummary {
+	out := DiscoverySummary{
+		Importable:  len(resources),
+		Unsupported: opts.UnsupportedCount,
+		Total:       len(resources) + opts.UnsupportedCount,
+		ByType:      map[string]int{},
+		ByRegion:    map[string]int{},
+		ByTag:       map[string]int{},
+		ByGroup:     map[string]int{},
+		ScanSummary: ScanSummary{
+			Cloud:          opts.Cloud,
+			DurationMs:     opts.Duration.Milliseconds(),
+			RegionsScanned: copyStrings(opts.Regions),
+			TagSelectors:   tagSelectorStrings(opts.TagSelectors),
+		},
+	}
+
+	for _, r := range resources {
+		out.ByType[r.Identity.Type]++
+		out.ByRegion[r.Identity.Region]++
+		out.ByGroup[Category(r.Identity.Type)]++
+
+		// Identity.Tags is intentionally allowed to be nil (per #291,
+		// nil distinguishes "discoverer didn't fetch tags" from an
+		// empty map). Nil contributes nothing to ByTag.
+		for k, v := range r.Identity.Tags {
+			out.ByTag[k+"="+v]++
+		}
+	}
+
+	return out
+}
+
+// copyStrings returns a non-nil clone of s. Used to defend ScanSummary
+// from upstream mutation and to coerce nil inputs into []string{} so
+// the JSON output is always `[]` (never `null`).
+func copyStrings(s []string) []string {
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
+}
+
+// tagSelectorStrings flattens []SummaryTagSelector into the canonical
+// `key=value` string slice. Keeps the wire shape stable across cloud
+// providers — the AWS adapter's tagSelectorPair and GCP adapter's
+// tagSelectorPair both carry Key/Value; either funnels through
+// SummaryTagSelector here.
+//
+// The output is sorted to match Go's map-marshal sort order on ByTag,
+// so a consumer that diffs `tag_selectors` against the keys of
+// `by_tag` sees stable ordering across runs.
+func tagSelectorStrings(sels []SummaryTagSelector) []string {
+	out := make([]string, 0, len(sels))
+	for _, s := range sels {
+		out = append(out, s.Key+"="+s.Value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/composer/imported/summary_test.go
+++ b/pkg/composer/imported/summary_test.go
@@ -1,0 +1,381 @@
+package imported
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resWith is a tiny helper that builds an ImportedResource fixture for
+// summary tests; only the Identity fields the summarizer reads are
+// populated.
+func resWith(tfType, region string, tags map[string]string) ImportedResource {
+	return ImportedResource{
+		Identity: ResourceIdentity{
+			Cloud:    "aws",
+			Type:     tfType,
+			Address:  tfType + ".x",
+			ImportID: tfType + "-x",
+			Region:   region,
+			Tags:     tags,
+		},
+	}
+}
+
+// TestSummarizeResources_TotalAndImportable pins the Total / Importable /
+// Unsupported relationship: Importable == len(resources), Unsupported is
+// the caller-supplied count, Total == sum.
+func TestSummarizeResources_TotalAndImportable(t *testing.T) {
+	t.Parallel()
+	five := []ImportedResource{
+		resWith("aws_sqs_queue", "us-east-1", nil),
+		resWith("aws_sqs_queue", "us-east-1", nil),
+		resWith("aws_sqs_queue", "us-east-1", nil),
+		resWith("aws_sqs_queue", "us-east-1", nil),
+		resWith("aws_sqs_queue", "us-east-1", nil),
+	}
+
+	t.Run("no_unsupported", func(t *testing.T) {
+		t.Parallel()
+		got := SummarizeResources(five, SummaryOpts{Cloud: "aws"})
+		assert.Equal(t, 5, got.Total, "Total")
+		assert.Equal(t, 5, got.Importable, "Importable")
+		assert.Equal(t, 0, got.Unsupported, "Unsupported")
+	})
+
+	t.Run("with_unsupported", func(t *testing.T) {
+		t.Parallel()
+		got := SummarizeResources(five, SummaryOpts{Cloud: "aws", UnsupportedCount: 2})
+		assert.Equal(t, 7, got.Total, "Total = Importable + Unsupported")
+		assert.Equal(t, 5, got.Importable, "Importable counts Resources only")
+		assert.Equal(t, 2, got.Unsupported, "Unsupported pass-through")
+	})
+}
+
+// TestSummarizeResources_ByType_BucketsByIdentityType pins ByType bucketing.
+// A regression that bucketed by Cloud or Address would surface here.
+func TestSummarizeResources_ByType_BucketsByIdentityType(t *testing.T) {
+	t.Parallel()
+	rs := []ImportedResource{
+		resWith("aws_sqs_queue", "us-east-1", nil),
+		resWith("aws_sqs_queue", "us-east-1", nil),
+		resWith("aws_sqs_queue", "us-east-1", nil),
+		resWith("aws_lambda_function", "us-east-1", nil),
+		resWith("aws_lambda_function", "us-east-1", nil),
+		resWith("aws_s3_bucket", "us-east-1", nil),
+	}
+	got := SummarizeResources(rs, SummaryOpts{Cloud: "aws"})
+	assert.Equal(t, 3, got.ByType["aws_sqs_queue"])
+	assert.Equal(t, 2, got.ByType["aws_lambda_function"])
+	assert.Equal(t, 1, got.ByType["aws_s3_bucket"])
+	assert.Len(t, got.ByType, 3, "no extra buckets")
+}
+
+// TestSummarizeResources_ByRegion_BucketsByIdentityRegion pins multi-region
+// bucketing. A regression that bucketed by Cloud or fell back to Location
+// would surface here.
+func TestSummarizeResources_ByRegion_BucketsByIdentityRegion(t *testing.T) {
+	t.Parallel()
+	rs := []ImportedResource{
+		resWith("aws_sqs_queue", "us-east-1", nil),
+		resWith("aws_sqs_queue", "us-east-1", nil),
+		resWith("aws_sqs_queue", "eu-west-1", nil),
+		resWith("aws_sqs_queue", "ap-south-1", nil),
+	}
+	got := SummarizeResources(rs, SummaryOpts{Cloud: "aws"})
+	assert.Equal(t, 2, got.ByRegion["us-east-1"])
+	assert.Equal(t, 1, got.ByRegion["eu-west-1"])
+	assert.Equal(t, 1, got.ByRegion["ap-south-1"])
+}
+
+// TestSummarizeResources_ByRegion_EmptyRegionLandsInEmptyKey pins that
+// the region totals match Importable when some resources have no Region.
+// A regression that dropped the empty-region bucket would underflow the
+// summary's by_region totals vs. Importable.
+func TestSummarizeResources_ByRegion_EmptyRegionLandsInEmptyKey(t *testing.T) {
+	t.Parallel()
+	rs := []ImportedResource{
+		resWith("aws_sqs_queue", "us-east-1", nil),
+		resWith("aws_iam_role", "", nil),
+	}
+	got := SummarizeResources(rs, SummaryOpts{Cloud: "aws"})
+	assert.Equal(t, 1, got.ByRegion[""], "global resources land in the \"\" bucket")
+	sum := 0
+	for _, n := range got.ByRegion {
+		sum += n
+	}
+	assert.Equal(t, got.Importable, sum, "ByRegion totals match Importable")
+}
+
+// TestSummarizeResources_ByTag_OneEntryPerKVPair pins that a single
+// resource with N tags contributes N entries to ByTag.
+func TestSummarizeResources_ByTag_OneEntryPerKVPair(t *testing.T) {
+	t.Parallel()
+	rs := []ImportedResource{
+		resWith("aws_sqs_queue", "us-east-1", map[string]string{
+			"env":  "prod",
+			"team": "growth",
+		}),
+	}
+	got := SummarizeResources(rs, SummaryOpts{Cloud: "aws"})
+	assert.Equal(t, 1, got.ByTag["env=prod"])
+	assert.Equal(t, 1, got.ByTag["team=growth"])
+	assert.Len(t, got.ByTag, 2, "exactly one entry per kv pair")
+}
+
+// TestSummarizeResources_ByTag_NilTagsContributeNothing pins the #291 nil-
+// vs-empty distinction: a resource with nil Tags doesn't synthesize an
+// empty bucket. A regression that emitted "=" or similar for nil-tagged
+// resources would surface here.
+func TestSummarizeResources_ByTag_NilTagsContributeNothing(t *testing.T) {
+	t.Parallel()
+	rs := []ImportedResource{
+		resWith("aws_sqs_queue", "us-east-1", nil),
+		resWith("aws_sqs_queue", "us-east-1", map[string]string{}),
+	}
+	got := SummarizeResources(rs, SummaryOpts{Cloud: "aws"})
+	assert.Empty(t, got.ByTag, "nil/empty Tags must not contribute")
+	assert.NotNil(t, got.ByTag, "ByTag must be non-nil empty map")
+}
+
+// TestSummarizeResources_ByTag_DuplicatePairsSumAcrossResources pins
+// the cross-resource accumulation: two resources tagged env=prod
+// produce one entry with count 2.
+func TestSummarizeResources_ByTag_DuplicatePairsSumAcrossResources(t *testing.T) {
+	t.Parallel()
+	rs := []ImportedResource{
+		resWith("aws_sqs_queue", "us-east-1", map[string]string{"env": "prod"}),
+		resWith("aws_lambda_function", "us-east-1", map[string]string{"env": "prod"}),
+		resWith("aws_s3_bucket", "us-east-1", map[string]string{"env": "staging"}),
+	}
+	got := SummarizeResources(rs, SummaryOpts{Cloud: "aws"})
+	assert.Equal(t, 2, got.ByTag["env=prod"])
+	assert.Equal(t, 1, got.ByTag["env=staging"])
+}
+
+// TestSummarizeResources_ByGroup_UsesCategoryHelper pins that ByGroup is
+// derived from imported.Category. A regression that ran an inline
+// type→group switch would diverge from the Category map and the wizard's
+// group rendering would split.
+func TestSummarizeResources_ByGroup_UsesCategoryHelper(t *testing.T) {
+	t.Parallel()
+	rs := []ImportedResource{
+		// aws_sqs_queue → CategoryEvents
+		resWith("aws_sqs_queue", "us-east-1", nil),
+		// aws_s3_bucket → CategoryDataStorage
+		resWith("aws_s3_bucket", "us-east-1", nil),
+		resWith("aws_s3_bucket", "us-east-1", nil),
+		// aws_lambda_function → CategoryVirtualMachines
+		resWith("aws_lambda_function", "us-east-1", nil),
+	}
+	got := SummarizeResources(rs, SummaryOpts{Cloud: "aws"})
+	assert.Equal(t, 1, got.ByGroup[CategoryEvents])
+	assert.Equal(t, 2, got.ByGroup[CategoryDataStorage])
+	assert.Equal(t, 1, got.ByGroup[CategoryVirtualMachines])
+}
+
+// TestSummarizeResources_ByGroup_UnmappedTypeLandsInEmptyKey pins the
+// "Other" fallback contract: a Terraform type with no Category mapping
+// is bucketed under "" so the wizard's "Other" bucket is populated and
+// the per-group totals still match Importable.
+func TestSummarizeResources_ByGroup_UnmappedTypeLandsInEmptyKey(t *testing.T) {
+	t.Parallel()
+	rs := []ImportedResource{
+		resWith("aws_brand_new_thing_2099", "us-east-1", nil),
+		resWith("aws_sqs_queue", "us-east-1", nil),
+	}
+	got := SummarizeResources(rs, SummaryOpts{Cloud: "aws"})
+	assert.Equal(t, 1, got.ByGroup[""])
+	assert.Equal(t, 1, got.ByGroup[CategoryEvents])
+}
+
+// TestSummarizeResources_EmptyInputProducesValidShape pins the "no
+// resources discovered" wire shape: every map non-nil-empty, every slice
+// non-nil-empty, JSON marshals every map as `{}` and every slice as `[]`.
+// A regression that left a nil map would surface as `null` in the body.
+func TestSummarizeResources_EmptyInputProducesValidShape(t *testing.T) {
+	t.Parallel()
+	got := SummarizeResources(nil, SummaryOpts{Cloud: "aws"})
+	assert.Equal(t, 0, got.Total)
+	assert.Equal(t, 0, got.Importable)
+	assert.Equal(t, 0, got.Unsupported)
+
+	require.NotNil(t, got.ByType)
+	require.NotNil(t, got.ByRegion)
+	require.NotNil(t, got.ByTag)
+	require.NotNil(t, got.ByGroup)
+	require.NotNil(t, got.ScanSummary.RegionsScanned)
+	require.NotNil(t, got.ScanSummary.TagSelectors)
+
+	body, err := json.Marshal(got)
+	require.NoError(t, err)
+	// Spot-check a few of the canonical empty markers; a `null` for
+	// any of the four maps or two slices would slip past Empty() on
+	// the in-memory struct.
+	for _, want := range []string{
+		`"by_type":{}`,
+		`"by_region":{}`,
+		`"by_tag":{}`,
+		`"by_group":{}`,
+		`"regions_scanned":[]`,
+		`"tag_selectors":[]`,
+	} {
+		assert.Contains(t, string(body), want,
+			"empty summary must serialize %q", want)
+	}
+}
+
+// TestSummarizeResources_ScanSummaryReflectsOpts pins that the scope
+// inputs (Cloud, Duration, Regions, TagSelectors) round-trip into
+// ScanSummary.
+func TestSummarizeResources_ScanSummaryReflectsOpts(t *testing.T) {
+	t.Parallel()
+	got := SummarizeResources(nil, SummaryOpts{
+		Cloud:    "gcp",
+		Duration: 12345 * time.Millisecond,
+		Regions:  []string{"us-central1", "europe-west1"},
+		TagSelectors: []SummaryTagSelector{
+			{Key: "env", Value: "prod"},
+			{Key: "team", Value: "growth"},
+		},
+	})
+	assert.Equal(t, "gcp", got.ScanSummary.Cloud)
+	assert.Equal(t, int64(12345), got.ScanSummary.DurationMs)
+	assert.Equal(t, []string{"us-central1", "europe-west1"}, got.ScanSummary.RegionsScanned)
+	// TagSelectors are sorted into the canonical key=value form so a
+	// regression that left them in caller order or dropped the sort
+	// surfaces here.
+	assert.Equal(t, []string{"env=prod", "team=growth"}, got.ScanSummary.TagSelectors)
+}
+
+// TestSummarizeResources_RegionsSliceIsCopied pins that ScanSummary's
+// RegionsScanned is a clone of opts.Regions, not the same backing array.
+// A regression that aliased the caller's slice would let later
+// mutations leak into a previously-emitted summary.
+func TestSummarizeResources_RegionsSliceIsCopied(t *testing.T) {
+	t.Parallel()
+	in := []string{"us-east-1", "eu-west-1"}
+	got := SummarizeResources(nil, SummaryOpts{Cloud: "aws", Regions: in})
+	in[0] = "MUTATED"
+	assert.Equal(t, "us-east-1", got.ScanSummary.RegionsScanned[0],
+		"caller's slice mutation must not leak into the summary")
+}
+
+// TestSummarizeResources_DeterministicAcrossRuns pins byte-identical JSON
+// across runs of the same input. Caller ordering and map iteration order
+// must not influence the output.
+func TestSummarizeResources_DeterministicAcrossRuns(t *testing.T) {
+	t.Parallel()
+	rs := []ImportedResource{
+		resWith("aws_sqs_queue", "us-east-1", map[string]string{"env": "prod", "team": "growth"}),
+		resWith("aws_lambda_function", "eu-west-1", map[string]string{"env": "staging"}),
+		resWith("aws_s3_bucket", "us-east-1", map[string]string{"env": "prod"}),
+	}
+	opts := SummaryOpts{
+		Cloud:            "aws",
+		UnsupportedCount: 3,
+		Duration:         500 * time.Millisecond,
+		Regions:          []string{"us-east-1", "eu-west-1"},
+		TagSelectors: []SummaryTagSelector{
+			{Key: "env", Value: "prod"},
+		},
+	}
+	// Marshal five times — Go's map iteration is non-deterministic, so
+	// any latent reliance on map order would flake within a few iters.
+	var first []byte
+	for i := 0; i < 5; i++ {
+		body, err := json.MarshalIndent(SummarizeResources(rs, opts), "", "  ")
+		require.NoError(t, err)
+		if i == 0 {
+			first = body
+			continue
+		}
+		assert.Equal(t, string(first), string(body),
+			"run %d: summary JSON must be byte-identical across runs", i)
+	}
+}
+
+// TestSummarizeResources_GoldenSnapshot pins the canonical fixture output
+// against testdata/summary.golden. Re-seed with `UPDATE_GOLDEN=1 go test
+// ./pkg/composer/imported/ -run TestSummarizeResources_GoldenSnapshot`.
+func TestSummarizeResources_GoldenSnapshot(t *testing.T) {
+	rs := []ImportedResource{
+		// Two SQS queues across two regions, one tagged env=prod, one
+		// tagged env=prod team=growth.
+		{
+			Identity: ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_sqs_queue",
+				Address:  "aws_sqs_queue.alpha",
+				ImportID: "https://example/alpha",
+				Region:   "us-east-1",
+				Tags:     map[string]string{"env": "prod"},
+			},
+		},
+		{
+			Identity: ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_sqs_queue",
+				Address:  "aws_sqs_queue.bravo",
+				ImportID: "https://example/bravo",
+				Region:   "eu-west-1",
+				Tags:     map[string]string{"env": "prod", "team": "growth"},
+			},
+		},
+		// One Lambda in us-east-1, no tags (Identity.Tags=nil — the
+		// discoverer didn't fetch tags for this row).
+		{
+			Identity: ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_lambda_function",
+				Address:  "aws_lambda_function.charlie",
+				ImportID: "charlie",
+				Region:   "us-east-1",
+			},
+		},
+		// One S3 bucket with empty Tags map (the discoverer fetched
+		// tags but the bucket genuinely has none).
+		{
+			Identity: ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_s3_bucket",
+				Address:  "aws_s3_bucket.delta",
+				ImportID: "delta",
+				Region:   "us-east-1",
+				Tags:     map[string]string{},
+			},
+		},
+	}
+	opts := SummaryOpts{
+		Cloud:            "aws",
+		UnsupportedCount: 4,
+		Duration:         12345 * time.Millisecond,
+		Regions:          []string{"us-east-1", "eu-west-1"},
+		TagSelectors: []SummaryTagSelector{
+			{Key: "env", Value: "prod"},
+		},
+	}
+	body, err := json.MarshalIndent(SummarizeResources(rs, opts), "", "  ")
+	require.NoError(t, err)
+	body = append(body, '\n')
+
+	goldenPath := filepath.Join("testdata", "summary.golden")
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		require.NoError(t, os.MkdirAll(filepath.Dir(goldenPath), 0o755))
+		require.NoError(t, os.WriteFile(goldenPath, body, 0o644))
+		t.Logf("wrote golden: %s", goldenPath)
+		return
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	require.NoError(t, err,
+		"golden missing — run `UPDATE_GOLDEN=1 go test ./pkg/composer/imported/ -run TestSummarizeResources_GoldenSnapshot`")
+	require.Equal(t, string(want), string(body),
+		"summary.json wire format drifted from %s. If this is intentional, re-seed via UPDATE_GOLDEN=1.",
+		goldenPath)
+}

--- a/pkg/composer/imported/testdata/summary.golden
+++ b/pkg/composer/imported/testdata/summary.golden
@@ -1,0 +1,34 @@
+{
+  "total": 8,
+  "importable": 4,
+  "unsupported": 4,
+  "by_type": {
+    "aws_lambda_function": 1,
+    "aws_s3_bucket": 1,
+    "aws_sqs_queue": 2
+  },
+  "by_region": {
+    "eu-west-1": 1,
+    "us-east-1": 3
+  },
+  "by_tag": {
+    "env=prod": 2,
+    "team=growth": 1
+  },
+  "by_group": {
+    "Data Storage": 1,
+    "Events": 2,
+    "Virtual Machines": 1
+  },
+  "scan_summary": {
+    "duration_ms": 12345,
+    "regions_scanned": [
+      "us-east-1",
+      "eu-west-1"
+    ],
+    "tag_selectors": [
+      "env=prod"
+    ],
+    "cloud": "aws"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/composer/imported.SummarizeResources` — a pure function that builds a `DiscoverySummary` (Total/Importable/Unsupported + by_type / by_region / by_tag / by_group buckets + ScanSummary scope) from `[]ImportedResource`.
- Wires `cmd/insideout-import` to emit `summary.json` next to `imported.json` on every successful discover run (always-on, no flag).
- `by_tag` reads `Identity.Tags` (#291); `by_group` reads `imported.Category` (#297). Nil tags contribute nothing; types without a category mapping land in the `""` bucket so the wizard's "Other" bucket is populated.
- `--from-manifest` (#292) re-import path also emits `summary.json` so the discovery-review screen has data after a replay.
- Soft-failure on `summary.json` write logs a stderr WARN and continues; `imported.json` remains the source of truth.

## Closes / Part of

Closes #298. Part of #289 (Bundle 2 / PR 4).

Stacked on PR #302 (#297 → category + graph). Stack order: main → #299 → #300 → #301 → #302 → THIS PR. Base branch is `feat/category-graph-297`; merge when #302 lands.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/insideout-import/... ./pkg/composer/... ./pkg/insideout-import/... -count=1 -race` — 2007 passed
- [x] `go vet ./...` clean
- [x] `gofmt -l cmd/ pkg/` clean
- [x] All 8 lint scripts pass (project-tag, project-label, sensitive-for-each, foreach-unknown-keys, no-root-only-blocks, shared-no-cloud-providers, labelless-name-prefix, gcp-project-pin)
- [x] `summary.json` byte-determinism verified by running each determinism test 5×
- [x] Stacked PR — CI gates on base merge; locally green is the bar.

## Stacking note

Base = `feat/category-graph-297` (PR #302). Once #302 merges to main, GitHub will auto-update this PR's diff against main. CI failures rooted in the unmerged base branch are expected until then; they do not represent regressions in this PR.

## Notes

Wire-format invariants pinned by tests:

- All four map fields (`by_type`, `by_region`, `by_tag`, `by_group`) default to `map[string]int{}` so summary.json marshals empty buckets as `{}` not `null`.
- `regions_scanned` and `tag_selectors` default to `[]string{}` for the same reason.
- Tag-selectors emit as canonical sorted `key=value` strings (matches the sort order Go applies to `by_tag` keys), so a wizard consumer that diffs the two sees stable ordering.
- Determinism comes from Go's `encoding/json` marshalling map keys in sorted order plus `SummarizeResources` consuming caller-supplied input order with no reliance on iteration order.

Category integration: `by_group` calls `imported.Category(Identity.Type)` directly; a regression that ran an inline switch would diverge from the canonical map. Pinned by `TestSummarizeResources_ByGroup_UsesCategoryHelper`.

Region-vs-Location: ScanSummary tracks `regions_scanned` from the operator-supplied `--regions`, but `by_region` buckets each resource by `Identity.Region`. Resources with empty Region land in the `""` bucket so per-region totals match `Importable`. Pinned by `TestSummarizeResources_ByRegion_EmptyRegionLandsInEmptyKey`.

Soft-failure rationale: argument-validation fatals exit before the deferred summary writer's gate flips on, so no stray `summary.json` is left behind on a bad-argv run. After `imported.json` writes successfully, every successful exit path (including a Stage 2b/2c1/2c3 failure that left `imported.json` on disk) emits a coherent summary — pinned by `TestRunDiscoverWithDeps_SummaryNotEmittedOnEarlyValidationFailure`.