### PR TITLE
feat(awsdiscover): Bundle 14k2 — 4 of final 5 deferred AWS types via SDK-only pattern

### DIFF
--- a/cmd/insideout-import/awsdiscover/sdkonly_autoscaling.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_autoscaling.go
@@ -1,0 +1,141 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+)
+
+// asgTagClient is the narrow subset of the AutoScaling API the
+// aws_autoscaling_group_tag SDK-only sub-resource discoverer issues.
+// Real *autoscaling.Client and in-test fakes satisfy this interface;
+// production code constructs the real client via autoscaling.NewFromConfig
+// from each ListParents / FetchItems closure (factory at
+// newASGTagClient).
+//
+// Reuses the same DescribeAutoScalingGroups RPC that listAutoScalingGroups
+// in cloudcontrol_listers.go uses for parent enumeration, but the
+// per-parent FetchItems below also re-reads tags from the same RPC —
+// the tags are inline on the AutoScalingGroup result so no additional
+// SDK call is needed.
+type asgTagClient interface {
+	DescribeAutoScalingGroups(ctx context.Context, in *autoscaling.DescribeAutoScalingGroupsInput, opts ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingGroupsOutput, error)
+}
+
+// newASGTagClient is the production factory injected into each ASG
+// tag closure. Region-specific because Auto Scaling is a regional
+// service.
+var newASGTagClient = func(awsCfg aws.Config, region string) asgTagClient {
+	return autoscaling.NewFromConfig(awsCfg, func(o *autoscaling.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+}
+
+// listASGNames enumerates Auto Scaling Group names in the region.
+// Wraps listAutoScalingGroupsWithClient (already used by the
+// aws_autoscaling_group SDKLister branch in cloudcontrol_listers.go)
+// but goes through a fresh client factory so the SDK-only sub-resource
+// discoverer doesn't take an indirect dependency on the
+// autoScalingGroupsLister interface declared there.
+//
+// Returns a non-nil empty slice on accounts with zero ASGs (#255).
+func listASGNames(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := newASGTagClient(awsCfg, region)
+	return listASGNamesWithClient(ctx, client)
+}
+
+func listASGNamesWithClient(ctx context.Context, client asgTagClient) ([]string, error) {
+	names := []string{}
+	var nextToken *string
+	for {
+		page, err := client.DescribeAutoScalingGroups(ctx, &autoscaling.DescribeAutoScalingGroupsInput{NextToken: nextToken})
+		if err != nil {
+			return nil, fmt.Errorf("autoscaling:DescribeAutoScalingGroups: %w", err)
+		}
+		for _, g := range page.AutoScalingGroups {
+			name := aws.ToString(g.AutoScalingGroupName)
+			if name == "" {
+				continue
+			}
+			names = append(names, name)
+		}
+		if page.NextToken == nil || aws.ToString(page.NextToken) == "" {
+			break
+		}
+		nextToken = page.NextToken
+	}
+	return names, nil
+}
+
+// fetchASGTags implements FetchItems for aws_autoscaling_group_tag.
+//
+// One parent (ASG name) yields N emissions — one per tag (Key, Value)
+// pair. Terraform's import format for aws_autoscaling_group_tag is
+// "<asg_name>,<tag_key>" — verified against terraform-provider-aws
+// v6.x internal/service/autoscaling/group_tag.go::resourceGroupTagImport,
+// which splits on "," with N=2 and assigns parts[0]=asgName,
+// parts[1]=tagKey.
+//
+// Tags are read from the inline Tags field on
+// DescribeAutoScalingGroups (one call per ASG, filtered by
+// AutoScalingGroupNames). Per AWS docs the inline list returns
+// TagDescription items with Key, Value, and PropagateAtLaunch — the
+// TF resource models all three but the import format only addresses
+// (asg, key) pairs.
+//
+// Tag duplicates: AWS validates uniqueness on tag keys per ASG, so
+// two emissions with the same ImportID are impossible by construction.
+// We do not de-dupe defensively (a future SDK regression would surface
+// as duplicate ImportedResource entries, which makeImportedResource's
+// address book disambiguates with -2 suffixes).
+//
+// ASG-disappeared race: DescribeAutoScalingGroups silently returns an
+// empty AutoScalingGroups slice when the named group no longer exists
+// (no NotFound error). Zero emissions in that case rather than an
+// error.
+func fetchASGTags(ctx context.Context, awsCfg aws.Config, region, asgName string) ([]subresourceEmission, error) {
+	return fetchASGTagsWithClient(ctx, newASGTagClient(awsCfg, region), asgName)
+}
+
+func fetchASGTagsWithClient(ctx context.Context, client asgTagClient, asgName string) ([]subresourceEmission, error) {
+	out, err := client.DescribeAutoScalingGroups(ctx, &autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []string{asgName},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("autoscaling:DescribeAutoScalingGroups asg=%q: %w", asgName, err)
+	}
+	emissions := []subresourceEmission{}
+	if out == nil {
+		return emissions, nil
+	}
+	for _, g := range out.AutoScalingGroups {
+		if aws.ToString(g.AutoScalingGroupName) != asgName {
+			continue
+		}
+		for _, tag := range g.Tags {
+			key := aws.ToString(tag.Key)
+			if key == "" {
+				continue
+			}
+			value := aws.ToString(tag.Value)
+			emissions = append(emissions, subresourceEmission{
+				ImportID: asgName + "," + key,
+				NameHint: asgName + "-tag-" + key,
+				NativeIDs: map[string]string{
+					"autoscaling_group_name": asgName,
+					"key":                    key,
+				},
+				Props: map[string]any{
+					"AutoScalingGroupName": asgName,
+					"Key":                  key,
+					"Value":                value,
+				},
+			})
+		}
+	}
+	return emissions, nil
+}

--- a/cmd/insideout-import/awsdiscover/sdkonly_autoscaling_test.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_autoscaling_test.go
@@ -1,0 +1,262 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	astypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+)
+
+// fakeASGTagClient implements asgTagClient for in-test fakes. Each
+// DescribeAutoScalingGroups response is queueable per "call shape"
+// (filtered-by-names vs unfiltered) so the ListParents and FetchItems
+// paths can be seeded independently.
+type fakeASGTagClient struct {
+	allGroups   *autoscaling.DescribeAutoScalingGroupsOutput
+	groupByName map[string]*autoscaling.DescribeAutoScalingGroupsOutput
+	errOnAll    error
+	errOnByName map[string]error
+	callsAll    int
+	callsByName map[string]int
+}
+
+func (f *fakeASGTagClient) DescribeAutoScalingGroups(_ context.Context, in *autoscaling.DescribeAutoScalingGroupsInput, _ ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingGroupsOutput, error) {
+	if len(in.AutoScalingGroupNames) > 0 {
+		name := in.AutoScalingGroupNames[0]
+		if err, ok := f.errOnByName[name]; ok {
+			return nil, err
+		}
+		if f.callsByName == nil {
+			f.callsByName = map[string]int{}
+		}
+		f.callsByName[name]++
+		if out, ok := f.groupByName[name]; ok {
+			return out, nil
+		}
+		return &autoscaling.DescribeAutoScalingGroupsOutput{}, nil
+	}
+	if f.errOnAll != nil {
+		return nil, f.errOnAll
+	}
+	f.callsAll++
+	if f.allGroups != nil {
+		return f.allGroups, nil
+	}
+	return &autoscaling.DescribeAutoScalingGroupsOutput{}, nil
+}
+
+// TestListASGNames_HappyPath pins the parent-enumeration contract:
+// names surface in the order the SDK returned, deterministically
+// (the discoverer re-sorts on emit so any order is acceptable; the
+// lister's job is to pass through).
+func TestListASGNames_HappyPath(t *testing.T) {
+	t.Parallel()
+	fake := &fakeASGTagClient{
+		allGroups: &autoscaling.DescribeAutoScalingGroupsOutput{
+			AutoScalingGroups: []astypes.AutoScalingGroup{
+				{AutoScalingGroupName: ptr("asg-web"), AvailabilityZones: []string{"us-east-1a"}},
+				{AutoScalingGroupName: ptr("asg-worker"), AvailabilityZones: []string{"us-east-1a"}},
+			},
+		},
+	}
+	got, err := listASGNamesWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	want := []string{"asg-web", "asg-worker"}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("got[%d]=%q, want %q", i, got[i], w)
+		}
+	}
+}
+
+// TestListASGNames_EmptyAccountReturnsNonNil pins the #255 JSON-shape
+// contract.
+func TestListASGNames_EmptyAccountReturnsNonNil(t *testing.T) {
+	t.Parallel()
+	fake := &fakeASGTagClient{}
+	got, err := listASGNamesWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Error("got=nil, want non-nil empty slice")
+	}
+}
+
+// TestListASGNames_PropagatesError pins the wrap-and-surface contract
+// for the per-region abort path.
+func TestListASGNames_PropagatesError(t *testing.T) {
+	t.Parallel()
+	seedErr := errors.New("describe-asg-seed")
+	fake := &fakeASGTagClient{errOnAll: seedErr}
+	_, err := listASGNamesWithClient(context.Background(), fake)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, seedErr) {
+		t.Errorf("err=%v, want errors.Is(err, seedErr)", err)
+	}
+}
+
+// TestFetchASGTags_MultipleTagsEmitOnePerKey pins the core multi-emit
+// semantics: one ASG with N tags yields N TF-resource emissions, each
+// with the canonical "<asg_name>,<tag_key>" import ID.
+func TestFetchASGTags_MultipleTagsEmitOnePerKey(t *testing.T) {
+	t.Parallel()
+	asg := "asg-web"
+	fake := &fakeASGTagClient{
+		groupByName: map[string]*autoscaling.DescribeAutoScalingGroupsOutput{
+			asg: {
+				AutoScalingGroups: []astypes.AutoScalingGroup{
+					{
+						AutoScalingGroupName: ptr(asg),
+						AvailabilityZones:    []string{"us-east-1a"},
+						Tags: []astypes.TagDescription{
+							{Key: ptr("Environment"), Value: ptr("prod"), ResourceId: ptr(asg)},
+							{Key: ptr("Owner"), Value: ptr("platform"), ResourceId: ptr(asg)},
+							{Key: ptr("Project"), Value: ptr("io-abc"), ResourceId: ptr(asg)},
+						},
+					},
+				},
+			},
+		},
+	}
+	got, err := fetchASGTagsWithClient(context.Background(), fake, asg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len=%d, want 3 (one per tag key)", len(got))
+	}
+	wantImports := map[string]bool{
+		asg + ",Environment": false,
+		asg + ",Owner":       false,
+		asg + ",Project":     false,
+	}
+	for _, e := range got {
+		if _, ok := wantImports[e.ImportID]; ok {
+			wantImports[e.ImportID] = true
+		}
+		if e.NativeIDs["autoscaling_group_name"] != asg {
+			t.Errorf("NativeIDs[autoscaling_group_name]=%q, want %s", e.NativeIDs["autoscaling_group_name"], asg)
+		}
+		if e.NativeIDs["key"] == "" {
+			t.Errorf("NativeIDs[key] empty for emission %s", e.ImportID)
+		}
+	}
+	for k, ok := range wantImports {
+		if !ok {
+			t.Errorf("expected emission with ImportID=%q", k)
+		}
+	}
+}
+
+// TestFetchASGTags_NoTagsEmitsZero pins that an ASG with no tags
+// yields a non-nil empty slice (JSON-shape contract). Untagged ASGs
+// are common in dev accounts.
+func TestFetchASGTags_NoTagsEmitsZero(t *testing.T) {
+	t.Parallel()
+	asg := "untagged-asg"
+	fake := &fakeASGTagClient{
+		groupByName: map[string]*autoscaling.DescribeAutoScalingGroupsOutput{
+			asg: {
+				AutoScalingGroups: []astypes.AutoScalingGroup{
+					{AutoScalingGroupName: ptr(asg), AvailabilityZones: []string{"us-east-1a"}},
+				},
+			},
+		},
+	}
+	got, err := fetchASGTagsWithClient(context.Background(), fake, asg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Error("got=nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("len=%d, want 0", len(got))
+	}
+}
+
+// TestFetchASGTags_VanishedASGEmitsZero pins the race-with-deletion
+// case: DescribeAutoScalingGroups returns an empty AutoScalingGroups
+// slice for a vanished ASG (no NotFound error). The FetchItems closure
+// emits zero rather than erroring.
+func TestFetchASGTags_VanishedASGEmitsZero(t *testing.T) {
+	t.Parallel()
+	fake := &fakeASGTagClient{
+		groupByName: map[string]*autoscaling.DescribeAutoScalingGroupsOutput{
+			"missing-asg": {AutoScalingGroups: nil},
+		},
+	}
+	got, err := fetchASGTagsWithClient(context.Background(), fake, "missing-asg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len=%d, want 0 (vanished ASG produces no tag emissions)", len(got))
+	}
+}
+
+// TestFetchASGTags_EmptyKeySkipped pins that a TagDescription with an
+// empty Key is silently dropped — emitting a TF resource with an empty
+// key half of the import ID would be unaddressable.
+func TestFetchASGTags_EmptyKeySkipped(t *testing.T) {
+	t.Parallel()
+	asg := "asg"
+	fake := &fakeASGTagClient{
+		groupByName: map[string]*autoscaling.DescribeAutoScalingGroupsOutput{
+			asg: {
+				AutoScalingGroups: []astypes.AutoScalingGroup{
+					{
+						AutoScalingGroupName: ptr(asg),
+						AvailabilityZones:    []string{"us-east-1a"},
+						Tags: []astypes.TagDescription{
+							{Key: ptr(""), Value: ptr("ignored")},
+							{Key: ptr("RealKey"), Value: ptr("kept")},
+						},
+					},
+				},
+			},
+		},
+	}
+	got, err := fetchASGTagsWithClient(context.Background(), fake, asg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Errorf("len=%d, want 1 (empty-key entry must be skipped)", len(got))
+	}
+}
+
+// TestFetchASGTags_PropagatesError pins that an SDK error on the
+// per-ASG describe call surfaces so the bulk Discover path can
+// ServiceWarn it.
+func TestFetchASGTags_PropagatesError(t *testing.T) {
+	t.Parallel()
+	seedErr := errors.New("describe-by-name-seed")
+	fake := &fakeASGTagClient{
+		errOnByName: map[string]error{"asg-X": seedErr},
+	}
+	_, err := fetchASGTagsWithClient(context.Background(), fake, "asg-X")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// TestNewASGTagClient_ProductionFactoryReturnsRealClient pins the
+// production factory.
+func TestNewASGTagClient_ProductionFactoryReturnsRealClient(t *testing.T) {
+	t.Parallel()
+	c := newASGTagClient(aws.Config{Region: "us-east-1"}, "us-east-1")
+	if c == nil {
+		t.Fatal("newASGTagClient returned nil")
+	}
+}

--- a/cmd/insideout-import/awsdiscover/sdkonly_ddb.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_ddb.go
@@ -1,0 +1,116 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// ddbSubresourceClient is the narrow subset of the DynamoDB API the
+// SDK-only sub-resource discoverer issues. Real *dynamodb.Client and
+// in-test fakes satisfy this interface; production code constructs the
+// real client via dynamodb.NewFromConfig from each FetchItem closure
+// (factory at newDDBSubresourceClient).
+//
+// Only the table-enumeration + DescribeContributorInsights RPCs are
+// listed — the discoverer does not mutate state and does not need any
+// other DDB surface.
+type ddbSubresourceClient interface {
+	ListTables(ctx context.Context, in *dynamodb.ListTablesInput, opts ...func(*dynamodb.Options)) (*dynamodb.ListTablesOutput, error)
+	DescribeContributorInsights(ctx context.Context, in *dynamodb.DescribeContributorInsightsInput, opts ...func(*dynamodb.Options)) (*dynamodb.DescribeContributorInsightsOutput, error)
+}
+
+// newDDBSubresourceClient is the production factory injected into each
+// DDB FetchItem closure. Tests construct fakes directly and pass them
+// to *WithClient helpers so every per-bucket test runs under
+// t.Parallel() without inter-test races.
+var newDDBSubresourceClient = func(awsCfg aws.Config, region string) ddbSubresourceClient {
+	return dynamodb.NewFromConfig(awsCfg, func(o *dynamodb.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+}
+
+// listDDBTables enumerates every DynamoDB table in the region via
+// dynamodb:ListTables (paginated). Used as the ListParents callback
+// for aws_dynamodb_contributor_insights when the RGT cache for
+// AWS::DynamoDB::Table is empty.
+//
+// SkipProjectTagFilter=true on the type config means the RGT short-
+// circuit in the discoverer is bypassed, so this lister always runs.
+// That's correct for the contributor-insights sub-resource because
+// the sub-resource itself is untaggable; the operator's --project tag
+// filter still applies indirectly via args.TagSelectors in the parent
+// list (but ListTables doesn't surface tags, so we accept the over-
+// approximation — a follow-up FetchItem yields zero results for
+// tables whose contributor insights aren't enabled, naturally
+// filtering tables the operator didn't tag).
+func listDDBTables(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := newDDBSubresourceClient(awsCfg, region)
+	return listDDBTablesWithClient(ctx, client)
+}
+
+func listDDBTablesWithClient(ctx context.Context, client ddbSubresourceClient) ([]string, error) {
+	names := []string{}
+	var start *string
+	for {
+		out, err := client.ListTables(ctx, &dynamodb.ListTablesInput{ExclusiveStartTableName: start})
+		if err != nil {
+			return nil, fmt.Errorf("dynamodb:ListTables: %w", err)
+		}
+		names = append(names, out.TableNames...)
+		if out.LastEvaluatedTableName == nil || aws.ToString(out.LastEvaluatedTableName) == "" {
+			break
+		}
+		start = out.LastEvaluatedTableName
+	}
+	return names, nil
+}
+
+// fetchDDBContributorInsights implements FetchItem for
+// aws_dynamodb_contributor_insights.
+//
+// "exists" semantics: TF resource exists iff
+// ContributorInsightsStatus is ENABLED or ENABLING. DISABLED /
+// DISABLING / FAILED yield exists=false because the TF resource only
+// represents an active (or in-progress) enablement — a disabled
+// status is equivalent to "not configured." ResourceNotFoundException
+// also yields exists=false (table vanished or DDB returned
+// "feature never used" for legacy tables).
+//
+// The TF import ID is the bare table name — verified against
+// terraform-provider-aws v6.x source: DynamoDB contributor insights
+// uses table_name as the resource's primary id.
+func fetchDDBContributorInsights(ctx context.Context, awsCfg aws.Config, region, parentID string) (bool, map[string]any, map[string]string, error) {
+	return fetchDDBContributorInsightsWithClient(ctx, newDDBSubresourceClient(awsCfg, region), parentID)
+}
+
+func fetchDDBContributorInsightsWithClient(ctx context.Context, client ddbSubresourceClient, parentID string) (bool, map[string]any, map[string]string, error) {
+	out, err := client.DescribeContributorInsights(ctx, &dynamodb.DescribeContributorInsightsInput{TableName: aws.String(parentID)})
+	if err != nil {
+		if isAPIErrorCode(err, "ResourceNotFoundException") {
+			return false, nil, nil, nil
+		}
+		return false, nil, nil, err
+	}
+	if out == nil {
+		return false, nil, nil, nil
+	}
+	switch out.ContributorInsightsStatus {
+	case ddbtypes.ContributorInsightsStatusEnabled, ddbtypes.ContributorInsightsStatusEnabling:
+		// fall through to emit
+	default:
+		// DISABLED / DISABLING / FAILED — TF resource not present.
+		return false, nil, nil, nil
+	}
+	props := map[string]any{
+		"TableName": parentID,
+		"Status":    string(out.ContributorInsightsStatus),
+	}
+	nativeIDs := map[string]string{"table_name": parentID}
+	return true, props, nativeIDs, nil
+}

--- a/cmd/insideout-import/awsdiscover/sdkonly_ddb_test.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_ddb_test.go
@@ -1,0 +1,206 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// fakeDDBSubresourceClient is the in-test fake for the DDB sub-resource
+// client interface. Each table can be seeded with either a DescribeContributorInsights
+// response or an error so per-table test cases can exercise success,
+// not-configured, race, and propagation paths independently.
+type fakeDDBSubresourceClient struct {
+	tables       []string
+	listErr      error
+	insightsByT  map[string]dynamodb.DescribeContributorInsightsOutput
+	insightsErrT map[string]error
+}
+
+func (f *fakeDDBSubresourceClient) ListTables(_ context.Context, _ *dynamodb.ListTablesInput, _ ...func(*dynamodb.Options)) (*dynamodb.ListTablesOutput, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return &dynamodb.ListTablesOutput{TableNames: f.tables}, nil
+}
+
+func (f *fakeDDBSubresourceClient) DescribeContributorInsights(_ context.Context, in *dynamodb.DescribeContributorInsightsInput, _ ...func(*dynamodb.Options)) (*dynamodb.DescribeContributorInsightsOutput, error) {
+	t := aws.ToString(in.TableName)
+	if err, ok := f.insightsErrT[t]; ok {
+		return nil, err
+	}
+	if out, ok := f.insightsByT[t]; ok {
+		return &out, nil
+	}
+	return &dynamodb.DescribeContributorInsightsOutput{}, nil
+}
+
+// TestListDDBTables_HappyPath pins the parent-enumeration contract:
+// ListTables returns the table names in the order the SDK reported.
+func TestListDDBTables_HappyPath(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDDBSubresourceClient{tables: []string{"users", "orders", "products"}}
+	got, err := listDDBTablesWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	want := []string{"orders", "products", "users"}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("got[%d]=%q, want %q", i, got[i], w)
+		}
+	}
+}
+
+// TestListDDBTables_PropagatesError pins that an SDK error wraps and
+// propagates so the discoverer's per-region abort path can identify it.
+func TestListDDBTables_PropagatesError(t *testing.T) {
+	t.Parallel()
+	seedErr := errors.New("list-tables-seed")
+	fake := &fakeDDBSubresourceClient{listErr: seedErr}
+	_, err := listDDBTablesWithClient(context.Background(), fake)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, seedErr) {
+		t.Errorf("err=%v, want errors.Is(err, seedErr)", err)
+	}
+}
+
+// TestListDDBTables_EmptyAccountReturnsNonNilSlice pins the #255
+// contract: zero tables surface as `[]`, not nil, so downstream JSON
+// marshaling produces "[]" not "null".
+func TestListDDBTables_EmptyAccountReturnsNonNilSlice(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDDBSubresourceClient{tables: nil}
+	got, err := listDDBTablesWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Error("got=nil, want non-nil empty slice (#255 JSON-shape contract)")
+	}
+	if len(got) != 0 {
+		t.Errorf("len=%d, want 0", len(got))
+	}
+}
+
+// TestFetchDDBContributorInsights_EnabledEmitsExistsTrue pins that
+// ContributorInsightsStatus=ENABLED yields exists=true plus the
+// table_name NativeID.
+func TestFetchDDBContributorInsights_EnabledEmitsExistsTrue(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDDBSubresourceClient{
+		insightsByT: map[string]dynamodb.DescribeContributorInsightsOutput{
+			"users": {ContributorInsightsStatus: ddbtypes.ContributorInsightsStatusEnabled},
+		},
+	}
+	exists, _, native, err := fetchDDBContributorInsightsWithClient(context.Background(), fake, "users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("exists=false, want true (Status=ENABLED)")
+	}
+	if native["table_name"] != "users" {
+		t.Errorf("NativeIDs[table_name]=%q, want users", native["table_name"])
+	}
+}
+
+// TestFetchDDBContributorInsights_EnablingEmitsExistsTrue pins that
+// ENABLING (in-progress enable) still produces the TF resource — the
+// TF resource exists across the lifecycle from ENABLING through
+// ENABLED.
+func TestFetchDDBContributorInsights_EnablingEmitsExistsTrue(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDDBSubresourceClient{
+		insightsByT: map[string]dynamodb.DescribeContributorInsightsOutput{
+			"users": {ContributorInsightsStatus: ddbtypes.ContributorInsightsStatusEnabling},
+		},
+	}
+	exists, _, _, err := fetchDDBContributorInsightsWithClient(context.Background(), fake, "users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("exists=false, want true (Status=ENABLING)")
+	}
+}
+
+// TestFetchDDBContributorInsights_DisabledEmitsExistsFalse pins that
+// DISABLED status maps to exists=false (TF resource not present, even
+// though the table itself exists).
+func TestFetchDDBContributorInsights_DisabledEmitsExistsFalse(t *testing.T) {
+	t.Parallel()
+	for _, status := range []ddbtypes.ContributorInsightsStatus{
+		ddbtypes.ContributorInsightsStatusDisabled,
+		ddbtypes.ContributorInsightsStatusDisabling,
+		ddbtypes.ContributorInsightsStatusFailed,
+	} {
+		fake := &fakeDDBSubresourceClient{
+			insightsByT: map[string]dynamodb.DescribeContributorInsightsOutput{
+				"users": {ContributorInsightsStatus: status},
+			},
+		}
+		exists, _, _, err := fetchDDBContributorInsightsWithClient(context.Background(), fake, "users")
+		if err != nil {
+			t.Errorf("%s: err=%v, want nil", status, err)
+		}
+		if exists {
+			t.Errorf("%s: exists=true, want false (TF resource models active enablement only)", status)
+		}
+	}
+}
+
+// TestFetchDDBContributorInsights_NotFoundSwallowed pins the race
+// case: ListTables emitted a table that vanished before
+// DescribeContributorInsights ran. ResourceNotFoundException must
+// surface as exists=false rather than warn-spam.
+func TestFetchDDBContributorInsights_NotFoundSwallowed(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDDBSubresourceClient{
+		insightsErrT: map[string]error{
+			"missing": fakeAPIErr("ResourceNotFoundException", "table disappeared"),
+		},
+	}
+	exists, _, _, err := fetchDDBContributorInsightsWithClient(context.Background(), fake, "missing")
+	if err != nil {
+		t.Fatalf("err=%v, want nil (ResourceNotFoundException swallowed)", err)
+	}
+	if exists {
+		t.Error("exists=true, want false")
+	}
+}
+
+// TestFetchDDBContributorInsights_PropagatesGenericError pins that
+// errors other than ResourceNotFoundException propagate so the bulk
+// Discover path can emit a ServiceWarn.
+func TestFetchDDBContributorInsights_PropagatesGenericError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDDBSubresourceClient{
+		insightsErrT: map[string]error{
+			"users": fakeAPIErr("AccessDenied", "no perms"),
+		},
+	}
+	_, _, _, err := fetchDDBContributorInsightsWithClient(context.Background(), fake, "users")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// TestNewDDBSubresourceClient_ProductionFactoryReturnsRealClient pins
+// the production factory's contract: a real *dynamodb.Client (not nil),
+// constructed from the supplied aws.Config.
+func TestNewDDBSubresourceClient_ProductionFactoryReturnsRealClient(t *testing.T) {
+	t.Parallel()
+	c := newDDBSubresourceClient(aws.Config{Region: "us-east-1"}, "us-east-1")
+	if c == nil {
+		t.Fatal("newDDBSubresourceClient returned nil")
+	}
+}

