### PR TITLE
feat(awsdiscover): Bundle 14c — 5 new AWS types via ParentLister activation

### DIFF
--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -718,6 +718,291 @@ func TestACMCertificateConfig(t *testing.T) {
 	}
 }
 
+// TestApigatewayv2RouteConfig pins the per-type extractors for
+// aws_apigatewayv2_route: compound CC identifier `<ApiId>|<RouteId>`
+// rewrites to TF import format `<ApiId>/<RouteId>`, NameHint reads
+// RouteKey, NativeIDs split into a structured api_id/route_id map, and
+// Tags is the non-nil empty map per the #255 contract (CFN schema has
+// no Tags property on this type).
+func TestApigatewayv2RouteConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_apigatewayv2_route")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_apigatewayv2_route: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.CloudFormationType != "AWS::ApiGatewayV2::Route" {
+		t.Errorf("CloudFormationType=%q, want AWS::ApiGatewayV2::Route", cfg.CloudFormationType)
+	}
+	if cfg.ParentLister == nil {
+		t.Fatal("ParentLister must be set; CC ListResources is parent-scoped on ApiId")
+	}
+	if cfg.SDKLister != nil {
+		t.Error("SDKLister must be nil (ParentLister-scoped, not SDK-scoped)")
+	}
+
+	id := "aabbccddee|1122334"
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != "aabbccddee/1122334" {
+		t.Errorf("ImportID rewrite |→/: got %q, want %q", got, "aabbccddee/1122334")
+	}
+
+	props := map[string]any{"RouteKey": "POST /signup"}
+	if got := cfg.NameHintFromProperties(id, props); got != "POST /signup" {
+		t.Errorf("NameHint: got %q, want %q", got, "POST /signup")
+	}
+	if got := cfg.NameHintFromProperties(id, map[string]any{}); got != id {
+		t.Errorf("NameHint fallback: got %q, want identifier", got)
+	}
+
+	native := cfg.NativeIDsFromProperties(id, nil)
+	want := map[string]string{"api_id": "aabbccddee", "route_id": "1122334"}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	// Defensive: malformed identifier (no `|`) — NativeIDs must
+	// return nil so downstream doesn't render half-stitched keys.
+	if got := cfg.NativeIDsFromProperties("orphan", nil); got != nil {
+		t.Errorf("NativeIDs malformed-id: got %+v, want nil", got)
+	}
+
+	tags := cfg.TagsFromProperties(map[string]any{"Tags": []any{
+		map[string]any{"Key": "env", "Value": "prod"},
+	}})
+	if tags == nil {
+		t.Fatal("Tags must be non-nil empty map per #255 contract")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %v, want empty map (untaggable)", tags)
+	}
+}
+
+// TestApigatewayv2IntegrationConfig pins the per-type extractors for
+// aws_apigatewayv2_integration: compound CC identifier
+// `<ApiId>|<IntegrationId>` rewrites to TF import format
+// `<ApiId>/<IntegrationId>`, NameHint falls back through
+// Description → IntegrationType → identifier (no stable Name field on
+// this type), NativeIDs split into api_id/integration_id, and Tags is
+// the non-nil empty map.
+func TestApigatewayv2IntegrationConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_apigatewayv2_integration")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_apigatewayv2_integration: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.CloudFormationType != "AWS::ApiGatewayV2::Integration" {
+		t.Errorf("CloudFormationType=%q, want AWS::ApiGatewayV2::Integration", cfg.CloudFormationType)
+	}
+	if cfg.ParentLister == nil {
+		t.Fatal("ParentLister must be set; CC ListResources is parent-scoped on ApiId")
+	}
+
+	id := "aabbccddee|abc123xyz"
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != "aabbccddee/abc123xyz" {
+		t.Errorf("ImportID rewrite |→/: got %q, want %q", got, "aabbccddee/abc123xyz")
+	}
+
+	// NameHint chain: Description wins.
+	if got := cfg.NameHintFromProperties(id, map[string]any{
+		"Description":     "user signup",
+		"IntegrationType": "AWS_PROXY",
+	}); got != "user signup" {
+		t.Errorf("NameHint (Description present): got %q, want %q", got, "user signup")
+	}
+	// Description absent: IntegrationType is the fallback.
+	if got := cfg.NameHintFromProperties(id, map[string]any{
+		"IntegrationType": "AWS_PROXY",
+	}); got != "AWS_PROXY" {
+		t.Errorf("NameHint (IntegrationType fallback): got %q, want AWS_PROXY", got)
+	}
+	// Neither set: identifier is the last resort.
+	if got := cfg.NameHintFromProperties(id, map[string]any{}); got != id {
+		t.Errorf("NameHint (identifier fallback): got %q, want %q", got, id)
+	}
+
+	native := cfg.NativeIDsFromProperties(id, nil)
+	want := map[string]string{"api_id": "aabbccddee", "integration_id": "abc123xyz"}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	if got := cfg.NativeIDsFromProperties("orphan", nil); got != nil {
+		t.Errorf("NativeIDs malformed-id: got %+v, want nil", got)
+	}
+
+	tags := cfg.TagsFromProperties(map[string]any{})
+	if tags == nil {
+		t.Fatal("Tags must be non-nil empty map")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %v, want empty", tags)
+	}
+}
+
+// TestApigatewayv2AuthorizerConfig pins the per-type extractors for
+// aws_apigatewayv2_authorizer: compound CC identifier
+// `<ApiId>|<AuthorizerId>` rewrites to TF import format
+// `<ApiId>/<AuthorizerId>`, NameHint reads Name, NativeIDs split into
+// api_id/authorizer_id, and Tags is the non-nil empty map.
+func TestApigatewayv2AuthorizerConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_apigatewayv2_authorizer")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_apigatewayv2_authorizer: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.CloudFormationType != "AWS::ApiGatewayV2::Authorizer" {
+		t.Errorf("CloudFormationType=%q, want AWS::ApiGatewayV2::Authorizer", cfg.CloudFormationType)
+	}
+	if cfg.ParentLister == nil {
+		t.Fatal("ParentLister must be set; CC ListResources is parent-scoped on ApiId")
+	}
+
+	id := "aabbccddee|auth-001"
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != "aabbccddee/auth-001" {
+		t.Errorf("ImportID rewrite |→/: got %q, want %q", got, "aabbccddee/auth-001")
+	}
+
+	props := map[string]any{"Name": "jwt-auth"}
+	if got := cfg.NameHintFromProperties(id, props); got != "jwt-auth" {
+		t.Errorf("NameHint: got %q, want jwt-auth", got)
+	}
+	if got := cfg.NameHintFromProperties(id, map[string]any{}); got != id {
+		t.Errorf("NameHint fallback: got %q, want identifier", got)
+	}
+
+	native := cfg.NativeIDsFromProperties(id, nil)
+	want := map[string]string{"api_id": "aabbccddee", "authorizer_id": "auth-001"}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	if got := cfg.NativeIDsFromProperties("orphan", nil); got != nil {
+		t.Errorf("NativeIDs malformed-id: got %+v, want nil", got)
+	}
+
+	tags := cfg.TagsFromProperties(map[string]any{})
+	if tags == nil {
+		t.Fatal("Tags must be non-nil empty map")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %v, want empty", tags)
+	}
+}
+
+// TestCognitoIdentityProviderConfig pins the per-type extractors for
+// aws_cognito_identity_provider: compound CC identifier
+// `<UserPoolId>|<ProviderName>` rewrites to TF import format
+// `<UserPoolId>:<ProviderName>` — note the COLON delimiter, which
+// diverges from the slash used by every other compound-ID type in
+// cloudControlTypeConfigs. Verified against terraform-provider-aws v6.x
+// docs for this resource.
+func TestCognitoIdentityProviderConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_cognito_identity_provider")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_cognito_identity_provider: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.CloudFormationType != "AWS::Cognito::UserPoolIdentityProvider" {
+		t.Errorf("CloudFormationType=%q, want AWS::Cognito::UserPoolIdentityProvider", cfg.CloudFormationType)
+	}
+	if cfg.ParentLister == nil {
+		t.Fatal("ParentLister must be set; CC ListResources is parent-scoped on UserPoolId")
+	}
+
+	id := "us-east-1_AbCdE|CorpAD"
+	// Critical: TF import for this resource uses `:` not `/`. A naive
+	// `|`→`/` rewrite shared with apigatewayv2 children would emit an
+	// import statement Terraform rejects.
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != "us-east-1_AbCdE:CorpAD" {
+		t.Errorf("ImportID rewrite |→: (colon, not slash): got %q, want %q",
+			got, "us-east-1_AbCdE:CorpAD")
+	}
+
+	props := map[string]any{"ProviderName": "CorpAD"}
+	if got := cfg.NameHintFromProperties(id, props); got != "CorpAD" {
+		t.Errorf("NameHint: got %q, want CorpAD", got)
+	}
+	if got := cfg.NameHintFromProperties(id, map[string]any{}); got != id {
+		t.Errorf("NameHint fallback: got %q, want identifier", got)
+	}
+
+	native := cfg.NativeIDsFromProperties(id, nil)
+	want := map[string]string{"user_pool_id": "us-east-1_AbCdE", "provider_name": "CorpAD"}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	if got := cfg.NativeIDsFromProperties("orphan", nil); got != nil {
+		t.Errorf("NativeIDs malformed-id: got %+v, want nil", got)
+	}
+
+	tags := cfg.TagsFromProperties(map[string]any{})
+	if tags == nil {
+		t.Fatal("Tags must be non-nil empty map")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %v, want empty", tags)
+	}
+}
+
+// TestCognitoResourceServerConfig pins the per-type extractors for
+// aws_cognito_resource_server: compound CC identifier
+// `<UserPoolId>|<Identifier>` passes through to TF import format
+// unchanged (the pipe IS the delimiter Terraform expects). NameHint
+// falls back through Name → Identifier → resource identifier; NativeIDs
+// split into user_pool_id/identifier; Tags is the non-nil empty map.
+func TestCognitoResourceServerConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_cognito_resource_server")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_cognito_resource_server: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.CloudFormationType != "AWS::Cognito::UserPoolResourceServer" {
+		t.Errorf("CloudFormationType=%q, want AWS::Cognito::UserPoolResourceServer", cfg.CloudFormationType)
+	}
+	if cfg.ParentLister == nil {
+		t.Fatal("ParentLister must be set; CC ListResources is parent-scoped on UserPoolId")
+	}
+
+	id := "us-east-1_AbCdE|https://example.com"
+	// TF import for this resource preserves the `|` delimiter (unlike
+	// every other compound-ID Cognito child). Passthrough — any rewrite
+	// would break import.
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != id {
+		t.Errorf("ImportID passthrough (preserves |): got %q, want %q", got, id)
+	}
+
+	// NameHint chain: Name wins.
+	if got := cfg.NameHintFromProperties(id, map[string]any{
+		"Name":       "Solar System Data",
+		"Identifier": "https://example.com",
+	}); got != "Solar System Data" {
+		t.Errorf("NameHint (Name wins): got %q, want %q", got, "Solar System Data")
+	}
+	// Name absent: Identifier wins.
+	if got := cfg.NameHintFromProperties(id, map[string]any{
+		"Identifier": "https://example.com",
+	}); got != "https://example.com" {
+		t.Errorf("NameHint (Identifier fallback): got %q, want %q", got, "https://example.com")
+	}
+	// Neither set: identifier is the last resort.
+	if got := cfg.NameHintFromProperties(id, map[string]any{}); got != id {
+		t.Errorf("NameHint (identifier fallback): got %q, want %q", got, id)
+	}
+
+	native := cfg.NativeIDsFromProperties(id, nil)
+	want := map[string]string{"user_pool_id": "us-east-1_AbCdE", "identifier": "https://example.com"}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	if got := cfg.NativeIDsFromProperties("orphan", nil); got != nil {
+		t.Errorf("NativeIDs malformed-id: got %+v, want nil", got)
+	}
+
+	tags := cfg.TagsFromProperties(map[string]any{})
+	if tags == nil {
+		t.Fatal("Tags must be non-nil empty map")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %v, want empty", tags)
+	}
+}
+
 // TestEmptyTagsExtractor_NonNilEmptyMap pins the contract of the
 // helper used by genuinely-untaggable Cloud Control types: it must
 // always return a non-nil empty map. Per the #255 JSON-marshal

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -744,6 +744,15 @@ func TestApigatewayv2RouteConfig(t *testing.T) {
 	if got := cfg.ImportIDFromIdentifier(id, nil); got != "aabbccddee/1122334" {
 		t.Errorf("ImportID rewrite |→/: got %q, want %q", got, "aabbccddee/1122334")
 	}
+	// First-`|`-only rewrite contract: a hypothetical identifier
+	// containing a literal `|` inside a segment (extremely unlikely
+	// for ApiGatewayV2 RouteIds but defended for symmetry with the
+	// SplitN-on-`|`-cap-2 NativeIDs branch) must preserve every
+	// `|` after the first.
+	if got := cfg.ImportIDFromIdentifier("api|route|with|pipes", nil); got != "api/route|with|pipes" {
+		t.Errorf("ImportID multi-pipe (first-only rewrite): got %q, want %q",
+			got, "api/route|with|pipes")
+	}
 
 	props := map[string]any{"RouteKey": "POST /signup"}
 	if got := cfg.NameHintFromProperties(id, props); got != "POST /signup" {
@@ -764,6 +773,9 @@ func TestApigatewayv2RouteConfig(t *testing.T) {
 		t.Errorf("NativeIDs malformed-id: got %+v, want nil", got)
 	}
 
+	// Even with a populated Tags input, emptyTagsExtractor must
+	// discard it and return the non-nil empty map — the input is a
+	// no-op for genuinely-untaggable types.
 	tags := cfg.TagsFromProperties(map[string]any{"Tags": []any{
 		map[string]any{"Key": "env", "Value": "prod"},
 	}})
@@ -771,7 +783,7 @@ func TestApigatewayv2RouteConfig(t *testing.T) {
 		t.Fatal("Tags must be non-nil empty map per #255 contract")
 	}
 	if len(tags) != 0 {
-		t.Errorf("Tags: got %v, want empty map (untaggable)", tags)
+		t.Errorf("Tags: got %v, want empty map (untaggable; emptyTagsExtractor ignores input)", tags)
 	}
 }
 
@@ -910,8 +922,15 @@ func TestCognitoIdentityProviderConfig(t *testing.T) {
 	// `|`→`/` rewrite shared with apigatewayv2 children would emit an
 	// import statement Terraform rejects.
 	if got := cfg.ImportIDFromIdentifier(id, nil); got != "us-east-1_AbCdE:CorpAD" {
-		t.Errorf("ImportID rewrite |→: (colon, not slash): got %q, want %q",
+		t.Errorf("ImportID rewrite |→COLON (not slash): got %q, want %q",
 			got, "us-east-1_AbCdE:CorpAD")
+	}
+	// First-`|`-only rewrite: defensive pin matching the
+	// SplitN-on-`|`-cap-2 NativeIDs branch — any `|` past the first
+	// must survive verbatim.
+	if got := cfg.ImportIDFromIdentifier("pool|name|with|pipes", nil); got != "pool:name|with|pipes" {
+		t.Errorf("ImportID multi-pipe (first-only rewrite): got %q, want %q",
+			got, "pool:name|with|pipes")
 	}
 
 	props := map[string]any{"ProviderName": "CorpAD"}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 )
@@ -28,6 +29,15 @@ type lambdaFunctionsLister interface {
 // ACM certificate SDK enumerator.
 type acmCertificatesLister interface {
 	ListCertificates(ctx context.Context, in *acm.ListCertificatesInput, opts ...func(*acm.Options)) (*acm.ListCertificatesOutput, error)
+}
+
+// apigatewayv2APIsLister is the narrow subset of the API Gateway v2 SDK
+// used by the parent-API enumerator that seeds Route / Integration /
+// Authorizer fan-out. apigatewayv2_stage.go also lists APIs via its own
+// hand-rolled client interface; we intentionally keep these interfaces
+// separate so each call site can evolve independently.
+type apigatewayv2APIsLister interface {
+	GetApis(ctx context.Context, in *apigatewayv2.GetApisInput, opts ...func(*apigatewayv2.Options)) (*apigatewayv2.GetApisOutput, error)
 }
 
 // listCognitoUserPools enumerates all Cognito user pools in the region
@@ -211,5 +221,43 @@ func listACMCertificatesWithClient(ctx context.Context, client acmCertificatesLi
 		nextToken = page.NextToken
 	}
 	return arns, nil
+}
+
+// listApigatewayv2Apis enumerates ApiGatewayV2 APIs in the region and
+// returns one parent ResourceModel JSON string per API, suitable for
+// feeding into Cloud Control ListResources for child types scoped on
+// ApiId (Route / Integration / Authorizer). Returns an empty slice (not
+// nil) when no APIs exist, so the discoverer's `len(parentModels) == 0`
+// early-exit fires cleanly.
+func listApigatewayv2Apis(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := apigatewayv2.NewFromConfig(awsCfg, func(o *apigatewayv2.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+	return listApigatewayv2ApisWithClient(ctx, client)
+}
+
+func listApigatewayv2ApisWithClient(ctx context.Context, client apigatewayv2APIsLister) ([]string, error) {
+	models := []string{}
+	var nextToken *string
+	for {
+		page, err := client.GetApis(ctx, &apigatewayv2.GetApisInput{NextToken: nextToken})
+		if err != nil {
+			return nil, fmt.Errorf("apigatewayv2:GetApis: %w", err)
+		}
+		for _, api := range page.Items {
+			id := aws.ToString(api.ApiId)
+			if id == "" {
+				continue
+			}
+			models = append(models, fmt.Sprintf(`{"ApiId":%q}`, id))
+		}
+		if page.NextToken == nil || aws.ToString(page.NextToken) == "" {
+			break
+		}
+		nextToken = page.NextToken
+	}
+	return models, nil
 }
 

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
@@ -433,14 +433,19 @@ func TestListACMCertificates_EmptyReturnsNonNilEmpty(t *testing.T) {
 
 // fakeAPIGWv2APIsLister is a hand-rolled fake for the ApiGatewayV2 SDK
 // subset used by listApigatewayv2Apis. Mirrors the fake-and-pagination
-// shape of the other listers in this file.
+// shape of the other listers in this file. tokensSeen captures each
+// in.NextToken value the lister sends so tests can pin that the
+// pagination cursor is actually round-tripped between pages (not just
+// "called 3 times").
 type fakeAPIGWv2APIsLister struct {
-	listPages []apigatewayv2.GetApisOutput
-	listCalls int
-	listErr   error
+	listPages   []apigatewayv2.GetApisOutput
+	listCalls   int
+	listErr     error
+	tokensSeen  []*string
 }
 
-func (f *fakeAPIGWv2APIsLister) GetApis(_ context.Context, _ *apigatewayv2.GetApisInput, _ ...func(*apigatewayv2.Options)) (*apigatewayv2.GetApisOutput, error) {
+func (f *fakeAPIGWv2APIsLister) GetApis(_ context.Context, in *apigatewayv2.GetApisInput, _ ...func(*apigatewayv2.Options)) (*apigatewayv2.GetApisOutput, error) {
+	f.tokensSeen = append(f.tokensSeen, in.NextToken)
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
@@ -497,6 +502,26 @@ func TestListApigatewayv2Apis_PaginatesAndReturnsModels(t *testing.T) {
 	if fake.listCalls != 3 {
 		t.Errorf("listCalls=%d, want 3 (paginated across three pages)", fake.listCalls)
 	}
+	// Pin the pagination cursor round-trip: the lister must feed
+	// each page's NextToken into the next request. A regression that
+	// passes `nil` on every call (e.g. dropping `nextToken =
+	// page.NextToken`) would still produce 3 calls because the fake
+	// serves pages by call-count — only this assertion catches it.
+	if len(fake.tokensSeen) != 3 {
+		t.Fatalf("tokensSeen len=%d, want 3", len(fake.tokensSeen))
+	}
+	if fake.tokensSeen[0] != nil {
+		t.Errorf("tokensSeen[0]=%q, want nil (first request must not send a NextToken)",
+			aws.ToString(fake.tokensSeen[0]))
+	}
+	if aws.ToString(fake.tokensSeen[1]) != "tok1" {
+		t.Errorf("tokensSeen[1]=%q, want tok1 (must round-trip page-1's NextToken)",
+			aws.ToString(fake.tokensSeen[1]))
+	}
+	if aws.ToString(fake.tokensSeen[2]) != "tok2" {
+		t.Errorf("tokensSeen[2]=%q, want tok2 (must round-trip page-2's NextToken)",
+			aws.ToString(fake.tokensSeen[2]))
+	}
 	// Each emitted model must round-trip as JSON with the ApiId key
 	// present — a malformed string would crash the downstream CC
 	// ListResources call.
@@ -547,6 +572,37 @@ func TestListApigatewayv2Apis_PropagatesListError(t *testing.T) {
 	_, err := listApigatewayv2ApisWithClient(context.Background(), fake)
 	if !errors.Is(err, sentinel) {
 		t.Errorf("error chain: got %v, want chain containing %v", err, sentinel)
+	}
+}
+
+// TestListApigatewayv2Apis_EmptyStringNextTokenTerminates pins the
+// other half of the pagination terminator: the loop must also break
+// when GetApis returns NextToken=&"" (an empty pointer, not nil) on
+// the final page. The lister guards on both `nil` AND
+// `aws.ToString(*token) == ""`; without the empty-string branch we'd
+// loop forever passing an empty token to GetApis (which most likely
+// returns an error or silently restarts pagination).
+func TestListApigatewayv2Apis_EmptyStringNextTokenTerminates(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAPIGWv2APIsLister{
+		listPages: []apigatewayv2.GetApisOutput{
+			// Final page deliberately has NextToken=&"" rather than nil.
+			{
+				Items:     []apigwv2types.Api{{ApiId: aws.String("api-final")}},
+				NextToken: aws.String(""),
+			},
+		},
+	}
+	got, err := listApigatewayv2ApisWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{`{"ApiId":"api-final"}`}) {
+		t.Errorf("models drift: got %v, want [api-final only]", got)
+	}
+	if fake.listCalls != 1 {
+		t.Errorf("listCalls=%d, want 1 (empty-string NextToken must terminate the loop, not trigger another GetApis)",
+			fake.listCalls)
 	}
 }
 

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
 	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
+	apigwv2types "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
 	cogniidptypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -426,5 +428,153 @@ func TestListACMCertificates_EmptyReturnsNonNilEmpty(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("len=%d, want 0", len(got))
+	}
+}
+
+// fakeAPIGWv2APIsLister is a hand-rolled fake for the ApiGatewayV2 SDK
+// subset used by listApigatewayv2Apis. Mirrors the fake-and-pagination
+// shape of the other listers in this file.
+type fakeAPIGWv2APIsLister struct {
+	listPages []apigatewayv2.GetApisOutput
+	listCalls int
+	listErr   error
+}
+
+func (f *fakeAPIGWv2APIsLister) GetApis(_ context.Context, _ *apigatewayv2.GetApisInput, _ ...func(*apigatewayv2.Options)) (*apigatewayv2.GetApisOutput, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if f.listCalls >= len(f.listPages) {
+		return &apigatewayv2.GetApisOutput{}, nil
+	}
+	page := f.listPages[f.listCalls]
+	f.listCalls++
+	return &page, nil
+}
+
+func apigwv2APIsPage(token string, apiIDs ...string) apigatewayv2.GetApisOutput {
+	items := make([]apigwv2types.Api, 0, len(apiIDs))
+	for _, id := range apiIDs {
+		items = append(items, apigwv2types.Api{ApiId: aws.String(id)})
+	}
+	out := apigatewayv2.GetApisOutput{Items: items}
+	if token != "" {
+		out.NextToken = aws.String(token)
+	}
+	return out
+}
+
+// TestListApigatewayv2Apis_PaginatesAndReturnsModels pins the
+// API-enumeration helper used by aws_apigatewayv2_route /
+// _integration / _authorizer's ParentLister: every API across every
+// page must surface as a well-formed JSON ResourceModel string with
+// ApiId set. A regression that drops a page or emits malformed JSON
+// would silently produce zero child Route/Integration/Authorizer
+// emissions for any HTTP API after the first page.
+func TestListApigatewayv2Apis_PaginatesAndReturnsModels(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAPIGWv2APIsLister{
+		listPages: []apigatewayv2.GetApisOutput{
+			apigwv2APIsPage("tok1", "api-aaa", "api-bbb"),
+			apigwv2APIsPage("tok2", "api-ccc"),
+			apigwv2APIsPage("", "api-ddd", "api-eee"),
+		},
+	}
+	got, err := listApigatewayv2ApisWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		`{"ApiId":"api-aaa"}`,
+		`{"ApiId":"api-bbb"}`,
+		`{"ApiId":"api-ccc"}`,
+		`{"ApiId":"api-ddd"}`,
+		`{"ApiId":"api-eee"}`,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("models drift:\n got %v\nwant %v", got, want)
+	}
+	if fake.listCalls != 3 {
+		t.Errorf("listCalls=%d, want 3 (paginated across three pages)", fake.listCalls)
+	}
+	// Each emitted model must round-trip as JSON with the ApiId key
+	// present — a malformed string would crash the downstream CC
+	// ListResources call.
+	for _, m := range got {
+		var parsed map[string]string
+		if err := json.Unmarshal([]byte(m), &parsed); err != nil {
+			t.Errorf("model %q is not valid JSON: %v", m, err)
+			continue
+		}
+		if parsed["ApiId"] == "" {
+			t.Errorf("model %q missing ApiId key", m)
+		}
+	}
+}
+
+// TestListApigatewayv2Apis_EmptyAccountReturnsNonNilEmpty pins the
+// non-nil empty contract: zero APIs returns []string{}, not nil. The
+// discoverer's `len(parentModels) == 0` early-exit branch needs the
+// slice to be non-nil for the empty-region path to fire cleanly.
+func TestListApigatewayv2Apis_EmptyAccountReturnsNonNilEmpty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAPIGWv2APIsLister{
+		listPages: []apigatewayv2.GetApisOutput{
+			apigwv2APIsPage(""),
+		},
+	}
+	got, err := listApigatewayv2ApisWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("empty-region result must be non-nil (else len-check early-exit misfires)")
+	}
+	if len(got) != 0 {
+		t.Errorf("len=%d, want 0", len(got))
+	}
+}
+
+// TestListApigatewayv2Apis_PropagatesListError pins error propagation:
+// an apigateway:GetApis failure must surface to the caller wrapped, not
+// silently swallowed. The discoverer's outer error path emits a
+// ServiceFinish + propagates — losing the error here would silently
+// skip the type for the whole region.
+func TestListApigatewayv2Apis_PropagatesListError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("apigateway:GetApis boom")
+	fake := &fakeAPIGWv2APIsLister{listErr: sentinel}
+	_, err := listApigatewayv2ApisWithClient(context.Background(), fake)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("error chain: got %v, want chain containing %v", err, sentinel)
+	}
+}
+
+// TestListApigatewayv2Apis_SkipsEmptyApiID guards a defensive branch:
+// an Api whose ApiId is "" (defensively guarded in the lister) must be
+// dropped, never emitted as `{"ApiId":""}`. The downstream CC
+// ListResources call would reject the empty-ID parent model.
+func TestListApigatewayv2Apis_SkipsEmptyApiID(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAPIGWv2APIsLister{
+		listPages: []apigatewayv2.GetApisOutput{
+			{Items: []apigwv2types.Api{
+				{ApiId: aws.String("api-good")},
+				{ApiId: nil},
+				{ApiId: aws.String("")},
+				{ApiId: aws.String("api-also-good")},
+			}},
+		},
+	}
+	got, err := listApigatewayv2ApisWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		`{"ApiId":"api-good"}`,
+		`{"ApiId":"api-also-good"}`,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("empty-ID skip drift:\n got %v\nwant %v", got, want)
 	}
 }

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -793,6 +793,186 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		NativeIDsFromProperties: arnUnderKey("Arn"),
 		TagsFromProperties:      tagsFromKey("Tags"),
 	},
