### PR TITLE
feat(composer): coherence rules — StripOrphanConfig + DeriveCrossComponentFields

### DIFF
--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -1,0 +1,261 @@
+package composer
+
+// coherence.go owns the rules that make a (Components, Config) pair coherent:
+//
+//   - StripOrphanConfig clears per-component config sub-blocks whose component
+//     is no longer selected. Orphan config sub-blocks otherwise outlive the
+//     component that produced them and leak into deploy payloads (the NAT-on-
+//     Public-VPC apply failure on sess_v2_CnqUJ6NRJnLC, luthersystems/reliable#1435).
+//
+//   - DeriveCrossComponentFields recomputes config fields whose correct value
+//     is a function of which OTHER components are selected — today the AWS
+//     VPC topology knobs whose preset HCL default of NAT=true must NOT survive
+//     onto a stack that no longer needs private subnets.
+//
+// Both functions are pure. They are intended to be composed around
+// (*Client).ApplyPresetDefaults — strip + derive BEFORE the backfill catches
+// "stale-then-removed" carry-forward, and AFTER the backfill catches "fresh
+// allocation" cases where ApplyPresetDefaults just landed NAT=true onto a
+// Public-VPC-only stack.
+//
+// Tracked under luthersystems/reliable#1437.
+
+import "reflect"
+
+// ComponentSelected reports whether the given component is selected on the
+// provided Components value. Pointer-typed components require non-nil AND
+// *true (so an explicit aws_opensearch=false is treated as deselected).
+// String-typed components (AWSVPC, AWSEC2, GCPCompute) require != "".
+// Struct-pointer components (AWSBackups, GCPBackups) require != nil; the
+// backup config itself encodes the selection.
+//
+// Returns false for ComponentKeys that don't appear on Components (e.g.,
+// KeyAWSEKSNodeGroup / KeyAWSEKSControlPlane — those are polymorphic preset
+// keys driven by other component selections, not standalone components).
+func ComponentSelected(c *Components, key ComponentKey) bool {
+	if c == nil {
+		return false
+	}
+	switch key {
+	// String-typed selections.
+	case KeyAWSVPC:
+		return c.AWSVPC != ""
+	case KeyAWSEC2:
+		return c.AWSEC2 != ""
+	case KeyGCPCompute:
+		return c.GCPCompute != ""
+	// AWS pointer-typed selections.
+	case KeyAWSBastion:
+		return boolPtrTrue(c.AWSBastion)
+	case KeyAWSEKS:
+		return boolPtrTrue(c.AWSEKS)
+	case KeyAWSECS:
+		return boolPtrTrue(c.AWSECS)
+	case KeyAWSLambda:
+		return boolPtrTrue(c.AWSLambda)
+	case KeyAWSALB:
+		return boolPtrTrue(c.AWSALB)
+	case KeyAWSCloudfront:
+		return boolPtrTrue(c.AWSCloudFront)
+	case KeyAWSWAF:
+		return boolPtrTrue(c.AWSWAF)
+	case KeyAWSAPIGateway:
+		return boolPtrTrue(c.AWSAPIGateway)
+	case KeyAWSRDS:
+		return boolPtrTrue(c.AWSRDS)
+	case KeyAWSElastiCache:
+		return boolPtrTrue(c.AWSElastiCache)
+	case KeyAWSDynamoDB:
+		return boolPtrTrue(c.AWSDynamoDB)
+	case KeyAWSS3:
+		return boolPtrTrue(c.AWSS3)
+	case KeyAWSKMS:
+		return boolPtrTrue(c.AWSKMS)
+	case KeyAWSSecretsManager:
+		return boolPtrTrue(c.AWSSecretsManager)
+	case KeyAWSOpenSearch:
+		return boolPtrTrue(c.AWSOpenSearch)
+	case KeyAWSBedrock:
+		return boolPtrTrue(c.AWSBedrock)
+	case KeyAWSSQS:
+		return boolPtrTrue(c.AWSSQS)
+	case KeyAWSMSK:
+		return boolPtrTrue(c.AWSMSK)
+	case KeyAWSCloudWatchLogs:
+		return boolPtrTrue(c.AWSCloudWatchLogs)
+	case KeyAWSCloudWatchMonitoring:
+		return boolPtrTrue(c.AWSCloudWatchMonitoring)
+	case KeyAWSGrafana:
+		return boolPtrTrue(c.AWSGrafana)
+	case KeyAWSCognito:
+		return boolPtrTrue(c.AWSCognito)
+	case KeyAWSGitHubActions:
+		return boolPtrTrue(c.AWSGitHubActions)
+	case KeyAWSCodePipeline:
+		return boolPtrTrue(c.AWSCodePipeline)
+	case KeyAWSBackups:
+		return c.AWSBackups != nil
+	// GCP pointer-typed selections.
+	case KeyGCPVPC:
+		return boolPtrTrue(c.GCPVPC)
+	case KeyGCPBastion:
+		return boolPtrTrue(c.GCPBastion)
+	case KeyGCPGKE:
+		return boolPtrTrue(c.GCPGKE)
+	case KeyGCPCloudRun:
+		return boolPtrTrue(c.GCPCloudRun)
+	case KeyGCPCloudFunctions:
+		return boolPtrTrue(c.GCPCloudFunctions)
+	case KeyGCPLoadbalancer:
+		return boolPtrTrue(c.GCPLoadbalancer)
+	case KeyGCPCloudArmor:
+		return boolPtrTrue(c.GCPCloudArmor)
+	case KeyGCPAPIGateway:
+		return boolPtrTrue(c.GCPAPIGateway)
+	case KeyGCPCloudSQL:
+		return boolPtrTrue(c.GCPCloudSQL)
+	case KeyGCPMemorystore:
+		return boolPtrTrue(c.GCPMemorystore)
+	case KeyGCPFirestore:
+		return boolPtrTrue(c.GCPFirestore)
+	case KeyGCPGCS:
+		return boolPtrTrue(c.GCPGCS)
+	case KeyGCPCloudKMS:
+		return boolPtrTrue(c.GCPCloudKMS)
+	case KeyGCPSecretManager:
+		return boolPtrTrue(c.GCPSecretManager)
+	case KeyGCPVertexAI:
+		return boolPtrTrue(c.GCPVertexAI)
+	case KeyGCPPubSub:
+		return boolPtrTrue(c.GCPPubSub)
+	case KeyGCPCloudLogging:
+		return boolPtrTrue(c.GCPCloudLogging)
+	case KeyGCPCloudMonitoring:
+		return boolPtrTrue(c.GCPCloudMonitoring)
+	case KeyGCPIdentityPlatform:
+		return boolPtrTrue(c.GCPIdentityPlatform)
+	case KeyGCPCloudBuild:
+		return boolPtrTrue(c.GCPCloudBuild)
+	case KeyGCPBackups:
+		return c.GCPBackups != nil
+	// External / third-party.
+	case KeySplunk:
+		return boolPtrTrue(c.Splunk)
+	case KeyDatadog:
+		return boolPtrTrue(c.Datadog)
+	}
+	return false
+}
+
+// StackNeedsPrivateSubnets reports whether the stack includes any AWS
+// component that requires private subnets — and therefore NAT egress. The
+// mapper enforces the same predicate to coerce NAT off on Public-VPC stacks
+// (see KeyAWSVPC branch in BuildModuleValues). Exporting it lets persistence-
+// layer callers (luthersystems/reliable) make the same decision upstream of
+// the mapper so cfg.AWSVPC.EnableNATGateway never gets persisted as &true
+// on a stack that doesn't need NAT.
+func StackNeedsPrivateSubnets(c *Components) bool {
+	return stackNeedsPrivateSubnets(c)
+}
+
+// StripOrphanConfig clears every cfg.<component> sub-block whose
+// corresponding component is NOT selected in `comps`. Pure, idempotent. A
+// no-op when cfg is nil or comps is nil (an unknown components state cannot
+// safely conclude orphanhood).
+//
+// Treats "non-nil but empty" sub-structs as orphan when their component is
+// unselected — an empty &AWSOpenSearch{} conveys no actual configuration and
+// must not survive when opensearch is dropped.
+//
+// The set of stripped fields is determined reflectively: any *struct sub-
+// field on Config whose json tag matches a known ComponentKey is in scope.
+// Adding a new component to Components + Config + KeyXxx requires no edit
+// here.
+func StripOrphanConfig(comps *Components, cfg *Config) {
+	if comps == nil || cfg == nil {
+		return
+	}
+	cfgVal := reflect.ValueOf(cfg).Elem()
+	cfgType := cfgVal.Type()
+	for i := 0; i < cfgType.NumField(); i++ {
+		ft := cfgType.Field(i)
+		if ft.Type.Kind() != reflect.Pointer || ft.Type.Elem().Kind() != reflect.Struct {
+			continue
+		}
+		tag := jsonTagName(ft.Tag.Get("json"))
+		if tag == "" {
+			continue
+		}
+		key := ComponentKey(tag)
+		if !isOrphanStrippableKey(key) {
+			continue
+		}
+		if !ComponentSelected(comps, key) {
+			fv := cfgVal.Field(i)
+			if fv.CanSet() && !fv.IsNil() {
+				fv.Set(reflect.Zero(fv.Type()))
+			}
+		}
+	}
+}
+
+// DeriveCrossComponentFields re-derives cfg fields whose correct value is a
+// function of which OTHER components are selected. Today covers the AWS VPC
+// topology knobs:
+//
+//   - cfg.AWSVPC.EnableNATGateway
+//   - cfg.AWSVPC.SingleNATGateway
+//   - cfg.AWSVPC.AZCount
+//
+// When no selected component needs private subnets, the three fields are
+// cleared. If every field of the AWSVPC sub-block ends up nil, the
+// sub-block pointer itself is cleared so json:",omitempty" hides it.
+//
+// Why both this AND StripOrphanConfig: AWSVPC is selected (the user keeps a
+// Public VPC) even when no DOWNSTREAM component needs private subnets. The
+// orphan strip cannot help — the VPC component itself is in scope. Cross-
+// component derive is the rule that catches "VPC stays, but its NAT-related
+// sub-fields no longer have a justification."
+//
+// Pure, idempotent.
+func DeriveCrossComponentFields(comps *Components, cfg *Config) {
+	if comps == nil || cfg == nil || cfg.AWSVPC == nil {
+		return
+	}
+	if !stackNeedsPrivateSubnets(comps) {
+		cfg.AWSVPC.EnableNATGateway = nil
+		cfg.AWSVPC.SingleNATGateway = nil
+		cfg.AWSVPC.AZCount = nil
+		if cfg.AWSVPC.EnableNATGateway == nil &&
+			cfg.AWSVPC.SingleNATGateway == nil &&
+			cfg.AWSVPC.AZCount == nil {
+			cfg.AWSVPC = nil
+		}
+	}
+}
+
+// isOrphanStrippableKey reports whether the given ComponentKey has a per-
+// component sub-block on Config that participates in the orphan strip. The
+// list mirrors the *struct sub-fields of Config with cloud-prefixed json
+// tags. Polymorphic preset keys (KeyAWSEKSNodeGroup / KeyAWSEKSControlPlane)
+// and pure non-config components (KeyAWSALB / KeyAWSGrafana / KeyAWSWAF /
+// KeySplunk / KeyDatadog / KeyGitHubActions etc.) are NOT in scope — there
+// is no cfg.<key> sub-block to strip.
+func isOrphanStrippableKey(key ComponentKey) bool {
+	switch key {
+	case KeyAWSEC2, KeyAWSEKS, KeyAWSECS, KeyAWSVPC,
+		KeyAWSCloudfront, KeyAWSRDS, KeyAWSElastiCache,
+		KeyAWSS3, KeyAWSDynamoDB, KeyAWSSQS, KeyAWSMSK,
+		KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
+		KeyAWSCognito, KeyAWSLambda, KeyAWSAPIGateway,
+		KeyAWSKMS, KeyAWSSecretsManager, KeyAWSOpenSearch,
+		KeyAWSBedrock, KeyAWSBackups,
+		KeyGCPCompute, KeyGCPGKE, KeyGCPCloudRun,
+		KeyGCPCloudFunctions, KeyGCPLoadbalancer,
+		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,
+		KeyGCPPubSub, KeyGCPCloudLogging,
+		KeyGCPIdentityPlatform, KeyGCPAPIGateway, KeyGCPBackups:
+		return true
+	}
+	return false
+}

