### PR TITLE
fix(awsdiscover): soft-handle CC ListResources NotFound in ParentLister fan-out

### DIFF
--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
@@ -306,6 +306,27 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 					for paginator.HasMorePages() {
 						page, err := paginator.NextPage(ctx)
 						if err != nil {
+							// Per-parent ListResources fan-out: some
+							// CFN handlers (e.g. AWS::Lambda::Permission
+							// per #426) return ResourceNotFoundException
+							// when a parent legitimately has zero
+							// children of the queried type, instead of
+							// returning an empty list. Treat that as an
+							// empty result for this parent, emit a soft
+							// ServiceWarn for visibility, and continue
+							// to the next parent rather than aborting
+							// the whole type's discovery. Only applies
+							// to the parent-scoped path: when
+							// parentModel is "" we're doing the
+							// top-level type list and a NotFound there
+							// is a real failure (the type itself is
+							// missing or misconfigured).
+							if parentModel != "" && isCloudControlNotFound(err) {
+								args.Emitter.ServiceWarn(d.cfg.Slug, region,
+									fmt.Sprintf("ListResources %s%s: NotFound treated as empty (#426 — CFN handler returned NotFound for a parent with zero children of this type): %v",
+										d.cfg.CloudFormationType, parentLabelFromModel(parentModel), err))
+								break
+							}
 							args.Emitter.ServiceFinish(d.cfg.Slug, region, regionCount, time.Since(regionStart))
 							return nil, fmt.Errorf("ListResources %s (region=%s): %w", d.cfg.CloudFormationType, region, err)
 						}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
@@ -1165,6 +1165,122 @@ func TestCloudControlDiscover_ParentListerErrorEmitsFinishAndPropagates(t *testi
 	}
 }
 
+// TestCloudControlDiscover_ParentListerListNotFoundIsSoftEmpty pins
+// the #426 regression contract: when CC ListResources returns
+// ResourceNotFoundException for a parent in the fan-out (some CFN
+// handlers — AWS::Lambda::Permission notably — return NotFound when
+// a parent legitimately has zero children, rather than an empty
+// list), the discoverer must:
+//
+//  1. NOT propagate the error (no exit-1 abort on a type with mixed
+//     populated + empty parents);
+//  2. emit a ServiceWarn so the soft-fail is visible in the run log;
+//  3. continue to the next parent;
+//  4. STILL emit all children of OTHER parents that didn't return
+//     NotFound.
+//
+// This is parent-scope-only: when parentModel is "" (top-level list)
+// a NotFound still propagates — that's covered by
+// TestCloudControlDiscover_PropagatesListError_AlsoEmitsServiceFinish.
+func TestCloudControlDiscover_ParentListerListNotFoundIsSoftEmpty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{
+		propsByIdentifier: map[string]map[string]any{
+			"aa": {"UserPoolId": "A", "ClientId": "aa"},
+			"ab": {"UserPoolId": "A", "ClientId": "ab"},
+		},
+	}
+	parentACalls := 0
+	parentBCalls := 0
+	listMux := func(in *cloudcontrol.ListResourcesInput) (*cloudcontrol.ListResourcesOutput, error) {
+		if in.ResourceModel == nil {
+			return nil, errors.New("expected ResourceModel for parent-scoped list")
+		}
+		switch *in.ResourceModel {
+		case `{"UserPoolId":"A"}`:
+			parentACalls++
+			page := listPage("", "aa", "ab")
+			return &page, nil
+		case `{"UserPoolId":"B"}`:
+			parentBCalls++
+			// Simulate the AWS::Lambda::Permission CFN-handler quirk:
+			// NotFound returned for a parent with zero children.
+			return nil, &cctypes.ResourceNotFoundException{Message: ptr("zero children for parent B")}
+		default:
+			return nil, errors.New("unexpected parent model: " + *in.ResourceModel)
+		}
+	}
+	cfg := testConfig()
+	cfg.ParentLister = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		return []string{`{"UserPoolId":"A"}`, `{"UserPoolId":"B"}`}, nil
+	}
+	d := &cloudControlDiscoverer{
+		cfg: cfg,
+		new: func(_ string) cloudControlClient {
+			return &parentMuxClient{listFn: listMux, getFn: fake.GetResource}
+		},
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	})
+	if err != nil {
+		t.Fatalf("NotFound on a parent must be soft-handled, got hard error: %v", err)
+	}
+	// Both parents were attempted; A produced 2 emissions; B was
+	// soft-skipped on NotFound.
+	if parentACalls != 1 {
+		t.Errorf("parent A list calls=%d, want 1 (well-behaved parent must still be queried)", parentACalls)
+	}
+	if parentBCalls != 1 {
+		t.Errorf("parent B list calls=%d, want 1 (NotFound parent must still be attempted, not skipped pre-call)", parentBCalls)
+	}
+	if len(got) != 2 {
+		t.Fatalf("emit count=%d, want 2 (parent A's two children; parent B's NotFound must produce zero, not abort)", len(got))
+	}
+	// Pin the ServiceWarn surface: a #426 NotFound must produce
+	// exactly one warn that names the parent so an operator scanning
+	// the run log can map it back to a specific resource.
+	var warns int
+	var sawNotFoundWarn bool
+	for _, e := range rec.snapshot() {
+		if e.Kind == "service_warn" {
+			warns++
+			// Message must mention "NotFound" so log scanners can
+			// distinguish this from other soft-fails (RGT, GetResource
+			// failures). The "#426" reference is load-bearing for
+			// future readers debugging the same pattern.
+			if strings.Contains(e.Message, "NotFound") && strings.Contains(e.Message, `{"UserPoolId":"B"}`) {
+				sawNotFoundWarn = true
+			}
+		}
+	}
+	if warns != 1 {
+		t.Errorf("service_warn count=%d, want 1 (exactly one warn per soft-NotFound parent)", warns)
+	}
+	if !sawNotFoundWarn {
+		t.Error("ServiceWarn message must mention NotFound + the parent ResourceModel so operators can correlate it")
+	}
+	// ServiceFinish must close the bracket with count=2 (the
+	// soft-empty parent doesn't subtract from the count of other
+	// parents' successful emissions).
+	var finishes int
+	for _, e := range rec.snapshot() {
+		if e.Kind == "service_finish" {
+			finishes++
+			if e.Count != 2 {
+				t.Errorf("service_finish.Count=%d, want 2 (parent A's emissions, not affected by parent B's soft-empty)", e.Count)
+			}
+		}
+	}
+	if finishes != 1 {
+		t.Errorf("service_finish count=%d, want 1", finishes)
+	}
+}
+
 // TestCloudControlDiscover_PropagatesListError_AlsoEmitsServiceFinish
 // pins the ListResources-error path's ServiceFinish bracket close.
 // Existing TestCloudControlDiscover_PropagatesListError covers the


