### PR TITLE
fix(genconfig): four Bundle 6 provider-quirk fixups (#348, #349, #350, #351)

### DIFF
--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -58,6 +58,10 @@ var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_lb":              fixupLBSubnetMappingConflict,
 	"aws_subnet":          fixupSubnetProviderQuirks,
 	"aws_route_table":     fixupRouteTableEmptyRouteFields,
+	"aws_nat_gateway":     fixupNATGatewaySecondaryIPConflict,
+	"aws_lb_listener":     fixupLBListenerStickinessDurationZero,
+	"aws_lb_target_group": fixupLBTargetGroupProviderQuirks,
+	"aws_vpc_endpoint":    fixupVPCEndpointEmptyDNSDomains,
 }
 
 // lambdaPlaceholderFile is what we set `filename` to so the block
@@ -367,6 +371,126 @@ func nullEmptyStringFieldsInObject(v cty.Value) (cty.Value, bool) {
 	return cty.ObjectVal(fields), true
 }
 
+// fixupNATGatewaySecondaryIPConflict resolves the
+// secondary_private_ip_address_count vs secondary_private_ip_addresses
+// mutual-exclusion. terraform plan -generate-config-out emits both
+// (count = 0, addresses = []) for every NAT gateway not configured
+// with secondary IPs. The provider rejects co-presence even when both
+// carry the no-info shape.
+//
+// Heuristic: when both attrs carry the no-info shape (count = 0 AND
+// addresses = []), drop both — neither carries information. When
+// either side carries a meaningful value, keep it and drop the other.
+// Issue #348.
+func fixupNATGatewaySecondaryIPConflict(blk *hclwrite.Block) {
+	body := blk.Body()
+	hasCount := body.GetAttribute("secondary_private_ip_address_count") != nil
+	hasAddrs := body.GetAttribute("secondary_private_ip_addresses") != nil
+	if !hasCount || !hasAddrs {
+		return
+	}
+	countZero := isAttrLiteralZero(body, "secondary_private_ip_address_count")
+	addrsEmpty := isAttrLiteralEmptyList(body, "secondary_private_ip_addresses")
+	switch {
+	case countZero && addrsEmpty:
+		// Both no-info — drop both.
+		body.RemoveAttribute("secondary_private_ip_address_count")
+		body.RemoveAttribute("secondary_private_ip_addresses")
+	case countZero:
+		// Operator pinned addresses; the count is redundant + conflicts.
+		body.RemoveAttribute("secondary_private_ip_address_count")
+	case addrsEmpty:
+		// Operator pinned count; the empty list is redundant + conflicts.
+		body.RemoveAttribute("secondary_private_ip_addresses")
+	}
+}
+
+// fixupLBListenerStickinessDisabledDropped drops the entire stickiness
+// sub-block from default_action.forward when its enabled = false.
+// terraform plan -generate-config-out emits a stickiness block
+// carrying `enabled = false` (and `duration = 0`, which schema cleanup
+// drops as Computed-default before this fixup runs) for any forward
+// target group not configured for stickiness. The provider treats
+// `duration` as a required argument whenever the stickiness block is
+// present — so leaving an empty `stickiness { enabled = false }`
+// block fails validate with "Missing required argument". Drop the
+// entire stickiness block when disabled; the provider treats
+// stickiness as optional and accepts its absence. Issue #349.
+func fixupLBListenerStickinessDurationZero(blk *hclwrite.Block) {
+	for _, da := range blk.Body().Blocks() {
+		if da.Type() != "default_action" {
+			continue
+		}
+		for _, fwd := range da.Body().Blocks() {
+			if fwd.Type() != "forward" {
+				continue
+			}
+			for _, st := range fwd.Body().Blocks() {
+				if st.Type() != "stickiness" {
+					continue
+				}
+				// Drop the whole block when stickiness is disabled.
+				// A real stickiness configuration carrying duration is
+				// preserved (enabled = true with duration set).
+				if isAttrLiteralFalse(st.Body(), "enabled") {
+					fwd.Body().RemoveBlock(st)
+				}
+			}
+		}
+	}
+}
+
+// fixupLBTargetGroupProviderQuirks resolves three terraform-provider-aws
+// schema constraints terraform plan -generate-config-out emits in
+// violation of:
+//
+//   - target_control_port = 0 (provider rejects literal 0; range
+//     1-65535). Drop the literal-zero attribute.
+//   - target_failover block with on_deregistration = null AND
+//     on_unhealthy = null (both required by schema; null fails the
+//     required check). Drop the entire block.
+//   - target_health_state block with
+//     enable_unhealthy_connection_termination = null (required by
+//     schema). Drop the entire block.
+//
+// Conservative: each block-drop fires only when the required field is
+// the null literal. A real configuration carrying meaningful values
+// preserves the block. Issue #350.
+func fixupLBTargetGroupProviderQuirks(blk *hclwrite.Block) {
+	body := blk.Body()
+	if isAttrLiteralZero(body, "target_control_port") {
+		body.RemoveAttribute("target_control_port")
+	}
+	for _, sub := range body.Blocks() {
+		switch sub.Type() {
+		case "target_failover":
+			if isAttrLiteralNull(sub.Body(), "on_deregistration") && isAttrLiteralNull(sub.Body(), "on_unhealthy") {
+				body.RemoveBlock(sub)
+			}
+		case "target_health_state":
+			if isAttrLiteralNull(sub.Body(), "enable_unhealthy_connection_termination") {
+				body.RemoveBlock(sub)
+			}
+		}
+	}
+}
+
+// fixupVPCEndpointEmptyDNSDomains drops the empty
+// private_dns_specified_domains list inside the dns_options nested
+// block. The provider's schema marks the list as MinItems=1 — empty
+// list violates the constraint. The dns_options block accepts the
+// field's absence as "default to nil". Issue #351.
+func fixupVPCEndpointEmptyDNSDomains(blk *hclwrite.Block) {
+	for _, sub := range blk.Body().Blocks() {
+		if sub.Type() != "dns_options" {
+			continue
+		}
+		if isAttrLiteralEmptyList(sub.Body(), "private_dns_specified_domains") {
+			sub.Body().RemoveAttribute("private_dns_specified_domains")
+		}
+	}
+}
+
 // isAttrLiteralZero reports whether the named attribute exists and its
 // expression is exactly the literal `0` (after whitespace trimming).
 // It does NOT match `0.0`, `00`, or any computed expression that
