### PR TITLE
fix(import): bundle 4 follow-ups — RE2 cross-region + genconfig fixups (#336, #337, #338)

### DIFF
--- a/cmd/insideout-import/awsdiscover/resourceexplorer2_index.go
+++ b/cmd/insideout-import/awsdiscover/resourceexplorer2_index.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
 	re2types "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2/types"
 	"golang.org/x/sync/errgroup"
@@ -136,6 +137,18 @@ func (d *resourceExplorer2IndexDiscoverer) Discover(ctx context.Context, args Di
 					mu.Lock()
 					ok = append(ok, ix)
 					mu.Unlock()
+					return nil
+				}
+				// Issue #336: ListIndexes returns ARNs from every region
+				// in the account regardless of the SDK client's region.
+				// Per-region clients can't tag-fetch foreign ARNs (the
+				// API rejects with BadRequestException "expected region
+				// X"), and addressBook dedup keys on the outer-loop
+				// region — emitting an off-region ARN here would also
+				// produce a duplicate ImportedResource when the operator
+				// listed the home region. Drop both the tag-fetch and
+				// the emission for ARNs whose region != outer-loop.
+				if parsed, perr := awsarn.Parse(ix.arn); perr == nil && parsed.Region != "" && parsed.Region != region {
 					return nil
 				}
 				tagsOut, err := client.ListTagsForResource(gctx, &resourceexplorer2.ListTagsForResourceInput{ResourceArn: aws.String(ix.arn)})

--- a/cmd/insideout-import/awsdiscover/resourceexplorer2_index_test.go
+++ b/cmd/insideout-import/awsdiscover/resourceexplorer2_index_test.go
@@ -373,6 +373,56 @@ func TestResourceExplorer2IndexDiscover_MultiRegionTriggersOneSDKCallPerRegion(t
 	}
 }
 
+// TestResourceExplorer2IndexDiscover_SkipsCrossRegionARNs pins the
+// fix for issue #336: ListIndexes returns ARNs from every region in
+// the account regardless of the SDK client's region. Per-region
+// clients can't tag-fetch foreign ARNs (BadRequestException), and
+// emitting them would produce duplicates because addressBook keys
+// on the outer-loop region. ARNs whose ARN-region != outer-loop
+// region must be dropped before the tag-fetch and before emission.
+func TestResourceExplorer2IndexDiscover_SkipsCrossRegionARNs(t *testing.T) {
+	t.Parallel()
+	const homeARN = "arn:aws:resource-explorer-2:us-east-1:123:index/home-uuid"
+	const foreignARN = "arn:aws:resource-explorer-2:eu-central-1:123:index/foreign-uuid"
+	fake := &fakeRE2IndexClient{
+		pages: []resourceexplorer2.ListIndexesOutput{{
+			Indexes: []re2types.Index{
+				re2Index(homeARN, "us-east-1", re2types.IndexTypeAggregator),
+				re2Index(foreignARN, "eu-central-1", re2types.IndexTypeLocal),
+			},
+		}},
+		tagsByID: map[string]map[string]string{
+			homeARN:    {},
+			foreignARN: {},
+		},
+	}
+	d := &resourceExplorer2IndexDiscoverer{
+		new:            func(_ string) resourceExplorer2IndexClient { return fake },
+		maxConcurrency: 4,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Tag-fetch must happen for the home-region ARN only.
+	if len(fake.tagCalls) != 1 {
+		t.Fatalf("ListTagsForResource called %d times, want 1 (cross-region must be skipped): %v", len(fake.tagCalls), fake.tagCalls)
+	}
+	if fake.tagCalls[0] != homeARN {
+		t.Errorf("tag-fetch ARN=%q, want %q", fake.tagCalls[0], homeARN)
+	}
+	// Emission must include the home-region ARN only.
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (cross-region must not be emitted)", len(got))
+	}
+	if got[0].Identity.ImportID != homeARN {
+		t.Errorf("ImportID=%q, want %q", got[0].Identity.ImportID, homeARN)
+	}
+}
+
 // blockingRE2IndexClient mirrors blockingDynamoClient — used for the
 // bounded-concurrency test below.
 type blockingRE2IndexClient struct {

--- a/cmd/insideout-import/awsdiscover/resourceexplorer2_view.go
+++ b/cmd/insideout-import/awsdiscover/resourceexplorer2_view.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
 	re2types "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2/types"
 	"golang.org/x/sync/errgroup"
@@ -129,6 +130,18 @@ func (d *resourceExplorer2ViewDiscoverer) Discover(ctx context.Context, args Dis
 					mu.Lock()
 					ok = append(ok, v)
 					mu.Unlock()
+					return nil
+				}
+				// Issue #336: ListViews returns ARNs from every region
+				// in the account regardless of the SDK client's region.
+				// Per-region clients can't tag-fetch foreign ARNs (the
+				// API rejects with BadRequestException "expected region
+				// X"), and addressBook dedup keys on the outer-loop
+				// region — emitting an off-region ARN here would also
+				// produce a duplicate ImportedResource when the operator
+				// listed the home region. Drop both the tag-fetch and
+				// the emission for ARNs whose region != outer-loop.
+				if parsed, perr := awsarn.Parse(v.arn); perr == nil && parsed.Region != "" && parsed.Region != region {
 					return nil
 				}
 				tagsOut, err := client.ListTagsForResource(gctx, &resourceexplorer2.ListTagsForResourceInput{ResourceArn: aws.String(v.arn)})

--- a/cmd/insideout-import/awsdiscover/resourceexplorer2_view_test.go
+++ b/cmd/insideout-import/awsdiscover/resourceexplorer2_view_test.go
@@ -348,6 +348,53 @@ func TestResourceExplorer2ViewDiscover_MultiRegionTriggersOneSDKCallPerRegion(t 
 	}
 }
 
