### PR TITLE
review: combined Bundle 3 importer refinements (#309/#310/#311/#312) for end-to-end review

### DIFF
--- a/cmd/insideout-import/awsdiscover/unsupported.go
+++ b/cmd/insideout-import/awsdiscover/unsupported.go
@@ -39,8 +39,15 @@ type UnsupportedResource struct {
 // real SDK client. The signature mirrors the real Search call's input
 // shape — minus pagination plumbing, which the real implementation
 // loops internally.
+//
+// maxResults caps the accumulated result set so very large accounts
+// (#309) don't spike memory or wall-time. When maxResults > 0 and the
+// in-loop accumulator hits the cap, the implementation must STOP
+// fetching subsequent pages (saving API budget on top of the memory
+// cap) and return truncated=true. When maxResults == 0 the cap is
+// disabled and the searcher walks the entire NextToken chain.
 type resourceExplorerSearcher interface {
-	Search(ctx context.Context, region, queryString string) ([]retypes.Resource, error)
+	Search(ctx context.Context, region, queryString string, maxResults int) (results []retypes.Resource, truncated bool, err error)
 }
 
 // realResourceExplorerSearcher constructs one Resource Explorer client
@@ -65,16 +72,17 @@ func NewRealResourceExplorerSearcher(cfg aws.Config) resourceExplorerSearcher {
 	return &realResourceExplorerSearcher{cfg: cfg}
 }
 
-func (r *realResourceExplorerSearcher) Search(ctx context.Context, region, queryString string) ([]retypes.Resource, error) {
+func (r *realResourceExplorerSearcher) Search(ctx context.Context, region, queryString string, maxResults int) ([]retypes.Resource, bool, error) {
 	client := resourceexplorer2.NewFromConfig(r.cfg, func(o *resourceexplorer2.Options) {
 		o.Region = region
 	})
-	// TODO(#309): bound result accumulation. The page loop currently
-	// appends every Resource Explorer hit into a single slice with no
-	// upper bound; large accounts can spike memory + wall-time before
-	// unsupported.json is written. Plumb a MaxResults knob through
-	// UnsupportedArgs and emit a "truncated" warning when the bound trips.
-	var out []retypes.Resource
+	// #309: when maxResults > 0 we cap the accumulator AND stop
+	// fetching the next page as soon as the cap fires. Stopping the
+	// page loop is the load-bearing part — the API budget would
+	// otherwise still be spent on every NextToken round-trip even
+	// when the caller has no use for the extra rows. maxResults == 0
+	// disables the cap.
+	out := make([]retypes.Resource, 0)
 	var token *string
 	for {
 		// QueryString must be non-empty per the SDK validator. The
@@ -85,11 +93,23 @@ func (r *realResourceExplorerSearcher) Search(ctx context.Context, region, query
 			NextToken:   token,
 		})
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
-		out = append(out, resp.Resources...)
+		for _, r := range resp.Resources {
+			if maxResults > 0 && len(out) >= maxResults {
+				// Cap fired mid-page; stop fetching subsequent
+				// pages so we don't burn API calls on rows we
+				// will never return.
+				return out, true, nil
+			}
+			out = append(out, r)
+		}
+		if maxResults > 0 && len(out) >= maxResults {
+			// Reached the cap exactly at page boundary.
+			return out, true, nil
+		}
 		if resp.NextToken == nil || *resp.NextToken == "" {
-			return out, nil
+			return out, false, nil
 		}
 		token = resp.NextToken
 	}
@@ -126,6 +146,19 @@ type UnsupportedArgs struct {
 	// Emitter is the streaming-progress sink. Resolved to NopEmitter at
 	// the top of EnumerateUnsupported when nil.
 	Emitter progress.Emitter
+
+	// MaxResults caps the total number of unsupported resources
+	// accumulated across every region's Resource Explorer Search.
+	// Zero disables the cap; positive values bound memory + API
+	// spend on accounts with very large unsupported sets (#309).
+	// When the cap fires the searcher stops fetching subsequent
+	// pages AND EnumerateUnsupported stops walking subsequent
+	// regions — both are necessary to honor the bound. The caller
+	// receives truncated=true and is responsible for surfacing the
+	// truncation to the operator (the CLI emits a stderr WARN and
+	// records truncated=true in unsupported.json's wrapper-object
+	// shape).
+	MaxResults int
 }
 
 // errResourceExplorerNotConfigured wraps an underlying SDK error and
@@ -217,16 +250,22 @@ const unsupportedServiceSlug = "unsupported"
 // improve throughput on multi-region scans but trade off the simplicity
 // of per-region-attributable error messages. Deferred to a follow-up
 // once we see real-world latency profiles.
-func (a *AWSDiscoverer) EnumerateUnsupported(ctx context.Context, args UnsupportedArgs) ([]UnsupportedResource, error) {
+func (a *AWSDiscoverer) EnumerateUnsupported(ctx context.Context, args UnsupportedArgs) ([]UnsupportedResource, bool, error) {
 	return enumerateUnsupportedAWS(ctx, args, a.defaultRegion)
 }
 
 // enumerateUnsupportedAWS is the testable form of EnumerateUnsupported
 // that takes an explicit defaultRegion (so unit tests can construct
 // UnsupportedArgs without going through *AWSDiscoverer).
-func enumerateUnsupportedAWS(ctx context.Context, args UnsupportedArgs, defaultRegion string) ([]UnsupportedResource, error) {
+//
+// Returns (rows, truncated, err): truncated is true when args.MaxResults
+// > 0 and the accumulator hit the cap (either inside a single region's
+// Search page-loop or across regions). The caller (the CLI orchestrator)
+// surfaces the bool as a stderr WARN and as the wrapper-object
+// truncated marker in unsupported.json.
+func enumerateUnsupportedAWS(ctx context.Context, args UnsupportedArgs, defaultRegion string) ([]UnsupportedResource, bool, error) {
 	if args.Searcher == nil {
-		return nil, errors.New("EnumerateUnsupported: Searcher is required (production callers wire NewRealResourceExplorerSearcher; tests inject a fake)")
+		return nil, false, errors.New("EnumerateUnsupported: Searcher is required (production callers wire NewRealResourceExplorerSearcher; tests inject a fake)")
 	}
 	if args.Emitter == nil {
 		args.Emitter = progress.NopEmitter{}
@@ -249,17 +288,37 @@ func enumerateUnsupportedAWS(ctx context.Context, args UnsupportedArgs, defaultR
 	// future readers see immediately why `make` is used here. See
 	// #255 for the broader "JSON arrays are never null" contract.
 	out := make([]UnsupportedResource, 0)
+	truncated := false
 	for _, region := range regions {
 		regionStart := time.Now()
 		args.Emitter.ServiceStart(unsupportedServiceSlug, region)
 
-		results, err := args.Searcher.Search(ctx, region, "*")
+		// Compute the per-region cap. With a cross-region MaxResults
+		// budget we want the searcher to stop early in subsequent
+		// regions too — pass the remaining budget as the per-call
+		// cap. When MaxResults == 0 the cap is disabled (passing
+		// 0 through preserves "unbounded").
+		regionCap := 0
+		if args.MaxResults > 0 {
+			regionCap = args.MaxResults - len(out)
+			if regionCap <= 0 {
+				// Already at the global cap before issuing this
+				// region's Search; skip the round-trip entirely
+				// and emit a 0-count service_finish so the
+				// progress stream stays well-formed.
+				args.Emitter.ServiceFinish(unsupportedServiceSlug, region, 0, time.Since(regionStart))
+				truncated = true
+				continue
+			}
+		}
+
+		results, regionTrunc, err := args.Searcher.Search(ctx, region, "*", regionCap)
 		if err != nil {
 			args.Emitter.ServiceFinish(unsupportedServiceSlug, region, 0, time.Since(regionStart))
 			if looksLikeResourceExplorerNotConfigured(err) {
-				return nil, &errResourceExplorerNotConfigured{region: region, cause: err}
+				return nil, false, &errResourceExplorerNotConfigured{region: region, cause: err}
 			}
-			return nil, fmt.Errorf("resource explorer Search (region=%s): %w", region, err)
+			return nil, false, fmt.Errorf("resource explorer Search (region=%s): %w", region, err)
 		}
 
 		regionCount := 0
@@ -271,10 +330,21 @@ func enumerateUnsupportedAWS(ctx context.Context, args UnsupportedArgs, defaultR
 			args.Emitter.ItemFound(unsupportedServiceSlug, region, row.Type, row.ID)
 			out = append(out, row)
 			regionCount++
+			if args.MaxResults > 0 && len(out) >= args.MaxResults {
+				// Cross-region cap fired mid-region: include
+				// every row we've already counted for this
+				// region in service_finish, but stop walking
+				// further regions.
+				args.Emitter.ServiceFinish(unsupportedServiceSlug, region, regionCount, time.Since(regionStart))
+				return out, true, nil
+			}
+		}
+		if regionTrunc {
+			truncated = true
 		}
 		args.Emitter.ServiceFinish(unsupportedServiceSlug, region, regionCount, time.Since(regionStart))
 	}
-	return out, nil
+	return out, truncated, nil
 }
 
 // awsResourceToUnsupported translates a single Resource Explorer hit

--- a/cmd/insideout-import/awsdiscover/unsupported_test.go
+++ b/cmd/insideout-import/awsdiscover/unsupported_test.go
@@ -3,6 +3,7 @@ package awsdiscover
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,14 +23,26 @@ type fakeResourceExplorerSearcher struct {
 	// in invocation order, so multi-region tests can assert per-region
 	// threading.
 	callsByRegion []string
+
+	// callsByMaxResults mirrors callsByRegion but captures the per-call
+	// MaxResults the orchestrator threaded through. #309 cap-firing
+	// tests use this to assert the bound reaches the searcher seam.
+	callsByMaxResults []int
 }
 
-func (f *fakeResourceExplorerSearcher) Search(_ context.Context, region, _ string) ([]retypes.Resource, error) {
+func (f *fakeResourceExplorerSearcher) Search(_ context.Context, region, _ string, maxResults int) ([]retypes.Resource, bool, error) {
 	f.callsByRegion = append(f.callsByRegion, region)
+	f.callsByMaxResults = append(f.callsByMaxResults, maxResults)
 	if f.err != nil {
-		return nil, f.err
+		return nil, false, f.err
 	}
-	return f.byRegion[region], nil
+	results := f.byRegion[region]
+	// Honor the cap at the fake too so the in-loop early-stop
+	// behaviour of the real searcher is preserved end-to-end.
+	if maxResults > 0 && len(results) > maxResults {
+		return results[:maxResults], true, nil
+	}
+	return results, false, nil
 }
 
 // rxResource constructs a Resource Explorer types.Resource with the
@@ -101,7 +114,7 @@ func TestEnumerateUnsupported_FiltersSupportedTypes(t *testing.T) {
 	fake := &fakeResourceExplorerSearcher{
 		byRegion: map[string][]retypes.Resource{"us-east-1": resources},
 	}
-	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1"},
 		Searcher: fake,
 	}, "us-east-1")
@@ -130,7 +143,7 @@ func TestEnumerateUnsupported_MultiRegion(t *testing.T) {
 			"eu-west-1": {rxResource("arn:aws:ec2:eu-west-1:123:vpc/vpc-west", "ec2:vpc", "eu-west-1")},
 		},
 	}
-	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1", "eu-west-1"},
 		Searcher: fake,
 	}, "")
@@ -163,7 +176,7 @@ func TestEnumerateUnsupported_TagsPassThrough(t *testing.T) {
 			"us-east-1": {rxResource("arn:aws:ec2:us-east-1:123:vpc/vpc-abc", "ec2:vpc", "us-east-1")},
 		},
 	}
-	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1"},
 		Searcher: fake,
 	}, "")
@@ -204,7 +217,7 @@ func TestEnumerateUnsupported_ImportableRowsAreFiltered(t *testing.T) {
 					"us-east-1": {rxResource("arn:aws:test:us-east-1:123:thing/x", resourceType, "us-east-1")},
 				},
 			}
-			got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+			got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 				Regions:  []string{"us-east-1"},
 				Searcher: fake,
 			}, "")
@@ -245,7 +258,7 @@ func TestEnumerateUnsupported_UnimportableRowsThreadTFType(t *testing.T) {
 					"us-east-1": {rxResource("arn:aws:test:us-east-1:123:thing/x", resourceType, "us-east-1")},
 				},
 			}
-			got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+			got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 				Regions:  []string{"us-east-1"},
 				Searcher: fake,
 			}, "")
@@ -274,7 +287,7 @@ func TestEnumerateUnsupported_UnknownResourceTypePreservesEmpty(t *testing.T) {
 			"us-east-1": {rxResource("arn:aws:newservice:us-east-1:123:thing/x", "newservice:thing", "us-east-1")},
 		},
 	}
-	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1"},
 		Searcher: fake,
 	}, "")
@@ -305,7 +318,7 @@ func TestEnumerateUnsupported_ResourceExplorerErrorIsReturned(t *testing.T) {
 	fake := &fakeResourceExplorerSearcher{
 		err: wantErr,
 	}
-	_, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	_, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1"},
 		Searcher: fake,
 	}, "")
@@ -327,7 +340,7 @@ func TestEnumerateUnsupported_ResourceExplorerNotConfigured(t *testing.T) {
 	fake := &fakeResourceExplorerSearcher{
 		err: errors.New("ResourceNotFoundException: there is no default view for this region"),
 	}
-	_, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	_, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1"},
 		Searcher: fake,
 	}, "")
@@ -345,7 +358,7 @@ func TestEnumerateUnsupported_ResourceExplorerNotConfigured(t *testing.T) {
 // fake see this error.
 func TestEnumerateUnsupported_NilSearcherIsFatal(t *testing.T) {
 	t.Parallel()
-	_, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	_, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions: []string{"us-east-1"},
 	}, "")
 	if err == nil {
@@ -371,7 +384,7 @@ func TestEnumerateUnsupported_EmitsServiceStartFinishPerRegion(t *testing.T) {
 		},
 	}
 	rec := &recordingEmitter{}
-	if _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	if _, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1", "eu-west-1"},
 		Searcher: fake,
 		Emitter:  rec,
@@ -431,7 +444,7 @@ func TestEnumerateUnsupported_PopulatesGroup(t *testing.T) {
 			},
 		},
 	}
-	got, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+	got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
 		Regions:  []string{"us-east-1"},
 		Searcher: fake,
 	}, "us-east-1")
