### PR TITLE
fix(composer): coerce stale enable_nat_gateway + multi-layer static guards (#389)

### DIFF
--- a/aws/vpc/outputs.tf
+++ b/aws/vpc/outputs.tf
@@ -1,6 +1,22 @@
 output "vpc_id" {
   description = "The VPC ID"
   value       = module.this.vpc_id
+
+  # Cross-variable invariant: NAT requires private subnets. The upstream
+  # terraform-aws-modules/vpc/aws otherwise plans aws_route.private_nat_gateway
+  # against an empty aws_route_table.private and apply fails at the element()
+  # call with "cannot use element function with an empty list" (issue #389).
+  #
+  # Preset-level backstop for the composer's mapper coercion in
+  # pkg/composer/mapper.go — fires at terraform plan for any consumer of this
+  # preset (composer or hand-authored) that emits the inconsistent pair.
+  # Attached to the output rather than a separate terraform_data resource
+  # because the latter would force the composer's required_providers
+  # discovery to emit the built-in `terraform` provider, which has no source.
+  precondition {
+    condition     = !(var.enable_nat_gateway && !var.enable_private_subnets)
+    error_message = "enable_nat_gateway=true requires enable_private_subnets=true: NAT routes attach to the private route table, which is empty when private subnets are disabled (issue #389)."
+  }
 }
 
 output "private_subnet_ids" {

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -280,6 +280,7 @@ func (c *Client) composeSingleImpl(opts ComposeSingleOpts) (*ComposeSingleResult
 
 	issues = append(issues, validateRequiredIssues(vars, wired, vals, string(opts.Key))...)
 	issues = append(issues, ValidateGCPProjectID(cloud, opts.GCPProjectID)...)
+	issues = append(issues, ValidateAWSVPCNATConsistency(cloud, opts.Comps, opts.Cfg)...)
 
 	var tfvars []VarEntry
 	for _, v := range vars {
@@ -703,6 +704,7 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	issues = append(issues, ValidateSensitivePropagation(blocks, presetPaths)...)
 	issues = append(issues, ValidateComposedRoot(files)...)
 	issues = append(issues, ValidateGCPProjectID(cloud, opts.GCPProjectID)...)
+	issues = append(issues, ValidateAWSVPCNATConsistency(cloud, opts.Comps, opts.Cfg)...)
 
 	return &ComposeStackResult{Files: files, Issues: issues}, nil
 }

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -2445,19 +2445,30 @@ func TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate(t *testing.
 }
 
 // TestComposeStack_AWS_PublicVPC_TerraformValidate is the AWS analogue of
-// the GCP issue-#178 closure above. It composes representative AWS stacks
-// — including the #389 bug shape (Public VPC + no private-subnet consumers
-// + stale cfg.AWSVPC.EnableNATGateway=true) — and runs `terraform init &&
-// terraform validate` on the composed root. Closes the parity gap that
-// let #389 reach apply time: prior to this test, AWS-side composer output
-// was only HCL-parsed by compose_stack_test.go:780, never validated.
+// the GCP issue-#178 closure (TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate
+// above). It composes representative AWS stacks and runs `terraform init &&
+// terraform validate` on the composed root. Closes the parity gap with the
+// GCP-only existing gate: prior to this test, AWS-side composer output was
+// only HCL-parsed (compose_stack_test.go:780), never validated.
 //
-// The bug shape's expected behavior here is "validates clean": Layer 1a
-// in the mapper coerces enable_nat_gateway=false in the emitted tfvars,
-// so even though the caller's cfg is stale, the validate gate sees the
-// coerced inputs and passes. To reproduce the #389 apply failure in
-// validate, revert just the mapper coercion (validate will surface the
-// "element() on empty list" / precondition error).
+// SCOPE — what this gate catches and what it does NOT catch.
+//
+// validate exercises HCL syntax, type conformance, and attribute existence
+// across the whole composed root including child modules. It does NOT
+// evaluate expressions like element() / slice() — so the specific #389
+// failure mode (element() against an empty private route table at apply)
+// is NOT what this gate catches. That class of failure needs `terraform
+// plan` to surface, which is what TestComposeStack_GCPCloudKMS_TerraformPlan
+// uses for the sibling #182 slice() bug. For #389 specifically, the
+// behaviour-level gate is the mapper coercion (verified by
+// TestComposeStackWithIssues_AWSVPCStaleNATGateway_Issue389 in
+// validate_aws_vpc_test.go) plus the preset-level output precondition
+// (verified by TestAWSVPCPresetPrecondition_RejectsBadPair below).
+//
+// What THIS test does catch: a future composer regression that emits a
+// composed root with broken cross-module wiring, missing/extra attributes
+// on AWS provider-versioned resources, or HCL syntax issues. Closes the
+// validate-side parity gap for #389-class incidents going forward.
 //
 // Behavior on init failure mirrors the GCP test: hard-fail in CI, skip
 // locally so offline `go test ./...` still runs.
@@ -2471,13 +2482,11 @@ func TestComposeStack_AWS_PublicVPC_TerraformValidate(t *testing.T) {
 
 	inCI := os.Getenv("CI") == "true"
 	boolPtr := func(v bool) *bool { return &v }
+	// Use the shared cfgWithAWSVPC helper (mapper_test.go:182) to avoid
+	// re-declaring the anonymous Config.AWSVPC struct in multiple places.
 	awsVPCCfg := func(enable *bool) *Config {
-		c := &Config{Region: "us-east-1"}
-		c.AWSVPC = &struct {
-			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
-			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
-			AZCount          *int  `json:"azCount,omitempty"`
-		}{EnableNATGateway: enable}
+		c := cfgWithAWSVPC(nil, enable, nil)
+		c.Region = "us-east-1"
 		return c
 	}
 
@@ -2488,10 +2497,12 @@ func TestComposeStack_AWS_PublicVPC_TerraformValidate(t *testing.T) {
 		cfg   *Config
 	}{
 		{
-			// The #389 minimal repro. Without the Layer 1a mapper coercion,
-			// `terraform validate` would surface either the precondition
-			// fail (Layer 2 backstop) or the upstream's empty-tuple error.
-			name: "Public VPC with stale EnableNATGateway=true (#389 bug shape)",
+			// Post-coercion shape from the #389 bug stack: composer emits
+			// enable_nat_gateway=false (Layer 1a mapper coercion already
+			// fired) — this combo proves the resulting composed root is
+			// well-formed terraform. It does NOT prove the bug would be
+			// caught if the coercion regressed (see docstring SCOPE).
+			name: "Public VPC, no private-subnet consumers (post-coercion shape)",
 			keys: []ComponentKey{KeyAWSVPC, KeyAWSS3, KeyAWSKMS, KeyAWSLambda, KeyAWSSecretsManager, KeyAWSCloudWatchLogs},
 			comps: &Components{
 				Cloud:             "AWS",
@@ -2563,18 +2574,120 @@ func TestComposeStack_AWS_PublicVPC_TerraformValidate(t *testing.T) {
 			validateCmd := exec.Command("terraform", "validate", "-no-color")
 			validateCmd.Dir = dir
 			validateOut, err := validateCmd.CombinedOutput()
-			require.NoError(t, err, "terraform validate must succeed on composed stack (issue #389):\n%s", validateOut)
-			// The #389 deploy-time symptom — surface here so a future
-			// mapper regression that drops the coercion is named
-			// precisely instead of just "validate failed".
-			require.NotContains(t, string(validateOut), "empty tuple",
-				"terraform validate surfaced 'empty tuple' — #389 regression: composer emitted enable_nat_gateway=true with private subnets disabled")
-			require.NotContains(t, string(validateOut), "element function",
-				"terraform validate surfaced 'element function' — #389 regression: NAT route attached to empty private route table")
-			require.NotContains(t, string(validateOut), "Resource precondition failed",
-				"terraform validate surfaced a precondition failure — Layer 2 backstop fired, meaning the Layer 1a mapper coercion regressed")
+			require.NoError(t, err, "terraform validate must succeed on composed AWS stack:\n%s", validateOut)
 		})
 	}
+}
+
+// TestAWSVPCPresetPrecondition_RejectsBadPair is the honest Layer 2
+// behaviour gate for #389 at the preset level. It runs `terraform plan`
+// against the aws/vpc preset standalone with the inconsistent
+// (enable_nat_gateway=true, enable_private_subnets=false) pair and asserts
+// the output precondition added in aws/vpc/outputs.tf fires with the
+// #389 reference.
+//
+// Why preset-standalone and not the composed root: the precondition is
+// a property of the preset itself, the composed-root case is already
+// covered by the unit tests above (mapper coercion + ValidationIssue),
+// and standalone plan avoids needing to model every consumer of the
+// composed stack. Why plan and not validate: validate does not evaluate
+// preconditions (verified empirically — they only fire during plan).
+//
+// AWS credentials are stubbed via env vars so the provider initializes
+// in CI; data sources (aws_availability_zones, aws_region) will fail
+// their API calls but the precondition is evaluated regardless and its
+// error string is what we assert on. Mirrors the GCP fake-OAuth-token
+// pattern in TestComposeStack_GCPCloudKMS_TerraformPlan above.
+//
+// CI vs local skip rules match the sibling tests: CI=true → init failure
+// is fatal; local dev → skip on init failure so offline `go test ./...`
+// works.
+func TestAWSVPCPresetPrecondition_RejectsBadPair(t *testing.T) {
+	if testing.Short() {
+		t.Skip("-short skips multi-second terraform init+plan")
+	}
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform binary not on PATH; skipping integration plan")
+	}
+
+	inCI := os.Getenv("CI") == "true"
+
+	// Locate aws/vpc relative to this test package. The embedded preset
+	// FS is read-only; for `terraform init` we need a real-filesystem
+	// directory, so copy the preset out to a tempdir.
+	presetSrc := filepath.Join("..", "..", "aws", "vpc")
+	dir := t.TempDir()
+	entries, err := os.ReadDir(presetSrc)
+	require.NoError(t, err, "read aws/vpc directory")
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(presetSrc, e.Name()))
+		require.NoError(t, err, "read %s", e.Name())
+		require.NoError(t,
+			os.WriteFile(filepath.Join(dir, e.Name()), b, 0o600),
+			"write %s to tempdir", e.Name())
+	}
+
+	// Provider override: AWS provider would otherwise call STS to
+	// validate the bogus credentials before reaching plan. With
+	// skip_credentials_validation + skip_requesting_account_id +
+	// skip_metadata_api_check, the provider initializes offline and
+	// plan proceeds to evaluate the output precondition. Data sources
+	// (aws_availability_zones, aws_region) will still fail their API
+	// calls, but terraform reports the precondition error alongside
+	// in the same plan run — which is what we assert on.
+	providerOverride := []byte(`provider "aws" {
+  region                      = "us-east-1"
+  access_key                  = "AKIATESTNOTREAL"
+  secret_key                  = "test-secret-not-real"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+}
+`)
+	require.NoError(t,
+		os.WriteFile(filepath.Join(dir, "provider_test_override.tf"), providerOverride, 0o600),
+		"write provider override")
+
+	initCmd := exec.Command("terraform", "init", "-backend=false", "-input=false", "-no-color")
+	initCmd.Dir = dir
+	initOut, err := initCmd.CombinedOutput()
+	if err != nil {
+		if inCI {
+			require.NoError(t, err,
+				"terraform init must succeed in CI; this gate is the Layer 2 backstop closure for #389 and must not silently skip on transient registry failures:\n%s", initOut)
+		}
+		t.Skipf("terraform init unavailable (network/cache) in local dev: %s\n%s", err, initOut)
+	}
+
+	planCmd := exec.Command(
+		"terraform", "plan",
+		"-refresh=false", "-input=false", "-no-color",
+		"-var=enable_nat_gateway=true",
+		"-var=enable_private_subnets=false",
+		"-var=environment=test",
+	)
+	planCmd.Dir = dir
+	// Stub AWS credentials so the provider initializes; the test never
+	// hits a real AWS call, and even though data sources will fail their
+	// API calls, terraform still evaluates the output precondition and
+	// reports its error in the same plan run.
+	planCmd.Env = append(os.Environ(),
+		"AWS_ACCESS_KEY_ID=AKIATESTNOTREAL",
+		"AWS_SECRET_ACCESS_KEY=test-secret-not-real",
+		"AWS_DEFAULT_REGION=us-east-1",
+		"AWS_REGION=us-east-1",
+	)
+	planOut, _ := planCmd.CombinedOutput()
+	// Plan is expected to FAIL (the precondition aborts it). Don't
+	// require.NoError; assert on the failure substring.
+	out := string(planOut)
+	require.Contains(t, out, "precondition failed",
+		"expected output precondition to fail plan for the bad-pair vars (issue #389 Layer 2 backstop):\n%s", out)
+	require.Contains(t, out, "#389",
+		"precondition error must cite #389 so future readers can locate context:\n%s", out)
 }
 
 // TestComposeStack_GCPCloudKMS_TerraformPlan is the formal closure

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -2444,6 +2444,139 @@ func TestComposeStack_GCPRouterAndConnectorOutputs_TerraformValidate(t *testing.
 	}
 }
 