+// TestResourceExplorer2ViewDiscover_SkipsCrossRegionARNs pins the
+// fix for issue #336: ListViews returns ARNs from every region in
+// the account regardless of the SDK client's region. Per-region
+// clients can't tag-fetch foreign ARNs (BadRequestException), and
+// emitting them would produce duplicates because addressBook keys
+// on the outer-loop region. ARNs whose ARN-region != outer-loop
+// region must be dropped before the tag-fetch and before emission.
+func TestResourceExplorer2ViewDiscover_SkipsCrossRegionARNs(t *testing.T) {
+	t.Parallel()
+	const homeARN = "arn:aws:resource-explorer-2:us-east-1:123:view/home/home-uuid"
+	const foreignARN = "arn:aws:resource-explorer-2:eu-central-1:123:view/foreign/foreign-uuid"
+	fake := &fakeRE2ViewClient{
+		pages: []resourceexplorer2.ListViewsOutput{{
+			Views: []string{homeARN, foreignARN},
+		}},
+		tagsByID: map[string]map[string]string{
+			homeARN:    {},
+			foreignARN: {},
+		},
+	}
+	d := &resourceExplorer2ViewDiscoverer{
+		new:            func(_ string) resourceExplorer2ViewClient { return fake },
+		maxConcurrency: 4,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Tag-fetch must happen for the home-region ARN only.
+	if len(fake.tagCalls) != 1 {
+		t.Fatalf("ListTagsForResource called %d times, want 1 (cross-region must be skipped): %v", len(fake.tagCalls), fake.tagCalls)
+	}
+	if fake.tagCalls[0] != homeARN {
+		t.Errorf("tag-fetch ARN=%q, want %q", fake.tagCalls[0], homeARN)
+	}
+	// Emission must include the home-region ARN only.
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (cross-region must not be emitted)", len(got))
+	}
+	if got[0].Identity.ImportID != homeARN {
+		t.Errorf("ImportID=%q, want %q", got[0].Identity.ImportID, homeARN)
+	}
+}
+
 // blockingRE2ViewClient mirrors blockingDynamoClient — used for the
 // bounded-concurrency test below.
 type blockingRE2ViewClient struct {

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -53,6 +53,8 @@ var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_lambda_function": fixupLambdaSource,
 	"aws_kms_key":         fixupKMSRotationPeriodZero,
 	"aws_dynamodb_table":  fixupDynamoDBPITRRecoveryPeriodZero,
+	"aws_vpc":             fixupVPCIPv6NetmaskOrphan,
+	"aws_lb":              fixupLBSubnetMappingConflict,
 }
 
 // lambdaPlaceholderFile is what we set `filename` to so the block