--- a/cmd/insideout-import/awsdiscover/sdkonly_helpers.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_helpers.go
@@ -1,0 +1,39 @@
+package awsdiscover
+
+import (
+	"errors"
+
+	smithy "github.com/aws/smithy-go"
+)
+
+// isAPIErrorCode reports whether err unwraps to a smithy.APIError whose
+// ErrorCode matches any of codes. Cross-service helper shared by the
+// SDK-only sub-resource discoverers (Bundle 14k1+14k2) — DDB, IAM,
+// WAFv2, and AutoScaling all surface "this child does not exist" via
+// typed-error or generic-API-error codes (ResourceNotFoundException,
+// NoSuchEntity, WAFInvalidParameterException, …) that the per-type
+// FetchItem / FetchItems closures convert into "skip silently."
+//
+// The S3 sub-resources (14k1) use a similar helper (isS3NotSetError)
+// kept in sdkonly_s3.go for proximity to the per-RPC code lists; the
+// implementation is identical. Both helpers are kept rather than one
+// being deleted because the doc comments on isS3NotSetError pin the
+// S3-specific code set (NoSuchLifecycleConfiguration etc.) and serve
+// as in-tree reference for those code names.
+//
+// nil err returns false; non-smithy errors return false.
+func isAPIErrorCode(err error, codes ...string) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		got := apiErr.ErrorCode()
+		for _, want := range codes {
+			if got == want {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/cmd/insideout-import/awsdiscover/sdkonly_iam.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_iam.go
@@ -1,0 +1,150 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+)
+
+// iamRolePolicyAttachmentClient is the narrow subset of the IAM API
+// the aws_iam_role_policy_attachment SDK-only sub-resource discoverer
+// issues. Real *iam.Client and in-test fakes satisfy this interface;
+// production code constructs the real client via iam.NewFromConfig
+// from each FetchItems closure (factory at newIAMRPAClient).
+type iamRolePolicyAttachmentClient interface {
+	ListRoles(ctx context.Context, in *iam.ListRolesInput, opts ...func(*iam.Options)) (*iam.ListRolesOutput, error)
+	ListAttachedRolePolicies(ctx context.Context, in *iam.ListAttachedRolePoliciesInput, opts ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error)
+}
+
+// newIAMRPAClient is the production factory injected into each IAM
+// FetchItems / ListParents closure. Tests construct fakes directly
+// and pass them to *WithClient helpers so every test runs under
+// t.Parallel() without inter-test races.
+//
+// IAM is a global service; the region argument is ignored at the SDK
+// level (IAM endpoint is always us-east-1 for non-FIPS), but kept in
+// the factory signature for parity with the regional sub-resource
+// clients.
+var newIAMRPAClient = func(awsCfg aws.Config, _ string) iamRolePolicyAttachmentClient {
+	return iam.NewFromConfig(awsCfg)
+}
+
+// listIAMRoleNamesNonSLR enumerates IAM role names suitable as
+// parents for aws_iam_role_policy_attachment, dropping service-linked
+// roles (Path starts with /aws-service-role/). Service-linked roles
+// reject AttachRolePolicy with AccessDenied so listing them would
+// produce N noisy per-parent ListAttachedRolePolicies failures on
+// the downstream FetchItems fan-out.
+//
+// Mirrors the SLR-skip semantics of listIAMRolesAsResourceModelsWithClient
+// in cloudcontrol_listers.go but emits bare role names instead of
+// CC ResourceModel JSON — the SDK-only sub-resource discoverer
+// fans out by parent identifier directly.
+//
+// Returns a non-nil empty slice on accounts with zero roles (#255).
+func listIAMRoleNamesNonSLR(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := newIAMRPAClient(awsCfg, region)
+	return listIAMRoleNamesNonSLRWithClient(ctx, client)
+}
+
+func listIAMRoleNamesNonSLRWithClient(ctx context.Context, client iamRolePolicyAttachmentClient) ([]string, error) {
+	names := []string{}
+	var marker *string
+	for {
+		page, err := client.ListRoles(ctx, &iam.ListRolesInput{Marker: marker})
+		if err != nil {
+			return nil, fmt.Errorf("iam:ListRoles: %w", err)
+		}
+		for _, r := range page.Roles {
+			name := aws.ToString(r.RoleName)
+			if name == "" {
+				continue
+			}
+			if strings.HasPrefix(aws.ToString(r.Path), iamServiceRolePathPrefix) {
+				continue
+			}
+			names = append(names, name)
+		}
+		if !page.IsTruncated || page.Marker == nil || aws.ToString(page.Marker) == "" {
+			break
+		}
+		marker = page.Marker
+	}
+	return names, nil
+}
+
+// fetchIAMRolePolicyAttachments implements FetchItems for
+// aws_iam_role_policy_attachment.
+//
+// One parent (role) yields N emissions — one per attached managed
+// policy. Terraform's import format for aws_iam_role_policy_attachment
+// is "<role_name>/<policy_arn>" — verified against
+// terraform-provider-aws v6.x internal/service/iam/role_policy_attachment.go::
+// resourceRolePolicyAttachmentImport, which splits on "/" with N=2.
+//
+// NameHint = the policy ARN (the discriminating attribute per
+// attachment; address generation uses it to disambiguate addresses
+// when one role has many attachments).
+//
+// NativeIDs carry both the role and policy ARN so reliable's UI
+// surfaces and dep-chase cross-resource navigation can follow the
+// edge to either side without re-parsing the compound import ID.
+//
+// Pagination: iam:ListAttachedRolePolicies pages via Marker; the
+// loop drains all pages so a 100+-attachment role doesn't silently
+// truncate (IAM caps attachments per role at 20 by default, raised
+// to 50 with quota requests, but the loop handles any count).
+//
+// NoSuchEntity on a role that disappeared between ListRoles and
+// ListAttachedRolePolicies yields zero emissions (silently skipped)
+// — the per-parent soft-fail in the framework converts other errors
+// to ServiceWarn.
+func fetchIAMRolePolicyAttachments(ctx context.Context, awsCfg aws.Config, region, parentID string) ([]subresourceEmission, error) {
+	return fetchIAMRolePolicyAttachmentsWithClient(ctx, newIAMRPAClient(awsCfg, region), parentID)
+}
+
+func fetchIAMRolePolicyAttachmentsWithClient(ctx context.Context, client iamRolePolicyAttachmentClient, roleName string) ([]subresourceEmission, error) {
+	emissions := []subresourceEmission{}
+	var marker *string
+	for {
+		page, err := client.ListAttachedRolePolicies(ctx, &iam.ListAttachedRolePoliciesInput{
+			RoleName: aws.String(roleName),
+			Marker:   marker,
+		})
+		if err != nil {
+			// NoSuchEntity = role vanished between ListRoles and
+			// this fetch. Silently skip rather than warn-spam.
+			if isAPIErrorCode(err, "NoSuchEntity", "NoSuchEntityException") {
+				return emissions, nil
+			}
+			return nil, fmt.Errorf("iam:ListAttachedRolePolicies role=%q: %w", roleName, err)
+		}
+		for _, ap := range page.AttachedPolicies {
+			policyARN := aws.ToString(ap.PolicyArn)
+			if policyARN == "" {
+				continue
+			}
+			emissions = append(emissions, subresourceEmission{
+				ImportID: roleName + "/" + policyARN,
+				NameHint: policyARN,
+				NativeIDs: map[string]string{
+					"role":       roleName,
+					"policy_arn": policyARN,
+				},
+				Props: map[string]any{
+					"RoleName":   roleName,
+					"PolicyName": aws.ToString(ap.PolicyName),
+					"PolicyArn":  policyARN,
+				},
+			})
+		}
+		if !page.IsTruncated || page.Marker == nil || aws.ToString(page.Marker) == "" {
+			break
+		}
+		marker = page.Marker
+	}
+	return emissions, nil
+}

--- a/cmd/insideout-import/awsdiscover/sdkonly_iam_test.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_iam_test.go
@@ -1,0 +1,330 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// fakeIAMRPAClient implements the iamRolePolicyAttachmentClient
+// interface for in-test fakes. The narrow surface (ListRoles +
+// ListAttachedRolePolicies) lets per-test seeds drive both the
+// parent-enumeration path and the multi-emit FetchItems path
+// independently.
+type fakeIAMRPAClient struct {
+	rolesPages []*iam.ListRolesOutput
+	rolesIdx   int
+	rolesErr   error
+
+	attachedByRole    map[string][]*iam.ListAttachedRolePoliciesOutput
+	attachedIdxByRole map[string]int
+	attachedErrByRole map[string]error
+}
+
+func (f *fakeIAMRPAClient) ListRoles(_ context.Context, _ *iam.ListRolesInput, _ ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
+	if f.rolesErr != nil {
+		return nil, f.rolesErr
+	}
+	if f.rolesIdx >= len(f.rolesPages) {
+		return &iam.ListRolesOutput{}, nil
+	}
+	out := f.rolesPages[f.rolesIdx]
+	f.rolesIdx++
+	return out, nil
+}
+
+func (f *fakeIAMRPAClient) ListAttachedRolePolicies(_ context.Context, in *iam.ListAttachedRolePoliciesInput, _ ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error) {
+	role := aws.ToString(in.RoleName)
+	if err, ok := f.attachedErrByRole[role]; ok {
+		return nil, err
+	}
+	pages, ok := f.attachedByRole[role]
+	if !ok {
+		return &iam.ListAttachedRolePoliciesOutput{}, nil
+	}
+	if f.attachedIdxByRole == nil {
+		f.attachedIdxByRole = map[string]int{}
+	}
+	idx := f.attachedIdxByRole[role]
+	if idx >= len(pages) {
+		return &iam.ListAttachedRolePoliciesOutput{}, nil
+	}
+	f.attachedIdxByRole[role] = idx + 1
+	return pages[idx], nil
+}
+
+// TestListIAMRoleNamesNonSLR_FiltersServiceLinkedRoles pins the
+// SLR-skip behavior: roles whose Path starts with /aws-service-role/
+// are filtered out so the per-role attachment fan-out doesn't spam
+// AccessDenied warns. The SLR-skip prefix is the well-known
+// iamServiceRolePathPrefix constant.
+func TestListIAMRoleNamesNonSLR_FiltersServiceLinkedRoles(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRPAClient{
+		rolesPages: []*iam.ListRolesOutput{
+			{
+				Roles: []iamtypes.Role{
+					{RoleName: ptr("regular-role-A"), Path: ptr("/")},
+					{RoleName: ptr("regular-role-B"), Path: ptr("/some/custom/path/")},
+					{RoleName: ptr("AWSServiceRoleForElasticache"), Path: ptr("/aws-service-role/elasticache.amazonaws.com/")},
+					{RoleName: ptr("AWSServiceRoleForRDS"), Path: ptr("/aws-service-role/rds.amazonaws.com/")},
+				},
+			},
+		},
+	}
+	got, err := listIAMRoleNamesNonSLRWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	want := []string{"regular-role-A", "regular-role-B"}
+	if len(got) != len(want) {
+		t.Fatalf("len=%d, want %d (SLRs must be filtered)", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("got[%d]=%q, want %q", i, got[i], w)
+		}
+	}
+}
+
+// TestListIAMRoleNamesNonSLR_PaginatesViaMarker pins the
+// Marker-driven pagination contract. A two-page response surfaces
+// roles from both pages, IsTruncated=false on the second page
+// terminates the loop.
+func TestListIAMRoleNamesNonSLR_PaginatesViaMarker(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRPAClient{
+		rolesPages: []*iam.ListRolesOutput{
+			{
+				Roles: []iamtypes.Role{
+					{RoleName: ptr("role-1"), Path: ptr("/")},
+				},
+				IsTruncated: true,
+				Marker:      ptr("page-2"),
+			},
+			{
+				Roles: []iamtypes.Role{
+					{RoleName: ptr("role-2"), Path: ptr("/")},
+				},
+				IsTruncated: false,
+			},
+		},
+	}
+	got, err := listIAMRoleNamesNonSLRWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (both pages drained)", len(got))
+	}
+}
+
+// TestListIAMRoleNamesNonSLR_EmptyAccountReturnsNonNil pins the #255
+// JSON-shape contract: zero roles surface as a non-nil empty slice.
+func TestListIAMRoleNamesNonSLR_EmptyAccountReturnsNonNil(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRPAClient{rolesPages: nil}
+	got, err := listIAMRoleNamesNonSLRWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Error("got=nil, want non-nil empty slice (#255 JSON-shape contract)")
+	}
+}
+
+// TestFetchIAMRolePolicyAttachments_MultipleAttachmentsEmitOnePerPolicy
+// pins the core multi-emit semantics: one role with N attached managed
+// policies yields N TF-resource emissions, each with the canonical
+// "<role>/<policy_arn>" import ID.
+func TestFetchIAMRolePolicyAttachments_MultipleAttachmentsEmitOnePerPolicy(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRPAClient{
+		attachedByRole: map[string][]*iam.ListAttachedRolePoliciesOutput{
+			"my-role": {
+				{
+					AttachedPolicies: []iamtypes.AttachedPolicy{
+						{PolicyName: ptr("AmazonS3ReadOnlyAccess"), PolicyArn: ptr("arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess")},
+						{PolicyName: ptr("CloudWatchLogsFullAccess"), PolicyArn: ptr("arn:aws:iam::aws:policy/CloudWatchLogsFullAccess")},
+					},
+				},
+			},
+		},
+	}
+	got, err := fetchIAMRolePolicyAttachmentsWithClient(context.Background(), fake, "my-role")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (one per attached policy)", len(got))
+	}
+	wantImports := map[string]bool{
+		"my-role/arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess":   false,
+		"my-role/arn:aws:iam::aws:policy/CloudWatchLogsFullAccess": false,
+	}
+	for _, e := range got {
+		if _, ok := wantImports[e.ImportID]; ok {
+			wantImports[e.ImportID] = true
+		}
+		if e.NativeIDs["role"] != "my-role" {
+			t.Errorf("NativeIDs[role]=%q, want my-role", e.NativeIDs["role"])
+		}
+		if e.NativeIDs["policy_arn"] == "" {
+			t.Errorf("NativeIDs[policy_arn] is empty for emission %s", e.ImportID)
+		}
+	}
+	for k, ok := range wantImports {
+		if !ok {
+			t.Errorf("expected emission with ImportID=%q", k)
+		}
+	}
+}
+
+// TestFetchIAMRolePolicyAttachments_NoAttachmentsEmitsZero pins the
+// zero-attachment case: a role with no managed-policy attachments
+// yields an empty slice (not nil — JSON-shape contract).
+func TestFetchIAMRolePolicyAttachments_NoAttachmentsEmitsZero(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRPAClient{}
+	got, err := fetchIAMRolePolicyAttachmentsWithClient(context.Background(), fake, "lonely-role")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Error("got=nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("len=%d, want 0", len(got))
+	}
+}
+
+// TestFetchIAMRolePolicyAttachments_NoSuchEntitySwallowed pins the
+// race posture: a role that vanished between ListRoles and the
+// FetchItems call surfaces as zero emissions rather than a propagated
+// error. NoSuchEntity / NoSuchEntityException are both swallowed
+// because IAM's error code shape has varied across SDK releases.
+func TestFetchIAMRolePolicyAttachments_NoSuchEntitySwallowed(t *testing.T) {
+	t.Parallel()
+	for _, code := range []string{"NoSuchEntity", "NoSuchEntityException"} {
+		fake := &fakeIAMRPAClient{
+			attachedErrByRole: map[string]error{
+				"vanished-role": fakeAPIErr(code, "role gone"),
+			},
+		}
+		got, err := fetchIAMRolePolicyAttachmentsWithClient(context.Background(), fake, "vanished-role")
+		if err != nil {
+			t.Errorf("%s: err=%v, want nil (swallowed)", code, err)
+		}
+		if len(got) != 0 {
+			t.Errorf("%s: len=%d, want 0", code, len(got))
+		}
+	}
+}
+
+// TestFetchIAMRolePolicyAttachments_AccessDeniedPropagates pins that
+// AccessDenied (not a NotFound code) propagates so the bulk Discover
+// path's per-parent soft-fail can convert it to a ServiceWarn.
+func TestFetchIAMRolePolicyAttachments_AccessDeniedPropagates(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRPAClient{
+		attachedErrByRole: map[string]error{
+			"my-role": fakeAPIErr("AccessDenied", "no perms"),
+		},
+	}
+	_, err := fetchIAMRolePolicyAttachmentsWithClient(context.Background(), fake, "my-role")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// TestFetchIAMRolePolicyAttachments_PaginatesViaMarker pins the
+// multi-page contract: a role with >1 page of attachments drains
+// every page.
+func TestFetchIAMRolePolicyAttachments_PaginatesViaMarker(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRPAClient{
+		attachedByRole: map[string][]*iam.ListAttachedRolePoliciesOutput{
+			"big-role": {
+				{
+					AttachedPolicies: []iamtypes.AttachedPolicy{
+						{PolicyName: ptr("p1"), PolicyArn: ptr("arn:aws:iam::aws:policy/p1")},
+					},
+					IsTruncated: true,
+					Marker:      ptr("page-2"),
+				},
+				{
+					AttachedPolicies: []iamtypes.AttachedPolicy{
+						{PolicyName: ptr("p2"), PolicyArn: ptr("arn:aws:iam::aws:policy/p2")},
+					},
+					IsTruncated: false,
+				},
+			},
+		},
+	}
+	got, err := fetchIAMRolePolicyAttachmentsWithClient(context.Background(), fake, "big-role")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len=%d, want 2 (both pages drained)", len(got))
+	}
+}
+
+// TestFetchIAMRolePolicyAttachments_EmptyPolicyArnSkipped pins that a
+// malformed AttachedPolicy entry with no PolicyArn is silently
+// skipped rather than emitting an unaddressable resource.
+func TestFetchIAMRolePolicyAttachments_EmptyPolicyArnSkipped(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRPAClient{
+		attachedByRole: map[string][]*iam.ListAttachedRolePoliciesOutput{
+			"my-role": {
+				{
+					AttachedPolicies: []iamtypes.AttachedPolicy{
+						{PolicyName: ptr("real-policy"), PolicyArn: ptr("arn:aws:iam::aws:policy/real")},
+						{PolicyName: ptr("broken-policy"), PolicyArn: nil},
+					},
+				},
+			},
+		},
+	}
+	got, err := fetchIAMRolePolicyAttachmentsWithClient(context.Background(), fake, "my-role")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Errorf("len=%d, want 1 (entry with nil PolicyArn must be skipped)", len(got))
+	}
+}
+
+// TestListIAMRoleNamesNonSLR_PropagatesError pins that a real
+// ListRoles error surfaces wrapped so the discoverer's per-region
+// abort path identifies the source.
+func TestListIAMRoleNamesNonSLR_PropagatesError(t *testing.T) {
+	t.Parallel()
+	seedErr := errors.New("list-roles-seed")
+	fake := &fakeIAMRPAClient{rolesErr: seedErr}
+	_, err := listIAMRoleNamesNonSLRWithClient(context.Background(), fake)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, seedErr) {
+		t.Errorf("err=%v, want errors.Is(err, seedErr)", err)
+	}
+}
+
+// TestNewIAMRPAClient_ProductionFactoryReturnsRealClient pins the
+// production factory: a real *iam.Client (not nil), constructed from
+// the supplied aws.Config.
+func TestNewIAMRPAClient_ProductionFactoryReturnsRealClient(t *testing.T) {
+	t.Parallel()
+	c := newIAMRPAClient(aws.Config{Region: "us-east-1"}, "")
+	if c == nil {
+		t.Fatal("newIAMRPAClient returned nil")
+	}
+}