### PR DESCRIPTION
## Summary

Hotfix for **#426**, found by the post-merge live smoke of Bundle 14d (#422) against test account 141812438321 / project \`io-f-v6e-hzw-zt\`:

\`aws_lambda_permission\` exits discovery with a hard error because \`AWS::Lambda::Permission\`'s CC LIST handler returns \`ResourceNotFoundException\` when a Lambda function has zero resource-based policies attached — instead of returning an empty list. The ParentLister fan-out (one CC ListResources per Lambda) hit that case on the test account → exit 1.

After fix: same 45 emissions as the prior smoke, 3 expected soft \`service_warn\`s on \`lambda_permission\` (one per Lambda with zero permissions), zero hard errors.

## Fix

Scope-limited soft-handling in the ParentLister fan-out path of \`cloudControlDiscoverer.Discover\`:

- When \`isCloudControlNotFound(err)\` AND \`parentModel != \"\"\`: emit \`ServiceWarn\` naming the parent + #426 reference, then \`break\` out of the paginator loop (treating this parent as having no children) and continue to the next parent.
- All other CC errors continue to propagate as before (auth, throttle, InvalidRequestException, etc.).
- Top-level type list (parentModel == \"\") still propagates NotFound as a hard error — that scenario indicates the type itself is missing or misconfigured, not an empty-result quirk.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/insideout-import/awsdiscover/... -race -count=1\` — 360/360 pass (359 prior + 1 new regression test)
- [x] \`terraform fmt -check -recursive\` clean
- [x] All four lint scripts PASS
- [x] **Live re-smoke** on 141812438321 / io-f-v6e-hzw-zt: **exit 0, 45 emissions, 3 expected \`service_warn\` lines on \`lambda_permission\`**, zero hard errors. Identical baseline to the post-#421 smoke.

## New regression test

\`TestCloudControlDiscover_ParentListerListNotFoundIsSoftEmpty\` pins four contracts simultaneously:

1. No hard error returned to the caller.
2. ServiceWarn emitted exactly once per soft-NotFound parent.
3. Well-behaved parents still emit their children.
4. ServiceFinish count reflects partial-success accurately.

A fake parent-mux client returns NotFound for parent B and a populated list for parent A; the test asserts 2 emissions (A's children), 1 \`service_warn\` mentioning the parent B model + \"NotFound\", and \`service_finish.Count=2\`.

## Why this matters beyond Lambda::Permission

The same CFN-handler quirk likely affects other parent-scoped types whose handlers were written before AWS standardized empty-list semantics. A general framework fix (rather than per-type opt-outs) means future bundle adds of similarly-quirky types get the right behavior by default.

Closes #426. Follows #422.