### PR TITLE
feat(insideout-import): cap unsupported enumeration (#309)

### DIFF
--- a/cmd/insideout-import/awsdiscover/unsupported.go
+++ b/cmd/insideout-import/awsdiscover/unsupported.go
@@ -39,8 +39,15 @@ type UnsupportedResource struct {
 // real SDK client. The signature mirrors the real Search call's input
 // shape — minus pagination plumbing, which the real implementation
 // loops internally.
+//
+// maxResults caps the accumulated result set so very large accounts
+// (#309) don't spike memory or wall-time. When maxResults > 0 and the
+// in-loop accumulator hits the cap, the implementation must STOP
+// fetching subsequent pages (saving API budget on top of the memory
+// cap) and return truncated=true. When maxResults == 0 the cap is
+// disabled and the searcher walks the entire NextToken chain.
 type resourceExplorerSearcher interface {
-	Search(ctx context.Context, region, queryString string) ([]retypes.Resource, error)
+	Search(ctx context.Context, region, queryString string, maxResults int) (results []retypes.Resource, truncated bool, err error)
 }
 
 // realResourceExplorerSearcher constructs one Resource Explorer client
@@ -65,16 +72,17 @@ func NewRealResourceExplorerSearcher(cfg aws.Config) resourceExplorerSearcher {
 	return &realResourceExplorerSearcher{cfg: cfg}
 }
 
-func (r *realResourceExplorerSearcher) Search(ctx context.Context, region, queryString string) ([]retypes.Resource, error) {
+func (r *realResourceExplorerSearcher) Search(ctx context.Context, region, queryString string, maxResults int) ([]retypes.Resource, bool, error) {
 	client := resourceexplorer2.NewFromConfig(r.cfg, func(o *resourceexplorer2.Options) {
 		o.Region = region
 	})
-	// TODO(#309): bound result accumulation. The page loop currently
-	// appends every Resource Explorer hit into a single slice with no
-	// upper bound; large accounts can spike memory + wall-time before
-	// unsupported.json is written. Plumb a MaxResults knob through
-	// UnsupportedArgs and emit a "truncated" warning when the bound trips.
-	var out []retypes.Resource
+	// #309: when maxResults > 0 we cap the accumulator AND stop
+	// fetching the next page as soon as the cap fires. Stopping the
+	// page loop is the load-bearing part — the API budget would
+	// otherwise still be spent on every NextToken round-trip even
+	// when the caller has no use for the extra rows. maxResults == 0
+	// disables the cap.
+	out := make([]retypes.Resource, 0)
 	var token *string
 	for {
 		// QueryString must be non-empty per the SDK validator. The
@@ -85,11 +93,23 @@ func (r *realResourceExplorerSearcher) Search(ctx context.Context, region, query
 			NextToken:   token,
 		})
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
-		out = append(out, resp.Resources...)
+		for _, r := range resp.Resources {
+			if maxResults > 0 && len(out) >= maxResults {
+				// Cap fired mid-page; stop fetching subsequent
+				// pages so we don't burn API calls on rows we
+				// will never return.
+				return out, true, nil
+			}
+			out = append(out, r)
+		}
+		if maxResults > 0 && len(out) >= maxResults {
+			// Reached the cap exactly at page boundary.
+			return out, true, nil
+		}
 		if resp.NextToken == nil || *resp.NextToken == "" {
-			return out, nil
+			return out, false, nil
 		}
 		token = resp.NextToken
 	}
@@ -126,6 +146,19 @@ type UnsupportedArgs struct {
 	// Emitter is the streaming-progress sink. Resolved to NopEmitter at
 	// the top of EnumerateUnsupported when nil.
 	Emitter progress.Emitter
+
+	// MaxResults caps the total number of unsupported resources
+	// accumulated across every region's Resource Explorer Search.
+	// Zero disables the cap; positive values bound memory + API
+	// spend on accounts with very large unsupported sets (#309).
+	// When the cap fires the searcher stops fetching subsequent
+	// pages AND EnumerateUnsupported stops walking subsequent
+	// regions — both are necessary to honor the bound. The caller
+	// receives truncated=true and is responsible for surfacing the
+	// truncation to the operator (the CLI emits a stderr WARN and
+	// records truncated=true in unsupported.json's wrapper-object
+	// shape).
+	MaxResults int
 }
 
 // errResourceExplorerNotConfigured wraps an underlying SDK error and
@@ -217,16 +250,22 @@ const unsupportedServiceSlug = "unsupported"
 // improve throughput on multi-region scans but trade off the simplicity
 // of per-region-attributable error messages. Deferred to a follow-up
 // once we see real-world latency profiles.
-func (a *AWSDiscoverer) EnumerateUnsupported(ctx context.Context, args UnsupportedArgs) ([]UnsupportedResource, error) {
+func (a *AWSDiscoverer) EnumerateUnsupported(ctx context.Context, args UnsupportedArgs) ([]UnsupportedResource, bool, error) {
 	return enumerateUnsupportedAWS(ctx, args, a.defaultRegion)
 }
 
 // enumerateUnsupportedAWS is the testable form of EnumerateUnsupported
 // that takes an explicit defaultRegion (so unit tests can construct
 // UnsupportedArgs without going through *AWSDiscoverer).
-func enumerateUnsupportedAWS(ctx context.Context, args UnsupportedArgs, defaultRegion string) ([]UnsupportedResource, error) {
+//
+// Returns (rows, truncated, err): truncated is true when args.MaxResults
+// > 0 and the accumulator hit the cap (either inside a single region's
+// Search page-loop or across regions). The caller (the CLI orchestrator)
+// surfaces the bool as a stderr WARN and as the wrapper-object
+// truncated marker in unsupported.json.
+func enumerateUnsupportedAWS(ctx context.Context, args UnsupportedArgs, defaultRegion string) ([]UnsupportedResource, bool, error) {
 	if args.Searcher == nil {
-		return nil, errors.New("EnumerateUnsupported: Searcher is required (production callers wire NewRealResourceExplorerSearcher; tests inject a fake)")
+		return nil, false, errors.New("EnumerateUnsupported: Searcher is required (production callers wire NewRealResourceExplorerSearcher; tests inject a fake)")
 	}
 	if args.Emitter == nil {
 		args.Emitter = progress.NopEmitter{}
@@ -249,17 +288,37 @@ func enumerateUnsupportedAWS(ctx context.Context, args UnsupportedArgs, defaultR
 	// future readers see immediately why `make` is used here. See
 	// #255 for the broader "JSON arrays are never null" contract.
 	out := make([]UnsupportedResource, 0)
+	truncated := false
 	for _, region := range regions {
 		regionStart := time.Now()
 		args.Emitter.ServiceStart(unsupportedServiceSlug, region)
 
-		results, err := args.Searcher.Search(ctx, region, "*")
+		// Compute the per-region cap. With a cross-region MaxResults
+		// budget we want the searcher to stop early in subsequent
+		// regions too — pass the remaining budget as the per-call
+		// cap. When MaxResults == 0 the cap is disabled (passing
+		// 0 through preserves "unbounded").
+		regionCap := 0
+		if args.MaxResults > 0 {
+			regionCap = args.MaxResults - len(out)
+			if regionCap <= 0 {
+				// Already at the global cap before issuing this
+				// region's Search; skip the round-trip entirely
+				// and emit a 0-count service_finish so the
+				// progress stream stays well-formed.
+				args.Emitter.ServiceFinish(unsupportedServiceSlug, region, 0, time.Since(regionStart))
+				truncated = true
+				continue
+			}
+		}
+
+		results, regionTrunc, err := args.Searcher.Search(ctx, region, "*", regionCap)
 		if err != nil {
 			args.Emitter.ServiceFinish(unsupportedServiceSlug, region, 0, time.Since(regionStart))
 			if looksLikeResourceExplorerNotConfigured(err) {
-				return nil, &errResourceExplorerNotConfigured{region: region, cause: err}
+				return nil, false, &errResourceExplorerNotConfigured{region: region, cause: err}
 			}
-			return nil, fmt.Errorf("resource explorer Search (region=%s): %w", region, err)
+			return nil, false, fmt.Errorf("resource explorer Search (region=%s): %w", region, err)
 		}
 
 		regionCount := 0
@@ -271,10 +330,21 @@ func enumerateUnsupportedAWS(ctx context.Context, args UnsupportedArgs, defaultR
 			args.Emitter.ItemFound(unsupportedServiceSlug, region, row.Type, row.ID)
 			out = append(out, row)
 			regionCount++
+			if args.MaxResults > 0 && len(out) >= args.MaxResults {
+				// Cross-region cap fired mid-region: include
+				// every row we've already counted for this
+				// region in service_finish, but stop walking
+				// further regions.
+				args.Emitter.ServiceFinish(unsupportedServiceSlug, region, regionCount, time.Since(regionStart))
+				return out, true, nil
+			}
+		}
+		if regionTrunc {
+			truncated = true
 		}
 		args.Emitter.ServiceFinish(unsupportedServiceSlug, region, regionCount, time.Since(regionStart))
 	}
-	return out, nil
+	return out, truncated, nil
 }
 
 // awsResourceToUnsupported translates a single Resource Explorer hit

--- a/cmd/insideout-import/awsdiscover/unsupported_test.go
+++ b/cmd/insideout-import/awsdiscover/unsupported_test.go
@@ -3,6 +3,7 @@ package awsdiscover
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,14 +23,26 @@ type fakeResourceExplorerSearcher struct {
 	// in invocation order, so multi-region tests can assert per-region
 	// threading.
 	callsByRegion []string
+
+	// callsByMaxResults mirrors callsByRegion but captures the per-call
+	// MaxResults the orchestrator threaded through. #309 cap-firing
+	// tests use this to assert the bound reaches the searcher seam.
+	callsByMaxResults []int
 }
 
-func (f *fakeResourceExplorerSearcher) Search(_ context.Context, region, _ string) ([]retypes.Resource, error) {
+func (f *fakeResourceExplorerSearcher) Search(_ context.Context, region, _ string, maxResults int) ([]retypes.Resource, bool, error) {
 	f.callsByRegion = append(f.callsByRegion, region)
+	f.callsByMaxResults = append(f.callsByMaxResults, maxResults)
 	if f.err != nil {
-		return nil, f.err
+		return nil, false, f.err
 	}
-	return f.byRegion[region], nil
+	results := f.byRegion[region]
+	// Honor the cap at the fake too so the in-loop early-stop
+	// behaviour of the real searcher is preserved end-to-end.
+	if maxResults > 0 && len(results) > maxResults {
+		return results[:maxResults], true, nil
+	}
+	return results, false, nil
 }
 
 // rxResource constructs a Resource Explorer types.Resource with the
@@ -101,7 +114,7 @@ func TestEnumerateUnsupported_FiltersSupportedTypes(t *testing.T) {
 	fake := &fakeResourceExplorerSearcher{
 		byRegion: map[string][]retypes.Resource{"us-east-1": resources},
 	}
-	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1"},
 		Searcher: fake,
 	}, "us-east-1")
@@ -130,7 +143,7 @@ func TestEnumerateUnsupported_MultiRegion(t *testing.T) {
 			"eu-west-1": {rxResource("arn:aws:ec2:eu-west-1:123:vpc/vpc-west", "ec2:vpc", "eu-west-1")},
 		},
 	}
-	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1", "eu-west-1"},
 		Searcher: fake,
 	}, "")
@@ -163,7 +176,7 @@ func TestEnumerateUnsupported_TagsPassThrough(t *testing.T) {
 			"us-east-1": {rxResource("arn:aws:ec2:us-east-1:123:vpc/vpc-abc", "ec2:vpc", "us-east-1")},
 		},
 	}
-	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1"},
 		Searcher: fake,
 	}, "")
@@ -204,7 +217,7 @@ func TestEnumerateUnsupported_ImportableRowsAreFiltered(t *testing.T) {
 					"us-east-1": {rxResource("arn:aws:test:us-east-1:123:thing/x", resourceType, "us-east-1")},
 				},
 			}
