### PR TITLE
feat(awsdiscover): VPC core discoverers (vpc, subnet, security_group) (#319)

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -133,6 +133,9 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 			"aws_iam_policy":            newIAMPolicyDiscoverer(cfg),
 			"aws_kms_key":               newKMSDiscoverer(cfg),
 			"aws_s3_bucket":             newS3Discoverer(cfg),
+			"aws_vpc":                   newVPCDiscoverer(cfg),
+			"aws_subnet":                newSubnetDiscoverer(cfg),
+			"aws_security_group":        newSecurityGroupDiscoverer(cfg),
 		},
 	}
 }
@@ -156,6 +159,9 @@ var serviceSlugByTFType = map[string]string{
 	"aws_iam_policy":            "iam_policy",
 	"aws_kms_key":               "kms",
 	"aws_s3_bucket":             "s3",
+	"aws_vpc":                   "vpc",
+	"aws_subnet":                "subnet",
+	"aws_security_group":        "security_group",
 }
 
 // ServiceSlug returns the progress-event slug for a Terraform resource

--- a/cmd/insideout-import/awsdiscover/security_group.go
+++ b/cmd/insideout-import/awsdiscover/security_group.go
@@ -1,0 +1,208 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// securityGroupClient is the narrow subset of the EC2 SDK the security
+// group discoverer uses. The describe response carries the tag map inline
+// so no separate DescribeTags round-trip is required (Bundle 4 / #319).
+type securityGroupClient interface {
+	DescribeSecurityGroups(ctx context.Context, in *ec2.DescribeSecurityGroupsInput, opts ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error)
+}
+
+type securityGroupDiscoverer struct {
+	new func(region string) securityGroupClient
+}
+
+func newSecurityGroupDiscoverer(cfg aws.Config) Discoverer {
+	return &securityGroupDiscoverer{new: func(region string) securityGroupClient {
+		return ec2.NewFromConfig(cfg, func(o *ec2.Options) {
+			if region != "" {
+				o.Region = region
+			}
+		})
+	}}
+}
+
+func (d *securityGroupDiscoverer) ResourceType() string { return "aws_security_group" }
+
+// Discover lists security groups whose Project tag matches args.Project.
+// EC2 supports server-side `tag:Key` filters on DescribeSecurityGroups,
+// so we never have to download every SG in the account just to filter
+// client-side. When args.Project is empty (admin path) the request omits
+// the filter.
+//
+// Multi-region (#291): loops args.Regions, building a per-region SDK
+// client. Tags are inline on each ec2types.SecurityGroup — no
+// per-resource DescribeTags fetch is needed.
+//
+// Import ID for aws_security_group is the group ID (sg-XXXXXXXX).
+//
+// Note: the AWS-managed default security group ("default" GroupName) on
+// every VPC is currently included in the result set. Skip-list handling
+// is deferred to Bundle 4 PR 3 (per #319's "out of scope" note).
+func (d *securityGroupDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
+	book := addressBook{}
+	const slug = "security_group"
+	var out []imported.ImportedResource
+	for _, region := range args.Regions {
+		regionStart := time.Now()
+		args.Emitter.ServiceStart(slug, region)
+		regionCount := 0
+		client := d.new(region)
+		input := &ec2.DescribeSecurityGroupsInput{}
+		if args.Project != "" {
+			input.Filters = []ec2types.Filter{{
+				Name:   aws.String("tag:Project"),
+				Values: []string{args.Project},
+			}}
+		}
+
+		groups, err := paginateDescribeSecurityGroups(ctx, client, input)
+		if err != nil {
+			args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
+			return nil, fmt.Errorf("DescribeSecurityGroups (region=%s): %w", region, err)
+		}
+
+		// Sort by group ID so the emitted manifest is deterministic across runs.
+		sort.Slice(groups, func(i, j int) bool {
+			return aws.ToString(groups[i].GroupId) < aws.ToString(groups[j].GroupId)
+		})
+
+		for i := range groups {
+			g := &groups[i]
+			id := aws.ToString(g.GroupId)
+			tags := ec2TagsToMap(g.Tags)
+			if !MatchesAll(tags, args.TagSelectors) {
+				continue
+			}
+			// Prefer the SDK GroupName (always set) over a Name tag — for
+			// security groups the GroupName is the canonical human-readable
+			// label and is what the AWS console surfaces in pickers.
+			name := aws.ToString(g.GroupName)
+			if name == "" {
+				name = id
+			}
+			out = append(out, makeImportedResource(
+				book,
+				"aws_security_group",
+				name,
+				id,
+				region,
+				args.AccountID,
+				map[string]string{
+					"group_id":   id,
+					"group_name": aws.ToString(g.GroupName),
+					"vpc_id":     aws.ToString(g.VpcId),
+				},
+				tags,
+			))
+			args.Emitter.ItemFound(slug, region, "aws_security_group", id)
+			regionCount++
+		}
+		args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
+	}
+	return out, nil
+}
+
+// DiscoverByID resolves a security group by group ID (sg-XXXXXXXX) or ARN
+// (arn:aws:ec2:<region>:<account>:security-group/sg-XXXXXXXX). Issues a
+// single DescribeSecurityGroups call with the group ID to verify existence.
+func (d *securityGroupDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	groupID, err := securityGroupIDFromID(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
+
+	client := d.new(region)
+	out, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{GroupIds: []string{groupID}})
+	if err != nil {
+		// EC2 surfaces "InvalidGroup.NotFound" as a generic API error,
+		// not a typed exception. Match by code substring (mirror s3.go).
+		if strings.Contains(err.Error(), "InvalidGroup.NotFound") {
+			return imported.ImportedResource{}, fmt.Errorf("aws_security_group %q: %w", groupID, ErrNotFound)
+		}
+		return imported.ImportedResource{}, fmt.Errorf("DescribeSecurityGroups: %w", err)
+	}
+	if len(out.SecurityGroups) == 0 {
+		return imported.ImportedResource{}, fmt.Errorf("aws_security_group %q: %w", groupID, ErrNotFound)
+	}
+	g := &out.SecurityGroups[0]
+	name := aws.ToString(g.GroupName)
+	if name == "" {
+		name = groupID
+	}
+	return makeImportedResource(
+		addressBook{},
+		"aws_security_group",
+		name,
+		groupID,
+		region,
+		accountID,
+		map[string]string{
+			"group_id":   groupID,
+			"group_name": aws.ToString(g.GroupName),
+			"vpc_id":     aws.ToString(g.VpcId),
+		},
+		nil,
+	), nil
+}
+
+// securityGroupIDFromID extracts the group ID (sg-XXXXXXXX) from one of
+// two accepted inputs: the bare group ID, or an EC2 ARN of the shape
+// arn:aws:ec2:<region>:<account>:security-group/sg-XXXXXXXX. Anything
+// else returns ErrNotSupported so dep-chase routes it to its
+// unresolvable bucket.
+func securityGroupIDFromID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("security_group: empty id: %w", ErrNotSupported)
+	}
+	if awsarn.IsARN(id) {
+		parsed, err := awsarn.Parse(id)
+		if err != nil {
+			return "", fmt.Errorf("security_group: parse arn: %w", err)
+		}
+		if parsed.Service != "ec2" {
+			return "", fmt.Errorf("security_group: not an ec2 arn (service=%q): %w", parsed.Service, ErrNotSupported)
+		}
+		parts := strings.SplitN(parsed.Resource, "/", 2)
+		if len(parts) != 2 || parts[0] != "security-group" || !strings.HasPrefix(parts[1], "sg-") {
+			return "", fmt.Errorf("security_group: arn resource %q is not security-group/sg-…: %w", parsed.Resource, ErrNotSupported)
+		}
+		return parts[1], nil
+	}
+	if !strings.HasPrefix(id, "sg-") || strings.ContainsAny(id, " :/") {
+		return "", fmt.Errorf("security_group: unrecognized id %q: %w", id, ErrNotSupported)
+	}
+	return id, nil
+}
+
+// paginateDescribeSecurityGroups walks all NextToken pages.
+func paginateDescribeSecurityGroups(ctx context.Context, client securityGroupClient, input *ec2.DescribeSecurityGroupsInput) ([]ec2types.SecurityGroup, error) {
+	var all []ec2types.SecurityGroup
+	for {
+		out, err := client.DescribeSecurityGroups(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, out.SecurityGroups...)
+		if out.NextToken == nil || *out.NextToken == "" {
+			return all, nil
+		}
+		input.NextToken = out.NextToken
+	}
+}

