### PR TITLE
feat(composer): union helpers — UnionConfig + UnionComponents

### DIFF
--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -1,0 +1,261 @@
+package composer
+
+// coherence.go owns the rules that make a (Components, Config) pair coherent:
+//
+//   - StripOrphanConfig clears per-component config sub-blocks whose component
+//     is no longer selected. Orphan config sub-blocks otherwise outlive the
+//     component that produced them and leak into deploy payloads (the NAT-on-
+//     Public-VPC apply failure on sess_v2_CnqUJ6NRJnLC, luthersystems/reliable#1435).
+//
+//   - DeriveCrossComponentFields recomputes config fields whose correct value
+//     is a function of which OTHER components are selected — today the AWS
+//     VPC topology knobs whose preset HCL default of NAT=true must NOT survive
+//     onto a stack that no longer needs private subnets.
+//
+// Both functions are pure. They are intended to be composed around
+// (*Client).ApplyPresetDefaults — strip + derive BEFORE the backfill catches
+// "stale-then-removed" carry-forward, and AFTER the backfill catches "fresh
+// allocation" cases where ApplyPresetDefaults just landed NAT=true onto a
+// Public-VPC-only stack.
+//
+// Tracked under luthersystems/reliable#1437.
+
+import "reflect"
+
+// ComponentSelected reports whether the given component is selected on the
+// provided Components value. Pointer-typed components require non-nil AND
+// *true (so an explicit aws_opensearch=false is treated as deselected).
+// String-typed components (AWSVPC, AWSEC2, GCPCompute) require != "".
+// Struct-pointer components (AWSBackups, GCPBackups) require != nil; the
+// backup config itself encodes the selection.
+//
+// Returns false for ComponentKeys that don't appear on Components (e.g.,
+// KeyAWSEKSNodeGroup / KeyAWSEKSControlPlane — those are polymorphic preset
+// keys driven by other component selections, not standalone components).
+func ComponentSelected(c *Components, key ComponentKey) bool {
+	if c == nil {
+		return false
+	}
+	switch key {
+	// String-typed selections.
+	case KeyAWSVPC:
+		return c.AWSVPC != ""
+	case KeyAWSEC2:
+		return c.AWSEC2 != ""
+	case KeyGCPCompute:
+		return c.GCPCompute != ""
+	// AWS pointer-typed selections.
+	case KeyAWSBastion:
+		return boolPtrTrue(c.AWSBastion)
+	case KeyAWSEKS:
+		return boolPtrTrue(c.AWSEKS)
+	case KeyAWSECS:
+		return boolPtrTrue(c.AWSECS)
+	case KeyAWSLambda:
+		return boolPtrTrue(c.AWSLambda)
+	case KeyAWSALB:
+		return boolPtrTrue(c.AWSALB)
+	case KeyAWSCloudfront:
+		return boolPtrTrue(c.AWSCloudFront)
+	case KeyAWSWAF:
+		return boolPtrTrue(c.AWSWAF)
+	case KeyAWSAPIGateway:
+		return boolPtrTrue(c.AWSAPIGateway)
+	case KeyAWSRDS:
+		return boolPtrTrue(c.AWSRDS)
+	case KeyAWSElastiCache:
+		return boolPtrTrue(c.AWSElastiCache)
+	case KeyAWSDynamoDB:
+		return boolPtrTrue(c.AWSDynamoDB)
+	case KeyAWSS3:
+		return boolPtrTrue(c.AWSS3)
+	case KeyAWSKMS:
+		return boolPtrTrue(c.AWSKMS)
+	case KeyAWSSecretsManager:
+		return boolPtrTrue(c.AWSSecretsManager)
+	case KeyAWSOpenSearch:
+		return boolPtrTrue(c.AWSOpenSearch)
+	case KeyAWSBedrock:
+		return boolPtrTrue(c.AWSBedrock)
+	case KeyAWSSQS:
+		return boolPtrTrue(c.AWSSQS)
+	case KeyAWSMSK:
+		return boolPtrTrue(c.AWSMSK)
+	case KeyAWSCloudWatchLogs:
+		return boolPtrTrue(c.AWSCloudWatchLogs)
+	case KeyAWSCloudWatchMonitoring:
+		return boolPtrTrue(c.AWSCloudWatchMonitoring)
+	case KeyAWSGrafana:
+		return boolPtrTrue(c.AWSGrafana)
+	case KeyAWSCognito:
+		return boolPtrTrue(c.AWSCognito)
+	case KeyAWSGitHubActions:
+		return boolPtrTrue(c.AWSGitHubActions)
+	case KeyAWSCodePipeline:
+		return boolPtrTrue(c.AWSCodePipeline)
+	case KeyAWSBackups:
+		return c.AWSBackups != nil
+	// GCP pointer-typed selections.
+	case KeyGCPVPC:
+		return boolPtrTrue(c.GCPVPC)
+	case KeyGCPBastion:
+		return boolPtrTrue(c.GCPBastion)
+	case KeyGCPGKE:
+		return boolPtrTrue(c.GCPGKE)
+	case KeyGCPCloudRun:
+		return boolPtrTrue(c.GCPCloudRun)
+	case KeyGCPCloudFunctions:
+		return boolPtrTrue(c.GCPCloudFunctions)
+	case KeyGCPLoadbalancer:
+		return boolPtrTrue(c.GCPLoadbalancer)
+	case KeyGCPCloudArmor:
+		return boolPtrTrue(c.GCPCloudArmor)
+	case KeyGCPAPIGateway:
+		return boolPtrTrue(c.GCPAPIGateway)
+	case KeyGCPCloudSQL:
+		return boolPtrTrue(c.GCPCloudSQL)
+	case KeyGCPMemorystore:
+		return boolPtrTrue(c.GCPMemorystore)
+	case KeyGCPFirestore:
+		return boolPtrTrue(c.GCPFirestore)
+	case KeyGCPGCS:
+		return boolPtrTrue(c.GCPGCS)
+	case KeyGCPCloudKMS:
+		return boolPtrTrue(c.GCPCloudKMS)
+	case KeyGCPSecretManager:
+		return boolPtrTrue(c.GCPSecretManager)
+	case KeyGCPVertexAI:
+		return boolPtrTrue(c.GCPVertexAI)
+	case KeyGCPPubSub:
+		return boolPtrTrue(c.GCPPubSub)
+	case KeyGCPCloudLogging:
+		return boolPtrTrue(c.GCPCloudLogging)
+	case KeyGCPCloudMonitoring:
+		return boolPtrTrue(c.GCPCloudMonitoring)
+	case KeyGCPIdentityPlatform:
+		return boolPtrTrue(c.GCPIdentityPlatform)
+	case KeyGCPCloudBuild:
+		return boolPtrTrue(c.GCPCloudBuild)
+	case KeyGCPBackups:
+		return c.GCPBackups != nil
+	// External / third-party.
+	case KeySplunk:
+		return boolPtrTrue(c.Splunk)
+	case KeyDatadog:
+		return boolPtrTrue(c.Datadog)
+	}
+	return false
+}
+
+// StackNeedsPrivateSubnets reports whether the stack includes any AWS
+// component that requires private subnets — and therefore NAT egress. The
+// mapper enforces the same predicate to coerce NAT off on Public-VPC stacks
+// (see KeyAWSVPC branch in BuildModuleValues). Exporting it lets persistence-
+// layer callers (luthersystems/reliable) make the same decision upstream of
+// the mapper so cfg.AWSVPC.EnableNATGateway never gets persisted as &true
+// on a stack that doesn't need NAT.
+func StackNeedsPrivateSubnets(c *Components) bool {
+	return stackNeedsPrivateSubnets(c)
+}
+
+// StripOrphanConfig clears every cfg.<component> sub-block whose
+// corresponding component is NOT selected in `comps`. Pure, idempotent. A
+// no-op when cfg is nil or comps is nil (an unknown components state cannot
+// safely conclude orphanhood).
+//
+// Treats "non-nil but empty" sub-structs as orphan when their component is
+// unselected — an empty &AWSOpenSearch{} conveys no actual configuration and
+// must not survive when opensearch is dropped.
+//
+// The set of stripped fields is determined reflectively: any *struct sub-
+// field on Config whose json tag matches a known ComponentKey is in scope.
+// Adding a new component to Components + Config + KeyXxx requires no edit
+// here.
+func StripOrphanConfig(comps *Components, cfg *Config) {
+	if comps == nil || cfg == nil {
+		return
+	}
+	cfgVal := reflect.ValueOf(cfg).Elem()
+	cfgType := cfgVal.Type()
+	for i := 0; i < cfgType.NumField(); i++ {
+		ft := cfgType.Field(i)
+		if ft.Type.Kind() != reflect.Pointer || ft.Type.Elem().Kind() != reflect.Struct {
+			continue
+		}
+		tag := jsonTagName(ft.Tag.Get("json"))
+		if tag == "" {
+			continue
+		}
+		key := ComponentKey(tag)
+		if !isOrphanStrippableKey(key) {
+			continue
+		}
+		if !ComponentSelected(comps, key) {
+			fv := cfgVal.Field(i)
+			if fv.CanSet() && !fv.IsNil() {
+				fv.Set(reflect.Zero(fv.Type()))
+			}
+		}
+	}
+}
+
+// DeriveCrossComponentFields re-derives cfg fields whose correct value is a
+// function of which OTHER components are selected. Today covers the AWS VPC
+// topology knobs:
+//
+//   - cfg.AWSVPC.EnableNATGateway
+//   - cfg.AWSVPC.SingleNATGateway
+//   - cfg.AWSVPC.AZCount
+//
+// When no selected component needs private subnets, the three fields are
+// cleared. If every field of the AWSVPC sub-block ends up nil, the
+// sub-block pointer itself is cleared so json:",omitempty" hides it.
+//
+// Why both this AND StripOrphanConfig: AWSVPC is selected (the user keeps a
+// Public VPC) even when no DOWNSTREAM component needs private subnets. The
+// orphan strip cannot help — the VPC component itself is in scope. Cross-
+// component derive is the rule that catches "VPC stays, but its NAT-related
+// sub-fields no longer have a justification."
+//
+// Pure, idempotent.
+func DeriveCrossComponentFields(comps *Components, cfg *Config) {
+	if comps == nil || cfg == nil || cfg.AWSVPC == nil {
+		return
+	}
+	if !stackNeedsPrivateSubnets(comps) {
+		cfg.AWSVPC.EnableNATGateway = nil
+		cfg.AWSVPC.SingleNATGateway = nil
+		cfg.AWSVPC.AZCount = nil
+		if cfg.AWSVPC.EnableNATGateway == nil &&
+			cfg.AWSVPC.SingleNATGateway == nil &&
+			cfg.AWSVPC.AZCount == nil {
+			cfg.AWSVPC = nil
+		}
+	}
+}
+
+// isOrphanStrippableKey reports whether the given ComponentKey has a per-
+// component sub-block on Config that participates in the orphan strip. The
+// list mirrors the *struct sub-fields of Config with cloud-prefixed json
+// tags. Polymorphic preset keys (KeyAWSEKSNodeGroup / KeyAWSEKSControlPlane)
+// and pure non-config components (KeyAWSALB / KeyAWSGrafana / KeyAWSWAF /
+// KeySplunk / KeyDatadog / KeyGitHubActions etc.) are NOT in scope — there
+// is no cfg.<key> sub-block to strip.
+func isOrphanStrippableKey(key ComponentKey) bool {
+	switch key {
+	case KeyAWSEC2, KeyAWSEKS, KeyAWSECS, KeyAWSVPC,
+		KeyAWSCloudfront, KeyAWSRDS, KeyAWSElastiCache,
+		KeyAWSS3, KeyAWSDynamoDB, KeyAWSSQS, KeyAWSMSK,
+		KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
+		KeyAWSCognito, KeyAWSLambda, KeyAWSAPIGateway,
+		KeyAWSKMS, KeyAWSSecretsManager, KeyAWSOpenSearch,
+		KeyAWSBedrock, KeyAWSBackups,
+		KeyGCPCompute, KeyGCPGKE, KeyGCPCloudRun,
+		KeyGCPCloudFunctions, KeyGCPLoadbalancer,
+		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,
+		KeyGCPPubSub, KeyGCPCloudLogging,
+		KeyGCPIdentityPlatform, KeyGCPAPIGateway, KeyGCPBackups:
+		return true
+	}
+	return false
+}