+
+	// =====================================================================
+	// ApiGatewayV2 Route — parent-scoped on ApiId, untaggable
+	// =====================================================================
+	{
+		// AWS::ApiGatewayV2::Route is parent-scoped: CC ListResources
+		// requires ResourceModel={"ApiId":"..."}. The CFN schema has no
+		// Tags property — SkipProjectTagFilter bypasses the Project
+		// filter (tagging happens on the parent Api).
+		TFType:               "aws_apigatewayv2_route",
+		CloudFormationType:   "AWS::ApiGatewayV2::Route",
+		Slug:                 "apigatewayv2_route",
+		SkipProjectTagFilter: true,
+		ParentLister:         listApigatewayv2Apis,
+		// Cloud Control identifier = "<ApiId>|<RouteId>"; Terraform
+		// import format = "<ApiId>/<RouteId>" (forward-slash).
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			return strings.Replace(identifier, "|", "/", 1)
+		},
+		// RouteKey (e.g. "POST /signup") is the most human-readable
+		// hint; fall back to the identifier when absent.
+		NameHintFromProperties: nameOrIdentifier("RouteKey"),
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return nil
+			}
+			return map[string]string{
+				"api_id":   parts[0],
+				"route_id": parts[1],
+			}
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
+
+	// =====================================================================
+	// ApiGatewayV2 Integration — parent-scoped on ApiId, untaggable
+	// =====================================================================
+	{
+		// AWS::ApiGatewayV2::Integration is parent-scoped on ApiId. No
+		// Tags property in the CFN schema.
+		TFType:               "aws_apigatewayv2_integration",
+		CloudFormationType:   "AWS::ApiGatewayV2::Integration",
+		Slug:                 "apigatewayv2_integration",
+		SkipProjectTagFilter: true,
+		ParentLister:         listApigatewayv2Apis,
+		// Cloud Control identifier = "<ApiId>|<IntegrationId>";
+		// Terraform import format = "<ApiId>/<IntegrationId>".
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			return strings.Replace(identifier, "|", "/", 1)
+		},
+		// No stable "name" on this type — Description when present,
+		// IntegrationType ("AWS_PROXY", "HTTP_PROXY", …) otherwise,
+		// then the identifier.
+		NameHintFromProperties: func(identifier string, props map[string]any) string {
+			if name := extractString(props, "Description"); name != "" {
+				return name
+			}
+			if name := extractString(props, "IntegrationType"); name != "" {
+				return name
+			}
+			return identifier
+		},
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return nil
+			}
+			return map[string]string{
+				"api_id":         parts[0],
+				"integration_id": parts[1],
+			}
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
+
+	// =====================================================================
+	// ApiGatewayV2 Authorizer — parent-scoped on ApiId, untaggable
+	// =====================================================================
+	{
+		// AWS::ApiGatewayV2::Authorizer is parent-scoped on ApiId. No
+		// Tags property in the CFN schema.
+		TFType:               "aws_apigatewayv2_authorizer",
+		CloudFormationType:   "AWS::ApiGatewayV2::Authorizer",
+		Slug:                 "apigatewayv2_authorizer",
+		SkipProjectTagFilter: true,
+		ParentLister:         listApigatewayv2Apis,
+		// Cloud Control identifier = "<ApiId>|<AuthorizerId>";
+		// Terraform import format = "<ApiId>/<AuthorizerId>".
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			return strings.Replace(identifier, "|", "/", 1)
+		},
+		NameHintFromProperties: nameOrIdentifier("Name"),
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return nil
+			}
+			return map[string]string{
+				"api_id":        parts[0],
+				"authorizer_id": parts[1],
+			}
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
+
+	// =====================================================================
+	// Cognito Identity Provider — parent-scoped on UserPoolId, untaggable
+	// =====================================================================
+	{
+		// AWS::Cognito::UserPoolIdentityProvider is parent-scoped on
+		// UserPoolId. No Tags property in the CFN schema.
+		TFType:               "aws_cognito_identity_provider",
+		CloudFormationType:   "AWS::Cognito::UserPoolIdentityProvider",
+		Slug:                 "cognito_identity_provider",
+		SkipProjectTagFilter: true,
+		ParentLister:         listCognitoUserPools,
+		// Cloud Control identifier = "<UserPoolId>|<ProviderName>";
+		// Terraform import format = "<UserPoolId>:<ProviderName>"
+		// (colon, NOT forward-slash — divergent from the other
+		// compound-ID types in this file). Verified against
+		// terraform-provider-aws v6.x docs for
+		// aws_cognito_identity_provider.
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			return strings.Replace(identifier, "|", ":", 1)
+		},
+		NameHintFromProperties: nameOrIdentifier("ProviderName"),
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return nil
+			}
+			return map[string]string{
+				"user_pool_id":  parts[0],
+				"provider_name": parts[1],
+			}
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
+
+	// =====================================================================
+	// Cognito Resource Server — parent-scoped on UserPoolId, untaggable
+	// =====================================================================
+	{
+		// AWS::Cognito::UserPoolResourceServer is parent-scoped on
+		// UserPoolId. No Tags property in the CFN schema.
+		TFType:               "aws_cognito_resource_server",
+		CloudFormationType:   "AWS::Cognito::UserPoolResourceServer",
+		Slug:                 "cognito_resource_server",
+		SkipProjectTagFilter: true,
+		ParentLister:         listCognitoUserPools,
+		// Cloud Control identifier = "<UserPoolId>|<Identifier>";
+		// Terraform import format is the same pipe-delimited shape
+		// (NOT rewritten to "/"). Verified against
+		// terraform-provider-aws v6.x docs for
+		// aws_cognito_resource_server.
+		ImportIDFromIdentifier: passthroughImportID,
+		// Resource Server "Name" is the human-readable display name;
+		// "Identifier" is the OAuth scope namespace (also useful).
+		NameHintFromProperties: func(identifier string, props map[string]any) string {
+			if name := extractString(props, "Name"); name != "" {
+				return name
+			}
+			if name := extractString(props, "Identifier"); name != "" {
+				return name
+			}
+			return identifier
+		},
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return nil
+			}
+			return map[string]string{
+				"user_pool_id": parts[0],
+				"identifier":   parts[1],
+			}
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
 }
 
 // passthroughImportID is the common ImportIDFromIdentifier used by every

