### PR TITLE
feat(insideout-import): IAM permissions manifest (#305)

### DIFF
--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "provider": "aws",
+  "permissions": [
+    {"service": "cloudwatchlogs", "iam_action": "logs:DescribeLogGroups", "purpose": "list log groups (server-side LogGroupNamePattern filter)"},
+    {"service": "cloudwatchlogs", "iam_action": "logs:ListTagsForResource", "purpose": "fetch log-group tags for tag selectors and Identity.Tags"},
+    {"service": "dynamodb", "iam_action": "dynamodb:DescribeTable", "purpose": "resolve a single table by name in DiscoverByID"},
+    {"service": "dynamodb", "iam_action": "dynamodb:ListTables", "purpose": "list per-region tables (paginated)"},
+    {"service": "dynamodb", "iam_action": "dynamodb:ListTagsOfResource", "purpose": "fetch table tags for tag selectors and Identity.Tags"},
+    {"service": "iam_policy", "iam_action": "iam:GetPolicy", "purpose": "resolve a single managed policy by ARN in DiscoverByID"},
+    {"service": "iam_policy", "iam_action": "iam:ListPolicies", "purpose": "list customer-managed (Scope=Local) IAM policies"},
+    {"service": "iam_policy", "iam_action": "iam:ListPolicyTags", "purpose": "fetch policy tags for tag selectors and Identity.Tags"},
+    {"service": "iam_role", "iam_action": "iam:GetRole", "purpose": "resolve a single role by name in DiscoverByID"},
+    {"service": "iam_role", "iam_action": "iam:ListRoleTags", "purpose": "fetch role tags for tag selectors and Identity.Tags"},
+    {"service": "iam_role", "iam_action": "iam:ListRoles", "purpose": "list IAM roles (paginated)"},
+    {"service": "kms", "iam_action": "kms:DescribeKey", "purpose": "resolve a single key by UUID/alias in DiscoverByID"},
+    {"service": "kms", "iam_action": "kms:ListAliases", "purpose": "list KMS aliases for the project (account/region scoped)"},
+    {"service": "kms", "iam_action": "kms:ListResourceTags", "purpose": "fetch key tags for tag selectors and Identity.Tags"},
+    {"service": "lambda", "iam_action": "lambda:GetFunction", "purpose": "resolve a single function by name/ARN in DiscoverByID"},
+    {"service": "lambda", "iam_action": "lambda:ListFunctions", "purpose": "list per-region Lambda functions (paginated)"},
+    {"service": "lambda", "iam_action": "lambda:ListTags", "purpose": "fetch function tags for tag selectors and Identity.Tags"},
+    {"service": "resource_explorer_2", "iam_action": "resource-explorer-2:Search", "purpose": "broad enumeration of unsupported resource types (--include-unsupported, gap #6)"},
+    {"service": "s3", "iam_action": "s3:GetBucketTagging", "purpose": "fetch bucket tags for tag selectors and Identity.Tags"},
+    {"service": "s3", "iam_action": "s3:HeadBucket", "purpose": "verify bucket existence in DiscoverByID"},
+    {"service": "s3", "iam_action": "s3:ListAllMyBuckets", "purpose": "list buckets account-globally (ListBuckets)"},
+    {"service": "secretsmanager", "iam_action": "secretsmanager:DescribeSecret", "purpose": "resolve a single secret by name/ARN in DiscoverByID"},
+    {"service": "secretsmanager", "iam_action": "secretsmanager:ListSecrets", "purpose": "list per-region secrets (server-side TagKey/TagValue filter when project is set)"},
+    {"service": "sqs", "iam_action": "sqs:GetQueueUrl", "purpose": "resolve a queue URL by name in DiscoverByID"},
+    {"service": "sqs", "iam_action": "sqs:ListQueueTags", "purpose": "fetch queue tags for tag selectors and Identity.Tags"},
+    {"service": "sqs", "iam_action": "sqs:ListQueues", "purpose": "list per-region queues (server-side QueueNamePrefix filter when project is set)"},
+    {"service": "sts", "iam_action": "sts:GetCallerIdentity", "purpose": "stamp the AccountID on every discovered resource (one call per run)"}
+  ]
+}

--- a/pkg/insideout-import/permissions/gcp.json
+++ b/pkg/insideout-import/permissions/gcp.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "provider": "gcp",
+  "permissions": [
+    {"service": "cloud_asset_inventory", "gcp_role": "roles/cloudasset.viewer", "iam_permission": "cloudasset.assets.searchAllResources", "purpose": "single Cloud Asset SearchAllResources call enumerates every supported and unsupported resource type"}
+  ]
+}

