### PR TITLE
feat(gcpdiscover): SDK-based attribute enrichment for google_storage_bucket (#403)

### DIFF
--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -1,0 +1,158 @@
+package gcpdiscover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	storagev1 "google.golang.org/api/storage/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// enrichServiceSlug is the progress-event service slug for the SDK
+// attribute-enrichment phase. Distinct from the CAI / non-CAI slugs so
+// progress consumers can attribute events correctly when EnrichAttributes
+// runs interleaved with or after DiscoverTypes.
+const enrichServiceSlug = "gcp_sdk_enrich"
+
+// AttributeEnricher is the per-resource-type contract for populating
+// `imported.ImportedResource.Attrs` (the typed Layer 1 payload) from a
+// cloud-side SDK Get/Describe call. Sibling interface to Discoverer:
+// Discoverers produce Identity-only records via Cloud Asset Inventory
+// (one CAI fanout per project), and AttributeEnrichers later turn each
+// into a fully-populated record by calling the resource type's own
+// SDK API and writing the result into ir.Attrs.
+//
+// Why this exists: Stage 2b's `terraform plan -generate-config-out`
+// path needs a `terraform` binary in $PATH and several round-trips per
+// resource. UI/SaaS consumers (e.g. a Vercel handler — see
+// luthersystems/reliable#1346) can't shell out to terraform under
+// their runtime constraints; this is the terraform-binary-free path
+// that produces decision-#34-clean HCL via composer.EmitImportedTF.
+//
+// Why ir.Attrs not ir.Attributes: composer.EmitImportedTF's opaque
+// `Attributes` path (pkg/composer/imported_emit.go:236) routes
+// `map[string]any` through cty.ObjectVal, which emits an HCL `{ ... }`
+// literal — never a sub-block. For resources whose configurable
+// surface is dominated by nested blocks (storage_bucket has 12 such
+// blocks: versioning, lifecycle_rule, cors, encryption, ...) the
+// opaque path can't reach decision #34. The typed `Attrs` path
+// (imported_emit.go:218-228) calls generated.MarshalHCL which DOES
+// emit nested blocks correctly, so enrichers populate that.
+//
+// Per-type enrichers map their cloud SDK response struct into the
+// matching pkg/composer/imported/generated.Google<Type> typed model
+// and JSON-marshal it into ir.Attrs. Per decision #5 (managed-
+// resource-tiers.md "Composer emission rule") computed-only fields
+// are not populated; per decision #36 sensitive fields follow the
+// downstream redaction policy (the enricher writes the value, the
+// emit/persist layers redact at write time — Phase-1 storage_bucket
+// has no Sensitive fields anyway).
+type AttributeEnricher interface {
+	// ResourceType returns the Terraform type this enricher covers,
+	// e.g. "google_storage_bucket". Must match the registered
+	// Discoverer of the same type.
+	ResourceType() string
+
+	// Enrich fetches live cloud-side state for ir (whose Identity is
+	// already populated by the corresponding Discoverer) and writes
+	// the typed payload into ir.Attrs. The enricher must not touch
+	// ir.Identity. clients carries the SDK clients the enricher
+	// needs; a nil required client is reported as ErrEnrichClientUnavailable
+	// so callers can distinguish "not configured" from "real API
+	// error".
+	Enrich(ctx context.Context, ir *imported.ImportedResource, clients EnrichClients) error
+}
+
+// EnrichClients bundles the cloud SDK clients per-type enrichers
+// dispatch to. Construct once per discover run (the lifecycle is
+// owned by the caller — close the underlying clients when done).
+// A nil field is tolerated: enrichers whose required client is nil
+// return ErrEnrichClientUnavailable, which EnrichAttributes
+// surfaces as a per-resource progress.ServiceWarn rather than
+// failing the whole batch. ProjectID is the real GCP project ID
+// (the same value passed to NewGCPDiscoverer), threaded through
+// for enrichers whose cloud SDK doesn't return a project-ID-as-
+// string field — google.golang.org/api/storage/v1.Bucket reports
+// only ProjectNumber (uint64), so the enricher pulls the string
+// project ID from here to populate the TF `project` attribute.
+type EnrichClients struct {
+	Storage   *storagev1.Service
+	ProjectID string
+}
+
+// ErrEnrichClientUnavailable signals that the SDK client an enricher
+// needs is nil on EnrichClients. Distinguishable from a real API
+// error so EnrichAttributes can downgrade it to a per-resource warning
+// (the type is silently un-enriched in the output) instead of a batch-
+// fatal error. Mirrors the existing nonCAIDiscovererHasLister warn
+// path in DiscoverTypes (gcpdiscover.go:430).
+var ErrEnrichClientUnavailable = errors.New("enrich: required SDK client unavailable on EnrichClients")
+
+// EnrichAttributes populates ir.Attrs in place for every imported
+// resource whose Identity.Type has a registered enricher. Resources
+// of types without a registered enricher are left untouched; the
+// caller can detect this via len(ir.Attrs) == 0 on return.
+//
+// Errors are accumulated per-resource and surfaced together at the
+// end so a single mid-batch failure doesn't lose results from earlier
+// successful enrichments — a partial result is more useful than no
+// result. ErrEnrichClientUnavailable failures are downgraded to
+// progress.ServiceWarn events (and not included in the returned
+// error) since they reflect caller-side configuration, not API
+// failures. The returned error wraps the joined per-resource errors;
+// callers may inspect via errors.Is / errors.As.
+//
+// emitter receives ItemFound per successfully enriched resource and
+// ServiceWarn per ErrEnrichClientUnavailable. The standard
+// (ServiceStart, ServiceFinish) pair brackets the whole batch under
+// enrichServiceSlug.
+func (g *GCPDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.ImportedResource, clients EnrichClients, emitter progress.Emitter) error {
+	if emitter == nil {
+		emitter = progress.NopEmitter{}
+	}
+	stageStart := time.Now()
+	emitter.ServiceStart(enrichServiceSlug, "")
+	defer func() { emitter.ServiceFinish(enrichServiceSlug, "", len(irs), time.Since(stageStart)) }()
+
+	// Dispatch in deterministic order so progress events and any
+	// emitted warnings are stable across runs.
+	idx := make([]int, 0, len(irs))
+	for i := range irs {
+		if _, ok := g.byTypeEnricher[irs[i].Identity.Type]; ok {
+			idx = append(idx, i)
+		}
+	}
+	sort.SliceStable(idx, func(a, b int) bool {
+		ia, ib := idx[a], idx[b]
+		if irs[ia].Identity.Type != irs[ib].Identity.Type {
+			return irs[ia].Identity.Type < irs[ib].Identity.Type
+		}
+		return irs[ia].Identity.Address < irs[ib].Identity.Address
+	})
+
+	var errs []error
+	for _, i := range idx {
+		enr := g.byTypeEnricher[irs[i].Identity.Type]
+		err := enr.Enrich(ctx, &irs[i], clients)
+		switch {
+		case err == nil:
+			emitter.ItemFound(enrichServiceSlug, irs[i].Identity.Location, irs[i].Identity.Type, irs[i].Identity.ImportID)
+		case errors.Is(err, ErrEnrichClientUnavailable):
+			// Client-side configuration failure — surface as a
+			// warn but don't accumulate as an error. Mirrors the
+			// nonCAIDiscovererHasLister warn semantics.
+			emitter.ServiceWarn(enrichServiceSlug, "", fmt.Sprintf("%s/%s: %v", irs[i].Identity.Type, irs[i].Identity.Address, err))
+		default:
+			errs = append(errs, fmt.Errorf("enrich %s/%s: %w", irs[i].Identity.Type, irs[i].Identity.Address, err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}

--- a/cmd/insideout-import/gcpdiscover/enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/enrich_test.go
@@ -1,0 +1,149 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	storagev1 "google.golang.org/api/storage/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// fakeEnricher is a minimal AttributeEnricher that records its calls
+// and returns a configurable result. Used to exercise EnrichAttributes
+// dispatch / ordering / error-accumulation semantics without standing
+// up real SDK clients.
+type fakeEnricher struct {
+	tfType string
+	calls  []string                               // bucket-of-Identity.ImportID per call
+	result func(*imported.ImportedResource) error // per-call result
+}
+
+func (f *fakeEnricher) ResourceType() string { return f.tfType }
+func (f *fakeEnricher) Enrich(_ context.Context, ir *imported.ImportedResource, _ EnrichClients) error {
+	f.calls = append(f.calls, ir.Identity.ImportID)
+	if f.result == nil {
+		ir.Attrs = json.RawMessage(`{}`)
+		return nil
+	}
+	return f.result(ir)
+}
+
+func TestEnrichAttributes_SkipsUnregisteredTypes(t *testing.T) {
+	t.Parallel()
+	g := &GCPDiscoverer{
+		byTypeEnricher: map[string]AttributeEnricher{
+			"google_storage_bucket": &fakeEnricher{tfType: "google_storage_bucket"},
+		},
+	}
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "google_pubsub_topic", ImportID: "t1", Address: "google_pubsub_topic.t1"}},
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "b1", Address: "google_storage_bucket.b1"}},
+	}
+	require.NoError(t, g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, nil))
+
+	// Only the storage_bucket got enriched.
+	assert.Empty(t, irs[0].Attrs, "google_pubsub_topic has no enricher; Attrs must remain empty")
+	assert.NotEmpty(t, irs[1].Attrs, "google_storage_bucket Attrs must be populated")
+}
+
+func TestEnrichAttributes_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+	enr := &fakeEnricher{tfType: "google_storage_bucket"}
+	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"google_storage_bucket": enr}}
+
+	// Intentionally out-of-order Addresses; aggregator must sort
+	// (type, address) so progress events are stable across runs.
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "z", Address: "google_storage_bucket.z"}},
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "a", Address: "google_storage_bucket.a"}},
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "m", Address: "google_storage_bucket.m"}},
+	}
+	require.NoError(t, g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, nil))
+	assert.Equal(t, []string{"a", "m", "z"}, enr.calls,
+		"enrich must dispatch in sorted (type, address) order regardless of input order")
+}
+
+func TestEnrichAttributes_AccumulatesErrors(t *testing.T) {
+	t.Parallel()
+	failBoth := &fakeEnricher{
+		tfType: "google_storage_bucket",
+		result: func(ir *imported.ImportedResource) error {
+			return errors.New("403: " + ir.Identity.ImportID)
+		},
+	}
+	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"google_storage_bucket": failBoth}}
+
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "a", Address: "google_storage_bucket.a"}},
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "b", Address: "google_storage_bucket.b"}},
+	}
+	err := g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, nil)
+	require.Error(t, err)
+	// Both per-resource errors must be present in the joined error so
+	// the operator sees every failure in one shot rather than playing
+	// whack-a-mole.
+	assert.Contains(t, err.Error(), "a")
+	assert.Contains(t, err.Error(), "b")
+}
+
+func TestEnrichAttributes_DowngradesClientUnavailable(t *testing.T) {
+	t.Parallel()
+	enr := &fakeEnricher{
+		tfType: "google_storage_bucket",
+		result: func(ir *imported.ImportedResource) error {
+			return ErrEnrichClientUnavailable
+		},
+	}
+	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"google_storage_bucket": enr}}
+
+	rec := &recordingEmitter{}
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "b1", Address: "google_storage_bucket.b1"}},
+	}
+	err := g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: nil}, rec)
+	require.NoError(t, err, "ErrEnrichClientUnavailable must downgrade to a warn, not a returned error")
+	warns := filterEvents(rec.snapshot(), "service_warn")
+	require.Len(t, warns, 1, "exactly one ServiceWarn must be emitted for the unavailable client")
+	assert.Contains(t, warns[0].Message, "google_storage_bucket")
+	assert.Contains(t, warns[0].Message, "client unavailable")
+}
+
+func TestEnrichAttributes_EmitsItemFoundOnSuccess(t *testing.T) {
+	t.Parallel()
+	enr := &fakeEnricher{tfType: "google_storage_bucket"}
+	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"google_storage_bucket": enr}}
+
+	rec := &recordingEmitter{}
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "b1", Address: "google_storage_bucket.b1", Location: "us"}},
+	}
+	require.NoError(t, g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, rec))
+	events := rec.snapshot()
+	items := filterEvents(events, "item_found")
+	require.Len(t, items, 1)
+	assert.Equal(t, "b1", items[0].ImportID)
+	assert.Equal(t, "google_storage_bucket", items[0].TFType)
+	assert.Equal(t, 1, len(filterEvents(events, "service_finish")),
+		"ServiceFinish must fire once per call, regardless of per-item outcomes")
+	assert.Equal(t, 1, len(filterEvents(events, "service_start")),
+		"ServiceStart must fire exactly once per call")
+}
+
+// filterEvents returns the subset of recorded events whose Kind matches
+// kind. Tiny helper kept local to enrich_test.go since it is only used
+// by the EnrichAttributes assertions and the existing testhelpers
+// recordingEmitter does not export a per-kind accessor.
+func filterEvents(events []recordedEvent, kind string) []recordedEvent {
+	out := make([]recordedEvent, 0, len(events))
+	for _, e := range events {
+		if e.Kind == kind {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -220,7 +220,8 @@ type GCPDiscoverer struct {
 	searcher  gcpAssetSearcher
 	projectID string
 
-	byType map[string]Discoverer // keyed on Terraform type
+	byType         map[string]Discoverer        // keyed on Terraform type
+	byTypeEnricher map[string]AttributeEnricher // keyed on Terraform type; populated for types with an SDK enricher (#403)
 }
 
 // GCPDiscovererOpts bundles the non-CAI per-service listers injected
@@ -287,6 +288,16 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string, opts GCPDisco
 			"google_logging_project_sink":     newLoggingProjectSinkDiscoverer(opts.SinkLister),
 			"google_sql_user":                 newSQLUserDiscoverer(opts.SQLUserLister),
 			"google_identity_platform_config": newIdentityPlatformConfigDiscoverer(opts.IdentityPlatformLister),
+		},
+		// Per-type SDK attribute enrichers (#403). Each entry is a sibling
+		// to the byType discoverer of the same name and populates ir.Attrs
+		// (the typed Layer 1 payload) so callers can produce decision-#34-
+		// clean HCL via composer.EmitImportedTF without needing the
+		// terraform-driven Stage 2b path. Types without an entry here are
+		// silently skipped by EnrichAttributes — the full enricher rollout
+		// follows the existing per-type ordering one PR at a time.
+		byTypeEnricher: map[string]AttributeEnricher{
+			"google_storage_bucket": newStorageBucketEnricher(),
 		},
 	}
 }

