### PR TITLE
feat(gcpdiscover): discover google_compute_global_address + global_forwarding_rule (#384)

### DIFF
--- a/cmd/insideout-import/gcpdiscover/compute_address.go
+++ b/cmd/insideout-import/gcpdiscover/compute_address.go
@@ -28,11 +28,12 @@ import (
 // Global vs regional split: CAI returns global addresses under the
 // same compute.googleapis.com/Address slug with Location="global", but
 // Terraform's `google_compute_address` type is regional-only —
-// `google_compute_global_address` is a separate type, not part of
-// Bundle 8. This discoverer's FromAsset filters out the global rows
-// so they don't get an invalid `projects/<p>/regions/global/...`
-// ImportID; they're skipped silently and surface in the unsupported
-// stream when --include-unsupported is set.
+// `google_compute_global_address` is a separate type (#384). This
+// discoverer's FromAsset filters out the global rows; the companion
+// google_compute_global_address discoverer in compute_global_address.go
+// processes them via the inverse filter against the same shared CAI
+// bucket. The two discoverers always co-register (assetTypesOf dedups
+// the shared slug at search time).
 
 const (
 	computeAddressTFType    = "google_compute_address"
@@ -48,10 +49,11 @@ func (computeAddressDiscoverer) AssetType() string      { return computeAddressA
 func (computeAddressDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleLabels }
 
 func (computeAddressDiscoverer) FromAsset(book addressBook, a gcpAssetResult, projectID string) imported.ImportedResource {
-	// Global rows must be skipped — they belong to google_compute_global_address,
-	// a separate TF type not in Bundle 8. Returning a zero
-	// ImportedResource signals the orchestrator to drop the row (it
-	// filters on empty Identity.Type before emitting).
+	// Global rows are processed by computeGlobalAddressDiscoverer
+	// (#384) via the same shared compute.googleapis.com/Address asset
+	// bucket. Returning a zero ImportedResource signals the
+	// orchestrator to drop the row from THIS discoverer's emit set —
+	// the global discoverer's inverse filter then keeps it.
 	if isGlobalAddressOrForwardingRule(a) {
 		return imported.ImportedResource{}
 	}
@@ -103,14 +105,11 @@ func (computeAddressDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearch
 	}, nil), nil
 }
 
-// computeAddressPartsFromID parses the regional shape only. Globals are
-// rejected with ErrNotSupported — they belong to google_compute_global_address,
-// a separate TF type not in Bundle 8 (and emitting them under
-// google_compute_address would produce an import-id Terraform's
-// regional-only schema rejects). Symmetric with FromAsset's
-// isGlobalAddressOrForwardingRule skip — keeps the dep-chase code path
-// from resurrecting the live-smoke bug that motivated the skip
-// sentinel in the first place.
+// computeAddressPartsFromID parses the regional shape only. Globals
+// are rejected with ErrNotSupported — they belong to
+// google_compute_global_address (#384). Symmetric with FromAsset's
+// filter; keeps the dep-chase code path from emitting a malformed
+// `projects/<p>/regions/global/...` import-id.
 func computeAddressPartsFromID(id string) (string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {

--- a/cmd/insideout-import/gcpdiscover/compute_forwarding_rule.go
+++ b/cmd/insideout-import/gcpdiscover/compute_forwarding_rule.go
@@ -16,7 +16,9 @@ import (
 //
 // Regional forwarding rules carry labels per the provider schema →
 // ScopeStyleLabels. Global forwarding rules use the parallel TF type
-// google_compute_global_forwarding_rule — not a Bundle 8 target.
+// google_compute_global_forwarding_rule (#384), processed by the
+// companion discoverer via the inverse filter against the same shared
+// compute.googleapis.com/ForwardingRule asset bucket.
 
 const (
 	computeForwardingRuleTFType    = "google_compute_forwarding_rule"
@@ -32,10 +34,9 @@ func (computeForwardingRuleDiscoverer) AssetType() string      { return computeF
 func (computeForwardingRuleDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleLabels }
 
 func (computeForwardingRuleDiscoverer) FromAsset(book addressBook, a gcpAssetResult, projectID string) imported.ImportedResource {
-	// Global forwarding rules belong to google_compute_global_forwarding_rule,
-	// a separate TF type not in Bundle 8 — skip by returning a zero
-	// ImportedResource. The orchestrator filters out empty Identity.Type
-	// rows before emitting.
+	// Global rows are processed by computeGlobalForwardingRuleDiscoverer
+	// (#384) via the same shared compute.googleapis.com/ForwardingRule
+	// asset bucket.
 	if isGlobalAddressOrForwardingRule(a) {
 		return imported.ImportedResource{}
 	}

--- a/cmd/insideout-import/gcpdiscover/compute_global_address.go
+++ b/cmd/insideout-import/gcpdiscover/compute_global_address.go
@@ -82,17 +82,36 @@ func (computeGlobalAddressDiscoverer) DiscoverByID(_ context.Context, _ gcpAsset
 // `projects/<p>/global/addresses/<n>` import-id for a row whose real
 // type is the regional one.
 func computeGlobalAddressNameFromID(id string) (string, error) {
+	return parseGlobalNameFromID(id, "/global/addresses/", "compute_global_address", "google_compute_address")
+}
+
+// parseGlobalNameFromID is the shared parser for the two global
+// compute discoverers (#384). The shape is:
+//
+//   - input may be a Cloud Asset full resource name or a Terraform
+//     import-id; either way the global path marker `/global/<collection>/`
+//     appears once.
+//   - `tfPrefix` (e.g. "compute_global_address") prefixes the error
+//     message so the test/log surface names the offending discoverer.
+//   - `siblingType` (e.g. "google_compute_address") is named in the
+//     unrecognized-id error so an operator who passed a regional
+//     shape sees the actionable cross-reference.
+//
+// Regional inputs surface as "unrecognized id" since the marker is
+// absent; the explicit "belongs to siblingType" hint surfaces the
+// migration path.
+func parseGlobalNameFromID(id, marker, tfPrefix, siblingType string) (string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", fmt.Errorf("compute_global_address: empty id: %w", ErrNotSupported)
+		return "", fmt.Errorf("%s: empty id: %w", tfPrefix, ErrNotSupported)
 	}
-	_, after, ok := strings.Cut(id, "/global/addresses/")
+	_, after, ok := strings.Cut(id, marker)
 	if !ok {
-		return "", fmt.Errorf("compute_global_address: unrecognized id %q (expected /global/addresses/ shape): %w", id, ErrNotSupported)
+		return "", fmt.Errorf("%s: unrecognized id %q (regional inputs belong to %s): %w", tfPrefix, id, siblingType, ErrNotSupported)
 	}
 	name, _, _ := strings.Cut(after, "/")
 	if name == "" {
-		return "", fmt.Errorf("compute_global_address: empty name in id %q: %w", id, ErrNotSupported)
+		return "", fmt.Errorf("%s: empty name in id %q: %w", tfPrefix, id, ErrNotSupported)
 	}
 	return name, nil
 }

--- a/cmd/insideout-import/gcpdiscover/compute_global_address.go
+++ b/cmd/insideout-import/gcpdiscover/compute_global_address.go
@@ -1,0 +1,98 @@
+package gcpdiscover
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// Per-type discoverer for google_compute_global_address.
+//
+// Cloud Asset Inventory: compute.googleapis.com/Address (same slug as
+// the regional sibling — Cloud Asset doesn't separate regional from
+// global addresses by asset type, only by path shape).
+// Asset name shape:      //compute.googleapis.com/projects/<proj>/global/addresses/<name>
+// Terraform import ID:   projects/<proj>/global/addresses/<name>
+//
+// google_compute_global_address resources carry labels per the
+// provider schema (the `labels` attribute on the resource block), so
+// this discoverer uses ScopeStyleLabels. The shared asset-type slug
+// with google_compute_address is intentional — both discoverers
+// register the same CAI slug and the search-time bucket is one call,
+// not two (see assetTypesOf's dedup in gcpdiscover.go). Per-discoverer
+// FromAsset filters select the regional vs global subset.
+//
+// Companion to compute_address.go (#369, #384). Adding this discoverer
+// converts the post-#380 zero-Identity skip on global rows into a
+// genuine discovery — pre-PR, the diagramtest2025-09-14 stack's global
+// LB IP discovered as 0; post-PR, 1.
+
+const (
+	computeGlobalAddressTFType    = "google_compute_global_address"
+	computeGlobalAddressAssetType = "compute.googleapis.com/Address"
+)
+
+type computeGlobalAddressDiscoverer struct{}
+
+func newComputeGlobalAddressDiscoverer() Discoverer { return &computeGlobalAddressDiscoverer{} }
+
+func (computeGlobalAddressDiscoverer) ResourceType() string   { return computeGlobalAddressTFType }
+func (computeGlobalAddressDiscoverer) AssetType() string      { return computeGlobalAddressAssetType }
+func (computeGlobalAddressDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleLabels }
+
+func (computeGlobalAddressDiscoverer) FromAsset(book addressBook, a gcpAssetResult, projectID string) imported.ImportedResource {
+	// Inverse of the regional discoverer's filter: keep only global
+	// rows. Regional rows are processed by computeAddressDiscoverer
+	// and skipped here via the zero-Identity sentinel.
+	if !isGlobalAddressOrForwardingRule(a) {
+		return imported.ImportedResource{}
+	}
+	name := shortName(a.Name)
+	importID := fmt.Sprintf("projects/%s/global/addresses/%s", projectID, name)
+	selfLink := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/addresses/%s", projectID, name)
+	// Location is intentionally empty for global addresses (the
+	// "global" path segment is not a GCP location/region). Matches
+	// google_compute_firewall and other intrinsically-global types.
+	return makeImportedResource(book, computeGlobalAddressTFType, name, importID, projectID, "", map[string]string{
+		"asset_name": a.Name,
+		"self_link":  selfLink,
+	}, a.Labels)
+}
+
+func (computeGlobalAddressDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, id, projectID string) (imported.ImportedResource, error) {
+	name, err := computeGlobalAddressNameFromID(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
+	importID := fmt.Sprintf("projects/%s/global/addresses/%s", projectID, name)
+	selfLink := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/addresses/%s", projectID, name)
+	assetName := fmt.Sprintf("//%s/projects/%s/global/addresses/%s", computeAssetHost, projectID, name)
+	return makeImportedResource(addressBook{}, computeGlobalAddressTFType, name, importID, projectID, "", map[string]string{
+		"asset_name": assetName,
+		"self_link":  selfLink,
+	}, nil), nil
+}
+
+// computeGlobalAddressNameFromID parses the global shape only.
+// Regional inputs are rejected with ErrNotSupported — they belong to
+// google_compute_address, the regional sibling. Symmetric with
+// FromAsset's filter: keeps the dep-chase code path from emitting a
+// `projects/<p>/global/addresses/<n>` import-id for a row whose real
+// type is the regional one.
+func computeGlobalAddressNameFromID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("compute_global_address: empty id: %w", ErrNotSupported)
+	}
+	_, after, ok := strings.Cut(id, "/global/addresses/")
+	if !ok {
+		return "", fmt.Errorf("compute_global_address: unrecognized id %q (expected /global/addresses/ shape): %w", id, ErrNotSupported)
+	}
+	name, _, _ := strings.Cut(after, "/")
+	if name == "" {
+		return "", fmt.Errorf("compute_global_address: empty name in id %q: %w", id, ErrNotSupported)
+	}
+	return name, nil
+}

--- a/cmd/insideout-import/gcpdiscover/compute_global_address_test.go
+++ b/cmd/insideout-import/gcpdiscover/compute_global_address_test.go
@@ -3,8 +3,6 @@ package gcpdiscover
 import (
 	"context"
 	"errors"
-	"reflect"
-	"sort"
 	"testing"
 )
 
@@ -178,22 +176,27 @@ func TestDiscoverTypes_AddressRegionalAndGlobal_CoexistOnSharedSlug(t *testing.T
 	// loop iterates discoverers in their registration order; the
 	// global comes after the regional alphabetically, but pinning
 	// the set membership is more mutation-resistant than the order.
-	gotTypes := []string{got[0].Identity.Type, got[1].Identity.Type}
-	sort.Strings(gotTypes)
-	wantTypes := []string{"google_compute_address", "google_compute_global_address"}
-	if !reflect.DeepEqual(gotTypes, wantTypes) {
-		t.Errorf("emitted types=%v, want %v (one regional + one global)", gotTypes, wantTypes)
+	// Pin the type-to-import-id binding directly per resource, not via
+	// sorted-set membership. A mutation that inverted the per-discoverer
+	// filter would still produce {regional, global} type membership
+	// (both discoverers still iterate the bucket and emit one each) —
+	// but the regional discoverer processing a global asset would
+	// produce a malformed ImportID like
+	// `projects/real-proj/regions/global/addresses/...` (asset's
+	// Location="global" flows into the region slot). Pinning the
+	// type→import-id pair catches this directly rather than relying on
+	// the malformed import-id leaking into a sorted-slice assertion.
+	byType := make(map[string]string, len(got))
+	for _, r := range got {
+		if _, dup := byType[r.Identity.Type]; dup {
+			t.Errorf("duplicate emit for type %q (got: %+v)", r.Identity.Type, got)
+		}
+		byType[r.Identity.Type] = r.Identity.ImportID
 	}
-	// Both share NameHint=io-foo-shared but their ImportIDs MUST be
-	// distinct — the regional carries /regions/<r>/, the global
-	// carries /global/.
-	gotImports := []string{got[0].Identity.ImportID, got[1].Identity.ImportID}
-	sort.Strings(gotImports)
-	wantImports := []string{
-		"projects/real-proj/global/addresses/io-foo-shared",
-		"projects/real-proj/regions/us-central1/addresses/io-foo-shared",
+	if want, got := "projects/real-proj/regions/us-central1/addresses/io-foo-shared", byType["google_compute_address"]; got != want {
+		t.Errorf("google_compute_address.ImportID = %q, want %q (regional discoverer must process the /regions/<r>/ row)", got, want)
 	}
-	if !reflect.DeepEqual(gotImports, wantImports) {
-		t.Errorf("emitted ImportIDs=%v, want %v", gotImports, wantImports)
+	if want, got := "projects/real-proj/global/addresses/io-foo-shared", byType["google_compute_global_address"]; got != want {
+		t.Errorf("google_compute_global_address.ImportID = %q, want %q (global discoverer must process the /global/ row)", got, want)
 	}
 }

--- a/cmd/insideout-import/gcpdiscover/compute_global_address_test.go
+++ b/cmd/insideout-import/gcpdiscover/compute_global_address_test.go
@@ -1,0 +1,199 @@
+package gcpdiscover
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestComputeGlobalAddressFromAsset_Global pins the happy path for
+// the global discoverer (#384): a //compute.googleapis.com/.../global/
+// addresses/... row produces a real ImportedResource with the
+// projects/<p>/global/addresses/<n> import-ID and an empty Location
+// (since "global" is a path segment, not a GCP location).
+func TestComputeGlobalAddressFromAsset_Global(t *testing.T) {
+	t.Parallel()
+	d := newComputeGlobalAddressDiscoverer()
+	got := d.FromAsset(addressBook{},
+		gcpAssetResult{
+			Name:      "//compute.googleapis.com/projects/real-proj/global/addresses/io-foo-lb-ip",
+			AssetType: "compute.googleapis.com/Address",
+			Project:   "real-proj",
+			Location:  "global",
+		},
+		"real-proj")
+	if got.Identity.Type != "google_compute_global_address" {
+		t.Errorf("Type=%q, want google_compute_global_address", got.Identity.Type)
+	}
+	if got.Identity.NameHint != "io-foo-lb-ip" {
+		t.Errorf("NameHint=%q, want io-foo-lb-ip", got.Identity.NameHint)
+	}
+	wantImport := "projects/real-proj/global/addresses/io-foo-lb-ip"
+	if got.Identity.ImportID != wantImport {
+		t.Errorf("ImportID=%q, want %q", got.Identity.ImportID, wantImport)
+	}
+	if got.Identity.Location != "" {
+		t.Errorf("Location=%q, want empty (globals carry no location)", got.Identity.Location)
+	}
+}
+
+// TestComputeGlobalAddressFromAsset_Regional_IsSkipped pins the
+// inverse skip-sentinel contract (#384) — the global discoverer must
+// drop regional rows so its emit set is disjoint from the regional
+// discoverer's. Mirrors TestComputeAddressFromAsset_Global_IsSkipped
+// on the regional side.
+func TestComputeGlobalAddressFromAsset_Regional_IsSkipped(t *testing.T) {
+	t.Parallel()
+	d := newComputeGlobalAddressDiscoverer()
+	got := d.FromAsset(addressBook{},
+		gcpAssetResult{
+			Name:      "//compute.googleapis.com/projects/real-proj/regions/us-central1/addresses/io-foo-ip",
+			AssetType: "compute.googleapis.com/Address",
+			Project:   "real-proj",
+			Location:  "us-central1",
+		},
+		"real-proj")
+	if got.Identity.Type != "" {
+		t.Errorf("Identity.Type=%q, want empty (regional address must be skipped — orchestrator filters out zero-Type rows; regional rows belong to google_compute_address)", got.Identity.Type)
+	}
+	if got.Identity.ImportID != "" {
+		t.Errorf("Identity.ImportID=%q, want empty", got.Identity.ImportID)
+	}
+}
+
+func TestComputeGlobalAddressDiscoverByID(t *testing.T) {
+	t.Parallel()
+	d := newComputeGlobalAddressDiscoverer()
+	cases := []struct {
+		name, in, wantName string
+		wantErr            error
+	}{
+		{name: "global asset name", in: "//compute.googleapis.com/projects/p/global/addresses/lb-ip", wantName: "lb-ip"},
+		{name: "global import id", in: "projects/p/global/addresses/lb-ip", wantName: "lb-ip"},
+		// Regional rows are symmetrically rejected — they belong to
+		// google_compute_address, the regional sibling. Without this
+		// rejection the dep-chase code path would emit a malformed
+		// `projects/<p>/global/addresses/...` import-id for a regional
+		// resource (the inverse of the bug the regional discoverer
+		// guards against).
+		{name: "regional asset name rejected (different TF type)", in: "//compute.googleapis.com/projects/p/regions/us-east1/addresses/ip1", wantErr: ErrNotSupported},
+		{name: "regional import id rejected (different TF type)", in: "projects/p/regions/us-east1/addresses/ip1", wantErr: ErrNotSupported},
+		{name: "empty", in: "", wantErr: ErrNotSupported},
+		{name: "bare name rejected (no /global/addresses/ marker)", in: "lb-ip", wantErr: ErrNotSupported},
+		// Adversarial: the substring "/global/addresses/" but with
+		// empty name after the trailing slash — production CAI never
+		// emits this shape, but pinning the empty-name guard surfaces
+		// a regression that dropped it.
+		{name: "trailing-slash empty name rejected", in: "projects/p/global/addresses/", wantErr: ErrNotSupported},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := d.DiscoverByID(context.Background(), nil, tc.in, "real-proj")
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Errorf("err=%v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Identity.NameHint != tc.wantName {
+				t.Errorf("NameHint=%q, want %q", got.Identity.NameHint, tc.wantName)
+			}
+			if got.Identity.Type != "google_compute_global_address" {
+				t.Errorf("Type=%q, want google_compute_global_address", got.Identity.Type)
+			}
+			if got.Identity.Location != "" {
+				t.Errorf("Location=%q, want empty (globals carry no location)", got.Identity.Location)
+			}
+		})
+	}
+}
+
+// TestDiscoverTypes_AddressRegionalAndGlobal_CoexistOnSharedSlug is
+// the acceptance test from #384: when the live registry holds BOTH
+// google_compute_address and google_compute_global_address (sharing
+// the compute.googleapis.com/Address CAI slug), an asset bucket
+// containing one regional + one global with identical short names
+// must produce one ImportedResource of each TF type.
+//
+// Three properties under test:
+//
+//  1. assetTypesOf's dedup at gcpdiscover.go (#384) — the asset-type
+//     list passed to SearchAll must NOT carry duplicates even though
+//     two discoverers register the same slug.
+//  2. Each discoverer's FromAsset filter is the inverse of the other,
+//     so the regional row goes to google_compute_address and the
+//     global row goes to google_compute_global_address.
+//  3. No row is dropped or doubled.
+//
+// Uses identical short names on both rows to defeat any short-name-
+// based partition logic that might be inadvertently introduced — the
+// only correct discriminator is the /regions/<r>/ vs /global/ path
+// marker.
+func TestDiscoverTypes_AddressRegionalAndGlobal_CoexistOnSharedSlug(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{
+			{
+				Name:      "//compute.googleapis.com/projects/real-proj/regions/us-central1/addresses/io-foo-shared",
+				AssetType: "compute.googleapis.com/Address",
+				Project:   "real-proj",
+				Location:  "us-central1",
+				Labels:    map[string]string{"project": "io-foo"},
+			},
+			{
+				Name:      "//compute.googleapis.com/projects/real-proj/global/addresses/io-foo-shared",
+				AssetType: "compute.googleapis.com/Address",
+				Project:   "real-proj",
+				Location:  "global",
+				Labels:    map[string]string{"project": "io-foo"},
+			},
+		},
+	}
+	g := NewGCPDiscoverer(fake, "real-proj")
+	got, err := g.DiscoverTypes(context.Background(),
+		[]string{"google_compute_address", "google_compute_global_address"},
+		DiscoverArgs{Project: "io-foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// One SearchAll call (both discoverers labels-bucket, same slug).
+	if len(fake.calls) != 1 {
+		t.Fatalf("SearchAll calls=%d, want 1 — assetTypesOf must dedup shared CAI slugs", len(fake.calls))
+	}
+	// Dedup pins: the assetTypes slice on the call has exactly one
+	// entry, not two.
+	if len(fake.calls[0].assetTypes) != 1 {
+		t.Errorf("call.assetTypes=%v, want exactly 1 entry (deduped)", fake.calls[0].assetTypes)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d ImportedResources, want 2 (one regional + one global); got: %+v", len(got), got)
+	}
+	// Pin partition: one of each TF type. The orchestrator's emit
+	// loop iterates discoverers in their registration order; the
+	// global comes after the regional alphabetically, but pinning
+	// the set membership is more mutation-resistant than the order.
+	gotTypes := []string{got[0].Identity.Type, got[1].Identity.Type}
+	sort.Strings(gotTypes)
+	wantTypes := []string{"google_compute_address", "google_compute_global_address"}
+	if !reflect.DeepEqual(gotTypes, wantTypes) {
+		t.Errorf("emitted types=%v, want %v (one regional + one global)", gotTypes, wantTypes)
+	}
+	// Both share NameHint=io-foo-shared but their ImportIDs MUST be
+	// distinct — the regional carries /regions/<r>/, the global
+	// carries /global/.
+	gotImports := []string{got[0].Identity.ImportID, got[1].Identity.ImportID}
+	sort.Strings(gotImports)
+	wantImports := []string{
+		"projects/real-proj/global/addresses/io-foo-shared",
+		"projects/real-proj/regions/us-central1/addresses/io-foo-shared",
+	}
+	if !reflect.DeepEqual(gotImports, wantImports) {
+		t.Errorf("emitted ImportIDs=%v, want %v", gotImports, wantImports)
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/compute_global_forwarding_rule.go
+++ b/cmd/insideout-import/gcpdiscover/compute_global_forwarding_rule.go
@@ -3,7 +3,6 @@ package gcpdiscover
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
@@ -71,19 +70,9 @@ func (computeGlobalForwardingRuleDiscoverer) DiscoverByID(_ context.Context, _ g
 
 // computeGlobalForwardingRuleNameFromID parses the global shape only.
 // Regional inputs are rejected with ErrNotSupported — they belong to
-// google_compute_forwarding_rule, the regional sibling.
+// google_compute_forwarding_rule, the regional sibling. See
+// parseGlobalNameFromID in compute_global_address.go for the shared
+// shape.
 func computeGlobalForwardingRuleNameFromID(id string) (string, error) {
-	id = strings.TrimSpace(id)
-	if id == "" {
-		return "", fmt.Errorf("compute_global_forwarding_rule: empty id: %w", ErrNotSupported)
-	}
-	_, after, ok := strings.Cut(id, "/global/forwardingRules/")
-	if !ok {
-		return "", fmt.Errorf("compute_global_forwarding_rule: unrecognized id %q (expected /global/forwardingRules/ shape): %w", id, ErrNotSupported)
-	}
-	name, _, _ := strings.Cut(after, "/")
-	if name == "" {
-		return "", fmt.Errorf("compute_global_forwarding_rule: empty name in id %q: %w", id, ErrNotSupported)
-	}
-	return name, nil
+	return parseGlobalNameFromID(id, "/global/forwardingRules/", "compute_global_forwarding_rule", "google_compute_forwarding_rule")
 }

--- a/cmd/insideout-import/gcpdiscover/compute_global_forwarding_rule.go
+++ b/cmd/insideout-import/gcpdiscover/compute_global_forwarding_rule.go
@@ -1,0 +1,89 @@
+package gcpdiscover
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// Per-type discoverer for google_compute_global_forwarding_rule.
+//
+// Cloud Asset Inventory: compute.googleapis.com/ForwardingRule (same
+// slug as the regional sibling — Cloud Asset doesn't separate
+// regional from global forwarding rules by asset type, only by path
+// shape).
+// Asset name shape:      //compute.googleapis.com/projects/<proj>/global/forwardingRules/<name>
+// Terraform import ID:   projects/<proj>/global/forwardingRules/<name>
+//
+// Global forwarding rules carry labels per the provider schema, so
+// this discoverer uses ScopeStyleLabels. The shared asset-type slug
+// with google_compute_forwarding_rule is intentional — see
+// compute_global_address.go's docblock for the dispatch shape.
+//
+// Companion to compute_forwarding_rule.go (#375, #384). Adding this
+// discoverer converts the post-#380 zero-Identity skip on global rows
+// into a genuine discovery.
+
+const (
+	computeGlobalForwardingRuleTFType    = "google_compute_global_forwarding_rule"
+	computeGlobalForwardingRuleAssetType = "compute.googleapis.com/ForwardingRule"
+)
+
+type computeGlobalForwardingRuleDiscoverer struct{}
+
+func newComputeGlobalForwardingRuleDiscoverer() Discoverer {
+	return &computeGlobalForwardingRuleDiscoverer{}
+}
+
+func (computeGlobalForwardingRuleDiscoverer) ResourceType() string {
+	return computeGlobalForwardingRuleTFType
+}
+func (computeGlobalForwardingRuleDiscoverer) AssetType() string {
+	return computeGlobalForwardingRuleAssetType
+}
+func (computeGlobalForwardingRuleDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleLabels }
+
+func (computeGlobalForwardingRuleDiscoverer) FromAsset(book addressBook, a gcpAssetResult, projectID string) imported.ImportedResource {
+	// Inverse of the regional discoverer's filter: keep only global
+	// rows.
+	if !isGlobalAddressOrForwardingRule(a) {
+		return imported.ImportedResource{}
+	}
+	name := shortName(a.Name)
+	importID := fmt.Sprintf("projects/%s/global/forwardingRules/%s", projectID, name)
+	return makeImportedResource(book, computeGlobalForwardingRuleTFType, name, importID, projectID, "", map[string]string{
+		"asset_name": a.Name,
+	}, a.Labels)
+}
+
+func (computeGlobalForwardingRuleDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, id, projectID string) (imported.ImportedResource, error) {
+	name, err := computeGlobalForwardingRuleNameFromID(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
+	importID := fmt.Sprintf("projects/%s/global/forwardingRules/%s", projectID, name)
+	return makeImportedResource(addressBook{}, computeGlobalForwardingRuleTFType, name, importID, projectID, "", map[string]string{
+		"asset_name": fmt.Sprintf("//%s/projects/%s/global/forwardingRules/%s", computeAssetHost, projectID, name),
+	}, nil), nil
+}
+
+// computeGlobalForwardingRuleNameFromID parses the global shape only.
+// Regional inputs are rejected with ErrNotSupported — they belong to
+// google_compute_forwarding_rule, the regional sibling.
+func computeGlobalForwardingRuleNameFromID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("compute_global_forwarding_rule: empty id: %w", ErrNotSupported)
+	}
+	_, after, ok := strings.Cut(id, "/global/forwardingRules/")
+	if !ok {
+		return "", fmt.Errorf("compute_global_forwarding_rule: unrecognized id %q (expected /global/forwardingRules/ shape): %w", id, ErrNotSupported)
+	}
+	name, _, _ := strings.Cut(after, "/")
+	if name == "" {
+		return "", fmt.Errorf("compute_global_forwarding_rule: empty name in id %q: %w", id, ErrNotSupported)
+	}
+	return name, nil
+}

--- a/cmd/insideout-import/gcpdiscover/compute_global_forwarding_rule_test.go
+++ b/cmd/insideout-import/gcpdiscover/compute_global_forwarding_rule_test.go
@@ -93,3 +93,64 @@ func TestComputeGlobalForwardingRuleDiscoverByID(t *testing.T) {
 		})
 	}
 }
+
+// TestDiscoverTypes_ForwardingRuleRegionalAndGlobal_CoexistOnSharedSlug
+// is the ForwardingRule counterpart to the Address coexistence test
+// (#384). Pinning the same dispatch contract per shared-slug pair is
+// a defense-in-depth move — the Address and ForwardingRule discoverers
+// share isGlobalAddressOrForwardingRule today, but that's an
+// implementation accident. A future refactor that diverged the
+// per-type filters could break ForwardingRule's dispatch without
+// failing the Address-only coexist test.
+func TestDiscoverTypes_ForwardingRuleRegionalAndGlobal_CoexistOnSharedSlug(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{
+			{
+				Name:      "//compute.googleapis.com/projects/real-proj/regions/us-central1/forwardingRules/io-foo-shared",
+				AssetType: "compute.googleapis.com/ForwardingRule",
+				Project:   "real-proj",
+				Location:  "us-central1",
+				Labels:    map[string]string{"project": "io-foo"},
+			},
+			{
+				Name:      "//compute.googleapis.com/projects/real-proj/global/forwardingRules/io-foo-shared",
+				AssetType: "compute.googleapis.com/ForwardingRule",
+				Project:   "real-proj",
+				Location:  "global",
+				Labels:    map[string]string{"project": "io-foo"},
+			},
+		},
+	}
+	g := NewGCPDiscoverer(fake, "real-proj")
+	got, err := g.DiscoverTypes(context.Background(),
+		[]string{"google_compute_forwarding_rule", "google_compute_global_forwarding_rule"},
+		DiscoverArgs{Project: "io-foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("SearchAll calls=%d, want 1 — assetTypesOf must dedup shared CAI slugs", len(fake.calls))
+	}
+	if len(fake.calls[0].assetTypes) != 1 {
+		t.Errorf("call.assetTypes=%v, want exactly 1 entry (deduped)", fake.calls[0].assetTypes)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d ImportedResources, want 2 (one regional + one global); got: %+v", len(got), got)
+	}
+	// Pin the type-to-import-id binding directly — see the Address
+	// coexist test's comment for the mutation-resistance rationale.
+	byType := make(map[string]string, len(got))
+	for _, r := range got {
+		if _, dup := byType[r.Identity.Type]; dup {
+			t.Errorf("duplicate emit for type %q (got: %+v)", r.Identity.Type, got)
+		}
+		byType[r.Identity.Type] = r.Identity.ImportID
+	}
+	if want, got := "projects/real-proj/regions/us-central1/forwardingRules/io-foo-shared", byType["google_compute_forwarding_rule"]; got != want {
+		t.Errorf("google_compute_forwarding_rule.ImportID = %q, want %q (regional discoverer must process the /regions/<r>/ row)", got, want)
+	}
+	if want, got := "projects/real-proj/global/forwardingRules/io-foo-shared", byType["google_compute_global_forwarding_rule"]; got != want {
+		t.Errorf("google_compute_global_forwarding_rule.ImportID = %q, want %q (global discoverer must process the /global/ row)", got, want)
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/compute_global_forwarding_rule_test.go
+++ b/cmd/insideout-import/gcpdiscover/compute_global_forwarding_rule_test.go
@@ -1,0 +1,95 @@
+package gcpdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestComputeGlobalForwardingRuleFromAsset_Global(t *testing.T) {
+	t.Parallel()
+	d := newComputeGlobalForwardingRuleDiscoverer()
+	got := d.FromAsset(addressBook{},
+		gcpAssetResult{
+			Name:      "//compute.googleapis.com/projects/real-proj/global/forwardingRules/io-foo-lb-fwd",
+			AssetType: "compute.googleapis.com/ForwardingRule",
+			Project:   "real-proj",
+			Location:  "global",
+		},
+		"real-proj")
+	if got.Identity.Type != "google_compute_global_forwarding_rule" {
+		t.Errorf("Type=%q, want google_compute_global_forwarding_rule", got.Identity.Type)
+	}
+	if got.Identity.NameHint != "io-foo-lb-fwd" {
+		t.Errorf("NameHint=%q, want io-foo-lb-fwd", got.Identity.NameHint)
+	}
+	wantImport := "projects/real-proj/global/forwardingRules/io-foo-lb-fwd"
+	if got.Identity.ImportID != wantImport {
+		t.Errorf("ImportID=%q, want %q", got.Identity.ImportID, wantImport)
+	}
+	if got.Identity.Location != "" {
+		t.Errorf("Location=%q, want empty (globals carry no location)", got.Identity.Location)
+	}
+}
+
+// TestComputeGlobalForwardingRuleFromAsset_Regional_IsSkipped pins
+// the inverse skip-sentinel — mirrors the global address test.
+func TestComputeGlobalForwardingRuleFromAsset_Regional_IsSkipped(t *testing.T) {
+	t.Parallel()
+	d := newComputeGlobalForwardingRuleDiscoverer()
+	got := d.FromAsset(addressBook{},
+		gcpAssetResult{
+			Name:      "//compute.googleapis.com/projects/real-proj/regions/us-central1/forwardingRules/io-foo-fwd",
+			AssetType: "compute.googleapis.com/ForwardingRule",
+			Project:   "real-proj",
+			Location:  "us-central1",
+		},
+		"real-proj")
+	if got.Identity.Type != "" {
+		t.Errorf("Identity.Type=%q, want empty (regional row must be skipped; belongs to google_compute_forwarding_rule)", got.Identity.Type)
+	}
+	if got.Identity.ImportID != "" {
+		t.Errorf("Identity.ImportID=%q, want empty", got.Identity.ImportID)
+	}
+}
+
+func TestComputeGlobalForwardingRuleDiscoverByID(t *testing.T) {
+	t.Parallel()
+	d := newComputeGlobalForwardingRuleDiscoverer()
+	cases := []struct {
+		name, in, wantName string
+		wantErr            error
+	}{
+		{name: "global asset name", in: "//compute.googleapis.com/projects/p/global/forwardingRules/lb-fwd", wantName: "lb-fwd"},
+		{name: "global import id", in: "projects/p/global/forwardingRules/lb-fwd", wantName: "lb-fwd"},
+		{name: "regional asset name rejected (different TF type)", in: "//compute.googleapis.com/projects/p/regions/us-east1/forwardingRules/fwd1", wantErr: ErrNotSupported},
+		{name: "regional import id rejected (different TF type)", in: "projects/p/regions/us-east1/forwardingRules/fwd1", wantErr: ErrNotSupported},
+		{name: "empty", in: "", wantErr: ErrNotSupported},
+		{name: "bare name rejected (no /global/forwardingRules/ marker)", in: "fwd1", wantErr: ErrNotSupported},
+		{name: "trailing-slash empty name rejected", in: "projects/p/global/forwardingRules/", wantErr: ErrNotSupported},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := d.DiscoverByID(context.Background(), nil, tc.in, "real-proj")
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Errorf("err=%v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Identity.NameHint != tc.wantName {
+				t.Errorf("NameHint=%q, want %q", got.Identity.NameHint, tc.wantName)
+			}
+			if got.Identity.Type != "google_compute_global_forwarding_rule" {
+				t.Errorf("Type=%q, want google_compute_global_forwarding_rule", got.Identity.Type)
+			}
+			if got.Identity.Location != "" {
+				t.Errorf("Location=%q, want empty (globals carry no location)", got.Identity.Location)
+			}
+		})
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -205,6 +205,7 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string) *GCPDiscovere
 			"google_compute_firewall":                newComputeFirewallDiscoverer(),
 			"google_compute_router":                  newComputeRouterDiscoverer(),
 			"google_compute_address":                 newComputeAddressDiscoverer(),
+			"google_compute_global_address":          newComputeGlobalAddressDiscoverer(),
 			"google_compute_instance":                newComputeInstanceDiscoverer(),
 			"google_container_cluster":               newContainerClusterDiscoverer(),
 			"google_container_node_pool":             newContainerNodePoolDiscoverer(),
@@ -212,6 +213,7 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string) *GCPDiscovere
 			"google_cloud_run_v2_service":            newCloudRunV2ServiceDiscoverer(),
 			"google_cloudfunctions2_function":        newCloudFunctions2FunctionDiscoverer(),
 			"google_compute_forwarding_rule":         newComputeForwardingRuleDiscoverer(),
+			"google_compute_global_forwarding_rule":  newComputeGlobalForwardingRuleDiscoverer(),
 			"google_compute_target_https_proxy":      newComputeTargetHTTPSProxyDiscoverer(),
 			"google_compute_url_map":                 newComputeURLMapDiscoverer(),
 			"google_api_gateway_api":                 newAPIGatewayAPIDiscoverer(),
@@ -511,13 +513,25 @@ func (g *GCPDiscoverer) searchBuckets(ctx context.Context, scope string, args Di
 	return out, nil
 }
 
-// assetTypesOf collects the Cloud Asset asset-type strings from a slice
-// of discoverers, preserving order so unit tests can pin per-bucket
-// asset-type partitioning.
+// assetTypesOf collects the Cloud Asset asset-type strings from a
+// slice of discoverers, deduped while preserving first-appearance
+// order. Order preservation lets unit tests pin per-bucket asset-type
+// partitioning; dedup is required when two discoverers share an asset
+// type (e.g. google_compute_address + google_compute_global_address
+// both register compute.googleapis.com/Address — #384). Without
+// dedup, Cloud Asset's SearchAllResources receives a duplicated
+// assetTypes list which is at best wasteful and at worst could
+// influence pagination/quota accounting.
 func assetTypesOf(ds []Discoverer) []string {
+	seen := make(map[string]struct{}, len(ds))
 	out := make([]string, 0, len(ds))
 	for _, d := range ds {
-		out = append(out, d.AssetType())
+		at := d.AssetType()
+		if _, dup := seen[at]; dup {
+			continue
+		}
+		seen[at] = struct{}{}
+		out = append(out, at)
 	}
 	return out
 }

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
@@ -33,6 +33,7 @@ var expectedRegisteredTypes = map[string]bool{
 	"google_compute_firewall":                false,
 	"google_compute_router":                  false,
 	"google_compute_address":                 false,
+	"google_compute_global_address":          false,
 	"google_compute_instance":                false,
 	"google_container_cluster":               false,
 	"google_container_node_pool":             false,
@@ -40,6 +41,7 @@ var expectedRegisteredTypes = map[string]bool{
 	"google_cloud_run_v2_service":            false,
 	"google_cloudfunctions2_function":        false,
 	"google_compute_forwarding_rule":         false,
+	"google_compute_global_forwarding_rule":  false,
 	"google_compute_target_https_proxy":      false,
 	"google_compute_url_map":                 false,
 	"google_api_gateway_api":                 false,
@@ -128,15 +130,28 @@ func TestDiscoverTypes_DefaultsToAllSupported(t *testing.T) {
 	if len(fake.calls) != wantCalls {
 		t.Fatalf("SearchAll called %d times, want %d (one per non-empty ScopeStyle bucket)", len(fake.calls), wantCalls)
 	}
+	// Collect the distinct Cloud Asset asset-types requested across
+	// all calls. The count must equal the number of DISTINCT asset
+	// types in the registry — strictly less than the number of
+	// registered TF types when two discoverers share a CAI slug
+	// (regional + global address share compute.googleapis.com/Address,
+	// regional + global forwarding rule share
+	// compute.googleapis.com/ForwardingRule; see #384). Compute the
+	// expected from the registry itself rather than hardcoding so
+	// future shared-slug pairs don't drift this assertion.
 	covered := map[string]struct{}{}
 	for _, c := range fake.calls {
 		for _, at := range c.assetTypes {
 			covered[at] = struct{}{}
 		}
 	}
-	if len(covered) != len(g.SupportedTypes()) {
-		t.Errorf("covered asset-types=%d (across %d calls), want %d (one per registered type)",
-			len(covered), len(fake.calls), len(g.SupportedTypes()))
+	wantDistinctAssetTypes := map[string]struct{}{}
+	for _, d := range g.byType {
+		wantDistinctAssetTypes[d.AssetType()] = struct{}{}
+	}
+	if len(covered) != len(wantDistinctAssetTypes) {
+		t.Errorf("covered asset-types=%d (across %d calls), want %d (one per DISTINCT asset type — shared-CAI-slug pairs count once)",
+			len(covered), len(fake.calls), len(wantDistinctAssetTypes))
 	}
 }
 
@@ -653,6 +668,7 @@ var expectedScopeStyle = map[string]ScopeStyle{
 	"google_compute_firewall":                ScopeStyleNamePrefix,       // firewalls have no labels (#369)
 	"google_compute_router":                  ScopeStyleNamePrefix,       // routers have no labels (#369)
 	"google_compute_address":                 ScopeStyleLabels,           // addresses carry labels (#369)
+	"google_compute_global_address":          ScopeStyleLabels,           // global addresses carry labels (#384)
 	"google_compute_instance":                ScopeStyleLabels,           // VMs carry labels (#370)
 	"google_container_cluster":               ScopeStyleLabels,           // GKE clusters carry labels (#371)
 	"google_container_node_pool":             ScopeStyleParentNamePrefix, // child of cluster (#381)
@@ -660,6 +676,7 @@ var expectedScopeStyle = map[string]ScopeStyle{
 	"google_cloud_run_v2_service":            ScopeStyleLabels,     // Cloud Run v2 carries labels (#373)
 	"google_cloudfunctions2_function":        ScopeStyleLabels,     // Cloud Functions v2 carries labels (#373)
 	"google_compute_forwarding_rule":         ScopeStyleLabels,     // forwarding rules carry labels (#375)
+	"google_compute_global_forwarding_rule":  ScopeStyleLabels,     // global forwarding rules carry labels (#384)
 	"google_compute_target_https_proxy":      ScopeStyleNamePrefix, // target HTTPS proxies have no labels (#375)
 	"google_compute_url_map":                 ScopeStyleNamePrefix, // URL maps have no labels (#375)
 	"google_api_gateway_api":                 ScopeStyleLabels,     // API Gateway APIs carry labels (#376)
@@ -705,6 +722,32 @@ func TestScopeStyle_PinsPerTypeContract(t *testing.T) {
 		if _, ok := g.byType[tfType]; !ok {
 			t.Errorf("expectedScopeStyle row for %q has no live registration — remove the row or register the type", tfType)
 		}
+	}
+}
+
+// TestAssetTypesOf_DedupsSharedSlug_PreservesFirstAppearanceOrder
+// pins the dedup contract added in #384. Two discoverers register the
+// same compute.googleapis.com/Address slug; the helper must return a
+// single-entry slice in first-appearance order. Order is observable
+// downstream (unit tests pin per-bucket asset-type partitioning), so
+// the contract is "dedup AND preserve order", not just "dedup".
+func TestAssetTypesOf_DedupsSharedSlug_PreservesFirstAppearanceOrder(t *testing.T) {
+	t.Parallel()
+	ds := []Discoverer{
+		newComputeAddressDiscoverer(),
+		newComputeGlobalAddressDiscoverer(),
+		newPubsubTopicDiscoverer(),
+		newComputeForwardingRuleDiscoverer(),
+		newComputeGlobalForwardingRuleDiscoverer(),
+	}
+	got := assetTypesOf(ds)
+	want := []string{
+		"compute.googleapis.com/Address",        // from regional address (first appearance)
+		"pubsub.googleapis.com/Topic",           // distinct slug
+		"compute.googleapis.com/ForwardingRule", // from regional fwd rule (first appearance)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("assetTypesOf = %v, want %v (dedup + first-appearance order)", got, want)
 	}
 }
 

--- a/pkg/composer/imported/category.go
+++ b/pkg/composer/imported/category.go
@@ -131,6 +131,8 @@ var categoryByTFType = map[string]string{
 	"google_compute_disk":                    CategoryDataStorage,
 	"google_compute_firewall":                CategoryNetworkSecurity,
 	"google_compute_forwarding_rule":         CategoryNetworkSecurity,
+	"google_compute_global_address":          CategoryNetworkSecurity,
+	"google_compute_global_forwarding_rule":  CategoryNetworkSecurity,
 	"google_compute_instance":                CategoryVirtualMachines,
 	"google_compute_network":                 CategoryNetworkSecurity,
 	"google_compute_router":                  CategoryNetworkSecurity,

--- a/pkg/composer/imported/testdata/category.golden
+++ b/pkg/composer/imported/testdata/category.golden
@@ -51,6 +51,8 @@ google_compute_address	Network Security
 google_compute_disk	Data Storage
 google_compute_firewall	Network Security
 google_compute_forwarding_rule	Network Security
+google_compute_global_address	Network Security
+google_compute_global_forwarding_rule	Network Security
 google_compute_instance	Virtual Machines
 google_compute_network	Network Security
 google_compute_router	Network Security

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -73,6 +73,8 @@ var gcpTypes = []string{
 	"google_compute_address",
 	"google_compute_firewall",
 	"google_compute_forwarding_rule",
+	"google_compute_global_address",
+	"google_compute_global_forwarding_rule",
 	"google_compute_instance",
 	"google_compute_network",
 	"google_compute_router",

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -72,6 +72,8 @@ func TestSupportedDiscoverTypes_GCP_ReturnsCanonicalSortedList(t *testing.T) {
 		"google_compute_address",
 		"google_compute_firewall",
 		"google_compute_forwarding_rule",
+		"google_compute_global_address",
+		"google_compute_global_forwarding_rule",
 		"google_compute_instance",
 		"google_compute_network",
 		"google_compute_router",


### PR DESCRIPTION
## Summary

- Adds dedicated discoverers for the two global TF types whose Cloud Asset Inventory slug is shared with their regional siblings: `google_compute_global_address` and `google_compute_global_forwarding_rule`.
- Closes the pre-PR skip path: the live-smoke gap surfaced by #380 — both halves of the regional/global split were dropping their counterpart's rows via the zero-Identity sentinel. With both discoverers registered, regional rows route to the regional discoverer and global rows route to the global discoverer via inverse `/global/`-path filters.
- `assetTypesOf` now dedups the Cloud Asset `assetTypes` argument while preserving first-appearance order, so the two pairs of sibling discoverers don't pass duplicated slugs to SearchAllResources.

## Test plan
- [x] `go test ./cmd/insideout-import/gcpdiscover/... -count=1` (371 tests)
- [x] `go test ./... -count=1` (4170 tests)
- [x] `/verify` — `terraform fmt -check`, all 4 lint scripts PASS
- [x] **Live smoke against `diagramtest2025-09-14` / `io-qtyb4nkwp5n8`** ✓
  - `google_compute_global_address` → **1 discovered** (was 0): `io-qtyb4nkwp5n8-main-ec5aa4d4-ip`
  - `google_compute_global_forwarding_rule` → **1 discovered** (was 0): `io-qtyb4nkwp5n8-main-ec5aa4d4-http`

## Review notes
- `/review`: 0 P0, 0 P1. P2/P3 drive-bys addressed in fixup commit — type→import-id binding pinned directly per resource in the coexistence tests (not via sorted-set membership), `parseGlobalNameFromID` helper extracted, error-message convention aligned with sibling parsers.
- `qa-professor`: P0 (missing ForwardingRule coexistence test) addressed in fixup. P2 (sorted-set mutation gap) addressed by the direct binding.

## Implementation notes
- Both new discoverers use `ScopeStyleLabels` — live smoke confirms the global compute address/forwarding-rule resources carry labels and are attributed via the server-side `labels.project:` clause.
- The shared `isGlobalAddressOrForwardingRule` predicate keeps the regional/global filter logic in one place. New parent-of-sibling discoverer pairs can follow the same pattern.

Closes #384