@@ -402,4 +526,59 @@ func hasUsableValue(body *hclwrite.Body, name string) bool {
 		sb.Write(t.Bytes)
 	}
 	return strings.TrimSpace(sb.String()) != "null"
+}
+
+// isAttrLiteralNull reports whether the named attribute exists and its
+// expression is exactly the literal `null` (after whitespace trimming).
+// Mirrors isAttrLiteralZero — only the raw literal terraform plan
+// -generate-config-out would emit for a Required-but-unset attribute,
+// not any computed expression that evaluates to null.
+func isAttrLiteralNull(body *hclwrite.Body, name string) bool {
+	attr := body.GetAttribute(name)
+	if attr == nil {
+		return false
+	}
+	tokens := attr.Expr().BuildTokens(nil)
+	var sb strings.Builder
+	for _, t := range tokens {
+		sb.Write(t.Bytes)
+	}
+	return strings.TrimSpace(sb.String()) == "null"
+}
+
+// isAttrLiteralEmptyList reports whether the named attribute exists and
+// its expression is exactly the literal `[]` (after whitespace
+// trimming). Mirrors isAttrLiteralZero — only the raw literal
+// terraform plan -generate-config-out would emit for an empty
+// list-shaped field, not any computed expression that evaluates to
+// an empty list.
+func isAttrLiteralEmptyList(body *hclwrite.Body, name string) bool {
+	attr := body.GetAttribute(name)
+	if attr == nil {
+		return false
+	}
+	tokens := attr.Expr().BuildTokens(nil)
+	var sb strings.Builder
+	for _, t := range tokens {
+		sb.Write(t.Bytes)
+	}
+	return strings.TrimSpace(sb.String()) == "[]"
+}
+
+// isAttrLiteralFalse reports whether the named attribute exists and its
+// expression is exactly the literal `false` (after whitespace
+// trimming). Mirrors isAttrLiteralZero / isAttrLiteralNull — only the
+// raw literal terraform plan -generate-config-out would emit, not any
+// computed expression evaluating to false.
+func isAttrLiteralFalse(body *hclwrite.Body, name string) bool {
+	attr := body.GetAttribute(name)
+	if attr == nil {
+		return false
+	}
+	tokens := attr.Expr().BuildTokens(nil)
+	var sb strings.Builder
+	for _, t := range tokens {
+		sb.Write(t.Bytes)
+	}
+	return strings.TrimSpace(sb.String()) == "false"
 }

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -1288,3 +1288,350 @@ func TestFixupRouteTable_MultipleRouteObjectsAllNulled(t *testing.T) {
 		t.Errorf("second route's nat_gateway_id must be preserved\n--- got ---\n%s", got)
 	}
 }
