### PR TITLE
review: Bundle 7 — discoverer + genconfig fixups, orphan-import safety net, UX polish (#355)

### DIFF
--- a/cmd/insideout-import/awsdiscover/network_acl.go
+++ b/cmd/insideout-import/awsdiscover/network_acl.go
@@ -49,12 +49,21 @@ func (d *networkACLDiscoverer) ResourceType() string { return "aws_network_acl" 
 // client. Tags are inline on each ec2types.NetworkAcl — no per-resource
 // DescribeTags fetch is needed.
 //
-// Note: each VPC carries one auto-created default NACL (IsDefault=true).
-// Untagged defaults are dropped by the server-side `tag:Project` filter,
-// which is correct: a default NACL cannot be imported standalone — the
-// operator imports rules onto it via aws_network_acl_rule. Project-tagged
-// defaults still come through so the picker surfaces them; the operator
-// can then choose whether to import them.
+// Default NACLs (#357): each VPC carries one auto-created default NACL
+// (IsDefault=true) whose rule set is inherited from the VPC. The AWS
+// provider models these via aws_default_network_acl, NOT
+// aws_network_acl — `terraform plan -generate-config-out` for an
+// aws_network_acl import block targeting a default NACL produces no
+// resource body, which then breaks Stage 2c1 with "Configuration for
+// import target does not exist". InsideOut presets propagate the
+// Project tag to default NACLs via merge(module.x.tags, var.tags),
+// so the server-side tag:Project filter is NOT enough to skip them.
+// We filter IsDefault=true client-side after the describe call.
+//
+// Re-typing defaults as aws_default_network_acl is the "fully correct"
+// alternative but adds a new typed discoverer and a separate import
+// path; deferred until a customer needs default-NACL rule management
+// (today the inherited rule set is the operating contract).
 //
 // Import ID for aws_network_acl is the network-ACL ID (acl-XXXXXXXX).
 func (d *networkACLDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
@@ -91,6 +100,11 @@ func (d *networkACLDiscoverer) Discover(ctx context.Context, args DiscoverArgs) 
 			id := aws.ToString(nacl.NetworkAclId)
 			tags := ec2TagsToMap(nacl.Tags)
 			if !MatchesAll(tags, args.TagSelectors) {
+				continue
+			}
+			// Default NACLs (#357) cannot be modeled as aws_network_acl;
+			// emitting an import block for them breaks Stage 2c1.
+			if aws.ToBool(nacl.IsDefault) {
 				continue
 			}
 			name := vpcName(nacl.Tags, id)

--- a/cmd/insideout-import/awsdiscover/network_acl_test.go
+++ b/cmd/insideout-import/awsdiscover/network_acl_test.go
@@ -149,10 +149,54 @@ func TestNetworkACLDiscover_DefaultNACLSkippedAmongMixedSet(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("len=%d, want 2 (only 2 non-default NACLs survive)", len(got))
 	}
+	// Pin which IDs survive — a mutation that inverted the filter (dropped
+	// non-defaults and kept defaults) would still produce len==2 with
+	// is_default="false" if it happened to leave a coincidental pair.
+	// Asserting the actual IDs catches that class of regression.
+	gotIDs := map[string]bool{}
 	for _, ir := range got {
+		gotIDs[ir.Identity.ImportID] = true
 		if ir.Identity.NativeIDs["is_default"] != "false" {
 			t.Errorf("ImportID=%q is_default=%q; expected only is_default=false NACLs", ir.Identity.ImportID, ir.Identity.NativeIDs["is_default"])
 		}
+	}
+	if !gotIDs["acl-nondefault0001"] || !gotIDs["acl-nondefault0002"] {
+		t.Errorf("expected both non-default NACLs to survive; got %v", gotIDs)
+	}
+	if gotIDs["acl-default0000001"] || gotIDs["acl-default0000002"] {
+		t.Errorf("expected NO default NACLs to survive; got %v", gotIDs)
+	}
+}
+
+// TestNetworkACLDiscoverByID_AcceptsDefaultNACL (#357) pins that
+// DiscoverByID — the dep-chase per-ID lookup path — does NOT apply
+// the IsDefault filter that Discover does. The Discover-side filter
+// is about avoiding orphan import blocks in batch flow; ByID is
+// called for explicit-ID lookups where the caller has already
+// decided to fetch this specific NACL. A future refactor that
+// copy-pasted the `if aws.ToBool(nacl.IsDefault) { continue }`
+// guard into DiscoverByID would break dep-chase for any default NACL
+// that needs to be resolved as a dependency (e.g. attribute reference
+// from a sibling resource). This test pins the contract: ByID
+// surfaces defaults; Discover does not.
+func TestNetworkACLDiscoverByID_AcceptsDefaultNACL(t *testing.T) {
+	t.Parallel()
+	d := &networkACLDiscoverer{new: func(_ string) networkACLClient {
+		return &fakeNetworkACLClient{pages: []ec2.DescribeNetworkAclsOutput{
+			{NetworkAcls: []ec2types.NetworkAcl{
+				networkACLWithTags("acl-default0000001", "vpc-1", true, nil),
+			}},
+		}}
+	}}
+	got, err := d.DiscoverByID(context.Background(), "acl-default0000001", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.ImportID != "acl-default0000001" {
+		t.Errorf("ImportID=%q, want acl-default0000001 (ByID must accept defaults)", got.Identity.ImportID)
+	}
+	if got.Identity.NativeIDs["is_default"] != "true" {
+		t.Errorf("is_default=%q, want \"true\"", got.Identity.NativeIDs["is_default"])
 	}
 }
 

--- a/cmd/insideout-import/awsdiscover/network_acl_test.go
+++ b/cmd/insideout-import/awsdiscover/network_acl_test.go
@@ -52,6 +52,9 @@ func TestNetworkACLDiscover_HappyPath(t *testing.T) {
 				{
 					NetworkAcls: []ec2types.NetworkAcl{
 						networkACLWithTags("acl-09fd2b515b8886254", "vpc-052c72972a11f8677", false, map[string]string{"Name": "io-foo-public-nacl", "Project": "io-foo"}),
+						// Project-tagged default NACL — must be filtered
+						// out (#357) because aws_network_acl cannot model
+						// it. See discoverer doc.
 						networkACLWithTags("acl-0a1b2c3d4e5f60718", "vpc-052c72972a11f8677", true, map[string]string{"Project": "io-foo"}),
 					},
 				},
@@ -62,47 +65,94 @@ func TestNetworkACLDiscover_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (the project-tagged default NACL must be filtered)", len(got))
+	}
+	ir := got[0]
+	if ir.Identity.Type != "aws_network_acl" {
+		t.Errorf("Type=%q, want aws_network_acl", ir.Identity.Type)
+	}
+	if ir.Identity.ImportID != "acl-09fd2b515b8886254" {
+		t.Errorf("ImportID=%q, want acl-09fd2b515b8886254", ir.Identity.ImportID)
+	}
+	if ir.Identity.NameHint != "io-foo-public-nacl" {
+		t.Errorf("NameHint=%q, want io-foo-public-nacl (Name tag)", ir.Identity.NameHint)
+	}
+	if ir.Identity.NativeIDs["network_acl_id"] != "acl-09fd2b515b8886254" {
+		t.Errorf("NativeIDs[network_acl_id]=%q", ir.Identity.NativeIDs["network_acl_id"])
+	}
+	if ir.Identity.NativeIDs["vpc_id"] != "vpc-052c72972a11f8677" {
+		t.Errorf("NativeIDs[vpc_id]=%q", ir.Identity.NativeIDs["vpc_id"])
+	}
+	if ir.Identity.NativeIDs["is_default"] != "false" {
+		t.Errorf("is_default=%q, want \"false\"", ir.Identity.NativeIDs["is_default"])
+	}
+	if ir.Identity.Tags["Project"] != "io-foo" {
+		t.Errorf("Tags[Project]=%q, want io-foo", ir.Identity.Tags["Project"])
+	}
+}
+
+// TestNetworkACLDiscover_SkipsDefaultNACL (#357) covers the
+// project-tagged-default-NACL case in isolation: a default NACL whose
+// Project tag matches the stack must still be filtered out, otherwise
+// Stage 2c1 dies with "Configuration for import target does not exist"
+// because terraform plan -generate-config-out can't emit a body for
+// aws_network_acl on a default NACL (provider models it via
+// aws_default_network_acl).
+func TestNetworkACLDiscover_SkipsDefaultNACL(t *testing.T) {
+	t.Parallel()
+	d := &networkACLDiscoverer{new: func(_ string) networkACLClient {
+		return &fakeNetworkACLClient{
+			pages: []ec2.DescribeNetworkAclsOutput{{
+				NetworkAcls: []ec2types.NetworkAcl{
+					// Only the default NACL is present. It carries the
+					// project tag (InsideOut VPC preset propagates it via
+					// merge(module.x.tags, var.tags)), so the server-side
+					// tag:Project filter would let it through — we rely on
+					// the client-side IsDefault check.
+					networkACLWithTags("acl-default0000001", "vpc-1", true, map[string]string{"Project": "io-foo"}),
+				},
+			}},
+		}
+	}}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("len=%d, want 0 (default NACL must be skipped)", len(got))
+	}
+}
+
+// TestNetworkACLDiscover_DefaultNACLSkippedAmongMixedSet pins the
+// ordering invariant: when both default and non-default NACLs come back
+// from the describe call, only the non-defaults survive — regardless of
+// the order the API returns them in.
+func TestNetworkACLDiscover_DefaultNACLSkippedAmongMixedSet(t *testing.T) {
+	t.Parallel()
+	d := &networkACLDiscoverer{new: func(_ string) networkACLClient {
+		return &fakeNetworkACLClient{
+			pages: []ec2.DescribeNetworkAclsOutput{{
+				NetworkAcls: []ec2types.NetworkAcl{
+					networkACLWithTags("acl-default0000001", "vpc-1", true, map[string]string{"Project": "io-foo"}),
+					networkACLWithTags("acl-nondefault0001", "vpc-1", false, map[string]string{"Project": "io-foo"}),
+					networkACLWithTags("acl-default0000002", "vpc-1", true, map[string]string{"Project": "io-foo"}),
+					networkACLWithTags("acl-nondefault0002", "vpc-1", false, map[string]string{"Project": "io-foo"}),
+				},
+			}},
+		}
+	}}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(got) != 2 {
-		t.Fatalf("len=%d, want 2", len(got))
+		t.Fatalf("len=%d, want 2 (only 2 non-default NACLs survive)", len(got))
 	}
 	for _, ir := range got {
-		if ir.Identity.Type != "aws_network_acl" {
-			t.Errorf("Type=%q, want aws_network_acl", ir.Identity.Type)
+		if ir.Identity.NativeIDs["is_default"] != "false" {
+			t.Errorf("ImportID=%q is_default=%q; expected only is_default=false NACLs", ir.Identity.ImportID, ir.Identity.NativeIDs["is_default"])
 		}
-		if ir.Identity.ImportID == "" {
-			t.Error("ImportID empty")
-		}
-		if ir.Identity.NativeIDs["network_acl_id"] == "" {
-			t.Error("NativeIDs[network_acl_id] empty")
-		}
-		if ir.Identity.NativeIDs["vpc_id"] == "" {
-			t.Error("NativeIDs[vpc_id] empty")
-		}
-		if ir.Identity.NativeIDs["is_default"] == "" {
-			t.Error("NativeIDs[is_default] empty (must be 'true' or 'false')")
-		}
-	}
-	// Sorted by NACL ID; acl-0a1b... sorts before acl-09fd...
-	if got[0].Identity.ImportID != "acl-09fd2b515b8886254" {
-		t.Errorf("first ImportID=%q, want acl-09fd2b515b8886254 (sorted)", got[0].Identity.ImportID)
-	}
-	// Name tag wins over the bare NACL ID for NameHint.
-	if got[0].Identity.NameHint != "io-foo-public-nacl" {
-		t.Errorf("first NameHint=%q, want io-foo-public-nacl (Name tag)", got[0].Identity.NameHint)
-	}
-	// Fallback to NACL ID when no Name tag.
-	if got[1].Identity.NameHint != "acl-0a1b2c3d4e5f60718" {
-		t.Errorf("second NameHint=%q, want fallback to NACL ID", got[1].Identity.NameHint)
-	}
-	// is_default round-trips as a string.
-	if got[0].Identity.NativeIDs["is_default"] != "false" {
-		t.Errorf("first is_default=%q, want \"false\"", got[0].Identity.NativeIDs["is_default"])
-	}
-	if got[1].Identity.NativeIDs["is_default"] != "true" {
-		t.Errorf("second is_default=%q, want \"true\"", got[1].Identity.NativeIDs["is_default"])
-	}
-	if got[0].Identity.Tags["Project"] != "io-foo" {
-		t.Errorf("Tags[Project]=%q, want io-foo", got[0].Identity.Tags["Project"])
 	}
 }
 

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -802,6 +802,27 @@ Exit codes:
 	summaryResources = resources
 	fmt.Fprintf(summaryOut, "wrote %s (%d resource(s) discovered)\n", out, n)
 
+	// Empty-filter-match WARN (#364): if the operator passed a label/
+	// tag filter and zero resources came through, it's almost always a
+	// typo in --project (e.g. "io-foo" instead of "io-fo0") rather than
+	// a genuinely empty scope. Surface it as a hint — the run still
+	// exits 0 (the manifest is on-disk and downstream stages no-op
+	// cleanly on len(resources)==0). Heuristic is intentionally simple:
+	// any --project value with zero discovered resources triggers the
+	// hint. A genuinely empty scope wears the same hint as a typo'd
+	// filter; the cost is one extra line of stderr, which is cheaper
+	// than the ~3 minutes of triage operators spent figuring this out
+	// during the 2026-05-10 smoke. The same UX pattern applies to AWS
+	// (per-service describe with tag:Project=<typo> returns zero).
+	if n == 0 && strings.TrimSpace(*project) != "" {
+		fmt.Fprintf(os.Stderr,
+			"discover: WARN: --project filter %q matched zero resources in the configured scope. "+
+				"If you expected resources to be discovered, double-check the stack prefix "+
+				"(this is the InsideOut --project label/tag value, e.g. \"io-abc1234567\", "+
+				"NOT the cloud account or GCP project ID).\n",
+			*project)
+	}
+
 	// --include-unsupported (#296): broad-enumerate types NOT yet wired
 	// into per-service discoverers and emit them in a parallel
 	// unsupported.json. Soft-fails so a Resource-Explorer-not-configured

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -568,7 +568,10 @@ func TestRunDiscoverWithDeps_NonEmptyResultsSuppressesWARN(t *testing.T) {
 	if rc != discoverExitOK {
 		t.Fatalf("rc=%d, want %d", rc, discoverExitOK)
 	}
-	if strings.Contains(stderr, "matched zero resources") {
+	// "double-check the stack prefix" is distinctive to this WARN
+	// (less collision-prone than the generic "matched zero resources"
+	// substring, which could appear in future unrelated WARN lines).
+	if strings.Contains(stderr, "double-check the stack prefix") {
 		t.Errorf("non-empty result must NOT emit the empty-filter WARN\n--- got ---\n%s", stderr)
 	}
 }

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -522,6 +522,57 @@ func TestRunDiscoverWithDeps_HappyPathWritesManifest(t *testing.T) {
 	}
 }
 
+// TestRunDiscoverWithDeps_EmptyResultsWithProjectFilterEmitsWARN covers
+// #364: when --project is set and zero resources come through, the
+// operator almost always typo'd the stack prefix. Surface a stderr
+// WARN with a concrete "check the stack prefix" hint. The run still
+// exits 0 (the empty manifest is a valid outcome).
+//
+// Not t.Parallel: captureStderr swaps the package-global os.Stderr,
+// which races against other parallel users of stderr.
+func TestRunDiscoverWithDeps_EmptyResultsWithProjectFilterEmitsWARN(t *testing.T) {
+	dir := t.TempDir()
+	agg := &fakeAggregator{out: nil} // zero results
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "io-typoed", "--region", "us-east-1",
+			"--output-dir", dir, "--no-hcl",
+		}, okDeps(agg))
+	})
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want %d (empty manifest is a valid outcome)", rc, discoverExitOK)
+	}
+	if !strings.Contains(stderr, "WARN") || !strings.Contains(stderr, `--project filter "io-typoed"`) {
+		t.Errorf("stderr must contain a WARN naming the project filter\n--- got ---\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "stack prefix") {
+		t.Errorf("stderr must hint at the stack-prefix concept\n--- got ---\n%s", stderr)
+	}
+}
+
+// TestRunDiscoverWithDeps_NonEmptyResultsSuppressesWARN pins the
+// narrowness of the empty-filter WARN. A non-empty result (the
+// happy path) must NOT emit the WARN. A regression that always-warned
+// would noise up every run.
+func TestRunDiscoverWithDeps_NonEmptyResultsSuppressesWARN(t *testing.T) {
+	dir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.alpha")}}
+	var rc int
+	stderr := captureStderr(t, func() {
+		rc = runDiscoverWithDeps([]string{
+			"--provider", "aws", "--project", "io-foo", "--region", "us-east-1",
+			"--output-dir", dir, "--no-hcl",
+		}, okDeps(agg))
+	})
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want %d", rc, discoverExitOK)
+	}
+	if strings.Contains(stderr, "matched zero resources") {
+		t.Errorf("non-empty result must NOT emit the empty-filter WARN\n--- got ---\n%s", stderr)
+	}
+}
+
 func TestRunDiscoverWithDeps_LoadConfigFails(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/cmd/insideout-import/gcpdiscover/searcher.go
+++ b/cmd/insideout-import/gcpdiscover/searcher.go
@@ -134,10 +134,14 @@ func wrapSearchAllError(err error) error {
 	if s, ok := status.FromError(err); ok {
 		switch s.Code() {
 		case codes.Unauthenticated:
+			// %w preserves the gRPC status in the error chain so a
+			// future caller can errors.As(err, &grpcStatus) or
+			// errors.Is against the original. The rendered Error()
+			// output is byte-identical to %v.
 			return fmt.Errorf("search all resources: GCP authentication failed.\n"+
 				"  Application Default Credentials need to be refreshed.\n"+
 				"  Run: gcloud auth application-default login\n"+
-				"  (underlying error: %v)", err)
+				"  (underlying error: %w)", err)
 		case codes.PermissionDenied:
 			// "API … not enabled" is the documented marker the
 			// service-usage service emits when the Cloud Asset API
@@ -148,7 +152,7 @@ func wrapSearchAllError(err error) error {
 				return fmt.Errorf("search all resources: Cloud Asset API is not enabled on the ADC quota project.\n"+
 					"  The Cloud Asset API needs to be enabled on the project that owns the ADC credentials (the ADC quota project), NOT necessarily on the scope project you're searching.\n"+
 					"  Check `gcloud auth application-default print-access-token` and enable cloudasset.googleapis.com on the project the token bills against.\n"+
-					"  (underlying error: %v)", err)
+					"  (underlying error: %w)", err)
 			}
 		}
 	}

