### PR TITLE
prototype(#339): terraform query for aws_vpc discovery

### DIFF
--- a/cmd/insideout-import/awsdiscover/export_for_prototype.go
+++ b/cmd/insideout-import/awsdiscover/export_for_prototype.go
@@ -1,0 +1,32 @@
+package awsdiscover
+
+import "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+
+// AddressBook is the exported alias used by the
+// prototype/vpcquery research package (issue #339) so a parallel
+// terraform-query-backed Discover can build addresses without poking
+// the unexported internals of this package.
+//
+// The production discoverers use the unexported `addressBook` type
+// directly. This export exists ONLY for the prototype — if it is still
+// referenced after the migrate-or-stay decision is taken, the
+// prototype owners should either (a) inline the shim into their package,
+// or (b) delete this file together with the prototype directory.
+type AddressBook = addressBook
+
+// NewAddressBook returns an empty AddressBook. The unexported type is a
+// `map[string]struct{}`, so callers could `make(AddressBook)` directly,
+// but giving them a constructor keeps the surface narrow if the
+// underlying type ever changes.
+func NewAddressBook() AddressBook { return addressBook{} }
+
+// MakeImportedResource is the exported wrapper around the package-internal
+// makeImportedResource used by every production discoverer (vpc.go,
+// sqs.go, etc.) to build a Phase-2 ImportedResource with a
+// deterministically-generated address. See identity.go::makeImportedResource
+// for the full semantics — this thin shim exists so the prototype can
+// share the SAME address-generation path as production (no parallel
+// implementation drift, no #255-style nil-vs-empty regressions).
+func MakeImportedResource(book AddressBook, typ, name, importID, region, accountID string, nativeIDs, tags map[string]string) imported.ImportedResource {
+	return makeImportedResource(book, typ, name, importID, region, accountID, nativeIDs, tags)
+}

--- a/cmd/insideout-import/awsdiscover/prototype/vpcquery/cmd/smoke/main.go
+++ b/cmd/insideout-import/awsdiscover/prototype/vpcquery/cmd/smoke/main.go
@@ -1,0 +1,96 @@
+// Live smoke driver for prototype/vpcquery (#339).
+// Run with AWS creds for CUST3 (031780745048):
+//
+//	go run ./cmd/insideout-import/awsdiscover/prototype/vpcquery/cmd/smoke \
+//	  -project=io-oukrhfwhmflf -region=us-east-1
+//
+// Compares prototype output to the hand-written vpcDiscoverer for parity.
+// Requires terraform 1.14+ on PATH (see docs/terraform-query-prototype.md).
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover/prototype/vpcquery"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+func main() {
+	project := flag.String("project", "", "Project tag value (empty = list all)")
+	region := flag.String("region", "us-east-1", "AWS region")
+	account := flag.String("account", "031780745048", "AWS account ID (for Identity stamping)")
+	flag.Parse()
+
+	ctx := context.Background()
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(*region))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "load config:", err)
+		os.Exit(2)
+	}
+
+	args := awsdiscover.DiscoverArgs{
+		Project:   *project,
+		Regions:   []string{*region},
+		AccountID: *account,
+	}
+
+	prod := awsdiscover.NewAWSDiscoverer(cfg)
+	prodOut, err := prod.DiscoverTypes(ctx, []string{"aws_vpc"}, args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "production discover:", err)
+		os.Exit(2)
+	}
+
+	proto := vpcquery.NewDiscoverer(cfg)
+	protoOut, err := proto.Discover(ctx, args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "prototype discover:", err)
+		os.Exit(2)
+	}
+
+	prodIDs := importIDs(prodOut)
+	protoIDs := importIDs(protoOut)
+	sort.Strings(prodIDs)
+	sort.Strings(protoIDs)
+
+	fmt.Printf("PRODUCTION: %d VPCs  %v\n", len(prodIDs), prodIDs)
+	fmt.Printf("PROTOTYPE:  %d VPCs  %v\n", len(protoIDs), protoIDs)
+
+	if !reflect.DeepEqual(prodIDs, protoIDs) {
+		fmt.Fprintln(os.Stderr, "MISMATCH")
+		os.Exit(1)
+	}
+
+	// Spot-check Identity equality on the first match.
+	if len(prodOut) > 0 && len(protoOut) > 0 {
+		p := prodOut[0].Identity
+		q := protoOut[0].Identity
+		fmt.Printf("PROD[0] Address=%s NameHint=%s Tags=%v\n", p.Address, p.NameHint, p.Tags)
+		fmt.Printf("PROT[0] Address=%s NameHint=%s Tags=%v\n", q.Address, q.NameHint, q.Tags)
+		if p.Address != q.Address {
+			fmt.Fprintf(os.Stderr, "address mismatch: prod=%s proto=%s\n", p.Address, q.Address)
+			os.Exit(1)
+		}
+		if !reflect.DeepEqual(p.Tags, q.Tags) {
+			fmt.Fprintf(os.Stderr, "tags mismatch: prod=%v proto=%v\n", p.Tags, q.Tags)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("PARITY OK")
+}
+
+func importIDs(rs []imported.ImportedResource) []string {
+	out := make([]string, 0, len(rs))
+	for _, r := range rs {
+		out = append(out, r.Identity.ImportID)
+	}
+	return out
+}

--- a/cmd/insideout-import/awsdiscover/prototype/vpcquery/providers.tf.tmpl
+++ b/cmd/insideout-import/awsdiscover/prototype/vpcquery/providers.tf.tmpl
@@ -1,0 +1,20 @@
+// providers.tf.tmpl is the minimal terraform/provider config rendered into
+// the scratch workdir alongside vpc.tfquery.hcl. We pin AWS provider >= 6.0
+// (matches the version constraint every preset main.tf already declares —
+// list resources require provider 6.x). The {{.Region}} placeholder is
+// substituted at runtime so each per-region query targets the right
+// regional endpoint without depending on operator AWS_REGION env state.
+
+terraform {
+  required_version = ">= 1.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "{{.Region}}"
+}

--- a/cmd/insideout-import/awsdiscover/prototype/vpcquery/vpc.tfquery.hcl
+++ b/cmd/insideout-import/awsdiscover/prototype/vpcquery/vpc.tfquery.hcl
@@ -1,0 +1,47 @@
+// vpc.tfquery.hcl is the Terraform 1.14 query definition for aws_vpc.
+//
+// It is consumed by the prototype/vpcquery package: the Go wrapper renders
+// this file (along with a tiny providers.tf) into a scratch directory,
+// runs `terraform init` once and `terraform query -json` per region, and
+// parses the streaming JSON line-protocol into []imported.ImportedResource.
+//
+// Tags are NOT carried in the list-resource result envelope (the AWS
+// provider list_resource_schema for aws_vpc exposes only region, vpc_ids,
+// and the filter block — no tag attribute, no tag passthrough on the
+// matched record). Project-tag filtering still happens server-side via
+// the EC2 `tag:Project` filter — wired up below — but Identity.Tags is
+// reconstructed by the wrapper using the existing DescribeVpcs path.
+//
+// See docs/terraform-query-prototype.md for the full decision record
+// behind this file (issue #339).
+
+variable "project_filter" {
+  type        = string
+  description = <<-EOT
+    Project tag value to filter VPCs by. When non-empty the query passes a
+    server-side `tag:Project = <value>` filter to EC2 (parity with the
+    hand-written DescribeVpcsInput.Filters used by vpcDiscoverer.Discover).
+    Empty string disables the filter so the query returns every VPC in
+    the account/region — used by the admin/audit code path.
+  EOT
+  default     = ""
+}
+
+list "aws_vpc" "all" {
+  provider = aws
+
+  config {
+    // Server-side Project-tag filter, conditional on var.project_filter.
+    // Mirrors the EC2 DescribeVpcs `tag:Project` filter the hand-written
+    // vpcDiscoverer assembles in vpc.go::Discover. A dynamic block is the
+    // shortest way to express "include this filter only when the value
+    // is non-empty" without two list blocks.
+    dynamic "filter" {
+      for_each = var.project_filter == "" ? [] : [1]
+      content {
+        name   = "tag:Project"
+        values = [var.project_filter]
+      }
+    }
+  }
+}

--- a/cmd/insideout-import/awsdiscover/prototype/vpcquery/vpcquery.go
+++ b/cmd/insideout-import/awsdiscover/prototype/vpcquery/vpcquery.go
@@ -1,0 +1,477 @@
+// Package vpcquery is a research prototype (issue #339) that demonstrates
+// using Terraform 1.14's `terraform query -json` command as a replacement
+// for the List+filter half of an AWS discoverer. Target type: aws_vpc.
+//
+// This package is OPT-IN. The production aws_vpc discoverer remains in
+// cmd/insideout-import/awsdiscover/vpc.go and is registered in
+// awsdiscover.NewAWSDiscovererWithConcurrency. Nothing in the production
+// pipeline imports this package; it exists for benchmarking, decision-
+// making, and as a reference implementation for the follow-up "should we
+// migrate the other 27 covered AWS types?" ticket.
+//
+// # Shape
+//
+//  1. vpc.tfquery.hcl + providers.tf.tmpl are embedded via embed.FS.
+//  2. Discoverer.Discover renders both into an os.MkdirTemp workdir per
+//     region, runs `terraform init -input=false` once and
+//     `terraform query -json -var project_filter=<…>` per region.
+//  3. The streaming JSON line-protocol (one JSON object per line on stdout)
+//     is parsed for `type=list_resource_found` events; each carries an
+//     `identity.id` (vpc-XXXXXXXX) and `display_name`.
+//  4. For each match, the wrapper does a follow-up DescribeVpcs(VpcIds=[id])
+//     via the existing vpcClient surface to fetch tags and CIDR. That
+//     second round-trip is what keeps Identity.Tags populated; the AWS
+//     provider's list_resource_schema for aws_vpc exposes ONLY region,
+//     vpc_ids, and a filter block — no tag attribute, no tag passthrough
+//     on matched records. (verified: terraform providers schema -json
+//     against hashicorp/aws v6.44.0).
+//  5. Identity construction reuses the parent package's makeImportedResource
+//     via an exported shim — no IR shape divergence between the two paths.
+//
+// # What this prototype proves
+//
+//   - The tfquery.hcl + JSON pipe works end-to-end against a real AWS
+//     account (CUST3 / 031780745048 / us-east-1 — see live-smoke note in
+//     docs/terraform-query-prototype.md).
+//   - The provider exposes the same server-side filter primitives as the
+//     EC2 SDK, so Project-tag filtering migrates 1:1.
+//   - Tag fetch is NOT subsumed by `terraform query` — Identity.Tags
+//     still requires a second AWS API call. This kills the "75% LOC
+//     savings" hypothesis from the issue (real savings ~30-40%, see decision
+//     doc).
+//   - Per-region scoping requires re-rendering providers.tf (or sticking
+//     a per-region provider alias in one file). Either way, scratch-dir
+//     management is on the wrapper.
+//
+// # What this prototype does NOT do
+//
+//   - DiscoverByID — the issue scope is Stage 2a (bulk discover) only.
+//     Single-resource lookup stays on the SDK because `terraform query`
+//     would be a 5x latency hit (init + query) for a single ID.
+//   - Replace the parent vpcDiscoverer in production. Wiring this into
+//     the aggregator is a follow-up only if the decision is "migrate."
+package vpcquery
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+//go:embed vpc.tfquery.hcl
+var vpcQueryHCL []byte
+
+//go:embed providers.tf.tmpl
+var providersTmplSrc string
+
+// providersTmpl is parsed once at package init; rendering per region is a
+// cheap text/template Execute. Failing here at init means the embed and
+// the template are catastrophically out of sync, which is a build-time
+// bug rather than a runtime one.
+var providersTmpl = template.Must(template.New("providers").Parse(providersTmplSrc))
+
+// VpcClient is the narrow EC2 surface this prototype consumes. It mirrors
+// the parent package's vpcClient interface (which is unexported) so unit
+// tests can plug in a fake without dragging in the real EC2 SDK. The
+// production wrapper builds a real ec2.Client from the supplied aws.Config.
+type VpcClient interface {
+	DescribeVpcs(ctx context.Context, in *ec2.DescribeVpcsInput, opts ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error)
+}
+
+// QueryRunner abstracts `terraform init` + `terraform query -json` so unit
+// tests can avoid shelling out. Production wires up TerraformBinaryRunner
+// (below); tests inject a recorded-event runner.
+//
+// Run returns the raw bytes of the terraform-query stdout (newline-
+// delimited JSON, one event per line). It is the caller's responsibility
+// to parse the lines — keeping the runner dumb makes the contract small
+// enough to mock cleanly.
+type QueryRunner interface {
+	Run(ctx context.Context, workDir, region, projectFilter string) ([]byte, error)
+}
+
+// Discoverer is the Stage 2a entry point for the tfquery-backed aws_vpc
+// path. Constructed via NewDiscoverer; the test surface wires the fields
+// directly.
+//
+// This type intentionally does NOT implement awsdiscover.Discoverer —
+// while the Discover signature matches, registering it in
+// NewAWSDiscovererWithConcurrency would require also providing a
+// DiscoverByID, and the prototype scope (#339) is "bulk discover only."
+// A follow-up migration ticket would either (a) add DiscoverByID here
+// or (b) compose this with the SDK-only DiscoverByID from vpc.go.
+type Discoverer struct {
+	// runner shells out to `terraform query`. Must be non-nil.
+	runner QueryRunner
+	// new builds a per-region EC2 client used for the tag-fetch round-trip
+	// (terraform query does not return tags — see package doc).
+	new func(region string) VpcClient
+}
+
+// NewDiscoverer builds a production-ready prototype Discoverer. The
+// runner shells out to the operator's terraform binary on $PATH (which
+// MUST be Terraform 1.14+ — earlier versions reject the `list { }`
+// block in vpc.tfquery.hcl with a parse error).
+func NewDiscoverer(cfg aws.Config) *Discoverer {
+	return &Discoverer{
+		runner: TerraformBinaryRunner{},
+		new: func(region string) VpcClient {
+			return ec2.NewFromConfig(cfg, func(o *ec2.Options) {
+				if region != "" {
+					o.Region = region
+				}
+			})
+		},
+	}
+}
+
+// ResourceType returns the Terraform type this prototype covers. Mirrors
+// the parent vpcDiscoverer.ResourceType so the two are interchangeable
+// from the aggregator's perspective.
+func (d *Discoverer) ResourceType() string { return "aws_vpc" }
+
+// Discover runs `terraform query` once per region, parses the resulting
+// list_resource_found events, fetches tags for each match, and returns
+// []imported.ImportedResource. Output is sorted by VPC ID for parity
+// with the parent vpcDiscoverer.
+//
+// Project-tag filter: passed to the query as -var project_filter=<…>.
+// Empty filter disables the server-side EC2 filter — the admin/audit
+// path. The TagSelectors AND-conjunction is enforced client-side after
+// the tag fetch (parity with parent).
+//
+// Multi-region (#291): one query invocation per region, mirroring the
+// parent's `for _, region := range args.Regions` loop. Each region gets
+// its own scratch workdir (so terraform init's per-provider lockfile
+// and .terraform plugin cache don't collide if we ever parallelize).
+func (d *Discoverer) Discover(ctx context.Context, args awsdiscover.DiscoverArgs) ([]imported.ImportedResource, error) {
+	if d.runner == nil {
+		return nil, errors.New("vpcquery: nil QueryRunner")
+	}
+	if d.new == nil {
+		return nil, errors.New("vpcquery: nil VpcClient factory")
+	}
+
+	var out []imported.ImportedResource
+	for _, region := range args.Regions {
+		regionStart := time.Now()
+		hits, err := d.discoverRegion(ctx, region, args)
+		if err != nil {
+			return nil, fmt.Errorf("vpcquery (region=%s): %w", region, err)
+		}
+		out = append(out, hits...)
+		_ = regionStart // emitter integration left to follow-up if migration goes ahead
+	}
+	return out, nil
+}
+
+// discoverRegion handles one region: render the workdir, run terraform
+// init+query, parse events, fetch tags, build ImportedResources.
+func (d *Discoverer) discoverRegion(ctx context.Context, region string, args awsdiscover.DiscoverArgs) ([]imported.ImportedResource, error) {
+	workDir, cleanup, err := d.prepareWorkDir(region)
+	if err != nil {
+		return nil, fmt.Errorf("prepare workdir: %w", err)
+	}
+	defer cleanup()
+
+	stdout, err := d.runner.Run(ctx, workDir, region, args.Project)
+	if err != nil {
+		return nil, fmt.Errorf("terraform query: %w", err)
+	}
+
+	matches, err := parseQueryEvents(stdout)
+	if err != nil {
+		return nil, fmt.Errorf("parse events: %w", err)
+	}
+
+	// Sort by VPC ID for deterministic ImportedResource address generation.
+	// Parity with vpc.go::Discover which sorts vpcs by ID before the loop.
+	sort.Slice(matches, func(i, j int) bool { return matches[i].VPCID < matches[j].VPCID })
+
+	if len(matches) == 0 {
+		return nil, nil
+	}
+
+	client := d.new(region)
+	ids := make([]string, 0, len(matches))
+	for _, m := range matches {
+		ids = append(ids, m.VPCID)
+	}
+
+	// Single DescribeVpcs(VpcIds=[…]) round-trip: avoids one-call-per-
+	// VPC when the match set is small enough to fit in a single page
+	// (1000 IDs, EC2's hard cap). For accounts with > 1000 matches the
+	// follow-up migration would chunk this — the prototype keeps the
+	// simple path because the production hand-written discoverer
+	// doesn't need to either (the inline DescribeVpcs already returns
+	// tags for everything).
+	resp, err := client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{VpcIds: ids})
+	if err != nil {
+		return nil, fmt.Errorf("DescribeVpcs (tags): %w", err)
+	}
+
+	byID := make(map[string]ec2types.Vpc, len(resp.Vpcs))
+	for i := range resp.Vpcs {
+		byID[aws.ToString(resp.Vpcs[i].VpcId)] = resp.Vpcs[i]
+	}
+
+	book := awsdiscover.NewAddressBook()
+	out := make([]imported.ImportedResource, 0, len(matches))
+	for _, m := range matches {
+		v, ok := byID[m.VPCID]
+		if !ok {
+			// Race between query and tag fetch (rare, but possible):
+			// VPC was deleted between the two calls. Skip and let the
+			// next discover run pick up the missing entry.
+			continue
+		}
+		tags := ec2TagsToMap(v.Tags)
+		if !awsdiscover.MatchesAll(tags, args.TagSelectors) {
+			continue
+		}
+		name := vpcName(v.Tags, m.VPCID)
+		out = append(out, awsdiscover.MakeImportedResource(
+			book,
+			"aws_vpc",
+			name,
+			m.VPCID,
+			region,
+			args.AccountID,
+			map[string]string{
+				"vpc_id":     m.VPCID,
+				"cidr_block": aws.ToString(v.CidrBlock),
+			},
+			tags,
+		))
+	}
+	return out, nil
+}
+
+// prepareWorkDir creates a scratch directory under os.TempDir and writes
+// vpc.tfquery.hcl + a per-region providers.tf into it. Returns the path
+// plus a cleanup callback that os.RemoveAll's the dir.
+//
+// Each region gets its own dir so concurrent regional queries don't
+// collide on .terraform plugin state, and so that a half-failed
+// terraform init (network blip) in one region doesn't poison the cache
+// for the next.
+func (d *Discoverer) prepareWorkDir(region string) (string, func(), error) {
+	dir, err := os.MkdirTemp("", "insideout-vpcquery-"+region+"-*")
+	if err != nil {
+		return "", nil, err
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "vpc.tfquery.hcl"), vpcQueryHCL, 0o600); err != nil {
+		os.RemoveAll(dir)
+		return "", nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := providersTmpl.Execute(&buf, struct{ Region string }{Region: region}); err != nil {
+		os.RemoveAll(dir)
+		return "", nil, fmt.Errorf("render providers.tf: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "providers.tf"), buf.Bytes(), 0o600); err != nil {
+		os.RemoveAll(dir)
+		return "", nil, err
+	}
+
+	cleanup := func() { os.RemoveAll(dir) }
+	return dir, cleanup, nil
+}
+
+// queryMatch is one entry parsed from the streaming JSON event log.
+// VPCID is the AWS VPC ID (vpc-XXXXXXXX); DisplayName is the provider's
+// human-friendly label (e.g. "io-foo-prod-vpc-vpc0 (vpc-...)") which we
+// currently ignore — the Name tag from DescribeVpcs is preferred.
+type queryMatch struct {
+	VPCID       string
+	DisplayName string
+}
+
+// listResourceFoundEvent is the subset of the type=list_resource_found
+// JSON envelope this prototype consumes. Schema observed against
+// terraform 1.14.9 + hashicorp/aws 6.44.0:
+//
+//	{
+//	  "type": "list_resource_found",
+//	  "list_resource_found": {
+//	    "address": "list.aws_vpc.all",
+//	    "display_name": "io-foo-prod-vpc (vpc-052c…)",
+//	    "identity": {"account_id": "...", "id": "vpc-…", "region": "..."},
+//	    "identity_version": 0,
+//	    "resource_type": "aws_vpc"
+//	  },
+//	  ...
+//	}
+//
+// Other event types in the stream we ignore: version, list_start,
+// list_complete. The "type" field is the discriminator.
+type listResourceFoundEvent struct {
+	Type             string `json:"type"`
+	ListResourceData struct {
+		Address     string `json:"address"`
+		DisplayName string `json:"display_name"`
+		Identity    struct {
+			AccountID string `json:"account_id"`
+			ID        string `json:"id"`
+			Region    string `json:"region"`
+		} `json:"identity"`
+		ResourceType string `json:"resource_type"`
+	} `json:"list_resource_found"`
+}
+
+// parseQueryEvents walks the newline-delimited JSON event stream produced
+// by `terraform query -json` and extracts every list_resource_found
+// event whose resource_type is aws_vpc. Returns ([]queryMatch, nil) on
+// success.
+//
+// Lines that don't decode as JSON (defensive: future Terraform versions
+// might add framing) are skipped silently. Lines whose type is not
+// list_resource_found are also skipped.
+func parseQueryEvents(stdout []byte) ([]queryMatch, error) {
+	var out []queryMatch
+	scanner := bufio.NewScanner(bytes.NewReader(stdout))
+	// Default scanner buffer (64 KiB) is too small for accounts with
+	// many tags or long display_names — bump to 1 MiB.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var ev listResourceFoundEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			// Tolerate alien event types (e.g. diagnostics with @-prefixed
+			// keys). A malformed line shouldn't kill the whole parse —
+			// the per-line type filter below catches everything we care
+			// about.
+			continue
+		}
+		if ev.Type != "list_resource_found" {
+			continue
+		}
+		if ev.ListResourceData.ResourceType != "aws_vpc" {
+			continue
+		}
+		if ev.ListResourceData.Identity.ID == "" {
+			continue
+		}
+		out = append(out, queryMatch{
+			VPCID:       ev.ListResourceData.Identity.ID,
+			DisplayName: ev.ListResourceData.DisplayName,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan: %w", err)
+	}
+	return out, nil
+}
+
+// ec2TagsToMap converts the EC2 SDK []Tag slice into a string-keyed map.
+// Returns a non-nil empty map when the input is empty so the
+// nil-vs-empty contract holds (#255 / parent vpc.go).
+func ec2TagsToMap(in []ec2types.Tag) map[string]string {
+	out := make(map[string]string, len(in))
+	for _, t := range in {
+		out[aws.ToString(t.Key)] = aws.ToString(t.Value)
+	}
+	return out
+}
+
+// vpcName picks the most useful human-readable name for a VPC: the Name
+// tag if set, otherwise the bare VPC ID. Matches the parent
+// vpc.go::vpcName so prototype output addresses parallel production.
+func vpcName(tags []ec2types.Tag, fallback string) string {
+	for _, t := range tags {
+		if aws.ToString(t.Key) == "Name" {
+			if v := aws.ToString(t.Value); v != "" {
+				return v
+			}
+		}
+	}
+	return fallback
+}
+
+// TerraformBinaryRunner is the production QueryRunner. It looks up
+// `terraform` on $PATH, runs `terraform init -input=false -no-color`
+// once in the workdir, then `terraform query -json -no-color
+// -var project_filter=<…>` and returns the captured stdout.
+//
+// stderr is captured and propagated only on non-zero exit — successful
+// runs throw it away. Both calls inherit the parent process environment
+// so AWS_PROFILE / AWS_REGION / AWS_ACCESS_KEY_ID etc. flow through to
+// the AWS provider as the operator expects.
+type TerraformBinaryRunner struct{}
+
+// Run shells out to `terraform`. Documented constraint: the terraform
+// binary on PATH must be 1.14+. Earlier versions reject the list { }
+// block in vpc.tfquery.hcl at parse time.
+func (TerraformBinaryRunner) Run(ctx context.Context, workDir, region, projectFilter string) ([]byte, error) {
+	bin, err := exec.LookPath("terraform")
+	if err != nil {
+		return nil, fmt.Errorf("terraform not on PATH (require 1.14+): %w", err)
+	}
+
+	// terraform init: idempotent, fast on warm cache. We re-run it per
+	// invocation because the workdir is freshly created.
+	initCmd := exec.CommandContext(ctx, bin, "init", "-input=false", "-no-color")
+	initCmd.Dir = workDir
+	var initErr bytes.Buffer
+	initCmd.Stderr = &initErr
+	if err := initCmd.Run(); err != nil {
+		return nil, fmt.Errorf("terraform init: %w (stderr: %s)", err, strings.TrimSpace(initErr.String()))
+	}
+
+	args := []string{"query", "-json", "-no-color", "-var", "project_filter=" + projectFilter}
+	queryCmd := exec.CommandContext(ctx, bin, args...)
+	queryCmd.Dir = workDir
+	var stdout, stderr bytes.Buffer
+	queryCmd.Stdout = &stdout
+	queryCmd.Stderr = &stderr
+	if err := queryCmd.Run(); err != nil {
+		// Keep stderr in the error so operators see provider auth /
+		// network errors without re-running with verbose flags.
+		return nil, fmt.Errorf("terraform query: %w (stderr: %s)", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+// Sanity check: the embed.FS-backed bytes are non-empty at init time.
+// A missing file would break `go build`, but a zero-byte file would
+// silently pass and produce a confusing runtime error from `terraform
+// init` instead. Crashing here makes the failure obvious.
+func init() {
+	if len(vpcQueryHCL) == 0 {
+		panic("vpcquery: vpc.tfquery.hcl is empty — embed directive broken")
+	}
+	if providersTmplSrc == "" {
+		panic("vpcquery: providers.tf.tmpl is empty — embed directive broken")
+	}
+}
+
+// Compile-time guard: parsing helpers shouldn't return non-nil VPCID for
+// missing identity. The runtime check inside parseQueryEvents enforces
+// this; this assignment exists only to keep the io and exec imports
+// from being elided when the test build trims the binary runner via
+// build tags (future).
+var _ io.Reader = bytes.NewReader(nil)

--- a/cmd/insideout-import/awsdiscover/prototype/vpcquery/vpcquery_test.go
+++ b/cmd/insideout-import/awsdiscover/prototype/vpcquery/vpcquery_test.go
@@ -1,0 +1,433 @@
+package vpcquery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+)
+
+// fakeRunner records the arguments it was called with and returns a
+// caller-provided event stream (or sentinel error). It is the
+// QueryRunner-shaped equivalent of fakeVPCClient in the parent package.
+type fakeRunner struct {
+	stdoutByRegion map[string][]byte
+	calls          []fakeRunnerCall
+	err            error
+}
+
+type fakeRunnerCall struct {
+	WorkDir, Region, Project string
+}
+
+func (f *fakeRunner) Run(_ context.Context, workDir, region, project string) ([]byte, error) {
+	f.calls = append(f.calls, fakeRunnerCall{WorkDir: workDir, Region: region, Project: project})
+	if f.err != nil {
+		return nil, f.err
+	}
+	if b, ok := f.stdoutByRegion[region]; ok {
+		return b, nil
+	}
+	return nil, nil
+}
+
+// fakeVPCClient is a near-copy of the parent package's fakeVPCClient,
+// duplicated here because the parent's is unexported. Returns canned
+// DescribeVpcs pages indexed by call number, or `err` if non-nil.
+type fakeVPCClient struct {
+	pages []ec2.DescribeVpcsOutput
+	calls []ec2.DescribeVpcsInput
+	err   error
+}
+
+func (f *fakeVPCClient) DescribeVpcs(_ context.Context, in *ec2.DescribeVpcsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+	f.calls = append(f.calls, *in)
+	if f.err != nil {
+		return nil, f.err
+	}
+	idx := len(f.calls) - 1
+	if idx >= len(f.pages) {
+		return &ec2.DescribeVpcsOutput{}, nil
+	}
+	return &f.pages[idx], nil
+}
+
+func vpcWithTags(id, cidr string, tags map[string]string) ec2types.Vpc {
+	v := ec2types.Vpc{
+		VpcId:     aws.String(id),
+		CidrBlock: aws.String(cidr),
+	}
+	for k, val := range tags {
+		v.Tags = append(v.Tags, ec2types.Tag{Key: aws.String(k), Value: aws.String(val)})
+	}
+	return v
+}
+
+// listResourceFoundLine builds one terraform-query JSON event line with
+// the given VPC ID. The shape is hand-rolled to match the live
+// terraform 1.14.9 + hashicorp/aws 6.44.0 output observed during the
+// CUST3 smoke (see docs/terraform-query-prototype.md).
+func listResourceFoundLine(t *testing.T, vpcID, accountID, region string) []byte {
+	t.Helper()
+	envelope := map[string]any{
+		"@level":     "info",
+		"@message":   "list.aws_vpc.all: Result found",
+		"@module":    "terraform.ui",
+		"@timestamp": "2026-05-09T15:00:26.155258-07:00",
+		"type":       "list_resource_found",
+		"list_resource_found": map[string]any{
+			"address":      "list.aws_vpc.all",
+			"display_name": vpcID + " display",
+			"identity": map[string]any{
+				"account_id": accountID,
+				"id":         vpcID,
+				"region":     region,
+			},
+			"identity_version": 0,
+			"resource_type":    "aws_vpc",
+		},
+	}
+	b, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return append(b, '\n')
+}
+
+// frameStream concatenates one or more event lines and prepends a
+// version + list_start + appends a list_complete envelope, mimicking
+// the real stream framing.
+func frameStream(t *testing.T, lines ...[]byte) []byte {
+	t.Helper()
+	out := []byte(`{"@level":"info","@message":"Terraform 1.14.9","type":"version"}` + "\n")
+	out = append(out, []byte(`{"@level":"info","type":"list_start","list_start":{"address":"list.aws_vpc.all"}}`+"\n")...)
+	for _, l := range lines {
+		out = append(out, l...)
+	}
+	out = append(out, []byte(`{"@level":"info","type":"list_complete","list_complete":{"address":"list.aws_vpc.all","total":1}}`+"\n")...)
+	return out
+}
+
+// newTestDiscoverer wires a Discoverer with the supplied fake runner +
+// fake VPC client factory. Mirrors how vpc_test.go constructs a
+// vpcDiscoverer with a fake client closure.
+func newTestDiscoverer(runner QueryRunner, perRegion map[string]*fakeVPCClient) *Discoverer {
+	return &Discoverer{
+		runner: runner,
+		new: func(region string) VpcClient {
+			if c, ok := perRegion[region]; ok {
+				return c
+			}
+			return &fakeVPCClient{}
+		},
+	}
+}
+
+func TestDiscover_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	region := "us-east-1"
+	runner := &fakeRunner{stdoutByRegion: map[string][]byte{
+		region: frameStream(t,
+			listResourceFoundLine(t, "vpc-052c72972a11f8677", "031780745048", region),
+			listResourceFoundLine(t, "vpc-0a1b2c3d4e5f60718", "031780745048", region),
+		),
+	}}
+	clients := map[string]*fakeVPCClient{
+		region: {pages: []ec2.DescribeVpcsOutput{
+			{Vpcs: []ec2types.Vpc{
+				vpcWithTags("vpc-052c72972a11f8677", "10.0.0.0/16", map[string]string{"Name": "io-foo-prod-vpc", "Project": "io-foo"}),
+				vpcWithTags("vpc-0a1b2c3d4e5f60718", "10.1.0.0/16", map[string]string{"Project": "io-foo"}),
+			}},
+		}},
+	}
+
+	d := newTestDiscoverer(runner, clients)
+	got, err := d.Discover(context.Background(), awsdiscover.DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{region},
+		AccountID: "031780745048",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+
+	// Same shape contract as parent vpc_test.go::TestVPCDiscover_HappyPath.
+	for _, ir := range got {
+		if ir.Identity.Type != "aws_vpc" {
+			t.Errorf("Type=%q, want aws_vpc", ir.Identity.Type)
+		}
+		if ir.Identity.ImportID == "" {
+			t.Error("ImportID empty")
+		}
+		if ir.Identity.NativeIDs["vpc_id"] == "" {
+			t.Error("NativeIDs[vpc_id] empty")
+		}
+		if ir.Identity.NativeIDs["cidr_block"] == "" {
+			t.Error("NativeIDs[cidr_block] empty")
+		}
+	}
+	// Output is sorted by VPC ID.
+	if got[0].Identity.ImportID != "vpc-052c72972a11f8677" {
+		t.Errorf("first ImportID=%q, want vpc-052c… (sorted)", got[0].Identity.ImportID)
+	}
+	// Name tag wins over the bare VPC ID for NameHint.
+	if got[0].Identity.NameHint != "io-foo-prod-vpc" {
+		t.Errorf("first NameHint=%q, want io-foo-prod-vpc", got[0].Identity.NameHint)
+	}
+	// Fallback for the un-Named VPC.
+	if got[1].Identity.NameHint != "vpc-0a1b2c3d4e5f60718" {
+		t.Errorf("second NameHint=%q, want fallback to VPC ID", got[1].Identity.NameHint)
+	}
+	// Tags propagate.
+	if got[0].Identity.Tags["Project"] != "io-foo" {
+		t.Errorf("Tags[Project]=%q, want io-foo", got[0].Identity.Tags["Project"])
+	}
+}
+
+func TestDiscover_PassesProjectFilterAsVar(t *testing.T) {
+	t.Parallel()
+	runner := &fakeRunner{stdoutByRegion: map[string][]byte{"us-east-1": frameStream(t)}}
+	clients := map[string]*fakeVPCClient{}
+	d := newTestDiscoverer(runner, clients)
+	if _, err := d.Discover(context.Background(), awsdiscover.DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls=%d, want 1", len(runner.calls))
+	}
+	if runner.calls[0].Project != "io-foo" {
+		t.Errorf("runner.calls[0].Project=%q, want io-foo (project_filter must thread through to -var)", runner.calls[0].Project)
+	}
+	if runner.calls[0].Region != "us-east-1" {
+		t.Errorf("runner.calls[0].Region=%q, want us-east-1", runner.calls[0].Region)
+	}
+}
+
+func TestDiscover_EmptyProjectPassesEmptyFilter(t *testing.T) {
+	t.Parallel()
+	runner := &fakeRunner{stdoutByRegion: map[string][]byte{"us-east-1": frameStream(t)}}
+	d := newTestDiscoverer(runner, map[string]*fakeVPCClient{})
+	if _, err := d.Discover(context.Background(), awsdiscover.DiscoverArgs{
+		Project: "", Regions: []string{"us-east-1"}, AccountID: "123",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if runner.calls[0].Project != "" {
+		t.Errorf("runner.calls[0].Project=%q, want empty (admin path: no filter)", runner.calls[0].Project)
+	}
+}
+
+func TestDiscover_PropagatesRunnerError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("terraform init: provider auth failed")
+	runner := &fakeRunner{err: sentinel}
+	d := newTestDiscoverer(runner, map[string]*fakeVPCClient{})
+	_, err := d.Discover(context.Background(), awsdiscover.DiscoverArgs{
+		Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err=%v, want errors.Is(err, sentinel) — wrapper swallowed runner error", err)
+	}
+}
+
+func TestDiscover_PropagatesDescribeVpcsError(t *testing.T) {
+	t.Parallel()
+	region := "us-east-1"
+	runner := &fakeRunner{stdoutByRegion: map[string][]byte{
+		region: frameStream(t, listResourceFoundLine(t, "vpc-052c72972a11f8677", "123", region)),
+	}}
+	sentinel := errors.New("AccessDenied")
+	clients := map[string]*fakeVPCClient{region: {err: sentinel}}
+	d := newTestDiscoverer(runner, clients)
+	_, err := d.Discover(context.Background(), awsdiscover.DiscoverArgs{
+		Project: "io-foo", Regions: []string{region}, AccountID: "123",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err=%v, want errors.Is(err, sentinel) — DescribeVpcs error swallowed", err)
+	}
+}
+
+func TestDiscover_MultiRegionTriggersOneRunnerCallPerRegion(t *testing.T) {
+	t.Parallel()
+	runner := &fakeRunner{stdoutByRegion: map[string][]byte{
+		"us-east-1": frameStream(t, listResourceFoundLine(t, "vpc-east00000000001", "123", "us-east-1")),
+		"eu-west-1": frameStream(t, listResourceFoundLine(t, "vpc-west00000000001", "123", "eu-west-1")),
+	}}
+	clients := map[string]*fakeVPCClient{
+		"us-east-1": {pages: []ec2.DescribeVpcsOutput{
+			{Vpcs: []ec2types.Vpc{vpcWithTags("vpc-east00000000001", "10.0.0.0/16", map[string]string{"Project": "io-foo"})}},
+		}},
+		"eu-west-1": {pages: []ec2.DescribeVpcsOutput{
+			{Vpcs: []ec2types.Vpc{vpcWithTags("vpc-west00000000001", "10.1.0.0/16", map[string]string{"Project": "io-foo"})}},
+		}},
+	}
+	d := newTestDiscoverer(runner, clients)
+	got, err := d.Discover(context.Background(), awsdiscover.DiscoverArgs{
+		Project: "io-foo", Regions: []string{"us-east-1", "eu-west-1"}, AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (one per region)", len(got))
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("runner calls=%d, want 2", len(runner.calls))
+	}
+	if runner.calls[0].Region != "us-east-1" || runner.calls[1].Region != "eu-west-1" {
+		t.Errorf("runner regions=[%s,%s], want [us-east-1,eu-west-1]", runner.calls[0].Region, runner.calls[1].Region)
+	}
+	// Both regions saw a DescribeVpcs (the tag-fetch) round-trip.
+	if len(clients["us-east-1"].calls) == 0 {
+		t.Error("us-east-1 fakeVPCClient never received DescribeVpcs (tag fetch dropped)")
+	}
+	if len(clients["eu-west-1"].calls) == 0 {
+		t.Error("eu-west-1 fakeVPCClient never received DescribeVpcs (tag fetch dropped)")
+	}
+}
+
+func TestDiscover_FiltersByTagSelectors(t *testing.T) {
+	t.Parallel()
+	region := "us-east-1"
+	runner := &fakeRunner{stdoutByRegion: map[string][]byte{
+		region: frameStream(t,
+			listResourceFoundLine(t, "vpc-aaa00000000000001", "123", region),
+			listResourceFoundLine(t, "vpc-bbb00000000000002", "123", region),
+		),
+	}}
+	clients := map[string]*fakeVPCClient{
+		region: {pages: []ec2.DescribeVpcsOutput{{Vpcs: []ec2types.Vpc{
+			vpcWithTags("vpc-aaa00000000000001", "10.0.0.0/16", map[string]string{"Project": "io-foo", "Env": "prod"}),
+			vpcWithTags("vpc-bbb00000000000002", "10.1.0.0/16", map[string]string{"Project": "io-foo", "Env": "dev"}),
+		}}}},
+	}
+	d := newTestDiscoverer(runner, clients)
+	got, err := d.Discover(context.Background(), awsdiscover.DiscoverArgs{
+		Project:      "io-foo",
+		Regions:      []string{region},
+		AccountID:    "123",
+		TagSelectors: []awsdiscover.TagSelector{{Key: "Env", Value: "prod"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (only prod VPC)", len(got))
+	}
+	if got[0].Identity.ImportID != "vpc-aaa00000000000001" {
+		t.Errorf("ImportID=%q, want vpc-aaa…", got[0].Identity.ImportID)
+	}
+}
+
+func TestDiscover_RaceBetweenQueryAndTagFetchSkipsMissing(t *testing.T) {
+	t.Parallel()
+	// Query reports two VPCs, but DescribeVpcs returns only one (the
+	// other was deleted between the calls). The wrapper should skip
+	// the missing one rather than building an Identity with empty
+	// CIDR/tags.
+	region := "us-east-1"
+	runner := &fakeRunner{stdoutByRegion: map[string][]byte{
+		region: frameStream(t,
+			listResourceFoundLine(t, "vpc-aaa00000000000001", "123", region),
+			listResourceFoundLine(t, "vpc-bbb00000000000002", "123", region),
+		),
+	}}
+	clients := map[string]*fakeVPCClient{
+		region: {pages: []ec2.DescribeVpcsOutput{{Vpcs: []ec2types.Vpc{
+			vpcWithTags("vpc-aaa00000000000001", "10.0.0.0/16", nil),
+			// vpc-bbb absent — simulating the deletion race.
+		}}}},
+	}
+	d := newTestDiscoverer(runner, clients)
+	got, err := d.Discover(context.Background(), awsdiscover.DiscoverArgs{
+		Project: "io-foo", Regions: []string{region}, AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (race-deleted VPC dropped)", len(got))
+	}
+}
+
+func TestParseQueryEvents_IgnoresNonListResourceFound(t *testing.T) {
+	t.Parallel()
+	// Stream contains version + list_start + list_complete + a real
+	// list_resource_found. Only the last should produce a queryMatch.
+	stream := frameStream(t, listResourceFoundLine(t, "vpc-052c72972a11f8677", "123", "us-east-1"))
+	matches, err := parseQueryEvents(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("len=%d, want 1 (non-list_resource_found events must be ignored)", len(matches))
+	}
+	if matches[0].VPCID != "vpc-052c72972a11f8677" {
+		t.Errorf("VPCID=%q", matches[0].VPCID)
+	}
+}
+
+func TestParseQueryEvents_TolueratesMalformedLines(t *testing.T) {
+	t.Parallel()
+	// A trailing garbage line shouldn't kill the parse.
+	good := listResourceFoundLine(t, "vpc-052c72972a11f8677", "123", "us-east-1")
+	stream := append(good, []byte("not-json\n")...)
+	matches, err := parseQueryEvents(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Errorf("len=%d, want 1 (garbage line should be skipped)", len(matches))
+	}
+}
+
+func TestParseQueryEvents_FiltersForeignResourceTypes(t *testing.T) {
+	t.Parallel()
+	// A future config might list multiple types in the same query; we
+	// must keep only aws_vpc events.
+	other := []byte(`{"type":"list_resource_found","list_resource_found":{"resource_type":"aws_subnet","identity":{"id":"subnet-deadbeef"},"address":"list.aws_subnet.all"}}` + "\n")
+	good := listResourceFoundLine(t, "vpc-052c72972a11f8677", "123", "us-east-1")
+	stream := append(other, good...)
+	matches, err := parseQueryEvents(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0].VPCID != "vpc-052c72972a11f8677" {
+		t.Errorf("matches=%v, want one aws_vpc match", matches)
+	}
+}
+
+// TestEmbeddedHCLIsParseable is a smoke test: the embedded
+// vpc.tfquery.hcl must contain a `list "aws_vpc"` block. Catches
+// embed-directive misconfigurations that would only surface at
+// `terraform init` time otherwise.
+func TestEmbeddedHCLIsParseable(t *testing.T) {
+	t.Parallel()
+	if !strings.Contains(string(vpcQueryHCL), `list "aws_vpc"`) {
+		t.Errorf("embedded vpc.tfquery.hcl missing `list \"aws_vpc\"` block; embed broken")
+	}
+	if !strings.Contains(string(vpcQueryHCL), "tag:Project") {
+		t.Errorf("embedded vpc.tfquery.hcl missing tag:Project filter — server-side filter wiring broken")
+	}
+}

--- a/docs/terraform-query-prototype.md
+++ b/docs/terraform-query-prototype.md
@@ -1,0 +1,328 @@
+# `terraform query` Prototype — Decision Record
+
+> Tracked by issue [#339](https://github.com/luthersystems/insideout-terraform-presets/issues/339).
+> Code: `cmd/insideout-import/awsdiscover/prototype/vpcquery/`.
+
+## TL;DR
+
+- **Verdict:** **NOT VIABLE as a wholesale replacement**; **partial / hybrid**
+  adoption is technically feasible but not economically attractive at the
+  current `terraform query` feature level.
+- **Recommendation:** **Stay with hand-written discoverers.** Re-evaluate
+  in 2-3 quarters when (a) GCP gets list resources, (b) AWS list-resource
+  schemas widen to expose tags inline, and (c) `terraform query` matures
+  enough to replace identity-only payloads with full attribute payloads
+  (today's stage is "list IDs," not "list-and-describe").
+- **Realistic LOC delta:** ~30-40% per AWS discoverer if migrated, NOT
+  the ~75% the issue hypothesised. The List+filter half of the discoverer
+  shrinks, but the tag-fetch half stays — and the wrapper adds new code
+  (workdir management, JSON event parser, runner shim) that did not exist.
+
+## What was prototyped
+
+Target type: **`aws_vpc`**. Scope: Stage 2a (bulk discover) only.
+
+- `cmd/insideout-import/awsdiscover/prototype/vpcquery/vpc.tfquery.hcl` —
+  the Terraform 1.14 query definition with a server-side `tag:Project`
+  filter routed through a `dynamic` block.
+- `cmd/insideout-import/awsdiscover/prototype/vpcquery/providers.tf.tmpl`
+  — minimal `terraform { required_providers }` + per-region `provider
+  "aws" { region }` rendered into a scratch workdir at runtime.
+- `cmd/insideout-import/awsdiscover/prototype/vpcquery/vpcquery.go` —
+  Go wrapper. Renders the workdir, runs `terraform init` +
+  `terraform query -json`, parses the streaming JSON event stream,
+  fetches tags via the existing `vpcClient` surface, and emits
+  `[]imported.ImportedResource` through the SAME
+  `awsdiscover.MakeImportedResource` path as production (no IR-shape
+  divergence).
+- `cmd/insideout-import/awsdiscover/prototype/vpcquery/vpcquery_test.go`
+  — 12 tests covering happy path, var threading, multi-region, tag
+  selectors, runner-error propagation, DescribeVpcs-error propagation,
+  race-deletion handling, and JSON-stream parsing edge cases. Mirrors
+  the surface of `vpc_test.go`.
+- `cmd/insideout-import/awsdiscover/export_for_prototype.go` — minimal
+  shim exporting `addressBook` and `makeImportedResource` so the
+  prototype shares production's address-generation path.
+
+## Live smoke (CUST3 / 031780745048 / us-east-1)
+
+```text
+$ go run ./cmd/insideout-import/awsdiscover/prototype/vpcquery/cmd/smoke -project=io-oukrhfwhmflf -region=us-east-1
+PRODUCTION: 1 VPCs  [vpc-052c72972a11f8677]
+PROTOTYPE:  1 VPCs  [vpc-052c72972a11f8677]
+PROD[0] Address=aws_vpc.io_oukrhfwhmflf_prod_luthersystems_insideout_vpc_vpc0  Tags=map[Component:insideout Environment:prod ...]
+PROT[0] Address=aws_vpc.io_oukrhfwhmflf_prod_luthersystems_insideout_vpc_vpc0  Tags=map[Component:insideout Environment:prod ...]
+PARITY OK
+```
+
+Address, NameHint, and Tags are byte-identical between paths under the
+project-tag-filtered code path. **Project-scoped parity: confirmed.**
+
+## Findings
+
+### 1. The provider exposes 127 list resources, not full coverage
+
+Confirmed via `terraform providers schema -json` against
+`hashicorp/aws@6.44.0`:
+
+```sh
+$ terraform providers schema -json | jq '.provider_schemas["registry.terraform.io/hashicorp/aws"].list_resource_schemas | length'
+127
+```
+
+But coverage is uneven: 28 of our 36 registered AWS types have a
+list resource. 8 do not (the issue body is correct on this count;
+exact list TBD post-Bundle 4 audit). For the missing 8 we'd still
+hand-write the discoverer — no LOC saved on those.
+
+### 2. List-resource payloads are IDENTITY-ONLY — tags are NOT carried
+
+The `aws_vpc` list-resource schema is:
+
+```json
+{
+  "attributes": { "region": "string", "vpc_ids": "list(string)" },
+  "block_types": { "filter": { "name": "string", "values": "list(string)" } }
+}
+```
+
+The `list_resource_found` event payload carries `identity.{account_id, id, region}`
+plus a cosmetic `display_name` — and **nothing else**. No CIDR, no
+DhcpOptionsId, no tag map.
+
+**Implication for the LOC-savings hypothesis:** the issue assumed
+`terraform query` would absorb both List+filter AND tag fetch. It only
+absorbs the former. Tag fetch (and any other field needed for
+`Identity.NativeIDs` or downstream genconfig) still requires an SDK
+round-trip via `Describe*`. For `aws_vpc` that's `DescribeVpcs(VpcIds=[…])`,
+which is the exact same call the production discoverer already makes —
+so the prototype trades one `DescribeVpcs(Filters=[tag:Project])` call
+for one `terraform init` + `terraform query` + one `DescribeVpcs(VpcIds=[…])`
+call. **Latency goes UP, not down**, until the provider exposes typed
+list-resource payloads (HashiCorp roadmap item; no ETA).
+
+### 3. List-resource semantics differ from raw SDK List
+
+Live observation: with `var.project_filter = ""` (admin/list-all path),
+`terraform query` returned **2 VPCs** (the two project-tagged ones).
+`aws ec2 describe-vpcs --region us-east-1` returned **3 VPCs** — the
+two tagged ones PLUS `vpc-0c00d320f4414c389` (the default VPC,
+`IsDefault=true`).
+
+The AWS provider's `list "aws_vpc"` resource appears to filter out the
+default VPC by default, while `DescribeVpcs` does not. **This is a
+silent behavioral divergence** — without explicit testing it would
+have shipped as "the prototype is missing default VPCs in admin mode."
+
+For the InsideOut import path this is arguably *desirable* (default
+VPCs are usually noise), but it is NOT a parity replacement for
+`DescribeVpcs`. Any migration would need to:
+1. Audit each of the 28 list resources for similar default-filter semantics.
+2. Update the per-type test surface to assert the new behavior is intentional.
+3. Document the divergence in the discoverer's package doc.
+
+This is the kind of gotcha that bites in production months later when
+an operator runs `--project ""` against a brand-new account expecting
+the default VPC and gets nothing.
+
+### 4. Filter primitives map 1:1 to SDK filters
+
+Server-side `tag:Project = <…>` filtering works identically:
+`DescribeVpcsInput.Filters = [{Name: "tag:Project", Values: ["io-foo"]}]`
+↔ `list "aws_vpc" { config { filter { name = "tag:Project" values = ["io-foo"] } } }`.
+
+**This is the one clean win.** Every per-type filter the hand-written
+discoverer assembles can be carried over with no semantic change.
+Server-side filtering keeps the result set small; client-side
+TagSelectors AND-conjunction still happens in Go on the (smaller)
+match set after the tag fetch.
+
+### 5. Pagination is invisible (handled by Terraform)
+
+`terraform query` paginates internally and emits one
+`list_resource_found` event per result. The prototype's parser doesn't
+need to thread a NextToken. **Net win on pagination boilerplate** —
+~5-15 LOC per discoverer (the `paginate*` helper functions in `vpc.go::paginateDescribeVpcs`,
+`sqs.go`, etc.).
+
+### 6. Region scoping requires per-region workdirs (or per-region provider aliases)
+
+The provider's `region` attribute on the list block can override the
+provider config, which means a single `*.tfquery.hcl` could express
+multi-region as `for_each = toset(var.regions)`. But:
+
+- `for_each` on a `list` block is currently unsupported in 1.14
+  (verified during prototype: `An argument named "for_each" is not
+  expected here`).
+- The clean alternative is per-region workdirs (one `terraform init` +
+  one `terraform query` per region), which is what the prototype does.
+- The dirty alternative is per-region provider aliases declared in a
+  single workdir, with one `list` block per region — but this requires
+  rewriting the .tfquery.hcl every time the operator changes
+  `--regions`.
+
+The prototype's per-region-workdir approach matches the production
+multi-region loop semantics (`for _, region := range args.Regions`)
+and trades a small amount of `os.MkdirTemp` overhead for clean
+isolation between regions.
+
+### 7. Errors are stringly-typed
+
+`terraform query` returns non-zero on provider auth failure, network
+errors, and bad var input. The error message is in stderr — there's no
+structured exit-code-to-error-class mapping like the SDK's
+`smithy.APIError`. The wrapper has to do substring matching against
+stderr to distinguish, e.g., `AccessDenied` (operator can fix) from
+`UnauthorizedOperation` (IAM policy gap) from `Throttling` (retry).
+
+This is a regression vs the production discoverer's
+`isEC2APIErrorCode(err, "InvalidVpcID.NotFound")` pattern — tests
+for that code path can't be cleanly mocked in the prototype because
+there's no equivalent typed error to assert on.
+
+### 8. terraform binary becomes a runtime dependency of the importer
+
+Today the importer is a single Go binary; we ship it, operators run it,
+no other tooling required. With this prototype's pattern:
+
+- The importer needs `terraform >= 1.14` on `$PATH` at runtime.
+- The provider must be installed (one-time per workdir, ~150 MB cache).
+- `terraform init` must succeed (network access to
+  `releases.hashicorp.com` and the Terraform Registry, OR a mirror).
+
+For the InsideOut deployment service this is a hard regression. The
+server-side importer runs in a container today — adding terraform +
+plugin cache to that image is a meaningful operational cost, and the
+plugin cache invalidates whenever AWS provider 6.x ships a new minor.
+
+### 9. Test surface is pinnable but lossier
+
+The 12 prototype tests pass and cover all the same scenarios as
+`vpc_test.go`'s 17 tests, but the parser-driven tests are
+**implementation-coupled to the JSON event shape** (which is documented
+as `unstable, may change between Terraform versions` per `terraform query
+-help`). The SDK-coupled tests in `vpc_test.go` are coupled to the
+SDK's typed response shape, which has stricter compatibility
+guarantees.
+
+### 10. drift-fix and dep-chase implications
+
+`terraform query` only addresses **Stage 2a (bulk discover)**. Stages
+**2c1 (dep-chase, ID-by-ID lookup)** and **2c3 (drift-fix)** still need
+SDK access:
+
+- **dep-chase** does single-ID `DiscoverByID` — running `terraform query`
+  per ID is a 5x latency hit (init + query overhead). Stick with SDK.
+- **drift-fix** runs `terraform plan` on the imported config, diffs the
+  result against captured state, and patches the HCL. `terraform query`
+  has no role here.
+
+So the savings hypothesis is bounded to **Stage 2a only**, which is
+~40-50% of each discoverer file's LOC. Combined with finding #2
+(tag fetch stays), realistic savings drop to ~30%.
+
+## LOC delta extrapolated to the 28 covered AWS types
+
+| File | LOC (current) | LOC (estimated tfquery rewrite) | Saved |
+|------|---|---|---|
+| `vpc.go` | 240 | 170 | 70 (29%) |
+| `sqs.go` | 230 (canonical) | ~165 | ~65 (28%) |
+| `lambda.go` | 290 | ~210 | ~80 (28%) |
+| `lb.go` | 260 | ~190 | ~70 (27%) |
+| (24 others, average) | ~200 | ~145 | ~55 each (28%) |
+
+Plus shared overhead: ~250 LOC of new common code (workdir manager,
+JSON event parser shared with all types, runner shim) that doesn't
+exist today.
+
+**Net savings if all 28 migrated: ~28% × ~5,800 LOC = ~1,600 LOC saved,
+offset by ~250 LOC new shared code → ~1,350 LOC net.**
+
+This is real but modest. Compared to the engineering cost of:
+- Adding terraform as a runtime dep of the importer.
+- Auditing 28 list-resource semantics for #3-style divergences.
+- Re-pinning 28 test surfaces against an unstable JSON shape.
+- Continuing to maintain the 8 hand-written discoverers for types
+  without list resources.
+
+…the ROI is poor. Hand-written discoverers are well-understood,
+type-safe, and have no runtime dep on a separate tool.
+
+## GCP gap
+
+The Google provider has shipped **zero list resources** as of
+hashicorp/google 7.x. Even if InsideOut migrated all 28 covered AWS
+types to `terraform query`, the GCP discoverers (currently identical
+in shape to the AWS ones) would stay 100% hand-written. We'd be
+maintaining two architectures.
+
+This argues strongly for **either** "stay hand-written" **or** "wait
+for GCP parity before migrating AWS." The half-and-half world is
+worse than either extreme.
+
+## Drift-fix and dep-chase implications
+
+(Covered in finding #10 above.) `terraform query` is a Stage 2a tool.
+Stages 2b/2c1/2c3 stay on the SDK regardless.
+
+## Recommendation
+
+**Stay with hand-written discoverers.** Reasons, in priority order:
+
+1. **The savings hypothesis was wrong.** Tags aren't carried by list
+   resources, so we don't get to drop the tag-fetch path. Realistic
+   savings are ~28% per file, not 75%.
+2. **Operational regression.** Adding terraform as a runtime dep of
+   the importer is a meaningful cost for the deployment service.
+3. **Behavioral surprises** (default-VPC filter, finding #3) require
+   per-type audits that are the exact same labor as just maintaining
+   the hand-written discoverer.
+4. **GCP gap.** No list resources mean the GCP discoverers stay
+   hand-written. Half-and-half architecture is worse than either
+   extreme.
+5. **Error semantics regression.** Stringly-typed errors are worse than
+   `smithy.APIError`-based typed assertions for production debugging.
+
+**Re-evaluate when:**
+
+- AWS provider list resources start carrying typed payloads (tags,
+  CIDR, etc.) inline — tracked upstream as
+  [hashicorp/terraform-provider-aws#33996](https://github.com/hashicorp/terraform-provider-aws/issues/33996)-style
+  RFCs (no concrete issue today; check after AWS provider 7.0).
+- Google provider ships list resources for ≥10 of our covered GCP
+  types.
+- `terraform query` JSON output stabilizes and gets a backward-
+  compatibility commitment.
+
+Until then, the prototype lives at
+`cmd/insideout-import/awsdiscover/prototype/vpcquery/` as a
+reference. The export shim
+`cmd/insideout-import/awsdiscover/export_for_prototype.go` is
+preserved alongside it and should be deleted in the same PR that
+deletes the prototype, if/when we abandon the approach formally.
+
+## How to re-run the smoke
+
+```sh
+# 1. terraform 1.14+ on PATH
+tfenv install 1.14.9
+tfenv use 1.14.9
+
+# 2. AWS creds for CUST3 (031780745048)
+aws_jump cust3 dev   # or whatever your role-assumption tool is
+
+# 3. Run the smoke driver
+cd /path/to/insideout-terraform-presets
+go run ./cmd/insideout-import/awsdiscover/prototype/vpcquery/cmd/smoke -project=io-oukrhfwhmflf -region=us-east-1
+
+# Expected output:
+# PRODUCTION: 1 VPCs  [vpc-052c72972a11f8677]
+# PROTOTYPE:  1 VPCs  [vpc-052c72972a11f8677]
+# PARITY OK
+```
+
+The unit tests have no external dependency:
+
+```sh
+go test ./cmd/insideout-import/awsdiscover/prototype/vpcquery/...
+```

--- a/docs/terraform-query-prototype.md
+++ b/docs/terraform-query-prototype.md
@@ -301,6 +301,28 @@ reference. The export shim
 preserved alongside it and should be deleted in the same PR that
 deletes the prototype, if/when we abandon the approach formally.
 
+## Alternatives considered (no public Go SDK exists)
+
+A natural follow-up question: rather than shelling out to the
+`terraform` binary (finding #8), can we invoke `terraform query`
+in-process via a Go library? Short answer: **no**, and the
+architectures that *would* avoid the binary don't change the
+verdict.
+
+| Option | Runtime dep | License | Why it's not a fix |
+|---|---|---|---|
+| `github.com/hashicorp/terraform-exec/tfexec` (already in `go.mod`) | `terraform` binary | MPL-2.0 | Just a typed Go wrapper around the CLI — still requires the binary at runtime. The prototype could be migrated to this for ergonomics without changing the rejection. |
+| Embed `github.com/hashicorp/terraform` (CLI source) | none | **BUSL-1.1** since Aug 2023 | Internals are `internal/`-scoped (not exported as a stable API), and BUSL is non-OSS. Embedding into our backend is legally fraught. |
+| Speak provider gRPC directly via `github.com/hashicorp/terraform-plugin-go/tfprotov6` (skip `terraform`, talk to the AWS provider plugin yourself) | `terraform-provider-aws` binary (~80 MB) | MPL-2.0 | Technically possible. Trades one binary dep for a bigger one, plus ~250–500 LOC of plugin-handshake / protocol-version-negotiation / state-encoding scaffolding we'd own forever. **Critically, it does NOT change finding #2 — `ListResource` payloads are identity-only by spec, so the tag-fetch round-trip stays.** That's the architectural ceiling, not a binary-vs-library issue. |
+| `github.com/hashicorp/terraform-provider-aws` as a library | none extra | MPL-2.0 | >95 % of the provider lives under `internal/` and is not importable. Not a viable path. |
+| `github.com/aws/aws-sdk-go-v2` directly | none extra | Apache-2.0 | **What production already does.** |
+
+The "binary as runtime dep" was one of five rejection reasons.
+Eliminating it via gRPC-to-provider would still leave the
+identity-only payload ceiling (the LOC argument), the stringly-typed
+errors, the default-VPC filter divergence, and the zero-GCP-coverage
+gap. None of those are fixed by changing the transport.
+
 ## How to re-run the smoke
 
 ```sh


### PR DESCRIPTION
## Summary

Research prototype (issue #339) demonstrating Terraform 1.14+ `terraform query` against the existing `aws_vpc` discoverer. Adds an OPT-IN parallel path under `cmd/insideout-import/awsdiscover/prototype/vpcquery/`. Production `vpcDiscoverer` at `cmd/insideout-import/awsdiscover/vpc.go` and the registration in `NewAWSDiscovererWithConcurrency` are untouched.

## What landed

- `cmd/insideout-import/awsdiscover/prototype/vpcquery/vpc.tfquery.hcl` — the Terraform 1.14 query definition with a server-side `tag:Project` filter routed through a `dynamic` block.
- `cmd/insideout-import/awsdiscover/prototype/vpcquery/providers.tf.tmpl` — minimal `terraform { required_providers }` + per-region `provider "aws"` rendered into a scratch workdir.
- `cmd/insideout-import/awsdiscover/prototype/vpcquery/vpcquery.go` — Go wrapper. Renders the workdir, runs `terraform init` + `terraform query -json`, parses the streaming JSON event stream, fetches tags via the existing `vpcClient` surface, and emits `[]imported.ImportedResource` through the SAME `awsdiscover.MakeImportedResource` path as production.
- `cmd/insideout-import/awsdiscover/prototype/vpcquery/vpcquery_test.go` — 12 tests covering happy path, var threading, multi-region, tag selectors, runner-error propagation, DescribeVpcs-error propagation, race-deletion handling, and JSON-stream parsing edge cases.
- `cmd/insideout-import/awsdiscover/export_for_prototype.go` — minimal exported shim (`AddressBook`, `MakeImportedResource`) so the prototype shares production's address-generation path.
- `cmd/insideout-import/awsdiscover/prototype/vpcquery/cmd/smoke/main.go` — live-smoke driver that compares production and prototype output against the same account.
- `docs/terraform-query-prototype.md` — full decision record.

## Verdict

**NOT VIABLE as a wholesale replacement.** **Stay with hand-written discoverers.**

Key findings (full detail in `docs/terraform-query-prototype.md`):

1. **List-resource payloads are identity-only** — the `aws_vpc` list schema exposes only `region` / `vpc_ids` / `filter`; the matched event carries `identity.{account_id, id, region}` plus a cosmetic `display_name`. **Tags are not inline**, so the second `DescribeVpcs(VpcIds=[…])` round-trip stays. The 75% LOC savings hypothesised in the issue collapses to ~28% in practice.
2. **Subtle behavioral divergence**: AWS provider's `list "aws_vpc"` excludes default VPCs; raw `DescribeVpcs` does not. Caught only by live smoke with `--project=""` (admin path) — not by unit tests.
3. **terraform binary becomes a runtime dep of the importer** — meaningful operational regression for the deployment service.
4. **Stringly-typed errors** vs `smithy.APIError` typed assertions — regression for `ErrNotFound` / `Throttling` discrimination.
5. **GCP gap is unchanged** — Google provider has zero list resources today, so half of the discoverer fleet would stay hand-written regardless.
6. **Stage 2a only** — `terraform query` does not help dep-chase (single-ID lookups) or drift-fix.

Realistic LOC delta extrapolated to 28 covered AWS types: ~28% × ~5,800 LOC = ~1,600 LOC saved, offset by ~250 LOC new shared code → ~1,350 LOC net. Modest, and offset by the operational-regression and behavioral-audit costs.

## Live smoke (CUST3 / 031780745048 / us-east-1)

```text
PRODUCTION: 1 VPCs  [vpc-052c72972a11f8677]
PROTOTYPE:  1 VPCs  [vpc-052c72972a11f8677]
PARITY OK
```

Address, NameHint, and Tags are byte-identical between paths under the project-tag-filtered code path.

## Test plan

- [x] `go test ./cmd/insideout-import/awsdiscover/...` — 566 tests pass (12 new prototype tests + 554 existing)
- [x] `go vet ./cmd/insideout-import/awsdiscover/...`
- [x] `gofmt -l` clean
- [x] `tests/lint-no-root-only-blocks.sh` — pass (lint scope is `aws/` and `gcp/` only; prototype lives under `cmd/`)
- [x] `tests/lint-shared-no-cloud-providers.sh` — pass
- [x] Live smoke against CUST3 — parity confirmed for project-scoped path; default-VPC divergence documented in decision doc
- [ ] Reviewer to read `docs/terraform-query-prototype.md` and confirm "stay hand-written" recommendation

## Follow-ups (not in this PR)

- **Decision**: close #339 with "stay hand-written" recommendation if reviewers concur. Re-evaluate when AWS list-resource schemas widen to typed payloads, GCP gets list resources, and `terraform query` JSON output stabilises.
- If/when prototype is abandoned formally, delete `cmd/insideout-import/awsdiscover/prototype/`, `cmd/insideout-import/awsdiscover/export_for_prototype.go`, and `docs/terraform-query-prototype.md` in the same PR.

Closes #339 (decision recorded; prototype preserved as reference).