### PR TITLE
feat(composer): pricing merge — MergePricing + ApplyCarryForward + PricingData

### DIFF
--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -1,0 +1,261 @@
+package composer
+
+// coherence.go owns the rules that make a (Components, Config) pair coherent:
+//
+//   - StripOrphanConfig clears per-component config sub-blocks whose component
+//     is no longer selected. Orphan config sub-blocks otherwise outlive the
+//     component that produced them and leak into deploy payloads (the NAT-on-
+//     Public-VPC apply failure on sess_v2_CnqUJ6NRJnLC, luthersystems/reliable#1435).
+//
+//   - DeriveCrossComponentFields recomputes config fields whose correct value
+//     is a function of which OTHER components are selected — today the AWS
+//     VPC topology knobs whose preset HCL default of NAT=true must NOT survive
+//     onto a stack that no longer needs private subnets.
+//
+// Both functions are pure. They are intended to be composed around
+// (*Client).ApplyPresetDefaults — strip + derive BEFORE the backfill catches
+// "stale-then-removed" carry-forward, and AFTER the backfill catches "fresh
+// allocation" cases where ApplyPresetDefaults just landed NAT=true onto a
+// Public-VPC-only stack.
+//
+// Tracked under luthersystems/reliable#1437.
+
+import "reflect"
+
+// ComponentSelected reports whether the given component is selected on the
+// provided Components value. Pointer-typed components require non-nil AND
+// *true (so an explicit aws_opensearch=false is treated as deselected).
+// String-typed components (AWSVPC, AWSEC2, GCPCompute) require != "".
+// Struct-pointer components (AWSBackups, GCPBackups) require != nil; the
+// backup config itself encodes the selection.
+//
+// Returns false for ComponentKeys that don't appear on Components (e.g.,
+// KeyAWSEKSNodeGroup / KeyAWSEKSControlPlane — those are polymorphic preset
+// keys driven by other component selections, not standalone components).
+func ComponentSelected(c *Components, key ComponentKey) bool {
+	if c == nil {
+		return false
+	}
+	switch key {
+	// String-typed selections.
+	case KeyAWSVPC:
+		return c.AWSVPC != ""
+	case KeyAWSEC2:
+		return c.AWSEC2 != ""
+	case KeyGCPCompute:
+		return c.GCPCompute != ""
+	// AWS pointer-typed selections.
+	case KeyAWSBastion:
+		return boolPtrTrue(c.AWSBastion)
+	case KeyAWSEKS:
+		return boolPtrTrue(c.AWSEKS)
+	case KeyAWSECS:
+		return boolPtrTrue(c.AWSECS)
+	case KeyAWSLambda:
+		return boolPtrTrue(c.AWSLambda)
+	case KeyAWSALB:
+		return boolPtrTrue(c.AWSALB)
+	case KeyAWSCloudfront:
+		return boolPtrTrue(c.AWSCloudFront)
+	case KeyAWSWAF:
+		return boolPtrTrue(c.AWSWAF)
+	case KeyAWSAPIGateway:
+		return boolPtrTrue(c.AWSAPIGateway)
+	case KeyAWSRDS:
+		return boolPtrTrue(c.AWSRDS)
+	case KeyAWSElastiCache:
+		return boolPtrTrue(c.AWSElastiCache)
+	case KeyAWSDynamoDB:
+		return boolPtrTrue(c.AWSDynamoDB)
+	case KeyAWSS3:
+		return boolPtrTrue(c.AWSS3)
+	case KeyAWSKMS:
+		return boolPtrTrue(c.AWSKMS)
+	case KeyAWSSecretsManager:
+		return boolPtrTrue(c.AWSSecretsManager)
+	case KeyAWSOpenSearch:
+		return boolPtrTrue(c.AWSOpenSearch)
+	case KeyAWSBedrock:
+		return boolPtrTrue(c.AWSBedrock)
+	case KeyAWSSQS:
+		return boolPtrTrue(c.AWSSQS)
+	case KeyAWSMSK:
+		return boolPtrTrue(c.AWSMSK)
+	case KeyAWSCloudWatchLogs:
+		return boolPtrTrue(c.AWSCloudWatchLogs)
+	case KeyAWSCloudWatchMonitoring:
+		return boolPtrTrue(c.AWSCloudWatchMonitoring)
+	case KeyAWSGrafana:
+		return boolPtrTrue(c.AWSGrafana)
+	case KeyAWSCognito:
+		return boolPtrTrue(c.AWSCognito)
+	case KeyAWSGitHubActions:
+		return boolPtrTrue(c.AWSGitHubActions)
+	case KeyAWSCodePipeline:
+		return boolPtrTrue(c.AWSCodePipeline)
+	case KeyAWSBackups:
+		return c.AWSBackups != nil
+	// GCP pointer-typed selections.
+	case KeyGCPVPC:
+		return boolPtrTrue(c.GCPVPC)
+	case KeyGCPBastion:
+		return boolPtrTrue(c.GCPBastion)
+	case KeyGCPGKE:
+		return boolPtrTrue(c.GCPGKE)
+	case KeyGCPCloudRun:
+		return boolPtrTrue(c.GCPCloudRun)
+	case KeyGCPCloudFunctions:
+		return boolPtrTrue(c.GCPCloudFunctions)
+	case KeyGCPLoadbalancer:
+		return boolPtrTrue(c.GCPLoadbalancer)
+	case KeyGCPCloudArmor:
+		return boolPtrTrue(c.GCPCloudArmor)
+	case KeyGCPAPIGateway:
+		return boolPtrTrue(c.GCPAPIGateway)
+	case KeyGCPCloudSQL:
+		return boolPtrTrue(c.GCPCloudSQL)
+	case KeyGCPMemorystore:
+		return boolPtrTrue(c.GCPMemorystore)
+	case KeyGCPFirestore:
+		return boolPtrTrue(c.GCPFirestore)
+	case KeyGCPGCS:
+		return boolPtrTrue(c.GCPGCS)
+	case KeyGCPCloudKMS:
+		return boolPtrTrue(c.GCPCloudKMS)
+	case KeyGCPSecretManager:
+		return boolPtrTrue(c.GCPSecretManager)
+	case KeyGCPVertexAI:
+		return boolPtrTrue(c.GCPVertexAI)
+	case KeyGCPPubSub:
+		return boolPtrTrue(c.GCPPubSub)
+	case KeyGCPCloudLogging:
+		return boolPtrTrue(c.GCPCloudLogging)
+	case KeyGCPCloudMonitoring:
+		return boolPtrTrue(c.GCPCloudMonitoring)
+	case KeyGCPIdentityPlatform:
+		return boolPtrTrue(c.GCPIdentityPlatform)
+	case KeyGCPCloudBuild:
+		return boolPtrTrue(c.GCPCloudBuild)
+	case KeyGCPBackups:
+		return c.GCPBackups != nil
+	// External / third-party.
+	case KeySplunk:
+		return boolPtrTrue(c.Splunk)
+	case KeyDatadog:
+		return boolPtrTrue(c.Datadog)
+	}
+	return false
+}
+
+// StackNeedsPrivateSubnets reports whether the stack includes any AWS
+// component that requires private subnets — and therefore NAT egress. The
+// mapper enforces the same predicate to coerce NAT off on Public-VPC stacks
+// (see KeyAWSVPC branch in BuildModuleValues). Exporting it lets persistence-
+// layer callers (luthersystems/reliable) make the same decision upstream of
+// the mapper so cfg.AWSVPC.EnableNATGateway never gets persisted as &true
+// on a stack that doesn't need NAT.
+func StackNeedsPrivateSubnets(c *Components) bool {
+	return stackNeedsPrivateSubnets(c)
+}
+
+// StripOrphanConfig clears every cfg.<component> sub-block whose
+// corresponding component is NOT selected in `comps`. Pure, idempotent. A
+// no-op when cfg is nil or comps is nil (an unknown components state cannot
+// safely conclude orphanhood).
+//
+// Treats "non-nil but empty" sub-structs as orphan when their component is
+// unselected — an empty &AWSOpenSearch{} conveys no actual configuration and
+// must not survive when opensearch is dropped.
+//
+// The set of stripped fields is determined reflectively: any *struct sub-
+// field on Config whose json tag matches a known ComponentKey is in scope.
+// Adding a new component to Components + Config + KeyXxx requires no edit
+// here.
+func StripOrphanConfig(comps *Components, cfg *Config) {
+	if comps == nil || cfg == nil {
+		return
+	}
+	cfgVal := reflect.ValueOf(cfg).Elem()
+	cfgType := cfgVal.Type()
+	for i := 0; i < cfgType.NumField(); i++ {
+		ft := cfgType.Field(i)
+		if ft.Type.Kind() != reflect.Pointer || ft.Type.Elem().Kind() != reflect.Struct {
+			continue
+		}
+		tag := jsonTagName(ft.Tag.Get("json"))
+		if tag == "" {
+			continue
+		}
+		key := ComponentKey(tag)
+		if !isOrphanStrippableKey(key) {
+			continue
+		}
+		if !ComponentSelected(comps, key) {
+			fv := cfgVal.Field(i)
+			if fv.CanSet() && !fv.IsNil() {
+				fv.Set(reflect.Zero(fv.Type()))
+			}
+		}
+	}
+}
+
+// DeriveCrossComponentFields re-derives cfg fields whose correct value is a
+// function of which OTHER components are selected. Today covers the AWS VPC
+// topology knobs:
+//
+//   - cfg.AWSVPC.EnableNATGateway
+//   - cfg.AWSVPC.SingleNATGateway
+//   - cfg.AWSVPC.AZCount
+//
+// When no selected component needs private subnets, the three fields are
+// cleared. If every field of the AWSVPC sub-block ends up nil, the
+// sub-block pointer itself is cleared so json:",omitempty" hides it.
+//
+// Why both this AND StripOrphanConfig: AWSVPC is selected (the user keeps a
+// Public VPC) even when no DOWNSTREAM component needs private subnets. The
+// orphan strip cannot help — the VPC component itself is in scope. Cross-
+// component derive is the rule that catches "VPC stays, but its NAT-related
+// sub-fields no longer have a justification."
+//
+// Pure, idempotent.
+func DeriveCrossComponentFields(comps *Components, cfg *Config) {
+	if comps == nil || cfg == nil || cfg.AWSVPC == nil {
+		return
+	}
+	if !stackNeedsPrivateSubnets(comps) {
+		cfg.AWSVPC.EnableNATGateway = nil
+		cfg.AWSVPC.SingleNATGateway = nil
+		cfg.AWSVPC.AZCount = nil
+		if cfg.AWSVPC.EnableNATGateway == nil &&
+			cfg.AWSVPC.SingleNATGateway == nil &&
+			cfg.AWSVPC.AZCount == nil {
+			cfg.AWSVPC = nil
+		}
+	}
+}
+
+// isOrphanStrippableKey reports whether the given ComponentKey has a per-
+// component sub-block on Config that participates in the orphan strip. The
+// list mirrors the *struct sub-fields of Config with cloud-prefixed json
+// tags. Polymorphic preset keys (KeyAWSEKSNodeGroup / KeyAWSEKSControlPlane)
+// and pure non-config components (KeyAWSALB / KeyAWSGrafana / KeyAWSWAF /
+// KeySplunk / KeyDatadog / KeyGitHubActions etc.) are NOT in scope — there
+// is no cfg.<key> sub-block to strip.
+func isOrphanStrippableKey(key ComponentKey) bool {
+	switch key {
+	case KeyAWSEC2, KeyAWSEKS, KeyAWSECS, KeyAWSVPC,
+		KeyAWSCloudfront, KeyAWSRDS, KeyAWSElastiCache,
+		KeyAWSS3, KeyAWSDynamoDB, KeyAWSSQS, KeyAWSMSK,
+		KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
+		KeyAWSCognito, KeyAWSLambda, KeyAWSAPIGateway,
+		KeyAWSKMS, KeyAWSSecretsManager, KeyAWSOpenSearch,
+		KeyAWSBedrock, KeyAWSBackups,
+		KeyGCPCompute, KeyGCPGKE, KeyGCPCloudRun,
+		KeyGCPCloudFunctions, KeyGCPLoadbalancer,
+		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,
+		KeyGCPPubSub, KeyGCPCloudLogging,
+		KeyGCPIdentityPlatform, KeyGCPAPIGateway, KeyGCPBackups:
+		return true
+	}
+	return false
+}

