### PR TITLE
fix(genconfig): drop orphan ipv6_netmask_length and subnet_mapping/subnets conflict (#337, #338)

### DIFF
--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -53,6 +53,8 @@ var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_lambda_function": fixupLambdaSource,
 	"aws_kms_key":         fixupKMSRotationPeriodZero,
 	"aws_dynamodb_table":  fixupDynamoDBPITRRecoveryPeriodZero,
+	"aws_vpc":             fixupVPCIPv6NetmaskOrphan,
+	"aws_lb":              fixupLBSubnetMappingConflict,
 }
 
 // lambdaPlaceholderFile is what we set `filename` to so the block
@@ -131,6 +133,89 @@ func fixupDynamoDBPITRRecoveryPeriodZero(blk *hclwrite.Block) {
 		if isAttrLiteralZero(sub.Body(), "recovery_period_in_days") {
 			sub.Body().RemoveAttribute("recovery_period_in_days")
 		}
+	}
+}
+
+// fixupVPCIPv6NetmaskOrphan drops aws_vpc.ipv6_netmask_length when its
+// emitted value is the literal `0` AND ipv6_ipam_pool_id has no usable
+// value. The provider schema marks the pair as mutually-required: if one
+// is specified, the other must be too. `terraform plan
+// -generate-config-out` always emits both attributes regardless of
+// whether the running VPC was provisioned from an IPAM pool, so for the
+// common non-IPAM case generate-config-out produces
+// `ipv6_ipam_pool_id = null` + `ipv6_netmask_length = 0`, which fails
+// `terraform validate` with `"ipv6_netmask_length": all of
+// `ipv6_ipam_pool_id,ipv6_netmask_length` must be specified`.
+//
+// Conservative shape: only the orphan pairing (no pool + literal 0
+// netmask) triggers the drop. A real IPAM-pinned VPC carrying both
+// values is preserved untouched. Issue #337.
+func fixupVPCIPv6NetmaskOrphan(blk *hclwrite.Block) {
+	body := blk.Body()
+	if hasUsableValue(body, "ipv6_ipam_pool_id") {
+		return
+	}
+	if !isAttrLiteralZero(body, "ipv6_netmask_length") {
+		return
+	}
+	body.RemoveAttribute("ipv6_netmask_length")
+}
+
+// fixupLBSubnetMappingConflict resolves the aws_lb subnet_mapping vs
+// subnets mutual-exclusion conflict. The provider schema marks the pair
+// as mutually exclusive (`only one of `subnet_mapping,subnets` can be
+// specified`), but `terraform plan -generate-config-out` always emits
+// both: `subnets` as a string list and `subnet_mapping` as one block per
+// subnet attachment.
+//
+// Heuristic: subnet_mapping is only meaningful when the operator has
+// pinned static IPs on a load-balancer interface (Network LB EIP
+// allocation, private IPv4 pin, or IPv6 pin). If any sub-block carries
+// `allocation_id`, `private_ipv4_address`, or `ipv6_address` with a
+// usable value, drop `subnets` and keep the subnet_mapping blocks.
+// Otherwise the subnet_mapping blocks contribute no information beyond
+// what `subnets` already conveys, so drop them all and keep `subnets`
+// (the canonical ALB shape). Issue #338.
+func fixupLBSubnetMappingConflict(blk *hclwrite.Block) {
+	body := blk.Body()
+
+	// Find the subnet_mapping sub-blocks (may be zero, one, or many).
+	var mappings []*hclwrite.Block
+	for _, sub := range body.Blocks() {
+		if sub.Type() == "subnet_mapping" {
+			mappings = append(mappings, sub)
+		}
+	}
+	hasSubnets := body.GetAttribute("subnets") != nil
+
+	// If neither side is present, nothing to reconcile.
+	if len(mappings) == 0 && !hasSubnets {
+		return
+	}
+	// If only one side is present, no conflict to resolve.
+	if len(mappings) == 0 || !hasSubnets {
+		return
+	}
+
+	// Both sides present. Decide which to keep based on whether any
+	// sub-block carries an operator-supplied static IP pin.
+	pinned := false
+	for _, m := range mappings {
+		mb := m.Body()
+		if hasUsableValue(mb, "allocation_id") ||
+			hasUsableValue(mb, "private_ipv4_address") ||
+			hasUsableValue(mb, "ipv6_address") {
+			pinned = true
+			break
+		}
+	}
+
+	if pinned {
+		body.RemoveAttribute("subnets")
+		return
+	}
+	for _, m := range mappings {
+		body.RemoveBlock(m)
 	}
 }
 

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -360,6 +360,294 @@ func TestFixupDynamoDB_MultiplePITRBlocksAllZerosDropped(t *testing.T) {
 	}
 }
 
