### PR TITLE
feat(awsdiscover): Bundle 14d — 5 new AWS types via ParentLister activation

### DIFF
--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -1064,6 +1064,364 @@ func TestCognitoResourceServerConfig(t *testing.T) {
 	}
 }
 
+// ===========================================================================
+// Bundle 14d (#422) — five new ParentLister-backed types
+// ===========================================================================
+
+// TestLambdaPermissionConfig pins the per-type extractors for
+// aws_lambda_permission: compound CC identifier `<FunctionName>|<Id>`
+// rewrites to TF import format `<FunctionName>/<Id>` (forward-slash,
+// first-pipe-only), NameHint extracts the StatementId tail, NativeIDs
+// split into a structured function_name/statement_id map, and Tags is
+// the non-nil empty map (CFN schema has no Tags property).
+func TestLambdaPermissionConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_lambda_permission")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_lambda_permission: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.CloudFormationType != "AWS::Lambda::Permission" {
+		t.Errorf("CloudFormationType=%q, want AWS::Lambda::Permission", cfg.CloudFormationType)
+	}
+	if cfg.ParentLister == nil {
+		t.Fatal("ParentLister must be set; CC ListResources is parent-scoped on FunctionName")
+	}
+	if cfg.SDKLister != nil {
+		t.Error("SDKLister must be nil (ParentLister-scoped, not SDK-scoped)")
+	}
+
+	id := "my-fn|AllowExecutionFromCloudWatch"
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != "my-fn/AllowExecutionFromCloudWatch" {
+		t.Errorf("ImportID rewrite |→/: got %q, want %q", got, "my-fn/AllowExecutionFromCloudWatch")
+	}
+	// First-`|`-only rewrite: a hypothetical identifier with multiple
+	// pipes (illegal per the Lambda function name regex but defended
+	// for symmetry with SplitN-cap-2 NativeIDs) must preserve every
+	// `|` after the first. A regression to strings.ReplaceAll would
+	// fail loudly here.
+	if got := cfg.ImportIDFromIdentifier("fn|stmt|with|pipes", nil); got != "fn/stmt|with|pipes" {
+		t.Errorf("ImportID multi-pipe (first-only rewrite): got %q, want %q",
+			got, "fn/stmt|with|pipes")
+	}
+
+	// NameHint reads the StatementId tail from the identifier.
+	if got := cfg.NameHintFromProperties(id, nil); got != "AllowExecutionFromCloudWatch" {
+		t.Errorf("NameHint: got %q, want %q", got, "AllowExecutionFromCloudWatch")
+	}
+	// Malformed identifier (no `|`) — fall back to the identifier.
+	if got := cfg.NameHintFromProperties("orphan", nil); got != "orphan" {
+		t.Errorf("NameHint fallback: got %q, want %q", got, "orphan")
+	}
+	// Identifier with empty StatementId — fall back to the identifier
+	// (defensive: empty-StatementId would surface as `""` if we
+	// returned parts[1] directly without the truthy check).
+	if got := cfg.NameHintFromProperties("fn|", nil); got != "fn|" {
+		t.Errorf("NameHint empty-statement-id fallback: got %q, want %q", got, "fn|")
+	}
+
+	native := cfg.NativeIDsFromProperties(id, nil)
+	want := map[string]string{"function_name": "my-fn", "statement_id": "AllowExecutionFromCloudWatch"}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	// Defensive: malformed identifier — NativeIDs must return nil so
+	// downstream doesn't render half-stitched keys.
+	if got := cfg.NativeIDsFromProperties("orphan", nil); got != nil {
+		t.Errorf("NativeIDs malformed-id: got %+v, want nil", got)
+	}
+
+	// Tags: emptyTagsExtractor returns the non-nil empty map per the
+	// #255 contract; populated Tags input must be discarded.
+	tags := cfg.TagsFromProperties(map[string]any{"Tags": []any{
+		map[string]any{"Key": "env", "Value": "prod"},
+	}})
+	if tags == nil {
+		t.Fatal("Tags must be non-nil empty map per #255 contract")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %v, want empty map (untaggable; emptyTagsExtractor ignores input)", tags)
+	}
+}
+
+// TestLambdaFunctionURLConfig pins the per-type extractors for
+// aws_lambda_function_url: CC primary identifier is the full
+// FunctionArn (single, not compound), Terraform import format is the
+// bare function NAME (or "<name>/<qualifier>"), so the extractor strips
+// the `arn:...:function:` prefix. NameHint reads TargetFunctionArn from
+// props (the parent key) and extracts the bare name. NativeIDs always
+// stamps "arn" and, when ARN-shaped, also "function_name". Tags is the
+// non-nil empty map.
+func TestLambdaFunctionURLConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_lambda_function_url")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_lambda_function_url: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.CloudFormationType != "AWS::Lambda::Url" {
+		t.Errorf("CloudFormationType=%q, want AWS::Lambda::Url", cfg.CloudFormationType)
+	}
+	if cfg.ParentLister == nil {
+		t.Fatal("ParentLister must be set; CC ListResources is parent-scoped on TargetFunctionArn")
+	}
+	if cfg.SDKLister != nil {
+		t.Error("SDKLister must be nil (ParentLister-scoped, not SDK-scoped)")
+	}
+
+	// ImportID: ARN → bare name.
+	arnPlain := "arn:aws:lambda:us-east-1:111:function:my-fn"
+	if got := cfg.ImportIDFromIdentifier(arnPlain, nil); got != "my-fn" {
+		t.Errorf("ImportID ARN→bare name: got %q, want %q", got, "my-fn")
+	}
+	// ARN with qualifier: "<name>:<qual>" → "<name>/<qual>" per TF docs.
+	arnQual := "arn:aws:lambda:us-east-1:111:function:my-fn:PROD"
+	if got := cfg.ImportIDFromIdentifier(arnQual, nil); got != "my-fn/PROD" {
+		t.Errorf("ImportID ARN+qualifier: got %q, want %q", got, "my-fn/PROD")
+	}
+	// Already-bare name (or unparseable) — passthrough.
+	if got := cfg.ImportIDFromIdentifier("bare-fn", nil); got != "bare-fn" {
+		t.Errorf("ImportID bare-name passthrough: got %q, want %q", got, "bare-fn")
+	}
+
+	// NameHint: extract the function name from TargetFunctionArn in props.
+	if got := cfg.NameHintFromProperties(arnPlain, map[string]any{
+		"TargetFunctionArn": arnPlain,
+	}); got != "my-fn" {
+		t.Errorf("NameHint: got %q, want %q", got, "my-fn")
+	}
+	// NameHint with qualifier: drop the qualifier (return only function name).
+	if got := cfg.NameHintFromProperties(arnQual, map[string]any{
+		"TargetFunctionArn": arnQual,
+	}); got != "my-fn" {
+		t.Errorf("NameHint qualifier-stripped: got %q, want %q", got, "my-fn")
+	}
+	// NameHint with non-ARN TargetFunctionArn — return the value as-is.
+	if got := cfg.NameHintFromProperties(arnPlain, map[string]any{
+		"TargetFunctionArn": "bare-name-in-props",
+	}); got != "bare-name-in-props" {
+		t.Errorf("NameHint non-ARN passthrough: got %q, want %q", got, "bare-name-in-props")
+	}
+	// NameHint with missing TargetFunctionArn — fall back to identifier.
+	if got := cfg.NameHintFromProperties(arnPlain, map[string]any{}); got != arnPlain {
+		t.Errorf("NameHint fallback: got %q, want %q", got, arnPlain)
+	}
+
+	// NativeIDs: always stamp "arn", and extract function_name when ARN-shaped.
+	native := cfg.NativeIDsFromProperties(arnPlain, nil)
+	wantPlain := map[string]string{"arn": arnPlain, "function_name": "my-fn"}
+	if !reflect.DeepEqual(native, wantPlain) {
+		t.Errorf("NativeIDs ARN-shaped: got %+v, want %+v", native, wantPlain)
+	}
+	// Qualified ARN: function_name is the part BEFORE the qualifier
+	// colon (qualifier is dropped from the by-name native-id slot).
+	nativeQ := cfg.NativeIDsFromProperties(arnQual, nil)
+	wantQ := map[string]string{"arn": arnQual, "function_name": "my-fn"}
+	if !reflect.DeepEqual(nativeQ, wantQ) {
+		t.Errorf("NativeIDs ARN+qual: got %+v, want %+v", nativeQ, wantQ)
+	}
+	// Non-ARN identifier: "arn" stamped to the raw identifier; no
+	// function_name (the ARN-extraction branch never fires). Must be
+	// non-nil so out["arn"] is always readable.
+	nativeBare := cfg.NativeIDsFromProperties("bare-fn", nil)
+	wantBare := map[string]string{"arn": "bare-fn"}
+	if !reflect.DeepEqual(nativeBare, wantBare) {
+		t.Errorf("NativeIDs non-ARN: got %+v, want %+v", nativeBare, wantBare)
+	}
+
+	tags := cfg.TagsFromProperties(map[string]any{})
+	if tags == nil {
+		t.Fatal("Tags must be non-nil empty map per #255 contract")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %v, want empty map (untaggable)", tags)
+	}
+}
+
+// TestApiGatewayStageConfig pins the per-type extractors for
+// aws_api_gateway_stage: compound CC identifier `<RestApiId>|<StageName>`
+// rewrites to `<RestApiId>/<StageName>` (forward-slash, first-pipe-only),
+// NameHint reads StageName, NativeIDs split into rest_api_id/stage_name,
+// and Tags is TAGGABLE — `tagsFromKey("Tags")` extracts the
+// `[]{Key,Value}` shape. UNLIKE the other four #422 types,
+// SkipProjectTagFilter is false.
+func TestApiGatewayStageConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_api_gateway_stage")
+	if cfg.SkipProjectTagFilter {
+		t.Error("aws_api_gateway_stage: SkipProjectTagFilter must be FALSE (CFN schema HAS a Tags property — taggable)")
+	}
+	if cfg.CloudFormationType != "AWS::ApiGateway::Stage" {
+		t.Errorf("CloudFormationType=%q, want AWS::ApiGateway::Stage", cfg.CloudFormationType)
+	}
+	if cfg.ParentLister == nil {
+		t.Fatal("ParentLister must be set; CC ListResources is parent-scoped on RestApiId")
+	}
+	if cfg.SDKLister != nil {
+		t.Error("SDKLister must be nil (ParentLister-scoped, not SDK-scoped)")
+	}
+
+	id := "12345abcde|prod"
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != "12345abcde/prod" {
+		t.Errorf("ImportID rewrite |→/: got %q, want %q", got, "12345abcde/prod")
+	}
+	// First-`|`-only rewrite pin.
+	if got := cfg.ImportIDFromIdentifier("api|stage|with|pipes", nil); got != "api/stage|with|pipes" {
+		t.Errorf("ImportID multi-pipe (first-only rewrite): got %q, want %q",
+			got, "api/stage|with|pipes")
+	}
+
+	if got := cfg.NameHintFromProperties(id, map[string]any{"StageName": "prod"}); got != "prod" {
+		t.Errorf("NameHint: got %q, want %q", got, "prod")
+	}
+	if got := cfg.NameHintFromProperties(id, map[string]any{}); got != id {
+		t.Errorf("NameHint fallback: got %q, want identifier", got)
+	}
+
+	native := cfg.NativeIDsFromProperties(id, nil)
+	want := map[string]string{"rest_api_id": "12345abcde", "stage_name": "prod"}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	if got := cfg.NativeIDsFromProperties("orphan", nil); got != nil {
+		t.Errorf("NativeIDs malformed-id: got %+v, want nil", got)
+	}
+
+	// Tags: `[]Tag` shape per the CFN schema. tagsFromKey extracts a
+	// flat map[string]string.
+	tags := cfg.TagsFromProperties(map[string]any{"Tags": []any{
+		map[string]any{"Key": "env", "Value": "prod"},
+		map[string]any{"Key": "owner", "Value": "team-a"},
+	}})
+	wantTags := map[string]string{"env": "prod", "owner": "team-a"}
+	if !reflect.DeepEqual(tags, wantTags) {
+		t.Errorf("Tags: got %+v, want %+v", tags, wantTags)
+	}
+}
+
+// TestApiGatewayDeploymentConfig pins the per-type extractors for
+// aws_api_gateway_deployment: CC identifier is
+// `<DeploymentId>|<RestApiId>` (note ORDER per the CC
+// primaryIdentifier: [DeploymentId, RestApiId]) but Terraform's import
+// format is `<RestApiId>/<DeploymentId>` — REVERSE order, not a naive
+// pipe→slash. The test explicitly pins this divergence; a regression to
+// `strings.Replace(id, "|", "/", 1)` would emit invalid imports.
+func TestApiGatewayDeploymentConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_api_gateway_deployment")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_api_gateway_deployment: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.CloudFormationType != "AWS::ApiGateway::Deployment" {
+		t.Errorf("CloudFormationType=%q, want AWS::ApiGateway::Deployment", cfg.CloudFormationType)
+	}
+	if cfg.ParentLister == nil {
+		t.Fatal("ParentLister must be set; CC ListResources is parent-scoped on RestApiId")
+	}
+	if cfg.SDKLister != nil {
+		t.Error("SDKLister must be nil")
+	}
+
+	// CC identifier order is DeploymentId|RestApiId; TF import is
+	// RestApiId/DeploymentId — REVERSE order pin. A naive pipe→slash
+	// here would emit `1122334/aabbccddee` (invalid).
+	id := "1122334|aabbccddee" // CC: <DeploymentId>|<RestApiId>
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != "aabbccddee/1122334" {
+		t.Errorf("ImportID reverse-order rewrite: got %q, want %q (RestApiId first, DeploymentId second)",
+			got, "aabbccddee/1122334")
+	}
+	// Malformed identifier (no `|`) — passthrough rather than panic.
+	if got := cfg.ImportIDFromIdentifier("orphan", nil); got != "orphan" {
+		t.Errorf("ImportID malformed-id passthrough: got %q, want %q", got, "orphan")
+	}
+
+	// NameHint chain: Description wins, identifier fallback.
+	if got := cfg.NameHintFromProperties(id, map[string]any{
+		"Description": "v3 release",
+	}); got != "v3 release" {
+		t.Errorf("NameHint (Description present): got %q, want %q", got, "v3 release")
+	}
+	if got := cfg.NameHintFromProperties(id, map[string]any{}); got != id {
+		t.Errorf("NameHint fallback: got %q, want identifier", got)
+	}
+
+	// NativeIDs: keys reflect the CC identifier order (DeploymentId|RestApiId).
+	native := cfg.NativeIDsFromProperties(id, nil)
+	want := map[string]string{"deployment_id": "1122334", "rest_api_id": "aabbccddee"}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	if got := cfg.NativeIDsFromProperties("orphan", nil); got != nil {
+		t.Errorf("NativeIDs malformed-id: got %+v, want nil", got)
+	}
+
+	tags := cfg.TagsFromProperties(map[string]any{})
+	if tags == nil {
+		t.Fatal("Tags must be non-nil empty map per #255 contract")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %v, want empty map (untaggable)", tags)
+	}
+}
+
+// TestApiGatewayResourceConfig pins the per-type extractors for
+// aws_api_gateway_resource: compound CC identifier
+// `<RestApiId>|<ResourceId>` rewrites to `<RestApiId>/<ResourceId>`
+// (forward-slash, first-pipe-only), NameHint reads PathPart,
+// NativeIDs split into rest_api_id/resource_id, and Tags is the
+// non-nil empty map.
+func TestApiGatewayResourceConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_api_gateway_resource")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_api_gateway_resource: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.CloudFormationType != "AWS::ApiGateway::Resource" {
+		t.Errorf("CloudFormationType=%q, want AWS::ApiGateway::Resource", cfg.CloudFormationType)
+	}
+	if cfg.ParentLister == nil {
+		t.Fatal("ParentLister must be set; CC ListResources is parent-scoped on RestApiId")
+	}
+	if cfg.SDKLister != nil {
+		t.Error("SDKLister must be nil")
+	}
+
+	id := "12345abcde|67890fghij"
+	if got := cfg.ImportIDFromIdentifier(id, nil); got != "12345abcde/67890fghij" {
+		t.Errorf("ImportID rewrite |→/: got %q, want %q", got, "12345abcde/67890fghij")
+	}
+	// First-`|`-only rewrite pin.
+	if got := cfg.ImportIDFromIdentifier("api|res|with|pipes", nil); got != "api/res|with|pipes" {
+		t.Errorf("ImportID multi-pipe (first-only rewrite): got %q, want %q",
+			got, "api/res|with|pipes")
+	}
+
+	// NameHint: PathPart wins (e.g. "users", "{userId}").
+	if got := cfg.NameHintFromProperties(id, map[string]any{"PathPart": "users"}); got != "users" {
+		t.Errorf("NameHint: got %q, want %q", got, "users")
+	}
+	if got := cfg.NameHintFromProperties(id, map[string]any{}); got != id {
+		t.Errorf("NameHint fallback: got %q, want identifier", got)
+	}
+
+	native := cfg.NativeIDsFromProperties(id, nil)
+	want := map[string]string{"rest_api_id": "12345abcde", "resource_id": "67890fghij"}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	if got := cfg.NativeIDsFromProperties("orphan", nil); got != nil {
+		t.Errorf("NativeIDs malformed-id: got %+v, want nil", got)
+	}
+
+	tags := cfg.TagsFromProperties(map[string]any{"Tags": []any{
+		map[string]any{"Key": "env", "Value": "prod"},
+	}})
+	if tags == nil {
+		t.Fatal("Tags must be non-nil empty map per #255 contract")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %v, want empty map (untaggable; emptyTagsExtractor ignores input)", tags)
+	}
+}
+
 // TestEmptyTagsExtractor_NonNilEmptyMap pins the contract of the
 // helper used by genuinely-untaggable Cloud Control types: it must
 // always return a non-nil empty map. Per the #255 JSON-marshal

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -38,6 +39,15 @@ type acmCertificatesLister interface {
 // separate so each call site can evolve independently.
 type apigatewayv2APIsLister interface {
 	GetApis(ctx context.Context, in *apigatewayv2.GetApisInput, opts ...func(*apigatewayv2.Options)) (*apigatewayv2.GetApisOutput, error)
+}
+
+// apigatewayRestAPIsLister is the narrow subset of the API Gateway v1
+// SDK used by the parent-RestApi enumerator that seeds Stage /
+// Deployment / Resource fan-out (#422). The v1 service uses `Position`
+// as the pagination cursor (not `NextToken`), so this interface lives
+// alongside but separate from apigatewayv2APIsLister.
+type apigatewayRestAPIsLister interface {
+	GetRestApis(ctx context.Context, in *apigateway.GetRestApisInput, opts ...func(*apigateway.Options)) (*apigateway.GetRestApisOutput, error)
 }
 
 // listCognitoUserPools enumerates all Cognito user pools in the region
@@ -271,6 +281,90 @@ func listApigatewayv2ApisWithClient(ctx context.Context, client apigatewayv2APIs
 			break
 		}
 		nextToken = page.NextToken
+	}
+	return models, nil
+}
+
+// listApigatewayRestAPIs enumerates API Gateway v1 (REST) APIs in the
+// region and returns one parent ResourceModel JSON string per API,
+// suitable for feeding into Cloud Control ListResources for child types
+// scoped on RestApiId (Stage / Deployment / Resource — #422). Returns
+// an empty slice (not nil) when no APIs exist, so the discoverer's
+// `len(parentModels) == 0` early-exit fires cleanly.
+//
+// API Gateway v1 paginates via `Position` (string cursor), not
+// `NextToken`, so the pagination loop here uses Position. The
+// terminator condition mirrors listApigatewayv2Apis: stop on both nil
+// AND empty-string cursors, since some SDK responses return `&""`
+// instead of nil on the final page.
+func listApigatewayRestAPIs(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := apigateway.NewFromConfig(awsCfg, func(o *apigateway.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+	return listApigatewayRestAPIsWithClient(ctx, client)
+}
+
+func listApigatewayRestAPIsWithClient(ctx context.Context, client apigatewayRestAPIsLister) ([]string, error) {
+	models := []string{}
+	var position *string
+	for {
+		page, err := client.GetRestApis(ctx, &apigateway.GetRestApisInput{Position: position})
+		if err != nil {
+			return nil, fmt.Errorf("apigateway:GetRestApis: %w", err)
+		}
+		for _, api := range page.Items {
+			id := aws.ToString(api.Id)
+			if id == "" {
+				continue
+			}
+			models = append(models, fmt.Sprintf(`{"RestApiId":%q}`, id))
+		}
+		if page.Position == nil || aws.ToString(page.Position) == "" {
+			break
+		}
+		position = page.Position
+	}
+	return models, nil
+}
+
+// listLambdaFunctionArns enumerates Lambda functions and returns one
+// parent ResourceModel JSON string per function, keyed under
+// `TargetFunctionArn` (the field name expected by
+// AWS::Lambda::Url's CC list-handler schema — #422). Distinct from
+// listLambdaFunctions, which emits `{"FunctionName":"..."}` for types
+// whose CC list-handler keys on FunctionName (e.g. AWS::Lambda::Alias,
+// AWS::Lambda::Permission). Reuses the lambdaFunctionsLister interface
+// (same SDK call, ListFunctions; different ResourceModel emission).
+func listLambdaFunctionArns(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := lambda.NewFromConfig(awsCfg, func(o *lambda.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+	return listLambdaFunctionArnsWithClient(ctx, client)
+}
+
+func listLambdaFunctionArnsWithClient(ctx context.Context, client lambdaFunctionsLister) ([]string, error) {
+	models := []string{}
+	var marker *string
+	for {
+		page, err := client.ListFunctions(ctx, &lambda.ListFunctionsInput{Marker: marker})
+		if err != nil {
+			return nil, fmt.Errorf("lambda:ListFunctions: %w", err)
+		}
+		for _, fn := range page.Functions {
+			arn := aws.ToString(fn.FunctionArn)
+			if arn == "" {
+				continue
+			}
+			models = append(models, fmt.Sprintf(`{"TargetFunctionArn":%q}`, arn))
+		}
+		if page.NextMarker == nil || aws.ToString(page.NextMarker) == "" {
+			break
+		}
+		marker = page.NextMarker
 	}
 	return models, nil
 }

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
@@ -177,14 +177,20 @@ func TestListCognitoUserPools_PropagatesListError(t *testing.T) {
 }
 
 // fakeLambdaFunctionsLister is a hand-rolled fake satisfying the
-// lambdaFunctionsLister interface.
+// lambdaFunctionsLister interface. markersSeen captures each in.Marker
+// the lister sends so tests can pin that the pagination cursor is
+// round-tripped between pages (added in #422 for the
+// listLambdaFunctionArns coverage — pre-existing callers that don't
+// read this field are unaffected since it's nil-initialized).
 type fakeLambdaFunctionsLister struct {
-	listPages []lambda.ListFunctionsOutput
-	listCalls int
-	listErr   error
+	listPages    []lambda.ListFunctionsOutput
+	listCalls    int
+	listErr      error
+	markersSeen  []*string
 }
 
-func (f *fakeLambdaFunctionsLister) ListFunctions(_ context.Context, _ *lambda.ListFunctionsInput, _ ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error) {
+func (f *fakeLambdaFunctionsLister) ListFunctions(_ context.Context, in *lambda.ListFunctionsInput, _ ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error) {
+	f.markersSeen = append(f.markersSeen, in.Marker)
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
@@ -919,6 +925,22 @@ func TestListLambdaFunctionArns_PaginatesAndReturnsModels(t *testing.T) {
 	}
 	if fake.listCalls != 2 {
 		t.Errorf("listCalls=%d, want 2", fake.listCalls)
+	}
+	// Pin the Marker cursor round-trip: the lister must feed each
+	// page's NextMarker into the next request. A regression that
+	// passes `nil` on every call (e.g. dropping `marker =
+	// page.NextMarker`) would still produce 2 calls because the fake
+	// serves by call-count — only this assertion catches it.
+	if len(fake.markersSeen) != 2 {
+		t.Fatalf("markersSeen len=%d, want 2", len(fake.markersSeen))
+	}
+	if fake.markersSeen[0] != nil {
+		t.Errorf("markersSeen[0]=%q, want nil (first request must not send a Marker)",
+			aws.ToString(fake.markersSeen[0]))
+	}
+	if aws.ToString(fake.markersSeen[1]) != "m1" {
+		t.Errorf("markersSeen[1]=%q, want m1 (must round-trip page-1's NextMarker)",
+			aws.ToString(fake.markersSeen[1]))
 	}
 	// Each emitted model must round-trip as JSON with TargetFunctionArn
 	// set — a malformed string would crash the downstream CC

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
 	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway"
+	apigwtypes "github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	apigwv2types "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
@@ -658,5 +660,341 @@ func TestListApigatewayv2Apis_SkipsEmptyApiID(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("empty-ID skip drift:\n got %v\nwant %v", got, want)
+	}
+}
+
+// ===========================================================================
+// API Gateway v1 (REST) APIs lister — #422
+// ===========================================================================
+
+// fakeAPIGWRestAPIsLister is a hand-rolled fake for the API Gateway v1
+// SDK subset used by listApigatewayRestAPIs. The v1 service paginates
+// via `Position` (not NextToken), so positionsSeen captures each
+// in.Position the lister sends to pin the round-trip cursor.
+type fakeAPIGWRestAPIsLister struct {
+	listPages     []apigateway.GetRestApisOutput
+	listCalls     int
+	listErr       error
+	positionsSeen []*string
+}
+
+func (f *fakeAPIGWRestAPIsLister) GetRestApis(_ context.Context, in *apigateway.GetRestApisInput, _ ...func(*apigateway.Options)) (*apigateway.GetRestApisOutput, error) {
+	f.positionsSeen = append(f.positionsSeen, in.Position)
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if f.listCalls >= len(f.listPages) {
+		return &apigateway.GetRestApisOutput{}, nil
+	}
+	page := f.listPages[f.listCalls]
+	f.listCalls++
+	return &page, nil
+}
+
+func apigwRestAPIsPage(position string, restAPIIds ...string) apigateway.GetRestApisOutput {
+	items := make([]apigwtypes.RestApi, 0, len(restAPIIds))
+	for _, id := range restAPIIds {
+		items = append(items, apigwtypes.RestApi{Id: aws.String(id)})
+	}
+	out := apigateway.GetRestApisOutput{Items: items}
+	if position != "" {
+		out.Position = aws.String(position)
+	}
+	return out
+}
+
+// TestListApigatewayRestAPIs_PaginatesAndReturnsModels pins the
+// API-enumeration helper shared by aws_api_gateway_{stage,deployment,resource}'s
+// ParentLister: every REST API across every page must surface as a
+// well-formed JSON ResourceModel string with RestApiId set. A regression
+// that drops a page or emits malformed JSON would silently produce zero
+// child Stage/Deployment/Resource emissions after the first page.
+//
+// Also pins the Position cursor round-trip (positionsSeen) — without
+// this, a regression that drops `position = page.Position` would still
+// produce 3 calls because the fake serves by call-count.
+func TestListApigatewayRestAPIs_PaginatesAndReturnsModels(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAPIGWRestAPIsLister{
+		listPages: []apigateway.GetRestApisOutput{
+			apigwRestAPIsPage("pos1", "rest-aaa", "rest-bbb"),
+			apigwRestAPIsPage("pos2", "rest-ccc"),
+			apigwRestAPIsPage("", "rest-ddd", "rest-eee"),
+		},
+	}
+	got, err := listApigatewayRestAPIsWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		`{"RestApiId":"rest-aaa"}`,
+		`{"RestApiId":"rest-bbb"}`,
+		`{"RestApiId":"rest-ccc"}`,
+		`{"RestApiId":"rest-ddd"}`,
+		`{"RestApiId":"rest-eee"}`,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("models drift:\n got %v\nwant %v", got, want)
+	}
+	if fake.listCalls != 3 {
+		t.Errorf("listCalls=%d, want 3 (paginated across three pages)", fake.listCalls)
+	}
+	if len(fake.positionsSeen) != 3 {
+		t.Fatalf("positionsSeen len=%d, want 3", len(fake.positionsSeen))
+	}
+	if fake.positionsSeen[0] != nil {
+		t.Errorf("positionsSeen[0]=%q, want nil (first request must not send a Position)",
+			aws.ToString(fake.positionsSeen[0]))
+	}
+	if aws.ToString(fake.positionsSeen[1]) != "pos1" {
+		t.Errorf("positionsSeen[1]=%q, want pos1 (must round-trip page-1's Position)",
+			aws.ToString(fake.positionsSeen[1]))
+	}
+	if aws.ToString(fake.positionsSeen[2]) != "pos2" {
+		t.Errorf("positionsSeen[2]=%q, want pos2 (must round-trip page-2's Position)",
+			aws.ToString(fake.positionsSeen[2]))
+	}
+	for _, m := range got {
+		var parsed map[string]string
+		if err := json.Unmarshal([]byte(m), &parsed); err != nil {
+			t.Errorf("model %q is not valid JSON: %v", m, err)
+			continue
+		}
+		if parsed["RestApiId"] == "" {
+			t.Errorf("model %q missing RestApiId key", m)
+		}
+	}
+}
+
+// TestListApigatewayRestAPIs_EmptyAccountReturnsNonNilEmpty pins the
+// non-nil empty contract: zero REST APIs returns []string{}, not nil.
+// The discoverer's `len(parentModels) == 0` early-exit branch needs the
+// slice to be non-nil for the empty-region path to fire cleanly.
+func TestListApigatewayRestAPIs_EmptyAccountReturnsNonNilEmpty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAPIGWRestAPIsLister{
+		listPages: []apigateway.GetRestApisOutput{
+			apigwRestAPIsPage(""),
+		},
+	}
+	got, err := listApigatewayRestAPIsWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("empty-region result must be non-nil (else len-check early-exit misfires)")
+	}
+	if len(got) != 0 {
+		t.Errorf("len=%d, want 0", len(got))
+	}
+}
+
+// TestListApigatewayRestAPIs_PropagatesListError pins error
+// propagation: an apigateway:GetRestApis failure must surface to the
+// caller wrapped, not silently swallowed. The discoverer's outer error
+// path emits a ServiceFinish + propagates — losing the error here
+// would silently skip the type for the whole region.
+func TestListApigatewayRestAPIs_PropagatesListError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("apigateway:GetRestApis boom")
+	fake := &fakeAPIGWRestAPIsLister{listErr: sentinel}
+	_, err := listApigatewayRestAPIsWithClient(context.Background(), fake)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("error chain: got %v, want chain containing %v", err, sentinel)
+	}
+}
+
+// TestListApigatewayRestAPIs_EmptyStringPositionTerminates pins the
+// other half of the pagination terminator: the loop must also break
+// when GetRestApis returns Position=&"" (an empty pointer, not nil) on
+// the final page. The lister guards on both `nil` AND
+// `aws.ToString(*position)==""`; without the empty-string branch we'd
+// loop forever passing an empty Position to GetRestApis.
+func TestListApigatewayRestAPIs_EmptyStringPositionTerminates(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAPIGWRestAPIsLister{
+		listPages: []apigateway.GetRestApisOutput{
+			// Final page deliberately has Position=&"" rather than nil.
+			{
+				Items:    []apigwtypes.RestApi{{Id: aws.String("rest-final")}},
+				Position: aws.String(""),
+			},
+		},
+	}
+	got, err := listApigatewayRestAPIsWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{`{"RestApiId":"rest-final"}`}) {
+		t.Errorf("models drift: got %v, want [rest-final only]", got)
+	}
+	if fake.listCalls != 1 {
+		t.Errorf("listCalls=%d, want 1 (empty-string Position must terminate the loop, not trigger another GetRestApis)",
+			fake.listCalls)
+	}
+}
+
+// TestListApigatewayRestAPIs_SkipsEmptyRestApiID guards the defensive
+// branch: a RestApi whose Id is "" or nil must be dropped, never
+// emitted as `{"RestApiId":""}`. The downstream CC ListResources call
+// would reject the empty-ID parent model.
+func TestListApigatewayRestAPIs_SkipsEmptyRestApiID(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAPIGWRestAPIsLister{
+		listPages: []apigateway.GetRestApisOutput{
+			{Items: []apigwtypes.RestApi{
+				{Id: aws.String("rest-good")},
+				{Id: nil},
+				{Id: aws.String("")},
+				{Id: aws.String("rest-also-good")},
+			}},
+		},
+	}
+	got, err := listApigatewayRestAPIsWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		`{"RestApiId":"rest-good"}`,
+		`{"RestApiId":"rest-also-good"}`,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("empty-ID skip drift:\n got %v\nwant %v", got, want)
+	}
+}
+
+// ===========================================================================
+// Lambda function ARNs lister — #422 (parent for aws_lambda_function_url)
+// ===========================================================================
+
+// lambdaArnListPage builds a ListFunctionsOutput populated with both
+// FunctionName and FunctionArn for each function — the
+// listLambdaFunctionArns lister reads FunctionArn (not FunctionName).
+// Without populating FunctionArn, the lister would emit empty-key
+// models and the defensive skip would drop every function.
+func lambdaArnListPage(marker string, fnArns ...string) lambda.ListFunctionsOutput {
+	fns := make([]lambdatypes.FunctionConfiguration, 0, len(fnArns))
+	for _, a := range fnArns {
+		fns = append(fns, lambdatypes.FunctionConfiguration{FunctionArn: aws.String(a)})
+	}
+	out := lambda.ListFunctionsOutput{Functions: fns}
+	if marker != "" {
+		out.NextMarker = aws.String(marker)
+	}
+	return out
+}
+
+// TestListLambdaFunctionArns_PaginatesAndReturnsModels pins the
+// ARN-keyed Lambda-functions enumerator used by aws_lambda_function_url's
+// ParentLister: every function's ARN across every page surfaces as a
+// JSON ResourceModel with TargetFunctionArn set (NOT FunctionName — the
+// CC list-handler schema for AWS::Lambda::Url keys on TargetFunctionArn).
+// A regression that flipped to FunctionName here would silently emit
+// `{"TargetFunctionArn":""}` for every function (since fixtures populate
+// only FunctionArn) and the defensive skip would yield zero parents.
+func TestListLambdaFunctionArns_PaginatesAndReturnsModels(t *testing.T) {
+	t.Parallel()
+	fake := &fakeLambdaFunctionsLister{
+		listPages: []lambda.ListFunctionsOutput{
+			lambdaArnListPage("m1",
+				"arn:aws:lambda:us-east-1:111:function:fn-alpha",
+				"arn:aws:lambda:us-east-1:111:function:fn-beta",
+			),
+			lambdaArnListPage("",
+				"arn:aws:lambda:us-east-1:111:function:fn-gamma",
+			),
+		},
+	}
+	got, err := listLambdaFunctionArnsWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		`{"TargetFunctionArn":"arn:aws:lambda:us-east-1:111:function:fn-alpha"}`,
+		`{"TargetFunctionArn":"arn:aws:lambda:us-east-1:111:function:fn-beta"}`,
+		`{"TargetFunctionArn":"arn:aws:lambda:us-east-1:111:function:fn-gamma"}`,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("models drift:\n got %v\nwant %v", got, want)
+	}
+	if fake.listCalls != 2 {
+		t.Errorf("listCalls=%d, want 2", fake.listCalls)
+	}
+	// Each emitted model must round-trip as JSON with TargetFunctionArn
+	// set — a malformed string would crash the downstream CC
+	// ListResources call.
+	for _, m := range got {
+		var parsed map[string]string
+		if err := json.Unmarshal([]byte(m), &parsed); err != nil {
+			t.Errorf("model %q is not valid JSON: %v", m, err)
+			continue
+		}
+		if parsed["TargetFunctionArn"] == "" {
+			t.Errorf("model %q missing TargetFunctionArn key", m)
+		}
+	}
+}
+
+// TestListLambdaFunctionArns_EmptyAccountReturnsNonNilEmpty pins the
+// non-nil empty contract for the ARN-keyed lister: zero functions
+// returns []string{}, not nil.
+func TestListLambdaFunctionArns_EmptyAccountReturnsNonNilEmpty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeLambdaFunctionsLister{
+		listPages: []lambda.ListFunctionsOutput{lambdaArnListPage("")},
+	}
+	got, err := listLambdaFunctionArnsWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("empty-region result must be non-nil")
+	}
+	if len(got) != 0 {
+		t.Errorf("len=%d, want 0", len(got))
+	}
+}
+
+// TestListLambdaFunctionArns_PropagatesListError pins error
+// propagation: a lambda:ListFunctions failure surfaces wrapped to
+// the caller via errors.Is.
+func TestListLambdaFunctionArns_PropagatesListError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("lambda:ListFunctions boom")
+	fake := &fakeLambdaFunctionsLister{listErr: sentinel}
+	_, err := listLambdaFunctionArnsWithClient(context.Background(), fake)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("error chain: got %v, want chain containing %v", err, sentinel)
+	}
+}
+
+// TestListLambdaFunctionArns_SkipsEmptyFunctionArn pins the defensive
+// skip: a function with FunctionArn nil or "" must be dropped rather
+// than emitted as `{"TargetFunctionArn":""}`. A regression that flipped
+// the field read from FunctionArn to FunctionName would also be caught
+// here (fixtures populate only FunctionArn, so the wrong-field read
+// would yield three empty-ARN drops).
+func TestListLambdaFunctionArns_SkipsEmptyFunctionArn(t *testing.T) {
+	t.Parallel()
+	fake := &fakeLambdaFunctionsLister{
+		listPages: []lambda.ListFunctionsOutput{
+			{Functions: []lambdatypes.FunctionConfiguration{
+				{FunctionArn: aws.String("arn:aws:lambda:us-east-1:111:function:fn-good")},
+				{FunctionArn: nil},
+				{FunctionArn: aws.String("")},
+				{FunctionArn: aws.String("arn:aws:lambda:us-east-1:111:function:fn-also-good")},
+			}},
+		},
+	}
+	got, err := listLambdaFunctionArnsWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		`{"TargetFunctionArn":"arn:aws:lambda:us-east-1:111:function:fn-good"}`,
+		`{"TargetFunctionArn":"arn:aws:lambda:us-east-1:111:function:fn-also-good"}`,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("empty-ARN skip drift:\n got %v\nwant %v", got, want)
 	}
 }

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -1006,6 +1006,250 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		},
 		TagsFromProperties: emptyTagsExtractor,
 	},