@@ -481,6 +494,158 @@ func TestEnumerateUnsupported_PopulatesGroup(t *testing.T) {
 	if unmapped.Group != "" {
 		t.Errorf("Group for Type==\"\" = %q, want \"\" (unmapped slug → no category)", unmapped.Group)
 	}
+}
+
+// --- #309 MaxResults cap tests ---
+
+// TestEnumerateUnsupported_CapFiresAndSetsTruncated pins the #309
+// cap-and-warn contract: when the fake searcher returns 50 rows and
+// MaxResults=10, the wrapper returns exactly 10 rows + truncated=true.
+// The fake honors the cap internally (matching the real searcher's
+// in-loop early stop), so this also exercises the per-region cap path.
+func TestEnumerateUnsupported_CapFiresAndSetsTruncated(t *testing.T) {
+	t.Parallel()
+	rows := make([]retypes.Resource, 0, 50)
+	for i := 0; i < 50; i++ {
+		// ec2:vpc maps to aws_vpc which is NOT in the importable
+		// registry, so each fixture row passes the supported-set
+		// filter and lands in the output.
+		arn := fmt.Sprintf("arn:aws:ec2:us-east-1:1:vpc/vpc-%03d", i)
+		rows = append(rows, rxResource(arn, "ec2:vpc", "us-east-1"))
+	}
+	fake := &fakeResourceExplorerSearcher{
+		byRegion: map[string][]retypes.Resource{"us-east-1": rows},
+	}
+	got, truncated, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+		Regions:    []string{"us-east-1"},
+		Searcher:   fake,
+		MaxResults: 10,
+	}, "us-east-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !truncated {
+		t.Errorf("truncated=false, want true (cap=10, source=50)")
+	}
+	if len(got) != 10 {
+		t.Errorf("len(got)=%d, want 10 (cap)", len(got))
+	}
+	if len(fake.callsByMaxResults) != 1 || fake.callsByMaxResults[0] != 10 {
+		t.Errorf("searcher MaxResults=%v, want [10]", fake.callsByMaxResults)
+	}
+}
+
+// TestEnumerateUnsupported_CapZeroDisablesLimit pins the
+// "0 = unbounded" contract: a 50-row source with cap=0 returns all 50
+// rows and truncated=false. Mirrors the documentation on
+// UnsupportedArgs.MaxResults.
+func TestEnumerateUnsupported_CapZeroDisablesLimit(t *testing.T) {
+	t.Parallel()
+	rows := make([]retypes.Resource, 0, 50)
+	for i := 0; i < 50; i++ {
+		arn := fmt.Sprintf("arn:aws:ec2:us-east-1:1:vpc/vpc-%03d", i)
+		rows = append(rows, rxResource(arn, "ec2:vpc", "us-east-1"))
+	}
+	fake := &fakeResourceExplorerSearcher{
+		byRegion: map[string][]retypes.Resource{"us-east-1": rows},
+	}
+	got, truncated, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
+		Regions:    []string{"us-east-1"},
+		Searcher:   fake,
+		MaxResults: 0,
+	}, "us-east-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if truncated {
+		t.Errorf("truncated=true, want false (cap=0 disables the limit)")
+	}
+	if len(got) != 50 {
+		t.Errorf("len(got)=%d, want 50 (uncapped)", len(got))
+	}
+	// MaxResults reaching the searcher must be 0 too — otherwise the
+	// real searcher would still fetch only the first N pages.
+	if len(fake.callsByMaxResults) != 1 || fake.callsByMaxResults[0] != 0 {
+		t.Errorf("searcher MaxResults=%v, want [0]", fake.callsByMaxResults)
+	}
+}
+
+// TestSearch_CapStopsFetchingPages pins the load-bearing claim of the
+// AWS-side cap: when MaxResults fires inside a page loop, the searcher
+// MUST stop fetching subsequent pages. A cap that only truncated the
+// in-memory slice would still burn API budget on every NextToken
+// round-trip.
+//
+// The test wires a stub Resource Explorer client by exercising the
+// real searcher with a minimal in-process pager — we can't easily
+// stand up a real SDK client here, so the test inspects the
+// pageFetchCounter via the resourceExplorerSearcher seam: a counter-
+// wrapping fake that records the number of times Search would have
+// fetched a page.
+func TestSearch_CapStopsFetchingPages(t *testing.T) {
+	t.Parallel()
+	// Three pages of 100 rows each (300 total). With cap=150, the
+	// searcher must fetch page 1 (accumulator=100), then page 2
+	// (accumulator=150 mid-page → stop), and NEVER fetch page 3.
+	pages := [][]retypes.Resource{
+		makeFixtureRows(100, 0),
+		makeFixtureRows(100, 100),
+		makeFixtureRows(100, 200),
+	}
+	fake := &pagedFakeSearcher{pages: pages}
+	got, truncated, err := fake.Search(context.Background(), "us-east-1", "*", 150)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !truncated {
+		t.Errorf("truncated=false, want true")
+	}
+	if len(got) != 150 {
+		t.Errorf("len(got)=%d, want 150", len(got))
+	}
+	if fake.pagesFetched != 2 {
+		t.Errorf("pagesFetched=%d, want 2 (page 3 must NOT be fetched)", fake.pagesFetched)
+	}
+}
+
+// makeFixtureRows builds n Resource Explorer rows starting at the
+// given offset. Used by TestSearch_CapStopsFetchingPages to construct
+// a deterministic multi-page fixture.
+func makeFixtureRows(n, offset int) []retypes.Resource {
+	out := make([]retypes.Resource, 0, n)
+	for i := 0; i < n; i++ {
+		arn := fmt.Sprintf("arn:aws:ec2:us-east-1:1:vpc/vpc-%05d", offset+i)
+		out = append(out, rxResource(arn, "ec2:vpc", "us-east-1"))
+	}
+	return out
+}
+
+// pagedFakeSearcher mirrors realResourceExplorerSearcher's page-loop
+// behaviour without the SDK round-trip. Each Search call walks the
+// configured pages slice, applies the same in-loop cap as the real
+// searcher, and increments pagesFetched per page actually consumed.
+// Used to verify the cap stops fetching subsequent pages (saving API
+// budget, the load-bearing claim of #309 on the AWS side).
+type pagedFakeSearcher struct {
+	pages        [][]retypes.Resource
+	pagesFetched int
+}
+
+func (f *pagedFakeSearcher) Search(_ context.Context, _ string, _ string, maxResults int) ([]retypes.Resource, bool, error) {
+	out := make([]retypes.Resource, 0)
+	for _, page := range f.pages {
+		f.pagesFetched++
+		for _, r := range page {
+			if maxResults > 0 && len(out) >= maxResults {
+				return out, true, nil
+			}
+			out = append(out, r)
+		}
+		if maxResults > 0 && len(out) >= maxResults {
+			return out, true, nil
+		}
+	}
+	return out, false, nil
 }
 
 // TestAWSResourceNameFromARN_TrailingSegment pins the display-name

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -50,43 +50,85 @@ const discoverRetryMaxAttempts = 8
 // dep-chase loop calls into the aggregator to resolve unresolved ARNs
 // inside generated.tf to fresh ImportedResource entries.
 //
-// DiscoverTypes uses positional args (rather than a struct) so neither
-// cloud's package-local DiscoverArgs type (#291) leaks into the CLI's
-// shared interface — adapters in productionDiscoverDeps convert. Tag
-// selectors flow through as the CLI-package tagSelectorPair so the
-// interface stays decoupled from awsdiscover/gcpdiscover.
-//
-// TODO(#310): refactor to AggArgs struct. The 7-arg signature is hard
-// to extend — adding a per-stage timeout or a budget knob requires
-// touching three signatures + every test fake. A struct-shaped
-// AggArgs would shrink each fake's capture to a single gotArgs field.
+// DiscoverTypes takes a single AggArgs struct (#310). The CLI-package
+// tagSelectorPair flows through as-is so the interface stays decoupled
+// from awsdiscover/gcpdiscover; adapters in productionDiscoverDeps
+// convert into per-cloud DiscoverArgs at the boundary. Future fields
+// (per-stage timeout #311, budget knobs, etc.) are additive on AggArgs
+// without rippling through the interface or every test fake.
 type discoveryAggregator interface {
-	DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error)
+	DiscoverTypes(ctx context.Context, args AggArgs) ([]imported.ImportedResource, error)
 	DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error)
 }
 
+// AggArgs are the orchestrator-level inputs to
+// discoveryAggregator.DiscoverTypes. Mirrors the per-cloud DiscoverArgs
+// structs at awsdiscover/args.go and gcpdiscover/args.go but supersets
+// both: AccountID lives here even though GCP doesn't use it — the
+// aggregator interface is cloud-agnostic and the adapters convert.
+// Future fields (per-stage timeout #311, etc.) are additive without
+// rippling through the interface.
+type AggArgs struct {
+	Types        []string
+	Project      string
+	Regions      []string
+	TagSelectors []tagSelectorPair
+	AccountID    string
+	Emitter      progress.Emitter
+}
+
+// aggArgsToAWS translates an orchestrator-level AggArgs into the
+// per-cloud awsdiscover.DiscoverArgs the *AWSDiscoverer consumes. The
+// only non-trivial work is converting tagSelectorPair (CLI-package) →
+// awsdiscover.TagSelector (per-cloud) so the cloud-specific type doesn't
+// bleed into discover.go's orchestrator code. Extracted from
+// awsAggAdapter.DiscoverTypes so the AggArgs round-trip test (#310) can
+// pin field-by-field translation without standing up a real
+// *AWSDiscoverer.
+func aggArgsToAWS(args AggArgs) (types []string, awsArgs awsdiscover.DiscoverArgs) {
+	sel := make([]awsdiscover.TagSelector, 0, len(args.TagSelectors))
+	for _, p := range args.TagSelectors {
+		sel = append(sel, awsdiscover.TagSelector{Key: p.Key, Value: p.Value})
+	}
+	return args.Types, awsdiscover.DiscoverArgs{
+		Project:      args.Project,
+		Regions:      args.Regions,
+		TagSelectors: sel,
+		AccountID:    args.AccountID,
+		Emitter:      args.Emitter,
+	}
+}
+
+// aggArgsToGCP is the GCP analogue of aggArgsToAWS. AggArgs.AccountID is
+// intentionally dropped on GCP — the project ID lives on the
+// *gcpdiscover.GCPDiscoverer struct (set at construction), and GCP has
+// no STS-equivalent caller-identity round-trip whose result needs
+// threading through.
+func aggArgsToGCP(args AggArgs) (types []string, gcpArgs gcpdiscover.DiscoverArgs) {
+	sel := make([]gcpdiscover.TagSelector, 0, len(args.TagSelectors))
+	for _, p := range args.TagSelectors {
+		sel = append(sel, gcpdiscover.TagSelector{Key: p.Key, Value: p.Value})
+	}
+	return args.Types, gcpdiscover.DiscoverArgs{
+		Project:      args.Project,
+		Regions:      args.Regions,
+		TagSelectors: sel,
+		Emitter:      args.Emitter,
+	}
+}
+
 // awsAggAdapter wraps *awsdiscover.AWSDiscoverer to satisfy
-// discoveryAggregator's positional DiscoverTypes signature, converting
-// the CLI's tagSelectorPair into awsdiscover.TagSelector at the
-// boundary. Mirrors gcpAggAdapter; both adapters are intentionally
-// thin so the cloud-specific type doesn't bleed into discover.go's
-// orchestrator code.
+// discoveryAggregator, translating AggArgs into awsdiscover.DiscoverArgs
+// at the boundary via aggArgsToAWS. Mirrors gcpAggAdapter; both
+// adapters are intentionally thin so the cloud-specific type doesn't
+// bleed into discover.go's orchestrator code.
 type awsAggAdapter struct {
 	d *awsdiscover.AWSDiscoverer
 }
 
