### PR TITLE
feat(gcpdiscover): ScopeStyle dispatch for label-less GCP types (#366)

### DIFF
--- a/cmd/insideout-import/gcpdiscover/compute_network.go
+++ b/cmd/insideout-import/gcpdiscover/compute_network.go
@@ -29,8 +29,9 @@ type computeNetworkDiscoverer struct{}
 
 func newComputeNetworkDiscoverer() Discoverer { return &computeNetworkDiscoverer{} }
 
-func (computeNetworkDiscoverer) ResourceType() string { return computeNetworkTFType }
-func (computeNetworkDiscoverer) AssetType() string    { return computeNetworkAssetType }
+func (computeNetworkDiscoverer) ResourceType() string   { return computeNetworkTFType }
+func (computeNetworkDiscoverer) AssetType() string      { return computeNetworkAssetType }
+func (computeNetworkDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleLabels }
 
 func (computeNetworkDiscoverer) FromAsset(book addressBook, a gcpAssetResult, projectID string) imported.ImportedResource {
 	name := shortName(a.Name)

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -36,13 +36,36 @@ import (
 )
 
 // gcpServiceSlug is the progress-event service slug used for the
-// single Cloud Asset Inventory call that powers GCP discovery (#295).
-// One CAI SearchAllResources covers every requested asset type for a
-// project, so we emit one (service_start/service_finish) pair around
-// it rather than per-asset-type. The slug name matches the Cloud
-// Asset API's product naming so consumers know what the events
+// Cloud Asset Inventory calls that power GCP discovery (#295). One or
+// two CAI SearchAllResources calls cover every requested asset type
+// for a project (one per ScopeStyle bucket, see #366), so we emit one
+// (service_start/service_finish) pair around the combined operation
+// rather than per-call or per-asset-type. The slug name matches the
+// Cloud Asset API's product naming so consumers know what the events
 // represent.
 const gcpServiceSlug = "cloud_asset_inventory"
+
+// ScopeStyle identifies how an asset-type is scoped to the operator's
+// stack project inside Cloud Asset Inventory queries. The aggregator
+// groups discoverers by ScopeStyle and issues one SearchAllResources
+// call per non-empty group; results from the name-prefix group are
+// then post-filtered against args.Project on the client.
+type ScopeStyle int
+
+const (
+	// ScopeStyleLabels (default) uses the server-side
+	// `labels.project:<stack>` clause. Applies to every Phase-1 GCP
+	// type — all five are labelable.
+	ScopeStyleLabels ScopeStyle = iota
+	// ScopeStyleNamePrefix is for resource types that don't carry GCP
+	// labels (IAM service accounts, KMS keyrings/keys, compute
+	// firewalls, etc.). The CLAUDE.md "label-less GCP resources"
+	// convention says the resource name contains the stack project as
+	// a substring. The aggregator drops the labels.project clause
+	// from the server query and applies the name-substring filter
+	// client-side.
+	ScopeStyleNamePrefix
+)
 
 // ErrNotSupported signals that a discoverer cannot resolve a given ID
 // (e.g. a Terraform type for which no discoverer is registered, or a GCP
@@ -81,6 +104,11 @@ type Discoverer interface {
 	// "pubsub.googleapis.com/Topic". Used by the aggregator to build the
 	// SearchAllResources asset-type filter.
 	AssetType() string
+	// ScopeStyle reports how the orchestrator filters asset results
+	// down to the operator's stack project (#366). Most types return
+	// ScopeStyleLabels; label-less types (per CLAUDE.md's label-less
+	// GCP resource convention) return ScopeStyleNamePrefix.
+	ScopeStyle() ScopeStyle
 	// FromAsset translates a single Cloud Asset SearchAllResources result
 	// (already filtered to this discoverer's AssetType) into an
 	// ImportedResource. Implementations populate Identity (Cloud, Type,
@@ -145,11 +173,11 @@ func (g *GCPDiscoverer) SupportedTypes() []string {
 	return out
 }
 
-// DiscoverTypes runs a single SearchAllResources call covering every named
-// Terraform type, then fans out per-asset translation across the registered
-// discoverers. Unknown type names are reported as a single error containing
-// all invalid names so the operator sees the full set of misspellings in
-// one shot.
+// DiscoverTypes runs one SearchAllResources call per ScopeStyle bucket
+// covering every named Terraform type, then fans out per-asset translation
+// across the registered discoverers. Unknown type names are reported as a
+// single error containing all invalid names so the operator sees the full
+// set of misspellings in one shot.
 //
 // args.Regions populates the Cloud Asset query's `location:` filter. Zero
 // regions ⇒ no location clause (asset-API "all locations"). One ⇒
@@ -157,7 +185,10 @@ func (g *GCPDiscoverer) SupportedTypes() []string {
 // args.TagSelectors append `labels.<k>:<v>` clauses to the asset query
 // (server-side AND-conjunction). The legacy implicit
 // `labels.project:<project>` clause is preserved when args.Project is
-// non-empty.
+// non-empty for the ScopeStyleLabels bucket. For the ScopeStyleNamePrefix
+// bucket the labels clause is dropped and a client-side substring filter
+// on asset.Name takes its place (#366 — required for label-less GCP
+// resource types).
 func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args DiscoverArgs) ([]imported.ImportedResource, error) {
 	if len(types) == 0 {
 		types = g.SupportedTypes()
@@ -170,7 +201,6 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 
 	var unknown []string
 	selected := make([]Discoverer, 0, len(types))
-	assetTypes := make([]string, 0, len(types))
 	for _, t := range types {
 		d, ok := g.byType[t]
 		if !ok {
@@ -178,21 +208,40 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 			continue
 		}
 		selected = append(selected, d)
-		assetTypes = append(assetTypes, d.AssetType())
 	}
 	if len(unknown) > 0 {
 		return nil, fmt.Errorf("unknown resource type(s): %v (supported: %v)", unknown, g.SupportedTypes())
 	}
 
+	// Group discoverers by ScopeStyle (#366). The two buckets are
+	// dispatched as independent SearchAllResources calls because the
+	// labels.project clause is required for labelable types and counter-
+	// productive (returns zero results) for label-less types.
+	//
+	// The switch is exhaustive on purpose — an unknown ScopeStyle
+	// should fail loudly rather than silently routing to the
+	// labels-bucket (where the labels.project clause would return
+	// zero results for a type the discoverer marked as label-less).
+	var labelsBucket, namePrefixBucket []Discoverer
+	for _, d := range selected {
+		switch d.ScopeStyle() {
+		case ScopeStyleLabels:
+			labelsBucket = append(labelsBucket, d)
+		case ScopeStyleNamePrefix:
+			namePrefixBucket = append(namePrefixBucket, d)
+		default:
+			return nil, fmt.Errorf("discoverer %q reported unknown ScopeStyle %v", d.ResourceType(), d.ScopeStyle())
+		}
+	}
+
 	scope := fmt.Sprintf("projects/%s", g.projectID)
-	query := buildSearchQuery(args.Project, args.Regions, args.TagSelectors)
 
 	stageStart := time.Now()
 	args.Emitter.ServiceStart(gcpServiceSlug, "")
-	results, err := g.searcher.SearchAll(ctx, scope, assetTypes, query)
+	results, err := g.searchBuckets(ctx, scope, args, labelsBucket, namePrefixBucket)
 	if err != nil {
 		args.Emitter.ServiceFinish(gcpServiceSlug, "", 0, time.Since(stageStart))
-		return nil, fmt.Errorf("cloud asset SearchAllResources: %w", err)
+		return nil, err
 	}
 
 	// Group by asset type so each per-type discoverer sees a deterministic
@@ -296,4 +345,85 @@ func buildSearchQuery(stackProject string, locations []string, selectors []TagSe
 		clauses = append(clauses, "labels."+s.Key+":"+s.Value)
 	}
 	return strings.Join(clauses, " AND ")
+}
+
+// searchBuckets issues one SearchAllResources call per non-empty
+// ScopeStyle bucket and concatenates the results (#366). The
+// labels-style bucket gets the legacy query with the
+// `labels.project:<stack>` clause; the name-prefix-style bucket gets
+// the same query with the labels.project clause omitted, plus a
+// client-side substring filter on asset.Name. Empty buckets are
+// skipped, so the all-labels-style path (today's only path) remains
+// one round-trip — not two.
+func (g *GCPDiscoverer) searchBuckets(ctx context.Context, scope string, args DiscoverArgs, labelsBucket, namePrefixBucket []Discoverer) ([]gcpAssetResult, error) {
+	var out []gcpAssetResult
+
+	if len(labelsBucket) > 0 {
+		query := buildSearchQuery(args.Project, args.Regions, args.TagSelectors)
+		rs, err := g.searcher.SearchAll(ctx, scope, assetTypesOf(labelsBucket), query)
+		if err != nil {
+			return nil, fmt.Errorf("cloud asset SearchAllResources (labels scope): %w", err)
+		}
+		out = append(out, rs...)
+	}
+
+	if len(namePrefixBucket) > 0 {
+		// args.Project is intentionally omitted from the query — the
+		// server-side labels.project clause is N/A for label-less
+		// types. We apply the equivalent filter client-side below.
+		query := buildSearchQuery("", args.Regions, args.TagSelectors)
+		rs, err := g.searcher.SearchAll(ctx, scope, assetTypesOf(namePrefixBucket), query)
+		if err != nil {
+			return nil, fmt.Errorf("cloud asset SearchAllResources (name-prefix scope): %w", err)
+		}
+		if args.Project != "" {
+			// Allocate a fresh slice rather than reslicing `rs` in
+			// place — the searcher owns the backing array, and a
+			// test fake that returns its own field directly would
+			// observe a corrupted slice on a second call. Production
+			// gRPC clients build a fresh slice per call so the
+			// aliasing path is harmless there, but the explicit
+			// allocation makes the contract robust under either
+			// caller.
+			kept := make([]gcpAssetResult, 0, len(rs))
+			for _, r := range rs {
+				if matchesNamePrefix(r.Name, args.Project) {
+					kept = append(kept, r)
+				}
+			}
+			rs = kept
+		}
+		out = append(out, rs...)
+	}
+	return out, nil
+}
+
+// assetTypesOf collects the Cloud Asset asset-type strings from a slice
+// of discoverers, preserving order so unit tests can pin per-bucket
+// asset-type partitioning.
+func assetTypesOf(ds []Discoverer) []string {
+	out := make([]string, 0, len(ds))
+	for _, d := range ds {
+		out = append(out, d.AssetType())
+	}
+	return out
+}
+
+// matchesNamePrefix reports whether the trailing resource-name segment
+// of a Cloud Asset full resource name contains stackProject as a
+// substring. Implements the CLAUDE.md label-less-resource scoping
+// convention: when a GCP resource type doesn't carry labels, callers
+// are required to name resources with the stack project as a prefix or
+// substring so the InsideOut inspector can attribute them. The trailing
+// segment (split on '/') is the right scope to check — the leading
+// `//service/projects/<gcp-project-id>/...` segments contain the real
+// GCP project ID, which we never want to match against the stack name.
+//
+// Empty stackProject is a programmer error — callers must skip this
+// filter when args.Project is empty. Go's strings.Contains returns
+// true for an empty needle, so an empty stackProject would match
+// every asset and produce the opposite of the intended scoping; the
+// caller-side guard in searchBuckets defends against that.
+func matchesNamePrefix(assetName, stackProject string) bool {
+	return strings.Contains(shortName(assetName), stackProject)
 }

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -539,4 +540,413 @@ func TestGCPDiscoverTypes_EmitsStageFinish(t *testing.T) {
 	if stageEvents != 1 {
 		t.Errorf("stage_finish count=%d, want 1", stageEvents)
 	}
+}
+
+// TestScopeStyle_AllPhase1DiscoverersUseLabels is a regression guard
+// (#366). All five currently-registered discoverers cover labelable GCP
+// resource types — every type's preset attaches the `project` label —
+// so each one must report ScopeStyleLabels. A mutation that flipped
+// any of them to ScopeStyleNamePrefix would silently drop the
+// labels.project clause from its server-side query, returning the
+// project's full inventory instead of just the stack's assets.
+//
+// Test source-of-truth is the live registration map produced by
+// NewGCPDiscoverer, not hand-listed constructors — that way the test
+// stays a regression guard for production behavior. A future PR that
+// forgot to register a constructor in byType (or that registered a
+// new ScopeStyleNamePrefix discoverer alongside the labels-style set)
+// surfaces here.
+func TestScopeStyle_AllPhase1DiscoverersUseLabels(t *testing.T) {
+	t.Parallel()
+	g := NewGCPDiscoverer(&fakeAssetSearcher{}, "p")
+	if len(g.byType) == 0 {
+		t.Fatal("no discoverers registered; ScopeStyle parity test would be vacuous")
+	}
+	for tfType, d := range g.byType {
+		t.Run(tfType, func(t *testing.T) {
+			t.Parallel()
+			if got := d.ScopeStyle(); got != ScopeStyleLabels {
+				t.Errorf("%s.ScopeStyle()=%v, want ScopeStyleLabels (%v) — every Phase-1 GCP type carries the project label",
+					tfType, got, ScopeStyleLabels)
+			}
+		})
+	}
+}
+
+// TestDiscoverTypes_LabelsBucketOnly_SingleSearchCall pins today's
+// labels-only path (#366) — when every selected discoverer reports
+// ScopeStyleLabels, the orchestrator issues exactly one
+// SearchAllResources call and its query carries the legacy
+// `labels.project:<stack>` clause. Regression guard against the
+// two-bucket refactor accidentally splitting the all-labels path into
+// two round-trips.
+func TestDiscoverTypes_LabelsBucketOnly_SingleSearchCall(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{}
+	g := NewGCPDiscoverer(fake, "real-proj")
+	if _, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic", "google_storage_bucket"}, DiscoverArgs{
+		Project: "io-foo",
+		Regions: []string{""},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("SearchAll calls=%d, want 1 (all selected types are ScopeStyleLabels)", len(fake.calls))
+	}
+	if !strings.Contains(fake.calls[0].query, "labels.project:io-foo") {
+		t.Errorf("labels-bucket query=%q, want it to include labels.project:io-foo", fake.calls[0].query)
+	}
+}
+
+// TestDiscoverTypes_NamePrefixBucketOnly_OneCallWithoutLabelsClause
+// pins the name-prefix-only path (#366): one SearchAllResources call,
+// and its query MUST NOT include `labels.project:` — label-less GCP
+// resource types don't carry the label, so the server-side clause
+// would unconditionally exclude every result.
+func TestDiscoverTypes_NamePrefixBucketOnly_OneCallWithoutLabelsClause(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{}
+	g := &GCPDiscoverer{
+		searcher:  fake,
+		projectID: "real-proj",
+		byType: map[string]Discoverer{
+			"google_fake_namepref": &fakeNamePrefixDiscoverer{
+				resourceType: "google_fake_namepref",
+				assetType:    "test.googleapis.com/NamePrefixed",
+			},
+		},
+	}
+	if _, err := g.DiscoverTypes(context.Background(), []string{"google_fake_namepref"}, DiscoverArgs{
+		Project: "io-foo",
+		Regions: []string{"us-central1"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("SearchAll calls=%d, want 1 (one bucket, one round-trip)", len(fake.calls))
+	}
+	if strings.Contains(fake.calls[0].query, "labels.project:") {
+		t.Errorf("name-prefix-bucket query=%q, want NO labels.project clause", fake.calls[0].query)
+	}
+	// Sanity: the other clauses still propagate (location, selectors).
+	if !strings.Contains(fake.calls[0].query, "location:us-central1") {
+		t.Errorf("name-prefix-bucket query=%q, want location:us-central1 to still propagate", fake.calls[0].query)
+	}
+}
+
+// TestDiscoverTypes_MixedBuckets_TwoSearchCallsWithDifferentQueries
+// pins the two-call dispatch (#366) when both ScopeStyle buckets are
+// non-empty: each bucket gets its own SearchAllResources, partitioned
+// by asset type. The labels-bucket call carries `labels.project:`; the
+// name-prefix-bucket call doesn't.
+func TestDiscoverTypes_MixedBuckets_TwoSearchCallsWithDifferentQueries(t *testing.T) {
+	t.Parallel()
+	fake := &bucketedFakeSearcher{
+		resultsByAssetType: map[string][]gcpAssetResult{
+			"pubsub.googleapis.com/Topic": {
+				{Name: "//pubsub.googleapis.com/projects/real-proj/topics/io-foo-events", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+			},
+			"test.googleapis.com/NamePrefixed": {
+				{Name: "//test.googleapis.com/projects/real-proj/widgets/io-foo-widget", AssetType: "test.googleapis.com/NamePrefixed", Project: "real-proj"},
+			},
+		},
+	}
+	g := &GCPDiscoverer{
+		searcher:  fake,
+		projectID: "real-proj",
+		byType: map[string]Discoverer{
+			"google_pubsub_topic": newPubsubTopicDiscoverer(),
+			"google_fake_namepref": &fakeNamePrefixDiscoverer{
+				resourceType: "google_fake_namepref",
+				assetType:    "test.googleapis.com/NamePrefixed",
+			},
+		},
+	}
+	got, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic", "google_fake_namepref"}, DiscoverArgs{
+		Project: "io-foo",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 2 {
+		t.Fatalf("SearchAll calls=%d, want 2 (one per ScopeStyle bucket)", len(fake.calls))
+	}
+
+	// Find the calls by their asset-type partition; the orchestrator
+	// iterates labels-bucket before name-prefix-bucket, but pinning the
+	// order is brittle — pin the contents instead.
+	var labelsCall, nameCall *searchAllCall
+	for i := range fake.calls {
+		c := &fake.calls[i]
+		switch {
+		case slices.Contains(c.assetTypes, "pubsub.googleapis.com/Topic"):
+			labelsCall = c
+		case slices.Contains(c.assetTypes, "test.googleapis.com/NamePrefixed"):
+			nameCall = c
+		}
+	}
+	if labelsCall == nil {
+		t.Fatal("no SearchAll call carried the labels-bucket asset type pubsub.googleapis.com/Topic")
+	}
+	if nameCall == nil {
+		t.Fatal("no SearchAll call carried the name-prefix-bucket asset type test.googleapis.com/NamePrefixed")
+	}
+
+	if !strings.Contains(labelsCall.query, "labels.project:io-foo") {
+		t.Errorf("labels-bucket call query=%q, want labels.project:io-foo", labelsCall.query)
+	}
+	// Belt-and-braces: the labels-bucket query carries exactly one
+	// labels.project clause. A regression that double-emitted the
+	// clause (e.g. labels.project:io-foo AND labels.project:io-foo)
+	// or that merged in tag selectors as labels.project would still
+	// satisfy the Contains() check above.
+	if c := strings.Count(labelsCall.query, "labels.project:"); c != 1 {
+		t.Errorf("labels-bucket labels.project count=%d, want 1; query=%q", c, labelsCall.query)
+	}
+	if strings.Contains(nameCall.query, "labels.project:") {
+		t.Errorf("name-prefix-bucket call query=%q, want NO labels.project clause", nameCall.query)
+	}
+
+	// Asset-type partition is strict: neither call carries the other
+	// bucket's type. A regression that issued one combined call would
+	// fail here.
+	if slices.Contains(labelsCall.assetTypes, "test.googleapis.com/NamePrefixed") {
+		t.Errorf("labels-bucket call asset types=%v, must not include name-prefix-bucket types", labelsCall.assetTypes)
+	}
+	if slices.Contains(nameCall.assetTypes, "pubsub.googleapis.com/Topic") {
+		t.Errorf("name-prefix-bucket call asset types=%v, must not include labels-bucket types", nameCall.assetTypes)
+	}
+
+	// Both buckets contribute to the returned resource set.
+	if len(got) != 2 {
+		t.Fatalf("ImportedResources=%d, want 2 (one per bucket)", len(got))
+	}
+}
+
+// TestDiscoverTypes_NamePrefixFiltersAssetNameClientSide pins the
+// client-side filter (#366): when the name-prefix bucket returns
+// assets whose short name doesn't contain args.Project, the
+// orchestrator drops them. The server has no `labels.project:` clause
+// for this bucket — so the filter must apply on the client, otherwise
+// label-less GCP resources from other stacks would leak into the
+// import set.
+func TestDiscoverTypes_NamePrefixFiltersAssetNameClientSide(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{
+			// Matches "io-foo" via substring on the short name.
+			{Name: "//test.googleapis.com/projects/real-proj/widgets/io-foo-widget-a", AssetType: "test.googleapis.com/NamePrefixed"},
+			// Does NOT contain "io-foo" — must be dropped.
+			{Name: "//test.googleapis.com/projects/real-proj/widgets/other-stack-widget", AssetType: "test.googleapis.com/NamePrefixed"},
+			// Matches via substring at the end.
+			{Name: "//test.googleapis.com/projects/real-proj/widgets/widget-io-foo", AssetType: "test.googleapis.com/NamePrefixed"},
+		},
+	}
+	g := &GCPDiscoverer{
+		searcher:  fake,
+		projectID: "real-proj",
+		byType: map[string]Discoverer{
+			"google_fake_namepref": &fakeNamePrefixDiscoverer{
+				resourceType: "google_fake_namepref",
+				assetType:    "test.googleapis.com/NamePrefixed",
+			},
+		},
+	}
+	got, err := g.DiscoverTypes(context.Background(), []string{"google_fake_namepref"}, DiscoverArgs{
+		Project: "io-foo",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Pin both the partition (exactly which assets survived) and the
+	// order (DiscoverTypes stable-sorts per-asset-type by Cloud Asset
+	// Name). A mutation that kept one asset twice or that swapped
+	// asset[0]/asset[2] would survive a count-only check; deep-equal
+	// against the sorted-by-short-name expected slice pins it.
+	wantNames := []string{"io-foo-widget-a", "widget-io-foo"}
+	gotNames := namesOf(got)
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Errorf("kept names = %v, want %v (filter must keep the io-foo-tagged assets in stable order, drop other-stack-widget)", gotNames, wantNames)
+	}
+}
+
+// TestDiscoverTypes_NamePrefixEmptyProjectPassesThrough pins the
+// no-filter case (#366): when args.Project is empty, the name-prefix
+// bucket's client-side filter is skipped so every asset passes
+// through. Symmetric with the labels bucket, where an empty stack
+// project also omits the labels.project clause and returns the
+// project's full inventory.
+//
+// Mutation-resistance: strings.Contains(s, "") is always true in Go,
+// so a regression that removed the `if args.Project != ""` guard
+// would still produce a 2-result happy-path under any reasonable
+// fixture — the count-only assertion is tautological. To pin the
+// behavior, this test feeds three assets whose short names share
+// nothing in common (no substring overlap) and asserts the returned
+// slice exactly equals the input by name AND order. The labels-style
+// `len == in` shape and unordered membership would not catch a
+// stable-sort regression on the name-prefix path; deep-equal pins it.
+func TestDiscoverTypes_NamePrefixEmptyProjectPassesThrough(t *testing.T) {
+	t.Parallel()
+	// Three assets whose short names form an antichain under
+	// strings.Contains — no name is a substring of another, so any
+	// substring filter run against a non-empty needle would drop at
+	// least one. The skip-the-filter branch must keep all three.
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{
+			{Name: "//test.googleapis.com/projects/real-proj/widgets/alpha", AssetType: "test.googleapis.com/NamePrefixed"},
+			{Name: "//test.googleapis.com/projects/real-proj/widgets/zeta", AssetType: "test.googleapis.com/NamePrefixed"},
+			{Name: "//test.googleapis.com/projects/real-proj/widgets/mid", AssetType: "test.googleapis.com/NamePrefixed"},
+		},
+	}
+	g := &GCPDiscoverer{
+		searcher:  fake,
+		projectID: "real-proj",
+		byType: map[string]Discoverer{
+			"google_fake_namepref": &fakeNamePrefixDiscoverer{
+				resourceType: "google_fake_namepref",
+				assetType:    "test.googleapis.com/NamePrefixed",
+			},
+		},
+	}
+	got, err := g.DiscoverTypes(context.Background(), []string{"google_fake_namepref"}, DiscoverArgs{
+		Project: "",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// DiscoverTypes sorts each per-asset-type bucket by Cloud Asset
+	// Name (gcpdiscover.go's stable-sort), so the expected order is
+	// the alphabetical sort of short names: alpha, mid, zeta.
+	wantNames := []string{"alpha", "mid", "zeta"}
+	gotNames := namesOf(got)
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Errorf("kept names = %v, want %v (every input must pass through unchanged when args.Project is empty)", gotNames, wantNames)
+	}
+}
+
+// TestMatchesNamePrefix pins the helper's contract (#366): substring
+// match against the trailing path segment of a Cloud Asset name, with
+// the rest of the path explicitly excluded from the match. The
+// adversarial cases (5-8) are load-bearing: they pin the property
+// that earlier path segments — including the GCP project ID, the
+// location, and the resource-collection name — cannot trigger a
+// false-positive match. A mutation that replaced
+// `strings.Contains(shortName(assetName), stackProject)` with
+// `strings.Contains(assetName, stackProject)` would silently widen
+// the scope to the entire stack's project, returning resources
+// belonging to other stacks. The adversarial rows fail loudly.
+func TestMatchesNamePrefix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		assetName string
+		project   string
+		want      bool
+	}{
+		// Happy paths — substring at every position of the short name.
+		{"prefix match in short name", "//iam.googleapis.com/projects/p/serviceAccounts/io-foo-sa@p.iam.gserviceaccount.com", "io-foo", true},
+		{"infix match in short name", "//compute.googleapis.com/projects/p/global/firewalls/fw-io-foo-allow", "io-foo", true},
+		{"suffix match in short name", "//cloudkms.googleapis.com/projects/p/locations/global/keyRings/ring-io-foo", "io-foo", true},
+		{"no match anywhere", "//compute.googleapis.com/projects/p/global/firewalls/other-stack-fw", "io-foo", false},
+
+		// Adversarial: the stack project appears in earlier segments
+		// (the GCP project ID, an intermediate path segment, or both)
+		// while the trailing short name is OWNED BY A DIFFERENT STACK.
+		// Each must return false — only short-name matches count.
+		{"stack project in GCP project ID segment", "//iam.googleapis.com/projects/io-foo-real-proj/serviceAccounts/other-stack-sa@x.iam.gserviceaccount.com", "io-foo", false},
+		{"stack project equals GCP project ID", "//compute.googleapis.com/projects/io-foo/global/firewalls/different-stack-fw", "io-foo", false},
+		{"stack project is substring of GCP project ID", "//compute.googleapis.com/projects/my-io-foo-prod/global/firewalls/different-stack-fw", "io-foo", false},
+		{"stack project in intermediate location segment", "//cloudkms.googleapis.com/projects/p/locations/io-foo-zone/keyRings/other-stack-ring", "io-foo", false},
+
+		// Edge cases.
+		{"bare name (no slashes)", "io-foo-widget", "io-foo", true},
+		{"empty asset name", "", "io-foo", false},
+
+		// Trailing slash is malformed Cloud Asset input — production
+		// names never end in '/'. shortName's defensive fallback
+		// returns the entire asset name; the substring match then
+		// sees earlier segments and may produce false positives.
+		// Pinning current behavior so a refactor that silently
+		// strengthened the trailing-slash branch (e.g. returning ""
+		// instead of the full name) surfaces here.
+		{"trailing slash falls back to full asset name (documented surface)", "//svc.googleapis.com/projects/io-foo-real/widgets/", "io-foo", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := matchesNamePrefix(tc.assetName, tc.project); got != tc.want {
+				t.Errorf("matchesNamePrefix(%q, %q) = %v, want %v", tc.assetName, tc.project, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDiscoverTypes_TwoBucketsEmitOneServiceStartFinishPair extends
+// the #295 contract to the two-bucket path (#366): even when both
+// ScopeStyle buckets issue independent SearchAllResources calls, the
+// orchestrator emits exactly one (service_start, service_finish) pair
+// around the combined operation. A regression that moved the pair
+// inside searchBuckets would double the events.
+func TestDiscoverTypes_TwoBucketsEmitOneServiceStartFinishPair(t *testing.T) {
+	t.Parallel()
+	fake := &bucketedFakeSearcher{
+		resultsByAssetType: map[string][]gcpAssetResult{
+			"pubsub.googleapis.com/Topic": {
+				{Name: "//pubsub.googleapis.com/projects/real-proj/topics/io-foo-events", AssetType: "pubsub.googleapis.com/Topic"},
+			},
+			"test.googleapis.com/NamePrefixed": {
+				{Name: "//test.googleapis.com/projects/real-proj/widgets/io-foo-widget", AssetType: "test.googleapis.com/NamePrefixed"},
+			},
+		},
+	}
+	g := &GCPDiscoverer{
+		searcher:  fake,
+		projectID: "real-proj",
+		byType: map[string]Discoverer{
+			"google_pubsub_topic": newPubsubTopicDiscoverer(),
+			"google_fake_namepref": &fakeNamePrefixDiscoverer{
+				resourceType: "google_fake_namepref",
+				assetType:    "test.googleapis.com/NamePrefixed",
+			},
+		},
+	}
+	rec := &recordingEmitter{}
+	if _, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic", "google_fake_namepref"}, DiscoverArgs{
+		Project: "io-foo",
+		Emitter: rec,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	starts, finishes := 0, 0
+	for _, e := range rec.snapshot() {
+		switch e.Kind {
+		case "service_start":
+			starts++
+			if e.Service != "cloud_asset_inventory" {
+				t.Errorf("service_start.service=%q, want cloud_asset_inventory", e.Service)
+			}
+		case "service_finish":
+			finishes++
+			if e.Service != "cloud_asset_inventory" {
+				t.Errorf("service_finish.service=%q, want cloud_asset_inventory", e.Service)
+			}
+		}
+	}
+	if starts != 1 {
+		t.Errorf("service_start count=%d, want 1 (one pair across both ScopeStyle buckets)", starts)
+	}
+	if finishes != 1 {
+		t.Errorf("service_finish count=%d, want 1 (one pair across both ScopeStyle buckets)", finishes)
+	}
+}
+
+// namesOf collects NameHints from a discover result for failure-message
+// readability — `got 1 names: [alpha]` beats `got 1 items`.
+func namesOf(rs []imported.ImportedResource) []string {
+	out := make([]string, 0, len(rs))
+	for _, r := range rs {
+		out = append(out, r.Identity.NameHint)
+	}
+	return out
 }

--- a/cmd/insideout-import/gcpdiscover/pubsub_subscription.go
+++ b/cmd/insideout-import/gcpdiscover/pubsub_subscription.go
@@ -23,8 +23,9 @@ type pubsubSubscriptionDiscoverer struct{}
 
 func newPubsubSubscriptionDiscoverer() Discoverer { return &pubsubSubscriptionDiscoverer{} }
 
-func (pubsubSubscriptionDiscoverer) ResourceType() string { return pubsubSubscriptionTFType }
-func (pubsubSubscriptionDiscoverer) AssetType() string    { return pubsubSubscriptionAssetType }
+func (pubsubSubscriptionDiscoverer) ResourceType() string   { return pubsubSubscriptionTFType }
+func (pubsubSubscriptionDiscoverer) AssetType() string      { return pubsubSubscriptionAssetType }
+func (pubsubSubscriptionDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleLabels }
 
 func (pubsubSubscriptionDiscoverer) FromAsset(book addressBook, a gcpAssetResult, projectID string) imported.ImportedResource {
 	name := shortName(a.Name)

--- a/cmd/insideout-import/gcpdiscover/pubsub_topic.go
+++ b/cmd/insideout-import/gcpdiscover/pubsub_topic.go
@@ -30,8 +30,9 @@ type pubsubTopicDiscoverer struct{}
 
 func newPubsubTopicDiscoverer() Discoverer { return &pubsubTopicDiscoverer{} }
 
-func (pubsubTopicDiscoverer) ResourceType() string { return pubsubTopicTFType }
-func (pubsubTopicDiscoverer) AssetType() string    { return pubsubTopicAssetType }
+func (pubsubTopicDiscoverer) ResourceType() string   { return pubsubTopicTFType }
+func (pubsubTopicDiscoverer) AssetType() string      { return pubsubTopicAssetType }
+func (pubsubTopicDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleLabels }
 
 func (pubsubTopicDiscoverer) FromAsset(book addressBook, a gcpAssetResult, projectID string) imported.ImportedResource {
 	name := shortName(a.Name)

--- a/cmd/insideout-import/gcpdiscover/secret_manager_secret.go
+++ b/cmd/insideout-import/gcpdiscover/secret_manager_secret.go
@@ -30,8 +30,9 @@ type secretManagerSecretDiscoverer struct{}
 
 func newSecretManagerSecretDiscoverer() Discoverer { return &secretManagerSecretDiscoverer{} }
 
-func (secretManagerSecretDiscoverer) ResourceType() string { return secretManagerSecretTFType }
-func (secretManagerSecretDiscoverer) AssetType() string    { return secretManagerSecretAssetType }
+func (secretManagerSecretDiscoverer) ResourceType() string   { return secretManagerSecretTFType }
+func (secretManagerSecretDiscoverer) AssetType() string      { return secretManagerSecretAssetType }
+func (secretManagerSecretDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleLabels }
 
 func (secretManagerSecretDiscoverer) FromAsset(book addressBook, a gcpAssetResult, projectID string) imported.ImportedResource {
 	name := shortName(a.Name)

--- a/cmd/insideout-import/gcpdiscover/storage_bucket.go
+++ b/cmd/insideout-import/gcpdiscover/storage_bucket.go
@@ -31,8 +31,9 @@ type storageBucketDiscoverer struct{}
 
 func newStorageBucketDiscoverer() Discoverer { return &storageBucketDiscoverer{} }
 
-func (storageBucketDiscoverer) ResourceType() string { return storageBucketTFType }
-func (storageBucketDiscoverer) AssetType() string    { return storageBucketAssetType }
+func (storageBucketDiscoverer) ResourceType() string   { return storageBucketTFType }
+func (storageBucketDiscoverer) AssetType() string      { return storageBucketAssetType }
+func (storageBucketDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleLabels }
 
 func (storageBucketDiscoverer) FromAsset(book addressBook, a gcpAssetResult, projectID string) imported.ImportedResource {
 	name := shortName(a.Name)

--- a/cmd/insideout-import/gcpdiscover/testhelpers_test.go
+++ b/cmd/insideout-import/gcpdiscover/testhelpers_test.go
@@ -2,8 +2,11 @@ package gcpdiscover
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
 // recordedEvent is a single emit observed by recordingEmitter (#295).
@@ -87,4 +90,74 @@ func (f *fakeAssetSearcher) SearchAll(_ context.Context, scope string, assetType
 		return nil, f.err
 	}
 	return f.results, nil
+}
+
+// bucketedFakeSearcher is a fakeAssetSearcher that returns a different
+// result slice per call, indexed by the call's first asset-type. Used
+// by mixed-bucket tests that need the labels-style and name-prefix-style
+// SearchAll calls to surface distinct rows so the orchestrator's
+// per-bucket assembly + client-side filter can be pinned independently.
+//
+// The two-bucket dispatch in DiscoverTypes is sequential today
+// (gcpdiscover.go's searchBuckets calls labels-bucket then name-
+// prefix-bucket), so the mutex is a no-op in practice — but pinning
+// `calls` under a lock matches the recordingEmitter sibling and stays
+// safe against a future refactor that parallelizes the two SearchAll
+// invocations.
+type bucketedFakeSearcher struct {
+	resultsByAssetType map[string][]gcpAssetResult
+
+	mu    sync.Mutex
+	calls []searchAllCall
+}
+
+func (b *bucketedFakeSearcher) SearchAll(_ context.Context, scope string, assetTypes []string, query string) ([]gcpAssetResult, error) {
+	cp := make([]string, len(assetTypes))
+	copy(cp, assetTypes)
+	b.mu.Lock()
+	b.calls = append(b.calls, searchAllCall{scope: scope, assetTypes: cp, query: query})
+	b.mu.Unlock()
+	var out []gcpAssetResult
+	for _, at := range assetTypes {
+		out = append(out, b.resultsByAssetType[at]...)
+	}
+	return out, nil
+}
+
+// fakeNamePrefixDiscoverer is the unit-test counterpart to the
+// label-style discoverers — it returns ScopeStyleNamePrefix so the
+// orchestrator routes its asset-type into the name-prefix bucket. Used
+// to exercise the two-bucket dispatch surface introduced in #366
+// without registering a real label-less type (those land in PRs 2+).
+//
+// resourceType and assetType are constructor params so multiple
+// fakes can co-register in one test without colliding.
+type fakeNamePrefixDiscoverer struct {
+	resourceType string
+	assetType    string
+}
+
+func (d *fakeNamePrefixDiscoverer) ResourceType() string   { return d.resourceType }
+func (d *fakeNamePrefixDiscoverer) AssetType() string      { return d.assetType }
+func (d *fakeNamePrefixDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleNamePrefix }
+
+func (d *fakeNamePrefixDiscoverer) FromAsset(_ addressBook, a gcpAssetResult, projectID string) imported.ImportedResource {
+	name := shortName(a.Name)
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:     "gcp",
+			Type:      d.resourceType,
+			Address:   fmt.Sprintf("%s.%s", d.resourceType, name),
+			ImportID:  name,
+			NameHint:  name,
+			ProjectID: projectID,
+			Location:  a.Location,
+		},
+		Tier:   imported.TierImportedFlat,
+		Source: imported.SourceImporter,
+	}
+}
+
+func (d *fakeNamePrefixDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, _ string, _ string) (imported.ImportedResource, error) {
+	return imported.ImportedResource{}, ErrNotSupported
 }


### PR DESCRIPTION
## Summary

Bundle 8 PR 1 — infrastructure prereq that unblocks PRs 2-12 (#367–#377) of the GCP discoverer coverage expansion.

- Adds `Discoverer.ScopeStyle()` returning `ScopeStyleLabels` (default) or `ScopeStyleNamePrefix`.
- `DiscoverTypes` groups discoverers by ScopeStyle and issues one `SearchAllResources` call per non-empty bucket. Labels-bucket keeps the legacy `labels.project:<stack>` query; name-prefix-bucket drops it server-side and applies a client-side substring filter on `asset.Name` (CLAUDE.md label-less-GCP convention).
- All 5 Phase-1 discoverers adopt `ScopeStyleLabels`. **No new resource types** — that's PRs 2-12.

## Verification

- **Unit:** `go test ./cmd/insideout-import/gcpdiscover/... -count=1 -race` — 139 tests pass (115 existing + 24 new from 8 functions, several table-driven).
- **Repo-wide:** `go test ./cmd/insideout-import/... -count=1` — 1178 tests pass across 9 packages.
- **Live GCP smoke:** ran the binary against `diagramtest2025-09-14` (stack `io-qtyb4nkwp5n8`); 3 GCS buckets discovered with full identity. Manifest is byte-identical to a same-flags run of the main-branch binary.
- **/verify:** `terraform fmt -check -recursive` clean; all 4 static lint scripts pass.

## Test plan
- [ ] CI green on all required checks
- [ ] No regression in `TestRegistryParity_GCP_LiveMatchesRegistry`
- [ ] No regression in `TestGCPDiscoverTypes_EmitsServiceStartFinish_OnceForCloudAssetInventory`

## Review notes
- /review findings: P0/P1 none. P2 ×2 resolved (slice-aliasing footgun in `searchBuckets` → fresh allocation; non-exhaustive ScopeStyle switch → explicit cases with error on unknown). P3 ×3 addressed inline (comment correctness; remaining P3s — `String()` on enum, test-fake `DiscoverByID` wrap — deferred as non-blocking).
- qa-professor findings: P0 tautological empty-project test → rewrote with antichain fixture + deep-equal; P1 thin adversarial coverage on `matchesNamePrefix` → expanded to 12 cases including 4 GCP-project-ID-collision rows; P1 bogus trailing-slash row → replaced with a documented true-positive that pins the defensive fallback; P2 count-only filter assertion → deep-equal against expected sorted slice; P2 labels.project count belt-and-braces; P3 mutex on `bucketedFakeSearcher`; P3 registry-parity iteration.

Closes #366.