--- a/pkg/composer/coherence_test.go
+++ b/pkg/composer/coherence_test.go
@@ -1,0 +1,623 @@
+package composer
+
+// coherence_test.go locks the (Components, Config) coherence rules upstream.
+// Ports the pure-function regression suite that originated in
+// luthersystems/reliable's chatv2 + agentapi packages (#1435) so the same
+// invariant cannot regress on either side.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func intPtr(i int) *int { return &i }
+
+// awsVPCSubFields mirrors the anonymous struct shape on Config.AWSVPC.
+// Mirrors the literal used in mapper_test.go's cfgWithAWSVPC helper.
+func cfgWithVPCSubBlock(single, enable *bool, az *int) *Config {
+	c := &Config{}
+	c.AWSVPC = &struct {
+		SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+		EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+		AZCount          *int  `json:"azCount,omitempty"`
+	}{SingleNATGateway: single, EnableNATGateway: enable, AZCount: az}
+	return c
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// ComponentSelected
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestComponentSelected_StringFields(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, ComponentSelected(&Components{}, KeyAWSVPC))
+	assert.True(t, ComponentSelected(&Components{AWSVPC: "Public VPC"}, KeyAWSVPC))
+
+	assert.False(t, ComponentSelected(&Components{}, KeyAWSEC2))
+	assert.True(t, ComponentSelected(&Components{AWSEC2: "Intel"}, KeyAWSEC2))
+
+	assert.False(t, ComponentSelected(&Components{}, KeyGCPCompute))
+	assert.True(t, ComponentSelected(&Components{GCPCompute: "n2-standard-2"}, KeyGCPCompute))
+}
+
+func TestComponentSelected_PointerFields_RequireTrue(t *testing.T) {
+	t.Parallel()
+
+	// nil pointer → not selected.
+	assert.False(t, ComponentSelected(&Components{}, KeyAWSOpenSearch))
+
+	// explicit &false → not selected (so cfg.AWSOpenSearch is stripped).
+	assert.False(t, ComponentSelected(&Components{AWSOpenSearch: boolPtr(false)}, KeyAWSOpenSearch),
+		"explicit &false must be treated as deselected so its config sub-block is stripped")
+
+	// &true → selected.
+	assert.True(t, ComponentSelected(&Components{AWSOpenSearch: boolPtr(true)}, KeyAWSOpenSearch))
+}
+
+func TestComponentSelected_BackupsPointer_NonNilEqualsSelected(t *testing.T) {
+	t.Parallel()
+
+	// AWSBackups is a *struct{...}; its presence alone signals selection.
+	c := &Components{}
+	assert.False(t, ComponentSelected(c, KeyAWSBackups))
+
+	c.AWSBackups = &struct {
+		EC2         *bool `json:"aws_ec2,omitempty"`
+		RDS         *bool `json:"aws_rds,omitempty"`
+		ElastiCache *bool `json:"aws_elasticache,omitempty"`
+		DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+		S3          *bool `json:"aws_s3,omitempty"`
+	}{}
+	assert.True(t, ComponentSelected(c, KeyAWSBackups))
+}
+
+func TestComponentSelected_NilComponents_AlwaysFalse(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range []ComponentKey{
+		KeyAWSVPC, KeyAWSEC2, KeyAWSOpenSearch, KeyGCPCompute, KeyGCPBackups,
+	} {
+		assert.False(t, ComponentSelected(nil, key), "nil components must report not-selected for %s", key)
+	}
+}
+
+func TestComponentSelected_PolymorphicAndNonConfigKeys_AlwaysFalse(t *testing.T) {
+	t.Parallel()
+
+	// Polymorphic preset keys (KeyAWSEKSNodeGroup / KeyAWSEKSControlPlane)
+	// don't map to a Components field — selection is encoded by AWSEKS +
+	// AWSLambda. ComponentSelected must NOT report them as a standalone
+	// selection (downstream code would treat them as orphan-strippable and
+	// misbehave).
+	c := &Components{AWSEKS: boolPtr(true), AWSLambda: boolPtr(true)}
+	assert.False(t, ComponentSelected(c, KeyAWSEKSNodeGroup))
+	assert.False(t, ComponentSelected(c, KeyAWSEKSControlPlane))
+
+	// KeyComposer / KeyArch / KeyCloud are meta-keys, not components.
+	assert.False(t, ComponentSelected(c, KeyComposer))
+	assert.False(t, ComponentSelected(c, KeyArch))
+	assert.False(t, ComponentSelected(c, KeyCloud))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// StackNeedsPrivateSubnets — exported wrapper around the mapper helper.
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestStackNeedsPrivateSubnets_Exported(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, StackNeedsPrivateSubnets(nil))
+	assert.False(t, StackNeedsPrivateSubnets(&Components{}))
+
+	for _, c := range []*Components{
+		{AWSEKS: boolPtr(true)},
+		{AWSECS: boolPtr(true)},
+		{AWSRDS: boolPtr(true)},
+		{AWSElastiCache: boolPtr(true)},
+		{AWSOpenSearch: boolPtr(true)},
+		{AWSEC2: "Intel"},
+		{AWSEC2: "ARM"},
+	} {
+		assert.True(t, StackNeedsPrivateSubnets(c), "%+v should need private subnets", c)
+	}
+
+	// Components that DON'T need private subnets:
+	assert.False(t, StackNeedsPrivateSubnets(&Components{AWSLambda: boolPtr(true)}))
+	assert.False(t, StackNeedsPrivateSubnets(&Components{AWSS3: boolPtr(true), AWSKMS: boolPtr(true)}))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// StripOrphanConfig
+// ──────────────────────────────────────────────────────────────────────────
+
+// TestStripOrphanConfig_ClearsUnselectedSubBlocks ports the failure shape
+// from sess_v2_CnqUJ6NRJnLC: a config.aws_opensearch sub-block survives
+// after aws_opensearch is removed from components. Strip must clear it.
+func TestStripOrphanConfig_ClearsUnselectedSubBlocks(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Cloud: "AWS",
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production", InstanceType: "m6g.large"},
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Runtime: "nodejs20.x", Timeout: "30s"},
+	}
+	comps := &Components{
+		Cloud:     "AWS",
+		AWSVPC:    "Public VPC",
+		AWSLambda: boolPtr(true),
+		// AWSOpenSearch intentionally omitted.
+	}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSOpenSearch, "orphan opensearch sub-block must be cleared")
+	assert.NotNil(t, cfg.AWSLambda, "selected Lambda sub-block must survive")
+	assert.Equal(t, "nodejs20.x", cfg.AWSLambda.Runtime, "user values on selected components must survive")
+}
+
+// TestStripOrphanConfig_EmptyAllocatedSubBlockIsOrphan locks the "non-nil-
+// but-empty" rule: an &AWSOpenSearch{} sub-block (no actual configuration)
+// must NOT be a signal that opensearch is selected. The Components blob is
+// the canonical selection witness.
+func TestStripOrphanConfig_EmptyAllocatedSubBlockIsOrphan(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{}, // allocated but empty
+	}
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC"}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSOpenSearch,
+		"an allocated-but-empty sub-block must be treated as orphan when its component is unselected")
+}
+
+// TestStripOrphanConfig_ExplicitFalsePointerStripsConfig captures the
+// "explicit aws_opensearch=false" case: the user (or a downstream rule)
+// signalled deselection by writing &false to the components blob. The
+// config sub-block must be cleared.
+func TestStripOrphanConfig_ExplicitFalsePointerStripsConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production"},
+	}
+	comps := &Components{
+		Cloud:         "AWS",
+		AWSVPC:        "Public VPC",
+		AWSOpenSearch: boolPtr(false), // explicit deselection
+	}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSOpenSearch,
+		"AWSOpenSearch=&false must trigger strip — explicit deselection is still deselection")
+}
+
+// TestStripOrphanConfig_LeavesNonStrippableUntouched checks that fields
+// outside the orphan-strippable set (Region, Cloud, EstimatedMonthlyRequests)
+// survive the strip even when other components are missing.
+func TestStripOrphanConfig_LeavesNonStrippableUntouched(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Cloud:                    "AWS",
+		Region:                   "us-east-2",
+		EstimatedMonthlyRequests: 100_000,
+		EstimatedAvgDurationMs:   250,
+	}
+	comps := &Components{Cloud: "AWS"} // nothing selected
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Equal(t, "AWS", cfg.Cloud)
+	assert.Equal(t, "us-east-2", cfg.Region)
+	assert.Equal(t, int64(100_000), cfg.EstimatedMonthlyRequests)
+	assert.Equal(t, 250, cfg.EstimatedAvgDurationMs)
+}
+
+// TestStripOrphanConfig_AWSBackupsRespectsSelection ports the
+// Components.AWSBackups != nil convention: when AWSBackups is selected, the
+// cfg.AWSBackups sub-block must survive even if some inner backup configs
+// are zero.
+func TestStripOrphanConfig_AWSBackupsRespectsSelection(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSBackups: &struct {
+			EC2 *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_ec2,omitempty"`
+			RDS *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_rds,omitempty"`
+			ElastiCache *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_elasticache,omitempty"`
+			DynamoDB *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_dynamodb,omitempty"`
+			S3 *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_s3,omitempty"`
+		}{},
+	}
+	comps := &Components{
+		Cloud: "AWS",
+		AWSBackups: &struct {
+			EC2         *bool `json:"aws_ec2,omitempty"`
+			RDS         *bool `json:"aws_rds,omitempty"`
+			ElastiCache *bool `json:"aws_elasticache,omitempty"`
+			DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+			S3          *bool `json:"aws_s3,omitempty"`
+		}{S3: boolPtr(true)},
+	}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.NotNil(t, cfg.AWSBackups, "cfg.AWSBackups must survive when comps.AWSBackups is non-nil")
+}
+
+// TestStripOrphanConfig_AWSBackupsCleared captures the orphan path: comps
+// has no AWSBackups, so cfg.AWSBackups is stripped.
+func TestStripOrphanConfig_AWSBackupsCleared(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSBackups: &struct {
+			EC2 *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_ec2,omitempty"`
+			RDS *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_rds,omitempty"`
+			ElastiCache *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_elasticache,omitempty"`
+			DynamoDB *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_dynamodb,omitempty"`
+			S3 *struct {
+				FrequencyHours int    `json:"frequencyHours,omitempty"`
+				RetentionDays  int    `json:"retentionDays,omitempty"`
+				Region         string `json:"region,omitempty"`
+			} `json:"aws_s3,omitempty"`
+		}{},
+	}
+	comps := &Components{Cloud: "AWS"} // no AWSBackups
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSBackups, "orphan AWSBackups sub-block must be cleared when comps.AWSBackups is nil")
+}
+
+// TestStripOrphanConfig_CrossCloudResidual locks the rule that a switch to
+// the opposite cloud strips the previous cloud's sub-blocks. Mirrors the
+// reliable-side TestUnion_Issue1435_OrphanConfig_CrossCloudResidual.
+func TestStripOrphanConfig_CrossCloudResidual(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Cloud: "GCP",
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Runtime: "nodejs20.x"},
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{},
+		GCPCloudRun: &struct {
+			Memory       string `json:"memory,omitempty"`
+			CPU          string `json:"cpu,omitempty"`
+			MinInstances *int   `json:"minInstances,omitempty"`
+			MaxInstances *int   `json:"maxInstances,omitempty"`
+		}{Memory: "512Mi"},
+	}
+	comps := &Components{
+		Cloud:       "GCP",
+		GCPVPC:      boolPtr(true),
+		GCPCloudRun: boolPtr(true),
+	}
+
+	StripOrphanConfig(comps, cfg)
+
+	assert.Nil(t, cfg.AWSLambda, "AWS Lambda sub-block must be stripped on a GCP stack")
+	assert.Nil(t, cfg.AWSOpenSearch, "AWS OpenSearch sub-block must be stripped on a GCP stack")
+	assert.NotNil(t, cfg.GCPCloudRun, "GCP Cloud Run sub-block must survive when selected")
+	assert.Equal(t, "512Mi", cfg.GCPCloudRun.Memory)
+}
+
+// TestStripOrphanConfig_Idempotent guards against a future "smart" rewrite
+// that drifts on repeat calls.
+func TestStripOrphanConfig_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production"},
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Runtime: "nodejs20.x"},
+	}
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+
+	StripOrphanConfig(comps, cfg)
+	first, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	StripOrphanConfig(comps, cfg)
+	second, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second))
+}
+
+func TestStripOrphanConfig_NilInputs_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() { StripOrphanConfig(nil, &Config{}) })
+	assert.NotPanics(t, func() { StripOrphanConfig(&Components{}, nil) })
+	assert.NotPanics(t, func() { StripOrphanConfig(nil, nil) })
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// DeriveCrossComponentFields
+// ──────────────────────────────────────────────────────────────────────────
+
+// TestDeriveCrossComponentFields_NoPrivateSubnets_ClearsNAT pins the actual
+// production failure mode from sess_v2_CnqUJ6NRJnLC: a leftover
+// EnableNATGateway=&true on a Public-VPC stack with no NAT-needing
+// components must be cleared. If every AWSVPC field is cleared, the
+// sub-block pointer itself is cleared so json:",omitempty" hides it.
+func TestDeriveCrossComponentFields_NoPrivateSubnets_ClearsNAT(t *testing.T) {
+	t.Parallel()
+
+	cfg := cfgWithVPCSubBlock(boolPtr(true), boolPtr(true), intPtr(2))
+	comps := &Components{
+		Cloud:     "AWS",
+		AWSVPC:    "Public VPC",
+		AWSLambda: boolPtr(true),
+		AWSS3:     boolPtr(true),
+		// No EKS/ECS/RDS/ElastiCache/OpenSearch/EC2.
+	}
+
+	DeriveCrossComponentFields(comps, cfg)
+
+	assert.Nil(t, cfg.AWSVPC,
+		"NAT-related fields all cleared → AWSVPC sub-block pointer cleared too")
+}
+
+// TestDeriveCrossComponentFields_NeedsPrivateSubnets_Preserves locks the
+// non-clobber rule: when the stack DOES need private subnets, the user's
+// AWSVPC settings must survive untouched.
+func TestDeriveCrossComponentFields_NeedsPrivateSubnets_Preserves(t *testing.T) {
+	t.Parallel()
+
+	cfg := cfgWithVPCSubBlock(boolPtr(false), boolPtr(true), intPtr(3))
+	comps := &Components{
+		Cloud:     "AWS",
+		AWSVPC:    "Private VPC",
+		AWSEKS:    boolPtr(true),
+		AWSLambda: boolPtr(true),
+	}
+
+	DeriveCrossComponentFields(comps, cfg)
+
+	require.NotNil(t, cfg.AWSVPC)
+	require.NotNil(t, cfg.AWSVPC.EnableNATGateway)
+	assert.True(t, *cfg.AWSVPC.EnableNATGateway, "NAT must survive when EKS is selected")
+	require.NotNil(t, cfg.AWSVPC.AZCount)
+	assert.Equal(t, 3, *cfg.AWSVPC.AZCount, "AZCount must survive when stack needs private subnets")
+}
+
+// TestDeriveCrossComponentFields_ClearsAllNATFields covers each of the
+// three AWSVPC topology knobs in isolation.
+func TestDeriveCrossComponentFields_ClearsAllNATFields(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		build func() *Config
+	}{
+		{
+			"only_SingleNATGateway",
+			func() *Config { return cfgWithVPCSubBlock(boolPtr(true), nil, nil) },
+		},
+		{
+			"only_EnableNATGateway",
+			func() *Config { return cfgWithVPCSubBlock(nil, boolPtr(true), nil) },
+		},
+		{
+			"only_AZCount",
+			func() *Config { return cfgWithVPCSubBlock(nil, nil, intPtr(3)) },
+		},
+	}
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.build()
+			DeriveCrossComponentFields(comps, cfg)
+			assert.Nil(t, cfg.AWSVPC, "AWSVPC must be nil after all fields cleared")
+		})
+	}
+}
+
+// TestDeriveCrossComponentFields_Idempotent locks no-drift on stable inputs.
+func TestDeriveCrossComponentFields_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	cfg := cfgWithVPCSubBlock(boolPtr(true), boolPtr(true), intPtr(2))
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+
+	DeriveCrossComponentFields(comps, cfg)
+	first, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	DeriveCrossComponentFields(comps, cfg)
+	second, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second))
+}
+
+func TestDeriveCrossComponentFields_NilInputs_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() { DeriveCrossComponentFields(nil, &Config{}) })
+	assert.NotPanics(t, func() { DeriveCrossComponentFields(&Components{}, nil) })
+	assert.NotPanics(t, func() { DeriveCrossComponentFields(&Components{}, &Config{}) })
+	assert.NotPanics(t, func() { DeriveCrossComponentFields(nil, nil) })
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Composition with ApplyPresetDefaults — the production pipeline shape.
+// ──────────────────────────────────────────────────────────────────────────
+
+// TestCoherence_PipelineWithApplyPresetDefaults mirrors the wrapper sequence
+// used in luthersystems/reliable's persistence path:
+//
+//	StripOrphanConfig → DeriveCrossComponentFields → ApplyPresetDefaults →
+//	DeriveCrossComponentFields
+//
+// Inputs: stale NAT=&true from a prior turn on a now-Public-VPC stack that
+// no longer needs private subnets. Expected: NAT is off (or cleared) and
+// orphan sub-blocks for unselected components are gone.
+func TestCoherence_PipelineWithApplyPresetDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Cloud: "AWS",
+		AWSVPC: &struct {
+			SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+			EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+			AZCount          *int  `json:"azCount,omitempty"`
+		}{
+			SingleNATGateway: boolPtr(true),
+			EnableNATGateway: boolPtr(true),
+			AZCount:          intPtr(2),
+		},
+		// Orphan opensearch sub-block from when it WAS in the stack:
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production"},
+	}
+	comps := &Components{
+		Cloud:             "AWS",
+		Architecture:      "Serverless",
+		AWSVPC:            "Public VPC",
+		AWSLambda:         boolPtr(true),
+		AWSS3:             boolPtr(true),
+		AWSKMS:            boolPtr(true),
+		AWSSecretsManager: boolPtr(true),
+		AWSCloudWatchLogs: boolPtr(true),
+	}
+	selected := []ComponentKey{
+		KeyAWSVPC, KeyAWSLambda, KeyAWSS3, KeyAWSKMS,
+		KeyAWSSecretsManager, KeyAWSCloudWatchLogs,
+	}
+
+	// Pipeline: strip → derive → ApplyPresetDefaults → derive.
+	StripOrphanConfig(comps, cfg)
+	DeriveCrossComponentFields(comps, cfg)
+	require.NoError(t, New().ApplyPresetDefaults(cfg, comps, selected))
+	DeriveCrossComponentFields(comps, cfg)
+
+	assert.Nil(t, cfg.AWSOpenSearch, "orphan opensearch must be gone")
+
+	// Either AWSVPC stays nil or its NAT fields are not true. Both are
+	// acceptable outcomes — what we cannot tolerate is NAT=&true on a stack
+	// that doesn't need private subnets.
+	if cfg.AWSVPC != nil && cfg.AWSVPC.EnableNATGateway != nil {
+		assert.False(t, *cfg.AWSVPC.EnableNATGateway,
+			"#1435: NAT must be off on a Public-VPC stack with no private-subnet-needing components")
+	}
+	if cfg.AWSVPC != nil && cfg.AWSVPC.SingleNATGateway != nil {
+		assert.False(t, *cfg.AWSVPC.SingleNATGateway,
+			"#1435: SingleNATGateway must be off on a Public-VPC stack with no private-subnet-needing components")
+	}
+}
+
+// TestCoherence_PipelineSurvivesUserSetFields locks the guardrail: the
+// pipeline must NOT clobber user-set values on SELECTED components. Mirrors
+// reliable's TestApplyPresetDefaults_Issue1435_UserSetFieldNotOverwritten.
+func TestCoherence_PipelineSurvivesUserSetFields(t *testing.T) {
+	t.Parallel()
+
+	userTimeout := "120s"
+	userMem := "2048"
+	cfg := &Config{
+		Cloud: "AWS",
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Timeout: userTimeout, MemorySize: userMem},
+	}
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+	selected := []ComponentKey{KeyAWSVPC, KeyAWSLambda}
+
+	StripOrphanConfig(comps, cfg)
+	DeriveCrossComponentFields(comps, cfg)
+	require.NoError(t, New().ApplyPresetDefaults(cfg, comps, selected))
+	DeriveCrossComponentFields(comps, cfg)
+
+	require.NotNil(t, cfg.AWSLambda)
+	assert.Equal(t, userTimeout, cfg.AWSLambda.Timeout)
+	assert.Equal(t, userMem, cfg.AWSLambda.MemorySize)
+}

