### PR TITLE
refactor(insideout-import): discoveryAggregator.DiscoverTypes → AggArgs struct (#310)

### DIFF
--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -50,43 +50,85 @@ const discoverRetryMaxAttempts = 8
 // dep-chase loop calls into the aggregator to resolve unresolved ARNs
 // inside generated.tf to fresh ImportedResource entries.
 //
-// DiscoverTypes uses positional args (rather than a struct) so neither
-// cloud's package-local DiscoverArgs type (#291) leaks into the CLI's
-// shared interface — adapters in productionDiscoverDeps convert. Tag
-// selectors flow through as the CLI-package tagSelectorPair so the
-// interface stays decoupled from awsdiscover/gcpdiscover.
-//
-// TODO(#310): refactor to AggArgs struct. The 7-arg signature is hard
-// to extend — adding a per-stage timeout or a budget knob requires
-// touching three signatures + every test fake. A struct-shaped
-// AggArgs would shrink each fake's capture to a single gotArgs field.
+// DiscoverTypes takes a single AggArgs struct (#310). The CLI-package
+// tagSelectorPair flows through as-is so the interface stays decoupled
+// from awsdiscover/gcpdiscover; adapters in productionDiscoverDeps
+// convert into per-cloud DiscoverArgs at the boundary. Future fields
+// (per-stage timeout #311, budget knobs, etc.) are additive on AggArgs
+// without rippling through the interface or every test fake.
 type discoveryAggregator interface {
-	DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error)
+	DiscoverTypes(ctx context.Context, args AggArgs) ([]imported.ImportedResource, error)
 	DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error)
 }
 
+// AggArgs are the orchestrator-level inputs to
+// discoveryAggregator.DiscoverTypes. Mirrors the per-cloud DiscoverArgs
+// structs at awsdiscover/args.go and gcpdiscover/args.go but supersets
+// both: AccountID lives here even though GCP doesn't use it — the
+// aggregator interface is cloud-agnostic and the adapters convert.
+// Future fields (per-stage timeout #311, etc.) are additive without
+// rippling through the interface.
+type AggArgs struct {
+	Types        []string
+	Project      string
+	Regions      []string
+	TagSelectors []tagSelectorPair
+	AccountID    string
+	Emitter      progress.Emitter
+}
+
+// aggArgsToAWS translates an orchestrator-level AggArgs into the
+// per-cloud awsdiscover.DiscoverArgs the *AWSDiscoverer consumes. The
+// only non-trivial work is converting tagSelectorPair (CLI-package) →
+// awsdiscover.TagSelector (per-cloud) so the cloud-specific type doesn't
+// bleed into discover.go's orchestrator code. Extracted from
+// awsAggAdapter.DiscoverTypes so the AggArgs round-trip test (#310) can
+// pin field-by-field translation without standing up a real
+// *AWSDiscoverer.
+func aggArgsToAWS(args AggArgs) (types []string, awsArgs awsdiscover.DiscoverArgs) {
+	sel := make([]awsdiscover.TagSelector, 0, len(args.TagSelectors))
+	for _, p := range args.TagSelectors {
+		sel = append(sel, awsdiscover.TagSelector{Key: p.Key, Value: p.Value})
+	}
+	return args.Types, awsdiscover.DiscoverArgs{
+		Project:      args.Project,
+		Regions:      args.Regions,
+		TagSelectors: sel,
+		AccountID:    args.AccountID,
+		Emitter:      args.Emitter,
+	}
+}
+
+// aggArgsToGCP is the GCP analogue of aggArgsToAWS. AggArgs.AccountID is
+// intentionally dropped on GCP — the project ID lives on the
+// *gcpdiscover.GCPDiscoverer struct (set at construction), and GCP has
+// no STS-equivalent caller-identity round-trip whose result needs
+// threading through.
+func aggArgsToGCP(args AggArgs) (types []string, gcpArgs gcpdiscover.DiscoverArgs) {
+	sel := make([]gcpdiscover.TagSelector, 0, len(args.TagSelectors))
+	for _, p := range args.TagSelectors {
+		sel = append(sel, gcpdiscover.TagSelector{Key: p.Key, Value: p.Value})
+	}
+	return args.Types, gcpdiscover.DiscoverArgs{
+		Project:      args.Project,
+		Regions:      args.Regions,
+		TagSelectors: sel,
+		Emitter:      args.Emitter,
+	}
+}
+
 // awsAggAdapter wraps *awsdiscover.AWSDiscoverer to satisfy
