### PR TITLE
feat(imported-codegen): wire provider versions through codegen (#453)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ gen-imported: ## Regenerate typed resource files from filtered schemas.
 	    --aws-schema $(SCHEMAS_DIR)/aws.filtered.json \
 	    --google-schema $(SCHEMAS_DIR)/google.filtered.json \
 	    --google-beta-schema $(SCHEMAS_DIR)/google-beta.filtered.json \
+	    --providers-tf $(SCHEMAS_DIR)/providers.tf \
 	    --out $(GEN_DIR)
 	$(GO) build ./...
 
@@ -51,6 +52,7 @@ gen-zod: ## Emit TS Zod fragments to ZOD_OUT (default .tmp/zod-out).
 	    --aws-schema $(SCHEMAS_DIR)/aws.filtered.json \
 	    --google-schema $(SCHEMAS_DIR)/google.filtered.json \
 	    --google-beta-schema $(SCHEMAS_DIR)/google-beta.filtered.json \
+	    --providers-tf $(SCHEMAS_DIR)/providers.tf \
 	    --out $(ZOD_OUT)
 
 .PHONY: verify-gen

--- a/cmd/imported-codegen/emit_zod.go
+++ b/cmd/imported-codegen/emit_zod.go
@@ -112,14 +112,28 @@ func EmitZodValueFile(outDir string) (string, error) {
 }
 
 // EmitZodRegistryFile writes _registry.ts indexing every emitted type
-// by its Terraform resource type.
-func EmitZodRegistryFile(outDir string, entries []ZodRegistryEntry) (string, error) {
+// by its Terraform resource type and exposing a versions map keyed by
+// provider source.
+//
+// The versions map mirrors the per-provider constants in
+// pkg/composer/imported/generated/version.gen.go on the Go side:
+// downstream consumers do `versions[registry[tfType].providerSource]`
+// to recover the exact pinned version active at codegen time.
+func EmitZodRegistryFile(outDir string, entries []ZodRegistryEntry, pins ProviderPins) (string, error) {
 	tmpl, err := template.New("registry.zod").Parse(zodRegistryTemplateSrc)
 	if err != nil {
 		return "", fmt.Errorf("parse zod registry template: %w", err)
 	}
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, map[string]any{"Entries": entries}); err != nil {
+	data := map[string]any{
+		"Entries": entries,
+		"Versions": []zodRegistryVersion{
+			{Source: AWSProviderSource, Version: pins.AWS},
+			{Source: GoogleProviderSource, Version: pins.Google},
+			{Source: GoogleBetaProviderSource, Version: pins.GoogleBeta},
+		},
+	}
+	if err := tmpl.Execute(&buf, data); err != nil {
 		return "", fmt.Errorf("execute zod registry template: %w", err)
 	}
 	path := filepath.Join(outDir, "_registry.ts")
@@ -127,6 +141,14 @@ func EmitZodRegistryFile(outDir string, entries []ZodRegistryEntry) (string, err
 		return "", fmt.Errorf("write %s: %w", path, err)
 	}
 	return path, nil
+}
+
+// zodRegistryVersion is one row in the emitted versions map. Stable
+// per-source ordering matters for byte-for-byte parity across runs;
+// the slice is iterated in the order the template renders it.
+type zodRegistryVersion struct {
+	Source  string
+	Version string
 }
 
 func buildZodTypeData(res *tfjson.Schema, tfType, providerSource string) (*ZodTypeData, error) {

--- a/cmd/imported-codegen/emit_zod_test.go
+++ b/cmd/imported-codegen/emit_zod_test.go
@@ -41,6 +41,7 @@ func TestEmitZod_AllWantedTypes(t *testing.T) {
 		"--aws-schema", filepath.Join(root, "schemas", "aws.filtered.json"),
 		"--google-schema", filepath.Join(root, "schemas", "google.filtered.json"),
 		"--google-beta-schema", filepath.Join(root, "schemas", "google-beta.filtered.json"),
+		"--providers-tf", filepath.Join(root, "schemas", "providers.tf"),
 		"--out", outDir,
 	})
 	require.Equal(t, 0, rc, "runZod must exit 0")
@@ -90,6 +91,32 @@ func TestEmitZod_AllWantedTypes(t *testing.T) {
 	for _, tfType := range want {
 		assert.Containsf(t, string(registry), fmt.Sprintf(`"%s":`, tfType), "_registry.ts missing entry for %s", tfType)
 	}
+
+	// Versions map: load the same providers.tf the emitter consumed
+	// and assert the emitted block is byte-anchored against the
+	// expected source/version pairs in template-iteration order.
+	// This is the load-bearing TS-side drift signal — a downstream
+	// consumer reads versions[providerSource] to stamp
+	// ResourceIdentity.providerVersion at import time. A weaker
+	// Contains-per-pair check would pass if the pairs leaked into a
+	// comment or a second (corrupt) map; the block-anchored check +
+	// single-occurrence guard catches both regressions.
+	pins, err := LoadProviderPins(filepath.Join(root, "schemas", "providers.tf"))
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(string(registry), "export const versions = {"),
+		"_registry.ts must declare exactly one versions map")
+	wantBlock := fmt.Sprintf(
+		"export const versions = {\n"+
+			"  %q: %q,\n"+
+			"  %q: %q,\n"+
+			"  %q: %q,\n"+
+			"} as const;",
+		AWSProviderSource, pins.AWS,
+		GoogleProviderSource, pins.Google,
+		GoogleBetaProviderSource, pins.GoogleBeta,
+	)
+	assert.Contains(t, string(registry), wantBlock,
+		"_registry.ts versions block must match expected layout byte-for-byte")
 }
 
 // TestParseTypesFilter pins the parser semantics: empty / whitespace
@@ -276,6 +303,7 @@ func TestEmitZod_FilterFlag(t *testing.T) {
 		"--aws-schema", filepath.Join(root, "schemas", "aws.filtered.json"),
 		"--google-schema", filepath.Join(root, "schemas", "google.filtered.json"),
 		"--google-beta-schema", filepath.Join(root, "schemas", "google-beta.filtered.json"),
+		"--providers-tf", filepath.Join(root, "schemas", "providers.tf"),
 		"--out", outDir,
 		"--types", "aws_sqs_queue,google_storage_bucket",
 	})