--- a/pkg/composer/coherence_test.go
+++ b/pkg/composer/coherence_test.go
@@ -1,0 +1,623 @@
+package composer
+
+// coherence_test.go locks the (Components, Config) coherence rules upstream.
+// Ports the pure-function regression suite that originated in
+// luthersystems/reliable's chatv2 + agentapi packages (#1435) so the same
+// invariant cannot regress on either side.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func intPtr(i int) *int { return &i }
+
+// awsVPCSubFields mirrors the anonymous struct shape on Config.AWSVPC.
+// Mirrors the literal used in mapper_test.go's cfgWithAWSVPC helper.
+func cfgWithVPCSubBlock(single, enable *bool, az *int) *Config {
+	c := &Config{}
+	c.AWSVPC = &struct {
+		SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+		EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+		AZCount          *int  `json:"azCount,omitempty"`
+	}{SingleNATGateway: single, EnableNATGateway: enable, AZCount: az}
+	return c
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// ComponentSelected
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestComponentSelected_StringFields(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, ComponentSelected(&Components{}, KeyAWSVPC))
+	assert.True(t, ComponentSelected(&Components{AWSVPC: "Public VPC"}, KeyAWSVPC))
+
+	assert.False(t, ComponentSelected(&Components{}, KeyAWSEC2))
+	assert.True(t, ComponentSelected(&Components{AWSEC2: "Intel"}, KeyAWSEC2))
+
+	assert.False(t, ComponentSelected(&Components{}, KeyGCPCompute))
+	assert.True(t, ComponentSelected(&Components{GCPCompute: "n2-standard-2"}, KeyGCPCompute))
+}
+
+func TestComponentSelected_PointerFields_RequireTrue(t *testing.T) {
+	t.Parallel()
+
+	// nil pointer → not selected.
+	assert.False(t, ComponentSelected(&Components{}, KeyAWSOpenSearch))
+
+	// explicit &false → not selected (so cfg.AWSOpenSearch is stripped).
+	assert.False(t, ComponentSelected(&Components{AWSOpenSearch: boolPtr(false)}, KeyAWSOpenSearch),
+		"explicit &false must be treated as deselected so its config sub-block is stripped")
+
+	// &true → selected.
+	assert.True(t, ComponentSelected(&Components{AWSOpenSearch: boolPtr(true)}, KeyAWSOpenSearch))
+}
+
+func TestComponentSelected_BackupsPointer_NonNilEqualsSelected(t *testing.T) {
+	t.Parallel()
+
+	// AWSBackups is a *struct{...}; its presence alone signals selection.
+	c := &Components{}
+	assert.False(t, ComponentSelected(c, KeyAWSBackups))
+
+	c.AWSBackups = &struct {
+		EC2         *bool `json:"aws_ec2,omitempty"`
+		RDS         *bool `json:"aws_rds,omitempty"`
+		ElastiCache *bool `json:"aws_elasticache,omitempty"`
+		DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+		S3          *bool `json:"aws_s3,omitempty"`
+	}{}
+	assert.True(t, ComponentSelected(c, KeyAWSBackups))
+}
+
+func TestComponentSelected_NilComponents_AlwaysFalse(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range []ComponentKey{
+		KeyAWSVPC, KeyAWSEC2, KeyAWSOpenSearch, KeyGCPCompute, KeyGCPBackups,
+	} {
+		assert.False(t, ComponentSelected(nil, key), "nil components must report not-selected for %s", key)
+	}
+}
+
+func TestComponentSelected_PolymorphicAndNonConfigKeys_AlwaysFalse(t *testing.T) {
+	t.Parallel()
+
+	// Polymorphic preset keys (KeyAWSEKSNodeGroup / KeyAWSEKSControlPlane)
+	// don't map to a Components field — selection is encoded by AWSEKS +
+	// AWSLambda. ComponentSelected must NOT report them as a standalone
+	// selection (downstream code would treat them as orphan-strippable and
+	// misbehave).
+	c := &Components{AWSEKS: boolPtr(true), AWSLambda: boolPtr(true)}
+	assert.False(t, ComponentSelected(c, KeyAWSEKSNodeGroup))
+	assert.False(t, ComponentSelected(c, KeyAWSEKSControlPlane))
+
+	// KeyComposer / KeyArch / KeyCloud are meta-keys, not components.
+	assert.False(t, ComponentSelected(c, KeyComposer))
+	assert.False(t, ComponentSelected(c, KeyArch))
+	assert.False(t, ComponentSelected(c, KeyCloud))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// StackNeedsPrivateSubnets — exported wrapper around the mapper helper.
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestStackNeedsPrivateSubnets_Exported(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, StackNeedsPrivateSubnets(nil))
+	assert.False(t, StackNeedsPrivateSubnets(&Components{}))
+
+	for _, c := range []*Components{
+		{AWSEKS: boolPtr(true)},
+		{AWSECS: boolPtr(true)},
+		{AWSRDS: boolPtr(true)},
+		{AWSElastiCache: boolPtr(true)},
+		{AWSOpenSearch: boolPtr(true)},
+		{AWSEC2: "Intel"},
+		{AWSEC2: "ARM"},
+	} {
+		assert.True(t, StackNeedsPrivateSubnets(c), "%+v should need private subnets", c)
+	}
+
+	// Components that DON'T need private subnets:
+	assert.False(t, StackNeedsPrivateSubnets(&Components{AWSLambda: boolPtr(true)}))
+	assert.False(t, StackNeedsPrivateSubnets(&Components{AWSS3: boolPtr(true), AWSKMS: boolPtr(true)}))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// StripOrphanConfig
+// ──────────────────────────────────────────────────────────────────────────
+
+// TestStripOrphanConfig_ClearsUnselectedSubBlocks ports the failure shape
+// from sess_v2_CnqUJ6NRJnLC: a config.aws_opensearch sub-block survives
+// after aws_opensearch is removed from components. Strip must clear it.
+func TestStripOrphanConfig_ClearsUnselectedSubBlocks(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Cloud: "AWS",
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production", InstanceType: "m6g.large"},
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Runtime: "nodejs20.x", Timeout: "30s"},
+	}
+	comps := &Components{
+		Cloud:     "AWS",
+		AWSVPC:    "Public VPC",
+		AWSLambda: boolPtr(true),
+		// AWSOpenSearch intentionally omitted.
+	}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSOpenSearch, "orphan opensearch sub-block must be cleared")
+	assert.NotNil(t, cfg.AWSLambda, "selected Lambda sub-block must survive")
+	assert.Equal(t, "nodejs20.x", cfg.AWSLambda.Runtime, "user values on selected components must survive")
+}
+
+// TestStripOrphanConfig_EmptyAllocatedSubBlockIsOrphan locks the "non-nil-
+// but-empty" rule: an &AWSOpenSearch{} sub-block (no actual configuration)
+// must NOT be a signal that opensearch is selected. The Components blob is
+// the canonical selection witness.
+func TestStripOrphanConfig_EmptyAllocatedSubBlockIsOrphan(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{}, // allocated but empty
+	}
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC"}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSOpenSearch,
+		"an allocated-but-empty sub-block must be treated as orphan when its component is unselected")
+}
+
+// TestStripOrphanConfig_ExplicitFalsePointerStripsConfig captures the
+// "explicit aws_opensearch=false" case: the user (or a downstream rule)
+// signalled deselection by writing &false to the components blob. The
+// config sub-block must be cleared.
+func TestStripOrphanConfig_ExplicitFalsePointerStripsConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production"},
+	}
+	comps := &Components{
+		Cloud:         "AWS",
+		AWSVPC:        "Public VPC",
+		AWSOpenSearch: boolPtr(false), // explicit deselection
+	}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSOpenSearch,
+		"AWSOpenSearch=&false must trigger strip — explicit deselection is still deselection")
+}
+
+// TestStripOrphanConfig_LeavesNonStrippableUntouched checks that fields
+// outside the orphan-strippable set (Region, Cloud, EstimatedMonthlyRequests)
+// survive the strip even when other components are missing.
+func TestStripOrphanConfig_LeavesNonStrippableUntouched(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Cloud:                    "AWS",
+		Region:                   "us-east-2",
+		EstimatedMonthlyRequests: 100_000,
+		EstimatedAvgDurationMs:   250,
+	}
+	comps := &Components{Cloud: "AWS"} // nothing selected
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Equal(t, "AWS", cfg.Cloud)
+	assert.Equal(t, "us-east-2", cfg.Region)
+	assert.Equal(t, int64(100_000), cfg.EstimatedMonthlyRequests)
+	assert.Equal(t, 250, cfg.EstimatedAvgDurationMs)
+}
+
+// TestStripOrphanConfig_AWSBackupsRespectsSelection ports the
+// Components.AWSBackups != nil convention: when AWSBackups is selected, the
+// cfg.AWSBackups sub-block must survive even if some inner backup configs
+// are zero.
+func TestStripOrphanConfig_AWSBackupsRespectsSelection(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSBackups: &struct {
+			EC2 *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_ec2,omitempty"`
+			RDS *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_rds,omitempty"`
+			ElastiCache *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_elasticache,omitempty"`
+			DynamoDB *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_dynamodb,omitempty"`
+			S3 *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_s3,omitempty"`
+		}{},
+	}
+	comps := &Components{
+		Cloud: "AWS",
+		AWSBackups: &struct {
+			EC2         *bool `json:"aws_ec2,omitempty"`
+			RDS         *bool `json:"aws_rds,omitempty"`
+			ElastiCache *bool `json:"aws_elasticache,omitempty"`
+			DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+			S3          *bool `json:"aws_s3,omitempty"`
+		}{S3: boolPtr(true)},
+	}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.NotNil(t, cfg.AWSBackups, "cfg.AWSBackups must survive when comps.AWSBackups is non-nil")
+}
+
+// TestStripOrphanConfig_AWSBackupsCleared captures the orphan path: comps
+// has no AWSBackups, so cfg.AWSBackups is stripped.
+func TestStripOrphanConfig_AWSBackupsCleared(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSBackups: &struct {
+			EC2 *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_ec2,omitempty"`
+			RDS *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_rds,omitempty"`
+			ElastiCache *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_elasticache,omitempty"`
+			DynamoDB *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_dynamodb,omitempty"`
+			S3 *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_s3,omitempty"`
+		}{},
+	}
+	comps := &Components{Cloud: "AWS"} // no AWSBackups
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSBackups, "orphan AWSBackups sub-block must be cleared when comps.AWSBackups is nil")
+}
+
+// TestStripOrphanConfig_CrossCloudResidual locks the rule that a switch to
+// the opposite cloud strips the previous cloud's sub-blocks. Mirrors the
+// reliable-side TestUnion_Issue1435_OrphanConfig_CrossCloudResidual.
+func TestStripOrphanConfig_CrossCloudResidual(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Cloud: "GCP",
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Runtime: "nodejs20.x"},
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{},
+		GCPCloudRun: &struct {
+			Memory       string `json:"memory,omitempty"`
+			CPU          string `json:"cpu,omitempty"`
+			MinInstances *int   `json:"minInstances,omitempty"`
+			MaxInstances *int   `json:"maxInstances,omitempty"`
+		}{Memory: "512Mi"},
+	}
+	comps := &Components{
+		Cloud:       "GCP",
+		GCPVPC:      boolPtr(true),
+		GCPCloudRun: boolPtr(true),
+	}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSLambda, "AWS Lambda sub-block must be stripped on a GCP stack")
+	assert.Nil(t, cfg.AWSOpenSearch, "AWS OpenSearch sub-block must be stripped on a GCP stack")
+	assert.NotNil(t, cfg.GCPCloudRun, "GCP Cloud Run sub-block must survive when selected")
+	assert.Equal(t, "512Mi", cfg.GCPCloudRun.Memory)
+}
+
+// TestStripOrphanConfig_Idempotent guards against a future "smart" rewrite
+// that drifts on repeat calls.
+func TestStripOrphanConfig_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production"},
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Runtime: "nodejs20.x"},
+	}
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+
+	StripOrphanConfig(comps, cfg)
+	first, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	StripOrphanConfig(comps, cfg)
+	second, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second))
+}
+
+func TestStripOrphanConfig_NilInputs_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() { StripOrphanConfig(nil, &Config{}) })
+	assert.NotPanics(t, func() { StripOrphanConfig(&Components{}, nil) })
+	assert.NotPanics(t, func() { StripOrphanConfig(nil, nil) })
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// DeriveCrossComponentFields
+// ──────────────────────────────────────────────────────────────────────────
+
+// TestDeriveCrossComponentFields_NoPrivateSubnets_ClearsNAT pins the actual
+// production failure mode from sess_v2_CnqUJ6NRJnLC: a leftover
+// EnableNATGateway=&true on a Public-VPC stack with no NAT-needing
+// components must be cleared. If every AWSVPC field is cleared, the
+// sub-block pointer itself is cleared so json:",omitempty" hides it.
+func TestDeriveCrossComponentFields_NoPrivateSubnets_ClearsNAT(t *testing.T) {
+	t.Parallel()
+
+	cfg := cfgWithVPCSubBlock(boolPtr(true), boolPtr(true), intPtr(2))
+	comps := &Components{
+		Cloud:     "AWS",
+		AWSVPC:    "Public VPC",
+		AWSLambda: boolPtr(true),
+		AWSS3:     boolPtr(true),
+		// No EKS/ECS/RDS/ElastiCache/OpenSearch/EC2.
+	}
+
+	DeriveCrossComponentFields(comps, cfg)
+
+	assert.Nil(t, cfg.AWSVPC,
+		"NAT-related fields all cleared → AWSVPC sub-block pointer cleared too")
+}
+
+// TestDeriveCrossComponentFields_NeedsPrivateSubnets_Preserves locks the
+// non-clobber rule: when the stack DOES need private subnets, the user's
+// AWSVPC settings must survive untouched.
+func TestDeriveCrossComponentFields_NeedsPrivateSubnets_Preserves(t *testing.T) {
+	t.Parallel()
+
+	cfg := cfgWithVPCSubBlock(boolPtr(false), boolPtr(true), intPtr(3))
+	comps := &Components{
+		Cloud:     "AWS",
+		AWSVPC:    "Private VPC",
+		AWSEKS:    boolPtr(true),
+		AWSLambda: boolPtr(true),
+	}
+
+	DeriveCrossComponentFields(comps, cfg)
+
+	require.NotNil(t, cfg.AWSVPC)
+	require.NotNil(t, cfg.AWSVPC.EnableNATGateway)
+	assert.True(t, *cfg.AWSVPC.EnableNATGateway, "NAT must survive when EKS is selected")
+	require.NotNil(t, cfg.AWSVPC.AZCount)
+	assert.Equal(t, 3, *cfg.AWSVPC.AZCount, "AZCount must survive when stack needs private subnets")
+}
+
+// TestDeriveCrossComponentFields_ClearsAllNATFields covers each of the
+// three AWSVPC topology knobs in isolation.
+func TestDeriveCrossComponentFields_ClearsAllNATFields(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		build func() *Config
+	}{
+		{
+			"only_SingleNATGateway",
+			func() *Config { return cfgWithVPCSubBlock(boolPtr(true), nil, nil) },
+		},
+		{
+			"only_EnableNATGateway",
+			func() *Config { return cfgWithVPCSubBlock(nil, boolPtr(true), nil) },
+		},
+		{
+			"only_AZCount",
+			func() *Config { return cfgWithVPCSubBlock(nil, nil, intPtr(3)) },
+		},
+	}
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.build()
+			DeriveCrossComponentFields(comps, cfg)
+			assert.Nil(t, cfg.AWSVPC, "AWSVPC must be nil after all fields cleared")
+		})
+	}
+}
+
+// TestDeriveCrossComponentFields_Idempotent locks no-drift on stable inputs.
+func TestDeriveCrossComponentFields_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	cfg := cfgWithVPCSubBlock(boolPtr(true), boolPtr(true), intPtr(2))
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+
+	DeriveCrossComponentFields(comps, cfg)
+	first, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	DeriveCrossComponentFields(comps, cfg)
+	second, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second))
+}
+
+func TestDeriveCrossComponentFields_NilInputs_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() { DeriveCrossComponentFields(nil, &Config{}) })
+	assert.NotPanics(t, func() { DeriveCrossComponentFields(&Components{}, nil) })
+	assert.NotPanics(t, func() { DeriveCrossComponentFields(&Components{}, &Config{}) })
+	assert.NotPanics(t, func() { DeriveCrossComponentFields(nil, nil) })
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Composition with ApplyPresetDefaults — the production pipeline shape.
+// ──────────────────────────────────────────────────────────────────────────
+
+// TestCoherence_PipelineWithApplyPresetDefaults mirrors the wrapper sequence
+// used in luthersystems/reliable's persistence path:
+//
+//	StripOrphanConfig → DeriveCrossComponentFields → ApplyPresetDefaults →
+//	DeriveCrossComponentFields
+//
+// Inputs: stale NAT=&true from a prior turn on a now-Public-VPC stack that
+// no longer needs private subnets. Expected: NAT is off (or cleared) and
+// orphan sub-blocks for unselected components are gone.
+func TestCoherence_PipelineWithApplyPresetDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Cloud: "AWS",
+		AWSVPC: &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{
+			SingleNATGateway: boolPtr(true),
+			EnableNATGateway: boolPtr(true),
+			AZCount:          intPtr(2),
+		},
+		// Orphan opensearch sub-block from when it WAS in the stack:
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production"},
+	}
+	comps := &Components{
+		Cloud:             "AWS",
+		Architecture:      "Serverless",
+		AWSVPC:            "Public VPC",
+		AWSLambda:         boolPtr(true),
+		AWSS3:             boolPtr(true),
+		AWSKMS:            boolPtr(true),
+		AWSSecretsManager: boolPtr(true),
+		AWSCloudWatchLogs: boolPtr(true),
+	}
+	selected := []ComponentKey{
+		KeyAWSVPC, KeyAWSLambda, KeyAWSS3, KeyAWSKMS,
+		KeyAWSSecretsManager, KeyAWSCloudWatchLogs,
+	}
+
+	// Pipeline: strip → derive → ApplyPresetDefaults → derive.
+	StripOrphanConfig(comps, cfg)
+	DeriveCrossComponentFields(comps, cfg)
+	require.NoError(t, New().ApplyPresetDefaults(cfg, comps, selected))
+	DeriveCrossComponentFields(comps, cfg)
+
+	assert.Nil(t, cfg.AWSOpenSearch, "orphan opensearch must be gone")
+
+	// Either AWSVPC stays nil or its NAT fields are not true. Both are
+	// acceptable outcomes — what we cannot tolerate is NAT=&true on a stack
+	// that doesn't need private subnets.
+	if cfg.AWSVPC != nil && cfg.AWSVPC.EnableNATGateway != nil {
+		assert.False(t, *cfg.AWSVPC.EnableNATGateway,
+			"#1435: NAT must be off on a Public-VPC stack with no private-subnet-needing components")
+	}
+	if cfg.AWSVPC != nil && cfg.AWSVPC.SingleNATGateway != nil {
+		assert.False(t, *cfg.AWSVPC.SingleNATGateway,
+			"#1435: SingleNATGateway must be off on a Public-VPC stack with no private-subnet-needing components")
+	}
+}
+
+// TestCoherence_PipelineSurvivesUserSetFields locks the guardrail: the
+// pipeline must NOT clobber user-set values on SELECTED components. Mirrors
+// reliable's TestApplyPresetDefaults_Issue1435_UserSetFieldNotOverwritten.
+func TestCoherence_PipelineSurvivesUserSetFields(t *testing.T) {
+	t.Parallel()
+
+	userTimeout := "120s"
+	userMem := "2048"
+	cfg := &Config{
+		Cloud: "AWS",
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Timeout: userTimeout, MemorySize: userMem},
+	}
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+	selected := []ComponentKey{KeyAWSVPC, KeyAWSLambda}
+
+	StripOrphanConfig(comps, cfg)
+	DeriveCrossComponentFields(comps, cfg)
+	require.NoError(t, New().ApplyPresetDefaults(cfg, comps, selected))
+	DeriveCrossComponentFields(comps, cfg)
+
+	require.NotNil(t, cfg.AWSLambda)
+	assert.Equal(t, userTimeout, cfg.AWSLambda.Timeout)
+	assert.Equal(t, userMem, cfg.AWSLambda.MemorySize)
+}