+// TestComposeStack_AWS_PublicVPC_TerraformValidate is the AWS analogue of
+// the GCP issue-#178 closure above. It composes representative AWS stacks
+// — including the #389 bug shape (Public VPC + no private-subnet consumers
+// + stale cfg.AWSVPC.EnableNATGateway=true) — and runs `terraform init &&
+// terraform validate` on the composed root. Closes the parity gap that
+// let #389 reach apply time: prior to this test, AWS-side composer output
+// was only HCL-parsed by compose_stack_test.go:780, never validated.
+//
+// The bug shape's expected behavior here is "validates clean": Layer 1a
+// in the mapper coerces enable_nat_gateway=false in the emitted tfvars,
+// so even though the caller's cfg is stale, the validate gate sees the
+// coerced inputs and passes. To reproduce the #389 apply failure in
+// validate, revert just the mapper coercion (validate will surface the
+// "element() on empty list" / precondition error).
+//
+// Behavior on init failure mirrors the GCP test: hard-fail in CI, skip
+// locally so offline `go test ./...` still runs.
+func TestComposeStack_AWS_PublicVPC_TerraformValidate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("-short skips multi-second terraform init+validate")
+	}
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform binary not on PATH; skipping integration validate")
+	}
+
+	inCI := os.Getenv("CI") == "true"
+	boolPtr := func(v bool) *bool { return &v }
+	awsVPCCfg := func(enable *bool) *Config {
+		c := &Config{Region: "us-east-1"}
+		c.AWSVPC = &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{EnableNATGateway: enable}
+		return c
+	}
+
+	combos := []struct {
+		name  string
+		keys  []ComponentKey
+		comps *Components
+		cfg   *Config
+	}{
+		{
+			// The #389 minimal repro. Without the Layer 1a mapper coercion,
+			// `terraform validate` would surface either the precondition
+			// fail (Layer 2 backstop) or the upstream's empty-tuple error.
+			name: "Public VPC with stale EnableNATGateway=true (#389 bug shape)",
+			keys: []ComponentKey{KeyAWSVPC, KeyAWSS3, KeyAWSKMS, KeyAWSLambda, KeyAWSSecretsManager, KeyAWSCloudWatchLogs},
+			comps: &Components{
+				Cloud:             "AWS",
+				AWSS3:             boolPtr(true),
+				AWSKMS:            boolPtr(true),
+				AWSVPC:            "Public VPC",
+				AWSLambda:         boolPtr(true),
+				Architecture:      "Serverless",
+				AWSSecretsManager: boolPtr(true),
+				AWSCloudWatchLogs: boolPtr(true),
+			},
+			cfg: awsVPCCfg(boolPtr(true)),
+		},
+		{
+			// Symmetry: Public VPC with EKS (private subnets still needed)
+			// must validate clean — the override stays legitimate.
+			name: "Public VPC + EKS keeps private subnets + NAT",
+			keys: []ComponentKey{KeyAWSVPC, KeyAWSEKS},
+			comps: &Components{
+				Cloud:        "AWS",
+				AWSVPC:       "Public VPC",
+				AWSEKS:       boolPtr(true),
+				Architecture: "Kubernetes",
+			},
+			cfg: awsVPCCfg(boolPtr(true)),
+		},
+		{
+			// Baseline: Private VPC with defaults (the "happy path" any
+			// future regression would also have to keep passing).
+			name: "Private VPC with defaults",
+			keys: []ComponentKey{KeyAWSVPC, KeyAWSS3, KeyAWSLambda},
+			comps: &Components{
+				Cloud:        "AWS",
+				AWSVPC:       "Private VPC",
+				AWSS3:        boolPtr(true),
+				AWSLambda:    boolPtr(true),
+				Architecture: "Serverless",
+			},
+			cfg: &Config{Region: "us-east-1"},
+		},
+	}
+
+	for _, combo := range combos {
+		t.Run(combo.name, func(t *testing.T) {
+			c := newTestClient()
+			out, err := c.ComposeStack(ComposeStackOpts{
+				Cloud:        "aws",
+				SelectedKeys: combo.keys,
+				Comps:        combo.comps,
+				Cfg:          combo.cfg,
+				Project:      "test-389",
+				Region:       "us-east-1",
+			})
+			require.NoError(t, err)
+
+			dir := t.TempDir()
+			writeOutputs(t, out, dir)
+
+			initCmd := exec.Command("terraform", "init", "-backend=false", "-input=false", "-no-color")
+			initCmd.Dir = dir
+			initOut, err := initCmd.CombinedOutput()
+			if err != nil {
+				if inCI {
+					require.NoError(t, err,
+						"terraform init must succeed in CI; this gate is the AWS analogue of issue #178/closure for #389 and must not silently skip on transient registry failures:\n%s", initOut)
+				}
+				t.Skipf("terraform init unavailable (network/cache) in local dev: %s\n%s", err, initOut)
+			}
+			validateCmd := exec.Command("terraform", "validate", "-no-color")
+			validateCmd.Dir = dir
+			validateOut, err := validateCmd.CombinedOutput()
+			require.NoError(t, err, "terraform validate must succeed on composed stack (issue #389):\n%s", validateOut)
+			// The #389 deploy-time symptom — surface here so a future
+			// mapper regression that drops the coercion is named
+			// precisely instead of just "validate failed".
+			require.NotContains(t, string(validateOut), "empty tuple",
+				"terraform validate surfaced 'empty tuple' — #389 regression: composer emitted enable_nat_gateway=true with private subnets disabled")
+			require.NotContains(t, string(validateOut), "element function",
+				"terraform validate surfaced 'element function' — #389 regression: NAT route attached to empty private route table")
+			require.NotContains(t, string(validateOut), "Resource precondition failed",
+				"terraform validate surfaced a precondition failure — Layer 2 backstop fired, meaning the Layer 1a mapper coercion regressed")
+		})
+	}
+}
+
 // TestComposeStack_GCPCloudKMS_TerraformPlan is the formal closure
 // for issue #182's acceptance criterion: a fresh GCP session that
 // selects gcp/kms with default config (and with non-default

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -143,6 +143,20 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+		// NAT-vs-private-subnets coercion (#389). If private subnets were
+		// disabled above (Public VPC with no downstream consumers), NAT must
+		// be off too — the upstream terraform-aws-modules/vpc/aws plans
+		// aws_route.private_nat_gateway against the now-empty
+		// aws_route_table.private and apply fails with "element() on empty
+		// list". This rule overrides cfg.AWSVPC.EnableNATGateway when the
+		// caller's saved config is stale (e.g. OpenSearch was removed from
+		// the stack but EnableNATGateway=true persisted). A parallel
+		// ValidationIssue ("aws_vpc_stale_nat_gateway") surfaces the
+		// coercion to upstream callers so the stale field can be cleared.
+		if pSubn, ok := vals["enable_private_subnets"].(bool); ok && !pSubn {
+			vals["enable_nat_gateway"] = false
+		}
+
 	case KeyCloud:
 		// Example: cloud/provider selection
 		if comps != nil && comps.Cloud != "" {

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -240,12 +240,35 @@ func TestBuildModuleValues_VPC_AWSVPCConfig(t *testing.T) {
 		assert.False(t, vals["single_nat_gateway"].(bool), "user config still applies")
 	})
 
