### PR TITLE
fix(awsdiscover): skip resourceexplorer2 ARNs from non-loop regions (#336)

### DIFF
--- a/cmd/insideout-import/awsdiscover/resourceexplorer2_index.go
+++ b/cmd/insideout-import/awsdiscover/resourceexplorer2_index.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
 	re2types "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2/types"
 	"golang.org/x/sync/errgroup"
@@ -136,6 +137,18 @@ func (d *resourceExplorer2IndexDiscoverer) Discover(ctx context.Context, args Di
 					mu.Lock()
 					ok = append(ok, ix)
 					mu.Unlock()
+					return nil
+				}
+				// Issue #336: ListIndexes returns ARNs from every region
+				// in the account regardless of the SDK client's region.
+				// Per-region clients can't tag-fetch foreign ARNs (the
+				// API rejects with BadRequestException "expected region
+				// X"), and addressBook dedup keys on the outer-loop
+				// region — emitting an off-region ARN here would also
+				// produce a duplicate ImportedResource when the operator
+				// listed the home region. Drop both the tag-fetch and
+				// the emission for ARNs whose region != outer-loop.
+				if parsed, perr := awsarn.Parse(ix.arn); perr == nil && parsed.Region != "" && parsed.Region != region {
 					return nil
 				}
 				tagsOut, err := client.ListTagsForResource(gctx, &resourceexplorer2.ListTagsForResourceInput{ResourceArn: aws.String(ix.arn)})

--- a/cmd/insideout-import/awsdiscover/resourceexplorer2_index_test.go
+++ b/cmd/insideout-import/awsdiscover/resourceexplorer2_index_test.go
@@ -373,6 +373,56 @@ func TestResourceExplorer2IndexDiscover_MultiRegionTriggersOneSDKCallPerRegion(t
 	}
 }
 
+// TestResourceExplorer2IndexDiscover_SkipsCrossRegionARNs pins the
+// fix for issue #336: ListIndexes returns ARNs from every region in
+// the account regardless of the SDK client's region. Per-region
+// clients can't tag-fetch foreign ARNs (BadRequestException), and
+// emitting them would produce duplicates because addressBook keys
+// on the outer-loop region. ARNs whose ARN-region != outer-loop
+// region must be dropped before the tag-fetch and before emission.
+func TestResourceExplorer2IndexDiscover_SkipsCrossRegionARNs(t *testing.T) {
+	t.Parallel()
+	const homeARN = "arn:aws:resource-explorer-2:us-east-1:123:index/home-uuid"
+	const foreignARN = "arn:aws:resource-explorer-2:eu-central-1:123:index/foreign-uuid"
+	fake := &fakeRE2IndexClient{
+		pages: []resourceexplorer2.ListIndexesOutput{{
+			Indexes: []re2types.Index{
+				re2Index(homeARN, "us-east-1", re2types.IndexTypeAggregator),
+				re2Index(foreignARN, "eu-central-1", re2types.IndexTypeLocal),
+			},
+		}},
+		tagsByID: map[string]map[string]string{
+			homeARN:    {},
+			foreignARN: {},
+		},
+	}
+	d := &resourceExplorer2IndexDiscoverer{
+		new:            func(_ string) resourceExplorer2IndexClient { return fake },
+		maxConcurrency: 4,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Tag-fetch must happen for the home-region ARN only.
+	if len(fake.tagCalls) != 1 {
+		t.Fatalf("ListTagsForResource called %d times, want 1 (cross-region must be skipped): %v", len(fake.tagCalls), fake.tagCalls)
+	}
+	if fake.tagCalls[0] != homeARN {
+		t.Errorf("tag-fetch ARN=%q, want %q", fake.tagCalls[0], homeARN)
+	}
+	// Emission must include the home-region ARN only.
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (cross-region must not be emitted)", len(got))
+	}
+	if got[0].Identity.ImportID != homeARN {
+		t.Errorf("ImportID=%q, want %q", got[0].Identity.ImportID, homeARN)
+	}
+}
+
 // blockingRE2IndexClient mirrors blockingDynamoClient — used for the
 // bounded-concurrency test below.
 type blockingRE2IndexClient struct {

--- a/cmd/insideout-import/awsdiscover/resourceexplorer2_view.go
+++ b/cmd/insideout-import/awsdiscover/resourceexplorer2_view.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
 	re2types "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2/types"
 	"golang.org/x/sync/errgroup"
@@ -129,6 +130,18 @@ func (d *resourceExplorer2ViewDiscoverer) Discover(ctx context.Context, args Dis
 					mu.Lock()
 					ok = append(ok, v)
 					mu.Unlock()
+					return nil
+				}
+				// Issue #336: ListViews returns ARNs from every region
+				// in the account regardless of the SDK client's region.
+				// Per-region clients can't tag-fetch foreign ARNs (the
+				// API rejects with BadRequestException "expected region
+				// X"), and addressBook dedup keys on the outer-loop
+				// region — emitting an off-region ARN here would also
+				// produce a duplicate ImportedResource when the operator
+				// listed the home region. Drop both the tag-fetch and
+				// the emission for ARNs whose region != outer-loop.
+				if parsed, perr := awsarn.Parse(v.arn); perr == nil && parsed.Region != "" && parsed.Region != region {
 					return nil
 				}
 				tagsOut, err := client.ListTagsForResource(gctx, &resourceexplorer2.ListTagsForResourceInput{ResourceArn: aws.String(v.arn)})

--- a/cmd/insideout-import/awsdiscover/resourceexplorer2_view_test.go
+++ b/cmd/insideout-import/awsdiscover/resourceexplorer2_view_test.go
@@ -348,6 +348,53 @@ func TestResourceExplorer2ViewDiscover_MultiRegionTriggersOneSDKCallPerRegion(t 
 	}
 }
 