--- a/pkg/composer/pricing.go
+++ b/pkg/composer/pricing.go
@@ -1,0 +1,589 @@
+package composer
+
+// pricing.go owns the canonical PricingData / PricingItem / *PricingBackups
+// type family for cost estimates produced by the cost-LLM and persisted by
+// reliable. Migrated from reliable per luthersystems/reliable#1437 PR-3 so the
+// merge-side rules (carry-forward, repriceSet, phantom-strip, gap-surface)
+// can live next to the types they manipulate and the (Components, Config)
+// coherence rules they cooperate with (pkg/composer/coherence.go).
+//
+// Two things to know:
+//
+//   - `PricingData.GuidanceVersion` carries the `jsonschema:"-"` tag so the
+//     LLM JSON schema generator hides it from the model. The field is stamped
+//     server-side after pricing is computed and used to bust carry-forward
+//     when the pricing prompt or table generation changes.
+//   - The anonymous `PricingData.Components` sub-struct keeps BOTH the cloud-
+//     prefixed cloud-specific fields (aws_*, gcp_*) AND the legacy unprefixed
+//     fields. `PricingData.Normalize()` is the cross-cloud scrub + legacy-
+//     field sync that runs before any per-component merge — do not delete the
+//     legacy fields, they are a bridge for older snapshots.
+
+// PricingItem represents the pricing details for a single component or status.
+type PricingItem struct {
+	MonthlyUSD   *float64 `json:"monthlyUSD,omitempty"`
+	UnitPriceUSD *float64 `json:"unitPriceUSD,omitempty"`
+	Quantity     *float64 `json:"quantity,omitempty"`
+	Unit         string   `json:"unit,omitempty"`
+	Status       string   `json:"status,omitempty"` // "Included", "Excluded", "N/A"
+	Details      string   `json:"details,omitempty"`
+}
+
+// PricingBackups represents AWS backup pricing
+type PricingBackups struct {
+	EC2         *PricingItem `json:"aws_ec2,omitempty"`
+	Rds         *PricingItem `json:"aws_rds,omitempty"`
+	ElastiCache *PricingItem `json:"aws_elasticache,omitempty"`
+	DynamoDB    *PricingItem `json:"aws_dynamodb,omitempty"`
+	S3          *PricingItem `json:"aws_s3,omitempty"`
+}
+
+// GCPPricingBackups represents GCP backup pricing
+type GCPPricingBackups struct {
+	Compute  *PricingItem `json:"gcp_compute,omitempty"`
+	CloudSQL *PricingItem `json:"gcp_cloudsql,omitempty"`
+	GCS      *PricingItem `json:"gcp_gcs,omitempty"`
+}
+
+// PricingData represents the overall pricing structure, keyed by component.
+// Keys must strictly match the StackComponents structure.
+type PricingData struct {
+	Currency string `json:"currency,omitempty"`
+
+	// GuidanceVersion is stamped server-side after pricing is computed and is
+	// used to bust carry-forward caching when the pricing prompt/table changes.
+	// Hidden from the LLM JSON schema via jsonschema:"-" so the model cannot
+	// populate it.
+	GuidanceVersion string `json:"_guidance_version,omitempty" jsonschema:"-"`
+
+	// Components wraps all component-specific pricing
+	Components struct {
+		Architecture *PricingItem `json:"architecture,omitempty"`
+		Cloud        *PricingItem `json:"cloud,omitempty"`
+
+		// AWS Components
+		AWSVPC                  *PricingItem    `json:"aws_vpc,omitempty"`
+		AWSBastion              *PricingItem    `json:"aws_bastion,omitempty"`
+		AWSEC2                  *PricingItem    `json:"aws_ec2,omitempty"`
+		AWSEKS                  *PricingItem    `json:"aws_eks,omitempty"`
+		AWSECS                  *PricingItem    `json:"aws_ecs,omitempty"`
+		AWSLambda               *PricingItem    `json:"aws_lambda,omitempty"`
+		AWSALB                  *PricingItem    `json:"aws_alb,omitempty"`
+		AWSCloudFront           *PricingItem    `json:"aws_cloudfront,omitempty"`
+		AWSWAF                  *PricingItem    `json:"aws_waf,omitempty"`
+		AWSAPIGateway           *PricingItem    `json:"aws_apigateway,omitempty"`
+		AWSRDS                  *PricingItem    `json:"aws_rds,omitempty"`
+		AWSElastiCache          *PricingItem    `json:"aws_elasticache,omitempty"`
+		AWSDynamoDB             *PricingItem    `json:"aws_dynamodb,omitempty"`
+		AWSOpenSearch           *PricingItem    `json:"aws_opensearch,omitempty"`
+		AWSS3                   *PricingItem    `json:"aws_s3,omitempty"`
+		AWSKMS                  *PricingItem    `json:"aws_kms,omitempty"`
+		AWSSecretsManager       *PricingItem    `json:"aws_secretsmanager,omitempty"`
+		AWSBedrock              *PricingItem    `json:"aws_bedrock,omitempty"`
+		AWSSQS                  *PricingItem    `json:"aws_sqs,omitempty"`
+		AWSMSK                  *PricingItem    `json:"aws_msk,omitempty"`
+		AWSCloudWatchLogs       *PricingItem    `json:"aws_cloudwatch_logs,omitempty"`
+		AWSCloudWatchMonitoring *PricingItem    `json:"aws_cloudwatch_monitoring,omitempty"`
+		AWSGrafana              *PricingItem    `json:"aws_grafana,omitempty"`
+		AWSCognito              *PricingItem    `json:"aws_cognito,omitempty"`
+		AWSGitHubActions        *PricingItem    `json:"aws_github_actions,omitempty"`
+		AWSCodePipeline         *PricingItem    `json:"aws_codepipeline,omitempty"`
+		AWSBackups              *PricingBackups `json:"aws_backups,omitempty"`
+
+		// GCP Components
+		GCPVPC              *PricingItem       `json:"gcp_vpc,omitempty"`
+		GCPBastion          *PricingItem       `json:"gcp_bastion,omitempty"`
+		GCPCompute          *PricingItem       `json:"gcp_compute,omitempty"`
+		GCPGKE              *PricingItem       `json:"gcp_gke,omitempty"`
+		GCPCloudRun         *PricingItem       `json:"gcp_cloud_run,omitempty"`
+		GCPCloudFunctions   *PricingItem       `json:"gcp_cloud_functions,omitempty"`
+		GCPLoadbalancer     *PricingItem       `json:"gcp_loadbalancer,omitempty"`
+		GCPCloudArmor       *PricingItem       `json:"gcp_cloud_armor,omitempty"`
+		GCPAPIGateway       *PricingItem       `json:"gcp_api_gateway,omitempty"`
+		GCPCloudSQL         *PricingItem       `json:"gcp_cloudsql,omitempty"`
+		GCPMemorystore      *PricingItem       `json:"gcp_memorystore,omitempty"`
+		GCPFirestore        *PricingItem       `json:"gcp_firestore,omitempty"`
+		GCPGCS              *PricingItem       `json:"gcp_gcs,omitempty"`
+		GCPCloudKMS         *PricingItem       `json:"gcp_cloud_kms,omitempty"`
+		GCPSecretManager    *PricingItem       `json:"gcp_secret_manager,omitempty"`
+		GCPVertexAI         *PricingItem       `json:"gcp_vertex_ai,omitempty"`
+		GCPPubSub           *PricingItem       `json:"gcp_pubsub,omitempty"`
+		GCPCloudLogging     *PricingItem       `json:"gcp_cloud_logging,omitempty"`
+		GCPCloudMonitoring  *PricingItem       `json:"gcp_cloud_monitoring,omitempty"`
+		GCPIdentityPlatform *PricingItem       `json:"gcp_identity_platform,omitempty"`
+		GCPCloudBuild       *PricingItem       `json:"gcp_cloud_build,omitempty"`
+		GCPBackups          *GCPPricingBackups `json:"gcp_backups,omitempty"`
+
+		// External/Third-Party
+		Splunk        *PricingItem `json:"splunk,omitempty"`
+		Datadog       *PricingItem `json:"datadog,omitempty"`
+		GitHubActions *PricingItem `json:"githubactions,omitempty"`
+
+		// Legacy fields (backward compatibility)
+		EC2                  *PricingItem    `json:"ec2,omitempty"`
+		Resource             *PricingItem    `json:"resource,omitempty"`
+		VPC                  *PricingItem    `json:"vpc,omitempty"`
+		Bastion              *PricingItem    `json:"bastion,omitempty"`
+		ALB                  *PricingItem    `json:"alb,omitempty"`
+		CloudFront           *PricingItem    `json:"cloudfront,omitempty"`
+		WAF                  *PricingItem    `json:"waf,omitempty"`
+		Postgres             *PricingItem    `json:"postgres,omitempty"`
+		ElastiCache          *PricingItem    `json:"elasticache,omitempty"`
+		S3                   *PricingItem    `json:"s3,omitempty"`
+		DynamoDB             *PricingItem    `json:"dynamodb,omitempty"`
+		SQS                  *PricingItem    `json:"sqs,omitempty"`
+		MSK                  *PricingItem    `json:"msk,omitempty"`
+		CloudWatchLogs       *PricingItem    `json:"cloudwatchlogs,omitempty"`
+		CloudWatchMonitoring *PricingItem    `json:"cloudwatchmonitoring,omitempty"`
+		Grafana              *PricingItem    `json:"grafana,omitempty"`
+		Cognito              *PricingItem    `json:"cognito,omitempty"`
+		APIGateway           *PricingItem    `json:"apigateway,omitempty"`
+		KMS                  *PricingItem    `json:"kms,omitempty"`
+		SecretsManager       *PricingItem    `json:"secretsmanager,omitempty"`
+		OpenSearch           *PricingItem    `json:"opensearch,omitempty"`
+		Bedrock              *PricingItem    `json:"bedrock,omitempty"`
+		Lambda               *PricingItem    `json:"lambda,omitempty"`
+		CodePipeline         *PricingItem    `json:"codepipeline,omitempty"`
+		Backups              *PricingBackups `json:"backups,omitempty"`
+	} `json:"components,omitempty"`
+
+	SubtotalMonthlyUSD *float64 `json:"subtotalMonthlyUSD,omitempty"`
+}
+
+// Normalize syncs cloud-prefixed AWS fields and legacy fields for unified checking
+func (p *PricingData) Normalize() {
+	if p == nil {
+		return
+	}
+
+	c := &p.Components
+
+	// Determine cloud from components by checking which fields are present
+	cloud := ""
+	if c.GCPVPC != nil || c.GCPGKE != nil || c.GCPCloudSQL != nil || c.GCPCompute != nil || c.GCPCloudRun != nil {
+		cloud = "GCP"
+	} else if c.AWSVPC != nil || c.AWSEKS != nil || c.AWSRDS != nil || c.AWSEC2 != nil {
+		cloud = "AWS"
+	}
+
+	if cloud == "GCP" {
+		// Clear AWS specific pricing
+		c.AWSVPC = nil
+		c.AWSBastion = nil
+		c.AWSEC2 = nil
+		c.AWSEKS = nil
+		c.AWSECS = nil
+		c.AWSLambda = nil
+		c.AWSALB = nil
+		c.AWSCloudFront = nil
+		c.AWSWAF = nil
+		c.AWSAPIGateway = nil
+		c.AWSRDS = nil
+		c.AWSElastiCache = nil
+		c.AWSDynamoDB = nil
+		c.AWSOpenSearch = nil
+		c.AWSS3 = nil
+		c.AWSKMS = nil
+		c.AWSSecretsManager = nil
+		c.AWSBedrock = nil
+		c.AWSSQS = nil
+		c.AWSMSK = nil
+		c.AWSCloudWatchLogs = nil
+		c.AWSCloudWatchMonitoring = nil
+		c.AWSGrafana = nil
+		c.AWSCognito = nil
+		c.AWSGitHubActions = nil
+		c.AWSCodePipeline = nil
+		c.AWSBackups = nil
+
+		// Sync legacy and cloud-specific fields for GCP
+		// Sync VPC
+		if c.GCPVPC != nil && c.VPC == nil {
+			c.VPC = c.GCPVPC
+		} else if c.VPC != nil && c.GCPVPC == nil {
+			c.GCPVPC = c.VPC
+		}
+
+		// Sync Bastion
+		if c.GCPBastion != nil && c.Bastion == nil {
+			c.Bastion = c.GCPBastion
+		} else if c.Bastion != nil && c.GCPBastion == nil {
+			c.GCPBastion = c.Bastion
+		}
+
+		// Sync Compute -> EC2
+		if c.GCPCompute != nil && c.EC2 == nil {
+			c.EC2 = c.GCPCompute
+		} else if c.EC2 != nil && c.GCPCompute == nil {
+			c.GCPCompute = c.EC2
+		}
+
+		// Sync GKE/CloudRun -> Resource
+		if (c.GCPGKE != nil || c.GCPCloudRun != nil) && c.Resource == nil {
+			if c.GCPGKE != nil {
+				c.Resource = c.GCPGKE
+			} else {
+				c.Resource = c.GCPCloudRun
+			}
+		} else if c.Resource != nil && c.GCPGKE == nil && c.GCPCloudRun == nil {
+			c.GCPGKE = c.Resource
+		}
+
+		// Sync CloudSQL -> Postgres
+		if c.GCPCloudSQL != nil && c.Postgres == nil {
+			c.Postgres = c.GCPCloudSQL
+		} else if c.Postgres != nil && c.GCPCloudSQL == nil {
+			c.GCPCloudSQL = c.Postgres
+		}
+
+		// Sync Memorystore -> ElastiCache
+		if c.GCPMemorystore != nil && c.ElastiCache == nil {
+			c.ElastiCache = c.GCPMemorystore
+		} else if c.ElastiCache != nil && c.GCPMemorystore == nil {
+			c.GCPMemorystore = c.ElastiCache
+		}
+
+		// Sync GCS -> S3
+		if c.GCPGCS != nil && c.S3 == nil {
+			c.S3 = c.GCPGCS
+		} else if c.S3 != nil && c.GCPGCS == nil {
+			c.GCPGCS = c.S3
+		}
+
+		// Sync Loadbalancer -> ALB
+		if c.GCPLoadbalancer != nil && c.ALB == nil {
+			c.ALB = c.GCPLoadbalancer
+		} else if c.ALB != nil && c.GCPLoadbalancer == nil {
+			c.GCPLoadbalancer = c.ALB
+		}
+
+		// (CloudCDN/CloudFront sync removed: GCPCloudCDN field deleted with
+		// upstream preset removal in insideout-terraform-presets v0.10.0.)
+
+		// Sync CloudArmor -> WAF
+		if c.GCPCloudArmor != nil && c.WAF == nil {
+			c.WAF = c.GCPCloudArmor
+		} else if c.WAF != nil && c.GCPCloudArmor == nil {
+			c.GCPCloudArmor = c.WAF
+		}
+
+		// Sync PubSub -> SQS
+		if c.GCPPubSub != nil && c.SQS == nil {
+			c.SQS = c.GCPPubSub
+		} else if c.SQS != nil && c.GCPPubSub == nil {
+			c.GCPPubSub = c.SQS
+		}
+
+		// Sync CloudLogging -> CloudWatchLogs
+		if c.GCPCloudLogging != nil && c.CloudWatchLogs == nil {
+			c.CloudWatchLogs = c.GCPCloudLogging
+		} else if c.CloudWatchLogs != nil && c.GCPCloudLogging == nil {
+			c.GCPCloudLogging = c.CloudWatchLogs
+		}
+
+		// Sync CloudMonitoring -> CloudWatchMonitoring
+		if c.GCPCloudMonitoring != nil && c.CloudWatchMonitoring == nil {
+			c.CloudWatchMonitoring = c.GCPCloudMonitoring
+		} else if c.CloudWatchMonitoring != nil && c.GCPCloudMonitoring == nil {
+			c.GCPCloudMonitoring = c.CloudWatchMonitoring
+		}
+
+		// Sync IdentityPlatform -> Cognito
+		if c.GCPIdentityPlatform != nil && c.Cognito == nil {
+			c.Cognito = c.GCPIdentityPlatform
+		} else if c.Cognito != nil && c.GCPIdentityPlatform == nil {
+			c.GCPIdentityPlatform = c.Cognito
+		}
+
+		// Sync CloudBuild -> CodePipeline
+		if c.GCPCloudBuild != nil && c.CodePipeline == nil {
+			c.CodePipeline = c.GCPCloudBuild
+		} else if c.CodePipeline != nil && c.GCPCloudBuild == nil {
+			c.GCPCloudBuild = c.CodePipeline
+		}
+
+		// Sync SecretManager -> SecretsManager
+		if c.GCPSecretManager != nil && c.SecretsManager == nil {
+			c.SecretsManager = c.GCPSecretManager
+		} else if c.SecretsManager != nil && c.GCPSecretManager == nil {
+			c.GCPSecretManager = c.SecretsManager
+		}
+
+		// Sync CloudKMS -> KMS
+		if c.GCPCloudKMS != nil && c.KMS == nil {
+			c.KMS = c.GCPCloudKMS
+		} else if c.KMS != nil && c.GCPCloudKMS == nil {
+			c.GCPCloudKMS = c.KMS
+		}
+
+		// Sync APIGateway
+		if c.GCPAPIGateway != nil && c.APIGateway == nil {
+			c.APIGateway = c.GCPAPIGateway
+		} else if c.APIGateway != nil && c.GCPAPIGateway == nil {
+			c.GCPAPIGateway = c.APIGateway
+		}
+
+		// Sync VertexAI -> Bedrock
+		if c.GCPVertexAI != nil && c.Bedrock == nil {
+			c.Bedrock = c.GCPVertexAI
+		} else if c.Bedrock != nil && c.GCPVertexAI == nil {
+			c.GCPVertexAI = c.Bedrock
+		}
+
+		// Sync Backups
+		if c.GCPBackups != nil && c.Backups == nil {
+			c.Backups = &PricingBackups{
+				EC2: c.GCPBackups.Compute,
+				Rds: c.GCPBackups.CloudSQL,
+				S3:  c.GCPBackups.GCS,
+			}
+		} else if c.Backups != nil && c.GCPBackups == nil {
+			c.GCPBackups = &GCPPricingBackups{
+				Compute:  c.Backups.EC2,
+				CloudSQL: c.Backups.Rds,
+				GCS:      c.Backups.S3,
+			}
+		}
+	} else {
+		// Default to AWS (or cloud is explicitly AWS)
+		// Clear GCP specific pricing
+		c.GCPVPC = nil
+		c.GCPBastion = nil
+		c.GCPCompute = nil
+		c.GCPGKE = nil
+		c.GCPCloudRun = nil
+		c.GCPCloudFunctions = nil
+		c.GCPLoadbalancer = nil
+		c.GCPCloudArmor = nil
+		c.GCPAPIGateway = nil
+		c.GCPCloudSQL = nil
+		c.GCPMemorystore = nil
+		c.GCPFirestore = nil
+		c.GCPGCS = nil
+		c.GCPCloudKMS = nil
+		c.GCPSecretManager = nil
+		c.GCPVertexAI = nil
+		c.GCPPubSub = nil
+		c.GCPCloudLogging = nil
+		c.GCPCloudMonitoring = nil
+		c.GCPIdentityPlatform = nil
+		c.GCPCloudBuild = nil
+		c.GCPBackups = nil
+
+		// Sync legacy and cloud-specific fields for AWS
+		// Sync VPC
+		if c.AWSVPC != nil && c.VPC == nil {
+			c.VPC = c.AWSVPC
+		} else if c.VPC != nil && c.AWSVPC == nil {
+			c.AWSVPC = c.VPC
+		}
+
+		// Sync Bastion
+		if c.AWSBastion != nil && c.Bastion == nil {
+			c.Bastion = c.AWSBastion
+		} else if c.Bastion != nil && c.AWSBastion == nil {
+			c.AWSBastion = c.Bastion
+		}
+
+		// Sync EC2
+		if c.AWSEC2 != nil && c.EC2 == nil {
+			c.EC2 = c.AWSEC2
+		} else if c.EC2 != nil && c.AWSEC2 == nil {
+			c.AWSEC2 = c.EC2
+		}
+
+		// Sync EKS/ECS -> Resource
+		if (c.AWSEKS != nil || c.AWSECS != nil) && c.Resource == nil {
+			if c.AWSEKS != nil {
+				c.Resource = c.AWSEKS
+			} else {
+				c.Resource = c.AWSECS
+			}
+		} else if c.Resource != nil && c.AWSEKS == nil && c.AWSECS == nil {
+			c.AWSEKS = c.Resource
+		}
+
+		// Sync Lambda
+		if c.AWSLambda != nil && c.Lambda == nil {
+			c.Lambda = c.AWSLambda
+		} else if c.Lambda != nil && c.AWSLambda == nil {
+			c.AWSLambda = c.Lambda
+		}
+
+		// Sync ALB
+		if c.AWSALB != nil && c.ALB == nil {
+			c.ALB = c.AWSALB
+		} else if c.ALB != nil && c.AWSALB == nil {
+			c.AWSALB = c.ALB
+		}
+
+		// Sync CloudFront
+		if c.AWSCloudFront != nil && c.CloudFront == nil {
+			c.CloudFront = c.AWSCloudFront
+		} else if c.CloudFront != nil && c.AWSCloudFront == nil {
+			c.AWSCloudFront = c.CloudFront
+		}
+
+		// Sync WAF
+		if c.AWSWAF != nil && c.WAF == nil {
+			c.WAF = c.AWSWAF
+		} else if c.WAF != nil && c.AWSWAF == nil {
+			c.AWSWAF = c.WAF
+		}
+
+		// Sync APIGateway
+		if c.AWSAPIGateway != nil && c.APIGateway == nil {
+			c.APIGateway = c.AWSAPIGateway
+		} else if c.APIGateway != nil && c.AWSAPIGateway == nil {
+			c.AWSAPIGateway = c.APIGateway
+		}
+
+		// Sync RDS -> Postgres
+		if c.AWSRDS != nil && c.Postgres == nil {
+			c.Postgres = c.AWSRDS
+		} else if c.Postgres != nil && c.AWSRDS == nil {
+			c.AWSRDS = c.Postgres
+		}
+
+		// Sync ElastiCache
+		if c.AWSElastiCache != nil && c.ElastiCache == nil {
+			c.ElastiCache = c.AWSElastiCache
+		} else if c.ElastiCache != nil && c.AWSElastiCache == nil {
+			c.AWSElastiCache = c.ElastiCache
+		}
+
+		// Sync DynamoDB
+		if c.AWSDynamoDB != nil && c.DynamoDB == nil {
+			c.DynamoDB = c.AWSDynamoDB
+		} else if c.DynamoDB != nil && c.AWSDynamoDB == nil {
+			c.AWSDynamoDB = c.DynamoDB
+		}
+
+		// Sync OpenSearch
+		if c.AWSOpenSearch != nil && c.OpenSearch == nil {
+			c.OpenSearch = c.AWSOpenSearch
+		} else if c.OpenSearch != nil && c.AWSOpenSearch == nil {
+			c.AWSOpenSearch = c.OpenSearch
+		}
+
+		// Sync S3
+		if c.AWSS3 != nil && c.S3 == nil {
+			c.S3 = c.AWSS3
+		} else if c.S3 != nil && c.AWSS3 == nil {
+			c.AWSS3 = c.S3
+		}
+
+		// Sync KMS
+		if c.AWSKMS != nil && c.KMS == nil {
+			c.KMS = c.AWSKMS
+		} else if c.KMS != nil && c.AWSKMS == nil {
+			c.AWSKMS = c.KMS
+		}
+
+		// Sync SecretsManager
+		if c.AWSSecretsManager != nil && c.SecretsManager == nil {
+			c.SecretsManager = c.AWSSecretsManager
+		} else if c.SecretsManager != nil && c.AWSSecretsManager == nil {
+			c.AWSSecretsManager = c.SecretsManager
+		}
+
+		// Sync Bedrock
+		if c.AWSBedrock != nil && c.Bedrock == nil {
+			c.Bedrock = c.AWSBedrock
+		} else if c.Bedrock != nil && c.AWSBedrock == nil {
+			c.AWSBedrock = c.Bedrock
+		}
+
+		// Sync SQS
+		if c.AWSSQS != nil && c.SQS == nil {
+			c.SQS = c.AWSSQS
+		} else if c.SQS != nil && c.AWSSQS == nil {
+			c.AWSSQS = c.SQS
+		}
+
+		// Sync MSK
+		if c.AWSMSK != nil && c.MSK == nil {
+			c.MSK = c.AWSMSK
+		} else if c.MSK != nil && c.AWSMSK == nil {
+			c.AWSMSK = c.MSK
+		}
+
+		// Sync CloudWatchLogs
+		if c.AWSCloudWatchLogs != nil && c.CloudWatchLogs == nil {
+			c.CloudWatchLogs = c.AWSCloudWatchLogs
+		} else if c.CloudWatchLogs != nil && c.AWSCloudWatchLogs == nil {
+			c.AWSCloudWatchLogs = c.CloudWatchLogs
+		}
+
+		// Sync CloudWatchMonitoring
+		if c.AWSCloudWatchMonitoring != nil && c.CloudWatchMonitoring == nil {
+			c.CloudWatchMonitoring = c.AWSCloudWatchMonitoring
+		} else if c.CloudWatchMonitoring != nil && c.AWSCloudWatchMonitoring == nil {
+			c.AWSCloudWatchMonitoring = c.CloudWatchMonitoring
+		}
+
+		// Sync Grafana
+		if c.AWSGrafana != nil && c.Grafana == nil {
+			c.Grafana = c.AWSGrafana
+		} else if c.Grafana != nil && c.AWSGrafana == nil {
+			c.AWSGrafana = c.Grafana
+		}
+
+		// Sync Cognito
+		if c.AWSCognito != nil && c.Cognito == nil {
+			c.Cognito = c.AWSCognito
+		} else if c.Cognito != nil && c.AWSCognito == nil {
+			c.AWSCognito = c.Cognito
+		}
+
+		// Sync GitHubActions
+		if c.AWSGitHubActions != nil && c.GitHubActions == nil {
+			c.GitHubActions = c.AWSGitHubActions
+		} else if c.GitHubActions != nil && c.AWSGitHubActions == nil {
+			c.AWSGitHubActions = c.GitHubActions
+		}
+
+		// Sync CodePipeline
+		if c.AWSCodePipeline != nil && c.CodePipeline == nil {
+			c.CodePipeline = c.AWSCodePipeline
+		} else if c.CodePipeline != nil && c.AWSCodePipeline == nil {
+			c.AWSCodePipeline = c.CodePipeline
+		}
+
+		// Sync Backups
+		if c.AWSBackups != nil && c.Backups == nil {
+			c.Backups = c.AWSBackups
+		} else if c.Backups != nil && c.AWSBackups == nil {
+			c.AWSBackups = c.Backups
+		}
+	}
+
+	// Clear all legacy fields to prevent them from being serialized
+	// This ensures only cloud-prefixed fields (aws_*, gcp_*) appear in output
+	c.VPC = nil
+	c.Bastion = nil
+	c.EC2 = nil
+	c.Resource = nil
+	c.Lambda = nil
+	c.ALB = nil
+	c.CloudFront = nil
+	c.WAF = nil
+	c.APIGateway = nil
+	c.Postgres = nil
+	c.ElastiCache = nil
+	c.DynamoDB = nil
+	c.OpenSearch = nil
+	c.S3 = nil
+	c.KMS = nil
+	c.SecretsManager = nil
+	c.Bedrock = nil
+	c.SQS = nil
+	c.MSK = nil
+	c.CloudWatchLogs = nil
+	c.CloudWatchMonitoring = nil
+	c.Grafana = nil
+	c.Cognito = nil
+	c.GitHubActions = nil
+	c.CodePipeline = nil
+	c.Backups = nil
+}

