### PR TITLE
feat(insideout-import): per-stage context timeouts (#311)

### DIFF
--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -27,8 +27,37 @@ import (
 const (
 	discoverExitOK    = 0
 	discoverExitFatal = 1
+)
 
-	discoverTimeout = 15 * time.Minute
+// Per-stage discovery budgets (#311).
+//
+// Each stage's call site wraps the parent ctx in
+// context.WithTimeout(parentCtx, perStageTimeout) so an optional or
+// misbehaving stage cannot starve mandatory ones — historically a
+// single 15-minute outer cap meant a slow Stage 2a could leave Stage
+// 2b with seconds-of-budget and surface as a confusing "context
+// deadline exceeded" mid-binary. Operators can't tune these today;
+// expose CLI flags in a follow-up if real-world budgets demand it.
+//
+// Declared as `var` (not `const`) so tests can swap the budget down to
+// a few milliseconds via withTestStageTimeout(); production code paths
+// never mutate these. The runtime cost of a package-level var read vs
+// a const read is negligible — picking testability over the marginal
+// safety of a const is the right trade-off here.
+var (
+	stageTimeoutAWSConfig   = 1 * time.Minute // loadConfig + GetCallerIdentity
+	stageTimeoutGCPConnect  = 1 * time.Minute // newGCPDiscoverer (gRPC dial + ADC)
+	stageTimeoutDiscover    = 5 * time.Minute // Stage 2a: DiscoverTypes
+	stageTimeoutUnsupported = 2 * time.Minute // Stage 1.5: optional --include-unsupported
+	stageTimeoutGenconfig   = 5 * time.Minute // Stage 2b: terraform plan -generate-config-out
+	stageTimeoutDriftfix    = 3 * time.Minute // Stage 2c1: drift fix loop
+	stageTimeoutDepchase    = 5 * time.Minute // Stage 2c3: dep chase loop (already iteration-bounded)
+
+	// discoverTimeoutOverall is the outer cap. Defense-in-depth: the
+	// sum of per-stage budgets plus headroom. Stages skipped via
+	// --no-hcl / --no-driftfix / --no-depchase don't claim their
+	// per-stage budget, but the outer cap is unchanged.
+	discoverTimeoutOverall = 25 * time.Minute
 )
 
 // discoverRetryMaxAttempts raises the SDK retryer's attempt budget above
@@ -38,7 +67,7 @@ const (
 // ListTagsOfResource fanout on a few-hundred-table account. With v2's
 // adaptive backoff (jitter + exponential) attempt 8 lands ~30s after
 // attempt 1, which matches the per-call budget the operator-facing
-// 15-minute discoverTimeout can absorb.
+// stage budgets above can absorb.
 const discoverRetryMaxAttempts = 8
 
 // discoveryAggregator is the small subset of awsdiscover.AWSDiscoverer
@@ -464,12 +493,14 @@ Exit codes:
 
 	types := splitCSV(*resourceTypes)
 
-	// TODO(#311): per-stage context timeouts. A single discoverTimeout
-	// covers Stage 2a (DiscoverTypes), Stage 2b (genconfig), Stage 2c1
-	// (driftfix), and Stage 2c3 (depchase). When Stage 2a or 2c3 burns
-	// most of the budget, Stage 2b can be context-cancelled mid-binary
-	// without ever surfacing which stage actually took too long.
-	ctx, cancel := context.WithTimeout(context.Background(), discoverTimeout)
+	// Outer cap (#311). Each stage call site below derives a per-stage
+	// child via context.WithTimeout(ctx, stageTimeoutXxx) so a slow
+	// optional Stage 1.5 (--include-unsupported) or a runaway Stage
+	// 2c3 dep-chase iteration cannot starve mandatory stages. The
+	// outer cap is defense-in-depth — the sum of the per-stage budgets
+	// plus headroom — and surfaces the same `context.DeadlineExceeded`
+	// when the entire run drags on too long.
+	ctx, cancel := context.WithTimeout(context.Background(), discoverTimeoutOverall)
 	defer cancel()
 
 	// summaryStart is the wall-clock anchor for ScanSummary.duration_ms
@@ -602,8 +633,22 @@ Exit codes:
 	)
 	switch cloud {
 	case "aws":
-		cfg, err := deps.loadConfig(ctx, primaryRegion, *awsEndpointURL)
+		// Stage: AWS config load + STS GetCallerIdentity. Both calls
+		// share a single per-stage budget — they're a tight pair (config
+		// resolution feeds STS) and a stuck IMDS / endpoint-discovery
+		// hop should fail fast rather than gnaw the outer cap. The
+		// deferred cancel guarantees the timer is freed on every exit
+		// path (success, mid-block error, multi-account fatal) — the
+		// stage budget only constrains loadConfig + getAccount, but
+		// holding the cancel until the function returns is harmless
+		// since the timer fires once and then becomes a no-op.
+		awsCfgCtx, awsCfgCancel := context.WithTimeout(ctx, stageTimeoutAWSConfig)
+		defer awsCfgCancel()
+		cfg, err := deps.loadConfig(awsCfgCtx, primaryRegion, *awsEndpointURL)
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "aws-config", stageTimeoutAWSConfig, err)
+			}
 			fmt.Fprintf(os.Stderr, "discover: load AWS config: %v\n", err)
 			return discoverExitFatal
 		}