@@ -316,6 +344,7 @@ func TestEmitZodMetadataMatchesGoSchema(t *testing.T) {
 		"--aws-schema", filepath.Join(root, "schemas", "aws.filtered.json"),
 		"--google-schema", filepath.Join(root, "schemas", "google.filtered.json"),
 		"--google-beta-schema", filepath.Join(root, "schemas", "google-beta.filtered.json"),
+		"--providers-tf", filepath.Join(root, "schemas", "providers.tf"),
 		"--out", outDir,
 	})
 	require.Equal(t, 0, rc)

--- a/cmd/imported-codegen/main.go
+++ b/cmd/imported-codegen/main.go
@@ -67,6 +67,7 @@ func runGen(args []string) int {
 	awsSchema := fs.String("aws-schema", "schemas/aws.filtered.json", "path to filtered AWS provider schema JSON")
 	googleSchema := fs.String("google-schema", "schemas/google.filtered.json", "path to filtered Google provider schema JSON")
 	googleBetaSchema := fs.String("google-beta-schema", "schemas/google-beta.filtered.json", "path to filtered Google-Beta provider schema JSON")
+	providersTF := fs.String("providers-tf", "schemas/providers.tf", "path to providers.tf pinning exact provider versions")
 	outDir := fs.String("out", "pkg/composer/imported/generated", "directory to write generated *.gen.go files")
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -93,9 +94,11 @@ func runGen(args []string) int {
 		return 1
 	}
 
-	awsVersion := providerVersion(awsPS, AWSProviderSource)
-	googleVersion := providerVersion(googlePS, GoogleProviderSource)
-	googleBetaVersion := providerVersion(googleBetaPS, GoogleBetaProviderSource)
+	pins, err := LoadProviderPins(*providersTF)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load provider pins: %v\n", err)
+		return 1
+	}
 
 	for _, tfType := range WantedAWS {
 		res, _, err := FindResource(awsPS, AWSProviderSource, tfType)
@@ -103,7 +106,7 @@ func runGen(args []string) int {
 			fmt.Fprintf(os.Stderr, "%s: %v\n", tfType, err)
 			return 1
 		}
-		path, err := EmitTypeFile(*outDir, res, AWSProviderSource, tfType, awsVersion)
+		path, err := EmitTypeFile(*outDir, res, AWSProviderSource, tfType, pins.AWS)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %v\n", tfType, err)
 			return 1
@@ -116,7 +119,7 @@ func runGen(args []string) int {
 			fmt.Fprintf(os.Stderr, "%s: %v\n", tfType, err)
 			return 1
 		}
-		path, err := EmitTypeFile(*outDir, res, GoogleProviderSource, tfType, googleVersion)
+		path, err := EmitTypeFile(*outDir, res, GoogleProviderSource, tfType, pins.Google)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %v\n", tfType, err)
 			return 1
@@ -129,7 +132,7 @@ func runGen(args []string) int {
 			fmt.Fprintf(os.Stderr, "%s: %v\n", tfType, err)
 			return 1
 		}
-		path, err := EmitTypeFile(*outDir, res, GoogleBetaProviderSource, tfType, googleBetaVersion)
+		path, err := EmitTypeFile(*outDir, res, GoogleBetaProviderSource, tfType, pins.GoogleBeta)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %v\n", tfType, err)
 			return 1
@@ -137,7 +140,7 @@ func runGen(args []string) int {
 		fmt.Println(filepath.Base(path))
 	}
 
-	if _, err := EmitVersionFile(*outDir, awsVersion, googleVersion, googleBetaVersion); err != nil {
+	if _, err := EmitVersionFile(*outDir, pins.AWS, pins.Google, pins.GoogleBeta); err != nil {
 		fmt.Fprintf(os.Stderr, "version.gen.go: %v\n", err)
 		return 1
 	}
@@ -157,6 +160,7 @@ func runZod(args []string) int {
 	awsSchema := fs.String("aws-schema", "schemas/aws.filtered.json", "path to filtered AWS provider schema JSON")
 	googleSchema := fs.String("google-schema", "schemas/google.filtered.json", "path to filtered Google provider schema JSON")
 	googleBetaSchema := fs.String("google-beta-schema", "schemas/google-beta.filtered.json", "path to filtered Google-Beta provider schema JSON")
+	providersTF := fs.String("providers-tf", "schemas/providers.tf", "path to providers.tf pinning exact provider versions")
 	outDir := fs.String("out", "out/zod", "directory to write generated *.ts files")
 	typesFilter := fs.String("types", "", "comma-separated subset of Terraform resource types to emit (default: all WantedAWS+WantedGoogle+WantedGoogleBeta)")
 	if err := fs.Parse(args); err != nil {
@@ -181,6 +185,12 @@ func runZod(args []string) int {
 	googleBetaPS, err := LoadFiltered(*googleBetaSchema)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "load google-beta schema: %v\n", err)
+		return 1
+	}
+
+	pins, err := LoadProviderPins(*providersTF)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load provider pins: %v\n", err)
 		return 1
 	}
 
@@ -230,7 +240,7 @@ func runZod(args []string) int {
 		return 1
 	}
 
-	if _, err := EmitZodRegistryFile(*outDir, entries); err != nil {
+	if _, err := EmitZodRegistryFile(*outDir, entries, pins); err != nil {
 		fmt.Fprintf(os.Stderr, "_registry.ts: %v\n", err)
 		return 1
 	}
@@ -294,19 +304,3 @@ func (f typesFilter) unknownAgainst(wants ...[]string) []string {
 	return unknown
 }
 
-// providerVersion reads the provider version recorded in a ProviderSchemas
-// dump. terraform-json exposes this as ProviderSchema.ConfigSchema or via
-// the dump's `provider_versions` map; we use the top-level metadata map
-// when present and fall back to "" otherwise.
-func providerVersion(ps any, _ string) string {
-	// terraform-json's ProviderSchemas does not surface provider versions
-	// directly on the struct in older versions of the library. The
-	// version is captured at refresh time by `terraform providers schema`
-	// but the field name moves between releases. For now we leave this
-	// blank in code and rely on `make refresh-schemas` to record versions
-	// alongside the JSON in schemas/providers.tf — operators bumping a
-	// provider edit both. The runtime version constants come from
-	// version.gen.go's template substitution which is fed from CLI flags
-	// in a future enhancement (see TODO in EmitVersionFile callers).
-	return ""
-}

--- a/cmd/imported-codegen/providers.go
+++ b/cmd/imported-codegen/providers.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+)
+
+// providerSources pins the registry source each ProviderPins field
+// must declare. extractExactPin asserts the parsed required_providers
+// entry uses these — guarding against the silent drift signal that
+// otherwise happens when a providers.tf declares
+// `aws = { source = "foo/aws", ... }`: codegen would key the version
+// map off our hard-coded AWSProviderSource while the actual provider
+// being pinned is foreign.
+var providerSources = map[string]string{
+	"aws":         "hashicorp/aws",
+	"google":      "hashicorp/google",
+	"google-beta": "hashicorp/google-beta",
+}
+
+// ProviderPins is the per-provider version pin captured from
+// schemas/providers.tf. Each field is the bare version string (e.g.
+// "5.70.0"), already stripped of the "= " constraint prefix and
+// validated as an exact pin.
+//
+// The codegen feeds these strings into version.gen.go's template
+// substitution (and the TS _registry.ts versions map) so
+// imported.ResourceIdentity.ProviderVersion can carry the exact
+// version active when a resource was imported — the load-bearing
+// signal for schema-drift detection on re-import.
+type ProviderPins struct {
+	AWS        string
+	Google     string
+	GoogleBeta string
+}
+
+// LoadProviderPins parses the providers.tf file at path (and only
+// that file — sibling .tf files in the same directory are NOT
+// aggregated) and returns the exact version pin for each of the
+// three providers the imported-codegen pipeline emits.
+//
+// Errors when:
+//   - the file fails to parse as HCL
+//   - one of the three providers is missing from required_providers
+//   - a provider has zero or more than one version constraint
+//   - a provider declares an unexpected source (e.g. foo/aws instead
+//     of hashicorp/aws), which would otherwise cause the emitted
+//     versions map to silently mis-key under the canonical
+//     *ProviderSource constants
+//   - the constraint is not an exact pin ("= X.Y.Z" or bare "X.Y.Z").
+//     Range / pessimistic constraints (>=, <=, ~>, !=, comma-joined
+//     ranges) are rejected because drift detection requires a single
+//     unambiguous version per provider.
+func LoadProviderPins(path string) (ProviderPins, error) {
+	parser := hclparse.NewParser()
+	file, diags := parser.ParseHCLFile(path)
+	if diags.HasErrors() {
+		return ProviderPins{}, fmt.Errorf("parse %s: %w", path, diags)
+	}
+	mod := tfconfig.NewModule(path)
+	if loadDiags := tfconfig.LoadModuleFromFile(file, mod); loadDiags.HasErrors() {
+		return ProviderPins{}, fmt.Errorf("load %s: %w", path, loadDiags)
+	}
+
+	aws, err := extractExactPin(mod.RequiredProviders, "aws")
+	if err != nil {
+		return ProviderPins{}, err
+	}
+	google, err := extractExactPin(mod.RequiredProviders, "google")
+	if err != nil {
+		return ProviderPins{}, err
+	}
+	googleBeta, err := extractExactPin(mod.RequiredProviders, "google-beta")
+	if err != nil {
+		return ProviderPins{}, err
+	}
+
+	return ProviderPins{
+		AWS:        aws,
+		Google:     google,
+		GoogleBeta: googleBeta,
+	}, nil
+}
+
+// extractExactPin pulls the single exact-equality version constraint
+// for the named provider out of a tfconfig RequiredProviders map.
+// The caller's name argument must be one of the keys in
+// providerSources; the matching source string is enforced against
+// req.Source to catch a hand-edited providers.tf that points the
+// local name at a foreign registry source.
+func extractExactPin(reqs map[string]*tfconfig.ProviderRequirement, name string) (string, error) {
+	wantSource, ok := providerSources[name]
+	if !ok {
+		return "", fmt.Errorf("provider %q: not a recognized imported-codegen target", name)
+	}
+	req, ok := reqs[name]
+	if !ok || req == nil {
+		return "", fmt.Errorf("provider %q: not declared in required_providers", name)
+	}
+	if req.Source != wantSource {
+		return "", fmt.Errorf("provider %q: source mismatch — required_providers declares %q, codegen pins %q", name, req.Source, wantSource)
+	}
+	if len(req.VersionConstraints) == 0 {
+		return "", fmt.Errorf("provider %q: no version constraint set", name)
+	}
+	if len(req.VersionConstraints) > 1 {
+		return "", fmt.Errorf("provider %q: expected exactly one version constraint, got %d (%v)", name, len(req.VersionConstraints), req.VersionConstraints)
+	}
+	pin, err := parseExactPin(req.VersionConstraints[0])
+	if err != nil {
+		return "", fmt.Errorf("provider %q: %w", name, err)
+	}
+	return pin, nil
+}
+
+// parseExactPin accepts a Terraform version constraint string and
+// returns the bare version iff it is an exact-equality pin.
+//
+// Accepted shapes (whitespace flexible):
+//
+//	"= 5.70.0"
+//	"=5.70.0"
+//	"5.70.0"  (bare version is implicit exact in Terraform)
+//
+// SemVer pre-release and build metadata are preserved:
+//
+//	"= 6.10.0-beta1"        → "6.10.0-beta1"
+//	"= 1.2.3+meta.build"    → "1.2.3+meta.build"
+//	"= 1.2.3-rc1+build.4"   → "1.2.3-rc1+build.4"
+//
+// Rejected:
+//
+//	">= 5.70.0", "> 5.70.0", "<= 5.70.0", "< 5.70.0",
+//	"!= 5.70.0", "~> 5.70.0", "== 5.70.0",
+//	">= 5.0, < 6.0" (comma-joined ranges),
+//	anything that doesn't match the semVerShape regex below (e.g.
+//	"v5.70.0", "-5.70.0", "5.70.0a", embedded whitespace/newlines).
+var errNotExactPin = errors.New("constraint is not an exact pin (only `= X.Y.Z` accepted)")
+
+// semVerShape matches the SemVer subset Terraform accepts as a
+// version string. Three numeric segments, optional pre-release
+// (alnum / dot / hyphen), optional build metadata (same charset).
+// Anchored to defend against embedded whitespace, newlines, leading
+// `v`, leading `-`, and other garbage that the operator-character
+// check below would not catch.
+var semVerShape = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$`)
+
+func parseExactPin(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("constraint is empty")
+	}
+	if rest, ok := strings.CutPrefix(trimmed, "="); ok {
+		// Guard against "==" (illegal in TF but defensive).
+		if strings.HasPrefix(rest, "=") {
+			return "", fmt.Errorf("%w: %q", errNotExactPin, raw)
+		}
+		trimmed = strings.TrimSpace(rest)
+	}
+	// At this point trimmed should be a bare version. Reject any
+	// operator / separator chars that would indicate a range — this
+	// gives a clearer error message than the regex check below for
+	// the common cases.
+	if strings.ContainsAny(trimmed, "=<>~!,") {
+		return "", fmt.Errorf("%w: %q", errNotExactPin, raw)
+	}
+	if !semVerShape.MatchString(trimmed) {
+		return "", fmt.Errorf("%w: %q", errNotExactPin, raw)
+	}
+	return trimmed, nil
+}

--- a/cmd/imported-codegen/providers_test.go
+++ b/cmd/imported-codegen/providers_test.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseExactPin_Accepted(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"= 5.70.0", "5.70.0"},
+		{"=5.70.0", "5.70.0"},
+		{"5.70.0", "5.70.0"},
+		{"  = 5.70.0  ", "5.70.0"},
+		{"= 6.10.0-beta1", "6.10.0-beta1"},
+		{"= 1.2.3+meta.build", "1.2.3+meta.build"},
+		{"= 1.2.3-rc1+build.4", "1.2.3-rc1+build.4"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseExactPin(tc.in)
+			require.NoErrorf(t, err, "parseExactPin(%q)", tc.in)
+			assert.Equalf(t, tc.want, got, "parseExactPin(%q)", tc.in)
+		})
+	}
+}
+
+func TestParseExactPin_Rejected(t *testing.T) {
+	t.Parallel()
+	// Every rejected case must surface errNotExactPin so callers can
+	// branch on the class of failure. The substring assertions on
+	// other error classes (missing provider, source mismatch) live in
+	// TestExtractExactPin below.
+	cases := []string{
+		">= 5.70.0",
+		"> 5.70.0",
+		"<= 5.70.0",
+		"< 5.70.0",
+		"!= 5.70.0",
+		"~> 5.70.0",
+		"~> 5.70",
+		"== 5.70.0",
+		"=== 5.70.0",
+		">= 5.0, < 6.0",
+		"= ",
+		"=   ",
+		"v5.70.0",
+		"-5.70.0",
+		"5.70.0a",
+		"5.70",     // missing patch
+		"5",        // missing minor + patch
+		"5.70.0.1", // extra segment
+		"5.70.0\n5.71.0",
+		"version",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseExactPin(in)
+			require.Errorf(t, err, "parseExactPin(%q) should error, got %q", in, got)
+			assert.ErrorIs(t, err, errNotExactPin,
+				"parseExactPin(%q) must wrap errNotExactPin, got %v", in, err)
+		})
+	}
+}
+
+// TestParseExactPin_Empty pins the early-exit branch: blank input
+// errors with a distinct (non-errNotExactPin) message because there's
+// nothing to classify yet.
+func TestParseExactPin_Empty(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"", "   "} {
+		_, err := parseExactPin(in)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	}
+}
+
+func TestLoadProviderPins(t *testing.T) {
+	t.Parallel()
+
+	type want struct {
+		pins      ProviderPins
+		errMsg    string // substring; empty means expect success
+		errIsKind error  // optional sentinel to assert via errors.Is
+	}
+	cases := []struct {
+		name string
+		body string
+		want want
+	}{
+		{
+			name: "happy path",
+			body: `
+terraform {
+  required_providers {
+    aws         = { source = "hashicorp/aws", version = "= 5.70.0" }
+    google      = { source = "hashicorp/google", version = "= 6.10.0" }
+    google-beta = { source = "hashicorp/google-beta", version = "= 6.10.0" }
+  }
+}
+`,
+			want: want{pins: ProviderPins{AWS: "5.70.0", Google: "6.10.0", GoogleBeta: "6.10.0"}},
+		},
+		{
+			name: "bare versions",
+			body: `
+terraform {
+  required_providers {
+    aws         = { source = "hashicorp/aws", version = "5.70.0" }
+    google      = { source = "hashicorp/google", version = "6.10.0" }
+    google-beta = { source = "hashicorp/google-beta", version = "6.10.0" }
+  }
+}
+`,
+			want: want{pins: ProviderPins{AWS: "5.70.0", Google: "6.10.0", GoogleBeta: "6.10.0"}},
+		},
+		{
+			name: "aws missing",
+			body: `
+terraform {
+  required_providers {
+    google      = { source = "hashicorp/google", version = "= 6.10.0" }
+    google-beta = { source = "hashicorp/google-beta", version = "= 6.10.0" }
+  }
+}
+`,
+			want: want{errMsg: `provider "aws": not declared`},
+		},
+		{
+			name: "aws wrong source",
+			body: `
+terraform {
+  required_providers {
+    aws         = { source = "foo/aws", version = "= 5.70.0" }
+    google      = { source = "hashicorp/google", version = "= 6.10.0" }
+    google-beta = { source = "hashicorp/google-beta", version = "= 6.10.0" }
+  }
+}
+`,
+			want: want{errMsg: `source mismatch`},
+		},
+		{
+			name: "range constraint",
+			body: `
+terraform {
+  required_providers {
+    aws         = { source = "hashicorp/aws", version = ">= 5.70.0" }
+    google      = { source = "hashicorp/google", version = "= 6.10.0" }
+    google-beta = { source = "hashicorp/google-beta", version = "= 6.10.0" }
+  }
+}
+`,
+			want: want{errIsKind: errNotExactPin},
+		},
+		{
+			name: "pessimistic constraint",
+			body: `
+terraform {
+  required_providers {
+    aws         = { source = "hashicorp/aws", version = "~> 5.70" }
+    google      = { source = "hashicorp/google", version = "= 6.10.0" }
+    google-beta = { source = "hashicorp/google-beta", version = "= 6.10.0" }
+  }
+}
+`,
+			want: want{errIsKind: errNotExactPin},
+		},
+		{
+			name: "comma-joined range",
+			body: `
+terraform {
+  required_providers {
+    aws         = { source = "hashicorp/aws", version = ">= 5.0, < 6.0" }
+    google      = { source = "hashicorp/google", version = "= 6.10.0" }
+    google-beta = { source = "hashicorp/google-beta", version = "= 6.10.0" }
+  }
+}
+`,
+			want: want{errIsKind: errNotExactPin},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			path := filepath.Join(dir, "providers.tf")
+			require.NoError(t, os.WriteFile(path, []byte(tc.body), 0o644))
+			got, err := LoadProviderPins(path)
+			if tc.want.errIsKind != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.want.errIsKind)
+				return
+			}
+			if tc.want.errMsg != "" {
+				require.Error(t, err, "expected error containing %q", tc.want.errMsg)
+				assert.Contains(t, err.Error(), tc.want.errMsg)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want.pins, got)
+		})
+	}
+}
+
+// TestLoadProviderPins_FileOnly pins the load-bearing "only the named
+// file is parsed" property: a sibling .tf in the same directory that
+// declares a *different* constraint must NOT aggregate into the
+// result. This was the silent-multi-file-aggregation footgun called
+// out in code review — without this guarantee, an unrelated .tf in
+// the schemas/ directory could shadow providers.tf's pins.
+func TestLoadProviderPins_FileOnly(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "providers.tf"), []byte(`
+terraform {
+  required_providers {
+    aws         = { source = "hashicorp/aws", version = "= 5.70.0" }
+    google      = { source = "hashicorp/google", version = "= 6.10.0" }
+    google-beta = { source = "hashicorp/google-beta", version = "= 6.10.0" }
+  }
+}
+`), 0o644))
+	// Sibling declares a conflicting aws version. If LoadProviderPins
+	// switched back to module-level aggregation, the resulting
+	// VersionConstraints list would have len() == 2 and we'd surface
+	// the "expected exactly one" error.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "noise.tf"), []byte(`
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "= 5.99.0" }
+  }
+}
+`), 0o644))
+	got, err := LoadProviderPins(filepath.Join(dir, "providers.tf"))
+	require.NoError(t, err)
+	assert.Equal(t, ProviderPins{AWS: "5.70.0", Google: "6.10.0", GoogleBeta: "6.10.0"}, got)
+}
+
+// TestExtractExactPin_MultiConstraint exercises the
+// "more than one version constraint" branch directly with a
+// hand-built tfconfig map, decoupling the test from tfconfig's
+// aggregation semantics.
+func TestExtractExactPin_MultiConstraint(t *testing.T) {
+	t.Parallel()
+	reqs := map[string]*tfconfig.ProviderRequirement{
+		"aws": {
+			Source:             "hashicorp/aws",
+			VersionConstraints: []string{"= 5.70.0", "= 5.71.0"},
+		},
+	}
+	_, err := extractExactPin(reqs, "aws")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `provider "aws"`)
+	assert.Contains(t, err.Error(), "expected exactly one")
+}
+
+// TestExtractExactPin_UnknownTarget pins the fail-fast guard against
+// callers passing a provider name outside providerSources.
+func TestExtractExactPin_UnknownTarget(t *testing.T) {
+	t.Parallel()
+	_, err := extractExactPin(map[string]*tfconfig.ProviderRequirement{}, "azurerm")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a recognized imported-codegen target")
+}
+
+// TestLoadProviderPins_FileNotFound pins the file-existence path:
+// we must surface an HCL parse failure (not a misleading
+// "provider not declared" cascade) when the named file is absent.
+func TestLoadProviderPins_FileNotFound(t *testing.T) {
+	t.Parallel()
+	_, err := LoadProviderPins(filepath.Join(t.TempDir(), "does-not-exist.tf"))
+	require.Error(t, err)
+	// HCL's diagnostic format includes the filename — assert it
+	// surfaces rather than the downstream "provider \"aws\": not
+	// declared" error.
+	assert.Contains(t, err.Error(), "parse")
+}
+

--- a/cmd/imported-codegen/templates/registry.zod.ts.tmpl
+++ b/cmd/imported-codegen/templates/registry.zod.ts.tmpl
@@ -14,3 +14,16 @@ export const registry = {
 } as const;
 
 export type RegistryKey = keyof typeof registry;
+
+// versions pins the exact Terraform provider version active when this
+// file was generated, keyed by provider source. Mirrors the
+// AWSProviderVersion / GoogleProviderVersion / GoogleBetaProviderVersion
+// constants in pkg/composer/imported/generated/version.gen.go on the
+// Go side. Consumers use it to stamp
+// ResourceIdentity.providerVersion at import time so a re-import
+// can detect schema drift.
+export const versions = {
+{{- range .Versions}}
+  "{{.Source}}": "{{.Version}}",
+{{- end}}
+} as const;

--- a/cmd/imported-codegen/version_drift_test.go
+++ b/cmd/imported-codegen/version_drift_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVersionDrift_GeneratedMatchesProvidersTF is the drift gate
+// between schemas/providers.tf (the committed source of truth for
+// provider pins) and pkg/composer/imported/generated/version.gen.go
+// (the committed codegen output).
+//
+// Failure scenarios this catches:
+//
+//   - Edit schemas/providers.tf (bump aws to 5.71.0) without running
+//     `make gen-imported`. version.gen.go still says 5.70.0; the
+//     matching subtest flips red.
+//   - Edit version.gen.go by hand. Same failure.
+//
+// `make verify-gen` already gates on a git diff after re-running the
+// generator and covers the same regression class — this test is the
+// faster-failing in-package signal that names the exact provider
+// without shelling out to `make`.
+func TestVersionDrift_GeneratedMatchesProvidersTF(t *testing.T) {
+	t.Parallel()
+	root := repoRoot(t)
+	pins, err := LoadProviderPins(filepath.Join(root, "schemas", "providers.tf"))
+	require.NoError(t, err)
+
+	cases := []struct {
+		name  string
+		pin   string
+		genGo string
+	}{
+		{"aws", pins.AWS, generated.AWSProviderVersion},
+		{"google", pins.Google, generated.GoogleProviderVersion},
+		{"google-beta", pins.GoogleBeta, generated.GoogleBetaProviderVersion},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equalf(t, tc.pin, tc.genGo,
+				"provider %q: schemas/providers.tf pins %q but generated/version.gen.go has %q — run `make gen-imported` and commit",
+				tc.name, tc.pin, tc.genGo)
+		})
+	}
+}

--- a/pkg/composer/imported/generated/version.gen.go
+++ b/pkg/composer/imported/generated/version.gen.go
@@ -8,10 +8,10 @@ package generated
 // schema drift.
 const (
 	AWSProviderSource         = "registry.terraform.io/hashicorp/aws"
-	AWSProviderVersion        = ""
+	AWSProviderVersion        = "5.70.0"
 	GoogleProviderSource      = "registry.terraform.io/hashicorp/google"
-	GoogleProviderVersion     = ""
+	GoogleProviderVersion     = "6.10.0"
 	GoogleBetaProviderSource  = "registry.terraform.io/hashicorp/google-beta"
-	GoogleBetaProviderVersion = ""
+	GoogleBetaProviderVersion = "6.10.0"
 	SchemaCodegenVersion      = "1"
 )


### PR DESCRIPTION
## Summary

- Parse `schemas/providers.tf` via `terraform-config-inspect` and pin the resulting versions into `generated.*ProviderVersion` constants and the new TS `_registry.ts` `versions` map. Before this change, every emitted constant was the empty string and `ResourceIdentity.ProviderVersion` — documented as the drift-detection signal — silently carried no value end-to-end.
- Enforce exact-equality constraints (`= X.Y.Z` or bare `X.Y.Z`), validate registry source against the codegen-pinned source string, and parse only the named file (not the parent directory) so a stray sibling `.tf` cannot shadow canonical pins.
- Drift gate (`TestVersionDrift_GeneratedMatchesProvidersTF`) asserts each committed `generated.*ProviderVersion` equals what `LoadProviderPins` reads from `providers.tf` — the in-package fast-failing signal that complements `make verify-gen`'s git-diff check.

Closes #453.

## What this enables

`awsdiscover/identity.go:9-10` flags "Stage 2b will set ProviderVersion from the actual terraform init output" — Stage 2b can now read `generated.AWSProviderVersion` and friends and get a real value, instead of an empty string. Same on the TS side: downstream consumers (e.g. `luthersystems/reliable`) do `versions[registry[tfType].providerSource]`.

## Test plan

- [x] `go test ./cmd/imported-codegen -count=1 -race` (113 pass)
- [x] `go test ./... -count=1 -race` (4535 pass)
- [x] `make verify-gen` (clean)
- [x] `make gen-zod ZOD_OUT=.tmp/zod-out` — confirmed `versions` block in `_registry.ts` with the three pinned versions

## Review notes

- /review findings (mixed P1 + P2): all addressed
  - SemVer-shape regex guard on `parseExactPin` (was accepting `v5.70.0`, `-5.70.0`, embedded newlines)
  - File-only parsing via `hclparse` + `LoadModuleFromFile` (was loading the whole parent dir via `tfconfig.LoadModule(Dir(path))`)
  - Source-mismatch validation in `extractExactPin` (rejects `aws = { source = "foo/aws" }`)
  - `errors.Is(err, errNotExactPin)` in rejection tests (was substring-only)
  - Block-anchored `versions`-map assertion + single-occurrence guard (was Contains-per-pair)
- qa-professor findings: all addressed (slice-driven subtests, synthetic `extractExactPin` multi-constraint test decoupled from tfconfig aggregation, drift gate split into per-provider subtests, deleted weaker `TestLoadProviderPins_LiveSchemasProvidersTF`)

## Out of scope

- Wiring `awsdiscover` / GCP discoverers to actually consume `generated.AWSProviderVersion` at discover time (Stage 2b — separate ticket).