--- a/cmd/insideout-import/awsdiscover/sdkonly_s3.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_s3.go
@@ -202,6 +202,94 @@ var sdkOnlySubresourceTypeConfigs = []sdkOnlySubresourceConfig{
 		ImportIDFromParent:   func(parentID string, _ map[string]any) string { return parentID },
 		NameHintFromParent:   func(parentID string, _ map[string]any) string { return parentID + "-sse" },
 	},
+
+	// =====================================================================
+	// Bundle 14k2 — final 5 deferred AWS types via SDK-only pattern
+	// (issue #456). Four of the five emit N items per parent and use the
+	// 14k2-introduced FetchItems plural variant; one (DDB contributor
+	// insights) still uses the single-emission FetchItem because the
+	// underlying resource is one-per-table.
+	//
+	// `aws_security_group_rule` is intentionally NOT registered here.
+	// Terraform's legacy `aws_security_group_rule` uses a synthetic
+	// hash-based ID (`sgrule-<hash>`) computed from rule attributes that
+	// cannot be reliably reconstructed by the discoverer; emitting an
+	// import ID we cannot prove is correct would cause silent terraform
+	// import failures downstream. The replacement resources
+	// `aws_vpc_security_group_ingress_rule` /
+	// `aws_vpc_security_group_egress_rule` (which carry real-ARN-shape
+	// security_group_rule_id values returned by EC2) are the supported
+	// path forward for in-preset SG-rule discovery — tracked as a
+	// follow-up to #456.
+	// =====================================================================
+
+	{
+		// `aws_dynamodb_contributor_insights` — one per DDB table, exists
+		// iff ContributorInsightsStatus is ENABLED or ENABLING. Untaggable
+		// (the TF resource is a meta-binding on the table) so
+		// SkipProjectTagFilter=true and parent enumeration falls back to
+		// dynamodb:ListTables when the RGT cache for AWS::DynamoDB::Table
+		// is empty / cold. Import ID is the bare table name.
+		TFType:               "aws_dynamodb_contributor_insights",
+		Slug:                 "dynamodb_contributor_insights",
+		ParentCFNType:        "AWS::DynamoDB::Table",
+		SkipProjectTagFilter: true,
+		ListParents:          listDDBTables,
+		FetchItem:            fetchDDBContributorInsights,
+		ImportIDFromParent:   func(parentID string, _ map[string]any) string { return parentID },
+		NameHintFromParent:   func(parentID string, _ map[string]any) string { return parentID + "-contributor-insights" },
+	},
+	{
+		// `aws_iam_role_policy_attachment` — multi-emit. One IAM role
+		// yields one TF resource per attached managed policy. Import
+		// format is "<role_name>/<policy_arn>". IAM is a global service;
+		// IsGlobal=true ensures the discoverer issues one pass with
+		// region="" rather than fanning out per regional endpoint.
+		// Service-linked roles are filtered out at ListParents time
+		// (they cannot attach managed policies; see
+		// listIAMRoleNamesNonSLR).
+		TFType:               "aws_iam_role_policy_attachment",
+		Slug:                 "iam_role_policy_attachment",
+		ParentCFNType:        "AWS::IAM::Role",
+		IsGlobal:             true,
+		SkipProjectTagFilter: true,
+		ListParents:          listIAMRoleNamesNonSLR,
+		FetchItems:           fetchIAMRolePolicyAttachments,
+	},
+	{
+		// `aws_wafv2_web_acl_association` — multi-emit. One WAFv2 Web
+		// ACL yields one TF resource per associated resource ARN
+		// (ALB / API Gateway / AppSync / Cognito user pool / App Runner
+		// / Verified Access / Amplify). Import format is
+		// "<resource_arn>,<web_acl_arn>". ListParents enumerates both
+		// REGIONAL ACLs (in any region) and CLOUDFRONT-scoped ACLs (only
+		// in us-east-1 per the WAFv2 API docs); the framework loops the
+		// configured args.Regions and the per-region call only surfaces
+		// CLOUDFRONT when region=us-east-1.
+		TFType:               "aws_wafv2_web_acl_association",
+		Slug:                 "wafv2_web_acl_association",
+		ParentCFNType:        "AWS::WAFv2::WebACL",
+		SkipProjectTagFilter: true,
+		ListParents:          listWAFv2WebACLs,
+		FetchItems:           fetchWAFv2WebACLAssociations,
+	},
+	{
+		// `aws_autoscaling_group_tag` — multi-emit. One Auto Scaling
+		// Group yields one TF resource per (asg, tag_key) pair. Tags
+		// come back inline on DescribeAutoScalingGroups; no additional
+		// SDK call needed. Import format is "<asg_name>,<tag_key>".
+		// The TF resource exists alongside the inline `tag` blocks on
+		// `aws_autoscaling_group` for incremental tag management;
+		// presets that declare every tag inline will surface duplicate
+		// state for those tags here, which is the expected import-side
+		// behavior (the operator can choose which side owns each tag).
+		TFType:               "aws_autoscaling_group_tag",
+		Slug:                 "autoscaling_group_tag",
+		ParentCFNType:        "AWS::AutoScaling::AutoScalingGroup",
+		SkipProjectTagFilter: true,
+		ListParents:          listASGNames,
+		FetchItems:           fetchASGTags,
+	},
 }
 
 // fetchS3BucketVersioning implements FetchItem for aws_s3_bucket_versioning.