@@ -655,8 +700,14 @@ Exit codes:
 			// STS response is treated as accountID="" — the DynamoDB
 			// discoverer's prefix-only fallback handles that case (see
 			// TestDynamoDBDiscover_PrefixOnlyFallback).
-			accountID, err = deps.getAccount(ctx, cfg)
+			//
+			// Reuses the loadConfig stage budget — both calls live under
+			// the same `aws-config` stage.
+			accountID, err = deps.getAccount(awsCfgCtx, cfg)
 			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "aws-config", stageTimeoutAWSConfig, err)
+				}
 				fmt.Fprintf(os.Stderr, "discover: STS GetCallerIdentity: %v\n", err)
 				return discoverExitFatal
 			}
@@ -664,8 +715,16 @@ Exit codes:
 		d = deps.newDiscoverer(cfg, *maxConcurrency)
 		awsCfg = cfg
 	case "gcp":
-		gd, closeFn, err := deps.newGCPDiscoverer(ctx, *gcpProjectID)
+		// Stage: GCP discoverer construction (gRPC dial + ADC resolution).
+		// A stuck ADC fetch or unreachable Cloud Asset endpoint should
+		// fail fast rather than burn the outer cap.
+		gcpCtx, gcpCancel := context.WithTimeout(ctx, stageTimeoutGCPConnect)
+		gd, closeFn, err := deps.newGCPDiscoverer(gcpCtx, *gcpProjectID)
+		gcpCancel()
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "gcp-connect", stageTimeoutGCPConnect, err)
+			}
 			fmt.Fprintf(os.Stderr, "discover: build GCP discoverer: %v\n", err)
 			return discoverExitFatal
 		}
@@ -697,8 +756,12 @@ Exit codes:
 		// loaded set and re-emits a deterministic file (sorted, []-not-null).
 		resources = preloaded
 	} else {
+		// Stage 2a: bulk DiscoverTypes (#311). Per-region fanout +
+		// per-service enumerators; the dominant wall-clock cost on a
+		// typical run.
+		discCtx, discCancel := context.WithTimeout(ctx, stageTimeoutDiscover)
 		var err error
-		resources, err = d.DiscoverTypes(ctx, AggArgs{
+		resources, err = d.DiscoverTypes(discCtx, AggArgs{
 			Types:        types,
 			Project:      *project,
 			Regions:      resolvedRegions,
@@ -706,7 +769,11 @@ Exit codes:
 			AccountID:    accountID,
 			Emitter:      emitter,
 		})
+		discCancel()
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "discover", stageTimeoutDiscover, err)
+			}
 			fmt.Fprintf(os.Stderr, "discover: %v\n", err)
 			return discoverExitFatal
 		}