-	t.Run("user EnableNATGateway=true overrides Public-VPC-derived false", func(t *testing.T) {
+	t.Run("stale EnableNATGateway=true is coerced to false on a Public VPC with no private-subnet components (#389)", func(t *testing.T) {
+		// Reproduces the #389 bug shape: caller's saved cfg has
+		// EnableNATGateway=true left over from a prior config (e.g. when
+		// OpenSearch was selected). After OpenSearch is removed the stack
+		// is Public-VPC + no private-subnet consumers; the upstream VPC
+		// module would otherwise plan aws_route.private_nat_gateway against
+		// an empty private route table and fail apply. The mapper coerces
+		// enable_nat_gateway=false to keep the deploy correct; the
+		// composer surfaces aws_vpc_stale_nat_gateway as a ValidationIssue
+		// so the upstream caller can clear the stale field.
 		comps := &Components{AWSVPC: "Public VPC"}
 		cfg := cfgWithAWSVPC(nil, boolPtr(true), nil)
 		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
 		require.NoError(t, err)
-		assert.True(t, vals["enable_nat_gateway"].(bool), "user override wins over Public VPC default")
+		assert.Equal(t, false, vals["enable_private_subnets"], "Public VPC with no consumers still disables private subnets")
+		assert.Equal(t, false, vals["enable_nat_gateway"], "stale cfg EnableNATGateway=true must be coerced to false (#389)")
+	})
+
+	t.Run("legitimate EnableNATGateway=true is preserved when a private-subnet component is present", func(t *testing.T) {
+		// Sanity: when the user has an EKS/RDS/etc. consumer, private
+		// subnets stay enabled so cfg.AWSVPC.EnableNATGateway=true is a
+		// legitimate setting and must survive the coercion path.
+		comps := &Components{AWSVPC: "Public VPC", AWSEKS: boolPtr(true)}
+		cfg := cfgWithAWSVPC(nil, boolPtr(true), nil)
+		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		_, hasPrivate := vals["enable_private_subnets"]
+		assert.False(t, hasPrivate, "preset default (true) takes effect; mapper does not override")
+		assert.True(t, vals["enable_nat_gateway"].(bool), "legitimate EnableNATGateway=true survives when private subnets remain enabled")
 	})
 }
 

--- a/pkg/composer/validate.go
+++ b/pkg/composer/validate.go
@@ -132,6 +132,7 @@ func ValidateAll(
 		all = append(all, ValidateOpts(opts[0])...)
 		all = append(all, ValidateImportedResources(opts[0].Cloud, opts[0].Imported)...)
 		all = append(all, ValidateImportedResourceAuthorization(opts[0].Cloud, opts[0].Imported)...)
+		all = append(all, ValidateAWSVPCNATConsistency(opts[0].Cloud, comps, cfg)...)
 	}
 	return dedupeAndSortIssues(all)
 }

