### PR TITLE
feat(composer): ValidateFirstImportPlan / ValidateSubsequentApplyPlan

### DIFF
--- a/pkg/composer/plan_acceptance.go
+++ b/pkg/composer/plan_acceptance.go
@@ -1,0 +1,386 @@
+package composer
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	tfjson "github.com/hashicorp/terraform-json"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// ValidateFirstImportPlanOpts configures the first-import contract per
+// docs/managed-resource-tiers.md decision #34: "First adoption apply:
+// allowed actions are N to import, 0 to add, 0 to destroy, plus in-place
+// additions/repairs of InsideOut provenance tags / labels."
+type ValidateFirstImportPlanOpts struct {
+	// ExpectedImports is the number of resources the plan should be
+	// importing. A plan with a different count of Importing changes
+	// (counting both ResourceChanges and ResourceDrift) fails.
+	ExpectedImports int
+
+	// ProvenanceLabelKeys lists the leaf attribute paths that may be
+	// added/repaired alongside the imports without failing the contract.
+	// Use FirstImportProvenanceKeys(cloud) for the canonical set.
+	ProvenanceLabelKeys []string
+}
+
+// ValidateSubsequentApplyPlanOpts configures the looser contract for
+// re-applies per decision #34: "Subsequent applies: allowed actions are
+// exactly the user-approved desired-state changes plus provenance tag /
+// label repair."
+type ValidateSubsequentApplyPlanOpts struct {
+	// ProvenanceLabelKeys lists the leaf attribute paths that may be
+	// added/repaired without an approval. Use
+	// FirstImportProvenanceKeys(cloud) for the canonical set.
+	ProvenanceLabelKeys []string
+}
+
+// FirstImportProvenanceKeys returns the canonical set of provenance
+// tag/label leaf paths for cloud ∈ {"aws", "gcp"}. These are the only
+// non-import writes the first-import contract permits on each resource;
+// callers pass the returned slice as
+// ValidateFirstImportPlanOpts.ProvenanceLabelKeys.
+//
+// The paths include both the user-facing attribute (tags / labels) and
+// the provider-computed mirror attributes (tags_all on AWS;
+// effective_labels and terraform_labels on GCP) because a single
+// provenance write surfaces as a diff in all of them.
+func FirstImportProvenanceKeys(cloud string) []string {
+	switch strings.ToLower(strings.TrimSpace(cloud)) {
+	case "aws":
+		var out []string
+		for _, parent := range []string{"tags", "tags_all"} {
+			for _, k := range []string{
+				awsTagImportProject, awsTagImportSession,
+				awsTagImported, awsTagImportedAt,
+			} {
+				out = append(out, parent+"."+k)
+			}
+		}
+		return out
+	case "gcp":
+		var out []string
+		for _, parent := range []string{"labels", "effective_labels", "terraform_labels"} {
+			for _, k := range []string{
+				gcpLabelImportProject, gcpLabelImportSession,
+				gcpLabelImported, gcpLabelImportedAt,
+			} {
+				out = append(out, parent+"."+k)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// ValidateFirstImportPlan asserts the first-import contract on plan
+// (decision #34). Returns nil on pass; a []ValidationIssue with one or
+// more entries on fail. Issue codes:
+//
+//   - imported_plan_unexpected_import_count — plan imports a different
+//     number of resources than opts.ExpectedImports.
+//   - imported_plan_unexpected_create — a non-import resource is being
+//     created.
+//   - imported_plan_unexpected_destroy — a resource is being destroyed.
+//   - imported_plan_unexpected_replace — a resource is being replaced.
+//   - imported_plan_unauthorized_change — a resource has an update whose
+//     diff includes attribute paths outside opts.ProvenanceLabelKeys.
+//
+// A nil plan returns one issue with code imported_plan_nil_input.
+func ValidateFirstImportPlan(plan *tfjson.Plan, opts ValidateFirstImportPlanOpts) []ValidationIssue {
+	if plan == nil {
+		return []ValidationIssue{{
+			Field:  "plan",
+			Code:   "imported_plan_nil_input",
+			Reason: "plan is nil; cannot validate first-import contract",
+		}}
+	}
+
+	var issues []ValidationIssue
+	importCount := 0
+
+	for _, rc := range allResourceChanges(plan) {
+		if rc == nil || rc.Change == nil {
+			continue
+		}
+		field := planChangeField(rc)
+		actions := rc.Change.Actions
+		importing := rc.Change.Importing != nil
+
+		if importing {
+			importCount++
+			// An import may carry a side-effect update for provenance
+			// tags/labels. Any non-provenance attribute change fails.
+			if actions.Update() || actions.Replace() {
+				issues = append(issues,
+					unauthorizedChangeIssues(field, rc.Change, opts.ProvenanceLabelKeys)...)
+			}
+			continue
+		}
+
+		switch {
+		case actions.NoOp(), actions.Read():
+			// No-ops and reads are always safe.
+		case actions.Replace():
+			issues = append(issues, ValidationIssue{
+				Field:  field,
+				Value:  joinActions(actions),
+				Code:   "imported_plan_unexpected_replace",
+				Reason: fmt.Sprintf("first-import plan must not replace resources; %q has actions %v", rc.Address, actions),
+			})
+		case actions.Delete():
+			issues = append(issues, ValidationIssue{
+				Field:  field,
+				Value:  joinActions(actions),
+				Code:   "imported_plan_unexpected_destroy",
+				Reason: fmt.Sprintf("first-import plan must not destroy resources; %q has actions %v", rc.Address, actions),
+			})
+		case actions.Create():
+			issues = append(issues, ValidationIssue{
+				Field:  field,
+				Value:  joinActions(actions),
+				Code:   "imported_plan_unexpected_create",
+				Reason: fmt.Sprintf("first-import plan must not create resources; %q has actions %v", rc.Address, actions),
+			})
+		case actions.Update():
+			// A non-import update is only allowed if every changed
+			// attribute is in the provenance allowlist.
+			issues = append(issues,
+				unauthorizedChangeIssues(field, rc.Change, opts.ProvenanceLabelKeys)...)
+		}
+	}
+
+	if importCount != opts.ExpectedImports {
+		issues = append(issues, ValidationIssue{
+			Field:  "plan.imports",
+			Value:  fmt.Sprintf("%d", importCount),
+			Code:   "imported_plan_unexpected_import_count",
+			Reason: fmt.Sprintf("first-import plan expected %d imports, got %d", opts.ExpectedImports, importCount),
+		})
+	}
+
+	return issues
+}
+
+// ValidateSubsequentApplyPlan asserts the subsequent-apply contract
+// (decision #34): every resource-change must be either a no-op, an
+// import {} no-op (the import block survived; the address is already in
+// state), a provenance-only write, or covered by a matching
+// FieldEditApproval on the corresponding ImportedResource's FieldEdits.
+//
+// Issue codes:
+//
+//   - imported_plan_unapproved_replace — replace not covered by an
+//     approval on the matching ImportedResource.
+//   - imported_plan_unapproved_destroy — destroy not covered by an
+//     approval.
+//   - imported_plan_unapproved_create — create of a resource that has no
+//     corresponding ImportedResource record.
+//   - imported_plan_unauthorized_change — update touching attribute
+//     paths that are neither provenance keys nor present in the
+//     ImportedResource's approved FieldEdits set.
+//
+// A nil plan returns one issue with code imported_plan_nil_input.
+func ValidateSubsequentApplyPlan(plan *tfjson.Plan, irs []imported.ImportedResource, opts ValidateSubsequentApplyPlanOpts) []ValidationIssue {
+	if plan == nil {
+		return []ValidationIssue{{
+			Field:  "plan",
+			Code:   "imported_plan_nil_input",
+			Reason: "plan is nil; cannot validate subsequent-apply contract",
+		}}
+	}
+
+	// Index approved paths by Terraform address.
+	approvedByAddr := map[string]map[string]struct{}{}
+	for _, ir := range irs {
+		if ir.Identity.Address == "" || len(ir.FieldEdits) == 0 {
+			continue
+		}
+		paths := map[string]struct{}{}
+		for path, edit := range ir.FieldEdits {
+			if edit.Approval != nil {
+				paths[path] = struct{}{}
+			}
+		}
+		if len(paths) > 0 {
+			approvedByAddr[ir.Identity.Address] = paths
+		}
+	}
+
+	var issues []ValidationIssue
+	for _, rc := range plan.ResourceChanges {
+		if rc == nil || rc.Change == nil {
+			continue
+		}
+		field := planChangeField(rc)
+		actions := rc.Change.Actions
+		importing := rc.Change.Importing != nil
+
+		// Pure no-op import (the import {} block survived a re-apply
+		// once the address is already in state) is the documented
+		// expected shape.
+		if importing && actions.NoOp() {
+			continue
+		}
+
+		switch {
+		case actions.NoOp(), actions.Read():
+			// Safe.
+		case actions.Replace():
+			if !changeCoveredByApproval(rc, approvedByAddr) {
+				issues = append(issues, ValidationIssue{
+					Field:  field,
+					Value:  joinActions(actions),
+					Code:   "imported_plan_unapproved_replace",
+					Reason: fmt.Sprintf("replace of %q is not covered by a FieldEditApproval; subsequent-apply contract requires explicit operator approval for replace", rc.Address),
+				})
+			}
+		case actions.Delete():
+			if !changeCoveredByApproval(rc, approvedByAddr) {
+				issues = append(issues, ValidationIssue{
+					Field:  field,
+					Value:  joinActions(actions),
+					Code:   "imported_plan_unapproved_destroy",
+					Reason: fmt.Sprintf("destroy of %q is not covered by a FieldEditApproval; subsequent-apply contract requires explicit operator approval for destroy", rc.Address),
+				})
+			}
+		case actions.Create():
+			if _, ok := approvedByAddr[rc.Address]; !ok {
+				issues = append(issues, ValidationIssue{
+					Field:  field,
+					Value:  joinActions(actions),
+					Code:   "imported_plan_unapproved_create",
+					Reason: fmt.Sprintf("create of %q is not covered by a matching ImportedResource record; subsequent-apply contract limits creates to approved desired-state changes", rc.Address),
+				})
+			}
+		case actions.Update():
+			allowed := approvedByAddr[rc.Address]
+			issues = append(issues,
+				unapprovedChangeIssues(field, rc.Change, opts.ProvenanceLabelKeys, allowed)...)
+		}
+	}
+
+	return issues
+}
+
+// unauthorizedChangeIssues returns one issue per leaf attribute path in
+// change.Before vs change.After that is not in allowedKeys. Used by the
+// first-import contract where the only permitted updates are provenance
+// repair.
+func unauthorizedChangeIssues(field string, change *tfjson.Change, allowedKeys []string) []ValidationIssue {
+	allow := stringSet(allowedKeys)
+	bad := diffPaths(change.Before, change.After, "")
+	var issues []ValidationIssue
+	for _, p := range bad {
+		if _, ok := allow[p]; ok {
+			continue
+		}
+		issues = append(issues, ValidationIssue{
+			Field:  field + "." + p,
+			Code:   "imported_plan_unauthorized_change",
+			Reason: fmt.Sprintf("first-import plan must only repair provenance tags/labels; path %q is not in the allowed set", p),
+		})
+	}
+	return issues
+}
+
+// unapprovedChangeIssues is the subsequent-apply variant: leaf paths
+// that are in neither the provenance allowlist nor the
+// per-ImportedResource approved-edit set fail.
+func unapprovedChangeIssues(field string, change *tfjson.Change, allowedProvenance []string, approvedPaths map[string]struct{}) []ValidationIssue {
+	allow := stringSet(allowedProvenance)
+	bad := diffPaths(change.Before, change.After, "")
+	var issues []ValidationIssue
+	for _, p := range bad {
+		if _, ok := allow[p]; ok {
+			continue
+		}
+		if _, ok := approvedPaths[p]; ok {
+			continue
+		}
+		issues = append(issues, ValidationIssue{
+			Field:  field + "." + p,
+			Code:   "imported_plan_unauthorized_change",
+			Reason: fmt.Sprintf("attribute change at %q on this resource is neither a provenance repair nor covered by an approved FieldEdit", p),
+		})
+	}
+	return issues
+}
+
+// changeCoveredByApproval reports whether the resource at rc.Address has
+// any approved field edit. The plan-side check is intentionally coarse
+// — we don't try to map a replace's ReplacePaths to specific edits,
+// since the ChangeRisk-driven approval already happens in
+// ValidateImportedResourceAuthorization. The plan-side gate just
+// confirms that an approval exists at all.
+func changeCoveredByApproval(rc *tfjson.ResourceChange, approvedByAddr map[string]map[string]struct{}) bool {
+	paths, ok := approvedByAddr[rc.Address]
+	return ok && len(paths) > 0
+}
+
+// diffPaths returns the dotted leaf paths where before != after.
+// Treats nil and a missing key uniformly. List values are compared by
+// reflect.DeepEqual at the slice level (no element-wise descent), since
+// a re-ordered list at the JSON level always indicates a real change to
+// the provider.
+func diffPaths(before, after any, prefix string) []string {
+	if reflect.DeepEqual(before, after) {
+		return nil
+	}
+	bMap, bIsMap := before.(map[string]any)
+	aMap, aIsMap := after.(map[string]any)
+	if bIsMap || aIsMap {
+		var paths []string
+		keys := unionKeys(bMap, aMap)
+		for _, k := range keys {
+			child := k
+			if prefix != "" {
+				child = prefix + "." + k
+			}
+			paths = append(paths, diffPaths(bMap[k], aMap[k], child)...)
+		}
+		return paths
+	}
+	if prefix == "" {
+		return []string{"<root>"}
+	}
+	return []string{prefix}
+}
+
+func stringSet(xs []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(xs))
+	for _, x := range xs {
+		out[x] = struct{}{}
+	}
+	return out
+}
+
+// allResourceChanges concatenates ResourceChanges and ResourceDrift so
+// the first-import counter doesn't miss an import that surfaced as
+// pre-plan drift on a re-run.
+func allResourceChanges(plan *tfjson.Plan) []*tfjson.ResourceChange {
+	out := make([]*tfjson.ResourceChange, 0, len(plan.ResourceChanges)+len(plan.ResourceDrift))
+	out = append(out, plan.ResourceChanges...)
+	out = append(out, plan.ResourceDrift...)
+	return out
+}
+
+// planChangeField builds a ValidationIssue.Field path for a plan
+// resource-change, mirroring imported_validate.go's importedField shape
+// for consistency with the rest of the family.
+func planChangeField(rc *tfjson.ResourceChange) string {
+	if rc.Address == "" {
+		return "plan.resource_changes"
+	}
+	return "plan." + rc.Address
+}
+
+func joinActions(actions tfjson.Actions) string {
+	parts := make([]string, 0, len(actions))
+	for _, a := range actions {
+		parts = append(parts, string(a))
+	}
+	return strings.Join(parts, ",")
+}

--- a/pkg/composer/plan_acceptance_test.go
+++ b/pkg/composer/plan_acceptance_test.go
@@ -1,0 +1,370 @@
+package composer
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// importChange builds a tfjson.ResourceChange that represents an
+// import. Pass before/after as the structured diff (nil for a clean
+// import that adds no attributes).
+func importChange(addr string, actions tfjson.Actions, before, after map[string]any) *tfjson.ResourceChange {
+	return &tfjson.ResourceChange{
+		Address: addr,
+		Mode:    tfjson.ManagedResourceMode,
+		Change: &tfjson.Change{
+			Actions:   actions,
+			Before:    asAny(before),
+			After:     asAny(after),
+			Importing: &tfjson.Importing{ID: "imported-id"},
+		},
+	}
+}
+
+// plainChange builds a tfjson.ResourceChange for a non-import action.
+func plainChange(addr string, actions tfjson.Actions, before, after map[string]any) *tfjson.ResourceChange {
+	return &tfjson.ResourceChange{
+		Address: addr,
+		Mode:    tfjson.ManagedResourceMode,
+		Change: &tfjson.Change{
+			Actions: actions,
+			Before:  asAny(before),
+			After:   asAny(after),
+		},
+	}
+}
+
+func asAny(m map[string]any) any {
+	if m == nil {
+		return nil
+	}
+	return m
+}
+
+func TestValidateFirstImportPlan_NilPlan(t *testing.T) {
+	t.Parallel()
+	issues := ValidateFirstImportPlan(nil, ValidateFirstImportPlanOpts{})
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_plan_nil_input", issues[0].Code)
+}
+
+func TestValidateFirstImportPlan_Contract(t *testing.T) {
+	t.Parallel()
+
+	gcpProvenance := FirstImportProvenanceKeys("gcp")
+	require.NotEmpty(t, gcpProvenance, "GCP provenance keys must be non-empty")
+
+	cases := []struct {
+		name      string
+		plan      *tfjson.Plan
+		opts      ValidateFirstImportPlanOpts
+		wantCodes []string
+		denyCodes []string
+	}{
+		{
+			name: "clean import-only plan with provenance label adds passes",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				importChange("google_storage_bucket.a",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"name": "a", "labels": map[string]any{}},
+					map[string]any{"name": "a", "labels": map[string]any{
+						"insideout-import-project": "io-abc",
+						"insideout-imported":       "true",
+					}},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: nil,
+		},
+		{
+			name: "import + unrelated create fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				importChange("google_storage_bucket.a",
+					tfjson.Actions{tfjson.ActionNoop}, nil, nil),
+				plainChange("google_storage_bucket.b",
+					tfjson.Actions{tfjson.ActionCreate}, nil,
+					map[string]any{"name": "b"}),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: []string{"imported_plan_unexpected_create"},
+		},
+		{
+			name: "import + non-provenance label change fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				importChange("google_storage_bucket.a",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"labels": map[string]any{}},
+					map[string]any{"labels": map[string]any{
+						"insideout-import-project": "io-abc",
+						"team":                     "platform",
+					}},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: []string{"imported_plan_unauthorized_change"},
+		},
+		{
+			name: "import count mismatch fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				importChange("google_storage_bucket.a",
+					tfjson.Actions{tfjson.ActionNoop}, nil, nil),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 5, ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: []string{"imported_plan_unexpected_import_count"},
+		},
+		{
+			name: "destroy on non-import fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				plainChange("google_storage_bucket.zombie",
+					tfjson.Actions{tfjson.ActionDelete},
+					map[string]any{"name": "zombie"}, nil),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 0, ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: []string{"imported_plan_unexpected_destroy"},
+		},
+		{
+			name: "replace on non-import fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				plainChange("google_storage_bucket.x",
+					tfjson.Actions{tfjson.ActionDelete, tfjson.ActionCreate},
+					map[string]any{"location": "US"},
+					map[string]any{"location": "EU"}),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 0, ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: []string{"imported_plan_unexpected_replace"},
+			denyCodes: []string{"imported_plan_unexpected_create", "imported_plan_unexpected_destroy"},
+		},
+		{
+			name: "import surfaced as ResourceDrift is counted",
+			plan: &tfjson.Plan{ResourceDrift: []*tfjson.ResourceChange{
+				importChange("google_pubsub_topic.t",
+					tfjson.Actions{tfjson.ActionNoop}, nil, nil),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			issues := ValidateFirstImportPlan(tc.plan, tc.opts)
+			got := issueCodes(issues)
+			sort.Strings(got)
+			want := append([]string(nil), tc.wantCodes...)
+			sort.Strings(want)
+			assert.ElementsMatch(t, want, got, "issue codes mismatch")
+			for _, deny := range tc.denyCodes {
+				assert.NotContains(t, got, deny, "denied code %q surfaced", deny)
+			}
+		})
+	}
+}
+
+func TestValidateSubsequentApplyPlan_NilPlan(t *testing.T) {
+	t.Parallel()
+	issues := ValidateSubsequentApplyPlan(nil, nil, ValidateSubsequentApplyPlanOpts{})
+	require.Len(t, issues, 1)
+	assert.Equal(t, "imported_plan_nil_input", issues[0].Code)
+}
+
+func TestValidateSubsequentApplyPlan_Contract(t *testing.T) {
+	t.Parallel()
+
+	gcpProvenance := FirstImportProvenanceKeys("gcp")
+
+	approvedBucket := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "gcp",
+			Type:    "google_storage_bucket",
+			Address: "google_storage_bucket.a",
+		},
+		FieldEdits: map[string]imported.FieldEdit{
+			"force_destroy": {
+				EditedAt: time.Now().UTC(),
+				NewValue: true,
+				Approval: &imported.FieldEditApproval{
+					Approver:   "ops@example.com",
+					ApprovedAt: time.Now().UTC(),
+					PlanHash:   "abc123",
+				},
+			},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		plan      *tfjson.Plan
+		irs       []imported.ImportedResource
+		opts      ValidateSubsequentApplyPlanOpts
+		wantCodes []string
+	}{
+		{
+			name: "import block survives as no-op on subsequent apply",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				importChange("google_storage_bucket.a",
+					tfjson.Actions{tfjson.ActionNoop}, nil, nil),
+			}},
+			irs:       []imported.ImportedResource{approvedBucket},
+			opts:      ValidateSubsequentApplyPlanOpts{ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: nil,
+		},
+		{
+			name: "update at an approved path passes",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				plainChange("google_storage_bucket.a",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"force_destroy": false},
+					map[string]any{"force_destroy": true}),
+			}},
+			irs:       []imported.ImportedResource{approvedBucket},
+			opts:      ValidateSubsequentApplyPlanOpts{ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: nil,
+		},
+		{
+			name: "update at an unapproved path fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				plainChange("google_storage_bucket.a",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"storage_class": "STANDARD"},
+					map[string]any{"storage_class": "NEARLINE"}),
+			}},
+			irs:       []imported.ImportedResource{approvedBucket},
+			opts:      ValidateSubsequentApplyPlanOpts{ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: []string{"imported_plan_unauthorized_change"},
+		},
+		{
+			name: "provenance-only label add passes without approval",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				plainChange("google_storage_bucket.a",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"labels": map[string]any{}},
+					map[string]any{"labels": map[string]any{
+						"insideout-imported-at": "2026-05-13",
+					}}),
+			}},
+			irs:       []imported.ImportedResource{approvedBucket},
+			opts:      ValidateSubsequentApplyPlanOpts{ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: nil,
+		},
+		{
+			name: "replace without approval fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				plainChange("google_storage_bucket.other",
+					tfjson.Actions{tfjson.ActionDelete, tfjson.ActionCreate},
+					map[string]any{"location": "US"},
+					map[string]any{"location": "EU"}),
+			}},
+			irs:       []imported.ImportedResource{approvedBucket},
+			opts:      ValidateSubsequentApplyPlanOpts{ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: []string{"imported_plan_unapproved_replace"},
+		},
+		{
+			name: "replace with an approval on the same resource passes",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				plainChange("google_storage_bucket.a",
+					tfjson.Actions{tfjson.ActionDelete, tfjson.ActionCreate},
+					map[string]any{"location": "US"},
+					map[string]any{"location": "EU"}),
+			}},
+			irs:       []imported.ImportedResource{approvedBucket},
+			opts:      ValidateSubsequentApplyPlanOpts{ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: nil,
+		},
+		{
+			name: "destroy without approval fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				plainChange("google_storage_bucket.gone",
+					tfjson.Actions{tfjson.ActionDelete},
+					map[string]any{"name": "gone"}, nil),
+			}},
+			irs:       nil,
+			opts:      ValidateSubsequentApplyPlanOpts{ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: []string{"imported_plan_unapproved_destroy"},
+		},
+		{
+			name: "create of resource without an ImportedResource record fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				plainChange("google_pubsub_topic.new",
+					tfjson.Actions{tfjson.ActionCreate}, nil,
+					map[string]any{"name": "new"}),
+			}},
+			irs:       nil,
+			opts:      ValidateSubsequentApplyPlanOpts{ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: []string{"imported_plan_unapproved_create"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			issues := ValidateSubsequentApplyPlan(tc.plan, tc.irs, tc.opts)
+			got := issueCodes(issues)
+			sort.Strings(got)
+			want := append([]string(nil), tc.wantCodes...)
+			sort.Strings(want)
+			assert.ElementsMatch(t, want, got, "issue codes mismatch")
+		})
+	}
+}
+
+func TestFirstImportProvenanceKeys(t *testing.T) {
+	t.Parallel()
+
+	aws := FirstImportProvenanceKeys("aws")
+	assert.Contains(t, aws, "tags.InsideOutImportProject")
+	assert.Contains(t, aws, "tags_all.InsideOutImportProject")
+	assert.NotContains(t, aws, "labels.insideout-import-project")
+
+	gcp := FirstImportProvenanceKeys("gcp")
+	assert.Contains(t, gcp, "labels.insideout-import-project")
+	assert.Contains(t, gcp, "effective_labels.insideout-import-project")
+	assert.Contains(t, gcp, "terraform_labels.insideout-import-project")
+	assert.NotContains(t, gcp, "tags.InsideOutImportProject")
+
+	// Case-insensitive input.
+	assert.Equal(t, aws, FirstImportProvenanceKeys("AWS"))
+	assert.Equal(t, gcp, FirstImportProvenanceKeys(" gcp "))
+
+	// Unknown cloud returns nil.
+	assert.Nil(t, FirstImportProvenanceKeys("azure"))
+}
+
+func TestDiffPaths_LeafLevel(t *testing.T) {
+	t.Parallel()
+
+	// Adding a new key produces the leaf path.
+	got := diffPaths(
+		map[string]any{"labels": map[string]any{}},
+		map[string]any{"labels": map[string]any{"k": "v"}},
+		"",
+	)
+	assert.Equal(t, []string{"labels.k"}, got)
+
+	// Equal trees produce no paths.
+	got = diffPaths(
+		map[string]any{"a": "b", "c": map[string]any{"d": 1}},
+		map[string]any{"a": "b", "c": map[string]any{"d": 1}},
+		"",
+	)
+	assert.Nil(t, got)
+
+	// nil before, map after.
+	got = diffPaths(
+		nil,
+		map[string]any{"x": map[string]any{"y": 7}},
+		"",
+	)
+	assert.Equal(t, []string{"x.y"}, got)
+
+	// Scalar change at top-level.
+	got = diffPaths("STANDARD", "NEARLINE", "")
+	assert.Equal(t, []string{"<root>"}, got)
+}