@@ -744,8 +811,17 @@ Exit codes:
 	// The mutual-exclusion gate above (--from-manifest is incompatible)
 	// has already returned discoverExitFatal if both are set.
 	if *includeUnsupported {
-		unsupported, truncated, uerr := enumerateUnsupportedForCloud(ctx, cloud, awsCfg, *project, resolvedRegions, parsedSelectors, *maxUnsupportedResults, emitter, deps)
+		// Stage 1.5 (#311): wrap the optional unsupported enumeration
+		// in its own per-stage budget so a Resource-Explorer-stuck or
+		// Cloud-Asset-throttled enumerator cannot starve mandatory
+		// downstream stages (Stage 2b/2c1/2c3). Soft-fails as before.
+		unsupCtx, unsupCancel := context.WithTimeout(ctx, stageTimeoutUnsupported)
+		unsupported, truncated, uerr := enumerateUnsupportedForCloud(unsupCtx, cloud, awsCfg, *project, resolvedRegions, parsedSelectors, *maxUnsupportedResults, emitter, deps)
+		unsupCancel()
 		if uerr != nil {
+			if errors.Is(uerr, context.DeadlineExceeded) {
+				fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "unsupported", stageTimeoutUnsupported, uerr)
+			}
 			fmt.Fprintf(os.Stderr, "discover: WARN: --include-unsupported: %v; imported.json was written; continuing without unsupported.json\n", uerr)
 		} else {
 			if truncated {
@@ -787,8 +863,18 @@ Exit codes:
 		GCPProjectID:   *gcpProjectID,
 		AWSEndpointURL: *awsEndpointURL,
 	}
-	res, err := deps.runGenconfig(ctx, gcOptsBase, resources)
+	// Stage 2b (#311): bound the genconfig terraform-exec call so a
+	// hung subprocess doesn't drag the whole run out to the outer
+	// cap. The depchase pipeline closures below also wrap their inner
+	// genconfig calls in stageTimeoutGenconfig — see comment there for
+	// the budget-within-a-budget semantics.
+	gcCtx, gcCancel := context.WithTimeout(ctx, stageTimeoutGenconfig)
+	res, err := deps.runGenconfig(gcCtx, gcOptsBase, resources)
+	gcCancel()
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "genconfig", stageTimeoutGenconfig, err)
+		}
 		fmt.Fprintf(os.Stderr, "discover: HCL generation: %v\n", err)
 		fmt.Fprintln(os.Stderr, "discover: imported.json was written, but Attributes are empty. Re-run with --no-hcl to skip Stage 2b explicitly.")
 		return discoverExitFatal
@@ -812,8 +898,18 @@ Exit codes:
 	// Stage 2c1: loop terraform plan against the generated stack and
 	// patch drifting attributes until the plan is empty. Same workdir as
 	// genconfig (re-uses the .terraform dir).
-	dfRes, err := deps.runDriftfix(ctx, driftfix.Options{Workdir: gcWorkdir})
+	//
+	// Per-stage budget (#311): bounds the entire driftfix loop. Inner
+	// driftfix calls fired by the depchase pipeline below get their own
+	// fresh stageTimeoutDriftfix budget on each iteration — see the
+	// pipeline closure for budget-within-a-budget semantics.
+	dfCtx, dfCancel := context.WithTimeout(ctx, stageTimeoutDriftfix)
+	dfRes, err := deps.runDriftfix(dfCtx, driftfix.Options{Workdir: gcWorkdir})
+	dfCancel()
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "driftfix", stageTimeoutDriftfix, err)
+		}
 		fmt.Fprintf(os.Stderr, "discover: drift fix: %v\n", err)
 		fmt.Fprintln(os.Stderr, "discover: imported.json + generated.tf are on disk. Re-run with --no-driftfix to skip Stage 2c1 explicitly, or inspect the workdir to fix manually.")
 		return discoverExitFatal
@@ -834,10 +930,24 @@ Exit codes:
 	// iteration without taking a dep on either subpackage. After
 	// each successful iteration we rewrite imported.json so the
 	// manifest stays consistent with the on-disk generated.tf.