--- a/pkg/composer/coherence_test.go
+++ b/pkg/composer/coherence_test.go
@@ -1,0 +1,623 @@
+package composer
+
+// coherence_test.go locks the (Components, Config) coherence rules upstream.
+// Ports the pure-function regression suite that originated in
+// luthersystems/reliable's chatv2 + agentapi packages (#1435) so the same
+// invariant cannot regress on either side.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func intPtr(i int) *int { return &i }
+
+// awsVPCSubFields mirrors the anonymous struct shape on Config.AWSVPC.
+// Mirrors the literal used in mapper_test.go's cfgWithAWSVPC helper.
+func cfgWithVPCSubBlock(single, enable *bool, az *int) *Config {
+	c := &Config{}
+	c.AWSVPC = &struct {
+		SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+		EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+		AZCount          *int  `json:"azCount,omitempty"`
+	}{SingleNATGateway: single, EnableNATGateway: enable, AZCount: az}
+	return c
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// ComponentSelected
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestComponentSelected_StringFields(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, ComponentSelected(&Components{}, KeyAWSVPC))
+	assert.True(t, ComponentSelected(&Components{AWSVPC: "Public VPC"}, KeyAWSVPC))
+
+	assert.False(t, ComponentSelected(&Components{}, KeyAWSEC2))
+	assert.True(t, ComponentSelected(&Components{AWSEC2: "Intel"}, KeyAWSEC2))
+
+	assert.False(t, ComponentSelected(&Components{}, KeyGCPCompute))
+	assert.True(t, ComponentSelected(&Components{GCPCompute: "n2-standard-2"}, KeyGCPCompute))
+}
+
+func TestComponentSelected_PointerFields_RequireTrue(t *testing.T) {
+	t.Parallel()
+
+	// nil pointer → not selected.
+	assert.False(t, ComponentSelected(&Components{}, KeyAWSOpenSearch))
+
+	// explicit &false → not selected (so cfg.AWSOpenSearch is stripped).
+	assert.False(t, ComponentSelected(&Components{AWSOpenSearch: boolPtr(false)}, KeyAWSOpenSearch),
+		"explicit &false must be treated as deselected so its config sub-block is stripped")
+
+	// &true → selected.
+	assert.True(t, ComponentSelected(&Components{AWSOpenSearch: boolPtr(true)}, KeyAWSOpenSearch))
+}
+
+func TestComponentSelected_BackupsPointer_NonNilEqualsSelected(t *testing.T) {
+	t.Parallel()
+
+	// AWSBackups is a *struct{...}; its presence alone signals selection.
+	c := &Components{}
+	assert.False(t, ComponentSelected(c, KeyAWSBackups))
+
+	c.AWSBackups = &struct {
+		EC2         *bool `json:"aws_ec2,omitempty"`
+		RDS         *bool `json:"aws_rds,omitempty"`
+		ElastiCache *bool `json:"aws_elasticache,omitempty"`
+		DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+		S3          *bool `json:"aws_s3,omitempty"`
+	}{}
+	assert.True(t, ComponentSelected(c, KeyAWSBackups))
+}
+
+func TestComponentSelected_NilComponents_AlwaysFalse(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range []ComponentKey{
+		KeyAWSVPC, KeyAWSEC2, KeyAWSOpenSearch, KeyGCPCompute, KeyGCPBackups,
+	} {
+		assert.False(t, ComponentSelected(nil, key), "nil components must report not-selected for %s", key)
+	}
+}
+
+func TestComponentSelected_PolymorphicAndNonConfigKeys_AlwaysFalse(t *testing.T) {
+	t.Parallel()
+
+	// Polymorphic preset keys (KeyAWSEKSNodeGroup / KeyAWSEKSControlPlane)
+	// don't map to a Components field — selection is encoded by AWSEKS +
+	// AWSLambda. ComponentSelected must NOT report them as a standalone
+	// selection (downstream code would treat them as orphan-strippable and
+	// misbehave).
+	c := &Components{AWSEKS: boolPtr(true), AWSLambda: boolPtr(true)}
+	assert.False(t, ComponentSelected(c, KeyAWSEKSNodeGroup))
+	assert.False(t, ComponentSelected(c, KeyAWSEKSControlPlane))
+
+	// KeyComposer / KeyArch / KeyCloud are meta-keys, not components.
+	assert.False(t, ComponentSelected(c, KeyComposer))
+	assert.False(t, ComponentSelected(c, KeyArch))
+	assert.False(t, ComponentSelected(c, KeyCloud))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// StackNeedsPrivateSubnets — exported wrapper around the mapper helper.
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestStackNeedsPrivateSubnets_Exported(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, StackNeedsPrivateSubnets(nil))
+	assert.False(t, StackNeedsPrivateSubnets(&Components{}))
+
+	for _, c := range []*Components{
+		{AWSEKS: boolPtr(true)},
+		{AWSECS: boolPtr(true)},
+		{AWSRDS: boolPtr(true)},
+		{AWSElastiCache: boolPtr(true)},
+		{AWSOpenSearch: boolPtr(true)},
+		{AWSEC2: "Intel"},
+		{AWSEC2: "ARM"},
+	} {
+		assert.True(t, StackNeedsPrivateSubnets(c), "%+v should need private subnets", c)
+	}
+
+	// Components that DON'T need private subnets:
+	assert.False(t, StackNeedsPrivateSubnets(&Components{AWSLambda: boolPtr(true)}))
+	assert.False(t, StackNeedsPrivateSubnets(&Components{AWSS3: boolPtr(true), AWSKMS: boolPtr(true)}))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// StripOrphanConfig
+// ──────────────────────────────────────────────────────────────────────────
+
+// TestStripOrphanConfig_ClearsUnselectedSubBlocks ports the failure shape
+// from sess_v2_CnqUJ6NRJnLC: a config.aws_opensearch sub-block survives
+// after aws_opensearch is removed from components. Strip must clear it.
+func TestStripOrphanConfig_ClearsUnselectedSubBlocks(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Cloud: "AWS",
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production", InstanceType: "m6g.large"},
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Runtime: "nodejs20.x", Timeout: "30s"},
+	}
+	comps := &Components{
+		Cloud:     "AWS",
+		AWSVPC:    "Public VPC",
+		AWSLambda: boolPtr(true),
+		// AWSOpenSearch intentionally omitted.
+	}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSOpenSearch, "orphan opensearch sub-block must be cleared")
+	assert.NotNil(t, cfg.AWSLambda, "selected Lambda sub-block must survive")
+	assert.Equal(t, "nodejs20.x", cfg.AWSLambda.Runtime, "user values on selected components must survive")
+}
+
+// TestStripOrphanConfig_EmptyAllocatedSubBlockIsOrphan locks the "non-nil-
+// but-empty" rule: an &AWSOpenSearch{} sub-block (no actual configuration)
+// must NOT be a signal that opensearch is selected. The Components blob is
+// the canonical selection witness.
+func TestStripOrphanConfig_EmptyAllocatedSubBlockIsOrphan(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{}, // allocated but empty
+	}
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC"}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSOpenSearch,
+		"an allocated-but-empty sub-block must be treated as orphan when its component is unselected")
+}
+
+// TestStripOrphanConfig_ExplicitFalsePointerStripsConfig captures the
+// "explicit aws_opensearch=false" case: the user (or a downstream rule)
+// signalled deselection by writing &false to the components blob. The
+// config sub-block must be cleared.
+func TestStripOrphanConfig_ExplicitFalsePointerStripsConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production"},
+	}
+	comps := &Components{
+		Cloud:         "AWS",
+		AWSVPC:        "Public VPC",
+		AWSOpenSearch: boolPtr(false), // explicit deselection
+	}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSOpenSearch,
+		"AWSOpenSearch=&false must trigger strip — explicit deselection is still deselection")
+}
+
+// TestStripOrphanConfig_LeavesNonStrippableUntouched checks that fields
+// outside the orphan-strippable set (Region, Cloud, EstimatedMonthlyRequests)
+// survive the strip even when other components are missing.
+func TestStripOrphanConfig_LeavesNonStrippableUntouched(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Cloud:                    "AWS",
+		Region:                   "us-east-2",
+		EstimatedMonthlyRequests: 100_000,
+		EstimatedAvgDurationMs:   250,
+	}
+	comps := &Components{Cloud: "AWS"} // nothing selected
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Equal(t, "AWS", cfg.Cloud)
+	assert.Equal(t, "us-east-2", cfg.Region)
+	assert.Equal(t, int64(100_000), cfg.EstimatedMonthlyRequests)
+	assert.Equal(t, 250, cfg.EstimatedAvgDurationMs)
+}
+
+// TestStripOrphanConfig_AWSBackupsRespectsSelection ports the
+// Components.AWSBackups != nil convention: when AWSBackups is selected, the
+// cfg.AWSBackups sub-block must survive even if some inner backup configs
+// are zero.
+func TestStripOrphanConfig_AWSBackupsRespectsSelection(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSBackups: &struct {
+			EC2 *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_ec2,omitempty"`
+			RDS *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_rds,omitempty"`
+			ElastiCache *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_elasticache,omitempty"`
+			DynamoDB *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_dynamodb,omitempty"`
+			S3 *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_s3,omitempty"`
+		}{},
+	}
+	comps := &Components{
+		Cloud: "AWS",
+		AWSBackups: &struct {
+			EC2         *bool `json:"aws_ec2,omitempty"`
+			RDS         *bool `json:"aws_rds,omitempty"`
+			ElastiCache *bool `json:"aws_elasticache,omitempty"`
+			DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+			S3          *bool `json:"aws_s3,omitempty"`
+		}{S3: boolPtr(true)},
+	}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.NotNil(t, cfg.AWSBackups, "cfg.AWSBackups must survive when comps.AWSBackups is non-nil")
+}
+
+// TestStripOrphanConfig_AWSBackupsCleared captures the orphan path: comps
+// has no AWSBackups, so cfg.AWSBackups is stripped.
+func TestStripOrphanConfig_AWSBackupsCleared(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSBackups: &struct {
+			EC2 *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_ec2,omitempty"`
+			RDS *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_rds,omitempty"`
+			ElastiCache *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_elasticache,omitempty"`
+			DynamoDB *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_dynamodb,omitempty"`
+			S3 *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_s3,omitempty"`
+		}{},
+	}
+	comps := &Components{Cloud: "AWS"} // no AWSBackups
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSBackups, "orphan AWSBackups sub-block must be cleared when comps.AWSBackups is nil")
+}
+
+// TestStripOrphanConfig_CrossCloudResidual locks the rule that a switch to
+// the opposite cloud strips the previous cloud's sub-blocks. Mirrors the
+// reliable-side TestUnion_Issue1435_OrphanConfig_CrossCloudResidual.
+func TestStripOrphanConfig_CrossCloudResidual(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Cloud: "GCP",
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Runtime: "nodejs20.x"},
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{},
+		GCPCloudRun: &struct {
+			Memory       string `json:"memory,omitempty"`
+			CPU          string `json:"cpu,omitempty"`
+			MinInstances *int   `json:"minInstances,omitempty"`
+			MaxInstances *int   `json:"maxInstances,omitempty"`
+		}{Memory: "512Mi"},
+	}
+	comps := &Components{
+		Cloud:       "GCP",
+		GCPVPC:      boolPtr(true),
+		GCPCloudRun: boolPtr(true),
+	}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSLambda, "AWS Lambda sub-block must be stripped on a GCP stack")
+	assert.Nil(t, cfg.AWSOpenSearch, "AWS OpenSearch sub-block must be stripped on a GCP stack")
+	assert.NotNil(t, cfg.GCPCloudRun, "GCP Cloud Run sub-block must survive when selected")
+	assert.Equal(t, "512Mi", cfg.GCPCloudRun.Memory)
+}
+
+// TestStripOrphanConfig_Idempotent guards against a future "smart" rewrite
+// that drifts on repeat calls.
+func TestStripOrphanConfig_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production"},
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Runtime: "nodejs20.x"},
+	}
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+
+	StripOrphanConfig(comps, cfg)
+	first, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	StripOrphanConfig(comps, cfg)
+	second, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second))
+}
+
+func TestStripOrphanConfig_NilInputs_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() { StripOrphanConfig(nil, &Config{}) })
+	assert.NotPanics(t, func() { StripOrphanConfig(&Components{}, nil) })
+	assert.NotPanics(t, func() { StripOrphanConfig(nil, nil) })
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// DeriveCrossComponentFields
+// ──────────────────────────────────────────────────────────────────────────
+
+// TestDeriveCrossComponentFields_NoPrivateSubnets_ClearsNAT pins the actual
+// production failure mode from sess_v2_CnqUJ6NRJnLC: a leftover
+// EnableNATGateway=&true on a Public-VPC stack with no NAT-needing
+// components must be cleared. If every AWSVPC field is cleared, the
+// sub-block pointer itself is cleared so json:",omitempty" hides it.
+func TestDeriveCrossComponentFields_NoPrivateSubnets_ClearsNAT(t *testing.T) {
+	t.Parallel()
+
+	cfg := cfgWithVPCSubBlock(boolPtr(true), boolPtr(true), intPtr(2))
+	comps := &Components{
+		Cloud:     "AWS",
+		AWSVPC:    "Public VPC",
+		AWSLambda: boolPtr(true),
+		AWSS3:     boolPtr(true),
+		// No EKS/ECS/RDS/ElastiCache/OpenSearch/EC2.
+	}
+
+	DeriveCrossComponentFields(comps, cfg)
+
+	assert.Nil(t, cfg.AWSVPC,
+		"NAT-related fields all cleared → AWSVPC sub-block pointer cleared too")
+}
+
+// TestDeriveCrossComponentFields_NeedsPrivateSubnets_Preserves locks the
+// non-clobber rule: when the stack DOES need private subnets, the user's
+// AWSVPC settings must survive untouched.
+func TestDeriveCrossComponentFields_NeedsPrivateSubnets_Preserves(t *testing.T) {
+	t.Parallel()
+
+	cfg := cfgWithVPCSubBlock(boolPtr(false), boolPtr(true), intPtr(3))
+	comps := &Components{
+		Cloud:     "AWS",
+		AWSVPC:    "Private VPC",
+		AWSEKS:    boolPtr(true),
+		AWSLambda: boolPtr(true),
+	}
+
+	DeriveCrossComponentFields(comps, cfg)
+
+	require.NotNil(t, cfg.AWSVPC)
+	require.NotNil(t, cfg.AWSVPC.EnableNATGateway)
+	assert.True(t, *cfg.AWSVPC.EnableNATGateway, "NAT must survive when EKS is selected")
+	require.NotNil(t, cfg.AWSVPC.AZCount)
+	assert.Equal(t, 3, *cfg.AWSVPC.AZCount, "AZCount must survive when stack needs private subnets")
+}
+
+// TestDeriveCrossComponentFields_ClearsAllNATFields covers each of the
+// three AWSVPC topology knobs in isolation.
+func TestDeriveCrossComponentFields_ClearsAllNATFields(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		build func() *Config
+	}{
+		{
+			"only_SingleNATGateway",
+			func() *Config { return cfgWithVPCSubBlock(boolPtr(true), nil, nil) },
+		},
+		{
+			"only_EnableNATGateway",
+			func() *Config { return cfgWithVPCSubBlock(nil, boolPtr(true), nil) },
+		},
+		{
+			"only_AZCount",
+			func() *Config { return cfgWithVPCSubBlock(nil, nil, intPtr(3)) },
+		},
+	}
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.build()
+			DeriveCrossComponentFields(comps, cfg)
+			assert.Nil(t, cfg.AWSVPC, "AWSVPC must be nil after all fields cleared")
+		})
+	}
+}
+
+// TestDeriveCrossComponentFields_Idempotent locks no-drift on stable inputs.
+func TestDeriveCrossComponentFields_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	cfg := cfgWithVPCSubBlock(boolPtr(true), boolPtr(true), intPtr(2))
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+
+	DeriveCrossComponentFields(comps, cfg)
+	first, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	DeriveCrossComponentFields(comps, cfg)
+	second, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second))
+}
+
+func TestDeriveCrossComponentFields_NilInputs_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() { DeriveCrossComponentFields(nil, &Config{}) })
+	assert.NotPanics(t, func() { DeriveCrossComponentFields(&Components{}, nil) })
+	assert.NotPanics(t, func() { DeriveCrossComponentFields(&Components{}, &Config{}) })
+	assert.NotPanics(t, func() { DeriveCrossComponentFields(nil, nil) })
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Composition with ApplyPresetDefaults — the production pipeline shape.
+// ──────────────────────────────────────────────────────────────────────────
+
+// TestCoherence_PipelineWithApplyPresetDefaults mirrors the wrapper sequence
+// used in luthersystems/reliable's persistence path:
+//
+//	StripOrphanConfig → DeriveCrossComponentFields → ApplyPresetDefaults →
+//	DeriveCrossComponentFields
+//
+// Inputs: stale NAT=&true from a prior turn on a now-Public-VPC stack that
+// no longer needs private subnets. Expected: NAT is off (or cleared) and
+// orphan sub-blocks for unselected components are gone.
+func TestCoherence_PipelineWithApplyPresetDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Cloud: "AWS",
+		AWSVPC: &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{
+			SingleNATGateway: boolPtr(true),
+			EnableNATGateway: boolPtr(true),
+			AZCount:          intPtr(2),
+		},
+		// Orphan opensearch sub-block from when it WAS in the stack:
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production"},
+	}
+	comps := &Components{
+		Cloud:             "AWS",
+		Architecture:      "Serverless",
+		AWSVPC:            "Public VPC",
+		AWSLambda:         boolPtr(true),
+		AWSS3:             boolPtr(true),
+		AWSKMS:            boolPtr(true),
+		AWSSecretsManager: boolPtr(true),
+		AWSCloudWatchLogs: boolPtr(true),
+	}
+	selected := []ComponentKey{
+		KeyAWSVPC, KeyAWSLambda, KeyAWSS3, KeyAWSKMS,
+		KeyAWSSecretsManager, KeyAWSCloudWatchLogs,
+	}
+
+	// Pipeline: strip → derive → ApplyPresetDefaults → derive.
+	StripOrphanConfig(comps, cfg)
+	DeriveCrossComponentFields(comps, cfg)
+	require.NoError(t, New().ApplyPresetDefaults(cfg, comps, selected))
+	DeriveCrossComponentFields(comps, cfg)
+
+	assert.Nil(t, cfg.AWSOpenSearch, "orphan opensearch must be gone")
+
+	// Either AWSVPC stays nil or its NAT fields are not true. Both are
+	// acceptable outcomes — what we cannot tolerate is NAT=&true on a stack
+	// that doesn't need private subnets.
+	if cfg.AWSVPC != nil && cfg.AWSVPC.EnableNATGateway != nil {
+		assert.False(t, *cfg.AWSVPC.EnableNATGateway,
+			"#1435: NAT must be off on a Public-VPC stack with no private-subnet-needing components")
+	}
+	if cfg.AWSVPC != nil && cfg.AWSVPC.SingleNATGateway != nil {
+		assert.False(t, *cfg.AWSVPC.SingleNATGateway,
+			"#1435: SingleNATGateway must be off on a Public-VPC stack with no private-subnet-needing components")
+	}
+}
+
+// TestCoherence_PipelineSurvivesUserSetFields locks the guardrail: the
+// pipeline must NOT clobber user-set values on SELECTED components. Mirrors
+// reliable's TestApplyPresetDefaults_Issue1435_UserSetFieldNotOverwritten.
+func TestCoherence_PipelineSurvivesUserSetFields(t *testing.T) {
+	t.Parallel()
+
+	userTimeout := "120s"
+	userMem := "2048"
+	cfg := &Config{
+		Cloud: "AWS",
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Timeout: userTimeout, MemorySize: userMem},
+	}
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+	selected := []ComponentKey{KeyAWSVPC, KeyAWSLambda}
+
+	StripOrphanConfig(comps, cfg)
+	DeriveCrossComponentFields(comps, cfg)
+	require.NoError(t, New().ApplyPresetDefaults(cfg, comps, selected))
+	DeriveCrossComponentFields(comps, cfg)
+
+	require.NotNil(t, cfg.AWSLambda)
+	assert.Equal(t, userTimeout, cfg.AWSLambda.Timeout)
+	assert.Equal(t, userMem, cfg.AWSLambda.MemorySize)
+}