--- a/pkg/insideout-import/permissions/permissions.go
+++ b/pkg/insideout-import/permissions/permissions.go
@@ -1,0 +1,98 @@
+// Package permissions exposes the canonical, versioned manifests of
+// read-only cloud-API permissions the insideout-import discover pipeline
+// requires for each provider.
+//
+// Reliable's importer wizard ConnectCloud step probes a candidate
+// credential against this list (via simulate-policy / IAM-permissions test)
+// before letting the operator advance — turning the manifest into the
+// single source of truth that travels alongside the discoverer code.
+// Adding a new SDK call to a per-service AWS discoverer (or a new GCP
+// asset family) is a manifest edit, not a code change in two places.
+//
+// Manifest files are checked into this directory as JSON and embedded via
+// `//go:embed` so reliable's MCP server gets the same bytes the CI
+// coverage test verifies. JSON is the surface contract — keep entries
+// sorted by (service, iam_action) on disk so byte-stable comparisons hold
+// across releases.
+//
+// File-location decision: the JSON files live next to permissions.go (not
+// under cmd/insideout-import/permissions/ as the issue body initially
+// suggested) so the //go:embed paths are simple, sibling-relative
+// references. The cmd-side directory carries no Go package and would be
+// awkward to embed across the repo root. See PR #305 / issue #305.
+package permissions
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+)
+
+// Manifest is the on-disk shape for a per-provider permissions manifest.
+// Version is incremented on any breaking shape change (rename of the
+// outer fields, restructured Permission entries) so reliable can reject
+// manifests it has not been updated for.
+type Manifest struct {
+	Version     int          `json:"version"`
+	Provider    string       `json:"provider"`
+	Permissions []Permission `json:"permissions"`
+}
+
+// Permission is one (service, action-or-role, purpose) row in a manifest.
+//
+// Per-provider field semantics (mutually exclusive at construction time
+// today; readers should accept either shape so future hybrid providers
+// don't break consumers):
+//
+//   - AWS: IAMAction holds the IAM action string (e.g. "sqs:ListQueues").
+//     GCPRole and IAMPermission stay empty.
+//   - GCP: GCPRole holds the predefined-role name
+//     ("roles/cloudasset.viewer") and IAMPermission holds the underlying
+//     permission constant ("cloudasset.assets.searchAllResources"). Both
+//     are emitted because reliable's probe surface today maps to the
+//     IAM permission constant; the role name is documentation for the
+//     operator (it's the role the manifest expects to be granted).
+//     IAMAction stays empty.
+//
+// Service is the CLI-side per-service slug (matches awsdiscover's
+// ServiceSlug for AWS rows; identifies the GCP API surface for GCP rows).
+// Purpose is a one-line human-readable string explaining why the
+// discoverer needs the permission — surfaced verbatim by reliable's
+// wizard when explaining a missing-permission failure to the operator.
+type Permission struct {
+	Service       string `json:"service"`
+	IAMAction     string `json:"iam_action,omitempty"`
+	GCPRole       string `json:"gcp_role,omitempty"`
+	IAMPermission string `json:"iam_permission,omitempty"`
+	Purpose       string `json:"purpose"`
+}
+
+//go:embed aws.json
+var awsRaw []byte
+
+//go:embed gcp.json
+var gcpRaw []byte
+
+// LoadAWSManifest parses the embedded aws.json into a Manifest. The
+// returned value is a fresh struct on each call; callers may mutate the
+// Permissions slice without affecting subsequent calls. An error wraps
+// the underlying json.Unmarshal failure with enough context to identify
+// which file failed to parse — useful when a contributor edits aws.json
+// by hand and produces invalid JSON.
+func LoadAWSManifest() (Manifest, error) {
+	var m Manifest
+	if err := json.Unmarshal(awsRaw, &m); err != nil {
+		return Manifest{}, fmt.Errorf("permissions: parse aws.json: %w", err)
+	}
+	return m, nil
+}
+
+// LoadGCPManifest parses the embedded gcp.json into a Manifest. See
+// LoadAWSManifest for ownership and error-shape semantics.
+func LoadGCPManifest() (Manifest, error) {
+	var m Manifest
+	if err := json.Unmarshal(gcpRaw, &m); err != nil {
+		return Manifest{}, fmt.Errorf("permissions: parse gcp.json: %w", err)
+	}
+	return m, nil
+}

