### PR TITLE
feat(adopt): ParseAddresses HCL → terraform addresses helper (#304)

### DIFF
--- a/cmd/insideout-import/adopt_parse.go
+++ b/cmd/insideout-import/adopt_parse.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// AdoptAddressEntry describes a single Terraform resource address extracted
+// from HCL bytes by ParseAddresses. The fields are intended to feed
+// reliable's importer wizard "upload-hcl" step, which renders one row per
+// entry with the address as the primary key.
+type AdoptAddressEntry struct {
+	// Address is the Terraform-style address: "<type>.<name>" for root
+	// resources and "module.<name>[.module.<name>...].<type>.<name>" when
+	// the resource is nested inside a module block. v1 walks only the root
+	// document, so ModulePath is always "" today; the field is reserved
+	// for the follow-up that recurses through `module` blocks.
+	Address string `json:"address"`
+	// Type is the first label of the resource block, e.g. "aws_sqs_queue".
+	Type string `json:"type"`
+	// Name is the second label of the resource block, e.g. "dlq".
+	Name string `json:"name"`
+	// ModulePath is the dotted module-prefix portion of Address with the
+	// "module." tokens stripped — empty string for root-level resources.
+	// e.g. "foo" for "module.foo.aws_sqs_queue.dlq", "foo.bar" for
+	// "module.foo.module.bar.aws_sqs_queue.dlq".
+	ModulePath string `json:"module_path,omitempty"`
+	// File is the filename passed in to ParseAddresses, propagated
+	// unchanged. Informational only; used by callers that aggregate
+	// entries across multiple files.
+	File string `json:"file,omitempty"`
+	// Line is the 1-based source line of the resource block keyword.
+	Line int `json:"line"`
+}
+
+// ParseAddresses parses HCL bytes and returns one AdoptAddressEntry per
+// `resource` block declared at the top level of the document, in source
+// order. Diagnostics from the HCL parser surface as a non-nil error whose
+// string includes the supplied filename plus line/column context for the
+// first diagnostic.
+//
+// v1 limitations (documented in #304 follow-ups):
+//
+//   - Only top-level `resource` blocks are emitted. `data`, `module`,
+//     `provider`, `terraform`, `variable`, `output`, and `locals` blocks
+//     are ignored.
+//   - Nested resources declared inside a child `module` block are NOT
+//     recursed into — the parser walks the supplied byte stream only,
+//     and a `module "foo" { source = "./bar" }` block does not pull
+//     `./bar/*.tf` files from disk. Callers wanting nested addresses
+//     should call ParseAddresses once per file and merge the results
+//     with the appropriate ModulePath prefix applied externally.
+//   - `for_each` / `count` instance keys are not enumerated. The
+//     returned Address is always the static block address; downstream
+//     code that needs `["x"]` instance addresses must derive them
+//     itself.
+//
+// ParseAddresses is pure: it performs no I/O, mutates no global state,
+// and returns a freshly-allocated slice. An empty input or an input with
+// no resource blocks returns a non-nil empty slice (never `nil`) so JSON
+// callers always see `[]` rather than `null`.
+func ParseAddresses(src []byte, filename string) ([]AdoptAddressEntry, error) {
+	out := []AdoptAddressEntry{}
+
+	file, diags := hclsyntax.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("adopt.ParseAddresses: %s", firstDiagString(diags))
+	}
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		// hclsyntax.ParseConfig should always yield a *hclsyntax.Body, but
+		// defend against API drift rather than panic.
+		return nil, fmt.Errorf("adopt.ParseAddresses: unexpected body type %T", file.Body)
+	}
+
+	for _, block := range body.Blocks {
+		if block.Type != "resource" {
+			continue
+		}
+		// Resource blocks always carry exactly two labels per the
+		// Terraform grammar: <type> and <name>. If the user wrote a
+		// malformed block (e.g. only one label), HCL would have
+		// returned diagnostics above; reaching this branch with a
+		// short label slice should not happen, but we guard anyway.
+		if len(block.Labels) < 2 {
+			return nil, fmt.Errorf(
+				"adopt.ParseAddresses: %s:%d: resource block requires <type> <name> labels",
+				filename, block.DefRange().Start.Line,
+			)
+		}
+		typ := block.Labels[0]
+		name := block.Labels[1]
+		out = append(out, AdoptAddressEntry{
+			Address:    typ + "." + name,
+			Type:       typ,
+			Name:       name,
+			ModulePath: "",
+			File:       filename,
+			Line:       block.DefRange().Start.Line,
+		})
+	}
+
+	return out, nil
+}
+
+// firstDiagString renders the first error diagnostic as
+// "<filename>:<line>:<col>: <summary>: <detail>" so callers see actionable
+// context. We sort to make output deterministic when HCL emits multiple
+// diagnostics from a single parse — by source position then summary.
+func firstDiagString(diags hcl.Diagnostics) string {
+	errs := make([]*hcl.Diagnostic, 0, len(diags))
+	for _, d := range diags {
+		if d.Severity == hcl.DiagError {
+			errs = append(errs, d)
+		}
+	}
+	if len(errs) == 0 {
+		// Should be unreachable because the caller already checked
+		// HasErrors, but render the first diagnostic regardless.
+		return diags.Error()
+	}
+	sort.SliceStable(errs, func(i, j int) bool {
+		ai, aj := errs[i], errs[j]
+		if ai.Subject == nil || aj.Subject == nil {
+			return ai.Summary < aj.Summary
+		}
+		if ai.Subject.Start.Line != aj.Subject.Start.Line {
+			return ai.Subject.Start.Line < aj.Subject.Start.Line
+		}
+		if ai.Subject.Start.Column != aj.Subject.Start.Column {
+			return ai.Subject.Start.Column < aj.Subject.Start.Column
+		}
+		return ai.Summary < aj.Summary
+	})
+	d := errs[0]
+	if d.Subject == nil {
+		return fmt.Sprintf("%s: %s", d.Summary, d.Detail)
+	}
+	if d.Detail == "" {
+		return fmt.Sprintf("%s:%d:%d: %s",
+			d.Subject.Filename, d.Subject.Start.Line, d.Subject.Start.Column,
+			d.Summary)
+	}
+	return fmt.Sprintf("%s:%d:%d: %s: %s",
+		d.Subject.Filename, d.Subject.Start.Line, d.Subject.Start.Column,
+		d.Summary, d.Detail)
+}