--- a/pkg/composer/union.go
+++ b/pkg/composer/union.go
@@ -1,0 +1,137 @@
+package composer
+
+// union.go owns the partial-record fold for Components and Config: turning an
+// ordered slice of partial values (each from one persistence record / one
+// session-state snapshot / one user edit) into a single coherent value with
+// last-non-zero-wins semantics.
+//
+// Migrated upstream from luthersystems/reliable's chatv2 package (the
+// mergeComponents + mergeConfig hand-rolled families in
+// internal/chatv2/stack_components.go) per luthersystems/reliable#1437 PR-2,
+// so both reliable and any other composer consumer share one merge
+// implementation. Pairs with coherence.go (PR-1, #429) — the typical pipeline
+// is: parts → UnionConfig / UnionComponents → StripOrphanConfig →
+// DeriveCrossComponentFields.
+//
+// Contract — see UnionConfig / UnionComponents godoc for the full rule set.
+// Highlights:
+//   - Last-non-zero per leaf field wins (later parts override earlier non-zero
+//     values; a part that is zero at a given leaf contributes nothing there).
+//   - Pointer-to-false is non-zero (the *pointer* is non-nil, not the
+//     dereferenced value); an explicit "disable" must overwrite an earlier
+//     "enable". This is the #1043 deselection canary.
+//   - Recurses into *struct sub-fields with the same rule; sub-field-level
+//     overlay applies at every depth.
+//   - When the destination's inner *struct is nil, a FRESH inner struct is
+//     allocated on the destination — never shared with the source — matching
+//     MergeConfigs's existing semantics in defaults.go.
+//   - No Normalize calls inside Union. Callers pre-normalise via their own
+//     adapter (composeradapter.NormalizeConfig on the reliable side) before
+//     handing parts to Union; Union is just the merge.
+
+import "reflect"
+
+// UnionComponents folds an ordered slice of partial Components values into a
+// single coherent result. Last-non-zero per leaf field wins (later parts
+// override earlier ones where they have a non-zero value). Pure function. A
+// nil or empty input returns a zero Components.
+//
+// Semantics (uniform at every depth, per reflect.Value.IsZero):
+//   - Scalar fields (string, int, bool): non-zero src overrides dst.
+//   - Pointer fields (*bool, *int, *string, *struct): non-nil src overrides
+//     dst. Pointer-to-false is non-nil and therefore overrides — required to
+//     lock explicit-deselect (#1043).
+//   - Slice / map fields: non-nil src overrides dst. (A non-nil empty slice
+//     counts as non-zero; callers that want "empty means defer" must omit the
+//     field — set the pointer / slice to nil — rather than allocate an empty
+//     value.)
+//   - *struct sub-fields (AWSBackups, GCPBackups): recurse into the inner
+//     struct. If dst's inner pointer is nil and src's is non-nil, a FRESH
+//     inner struct is allocated on dst; src's pointer is never shared at the
+//     *struct level. Scalar-pointer fields INSIDE the struct are still
+//     shallow-copied (dst and result share the *bool / *int pointers with the
+//     latest part that set them).
+//
+// Callers must not mutate part values after calling UnionComponents.
+func UnionComponents(parts []Components) Components {
+	var result Components
+	if len(parts) == 0 {
+		return result
+	}
+	dst := reflect.ValueOf(&result).Elem()
+	for i := range parts {
+		// Range by index so we take addresses of the underlying slice
+		// elements (cheaper than copying each Components into a loop var,
+		// and matches the "last part wins" intent — we read each part's
+		// fields directly).
+		overlayNonZero(dst, reflect.ValueOf(&parts[i]).Elem())
+	}
+	return result
+}
+
+// UnionConfig folds an ordered slice of partial Config values into a single
+// coherent result. Last-non-zero per leaf field wins. Pure function. A nil or
+// empty input returns a zero Config.
+//
+// Semantics are identical to UnionComponents — same pointer-non-nil rule,
+// same *struct-sub-field recursion, same fresh-inner-struct allocation. See
+// UnionComponents for the full contract.
+func UnionConfig(parts []Config) Config {
+	var result Config
+	if len(parts) == 0 {
+		return result
+	}
+	dst := reflect.ValueOf(&result).Elem()
+	for i := range parts {
+		overlayNonZero(dst, reflect.ValueOf(&parts[i]).Elem())
+	}
+	return result
+}
+
+// overlayNonZero copies non-zero values from src into dst (both must be struct
+// values of the same type), recursing into nested *struct fields with the same
+// allocate-on-demand semantics used by MergeConfigs.
+//
+// This is the "src wins" sibling of overlayZero in defaults.go. Where
+// overlayZero fills only dst's zero-valued leaves (dst wins), overlayNonZero
+// overwrites dst's leaves whenever src has a non-zero value at the same leaf
+// (src wins). The recursion shape is otherwise identical:
+//
+//   - Nested *struct: recurse; allocate a FRESH inner struct on dst when dst's
+//     pointer is nil and src's is non-nil. dst never shares src's struct
+//     pointer — so a post-call mutation of dst's inner struct cannot leak back
+//     into src.
+//   - Leaf scalar / slice / map / scalar-pointer: if src is non-zero, copy via
+//     reflect.Value.Set (which is a shallow copy for pointers and slice
+//     headers — callers must not mutate parts post-call).
+func overlayNonZero(dst, src reflect.Value) {
+	for i := 0; i < dst.NumField(); i++ {
+		df, sf := dst.Field(i), src.Field(i)
+		if !df.CanSet() {
+			continue
+		}
+		// Recurse into nested *struct (e.g. AWSBackups, AWSVPC) so a later
+		// part setting only AWSVPC.AZCount doesn't clobber an earlier part's
+		// AWSVPC.EnableNATGateway.
+		if df.Kind() == reflect.Pointer && df.Type().Elem().Kind() == reflect.Struct {
+			if sf.IsNil() {
+				continue
+			}
+			if df.IsNil() {
+				// Allocate a FRESH inner struct on dst; do NOT share src's
+				// pointer. Matches MergeConfigs's "dst gets a FRESH pointer"
+				// rule in defaults.go.
+				df.Set(reflect.New(df.Type().Elem()))
+			}
+			overlayNonZero(df.Elem(), sf.Elem())
+			continue
+		}
+		// Leaf branch: src wins iff src is non-zero. Pointer-to-false is
+		// non-nil and therefore IsZero()==false, so explicit-deselect (e.g.
+		// AWSOpenSearch: &false) correctly overrides an earlier &true.
+		if sf.IsZero() {
+			continue
+		}
+		df.Set(sf)
+	}
+}