+// TestFixupVPC_IPv6NetmaskOrphanRemoved pins the canonical orphan shape:
+// generate-config-out emits both attrs (pool=null, netmask=0) for a
+// non-IPAM VPC. The fixup must drop the orphan netmask so the provider's
+// `all of ...` validator stops failing. Issue #337.
+func TestFixupVPC_IPv6NetmaskOrphanRemoved(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_vpc" "main" {
+  cidr_block          = "10.0.0.0/16"
+  ipv6_ipam_pool_id   = null
+  ipv6_netmask_length = 0
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "ipv6_netmask_length") {
+		t.Errorf("orphan ipv6_netmask_length must be dropped\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupVPC_IPv6NetmaskPreservedWhenPoolSet pins conservative scope:
+// a real IPAM-pinned VPC carrying both `ipv6_ipam_pool_id` and a non-zero
+// `ipv6_netmask_length` must be left untouched. The fixup only fires on
+// the orphan (no pool + zero netmask) shape.
+func TestFixupVPC_IPv6NetmaskPreservedWhenPoolSet(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_vpc" "main" {
+  cidr_block          = "10.0.0.0/16"
+  ipv6_ipam_pool_id   = "ipam-pool-0123456789abcdef0"
+  ipv6_netmask_length = 64
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`ipv6_ipam_pool_id\s*=\s*"ipam-pool-0123456789abcdef0"`).MatchString(got) {
+		t.Errorf("ipv6_ipam_pool_id must be preserved when set\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`ipv6_netmask_length\s*=\s*64`).MatchString(got) {
+		t.Errorf("ipv6_netmask_length=64 must be preserved when pool is set\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupVPC_NoOpWhenNeitherSet pins that a VPC block emitted without
+// either ipv6_* attribute (the older provider behaviour, or operator-
+// hand-edited HCL) is a pure no-op. A mutation that always wrote a stub
+// would fail this.
+func TestFixupVPC_NoOpWhenNeitherSet(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(in) {
+		t.Errorf("no ipv6_* attrs must yield identical output\n--- in ---\n%s\n--- out ---\n%s", in, out)
+	}
+}
+
+// TestFixupVPC_OtherAttrsUntouched pins isolation within the VPC block:
+// the fixup only touches the orphan netmask attribute. Other attrs
+// (cidr_block, instance_tenancy, enable_dns_hostnames) flow through
+// untouched.
+func TestFixupVPC_OtherAttrsUntouched(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  instance_tenancy     = "default"
+  enable_dns_hostnames = true
+  ipv6_ipam_pool_id    = null
+  ipv6_netmask_length  = 0
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`cidr_block\s*=\s*"10\.0\.0\.0/16"`).MatchString(got) {
+		t.Errorf("cidr_block must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`instance_tenancy\s*=\s*"default"`).MatchString(got) {
+		t.Errorf("instance_tenancy must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`enable_dns_hostnames\s*=\s*true`).MatchString(got) {
+		t.Errorf("enable_dns_hostnames must be preserved\n--- got ---\n%s", got)
+	}
+	if strings.Contains(got, "ipv6_netmask_length") {
+		t.Errorf("orphan ipv6_netmask_length must still be dropped\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupVPC_OnlyAffectsAWSVPCBlocks pins resource-type isolation: a
+// sibling aws_subnet block carrying its own (unrelated) ipv6_*
+// attributes must NOT be touched by the VPC fixup. The fixup table is
+// keyed by resource type, so a mutation broadening it to "any resource
+// with these attrs" would corrupt the subnet block.
+func TestFixupVPC_OnlyAffectsAWSVPCBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_vpc" "main" {
+  cidr_block          = "10.0.0.0/16"
+  ipv6_ipam_pool_id   = null
+  ipv6_netmask_length = 0
+}
+
+resource "aws_subnet" "sub" {
+  vpc_id              = "vpc-123"
+  cidr_block          = "10.0.1.0/24"
+  ipv6_netmask_length = 0
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// VPC's orphan should be dropped...
+	if strings.Count(got, "ipv6_netmask_length") != 1 {
+		t.Errorf("expected exactly one ipv6_netmask_length remaining (the subnet's), got %d\n--- got ---\n%s",
+			strings.Count(got, "ipv6_netmask_length"), got)
+	}
+	// ...but the subnet block must keep its own ipv6_netmask_length.
+	if !regexp.MustCompile(`(?s)resource "aws_subnet"[^}]*ipv6_netmask_length`).MatchString(got) {
+		t.Errorf("aws_subnet's ipv6_netmask_length must be preserved (fixup is keyed by aws_vpc)\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLB_DropsSubnetMappingWhenNoIPPinned pins the common ALB
+// shape: generate-config-out emits both subnet_mapping (one block per
+// subnet) and subnets (the canonical list). When no sub-block carries a
+// static IP pin, drop the subnet_mapping blocks. Issue #338.
+func TestFixupLB_DropsSubnetMappingWhenNoIPPinned(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb" "main" {
+  name     = "alpha"
+  internal = false
+  subnets  = ["subnet-aaa", "subnet-bbb"]
+  subnet_mapping {
+    subnet_id = "subnet-aaa"
+  }
+  subnet_mapping {
+    subnet_id = "subnet-bbb"
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "subnet_mapping") {
+		t.Errorf("subnet_mapping blocks must be dropped when no static IP pin present\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`subnets\s*=\s*\["subnet-aaa",\s*"subnet-bbb"\]`).MatchString(got) {
+		t.Errorf("subnets list must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLB_PreservesSubnetMappingWhenAllocationIDSet pins the NLB-EIP
+// case: an operator pinning an Elastic IP via allocation_id is
+// expressing static-IP intent that subnet_mapping carries and `subnets`
+// does not. Drop `subnets`, keep the mapping blocks.
+func TestFixupLB_PreservesSubnetMappingWhenAllocationIDSet(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb" "main" {
+  name               = "nlb"
+  load_balancer_type = "network"
+  subnets            = ["subnet-aaa", "subnet-bbb"]
+  subnet_mapping {
+    subnet_id     = "subnet-aaa"
+    allocation_id = "eipalloc-0123456789abcdef0"
+  }
+  subnet_mapping {
+    subnet_id = "subnet-bbb"
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*subnets\s*=`).MatchString(got) {
+		t.Errorf("subnets attribute must be dropped when subnet_mapping carries allocation_id\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, "subnet_mapping") {
+		t.Errorf("subnet_mapping blocks must be preserved when allocation_id present\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, `allocation_id = "eipalloc-0123456789abcdef0"`) {
+		t.Errorf("allocation_id value must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLB_PreservesSubnetMappingWhenPrivateIPv4Set pins the
+// internal-LB private-IP case: a sub-block carrying private_ipv4_address
+// also expresses static-IP intent. Same outcome as the allocation_id
+// case — drop `subnets`, keep mappings.
+func TestFixupLB_PreservesSubnetMappingWhenPrivateIPv4Set(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb" "main" {
+  name     = "internal"
+  internal = true
+  subnets  = ["subnet-aaa"]
+  subnet_mapping {
+    subnet_id            = "subnet-aaa"
+    private_ipv4_address = "10.0.1.42"
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*subnets\s*=`).MatchString(got) {
+		t.Errorf("subnets attribute must be dropped when subnet_mapping carries private_ipv4_address\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, `private_ipv4_address = "10.0.1.42"`) {
+		t.Errorf("private_ipv4_address value must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLB_NoOpWhenNeitherPresent pins the operator-hand-edited /
+// minimal-LB case: no subnets attribute and no subnet_mapping blocks.
+// The fixup must not invent either, and other attrs flow through.
+func TestFixupLB_NoOpWhenNeitherPresent(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb" "main" {
+  name     = "alpha"
+  internal = true
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(in) {
+		t.Errorf("no subnets/subnet_mapping must yield identical output\n--- in ---\n%s\n--- out ---\n%s", in, out)
+	}
+}
+
+// TestFixupLB_OnlyAffectsAWSLBBlocks pins resource-type isolation: a
+// sibling aws_lb_target_group block (which has no subnet_mapping/subnets
+// schema) must not be perturbed by the LB fixup. The fixup table is
+// keyed by aws_lb so any block with a different resource type passes
+// through untouched.
+func TestFixupLB_OnlyAffectsAWSLBBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb" "main" {
+  name    = "alpha"
+  subnets = ["subnet-aaa"]
+  subnet_mapping {
+    subnet_id = "subnet-aaa"
+  }
+}
+
+resource "aws_lb_target_group" "tg" {
+  name     = "alpha-tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "vpc-123"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// LB had no IP pin → subnet_mapping dropped; subnets kept.
+	if strings.Contains(got, "subnet_mapping") {
+		t.Errorf("aws_lb's subnet_mapping must be dropped\n--- got ---\n%s", got)
+	}
+	// Target group block must remain intact.
+	if !regexp.MustCompile(`(?s)resource "aws_lb_target_group" "tg" \{[^}]*name\s*=\s*"alpha-tg"`).MatchString(got) {
+		t.Errorf("aws_lb_target_group must pass through untouched\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?s)resource "aws_lb_target_group" "tg" \{[^}]*port\s*=\s*80`).MatchString(got) {
+		t.Errorf("aws_lb_target_group port must be preserved\n--- got ---\n%s", got)
+	}
+}
+
 // TestFixupLambda_MultipleLambdasBothFixed pins iteration: two Lambda
 // blocks in input order both get the placeholder + ignore_changes
 // treatment. A mutation that exited after the first block would survive


### PR DESCRIPTION
## Summary
- aws_vpc: drop ipv6_netmask_length when ipv6_ipam_pool_id is absent
- aws_lb: drop subnet_mapping when no static IP pin; otherwise drop subnets

Both surfaced via live CUST3 smoke during PR #335 validation. Pre-existing genconfig bugs that only became visible once Bundle 4 added the aws_vpc and aws_lb discoverers.

## Test plan
- [x] go test ./cmd/insideout-import/genconfig/... -race -count=1
- [x] gofmt clean
- [x] go vet clean
- [ ] CI green
- [ ] Live smoke re-run after merge confirms terraform validate exits 0 (deferred to integration PR)

Closes #337
Closes #338