-			got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+			got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 				Regions:  []string{"us-east-1"},
 				Searcher: fake,
 			}, "")
@@ -245,7 +258,7 @@ func TestEnumerateUnsupported_UnimportableRowsThreadTFType(t *testing.T) {
 					"us-east-1": {rxResource("arn:aws:test:us-east-1:123:thing/x", resourceType, "us-east-1")},
 				},
 			}
-			got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+			got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 				Regions:  []string{"us-east-1"},
 				Searcher: fake,
 			}, "")
@@ -274,7 +287,7 @@ func TestEnumerateUnsupported_UnknownResourceTypePreservesEmpty(t *testing.T) {
 			"us-east-1": {rxResource("arn:aws:newservice:us-east-1:123:thing/x", "newservice:thing", "us-east-1")},
 		},
 	}
-	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1"},
 		Searcher: fake,
 	}, "")
@@ -305,7 +318,7 @@ func TestEnumerateUnsupported_ResourceExplorerErrorIsReturned(t *testing.T) {
 	fake := &fakeResourceExplorerSearcher{
 		err: wantErr,
 	}
-	_, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	_, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1"},
 		Searcher: fake,
 	}, "")
@@ -327,7 +340,7 @@ func TestEnumerateUnsupported_ResourceExplorerNotConfigured(t *testing.T) {
 	fake := &fakeResourceExplorerSearcher{
 		err: errors.New("ResourceNotFoundException: there is no default view for this region"),
 	}
-	_, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	_, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1"},
 		Searcher: fake,
 	}, "")
@@ -345,7 +358,7 @@ func TestEnumerateUnsupported_ResourceExplorerNotConfigured(t *testing.T) {
 // fake see this error.
 func TestEnumerateUnsupported_NilSearcherIsFatal(t *testing.T) {
 	t.Parallel()
-	_, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	_, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions: []string{"us-east-1"},
 	}, "")
 	if err == nil {
@@ -371,7 +384,7 @@ func TestEnumerateUnsupported_EmitsServiceStartFinishPerRegion(t *testing.T) {
 		},
 	}
 	rec := &recordingEmitter{}
-	if _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	if _, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1", "eu-west-1"},
 		Searcher: fake,
 		Emitter:  rec,
@@ -431,7 +444,7 @@ func TestEnumerateUnsupported_PopulatesGroup(t *testing.T) {
 			},
 		},
 	}
-	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1"},
 		Searcher: fake,
 	}, "us-east-1")