@@ -131,6 +133,89 @@ func fixupDynamoDBPITRRecoveryPeriodZero(blk *hclwrite.Block) {
 		if isAttrLiteralZero(sub.Body(), "recovery_period_in_days") {
 			sub.Body().RemoveAttribute("recovery_period_in_days")
 		}
+	}
+}
+
+// fixupVPCIPv6NetmaskOrphan drops aws_vpc.ipv6_netmask_length when its
+// emitted value is the literal `0` AND ipv6_ipam_pool_id has no usable
+// value. The provider schema marks the pair as mutually-required: if one
+// is specified, the other must be too. `terraform plan
+// -generate-config-out` always emits both attributes regardless of
+// whether the running VPC was provisioned from an IPAM pool, so for the
+// common non-IPAM case generate-config-out produces
+// `ipv6_ipam_pool_id = null` + `ipv6_netmask_length = 0`, which fails
+// `terraform validate` with `"ipv6_netmask_length": all of
+// `ipv6_ipam_pool_id,ipv6_netmask_length` must be specified`.
+//
+// Conservative shape: only the orphan pairing (no pool + literal 0
+// netmask) triggers the drop. A real IPAM-pinned VPC carrying both
+// values is preserved untouched. Issue #337.
+func fixupVPCIPv6NetmaskOrphan(blk *hclwrite.Block) {
+	body := blk.Body()
+	if hasUsableValue(body, "ipv6_ipam_pool_id") {
+		return
+	}
+	if !isAttrLiteralZero(body, "ipv6_netmask_length") {
+		return
+	}
+	body.RemoveAttribute("ipv6_netmask_length")
+}
+
+// fixupLBSubnetMappingConflict resolves the aws_lb subnet_mapping vs
+// subnets mutual-exclusion conflict. The provider schema marks the pair
+// as mutually exclusive (`only one of `subnet_mapping,subnets` can be
+// specified`), but `terraform plan -generate-config-out` always emits
+// both: `subnets` as a string list and `subnet_mapping` as one block per
+// subnet attachment.
+//
+// Heuristic: subnet_mapping is only meaningful when the operator has
+// pinned static IPs on a load-balancer interface (Network LB EIP
+// allocation, private IPv4 pin, or IPv6 pin). If any sub-block carries
+// `allocation_id`, `private_ipv4_address`, or `ipv6_address` with a
+// usable value, drop `subnets` and keep the subnet_mapping blocks.
+// Otherwise the subnet_mapping blocks contribute no information beyond
+// what `subnets` already conveys, so drop them all and keep `subnets`
+// (the canonical ALB shape). Issue #338.
+func fixupLBSubnetMappingConflict(blk *hclwrite.Block) {
+	body := blk.Body()
+
+	// Find the subnet_mapping sub-blocks (may be zero, one, or many).
+	var mappings []*hclwrite.Block
+	for _, sub := range body.Blocks() {
+		if sub.Type() == "subnet_mapping" {
+			mappings = append(mappings, sub)
+		}
+	}
+	hasSubnets := body.GetAttribute("subnets") != nil
+
+	// If neither side is present, nothing to reconcile.
+	if len(mappings) == 0 && !hasSubnets {
+		return
+	}
+	// If only one side is present, no conflict to resolve.
+	if len(mappings) == 0 || !hasSubnets {
+		return
+	}
+
+	// Both sides present. Decide which to keep based on whether any
+	// sub-block carries an operator-supplied static IP pin.
+	pinned := false
+	for _, m := range mappings {
+		mb := m.Body()
+		if hasUsableValue(mb, "allocation_id") ||
+			hasUsableValue(mb, "private_ipv4_address") ||
+			hasUsableValue(mb, "ipv6_address") {
+			pinned = true
+			break
+		}
+	}
+
+	if pinned {
+		body.RemoveAttribute("subnets")
+		return
+	}
+	for _, m := range mappings {
+		body.RemoveBlock(m)
 	}
 }
 

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -360,6 +360,294 @@ func TestFixupDynamoDB_MultiplePITRBlocksAllZerosDropped(t *testing.T) {
 	}
 }
 