--- a/pkg/insideout-import/permissions/permissions_test.go
+++ b/pkg/insideout-import/permissions/permissions_test.go
@@ -1,0 +1,234 @@
+package permissions
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
+)
+
+// awsTFTypeToServiceSlug mirrors awsdiscover.serviceSlugByTFType. We
+// duplicate it here (rather than import the cmd-side map) so this
+// pkg-level test stays free of cmd/ imports — the registry package
+// follows the same posture for its parity tests. Drift between this
+// table and the awsdiscover slug map will surface as a coverage-test
+// failure: any TF type from the registry whose slug isn't keyed here
+// (or whose slug isn't represented in aws.json) trips the assertion.
+var awsTFTypeToServiceSlug = map[string]string{
+	"aws_cloudwatch_log_group":  "cloudwatchlogs",
+	"aws_dynamodb_table":        "dynamodb",
+	"aws_iam_policy":            "iam_policy",
+	"aws_iam_role":              "iam_role",
+	"aws_kms_key":               "kms",
+	"aws_lambda_function":       "lambda",
+	"aws_s3_bucket":             "s3",
+	"aws_secretsmanager_secret": "secretsmanager",
+	"aws_sqs_queue":             "sqs",
+}
+
+func TestLoadAWSManifest_ParsesAndIsNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	m, err := LoadAWSManifest()
+	if err != nil {
+		t.Fatalf("LoadAWSManifest: %v", err)
+	}
+	if m.Version != 1 {
+		t.Errorf("Version: got %d, want 1", m.Version)
+	}
+	if m.Provider != "aws" {
+		t.Errorf("Provider: got %q, want %q", m.Provider, "aws")
+	}
+	if len(m.Permissions) == 0 {
+		t.Fatal("Permissions: empty slice; aws.json must declare at least one entry per discoverer")
+	}
+}
+
+func TestLoadGCPManifest_ParsesAndIsNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	m, err := LoadGCPManifest()
+	if err != nil {
+		t.Fatalf("LoadGCPManifest: %v", err)
+	}
+	if m.Version != 1 {
+		t.Errorf("Version: got %d, want 1", m.Version)
+	}
+	if m.Provider != "gcp" {
+		t.Errorf("Provider: got %q, want %q", m.Provider, "gcp")
+	}
+	if len(m.Permissions) == 0 {
+		t.Fatal("Permissions: empty slice; gcp.json must declare at least one entry")
+	}
+}
+
+// TestAWSManifest_CoversAllAWSDiscovererServices asserts every service
+// slug derived from registry.SupportedDiscoverTypes("aws") appears at
+// least once in the AWS manifest. Adding a new TF type to the registry
+// (and therefore a new per-service discoverer) without updating aws.json
+// fails this test — the credential probe in reliable would silently
+// under-test the new service otherwise.
+func TestAWSManifest_CoversAllAWSDiscovererServices(t *testing.T) {
+	t.Parallel()
+
+	m, err := LoadAWSManifest()
+	if err != nil {
+		t.Fatalf("LoadAWSManifest: %v", err)
+	}
+
+	slugInManifest := make(map[string]bool, len(m.Permissions))
+	for _, p := range m.Permissions {
+		slugInManifest[p.Service] = true
+	}
+
+	tfTypes := registry.SupportedDiscoverTypes(registry.ProviderAWS)
+	if len(tfTypes) == 0 {
+		t.Fatal("registry.SupportedDiscoverTypes(aws) returned empty; manifest coverage cannot be checked")
+	}
+	for _, tfType := range tfTypes {
+		slug, ok := awsTFTypeToServiceSlug[tfType]
+		if !ok {
+			t.Errorf("awsTFTypeToServiceSlug missing entry for %q (registry exposes it but the test slug map does not); update awsTFTypeToServiceSlug AND aws.json", tfType)
+			continue
+		}
+		if !slugInManifest[slug] {
+			t.Errorf("aws.json: missing permission entry for service slug %q (TF type %q); add at least one IAM action row", slug, tfType)
+		}
+	}
+
+	// sts is a one-call-per-run dependency that isn't tied to a TF
+	// type via the registry, but the credential probe still needs it
+	// — gate explicitly so the manifest can't drop sts:GetCallerIdentity.
+	if !slugInManifest["sts"] {
+		t.Error("aws.json: missing sts entry; sts:GetCallerIdentity is called once per discover run to stamp AccountID")
+	}
+}
+
+// TestGCPManifest_CoversCloudAssetInventory asserts the single
+// cloud_asset_inventory row that powers every GCP discoverer is present.
+// If a future PR breaks GCP into per-API discoverers, this test should
+// be updated alongside that change rather than removed wholesale.
+func TestGCPManifest_CoversCloudAssetInventory(t *testing.T) {
+	t.Parallel()
+
+	m, err := LoadGCPManifest()
+	if err != nil {
+		t.Fatalf("LoadGCPManifest: %v", err)
+	}
+	for _, p := range m.Permissions {
+		if p.Service == "cloud_asset_inventory" {
+			if p.GCPRole != "roles/cloudasset.viewer" {
+				t.Errorf("cloud_asset_inventory: GCPRole=%q, want roles/cloudasset.viewer", p.GCPRole)
+			}
+			if p.IAMPermission != "cloudasset.assets.searchAllResources" {
+				t.Errorf("cloud_asset_inventory: IAMPermission=%q, want cloudasset.assets.searchAllResources", p.IAMPermission)
+			}
+			return
+		}
+	}
+	t.Error("gcp.json: missing cloud_asset_inventory entry; SearchAllResources is the only API every GCP discoverer calls")
+}
+
+// TestAWSManifest_DeterministicSortedByServiceAndAction protects the
+// byte-stability invariant: the on-disk JSON must be sorted by
+// (service, iam_action) so a downstream byte-comparison probe (e.g.
+// reliable's CI gate that checksums the embedded blob) doesn't churn
+// when an unrelated PR touches the file. A regression that re-orders
+// entries without re-sorting fails this test.
+func TestAWSManifest_DeterministicSortedByServiceAndAction(t *testing.T) {
+	t.Parallel()
+
+	m, err := LoadAWSManifest()
+	if err != nil {
+		t.Fatalf("LoadAWSManifest: %v", err)
+	}
+
+	want := make([]Permission, len(m.Permissions))
+	copy(want, m.Permissions)
+	sort.SliceStable(want, func(i, j int) bool {
+		if want[i].Service != want[j].Service {
+			return want[i].Service < want[j].Service
+		}
+		return want[i].IAMAction < want[j].IAMAction
+	})
+	for i := range m.Permissions {
+		if m.Permissions[i] != want[i] {
+			t.Fatalf("aws.json entry %d unsorted: got (service=%q, action=%q), want (service=%q, action=%q); re-sort the file by (service, iam_action)",
+				i, m.Permissions[i].Service, m.Permissions[i].IAMAction, want[i].Service, want[i].IAMAction)
+		}
+	}
+}
+
+// TestAWSManifest_NoUnknownPurposeStrings asserts every entry carries a
+// non-empty Purpose. Reliable's wizard surfaces Purpose verbatim when
+// explaining a missing-permission failure to the operator; an empty
+// string would render a blank explanation row.
+func TestAWSManifest_NoUnknownPurposeStrings(t *testing.T) {
+	t.Parallel()
+
+	m, err := LoadAWSManifest()
+	if err != nil {
+		t.Fatalf("LoadAWSManifest: %v", err)
+	}
+	for i, p := range m.Permissions {
+		if p.Purpose == "" {
+			t.Errorf("aws.json entry %d (service=%q, action=%q): empty Purpose", i, p.Service, p.IAMAction)
+		}
+	}
+}
+
+// TestGCPManifest_NoUnknownPurposeStrings is the GCP-side mirror of the
+// purpose-non-empty contract.
+func TestGCPManifest_NoUnknownPurposeStrings(t *testing.T) {
+	t.Parallel()
+
+	m, err := LoadGCPManifest()
+	if err != nil {
+		t.Fatalf("LoadGCPManifest: %v", err)
+	}
+	for i, p := range m.Permissions {
+		if p.Purpose == "" {
+			t.Errorf("gcp.json entry %d (service=%q, role=%q): empty Purpose", i, p.Service, p.GCPRole)
+		}
+	}
+}
+
+// TestManifests_RoundTripJSON sanity-checks that loaded manifests
+// re-marshal to valid JSON without losing fields. Catches struct-tag
+// typos that would silently drop a field on either the read or write
+// path.
+func TestManifests_RoundTripJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		load func() (Manifest, error)
+	}{
+		{"aws", LoadAWSManifest},
+		{"gcp", LoadGCPManifest},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m, err := tc.load()
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			b, err := json.Marshal(m)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var round Manifest
+			if err := json.Unmarshal(b, &round); err != nil {
+				t.Fatalf("unmarshal round-trip: %v", err)
+			}
+			if round.Version != m.Version || round.Provider != m.Provider {
+				t.Errorf("round-trip drift: got %+v, want %+v", round, m)
+			}
+			if len(round.Permissions) != len(m.Permissions) {
+				t.Errorf("round-trip permission count: got %d, want %d", len(round.Permissions), len(m.Permissions))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds versioned, embedded JSON manifests of the read-only IAM actions / GCP roles the `insideout-import discover` pipeline needs for each provider, plus a `pkg/insideout-import/permissions` Go package exposing `LoadAWSManifest()` and `LoadGCPManifest()` backed by `//go:embed`. Reliable's importer wizard ConnectCloud step will turn the AWS action list into a simulate-policy probe and the GCP entry into an `iam.permissions.testIamPermissions` probe so credentials fail fast at wizard time.

- `pkg/insideout-import/permissions/aws.json` — every IAM action actually called by the per-service AWS discoverers (sqs, dynamodb, cloudwatchlogs, secretsmanager, lambda, iam_role, iam_policy, kms, s3, sts, plus `resource-explorer-2:Search` for `--include-unsupported`). Sorted by `(service, iam_action)` for byte-stable diffs.
- `pkg/insideout-import/permissions/gcp.json` — single `cloud_asset_inventory` row carrying both `gcp_role: roles/cloudasset.viewer` and `iam_permission: cloudasset.assets.searchAllResources` (the underlying permission constant). Every GCP discoverer goes through `SearchAllResources`.
- `pkg/insideout-import/permissions/permissions.go` — `Manifest` / `Permission` types and the two `Load*Manifest()` constructors. JSON files co-located with the Go file so `//go:embed` paths are simple sibling references.
- Coverage tests block drift: adding a new TF type to `SupportedDiscoverTypes` without a matching manifest entry fails `TestAWSManifest_CoversAllAWSDiscovererServices`. Sort discipline is gated by `TestAWSManifest_DeterministicSortedByServiceAndAction`.

## Closes / Part of

- Closes #305.
- Part of #289 (Bundle 2 / PR 6).
- Sibling to PR #304 off the same base `feat/discovery-summary-298`. Files do not overlap.

## Test plan

- `go build ./...` — clean.
- `go test ./cmd/insideout-import/... ./pkg/composer/... ./pkg/insideout-import/... -count=1 -race` — 2025 passed in 13 packages.
- `go vet ./...` — clean.
- `gofmt -l cmd/ pkg/` — empty.
- All eight static-Terraform lints — clean.
- New tests in `pkg/insideout-import/permissions/`:
  - `TestLoadAWSManifest_ParsesAndIsNonEmpty`
  - `TestLoadGCPManifest_ParsesAndIsNonEmpty`
  - `TestAWSManifest_CoversAllAWSDiscovererServices`
  - `TestGCPManifest_CoversCloudAssetInventory`
  - `TestAWSManifest_DeterministicSortedByServiceAndAction`
  - `TestAWSManifest_NoUnknownPurposeStrings`
  - `TestGCPManifest_NoUnknownPurposeStrings`
  - `TestManifests_RoundTripJSON`

## Stacking note

Stacks on top of PR #303 (`feat/discovery-summary-298`); CI on stacked PRs gates on the base merging to main. Locally-green is the bar today. Once #303 lands the GitHub Actions checks here will go green automatically.

## Notes — JSON file location decision

The issue body suggested `cmd/insideout-import/permissions/aws.json`. The PR co-locates the JSON with the Go package at `pkg/insideout-import/permissions/aws.json` instead. Rationale:

- `//go:embed aws.json` (sibling reference) is simpler and less brittle than `//go:embed ../../cmd/insideout-import/permissions/aws.json` (path-traversal).
- The `cmd/` directory does not host its own Go package and would be an awkward home for files that exist solely to be embedded by the `pkg/` package.
- Reliable's MCP server consumes the manifest via `permissions.LoadAWSManifest()`, not by reading the JSON directly — the on-disk path is an internal detail of this repo.

The header doc comment on `permissions.go` records the decision with a back-reference to #305.

## Service slug map (test-side duplication)

`permissions_test.go` declares `awsTFTypeToServiceSlug`, a copy of `awsdiscover.serviceSlugByTFType`. Same posture as the registry parity tests — keeps `pkg/insideout-import/...` free of `cmd/` imports. A drift between the two maps surfaces as a coverage-test failure pointing at the missing `(tf_type, slug)` pair.