### PR TITLE
fix(progress): emit count=0 on finish events via Event.MarshalJSON (#312)

### DIFF
--- a/cmd/insideout-import/progress/progress.go
+++ b/cmd/insideout-import/progress/progress.go
@@ -30,36 +30,151 @@ import (
 	"time"
 )
 
-// Event is the on-the-wire shape produced by JSONEmitter. Field order in
-// the JSON output is determined by the struct layout (Go's encoding/json
-// emits in declaration order); we keep the most-discriminating fields
-// first so a streaming consumer can route on `event` without reading the
-// rest of the line.
+// Event is the on-the-wire shape produced by JSONEmitter. Each event
+// type carries a specific, fixed field set defined by the
+// MarshalJSON dispatch below; the on-the-wire field order follows the
+// per-event branch in MarshalJSON, with `event` always first and `ts`
+// always last so a streaming consumer can route on `event` without
+// reading the rest of the line.
 //
-// Optional fields use `omitempty` so each event type carries only the
-// fields that apply to it — service_start has no Count/DurationMs, etc.
-// The Timestamp field is always present; tests inject a fixed clock via
-// JSONEmitter.WithNow so golden output is deterministic.
+// The struct tags carry no `omitempty` on the numeric fields
+// (Count/Total/DurationMs) because MarshalJSON elides absent fields
+// per event type rather than relying on Go's zero-value-elision.
+// This is the fix for #312: a service_finish or stage_finish whose
+// scope yielded zero items must still emit `"count":0` so SSE
+// consumers don't have to special-case "count missing" vs
+// "count == 0". The Timestamp field is always present; tests inject
+// a fixed clock via JSONEmitter.WithNow so golden output is
+// deterministic.
 //
-// TODO(#312): typed sub-events or MarshalJSON. The omitempty Count
-// field drops `count` from service_finish/stage_finish events whose
-// scope yielded zero items; the SSE consumer renders that as "count
-// missing" rather than "count = 0". Either split into typed
-// sub-events or add a custom MarshalJSON that always emits count for
-// service_finish + stage_finish (and never for service_start +
-// item_found).
+// Region vs Location: today AWS discoverers populate Region and GCP
+// discoverers populate Location (the public Emitter API takes a
+// `region` parameter that GCP overloads with location values, but
+// the Event struct keeps them distinct for downstream consumers).
+// MarshalJSON emits exactly one of `region` or `location` on
+// service_*/item_found events: Location wins if both are set
+// (defensive), Region is emitted otherwise. If both are empty
+// (e.g. global services like IAM that pass region=""), MarshalJSON
+// emits `"region":""` — preserving the previous omitempty-absent
+// shape would require a third branch and the empty string is
+// already semantically "no region scope", which downstream parses
+// the same way.
 type Event struct {
-	Event      string    `json:"event"`                 // service_start | service_finish | item_found | stage_finish
-	Service    string    `json:"service,omitempty"`     // AWS service slug (sqs, dynamodb, ...) or GCP asset_type slug (cloud_asset_inventory)
-	Region     string    `json:"region,omitempty"`      // AWS region; empty for global services (IAM, S3) and GCP
-	Location   string    `json:"location,omitempty"`    // GCP location; empty for project-global types and AWS
-	TFType     string    `json:"tf_type,omitempty"`     // Terraform resource type for item_found
-	ImportID   string    `json:"import_id,omitempty"`   // Terraform import ID for item_found
-	Stage      string    `json:"stage,omitempty"`       // discover for stage_finish (room for future stages: hcl_gen, drift_fix, dep_chase)
-	Count      int       `json:"count,omitempty"`       // service_finish, stage_finish — items emitted in scope
-	Total      int       `json:"total,omitempty"`       // stage_finish — total items across the stage (==Count today, separate field for future fan-in)
-	DurationMs int64     `json:"duration_ms,omitempty"` // service_finish, stage_finish — wall-time spent in the scope
-	Timestamp  time.Time `json:"ts"`                    // every event; injectable for deterministic tests via WithNow
+	Event      string    `json:"event"`               // service_start | service_finish | item_found | stage_finish
+	Service    string    `json:"service,omitempty"`   // AWS service slug (sqs, dynamodb, ...) or GCP asset_type slug (cloud_asset_inventory)
+	Region     string    `json:"region,omitempty"`    // AWS region; empty for global services (IAM, S3) and GCP
+	Location   string    `json:"location,omitempty"`  // GCP location; empty for project-global types and AWS
+	TFType     string    `json:"tf_type,omitempty"`   // Terraform resource type for item_found
+	ImportID   string    `json:"import_id,omitempty"` // Terraform import ID for item_found
+	Stage      string    `json:"stage,omitempty"`     // discover for stage_finish (room for future stages: hcl_gen, drift_fix, dep_chase)
+	Count      int       `json:"count"`               // service_finish, stage_finish — items emitted in scope; always emitted on those events even when zero (#312)
+	Total      int       `json:"total"`               // stage_finish — total items across the stage (==Count today, separate field for future fan-in); always emitted on stage_finish even when zero (#312)
+	DurationMs int64     `json:"duration_ms"`         // service_finish, stage_finish — wall-time spent in the scope; always emitted on those events even when zero (#312)
+	Timestamp  time.Time `json:"ts"`                  // every event; injectable for deterministic tests via WithNow
+}
+
+// MarshalJSON implements per-event-type field dispatch so each event
+// carries exactly the field set its type requires (#312). The
+// per-event branches build typed structs (rather than a
+// map[string]any) so output preserves declaration order — every
+// emit starts with `event` and ends with `ts`, with the
+// type-specific fields between in the order documented in the
+// issue body. This is purely a readability concern; JSON consumers
+// parse objects unordered.
+//
+// The fix for #312 is structural: the typed event structs declare
+// Count/Total/DurationMs WITHOUT `omitempty`, so a service_finish
+// or stage_finish whose scope yielded zero items still emits
+// `"count":0`. The previous shared-struct + omitempty approach
+// dropped those fields and forced SSE consumers to special-case
+// "count missing" vs "count == 0".
+//
+// Field-set contract by event type:
+//
+//	service_start:  event, service, (region|location), ts
+//	service_finish: event, service, (region|location), count, duration_ms, ts
+//	item_found:     event, service, (region|location), tf_type, import_id, ts
+//	stage_finish:   event, stage, count, total, duration_ms, ts
+//
+// Region/Location selection: prefer Location when set (GCP
+// emitters), otherwise emit Region (AWS emitters and global
+// services). Empty Region for global AWS services produces
+// `"region":""`, matching the existing IAM emit shape. An unknown
+// Event value falls back to a struct-alias marshal so we don't
+// silently drop fields if the contract grows.
+func (e Event) MarshalJSON() ([]byte, error) {
+	switch e.Event {
+	case "service_start":
+		if e.Location != "" {
+			return json.Marshal(struct {
+				Event     string    `json:"event"`
+				Service   string    `json:"service"`
+				Location  string    `json:"location"`
+				Timestamp time.Time `json:"ts"`
+			}{e.Event, e.Service, e.Location, e.Timestamp})
+		}
+		return json.Marshal(struct {
+			Event     string    `json:"event"`
+			Service   string    `json:"service"`
+			Region    string    `json:"region"`
+			Timestamp time.Time `json:"ts"`
+		}{e.Event, e.Service, e.Region, e.Timestamp})
+	case "service_finish":
+		if e.Location != "" {
+			return json.Marshal(struct {
+				Event      string    `json:"event"`
+				Service    string    `json:"service"`
+				Location   string    `json:"location"`
+				Count      int       `json:"count"`
+				DurationMs int64     `json:"duration_ms"`
+				Timestamp  time.Time `json:"ts"`
+			}{e.Event, e.Service, e.Location, e.Count, e.DurationMs, e.Timestamp})
+		}
+		return json.Marshal(struct {
+			Event      string    `json:"event"`
+			Service    string    `json:"service"`
+			Region     string    `json:"region"`
+			Count      int       `json:"count"`
+			DurationMs int64     `json:"duration_ms"`
+			Timestamp  time.Time `json:"ts"`
+		}{e.Event, e.Service, e.Region, e.Count, e.DurationMs, e.Timestamp})
+	case "item_found":
+		if e.Location != "" {
+			return json.Marshal(struct {
+				Event     string    `json:"event"`
+				Service   string    `json:"service"`
+				Location  string    `json:"location"`
+				TFType    string    `json:"tf_type"`
+				ImportID  string    `json:"import_id"`
+				Timestamp time.Time `json:"ts"`
+			}{e.Event, e.Service, e.Location, e.TFType, e.ImportID, e.Timestamp})
+		}
+		return json.Marshal(struct {
+			Event     string    `json:"event"`
+			Service   string    `json:"service"`
+			Region    string    `json:"region"`
+			TFType    string    `json:"tf_type"`
+			ImportID  string    `json:"import_id"`
+			Timestamp time.Time `json:"ts"`
+		}{e.Event, e.Service, e.Region, e.TFType, e.ImportID, e.Timestamp})
+	case "stage_finish":
+		return json.Marshal(struct {
+			Event      string    `json:"event"`
+			Stage      string    `json:"stage"`
+			Count      int       `json:"count"`
+			Total      int       `json:"total"`
+			DurationMs int64     `json:"duration_ms"`
+			Timestamp  time.Time `json:"ts"`
+		}{e.Event, e.Stage, e.Count, e.Total, e.DurationMs, e.Timestamp})
+	default:
+		// Unknown event type — defensive fallback. Marshal the
+		// struct verbatim via an alias to avoid recursing back
+		// into this method. The struct-tag omitempty on the
+		// optional fields suppresses zero-value noise for unknown
+		// shapes (where we have no per-event contract to honor).
+		type alias Event
+		return json.Marshal(alias(e))
+	}
 }
 
 // Emitter is the per-service progress contract. Default implementation

--- a/cmd/insideout-import/progress/progress_test.go
+++ b/cmd/insideout-import/progress/progress_test.go
@@ -49,7 +49,9 @@ func TestJSONEmitter_ItemFoundShape(t *testing.T) {
 // AND asserts that DurationMs comes through as the integer milliseconds
 // of the supplied time.Duration (1.234s → 1234). A regression that
 // switched to Nanoseconds() / Seconds() would silently shift the units
-// the downstream UI reads.
+// the downstream UI reads. Per #312, count and duration_ms must always
+// appear on service_finish — see TestJSONEmitter_ServiceFinishCountZeroEmitted
+// for the count==0 negative half of the same contract.
 func TestJSONEmitter_ServiceFinishShape(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
@@ -61,8 +63,26 @@ func TestJSONEmitter_ServiceFinishShape(t *testing.T) {
 	if got != want {
 		t.Errorf("ServiceFinish line mismatch:\n got: %s\nwant: %s", got, want)
 	}
+	// Belt-and-suspenders: parse the bytes and confirm count + duration_ms
+	// are present (#312 fix). The exact-string match above already pins
+	// this, but the field-presence assertion catches a regression that
+	// shifts ordering without dropping the field.
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, ok := evt["count"]; !ok {
+		t.Errorf("count must be present on service_finish (#312)")
+	}
+	if _, ok := evt["duration_ms"]; !ok {
+		t.Errorf("duration_ms must be present on service_finish (#312)")
+	}
 }
 
+// TestJSONEmitter_StageFinishShape pins all three numeric fields
+// (count, total, duration_ms) MUST appear on stage_finish, and pairs
+// with TestJSONEmitter_StageFinishCountZeroEmitted for the count==0
+// half of the #312 contract.
 func TestJSONEmitter_StageFinishShape(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
@@ -73,6 +93,194 @@ func TestJSONEmitter_StageFinishShape(t *testing.T) {
 	want := `{"event":"stage_finish","stage":"discover","count":7,"total":7,"duration_ms":5000,"ts":"2026-05-07T12:00:00Z"}`
 	if got != want {
 		t.Errorf("StageFinish line mismatch:\n got: %s\nwant: %s", got, want)
+	}
+	// Belt-and-suspenders: parse and confirm all three numeric fields
+	// land on the wire — the failure mode #312 fixes is silent absence,
+	// not wrong values, so a presence-pin guards future refactors.
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, k := range []string{"count", "total", "duration_ms"} {
+		if _, ok := evt[k]; !ok {
+			t.Errorf("%q must be present on stage_finish (#312)", k)
+		}
+	}
+}
+
+// TestJSONEmitter_ServiceFinishCountZeroEmitted is the headline #312
+// regression test: a service_finish event whose scope yielded zero
+// items must still emit `"count":0` and `"duration_ms":0` so SSE
+// consumers can render "0 of 0" without special-casing absent
+// fields. The pre-fix shape used omitempty on Count/DurationMs and
+// dropped both keys on the zero-result branch.
+func TestJSONEmitter_ServiceFinishCountZeroEmitted(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.ServiceFinish("sqs", "us-east-1", 0, 0)
+
+	got := strings.TrimRight(buf.String(), "\n")
+	if !strings.Contains(got, `"count":0`) {
+		t.Errorf(`expected "count":0 on zero-result service_finish; got: %s`, got)
+	}
+	if !strings.Contains(got, `"duration_ms":0`) {
+		t.Errorf(`expected "duration_ms":0 on zero-result service_finish; got: %s`, got)
+	}
+	// Parse for structural assertion — the substring match above
+	// would also fire on `"count":0,"other":1` etc., but the parse
+	// confirms count is genuinely a top-level field.
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if v, ok := evt["count"]; !ok || v.(float64) != 0 {
+		t.Errorf("count must be 0 on zero-result service_finish; got %v ok=%v", v, ok)
+	}
+	if v, ok := evt["duration_ms"]; !ok || v.(float64) != 0 {
+		t.Errorf("duration_ms must be 0 on zero-result service_finish; got %v ok=%v", v, ok)
+	}
+}
+
+// TestJSONEmitter_StageFinishCountZeroEmitted asserts the second half
+// of the #312 contract: stage_finish with zero items must emit all
+// three numeric fields, including total=0 (which omitempty also
+// dropped pre-fix).
+func TestJSONEmitter_StageFinishCountZeroEmitted(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.StageFinish("discover", 0, 0)
+
+	got := strings.TrimRight(buf.String(), "\n")
+	for _, want := range []string{`"count":0`, `"total":0`, `"duration_ms":0`} {
+		if !strings.Contains(got, want) {
+			t.Errorf(`expected %s on zero-result stage_finish; got: %s`, want, got)
+		}
+	}
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, k := range []string{"count", "total", "duration_ms"} {
+		v, ok := evt[k]
+		if !ok {
+			t.Errorf("%q must be present on zero-result stage_finish (#312)", k)
+			continue
+		}
+		if f, isF := v.(float64); !isF || f != 0 {
+			t.Errorf("%q must be 0 on zero-result stage_finish; got %v", k, v)
+		}
+	}
+}
+
+// TestJSONEmitter_ItemFoundOmitsCountField pins the negative half of
+// the #312 contract: numeric fields that belong to service_finish /
+// stage_finish must NOT appear on item_found, even though
+// MarshalJSON now disables struct-tag omitempty on them.
+func TestJSONEmitter_ItemFoundOmitsCountField(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.ItemFound("sqs", "us-east-1", "aws_sqs_queue", "https://sqs.us-east-1.amazonaws.com/123/q1")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, k := range []string{"count", "total", "duration_ms"} {
+		if _, present := evt[k]; present {
+			t.Errorf("item_found must not carry %q; got: %s", k, got)
+		}
+	}
+}
+
+// TestJSONEmitter_ServiceStartOmitsCountField is the negative pin for
+// service_start: a phase-start event has no count/total/duration yet,
+// and MarshalJSON must not leak zero-valued numeric fields.
+func TestJSONEmitter_ServiceStartOmitsCountField(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.ServiceStart("sqs", "us-east-1")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, k := range []string{"count", "total", "duration_ms"} {
+		if _, present := evt[k]; present {
+			t.Errorf("service_start must not carry %q; got: %s", k, got)
+		}
+	}
+}
+
+// TestJSONEmitter_GCPLocationFieldUsed exercises the Region vs Location
+// branch in MarshalJSON: when an Event has Location set (GCP
+// discoverers), the wire shape must emit `"location":...` and never
+// `"region":...`. The public Emitter API on JSONEmitter only takes a
+// `region` parameter, so we construct the Event directly and call
+// json.Marshal — the same path the writer uses internally.
+func TestJSONEmitter_GCPLocationFieldUsed(t *testing.T) {
+	t.Parallel()
+	ts, _ := time.Parse(time.RFC3339Nano, "2026-05-07T12:00:00Z")
+	for _, eventType := range []string{"service_start", "service_finish", "item_found"} {
+		eventType := eventType
+		t.Run(eventType, func(t *testing.T) {
+			t.Parallel()
+			evt := Event{
+				Event:     eventType,
+				Service:   "cloud_asset_inventory",
+				Location:  "us-central1",
+				TFType:    "google_compute_instance",
+				ImportID:  "projects/p/zones/us-central1-a/instances/i",
+				Count:     5,
+				Timestamp: ts,
+			}
+			b, err := json.Marshal(evt)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			s := string(b)
+			if !strings.Contains(s, `"location":"us-central1"`) {
+				t.Errorf(`expected "location":"us-central1" on %s; got: %s`, eventType, s)
+			}
+			if strings.Contains(s, `"region":`) {
+				t.Errorf("Location-set event must not also emit region; got: %s", s)
+			}
+		})
+	}
+}
+
+// TestJSONEmitter_GlobalServiceEmptyRegionShape pins the IAM-style
+// global-service emit shape: when an emitter calls ServiceStart(slug,
+// "") the wire output carries "region":"" rather than dropping the
+// field entirely. This is a deliberate semantic choice (see Event
+// docstring) — the empty string parses identically to "no region
+// scope" downstream, and avoiding a third Marshal branch keeps the
+// dispatch readable.
+func TestJSONEmitter_GlobalServiceEmptyRegionShape(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.ServiceStart("iam", "")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	v, ok := evt["region"]
+	if !ok {
+		t.Errorf("global service ServiceStart must emit region key; got: %s", got)
+	}
+	if s, isS := v.(string); !isS || s != "" {
+		t.Errorf(`region must be "" on global service; got %v`, v)
+	}
+	if _, present := evt["location"]; present {
+		t.Errorf("global service ServiceStart must not emit location; got: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `Event.MarshalJSON` to `cmd/insideout-import/progress/progress.go` that dispatches on `Event` and emits exactly the field set each event type requires.
- Fixes the `omitempty` bug where `service_finish` / `stage_finish` events with zero results dropped `count`, `total`, and `duration_ms` from the wire entirely, forcing SSE consumers to special-case "count missing" vs "count == 0".
- Per-event branches use typed structs so declaration order is preserved on the wire: `event` first, `ts` last, type-specific fields between.
- Region vs Location: prefer `location` when set (GCP discoverers), otherwise emit `region` (AWS + global services like IAM emit `"region":""`).
- Drop the `// TODO(#312)` block from the Event docstring; replace with the new contract.

## Closes / Part of

Closes #312. Stacked on PR #315 (`feat/per-stage-timeouts-311`) → #314 → #313 → main. Bundle 3 / PR 4 of #289 (final).

## Test plan

CI on stacked PRs gates on base merge to main; locally-green is the bar.

- [x] `go build ./...`
- [x] `go test ./cmd/insideout-import/... ./pkg/composer/... ./pkg/insideout-import/... -count=1 -race` — 2071 passed across 13 packages
- [x] `go test ./cmd/insideout-import/progress/... -count=10 -race` — stress run, 160 passed (16 tests x 10 iterations)
- [x] `go vet ./...` clean
- [x] `gofmt -l cmd/ pkg/` empty
- [x] All 8 static lint scripts PASS (`lint-project-tag`, `lint-project-label`, `lint-sensitive-for-each`, `lint-foreach-unknown-keys`, `lint-no-root-only-blocks`, `lint-shared-no-cloud-providers`, `lint-labelless-name-prefix`, `lint-gcp-project-pin`).
- [x] Existing `TestRunDiscoverWithDeps_ProgressJSONMovesSummaryToStderr` still passes — the `emittingFakeAggregator` fires `StageFinish("discover", 1, 0)` with non-zero count, so behavior is unchanged for the non-zero path.
- [x] New tests cover both halves of the #312 contract:
  - `TestJSONEmitter_ServiceFinishCountZeroEmitted` — headline fix; asserts `"count":0` and `"duration_ms":0` on the wire.
  - `TestJSONEmitter_StageFinishCountZeroEmitted` — same for stage_finish, plus `"total":0`.
  - `TestJSONEmitter_ItemFoundOmitsCountField` / `TestJSONEmitter_ServiceStartOmitsCountField` — negative pins; numeric fields must NOT appear on those event types.
  - `TestJSONEmitter_GCPLocationFieldUsed` — Location branch fires for all three location-bearing event types.
  - `TestJSONEmitter_GlobalServiceEmptyRegionShape` — IAM-style empty region renders as `"region":""`.

## Stacking note

This PR targets `feat/per-stage-timeouts-311`. Once #313/#314/#315 land on main in order, the GitHub Actions CI suite will exercise this PR with a clean diff. Local verification has been run against the stacked tip.

## Wire-format note

`service_finish` and `stage_finish` events now ALWAYS carry `count` and `duration_ms` (and `stage_finish` also carries `total`), even when those values are zero. `item_found` and `service_start` never carry them. This is a deliberate semantic change vs the pre-fix shape; it's the right tradeoff because:

- The downstream SSE consumer in `reliable` has not shipped the discovery-progress UI yet (only the agent-API wiring), so there is no in-the-wild consumer to back-compat against.
- "Always present" is the only contract that lets consumers render "0 of 0" without conditional-absent special cases — which is exactly the misalignment #312 reports.
- Field absence (`undefined` vs `0`) is a subtle JS/TS pitfall the typed-event-record approach in the consumer would otherwise have to guard at every render boundary.

Region selection: if both `Region` and `Location` are populated (shouldn't happen but defensive), `location` wins. If both are empty (global AWS services like IAM that pass `region=""`), the wire emits `"region":""` rather than dropping the key — preserving the previous omitempty-absent shape would require a third Marshal branch and the empty string already parses identically to "no region scope" downstream.