--- a/pkg/composer/validate.go
+++ b/pkg/composer/validate.go
@@ -132,8 +132,20 @@ func ValidateAll(
 		all = append(all, ValidateOpts(opts[0])...)
 		all = append(all, ValidateImportedResources(opts[0].Cloud, opts[0].Imported)...)
 		all = append(all, ValidateImportedResourceAuthorization(opts[0].Cloud, opts[0].Imported)...)
-		all = append(all, ValidateAWSVPCNATConsistency(opts[0].Cloud, comps, cfg)...)
 	}
+	// AWS-VPC cross-field check runs regardless of whether opts were supplied:
+	// dry-run callers (per ValidateAll's docstring) may pass no opts but still
+	// have a cloud-bearing Comps. Mirror ValidateOpts's cloud-resolution
+	// (explicit opts.Cloud → Comps.Cloud) so external callers of ValidateAll
+	// get the same coverage as ComposeStack/Single.
+	cloud := ""
+	if len(opts) > 0 {
+		cloud = opts[0].Cloud
+	}
+	if cloud == "" && comps != nil {
+		cloud = comps.Cloud
+	}
+	all = append(all, ValidateAWSVPCNATConsistency(cloud, comps, cfg)...)
 	return dedupeAndSortIssues(all)
 }
 