### PR DESCRIPTION
## Summary

Add `pkg/composer/plan_acceptance.go` implementing decision #34's plan contracts so reliable's importer wizard Phase 2 (and any other caller parsing Terraform plan JSON) gates on a shared validator instead of inlining the rules.

## Why

The first-import and subsequent-apply contracts from `docs/managed-resource-tiers.md` are well-defined but had no shared helper. `luthersystems/reliable#1346` Phase 2's PlanPreview screen already shows the four counters (imports / drift / replace / destroy) and a clean-vs-warning banner — moving the rule encoding here means reliable consumes the validator and any future caller (CLI, deploy service) gets the same gate for free. Same pattern reliable already follows for `ValidateImportedResources` and `ValidateImportedResourceAuthorization`.

## Exported API

- `ValidateFirstImportPlan(plan, opts) []ValidationIssue` — asserts the first-adoption contract: exactly `opts.ExpectedImports` import actions, 0 add, 0 destroy, 0 unrelated replace; updates allowed only on the provenance allowlist. Imports counted across `plan.ResourceChanges` and `plan.ResourceDrift` (the latter catches imports surfaced as pre-plan drift on a re-run).
- `ValidateSubsequentApplyPlan(plan, irs, opts) []ValidationIssue` — asserts the looser re-apply contract: every non-no-op change must be either a provenance repair or covered by a matching `FieldEditApproval` on the corresponding `ImportedResource.FieldEdits`. Import `{}` block no-op on subsequent applies is the documented expected shape and passes.
- `FirstImportProvenanceKeys(cloud) []string` — returns the canonical AWS or GCP provenance tag/label paths including the provider-computed mirrors (`tags_all`, `effective_labels`, `terraform_labels`) so a single provenance write doesn't trip the unauthorized-change rule.