--- a/cmd/insideout-import/adopt_parse_test.go
+++ b/cmd/insideout-import/adopt_parse_test.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestParseAddresses_HappyPath asserts that a small HCL fragment with
+// three resources of different types yields the expected addresses,
+// types, names, and 1-based line numbers. The fixture is intentionally
+// small enough to inline so the line-number assertions stay obvious.
+func TestParseAddresses_HappyPath(t *testing.T) {
+	src := `resource "aws_sqs_queue" "dlq" {
+  name = "dlq"
+}
+
+resource "aws_s3_bucket" "logs" {
+  bucket = "logs"
+}
+
+resource "aws_iam_role" "task" {
+  name = "task"
+}
+`
+	got, err := ParseAddresses([]byte(src), "happy.tf")
+	if err != nil {
+		t.Fatalf("ParseAddresses returned unexpected error: %v", err)
+	}
+	want := []AdoptAddressEntry{
+		{Address: "aws_sqs_queue.dlq", Type: "aws_sqs_queue", Name: "dlq", File: "happy.tf", Line: 1},
+		{Address: "aws_s3_bucket.logs", Type: "aws_s3_bucket", Name: "logs", File: "happy.tf", Line: 5},
+		{Address: "aws_iam_role.task", Type: "aws_iam_role", Name: "task", File: "happy.tf", Line: 9},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry[%d]: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestParseAddresses_HCLSyntaxErrorReturnedAsError asserts that a
+// malformed HCL document surfaces as a non-nil error whose string carries
+// the filename plus line/column context (so callers can render
+// "filename:line:col: ..." messages back to operators).
+func TestParseAddresses_HCLSyntaxErrorReturnedAsError(t *testing.T) {
+	// Unbalanced brace — guarantees a parse-time diagnostic.
+	src := `resource "aws_sqs_queue" "dlq" {
+  name = "dlq"
+`
+	_, err := ParseAddresses([]byte(src), "broken.tf")
+	if err == nil {
+		t.Fatalf("ParseAddresses returned nil error for malformed HCL")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "broken.tf") {
+		t.Errorf("error message %q does not contain filename %q", msg, "broken.tf")
+	}
+	// Standard hcl diagnostic format: filename:line:col:.
+	if !strings.Contains(msg, ":") {
+		t.Errorf("error message %q is missing :line:col context", msg)
+	}
+	if !strings.Contains(msg, "adopt.ParseAddresses") {
+		t.Errorf("error message %q is missing adopt.ParseAddresses prefix", msg)
+	}
+}
+
+// TestParseAddresses_IgnoresNonResourceBlocks asserts that every
+// non-`resource` top-level block type is skipped and only the resource
+// blocks come back. Each block type that adopt's v1 explicitly skips
+// (per the function header) is exercised here so a future refactor that
+// accidentally starts emitting `data` / `module` addresses fails this
+// test instead of leaking through.
+func TestParseAddresses_IgnoresNonResourceBlocks(t *testing.T) {
+	src := `terraform {
+  required_version = ">= 1.5"
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+variable "name" {
+  type = string
+}
+
+output "queue" {
+  value = "x"
+}
+
+locals {
+  prefix = "p"
+}
+
+data "aws_caller_identity" "me" {}
+
+module "child" {
+  source = "./child"
+}
+
+resource "aws_sqs_queue" "kept" {
+  name = "kept"
+}
+`
+	got, err := ParseAddresses([]byte(src), "mixed.tf")
+	if err != nil {
+		t.Fatalf("ParseAddresses returned unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 resource block kept, got %d: %+v", len(got), got)
+	}
+	if got[0].Address != "aws_sqs_queue.kept" {
+		t.Errorf("kept resource address = %q, want %q", got[0].Address, "aws_sqs_queue.kept")
+	}
+	if got[0].Type != "aws_sqs_queue" || got[0].Name != "kept" {
+		t.Errorf("kept resource type/name = %q/%q, want aws_sqs_queue/kept", got[0].Type, got[0].Name)
+	}
+}
+
+// TestParseAddresses_PreservesSourceOrder asserts that the returned
+// slice matches file declaration order even when block types are
+// scrambled. HCL preserves Body.Blocks order; this test guards against a
+// future refactor that sorts internally and breaks consumers relying on
+// "first-in-file = first-emitted".
+func TestParseAddresses_PreservesSourceOrder(t *testing.T) {
+	src := `resource "aws_iam_role" "r3" {}
+resource "aws_sqs_queue" "r1" {}
+resource "aws_s3_bucket" "r5" {}
+resource "aws_iam_role" "r2" {}
+resource "aws_sqs_queue" "r4" {}
+`
+	got, err := ParseAddresses([]byte(src), "ordered.tf")
+	if err != nil {
+		t.Fatalf("ParseAddresses returned unexpected error: %v", err)
+	}
+	wantNames := []string{"r3", "r1", "r5", "r2", "r4"}
+	if len(got) != len(wantNames) {
+		t.Fatalf("got %d entries, want %d", len(got), len(wantNames))
+	}
+	for i, want := range wantNames {
+		if got[i].Name != want {
+			t.Errorf("entry[%d].Name = %q, want %q (order broken)", i, got[i].Name, want)
+		}
+	}
+}
+
+// TestParseAddresses_EmptyInputReturnsEmptySlice asserts that the empty
+// HCL document returns a non-nil empty slice. The non-nil contract
+// matters because the discovery-inspector convention (#255) requires
+// JSON-marshaled output to be `[]`, never `null`, so reliable's UI
+// renders an empty-state row rather than the deploy-first fallback.
+func TestParseAddresses_EmptyInputReturnsEmptySlice(t *testing.T) {
+	got, err := ParseAddresses([]byte(""), "empty.tf")
+	if err != nil {
+		t.Fatalf("ParseAddresses returned unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("ParseAddresses returned nil slice; want empty non-nil slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("ParseAddresses returned %d entries; want 0", len(got))
+	}
+	// Belt-and-suspenders: assert the JSON shape too.
+	b, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal(empty result) returned unexpected error: %v", err)
+	}
+	if string(b) != "[]" {
+		t.Errorf("json.Marshal = %q, want %q", string(b), "[]")
+	}
+}
+
+// TestParseAddresses_FilenameThreadsToError asserts that the filename
+// argument propagates into the error string for a malformed document.
+// This is the contract reliable's wizard relies on to render
+// "filename:line: ..." in the upload-hcl error toast.
+func TestParseAddresses_FilenameThreadsToError(t *testing.T) {
+	src := `resource "aws_sqs_queue" {
+}
+`
+	_, err := ParseAddresses([]byte(src), "my.tf")
+	if err == nil {
+		t.Fatalf("ParseAddresses returned nil error for missing label")
+	}
+	if !strings.Contains(err.Error(), "my.tf") {
+		t.Errorf("error %q missing filename %q", err.Error(), "my.tf")
+	}
+}
+
+// TestParseAddresses_ModuleQualifiedAddressInComment is a pin: the HCL
+// parser does not auto-recurse into a referenced child `module` source
+// directory, so we never see `module.x.aws_sqs_queue.dlq` from a single
+// ParseAddresses call. v1 of the helper reflects this: only root-scoped
+// blocks come back, with ModulePath always empty.
+func TestParseAddresses_ModuleQualifiedAddressInComment(t *testing.T) {
+	src := `module "child" {
+  source = "./child"
+}
+
+resource "aws_sqs_queue" "root_q" {}
+`
+	got, err := ParseAddresses([]byte(src), "parent.tf")
+	if err != nil {
+		t.Fatalf("ParseAddresses returned unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 root resource, got %d: %+v", len(got), got)
+	}
+	if got[0].ModulePath != "" {
+		t.Errorf("ModulePath = %q, want empty (v1 does not recurse modules)", got[0].ModulePath)
+	}
+	if got[0].Address != "aws_sqs_queue.root_q" {
+		t.Errorf("Address = %q, want aws_sqs_queue.root_q", got[0].Address)
+	}
+}
+
+// TestParseAddresses_QuotedLabelsAccepted pins the shape adopt expects
+// from upstream: HCL resource labels are quoted strings. HCL's grammar
+// does not actually permit bare-identifier labels for resource blocks
+// (the `LabelNames []string` slot in resource block definitions is
+// always quoted in Terraform), so this test asserts the quoted form
+// works and documents the lack of a bare-identifier alternative.
+func TestParseAddresses_QuotedLabelsAccepted(t *testing.T) {
+	src := `resource "aws_sqs_queue" "dlq" {}
+resource "aws_sqs_queue" "main_q" {}
+`
+	got, err := ParseAddresses([]byte(src), "labels.tf")
+	if err != nil {
+		t.Fatalf("ParseAddresses returned unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+	want := []string{"aws_sqs_queue.dlq", "aws_sqs_queue.main_q"}
+	for i, w := range want {
+		if got[i].Address != w {
+			t.Errorf("entry[%d].Address = %q, want %q", i, got[i].Address, w)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ParseAddresses(hcl []byte, filename string) ([]AdoptAddressEntry, error)` in `cmd/insideout-import/adopt_parse.go` — a pure HCL-bytes-to-terraform-addresses helper the reliable importer wizard's MCP server can call in-process from its `upload-hcl` step.
- Walks top-level `resource` blocks only; emits `{Address, Type, Name, ModulePath, File, Line}` in source order; ignores `provider`, `terraform`, `variable`, `output`, `locals`, `data`, and `module` blocks (per the v1 doc-comment).
- Surfaces HCL diagnostics as errors with `adopt.ParseAddresses: filename:line:col: <summary>: <detail>` so callers get actionable context for malformed uploads.
- Returns a non-nil empty slice for empty input — `json.Marshal` yields `[]`, not `null` — matching the discovery-inspector contract from #255 so reliable's UI doesn't fall through to the deploy-first fallback.
- 8 table-style tests cover the happy path, syntax errors, non-resource block filtering, source-order preservation, empty input, filename threading, the v1 module-recursion limitation, and quoted-label acceptance.

## Closes / Part of

- Closes #304.
- Part of #289 (Bundle 2 / PR 5).
- Stacked on #303 (`feat/discovery-summary-298`).

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/insideout-import/... ./pkg/composer/... ./pkg/insideout-import/... -count=1 -race` — 2015 passed across 12 packages.
- [x] `go vet ./...` — clean.
- [x] `gofmt -l cmd/ pkg/` — empty.
- [x] All 8 static lints (`lint-project-tag`, `lint-project-label`, `lint-sensitive-for-each`, `lint-foreach-unknown-keys`, `lint-no-root-only-blocks`, `lint-shared-no-cloud-providers`, `lint-labelless-name-prefix`, `lint-gcp-project-pin`) PASS.

## Stacking note

Targets `feat/discovery-summary-298` (PR #303), not `main`. Stacked-PR CI gates on the base merge to `main` — the local-green bar is what matters here. Once #303 merges, GitHub will retarget this PR onto `main` automatically (or it will be rebased).

## Notes

- **Module recursion deferred (v1).** The helper does not auto-recurse into directories referenced by `module "x" { source = "./y" }` blocks — `ParseAddresses` operates on a single `[]byte` document and never touches the filesystem. Callers wanting nested addresses should call `ParseAddresses` once per file and merge with the appropriate `ModulePath` prefix applied externally. The `ModulePath` field is reserved on the struct so a follow-up can fill it in without an API change.
- **Instance keys deferred.** `for_each` / `count` instance addresses (e.g. `aws_sqs_queue.q["a"]`) are not enumerated; the returned `Address` is always the static block address.
- **Diagnostics format.** Errors take the shape `adopt.ParseAddresses: <filename>:<line>:<col>: <summary>: <detail>`. Multiple HCL diagnostics from one parse are sorted by source position then summary so the rendered "first" error is deterministic for tests and for operators tailing logs.