--- a/cmd/insideout-import/gcpdiscover/searcher.go
+++ b/cmd/insideout-import/gcpdiscover/searcher.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	asset "cloud.google.com/go/asset/apiv1"
 	"cloud.google.com/go/asset/apiv1/assetpb"
 	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // gcpAssetResult is a flattened view of a Cloud Asset SearchAllResources
@@ -105,10 +108,51 @@ func (s *RealAssetSearcher) SearchAll(ctx context.Context, scope string, assetTy
 			return out, nil
 		}
 		if err != nil {
-			return nil, fmt.Errorf("search all resources: %w", err)
+			return nil, wrapSearchAllError(err)
 		}
 		out = append(out, assetResultFromProto(r))
 	}
+}
+
+// wrapSearchAllError annotates a Cloud Asset SearchAllResources error
+// with operator-actionable hints (#365). Default gRPC error messages
+// for the two common auth-failure modes are unactionable to operators
+// unfamiliar with Google auth internals:
+//
+//   - codes.Unauthenticated (typical body: "invalid_grant / invalid_rapt"
+//     for stale ADC; "could not refresh access token" for an expired
+//     short-lived token). The fix is `gcloud auth application-default
+//     login`.
+//   - codes.PermissionDenied with a "API … not enabled" body. The fix
+//     is to enable Cloud Asset API on the ADC quota project (NOT the
+//     scope project — a subtle gotcha; see GCP smoke notes 2026-05-10).
+//
+// Other error codes pass through with the original message wrapped in
+// the "search all resources" prefix, preserving the existing contract
+// for log-search-based debugging.
+func wrapSearchAllError(err error) error {
+	if s, ok := status.FromError(err); ok {
+		switch s.Code() {
+		case codes.Unauthenticated:
+			return fmt.Errorf("search all resources: GCP authentication failed.\n"+
+				"  Application Default Credentials need to be refreshed.\n"+
+				"  Run: gcloud auth application-default login\n"+
+				"  (underlying error: %v)", err)
+		case codes.PermissionDenied:
+			// "API … not enabled" is the documented marker the
+			// service-usage service emits when the Cloud Asset API
+			// isn't enabled. Match on the substring so we don't
+			// over-claim on every PermissionDenied (which could also
+			// be a missing IAM role on the principal).
+			if strings.Contains(s.Message(), "not enabled") || strings.Contains(s.Message(), "API not enabled") {
+				return fmt.Errorf("search all resources: Cloud Asset API is not enabled on the ADC quota project.\n"+
+					"  The Cloud Asset API needs to be enabled on the project that owns the ADC credentials (the ADC quota project), NOT necessarily on the scope project you're searching.\n"+
+					"  Check `gcloud auth application-default print-access-token` and enable cloudasset.googleapis.com on the project the token bills against.\n"+
+					"  (underlying error: %v)", err)
+			}
+		}
+	}
+	return fmt.Errorf("search all resources: %w", err)
 }
 
 // assetResultFromProto projects a single Cloud Asset SearchAllResources