--- a/pkg/composer/validate_aws_vpc.go
+++ b/pkg/composer/validate_aws_vpc.go
@@ -1,0 +1,47 @@
+package composer
+
+import "strings"
+
+// ValidateAWSVPCNATConsistency returns a ValidationIssue when
+// cfg.AWSVPC.EnableNATGateway=true is paired with a Public-VPC stack that has
+// no components requiring private subnets — the shape that triggered issue
+// #389. The mapper coerces enable_nat_gateway=false in this case so the
+// deploy succeeds, but the issue is surfaced so the upstream caller can
+// clear the stale field (typically left over after the user removed an
+// OpenSearch/Bedrock component that previously required NAT).
+//
+// Behavior contract:
+//
+//   - Default mode: warning-equivalent — the issue is appended to
+//     Result.Issues but the compose still succeeds (with the coerced
+//     enable_nat_gateway=false in the emitted tfvars).
+//   - StrictValidate=true: ComposeStackWithIssues / ComposeSingleWithIssues
+//     escalate any non-empty Issues to an aggregated error (see compose.go).
+//
+// No-op when cloud is not AWS, or when the inputs don't match the bug
+// shape (Public VPC + no private-subnet-needing components + EnableNATGateway=true).
+func ValidateAWSVPCNATConsistency(cloud string, comps *Components, cfg *Config) []ValidationIssue {
+	if !strings.EqualFold(strings.TrimSpace(cloud), "aws") {
+		return nil
+	}
+	if comps == nil || !strings.EqualFold(comps.AWSVPC, "Public VPC") {
+		return nil
+	}
+	if stackNeedsPrivateSubnets(comps) {
+		return nil
+	}
+	if cfg == nil || cfg.AWSVPC == nil || cfg.AWSVPC.EnableNATGateway == nil || !*cfg.AWSVPC.EnableNATGateway {
+		return nil
+	}
+	return []ValidationIssue{{
+		Field: "cfg.aws_vpc.enable_nat_gateway",
+		Value: "true",
+		Code:  "aws_vpc_stale_nat_gateway",
+		Reason: "cfg.aws_vpc.enable_nat_gateway=true is incompatible with a Public VPC that has no components " +
+			"requiring private subnets (EKS/ECS/RDS/ElastiCache/OpenSearch/EC2 nodes): NAT routes would attach " +
+			"to an empty private route table and terraform apply would fail. The composer coerced " +
+			"enable_nat_gateway=false in the emitted tfvars to keep the deploy correct (#389)",
+		Suggestion: "clear cfg.aws_vpc.enable_nat_gateway (usually a stale leftover from a prior config that included " +
+			"a private-subnet-needing component), or add a downstream component, or switch to Private VPC",
+	}}
+}