--- a/pkg/composer/union_test.go
+++ b/pkg/composer/union_test.go
@@ -1,0 +1,441 @@
+package composer
+
+// union_test.go locks the fold-of-partial-records contract that the
+// UnionConfig + UnionComponents helpers carry. Mirrors the regression suite
+// the same rules were under on the reliable side (chatv2/stack_components.go's
+// mergeConfig / mergeComponents families) so the upstream-migration in
+// luthersystems/reliable#1437 PR-2 cannot regress on either side.
+//
+// Key invariants under test:
+//
+//   - Last-non-zero per leaf wins (later parts in the slice override earlier
+//     parts where the later part has a non-zero value at that leaf).
+//   - Pointer-to-false is non-zero — explicit-deselect must overwrite an
+//     earlier explicit-select. This is the #1043 deselection canary.
+//   - Sub-struct recursion: a later part that touches only AWSVPC.AZCount
+//     must not clobber an earlier part's AWSVPC.EnableNATGateway.
+//   - Allocate-on-demand: when dst's inner *struct is nil and src's isn't,
+//     dst gets a FRESH inner struct — not src's pointer — so callers can't
+//     accidentally mutate part values via the result.
+//   - Union performs MERGE ONLY. Normalization (cross-cloud stripping, etc.)
+//     is a separate concern handled by Components.Normalize / Config.Normalize
+//     or by the caller's adapter — Union must not auto-strip.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ──────────────────────────────────────────────────────────────────────────
+// UnionConfig
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestUnionConfig_LastNonZeroWins(t *testing.T) {
+	t.Parallel()
+
+	parts := []Config{
+		{Cloud: "AWS", Region: "us-east-1"},
+		{Cloud: "GCP"},
+	}
+	got := UnionConfig(parts)
+
+	assert.Equal(t, "GCP", got.Cloud, "later non-zero Cloud must override earlier")
+	assert.Equal(t, "us-east-1", got.Region, "earlier Region must survive when later part is zero at that leaf")
+}
+
+func TestUnionConfig_EmptyPartsIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	parts := []Config{
+		{Cloud: "AWS", Region: "us-east-1"},
+		{}, // entirely zero — contributes nothing
+		{},
+	}
+	got := UnionConfig(parts)
+
+	assert.Equal(t, "AWS", got.Cloud)
+	assert.Equal(t, "us-east-1", got.Region)
+}
+
+func TestUnionConfig_PointerToFalsePreserved(t *testing.T) {
+	t.Parallel()
+
+	// Part 1 enables NAT; part 2 explicitly disables it. Result must be
+	// the explicit-false pointer — the canary that we lock on
+	// pointer-non-nil (not dereferenced value) for the IsZero predicate.
+	parts := []Config{
+		*cfgWithVPCSubBlock(nil, boolPtr(true), nil),
+		*cfgWithVPCSubBlock(nil, boolPtr(false), nil),
+	}
+	got := UnionConfig(parts)
+
+	require.NotNil(t, got.AWSVPC)
+	require.NotNil(t, got.AWSVPC.EnableNATGateway,
+		"explicit *bool(&false) must override an earlier *bool(&true)")
+	assert.False(t, *got.AWSVPC.EnableNATGateway,
+		"final dereferenced value must be the later part's false")
+}
+
+func TestUnionConfig_SubStructRecursion(t *testing.T) {
+	t.Parallel()
+
+	// Part 1 sets only EnableNATGateway. Part 2 sets only AZCount. Result
+	// must have BOTH populated in a single AWSVPC sub-block — proves the
+	// recursion descends into the inner struct rather than wholesale
+	// replacing the *struct pointer.
+	parts := []Config{
+		*cfgWithVPCSubBlock(nil, boolPtr(true), nil),
+		*cfgWithVPCSubBlock(nil, nil, intPtr(3)),
+	}
+	got := UnionConfig(parts)
+
+	require.NotNil(t, got.AWSVPC)
+	require.NotNil(t, got.AWSVPC.EnableNATGateway, "earlier sub-field must survive")
+	assert.True(t, *got.AWSVPC.EnableNATGateway)
+	require.NotNil(t, got.AWSVPC.AZCount, "later sub-field must land")
+	assert.Equal(t, 3, *got.AWSVPC.AZCount)
+}
+
+func TestUnionConfig_AllocatesFreshInnerStruct(t *testing.T) {
+	t.Parallel()
+
+	// Build a single-part fold. Mutate the result's inner *struct after
+	// the call; the part's inner *struct must NOT be affected — proves dst
+	// got a fresh inner struct rather than shared src's pointer.
+	part := *cfgWithVPCSubBlock(nil, boolPtr(true), intPtr(2))
+	require.NotNil(t, part.AWSVPC)
+	originalAZCount := *part.AWSVPC.AZCount
+
+	got := UnionConfig([]Config{part})
+	require.NotNil(t, got.AWSVPC)
+
+	// Pointer identity check at the *struct level — must differ.
+	assert.NotSame(t, part.AWSVPC, got.AWSVPC,
+		"result's inner *struct must be a fresh allocation, not the part's pointer")
+
+	// Mutate the result's inner struct via a new scalar pointer field; the
+	// part's AZCount pointer must be unchanged.
+	got.AWSVPC.AZCount = intPtr(99)
+	assert.Equal(t, originalAZCount, *part.AWSVPC.AZCount,
+		"mutating result.AWSVPC.AZCount must not affect the part's AZCount")
+}
+
+func TestUnionConfig_NilSlice_NoOverride(t *testing.T) {
+	t.Parallel()
+
+	// Part 1 populates AWSEC2.CustomIngressPorts; part 2 leaves it nil.
+	// Result must keep the populated slice — nil src is zero and therefore
+	// does not override.
+	parts := []Config{
+		{
+			AWSEC2: &struct {
+				InstanceType          string `json:"instanceType,omitempty"`
+				NumServers            string `json:"numServers,omitempty"`
+				NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
+				DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
+				UserData              string `json:"userData,omitempty"`
+				UserDataURL           string `json:"userDataURL,omitempty"`
+				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
+				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
+				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			}{
+				CustomIngressPorts: []int{22, 80, 443},
+			},
+		},
+		{
+			AWSEC2: &struct {
+				InstanceType          string `json:"instanceType,omitempty"`
+				NumServers            string `json:"numServers,omitempty"`
+				NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
+				DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
+				UserData              string `json:"userData,omitempty"`
+				UserDataURL           string `json:"userDataURL,omitempty"`
+				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
+				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
+				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			}{
+				InstanceType: "t3.large", // populated leaf
+				// CustomIngressPorts left nil — must not override
+			},
+		},
+	}
+	got := UnionConfig(parts)
+
+	require.NotNil(t, got.AWSEC2)
+	assert.Equal(t, []int{22, 80, 443}, got.AWSEC2.CustomIngressPorts,
+		"nil slice in a later part must not override an earlier populated slice")
+	assert.Equal(t, "t3.large", got.AWSEC2.InstanceType,
+		"later non-zero scalar must still override")
+}
+
+func TestUnionConfig_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Cloud:  "AWS",
+		Region: "us-east-1",
+	}
+	cfg.AWSVPC = &struct {
+		SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+		EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+		AZCount          *int  `json:"azCount,omitempty"`
+	}{EnableNATGateway: boolPtr(true), AZCount: intPtr(2)}
+
+	// Fold of one element must equal cfg (JSON-roundtrip equal — pointer
+	// identity at the *struct level differs by design, that's fine).
+	one := UnionConfig([]Config{cfg})
+	assertConfigJSONEqual(t, cfg, one)
+
+	// Fold of two copies must match fold of one — idempotent in the
+	// "applying the same record twice changes nothing" sense.
+	two := UnionConfig([]Config{cfg, cfg})
+	assertConfigJSONEqual(t, one, two)
+}
+
+func TestUnionConfig_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, Config{}, UnionConfig(nil), "nil input must yield zero Config")
+	assert.Equal(t, Config{}, UnionConfig([]Config{}), "empty slice input must yield zero Config")
+}
+
+func TestUnionConfig_AWSBackupsRecursion(t *testing.T) {
+	t.Parallel()
+
+	// Part 1 sets AWSBackups.RDS.FrequencyHours; part 2 sets only
+	// AWSBackups.S3.FrequencyHours. Result must have BOTH sub-sub-blocks
+	// populated — proves recursion descends through the AWSBackups *struct
+	// AND through the per-component *struct underneath.
+	p1 := Config{}
+	p1.AWSBackups = newAWSBackups()
+	p1.AWSBackups.RDS = &struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	}{FrequencyHours: 4}
+
+	p2 := Config{}
+	p2.AWSBackups = newAWSBackups()
+	p2.AWSBackups.S3 = &struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	}{FrequencyHours: 24}
+
+	got := UnionConfig([]Config{p1, p2})
+
+	require.NotNil(t, got.AWSBackups)
+	require.NotNil(t, got.AWSBackups.RDS, "earlier-part backup leaf must survive")
+	assert.Equal(t, 4, got.AWSBackups.RDS.FrequencyHours)
+	require.NotNil(t, got.AWSBackups.S3, "later-part backup leaf must land")
+	assert.Equal(t, 24, got.AWSBackups.S3.FrequencyHours)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// UnionComponents
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestUnionComponents_LastNonZeroWins(t *testing.T) {
+	t.Parallel()
+
+	parts := []Components{
+		{Cloud: "AWS", AWSVPC: "Public VPC"},
+		{AWSVPC: "Private VPC"},
+	}
+	got := UnionComponents(parts)
+
+	assert.Equal(t, "AWS", got.Cloud, "earlier non-zero scalar must survive when later part is zero")
+	assert.Equal(t, "Private VPC", got.AWSVPC, "later non-zero string must override earlier")
+}
+
+func TestUnionComponents_PointerToFalsePreserved(t *testing.T) {
+	t.Parallel()
+
+	// Canonical #1043 case: explicit deselection must beat an earlier
+	// explicit selection. Locks the pointer-non-nil discriminator.
+	parts := []Components{
+		{AWSOpenSearch: boolPtr(true)},
+		{AWSOpenSearch: boolPtr(false)},
+	}
+	got := UnionComponents(parts)
+
+	require.NotNil(t, got.AWSOpenSearch,
+		"explicit *bool(&false) is non-nil and must override earlier *bool(&true)")
+	assert.False(t, *got.AWSOpenSearch,
+		"final dereferenced value must be the later part's false")
+}
+
+func TestUnionComponents_Recurses_AWSBackups(t *testing.T) {
+	t.Parallel()
+
+	// Part 1 selects RDS backups; part 2 selects S3 backups. Result must
+	// have BOTH leaves populated under a single AWSBackups sub-struct —
+	// proves recursion at the *struct level.
+	p1 := Components{}
+	p1.AWSBackups = &struct {
+		EC2         *bool `json:"aws_ec2,omitempty"`
+		RDS         *bool `json:"aws_rds,omitempty"`
+		ElastiCache *bool `json:"aws_elasticache,omitempty"`
+		DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+		S3          *bool `json:"aws_s3,omitempty"`
+	}{RDS: boolPtr(true)}
+
+	p2 := Components{}
+	p2.AWSBackups = &struct {
+		EC2         *bool `json:"aws_ec2,omitempty"`
+		RDS         *bool `json:"aws_rds,omitempty"`
+		ElastiCache *bool `json:"aws_elasticache,omitempty"`
+		DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+		S3          *bool `json:"aws_s3,omitempty"`
+	}{S3: boolPtr(true)}
+
+	got := UnionComponents([]Components{p1, p2})
+
+	require.NotNil(t, got.AWSBackups)
+	require.NotNil(t, got.AWSBackups.RDS, "earlier part's RDS selection must survive")
+	assert.True(t, *got.AWSBackups.RDS)
+	require.NotNil(t, got.AWSBackups.S3, "later part's S3 selection must land")
+	assert.True(t, *got.AWSBackups.S3)
+}
+
+func TestUnionComponents_CrossCloud_LastCloudWins(t *testing.T) {
+	t.Parallel()
+
+	// Part 1 is an AWS stack; part 2 is a GCP stack. Result has Cloud=GCP
+	// and BOTH clouds' field sets survive — Union does merge only, NOT
+	// normalize. Stripping the opposite-cloud fields is Components.Normalize's
+	// job and must NOT happen here.
+	parts := []Components{
+		{Cloud: "AWS", AWSVPC: "Public VPC", AWSEC2: "Intel"},
+		{Cloud: "GCP", GCPVPC: boolPtr(true), GCPCompute: "n2-standard-2"},
+	}
+	got := UnionComponents(parts)
+
+	assert.Equal(t, "GCP", got.Cloud, "later Cloud must override")
+	assert.Equal(t, "Public VPC", got.AWSVPC,
+		"AWS field from earlier part must survive — Union does not auto-strip")
+	assert.Equal(t, "Intel", got.AWSEC2,
+		"AWS field from earlier part must survive — Union does not auto-strip")
+	require.NotNil(t, got.GCPVPC, "GCP field from later part must land")
+	assert.True(t, *got.GCPVPC)
+	assert.Equal(t, "n2-standard-2", got.GCPCompute)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Composition with the PR-1 coherence pipeline
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestUnion_Then_StripOrphanConfig_PipelineSequence(t *testing.T) {
+	t.Parallel()
+
+	// Two-part fold then strip — verifies UnionConfig output flows cleanly
+	// through StripOrphanConfig (PR-1). Part 1 has OpenSearch selected with
+	// config; part 2 explicitly deselects it. After UnionConfig the *bool
+	// pointer is &false but the cfg.AWSOpenSearch sub-block survives from
+	// part 1 — StripOrphanConfig must then clear it.
+	cfgPart1 := Config{
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production", InstanceType: "m6g.large"},
+	}
+	cfgPart2 := Config{} // empty — does not touch AWSOpenSearch
+
+	mergedCfg := UnionConfig([]Config{cfgPart1, cfgPart2})
+	require.NotNil(t, mergedCfg.AWSOpenSearch,
+		"merged Config retains AWSOpenSearch sub-block from part 1")
+
+	// Components fold: part 1 selects OpenSearch; part 2 deselects it.
+	mergedComps := UnionComponents([]Components{
+		{AWSOpenSearch: boolPtr(true)},
+		{AWSOpenSearch: boolPtr(false)},
+	})
+	require.NotNil(t, mergedComps.AWSOpenSearch)
+	assert.False(t, *mergedComps.AWSOpenSearch,
+		"explicit-deselect must win the Components fold")
+
+	// Now run the PR-1 strip — the orphan cfg.AWSOpenSearch must go.
+	StripOrphanConfig(&mergedComps, &mergedCfg)
+	assert.Nil(t, mergedCfg.AWSOpenSearch,
+		"StripOrphanConfig must clear cfg.AWSOpenSearch when the component is explicitly deselected")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+// newAWSBackups returns a zero-valued AWSBackups sub-struct pointer in the
+// exact anonymous shape declared on Config. Helper because the literal type
+// is verbose to write inline.
+func newAWSBackups() *struct {
+	EC2 *struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	} `json:"aws_ec2,omitempty"`
+	RDS *struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	} `json:"aws_rds,omitempty"`
+	ElastiCache *struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	} `json:"aws_elasticache,omitempty"`
+	DynamoDB *struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	} `json:"aws_dynamodb,omitempty"`
+	S3 *struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	} `json:"aws_s3,omitempty"`
+} {
+	return &struct {
+		EC2 *struct {
+			FrequencyHours int    `json:"frequencyHours,omitempty"`
+			RetentionDays  int    `json:"retentionDays,omitempty"`
+			Region         string `json:"region,omitempty"`
+		} `json:"aws_ec2,omitempty"`
+		RDS *struct {
+			FrequencyHours int    `json:"frequencyHours,omitempty"`
+			RetentionDays  int    `json:"retentionDays,omitempty"`
+			Region         string `json:"region,omitempty"`
+		} `json:"aws_rds,omitempty"`
+		ElastiCache *struct {
+			FrequencyHours int    `json:"frequencyHours,omitempty"`
+			RetentionDays  int    `json:"retentionDays,omitempty"`
+			Region         string `json:"region,omitempty"`
+		} `json:"aws_elasticache,omitempty"`
+		DynamoDB *struct {
+			FrequencyHours int    `json:"frequencyHours,omitempty"`
+			RetentionDays  int    `json:"retentionDays,omitempty"`
+			Region         string `json:"region,omitempty"`
+		} `json:"aws_dynamodb,omitempty"`
+		S3 *struct {
+			FrequencyHours int    `json:"frequencyHours,omitempty"`
+			RetentionDays  int    `json:"retentionDays,omitempty"`
+			Region         string `json:"region,omitempty"`
+		} `json:"aws_s3,omitempty"`
+	}{}
+}
+
+// assertConfigJSONEqual checks two Configs are equivalent under JSON
+// marshal-roundtrip — the equality that matters for persistence parity.
+// Pointer identity at the *struct level may differ; that's expected and fine.
+func assertConfigJSONEqual(t *testing.T, want, got Config) {
+	t.Helper()
+	wb, err := json.Marshal(want)
+	require.NoError(t, err)
+	gb, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(wb), string(gb))
+}