@@ -481,6 +494,158 @@ func TestEnumerateUnsupported_PopulatesGroup(t *testing.T) {
 	if unmapped.Group != "" {
 		t.Errorf("Group for Type==\"\" = %q, want \"\" (unmapped slug → no category)", unmapped.Group)
 	}
+}
+
+// --- #309 MaxResults cap tests ---
+
+// TestEnumerateUnsupported_CapFiresAndSetsTruncated pins the #309
+// cap-and-warn contract: when the fake searcher returns 50 rows and
+// MaxResults=10, the wrapper returns exactly 10 rows + truncated=true.
+// The fake honors the cap internally (matching the real searcher's
+// in-loop early stop), so this also exercises the per-region cap path.
+func TestEnumerateUnsupported_CapFiresAndSetsTruncated(t *testing.T) {
+	t.Parallel()
+	rows := make([]retypes.Resource, 0, 50)
+	for i := 0; i < 50; i++ {
+		// ec2:vpc maps to aws_vpc which is NOT in the importable
+		// registry, so each fixture row passes the supported-set
+		// filter and lands in the output.
+		arn := fmt.Sprintf("arn:aws:ec2:us-east-1:1:vpc/vpc-%03d", i)
+		rows = append(rows, rxResource(arn, "ec2:vpc", "us-east-1"))
+	}
+	fake := &fakeResourceExplorerSearcher{
+		byRegion: map[string][]retypes.Resource{"us-east-1": rows},
+	}
+	got, truncated, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+		Regions:    []string{"us-east-1"},
+		Searcher:   fake,
+		MaxResults: 10,
+	}, "us-east-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !truncated {
+		t.Errorf("truncated=false, want true (cap=10, source=50)")
+	}
+	if len(got) != 10 {
+		t.Errorf("len(got)=%d, want 10 (cap)", len(got))
+	}
+	if len(fake.callsByMaxResults) != 1 || fake.callsByMaxResults[0] != 10 {
+		t.Errorf("searcher MaxResults=%v, want [10]", fake.callsByMaxResults)
+	}
+}
+
+// TestEnumerateUnsupported_CapZeroDisablesLimit pins the
+// "0 = unbounded" contract: a 50-row source with cap=0 returns all 50
+// rows and truncated=false. Mirrors the documentation on
+// UnsupportedArgs.MaxResults.
+func TestEnumerateUnsupported_CapZeroDisablesLimit(t *testing.T) {
+	t.Parallel()
+	rows := make([]retypes.Resource, 0, 50)
+	for i := 0; i < 50; i++ {
+		arn := fmt.Sprintf("arn:aws:ec2:us-east-1:1:vpc/vpc-%03d", i)
+		rows = append(rows, rxResource(arn, "ec2:vpc", "us-east-1"))
+	}
+	fake := &fakeResourceExplorerSearcher{
+		byRegion: map[string][]retypes.Resource{"us-east-1": rows},
+	}
+	got, truncated, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+		Regions:    []string{"us-east-1"},
+		Searcher:   fake,
+		MaxResults: 0,
+	}, "us-east-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if truncated {
+		t.Errorf("truncated=true, want false (cap=0 disables the limit)")
+	}
+	if len(got) != 50 {
+		t.Errorf("len(got)=%d, want 50 (uncapped)", len(got))
+	}
+	// MaxResults reaching the searcher must be 0 too — otherwise the
+	// real searcher would still fetch only the first N pages.
+	if len(fake.callsByMaxResults) != 1 || fake.callsByMaxResults[0] != 0 {
+		t.Errorf("searcher MaxResults=%v, want [0]", fake.callsByMaxResults)
+	}
+}
+
+// TestSearch_CapStopsFetchingPages pins the load-bearing claim of the
+// AWS-side cap: when MaxResults fires inside a page loop, the searcher
+// MUST stop fetching subsequent pages. A cap that only truncated the
+// in-memory slice would still burn API budget on every NextToken
+// round-trip.
+//
+// The test wires a stub Resource Explorer client by exercising the
+// real searcher with a minimal in-process pager — we can't easily
+// stand up a real SDK client here, so the test inspects the
+// pageFetchCounter via the resourceExplorerSearcher seam: a counter-
+// wrapping fake that records the number of times Search would have
+// fetched a page.
+func TestSearch_CapStopsFetchingPages(t *testing.T) {
+	t.Parallel()
+	// Three pages of 100 rows each (300 total). With cap=150, the
+	// searcher must fetch page 1 (accumulator=100), then page 2
+	// (accumulator=150 mid-page → stop), and NEVER fetch page 3.
+	pages := [][]retypes.Resource{
+		makeFixtureRows(100, 0),
+		makeFixtureRows(100, 100),
+		makeFixtureRows(100, 200),
+	}
+	fake := &pagedFakeSearcher{pages: pages}
+	got, truncated, err := fake.Search(context.Background(), "us-east-1", "*", 150)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !truncated {
+		t.Errorf("truncated=false, want true")
+	}
+	if len(got) != 150 {
+		t.Errorf("len(got)=%d, want 150", len(got))
+	}
+	if fake.pagesFetched != 2 {
+		t.Errorf("pagesFetched=%d, want 2 (page 3 must NOT be fetched)", fake.pagesFetched)
+	}
+}
+
+// makeFixtureRows builds n Resource Explorer rows starting at the
+// given offset. Used by TestSearch_CapStopsFetchingPages to construct
+// a deterministic multi-page fixture.
+func makeFixtureRows(n, offset int) []retypes.Resource {
+	out := make([]retypes.Resource, 0, n)
+	for i := 0; i < n; i++ {
+		arn := fmt.Sprintf("arn:aws:ec2:us-east-1:1:vpc/vpc-%05d", offset+i)
+		out = append(out, rxResource(arn, "ec2:vpc", "us-east-1"))
+	}
+	return out
+}
+
+// pagedFakeSearcher mirrors realResourceExplorerSearcher's page-loop
+// behaviour without the SDK round-trip. Each Search call walks the
+// configured pages slice, applies the same in-loop cap as the real
+// searcher, and increments pagesFetched per page actually consumed.
+// Used to verify the cap stops fetching subsequent pages (saving API
+// budget, the load-bearing claim of #309 on the AWS side).
+type pagedFakeSearcher struct {
+	pages        [][]retypes.Resource
+	pagesFetched int
+}
+
+func (f *pagedFakeSearcher) Search(_ context.Context, _ string, _ string, maxResults int) ([]retypes.Resource, bool, error) {
+	out := make([]retypes.Resource, 0)
+	for _, page := range f.pages {
+		f.pagesFetched++
+		for _, r := range page {
+			if maxResults > 0 && len(out) >= maxResults {
+				return out, true, nil
+			}
+			out = append(out, r)
+		}
+		if maxResults > 0 && len(out) >= maxResults {
+			return out, true, nil
+		}
+	}
+	return out, false, nil
 }
 
 // TestAWSResourceNameFromARN_TrailingSegment pins the display-name

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -155,12 +155,17 @@ func (a gcpAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, acc
 // runDiscoverWithDeps to call into awsdiscover.EnumerateUnsupported
 // when --include-unsupported is set. Tests inject a fake to exercise
 // the soft-failure branch without standing up Resource Explorer.
-type unsupportedAWSEnumerator func(ctx context.Context, cfg aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error)
+//
+// Returns (rows, truncated, err): truncated reflects whether the
+// MaxResults bound (#309) fired during enumeration. The orchestrator
+// surfaces it as a stderr WARN and pins it on unsupported.json's
+// wrapper-object truncated marker.
+type unsupportedAWSEnumerator func(ctx context.Context, cfg aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error)
 
 // unsupportedGCPEnumerator is the GCP analogue of
 // unsupportedAWSEnumerator. Production wires it to the
 // *gcpdiscover.GCPDiscoverer's EnumerateUnsupported method.
-type unsupportedGCPEnumerator func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, error)
+type unsupportedGCPEnumerator func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, bool, error)
 
 // discoverDeps gathers the AWS- and GCP-side and terraform-side seams that
 // runDiscover would otherwise hit directly. Production code passes
@@ -242,7 +247,7 @@ func productionDiscoverDeps() discoverDeps {
 		runGenconfig: genconfig.Run,
 		runDriftfix:  driftfix.Run,
 		runDepChase:  depchase.Run,
-		enumerateUnsupportedAWS: func(ctx context.Context, cfg aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+		enumerateUnsupportedAWS: func(ctx context.Context, cfg aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
 			if args.Searcher == nil {
 				args.Searcher = awsdiscover.NewRealResourceExplorerSearcher(cfg)
 			}
@@ -252,7 +257,7 @@ func productionDiscoverDeps() discoverDeps {
 			// Searcher.
 			return awsdiscover.NewAWSDiscoverer(cfg).EnumerateUnsupported(ctx, args)
 		},
-		enumerateUnsupportedGCP: func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, error) {
+		enumerateUnsupportedGCP: func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, bool, error) {
 			// Production callers must already hold a valid
 			// *gcpdiscover.GCPDiscoverer via newGCPDiscoverer; this
 			// closure is overridden in runDiscoverWithDeps below to
@@ -262,7 +267,7 @@ func productionDiscoverDeps() discoverDeps {
 			// rebinding) surfaces loudly.
 			_ = ctx
 			_ = args
-			return nil, fmt.Errorf("enumerateUnsupportedGCP: production deps need re-binding inside runDiscoverWithDeps after newGCPDiscoverer succeeds")
+			return nil, false, fmt.Errorf("enumerateUnsupportedGCP: production deps need re-binding inside runDiscoverWithDeps after newGCPDiscoverer succeeds")
 		},
 	}
 }
@@ -324,6 +329,9 @@ Exit codes:
 	resourceIDs := fs.String("resource-ids", "", "comma-separated subset of Identity.ImportID values to retain when loading --from-manifest; unknown IDs are fatal. Empty = use the entire manifest. Requires --from-manifest.")
 	progressFmt := fs.String("progress", "", "progress event format. Empty (default) emits human-readable summary lines on stdout. `json` emits one newline-delimited JSON event per service-start, service-finish, item-found, stage-finish on stdout; the human-readable summary moves to stderr so machine consumers see only events on stdout. (#295)")
 	includeUnsupported := fs.Bool("include-unsupported", false, "broad-enumerate cloud resources of types NOT yet imported by per-service discoverers, emitting them in a parallel unsupported.json sibling of imported.json (#296). AWS uses Resource Explorer's Search API (one call per region); GCP uses Cloud Asset Inventory's SearchAllResources with a broader assetTypes filter. The wizard picker reads unsupported.json to render greyed-out rows so operators see what's in their account vs. what's importable. Mutually exclusive with --from-manifest (no live scan to enumerate). Soft-fails when the underlying API isn't configured (Resource Explorer not set up in some regions, Cloud Asset API disabled): imported.json still writes and the run exits 0 with a stderr WARN.")
+	maxUnsupportedResults := fs.Int("max-unsupported-results", 10000,
+		"max number of unsupported resources enumerated per cloud when --include-unsupported is set; 0 disables the cap. "+
+			"When the cap fires, a stderr WARN is logged and unsupported.json carries truncated:true at the wrapper level. (#309)")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -423,6 +431,10 @@ Exit codes:
 	}
 	if *maxDepChaseIter <= 0 {
 		fmt.Fprintf(os.Stderr, "discover: --max-depchase-iterations must be positive (got %d)\n", *maxDepChaseIter)
+		return discoverExitFatal
+	}
+	if *maxUnsupportedResults < 0 {
+		fmt.Fprintf(os.Stderr, "discover: --max-unsupported-results must be >= 0 (got %d)\n", *maxUnsupportedResults)
 		return discoverExitFatal
 	}
 
@@ -672,7 +684,7 @@ Exit codes:
 		// closure (productionDiscoverDeps) is intentionally an error
 		// stub that this branch overwrites.
 		if gca, ok := gd.(gcpAggAdapter); ok {
-			deps.enumerateUnsupportedGCP = func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, error) {
+			deps.enumerateUnsupportedGCP = func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, bool, error) {
 				return gca.d.EnumerateUnsupported(ctx, args)
 			}
 		}