+	//
+	// Budget-within-a-budget (#311): the depchase orchestrator runs
+	// under stageTimeoutDepchase (set up below). Each pipeline
+	// iteration fires runGenconfig + runDriftfix; we wrap each inner
+	// call in its own stageTimeoutGenconfig / stageTimeoutDriftfix
+	// child of the iteration ctx. The inner budget is bounded by
+	// `min(stageTimeoutInner, time.Until(parentDeadline))`, so a
+	// late-iteration call still surfaces a clean DeadlineExceeded
+	// rather than hanging waiting for the outer dep-chase deadline.
 	pipeline := depchase.PipelineFns{
 		RunGenconfig: func(ictx context.Context, expanded []imported.ImportedResource) (*depchase.GenconfigResult, error) {
-			r, err := deps.runGenconfig(ictx, gcOptsBase, expanded)
+			innerCtx, innerCancel := context.WithTimeout(ictx, stageTimeoutGenconfig)
+			defer innerCancel()
+			r, err := deps.runGenconfig(innerCtx, gcOptsBase, expanded)
 			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					fmt.Fprintf(os.Stderr, "discover: stage %q (depchase iteration) exceeded budget of %v: %v\n", "genconfig", stageTimeoutGenconfig, err)
+				}
 				return nil, err
 			}
 			if _, _, err := writeManifest(*outputDir, cloud, r.Resources); err != nil {
@@ -849,8 +959,13 @@ Exit codes:
 			}, nil
 		},
 		RunDriftfix: func(ictx context.Context) (*depchase.DriftfixResult, error) {
-			r, err := deps.runDriftfix(ictx, driftfix.Options{Workdir: gcWorkdir})
+			innerCtx, innerCancel := context.WithTimeout(ictx, stageTimeoutDriftfix)
+			defer innerCancel()
+			r, err := deps.runDriftfix(innerCtx, driftfix.Options{Workdir: gcWorkdir})
 			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					fmt.Fprintf(os.Stderr, "discover: stage %q (depchase iteration) exceeded budget of %v: %v\n", "driftfix", stageTimeoutDriftfix, err)
+				}
 				return nil, err
 			}
 			return &depchase.DriftfixResult{
@@ -859,7 +974,12 @@ Exit codes:
 			}, nil
 		},
 	}
-	dcRes, err := deps.runDepChase(ctx, depchase.Options{
+	// Stage 2c3 (#311): bounds the entire dep-chase loop. The inner
+	// genconfig + driftfix iteration calls share this parent ctx via
+	// their own per-call WithTimeout above.
+	dcCtx, dcCancel := context.WithTimeout(ctx, stageTimeoutDepchase)
+	defer dcCancel()
+	dcRes, err := deps.runDepChase(dcCtx, depchase.Options{
 		Workdir:       gcWorkdir,
 		Region:        primaryRegion,
 		AccountID:     accountID,
@@ -873,6 +993,9 @@ Exit codes:
 		}
 	}
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "depchase", stageTimeoutDepchase, err)
+		}
 		fmt.Fprintf(os.Stderr, "discover: dependency chase: %v\n", err)
 		fmt.Fprintln(os.Stderr, "discover: imported.json + generated.tf are on disk. Re-run with --no-depchase to skip Stage 2c3 explicitly, or raise --max-depchase-iterations and rerun.")
 		return discoverExitFatal

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
@@ -2947,4 +2948,202 @@ func TestAggArgs_RoundTripsThroughAdapters(t *testing.T) {
 		assert.Empty(t, awsArgs.TagSelectors)
 		assert.Empty(t, gcpArgs.TagSelectors)
 	})