### PR DESCRIPTION
PR-2 of 3 on luthersystems/reliable#1437. Stacked on #429 (PR-1, `feat/1437-coherence`). View the incremental diff only — base is the PR-1 branch, not `main`.

## Summary

Migrates the partial-record fold from reliable's `internal/chatv2/stack_components.go` (`mergeComponents` + `mergeConfig` and their per-component helpers) upstream into `pkg/composer`. PR-1 brought the coherence rules upstream; this PR brings the merge itself, so the full reliable-side pipeline (`UnionConfig` → `StripOrphanConfig` → `DeriveCrossComponentFields` → `ApplyPresetDefaults`) lives next to the schemas it operates on.

## Public API

```go
func UnionComponents(parts []Components) Components
func UnionConfig(parts []Config) Config
```

Both are pure, reflection-driven, and additive — nothing existing is touched.

## Contract

- **Last-non-zero per leaf wins.** Later parts override earlier ones only where they have a non-zero value at the same leaf.
- **Pointer-to-false is non-zero.** `&false` (the *pointer* being non-nil) overrides an earlier `&true`. This is the reliable#1043 explicit-deselect canary — locked in tests for both Components and Config layers.
- **Sub-struct recursion.** A later part that touches only `AWSVPC.AZCount` does not clobber an earlier part's `AWSVPC.EnableNATGateway`. Recursion descends into every nested `*struct` (`AWSBackups`, `GCPBackups`, `AWSVPC`, …) with the same rule.
- **Allocate-on-demand.** When dst's inner `*struct` is nil and src's is non-nil, dst gets a **fresh** inner struct — not src's pointer. Mirrors `MergeConfigs`'s existing semantics in `defaults.go`. Scalar-pointer fields *inside* the struct (`*bool`, `*int`) are still shallow-copied across.
- **No Normalize calls inside Union.** Cross-cloud stripping is `Components.Normalize` / `Config.Normalize`'s job — Union is just the merge. The cross-cloud test explicitly locks that BOTH cloud field sets survive.