--- a/cmd/insideout-import/gcpdiscover/storage_bucket_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/storage_bucket_enrich.go
@@ -1,0 +1,380 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	storagev1 "google.golang.org/api/storage/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// storageBucketEnricher implements AttributeEnricher for
+// google_storage_bucket. Pairs with storageBucketDiscoverer (Identity)
+// — same package convention as the per-type Discoverer files.
+//
+// Mapping target: pkg/composer/imported/generated.GoogleStorageBucket
+// (the Layer 1 typed model). SDK source:
+// google.golang.org/api/storage/v1.Bucket — the raw JSON API client,
+// matching what terraform-provider-google itself uses internally
+// (vs. the higher-level cloud.google.com/go/storage SDK which strips
+// fields like ip_filter and returns time.Duration values that don't
+// match the TF int64-seconds shape). See PR/issue discussion on #403
+// for the full rationale.
+//
+// Configurable fields populated (decision #5: Optional || Required,
+// also Optional+Computed where the existing golden fixture at
+// pkg/composer/imported/generated/testdata/fixtures/google_storage_bucket.tf
+// pins the looser Configurable() gate emit_imported uses):
+//
+//   - name, location, storage_class, project, labels
+//   - default_event_based_hold, requester_pays, force_destroy
+//   - enable_object_retention, public_access_prevention, rpo
+//   - uniform_bucket_level_access (flattened from
+//     iamConfiguration.uniformBucketLevelAccess.enabled)
+//   - versioning { enabled }
+//   - encryption { default_kms_key_name }
+//   - logging { log_bucket, log_object_prefix }
+//   - cors[] { origin, method, response_header, max_age_seconds }
+//   - lifecycle_rule[] { action { type, storage_class }, condition {...} }
+//   - retention_policy { is_locked, retention_period }
+//   - soft_delete_policy { retention_duration_seconds }
+//   - autoclass { enabled, terminal_storage_class }
+//   - custom_placement_config { data_locations }
+//   - hierarchical_namespace { enabled }
+//   - website { main_page_suffix, not_found_page }
+//
+// Computed-only fields not populated (decision #5): effective_labels,
+// project_number, self_link, terraform_labels, url, id.
+//
+// Known Phase-1 limitations (tracked for follow-up):
+//   - ip_filter: present on the raw JSON API as Bucket.IpFilter but
+//     absent from the Layer 1 generated.GoogleStorageBucket struct
+//     (preview feature; the Layer 1 codegen pre-dates it). Re-running
+//     cmd/imported-codegen against a newer provider schema will pick
+//     it up; this enricher then only needs the mapper added. Until
+//     then the field is silently dropped on enrichment — buckets
+//     using ip_filter will see a `~` change for it on first plan
+//     until the codegen catches up.
+//   - acl / default_object_acl: deprecated in favor of
+//     uniform_bucket_level_access; absent from the Layer 1 struct;
+//     not populated.
+//
+// Sensitive fields: none on this resource (verified against
+// GoogleStorageBucketSchema). Decision #36 redaction is downstream's
+// concern.
+type storageBucketEnricher struct {
+	// fetch is overridable for tests. Defaults to a real Buckets.Get
+	// call against the storagev1.Service in EnrichClients. Tests
+	// inject a fake by constructing the enricher via
+	// newStorageBucketEnricherWithFetch — keeps the enricher
+	// hermetically testable without spinning up a fake HTTP server
+	// for the storage client.
+	fetch func(ctx context.Context, svc *storagev1.Service, bucketName string) (*storagev1.Bucket, error)
+}
+
+func newStorageBucketEnricher() AttributeEnricher {
+	return &storageBucketEnricher{fetch: defaultStorageBucketFetch}
+}
+
+func (storageBucketEnricher) ResourceType() string { return storageBucketTFType }
+
+// Enrich populates ir.Attrs with a typed GoogleStorageBucket payload
+// for the bucket identified by ir.Identity. Returns
+// ErrEnrichClientUnavailable if EnrichClients.Storage is nil; any
+// other error reflects a real GCS API failure.
+func (e storageBucketEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if c.Storage == nil {
+		return ErrEnrichClientUnavailable
+	}
+	name := bucketNameForEnrich(ir)
+	if name == "" {
+		return fmt.Errorf("storage_bucket: cannot derive bucket name from Identity (Address=%q ImportID=%q NativeIDs.asset_name=%q)",
+			ir.Identity.Address, ir.Identity.ImportID, ir.Identity.NativeIDs["asset_name"])
+	}
+	b, err := e.fetch(ctx, c.Storage, name)
+	if err != nil {
+		return fmt.Errorf("storage_bucket: get %q: %w", name, err)
+	}
+	typed := mapStorageBucket(b, c.ProjectID)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return fmt.Errorf("storage_bucket: marshal Attrs: %w", err)
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// bucketNameForEnrich pulls the bucket name from the identifiers
+// FromAsset / DiscoverByID populate. Bucket names are globally unique
+// in GCS so the import-ID slot is the bare name; we prefer that for
+// its unconditional shape, and fall back to parsing the asset_name
+// (//storage.googleapis.com/<name>) for safety against future shape
+// drift.
+func bucketNameForEnrich(ir *imported.ImportedResource) string {
+	if ir.Identity.ImportID != "" {
+		return ir.Identity.ImportID
+	}
+	if asset := ir.Identity.NativeIDs["asset_name"]; asset != "" {
+		if name, err := storageBucketNameFromID(asset); err == nil {
+			return name
+		}
+	}
+	return ""
+}
+
+// defaultStorageBucketFetch is the production fetch path: a single
+// GCS Buckets.Get call, no projection or partial-response trimming
+// (the response is not large for typical buckets, and we'd risk
+// missing fields if the storage API adds them). Context cancellation
+// is honored via the standard tooling-API ctx wiring.
+func defaultStorageBucketFetch(ctx context.Context, svc *storagev1.Service, bucketName string) (*storagev1.Bucket, error) {
+	return svc.Buckets.Get(bucketName).Context(ctx).Do()
+}
+
+// mapStorageBucket builds the typed Layer 1 payload from the raw
+// GCS API response. Pure function — no I/O, no global state — so
+// unit tests can drive it with handcrafted *storagev1.Bucket
+// fixtures without going through the AttributeEnricher boundary.
+//
+// projectID is the real GCP project ID supplied by the caller (via
+// EnrichClients.ProjectID). The raw API only reports ProjectNumber
+// (uint64) and the TF `project` attribute is a string project ID,
+// so the enricher cannot derive it from the API response alone.
+func mapStorageBucket(b *storagev1.Bucket, projectID string) *generated.GoogleStorageBucket {
+	out := &generated.GoogleStorageBucket{
+		Name:     generated.LiteralOf(b.Name),
+		Location: generated.LiteralOf(strings.ToUpper(b.Location)),
+	}
+	if b.StorageClass != "" {
+		out.StorageClass = generated.LiteralOf(b.StorageClass)
+	}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if len(b.Labels) > 0 {
+		// Strip goog-managed labels (goog-* / goog_*) — these are
+		// system labels TF state does not track. terraform-provider-
+		// google filters them in flattenLabels via tpgresource;
+		// reproducing that here keeps decision-#34 safe for buckets
+		// that have system labels applied alongside user labels.
+		labels := map[string]*generated.Value[string]{}
+		for k, v := range b.Labels {
+			if strings.HasPrefix(k, "goog-") || strings.HasPrefix(k, "goog_") {
+				continue
+			}
+			labels[k] = generated.LiteralOf(v)
+		}
+		if len(labels) > 0 {
+			out.Labels = labels
+		}
+	}
+
+	// Default-false bools: emit explicitly so the typed payload
+	// carries an unambiguous value rather than relying on the HCL
+	// emitter omitting absent pointers (which is also fine, but
+	// explicit literals make round-trip equality easier to test
+	// against the golden fixture).
+	out.DefaultEventBasedHold = generated.LiteralOf(b.DefaultEventBasedHold)
+	out.RequesterPays = generated.LiteralOf(billingRequesterPays(b.Billing))
+	out.EnableObjectRetention = generated.LiteralOf(b.ObjectRetention != nil)
+	// force_destroy is a Terraform-only sentinel — the GCS API has no
+	// equivalent. Default false is safe; users who set true must do so
+	// post-import via an explicit edit (and re-emit).
+	out.ForceDestroy = generated.LiteralOf(false)
+
+	if b.Rpo != "" {
+		out.Rpo = generated.LiteralOf(b.Rpo)
+	}
+
+	// IAM configuration flattens into two TF top-level fields.
+	if b.IamConfiguration != nil {
+		if pap := b.IamConfiguration.PublicAccessPrevention; pap != "" {
+			out.PublicAccessPrevention = generated.LiteralOf(pap)
+		}
+		if ubla := b.IamConfiguration.UniformBucketLevelAccess; ubla != nil {
+			out.UniformBucketLevelAccess = generated.LiteralOf(ubla.Enabled)
+		}
+	}
+
+	if b.Versioning != nil {
+		out.Versioning = []generated.GoogleStorageBucketVersioning{{
+			Enabled: generated.LiteralOf(b.Versioning.Enabled),
+		}}
+	}
+	if b.Encryption != nil && b.Encryption.DefaultKmsKeyName != "" {
+		out.Encryption = []generated.GoogleStorageBucketEncryption{{
+			DefaultKMSKeyName: generated.LiteralOf(b.Encryption.DefaultKmsKeyName),
+		}}
+	}
+	if b.Logging != nil {
+		blk := generated.GoogleStorageBucketLogging{
+			LogBucket: generated.LiteralOf(b.Logging.LogBucket),
+		}
+		if b.Logging.LogObjectPrefix != "" {
+			blk.LogObjectPrefix = generated.LiteralOf(b.Logging.LogObjectPrefix)
+		}
+		out.Logging = []generated.GoogleStorageBucketLogging{blk}
+	}
+	if b.Website != nil && (b.Website.MainPageSuffix != "" || b.Website.NotFoundPage != "") {
+		blk := generated.GoogleStorageBucketWebsite{}
+		if b.Website.MainPageSuffix != "" {
+			blk.MainPageSuffix = generated.LiteralOf(b.Website.MainPageSuffix)
+		}
+		if b.Website.NotFoundPage != "" {
+			blk.NotFoundPage = generated.LiteralOf(b.Website.NotFoundPage)
+		}
+		out.Website = []generated.GoogleStorageBucketWebsite{blk}
+	}
+	if b.Autoclass != nil {
+		blk := generated.GoogleStorageBucketAutoclass{
+			Enabled: generated.LiteralOf(b.Autoclass.Enabled),
+		}
+		if b.Autoclass.TerminalStorageClass != "" {
+			blk.TerminalStorageClass = generated.LiteralOf(b.Autoclass.TerminalStorageClass)
+		}
+		out.Autoclass = []generated.GoogleStorageBucketAutoclass{blk}
+	}
+	if b.HierarchicalNamespace != nil {
+		out.HierarchicalNamespace = []generated.GoogleStorageBucketHierarchicalNamespace{{
+			Enabled: generated.LiteralOf(b.HierarchicalNamespace.Enabled),
+		}}
+	}
+	if b.CustomPlacementConfig != nil && len(b.CustomPlacementConfig.DataLocations) > 0 {
+		out.CustomPlacementConfig = []generated.GoogleStorageBucketCustomPlacementConfig{{
+			DataLocations: stringSliceToValues(b.CustomPlacementConfig.DataLocations),
+		}}
+	}
+	if b.RetentionPolicy != nil {
+		out.RetentionPolicy = []generated.GoogleStorageBucketRetentionPolicy{{
+			IsLocked:        generated.LiteralOf(b.RetentionPolicy.IsLocked),
+			RetentionPeriod: generated.LiteralOf(b.RetentionPolicy.RetentionPeriod),
+		}}
+	}
+	if b.SoftDeletePolicy != nil && b.SoftDeletePolicy.RetentionDurationSeconds > 0 {
+		out.SoftDeletePolicy = []generated.GoogleStorageBucketSoftDeletePolicy{{
+			RetentionDurationSeconds: generated.LiteralOf(b.SoftDeletePolicy.RetentionDurationSeconds),
+		}}
+	}
+
+	if len(b.Cors) > 0 {
+		blocks := make([]generated.GoogleStorageBucketCors, 0, len(b.Cors))
+		for _, c := range b.Cors {
+			if c == nil {
+				continue
+			}
+			blk := generated.GoogleStorageBucketCors{}
+			if c.MaxAgeSeconds != 0 {
+				blk.MaxAgeSeconds = generated.LiteralOf(c.MaxAgeSeconds)
+			}
+			if len(c.Method) > 0 {
+				blk.Method = stringSliceToValues(c.Method)
+			}
+			if len(c.Origin) > 0 {
+				blk.Origin = stringSliceToValues(c.Origin)
+			}
+			if len(c.ResponseHeader) > 0 {
+				blk.ResponseHeader = stringSliceToValues(c.ResponseHeader)
+			}
+			blocks = append(blocks, blk)
+		}
+		if len(blocks) > 0 {
+			out.Cors = blocks
+		}
+	}
+
+	if b.Lifecycle != nil && len(b.Lifecycle.Rule) > 0 {
+		blocks := make([]generated.GoogleStorageBucketLifecycleRule, 0, len(b.Lifecycle.Rule))
+		for _, r := range b.Lifecycle.Rule {
+			if r == nil {
+				continue
+			}
+			blocks = append(blocks, mapLifecycleRule(r))
+		}
+		if len(blocks) > 0 {
+			out.LifecycleRule = blocks
+		}
+	}
+	return out
+}
+
+func mapLifecycleRule(r *storagev1.BucketLifecycleRule) generated.GoogleStorageBucketLifecycleRule {
+	out := generated.GoogleStorageBucketLifecycleRule{}
+	if r.Action != nil {
+		act := generated.GoogleStorageBucketLifecycleRuleAction{}
+		if r.Action.Type != "" {
+			act.Type_ = generated.LiteralOf(r.Action.Type)
+		}
+		if r.Action.StorageClass != "" {
+			act.StorageClass = generated.LiteralOf(r.Action.StorageClass)
+		}
+		out.Action = []generated.GoogleStorageBucketLifecycleRuleAction{act}
+	}
+	if r.Condition != nil {
+		c := r.Condition
+		cond := generated.GoogleStorageBucketLifecycleRuleCondition{}
+		if c.Age != nil {
+			cond.Age = generated.LiteralOf(float64(*c.Age))
+		}
+		if c.CreatedBefore != "" {
+			cond.CreatedBefore = generated.LiteralOf(c.CreatedBefore)
+		}
+		if c.CustomTimeBefore != "" {
+			cond.CustomTimeBefore = generated.LiteralOf(c.CustomTimeBefore)
+		}
+		if c.DaysSinceCustomTime != 0 {
+			cond.DaysSinceCustomTime = generated.LiteralOf(float64(c.DaysSinceCustomTime))
+		}
+		if c.DaysSinceNoncurrentTime != 0 {
+			cond.DaysSinceNoncurrentTime = generated.LiteralOf(float64(c.DaysSinceNoncurrentTime))
+		}
+		if len(c.MatchesPrefix) > 0 {
+			cond.MatchesPrefix = stringSliceToValues(c.MatchesPrefix)
+		}
+		if len(c.MatchesStorageClass) > 0 {
+			cond.MatchesStorageClass = stringSliceToValues(c.MatchesStorageClass)
+		}
+		if len(c.MatchesSuffix) > 0 {
+			cond.MatchesSuffix = stringSliceToValues(c.MatchesSuffix)
+		}
+		if c.NoncurrentTimeBefore != "" {
+			cond.NoncurrentTimeBefore = generated.LiteralOf(c.NoncurrentTimeBefore)
+		}
+		if c.NumNewerVersions != 0 {
+			cond.NumNewerVersions = generated.LiteralOf(float64(c.NumNewerVersions))
+		}
+		// IsLive maps to with_state per the TF provider's convention:
+		// nil → "ANY", true → "LIVE", false → "ARCHIVED" (terraform-
+		// provider-google/google/services/storage/resource_storage_bucket.go).
+		if c.IsLive != nil {
+			cond.WithState = generated.LiteralOf(map[bool]string{true: "LIVE", false: "ARCHIVED"}[*c.IsLive])
+		}
+		// send_*_if_zero sentinels are TF-only (no API equivalent).
+		// Not populated; defaults match the API's behavior of treating
+		// zero as unset — emitting absent here matches what the
+		// provider does at -generate-config-out time.
+		out.Condition = []generated.GoogleStorageBucketLifecycleRuleCondition{cond}
+	}
+	return out
+}
+
+func billingRequesterPays(b *storagev1.BucketBilling) bool {
+	if b == nil {
+		return false
+	}
+	return b.RequesterPays
+}
+
+func stringSliceToValues(in []string) []*generated.Value[string] {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*generated.Value[string], len(in))
+	for i, s := range in {
+		out[i] = generated.LiteralOf(s)
+	}
+	return out
+}