--- a/pkg/composer/validate_aws_vpc_test.go
+++ b/pkg/composer/validate_aws_vpc_test.go
@@ -1,0 +1,185 @@
+package composer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// awsVPCNATCfg builds the minimal *Config needed for the validator's input
+// shape — only AWSVPC.EnableNATGateway matters here. Kept inline so the
+// tests don't reach into the cfgWithAWSVPC helper from mapper_test.go and
+// stay self-contained.
+func awsVPCNATCfg(enable *bool) *Config {
+	c := &Config{}
+	c.AWSVPC = &struct {
+		SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+		EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+		AZCount          *int  `json:"azCount,omitempty"`
+	}{EnableNATGateway: enable}
+	return c
+}
+
+// TestValidateAWSVPCNATConsistency pins every branch of the #389 validator.
+// The matrix locks in cloud-gating (GCP / empty are no-ops), the bug shape
+// (Public VPC + no private-subnet components + EnableNATGateway=true), and
+// every adjacent "legitimate" shape that must NOT emit the issue.
+func TestValidateAWSVPCNATConsistency(t *testing.T) {
+	t.Parallel()
+	boolPtr := func(v bool) *bool { return &v }
+
+	cases := []struct {
+		name      string
+		cloud     string
+		comps     *Components
+		cfg       *Config
+		wantIssue bool
+	}{
+		// Bug shape — must fire.
+		{
+			name:      "Public VPC + no consumers + EnableNATGateway=true (#389 bug shape)",
+			cloud:     "aws",
+			comps:     &Components{AWSVPC: "Public VPC"},
+			cfg:       awsVPCNATCfg(boolPtr(true)),
+			wantIssue: true,
+		},
+
+		// Cloud gating.
+		{name: "gcp cloud is a no-op", cloud: "gcp", comps: &Components{AWSVPC: "Public VPC"}, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: false},
+		{name: "empty cloud is a no-op", cloud: "", comps: &Components{AWSVPC: "Public VPC"}, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: false},
+		{name: "case-insensitive cloud match", cloud: "AWS", comps: &Components{AWSVPC: "Public VPC"}, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: true},
+
+		// Nil-input safety.
+		{name: "nil comps is a no-op", cloud: "aws", comps: nil, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: false},
+		{name: "nil cfg is a no-op", cloud: "aws", comps: &Components{AWSVPC: "Public VPC"}, cfg: nil, wantIssue: false},
+		{name: "nil cfg.AWSVPC is a no-op", cloud: "aws", comps: &Components{AWSVPC: "Public VPC"}, cfg: &Config{}, wantIssue: false},
+		{name: "nil cfg.AWSVPC.EnableNATGateway is a no-op", cloud: "aws", comps: &Components{AWSVPC: "Public VPC"}, cfg: awsVPCNATCfg(nil), wantIssue: false},
+
+		// VPC-shape gating.
+		{name: "Private VPC is a no-op (NAT is the documented default)", cloud: "aws", comps: &Components{AWSVPC: "Private VPC"}, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: false},
+		{name: "empty AWSVPC is a no-op", cloud: "aws", comps: &Components{}, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: false},
+		{name: "EnableNATGateway=false on Public VPC is a no-op (mapper's :120 reject handles the inverse)", cloud: "aws", comps: &Components{AWSVPC: "Public VPC"}, cfg: awsVPCNATCfg(boolPtr(false)), wantIssue: false},
+
+		// Consumer-presence gating — when a private-subnet-needing component
+		// is present, EnableNATGateway=true is legitimate. Cover every
+		// member of stackNeedsPrivateSubnets explicitly so a future
+		// regression that drops one from the predicate gets caught here.
+		{name: "AWSEKS present -> legitimate NAT, no issue", cloud: "aws", comps: &Components{AWSVPC: "Public VPC", AWSEKS: boolPtr(true)}, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: false},
+		{name: "AWSECS present -> legitimate NAT, no issue", cloud: "aws", comps: &Components{AWSVPC: "Public VPC", AWSECS: boolPtr(true)}, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: false},
+		{name: "AWSRDS present -> legitimate NAT, no issue", cloud: "aws", comps: &Components{AWSVPC: "Public VPC", AWSRDS: boolPtr(true)}, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: false},
+		{name: "AWSElastiCache present -> legitimate NAT, no issue", cloud: "aws", comps: &Components{AWSVPC: "Public VPC", AWSElastiCache: boolPtr(true)}, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: false},
+		{name: "AWSOpenSearch present -> legitimate NAT, no issue (the v5-stack predecessor of #389)", cloud: "aws", comps: &Components{AWSVPC: "Public VPC", AWSOpenSearch: boolPtr(true)}, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: false},
+		{name: "AWSEC2 present -> legitimate NAT, no issue", cloud: "aws", comps: &Components{AWSVPC: "Public VPC", AWSEC2: "Intel"}, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ValidateAWSVPCNATConsistency(tc.cloud, tc.comps, tc.cfg)
+			if !tc.wantIssue {
+				require.Empty(t, got, "expected no issues, got %#v", got)
+				return
+			}
+			require.Len(t, got, 1, "expected exactly one issue")
+			require.Equal(t, "aws_vpc_stale_nat_gateway", got[0].Code)
+			require.Equal(t, "cfg.aws_vpc.enable_nat_gateway", got[0].Field)
+			require.Equal(t, "true", got[0].Value)
+			require.NotEmpty(t, got[0].Reason)
+			require.NotEmpty(t, got[0].Suggestion)
+			require.Contains(t, got[0].Reason, "#389", "reason should reference the issue so downstream callers can find context")
+		})
+	}
+}
+
+// TestComposeStackWithIssues_AWSVPCStaleNATGateway_Issue389 closes the
+// integration loop end-to-end. It composes the exact stack from the bug
+// report (Public VPC, no private-subnet consumers, stale
+// cfg.AWSVPC.EnableNATGateway=true) and asserts:
+//
+//   - the emitted vpc.auto.tfvars contains enable_nat_gateway=false (Layer
+//     1a coercion makes the deploy correct)
+//   - Result.Issues contains aws_vpc_stale_nat_gateway (Layer 1b surfacing)
+//   - StrictValidate=true escalates that issue to an error so callers that
+//     prefer hard-fail get it
+func TestComposeStackWithIssues_AWSVPCStaleNATGateway_Issue389(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+
+	// Build the components blob from the bug report.
+	comps := &Components{
+		Cloud:              "AWS",
+		AWSS3:              boolPtr(true),
+		AWSKMS:             boolPtr(true),
+		AWSVPC:             "Public VPC",
+		AWSLambda:          boolPtr(true),
+		Architecture:       "Serverless",
+		AWSSecretsManager:  boolPtr(true),
+		AWSCloudWatchLogs:  boolPtr(true),
+	}
+	cfg := awsVPCNATCfg(boolPtr(true))
+	cfg.Region = "us-east-1"
+
+	opts := ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC, KeyAWSS3, KeyAWSKMS, KeyAWSLambda, KeyAWSSecretsManager, KeyAWSCloudWatchLogs},
+		Comps:        comps,
+		Cfg:          cfg,
+		Project:      "test-389",
+		Region:       "us-east-1",
+	}
+
+	c := newTestClient()
+
+	t.Run("default mode: coerces tfvars and surfaces the issue", func(t *testing.T) {
+		out, err := c.ComposeStackWithIssues(opts)
+		require.NoError(t, err, "default mode should not hard-fail; it surfaces the issue")
+		require.NotNil(t, out)
+
+		// Confirm the emitted tfvars no longer contains the bad pair.
+		// The vpc-namespaced key for enable_nat_gateway is vpc_enable_nat_gateway.
+		tfvarsBytes, ok := out.Files["/aws_vpc.auto.tfvars"]
+		require.True(t, ok, "expected /aws_vpc.auto.tfvars in composed files; got: %v", filesKeys(out.Files))
+		// EmitAutoTFVars pads names for alignment, so collapse whitespace
+		// before asserting key=value pairs.
+		tfvars := strings.Join(strings.Fields(string(tfvarsBytes)), " ")
+		require.Contains(t, tfvars, "aws_vpc_enable_nat_gateway = false", "Layer 1a coercion must zero NAT in the emitted tfvars")
+		require.Contains(t, tfvars, "aws_vpc_enable_private_subnets = false", "Public VPC + no consumers still disables private subnets")
+
+		// Confirm the warning surfaced.
+		var found *ValidationIssue
+		for i := range out.Issues {
+			if out.Issues[i].Code == "aws_vpc_stale_nat_gateway" {
+				found = &out.Issues[i]
+				break
+			}
+		}
+		require.NotNil(t, found, "expected aws_vpc_stale_nat_gateway in Issues; got: %#v", out.Issues)
+		assert.Equal(t, "cfg.aws_vpc.enable_nat_gateway", found.Field)
+		assert.Equal(t, "true", found.Value)
+		assert.Contains(t, found.Reason, "Public VPC")
+	})
+
+	t.Run("StrictValidate=true escalates the issue to an error", func(t *testing.T) {
+		strictOpts := opts
+		strictOpts.StrictValidate = true
+		_, err := c.ComposeStackWithIssues(strictOpts)
+		require.Error(t, err, "StrictValidate must promote the warning to a hard error")
+		// summarizeIssues renders "Field: Reason"; assert on the field path
+		// (stable) and that the bug-source marker "#389" is included
+		// (the Code itself isn't surfaced in summarizeIssues output).
+		assert.Contains(t, err.Error(), "cfg.aws_vpc.enable_nat_gateway",
+			"error should name the failing field so callers can route on it; got: %v", err)
+		assert.Contains(t, err.Error(), "#389",
+			"error should carry the issue reference; got: %v", err)
+	})
+}
+
+// filesKeys returns the file paths from a Files map, for legible failure messages.
+func filesKeys(f Files) []string {
+	out := make([]string, 0, len(f))
+	for k := range f {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/composer/validate_aws_vpc_test.go
+++ b/pkg/composer/validate_aws_vpc_test.go
@@ -8,18 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// awsVPCNATCfg builds the minimal *Config needed for the validator's input
-// shape — only AWSVPC.EnableNATGateway matters here. Kept inline so the
-// tests don't reach into the cfgWithAWSVPC helper from mapper_test.go and
-// stay self-contained.
+// awsVPCNATCfg is a thin shim over cfgWithAWSVPC (mapper_test.go:182) that
+// only sets EnableNATGateway — the only field this validator inspects.
+// Reuse keeps the test refactor-resilient: any future field added to
+// Config.AWSVPC only needs to touch the shared helper.
 func awsVPCNATCfg(enable *bool) *Config {
-	c := &Config{}
-	c.AWSVPC = &struct {
-		SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
-		EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
-		AZCount          *int  `json:"azCount,omitempty"`
-	}{EnableNATGateway: enable}
-	return c
+	return cfgWithAWSVPC(nil, enable, nil)
 }
 
 // TestValidateAWSVPCNATConsistency pins every branch of the #389 validator.
@@ -82,13 +76,17 @@ func TestValidateAWSVPCNATConsistency(t *testing.T) {
 				require.Empty(t, got, "expected no issues, got %#v", got)
 				return
 			}
+			// require gates the indexing into got[0]; the per-field checks
+			// below are the assertions under test and use assert so a
+			// single mismatch surfaces every other field-level discrepancy
+			// in one run (per golang-guidance §13).
 			require.Len(t, got, 1, "expected exactly one issue")
-			require.Equal(t, "aws_vpc_stale_nat_gateway", got[0].Code)
-			require.Equal(t, "cfg.aws_vpc.enable_nat_gateway", got[0].Field)
-			require.Equal(t, "true", got[0].Value)
-			require.NotEmpty(t, got[0].Reason)
-			require.NotEmpty(t, got[0].Suggestion)
-			require.Contains(t, got[0].Reason, "#389", "reason should reference the issue so downstream callers can find context")
+			assert.Equal(t, "aws_vpc_stale_nat_gateway", got[0].Code)
+			assert.Equal(t, "cfg.aws_vpc.enable_nat_gateway", got[0].Field)
+			assert.Equal(t, "true", got[0].Value)
+			assert.NotEmpty(t, got[0].Reason)
+			assert.NotEmpty(t, got[0].Suggestion)
+			assert.Contains(t, got[0].Reason, "#389", "reason should reference the issue so downstream callers can find context")
 		})
 	}
 }