-// discoveryAggregator's positional DiscoverTypes signature, converting
-// the CLI's tagSelectorPair into awsdiscover.TagSelector at the
-// boundary. Mirrors gcpAggAdapter; both adapters are intentionally
-// thin so the cloud-specific type doesn't bleed into discover.go's
-// orchestrator code.
+// discoveryAggregator, translating AggArgs into awsdiscover.DiscoverArgs
+// at the boundary via aggArgsToAWS. Mirrors gcpAggAdapter; both
+// adapters are intentionally thin so the cloud-specific type doesn't
+// bleed into discover.go's orchestrator code.
 type awsAggAdapter struct {
 	d *awsdiscover.AWSDiscoverer
 }
 
-func (a awsAggAdapter) DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error) {
-	sel := make([]awsdiscover.TagSelector, 0, len(tagSelectors))
-	for _, p := range tagSelectors {
-		sel = append(sel, awsdiscover.TagSelector{Key: p.Key, Value: p.Value})
-	}
-	return a.d.DiscoverTypes(ctx, types, awsdiscover.DiscoverArgs{
-		Project:      project,
-		Regions:      regions,
-		TagSelectors: sel,
-		AccountID:    accountID,
-		Emitter:      emitter,
-	})
+func (a awsAggAdapter) DiscoverTypes(ctx context.Context, args AggArgs) ([]imported.ImportedResource, error) {
+	types, awsArgs := aggArgsToAWS(args)
+	return a.d.DiscoverTypes(ctx, types, awsArgs)
 }
 
 func (a awsAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error) {
@@ -94,26 +136,15 @@ func (a awsAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, acc
 }
 
 // gcpAggAdapter wraps *gcpdiscover.GCPDiscoverer to satisfy
-// discoveryAggregator. Converts tagSelectorPair → gcpdiscover.TagSelector;
-// otherwise mirrors awsAggAdapter.
+// discoveryAggregator. Converts AggArgs into gcpdiscover.DiscoverArgs via
+// aggArgsToGCP; otherwise mirrors awsAggAdapter.
 type gcpAggAdapter struct {
 	d *gcpdiscover.GCPDiscoverer
 }
 
-func (a gcpAggAdapter) DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error) {
-	sel := make([]gcpdiscover.TagSelector, 0, len(tagSelectors))
-	for _, p := range tagSelectors {
-		sel = append(sel, gcpdiscover.TagSelector{Key: p.Key, Value: p.Value})
-	}
-	// accountID is unused on GCP — the project ID lives on the
-	// *gcpdiscover.GCPDiscoverer struct (set at construction).
-	_ = accountID
-	return a.d.DiscoverTypes(ctx, types, gcpdiscover.DiscoverArgs{
-		Project:      project,
-		Regions:      regions,
-		TagSelectors: sel,
-		Emitter:      emitter,
-	})
+func (a gcpAggAdapter) DiscoverTypes(ctx context.Context, args AggArgs) ([]imported.ImportedResource, error) {
+	types, gcpArgs := aggArgsToGCP(args)
+	return a.d.DiscoverTypes(ctx, types, gcpArgs)
 }
 
 func (a gcpAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error) {
@@ -655,7 +686,14 @@ Exit codes:
 		resources = preloaded
 	} else {
 		var err error
-		resources, err = d.DiscoverTypes(ctx, types, *project, resolvedRegions, parsedSelectors, accountID, emitter)
+		resources, err = d.DiscoverTypes(ctx, AggArgs{
+			Types:        types,
+			Project:      *project,
+			Regions:      resolvedRegions,
+			TagSelectors: parsedSelectors,
+			AccountID:    accountID,
+			Emitter:      emitter,
+		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "discover: %v\n", err)
 			return discoverExitFatal

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -204,7 +204,7 @@ func TestRunDiscoverWithDeps_MultiRegionThreadsAllRegionsToAggregator(t *testing
 	if lastLoadRegion != "us-east-1" {
 		t.Errorf("loadConfig got region=%q, want us-east-1 (primaryRegion = first --regions value)", lastLoadRegion)
 	}
-	if got, want := agg.gotRegions, []string{"us-east-1", "eu-west-1"}; !equalSlices(got, want) {
+	if got, want := agg.gotArgs.Regions, []string{"us-east-1", "eu-west-1"}; !equalSlices(got, want) {
 		t.Errorf("Regions threaded = %v, want %v", got, want)
 	}
 }
@@ -232,7 +232,7 @@ func TestRunDiscoverWithDeps_DeprecatedRegionStillThreadsAsRegions(t *testing.T)
 	if rc != discoverExitOK {
 		t.Fatalf("rc=%d, want ok", rc)
 	}
-	if got, want := agg.gotRegions, []string{"us-east-1"}; !equalSlices(got, want) {
+	if got, want := agg.gotArgs.Regions, []string{"us-east-1"}; !equalSlices(got, want) {
 		t.Errorf("Regions threaded = %v, want [us-east-1] (deprecated --region alias)", got)
 	}
 	if !strings.Contains(stderr, "deprecated") {
@@ -242,8 +242,10 @@ func TestRunDiscoverWithDeps_DeprecatedRegionStillThreadsAsRegions(t *testing.T)
 
 // TestRunDiscoverWithDeps_TagSelectorsThreadedToAggregator pins that
 // --tag-selectors flow through the parser into the aggregator's
-// observed gotSelectors slice. The CLI parser produces tagSelectorPair
-// entries; the aggregator adapter converts them per-cloud.
+// captured AggArgs.TagSelectors slice. The CLI parser produces
+// tagSelectorPair entries; the aggregator adapter converts them
+// per-cloud (see TestAggArgs_RoundTripsThroughAdapters for the
+// boundary translation pin).
 func TestRunDiscoverWithDeps_TagSelectorsThreadedToAggregator(t *testing.T) {
 	t.Parallel()
 	agg := &fakeAggregator{}
@@ -261,12 +263,12 @@ func TestRunDiscoverWithDeps_TagSelectorsThreadedToAggregator(t *testing.T) {
 		t.Fatalf("rc=%d, want ok", rc)
 	}
 	want := []tagSelectorPair{{Key: "env", Value: "prod"}, {Key: "team", Value: "growth"}}
-	if len(agg.gotSelectors) != len(want) {
-		t.Fatalf("selectors len=%d, want %d", len(agg.gotSelectors), len(want))
+	if len(agg.gotArgs.TagSelectors) != len(want) {
+		t.Fatalf("selectors len=%d, want %d", len(agg.gotArgs.TagSelectors), len(want))
 	}
 	for i, w := range want {
-		if agg.gotSelectors[i] != w {
-			t.Errorf("selector[%d]=%+v, want %+v", i, agg.gotSelectors[i], w)
+		if agg.gotArgs.TagSelectors[i] != w {
+			t.Errorf("selector[%d]=%+v, want %+v", i, agg.gotArgs.TagSelectors[i], w)
 		}
 	}
 }
@@ -305,20 +307,15 @@ func equalSlices(a, b []string) bool {
 
 // fakeAggregator is a lightweight stand-in for awsdiscover.AWSDiscoverer that
 // captures the inputs DiscoverTypes was called with and returns canned output.
+//
+// Per #310 the per-field capture slots collapsed to a single gotArgs
+// AggArgs; assertions throughout this file read agg.gotArgs.Project /
+// .Regions / .TagSelectors / etc. directly.
 type fakeAggregator struct {
-	out        []imported.ImportedResource
-	err        error
-	gotProject string
-	// gotRegions captures the full Regions slice (#291). gotRegion is
-	// the legacy single-region accessor, kept as the first element of
-	// Regions so existing test assertions continue to match for the
-	// pre-#291 single-region happy path.
-	gotRegions   []string
-	gotSelectors []tagSelectorPair
-	gotAccount   string
-	gotTypes     []string
-	gotEmitter   progress.Emitter
-	called       int
+	out     []imported.ImportedResource
+	err     error
+	gotArgs AggArgs
+	called  int
 
 	// DiscoverByID wiring for Stage 2c3 dep-chase tests. byID is keyed
 	// on tfType|id; missing entries return ErrNotFound.
@@ -330,16 +327,15 @@ type fakeAggregator struct {
 // gotRegion returns the first captured region for back-compat with
 // pre-#291 single-region test assertions.
 func (f *fakeAggregator) gotRegion() string {
-	if len(f.gotRegions) == 0 {
+	if len(f.gotArgs.Regions) == 0 {
 		return ""
 	}
-	return f.gotRegions[0]
+	return f.gotArgs.Regions[0]
 }
 
-func (f *fakeAggregator) DiscoverTypes(_ context.Context, types []string, project string, regions []string, selectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error) {
+func (f *fakeAggregator) DiscoverTypes(_ context.Context, args AggArgs) ([]imported.ImportedResource, error) {
 	f.called++
-	f.gotProject, f.gotRegions, f.gotSelectors, f.gotAccount, f.gotTypes = project, regions, selectors, accountID, types
-	f.gotEmitter = emitter
+	f.gotArgs = args
 	return f.out, f.err
 }
 
@@ -517,8 +513,8 @@ func TestRunDiscoverWithDeps_HappyPathWritesManifest(t *testing.T) {
 	if agg.called != 1 {
 		t.Errorf("DiscoverTypes called %d times, want 1", agg.called)
 	}
-	if agg.gotProject != "io-foo" || agg.gotRegion() != "us-east-1" || agg.gotAccount != "1234567890" {
-		t.Errorf("dispatch args = (%q,%q,%q), want (io-foo,us-east-1,1234567890)", agg.gotProject, agg.gotRegion(), agg.gotAccount)
+	if agg.gotArgs.Project != "io-foo" || agg.gotRegion() != "us-east-1" || agg.gotArgs.AccountID != "1234567890" {
+		t.Errorf("dispatch args = (%q,%q,%q), want (io-foo,us-east-1,1234567890)", agg.gotArgs.Project, agg.gotRegion(), agg.gotArgs.AccountID)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "imported.json")); err != nil {
 		t.Errorf("imported.json not written: %v", err)
@@ -587,8 +583,8 @@ func TestRunDiscoverWithDeps_EmptySTSAccountThreadsEmpty(t *testing.T) {
 	if rc != discoverExitOK {
 		t.Errorf("rc=%d, want OK (empty Account is not fatal)", rc)
 	}
-	if agg.gotAccount != "" {
-		t.Errorf("accountID threaded = %q, want empty", agg.gotAccount)
+	if agg.gotArgs.AccountID != "" {
+		t.Errorf("accountID threaded = %q, want empty", agg.gotArgs.AccountID)
 	}
 }
 
@@ -1594,8 +1590,8 @@ func TestRunDiscoverWithDeps_GCPHappyPathWritesManifest(t *testing.T) {
 	if agg.called != 1 {
 		t.Errorf("DiscoverTypes called %d times, want 1", agg.called)
 	}
-	if agg.gotProject != "io-foo" || agg.gotAccount != "real-proj" {
-		t.Errorf("dispatch args = (%q,%q,%q), want (io-foo, *, real-proj)", agg.gotProject, agg.gotRegion(), agg.gotAccount)
+	if agg.gotArgs.Project != "io-foo" || agg.gotArgs.AccountID != "real-proj" {
+		t.Errorf("dispatch args = (%q,%q,%q), want (io-foo, *, real-proj)", agg.gotArgs.Project, agg.gotRegion(), agg.gotArgs.AccountID)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, "imported.json"))
 	if err != nil {
@@ -2203,10 +2199,10 @@ type emittingFakeAggregator struct {
 	fakeAggregator
 }
 
-func (f *emittingFakeAggregator) DiscoverTypes(ctx context.Context, types []string, project string, regions []string, selectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error) {
-	out, err := f.fakeAggregator.DiscoverTypes(ctx, types, project, regions, selectors, accountID, emitter)
-	if emitter != nil {
-		emitter.StageFinish("discover", len(out), 0)
+func (f *emittingFakeAggregator) DiscoverTypes(ctx context.Context, args AggArgs) ([]imported.ImportedResource, error) {
+	out, err := f.fakeAggregator.DiscoverTypes(ctx, args)
+	if args.Emitter != nil {
+		args.Emitter.StageFinish("discover", len(out), 0)
 	}
 	return out, err
 }
@@ -2712,4 +2708,92 @@ func readSummaryWithoutDuration(t *testing.T, path string) string {
 	out, err := json.MarshalIndent(s, "", "  ")
 	require.NoError(t, err)
 	return string(out)
+}
+
+// TestAggArgs_RoundTripsThroughAdapters (#310) pins that aggArgsToAWS
+// and aggArgsToGCP — the AggArgs → per-cloud DiscoverArgs translation
+// helpers used by awsAggAdapter and gcpAggAdapter — copy every field
+// across the boundary. A regression that drops a field (e.g. a future
+// PR that adds AggArgs.Timeout but forgets the AWS adapter) would
+// surface here as a zero-value on the per-cloud side.
+//
+// AccountID is asserted only on the AWS path: GCP intentionally drops
+// it because the project ID lives on the *gcpdiscover.GCPDiscoverer
+// struct (see gcpAggAdapter doc comment). TagSelector translation
+// (CLI tagSelectorPair → per-cloud TagSelector) is exercised on both
+// paths since the cloud-specific type wrappers differ.
+func TestAggArgs_RoundTripsThroughAdapters(t *testing.T) {
+	t.Parallel()
+
+	emitter := progress.NopEmitter{}
+	args := AggArgs{
+		Types:        []string{"aws_sqs_queue", "aws_dynamodb_table"},
+		Project:      "io-foo",
+		Regions:      []string{"us-east-1", "eu-west-1"},
+		TagSelectors: []tagSelectorPair{{Key: "env", Value: "prod"}, {Key: "team", Value: "growth"}},
+		AccountID:    "123456789012",
+		Emitter:      emitter,
+	}
+
+	t.Run("aws", func(t *testing.T) {
+		t.Parallel()
+		gotTypes, gotArgs := aggArgsToAWS(args)
+
+		assert.Equal(t, args.Types, gotTypes, "Types")
+		assert.Equal(t, args.Project, gotArgs.Project, "Project")
+		assert.Equal(t, args.Regions, gotArgs.Regions, "Regions")
+		assert.Equal(t, args.AccountID, gotArgs.AccountID, "AccountID")
+		assert.Equal(t, args.Emitter, gotArgs.Emitter, "Emitter")
+
+		wantSel := []awsdiscover.TagSelector{
+			{Key: "env", Value: "prod"},
+			{Key: "team", Value: "growth"},
+		}
+		assert.Equal(t, wantSel, gotArgs.TagSelectors, "TagSelectors")
+	})
+
+	t.Run("gcp", func(t *testing.T) {
+		t.Parallel()
+		gotTypes, gotArgs := aggArgsToGCP(args)
+
+		assert.Equal(t, args.Types, gotTypes, "Types")
+		assert.Equal(t, args.Project, gotArgs.Project, "Project")
+		assert.Equal(t, args.Regions, gotArgs.Regions, "Regions")
+		assert.Equal(t, args.Emitter, gotArgs.Emitter, "Emitter")
+
+		wantSel := []gcpdiscover.TagSelector{
+			{Key: "env", Value: "prod"},
+			{Key: "team", Value: "growth"},
+		}
+		assert.Equal(t, wantSel, gotArgs.TagSelectors, "TagSelectors")
+
+		// AccountID is intentionally dropped — gcpdiscover.DiscoverArgs
+		// has no such field. The pin: the GCP DiscoverArgs struct still
+		// has exactly the four fields its package declares, so a
+		// regression that smuggles AccountID into the GCP path would
+		// fail to compile against this test's struct comparison.
+		assert.Equal(t, gcpdiscover.DiscoverArgs{
+			Project:      args.Project,
+			Regions:      args.Regions,
+			TagSelectors: wantSel,
+			Emitter:      args.Emitter,
+		}, gotArgs, "full GCP DiscoverArgs (no AccountID)")
+	})
+
+	t.Run("empty_selectors_yield_empty_not_nil", func(t *testing.T) {
+		t.Parallel()
+		// Both helpers eagerly allocate the slice (make with len=0). A
+		// regression that switched to `var sel []TagSelector` would
+		// emit JSON `null` on the wire vs. `[]`, which the wizard
+		// historically struggles with (see #255). This is a thinner
+		// pin than the discovery inspector test contract, but it
+		// catches the same accidental nil-slice path at the boundary.
+		empty := AggArgs{}
+		_, awsArgs := aggArgsToAWS(empty)
+		_, gcpArgs := aggArgsToGCP(empty)
+		require.NotNil(t, awsArgs.TagSelectors, "AWS TagSelectors must be empty slice, not nil")
+		require.NotNil(t, gcpArgs.TagSelectors, "GCP TagSelectors must be empty slice, not nil")
+		assert.Empty(t, awsArgs.TagSelectors)
+		assert.Empty(t, gcpArgs.TagSelectors)
+	})
 }

--- a/cmd/insideout-import/imported_unsupported.go
+++ b/cmd/insideout-import/imported_unsupported.go
@@ -64,14 +64,10 @@ type UnsupportedResource struct {
 	Tags map[string]string `json:"tags,omitempty"`
 
 	// Group is the high-level UI category ("Events", "Data Storage",
-	// "Network Security", ...) the wizard groups picker rows under. This
-	// PR (#296) leaves Group empty intentionally — the Category map that
-	// translates Type → Group lands in the parallel #297 (Bundle 2 / PR 3)
-	// PR, which iterates this slice and stamps Group post-emit. Until
-	// then the picker uses an "Other" fallback bucket.
-	//
-	// TODO(#297): populate Group from the imported.Category map once it
-	// lands; this PR ships the field on the wire so #297 is a pure
-	// composer change without an unsupported.json schema bump.
+	// "Network Security", ...) the wizard groups picker rows under. The
+	// per-cloud unsupported emitters stamp this from imported.Category
+	// at construction (awsdiscover/unsupported.go and
+	// gcpdiscover/unsupported.go). The picker falls back to "Other" when
+	// Category returns the empty string for an unknown type.
 	Group string `json:"group,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Collapse `discoveryAggregator.DiscoverTypes`'s 7-arg positional signature into a single `AggArgs` struct so future fields (per-stage timeout #311, budget knobs, etc.) are additive without touching three signatures + every test fake.
- Extract `aggArgsToAWS` / `aggArgsToGCP` translation helpers from the adapter bodies. Pure functions; the boundary translation is now unit-testable without standing up a real `*AWSDiscoverer` / `*GCPDiscoverer`.
- Collapse `fakeAggregator`'s six per-field capture slots (`gotProject`, `gotRegions`, `gotSelectors`, `gotAccount`, `gotTypes`, `gotEmitter`) into a single `gotArgs AggArgs`; rewire every assertion in `discover_test.go` to read `agg.gotArgs.<Field>`. `gotRegion()` (singular helper) is preserved for back-compat with pre-#291 single-region assertions.
- New `TestAggArgs_RoundTripsThroughAdapters` pins field-by-field translation on both AWS and GCP paths, plus a non-nil empty-slice pin on `TagSelectors` (catches the same accidental nil-slice regression class as #255 at the boundary).

## Closes

Closes #310

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/insideout-import/... ./pkg/composer/... ./pkg/insideout-import/... -count=1 -race` (2046 tests pass)
- [x] `go vet ./...`
- [x] `gofmt -l cmd/ pkg/` (clean)
- [x] `bash tests/lint-project-tag.sh`
- [x] `bash tests/lint-project-label.sh`
- [x] `bash tests/lint-sensitive-for-each.sh`
- [x] `bash tests/lint-foreach-unknown-keys.sh`
- [x] `bash tests/lint-no-root-only-blocks.sh`
- [x] `bash tests/lint-shared-no-cloud-providers.sh`
- [x] `bash tests/lint-labelless-name-prefix.sh`
- [x] `bash tests/lint-gcp-project-pin.sh`
- [x] Self-review: every changed test asserts what its name claims; no orphaned `gotProject`/`gotRegions`/`gotSelectors`/`gotAccount`/`gotTypes`/`gotEmitter` references remain anywhere in the package.
- [ ] CI green

## Notes

- **Drive-by:** dropped the stale `TODO(#297)` on `imported_unsupported.go`'s `Group` field. That issue already shipped — `Group` is populated via `imported.Category(tfType)` at `awsdiscover/unsupported.go:324` and `gcpdiscover/unsupported.go:155`. Comment now describes the actual wiring + the "Other" fallback.
- **Future-additive shape:** the next PRs in Bundle 3 (per-stage timeout #311 etc.) add fields onto `AggArgs` without re-touching the interface or the per-cloud `DiscoverArgs` structs — adapters absorb the translation in one spot.
- **Adapter testability:** rather than refactor `awsAggAdapter` / `gcpAggAdapter` to take an interface seam over the concrete `*Discoverer` (which would have rippled through every production call site), I extracted the AggArgs → per-cloud `DiscoverArgs` translation as `aggArgsToAWS` / `aggArgsToGCP` and tested those directly. The adapters now read as a 2-line passthrough; the boundary mapping is the only logic worth pinning, and that's where the new test lives.