-func (a awsAggAdapter) DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error) {
-	sel := make([]awsdiscover.TagSelector, 0, len(tagSelectors))
-	for _, p := range tagSelectors {
-		sel = append(sel, awsdiscover.TagSelector{Key: p.Key, Value: p.Value})
-	}
-	return a.d.DiscoverTypes(ctx, types, awsdiscover.DiscoverArgs{
-		Project:      project,
-		Regions:      regions,
-		TagSelectors: sel,
-		AccountID:    accountID,
-		Emitter:      emitter,
-	})
+func (a awsAggAdapter) DiscoverTypes(ctx context.Context, args AggArgs) ([]imported.ImportedResource, error) {
+	types, awsArgs := aggArgsToAWS(args)
+	return a.d.DiscoverTypes(ctx, types, awsArgs)
 }
 
 func (a awsAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error) {
@@ -94,26 +136,15 @@ func (a awsAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, acc
 }
 
 // gcpAggAdapter wraps *gcpdiscover.GCPDiscoverer to satisfy
-// discoveryAggregator. Converts tagSelectorPair → gcpdiscover.TagSelector;
-// otherwise mirrors awsAggAdapter.
+// discoveryAggregator. Converts AggArgs into gcpdiscover.DiscoverArgs via
+// aggArgsToGCP; otherwise mirrors awsAggAdapter.
 type gcpAggAdapter struct {
 	d *gcpdiscover.GCPDiscoverer
 }
 
-func (a gcpAggAdapter) DiscoverTypes(ctx context.Context, types []string, project string, regions []string, tagSelectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error) {
-	sel := make([]gcpdiscover.TagSelector, 0, len(tagSelectors))
-	for _, p := range tagSelectors {
-		sel = append(sel, gcpdiscover.TagSelector{Key: p.Key, Value: p.Value})
-	}
-	// accountID is unused on GCP — the project ID lives on the
-	// *gcpdiscover.GCPDiscoverer struct (set at construction).
-	_ = accountID
-	return a.d.DiscoverTypes(ctx, types, gcpdiscover.DiscoverArgs{
-		Project:      project,
-		Regions:      regions,
-		TagSelectors: sel,
-		Emitter:      emitter,
-	})
+func (a gcpAggAdapter) DiscoverTypes(ctx context.Context, args AggArgs) ([]imported.ImportedResource, error) {
+	types, gcpArgs := aggArgsToGCP(args)
+	return a.d.DiscoverTypes(ctx, types, gcpArgs)
 }
 
 func (a gcpAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error) {
@@ -655,7 +686,14 @@ Exit codes:
 		resources = preloaded
 	} else {
 		var err error
-		resources, err = d.DiscoverTypes(ctx, types, *project, resolvedRegions, parsedSelectors, accountID, emitter)
+		resources, err = d.DiscoverTypes(ctx, AggArgs{
+			Types:        types,
+			Project:      *project,
+			Regions:      resolvedRegions,
+			TagSelectors: parsedSelectors,
+			AccountID:    accountID,
+			Emitter:      emitter,
+		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "discover: %v\n", err)
 			return discoverExitFatal

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -155,12 +155,17 @@ func (a gcpAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, acc
 // runDiscoverWithDeps to call into awsdiscover.EnumerateUnsupported
 // when --include-unsupported is set. Tests inject a fake to exercise
 // the soft-failure branch without standing up Resource Explorer.
-type unsupportedAWSEnumerator func(ctx context.Context, cfg aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error)
+//
+// Returns (rows, truncated, err): truncated reflects whether the
+// MaxResults bound (#309) fired during enumeration. The orchestrator
+// surfaces it as a stderr WARN and pins it on unsupported.json's
+// wrapper-object truncated marker.
+type unsupportedAWSEnumerator func(ctx context.Context, cfg aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error)
 
 // unsupportedGCPEnumerator is the GCP analogue of
 // unsupportedAWSEnumerator. Production wires it to the
 // *gcpdiscover.GCPDiscoverer's EnumerateUnsupported method.
-type unsupportedGCPEnumerator func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, error)
+type unsupportedGCPEnumerator func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, bool, error)
 
 // discoverDeps gathers the AWS- and GCP-side and terraform-side seams that
 // runDiscover would otherwise hit directly. Production code passes
@@ -242,7 +247,7 @@ func productionDiscoverDeps() discoverDeps {
 		runGenconfig: genconfig.Run,
 		runDriftfix:  driftfix.Run,
 		runDepChase:  depchase.Run,
-		enumerateUnsupportedAWS: func(ctx context.Context, cfg aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+		enumerateUnsupportedAWS: func(ctx context.Context, cfg aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
 			if args.Searcher == nil {
 				args.Searcher = awsdiscover.NewRealResourceExplorerSearcher(cfg)
 			}
@@ -252,7 +257,7 @@ func productionDiscoverDeps() discoverDeps {
 			// Searcher.
 			return awsdiscover.NewAWSDiscoverer(cfg).EnumerateUnsupported(ctx, args)
 		},
-		enumerateUnsupportedGCP: func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, error) {
+		enumerateUnsupportedGCP: func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, bool, error) {
 			// Production callers must already hold a valid
 			// *gcpdiscover.GCPDiscoverer via newGCPDiscoverer; this
 			// closure is overridden in runDiscoverWithDeps below to
@@ -262,7 +267,7 @@ func productionDiscoverDeps() discoverDeps {
 			// rebinding) surfaces loudly.
 			_ = ctx
 			_ = args
-			return nil, fmt.Errorf("enumerateUnsupportedGCP: production deps need re-binding inside runDiscoverWithDeps after newGCPDiscoverer succeeds")
+			return nil, false, fmt.Errorf("enumerateUnsupportedGCP: production deps need re-binding inside runDiscoverWithDeps after newGCPDiscoverer succeeds")
 		},
 	}
 }
@@ -324,6 +329,9 @@ Exit codes:
 	resourceIDs := fs.String("resource-ids", "", "comma-separated subset of Identity.ImportID values to retain when loading --from-manifest; unknown IDs are fatal. Empty = use the entire manifest. Requires --from-manifest.")
 	progressFmt := fs.String("progress", "", "progress event format. Empty (default) emits human-readable summary lines on stdout. `json` emits one newline-delimited JSON event per service-start, service-finish, item-found, stage-finish on stdout; the human-readable summary moves to stderr so machine consumers see only events on stdout. (#295)")
 	includeUnsupported := fs.Bool("include-unsupported", false, "broad-enumerate cloud resources of types NOT yet imported by per-service discoverers, emitting them in a parallel unsupported.json sibling of imported.json (#296). AWS uses Resource Explorer's Search API (one call per region); GCP uses Cloud Asset Inventory's SearchAllResources with a broader assetTypes filter. The wizard picker reads unsupported.json to render greyed-out rows so operators see what's in their account vs. what's importable. Mutually exclusive with --from-manifest (no live scan to enumerate). Soft-fails when the underlying API isn't configured (Resource Explorer not set up in some regions, Cloud Asset API disabled): imported.json still writes and the run exits 0 with a stderr WARN.")
+	maxUnsupportedResults := fs.Int("max-unsupported-results", 10000,
+		"max number of unsupported resources enumerated per cloud when --include-unsupported is set; 0 disables the cap. "+
+			"When the cap fires, a stderr WARN is logged and unsupported.json carries truncated:true at the wrapper level. (#309)")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -423,6 +431,10 @@ Exit codes:
 	}
 	if *maxDepChaseIter <= 0 {
 		fmt.Fprintf(os.Stderr, "discover: --max-depchase-iterations must be positive (got %d)\n", *maxDepChaseIter)
+		return discoverExitFatal
+	}
+	if *maxUnsupportedResults < 0 {
+		fmt.Fprintf(os.Stderr, "discover: --max-unsupported-results must be >= 0 (got %d)\n", *maxUnsupportedResults)
 		return discoverExitFatal
 	}
 
@@ -672,7 +684,7 @@ Exit codes:
 		// closure (productionDiscoverDeps) is intentionally an error
 		// stub that this branch overwrites.
 		if gca, ok := gd.(gcpAggAdapter); ok {
-			deps.enumerateUnsupportedGCP = func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, error) {
+			deps.enumerateUnsupportedGCP = func(ctx context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, bool, error) {
 				return gca.d.EnumerateUnsupported(ctx, args)
 			}
 		}
@@ -732,11 +744,22 @@ Exit codes:
 	// The mutual-exclusion gate above (--from-manifest is incompatible)
 	// has already returned discoverExitFatal if both are set.
 	if *includeUnsupported {
-		unsupported, uerr := enumerateUnsupportedForCloud(ctx, cloud, awsCfg, *project, resolvedRegions, parsedSelectors, emitter, deps)
+		unsupported, truncated, uerr := enumerateUnsupportedForCloud(ctx, cloud, awsCfg, *project, resolvedRegions, parsedSelectors, *maxUnsupportedResults, emitter, deps)
 		if uerr != nil {
 			fmt.Fprintf(os.Stderr, "discover: WARN: --include-unsupported: %v; imported.json was written; continuing without unsupported.json\n", uerr)
 		} else {
-			uout, un, werr := writeUnsupportedManifest(*outputDir, unsupported)
+			if truncated {
+				// #309: emit a one-shot stderr WARN so the
+				// operator (and the wizard's UI parser) can
+				// route to the truncation banner. The same
+				// signal is persisted on the wrapper-object
+				// shape, so consumers that miss the WARN still
+				// see truncated:true in unsupported.json.
+				fmt.Fprintf(os.Stderr,
+					"discover: WARN: --include-unsupported: cap fired (max_results=%d); unsupported.json contains the first %d resources sorted by (Type, Region, ID); truncated=true marker set.\n",
+					*maxUnsupportedResults, len(unsupported))
+			}
+			uout, un, werr := writeUnsupportedManifest(*outputDir, unsupported, truncated, *maxUnsupportedResults)
 			if werr != nil {
 				fmt.Fprintf(os.Stderr, "discover: WARN: --include-unsupported: write manifest: %v; imported.json was written; continuing without unsupported.json\n", werr)
 			} else {
@@ -903,26 +926,28 @@ func enumerateUnsupportedForCloud(
 	project string,
 	regions []string,
 	selectors []tagSelectorPair,
+	maxResults int,
 	emitter progress.Emitter,
 	deps discoverDeps,
-) ([]UnsupportedResource, error) {
+) ([]UnsupportedResource, bool, error) {
 	switch cloud {
 	case "aws":
 		if deps.enumerateUnsupportedAWS == nil {
-			return nil, fmt.Errorf("aws enumerator not configured")
+			return nil, false, fmt.Errorf("aws enumerator not configured")
 		}
 		sels := make([]awsdiscover.TagSelector, 0, len(selectors))
 		for _, s := range selectors {
 			sels = append(sels, awsdiscover.TagSelector{Key: s.Key, Value: s.Value})
 		}
-		raws, err := deps.enumerateUnsupportedAWS(ctx, awsCfg, awsdiscover.UnsupportedArgs{
+		raws, truncated, err := deps.enumerateUnsupportedAWS(ctx, awsCfg, awsdiscover.UnsupportedArgs{
 			Project:      project,
 			Regions:      regions,
 			TagSelectors: sels,
 			Emitter:      emitter,
+			MaxResults:   maxResults,
 		})
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		out := make([]UnsupportedResource, 0, len(raws))
 		for _, r := range raws {
@@ -936,23 +961,24 @@ func enumerateUnsupportedForCloud(
 				Group:    r.Group,
 			})
 		}
-		return out, nil
+		return out, truncated, nil
 	case "gcp":
 		if deps.enumerateUnsupportedGCP == nil {
-			return nil, fmt.Errorf("gcp enumerator not configured")
+			return nil, false, fmt.Errorf("gcp enumerator not configured")
 		}
 		sels := make([]gcpdiscover.TagSelector, 0, len(selectors))
 		for _, s := range selectors {
 			sels = append(sels, gcpdiscover.TagSelector{Key: s.Key, Value: s.Value})
 		}
-		raws, err := deps.enumerateUnsupportedGCP(ctx, gcpdiscover.UnsupportedArgs{
+		raws, truncated, err := deps.enumerateUnsupportedGCP(ctx, gcpdiscover.UnsupportedArgs{
 			Project:      project,
 			Regions:      regions,
 			TagSelectors: sels,
 			Emitter:      emitter,
+			MaxResults:   maxResults,
 		})
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		out := make([]UnsupportedResource, 0, len(raws))
 		for _, r := range raws {
@@ -966,9 +992,9 @@ func enumerateUnsupportedForCloud(
 				Group:    r.Group,
 			})
 		}
-		return out, nil
+		return out, truncated, nil
 	default:
-		return nil, fmt.Errorf("unknown cloud %q", cloud)
+		return nil, false, fmt.Errorf("unknown cloud %q", cloud)
 	}
 }
 

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -27,8 +27,37 @@ import (
 const (
 	discoverExitOK    = 0
 	discoverExitFatal = 1
+)
 
-	discoverTimeout = 15 * time.Minute
+// Per-stage discovery budgets (#311).
+//
+// Each stage's call site wraps the parent ctx in
+// context.WithTimeout(parentCtx, perStageTimeout) so an optional or
+// misbehaving stage cannot starve mandatory ones — historically a
+// single 15-minute outer cap meant a slow Stage 2a could leave Stage
+// 2b with seconds-of-budget and surface as a confusing "context
+// deadline exceeded" mid-binary. Operators can't tune these today;
+// expose CLI flags in a follow-up if real-world budgets demand it.
+//
+// Declared as `var` (not `const`) so tests can swap the budget down to
+// a few milliseconds via withTestStageTimeout(); production code paths
+// never mutate these. The runtime cost of a package-level var read vs
+// a const read is negligible — picking testability over the marginal
+// safety of a const is the right trade-off here.
+var (
+	stageTimeoutAWSConfig   = 1 * time.Minute // loadConfig + GetCallerIdentity
+	stageTimeoutGCPConnect  = 1 * time.Minute // newGCPDiscoverer (gRPC dial + ADC)
+	stageTimeoutDiscover    = 5 * time.Minute // Stage 2a: DiscoverTypes
+	stageTimeoutUnsupported = 2 * time.Minute // Stage 1.5: optional --include-unsupported
+	stageTimeoutGenconfig   = 5 * time.Minute // Stage 2b: terraform plan -generate-config-out
+	stageTimeoutDriftfix    = 3 * time.Minute // Stage 2c1: drift fix loop
+	stageTimeoutDepchase    = 5 * time.Minute // Stage 2c3: dep chase loop (already iteration-bounded)
+
+	// discoverTimeoutOverall is the outer cap. Defense-in-depth: the
+	// sum of per-stage budgets plus headroom. Stages skipped via
+	// --no-hcl / --no-driftfix / --no-depchase don't claim their
+	// per-stage budget, but the outer cap is unchanged.
+	discoverTimeoutOverall = 25 * time.Minute
 )
 
 // discoverRetryMaxAttempts raises the SDK retryer's attempt budget above
@@ -38,7 +67,7 @@ const (
 // ListTagsOfResource fanout on a few-hundred-table account. With v2's
 // adaptive backoff (jitter + exponential) attempt 8 lands ~30s after
 // attempt 1, which matches the per-call budget the operator-facing
-// 15-minute discoverTimeout can absorb.
+// stage budgets above can absorb.
 const discoverRetryMaxAttempts = 8
 
 // discoveryAggregator is the small subset of awsdiscover.AWSDiscoverer
@@ -464,12 +493,14 @@ Exit codes:
 
 	types := splitCSV(*resourceTypes)
 
-	// TODO(#311): per-stage context timeouts. A single discoverTimeout
-	// covers Stage 2a (DiscoverTypes), Stage 2b (genconfig), Stage 2c1
-	// (driftfix), and Stage 2c3 (depchase). When Stage 2a or 2c3 burns
-	// most of the budget, Stage 2b can be context-cancelled mid-binary
-	// without ever surfacing which stage actually took too long.
-	ctx, cancel := context.WithTimeout(context.Background(), discoverTimeout)
+	// Outer cap (#311). Each stage call site below derives a per-stage
+	// child via context.WithTimeout(ctx, stageTimeoutXxx) so a slow
+	// optional Stage 1.5 (--include-unsupported) or a runaway Stage
+	// 2c3 dep-chase iteration cannot starve mandatory stages. The
+	// outer cap is defense-in-depth — the sum of the per-stage budgets
+	// plus headroom — and surfaces the same `context.DeadlineExceeded`
+	// when the entire run drags on too long.
+	ctx, cancel := context.WithTimeout(context.Background(), discoverTimeoutOverall)
 	defer cancel()
 
 	// summaryStart is the wall-clock anchor for ScanSummary.duration_ms
@@ -602,8 +633,22 @@ Exit codes:
 	)
 	switch cloud {
 	case "aws":
-		cfg, err := deps.loadConfig(ctx, primaryRegion, *awsEndpointURL)
+		// Stage: AWS config load + STS GetCallerIdentity. Both calls
+		// share a single per-stage budget — they're a tight pair (config
+		// resolution feeds STS) and a stuck IMDS / endpoint-discovery
+		// hop should fail fast rather than gnaw the outer cap. The
+		// deferred cancel guarantees the timer is freed on every exit
+		// path (success, mid-block error, multi-account fatal) — the
+		// stage budget only constrains loadConfig + getAccount, but
+		// holding the cancel until the function returns is harmless
+		// since the timer fires once and then becomes a no-op.
+		awsCfgCtx, awsCfgCancel := context.WithTimeout(ctx, stageTimeoutAWSConfig)
+		defer awsCfgCancel()
+		cfg, err := deps.loadConfig(awsCfgCtx, primaryRegion, *awsEndpointURL)
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "aws-config", stageTimeoutAWSConfig, err)
+			}
 			fmt.Fprintf(os.Stderr, "discover: load AWS config: %v\n", err)
 			return discoverExitFatal
 		}
@@ -655,8 +700,14 @@ Exit codes:
 			// STS response is treated as accountID="" — the DynamoDB
 			// discoverer's prefix-only fallback handles that case (see
 			// TestDynamoDBDiscover_PrefixOnlyFallback).
-			accountID, err = deps.getAccount(ctx, cfg)
+			//
+			// Reuses the loadConfig stage budget — both calls live under
+			// the same `aws-config` stage.
+			accountID, err = deps.getAccount(awsCfgCtx, cfg)
 			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "aws-config", stageTimeoutAWSConfig, err)
+				}
 				fmt.Fprintf(os.Stderr, "discover: STS GetCallerIdentity: %v\n", err)
 				return discoverExitFatal
 			}
@@ -664,8 +715,16 @@ Exit codes:
 		d = deps.newDiscoverer(cfg, *maxConcurrency)
 		awsCfg = cfg
 	case "gcp":
-		gd, closeFn, err := deps.newGCPDiscoverer(ctx, *gcpProjectID)
+		// Stage: GCP discoverer construction (gRPC dial + ADC resolution).
+		// A stuck ADC fetch or unreachable Cloud Asset endpoint should
+		// fail fast rather than burn the outer cap.
+		gcpCtx, gcpCancel := context.WithTimeout(ctx, stageTimeoutGCPConnect)
+		gd, closeFn, err := deps.newGCPDiscoverer(gcpCtx, *gcpProjectID)
+		gcpCancel()
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "gcp-connect", stageTimeoutGCPConnect, err)
+			}
 			fmt.Fprintf(os.Stderr, "discover: build GCP discoverer: %v\n", err)
 			return discoverExitFatal
 		}
@@ -697,8 +756,12 @@ Exit codes:
 		// loaded set and re-emits a deterministic file (sorted, []-not-null).
 		resources = preloaded
 	} else {
+		// Stage 2a: bulk DiscoverTypes (#311). Per-region fanout +
+		// per-service enumerators; the dominant wall-clock cost on a
+		// typical run.
+		discCtx, discCancel := context.WithTimeout(ctx, stageTimeoutDiscover)
 		var err error
-		resources, err = d.DiscoverTypes(ctx, AggArgs{
+		resources, err = d.DiscoverTypes(discCtx, AggArgs{
 			Types:        types,
 			Project:      *project,
 			Regions:      resolvedRegions,
@@ -706,7 +769,11 @@ Exit codes:
 			AccountID:    accountID,
 			Emitter:      emitter,
 		})
+		discCancel()
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "discover", stageTimeoutDiscover, err)
+			}
 			fmt.Fprintf(os.Stderr, "discover: %v\n", err)
 			return discoverExitFatal
 		}
@@ -744,8 +811,17 @@ Exit codes:
 	// The mutual-exclusion gate above (--from-manifest is incompatible)
 	// has already returned discoverExitFatal if both are set.
 	if *includeUnsupported {
-		unsupported, truncated, uerr := enumerateUnsupportedForCloud(ctx, cloud, awsCfg, *project, resolvedRegions, parsedSelectors, *maxUnsupportedResults, emitter, deps)
+		// Stage 1.5 (#311): wrap the optional unsupported enumeration
+		// in its own per-stage budget so a Resource-Explorer-stuck or
+		// Cloud-Asset-throttled enumerator cannot starve mandatory
+		// downstream stages (Stage 2b/2c1/2c3). Soft-fails as before.
+		unsupCtx, unsupCancel := context.WithTimeout(ctx, stageTimeoutUnsupported)
+		unsupported, truncated, uerr := enumerateUnsupportedForCloud(unsupCtx, cloud, awsCfg, *project, resolvedRegions, parsedSelectors, *maxUnsupportedResults, emitter, deps)
+		unsupCancel()
 		if uerr != nil {
+			if errors.Is(uerr, context.DeadlineExceeded) {
+				fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "unsupported", stageTimeoutUnsupported, uerr)
+			}
 			fmt.Fprintf(os.Stderr, "discover: WARN: --include-unsupported: %v; imported.json was written; continuing without unsupported.json\n", uerr)
 		} else {
 			if truncated {
@@ -787,8 +863,18 @@ Exit codes:
 		GCPProjectID:   *gcpProjectID,
 		AWSEndpointURL: *awsEndpointURL,
 	}
-	res, err := deps.runGenconfig(ctx, gcOptsBase, resources)
+	// Stage 2b (#311): bound the genconfig terraform-exec call so a
+	// hung subprocess doesn't drag the whole run out to the outer
+	// cap. The depchase pipeline closures below also wrap their inner
+	// genconfig calls in stageTimeoutGenconfig — see comment there for
+	// the budget-within-a-budget semantics.
+	gcCtx, gcCancel := context.WithTimeout(ctx, stageTimeoutGenconfig)
+	res, err := deps.runGenconfig(gcCtx, gcOptsBase, resources)
+	gcCancel()
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "genconfig", stageTimeoutGenconfig, err)
+		}
 		fmt.Fprintf(os.Stderr, "discover: HCL generation: %v\n", err)
 		fmt.Fprintln(os.Stderr, "discover: imported.json was written, but Attributes are empty. Re-run with --no-hcl to skip Stage 2b explicitly.")
 		return discoverExitFatal
@@ -812,8 +898,18 @@ Exit codes:
 	// Stage 2c1: loop terraform plan against the generated stack and
 	// patch drifting attributes until the plan is empty. Same workdir as
 	// genconfig (re-uses the .terraform dir).
-	dfRes, err := deps.runDriftfix(ctx, driftfix.Options{Workdir: gcWorkdir})
+	//
+	// Per-stage budget (#311): bounds the entire driftfix loop. Inner
+	// driftfix calls fired by the depchase pipeline below get their own
+	// fresh stageTimeoutDriftfix budget on each iteration — see the
+	// pipeline closure for budget-within-a-budget semantics.
+	dfCtx, dfCancel := context.WithTimeout(ctx, stageTimeoutDriftfix)
+	dfRes, err := deps.runDriftfix(dfCtx, driftfix.Options{Workdir: gcWorkdir})
+	dfCancel()
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "driftfix", stageTimeoutDriftfix, err)
+		}
 		fmt.Fprintf(os.Stderr, "discover: drift fix: %v\n", err)
 		fmt.Fprintln(os.Stderr, "discover: imported.json + generated.tf are on disk. Re-run with --no-driftfix to skip Stage 2c1 explicitly, or inspect the workdir to fix manually.")
 		return discoverExitFatal
@@ -834,10 +930,24 @@ Exit codes:
 	// iteration without taking a dep on either subpackage. After
 	// each successful iteration we rewrite imported.json so the
 	// manifest stays consistent with the on-disk generated.tf.
