### PR TITLE
Bundle 14b: AWS discovery +5 types via ParentLister activation + SDKLister branch

### DIFF
--- a/cmd/insideout-import/awsdiscover/arn_rules.go
+++ b/cmd/insideout-import/awsdiscover/arn_rules.go
@@ -234,6 +234,25 @@ var arnRules = []arnRule{
 	{matchService: "cognito-idp", matchResourceType: "userpool",
 		cfnType: "AWS::Cognito::UserPool", identifierFn: identityResourceID},
 
+	// ACM Certificate — Cloud Control primary identifier is the full ARN.
+	{matchService: "acm", matchResourceType: "certificate",
+		cfnType: "AWS::CertificateManager::Certificate", identifierFn: identityFullARN},
+
+	// WAFv2 WebACL — ARN form is `arn:aws:wafv2:<region>:<acct>:<scope>/webacl/<name>/<id>`.
+	// parseARN sees resourceType=<scope> (lowercase: `regional` or `global`),
+	// resourceID=`webacl/<name>/<id>`. Cloud Control primary identifier is
+	// `<Name>|<Id>|<Scope>` with title-case Scope (`REGIONAL` or `CLOUDFRONT` —
+	// the ARN's `global` maps to CFN's `CLOUDFRONT`).
+	{matchService: "wafv2", matchResourceType: "regional",
+		cfnType: "AWS::WAFv2::WebACL", identifierFn: wafv2WebACLIdentifier("REGIONAL")},
+	{matchService: "wafv2", matchResourceType: "global",
+		cfnType: "AWS::WAFv2::WebACL", identifierFn: wafv2WebACLIdentifier("CLOUDFRONT")},
+
+	// Note: aws_cognito_user_pool_client and aws_lambda_alias are
+	// reached via ParentLister, not RGT. Both are untaggable
+	// (SkipProjectTagFilter=true) so the cache short-circuit is
+	// bypassed; adding ARN rules here would never fire.
+
 	// SSM Parameter — ARN form is `arn:aws:ssm:<region>:<account>:parameter/path/to/name`.
 	// Cloud Control's identifier is the full parameter name including the
 	// leading `/` (e.g. `/path/to/name`); parseARN strips the leading `/`
@@ -277,6 +296,21 @@ func identityResourceID(p parsedARN) string { return p.resourceID }
 // identityFullARN is the common identifierFn for types whose Cloud Control
 // primary identifier is the entire ARN string.
 func identityFullARN(p parsedARN) string { return p.full }
+
+// wafv2WebACLIdentifier builds the Cloud Control primary identifier
+// for AWS::WAFv2::WebACL from a parsed ARN. The CC identifier is
+// `<Name>|<Id>|<Scope>` (title-case Scope: REGIONAL or CLOUDFRONT) but
+// the ARN's resourceID is `webacl/<name>/<id>` (the scope lives in
+// resourceType, lowercase). Callers pass the title-case scope to map.
+func wafv2WebACLIdentifier(scope string) func(parsedARN) string {
+	return func(p parsedARN) string {
+		parts := strings.SplitN(p.resourceID, "/", 3)
+		if len(parts) != 3 {
+			return p.resourceID
+		}
+		return parts[1] + "|" + parts[2] + "|" + scope
+	}
+}
 
 // lookupRule returns the first arnRule that matches the parsed ARN, or
 // (zero, false) if no rule applies. Callers treat "no rule" as a soft

--- a/cmd/insideout-import/awsdiscover/arn_rules_test.go
+++ b/cmd/insideout-import/awsdiscover/arn_rules_test.go
@@ -243,6 +243,39 @@ func TestParseARN(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			name: "acm_certificate",
+			arn:  "arn:aws:acm:us-east-1:111111111111:certificate/abc-12345-6789-def0",
+			want: parsedARN{
+				full: "arn:aws:acm:us-east-1:111111111111:certificate/abc-12345-6789-def0", partition: "aws",
+				service: "acm", region: "us-east-1", accountID: "111111111111",
+				resourceType: "certificate", resourceID: "abc-12345-6789-def0",
+			},
+			wantOK: true,
+		},
+		{
+			// WAFv2 ARN encodes the scope (regional|global) as the first
+			// segment of the resource portion; parseARN sees it as
+			// resourceType=<scope>, resourceID=`webacl/<name>/<id>`.
+			name: "wafv2_webacl_regional",
+			arn:  "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/my-acl/abc-12345",
+			want: parsedARN{
+				full: "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/my-acl/abc-12345", partition: "aws",
+				service: "wafv2", region: "us-east-1", accountID: "111111111111",
+				resourceType: "regional", resourceID: "webacl/my-acl/abc-12345",
+			},
+			wantOK: true,
+		},
+		{
+			name: "wafv2_webacl_global",
+			arn:  "arn:aws:wafv2:us-east-1:111111111111:global/webacl/my-acl/abc-12345",
+			want: parsedARN{
+				full: "arn:aws:wafv2:us-east-1:111111111111:global/webacl/my-acl/abc-12345", partition: "aws",
+				service: "wafv2", region: "us-east-1", accountID: "111111111111",
+				resourceType: "global", resourceID: "webacl/my-acl/abc-12345",
+			},
+			wantOK: true,
+		},
+		{
 			name:   "malformed_not_arn",
 			arn:    "not-an-arn",
 			wantOK: false,
@@ -401,6 +434,24 @@ func TestLookupRule(t *testing.T) {
 		// Cognito
 		{name: "cognito_userpool", arn: "arn:aws:cognito-idp:us-east-1:111111111111:userpool/us-east-1_AbCdE",
 			wantCFN: "AWS::Cognito::UserPool", wantIdent: "us-east-1_AbCdE"},
+
+		// ACM — Cloud Control primary identifier is the full ARN.
+		{name: "acm_certificate_full_arn",
+			arn:     "arn:aws:acm:us-east-1:111111111111:certificate/abc-12345-6789-def0",
+			wantCFN: "AWS::CertificateManager::Certificate",
+			wantIdent: "arn:aws:acm:us-east-1:111111111111:certificate/abc-12345-6789-def0"},
+
+		// WAFv2 — ARN scope (regional/global) maps to CFN Scope
+		// (REGIONAL/CLOUDFRONT); identifier rebuilds as
+		// `<Name>|<Id>|<Scope>`.
+		{name: "wafv2_webacl_regional_compound_rewrite",
+			arn:       "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/my-acl/abc-12345",
+			wantCFN:   "AWS::WAFv2::WebACL",
+			wantIdent: "my-acl|abc-12345|REGIONAL"},
+		{name: "wafv2_webacl_global_compound_rewrite",
+			arn:       "arn:aws:wafv2:us-east-1:111111111111:global/webacl/my-acl/abc-12345",
+			wantCFN:   "AWS::WAFv2::WebACL",
+			wantIdent: "my-acl|abc-12345|CLOUDFRONT"},
 
 		// SSM Parameter — leading `/` re-prepended onto resourceID
 		{name: "ssm_parameter_single_segment",

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
@@ -75,7 +75,20 @@ type cloudControlClient interface {
 //     is parent-scoped on UserPoolId). The returned slice contains one
 //     ResourceModel JSON-string per parent; the discoverer threads it
 //     through ListResourcesInput.ResourceModel. Returns nil for non-
-//     parent-scoped types.
+//     parent-scoped types. Receives an aws.Config so the lister can
+//     construct typed SDK clients to enumerate parents
+//     (cognito-idp:ListUserPools, lambda:ListFunctions, …).
+//     Mutually exclusive with SDKLister; setting both panics at
+//     registration time.
+//   - SDKLister: optional. When set, the discoverer bypasses Cloud
+//     Control ListResources entirely and seeds the per-identifier
+//     GetResource fan-out with the identifiers this function returns.
+//     Use for types where CC GetResource is supported but CC
+//     ListResources returns UnsupportedActionException (e.g.
+//     AWS::Cognito::UserPoolDomain via cognito-idp:DescribeUserPool;
+//     AWS::CertificateManager::Certificate via acm:ListCertificates).
+//     Mutually exclusive with ParentLister; setting both panics at
+//     registration time.
 //   - SkipProjectTagFilter: when true, the discoverer (a) bypasses the
 //     RGT-cache short-circuit and always drives through ListResources,
 //     and (b) bypasses the post-fetch `args.Project` Project-tag filter
@@ -106,7 +119,8 @@ type cloudControlConfig struct {
 	NameHintFromProperties  func(identifier string, props map[string]any) string
 	NativeIDsFromProperties func(identifier string, props map[string]any) map[string]string
 	TagsFromProperties      func(props map[string]any) map[string]string
-	ParentLister            func(ctx context.Context, client cloudControlClient, args DiscoverArgs) ([]string, error)
+	ParentLister            func(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error)
+	SDKLister               func(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error)
 }
 
 // cloudControlDiscoverer is the generic per-type Discoverer that routes
@@ -122,16 +136,26 @@ type cloudControlConfig struct {
 // non-CAI fanout posture.
 type cloudControlDiscoverer struct {
 	cfg            cloudControlConfig
+	awsCfg         aws.Config
 	new            func(region string) cloudControlClient
 	maxConcurrency int
 }
 
 func newCloudControlDiscoverer(cfg cloudControlConfig, awsCfg aws.Config, maxConcurrency int) *cloudControlDiscoverer {
+	if cfg.SDKLister != nil && cfg.ParentLister != nil {
+		// Programming error at registration time, not a runtime
+		// failure: a registrant that wires both fields would silently
+		// pick one branch over the other and quietly skip the other's
+		// enumeration. Panic so the regression surfaces in any test
+		// run that constructs the discoverer.
+		panic(fmt.Sprintf("cloudControlConfig %s: SDKLister and ParentLister are mutually exclusive", cfg.TFType))
+	}
 	if maxConcurrency <= 0 {
 		maxConcurrency = DefaultMaxConcurrency
 	}
 	return &cloudControlDiscoverer{
-		cfg: cfg,
+		cfg:    cfg,
+		awsCfg: awsCfg,
 		new: func(region string) cloudControlClient {
 			return cloudcontrol.NewFromConfig(awsCfg, func(o *cloudcontrol.Options) {
 				if region != "" {
@@ -230,44 +254,68 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 		}
 
 		if !cacheUsed {
-			// Per-parent enumeration: ParentLister returns N
-			// parent-scoped resource-model JSON strings; for
-			// non-parent types it returns nil and we issue one
-			// ListResources without a ResourceModel.
-			parentModels := []string{""}
-			if d.cfg.ParentLister != nil {
-				models, err := d.cfg.ParentLister(ctx, client, args)
+			if d.cfg.SDKLister != nil {
+				// Native-SDK enumeration: types whose CC ListResources
+				// returns UnsupportedActionException despite CC
+				// GetResource being supported (e.g.
+				// AWS::Cognito::UserPoolDomain via
+				// cognito-idp:DescribeUserPool walking;
+				// AWS::CertificateManager::Certificate via
+				// acm:ListCertificates). SDKLister returns primary
+				// identifiers directly; the standard GetResource
+				// fan-out + extractor pipeline runs unchanged.
+				ids, err := d.cfg.SDKLister(ctx, d.awsCfg, region, args)
 				if err != nil {
 					args.Emitter.ServiceFinish(d.cfg.Slug, region, regionCount, time.Since(regionStart))
-					return nil, fmt.Errorf("%s parent enumeration (region=%s): %w", d.cfg.Slug, region, err)
+					return nil, fmt.Errorf("%s SDK enumeration (region=%s): %w", d.cfg.Slug, region, err)
 				}
-				parentModels = models
-				if len(parentModels) == 0 {
+				if len(ids) == 0 {
 					args.Emitter.ServiceFinish(d.cfg.Slug, region, regionCount, time.Since(regionStart))
 					continue
 				}
-			}
-
-			for _, parentModel := range parentModels {
-				input := &cloudcontrol.ListResourcesInput{
-					TypeName: aws.String(d.cfg.CloudFormationType),
+				for _, id := range ids {
+					refs = append(refs, itemRef{identifier: id})
 				}
-				if parentModel != "" {
-					input.ResourceModel = aws.String(parentModel)
-				}
-				paginator := cloudcontrol.NewListResourcesPaginator(client, input)
-				for paginator.HasMorePages() {
-					page, err := paginator.NextPage(ctx)
+			} else {
+				// Per-parent enumeration: ParentLister returns N
+				// parent-scoped resource-model JSON strings; for
+				// non-parent types it returns nil and we issue one
+				// ListResources without a ResourceModel.
+				parentModels := []string{""}
+				if d.cfg.ParentLister != nil {
+					models, err := d.cfg.ParentLister(ctx, d.awsCfg, region, args)
 					if err != nil {
 						args.Emitter.ServiceFinish(d.cfg.Slug, region, regionCount, time.Since(regionStart))
-						return nil, fmt.Errorf("ListResources %s (region=%s): %w", d.cfg.CloudFormationType, region, err)
+						return nil, fmt.Errorf("%s parent enumeration (region=%s): %w", d.cfg.Slug, region, err)
 					}
-					for _, desc := range page.ResourceDescriptions {
-						refs = append(refs, itemRef{
-							identifier:  aws.ToString(desc.Identifier),
-							parentModel: parentModel,
-							parentLabel: parentLabelFromModel(parentModel),
-						})
+					parentModels = models
+					if len(parentModels) == 0 {
+						args.Emitter.ServiceFinish(d.cfg.Slug, region, regionCount, time.Since(regionStart))
+						continue
+					}
+				}
+
+				for _, parentModel := range parentModels {
+					input := &cloudcontrol.ListResourcesInput{
+						TypeName: aws.String(d.cfg.CloudFormationType),
+					}
+					if parentModel != "" {
+						input.ResourceModel = aws.String(parentModel)
+					}
+					paginator := cloudcontrol.NewListResourcesPaginator(client, input)
+					for paginator.HasMorePages() {
+						page, err := paginator.NextPage(ctx)
+						if err != nil {
+							args.Emitter.ServiceFinish(d.cfg.Slug, region, regionCount, time.Since(regionStart))
+							return nil, fmt.Errorf("ListResources %s (region=%s): %w", d.cfg.CloudFormationType, region, err)
+						}
+						for _, desc := range page.ResourceDescriptions {
+							refs = append(refs, itemRef{
+								identifier:  aws.ToString(desc.Identifier),
+								parentModel: parentModel,
+								parentLabel: parentLabelFromModel(parentModel),
+							})
+						}
 					}
 				}
 			}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	cctypes "github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	smithy "github.com/aws/smithy-go"
@@ -548,7 +549,7 @@ func TestCloudControlDiscover_ParentListerFansOutPerParent(t *testing.T) {
 		}
 	}
 	cfg := testConfig()
-	cfg.ParentLister = func(_ context.Context, _ cloudControlClient, _ DiscoverArgs) ([]string, error) {
+	cfg.ParentLister = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
 		return []string{`{"UserPoolId":"A"}`, `{"UserPoolId":"B"}`}, nil
 	}
 	d := &cloudControlDiscoverer{
@@ -1085,7 +1086,7 @@ func TestCloudControlDiscover_NativeIDsFromPropertiesPropagates(t *testing.T) {
 func TestCloudControlDiscover_ParentListerReturnsEmptyEmitsCleanFinish(t *testing.T) {
 	t.Parallel()
 	cfg := testConfig()
-	cfg.ParentLister = func(_ context.Context, _ cloudControlClient, _ DiscoverArgs) ([]string, error) {
+	cfg.ParentLister = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
 		return []string{}, nil
 	}
 	d := &cloudControlDiscoverer{
@@ -1130,7 +1131,7 @@ func TestCloudControlDiscover_ParentListerReturnsEmptyEmitsCleanFinish(t *testin
 func TestCloudControlDiscover_ParentListerErrorEmitsFinishAndPropagates(t *testing.T) {
 	t.Parallel()
 	cfg := testConfig()
-	cfg.ParentLister = func(_ context.Context, _ cloudControlClient, _ DiscoverArgs) ([]string, error) {
+	cfg.ParentLister = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
 		return nil, errCCSeed
 	}
 	d := &cloudControlDiscoverer{
@@ -1622,4 +1623,184 @@ func mapEqual(a, b map[string]string) bool {
 		}
 	}
 	return true
+}
+
+// TestCloudControlDiscover_SDKListerBypassesListResources pins the
+// new SDKLister code path: when set, ListResources MUST NOT be called
+// and the per-identifier GetResource fan-out runs against the
+// SDKLister-emitted set. The discoverer must call SDKLister exactly
+// once per region (a regression that double-invokes it would do an
+// extra round-trip).
+func TestCloudControlDiscover_SDKListerBypassesListResources(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{
+		// listPages intentionally non-empty — if the discoverer
+		// erroneously fell through to ListResources, it'd pick this
+		// up and the assertion would catch it.
+		listPages: []cloudcontrol.ListResourcesOutput{
+			listPage("", "should-not-be-listed"),
+		},
+		propsByIdentifier: map[string]map[string]any{
+			"id-a":                {"Tags": map[string]any{"Project": "io-foo"}},
+			"id-b":                {"Tags": map[string]any{"Project": "io-foo"}},
+			"should-not-be-listed": {"Tags": map[string]any{}},
+		},
+	}
+	cfg := testConfig()
+	var sdkCalls int
+	cfg.SDKLister = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		sdkCalls++
+		return []string{"id-a", "id-b"}, nil
+	}
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sdkCalls != 1 {
+		t.Errorf("SDKLister calls: got %d, want 1 (per-region invocation)", sdkCalls)
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListResources calls: got %d, want 0 (SDKLister branch must bypass CC ListResources)", fake.listCalls)
+	}
+	if len(got) != 2 {
+		t.Fatalf("emit count: got %d, want 2 (both SDKLister-emitted IDs must surface)", len(got))
+	}
+	names := []string{got[0].Identity.ImportID, got[1].Identity.ImportID}
+	sort.Strings(names)
+	if names[0] != "id-a" || names[1] != "id-b" {
+		t.Errorf("ImportIDs: got %v, want [id-a id-b]", names)
+	}
+}
+
+// TestCloudControlDiscover_SDKListerErrorEmitsFinishAndPropagates is
+// the SDKLister twin of …ParentListerErrorEmitsFinishAndPropagates: an
+// SDKLister error must close the ServiceFinish bracket (Count=0) and
+// propagate via %w so errors.Is unwraps to the sentinel.
+func TestCloudControlDiscover_SDKListerErrorEmitsFinishAndPropagates(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.SDKLister = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		return nil, errCCSeed
+	}
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return &fakeCloudControlClient{} },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	rec := &recordingEmitter{}
+	_, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	})
+	if err == nil {
+		t.Fatal("expected error from SDKLister failure")
+	}
+	if !errors.Is(err, errCCSeed) {
+		t.Errorf("err=%v, want errors.Is(err, errCCSeed) (error must wrap sentinel via %%w)", err)
+	}
+	var finishes int
+	for _, e := range rec.snapshot() {
+		if e.Kind == "service_finish" {
+			finishes++
+			if e.Count != 0 {
+				t.Errorf("service_finish.Count=%d, want 0 (error path must close bracket with zero emits)", e.Count)
+			}
+		}
+	}
+	if finishes != 1 {
+		t.Errorf("service_finish count=%d, want 1 (SDKLister error path must still close the bracket)", finishes)
+	}
+}
+
+// TestCloudControlDiscover_SDKListerEmptyResultEmitsCleanFinish pins
+// the empty-region early-exit branch on the SDKLister path: when
+// SDKLister returns []string{} (no identifiers in this region), the
+// discoverer emits ServiceFinish(Count=0) and continues to the next
+// region rather than falling through to the GetResource fan-out (which
+// would do nothing) or erroring.
+func TestCloudControlDiscover_SDKListerEmptyResultEmitsCleanFinish(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.SDKLister = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		return []string{}, nil
+	}
+	fake := &fakeCloudControlClient{}
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	})
+	if err != nil {
+		t.Fatalf("empty SDKLister result must succeed; got err=%v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("emit count: got %d, want 0", len(got))
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListResources calls: got %d, want 0 (empty SDKLister result must not fall through to ListResources)", fake.listCalls)
+	}
+	var finishes int
+	for _, e := range rec.snapshot() {
+		if e.Kind == "service_finish" {
+			finishes++
+			if e.Count != 0 {
+				t.Errorf("service_finish.Count=%d, want 0", e.Count)
+			}
+		}
+	}
+	if finishes != 1 {
+		t.Errorf("service_finish count=%d, want 1", finishes)
+	}
+}
+
+// TestNewCloudControlDiscoverer_PanicsOnSDKListerAndParentListerBothSet
+// pins the mutual-exclusion guard. Setting both fields is a
+// registration-time programming error that would silently pick one
+// branch over the other in production. The panic at construction time
+// surfaces the regression in any test run that builds the discoverer.
+func TestNewCloudControlDiscoverer_PanicsOnSDKListerAndParentListerBothSet(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.ParentLister = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		return nil, nil
+	}
+	cfg.SDKLister = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		return nil, nil
+	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic; got nil")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("panic value is not string: %T %v", r, r)
+		}
+		// Pin the message contains the TFType + the contract keywords so
+		// a regression that swaps panic-vs-error or drops the type label
+		// is caught.
+		if !strings.Contains(msg, "aws_test_resource") {
+			t.Errorf("panic message missing TFType: %q", msg)
+		}
+		if !strings.Contains(msg, "mutually exclusive") {
+			t.Errorf("panic message missing 'mutually exclusive': %q", msg)
+		}
+	}()
+	_ = newCloudControlDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
 }

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
@@ -1636,14 +1636,18 @@ func TestCloudControlDiscover_SDKListerBypassesListResources(t *testing.T) {
 	fake := &fakeCloudControlClient{
 		// listPages intentionally non-empty — if the discoverer
 		// erroneously fell through to ListResources, it'd pick this
-		// up and the assertion would catch it.
+		// up and surface as a 3rd emit. Project-matching tags on the
+		// stray ensure the post-fetch Project filter wouldn't mask
+		// the regression (double-pinning the bypass contract: the
+		// listCalls counter catches the round-trip, the emit count
+		// catches the data leak).
 		listPages: []cloudcontrol.ListResourcesOutput{
 			listPage("", "should-not-be-listed"),
 		},
 		propsByIdentifier: map[string]map[string]any{
-			"id-a":                {"Tags": map[string]any{"Project": "io-foo"}},
-			"id-b":                {"Tags": map[string]any{"Project": "io-foo"}},
-			"should-not-be-listed": {"Tags": map[string]any{}},
+			"id-a":                 {"Tags": map[string]any{"Project": "io-foo"}},
+			"id-b":                 {"Tags": map[string]any{"Project": "io-foo"}},
+			"should-not-be-listed": {"Tags": map[string]any{"Project": "io-foo"}},
 		},
 	}
 	cfg := testConfig()

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -446,6 +446,265 @@ func TestCloudControlDiscover_SkipProjectTagFilter_BypassesRGTCache(t *testing.T
 	}
 }
 
+// TestCognitoUserPoolClientConfig pins the per-type extractors for
+// aws_cognito_user_pool_client: compound CC identifier
+// `<UserPoolId>|<ClientId>` rewrites to TF import format
+// `<UserPoolId>/<ClientId>`, NameHint reads ClientName, NativeIDs
+// split into a structured map, and Tags is the non-nil empty map per
+// the #255 contract (CFN schema has no Tags property on this type).
+func TestCognitoUserPoolClientConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_cognito_user_pool_client")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_cognito_user_pool_client: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.CloudFormationType != "AWS::Cognito::UserPoolClient" {
+		t.Errorf("CloudFormationType=%q, want AWS::Cognito::UserPoolClient", cfg.CloudFormationType)
+	}
+	if cfg.ParentLister == nil {
+		t.Fatal("ParentLister must be set; CC ListResources is parent-scoped on UserPoolId")
+	}
+	if cfg.SDKLister != nil {
+		t.Error("SDKLister must be nil (ParentLister-scoped, not SDK-scoped)")
+	}
+
+	id := "us-east-1_AbCdE|3ho4ek12345678909nh3fmhpko"
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != "us-east-1_AbCdE/3ho4ek12345678909nh3fmhpko" {
+		t.Errorf("ImportID rewrite |→/: got %q, want %q", got, "us-east-1_AbCdE/3ho4ek12345678909nh3fmhpko")
+	}
+
+	props := map[string]any{"ClientName": "my-client"}
+	if got := cfg.NameHintFromProperties(id, props); got != "my-client" {
+		t.Errorf("NameHint: got %q, want my-client", got)
+	}
+	if got := cfg.NameHintFromProperties(id, map[string]any{}); got != id {
+		t.Errorf("NameHint fallback: got %q, want identifier", got)
+	}
+
+	native := cfg.NativeIDsFromProperties(id, nil)
+	want := map[string]string{"user_pool_id": "us-east-1_AbCdE", "client_id": "3ho4ek12345678909nh3fmhpko"}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v (exact map equality)", native, want)
+	}
+	// Defensive: malformed identifier (no `|`) — NativeIDs must
+	// return nil so downstream doesn't render half-stitched keys.
+	if got := cfg.NativeIDsFromProperties("orphan", nil); got != nil {
+		t.Errorf("NativeIDs malformed-id: got %+v, want nil", got)
+	}
+
+	tags := cfg.TagsFromProperties(map[string]any{"Tags": []any{
+		map[string]any{"Key": "env", "Value": "prod"},
+	}})
+	if tags == nil {
+		t.Fatal("Tags must be non-nil empty map per #255 contract")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %v, want empty map (untaggable)", tags)
+	}
+}
+
+// TestLambdaAliasConfig pins the per-type extractors for
+// aws_lambda_alias: compound CC identifier `<FunctionName>|<AliasName>`
+// rewrites to TF import format `<FunctionName>/<AliasName>`, NameHint
+// reads Name, NativeIDs stamp function_name+name+arn, Tags is the
+// non-nil empty map.
+func TestLambdaAliasConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_lambda_alias")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_lambda_alias: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.ParentLister == nil {
+		t.Fatal("ParentLister must be set; CC ListResources is parent-scoped on FunctionName")
+	}
+	if cfg.SDKLister != nil {
+		t.Error("SDKLister must be nil")
+	}
+
+	id := "my-fn|PROD"
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != "my-fn/PROD" {
+		t.Errorf("ImportID rewrite |→/: got %q, want my-fn/PROD", got)
+	}
+
+	props := map[string]any{
+		"Name":     "PROD",
+		"AliasArn": "arn:aws:lambda:us-east-1:111111111111:function:my-fn:PROD",
+	}
+	if got := cfg.NameHintFromProperties(id, props); got != "PROD" {
+		t.Errorf("NameHint: got %q, want PROD", got)
+	}
+
+	native := cfg.NativeIDsFromProperties(id, props)
+	want := map[string]string{
+		"function_name": "my-fn",
+		"name":          "PROD",
+		"arn":           "arn:aws:lambda:us-east-1:111111111111:function:my-fn:PROD",
+	}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v (exact map equality)", native, want)
+	}
+
+	// Tags: always empty for the aliases type.
+	tags := cfg.TagsFromProperties(map[string]any{"AliasArn": "..."})
+	if tags == nil {
+		t.Fatal("Tags must be non-nil empty map")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %v, want empty", tags)
+	}
+}
+
+// TestWAFv2WebACLConfig pins the per-type extractors for
+// aws_wafv2_web_acl: compound CC identifier `<Name>|<Id>|<Scope>`
+// rewrites to TF import format `<Id>/<Name>/<Scope>` (note the field
+// reorder — Name and Id swap), NameHint reads Name, NativeIDs stamps
+// the Arn, Tags is the standard Key/Value list shape.
+func TestWAFv2WebACLConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_wafv2_web_acl")
+	if cfg.SkipProjectTagFilter {
+		t.Error("aws_wafv2_web_acl: SkipProjectTagFilter must be false (WAFv2 ACLs are taggable; --project must filter on them)")
+	}
+	if cfg.ParentLister == nil {
+		t.Fatal("ParentLister must be set; CC ListResources is parent-scoped on Scope")
+	}
+
+	// Identifier ordering: CC primary identifier puts Name first,
+	// then Id, then Scope. TF import format reorders to <Id>/<Name>/<Scope>.
+	id := "my-acl|abc-12345|REGIONAL"
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != "abc-12345/my-acl/REGIONAL" {
+		t.Errorf("ImportID rewrite (Name|Id|Scope → Id/Name/Scope): got %q, want %q",
+			got, "abc-12345/my-acl/REGIONAL")
+	}
+	// Malformed identifier passthrough.
+	if got := cfg.ImportIDFromIdentifier("malformed", nil); got != "malformed" {
+		t.Errorf("ImportID malformed passthrough: got %q, want malformed", got)
+	}
+
+	props := map[string]any{
+		"Name": "my-acl",
+		"Arn":  "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/my-acl/abc-12345",
+		"Tags": []any{
+			map[string]any{"Key": "env", "Value": "prod"},
+		},
+	}
+	if got := cfg.NameHintFromProperties(id, props); got != "my-acl" {
+		t.Errorf("NameHint: got %q, want my-acl", got)
+	}
+	native := cfg.NativeIDsFromProperties(id, props)
+	wantNative := map[string]string{"arn": "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/my-acl/abc-12345"}
+	if !reflect.DeepEqual(native, wantNative) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, wantNative)
+	}
+	tags := cfg.TagsFromProperties(props)
+	wantTags := map[string]string{"env": "prod"}
+	if !reflect.DeepEqual(tags, wantTags) {
+		t.Errorf("Tags: got %+v, want %+v", tags, wantTags)
+	}
+}
+
+// TestCognitoUserPoolDomainConfig pins the per-type extractors for
+// aws_cognito_user_pool_domain: passthrough CC identifier (domain
+// string), domain-as-NameHint, structured NativeIDs with optional
+// UserPoolId, empty Tags, and SDKLister-only enumeration (CC
+// ListResources is unsupported).
+func TestCognitoUserPoolDomainConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_cognito_user_pool_domain")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_cognito_user_pool_domain: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.SDKLister == nil {
+		t.Fatal("SDKLister must be set; CC ListResources returns UnsupportedActionException for this type")
+	}
+	if cfg.ParentLister != nil {
+		t.Error("ParentLister must be nil (mutually exclusive with SDKLister)")
+	}
+
+	id := "my-app-auth"
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != id {
+		t.Errorf("ImportID passthrough: got %q, want %q", got, id)
+	}
+	if got := cfg.NameHintFromProperties(id, nil); got != id {
+		t.Errorf("NameHint: got %q, want %q (domain string)", got, id)
+	}
+
+	native := cfg.NativeIDsFromProperties(id, map[string]any{"UserPoolId": "us-east-1_AbCdE"})
+	want := map[string]string{"domain": id, "user_pool_id": "us-east-1_AbCdE"}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	// Defensive: NativeIDs still emits the domain key when UserPoolId
+	// is absent from the properties payload (so downstream readers
+	// always see the canonical domain string).
+	nativeNoPool := cfg.NativeIDsFromProperties(id, map[string]any{})
+	wantNoPool := map[string]string{"domain": id}
+	if !reflect.DeepEqual(nativeNoPool, wantNoPool) {
+		t.Errorf("NativeIDs no-pool: got %+v, want %+v", nativeNoPool, wantNoPool)
+	}
+
+	tags := cfg.TagsFromProperties(map[string]any{"Tags": []any{
+		map[string]any{"Key": "env", "Value": "prod"},
+	}})
+	if tags == nil {
+		t.Fatal("Tags must be non-nil empty map")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %v, want empty (untaggable)", tags)
+	}
+}
+
+// TestACMCertificateConfig pins the per-type extractors for
+// aws_acm_certificate: passthrough CC identifier (full ARN),
+// DomainName NameHint, Arn NativeID, Tags from the standard
+// Key/Value list, and SDKLister-only enumeration (CC ListResources is
+// unsupported for this type).
+func TestACMCertificateConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_acm_certificate")
+	if cfg.SkipProjectTagFilter {
+		t.Error("aws_acm_certificate: SkipProjectTagFilter must be false (ACM certs are taggable; --project must filter)")
+	}
+	if cfg.SDKLister == nil {
+		t.Fatal("SDKLister must be set; CC ListResources is unsupported for this type")
+	}
+	if cfg.ParentLister != nil {
+		t.Error("ParentLister must be nil (mutually exclusive with SDKLister)")
+	}
+
+	id := "arn:aws:acm:us-east-1:111111111111:certificate/abc-12345"
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != id {
+		t.Errorf("ImportID passthrough: got %q, want %q", got, id)
+	}
+
+	props := map[string]any{
+		"DomainName": "example.com",
+		"Arn":        id,
+		"Tags": []any{
+			map[string]any{"Key": "env", "Value": "prod"},
+			map[string]any{"Key": "Project", "Value": "io-foo"},
+		},
+	}
+	if got := cfg.NameHintFromProperties(id, props); got != "example.com" {
+		t.Errorf("NameHint: got %q, want example.com", got)
+	}
+	if got := cfg.NameHintFromProperties(id, map[string]any{}); got != id {
+		t.Errorf("NameHint fallback: got %q, want %q", got, id)
+	}
+
+	native := cfg.NativeIDsFromProperties(id, props)
+	wantNative := map[string]string{"arn": id}
+	if !reflect.DeepEqual(native, wantNative) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, wantNative)
+	}
+
+	tags := cfg.TagsFromProperties(props)
+	wantTags := map[string]string{"env": "prod", "Project": "io-foo"}
+	if !reflect.DeepEqual(tags, wantTags) {
+		t.Errorf("Tags: got %+v, want %+v", tags, wantTags)
+	}
+}
+
 // TestEmptyTagsExtractor_NonNilEmptyMap pins the contract of the
 // helper used by genuinely-untaggable Cloud Control types: it must
 // always return a non-nil empty map. Per the #255 JSON-marshal

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -543,6 +543,12 @@ func TestLambdaAliasConfig(t *testing.T) {
 	if !reflect.DeepEqual(native, want) {
 		t.Errorf("NativeIDs: got %+v, want %+v (exact map equality)", native, want)
 	}
+	// Defensive: malformed identifier (no `|`) and no AliasArn —
+	// NativeIDs must return nil rather than half-stitched keys.
+	// Symmetric with TestCognitoUserPoolClientConfig's malformed-id pin.
+	if got := cfg.NativeIDsFromProperties("orphan", nil); got != nil {
+		t.Errorf("NativeIDs malformed-id: got %+v, want nil", got)
+	}
 
 	// Tags: always empty for the aliases type.
 	tags := cfg.TagsFromProperties(map[string]any{"AliasArn": "..."})
@@ -576,9 +582,16 @@ func TestWAFv2WebACLConfig(t *testing.T) {
 		t.Errorf("ImportID rewrite (Name|Id|Scope → Id/Name/Scope): got %q, want %q",
 			got, "abc-12345/my-acl/REGIONAL")
 	}
-	// Malformed identifier passthrough.
+	// Malformed identifier passthrough — both shapes (1-segment and
+	// 2-segment) hit the `len(parts) != 3` early-return. Including
+	// the 2-segment case prevents a regression that loosens the
+	// equality check to `>= 3` (which would silently consume extra
+	// fields).
 	if got := cfg.ImportIDFromIdentifier("malformed", nil); got != "malformed" {
-		t.Errorf("ImportID malformed passthrough: got %q, want malformed", got)
+		t.Errorf("ImportID malformed (1-seg) passthrough: got %q, want malformed", got)
+	}
+	if got := cfg.ImportIDFromIdentifier("a|b", nil); got != "a|b" {
+		t.Errorf("ImportID malformed (2-seg) passthrough: got %q, want a|b", got)
 	}
 
 	props := map[string]any{

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
@@ -97,6 +97,9 @@ func listLambdaFunctionsWithClient(ctx context.Context, client lambdaFunctionsLi
 // AWS WAFv2 docs; from any other region we surface REGIONAL only.
 // Returning the CLOUDFRONT scope from non-us-east-1 would cause the
 // downstream CC ListResources call to return InvalidRequestException.
+//
+// Emit order is REGIONAL first, then CLOUDFRONT — the discoverer
+// preserves the order for emit determinism, so tests pin this.
 func wafv2ParentModels(_ context.Context, _ aws.Config, region string, _ DiscoverArgs) ([]string, error) {
 	if region == "us-east-1" {
 		return []string{

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
@@ -1,0 +1,212 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acm"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+)
+
+// cognitoUserPoolsLister is the narrow subset of the Cognito IDP SDK
+// the Bundle 14b listers use. The interface is package-private so test
+// fakes can satisfy it without depending on the full client surface.
+type cognitoUserPoolsLister interface {
+	ListUserPools(ctx context.Context, in *cognitoidentityprovider.ListUserPoolsInput, opts ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.ListUserPoolsOutput, error)
+	DescribeUserPool(ctx context.Context, in *cognitoidentityprovider.DescribeUserPoolInput, opts ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.DescribeUserPoolOutput, error)
+}
+
+// lambdaFunctionsLister is the narrow subset of the Lambda SDK used by
+// the Lambda alias parent enumerator.
+type lambdaFunctionsLister interface {
+	ListFunctions(ctx context.Context, in *lambda.ListFunctionsInput, opts ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error)
+}
+
+// acmCertificatesLister is the narrow subset of the ACM SDK used by the
+// ACM certificate SDK enumerator.
+type acmCertificatesLister interface {
+	ListCertificates(ctx context.Context, in *acm.ListCertificatesInput, opts ...func(*acm.Options)) (*acm.ListCertificatesOutput, error)
+}
+
+// listCognitoUserPools enumerates all Cognito user pools in the region
+// and returns one parent ResourceModel JSON string per pool, suitable
+// for feeding into Cloud Control ListResources for child types scoped
+// on UserPoolId (e.g. AWS::Cognito::UserPoolClient). Returns an empty
+// slice (not nil) when no pools exist, so the discoverer's
+// `len(parentModels) == 0` early-exit fires cleanly.
+func listCognitoUserPools(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := cognitoidentityprovider.NewFromConfig(awsCfg, func(o *cognitoidentityprovider.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+	return listCognitoUserPoolsWithClient(ctx, client)
+}
+
+func listCognitoUserPoolsWithClient(ctx context.Context, client cognitoUserPoolsLister) ([]string, error) {
+	ids, err := listCognitoUserPoolIDsWithClient(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	models := make([]string, 0, len(ids))
+	for _, id := range ids {
+		models = append(models, fmt.Sprintf(`{"UserPoolId":%q}`, id))
+	}
+	return models, nil
+}
+
+// listLambdaFunctions enumerates Lambda functions and returns one
+// parent ResourceModel JSON string per function for AWS::Lambda::Alias
+// fan-out.
+func listLambdaFunctions(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := lambda.NewFromConfig(awsCfg, func(o *lambda.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+	return listLambdaFunctionsWithClient(ctx, client)
+}
+
+func listLambdaFunctionsWithClient(ctx context.Context, client lambdaFunctionsLister) ([]string, error) {
+	models := []string{}
+	var marker *string
+	for {
+		page, err := client.ListFunctions(ctx, &lambda.ListFunctionsInput{Marker: marker})
+		if err != nil {
+			return nil, fmt.Errorf("lambda:ListFunctions: %w", err)
+		}
+		for _, fn := range page.Functions {
+			name := aws.ToString(fn.FunctionName)
+			if name == "" {
+				continue
+			}
+			models = append(models, fmt.Sprintf(`{"FunctionName":%q}`, name))
+		}
+		if page.NextMarker == nil || aws.ToString(page.NextMarker) == "" {
+			break
+		}
+		marker = page.NextMarker
+	}
+	return models, nil
+}
+
+// wafv2ParentModels returns the static WAFv2 parent ResourceModel list.
+// CLOUDFRONT scope is only valid against the us-east-1 endpoint per the
+// AWS WAFv2 docs; from any other region we surface REGIONAL only.
+// Returning the CLOUDFRONT scope from non-us-east-1 would cause the
+// downstream CC ListResources call to return InvalidRequestException.
+func wafv2ParentModels(_ context.Context, _ aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	if region == "us-east-1" {
+		return []string{
+			`{"Scope":"REGIONAL"}`,
+			`{"Scope":"CLOUDFRONT"}`,
+		}, nil
+	}
+	return []string{`{"Scope":"REGIONAL"}`}, nil
+}
+
+// listCognitoUserPoolDomains walks user pools and emits the domain
+// string for each pool that has Domain (Cognito-hosted) or
+// CustomDomain (customer DNS) configured. CFN treats Domain and
+// CustomDomain as separate AWS::Cognito::UserPoolDomain resources so
+// both are emitted when both are present. Returns identifiers suitable
+// for direct GetResource calls (the domain string is the CC primary
+// identifier).
+func listCognitoUserPoolDomains(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := cognitoidentityprovider.NewFromConfig(awsCfg, func(o *cognitoidentityprovider.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+	return listCognitoUserPoolDomainsWithClient(ctx, client)
+}
+
+func listCognitoUserPoolDomainsWithClient(ctx context.Context, client cognitoUserPoolsLister) ([]string, error) {
+	pools, err := listCognitoUserPoolIDsWithClient(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	domains := []string{}
+	for _, id := range pools {
+		out, err := client.DescribeUserPool(ctx, &cognitoidentityprovider.DescribeUserPoolInput{
+			UserPoolId: aws.String(id),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("cognito-idp:DescribeUserPool %s: %w", id, err)
+		}
+		if out == nil || out.UserPool == nil {
+			continue
+		}
+		if d := aws.ToString(out.UserPool.Domain); d != "" {
+			domains = append(domains, d)
+		}
+		if cd := aws.ToString(out.UserPool.CustomDomain); cd != "" {
+			domains = append(domains, cd)
+		}
+	}
+	return domains, nil
+}
+
+// listCognitoUserPoolIDsWithClient is a small helper shared by the
+// pool-walking listers. Returns pool IDs only, not ResourceModel JSON.
+func listCognitoUserPoolIDsWithClient(ctx context.Context, client cognitoUserPoolsLister) ([]string, error) {
+	ids := []string{}
+	var nextToken *string
+	for {
+		page, err := client.ListUserPools(ctx, &cognitoidentityprovider.ListUserPoolsInput{
+			MaxResults: aws.Int32(60),
+			NextToken:  nextToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("cognito-idp:ListUserPools: %w", err)
+		}
+		for _, p := range page.UserPools {
+			id := aws.ToString(p.Id)
+			if id != "" {
+				ids = append(ids, id)
+			}
+		}
+		if page.NextToken == nil || aws.ToString(page.NextToken) == "" {
+			break
+		}
+		nextToken = page.NextToken
+	}
+	return ids, nil
+}
+
+// listACMCertificates returns the certificate ARN for every ACM
+// certificate in the region. ARN is the CC primary identifier for
+// AWS::CertificateManager::Certificate.
+func listACMCertificates(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := acm.NewFromConfig(awsCfg, func(o *acm.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+	return listACMCertificatesWithClient(ctx, client)
+}
+
+func listACMCertificatesWithClient(ctx context.Context, client acmCertificatesLister) ([]string, error) {
+	arns := []string{}
+	var nextToken *string
+	for {
+		page, err := client.ListCertificates(ctx, &acm.ListCertificatesInput{NextToken: nextToken})
+		if err != nil {
+			return nil, fmt.Errorf("acm:ListCertificates: %w", err)
+		}
+		for _, c := range page.CertificateSummaryList {
+			a := aws.ToString(c.CertificateArn)
+			if a != "" {
+				arns = append(arns, a)
+			}
+		}
+		if page.NextToken == nil || aws.ToString(page.NextToken) == "" {
+			break
+		}
+		nextToken = page.NextToken
+	}
+	return arns, nil
+}
+

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
@@ -291,11 +291,10 @@ func TestListCognitoUserPoolDomains_EmitsDomainAndCustomDomain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Order is implementation-defined (pool walk × Domain-then-CustomDomain);
-	// sort both sides for comparison.
+	// Order is implementation-defined (pool walk × Domain-then-CustomDomain).
+	// `want` is already sorted; sort `got` to compare set-shaped.
 	sort.Strings(got)
 	want := []string{"alone.example", "auth.example", "co-hosted.example", "custom.example"}
-	sort.Strings(want)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("domains drift:\n got %v\nwant %v", got, want)
 	}
@@ -325,12 +324,19 @@ func TestListCognitoUserPoolDomains_PropagatesDescribeError(t *testing.T) {
 		describeErr:    sentinel,
 		describeErrFor: "pool-b",
 	}
-	_, err := listCognitoUserPoolDomainsWithClient(context.Background(), fake)
+	got, err := listCognitoUserPoolDomainsWithClient(context.Background(), fake)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !errors.Is(err, sentinel) {
 		t.Errorf("err does not wrap sentinel; got %v", err)
+	}
+	// Pin the no-partial-success contract: a mid-walk error must
+	// return nil, not a truncated slice containing pool-a's domain.
+	// Callers retrying on error expect to retry the whole walk; a
+	// partial slice combined with a retry would double-emit pool-a.
+	if got != nil {
+		t.Errorf("partial result leaked on error: got %v, want nil", got)
 	}
 }
 

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
@@ -1,0 +1,424 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acm"
+	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+	cogniidptypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+)
+
+// This file holds unit tests for the SDK-backed listers in
+// cloudcontrol_listers.go. Each lister is exercised end-to-end through
+// its narrow client interface with a hand-rolled fake — the pagination
+// loops, JSON-shape of the emitted ResourceModel strings, and
+// nil-vs-empty semantics on empty responses are all load-bearing for
+// the discoverer's downstream branches.
+
+// fakeCognitoUserPoolsLister is a hand-rolled fake satisfying the
+// cognitoUserPoolsLister interface. listPages drives the ListUserPools
+// pagination; describeByID drives DescribeUserPool (used by the
+// UserPoolDomain walker).
+type fakeCognitoUserPoolsLister struct {
+	listPages       []cognitoidentityprovider.ListUserPoolsOutput
+	listCalls       int
+	listErr         error
+	describeByID    map[string]cognitoidentityprovider.DescribeUserPoolOutput
+	describeCalls   int
+	describeErr     error
+	describeErrFor  string // when set, DescribeUserPool returns describeErr only for this pool ID
+	describeCallIDs []string
+}
+
+func (f *fakeCognitoUserPoolsLister) ListUserPools(_ context.Context, _ *cognitoidentityprovider.ListUserPoolsInput, _ ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.ListUserPoolsOutput, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if f.listCalls >= len(f.listPages) {
+		// Exhausted: return empty no-token page so the paginator stops.
+		return &cognitoidentityprovider.ListUserPoolsOutput{}, nil
+	}
+	page := f.listPages[f.listCalls]
+	f.listCalls++
+	return &page, nil
+}
+
+func (f *fakeCognitoUserPoolsLister) DescribeUserPool(_ context.Context, in *cognitoidentityprovider.DescribeUserPoolInput, _ ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.DescribeUserPoolOutput, error) {
+	id := aws.ToString(in.UserPoolId)
+	f.describeCalls++
+	f.describeCallIDs = append(f.describeCallIDs, id)
+	if f.describeErrFor != "" && f.describeErrFor == id {
+		return nil, f.describeErr
+	}
+	if f.describeErr != nil && f.describeErrFor == "" {
+		return nil, f.describeErr
+	}
+	out, ok := f.describeByID[id]
+	if !ok {
+		return &cognitoidentityprovider.DescribeUserPoolOutput{}, nil
+	}
+	return &out, nil
+}
+
+// cognitoListPage builds a ListUserPoolsOutput with the given pool IDs
+// and an optional NextToken. Used to construct multi-page fixtures.
+func cognitoListPage(token string, ids ...string) cognitoidentityprovider.ListUserPoolsOutput {
+	descs := make([]cogniidptypes.UserPoolDescriptionType, 0, len(ids))
+	for _, id := range ids {
+		descs = append(descs, cogniidptypes.UserPoolDescriptionType{Id: aws.String(id)})
+	}
+	out := cognitoidentityprovider.ListUserPoolsOutput{UserPools: descs}
+	if token != "" {
+		out.NextToken = aws.String(token)
+	}
+	return out
+}
+
+// TestListCognitoUserPools_PaginatesAndReturnsModels pins the
+// pool-enumeration helper used by aws_cognito_user_pool_client's
+// ParentLister: every pool across every page must surface as a
+// well-formed JSON ResourceModel string with UserPoolId set. A
+// regression that drops a page or emits malformed JSON would
+// silently produce zero child clients.
+func TestListCognitoUserPools_PaginatesAndReturnsModels(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCognitoUserPoolsLister{
+		listPages: []cognitoidentityprovider.ListUserPoolsOutput{
+			cognitoListPage("tok1", "us-east-1_AAA", "us-east-1_BBB"),
+			cognitoListPage("tok2", "us-east-1_CCC"),
+			cognitoListPage("", "us-east-1_DDD", "us-east-1_EEE"),
+		},
+	}
+	got, err := listCognitoUserPoolsWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("listCognitoUserPools returned nil — must be non-nil per the discoverer's len(parentModels)==0 contract")
+	}
+	want := []string{
+		`{"UserPoolId":"us-east-1_AAA"}`,
+		`{"UserPoolId":"us-east-1_BBB"}`,
+		`{"UserPoolId":"us-east-1_CCC"}`,
+		`{"UserPoolId":"us-east-1_DDD"}`,
+		`{"UserPoolId":"us-east-1_EEE"}`,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("models drift:\n got %v\nwant %v", got, want)
+	}
+	if fake.listCalls != 3 {
+		t.Errorf("listCalls=%d, want 3 (paginated)", fake.listCalls)
+	}
+	// Every emitted model must be parseable JSON with UserPoolId set —
+	// the CC schema requires this exact key.
+	for _, m := range got {
+		var parsed map[string]string
+		if err := json.Unmarshal([]byte(m), &parsed); err != nil {
+			t.Errorf("emitted model %q is not valid JSON: %v", m, err)
+		}
+		if _, ok := parsed["UserPoolId"]; !ok {
+			t.Errorf("model %q missing UserPoolId key", m)
+		}
+	}
+}
+
+// TestListCognitoUserPools_EmptyAccountReturnsNonNilEmpty pins the
+// non-nil-empty contract: an account with zero user pools must return
+// an empty slice (not nil) so the discoverer's len-check short-circuits
+// cleanly rather than treating "no pools" as "ParentLister not set."
+func TestListCognitoUserPools_EmptyAccountReturnsNonNilEmpty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCognitoUserPoolsLister{
+		listPages: []cognitoidentityprovider.ListUserPoolsOutput{
+			cognitoListPage(""),
+		},
+	}
+	got, err := listCognitoUserPoolsWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("empty-account result must be non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("len=%d, want 0", len(got))
+	}
+}
+
+// TestListCognitoUserPools_PropagatesListError pins that an SDK error
+// on ListUserPools surfaces via errors.Is rather than being swallowed
+// or rewrapped — symmetric with the discoverer's ListResources error
+// path.
+func TestListCognitoUserPools_PropagatesListError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("AccessDenied: cognito-idp:ListUserPools")
+	fake := &fakeCognitoUserPoolsLister{listErr: sentinel}
+	_, err := listCognitoUserPoolsWithClient(context.Background(), fake)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err does not wrap sentinel; got %v", err)
+	}
+}
+
+// fakeLambdaFunctionsLister is a hand-rolled fake satisfying the
+// lambdaFunctionsLister interface.
+type fakeLambdaFunctionsLister struct {
+	listPages []lambda.ListFunctionsOutput
+	listCalls int
+	listErr   error
+}
+
+func (f *fakeLambdaFunctionsLister) ListFunctions(_ context.Context, _ *lambda.ListFunctionsInput, _ ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if f.listCalls >= len(f.listPages) {
+		return &lambda.ListFunctionsOutput{}, nil
+	}
+	page := f.listPages[f.listCalls]
+	f.listCalls++
+	return &page, nil
+}
+
+func lambdaListPage(marker string, fnNames ...string) lambda.ListFunctionsOutput {
+	fns := make([]lambdatypes.FunctionConfiguration, 0, len(fnNames))
+	for _, n := range fnNames {
+		fns = append(fns, lambdatypes.FunctionConfiguration{FunctionName: aws.String(n)})
+	}
+	out := lambda.ListFunctionsOutput{Functions: fns}
+	if marker != "" {
+		out.NextMarker = aws.String(marker)
+	}
+	return out
+}
+
+// TestListLambdaFunctions_PaginatesAndReturnsModels mirrors the
+// Cognito-pool pagination pin for the Lambda alias ParentLister's
+// upstream enumeration: every function across every page surfaces as
+// a JSON ResourceModel with FunctionName set.
+func TestListLambdaFunctions_PaginatesAndReturnsModels(t *testing.T) {
+	t.Parallel()
+	fake := &fakeLambdaFunctionsLister{
+		listPages: []lambda.ListFunctionsOutput{
+			lambdaListPage("m1", "fn-alpha", "fn-beta"),
+			lambdaListPage("", "fn-gamma"),
+		},
+	}
+	got, err := listLambdaFunctionsWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		`{"FunctionName":"fn-alpha"}`,
+		`{"FunctionName":"fn-beta"}`,
+		`{"FunctionName":"fn-gamma"}`,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("models drift:\n got %v\nwant %v", got, want)
+	}
+	if fake.listCalls != 2 {
+		t.Errorf("listCalls=%d, want 2", fake.listCalls)
+	}
+}
+
+// TestWAFv2ParentModels_CloudFrontOnlyInUSEast1 pins the
+// region-conditional scope behavior: WAFv2's CLOUDFRONT scope is only
+// valid at the us-east-1 endpoint. Returning CLOUDFRONT from
+// eu-west-1 would cause CC ListResources to fail with
+// InvalidRequestException.
+func TestWAFv2ParentModels_CloudFrontOnlyInUSEast1(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		region string
+		want   []string
+	}{
+		{region: "us-east-1", want: []string{`{"Scope":"REGIONAL"}`, `{"Scope":"CLOUDFRONT"}`}},
+		{region: "us-west-2", want: []string{`{"Scope":"REGIONAL"}`}},
+		{region: "eu-west-1", want: []string{`{"Scope":"REGIONAL"}`}},
+		{region: "ap-southeast-2", want: []string{`{"Scope":"REGIONAL"}`}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.region, func(t *testing.T) {
+			t.Parallel()
+			got, err := wafv2ParentModels(context.Background(), aws.Config{}, tc.region, DiscoverArgs{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("region=%s scopes: got %v, want %v", tc.region, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestListCognitoUserPoolDomains_EmitsDomainAndCustomDomain pins the
+// rare-state behavior where a single user pool has BOTH Domain
+// (Cognito-hosted) and CustomDomain (customer DNS) configured. CFN
+// treats those as two distinct AWS::Cognito::UserPoolDomain resources
+// with separate primary identifiers, so the SDKLister must emit both.
+func TestListCognitoUserPoolDomains_EmitsDomainAndCustomDomain(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCognitoUserPoolsLister{
+		listPages: []cognitoidentityprovider.ListUserPoolsOutput{
+			cognitoListPage("", "pool-with-domain", "pool-with-both", "pool-with-neither", "pool-with-custom-only"),
+		},
+		describeByID: map[string]cognitoidentityprovider.DescribeUserPoolOutput{
+			"pool-with-domain": {UserPool: &cogniidptypes.UserPoolType{
+				Domain: aws.String("auth.example"),
+			}},
+			"pool-with-both": {UserPool: &cogniidptypes.UserPoolType{
+				Domain:       aws.String("co-hosted.example"),
+				CustomDomain: aws.String("custom.example"),
+			}},
+			"pool-with-neither": {UserPool: &cogniidptypes.UserPoolType{}},
+			"pool-with-custom-only": {UserPool: &cogniidptypes.UserPoolType{
+				CustomDomain: aws.String("alone.example"),
+			}},
+		},
+	}
+	got, err := listCognitoUserPoolDomainsWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Order is implementation-defined (pool walk × Domain-then-CustomDomain);
+	// sort both sides for comparison.
+	sort.Strings(got)
+	want := []string{"alone.example", "auth.example", "co-hosted.example", "custom.example"}
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("domains drift:\n got %v\nwant %v", got, want)
+	}
+	// Every pool was probed exactly once (no DescribeUserPool retry
+	// or skip — a regression that short-circuits on first-empty-pool
+	// would survive only here).
+	if fake.describeCalls != 4 {
+		t.Errorf("describeCalls=%d, want 4 (one per pool)", fake.describeCalls)
+	}
+}
+
+// TestListCognitoUserPoolDomains_PropagatesDescribeError pins that a
+// DescribeUserPool failure for a single pool aborts enumeration via
+// errors.Is — symmetric with the cloudControlDiscoverer's
+// ListResources error path. Partial-success would silently emit a
+// truncated set; explicit propagation lets callers retry.
+func TestListCognitoUserPoolDomains_PropagatesDescribeError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("AccessDenied: cognito-idp:DescribeUserPool")
+	fake := &fakeCognitoUserPoolsLister{
+		listPages: []cognitoidentityprovider.ListUserPoolsOutput{
+			cognitoListPage("", "pool-a", "pool-b"),
+		},
+		describeByID: map[string]cognitoidentityprovider.DescribeUserPoolOutput{
+			"pool-a": {UserPool: &cogniidptypes.UserPoolType{Domain: aws.String("a.example")}},
+		},
+		describeErr:    sentinel,
+		describeErrFor: "pool-b",
+	}
+	_, err := listCognitoUserPoolDomainsWithClient(context.Background(), fake)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err does not wrap sentinel; got %v", err)
+	}
+}
+
+// fakeACMCertificatesLister is a hand-rolled fake for the ACM SDK
+// subset used by listACMCertificates.
+type fakeACMCertificatesLister struct {
+	listPages []acm.ListCertificatesOutput
+	listCalls int
+	listErr   error
+}
+
+func (f *fakeACMCertificatesLister) ListCertificates(_ context.Context, _ *acm.ListCertificatesInput, _ ...func(*acm.Options)) (*acm.ListCertificatesOutput, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if f.listCalls >= len(f.listPages) {
+		return &acm.ListCertificatesOutput{}, nil
+	}
+	page := f.listPages[f.listCalls]
+	f.listCalls++
+	return &page, nil
+}
+
+func acmListPage(token string, arns ...string) acm.ListCertificatesOutput {
+	summaries := make([]acmtypes.CertificateSummary, 0, len(arns))
+	for _, a := range arns {
+		summaries = append(summaries, acmtypes.CertificateSummary{CertificateArn: aws.String(a)})
+	}
+	out := acm.ListCertificatesOutput{CertificateSummaryList: summaries}
+	if token != "" {
+		out.NextToken = aws.String(token)
+	}
+	return out
+}
+
+// TestListACMCertificates_PaginatesARNs pins that the ACM SDKLister
+// paginates and emits one ARN per certificate. This is the canonical
+// SDKLister-pattern test — a regression that drops pagination or emits
+// the wrong field would silently truncate the cert set.
+func TestListACMCertificates_PaginatesARNs(t *testing.T) {
+	t.Parallel()
+	fake := &fakeACMCertificatesLister{
+		listPages: []acm.ListCertificatesOutput{
+			acmListPage("tok1",
+				"arn:aws:acm:us-east-1:111:certificate/aaa-111",
+				"arn:aws:acm:us-east-1:111:certificate/bbb-222",
+			),
+			acmListPage("",
+				"arn:aws:acm:us-east-1:111:certificate/ccc-333",
+			),
+		},
+	}
+	got, err := listACMCertificatesWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		"arn:aws:acm:us-east-1:111:certificate/aaa-111",
+		"arn:aws:acm:us-east-1:111:certificate/bbb-222",
+		"arn:aws:acm:us-east-1:111:certificate/ccc-333",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ARNs drift:\n got %v\nwant %v", got, want)
+	}
+	if fake.listCalls != 2 {
+		t.Errorf("listCalls=%d, want 2 (paginated)", fake.listCalls)
+	}
+}
+
+// TestListACMCertificates_EmptyReturnsNonNilEmpty pins the non-nil
+// empty contract: zero certs returns []string{}, not nil. The
+// discoverer's `len(ids) == 0` early-exit needs the slice to be
+// non-nil for the empty-region branch to fire cleanly.
+func TestListACMCertificates_EmptyReturnsNonNilEmpty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeACMCertificatesLister{
+		listPages: []acm.ListCertificatesOutput{
+			acmListPage(""),
+		},
+	}
+	got, err := listACMCertificatesWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("empty-region result must be non-nil")
+	}
+	if len(got) != 0 {
+		t.Errorf("len=%d, want 0", len(got))
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -652,6 +652,147 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		},
 		TagsFromProperties: tagsFromKey("Tags"),
 	},
+
+	// =====================================================================
+	// Cognito User Pool Client — parent-scoped on UserPoolId, untaggable
+	// =====================================================================
+	{
+		// AWS::Cognito::UserPoolClient is parent-scoped: CC ListResources
+		// requires ResourceModel={"UserPoolId":"..."}. The CFN schema has
+		// no Tags property, so SkipProjectTagFilter bypasses the legacy
+		// Project filter (matching the aws_iam_instance_profile precedent).
+		TFType:               "aws_cognito_user_pool_client",
+		CloudFormationType:   "AWS::Cognito::UserPoolClient",
+		Slug:                 "cognito_user_pool_client",
+		SkipProjectTagFilter: true,
+		ParentLister:         listCognitoUserPools,
+		// Cloud Control identifier = "<UserPoolId>|<ClientId>"; Terraform
+		// import format = "<UserPoolId>/<ClientId>" (forward-slash).
+		// Verified against terraform-provider-aws v6.x docs.
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			return strings.Replace(identifier, "|", "/", 1)
+		},
+		NameHintFromProperties: nameOrIdentifier("ClientName"),
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return nil
+			}
+			return map[string]string{
+				"user_pool_id": parts[0],
+				"client_id":    parts[1],
+			}
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
+
+	// =====================================================================
+	// Lambda Alias — parent-scoped on FunctionName, untaggable
+	// =====================================================================
+	{
+		// AWS::Lambda::Alias is parent-scoped on FunctionName. The CFN
+		// schema has no Tags property; aliases inherit nothing from
+		// their parent function for tagging purposes.
+		TFType:               "aws_lambda_alias",
+		CloudFormationType:   "AWS::Lambda::Alias",
+		Slug:                 "lambda_alias",
+		SkipProjectTagFilter: true,
+		ParentLister:         listLambdaFunctions,
+		// Cloud Control identifier = "<FunctionName>|<AliasName>";
+		// Terraform import format = "<FunctionName>/<AliasName>".
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			return strings.Replace(identifier, "|", "/", 1)
+		},
+		NameHintFromProperties: nameOrIdentifier("Name"),
+		NativeIDsFromProperties: func(identifier string, props map[string]any) map[string]string {
+			out := map[string]string{}
+			if parts := strings.SplitN(identifier, "|", 2); len(parts) == 2 {
+				out["function_name"] = parts[0]
+				out["name"] = parts[1]
+			}
+			if arn := extractString(props, "AliasArn"); arn != "" {
+				out["arn"] = arn
+			}
+			if len(out) == 0 {
+				return nil
+			}
+			return out
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
+
+	// =====================================================================
+	// WAFv2 WebACL — parent-scoped on Scope (REGIONAL / CLOUDFRONT)
+	// =====================================================================
+	{
+		// AWS::WAFv2::WebACL is parent-scoped on Scope. CLOUDFRONT scope
+		// is only valid against the us-east-1 endpoint per AWS docs —
+		// wafv2ParentModels returns REGIONAL only from other regions to
+		// avoid InvalidRequestException.
+		TFType:             "aws_wafv2_web_acl",
+		CloudFormationType: "AWS::WAFv2::WebACL",
+		Slug:               "wafv2_web_acl",
+		ParentLister:       wafv2ParentModels,
+		// Cloud Control identifier = "<Name>|<Id>|<Scope>"; Terraform
+		// import format = "<Id>/<Name>/<Scope>" — different delimiter AND
+		// reordered (Name and Id are swapped). Verified against
+		// terraform-provider-aws v6.x docs.
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			parts := strings.SplitN(identifier, "|", 3)
+			if len(parts) != 3 {
+				return identifier
+			}
+			return parts[1] + "/" + parts[0] + "/" + parts[2]
+		},
+		NameHintFromProperties:  nameOrIdentifier("Name"),
+		NativeIDsFromProperties: arnUnderKey("Arn"),
+		TagsFromProperties:      tagsFromKey("Tags"),
+	},
+
+	// =====================================================================
+	// Cognito User Pool Domain — SDKLister-listed, untaggable
+	// =====================================================================
+	{
+		// AWS::Cognito::UserPoolDomain's CC ListResources returns
+		// UnsupportedActionException even though GetResource works.
+		// SDKLister walks user pools and emits the Domain (and
+		// CustomDomain, when set) for each pool. Domain string itself
+		// is the CC primary identifier.
+		TFType:                 "aws_cognito_user_pool_domain",
+		CloudFormationType:     "AWS::Cognito::UserPoolDomain",
+		Slug:                   "cognito_user_pool_domain",
+		SkipProjectTagFilter:   true,
+		SDKLister:              listCognitoUserPoolDomains,
+		ImportIDFromIdentifier: passthroughImportID,
+		NameHintFromProperties: func(identifier string, _ map[string]any) string { return identifier },
+		NativeIDsFromProperties: func(identifier string, props map[string]any) map[string]string {
+			out := map[string]string{"domain": identifier}
+			if id := extractString(props, "UserPoolId"); id != "" {
+				out["user_pool_id"] = id
+			}
+			return out
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
+
+	// =====================================================================
+	// ACM Certificate — SDKLister-listed (CC LIST unsupported), taggable
+	// =====================================================================
+	{
+		// AWS::CertificateManager::Certificate's CC ListResources
+		// returns UnsupportedActionException; SDKLister enumerates via
+		// acm:ListCertificates. CC GetResource is supported and is the
+		// authoritative source for the properties payload (including
+		// Tags as a Key/Value list).
+		TFType:                  "aws_acm_certificate",
+		CloudFormationType:      "AWS::CertificateManager::Certificate",
+		Slug:                    "acm_certificate",
+		SDKLister:               listACMCertificates,
+		ImportIDFromIdentifier:  passthroughImportID,
+		NameHintFromProperties:  nameOrIdentifier("DomainName"),
+		NativeIDsFromProperties: arnUnderKey("Arn"),
+		TagsFromProperties:      tagsFromKey("Tags"),
+	},
 }
 
 // passthroughImportID is the common ImportIDFromIdentifier used by every

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
+	github.com/aws/aws-sdk-go-v2/service/acm v1.38.3
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3
 	github.com/aws/aws-sdk-go-v2/service/backup v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueO
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 h1:OQqn11BtaYv1WLUowvcA30MpzIu8Ti4pcLPIIyoKZrA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24/go.mod h1:X5ZJyfwVrWA96GzPmUCWFQaEARPR7gCrpq2E92PJwAE=
+github.com/aws/aws-sdk-go-v2/service/acm v1.38.3 h1:Fzab84hCu3rw9R9Y3mH7SHfr/cSEHnCB0Mq1JCdr9t0=
+github.com/aws/aws-sdk-go-v2/service/acm v1.38.3/go.mod h1:yCteizCNPaHt0SnNusoGGHvy0JDB0tvGDTVhEt5anZM=
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3 h1:JqFmDekar5Ije9SKKBUAmvuqardAXgCoJV78dt2BQSI=
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3/go.mod h1:+ONaMzn4bVIQwVsamP28xDWWZuYO+6cWupJpZOSlUNE=
 github.com/aws/aws-sdk-go-v2/service/backup v1.55.2 h1:WhdT1PwOjTjKLGuD9lJDyNMgYmVaZgTHK06ioJKMBYE=

--- a/pkg/composer/imported/category.go
+++ b/pkg/composer/imported/category.go
@@ -76,6 +76,7 @@ const (
 // readable. The golden file enforces the same key order.
 var categoryByTFType = map[string]string{
 	// --- AWS ---
+	"aws_acm_certificate":                 CategorySecurity,
 	"aws_apigatewayv2_api":                CategoryNetworkSecurity,
 	"aws_apigatewayv2_stage":              CategoryNetworkSecurity,
 	"aws_backup_plan":                     CategoryDataStorage,
@@ -88,6 +89,8 @@ var categoryByTFType = map[string]string{
 	"aws_cloudwatch_log_group":            CategoryObservability,
 	"aws_cloudwatch_metric_alarm":         CategoryObservability,
 	"aws_cognito_user_pool":               CategorySecurity,
+	"aws_cognito_user_pool_client":        CategorySecurity,
+	"aws_cognito_user_pool_domain":        CategorySecurity,
 	"aws_db_instance":                     CategoryDataStorage,
 	"aws_db_parameter_group":              CategoryDataStorage,
 	"aws_db_subnet_group":                 CategoryDataStorage,
@@ -103,6 +106,7 @@ var categoryByTFType = map[string]string{
 	"aws_iam_role":                        CategorySecurity,
 	"aws_internet_gateway":                CategoryNetworkSecurity,
 	"aws_kms_key":                         CategorySecurity,
+	"aws_lambda_alias":                    CategoryVirtualMachines,
 	"aws_lambda_event_source_mapping":     CategoryEvents,
 	"aws_lambda_function":                 CategoryVirtualMachines,
 	"aws_lb":                              CategoryNetworkSecurity,
@@ -127,6 +131,7 @@ var categoryByTFType = map[string]string{
 	"aws_vpc":                             CategoryNetworkSecurity,
 	"aws_vpc_dhcp_options":                CategoryNetworkSecurity,
 	"aws_vpc_endpoint":                    CategoryNetworkSecurity,
+	"aws_wafv2_web_acl":                   CategorySecurity,
 
 	// --- GCP ---
 	"google_api_gateway_api":                 CategoryNetworkSecurity,

--- a/pkg/composer/imported/testdata/category.golden
+++ b/pkg/composer/imported/testdata/category.golden
@@ -1,3 +1,4 @@
+aws_acm_certificate	Security
 aws_apigatewayv2_api	Network Security
 aws_apigatewayv2_stage	Network Security
 aws_backup_plan	Data Storage
@@ -10,6 +11,8 @@ aws_cloudwatch_event_rule	Events
 aws_cloudwatch_log_group	Observability
 aws_cloudwatch_metric_alarm	Observability
 aws_cognito_user_pool	Security
+aws_cognito_user_pool_client	Security
+aws_cognito_user_pool_domain	Security
 aws_db_instance	Data Storage
 aws_db_parameter_group	Data Storage
 aws_db_subnet_group	Data Storage
@@ -25,6 +28,7 @@ aws_iam_policy	Security
 aws_iam_role	Security
 aws_internet_gateway	Network Security
 aws_kms_key	Security
+aws_lambda_alias	Virtual Machines
 aws_lambda_event_source_mapping	Events
 aws_lambda_function	Virtual Machines
 aws_lb	Network Security
@@ -49,6 +53,7 @@ aws_subnet	Network Security
 aws_vpc	Network Security
 aws_vpc_dhcp_options	Network Security
 aws_vpc_endpoint	Network Security
+aws_wafv2_web_acl	Security
 google_api_gateway_api	Network Security
 google_api_gateway_api_config	Network Security
 google_api_gateway_gateway	Network Security

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -55,6 +55,7 @@ var untaggableAWS = map[string]struct{}{
 	"aws_iam_role_policy_attachment":                     {},
 	"aws_iam_service_linked_role":                        {},
 	"aws_kms_alias":                                      {},
+	"aws_lambda_alias":                                   {},
 	"aws_msk_configuration":                              {},
 	"aws_opensearchserverless_access_policy":             {},
 	"aws_opensearchserverless_security_policy":           {},

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -3,6 +3,26 @@
   "provider": "aws",
   "permissions": [
     {
+      "service": "acm_certificate",
+      "iam_action": "acm:DescribeCertificate",
+      "purpose": "Cloud Control GetResource for aws_acm_certificate delegates to acm:DescribeCertificate"
+    },
+    {
+      "service": "acm_certificate",
+      "iam_action": "acm:ListCertificates",
+      "purpose": "enumerate certificate ARNs via the ACM SDK (Cloud Control ListResources is unsupported for this type)"
+    },
+    {
+      "service": "acm_certificate",
+      "iam_action": "acm:ListTagsForCertificate",
+      "purpose": "Cloud Control GetResource delegate for the Tags property"
+    },
+    {
+      "service": "acm_certificate",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::CertificateManager::Certificate (#412 SDKLister branch)"
+    },
+    {
       "service": "apigatewayv2_api",
       "iam_action": "apigateway:GET",
       "purpose": "list HTTP APIs and fetch per-API metadata (GET /apis, GET /apis/*/stages)"
@@ -231,6 +251,46 @@
       "service": "cognito_user_pool",
       "iam_action": "cognito-idp:ListUserPools",
       "purpose": "Cloud Control ListResources for AWS::Cognito::UserPool delegates to cognito-idp:ListUserPools"
+    },
+    {
+      "service": "cognito_user_pool_client",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::Cognito::UserPoolClient (#412 ParentLister branch)"
+    },
+    {
+      "service": "cognito_user_pool_client",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::Cognito::UserPoolClient (per-UserPoolId fan-out)"
+    },
+    {
+      "service": "cognito_user_pool_client",
+      "iam_action": "cognito-idp:DescribeUserPoolClient",
+      "purpose": "Cloud Control GetResource for aws_cognito_user_pool_client delegates to cognito-idp:DescribeUserPoolClient"
+    },
+    {
+      "service": "cognito_user_pool_client",
+      "iam_action": "cognito-idp:ListUserPools",
+      "purpose": "parent enumeration: list UserPools to fan ListResources out per UserPoolId"
+    },
+    {
+      "service": "cognito_user_pool_domain",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::Cognito::UserPoolDomain (#412 SDKLister branch)"
+    },
+    {
+      "service": "cognito_user_pool_domain",
+      "iam_action": "cognito-idp:DescribeUserPool",
+      "purpose": "SDKLister enumeration: walk UserPools to read Domain/CustomDomain (Cloud Control ListResources unsupported)"
+    },
+    {
+      "service": "cognito_user_pool_domain",
+      "iam_action": "cognito-idp:DescribeUserPoolDomain",
+      "purpose": "Cloud Control GetResource for aws_cognito_user_pool_domain delegates to cognito-idp:DescribeUserPoolDomain"
+    },
+    {
+      "service": "cognito_user_pool_domain",
+      "iam_action": "cognito-idp:ListUserPools",
+      "purpose": "SDKLister enumeration: paginate UserPools to discover domains attached to each"
     },
     {
       "service": "db_instance",
@@ -491,6 +551,26 @@
       "service": "lambda",
       "iam_action": "lambda:ListTags",
       "purpose": "fetch function tags for tag selectors and Identity.Tags"
+    },
+    {
+      "service": "lambda_alias",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::Lambda::Alias (#412 ParentLister branch)"
+    },
+    {
+      "service": "lambda_alias",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::Lambda::Alias (per-FunctionName fan-out)"
+    },
+    {
+      "service": "lambda_alias",
+      "iam_action": "lambda:GetAlias",
+      "purpose": "Cloud Control GetResource for aws_lambda_alias delegates to lambda:GetAlias"
+    },
+    {
+      "service": "lambda_alias",
+      "iam_action": "lambda:ListFunctions",
+      "purpose": "parent enumeration: list Lambda functions to fan ListResources out per FunctionName"
     },
     {
       "service": "lambda_event_source_mapping",
@@ -926,6 +1006,26 @@
       "service": "vpc_endpoint",
       "iam_action": "ec2:DescribeVpcEndpoints",
       "purpose": "list per-region VPC endpoints; skip State=deleted/deleting tombstones (server-side tag:Project filter when project is set; tags inline)"
+    },
+    {
+      "service": "wafv2_web_acl",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::WAFv2::WebACL (#412 ParentLister branch)"
+    },
+    {
+      "service": "wafv2_web_acl",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::WAFv2::WebACL (per-Scope fan-out: REGIONAL + CLOUDFRONT in us-east-1)"
+    },
+    {
+      "service": "wafv2_web_acl",
+      "iam_action": "wafv2:GetWebACL",
+      "purpose": "Cloud Control GetResource for aws_wafv2_web_acl delegates to wafv2:GetWebACL"
+    },
+    {
+      "service": "wafv2_web_acl",
+      "iam_action": "wafv2:ListTagsForResource",
+      "purpose": "Cloud Control GetResource delegate for the Tags property"
     }
   ]
 }

--- a/pkg/insideout-import/permissions/permissions_test.go
+++ b/pkg/insideout-import/permissions/permissions_test.go
@@ -17,6 +17,7 @@ import (
 // uses the exported awsdiscover.ServiceSlug to fence the table off
 // against the production source of truth.
 var awsTFTypeToServiceSlug = map[string]string{
+	"aws_acm_certificate":                 "acm_certificate",
 	"aws_apigatewayv2_api":                "apigatewayv2_api",
 	"aws_apigatewayv2_stage":              "apigatewayv2_stage",
 	"aws_backup_plan":                     "backup_plan",
@@ -29,6 +30,8 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_cloudwatch_log_group":            "cloudwatchlogs",
 	"aws_cloudwatch_metric_alarm":         "cloudwatch_metric_alarm",
 	"aws_cognito_user_pool":               "cognito_user_pool",
+	"aws_cognito_user_pool_client":        "cognito_user_pool_client",
+	"aws_cognito_user_pool_domain":        "cognito_user_pool_domain",
 	"aws_db_instance":                     "db_instance",
 	"aws_db_parameter_group":              "db_parameter_group",
 	"aws_db_subnet_group":                 "db_subnet_group",
@@ -40,6 +43,7 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_iam_role":                        "iam_role",
 	"aws_internet_gateway":                "internet_gateway",
 	"aws_kms_key":                         "kms",
+	"aws_lambda_alias":                    "lambda_alias",
 	"aws_lambda_event_source_mapping":     "lambda_event_source_mapping",
 	"aws_lambda_function":                 "lambda",
 	"aws_lb":                              "lb",
@@ -63,6 +67,7 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_vpc":                             "vpc",
 	"aws_vpc_dhcp_options":                "vpc_dhcp_options",
 	"aws_vpc_endpoint":                    "vpc_endpoint",
+	"aws_wafv2_web_acl":                   "wafv2_web_acl",
 }
 
 // TestSlugMap_MatchesAwsdiscover pins the test-local slug table

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -23,6 +23,7 @@ const (
 // discover pipeline emits clean HCL for. Keep sorted lexicographically; the
 // awsdiscover parity test will fail if this drifts from the live constructor.
 var awsTypes = []string{
+	"aws_acm_certificate",
 	"aws_apigatewayv2_api",
 	"aws_apigatewayv2_stage",
 	"aws_backup_plan",
@@ -35,6 +36,8 @@ var awsTypes = []string{
 	"aws_cloudwatch_log_group",
 	"aws_cloudwatch_metric_alarm",
 	"aws_cognito_user_pool",
+	"aws_cognito_user_pool_client",
+	"aws_cognito_user_pool_domain",
 	"aws_db_instance",
 	"aws_db_parameter_group",
 	"aws_db_subnet_group",
@@ -46,6 +49,7 @@ var awsTypes = []string{
 	"aws_iam_role",
 	"aws_internet_gateway",
 	"aws_kms_key",
+	"aws_lambda_alias",
 	"aws_lambda_event_source_mapping",
 	"aws_lambda_function",
 	"aws_lb",
@@ -69,6 +73,7 @@ var awsTypes = []string{
 	"aws_vpc",
 	"aws_vpc_dhcp_options",
 	"aws_vpc_endpoint",
+	"aws_wafv2_web_acl",
 }
 
 // gcpTypes is the canonical, sorted list of GCP Terraform resource types the

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -18,6 +18,7 @@ import (
 func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 	t.Parallel()
 	want := []string{
+		"aws_acm_certificate",
 		"aws_apigatewayv2_api",
 		"aws_apigatewayv2_stage",
 		"aws_backup_plan",
@@ -30,6 +31,8 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_cloudwatch_log_group",
 		"aws_cloudwatch_metric_alarm",
 		"aws_cognito_user_pool",
+		"aws_cognito_user_pool_client",
+		"aws_cognito_user_pool_domain",
 		"aws_db_instance",
 		"aws_db_parameter_group",
 		"aws_db_subnet_group",
@@ -41,6 +44,7 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_iam_role",
 		"aws_internet_gateway",
 		"aws_kms_key",
+		"aws_lambda_alias",
 		"aws_lambda_event_source_mapping",
 		"aws_lambda_function",
 		"aws_lb",
@@ -64,6 +68,7 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_vpc",
 		"aws_vpc_dhcp_options",
 		"aws_vpc_endpoint",
+		"aws_wafv2_web_acl",
 	}
 	got := SupportedDiscoverTypes(ProviderAWS)
 	if !reflect.DeepEqual(got, want) {
@@ -158,7 +163,7 @@ func TestSupportedDiscoverTypes_ReturnsCopy_PackageStateUnchanged(t *testing.T) 
 		// [0] no longer matches.
 		firstLiteral string
 	}{
-		{provider: ProviderAWS, firstLiteral: "aws_apigatewayv2_api"},
+		{provider: ProviderAWS, firstLiteral: "aws_acm_certificate"},
 		{provider: ProviderGCP, firstLiteral: "google_api_gateway_api"}, // first entry after Bundle 10
 	}
 	for _, tc := range cases {

--- a/tests/lint-project-tag.sh
+++ b/tests/lint-project-tag.sh
@@ -42,6 +42,7 @@ NON_TAGGABLE_AWS=(
   aws_iam_role_policy_attachment
   aws_iam_service_linked_role
   aws_kms_alias
+  aws_lambda_alias
   aws_msk_configuration
   aws_opensearchserverless_access_policy
   aws_opensearchserverless_security_policy


### PR DESCRIPTION
## Summary

Brings AWS unified-Cloud-Control coverage from 45 → 50 types by activating the existing `ParentLister` framework (3 types) and introducing a new `SDKLister` branch (2 types).

- `aws_cognito_user_pool_client`, `aws_lambda_alias`, `aws_wafv2_web_acl` — **ParentLister** (zero framework code; the field has been plumbed but unused since the framework landed).
- `aws_cognito_user_pool_domain`, `aws_acm_certificate` — **SDKLister** (new field on `cloudControlConfig`; CC `ListResources` returns `UnsupportedActionException` for these types, but `GetResource` works fine, so we drive enumeration via native SDK and feed identifiers into the existing GetResource fan-out).

## Framework changes

- New `SDKLister func(ctx, awsCfg, region, args) ([]string, error)` field on `cloudControlConfig`. Mutually exclusive with `ParentLister` — setting both panics at registration time (pinned in a test).
- `ParentLister` signature widened to match (`(ctx, awsCfg, region, args)` instead of `(ctx, cloudControlClient, args)`) so listers can construct typed SDK clients. Zero production callers pre-change; the 3 existing unit tests for the framework were updated in the same commit.
- `aws.Config` plumbed onto `cloudControlDiscoverer` for SDK client construction.

## Compound-ID rewrites (verified against terraform-provider-aws v6.x docs)

- `aws_cognito_user_pool_client`: CC `<UserPoolId>\|<ClientId>` → TF `<UserPoolId>/<ClientId>`
- `aws_lambda_alias`: CC `<FunctionName>\|<AliasName>` → TF `<FunctionName>/<AliasName>`
- `aws_wafv2_web_acl`: CC `<Name>\|<Id>\|<Scope>` → TF `<Id>/<Name>/<Scope>` (Name/Id swap + lowercase→title-case scope)

## ARN rules

Added defensively only for the 2 taggable types (ACM cert, WAFv2 WebACL) whose ARNs surface via RGT. The 3 untaggable types have `SkipProjectTagFilter: true` which bypasses the RGT-cache short-circuit anyway — adding ARN rules for them would never fire.

## Test plan

- [x] `go test ./... -race` — **4187 passed in 26 packages**
- [x] `terraform fmt -check -recursive` — clean
- [x] All 4 lint scripts pass (`lint-project-tag`, `lint-project-label`, `lint-sensitive-for-each`, `lint-foreach-unknown-keys`)
- [ ] Live smoke on test account 141812438321 / `io-f-v6e-hzw-zt` — pending operator re-auth

## Review

- /review: 0 P0/P1 findings on the diff itself
- qa-professor: 0 P0/P1 in tests; 2 P2s + 4 P3s all addressed in commit `80873dd`

## WAFv2 region note

WAFv2 CLOUDFRONT scope is only valid at the `us-east-1` endpoint per the AWS docs; the static parent lister returns REGIONAL-only from any other region so we don't trigger `InvalidRequestException` on EU/AP/etc. scans.

Closes #412.