--- a/pkg/composer/pricing_merge.go
+++ b/pkg/composer/pricing_merge.go
@@ -1,0 +1,390 @@
+package composer
+
+// pricing_merge.go owns the carry-forward merge that combines a prior
+// PricingData with a freshly-LLM-returned PricingData, gated by the pricing
+// guidance version and the per-component repriceSet. Migrated from reliable
+// per luthersystems/reliable#1437 PR-3.
+//
+// The Components witness — formerly a `...Components` variadic in reliable —
+// is now an explicit `Components` parameter on MergePricing and
+// ApplyCarryForward. Callers that have no witness pass `Components{}`;
+// ComponentSelected(&Components{}, key) returns false for every key, so the
+// witness-driven gap-surface (missing-reprice sentinel) and phantom-strip
+// become no-ops in the no-witness case. This makes the witness argument
+// non-optional at the type level — explicit > variadic per the #1437 design.
+//
+// The actual rules (what carries, what is repriced, what triggers a gap
+// sentinel) are unchanged from the reliable implementation. Selection
+// predicates now use the canonical ComponentSelected from coherence.go
+// instead of an in-file duplicate.
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+// MergeStats reports the outcome of a carry-forward merge. Emitted in the
+// pricing log line so we can measure the LLM-cost / jitter reduction (#921 AC-3).
+type MergeStats struct {
+	Total           int  // per-component pricing items present in merged output
+	Repriced        int  // items taken from the fresh LLM response
+	Carried         int  // items copied from the prior version
+	GuidanceBust    bool // true when the prior's guidance version didn't match; full reprice used
+	MissingReprices int  // #1434: components in repriceSet+selected but absent from prior AND fresh
+	PhantomsDropped int  // #1434: fresh rows for components NOT selected in witness (stripped)
+}
+
+// ApplyCarryForward is the single entrypoint the call-site should use. It
+// enforces the guidance-version gate, then delegates to MergePricing when
+// carry-forward is safe. On gate-bust, returns fresh unchanged with
+// GuidanceBust=true so the caller can log the condition.
+//
+// The `components` witness threads the current components selection into the
+// merge so MergePricing can (a) strip phantom rows for unselected components
+// and (b) surface gaps where a selected+repriced component is missing from
+// both prior and fresh (#1434). Callers with no witness pass `Components{}`
+// — every selection predicate returns false on the zero value, which makes
+// the witness-driven steps no-ops without special-casing.
+func ApplyCarryForward(prior, fresh *PricingData, repriceSet map[ComponentKey]bool, components Components) (*PricingData, MergeStats) {
+	if !ShouldCarryForward(prior) {
+		stats := MergeStats{}
+		if fresh != nil {
+			// #1434: strip phantom rows on the bust path too — fresh wins,
+			// but rows for unselected components are still hallucinations.
+			stripPhantomPricing(&fresh.Components, components, &stats)
+			n := countComponentItems(&fresh.Components)
+			stats.Total = n
+			stats.Repriced = n
+		}
+		if prior != nil {
+			stats.GuidanceBust = true
+		}
+		if fresh != nil {
+			recomputeSubtotal(fresh)
+		}
+		return fresh, stats
+	}
+	merged, stats := MergePricing(prior, fresh, repriceSet, components)
+	if merged != nil {
+		recomputeSubtotal(merged)
+	}
+	return merged, stats
+}
+
+// MergePricing applies carry-forward: for every per-component pricing item in
+// `fresh`, if the component is NOT in repriceSet, overwrite fresh's item with
+// prior's (when prior has one). Items in repriceSet keep their fresh value.
+//
+// This eliminates LLM-jitter on untouched components without discarding the
+// LLM's holistic view (the LLM still sees the full stack when it prices).
+//
+// Pass-through behavior:
+//   - fresh == nil → returns nil, zero stats (caller handles error upstream).
+//   - prior == nil → every fresh item is counted as repriced; no-op merge.
+//
+// The guidance-version check is NOT enforced here — use ApplyCarryForward for
+// the gated path; MergePricing is exposed for testing the merge mechanics in
+// isolation.
+//
+// The `components` witness (#1434):
+//   - strips phantom rows for components the witness says are NOT selected,
+//     and
+//   - attaches a sentinel `PricingItem{Status:"missing"}` for components the
+//     witness says ARE selected but where both prior and fresh have no row
+//     (and the key is in `repriceSet`).
+//
+// A zero-value witness (`Components{}`) reports every key as unselected, so
+// both steps become no-ops: phantom-strip clears nothing (because there's
+// nothing to compare against intentionally) and gap-surface never fires. The
+// signature is non-optional so the design intent is visible at the call site
+// — passing `Components{}` is the explicit "I have no witness" path.
+//
+// Implementation details:
+//   - fresh is Normalize()'d first so LLM-populated legacy fields don't inflate
+//     the repriced count.
+//   - prior is deep-copied via JSON so the merged output never shares
+//     PricingItem pointers with the caller's prior (defence against accidental
+//     aliasing that could corrupt the persisted prior on mutation).
+//   - The walk uses reflection over PricingData.Components (mirrors the
+//     composer.DiffConfigs pattern) so new fields are handled automatically.
+func MergePricing(prior, fresh *PricingData, repriceSet map[ComponentKey]bool, components Components) (*PricingData, MergeStats) {
+	var stats MergeStats
+	if fresh == nil {
+		return nil, stats
+	}
+	fresh.Normalize()
+	// #1434: strip phantom rows BEFORE the merge walk. When the Components
+	// witness says a component is NOT selected, any pricing row for it on
+	// fresh is a hallucination — drop it so downstream layers can't render
+	// it. A zero-value witness no-ops on every field. Updates
+	// stats.PhantomsDropped.
+	stripPhantomPricing(&fresh.Components, components, &stats)
+
+	if prior == nil {
+		n := countComponentItems(&fresh.Components)
+		stats.Repriced = n
+		stats.Total = n
+		return fresh, stats
+	}
+
+	priorCopy := deepCopyPricing(prior)
+	if priorCopy == nil {
+		// Marshal failure (should never happen); degrade to full reprice.
+		n := countComponentItems(&fresh.Components)
+		stats.Repriced = n
+		stats.Total = n
+		return fresh, stats
+	}
+
+	priorC := reflect.ValueOf(&priorCopy.Components).Elem()
+	freshC := reflect.ValueOf(&fresh.Components).Elem()
+	t := priorC.Type()
+	if priorC.Type() != freshC.Type() {
+		// Struct layouts diverged — skip merge rather than risk a Set panic.
+		n := countComponentItems(&fresh.Components)
+		stats.Repriced = n
+		stats.Total = n
+		return fresh, stats
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		tag := JSONTagName(t.Field(i))
+		if tag == "" {
+			continue
+		}
+		priorF := priorC.Field(i)
+		freshF := freshC.Field(i)
+		if priorF.Kind() != reflect.Pointer || freshF.Kind() != reflect.Pointer {
+			continue
+		}
+		if priorF.Type() != freshF.Type() {
+			continue
+		}
+
+		key := ComponentKey(tag)
+		if repriceSet[key] {
+			if !freshF.IsNil() {
+				stats.Repriced++
+				stats.Total++
+				continue
+			}
+			// #1434: repriceSet[k]=true AND freshF is nil. Two shapes:
+			//   - prior has it → user removed; correct drop. Leave nil.
+			//   - prior also nil → either (a) component selected this turn
+			//     and fresh forgot it (the prod failure shape), or (b) a
+			//     spurious entry in repriceSet (e.g. reverse-pricing-dep
+			//     expansion includes a component not in the stack — see
+			//     KeyAWSCloudWatchLogs in PricingDependencies[Lambda]).
+			//     The gap-surface sentinel ONLY fires when the Components
+			//     witness confirms the component is selected; otherwise
+			//     we'd over-report on stacks that never had the component.
+			if !priorF.IsNil() {
+				continue
+			}
+			if !ComponentSelected(&components, key) {
+				continue
+			}
+			setPricingSentinel(freshF, key)
+			stats.MissingReprices++
+			stats.Total++
+			continue
+		}
+
+		// Carry-forward when prior has a value for this component.
+		if !priorF.IsNil() {
+			freshF.Set(priorF)
+			stats.Carried++
+			stats.Total++
+			continue
+		}
+
+		// Prior had nothing; fresh may or may not have a value. If fresh has
+		// one, count it as repriced (new component the differ didn't flag).
+		if !freshF.IsNil() {
+			stats.Repriced++
+			stats.Total++
+		}
+	}
+	return fresh, stats
+}
+
+// stripPhantomPricing walks the reflected per-component pricing fields and
+// nils out any field whose component key is NOT selected in the witness.
+// Updates stats.PhantomsDropped for each row dropped.
+//
+// No-witness short-circuit: a fully-zero `Components` (the value callers pass
+// to mean "I have no witness") carries no information to drive a strip — so
+// the function early-returns. Without this guard, every fresh row would be
+// dropped on a `Components{}` call, which is the opposite of the no-witness
+// intent. With any populated field on the witness (Cloud, AWSLambda, …)
+// stripPhantomPricing proceeds normally.
+//
+// #1434.
+func stripPhantomPricing(comps any, witness Components, stats *MergeStats) {
+	if isZeroComponents(witness) {
+		return
+	}
+	v := reflect.ValueOf(comps).Elem()
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		tag := JSONTagName(t.Field(i))
+		if tag == "" {
+			continue
+		}
+		f := v.Field(i)
+		if f.Kind() != reflect.Pointer || f.IsNil() {
+			continue
+		}
+		key := ComponentKey(tag)
+		if ComponentSelected(&witness, key) {
+			continue
+		}
+		f.Set(reflect.Zero(f.Type()))
+		if stats != nil {
+			stats.PhantomsDropped++
+		}
+	}
+}
+
+// isZeroComponents reports whether the witness has NO selection fields set —
+// i.e. the literal `Components{}`. Cheap reflective check; only used by
+// stripPhantomPricing to distinguish "explicit empty stack" from "caller
+// didn't supply a witness".
+func isZeroComponents(c Components) bool {
+	v := reflect.ValueOf(c)
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		f := v.Field(i)
+		switch f.Kind() {
+		case reflect.String:
+			if f.String() != "" {
+				return false
+			}
+		case reflect.Pointer:
+			if !f.IsNil() {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// setPricingSentinel sets the given reflected *PricingItem field to a
+// fresh `PricingItem{Status:"missing", ...}` so the caller can detect
+// post-merge that the LLM omitted pricing for a selected+repriced
+// component. Embeds the component key in the details for downstream log
+// correlation. Used by MergePricing when prior/fresh both lack a row.
+// #1434.
+func setPricingSentinel(field reflect.Value, key ComponentKey) {
+	if field.Kind() != reflect.Pointer {
+		return
+	}
+	elemT := field.Type().Elem()
+	if elemT != reflect.TypeOf(PricingItem{}) {
+		// PricingBackups sub-struct etc — skip the sentinel for those.
+		return
+	}
+	sentinel := PricingItem{
+		Status:  "missing",
+		Details: "fresh pricing omitted for " + string(key) + "; needs reprice (#1434)",
+	}
+	field.Set(reflect.ValueOf(&sentinel))
+}
+
+// ShouldCarryForward returns true if carry-forward merging is safe given the
+// prior version's stamped guidance version. When the prior was priced under a
+// different guidance, old numbers may be wrong and must be re-computed.
+func ShouldCarryForward(prior *PricingData) bool {
+	if prior == nil {
+		return false
+	}
+	return prior.GuidanceVersion == PriceGuidanceVersion
+}
+
+// countComponentItems returns the number of non-nil per-component pricing
+// pointer fields on the Components struct.
+func countComponentItems(c any) int {
+	v := reflect.ValueOf(c).Elem()
+	t := v.Type()
+	n := 0
+	for i := 0; i < t.NumField(); i++ {
+		if JSONTagName(t.Field(i)) == "" {
+			continue
+		}
+		f := v.Field(i)
+		if f.Kind() != reflect.Pointer {
+			continue
+		}
+		if !f.IsNil() {
+			n++
+		}
+	}
+	return n
+}
+
+// deepCopyPricing returns an independent copy of a PricingData via a
+// JSON round-trip. Returns nil on marshal failure (caller treats as absent).
+func deepCopyPricing(p *PricingData) *PricingData {
+	if p == nil {
+		return nil
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return nil
+	}
+	out := &PricingData{}
+	if err := json.Unmarshal(data, out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// recomputeSubtotal walks every *PricingItem (including the children of the
+// Backups sub-structs) and assigns the sum of non-nil MonthlyUSD values to
+// pd.SubtotalMonthlyUSD. Must be called after any mutation to Components so
+// the subtotal stays consistent with line items (#921 P0 correctness fix).
+func recomputeSubtotal(pd *PricingData) {
+	if pd == nil {
+		return
+	}
+	var total float64
+	walkPricingItems(&pd.Components, func(item *PricingItem) {
+		if item != nil && item.MonthlyUSD != nil {
+			total += *item.MonthlyUSD
+		}
+	})
+	pd.SubtotalMonthlyUSD = &total
+}
+
+// walkPricingItems walks a PricingData.Components (anonymous struct) value
+// and calls visit on every *PricingItem it finds — including the children of
+// nested sub-structs like *PricingBackups / *GCPPricingBackups.
+func walkPricingItems(c any, visit func(*PricingItem)) {
+	v := reflect.ValueOf(c)
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return
+	}
+	t := v.Type()
+	pricingItemType := reflect.TypeOf((*PricingItem)(nil))
+	for i := 0; i < t.NumField(); i++ {
+		f := v.Field(i)
+		if f.Kind() != reflect.Pointer || f.IsNil() {
+			continue
+		}
+		// Direct *PricingItem fields.
+		if f.Type() == pricingItemType {
+			visit(f.Interface().(*PricingItem))
+			continue
+		}
+		// Sub-struct pointers (Backups variants): recurse into their fields.
+		if f.Type().Elem().Kind() == reflect.Struct {
+			walkPricingItems(f.Interface(), visit)
+		}
+	}
+}

--- a/pkg/composer/pricing_merge_test.go
+++ b/pkg/composer/pricing_merge_test.go
@@ -1,0 +1,387 @@
+package composer
+
+// Regression tests for luthersystems/reliable#1434 — pricing carry-forward
+// across component add / remove / re-add and across config-driven repricing.
+//
+// Migrated from reliable per luthersystems/reliable#1437 PR-3 with the
+// variadic `componentsOpt ...Components` argument flattened to an explicit
+// `Components` parameter. Callers with no witness pass `Components{}`.
+//
+// These exercise `MergePricing` (the public surface of `ApplyCarryForward`)
+// in isolation, no LLM and no DB. They pin the desired semantics that
+//   (a) a removed component's prior price must not carry forward,
+//   (b) a re-added component must be repriced from fresh, not carried,
+//   (c) a config change for a kept component triggers repricing,
+//   (d) the LLM fabricating an extra pricing row for an unselected component
+//       must NOT be quietly merged.
+//
+// The actual prod failure mode (sess_v2_CnqUJ6NRJnLC) is that the fresh
+// pricing payload comes back WITHOUT a re-added component (the LLM "forgot"
+// to price it). That manifests two layers above this file
+// (`calculate_current_costs` tool returning a payload with no `aws_opensearch`
+// row); MergePricing's only job is then to surface the gap cleanly. These
+// tests pin that surface so a future merge tweak doesn't paper over the LLM
+// bug by silently carrying the prior price.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pricingFromJSON parses the inline anonymous Components struct on
+// PricingData by going through JSON. Fields are only constructible by the
+// package itself so tests use this helper to build fixtures.
+func pricingFromJSON(t *testing.T, payload string) *PricingData {
+	t.Helper()
+	var p PricingData
+	require.NoError(t, json.Unmarshal([]byte(payload), &p))
+	return &p
+}
+
+// boolPtrLocal — small wrapper that matches the reliable test fixture name
+// so the ported assertions read the same. `boolPtr` already exists in
+// types_test.go for package-level fixtures.
+func boolPtrLocal(b bool) *bool { return &b }
+
+// TestMergePricing_Issue1434_RemovedComponentClearsPriorPrice pins the
+// carry-forward semantics for a removal: prior had aws_opensearch=$345.60;
+// the user just removed opensearch; fresh pricing correctly omits it. The
+// merged result must NOT carry the prior price forward (that would be the
+// classic "deselected component still showing in cost") — the toggle diff
+// puts the component in repriceSet, and the fresh nil wins.
+//
+// Today GREEN — locks the documented #921 invariant ("dropping a component
+// silently kept its stale price" was the bug fixed).
+func TestMergePricing_Issue1434_RemovedComponentClearsPriorPrice(t *testing.T) {
+	prior := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_s3":{"monthlyUSD":2.30},
+		"aws_opensearch":{"monthlyUSD":345.60}
+	}}`)
+	fresh := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_s3":{"monthlyUSD":2.30}
+	}}`)
+	repriceSet := RepriceSet(map[ComponentKey]bool{KeyAWSOpenSearch: true})
+
+	merged, _ := MergePricing(prior, fresh, repriceSet, Components{})
+	require.NotNil(t, merged)
+	assert.Nil(t, merged.Components.AWSOpenSearch,
+		"#1434/#921: a removed component's prior price must NOT carry forward — repriceSet wins and fresh is nil")
+}
+
+// TestMergePricing_Issue1434_ReAddRepricesNotCarries pins the re-add side:
+// prior pricing happened during a turn that had opensearch; the user then
+// removed it; then re-added on this turn. Fresh pricing comes back with a
+// FRESH price for opensearch (the desired LLM behaviour). The merged result
+// must use the fresh price, not carry-forward any historical price.
+func TestMergePricing_Issue1434_ReAddRepricesNotCarries(t *testing.T) {
+	prior := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_opensearch":{"monthlyUSD":345.60}
+	}}`)
+	fresh := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_opensearch":{"monthlyUSD":172.80,"details":"Half OCU reserved"}
+	}}`)
+	repriceSet := RepriceSet(map[ComponentKey]bool{KeyAWSOpenSearch: true})
+
+	merged, _ := MergePricing(prior, fresh, repriceSet, Components{})
+	require.NotNil(t, merged)
+	require.NotNil(t, merged.Components.AWSOpenSearch)
+	require.NotNil(t, merged.Components.AWSOpenSearch.MonthlyUSD)
+	assert.InDelta(t, 172.80, *merged.Components.AWSOpenSearch.MonthlyUSD, 0.001,
+		"#1434: fresh price for a re-added component must replace the prior price, not be shadowed by carry-forward")
+}
+
+// TestMergePricing_Issue1434_FreshOmitsRepriceComponent is the exact
+// sess_v2_CnqUJ6NRJnLC failure shape: the LLM was asked to re-price after
+// re-adding opensearch, but the tool returned a payload with NO
+// aws_opensearch row at all. repriceSet has aws_opensearch (toggle change
+// v_prev=false → v_current=true). Today `MergePricing` sees `repriceSet[k]=
+// true` and `freshF.IsNil()` and — with the witness — attaches a missing-
+// reprice sentinel so the gap is surfaced post-merge.
+func TestMergePricing_Issue1434_FreshOmitsRepriceComponent(t *testing.T) {
+	prior := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_s3":{"monthlyUSD":0.23}
+	}}`)
+	fresh := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_s3":{"monthlyUSD":0.23}
+	}}`)
+	repriceSet := RepriceSet(map[ComponentKey]bool{KeyAWSOpenSearch: true})
+
+	// #1435 fix: thread a Components witness that confirms opensearch IS
+	// selected this turn. Without it the merge can't distinguish "user
+	// added it and LLM forgot" from "spurious reverse-pricing-dep entry"
+	// — both shapes have prior+fresh nil. With the witness, the missing-
+	// reprice sentinel fires.
+	witness := Components{
+		Cloud:         "AWS",
+		AWSLambda:     boolPtrLocal(true),
+		AWSS3:         boolPtrLocal(true),
+		AWSOpenSearch: boolPtrLocal(true),
+	}
+
+	merged, stats := MergePricing(prior, fresh, repriceSet, witness)
+	require.NotNil(t, merged)
+
+	assert.NotNil(t, merged.Components.AWSOpenSearch,
+		"#1434: when a component is in repriceSet but fresh omits it, MergePricing must surface "+
+			"the gap (return error, mark stats, or attach a sentinel item) instead of silently producing "+
+			"a pricing snapshot with no row for the selected component — this is the prod failure shape")
+	assert.Equal(t, 1, stats.MissingReprices,
+		"#1434: stats.MissingReprices must count the gap so the caller can log it")
+}
+
+// TestMergePricing_Issue1434_PhantomFreshPriceForUnselectedComponent pins
+// the inverse: the LLM hallucinates a pricing row for a component that is
+// NOT in the components selection. With the witness, MergePricing strips
+// the phantom row so it can't survive into the merged snapshot.
+func TestMergePricing_Issue1434_PhantomFreshPriceForUnselectedComponent(t *testing.T) {
+	prior := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_opensearch":{"monthlyUSD":345.60}
+	}}`)
+	// User just removed opensearch. Fresh should be without it. But the
+	// LLM hallucinated and kept pricing it anyway.
+	fresh := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_opensearch":{"monthlyUSD":345.60,"details":"hallucinated by LLM"}
+	}}`)
+	repriceSet := RepriceSet(map[ComponentKey]bool{KeyAWSOpenSearch: true})
+
+	// #1435 fix: MergePricing accepts a Components witness reflecting the
+	// user's CURRENT selection (post-removal, opensearch is absent). The
+	// merge strips any fresh row whose component is not selected — the
+	// phantom doesn't survive.
+	witness := Components{Cloud: "AWS", AWSLambda: boolPtrLocal(true)}
+
+	merged, stats := MergePricing(prior, fresh, repriceSet, witness)
+	require.NotNil(t, merged)
+
+	assert.Nil(t, merged.Components.AWSOpenSearch,
+		"#1434: a phantom pricing row for an unselected component must not survive into the merged result")
+	assert.GreaterOrEqual(t, stats.PhantomsDropped, 1,
+		"#1434: stats.PhantomsDropped must count the stripped phantom row")
+}
+
+// TestMergePricing_Issue1434_ConfigChangeDoesNotCarry pins the documented
+// carry-forward escape hatch: when the user changes a kept component's
+// config (e.g. Lambda memorySize 1024 → 2048), the component goes into the
+// repriceSet and the fresh price wins. Original #921 mechanism, must keep
+// working.
+func TestMergePricing_Issue1434_ConfigChangeDoesNotCarry(t *testing.T) {
+	prior := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_s3":{"monthlyUSD":0.23}
+	}}`)
+	fresh := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":3.53,"details":"Bumped memory to 2048MB"},
+		"aws_s3":{"monthlyUSD":0.23}
+	}}`)
+	// Toggle didn't change, but Lambda config changed → repriceSet.
+	repriceSet := RepriceSet(map[ComponentKey]bool{KeyAWSLambda: true})
+
+	merged, _ := MergePricing(prior, fresh, repriceSet, Components{})
+	require.NotNil(t, merged)
+	require.NotNil(t, merged.Components.AWSLambda)
+	require.NotNil(t, merged.Components.AWSLambda.MonthlyUSD)
+	assert.InDelta(t, 3.53, *merged.Components.AWSLambda.MonthlyUSD, 0.001,
+		"#1434: a config change for a kept component must trigger repricing, not carry-forward")
+
+	// And S3 untouched → must carry forward (not a regression flag).
+	require.NotNil(t, merged.Components.AWSS3)
+	require.NotNil(t, merged.Components.AWSS3.MonthlyUSD)
+	assert.InDelta(t, 0.23, *merged.Components.AWSS3.MonthlyUSD, 0.001,
+		"S3 unchanged and untouched in this turn → carry-forward keeps the prior price stable")
+}
+
+// TestMergePricing_Issue1434_GuidanceVersionBustForcesFullReprice pins the
+// other escape hatch: when the prior pricing was stamped under a different
+// guidance version, the carry-forward gate fails and all of fresh wins.
+func TestMergePricing_Issue1434_GuidanceVersionBustForcesFullReprice(t *testing.T) {
+	prior := pricingFromJSON(t, `{"_guidance_version":"v0","components":{
+		"aws_lambda":{"monthlyUSD":9.99}
+	}}`)
+	fresh := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87}
+	}}`)
+	// Empty repriceSet — without the guidance bust, MergePricing would
+	// carry forward $9.99. With the bust, fresh wins.
+	repriceSet := RepriceSet(map[ComponentKey]bool{})
+
+	merged, stats := ApplyCarryForward(prior, fresh, repriceSet, Components{})
+	require.NotNil(t, merged)
+	assert.True(t, stats.GuidanceBust, "prior under v0 must trip the bust gate when current is v1")
+	require.NotNil(t, merged.Components.AWSLambda)
+	require.NotNil(t, merged.Components.AWSLambda.MonthlyUSD)
+	assert.InDelta(t, 1.87, *merged.Components.AWSLambda.MonthlyUSD, 0.001,
+		"under guidance-bust, the prior price must NOT survive — fresh wins for every component")
+}
+
+// TestMergePricing_Issue1434_CrossCloudCarryForward captures cross-cloud
+// pricing residual. Prior pricing was for an AWS stack; current turn
+// switched to GCP. Repriced via toggles for the AWS components going off
+// and GCP components coming on. Fresh has GCP-only rows. Expected merged:
+// no AWS rows.
+func TestMergePricing_Issue1434_CrossCloudCarryForward(t *testing.T) {
+	prior := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_s3":{"monthlyUSD":0.23}
+	}}`)
+	// gcp_vpc presence is what flips PricingData.Normalize's cloud heuristic
+	// to GCP, which is required to keep the GCP fields after the in-merge
+	// Normalize pass. Without it Normalize defaults to AWS and nukes every
+	// GCP row.
+	fresh := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"gcp_vpc":{"monthlyUSD":0},
+		"gcp_cloud_functions":{"monthlyUSD":1.50},
+		"gcp_gcs":{"monthlyUSD":0.20}
+	}}`)
+	repriceSet := RepriceSet(map[ComponentKey]bool{
+		KeyAWSLambda:         true,
+		KeyAWSS3:             true,
+		KeyGCPVPC:            true,
+		KeyGCPCloudFunctions: true,
+		KeyGCPGCS:            true,
+	})
+
+	merged, _ := MergePricing(prior, fresh, repriceSet, Components{})
+	require.NotNil(t, merged)
+	assert.Nil(t, merged.Components.AWSLambda,
+		"#1434: AWS Lambda price must not carry into a GCP-only stack")
+	assert.Nil(t, merged.Components.AWSS3,
+		"#1434: AWS S3 price must not carry into a GCP-only stack")
+	require.NotNil(t, merged.Components.GCPCloudFunctions, "GCP fresh price should land")
+	require.NotNil(t, merged.Components.GCPGCS, "GCP fresh price should land")
+}
+
+// TestMergePricing_Issue1434_SubtotalRecomputedAfterCarryForward pins that
+// the merged result's `subtotalMonthlyUSD` reflects the merged components,
+// not whatever subtotal happened to be on `prior` or `fresh`.
+func TestMergePricing_Issue1434_SubtotalRecomputedAfterCarryForward(t *testing.T) {
+	prior := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_opensearch":{"monthlyUSD":345.60}
+	},"subtotalMonthlyUSD":347.47}`)
+	fresh := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87}
+	},"subtotalMonthlyUSD":1.87}`)
+	repriceSet := RepriceSet(map[ComponentKey]bool{KeyAWSOpenSearch: true})
+
+	merged, _ := ApplyCarryForward(prior, fresh, repriceSet, Components{})
+	require.NotNil(t, merged)
+	require.NotNil(t, merged.SubtotalMonthlyUSD,
+		"recomputeSubtotal must populate SubtotalMonthlyUSD on the merged result")
+	assert.InDelta(t, 1.87, *merged.SubtotalMonthlyUSD, 0.001,
+		"#1434: subtotal after removing opensearch must equal sum of remaining components ($1.87), "+
+			"not the stale prior subtotal ($347.47) or the fresh subtotal computed before merge")
+}
+
+// TestMergePricing_Issue1434_NoComponentsAtAllReturnsNilSubtotal pins the
+// empty-merge edge: fresh has no components, prior has none either, no
+// repriceSet. The merged result must be defined (not panic) and its
+// subtotal should reflect "no components priced" — zero.
+func TestMergePricing_Issue1434_NoComponentsAtAllReturnsNilSubtotal(t *testing.T) {
+	prior := pricingFromJSON(t, `{"_guidance_version":"v1","components":{}}`)
+	fresh := pricingFromJSON(t, `{"_guidance_version":"v1","components":{}}`)
+	repriceSet := RepriceSet(map[ComponentKey]bool{})
+
+	merged, _ := ApplyCarryForward(prior, fresh, repriceSet, Components{})
+	require.NotNil(t, merged)
+	require.NotNil(t, merged.SubtotalMonthlyUSD)
+	assert.InDelta(t, 0.0, *merged.SubtotalMonthlyUSD, 0.001,
+		"empty merge must yield a zero subtotal, not nil or NaN")
+}
+
+// TestMergePricing_Issue1434_StatusOnlyItemSurvivesCarry pins an oft-
+// overlooked shape: pricing items with `status:"Included"` and no
+// `monthlyUSD`. The LLM uses these for "Serverless architecture — Included"
+// rows and they must carry-forward correctly when nothing changed.
+func TestMergePricing_Issue1434_StatusOnlyItemSurvivesCarry(t *testing.T) {
+	prior := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"architecture":{"status":"Included","details":"Serverless"},
+		"aws_lambda":{"monthlyUSD":1.87}
+	}}`)
+	fresh := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87}
+	}}`)
+	// Nothing changed — empty repriceSet.
+	repriceSet := RepriceSet(map[ComponentKey]bool{})
+
+	merged, _ := MergePricing(prior, fresh, repriceSet, Components{})
+	require.NotNil(t, merged)
+	require.NotNil(t, merged.Components.Architecture,
+		"status-only 'Included' rows must carry-forward when unchanged")
+	assert.Equal(t, "Included", merged.Components.Architecture.Status)
+}
+
+// =========================================================================
+// New upstream-specific tests beyond the reliable port — lock the explicit-
+// Components signature semantics that replaced the reliable variadic.
+// =========================================================================
+
+// TestMergePricing_ExplicitComponentsParam_NoWitnessUsesZero locks the
+// no-witness behaviour of the upstream signature: passing the zero
+// `Components{}` value MUST behave as "no witness" — no phantom-strip, no
+// gap-surface, no panic. The reliable variadic relied on `len(componentsOpt)`
+// to decide this; the upstream explicit-param design decodes a fully-zero
+// Components instead. Locked here because a refactor that dropped the
+// zero-witness short-circuit would silently start stripping every fresh row
+// on every no-witness call.
+func TestMergePricing_ExplicitComponentsParam_NoWitnessUsesZero(t *testing.T) {
+	// fresh has a row that NO populated witness would say is selected — but
+	// no witness is supplied, so the strip MUST NOT fire.
+	prior := pricingFromJSON(t, `{"_guidance_version":"v1","components":{}}`)
+	fresh := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_opensearch":{"monthlyUSD":345.60}
+	}}`)
+	repriceSet := RepriceSet(map[ComponentKey]bool{KeyAWSLambda: true})
+
+	merged, stats := MergePricing(prior, fresh, repriceSet, Components{})
+	require.NotNil(t, merged)
+	// No phantom strip without a witness.
+	require.NotNil(t, merged.Components.AWSLambda, "no-witness call must not strip fresh rows")
+	require.NotNil(t, merged.Components.AWSOpenSearch, "no-witness call must not strip fresh rows")
+	assert.Equal(t, 0, stats.PhantomsDropped, "no-witness call must report zero phantoms dropped")
+	// No gap-surface either: repriceSet[KeyAWSLambda]=true and fresh has a row,
+	// so this is the normal repriced path, not the sentinel path.
+	assert.Equal(t, 0, stats.MissingReprices, "no-witness call must not emit gap sentinels")
+}
+
+// TestApplyCarryForward_ExplicitComponentsParam_FlowsToInner locks the wiring
+// of the explicit Components param from ApplyCarryForward through to the
+// inner MergePricing strip/gap pipeline. A populated witness MUST result in
+// phantom-strip behaviour on the bust path AND on the merge path — the
+// reliable variadic threaded both, and the upstream explicit param must too.
+func TestApplyCarryForward_ExplicitComponentsParam_FlowsToInner(t *testing.T) {
+	// Build a prior under the current guidance version (no bust), with the
+	// phantom row already cleared from prior — the strip is concerned with
+	// fresh's hallucinated rows.
+	prior := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87}
+	}}`)
+	fresh := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_opensearch":{"monthlyUSD":345.60,"details":"hallucinated by LLM"}
+	}}`)
+	repriceSet := RepriceSet(map[ComponentKey]bool{KeyAWSLambda: true})
+
+	// Witness says only Lambda is selected; opensearch on fresh is a phantom.
+	witness := Components{Cloud: "AWS", AWSLambda: boolPtrLocal(true)}
+
+	merged, stats := ApplyCarryForward(prior, fresh, repriceSet, witness)
+	require.NotNil(t, merged)
+	assert.Nil(t, merged.Components.AWSOpenSearch,
+		"phantom strip MUST fire when ApplyCarryForward passes a populated witness through to MergePricing")
+	assert.GreaterOrEqual(t, stats.PhantomsDropped, 1,
+		"phantom strip count MUST be surfaced on the stats out of ApplyCarryForward")
+	require.NotNil(t, merged.Components.AWSLambda)
+}
+