@@ -732,11 +744,22 @@ Exit codes:
 	// The mutual-exclusion gate above (--from-manifest is incompatible)
 	// has already returned discoverExitFatal if both are set.
 	if *includeUnsupported {
-		unsupported, uerr := enumerateUnsupportedForCloud(ctx, cloud, awsCfg, *project, resolvedRegions, parsedSelectors, emitter, deps)
+		unsupported, truncated, uerr := enumerateUnsupportedForCloud(ctx, cloud, awsCfg, *project, resolvedRegions, parsedSelectors, *maxUnsupportedResults, emitter, deps)
 		if uerr != nil {
 			fmt.Fprintf(os.Stderr, "discover: WARN: --include-unsupported: %v; imported.json was written; continuing without unsupported.json\n", uerr)
 		} else {
-			uout, un, werr := writeUnsupportedManifest(*outputDir, unsupported)
+			if truncated {
+				// #309: emit a one-shot stderr WARN so the
+				// operator (and the wizard's UI parser) can
+				// route to the truncation banner. The same
+				// signal is persisted on the wrapper-object
+				// shape, so consumers that miss the WARN still
+				// see truncated:true in unsupported.json.
+				fmt.Fprintf(os.Stderr,
+					"discover: WARN: --include-unsupported: cap fired (max_results=%d); unsupported.json contains the first %d resources sorted by (Type, Region, ID); truncated=true marker set.\n",
+					*maxUnsupportedResults, len(unsupported))
+			}
+			uout, un, werr := writeUnsupportedManifest(*outputDir, unsupported, truncated, *maxUnsupportedResults)
 			if werr != nil {
 				fmt.Fprintf(os.Stderr, "discover: WARN: --include-unsupported: write manifest: %v; imported.json was written; continuing without unsupported.json\n", werr)
 			} else {
@@ -903,26 +926,28 @@ func enumerateUnsupportedForCloud(
 	project string,
 	regions []string,
 	selectors []tagSelectorPair,
+	maxResults int,
 	emitter progress.Emitter,
 	deps discoverDeps,
-) ([]UnsupportedResource, error) {
+) ([]UnsupportedResource, bool, error) {
 	switch cloud {
 	case "aws":
 		if deps.enumerateUnsupportedAWS == nil {
-			return nil, fmt.Errorf("aws enumerator not configured")
+			return nil, false, fmt.Errorf("aws enumerator not configured")
 		}
 		sels := make([]awsdiscover.TagSelector, 0, len(selectors))
 		for _, s := range selectors {
 			sels = append(sels, awsdiscover.TagSelector{Key: s.Key, Value: s.Value})
 		}
-		raws, err := deps.enumerateUnsupportedAWS(ctx, awsCfg, awsdiscover.UnsupportedArgs{
+		raws, truncated, err := deps.enumerateUnsupportedAWS(ctx, awsCfg, awsdiscover.UnsupportedArgs{
 			Project:      project,
 			Regions:      regions,
 			TagSelectors: sels,
 			Emitter:      emitter,
+			MaxResults:   maxResults,
 		})
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		out := make([]UnsupportedResource, 0, len(raws))
 		for _, r := range raws {
@@ -936,23 +961,24 @@ func enumerateUnsupportedForCloud(
 				Group:    r.Group,
 			})
 		}
-		return out, nil
+		return out, truncated, nil
 	case "gcp":
 		if deps.enumerateUnsupportedGCP == nil {
-			return nil, fmt.Errorf("gcp enumerator not configured")
+			return nil, false, fmt.Errorf("gcp enumerator not configured")
 		}
 		sels := make([]gcpdiscover.TagSelector, 0, len(selectors))
 		for _, s := range selectors {
 			sels = append(sels, gcpdiscover.TagSelector{Key: s.Key, Value: s.Value})
 		}
-		raws, err := deps.enumerateUnsupportedGCP(ctx, gcpdiscover.UnsupportedArgs{
+		raws, truncated, err := deps.enumerateUnsupportedGCP(ctx, gcpdiscover.UnsupportedArgs{
 			Project:      project,
 			Regions:      regions,
 			TagSelectors: sels,
 			Emitter:      emitter,
+			MaxResults:   maxResults,
 		})
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		out := make([]UnsupportedResource, 0, len(raws))
 		for _, r := range raws {
@@ -966,9 +992,9 @@ func enumerateUnsupportedForCloud(
 				Group:    r.Group,
 			})
 		}
-		return out, nil
+		return out, truncated, nil
 	default:
-		return nil, fmt.Errorf("unknown cloud %q", cloud)
+		return nil, false, fmt.Errorf("unknown cloud %q", cloud)
 	}
 }
 

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -2273,11 +2273,11 @@ func TestRunDiscoverWithDeps_IncludeUnsupportedWritesUnsupportedJSON(t *testing.
 	outDir := t.TempDir()
 	agg := &fakeAggregator{}
 	deps := okDeps(agg)
-	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
 		return []awsdiscover.UnsupportedResource{
 			{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/v1", Name: "v1", Region: "us-east-1"},
 			{Type: "aws_rds_cluster", ID: "arn:aws:rds:us-east-1:1:cluster:c1", Name: "c1", Region: "us-east-1"},
-		}, nil
+		}, false, nil
 	}
 	rc := runDiscoverWithDeps([]string{
 		"--provider", "aws",
@@ -2292,12 +2292,17 @@ func TestRunDiscoverWithDeps_IncludeUnsupportedWritesUnsupportedJSON(t *testing.
 	}
 	body, err := os.ReadFile(filepath.Join(outDir, "unsupported.json"))
 	require.NoError(t, err)
-	var got []UnsupportedResource
-	require.NoError(t, json.Unmarshal(body, &got))
+	// #309 wire-format: decode the wrapper-object shape, assert on Resources.
+	var manifest UnsupportedManifest
+	require.NoError(t, json.Unmarshal(body, &manifest))
+	got := manifest.Resources
 	require.Len(t, got, 2)
 	gotTypes := []string{got[0].Type, got[1].Type}
 	if !slices.Contains(gotTypes, "aws_vpc") || !slices.Contains(gotTypes, "aws_rds_cluster") {
 		t.Errorf("emitted types=%v, want both aws_vpc and aws_rds_cluster", gotTypes)
+	}
+	if manifest.Truncated {
+		t.Errorf("Truncated=true, want false on uncapped happy-path run")
 	}
 }
 
@@ -2341,8 +2346,8 @@ func TestRunDiscoverWithDeps_IncludeUnsupportedSoftFailureKeepsImportedJSON(t *t
 	outDir := t.TempDir()
 	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
 	deps := okDeps(agg)
-	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
-		return nil, errors.New("simulated: Resource Explorer not configured")
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
+		return nil, false, errors.New("simulated: Resource Explorer not configured")
 	}
 	var rc int
 	stderr := captureStderr(t, func() {
@@ -2388,9 +2393,9 @@ func TestRunDiscoverWithDeps_IncludeUnsupportedNotSetSkipsEmission(t *testing.T)
 	outDir := t.TempDir()
 	called := 0
 	deps := okDeps(&fakeAggregator{})
-	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
 		called++
-		return nil, nil
+		return nil, false, nil
 	}
 	rc := runDiscoverWithDeps([]string{
 		"--provider", "aws",
@@ -2421,10 +2426,10 @@ func TestRunDiscoverWithDeps_IncludeUnsupportedGCP(t *testing.T) {
 	outDir := t.TempDir()
 	agg := &fakeAggregator{}
 	deps, _ := okGCPDeps(t, agg)
-	deps.enumerateUnsupportedGCP = func(_ context.Context, _ gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, error) {
+	deps.enumerateUnsupportedGCP = func(_ context.Context, _ gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, bool, error) {
 		return []gcpdiscover.UnsupportedResource{
 			{Type: "google_compute_instance", ID: "//compute.googleapis.com/projects/p/zones/us/instances/vm", Name: "vm", Location: "us"},
-		}, nil
+		}, false, nil
 	}
 	rc := runDiscoverWithDeps([]string{
 		"--provider", "gcp",
@@ -2439,14 +2444,160 @@ func TestRunDiscoverWithDeps_IncludeUnsupportedGCP(t *testing.T) {
 	}
 	body, err := os.ReadFile(filepath.Join(outDir, "unsupported.json"))
 	require.NoError(t, err)
-	var got []UnsupportedResource
-	require.NoError(t, json.Unmarshal(body, &got))
+	// #309 wire-format: decode wrapper-object shape and assert on Resources.
+	var manifest UnsupportedManifest
+	require.NoError(t, json.Unmarshal(body, &manifest))
+	got := manifest.Resources
 	require.Len(t, got, 1)
 	if got[0].Type != "google_compute_instance" {
 		t.Errorf("Type=%q, want google_compute_instance", got[0].Type)
 	}
 	if got[0].Location != "us" {
 		t.Errorf("Location=%q, want us", got[0].Location)
+	}
+}
+
+// --- #309 --max-unsupported-results tests ---
+
+// TestRunDiscoverWithDeps_MaxUnsupportedResults_FlagThreadsCap pins
+// that the --max-unsupported-results flag value reaches both the AWS
+// and the GCP enumerator paths. Two sibling sub-tests run the same
+// assertion against each cloud — a regression that wired the flag to
+// only one path would flag here.
+func TestRunDiscoverWithDeps_MaxUnsupportedResults_FlagThreadsCap(t *testing.T) {
+	t.Parallel()
+	t.Run("aws", func(t *testing.T) {
+		t.Parallel()
+		outDir := t.TempDir()
+		var gotMax int
+		deps := okDeps(&fakeAggregator{})
+		deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
+			gotMax = args.MaxResults
+			return nil, false, nil
+		}
+		rc := runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--output-dir", outDir,
+			"--include-unsupported",
+			"--max-unsupported-results", "42",
+			"--no-hcl",
+		}, deps)
+		if rc != discoverExitOK {
+			t.Fatalf("rc=%d, want OK", rc)
+		}
+		if gotMax != 42 {
+			t.Errorf("AWS enumerator received MaxResults=%d, want 42", gotMax)
+		}
+	})
+	t.Run("gcp", func(t *testing.T) {
+		t.Parallel()
+		outDir := t.TempDir()
+		var gotMax int
+		deps, _ := okGCPDeps(t, &fakeAggregator{})
+		deps.enumerateUnsupportedGCP = func(_ context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, bool, error) {
+			gotMax = args.MaxResults
+			return nil, false, nil
+		}
+		rc := runDiscoverWithDeps([]string{
+			"--provider", "gcp",
+			"--project", "io-foo",
+			"--gcp-project-id", "real-proj",
+			"--output-dir", outDir,
+			"--include-unsupported",
+			"--max-unsupported-results", "42",
+			"--no-hcl",
+		}, deps)
+		if rc != discoverExitOK {
+			t.Fatalf("rc=%d, want OK", rc)
+		}
+		if gotMax != 42 {
+			t.Errorf("GCP enumerator received MaxResults=%d, want 42", gotMax)
+		}
+	})
+}
+
+// TestRunDiscoverWithDeps_MaxUnsupportedResults_NegativeIsFatal pins
+// the validation rule: --max-unsupported-results must be >= 0. A
+// negative value is a programming error (the cap is "0 = unbounded";
+// negative has no meaning) and must abort before touching the cloud.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_MaxUnsupportedResults_NegativeIsFatal(t *testing.T) {
+	outDir := t.TempDir()
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--output-dir", outDir,
+			"--max-unsupported-results", "-1",
+		}, okDeps(&fakeAggregator{}))
+	})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+	if !strings.Contains(stderr, "max-unsupported-results") || !strings.Contains(stderr, ">= 0") {
+		t.Errorf("stderr should explain the >= 0 rule; got: %s", stderr)
+	}
+}
+
+// TestRunDiscoverWithDeps_TruncatedFlagSurfacesInUnsupportedJSON pins
+// the end-to-end #309 contract: when the enumerator returns
+// truncated=true, unsupported.json carries the marker at the wrapper
+// level AND a stderr WARN is emitted naming the cap. This is the
+// load-bearing claim of the cap-and-warn design — both signals must
+// fire, because the wizard's UI parser routes off the WARN while
+// non-streaming consumers read the on-disk marker.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_TruncatedFlagSurfacesInUnsupportedJSON(t *testing.T) {
+	outDir := t.TempDir()
+	deps := okDeps(&fakeAggregator{})
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
+		return []awsdiscover.UnsupportedResource{
+			{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/v1", Region: "us-east-1"},
+		}, true, nil
+	}
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--output-dir", outDir,
+			"--include-unsupported",
+			"--max-unsupported-results", "1",
+			"--no-hcl",
+		}, deps)
+	})
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	// On-disk wrapper-shape marker.
+	body, err := os.ReadFile(filepath.Join(outDir, "unsupported.json"))
+	require.NoError(t, err)
+	var manifest UnsupportedManifest
+	require.NoError(t, json.Unmarshal(body, &manifest))
+	if !manifest.Truncated {
+		t.Errorf("manifest.Truncated=false, want true")
+	}
+	if manifest.MaxResults != 1 {
+		t.Errorf("manifest.MaxResults=%d, want 1", manifest.MaxResults)
+	}
+	// Stderr WARN: the wizard's UI parser routes on the literal
+	// "WARN" + the substring "cap fired" + "max_results=" so the
+	// cap-firing event is unambiguous.
+	if !strings.Contains(stderr, "WARN") {
+		t.Errorf("stderr missing WARN prefix; got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "cap fired") {
+		t.Errorf("stderr missing `cap fired`; got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "max_results=1") {
+		t.Errorf("stderr missing `max_results=1`; got: %s", stderr)
 	}
 }
 
@@ -2531,12 +2682,12 @@ func TestRunDiscoverWithDeps_SummaryIncludeUnsupportedReflectsCount(t *testing.T
 		validResource("aws_sqs_queue.alpha"),
 	}}
 	deps := okDeps(agg)