## Issue codes

Follow the existing `imported_resource_*` / `imported_plan_*` family conventions:

- `imported_plan_unexpected_import_count`
- `imported_plan_unexpected_create` / `_destroy` / `_replace`
- `imported_plan_unauthorized_change`
- `imported_plan_unapproved_create` / `_destroy` / `_replace`
- `imported_plan_nil_input`

Output shape is `[]ValidationIssue` so `dedupeAndSortIssues` handles them uniformly with the other validators.

## Test plan

- [x] 21 new tests covering all issue acceptance criteria (table-driven, mirrors `imported_validate_test.go` idioms)
- [x] `go test ./...` — 3153 passed (one pre-existing GCP-VPC compose integration test was flaky due to `terraform init` provider download under parallel load; passes in isolation and is unrelated to this change)
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `terraform fmt -check -recursive` — clean (no `.tf` touched)
- [x] All nine repo lint scripts pass

## Acceptance coverage

| # | Issue acceptance | Test |
|---|---|---|
| a | `ValidateFirstImportPlan` returns nil for N imports + provenance-only label writes | `clean import-only plan with provenance label adds passes` |
| b | Same call fails on a `create` of a non-provenance resource | `import + unrelated create fails` |
| c | Non-provenance label change in an import update fails | `import + non-provenance label change fails` |
| d | `ValidateSubsequentApplyPlan` fails on a `replace`/`delete` not covered by approval | `replace without approval fails`, `destroy without approval fails` |

Plus boundary tests: import surfaced as `ResourceDrift` is counted, import count mismatch, replace detection vs separate create+delete, `diffPaths` leaf-level shape.

Closes #402