--- a/cmd/insideout-import/gcpdiscover/storage_bucket_enrich_live_test.go
+++ b/cmd/insideout-import/gcpdiscover/storage_bucket_enrich_live_test.go
@@ -1,0 +1,142 @@
+//go:build integration
+
+// Live-smoke for the SDK attribute-enrichment path on a real GCS
+// bucket. Build-tag gated because it requires real GCP credentials,
+// a live bucket, and a terraform binary in $PATH; CI must NOT run
+// this on every PR.
+//
+// Run with:
+//
+//	go test -tags=integration ./cmd/insideout-import/gcpdiscover \
+//	    -run TestLive403_StorageBucketEnrichDecisionThirtyFour \
+//	    -enrich-bucket=<name> -enrich-project=<gcp-project-id>
+//
+// What it asserts: the decision-#34 first-import plan contract end-to-
+// end. Discovers the bucket via the existing storage_bucket discoverer
+// (Identity-only), calls the new EnrichAttributes path to populate
+// ir.Attrs from the live GCS API, runs the result through
+// composer.EmitImportedTF + provenance injection, then `terraform init`
+// + `terraform plan` and parses the plan output for "1 to import,
+// 0 to add, 0 to change, 0 to destroy" — the exact decision-#34
+// contract from docs/managed-resource-tiers.md.
+//
+// This is the test that pins "the SDK enrichment path is a viable
+// substitute for the terraform-driven Stage 2b flow." Without it,
+// regressions in the per-type mapper (e.g. a forgotten field, an
+// inverted bool) would only surface in production deploys.
+
+package gcpdiscover
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+	storagev1 "google.golang.org/api/storage/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+var (
+	enrichLiveBucket  = flag.String("enrich-bucket", "", "GCS bucket name to use for live enrichment smoke test")
+	enrichLiveProject = flag.String("enrich-project", "", "GCP project ID owning the bucket")
+)
+
+// TestLive403_StorageBucketEnrichDecisionThirtyFour proves the SDK
+// enrichment path produces decision-#34-clean HCL against a real
+// bucket. Skipped unless both -enrich-bucket and -enrich-project are
+// set so the test self-skips in CI rather than failing on missing
+// credentials.
+func TestLive403_StorageBucketEnrichDecisionThirtyFour(t *testing.T) {
+	if *enrichLiveBucket == "" || *enrichLiveProject == "" {
+		t.Skip("set -enrich-bucket and -enrich-project to run")
+	}
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skipf("terraform binary not in PATH: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	svc, err := storagev1.NewService(ctx, option.WithScopes(storagev1.DevstorageReadOnlyScope))
+	require.NoError(t, err, "construct storagev1.Service (check ADC / GOOGLE_APPLICATION_CREDENTIALS)")
+
+	enr := storageBucketEnricher{fetch: defaultStorageBucketFetch}
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:     "gcp",
+			Type:      storageBucketTFType,
+			Address:   fmt.Sprintf("%s.live", storageBucketTFType),
+			ImportID:  *enrichLiveBucket,
+			NameHint:  *enrichLiveBucket,
+			ProjectID: *enrichLiveProject,
+		},
+		Tier:   imported.TierImportedFlat,
+		Source: imported.SourceImporter,
+	}
+	require.NoError(t, enr.Enrich(ctx, &ir, EnrichClients{Storage: svc, ProjectID: *enrichLiveProject}),
+		"SDK enrichment must succeed against a real bucket")
+	require.NotEmpty(t, ir.Attrs, "Attrs must be populated by Enrich")
+
+	// Compose the workspace: provider + emitted resource + import block.
+	workdir := t.TempDir()
+	out, used := composer.EmitImportedTF("gcp", []imported.ImportedResource{ir}, composer.EmitImportedOpts{})
+	require.NotNil(t, out)
+	require.True(t, used["gcp"])
+
+	mainTF := []byte(fmt.Sprintf(`terraform {
+  required_providers {
+    google = { source = "hashicorp/google", version = "~> 5.0" }
+  }
+}
+
+provider "google" {
+  alias   = "imported"
+  project = %q
+}
+`, *enrichLiveProject))
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "main.tf"), mainTF, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "imported.tf"), out, 0o644))
+
+	runTF := func(args ...string) ([]byte, error) {
+		cmd := exec.CommandContext(ctx, "terraform", args...)
+		cmd.Dir = workdir
+		return cmd.CombinedOutput()
+	}
+	if b, err := runTF("init", "-input=false"); err != nil {
+		t.Fatalf("terraform init failed: %v\n%s", err, b)
+	}
+	planOut, err := runTF("plan", "-input=false", "-no-color")
+	if err != nil {
+		t.Fatalf("terraform plan failed: %v\n%s", err, planOut)
+	}
+	planText := string(planOut)
+	t.Logf("plan output:\n%s", planText)
+
+	// Decision #34: "N to import, 0 to add, 0 to destroy, plus in-place
+	// additions/repairs of InsideOut provenance tags / labels". For
+	// our single-resource smoke we want exactly 1 to import and 0
+	// other infrastructure changes; the only allowed in-place change
+	// is the provenance label addition from EmitImportedOpts (left
+	// off the test for now — adding it once #403 follow-up wires
+	// EmitImportedOpts.Provenance into this test).
+	require.Contains(t, planText, "1 to import",
+		"decision #34 violation: expected 1 import in plan; got:\n%s", planText)
+	for _, banned := range []string{
+		" to add",     // "N to add" with N>0 lacks our specific phrasing
+		" to destroy", // same
+	} {
+		// Allow the literal "0 to add" / "0 to destroy".
+		require.Falsef(t,
+			strings.Contains(planText, "1 to add") || strings.Contains(planText, "2 to add"),
+			"decision #34 violation: %q forbidden adds in plan:\n%s", banned, planText)
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/storage_bucket_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/storage_bucket_enrich_test.go
@@ -1,0 +1,548 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	storagev1 "google.golang.org/api/storage/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// TestMapStorageBucket_Minimal pins the smallest non-trivial mapping:
+// a bucket with only the API-required fields populated (name, location,
+// storageClass) plus the always-emitted defaults (force_destroy,
+// default_event_based_hold, requester_pays, enable_object_retention).
+// The location must be uppercased — Terraform state holds GCS
+// locations in uppercase regardless of the API's casing — and the
+// project must come from the projectID argument since the API only
+// returns ProjectNumber (uint64).
+func TestMapStorageBucket_Minimal(t *testing.T) {
+	t.Parallel()
+	src := &storagev1.Bucket{
+		Name:          "io-test-assets",
+		Location:      "us",
+		StorageClass:  "STANDARD",
+		ProjectNumber: 12345, // intentionally ignored — TF needs the string project ID
+	}
+	got := mapStorageBucket(src, "my-real-project")
+
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "io-test-assets", *got.Name.Literal)
+	require.NotNil(t, got.Location)
+	assert.Equal(t, "US", *got.Location.Literal, "location must be uppercased to match TF state shape")
+	require.NotNil(t, got.StorageClass)
+	assert.Equal(t, "STANDARD", *got.StorageClass.Literal)
+	require.NotNil(t, got.Project)
+	assert.Equal(t, "my-real-project", *got.Project.Literal)
+	require.NotNil(t, got.ForceDestroy)
+	assert.False(t, *got.ForceDestroy.Literal, "force_destroy is a TF-only sentinel; default false")
+	require.NotNil(t, got.DefaultEventBasedHold)
+	assert.False(t, *got.DefaultEventBasedHold.Literal)
+	require.NotNil(t, got.RequesterPays)
+	assert.False(t, *got.RequesterPays.Literal, "billing.requesterPays is nil → false")
+	require.NotNil(t, got.EnableObjectRetention)
+	assert.False(t, *got.EnableObjectRetention.Literal, "objectRetention is nil → false")
+
+	// Computed-only fields must not be populated (decision #5).
+	assert.Nil(t, got.ID, "id is computed-only")
+	assert.Nil(t, got.SelfLink, "self_link is computed-only")
+	assert.Nil(t, got.URL, "url is computed-only")
+	assert.Nil(t, got.ProjectNumber, "project_number is computed-only")
+	assert.Nil(t, got.EffectiveLabels, "effective_labels is computed-only")
+	assert.Nil(t, got.TerraformLabels, "terraform_labels is computed-only")
+}
+
+// TestMapStorageBucket_LabelsStripGoogManaged verifies the goog-* /
+// goog_* label filter. terraform-provider-google strips system labels
+// in flattenLabels; reproducing that here keeps decision-#34 safe for
+// buckets with both user labels and system labels.
+func TestMapStorageBucket_LabelsStripGoogManaged(t *testing.T) {
+	t.Parallel()
+	src := &storagev1.Bucket{
+		Name:     "b",
+		Location: "US",
+		Labels: map[string]string{
+			"environment":      "staging",
+			"goog-managed":     "true",
+			"goog_other_thing": "x",
+			"team":             "platform",
+		},
+	}
+	got := mapStorageBucket(src, "")
+
+	require.NotNil(t, got.Labels)
+	assert.Len(t, got.Labels, 2, "goog-/goog_ system labels must be filtered")
+	require.Contains(t, got.Labels, "environment")
+	assert.Equal(t, "staging", *got.Labels["environment"].Literal)
+	require.Contains(t, got.Labels, "team")
+	assert.Equal(t, "platform", *got.Labels["team"].Literal)
+	assert.NotContains(t, got.Labels, "goog-managed")
+	assert.NotContains(t, got.Labels, "goog_other_thing")
+}
+
+// TestMapStorageBucket_LabelsAllSystemFiltered pins that an all-
+// system-label bucket produces a nil Labels map (not an empty one),
+// so the typed emitter omits the labels = {} block entirely. An
+// empty `labels = {}` would diff against the bucket's actual state
+// (no user labels) and break decision-#34.
+func TestMapStorageBucket_LabelsAllSystemFiltered(t *testing.T) {
+	t.Parallel()
+	src := &storagev1.Bucket{
+		Name:     "b",
+		Location: "US",
+		Labels: map[string]string{
+			"goog-managed-by": "iam",
+		},
+	}
+	got := mapStorageBucket(src, "")
+	assert.Nil(t, got.Labels, "all-system-label input must produce nil Labels (not empty map)")
+}
+
+// TestMapStorageBucket_IamConfigurationFlatten verifies that the
+// raw API's nested iamConfiguration.uniformBucketLevelAccess.enabled
+// flattens to the TF top-level uniform_bucket_level_access bool, and
+// publicAccessPrevention to the TF top-level field of the same name.
+func TestMapStorageBucket_IamConfigurationFlatten(t *testing.T) {
+	t.Parallel()
+	src := &storagev1.Bucket{
+		Name:     "b",
+		Location: "US",
+		IamConfiguration: &storagev1.BucketIamConfiguration{
+			PublicAccessPrevention: "enforced",
+			UniformBucketLevelAccess: &storagev1.BucketIamConfigurationUniformBucketLevelAccess{
+				Enabled: true,
+			},
+		},
+	}
+	got := mapStorageBucket(src, "")
+
+	require.NotNil(t, got.UniformBucketLevelAccess)
+	assert.True(t, *got.UniformBucketLevelAccess.Literal)
+	require.NotNil(t, got.PublicAccessPrevention)
+	assert.Equal(t, "enforced", *got.PublicAccessPrevention.Literal)
+}
+
+// TestMapStorageBucket_NestedBlocksOmittedWhenAbsent pins that a
+// bucket with no versioning / encryption / lifecycle / etc. produces
+// empty / nil block slices on the typed model. The HCL emitter omits
+// blocks whose slice is empty, which is what decision #34 requires
+// (a `versioning {}` block emitted against a bucket without versioning
+// would diff).
+func TestMapStorageBucket_NestedBlocksOmittedWhenAbsent(t *testing.T) {
+	t.Parallel()
+	src := &storagev1.Bucket{Name: "b", Location: "US"}
+	got := mapStorageBucket(src, "")
+
+	assert.Empty(t, got.Versioning, "versioning block omitted when API field nil")
+	assert.Empty(t, got.Encryption)
+	assert.Empty(t, got.Logging)
+	assert.Empty(t, got.Website)
+	assert.Empty(t, got.Autoclass)
+	assert.Empty(t, got.HierarchicalNamespace)
+	assert.Empty(t, got.CustomPlacementConfig)
+	assert.Empty(t, got.RetentionPolicy)
+	assert.Empty(t, got.SoftDeletePolicy)
+	assert.Empty(t, got.Cors)
+	assert.Empty(t, got.LifecycleRule)
+}
+
+// TestMapStorageBucket_VersioningEnabled pins that a bucket with
+// versioning enabled produces a single versioning block carrying the
+// enabled value. Documents the decision to copy the API value verbatim
+// rather than only emitting when enabled=true (the provider tracks
+// explicit `enabled = false` distinctly from absent).
+func TestMapStorageBucket_VersioningEnabled(t *testing.T) {
+	t.Parallel()
+	src := &storagev1.Bucket{
+		Name:       "b",
+		Location:   "US",
+		Versioning: &storagev1.BucketVersioning{Enabled: true},
+	}
+	got := mapStorageBucket(src, "")
+
+	require.Len(t, got.Versioning, 1)
+	require.NotNil(t, got.Versioning[0].Enabled)
+	assert.True(t, *got.Versioning[0].Enabled.Literal)
+}
+
+// TestMapStorageBucket_LifecycleRuleFull exercises the most complex
+// nested-block path: a lifecycle rule with both action and condition,
+// all condition sub-fields populated, and the IsLive *bool tri-state
+// mapped to with_state. Critical because lifecycle rules are the
+// dominant configurable surface for non-trivial buckets and the
+// site of most provider/SDK shape mismatches.
+func TestMapStorageBucket_LifecycleRuleFull(t *testing.T) {
+	t.Parallel()
+	isLive := true
+	ageGT := int64(7)
+	src := &storagev1.Bucket{
+		Name:     "b",
+		Location: "US",
+		Lifecycle: &storagev1.BucketLifecycle{
+			Rule: []*storagev1.BucketLifecycleRule{
+				{
+					Action: &storagev1.BucketLifecycleRuleAction{
+						Type:         "SetStorageClass",
+						StorageClass: "NEARLINE",
+					},
+					Condition: &storagev1.BucketLifecycleRuleCondition{
+						Age:                     &ageGT,
+						CreatedBefore:           "2024-01-01",
+						CustomTimeBefore:        "2024-01-02",
+						DaysSinceCustomTime:     30,
+						DaysSinceNoncurrentTime: 60,
+						MatchesPrefix:           []string{"logs/", "tmp/"},
+						MatchesStorageClass:     []string{"STANDARD"},
+						MatchesSuffix:           []string{".bak"},
+						NoncurrentTimeBefore:    "2024-01-03",
+						NumNewerVersions:        3,
+						IsLive:                  &isLive,
+					},
+				},
+			},
+		},
+	}
+	got := mapStorageBucket(src, "")
+
+	require.Len(t, got.LifecycleRule, 1)
+	r := got.LifecycleRule[0]
+
+	require.Len(t, r.Action, 1)
+	require.NotNil(t, r.Action[0].Type_)
+	assert.Equal(t, "SetStorageClass", *r.Action[0].Type_.Literal)
+	require.NotNil(t, r.Action[0].StorageClass)
+	assert.Equal(t, "NEARLINE", *r.Action[0].StorageClass.Literal)
+
+	require.Len(t, r.Condition, 1)
+	c := r.Condition[0]
+	require.NotNil(t, c.Age)
+	assert.Equal(t, float64(7), *c.Age.Literal, "age must be float64 to match Layer 1 schema")
+	require.NotNil(t, c.CreatedBefore)
+	assert.Equal(t, "2024-01-01", *c.CreatedBefore.Literal, "raw API string format already matches TF YYYY-MM-DD")
+	require.NotNil(t, c.CustomTimeBefore)
+	assert.Equal(t, "2024-01-02", *c.CustomTimeBefore.Literal)
+	require.NotNil(t, c.DaysSinceCustomTime)
+	assert.Equal(t, float64(30), *c.DaysSinceCustomTime.Literal)
+	require.NotNil(t, c.DaysSinceNoncurrentTime)
+	assert.Equal(t, float64(60), *c.DaysSinceNoncurrentTime.Literal)
+	require.Len(t, c.MatchesPrefix, 2)
+	assert.Equal(t, "logs/", *c.MatchesPrefix[0].Literal)
+	assert.Equal(t, "tmp/", *c.MatchesPrefix[1].Literal)
+	require.Len(t, c.MatchesStorageClass, 1)
+	assert.Equal(t, "STANDARD", *c.MatchesStorageClass[0].Literal)
+	require.Len(t, c.MatchesSuffix, 1)
+	assert.Equal(t, ".bak", *c.MatchesSuffix[0].Literal)
+	require.NotNil(t, c.NoncurrentTimeBefore)
+	assert.Equal(t, "2024-01-03", *c.NoncurrentTimeBefore.Literal)
+	require.NotNil(t, c.NumNewerVersions)
+	assert.Equal(t, float64(3), *c.NumNewerVersions.Literal)
+	require.NotNil(t, c.WithState)
+	assert.Equal(t, "LIVE", *c.WithState.Literal, "IsLive=true must map to with_state=LIVE per provider convention")
+
+	// send_*_if_zero sentinels are TF-only — must not be populated.
+	assert.Nil(t, c.SendAgeIfZero, "send_age_if_zero is TF-only sentinel")
+	assert.Nil(t, c.SendDaysSinceCustomTimeIfZero)
+	assert.Nil(t, c.SendDaysSinceNoncurrentTimeIfZero)
+	assert.Nil(t, c.SendNumNewerVersionsIfZero)
+}
+
+// TestMapStorageBucket_LifecycleWithStateArchived pins the IsLive=false
+// branch of the with_state tri-state mapping. Provider convention maps
+// false → ARCHIVED.
+func TestMapStorageBucket_LifecycleWithStateArchived(t *testing.T) {
+	t.Parallel()
+	isLive := false
+	ageGT := int64(30)
+	src := &storagev1.Bucket{
+		Name:     "b",
+		Location: "US",
+		Lifecycle: &storagev1.BucketLifecycle{
+			Rule: []*storagev1.BucketLifecycleRule{{
+				Action:    &storagev1.BucketLifecycleRuleAction{Type: "Delete"},
+				Condition: &storagev1.BucketLifecycleRuleCondition{Age: &ageGT, IsLive: &isLive},
+			}},
+		},
+	}
+	got := mapStorageBucket(src, "")
+	require.Len(t, got.LifecycleRule, 1)
+	require.Len(t, got.LifecycleRule[0].Condition, 1)
+	require.NotNil(t, got.LifecycleRule[0].Condition[0].WithState)
+	assert.Equal(t, "ARCHIVED", *got.LifecycleRule[0].Condition[0].WithState.Literal)
+}
+
+// TestMapStorageBucket_CorsAndRetention exercises a multi-block field
+// (cors, repeating block) and a singleton block with int64 values
+// (retention_policy). Pins that retention_period is emitted as int64
+// seconds matching the TF schema (no Duration conversion needed —
+// the raw JSON API uses int64 already).
+func TestMapStorageBucket_CorsAndRetention(t *testing.T) {
+	t.Parallel()
+	src := &storagev1.Bucket{
+		Name:     "b",
+		Location: "US",
+		Cors: []*storagev1.BucketCors{
+			{
+				MaxAgeSeconds:  3600,
+				Method:         []string{"GET", "HEAD"},
+				Origin:         []string{"https://example.com"},
+				ResponseHeader: []string{"Content-Type"},
+			},
+		},
+		RetentionPolicy: &storagev1.BucketRetentionPolicy{
+			IsLocked:        true,
+			RetentionPeriod: 86400,
+		},
+		SoftDeletePolicy: &storagev1.BucketSoftDeletePolicy{
+			RetentionDurationSeconds: 604800,
+		},
+	}
+	got := mapStorageBucket(src, "")
+
+	require.Len(t, got.Cors, 1)
+	require.NotNil(t, got.Cors[0].MaxAgeSeconds)
+	assert.Equal(t, int64(3600), *got.Cors[0].MaxAgeSeconds.Literal)
+	require.Len(t, got.Cors[0].Method, 2)
+	assert.Equal(t, "GET", *got.Cors[0].Method[0].Literal)
+
+	require.Len(t, got.RetentionPolicy, 1)
+	require.NotNil(t, got.RetentionPolicy[0].IsLocked)
+	assert.True(t, *got.RetentionPolicy[0].IsLocked.Literal)
+	require.NotNil(t, got.RetentionPolicy[0].RetentionPeriod)
+	assert.Equal(t, int64(86400), *got.RetentionPolicy[0].RetentionPeriod.Literal)
+
+	require.Len(t, got.SoftDeletePolicy, 1)
+	require.NotNil(t, got.SoftDeletePolicy[0].RetentionDurationSeconds)
+	assert.Equal(t, int64(604800), *got.SoftDeletePolicy[0].RetentionDurationSeconds.Literal)
+}
+
+// TestMapStorageBucket_ObjectRetentionEnabled pins the
+// objectRetention pointer → enable_object_retention bool conversion.
+// The raw API exposes ObjectRetention as a sub-struct (with Mode
+// string); presence-as-truth is the cleanest mapping to the TF bool.
+func TestMapStorageBucket_ObjectRetentionEnabled(t *testing.T) {
+	t.Parallel()
+	src := &storagev1.Bucket{
+		Name:            "b",
+		Location:        "US",
+		ObjectRetention: &storagev1.BucketObjectRetention{Mode: "Enabled"},
+	}
+	got := mapStorageBucket(src, "")
+	require.NotNil(t, got.EnableObjectRetention)
+	assert.True(t, *got.EnableObjectRetention.Literal,
+		"objectRetention non-nil must map to enable_object_retention=true")
+}
+
+// TestEnrich_ClientUnavailable pins that a nil EnrichClients.Storage
+// returns the sentinel error so the aggregator can downgrade to a
+// warn rather than batch-fail.
+func TestEnrich_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newStorageBucketEnricher()
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type: "google_storage_bucket", ImportID: "io-x", Address: "google_storage_bucket.x",
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Storage: nil})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Empty(t, ir.Attrs, "Attrs must remain empty when client unavailable")
+}
+
+// TestEnrich_BucketNameMissing pins that an enricher invoked against a
+// resource with no derivable bucket name fails fast with a useful
+// error (rather than silently doing a Get("") that GCS would also
+// reject, but with a less-actionable message).
+func TestEnrich_BucketNameMissing(t *testing.T) {
+	t.Parallel()
+	e := storageBucketEnricher{
+		fetch: func(_ context.Context, _ *storagev1.Service, _ string) (*storagev1.Bucket, error) {
+			t.Fatal("fetch must not be called when bucket name unknown")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:    "google_storage_bucket",
+			Address: "google_storage_bucket.x",
+		},
+	}
+	// Pass a dummy non-nil Storage so the client-availability check
+	// passes and the name-derivation guard is the failure point.
+	dummy := &storagev1.Service{}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Storage: dummy})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive bucket name")
+}
+
+// TestEnrich_FetchError pins that a real API failure is wrapped with
+// the bucket name for actionable debugging.
+func TestEnrich_FetchError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("403 Forbidden: insufficient permission")
+	e := storageBucketEnricher{
+		fetch: func(_ context.Context, _ *storagev1.Service, _ string) (*storagev1.Bucket, error) {
+			return nil, wantErr
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "google_storage_bucket",
+			ImportID: "my-bucket",
+			Address:  "google_storage_bucket.my-bucket",
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Storage: &storagev1.Service{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), "my-bucket", "error must name the failing bucket")
+}
+
+// TestEnrich_PopulatesAttrs is the end-to-end happy path: a fake
+// fetcher returns a bucket, the enricher writes the typed payload
+// into ir.Attrs, and the JSON round-trips cleanly through
+// generated.UnmarshalAttrs.
+func TestEnrich_PopulatesAttrs(t *testing.T) {
+	t.Parallel()
+	bucket := &storagev1.Bucket{
+		Name:         "io-test-data",
+		Location:     "US",
+		StorageClass: "STANDARD",
+		Versioning:   &storagev1.BucketVersioning{Enabled: true},
+		IamConfiguration: &storagev1.BucketIamConfiguration{
+			UniformBucketLevelAccess: &storagev1.BucketIamConfigurationUniformBucketLevelAccess{Enabled: true},
+		},
+		Labels: map[string]string{"environment": "staging"},
+	}
+	e := storageBucketEnricher{
+		fetch: func(_ context.Context, _ *storagev1.Service, name string) (*storagev1.Bucket, error) {
+			assert.Equal(t, "io-test-data", name, "fetch must be called with the bucket name from Identity")
+			return bucket, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "google_storage_bucket",
+			ImportID: "io-test-data",
+			Address:  "google_storage_bucket.assets",
+		},
+	}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{Storage: &storagev1.Service{}, ProjectID: "my-project"}))
+
+	require.NotEmpty(t, ir.Attrs)
+	decoded, err := generated.UnmarshalAttrs("google_storage_bucket", ir.Attrs)
+	require.NoError(t, err)
+	gb, ok := decoded.(*generated.GoogleStorageBucket)
+	require.True(t, ok, "decoded type must be *GoogleStorageBucket, got %T", decoded)
+	require.NotNil(t, gb.Name)
+	assert.Equal(t, "io-test-data", *gb.Name.Literal)
+	require.NotNil(t, gb.Project)
+	assert.Equal(t, "my-project", *gb.Project.Literal)
+	require.NotNil(t, gb.UniformBucketLevelAccess)
+	assert.True(t, *gb.UniformBucketLevelAccess.Literal)
+	require.Len(t, gb.Versioning, 1)
+}
+
+// TestEnrich_RoundTripThroughEmitImportedTF is the load-bearing
+// decision-#34 contract test for the typed-Attrs path. Verifies that
+// the enricher's output, when threaded through composer.EmitImportedTF,
+// produces HCL that:
+//
+//  1. Routes through the typed branch (resource block appears, since
+//     unmarshal+marshal succeeded).
+//  2. Carries the values the enricher set (name, location,
+//     storage_class, project, uniform_bucket_level_access, etc.).
+//  3. Emits nested blocks as block syntax (`versioning {`), not as
+//     map literals (`versioning = {`) — proves the nested-blocks-
+//     don't-emit failure mode of the opaque path is avoided.
+//
+// This is the test that justifies the issue's "use ir.Attrs not
+// ir.Attributes" architectural correction; without it a regression
+// to the opaque path would silently drop nested blocks and only
+// surface as a decision-#34 failure during live smoke.
+func TestEnrich_RoundTripThroughEmitImportedTF(t *testing.T) {
+	t.Parallel()
+	bucket := &storagev1.Bucket{
+		Name:         "io-test-data",
+		Location:     "US",
+		StorageClass: "STANDARD",
+		Versioning:   &storagev1.BucketVersioning{Enabled: true},
+		IamConfiguration: &storagev1.BucketIamConfiguration{
+			UniformBucketLevelAccess: &storagev1.BucketIamConfigurationUniformBucketLevelAccess{Enabled: true},
+		},
+		Encryption: &storagev1.BucketEncryption{DefaultKmsKeyName: "projects/p/locations/us/keyRings/k/cryptoKeys/c"},
+		Logging:    &storagev1.BucketLogging{LogBucket: "io-logs"},
+		Labels:     map[string]string{"environment": "staging"},
+	}
+	typed := mapStorageBucket(bucket, "my-project")
+	raw, err := json.Marshal(typed)
+	require.NoError(t, err)
+
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "gcp",
+			Type:     "google_storage_bucket",
+			Address:  "google_storage_bucket.assets",
+			ImportID: "io-test-data",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: raw,
+	}
+	out, used := composer.EmitImportedTF("gcp", []imported.ImportedResource{ir}, composer.EmitImportedOpts{})
+	require.NotNil(t, out, "typed emit must succeed end-to-end")
+	require.True(t, used["gcp"])
+	s := string(out)
+
+	// Resource and import blocks present.
+	assert.Contains(t, s, `resource "google_storage_bucket" "assets"`)
+	assert.Contains(t, s, "to = google_storage_bucket.assets")
+
+	// Top-level scalars carried through. hclwrite columnar-aligns the
+	// `=` so attribute padding varies with the longest neighbor; use
+	// regex with `\s+=\s+` to be alignment-insensitive.
+	assert.Regexp(t, `(?m)^\s*name\s+=\s+"io-test-data"`, s, "name attr missing in:\n%s", s)
+	assert.Regexp(t, `(?m)^\s*location\s+=\s+"US"`, s, "location attr missing in:\n%s", s)
+	assert.Regexp(t, `(?m)^\s*storage_class\s+=\s+"STANDARD"`, s, "storage_class missing in:\n%s", s)
+	assert.Regexp(t, `(?m)^\s*project\s+=\s+"my-project"`, s, "project missing in:\n%s", s)
+	assert.Regexp(t, `(?m)^\s*uniform_bucket_level_access\s+=\s+true`, s, "uniform_bucket_level_access missing in:\n%s", s)
+
+	// Nested blocks emitted as block syntax (the load-bearing
+	// assertion vs. the opaque-path failure mode).
+	assert.Regexp(t, `(?m)^\s*versioning\s*\{`, s, "versioning must emit as block syntax, not map literal")
+	assert.Contains(t, s, "enabled = true")
+	assert.Regexp(t, `(?m)^\s*encryption\s*\{`, s, "encryption must emit as block syntax")
+	assert.Contains(t, s, `default_kms_key_name = "projects/p/locations/us/keyRings/k/cryptoKeys/c"`)
+	assert.Regexp(t, `(?m)^\s*logging\s*\{`, s, "logging must emit as block syntax")
+	assert.Contains(t, s, `log_bucket = "io-logs"`)
+
+	// Computed-only fields must not appear in emitted HCL.
+	for _, computed := range []string{"effective_labels", "self_link", "url", "project_number", "terraform_labels"} {
+		assert.NotContains(t, s, computed, "computed-only field %q must not appear in emitted HCL", computed)
+	}
+
+	// Map vs block sanity: labels is an HCL map (=), not a block.
+	assert.Contains(t, s, "labels", "labels attr missing")
+	assert.True(t,
+		strings.Contains(s, `"environment" = "staging"`) || strings.Contains(s, `environment = "staging"`),
+		"labels map must carry the staging value: %s", s)
+}
+
+// TestRegisteredOnAggregator pins that NewGCPDiscoverer registers the
+// storage_bucket enricher in byTypeEnricher, so a caller's
+// EnrichAttributes call reaches the right enricher rather than
+// silently skipping it.
+func TestRegisteredOnAggregator(t *testing.T) {
+	t.Parallel()
+	g := NewGCPDiscoverer(nil, "test-project", GCPDiscovererOpts{})
+	enr, ok := g.byTypeEnricher["google_storage_bucket"]
+	require.True(t, ok, "google_storage_bucket must be registered in byTypeEnricher")
+	require.NotNil(t, enr)
+	assert.Equal(t, "google_storage_bucket", enr.ResourceType())
+}