@@ -172,6 +170,64 @@ func TestComposeStackWithIssues_AWSVPCStaleNATGateway_Issue389(t *testing.T) {
 			"error should name the failing field so callers can route on it; got: %v", err)
 		assert.Contains(t, err.Error(), "#389",
 			"error should carry the issue reference; got: %v", err)
+	})
+}
+
+// findIssue returns the first issue with the given code, or nil. Used to
+// keep the cloud-resolution subtests below readable without growing a full
+// suite-level helper.
+func findIssue(issues []ValidationIssue, code string) *ValidationIssue {
+	for i := range issues {
+		if issues[i].Code == code {
+			return &issues[i]
+		}
+	}
+	return nil
+}
+
+// TestValidateAll_AWSVPCStaleNATGateway_CloudResolution locks in BOTH halves
+// of the cloud-resolution contract that ValidateAll uses to gate the AWS-VPC
+// cross-field check:
+//
+//  1. No-opts fallback (the original gap): dry-run callers (per
+//     ValidateAll's docstring) pass no ComposeStackOpts; the validator
+//     must still run when Comps.Cloud carries the cloud identity.
+//  2. Explicit-opts precedence: when both opts.Cloud and Comps.Cloud are
+//     present, opts.Cloud wins. Mirrors ValidateOpts's behaviour
+//     (validate_gcp_project.go:30-32); a regression that read Comps.Cloud
+//     unconditionally would slip past test 1 alone.
+func TestValidateAll_AWSVPCStaleNATGateway_CloudResolution(t *testing.T) {
+	t.Parallel()
+	boolPtr := func(v bool) *bool { return &v }
+
+	t.Run("no opts: fallback to Comps.Cloud (AWS-shaped bug fires)", func(t *testing.T) {
+		t.Parallel()
+		comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC"}
+		cfg := awsVPCNATCfg(boolPtr(true))
+
+		issues := ValidateAll(comps, cfg, nil, nil, nil, nil)
+
+		got := findIssue(issues, "aws_vpc_stale_nat_gateway")
+		require.NotNil(t, got, "ValidateAll(no opts) must emit aws_vpc_stale_nat_gateway when Comps.Cloud=AWS; got: %#v", issues)
+		assert.Equal(t, "cfg.aws_vpc.enable_nat_gateway", got.Field)
+	})
+
+	t.Run("explicit opts.Cloud=gcp wins over Comps.Cloud=AWS (no AWS issue emitted)", func(t *testing.T) {
+		t.Parallel()
+		// Mismatch case: opts.Cloud must override Comps.Cloud. The
+		// composer's chat-preview path can deliberately pass an opts.Cloud
+		// that differs from leftover Comps.Cloud (see ValidateOpts test
+		// TestValidateOpts/"opts.Cloud=aws is a no-op even when
+		// Comps.Cloud=GCP" at validate_gcp_project_test.go:81-92). A
+		// regression that read Comps.Cloud unconditionally for the AWS
+		// check would emit a spurious aws_vpc_stale_nat_gateway here.
+		comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC"}
+		cfg := awsVPCNATCfg(boolPtr(true))
+
+		issues := ValidateAll(comps, cfg, nil, nil, nil, nil, ComposeStackOpts{Cloud: "gcp"})
+
+		got := findIssue(issues, "aws_vpc_stale_nat_gateway")
+		assert.Nil(t, got, "explicit opts.Cloud=gcp must suppress the AWS-side check even when Comps.Cloud=AWS; got: %#v", issues)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Composer's KeyAWSVPC mapper produced \`enable_private_subnets=false\` + \`enable_nat_gateway=true\` when a Public-VPC stack had stale \`cfg.aws_vpc.enableNatGateway=true\` left over after the user removed a private-subnet-needing component (#389 repro: OpenSearch was on, then removed). The upstream \`terraform-aws-modules/vpc/aws\` then planned \`aws_route.private_nat_gateway\` against an empty \`aws_route_table.private\` and apply failed at \`element()\`.
- Multi-layer static-time defense so the same class of cross-field invariant bug can't reach apply time again:
  - **L1a — mapper coerces** \`enable_nat_gateway=false\` whenever \`enable_private_subnets=false\` (\`pkg/composer/mapper.go\`).
  - **L1b — composer emits** \`aws_vpc_stale_nat_gateway\` \`ValidationIssue\` so the upstream caller (reliable / LLM) sees the stale field; \`StrictValidate=true\` escalates (\`pkg/composer/validate_aws_vpc.go\`).
  - **L2 — preset \`precondition\`** on \`output "vpc_id"\` in \`aws/vpc/outputs.tf\` fails \`terraform plan\` for any consumer emitting the inconsistent pair.
  - **L3 — AWS compose-and-\`terraform validate\` CI gate** (\`TestComposeStack_AWS_PublicVPC_TerraformValidate\`) plus a Layer 2 plan-time gate (\`TestAWSVPCPresetPrecondition_RejectsBadPair\`) closes the AWS-side parity gap with the existing GCP \`terraform validate\` gate (#178 closure).

## Test plan
- [x] \`go test -count=1 -short ./pkg/composer/\` — 1159 pass
- [x] \`CI=true go test -count=1 -run 'TestAWSVPCPresetPrecondition_RejectsBadPair|TestComposeStack_AWS_PublicVPC_TerraformValidate|TestValidateAWSVPCNATConsistency|TestValidateAll_AWSVPCStaleNATGateway_CloudResolution|TestComposeStackWithIssues_AWSVPCStaleNATGateway_Issue389|TestBuildModuleValues_VPC_AWSVPCConfig$' ./pkg/composer/\` — all pass (239s, terraform-heavy)
- [x] \`go test -count=1 -short ./...\` — 4252 pass across 26 packages
- [x] \`terraform fmt -check -recursive aws/ gcp/\` — clean
- [x] All 9 \`tests/lint-*.sh\` — pass
- [x] Standalone \`terraform plan\` on \`aws/vpc\` with bad-pair vars fires the precondition; with valid vars plan proceeds (verified manually + automated via the new \`TestAWSVPCPresetPrecondition_RejectsBadPair\`)
- [x] Mutation check: with L1a removed, the new Layer 2 plan test correctly fails ("expected output precondition to fail plan for the bad-pair vars"); with the precondition removed, ditto — both gates have proven mutation sensitivity.

## Review notes
- \`/review\` findings: P0/P1 none; two P2s resolved (\`ValidateAll\` no-opts gap; \`require\` overuse in subtests); P3s skipped (helper consolidation done as drive-by; long comment kept — load-bearing for the non-obvious cross-module invariant)
- qa-professor findings: MAJOR (cloud-precedence pinning) addressed via dual no-opts/explicit-opts subtests; MINOR (negative-grep theater) addressed by replacing fake \`terraform validate\` assertions with a real plan-time precondition test; MINOR (helper duplication) consolidated onto \`cfgWithAWSVPC\`. Mutation sensitivity of the Layer 2 test verified by deleting the precondition and watching the test fail.

## Deferred follow-ups
- Generalised cross-field invariants validator registry in \`ValidateAll\` — out of scope; the current three layers + CI gate close #389 and the class-of-bugs at independent gates. Open a follow-up issue if a second invariant of this shape appears.
- The upstream \`reliable\` cleanup (clearing stale \`config.aws_vpc.enableNatGateway\` when consumers change) — different repo, different bug class; the mapper coercion + \`ValidationIssue\` give that path everything it needs.

Closes #389