--- a/cmd/insideout-import/awsdiscover/security_group_test.go
+++ b/cmd/insideout-import/awsdiscover/security_group_test.go
@@ -1,0 +1,406 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// errSGSeed is the package-level sentinel for security_group error
+// propagation — see vpc_test.go for the contract.
+var errSGSeed = errors.New("AccessDenied")
+
+type fakeSecurityGroupClient struct {
+	pages []ec2.DescribeSecurityGroupsOutput
+	calls []ec2.DescribeSecurityGroupsInput
+	err   error
+}
+
+func (f *fakeSecurityGroupClient) DescribeSecurityGroups(_ context.Context, in *ec2.DescribeSecurityGroupsInput, _ ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+	f.calls = append(f.calls, *in)
+	if f.err != nil {
+		return nil, f.err
+	}
+	idx := len(f.calls) - 1
+	if idx >= len(f.pages) {
+		return &ec2.DescribeSecurityGroupsOutput{}, nil
+	}
+	return &f.pages[idx], nil
+}
+
+func sgWithTags(id, name, vpcID string, tags map[string]string) ec2types.SecurityGroup {
+	g := ec2types.SecurityGroup{
+		GroupId:   aws.String(id),
+		GroupName: aws.String(name),
+		VpcId:     aws.String(vpcID),
+	}
+	for k, v := range tags {
+		g.Tags = append(g.Tags, ec2types.Tag{Key: aws.String(k), Value: aws.String(v)})
+	}
+	return g
+}
+
+func TestSecurityGroupDiscover_HappyPath(t *testing.T) {
+	t.Parallel()
+	d := &securityGroupDiscoverer{new: func(_ string) securityGroupClient {
+		return &fakeSecurityGroupClient{
+			pages: []ec2.DescribeSecurityGroupsOutput{
+				{
+					SecurityGroups: []ec2types.SecurityGroup{
+						sgWithTags("sg-0947e82d14371a085", "io-foo-app", "vpc-052c72972a11f8677", map[string]string{"Project": "io-foo"}),
+						sgWithTags("sg-0aaaa00000000aaa1", "io-foo-db", "vpc-052c72972a11f8677", map[string]string{"Project": "io-foo"}),
+					},
+				},
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+	for _, ir := range got {
+		if ir.Identity.Type != "aws_security_group" {
+			t.Errorf("Type=%q, want aws_security_group", ir.Identity.Type)
+		}
+		if ir.Identity.ImportID == "" {
+			t.Error("ImportID empty")
+		}
+		if ir.Identity.NativeIDs["group_id"] == "" {
+			t.Error("NativeIDs[group_id] empty")
+		}
+		if ir.Identity.NativeIDs["group_name"] == "" {
+			t.Error("NativeIDs[group_name] empty")
+		}
+		if ir.Identity.NativeIDs["vpc_id"] == "" {
+			t.Error("NativeIDs[vpc_id] empty")
+		}
+	}
+	// Output is sorted by group ID.
+	if got[0].Identity.ImportID != "sg-0947e82d14371a085" {
+		t.Errorf("first ImportID=%q, want sg-0947e82d14371a085 (sorted)", got[0].Identity.ImportID)
+	}
+	// GroupName wins as NameHint over any Name tag — for SGs the
+	// GroupName is the canonical label.
+	if got[0].Identity.NameHint != "io-foo-app" {
+		t.Errorf("first NameHint=%q, want io-foo-app (GroupName)", got[0].Identity.NameHint)
+	}
+}
+
+func TestSecurityGroupDiscover_PaginatesUntilNoToken(t *testing.T) {
+	t.Parallel()
+	d := &securityGroupDiscoverer{new: func(_ string) securityGroupClient {
+		return &fakeSecurityGroupClient{
+			pages: []ec2.DescribeSecurityGroupsOutput{
+				{SecurityGroups: []ec2types.SecurityGroup{sgWithTags("sg-aaa00000000000001", "a", "vpc-1", nil)}, NextToken: aws.String("tok1")},
+				{SecurityGroups: []ec2types.SecurityGroup{sgWithTags("sg-bbb00000000000002", "b", "vpc-1", nil)}, NextToken: aws.String("tok2")},
+				{SecurityGroups: []ec2types.SecurityGroup{sgWithTags("sg-ccc00000000000003", "c", "vpc-1", nil)}}, // terminal
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len=%d, want 3 (paginated)", len(got))
+	}
+}
+
+func TestSecurityGroupDiscover_PassesProjectTagFilterServerSide(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSecurityGroupClient{}
+	d := &securityGroupDiscoverer{new: func(_ string) securityGroupClient { return fake }}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) == 0 {
+		t.Fatal("expected at least one DescribeSecurityGroups call")
+	}
+	in := fake.calls[0]
+	if len(in.Filters) == 0 {
+		t.Fatal("expected at least one Filter on DescribeSecurityGroupsInput")
+	}
+	if got := aws.ToString(in.Filters[0].Name); got != "tag:Project" {
+		t.Errorf("Filters[0].Name=%q, want tag:Project", got)
+	}
+	if len(in.Filters[0].Values) == 0 || in.Filters[0].Values[0] != "io-foo" {
+		t.Errorf("Filters[0].Values=%v, want [io-foo]", in.Filters[0].Values)
+	}
+}
+
+func TestSecurityGroupDiscover_EmptyProjectPassesNoFilter(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSecurityGroupClient{}
+	d := &securityGroupDiscoverer{new: func(_ string) securityGroupClient { return fake }}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{Project: "", Regions: []string{"us-east-1"}, AccountID: "123"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) == 0 {
+		t.Fatal("expected at least one DescribeSecurityGroups call")
+	}
+	if len(fake.calls[0].Filters) != 0 {
+		t.Errorf("Filters=%v, want empty for empty project", fake.calls[0].Filters)
+	}
+}
+
+func TestSecurityGroupDiscover_PropagatesError(t *testing.T) {
+	t.Parallel()
+	d := &securityGroupDiscoverer{new: func(_ string) securityGroupClient {
+		return &fakeSecurityGroupClient{err: errSGSeed}
+	}}
+	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, errSGSeed) {
+		t.Errorf("err=%v, want errors.Is(err, errSGSeed)", err)
+	}
+}
+
+func TestSecurityGroupDiscoverByID_AcceptsGroupID(t *testing.T) {
+	t.Parallel()
+	d := &securityGroupDiscoverer{new: func(_ string) securityGroupClient {
+		return &fakeSecurityGroupClient{pages: []ec2.DescribeSecurityGroupsOutput{
+			{SecurityGroups: []ec2types.SecurityGroup{sgWithTags("sg-0947e82d14371a085", "io-foo-app", "vpc-052c72972a11f8677", nil)}},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), "sg-0947e82d14371a085", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.Type != "aws_security_group" {
+		t.Errorf("Type=%q", got.Identity.Type)
+	}
+	if got.Identity.ImportID != "sg-0947e82d14371a085" {
+		t.Errorf("ImportID=%q", got.Identity.ImportID)
+	}
+	if got.Identity.NameHint != "io-foo-app" {
+		t.Errorf("NameHint=%q, want io-foo-app", got.Identity.NameHint)
+	}
+	if got.Identity.NativeIDs["vpc_id"] != "vpc-052c72972a11f8677" {
+		t.Errorf("NativeIDs[vpc_id]=%q", got.Identity.NativeIDs["vpc_id"])
+	}
+	if got.Identity.Tags != nil {
+		t.Errorf("Tags=%v, want nil from DiscoverByID", got.Identity.Tags)
+	}
+}
+
+func TestSecurityGroupDiscoverByID_AcceptsARN(t *testing.T) {
+	t.Parallel()
+	d := &securityGroupDiscoverer{new: func(_ string) securityGroupClient {
+		return &fakeSecurityGroupClient{pages: []ec2.DescribeSecurityGroupsOutput{
+			{SecurityGroups: []ec2types.SecurityGroup{sgWithTags("sg-0947e82d14371a085", "io-foo-app", "vpc-1", nil)}},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(),
+		"arn:aws:ec2:us-east-1:123:security-group/sg-0947e82d14371a085", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.ImportID != "sg-0947e82d14371a085" {
+		t.Errorf("ImportID=%q", got.Identity.ImportID)
+	}
+}
+
+func TestSecurityGroupDiscoverByID_NotFound(t *testing.T) {
+	t.Parallel()
+	d := &securityGroupDiscoverer{new: func(_ string) securityGroupClient { return &fakeSecurityGroupClient{} }}
+	_, err := d.DiscoverByID(context.Background(), "sg-deadbeef00000000", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestSecurityGroupDiscoverByID_NotFound_FromAPIErrorCode(t *testing.T) {
+	t.Parallel()
+	d := &securityGroupDiscoverer{new: func(_ string) securityGroupClient {
+		return &fakeSecurityGroupClient{err: errors.New("api error InvalidGroup.NotFound: The security group 'sg-deadbeef' does not exist")}
+	}}
+	_, err := d.DiscoverByID(context.Background(), "sg-deadbeef00000000", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestSecurityGroupDiscover_MultiRegionTriggersOneSDKCallPerRegion(t *testing.T) {
+	t.Parallel()
+	fakes := map[string]*fakeSecurityGroupClient{
+		"us-east-1": {pages: []ec2.DescribeSecurityGroupsOutput{
+			{SecurityGroups: []ec2types.SecurityGroup{sgWithTags("sg-east0000000000001", "east", "vpc-1", nil)}},
+		}},
+		"eu-west-1": {pages: []ec2.DescribeSecurityGroupsOutput{
+			{SecurityGroups: []ec2types.SecurityGroup{sgWithTags("sg-west0000000000001", "west", "vpc-2", nil)}},
+		}},
+	}
+	var seenRegions []string
+	d := &securityGroupDiscoverer{new: func(region string) securityGroupClient {
+		seenRegions = append(seenRegions, region)
+		f, ok := fakes[region]
+		if !ok {
+			t.Fatalf("closure called with unexpected region %q", region)
+		}
+		return f
+	}}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(seenRegions) != 2 {
+		t.Errorf("region closure invocations = %v, want 2 entries", seenRegions)
+	}
+	if len(fakes["us-east-1"].calls) == 0 || len(fakes["eu-west-1"].calls) == 0 {
+		t.Error("expected one DescribeSecurityGroups call per region")
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+}
+
+func TestSecurityGroupDiscover_TagSelectorAppliedAsFilter(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSecurityGroupClient{
+		pages: []ec2.DescribeSecurityGroupsOutput{{SecurityGroups: []ec2types.SecurityGroup{
+			sgWithTags("sg-prod000000000001", "prod-sg", "vpc-1", map[string]string{"env": "prod"}),
+			sgWithTags("sg-stag000000000002", "staging-sg", "vpc-1", map[string]string{"env": "staging"}),
+		}}},
+	}
+	d := &securityGroupDiscoverer{new: func(_ string) securityGroupClient { return fake }}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:      "io-foo",
+		Regions:      []string{"us-east-1"},
+		AccountID:    "123",
+		TagSelectors: []TagSelector{{Key: "env", Value: "prod"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (only env=prod SG should pass)", len(got))
+	}
+	if got[0].Identity.NameHint != "prod-sg" {
+		t.Errorf("NameHint=%q, want prod-sg", got[0].Identity.NameHint)
+	}
+	if got[0].Identity.Tags["env"] != "prod" {
+		t.Errorf("Tags[env]=%q, want prod (filter+persist contract)", got[0].Identity.Tags["env"])
+	}
+}
+
+func TestSecurityGroupDiscover_EmitsServiceStartFinish_PerRegion(t *testing.T) {
+	t.Parallel()
+	fakes := map[string]*fakeSecurityGroupClient{
+		"us-east-1": {pages: []ec2.DescribeSecurityGroupsOutput{
+			{SecurityGroups: []ec2types.SecurityGroup{sgWithTags("sg-east0000000000001", "east", "vpc-1", nil)}},
+		}},
+		"eu-west-1": {pages: []ec2.DescribeSecurityGroupsOutput{
+			{SecurityGroups: []ec2types.SecurityGroup{sgWithTags("sg-west0000000000001", "west", "vpc-2", nil)}},
+		}},
+	}
+	d := &securityGroupDiscoverer{new: func(region string) securityGroupClient { return fakes[region] }}
+	rec := &recordingEmitter{}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	events := rec.snapshot()
+
+	type bracket struct{ start, finish int }
+	got := map[string]bracket{}
+	for i, e := range events {
+		switch e.Kind {
+		case "service_start":
+			b := got[e.Region]
+			b.start = i + 1
+			got[e.Region] = b
+		case "service_finish":
+			b := got[e.Region]
+			b.finish = i + 1
+			got[e.Region] = b
+		}
+		if e.Kind == "service_start" || e.Kind == "service_finish" {
+			if e.Service != "security_group" {
+				t.Errorf("event %d: service=%q, want security_group", i, e.Service)
+			}
+		}
+	}
+	for _, region := range []string{"us-east-1", "eu-west-1"} {
+		if got[region].start == 0 || got[region].finish == 0 {
+			t.Errorf("%s: missing service_start or service_finish: %+v", region, got[region])
+		}
+		if got[region].start >= got[region].finish {
+			t.Errorf("%s: start at %d >= finish at %d", region, got[region].start, got[region].finish)
+		}
+	}
+}
+
+func TestSecurityGroupDiscover_EmitsItemFound_PerSecurityGroup(t *testing.T) {
+	t.Parallel()
+	ids := []string{"sg-aaa00000000000001", "sg-bbb00000000000002", "sg-ccc00000000000003"}
+	gs := make([]ec2types.SecurityGroup, 0, len(ids))
+	for _, id := range ids {
+		gs = append(gs, sgWithTags(id, "name-"+id, "vpc-1", nil))
+	}
+	fake := &fakeSecurityGroupClient{pages: []ec2.DescribeSecurityGroupsOutput{{SecurityGroups: gs}}}
+	d := &securityGroupDiscoverer{new: func(_ string) securityGroupClient { return fake }}
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var items []recordedEvent
+	for _, e := range rec.snapshot() {
+		if e.Kind == "item_found" {
+			items = append(items, e)
+		}
+	}
+	if len(items) != len(got) {
+		t.Errorf("item_found count = %d, want %d", len(items), len(got))
+	}
+	for i, it := range items {
+		if it.Service != "security_group" {
+			t.Errorf("item %d: service=%q, want security_group", i, it.Service)
+		}
+		if it.TFType != "aws_security_group" {
+			t.Errorf("item %d: tf_type=%q, want aws_security_group", i, it.TFType)
+		}
+	}
+}
+
+func TestSecurityGroupDiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &securityGroupDiscoverer{new: func(_ string) securityGroupClient { return &fakeSecurityGroupClient{} }}
+	cases := []string{
+		"",
+		"arn:aws:s3:::some-bucket",
+		"arn:aws:ec2:us-east-1:123:vpc/vpc-abc", // ec2 but not security-group
+		"vpc-1234",                              // wrong prefix
+		"sg 1234",                               // contains space
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/subnet.go
+++ b/cmd/insideout-import/awsdiscover/subnet.go
@@ -1,0 +1,196 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// subnetClient is the narrow subset of the EC2 SDK the subnet discoverer
+// uses. The describe response carries the tag map inline so no separate
+// DescribeTags round-trip is required (Bundle 4 / #319).
+type subnetClient interface {
+	DescribeSubnets(ctx context.Context, in *ec2.DescribeSubnetsInput, opts ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)
+}
+
+type subnetDiscoverer struct {
+	new func(region string) subnetClient
+}
+
+func newSubnetDiscoverer(cfg aws.Config) Discoverer {
+	return &subnetDiscoverer{new: func(region string) subnetClient {
+		return ec2.NewFromConfig(cfg, func(o *ec2.Options) {
+			if region != "" {
+				o.Region = region
+			}
+		})
+	}}
+}
+
+func (d *subnetDiscoverer) ResourceType() string { return "aws_subnet" }
+
+// Discover lists subnets whose Project tag matches args.Project. EC2
+// supports server-side `tag:Key` filters on DescribeSubnets, so we never
+// have to download every subnet in the account just to filter
+// client-side. When args.Project is empty (admin path) the request omits
+// the filter.
+//
+// Multi-region (#291): loops args.Regions, building a per-region SDK
+// client. Tags are inline on each ec2types.Subnet — no per-resource
+// DescribeTags fetch is needed.
+//
+// Import ID for aws_subnet is the subnet ID (subnet-XXXXXXXX).
+func (d *subnetDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
+	book := addressBook{}
+	const slug = "subnet"
+	var out []imported.ImportedResource
+	for _, region := range args.Regions {
+		regionStart := time.Now()
+		args.Emitter.ServiceStart(slug, region)
+		regionCount := 0
+		client := d.new(region)
+		input := &ec2.DescribeSubnetsInput{}
+		if args.Project != "" {
+			input.Filters = []ec2types.Filter{{
+				Name:   aws.String("tag:Project"),
+				Values: []string{args.Project},
+			}}
+		}
+
+		subnets, err := paginateDescribeSubnets(ctx, client, input)
+		if err != nil {
+			args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
+			return nil, fmt.Errorf("DescribeSubnets (region=%s): %w", region, err)
+		}
+
+		// Sort by subnet ID so the emitted manifest is deterministic across runs.
+		sort.Slice(subnets, func(i, j int) bool {
+			return aws.ToString(subnets[i].SubnetId) < aws.ToString(subnets[j].SubnetId)
+		})
+
+		for i := range subnets {
+			s := &subnets[i]
+			id := aws.ToString(s.SubnetId)
+			tags := ec2TagsToMap(s.Tags)
+			if !MatchesAll(tags, args.TagSelectors) {
+				continue
+			}
+			name := vpcName(s.Tags, id) // reuse the Name-tag-or-fallback helper
+			out = append(out, makeImportedResource(
+				book,
+				"aws_subnet",
+				name,
+				id,
+				region,
+				args.AccountID,
+				map[string]string{
+					"subnet_id":         id,
+					"vpc_id":            aws.ToString(s.VpcId),
+					"availability_zone": aws.ToString(s.AvailabilityZone),
+					"cidr_block":        aws.ToString(s.CidrBlock),
+				},
+				tags,
+			))
+			args.Emitter.ItemFound(slug, region, "aws_subnet", id)
+			regionCount++
+		}
+		args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
+	}
+	return out, nil
+}
+
+// DiscoverByID resolves a subnet by subnet ID (subnet-XXXXXXXX) or ARN
+// (arn:aws:ec2:<region>:<account>:subnet/subnet-XXXXXXXX). Issues a
+// single DescribeSubnets call with the subnet ID to verify existence.
+func (d *subnetDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	subnetID, err := subnetIDFromID(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
+
+	client := d.new(region)
+	out, err := client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{SubnetIds: []string{subnetID}})
+	if err != nil {
+		// EC2 surfaces "InvalidSubnetID.NotFound" as a generic API error,
+		// not a typed exception. Match by code substring (mirror s3.go).
+		if strings.Contains(err.Error(), "InvalidSubnetID.NotFound") {
+			return imported.ImportedResource{}, fmt.Errorf("aws_subnet %q: %w", subnetID, ErrNotFound)
+		}
+		return imported.ImportedResource{}, fmt.Errorf("DescribeSubnets: %w", err)
+	}
+	if len(out.Subnets) == 0 {
+		return imported.ImportedResource{}, fmt.Errorf("aws_subnet %q: %w", subnetID, ErrNotFound)
+	}
+	s := &out.Subnets[0]
+	name := vpcName(s.Tags, subnetID)
+	return makeImportedResource(
+		addressBook{},
+		"aws_subnet",
+		name,
+		subnetID,
+		region,
+		accountID,
+		map[string]string{
+			"subnet_id":         subnetID,
+			"vpc_id":            aws.ToString(s.VpcId),
+			"availability_zone": aws.ToString(s.AvailabilityZone),
+			"cidr_block":        aws.ToString(s.CidrBlock),
+		},
+		nil,
+	), nil
+}
+
+// subnetIDFromID extracts the subnet ID (subnet-XXXXXXXX) from one of two
+// accepted inputs: the bare subnet ID, or an EC2 ARN of the shape
+// arn:aws:ec2:<region>:<account>:subnet/subnet-XXXXXXXX. Anything else
+// returns ErrNotSupported so dep-chase routes it to its unresolvable bucket.
+func subnetIDFromID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("subnet: empty id: %w", ErrNotSupported)
+	}
+	if awsarn.IsARN(id) {
+		parsed, err := awsarn.Parse(id)
+		if err != nil {
+			return "", fmt.Errorf("subnet: parse arn: %w", err)
+		}
+		if parsed.Service != "ec2" {
+			return "", fmt.Errorf("subnet: not an ec2 arn (service=%q): %w", parsed.Service, ErrNotSupported)
+		}
+		parts := strings.SplitN(parsed.Resource, "/", 2)
+		if len(parts) != 2 || parts[0] != "subnet" || !strings.HasPrefix(parts[1], "subnet-") {
+			return "", fmt.Errorf("subnet: arn resource %q is not subnet/subnet-…: %w", parsed.Resource, ErrNotSupported)
+		}
+		return parts[1], nil
+	}
+	if !strings.HasPrefix(id, "subnet-") || strings.ContainsAny(id, " :/") {
+		return "", fmt.Errorf("subnet: unrecognized id %q: %w", id, ErrNotSupported)
+	}
+	return id, nil
+}
+
+// paginateDescribeSubnets walks all NextToken pages.
+func paginateDescribeSubnets(ctx context.Context, client subnetClient, input *ec2.DescribeSubnetsInput) ([]ec2types.Subnet, error) {
+	var all []ec2types.Subnet
+	for {
+		out, err := client.DescribeSubnets(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, out.Subnets...)
+		if out.NextToken == nil || *out.NextToken == "" {
+			return all, nil
+		}
+		input.NextToken = out.NextToken
+	}
+}

--- a/cmd/insideout-import/awsdiscover/subnet_test.go
+++ b/cmd/insideout-import/awsdiscover/subnet_test.go
@@ -1,0 +1,411 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// errSubnetSeed is the package-level sentinel for subnet error
+// propagation — see vpc_test.go for the contract.
+var errSubnetSeed = errors.New("AccessDenied")
+
+type fakeSubnetClient struct {
+	pages []ec2.DescribeSubnetsOutput
+	calls []ec2.DescribeSubnetsInput
+	err   error
+}
+
+func (f *fakeSubnetClient) DescribeSubnets(_ context.Context, in *ec2.DescribeSubnetsInput, _ ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+	f.calls = append(f.calls, *in)
+	if f.err != nil {
+		return nil, f.err
+	}
+	idx := len(f.calls) - 1
+	if idx >= len(f.pages) {
+		return &ec2.DescribeSubnetsOutput{}, nil
+	}
+	return &f.pages[idx], nil
+}
+
+func subnetWithTags(id, vpcID, az, cidr string, tags map[string]string) ec2types.Subnet {
+	s := ec2types.Subnet{
+		SubnetId:         aws.String(id),
+		VpcId:            aws.String(vpcID),
+		AvailabilityZone: aws.String(az),
+		CidrBlock:        aws.String(cidr),
+	}
+	for k, v := range tags {
+		s.Tags = append(s.Tags, ec2types.Tag{Key: aws.String(k), Value: aws.String(v)})
+	}
+	return s
+}
+
+func TestSubnetDiscover_HappyPath(t *testing.T) {
+	t.Parallel()
+	d := &subnetDiscoverer{new: func(_ string) subnetClient {
+		return &fakeSubnetClient{
+			pages: []ec2.DescribeSubnetsOutput{
+				{
+					Subnets: []ec2types.Subnet{
+						subnetWithTags("subnet-aaaa00000000001", "vpc-052c72972a11f8677", "us-east-1a", "10.0.1.0/24", map[string]string{"Name": "io-foo-private-1a", "Project": "io-foo"}),
+						subnetWithTags("subnet-bbbb00000000002", "vpc-052c72972a11f8677", "us-east-1b", "10.0.2.0/24", map[string]string{"Project": "io-foo"}),
+					},
+				},
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+	for _, ir := range got {
+		if ir.Identity.Type != "aws_subnet" {
+			t.Errorf("Type=%q, want aws_subnet", ir.Identity.Type)
+		}
+		if ir.Identity.ImportID == "" {
+			t.Error("ImportID empty")
+		}
+		if ir.Identity.NativeIDs["subnet_id"] == "" {
+			t.Error("NativeIDs[subnet_id] empty")
+		}
+		if ir.Identity.NativeIDs["vpc_id"] == "" {
+			t.Error("NativeIDs[vpc_id] empty")
+		}
+		if ir.Identity.NativeIDs["availability_zone"] == "" {
+			t.Error("NativeIDs[availability_zone] empty")
+		}
+		if ir.Identity.NativeIDs["cidr_block"] == "" {
+			t.Error("NativeIDs[cidr_block] empty")
+		}
+	}
+	// Output is sorted by subnet ID.
+	if got[0].Identity.ImportID != "subnet-aaaa00000000001" {
+		t.Errorf("first ImportID=%q, want subnet-aaaa00000000001 (sorted)", got[0].Identity.ImportID)
+	}
+	if got[0].Identity.NameHint != "io-foo-private-1a" {
+		t.Errorf("first NameHint=%q, want io-foo-private-1a (Name tag)", got[0].Identity.NameHint)
+	}
+	if got[1].Identity.NameHint != "subnet-bbbb00000000002" {
+		t.Errorf("second NameHint=%q, want fallback to subnet ID", got[1].Identity.NameHint)
+	}
+}
+
+func TestSubnetDiscover_PaginatesUntilNoToken(t *testing.T) {
+	t.Parallel()
+	d := &subnetDiscoverer{new: func(_ string) subnetClient {
+		return &fakeSubnetClient{
+			pages: []ec2.DescribeSubnetsOutput{
+				{Subnets: []ec2types.Subnet{subnetWithTags("subnet-a000000000000001", "vpc-1", "us-east-1a", "10.0.1.0/24", nil)}, NextToken: aws.String("tok1")},
+				{Subnets: []ec2types.Subnet{subnetWithTags("subnet-b000000000000002", "vpc-1", "us-east-1b", "10.0.2.0/24", nil)}, NextToken: aws.String("tok2")},
+				{Subnets: []ec2types.Subnet{subnetWithTags("subnet-c000000000000003", "vpc-1", "us-east-1c", "10.0.3.0/24", nil)}}, // terminal
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len=%d, want 3 (paginated)", len(got))
+	}
+}
+
+func TestSubnetDiscover_PassesProjectTagFilterServerSide(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSubnetClient{}
+	d := &subnetDiscoverer{new: func(_ string) subnetClient { return fake }}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) == 0 {
+		t.Fatal("expected at least one DescribeSubnets call")
+	}
+	in := fake.calls[0]
+	if len(in.Filters) == 0 {
+		t.Fatal("expected at least one Filter on DescribeSubnetsInput")
+	}
+	if got := aws.ToString(in.Filters[0].Name); got != "tag:Project" {
+		t.Errorf("Filters[0].Name=%q, want tag:Project", got)
+	}
+	if len(in.Filters[0].Values) == 0 || in.Filters[0].Values[0] != "io-foo" {
+		t.Errorf("Filters[0].Values=%v, want [io-foo]", in.Filters[0].Values)
+	}
+}
+
+func TestSubnetDiscover_EmptyProjectPassesNoFilter(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSubnetClient{}
+	d := &subnetDiscoverer{new: func(_ string) subnetClient { return fake }}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{Project: "", Regions: []string{"us-east-1"}, AccountID: "123"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) == 0 {
+		t.Fatal("expected at least one DescribeSubnets call")
+	}
+	if len(fake.calls[0].Filters) != 0 {
+		t.Errorf("Filters=%v, want empty for empty project", fake.calls[0].Filters)
+	}
+}
+
+func TestSubnetDiscover_PropagatesError(t *testing.T) {
+	t.Parallel()
+	d := &subnetDiscoverer{new: func(_ string) subnetClient {
+		return &fakeSubnetClient{err: errSubnetSeed}
+	}}
+	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, errSubnetSeed) {
+		t.Errorf("err=%v, want errors.Is(err, errSubnetSeed)", err)
+	}
+}
+
+func TestSubnetDiscoverByID_AcceptsSubnetID(t *testing.T) {
+	t.Parallel()
+	d := &subnetDiscoverer{new: func(_ string) subnetClient {
+		return &fakeSubnetClient{pages: []ec2.DescribeSubnetsOutput{
+			{Subnets: []ec2types.Subnet{subnetWithTags("subnet-aaaa00000000001", "vpc-052c72972a11f8677", "us-east-1a", "10.0.1.0/24", map[string]string{"Name": "io-foo-private-1a"})}},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), "subnet-aaaa00000000001", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.Type != "aws_subnet" {
+		t.Errorf("Type=%q", got.Identity.Type)
+	}
+	if got.Identity.ImportID != "subnet-aaaa00000000001" {
+		t.Errorf("ImportID=%q", got.Identity.ImportID)
+	}
+	if got.Identity.NameHint != "io-foo-private-1a" {
+		t.Errorf("NameHint=%q", got.Identity.NameHint)
+	}
+	if got.Identity.NativeIDs["vpc_id"] != "vpc-052c72972a11f8677" {
+		t.Errorf("NativeIDs[vpc_id]=%q", got.Identity.NativeIDs["vpc_id"])
+	}
+	if got.Identity.NativeIDs["availability_zone"] != "us-east-1a" {
+		t.Errorf("NativeIDs[availability_zone]=%q", got.Identity.NativeIDs["availability_zone"])
+	}
+	if got.Identity.Tags != nil {
+		t.Errorf("Tags=%v, want nil from DiscoverByID", got.Identity.Tags)
+	}
+}
+
+func TestSubnetDiscoverByID_AcceptsARN(t *testing.T) {
+	t.Parallel()
+	d := &subnetDiscoverer{new: func(_ string) subnetClient {
+		return &fakeSubnetClient{pages: []ec2.DescribeSubnetsOutput{
+			{Subnets: []ec2types.Subnet{subnetWithTags("subnet-aaaa00000000001", "vpc-1", "us-east-1a", "10.0.1.0/24", nil)}},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(),
+		"arn:aws:ec2:us-east-1:123:subnet/subnet-aaaa00000000001", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.ImportID != "subnet-aaaa00000000001" {
+		t.Errorf("ImportID=%q", got.Identity.ImportID)
+	}
+}
+
+func TestSubnetDiscoverByID_NotFound(t *testing.T) {
+	t.Parallel()
+	d := &subnetDiscoverer{new: func(_ string) subnetClient { return &fakeSubnetClient{} }}
+	_, err := d.DiscoverByID(context.Background(), "subnet-deadbeef00000000", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestSubnetDiscoverByID_NotFound_FromAPIErrorCode(t *testing.T) {
+	t.Parallel()
+	d := &subnetDiscoverer{new: func(_ string) subnetClient {
+		return &fakeSubnetClient{err: errors.New("api error InvalidSubnetID.NotFound: The subnet ID 'subnet-deadbeef' does not exist")}
+	}}
+	_, err := d.DiscoverByID(context.Background(), "subnet-deadbeef00000000", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestSubnetDiscover_MultiRegionTriggersOneSDKCallPerRegion(t *testing.T) {
+	t.Parallel()
+	fakes := map[string]*fakeSubnetClient{
+		"us-east-1": {pages: []ec2.DescribeSubnetsOutput{
+			{Subnets: []ec2types.Subnet{subnetWithTags("subnet-east0000000001", "vpc-1", "us-east-1a", "10.0.1.0/24", nil)}},
+		}},
+		"eu-west-1": {pages: []ec2.DescribeSubnetsOutput{
+			{Subnets: []ec2types.Subnet{subnetWithTags("subnet-west0000000001", "vpc-2", "eu-west-1a", "10.1.1.0/24", nil)}},
+		}},
+	}
+	var seenRegions []string
+	d := &subnetDiscoverer{new: func(region string) subnetClient {
+		seenRegions = append(seenRegions, region)
+		f, ok := fakes[region]
+		if !ok {
+			t.Fatalf("closure called with unexpected region %q", region)
+		}
+		return f
+	}}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(seenRegions) != 2 {
+		t.Errorf("region closure invocations = %v, want 2 entries", seenRegions)
+	}
+	if len(fakes["us-east-1"].calls) == 0 || len(fakes["eu-west-1"].calls) == 0 {
+		t.Error("expected one DescribeSubnets call per region")
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+}
+
+func TestSubnetDiscover_TagSelectorAppliedAsFilter(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSubnetClient{
+		pages: []ec2.DescribeSubnetsOutput{{Subnets: []ec2types.Subnet{
+			subnetWithTags("subnet-prod000000001", "vpc-1", "us-east-1a", "10.0.1.0/24", map[string]string{"Name": "prod-1a", "env": "prod"}),
+			subnetWithTags("subnet-stag000000001", "vpc-1", "us-east-1a", "10.0.2.0/24", map[string]string{"Name": "staging-1a", "env": "staging"}),
+		}}},
+	}
+	d := &subnetDiscoverer{new: func(_ string) subnetClient { return fake }}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:      "io-foo",
+		Regions:      []string{"us-east-1"},
+		AccountID:    "123",
+		TagSelectors: []TagSelector{{Key: "env", Value: "prod"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (only env=prod subnet should pass)", len(got))
+	}
+	if got[0].Identity.Tags["env"] != "prod" {
+		t.Errorf("Tags[env]=%q, want prod (filter+persist contract)", got[0].Identity.Tags["env"])
+	}
+}
+
+func TestSubnetDiscover_EmitsServiceStartFinish_PerRegion(t *testing.T) {
+	t.Parallel()
+	fakes := map[string]*fakeSubnetClient{
+		"us-east-1": {pages: []ec2.DescribeSubnetsOutput{
+			{Subnets: []ec2types.Subnet{subnetWithTags("subnet-east0000000001", "vpc-1", "us-east-1a", "10.0.1.0/24", nil)}},
+		}},
+		"eu-west-1": {pages: []ec2.DescribeSubnetsOutput{
+			{Subnets: []ec2types.Subnet{subnetWithTags("subnet-west0000000001", "vpc-2", "eu-west-1a", "10.1.1.0/24", nil)}},
+		}},
+	}
+	d := &subnetDiscoverer{new: func(region string) subnetClient { return fakes[region] }}
+	rec := &recordingEmitter{}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	events := rec.snapshot()
+
+	type bracket struct{ start, finish int }
+	got := map[string]bracket{}
+	for i, e := range events {
+		switch e.Kind {
+		case "service_start":
+			b := got[e.Region]
+			b.start = i + 1
+			got[e.Region] = b
+		case "service_finish":
+			b := got[e.Region]
+			b.finish = i + 1
+			got[e.Region] = b
+		}
+		if e.Kind == "service_start" || e.Kind == "service_finish" {
+			if e.Service != "subnet" {
+				t.Errorf("event %d: service=%q, want subnet", i, e.Service)
+			}
+		}
+	}
+	for _, region := range []string{"us-east-1", "eu-west-1"} {
+		if got[region].start == 0 || got[region].finish == 0 {
+			t.Errorf("%s: missing service_start or service_finish: %+v", region, got[region])
+		}
+		if got[region].start >= got[region].finish {
+			t.Errorf("%s: start at %d >= finish at %d", region, got[region].start, got[region].finish)
+		}
+	}
+}
+
+func TestSubnetDiscover_EmitsItemFound_PerSubnet(t *testing.T) {
+	t.Parallel()
+	ids := []string{"subnet-aaa00000000001", "subnet-bbb00000000002", "subnet-ccc00000000003"}
+	subs := make([]ec2types.Subnet, 0, len(ids))
+	for _, id := range ids {
+		subs = append(subs, subnetWithTags(id, "vpc-1", "us-east-1a", "10.0.1.0/24", nil))
+	}
+	fake := &fakeSubnetClient{pages: []ec2.DescribeSubnetsOutput{{Subnets: subs}}}
+	d := &subnetDiscoverer{new: func(_ string) subnetClient { return fake }}
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var items []recordedEvent
+	for _, e := range rec.snapshot() {
+		if e.Kind == "item_found" {
+			items = append(items, e)
+		}
+	}
+	if len(items) != len(got) {
+		t.Errorf("item_found count = %d, want %d", len(items), len(got))
+	}
+	for i, it := range items {
+		if it.Service != "subnet" {
+			t.Errorf("item %d: service=%q, want subnet", i, it.Service)
+		}
+		if it.TFType != "aws_subnet" {
+			t.Errorf("item %d: tf_type=%q, want aws_subnet", i, it.TFType)
+		}
+	}
+}
+
+func TestSubnetDiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &subnetDiscoverer{new: func(_ string) subnetClient { return &fakeSubnetClient{} }}
+	cases := []string{
+		"",
+		"arn:aws:s3:::some-bucket",
+		"arn:aws:ec2:us-east-1:123:vpc/vpc-abc", // ec2 but not subnet
+		"vpc-1234",                              // wrong prefix
+		"subnet 1234",                           // contains space
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/unsupported_test.go
+++ b/cmd/insideout-import/awsdiscover/unsupported_test.go
@@ -83,7 +83,7 @@ func TestEnumerateUnsupported_FiltersSupportedTypes(t *testing.T) {
 	fixtureRows := []fixtureRow{
 		{"arn:aws:sqs:us-east-1:123:io-queue", "sqs:queue", "aws_sqs_queue", "us-east-1", false},          // importable
 		{"arn:aws:iam::123:role/io-role", "iam:role", "aws_iam_role", "us-east-1", false},                 // importable
-		{"arn:aws:ec2:us-east-1:123:vpc/vpc-abc", "ec2:vpc", "aws_vpc", "us-east-1", true},                // unsupported
+		{"arn:aws:ec2:us-east-1:123:vpc/vpc-abc", "ec2:vpc", "aws_vpc", "us-east-1", false},               // importable (Bundle 4 PR 1)
 		{"arn:aws:rds:us-east-1:123:cluster:my-clu", "rds:cluster", "aws_rds_cluster", "us-east-1", true}, // unsupported
 		{"arn:aws:eks:us-east-1:123:cluster/my-eks", "eks:cluster", "aws_eks_cluster", "us-east-1", true}, // unsupported
 	}
@@ -139,8 +139,8 @@ func TestEnumerateUnsupported_MultiRegion(t *testing.T) {
 	t.Parallel()
 	fake := &fakeResourceExplorerSearcher{
 		byRegion: map[string][]retypes.Resource{
-			"us-east-1": {rxResource("arn:aws:ec2:us-east-1:123:vpc/vpc-east", "ec2:vpc", "us-east-1")},
-			"eu-west-1": {rxResource("arn:aws:ec2:eu-west-1:123:vpc/vpc-west", "ec2:vpc", "eu-west-1")},
+			"us-east-1": {rxResource("arn:aws:rds:us-east-1:123:cluster:c-east", "rds:cluster", "us-east-1")},
+			"eu-west-1": {rxResource("arn:aws:rds:eu-west-1:123:cluster:c-west", "rds:cluster", "eu-west-1")},
 		},
 	}
 	got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
@@ -173,7 +173,7 @@ func TestEnumerateUnsupported_TagsPassThrough(t *testing.T) {
 	t.Parallel()
 	fake := &fakeResourceExplorerSearcher{
 		byRegion: map[string][]retypes.Resource{
-			"us-east-1": {rxResource("arn:aws:ec2:us-east-1:123:vpc/vpc-abc", "ec2:vpc", "us-east-1")},
+			"us-east-1": {rxResource("arn:aws:rds:us-east-1:123:cluster:c-abc", "rds:cluster", "us-east-1")},
 		},
 	}
 	got, _, err := enumerateUnsupportedAWS(context.Background(), UnsupportedArgs{
@@ -375,11 +375,11 @@ func TestEnumerateUnsupported_EmitsServiceStartFinishPerRegion(t *testing.T) {
 	fake := &fakeResourceExplorerSearcher{
 		byRegion: map[string][]retypes.Resource{
 			"us-east-1": {
-				rxResource("arn:aws:ec2:us-east-1:123:vpc/vpc-east-1", "ec2:vpc", "us-east-1"),
-				rxResource("arn:aws:ec2:us-east-1:123:vpc/vpc-east-2", "ec2:vpc", "us-east-1"),
+				rxResource("arn:aws:rds:us-east-1:123:cluster:c-east-1", "rds:cluster", "us-east-1"),
+				rxResource("arn:aws:rds:us-east-1:123:cluster:c-east-2", "rds:cluster", "us-east-1"),
 			},
 			"eu-west-1": {
-				rxResource("arn:aws:ec2:eu-west-1:123:vpc/vpc-west-1", "ec2:vpc", "eu-west-1"),
+				rxResource("arn:aws:rds:eu-west-1:123:cluster:c-west-1", "rds:cluster", "eu-west-1"),
 			},
 		},
 	}
@@ -437,7 +437,7 @@ func TestEnumerateUnsupported_PopulatesGroup(t *testing.T) {
 	fake := &fakeResourceExplorerSearcher{
 		byRegion: map[string][]retypes.Resource{
 			"us-east-1": {
-				rxResource("arn:aws:ec2:us-east-1:123:vpc/vpc-abc", "ec2:vpc", "us-east-1"),
+				rxResource("arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/n/x", "elasticloadbalancing:loadbalancer", "us-east-1"),
 				rxResource("arn:aws:eks:us-east-1:123:cluster/c", "eks:cluster", "us-east-1"),
 				rxResource("arn:aws:rds:us-east-1:123:cluster:rds-c", "rds:cluster", "us-east-1"),
 				rxResource("arn:aws:newservice:us-east-1:123:thing/x", "newservice:thing", "us-east-1"),
@@ -457,7 +457,7 @@ func TestEnumerateUnsupported_PopulatesGroup(t *testing.T) {
 	// assert Group on the matching entry; for the unmapped row, walk
 	// for the Type=="" entry and assert Group=="".
 	wantGroup := map[string]string{
-		"aws_vpc":         "Network Security",
+		"aws_lb":          "Network Security",
 		"aws_eks_cluster": "Virtual Machines",
 		"aws_rds_cluster": "Data Storage",
 	}
@@ -507,11 +507,11 @@ func TestEnumerateUnsupported_CapFiresAndSetsTruncated(t *testing.T) {
 	t.Parallel()
 	rows := make([]retypes.Resource, 0, 50)
 	for i := 0; i < 50; i++ {
-		// ec2:vpc maps to aws_vpc which is NOT in the importable
-		// registry, so each fixture row passes the supported-set
-		// filter and lands in the output.
-		arn := fmt.Sprintf("arn:aws:ec2:us-east-1:1:vpc/vpc-%03d", i)
-		rows = append(rows, rxResource(arn, "ec2:vpc", "us-east-1"))
+		// rds:cluster maps to aws_rds_cluster which is NOT in the
+		// importable registry, so each fixture row passes the
+		// supported-set filter and lands in the output.
+		arn := fmt.Sprintf("arn:aws:rds:us-east-1:1:cluster:c-%03d", i)
+		rows = append(rows, rxResource(arn, "rds:cluster", "us-east-1"))
 	}
 	fake := &fakeResourceExplorerSearcher{
 		byRegion: map[string][]retypes.Resource{"us-east-1": rows},
@@ -543,8 +543,8 @@ func TestEnumerateUnsupported_CapZeroDisablesLimit(t *testing.T) {
 	t.Parallel()
 	rows := make([]retypes.Resource, 0, 50)
 	for i := 0; i < 50; i++ {
-		arn := fmt.Sprintf("arn:aws:ec2:us-east-1:1:vpc/vpc-%03d", i)
-		rows = append(rows, rxResource(arn, "ec2:vpc", "us-east-1"))
+		arn := fmt.Sprintf("arn:aws:rds:us-east-1:1:cluster:c-%03d", i)
+		rows = append(rows, rxResource(arn, "rds:cluster", "us-east-1"))
 	}
 	fake := &fakeResourceExplorerSearcher{
 		byRegion: map[string][]retypes.Resource{"us-east-1": rows},
@@ -614,8 +614,8 @@ func TestSearch_CapStopsFetchingPages(t *testing.T) {
 func makeFixtureRows(n, offset int) []retypes.Resource {
 	out := make([]retypes.Resource, 0, n)
 	for i := 0; i < n; i++ {
-		arn := fmt.Sprintf("arn:aws:ec2:us-east-1:1:vpc/vpc-%05d", offset+i)
-		out = append(out, rxResource(arn, "ec2:vpc", "us-east-1"))
+		arn := fmt.Sprintf("arn:aws:rds:us-east-1:1:cluster:c-%05d", offset+i)
+		out = append(out, rxResource(arn, "rds:cluster", "us-east-1"))
 	}
 	return out
 }

--- a/cmd/insideout-import/awsdiscover/vpc.go
+++ b/cmd/insideout-import/awsdiscover/vpc.go
@@ -1,0 +1,215 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// vpcClient is the narrow subset of the EC2 SDK the VPC discoverer uses.
+// The describe response carries the tag map inline so no separate
+// DescribeTags round-trip is required (Bundle 4 / #319).
+type vpcClient interface {
+	DescribeVpcs(ctx context.Context, in *ec2.DescribeVpcsInput, opts ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error)
+}
+
+type vpcDiscoverer struct {
+	new func(region string) vpcClient
+}
+
+func newVPCDiscoverer(cfg aws.Config) Discoverer {
+	return &vpcDiscoverer{new: func(region string) vpcClient {
+		return ec2.NewFromConfig(cfg, func(o *ec2.Options) {
+			if region != "" {
+				o.Region = region
+			}
+		})
+	}}
+}
+
+func (d *vpcDiscoverer) ResourceType() string { return "aws_vpc" }
+
+// Discover lists VPCs whose Project tag matches args.Project. EC2 supports
+// server-side `tag:Key` filters on DescribeVpcs, so we never have to
+// download every VPC in the account just to filter client-side. When
+// args.Project is empty (admin path) the request omits the filter.
+//
+// Multi-region (#291): loops args.Regions, building a per-region SDK
+// client. Tags are inline on each ec2types.Vpc — no per-resource
+// DescribeTags fetch is needed.
+//
+// Import ID for aws_vpc is the VPC ID (vpc-XXXXXXXX).
+func (d *vpcDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
+	book := addressBook{}
+	const slug = "vpc"
+	var out []imported.ImportedResource
+	for _, region := range args.Regions {
+		regionStart := time.Now()
+		args.Emitter.ServiceStart(slug, region)
+		regionCount := 0
+		client := d.new(region)
+		input := &ec2.DescribeVpcsInput{}
+		if args.Project != "" {
+			input.Filters = []ec2types.Filter{{
+				Name:   aws.String("tag:Project"),
+				Values: []string{args.Project},
+			}}
+		}
+
+		vpcs, err := paginateDescribeVpcs(ctx, client, input)
+		if err != nil {
+			args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
+			return nil, fmt.Errorf("DescribeVpcs (region=%s): %w", region, err)
+		}
+
+		// Sort by VPC ID so the emitted manifest is deterministic across runs.
+		sort.Slice(vpcs, func(i, j int) bool {
+			return aws.ToString(vpcs[i].VpcId) < aws.ToString(vpcs[j].VpcId)
+		})
+
+		for i := range vpcs {
+			v := &vpcs[i]
+			id := aws.ToString(v.VpcId)
+			tags := ec2TagsToMap(v.Tags)
+			if !MatchesAll(tags, args.TagSelectors) {
+				continue
+			}
+			name := vpcName(v.Tags, id)
+			cidr := aws.ToString(v.CidrBlock)
+			out = append(out, makeImportedResource(
+				book,
+				"aws_vpc",
+				name,
+				id,
+				region,
+				args.AccountID,
+				map[string]string{"vpc_id": id, "cidr_block": cidr},
+				tags,
+			))
+			args.Emitter.ItemFound(slug, region, "aws_vpc", id)
+			regionCount++
+		}
+		args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
+	}
+	return out, nil
+}
+
+// DiscoverByID resolves a VPC by VPC ID (vpc-XXXXXXXX) or ARN
+// (arn:aws:ec2:<region>:<account>:vpc/vpc-XXXXXXXX). Issues a single
+// DescribeVpcs call with the VPC ID to verify existence.
+func (d *vpcDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	vpcID, err := vpcIDFromID(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
+
+	client := d.new(region)
+	out, err := client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{VpcIds: []string{vpcID}})
+	if err != nil {
+		// EC2 surfaces "InvalidVpcID.NotFound" as a generic API error,
+		// not a typed exception. Match by code substring (mirror s3.go).
+		if strings.Contains(err.Error(), "InvalidVpcID.NotFound") {
+			return imported.ImportedResource{}, fmt.Errorf("aws_vpc %q: %w", vpcID, ErrNotFound)
+		}
+		return imported.ImportedResource{}, fmt.Errorf("DescribeVpcs: %w", err)
+	}
+	if len(out.Vpcs) == 0 {
+		return imported.ImportedResource{}, fmt.Errorf("aws_vpc %q: %w", vpcID, ErrNotFound)
+	}
+	v := &out.Vpcs[0]
+	cidr := aws.ToString(v.CidrBlock)
+	name := vpcName(v.Tags, vpcID)
+	return makeImportedResource(
+		addressBook{},
+		"aws_vpc",
+		name,
+		vpcID,
+		region,
+		accountID,
+		map[string]string{"vpc_id": vpcID, "cidr_block": cidr},
+		nil,
+	), nil
+}
+
+// vpcIDFromID extracts the VPC ID (vpc-XXXXXXXX) from one of two accepted
+// inputs: the bare VPC ID, or an EC2 ARN of the shape
+// arn:aws:ec2:<region>:<account>:vpc/vpc-XXXXXXXX. Anything else returns
+// ErrNotSupported so dep-chase routes it to its unresolvable bucket.
+func vpcIDFromID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("vpc: empty id: %w", ErrNotSupported)
+	}
+	if awsarn.IsARN(id) {
+		parsed, err := awsarn.Parse(id)
+		if err != nil {
+			return "", fmt.Errorf("vpc: parse arn: %w", err)
+		}
+		if parsed.Service != "ec2" {
+			return "", fmt.Errorf("vpc: not an ec2 arn (service=%q): %w", parsed.Service, ErrNotSupported)
+		}
+		// Resource is "vpc/vpc-XXXXXXXX".
+		parts := strings.SplitN(parsed.Resource, "/", 2)
+		if len(parts) != 2 || parts[0] != "vpc" || !strings.HasPrefix(parts[1], "vpc-") {
+			return "", fmt.Errorf("vpc: arn resource %q is not vpc/vpc-…: %w", parsed.Resource, ErrNotSupported)
+		}
+		return parts[1], nil
+	}
+	if !strings.HasPrefix(id, "vpc-") || strings.ContainsAny(id, " :/") {
+		return "", fmt.Errorf("vpc: unrecognized id %q: %w", id, ErrNotSupported)
+	}
+	return id, nil
+}
+
+// paginateDescribeVpcs walks all NextToken pages. The SDK returns at most
+// 1000 VPCs per page, but it's cheaper to be paranoid than to silently
+// drop the tail of an account that happens to have crossed the threshold.
+func paginateDescribeVpcs(ctx context.Context, client vpcClient, input *ec2.DescribeVpcsInput) ([]ec2types.Vpc, error) {
+	var all []ec2types.Vpc
+	for {
+		out, err := client.DescribeVpcs(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, out.Vpcs...)
+		if out.NextToken == nil || *out.NextToken == "" {
+			return all, nil
+		}
+		input.NextToken = out.NextToken
+	}
+}
+
+// ec2TagsToMap converts the EC2 SDK's []Tag slice into a string-keyed map.
+// Returns a non-nil empty map (not nil) so the filter+persist contract
+// holds: nil = "didn't fetch", empty = "fetched, no tags".
+func ec2TagsToMap(in []ec2types.Tag) map[string]string {
+	out := make(map[string]string, len(in))
+	for _, t := range in {
+		out[aws.ToString(t.Key)] = aws.ToString(t.Value)
+	}
+	return out
+}
+
+// vpcName picks the most useful human-readable name for a VPC: the `Name`
+// tag if set, otherwise the bare VPC ID. Mirrors how the AWS console
+// labels VPCs in its picker.
+func vpcName(tags []ec2types.Tag, fallback string) string {
+	for _, t := range tags {
+		if aws.ToString(t.Key) == "Name" {
+			if v := aws.ToString(t.Value); v != "" {
+				return v
+			}
+		}
+	}
+	return fallback
+}

--- a/cmd/insideout-import/awsdiscover/vpc_test.go
+++ b/cmd/insideout-import/awsdiscover/vpc_test.go
@@ -1,0 +1,457 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// errVPCSeed is the package-level sentinel returned by the fake VPC
+// client in tests that want to assert error propagation. Tests should
+// use errors.Is(err, errVPCSeed) rather than asserting only on
+// `err != nil` — the latter masks regressions where the discover layer
+// silently swallows the SDK error and returns a different one.
+var errVPCSeed = errors.New("AccessDenied")
+
+type fakeVPCClient struct {
+	pages []ec2.DescribeVpcsOutput
+	calls []ec2.DescribeVpcsInput
+	err   error // when non-nil, every DescribeVpcs call returns this
+}
+
+func (f *fakeVPCClient) DescribeVpcs(_ context.Context, in *ec2.DescribeVpcsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+	f.calls = append(f.calls, *in)
+	if f.err != nil {
+		return nil, f.err
+	}
+	idx := len(f.calls) - 1
+	if idx >= len(f.pages) {
+		return &ec2.DescribeVpcsOutput{}, nil
+	}
+	return &f.pages[idx], nil
+}
+
+func vpcWithTags(id, cidr string, tags map[string]string) ec2types.Vpc {
+	v := ec2types.Vpc{
+		VpcId:     aws.String(id),
+		CidrBlock: aws.String(cidr),
+	}
+	for k, val := range tags {
+		v.Tags = append(v.Tags, ec2types.Tag{Key: aws.String(k), Value: aws.String(val)})
+	}
+	return v
+}
+
+func TestVPCDiscover_HappyPath(t *testing.T) {
+	t.Parallel()
+	d := &vpcDiscoverer{new: func(_ string) vpcClient {
+		return &fakeVPCClient{
+			pages: []ec2.DescribeVpcsOutput{
+				{
+					Vpcs: []ec2types.Vpc{
+						vpcWithTags("vpc-052c72972a11f8677", "10.0.0.0/16", map[string]string{"Name": "io-foo-prod-vpc", "Project": "io-foo"}),
+						vpcWithTags("vpc-0a1b2c3d4e5f60718", "10.1.0.0/16", map[string]string{"Project": "io-foo"}),
+					},
+				},
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+	for _, ir := range got {
+		if ir.Identity.Type != "aws_vpc" {
+			t.Errorf("Type=%q, want aws_vpc", ir.Identity.Type)
+		}
+		if ir.Identity.ImportID == "" {
+			t.Error("ImportID empty")
+		}
+		if ir.Identity.NativeIDs["vpc_id"] == "" {
+			t.Error("NativeIDs[vpc_id] empty")
+		}
+		if ir.Identity.NativeIDs["cidr_block"] == "" {
+			t.Error("NativeIDs[cidr_block] empty")
+		}
+		if ir.Identity.NativeIDs["name"] == "" {
+			t.Error("NativeIDs[name] empty")
+		}
+	}
+	// Output is sorted by VPC ID → addresses are deterministic.
+	if got[0].Identity.ImportID != "vpc-052c72972a11f8677" {
+		t.Errorf("first ImportID=%q, want vpc-052c72972a11f8677 (sorted)", got[0].Identity.ImportID)
+	}
+	// Name tag wins over the bare VPC ID for NameHint.
+	if got[0].Identity.NameHint != "io-foo-prod-vpc" {
+		t.Errorf("first NameHint=%q, want io-foo-prod-vpc (Name tag)", got[0].Identity.NameHint)
+	}
+	// Fallback: VPC with no Name tag uses the VPC ID itself.
+	if got[1].Identity.NameHint != "vpc-0a1b2c3d4e5f60718" {
+		t.Errorf("second NameHint=%q, want fallback to VPC ID", got[1].Identity.NameHint)
+	}
+	// Tags propagate onto Identity.Tags (filter+persist contract).
+	if got[0].Identity.Tags["Project"] != "io-foo" {
+		t.Errorf("Tags[Project]=%q, want io-foo", got[0].Identity.Tags["Project"])
+	}
+}
+
+func TestVPCDiscover_PaginatesUntilNoToken(t *testing.T) {
+	t.Parallel()
+	d := &vpcDiscoverer{new: func(_ string) vpcClient {
+		return &fakeVPCClient{
+			pages: []ec2.DescribeVpcsOutput{
+				{Vpcs: []ec2types.Vpc{vpcWithTags("vpc-aaa00000000000001", "10.0.0.0/16", nil)}, NextToken: aws.String("tok1")},
+				{Vpcs: []ec2types.Vpc{vpcWithTags("vpc-bbb00000000000002", "10.1.0.0/16", nil)}, NextToken: aws.String("tok2")},
+				{Vpcs: []ec2types.Vpc{vpcWithTags("vpc-ccc00000000000003", "10.2.0.0/16", nil)}}, // terminal
+			},
+		}
+	}}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len=%d, want 3 (paginated)", len(got))
+	}
+}
+
+func TestVPCDiscover_PassesProjectTagFilterServerSide(t *testing.T) {
+	t.Parallel()
+	fake := &fakeVPCClient{}
+	d := &vpcDiscoverer{new: func(_ string) vpcClient { return fake }}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) == 0 {
+		t.Fatal("expected at least one DescribeVpcs call")
+	}
+	in := fake.calls[0]
+	if len(in.Filters) == 0 {
+		t.Fatal("expected at least one Filter on DescribeVpcsInput")
+	}
+	if got := aws.ToString(in.Filters[0].Name); got != "tag:Project" {
+		t.Errorf("Filters[0].Name=%q, want tag:Project", got)
+	}
+	if len(in.Filters[0].Values) == 0 || in.Filters[0].Values[0] != "io-foo" {
+		t.Errorf("Filters[0].Values=%v, want [io-foo]", in.Filters[0].Values)
+	}
+}
+
+func TestVPCDiscover_EmptyProjectPassesNoFilter(t *testing.T) {
+	t.Parallel()
+	fake := &fakeVPCClient{}
+	d := &vpcDiscoverer{new: func(_ string) vpcClient { return fake }}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{Project: "", Regions: []string{"us-east-1"}, AccountID: "123"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) == 0 {
+		t.Fatal("expected at least one DescribeVpcs call")
+	}
+	if len(fake.calls[0].Filters) != 0 {
+		t.Errorf("Filters=%v, want empty for empty project", fake.calls[0].Filters)
+	}
+}
+
+func TestVPCDiscover_PropagatesError(t *testing.T) {
+	t.Parallel()
+	d := &vpcDiscoverer{new: func(_ string) vpcClient {
+		return &fakeVPCClient{err: errVPCSeed}
+	}}
+	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, errVPCSeed) {
+		t.Errorf("err=%v, want errors.Is(err, errVPCSeed) — discover swallowed the SDK error", err)
+	}
+}
+
+func TestVPCDiscoverByID_AcceptsVPCID(t *testing.T) {
+	t.Parallel()
+	d := &vpcDiscoverer{new: func(_ string) vpcClient {
+		return &fakeVPCClient{pages: []ec2.DescribeVpcsOutput{
+			{Vpcs: []ec2types.Vpc{vpcWithTags("vpc-052c72972a11f8677", "10.0.0.0/16", map[string]string{"Name": "io-foo-prod-vpc"})}},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), "vpc-052c72972a11f8677", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.Type != "aws_vpc" {
+		t.Errorf("Type=%q", got.Identity.Type)
+	}
+	if got.Identity.ImportID != "vpc-052c72972a11f8677" {
+		t.Errorf("ImportID=%q", got.Identity.ImportID)
+	}
+	if got.Identity.NameHint != "io-foo-prod-vpc" {
+		t.Errorf("NameHint=%q, want io-foo-prod-vpc", got.Identity.NameHint)
+	}
+	if got.Identity.NativeIDs["vpc_id"] != "vpc-052c72972a11f8677" {
+		t.Errorf("NativeIDs[vpc_id]=%q", got.Identity.NativeIDs["vpc_id"])
+	}
+	if got.Identity.NativeIDs["cidr_block"] != "10.0.0.0/16" {
+		t.Errorf("NativeIDs[cidr_block]=%q", got.Identity.NativeIDs["cidr_block"])
+	}
+	// DiscoverByID does not fetch tags — Identity.Tags is nil per the
+	// makeImportedResource contract.
+	if got.Identity.Tags != nil {
+		t.Errorf("Tags=%v, want nil from DiscoverByID", got.Identity.Tags)
+	}
+}
+
+func TestVPCDiscoverByID_AcceptsARN(t *testing.T) {
+	t.Parallel()
+	d := &vpcDiscoverer{new: func(_ string) vpcClient {
+		return &fakeVPCClient{pages: []ec2.DescribeVpcsOutput{
+			{Vpcs: []ec2types.Vpc{vpcWithTags("vpc-052c72972a11f8677", "10.0.0.0/16", nil)}},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(),
+		"arn:aws:ec2:us-east-1:123:vpc/vpc-052c72972a11f8677", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.ImportID != "vpc-052c72972a11f8677" {
+		t.Errorf("ImportID=%q", got.Identity.ImportID)
+	}
+}
+
+func TestVPCDiscoverByID_NotFound(t *testing.T) {
+	t.Parallel()
+	// Empty fake → DescribeVpcs returns empty Vpcs slice → ErrNotFound.
+	d := &vpcDiscoverer{new: func(_ string) vpcClient { return &fakeVPCClient{} }}
+	_, err := d.DiscoverByID(context.Background(), "vpc-deadbeef00000000", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestVPCDiscoverByID_NotFound_FromAPIErrorCode(t *testing.T) {
+	t.Parallel()
+	// Real AWS responses for an unknown VPC ID return a smithy error
+	// containing "InvalidVpcID.NotFound" — match the substring path.
+	d := &vpcDiscoverer{new: func(_ string) vpcClient {
+		return &fakeVPCClient{err: errors.New("api error InvalidVpcID.NotFound: The vpc ID 'vpc-deadbeef00000000' does not exist")}
+	}}
+	_, err := d.DiscoverByID(context.Background(), "vpc-deadbeef00000000", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+// TestVPCDiscover_MultiRegionTriggersOneSDKCallPerRegion is the
+// pattern-pin for the per-service Discover's `for _, region := range
+// args.Regions` loop — see the SQS canonical version for the contract.
+func TestVPCDiscover_MultiRegionTriggersOneSDKCallPerRegion(t *testing.T) {
+	t.Parallel()
+	fakes := map[string]*fakeVPCClient{
+		"us-east-1": {pages: []ec2.DescribeVpcsOutput{
+			{Vpcs: []ec2types.Vpc{vpcWithTags("vpc-east00000000001", "10.0.0.0/16", nil)}},
+		}},
+		"eu-west-1": {pages: []ec2.DescribeVpcsOutput{
+			{Vpcs: []ec2types.Vpc{vpcWithTags("vpc-west00000000001", "10.1.0.0/16", nil)}},
+		}},
+	}
+	var seenRegions []string
+	d := &vpcDiscoverer{new: func(region string) vpcClient {
+		seenRegions = append(seenRegions, region)
+		f, ok := fakes[region]
+		if !ok {
+			t.Fatalf("closure called with unexpected region %q", region)
+		}
+		return f
+	}}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(seenRegions) != 2 || seenRegions[0] != "us-east-1" || seenRegions[1] != "eu-west-1" {
+		t.Errorf("region closure invocations = %v, want [us-east-1 eu-west-1]", seenRegions)
+	}
+	if len(fakes["us-east-1"].calls) == 0 {
+		t.Error("us-east-1 fake never received DescribeVpcs; per-region loop dropped the first region")
+	}
+	if len(fakes["eu-west-1"].calls) == 0 {
+		t.Error("eu-west-1 fake never received DescribeVpcs; per-region loop dropped the second region")
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (one per region)", len(got))
+	}
+	gotIDs := map[string]bool{}
+	for _, ir := range got {
+		gotIDs[ir.Identity.ImportID] = true
+	}
+	if !gotIDs["vpc-east00000000001"] || !gotIDs["vpc-west00000000001"] {
+		t.Errorf("manifest IDs = %v, want both east + west VPCs", gotIDs)
+	}
+}
+
+// TestVPCDiscover_TagSelectorAppliedAsFilter is the pattern-pin for the
+// `if !MatchesAll(...) { continue }` in-loop filter — see SQS canonical
+// version for the contract.
+func TestVPCDiscover_TagSelectorAppliedAsFilter(t *testing.T) {
+	t.Parallel()
+	fake := &fakeVPCClient{
+		pages: []ec2.DescribeVpcsOutput{{Vpcs: []ec2types.Vpc{
+			vpcWithTags("vpc-prod000000000001", "10.0.0.0/16", map[string]string{"Name": "io-foo-prod", "env": "prod"}),
+			vpcWithTags("vpc-stag000000000002", "10.1.0.0/16", map[string]string{"Name": "io-foo-staging", "env": "staging"}),
+		}}},
+	}
+	d := &vpcDiscoverer{new: func(_ string) vpcClient { return fake }}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:      "io-foo",
+		Regions:      []string{"us-east-1"},
+		AccountID:    "123",
+		TagSelectors: []TagSelector{{Key: "env", Value: "prod"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (only env=prod VPC should pass)", len(got))
+	}
+	if got[0].Identity.NameHint != "io-foo-prod" {
+		t.Errorf("NameHint=%q, want io-foo-prod", got[0].Identity.NameHint)
+	}
+	if got[0].Identity.Tags["env"] != "prod" {
+		t.Errorf("Tags[env]=%q, want prod (filter+persist contract)", got[0].Identity.Tags["env"])
+	}
+}
+
+// TestVPCDiscover_EmitsServiceStartFinish_PerRegion pins the per-region
+// service-scope progress contract — see the SQS canonical version.
+func TestVPCDiscover_EmitsServiceStartFinish_PerRegion(t *testing.T) {
+	t.Parallel()
+	fakes := map[string]*fakeVPCClient{
+		"us-east-1": {pages: []ec2.DescribeVpcsOutput{
+			{Vpcs: []ec2types.Vpc{vpcWithTags("vpc-east00000000001", "10.0.0.0/16", nil)}},
+		}},
+		"eu-west-1": {pages: []ec2.DescribeVpcsOutput{
+			{Vpcs: []ec2types.Vpc{vpcWithTags("vpc-west00000000001", "10.1.0.0/16", nil)}},
+		}},
+	}
+	d := &vpcDiscoverer{new: func(region string) vpcClient { return fakes[region] }}
+	rec := &recordingEmitter{}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	events := rec.snapshot()
+
+	type bracket struct{ start, finish int }
+	got := map[string]bracket{}
+	for i, e := range events {
+		switch e.Kind {
+		case "service_start":
+			b := got[e.Region]
+			b.start = i + 1
+			got[e.Region] = b
+		case "service_finish":
+			b := got[e.Region]
+			b.finish = i + 1
+			got[e.Region] = b
+		}
+		if e.Kind == "service_start" || e.Kind == "service_finish" {
+			if e.Service != "vpc" {
+				t.Errorf("event %d: service=%q, want vpc", i, e.Service)
+			}
+		}
+	}
+	if got["us-east-1"].start == 0 || got["us-east-1"].finish == 0 {
+		t.Errorf("us-east-1: missing service_start or service_finish: %+v", got["us-east-1"])
+	}
+	if got["eu-west-1"].start == 0 || got["eu-west-1"].finish == 0 {
+		t.Errorf("eu-west-1: missing service_start or service_finish: %+v", got["eu-west-1"])
+	}
+	if got["us-east-1"].start >= got["us-east-1"].finish {
+		t.Errorf("us-east-1: start at index %d >= finish at index %d", got["us-east-1"].start, got["us-east-1"].finish)
+	}
+}
+
+// TestVPCDiscover_EmitsItemFound_PerVPC pins one item_found per emitted
+// resource — see SQS canonical version for the contract.
+func TestVPCDiscover_EmitsItemFound_PerVPC(t *testing.T) {
+	t.Parallel()
+	ids := []string{"vpc-aaa00000000000001", "vpc-bbb00000000000002", "vpc-ccc00000000000003"}
+	vpcs := make([]ec2types.Vpc, 0, len(ids))
+	for _, id := range ids {
+		vpcs = append(vpcs, vpcWithTags(id, "10.0.0.0/16", nil))
+	}
+	fake := &fakeVPCClient{pages: []ec2.DescribeVpcsOutput{{Vpcs: vpcs}}}
+	d := &vpcDiscoverer{new: func(_ string) vpcClient { return fake }}
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var items []recordedEvent
+	for _, e := range rec.snapshot() {
+		if e.Kind == "item_found" {
+			items = append(items, e)
+		}
+	}
+	if len(items) != len(got) {
+		t.Errorf("item_found count = %d, want %d (one per emitted resource)", len(items), len(got))
+	}
+	wantIDs := map[string]bool{ids[0]: true, ids[1]: true, ids[2]: true}
+	for i, it := range items {
+		if it.Service != "vpc" {
+			t.Errorf("item %d: service=%q, want vpc", i, it.Service)
+		}
+		if it.Region != "us-east-1" {
+			t.Errorf("item %d: region=%q, want us-east-1", i, it.Region)
+		}
+		if it.TFType != "aws_vpc" {
+			t.Errorf("item %d: tf_type=%q, want aws_vpc", i, it.TFType)
+		}
+		if !wantIDs[it.ImportID] {
+			t.Errorf("item %d: import_id=%q not in expected IDs", i, it.ImportID)
+		}
+	}
+	for _, e := range rec.snapshot() {
+		if e.Kind == "service_finish" && e.Count != len(got) {
+			t.Errorf("service_finish.count=%d, want %d", e.Count, len(got))
+		}
+	}
+}
+
+func TestVPCDiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &vpcDiscoverer{new: func(_ string) vpcClient { return &fakeVPCClient{} }}
+	cases := []string{
+		"",
+		"arn:aws:s3:::some-bucket", // wrong service
+		"arn:aws:lambda:us-east-1:123:function:hello", // wrong service
+		"arn:aws:ec2:us-east-1:123:subnet/subnet-abc", // ec2 but not vpc
+		"subnet-1234",  // wrong prefix
+		"vpc 12345678", // contains space
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
+	}
+}

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -25,9 +25,12 @@
     {"service": "s3", "iam_action": "s3:ListAllMyBuckets", "purpose": "list buckets account-globally (ListBuckets)"},
     {"service": "secretsmanager", "iam_action": "secretsmanager:DescribeSecret", "purpose": "resolve a single secret by name/ARN in DiscoverByID"},
     {"service": "secretsmanager", "iam_action": "secretsmanager:ListSecrets", "purpose": "list per-region secrets (server-side TagKey/TagValue filter when project is set)"},
+    {"service": "security_group", "iam_action": "ec2:DescribeSecurityGroups", "purpose": "list per-region security groups (server-side tag:Project filter when project is set; tags inline)"},
     {"service": "sqs", "iam_action": "sqs:GetQueueUrl", "purpose": "resolve a queue URL by name in DiscoverByID"},
     {"service": "sqs", "iam_action": "sqs:ListQueueTags", "purpose": "fetch queue tags for tag selectors and Identity.Tags"},
     {"service": "sqs", "iam_action": "sqs:ListQueues", "purpose": "list per-region queues (server-side QueueNamePrefix filter when project is set)"},
-    {"service": "sts", "iam_action": "sts:GetCallerIdentity", "purpose": "stamp the AccountID on every discovered resource (one call per run)"}
+    {"service": "sts", "iam_action": "sts:GetCallerIdentity", "purpose": "stamp the AccountID on every discovered resource (one call per run)"},
+    {"service": "subnet", "iam_action": "ec2:DescribeSubnets", "purpose": "list per-region subnets (server-side tag:Project filter when project is set; tags inline)"},
+    {"service": "vpc", "iam_action": "ec2:DescribeVpcs", "purpose": "list per-region VPCs (server-side tag:Project filter when project is set; tags inline)"}
   ]
 }

--- a/pkg/insideout-import/permissions/permissions_test.go
+++ b/pkg/insideout-import/permissions/permissions_test.go
@@ -25,7 +25,10 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_lambda_function":       "lambda",
 	"aws_s3_bucket":             "s3",
 	"aws_secretsmanager_secret": "secretsmanager",
+	"aws_security_group":        "security_group",
 	"aws_sqs_queue":             "sqs",
+	"aws_subnet":                "subnet",
+	"aws_vpc":                   "vpc",
 }
 
 // TestSlugMap_MatchesAwsdiscover pins the test-local slug table

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -31,7 +31,10 @@ var awsTypes = []string{
 	"aws_lambda_function",
 	"aws_s3_bucket",
 	"aws_secretsmanager_secret",
+	"aws_security_group",
 	"aws_sqs_queue",
+	"aws_subnet",
+	"aws_vpc",
 }
 
 // gcpTypes is the canonical, sorted list of GCP Terraform resource types the

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -26,7 +26,10 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_lambda_function",
 		"aws_s3_bucket",
 		"aws_secretsmanager_secret",
+		"aws_security_group",
 		"aws_sqs_queue",
+		"aws_subnet",
+		"aws_vpc",
 	}
 	got := SupportedDiscoverTypes(ProviderAWS)
 	if !reflect.DeepEqual(got, want) {

--- a/tests/localstack-discover-gate.sh
+++ b/tests/localstack-discover-gate.sh
@@ -86,11 +86,20 @@ mkdir -p "${OUT_DIR}"
 rm -rf "${OUT_DIR:?}"/*
 
 log "Running insideout-import discover against ${LOCALSTACK_URL}"
+# --resource-types pins the discovery to the 8 types this test seeds.
+# LocalStack Community's `SERVICES` env var only enables a fixed
+# allowlist (lambda,dynamodb,logs,secretsmanager,sqs,iam,kms,s3,sts), so
+# adding new discoverers (e.g. EC2 vpc/subnet/sg in #319) without an
+# explicit type filter would 501 here. Update this list when adding a
+# discoverer that LocalStack Community supports — and when a new type
+# isn't supported by LocalStack, leave it out of the seed and out of
+# this list.
 ( cd "${REPO_ROOT}" && go run ./cmd/insideout-import discover \
     --provider aws \
     --project "${PROJECT}" \
     --region "${REGION}" \
     --output-dir "${OUT_DIR}" \
+    --resource-types aws_cloudwatch_log_group,aws_dynamodb_table,aws_iam_policy,aws_iam_role,aws_kms_key,aws_lambda_function,aws_s3_bucket,aws_secretsmanager_secret \
     --aws-endpoint-url "${LOCALSTACK_URL}" )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bundle 4 / PR 1 of 8 toward [#318](https://github.com/luthersystems/insideout-terraform-presets/issues/318). Adds three new per-service discoverers covering the core EC2 networking primitives every InsideOut VPC stack creates: `aws_vpc`, `aws_subnet`, `aws_security_group`.

- Each discoverer mirrors the canonical `sqs.go` pattern: narrow SDK client interface, per-region inner loop, server-side `tag:Project` filter when project is set (empty project = no filter, admin path), inline tag map, MatchesAll tag-selector post-filter, deterministic sort, per-region service_start/service_finish progress events.
- Tags come back inline on every EC2 Describe response — no separate `DescribeTags` round-trip per resource (saves N+1 list-call inflation; fewer IAM permissions required).
- `DiscoverByID` accepts both bare IDs (`vpc-…`, `subnet-…`, `sg-…`) and the corresponding `arn:aws:ec2:…` forms. EC2 surfaces `InvalidVpcID.NotFound` / `InvalidSubnetID.NotFound` / `InvalidGroup.NotFound` as untyped API errors; we substring-match the code (mirroring `s3.go`) and normalize to `ErrNotFound`.

## Closes / Part of

Closes #319. Part of #318 (Bundle 4 / PR 1 of 8).

## Test plan

- [x] `go test ./cmd/insideout-import/... ./pkg/composer/... ./pkg/insideout-import/... -count=1 -race` — 2113 passed.
- [x] `go vet ./...` clean; `gofmt -l cmd/ pkg/` empty.
- [x] All 8 lint scripts pass as no-ops (no `.tf` changes in this PR).
- [x] `TestRegistryParity_AWS_LiveMatchesRegistry` and `TestAWSManifest_CoversAllAWSDiscovererServices` both pass — drift between live constructor map, registry, and IAM manifest is gated.
- [x] Updated `TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList` and the per-test slug map in `permissions_test.go` to include the three new types.
- [x] Live smoke against CUST3 (account 031780745048, project `io-oukrhfwhmflf`, region `us-east-1`): 7 resources discovered cleanly — 1 VPC + 4 subnets + 2 SGs (default + alb), all carrying the expected `Project = io-oukrhfwhmflf` tag.

## Notes

- **Server-side `tag:Project` filter rationale.** EC2's `DescribeVpcs` / `DescribeSubnets` / `DescribeSecurityGroups` all accept the `tag:<key>` filter form, so we never have to download every VPC/subnet/SG in the account just to filter client-side. The empty-project (admin) path omits the filter and falls back to listing all resources, matching the SQS / IAM semantics of `args.Project == ""`.
- **Default security group / default VPC handling.** Out of scope for this PR per `#319`. The live smoke currently surfaces the project-tagged default SG for `vpc-052c…` (`sg-0947e82d14371a085`) because InsideOut tags it during VPC creation. Default-VPC and default-SG skip-list logic is deferred to Bundle 4 PR 3 if needed.
- **Unsupported-enumerator fixture rebase.** The pre-existing `unsupported_test.go` fixtures used `ec2:vpc` as a "still-unsupported" type to exercise the registry-subtraction code path. With `aws_vpc` joining the registry, those fixture rows were swapped to `rds:cluster` (still unsupported) / `elasticloadbalancing:loadbalancer` (still unsupported, in the Network Security category) so the same paths stay covered. The fixture-drift checker in `TestEnumerateUnsupported_FiltersSupportedTypes` caught this automatically.