### PR TITLE
fix(genconfig): drop aws_subnet provider-quirk attributes (#343, #344)

### DIFF
--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -55,6 +55,7 @@ var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_dynamodb_table":  fixupDynamoDBPITRRecoveryPeriodZero,
 	"aws_vpc":             fixupVPCIPv6NetmaskOrphan,
 	"aws_lb":              fixupLBSubnetMappingConflict,
+	"aws_subnet":          fixupSubnetProviderQuirks,
 }
 
 // lambdaPlaceholderFile is what we set `filename` to so the block
@@ -216,6 +217,44 @@ func fixupLBSubnetMappingConflict(blk *hclwrite.Block) {
 	}
 	for _, m := range mappings {
 		body.RemoveBlock(m)
+	}
+}
+
+// fixupSubnetProviderQuirks resolves three terraform-provider-aws schema
+// constraints that `terraform plan -generate-config-out` emits in
+// violation of:
+//
+//   - availability_zone vs availability_zone_id (mutually exclusive). The
+//     provider rejects both being specified. generate-config-out always
+//     emits both for any subnet that has an AZ assignment. Drop the ID
+//     in favor of the human-readable AZ. Issue #343.
+//   - enable_lni_at_device_index = 0 (provider rejects literal 0; the
+//     attribute's documented domain starts at 1). generate-config-out
+//     emits 0 for any subnet not configured for Local Network Interfaces.
+//     Issue #344.
+//   - map_customer_owned_ip_on_launch orphan (mutually-required trio with
+//     customer_owned_ipv4_pool and outpost_arn). generate-config-out emits
+//     `map_customer_owned_ip_on_launch = false` standalone for every
+//     non-Outpost subnet, breaking the all-of constraint. Drop the orphan
+//     when neither sibling carries a usable value. Issue #344.
+//
+// Conservative shape: each transform fires only on its specific orphan
+// pattern. A real Outpost-pinned subnet (outpost_arn set) preserves the
+// trio; a real LNI-configured subnet (index >=1) preserves the index; an
+// AZ-id-only subnet preserves the ID.
+func fixupSubnetProviderQuirks(blk *hclwrite.Block) {
+	body := blk.Body()
+	// #343 — AZ vs AZ-ID mutual exclusion.
+	if hasUsableValue(body, "availability_zone") && hasUsableValue(body, "availability_zone_id") {
+		body.RemoveAttribute("availability_zone_id")
+	}
+	// #344a — enable_lni_at_device_index = 0 (provider rejects literal 0).
+	if isAttrLiteralZero(body, "enable_lni_at_device_index") {
+		body.RemoveAttribute("enable_lni_at_device_index")
+	}
+	// #344b — map_customer_owned_ip_on_launch orphan trio.
+	if !hasUsableValue(body, "customer_owned_ipv4_pool") && !hasUsableValue(body, "outpost_arn") {
+		body.RemoveAttribute("map_customer_owned_ip_on_launch")
 	}
 }
 

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -784,12 +784,13 @@ func TestFixupSubnet_AZIdDroppedWhenAZSet(t *testing.T) {
 func TestFixupSubnet_AZAttrsPreservedWhenOnlyOneSet(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name string
-		in   string
-		want string
+		name        string
+		in          string
+		wantPresent string
+		wantAbsent  string
 	}{
-		{"only_az", `availability_zone = "us-east-1a"`, `availability_zone\s*=\s*"us-east-1a"`},
-		{"only_az_id", `availability_zone_id = "use1-az6"`, `availability_zone_id\s*=\s*"use1-az6"`},
+		{"only_az", `availability_zone = "us-east-1a"`, `availability_zone\s*=\s*"us-east-1a"`, `(?m)^\s*availability_zone_id\s*=`},
+		{"only_az_id", `availability_zone_id = "use1-az6"`, `availability_zone_id\s*=\s*"use1-az6"`, `(?m)^\s*availability_zone\s*=`},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -806,10 +807,69 @@ func TestFixupSubnet_AZAttrsPreservedWhenOnlyOneSet(t *testing.T) {
 				t.Fatal(err)
 			}
 			got := string(out)
-			if !regexp.MustCompile(tc.want).MatchString(got) {
-				t.Errorf("expected %q to match %q\n--- got ---\n%s", got, tc.want, got)
+			if !regexp.MustCompile(tc.wantPresent).MatchString(got) {
+				t.Errorf("expected %q to match\n--- got ---\n%s", tc.wantPresent, got)
+			}
+			// Negative assertion: the fixup must not inject the absent
+			// sibling. Pins against a mutation that always emits a
+			// default AZ when only one of the pair is present.
+			if regexp.MustCompile(tc.wantAbsent).MatchString(got) {
+				t.Errorf("fixup must not inject %q when only one AZ attr is present\n--- got ---\n%s", tc.wantAbsent, got)
 			}
 		})
+	}
+}
+
+// TestFixupSubnet_NullLiteralAZIDPreserved pins the null-literal branch
+// of hasUsableValue: generate-config-out emits availability_zone = null
+// for any subnet whose AZ string is null at read time. The fixup must
+// recognize null-literal as "no usable value" and preserve the ID. A
+// mutation that replaced hasUsableValue with `GetAttribute(name) != nil`
+// would survive the existing "only one set" carve-out (which tested
+// attribute absence) but fail here.
+func TestFixupSubnet_NullLiteralAZIDPreserved(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_subnet" "main" {
+  vpc_id               = "vpc-123"
+  cidr_block           = "10.0.1.0/24"
+  availability_zone    = null
+  availability_zone_id = "use1-az6"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`(?m)^\s*availability_zone_id\s*=\s*"use1-az6"`).MatchString(got) {
+		t.Errorf("availability_zone_id must be preserved when availability_zone is null\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupSubnet_NullLiteralOutpostTrioStillDropsOrphan pins the
+// null-literal branch on the trio: generate-config-out emits both
+// customer_owned_ipv4_pool = null and outpost_arn = null for any
+// non-Outpost subnet. The fixup must still drop the orphan
+// map_customer_owned_ip_on_launch. A mutation that treated null as
+// "present" would survive the existing absent-sibling test but fail
+// here.
+func TestFixupSubnet_NullLiteralOutpostTrioStillDropsOrphan(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_subnet" "main" {
+  vpc_id                          = "vpc-123"
+  cidr_block                      = "10.0.1.0/24"
+  customer_owned_ipv4_pool        = null
+  outpost_arn                     = null
+  map_customer_owned_ip_on_launch = false
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*map_customer_owned_ip_on_launch\s*=`).MatchString(got) {
+		t.Errorf("orphan map_customer_owned_ip_on_launch must be dropped when both siblings are null\n--- got ---\n%s", got)
 	}
 }
 

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -750,3 +750,223 @@ func TestFixupLB_PreservesSubnetMappingWhenIPv6AddressSet(t *testing.T) {
 		t.Errorf("ipv6_address value must be preserved\n--- got ---\n%s", got)
 	}
 }
+
+// TestFixupSubnet_AZIdDroppedWhenAZSet pins #343: when both
+// availability_zone and availability_zone_id are present (the
+// generate-config-out default), drop the ID and keep the human-readable
+// AZ.
+func TestFixupSubnet_AZIdDroppedWhenAZSet(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_subnet" "main" {
+  vpc_id               = "vpc-123"
+  cidr_block           = "10.0.1.0/24"
+  availability_zone    = "us-east-1a"
+  availability_zone_id = "use1-az6"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*availability_zone_id\s*=`).MatchString(got) {
+		t.Errorf("availability_zone_id must be dropped when availability_zone is set\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?m)^\s*availability_zone\s*=\s*"us-east-1a"`).MatchString(got) {
+		t.Errorf("availability_zone must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupSubnet_AZAttrsPreservedWhenOnlyOneSet pins the carve-out:
+// the fixup only fires when BOTH AZ attrs are present. A subnet with
+// only availability_zone (or only availability_zone_id) flows through
+// untouched.
+func TestFixupSubnet_AZAttrsPreservedWhenOnlyOneSet(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"only_az", `availability_zone = "us-east-1a"`, `availability_zone\s*=\s*"us-east-1a"`},
+		{"only_az_id", `availability_zone_id = "use1-az6"`, `availability_zone_id\s*=\s*"use1-az6"`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := []byte(`resource "aws_subnet" "main" {
+  vpc_id     = "vpc-123"
+  cidr_block = "10.0.1.0/24"
+  ` + tc.in + `
+}
+`)
+			out, err := applyResourceTypeFixups(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(out)
+			if !regexp.MustCompile(tc.want).MatchString(got) {
+				t.Errorf("expected %q to match %q\n--- got ---\n%s", got, tc.want, got)
+			}
+		})
+	}
+}
+
+// TestFixupSubnet_LniAtDeviceIndexZeroDropped pins #344a: literal 0
+// fails provider validation (`enable_lni_at_device_index must not be
+// zero, got 0`). Drop the attribute.
+func TestFixupSubnet_LniAtDeviceIndexZeroDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_subnet" "main" {
+  vpc_id                     = "vpc-123"
+  cidr_block                 = "10.0.1.0/24"
+  enable_lni_at_device_index = 0
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "enable_lni_at_device_index") {
+		t.Errorf("enable_lni_at_device_index = 0 must be dropped\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupSubnet_LniAtDeviceIndexNonZeroPreserved pins the carve-out:
+// non-zero values are valid (provider domain starts at 1) and must be
+// preserved. Table-driven over realistic values.
+func TestFixupSubnet_LniAtDeviceIndexNonZeroPreserved(t *testing.T) {
+	t.Parallel()
+	cases := []string{"1", "2", "7"}
+	for _, v := range cases {
+		v := v
+		t.Run("idx_"+v, func(t *testing.T) {
+			t.Parallel()
+			in := []byte(`resource "aws_subnet" "main" {
+  vpc_id                     = "vpc-123"
+  cidr_block                 = "10.0.1.0/24"
+  enable_lni_at_device_index = ` + v + `
+}
+`)
+			out, err := applyResourceTypeFixups(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(out)
+			if !regexp.MustCompile(`enable_lni_at_device_index\s*=\s*` + v).MatchString(got) {
+				t.Errorf("non-zero enable_lni_at_device_index=%s must be preserved\n--- got ---\n%s", v, got)
+			}
+		})
+	}
+}
+
+// TestFixupSubnet_CustomerOwnedIPOrphanDropped pins #344b: drop
+// map_customer_owned_ip_on_launch when both customer_owned_ipv4_pool
+// AND outpost_arn are absent. The trio is mutually-required by the
+// provider schema; orphan presence fails validate.
+func TestFixupSubnet_CustomerOwnedIPOrphanDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_subnet" "main" {
+  vpc_id                          = "vpc-123"
+  cidr_block                      = "10.0.1.0/24"
+  map_customer_owned_ip_on_launch = false
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "map_customer_owned_ip_on_launch") {
+		t.Errorf("orphan map_customer_owned_ip_on_launch must be dropped\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupSubnet_CustomerOwnedIPPreservedWhenOutpostSet pins the
+// carve-out: a real Outpost subnet carrying outpost_arn (or
+// customer_owned_ipv4_pool) preserves the full trio. Table-driven over
+// each sibling.
+func TestFixupSubnet_CustomerOwnedIPPreservedWhenOutpostSet(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"outpost_arn", `outpost_arn = "arn:aws:outposts:us-east-1:123:outpost/op-abc"`},
+		{"customer_owned_ipv4_pool", `customer_owned_ipv4_pool = "ipv4pool-coip-0123456789abcdef0"`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := []byte(`resource "aws_subnet" "main" {
+  vpc_id                          = "vpc-123"
+  cidr_block                      = "10.0.1.0/24"
+  map_customer_owned_ip_on_launch = true
+  ` + tc.in + `
+}
+`)
+			out, err := applyResourceTypeFixups(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(out)
+			if !strings.Contains(got, "map_customer_owned_ip_on_launch") {
+				t.Errorf("map_customer_owned_ip_on_launch must be preserved when %s is set\n--- got ---\n%s", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestFixupSubnet_OnlyAffectsAWSSubnetBlocks pins resource-type
+// isolation: a sibling aws_vpc block carrying its own (unrelated)
+// availability_zone_id and map_customer_owned_ip_on_launch flows
+// through untouched. The fixup table is keyed by aws_subnet, so a
+// mutation broadening it to "any resource with these attrs" would
+// corrupt the VPC block.
+func TestFixupSubnet_OnlyAffectsAWSSubnetBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_subnet" "sub" {
+  vpc_id                          = "vpc-123"
+  cidr_block                      = "10.0.1.0/24"
+  availability_zone               = "us-east-1a"
+  availability_zone_id            = "use1-az6"
+  enable_lni_at_device_index      = 0
+  map_customer_owned_ip_on_launch = false
+}
+
+resource "aws_vpc" "vpc" {
+  cidr_block                      = "10.0.0.0/16"
+  availability_zone_id            = "use1-az6"
+  enable_lni_at_device_index      = 0
+  map_customer_owned_ip_on_launch = false
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// VPC block must keep its (unrelated, non-schema) attributes.
+	if !regexp.MustCompile(`(?s)resource "aws_vpc" "vpc"[^}]*availability_zone_id\s*=\s*"use1-az6"`).MatchString(got) {
+		t.Errorf("aws_vpc.availability_zone_id must be preserved (fixup keyed by aws_subnet only)\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?s)resource "aws_vpc" "vpc"[^}]*enable_lni_at_device_index\s*=\s*0`).MatchString(got) {
+		t.Errorf("aws_vpc.enable_lni_at_device_index must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?s)resource "aws_vpc" "vpc"[^}]*map_customer_owned_ip_on_launch\s*=\s*false`).MatchString(got) {
+		t.Errorf("aws_vpc.map_customer_owned_ip_on_launch must be preserved\n--- got ---\n%s", got)
+	}
+	// Subnet block must have all three transforms applied.
+	if regexp.MustCompile(`(?s)resource "aws_subnet" "sub"[^}]*availability_zone_id\s*=`).MatchString(got) {
+		t.Errorf("aws_subnet.availability_zone_id must be dropped\n--- got ---\n%s", got)
+	}
+	if regexp.MustCompile(`(?s)resource "aws_subnet" "sub"[^}]*enable_lni_at_device_index\s*=`).MatchString(got) {
+		t.Errorf("aws_subnet.enable_lni_at_device_index = 0 must be dropped\n--- got ---\n%s", got)
+	}
+	if regexp.MustCompile(`(?s)resource "aws_subnet" "sub"[^}]*map_customer_owned_ip_on_launch\s*=`).MatchString(got) {
+		t.Errorf("aws_subnet.map_customer_owned_ip_on_launch must be dropped\n--- got ---\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

\`terraform plan -generate-config-out\` emits three terraform-provider-aws schema-violating attributes for every \`aws_subnet\`. All three fail \`terraform validate\` against the common non-Outpost case:

- **#343** — \`availability_zone\` vs \`availability_zone_id\` (mutually exclusive). Drop the ID; prefer the human-readable AZ.
- **#344a** — \`enable_lni_at_device_index = 0\` (provider rejects literal 0; domain starts at 1). Drop the literal-zero attribute.
- **#344b** — \`map_customer_owned_ip_on_launch\` orphan (mutually-required trio with \`customer_owned_ipv4_pool\`, \`outpost_arn\`). Drop the orphan when neither sibling carries a usable value.

Conservative shape — each transform fires only on its specific orphan pattern. Outpost-pinned subnets, LNI-configured subnets, and AZ-id-only subnets all flow through untouched.

Surfaced via live CUST3 smoke after PR #342 merged. Same family as #337/#338 — pre-existing genconfig bugs newly visible because Bundle 4 added the \`aws_subnet\` discoverer.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/insideout-import/genconfig/... -race -count=1\` — 104 passed (+14 new tests)
- [x] \`gofmt\` clean, \`go vet\` clean
- [ ] CI green
- [ ] Live smoke after merge confirms aws_subnet validate-clean (verified via the stacked PR for #345)

## Stacked PR follow-up

PR 2 (\`fix/genconfig-route-table-empty-cidr\` for #345) follows this one and addresses the remaining 2 validate errors from the post-#342 smoke output. After both land, smoke should reach \`terraform validate\` exit 0.

Closes #343
Closes #344