### PR TITLE
fix(gcpdiscover): parent-name-aware scoping for child resources (#381)

### DIFF
--- a/cmd/insideout-import/gcpdiscover/container_node_pool.go
+++ b/cmd/insideout-import/gcpdiscover/container_node_pool.go
@@ -15,9 +15,11 @@ import (
 // Terraform import ID:   projects/<proj>/locations/<loc>/clusters/<c>/nodePools/<name>
 //
 // Node pools have no labels of their own — labels live on the parent
-// cluster's resource_labels. Per the CLAUDE.md label-less convention,
-// node-pool names should embed the stack project; ScopeStyleNamePrefix
-// scopes them via name substring on the trailing pool name.
+// cluster's resource_labels. Node-pool names are conventionally short
+// (e.g. "default-pool"/"system-pool") with the stack project embedded
+// in the parent cluster name, so this discoverer is scoped via
+// ScopeStyleParentNamePrefix on the "/clusters/" segment (#381), not
+// ScopeStyleNamePrefix on the short pool name.
 
 const (
 	containerNodePoolTFType    = "google_container_node_pool"
@@ -30,7 +32,8 @@ func newContainerNodePoolDiscoverer() Discoverer { return &containerNodePoolDisc
 
 func (containerNodePoolDiscoverer) ResourceType() string   { return containerNodePoolTFType }
 func (containerNodePoolDiscoverer) AssetType() string      { return containerNodePoolAssetType }
-func (containerNodePoolDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleNamePrefix }
+func (containerNodePoolDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleParentNamePrefix }
+func (containerNodePoolDiscoverer) ParentMarker() string   { return "/clusters/" }
 
 func (containerNodePoolDiscoverer) FromAsset(book addressBook, a gcpAssetResult, projectID string) imported.ImportedResource {
 	loc, cluster, name := containerNodePoolAssetParts(a.Name)

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -71,6 +71,16 @@ const (
 	// from the server query and applies the name-substring filter
 	// client-side.
 	ScopeStyleNamePrefix
+	// ScopeStyleParentNamePrefix is for child resources whose own
+	// short name doesn't carry the stack project — the project is
+	// embedded in a parent path segment instead. Examples: KMS
+	// cryptokey (parent = keyring), GKE node pool (parent = cluster).
+	// The aggregator drops the labels.project clause and applies a
+	// per-discoverer parent-segment substring filter client-side; the
+	// marker (e.g. "/keyRings/") is supplied via the parentScopedDiscoverer
+	// side-interface. See #381 for the live-smoke gap that motivated
+	// this scope style.
+	ScopeStyleParentNamePrefix
 )
 
 // ErrNotSupported signals that a discoverer cannot resolve a given ID
@@ -133,6 +143,24 @@ type Discoverer interface {
 	// the ID alone (the asset name encodes type + project + name) when
 	// re-querying the Cloud Asset API for a single resource is wasteful.
 	DiscoverByID(ctx context.Context, searcher gcpAssetSearcher, id, projectID string) (imported.ImportedResource, error)
+}
+
+// parentScopedDiscoverer is an optional contract implemented by
+// Discoverers whose ScopeStyle returns ScopeStyleParentNamePrefix.
+// ParentMarker returns the path-segment marker (e.g. "/keyRings/",
+// "/clusters/") whose enclosed value is the parent name to match
+// against args.Project. The matcher extracts the substring between
+// marker and the next "/" as the parent name and substring-matches
+// that against args.Project.
+//
+// Keeping this on a side-interface (rather than extending Discoverer)
+// keeps the contract trivial for the ~20 discoverers that don't need
+// parent scoping; only the 2-3 child-of-parent types implement it. A
+// ScopeStyleParentNamePrefix discoverer that does NOT implement this
+// is a programmer error — the orchestrator fails loud at search time.
+type parentScopedDiscoverer interface {
+	Discoverer
+	ParentMarker() string
 }
 
 // GCPDiscoverer aggregates the per-type discoverers and fans out a single
@@ -249,13 +277,15 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	// should fail loudly rather than silently routing to the
 	// labels-bucket (where the labels.project clause would return
 	// zero results for a type the discoverer marked as label-less).
-	var labelsBucket, namePrefixBucket []Discoverer
+	var labelsBucket, namePrefixBucket, parentBucket []Discoverer
 	for _, d := range selected {
 		switch d.ScopeStyle() {
 		case ScopeStyleLabels:
 			labelsBucket = append(labelsBucket, d)
 		case ScopeStyleNamePrefix:
 			namePrefixBucket = append(namePrefixBucket, d)
+		case ScopeStyleParentNamePrefix:
+			parentBucket = append(parentBucket, d)
 		default:
 			return nil, fmt.Errorf("discoverer %q reported unknown ScopeStyle %v", d.ResourceType(), d.ScopeStyle())
 		}
@@ -265,7 +295,7 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 
 	stageStart := time.Now()
 	args.Emitter.ServiceStart(gcpServiceSlug, "")
-	results, err := g.searchBuckets(ctx, scope, args, labelsBucket, namePrefixBucket)
+	results, err := g.searchBuckets(ctx, scope, args, labelsBucket, namePrefixBucket, parentBucket)
 	if err != nil {
 		args.Emitter.ServiceFinish(gcpServiceSlug, "", 0, time.Since(stageStart))
 		return nil, err
@@ -384,14 +414,15 @@ func buildSearchQuery(stackProject string, locations []string, selectors []TagSe
 }
 
 // searchBuckets issues one SearchAllResources call per non-empty
-// ScopeStyle bucket and concatenates the results (#366). The
+// ScopeStyle bucket and concatenates the results (#366, #381). The
 // labels-style bucket gets the legacy query with the
-// `labels.project:<stack>` clause; the name-prefix-style bucket gets
-// the same query with the labels.project clause omitted, plus a
-// client-side substring filter on asset.Name. Empty buckets are
-// skipped, so the all-labels-style path (today's only path) remains
-// one round-trip — not two.
-func (g *GCPDiscoverer) searchBuckets(ctx context.Context, scope string, args DiscoverArgs, labelsBucket, namePrefixBucket []Discoverer) ([]gcpAssetResult, error) {
+// `labels.project:<stack>` clause; the name-prefix-style and
+// parent-name-prefix-style buckets get the same query with the
+// labels.project clause omitted, plus a client-side substring filter —
+// against the asset's short name and the asset's parent path segment
+// respectively. Empty buckets are skipped, so the all-labels-style
+// path remains one round-trip.
+func (g *GCPDiscoverer) searchBuckets(ctx context.Context, scope string, args DiscoverArgs, labelsBucket, namePrefixBucket, parentBucket []Discoverer) ([]gcpAssetResult, error) {
 	var out []gcpAssetResult
 
 	if len(labelsBucket) > 0 {
@@ -431,6 +462,45 @@ func (g *GCPDiscoverer) searchBuckets(ctx context.Context, scope string, args Di
 		}
 		out = append(out, rs...)
 	}
+
+	if len(parentBucket) > 0 {
+		query := buildSearchQuery("", args.Regions, args.TagSelectors)
+		rs, err := g.searcher.SearchAll(ctx, scope, assetTypesOf(parentBucket), query)
+		if err != nil {
+			return nil, fmt.Errorf("cloud asset SearchAllResources (parent-name-prefix scope): %w", err)
+		}
+		if args.Project != "" {
+			// Index discoverers by AssetType for per-result marker
+			// lookup. Each parent-scoped type has its own marker
+			// (e.g. /keyRings/ vs /clusters/), so unlike the
+			// labels/name-prefix buckets the filter is not uniform
+			// across the bucket.
+			markerByAsset := make(map[string]string, len(parentBucket))
+			for _, d := range parentBucket {
+				ps, ok := d.(parentScopedDiscoverer)
+				if !ok {
+					return nil, fmt.Errorf("discoverer %q reports ScopeStyleParentNamePrefix but does not implement parentScopedDiscoverer", d.ResourceType())
+				}
+				marker := ps.ParentMarker()
+				if marker == "" {
+					return nil, fmt.Errorf("discoverer %q ParentMarker() returned empty string", d.ResourceType())
+				}
+				markerByAsset[d.AssetType()] = marker
+			}
+			kept := make([]gcpAssetResult, 0, len(rs))
+			for _, r := range rs {
+				marker := markerByAsset[r.AssetType]
+				if marker == "" {
+					continue
+				}
+				if matchesParentNamePrefix(r.Name, marker, args.Project) {
+					kept = append(kept, r)
+				}
+			}
+			rs = kept
+		}
+		out = append(out, rs...)
+	}
 	return out, nil
 }
 
@@ -462,4 +532,40 @@ func assetTypesOf(ds []Discoverer) []string {
 // caller-side guard in searchBuckets defends against that.
 func matchesNamePrefix(assetName, stackProject string) bool {
 	return strings.Contains(shortName(assetName), stackProject)
+}
+
+// matchesParentNamePrefix reports whether the parent segment of a
+// Cloud Asset full resource name — the substring between `marker`
+// (e.g. "/keyRings/") and the next "/" — contains stackProject as a
+// substring. Implements the parent-name scoping convention for child
+// resources whose own short name doesn't carry the stack project (#381).
+//
+// Why the parent segment, not the short name: child resources like
+// KMS cryptokeys are conventionally named "default" / "primary" /
+// etc; the stack project lives in the parent (keyring) name. The
+// leading `//service/projects/<gcp-project-id>/...` segments must
+// NOT match — they hold the real GCP project ID, not the stack name.
+// The trailing short-name segment must also NOT match — see the
+// adversarial test rows in TestMatchesParentNamePrefix.
+//
+// Returns false when:
+//
+//   - marker is absent (defensive — Cloud Asset guarantees the shape
+//     for the asset types we register for ScopeStyleParentNamePrefix,
+//     but a future asset-shape change should fail closed rather than
+//     match every asset).
+//   - the parent segment is empty (e.g. "/keyRings//cryptoKeys/x").
+//
+// Empty stackProject is a programmer error — same caller-side guard
+// pattern as matchesNamePrefix.
+func matchesParentNamePrefix(assetName, marker, stackProject string) bool {
+	_, after, ok := strings.Cut(assetName, marker)
+	if !ok {
+		return false
+	}
+	parent, _, _ := strings.Cut(after, "/")
+	if parent == "" {
+		return false
+	}
+	return strings.Contains(parent, stackProject)
 }

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -121,9 +121,16 @@ type Discoverer interface {
 	// SearchAllResources asset-type filter.
 	AssetType() string
 	// ScopeStyle reports how the orchestrator filters asset results
-	// down to the operator's stack project (#366). Most types return
-	// ScopeStyleLabels; label-less types (per CLAUDE.md's label-less
-	// GCP resource convention) return ScopeStyleNamePrefix.
+	// down to the operator's stack project (#366, #381). Three
+	// return values are recognized:
+	//
+	//   - ScopeStyleLabels — type carries GCP labels.
+	//   - ScopeStyleNamePrefix — type is label-less; the stack
+	//     project is embedded in the resource's own short name.
+	//   - ScopeStyleParentNamePrefix — type is label-less and child
+	//     to a parent whose name embeds the stack project (e.g. KMS
+	//     cryptokey under keyring). Such types must additionally
+	//     implement parentScopedDiscoverer.ParentMarker().
 	ScopeStyle() ScopeStyle
 	// FromAsset translates a single Cloud Asset SearchAllResources result
 	// (already filtered to this discoverer's AssetType) into an
@@ -155,7 +162,7 @@ type Discoverer interface {
 //
 // Keeping this on a side-interface (rather than extending Discoverer)
 // keeps the contract trivial for the ~20 discoverers that don't need
-// parent scoping; only the 2-3 child-of-parent types implement it. A
+// parent scoping; only the few child-of-parent types implement it. A
 // ScopeStyleParentNamePrefix discoverer that does NOT implement this
 // is a programmer error — the orchestrator fails loud at search time.
 type parentScopedDiscoverer interface {

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
@@ -115,12 +115,12 @@ func TestDiscoverTypes_DefaultsToAllSupported(t *testing.T) {
 	if _, err := g.DiscoverTypes(context.Background(), nil, DiscoverArgs{Project: "io-foo", Regions: []string{""}}); err != nil {
 		t.Fatal(err)
 	}
-	// The two-bucket dispatch (#366) issues at most one SearchAll per
-	// non-empty ScopeStyle bucket. When the registry covers both
-	// buckets, the union of asset types across all calls must equal
-	// the supported set.
-	if len(fake.calls) < 1 || len(fake.calls) > 2 {
-		t.Fatalf("SearchAll called %d times, want 1 or 2 (one per non-empty ScopeStyle bucket)", len(fake.calls))
+	// The N-bucket dispatch (#366, #381) issues at most one SearchAll
+	// per non-empty ScopeStyle bucket. When the registry covers
+	// multiple ScopeStyles, the union of asset types across all calls
+	// must equal the supported set.
+	if len(fake.calls) < 1 || len(fake.calls) > 3 {
+		t.Fatalf("SearchAll called %d times, want 1-3 (one per non-empty ScopeStyle bucket)", len(fake.calls))
 	}
 	covered := map[string]struct{}{}
 	for _, c := range fake.calls {
@@ -623,28 +623,33 @@ func TestGCPDiscoverTypes_EmitsStageFinish(t *testing.T) {
 	}
 }
 
-// expectedScopeStyle is the per-type ScopeStyle contract (#366) —
-// adding a new discoverer to NewGCPDiscoverer requires an explicit
+// expectedScopeStyle is the per-type ScopeStyle contract (#366, #381)
+// — adding a new discoverer to NewGCPDiscoverer requires an explicit
 // row here, and TestScopeStyle_PinsPerTypeContract fails on drift in
 // either direction (unknown registered type, or known type with a
-// different ScopeStyle). Adding a row is an intentional decision: a
-// type that carries GCP labels should be ScopeStyleLabels; a label-
-// less type (CLAUDE.md L84 convention) should be ScopeStyleNamePrefix.
+// different ScopeStyle). Adding a row is an intentional decision:
+//
+//   - ScopeStyleLabels — type carries GCP labels.
+//   - ScopeStyleNamePrefix — type is label-less and the stack project
+//     is embedded in the resource's own short name (CLAUDE.md L84).
+//   - ScopeStyleParentNamePrefix — type is label-less and child to a
+//     parent whose name embeds the stack project (e.g. KMS cryptokey
+//     under keyring, GKE node pool under cluster) (#381).
 var expectedScopeStyle = map[string]ScopeStyle{
 	"google_pubsub_topic":                    ScopeStyleLabels,
 	"google_pubsub_subscription":             ScopeStyleLabels,
 	"google_storage_bucket":                  ScopeStyleLabels,
 	"google_secret_manager_secret":           ScopeStyleLabels,
 	"google_compute_network":                 ScopeStyleLabels,
-	"google_service_account":                 ScopeStyleNamePrefix, // IAM SAs have no labels (#367)
-	"google_kms_key_ring":                    ScopeStyleNamePrefix, // KMS keyrings have no labels (#368)
-	"google_kms_crypto_key":                  ScopeStyleNamePrefix, // KMS cryptokeys have no labels (#368)
-	"google_compute_firewall":                ScopeStyleNamePrefix, // firewalls have no labels (#369)
-	"google_compute_router":                  ScopeStyleNamePrefix, // routers have no labels (#369)
-	"google_compute_address":                 ScopeStyleLabels,     // addresses carry labels (#369)
-	"google_compute_instance":                ScopeStyleLabels,     // VMs carry labels (#370)
-	"google_container_cluster":               ScopeStyleLabels,     // GKE clusters carry labels (#371)
-	"google_container_node_pool":             ScopeStyleNamePrefix, // node pools have no labels (#371)
+	"google_service_account":                 ScopeStyleNamePrefix,       // IAM SAs have no labels (#367)
+	"google_kms_key_ring":                    ScopeStyleNamePrefix,       // KMS keyrings have no labels (#368)
+	"google_kms_crypto_key":                  ScopeStyleParentNamePrefix, // child of keyring (#381)
+	"google_compute_firewall":                ScopeStyleNamePrefix,       // firewalls have no labels (#369)
+	"google_compute_router":                  ScopeStyleNamePrefix,       // routers have no labels (#369)
+	"google_compute_address":                 ScopeStyleLabels,           // addresses carry labels (#369)
+	"google_compute_instance":                ScopeStyleLabels,           // VMs carry labels (#370)
+	"google_container_cluster":               ScopeStyleLabels,           // GKE clusters carry labels (#371)
+	"google_container_node_pool":             ScopeStyleParentNamePrefix, // child of cluster (#381)
 	"google_sql_database_instance":           ScopeStyleLabels,     // Cloud SQL via settings.user_labels (#372)
 	"google_cloud_run_v2_service":            ScopeStyleLabels,     // Cloud Run v2 carries labels (#373)
 	"google_cloudfunctions2_function":        ScopeStyleLabels,     // Cloud Functions v2 carries labels (#373)
@@ -1167,4 +1172,471 @@ func namesOf(rs []imported.ImportedResource) []string {
 		out = append(out, r.Identity.NameHint)
 	}
 	return out
+}
+
+// TestParentScopedDiscoverer_ContractMatchesScopeStyle pins the
+// bidirectional invariant between ScopeStyle() and the
+// parentScopedDiscoverer side-interface (#381):
+//
+//   - Every registered discoverer that reports
+//     ScopeStyleParentNamePrefix MUST implement parentScopedDiscoverer
+//     and return a non-empty ParentMarker. Otherwise the orchestrator's
+//     third-bucket post-filter has no marker to extract, and the
+//     searchBuckets path fails loud at search time — but in production,
+//     not in tests. This test surfaces it at compile-time-ish (test-time
+//     against the live registration map).
+//
+//   - No registered discoverer with a NON-ScopeStyleParentNamePrefix
+//     style may implement parentScopedDiscoverer. An accidental
+//     ParentMarker on (say) a ScopeStyleNamePrefix type signals
+//     contract drift — the marker won't be consulted and the silent
+//     dead-code is a maintenance trap.
+func TestParentScopedDiscoverer_ContractMatchesScopeStyle(t *testing.T) {
+	t.Parallel()
+	g := NewGCPDiscoverer(&fakeAssetSearcher{}, "p")
+	if len(g.byType) == 0 {
+		t.Fatal("no discoverers registered; parent-scoped contract test would be vacuous")
+	}
+	for tfType, d := range g.byType {
+		t.Run(tfType, func(t *testing.T) {
+			t.Parallel()
+			ps, isParent := d.(parentScopedDiscoverer)
+			switch d.ScopeStyle() {
+			case ScopeStyleParentNamePrefix:
+				if !isParent {
+					t.Errorf("%s.ScopeStyle()=ScopeStyleParentNamePrefix but does not implement parentScopedDiscoverer (add ParentMarker() string)", tfType)
+					return
+				}
+				if marker := ps.ParentMarker(); marker == "" {
+					t.Errorf("%s.ParentMarker() returned empty string; must be a non-empty path marker like \"/keyRings/\"", tfType)
+				}
+			default:
+				if isParent {
+					t.Errorf("%s implements parentScopedDiscoverer but ScopeStyle()=%v (not ScopeStyleParentNamePrefix) — accidental marker is dead code", tfType, d.ScopeStyle())
+				}
+			}
+		})
+	}
+}
+
+// TestDiscoverTypes_ParentBucketOnly_OneCallWithoutLabelsClause is the
+// parent-bucket counterpart of
+// TestDiscoverTypes_NamePrefixBucketOnly_OneCallWithoutLabelsClause
+// (#381). When every selected discoverer reports
+// ScopeStyleParentNamePrefix, the orchestrator issues exactly one
+// SearchAllResources call whose query MUST NOT include
+// `labels.project:` — parent-scoped types are label-less by
+// construction, so the server-side clause would unconditionally
+// exclude every result. Location and other clauses must still
+// propagate.
+func TestDiscoverTypes_ParentBucketOnly_OneCallWithoutLabelsClause(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{}
+	g := &GCPDiscoverer{
+		searcher:  fake,
+		projectID: "real-proj",
+		byType: map[string]Discoverer{
+			"google_fake_parent": &fakeParentNamePrefixDiscoverer{
+				resourceType: "google_fake_parent",
+				assetType:    "test.googleapis.com/ParentScoped",
+				parentMarker: "/parents/",
+			},
+		},
+	}
+	if _, err := g.DiscoverTypes(context.Background(), []string{"google_fake_parent"}, DiscoverArgs{
+		Project: "io-foo",
+		Regions: []string{"us-central1"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("SearchAll calls=%d, want 1 (one bucket, one round-trip)", len(fake.calls))
+	}
+	if strings.Contains(fake.calls[0].query, "labels.project:") {
+		t.Errorf("parent-bucket query=%q, want NO labels.project clause", fake.calls[0].query)
+	}
+	if !strings.Contains(fake.calls[0].query, "location:us-central1") {
+		t.Errorf("parent-bucket query=%q, want location:us-central1 to still propagate", fake.calls[0].query)
+	}
+}
+
+// TestDiscoverTypes_ParentNamePrefixFiltersOnParentSegment pins the
+// third-bucket client-side filter (#381). The filter must check the
+// parent path segment (between the discoverer's ParentMarker and the
+// next "/"), NOT the trailing short name and NOT earlier path segments
+// like /projects/<gcp-project-id>/. The three asset rows cover:
+//
+//  1. Parent contains the stack project → kept.
+//  2. Parent does NOT contain the stack project → dropped (the short
+//     name "default" alone is conventional for the parent-scoped types
+//     this lane serves).
+//  3. Stack project appears in /projects/<gcp-project-id>/ AND in the
+//     short name, but NOT in the parent segment → dropped. Pins that
+//     the filter is parent-segment-only — a regression that fell back
+//     to matchesNamePrefix or to a full-string strings.Contains would
+//     mistakenly keep this asset.
+//
+// Uses the live kms_crypto_key discoverer end-to-end so the registered
+// "/keyRings/" marker is exercised rather than a fake.
+func TestDiscoverTypes_ParentNamePrefixFiltersOnParentSegment(t *testing.T) {
+	t.Parallel()
+	const tfType = "google_kms_crypto_key"
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{
+			// 1. Parent ring carries io-foo.
+			{Name: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/io-foo-main-ring-abc/cryptoKeys/default", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
+			// 2. Parent ring does NOT carry io-foo.
+			{Name: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/other-stack-ring/cryptoKeys/default", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
+			// 3. io-foo in leading GCP project ID AND in trailing short
+			//    name, but NOT in the parent. Must drop.
+			{Name: "//cloudkms.googleapis.com/projects/io-foo-real-proj/locations/us-central1/keyRings/elsewhere/cryptoKeys/io-foo-shaped-name", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
+		},
+	}
+	g := &GCPDiscoverer{
+		searcher:  fake,
+		projectID: "real-proj",
+		byType: map[string]Discoverer{
+			tfType: newKMSCryptoKeyDiscoverer(),
+		},
+	}
+	got, err := g.DiscoverTypes(context.Background(), []string{tfType}, DiscoverArgs{
+		Project: "io-foo",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// All three assets are named "default" / "default" /
+	// "io-foo-shaped-name". The expected survivor has NameHint
+	// "default" but came from the ring that carries io-foo. That makes
+	// the NameHint alone an ambiguous assertion (#1 and #2 both produce
+	// "default"); pin on the parent ring extracted into
+	// NativeIDs["key_ring"] for unambiguous evidence.
+	if len(got) != 1 {
+		t.Fatalf("kept=%d, want 1 (only the io-foo-parent asset must survive); names=%v", len(got), namesOf(got))
+	}
+	if got[0].Identity.NameHint != "default" {
+		t.Errorf("kept NameHint=%q, want default", got[0].Identity.NameHint)
+	}
+	if ring := got[0].Identity.NativeIDs["key_ring"]; ring != "io-foo-main-ring-abc" {
+		t.Errorf("kept key_ring=%q, want io-foo-main-ring-abc — wrong asset survived?", ring)
+	}
+}
+
+// TestDiscoverTypes_ParentNamePrefixEmptyProjectPassesThrough pins
+// the no-filter case for the parent bucket (#381), symmetric with the
+// labels and name-prefix lanes: when args.Project is empty, the
+// per-result parent-segment filter is skipped and every asset passes
+// through.
+//
+// Antichain construction (same shape as
+// TestDiscoverTypes_NamePrefixEmptyProjectPassesThrough): three
+// parent rings (alpha/zeta/mid) with no substring overlap, all with
+// the conventional "default" child name. A regression that ran the
+// substring filter with an empty needle would still pass trivially
+// (strings.Contains(x, "") == true), so the assertion checks every
+// input survived AND in the orchestrator's stable-by-asset-Name
+// order.
+func TestDiscoverTypes_ParentNamePrefixEmptyProjectPassesThrough(t *testing.T) {
+	t.Parallel()
+	const tfType = "google_kms_crypto_key"
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{
+			{Name: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/alpha/cryptoKeys/default", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
+			{Name: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/zeta/cryptoKeys/default", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
+			{Name: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/mid/cryptoKeys/default", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
+		},
+	}
+	g := &GCPDiscoverer{
+		searcher:  fake,
+		projectID: "real-proj",
+		byType: map[string]Discoverer{
+			tfType: newKMSCryptoKeyDiscoverer(),
+		},
+	}
+	got, err := g.DiscoverTypes(context.Background(), []string{tfType}, DiscoverArgs{
+		Project: "",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Stable sort by full Cloud Asset Name puts alpha < mid < zeta.
+	// NameHint is "default" for all three (cryptokey names collide on
+	// "default" — the realistic shape that motivated #381) so pin via
+	// the parent ring instead.
+	if len(got) != 3 {
+		t.Fatalf("kept=%d, want 3 (empty stack project must pass every result through); names=%v", len(got), namesOf(got))
+	}
+	wantRings := []string{"alpha", "mid", "zeta"}
+	gotRings := make([]string, len(got))
+	for i, r := range got {
+		gotRings[i] = r.Identity.NativeIDs["key_ring"]
+	}
+	if !reflect.DeepEqual(gotRings, wantRings) {
+		t.Errorf("kept rings=%v, want %v (every input must pass through unchanged when args.Project is empty)", gotRings, wantRings)
+	}
+}
+
+// TestDiscoverTypes_MixedThreeBuckets_ThreeSearchCallsWithDifferentQueries
+// pins the three-call dispatch when all three ScopeStyle buckets are
+// non-empty (#381). Extension of the existing two-bucket
+// mixed-buckets test:
+//
+//   - 3 SearchAllResources calls, one per ScopeStyle.
+//   - Asset-type partition is strict — no asset type appears in
+//     more than one call.
+//   - Labels call carries `labels.project:io-foo`; the other two do not.
+//   - The full result set (one per bucket) is returned.
+func TestDiscoverTypes_MixedThreeBuckets_ThreeSearchCallsWithDifferentQueries(t *testing.T) {
+	t.Parallel()
+	fake := &bucketedFakeSearcher{
+		resultsByAssetType: map[string][]gcpAssetResult{
+			"pubsub.googleapis.com/Topic": {
+				{Name: "//pubsub.googleapis.com/projects/real-proj/topics/io-foo-events", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj", Labels: map[string]string{"project": "io-foo"}},
+			},
+			"test.googleapis.com/NamePrefixed": {
+				{Name: "//test.googleapis.com/projects/real-proj/widgets/io-foo-widget", AssetType: "test.googleapis.com/NamePrefixed", Project: "real-proj"},
+			},
+			"cloudkms.googleapis.com/CryptoKey": {
+				{Name: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/io-foo-ring/cryptoKeys/default", AssetType: "cloudkms.googleapis.com/CryptoKey", Project: "real-proj", Location: "us-central1"},
+			},
+		},
+	}
+	g := &GCPDiscoverer{
+		searcher:  fake,
+		projectID: "real-proj",
+		byType: map[string]Discoverer{
+			"google_pubsub_topic": newPubsubTopicDiscoverer(),
+			"google_fake_namepref": &fakeNamePrefixDiscoverer{
+				resourceType: "google_fake_namepref",
+				assetType:    "test.googleapis.com/NamePrefixed",
+			},
+			"google_kms_crypto_key": newKMSCryptoKeyDiscoverer(),
+		},
+	}
+	got, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic", "google_fake_namepref", "google_kms_crypto_key"}, DiscoverArgs{
+		Project: "io-foo",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 3 {
+		t.Fatalf("SearchAll calls=%d, want 3 (one per ScopeStyle bucket); calls=%+v", len(fake.calls), fake.calls)
+	}
+
+	var labelsCall, nameCall, parentCall *searchAllCall
+	for i := range fake.calls {
+		c := &fake.calls[i]
+		switch {
+		case slices.Contains(c.assetTypes, "pubsub.googleapis.com/Topic"):
+			labelsCall = c
+		case slices.Contains(c.assetTypes, "test.googleapis.com/NamePrefixed"):
+			nameCall = c
+		case slices.Contains(c.assetTypes, "cloudkms.googleapis.com/CryptoKey"):
+			parentCall = c
+		}
+	}
+	if labelsCall == nil {
+		t.Fatal("no SearchAll call carried the labels-bucket asset type")
+	}
+	if nameCall == nil {
+		t.Fatal("no SearchAll call carried the name-prefix-bucket asset type")
+	}
+	if parentCall == nil {
+		t.Fatal("no SearchAll call carried the parent-name-prefix-bucket asset type")
+	}
+
+	if !strings.Contains(labelsCall.query, "labels.project:io-foo") {
+		t.Errorf("labels-bucket query=%q, want labels.project:io-foo", labelsCall.query)
+	}
+	if strings.Contains(nameCall.query, "labels.project:") {
+		t.Errorf("name-prefix-bucket query=%q, want NO labels.project clause", nameCall.query)
+	}
+	if strings.Contains(parentCall.query, "labels.project:") {
+		t.Errorf("parent-bucket query=%q, want NO labels.project clause", parentCall.query)
+	}
+
+	// Strict partition — no asset type leaks across buckets.
+	for _, at := range []string{"test.googleapis.com/NamePrefixed", "cloudkms.googleapis.com/CryptoKey"} {
+		if slices.Contains(labelsCall.assetTypes, at) {
+			t.Errorf("labels-bucket call asset types=%v, must not include %q", labelsCall.assetTypes, at)
+		}
+	}
+	for _, at := range []string{"pubsub.googleapis.com/Topic", "cloudkms.googleapis.com/CryptoKey"} {
+		if slices.Contains(nameCall.assetTypes, at) {
+			t.Errorf("name-prefix-bucket call asset types=%v, must not include %q", nameCall.assetTypes, at)
+		}
+	}
+	for _, at := range []string{"pubsub.googleapis.com/Topic", "test.googleapis.com/NamePrefixed"} {
+		if slices.Contains(parentCall.assetTypes, at) {
+			t.Errorf("parent-bucket call asset types=%v, must not include %q", parentCall.assetTypes, at)
+		}
+	}
+
+	// All three buckets contribute to the returned slice.
+	if len(got) != 3 {
+		t.Fatalf("ImportedResources=%d, want 3 (one per bucket); names=%v", len(got), namesOf(got))
+	}
+}
+
+// TestDiscoverTypes_ThreeBucketsEmitOneServiceStartFinishPair extends
+// the single-pair contract (#295) to the three-bucket path (#381):
+// even when all three ScopeStyle buckets issue independent
+// SearchAllResources calls, the orchestrator emits exactly one
+// (service_start, service_finish) pair around the combined operation.
+func TestDiscoverTypes_ThreeBucketsEmitOneServiceStartFinishPair(t *testing.T) {
+	t.Parallel()
+	fake := &bucketedFakeSearcher{
+		resultsByAssetType: map[string][]gcpAssetResult{
+			"pubsub.googleapis.com/Topic": {
+				{Name: "//pubsub.googleapis.com/projects/real-proj/topics/io-foo-events", AssetType: "pubsub.googleapis.com/Topic"},
+			},
+			"test.googleapis.com/NamePrefixed": {
+				{Name: "//test.googleapis.com/projects/real-proj/widgets/io-foo-widget", AssetType: "test.googleapis.com/NamePrefixed"},
+			},
+			"cloudkms.googleapis.com/CryptoKey": {
+				{Name: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/io-foo-ring/cryptoKeys/default", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
+			},
+		},
+	}
+	g := &GCPDiscoverer{
+		searcher:  fake,
+		projectID: "real-proj",
+		byType: map[string]Discoverer{
+			"google_pubsub_topic": newPubsubTopicDiscoverer(),
+			"google_fake_namepref": &fakeNamePrefixDiscoverer{
+				resourceType: "google_fake_namepref",
+				assetType:    "test.googleapis.com/NamePrefixed",
+			},
+			"google_kms_crypto_key": newKMSCryptoKeyDiscoverer(),
+		},
+	}
+	rec := &recordingEmitter{}
+	if _, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic", "google_fake_namepref", "google_kms_crypto_key"}, DiscoverArgs{
+		Project: "io-foo",
+		Emitter: rec,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	starts, finishes := 0, 0
+	for _, e := range rec.snapshot() {
+		switch e.Kind {
+		case "service_start":
+			starts++
+		case "service_finish":
+			finishes++
+		}
+	}
+	if starts != 1 {
+		t.Errorf("service_start count=%d, want 1 (one pair across all three ScopeStyle buckets)", starts)
+	}
+	if finishes != 1 {
+		t.Errorf("service_finish count=%d, want 1 (one pair across all three ScopeStyle buckets)", finishes)
+	}
+}
+
+// TestMatchesParentNamePrefix pins the parent-segment matcher's
+// contract (#381). Same adversarial shape as TestMatchesNamePrefix:
+// the load-bearing rows are the ones that pin what the matcher MUST
+// NOT match. A regression that fell back to substring on the full
+// asset name (or on the trailing short name) would fail loudly.
+func TestMatchesParentNamePrefix(t *testing.T) {
+	t.Parallel()
+	const ringMarker = "/keyRings/"
+	cases := []struct {
+		name      string
+		assetName string
+		marker    string
+		project   string
+		want      bool
+	}{
+		// Happy paths.
+		{
+			name:      "parent contains project as prefix",
+			assetName: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/io-foo-main/cryptoKeys/default",
+			marker:    ringMarker, project: "io-foo", want: true,
+		},
+		{
+			name:      "parent equals project exactly",
+			assetName: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/io-foo/cryptoKeys/default",
+			marker:    ringMarker, project: "io-foo", want: true,
+		},
+		{
+			name:      "parent contains project as infix",
+			assetName: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/main-io-foo-ring/cryptoKeys/default",
+			marker:    ringMarker, project: "io-foo", want: true,
+		},
+		{
+			name:      "parent does not contain project",
+			assetName: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/other-stack/cryptoKeys/default",
+			marker:    ringMarker, project: "io-foo", want: false,
+		},
+
+		// Adversarial: stack project appears in earlier path segments
+		// (GCP project ID or location) while the parent ring is owned
+		// by a different stack. Must NOT match.
+		{
+			name:      "project in leading GCP project ID segment, not in parent",
+			assetName: "//cloudkms.googleapis.com/projects/io-foo-real-proj/locations/us-central1/keyRings/elsewhere/cryptoKeys/default",
+			marker:    ringMarker, project: "io-foo", want: false,
+		},
+		{
+			name:      "project in location segment, not in parent",
+			assetName: "//cloudkms.googleapis.com/projects/real-proj/locations/io-foo-zone/keyRings/other-stack/cryptoKeys/default",
+			marker:    ringMarker, project: "io-foo", want: false,
+		},
+
+		// Adversarial: project appears in the trailing child short name
+		// but NOT in the parent. The parent-bucket filter must consult
+		// the parent segment, not the short name — otherwise child
+		// names conventionally embedding the stack would mask the
+		// parent-name convention this scope style exists to enforce.
+		{
+			name:      "project in child short name only, not in parent",
+			assetName: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/elsewhere/cryptoKeys/io-foo-shaped-name",
+			marker:    ringMarker, project: "io-foo", want: false,
+		},
+
+		// Edge cases.
+		{
+			name:      "marker absent — defensive false (fails closed)",
+			assetName: "//pubsub.googleapis.com/projects/real-proj/topics/io-foo-events",
+			marker:    ringMarker, project: "io-foo", want: false,
+		},
+		{
+			name:      "empty parent segment between markers",
+			assetName: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings//cryptoKeys/default",
+			marker:    ringMarker, project: "io-foo", want: false,
+		},
+		{
+			name:      "empty asset name",
+			assetName: "",
+			marker:    ringMarker, project: "io-foo", want: false,
+		},
+		{
+			name:      "marker is the last token (no trailing slash) — full remainder is the parent",
+			assetName: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/io-foo-tail",
+			marker:    ringMarker, project: "io-foo", want: true,
+		},
+
+		// Clusters marker — pin that the helper is marker-generic, not
+		// keyrings-specific.
+		{
+			name:      "different marker (clusters) — parent contains project",
+			assetName: "//container.googleapis.com/projects/real-proj/locations/us-central1/clusters/io-foo-gke/nodePools/default-pool",
+			marker:    "/clusters/", project: "io-foo", want: true,
+		},
+		{
+			name:      "different marker (clusters) — parent does not contain project",
+			assetName: "//container.googleapis.com/projects/real-proj/locations/us-central1/clusters/other-gke/nodePools/default-pool",
+			marker:    "/clusters/", project: "io-foo", want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := matchesParentNamePrefix(tc.assetName, tc.marker, tc.project); got != tc.want {
+				t.Errorf("matchesParentNamePrefix(%q, %q, %q) = %v, want %v", tc.assetName, tc.marker, tc.project, got, tc.want)
+			}
+		})
+	}
 }

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
@@ -115,12 +115,18 @@ func TestDiscoverTypes_DefaultsToAllSupported(t *testing.T) {
 	if _, err := g.DiscoverTypes(context.Background(), nil, DiscoverArgs{Project: "io-foo", Regions: []string{""}}); err != nil {
 		t.Fatal(err)
 	}
-	// The N-bucket dispatch (#366, #381) issues at most one SearchAll
-	// per non-empty ScopeStyle bucket. When the registry covers
-	// multiple ScopeStyles, the union of asset types across all calls
-	// must equal the supported set.
-	if len(fake.calls) < 1 || len(fake.calls) > 3 {
-		t.Fatalf("SearchAll called %d times, want 1-3 (one per non-empty ScopeStyle bucket)", len(fake.calls))
+	// The N-bucket dispatch (#366, #381) issues one SearchAll per
+	// non-empty ScopeStyle bucket. The production registry currently
+	// populates all three buckets (labels + name-prefix + parent-
+	// name-prefix), so the production call count is exactly 3. A
+	// regression that collapsed two buckets into one would silently
+	// pass a `1-3` range assertion, so pin the exact value. If a
+	// future change empties a ScopeStyle bucket out of the registry
+	// (e.g. flips the last NamePrefix type to Labels), update this
+	// expected count in lockstep.
+	const wantCalls = 3
+	if len(fake.calls) != wantCalls {
+		t.Fatalf("SearchAll called %d times, want %d (one per non-empty ScopeStyle bucket)", len(fake.calls), wantCalls)
 	}
 	covered := map[string]struct{}{}
 	for _, c := range fake.calls {
@@ -1263,33 +1269,53 @@ func TestDiscoverTypes_ParentBucketOnly_OneCallWithoutLabelsClause(t *testing.T)
 // TestDiscoverTypes_ParentNamePrefixFiltersOnParentSegment pins the
 // third-bucket client-side filter (#381). The filter must check the
 // parent path segment (between the discoverer's ParentMarker and the
-// next "/"), NOT the trailing short name and NOT earlier path segments
-// like /projects/<gcp-project-id>/. The three asset rows cover:
+// next "/"), NOT the trailing short name and NOT earlier path
+// segments like /projects/<gcp-project-id>/.
 //
-//  1. Parent contains the stack project → kept.
-//  2. Parent does NOT contain the stack project → dropped (the short
-//     name "default" alone is conventional for the parent-scoped types
-//     this lane serves).
-//  3. Stack project appears in /projects/<gcp-project-id>/ AND in the
-//     short name, but NOT in the parent segment → dropped. Pins that
-//     the filter is parent-segment-only — a regression that fell back
-//     to matchesNamePrefix or to a full-string strings.Contains would
-//     mistakenly keep this asset.
+// Four asset rows, ordered so that:
 //
-// Uses the live kms_crypto_key discoverer end-to-end so the registered
-// "/keyRings/" marker is exercised rather than a fake.
+//   - the orchestrator's stable-sort-by-asset-Name puts a DROPPED
+//     asset first (alphabetically before any survivor), so a mutation
+//     that replaces the filter with `rs[:N]` (keep first N) fails.
+//   - TWO assets survive (alpha-prefix and zeta-prefix rings, both
+//     embedding "io-foo"), so a mutation that keeps only one
+//     element fails.
+//   - TWO assets are dropped, both adversarial in different ways
+//     (project-in-gcp-id+short-name vs project-in-location).
+//
+// Uses the live kms_crypto_key discoverer end-to-end so the
+// registered "/keyRings/" marker is exercised rather than a fake.
 func TestDiscoverTypes_ParentNamePrefixFiltersOnParentSegment(t *testing.T) {
 	t.Parallel()
 	const tfType = "google_kms_crypto_key"
+	// Asset names are sorted in the Cloud Asset response by the
+	// orchestrator (gcpdiscover.go's stable-sort), and the sort key
+	// is the full asset Name. The four entries here sort as:
+	//
+	//   1. //cloudkms.../keyRings/aaa-other-stack-ring/...      DROPPED
+	//   2. //cloudkms.../keyRings/io-foo-alpha-ring/...         KEPT
+	//   3. //cloudkms.../keyRings/io-foo-zeta-ring/...          KEPT
+	//   4. //cloudkms.../keyRings/zzz-elsewhere/...             DROPPED
+	//
+	// The DROPPED entry at position 1 defeats the "keep first" mutation.
+	// The KEPT entry at position 4 (zzz parent, but actually io-foo-zeta
+	// — see below) — wait, no: the io-foo-* keys sort before zzz. Layout
+	// after the orchestrator's stable-sort is exactly the order above.
 	fake := &fakeAssetSearcher{
 		results: []gcpAssetResult{
-			// 1. Parent ring carries io-foo.
-			{Name: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/io-foo-main-ring-abc/cryptoKeys/default", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
-			// 2. Parent ring does NOT carry io-foo.
-			{Name: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/other-stack-ring/cryptoKeys/default", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
-			// 3. io-foo in leading GCP project ID AND in trailing short
-			//    name, but NOT in the parent. Must drop.
-			{Name: "//cloudkms.googleapis.com/projects/io-foo-real-proj/locations/us-central1/keyRings/elsewhere/cryptoKeys/io-foo-shaped-name", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
+			// Adversarial: project-in-gcp-id AND in the trailing
+			// short name, but the parent ring is "zzz-elsewhere".
+			{Name: "//cloudkms.googleapis.com/projects/io-foo-real-proj/locations/us-central1/keyRings/zzz-elsewhere/cryptoKeys/io-foo-shaped-name", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
+			// Adversarial: parent ring does NOT carry io-foo
+			// (alphabetically first — sort makes this the first
+			// element in the bucket).
+			{Name: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/aaa-other-stack-ring/cryptoKeys/default", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
+			// KEPT: parent ring carries io-foo (alpha sort key
+			// puts it second after stable sort).
+			{Name: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/io-foo-alpha-ring/cryptoKeys/default", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
+			// KEPT: a second io-foo-* ring; pins that the filter
+			// keeps MULTIPLE matches, not just the first.
+			{Name: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/io-foo-zeta-ring/cryptoKeys/default", AssetType: "cloudkms.googleapis.com/CryptoKey", Location: "us-central1"},
 		},
 	}
 	g := &GCPDiscoverer{
@@ -1305,20 +1331,21 @@ func TestDiscoverTypes_ParentNamePrefixFiltersOnParentSegment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// All three assets are named "default" / "default" /
-	// "io-foo-shaped-name". The expected survivor has NameHint
-	// "default" but came from the ring that carries io-foo. That makes
-	// the NameHint alone an ambiguous assertion (#1 and #2 both produce
-	// "default"); pin on the parent ring extracted into
-	// NativeIDs["key_ring"] for unambiguous evidence.
-	if len(got) != 1 {
-		t.Fatalf("kept=%d, want 1 (only the io-foo-parent asset must survive); names=%v", len(got), namesOf(got))
+	// Three cryptokey names collide on "default" / "default" /
+	// "io-foo-shaped-name", and the trailing short name is "default"
+	// for the survivors — making NameHint a poor discriminator. Pin
+	// the parent ring via NativeIDs["key_ring"] (set by FromAsset
+	// from the parsed /keyRings/<name>/ segment).
+	if len(got) != 2 {
+		t.Fatalf("kept=%d, want 2 (the two io-foo-* parent rings must survive); names=%v", len(got), namesOf(got))
 	}
-	if got[0].Identity.NameHint != "default" {
-		t.Errorf("kept NameHint=%q, want default", got[0].Identity.NameHint)
+	gotRings := []string{
+		got[0].Identity.NativeIDs["key_ring"],
+		got[1].Identity.NativeIDs["key_ring"],
 	}
-	if ring := got[0].Identity.NativeIDs["key_ring"]; ring != "io-foo-main-ring-abc" {
-		t.Errorf("kept key_ring=%q, want io-foo-main-ring-abc — wrong asset survived?", ring)
+	wantRings := []string{"io-foo-alpha-ring", "io-foo-zeta-ring"}
+	if !reflect.DeepEqual(gotRings, wantRings) {
+		t.Errorf("kept rings=%v, want %v (filter must keep parent-ring matches and drop non-matches)", gotRings, wantRings)
 	}
 }
 
@@ -1617,6 +1644,37 @@ func TestMatchesParentNamePrefix(t *testing.T) {
 			assetName: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/io-foo-tail",
 			marker:    ringMarker, project: "io-foo", want: true,
 		},
+		// Programmer-error surface: empty marker is the caller's
+		// responsibility (searchBuckets rejects empty markers at the
+		// per-discoverer guard — pinned by
+		// TestSearchBuckets_ParentEmptyMarker_FailsLoud). Not exercised
+		// here because the helper's behavior with sep="" depends on
+		// where the first "/" lands in the asset string, which makes
+		// the result implementation-defined from the helper's point of
+		// view. The contract-pinning test sits at the caller layer.
+		//
+		// Programmer-error surface: empty project. strings.Contains
+		// with an empty needle returns true, so any non-empty parent
+		// segment "matches". Documented behavior — caller
+		// (searchBuckets's `if args.Project != ""` guard at
+		// gcpdiscover.go:472) MUST skip this filter for empty
+		// projects. Pin the behavior so a "harden the helper" change
+		// silently flipping it surfaces here.
+		{
+			name:      "empty project — caller responsibility (vacuous true match)",
+			assetName: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/anyring/cryptoKeys/default",
+			marker:    ringMarker, project: "", want: true,
+		},
+		// Marker appearing twice. strings.Cut splits on the first
+		// occurrence, so the parent is extracted from the FIRST
+		// /keyRings/ — the second is ignored as just another segment
+		// inside the child path. Pin the first-occurrence behavior
+		// against a refactor that swapped to LastIndex.
+		{
+			name:      "marker appears twice — first occurrence wins",
+			assetName: "//cloudkms.googleapis.com/projects/real-proj/locations/us-central1/keyRings/io-foo-ring/cryptoKeys/x/keyRings/decoy-not-io-foo",
+			marker:    ringMarker, project: "io-foo", want: true,
+		},
 
 		// Clusters marker — pin that the helper is marker-generic, not
 		// keyrings-specific.
@@ -1638,5 +1696,109 @@ func TestMatchesParentNamePrefix(t *testing.T) {
 				t.Errorf("matchesParentNamePrefix(%q, %q, %q) = %v, want %v", tc.assetName, tc.marker, tc.project, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestSearchBuckets_ParentMissingSideInterface_FailsLoud pins one of
+// the two programmer-error returns in searchBuckets (#381). A
+// Discoverer that reports ScopeStyleParentNamePrefix but does NOT
+// implement parentScopedDiscoverer (no ParentMarker method) must
+// cause DiscoverTypes to fail with a descriptive error rather than
+// silently route around it. Without this test, a refactor that
+// demoted the error to a continue would ship green.
+//
+// TestParentScopedDiscoverer_ContractMatchesScopeStyle covers the
+// live-registry side of the contract; this covers the runtime
+// fault-injection side.
+func TestSearchBuckets_ParentMissingSideInterface_FailsLoud(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{}
+	g := &GCPDiscoverer{
+		searcher:  fake,
+		projectID: "real-proj",
+		byType: map[string]Discoverer{
+			"google_broken_parent": &brokenParentScopeDiscoverer{
+				resourceType: "google_broken_parent",
+				assetType:    "test.googleapis.com/BrokenParent",
+			},
+		},
+	}
+	_, err := g.DiscoverTypes(context.Background(), []string{"google_broken_parent"}, DiscoverArgs{
+		Project: "io-foo",
+	})
+	if err == nil {
+		t.Fatal("DiscoverTypes returned nil error; expected programmer-error return for missing parentScopedDiscoverer")
+	}
+	if !strings.Contains(err.Error(), "does not implement parentScopedDiscoverer") {
+		t.Errorf("err=%v, want error mentioning the missing-side-interface contract", err)
+	}
+	if !strings.Contains(err.Error(), "google_broken_parent") {
+		t.Errorf("err=%v, want error to name the offending type", err)
+	}
+}
+
+// TestSearchBuckets_ParentEmptyMarker_FailsLoud pins the second
+// programmer-error return in searchBuckets (#381): a parent-scoped
+// discoverer that DOES implement the side-interface but returns ""
+// from ParentMarker. Returning empty would short-circuit
+// matchesParentNamePrefix's match (defensive false), silently
+// dropping every asset of that type — far worse than a loud error
+// at search time.
+func TestSearchBuckets_ParentEmptyMarker_FailsLoud(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{}
+	g := &GCPDiscoverer{
+		searcher:  fake,
+		projectID: "real-proj",
+		byType: map[string]Discoverer{
+			"google_empty_marker": &fakeParentNamePrefixDiscoverer{
+				resourceType: "google_empty_marker",
+				assetType:    "test.googleapis.com/EmptyMarker",
+				parentMarker: "", // the programmer-error shape
+			},
+		},
+	}
+	_, err := g.DiscoverTypes(context.Background(), []string{"google_empty_marker"}, DiscoverArgs{
+		Project: "io-foo",
+	})
+	if err == nil {
+		t.Fatal("DiscoverTypes returned nil error; expected programmer-error return for empty ParentMarker")
+	}
+	if !strings.Contains(err.Error(), "ParentMarker() returned empty string") {
+		t.Errorf("err=%v, want error mentioning the empty-marker contract", err)
+	}
+	if !strings.Contains(err.Error(), "google_empty_marker") {
+		t.Errorf("err=%v, want error to name the offending type", err)
+	}
+}
+
+// TestSearchBuckets_ParentEmptyMarker_SkippedWhenEmptyProject pins
+// that the programmer-error checks fire from inside the
+// `if args.Project != ""` guard — when args.Project is empty the
+// filter is skipped and the broken marker never trips. Symmetric
+// with the empty-project pass-through tests for the other two
+// buckets. Pinning this surface so a regression that moved the
+// marker-validation outside the guard (e.g. to NewGCPDiscoverer)
+// surfaces here; conversely, if a future refactor *intentionally*
+// moves the validation to wiring time, this test must be updated
+// to expect the error at construction.
+func TestSearchBuckets_ParentEmptyMarker_SkippedWhenEmptyProject(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{}
+	g := &GCPDiscoverer{
+		searcher:  fake,
+		projectID: "real-proj",
+		byType: map[string]Discoverer{
+			"google_empty_marker": &fakeParentNamePrefixDiscoverer{
+				resourceType: "google_empty_marker",
+				assetType:    "test.googleapis.com/EmptyMarker",
+				parentMarker: "",
+			},
+		},
+	}
+	if _, err := g.DiscoverTypes(context.Background(), []string{"google_empty_marker"}, DiscoverArgs{
+		Project: "",
+	}); err != nil {
+		t.Errorf("DiscoverTypes(empty project)=%v, want nil — marker validation MUST be inside the args.Project guard", err)
 	}
 }

--- a/cmd/insideout-import/gcpdiscover/kms_crypto_key.go
+++ b/cmd/insideout-import/gcpdiscover/kms_crypto_key.go
@@ -19,7 +19,12 @@ import (
 // '/') is just the key name; the ring must be parsed separately from
 // the asset path.
 //
-// Label-less per the cloudkms provider schema → ScopeStyleNamePrefix.
+// Label-less per the cloudkms provider schema. Crypto keys are
+// conventionally named "default"/"primary"/etc; the stack project
+// lives in the parent keyring name, so this discoverer is scoped
+// via ScopeStyleParentNamePrefix on the "/keyRings/" segment (#381),
+// not ScopeStyleNamePrefix on the short key name (which would miss
+// every cryptokey in stacks following the convention).
 
 const (
 	kmsCryptoKeyTFType    = "google_kms_crypto_key"
@@ -32,7 +37,8 @@ func newKMSCryptoKeyDiscoverer() Discoverer { return &kmsCryptoKeyDiscoverer{} }
 
 func (kmsCryptoKeyDiscoverer) ResourceType() string   { return kmsCryptoKeyTFType }
 func (kmsCryptoKeyDiscoverer) AssetType() string      { return kmsCryptoKeyAssetType }
-func (kmsCryptoKeyDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleNamePrefix }
+func (kmsCryptoKeyDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleParentNamePrefix }
+func (kmsCryptoKeyDiscoverer) ParentMarker() string   { return "/keyRings/" }
 
 func (kmsCryptoKeyDiscoverer) FromAsset(book addressBook, a gcpAssetResult, projectID string) imported.ImportedResource {
 	loc, ring, name := kmsCryptoKeyAssetParts(a.Name)

--- a/cmd/insideout-import/gcpdiscover/testhelpers_test.go
+++ b/cmd/insideout-import/gcpdiscover/testhelpers_test.go
@@ -161,3 +161,47 @@ func (d *fakeNamePrefixDiscoverer) FromAsset(_ addressBook, a gcpAssetResult, pr
 func (d *fakeNamePrefixDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, _ string, _ string) (imported.ImportedResource, error) {
 	return imported.ImportedResource{}, ErrNotSupported
 }
+
+// fakeParentNamePrefixDiscoverer is the unit-test counterpart to
+// fakeNamePrefixDiscoverer for the parent-name-prefix bucket (#381):
+// it returns ScopeStyleParentNamePrefix and implements
+// parentScopedDiscoverer.ParentMarker() so the orchestrator routes
+// its asset-type into the parent bucket and the third-bucket post-
+// filter is exercised end-to-end without registering a real
+// child-of-parent type.
+//
+// resourceType, assetType, and parentMarker are constructor params
+// so multiple fakes can co-register in one test with distinct
+// markers (e.g. "/parents1/" vs "/parents2/") to pin per-discoverer
+// marker dispatch.
+type fakeParentNamePrefixDiscoverer struct {
+	resourceType string
+	assetType    string
+	parentMarker string
+}
+
+func (d *fakeParentNamePrefixDiscoverer) ResourceType() string   { return d.resourceType }
+func (d *fakeParentNamePrefixDiscoverer) AssetType() string      { return d.assetType }
+func (d *fakeParentNamePrefixDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleParentNamePrefix }
+func (d *fakeParentNamePrefixDiscoverer) ParentMarker() string   { return d.parentMarker }
+
+func (d *fakeParentNamePrefixDiscoverer) FromAsset(_ addressBook, a gcpAssetResult, projectID string) imported.ImportedResource {
+	name := shortName(a.Name)
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:     "gcp",
+			Type:      d.resourceType,
+			Address:   fmt.Sprintf("%s.%s", d.resourceType, name),
+			ImportID:  name,
+			NameHint:  name,
+			ProjectID: projectID,
+			Location:  a.Location,
+		},
+		Tier:   imported.TierImportedFlat,
+		Source: imported.SourceImporter,
+	}
+}
+
+func (d *fakeParentNamePrefixDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, _ string, _ string) (imported.ImportedResource, error) {
+	return imported.ImportedResource{}, ErrNotSupported
+}

--- a/cmd/insideout-import/gcpdiscover/testhelpers_test.go
+++ b/cmd/insideout-import/gcpdiscover/testhelpers_test.go
@@ -205,3 +205,28 @@ func (d *fakeParentNamePrefixDiscoverer) FromAsset(_ addressBook, a gcpAssetResu
 func (d *fakeParentNamePrefixDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, _ string, _ string) (imported.ImportedResource, error) {
 	return imported.ImportedResource{}, ErrNotSupported
 }
+
+// brokenParentScopeDiscoverer reports ScopeStyleParentNamePrefix but
+// does NOT implement the parentScopedDiscoverer side-interface (no
+// ParentMarker method). Used by
+// TestSearchBuckets_ParentMissingSideInterface_FailsLoud to pin the
+// programmer-error path at gcpdiscover.go::searchBuckets — without a
+// fault-injection fake, the live registry's contract test cannot
+// reach those error returns at runtime, so a refactor that demoted
+// them to a silent continue would ship green.
+type brokenParentScopeDiscoverer struct {
+	resourceType string
+	assetType    string
+}
+
+func (d *brokenParentScopeDiscoverer) ResourceType() string   { return d.resourceType }
+func (d *brokenParentScopeDiscoverer) AssetType() string      { return d.assetType }
+func (d *brokenParentScopeDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleParentNamePrefix }
+
+func (d *brokenParentScopeDiscoverer) FromAsset(_ addressBook, _ gcpAssetResult, _ string) imported.ImportedResource {
+	return imported.ImportedResource{}
+}
+
+func (d *brokenParentScopeDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, _ string, _ string) (imported.ImportedResource, error) {
+	return imported.ImportedResource{}, ErrNotSupported
+}


### PR DESCRIPTION
## Summary

- Adds `ScopeStyleParentNamePrefix` — a third scope style for child resources whose own short name doesn't carry the stack project (the project lives in a parent path segment). Flips `google_kms_crypto_key` (parent = keyring) and `google_container_node_pool` (parent = cluster).
- Closes the live-smoke gap from PR #380: `diagramtest2025-09-14` / `io-qtyb4nkwp5n8` now discovers all 7 cryptokeys (each named `"default"` with project embedded in the keyring name). Pre-PR: 0 discovered.
- Parent-scoped types implement `parentScopedDiscoverer.ParentMarker()` on a side-interface, keeping the main `Discoverer` contract trivial for the ~20 non-parent-scoped types.

## Test plan
- [x] `go test ./cmd/insideout-import/gcpdiscover/... -count=1` (344 tests)
- [x] `go test ./... -count=1` (4140+ tests)
- [x] `/verify` — `terraform fmt -check`, all 4 lint scripts PASS
- [x] Live smoke against `diagramtest2025-09-14` / `io-qtyb4nkwp5n8`:
  - `google_kms_crypto_key` → **7 discovered** (acceptance criterion ✓)
  - `google_container_node_pool` → 0 discovered (no GKE clusters in the live stack — confirmed via `google_container_cluster` probe)

## Review notes
- `/review`: P0/P1 = none. P2/P3 drive-bys addressed in commit `18735aa` — fault-injection tests for the two `searchBuckets` programmer-error returns, tightened bucket-count assertion, mutation-resistant reorder of the parent-segment filter test (defeats `rs[:1]` and keep-first-N mutations), extra `TestMatchesParentNamePrefix` rows (empty project, double marker).
- `qa-professor`: P1 = added the two fault-injection tests. P2 = mutation-resistance reorder + helper-table rows. No deferrals.

## Out of scope (per plan)
- `google_api_gateway_api_config` — currently `ScopeStyleLabels` because API Gateway types carry labels. The issue lists it as potentially affected but only if Cloud Asset doesn't propagate labels to api_config (empirical question, separate live probe).
- Composer-side typed-Attrs codegen — orthogonal; covered by Bundle 9 umbrella (#385).

Closes #381