+
+	// =====================================================================
+	// Lambda Permission — parent-scoped on FunctionName, untaggable (#422)
+	// =====================================================================
+	{
+		// AWS::Lambda::Permission is parent-scoped: CC ListResources
+		// requires ResourceModel={"FunctionName":"..."}. The CFN schema
+		// has no Tags property — SkipProjectTagFilter bypasses the
+		// Project filter (the parent Lambda function carries tags).
+		TFType:               "aws_lambda_permission",
+		CloudFormationType:   "AWS::Lambda::Permission",
+		Slug:                 "lambda_permission",
+		SkipProjectTagFilter: true,
+		ParentLister:         listLambdaFunctions,
+		// Cloud Control identifier = "<FunctionName>|<Id>" (compound,
+		// pipe-separated per the CC primaryIdentifier convention).
+		// Terraform import format = "<FunctionName>/<Id>"
+		// (forward-slash; verified against terraform-provider-aws v6.x
+		// docs for aws_lambda_permission). First-`|`-only rewrite so
+		// hypothetical pipes inside FunctionName (illegal per the
+		// Lambda name regex but defended for symmetry with SplitN-cap-2
+		// NativeIDs) survive verbatim past the first.
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			return strings.Replace(identifier, "|", "/", 1)
+		},
+		// No "Name" on the Permission type — the StatementId (the
+		// second half of the identifier) is the most human-readable
+		// hint. We pull it out via the same SplitN that powers
+		// NativeIDs rather than re-parsing the identifier.
+		NameHintFromProperties: func(identifier string, _ map[string]any) string {
+			if parts := strings.SplitN(identifier, "|", 2); len(parts) == 2 && parts[1] != "" {
+				return parts[1]
+			}
+			return identifier
+		},
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return nil
+			}
+			return map[string]string{
+				"function_name": parts[0],
+				"statement_id":  parts[1],
+			}
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
+
+	// =====================================================================
+	// Lambda Function URL — parent-scoped on TargetFunctionArn, untaggable (#422)
+	// =====================================================================
+	{
+		// AWS::Lambda::Url is parent-scoped: CC ListResources requires
+		// ResourceModel={"TargetFunctionArn":"..."} (NB: not
+		// "FunctionName" — Lambda::Url uses the ARN where Permission /
+		// Alias use the name. The lister listLambdaFunctionArns emits
+		// the ARN-keyed model). CFN schema has no Tags property —
+		// SkipProjectTagFilter bypasses the Project filter.
+		TFType:               "aws_lambda_function_url",
+		CloudFormationType:   "AWS::Lambda::Url",
+		Slug:                 "lambda_function_url",
+		SkipProjectTagFilter: true,
+		ParentLister:         listLambdaFunctionArns,
+		// Cloud Control primary identifier = "<FunctionArn>" (full
+		// function ARN, single — the URL is uniquely keyed on the
+		// associated function). Terraform's import format is the bare
+		// function NAME (or "<name>/<qualifier>"), so the ARN must be
+		// rewritten to the bare name. Lambda ARN shape:
+		// arn:aws:lambda:<region>:<account>:function:<name>[:<qual>].
+		// We extract the segment after "function:" and preserve any
+		// qualifier as "<name>/<qualifier>" per the TF docs.
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			const marker = "function:"
+			idx := strings.Index(identifier, marker)
+			if idx < 0 {
+				// Already a bare name (or unparseable) — pass through.
+				return identifier
+			}
+			rest := identifier[idx+len(marker):]
+			// Rest is "<name>" or "<name>:<qualifier>". TF expects
+			// "<name>" or "<name>/<qualifier>".
+			if colon := strings.Index(rest, ":"); colon != -1 {
+				return rest[:colon] + "/" + rest[colon+1:]
+			}
+			return rest
+		},
+		// Most readable name hint is the function name extracted from
+		// the TargetFunctionArn (or the ARN identifier itself). Fall
+		// back to the identifier when neither is parseable.
+		NameHintFromProperties: func(identifier string, props map[string]any) string {
+			if arn := extractString(props, "TargetFunctionArn"); arn != "" {
+				if idx := strings.Index(arn, "function:"); idx >= 0 {
+					rest := arn[idx+len("function:"):]
+					if colon := strings.Index(rest, ":"); colon != -1 {
+						return rest[:colon]
+					}
+					return rest
+				}
+				return arn
+			}
+			return identifier
+		},
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			// identifier is the full FunctionArn — stamp under "arn"
+			// for downstream callers indexing by ARN, and (when
+			// recognizably ARN-shaped) extract the function_name for
+			// the by-name native-id slot. Returning a non-nil empty
+			// map when we can't extract a name (rather than nil) lets
+			// callers always read out["arn"] safely; the bare-name
+			// passthrough above means identifier may legitimately be
+			// non-ARN-shaped on test/fixture inputs.
+			out := map[string]string{"arn": identifier}
+			if idx := strings.Index(identifier, "function:"); idx >= 0 {
+				rest := identifier[idx+len("function:"):]
+				if colon := strings.Index(rest, ":"); colon != -1 {
+					out["function_name"] = rest[:colon]
+				} else {
+					out["function_name"] = rest
+				}
+			}
+			return out
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
+
+	// =====================================================================
+	// ApiGateway v1 Stage — parent-scoped on RestApiId, TAGGABLE (#422)
+	// =====================================================================
+	{
+		// AWS::ApiGateway::Stage is parent-scoped: CC ListResources
+		// requires ResourceModel={"RestApiId":"..."}. Unlike the other
+		// four #422 types, the CFN schema HAS a `Tags` property (array
+		// of {Key,Value}) — taggable, no SkipProjectTagFilter, real
+		// tagsFromKey extractor.
+		TFType:             "aws_api_gateway_stage",
+		CloudFormationType: "AWS::ApiGateway::Stage",
+		Slug:               "api_gateway_stage",
+		ParentLister:       listApigatewayRestAPIs,
+		// Cloud Control identifier = "<RestApiId>|<StageName>";
+		// Terraform import format = "<RestApiId>/<StageName>"
+		// (forward-slash; verified against terraform-provider-aws v6.x
+		// docs for aws_api_gateway_stage).
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			return strings.Replace(identifier, "|", "/", 1)
+		},
+		NameHintFromProperties: nameOrIdentifier("StageName"),
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return nil
+			}
+			return map[string]string{
+				"rest_api_id": parts[0],
+				"stage_name":  parts[1],
+			}
+		},
+		TagsFromProperties: tagsFromKey("Tags"),
+	},
+
+	// =====================================================================
+	// ApiGateway v1 Deployment — parent-scoped on RestApiId, untaggable (#422)
+	// =====================================================================
+	{
+		// AWS::ApiGateway::Deployment is parent-scoped on RestApiId.
+		// No Tags property in the CFN schema.
+		//
+		// IDENTIFIER ORDER DIVERGENCE: the CC primaryIdentifier is
+		// ["/properties/DeploymentId", "/properties/RestApiId"] (note
+		// order — DeploymentId FIRST, RestApiId second). That means
+		// the CC compound identifier comes in as
+		// "<DeploymentId>|<RestApiId>" but Terraform's import format
+		// is "<RestApiId>/<DeploymentId>" — REVERSE order, not a naive
+		// pipe→slash. Verified against terraform-provider-aws v6.x
+		// docs. The rewriter below splits and re-stitches; the
+		// extractor test pins this divergence to defend against a
+		// "looks like every other compound type" rewrite regression.
+		TFType:               "aws_api_gateway_deployment",
+		CloudFormationType:   "AWS::ApiGateway::Deployment",
+		Slug:                 "api_gateway_deployment",
+		SkipProjectTagFilter: true,
+		ParentLister:         listApigatewayRestAPIs,
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			// CC: "<DeploymentId>|<RestApiId>" → TF: "<RestApiId>/<DeploymentId>".
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return identifier
+			}
+			return parts[1] + "/" + parts[0]
+		},
+		// No "Name" on Deployment — Description when present,
+		// otherwise the identifier.
+		NameHintFromProperties: func(identifier string, props map[string]any) string {
+			if d := extractString(props, "Description"); d != "" {
+				return d
+			}
+			return identifier
+		},
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return nil
+			}
+			// CC identifier order is DeploymentId|RestApiId.
+			return map[string]string{
+				"deployment_id": parts[0],
+				"rest_api_id":   parts[1],
+			}
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
+
+	// =====================================================================
+	// ApiGateway v1 Resource — parent-scoped on RestApiId, untaggable (#422)
+	// =====================================================================
+	{
+		// AWS::ApiGateway::Resource is parent-scoped on RestApiId. No
+		// Tags property in the CFN schema.
+		TFType:               "aws_api_gateway_resource",
+		CloudFormationType:   "AWS::ApiGateway::Resource",
+		Slug:                 "api_gateway_resource",
+		SkipProjectTagFilter: true,
+		ParentLister:         listApigatewayRestAPIs,
+		// Cloud Control identifier = "<RestApiId>|<ResourceId>";
+		// Terraform import format = "<RestApiId>/<ResourceId>"
+		// (forward-slash). Verified against terraform-provider-aws
+		// v6.x docs for aws_api_gateway_resource.
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			return strings.Replace(identifier, "|", "/", 1)
+		},
+		// PathPart (e.g. "users", "{userId}") is the human-readable
+		// hint; fall back to the identifier when absent.
+		NameHintFromProperties: nameOrIdentifier("PathPart"),
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return nil
+			}
+			return map[string]string{
+				"rest_api_id": parts[0],
+				"resource_id": parts[1],
+			}
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
 }
 
 // passthroughImportID is the common ImportIDFromIdentifier used by every