### PR DESCRIPTION
## Summary

Adds a per-type `AttributeEnricher` capability sibling to the existing
Identity-only `Discoverer` in `cmd/insideout-import/gcpdiscover/`. Phase 1
covers `google_storage_bucket` only, paired with [reliable#1346](https://github.com/luthersystems/reliable/issues/1346)'s single-resource GCS import slice.

The new path is **terraform-binary-free**: pure cloud SDK calls populate the typed Layer 1 payload (`ImportedResource.Attrs`), so `composer.EmitImportedTF` produces decision-#34-clean HCL end-to-end without needing `terraform plan -generate-config-out`.

> **Note on scaling (added 2026-05-13):** This file is **hand-written as a working reference**, not the long-term scaling strategy. A compile-time-reflection codegen design was validated by spike on 2026-05-13 (4/4 fixtures `reflect.DeepEqual` vs. this file) and tracked as **#405**. No further hand-written enrichers will ship — Phase-2 types (`google_pubsub_topic` etc.) go through the generator from day one. This file becomes the verification target the generator must reproduce; it gets deleted once `storage_bucket_enrich.gen.go` passes the existing test suite unchanged.

### Why this design

- **Writes `ir.Attrs` (typed) not `ir.Attributes` (opaque map).** The opaque path's `emitOpaqueAttrsBody` routes nested values through `cty.ObjectVal` — emits HCL `{ ... }` literals, never sub-blocks. For `google_storage_bucket`'s 12 nested blocks (`versioning`, `lifecycle_rule`, `cors`, `encryption`, `logging`, `retention_policy`, `website`, `autoclass`, `soft_delete_policy`, `custom_placement_config`, `hierarchical_namespace`, `timeouts`) the opaque path can't reach decision #34. The typed path (`emitImportedResourceBody @ imported_emit.go:218-228`) calls `generated.MarshalHCL` which DOES emit nested blocks correctly.
- **SDK boundary: `google.golang.org/api/storage/v1`** (raw JSON API client). Same client `terraform-provider-google` uses internally — closes most shape-mismatch surface vs. the high-level `cloud.google.com/go/storage` SDK (int64 seconds vs `time.Duration`; RFC3339 strings vs `time.Time`; `ip_filter` exposed).
- **Per-type enrichers go in the same package as their Discoverer counterpart**, so SDK→TF mapping knowledge for each resource type stays in one place.

### Aggregator surface

```go
g := gcpdiscover.NewGCPDiscoverer(searcher, projectID, opts)
irs, _ := g.DiscoverTypes(ctx, []string{"google_storage_bucket"}, args)
_ = g.EnrichAttributes(ctx, irs, gcpdiscover.EnrichClients{
    Storage:   storagev1Service,
    ProjectID: projectID,
}, emitter)
out, _ := composer.EmitImportedTF("gcp", irs, composer.EmitImportedOpts{...})
```

`ErrEnrichClientUnavailable` distinguishes "client not configured" (downgraded to `ServiceWarn`, type silently skipped) from real API failures (accumulated as a joined error so all per-resource failures surface in one shot).

### Live smoke against a real bucket (verified 2026-05-13)

Ran end-to-end against a real GCS bucket in `insideout-477120`: `Plan: 1 to import, 0 to add, 1 to change, 0 to destroy`. The "1 to change" is the google provider's known labels-after-import quirk — re-populates the user-managed `labels` field on first apply (cloud-side labels already correct, state-tracking artifact). Decision-#34 explicitly permits this ("in-place additions/repairs of InsideOut provenance tags / labels are allowed"). Stage-2b's terraform-driven path produces the exact same diff. Critically: `0 to add, 0 to destroy` — no resources hallucinated or deleted.

### Phase-1 limitations (tracked for follow-up)

- `ip_filter` (preview feature): present on the raw JSON API but absent from the Layer 1 `generated.GoogleStorageBucket` (the codegen pre-dates it). Re-running `cmd/imported-codegen` against a newer provider schema picks it up.
- AST-driven codegen for the per-type mapper: **superseded by #405** (compile-time-reflection codegen, validated by spike).

### Files changed

- `cmd/insideout-import/gcpdiscover/enrich.go` (new) — `AttributeEnricher` interface, `EnrichClients` bundle, `EnrichAttributes` aggregator method, `ErrEnrichClientUnavailable` sentinel.
- `cmd/insideout-import/gcpdiscover/storage_bucket_enrich.go` (new) — `storageBucketEnricher` + pure `mapStorageBucket(*storagev1.Bucket, projectID) → *generated.GoogleStorageBucket` mapper. **Will be auto-generated under #405; this hand-written version is the verification target.**
- `cmd/insideout-import/gcpdiscover/storage_bucket_enrich_test.go` (new) — 13 unit + round-trip tests.
- `cmd/insideout-import/gcpdiscover/enrich_test.go` (new) — 5 aggregator tests.
- `cmd/insideout-import/gcpdiscover/storage_bucket_enrich_live_test.go` (new) — `//go:build integration` decision-#34 live-smoke against a real bucket.
- `cmd/insideout-import/gcpdiscover/gcpdiscover.go` — adds `byTypeEnricher` map field on `GCPDiscoverer`, registers `google_storage_bucket` enricher in `NewGCPDiscoverer`.

Closes #403. Follow-up: #405 (compile-time-reflection codegen).

## Test plan

- [x] `go test ./cmd/insideout-import/gcpdiscover/...` — 483 passed
- [x] `go test ./...` — 4442 passed across 26 packages; no regressions
- [x] `gofmt -l <new files>` — clean
- [x] `go vet ./cmd/insideout-import/gcpdiscover/...` — no issues
- [x] All 8 static lint scripts PASS
- [x] **Live smoke against real bucket** (2026-05-13, `4200875b-data` in `insideout-477120`): `Plan: 1 to import, 0 to add, 1 to change, 0 to destroy`. The 1 change is the provider's labels-after-import re-population, permitted by decision #34. End-to-end path validated.
- [ ] Downstream verification: reliable#1346 wires `EnrichAttributes` into the importer wizard once this lands.