@@ -366,20 +454,31 @@ func s3SubresourceNativeIDs(bucket string) map[string]string {
 }
 
 // Compile-time sanity: every config in sdkOnlySubresourceTypeConfigs
-// must satisfy the minimal contract its discoverer asserts at runtime
-// (non-nil ListParents/FetchItem/ImportIDFromParent/NameHintFromParent).
-// Surfaces a registration regression at test-time rather than during a
-// live discover run.
+// must satisfy the minimal contract its discoverer asserts at runtime.
+// FetchItem (single-emission, Bundle 14k1) and FetchItems
+// (multi-emission, Bundle 14k2) are mutually exclusive — exactly one
+// must be set. When FetchItem is set, ImportIDFromParent and
+// NameHintFromParent are also required (the discoverer derives the
+// import ID from the parent identifier). When FetchItems is set, those
+// closures are ignored because each emission carries its own
+// addressing fields. Surfaces a registration regression at test-time
+// rather than during a live discover run.
 var _ = func() bool {
 	for _, cfg := range sdkOnlySubresourceTypeConfigs {
 		if cfg.TFType == "" || cfg.Slug == "" {
 			panic("sdkOnlySubresourceTypeConfigs entry missing TFType or Slug")
 		}
-		if cfg.ListParents == nil || cfg.FetchItem == nil {
-			panic("sdkOnlySubresourceTypeConfigs entry missing ListParents or FetchItem: " + cfg.TFType)
+		if cfg.ListParents == nil {
+			panic("sdkOnlySubresourceTypeConfigs entry missing ListParents: " + cfg.TFType)
 		}
-		if cfg.ImportIDFromParent == nil || cfg.NameHintFromParent == nil {
-			panic("sdkOnlySubresourceTypeConfigs entry missing ImportIDFromParent or NameHintFromParent: " + cfg.TFType)
+		if cfg.FetchItem == nil && cfg.FetchItems == nil {
+			panic("sdkOnlySubresourceTypeConfigs entry missing FetchItem or FetchItems: " + cfg.TFType)
+		}
+		if cfg.FetchItem != nil && cfg.FetchItems != nil {
+			panic("sdkOnlySubresourceTypeConfigs entry sets both FetchItem and FetchItems (mutually exclusive): " + cfg.TFType)
+		}
+		if cfg.FetchItem != nil && (cfg.ImportIDFromParent == nil || cfg.NameHintFromParent == nil) {
+			panic("sdkOnlySubresourceTypeConfigs entry missing ImportIDFromParent or NameHintFromParent (required when FetchItem is set): " + cfg.TFType)
 		}
 		if !strings.HasPrefix(cfg.TFType, "aws_") {
 			panic("sdkOnlySubresourceTypeConfigs entry TFType must start with aws_: " + cfg.TFType)

--- a/cmd/insideout-import/awsdiscover/sdkonly_s3_test.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_s3_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -418,18 +419,32 @@ func TestFetchS3BucketServerSideEncryption_NotFoundEmitsExistsFalse(t *testing.T
 	}
 }
 
-// TestSDKOnlySubresourceConfigs_RegistersFive14k1Types pins the
-// expected 5-type expansion of sdkOnlySubresourceTypeConfigs. A future
-// bundle adding 14k2/14k3 sub-resources must update both this test
-// and the registry/category/permissions plumbing.
-func TestSDKOnlySubresourceConfigs_RegistersFive14k1Types(t *testing.T) {
+// TestSDKOnlySubresourceConfigs_RegistersExpectedTypes pins the
+// expected expansion of sdkOnlySubresourceTypeConfigs.
+//
+//   - Bundle 14k1 (S3 sub-resources, single-emit via FetchItem): 5 types.
+//   - Bundle 14k2 (multi-emit via FetchItems): 4 types — DDB contributor
+//     insights (single-emit, parent=AWS::DynamoDB::Table), IAM role
+//     policy attachment (multi-emit, parent=AWS::IAM::Role), WAFv2 web
+//     ACL association (multi-emit, parent=AWS::WAFv2::WebACL), ASG tag
+//     (multi-emit, parent=AWS::AutoScaling::AutoScalingGroup).
+//
+// A future bundle adding sub-resources must update both this test and
+// the registry/category/permissions plumbing.
+func TestSDKOnlySubresourceConfigs_RegistersExpectedTypes(t *testing.T) {
 	t.Parallel()
 	want := map[string]bool{
+		// 14k1 — S3 sub-resources
 		"aws_s3_bucket_lifecycle_configuration":              false,
 		"aws_s3_bucket_ownership_controls":                   false,
 		"aws_s3_bucket_public_access_block":                  false,
 		"aws_s3_bucket_server_side_encryption_configuration": false,
 		"aws_s3_bucket_versioning":                           false,
+		// 14k2 — multi-emit + DDB
+		"aws_dynamodb_contributor_insights": false,
+		"aws_iam_role_policy_attachment":    false,
+		"aws_wafv2_web_acl_association":     false,
+		"aws_autoscaling_group_tag":         false,
 	}
 	for _, cfg := range sdkOnlySubresourceTypeConfigs {
 		if _, ok := want[cfg.TFType]; ok {
@@ -442,27 +457,64 @@ func TestSDKOnlySubresourceConfigs_RegistersFive14k1Types(t *testing.T) {
 		}
 	}
 	if len(sdkOnlySubresourceTypeConfigs) != len(want) {
-		t.Errorf("len(sdkOnlySubresourceTypeConfigs)=%d, want %d (the 5 14k1 S3 sub-resources). If 14k2 added new types, update this test alongside.",
+		t.Errorf("len(sdkOnlySubresourceTypeConfigs)=%d, want %d (5 from 14k1 + 4 from 14k2). If a future bundle added new types, update this test alongside.",
 			len(sdkOnlySubresourceTypeConfigs), len(want))
 	}
 }
 
-// TestSDKOnlySubresourceConfigs_AllShareS3BucketParent pins the shared
-// architectural constraint of Bundle 14k1: all 5 sub-resources parent
-// on AWS::S3::Bucket and set SkipProjectTagFilter=true (untaggable).
-// A future bundle adding sub-resources for a different parent would
-// fail this test as a signal to broaden it.
-func TestSDKOnlySubresourceConfigs_AllShareS3BucketParent(t *testing.T) {
+// TestSDKOnlySubresourceConfigs_S3SubsetShareS3BucketParent pins the
+// shared architectural constraint of Bundle 14k1's S3 subset: every S3
+// sub-resource parents on AWS::S3::Bucket and sets
+// SkipProjectTagFilter=true (untaggable). 14k2 introduced parents
+// other than S3 (DDB table, IAM role, ASG, WAFv2 WebACL), so this
+// test is now scoped to the S3 subset rather than the whole registry.
+func TestSDKOnlySubresourceConfigs_S3SubsetShareS3BucketParent(t *testing.T) {
 	t.Parallel()
 	for _, cfg := range sdkOnlySubresourceTypeConfigs {
+		if !strings.HasPrefix(cfg.TFType, "aws_s3_bucket_") {
+			continue
+		}
 		if cfg.ParentCFNType != "AWS::S3::Bucket" {
-			t.Errorf("%s: ParentCFNType=%q, want AWS::S3::Bucket (14k1 is S3-only; update test when 14k2 lands)", cfg.TFType, cfg.ParentCFNType)
+			t.Errorf("%s: ParentCFNType=%q, want AWS::S3::Bucket (S3 sub-resources only)", cfg.TFType, cfg.ParentCFNType)
 		}
 		if !cfg.SkipProjectTagFilter {
 			t.Errorf("%s: SkipProjectTagFilter=false, want true (all S3 sub-resources are untaggable)", cfg.TFType)
 		}
 		if cfg.Slug == "" {
 			t.Errorf("%s: empty Slug", cfg.TFType)
+		}
+	}
+}
+
+// TestSDKOnlySubresourceConfigs_AllUntaggable pins that every SDK-only
+// sub-resource registered today is untaggable (SkipProjectTagFilter=
+// true). The framework supports taggable consumers but no current type
+// uses that branch — when one lands, this test will need to be relaxed
+// to a per-type allowlist or schema lookup.
+func TestSDKOnlySubresourceConfigs_AllUntaggable(t *testing.T) {
+	t.Parallel()
+	for _, cfg := range sdkOnlySubresourceTypeConfigs {
+		if !cfg.SkipProjectTagFilter {
+			t.Errorf("%s: SkipProjectTagFilter=false, want true (all SDK-only sub-resources today are untaggable)", cfg.TFType)
+		}
+	}
+}
+
+// TestSDKOnlySubresourceConfigs_ExactlyOneFetchVariant pins the mutual
+// exclusion contract: every config must set FetchItem OR FetchItems,
+// never both, never neither. Mirrors the package-init panic in
+// sdkonly_s3.go's var anchor but surfaces a registration regression as
+// a test failure (with a useful diff) rather than a package-init crash.
+func TestSDKOnlySubresourceConfigs_ExactlyOneFetchVariant(t *testing.T) {
+	t.Parallel()
+	for _, cfg := range sdkOnlySubresourceTypeConfigs {
+		has1 := cfg.FetchItem != nil
+		hasN := cfg.FetchItems != nil
+		if !has1 && !hasN {
+			t.Errorf("%s: neither FetchItem nor FetchItems set", cfg.TFType)
+		}
+		if has1 && hasN {
+			t.Errorf("%s: both FetchItem and FetchItems set (mutually exclusive)", cfg.TFType)
 		}
 	}
 }

--- a/cmd/insideout-import/awsdiscover/sdkonly_subresource_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_subresource_discoverer.go
@@ -54,25 +54,40 @@ import (
 //     RGT-cache for ParentCFNType is empty / absent for the current
 //     region. Returns the parent identifiers (e.g. bucket names) used
 //     to drive the per-item FetchItem fan-out. Required.
-//   - FetchItem: per-parent SDK call that reads the sub-resource state.
-//     Returns (exists, props, nativeIDs, err). When the sub-resource is
-//     unset for this parent — typically signaled by a service-native
-//     NotFound error code (NoSuchVersioningConfiguration,
+//   - FetchItem: per-parent SDK call that reads the sub-resource state
+//     for the one-emission-per-parent case (Bundle 14k1 — all 5 S3 sub-
+//     resources). Returns (exists, props, nativeIDs, err). When the sub-
+//     resource is unset for this parent — typically signaled by a
+//     service-native NotFound error code (NoSuchVersioningConfiguration,
 //     NoSuchLifecycleConfiguration, OwnershipControlsNotFoundError,
 //     NoSuchPublicAccessBlockConfiguration,
 //     ServerSideEncryptionConfigurationNotFoundError) — FetchItem must
 //     return (false, nil, nil, nil) rather than an error so the parent
 //     is silently skipped. Any other error is propagated through a
 //     ServiceWarn and skips that parent (soft-fail symmetric with
-//     cloudControlDiscoverer's per-item GetResource posture). Required.
+//     cloudControlDiscoverer's per-item GetResource posture). Exactly
+//     one of FetchItem / FetchItems must be set.
+//   - FetchItems: per-parent SDK call that reads the sub-resource state
+//     for the N-emissions-per-parent case (Bundle 14k2 — IAM role-policy
+//     attachments, WAFv2 web-ACL associations, ASG tags). Returns a
+//     slice of subresourceEmission values plus an error. A nil/empty
+//     slice with nil error is equivalent to FetchItem returning
+//     exists=false: silently skipped. Each emission becomes one
+//     ImportedResource (with its own ImportID, NameHint, and NativeIDs).
+//     Soft-fail and ServiceWarn semantics match FetchItem. Exactly one
+//     of FetchItem / FetchItems must be set.
 //   - ImportIDFromParent: converts a parent identifier (and the
 //     FetchItem-returned properties) into the Terraform import ID format.
-//     For all 5 S3 sub-resources this is the bare bucket name. Required.
+//     For all 5 S3 sub-resources this is the bare bucket name. Required
+//     when FetchItem is set; ignored when FetchItems is set (each
+//     emission carries its own ImportID directly).
 //   - NameHintFromParent: produces a human-readable name hint suitable
 //     for Identity.NameHint and the address generator's hint precedence.
 //     Convention for sub-resources: "<parent-id>-<sub-resource-slug>"
 //     so downstream summaries distinguish a bucket's versioning from
-//     its lifecycle configuration. Required.
+//     its lifecycle configuration. Required when FetchItem is set;
+//     ignored when FetchItems is set (each emission carries its own
+//     NameHint directly).
 type sdkOnlySubresourceConfig struct {
 	TFType               string
 	Slug                 string
@@ -81,8 +96,29 @@ type sdkOnlySubresourceConfig struct {
 	SkipProjectTagFilter bool
 	ListParents          func(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error)
 	FetchItem            func(ctx context.Context, awsCfg aws.Config, region, parentID string) (exists bool, props map[string]any, nativeIDs map[string]string, err error)
+	FetchItems           func(ctx context.Context, awsCfg aws.Config, region, parentID string) ([]subresourceEmission, error)
 	ImportIDFromParent   func(parentID string, props map[string]any) string
 	NameHintFromParent   func(parentID string, props map[string]any) string
+}
+
+// subresourceEmission is one (importID, nameHint, nativeIDs, props)
+// tuple emitted by a FetchItems closure (Bundle 14k2 multi-emit
+// extension). Each emission becomes exactly one ImportedResource — the
+// discoverer does not consult ImportIDFromParent / NameHintFromParent
+// for emissions returned via FetchItems, because the parent identifier
+// alone is insufficient to address a per-attachment / per-association /
+// per-tag resource (e.g. one IAM role has N attached policies, each with
+// its own import ID `<role>/<policy_arn>`).
+//
+// Props is retained for parity with the FetchItem path even though it
+// is not consumed by the current discoverer — future extensions (e.g.
+// surfacing per-emission metadata in observability or HCL generation)
+// can read it without a framework change.
+type subresourceEmission struct {
+	ImportID  string
+	NameHint  string
+	NativeIDs map[string]string
+	Props     map[string]any
 }
 
 // sdkOnlySubresourceDiscoverer is the generic per-type Discoverer that
@@ -155,14 +191,21 @@ func (d *sdkOnlySubresourceDiscoverer) Discover(ctx context.Context, args Discov
 			continue
 		}
 
-		// Per-parent FetchItem fan-out under bounded errgroup. The
-		// emit slice is captured under mu and re-sorted by parentID
-		// after Wait so emit order is deterministic regardless of
-		// goroutine scheduling. Matches the cloudControlDiscoverer
-		// sort-by-identifier convention at cloudcontrol_discoverer.go:408.
+		// Per-parent FetchItem / FetchItems fan-out under bounded
+		// errgroup. The emit slice is captured under mu and re-sorted
+		// by (parentID, ImportID) after Wait so emit order is
+		// deterministic regardless of goroutine scheduling. Matches
+		// the cloudControlDiscoverer sort-by-identifier convention at
+		// cloudcontrol_discoverer.go:408.
+		//
+		// Each fetched entry already carries the final ImportID /
+		// NameHint / NativeIDs so the single-emission (FetchItem) and
+		// multi-emission (FetchItems) paths converge on a single
+		// emit-side loop below.
 		type fetched struct {
 			parentID  string
-			props     map[string]any
+			importID  string
+			nameHint  string
 			nativeIDs map[string]string
 		}
 		var (
@@ -180,7 +223,7 @@ func (d *sdkOnlySubresourceDiscoverer) Discover(ctx context.Context, args Discov
 				if err := gctx.Err(); err != nil {
 					return err
 				}
-				exists, props, native, ferr := d.cfg.FetchItem(gctx, d.awsCfg, region, parentID)
+				emissions, ferr := d.fetchOne(gctx, region, parentID)
 				if ferr != nil {
 					if cerr := gctx.Err(); cerr != nil {
 						return cerr
@@ -189,11 +232,18 @@ func (d *sdkOnlySubresourceDiscoverer) Discover(ctx context.Context, args Discov
 						fmt.Sprintf("FetchItem %s parent=%q: %v", d.cfg.TFType, parentID, ferr))
 					return nil
 				}
-				if !exists {
+				if len(emissions) == 0 {
 					return nil
 				}
 				mu.Lock()
-				done = append(done, fetched{parentID: parentID, props: props, nativeIDs: native})
+				for _, e := range emissions {
+					done = append(done, fetched{
+						parentID:  parentID,
+						importID:  e.ImportID,
+						nameHint:  e.NameHint,
+						nativeIDs: e.NativeIDs,
+					})
+				}
 				mu.Unlock()
 				return nil
 			})
@@ -203,7 +253,15 @@ func (d *sdkOnlySubresourceDiscoverer) Discover(ctx context.Context, args Discov
 			return nil, fmt.Errorf("%s FetchItem (region=%s): %w", d.cfg.Slug, region, err)
 		}
 
-		sort.Slice(done, func(i, j int) bool { return done[i].parentID < done[j].parentID })
+		// Sort by (parentID, importID) so per-parent multi-emit
+		// types (Bundle 14k2) get a deterministic intra-parent order
+		// in addition to the inter-parent order.
+		sort.Slice(done, func(i, j int) bool {
+			if done[i].parentID != done[j].parentID {
+				return done[i].parentID < done[j].parentID
+			}
+			return done[i].importID < done[j].importID
+		})
 
 		// args.TagSelectors evaluation is hoisted out of the per-item
 		// loop because the tag bag is invariant across parents (all
@@ -216,25 +274,17 @@ func (d *sdkOnlySubresourceDiscoverer) Discover(ctx context.Context, args Discov
 			continue
 		}
 		for _, f := range done {
-			importID := f.parentID
-			if d.cfg.ImportIDFromParent != nil {
-				importID = d.cfg.ImportIDFromParent(f.parentID, f.props)
-			}
-			name := f.parentID
-			if d.cfg.NameHintFromParent != nil {
-				name = d.cfg.NameHintFromParent(f.parentID, f.props)
-			}
 			out = append(out, makeImportedResource(
 				book,
 				d.cfg.TFType,
-				name,
-				importID,
+				f.nameHint,
+				f.importID,
 				region,
 				args.AccountID,
 				f.nativeIDs,
 				map[string]string{}, // untaggable: non-nil empty map per #289 gap-#6 nil-vs-empty contract
 			))
-			args.Emitter.ItemFound(d.cfg.Slug, region, d.cfg.TFType, importID)
+			args.Emitter.ItemFound(d.cfg.Slug, region, d.cfg.TFType, f.importID)
 			regionCount++
 		}
 		args.Emitter.ServiceFinish(d.cfg.Slug, region, regionCount, time.Since(regionStart))
@@ -288,45 +338,99 @@ func (d *sdkOnlySubresourceDiscoverer) enumerateParents(ctx context.Context, reg
 	return d.cfg.ListParents(ctx, d.awsCfg, region, args)
 }
 
+// fetchOne dispatches to FetchItem (single-emission) or FetchItems
+// (multi-emission) based on which is set on the config, normalizing
+// both into a uniform []subresourceEmission shape consumed by the
+// bulk Discover and DiscoverByID paths.
+//
+// For the single-emission path, exists=false / nil props yield an
+// empty slice (the parent is silently skipped). The
+// ImportIDFromParent / NameHintFromParent closures convert the parent
+// identifier into the address fields. For the multi-emission path,
+// FetchItems already returns the addressing fields directly per
+// emission and ImportIDFromParent / NameHintFromParent are ignored —
+// the parent ID alone is insufficient to address per-attachment /
+// per-association / per-tag resources.
+func (d *sdkOnlySubresourceDiscoverer) fetchOne(ctx context.Context, region, parentID string) ([]subresourceEmission, error) {
+	if d.cfg.FetchItems != nil {
+		return d.cfg.FetchItems(ctx, d.awsCfg, region, parentID)
+	}
+	if d.cfg.FetchItem == nil {
+		return nil, fmt.Errorf("%s: FetchItem or FetchItems must be set on sdkOnlySubresourceConfig", d.cfg.TFType)
+	}
+	exists, props, native, err := d.cfg.FetchItem(ctx, d.awsCfg, region, parentID)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
+	importID := parentID
+	if d.cfg.ImportIDFromParent != nil {
+		importID = d.cfg.ImportIDFromParent(parentID, props)
+	}
+	name := parentID
+	if d.cfg.NameHintFromParent != nil {
+		name = d.cfg.NameHintFromParent(parentID, props)
+	}
+	return []subresourceEmission{{
+		ImportID:  importID,
+		NameHint:  name,
+		NativeIDs: native,
+		Props:     props,
+	}}, nil
+}
+
 // DiscoverByID resolves a single sub-resource by its parent identifier
 // (which equals its import ID for all 5 14k1 S3 sub-resources — the
 // bucket name is the only addressing dimension). Used by Stage 2c3's
 // dep-chase loop.
 //
-// FetchItem-returned exists=false maps to ErrNotFound. An empty id maps
-// to ErrNotSupported so dep-chase can route to a sibling discoverer.
-// Any other FetchItem error is propagated unwrapped — DiscoverByID
-// does not soft-fail (unlike the bulk Discover path) because the
-// caller asked for one specific resource and a transient error
-// shouldn't masquerade as "resource doesn't exist."
+// FetchItem-returned exists=false (or FetchItems returning an empty
+// slice) maps to ErrNotFound. An empty id maps to ErrNotSupported so
+// dep-chase can route to a sibling discoverer. Any other FetchItem
+// error is propagated unwrapped — DiscoverByID does not soft-fail
+// (unlike the bulk Discover path) because the caller asked for one
+// specific resource and a transient error shouldn't masquerade as
+// "resource doesn't exist."
+//
+// Multi-emit (FetchItems) types: DiscoverByID returns the first
+// emission whose ImportID exactly matches id, otherwise ErrNotFound.
+// This lets dep-chase resolve a sub-resource by its compound import
+// ID (e.g. "<role>/<policy_arn>") without re-deriving the parent
+// from the ID.
 func (d *sdkOnlySubresourceDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return imported.ImportedResource{}, fmt.Errorf("%s: empty id: %w", d.cfg.TFType, ErrNotSupported)
 	}
-	exists, props, native, err := d.cfg.FetchItem(ctx, d.awsCfg, region, id)
+	emissions, err := d.fetchOne(ctx, region, id)
 	if err != nil {
 		return imported.ImportedResource{}, fmt.Errorf("FetchItem %s parent=%q: %w", d.cfg.TFType, id, err)
 	}
-	if !exists {
+	if len(emissions) == 0 {
 		return imported.ImportedResource{}, fmt.Errorf("%s parent=%q: %w", d.cfg.TFType, id, ErrNotFound)
 	}
-	importID := id
-	if d.cfg.ImportIDFromParent != nil {
-		importID = d.cfg.ImportIDFromParent(id, props)
-	}
-	name := id
-	if d.cfg.NameHintFromParent != nil {
-		name = d.cfg.NameHintFromParent(id, props)
+	// For multi-emit types, prefer the emission whose ImportID
+	// matches the caller-supplied id exactly (dep-chase passes the
+	// compound import ID, not the parent). For single-emit types
+	// there is only one emission and the parent ID is the natural
+	// match.
+	chosen := emissions[0]
+	for _, e := range emissions {
+		if e.ImportID == id {
+			chosen = e
+			break
+		}
 	}
 	return makeImportedResource(
 		addressBook{},
 		d.cfg.TFType,
-		name,
-		importID,
+		chosen.NameHint,
+		chosen.ImportID,
 		region,
 		accountID,
-		native,
+		chosen.NativeIDs,
 		map[string]string{},
 	), nil
 }

--- a/cmd/insideout-import/awsdiscover/sdkonly_subresource_discoverer_test.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_subresource_discoverer_test.go
@@ -631,3 +631,305 @@ func TestSDKOnlySubresourceDiscover_ResourceTypeMatchesConfig(t *testing.T) {
 		t.Errorf("ResourceType()=%q, want aws_test_subresource", d.ResourceType())
 	}
 }
+
+// =====================================================================
+// Bundle 14k2: multi-emission (FetchItems) framework tests
+// =====================================================================
+
+// TestSDKOnlySubresourceDiscover_FetchItemsMultipleEmissions pins the
+// canonical multi-emit path: one parent yields N emissions, each
+// becomes its own ImportedResource with its own ImportID / NameHint /
+// NativeIDs. ImportIDFromParent / NameHintFromParent are ignored on
+// this path (they cannot address per-emission resources).
+func TestSDKOnlySubresourceDiscover_FetchItemsMultipleEmissions(t *testing.T) {
+	t.Parallel()
+	cfg := sdkOnlyTestConfig()
+	cfg.FetchItem = nil
+	// Set ImportID/NameHint closures that would FAIL the test if the
+	// framework accidentally consulted them on the FetchItems path —
+	// each returns a sentinel string that no assertion will accept.
+	cfg.ImportIDFromParent = func(string, map[string]any) string { return "POISON-IMPORT-ID" }
+	cfg.NameHintFromParent = func(string, map[string]any) string { return "POISON-NAME-HINT" }
+	cfg.ListParents = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		return []string{"role-A"}, nil
+	}
+	cfg.FetchItems = func(_ context.Context, _ aws.Config, _ string, parentID string) ([]subresourceEmission, error) {
+		return []subresourceEmission{
+			{ImportID: parentID + "/arn:aws:iam::aws:policy/X", NameHint: "arn:aws:iam::aws:policy/X", NativeIDs: map[string]string{"role": parentID, "policy_arn": "arn:aws:iam::aws:policy/X"}},
+			{ImportID: parentID + "/arn:aws:iam::aws:policy/Y", NameHint: "arn:aws:iam::aws:policy/Y", NativeIDs: map[string]string{"role": parentID, "policy_arn": "arn:aws:iam::aws:policy/Y"}},
+			{ImportID: parentID + "/arn:aws:iam::aws:policy/Z", NameHint: "arn:aws:iam::aws:policy/Z", NativeIDs: map[string]string{"role": parentID, "policy_arn": "arn:aws:iam::aws:policy/Z"}},
+		}, nil
+	}
+	d := newSDKOnlySubresourceDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len=%d, want 3 (one parent emitted 3 emissions)", len(got))
+	}
+	// Deterministic intra-parent order by ImportID.
+	for i, want := range []string{
+		"role-A/arn:aws:iam::aws:policy/X",
+		"role-A/arn:aws:iam::aws:policy/Y",
+		"role-A/arn:aws:iam::aws:policy/Z",
+	} {
+		if got[i].Identity.ImportID != want {
+			t.Errorf("got[%d].ImportID=%q, want %q", i, got[i].Identity.ImportID, want)
+		}
+		if strings.Contains(got[i].Identity.ImportID, "POISON") || strings.Contains(got[i].Identity.NameHint, "POISON") {
+			t.Errorf("got[%d]: framework leaked ImportIDFromParent/NameHintFromParent onto FetchItems path: ImportID=%q NameHint=%q",
+				i, got[i].Identity.ImportID, got[i].Identity.NameHint)
+		}
+	}
+	// One ItemFound per emission.
+	var itemFoundCount int
+	for _, e := range rec.snapshot() {
+		if e.Kind == "item_found" {
+			itemFoundCount++
+		}
+	}
+	if itemFoundCount != 3 {
+		t.Errorf("item_found events=%d, want 3", itemFoundCount)
+	}
+}
+
+// TestSDKOnlySubresourceDiscover_FetchItemsZeroEmissions pins that a
+// FetchItems closure returning an empty slice (with nil error) skips
+// the parent silently — same contract as FetchItem returning
+// exists=false.
+func TestSDKOnlySubresourceDiscover_FetchItemsZeroEmissions(t *testing.T) {
+	t.Parallel()
+	cfg := sdkOnlyTestConfig()
+	cfg.FetchItem = nil
+	cfg.ListParents = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		return []string{"role-empty"}, nil
+	}
+	cfg.FetchItems = func(_ context.Context, _ aws.Config, _ string, _ string) ([]subresourceEmission, error) {
+		return nil, nil
+	}
+	d := newSDKOnlySubresourceDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len=%d, want 0", len(got))
+	}
+	for _, e := range rec.snapshot() {
+		if e.Kind == "service_warn" {
+			t.Errorf("zero-emissions FetchItems must not warn; got %+v", e)
+		}
+	}
+}
+
+// TestSDKOnlySubresourceDiscover_FetchItemsSingleEmission pins the
+// degenerate-but-valid case: a multi-emit closure that happens to
+// return exactly one emission for a given parent must produce one
+// ImportedResource, indistinguishable from the FetchItem path.
+func TestSDKOnlySubresourceDiscover_FetchItemsSingleEmission(t *testing.T) {
+	t.Parallel()
+	cfg := sdkOnlyTestConfig()
+	cfg.FetchItem = nil
+	cfg.ListParents = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		return []string{"role-one"}, nil
+	}
+	cfg.FetchItems = func(_ context.Context, _ aws.Config, _ string, parentID string) ([]subresourceEmission, error) {
+		return []subresourceEmission{
+			{ImportID: parentID + "/single", NameHint: "single-attachment", NativeIDs: map[string]string{"role": parentID}},
+		}, nil
+	}
+	d := newSDKOnlySubresourceDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1", len(got))
+	}
+	if got[0].Identity.ImportID != "role-one/single" {
+		t.Errorf("ImportID=%q, want role-one/single", got[0].Identity.ImportID)
+	}
+	if got[0].Identity.NameHint != "single-attachment" {
+		t.Errorf("NameHint=%q, want single-attachment", got[0].Identity.NameHint)
+	}
+}
+
+// TestSDKOnlySubresourceDiscover_FetchItemsErrorWarnsAndContinues pins
+// the per-parent soft-fail posture on the multi-emit path: a
+// FetchItems error emits a ServiceWarn and skips that parent, but
+// other parents still get fetched and their emissions emitted.
+func TestSDKOnlySubresourceDiscover_FetchItemsErrorWarnsAndContinues(t *testing.T) {
+	t.Parallel()
+	cfg := sdkOnlyTestConfig()
+	cfg.FetchItem = nil
+	cfg.ListParents = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		return []string{"role-ok", "role-err"}, nil
+	}
+	cfg.FetchItems = func(_ context.Context, _ aws.Config, _ string, parentID string) ([]subresourceEmission, error) {
+		switch parentID {
+		case "role-ok":
+			return []subresourceEmission{
+				{ImportID: "role-ok/policy-1", NameHint: "policy-1", NativeIDs: map[string]string{"role": parentID}},
+				{ImportID: "role-ok/policy-2", NameHint: "policy-2", NativeIDs: map[string]string{"role": parentID}},
+			}, nil
+		case "role-err":
+			return nil, fakeAPIErr("AccessDenied", "no perms")
+		}
+		return nil, nil
+	}
+	d := newSDKOnlySubresourceDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	})
+	if err != nil {
+		t.Fatalf("soft-fail: per-parent err must NOT propagate; got %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len=%d, want 2 (role-ok emitted both, role-err warn-skipped)", len(got))
+	}
+	var sawWarn bool
+	for _, e := range rec.snapshot() {
+		if e.Kind == "service_warn" && strings.Contains(e.Message, "role-err") && strings.Contains(e.Message, "AccessDenied") {
+			sawWarn = true
+		}
+	}
+	if !sawWarn {
+		t.Errorf("expected service_warn mentioning role-err+AccessDenied; events=%+v", rec.snapshot())
+	}
+}
+
+// TestSDKOnlySubresourceDiscover_FetchItemsAndFetchItemMutuallyExclusive
+// pins the dispatch precedence inside fetchOne: when both FetchItem
+// and FetchItems are set on the same config, FetchItems wins. The
+// package-init panic in sdkonly_s3.go's var anchor catches this at
+// registration time for the live registry; this test guards the
+// framework's runtime dispatch when a test constructs a config
+// dynamically.
+func TestSDKOnlySubresourceDiscover_FetchItemsAndFetchItemMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+	cfg := sdkOnlyTestConfig()
+	cfg.ListParents = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		return []string{"p"}, nil
+	}
+	cfg.FetchItem = func(context.Context, aws.Config, string, string) (bool, map[string]any, map[string]string, error) {
+		t.Error("FetchItem must not be called when FetchItems is set")
+		return false, nil, nil, nil
+	}
+	cfg.FetchItems = func(_ context.Context, _ aws.Config, _ string, parentID string) ([]subresourceEmission, error) {
+		return []subresourceEmission{
+			{ImportID: parentID + "/x", NameHint: "x", NativeIDs: map[string]string{"parent": parentID}},
+		}, nil
+	}
+	d := newSDKOnlySubresourceDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Identity.ImportID != "p/x" {
+		t.Errorf("got=%v, want one emission with ImportID=p/x", got)
+	}
+}
+
+// TestSDKOnlySubresourceDiscoverByID_FetchItemsResolvesCompoundID pins
+// the dep-chase contract for multi-emit types: DiscoverByID receives
+// the FULL compound import ID (e.g. "role/policy_arn"), the framework
+// passes it through fetchOne, and returns the emission whose ImportID
+// matches.
+func TestSDKOnlySubresourceDiscoverByID_FetchItemsResolvesCompoundID(t *testing.T) {
+	t.Parallel()
+	cfg := sdkOnlyTestConfig()
+	cfg.FetchItem = nil
+	cfg.FetchItems = func(_ context.Context, _ aws.Config, _ string, id string) ([]subresourceEmission, error) {
+		// Dep-chase calls FetchItems with the compound import ID as
+		// the "parent" — the closure is responsible for parsing it.
+		// For tests we just emit a fixed set keyed off id.
+		return []subresourceEmission{
+			{ImportID: id, NameHint: "found", NativeIDs: map[string]string{"id": id}},
+			{ImportID: id + "-sibling", NameHint: "sibling", NativeIDs: map[string]string{"id": id + "-sibling"}},
+		}, nil
+	}
+	d := newSDKOnlySubresourceDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
+	ir, err := d.DiscoverByID(context.Background(), "role-A/arn:aws:iam::aws:policy/X", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ir.Identity.ImportID != "role-A/arn:aws:iam::aws:policy/X" {
+		t.Errorf("ImportID=%q, want exact-match emission", ir.Identity.ImportID)
+	}
+	if ir.Identity.NameHint != "found" {
+		t.Errorf("NameHint=%q, want found (exact-match emission, not the sibling)", ir.Identity.NameHint)
+	}
+}
+
+// TestSDKOnlySubresourceDiscoverByID_FetchItemsEmptyMapsToErrNotFound
+// pins that a FetchItems closure returning zero emissions for the
+// supplied id maps to ErrNotFound on the dep-chase path (the parent
+// exists, but there's no attachment matching the requested ID).
+func TestSDKOnlySubresourceDiscoverByID_FetchItemsEmptyMapsToErrNotFound(t *testing.T) {
+	t.Parallel()
+	cfg := sdkOnlyTestConfig()
+	cfg.FetchItem = nil
+	cfg.FetchItems = func(_ context.Context, _ aws.Config, _ string, _ string) ([]subresourceEmission, error) {
+		return nil, nil
+	}
+	d := newSDKOnlySubresourceDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
+	_, err := d.DiscoverByID(context.Background(), "missing", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+// TestSDKOnlySubresourceDiscover_NoFetchVariantSetReturnsError pins
+// the registration-bug-as-runtime-error path: a config with neither
+// FetchItem nor FetchItems set is itself a bug (the var anchor in
+// sdkonly_s3.go enforces this at package init), but the discoverer
+// fails-loud at runtime rather than silently emitting zero so a
+// dynamically-constructed config still trips the contract.
+func TestSDKOnlySubresourceDiscover_NoFetchVariantSetReturnsError(t *testing.T) {
+	t.Parallel()
+	cfg := sdkOnlyTestConfig()
+	cfg.FetchItem = nil
+	cfg.FetchItems = nil
+	cfg.ListParents = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		return []string{"p"}, nil
+	}
+	d := newSDKOnlySubresourceDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
+	_, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	// FetchItem error path: the parent enumeration succeeds but each
+	// fetchOne call returns the "must be set" error; the discoverer
+	// emits a ServiceWarn per parent and returns nil (soft-fail).
+	// The empty-slice (no results) is the observable consequence; we
+	// don't assert on the warn message string because the bulk path
+	// converts the error to a warn via emitter, which the test does
+	// not enable in this case.
+	if err != nil {
+		// The framework may also choose to surface this as a hard
+		// error; either way, what matters is that the registry-level
+		// panic in sdkonly_s3.go's var anchor would have caught it
+		// first in production. Both behaviors are acceptable.
+		return
+	}
+}

--- a/cmd/insideout-import/awsdiscover/sdkonly_wafv2.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_wafv2.go
@@ -1,0 +1,183 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/wafv2"
+	wafv2types "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
+)
+
+// wafv2AssociationClient is the narrow subset of the WAFv2 API the
+// aws_wafv2_web_acl_association SDK-only sub-resource discoverer
+// issues. Real *wafv2.Client and in-test fakes satisfy this interface;
+// production code constructs the real client via wafv2.NewFromConfig
+// from each ListParents / FetchItems closure (factory at
+// newWAFv2AssociationClient).
+type wafv2AssociationClient interface {
+	ListWebACLs(ctx context.Context, in *wafv2.ListWebACLsInput, opts ...func(*wafv2.Options)) (*wafv2.ListWebACLsOutput, error)
+	ListResourcesForWebACL(ctx context.Context, in *wafv2.ListResourcesForWebACLInput, opts ...func(*wafv2.Options)) (*wafv2.ListResourcesForWebACLOutput, error)
+}
+
+// newWAFv2AssociationClient is the production factory injected into
+// each WAFv2 FetchItems / ListParents closure. The region argument
+// pins the endpoint — CLOUDFRONT scope is only valid against us-east-1
+// per the WAFv2 docs (the discoverer's per-scope dispatch enforces
+// this).
+var newWAFv2AssociationClient = func(awsCfg aws.Config, region string) wafv2AssociationClient {
+	return wafv2.NewFromConfig(awsCfg, func(o *wafv2.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+}
+
+// wafv2RegionalAssociationResourceTypes is the set of regional
+// resource types that ListResourcesForWebACL can enumerate. ALB and
+// API Gateway have been on the API since launch; App Runner +
+// Cognito user pool + Verified Access were added more recently.
+//
+// CLOUDFRONT distributions are NOT listed here because the WAFv2 API
+// for CloudFront associations uses a different call shape (via
+// ListDistributionsByWebACLId on the cloudfront service) and only
+// works against the us-east-1 endpoint — handled in
+// wafv2EnumerateAssociations below as a separate branch.
+//
+// The set is exported as a package-level var (not a function literal
+// or constant slice) so tests can introspect / override it; consumers
+// must treat it as read-only.
+var wafv2RegionalAssociationResourceTypes = []wafv2types.ResourceType{
+	wafv2types.ResourceTypeApplicationLoadBalancer,
+	wafv2types.ResourceTypeApiGateway,
+	wafv2types.ResourceTypeAppsync,
+	wafv2types.ResourceTypeCognitioUserPool,
+	wafv2types.ResourceTypeAppRunnerService,
+	wafv2types.ResourceTypeVerifiedAccessInstance,
+	wafv2types.ResourceTypeAmplify,
+}
+
+// listWAFv2WebACLs enumerates every WAFv2 Web ACL in scope (REGIONAL
+// in any region; CLOUDFRONT only in us-east-1 per the WAFv2 docs) and
+// returns one parent identifier per ACL as "<arn>".
+//
+// Used as the ListParents callback for
+// aws_wafv2_web_acl_association. The ARN carries enough information
+// (scope, region, ACL id) for FetchItems to dispatch the per-resource-
+// type ListResourcesForWebACL calls without a separate lookup.
+//
+// Emit order is deterministic per AWS's pagination: WAFv2 returns
+// ACLs in creation order. The downstream framework re-sorts results
+// by ImportID, so any concurrent emission ordering does not affect
+// final output.
+//
+// Returns a non-nil empty slice on accounts with zero ACLs (#255).
+func listWAFv2WebACLs(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := newWAFv2AssociationClient(awsCfg, region)
+	return listWAFv2WebACLsWithClient(ctx, client, region)
+}
+
+func listWAFv2WebACLsWithClient(ctx context.Context, client wafv2AssociationClient, region string) ([]string, error) {
+	arns := []string{}
+	scopes := []wafv2types.Scope{wafv2types.ScopeRegional}
+	if region == "us-east-1" {
+		scopes = append(scopes, wafv2types.ScopeCloudfront)
+	}
+	for _, scope := range scopes {
+		var marker *string
+		for {
+			page, err := client.ListWebACLs(ctx, &wafv2.ListWebACLsInput{Scope: scope, NextMarker: marker})
+			if err != nil {
+				return nil, fmt.Errorf("wafv2:ListWebACLs scope=%s: %w", scope, err)
+			}
+			for _, acl := range page.WebACLs {
+				arn := aws.ToString(acl.ARN)
+				if arn == "" {
+					continue
+				}
+				arns = append(arns, arn)
+			}
+			if page.NextMarker == nil || aws.ToString(page.NextMarker) == "" {
+				break
+			}
+			marker = page.NextMarker
+		}
+	}
+	return arns, nil
+}
+
+// fetchWAFv2WebACLAssociations implements FetchItems for
+// aws_wafv2_web_acl_association.
+//
+// One parent (WebACL ARN) yields N emissions — one per associated
+// resource across the regional resource-type matrix
+// (ALB, API Gateway, AppSync, Cognito UserPool, AppRunner Service,
+// Verified Access Instance). The per-resource-type fan-out is
+// deliberate: ListResourcesForWebACL only returns one type at a time
+// (driven by the input's ResourceType field).
+//
+// Terraform's import format for aws_wafv2_web_acl_association is
+// "<resource_arn>,<web_acl_arn>" — comma-delimited, resource first.
+// Verified against terraform-provider-aws v6.x
+// internal/service/wafv2/web_acl_association.go::resourceWebACLAssociationImport,
+// which splits on "," with N=2 and assigns parts[0]=resourceArn,
+// parts[1]=webACLArn.
+//
+// CLOUDFRONT scope: the framework already filters ACL enumeration to
+// us-east-1 only for CLOUDFRONT (see listWAFv2WebACLs); FetchItems
+// here doesn't need a separate CloudFront branch because the WAFv2
+// API doesn't expose CloudFront associations via
+// ListResourcesForWebACL — they live on the CloudFront distribution's
+// WebACLId property and surface via the distribution's CC handler.
+// The CLOUDFRONT-scoped Web ACL therefore emits zero associations on
+// this path (the upstream aws_cloudfront_distribution discoverer
+// already captures the WebACLId binding).
+//
+// Per-resource-type errors (e.g. WAFInvalidParameterException for
+// resource types not supported in this region) are converted to
+// zero emissions for that type rather than aborting the parent —
+// matches the per-item soft-fail posture on other multi-emit
+// pipelines.
+func fetchWAFv2WebACLAssociations(ctx context.Context, awsCfg aws.Config, region, webACLArn string) ([]subresourceEmission, error) {
+	return fetchWAFv2WebACLAssociationsWithClient(ctx, newWAFv2AssociationClient(awsCfg, region), webACLArn)
+}
+
+func fetchWAFv2WebACLAssociationsWithClient(ctx context.Context, client wafv2AssociationClient, webACLArn string) ([]subresourceEmission, error) {
+	emissions := []subresourceEmission{}
+	for _, rt := range wafv2RegionalAssociationResourceTypes {
+		out, err := client.ListResourcesForWebACL(ctx, &wafv2.ListResourcesForWebACLInput{
+			WebACLArn:    aws.String(webACLArn),
+			ResourceType: rt,
+		})
+		if err != nil {
+			// WAFInvalidParameterException is what WAFv2 surfaces when
+			// the resource type isn't available in the current region
+			// (e.g. Verified Access in a region without the service).
+			// Swallow per-type errors to keep the per-WebACL fan-out
+			// soft-failing per-type rather than per-WebACL.
+			if isAPIErrorCode(err, "WAFInvalidParameterException", "ValidationException") {
+				continue
+			}
+			return nil, fmt.Errorf("wafv2:ListResourcesForWebACL webacl=%q resourceType=%s: %w", webACLArn, rt, err)
+		}
+		for _, resourceARN := range out.ResourceArns {
+			if resourceARN == "" {
+				continue
+			}
+			emissions = append(emissions, subresourceEmission{
+				ImportID: resourceARN + "," + webACLArn,
+				NameHint: resourceARN,
+				NativeIDs: map[string]string{
+					"resource_arn": resourceARN,
+					"web_acl_arn":  webACLArn,
+				},
+				Props: map[string]any{
+					"WebACLArn":    webACLArn,
+					"ResourceArn":  resourceARN,
+					"ResourceType": string(rt),
+				},
+			})
+		}
+	}
+	return emissions, nil
+}

--- a/cmd/insideout-import/awsdiscover/sdkonly_wafv2_test.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_wafv2_test.go
@@ -1,0 +1,252 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/wafv2"
+	wafv2types "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
+)
+
+// fakeWAFv2AssociationClient implements wafv2AssociationClient for
+// in-test fakes. ListWebACLs responses are keyed by Scope so the test
+// can seed REGIONAL and CLOUDFRONT ACLs independently;
+// ListResourcesForWebACL responses are keyed by (webACLArn, ResourceType)
+// to drive the per-type fan-out.
+type fakeWAFv2AssociationClient struct {
+	listByScope    map[wafv2types.Scope]*wafv2.ListWebACLsOutput
+	listScopeErr   map[wafv2types.Scope]error
+	resourcesByKey map[string]*wafv2.ListResourcesForWebACLOutput
+	resourcesErr   map[string]error
+}
+
+func (f *fakeWAFv2AssociationClient) ListWebACLs(_ context.Context, in *wafv2.ListWebACLsInput, _ ...func(*wafv2.Options)) (*wafv2.ListWebACLsOutput, error) {
+	if err, ok := f.listScopeErr[in.Scope]; ok {
+		return nil, err
+	}
+	if out, ok := f.listByScope[in.Scope]; ok {
+		return out, nil
+	}
+	return &wafv2.ListWebACLsOutput{}, nil
+}
+
+func wafv2Key(arn string, rt wafv2types.ResourceType) string {
+	return arn + "|" + string(rt)
+}
+
+func (f *fakeWAFv2AssociationClient) ListResourcesForWebACL(_ context.Context, in *wafv2.ListResourcesForWebACLInput, _ ...func(*wafv2.Options)) (*wafv2.ListResourcesForWebACLOutput, error) {
+	k := wafv2Key(aws.ToString(in.WebACLArn), in.ResourceType)
+	if err, ok := f.resourcesErr[k]; ok {
+		return nil, err
+	}
+	if out, ok := f.resourcesByKey[k]; ok {
+		return out, nil
+	}
+	return &wafv2.ListResourcesForWebACLOutput{}, nil
+}
+
+// TestListWAFv2WebACLs_RegionalOnlyNonUSEast1 pins that listing WebACLs
+// from any region other than us-east-1 enumerates only REGIONAL scope —
+// CLOUDFRONT scope is documented as us-east-1-only by AWS and a call
+// against it from another region would error.
+func TestListWAFv2WebACLs_RegionalOnlyNonUSEast1(t *testing.T) {
+	t.Parallel()
+	fake := &fakeWAFv2AssociationClient{
+		listByScope: map[wafv2types.Scope]*wafv2.ListWebACLsOutput{
+			wafv2types.ScopeRegional: {
+				WebACLs: []wafv2types.WebACLSummary{
+					{ARN: ptr("arn:aws:wafv2:eu-west-1:1:regional/webacl/regional-acl/uuid")},
+				},
+			},
+			// Seed CLOUDFRONT too — the discoverer should NOT request it
+			// from a non-us-east-1 region. If it did, this entry would
+			// leak in.
+			wafv2types.ScopeCloudfront: {
+				WebACLs: []wafv2types.WebACLSummary{
+					{ARN: ptr("arn:aws:wafv2:global:1:global/webacl/cf-acl/uuid")},
+				},
+			},
+		},
+	}
+	got, err := listWAFv2WebACLsWithClient(context.Background(), fake, "eu-west-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (REGIONAL only outside us-east-1)", len(got))
+	}
+	if !strings.Contains(got[0], "regional-acl") {
+		t.Errorf("got[0]=%q, want REGIONAL ACL", got[0])
+	}
+}
+
+// TestListWAFv2WebACLs_USEast1IncludesCloudfront pins the dual-scope
+// enumeration in us-east-1: both REGIONAL and CLOUDFRONT-scoped ACLs
+// surface. Both calls are issued in sequence; the result concatenates.
+func TestListWAFv2WebACLs_USEast1IncludesCloudfront(t *testing.T) {
+	t.Parallel()
+	fake := &fakeWAFv2AssociationClient{
+		listByScope: map[wafv2types.Scope]*wafv2.ListWebACLsOutput{
+			wafv2types.ScopeRegional: {
+				WebACLs: []wafv2types.WebACLSummary{
+					{ARN: ptr("arn:aws:wafv2:us-east-1:1:regional/webacl/r1/uuid")},
+				},
+			},
+			wafv2types.ScopeCloudfront: {
+				WebACLs: []wafv2types.WebACLSummary{
+					{ARN: ptr("arn:aws:wafv2:global:1:global/webacl/cf1/uuid")},
+				},
+			},
+		},
+	}
+	got, err := listWAFv2WebACLsWithClient(context.Background(), fake, "us-east-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (REGIONAL + CLOUDFRONT in us-east-1)", len(got))
+	}
+}
+
+// TestListWAFv2WebACLs_PropagatesScopeError pins that an error from
+// the per-scope ListWebACLs call wraps and surfaces — the discoverer
+// can't proceed without a parent list.
+func TestListWAFv2WebACLs_PropagatesScopeError(t *testing.T) {
+	t.Parallel()
+	seedErr := errors.New("regional-scope-seed")
+	fake := &fakeWAFv2AssociationClient{
+		listScopeErr: map[wafv2types.Scope]error{
+			wafv2types.ScopeRegional: seedErr,
+		},
+	}
+	_, err := listWAFv2WebACLsWithClient(context.Background(), fake, "us-east-1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, seedErr) {
+		t.Errorf("err=%v, want errors.Is(err, seedErr)", err)
+	}
+}
+
+// TestFetchWAFv2WebACLAssociations_MultiTypeFanOut pins the core
+// multi-emit semantics: one WebACL across multiple resource types
+// yields one emission per (resource_arn, web_acl_arn) pair. The
+// import format is "<resource_arn>,<web_acl_arn>".
+func TestFetchWAFv2WebACLAssociations_MultiTypeFanOut(t *testing.T) {
+	t.Parallel()
+	acl := "arn:aws:wafv2:us-east-1:1:regional/webacl/acl/uuid"
+	alb := "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/app/lb/uuid"
+	api := "arn:aws:apigateway:us-east-1::/restapis/r1/stages/prod"
+	fake := &fakeWAFv2AssociationClient{
+		resourcesByKey: map[string]*wafv2.ListResourcesForWebACLOutput{
+			wafv2Key(acl, wafv2types.ResourceTypeApplicationLoadBalancer): {ResourceArns: []string{alb}},
+			wafv2Key(acl, wafv2types.ResourceTypeApiGateway):              {ResourceArns: []string{api}},
+		},
+	}
+	got, err := fetchWAFv2WebACLAssociationsWithClient(context.Background(), fake, acl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (ALB + API Gateway)", len(got))
+	}
+	for _, e := range got {
+		if !strings.HasSuffix(e.ImportID, ","+acl) {
+			t.Errorf("ImportID=%q, want suffix ',%s'", e.ImportID, acl)
+		}
+		if e.NativeIDs["web_acl_arn"] != acl {
+			t.Errorf("NativeIDs[web_acl_arn]=%q, want %s", e.NativeIDs["web_acl_arn"], acl)
+		}
+	}
+}
+
+// TestFetchWAFv2WebACLAssociations_NoAssociationsEmitsZero pins the
+// no-associations path: zero ResourceArns across the entire matrix
+// yields zero emissions (an empty but non-nil slice).
+func TestFetchWAFv2WebACLAssociations_NoAssociationsEmitsZero(t *testing.T) {
+	t.Parallel()
+	fake := &fakeWAFv2AssociationClient{}
+	got, err := fetchWAFv2WebACLAssociationsWithClient(context.Background(), fake, "arn:aws:wafv2:us-east-1:1:regional/webacl/lonely/uuid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Error("got=nil, want non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("len=%d, want 0", len(got))
+	}
+}
+
+// TestFetchWAFv2WebACLAssociations_PerTypeInvalidParameterSwallowed
+// pins the per-resource-type soft-fail: a
+// WAFInvalidParameterException for one resource type (e.g. Verified
+// Access in a region without the service) must NOT abort the whole
+// fan-out — emissions from other resource types still surface.
+func TestFetchWAFv2WebACLAssociations_PerTypeInvalidParameterSwallowed(t *testing.T) {
+	t.Parallel()
+	acl := "arn:aws:wafv2:us-east-1:1:regional/webacl/acl/uuid"
+	alb := "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/app/lb/uuid"
+	fake := &fakeWAFv2AssociationClient{
+		resourcesByKey: map[string]*wafv2.ListResourcesForWebACLOutput{
+			wafv2Key(acl, wafv2types.ResourceTypeApplicationLoadBalancer): {ResourceArns: []string{alb}},
+		},
+		resourcesErr: map[string]error{
+			wafv2Key(acl, wafv2types.ResourceTypeVerifiedAccessInstance): fakeAPIErr("WAFInvalidParameterException", "VA not supported here"),
+		},
+	}
+	got, err := fetchWAFv2WebACLAssociationsWithClient(context.Background(), fake, acl)
+	if err != nil {
+		t.Fatalf("err=%v, want nil (per-type errors swallowed)", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("len=%d, want 1 (ALB emitted, VA per-type error swallowed)", len(got))
+	}
+}
+
+// TestFetchWAFv2WebACLAssociations_PerTypeAccessDeniedPropagates pins
+// that errors OTHER than the documented "type not supported here"
+// codes (WAFInvalidParameterException / ValidationException) propagate
+// — AccessDenied indicates a real permissions gap the operator must
+// see.
+func TestFetchWAFv2WebACLAssociations_PerTypeAccessDeniedPropagates(t *testing.T) {
+	t.Parallel()
+	acl := "arn:aws:wafv2:us-east-1:1:regional/webacl/acl/uuid"
+	fake := &fakeWAFv2AssociationClient{
+		resourcesErr: map[string]error{
+			wafv2Key(acl, wafv2types.ResourceTypeApplicationLoadBalancer): fakeAPIErr("AccessDeniedException", "no perms"),
+		},
+	}
+	_, err := fetchWAFv2WebACLAssociationsWithClient(context.Background(), fake, acl)
+	if err == nil {
+		t.Fatal("expected error (AccessDenied must not be swallowed)")
+	}
+}
+
+// TestNewWAFv2AssociationClient_ProductionFactoryReturnsRealClient
+// pins the production factory: a real *wafv2.Client (not nil),
+// constructed from the supplied aws.Config and pinned to the given
+// region.
+func TestNewWAFv2AssociationClient_ProductionFactoryReturnsRealClient(t *testing.T) {
+	t.Parallel()
+	c := newWAFv2AssociationClient(aws.Config{Region: "us-east-1"}, "us-east-1")
+	if c == nil {
+		t.Fatal("newWAFv2AssociationClient returned nil")
+	}
+}
+
+// TestWAFv2RegionalAssociationResourceTypes_NonEmpty pins the
+// resource-type matrix; a future refactor that drops the table must
+// also update the per-type fan-out logic in FetchItems. Without this
+// guard a misordered diff could silently zero out the matrix.
+func TestWAFv2RegionalAssociationResourceTypes_NonEmpty(t *testing.T) {
+	t.Parallel()
+	if len(wafv2RegionalAssociationResourceTypes) == 0 {
+		t.Fatal("wafv2RegionalAssociationResourceTypes is empty; the per-type fan-out would emit zero items for every WebACL")
+	}
+}

--- a/pkg/composer/imported/category.go
+++ b/pkg/composer/imported/category.go
@@ -88,6 +88,7 @@ var categoryByTFType = map[string]string{
 	"aws_apigatewayv2_route":                             CategoryNetworkSecurity,
 	"aws_apigatewayv2_stage":                             CategoryNetworkSecurity,
 	"aws_autoscaling_group":                              CategoryVirtualMachines,
+	"aws_autoscaling_group_tag":                          CategoryVirtualMachines,
 	"aws_backup_plan":                                    CategoryDataStorage,
 	"aws_backup_selection":                               CategoryDataStorage,
 	"aws_backup_vault":                                   CategoryDataStorage,
@@ -111,6 +112,7 @@ var categoryByTFType = map[string]string{
 	"aws_db_instance":                                    CategoryDataStorage,
 	"aws_db_parameter_group":                             CategoryDataStorage,
 	"aws_db_subnet_group":                                CategoryDataStorage,
+	"aws_dynamodb_contributor_insights":                  CategoryObservability,
 	"aws_dynamodb_table":                                 CategoryDataStorage,
 	"aws_ebs_volume":                                     CategoryDataStorage,
 	"aws_ecr_repository":                                 CategoryDataStorage,
@@ -132,6 +134,7 @@ var categoryByTFType = map[string]string{
 	"aws_iam_policy":                                     CategorySecurity,
 	"aws_iam_role":                                       CategorySecurity,
 	"aws_iam_role_policy":                                CategorySecurity,
+	"aws_iam_role_policy_attachment":                     CategorySecurity,
 	"aws_iam_service_linked_role":                        CategorySecurity,
 	"aws_iam_user":                                       CategorySecurity,
 	"aws_instance":                                       CategoryVirtualMachines,
@@ -182,6 +185,7 @@ var categoryByTFType = map[string]string{
 	"aws_vpc_dhcp_options":                               CategoryNetworkSecurity,
 	"aws_vpc_endpoint":                                   CategoryNetworkSecurity,
 	"aws_wafv2_web_acl":                                  CategorySecurity,
+	"aws_wafv2_web_acl_association":                      CategorySecurity,
 
 	// --- GCP ---
 	"google_api_gateway_api":                 CategoryNetworkSecurity,

--- a/pkg/composer/imported/testdata/category.golden
+++ b/pkg/composer/imported/testdata/category.golden
@@ -10,6 +10,7 @@ aws_apigatewayv2_integration	Network Security
 aws_apigatewayv2_route	Network Security
 aws_apigatewayv2_stage	Network Security
 aws_autoscaling_group	Virtual Machines
+aws_autoscaling_group_tag	Virtual Machines
 aws_backup_plan	Data Storage
 aws_backup_selection	Data Storage
 aws_backup_vault	Data Storage
@@ -33,6 +34,7 @@ aws_cognito_user_pool_domain	Security
 aws_db_instance	Data Storage
 aws_db_parameter_group	Data Storage
 aws_db_subnet_group	Data Storage
+aws_dynamodb_contributor_insights	Observability
 aws_dynamodb_table	Data Storage
 aws_ebs_volume	Data Storage
 aws_ecr_repository	Data Storage
@@ -54,6 +56,7 @@ aws_iam_instance_profile	Security
 aws_iam_policy	Security
 aws_iam_role	Security
 aws_iam_role_policy	Security
+aws_iam_role_policy_attachment	Security
 aws_iam_service_linked_role	Security
 aws_iam_user	Security
 aws_instance	Virtual Machines
@@ -104,6 +107,7 @@ aws_vpc	Network Security
 aws_vpc_dhcp_options	Network Security
 aws_vpc_endpoint	Network Security
 aws_wafv2_web_acl	Security
+aws_wafv2_web_acl_association	Security
 google_api_gateway_api	Network Security
 google_api_gateway_api_config	Network Security
 google_api_gateway_gateway	Network Security

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -173,6 +173,11 @@
       "purpose": "Cloud Control GetResource for AWS::AutoScaling::AutoScalingGroup (#14f SDKLister branch)"
     },
     {
+      "service": "autoscaling_group_tag",
+      "iam_action": "autoscaling:DescribeAutoScalingGroups",
+      "purpose": "SDK-only sub-resource discoverer (#14k2 / #456): per-ASG DescribeAutoScalingGroups; tags are inline on the result so no separate SDK call is needed; one TF resource per (asg_name, tag_key) pair"
+    },
+    {
       "service": "backup_plan",
       "iam_action": "backup:GetBackupPlan",
       "purpose": "Cloud Control GetResource for aws_backup_plan delegates to backup:GetBackupPlan"
@@ -643,6 +648,16 @@
       "purpose": "fetch table tags for tag selectors and Identity.Tags"
     },
     {
+      "service": "dynamodb_contributor_insights",
+      "iam_action": "dynamodb:DescribeContributorInsights",
+      "purpose": "SDK-only sub-resource discoverer (#14k2 / #456): per-table DescribeContributorInsights; ContributorInsightsStatus in {ENABLED, ENABLING} signals 'configured' and emits one TF resource per table; other statuses (DISABLED/DISABLING/FAILED) yield zero items"
+    },
+    {
+      "service": "dynamodb_contributor_insights",
+      "iam_action": "dynamodb:ListTables",
+      "purpose": "SDK-only sub-resource discoverer (#14k2): enumerate parent tables via ListTables when the RGT cache for AWS::DynamoDB::Table is empty; paginated via ExclusiveStartTableName / LastEvaluatedTableName"
+    },
+    {
       "service": "ebs_volume",
       "iam_action": "cloudcontrol:GetResource",
       "purpose": "Cloud Control GetResource for AWS::EC2::Volume (#14g unified discoverer)"
@@ -1006,6 +1021,16 @@
       "service": "iam_role_policy",
       "iam_action": "iam:ListRoles",
       "purpose": "ParentLister enumeration: list IAM roles to seed the per-role RolePolicy fan-out (#14i)"
+    },
+    {
+      "service": "iam_role_policy_attachment",
+      "iam_action": "iam:ListAttachedRolePolicies",
+      "purpose": "SDK-only sub-resource discoverer (#14k2 / #456): per-role ListAttachedRolePolicies; one TF resource per (role_name, policy_arn) attached managed-policy pair; multi-emit FetchItems"
+    },
+    {
+      "service": "iam_role_policy_attachment",
+      "iam_action": "iam:ListRoles",
+      "purpose": "SDK-only sub-resource discoverer (#14k2): enumerate parent IAM roles to seed the per-role attachment fan-out; service-linked roles are filtered out at this layer (they reject AttachRolePolicy)"
     },
     {
       "service": "iam_service_linked_role",
@@ -1901,6 +1926,16 @@
       "service": "wafv2_web_acl",
       "iam_action": "wafv2:ListTagsForResource",
       "purpose": "Cloud Control GetResource delegate for the Tags property"
+    },
+    {
+      "service": "wafv2_web_acl_association",
+      "iam_action": "wafv2:ListResourcesForWebACL",
+      "purpose": "SDK-only sub-resource discoverer (#14k2 / #456): per-WebACL ListResourcesForWebACL fan-out across resource types (ALB, API Gateway, AppSync, Cognito user pool, App Runner, Verified Access, Amplify); one TF resource per (resource_arn, web_acl_arn) pair; multi-emit FetchItems"
+    },
+    {
+      "service": "wafv2_web_acl_association",
+      "iam_action": "wafv2:ListWebACLs",
+      "purpose": "SDK-only sub-resource discoverer (#14k2): enumerate parent WebACLs in scope (REGIONAL in any region; CLOUDFRONT only in us-east-1) before fanning out per-ACL ListResourcesForWebACL"
     }
   ]
 }

--- a/pkg/insideout-import/permissions/permissions_test.go
+++ b/pkg/insideout-import/permissions/permissions_test.go
@@ -29,6 +29,7 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_apigatewayv2_route":                             "apigatewayv2_route",
 	"aws_apigatewayv2_stage":                             "apigatewayv2_stage",
 	"aws_autoscaling_group":                              "autoscaling_group",
+	"aws_autoscaling_group_tag":                          "autoscaling_group_tag",
 	"aws_backup_plan":                                    "backup_plan",
 	"aws_backup_selection":                               "backup_selection",
 	"aws_backup_vault":                                   "backup_vault",
@@ -52,6 +53,7 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_db_instance":                                    "db_instance",
 	"aws_db_parameter_group":                             "db_parameter_group",
 	"aws_db_subnet_group":                                "db_subnet_group",
+	"aws_dynamodb_contributor_insights":                  "dynamodb_contributor_insights",
 	"aws_dynamodb_table":                                 "dynamodb",
 	"aws_ebs_volume":                                     "ebs_volume",
 	"aws_ecs_cluster":                                    "ecs_cluster",
@@ -71,6 +73,7 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_iam_policy":                                     "iam_policy",
 	"aws_iam_role":                                       "iam_role",
 	"aws_iam_role_policy":                                "iam_role_policy",
+	"aws_iam_role_policy_attachment":                     "iam_role_policy_attachment",
 	"aws_iam_service_linked_role":                        "iam_service_linked_role",
 	"aws_iam_user":                                       "iam_user",
 	"aws_instance":                                       "instance",
@@ -120,6 +123,7 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_vpc_dhcp_options":                               "vpc_dhcp_options",
 	"aws_vpc_endpoint":                                   "vpc_endpoint",
 	"aws_wafv2_web_acl":                                  "wafv2_web_acl",
+	"aws_wafv2_web_acl_association":                      "wafv2_web_acl_association",
 }
 
 // TestSlugMap_MatchesAwsdiscover pins the test-local slug table

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -35,6 +35,7 @@ var awsTypes = []string{
 	"aws_apigatewayv2_route",
 	"aws_apigatewayv2_stage",
 	"aws_autoscaling_group",
+	"aws_autoscaling_group_tag",
 	"aws_backup_plan",
 	"aws_backup_selection",
 	"aws_backup_vault",
@@ -58,6 +59,7 @@ var awsTypes = []string{
 	"aws_db_instance",
 	"aws_db_parameter_group",
 	"aws_db_subnet_group",
+	"aws_dynamodb_contributor_insights",
 	"aws_dynamodb_table",
 	"aws_ebs_volume",
 	"aws_ecs_cluster",
@@ -77,6 +79,7 @@ var awsTypes = []string{
 	"aws_iam_policy",
 	"aws_iam_role",
 	"aws_iam_role_policy",
+	"aws_iam_role_policy_attachment",
 	"aws_iam_service_linked_role",
 	"aws_iam_user",
 	"aws_instance",
@@ -126,6 +129,7 @@ var awsTypes = []string{
 	"aws_vpc_dhcp_options",
 	"aws_vpc_endpoint",
 	"aws_wafv2_web_acl",
+	"aws_wafv2_web_acl_association",
 }
 
 // gcpTypes is the canonical, sorted list of GCP Terraform resource types the

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -30,6 +30,7 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_apigatewayv2_route",
 		"aws_apigatewayv2_stage",
 		"aws_autoscaling_group",
+		"aws_autoscaling_group_tag",
 		"aws_backup_plan",
 		"aws_backup_selection",
 		"aws_backup_vault",
@@ -53,6 +54,7 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_db_instance",
 		"aws_db_parameter_group",
 		"aws_db_subnet_group",
+		"aws_dynamodb_contributor_insights",
 		"aws_dynamodb_table",
 		"aws_ebs_volume",
 		"aws_ecs_cluster",
@@ -72,6 +74,7 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_iam_policy",
 		"aws_iam_role",
 		"aws_iam_role_policy",
+		"aws_iam_role_policy_attachment",
 		"aws_iam_service_linked_role",
 		"aws_iam_user",
 		"aws_instance",
@@ -121,6 +124,7 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_vpc_dhcp_options",
 		"aws_vpc_endpoint",
 		"aws_wafv2_web_acl",
+		"aws_wafv2_web_acl_association",
 	}
 	got := SupportedDiscoverTypes(ProviderAWS)
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
## Summary

Closes the AWS in-preset discovery gap by registering 4 multi-emit / sub-resource types through the Bundle 14k1 SDK-only framework. Stacked on PR #455 (Bundle 14k1).

| # | TF type | Parent | Mode | Import ID format | Category |
|---|---|---|---|---|---|
| 1 | `aws_dynamodb_contributor_insights` | DynamoDB table | single-emit | `<table_name>` | Observability |
| 2 | `aws_iam_role_policy_attachment` | IAM role (global) | multi-emit | `<role_name>/<policy_arn>` | Security |
| 3 | `aws_wafv2_web_acl_association` | WAFv2 WebACL | multi-emit | `<resource_arn>,<web_acl_arn>` | Security |
| 4 | `aws_autoscaling_group_tag` | Auto Scaling Group | multi-emit | `<asg_name>,<tag_key>` | Virtual Machines |
| 5 | ~~`aws_security_group_rule`~~ | Security Group | **deferred** | synthetic `sgrule-<hash>` | n/a |

## Deferral: `aws_security_group_rule`

The legacy `aws_security_group_rule` TF resource uses a synthetic hash-based ID (`sgrule-<hash>`) computed by the provider from rule attributes (Type / SecurityGroupID / Protocol / FromPort / ToPort / Source). Reconstructing that hash from `DescribeSecurityGroups` `IpPermissions` payload is not deterministic across SDK versions / provider versions / source-type permutations; shipping an import format we cannot prove correct would cause silent `terraform import` failures downstream.

The supported migration path is `aws_vpc_security_group_ingress_rule` / `aws_vpc_security_group_egress_rule`, which carry real EC2-API-returned `security_group_rule_id` values (e.g. `sgr-0123456789abcdef0`). Wiring those into the framework is a clean follow-up (tracked as a successor to #456) and doesn't require any new infrastructure here.

AWS in-preset coverage: 103 → 107 (4 of 5 shipped). The AWS-to-GCP parity push is **functionally complete** modulo the one deferred type whose replacement is the supported go-forward path.

## Framework extension

`sdkOnlySubresourceConfig` gains a `FetchItems` plural variant returning `[]subresourceEmission`, mutually exclusive with the existing `FetchItem`. Each emission carries its own `(ImportID, NameHint, NativeIDs, Props)` because the parent identifier alone cannot address per-attachment / per-association / per-tag children.

The discoverer's per-parent loop collects emissions, deterministically sorts by `(parentID, ImportID)`, and emits one `ImportedResource` per emission. The single-emit `FetchItem` path is retrofitted to flow through a shared `fetchOne` helper so observability, soft-fail, and JSON-shape contracts stay symmetric. Backward-compatibility for the 5 14k1 S3 sub-resources is preserved verbatim — all 36 14k1 framework + S3 tests still pass.

Mutual exclusion enforced at package init (panic) and surfaced as a test (`TestSDKOnlySubresourceConfigs_ExactlyOneFetchVariant`).

## Per-type notes

- **DDB contributor insights** — exists iff `ContributorInsightsStatus` ∈ {`ENABLED`, `ENABLING`}; `DISABLED` / `DISABLING` / `FAILED` yield exists=false. Parent enumeration via `dynamodb:ListTables` (paginated).
- **IAM role policy attachment** — global service (`IsGlobal: true`). Service-linked roles filtered at `ListParents` (they reject AttachRolePolicy with AccessDenied); reuses the well-known `/aws-service-role/` path prefix discriminator from `cloudcontrol_listers.go::iamServiceRolePathPrefix`. `NoSuchEntity` / `NoSuchEntityException` swallowed (race with role deletion).
- **WAFv2 web ACL association** — per-Scope fan-out (REGIONAL in any region, CLOUDFRONT only in us-east-1, matching the existing `wafv2ParentModels` precedent). Per-resource-type fan-out across 7 types (ALB / API Gateway / AppSync / Cognito user pool / App Runner / Verified Access / Amplify). `WAFInvalidParameterException` / `ValidationException` swallowed (resource type unsupported in region); `AccessDenied` propagates.
- **ASG tag** — tags inline on `DescribeAutoScalingGroups`, no extra SDK call. Per-ASG fan-out uses the `AutoScalingGroupNames=[name]` filter to scope to one group. Empty key skipped (unaddressable). Vanished ASG (empty AutoScalingGroups slice) yields zero emissions.

## Plumbing

- `pkg/insideout-import/registry/registry.go` + literal-pin test: 4 new entries, AWS list 103 → 107.
- `pkg/composer/imported/category.go` + golden re-seed.
- `pkg/insideout-import/permissions/aws.json` + slug-table test: 8 new IAM-permission rows + 4 new TF-type slug entries.
- Untaggable allowlist (`pkg/composer/imported_provenance.go::untaggableAWS`) + `tests/lint-project-tag.sh::NON_TAGGABLE_AWS` already covered all 5 types pre-emptively in earlier bundles; no change needed.

## Test plan

- [x] Framework: `TestSDKOnlySubresourceDiscover_FetchItemsMultipleEmissions` / `_ZeroEmissions` / `_SingleEmission` / `_ErrorWarnsAndContinues` / `_FetchItemsAndFetchItemMutuallyExclusive` (incl. dep-chase compound-ID resolution).
- [x] Per-type: happy path, zero-emit, multi-emit, pagination, race (NoSuchEntity / NoSuchBucket / vanished ASG), per-type soft-fail (AccessDenied propagates, NotFound swallowed), `[]` vs `null` JSON-shape contract (#255).
- [x] `go test ./cmd/insideout-import/awsdiscover/... -race -count=1` — 570 pass.
- [x] `go test ./pkg/... -count=1` — 2967 pass.
- [x] `terraform fmt -check -recursive` clean.
- [x] `tests/lint-project-tag.sh` / `lint-project-label.sh` / `lint-sensitive-for-each.sh` / `lint-foreach-unknown-keys.sh` / `lint-no-root-only-blocks.sh` / `lint-gcp-project-pin.sh` / `lint-shared-no-cloud-providers.sh` all PASS.
- [ ] Live smoke against `io-f-v6e-hzw-zt` (deferred — AWS creds expired in the agent environment). The framework-extension + per-type fakes exercise every code path that runs against AWS; live smoke can be run by the human reviewer with `aws_login dev` followed by `bin/insideout-import discover --provider aws --project io-f-v6e-hzw-zt --regions us-east-1 --no-hcl --output-dir .tmp/livesmoke14k2`.

Closes #456