--- a/pkg/composer/pricing_test.go
+++ b/pkg/composer/pricing_test.go
@@ -1,0 +1,54 @@
+package composer
+
+// Tests for the PricingData / PricingItem / PricingBackups type family.
+// Migrated from reliable per luthersystems/reliable#1437 PR-3.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPricingData_Normalize_RoundTrip locks the cross-cloud scrub +
+// legacy-field sync behaviour of PricingData.Normalize across two shapes:
+//
+//   - An AWS-shaped PricingData is idempotent under Normalize (calling it
+//     twice yields the same result) — locks the contract that the AWS path
+//     doesn't accumulate residue.
+//   - A GCP-shaped PricingData scrubs AWS residue: a phantom aws_lambda row
+//     persisted from a prior AWS turn MUST be cleared once the user has
+//     switched to GCP.
+//
+// This mirrors the reliable-side behaviour the merge layer depends on
+// (MergePricing calls fresh.Normalize() before the walk).
+func TestPricingData_Normalize_RoundTrip(t *testing.T) {
+	// AWS-shaped: Normalize is idempotent.
+	awsData := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"aws_lambda":{"monthlyUSD":1.87},
+		"aws_s3":{"monthlyUSD":0.23}
+	}}`)
+	awsData.Normalize()
+	once, err := json.Marshal(awsData)
+	require.NoError(t, err)
+	awsData.Normalize()
+	twice, err := json.Marshal(awsData)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(once), string(twice),
+		"PricingData.Normalize must be idempotent on AWS-shaped input")
+
+	// GCP-shaped with stale AWS residue: scrub. The composer JSON tag for
+	// GCP CloudSQL is `gcp_cloudsql` (no underscore between cloud and SQL)
+	// — that field's presence trips the cloud=GCP heuristic.
+	mixed := pricingFromJSON(t, `{"_guidance_version":"v1","components":{
+		"gcp_vpc":{"monthlyUSD":0},
+		"gcp_cloudsql":{"monthlyUSD":42.00},
+		"aws_lambda":{"monthlyUSD":1.87}
+	}}`)
+	mixed.Normalize()
+	assert.Nil(t, mixed.Components.AWSLambda,
+		"PricingData.Normalize must scrub AWS residue when GCP fields are present (cloud=GCP heuristic)")
+	require.NotNil(t, mixed.Components.GCPCloudSQL,
+		"GCP rows must survive the GCP-side scrub")
+}

--- a/pkg/composer/union.go
+++ b/pkg/composer/union.go
@@ -1,0 +1,137 @@
+package composer
+
+// union.go owns the partial-record fold for Components and Config: turning an
+// ordered slice of partial values (each from one persistence record / one
+// session-state snapshot / one user edit) into a single coherent value with
+// last-non-zero-wins semantics.
+//
+// Migrated upstream from luthersystems/reliable's chatv2 package (the
+// mergeComponents + mergeConfig hand-rolled families in
+// internal/chatv2/stack_components.go) per luthersystems/reliable#1437 PR-2,
+// so both reliable and any other composer consumer share one merge
+// implementation. Pairs with coherence.go (PR-1, #429) — the typical pipeline
+// is: parts → UnionConfig / UnionComponents → StripOrphanConfig →
+// DeriveCrossComponentFields.
+//
+// Contract — see UnionConfig / UnionComponents godoc for the full rule set.
+// Highlights:
+//   - Last-non-zero per leaf field wins (later parts override earlier non-zero
+//     values; a part that is zero at a given leaf contributes nothing there).
+//   - Pointer-to-false is non-zero (the *pointer* is non-nil, not the
+//     dereferenced value); an explicit "disable" must overwrite an earlier
+//     "enable". This is the #1043 deselection canary.
+//   - Recurses into *struct sub-fields with the same rule; sub-field-level
+//     overlay applies at every depth.
+//   - When the destination's inner *struct is nil, a FRESH inner struct is
+//     allocated on the destination — never shared with the source — matching
+//     MergeConfigs's existing semantics in defaults.go.
+//   - No Normalize calls inside Union. Callers pre-normalise via their own
+//     adapter (composeradapter.NormalizeConfig on the reliable side) before
+//     handing parts to Union; Union is just the merge.
+
+import "reflect"
+
+// UnionComponents folds an ordered slice of partial Components values into a
+// single coherent result. Last-non-zero per leaf field wins (later parts
+// override earlier ones where they have a non-zero value). Pure function. A
+// nil or empty input returns a zero Components.
+//
+// Semantics (uniform at every depth, per reflect.Value.IsZero):
+//   - Scalar fields (string, int, bool): non-zero src overrides dst.
+//   - Pointer fields (*bool, *int, *string, *struct): non-nil src overrides
+//     dst. Pointer-to-false is non-nil and therefore overrides — required to
+//     lock explicit-deselect (#1043).
+//   - Slice / map fields: non-nil src overrides dst. (A non-nil empty slice
+//     counts as non-zero; callers that want "empty means defer" must omit the
+//     field — set the pointer / slice to nil — rather than allocate an empty
+//     value.)
+//   - *struct sub-fields (AWSBackups, GCPBackups): recurse into the inner
+//     struct. If dst's inner pointer is nil and src's is non-nil, a FRESH
+//     inner struct is allocated on dst; src's pointer is never shared at the
+//     *struct level. Scalar-pointer fields INSIDE the struct are still
+//     shallow-copied (dst and result share the *bool / *int pointers with the
+//     latest part that set them).
+//
+// Callers must not mutate part values after calling UnionComponents.
+func UnionComponents(parts []Components) Components {
+	var result Components
+	if len(parts) == 0 {
+		return result
+	}
+	dst := reflect.ValueOf(&result).Elem()
+	for i := range parts {
+		// Range by index so we take addresses of the underlying slice
+		// elements (cheaper than copying each Components into a loop var,
+		// and matches the "last part wins" intent — we read each part's
+		// fields directly).
+		overlayNonZero(dst, reflect.ValueOf(&parts[i]).Elem())
+	}
+	return result
+}
+
+// UnionConfig folds an ordered slice of partial Config values into a single
+// coherent result. Last-non-zero per leaf field wins. Pure function. A nil or
+// empty input returns a zero Config.
+//
+// Semantics are identical to UnionComponents — same pointer-non-nil rule,
+// same *struct-sub-field recursion, same fresh-inner-struct allocation. See
+// UnionComponents for the full contract.
+func UnionConfig(parts []Config) Config {
+	var result Config
+	if len(parts) == 0 {
+		return result
+	}
+	dst := reflect.ValueOf(&result).Elem()
+	for i := range parts {
+		overlayNonZero(dst, reflect.ValueOf(&parts[i]).Elem())
+	}
+	return result
+}
+
+// overlayNonZero copies non-zero values from src into dst (both must be struct
+// values of the same type), recursing into nested *struct fields with the same
+// allocate-on-demand semantics used by MergeConfigs.
+//
+// This is the "src wins" sibling of overlayZero in defaults.go. Where
+// overlayZero fills only dst's zero-valued leaves (dst wins), overlayNonZero
+// overwrites dst's leaves whenever src has a non-zero value at the same leaf
+// (src wins). The recursion shape is otherwise identical:
+//
+//   - Nested *struct: recurse; allocate a FRESH inner struct on dst when dst's
+//     pointer is nil and src's is non-nil. dst never shares src's struct
+//     pointer — so a post-call mutation of dst's inner struct cannot leak back
+//     into src.
+//   - Leaf scalar / slice / map / scalar-pointer: if src is non-zero, copy via
+//     reflect.Value.Set (which is a shallow copy for pointers and slice
+//     headers — callers must not mutate parts post-call).
+func overlayNonZero(dst, src reflect.Value) {
+	for i := 0; i < dst.NumField(); i++ {
+		df, sf := dst.Field(i), src.Field(i)
+		if !df.CanSet() {
+			continue
+		}
+		// Recurse into nested *struct (e.g. AWSBackups, AWSVPC) so a later
+		// part setting only AWSVPC.AZCount doesn't clobber an earlier part's
+		// AWSVPC.EnableNATGateway.
+		if df.Kind() == reflect.Pointer && df.Type().Elem().Kind() == reflect.Struct {
+			if sf.IsNil() {
+				continue
+			}
+			if df.IsNil() {
+				// Allocate a FRESH inner struct on dst; do NOT share src's
+				// pointer. Matches MergeConfigs's "dst gets a FRESH pointer"
+				// rule in defaults.go.
+				df.Set(reflect.New(df.Type().Elem()))
+			}
+			overlayNonZero(df.Elem(), sf.Elem())
+			continue
+		}
+		// Leaf branch: src wins iff src is non-zero. Pointer-to-false is
+		// non-nil and therefore IsZero()==false, so explicit-deselect (e.g.
+		// AWSOpenSearch: &false) correctly overrides an earlier &true.
+		if sf.IsZero() {
+			continue
+		}
+		df.Set(sf)
+	}
+}

--- a/pkg/composer/union_test.go
+++ b/pkg/composer/union_test.go
@@ -1,0 +1,441 @@
+package composer
+
+// union_test.go locks the fold-of-partial-records contract that the
+// UnionConfig + UnionComponents helpers carry. Mirrors the regression suite
+// the same rules were under on the reliable side (chatv2/stack_components.go's
+// mergeConfig / mergeComponents families) so the upstream-migration in
+// luthersystems/reliable#1437 PR-2 cannot regress on either side.
+//
+// Key invariants under test:
+//
+//   - Last-non-zero per leaf wins (later parts in the slice override earlier
+//     parts where the later part has a non-zero value at that leaf).
+//   - Pointer-to-false is non-zero — explicit-deselect must overwrite an
+//     earlier explicit-select. This is the #1043 deselection canary.
+//   - Sub-struct recursion: a later part that touches only AWSVPC.AZCount
+//     must not clobber an earlier part's AWSVPC.EnableNATGateway.
+//   - Allocate-on-demand: when dst's inner *struct is nil and src's isn't,
+//     dst gets a FRESH inner struct — not src's pointer — so callers can't
+//     accidentally mutate part values via the result.
+//   - Union performs MERGE ONLY. Normalization (cross-cloud stripping, etc.)
+//     is a separate concern handled by Components.Normalize / Config.Normalize
+//     or by the caller's adapter — Union must not auto-strip.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ──────────────────────────────────────────────────────────────────────────
+// UnionConfig
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestUnionConfig_LastNonZeroWins(t *testing.T) {
+	t.Parallel()
+
+	parts := []Config{
+		{Cloud: "AWS", Region: "us-east-1"},
+		{Cloud: "GCP"},
+	}
+	got := UnionConfig(parts)
+
+	assert.Equal(t, "GCP", got.Cloud, "later non-zero Cloud must override earlier")
+	assert.Equal(t, "us-east-1", got.Region, "earlier Region must survive when later part is zero at that leaf")
+}
+
+func TestUnionConfig_EmptyPartsIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	parts := []Config{
+		{Cloud: "AWS", Region: "us-east-1"},
+		{}, // entirely zero — contributes nothing
+		{},
+	}
+	got := UnionConfig(parts)
+
+	assert.Equal(t, "AWS", got.Cloud)
+	assert.Equal(t, "us-east-1", got.Region)
+}
+
+func TestUnionConfig_PointerToFalsePreserved(t *testing.T) {
+	t.Parallel()
+
+	// Part 1 enables NAT; part 2 explicitly disables it. Result must be
+	// the explicit-false pointer — the canary that we lock on
+	// pointer-non-nil (not dereferenced value) for the IsZero predicate.
+	parts := []Config{
+		*cfgWithVPCSubBlock(nil, boolPtr(true), nil),
+		*cfgWithVPCSubBlock(nil, boolPtr(false), nil),
+	}
+	got := UnionConfig(parts)
+
+	require.NotNil(t, got.AWSVPC)
+	require.NotNil(t, got.AWSVPC.EnableNATGateway,
+		"explicit *bool(&false) must override an earlier *bool(&true)")
+	assert.False(t, *got.AWSVPC.EnableNATGateway,
+		"final dereferenced value must be the later part's false")
+}
+
+func TestUnionConfig_SubStructRecursion(t *testing.T) {
+	t.Parallel()
+
+	// Part 1 sets only EnableNATGateway. Part 2 sets only AZCount. Result
+	// must have BOTH populated in a single AWSVPC sub-block — proves the
+	// recursion descends into the inner struct rather than wholesale
+	// replacing the *struct pointer.
+	parts := []Config{
+		*cfgWithVPCSubBlock(nil, boolPtr(true), nil),
+		*cfgWithVPCSubBlock(nil, nil, intPtr(3)),
+	}
+	got := UnionConfig(parts)
+
+	require.NotNil(t, got.AWSVPC)
+	require.NotNil(t, got.AWSVPC.EnableNATGateway, "earlier sub-field must survive")
+	assert.True(t, *got.AWSVPC.EnableNATGateway)
+	require.NotNil(t, got.AWSVPC.AZCount, "later sub-field must land")
+	assert.Equal(t, 3, *got.AWSVPC.AZCount)
+}
+
+func TestUnionConfig_AllocatesFreshInnerStruct(t *testing.T) {
+	t.Parallel()
+
+	// Build a single-part fold. Mutate the result's inner *struct after
+	// the call; the part's inner *struct must NOT be affected — proves dst
+	// got a fresh inner struct rather than shared src's pointer.
+	part := *cfgWithVPCSubBlock(nil, boolPtr(true), intPtr(2))
+	require.NotNil(t, part.AWSVPC)
+	originalAZCount := *part.AWSVPC.AZCount
+
+	got := UnionConfig([]Config{part})
+	require.NotNil(t, got.AWSVPC)
+
+	// Pointer identity check at the *struct level — must differ.
+	assert.NotSame(t, part.AWSVPC, got.AWSVPC,
+		"result's inner *struct must be a fresh allocation, not the part's pointer")
+
+	// Mutate the result's inner struct via a new scalar pointer field; the
+	// part's AZCount pointer must be unchanged.
+	got.AWSVPC.AZCount = intPtr(99)
+	assert.Equal(t, originalAZCount, *part.AWSVPC.AZCount,
+		"mutating result.AWSVPC.AZCount must not affect the part's AZCount")
+}
+
+func TestUnionConfig_NilSlice_NoOverride(t *testing.T) {
+	t.Parallel()
+
+	// Part 1 populates AWSEC2.CustomIngressPorts; part 2 leaves it nil.
+	// Result must keep the populated slice — nil src is zero and therefore
+	// does not override.
+	parts := []Config{
+		{
+			AWSEC2: &struct {
+				InstanceType          string `json:"instanceType,omitempty"`
+				NumServers            string `json:"numServers,omitempty"`
+				NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
+				DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
+				UserData              string `json:"userData,omitempty"`
+				UserDataURL           string `json:"userDataURL,omitempty"`
+				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
+				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
+				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			}{
+				CustomIngressPorts: []int{22, 80, 443},
+			},
+		},
+		{
+			AWSEC2: &struct {
+				InstanceType          string `json:"instanceType,omitempty"`
+				NumServers            string `json:"numServers,omitempty"`
+				NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
+				DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
+				UserData              string `json:"userData,omitempty"`
+				UserDataURL           string `json:"userDataURL,omitempty"`
+				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
+				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
+				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			}{
+				InstanceType: "t3.large", // populated leaf
+				// CustomIngressPorts left nil — must not override
+			},
+		},
+	}
+	got := UnionConfig(parts)
+
+	require.NotNil(t, got.AWSEC2)
+	assert.Equal(t, []int{22, 80, 443}, got.AWSEC2.CustomIngressPorts,
+		"nil slice in a later part must not override an earlier populated slice")
+	assert.Equal(t, "t3.large", got.AWSEC2.InstanceType,
+		"later non-zero scalar must still override")
+}
+
+func TestUnionConfig_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Cloud:  "AWS",
+		Region: "us-east-1",
+	}
+	cfg.AWSVPC = &struct {
+		SingleNATGateway *bool `json:"singleNatGateway,omitempty"`
+		EnableNATGateway *bool `json:"enableNatGateway,omitempty"`
+		AZCount          *int  `json:"azCount,omitempty"`
+	}{EnableNATGateway: boolPtr(true), AZCount: intPtr(2)}
+
+	// Fold of one element must equal cfg (JSON-roundtrip equal — pointer
+	// identity at the *struct level differs by design, that's fine).
+	one := UnionConfig([]Config{cfg})
+	assertConfigJSONEqual(t, cfg, one)
+
+	// Fold of two copies must match fold of one — idempotent in the
+	// "applying the same record twice changes nothing" sense.
+	two := UnionConfig([]Config{cfg, cfg})
+	assertConfigJSONEqual(t, one, two)
+}
+
+func TestUnionConfig_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, Config{}, UnionConfig(nil), "nil input must yield zero Config")
+	assert.Equal(t, Config{}, UnionConfig([]Config{}), "empty slice input must yield zero Config")
+}
+
+func TestUnionConfig_AWSBackupsRecursion(t *testing.T) {
+	t.Parallel()
+
+	// Part 1 sets AWSBackups.RDS.FrequencyHours; part 2 sets only
+	// AWSBackups.S3.FrequencyHours. Result must have BOTH sub-sub-blocks
+	// populated — proves recursion descends through the AWSBackups *struct
+	// AND through the per-component *struct underneath.
+	p1 := Config{}
+	p1.AWSBackups = newAWSBackups()
+	p1.AWSBackups.RDS = &struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	}{FrequencyHours: 4}
+
+	p2 := Config{}
+	p2.AWSBackups = newAWSBackups()
+	p2.AWSBackups.S3 = &struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	}{FrequencyHours: 24}
+
+	got := UnionConfig([]Config{p1, p2})
+
+	require.NotNil(t, got.AWSBackups)
+	require.NotNil(t, got.AWSBackups.RDS, "earlier-part backup leaf must survive")
+	assert.Equal(t, 4, got.AWSBackups.RDS.FrequencyHours)
+	require.NotNil(t, got.AWSBackups.S3, "later-part backup leaf must land")
+	assert.Equal(t, 24, got.AWSBackups.S3.FrequencyHours)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// UnionComponents
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestUnionComponents_LastNonZeroWins(t *testing.T) {
+	t.Parallel()
+
+	parts := []Components{
+		{Cloud: "AWS", AWSVPC: "Public VPC"},
+		{AWSVPC: "Private VPC"},
+	}
+	got := UnionComponents(parts)
+
+	assert.Equal(t, "AWS", got.Cloud, "earlier non-zero scalar must survive when later part is zero")
+	assert.Equal(t, "Private VPC", got.AWSVPC, "later non-zero string must override earlier")
+}
+
+func TestUnionComponents_PointerToFalsePreserved(t *testing.T) {
+	t.Parallel()
+
+	// Canonical #1043 case: explicit deselection must beat an earlier
+	// explicit selection. Locks the pointer-non-nil discriminator.
+	parts := []Components{
+		{AWSOpenSearch: boolPtr(true)},
+		{AWSOpenSearch: boolPtr(false)},
+	}
+	got := UnionComponents(parts)
+
+	require.NotNil(t, got.AWSOpenSearch,
+		"explicit *bool(&false) is non-nil and must override earlier *bool(&true)")
+	assert.False(t, *got.AWSOpenSearch,
+		"final dereferenced value must be the later part's false")
+}
+
+func TestUnionComponents_Recurses_AWSBackups(t *testing.T) {
+	t.Parallel()
+
+	// Part 1 selects RDS backups; part 2 selects S3 backups. Result must
+	// have BOTH leaves populated under a single AWSBackups sub-struct —
+	// proves recursion at the *struct level.
+	p1 := Components{}
+	p1.AWSBackups = &struct {
+		EC2         *bool `json:"aws_ec2,omitempty"`
+		RDS         *bool `json:"aws_rds,omitempty"`
+		ElastiCache *bool `json:"aws_elasticache,omitempty"`
+		DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+		S3          *bool `json:"aws_s3,omitempty"`
+	}{RDS: boolPtr(true)}
+
+	p2 := Components{}
+	p2.AWSBackups = &struct {
+		EC2         *bool `json:"aws_ec2,omitempty"`
+		RDS         *bool `json:"aws_rds,omitempty"`
+		ElastiCache *bool `json:"aws_elasticache,omitempty"`
+		DynamoDB    *bool `json:"aws_dynamodb,omitempty"`
+		S3          *bool `json:"aws_s3,omitempty"`
+	}{S3: boolPtr(true)}
+
+	got := UnionComponents([]Components{p1, p2})
+
+	require.NotNil(t, got.AWSBackups)
+	require.NotNil(t, got.AWSBackups.RDS, "earlier part's RDS selection must survive")
+	assert.True(t, *got.AWSBackups.RDS)
+	require.NotNil(t, got.AWSBackups.S3, "later part's S3 selection must land")
+	assert.True(t, *got.AWSBackups.S3)
+}
+
+func TestUnionComponents_CrossCloud_LastCloudWins(t *testing.T) {
+	t.Parallel()
+
+	// Part 1 is an AWS stack; part 2 is a GCP stack. Result has Cloud=GCP
+	// and BOTH clouds' field sets survive — Union does merge only, NOT
+	// normalize. Stripping the opposite-cloud fields is Components.Normalize's
+	// job and must NOT happen here.
+	parts := []Components{
+		{Cloud: "AWS", AWSVPC: "Public VPC", AWSEC2: "Intel"},
+		{Cloud: "GCP", GCPVPC: boolPtr(true), GCPCompute: "n2-standard-2"},
+	}
+	got := UnionComponents(parts)
+
+	assert.Equal(t, "GCP", got.Cloud, "later Cloud must override")
+	assert.Equal(t, "Public VPC", got.AWSVPC,
+		"AWS field from earlier part must survive — Union does not auto-strip")
+	assert.Equal(t, "Intel", got.AWSEC2,
+		"AWS field from earlier part must survive — Union does not auto-strip")
+	require.NotNil(t, got.GCPVPC, "GCP field from later part must land")
+	assert.True(t, *got.GCPVPC)
+	assert.Equal(t, "n2-standard-2", got.GCPCompute)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Composition with the PR-1 coherence pipeline
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestUnion_Then_StripOrphanConfig_PipelineSequence(t *testing.T) {
+	t.Parallel()
+
+	// Two-part fold then strip — verifies UnionConfig output flows cleanly
+	// through StripOrphanConfig (PR-1). Part 1 has OpenSearch selected with
+	// config; part 2 explicitly deselects it. After UnionConfig the *bool
+	// pointer is &false but the cfg.AWSOpenSearch sub-block survives from
+	// part 1 — StripOrphanConfig must then clear it.
+	cfgPart1 := Config{
+		AWSOpenSearch: &struct {
+			DeploymentType string `json:"deploymentType,omitempty"`
+			InstanceType   string `json:"instanceType,omitempty"`
+			StorageSize    string `json:"storageSize,omitempty"`
+			MultiAZ        *bool  `json:"multiAz,omitempty"`
+		}{DeploymentType: "Production", InstanceType: "m6g.large"},
+	}
+	cfgPart2 := Config{} // empty — does not touch AWSOpenSearch
+
+	mergedCfg := UnionConfig([]Config{cfgPart1, cfgPart2})
+	require.NotNil(t, mergedCfg.AWSOpenSearch,
+		"merged Config retains AWSOpenSearch sub-block from part 1")
+
+	// Components fold: part 1 selects OpenSearch; part 2 deselects it.
+	mergedComps := UnionComponents([]Components{
+		{AWSOpenSearch: boolPtr(true)},
+		{AWSOpenSearch: boolPtr(false)},
+	})
+	require.NotNil(t, mergedComps.AWSOpenSearch)
+	assert.False(t, *mergedComps.AWSOpenSearch,
+		"explicit-deselect must win the Components fold")
+
+	// Now run the PR-1 strip — the orphan cfg.AWSOpenSearch must go.
+	StripOrphanConfig(&mergedComps, &mergedCfg)
+	assert.Nil(t, mergedCfg.AWSOpenSearch,
+		"StripOrphanConfig must clear cfg.AWSOpenSearch when the component is explicitly deselected")
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+// newAWSBackups returns a zero-valued AWSBackups sub-struct pointer in the
+// exact anonymous shape declared on Config. Helper because the literal type
+// is verbose to write inline.
+func newAWSBackups() *struct {
+	EC2 *struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	} `json:"aws_ec2,omitempty"`
+	RDS *struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	} `json:"aws_rds,omitempty"`
+	ElastiCache *struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	} `json:"aws_elasticache,omitempty"`
+	DynamoDB *struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	} `json:"aws_dynamodb,omitempty"`
+	S3 *struct {
+		FrequencyHours int    `json:"frequencyHours,omitempty"`
+		RetentionDays  int    `json:"retentionDays,omitempty"`
+		Region         string `json:"region,omitempty"`
+	} `json:"aws_s3,omitempty"`
+} {
+	return &struct {
+		EC2 *struct {
+			FrequencyHours int    `json:"frequencyHours,omitempty"`
+			RetentionDays  int    `json:"retentionDays,omitempty"`
+			Region         string `json:"region,omitempty"`
+		} `json:"aws_ec2,omitempty"`
+		RDS *struct {
+			FrequencyHours int    `json:"frequencyHours,omitempty"`
+			RetentionDays  int    `json:"retentionDays,omitempty"`
+			Region         string `json:"region,omitempty"`
+		} `json:"aws_rds,omitempty"`
+		ElastiCache *struct {
+			FrequencyHours int    `json:"frequencyHours,omitempty"`
+			RetentionDays  int    `json:"retentionDays,omitempty"`
+			Region         string `json:"region,omitempty"`
+		} `json:"aws_elasticache,omitempty"`
+		DynamoDB *struct {
+			FrequencyHours int    `json:"frequencyHours,omitempty"`
+			RetentionDays  int    `json:"retentionDays,omitempty"`
+			Region         string `json:"region,omitempty"`
+		} `json:"aws_dynamodb,omitempty"`
+		S3 *struct {
+			FrequencyHours int    `json:"frequencyHours,omitempty"`
+			RetentionDays  int    `json:"retentionDays,omitempty"`
+			Region         string `json:"region,omitempty"`
+		} `json:"aws_s3,omitempty"`
+	}{}
+}
+
+// assertConfigJSONEqual checks two Configs are equivalent under JSON
+// marshal-roundtrip — the equality that matters for persistence parity.
+// Pointer identity at the *struct level may differ; that's expected and fine.
+func assertConfigJSONEqual(t *testing.T, want, got Config) {
+	t.Helper()
+	wb, err := json.Marshal(want)
+	require.NoError(t, err)
+	gb, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(wb), string(gb))
+}


### PR DESCRIPTION
## Summary

PR-3 of three on luthersystems/reliable#1437. Migrates pricing carry-forward + the (Components, PricingData) witness logic from `luthersystems/reliable` upstream so the full rules engine lives in `pkg/composer`. Stacked on PR-2 (#431, union helpers), which is stacked on PR-1 (#429, coherence rules).

Half of pricing was already upstream (`PriceGuidanceVersion`, `PricingDependencies`, `RepriceSet`, `DiffConfigs`, `DiffComponents`). This finishes the move.

## Public API surface

```go
// pkg/composer/pricing.go (new) — types
type PricingItem        struct { … }
type PricingBackups     struct { … }   // AWS
type GCPPricingBackups  struct { … }
type PricingData        struct { Currency string; GuidanceVersion string; Components struct{ … }; SubtotalMonthlyUSD *float64 }
func (p *PricingData) Normalize()       // cross-cloud scrub + legacy-field sync