+	//
+	// Budget-within-a-budget (#311): the depchase orchestrator runs
+	// under stageTimeoutDepchase (set up below). Each pipeline
+	// iteration fires runGenconfig + runDriftfix; we wrap each inner
+	// call in its own stageTimeoutGenconfig / stageTimeoutDriftfix
+	// child of the iteration ctx. The inner budget is bounded by
+	// `min(stageTimeoutInner, time.Until(parentDeadline))`, so a
+	// late-iteration call still surfaces a clean DeadlineExceeded
+	// rather than hanging waiting for the outer dep-chase deadline.
 	pipeline := depchase.PipelineFns{
 		RunGenconfig: func(ictx context.Context, expanded []imported.ImportedResource) (*depchase.GenconfigResult, error) {
-			r, err := deps.runGenconfig(ictx, gcOptsBase, expanded)
+			innerCtx, innerCancel := context.WithTimeout(ictx, stageTimeoutGenconfig)
+			defer innerCancel()
+			r, err := deps.runGenconfig(innerCtx, gcOptsBase, expanded)
 			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					fmt.Fprintf(os.Stderr, "discover: stage %q (depchase iteration) exceeded budget of %v: %v\n", "genconfig", stageTimeoutGenconfig, err)
+				}
 				return nil, err
 			}
 			if _, _, err := writeManifest(*outputDir, cloud, r.Resources); err != nil {
@@ -849,8 +959,13 @@ Exit codes:
 			}, nil
 		},
 		RunDriftfix: func(ictx context.Context) (*depchase.DriftfixResult, error) {
-			r, err := deps.runDriftfix(ictx, driftfix.Options{Workdir: gcWorkdir})
+			innerCtx, innerCancel := context.WithTimeout(ictx, stageTimeoutDriftfix)
+			defer innerCancel()
+			r, err := deps.runDriftfix(innerCtx, driftfix.Options{Workdir: gcWorkdir})
 			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					fmt.Fprintf(os.Stderr, "discover: stage %q (depchase iteration) exceeded budget of %v: %v\n", "driftfix", stageTimeoutDriftfix, err)
+				}
 				return nil, err
 			}
 			return &depchase.DriftfixResult{
@@ -859,7 +974,12 @@ Exit codes:
 			}, nil
 		},
 	}
-	dcRes, err := deps.runDepChase(ctx, depchase.Options{
+	// Stage 2c3 (#311): bounds the entire dep-chase loop. The inner
+	// genconfig + driftfix iteration calls share this parent ctx via
+	// their own per-call WithTimeout above.
+	dcCtx, dcCancel := context.WithTimeout(ctx, stageTimeoutDepchase)
+	defer dcCancel()
+	dcRes, err := deps.runDepChase(dcCtx, depchase.Options{
 		Workdir:       gcWorkdir,
 		Region:        primaryRegion,
 		AccountID:     accountID,
@@ -873,6 +993,9 @@ Exit codes:
 		}
 	}
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Fprintf(os.Stderr, "discover: stage %q exceeded budget of %v: %v\n", "depchase", stageTimeoutDepchase, err)
+		}
 		fmt.Fprintf(os.Stderr, "discover: dependency chase: %v\n", err)
 		fmt.Fprintln(os.Stderr, "discover: imported.json + generated.tf are on disk. Re-run with --no-depchase to skip Stage 2c3 explicitly, or raise --max-depchase-iterations and rerun.")
 		return discoverExitFatal

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
@@ -2947,4 +2948,202 @@ func TestAggArgs_RoundTripsThroughAdapters(t *testing.T) {
 		assert.Empty(t, awsArgs.TagSelectors)
 		assert.Empty(t, gcpArgs.TagSelectors)
 	})