+// TestResourceExplorer2ViewDiscover_SkipsCrossRegionARNs pins the
+// fix for issue #336: ListViews returns ARNs from every region in
+// the account regardless of the SDK client's region. Per-region
+// clients can't tag-fetch foreign ARNs (BadRequestException), and
+// emitting them would produce duplicates because addressBook keys
+// on the outer-loop region. ARNs whose ARN-region != outer-loop
+// region must be dropped before the tag-fetch and before emission.
+func TestResourceExplorer2ViewDiscover_SkipsCrossRegionARNs(t *testing.T) {
+	t.Parallel()
+	const homeARN = "arn:aws:resource-explorer-2:us-east-1:123:view/home/home-uuid"
+	const foreignARN = "arn:aws:resource-explorer-2:eu-central-1:123:view/foreign/foreign-uuid"
+	fake := &fakeRE2ViewClient{
+		pages: []resourceexplorer2.ListViewsOutput{{
+			Views: []string{homeARN, foreignARN},
+		}},
+		tagsByID: map[string]map[string]string{
+			homeARN:    {},
+			foreignARN: {},
+		},
+	}
+	d := &resourceExplorer2ViewDiscoverer{
+		new:            func(_ string) resourceExplorer2ViewClient { return fake },
+		maxConcurrency: 4,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Tag-fetch must happen for the home-region ARN only.
+	if len(fake.tagCalls) != 1 {
+		t.Fatalf("ListTagsForResource called %d times, want 1 (cross-region must be skipped): %v", len(fake.tagCalls), fake.tagCalls)
+	}
+	if fake.tagCalls[0] != homeARN {
+		t.Errorf("tag-fetch ARN=%q, want %q", fake.tagCalls[0], homeARN)
+	}
+	// Emission must include the home-region ARN only.
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (cross-region must not be emitted)", len(got))
+	}
+	if got[0].Identity.ImportID != homeARN {
+		t.Errorf("ImportID=%q, want %q", got[0].Identity.ImportID, homeARN)
+	}
+}
+
 // blockingRE2ViewClient mirrors blockingDynamoClient — used for the
 // bounded-concurrency test below.
 type blockingRE2ViewClient struct {


### PR DESCRIPTION
## Summary
- Parse each ARN with awsarn.Parse and skip when region != outer-loop region
- Apply gate at both tag-fetch site and emission site
- Surfaced via live CUST3 smoke during PR #335 validation (WARN noise + risk of duplicate emission)

## Test plan
- [x] New TestResourceExplorer2{Index,View}Discover_SkipsCrossRegionARNs covers mixed-region ARN response
- [x] Existing TestResourceExplorer2{Index,View}Discover_MultiRegionTriggersOneSDKCallPerRegion still green
- [x] go test ./cmd/insideout-import/awsdiscover/... -race -count=1
- [x] gofmt clean, go vet clean
- [ ] CI green
- [ ] Live smoke re-run after merge confirms zero BadRequestException warnings (deferred to integration PR)

Closes #336