--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
+	github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.23 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 h1:OQqn11BtaYv1WLUowvcA30MpzIu
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24/go.mod h1:X5ZJyfwVrWA96GzPmUCWFQaEARPR7gCrpq2E92PJwAE=
 github.com/aws/aws-sdk-go-v2/service/acm v1.38.3 h1:Fzab84hCu3rw9R9Y3mH7SHfr/cSEHnCB0Mq1JCdr9t0=
 github.com/aws/aws-sdk-go-v2/service/acm v1.38.3/go.mod h1:yCteizCNPaHt0SnNusoGGHvy0JDB0tvGDTVhEt5anZM=
+github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3 h1:7MJlB7KGFd+KNKtnPgoFWYf52PGO1pd+1VHp10lNKhI=
+github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3/go.mod h1:MwilTAruv11x8EFjsk1R0VfjMdCxB6JHVtanCqsTR5o=
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3 h1:JqFmDekar5Ije9SKKBUAmvuqardAXgCoJV78dt2BQSI=
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3/go.mod h1:+ONaMzn4bVIQwVsamP28xDWWZuYO+6cWupJpZOSlUNE=
 github.com/aws/aws-sdk-go-v2/service/backup v1.55.2 h1:WhdT1PwOjTjKLGuD9lJDyNMgYmVaZgTHK06ioJKMBYE=