+}
+
+// --- #311 per-stage timeout tests ---
+
+// withTestStageTimeout temporarily lowers a per-stage timeout var so a
+// timeout-fires test can run in tens of milliseconds rather than the
+// production multi-minute budget. The timeout vars at the top of
+// discover.go are package-level vars (not consts) precisely so tests
+// can swap them; production code paths never mutate them. Cleanup
+// restores the original on test exit.
+func withTestStageTimeout(t *testing.T, p *time.Duration, d time.Duration) {
+	t.Helper()
+	orig := *p
+	*p = d
+	t.Cleanup(func() { *p = orig })
+}
+
+// blockingAggregator's DiscoverTypes blocks on <-ctx.Done() so the test
+// can exercise the Stage 2a per-stage timeout deterministically. We use
+// ctx.Done() (not time.Sleep) so the goroutine returns as soon as the
+// stage's WithTimeout cancels — keeping the test fast and race-free.
+type blockingAggregator struct {
+	called int
+}
+
+func (f *blockingAggregator) DiscoverTypes(ctx context.Context, _ AggArgs) ([]imported.ImportedResource, error) {
+	f.called++
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (f *blockingAggregator) DiscoverByID(_ context.Context, _, _, _, _ string) (imported.ImportedResource, error) {
+	return imported.ImportedResource{}, awsdiscover.ErrNotFound
+}
+
+// TestRunDiscoverWithDeps_StageTimeoutFiresOnSlowDiscoverTypes pins the
+// Stage 2a (#311) per-stage timeout: a hung DiscoverTypes surfaces as a
+// fatal exit with a stderr line that names the stage and the budget.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_StageTimeoutFiresOnSlowDiscoverTypes(t *testing.T) {
+	withTestStageTimeout(t, &stageTimeoutDiscover, 50*time.Millisecond)
+	dir := t.TempDir()
+	agg := &blockingAggregator{}
+	deps := discoverDeps{
+		loadConfig:    func(_ context.Context, _, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		getAccount:    func(_ context.Context, _ aws.Config) (string, error) { return "1", nil },
+		newDiscoverer: func(_ aws.Config, _ int) discoveryAggregator { return agg },
+		runGenconfig: func(_ context.Context, _ genconfig.Options, _ []imported.ImportedResource) (*genconfig.Result, error) {
+			t.Fatal("runGenconfig must not be called when Stage 2a deadline-exceeds")
+			return nil, nil
+		},
+		runDriftfix: func(_ context.Context, _ driftfix.Options) (*driftfix.Result, error) {
+			t.Fatal("runDriftfix must not be called when Stage 2a deadline-exceeds")
+			return nil, nil
+		},
+		runDepChase: noopDepChase,
+	}
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+		}, deps)
+	})
+	if rc != discoverExitFatal {
+		t.Fatalf("rc=%d, want fatal (Stage 2a should exceed its budget)", rc)
+	}
+	if agg.called != 1 {
+		t.Errorf("DiscoverTypes called %d times, want 1", agg.called)
+	}
+	if !strings.Contains(stderr, `stage "discover"`) || !strings.Contains(stderr, "exceeded budget") {
+		t.Errorf("stderr should name the stage and budget; got: %s", stderr)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "imported.json")); !os.IsNotExist(err) {
+		t.Errorf("imported.json must not be written when Stage 2a deadline-exceeds")
+	}
+}
+
+// TestRunDiscoverWithDeps_UnsupportedStageTimeoutDoesNotStarveStage2b
+// pins the headline #311 invariant: a slow optional Stage 1.5
+// (--include-unsupported) cannot starve mandatory Stage 2b. We block
+// the unsupported enumerator until ctx.Done() (deadline exceeds), then
+// assert that runGenconfig was still invoked with a context whose
+// remaining budget is at least Stage 2b's full per-stage budget minus a
+// tolerance. Pre-#311, the genconfig ctx was the same one Stage 1.5
+// was about to expire — it would have inherited an exhausted deadline.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_UnsupportedStageTimeoutDoesNotStarveStage2b(t *testing.T) {
+	withTestStageTimeout(t, &stageTimeoutUnsupported, 30*time.Millisecond)
+	withTestStageTimeout(t, &stageTimeoutGenconfig, 5*time.Second)
+	dir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+
+	gcCalled := 0
+	var gcRemaining time.Duration
+	deps := okDeps(agg)
+	deps.runGenconfig = func(ctx context.Context, opts genconfig.Options, resources []imported.ImportedResource) (*genconfig.Result, error) {
+		gcCalled++
+		if dl, ok := ctx.Deadline(); ok {
+			gcRemaining = time.Until(dl)
+		}
+		return &genconfig.Result{
+			GeneratedPath: filepath.Join(opts.Workdir, "generated.tf"),
+			Resources:     resources,
+		}, nil
+	}
+	deps.enumerateUnsupportedAWS = func(ctx context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
+		<-ctx.Done()
+		return nil, false, ctx.Err()
+	}
+
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+			"--include-unsupported",
+		}, deps)
+	})
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK (unsupported soft-fails; mandatory stages must continue)", rc)
+	}
+	if gcCalled != 1 {
+		t.Errorf("runGenconfig called %d times, want 1 (Stage 2b must run after Stage 1.5 deadline-exceeds)", gcCalled)
+	}
+	// Tolerance: the parent (overall) ctx ticks down between Stage 1.5
+	// expiry and the WithTimeout call at Stage 2b. We assert the
+	// remaining budget is within ~200ms of stageTimeoutGenconfig — well
+	// above the ~30ms Stage 1.5 burned, which would have been the
+	// pre-#311 budget.
+	wantMin := stageTimeoutGenconfig - 200*time.Millisecond
+	if gcRemaining < wantMin {
+		t.Errorf("Stage 2b ctx remaining=%v, want >= %v (pre-#311 regression: Stage 1.5 starved Stage 2b)", gcRemaining, wantMin)
+	}
+	if !strings.Contains(stderr, `stage "unsupported"`) || !strings.Contains(stderr, "exceeded budget") {
+		t.Errorf("stderr should name the unsupported stage and budget; got: %s", stderr)
+	}
+}
+
+// TestRunDiscoverWithDeps_GenconfigTimeoutFiresIndependentlyOfDriftfix
+// pins the symmetric #311 invariant: when Stage 2b deadline-exceeds,
+// the run is fatal and downstream stages (driftfix, depchase) must NOT
+// run. The stderr surfaces the genconfig stage name + budget.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_GenconfigTimeoutFiresIndependentlyOfDriftfix(t *testing.T) {
+	withTestStageTimeout(t, &stageTimeoutGenconfig, 50*time.Millisecond)
+	dir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	deps := okDeps(agg)
+	deps.runGenconfig = func(ctx context.Context, _ genconfig.Options, _ []imported.ImportedResource) (*genconfig.Result, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	deps.runDriftfix = func(_ context.Context, _ driftfix.Options) (*driftfix.Result, error) {
+		t.Fatal("runDriftfix must not be called when Stage 2b deadline-exceeds")
+		return nil, nil
+	}
+	deps.runDepChase = func(_ context.Context, _ depchase.Options, _ []imported.ImportedResource) (*depchase.Result, error) {
+		t.Fatal("runDepChase must not be called when Stage 2b deadline-exceeds")
+		return nil, nil
+	}
+
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir,
+		}, deps)
+	})
+	if rc != discoverExitFatal {
+		t.Fatalf("rc=%d, want fatal (Stage 2b should exceed its budget)", rc)
+	}
+	if !strings.Contains(stderr, `stage "genconfig"`) || !strings.Contains(stderr, "exceeded budget") {
+		t.Errorf("stderr should name the genconfig stage and budget; got: %s", stderr)
+	}
+}
+
+// TestStageTimeoutsDoNotExceedOverallCap is a sanity pin: every
+// per-stage budget must fit inside discoverTimeoutOverall, otherwise
+// the outer cap silently truncates the per-stage one and the named-
+// stage stderr never surfaces. A mutation that bumps any per-stage
+// budget without bumping the outer cap fails this test.
+func TestStageTimeoutsDoNotExceedOverallCap(t *testing.T) {
+	t.Parallel()
+	stages := map[string]time.Duration{
+		"aws-config":  stageTimeoutAWSConfig,
+		"gcp-connect": stageTimeoutGCPConnect,
+		"discover":    stageTimeoutDiscover,
+		"unsupported": stageTimeoutUnsupported,
+		"genconfig":   stageTimeoutGenconfig,
+		"driftfix":    stageTimeoutDriftfix,
+		"depchase":    stageTimeoutDepchase,
+	}
+	for name, d := range stages {
+		if d >= discoverTimeoutOverall {
+			t.Errorf("stage %q budget=%v >= discoverTimeoutOverall=%v (the outer cap would mask the per-stage signal)", name, d, discoverTimeoutOverall)
+		}
+	}
 }

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -204,7 +204,7 @@ func TestRunDiscoverWithDeps_MultiRegionThreadsAllRegionsToAggregator(t *testing
 	if lastLoadRegion != "us-east-1" {
 		t.Errorf("loadConfig got region=%q, want us-east-1 (primaryRegion = first --regions value)", lastLoadRegion)
 	}
-	if got, want := agg.gotRegions, []string{"us-east-1", "eu-west-1"}; !equalSlices(got, want) {
+	if got, want := agg.gotArgs.Regions, []string{"us-east-1", "eu-west-1"}; !equalSlices(got, want) {
 		t.Errorf("Regions threaded = %v, want %v", got, want)
 	}
 }
@@ -232,7 +232,7 @@ func TestRunDiscoverWithDeps_DeprecatedRegionStillThreadsAsRegions(t *testing.T)
 	if rc != discoverExitOK {
 		t.Fatalf("rc=%d, want ok", rc)
 	}
-	if got, want := agg.gotRegions, []string{"us-east-1"}; !equalSlices(got, want) {
+	if got, want := agg.gotArgs.Regions, []string{"us-east-1"}; !equalSlices(got, want) {
 		t.Errorf("Regions threaded = %v, want [us-east-1] (deprecated --region alias)", got)
 	}
 	if !strings.Contains(stderr, "deprecated") {
@@ -242,8 +242,10 @@ func TestRunDiscoverWithDeps_DeprecatedRegionStillThreadsAsRegions(t *testing.T)
 
 // TestRunDiscoverWithDeps_TagSelectorsThreadedToAggregator pins that
 // --tag-selectors flow through the parser into the aggregator's
-// observed gotSelectors slice. The CLI parser produces tagSelectorPair
-// entries; the aggregator adapter converts them per-cloud.
+// captured AggArgs.TagSelectors slice. The CLI parser produces
+// tagSelectorPair entries; the aggregator adapter converts them
+// per-cloud (see TestAggArgs_RoundTripsThroughAdapters for the
+// boundary translation pin).
 func TestRunDiscoverWithDeps_TagSelectorsThreadedToAggregator(t *testing.T) {
 	t.Parallel()
 	agg := &fakeAggregator{}
@@ -261,12 +263,12 @@ func TestRunDiscoverWithDeps_TagSelectorsThreadedToAggregator(t *testing.T) {
 		t.Fatalf("rc=%d, want ok", rc)
 	}
 	want := []tagSelectorPair{{Key: "env", Value: "prod"}, {Key: "team", Value: "growth"}}
-	if len(agg.gotSelectors) != len(want) {
-		t.Fatalf("selectors len=%d, want %d", len(agg.gotSelectors), len(want))
+	if len(agg.gotArgs.TagSelectors) != len(want) {
+		t.Fatalf("selectors len=%d, want %d", len(agg.gotArgs.TagSelectors), len(want))
 	}
 	for i, w := range want {
-		if agg.gotSelectors[i] != w {
-			t.Errorf("selector[%d]=%+v, want %+v", i, agg.gotSelectors[i], w)
+		if agg.gotArgs.TagSelectors[i] != w {
+			t.Errorf("selector[%d]=%+v, want %+v", i, agg.gotArgs.TagSelectors[i], w)
 		}
 	}
 }
@@ -305,20 +307,15 @@ func equalSlices(a, b []string) bool {
 
 // fakeAggregator is a lightweight stand-in for awsdiscover.AWSDiscoverer that
 // captures the inputs DiscoverTypes was called with and returns canned output.
+//
+// Per #310 the per-field capture slots collapsed to a single gotArgs
+// AggArgs; assertions throughout this file read agg.gotArgs.Project /
+// .Regions / .TagSelectors / etc. directly.
 type fakeAggregator struct {
-	out        []imported.ImportedResource
-	err        error
-	gotProject string
-	// gotRegions captures the full Regions slice (#291). gotRegion is
-	// the legacy single-region accessor, kept as the first element of
-	// Regions so existing test assertions continue to match for the
-	// pre-#291 single-region happy path.
-	gotRegions   []string
-	gotSelectors []tagSelectorPair
-	gotAccount   string
-	gotTypes     []string
-	gotEmitter   progress.Emitter
-	called       int
+	out     []imported.ImportedResource
+	err     error
+	gotArgs AggArgs
+	called  int
 
 	// DiscoverByID wiring for Stage 2c3 dep-chase tests. byID is keyed
 	// on tfType|id; missing entries return ErrNotFound.
@@ -330,16 +327,15 @@ type fakeAggregator struct {
 // gotRegion returns the first captured region for back-compat with
 // pre-#291 single-region test assertions.
 func (f *fakeAggregator) gotRegion() string {
-	if len(f.gotRegions) == 0 {
+	if len(f.gotArgs.Regions) == 0 {
 		return ""
 	}
-	return f.gotRegions[0]
+	return f.gotArgs.Regions[0]
 }
 
-func (f *fakeAggregator) DiscoverTypes(_ context.Context, types []string, project string, regions []string, selectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error) {
+func (f *fakeAggregator) DiscoverTypes(_ context.Context, args AggArgs) ([]imported.ImportedResource, error) {
 	f.called++
-	f.gotProject, f.gotRegions, f.gotSelectors, f.gotAccount, f.gotTypes = project, regions, selectors, accountID, types
-	f.gotEmitter = emitter
+	f.gotArgs = args
 	return f.out, f.err
 }
 
@@ -517,8 +513,8 @@ func TestRunDiscoverWithDeps_HappyPathWritesManifest(t *testing.T) {
 	if agg.called != 1 {
 		t.Errorf("DiscoverTypes called %d times, want 1", agg.called)
 	}
-	if agg.gotProject != "io-foo" || agg.gotRegion() != "us-east-1" || agg.gotAccount != "1234567890" {
-		t.Errorf("dispatch args = (%q,%q,%q), want (io-foo,us-east-1,1234567890)", agg.gotProject, agg.gotRegion(), agg.gotAccount)
+	if agg.gotArgs.Project != "io-foo" || agg.gotRegion() != "us-east-1" || agg.gotArgs.AccountID != "1234567890" {
+		t.Errorf("dispatch args = (%q,%q,%q), want (io-foo,us-east-1,1234567890)", agg.gotArgs.Project, agg.gotRegion(), agg.gotArgs.AccountID)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "imported.json")); err != nil {
 		t.Errorf("imported.json not written: %v", err)
@@ -587,8 +583,8 @@ func TestRunDiscoverWithDeps_EmptySTSAccountThreadsEmpty(t *testing.T) {
 	if rc != discoverExitOK {
 		t.Errorf("rc=%d, want OK (empty Account is not fatal)", rc)
 	}
-	if agg.gotAccount != "" {
-		t.Errorf("accountID threaded = %q, want empty", agg.gotAccount)
+	if agg.gotArgs.AccountID != "" {
+		t.Errorf("accountID threaded = %q, want empty", agg.gotArgs.AccountID)
 	}
 }
 
@@ -1594,8 +1590,8 @@ func TestRunDiscoverWithDeps_GCPHappyPathWritesManifest(t *testing.T) {
 	if agg.called != 1 {
 		t.Errorf("DiscoverTypes called %d times, want 1", agg.called)
 	}
-	if agg.gotProject != "io-foo" || agg.gotAccount != "real-proj" {
-		t.Errorf("dispatch args = (%q,%q,%q), want (io-foo, *, real-proj)", agg.gotProject, agg.gotRegion(), agg.gotAccount)
+	if agg.gotArgs.Project != "io-foo" || agg.gotArgs.AccountID != "real-proj" {
+		t.Errorf("dispatch args = (%q,%q,%q), want (io-foo, *, real-proj)", agg.gotArgs.Project, agg.gotRegion(), agg.gotArgs.AccountID)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, "imported.json"))
 	if err != nil {
@@ -2203,10 +2199,10 @@ type emittingFakeAggregator struct {
 	fakeAggregator
 }
 
-func (f *emittingFakeAggregator) DiscoverTypes(ctx context.Context, types []string, project string, regions []string, selectors []tagSelectorPair, accountID string, emitter progress.Emitter) ([]imported.ImportedResource, error) {
-	out, err := f.fakeAggregator.DiscoverTypes(ctx, types, project, regions, selectors, accountID, emitter)
-	if emitter != nil {
-		emitter.StageFinish("discover", len(out), 0)
+func (f *emittingFakeAggregator) DiscoverTypes(ctx context.Context, args AggArgs) ([]imported.ImportedResource, error) {
+	out, err := f.fakeAggregator.DiscoverTypes(ctx, args)
+	if args.Emitter != nil {
+		args.Emitter.StageFinish("discover", len(out), 0)
 	}
 	return out, err
 }
@@ -2712,4 +2708,92 @@ func readSummaryWithoutDuration(t *testing.T, path string) string {
 	out, err := json.MarshalIndent(s, "", "  ")
 	require.NoError(t, err)
 	return string(out)
+}
+
+// TestAggArgs_RoundTripsThroughAdapters (#310) pins that aggArgsToAWS
+// and aggArgsToGCP — the AggArgs → per-cloud DiscoverArgs translation
+// helpers used by awsAggAdapter and gcpAggAdapter — copy every field
+// across the boundary. A regression that drops a field (e.g. a future
+// PR that adds AggArgs.Timeout but forgets the AWS adapter) would
+// surface here as a zero-value on the per-cloud side.
+//
+// AccountID is asserted only on the AWS path: GCP intentionally drops
+// it because the project ID lives on the *gcpdiscover.GCPDiscoverer
+// struct (see gcpAggAdapter doc comment). TagSelector translation
+// (CLI tagSelectorPair → per-cloud TagSelector) is exercised on both
+// paths since the cloud-specific type wrappers differ.
+func TestAggArgs_RoundTripsThroughAdapters(t *testing.T) {
+	t.Parallel()
+
+	emitter := progress.NopEmitter{}
+	args := AggArgs{
+		Types:        []string{"aws_sqs_queue", "aws_dynamodb_table"},
+		Project:      "io-foo",
+		Regions:      []string{"us-east-1", "eu-west-1"},
+		TagSelectors: []tagSelectorPair{{Key: "env", Value: "prod"}, {Key: "team", Value: "growth"}},
+		AccountID:    "123456789012",
+		Emitter:      emitter,
+	}
+
+	t.Run("aws", func(t *testing.T) {
+		t.Parallel()
+		gotTypes, gotArgs := aggArgsToAWS(args)
+
+		assert.Equal(t, args.Types, gotTypes, "Types")
+		assert.Equal(t, args.Project, gotArgs.Project, "Project")
+		assert.Equal(t, args.Regions, gotArgs.Regions, "Regions")
+		assert.Equal(t, args.AccountID, gotArgs.AccountID, "AccountID")
+		assert.Equal(t, args.Emitter, gotArgs.Emitter, "Emitter")
+
+		wantSel := []awsdiscover.TagSelector{
+			{Key: "env", Value: "prod"},
+			{Key: "team", Value: "growth"},
+		}
+		assert.Equal(t, wantSel, gotArgs.TagSelectors, "TagSelectors")
+	})
+
+	t.Run("gcp", func(t *testing.T) {
+		t.Parallel()
+		gotTypes, gotArgs := aggArgsToGCP(args)
+
+		assert.Equal(t, args.Types, gotTypes, "Types")
+		assert.Equal(t, args.Project, gotArgs.Project, "Project")
+		assert.Equal(t, args.Regions, gotArgs.Regions, "Regions")
+		assert.Equal(t, args.Emitter, gotArgs.Emitter, "Emitter")
+
+		wantSel := []gcpdiscover.TagSelector{
+			{Key: "env", Value: "prod"},
+			{Key: "team", Value: "growth"},
+		}
+		assert.Equal(t, wantSel, gotArgs.TagSelectors, "TagSelectors")
+
+		// AccountID is intentionally dropped — gcpdiscover.DiscoverArgs
+		// has no such field. The pin: the GCP DiscoverArgs struct still
+		// has exactly the four fields its package declares, so a
+		// regression that smuggles AccountID into the GCP path would
+		// fail to compile against this test's struct comparison.
+		assert.Equal(t, gcpdiscover.DiscoverArgs{
+			Project:      args.Project,
+			Regions:      args.Regions,
+			TagSelectors: wantSel,
+			Emitter:      args.Emitter,
+		}, gotArgs, "full GCP DiscoverArgs (no AccountID)")
+	})
+
+	t.Run("empty_selectors_yield_empty_not_nil", func(t *testing.T) {
+		t.Parallel()
+		// Both helpers eagerly allocate the slice (make with len=0). A
+		// regression that switched to `var sel []TagSelector` would
+		// emit JSON `null` on the wire vs. `[]`, which the wizard
+		// historically struggles with (see #255). This is a thinner
+		// pin than the discovery inspector test contract, but it
+		// catches the same accidental nil-slice path at the boundary.
+		empty := AggArgs{}
+		_, awsArgs := aggArgsToAWS(empty)
+		_, gcpArgs := aggArgsToGCP(empty)
+		require.NotNil(t, awsArgs.TagSelectors, "AWS TagSelectors must be empty slice, not nil")
+		require.NotNil(t, gcpArgs.TagSelectors, "GCP TagSelectors must be empty slice, not nil")
+		assert.Empty(t, awsArgs.TagSelectors)
+		assert.Empty(t, gcpArgs.TagSelectors)
+	})
 }

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -2273,11 +2273,11 @@ func TestRunDiscoverWithDeps_IncludeUnsupportedWritesUnsupportedJSON(t *testing.
 	outDir := t.TempDir()
 	agg := &fakeAggregator{}
 	deps := okDeps(agg)
-	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
 		return []awsdiscover.UnsupportedResource{
 			{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/v1", Name: "v1", Region: "us-east-1"},
 			{Type: "aws_rds_cluster", ID: "arn:aws:rds:us-east-1:1:cluster:c1", Name: "c1", Region: "us-east-1"},
-		}, nil
+		}, false, nil
 	}
 	rc := runDiscoverWithDeps([]string{
 		"--provider", "aws",
@@ -2292,12 +2292,17 @@ func TestRunDiscoverWithDeps_IncludeUnsupportedWritesUnsupportedJSON(t *testing.
 	}
 	body, err := os.ReadFile(filepath.Join(outDir, "unsupported.json"))
 	require.NoError(t, err)
-	var got []UnsupportedResource
-	require.NoError(t, json.Unmarshal(body, &got))
+	// #309 wire-format: decode the wrapper-object shape, assert on Resources.
+	var manifest UnsupportedManifest
+	require.NoError(t, json.Unmarshal(body, &manifest))
+	got := manifest.Resources
 	require.Len(t, got, 2)
 	gotTypes := []string{got[0].Type, got[1].Type}
 	if !slices.Contains(gotTypes, "aws_vpc") || !slices.Contains(gotTypes, "aws_rds_cluster") {
 		t.Errorf("emitted types=%v, want both aws_vpc and aws_rds_cluster", gotTypes)
+	}
+	if manifest.Truncated {
+		t.Errorf("Truncated=true, want false on uncapped happy-path run")
 	}
 }
 
@@ -2341,8 +2346,8 @@ func TestRunDiscoverWithDeps_IncludeUnsupportedSoftFailureKeepsImportedJSON(t *t
 	outDir := t.TempDir()
 	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
 	deps := okDeps(agg)
-	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
-		return nil, errors.New("simulated: Resource Explorer not configured")
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
+		return nil, false, errors.New("simulated: Resource Explorer not configured")
 	}
 	var rc int
 	stderr := captureStderr(t, func() {
@@ -2388,9 +2393,9 @@ func TestRunDiscoverWithDeps_IncludeUnsupportedNotSetSkipsEmission(t *testing.T)
 	outDir := t.TempDir()
 	called := 0
 	deps := okDeps(&fakeAggregator{})
-	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
 		called++
-		return nil, nil
+		return nil, false, nil
 	}
 	rc := runDiscoverWithDeps([]string{
 		"--provider", "aws",
@@ -2421,10 +2426,10 @@ func TestRunDiscoverWithDeps_IncludeUnsupportedGCP(t *testing.T) {
 	outDir := t.TempDir()
 	agg := &fakeAggregator{}
 	deps, _ := okGCPDeps(t, agg)
-	deps.enumerateUnsupportedGCP = func(_ context.Context, _ gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, error) {
+	deps.enumerateUnsupportedGCP = func(_ context.Context, _ gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, bool, error) {
 		return []gcpdiscover.UnsupportedResource{
 			{Type: "google_compute_instance", ID: "//compute.googleapis.com/projects/p/zones/us/instances/vm", Name: "vm", Location: "us"},
-		}, nil
+		}, false, nil
 	}
 	rc := runDiscoverWithDeps([]string{
 		"--provider", "gcp",
@@ -2439,14 +2444,160 @@ func TestRunDiscoverWithDeps_IncludeUnsupportedGCP(t *testing.T) {
 	}
 	body, err := os.ReadFile(filepath.Join(outDir, "unsupported.json"))
 	require.NoError(t, err)
-	var got []UnsupportedResource
-	require.NoError(t, json.Unmarshal(body, &got))
+	// #309 wire-format: decode wrapper-object shape and assert on Resources.
+	var manifest UnsupportedManifest
+	require.NoError(t, json.Unmarshal(body, &manifest))
+	got := manifest.Resources
 	require.Len(t, got, 1)
 	if got[0].Type != "google_compute_instance" {
 		t.Errorf("Type=%q, want google_compute_instance", got[0].Type)
 	}
 	if got[0].Location != "us" {
 		t.Errorf("Location=%q, want us", got[0].Location)
+	}
+}
+
+// --- #309 --max-unsupported-results tests ---
+
+// TestRunDiscoverWithDeps_MaxUnsupportedResults_FlagThreadsCap pins
+// that the --max-unsupported-results flag value reaches both the AWS
+// and the GCP enumerator paths. Two sibling sub-tests run the same
+// assertion against each cloud — a regression that wired the flag to
+// only one path would flag here.
+func TestRunDiscoverWithDeps_MaxUnsupportedResults_FlagThreadsCap(t *testing.T) {
+	t.Parallel()
+	t.Run("aws", func(t *testing.T) {
+		t.Parallel()
+		outDir := t.TempDir()
+		var gotMax int
+		deps := okDeps(&fakeAggregator{})
+		deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
+			gotMax = args.MaxResults
+			return nil, false, nil
+		}
+		rc := runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--output-dir", outDir,
+			"--include-unsupported",
+			"--max-unsupported-results", "42",
+			"--no-hcl",
+		}, deps)
+		if rc != discoverExitOK {
+			t.Fatalf("rc=%d, want OK", rc)
+		}
+		if gotMax != 42 {
+			t.Errorf("AWS enumerator received MaxResults=%d, want 42", gotMax)
+		}
+	})
+	t.Run("gcp", func(t *testing.T) {
+		t.Parallel()
+		outDir := t.TempDir()
+		var gotMax int
+		deps, _ := okGCPDeps(t, &fakeAggregator{})
+		deps.enumerateUnsupportedGCP = func(_ context.Context, args gcpdiscover.UnsupportedArgs) ([]gcpdiscover.UnsupportedResource, bool, error) {
+			gotMax = args.MaxResults
+			return nil, false, nil
+		}
+		rc := runDiscoverWithDeps([]string{
+			"--provider", "gcp",
+			"--project", "io-foo",
+			"--gcp-project-id", "real-proj",
+			"--output-dir", outDir,
+			"--include-unsupported",
+			"--max-unsupported-results", "42",
+			"--no-hcl",
+		}, deps)
+		if rc != discoverExitOK {
+			t.Fatalf("rc=%d, want OK", rc)
+		}
+		if gotMax != 42 {
+			t.Errorf("GCP enumerator received MaxResults=%d, want 42", gotMax)
+		}
+	})
+}
+
+// TestRunDiscoverWithDeps_MaxUnsupportedResults_NegativeIsFatal pins
+// the validation rule: --max-unsupported-results must be >= 0. A
+// negative value is a programming error (the cap is "0 = unbounded";
+// negative has no meaning) and must abort before touching the cloud.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_MaxUnsupportedResults_NegativeIsFatal(t *testing.T) {
+	outDir := t.TempDir()
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--output-dir", outDir,
+			"--max-unsupported-results", "-1",
+		}, okDeps(&fakeAggregator{}))
+	})
+	if rc != discoverExitFatal {
+		t.Errorf("rc=%d, want fatal", rc)
+	}
+	if !strings.Contains(stderr, "max-unsupported-results") || !strings.Contains(stderr, ">= 0") {
+		t.Errorf("stderr should explain the >= 0 rule; got: %s", stderr)
+	}
+}
+
+// TestRunDiscoverWithDeps_TruncatedFlagSurfacesInUnsupportedJSON pins
+// the end-to-end #309 contract: when the enumerator returns
+// truncated=true, unsupported.json carries the marker at the wrapper
+// level AND a stderr WARN is emitted naming the cap. This is the
+// load-bearing claim of the cap-and-warn design — both signals must
+// fire, because the wizard's UI parser routes off the WARN while
+// non-streaming consumers read the on-disk marker.
+//
+// NOT t.Parallel(): captures global os.Stderr.
+func TestRunDiscoverWithDeps_TruncatedFlagSurfacesInUnsupportedJSON(t *testing.T) {
+	outDir := t.TempDir()
+	deps := okDeps(&fakeAggregator{})
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
+		return []awsdiscover.UnsupportedResource{
+			{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/v1", Region: "us-east-1"},
+		}, true, nil
+	}
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws",
+			"--project", "io-foo",
+			"--regions", "us-east-1",
+			"--output-dir", outDir,
+			"--include-unsupported",
+			"--max-unsupported-results", "1",
+			"--no-hcl",
+		}, deps)
+	})
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK", rc)
+	}
+	// On-disk wrapper-shape marker.
+	body, err := os.ReadFile(filepath.Join(outDir, "unsupported.json"))
+	require.NoError(t, err)
+	var manifest UnsupportedManifest
+	require.NoError(t, json.Unmarshal(body, &manifest))
+	if !manifest.Truncated {
+		t.Errorf("manifest.Truncated=false, want true")
+	}
+	if manifest.MaxResults != 1 {
+		t.Errorf("manifest.MaxResults=%d, want 1", manifest.MaxResults)
+	}
+	// Stderr WARN: the wizard's UI parser routes on the literal
+	// "WARN" + the substring "cap fired" + "max_results=" so the
+	// cap-firing event is unambiguous.
+	if !strings.Contains(stderr, "WARN") {
+		t.Errorf("stderr missing WARN prefix; got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "cap fired") {
+		t.Errorf("stderr missing `cap fired`; got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "max_results=1") {
+		t.Errorf("stderr missing `max_results=1`; got: %s", stderr)
 	}
 }
 
@@ -2531,12 +2682,12 @@ func TestRunDiscoverWithDeps_SummaryIncludeUnsupportedReflectsCount(t *testing.T
 		validResource("aws_sqs_queue.alpha"),
 	}}
 	deps := okDeps(agg)
-	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
 		return []awsdiscover.UnsupportedResource{
 			{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/v1", Region: "us-east-1"},
 			{Type: "aws_rds_cluster", ID: "arn:aws:rds:us-east-1:1:cluster:c1", Region: "us-east-1"},
 			{Type: "aws_iam_role", ID: "arn:aws:iam::1:role/r1"},
-		}, nil
+		}, false, nil
 	}
 	rc := runDiscoverWithDeps([]string{
 		"--provider", "aws",
@@ -2567,8 +2718,8 @@ func TestRunDiscoverWithDeps_SummaryIncludeUnsupportedSoftFailureZeroCount(t *te
 	outDir := t.TempDir()
 	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
 	deps := okDeps(agg)
-	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, error) {
-		return nil, errors.New("simulated: Resource Explorer not configured")
+	deps.enumerateUnsupportedAWS = func(_ context.Context, _ aws.Config, _ awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
+		return nil, false, errors.New("simulated: Resource Explorer not configured")
 	}
 	var rc int
 	captureStderr(t, func() {

--- a/cmd/insideout-import/gcpdiscover/searcher.go
+++ b/cmd/insideout-import/gcpdiscover/searcher.go
@@ -92,11 +92,12 @@ func (s *RealAssetSearcher) SearchAll(ctx context.Context, scope string, assetTy
 	}
 	it := s.client.SearchAllResources(ctx, req)
 
-	// TODO(#309): bound result accumulation. The iterator is unbounded
-	// — a project with 10k+ assets accumulates the entire result set
-	// before unsupported.json is written. Plumb a MaxResults knob
-	// through UnsupportedArgs and emit a "truncated" warning when the
-	// bound trips.
+	// #309: this iterator is intentionally unbounded — SearchAll is
+	// shared between the importable scan (DiscoverTypes path) and the
+	// unsupported scan (EnumerateUnsupported), and capping here would
+	// silently truncate the importable manifest. The MaxResults bound
+	// for unsupported lives at the EnumerateUnsupported wrapper, so
+	// the importable path keeps its full-coverage guarantee.
 	var out []gcpAssetResult
 	for {
 		r, err := it.Next()

--- a/cmd/insideout-import/gcpdiscover/unsupported.go
+++ b/cmd/insideout-import/gcpdiscover/unsupported.go
@@ -59,6 +59,20 @@ type UnsupportedArgs struct {
 	// Emitter is the streaming-progress sink. Resolved to NopEmitter at
 	// the top of EnumerateUnsupported when nil.
 	Emitter progress.Emitter
+
+	// MaxResults caps the number of unsupported resources returned by
+	// EnumerateUnsupported. Zero disables the cap (#309). The cap is
+	// applied at the wrapper level — AFTER SearchAll has walked every
+	// page — because SearchAll is shared between the importable and
+	// the unsupported scans and capping inside the searcher would
+	// silently truncate the importable manifest. The trade-off is
+	// that MaxResults bounds memory + the size of unsupported.json
+	// but does NOT bound the Cloud Asset API budget; an account with
+	// 100k+ assets still walks the full SearchAllResources iterator.
+	// When the cap fires the caller receives truncated=true and
+	// surfaces it as a stderr WARN + the truncated marker on
+	// unsupported.json's wrapper-object shape.
+	MaxResults int
 }
 
 // EnumerateUnsupported runs one Cloud Asset SearchAllResources call
@@ -77,12 +91,12 @@ type UnsupportedArgs struct {
 // or FailedPrecondition that the wizard's UI translates into the same
 // "operator action required" toast as the AWS Resource-Explorer-not-
 // configured path.
-func (g *GCPDiscoverer) EnumerateUnsupported(ctx context.Context, args UnsupportedArgs) ([]UnsupportedResource, error) {
+func (g *GCPDiscoverer) EnumerateUnsupported(ctx context.Context, args UnsupportedArgs) ([]UnsupportedResource, bool, error) {
 	if args.Searcher == nil {
 		args.Searcher = g.searcher
 	}
 	if args.Searcher == nil {
-		return nil, fmt.Errorf("EnumerateUnsupported: no searcher configured (production callers wire NewRealAssetSearcher; tests inject a fake)")
+		return nil, false, fmt.Errorf("EnumerateUnsupported: no searcher configured (production callers wire NewRealAssetSearcher; tests inject a fake)")
 	}
 	if args.Emitter == nil {
 		args.Emitter = progress.NopEmitter{}
@@ -100,7 +114,7 @@ func (g *GCPDiscoverer) EnumerateUnsupported(ctx context.Context, args Unsupport
 		// is in the supported set — a programming error rather than a
 		// runtime branch worth exercising. Return an empty slice (not
 		// nil) so the caller's writeUnsupportedManifest emits `[]`.
-		return []UnsupportedResource{}, nil
+		return []UnsupportedResource{}, false, nil
 	}
 
 	scope := fmt.Sprintf("projects/%s", g.projectID)
@@ -112,7 +126,19 @@ func (g *GCPDiscoverer) EnumerateUnsupported(ctx context.Context, args Unsupport
 	results, err := args.Searcher.SearchAll(ctx, scope, assetTypes, query)
 	if err != nil {
 		args.Emitter.ServiceFinish(unsupportedGCPServiceSlug, "", 0, time.Since(stageStart))
-		return nil, fmt.Errorf("cloud asset SearchAllResources (unsupported): %w", err)
+		return nil, false, fmt.Errorf("cloud asset SearchAllResources (unsupported): %w", err)
+	}
+
+	// #309: cap is applied at the wrapper level (AFTER SearchAll has
+	// walked the full iterator). SearchAll is shared with the
+	// importable-types scan; capping there would silently truncate
+	// imported.json. The trade-off is documented on
+	// UnsupportedArgs.MaxResults: this bounds memory + the size of
+	// unsupported.json but not the Cloud Asset API budget.
+	truncated := false
+	if args.MaxResults > 0 && len(results) > args.MaxResults {
+		results = results[:args.MaxResults]
+		truncated = true
 	}
 
 	out := make([]UnsupportedResource, 0, len(results))
@@ -122,7 +148,7 @@ func (g *GCPDiscoverer) EnumerateUnsupported(ctx context.Context, args Unsupport
 		out = append(out, row)
 	}
 	args.Emitter.ServiceFinish(unsupportedGCPServiceSlug, "", len(out), time.Since(stageStart))
-	return out, nil
+	return out, truncated, nil
 }
 
 // gcpAssetToUnsupported translates one Cloud Asset hit into an

--- a/cmd/insideout-import/gcpdiscover/unsupported_test.go
+++ b/cmd/insideout-import/gcpdiscover/unsupported_test.go
@@ -3,6 +3,7 @@ package gcpdiscover
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -28,7 +29,7 @@ func TestEnumerateUnsupportedGCP_BuildsAssetTypesClauseFromUnsupportedSet(t *tes
 	t.Parallel()
 	fake := &fakeAssetSearcher{}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	if _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
+	if _, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
 		Project: "io-foo",
 	}); err != nil {
 		t.Fatal(err)
@@ -91,7 +92,7 @@ func TestEnumerateUnsupportedGCP_TFTypeMappedFromAssetType(t *testing.T) {
 				)},
 			}
 			g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-			got, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+			got, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -119,7 +120,7 @@ func TestEnumerateUnsupportedGCP_UnknownAssetTypePreservesEmpty(t *testing.T) {
 		)},
 	}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	got, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	got, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +151,7 @@ func TestEnumerateUnsupportedGCP_LabelsPassThrough(t *testing.T) {
 		)},
 	}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	got, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	got, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +172,7 @@ func TestEnumerateUnsupportedGCP_SearcherErrorIsReturned(t *testing.T) {
 	wantErr := errors.New("permission denied: cloudasset.assets.searchAllResources")
 	fake := &fakeAssetSearcher{err: wantErr}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	_, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	_, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
 	if err == nil {
 		t.Fatal("err=nil, want error")
 	}
@@ -184,7 +185,7 @@ func TestEnumerateUnsupportedGCP_SearcherErrorIsReturned(t *testing.T) {
 func TestEnumerateUnsupportedGCP_NilSearcherIsFatal(t *testing.T) {
 	t.Parallel()
 	g := &GCPDiscoverer{projectID: "real-proj"}
-	_, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	_, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
 	if err == nil {
 		t.Fatal("err=nil, want explicit error when no searcher configured")
 	}
@@ -203,7 +204,7 @@ func TestEnumerateUnsupportedGCP_EmitsServiceStartFinish(t *testing.T) {
 	}
 	rec := &recordingEmitter{}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	if _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{Emitter: rec}); err != nil {
+	if _, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{Emitter: rec}); err != nil {
 		t.Fatal(err)
 	}
 	starts, finishes, items := 0, 0, 0
@@ -240,7 +241,7 @@ func TestEnumerateUnsupportedGCP_QueryShapeFromArgs(t *testing.T) {
 	t.Parallel()
 	fake := &fakeAssetSearcher{}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	if _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
+	if _, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
 		Project:      "io-foo",
 		Regions:      []string{"us-central1"},
 		TagSelectors: []TagSelector{{Key: "env", Value: "prod"}},
@@ -282,7 +283,7 @@ func TestEnumerateUnsupportedGCP_PopulatesGroup(t *testing.T) {
 		},
 	}
 	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
-	got, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
+	got, _, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -328,6 +329,76 @@ func TestEnumerateUnsupportedGCP_PopulatesGroup(t *testing.T) {
 	}
 	if unmapped.Group != "" {
 		t.Errorf("Group for Type==\"\" = %q, want \"\" (unmapped slug → no category)", unmapped.Group)
+	}
+}
+
+// --- #309 MaxResults cap tests ---
+
+// TestEnumerateUnsupportedGCP_CapFiresAndSetsTruncated pins the
+// wrapper-level cap (#309): a 50-asset fake response with cap=10
+// returns exactly 10 rows and truncated=true.
+//
+// IMPORTANT: unlike the AWS path, the GCP cap is at the
+// EnumerateUnsupported wrapper, not inside SearchAll. SearchAll is
+// shared between the importable and unsupported scans; capping there
+// would silently truncate the importable manifest. The trade-off is
+// that the cap bounds memory + on-disk size, but does NOT bound the
+// Cloud Asset API budget — SearchAll still walks the full iterator.
+func TestEnumerateUnsupportedGCP_CapFiresAndSetsTruncated(t *testing.T) {
+	t.Parallel()
+	results := make([]gcpAssetResult, 0, 50)
+	for i := 0; i < 50; i++ {
+		// compute.googleapis.com/Instance maps to google_compute_instance
+		// which is currently NOT in the GCP importable registry, so
+		// each fixture row passes through to the output.
+		name := fmt.Sprintf("//compute.googleapis.com/projects/p/zones/us/instances/vm-%03d", i)
+		results = append(results, gcpAsset(name, "compute.googleapis.com/Instance", "us", nil))
+	}
+	fake := &fakeAssetSearcher{results: results}
+	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
+	got, truncated, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
+		MaxResults: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !truncated {
+		t.Errorf("truncated=false, want true (cap=10, source=50)")
+	}
+	if len(got) != 10 {
+		t.Errorf("len(got)=%d, want 10 (cap)", len(got))
+	}
+	// Wrapper-level cap means SearchAll DID see all 50 results — it
+	// emits one call as usual; the truncation happens after the
+	// iterator returns. Pin the call count to defend against a
+	// future regression that "optimizes" the cap into SearchAll.
+	if len(fake.calls) != 1 {
+		t.Errorf("SearchAll calls=%d, want 1 (cap is wrapper-level, not per-call)", len(fake.calls))
+	}
+}
+
+// TestEnumerateUnsupportedGCP_CapZeroDisablesLimit pins the
+// "0 = unbounded" contract on the GCP path. Mirrors the AWS-side test.
+func TestEnumerateUnsupportedGCP_CapZeroDisablesLimit(t *testing.T) {
+	t.Parallel()
+	results := make([]gcpAssetResult, 0, 50)
+	for i := 0; i < 50; i++ {
+		name := fmt.Sprintf("//compute.googleapis.com/projects/p/zones/us/instances/vm-%03d", i)
+		results = append(results, gcpAsset(name, "compute.googleapis.com/Instance", "us", nil))
+	}
+	fake := &fakeAssetSearcher{results: results}
+	g := &GCPDiscoverer{searcher: fake, projectID: "real-proj"}
+	got, truncated, err := g.EnumerateUnsupported(context.Background(), UnsupportedArgs{
+		MaxResults: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if truncated {
+		t.Errorf("truncated=true, want false (cap=0 disables the limit)")
+	}
+	if len(got) != 50 {
+		t.Errorf("len(got)=%d, want 50 (uncapped)", len(got))
 	}
 }
 

--- a/cmd/insideout-import/imported_unsupported.go
+++ b/cmd/insideout-import/imported_unsupported.go
@@ -19,7 +19,9 @@ package main
 // and GCP enumerators apply.
 //
 // JSON wire-format invariants enforced by writeUnsupportedManifest:
-//   - top-level is always a JSON array, never `null` (empty input writes `[]`)
+//   - top-level is always the wrapper object {"resources":[…],"truncated":bool,"max_results":int}
+//     never a bare array (#309 wire-format break — see UnsupportedManifest).
+//     Resources is always a JSON array, never `null` (empty input writes `[]`)
 //   - rows sorted deterministically by (Type, Region, ID) so byte-identical
 //     output across runs for the same input
 //   - omitempty on the four optional fields — a row with no Region/Location/
@@ -70,4 +72,41 @@ type UnsupportedResource struct {
 	// gcpdiscover/unsupported.go). The picker falls back to "Other" when
 	// Category returns the empty string for an unknown type.
 	Group string `json:"group,omitempty"`
+}
+
+// UnsupportedManifest is the on-disk wrapper-object shape of
+// unsupported.json (#309). Prior to #309 the file was a bare JSON
+// array of UnsupportedResource; the cap-and-warn contract requires
+// stamping the top-level body with truncation metadata so downstream
+// readers know whether a missing row reflects a true zero-result run
+// or the cap firing on a too-large account.
+//
+// Wire-format break: this is incompatible with the v0.7-era bare-array
+// shape. The reliable wizard's consumer hasn't shipped yet, so the
+// break is contained to this repo. A version field is intentionally
+// NOT carried — adding `truncated` / `max_results` to a wrapper is a
+// one-shot break, not a versioned schema dance, and a future schema
+// change would warrant a new sibling file rather than versioning this
+// one.
+//
+// JSON wire-format invariants:
+//   - Resources is always a JSON array, never `null` (writeUnsupportedManifest
+//     coerces nil → []).
+//   - Truncated is true iff the per-cloud enumerator's MaxResults bound
+//     fired during this run.
+//   - MaxResults echoes the cap that was in effect (0 means "cap disabled"
+//     — see --max-unsupported-results=0).
+type UnsupportedManifest struct {
+	// Resources is the deterministically-sorted slice of unsupported
+	// rows. Sort key: (Type, Region, ID). Empty input writes [].
+	Resources []UnsupportedResource `json:"resources"`
+
+	// Truncated is true when the run hit the MaxResults cap and stopped
+	// enumerating early. The reliable wizard surfaces this as a banner
+	// over the picker: "Showing first N of many — re-run with a larger
+	// --max-unsupported-results to enumerate the rest."
+	Truncated bool `json:"truncated"`
+
+	// MaxResults echoes the per-run cap. 0 = no cap was set.
+	MaxResults int `json:"max_results"`
 }

--- a/cmd/insideout-import/imported_unsupported.go
+++ b/cmd/insideout-import/imported_unsupported.go
@@ -64,14 +64,10 @@ type UnsupportedResource struct {
 	Tags map[string]string `json:"tags,omitempty"`
 
 	// Group is the high-level UI category ("Events", "Data Storage",
-	// "Network Security", ...) the wizard groups picker rows under. This
-	// PR (#296) leaves Group empty intentionally — the Category map that
-	// translates Type → Group lands in the parallel #297 (Bundle 2 / PR 3)
-	// PR, which iterates this slice and stamps Group post-emit. Until
-	// then the picker uses an "Other" fallback bucket.
-	//
-	// TODO(#297): populate Group from the imported.Category map once it
-	// lands; this PR ships the field on the wire so #297 is a pure
-	// composer change without an unsupported.json schema bump.
+	// "Network Security", ...) the wizard groups picker rows under. The
+	// per-cloud unsupported emitters stamp this from imported.Category
+	// at construction (awsdiscover/unsupported.go and
+	// gcpdiscover/unsupported.go). The picker falls back to "Other" when
+	// Category returns the empty string for an unknown type.
 	Group string `json:"group,omitempty"`
 }

--- a/cmd/insideout-import/manifest.go
+++ b/cmd/insideout-import/manifest.go
@@ -174,24 +174,29 @@ func readManifest(path, cloud string) ([]imported.ImportedResource, error) {
 	return resources, nil
 }
 
-// writeUnsupportedManifest writes the JSON array of UnsupportedResource
-// rows into <dir>/unsupported.json (#296). Mirrors writeManifest's
-// invariants: nil → []-not-null, deterministic sort, file written
-// atomically via WriteFile.
+// writeUnsupportedManifest writes the wrapper-object form of
+// unsupported.json (#309 wire-format break) into <dir>/unsupported.json.
+// The pre-#309 shape was a bare JSON array; the cap-and-warn contract
+// (--max-unsupported-results) needs metadata at the top level so the
+// reliable wizard can render the "Showing first N of many" banner.
 //
-// Sort key is (Type, Region, ID) so byte-identical output across runs
-// for the same input. Type-first keeps the picker's "all aws_vpc rows"
-// runs together visually; Region tie-breaks within a type (multi-
-// region scans); ID is the final tiebreaker for rows that match on
-// both. Unlike writeManifest, no validator runs here — the unsupported
-// carrier has no IR-side schema to enforce: the wire shape is checked
-// by the field tags on UnsupportedResource and the test suite below.
+// Wire shape (with truncated=true, max_results=10):
 //
-// Returns (path, count, error). On marshal/write failure no file is
-// written so the caller's stderr surface is the only side-effect of a
-// soft-failure path (#296 contract: imported.json must complete even
-// when unsupported emission fails).
-func writeUnsupportedManifest(dir string, resources []UnsupportedResource) (string, int, error) {
+//	{"resources":[…sorted rows…],"truncated":true,"max_results":10}
+//
+// Mirrors writeManifest's invariants on the inner Resources slice:
+// nil → []-not-null, deterministic sort, file written atomically via
+// writeFileAtomic. Sort key is (Type, Region, ID) — byte-identical
+// output across runs for the same input. Unlike writeManifest no
+// validator runs here; the carrier has no IR-side schema to enforce.
+//
+// Returns (path, count, error). count is the post-truncation row count
+// (the size of resources passed in — the searcher already truncated
+// before this is called). On marshal/write failure no file is written
+// so the caller's stderr surface is the only side-effect of a soft-
+// failure path (#296 contract: imported.json must complete even when
+// unsupported emission fails).
+func writeUnsupportedManifest(dir string, resources []UnsupportedResource, truncated bool, maxResults int) (string, int, error) {
 	if resources == nil {
 		resources = []UnsupportedResource{}
 	}
@@ -205,7 +210,12 @@ func writeUnsupportedManifest(dir string, resources []UnsupportedResource) (stri
 		return resources[i].ID < resources[j].ID
 	})
 
-	body, err := json.MarshalIndent(resources, "", "  ")
+	manifest := UnsupportedManifest{
+		Resources:  resources,
+		Truncated:  truncated,
+		MaxResults: maxResults,
+	}
+	body, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
 		return "", 0, fmt.Errorf("marshal unsupported manifest: %w", err)
 	}

--- a/cmd/insideout-import/manifest_test.go
+++ b/cmd/insideout-import/manifest_test.go
@@ -333,7 +333,7 @@ func TestWriteUnsupportedManifest_HappyPath(t *testing.T) {
 		{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/b", Name: "b", Region: "us-east-1"},
 		{Type: "aws_vpc", ID: "arn:aws:ec2:us-east-1:1:vpc/a", Name: "a", Region: "us-east-1"},
 	}
-	path, n, err := writeUnsupportedManifest(dir, rows)
+	path, n, err := writeUnsupportedManifest(dir, rows, false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,28 +347,32 @@ func TestWriteUnsupportedManifest_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var got []UnsupportedResource
+	// #309 wire-format: the on-disk body is a wrapper object, not a
+	// bare array. Decode into UnsupportedManifest and assert on the
+	// inner Resources slice.
+	var got UnsupportedManifest
 	if err := json.Unmarshal(body, &got); err != nil {
 		t.Fatalf("unsupported.json is not valid JSON: %v", err)
 	}
-	if len(got) != 2 {
-		t.Fatalf("decoded len=%d, want 2", len(got))
+	if len(got.Resources) != 2 {
+		t.Fatalf("decoded len=%d, want 2", len(got.Resources))
 	}
 	// Sort key is (Type, Region, ID) — both rows share Type+Region, so
 	// the ID-tiebreak puts the .../vpc/a row first.
-	if got[0].Name != "a" {
-		t.Errorf("first Name=%q, want %q (sorted by (Type, Region, ID))", got[0].Name, "a")
+	if got.Resources[0].Name != "a" {
+		t.Errorf("first Name=%q, want %q (sorted by (Type, Region, ID))", got.Resources[0].Name, "a")
 	}
 }
 
 // TestWriteUnsupportedManifest_EmptyInputWritesArrayNotNull pins the
 // no-null contract: a nil/empty input still produces a `[]` on disk
-// (the wizard picker cannot range over null).
+// (the wizard picker cannot range over null) inside the wrapper-object
+// shape introduced in #309.
 func TestWriteUnsupportedManifest_EmptyInputWritesArrayNotNull(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	for _, in := range [][]UnsupportedResource{nil, {}} {
-		path, n, err := writeUnsupportedManifest(dir, in)
+		path, n, err := writeUnsupportedManifest(dir, in, false, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -380,10 +384,25 @@ func TestWriteUnsupportedManifest_EmptyInputWritesArrayNotNull(t *testing.T) {
 			t.Fatal(err)
 		}
 		if strings.TrimSpace(string(body)) == "null" {
-			t.Errorf("must emit `[]` not `null`; got: %s", body)
+			t.Errorf("must NOT emit `null`; got: %s", body)
 		}
-		if !bytes.HasPrefix(bytes.TrimSpace(body), []byte("[")) {
-			t.Errorf("must start with `[`; got: %s", body)
+		// Wrapper-object shape (#309): the body must START with `{`,
+		// not `[`. The inner resources slice still gets the `[]`-not-
+		// `null` contract — assert that the field is `[]` literally.
+		if !bytes.HasPrefix(bytes.TrimSpace(body), []byte("{")) {
+			t.Errorf("must start with `{` (wrapper-object shape); got: %s", body)
+		}
+		if !bytes.Contains(body, []byte(`"resources": []`)) {
+			t.Errorf("must contain `\"resources\": []` for empty input; got: %s", body)
+		}
+		// Verify the wrapper marshals into UnsupportedManifest with
+		// Resources != nil.
+		var got UnsupportedManifest
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode wrapper: %v", err)
+		}
+		if got.Resources == nil {
+			t.Errorf("decoded Resources=nil, want non-nil empty slice")
 		}
 	}
 }
@@ -400,14 +419,14 @@ func TestWriteUnsupportedManifest_DeterministicAcrossRuns(t *testing.T) {
 		{Type: "", ID: "asset-b", Name: "b"},
 	}
 	dir1, dir2 := t.TempDir(), t.TempDir()
-	if _, _, err := writeUnsupportedManifest(dir1, rows); err != nil {
+	if _, _, err := writeUnsupportedManifest(dir1, rows, false, 0); err != nil {
 		t.Fatal(err)
 	}
 	rev := make([]UnsupportedResource, len(rows))
 	for i := range rows {
 		rev[len(rows)-1-i] = rows[i]
 	}
-	if _, _, err := writeUnsupportedManifest(dir2, rev); err != nil {
+	if _, _, err := writeUnsupportedManifest(dir2, rev, false, 0); err != nil {
 		t.Fatal(err)
 	}
 	a, err := os.ReadFile(filepath.Join(dir1, "unsupported.json"))
@@ -435,17 +454,18 @@ func TestWriteUnsupportedManifest_SortOrder(t *testing.T) {
 		{Type: "aws_vpc", ID: "arn-a", Region: "us-east-1"},
 		{Type: "aws_vpc", ID: "arn-b", Region: "eu-west-1"},
 	}
-	if _, _, err := writeUnsupportedManifest(dir, rows); err != nil {
+	if _, _, err := writeUnsupportedManifest(dir, rows, false, 0); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, "unsupported.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	var got []UnsupportedResource
-	if err := json.Unmarshal(body, &got); err != nil {
+	var manifest UnsupportedManifest
+	if err := json.Unmarshal(body, &manifest); err != nil {
 		t.Fatal(err)
 	}
+	got := manifest.Resources
 	want := []struct {
 		typ, region, id string
 	}{
@@ -479,7 +499,7 @@ func TestWriteUnsupportedManifest_OmitemptyOptionalFields(t *testing.T) {
 		ID:   "arn-only",
 		Name: "only",
 	}
-	if _, _, err := writeUnsupportedManifest(dir, []UnsupportedResource{row}); err != nil {
+	if _, _, err := writeUnsupportedManifest(dir, []UnsupportedResource{row}, false, 0); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, "unsupported.json"))
@@ -491,6 +511,98 @@ func TestWriteUnsupportedManifest_OmitemptyOptionalFields(t *testing.T) {
 		if bytes.Contains(body, []byte(key)) {
 			t.Errorf("manifest carries %s for omitempty-zero value; got: %s", key, body)
 		}
+	}
+}
+
+// --- #309 wrapper-shape tests ---
+
+// TestWriteUnsupportedManifest_WrapperShape pins the on-disk shape
+// introduced in #309: unsupported.json is a wrapper object
+// {"resources":[…],"truncated":bool,"max_results":int}, NOT a bare
+// JSON array. The reliable wizard's consumer reads the wrapper to
+// surface a "showing first N of many" banner; a regression to the
+// bare-array shape would break the consumer's decode.
+func TestWriteUnsupportedManifest_WrapperShape(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rows := []UnsupportedResource{
+		{Type: "aws_vpc", ID: "arn-a", Name: "a", Region: "us-east-1"},
+	}
+	if _, _, err := writeUnsupportedManifest(dir, rows, false, 10000); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "unsupported.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Top-level must be a JSON object, not a bare array.
+	trimmed := bytes.TrimSpace(body)
+	if !bytes.HasPrefix(trimmed, []byte("{")) {
+		t.Errorf("on-disk top-level shape must be an object (start with `{`); got: %s", body)
+	}
+	if bytes.HasPrefix(trimmed, []byte("[")) {
+		t.Errorf("on-disk top-level shape regressed to a bare array; got: %s", body)
+	}
+	// Decode into UnsupportedManifest and assert every field.
+	var got UnsupportedManifest
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode wrapper: %v", err)
+	}
+	if len(got.Resources) != 1 {
+		t.Errorf("Resources len=%d, want 1", len(got.Resources))
+	}
+	if got.Truncated {
+		t.Errorf("Truncated=true, want false (writer was called with truncated=false)")
+	}
+	if got.MaxResults != 10000 {
+		t.Errorf("MaxResults=%d, want 10000", got.MaxResults)
+	}
+	// Field-name pins: assert the JSON tags match the contract.
+	for _, want := range []string{`"resources":`, `"truncated":`, `"max_results":`} {
+		if !bytes.Contains(body, []byte(want)) {
+			t.Errorf("body missing required wrapper field %s; got: %s", want, body)
+		}
+	}
+}
+
+// TestWriteUnsupportedManifest_TruncatedTrueOnDisk pins that the
+// truncated=true bool round-trips through writeUnsupportedManifest into
+// the on-disk JSON. A regression that hard-coded `false` (or that
+// dropped the parameter) would silently mask cap-firing runs from the
+// reliable wizard's banner.
+func TestWriteUnsupportedManifest_TruncatedTrueOnDisk(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rows := []UnsupportedResource{
+		{Type: "aws_vpc", ID: "arn-a", Region: "us-east-1"},
+	}
+	if _, _, err := writeUnsupportedManifest(dir, rows, true, 5); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "unsupported.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Direct substring assertion — the JSON encoder writes booleans
+	// as the literal `true` / `false` tokens, so a regression that
+	// emitted `0` / `1` (or omitted the field via omitempty) would
+	// fail this pin.
+	if !bytes.Contains(body, []byte(`"truncated": true`)) {
+		t.Errorf("body missing `\"truncated\": true`; got: %s", body)
+	}
+	if !bytes.Contains(body, []byte(`"max_results": 5`)) {
+		t.Errorf("body missing `\"max_results\": 5`; got: %s", body)
+	}
+	// Decode-side cross-check.
+	var got UnsupportedManifest
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode wrapper: %v", err)
+	}
+	if !got.Truncated {
+		t.Errorf("Truncated=false, want true")
+	}
+	if got.MaxResults != 5 {
+		t.Errorf("MaxResults=%d, want 5", got.MaxResults)
 	}
 }
 

--- a/cmd/insideout-import/progress/progress.go
+++ b/cmd/insideout-import/progress/progress.go
@@ -30,36 +30,151 @@ import (
 	"time"
 )
 
-// Event is the on-the-wire shape produced by JSONEmitter. Field order in
-// the JSON output is determined by the struct layout (Go's encoding/json
-// emits in declaration order); we keep the most-discriminating fields
-// first so a streaming consumer can route on `event` without reading the
-// rest of the line.
+// Event is the on-the-wire shape produced by JSONEmitter. Each event
+// type carries a specific, fixed field set defined by the
+// MarshalJSON dispatch below; the on-the-wire field order follows the
+// per-event branch in MarshalJSON, with `event` always first and `ts`
+// always last so a streaming consumer can route on `event` without
+// reading the rest of the line.
 //
-// Optional fields use `omitempty` so each event type carries only the
-// fields that apply to it — service_start has no Count/DurationMs, etc.
-// The Timestamp field is always present; tests inject a fixed clock via
-// JSONEmitter.WithNow so golden output is deterministic.
+// The struct tags carry no `omitempty` on the numeric fields
+// (Count/Total/DurationMs) because MarshalJSON elides absent fields
+// per event type rather than relying on Go's zero-value-elision.
+// This is the fix for #312: a service_finish or stage_finish whose
+// scope yielded zero items must still emit `"count":0` so SSE
+// consumers don't have to special-case "count missing" vs
+// "count == 0". The Timestamp field is always present; tests inject
+// a fixed clock via JSONEmitter.WithNow so golden output is
+// deterministic.
 //
-// TODO(#312): typed sub-events or MarshalJSON. The omitempty Count
-// field drops `count` from service_finish/stage_finish events whose
-// scope yielded zero items; the SSE consumer renders that as "count
-// missing" rather than "count = 0". Either split into typed
-// sub-events or add a custom MarshalJSON that always emits count for
-// service_finish + stage_finish (and never for service_start +
-// item_found).
+// Region vs Location: today AWS discoverers populate Region and GCP
+// discoverers populate Location (the public Emitter API takes a
+// `region` parameter that GCP overloads with location values, but
+// the Event struct keeps them distinct for downstream consumers).
+// MarshalJSON emits exactly one of `region` or `location` on
+// service_*/item_found events: Location wins if both are set
+// (defensive), Region is emitted otherwise. If both are empty
+// (e.g. global services like IAM that pass region=""), MarshalJSON
+// emits `"region":""` — preserving the previous omitempty-absent
+// shape would require a third branch and the empty string is
+// already semantically "no region scope", which downstream parses
+// the same way.
 type Event struct {
-	Event      string    `json:"event"`                 // service_start | service_finish | item_found | stage_finish
-	Service    string    `json:"service,omitempty"`     // AWS service slug (sqs, dynamodb, ...) or GCP asset_type slug (cloud_asset_inventory)
-	Region     string    `json:"region,omitempty"`      // AWS region; empty for global services (IAM, S3) and GCP
-	Location   string    `json:"location,omitempty"`    // GCP location; empty for project-global types and AWS
-	TFType     string    `json:"tf_type,omitempty"`     // Terraform resource type for item_found
-	ImportID   string    `json:"import_id,omitempty"`   // Terraform import ID for item_found
-	Stage      string    `json:"stage,omitempty"`       // discover for stage_finish (room for future stages: hcl_gen, drift_fix, dep_chase)
-	Count      int       `json:"count,omitempty"`       // service_finish, stage_finish — items emitted in scope
-	Total      int       `json:"total,omitempty"`       // stage_finish — total items across the stage (==Count today, separate field for future fan-in)
-	DurationMs int64     `json:"duration_ms,omitempty"` // service_finish, stage_finish — wall-time spent in the scope
-	Timestamp  time.Time `json:"ts"`                    // every event; injectable for deterministic tests via WithNow
+	Event      string    `json:"event"`               // service_start | service_finish | item_found | stage_finish
+	Service    string    `json:"service,omitempty"`   // AWS service slug (sqs, dynamodb, ...) or GCP asset_type slug (cloud_asset_inventory)
+	Region     string    `json:"region,omitempty"`    // AWS region; empty for global services (IAM, S3) and GCP
+	Location   string    `json:"location,omitempty"`  // GCP location; empty for project-global types and AWS
+	TFType     string    `json:"tf_type,omitempty"`   // Terraform resource type for item_found
+	ImportID   string    `json:"import_id,omitempty"` // Terraform import ID for item_found
+	Stage      string    `json:"stage,omitempty"`     // discover for stage_finish (room for future stages: hcl_gen, drift_fix, dep_chase)
+	Count      int       `json:"count"`               // service_finish, stage_finish — items emitted in scope; always emitted on those events even when zero (#312)
+	Total      int       `json:"total"`               // stage_finish — total items across the stage (==Count today, separate field for future fan-in); always emitted on stage_finish even when zero (#312)
+	DurationMs int64     `json:"duration_ms"`         // service_finish, stage_finish — wall-time spent in the scope; always emitted on those events even when zero (#312)
+	Timestamp  time.Time `json:"ts"`                  // every event; injectable for deterministic tests via WithNow
+}
+
+// MarshalJSON implements per-event-type field dispatch so each event
+// carries exactly the field set its type requires (#312). The
+// per-event branches build typed structs (rather than a
+// map[string]any) so output preserves declaration order — every
+// emit starts with `event` and ends with `ts`, with the
+// type-specific fields between in the order documented in the
+// issue body. This is purely a readability concern; JSON consumers
+// parse objects unordered.
+//
+// The fix for #312 is structural: the typed event structs declare
+// Count/Total/DurationMs WITHOUT `omitempty`, so a service_finish
+// or stage_finish whose scope yielded zero items still emits
+// `"count":0`. The previous shared-struct + omitempty approach
+// dropped those fields and forced SSE consumers to special-case
+// "count missing" vs "count == 0".
+//
+// Field-set contract by event type:
+//
+//	service_start:  event, service, (region|location), ts
+//	service_finish: event, service, (region|location), count, duration_ms, ts
+//	item_found:     event, service, (region|location), tf_type, import_id, ts
+//	stage_finish:   event, stage, count, total, duration_ms, ts
+//
+// Region/Location selection: prefer Location when set (GCP
+// emitters), otherwise emit Region (AWS emitters and global
+// services). Empty Region for global AWS services produces
+// `"region":""`, matching the existing IAM emit shape. An unknown
+// Event value falls back to a struct-alias marshal so we don't
+// silently drop fields if the contract grows.
+func (e Event) MarshalJSON() ([]byte, error) {
+	switch e.Event {
+	case "service_start":
+		if e.Location != "" {
+			return json.Marshal(struct {
+				Event     string    `json:"event"`
+				Service   string    `json:"service"`
+				Location  string    `json:"location"`
+				Timestamp time.Time `json:"ts"`
+			}{e.Event, e.Service, e.Location, e.Timestamp})
+		}
+		return json.Marshal(struct {
+			Event     string    `json:"event"`
+			Service   string    `json:"service"`
+			Region    string    `json:"region"`
+			Timestamp time.Time `json:"ts"`
+		}{e.Event, e.Service, e.Region, e.Timestamp})
+	case "service_finish":
+		if e.Location != "" {
+			return json.Marshal(struct {
+				Event      string    `json:"event"`
+				Service    string    `json:"service"`
+				Location   string    `json:"location"`
+				Count      int       `json:"count"`
+				DurationMs int64     `json:"duration_ms"`
+				Timestamp  time.Time `json:"ts"`
+			}{e.Event, e.Service, e.Location, e.Count, e.DurationMs, e.Timestamp})
+		}
+		return json.Marshal(struct {
+			Event      string    `json:"event"`
+			Service    string    `json:"service"`
+			Region     string    `json:"region"`
+			Count      int       `json:"count"`
+			DurationMs int64     `json:"duration_ms"`
+			Timestamp  time.Time `json:"ts"`
+		}{e.Event, e.Service, e.Region, e.Count, e.DurationMs, e.Timestamp})
+	case "item_found":
+		if e.Location != "" {
+			return json.Marshal(struct {
+				Event     string    `json:"event"`
+				Service   string    `json:"service"`
+				Location  string    `json:"location"`
+				TFType    string    `json:"tf_type"`
+				ImportID  string    `json:"import_id"`
+				Timestamp time.Time `json:"ts"`
+			}{e.Event, e.Service, e.Location, e.TFType, e.ImportID, e.Timestamp})
+		}
+		return json.Marshal(struct {
+			Event     string    `json:"event"`
+			Service   string    `json:"service"`
+			Region    string    `json:"region"`
+			TFType    string    `json:"tf_type"`
+			ImportID  string    `json:"import_id"`
+			Timestamp time.Time `json:"ts"`
+		}{e.Event, e.Service, e.Region, e.TFType, e.ImportID, e.Timestamp})
+	case "stage_finish":
+		return json.Marshal(struct {
+			Event      string    `json:"event"`
+			Stage      string    `json:"stage"`
+			Count      int       `json:"count"`
+			Total      int       `json:"total"`
+			DurationMs int64     `json:"duration_ms"`
+			Timestamp  time.Time `json:"ts"`
+		}{e.Event, e.Stage, e.Count, e.Total, e.DurationMs, e.Timestamp})
+	default:
+		// Unknown event type — defensive fallback. Marshal the
+		// struct verbatim via an alias to avoid recursing back
+		// into this method. The struct-tag omitempty on the
+		// optional fields suppresses zero-value noise for unknown
+		// shapes (where we have no per-event contract to honor).
+		type alias Event
+		return json.Marshal(alias(e))
+	}
 }
 
 // Emitter is the per-service progress contract. Default implementation

--- a/cmd/insideout-import/progress/progress_test.go
+++ b/cmd/insideout-import/progress/progress_test.go
@@ -49,7 +49,9 @@ func TestJSONEmitter_ItemFoundShape(t *testing.T) {
 // AND asserts that DurationMs comes through as the integer milliseconds
 // of the supplied time.Duration (1.234s → 1234). A regression that
 // switched to Nanoseconds() / Seconds() would silently shift the units
-// the downstream UI reads.
+// the downstream UI reads. Per #312, count and duration_ms must always
+// appear on service_finish — see TestJSONEmitter_ServiceFinishCountZeroEmitted
+// for the count==0 negative half of the same contract.
 func TestJSONEmitter_ServiceFinishShape(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
@@ -61,8 +63,26 @@ func TestJSONEmitter_ServiceFinishShape(t *testing.T) {
 	if got != want {
 		t.Errorf("ServiceFinish line mismatch:\n got: %s\nwant: %s", got, want)
 	}
+	// Belt-and-suspenders: parse the bytes and confirm count + duration_ms
+	// are present (#312 fix). The exact-string match above already pins
+	// this, but the field-presence assertion catches a regression that
+	// shifts ordering without dropping the field.
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, ok := evt["count"]; !ok {
+		t.Errorf("count must be present on service_finish (#312)")
+	}
+	if _, ok := evt["duration_ms"]; !ok {
+		t.Errorf("duration_ms must be present on service_finish (#312)")
+	}
 }
 
+// TestJSONEmitter_StageFinishShape pins all three numeric fields
+// (count, total, duration_ms) MUST appear on stage_finish, and pairs
+// with TestJSONEmitter_StageFinishCountZeroEmitted for the count==0
+// half of the #312 contract.
 func TestJSONEmitter_StageFinishShape(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
@@ -73,6 +93,194 @@ func TestJSONEmitter_StageFinishShape(t *testing.T) {
 	want := `{"event":"stage_finish","stage":"discover","count":7,"total":7,"duration_ms":5000,"ts":"2026-05-07T12:00:00Z"}`
 	if got != want {
 		t.Errorf("StageFinish line mismatch:\n got: %s\nwant: %s", got, want)
+	}
+	// Belt-and-suspenders: parse and confirm all three numeric fields
+	// land on the wire — the failure mode #312 fixes is silent absence,
+	// not wrong values, so a presence-pin guards future refactors.
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, k := range []string{"count", "total", "duration_ms"} {
+		if _, ok := evt[k]; !ok {
+			t.Errorf("%q must be present on stage_finish (#312)", k)
+		}
+	}
+}
+
+// TestJSONEmitter_ServiceFinishCountZeroEmitted is the headline #312
+// regression test: a service_finish event whose scope yielded zero
+// items must still emit `"count":0` and `"duration_ms":0` so SSE
+// consumers can render "0 of 0" without special-casing absent
+// fields. The pre-fix shape used omitempty on Count/DurationMs and
+// dropped both keys on the zero-result branch.
+func TestJSONEmitter_ServiceFinishCountZeroEmitted(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.ServiceFinish("sqs", "us-east-1", 0, 0)
+
+	got := strings.TrimRight(buf.String(), "\n")
+	if !strings.Contains(got, `"count":0`) {
+		t.Errorf(`expected "count":0 on zero-result service_finish; got: %s`, got)
+	}
+	if !strings.Contains(got, `"duration_ms":0`) {
+		t.Errorf(`expected "duration_ms":0 on zero-result service_finish; got: %s`, got)
+	}
+	// Parse for structural assertion — the substring match above
+	// would also fire on `"count":0,"other":1` etc., but the parse
+	// confirms count is genuinely a top-level field.
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if v, ok := evt["count"]; !ok || v.(float64) != 0 {
+		t.Errorf("count must be 0 on zero-result service_finish; got %v ok=%v", v, ok)
+	}
+	if v, ok := evt["duration_ms"]; !ok || v.(float64) != 0 {
+		t.Errorf("duration_ms must be 0 on zero-result service_finish; got %v ok=%v", v, ok)
+	}
+}
+
+// TestJSONEmitter_StageFinishCountZeroEmitted asserts the second half
+// of the #312 contract: stage_finish with zero items must emit all
+// three numeric fields, including total=0 (which omitempty also
+// dropped pre-fix).
+func TestJSONEmitter_StageFinishCountZeroEmitted(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.StageFinish("discover", 0, 0)
+
+	got := strings.TrimRight(buf.String(), "\n")
+	for _, want := range []string{`"count":0`, `"total":0`, `"duration_ms":0`} {
+		if !strings.Contains(got, want) {
+			t.Errorf(`expected %s on zero-result stage_finish; got: %s`, want, got)
+		}
+	}
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, k := range []string{"count", "total", "duration_ms"} {
+		v, ok := evt[k]
+		if !ok {
+			t.Errorf("%q must be present on zero-result stage_finish (#312)", k)
+			continue
+		}
+		if f, isF := v.(float64); !isF || f != 0 {
+			t.Errorf("%q must be 0 on zero-result stage_finish; got %v", k, v)
+		}
+	}
+}
+
+// TestJSONEmitter_ItemFoundOmitsCountField pins the negative half of
+// the #312 contract: numeric fields that belong to service_finish /
+// stage_finish must NOT appear on item_found, even though
+// MarshalJSON now disables struct-tag omitempty on them.
+func TestJSONEmitter_ItemFoundOmitsCountField(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.ItemFound("sqs", "us-east-1", "aws_sqs_queue", "https://sqs.us-east-1.amazonaws.com/123/q1")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, k := range []string{"count", "total", "duration_ms"} {
+		if _, present := evt[k]; present {
+			t.Errorf("item_found must not carry %q; got: %s", k, got)
+		}
+	}
+}
+
+// TestJSONEmitter_ServiceStartOmitsCountField is the negative pin for
+// service_start: a phase-start event has no count/total/duration yet,
+// and MarshalJSON must not leak zero-valued numeric fields.
+func TestJSONEmitter_ServiceStartOmitsCountField(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.ServiceStart("sqs", "us-east-1")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, k := range []string{"count", "total", "duration_ms"} {
+		if _, present := evt[k]; present {
+			t.Errorf("service_start must not carry %q; got: %s", k, got)
+		}
+	}
+}
+
+// TestJSONEmitter_GCPLocationFieldUsed exercises the Region vs Location
+// branch in MarshalJSON: when an Event has Location set (GCP
+// discoverers), the wire shape must emit `"location":...` and never
+// `"region":...`. The public Emitter API on JSONEmitter only takes a
+// `region` parameter, so we construct the Event directly and call
+// json.Marshal — the same path the writer uses internally.
+func TestJSONEmitter_GCPLocationFieldUsed(t *testing.T) {
+	t.Parallel()
+	ts, _ := time.Parse(time.RFC3339Nano, "2026-05-07T12:00:00Z")
+	for _, eventType := range []string{"service_start", "service_finish", "item_found"} {
+		eventType := eventType
+		t.Run(eventType, func(t *testing.T) {
+			t.Parallel()
+			evt := Event{
+				Event:     eventType,
+				Service:   "cloud_asset_inventory",
+				Location:  "us-central1",
+				TFType:    "google_compute_instance",
+				ImportID:  "projects/p/zones/us-central1-a/instances/i",
+				Count:     5,
+				Timestamp: ts,
+			}
+			b, err := json.Marshal(evt)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			s := string(b)
+			if !strings.Contains(s, `"location":"us-central1"`) {
+				t.Errorf(`expected "location":"us-central1" on %s; got: %s`, eventType, s)
+			}
+			if strings.Contains(s, `"region":`) {
+				t.Errorf("Location-set event must not also emit region; got: %s", s)
+			}
+		})
+	}
+}
+
+// TestJSONEmitter_GlobalServiceEmptyRegionShape pins the IAM-style
+// global-service emit shape: when an emitter calls ServiceStart(slug,
+// "") the wire output carries "region":"" rather than dropping the
+// field entirely. This is a deliberate semantic choice (see Event
+// docstring) — the empty string parses identically to "no region
+// scope" downstream, and avoiding a third Marshal branch keeps the
+// dispatch readable.
+func TestJSONEmitter_GlobalServiceEmptyRegionShape(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	e := NewJSONEmitter(&buf).WithNow(fixedNow())
+	e.ServiceStart("iam", "")
+
+	got := strings.TrimRight(buf.String(), "\n")
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(got), &evt); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	v, ok := evt["region"]
+	if !ok {
+		t.Errorf("global service ServiceStart must emit region key; got: %s", got)
+	}
+	if s, isS := v.(string); !isS || s != "" {
+		t.Errorf(`region must be "" on global service; got %v`, v)
+	}
+	if _, present := evt["location"]; present {
+		t.Errorf("global service ServiceStart must not emit location; got: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Purpose

A single branch + PR that subsumes all four open Bundle 3 PRs so the cumulative diff can be reviewed in one place. **This PR is for review convenience.** The actual landing path is the four individual stacked PRs — merge those, then close this one. Or, squash-merge this PR and close the rest. Either path lands the same code.

## Context

Bundle 3 — refinements deferred during the umbrella #289 review pass and tracked as four follow-up issues:

- **#309** — bound result accumulation in Resource Explorer + Cloud Asset enumeration
- **#310** — refactor `discoveryAggregator.DiscoverTypes` from a 7-arg signature to an `AggArgs` struct
- **#311** — per-stage context timeouts so optional Stage 1.5 (`--include-unsupported`) can't starve mandatory stages
- **#312** — `Event.MarshalJSON` so `service_finish`/`stage_finish` always emit `count=0` (today `omitempty` drops it)

## Stack

The four commits in this branch are exactly the tip commits of the four stacked PRs, in landing order:

| # | Commit    | Ticket | Source PR | Branch                            |
|---|-----------|--------|-----------|-----------------------------------|
| 1 | `f4c26ce` | #310   | #313      | `feat/aggargs-310`                |
| 2 | `1ed1daf` | #309   | #314      | `feat/maxresults-cap-309`         |
| 3 | `c243a30` | #311   | #315      | `feat/per-stage-timeouts-311`     |
| 4 | `2b7bc09` | #312   | #316      | `feat/event-marshaljson-312`      |

## What this delivers

- **#310 / AggArgs refactor** — `discoveryAggregator.DiscoverTypes` is now a single struct argument. Future fields (per-stage timeout budgets, etc.) are additive without re-touching every adapter and test fake. Drive-by drop of stale `TODO(#297)` on `imported_unsupported.go`.
- **#309 / `--max-unsupported-results`** — caps unsupported enumeration per cloud (default `10000`, `0` disables). AWS path stops fetching pages early (saves API budget); GCP path caps at the wrapper since `SearchAll` is shared with the importable scan. `unsupported.json` is now a wrapper object `{resources, truncated, max_results}` — wire-format break, justified inline.
- **#311 / per-stage context timeouts** — replaces the single 15-min `discoverTimeout` with seven per-stage budgets plus a 25-min outer cap. Each stage call site wraps the parent ctx in `context.WithTimeout`; misbehaving stages can't starve mandatory ones. `var` instead of `const` so tests can shrink budgets to ~50ms for fast deterministic timeout pins.
- **#312 / `Event.MarshalJSON`** — `service_finish` and `stage_finish` always emit `count`/`total`/`duration_ms` (no more `omitempty`-dropping `count=0`). `service_start` and `item_found` never carry those fields. Per-event-type field shape is explicit in code and pinned with new positive + negative tests.

## Verification

Locally on this combined branch (off `main`):

- [x] `go build ./...`
- [x] `go test ./cmd/insideout-import/... ./pkg/composer/... ./pkg/insideout-import/... -count=1 -race` — **2071 passed across 13 packages**
- [x] `go vet ./...`
- [x] `gofmt -l cmd/ pkg/` — no drift
- [x] All 8 static lint scripts (`lint-project-tag`, `lint-project-label`, `lint-sensitive-for-each`, `lint-foreach-unknown-keys`, `lint-no-root-only-blocks`, `lint-shared-no-cloud-providers`, `lint-labelless-name-prefix`, `lint-gcp-project-pin`) — PASS

## Closes

Closes #309, #310, #311, #312 on merge.

## Notes

- Commits preserved unsquashed so `git log --oneline` still maps cleanly to the four tickets. GitHub's "Squash and merge" works equivalently.
- Each individual stacked PR has its own per-ticket review thread if you want narrower diffs (#313, #314, #315, #316).
- Two wire-format breaks: (a) `unsupported.json` wrapper object (#309), and (b) finish-event `count=0` semantics (#312). Both justified — the reliable consumer hasn't shipped, so the cost of "correct now" beats "back-compat with the buggy shape."