--- a/pkg/composer/imported/category.go
+++ b/pkg/composer/imported/category.go
@@ -78,6 +78,9 @@ var categoryByTFType = map[string]string{
 	// --- AWS ---
 	"aws_acm_certificate":                 CategorySecurity,
 	"aws_apigatewayv2_api":                CategoryNetworkSecurity,
+	"aws_apigatewayv2_authorizer":         CategoryNetworkSecurity,
+	"aws_apigatewayv2_integration":        CategoryNetworkSecurity,
+	"aws_apigatewayv2_route":              CategoryNetworkSecurity,
 	"aws_apigatewayv2_stage":              CategoryNetworkSecurity,
 	"aws_backup_plan":                     CategoryDataStorage,
 	"aws_backup_selection":                CategoryDataStorage,
@@ -88,6 +91,8 @@ var categoryByTFType = map[string]string{
 	"aws_cloudwatch_event_rule":           CategoryEvents,
 	"aws_cloudwatch_log_group":            CategoryObservability,
 	"aws_cloudwatch_metric_alarm":         CategoryObservability,
+	"aws_cognito_identity_provider":       CategorySecurity,
+	"aws_cognito_resource_server":         CategorySecurity,
 	"aws_cognito_user_pool":               CategorySecurity,
 	"aws_cognito_user_pool_client":        CategorySecurity,
 	"aws_cognito_user_pool_domain":        CategorySecurity,

--- a/pkg/composer/imported/testdata/category.golden
+++ b/pkg/composer/imported/testdata/category.golden
@@ -1,5 +1,8 @@
 aws_acm_certificate	Security
 aws_apigatewayv2_api	Network Security
+aws_apigatewayv2_authorizer	Network Security
+aws_apigatewayv2_integration	Network Security
+aws_apigatewayv2_route	Network Security
 aws_apigatewayv2_stage	Network Security
 aws_backup_plan	Data Storage
 aws_backup_selection	Data Storage
@@ -10,6 +13,8 @@ aws_cloudwatch_dashboard	Observability
 aws_cloudwatch_event_rule	Events
 aws_cloudwatch_log_group	Observability
 aws_cloudwatch_metric_alarm	Observability
+aws_cognito_identity_provider	Security
+aws_cognito_resource_server	Security
 aws_cognito_user_pool	Security
 aws_cognito_user_pool_client	Security
 aws_cognito_user_pool_domain	Security

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -38,6 +38,9 @@ const (
 // this list stays in sync with the bash array.
 var untaggableAWS = map[string]struct{}{
 	"aws_apigatewayv2_api_mapping":                       {},
+	"aws_apigatewayv2_authorizer":                        {},
+	"aws_apigatewayv2_integration":                       {},
+	"aws_apigatewayv2_route":                             {},
 	"aws_backup_selection":                               {},
 	"aws_bedrock_model_invocation_logging_configuration": {},
 	"aws_cloudfront_monitoring_subscription":             {},
@@ -46,6 +49,7 @@ var untaggableAWS = map[string]struct{}{
 	"aws_cloudwatch_log_resource_policy":                 {},
 	"aws_cloudwatch_log_stream":                          {},
 	"aws_cognito_identity_provider":                      {},
+	"aws_cognito_resource_server":                        {},
 	"aws_cognito_user_pool_client":                       {},
 	"aws_cognito_user_pool_domain":                       {},
 	"aws_dynamodb_contributor_insights":                  {},

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -40,7 +40,7 @@
     {
       "service": "apigatewayv2_authorizer",
       "iam_action": "apigateway:GET",
-      "purpose": "Cloud Control GetResource for aws_apigatewayv2_authorizer delegates to apigateway:GET (GET /apis/*/authorizers/*)"
+      "purpose": "Cloud Control GetResource for aws_apigatewayv2_authorizer delegates to apigateway:GET (GET /apis/*/authorizers/*); also covers parent enumeration (GET /apis) to fan ListResources out per ApiId"
     },
     {
       "service": "apigatewayv2_authorizer",
@@ -55,7 +55,7 @@
     {
       "service": "apigatewayv2_integration",
       "iam_action": "apigateway:GET",
-      "purpose": "Cloud Control GetResource for aws_apigatewayv2_integration delegates to apigateway:GET (GET /apis/*/integrations/*)"
+      "purpose": "Cloud Control GetResource for aws_apigatewayv2_integration delegates to apigateway:GET (GET /apis/*/integrations/*); also covers parent enumeration (GET /apis) to fan ListResources out per ApiId"
     },
     {
       "service": "apigatewayv2_integration",
@@ -70,7 +70,7 @@
     {
       "service": "apigatewayv2_route",
       "iam_action": "apigateway:GET",
-      "purpose": "Cloud Control GetResource for aws_apigatewayv2_route delegates to apigateway:GET (GET /apis/*/routes/*)"
+      "purpose": "Cloud Control GetResource for aws_apigatewayv2_route delegates to apigateway:GET (GET /apis/*/routes/*); also covers parent enumeration (GET /apis) to fan ListResources out per ApiId"
     },
     {
       "service": "apigatewayv2_route",

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -38,6 +38,51 @@
       "purpose": "Cloud Control ListResources for AWS::ApiGatewayV2::Api (cache-miss fallback when RGT prefetch is unavailable)"
     },
     {
+      "service": "apigatewayv2_authorizer",
+      "iam_action": "apigateway:GET",
+      "purpose": "Cloud Control GetResource for aws_apigatewayv2_authorizer delegates to apigateway:GET (GET /apis/*/authorizers/*)"
+    },
+    {
+      "service": "apigatewayv2_authorizer",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::ApiGatewayV2::Authorizer (#416 ParentLister branch on ApiId)"
+    },
+    {
+      "service": "apigatewayv2_authorizer",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::ApiGatewayV2::Authorizer (per-ApiId fan-out)"
+    },
+    {
+      "service": "apigatewayv2_integration",
+      "iam_action": "apigateway:GET",
+      "purpose": "Cloud Control GetResource for aws_apigatewayv2_integration delegates to apigateway:GET (GET /apis/*/integrations/*)"
+    },
+    {
+      "service": "apigatewayv2_integration",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::ApiGatewayV2::Integration (#416 ParentLister branch on ApiId)"
+    },
+    {
+      "service": "apigatewayv2_integration",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::ApiGatewayV2::Integration (per-ApiId fan-out)"
+    },
+    {
+      "service": "apigatewayv2_route",
+      "iam_action": "apigateway:GET",
+      "purpose": "Cloud Control GetResource for aws_apigatewayv2_route delegates to apigateway:GET (GET /apis/*/routes/*)"
+    },
+    {
+      "service": "apigatewayv2_route",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::ApiGatewayV2::Route (#416 ParentLister branch on ApiId)"
+    },
+    {
+      "service": "apigatewayv2_route",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::ApiGatewayV2::Route (per-ApiId fan-out)"
+    },
+    {
       "service": "apigatewayv2_stage",
       "iam_action": "apigateway:GET",
       "purpose": "list per-API stages (GET /apis/*/stages); shares apigateway:GET with apigatewayv2_api"
@@ -226,6 +271,46 @@
       "service": "cloudwatchlogs",
       "iam_action": "logs:ListTagsForResource",
       "purpose": "fetch log-group tags for tag selectors and Identity.Tags"
+    },
+    {
+      "service": "cognito_identity_provider",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::Cognito::UserPoolIdentityProvider (#416 ParentLister branch on UserPoolId)"
+    },
+    {
+      "service": "cognito_identity_provider",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::Cognito::UserPoolIdentityProvider (per-UserPoolId fan-out)"
+    },
+    {
+      "service": "cognito_identity_provider",
+      "iam_action": "cognito-idp:DescribeIdentityProvider",
+      "purpose": "Cloud Control GetResource for aws_cognito_identity_provider delegates to cognito-idp:DescribeIdentityProvider"
+    },
+    {
+      "service": "cognito_identity_provider",
+      "iam_action": "cognito-idp:ListUserPools",
+      "purpose": "parent enumeration: list UserPools to fan ListResources out per UserPoolId"
+    },
+    {
+      "service": "cognito_resource_server",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::Cognito::UserPoolResourceServer (#416 ParentLister branch on UserPoolId)"
+    },
+    {
+      "service": "cognito_resource_server",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::Cognito::UserPoolResourceServer (per-UserPoolId fan-out)"
+    },
+    {
+      "service": "cognito_resource_server",
+      "iam_action": "cognito-idp:DescribeResourceServer",
+      "purpose": "Cloud Control GetResource for aws_cognito_resource_server delegates to cognito-idp:DescribeResourceServer"
+    },
+    {
+      "service": "cognito_resource_server",
+      "iam_action": "cognito-idp:ListUserPools",
+      "purpose": "parent enumeration: list UserPools to fan ListResources out per UserPoolId"
     },
     {
       "service": "cognito_user_pool",

--- a/pkg/insideout-import/permissions/permissions_test.go
+++ b/pkg/insideout-import/permissions/permissions_test.go
@@ -19,6 +19,9 @@ import (
 var awsTFTypeToServiceSlug = map[string]string{
 	"aws_acm_certificate":                 "acm_certificate",
 	"aws_apigatewayv2_api":                "apigatewayv2_api",
+	"aws_apigatewayv2_authorizer":         "apigatewayv2_authorizer",
+	"aws_apigatewayv2_integration":        "apigatewayv2_integration",
+	"aws_apigatewayv2_route":              "apigatewayv2_route",
 	"aws_apigatewayv2_stage":              "apigatewayv2_stage",
 	"aws_backup_plan":                     "backup_plan",
 	"aws_backup_selection":                "backup_selection",
@@ -29,6 +32,8 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_cloudwatch_event_rule":           "cloudwatch_event_rule",
 	"aws_cloudwatch_log_group":            "cloudwatchlogs",
 	"aws_cloudwatch_metric_alarm":         "cloudwatch_metric_alarm",
+	"aws_cognito_identity_provider":       "cognito_identity_provider",
+	"aws_cognito_resource_server":         "cognito_resource_server",
 	"aws_cognito_user_pool":               "cognito_user_pool",
 	"aws_cognito_user_pool_client":        "cognito_user_pool_client",
 	"aws_cognito_user_pool_domain":        "cognito_user_pool_domain",

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -25,6 +25,9 @@ const (
 var awsTypes = []string{
 	"aws_acm_certificate",
 	"aws_apigatewayv2_api",
+	"aws_apigatewayv2_authorizer",
+	"aws_apigatewayv2_integration",
+	"aws_apigatewayv2_route",
 	"aws_apigatewayv2_stage",
 	"aws_backup_plan",
 	"aws_backup_selection",
@@ -35,6 +38,8 @@ var awsTypes = []string{
 	"aws_cloudwatch_event_rule",
 	"aws_cloudwatch_log_group",
 	"aws_cloudwatch_metric_alarm",
+	"aws_cognito_identity_provider",
+	"aws_cognito_resource_server",
 	"aws_cognito_user_pool",
 	"aws_cognito_user_pool_client",
 	"aws_cognito_user_pool_domain",

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -20,6 +20,9 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 	want := []string{
 		"aws_acm_certificate",
 		"aws_apigatewayv2_api",
+		"aws_apigatewayv2_authorizer",
+		"aws_apigatewayv2_integration",
+		"aws_apigatewayv2_route",
 		"aws_apigatewayv2_stage",
 		"aws_backup_plan",
 		"aws_backup_selection",
@@ -30,6 +33,8 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_cloudwatch_event_rule",
 		"aws_cloudwatch_log_group",
 		"aws_cloudwatch_metric_alarm",
+		"aws_cognito_identity_provider",
+		"aws_cognito_resource_server",
 		"aws_cognito_user_pool",
 		"aws_cognito_user_pool_client",
 		"aws_cognito_user_pool_domain",

--- a/tests/lint-project-tag.sh
+++ b/tests/lint-project-tag.sh
@@ -25,6 +25,9 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # Keep sorted alphabetically.
 NON_TAGGABLE_AWS=(
   aws_apigatewayv2_api_mapping
+  aws_apigatewayv2_authorizer
+  aws_apigatewayv2_integration
+  aws_apigatewayv2_route
   aws_backup_selection
   aws_bedrock_model_invocation_logging_configuration
   aws_cloudfront_monitoring_subscription
@@ -33,6 +36,7 @@ NON_TAGGABLE_AWS=(
   aws_cloudwatch_log_resource_policy
   aws_cloudwatch_log_stream
   aws_cognito_identity_provider
+  aws_cognito_resource_server
   aws_cognito_user_pool_client
   aws_cognito_user_pool_domain
   aws_dynamodb_contributor_insights


### PR DESCRIPTION
## Summary

Expands AWS discovery coverage **50 → 55** by exercising the proven `ParentLister` branch (introduced in #412) for five more parent-scoped types. **Pure config + tests + wiring — no framework changes.**

Types added:

| TF type | CFN type | Parent enum (SDK) | Parent ResourceModel |
|---|---|---|---|
| `aws_apigatewayv2_route` | `AWS::ApiGatewayV2::Route` | `apigatewayv2:GetApis` | `{"ApiId":"..."}` |
| `aws_apigatewayv2_integration` | `AWS::ApiGatewayV2::Integration` | `apigatewayv2:GetApis` | `{"ApiId":"..."}` |
| `aws_apigatewayv2_authorizer` | `AWS::ApiGatewayV2::Authorizer` | `apigatewayv2:GetApis` | `{"ApiId":"..."}` |
| `aws_cognito_identity_provider` | `AWS::Cognito::UserPoolIdentityProvider` | `cognito-idp:ListUserPools` (reused from #412) | `{"UserPoolId":"..."}` |
| `aws_cognito_resource_server` | `AWS::Cognito::UserPoolResourceServer` | `cognito-idp:ListUserPools` (reused from #412) | `{"UserPoolId":"..."}` |

All five lack a CFN `Tags` property → `SkipProjectTagFilter=true`, `emptyTagsExtractor` (preserves the #255 non-nil empty-map contract).

### ImportID rewrites — five types, three different shapes

Pinned in extractor tests against terraform-provider-aws v6.x docs:

- `apigatewayv2_{route,integration,authorizer}`: `|→/` (forward-slash)
- `cognito_identity_provider`: `|→:` (**colon**, not slash — diverges from every other compound-ID type in the file)
- `cognito_resource_server`: passthrough (TF preserves the pipe)

The colon-vs-slash divergence is the most error-prone bit; the test failure message explicitly calls out `" |→COLON (not slash)"` so any naive standardization regresses loudly. Multi-pipe identifiers also pinned for first-`|`-only contract.

### NameHint chains

Each follows the human-readability heuristic of the underlying type:

- Route → `RouteKey` (e.g. `"POST /signup"`)
- Integration → `Description` → `IntegrationType` → identifier
- Authorizer → `Name`
- Identity provider → `ProviderName`
- Resource server → `Name` → `Identifier` → identifier

### Wiring

Standard pathways updated:

- `pkg/insideout-import/registry/{registry.go,registry_test.go}` — 5 sorted entries + canonical-list test
- `pkg/insideout-import/permissions/{aws.json,permissions_test.go}` — 20 IAM rows + slug-map entries (the apigatewayv2 children share `apigateway:GET` for both `GetResource` and parent enumeration; purpose strings document both call paths)
- `pkg/composer/imported/{category.go,testdata/category.golden}` — 5 categories (network/security)
- `pkg/composer/imported_provenance.go` — 4 entries added to `untaggableAWS` (`cognito_identity_provider` was already there)
- `tests/lint-project-tag.sh` — 4 entries in `NON_TAGGABLE_AWS`

## Test plan

- [x] `go test ./... -race -count=1` — 4197/4197 pass
- [x] `terraform fmt -check -recursive` — clean
- [x] `tests/lint-project-tag.sh` / `lint-project-label.sh` / `lint-sensitive-for-each.sh` / `lint-foreach-unknown-keys.sh` — all PASS
- [x] Extractor pins for all 5 types (ImportID, NameHint chain, NativeIDs structured + malformed-id `nil`, Tags non-nil empty)
- [x] Lister pins for the new `listApigatewayv2Apis`: pagination (multi-page), pagination cursor round-trip via captured `tokensSeen`, empty-account non-nil, error propagation via `errors.Is`, empty-ApiId skip, both `nil` and `&""` NextToken terminators
- [ ] Live smoke against test account 141812438321 / `io-f-v6e-hzw-zt` post-merge (expects non-zero emissions for apigatewayv2_route/integration/authorizer since the test project has `aws_apigatewayv2_api` emissions from #412's smoke)

## Review notes

- `/review`: 0× P0, 0× P1, 4× P2 — all addressed in fixup `ac96e05`
- `qa-professor`: PASS with 3× P3 — the one with real signal (fake didn't pin pagination cursor round-trip) is addressed in the same fixup; the other two are marginal and skipped

Closes #416.