### PR TITLE
ci(enrichgen): override-author citation lint (#415)

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -164,6 +164,9 @@ jobs:
       - name: Lint phantom-computed-fields denylist ↔ NOTE comments (#215)
         run: bash tests/lint-phantom-computed-fields.sh
 
+      - name: Lint enrichgen override citation comments (#415)
+        run: bash tests/lint-enrichgen-override-citations.sh
+
   # Validates phantom-computed-fields.txt against the live provider schema
   # pinned by schemas/providers.tf. Catches the failure mode where a
   # provider upgrade flips a field from pure-Computed to Optional+Computed

--- a/cmd/enrichgen/compute_network.go
+++ b/cmd/enrichgen/compute_network.go
@@ -31,10 +31,11 @@ var computeNetworkTarget = target{
 	outputPath:   "cmd/insideout-import/gcpdiscover/compute_network_enrich.gen.go",
 
 	overrides: map[string]override{
-		// project: from projectID parameter. The compute API's
-		// Network response includes a SelfLink that embeds the
-		// project, but we already have the string project ID from
-		// the discover context — use that to avoid a second parse.
+		// project: caller supplies via the projectID parameter.
+		// The compute API's Network response includes a SelfLink
+		// that embeds the project, but we already have the string
+		// project ID from the discover context — use that to avoid
+		// a second parse.
 		"GoogleComputeNetwork.project": {
 			snippet: func(b, f string) string {
 				return `if projectID != "" {
@@ -43,10 +44,12 @@ var computeNetworkTarget = target{
 			},
 		},
 
-		// routing_mode: the typed schema puts this at the top
-		// level, the API tucks it under RoutingConfig. The
-		// engine's wrapperIndirection mechanism is slice-only; this
-		// is the scalar version, done inline.
+		// routing_mode: mirror the provider's flatten of
+		// RoutingConfig.RoutingMode onto the top-level TF
+		// attribute. The typed schema puts this at the top level;
+		// the API tucks it under RoutingConfig. The engine's
+		// wrapperIndirection mechanism is slice-only, so this
+		// scalar version is done inline here.
 		"GoogleComputeNetwork.routing_mode": {
 			snippet: func(b, f string) string {
 				return `if ` + b + `.RoutingConfig != nil && ` + b + `.RoutingConfig.RoutingMode != "" {

--- a/cmd/enrichgen/pubsub_subscription.go
+++ b/cmd/enrichgen/pubsub_subscription.go
@@ -43,16 +43,18 @@ func pubsubSubscriptionShortName(full string) string {
 `,
 
 	overrides: map[string]override{
-		// name: same shape as pubsub_topic — API returns the
-		// fully-qualified form, TF state stores the short name.
+		// name: mirror the provider's read-time short-name flatten
+		// (same shape as pubsub_topic) — API returns the fully-
+		// qualified form, TF state stores the short name.
 		"GooglePubsubSubscription.name": {
 			snippet: func(b, f string) string {
 				return "out." + f + " = generated.LiteralOf(pubsubSubscriptionShortName(" + b + ".Name))"
 			},
 		},
 
-		// project: API embeds project only in Name; populate from
-		// the projectID parameter.
+		// project: caller supplies via the projectID parameter. The
+		// API embeds the project only in Name, but we already have
+		// the string project ID from the discover context.
 		"GooglePubsubSubscription.project": {
 			snippet: func(b, f string) string {
 				return `if projectID != "" {

--- a/cmd/enrichgen/secret_manager_secret.go
+++ b/cmd/enrichgen/secret_manager_secret.go
@@ -47,17 +47,17 @@ func secretShortID(full string) string {
 `,
 
 	overrides: map[string]override{
-		// secret_id: Required. Derived from API.Name's last segment
-		// — TF state stores the short ID, the API returns the full
-		// resource name.
+		// secret_id: Required. Mirror the provider's flatten of
+		// API.Name's last segment — TF state stores the short ID,
+		// the API returns the full resource name.
 		"GoogleSecretManagerSecret.secret_id": {
 			snippet: func(b, f string) string {
 				return "out." + f + " = generated.LiteralOf(secretShortID(" + b + ".Name))"
 			},
 		},
 
-		// project: from projectID parameter (same shape as the
-		// other Google services in this family).
+		// project: caller supplies via the projectID parameter
+		// (same shape as the other Google services in this family).
 		"GoogleSecretManagerSecret.project": {
 			snippet: func(b, f string) string {
 				return `if projectID != "" {
@@ -66,10 +66,12 @@ func secretShortID(full string) string {
 			},
 		},
 
-		// ttl: API field exists but is Input-only — the API never
-		// echoes it back on Get. The engine's default mapping would
-		// produce a no-op (the "" guard suppresses emission), but
-		// skip explicitly so the reader sees the intent.
+		// ttl: input-only API field — the API never echoes it back
+		// on Get, so it is effectively computed-only from the
+		// enricher's perspective (decision #5 territory). The
+		// engine's default mapping would produce a no-op (the ""
+		// guard suppresses emission), but skip explicitly so the
+		// reader sees the intent.
 		"GoogleSecretManagerSecret.ttl": {snippet: skip},
 
 		// Computed-only / TF-only sentinel fields per decision #5.

--- a/cmd/enrichgen/storage_bucket.go
+++ b/cmd/enrichgen/storage_bucket.go
@@ -131,10 +131,11 @@ func billingRequesterPays(b *storagev1.BucketBilling) bool {
 		"GoogleStorageBucket.terraform_labels": {snippet: skip},
 		"GoogleStorageBucket.timeouts":         {snippet: skip},
 
-		// LogBucket is TF-Required inside the logging block — emit
-		// unconditionally rather than guarding on != "" so a logging
-		// block with an empty bucket name (would be schema-invalid
-		// anyway) still emits the field for visibility on review.
+		// LogBucket: block-content for the logging block (TF-Required
+		// inside the gate). Emit unconditionally rather than guarding
+		// on != "" so a logging block with an empty bucket name (would
+		// be schema-invalid anyway) still emits the field for
+		// visibility on review.
 		"GoogleStorageBucketLogging.log_bucket": {
 			snippet: func(b, f string) string {
 				return "out." + f + " = generated.LiteralOf(" + b + ".LogBucket)"
@@ -150,9 +151,11 @@ func billingRequesterPays(b *storagev1.BucketBilling) bool {
 			},
 		},
 
-		// IsLive *bool tri-state → with_state enum mapping. nil means
-		// "ANY" which the provider expresses by omitting the field;
-		// true → "LIVE", false → "ARCHIVED".
+		// with_state: mirror terraform-provider-google's
+		// flattenBucketLifecycleRuleCondition mapping of the API's
+		// IsLive *bool tri-state onto the TF enum. nil → omit the
+		// field (the provider's "ANY" default); true → "LIVE";
+		// false → "ARCHIVED".
 		"GoogleStorageBucketLifecycleRuleCondition.with_state": {
 			snippet: func(b, f string) string {
 				return `if ` + b + `.IsLive != nil {
@@ -171,8 +174,9 @@ func billingRequesterPays(b *storagev1.BucketBilling) bool {
 		"GoogleStorageBucketLifecycleRuleCondition.send_days_since_noncurrent_time_if_zero": {snippet: skip},
 		"GoogleStorageBucketLifecycleRuleCondition.send_num_newer_versions_if_zero":         {snippet: skip},
 
-		// SoftDeletePolicy.effective_time is computed by the GCS API
-		// (it's the timestamp at which the policy took effect). Skip.
+		// SoftDeletePolicy.effective_time: computed-only (the GCS API
+		// returns the timestamp at which the policy took effect; TF
+		// schema marks it Computed per decision #5). Skip.
 		"GoogleStorageBucketSoftDeletePolicy.effective_time": {snippet: skip},
 	},
 

--- a/tests/lint-enrichgen-override-citations.sh
+++ b/tests/lint-enrichgen-override-citations.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Static analysis: every entry in a per-type `overrides:` map under
+# cmd/enrichgen/<type>.go must be preceded by a comment that places it
+# in one of nine allowed justification categories.
+#
+# Why this exists: overrides exist precisely because the engine's
+# default reflection-driven mapping doesn't capture the per-field
+# semantics the TF provider applies. The bug class this lint defends
+# against (e.g. issue #415, commit 6985127's `enable_object_retention`
+# Mode-gate fix) is "author wrote an override without checking what
+# terraform-provider-google actually does for that field, so our
+# generator's output diverges from real TF state on first import."
+#
+# The lint cannot verify that the author's claim is correct (no
+# automated provider-comparison harness; see issue #415 for the
+# investigation that ruled that out). But by requiring the author to
+# place each override in a labelled justification category, it
+# forces a deliberate moment of "why am I writing this override?"
+# at PR-author time and surfaces the answer at PR-review time.
+#
+# Categories (any one token in the preceding comment block, or on the
+# override key line itself, satisfies the lint):
+#
+#   1. Provider citation:    flattenXxx / setXxx / terraform-provider-google
+#                            / "mirror the provider"
+#   2. TF-only sentinel:     the literal token TF-only
+#   3. Computed-only skip:   computed-only
+#   4. Decision-doc ref:     decision #N (covers decision #5, decision #34, ...)
+#   5. Caller-supplied:      caller
+#   6. Block decoration:     block-
+#
+# Out of scope: wrapperIndirections and blockGates maps. Those are
+# emit-or-skip and traversal-shape decisions, different bug class from
+# the value-semantics drift overrides protect against.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+shopt -s nullglob
+files=("$REPO_ROOT"/cmd/enrichgen/*.go)
+if (( ${#files[@]} == 0 )); then
+  echo "FAIL: no files matched cmd/enrichgen/*.go — has the generator moved?"
+  exit 1
+fi
+
+echo "=== Checking cmd/enrichgen override entries for citation comments ==="
+echo
+
+any_fail=0
+
+for f in "${files[@]}"; do
+  # Skip files that have no overrides map at all (engine.go, registry.go,
+  # main.go). awk handles them safely too, but skipping is faster.
+  if ! grep -q 'overrides:[[:space:]]*map\[string\]override' "$f"; then
+    continue
+  fi
+
+  awk '
+    function matches_category(s,    re) {
+      # Provider citation: function name like flattenBucketX, or prose
+      # use of "flatten" / "flattened from", or an explicit terraform-
+      # provider-google reference, or a "Mirror... provider" claim.
+      if (s ~ /[fF]latten/) return 1
+      if (s ~ /[sS]et[A-Z][a-z]/) return 1
+      if (s ~ /terraform-provider-google/) return 1
+      if (s ~ /[Mm]irror[^.]*provider/) return 1
+      # TF-only sentinel.
+      if (s ~ /TF-only/) return 1
+      # Computed-only skip (decision #5).
+      if (s ~ /[Cc]omputed-only/) return 1
+      # Reference to a numbered decision doc (decision #5, decision-#34, ...).
+      if (s ~ /[Dd]ecision[ -]#[0-9]+/) return 1
+      # Caller-supplied (value comes from a parameter, not the API).
+      if (s ~ /[Cc]aller/) return 1
+      # Block decoration (field inside a nested block whose presence is
+      # gated by the parent blockGate).
+      if (s ~ /[Bb]lock-/) return 1
+      return 0
+    }
+
+    function report(line_no, text, comm,    n, ls, i) {
+      printf "%s:%d: ERROR: override entry lacks a citation comment\n", FILENAME, line_no
+      printf "  override key line: %s\n", text
+      if (comm != "") {
+        n = split(comm, ls, "\n")
+        printf "  preceding comment block (no allowed token):\n"
+        for (i = 1; i <= n; i++) { printf "    %s\n", ls[i] }
+      } else {
+        printf "  no preceding comment block\n"
+      }
+      printf "  Add a comment containing one of:\n"
+      printf "    - flattenXxx / setXxx / terraform-provider-google / \"mirror the provider\"\n"
+      printf "    - TF-only\n"
+      printf "    - computed-only\n"
+      printf "    - decision #N\n"
+      printf "    - caller\n"
+      printf "    - block-\n"
+      failed = 1
+    }
+
+    function check_entry(line_no, text, comm) {
+      if (matches_category(comm)) return
+      if (matches_category(text)) return
+      report(line_no, text, comm)
+    }
+
+    BEGIN {
+      failed = 0
+      comment_block = ""
+      pending = 0
+      pending_line = 0
+      pending_text = ""
+      pending_comment = ""
+      pending_count = 0
+    }
+
+    # Comment line: extend the current comment block.
+    /^[[:space:]]*\/\// {
+      if (comment_block == "") {
+        comment_block = $0
+      } else {
+        comment_block = comment_block "\n" $0
+      }
+      next
+    }
+
+    # Blank line: drop the comment block (it does not extend across
+    # blanks). Also abandon any pending classification — a key whose
+    # body never reached snippet:/APIPath: is malformed; let the Go
+    # compiler complain.
+    /^[[:space:]]*$/ {
+      comment_block = ""
+      if (pending) { pending = 0 }
+      next
+    }
+
+    # Override-key candidate: "Google<...>.<field>": {
+    /^[[:space:]]*"Google[A-Za-z]+\.[a-z_]+":[[:space:]]*\{/ {
+      key_line = NR
+      key_text = $0
+      if ($0 ~ /snippet:/) {
+        # Single-line entry (e.g. {snippet: skip},). Check immediately.
+        check_entry(key_line, key_text, comment_block)
+        # Keep comment_block in scope for consecutive entries.
+        next
+      }
+      if ($0 ~ /APIPath:/) {
+        # Inline wrapperIndirection — not in scope for this lint.
+        next
+      }
+      # Multi-line entry: defer the check until we know its kind.
+      pending = 1
+      pending_line = key_line
+      pending_text = key_text
+      pending_comment = comment_block
+      pending_count = 0
+      next
+    }
+
+    # While pending classification, peek subsequent lines for the
+    # discriminating keyword. Give up after a small window.
+    pending {
+      pending_count++
+      if ($0 ~ /snippet:/) {
+        check_entry(pending_line, pending_text, pending_comment)
+        pending = 0
+        next
+      }
+      if ($0 ~ /APIPath:/) {
+        pending = 0
+        next
+      }
+      if (pending_count > 8) {
+        # Not an override entry shape we recognize. Move on silently;
+        # the lint is best-effort, not a parser.
+        pending = 0
+      }
+      next
+    }
+
+    END { exit failed }
+  ' "$f" || any_fail=1
+done
+
+if (( any_fail )); then
+  echo
+  echo "FAIL: One or more overrides in cmd/enrichgen/*.go lack a justification comment."
+  echo "Fix: add a comment immediately above the override entry (or to the same"
+  echo "logical comment block) that places it in one of the six categories above."
+  echo "See tests/lint-enrichgen-override-citations.sh for the full rationale and"
+  echo "issue #415 for why this lint exists in lieu of a provider-comparison harness."
+  exit 1
+fi
+
+echo "PASS: All cmd/enrichgen overrides carry a citation comment."


### PR DESCRIPTION
## Summary

Adds `tests/lint-enrichgen-override-citations.sh` — a static check that every entry in a per-type `overrides:` map under `cmd/enrichgen/<type>.go` is preceded by a comment placing it in one of six labelled justification categories. Wired into the existing `lint` CI job; passes already on this branch's tree, with prose touch-ups across all 5 GCP enricher types to satisfy the categories without changing any generator output.

Closes #415.

## Why this and not the provider-comparison harness #415 originally proposed

The original issue proposed vendoring `terraform-provider-google`, exposing a shim around the package-private `setStorageBucket`, and driving its flatteners in CI to diff against our generated `mapXxx` output. After investigation:

- **No out-of-band representation of flatten semantics exists.** [Terraformer](https://github.com/GoogleCloudPlatform/terraformer) — the same problem class, archived March 2026 — never built a flatten-verification harness; their only check was `terraform plan` zero-diff after import. HashiCorp's official ["generate flatten/expand" codegen](https://github.com/hashicorp/terraform-plugin-codegen-framework/issues/31) has been open and unresolved since August 2023 and only targets plugin-framework providers anyway (terraform-provider-google is plugin-SDK).
- **Effort vs. bug rate.** Vendoring would add ~600 LOC of vendor/shim/build-tag machinery + ongoing maintenance for a bug class found at low frequency (1 in 5 types shipped, caught in pre-release).
- **The discipline that caught the bug already existed; it just wasn't enforced.** The `enable_object_retention` fix in 6985127 cites `flattenBucketObjectRetention` in its comment and adds a regression test. If that discipline had been required at PR-author time, the bug would have been caught at PR-review time. The lint operationalizes it.

## What the lint enforces

Every override entry's preceding comment block (or the override key line itself) must contain at least one token from these categories:

| Category | Example tokens |
| --- | --- |
| Provider citation | `flattenBucketObjectRetention`, `setStorageBucket`, `terraform-provider-google`, `Mirror the provider` |
| TF-only sentinel | `TF-only` |
| Computed-only skip | `computed-only` |
| Decision-doc reference | `decision #5`, `decision #34` |
| Caller-supplied | `caller` |
| Block decoration | `block-` |

The lint cannot verify that the author's claim is correct (no automated provider-comparison harness — see issue #415's investigation). But by requiring the author to label each override, it forces a deliberate "why am I writing this override?" moment at author time and surfaces the answer at review time.

## Out of scope (deferred to follow-ups if the bug rate warrants)

- Provider-binding verification (vendor, shim, build-tags).
- Mocked-HTTP + `terraform import` + golden state JSON harness.
- Promoting the existing pre-release live smokes to a weekly cron.
- AWS enricher coverage (AWS enrichers don't ship yet).

## Test plan

- [x] Lint passes on the current tree: `bash tests/lint-enrichgen-override-citations.sh` → PASS.
- [x] **Load-bearing acceptance check**: temporarily reverted the `enable_object_retention` comment to its pre-6985127 wording (which lacked a provider citation), re-ran the lint — it correctly failed at the right line. Comment restored.
- [x] `terraform fmt -check -recursive` clean.
- [x] All 4 existing lints pass plus the new one.
- [x] `go build ./...` / `go vet ./...` clean.
- [x] `go test ./cmd/enrichgen/... ./cmd/insideout-import/gcpdiscover/...` → 542 passed.
- [x] `go generate ./cmd/insideout-import/gcpdiscover/...` is byte-identical (comment-only changes to the generator source don't affect generated code).
- [ ] CI green on the new `Lint enrichgen override citation comments (#415)` step.