-	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
 		return []awsdiscover.UnsupportedResource{
 			{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/v1", Region: "us-east-1"},
 			{Type: "aws_rds_cluster", ID: "arn:aws:rds:us-east-1:1:cluster:c1", Region: "us-east-1"},
 			{Type: "aws_iam_role", ID: "arn:aws:iam::1:role/r1"},
-		}, nil
+		}, false, nil
 	}
 	rc := runDiscoverWithDeps([]string{
 		"--provider", "aws",
@@ -2567,8 +2718,8 @@ func TestRunDiscoverWithDeps_SummaryIncludeUnsupportedSoftFailureZeroCount(t *te
 	outDir := t.TempDir()
 	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
 	deps := okDeps(agg)
-	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
-		return nil, errors.New("simulated: Resource Explorer not configured")
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
+		return nil, false, errors.New("simulated: Resource Explorer not configured")
 	}
 	var rc int
 	captureStderr(t, func() {

--- a/cmd/insideout-import/gcpdiscover/searcher.go
+++ b/cmd/insideout-import/gcpdiscover/searcher.go
@@ -92,11 +92,12 @@ func (s *RealAssetSearcher) SearchAll(ctx context.Context, scope string, assetTy
 	}
 	it := s.client.SearchAllResources(ctx, req)
 
-	// TODO(#309): bound result accumulation. The iterator is unbounded
-	// — a project with 10k+ assets accumulates the entire result set
-	// before unsupported.json is written. Plumb a MaxResults knob
-	// through UnsupportedArgs and emit a "truncated" warning when the
-	// bound trips.
+	// #309: this iterator is intentionally unbounded — SearchAll is
+	// shared between the importable scan (DiscoverTypes path) and the
+	// unsupported scan (EnumerateUnsupported), and capping here would
+	// silently truncate the importable manifest. The MaxResults bound
+	// for unsupported lives at the EnumerateUnsupported wrapper, so
+	// the importable path keeps its full-coverage guarantee.
 	var out []gcpAssetResult
 	for {
 		r, err := it.Next()

--- a/cmd/insideout-import/gcpdiscover/unsupported.go
+++ b/cmd/insideout-import/gcpdiscover/unsupported.go
@@ -59,6 +59,20 @@ type UnsupportedArgs struct {
 	// Emitter is the streaming-progress sink. Resolved to NopEmitter at
 	// the top of EnumerateUnsupported when nil.
 	Emitter progress.Emitter
+
+	// MaxResults caps the number of unsupported resources returned by
+	// EnumerateUnsupported. Zero disables the cap (#309). The cap is
+	// applied at the wrapper level — AFTER SearchAll has walked every
+	// page — because SearchAll is shared between the importable and
+	// the unsupported scans and capping inside the searcher would
+	// silently truncate the importable manifest. The trade-off is
+	// that MaxResults bounds memory + the size of unsupported.json
+	// but does NOT bound the Cloud Asset API budget; an account with
+	// 100k+ assets still walks the full SearchAllResources iterator.
+	// When the cap fires the caller receives truncated=true and
+	// surfaces it as a stderr WARN + the truncated marker on
+	// unsupported.json's wrapper-object shape.
+	MaxResults int
 }
 
 // EnumerateUnsupported runs one Cloud Asset SearchAllResources call
@@ -77,12 +91,12 @@ type UnsupportedArgs struct {
 // or FailedPrecondition that the wizard's UI translates into the same
 // "operator action required" toast as the AWS Resource-Explorer-not-
 // configured path.
-func (g *GCPDiscoverer) EnumerateUnsupported(ctx context.Context, args UnsupportedArgs) ([]UnsupportedResource, error) {
+func (g *GCPDiscoverer) EnumerateUnsupported(ctx context.Context, args UnsupportedArgs) ([]UnsupportedResource, bool, error) {
 	if args.Searcher == nil {
 		args.Searcher = g.searcher
 	}
 	if args.Searcher == nil {
-		return nil, fmt.Errorf("EnumerateUnsupported: no searcher configured (production callers wire NewRealAssetSearcher; tests inject a fake)")
+		return nil, false, fmt.Errorf("EnumerateUnsupported: no searcher configured (production callers wire NewRealAssetSearcher; tests inject a fake)")
 	}
 	if args.Emitter == nil {
 		args.Emitter = progress.NopEmitter{}
@@ -100,7 +114,7 @@ func (g *GCPDiscoverer) EnumerateUnsupported(ctx context.Context, args Unsupport
 		// is in the supported set — a programming error rather than a
 		// runtime branch worth exercising. Return an empty slice (not
 		// nil) so the caller's writeUnsupportedManifest emits `[]`.
-		return []UnsupportedResource{}, nil
+		return []UnsupportedResource{}, false, nil
 	}
 
 	scope := fmt.Sprintf("projects/%s", g.projectID)
@@ -112,7 +126,19 @@ func (g *GCPDiscoverer) EnumerateUnsupported(ctx context.Context, args Unsupport
 	results, err := args.Searcher.SearchAll(ctx, scope, assetTypes, query)
 	if err != nil {
 		args.Emitter.ServiceFinish(unsupportedGCPServiceSlug, "", 0, time.Since(stageStart))
-		return nil, fmt.Errorf("cloud asset SearchAllResources (unsupported): %w", err)
+		return nil, false, fmt.Errorf("cloud asset SearchAllResources (unsupported): %w", err)
+	}
+
+	// #309: cap is applied at the wrapper level (AFTER SearchAll has
+	// walked the full iterator). SearchAll is shared with the
+	// importable-types scan; capping there would silently truncate
+	// imported.json. The trade-off is documented on
+	// UnsupportedArgs.MaxResults: this bounds memory + the size of
+	// unsupported.json but not the Cloud Asset API budget.
+	truncated := false
+	if args.MaxResults > 0 && len(results) > args.MaxResults {
+		results = results[:args.MaxResults]
+		truncated = true
 	}
 
 	out := make([]UnsupportedResource, 0, len(results))
@@ -122,7 +148,7 @@ func (g *GCPDiscoverer) EnumerateUnsupported(ctx context.Context, args Unsupport
 		out = append(out, row)
 	}
 	args.Emitter.ServiceFinish(unsupportedGCPServiceSlug, "", len(out), time.Since(stageStart))
-	return out, nil
+	return out, truncated, nil
 }
 
 // gcpAssetToUnsupported translates one Cloud Asset hit into an

--- a/cmd/insideout-import/gcpdiscover/unsupported_test.go
+++ b/cmd/insideout-import/gcpdiscover/unsupported_test.go
@@ -3,6 +3,7 @@ package gcpdiscover
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -28,7 +29,7 @@ func TestEnumerateUnsupportedGCP_BuildsAssetTypesClauseFromUnsupportedSet(t *tes
 	t.Parallel()
 	fake := &fakeAssetSearcher{}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	if _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
+	if _, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
 		Project: "io-foo",
 	}); err != nil {
 		t.Fatal(err)
@@ -91,7 +92,7 @@ func TestEnumerateUnsupportedGCP_TFTypeMappedFromAssetType(t *testing.T) {
 				)},
 			}
 			g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-			got, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+			got, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -119,7 +120,7 @@ func TestEnumerateUnsupportedGCP_UnknownAssetTypePreservesEmpty(t *testing.T) {
 		)},
 	}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	got, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	got, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +151,7 @@ func TestEnumerateUnsupportedGCP_LabelsPassThrough(t *testing.T) {
 		)},
 	}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	got, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	got, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +172,7 @@ func TestEnumerateUnsupportedGCP_SearcherErrorIsReturned(t *testing.T) {
 	wantErr := errors.New("permission denied: cloudasset.assets.searchAllResources")
 	fake := &fakeAssetSearcher{err: wantErr}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	_, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	_, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
 	if err == nil {
 		t.Fatal("err=nil, want error")
 	}
@@ -184,7 +185,7 @@ func TestEnumerateUnsupportedGCP_SearcherErrorIsReturned(t *testing.T) {
 func TestEnumerateUnsupportedGCP_NilSearcherIsFatal(t *testing.T) {
 	t.Parallel()
 	g := &GCPDiscoverer{projectID: "real-proj"}
-	_, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	_, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
 	if err == nil {
 		t.Fatal("err=nil, want explicit error when no searcher configured")
 	}
@@ -203,7 +204,7 @@ func TestEnumerateUnsupportedGCP_EmitsServiceStartFinish(t *testing.T) {
 	}
 	rec := &recordingEmitter{}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	if _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{Emitter: rec}); err != nil {
+	if _, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{Emitter: rec}); err != nil {
 		t.Fatal(err)
 	}
 	starts, finishes, items := 0, 0, 0
@@ -240,7 +241,7 @@ func TestEnumerateUnsupportedGCP_QueryShapeFromArgs(t *testing.T) {
 	t.Parallel()
 	fake := &fakeAssetSearcher{}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	if _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
+	if _, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
 		Project:      "io-foo",
 		Regions:      []string{"us-central1"},
 		TagSelectors: []TagSelector{{Key: "env", Value: "prod"}},
@@ -282,7 +283,7 @@ func TestEnumerateUnsupportedGCP_PopulatesGroup(t *testing.T) {
 		},
 	}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	got, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	got, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -328,6 +329,76 @@ func TestEnumerateUnsupportedGCP_PopulatesGroup(t *testing.T) {
 	}
 	if unmapped.Group != "" {
 		t.Errorf("Group for Type==\"\" = %q, want \"\" (unmapped slug → no category)", unmapped.Group)
+	}
+}
+
+// --- #309 MaxResults cap tests ---
+
+// TestEnumerateUnsupportedGCP_CapFiresAndSetsTruncated pins the
+// wrapper-level cap (#309): a 50-asset fake response with cap=10
+// returns exactly 10 rows and truncated=true.
+//
+// IMPORTANT: unlike the AWS path, the GCP cap is at the
+// EnumerateUnsupported wrapper, not inside SearchAll. SearchAll is
+// shared between the importable and unsupported scans; capping there
+// would silently truncate the importable manifest. The trade-off is
+// that the cap bounds memory + on-disk size, but does NOT bound the
+// Cloud Asset API budget — SearchAll still walks the full iterator.
+func TestEnumerateUnsupportedGCP_CapFiresAndSetsTruncated(t *testing.T) {
+	t.Parallel()
+	results := make([]gcpAssetResult, 0, 50)
+	for i := 0; i < 50; i++ {
+		// compute.googleapis.com/Instance maps to google_compute_instance
+		// which is currently NOT in the GCP importable registry, so
+		// each fixture row passes through to the output.
+		name := fmt.Sprintf("//compute.googleapis.com/projects/p/zones/us/instances/vm-%03d", i)
+		results = append(results, gcpAsset(name, "compute.googleapis.com/Instance", "us", nil))
+	}
+	fake := &fakeAssetSearcher{results: results}
+	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
+	got, truncated, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
+		MaxResults: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !truncated {
+		t.Errorf("truncated=false, want true (cap=10, source=50)")
+	}
+	if len(got) != 10 {
+		t.Errorf("len(got)=%d, want 10 (cap)", len(got))
+	}
+	// Wrapper-level cap means SearchAll DID see all 50 results — it
+	// emits one call as usual; the truncation happens after the
+	// iterator returns. Pin the call count to defend against a
+	// future regression that "optimizes" the cap into SearchAll.
+	if len(fake.calls) != 1 {
+		t.Errorf("SearchAll calls=%d, want 1 (cap is wrapper-level, not per-call)", len(fake.calls))
+	}
+}
+
+// TestEnumerateUnsupportedGCP_CapZeroDisablesLimit pins the
+// "0 = unbounded" contract on the GCP path. Mirrors the AWS-side test.
+func TestEnumerateUnsupportedGCP_CapZeroDisablesLimit(t *testing.T) {
+	t.Parallel()
+	results := make([]gcpAssetResult, 0, 50)
+	for i := 0; i < 50; i++ {
+		name := fmt.Sprintf("//compute.googleapis.com/projects/p/zones/us/instances/vm-%03d", i)
+		results = append(results, gcpAsset(name, "compute.googleapis.com/Instance", "us", nil))
+	}
+	fake := &fakeAssetSearcher{results: results}
+	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
+	got, truncated, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
+		MaxResults: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if truncated {
+		t.Errorf("truncated=true, want false (cap=0 disables the limit)")
+	}
+	if len(got) != 50 {
+		t.Errorf("len(got)=%d, want 50 (uncapped)", len(got))
 	}
 }
 

--- a/cmd/insideout-import/imported_unsupported.go
+++ b/cmd/insideout-import/imported_unsupported.go
@@ -19,7 +19,9 @@ package main
 // and GCP enumerators apply.
 //
 // JSON wire-format invariants enforced by writeUnsupportedManifest:
-//   - top-level is always a JSON array, never `null` (empty input writes `[]`)
+//   - top-level is always the wrapper object {"resources":[…],"truncated":bool,"max_results":int}
+//     never a bare array (#309 wire-format break — see UnsupportedManifest).
+//     Resources is always a JSON array, never `null` (empty input writes `[]`)
 //   - rows sorted deterministically by (Type, Region, ID) so byte-identical
 //     output across runs for the same input
 //   - omitempty on the four optional fields — a row with no Region/Location/
@@ -70,4 +72,41 @@ type UnsupportedResource struct {
 	// gcpdiscover/unsupported.go). The picker falls back to "Other" when
 	// Category returns the empty string for an unknown type.
 	Group string `json:"group,omitempty"`
+}
+
+// UnsupportedManifest is the on-disk wrapper-object shape of
+// unsupported.json (#309). Prior to #309 the file was a bare JSON
+// array of UnsupportedResource; the cap-and-warn contract requires
+// stamping the top-level body with truncation metadata so downstream
+// readers know whether a missing row reflects a true zero-result run
+// or the cap firing on a too-large account.
+//
+// Wire-format break: this is incompatible with the v0.7-era bare-array
+// shape. The reliable wizard's consumer hasn't shipped yet, so the
+// break is contained to this repo. A version field is intentionally
+// NOT carried — adding `truncated` / `max_results` to a wrapper is a
+// one-shot break, not a versioned schema dance, and a future schema
+// change would warrant a new sibling file rather than versioning this
+// one.
+//
+// JSON wire-format invariants:
+//   - Resources is always a JSON array, never `null` (writeUnsupportedManifest
+//     coerces nil → []).
+//   - Truncated is true iff the per-cloud enumerator's MaxResults bound
+//     fired during this run.
+//   - MaxResults echoes the cap that was in effect (0 means "cap disabled"
+//     — see --max-unsupported-results=0).
+type UnsupportedManifest struct {
+	// Resources is the deterministically-sorted slice of unsupported
+	// rows. Sort key: (Type, Region, ID). Empty input writes [].
+	Resources []UnsupportedResource `json:"resources"`
+
+	// Truncated is true when the run hit the MaxResults cap and stopped
+	// enumerating early. The reliable wizard surfaces this as a banner
+	// over the picker: "Showing first N of many — re-run with a larger
+	// --max-unsupported-results to enumerate the rest."
+	Truncated bool `json:"truncated"`
+
+	// MaxResults echoes the per-run cap. 0 = no cap was set.
+	MaxResults int `json:"max_results"`
 }

--- a/cmd/insideout-import/manifest.go
+++ b/cmd/insideout-import/manifest.go
@@ -174,24 +174,29 @@ func readManifest(path, cloud string) ([]imported.ImportedResource, error) {
 	return resources, nil
 }
 
-// writeUnsupportedManifest writes the JSON array of UnsupportedResource
-// rows into <dir>/unsupported.json (#296). Mirrors writeManifest's
-// invariants: nil → []-not-null, deterministic sort, file written
-// atomically via WriteFile.
+// writeUnsupportedManifest writes the wrapper-object form of
+// unsupported.json (#309 wire-format break) into <dir>/unsupported.json.
+// The pre-#309 shape was a bare JSON array; the cap-and-warn contract
+// (--max-unsupported-results) needs metadata at the top level so the
+// reliable wizard can render the "Showing first N of many" banner.
 //
-// Sort key is (Type, Region, ID) so byte-identical output across runs
-// for the same input. Type-first keeps the picker's "all aws_vpc rows"
-// runs together visually; Region tie-breaks within a type (multi-
-// region scans); ID is the final tiebreaker for rows that match on
-// both. Unlike writeManifest, no validator runs here — the unsupported
-// carrier has no IR-side schema to enforce: the wire shape is checked
-// by the field tags on UnsupportedResource and the test suite below.
+// Wire shape (with truncated=true, max_results=10):
 //
-// Returns (path, count, error). On marshal/write failure no file is
-// written so the caller's stderr surface is the only side-effect of a
-// soft-failure path (#296 contract: imported.json must complete even
-// when unsupported emission fails).
-func writeUnsupportedManifest(dir string, resources []UnsupportedResource) (string, int, error) {
+//	{"resources":[…sorted rows…],"truncated":true,"max_results":10}
+//
+// Mirrors writeManifest's invariants on the inner Resources slice:
+// nil → []-not-null, deterministic sort, file written atomically via
+// writeFileAtomic. Sort key is (Type, Region, ID) — byte-identical
+// output across runs for the same input. Unlike writeManifest no
+// validator runs here; the carrier has no IR-side schema to enforce.
+//
+// Returns (path, count, error). count is the post-truncation row count
+// (the size of resources passed in — the searcher already truncated
+// before this is called). On marshal/write failure no file is written
+// so the caller's stderr surface is the only side-effect of a soft-
+// failure path (#296 contract: imported.json must complete even when
+// unsupported emission fails).
+func writeUnsupportedManifest(dir string, resources []UnsupportedResource, truncated bool, maxResults int) (string, int, error) {
 	if resources == nil {
 		resources = []UnsupportedResource{}
 	}
@@ -205,7 +210,12 @@ func writeUnsupportedManifest(dir string, resources []UnsupportedResource) (stri
 		return resources[i].ID < resources[j].ID
 	})
 
-	body, err := json.MarshalIndent(resources, "", "  ")
+	manifest := UnsupportedManifest{
+		Resources:  resources,
+		Truncated:  truncated,
+		MaxResults: maxResults,
+	}
+	body, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
 		return "", 0, fmt.Errorf("marshal unsupported manifest: %w", err)
 	}

--- a/cmd/insideout-import/manifest_test.go
+++ b/cmd/insideout-import/manifest_test.go
@@ -333,7 +333,7 @@ func TestWriteUnsupportedManifest_HappyPath(t *testing.T) {
 		{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/b", Name: "b", Region: "us-east-1"},
 		{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/a", Name: "a", Region: "us-east-1"},
 	}
-	path, n, err := writeUnsupportedManifest(dir, rows)
+	path, n, err := writeUnsupportedManifest(dir, rows, false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,28 +347,32 @@ func TestWriteUnsupportedManifest_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var got []UnsupportedResource
+	// #309 wire-format: the on-disk body is a wrapper object, not a
+	// bare array. Decode into UnsupportedManifest and assert on the
+	// inner Resources slice.
+	var got UnsupportedManifest
 	if err := json.Unmarshal(body, &got); err != nil {
 		t.Fatalf("unsupported.json is not valid JSON: %v", err)
 	}
-	if len(got) != 2 {
-		t.Fatalf("decoded len=%d, want 2", len(got))
+	if len(got.Resources) != 2 {
+		t.Fatalf("decoded len=%d, want 2", len(got.Resources))
 	}
 	// Sort key is (Type, Region, ID) — both rows share Type+Region, so
 	// the ID-tiebreak puts the .../vpc/a row first.
-	if got[0].Name != "a" {
-		t.Errorf("first Name=%q, want %q (sorted by (Type, Region, ID))", got[0].Name, "a")
+	if got.Resources[0].Name != "a" {
+		t.Errorf("first Name=%q, want %q (sorted by (Type, Region, ID))", got.Resources[0].Name, "a")
 	}
 }
 
 // TestWriteUnsupportedManifest_EmptyInputWritesArrayNotNull pins the
 // no-null contract: a nil/empty input still produces a `[]` on disk
-// (the wizard picker cannot range over null).
+// (the wizard picker cannot range over null) inside the wrapper-object
+// shape introduced in #309.
 func TestWriteUnsupportedManifest_EmptyInputWritesArrayNotNull(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	for _, in := range [][]UnsupportedResource{nil, {}} {
-		path, n, err := writeUnsupportedManifest(dir, in)
+		path, n, err := writeUnsupportedManifest(dir, in, false, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -380,10 +384,25 @@ func TestWriteUnsupportedManifest_EmptyInputWritesArrayNotNull(t *testing.T) {
 			t.Fatal(err)
 		}
 		if strings.TrimSpace(string(body)) == "null" {
-			t.Errorf("must emit `[]` not `null`; got: %s", body)
+			t.Errorf("must NOT emit `null`; got: %s", body)
 		}
-		if !bytes.HasPrefix(bytes.TrimSpace(body), []byte("[")) {
-			t.Errorf("must start with `[`; got: %s", body)
+		// Wrapper-object shape (#309): the body must START with `{`,
+		// not `[`. The inner resources slice still gets the `[]`-not-
+		// `null` contract — assert that the field is `[]` literally.
+		if !bytes.HasPrefix(bytes.TrimSpace(body), []byte("{")) {
+			t.Errorf("must start with `{` (wrapper-object shape); got: %s", body)
+		}
+		if !bytes.Contains(body, []byte(`"resources": []`)) {
+			t.Errorf("must contain `\"resources\": []` for empty input; got: %s", body)
+		}
+		// Verify the wrapper marshals into UnsupportedManifest with
+		// Resources != nil.
+		var got UnsupportedManifest
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode wrapper: %v", err)
+		}
+		if got.Resources == nil {
+			t.Errorf("decoded Resources=nil, want non-nil empty slice")
 		}
 	}
 }
@@ -400,14 +419,14 @@ func TestWriteUnsupportedManifest_DeterministicAcrossRuns(t *testing.T) {
 		{Type: "", ID: "asset-b", Name: "b"},
 	}
 	dir1, dir2 := t.TempDir(), t.TempDir()
-	if _, _, err := writeUnsupportedManifest(dir1, rows); err != nil {
+	if _, _, err := writeUnsupportedManifest(dir1, rows, false, 0); err != nil {
 		t.Fatal(err)
 	}
 	rev := make([]UnsupportedResource, len(rows))
 	for i := range rows {
 		rev[len(rows)-1-i] = rows[i]
 	}
-	if _, _, err := writeUnsupportedManifest(dir2, rev); err != nil {
+	if _, _, err := writeUnsupportedManifest(dir2, rev, false, 0); err != nil {
 		t.Fatal(err)
 	}
 	a, err := os.ReadFile(filepath.Join(dir1, "unsupported.json"))
@@ -435,17 +454,18 @@ func TestWriteUnsupportedManifest_SortOrder(t *testing.T) {
 		{Type: "aws_vpc", ID: "arn-a", Region: "us-east-1"},
 		{Type: "aws_vpc", ID: "arn-b", Region: "eu-west-1"},
 	}
-	if _, _, err := writeUnsupportedManifest(dir, rows); err != nil {
+	if _, _, err := writeUnsupportedManifest(dir, rows, false, 0); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, "unsupported.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	var got []UnsupportedResource
-	if err := json.Unmarshal(body, &got); err != nil {
+	var manifest UnsupportedManifest
+	if err := json.Unmarshal(body, &manifest); err != nil {
 		t.Fatal(err)
 	}
+	got := manifest.Resources
 	want := []struct {
 		typ, region, id string
 	}{
@@ -479,7 +499,7 @@ func TestWriteUnsupportedManifest_OmitemptyOptionalFields(t *testing.T) {
 		ID:   "arn-only",
 		Name: "only",
 	}
-	if _, _, err := writeUnsupportedManifest(dir, []UnsupportedResource{row}); err != nil {
+	if _, _, err := writeUnsupportedManifest(dir, []UnsupportedResource{row}, false, 0); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, "unsupported.json"))
@@ -491,6 +511,98 @@ func TestWriteUnsupportedManifest_OmitemptyOptionalFields(t *testing.T) {
 		if bytes.Contains(body, []byte(key)) {
 			t.Errorf("manifest carries %s for omitempty-zero value; got: %s", key, body)
 		}
+	}
+}
+
+// --- #309 wrapper-shape tests ---
+
+// TestWriteUnsupportedManifest_WrapperShape pins the on-disk shape
+// introduced in #309: unsupported.json is a wrapper object
+// {"resources":[…],"truncated":bool,"max_results":int}, NOT a bare
+// JSON array. The reliable wizard's consumer reads the wrapper to
+// surface a "showing first N of many" banner; a regression to the
+// bare-array shape would break the consumer's decode.
+func TestWriteUnsupportedManifest_WrapperShape(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rows := []UnsupportedResource{
+		{Type: "aws_vpc", ID: "arn-a", Name: "a", Region: "us-east-1"},
+	}
+	if _, _, err := writeUnsupportedManifest(dir, rows, false, 10000); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "unsupported.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Top-level must be a JSON object, not a bare array.
+	trimmed := bytes.TrimSpace(body)
+	if !bytes.HasPrefix(trimmed, []byte("{")) {
+		t.Errorf("on-disk top-level shape must be an object (start with `{`); got: %s", body)
+	}
+	if bytes.HasPrefix(trimmed, []byte("[")) {
+		t.Errorf("on-disk top-level shape regressed to a bare array; got: %s", body)
+	}
+	// Decode into UnsupportedManifest and assert every field.
+	var got UnsupportedManifest
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode wrapper: %v", err)
+	}
+	if len(got.Resources) != 1 {
+		t.Errorf("Resources len=%d, want 1", len(got.Resources))
+	}
+	if got.Truncated {
+		t.Errorf("Truncated=true, want false (writer was called with truncated=false)")
+	}
+	if got.MaxResults != 10000 {
+		t.Errorf("MaxResults=%d, want 10000", got.MaxResults)
+	}
+	// Field-name pins: assert the JSON tags match the contract.
+	for _, want := range []string{`"resources":`, `"truncated":`, `"max_results":`} {
+		if !bytes.Contains(body, []byte(want)) {
+			t.Errorf("body missing required wrapper field %s; got: %s", want, body)
+		}
+	}
+}
+
+// TestWriteUnsupportedManifest_TruncatedTrueOnDisk pins that the
+// truncated=true bool round-trips through writeUnsupportedManifest into
+// the on-disk JSON. A regression that hard-coded `false` (or that
+// dropped the parameter) would silently mask cap-firing runs from the
+// reliable wizard's banner.
+func TestWriteUnsupportedManifest_TruncatedTrueOnDisk(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rows := []UnsupportedResource{
+		{Type: "aws_vpc", ID: "arn-a", Region: "us-east-1"},
+	}
+	if _, _, err := writeUnsupportedManifest(dir, rows, true, 5); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "unsupported.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Direct substring assertion — the JSON encoder writes booleans
+	// as the literal `true` / `false` tokens, so a regression that
+	// emitted `0` / `1` (or omitted the field via omitempty) would
+	// fail this pin.
+	if !bytes.Contains(body, []byte(`"truncated": true`)) {
+		t.Errorf("body missing `\"truncated\": true`; got: %s", body)
+	}
+	if !bytes.Contains(body, []byte(`"max_results": 5`)) {
+		t.Errorf("body missing `\"max_results\": 5`; got: %s", body)
+	}
+	// Decode-side cross-check.
+	var got UnsupportedManifest
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode wrapper: %v", err)
+	}
+	if !got.Truncated {
+		t.Errorf("Truncated=false, want true")
+	}
+	if got.MaxResults != 5 {
+		t.Errorf("MaxResults=%d, want 5", got.MaxResults)
 	}
 }
 


### PR DESCRIPTION
## Summary

- New CLI flag `--max-unsupported-results=N` (default 10000, 0 disables) caps the broad-enumeration paths that back `--include-unsupported`. Negative values are a fatal validation error.
- AWS cap is applied **at the searcher level** so the page loop stops as soon as the cap fires — saves API budget on top of the memory bound. Cross-region scans pass the remaining budget per region.
- GCP cap is applied **at the `EnumerateUnsupported` wrapper**, not inside `RealAssetSearcher.SearchAll`. `SearchAll` is shared with the importable scan; capping there would silently truncate `imported.json`. Trade-off: this bounds memory + on-disk size, not the Cloud Asset API budget.
- When the cap fires, a stderr `WARN` is emitted and `truncated=true` is stamped on the new wrapper-object shape of `unsupported.json`.

## Closes / Part of

- Closes #309
- Stacked on PR #313 (`feat/aggargs-310`)

## Wire-format break

`unsupported.json` is now a wrapper object instead of a bare JSON array:

```json
{
  "resources": [ … sorted rows … ],
  "truncated": false,
  "max_results": 10000
}
```

This is incompatible with the v0.7-era bare-array shape. The reliable wizard's consumer hasn't shipped yet (per the umbrella context), so the break is contained to this repo. No version field — adding `truncated` / `max_results` is a one-shot break, and a future schema change would warrant a new sibling file rather than versioning this one.

The inner `resources` slice keeps every prior invariant: `[]`-not-`null`, deterministic `(Type, Region, ID)` sort, atomic write via `writeFileAtomic`.

## Stacking note

Branched off `origin/feat/aggargs-310`. CI on stacked PRs gates on the base branch merging into `main`; locally green is the bar until then. Final-state CI will be green once #310 lands.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/insideout-import/... ./pkg/composer/... ./pkg/insideout-import/... -count=1 -race` (2058 passed)
- [x] `go vet ./...` clean
- [x] `gofmt -l cmd/ pkg/` empty
- [x] All 8 static lint scripts pass
- [x] New tests:
  - `TestEnumerateUnsupported_CapFiresAndSetsTruncated` (AWS)
  - `TestEnumerateUnsupported_CapZeroDisablesLimit` (AWS)
  - `TestSearch_CapStopsFetchingPages` (AWS, page-fetch counter pin)
  - `TestEnumerateUnsupportedGCP_CapFiresAndSetsTruncated` (GCP)
  - `TestEnumerateUnsupportedGCP_CapZeroDisablesLimit` (GCP)
  - `TestRunDiscoverWithDeps_MaxUnsupportedResults_FlagThreadsCap` (orchestrator, AWS+GCP)
  - `TestRunDiscoverWithDeps_MaxUnsupportedResults_NegativeIsFatal`
  - `TestRunDiscoverWithDeps_TruncatedFlagSurfacesInUnsupportedJSON` (end-to-end)
  - `TestWriteUnsupportedManifest_WrapperShape` (wire-format pin)
  - `TestWriteUnsupportedManifest_TruncatedTrueOnDisk` (truncated=true round-trip)

## Files

- `cmd/insideout-import/awsdiscover/unsupported.go` — searcher signature gains `maxResults`; `Search` stops fetching subsequent pages when cap fires; `enumerateUnsupportedAWS` returns `(rows, truncated, err)` and threads cross-region budget.
- `cmd/insideout-import/gcpdiscover/searcher.go` — TODO replaced with rationale comment; `SearchAll` intentionally unbounded.
- `cmd/insideout-import/gcpdiscover/unsupported.go` — `EnumerateUnsupported` truncates after `SearchAll` returns; documented trade-off.
- `cmd/insideout-import/imported_unsupported.go` — new `UnsupportedManifest` carrier for the wrapper shape.
- `cmd/insideout-import/manifest.go` — `writeUnsupportedManifest` takes `(truncated bool, maxResults int)` and emits the wrapper.
- `cmd/insideout-import/discover.go` — flag wiring + WARN + orchestrator threads `MaxResults` through both enumerator closures.