+
+// TestFixupNATGateway_BothNoInfoDropped pins #348 positive: when
+// generate-config-out emits both `secondary_private_ip_address_count = 0`
+// AND `secondary_private_ip_addresses = []`, drop both — neither
+// carries information, and the provider rejects co-presence.
+func TestFixupNATGateway_BothNoInfoDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_nat_gateway" "ngw" {
+  subnet_id                          = "subnet-abc"
+  secondary_private_ip_address_count = 0
+  secondary_private_ip_addresses     = []
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*secondary_private_ip_address_count\s*=`).MatchString(got) {
+		t.Errorf("secondary_private_ip_address_count must be dropped when both no-info\n--- got ---\n%s", got)
+	}
+	if regexp.MustCompile(`(?m)^\s*secondary_private_ip_addresses\s*=`).MatchString(got) {
+		t.Errorf("secondary_private_ip_addresses must be dropped when both no-info\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupNATGateway_CountWithEmptyAddrsDropsAddrs pins the
+// count-pinned carve-out: operator set count > 0; the empty addresses
+// list is redundant + conflicts. Drop the addresses list, keep the count.
+func TestFixupNATGateway_CountWithEmptyAddrsDropsAddrs(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_nat_gateway" "ngw" {
+  subnet_id                          = "subnet-abc"
+  secondary_private_ip_address_count = 2
+  secondary_private_ip_addresses     = []
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`(?m)^\s*secondary_private_ip_address_count\s*=\s*2`).MatchString(got) {
+		t.Errorf("secondary_private_ip_address_count = 2 must be preserved\n--- got ---\n%s", got)
+	}
+	if regexp.MustCompile(`(?m)^\s*secondary_private_ip_addresses\s*=`).MatchString(got) {
+		t.Errorf("empty secondary_private_ip_addresses must be dropped when count is set\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupNATGateway_AddrsWithZeroCountDropsCount pins the
+// addresses-pinned carve-out: operator set explicit addresses; the
+// count = 0 is redundant + conflicts. Drop the count, keep addresses.
+func TestFixupNATGateway_AddrsWithZeroCountDropsCount(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_nat_gateway" "ngw" {
+  subnet_id                          = "subnet-abc"
+  secondary_private_ip_address_count = 0
+  secondary_private_ip_addresses     = ["10.0.0.1"]
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*secondary_private_ip_address_count\s*=`).MatchString(got) {
+		t.Errorf("secondary_private_ip_address_count = 0 must be dropped when addresses are set\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`secondary_private_ip_addresses\s*=\s*\["10\.0\.0\.1"\]`).MatchString(got) {
+		t.Errorf("secondary_private_ip_addresses must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupNATGateway_OnlyOneAttrPresentNoOp pins the no-op carve-out:
+// when only one of the conflict pair is present, the fixup must do
+// nothing.
+func TestFixupNATGateway_OnlyOneAttrPresentNoOp(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_nat_gateway" "ngw" {
+  subnet_id                          = "subnet-abc"
+  secondary_private_ip_address_count = 0
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(in) {
+		t.Errorf("only-one-attr-present must be a no-op\n--- in ---\n%s\n--- out ---\n%s", in, out)
+	}
+}
+
+// TestFixupLBListener_DisabledStickinessBlockDropped pins #349 positive:
+// drop the entire stickiness sub-block from default_action.forward
+// when enabled = false. Schema cleanup drops duration = 0 before this
+// fixup runs, leaving `stickiness { enabled = false }` which the
+// provider rejects with "duration is required".
+func TestFixupLBListener_DisabledStickinessBlockDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb_listener" "listener" {
+  load_balancer_arn = "arn:..."
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type             = "forward"
+    target_group_arn = "arn:..."
+    forward {
+      stickiness {
+        enabled = false
+      }
+      target_group {
+        arn    = "arn:..."
+        weight = 1
+      }
+    }
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "stickiness") {
+		t.Errorf("disabled stickiness block must be dropped\n--- got ---\n%s", got)
+	}
+	// The forward block (and target_group, default_action) must survive.
+	if !strings.Contains(got, "target_group") {
+		t.Errorf("forward.target_group must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLBListener_EnabledStickinessBlockPreserved pins the
+// carve-out: a real stickiness configuration carrying enabled = true
+// with a duration is preserved untouched.
+func TestFixupLBListener_EnabledStickinessBlockPreserved(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb_listener" "listener" {
+  load_balancer_arn = "arn:..."
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type             = "forward"
+    target_group_arn = "arn:..."
+    forward {
+      stickiness {
+        enabled  = true
+        duration = 3600
+      }
+      target_group {
+        arn    = "arn:..."
+        weight = 1
+      }
+    }
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "stickiness") {
+		t.Errorf("enabled stickiness must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`duration\s*=\s*3600`).MatchString(got) {
+		t.Errorf("non-zero duration must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLBTargetGroup_TargetControlPortZeroDropped pins #350a:
+// drop the literal-zero target_control_port (range 1-65535).
+func TestFixupLBTargetGroup_TargetControlPortZeroDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb_target_group" "tg" {
+  name                = "tg"
+  port                = 80
+  protocol            = "HTTP"
+  target_control_port = 0
+  vpc_id              = "vpc-123"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*target_control_port\s*=`).MatchString(got) {
+		t.Errorf("target_control_port = 0 must be dropped\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLBTargetGroup_TargetControlPortNonZeroPreserved pins the
+// carve-out: a real target_control_port (e.g. 443) is preserved.
+func TestFixupLBTargetGroup_TargetControlPortNonZeroPreserved(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb_target_group" "tg" {
+  name                = "tg"
+  port                = 80
+  protocol            = "HTTP"
+  target_control_port = 443
+  vpc_id              = "vpc-123"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`(?m)^\s*target_control_port\s*=\s*443`).MatchString(got) {
+		t.Errorf("non-zero target_control_port must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLBTargetGroup_NullTargetFailoverBlockDropped pins #350b:
+// drop the entire target_failover block when both required fields are
+// null. Generate-config-out emits the block with null required fields
+// for any target_group not configured for failover.
+func TestFixupLBTargetGroup_NullTargetFailoverBlockDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb_target_group" "tg" {
+  name     = "tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "vpc-123"
+  target_failover {
+    on_deregistration = null
+    on_unhealthy      = null
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "target_failover") {
+		t.Errorf("target_failover block with null required fields must be dropped\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLBTargetGroup_PopulatedTargetFailoverPreserved pins the
+// carve-out: a real target_failover with non-null fields survives.
+func TestFixupLBTargetGroup_PopulatedTargetFailoverPreserved(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb_target_group" "tg" {
+  name     = "tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "vpc-123"
+  target_failover {
+    on_deregistration = "rebalance"
+    on_unhealthy      = "rebalance"
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "target_failover") {
+		t.Errorf("populated target_failover block must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`on_deregistration\s*=\s*"rebalance"`).MatchString(got) {
+		t.Errorf("on_deregistration value must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLBTargetGroup_NullTargetHealthStateBlockDropped pins #350c:
+// drop the entire target_health_state block when its required field
+// (enable_unhealthy_connection_termination) is null.
+func TestFixupLBTargetGroup_NullTargetHealthStateBlockDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb_target_group" "tg" {
+  name     = "tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "vpc-123"
+  target_health_state {
+    enable_unhealthy_connection_termination = null
+    unhealthy_draining_interval             = null
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "target_health_state") {
+		t.Errorf("target_health_state block with null required field must be dropped\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupVPCEndpoint_EmptyDNSDomainsDropped pins #351 positive: drop
+// the empty private_dns_specified_domains list inside dns_options.
+// Provider marks the list MinItems=1 — empty list fails validate.
+func TestFixupVPCEndpoint_EmptyDNSDomainsDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_vpc_endpoint" "ep" {
+  vpc_id            = "vpc-123"
+  service_name      = "com.amazonaws.us-east-1.s3"
+  vpc_endpoint_type = "Gateway"
+  dns_options {
+    dns_record_ip_type            = "service-defined"
+    private_dns_specified_domains = []
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*private_dns_specified_domains\s*=`).MatchString(got) {
+		t.Errorf("empty private_dns_specified_domains must be dropped\n--- got ---\n%s", got)
+	}
+	// dns_options block survives (we only dropped the inner attribute).
+	if !strings.Contains(got, "dns_options") {
+		t.Errorf("dns_options block must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupVPCEndpoint_PopulatedDNSDomainsPreserved pins the carve-out:
+// a non-empty list is preserved.
+func TestFixupVPCEndpoint_PopulatedDNSDomainsPreserved(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_vpc_endpoint" "ep" {
+  vpc_id            = "vpc-123"
+  service_name      = "com.amazonaws.us-east-1.s3"
+  vpc_endpoint_type = "Interface"
+  dns_options {
+    private_dns_specified_domains = ["example.com", "internal.example.com"]
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`private_dns_specified_domains\s*=\s*\["example.com",\s*"internal.example.com"\]`).MatchString(got) {
+		t.Errorf("populated private_dns_specified_domains must be preserved\n--- got ---\n%s", got)
+	}
+}

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -1635,3 +1635,228 @@ func TestFixupVPCEndpoint_PopulatedDNSDomainsPreserved(t *testing.T) {
 		t.Errorf("populated private_dns_specified_domains must be preserved\n--- got ---\n%s", got)
 	}
 }
+
+// TestFixupLBTargetGroup_PartiallyNullTargetFailoverPreserved pins
+// mutation-resistance on the && in fixupLBTargetGroupProviderQuirks's
+// target_failover guard. Both required fields must be null for the
+// block to be dropped — partial null (one set, one null) preserves
+// the block. A mutation that swapped && for || would always-drop and
+// fail this test.
+func TestFixupLBTargetGroup_PartiallyNullTargetFailoverPreserved(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"deregistration_set", `on_deregistration = "rebalance"
+    on_unhealthy      = null`},
+		{"unhealthy_set", `on_deregistration = null
+    on_unhealthy      = "no_rebalance"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := []byte(`resource "aws_lb_target_group" "tg" {
+  name     = "tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "vpc-123"
+  target_failover {
+    ` + tc.body + `
+  }
+}
+`)
+			out, err := applyResourceTypeFixups(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(out)
+			if !regexp.MustCompile(`(?m)^\s*target_failover\s*\{`).MatchString(got) {
+				t.Errorf("partially-null target_failover must be preserved\n--- got ---\n%s", got)
+			}
+		})
+	}
+}
+
+// TestFixupLBTargetGroup_PopulatedTargetHealthStatePreserved pins the
+// preserve-when-meaningful carve-out for the third target_group
+// transform: a real target_health_state with a non-null required
+// field survives. A mutation that always-dropped target_health_state
+// (or removed the isAttrLiteralNull guard) would fail this.
+func TestFixupLBTargetGroup_PopulatedTargetHealthStatePreserved(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb_target_group" "tg" {
+  name     = "tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "vpc-123"
+  target_health_state {
+    enable_unhealthy_connection_termination = true
+    unhealthy_draining_interval             = 60
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`(?m)^\s*target_health_state\s*\{`).MatchString(got) {
+		t.Errorf("populated target_health_state block must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`enable_unhealthy_connection_termination\s*=\s*true`).MatchString(got) {
+		t.Errorf("non-null enable_unhealthy_connection_termination must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupNATGateway_OnlyAffectsAWSNATGatewayBlocks pins resource-type
+// isolation: a sibling aws_eip carrying the same secondary_private_ip
+// attribute names must NOT be touched. The fixup table is keyed by
+// aws_nat_gateway only.
+func TestFixupNATGateway_OnlyAffectsAWSNATGatewayBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_nat_gateway" "ngw" {
+  subnet_id                          = "subnet-abc"
+  secondary_private_ip_address_count = 0
+  secondary_private_ip_addresses     = []
+}
+
+resource "aws_eip" "extra" {
+  domain                             = "vpc"
+  secondary_private_ip_address_count = 0
+  secondary_private_ip_addresses     = []
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`(?s)resource "aws_eip" "extra"[^}]*secondary_private_ip_address_count\s*=\s*0`).MatchString(got) {
+		t.Errorf("aws_eip.secondary_private_ip_address_count must be preserved (fixup keyed by aws_nat_gateway)\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?s)resource "aws_eip" "extra"[^}]*secondary_private_ip_addresses\s*=\s*\[\]`).MatchString(got) {
+		t.Errorf("aws_eip.secondary_private_ip_addresses=[] must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupLBListener_OnlyAffectsAWSLBListenerBlocks pins resource-type
+// isolation: a sibling aws_lb block carrying its own (hypothetical)
+// stickiness sub-block must not be touched. Fixup table keyed by
+// aws_lb_listener only.
+func TestFixupLBListener_OnlyAffectsAWSLBListenerBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb_listener" "listener" {
+  load_balancer_arn = "arn:..."
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type             = "forward"
+    target_group_arn = "arn:..."
+    forward {
+      stickiness {
+        enabled = false
+      }
+      target_group {
+        arn    = "arn:..."
+        weight = 1
+      }
+    }
+  }
+}
+
+resource "aws_lb" "extra" {
+  name = "alb"
+  default_action {
+    forward {
+      stickiness {
+        enabled = false
+      }
+    }
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// aws_lb's stickiness must survive untouched (fixup keyed by aws_lb_listener).
+	count := len(regexp.MustCompile(`(?m)^\s*stickiness\s*\{`).FindAllString(got, -1))
+	if count != 1 {
+		t.Errorf("expected exactly 1 stickiness block remaining (the aws_lb's), got %d\n--- got ---\n%s", count, got)
+	}
+}
+
+// TestFixupLBTargetGroup_OnlyAffectsAWSLBTargetGroupBlocks pins
+// resource-type isolation: a sibling aws_lb block carrying the same
+// attribute names (target_control_port, target_failover) must not be
+// touched.
+func TestFixupLBTargetGroup_OnlyAffectsAWSLBTargetGroupBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_lb_target_group" "tg" {
+  name                = "tg"
+  target_control_port = 0
+  target_failover {
+    on_deregistration = null
+    on_unhealthy      = null
+  }
+}
+
+resource "aws_lb" "extra" {
+  name                = "alb"
+  target_control_port = 0
+  target_failover {
+    on_deregistration = null
+    on_unhealthy      = null
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// aws_lb's target_control_port=0 must be preserved.
+	if !regexp.MustCompile(`(?s)resource "aws_lb" "extra"[^}]*target_control_port\s*=\s*0`).MatchString(got) {
+		t.Errorf("aws_lb.target_control_port=0 must be preserved (fixup keyed by aws_lb_target_group)\n--- got ---\n%s", got)
+	}
+	// Exactly 1 target_failover block remains (the aws_lb's).
+	count := len(regexp.MustCompile(`(?m)^\s*target_failover\s*\{`).FindAllString(got, -1))
+	if count != 1 {
+		t.Errorf("expected exactly 1 target_failover block remaining (the aws_lb's), got %d\n--- got ---\n%s", count, got)
+	}
+}
+
+// TestFixupVPCEndpoint_OnlyAffectsAWSVPCEndpointBlocks pins
+// resource-type isolation: a sibling aws_vpc carrying its own
+// (hypothetical) dns_options block with empty
+// private_dns_specified_domains must not be touched.
+func TestFixupVPCEndpoint_OnlyAffectsAWSVPCEndpointBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_vpc_endpoint" "ep" {
+  vpc_id            = "vpc-123"
+  service_name      = "com.amazonaws.us-east-1.s3"
+  vpc_endpoint_type = "Gateway"
+  dns_options {
+    private_dns_specified_domains = []
+  }
+}
+
+resource "aws_iam_policy" "extra" {
+  name = "p"
+  dns_options {
+    private_dns_specified_domains = []
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// aws_iam_policy's dns_options.private_dns_specified_domains=[] must be preserved.
+	if !regexp.MustCompile(`(?s)resource "aws_iam_policy" "extra"[^}]*\{[^}]*dns_options[^}]*\{[^}]*private_dns_specified_domains\s*=\s*\[\]`).MatchString(got) {
+		t.Errorf("aws_iam_policy's empty private_dns_specified_domains must be preserved (fixup keyed by aws_vpc_endpoint)\n--- got ---\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Live CUST3 smoke after the corrected #347 surfaced 8 more \`terraform validate\` errors across 4 resource types — same family as #337/#338/#343/#344/#345. This PR adds the four fixups; after this stack lands, **\`terraform validate\` exits 0** against the io-oukrhfwhmflf 38-resource set.

- **#348** — aws_nat_gateway: \`secondary_private_ip_address_count\` vs \`secondary_private_ip_addresses\` mutual exclusion (drop both when both no-info; drop the conflicting empty side when the other has a value)
- **#349** — aws_lb_listener: drop the entire \`stickiness\` sub-block from \`default_action.forward\` when \`enabled = false\`. \`cleanGenerated\` drops \`duration = 0\` before this fixup runs, leaving \`stickiness { enabled = false }\` which fails validate with "duration required"
- **#350** — aws_lb_target_group (3 transforms in one closure):
  - drop literal-zero \`target_control_port\` (range 1-65535)
  - drop entire \`target_failover\` block when both required fields are null
  - drop entire \`target_health_state\` block when its required field is null
- **#351** — aws_vpc_endpoint: drop empty \`private_dns_specified_domains\` list inside \`dns_options\` (provider MinItems=1)

## Helpers added

Three new isAttrLiteralX helpers mirroring isAttrLiteralZero (exact-literal match, no computed-expression coercion):
- \`isAttrLiteralNull\`
- \`isAttrLiteralEmptyList\`
- \`isAttrLiteralFalse\`

## Stacked PR

This PR is stacked on #347 (route_table fixup), which is stacked on #346 (subnet fixups). After all three merge, the Bundle 4+5+6 stack delivers validate-clean Stage 2b output.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/insideout-import/genconfig/... -race -count=1\` — 127 passed (+13 new tests)
- [x] \`go test ./... -race -count=1\` — 3847 passed across 24 packages
- [x] \`gofmt\` clean, \`go vet\` clean
- [x] **Live CUST3 smoke**: \`terraform validate\` exits 0 with this stack applied
- [ ] CI green (after rebase onto main)

Closes #348
Closes #349
Closes #350
Closes #351