+}
+
+// --- #311 per-stage timeout tests ---
+
+// withTestStageTimeout temporarily lowers a per-stage timeout var so a
+// timeout-fires test can run in tens of milliseconds rather than the
+// production multi-minute budget. The timeout vars at the top of
+// discover.go are package-level vars (not consts) precisely so tests
+// can swap them; production code paths never mutate them. Cleanup
+// restores the original on test exit.
+func withTestStageTimeout(t *testing.T, p *time.Duration, d time.Duration) {
+	t.Helper()
+	orig := *p
+	*p = d
+	t.Cleanup(func() { *p = orig })
+}
+
+// blockingAggregator's DiscoverTypes blocks on <-ctx.Done() so the test
+// can exercise the Stage 2a per-stage timeout deterministically. We use
+// ctx.Done() (not time.Sleep) so the goroutine returns as soon as the
+// stage's WithTimeout cancels — keeping the test fast and race-free.
+type blockingAggregator struct {
+	called int
+}
+
+func (f *blockingAggregator) DiscoverTypes(ctx context.Context, _ AggArgs) ([]imported.ImportedResource, error) {
+	f.called++
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (f *blockingAggregator) DiscoverByID(_ context.Context, _, _, _, _ string) (imported.ImportedResource, error) {
+	return imported.ImportedResource{}, awsdiscover.ErrNotFound
+}
+
+// TestRunDiscoverWithDeps_StageTimeoutFiresOnSlowDiscoverTypes pins the
+// Stage 2a (#311) per-stage timeout: a hung DiscoverTypes surfaces as a
+// fatal exit with a stderr line that names the stage and the budget.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_StageTimeoutFiresOnSlowDiscoverTypes(t *testing.T) {
+	withTestStageTimeout(t, &stageTimeoutDiscover, 50*time.Millisecond)
+	dir := t.TempDir()
+	agg := &blockingAggregator{}
+	deps := discoverDeps{
+		loadConfig:    func(_ context.Context, _, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "1", nil },
+		newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator { return agg },
+		runGenconfig: func(_ context.Context, _ genconfig.Options, _ []imported.ImportedResource) (*genconfig.Result, error) {
+			t.Fatal("runGenconfig must not be called when Stage 2a deadline-exceeds")
+			return nil, nil
+		},
+		runDriftfix: func(_ context.Context, _ driftfix.Options) (*driftfix.Result, error) {
+			t.Fatal("runDriftfix must not be called when Stage 2a deadline-exceeds")
+			return nil, nil
+		},
+		runDepChase: noopDepChase,
+	}
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+		}, deps)
+	})
+	if rc != discoverExitFatal {
+		t.Fatalf("rc=%d, want fatal (Stage 2a should exceed its budget)", rc)
+	}
+	if agg.called != 1 {
+		t.Errorf("DiscoverTypes called %d times, want 1", agg.called)
+	}
+	if !strings.Contains(stderr, `stage "discover"`) || !strings.Contains(stderr, "exceeded budget") {
+		t.Errorf("stderr should name the stage and budget; got: %s", stderr)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "imported.json")); !os.IsNotExist(err) {
+		t.Errorf("imported.json must not be written when Stage 2a deadline-exceeds")
+	}
+}
+
+// TestRunDiscoverWithDeps_UnsupportedStageTimeoutDoesNotStarveStage2b
+// pins the headline #311 invariant: a slow optional Stage 1.5
+// (--include-unsupported) cannot starve mandatory Stage 2b. We block
+// the unsupported enumerator until ctx.Done() (deadline exceeds), then
+// assert that runGenconfig was still invoked with a context whose
+// remaining budget is at least Stage 2b's full per-stage budget minus a
+// tolerance. Pre-#311, the genconfig ctx was the same one Stage 1.5
+// was about to expire — it would have inherited an exhausted deadline.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_UnsupportedStageTimeoutDoesNotStarveStage2b(t *testing.T) {
+	withTestStageTimeout(t, &stageTimeoutUnsupported, 30*time.Millisecond)
+	withTestStageTimeout(t, &stageTimeoutGenconfig, 5*time.Second)
+	dir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+
+	gcCalled := 0
+	var gcRemaining time.Duration
+	deps := okDeps(agg)
+	deps.runGenconfig = func(ctx context.Context, opts genconfig.Options, resources []imported.ImportedResource) (*genconfig.Result, error) {
+		gcCalled++
+		if dl, ok := ctx.Deadline(); ok {
+			gcRemaining = time.Until(dl)
+		}
+		return &genconfig.Result{
+			GeneratedPath: filepath.Join(opts.Workdir, "generated.tf"),
+			Resources:     resources,
+		}, nil
+	}
+	deps.enumerateUnsupportedAWS = func(ctx context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
+		<-ctx.Done()
+		return nil, false, ctx.Err()
+	}
+
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+			"--include-unsupported",
+		}, deps)
+	})
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK (unsupported soft-fails; mandatory stages must continue)", rc)
+	}
+	if gcCalled != 1 {
+		t.Errorf("runGenconfig called %d times, want 1 (Stage 2b must run after Stage 1.5 deadline-exceeds)", gcCalled)
+	}
+	// Tolerance: the parent (overall) ctx ticks down between Stage 1.5
+	// expiry and the WithTimeout call at Stage 2b. We assert the
+	// remaining budget is within ~200ms of stageTimeoutGenconfig — well
+	// above the ~30ms Stage 1.5 burned, which would have been the
+	// pre-#311 budget.
+	wantMin := stageTimeoutGenconfig - 200*time.Millisecond
+	if gcRemaining < wantMin {
+		t.Errorf("Stage 2b ctx remaining=%v, want >= %v (pre-#311 regression: Stage 1.5 starved Stage 2b)", gcRemaining, wantMin)
+	}
+	if !strings.Contains(stderr, `stage "unsupported"`) || !strings.Contains(stderr, "exceeded budget") {
+		t.Errorf("stderr should name the unsupported stage and budget; got: %s", stderr)
+	}
+}
+
+// TestRunDiscoverWithDeps_GenconfigTimeoutFiresIndependentlyOfDriftfix
+// pins the symmetric #311 invariant: when Stage 2b deadline-exceeds,
+// the run is fatal and downstream stages (driftfix, depchase) must NOT
+// run. The stderr surfaces the genconfig stage name + budget.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_GenconfigTimeoutFiresIndependentlyOfDriftfix(t *testing.T) {
+	withTestStageTimeout(t, &stageTimeoutGenconfig, 50*time.Millisecond)
+	dir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	deps := okDeps(agg)
+	deps.runGenconfig = func(ctx context.Context, _ genconfig.Options, _ []imported.ImportedResource) (*genconfig.Result, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	deps.runDriftfix = func(_ context.Context, _ driftfix.Options) (*driftfix.Result, error) {
+		t.Fatal("runDriftfix must not be called when Stage 2b deadline-exceeds")
+		return nil, nil
+	}
+	deps.runDepChase = func(_ context.Context, _ depchase.Options, _ []imported.ImportedResource) (*depchase.Result, error) {
+		t.Fatal("runDepChase must not be called when Stage 2b deadline-exceeds")
+		return nil, nil
+	}
+
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+		}, deps)
+	})
+	if rc != discoverExitFatal {
+		t.Fatalf("rc=%d, want fatal (Stage 2b should exceed its budget)", rc)
+	}
+	if !strings.Contains(stderr, `stage "genconfig"`) || !strings.Contains(stderr, "exceeded budget") {
+		t.Errorf("stderr should name the genconfig stage and budget; got: %s", stderr)
+	}
+}
+
+// TestStageTimeoutsDoNotExceedOverallCap is a sanity pin: every
+// per-stage budget must fit inside discoverTimeoutOverall, otherwise
+// the outer cap silently truncates the per-stage one and the named-
+// stage stderr never surfaces. A mutation that bumps any per-stage
+// budget without bumping the outer cap fails this test.
+func TestStageTimeoutsDoNotExceedOverallCap(t *testing.T) {
+	t.Parallel()
+	stages := map[string]time.Duration{
+		"aws-config":  stageTimeoutAWSConfig,
+		"gcp-connect": stageTimeoutGCPConnect,
+		"discover":    stageTimeoutDiscover,
+		"unsupported": stageTimeoutUnsupported,
+		"genconfig":   stageTimeoutGenconfig,
+		"driftfix":    stageTimeoutDriftfix,
+		"depchase":    stageTimeoutDepchase,
+	}
+	for name, d := range stages {
+		if d >= discoverTimeoutOverall {
+			t.Errorf("stage %q budget=%v >= discoverTimeoutOverall=%v (the outer cap would mask the per-stage signal)", name, d, discoverTimeoutOverall)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Replace the single `discoverTimeout = 15m` with per-stage `context.WithTimeout` derivations so an optional Stage 1.5 (`--include-unsupported`) or a runaway Stage 2c3 dep-chase iteration cannot starve mandatory stages.
- Surface a `stage \"<name>\" exceeded budget of <duration>` stderr line on `context.DeadlineExceeded` so operators (and the wizard UI parser) see *which* stage exhausted its budget instead of the generic `context deadline exceeded`.
- Outer `discoverTimeoutOverall = 25m` cap remains as defense-in-depth and is a strict superset of every per-stage budget (pinned by `TestStageTimeoutsDoNotExceedOverallCap`).
- Wraps every stage call site: `aws-config` (1m, loadConfig + STS share one budget), `gcp-connect` (1m), `discover` (5m, Stage 2a), `unsupported` (2m, Stage 1.5), `genconfig` (5m, Stage 2b), `driftfix` (3m, Stage 2c1), `depchase` (5m, Stage 2c3). Skipped stages via `--no-hcl` / `--no-driftfix` / `--no-depchase` don't claim their per-stage budget.
- Depchase pipeline closures derive per-iteration `stageTimeoutGenconfig` / `stageTimeoutDriftfix` children from the iteration ctx — \"budget within a budget\" so each pipeline pass is independently bounded inside the outer dep-chase deadline.

## Closes

Closes #311. Stacked on PR #314 -> PR #313 -> main.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/insideout-import/... ./pkg/composer/... ./pkg/insideout-import/... -count=1 -race -timeout 240s` (2062 passed)
- [x] `go vet ./...` clean
- [x] `gofmt -l cmd/ pkg/` empty
- [x] All 8 static lint scripts pass (`lint-project-tag`, `lint-project-label`, `lint-sensitive-for-each`, `lint-foreach-unknown-keys`, `lint-no-root-only-blocks`, `lint-shared-no-cloud-providers`, `lint-labelless-name-prefix`, `lint-gcp-project-pin`)
- [x] New tests run in <1s using `withTestStageTimeout` to shrink budgets to 30-50ms; each pins a different invariant:
  - `TestRunDiscoverWithDeps_StageTimeoutFiresOnSlowDiscoverTypes` — Stage 2a deadline-exceeds is fatal; stderr names stage + budget; downstream stages don't run.
  - `TestRunDiscoverWithDeps_UnsupportedStageTimeoutDoesNotStarveStage2b` — the headline #311 invariant: Stage 1.5 timeout still leaves Stage 2b with its full budget (asserts `time.Until(deadline)` ≥ stageTimeoutGenconfig - 200ms).
  - `TestRunDiscoverWithDeps_GenconfigTimeoutFiresIndependentlyOfDriftfix` — symmetric: Stage 2b deadline-exceeds is fatal; driftfix + depchase fakes are wired to `t.Fatal` on call.
  - `TestStageTimeoutsDoNotExceedOverallCap` — sanity pin: every per-stage budget < `discoverTimeoutOverall` so the outer cap can't mask the per-stage signal.

CI on stacked PRs gates on base merge to main — locally-green is the bar.

## Stacking note

Stack: main -> #313 (AggArgs) -> #314 (max-results cap) -> THIS PR. Branched from `origin/feat/maxresults-cap-309`, rebased clean.

## Notes

- **`var` vs `const` for the timeouts**: package-level `var`s let tests swap budgets via `withTestStageTimeout`; production code paths never mutate them. The runtime cost of a package-level var read vs a const read is negligible — testability is the better trade-off here. Documented in the constant-block header.
- **Stage budgets are not CLI flags** by design (per the plan). If operators ask for tunability, expose flags in a follow-up; the plumbing is local.
- **AWS config + STS share one stage budget** (`aws-config`) since they're a tight pair (config resolution feeds STS). The deferred cancel covers every exit path including the multi-AccountID fatal — vet is clean.
- **Depchase budget-within-a-budget**: each pipeline iteration's `runGenconfig` / `runDriftfix` is wrapped in its own `WithTimeout(ictx, stageTimeoutXxx)` child. The effective inner budget is `min(stageTimeoutInner, time.Until(parentDeadline))` so a late iteration cleanly surfaces a named-stage `DeadlineExceeded` rather than hanging on the outer dep-chase deadline.