+// TestFixupVPC_IPv6NetmaskOrphanRemoved pins the canonical orphan shape:
+// generate-config-out emits both attrs (pool=null, netmask=0) for a
+// non-IPAM VPC. The fixup must drop the orphan netmask so the provider's
+// `all of ...` validator stops failing. Issue #337.
+func TestFixupVPC_IPv6NetmaskOrphanRemoved(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_vpc" "main" {
+  cidr_block          = "10.0.0.0/16"
+  ipv6_ipam_pool_id   = null
+  ipv6_netmask_length = 0
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "ipv6_netmask_length") {
+		t.Errorf("orphan ipv6_netmask_length must be dropped\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupVPC_IPv6NetmaskPreservedWhenPoolSet pins conservative scope:
+// a real IPAM-pinned VPC carrying both `ipv6_ipam_pool_id` and a non-zero
+// `ipv6_netmask_length` must be left untouched. The fixup only fires on
+// the orphan (no pool + zero netmask) shape.
+func TestFixupVPC_IPv6NetmaskPreservedWhenPoolSet(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_vpc" "main" {
+  cidr_block          = "10.0.0.0/16"
+  ipv6_ipam_pool_id   = "ipam-pool-0123456789abcdef0"
+  ipv6_netmask_length = 64
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`ipv6_ipam_pool_id\s*=\s*"ipam-pool-0123456789abcdef0"`).MatchString(got) {
+		t.Errorf("ipv6_ipam_pool_id must be preserved when set\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`ipv6_netmask_length\s*=\s*64`).MatchString(got) {
+		t.Errorf("ipv6_netmask_length=64 must be preserved when pool is set\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupVPC_NoOpWhenNeitherSet pins that a VPC block emitted without
+// either ipv6_* attribute (the older provider behaviour, or operator-
+// hand-edited HCL) is a pure no-op. A mutation that always wrote a stub
+// would fail this.
+func TestFixupVPC_NoOpWhenNeitherSet(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(in) {
+		t.Errorf("no ipv6_* attrs must yield identical output\n--- in ---\n%s\n--- out ---\n%s", in, out)
+	}
+}
+
+// TestFixupVPC_OtherAttrsUntouched pins isolation within the VPC block:
+// the fixup only touches the orphan netmask attribute. Other attrs
+// (cidr_block, instance_tenancy, enable_dns_hostnames) flow through
+// untouched.
+func TestFixupVPC_OtherAttrsUntouched(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  instance_tenancy     = "default"
+  enable_dns_hostnames = true
+  ipv6_ipam_pool_id    = null
+  ipv6_netmask_length  = 0
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`cidr_block\s*=\s*"10\.0\.0\.0/16"`).MatchString(got) {
+		t.Errorf("cidr_block must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`instance_tenancy\s*=\s*"default"`).MatchString(got) {
+		t.Errorf("instance_tenancy must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`enable_dns_hostnames\s*=\s*true`).MatchString(got) {
+		t.Errorf("enable_dns_hostnames must be preserved\n--- got ---\n%s", got)
+	}
+	if strings.Contains(got, "ipv6_netmask_length") {
+		t.Errorf("orphan ipv6_netmask_length must still be dropped\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupVPC_OnlyAffectsAWSVPCBlocks pins resource-type isolation: a
+// sibling aws_subnet block carrying its own (unrelated) ipv6_*
+// attributes must NOT be touched by the VPC fixup. The fixup table is
+// keyed by resource type, so a mutation broadening it to "any resource
+// with these attrs" would corrupt the subnet block.
+func TestFixupVPC_OnlyAffectsAWSVPCBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_vpc" "main" {
+  cidr_block          = "10.0.0.0/16"
+  ipv6_ipam_pool_id   = null
+  ipv6_netmask_length = 0
+}
+
+resource "aws_subnet" "sub" {
+  vpc_id              = "vpc-123"
+  cidr_block          = "10.0.1.0/24"
+  ipv6_netmask_length = 0
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// VPC's orphan should be dropped...
+	if strings.Count(got, "ipv6_netmask_length") != 1 {
+		t.Errorf("expected exactly one ipv6_netmask_length remaining (the subnet's), got %d\n--- got ---\n%s",
+			strings.Count(got, "ipv6_netmask_length"), got)
+	}
+	// ...but the subnet block must keep its own ipv6_netmask_length.
+	if !regexp.MustCompile(`(?s)resource "aws_subnet"[^}]*ipv6_netmask_length`).MatchString(got) {
+		t.Errorf("aws_subnet's ipv6_netmask_length must be preserved (fixup is keyed by aws_vpc)\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLB_DropsSubnetMappingWhenNoIPPinned pins the common ALB
+// shape: generate-config-out emits both subnet_mapping (one block per
+// subnet) and subnets (the canonical list). When no sub-block carries a
+// static IP pin, drop the subnet_mapping blocks. Issue #338.
+func TestFixupLB_DropsSubnetMappingWhenNoIPPinned(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb" "main" {
+  name     = "alpha"
+  internal = false
+  subnets  = ["subnet-aaa", "subnet-bbb"]
+  subnet_mapping {
+    subnet_id = "subnet-aaa"
+  }
+  subnet_mapping {
+    subnet_id = "subnet-bbb"
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "subnet_mapping") {
+		t.Errorf("subnet_mapping blocks must be dropped when no static IP pin present\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`subnets\s*=\s*\["subnet-aaa",\s*"subnet-bbb"\]`).MatchString(got) {
+		t.Errorf("subnets list must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLB_PreservesSubnetMappingWhenAllocationIDSet pins the NLB-EIP
+// case: an operator pinning an Elastic IP via allocation_id is
+// expressing static-IP intent that subnet_mapping carries and `subnets`
+// does not. Drop `subnets`, keep the mapping blocks.
+func TestFixupLB_PreservesSubnetMappingWhenAllocationIDSet(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb" "main" {
+  name               = "nlb"
+  load_balancer_type = "network"
+  subnets            = ["subnet-aaa", "subnet-bbb"]
+  subnet_mapping {
+    subnet_id     = "subnet-aaa"
+    allocation_id = "eipalloc-0123456789abcdef0"
+  }
+  subnet_mapping {
+    subnet_id = "subnet-bbb"
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*subnets\s*=`).MatchString(got) {
+		t.Errorf("subnets attribute must be dropped when subnet_mapping carries allocation_id\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, "subnet_mapping") {
+		t.Errorf("subnet_mapping blocks must be preserved when allocation_id present\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, `allocation_id = "eipalloc-0123456789abcdef0"`) {
+		t.Errorf("allocation_id value must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLB_PreservesSubnetMappingWhenPrivateIPv4Set pins the
+// internal-LB private-IP case: a sub-block carrying private_ipv4_address
+// also expresses static-IP intent. Same outcome as the allocation_id
+// case — drop `subnets`, keep mappings.
+func TestFixupLB_PreservesSubnetMappingWhenPrivateIPv4Set(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb" "main" {
+  name     = "internal"
+  internal = true
+  subnets  = ["subnet-aaa"]
+  subnet_mapping {
+    subnet_id            = "subnet-aaa"
+    private_ipv4_address = "10.0.1.42"
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*subnets\s*=`).MatchString(got) {
+		t.Errorf("subnets attribute must be dropped when subnet_mapping carries private_ipv4_address\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, `private_ipv4_address = "10.0.1.42"`) {
+		t.Errorf("private_ipv4_address value must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLB_NoOpWhenNeitherPresent pins the operator-hand-edited /
+// minimal-LB case: no subnets attribute and no subnet_mapping blocks.
+// The fixup must not invent either, and other attrs flow through.
+func TestFixupLB_NoOpWhenNeitherPresent(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb" "main" {
+  name     = "alpha"
+  internal = true
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(in) {
+		t.Errorf("no subnets/subnet_mapping must yield identical output\n--- in ---\n%s\n--- out ---\n%s", in, out)
+	}
+}
+
+// TestFixupLB_OnlyAffectsAWSLBBlocks pins resource-type isolation: a
+// sibling aws_lb_target_group block (which has no subnet_mapping/subnets
+// schema) must not be perturbed by the LB fixup. The fixup table is
+// keyed by aws_lb so any block with a different resource type passes
+// through untouched.
+func TestFixupLB_OnlyAffectsAWSLBBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb" "main" {
+  name    = "alpha"
+  subnets = ["subnet-aaa"]
+  subnet_mapping {
+    subnet_id = "subnet-aaa"
+  }
+}
+
+resource "aws_lb_target_group" "tg" {
+  name     = "alpha-tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "vpc-123"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// LB had no IP pin → subnet_mapping dropped; subnets kept.
+	if strings.Contains(got, "subnet_mapping") {
+		t.Errorf("aws_lb's subnet_mapping must be dropped\n--- got ---\n%s", got)
+	}
+	// Target group block must remain intact.
+	if !regexp.MustCompile(`(?s)resource "aws_lb_target_group" "tg" \{[^}]*name\s*=\s*"alpha-tg"`).MatchString(got) {
+		t.Errorf("aws_lb_target_group must pass through untouched\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?s)resource "aws_lb_target_group" "tg" \{[^}]*port\s*=\s*80`).MatchString(got) {
+		t.Errorf("aws_lb_target_group port must be preserved\n--- got ---\n%s", got)
+	}
+}
+
 // TestFixupLambda_MultipleLambdasBothFixed pins iteration: two Lambda
 // blocks in input order both get the placeholder + ignore_changes
 // treatment. A mutation that exited after the first block would survive

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -517,7 +517,7 @@ func TestFixupLB_DropsSubnetMappingWhenNoIPPinned(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := string(out)
-	if strings.Contains(got, "subnet_mapping") {
+	if regexp.MustCompile(`(?m)^\s*subnet_mapping\s*\{`).MatchString(got) {
 		t.Errorf("subnet_mapping blocks must be dropped when no static IP pin present\n--- got ---\n%s", got)
 	}
 	if !regexp.MustCompile(`subnets\s*=\s*\["subnet-aaa",\s*"subnet-bbb"\]`).MatchString(got) {
@@ -678,5 +678,75 @@ resource "aws_lambda_function" "bravo" {
 	}
 	if strings.Count(got, "ignore_changes") != 2 {
 		t.Errorf("expected 2 ignore_changes injections, got %d", strings.Count(got, "ignore_changes"))
+	}
+}
+
+// TestFixupVPC_IPv6NetmaskNonLiteralZeroPreserved pins isAttrLiteralZero's
+// carve-out spec: only the literal `0` triggers the orphan drop. Variants
+// like `00`, `0.0`, or any computed expression are preserved untouched. A
+// mutation that loosened the trim to numeric coercion would survive the
+// canonical-orphan test but fail this one.
+func TestFixupVPC_IPv6NetmaskNonLiteralZeroPreserved(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		val  string
+	}{
+		{"double_zero", `00`},
+		{"zero_dot_zero", `0.0`},
+		{"computed_var", `var.netmask`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := []byte(`resource "aws_vpc" "main" {
+  cidr_block          = "10.0.0.0/16"
+  ipv6_ipam_pool_id   = null
+  ipv6_netmask_length = ` + tc.val + `
+}
+`)
+			out, err := applyResourceTypeFixups(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(out)
+			if !strings.Contains(got, "ipv6_netmask_length") {
+				t.Errorf("ipv6_netmask_length=%s must NOT be dropped (only literal 0 triggers the fixup)\n--- got ---\n%s", tc.val, got)
+			}
+		})
+	}
+}
+
+// TestFixupLB_PreservesSubnetMappingWhenIPv6AddressSet pins the third
+// static-IP-pin attribute (ipv6_address) — the production code checks
+// allocation_id, private_ipv4_address, AND ipv6_address. A mutation that
+// dropped the third disjunct or replaced || with && would survive the
+// other LB pin tests but fail this one.
+func TestFixupLB_PreservesSubnetMappingWhenIPv6AddressSet(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb" "main" {
+  name               = "dual-stack-nlb"
+  load_balancer_type = "network"
+  subnets            = ["subnet-aaa"]
+  subnet_mapping {
+    subnet_id    = "subnet-aaa"
+    ipv6_address = "2001:db8::1"
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*subnets\s*=`).MatchString(got) {
+		t.Errorf("subnets attribute must be dropped when subnet_mapping carries ipv6_address\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?m)^\s*subnet_mapping\s*\{`).MatchString(got) {
+		t.Errorf("subnet_mapping blocks must be preserved when ipv6_address present\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, `ipv6_address = "2001:db8::1"`) {
+		t.Errorf("ipv6_address value must be preserved\n--- got ---\n%s", got)
 	}
 }


### PR DESCRIPTION
## Summary

Three follow-up bug fixes surfaced by live CUST3 smoke during PR #335 (Bundle 4) validation. Discovery side of #318 was already satisfied by #335; this PR closes out the **clean-plan** side so `terraform validate` exits 0 against discovered output.

- **#336** — `resourceexplorer2_{index,view}` discoverers skip ARNs from non-loop regions (gates both tag-fetch and emission to avoid `BadRequestException` and addressBook duplicate emission)
- **#337** — genconfig fixup drops `aws_vpc.ipv6_netmask_length=0` orphan when `ipv6_ipam_pool_id` is absent (provider marks the pair mutually-required)
- **#338** — genconfig fixup resolves `aws_lb` `subnet_mapping` vs `subnets` mutual-exclusion conflict via static-IP-pin heuristic (drop mappings unless `allocation_id` / `private_ipv4_address` / `ipv6_address` is populated)

## Composition

Built up via two parallel sibling PRs against `fix/bundle4-followups`, then a qa-professor fixup commit:

- #340 — genconfig fixups (#337 + #338) — colocated to avoid `resourceTypeFixups` map-literal merge conflict
- #341 — RE2 cross-region (#336) — independent file ownership
- `dd775c4` — qa-professor P1+P2 follow-ups: pin `isAttrLiteralZero` carve-out spec, pin third LB pin attribute (`ipv6_address`), tighten `subnet_mapping` regex anchor

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -race -count=1` — 3805 passed across 24 packages
- [x] `gofmt -l cmd/ pkg/` clean, `go vet ./...` clean
- [x] `terraform fmt -check -recursive` clean
- [x] All 4 static lint scripts PASS (`lint-project-tag`, `lint-project-label`, `lint-sensitive-for-each`, `lint-foreach-unknown-keys`)
- [x] qa-professor APPROVED FOR MERGE on combined diff
- [x] /review pass on combined diff
- [ ] CI green
- [ ] Live CUST3 smoke re-run after merge confirms `terraform validate` exits 0 and zero `BadRequestException` warnings

Closes #336
Closes #337
Closes #338