### PR TITLE
fix(awsdiscover): rgtCache authoritative-zero + ApiGatewayV2 Stage warn suppression

### DIFF
--- a/cmd/insideout-import/awsdiscover/arn_rules.go
+++ b/cmd/insideout-import/awsdiscover/arn_rules.go
@@ -188,6 +188,15 @@ var arnRules = []arnRule{
 	{matchService: "apigateway", matchResourceType: "apis",
 		matchExtra: func(p parsedARN) bool { return !strings.Contains(p.resourceID, "/") },
 		cfnType:    "AWS::ApiGatewayV2::Api", identifierFn: identityResourceID},
+	// API Gateway v2 Stage — explicit known-skip so RGT doesn't emit a
+	// "no arnRule" warning for every stage ARN. Stages are discovered
+	// by the hand-rolled apigatewayv2_stage discoverer (per-API
+	// DescribeStage SDK loop) since Cloud Control READ is unsupported
+	// for this type. cfnType is intentionally blank — the prefetcher
+	// reads cfnType=="" as "matched-but-skipped, don't bucket and don't warn."
+	{matchService: "apigateway", matchResourceType: "apis",
+		matchExtra: func(p parsedARN) bool { return strings.Contains(p.resourceID, "/stages/") },
+		cfnType:    "", identifierFn: identityResourceID},
 
 	// Cognito
 	{matchService: "cognito-idp", matchResourceType: "userpool",

--- a/cmd/insideout-import/awsdiscover/arn_rules_test.go
+++ b/cmd/insideout-import/awsdiscover/arn_rules_test.go
@@ -334,11 +334,13 @@ func TestLookupRule(t *testing.T) {
 		{name: "apigatewayv2_api", arn: "arn:aws:apigateway:us-east-1::/apis/4hmoaslnr0",
 			wantCFN: "AWS::ApiGatewayV2::Api", wantIdent: "4hmoaslnr0"},
 
-		// API Gateway v2 — Stage URL-path-style should NOT match the Api rule
-		// (matchExtra rejects resourceID containing "/"). No Stage rule
-		// declared today (Cloud Control READ-unsupported).
-		{name: "apigatewayv2_stage_unmapped", arn: "arn:aws:apigateway:us-east-1::/apis/4hmoaslnr0/stages/$default",
-			wantNoMatch: true},
+		// API Gateway v2 — Stage URL-path-style matches an explicit
+		// known-skip rule (cfnType=="") so RGT silently drops it
+		// without a "no arnRule" warning. The hand-rolled
+		// apigatewayv2_stage discoverer owns this type (Cloud Control
+		// READ-unsupported).
+		{name: "apigatewayv2_stage_known_skip", arn: "arn:aws:apigateway:us-east-1::/apis/4hmoaslnr0/stages/$default",
+			wantCFN: "", wantIdent: "4hmoaslnr0/stages/$default"},
 
 		// REST API v1 — explicitly unmapped (only v2 in table today)
 		{name: "apigateway_v1_restapi_unmapped", arn: "arn:aws:apigateway:us-east-1::/restapis/abc123",
@@ -401,13 +403,13 @@ func TestLookupRule(t *testing.T) {
 }
 
 // TestLookupRule_ApiGatewayDisambiguation pins the matchExtra behavior
-// for the AWS::ApiGatewayV2::Api rule: a bare api ARN must match (no "/"
-// in resourceID), but a stage ARN under the same `apis` parent must NOT
-// match the Api rule. The Stage rule is intentionally absent from the
-// table today (Cloud Control returns UnsupportedActionException for
-// READ on AWS::ApiGatewayV2::Stage; see issue #406 and the hand-rolled
-// apigatewayv2_stage.go discoverer that continues to handle Stages via
-// the per-service SDK).
+// for the two ApiGatewayV2 rules: a bare api ARN matches the Api rule
+// (no "/" in resourceID), but a stage ARN under the same `apis` parent
+// matches the explicit known-skip rule (cfnType==""). The RGT
+// prefetcher reads cfnType=="" as "matched but intentionally not
+// bucketed — drop silently" (no warning, no fallback). The hand-rolled
+// apigatewayv2_stage discoverer owns Stages (Cloud Control READ
+// unsupported; see issue #406).
 func TestLookupRule_ApiGatewayDisambiguation(t *testing.T) {
 	t.Parallel()
 	bareAPI, _ := parseARN("arn:aws:apigateway:us-east-1::/apis/aaa")
@@ -420,7 +422,11 @@ func TestLookupRule_ApiGatewayDisambiguation(t *testing.T) {
 	}
 
 	stage, _ := parseARN("arn:aws:apigateway:us-east-1::/apis/aaa/stages/$default")
-	if r, ok := lookupRule(stage); ok {
-		t.Errorf("stage ARN should NOT match the Api rule (matchExtra), but matched cfnType=%q", r.cfnType)
+	r, ok = lookupRule(stage)
+	if !ok {
+		t.Fatal("stage ARN should match the known-skip rule (was previously falling through to 'no arnRule' warn)")
+	}
+	if r.cfnType != "" {
+		t.Errorf("stage ARN matched cfnType=%q, want \"\" (known-skip sentinel)", r.cfnType)
 	}
 }

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
@@ -1298,22 +1298,22 @@ func TestCloudControlDiscover_UsesRGTCache_SkipsListResources(t *testing.T) {
 	}
 }
 
-// TestCloudControlDiscover_CacheMiss_FallsBackToListResources pins the
-// fallback behavior: when the orchestrator ran the prefetcher but found
-// no ARNs for our CloudFormation type (cache miss), the existing
-// ListResources path must drive AND the legacy args.Project tag filter
-// (skipped on the cache-hit path) must remain active. The fixture seeds
-// two vault items with different Project tags; only the matching one
-// emits.
-func TestCloudControlDiscover_CacheMiss_FallsBackToListResources(t *testing.T) {
+// TestCloudControlDiscover_NoCache_FallsBackToListResources pins the
+// fallback behavior: when no RGT cache exists for the region at all
+// (cache is nil — the typical no-tag-filters path, or the orchestrator
+// skipped RGT entirely), ListResources must drive AND the legacy
+// args.Project tag filter (skipped on the cache-hit path) must remain
+// active. The fixture seeds two vault items with different Project
+// tags; only the matching one emits.
+func TestCloudControlDiscover_NoCache_FallsBackToListResources(t *testing.T) {
 	t.Parallel()
 	fake := &fakeCloudControlClient{
 		listPages: []cloudcontrol.ListResourcesOutput{
 			listPage("", "vault-match", "vault-other-project"),
 		},
 		propsByIdentifier: map[string]map[string]any{
-			"vault-match":          {"BackupVaultName": "vault-match", "BackupVaultTags": map[string]any{"Project": "io-foo"}},
-			"vault-other-project":  {"BackupVaultName": "vault-other-project", "BackupVaultTags": map[string]any{"Project": "io-bar"}},
+			"vault-match":         {"BackupVaultName": "vault-match", "BackupVaultTags": map[string]any{"Project": "io-foo"}},
+			"vault-other-project": {"BackupVaultName": "vault-other-project", "BackupVaultTags": map[string]any{"Project": "io-bar"}},
 		},
 	}
 	cfg := testConfig()
@@ -1326,7 +1326,49 @@ func TestCloudControlDiscover_CacheMiss_FallsBackToListResources(t *testing.T) {
 		new:            func(_ string) cloudControlClient { return fake },
 		maxConcurrency: DefaultMaxConcurrency,
 	}
-	// Cache populated for a DIFFERENT cfnType so this type misses.
+	// No cache set on args — the prefetcher returned nil (e.g. no
+	// tag filters), so the discoverer must fall back to ListResources.
+	args := DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"}
+
+	got, err := d.Discover(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if fake.listCalls == 0 {
+		t.Error("ListResources calls: got 0, want >=1 (no-cache should fall back to List)")
+	}
+	if len(got) != 1 {
+		t.Fatalf("emit count: got %d (%v), want 1 (Project filter must still run on cache-miss path)", len(got), got)
+	}
+	if got[0].Identity.ImportID != "vault-match" {
+		t.Errorf("emitted ImportID = %q, want vault-match (the Project=io-foo row); vault-other-project should have been filtered", got[0].Identity.ImportID)
+	}
+}
+
+// TestCloudControlDiscover_CacheRanRegionEmptyForCFN_AuthoritativeZero
+// pins the post-fix contract (#406 follow-up): when RGT ran
+// successfully for a region but found zero ARNs of our CloudFormation
+// type, the discoverer must emit zero items WITHOUT falling back to
+// ListResources. The fallback is invalid for parent-scoped CC types
+// (e.g. AWS::EKS::PodIdentityAssociation requires ClusterName in
+// ListResourcesInput.ResourceModel) and would return 400. Surfaced by
+// the live smoke against test account 141812438321 / project
+// io-f-v6e-hzw-zt (no pod identity associations existed → ListResources
+// 400 → discover exit 1).
+func TestCloudControlDiscover_CacheRanRegionEmptyForCFN_AuthoritativeZero(t *testing.T) {
+	t.Parallel()
+	// Fake's listPages is empty; if the discoverer tries to ListResources
+	// we count the call and assert it didn't happen.
+	fake := &fakeCloudControlClient{}
+	cfg := testConfig()
+	cfg.CloudFormationType = "AWS::EKS::PodIdentityAssociation"
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	// Cache has the region but NO bucket for our cfnType — RGT ran
+	// authoritatively and found zero EKS pod identity associations.
 	cache := &rgtCache{byRegionAndType: map[string]map[string][]arnInfo{
 		"us-east-1": {"AWS::SNS::Topic": {{ARN: "x", Identifier: "x"}}},
 	}}
@@ -1336,14 +1378,100 @@ func TestCloudControlDiscover_CacheMiss_FallsBackToListResources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Discover: %v", err)
 	}
-	if fake.listCalls == 0 {
-		t.Error("ListResources calls: got 0, want >=1 (cache miss should fall back to List)")
+	if fake.listCalls != 0 {
+		t.Errorf("ListResources calls: got %d, want 0 (RGT empty must NOT fall back — parent-scoped types 400 on List without ResourceModel)", fake.listCalls)
+	}
+	if len(got) != 0 {
+		t.Errorf("emit count: got %d, want 0 (authoritative empty)", len(got))
+	}
+}
+
+// TestCloudControlDiscover_MixedRegionsKnownEmptyVsUnknownFallback pins
+// that within a single Discover invocation the authoritative-empty
+// short-circuit and the unknown-region fallback are orthogonal: a
+// region present in the cache (even with zero of our cfnType) must
+// NOT call ListResources, while a region absent from the cache (RGT
+// failed there, or wasn't run for that region) MUST fall back. The
+// pre-fix code conflated these and produced 400s for the first arm;
+// a future regression that collapses them again should fail here.
+func TestCloudControlDiscover_MixedRegionsKnownEmptyVsUnknownFallback(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{
+		// us-west-2 hits the fallback path and ListResources returns one row.
+		listPages: []cloudcontrol.ListResourcesOutput{listPage("", "match-west")},
+		propsByIdentifier: map[string]map[string]any{
+			"match-west": {"BackupVaultName": "match-west", "BackupVaultTags": map[string]any{"Project": "io-foo"}},
+		},
+	}
+	cfg := testConfig()
+	cfg.CloudFormationType = "AWS::Backup::BackupVault"
+	cfg.TagsFromProperties = func(props map[string]any) map[string]string {
+		return extractStringMap(props, "BackupVaultTags")
+	}
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	// Cache has us-east-1 (no bucket for our cfnType → authoritative
+	// zero) but not us-west-2 (must fall back to ListResources).
+	cache := &rgtCache{byRegionAndType: map[string]map[string][]arnInfo{
+		"us-east-1": {"AWS::SNS::Topic": {{ARN: "x", Identifier: "x"}}},
+	}}
+	args := DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1", "us-west-2"}, AccountID: "123"}.withRGTCache(cache)
+
+	got, err := d.Discover(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	// Exactly one ListResources call — for us-west-2 only.
+	if fake.listCalls != 1 {
+		t.Errorf("ListResources calls: got %d, want 1 (only us-west-2 should fall back; us-east-1 must short-circuit)", fake.listCalls)
 	}
 	if len(got) != 1 {
-		t.Fatalf("emit count: got %d (%v), want 1 (Project filter must still run on cache-miss path)", len(got), got)
+		t.Fatalf("emit count: got %d, want 1 (the us-west-2 fallback row)", len(got))
 	}
-	if got[0].Identity.ImportID != "vault-match" {
-		t.Errorf("emitted ImportID = %q, want vault-match (the Project=io-foo row); vault-other-project should have been filtered", got[0].Identity.ImportID)
+	if got[0].Identity.ImportID != "match-west" {
+		t.Errorf("emitted ImportID = %q, want match-west", got[0].Identity.ImportID)
+	}
+}
+
+// TestCloudControlDiscover_IsGlobal_CacheRanEmptyForCFN_AuthoritativeZero
+// is the IsGlobal-arm twin of CacheRanRegionEmptyForCFN_AuthoritativeZero.
+// The pre-fix bug in ForGlobalCFN ("len(out)==0 → ok=false") would
+// regress global parent-scoped types (e.g. hypothetical zero
+// AWS::IAM::Role in an org locked to a single SSO) to a ListResources
+// fallback. Pins both the dedicated IsGlobal code branch
+// (cloudcontrol_discoverer.go:183-189) AND ForGlobalCFN's
+// "any-region-ran ⇒ ok=true" contract end-to-end.
+func TestCloudControlDiscover_IsGlobal_CacheRanEmptyForCFN_AuthoritativeZero(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{}
+	cfg := testConfig()
+	cfg.CloudFormationType = "AWS::IAM::Role"
+	cfg.IsGlobal = true
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	// Cache has regions (RGT ran successfully in some region) but no
+	// AWS::IAM::Role anywhere — authoritative-zero for the global type.
+	cache := &rgtCache{byRegionAndType: map[string]map[string][]arnInfo{
+		"us-east-1": {"AWS::SNS::Topic": {{ARN: "x", Identifier: "x"}}},
+		"us-west-2": {"AWS::SNS::Topic": {{ARN: "y", Identifier: "y"}}},
+	}}
+	args := DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1", "us-west-2"}, AccountID: "123"}.withRGTCache(cache)
+
+	got, err := d.Discover(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListResources calls: got %d, want 0 (global authoritative-zero must NOT fall back)", fake.listCalls)
+	}
+	if len(got) != 0 {
+		t.Errorf("emit count: got %d, want 0", len(got))
 	}
 }
 

--- a/cmd/insideout-import/awsdiscover/rgt_prefetcher.go
+++ b/cmd/insideout-import/awsdiscover/rgt_prefetcher.go
@@ -48,10 +48,16 @@ type rgtCache struct {
 	byRegionAndType map[string]map[string][]arnInfo
 }
 
-// ForCFN returns the ARNs prefetched for (region, cfnType), and ok=true
-// if the prefetcher saw at least one ARN for that bucket. A cache miss
-// (ok=false) signals the caller to fall back to its own per-type
-// ListResources. nil cache always returns ok=false.
+// ForCFN returns the ARNs prefetched for (region, cfnType). ok=true
+// signals "RGT ran successfully for this region, so the result is
+// authoritative" — including the empty case where RGT saw zero ARNs
+// of this cfnType. Callers must NOT fall back to ListResources on
+// ok=true: many Cloud Control types (e.g. AWS::EKS::PodIdentityAssociation)
+// reject ListResources without a parent ResourceModel, so the fallback
+// would 400 even when the truth is "the account has zero of these."
+// ok=false means RGT wasn't run for this region (nil cache, no tag
+// filters supplied, or the per-region RGT call failed and was
+// downgraded to a warn) — fall back to ListResources in that case.
 func (c *rgtCache) ForCFN(region, cfnType string) ([]arnInfo, bool) {
 	if c == nil || c.byRegionAndType == nil {
 		return nil, false
@@ -60,20 +66,20 @@ func (c *rgtCache) ForCFN(region, cfnType string) ([]arnInfo, bool) {
 	if !ok {
 		return nil, false
 	}
-	infos, ok := byType[cfnType]
-	if !ok {
-		return nil, false
-	}
-	return infos, true
+	return byType[cfnType], true
 }
 
 // ForGlobalCFN returns the de-duplicated union of ARNs across every
 // region bucket. Used by the discoverer for global CloudFormation types
 // (e.g. AWS::IAM::Role, AWS::CloudFront::Distribution) whose ARNs RGT
-// returns in every region's response. ok=true when at least one ARN
-// was found.
+// returns in every region's response. ok=true means RGT ran
+// successfully for at least one region — the union (which may be
+// empty) is authoritative. ok=false means no region's RGT call
+// succeeded; fall back to ListResources. The "authoritative empty"
+// signal matters for global types whose ListResources requires a
+// parent ResourceModel — see ForCFN doc for rationale.
 func (c *rgtCache) ForGlobalCFN(cfnType string) ([]arnInfo, bool) {
-	if c == nil || c.byRegionAndType == nil {
+	if c == nil || c.byRegionAndType == nil || len(c.byRegionAndType) == 0 {
 		return nil, false
 	}
 	seen := map[string]struct{}{}
@@ -91,9 +97,6 @@ func (c *rgtCache) ForGlobalCFN(cfnType string) ([]arnInfo, bool) {
 			seen[info.ARN] = struct{}{}
 			out = append(out, info)
 		}
-	}
-	if len(out) == 0 {
-		return nil, false
 	}
 	return out, true
 }
@@ -202,15 +205,21 @@ func (p *realRGTPrefetcher) Prefetch(ctx context.Context, regions []string, args
 
 	cache := &rgtCache{byRegionAndType: make(map[string]map[string][]arnInfo, len(results))}
 	for _, r := range results {
-		if len(r.byType) == 0 {
-			continue
-		}
+		// Record every region whose RGT call succeeded, even when
+		// byType is empty. The cache's presence-of-region key is the
+		// authoritative signal for ForCFN/ForGlobalCFN — see those
+		// methods' contract. Stripping empty regions here would
+		// regress to "0 results ⇒ fall back to ListResources," which
+		// 400s on parent-scoped types like AWS::EKS::PodIdentityAssociation.
 		// Sort each cfnType bucket by ARN for deterministic downstream
 		// emit order (the cloudControlDiscoverer downstream sorts by
 		// identifier — sorting by ARN here aligns the orderings since
 		// the ARN is the source-of-truth identity).
 		for _, infos := range r.byType {
 			sort.SliceStable(infos, func(i, j int) bool { return infos[i].ARN < infos[j].ARN })
+		}
+		if r.byType == nil {
+			r.byType = map[string][]arnInfo{}
 		}
 		cache.byRegionAndType[r.region] = r.byType
 	}
@@ -253,6 +262,15 @@ func (p *realRGTPrefetcher) fetchRegion(ctx context.Context, region string, filt
 			rule, ok := lookupRule(parsed)
 			if !ok {
 				unmapped[parsed.service+"/"+parsed.resourceType] = struct{}{}
+				continue
+			}
+			// A matched rule with an empty cfnType is an explicit
+			// "known-skip" — the ARN shape is recognized but its
+			// CloudFormation type is intentionally not discoverable
+			// via Cloud Control (e.g. AWS::ApiGatewayV2::Stage —
+			// hand-rolled discoverer owns it; CC READ is
+			// UnsupportedActionException). Drop without warning.
+			if rule.cfnType == "" {
 				continue
 			}
 			tags := make(map[string]string, len(m.Tags))

--- a/cmd/insideout-import/awsdiscover/rgt_prefetcher_test.go
+++ b/cmd/insideout-import/awsdiscover/rgt_prefetcher_test.go
@@ -337,6 +337,87 @@ func TestRGTPrefetcher_UnmappableARN_WarnsOncePerPair(t *testing.T) {
 	}
 }
 
+// TestRGTPrefetcher_KnownSkipRule_NoWarnNoBucket pins that an ARN
+// matched by a rule with cfnType=="" (an explicit known-skip — e.g.
+// AWS::ApiGatewayV2::Stage which is hand-rolled because Cloud Control
+// READ is unsupported) is silently dropped: no entry in the cache, no
+// "no arnRule" warn. Without this, every project's stage ARNs floods
+// the warn stream on every discover run (surfaced during the Bundle
+// 13c live smoke). The fixture also includes a genuinely-unmapped ARN
+// (organizations/account) so the test pins INDEPENDENCE of the
+// known-skip path from the unmapped-aggregator path: the org warn
+// must still fire, and the stage ARN must not get swept into it.
+func TestRGTPrefetcher_KnownSkipRule_NoWarnNoBucket(t *testing.T) {
+	t.Parallel()
+	fake := &fakeRGTClient{
+		pages: [][]rgttypes.ResourceTagMapping{
+			{
+				// Stage ARN — matches the known-skip rule, cfnType="".
+				mapping("arn:aws:apigateway:us-east-1::/apis/abc/stages/$default", "proj-1"),
+				// Api ARN — matches the AWS::ApiGatewayV2::Api rule.
+				mapping("arn:aws:apigateway:us-east-1::/apis/abc", "proj-1"),
+				// Genuinely-unmapped ARN — pins that known-skip
+				// suppression doesn't accidentally muzzle the
+				// unmapped-pair aggregator (the two paths must
+				// remain independent).
+				mapping("arn:aws:organizations::111111111111:account/o-123/111111111111", "proj-1"),
+			},
+		},
+	}
+	p := buildPrefetcherWithClients(map[string]*fakeRGTClient{"us-east-1": fake})
+	rec := &recordingEmitter{}
+
+	cache, err := p.Prefetch(context.Background(), []string{"us-east-1"},
+		DiscoverArgs{Project: "proj-1", Emitter: rec})
+	if err != nil {
+		t.Fatalf("Prefetch: %v", err)
+	}
+	// Api should be cached.
+	if infos, ok := cache.ForCFN("us-east-1", "AWS::ApiGatewayV2::Api"); !ok || len(infos) != 1 {
+		t.Errorf("Api bucket missing; got ok=%v len=%d", ok, len(infos))
+	}
+	// Stage must NOT appear under its cfnType (known-skip drops it).
+	// ForCFN returns ok=true because the region was prefetched (the
+	// authoritative-zero contract), but the slice MUST be empty —
+	// the prefetcher must not have bucketed the Stage ARN.
+	if infos, _ := cache.ForCFN("us-east-1", "AWS::ApiGatewayV2::Stage"); len(infos) != 0 {
+		t.Errorf("Stage cached under its cfnType; len=%d, want 0 (known-skip)", len(infos))
+	}
+	// Belt-and-suspenders: walk the raw byType map and confirm no
+	// known-skip cfnType key ever got created. An empty-string key
+	// would be a different bug (rule.cfnType being used as a map
+	// key without the skip guard).
+	if _, exists := cache.byRegionAndType["us-east-1"][""]; exists {
+		t.Error("known-skip ARN got bucketed under cfnType=\"\" (skip guard missing)")
+	}
+	// Walk every rgt warn and partition into the three signals we care about.
+	var (
+		stageWarn, orgWarn int
+		messages           []string
+	)
+	for _, ev := range rec.snapshot() {
+		if ev.Kind != "service_warn" || ev.Service != "rgt" {
+			continue
+		}
+		messages = append(messages, ev.Message)
+		switch {
+		case strings.Contains(ev.Message, "apigateway/apis"):
+			stageWarn++
+		case strings.Contains(ev.Message, "organizations/account"):
+			orgWarn++
+		}
+	}
+	if stageWarn != 0 {
+		t.Errorf("known-skip emitted warn: %d (Stage should be silent); messages=%v", stageWarn, messages)
+	}
+	if orgWarn != 1 {
+		t.Errorf("unmapped organizations warn: got %d, want 1 (independence pin); messages=%v", orgWarn, messages)
+	}
+	if len(messages) != 1 {
+		t.Errorf("total rgt warns: got %d, want 1 (just the unmapped org pair); messages=%v", len(messages), messages)
+	}
+}
+
 func TestRGTCache_ForGlobalCFN_DedupesAcrossRegions(t *testing.T) {
 	t.Parallel()
 	// Simulate an IAM role appearing in three regions (RGT surfaces
@@ -369,17 +450,34 @@ func TestRGTCache_ForGlobalCFN_DedupesAcrossRegions(t *testing.T) {
 	}
 }
 
-func TestRGTCache_ForCFN_MissReturnsFalse(t *testing.T) {
+func TestRGTCache_ForCFN_UnknownRegionMisses(t *testing.T) {
 	t.Parallel()
 	cache := &rgtCache{byRegionAndType: map[string]map[string][]arnInfo{
 		"us-east-1": {"AWS::EC2::VPC": {{ARN: "arn:aws:ec2:us-east-1:111111111111:vpc/vpc-a"}}},
 	}}
 
 	if _, ok := cache.ForCFN("us-west-2", "AWS::EC2::VPC"); ok {
-		t.Error("unknown region: ok=true, want false")
+		t.Error("unknown region: ok=true, want false (RGT didn't run there, caller must fall back)")
 	}
-	if _, ok := cache.ForCFN("us-east-1", "AWS::EC2::Subnet"); ok {
-		t.Error("unknown cfnType in known region: ok=true, want false")
+}
+
+func TestRGTCache_ForCFN_KnownRegionEmptyForCFN_AuthoritativeZero(t *testing.T) {
+	t.Parallel()
+	// RGT ran for us-east-1 and saw one VPC but zero Subnets. The
+	// Subnet query must return ok=true with an empty slice — the
+	// caller treats that as "authoritatively zero of these," not as
+	// "miss, fall back to ListResources." Many CC types (e.g.
+	// AWS::EKS::PodIdentityAssociation) reject ListResources without
+	// a parent ResourceModel, so the fallback would 400.
+	cache := &rgtCache{byRegionAndType: map[string]map[string][]arnInfo{
+		"us-east-1": {"AWS::EC2::VPC": {{ARN: "arn:aws:ec2:us-east-1:111111111111:vpc/vpc-a"}}},
+	}}
+	infos, ok := cache.ForCFN("us-east-1", "AWS::EC2::Subnet")
+	if !ok {
+		t.Fatal("known region + unknown cfnType: ok=false, want true (authoritative zero)")
+	}
+	if len(infos) != 0 {
+		t.Errorf("infos=%v, want empty slice", infos)
 	}
 }
 
@@ -394,11 +492,15 @@ func TestRGTCache_NilReceiver_ReturnsFalse(t *testing.T) {
 	}
 }
 
-func TestRGTPrefetcher_EmptyResults_NoBucketsCreated(t *testing.T) {
+func TestRGTPrefetcher_EmptyRegion_RecordedAsAuthoritativeZero(t *testing.T) {
 	t.Parallel()
-	// One region returns zero resources — the prefetcher must NOT add
-	// an empty map for that region (downstream ForCFN expects "no
-	// entry" not "empty entry").
+	// A region whose RGT call succeeded with zero results MUST appear
+	// in the cache as an empty map. Downstream ForCFN returns (nil, true)
+	// for that region+any-cfnType, signalling "authoritative zero, do
+	// NOT fall back to ListResources." Stripping the key would make
+	// ForCFN return ok=false → caller falls back to ListResources →
+	// parent-scoped types like AWS::EKS::PodIdentityAssociation reject
+	// the call with InvalidRequestException 400.
 	east := &fakeRGTClient{pages: [][]rgttypes.ResourceTagMapping{
 		{mapping("arn:aws:ec2:us-east-1:111111111111:vpc/vpc-aaa", "p")},
 	}}
@@ -413,8 +515,56 @@ func TestRGTPrefetcher_EmptyResults_NoBucketsCreated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Prefetch: %v", err)
 	}
-	if _, ok := cache.byRegionAndType["us-west-2"]; ok {
-		t.Error("empty region us-west-2 should not appear as a key in the cache")
+	byType, ok := cache.byRegionAndType["us-west-2"]
+	if !ok {
+		t.Fatal("empty region us-west-2 must appear in cache (authoritative zero signal)")
+	}
+	if len(byType) != 0 {
+		t.Errorf("us-west-2 byType=%v, want empty map", byType)
+	}
+	// ForCFN through the public path must agree.
+	infos, ok := cache.ForCFN("us-west-2", "AWS::EKS::PodIdentityAssociation")
+	if !ok {
+		t.Error("ForCFN on empty-but-succeeded region: ok=false, want true")
+	}
+	if len(infos) != 0 {
+		t.Errorf("ForCFN infos=%v, want empty slice", infos)
+	}
+}
+
+func TestRGTCache_ForGlobalCFN_NoRegions_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+	// Empty-but-non-nil byRegionAndType means no region's RGT call
+	// succeeded (or none was attempted). ForGlobalCFN MUST return
+	// ok=false so the discoverer falls back to ListResources for
+	// global types. The post-fix code guards on len(byRegionAndType)==0
+	// at rgt_prefetcher.go; without this test, a regression that
+	// removes the guard would silently flip "no region succeeded" into
+	// "authoritative zero" and suppress the only viable enumeration
+	// path for global types.
+	cache := &rgtCache{byRegionAndType: map[string]map[string][]arnInfo{}}
+	if _, ok := cache.ForGlobalCFN("AWS::IAM::Role"); ok {
+		t.Error("empty-but-non-nil byRegionAndType: ok=true, want false (no region succeeded → fall back)")
+	}
+}
+
+func TestRGTCache_ForGlobalCFN_AuthoritativeEmptyWhenAnyRegionRan(t *testing.T) {
+	t.Parallel()
+	// At least one region's RGT call succeeded, but it found zero
+	// global resources of this type. ForGlobalCFN must return
+	// ok=true with an empty slice — same authoritative-zero contract
+	// as ForCFN. Otherwise global parent-scoped types would 400 on
+	// the ListResources fallback when the account legitimately has
+	// none of them.
+	cache := &rgtCache{byRegionAndType: map[string]map[string][]arnInfo{
+		"us-east-1": {"AWS::EC2::VPC": {{ARN: "arn:aws:ec2:us-east-1:111111111111:vpc/vpc-a"}}},
+	}}
+	infos, ok := cache.ForGlobalCFN("AWS::IAM::Role")
+	if !ok {
+		t.Fatal("at-least-one-region-ran + zero global hits: ok=false, want true")
+	}
+	if len(infos) != 0 {
+		t.Errorf("infos=%v, want empty slice", infos)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two regressions surfaced by post-merge Bundle 13c (#407) live smoke against the test account 141812438321 / project io-f-v6e-hzw-zt.

- **rgtCache authoritative-zero contract**: `ForCFN`/`ForGlobalCFN` now distinguish "RGT didn't run for this region" (`ok=false` → fall back to `ListResources`) from "RGT ran and saw zero of this cfnType" (`ok=true`, empty slice → emit zero, no fallback). The pre-fix conflation broke parent-scoped Cloud Control types whose `ListResources` requires a `ResourceModel` (e.g. `AWS::EKS::PodIdentityAssociation` requires `ClusterName` and 400s without it).
- **ApiGatewayV2 Stage warn suppression**: explicit known-skip rule (`cfnType=""`, matchExtra detecting `/stages/`) so RGT silently drops Stage ARNs instead of emitting a "no arnRule for apigateway/apis" warn on every run. Stage is hand-rolled because Cloud Control READ is `UnsupportedActionException` for it — so the lookup miss is by design.

## Live smoke (pre-fix vs post-fix)

| Metric | Pre-fix | Post-fix |
|--------|---------|----------|
| Exit code | 1 | 0 |
| Resources discovered | failed mid-run | 28 |
| TFTypes round-tripped | n/a | 23 |
| EKS pod identity result | 400 InvalidRequestException | authoritative zero |
| RGT warns | 1 (apigateway/apis) | 0 |
| Error events | 1 | 0 |

## Test plan

- [x] `go test ./cmd/insideout-import/awsdiscover/... -count=1 -race` → 290 passed
- [x] `go test ./... -count=1 -race` → 4139 passed
- [x] `go vet ./...` clean
- [x] `terraform fmt -check -recursive` clean
- [x] Static lints: project-tag, project-label, sensitive-for-each, foreach-unknown-keys → all PASS
- [x] Live discover against 141812438321 / io-f-v6e-hzw-zt: exit 0, 28 resources across 23 TFTypes, zero warns

## Review notes

qa-professor surfaced 1 CRITICAL + 4 MAJOR test gaps in the first cut; all addressed before push:

- **CRITICAL** — added `TestCloudControlDiscover_IsGlobal_CacheRanEmptyForCFN_AuthoritativeZero` so the IsGlobal arm of `Discover` is exercised end-to-end (was only covered at the cache accessor level)
- **MAJOR** — added `TestCloudControlDiscover_MixedRegionsKnownEmptyVsUnknownFallback` (one cache hit + one fallback in a single Discover, asserting `listCalls == 1` not just "some fallback")
- **MAJOR** — added `TestRGTCache_ForGlobalCFN_NoRegions_ReturnsFalse` to pin the empty-but-non-nil `byRegionAndType` guard
- **MAJOR** — extended `TestRGTPrefetcher_KnownSkipRule_NoWarnNoBucket` with a genuinely unmapped ARN + exact-count warn assertion so known-skip independence from the unmapped-pair aggregator is pinned
- Test rename: `KnownRegionUnknownCFN_AuthoritativeEmpty` → `KnownRegionEmptyForCFN_AuthoritativeZero` (matches discoverer-level naming)

Closes #408