--- a/cmd/insideout-import/gcpdiscover/searcher_test.go
+++ b/cmd/insideout-import/gcpdiscover/searcher_test.go
@@ -1,10 +1,14 @@
 package gcpdiscover
 
 import (
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/asset/apiv1/assetpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TestAssetResultFromProto_FieldMapping pins the proto→gcpAssetResult
@@ -46,5 +50,105 @@ func TestAssetResultFromProto_NilProtoSafeFields(t *testing.T) {
 	got := assetResultFromProto(&assetpb.ResourceSearchResult{})
 	if got.Name != "" || got.AssetType != "" || got.Project != "" || got.Location != "" || got.Labels != nil {
 		t.Errorf("zero-proto must produce zero result; got %+v", got)
+	}
+}
+
+// TestWrapSearchAllError_UnauthenticatedSuggestsADCRefresh covers
+// #365: the raw gRPC Unauthenticated message ("invalid_grant /
+// invalid_rapt") is unactionable to operators not fluent in Google
+// auth internals. The wrap replaces it with a concrete command to
+// run, preserving the original error in parentheses so log-search
+// still works.
+func TestWrapSearchAllError_UnauthenticatedSuggestsADCRefresh(t *testing.T) {
+	t.Parallel()
+	raw := status.Error(codes.Unauthenticated, `transport: per-RPC creds failed due to error: auth: "invalid_grant" "reauth related error (invalid_rapt)"`)
+	wrapped := wrapSearchAllError(raw)
+	got := wrapped.Error()
+	if !strings.Contains(got, "gcloud auth application-default login") {
+		t.Errorf("wrapped error must contain the ADC-refresh command\n--- got ---\n%s", got)
+	}
+	// Original error message preserved for log search.
+	if !strings.Contains(got, "invalid_rapt") {
+		t.Errorf("original error must be preserved for log search\n--- got ---\n%s", got)
+	}
+	// The wrap is fmt.Errorf with %v — errors.Is should match neither
+	// codes nor the underlying error directly, but the underlying
+	// status error is preserved via the message body.
+	_ = errors.Is // imported to keep the test surface aware of error chains
+}
+
+// TestWrapSearchAllError_PermissionDeniedNotEnabledSuggestsQuotaProject
+// covers the second auth-failure mode: Cloud Asset API not enabled on
+// the ADC quota project. The 2026-05-10 smoke surfaced this as a
+// confusing failure because the user assumed the API needs to be
+// enabled on the scope project (the one they're searching), not the
+// quota project (the one that owns their ADC credentials).
+func TestWrapSearchAllError_PermissionDeniedNotEnabledSuggestsQuotaProject(t *testing.T) {
+	t.Parallel()
+	raw := status.Error(codes.PermissionDenied, "Cloud Asset API has not been used in project foo or it is disabled. API not enabled.")
+	wrapped := wrapSearchAllError(raw)
+	got := wrapped.Error()
+	if !strings.Contains(got, "ADC quota project") {
+		t.Errorf("wrapped error must reference the ADC quota project\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, "cloudasset.googleapis.com") {
+		t.Errorf("wrapped error must name the API to enable\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, "API not enabled") {
+		t.Errorf("original error must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestWrapSearchAllError_PermissionDeniedIAMPassThrough pins the
+// narrowness of the not-enabled wrap: a generic PermissionDenied
+// (e.g. principal lacks cloudasset.assets.searchAllResources) is NOT
+// transformed because the "enable the API" message would be wrong.
+// The original error is wrapped in the default "search all resources"
+// prefix.
+func TestWrapSearchAllError_PermissionDeniedIAMPassThrough(t *testing.T) {
+	t.Parallel()
+	raw := status.Error(codes.PermissionDenied, "User 'sam@example.com' does not have cloudasset.assets.searchAllResources permission on projects/foo.")
+	wrapped := wrapSearchAllError(raw)
+	got := wrapped.Error()
+	if strings.Contains(got, "ADC quota project") {
+		t.Errorf("generic PermissionDenied must NOT trigger the not-enabled wrap\n--- got ---\n%s", got)
+	}
+	if !strings.HasPrefix(got, "search all resources: ") {
+		t.Errorf("default prefix must apply\n--- got ---\n%s", got)
+	}
+}
+
+// TestWrapSearchAllError_OtherCodesPassThrough pins the
+// default-pass-through path. Any non-Unauthenticated /
+// non-PermissionDenied gRPC code (e.g. ResourceExhausted, Internal)
+// gets the original error verbatim — we don't have actionable advice
+// for those, and a wrong wrap would mask real bugs.
+func TestWrapSearchAllError_OtherCodesPassThrough(t *testing.T) {
+	t.Parallel()
+	raw := status.Error(codes.Internal, "internal server error")
+	wrapped := wrapSearchAllError(raw)
+	got := wrapped.Error()
+	if !strings.Contains(got, "internal server error") {
+		t.Errorf("non-auth errors must pass through verbatim\n--- got ---\n%s", got)
+	}
+	if strings.Contains(got, "gcloud auth") || strings.Contains(got, "ADC quota project") {
+		t.Errorf("non-auth errors must NOT trigger auth-wraps\n--- got ---\n%s", got)
+	}
+}
+
+// TestWrapSearchAllError_NonStatusErrorPassThrough pins the
+// non-gRPC-error path. A plain `errors.New("oops")` (not wrapped via
+// status.Error) is not a status, so the type-switch lookup fails and
+// we fall through to the default wrap.
+func TestWrapSearchAllError_NonStatusErrorPassThrough(t *testing.T) {
+	t.Parallel()
+	raw := errors.New("connection refused")
+	wrapped := wrapSearchAllError(raw)
+	got := wrapped.Error()
+	if !strings.Contains(got, "connection refused") {
+		t.Errorf("non-status errors must pass through verbatim\n--- got ---\n%s", got)
+	}
+	if !strings.HasPrefix(got, "search all resources: ") {
+		t.Errorf("default prefix must apply\n--- got ---\n%s", got)
 	}
 }

--- a/cmd/insideout-import/gcpdiscover/searcher_test.go
+++ b/cmd/insideout-import/gcpdiscover/searcher_test.go
@@ -71,10 +71,12 @@ func TestWrapSearchAllError_UnauthenticatedSuggestsADCRefresh(t *testing.T) {
 	if !strings.Contains(got, "invalid_rapt") {
 		t.Errorf("original error must be preserved for log search\n--- got ---\n%s", got)
 	}
-	// The wrap is fmt.Errorf with %v — errors.Is should match neither
-	// codes nor the underlying error directly, but the underlying
-	// status error is preserved via the message body.
-	_ = errors.Is // imported to keep the test surface aware of error chains
+	// %w wrap preserves the gRPC status in the chain: errors.Is
+	// against the original status error returns true. A regression to
+	// %v would break this.
+	if !errors.Is(wrapped, raw) {
+		t.Errorf("errors.Is must reach the wrapped gRPC status error (broken by %%v regression?)")
+	}
 }
 
 // TestWrapSearchAllError_PermissionDeniedNotEnabledSuggestsQuotaProject

--- a/cmd/insideout-import/gcpdiscover/searcher_test.go
+++ b/cmd/insideout-import/gcpdiscover/searcher_test.go
@@ -40,16 +40,32 @@ func TestAssetResultFromProto_FieldMapping(t *testing.T) {
 	}
 }
 
-// TestAssetResultFromProto_NilProtoSafeFields pins the GetX accessor
-// idioms — every proto getter on a nil/zero ResourceSearchResult
-// returns the zero value of its field type. A future refactor that
-// replaced `r.GetName()` with `r.Name` would panic on a nil proto;
-// asserting on a zero-valued proto guards that.
-func TestAssetResultFromProto_NilProtoSafeFields(t *testing.T) {
+// TestAssetResultFromProto_ZeroValueProtoYieldsZeroFields pins the
+// GetX accessor idioms against a zero-valued (non-nil) proto. Every
+// proto getter returns the zero value of its field type, so the
+// flattened gcpAssetResult is zero across the board. A future
+// refactor that replaced `r.GetName()` with `r.Name` would still pass
+// this test (both return "" on a zero-valued proto); the nil-receiver
+// case is covered by TestAssetResultFromProto_NilProtoIsSafe below.
+func TestAssetResultFromProto_ZeroValueProtoYieldsZeroFields(t *testing.T) {
 	t.Parallel()
 	got := assetResultFromProto(&assetpb.ResourceSearchResult{})
 	if got.Name != "" || got.AssetType != "" || got.Project != "" || got.Location != "" || got.Labels != nil {
 		t.Errorf("zero-proto must produce zero result; got %+v", got)
+	}
+}
+
+// TestAssetResultFromProto_NilProtoIsSafe pins the contract that
+// protoc-generated GetX accessors handle a nil receiver — a refactor
+// from `r.GetName()` to `r.Name` would panic here and break dep-chase
+// any time SearchAllResources surfaced a nil row (rare but possible
+// on transient gRPC errors that the iterator surfaces alongside the
+// stream).
+func TestAssetResultFromProto_NilProtoIsSafe(t *testing.T) {
+	t.Parallel()
+	got := assetResultFromProto(nil)
+	if got.Name != "" || got.AssetType != "" || got.Project != "" || got.Location != "" || got.Labels != nil {
+		t.Errorf("nil-proto must produce zero result; got %+v", got)
 	}
 }
 
@@ -122,19 +138,36 @@ func TestWrapSearchAllError_PermissionDeniedIAMPassThrough(t *testing.T) {
 
 // TestWrapSearchAllError_OtherCodesPassThrough pins the
 // default-pass-through path. Any non-Unauthenticated /
-// non-PermissionDenied gRPC code (e.g. ResourceExhausted, Internal)
-// gets the original error verbatim — we don't have actionable advice
-// for those, and a wrong wrap would mask real bugs.
+// non-PermissionDenied gRPC code (Internal, ResourceExhausted,
+// DeadlineExceeded, Unavailable) gets the original error verbatim —
+// we don't have actionable advice for those, and a wrong wrap would
+// mask real bugs. Table-driven so a regression that special-cased
+// (say) ResourceExhausted is caught.
 func TestWrapSearchAllError_OtherCodesPassThrough(t *testing.T) {
 	t.Parallel()
-	raw := status.Error(codes.Internal, "internal server error")
-	wrapped := wrapSearchAllError(raw)
-	got := wrapped.Error()
-	if !strings.Contains(got, "internal server error") {
-		t.Errorf("non-auth errors must pass through verbatim\n--- got ---\n%s", got)
+	cases := []struct {
+		name string
+		code codes.Code
+		msg  string
+	}{
+		{"Internal", codes.Internal, "internal server error"},
+		{"ResourceExhausted", codes.ResourceExhausted, "quota exceeded"},
+		{"DeadlineExceeded", codes.DeadlineExceeded, "context deadline exceeded"},
+		{"Unavailable", codes.Unavailable, "service unavailable"},
 	}
-	if strings.Contains(got, "gcloud auth") || strings.Contains(got, "ADC quota project") {
-		t.Errorf("non-auth errors must NOT trigger auth-wraps\n--- got ---\n%s", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			raw := status.Error(tc.code, tc.msg)
+			wrapped := wrapSearchAllError(raw)
+			got := wrapped.Error()
+			if !strings.Contains(got, tc.msg) {
+				t.Errorf("non-auth errors must pass through verbatim\n--- got ---\n%s", got)
+			}
+			if strings.Contains(got, "gcloud auth") || strings.Contains(got, "ADC quota project") {
+				t.Errorf("non-auth errors must NOT trigger auth-wraps\n--- got ---\n%s", got)
+			}
+		})
 	}
 }
 

--- a/cmd/insideout-import/genconfig/crossref.go
+++ b/cmd/insideout-import/genconfig/crossref.go
@@ -104,13 +104,68 @@ func addIfNew(m map[string]crossRefTarget, k string, v crossRefTarget) {
 	m[k] = v
 }
 
+// crossRefAttrKey identifies a specific (consumer-resource-type,
+// consumer-attribute) pair on which the default crossref reference
+// shape (.id for non-ARN ImportIDs, .arn for ARN-shaped ones, etc.)
+// must be overridden because the provider rejects the default at the
+// schema layer.
+//
+// Example: aws_db_instance.replicate_source_db resolves by default to
+// aws_db_instance.X.id (the source DB's identifier), but the AWS
+// provider enforces "replicate_source_db must be an ARN when
+// db_subnet_group_name is set" — so we force the reference to .arn
+// when this attribute is the consumer. Issue #360.
+type crossRefAttrKey struct {
+	ResourceType string
+	Attribute    string
+}
+
+// crossRefAttrOverrides maps consumer (resource-type, attribute) pairs
+// to the target attribute name (.arn, .url, .self_link, etc.) to use
+// instead of the index's default.
+//
+// The override applies AFTER the literal-match lookup — only attributes
+// whose value already matches a known in-batch identity are rewritten.
+// Existing crossref invariants stand: self-references, non-string
+// literals, and unmatched literals are left untouched.
+//
+// Extending the map: add an entry for any (consumer resource type,
+// attribute) pair whose provider-side validator rejects the default
+// reference shape, and verify the target resource type actually
+// exposes the overridden attribute (every AWS resource exposes .arn).
+var crossRefAttrOverrides = map[crossRefAttrKey]string{
+	// aws_db_instance.replicate_source_db: when db_subnet_group_name is
+	// set on the consumer (the replica), the provider rejects an
+	// identifier-form reference with "replicate_source_db must be an
+	// ARN when db_subnet_group_name is set." The default crossref maps
+	// the source DB's literal identifier to .id; we override to .arn.
+	{ResourceType: "aws_db_instance", Attribute: "replicate_source_db"}: "arn",
+}
+
+// resourceTypeFromAddr returns the TYPE half of a TYPE.NAME resource
+// address, or "" when the address is malformed. Used by crossRefAttrOverrides
+// lookups to key on the consumer resource type.
+func resourceTypeFromAddr(addr string) string {
+	if i := strings.IndexByte(addr, '.'); i > 0 {
+		return addr[:i]
+	}
+	return ""
+}
+
 // rewriteBlockAttrs walks every attribute on the given resource block and,
 // for each one whose expression is a single string literal matching the
 // crossref index, replaces it with a traversal to (Address.Attr). selfAddr
 // is the block's own address — a resource is not allowed to reference
 // itself, so any literal that maps back to selfAddr is left untouched.
+//
+// Per-attribute override (#360): when (selfAddr's resource type, name)
+// has an entry in crossRefAttrOverrides, the index's default Attr is
+// replaced with the override (e.g. .id → .arn) before constructing the
+// traversal. Only fires on already-matched literals — unmatched ones
+// pass through unchanged.
 func rewriteBlockAttrs(blk *hclwrite.Block, idx map[string]crossRefTarget, selfAddr string) {
 	body := blk.Body()
+	selfType := resourceTypeFromAddr(selfAddr)
 	for name, attr := range body.Attributes() {
 		lit, ok := stringLiteralValue(attr)
 		if !ok {
@@ -122,6 +177,12 @@ func rewriteBlockAttrs(blk *hclwrite.Block, idx map[string]crossRefTarget, selfA
 		}
 		if target.Address == selfAddr {
 			continue
+		}
+		// Per-(consumer-type, attribute) override of the default
+		// reference shape. Applies after match, so non-matching
+		// literals are unaffected.
+		if override, ok := crossRefAttrOverrides[crossRefAttrKey{ResourceType: selfType, Attribute: name}]; ok {
+			target.Attr = override
 		}
 		traversal := traversalForRef(target)
 		body.SetAttributeTraversal(name, traversal)

--- a/cmd/insideout-import/genconfig/crossref_test.go
+++ b/cmd/insideout-import/genconfig/crossref_test.go
@@ -198,12 +198,15 @@ func TestApplyCrossRefs_DBInstanceReplicateSourceUsesARN(t *testing.T) {
 	if !strings.Contains(got, "replicate_source_db  = aws_db_instance.io_foo_rds0.arn") {
 		t.Errorf("replicate_source_db must resolve to .arn (per crossRefAttrOverrides), not .id\n--- got ---\n%s", got)
 	}
-	if strings.Contains(got, `"io-foo-rds0"`) && !strings.Contains(got, `identifier           = "io-foo-rds0-replica-1"`) {
-		// The literal "io-foo-rds0" should be gone from
-		// replicate_source_db (replaced by the traversal). It can stay
-		// in identifier — that's the replica's own identifier, not
-		// the source's.
-		// Sanity-check: only the consumer attribute is rewritten.
+	// Sanity: only the consumer attribute is rewritten. The replica's
+	// own `identifier` literal must survive intact, and the
+	// replicate_source_db literal must be gone (replaced by the
+	// traversal).
+	if !strings.Contains(got, `identifier           = "io-foo-rds0-replica-1"`) {
+		t.Errorf("identifier literal must remain intact (only replicate_source_db is rewritten)\n--- got ---\n%s", got)
+	}
+	if strings.Contains(got, `replicate_source_db  = "io-foo-rds0"`) {
+		t.Errorf("replicate_source_db literal must have been replaced by a traversal\n--- got ---\n%s", got)
 	}
 }
 

--- a/cmd/insideout-import/genconfig/crossref_test.go
+++ b/cmd/insideout-import/genconfig/crossref_test.go
@@ -173,6 +173,96 @@ func TestApplyCrossRefs_NoResourcesNoChange(t *testing.T) {
 	}
 }
 
+// TestApplyCrossRefs_DBInstanceReplicateSourceUsesARN pins the
+// per-attribute ARN override (#360). When the consumer's attribute is
+// aws_db_instance.replicate_source_db, the index's default .id target
+// is overridden to .arn — the AWS provider rejects an identifier-form
+// reference with "replicate_source_db must be an ARN when
+// db_subnet_group_name is set."
+func TestApplyCrossRefs_DBInstanceReplicateSourceUsesARN(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_db_instance" "replica" {
+  identifier           = "io-foo-rds0-replica-1"
+  replicate_source_db  = "io-foo-rds0"
+  db_subnet_group_name = "io-foo-rds-subnets"
+}
+`)
+	resources := []imported.ImportedResource{
+		ir("aws_db_instance.io_foo_rds0", "io-foo-rds0", nil),
+	}
+	out, err := applyCrossRefs(in, resources, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "replicate_source_db  = aws_db_instance.io_foo_rds0.arn") {
+		t.Errorf("replicate_source_db must resolve to .arn (per crossRefAttrOverrides), not .id\n--- got ---\n%s", got)
+	}
+	if strings.Contains(got, `"io-foo-rds0"`) && !strings.Contains(got, `identifier           = "io-foo-rds0-replica-1"`) {
+		// The literal "io-foo-rds0" should be gone from
+		// replicate_source_db (replaced by the traversal). It can stay
+		// in identifier — that's the replica's own identifier, not
+		// the source's.
+		// Sanity-check: only the consumer attribute is rewritten.
+	}
+}
+
+// TestApplyCrossRefs_DBInstanceOtherAttrsUseDefault pins the
+// narrowness of the override: only replicate_source_db is escalated to
+// .arn. Other aws_db_instance attributes that match an in-batch
+// identity should resolve to the default .id form.
+func TestApplyCrossRefs_DBInstanceOtherAttrsUseDefault(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_db_instance" "primary" {
+  identifier           = "io-foo-rds0"
+  db_subnet_group_name = "io-foo-rds-subnets"
+}
+`)
+	// A hypothetical case where db_subnet_group_name happens to match
+	// some other in-batch identifier. Synthetic — the real composer
+	// emits db_subnet_group_name = aws_db_subnet_group.X.id via
+	// crossref against a literal string, so this test exercises the
+	// "no override" path.
+	resources := []imported.ImportedResource{
+		ir("aws_db_subnet_group.subnets", "io-foo-rds-subnets", nil),
+	}
+	out, err := applyCrossRefs(in, resources, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "db_subnet_group_name = aws_db_subnet_group.subnets.id") {
+		t.Errorf("db_subnet_group_name must resolve to .id (default), not .arn\n--- got ---\n%s", got)
+	}
+}
+
+// TestApplyCrossRefs_DBInstanceSelfReferenceUntouched pins that the
+// override does not regress the self-reference guard — a replica's
+// replicate_source_db pointing to its OWN identifier (which shouldn't
+// happen in practice, but a misconfigured stack could produce it) is
+// left as a literal.
+func TestApplyCrossRefs_DBInstanceSelfReferenceUntouched(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_db_instance" "rds" {
+  identifier          = "io-foo-rds0"
+  replicate_source_db = "io-foo-rds0"
+}
+`)
+	resources := []imported.ImportedResource{
+		ir("aws_db_instance.rds", "io-foo-rds0", nil),
+	}
+	out, err := applyCrossRefs(in, resources, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// Self-reference guard fires before the override, so the literal
+	// stays as a string.
+	if !strings.Contains(got, `replicate_source_db = "io-foo-rds0"`) {
+		t.Errorf("self-reference must remain a literal\n--- got ---\n%s", got)
+	}
+}
+
 // TestApplyCrossRefs_GCPIsNoOp pins the documented GCP scope: the
 // AWS-shaped ARN/URL crossref rewriter would silently mishandle GCP
 // self-link literals if it ran against google_* resources. ProviderGCP

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -62,8 +62,9 @@ var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_lb_listener":     fixupLBListenerStickinessDurationZero,
 	"aws_lb_target_group": fixupLBTargetGroupProviderQuirks,
 	"aws_vpc_endpoint":    fixupVPCEndpointEmptyDNSDomains,
-	"aws_db_instance":     fixupDBInstanceProviderQuirks,
+	"aws_db_instance":           fixupDBInstanceProviderQuirks,
 	"aws_secretsmanager_secret": fixupSecretsManagerSecretDefaults,
+	"google_compute_firewall":   fixupComputeFirewallEmptySourceTargetArrays,
 }
 
 // lambdaPlaceholderFile is what we set `filename` to so the block
@@ -542,6 +543,38 @@ func fixupSecretsManagerSecretDefaults(blk *hclwrite.Block) {
 	}
 	if isAttrLiteralNull(body, "recovery_window_in_days") {
 		body.SetAttributeValue("recovery_window_in_days", cty.NumberIntVal(30))
+	}
+}
+
+// fixupComputeFirewallEmptySourceTargetArrays is the first GCP-side
+// entry in resourceTypeFixups. terraform plan -generate-config-out
+// emits all four source/target arrays as literal `[]` even when only
+// one of the source pairs is configured:
+//
+//   source_service_accounts = []
+//   source_tags             = []
+//   target_service_accounts = []
+//   target_tags             = []
+//
+// The Google provider rejects the combination — source_service_accounts
+// is mutually-exclusive with source_tags, and target_service_accounts
+// is mutually-exclusive with source_tags (asymmetric on the target
+// side — target_tags is also caught by the cross-validator).
+//
+// Drop any of the four whose emitted value is the empty literal `[]`.
+// Non-empty values (the operator did configure one side of the pair)
+// are preserved. Same family as AWS #338/#343/#348/#351. Issue #363.
+func fixupComputeFirewallEmptySourceTargetArrays(blk *hclwrite.Block) {
+	body := blk.Body()
+	for _, name := range []string{
+		"source_service_accounts",
+		"source_tags",
+		"target_service_accounts",
+		"target_tags",
+	} {
+		if isAttrLiteralEmptyList(body, name) {
+			body.RemoveAttribute(name)
+		}
 	}
 }
 

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -51,17 +51,17 @@ func applyResourceTypeFixups(raw []byte) ([]byte, error) {
 // They must NOT depend on schema metadata — that's already been applied
 // by cleanGenerated.
 var resourceTypeFixups = map[string]func(*hclwrite.Block){
-	"aws_lambda_function": fixupLambdaSource,
-	"aws_kms_key":         fixupKMSRotationPeriodZero,
-	"aws_dynamodb_table":  fixupDynamoDBPITRRecoveryPeriodZero,
-	"aws_vpc":             fixupVPCIPv6NetmaskOrphan,
-	"aws_lb":              fixupLBSubnetMappingConflict,
-	"aws_subnet":          fixupSubnetProviderQuirks,
-	"aws_route_table":     fixupRouteTableEmptyRouteFields,
-	"aws_nat_gateway":     fixupNATGatewaySecondaryIPConflict,
-	"aws_lb_listener":     fixupLBListenerStickinessDurationZero,
-	"aws_lb_target_group": fixupLBTargetGroupProviderQuirks,
-	"aws_vpc_endpoint":    fixupVPCEndpointEmptyDNSDomains,
+	"aws_lambda_function":       fixupLambdaSource,
+	"aws_kms_key":               fixupKMSRotationPeriodZero,
+	"aws_dynamodb_table":        fixupDynamoDBPITRRecoveryPeriodZero,
+	"aws_vpc":                   fixupVPCIPv6NetmaskOrphan,
+	"aws_lb":                    fixupLBSubnetMappingConflict,
+	"aws_subnet":                fixupSubnetProviderQuirks,
+	"aws_route_table":           fixupRouteTableEmptyRouteFields,
+	"aws_nat_gateway":           fixupNATGatewaySecondaryIPConflict,
+	"aws_lb_listener":           fixupLBListenerStickinessDurationZero,
+	"aws_lb_target_group":       fixupLBTargetGroupProviderQuirks,
+	"aws_vpc_endpoint":          fixupVPCEndpointEmptyDNSDomains,
 	"aws_db_instance":           fixupDBInstanceProviderQuirks,
 	"aws_secretsmanager_secret": fixupSecretsManagerSecretDefaults,
 	"google_compute_firewall":   fixupComputeFirewallEmptySourceTargetArrays,
@@ -551,10 +551,10 @@ func fixupSecretsManagerSecretDefaults(blk *hclwrite.Block) {
 // emits all four source/target arrays as literal `[]` even when only
 // one of the source pairs is configured:
 //
-//   source_service_accounts = []
-//   source_tags             = []
-//   target_service_accounts = []
-//   target_tags             = []
+//	source_service_accounts = []
+//	source_tags             = []
+//	target_service_accounts = []
+//	target_tags             = []
 //
 // The Google provider rejects the combination — source_service_accounts
 // is mutually-exclusive with source_tags, and target_service_accounts

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -62,6 +62,7 @@ var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_lb_listener":     fixupLBListenerStickinessDurationZero,
 	"aws_lb_target_group": fixupLBTargetGroupProviderQuirks,
 	"aws_vpc_endpoint":    fixupVPCEndpointEmptyDNSDomains,
+	"aws_db_instance":     fixupDBInstanceProviderQuirks,
 }
 
 // lambdaPlaceholderFile is what we set `filename` to so the block
@@ -472,6 +473,41 @@ func fixupLBTargetGroupProviderQuirks(blk *hclwrite.Block) {
 				body.RemoveBlock(sub)
 			}
 		}
+	}
+}
+
+// fixupDBInstanceProviderQuirks resolves two terraform-provider-aws
+// schema constraints that `terraform plan -generate-config-out` emits
+// in violation of:
+//
+//   - domain_dns_ips = [] (provider rejects empty literal; the schema's
+//     MinItems=2 list requires either 0 or 2+ items, and 0 must mean
+//     "attribute absent", not "empty list"). generate-config-out emits
+//     `[]` for every aws_db_instance that has no AD-domain auth
+//     configured. Drop the empty literal. Issue #358.
+//   - db_name and username set on a read replica (replicate_source_db
+//     has a usable value). Both attrs are source-inherited on a replica
+//     and the provider marks them mutually-exclusive with
+//     replicate_source_db. generate-config-out doesn't honor that
+//     constraint when emitting the replica's body. Drop both attrs
+//     when the row is a replica. Issue #359.
+//
+// Conservative: each transform fires only on its specific orphan
+// pattern. A real Domain-auth DB carrying a populated domain_dns_ips
+// is preserved; a standalone (non-replica) DB carrying db_name and
+// username is preserved.
+func fixupDBInstanceProviderQuirks(blk *hclwrite.Block) {
+	body := blk.Body()
+	// #358 — domain_dns_ips=[] violates MinItems=2 list constraint.
+	if isAttrLiteralEmptyList(body, "domain_dns_ips") {
+		body.RemoveAttribute("domain_dns_ips")
+	}
+	// #359 — db_name and username conflict with replicate_source_db on
+	// read replicas. Source-inherited attributes that the provider
+	// rejects when both sides are set.
+	if hasUsableValue(body, "replicate_source_db") {
+		body.RemoveAttribute("db_name")
+		body.RemoveAttribute("username")
 	}
 }
 

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -63,6 +63,7 @@ var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_lb_target_group": fixupLBTargetGroupProviderQuirks,
 	"aws_vpc_endpoint":    fixupVPCEndpointEmptyDNSDomains,
 	"aws_db_instance":     fixupDBInstanceProviderQuirks,
+	"aws_secretsmanager_secret": fixupSecretsManagerSecretDefaults,
 }
 
 // lambdaPlaceholderFile is what we set `filename` to so the block
@@ -508,6 +509,39 @@ func fixupDBInstanceProviderQuirks(blk *hclwrite.Block) {
 	if hasUsableValue(body, "replicate_source_db") {
 		body.RemoveAttribute("db_name")
 		body.RemoveAttribute("username")
+	}
+}
+
+// fixupSecretsManagerSecretDefaults replaces the literal `null`
+// emitted by `terraform plan -generate-config-out` for two
+// default-rich Optional+Computed attributes with their schema
+// defaults, so the next plan after import is no-op rather than
+// "1 to change":
+//
+//   - force_overwrite_replica_secret = null → false. The provider
+//     marks this write-only; -generate-config-out can't read a real
+//     value back from AWS, so it emits null. The provider's
+//     schema default is false, and on the next plan the diff
+//     "null → false" shows as an in-place update. Pinning false in
+//     generated.tf eliminates the spurious diff.
+//   - recovery_window_in_days = null → 30. AWS API leaves the field
+//     unset on a non-pending-deletion secret, so the provider Reads
+//     nil. The schema default is 30 days, and on the next plan the
+//     diff "null → 30" shows as an in-place update. Pinning 30 in
+//     generated.tf eliminates the spurious diff.
+//
+// Conservative shape: each transform fires only on the literal
+// `null`. A secret deliberately configured with a different
+// recovery_window (e.g. 7 days) preserves -generate-config-out's
+// emitted value because the literal won't be `null`. Same shape as
+// fixupKMSRotationPeriodZero. Issue #361.
+func fixupSecretsManagerSecretDefaults(blk *hclwrite.Block) {
+	body := blk.Body()
+	if isAttrLiteralNull(body, "force_overwrite_replica_secret") {
+		body.SetAttributeValue("force_overwrite_replica_secret", cty.False)
+	}
+	if isAttrLiteralNull(body, "recovery_window_in_days") {
+		body.SetAttributeValue("recovery_window_in_days", cty.NumberIntVal(30))
 	}
 }
 

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -2003,6 +2003,138 @@ func TestFixupDBInstance_NullReplicateSourcePreservesAttrs(t *testing.T) {
 	}
 }
 
+// TestFixupSecretsManagerSecret_ReplacesNullWithSchemaDefault covers
+// #361: terraform plan -generate-config-out emits
+// force_overwrite_replica_secret=null and recovery_window_in_days=null
+// for every aws_secretsmanager_secret, and the next plan after import
+// shows them as "+ false" and "+ 30" — spurious 1-to-change drift.
+// Replacing the nulls with the provider's schema defaults in
+// generated.tf eliminates the diff.
+func TestFixupSecretsManagerSecret_ReplacesNullWithSchemaDefault(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_secretsmanager_secret" "sm" {
+  name                           = "io-foo-sm"
+  force_overwrite_replica_secret = null
+  recovery_window_in_days        = null
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`force_overwrite_replica_secret\s*=\s*false`).MatchString(got) {
+		t.Errorf("force_overwrite_replica_secret must be replaced with false\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`recovery_window_in_days\s*=\s*30`).MatchString(got) {
+		t.Errorf("recovery_window_in_days must be replaced with 30\n--- got ---\n%s", got)
+	}
+	// Other attrs survive.
+	if !regexp.MustCompile(`name\s*=\s*"io-foo-sm"`).MatchString(got) {
+		t.Errorf("name must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupSecretsManagerSecret_PreservesNonNullValues pins the
+// carve-out: a secret deliberately configured with a different
+// recovery_window (e.g. 7 days for a faster purge cycle) preserves
+// the operator-supplied value. Without this guard a mutation that
+// always-rewrote would corrupt deliberate non-default configurations.
+func TestFixupSecretsManagerSecret_PreservesNonNullValues(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_secretsmanager_secret" "sm" {
+  name                           = "io-foo-sm"
+  force_overwrite_replica_secret = true
+  recovery_window_in_days        = 7
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`force_overwrite_replica_secret\s*=\s*true`).MatchString(got) {
+		t.Errorf("force_overwrite_replica_secret=true must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`recovery_window_in_days\s*=\s*7`).MatchString(got) {
+		t.Errorf("recovery_window_in_days=7 must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupSecretsManagerSecret_PartialNullPreservesOther pins
+// independence of the two transforms: one attribute being null while
+// the other is operator-set must replace only the null half.
+func TestFixupSecretsManagerSecret_PartialNullPreservesOther(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "only_force_overwrite_null",
+			body: `force_overwrite_replica_secret = null
+  recovery_window_in_days        = 7`,
+			want: []string{`force_overwrite_replica_secret\s*=\s*false`, `recovery_window_in_days\s*=\s*7`},
+		},
+		{
+			name: "only_recovery_window_null",
+			body: `force_overwrite_replica_secret = true
+  recovery_window_in_days        = null`,
+			want: []string{`force_overwrite_replica_secret\s*=\s*true`, `recovery_window_in_days\s*=\s*30`},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := []byte(`resource "aws_secretsmanager_secret" "sm" {
+  name                           = "io-foo-sm"
+  ` + tc.body + `
+}
+`)
+			out, err := applyResourceTypeFixups(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(out)
+			for _, w := range tc.want {
+				if !regexp.MustCompile(w).MatchString(got) {
+					t.Errorf("missing %q\n--- got ---\n%s", w, got)
+				}
+			}
+		})
+	}
+}
+
+// TestFixupSecretsManagerSecret_OnlyAffectsAWSSecretsManagerSecretBlocks
+// pins resourceTypeFixups keying: a sibling resource type carrying
+// the same attribute names (e.g. a hypothetical type with the same
+// schema shape) is left untouched.
+func TestFixupSecretsManagerSecret_OnlyAffectsAWSSecretsManagerSecretBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_secretsmanager_secret" "sm" {
+  recovery_window_in_days = null
+}
+
+resource "aws_other_resource" "extra" {
+  recovery_window_in_days = null
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// aws_secretsmanager_secret got the fixup.
+	if !regexp.MustCompile(`(?s)resource "aws_secretsmanager_secret" "sm"[^}]*\{[^}]*recovery_window_in_days\s*=\s*30`).MatchString(got) {
+		t.Errorf("aws_secretsmanager_secret's null must be replaced with 30\n--- got ---\n%s", got)
+	}
+	// aws_other_resource left alone.
+	if !regexp.MustCompile(`(?s)resource "aws_other_resource" "extra"[^}]*\{[^}]*recovery_window_in_days\s*=\s*null`).MatchString(got) {
+		t.Errorf("aws_other_resource's null must be preserved (fixup keyed by aws_secretsmanager_secret)\n--- got ---\n%s", got)
+	}
+}
+
 // TestFixupDBInstance_OnlyAffectsAWSDBInstanceBlocks pins
 // resourceTypeFixups keying: a sibling resource type carrying the
 // same attribute names is left untouched.

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -1860,3 +1860,173 @@ resource "aws_iam_policy" "extra" {
 		t.Errorf("aws_iam_policy's empty private_dns_specified_domains must be preserved (fixup keyed by aws_vpc_endpoint)\n--- got ---\n%s", got)
 	}
 }
+
+// TestFixupDBInstance_DropsEmptyDomainDNSIPs covers #358: the
+// MinItems=2 list constraint on domain_dns_ips rejects the literal
+// empty list that generate-config-out emits for every DB instance
+// without AD-domain auth.
+func TestFixupDBInstance_DropsEmptyDomainDNSIPs(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_db_instance" "rds" {
+  identifier     = "io-foo-rds0"
+  engine         = "postgres"
+  instance_class = "db.t3.medium"
+  domain_dns_ips = []
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*domain_dns_ips\s*=`).MatchString(got) {
+		t.Errorf("empty domain_dns_ips must be dropped\n--- got ---\n%s", got)
+	}
+	// Other attrs survive.
+	if !regexp.MustCompile(`identifier\s*=\s*"io-foo-rds0"`).MatchString(got) {
+		t.Errorf("identifier must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupDBInstance_PopulatedDomainDNSIPsPreserved pins the carve-out:
+// a real AD-domain-auth DB carrying domain_dns_ips with two or more
+// entries is preserved untouched.
+func TestFixupDBInstance_PopulatedDomainDNSIPsPreserved(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_db_instance" "rds" {
+  identifier     = "io-foo-rds0"
+  engine         = "sqlserver-se"
+  domain         = "d-1234567890"
+  domain_dns_ips = ["10.0.0.10", "10.0.0.11"]
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`domain_dns_ips\s*=\s*\["10.0.0.10",\s*"10.0.0.11"\]`).MatchString(got) {
+		t.Errorf("populated domain_dns_ips must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupDBInstance_DropsReplicaConflictingAttrs covers #359: when
+// replicate_source_db has a usable (non-null) value, db_name and
+// username are source-inherited and the provider rejects both being
+// set alongside replicate_source_db.
+func TestFixupDBInstance_DropsReplicaConflictingAttrs(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_db_instance" "replica" {
+  identifier          = "io-foo-rds0-replica-1"
+  engine              = "postgres"
+  db_name             = "appdb"
+  username            = "app"
+  replicate_source_db = aws_db_instance.io_foo_rds0.id
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*db_name\s*=`).MatchString(got) {
+		t.Errorf("db_name must be dropped on a replica\n--- got ---\n%s", got)
+	}
+	if regexp.MustCompile(`(?m)^\s*username\s*=`).MatchString(got) {
+		t.Errorf("username must be dropped on a replica\n--- got ---\n%s", got)
+	}
+	// replicate_source_db survives — it's the marker that identified
+	// this row as a replica.
+	if !strings.Contains(got, "replicate_source_db") {
+		t.Errorf("replicate_source_db must be preserved\n--- got ---\n%s", got)
+	}
+	// Other attrs survive.
+	if !regexp.MustCompile(`identifier\s*=\s*"io-foo-rds0-replica-1"`).MatchString(got) {
+		t.Errorf("identifier must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupDBInstance_PrimaryPreservesNameAndUsername pins the
+// carve-out: a primary (non-replica) DB carrying db_name and username
+// is left untouched. Without this guard a mutation that swapped
+// "replicate_source_db usable" for "always" would silently strip
+// db_name/username from every primary.
+func TestFixupDBInstance_PrimaryPreservesNameAndUsername(t *testing.T) {
+	t.Parallel()
+	// replicate_source_db deliberately absent — this body is a primary.
+	in := []byte(`resource "aws_db_instance" "rds" {
+  identifier = "io-foo-rds0"
+  engine     = "postgres"
+  db_name    = "appdb"
+  username   = "app"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`db_name\s*=\s*"appdb"`).MatchString(got) {
+		t.Errorf("db_name must be preserved on a primary\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`username\s*=\s*"app"`).MatchString(got) {
+		t.Errorf("username must be preserved on a primary\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupDBInstance_NullReplicateSourcePreservesAttrs pins the
+// null-vs-usable boundary: terraform plan -generate-config-out emits
+// `replicate_source_db = null` on every primary, and hasUsableValue
+// treats null as "not set" — so db_name / username must be preserved
+// in that case. Without this carve-out an over-eager rewrite would
+// match the null-shaped attr and over-strip primaries.
+func TestFixupDBInstance_NullReplicateSourcePreservesAttrs(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_db_instance" "rds" {
+  identifier          = "io-foo-rds0"
+  engine              = "postgres"
+  db_name             = "appdb"
+  username            = "app"
+  replicate_source_db = null
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`db_name\s*=\s*"appdb"`).MatchString(got) {
+		t.Errorf("db_name must be preserved when replicate_source_db is null\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`username\s*=\s*"app"`).MatchString(got) {
+		t.Errorf("username must be preserved when replicate_source_db is null\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupDBInstance_OnlyAffectsAWSDBInstanceBlocks pins
+// resourceTypeFixups keying: a sibling resource type carrying the
+// same attribute names is left untouched.
+func TestFixupDBInstance_OnlyAffectsAWSDBInstanceBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_db_instance" "rds" {
+  domain_dns_ips = []
+}
+
+resource "aws_other_resource" "extra" {
+  domain_dns_ips = []
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// aws_db_instance got the fixup.
+	if regexp.MustCompile(`(?s)resource "aws_db_instance" "rds"[^}]*\{[^}]*domain_dns_ips\s*=\s*\[\]`).MatchString(got) {
+		t.Errorf("aws_db_instance's empty domain_dns_ips must be dropped\n--- got ---\n%s", got)
+	}
+	// aws_other_resource left alone.
+	if !regexp.MustCompile(`(?s)resource "aws_other_resource" "extra"[^}]*\{[^}]*domain_dns_ips\s*=\s*\[\]`).MatchString(got) {
+		t.Errorf("aws_other_resource's empty domain_dns_ips must be preserved (fixup keyed by aws_db_instance)\n--- got ---\n%s", got)
+	}
+}

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -1905,8 +1905,34 @@ func TestFixupDBInstance_PopulatedDomainDNSIPsPreserved(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := string(out)
-	if !regexp.MustCompile(`domain_dns_ips\s*=\s*\["10.0.0.10",\s*"10.0.0.11"\]`).MatchString(got) {
+	if !regexp.MustCompile(`domain_dns_ips\s*=\s*\["10\.0\.0\.10",\s*"10\.0\.0\.11"\]`).MatchString(got) {
 		t.Errorf("populated domain_dns_ips must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupDBInstance_SingleElementDomainDNSIPsPreserved pins the
+// boundary case: the provider's MinItems=2 constraint rejects 0 AND
+// 1 elements equally, but the fixup is targeted at `[]` only — a
+// 1-element list, while invalid at validate time, isn't the kind of
+// thing -generate-config-out emits (it would emit 0 or N≥2 from the
+// actual AWS state). The fixup must NOT silently rewrite a 1-element
+// list out from under the operator; if a future provider relaxes
+// MinItems to 1 the fixup remains correct. This test pins the
+// "fixup is `==[]`, not `len<2`" semantics.
+func TestFixupDBInstance_SingleElementDomainDNSIPsPreserved(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_db_instance" "rds" {
+  identifier     = "io-foo-rds0"
+  domain_dns_ips = ["10.0.0.10"]
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`domain_dns_ips\s*=\s*\["10\.0\.0\.10"\]`).MatchString(got) {
+		t.Errorf("single-element domain_dns_ips must be preserved (fixup targets `[]` only)\n--- got ---\n%s", got)
 	}
 }
 
@@ -2026,8 +2052,8 @@ func TestFixupSecretsManagerSecret_ReplacesNullWithSchemaDefault(t *testing.T) {
 	if !regexp.MustCompile(`force_overwrite_replica_secret\s*=\s*false`).MatchString(got) {
 		t.Errorf("force_overwrite_replica_secret must be replaced with false\n--- got ---\n%s", got)
 	}
-	if !regexp.MustCompile(`recovery_window_in_days\s*=\s*30`).MatchString(got) {
-		t.Errorf("recovery_window_in_days must be replaced with 30\n--- got ---\n%s", got)
+	if !regexp.MustCompile(`recovery_window_in_days\s*=\s*30\b`).MatchString(got) {
+		t.Errorf("recovery_window_in_days must be replaced with literal 30 (word-boundary; 300 would not satisfy the contract)\n--- got ---\n%s", got)
 	}
 	// Other attrs survive.
 	if !regexp.MustCompile(`name\s*=\s*"io-foo-sm"`).MatchString(got) {
@@ -2081,7 +2107,7 @@ func TestFixupSecretsManagerSecret_PartialNullPreservesOther(t *testing.T) {
 			name: "only_recovery_window_null",
 			body: `force_overwrite_replica_secret = true
   recovery_window_in_days        = null`,
-			want: []string{`force_overwrite_replica_secret\s*=\s*true`, `recovery_window_in_days\s*=\s*30`},
+			want: []string{`force_overwrite_replica_secret\s*=\s*true`, `recovery_window_in_days\s*=\s*30\b`},
 		},
 	}
 	for _, tc := range cases {
@@ -2189,10 +2215,10 @@ func TestFixupComputeFirewall_PreservesPopulatedServiceAccounts(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := string(out)
-	if !regexp.MustCompile(`source_service_accounts\s*=\s*\["worker@io-foo.iam.gserviceaccount.com"\]`).MatchString(got) {
+	if !regexp.MustCompile(`source_service_accounts\s*=\s*\["worker@io-foo\.iam\.gserviceaccount\.com"\]`).MatchString(got) {
 		t.Errorf("populated source_service_accounts must be preserved\n--- got ---\n%s", got)
 	}
-	if !regexp.MustCompile(`target_service_accounts\s*=\s*\["app@io-foo.iam.gserviceaccount.com"\]`).MatchString(got) {
+	if !regexp.MustCompile(`target_service_accounts\s*=\s*\["app@io-foo\.iam\.gserviceaccount\.com"\]`).MatchString(got) {
 		t.Errorf("populated target_service_accounts must be preserved\n--- got ---\n%s", got)
 	}
 	for _, name := range []string{"source_tags", "target_tags"} {
@@ -2204,15 +2230,23 @@ func TestFixupComputeFirewall_PreservesPopulatedServiceAccounts(t *testing.T) {
 
 // TestFixupComputeFirewall_OnlyAffectsGoogleComputeFirewallBlocks pins
 // resourceTypeFixups keying: a sibling resource type carrying the
-// same empty arrays is left untouched.
+// same empty arrays is left untouched. Iterates all four attributes
+// the fixup mutates so a partial-rekey regression (e.g. one of the
+// four still applies to sibling types) is caught.
 func TestFixupComputeFirewall_OnlyAffectsGoogleComputeFirewallBlocks(t *testing.T) {
 	t.Parallel()
 	in := []byte(`resource "google_compute_firewall" "fw" {
-  source_tags = []
+  source_service_accounts = []
+  source_tags             = []
+  target_service_accounts = []
+  target_tags             = []
 }
 
 resource "google_other_resource" "extra" {
-  source_tags = []
+  source_service_accounts = []
+  source_tags             = []
+  target_service_accounts = []
+  target_tags             = []
 }
 `)
 	out, err := applyResourceTypeFixups(in)
@@ -2220,13 +2254,15 @@ resource "google_other_resource" "extra" {
 		t.Fatal(err)
 	}
 	got := string(out)
-	// google_compute_firewall got the fixup.
-	if regexp.MustCompile(`(?s)resource "google_compute_firewall" "fw"[^}]*\{[^}]*source_tags\s*=\s*\[\]`).MatchString(got) {
-		t.Errorf("google_compute_firewall's empty source_tags must be dropped\n--- got ---\n%s", got)
-	}
-	// google_other_resource left alone.
-	if !regexp.MustCompile(`(?s)resource "google_other_resource" "extra"[^}]*\{[^}]*source_tags\s*=\s*\[\]`).MatchString(got) {
-		t.Errorf("google_other_resource's empty source_tags must be preserved (fixup keyed by google_compute_firewall)\n--- got ---\n%s", got)
+	for _, name := range []string{"source_service_accounts", "source_tags", "target_service_accounts", "target_tags"} {
+		// google_compute_firewall got the fixup for each attr.
+		if regexp.MustCompile(`(?s)resource "google_compute_firewall" "fw"[^}]*\{[^}]*` + name + `\s*=\s*\[\]`).MatchString(got) {
+			t.Errorf("google_compute_firewall's empty %s must be dropped\n--- got ---\n%s", name, got)
+		}
+		// google_other_resource left alone for each attr.
+		if !regexp.MustCompile(`(?s)resource "google_other_resource" "extra"[^}]*\{[^}]*` + name + `\s*=\s*\[\]`).MatchString(got) {
+			t.Errorf("google_other_resource's empty %s must be preserved (fixup keyed by google_compute_firewall)\n--- got ---\n%s", name, got)
+		}
 	}
 }
 
@@ -2250,8 +2286,8 @@ resource "aws_other_resource" "extra" {
 	}
 	got := string(out)
 	// aws_secretsmanager_secret got the fixup.
-	if !regexp.MustCompile(`(?s)resource "aws_secretsmanager_secret" "sm"[^}]*\{[^}]*recovery_window_in_days\s*=\s*30`).MatchString(got) {
-		t.Errorf("aws_secretsmanager_secret's null must be replaced with 30\n--- got ---\n%s", got)
+	if !regexp.MustCompile(`(?s)resource "aws_secretsmanager_secret" "sm"[^}]*\{[^}]*recovery_window_in_days\s*=\s*30\b`).MatchString(got) {
+		t.Errorf("aws_secretsmanager_secret's null must be replaced with literal 30 (word-boundary)\n--- got ---\n%s", got)
 	}
 	// aws_other_resource left alone.
 	if !regexp.MustCompile(`(?s)resource "aws_other_resource" "extra"[^}]*\{[^}]*recovery_window_in_days\s*=\s*null`).MatchString(got) {

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -2106,6 +2106,130 @@ func TestFixupSecretsManagerSecret_PartialNullPreservesOther(t *testing.T) {
 	}
 }
 
+// TestFixupComputeFirewall_DropsAllEmptySourceTargetArrays covers
+// #363: every google_compute_firewall produced by `terraform plan
+// -generate-config-out` carries
+// source_service_accounts/source_tags/target_service_accounts/target_tags
+// as literal [], and the Google provider rejects the combination
+// (mutually-exclusive cross-validators). Drop any of the four whose
+// value is [].
+func TestFixupComputeFirewall_DropsAllEmptySourceTargetArrays(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "google_compute_firewall" "fw" {
+  name                    = "io-foo-allow-ssh"
+  network                 = "io-foo-vpc"
+  direction               = "INGRESS"
+  source_ranges           = ["35.235.240.0/20"]
+  source_service_accounts = []
+  source_tags             = []
+  target_service_accounts = []
+  target_tags             = []
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	for _, name := range []string{"source_service_accounts", "source_tags", "target_service_accounts", "target_tags"} {
+		if regexp.MustCompile(`(?m)^\s*` + name + `\s*=`).MatchString(got) {
+			t.Errorf("empty %s must be dropped\n--- got ---\n%s", name, got)
+		}
+	}
+	// source_ranges (non-empty list) survives.
+	if !regexp.MustCompile(`source_ranges\s*=\s*\["35.235.240.0/20"\]`).MatchString(got) {
+		t.Errorf("source_ranges must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupComputeFirewall_PreservesPopulatedSourceTagsAndDropsEmptyServiceAccounts
+// pins the asymmetric carve-out: an operator-configured tag-based
+// firewall preserves source_tags but still drops the unused-and-empty
+// source_service_accounts (which would conflict at validate time).
+func TestFixupComputeFirewall_PreservesPopulatedSourceTagsAndDropsEmptyServiceAccounts(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "google_compute_firewall" "fw" {
+  name                    = "io-foo-allow-ssh"
+  source_tags             = ["bastion"]
+  source_service_accounts = []
+  target_service_accounts = []
+  target_tags             = []
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`source_tags\s*=\s*\["bastion"\]`).MatchString(got) {
+		t.Errorf("populated source_tags must be preserved\n--- got ---\n%s", got)
+	}
+	for _, name := range []string{"source_service_accounts", "target_service_accounts", "target_tags"} {
+		if regexp.MustCompile(`(?m)^\s*` + name + `\s*=`).MatchString(got) {
+			t.Errorf("empty %s must be dropped\n--- got ---\n%s", name, got)
+		}
+	}
+}
+
+// TestFixupComputeFirewall_PreservesPopulatedServiceAccounts pins the
+// reverse case: a service-account-based firewall preserves the
+// service-account attribute and drops the unused-and-empty tag side.
+func TestFixupComputeFirewall_PreservesPopulatedServiceAccounts(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "google_compute_firewall" "fw" {
+  name                    = "io-foo-allow-ssh"
+  source_service_accounts = ["worker@io-foo.iam.gserviceaccount.com"]
+  source_tags             = []
+  target_service_accounts = ["app@io-foo.iam.gserviceaccount.com"]
+  target_tags             = []
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`source_service_accounts\s*=\s*\["worker@io-foo.iam.gserviceaccount.com"\]`).MatchString(got) {
+		t.Errorf("populated source_service_accounts must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`target_service_accounts\s*=\s*\["app@io-foo.iam.gserviceaccount.com"\]`).MatchString(got) {
+		t.Errorf("populated target_service_accounts must be preserved\n--- got ---\n%s", got)
+	}
+	for _, name := range []string{"source_tags", "target_tags"} {
+		if regexp.MustCompile(`(?m)^\s*` + name + `\s*=`).MatchString(got) {
+			t.Errorf("empty %s must be dropped\n--- got ---\n%s", name, got)
+		}
+	}
+}
+
+// TestFixupComputeFirewall_OnlyAffectsGoogleComputeFirewallBlocks pins
+// resourceTypeFixups keying: a sibling resource type carrying the
+// same empty arrays is left untouched.
+func TestFixupComputeFirewall_OnlyAffectsGoogleComputeFirewallBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "google_compute_firewall" "fw" {
+  source_tags = []
+}
+
+resource "google_other_resource" "extra" {
+  source_tags = []
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	// google_compute_firewall got the fixup.
+	if regexp.MustCompile(`(?s)resource "google_compute_firewall" "fw"[^}]*\{[^}]*source_tags\s*=\s*\[\]`).MatchString(got) {
+		t.Errorf("google_compute_firewall's empty source_tags must be dropped\n--- got ---\n%s", got)
+	}
+	// google_other_resource left alone.
+	if !regexp.MustCompile(`(?s)resource "google_other_resource" "extra"[^}]*\{[^}]*source_tags\s*=\s*\[\]`).MatchString(got) {
+		t.Errorf("google_other_resource's empty source_tags must be preserved (fixup keyed by google_compute_firewall)\n--- got ---\n%s", got)
+	}
+}
+
 // TestFixupSecretsManagerSecret_OnlyAffectsAWSSecretsManagerSecretBlocks
 // pins resourceTypeFixups keying: a sibling resource type carrying
 // the same attribute names (e.g. a hypothetical type with the same

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -196,6 +196,32 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		return nil, fmt.Errorf("rewrite generated.tf: %w", err)
 	}
 
+	// Orphan-import safety net (#362): drop any import { to = X.Y }
+	// whose target resource has no body in generated.tf. terraform
+	// plan -generate-config-out occasionally produces no body for a
+	// type it can't render (default singletons modeled by sibling
+	// types, provider gaps, etc.). The orphan would fail Stage 2c1
+	// with "Configuration for import target does not exist"; dropping
+	// it here keeps the rest of the import set running. Captured
+	// orphans are written to imports-skipped.json for traceability
+	// plus a stderr WARN per drop so the operator sees the soft-fail.
+	skipped, err := pruneOrphanImports(opts.Workdir, cleaned)
+	if err != nil {
+		return nil, fmt.Errorf("orphan-import safety net: %w", err)
+	}
+	if len(skipped) > 0 {
+		if _, werr := writeOrphanImportsManifest(opts.Workdir, skipped); werr != nil {
+			// Soft-fail: we already pruned imports.tf successfully;
+			// failure to write the sibling manifest shouldn't block
+			// downstream stages.
+			fmt.Fprintf(os.Stderr, "genconfig: WARN: imports-skipped.json: %v (imports.tf was pruned; continuing)\n", werr)
+		}
+		for _, s := range skipped {
+			fmt.Fprintf(os.Stderr, "genconfig: WARN: dropped orphan import %s (id=%q, reason=%s) — terraform plan -generate-config-out produced no resource body\n",
+				s.Address, s.ImportID, s.Reason)
+		}
+	}
+
 	if err := runner.Validate(ctx); err != nil {
 		return nil, fmt.Errorf("terraform validate: %w", err)
 	}

--- a/cmd/insideout-import/genconfig/orphan_imports.go
+++ b/cmd/insideout-import/genconfig/orphan_imports.go
@@ -1,0 +1,212 @@
+package genconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// orphanImportsFile is the sibling JSON written when one or more
+// import blocks have to be dropped because their target resource has
+// no body in generated.tf. The wire shape mirrors imported.json /
+// unsupported.json — a wrapper object so future metadata (e.g. a
+// "reason" enum, the orphan-source discoverer) can be added without a
+// breaking change.
+const orphanImportsFile = "imports-skipped.json"
+
+// OrphanImport is one dropped import block.
+type OrphanImport struct {
+	// Address is the TYPE.NAME the import block targeted.
+	Address string `json:"address"`
+	// ImportID is the cloud-side identifier the import block carried.
+	// Preserved so callers can re-attempt the import via a corrected
+	// discoverer (or via aws_default_network_acl for the #357 family,
+	// etc.) without re-running discover.
+	ImportID string `json:"import_id"`
+	// Reason is the documented cause. Today the only producer is the
+	// orphan-import safety net (#362) which sets it to
+	// "no_generated_config" — terraform plan -generate-config-out
+	// produced no resource body for the target.
+	Reason string `json:"reason"`
+}
+
+// orphanImportsWrapper is the wire shape for imports-skipped.json.
+type orphanImportsWrapper struct {
+	// Imports is the list of dropped import blocks. Guaranteed
+	// non-nil so JSON marshal emits [] instead of null (parallel to
+	// the #255 nil-vs-empty contract on inspector returns).
+	Imports []OrphanImport `json:"imports"`
+}
+
+// pruneOrphanImports rewrites <workdir>/imports.tf in place, dropping
+// any import block whose `to = TYPE.NAME` target has no matching
+// `resource "TYPE" "NAME" { ... }` block in generated.
+//
+// Background (#362): the F1-class bug — a discoverer emits an import
+// block targeting a resource type that `terraform plan
+// -generate-config-out` cannot render (default singleton, provider
+// gap, type re-modeled into a sibling resource family, etc.) —
+// produces an orphan import that fails Stage 2c1 with
+// "Configuration for import target does not exist".
+//
+// The safety net is a non-fatal post-pass: orphans are dropped from
+// imports.tf, captured in the returned slice, and reported by the
+// caller via stderr WARN + imports-skipped.json. The remaining
+// non-orphan import blocks pass through to Stage 2c1 unchanged.
+//
+// Returns the (possibly empty) slice of dropped imports. Wire-shape
+// guarantee: empty result is the empty slice, never nil — so the
+// caller's JSON serialization produces `{"imports":[]}` not
+// `{"imports":null}`.
+//
+// Errors only on (a) IO failures reading imports.tf, (b) hclwrite
+// parse failures on either file, (c) failure rewriting imports.tf
+// back to disk. A malformed `to = ...` traversal in imports.tf is
+// not fatal — the block is left in place and Stage 2c1 surfaces it.
+func pruneOrphanImports(workdir string, generated []byte) ([]OrphanImport, error) {
+	importsPath := filepath.Join(workdir, importsFile)
+	importsRaw, err := os.ReadFile(importsPath)
+	if err != nil {
+		return nil, fmt.Errorf("read imports.tf: %w", err)
+	}
+	importsAST, diags := hclwrite.ParseConfig(importsRaw, importsFile, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("parse imports.tf: %s", diags.Error())
+	}
+	generatedAST, diags := hclwrite.ParseConfig(generated, generatedFile, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("parse generated.tf: %s", diags.Error())
+	}
+
+	// Index every resource block label-pair in generated.tf.
+	// Membership in this set is what makes an import target "valid".
+	resourceAddrs := map[string]struct{}{}
+	for _, blk := range generatedAST.Body().Blocks() {
+		if blk.Type() != "resource" {
+			continue
+		}
+		labels := blk.Labels()
+		if len(labels) != 2 {
+			continue
+		}
+		resourceAddrs[labels[0]+"."+labels[1]] = struct{}{}
+	}
+
+	skipped := []OrphanImport{}
+	body := importsAST.Body()
+	for _, blk := range body.Blocks() {
+		if blk.Type() != "import" {
+			continue
+		}
+		toAttr := blk.Body().GetAttribute("to")
+		if toAttr == nil {
+			// Malformed import block (no `to = ...`). Leave it for
+			// Stage 2c1 to complain about — we don't fix
+			// malformed-imports.tf here.
+			continue
+		}
+		addr := traversalAddrFromAttr(toAttr)
+		if addr == "" {
+			// Non-traversal expression — same "leave for Stage 2c1"
+			// disposition as the no-`to`-attr case.
+			continue
+		}
+		if _, ok := resourceAddrs[addr]; ok {
+			// Has a matching resource body — not an orphan.
+			continue
+		}
+		// Orphan. Drop the block, capture the import ID for
+		// imports-skipped.json.
+		importID := stringLitFromAttr(blk.Body().GetAttribute("id"))
+		skipped = append(skipped, OrphanImport{
+			Address:  addr,
+			ImportID: importID,
+			Reason:   "no_generated_config",
+		})
+		body.RemoveBlock(blk)
+	}
+
+	if len(skipped) == 0 {
+		// Don't touch imports.tf when there's nothing to drop. Keeps
+		// the byte-stable round-trip property the existing
+		// genconfig_test golden tests rely on.
+		return skipped, nil
+	}
+
+	// Sort deterministically so imports-skipped.json is byte-stable
+	// across runs for the same input.
+	sort.Slice(skipped, func(i, j int) bool {
+		if skipped[i].Address != skipped[j].Address {
+			return skipped[i].Address < skipped[j].Address
+		}
+		return skipped[i].ImportID < skipped[j].ImportID
+	})
+
+	if err := os.WriteFile(importsPath, importsAST.Bytes(), 0o644); err != nil {
+		return nil, fmt.Errorf("rewrite imports.tf: %w", err)
+	}
+	return skipped, nil
+}
+
+// writeOrphanImportsManifest emits the imports-skipped.json sibling.
+// Called only when pruneOrphanImports returned a non-empty slice — an
+// empty file is not written so existing genconfig consumers don't
+// have to learn a "maybe-present" sibling.
+//
+// Wire shape (always with non-nil Imports for JSON safety):
+//
+//	{"imports":[{"address":"aws_network_acl.foo","import_id":"acl-…","reason":"no_generated_config"}, …]}
+func writeOrphanImportsManifest(workdir string, skipped []OrphanImport) (string, error) {
+	if skipped == nil {
+		skipped = []OrphanImport{}
+	}
+	wrapper := orphanImportsWrapper{Imports: skipped}
+	buf, err := json.MarshalIndent(wrapper, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal imports-skipped.json: %w", err)
+	}
+	path := filepath.Join(workdir, orphanImportsFile)
+	if err := os.WriteFile(path, append(buf, '\n'), 0o644); err != nil {
+		return "", fmt.Errorf("write imports-skipped.json: %w", err)
+	}
+	return path, nil
+}
+
+// traversalAddrFromAttr extracts the TYPE.NAME address from an
+// hclwrite Attribute whose expression is the traversal
+// `aws_TYPE.NAME`. Returns "" when the expression is not a
+// two-component traversal — the caller treats that as "leave the
+// import alone".
+func traversalAddrFromAttr(attr *hclwrite.Attribute) string {
+	tokens := attr.Expr().BuildTokens(nil)
+	// Expected token shape: ident DOT ident (3 tokens). Leading/
+	// trailing whitespace tokens are stripped by hclwrite.
+	if len(tokens) != 3 {
+		return ""
+	}
+	if string(tokens[1].Bytes) != "." {
+		return ""
+	}
+	return string(tokens[0].Bytes) + "." + string(tokens[2].Bytes)
+}
+
+// stringLitFromAttr extracts the value of a `name = "string-literal"`
+// attribute. Returns "" for any non-literal expression — the import
+// ID field in imports.tf is always a plain string literal so we don't
+// need to handle traversals or interpolations.
+func stringLitFromAttr(attr *hclwrite.Attribute) string {
+	if attr == nil {
+		return ""
+	}
+	tokens := attr.Expr().BuildTokens(nil)
+	if len(tokens) != 3 {
+		return ""
+	}
+	// tokens: OQuote, QuotedLit, CQuote
+	return string(tokens[1].Bytes)
+}

--- a/cmd/insideout-import/genconfig/orphan_imports_test.go
+++ b/cmd/insideout-import/genconfig/orphan_imports_test.go
@@ -103,33 +103,98 @@ func TestPruneOrphanImports_AllNonOrphanLeavesFileUntouched(t *testing.T) {
 // contract documented in OrphanImport. Empty result must be the
 // empty slice so the JSON wrapper marshals as `{"imports":[]}` not
 // `{"imports":null}` — same contract as #255 inspector returns.
+//
+// Exercises the non-trivial early-return path: a non-empty imports.tf
+// with all imports having matching resource bodies. A mutation that
+// changed the `skipped := []OrphanImport{}` declaration at the top of
+// pruneOrphanImports to `var skipped []OrphanImport` would make the
+// early return at len==0 yield a nil slice (still len==0 but nil)
+// and break the JSON contract. The empty-input version of this test
+// would not catch that — both branches of the regression produce
+// length 0 — but a non-empty-input version forces the code through
+// the loop AND the early return, pinning the slice declaration.
 func TestPruneOrphanImports_ReturnsEmptySliceNotNil(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, importsFile), []byte(``), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, importsFile), []byte(`import {
+  to = aws_vpc.main
+  id = "vpc-123"
+}
+`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	skipped, err := pruneOrphanImports(dir, []byte(``))
+	generated := []byte(`resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+`)
+	skipped, err := pruneOrphanImports(dir, generated)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if skipped == nil {
-		t.Fatal("skipped is nil; want empty slice")
+		t.Fatal("skipped is nil; want empty slice (the JSON wrapper relies on non-nil for `[]` not `null`)")
 	}
 	if len(skipped) != 0 {
 		t.Fatalf("len(skipped)=%d, want 0", len(skipped))
 	}
 }
 
+// TestPruneOrphanImports_OrphanWithMissingIDEmitsEmptyImportID pins
+// the production-code contract that an orphan import block with no
+// `id = "..."` attribute is dropped but emits ImportID="". A
+// regression making stringLitFromAttr panic on a nil attribute would
+// be caught here — the orphan import has a `to` (so it gets
+// classified as orphan) but no `id` (so stringLitFromAttr returns "").
+func TestPruneOrphanImports_OrphanWithMissingIDEmitsEmptyImportID(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, importsFile), []byte(`import {
+  to = aws_network_acl.default_nacl
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skipped, err := pruneOrphanImports(dir, []byte(``))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("len(skipped)=%d, want 1", len(skipped))
+	}
+	if skipped[0].Address != "aws_network_acl.default_nacl" {
+		t.Errorf("Address=%q", skipped[0].Address)
+	}
+	if skipped[0].ImportID != "" {
+		t.Errorf("ImportID=%q, want \"\" (missing id attribute)", skipped[0].ImportID)
+	}
+	if skipped[0].Reason != "no_generated_config" {
+		t.Errorf("Reason=%q", skipped[0].Reason)
+	}
+}
+
 // TestPruneOrphanImports_MultipleOrphansSortedDeterministically pins
 // the byte-stable wire shape of imports-skipped.json — the slice is
 // sorted by (Address, ImportID) so consumers can diff successive runs.
+//
+// Runs the same orphan set twice with input ordering reversed,
+// verifying the output is identical. This proves determinism, not
+// just one example of correct sorting.
 func TestPruneOrphanImports_MultipleOrphansSortedDeterministically(t *testing.T) {
 	t.Parallel()
-	dir := t.TempDir()
-	// Intentional unsorted order in imports.tf — the prune should
-	// re-sort.
-	if err := os.WriteFile(filepath.Join(dir, importsFile), []byte(`import {
+	// Sort key: (Address, ImportID). aws_a_resource.first/a-1 sorts
+	// before aws_a_resource.first/a-2 sorts before aws_z_resource.last.
+	wants := []struct{ addr, id string }{
+		{"aws_a_resource.first", "a-1"},
+		{"aws_a_resource.first", "a-2"},
+		{"aws_z_resource.last", "z-1"},
+	}
+	cases := []struct {
+		name    string
+		imports string
+	}{
+		{
+			name: "unsorted_z_first",
+			imports: `import {
   to = aws_z_resource.last
   id = "z-1"
 }
@@ -143,28 +208,48 @@ import {
   to = aws_a_resource.first
   id = "a-1"
 }
-`), 0o644); err != nil {
-		t.Fatal(err)
+`,
+		},
+		{
+			name: "reverse_unsorted_a_first",
+			imports: `import {
+  to = aws_a_resource.first
+  id = "a-1"
+}
+
+import {
+  to = aws_a_resource.first
+  id = "a-2"
+}
+
+import {
+  to = aws_z_resource.last
+  id = "z-1"
+}
+`,
+		},
 	}
-	skipped, err := pruneOrphanImports(dir, []byte(``))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(skipped) != 3 {
-		t.Fatalf("len(skipped)=%d, want 3", len(skipped))
-	}
-	// Sort key: (Address, ImportID). aws_a_resource.first/a-1 sorts
-	// before aws_a_resource.first/a-2 sorts before aws_z_resource.last.
-	wants := []struct{ addr, id string }{
-		{"aws_a_resource.first", "a-1"},
-		{"aws_a_resource.first", "a-2"},
-		{"aws_z_resource.last", "z-1"},
-	}
-	for i, w := range wants {
-		if skipped[i].Address != w.addr || skipped[i].ImportID != w.id {
-			t.Errorf("skipped[%d]=(%q, %q), want (%q, %q)",
-				i, skipped[i].Address, skipped[i].ImportID, w.addr, w.id)
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, importsFile), []byte(tc.imports), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			skipped, err := pruneOrphanImports(dir, []byte(``))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(skipped) != len(wants) {
+				t.Fatalf("len(skipped)=%d, want %d", len(skipped), len(wants))
+			}
+			for i, w := range wants {
+				if skipped[i].Address != w.addr || skipped[i].ImportID != w.id {
+					t.Errorf("skipped[%d]=(%q, %q), want (%q, %q)",
+						i, skipped[i].Address, skipped[i].ImportID, w.addr, w.id)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/insideout-import/genconfig/orphan_imports_test.go
+++ b/cmd/insideout-import/genconfig/orphan_imports_test.go
@@ -1,0 +1,296 @@
+package genconfig
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPruneOrphanImports_DropsOrphan covers the canonical F1-class
+// (#357 / #362) case: imports.tf has an import block whose target
+// type+name has no matching resource block in generated.tf, so the
+// import is dropped and surfaces in the returned slice.
+func TestPruneOrphanImports_DropsOrphan(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, importsFile), []byte(`import {
+  to = aws_vpc.main
+  id = "vpc-123"
+}
+
+import {
+  to = aws_network_acl.default_nacl
+  id = "acl-deadbeef"
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	generated := []byte(`resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+`)
+
+	skipped, err := pruneOrphanImports(dir, generated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("len(skipped)=%d, want 1", len(skipped))
+	}
+	got := skipped[0]
+	if got.Address != "aws_network_acl.default_nacl" {
+		t.Errorf("Address=%q, want aws_network_acl.default_nacl", got.Address)
+	}
+	if got.ImportID != "acl-deadbeef" {
+		t.Errorf("ImportID=%q, want acl-deadbeef", got.ImportID)
+	}
+	if got.Reason != "no_generated_config" {
+		t.Errorf("Reason=%q, want no_generated_config", got.Reason)
+	}
+	// imports.tf was rewritten — the orphan is gone, the survivor remains.
+	rewritten, err := os.ReadFile(filepath.Join(dir, importsFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rewrittenStr := string(rewritten)
+	if !strings.Contains(rewrittenStr, "aws_vpc.main") {
+		t.Errorf("non-orphan import must survive\n--- got ---\n%s", rewrittenStr)
+	}
+	if strings.Contains(rewrittenStr, "aws_network_acl.default_nacl") {
+		t.Errorf("orphan import must be dropped\n--- got ---\n%s", rewrittenStr)
+	}
+}
+
+// TestPruneOrphanImports_AllNonOrphanLeavesFileUntouched pins the
+// byte-stability guarantee: when there are no orphans the file is
+// not rewritten. This matters because genconfig's golden tests rely
+// on imports.tf being a stable byte stream across runs.
+func TestPruneOrphanImports_AllNonOrphanLeavesFileUntouched(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	imports := []byte(`import {
+  to = aws_vpc.main
+  id = "vpc-123"
+}
+`)
+	if err := os.WriteFile(filepath.Join(dir, importsFile), imports, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	generated := []byte(`resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+`)
+	skipped, err := pruneOrphanImports(dir, generated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("len(skipped)=%d, want 0", len(skipped))
+	}
+	// Read back — must be byte-identical to input.
+	got, err := os.ReadFile(filepath.Join(dir, importsFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(imports) {
+		t.Errorf("imports.tf must be byte-identical when no orphans\n--- want ---\n%s\n--- got ---\n%s", imports, got)
+	}
+}
+
+// TestPruneOrphanImports_ReturnsEmptySliceNotNil pins the JSON shape
+// contract documented in OrphanImport. Empty result must be the
+// empty slice so the JSON wrapper marshals as `{"imports":[]}` not
+// `{"imports":null}` — same contract as #255 inspector returns.
+func TestPruneOrphanImports_ReturnsEmptySliceNotNil(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, importsFile), []byte(``), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skipped, err := pruneOrphanImports(dir, []byte(``))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if skipped == nil {
+		t.Fatal("skipped is nil; want empty slice")
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("len(skipped)=%d, want 0", len(skipped))
+	}
+}
+
+// TestPruneOrphanImports_MultipleOrphansSortedDeterministically pins
+// the byte-stable wire shape of imports-skipped.json — the slice is
+// sorted by (Address, ImportID) so consumers can diff successive runs.
+func TestPruneOrphanImports_MultipleOrphansSortedDeterministically(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Intentional unsorted order in imports.tf — the prune should
+	// re-sort.
+	if err := os.WriteFile(filepath.Join(dir, importsFile), []byte(`import {
+  to = aws_z_resource.last
+  id = "z-1"
+}
+
+import {
+  to = aws_a_resource.first
+  id = "a-2"
+}
+
+import {
+  to = aws_a_resource.first
+  id = "a-1"
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skipped, err := pruneOrphanImports(dir, []byte(``))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skipped) != 3 {
+		t.Fatalf("len(skipped)=%d, want 3", len(skipped))
+	}
+	// Sort key: (Address, ImportID). aws_a_resource.first/a-1 sorts
+	// before aws_a_resource.first/a-2 sorts before aws_z_resource.last.
+	wants := []struct{ addr, id string }{
+		{"aws_a_resource.first", "a-1"},
+		{"aws_a_resource.first", "a-2"},
+		{"aws_z_resource.last", "z-1"},
+	}
+	for i, w := range wants {
+		if skipped[i].Address != w.addr || skipped[i].ImportID != w.id {
+			t.Errorf("skipped[%d]=(%q, %q), want (%q, %q)",
+				i, skipped[i].Address, skipped[i].ImportID, w.addr, w.id)
+		}
+	}
+}
+
+// TestPruneOrphanImports_MalformedToAttrLeftAlone pins the
+// defensive-by-leave behavior: an import block with a non-traversal
+// `to = ...` expression is too weird for this pass to reason about,
+// so it's left in place for Stage 2c1 to complain about. The safety
+// net is a stopgap, not a HCL-recovery tool.
+func TestPruneOrphanImports_MalformedToAttrLeftAlone(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	in := []byte(`import {
+  to = some.deeply.nested.thing.that.is.not.a.simple.type.name
+  id = "weird"
+}
+`)
+	if err := os.WriteFile(filepath.Join(dir, importsFile), in, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skipped, err := pruneOrphanImports(dir, []byte(``))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("len(skipped)=%d, want 0 (malformed `to` must be left in place)", len(skipped))
+	}
+	got, err := os.ReadFile(filepath.Join(dir, importsFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "some.deeply.nested") {
+		t.Errorf("malformed import must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestPruneOrphanImports_GeneratedParseFailureReturnsErr pins the
+// fatal-on-parse-error path. The caller relies on errors to abort
+// the pipeline; a silent pass-through on parse failure would mask
+// upstream corruption.
+func TestPruneOrphanImports_GeneratedParseFailureReturnsErr(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, importsFile), []byte(``), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// `<<<` is not valid HCL — the parser will return diagnostics.
+	_, err := pruneOrphanImports(dir, []byte(`<<<not valid hcl>>>`))
+	if err == nil {
+		t.Fatal("expected error on malformed generated.tf")
+	}
+	if !strings.Contains(err.Error(), "parse generated.tf") {
+		t.Errorf("err=%v, want one mentioning parse generated.tf", err)
+	}
+}
+
+// TestPruneOrphanImports_ImportsFileMissingReturnsErr pins the
+// fatal-on-IO-failure path. The genconfig pipeline writes imports.tf
+// before calling pruneOrphanImports, so a missing file is a
+// programmer error, not a soft-fail case.
+func TestPruneOrphanImports_ImportsFileMissingReturnsErr(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, err := pruneOrphanImports(dir, []byte(``))
+	if err == nil {
+		t.Fatal("expected error when imports.tf does not exist")
+	}
+	if !strings.Contains(err.Error(), "read imports.tf") {
+		t.Errorf("err=%v, want one mentioning read imports.tf", err)
+	}
+}
+
+// TestWriteOrphanImportsManifest_WireShape pins the JSON wire shape:
+// always a wrapper object with a non-nil Imports slice. Mirrors the
+// #309 break on unsupported.json + the #255 nil-vs-empty contract.
+func TestWriteOrphanImportsManifest_WireShape(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	skipped := []OrphanImport{
+		{Address: "aws_network_acl.default_nacl", ImportID: "acl-deadbeef", Reason: "no_generated_config"},
+	}
+	path, err := writeOrphanImportsManifest(dir, skipped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path == "" || filepath.Base(path) != orphanImportsFile {
+		t.Errorf("path=%q, want one ending in %s", path, orphanImportsFile)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wrapper orphanImportsWrapper
+	if err := json.Unmarshal(raw, &wrapper); err != nil {
+		t.Fatal(err)
+	}
+	if len(wrapper.Imports) != 1 {
+		t.Fatalf("len(Imports)=%d, want 1", len(wrapper.Imports))
+	}
+	if wrapper.Imports[0].Address != "aws_network_acl.default_nacl" {
+		t.Errorf("Address=%q", wrapper.Imports[0].Address)
+	}
+	if wrapper.Imports[0].ImportID != "acl-deadbeef" {
+		t.Errorf("ImportID=%q", wrapper.Imports[0].ImportID)
+	}
+	if wrapper.Imports[0].Reason != "no_generated_config" {
+		t.Errorf("Reason=%q", wrapper.Imports[0].Reason)
+	}
+}
+
+// TestWriteOrphanImportsManifest_NilSliceEmitsEmptyArray pins the
+// nil-vs-empty contract on the wrapper. JSON null would crash
+// consumers that iterate over `.imports` (same shape as the #255
+// inspector array contract).
+func TestWriteOrphanImportsManifest_NilSliceEmitsEmptyArray(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path, err := writeOrphanImportsManifest(dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Must contain `"imports": []`, not `"imports": null`.
+	if !strings.Contains(string(raw), `"imports": []`) {
+		t.Errorf("wire shape must include `\"imports\": []` for nil input\n--- got ---\n%s", raw)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	google.golang.org/api v0.277.0
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
+	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -134,6 +135,5 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect
-	google.golang.org/grpc v1.80.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## Summary

Closes Bundle 7 umbrella (#355) — 9 sub-issues across discoverer, genconfig, crossref, and CLI UX surfaced by the 2026-05-10 CUST3 + `diagramtest2025-09-14` live smoke. Mirrors the Bundle 5+6 combined-review pattern (PR #353).

- **discoverer (#357)**: `aws_network_acl` filters `IsDefault=true` client-side so default NACLs (which `terraform plan -generate-config-out` can't render as `aws_network_acl`) don't break Stage 2c1
- **genconfig fixups (#358/#359/#361/#363)**: new `aws_db_instance`, `aws_secretsmanager_secret`, and **first GCP-side** `google_compute_firewall` closures
- **crossref (#360)**: per-(consumer resource type, attribute) override map; seeds `aws_db_instance.replicate_source_db` → `.arn`
- **safety net (#362)**: genconfig post-pass drops orphan import blocks + emits `imports-skipped.json`
- **UX (#364/#365)**: empty-`--project`-filter WARN and gRPC `Unauthenticated`/`PermissionDenied` wraps with actionable hints

Bundle 8 (#356, ~12 PRs for GCP discoverer coverage expansion) is the sibling umbrella — explicitly out of scope here.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l cmd/ pkg/` clean
- [x] `go test ./... -race -count=1` — 3904 pass across 26 packages
- [x] All 9 static lint scripts (`tests/lint-*.sh`) pass
- [x] `terraform fmt -check -recursive` clean
- [x] No `aws/` or `gcp/` preset modules touched — all changes confined to `cmd/insideout-import/`

## Review notes

- **/review findings**: 0 P0, 0 P1; 1 P2 fixed (`wrapSearchAllError` was using `%v` — switched to `%w` to preserve the error chain per golang-guidance §10); 1 P3 deferred (idiomatic, no change needed)
- **qa-professor findings**: 1 P0 fixed (dead-code `if` body in `TestApplyCrossRefs_DBInstanceReplicateSourceUsesARN` that fired no assertions), 7 P1 fixed (wire-shape contract test now exercises non-empty-imports path; new orphan-with-missing-id edge case; regex literal-dot escapes; word-boundary on `recovery_window_in_days=30`; only-affects-keyed-type test now iterates all 4 firewall attrs; new single-element-list carve-out for `domain_dns_ips`; new ID-set pinning for mixed-default-NACL test; new ByID-accepts-default-NACL test pinning the Discover-vs-ByID filter scope), 4 P2 drive-bys fixed (table-driven gRPC-code coverage; split nil-proto vs zero-proto tests; reverse-input determinism test for orphan sort; distinctive WARN substring)
- **Deferred (low value, would expand PR scope)**: P3 cosmetic refactors of `TestNetworkACLDiscover_HappyPath` double-duty and table-driven null-cases negative-matrix tightening; P2 reliance on production wrap message text in `TestPruneOrphanImports_*ParseFailure*` / `*MissingReturnsErr*` (low risk — refactoring those wraps would touch the tests, which is the desired correlation)

## Sub-issues closed

| Issue | Subject | Branch (logical) |
|-------|---------|-----------------|
| #357 | `aws_network_acl` default-NACL discoverer skip | `fix/network-acl-default-skip` |
| #358 | `aws_db_instance.domain_dns_ips=[]` violates MinItems=2 | `fix/genconfig-db-instance-fixups` |
| #359 | `aws_db_instance` replica `db_name`/`username` vs `replicate_source_db` | `fix/genconfig-db-instance-fixups` |
| #360 | `aws_db_instance` replica `replicate_source_db` needs `.arn` ref | `fix/crossref-db-instance-arn` |
| #361 | `aws_secretsmanager_secret` defaults preservation | `fix/genconfig-secretsmanager-defaults` |
| #362 | genconfig orphan-import safety net | `feat/genconfig-orphan-import-safety` |
| #363 | `google_compute_firewall` mutual-exclusion fixup — first GCP entry | `fix/genconfig-compute-firewall-fixups` |
| #364 | empty label-filter silent zero result UX | `feat/discover-cli-ux-polish` |
| #365 | GCP `invalid_rapt` raw error UX wrap | `feat/discover-cli-ux-polish` |

Closes #355 (umbrella). Closes #357, #358, #359, #360, #361, #362, #363, #364, #365.