### PR DESCRIPTION
## Summary

Migration of the schema-coherence union logic from `luthersystems/reliable` (the rules engine half of [luthersystems/reliable#1437](https://github.com/luthersystems/reliable/issues/1437), PR-1 of three). The same rules previously lived as in-repo copies on the reliable side, where each future caller of `pkg/composer` would have to re-derive them. They now live with the schemas they operate on.

## Public API

```go
// pkg/composer/coherence.go (new)
func ComponentSelected(c *Components, key ComponentKey) bool
func StackNeedsPrivateSubnets(c *Components) bool        // exported wrapper
func StripOrphanConfig(comps *Components, cfg *Config)
func DeriveCrossComponentFields(comps *Components, cfg *Config)
```

`StripOrphanConfig` clears every `cfg.<key>` sub-block whose component is not selected — scope determined reflectively over `Config`'s `*struct` fields with cloud-prefixed json tags, so a new component added to `types.go` + `contracts.go` is in scope automatically.

`DeriveCrossComponentFields` re-derives the three AWS VPC topology knobs (`EnableNATGateway`, `SingleNATGateway`, `AZCount`) when no selected component needs private subnets, and clears the `AWSVPC` sub-block pointer too if every field becomes `nil`. Required so the mapper's preset-defaults backfill of `NAT=true` doesn't surface on a Public-VPC stack with no private subnets.

`ComponentSelected` deliberately returns `false` for polymorphic preset keys (`KeyAWSEKSNodeGroup` / `KeyAWSEKSControlPlane`) and meta-keys (`KeyComposer` / `KeyArch` / `KeyCloud`) — selection of those is encoded by other components.

## Pinned production failure

[reliable#1435](https://github.com/luthersystems/reliable/issues/1435), session `sess_v2_CnqUJ6NRJnLC`: `EnableNATGateway=true` persisted from a prior turn that had OpenSearch + Bedrock; current turn dropped both; AWS VPC preset emitted `aws_route.private_nat_gateway` against an empty `aws_route_table.private` and apply failed with `cannot use element function with an empty list`. With `DeriveCrossComponentFields` wrapping the persistence-side call to `ApplyPresetDefaults`, the stale field gets stripped before the mapper runs.

## Test plan

- [x] 26 new pure-function regression tests in `coherence_test.go`:
  - `ComponentSelected` for string / pointer / backups-struct shapes
  - explicit `&false` ⇒ deselected ⇒ orphan-strippable
  - polymorphic preset keys intentionally NOT reported as components
  - orphan strip + cross-cloud residual + idempotency + nil-input safety
  - the full `strip → derive → ApplyPresetDefaults → derive` pipeline
  - user-set fields on selected components survive the pipeline
- [x] Pre-existing `pkg/composer/...` tests (1576 assertions) stay green
- [x] `golangci-lint run ./pkg/composer/...` adds no new findings vs `main` (uses `reflect.Pointer` so we don't inherit `defaults.go`'s pre-existing `inline: Constant reflect.Ptr` baseline)
- [x] `go vet ./pkg/composer/...` clean

## What this enables on the reliable side (PR-N follow-ups)

This is PR-1 of three on the reliable#1437 migration plan. The reliable repo will then bump the presets `go.mod`, swap its three in-repo copies (`internal/agentapi/preset_coherence.go`'s `stripOrphanConfigsComposer` / `deriveCrossComponentVPCComposer` / `componentSelectedComposer` / `stackNeedsPrivateSubnetsComposer`, plus the chatv2 union-pipeline counterparts in `internal/chatv2/stack_components.go`) for `composer.StripOrphanConfig` / `composer.DeriveCrossComponentFields` / `composer.ComponentSelected` / `composer.StackNeedsPrivateSubnets`, and delete the in-repo copies.

PR-2 (`UnionConfig` / `UnionComponents`) and PR-3 (`MergePricing` / `ApplyCarryForward` with a `Components` witness parameter) are tracked separately under reliable#1437.

## References

- luthersystems/reliable#1437 — tracking issue (this is PR-1 of 3)
- luthersystems/reliable#1435 — the in-repo fix that landed the rules in reliable
- luthersystems/reliable#1434 — companion pricing/prose mismatch
- This repo's #389 — symmetric mapper rejection (`stackNeedsPrivateSubnets` predicate)
- This repo's #393 — HCL defaults + `PristineCopy`, complementary upstream cleanup