--- a/pkg/composer/imported/category.go
+++ b/pkg/composer/imported/category.go
@@ -77,6 +77,9 @@ const (
 var categoryByTFType = map[string]string{
 	// --- AWS ---
 	"aws_acm_certificate":                 CategorySecurity,
+	"aws_api_gateway_deployment":          CategoryNetworkSecurity,
+	"aws_api_gateway_resource":            CategoryNetworkSecurity,
+	"aws_api_gateway_stage":               CategoryNetworkSecurity,
 	"aws_apigatewayv2_api":                CategoryNetworkSecurity,
 	"aws_apigatewayv2_authorizer":         CategoryNetworkSecurity,
 	"aws_apigatewayv2_integration":        CategoryNetworkSecurity,
@@ -114,6 +117,8 @@ var categoryByTFType = map[string]string{
 	"aws_lambda_alias":                    CategoryVirtualMachines,
 	"aws_lambda_event_source_mapping":     CategoryEvents,
 	"aws_lambda_function":                 CategoryVirtualMachines,
+	"aws_lambda_function_url":             CategoryNetworkSecurity,
+	"aws_lambda_permission":               CategorySecurity,
 	"aws_lb":                              CategoryNetworkSecurity,
 	"aws_lb_listener":                     CategoryNetworkSecurity,
 	"aws_lb_target_group":                 CategoryNetworkSecurity,

--- a/pkg/composer/imported/testdata/category.golden
+++ b/pkg/composer/imported/testdata/category.golden
@@ -1,4 +1,7 @@
 aws_acm_certificate	Security
+aws_api_gateway_deployment	Network Security
+aws_api_gateway_resource	Network Security
+aws_api_gateway_stage	Network Security
 aws_apigatewayv2_api	Network Security
 aws_apigatewayv2_authorizer	Network Security
 aws_apigatewayv2_integration	Network Security
@@ -36,6 +39,8 @@ aws_kms_key	Security
 aws_lambda_alias	Virtual Machines
 aws_lambda_event_source_mapping	Events
 aws_lambda_function	Virtual Machines
+aws_lambda_function_url	Network Security
+aws_lambda_permission	Security
 aws_lb	Network Security
 aws_lb_listener	Network Security
 aws_lb_target_group	Network Security

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -37,6 +37,8 @@ const (
 // the resource WeakLocked. TestUntaggableAllowlistsMatchLintScripts ensures
 // this list stays in sync with the bash array.
 var untaggableAWS = map[string]struct{}{
+	"aws_api_gateway_deployment":                         {},
+	"aws_api_gateway_resource":                           {},
 	"aws_apigatewayv2_api_mapping":                       {},
 	"aws_apigatewayv2_authorizer":                        {},
 	"aws_apigatewayv2_integration":                       {},
@@ -60,6 +62,8 @@ var untaggableAWS = map[string]struct{}{
 	"aws_iam_service_linked_role":                        {},
 	"aws_kms_alias":                                      {},
 	"aws_lambda_alias":                                   {},
+	"aws_lambda_function_url":                            {},
+	"aws_lambda_permission":                              {},
 	"aws_msk_configuration":                              {},
 	"aws_opensearchserverless_access_policy":             {},
 	"aws_opensearchserverless_security_policy":           {},

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -23,6 +23,51 @@
       "purpose": "Cloud Control GetResource for AWS::CertificateManager::Certificate (#412 SDKLister branch)"
     },
     {
+      "service": "api_gateway_deployment",
+      "iam_action": "apigateway:GET",
+      "purpose": "Cloud Control GetResource for aws_api_gateway_deployment delegates to apigateway:GET (GET /restapis/*/deployments/*); also covers parent enumeration (GET /restapis) to fan ListResources out per RestApiId"
+    },
+    {
+      "service": "api_gateway_deployment",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::ApiGateway::Deployment (#422 ParentLister branch on RestApiId)"
+    },
+    {
+      "service": "api_gateway_deployment",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::ApiGateway::Deployment (per-RestApiId fan-out)"
+    },
+    {
+      "service": "api_gateway_resource",
+      "iam_action": "apigateway:GET",
+      "purpose": "Cloud Control GetResource for aws_api_gateway_resource delegates to apigateway:GET (GET /restapis/*/resources/*); also covers parent enumeration (GET /restapis) to fan ListResources out per RestApiId"
+    },
+    {
+      "service": "api_gateway_resource",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::ApiGateway::Resource (#422 ParentLister branch on RestApiId)"
+    },
+    {
+      "service": "api_gateway_resource",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::ApiGateway::Resource (per-RestApiId fan-out)"
+    },
+    {
+      "service": "api_gateway_stage",
+      "iam_action": "apigateway:GET",
+      "purpose": "Cloud Control GetResource for aws_api_gateway_stage delegates to apigateway:GET (GET /restapis/*/stages/*); also covers parent enumeration (GET /restapis) to fan ListResources out per RestApiId"
+    },
+    {
+      "service": "api_gateway_stage",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::ApiGateway::Stage (#422 ParentLister branch on RestApiId)"
+    },
+    {
+      "service": "api_gateway_stage",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::ApiGateway::Stage (per-RestApiId fan-out)"
+    },
+    {
       "service": "apigatewayv2_api",
       "iam_action": "apigateway:GET",
       "purpose": "list HTTP APIs and fetch per-API metadata (GET /apis, GET /apis/*/stages)"
@@ -681,6 +726,46 @@
       "service": "lambda_event_source_mapping",
       "iam_action": "lambda:ListTags",
       "purpose": "Cloud Control GetResource delegate for the Tags property"
+    },
+    {
+      "service": "lambda_function_url",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::Lambda::Url (#422 ParentLister branch on TargetFunctionArn)"
+    },
+    {
+      "service": "lambda_function_url",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::Lambda::Url (per-TargetFunctionArn fan-out)"
+    },
+    {
+      "service": "lambda_function_url",
+      "iam_action": "lambda:GetFunctionUrlConfig",
+      "purpose": "Cloud Control GetResource for aws_lambda_function_url delegates to lambda:GetFunctionUrlConfig"
+    },
+    {
+      "service": "lambda_function_url",
+      "iam_action": "lambda:ListFunctions",
+      "purpose": "parent enumeration: list Lambda functions to fan ListResources out per TargetFunctionArn"
+    },
+    {
+      "service": "lambda_permission",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::Lambda::Permission (#422 ParentLister branch on FunctionName)"
+    },
+    {
+      "service": "lambda_permission",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::Lambda::Permission (per-FunctionName fan-out)"
+    },
+    {
+      "service": "lambda_permission",
+      "iam_action": "lambda:GetPolicy",
+      "purpose": "Cloud Control GetResource for aws_lambda_permission delegates to lambda:GetPolicy"
+    },
+    {
+      "service": "lambda_permission",
+      "iam_action": "lambda:ListFunctions",
+      "purpose": "parent enumeration: list Lambda functions to fan ListResources out per FunctionName"
     },
     {
       "service": "lb",

--- a/pkg/insideout-import/permissions/permissions_test.go
+++ b/pkg/insideout-import/permissions/permissions_test.go
@@ -18,6 +18,9 @@ import (
 // against the production source of truth.
 var awsTFTypeToServiceSlug = map[string]string{
 	"aws_acm_certificate":                 "acm_certificate",
+	"aws_api_gateway_deployment":          "api_gateway_deployment",
+	"aws_api_gateway_resource":            "api_gateway_resource",
+	"aws_api_gateway_stage":               "api_gateway_stage",
 	"aws_apigatewayv2_api":                "apigatewayv2_api",
 	"aws_apigatewayv2_authorizer":         "apigatewayv2_authorizer",
 	"aws_apigatewayv2_integration":        "apigatewayv2_integration",
@@ -51,6 +54,8 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_lambda_alias":                    "lambda_alias",
 	"aws_lambda_event_source_mapping":     "lambda_event_source_mapping",
 	"aws_lambda_function":                 "lambda",
+	"aws_lambda_function_url":             "lambda_function_url",
+	"aws_lambda_permission":               "lambda_permission",
 	"aws_lb":                              "lb",
 	"aws_lb_listener":                     "lb_listener",
 	"aws_lb_target_group":                 "lb_target_group",

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -24,6 +24,9 @@ const (
 // awsdiscover parity test will fail if this drifts from the live constructor.
 var awsTypes = []string{
 	"aws_acm_certificate",
+	"aws_api_gateway_deployment",
+	"aws_api_gateway_resource",
+	"aws_api_gateway_stage",
 	"aws_apigatewayv2_api",
 	"aws_apigatewayv2_authorizer",
 	"aws_apigatewayv2_integration",
@@ -57,6 +60,8 @@ var awsTypes = []string{
 	"aws_lambda_alias",
 	"aws_lambda_event_source_mapping",
 	"aws_lambda_function",
+	"aws_lambda_function_url",
+	"aws_lambda_permission",
 	"aws_lb",
 	"aws_lb_listener",
 	"aws_lb_target_group",

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -19,6 +19,9 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 	t.Parallel()
 	want := []string{
 		"aws_acm_certificate",
+		"aws_api_gateway_deployment",
+		"aws_api_gateway_resource",
+		"aws_api_gateway_stage",
 		"aws_apigatewayv2_api",
 		"aws_apigatewayv2_authorizer",
 		"aws_apigatewayv2_integration",
@@ -52,6 +55,8 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_lambda_alias",
 		"aws_lambda_event_source_mapping",
 		"aws_lambda_function",
+		"aws_lambda_function_url",
+		"aws_lambda_permission",
 		"aws_lb",
 		"aws_lb_listener",
 		"aws_lb_target_group",

--- a/tests/lint-project-tag.sh
+++ b/tests/lint-project-tag.sh
@@ -24,6 +24,8 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # Resource types that do NOT accept a tags attribute in AWS provider 6.x.
 # Keep sorted alphabetically.
 NON_TAGGABLE_AWS=(
+  aws_api_gateway_deployment
+  aws_api_gateway_resource
   aws_apigatewayv2_api_mapping
   aws_apigatewayv2_authorizer
   aws_apigatewayv2_integration
@@ -47,6 +49,8 @@ NON_TAGGABLE_AWS=(
   aws_iam_service_linked_role
   aws_kms_alias
   aws_lambda_alias
+  aws_lambda_function_url
+  aws_lambda_permission
   aws_msk_configuration
   aws_opensearchserverless_access_policy
   aws_opensearchserverless_security_policy


### PR DESCRIPTION
## Summary

AWS Cloud Control discovery coverage **55 → 60** by exercising the proven
`ParentLister` framework branch for five more parent-scoped types. Pure
config + tests + wiring on top of the framework introduced in #412
(and demonstrated in #416 / #418). No framework changes in this PR.

Closes #422.

## Types added

| TF type | CFN type | Parent (ResourceModel key) | Tags |
|---|---|---|---|
| `aws_lambda_permission` | `AWS::Lambda::Permission` | `FunctionName` (REUSE `listLambdaFunctions`) | untaggable |
| `aws_lambda_function_url` | `AWS::Lambda::Url` | `TargetFunctionArn` (NEW `listLambdaFunctionArns`) | untaggable |
| `aws_api_gateway_stage` | `AWS::ApiGateway::Stage` | `RestApiId` (NEW `listApigatewayRestAPIs`) | **TAGGABLE** |
| `aws_api_gateway_deployment` | `AWS::ApiGateway::Deployment` | `RestApiId` (REUSE) | untaggable |
| `aws_api_gateway_resource` | `AWS::ApiGateway::Resource` | `RestApiId` (REUSE) | untaggable |

## Types ruled out (and why)

Three originally-listed types in the Bundle 14d brief failed the schema-level
workability check against the live CFN registry schemas at
`schema.cloudformation.us-east-1.amazonaws.com` and were swapped:

- **`aws_route53_record`** — `AWS::Route53::RecordSet` has **no `handlers`
  block** in its CFN schema (no Cloud Control list/read). Legacy CFN-only.
- **`aws_iam_role_policy_attachment`** — no `AWS::IAM::RolePolicyAttachment`
  CFN type exists; managed-policy attachment lives as the
  `ManagedPolicyArns` array on `AWS::IAM::Role` itself.
- **`aws_cloudwatch_event_target`** — no `AWS::Events::Target` CFN type;
  targets are inline on `AWS::Events::Rule.Targets`.

Two further candidates from the brief's suggested swap list were also
ruled out:

- **`aws_sns_topic_subscription`** — `AWS::SNS::Subscription` IS
  Cloud-Control-listable, but its `list` handler is account-wide
  (`sns:ListSubscriptions`, no parent ResourceModel required). Doesn't
  fit this bundle's "ParentLister activation" theme.
- **`aws_sns_topic_policy`** — `AWS::SNS::TopicPolicy` has only
  create/update/delete handlers (no read, no list).

Replacements (`aws_lambda_function_url`, `aws_api_gateway_{stage,deployment,resource}`)
all carry verified Cloud Control `list` + `read` handlers with parent-required
schemas.

## Identifier rewrites — verified

Pinned in extractor tests against terraform-provider-aws v6.x docs:

- `lambda_permission`: CC `<FunctionName>\|<Id>` → TF `<FunctionName>/<Id>` (pipe→slash, first-only)
- `lambda_function_url`: CC `<FunctionArn>` → TF bare function name (or `<name>/<qualifier>`).
  Lambda ARN shape `arn:...:function:<name>[:<qual>]`; the rewriter extracts after
  `function:` and converts the qualifier `:` → `/`.
- `api_gateway_stage`: CC `<RestApiId>\|<StageName>` → TF `<RestApiId>/<StageName>`
- `api_gateway_resource`: CC `<RestApiId>\|<ResourceId>` → TF `<RestApiId>/<ResourceId>`
- `api_gateway_deployment`: **REVERSE-ORDER REWRITE.** CC `primaryIdentifier` is
  `[DeploymentId, RestApiId]`, so the CC compound is `<DeploymentId>\|<RestApiId>`
  but TF import is `<RestApiId>/<DeploymentId>`. Not a naive pipe→slash.
  A regression to `strings.Replace(id, "\|", "/", 1)` here would emit invalid
  imports — pinned explicitly in `TestApiGatewayDeploymentConfig`.

`api_gateway_stage` diverges from the other four #422 types in that its CFN
schema HAS a `Tags` property (`[]Tag`) — so `SkipProjectTagFilter` is FALSE
and `tagsFromKey("Tags")` extracts the tag map. The other four are
untaggable (`emptyTagsExtractor`, `SkipProjectTagFilter=true`).

## New listers (in `cloudcontrol_listers.go`)

- **`listApigatewayRestAPIs`** — paginates `apigateway:GetRestApis`. API
  Gateway v1 uses `Position` as the pagination cursor (not `NextToken`),
  so the loop terminator guards on both `nil` and `""`. Narrow
  `apigatewayRestAPIsLister` interface for testability.
- **`listLambdaFunctionArns`** — paginates `lambda:ListFunctions`, emits
  `{"TargetFunctionArn":"..."}` (the key Lambda::Url's list-handler schema
  requires — distinct from `listLambdaFunctions` which emits FunctionName).
  Reuses the existing `lambdaFunctionsLister` interface.

## Lister test coverage

Per the #418 pattern, every NEW lister gets:

- Pagination + **cursor round-trip** assertion (`positionsSeen` /
  `tokensSeen` / `markersSeen`) — without this, a regression dropping
  `position = page.Position` would still pass call-count assertions
  because the fake serves by call-count.
- Empty-account non-nil contract.
- Error wrap via `errors.Is`.
- Empty-string cursor termination (`Position=&""` on final page).
- Defensive empty-ID skip.

For compound-ID rewrites, **first-pipe-only contract** is pinned with
multi-pipe fixtures for every type — a regression to `strings.ReplaceAll`
would fail loudly.

## Wiring touchpoints

- `cmd/insideout-import/awsdiscover/cloudcontrol_listers.go` — 2 new
  listers + 1 new narrow interface
- `cmd/insideout-import/awsdiscover/cloudcontrol_types.go` — 5 entries
- `cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go` — 9 tests
- `cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go` — 5 `Test<Type>Config`
- `pkg/insideout-import/registry/registry.go` + test — 5 sorted entries
- `pkg/insideout-import/permissions/aws.json` + test — 17 IAM rows
- `pkg/composer/imported/category.go` + golden — 5 entries
- `pkg/composer/imported_provenance.go` — 4 untaggable (stage excluded)
- `tests/lint-project-tag.sh` — 4 entries
- `go.mod` — adds `github.com/aws/aws-sdk-go-v2/service/apigateway`

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — no issues
- [x] `go test ./... -race -count=1` — PASS
- [x] `terraform fmt -check -recursive` — clean
- [x] `bash tests/lint-project-tag.sh` — PASS
- [x] `bash tests/lint-project-label.sh` — PASS
- [x] `bash tests/lint-sensitive-for-each.sh` — PASS
- [x] `bash tests/lint-foreach-unknown-keys.sh` — PASS
- [ ] CI green

## References

- #412 — Introduced ParentLister + SDKLister framework fields
- #416 — Bundle 14c: 5 more types via ParentLister (apigatewayv2 children + cognito children)
- #422 — This bundle's tracking issue