### PR TITLE
feat(gcpdiscover): credentialed NewRealAssetSearcher accepts option.ClientOption (#445)

### DIFF
--- a/cmd/insideout-import/gcpdiscover/searcher.go
+++ b/cmd/insideout-import/gcpdiscover/searcher.go
@@ -9,6 +9,7 @@ import (
 	asset "cloud.google.com/go/asset/apiv1"
 	"cloud.google.com/go/asset/apiv1/assetpb"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -58,12 +59,26 @@ type RealAssetSearcher struct {
 	client *asset.Client
 }
 
-// NewRealAssetSearcher constructs a searcher backed by Application Default
-// Credentials. Returns an error wrapping the underlying NewClient failure
-// when ADC isn't configured (operator forgot `gcloud auth application-default
-// login`) or the project doesn't have the Cloud Asset API enabled.
-func NewRealAssetSearcher(ctx context.Context) (*RealAssetSearcher, error) {
-	c, err := asset.NewClient(ctx)
+// NewRealAssetSearcher constructs a searcher backed by a Cloud Asset
+// Inventory client. With no opts the underlying asset.NewClient falls
+// back to Application Default Credentials (the CLI use case — operator
+// has run `gcloud auth application-default login`). Returns an error
+// wrapping the underlying NewClient failure when ADC isn't configured
+// or the project doesn't have the Cloud Asset API enabled.
+//
+// Callers that need per-request credentials (multi-tenant server-side
+// consumers, e.g. reliable's /api/import/discover handler) pass an
+// option.ClientOption such as option.WithTokenSource(ts) so each
+// request can carry its own oauth2.TokenSource without touching
+// process-global state like GOOGLE_APPLICATION_CREDENTIALS, which
+// races between concurrent requests on the same warm function.
+//
+// Opts are forwarded verbatim to asset.NewClient — see the
+// google.golang.org/api/option package for the full set
+// (WithTokenSource, WithCredentialsJSON, WithEndpoint, WithUserAgent…).
+// See issue #445 for motivation.
+func NewRealAssetSearcher(ctx context.Context, opts ...option.ClientOption) (*RealAssetSearcher, error) {
+	c, err := asset.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create cloud asset client: %w", err)
 	}

--- a/cmd/insideout-import/gcpdiscover/searcher_test.go
+++ b/cmd/insideout-import/gcpdiscover/searcher_test.go
@@ -1,12 +1,14 @@
 package gcpdiscover
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strings"
 	"testing"
 
 	"cloud.google.com/go/asset/apiv1/assetpb"
+	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -185,5 +187,71 @@ func TestWrapSearchAllError_NonStatusErrorPassThrough(t *testing.T) {
 	}
 	if !strings.HasPrefix(got, "search all resources: ") {
 		t.Errorf("default prefix must apply\n--- got ---\n%s", got)
+	}
+}
+
+// TestNewRealAssetSearcher_AcceptsOptions pins the #445 variadic
+// option.ClientOption contract: NewRealAssetSearcher must thread caller
+// opts through to asset.NewClient so multi-tenant server-side consumers
+// can inject per-request BYOC credentials via option.WithTokenSource
+// without touching process-global state (GOOGLE_APPLICATION_CREDENTIALS).
+//
+// asset.NewClient's gRPC dial is lazy — the constructor accepts arbitrary
+// transport opts (here option.WithEndpoint to a sentinel value, plus
+// option.WithoutAuthentication so the client doesn't try to resolve ADC
+// in unit-test environments where it may not be configured) and returns
+// successfully without contacting the endpoint. A successful return is
+// proof that the variadic was forwarded: if the opts were dropped on
+// the floor, the client would still try ADC and fail in CI sandboxes
+// without GOOGLE_APPLICATION_CREDENTIALS set.
+func TestNewRealAssetSearcher_AcceptsOptions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// option.WithoutAuthentication short-circuits the credential
+	// resolver — proves the variadic is forwarded because dropping
+	// it would force ADC discovery in this hermetic test process.
+	// option.WithEndpoint exercises a second opt of a different
+	// kind (transport vs auth) so the variadic accepts a slice, not
+	// just one item.
+	s, err := NewRealAssetSearcher(ctx,
+		option.WithoutAuthentication(),
+		option.WithEndpoint("localhost:0"),
+	)
+	if err != nil {
+		t.Fatalf("NewRealAssetSearcher(opts...) must construct: %v", err)
+	}
+	if s == nil || s.client == nil {
+		t.Fatalf("searcher must be non-nil with a non-nil client; got %+v", s)
+	}
+	// Don't leak the gRPC conn even though it's lazy — Close is
+	// idempotent and the symmetric path matches the production
+	// caller (cmd/insideout-import/discover.go).
+	if err := s.Close(); err != nil {
+		t.Errorf("Close must succeed on a fresh searcher: %v", err)
+	}
+}
+
+// TestNewRealAssetSearcher_NoOptsKeepsADCFallback pins that callers
+// passing no opts (the CLI use case) continue to get the ADC-backed
+// client construction. The constructor returns a usable searcher
+// without an explicit credential opt because the underlying
+// asset.NewClient defers credential resolution to first RPC — so
+// the constructor itself succeeds even in test processes without
+// ADC configured. The contract this test locks is "zero-opt call
+// site keeps working" so a future refactor that made opts required
+// (e.g. by introducing a non-variadic signature) breaks here.
+func TestNewRealAssetSearcher_NoOptsKeepsADCFallback(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, err := NewRealAssetSearcher(ctx)
+	if err != nil {
+		t.Fatalf("zero-opt NewRealAssetSearcher must construct (ADC fallback path): %v", err)
+	}
+	if s == nil || s.client == nil {
+		t.Fatalf("searcher must be non-nil with a non-nil client; got %+v", s)
+	}
+	if err := s.Close(); err != nil {
+		t.Errorf("Close must succeed: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Tiny opt-passing change to `NewRealAssetSearcher` so multi-tenant consumers (specifically reliable's `/api/import/discover` handler) can inject per-request BYOC `oauth2.TokenSource` credentials. CLI callers passing nothing get the existing ADC fallback unchanged.

## Why

reliable's reverse-Terraform import slice (luthersystems/reliable#1346) needs per-request Google credentials threaded through Cloud Asset Inventory queries. Setting `GOOGLE_APPLICATION_CREDENTIALS` is process-global and races between concurrent Vercel function invocations. `asset.NewClient(ctx, option.WithTokenSource(...))` is the standard fix; the constructor just needs to forward the variadic.

Closes #445.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/insideout-import/gcpdiscover/...` clean (544 tests pass) — new `TestNewRealAssetSearcher_AcceptsOptions` covers the variadic, `TestNewRealAssetSearcher_NoOptsKeepsADCFallback` pins zero-opt ADC behavior
- [x] Existing CLI behavior unchanged — `NewRealAssetSearcher(ctx)` still uses ADC; `cmd/insideout-import/discover.go:270` (the only existing caller) is unaffected by the variadic addition

## Out of scope

- Wiring this into reliable. Lands as a separate go.mod pin bump in reliable once this merges.
