### PR TITLE
fix(genconfig): drop empty-string fields from aws_route_table.route (#345)

### DIFF
--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -56,6 +57,7 @@ var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_vpc":             fixupVPCIPv6NetmaskOrphan,
 	"aws_lb":              fixupLBSubnetMappingConflict,
 	"aws_subnet":          fixupSubnetProviderQuirks,
+	"aws_route_table":     fixupRouteTableEmptyRouteFields,
 }
 
 // lambdaPlaceholderFile is what we set `filename` to so the block
@@ -256,6 +258,106 @@ func fixupSubnetProviderQuirks(blk *hclwrite.Block) {
 	if !hasUsableValue(body, "customer_owned_ipv4_pool") && !hasUsableValue(body, "outpost_arn") {
 		body.RemoveAttribute("map_customer_owned_ip_on_launch")
 	}
+}
+
+// fixupRouteTableEmptyRouteFields drops empty-string fields from each
+// route object literal emitted in aws_route_table.route. The provider
+// validates fields like ipv6_cidr_block as a CIDR when present (even
+// as ""), and rejects the empty literal with `"" is not a valid CIDR
+// block`. terraform plan -generate-config-out emits "" for every
+// absent string field in the route object; broad-strip is safer than
+// targeted because future provider validation tightening on other
+// fields surfaces the same way.
+//
+// Shape note: generate-config-out emits route as an attribute carrying
+// a list-of-objects expression (route = [{...}, ...]), NOT as nested
+// route { ... } blocks. Mutation goes through cty round-trip rather
+// than block iteration: parse the attribute's expression bytes,
+// evaluate to a static cty value, filter empty-string fields per
+// object, re-emit via SetAttributeValue. Issue #345.
+func fixupRouteTableEmptyRouteFields(blk *hclwrite.Block) {
+	body := blk.Body()
+	attr := body.GetAttribute("route")
+	if attr == nil {
+		return
+	}
+	exprBytes := attr.Expr().BuildTokens(nil).Bytes()
+	expr, diags := hclsyntax.ParseExpression(exprBytes, "route", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return
+	}
+	val, diags := expr.Value(nil)
+	if diags.HasErrors() {
+		return
+	}
+	filtered, changed := dropEmptyStringFieldsFromTuple(val)
+	if !changed {
+		return
+	}
+	body.SetAttributeValue("route", filtered)
+}
+
+// dropEmptyStringFieldsFromTuple walks a tuple/list of object values and
+// returns a new tuple with each object's empty-string fields removed.
+// The boolean reports whether any field was dropped, so callers can
+// short-circuit a no-op back to the original tokens (avoids reformatting
+// unchanged HCL). Non-tuple/non-list inputs and unknown/null values pass
+// through unchanged.
+func dropEmptyStringFieldsFromTuple(v cty.Value) (cty.Value, bool) {
+	if v.IsNull() || !v.IsKnown() {
+		return v, false
+	}
+	t := v.Type()
+	if !t.IsTupleType() && !t.IsListType() {
+		return v, false
+	}
+	if v.LengthInt() == 0 {
+		return v, false
+	}
+	out := make([]cty.Value, 0, v.LengthInt())
+	changed := false
+	it := v.ElementIterator()
+	for it.Next() {
+		_, elem := it.Element()
+		cleaned, c := dropEmptyStringFieldsFromObject(elem)
+		if c {
+			changed = true
+		}
+		out = append(out, cleaned)
+	}
+	if !changed {
+		return v, false
+	}
+	return cty.TupleVal(out), true
+}
+
+// dropEmptyStringFieldsFromObject returns a new object value with
+// empty-string string fields removed. Non-object inputs pass through
+// unchanged. If every field is dropped the result is an empty object
+// (cty.EmptyObjectVal); the caller decides whether to keep that.
+func dropEmptyStringFieldsFromObject(v cty.Value) (cty.Value, bool) {
+	if v.IsNull() || !v.IsKnown() {
+		return v, false
+	}
+	if !v.Type().IsObjectType() {
+		return v, false
+	}
+	fields := map[string]cty.Value{}
+	changed := false
+	for k, fv := range v.AsValueMap() {
+		if fv.Type() == cty.String && !fv.IsNull() && fv.IsKnown() && fv.AsString() == "" {
+			changed = true
+			continue
+		}
+		fields[k] = fv
+	}
+	if !changed {
+		return v, false
+	}
+	if len(fields) == 0 {
+		return cty.EmptyObjectVal, true
+	}
+	return cty.ObjectVal(fields), true
 }
 
 // isAttrLiteralZero reports whether the named attribute exists and its

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -286,6 +286,10 @@ func fixupRouteTableEmptyRouteFields(blk *hclwrite.Block) {
 	if diags.HasErrors() {
 		return
 	}
+	// expr.Value(nil) fails on any variable / function reference. That's
+	// the intended bail-out — generate-config-out emits literals only,
+	// and we'd rather no-op than silently drop a reference. Future
+	// templating that mixes refs into route would need an EvalContext.
 	val, diags := expr.Value(nil)
 	if diags.HasErrors() {
 		return
@@ -293,6 +297,17 @@ func fixupRouteTableEmptyRouteFields(blk *hclwrite.Block) {
 	filtered, changed := dropEmptyStringFieldsFromTuple(val)
 	if !changed {
 		return
+	}
+	// Defensive: if any element became an empty object (every field was
+	// "" — degenerate but not impossible), bail rather than emit
+	// `route = [{}]`, which would convert the existing CIDR-validation
+	// error into a different missing-required-arg failure.
+	it := filtered.ElementIterator()
+	for it.Next() {
+		_, elem := it.Element()
+		if elem.Type().IsObjectType() && len(elem.AsValueMap()) == 0 {
+			return
+		}
 	}
 	body.SetAttributeValue("route", filtered)
 }

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -260,21 +260,23 @@ func fixupSubnetProviderQuirks(blk *hclwrite.Block) {
 	}
 }
 
-// fixupRouteTableEmptyRouteFields drops empty-string fields from each
-// route object literal emitted in aws_route_table.route. The provider
-// validates fields like ipv6_cidr_block as a CIDR when present (even
-// as ""), and rejects the empty literal with `"" is not a valid CIDR
-// block`. terraform plan -generate-config-out emits "" for every
-// absent string field in the route object; broad-strip is safer than
-// targeted because future provider validation tightening on other
-// fields surfaces the same way.
+// fixupRouteTableEmptyRouteFields replaces empty-string fields with
+// null in each route object literal emitted in aws_route_table.route.
+// The provider's per-field validators (CIDR check on ipv6_cidr_block,
+// resource-id format on gateway_id, etc.) reject literal "" but skip
+// null. terraform plan -generate-config-out emits "" for every absent
+// field in the route object; null-replacement satisfies the validators
+// while preserving the object type's field set (the route attribute is
+// schema-typed as an object with all 12 fields required to be present
+// — DROPPING fields breaks the object type and produces a different
+// "Incorrect attribute value type" failure).
 //
 // Shape note: generate-config-out emits route as an attribute carrying
 // a list-of-objects expression (route = [{...}, ...]), NOT as nested
 // route { ... } blocks. Mutation goes through cty round-trip rather
 // than block iteration: parse the attribute's expression bytes,
-// evaluate to a static cty value, filter empty-string fields per
-// object, re-emit via SetAttributeValue. Issue #345.
+// evaluate to a static cty value, replace "" string fields with
+// null per object, re-emit via SetAttributeValue. Issue #345.
 func fixupRouteTableEmptyRouteFields(blk *hclwrite.Block) {
 	body := blk.Body()
 	attr := body.GetAttribute("route")
@@ -294,31 +296,20 @@ func fixupRouteTableEmptyRouteFields(blk *hclwrite.Block) {
 	if diags.HasErrors() {
 		return
 	}
-	filtered, changed := dropEmptyStringFieldsFromTuple(val)
+	filtered, changed := nullEmptyStringFieldsInTuple(val)
 	if !changed {
 		return
-	}
-	// Defensive: if any element became an empty object (every field was
-	// "" — degenerate but not impossible), bail rather than emit
-	// `route = [{}]`, which would convert the existing CIDR-validation
-	// error into a different missing-required-arg failure.
-	it := filtered.ElementIterator()
-	for it.Next() {
-		_, elem := it.Element()
-		if elem.Type().IsObjectType() && len(elem.AsValueMap()) == 0 {
-			return
-		}
 	}
 	body.SetAttributeValue("route", filtered)
 }
 
-// dropEmptyStringFieldsFromTuple walks a tuple/list of object values and
-// returns a new tuple with each object's empty-string fields removed.
-// The boolean reports whether any field was dropped, so callers can
-// short-circuit a no-op back to the original tokens (avoids reformatting
-// unchanged HCL). Non-tuple/non-list inputs and unknown/null values pass
-// through unchanged.
-func dropEmptyStringFieldsFromTuple(v cty.Value) (cty.Value, bool) {
+// nullEmptyStringFieldsInTuple walks a tuple/list of object values and
+// returns a new tuple with each object's empty-string fields replaced
+// by null (preserving field set, just blanking the value). The boolean
+// reports whether any field was rewritten, so callers can short-circuit
+// a no-op back to the original tokens. Non-tuple/non-list inputs and
+// unknown/null values pass through unchanged.
+func nullEmptyStringFieldsInTuple(v cty.Value) (cty.Value, bool) {
 	if v.IsNull() || !v.IsKnown() {
 		return v, false
 	}
@@ -334,7 +325,7 @@ func dropEmptyStringFieldsFromTuple(v cty.Value) (cty.Value, bool) {
 	it := v.ElementIterator()
 	for it.Next() {
 		_, elem := it.Element()
-		cleaned, c := dropEmptyStringFieldsFromObject(elem)
+		cleaned, c := nullEmptyStringFieldsInObject(elem)
 		if c {
 			changed = true
 		}
@@ -346,11 +337,14 @@ func dropEmptyStringFieldsFromTuple(v cty.Value) (cty.Value, bool) {
 	return cty.TupleVal(out), true
 }
 
-// dropEmptyStringFieldsFromObject returns a new object value with
-// empty-string string fields removed. Non-object inputs pass through
-// unchanged. If every field is dropped the result is an empty object
-// (cty.EmptyObjectVal); the caller decides whether to keep that.
-func dropEmptyStringFieldsFromObject(v cty.Value) (cty.Value, bool) {
+// nullEmptyStringFieldsInObject returns a new object value with
+// empty-string string fields replaced by null. Non-object inputs pass
+// through unchanged. The field set is preserved (object type unchanged)
+// — this is the difference between "satisfies the schema's type
+// requirement that all 12 route fields be present" and "fails with
+// Incorrect attribute value type because we dropped fields the type
+// declared."
+func nullEmptyStringFieldsInObject(v cty.Value) (cty.Value, bool) {
 	if v.IsNull() || !v.IsKnown() {
 		return v, false
 	}
@@ -361,6 +355,7 @@ func dropEmptyStringFieldsFromObject(v cty.Value) (cty.Value, bool) {
 	changed := false
 	for k, fv := range v.AsValueMap() {
 		if fv.Type() == cty.String && !fv.IsNull() && fv.IsKnown() && fv.AsString() == "" {
+			fields[k] = cty.NullVal(cty.String)
 			changed = true
 			continue
 		}
@@ -368,9 +363,6 @@ func dropEmptyStringFieldsFromObject(v cty.Value) (cty.Value, bool) {
 	}
 	if !changed {
 		return v, false
-	}
-	if len(fields) == 0 {
-		return cty.EmptyObjectVal, true
 	}
 	return cty.ObjectVal(fields), true
 }

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -1030,3 +1030,191 @@ resource "aws_vpc" "vpc" {
 		t.Errorf("aws_subnet.map_customer_owned_ip_on_launch must be dropped\n--- got ---\n%s", got)
 	}
 }
+
+// TestFixupRouteTable_EmptyIPv6CIDRDropped pins #345: the actual bug
+// shape from live CUST3 smoke. ipv6_cidr_block = "" inside a route
+// object literal fails provider validation with `"" is not a valid
+// CIDR block`. The fixup must drop the empty-string field.
+func TestFixupRouteTable_EmptyIPv6CIDRDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_route_table" "rt" {
+  vpc_id = "vpc-123"
+  route = [{
+    cidr_block      = "0.0.0.0/0"
+    gateway_id      = "igw-abc"
+    ipv6_cidr_block = ""
+  }]
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "ipv6_cidr_block") {
+		t.Errorf("empty ipv6_cidr_block must be dropped\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, `cidr_block      = "0.0.0.0/0"`) && !regexp.MustCompile(`cidr_block\s*=\s*"0.0.0.0/0"`).MatchString(got) {
+		t.Errorf("non-empty cidr_block must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupRouteTable_AllEmptyStringFieldsDropped pins broad-strip
+// semantics: every field whose value is the literal "" must be removed
+// from each route object. The fixture mirrors the CUST3 smoke output
+// shape (12 absent fields emitted as ""). After fixup, only the
+// non-empty fields remain.
+func TestFixupRouteTable_AllEmptyStringFieldsDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_route_table" "rt" {
+  vpc_id = "vpc-123"
+  route = [{
+    carrier_gateway_id         = ""
+    cidr_block                 = "0.0.0.0/0"
+    core_network_arn           = ""
+    destination_prefix_list_id = ""
+    egress_only_gateway_id     = ""
+    gateway_id                 = ""
+    ipv6_cidr_block            = ""
+    local_gateway_id           = ""
+    nat_gateway_id             = "nat-0bf36e3c90fe23bf5"
+    network_interface_id       = ""
+    transit_gateway_id         = ""
+    vpc_endpoint_id            = ""
+    vpc_peering_connection_id  = ""
+  }]
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	emptyFields := []string{
+		"carrier_gateway_id",
+		"core_network_arn",
+		"destination_prefix_list_id",
+		"egress_only_gateway_id",
+		"gateway_id",
+		"ipv6_cidr_block",
+		"local_gateway_id",
+		"network_interface_id",
+		"transit_gateway_id",
+		"vpc_endpoint_id",
+		"vpc_peering_connection_id",
+	}
+	for _, f := range emptyFields {
+		// Anchor on `<field> =` (with leading whitespace) to avoid false
+		// positives — e.g. "gateway_id" is a substring of "nat_gateway_id".
+		if regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(f) + `\s*=`).MatchString(got) {
+			t.Errorf("empty %s field must be dropped\n--- got ---\n%s", f, got)
+		}
+	}
+	// Non-empty fields must survive.
+	if !regexp.MustCompile(`cidr_block\s*=\s*"0.0.0.0/0"`).MatchString(got) {
+		t.Errorf("cidr_block=\"0.0.0.0/0\" must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`nat_gateway_id\s*=\s*"nat-0bf36e3c90fe23bf5"`).MatchString(got) {
+		t.Errorf("nat_gateway_id must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupRouteTable_NonEmptyFieldsPreserved pins isolation: a route
+// object with no empty-string fields flows through untouched. A
+// mutation that broadened the filter to non-empty values would fail
+// this test.
+func TestFixupRouteTable_NonEmptyFieldsPreserved(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_route_table" "rt" {
+  vpc_id = "vpc-123"
+  route = [{
+    cidr_block     = "10.0.0.0/8"
+    gateway_id     = "igw-abc"
+    nat_gateway_id = "nat-xyz"
+  }]
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	for _, want := range []string{"cidr_block", "gateway_id", "nat_gateway_id"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("non-empty %s must be preserved\n--- got ---\n%s", want, got)
+		}
+	}
+}
+
+// TestFixupRouteTable_NoRouteAttrUntouched pins the no-op branch: a
+// route_table without a route attribute (or with `route = []`) is a
+// pure pass-through. A mutation that emitted a stub would fail.
+func TestFixupRouteTable_NoRouteAttrUntouched(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"no_route_attr", `vpc_id = "vpc-123"`},
+		{"empty_route_list", `vpc_id = "vpc-123"
+  route  = []`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := []byte(`resource "aws_route_table" "rt" {
+  ` + tc.body + `
+}
+`)
+			out, err := applyResourceTypeFixups(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(out) != string(in) {
+				t.Errorf("no-op case must yield identical output\n--- in ---\n%s\n--- out ---\n%s", in, out)
+			}
+		})
+	}
+}
+
+// TestFixupRouteTable_OnlyAffectsAWSRouteTableBlocks pins resource-type
+// isolation: a sibling aws_subnet block carrying its own route attribute
+// (hypothetical — not a real schema field) must NOT be touched. The
+// fixup table is keyed by aws_route_table only.
+func TestFixupRouteTable_OnlyAffectsAWSRouteTableBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_route_table" "rt" {
+  vpc_id = "vpc-123"
+  route = [{
+    cidr_block      = "0.0.0.0/0"
+    ipv6_cidr_block = ""
+  }]
+}
+
+resource "aws_route" "extra" {
+  route_table_id      = "rtb-123"
+  destination_cidr_block = "10.0.0.0/16"
+  ipv6_cidr_block     = ""
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// Count occurrences. Pre-fixup the input has 2 ipv6_cidr_block = ""
+	// (one in the route_table's nested route, one at the aws_route top
+	// level). The fixup should drop the route_table's, leaving exactly 1
+	// in the aws_route block. Use a whitespace-tolerant regex because the
+	// route_table block's cty-rendered formatting differs from the
+	// hclwrite-untouched aws_route block's alignment.
+	matches := regexp.MustCompile(`(?m)^\s*ipv6_cidr_block\s*=\s*""`).FindAllString(got, -1)
+	if len(matches) != 1 {
+		t.Errorf("expected exactly 1 ipv6_cidr_block=\"\" remaining (the aws_route's), got %d\n--- got ---\n%s", len(matches), got)
+	}
+	// The aws_route block must keep its top-level ipv6_cidr_block="".
+	if !regexp.MustCompile(`(?s)resource "aws_route" "extra"[^}]*ipv6_cidr_block\s*=\s*""`).MatchString(got) {
+		t.Errorf("aws_route.ipv6_cidr_block=\"\" must be preserved (fixup keyed by aws_route_table only)\n--- got ---\n%s", got)
+	}
+}

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -1031,11 +1031,15 @@ resource "aws_vpc" "vpc" {
 	}
 }
 
-// TestFixupRouteTable_EmptyIPv6CIDRDropped pins #345: the actual bug
-// shape from live CUST3 smoke. ipv6_cidr_block = "" inside a route
-// object literal fails provider validation with `"" is not a valid
-// CIDR block`. The fixup must drop the empty-string field.
-func TestFixupRouteTable_EmptyIPv6CIDRDropped(t *testing.T) {
+// TestFixupRouteTable_EmptyIPv6CIDRReplacedWithNull pins #345: the
+// actual bug shape from live CUST3 smoke. ipv6_cidr_block = "" inside
+// a route object literal fails provider validation with `"" is not a
+// valid CIDR block`. The fixup must rewrite "" to null so the per-field
+// CIDR validator skips it. (Earlier drop-the-field approach failed
+// because route is schema-typed as an object with all 12 fields
+// required-present — dropping fields produced a different "Incorrect
+// attribute value type" failure.)
+func TestFixupRouteTable_EmptyIPv6CIDRReplacedWithNull(t *testing.T) {
 	t.Parallel()
 	in := []byte(`resource "aws_route_table" "rt" {
   vpc_id = "vpc-123"
@@ -1051,20 +1055,26 @@ func TestFixupRouteTable_EmptyIPv6CIDRDropped(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := string(out)
-	if strings.Contains(got, "ipv6_cidr_block") {
-		t.Errorf("empty ipv6_cidr_block must be dropped\n--- got ---\n%s", got)
+	// ipv6_cidr_block must remain in the output (preserves object type)
+	// but now as null instead of "".
+	if !regexp.MustCompile(`(?m)^\s*ipv6_cidr_block\s*=\s*null`).MatchString(got) {
+		t.Errorf("empty ipv6_cidr_block must be rewritten to null (preserve field for object type)\n--- got ---\n%s", got)
 	}
-	if !strings.Contains(got, `cidr_block      = "0.0.0.0/0"`) && !regexp.MustCompile(`cidr_block\s*=\s*"0.0.0.0/0"`).MatchString(got) {
+	if regexp.MustCompile(`(?m)^\s*ipv6_cidr_block\s*=\s*""`).MatchString(got) {
+		t.Errorf("ipv6_cidr_block=\"\" must not survive (validator rejects empty literal)\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`cidr_block\s*=\s*"0.0.0.0/0"`).MatchString(got) {
 		t.Errorf("non-empty cidr_block must be preserved\n--- got ---\n%s", got)
 	}
 }
 
-// TestFixupRouteTable_AllEmptyStringFieldsDropped pins broad-strip
-// semantics: every field whose value is the literal "" must be removed
-// from each route object. The fixture mirrors the CUST3 smoke output
-// shape (12 absent fields emitted as ""). After fixup, only the
-// non-empty fields remain.
-func TestFixupRouteTable_AllEmptyStringFieldsDropped(t *testing.T) {
+// TestFixupRouteTable_AllEmptyStringFieldsNulled pins broad-strip
+// semantics with the null-replacement contract: every field whose
+// value is the literal "" gets rewritten to null. The fixture mirrors
+// the CUST3 smoke output shape (12 absent fields emitted as ""). After
+// fixup, all field names survive (object type preserved) but empty
+// values become null.
+func TestFixupRouteTable_AllEmptyStringFieldsNulled(t *testing.T) {
 	t.Parallel()
 	in := []byte(`resource "aws_route_table" "rt" {
   vpc_id = "vpc-123"
@@ -1104,13 +1114,19 @@ func TestFixupRouteTable_AllEmptyStringFieldsDropped(t *testing.T) {
 		"vpc_peering_connection_id",
 	}
 	for _, f := range emptyFields {
-		// Anchor on `<field> =` (with leading whitespace) to avoid false
-		// positives — e.g. "gateway_id" is a substring of "nat_gateway_id".
-		if regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(f) + `\s*=`).MatchString(got) {
-			t.Errorf("empty %s field must be dropped\n--- got ---\n%s", f, got)
+		// Each previously-empty field must now be `<f> = null`. Anchor
+		// on `<f> =` to avoid false positives (e.g. "gateway_id" is a
+		// substring of "nat_gateway_id" — anchored regex skips that).
+		nullPat := `(?m)^\s*` + regexp.QuoteMeta(f) + `\s*=\s*null`
+		if !regexp.MustCompile(nullPat).MatchString(got) {
+			t.Errorf("empty %s must be rewritten to null\n--- got ---\n%s", f, got)
+		}
+		emptyPat := `(?m)^\s*` + regexp.QuoteMeta(f) + `\s*=\s*""`
+		if regexp.MustCompile(emptyPat).MatchString(got) {
+			t.Errorf("empty literal %s=\"\" must not survive\n--- got ---\n%s", f, got)
 		}
 	}
-	// Non-empty fields must survive.
+	// Non-empty fields must survive untouched.
 	if !regexp.MustCompile(`cidr_block\s*=\s*"0.0.0.0/0"`).MatchString(got) {
 		t.Errorf("cidr_block=\"0.0.0.0/0\" must be preserved\n--- got ---\n%s", got)
 	}
@@ -1143,6 +1159,10 @@ func TestFixupRouteTable_NonEmptyFieldsPreserved(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("non-empty %s must be preserved\n--- got ---\n%s", want, got)
 		}
+	}
+	// Negative: no field should have been rewritten to null.
+	if regexp.MustCompile(`(?m)^\s*\w+\s*=\s*null`).MatchString(got) {
+		t.Errorf("no field should be rewritten to null when none were empty\n--- got ---\n%s", got)
 	}
 }
 
@@ -1179,9 +1199,9 @@ func TestFixupRouteTable_NoRouteAttrUntouched(t *testing.T) {
 }
 
 // TestFixupRouteTable_OnlyAffectsAWSRouteTableBlocks pins resource-type
-// isolation: a sibling aws_subnet block carrying its own route attribute
-// (hypothetical — not a real schema field) must NOT be touched. The
-// fixup table is keyed by aws_route_table only.
+// isolation: a sibling aws_route block carrying its own ipv6_cidr_block
+// = "" must NOT be touched. The fixup table is keyed by aws_route_table
+// only.
 func TestFixupRouteTable_OnlyAffectsAWSRouteTableBlocks(t *testing.T) {
 	t.Parallel()
 	in := []byte(`resource "aws_route_table" "rt" {
@@ -1203,55 +1223,29 @@ resource "aws_route" "extra" {
 		t.Fatal(err)
 	}
 	got := string(out)
-	// Count occurrences. Pre-fixup the input has 2 ipv6_cidr_block = ""
-	// (one in the route_table's nested route, one at the aws_route top
-	// level). The fixup should drop the route_table's, leaving exactly 1
-	// in the aws_route block. Use a whitespace-tolerant regex because the
-	// route_table block's cty-rendered formatting differs from the
-	// hclwrite-untouched aws_route block's alignment.
-	matches := regexp.MustCompile(`(?m)^\s*ipv6_cidr_block\s*=\s*""`).FindAllString(got, -1)
-	if len(matches) != 1 {
-		t.Errorf("expected exactly 1 ipv6_cidr_block=\"\" remaining (the aws_route's), got %d\n--- got ---\n%s", len(matches), got)
+	// The route_table's nested ipv6_cidr_block is rewritten to null;
+	// the aws_route block's top-level ipv6_cidr_block keeps its "".
+	// So we expect exactly 1 ipv6_cidr_block="" remaining.
+	emptyMatches := regexp.MustCompile(`(?m)^\s*ipv6_cidr_block\s*=\s*""`).FindAllString(got, -1)
+	if len(emptyMatches) != 1 {
+		t.Errorf("expected exactly 1 ipv6_cidr_block=\"\" remaining (the aws_route's), got %d\n--- got ---\n%s", len(emptyMatches), got)
 	}
-	// The aws_route block must keep its top-level ipv6_cidr_block="".
+	// And exactly 1 ipv6_cidr_block=null (the route_table's nested rewrite).
+	nullMatches := regexp.MustCompile(`(?m)^\s*ipv6_cidr_block\s*=\s*null`).FindAllString(got, -1)
+	if len(nullMatches) != 1 {
+		t.Errorf("expected exactly 1 ipv6_cidr_block=null (the route_table's nested rewrite), got %d\n--- got ---\n%s", len(nullMatches), got)
+	}
 	if !regexp.MustCompile(`(?s)resource "aws_route" "extra"[^}]*ipv6_cidr_block\s*=\s*""`).MatchString(got) {
 		t.Errorf("aws_route.ipv6_cidr_block=\"\" must be preserved (fixup keyed by aws_route_table only)\n--- got ---\n%s", got)
 	}
 }
 
-// TestFixupRouteTable_FullyEmptiedObjectBailsOut pins the defensive
-// guard against degenerate input. If a route object contains only
-// empty-string fields (no destination, no target — a shape
-// generate-config-out shouldn't produce but we don't gate on its
-// behavior), the cty round-trip would yield {} which renders as
-// `route = [{}]` and converts the original CIDR-validation error into
-// a different missing-required-arg failure. The fixup must bail out
-// (leave original tokens) rather than mutate to a worse state.
-func TestFixupRouteTable_FullyEmptiedObjectBailsOut(t *testing.T) {
-	t.Parallel()
-	in := []byte(`resource "aws_route_table" "rt" {
-  vpc_id = "vpc-123"
-  route = [{
-    cidr_block      = ""
-    ipv6_cidr_block = ""
-  }]
-}
-`)
-	out, err := applyResourceTypeFixups(in)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(out) != string(in) {
-		t.Errorf("fully-emptied route object must trigger bail-out (leave tokens untouched)\n--- in ---\n%s\n--- out ---\n%s", in, out)
-	}
-}
-
-// TestFixupRouteTable_MultipleRouteObjectsAllStripped pins the
+// TestFixupRouteTable_MultipleRouteObjectsAllNulled pins the
 // multi-element-tuple branch. A route_table can carry any number of
 // route entries; the fixup must clean each one independently. A
 // mutation that returned only the first cleaned element would survive
 // the single-route fixtures but fail this one.
-func TestFixupRouteTable_MultipleRouteObjectsAllStripped(t *testing.T) {
+func TestFixupRouteTable_MultipleRouteObjectsAllNulled(t *testing.T) {
 	t.Parallel()
 	in := []byte(`resource "aws_route_table" "rt" {
   vpc_id = "vpc-123"
@@ -1271,8 +1265,14 @@ func TestFixupRouteTable_MultipleRouteObjectsAllStripped(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := string(out)
-	if strings.Contains(got, "ipv6_cidr_block") {
-		t.Errorf("ipv6_cidr_block must be dropped from BOTH route objects\n--- got ---\n%s", got)
+	// Both routes' empty ipv6_cidr_block must be rewritten to null.
+	nullMatches := regexp.MustCompile(`(?m)^\s*ipv6_cidr_block\s*=\s*null`).FindAllString(got, -1)
+	if len(nullMatches) != 2 {
+		t.Errorf("expected 2 ipv6_cidr_block=null (one per route), got %d\n--- got ---\n%s", len(nullMatches), got)
+	}
+	// No empty literal should survive.
+	if regexp.MustCompile(`(?m)^\s*ipv6_cidr_block\s*=\s*""`).MatchString(got) {
+		t.Errorf("no ipv6_cidr_block=\"\" should survive\n--- got ---\n%s", got)
 	}
 	// Both routes' destination + target survive.
 	if !regexp.MustCompile(`cidr_block\s*=\s*"0.0.0.0/0"`).MatchString(got) {

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -1218,3 +1218,73 @@ resource "aws_route" "extra" {
 		t.Errorf("aws_route.ipv6_cidr_block=\"\" must be preserved (fixup keyed by aws_route_table only)\n--- got ---\n%s", got)
 	}
 }
+
+// TestFixupRouteTable_FullyEmptiedObjectBailsOut pins the defensive
+// guard against degenerate input. If a route object contains only
+// empty-string fields (no destination, no target — a shape
+// generate-config-out shouldn't produce but we don't gate on its
+// behavior), the cty round-trip would yield {} which renders as
+// `route = [{}]` and converts the original CIDR-validation error into
+// a different missing-required-arg failure. The fixup must bail out
+// (leave original tokens) rather than mutate to a worse state.
+func TestFixupRouteTable_FullyEmptiedObjectBailsOut(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_route_table" "rt" {
+  vpc_id = "vpc-123"
+  route = [{
+    cidr_block      = ""
+    ipv6_cidr_block = ""
+  }]
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(in) {
+		t.Errorf("fully-emptied route object must trigger bail-out (leave tokens untouched)\n--- in ---\n%s\n--- out ---\n%s", in, out)
+	}
+}
+
+// TestFixupRouteTable_MultipleRouteObjectsAllStripped pins the
+// multi-element-tuple branch. A route_table can carry any number of
+// route entries; the fixup must clean each one independently. A
+// mutation that returned only the first cleaned element would survive
+// the single-route fixtures but fail this one.
+func TestFixupRouteTable_MultipleRouteObjectsAllStripped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_route_table" "rt" {
+  vpc_id = "vpc-123"
+  route = [{
+    cidr_block      = "0.0.0.0/0"
+    gateway_id      = "igw-abc"
+    ipv6_cidr_block = ""
+  }, {
+    cidr_block      = "10.0.0.0/8"
+    nat_gateway_id  = "nat-xyz"
+    ipv6_cidr_block = ""
+  }]
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "ipv6_cidr_block") {
+		t.Errorf("ipv6_cidr_block must be dropped from BOTH route objects\n--- got ---\n%s", got)
+	}
+	// Both routes' destination + target survive.
+	if !regexp.MustCompile(`cidr_block\s*=\s*"0.0.0.0/0"`).MatchString(got) {
+		t.Errorf("first route's cidr_block must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`gateway_id\s*=\s*"igw-abc"`).MatchString(got) {
+		t.Errorf("first route's gateway_id must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`cidr_block\s*=\s*"10.0.0.0/8"`).MatchString(got) {
+		t.Errorf("second route's cidr_block must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`nat_gateway_id\s*=\s*"nat-xyz"`).MatchString(got) {
+		t.Errorf("second route's nat_gateway_id must be preserved\n--- got ---\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

\`terraform plan -generate-config-out\` emits \`aws_route_table.route\` as a list-of-objects expression where every absent string field gets \`""\` rather than being omitted. The provider validates fields like \`ipv6_cidr_block\` as a CIDR when present, and rejects \`""\` with \`"" is not a valid CIDR block\`.

Use cty round-trip: parse the route attribute's expression bytes via \`hclsyntax\`, evaluate to a static cty value (no variable refs in the expression), filter empty-string fields per object, re-emit via \`SetAttributeValue\`. Broad-strip rather than targeted on \`ipv6_cidr_block\` — future provider tightening on other fields would surface the same way.

Surfaced via live CUST3 smoke after PR #342 merged. Pre-existing genconfig bug newly visible because Bundle 4 added the \`aws_route_table\` discoverer.

## Stacked PR

This PR is stacked on #346 (fix/genconfig-subnet-fixups, closes #343/#344). Once #346 merges, this PR will rebase onto main and re-target.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/insideout-import/genconfig/... -race -count=1\` — 111 passed (+7 new tests)
- [x] \`go test ./... -race -count=1\` — 3831 passed across 24 packages
- [x] \`gofmt\` clean, \`go vet\` clean
- [ ] CI green (after rebase onto main)
- [ ] Live CUST3 smoke after merge confirms \`terraform validate\` exits 0

Closes #345