// pkg/composer/pricing_merge.go (new) — merge helpers
type MergeStats struct { Total, Repriced, Carried, MissingReprices, PhantomsDropped int; GuidanceBust bool }
func ApplyCarryForward(prior, fresh *PricingData, repriceSet map[ComponentKey]bool, components Components) (*PricingData, MergeStats)
func MergePricing     (prior, fresh *PricingData, repriceSet map[ComponentKey]bool, components Components) (*PricingData, MergeStats)
func ShouldCarryForward(prior *PricingData) bool
```

## Signature change vs reliable

The reliable side took the witness via `componentsOpt ...Components` for back-compat with 3-arg callers. Per [reliable#1437's PR-3 spec](https://github.com/luthersystems/reliable/issues/1437#:~:text=Extend%20signature%20to%20accept), the upstream signature is **explicit** — `components Components`. Callers without a witness pass `Components{}`; an internal `isZeroComponents` short-circuit makes phantom-strip and gap-surface no-ops in that case. No backward-compat shim; the reliable-side call sites get rewritten in the PR-N swap.

`componentSelectedInComposer` (a ~80-line duplicate of PR-1's `ComponentSelected`) is removed. The merge uses PR-1's exported `ComponentSelected` directly. PR-1's switch already covered every key the duplicate covered — verified before deletion.

## Pinned production failures

[reliable#1434](https://github.com/luthersystems/reliable/issues/1434) cluster. The two prod-fail shapes:

- **Phantom hallucination**: LLM emits a pricing row for a component the user no longer selects. Witness says "not selected" → row stripped pre-merge, `stats.PhantomsDropped` increments. Locked by `TestMergePricing_Issue1434_PhantomFreshPriceForUnselectedComponent`.
- **Reprice gap**: LLM is asked to reprice a component, but neither prior nor fresh has a row for it. Without a witness this can't be distinguished from a stale `RepriceSet` expansion (e.g. CloudWatch's reverse-dep on an unselected Lambda). With the witness, only "selected + repriceSet + missing" attaches a `PricingItem{Status:"missing"}` sentinel. Locked by `TestMergePricing_Issue1434_FreshOmitsRepriceComponent`.

## Test plan

- [x] **10 regression tests ported** from reliable's `internal/chatv2/pricing_carry_forward_regression_test.go` (mechanical port; `models.PricingData` → `PricingData`, `componentsOpt` → explicit `Components{...}`):
  - TestMergePricing_Issue1434_RemovedComponentClearsPriorPrice
  - TestMergePricing_Issue1434_ReAddRepricesNotCarries
  - TestMergePricing_Issue1434_FreshOmitsRepriceComponent
  - TestMergePricing_Issue1434_PhantomFreshPriceForUnselectedComponent
  - TestMergePricing_Issue1434_ConfigChangeDoesNotCarry
  - TestMergePricing_Issue1434_GuidanceVersionBustForcesFullReprice
  - TestMergePricing_Issue1434_CrossCloudCarryForward
  - TestMergePricing_Issue1434_SubtotalRecomputedAfterCarryForward
  - TestMergePricing_Issue1434_NoComponentsAtAllReturnsNilSubtotal
  - TestMergePricing_Issue1434_StatusOnlyItemSurvivesCarry
- [x] **3 new upstream-specific tests**:
  - TestMergePricing_ExplicitComponentsParam_NoWitnessUsesZero — `Components{}` short-circuits phantom-strip + gap-surface (no panic, no false positives)
  - TestApplyCarryForward_ExplicitComponentsParam_FlowsToInner — witness passes correctly from ApplyCarryForward → MergePricing
  - TestPricingData_Normalize_RoundTrip — Normalize is idempotent on AWS-shape; scrubs AWS residual on GCP-shape
- [x] `go build ./pkg/composer/...` — clean
- [x] `go test ./pkg/composer/... -count=1` — pricing + coherence + union tests all pass (37 in my filtered scope; full composer suite green minus a known network-flake `TestComposeStack_TerraformInit` that downloads hashicorp/aws provider from `registry.terraform.io` and intermittently times out — reproduced as such on stashed-clean baseline; not introduced by this PR)
- [x] `go vet ./pkg/composer/...` — clean
- [x] `golangci-lint run ./pkg/composer/...` — adds zero new findings vs main; pre-existing baseline (3 `reflect.Ptr` govet in `defaults.go`, 1 errcheck in `imported_provenance_test.go`, 2 staticcheck in `pkg/composer/imported/`) untouched. New files use `reflect.Pointer`.

## What reliable will swap to (PR-N follow-up)

After this lands + a new presets pseudo-version tag:
- `internal/chatv2/pricing_merge.go` deleted; reliable becomes a thin shim
- `internal/models/pricing.go` PricingData/PricingItem/PricingBackups/GCPPricingBackups deleted; reliable uses `composer.PricingData` etc throughout
- `componentsOpt ...Components` variadic call sites rewritten to pass `Components` explicitly (or `Components{}` for no-witness)
- The 10 regression tests deleted on the reliable side (replaced by these upstream ports + new tests)

## References

- luthersystems/reliable#1437 — tracking issue (this is PR-3 of 3)
- luthersystems/reliable#1434 — the bug this regression suite pins
- PR-2 (#431) — UnionConfig / UnionComponents (this PR stacks on it)
- PR-1 (#429) — coherence rules (StripOrphanConfig / DeriveCrossComponentFields / ComponentSelected / StackNeedsPrivateSubnets)