The new private helper `overlayNonZero` is the destination-loses sibling of `overlayZero` in `defaults.go`: same reflective shape, flipped predicate.

## Reliable-side follow-up (PR-3)

With this merged, reliable's `mergeConfig` / `mergeComponents` families and their per-component helpers (`mergeAWSEC2Config`, `mergeAWSEKSConfig`, …, `mergeGCPBackupsConfig`) can be deleted and the call site in `mergeAndDeriveStackComponents` (around line 700 of `internal/chatv2/stack_components.go`) can be swapped for `composer.UnionConfig` / `composer.UnionComponents` calls. PR-3 is gated on the presets bump landing first.

## Test plan

- [x] `go build ./pkg/composer/...` clean
- [x] `go test ./pkg/composer/... -count=1` — 1236 tests passed (14 new in `union_test.go`)
- [x] `go vet ./pkg/composer/...` clean
- [x] `golangci-lint run ./pkg/composer/...` — no new findings on the new files (6 pre-existing findings in `defaults.go` / `imported/` carry over from `main`, untouched)
- [x] Diff against `feat/1437-coherence` is exactly two new files (`union.go`, `union_test.go`); no PR-1 file modified

Locked invariants (14 new tests):

- `UnionConfig`: last-non-zero-wins, empty-parts-no-op, pointer-to-false preserved, sub-struct recursion (AWSVPC + AWSBackups), allocates-fresh-inner-struct, nil-slice-no-override, idempotent, empty/nil input safety
- `UnionComponents`: last-non-zero-wins, pointer-to-false preserved (the #1043 case), recurses through AWSBackups, cross-cloud fold preserves BOTH cloud field sets (Normalize is not Union's job)
- Composition: Union → `StripOrphanConfig` (PR-1) pipeline correctly clears `cfg.AWSOpenSearch` after an explicit-deselect fold

## Cross-references

- luthersystems/reliable#1437 (the umbrella issue)
- luthersystems/insideout-terraform-presets#429 (PR-1, this PR's base)
- luthersystems/reliable#1043 (explicit-deselect canary that motivates the pointer-to-false rule)