### PR TITLE
AWS discovery final %: 4 SDKLister types + EC2 SG rule migration

### DIFF
--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -77,9 +77,10 @@ resource "aws_security_group" "this" {
 
   tags = merge(module.name.tags, { Name = "${module.name.prefix}-sg" }, var.tags)
 
-  # ingress is managed entirely by aws_security_group_rule siblings below.
-  # Mixing inline egress + sibling ingress causes the provider to re-read both
-  # aggregates on refresh, which drift-check then flags.
+  # ingress is managed entirely by aws_vpc_security_group_ingress_rule
+  # siblings below. Mixing inline egress + sibling ingress causes the
+  # provider to re-read both aggregates on refresh, which drift-check
+  # then flags.
   lifecycle {
     ignore_changes = [ingress, egress]
   }
@@ -91,27 +92,48 @@ data "aws_ip_ranges" "ec2_instance_connect" {
   services = ["EC2_INSTANCE_CONNECT"]
 }
 
-resource "aws_security_group_rule" "instance_connect_ssh" {
-  count             = var.enable_instance_connect ? 1 : 0
-  type              = "ingress"
+# The legacy aws_security_group_rule resource carries a synthetic
+# `sgrule-<hash>` import ID that CloudFormation can't model. The
+# aws_vpc_security_group_ingress_rule replacement (TF provider v5+)
+# carries the real EC2-API security_group_rule_id (`sgr-XXXXX`) and is
+# CFN/CC-feasible — required for the InsideOut import/discovery pipeline
+# to round-trip these resources. See issue #460.
+#
+# Each replacement rule takes a single cidr_ipv4 (not a list), so the
+# previous one-rule-with-N-CIDRs semantics fan out into N rules via
+# for_each. Aggregate security posture is identical.
+resource "aws_vpc_security_group_ingress_rule" "instance_connect_ssh" {
+  for_each = var.enable_instance_connect ? toset(data.aws_ip_ranges.ec2_instance_connect[0].cidr_blocks) : toset([])
+
+  security_group_id = aws_security_group.this.id
+  ip_protocol       = "tcp"
   from_port         = 22
   to_port           = 22
-  protocol          = "tcp"
-  cidr_blocks       = data.aws_ip_ranges.ec2_instance_connect[0].cidr_blocks
-  security_group_id = aws_security_group.this.id
+  cidr_ipv4         = each.value
   description       = "SSH from EC2 Instance Connect service IPs"
+  tags              = merge(module.name.tags, var.tags)
 }
 
-resource "aws_security_group_rule" "custom_ingress" {
-  for_each = toset([for p in var.custom_ingress_ports : tostring(p)])
+resource "aws_vpc_security_group_ingress_rule" "custom_ingress" {
+  for_each = {
+    for tuple in flatten([
+      for port in var.custom_ingress_ports : [
+        for cidr in var.ingress_cidr_blocks : {
+          key  = "${port}-${cidr}"
+          port = port
+          cidr = cidr
+        }
+      ]
+    ]) : tuple.key => tuple
+  }
 
-  type              = "ingress"
-  from_port         = tonumber(each.value)
-  to_port           = tonumber(each.value)
-  protocol          = "tcp"
-  cidr_blocks       = var.ingress_cidr_blocks
   security_group_id = aws_security_group.this.id
-  description       = "Custom ingress on port ${each.value}"
+  ip_protocol       = "tcp"
+  from_port         = each.value.port
+  to_port           = each.value.port
+  cidr_ipv4         = each.value.cidr
+  description       = "Custom ingress on port ${each.value.port}"
+  tags              = merge(module.name.tags, var.tags)
 }
 
 # -------------------------------------------------------------

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -3400,3 +3400,126 @@ func TestAPIGatewayV2ApiMappingConfig(t *testing.T) {
 		t.Errorf("Tags: got %+v, want empty map", tags)
 	}
 }
+
+// TestVPCSecurityGroupIngressRuleConfig pins per-type extractors for
+// aws_vpc_security_group_ingress_rule (#460): CC default-list,
+// passthrough sgr-XXXXX identifier (Terraform import format matches
+// per provider docs), GroupId stamped under NativeIDs alongside the
+// rule ID, untaggable (CFN schema has no Tags property —
+// SkipProjectTagFilter must be true).
+func TestVPCSecurityGroupIngressRuleConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_vpc_security_group_ingress_rule")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_vpc_security_group_ingress_rule: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.IsGlobal {
+		t.Error("aws_vpc_security_group_ingress_rule: IsGlobal must be false (regional)")
+	}
+	if cfg.CloudFormationType != "AWS::EC2::SecurityGroupIngress" {
+		t.Errorf("CloudFormationType=%q, want AWS::EC2::SecurityGroupIngress", cfg.CloudFormationType)
+	}
+	if cfg.SDKLister != nil {
+		t.Error("SDKLister must be nil (CC ListResources is supported for this type — verified via live list)")
+	}
+	if cfg.ParentLister != nil {
+		t.Error("ParentLister must be nil (top-level, not parent-scoped)")
+	}
+
+	const ruleID = "sgr-0aa94a92e442faa91"
+	if got := cfg.ImportIDFromIdentifier(ruleID, nil); got != ruleID {
+		t.Errorf("ImportID passthrough: got %q, want %q (TF import format is the bare sgr-XXXXX per provider docs)", got, ruleID)
+	}
+	if got := cfg.NameHintFromProperties(ruleID, nil); got != ruleID {
+		t.Errorf("NameHint passthrough: got %q, want %q", got, ruleID)
+	}
+
+	// NativeIDs: rule ID always present; GroupId stamped when the
+	// properties payload carries it (CC GetResource always does).
+	native := cfg.NativeIDsFromProperties(ruleID, map[string]any{"GroupId": "sg-05b33367d0263c42d"})
+	want := map[string]string{
+		"security_group_rule_id": ruleID,
+		"security_group_id":      "sg-05b33367d0263c42d",
+	}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	// Defensive: properties missing GroupId — only the rule ID
+	// surfaces. A future schema change that drops GroupId from the
+	// payload would fail loudly with the wrong-keys assertion below
+	// rather than silently emitting a degraded native map.
+	nativeBare := cfg.NativeIDsFromProperties(ruleID, map[string]any{})
+	if !reflect.DeepEqual(nativeBare, map[string]string{"security_group_rule_id": ruleID}) {
+		t.Errorf("NativeIDs (no GroupId): got %+v, want {security_group_rule_id: %s}", nativeBare, ruleID)
+	}
+
+	// Tags: emptyTagsExtractor returns the non-nil empty map per
+	// #255; populated Tags input is discarded (the CFN schema has no
+	// Tags property, so this defends against a future provider
+	// release injecting one).
+	tags := cfg.TagsFromProperties(map[string]any{"Tags": []any{
+		map[string]any{"Key": "env", "Value": "prod"},
+	}})
+	if tags == nil {
+		t.Fatal("Tags: got nil, want non-nil empty map (#255 contract)")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %+v, want empty map (untaggable; emptyTagsExtractor ignores input)", tags)
+	}
+}
+
+// TestVPCSecurityGroupEgressRuleConfig pins per-type extractors for
+// aws_vpc_security_group_egress_rule (#460): mirror of the ingress
+// rule pin above. Both share the EC2-API sgr-XXXXX identifier shape;
+// CFN models them as distinct types so the discoverer registers them
+// separately.
+func TestVPCSecurityGroupEgressRuleConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_vpc_security_group_egress_rule")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_vpc_security_group_egress_rule: SkipProjectTagFilter must be true (CFN schema has no Tags property)")
+	}
+	if cfg.IsGlobal {
+		t.Error("aws_vpc_security_group_egress_rule: IsGlobal must be false (regional)")
+	}
+	if cfg.CloudFormationType != "AWS::EC2::SecurityGroupEgress" {
+		t.Errorf("CloudFormationType=%q, want AWS::EC2::SecurityGroupEgress", cfg.CloudFormationType)
+	}
+	if cfg.SDKLister != nil {
+		t.Error("SDKLister must be nil (CC ListResources is supported)")
+	}
+	if cfg.ParentLister != nil {
+		t.Error("ParentLister must be nil (top-level)")
+	}
+
+	const ruleID = "sgr-0a56783c0655d17b5"
+	if got := cfg.ImportIDFromIdentifier(ruleID, nil); got != ruleID {
+		t.Errorf("ImportID passthrough: got %q, want %q", got, ruleID)
+	}
+	if got := cfg.NameHintFromProperties(ruleID, nil); got != ruleID {
+		t.Errorf("NameHint passthrough: got %q, want %q", got, ruleID)
+	}
+
+	native := cfg.NativeIDsFromProperties(ruleID, map[string]any{"GroupId": "sg-abc"})
+	want := map[string]string{
+		"security_group_rule_id": ruleID,
+		"security_group_id":      "sg-abc",
+	}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	nativeBare := cfg.NativeIDsFromProperties(ruleID, map[string]any{})
+	if !reflect.DeepEqual(nativeBare, map[string]string{"security_group_rule_id": ruleID}) {
+		t.Errorf("NativeIDs (no GroupId): got %+v, want {security_group_rule_id: %s}", nativeBare, ruleID)
+	}
+
+	tags := cfg.TagsFromProperties(map[string]any{"Tags": []any{
+		map[string]any{"Key": "env", "Value": "prod"},
+	}})
+	if tags == nil {
+		t.Fatal("Tags: got nil, want non-nil empty map (#255 contract)")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %+v, want empty map (untaggable)", tags)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -3096,3 +3096,80 @@ func TestSNSTopicSubscriptionConfig(t *testing.T) {
 		t.Errorf("Tags: got %+v, want empty map", tags)
 	}
 }
+
+// =====================================================================
+// Phase A.2 — IAM RolePolicy extractor pins (#466)
+// =====================================================================
+
+// TestIAMRolePolicyConfig pins aws_iam_role_policy: SDKLister-listed
+// (CC ListResources unsupported), IsGlobal, compound CC identifier
+// `<PolicyName>|<RoleName>` rewritten to TF import `<RoleName>:<PolicyName>`
+// via halve-and-swap, NativeIDs split into policy_name + role_name,
+// untaggable (CFN schema has no Tags property).
+func TestIAMRolePolicyConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_iam_role_policy")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_iam_role_policy: SkipProjectTagFilter must be true (untaggable; CFN schema has no Tags property)")
+	}
+	if !cfg.IsGlobal {
+		t.Error("aws_iam_role_policy: IsGlobal must be true (IAM is a global service)")
+	}
+	if cfg.CloudFormationType != "AWS::IAM::RolePolicy" {
+		t.Errorf("CloudFormationType=%q, want AWS::IAM::RolePolicy", cfg.CloudFormationType)
+	}
+	if cfg.SDKLister == nil {
+		t.Error("SDKLister must be non-nil (CC ListResources unsupported for inline role policies)")
+	}
+	if cfg.ParentLister != nil {
+		t.Error("ParentLister must be nil (SDKLister and ParentLister are mutually exclusive)")
+	}
+
+	// ImportID rewrite: CC `<PolicyName>|<RoleName>` → TF `<RoleName>:<PolicyName>`.
+	const cc = "my-policy|my-role"
+	const tf = "my-role:my-policy"
+	if got := cfg.ImportIDFromIdentifier(cc, nil); got != tf {
+		t.Errorf("ImportID rewrite: got %q, want %q", got, tf)
+	}
+	// Malformed identifier (no `|`): passthrough so a downstream import
+	// surfaces a clear "wrong format" error rather than a silent mis-
+	// import. Matches the iam_service_linked_role fallback shape.
+	if got := cfg.ImportIDFromIdentifier("malformed-no-pipe", nil); got != "malformed-no-pipe" {
+		t.Errorf("ImportID fallback (no pipe): got %q, want %q", got, "malformed-no-pipe")
+	}
+
+	// NameHint: prefer PolicyName from properties; fall back to
+	// identifier verbatim when properties are absent.
+	if got := cfg.NameHintFromProperties(cc, map[string]any{"PolicyName": "my-policy"}); got != "my-policy" {
+		t.Errorf("NameHint from PolicyName: got %q, want %q", got, "my-policy")
+	}
+	if got := cfg.NameHintFromProperties(cc, map[string]any{}); got != cc {
+		t.Errorf("NameHint fallback: got %q, want %q", got, cc)
+	}
+
+	// NativeIDs: split on `|` into policy_name + role_name.
+	native := cfg.NativeIDsFromProperties(cc, nil)
+	want := map[string]string{
+		"policy_name": "my-policy",
+		"role_name":   "my-role",
+	}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	// Malformed identifier: defensive — stamp policy_name only so
+	// downstream readers can spot the drift rather than receive a
+	// half-populated map.
+	nativeBare := cfg.NativeIDsFromProperties("malformed-no-pipe", nil)
+	if !reflect.DeepEqual(nativeBare, map[string]string{"policy_name": "malformed-no-pipe"}) {
+		t.Errorf("NativeIDs (malformed): got %+v, want {policy_name: malformed-no-pipe}", nativeBare)
+	}
+
+	// Untaggable: non-nil empty map (#255 contract).
+	tags := cfg.TagsFromProperties(map[string]any{})
+	if tags == nil {
+		t.Error("Tags: got nil, want non-nil empty map (#255 contract; CFN schema has no Tags)")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %+v, want empty map", tags)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -3317,3 +3317,86 @@ func TestOSSSecurityPolicyConfig(t *testing.T) {
 		t.Errorf("Tags: got %+v, want empty map", tags)
 	}
 }
+
+// =====================================================================
+// Phase A.5 — API Gateway V2 ApiMapping extractor pins (#466)
+// =====================================================================
+
+// TestAPIGatewayV2ApiMappingConfig pins aws_apigatewayv2_api_mapping:
+// SDKLister-listed (CC ListResources unsupported), regional, compound
+// CC identifier `<ApiMappingId>|<DomainName>` rewritten to TF import
+// `<ApiMappingId>/<DomainName>` via single `|`→`/` replace (no swap),
+// NativeIDs split into api_mapping_id + domain_name, untaggable.
+func TestAPIGatewayV2ApiMappingConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_apigatewayv2_api_mapping")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_apigatewayv2_api_mapping: SkipProjectTagFilter must be true (untaggable; CFN schema has no Tags property)")
+	}
+	if cfg.IsGlobal {
+		t.Error("aws_apigatewayv2_api_mapping: IsGlobal must be false (regional)")
+	}
+	if cfg.CloudFormationType != "AWS::ApiGatewayV2::ApiMapping" {
+		t.Errorf("CloudFormationType=%q, want AWS::ApiGatewayV2::ApiMapping", cfg.CloudFormationType)
+	}
+	if cfg.SDKLister == nil {
+		t.Error("SDKLister must be non-nil (CC ListResources unsupported for API mappings)")
+	}
+	if cfg.ParentLister != nil {
+		t.Error("ParentLister must be nil (SDKLister and ParentLister are mutually exclusive)")
+	}
+
+	// ImportID rewrite: CC `<ApiMappingId>|<DomainName>` → TF
+	// `<ApiMappingId>/<DomainName>` (single `|`→`/` replace, no swap).
+	const cc = "1122334|ws-api.example.com"
+	const tf = "1122334/ws-api.example.com"
+	if got := cfg.ImportIDFromIdentifier(cc, nil); got != tf {
+		t.Errorf("ImportID rewrite: got %q, want %q", got, tf)
+	}
+	// First-pipe-only: subsequent `|` in the domain name (unlikely but
+	// defensive) must be preserved.
+	const ccDouble = "1122334|edge|case.example.com"
+	const tfDouble = "1122334/edge|case.example.com"
+	if got := cfg.ImportIDFromIdentifier(ccDouble, nil); got != tfDouble {
+		t.Errorf("ImportID first-pipe-only rewrite: got %q, want %q", got, tfDouble)
+	}
+
+	// NameHint: ApiMappingKey from properties wins.
+	if got := cfg.NameHintFromProperties(cc, map[string]any{"ApiMappingKey": "v1"}); got != "v1" {
+		t.Errorf("NameHint from ApiMappingKey: got %q, want %q", got, "v1")
+	}
+	// Empty ApiMappingKey (root mapping is a valid AWS state) falls
+	// through to the identifier so the UI sees a non-empty label.
+	if got := cfg.NameHintFromProperties(cc, map[string]any{"ApiMappingKey": ""}); got != cc {
+		t.Errorf("NameHint (empty key): got %q, want identifier", got)
+	}
+	// Properties absent: identifier fallback.
+	if got := cfg.NameHintFromProperties(cc, map[string]any{}); got != cc {
+		t.Errorf("NameHint fallback: got %q, want identifier", got)
+	}
+
+	// NativeIDs: split on FIRST `|` into api_mapping_id + domain_name.
+	native := cfg.NativeIDsFromProperties(cc, nil)
+	want := map[string]string{
+		"api_mapping_id": "1122334",
+		"domain_name":    "ws-api.example.com",
+	}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	// Malformed identifier (no `|`): emit only api_mapping_id half so
+	// downstream readers can spot the drift.
+	nativeBare := cfg.NativeIDsFromProperties("malformed-no-pipe", nil)
+	if !reflect.DeepEqual(nativeBare, map[string]string{"api_mapping_id": "malformed-no-pipe"}) {
+		t.Errorf("NativeIDs (malformed): got %+v, want {api_mapping_id: malformed-no-pipe}", nativeBare)
+	}
+
+	// Untaggable.
+	tags := cfg.TagsFromProperties(map[string]any{})
+	if tags == nil {
+		t.Error("Tags: got nil, want non-nil empty map (#255 contract)")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %+v, want empty map", tags)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -3164,13 +3164,21 @@ func TestIAMRolePolicyConfig(t *testing.T) {
 		t.Errorf("NativeIDs (malformed): got %+v, want {policy_name: malformed-no-pipe}", nativeBare)
 	}
 
-	// Untaggable: non-nil empty map (#255 contract).
-	tags := cfg.TagsFromProperties(map[string]any{})
-	if tags == nil {
-		t.Error("Tags: got nil, want non-nil empty map (#255 contract; CFN schema has no Tags)")
-	}
-	if len(tags) != 0 {
-		t.Errorf("Tags: got %+v, want empty map", tags)
+	// Untaggable: non-nil empty map (#255 contract). emptyTagsExtractor
+	// must IGNORE any Tags payload — a regression that fell through to a
+	// real extractor would surface as a non-empty map here.
+	for _, tagsIn := range []map[string]any{
+		{},
+		{"Tags": []any{map[string]any{"Key": "Project", "Value": "io-x"}}},
+		{"Tags": map[string]any{"Project": "io-x"}},
+	} {
+		tags := cfg.TagsFromProperties(tagsIn)
+		if tags == nil {
+			t.Errorf("Tags: got nil, want non-nil empty map (#255 contract; input=%v)", tagsIn)
+		}
+		if len(tags) != 0 {
+			t.Errorf("Tags: got %+v, want empty map (input=%v)", tags, tagsIn)
+		}
 	}
 }
 
@@ -3389,6 +3397,18 @@ func TestAPIGatewayV2ApiMappingConfig(t *testing.T) {
 	nativeBare := cfg.NativeIDsFromProperties("malformed-no-pipe", nil)
 	if !reflect.DeepEqual(nativeBare, map[string]string{"api_mapping_id": "malformed-no-pipe"}) {
 		t.Errorf("NativeIDs (malformed): got %+v, want {api_mapping_id: malformed-no-pipe}", nativeBare)
+	}
+	// NativeIDs must also split on FIRST `|` only — a regression that
+	// switched SplitN(s,"|",2) to Split(s,"|") would over-split and
+	// truncate the domain_name half. Pin the contract symmetrically with
+	// ImportID's double-pipe assertion above.
+	nativeDouble := cfg.NativeIDsFromProperties(ccDouble, nil)
+	wantDouble := map[string]string{
+		"api_mapping_id": "1122334",
+		"domain_name":    "edge|case.example.com",
+	}
+	if !reflect.DeepEqual(nativeDouble, wantDouble) {
+		t.Errorf("NativeIDs first-pipe-only split: got %+v, want %+v", nativeDouble, wantDouble)
 	}
 
 	// Untaggable.

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -3243,3 +3243,77 @@ func TestOSSAccessPolicyConfig(t *testing.T) {
 		t.Errorf("Tags: got %+v, want empty map", tags)
 	}
 }
+
+// =====================================================================
+// Phase A.4 — OpenSearch Serverless SecurityPolicy extractor pins (#466)
+// =====================================================================
+
+// TestOSSSecurityPolicyConfig pins aws_opensearchserverless_security_policy:
+// SDKLister-listed (CC ListResources unsupported), regional, compound CC
+// identifier `<Type>|<Name>` rewritten to TF import `<Name>/<Type>` via
+// halve-and-swap, NativeIDs split into type + name, untaggable.
+func TestOSSSecurityPolicyConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_opensearchserverless_security_policy")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_opensearchserverless_security_policy: SkipProjectTagFilter must be true (untaggable; CFN schema has no Tags property)")
+	}
+	if cfg.IsGlobal {
+		t.Error("aws_opensearchserverless_security_policy: IsGlobal must be false (regional service)")
+	}
+	if cfg.CloudFormationType != "AWS::OpenSearchServerless::SecurityPolicy" {
+		t.Errorf("CloudFormationType=%q, want AWS::OpenSearchServerless::SecurityPolicy", cfg.CloudFormationType)
+	}
+	if cfg.SDKLister == nil {
+		t.Error("SDKLister must be non-nil (CC ListResources unsupported for OSS security policies)")
+	}
+	if cfg.ParentLister != nil {
+		t.Error("ParentLister must be nil (SDKLister and ParentLister are mutually exclusive)")
+	}
+
+	// ImportID rewrite: CC `<Type>|<Name>` → TF `<Name>/<Type>`. Pin
+	// both supported policy types so a future enum addition forces a
+	// per-type review.
+	for _, tc := range []struct {
+		cc, tf string
+	}{
+		{"encryption|enc-1", "enc-1/encryption"},
+		{"network|net-1", "net-1/network"},
+	} {
+		if got := cfg.ImportIDFromIdentifier(tc.cc, nil); got != tc.tf {
+			t.Errorf("ImportID rewrite for %q: got %q, want %q", tc.cc, got, tc.tf)
+		}
+	}
+	// Malformed: passthrough.
+	if got := cfg.ImportIDFromIdentifier("malformed-no-pipe", nil); got != "malformed-no-pipe" {
+		t.Errorf("ImportID fallback (no pipe): got %q, want %q", got, "malformed-no-pipe")
+	}
+
+	// NameHint: prefer Name from properties.
+	if got := cfg.NameHintFromProperties("encryption|enc-1", map[string]any{"Name": "enc-1"}); got != "enc-1" {
+		t.Errorf("NameHint from Name: got %q, want %q", got, "enc-1")
+	}
+	if got := cfg.NameHintFromProperties("encryption|enc-1", map[string]any{}); got != "encryption|enc-1" {
+		t.Errorf("NameHint fallback: got %q, want identifier", got)
+	}
+
+	// NativeIDs: split into type + name.
+	native := cfg.NativeIDsFromProperties("network|net-1", nil)
+	want := map[string]string{"type": "network", "name": "net-1"}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	nativeBare := cfg.NativeIDsFromProperties("malformed-no-pipe", nil)
+	if !reflect.DeepEqual(nativeBare, map[string]string{"name": "malformed-no-pipe"}) {
+		t.Errorf("NativeIDs (malformed): got %+v, want {name: malformed-no-pipe}", nativeBare)
+	}
+
+	// Untaggable.
+	tags := cfg.TagsFromProperties(map[string]any{})
+	if tags == nil {
+		t.Error("Tags: got nil, want non-nil empty map (#255 contract)")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %+v, want empty map", tags)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -3173,3 +3173,73 @@ func TestIAMRolePolicyConfig(t *testing.T) {
 		t.Errorf("Tags: got %+v, want empty map", tags)
 	}
 }
+
+// =====================================================================
+// Phase A.3 — OpenSearch Serverless AccessPolicy extractor pins (#466)
+// =====================================================================
+
+// TestOSSAccessPolicyConfig pins aws_opensearchserverless_access_policy:
+// SDKLister-listed (CC ListResources unsupported), regional, compound
+// CC identifier `<Type>|<Name>` rewritten to TF import `<Name>/<Type>`
+// via halve-and-swap, NativeIDs split into type + name, untaggable
+// (CFN schema has no Tags property).
+func TestOSSAccessPolicyConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_opensearchserverless_access_policy")
+	if !cfg.SkipProjectTagFilter {
+		t.Error("aws_opensearchserverless_access_policy: SkipProjectTagFilter must be true (untaggable; CFN schema has no Tags property)")
+	}
+	if cfg.IsGlobal {
+		t.Error("aws_opensearchserverless_access_policy: IsGlobal must be false (regional service)")
+	}
+	if cfg.CloudFormationType != "AWS::OpenSearchServerless::AccessPolicy" {
+		t.Errorf("CloudFormationType=%q, want AWS::OpenSearchServerless::AccessPolicy", cfg.CloudFormationType)
+	}
+	if cfg.SDKLister == nil {
+		t.Error("SDKLister must be non-nil (CC ListResources unsupported for OSS access policies)")
+	}
+	if cfg.ParentLister != nil {
+		t.Error("ParentLister must be nil (SDKLister and ParentLister are mutually exclusive)")
+	}
+
+	// ImportID rewrite: CC `<Type>|<Name>` → TF `<Name>/<Type>`.
+	const cc = "data|my-policy"
+	const tf = "my-policy/data"
+	if got := cfg.ImportIDFromIdentifier(cc, nil); got != tf {
+		t.Errorf("ImportID rewrite: got %q, want %q", got, tf)
+	}
+	// Malformed: passthrough so downstream surfaces a clear error.
+	if got := cfg.ImportIDFromIdentifier("malformed-no-pipe", nil); got != "malformed-no-pipe" {
+		t.Errorf("ImportID fallback (no pipe): got %q, want %q", got, "malformed-no-pipe")
+	}
+
+	// NameHint: prefer Name from properties; fall back to identifier.
+	if got := cfg.NameHintFromProperties(cc, map[string]any{"Name": "my-policy"}); got != "my-policy" {
+		t.Errorf("NameHint from Name: got %q, want %q", got, "my-policy")
+	}
+	if got := cfg.NameHintFromProperties(cc, map[string]any{}); got != cc {
+		t.Errorf("NameHint fallback: got %q, want %q", got, cc)
+	}
+
+	// NativeIDs: split on `|` into type + name.
+	native := cfg.NativeIDsFromProperties(cc, nil)
+	want := map[string]string{"type": "data", "name": "my-policy"}
+	if !reflect.DeepEqual(native, want) {
+		t.Errorf("NativeIDs: got %+v, want %+v", native, want)
+	}
+	// Malformed: defensive — stamp name only so downstream readers see
+	// the half-populated map and can spot the drift.
+	nativeBare := cfg.NativeIDsFromProperties("malformed-no-pipe", nil)
+	if !reflect.DeepEqual(nativeBare, map[string]string{"name": "malformed-no-pipe"}) {
+		t.Errorf("NativeIDs (malformed): got %+v, want {name: malformed-no-pipe}", nativeBare)
+	}
+
+	// Untaggable: non-nil empty map.
+	tags := cfg.TagsFromProperties(map[string]any{})
+	if tags == nil {
+		t.Error("Tags: got nil, want non-nil empty map (#255 contract; CFN schema has no Tags)")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags: got %+v, want empty map", tags)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
@@ -1125,3 +1125,116 @@ func listIAMServiceLinkedRoleServiceNamesWithClient(ctx context.Context, client 
 	return names, nil
 }
 
+// =====================================================================
+// Phase A.2 — IAM RolePolicy SDKLister (#466)
+// =====================================================================
+
+// iamRolePoliciesLister is the narrow subset of the IAM SDK used by the
+// aws_iam_role_policy SDKLister. ListRoles enumerates the outer set;
+// ListRolePolicies enumerates the inner set (inline policies per role).
+// We keep the interface narrow on purpose so test fakes do not need to
+// implement the entire IAM client surface.
+type iamRolePoliciesLister interface {
+	ListRoles(ctx context.Context, in *iam.ListRolesInput, opts ...func(*iam.Options)) (*iam.ListRolesOutput, error)
+	ListRolePolicies(ctx context.Context, in *iam.ListRolePoliciesInput, opts ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error)
+}
+
+// listIAMRolePolicyIdentifiers enumerates IAM inline role policies
+// (global) and emits the CC compound primary identifier for each. Used
+// as the SDKLister for AWS::IAM::RolePolicy (#466) — CC ListResources
+// returns UnsupportedActionException for the type because inline
+// policies live under a parent role rather than as top-level IAM
+// resources.
+//
+// AWS::IAM::RolePolicy's CC primaryIdentifier is
+// [/properties/PolicyName, /properties/RoleName] (verified against the
+// public CFN schema:
+//
+//	https://schema.cloudformation.us-east-1.amazonaws.com/aws-iam-rolepolicy.json
+//
+// `primaryIdentifier: [/properties/PolicyName, /properties/RoleName]`).
+// The framework joins compound identifiers with `|` in the order
+// declared by the schema, so emitted identifiers are
+// "<PolicyName>|<RoleName>". The TF import rewrite (in
+// cloudcontrol_types.go) swaps the parts and joins them with `:` —
+// terraform-provider-aws v6.x docs:
+// "<role_name>:<role_policy_name>".
+//
+// We walk iam:ListRoles paginated → for each role, iam:ListRolePolicies
+// paginated. A single role can have many inline policies; the outer
+// loop is the parent enumerator and the inner loop is the per-role
+// fan-out. Service-linked roles (Path == "/aws-service-role/...") are
+// filtered out because they cannot hold inline policies (IAM rejects
+// PutRolePolicy on them), so issuing ListRolePolicies for them would
+// burn API budget on a guaranteed-empty result.
+//
+// Returns a non-nil empty slice on accounts with zero inline role
+// policies (#255 contract).
+func listIAMRolePolicyIdentifiers(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := iam.NewFromConfig(awsCfg, func(o *iam.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+	return listIAMRolePolicyIdentifiersWithClient(ctx, client)
+}
+
+func listIAMRolePolicyIdentifiersWithClient(ctx context.Context, client iamRolePoliciesLister) ([]string, error) {
+	ids := []string{}
+	seen := map[string]bool{}
+
+	// Outer loop: enumerate all IAM roles (paginated).
+	var roleMarker *string
+	for {
+		rolesPage, err := client.ListRoles(ctx, &iam.ListRolesInput{Marker: roleMarker})
+		if err != nil {
+			return nil, fmt.Errorf("iam:ListRoles: %w", err)
+		}
+		for _, r := range rolesPage.Roles {
+			roleName := aws.ToString(r.RoleName)
+			if roleName == "" {
+				continue
+			}
+			// Skip service-linked roles — they cannot hold inline policies
+			// (IAM rejects PutRolePolicy on /aws-service-role/ roles), so
+			// the per-role ListRolePolicies would always return zero.
+			if strings.HasPrefix(aws.ToString(r.Path), iamServiceRolePathPrefix) {
+				continue
+			}
+
+			// Inner loop: enumerate inline policies for this role.
+			var polMarker *string
+			for {
+				polPage, err := client.ListRolePolicies(ctx, &iam.ListRolePoliciesInput{
+					RoleName: aws.String(roleName),
+					Marker:   polMarker,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("iam:ListRolePolicies(role=%q): %w", roleName, err)
+				}
+				for _, policyName := range polPage.PolicyNames {
+					if policyName == "" {
+						continue
+					}
+					// CC compound identifier order matches the schema's
+					// primaryIdentifier declaration: PolicyName first.
+					id := policyName + "|" + roleName
+					if seen[id] {
+						continue
+					}
+					seen[id] = true
+					ids = append(ids, id)
+				}
+				if !polPage.IsTruncated || polPage.Marker == nil || aws.ToString(polPage.Marker) == "" {
+					break
+				}
+				polMarker = polPage.Marker
+			}
+		}
+		if !rolesPage.IsTruncated || rolesPage.Marker == nil || aws.ToString(rolesPage.Marker) == "" {
+			break
+		}
+		roleMarker = rolesPage.Marker
+	}
+	return ids, nil
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
@@ -1337,6 +1337,110 @@ func listOSSAccessPolicyIdentifiersWithClient(ctx context.Context, client ossAcc
 }
 
 // =====================================================================
+// Phase A.5 — API Gateway V2 ApiMapping SDKLister (#466)
+// =====================================================================
+
+// apigatewayv2DomainAndMappingsLister is the narrow subset of the API
+// Gateway v2 SDK used by the aws_apigatewayv2_api_mapping SDKLister.
+// GetDomainNames enumerates the outer set (custom domain names);
+// GetApiMappings enumerates the inner set (mappings under each domain).
+// Keeping the interface separate from apigatewayv2APIsLister
+// (route/integration parent enumerator) lets each call site evolve
+// independently.
+type apigatewayv2DomainAndMappingsLister interface {
+	GetDomainNames(ctx context.Context, in *apigatewayv2.GetDomainNamesInput, opts ...func(*apigatewayv2.Options)) (*apigatewayv2.GetDomainNamesOutput, error)
+	GetApiMappings(ctx context.Context, in *apigatewayv2.GetApiMappingsInput, opts ...func(*apigatewayv2.Options)) (*apigatewayv2.GetApiMappingsOutput, error)
+}
+
+// listAPIGatewayV2ApiMappingIdentifiers enumerates API Gateway V2 API
+// mappings (region-scoped) and emits the CC compound primary
+// identifier for each. Used as the SDKLister for
+// AWS::ApiGatewayV2::ApiMapping (#466) — CC ListResources returns
+// UnsupportedActionException for the type (no LIST handler), but CC
+// GetResource works on the compound primary identifier
+// [ApiMappingId, DomainName] per the public CFN schema:
+//
+//	https://schema.cloudformation.us-east-1.amazonaws.com/aws-apigatewayv2-apimapping.json
+//
+// `primaryIdentifier: [/properties/ApiMappingId, /properties/DomainName]`.
+//
+// Outer loop: apigatewayv2:GetDomainNames paginated (NextToken). For
+// each domain, the inner apigatewayv2:GetApiMappings call (which
+// requires DomainName as input) enumerates the mappings under that
+// domain, also paginated.
+//
+// Emits "<ApiMappingId>|<DomainName>" — framework joins compound
+// primary-identifier parts with `|` in schema-declared order.
+//
+// Terraform's import format is `<api_mapping_id>/<domain_name>`
+// (verified against terraform-provider-aws main
+// website/docs/r/apigatewayv2_api_mapping.html.markdown — Import
+// section). Because the CC `|` separator already has the parts in the
+// right order, the rewrite is a single `|` → `/` replace — no swap.
+//
+// Returns a non-nil empty slice on regions with zero API mappings
+// (#255 contract).
+func listAPIGatewayV2ApiMappingIdentifiers(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := apigatewayv2.NewFromConfig(awsCfg, func(o *apigatewayv2.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+	return listAPIGatewayV2ApiMappingIdentifiersWithClient(ctx, client)
+}
+
+func listAPIGatewayV2ApiMappingIdentifiersWithClient(ctx context.Context, client apigatewayv2DomainAndMappingsLister) ([]string, error) {
+	ids := []string{}
+	seen := map[string]bool{}
+
+	var domainToken *string
+	for {
+		domains, err := client.GetDomainNames(ctx, &apigatewayv2.GetDomainNamesInput{NextToken: domainToken})
+		if err != nil {
+			return nil, fmt.Errorf("apigatewayv2:GetDomainNames: %w", err)
+		}
+		for _, d := range domains.Items {
+			domainName := aws.ToString(d.DomainName)
+			if domainName == "" {
+				continue
+			}
+
+			var mappingToken *string
+			for {
+				mappings, err := client.GetApiMappings(ctx, &apigatewayv2.GetApiMappingsInput{
+					DomainName: aws.String(domainName),
+					NextToken:  mappingToken,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("apigatewayv2:GetApiMappings(domain=%q): %w", domainName, err)
+				}
+				for _, m := range mappings.Items {
+					mappingID := aws.ToString(m.ApiMappingId)
+					if mappingID == "" {
+						continue
+					}
+					id := mappingID + "|" + domainName
+					if seen[id] {
+						continue
+					}
+					seen[id] = true
+					ids = append(ids, id)
+				}
+				if mappings.NextToken == nil || aws.ToString(mappings.NextToken) == "" {
+					break
+				}
+				mappingToken = mappings.NextToken
+			}
+		}
+		if domains.NextToken == nil || aws.ToString(domains.NextToken) == "" {
+			break
+		}
+		domainToken = domains.NextToken
+	}
+	return ids, nil
+}
+
+// =====================================================================
 // Phase A.4 — OpenSearch Serverless SecurityPolicy SDKLister (#466)
 // =====================================================================
 

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
@@ -1335,3 +1335,96 @@ func listOSSAccessPolicyIdentifiersWithClient(ctx context.Context, client ossAcc
 	}
 	return ids, nil
 }
+
+// =====================================================================
+// Phase A.4 — OpenSearch Serverless SecurityPolicy SDKLister (#466)
+// =====================================================================
+
+// ossSecurityPoliciesLister is the narrow subset of the OpenSearch
+// Serverless SDK used by the aws_opensearchserverless_security_policy
+// SDKLister. Keeping it separate from ossAccessPoliciesLister means
+// each call site can evolve independently and test fakes stay focused.
+type ossSecurityPoliciesLister interface {
+	ListSecurityPolicies(ctx context.Context, in *opensearchserverless.ListSecurityPoliciesInput, opts ...func(*opensearchserverless.Options)) (*opensearchserverless.ListSecurityPoliciesOutput, error)
+}
+
+// ossSecurityPolicyTypes enumerates the SecurityPolicyType enum values
+// the OSS service accepts on ListSecurityPolicies. Both "encryption"
+// and "network" are valid (the two security-policy shapes OSS exposes).
+// We call ListSecurityPolicies once per type and concatenate.
+var ossSecurityPolicyTypes = []ossstypes.SecurityPolicyType{
+	ossstypes.SecurityPolicyTypeEncryption,
+	ossstypes.SecurityPolicyTypeNetwork,
+}
+
+// listOSSSecurityPolicyIdentifiers enumerates OpenSearch Serverless
+// security policies (region-scoped) and emits the CC compound primary
+// identifier for each. Used as the SDKLister for
+// AWS::OpenSearchServerless::SecurityPolicy (#466) — CC ListResources
+// returns UnsupportedActionException; CC GetResource is supported on
+// the compound primary identifier [Type, Name] per the public CFN
+// schema:
+//
+//	https://schema.cloudformation.us-east-1.amazonaws.com/aws-opensearchserverless-securitypolicy.json
+//
+// `primaryIdentifier: [/properties/Type, /properties/Name]`.
+//
+// Emits "<Type>|<Name>" — the framework joins compound identifier
+// parts with `|` in schema-declared order. ListSecurityPolicies
+// requires a Type filter (it's a required input), so we walk the
+// known type set and concatenate.
+//
+// Terraform's import format is `<name>/<type>` (verified against
+// terraform-provider-aws main website/docs/r/
+// opensearchserverless_security_policy.html.markdown — Import section).
+// The rewrite (in cloudcontrol_types.go) swaps halves and joins with
+// `/`.
+//
+// Returns a non-nil empty slice on accounts with zero security
+// policies (#255 contract).
+func listOSSSecurityPolicyIdentifiers(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := opensearchserverless.NewFromConfig(awsCfg, func(o *opensearchserverless.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+	return listOSSSecurityPolicyIdentifiersWithClient(ctx, client, ossSecurityPolicyTypes)
+}
+
+func listOSSSecurityPolicyIdentifiersWithClient(ctx context.Context, client ossSecurityPoliciesLister, types []ossstypes.SecurityPolicyType) ([]string, error) {
+	ids := []string{}
+	seen := map[string]bool{}
+	for _, t := range types {
+		var nextToken *string
+		for {
+			page, err := client.ListSecurityPolicies(ctx, &opensearchserverless.ListSecurityPoliciesInput{
+				Type:      t,
+				NextToken: nextToken,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("aoss:ListSecurityPolicies(type=%q): %w", string(t), err)
+			}
+			for _, p := range page.SecurityPolicySummaries {
+				name := aws.ToString(p.Name)
+				if name == "" {
+					continue
+				}
+				policyType := string(p.Type)
+				if policyType == "" {
+					policyType = string(t)
+				}
+				id := policyType + "|" + name
+				if seen[id] {
+					continue
+				}
+				seen[id] = true
+				ids = append(ids, id)
+			}
+			if page.NextToken == nil || aws.ToString(page.NextToken) == "" {
+				break
+			}
+			nextToken = page.NextToken
+		}
+	}
+	return ids, nil
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
@@ -20,6 +20,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/opensearch"
+	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
+	ossstypes "github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 )
 
@@ -1235,6 +1237,101 @@ func listIAMRolePolicyIdentifiersWithClient(ctx context.Context, client iamRoleP
 			break
 		}
 		roleMarker = rolesPage.Marker
+	}
+	return ids, nil
+}
+
+// =====================================================================
+// Phase A.3 — OpenSearch Serverless AccessPolicy SDKLister (#466)
+// =====================================================================
+
+// ossAccessPoliciesLister is the narrow subset of the OpenSearch
+// Serverless SDK used by the aws_opensearchserverless_access_policy
+// SDKLister. The interface is package-private so test fakes don't need
+// to implement the full client surface.
+type ossAccessPoliciesLister interface {
+	ListAccessPolicies(ctx context.Context, in *opensearchserverless.ListAccessPoliciesInput, opts ...func(*opensearchserverless.Options)) (*opensearchserverless.ListAccessPoliciesOutput, error)
+}
+
+// ossAccessPolicyTypes enumerates the AccessPolicyType enum values the
+// OSS service accepts on ListAccessPolicies. As of SDK v1.30.3 the only
+// type is "data". Listed explicitly so future enum additions (when AWS
+// adds a new access-policy kind) surface as a one-line entry.
+var ossAccessPolicyTypes = []ossstypes.AccessPolicyType{
+	ossstypes.AccessPolicyTypeData,
+}
+
+// listOSSAccessPolicyIdentifiers enumerates OpenSearch Serverless data-
+// access policies (region-scoped) and emits the CC compound primary
+// identifier for each. Used as the SDKLister for
+// AWS::OpenSearchServerless::AccessPolicy (#466) — CC ListResources
+// returns UnsupportedActionException for the type (CC has no LIST
+// handler), but CC GetResource is supported and keyed on the compound
+// primary identifier [Type, Name] per the public CFN schema:
+//
+//	https://schema.cloudformation.us-east-1.amazonaws.com/aws-opensearchserverless-accesspolicy.json
+//
+// `primaryIdentifier: [/properties/Type, /properties/Name]`.
+//
+// Emits "<Type>|<Name>" — the framework joins compound identifier
+// parts with `|` in schema-declared order. ListAccessPolicies requires
+// the Type filter (it's a required input parameter), so we walk the
+// known type set and concatenate results.
+//
+// Terraform's import format is `<name>/<type>` (verified against
+// terraform-provider-aws main website/docs/r/
+// opensearchserverless_access_policy.html.markdown — Import section).
+// The rewrite (in cloudcontrol_types.go) swaps halves and joins with
+// `/`.
+//
+// Returns a non-nil empty slice on accounts with zero access policies
+// (#255 contract).
+func listOSSAccessPolicyIdentifiers(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := opensearchserverless.NewFromConfig(awsCfg, func(o *opensearchserverless.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+	return listOSSAccessPolicyIdentifiersWithClient(ctx, client, ossAccessPolicyTypes)
+}
+
+func listOSSAccessPolicyIdentifiersWithClient(ctx context.Context, client ossAccessPoliciesLister, types []ossstypes.AccessPolicyType) ([]string, error) {
+	ids := []string{}
+	seen := map[string]bool{}
+	for _, t := range types {
+		var nextToken *string
+		for {
+			page, err := client.ListAccessPolicies(ctx, &opensearchserverless.ListAccessPoliciesInput{
+				Type:      t,
+				NextToken: nextToken,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("aoss:ListAccessPolicies(type=%q): %w", string(t), err)
+			}
+			for _, p := range page.AccessPolicySummaries {
+				name := aws.ToString(p.Name)
+				if name == "" {
+					continue
+				}
+				policyType := string(p.Type)
+				if policyType == "" {
+					// Defensive: fall back to the requested type when
+					// the SDK summary omits Type (shouldn't happen, but
+					// the field is a *string in the API surface).
+					policyType = string(t)
+				}
+				id := policyType + "|" + name
+				if seen[id] {
+					continue
+				}
+				seen[id] = true
+				ids = append(ids, id)
+			}
+			if page.NextToken == nil || aws.ToString(page.NextToken) == "" {
+				break
+			}
+			nextToken = page.NextToken
+		}
 	}
 	return ids, nil
 }

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
@@ -36,6 +36,8 @@ import (
 	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/aws/aws-sdk-go-v2/service/opensearch"
 	opensearchtypes "github.com/aws/aws-sdk-go-v2/service/opensearch/types"
+	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
+	ossstypes "github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 )
@@ -2825,5 +2827,191 @@ func TestListIAMRolePolicyIdentifiers_PropagatesListRolePoliciesError(t *testing
 	_, err := listIAMRolePolicyIdentifiersWithClient(context.Background(), fake)
 	if !errors.Is(err, sentinel) {
 		t.Errorf("err does not wrap sentinel; got %v", err)
+	}
+}
+
+// =====================================================================
+// Phase A.3 — OpenSearch Serverless AccessPolicy SDKLister (#466)
+// =====================================================================
+
+// fakeOSSAccessPoliciesLister drives ossAccessPoliciesLister against a
+// scripted (Type → page-sequence) map. Records the input Type and
+// NextToken on each call so tests can pin pagination semantics.
+type fakeOSSAccessPoliciesLister struct {
+	pagesByType    map[ossstypes.AccessPolicyType][]opensearchserverless.ListAccessPoliciesOutput
+	callsByType    map[ossstypes.AccessPolicyType]int
+	errByType      map[ossstypes.AccessPolicyType]error
+	tokenByCall    map[ossstypes.AccessPolicyType][]*string // observed NextToken inputs, in call order
+	typesRequested []ossstypes.AccessPolicyType
+}
+
+func (f *fakeOSSAccessPoliciesLister) ListAccessPolicies(_ context.Context, in *opensearchserverless.ListAccessPoliciesInput, _ ...func(*opensearchserverless.Options)) (*opensearchserverless.ListAccessPoliciesOutput, error) {
+	if f.tokenByCall == nil {
+		f.tokenByCall = map[ossstypes.AccessPolicyType][]*string{}
+	}
+	f.tokenByCall[in.Type] = append(f.tokenByCall[in.Type], in.NextToken)
+	f.typesRequested = append(f.typesRequested, in.Type)
+	if err, ok := f.errByType[in.Type]; ok && err != nil {
+		return nil, err
+	}
+	if f.callsByType == nil {
+		f.callsByType = map[ossstypes.AccessPolicyType]int{}
+	}
+	pages := f.pagesByType[in.Type]
+	idx := f.callsByType[in.Type]
+	if idx >= len(pages) {
+		return &opensearchserverless.ListAccessPoliciesOutput{}, nil
+	}
+	page := pages[idx]
+	f.callsByType[in.Type] = idx + 1
+	return &page, nil
+}
+
+// ossAccessPolicySummary is a tiny constructor for the AccessPolicySummary
+// type so tests don't repeat the &aws.String boilerplate.
+func ossAccessPolicySummary(name string, t ossstypes.AccessPolicyType) ossstypes.AccessPolicySummary {
+	return ossstypes.AccessPolicySummary{Name: aws.String(name), Type: t}
+}
+
+// ossAccessPolicyPage builds a single ListAccessPoliciesOutput page.
+// Pass `nextToken` to mark the page as truncated.
+func ossAccessPolicyPage(nextToken string, summaries ...ossstypes.AccessPolicySummary) opensearchserverless.ListAccessPoliciesOutput {
+	out := opensearchserverless.ListAccessPoliciesOutput{AccessPolicySummaries: summaries}
+	if nextToken != "" {
+		out.NextToken = aws.String(nextToken)
+	}
+	return out
+}
+
+// TestListOSSAccessPolicyIdentifiers_HappyPath_EmitsTypePipeName pins
+// the canonical shape: two access policies → two "<Type>|<Name>"
+// identifiers in API result order.
+func TestListOSSAccessPolicyIdentifiers_HappyPath_EmitsTypePipeName(t *testing.T) {
+	t.Parallel()
+	fake := &fakeOSSAccessPoliciesLister{
+		pagesByType: map[ossstypes.AccessPolicyType][]opensearchserverless.ListAccessPoliciesOutput{
+			ossstypes.AccessPolicyTypeData: {
+				ossAccessPolicyPage("",
+					ossAccessPolicySummary("policy-a", ossstypes.AccessPolicyTypeData),
+					ossAccessPolicySummary("policy-b", ossstypes.AccessPolicyTypeData),
+				),
+			},
+		},
+	}
+	got, err := listOSSAccessPolicyIdentifiersWithClient(context.Background(), fake,
+		[]ossstypes.AccessPolicyType{ossstypes.AccessPolicyTypeData})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"data|policy-a", "data|policy-b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
+	}
+}
+
+// TestListOSSAccessPolicyIdentifiers_PropagatesPagination pins the
+// nextToken contract: the token returned on page N must surface as
+// NextToken on page N+1, exactly once.
+func TestListOSSAccessPolicyIdentifiers_PropagatesPagination(t *testing.T) {
+	t.Parallel()
+	fake := &fakeOSSAccessPoliciesLister{
+		pagesByType: map[ossstypes.AccessPolicyType][]opensearchserverless.ListAccessPoliciesOutput{
+			ossstypes.AccessPolicyTypeData: {
+				ossAccessPolicyPage("CURSOR-1",
+					ossAccessPolicySummary("p1", ossstypes.AccessPolicyTypeData),
+				),
+				ossAccessPolicyPage("",
+					ossAccessPolicySummary("p2", ossstypes.AccessPolicyTypeData),
+				),
+			},
+		},
+	}
+	got, err := listOSSAccessPolicyIdentifiersWithClient(context.Background(), fake,
+		[]ossstypes.AccessPolicyType{ossstypes.AccessPolicyTypeData})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"data|p1", "data|p2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
+	}
+	tokens := fake.tokenByCall[ossstypes.AccessPolicyTypeData]
+	if len(tokens) != 2 {
+		t.Fatalf("expected 2 ListAccessPolicies calls; got %d tokens=%v", len(tokens), tokens)
+	}
+	if tokens[0] != nil {
+		t.Errorf("first call should have nil NextToken; got %v", aws.ToString(tokens[0]))
+	}
+	if aws.ToString(tokens[1]) != "CURSOR-1" {
+		t.Errorf("second call should carry forward the cursor; got %q want %q",
+			aws.ToString(tokens[1]), "CURSOR-1")
+	}
+}
+
+// TestListOSSAccessPolicyIdentifiers_EmptyAccountReturnsNonNilEmpty
+// guards the #255 contract.
+func TestListOSSAccessPolicyIdentifiers_EmptyAccountReturnsNonNilEmpty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeOSSAccessPoliciesLister{
+		pagesByType: map[ossstypes.AccessPolicyType][]opensearchserverless.ListAccessPoliciesOutput{
+			ossstypes.AccessPolicyTypeData: {ossAccessPolicyPage("")},
+		},
+	}
+	got, err := listOSSAccessPolicyIdentifiersWithClient(context.Background(), fake,
+		[]ossstypes.AccessPolicyType{ossstypes.AccessPolicyTypeData})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil, want non-nil empty slice (#255 contract)")
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty slice", got)
+	}
+}
+
+// TestListOSSAccessPolicyIdentifiers_PropagatesListError pins the
+// error wrap chain.
+func TestListOSSAccessPolicyIdentifiers_PropagatesListError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("AccessDenied: aoss:ListAccessPolicies")
+	fake := &fakeOSSAccessPoliciesLister{
+		errByType: map[ossstypes.AccessPolicyType]error{
+			ossstypes.AccessPolicyTypeData: sentinel,
+		},
+	}
+	_, err := listOSSAccessPolicyIdentifiersWithClient(context.Background(), fake,
+		[]ossstypes.AccessPolicyType{ossstypes.AccessPolicyTypeData})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err does not wrap sentinel; got %v", err)
+	}
+}
+
+// TestListOSSAccessPolicyIdentifiers_DefensiveTypeFallback pins the
+// SDK-safety belt: if a SummaryType is empty (shouldn't happen, but
+// the API field is an enum that could in theory be zero-valued), fall
+// back to the requested Type so the identifier always has both halves.
+func TestListOSSAccessPolicyIdentifiers_DefensiveTypeFallback(t *testing.T) {
+	t.Parallel()
+	fake := &fakeOSSAccessPoliciesLister{
+		pagesByType: map[ossstypes.AccessPolicyType][]opensearchserverless.ListAccessPoliciesOutput{
+			ossstypes.AccessPolicyTypeData: {
+				ossAccessPolicyPage("",
+					// Empty Type — the lister must fill it from the
+					// requested AccessPolicyType so the emitted ID has
+					// both halves.
+					ossstypes.AccessPolicySummary{Name: aws.String("orphan")},
+				),
+			},
+		},
+	}
+	got, err := listOSSAccessPolicyIdentifiersWithClient(context.Background(), fake,
+		[]ossstypes.AccessPolicyType{ossstypes.AccessPolicyTypeData})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"data|orphan"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
 	}
 }

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
@@ -3015,3 +3015,171 @@ func TestListOSSAccessPolicyIdentifiers_DefensiveTypeFallback(t *testing.T) {
 		t.Errorf("identifiers drift: got %v want %v", got, want)
 	}
 }
+
+// =====================================================================
+// Phase A.4 — OpenSearch Serverless SecurityPolicy SDKLister (#466)
+// =====================================================================
+
+// fakeOSSSecurityPoliciesLister drives ossSecurityPoliciesLister against
+// a scripted (Type → page-sequence) map. Records the input Type and
+// NextToken on each call so tests can pin pagination semantics.
+type fakeOSSSecurityPoliciesLister struct {
+	pagesByType    map[ossstypes.SecurityPolicyType][]opensearchserverless.ListSecurityPoliciesOutput
+	callsByType    map[ossstypes.SecurityPolicyType]int
+	errByType      map[ossstypes.SecurityPolicyType]error
+	tokenByCall    map[ossstypes.SecurityPolicyType][]*string
+	typesRequested []ossstypes.SecurityPolicyType
+}
+
+func (f *fakeOSSSecurityPoliciesLister) ListSecurityPolicies(_ context.Context, in *opensearchserverless.ListSecurityPoliciesInput, _ ...func(*opensearchserverless.Options)) (*opensearchserverless.ListSecurityPoliciesOutput, error) {
+	if f.tokenByCall == nil {
+		f.tokenByCall = map[ossstypes.SecurityPolicyType][]*string{}
+	}
+	f.tokenByCall[in.Type] = append(f.tokenByCall[in.Type], in.NextToken)
+	f.typesRequested = append(f.typesRequested, in.Type)
+	if err, ok := f.errByType[in.Type]; ok && err != nil {
+		return nil, err
+	}
+	if f.callsByType == nil {
+		f.callsByType = map[ossstypes.SecurityPolicyType]int{}
+	}
+	pages := f.pagesByType[in.Type]
+	idx := f.callsByType[in.Type]
+	if idx >= len(pages) {
+		return &opensearchserverless.ListSecurityPoliciesOutput{}, nil
+	}
+	page := pages[idx]
+	f.callsByType[in.Type] = idx + 1
+	return &page, nil
+}
+
+func ossSecurityPolicySummary(name string, t ossstypes.SecurityPolicyType) ossstypes.SecurityPolicySummary {
+	return ossstypes.SecurityPolicySummary{Name: aws.String(name), Type: t}
+}
+
+func ossSecurityPolicyPage(nextToken string, summaries ...ossstypes.SecurityPolicySummary) opensearchserverless.ListSecurityPoliciesOutput {
+	out := opensearchserverless.ListSecurityPoliciesOutput{SecurityPolicySummaries: summaries}
+	if nextToken != "" {
+		out.NextToken = aws.String(nextToken)
+	}
+	return out
+}
+
+// TestListOSSSecurityPolicyIdentifiers_HappyPath_BothTypesConcatenated
+// pins the canonical shape: encryption + network policies are
+// concatenated in the order ossSecurityPolicyTypes declares.
+func TestListOSSSecurityPolicyIdentifiers_HappyPath_BothTypesConcatenated(t *testing.T) {
+	t.Parallel()
+	fake := &fakeOSSSecurityPoliciesLister{
+		pagesByType: map[ossstypes.SecurityPolicyType][]opensearchserverless.ListSecurityPoliciesOutput{
+			ossstypes.SecurityPolicyTypeEncryption: {
+				ossSecurityPolicyPage("",
+					ossSecurityPolicySummary("enc-a", ossstypes.SecurityPolicyTypeEncryption),
+				),
+			},
+			ossstypes.SecurityPolicyTypeNetwork: {
+				ossSecurityPolicyPage("",
+					ossSecurityPolicySummary("net-a", ossstypes.SecurityPolicyTypeNetwork),
+					ossSecurityPolicySummary("net-b", ossstypes.SecurityPolicyTypeNetwork),
+				),
+			},
+		},
+	}
+	got, err := listOSSSecurityPolicyIdentifiersWithClient(context.Background(), fake,
+		[]ossstypes.SecurityPolicyType{
+			ossstypes.SecurityPolicyTypeEncryption,
+			ossstypes.SecurityPolicyTypeNetwork,
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		"encryption|enc-a",
+		"network|net-a",
+		"network|net-b",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
+	}
+}
+
+// TestListOSSSecurityPolicyIdentifiers_PropagatesPagination pins
+// nextToken propagation for the per-type loop.
+func TestListOSSSecurityPolicyIdentifiers_PropagatesPagination(t *testing.T) {
+	t.Parallel()
+	fake := &fakeOSSSecurityPoliciesLister{
+		pagesByType: map[ossstypes.SecurityPolicyType][]opensearchserverless.ListSecurityPoliciesOutput{
+			ossstypes.SecurityPolicyTypeEncryption: {
+				ossSecurityPolicyPage("ENC-CURSOR",
+					ossSecurityPolicySummary("e1", ossstypes.SecurityPolicyTypeEncryption),
+				),
+				ossSecurityPolicyPage("",
+					ossSecurityPolicySummary("e2", ossstypes.SecurityPolicyTypeEncryption),
+				),
+			},
+		},
+	}
+	got, err := listOSSSecurityPolicyIdentifiersWithClient(context.Background(), fake,
+		[]ossstypes.SecurityPolicyType{ossstypes.SecurityPolicyTypeEncryption})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"encryption|e1", "encryption|e2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
+	}
+	tokens := fake.tokenByCall[ossstypes.SecurityPolicyTypeEncryption]
+	if len(tokens) != 2 {
+		t.Fatalf("expected 2 ListSecurityPolicies calls; got %d tokens=%v", len(tokens), tokens)
+	}
+	if tokens[0] != nil {
+		t.Errorf("first call should have nil NextToken; got %v", aws.ToString(tokens[0]))
+	}
+	if aws.ToString(tokens[1]) != "ENC-CURSOR" {
+		t.Errorf("second call should carry forward the cursor; got %q want %q",
+			aws.ToString(tokens[1]), "ENC-CURSOR")
+	}
+}
+
+// TestListOSSSecurityPolicyIdentifiers_EmptyAccountReturnsNonNilEmpty
+// guards the #255 contract.
+func TestListOSSSecurityPolicyIdentifiers_EmptyAccountReturnsNonNilEmpty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeOSSSecurityPoliciesLister{
+		pagesByType: map[ossstypes.SecurityPolicyType][]opensearchserverless.ListSecurityPoliciesOutput{
+			ossstypes.SecurityPolicyTypeEncryption: {ossSecurityPolicyPage("")},
+			ossstypes.SecurityPolicyTypeNetwork:    {ossSecurityPolicyPage("")},
+		},
+	}
+	got, err := listOSSSecurityPolicyIdentifiersWithClient(context.Background(), fake,
+		[]ossstypes.SecurityPolicyType{
+			ossstypes.SecurityPolicyTypeEncryption,
+			ossstypes.SecurityPolicyTypeNetwork,
+		})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil, want non-nil empty slice (#255 contract)")
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty slice", got)
+	}
+}
+
+// TestListOSSSecurityPolicyIdentifiers_PropagatesListError pins the
+// error wrap chain.
+func TestListOSSSecurityPolicyIdentifiers_PropagatesListError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("AccessDenied: aoss:ListSecurityPolicies")
+	fake := &fakeOSSSecurityPoliciesLister{
+		errByType: map[ossstypes.SecurityPolicyType]error{
+			ossstypes.SecurityPolicyTypeEncryption: sentinel,
+		},
+	}
+	_, err := listOSSSecurityPolicyIdentifiersWithClient(context.Background(), fake,
+		[]ossstypes.SecurityPolicyType{ossstypes.SecurityPolicyTypeEncryption})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err does not wrap sentinel; got %v", err)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
@@ -3183,3 +3183,242 @@ func TestListOSSSecurityPolicyIdentifiers_PropagatesListError(t *testing.T) {
 		t.Errorf("err does not wrap sentinel; got %v", err)
 	}
 }
+
+// =====================================================================
+// Phase A.5 — API Gateway V2 ApiMapping SDKLister (#466)
+// =====================================================================
+
+// fakeAPIGatewayV2DomainAndMappingsLister implements
+// apigatewayv2DomainAndMappingsLister against a scripted page sequence
+// (outer GetDomainNames and per-domain GetApiMappings). Records the
+// inputs on each call so tests can pin pagination semantics on BOTH
+// the outer and inner loops.
+type fakeAPIGatewayV2DomainAndMappingsLister struct {
+	// Outer enumeration: apigatewayv2:GetDomainNames pages.
+	getDomainNamesPages  []apigatewayv2.GetDomainNamesOutput
+	getDomainNamesCalls  int
+	getDomainNamesErr    error
+	getDomainNamesTokens []*string // observed NextToken inputs
+
+	// Inner enumeration: apigatewayv2:GetApiMappings pages, keyed by
+	// DomainName.
+	getApiMappingsPagesByDomain  map[string][]apigatewayv2.GetApiMappingsOutput
+	getApiMappingsCallsByDomain  map[string]int
+	getApiMappingsErrByDomain    map[string]error
+	getApiMappingsTokensByDomain map[string][]*string // observed NextToken inputs by domain
+	getApiMappingsDomains        []string             // sequence of DomainName values the SUT supplied
+}
+
+func (f *fakeAPIGatewayV2DomainAndMappingsLister) GetDomainNames(_ context.Context, in *apigatewayv2.GetDomainNamesInput, _ ...func(*apigatewayv2.Options)) (*apigatewayv2.GetDomainNamesOutput, error) {
+	f.getDomainNamesTokens = append(f.getDomainNamesTokens, in.NextToken)
+	if f.getDomainNamesErr != nil {
+		return nil, f.getDomainNamesErr
+	}
+	if f.getDomainNamesCalls >= len(f.getDomainNamesPages) {
+		return &apigatewayv2.GetDomainNamesOutput{}, nil
+	}
+	page := f.getDomainNamesPages[f.getDomainNamesCalls]
+	f.getDomainNamesCalls++
+	return &page, nil
+}
+
+func (f *fakeAPIGatewayV2DomainAndMappingsLister) GetApiMappings(_ context.Context, in *apigatewayv2.GetApiMappingsInput, _ ...func(*apigatewayv2.Options)) (*apigatewayv2.GetApiMappingsOutput, error) {
+	domain := aws.ToString(in.DomainName)
+	if f.getApiMappingsTokensByDomain == nil {
+		f.getApiMappingsTokensByDomain = map[string][]*string{}
+	}
+	f.getApiMappingsTokensByDomain[domain] = append(f.getApiMappingsTokensByDomain[domain], in.NextToken)
+	f.getApiMappingsDomains = append(f.getApiMappingsDomains, domain)
+	if err, ok := f.getApiMappingsErrByDomain[domain]; ok && err != nil {
+		return nil, err
+	}
+	if f.getApiMappingsCallsByDomain == nil {
+		f.getApiMappingsCallsByDomain = map[string]int{}
+	}
+	pages := f.getApiMappingsPagesByDomain[domain]
+	idx := f.getApiMappingsCallsByDomain[domain]
+	if idx >= len(pages) {
+		return &apigatewayv2.GetApiMappingsOutput{}, nil
+	}
+	page := pages[idx]
+	f.getApiMappingsCallsByDomain[domain] = idx + 1
+	return &page, nil
+}
+
+func apigwv2DomainNamesPage(nextToken string, names ...string) apigatewayv2.GetDomainNamesOutput {
+	items := make([]apigwv2types.DomainName, 0, len(names))
+	for _, n := range names {
+		items = append(items, apigwv2types.DomainName{DomainName: aws.String(n)})
+	}
+	out := apigatewayv2.GetDomainNamesOutput{Items: items}
+	if nextToken != "" {
+		out.NextToken = aws.String(nextToken)
+	}
+	return out
+}
+
+func apigwv2ApiMappingsPage(nextToken string, ids ...string) apigatewayv2.GetApiMappingsOutput {
+	items := make([]apigwv2types.ApiMapping, 0, len(ids))
+	for _, id := range ids {
+		items = append(items, apigwv2types.ApiMapping{
+			ApiMappingId: aws.String(id),
+			ApiId:        aws.String("api-" + id),
+			Stage:        aws.String("$default"),
+		})
+	}
+	out := apigatewayv2.GetApiMappingsOutput{Items: items}
+	if nextToken != "" {
+		out.NextToken = aws.String(nextToken)
+	}
+	return out
+}
+
+// TestListAPIGatewayV2ApiMappingIdentifiers_HappyPath_FansOutPerDomain
+// pins the canonical shape: 2 domains × per-domain mappings → CC
+// compound identifiers in domain-then-mapping order.
+func TestListAPIGatewayV2ApiMappingIdentifiers_HappyPath_FansOutPerDomain(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAPIGatewayV2DomainAndMappingsLister{
+		getDomainNamesPages: []apigatewayv2.GetDomainNamesOutput{
+			apigwv2DomainNamesPage("", "api.example.com", "v1.example.com"),
+		},
+		getApiMappingsPagesByDomain: map[string][]apigatewayv2.GetApiMappingsOutput{
+			"api.example.com": {apigwv2ApiMappingsPage("", "mapping-a1", "mapping-a2")},
+			"v1.example.com":  {apigwv2ApiMappingsPage("", "mapping-b1")},
+		},
+	}
+	got, err := listAPIGatewayV2ApiMappingIdentifiersWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		"mapping-a1|api.example.com",
+		"mapping-a2|api.example.com",
+		"mapping-b1|v1.example.com",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
+	}
+}
+
+// TestListAPIGatewayV2ApiMappingIdentifiers_PropagatesOuterPagination
+// pins the outer apigatewayv2:GetDomainNames pagination contract.
+func TestListAPIGatewayV2ApiMappingIdentifiers_PropagatesOuterPagination(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAPIGatewayV2DomainAndMappingsLister{
+		getDomainNamesPages: []apigatewayv2.GetDomainNamesOutput{
+			apigwv2DomainNamesPage("DOMAIN-CURSOR", "d1.example.com"),
+			apigwv2DomainNamesPage("", "d2.example.com"),
+		},
+		getApiMappingsPagesByDomain: map[string][]apigatewayv2.GetApiMappingsOutput{
+			"d1.example.com": {apigwv2ApiMappingsPage("", "m1")},
+			"d2.example.com": {apigwv2ApiMappingsPage("", "m2")},
+		},
+	}
+	got, err := listAPIGatewayV2ApiMappingIdentifiersWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"m1|d1.example.com", "m2|d2.example.com"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
+	}
+	if len(fake.getDomainNamesTokens) != 2 {
+		t.Fatalf("expected 2 GetDomainNames calls; got %d tokens=%v", len(fake.getDomainNamesTokens), fake.getDomainNamesTokens)
+	}
+	if fake.getDomainNamesTokens[0] != nil {
+		t.Errorf("first GetDomainNames call should have nil NextToken; got %v", aws.ToString(fake.getDomainNamesTokens[0]))
+	}
+	if aws.ToString(fake.getDomainNamesTokens[1]) != "DOMAIN-CURSOR" {
+		t.Errorf("second GetDomainNames call should carry forward the cursor; got %q want %q",
+			aws.ToString(fake.getDomainNamesTokens[1]), "DOMAIN-CURSOR")
+	}
+}
+
+// TestListAPIGatewayV2ApiMappingIdentifiers_PropagatesInnerPagination
+// pins the inner per-domain apigatewayv2:GetApiMappings pagination
+// contract.
+func TestListAPIGatewayV2ApiMappingIdentifiers_PropagatesInnerPagination(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAPIGatewayV2DomainAndMappingsLister{
+		getDomainNamesPages: []apigatewayv2.GetDomainNamesOutput{
+			apigwv2DomainNamesPage("", "single.example.com"),
+		},
+		getApiMappingsPagesByDomain: map[string][]apigatewayv2.GetApiMappingsOutput{
+			"single.example.com": {
+				apigwv2ApiMappingsPage("MAPPINGS-CURSOR", "m1"),
+				apigwv2ApiMappingsPage("", "m2"),
+			},
+		},
+	}
+	got, err := listAPIGatewayV2ApiMappingIdentifiersWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"m1|single.example.com", "m2|single.example.com"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
+	}
+	tokens := fake.getApiMappingsTokensByDomain["single.example.com"]
+	if len(tokens) != 2 {
+		t.Fatalf("expected 2 inner GetApiMappings calls; got %d tokens=%v", len(tokens), tokens)
+	}
+	if tokens[0] != nil {
+		t.Errorf("first inner call should have nil NextToken; got %v", aws.ToString(tokens[0]))
+	}
+	if aws.ToString(tokens[1]) != "MAPPINGS-CURSOR" {
+		t.Errorf("second inner call should carry forward the cursor; got %q want %q",
+			aws.ToString(tokens[1]), "MAPPINGS-CURSOR")
+	}
+}
+
+// TestListAPIGatewayV2ApiMappingIdentifiers_EmptyAccountReturnsNonNilEmpty
+// guards the #255 contract.
+func TestListAPIGatewayV2ApiMappingIdentifiers_EmptyAccountReturnsNonNilEmpty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAPIGatewayV2DomainAndMappingsLister{
+		getDomainNamesPages: []apigatewayv2.GetDomainNamesOutput{apigwv2DomainNamesPage("")},
+	}
+	got, err := listAPIGatewayV2ApiMappingIdentifiersWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil, want non-nil empty slice (#255 contract)")
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty slice", got)
+	}
+}
+
+// TestListAPIGatewayV2ApiMappingIdentifiers_PropagatesGetDomainNamesError
+// pins the outer-loop error wrap chain.
+func TestListAPIGatewayV2ApiMappingIdentifiers_PropagatesGetDomainNamesError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("AccessDenied: apigatewayv2:GetDomainNames")
+	fake := &fakeAPIGatewayV2DomainAndMappingsLister{getDomainNamesErr: sentinel}
+	_, err := listAPIGatewayV2ApiMappingIdentifiersWithClient(context.Background(), fake)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err does not wrap sentinel; got %v", err)
+	}
+}
+
+// TestListAPIGatewayV2ApiMappingIdentifiers_PropagatesGetApiMappingsError
+// pins the inner-loop error wrap chain. Per the IAM RolePolicy
+// precedent, one domain's failure aborts the whole region.
+func TestListAPIGatewayV2ApiMappingIdentifiers_PropagatesGetApiMappingsError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("AccessDenied: apigatewayv2:GetApiMappings")
+	fake := &fakeAPIGatewayV2DomainAndMappingsLister{
+		getDomainNamesPages: []apigatewayv2.GetDomainNamesOutput{
+			apigwv2DomainNamesPage("", "bad.example.com"),
+		},
+		getApiMappingsErrByDomain: map[string]error{
+			"bad.example.com": sentinel,
+		},
+	}
+	_, err := listAPIGatewayV2ApiMappingIdentifiersWithClient(context.Background(), fake)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err does not wrap sentinel; got %v", err)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
@@ -2737,6 +2737,12 @@ func TestListIAMRolePolicyIdentifiers_PropagatesOuterPagination(t *testing.T) {
 		t.Errorf("second ListRoles call should carry forward the cursor; got %q want %q",
 			aws.ToString(fake.listRolesMarkers[1]), "OUTER-CURSOR-1")
 	}
+	// Belt-and-suspenders: inner ListRolePolicies must have been called
+	// for both pages' roles. A regression that skipped the inner fan-out
+	// after the outer cursor advance would surface here.
+	if got := fake.listPoliciesRoles; !reflect.DeepEqual(got, []string{"role-a", "role-b"}) {
+		t.Errorf("inner ListRolePolicies call sequence: got %v, want [role-a role-b]", got)
+	}
 }
 
 // TestListIAMRolePolicyIdentifiers_PropagatesInnerPagination pins the
@@ -2777,6 +2783,53 @@ func TestListIAMRolePolicyIdentifiers_PropagatesInnerPagination(t *testing.T) {
 	}
 }
 
+// TestListIAMRolePolicyIdentifiers_InnerPaginationResetsBetweenRoles
+// pins that the inner ListRolePolicies cursor is fresh for each outer
+// role. A regression that re-used the previous role's cursor would
+// either skip pages or refetch them forever (and surface here as a
+// marker-sequence drift on role-b's inner calls).
+func TestListIAMRolePolicyIdentifiers_InnerPaginationResetsBetweenRoles(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRolePoliciesLister{
+		listRolesPages: []iam.ListRolesOutput{
+			iamRolesPage("", [2]string{"/", "role-a"}, [2]string{"/", "role-b"}),
+		},
+		listPoliciesPagesByRole: map[string][]iam.ListRolePoliciesOutput{
+			"role-a": {
+				iamRolePoliciesPage("CURSOR-A", "policy-a1"),
+				iamRolePoliciesPage("", "policy-a2"),
+			},
+			"role-b": {
+				iamRolePoliciesPage("CURSOR-B", "policy-b1"),
+				iamRolePoliciesPage("", "policy-b2"),
+			},
+		},
+	}
+	got, err := listIAMRolePolicyIdentifiersWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		"policy-a1|role-a", "policy-a2|role-a",
+		"policy-b1|role-b", "policy-b2|role-b",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
+	}
+	// Each role's inner cursor must start at nil (not carry over from
+	// the previous role) and advance independently.
+	for _, role := range []string{"role-a", "role-b"} {
+		markers := fake.listPoliciesMarkersByRole[role]
+		if len(markers) != 2 {
+			t.Errorf("role=%s: expected 2 inner ListRolePolicies calls; got %d markers=%v", role, len(markers), markers)
+			continue
+		}
+		if markers[0] != nil {
+			t.Errorf("role=%s: first inner call should have nil Marker; got %v", role, aws.ToString(markers[0]))
+		}
+	}
+}
+
 // TestListIAMRolePolicyIdentifiers_EmptyAccountReturnsNonNilEmpty
 // guards the #255 contract for accounts with zero IAM roles (or zero
 // non-SLR roles) — the result must marshal to "[]" not "null".
@@ -2809,10 +2862,12 @@ func TestListIAMRolePolicyIdentifiers_PropagatesListRolesError(t *testing.T) {
 
 // TestListIAMRolePolicyIdentifiers_PropagatesListRolePoliciesError
 // pins the error wrap chain for the inner per-role call. An error on
-// one role's inner ListRolePolicies aborts the whole enumeration —
-// matches the iam_service_linked_role posture (the SDKLister returns
-// nil + error; the discoverer's per-region wrapper handles partial
-// failure via ServiceWarn at the per-identifier GetResource layer).
+// one role's inner ListRolePolicies aborts the whole region's
+// enumeration (the SDKLister returns nil + error, the discoverer's
+// per-region wrapper translates that into ServiceFinish + region
+// abort). Follow-up #466: a transient per-role AccessDenied should
+// soft-fail via ServiceWarn rather than kill the region — tracked
+// outside this PR because it changes the SDKLister contract.
 func TestListIAMRolePolicyIdentifiers_PropagatesListRolePoliciesError(t *testing.T) {
 	t.Parallel()
 	sentinel := errors.New("AccessDenied: iam:ListRolePolicies")
@@ -3142,7 +3197,9 @@ func TestListOSSSecurityPolicyIdentifiers_PropagatesPagination(t *testing.T) {
 }
 
 // TestListOSSSecurityPolicyIdentifiers_EmptyAccountReturnsNonNilEmpty
-// guards the #255 contract.
+// guards the #255 contract AND pins that BOTH known SecurityPolicyTypes
+// were enumerated. A regression that skipped one type entirely would
+// surface as `len(typesRequested) < 2`.
 func TestListOSSSecurityPolicyIdentifiers_EmptyAccountReturnsNonNilEmpty(t *testing.T) {
 	t.Parallel()
 	fake := &fakeOSSSecurityPoliciesLister{
@@ -3165,6 +3222,11 @@ func TestListOSSSecurityPolicyIdentifiers_EmptyAccountReturnsNonNilEmpty(t *test
 	if len(got) != 0 {
 		t.Errorf("got %v, want empty slice", got)
 	}
+	// Both types must have been requested, even though both return
+	// empty — a regression that only walked one type would surface here.
+	if len(fake.typesRequested) != 2 {
+		t.Errorf("typesRequested=%v, want 2 distinct ListSecurityPolicies calls", fake.typesRequested)
+	}
 }
 
 // TestListOSSSecurityPolicyIdentifiers_PropagatesListError pins the
@@ -3181,6 +3243,36 @@ func TestListOSSSecurityPolicyIdentifiers_PropagatesListError(t *testing.T) {
 		[]ossstypes.SecurityPolicyType{ossstypes.SecurityPolicyTypeEncryption})
 	if !errors.Is(err, sentinel) {
 		t.Errorf("err does not wrap sentinel; got %v", err)
+	}
+}
+
+// TestListOSSSecurityPolicyIdentifiers_DefensiveTypeFallback mirrors the
+// AccessPolicy fallback pin. When the SDK summary's Type is the zero
+// value (defensive: the API field is an enum that could in theory be
+// zero-valued), the lister must fill it from the requested
+// SecurityPolicyType so the identifier always has both halves.
+func TestListOSSSecurityPolicyIdentifiers_DefensiveTypeFallback(t *testing.T) {
+	t.Parallel()
+	fake := &fakeOSSSecurityPoliciesLister{
+		pagesByType: map[ossstypes.SecurityPolicyType][]opensearchserverless.ListSecurityPoliciesOutput{
+			ossstypes.SecurityPolicyTypeEncryption: {
+				ossSecurityPolicyPage("",
+					// Empty Type — the lister must fill it from the
+					// requested SecurityPolicyType so the emitted ID has
+					// both halves.
+					ossstypes.SecurityPolicySummary{Name: aws.String("orphan")},
+				),
+			},
+		},
+	}
+	got, err := listOSSSecurityPolicyIdentifiersWithClient(context.Background(), fake,
+		[]ossstypes.SecurityPolicyType{ossstypes.SecurityPolicyTypeEncryption})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"encryption|orphan"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
 	}
 }
 

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
@@ -2555,3 +2555,275 @@ func TestListIAMServiceLinkedRoleServiceNames_SkipsRolesWithMalformedPath(t *tes
 		t.Errorf("got %v, want %v (malformed path must be skipped)", got, want)
 	}
 }
+
+// =====================================================================
+// Phase A.2 — IAM RolePolicy SDKLister (#466)
+// =====================================================================
+
+// fakeIAMRolePoliciesLister implements iamRolePoliciesLister against a
+// scripted page sequence. listRolesPages drives the outer iam:ListRoles
+// loop; listPoliciesPagesByRole drives the inner per-role
+// iam:ListRolePolicies loop. Both record markers received from the
+// SUT so tests can assert pagination is propagated exactly once per
+// page transition.
+type fakeIAMRolePoliciesLister struct {
+	// Outer enumeration: iam:ListRoles paginated pages.
+	listRolesPages   []iam.ListRolesOutput
+	listRolesCalls   int
+	listRolesErr     error
+	listRolesMarkers []*string // markers sent on each call (incl. nil first call)
+
+	// Inner enumeration: iam:ListRolePolicies pages keyed by role name.
+	listPoliciesPagesByRole map[string][]iam.ListRolePoliciesOutput
+	listPoliciesCallsByRole map[string]int
+	listPoliciesErrByRole   map[string]error
+	// listPoliciesMarkersByRole records the marker the SUT supplied
+	// on each per-role call, in order. Pre-allocate the inner slice
+	// only when actually appending so a nil-vs-empty distinction
+	// survives reflect.DeepEqual checks in tests.
+	listPoliciesMarkersByRole map[string][]*string
+
+	// listPoliciesRoles records the role-name order the SUT requested
+	// inner pages for, so tests can assert filter behavior (e.g. SLRs
+	// must NOT trigger inner ListRolePolicies).
+	listPoliciesRoles []string
+}
+
+func (f *fakeIAMRolePoliciesLister) ListRoles(_ context.Context, in *iam.ListRolesInput, _ ...func(*iam.Options)) (*iam.ListRolesOutput, error) {
+	f.listRolesMarkers = append(f.listRolesMarkers, in.Marker)
+	if f.listRolesErr != nil {
+		return nil, f.listRolesErr
+	}
+	if f.listRolesCalls >= len(f.listRolesPages) {
+		return &iam.ListRolesOutput{}, nil
+	}
+	page := f.listRolesPages[f.listRolesCalls]
+	f.listRolesCalls++
+	return &page, nil
+}
+
+func (f *fakeIAMRolePoliciesLister) ListRolePolicies(_ context.Context, in *iam.ListRolePoliciesInput, _ ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error) {
+	role := aws.ToString(in.RoleName)
+	if f.listPoliciesMarkersByRole == nil {
+		f.listPoliciesMarkersByRole = map[string][]*string{}
+	}
+	f.listPoliciesMarkersByRole[role] = append(f.listPoliciesMarkersByRole[role], in.Marker)
+	f.listPoliciesRoles = append(f.listPoliciesRoles, role)
+	if err, ok := f.listPoliciesErrByRole[role]; ok && err != nil {
+		return nil, err
+	}
+	if f.listPoliciesCallsByRole == nil {
+		f.listPoliciesCallsByRole = map[string]int{}
+	}
+	pages := f.listPoliciesPagesByRole[role]
+	idx := f.listPoliciesCallsByRole[role]
+	if idx >= len(pages) {
+		return &iam.ListRolePoliciesOutput{}, nil
+	}
+	page := pages[idx]
+	f.listPoliciesCallsByRole[role] = idx + 1
+	return &page, nil
+}
+
+// iamRolePoliciesPage constructs a single ListRolePoliciesOutput from a
+// truncation marker plus a list of inline policy names.
+func iamRolePoliciesPage(marker string, names ...string) iam.ListRolePoliciesOutput {
+	out := iam.ListRolePoliciesOutput{PolicyNames: append([]string{}, names...)}
+	if marker != "" {
+		out.IsTruncated = true
+		out.Marker = aws.String(marker)
+	}
+	return out
+}
+
+// TestListIAMRolePolicyIdentifiers_HappyPath_FansOutPerRole pins the
+// canonical shape: two non-SLR roles × two inline policies each → four
+// emitted identifiers in CC compound form `<PolicyName>|<RoleName>`.
+// Order is preserved (role iteration order from the ListRoles page,
+// then policy order from each ListRolePolicies page).
+func TestListIAMRolePolicyIdentifiers_HappyPath_FansOutPerRole(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRolePoliciesLister{
+		listRolesPages: []iam.ListRolesOutput{
+			iamRolesPage("",
+				[2]string{"/", "role-a"},
+				[2]string{"/", "role-b"},
+			),
+		},
+		listPoliciesPagesByRole: map[string][]iam.ListRolePoliciesOutput{
+			"role-a": {iamRolePoliciesPage("", "policy-a1", "policy-a2")},
+			"role-b": {iamRolePoliciesPage("", "policy-b1", "policy-b2")},
+		},
+	}
+	got, err := listIAMRolePolicyIdentifiersWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		"policy-a1|role-a",
+		"policy-a2|role-a",
+		"policy-b1|role-b",
+		"policy-b2|role-b",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
+	}
+}
+
+// TestListIAMRolePolicyIdentifiers_SkipsServiceLinkedRoles pins the
+// SLR filter: roles whose Path starts with /aws-service-role/ must NOT
+// trigger an inner ListRolePolicies call (IAM rejects PutRolePolicy on
+// SLRs, so the inner result is guaranteed empty — the filter saves an
+// API call per SLR).
+func TestListIAMRolePolicyIdentifiers_SkipsServiceLinkedRoles(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRolePoliciesLister{
+		listRolesPages: []iam.ListRolesOutput{
+			iamRolesPage("",
+				[2]string{"/aws-service-role/elasticache.amazonaws.com/", "AWSServiceRoleForElastiCache"},
+				[2]string{"/", "real-role"},
+			),
+		},
+		listPoliciesPagesByRole: map[string][]iam.ListRolePoliciesOutput{
+			"real-role": {iamRolePoliciesPage("", "real-policy")},
+		},
+	}
+	got, err := listIAMRolePolicyIdentifiersWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"real-policy|real-role"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
+	}
+	// SLR must NOT be queried for inline policies.
+	if got := fake.listPoliciesRoles; !reflect.DeepEqual(got, []string{"real-role"}) {
+		t.Errorf("inner ListRolePolicies should only be called for non-SLR roles; got call sequence %v", got)
+	}
+}
+
+// TestListIAMRolePolicyIdentifiers_PropagatesOuterPagination pins the
+// outer iam:ListRoles pagination contract: the marker returned on page
+// N must surface as the Marker input on page N+1, exactly once.
+func TestListIAMRolePolicyIdentifiers_PropagatesOuterPagination(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRolePoliciesLister{
+		listRolesPages: []iam.ListRolesOutput{
+			iamRolesPage("OUTER-CURSOR-1", [2]string{"/", "role-a"}),
+			iamRolesPage("", [2]string{"/", "role-b"}),
+		},
+		listPoliciesPagesByRole: map[string][]iam.ListRolePoliciesOutput{
+			"role-a": {iamRolePoliciesPage("", "pa")},
+			"role-b": {iamRolePoliciesPage("", "pb")},
+		},
+	}
+	got, err := listIAMRolePolicyIdentifiersWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"pa|role-a", "pb|role-b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
+	}
+	if len(fake.listRolesMarkers) != 2 {
+		t.Fatalf("expected 2 ListRoles calls; got %d markers=%v", len(fake.listRolesMarkers), fake.listRolesMarkers)
+	}
+	if fake.listRolesMarkers[0] != nil {
+		t.Errorf("first ListRoles call should have nil Marker; got %v", aws.ToString(fake.listRolesMarkers[0]))
+	}
+	if aws.ToString(fake.listRolesMarkers[1]) != "OUTER-CURSOR-1" {
+		t.Errorf("second ListRoles call should carry forward the cursor; got %q want %q",
+			aws.ToString(fake.listRolesMarkers[1]), "OUTER-CURSOR-1")
+	}
+}
+
+// TestListIAMRolePolicyIdentifiers_PropagatesInnerPagination pins the
+// inner iam:ListRolePolicies pagination contract: the marker returned
+// on inner page N must surface as the Marker input on inner page N+1
+// for the SAME role, exactly once.
+func TestListIAMRolePolicyIdentifiers_PropagatesInnerPagination(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRolePoliciesLister{
+		listRolesPages: []iam.ListRolesOutput{
+			iamRolesPage("", [2]string{"/", "role-a"}),
+		},
+		listPoliciesPagesByRole: map[string][]iam.ListRolePoliciesOutput{
+			"role-a": {
+				iamRolePoliciesPage("INNER-CURSOR-A", "policy-1"),
+				iamRolePoliciesPage("", "policy-2"),
+			},
+		},
+	}
+	got, err := listIAMRolePolicyIdentifiersWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"policy-1|role-a", "policy-2|role-a"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers drift: got %v want %v", got, want)
+	}
+	markers := fake.listPoliciesMarkersByRole["role-a"]
+	if len(markers) != 2 {
+		t.Fatalf("expected 2 inner ListRolePolicies calls for role-a; got %d markers=%v", len(markers), markers)
+	}
+	if markers[0] != nil {
+		t.Errorf("first inner call should have nil Marker; got %v", aws.ToString(markers[0]))
+	}
+	if aws.ToString(markers[1]) != "INNER-CURSOR-A" {
+		t.Errorf("second inner call should carry forward the cursor; got %q want %q",
+			aws.ToString(markers[1]), "INNER-CURSOR-A")
+	}
+}
+
+// TestListIAMRolePolicyIdentifiers_EmptyAccountReturnsNonNilEmpty
+// guards the #255 contract for accounts with zero IAM roles (or zero
+// non-SLR roles) — the result must marshal to "[]" not "null".
+func TestListIAMRolePolicyIdentifiers_EmptyAccountReturnsNonNilEmpty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeIAMRolePoliciesLister{listRolesPages: []iam.ListRolesOutput{iamRolesPage("")}}
+	got, err := listIAMRolePolicyIdentifiersWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil, want non-nil empty slice (#255 contract)")
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty slice", got)
+	}
+}
+
+// TestListIAMRolePolicyIdentifiers_PropagatesListRolesError pins the
+// error wrap chain for the outer call.
+func TestListIAMRolePolicyIdentifiers_PropagatesListRolesError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("AccessDenied: iam:ListRoles")
+	fake := &fakeIAMRolePoliciesLister{listRolesErr: sentinel}
+	_, err := listIAMRolePolicyIdentifiersWithClient(context.Background(), fake)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err does not wrap sentinel; got %v", err)
+	}
+}
+
+// TestListIAMRolePolicyIdentifiers_PropagatesListRolePoliciesError
+// pins the error wrap chain for the inner per-role call. An error on
+// one role's inner ListRolePolicies aborts the whole enumeration —
+// matches the iam_service_linked_role posture (the SDKLister returns
+// nil + error; the discoverer's per-region wrapper handles partial
+// failure via ServiceWarn at the per-identifier GetResource layer).
+func TestListIAMRolePolicyIdentifiers_PropagatesListRolePoliciesError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("AccessDenied: iam:ListRolePolicies")
+	fake := &fakeIAMRolePoliciesLister{
+		listRolesPages: []iam.ListRolesOutput{
+			iamRolesPage("", [2]string{"/", "role-a"}),
+		},
+		listPoliciesErrByRole: map[string]error{
+			"role-a": sentinel,
+		},
+	}
+	_, err := listIAMRolePolicyIdentifiersWithClient(context.Background(), fake)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err does not wrap sentinel; got %v", err)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -2389,6 +2389,62 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		},
 		TagsFromProperties: emptyTagsExtractor,
 	},
+
+	// =====================================================================
+	// OpenSearch Serverless SecurityPolicy — SDKLister-listed, untaggable (Phase A.4 / #466)
+	// =====================================================================
+	{
+		// AWS::OpenSearchServerless::SecurityPolicy mirrors the access-
+		// policy shape: CC ListResources returns
+		// UnsupportedActionException, CC GetResource works on the
+		// compound primary identifier [Type, Name] (verified against
+		// the public CFN schema:
+		//   https://schema.cloudformation.us-east-1.amazonaws.com/aws-opensearchserverless-securitypolicy.json
+		// `primaryIdentifier: [/properties/Type, /properties/Name]`).
+		//
+		// The SDKLister calls aoss:ListSecurityPolicies once per
+		// SecurityPolicyType ("encryption" and "network") and
+		// concatenates per-type Name + Type pairs. Emits
+		// "<Type>|<Name>" — framework joins compound primary-identifier
+		// parts with `|` in schema-declared order.
+		//
+		// Terraform's import format is `<name>/<type>` (verified
+		// against terraform-provider-aws main
+		// website/docs/r/opensearchserverless_security_policy.html.markdown
+		// per the Import section:
+		//   "% terraform import aws_opensearchserverless_security_policy.example
+		//    example/encryption"
+		// ). The rewrite SWAPS the CC `<Type>|<Name>` halves and joins
+		// them with `/` to produce `<Name>/<Type>`.
+		//
+		// Untaggable (CFN schema has no Tags property); existing
+		// untaggableAWS / NON_TAGGABLE_AWS allowlist entry remains in
+		// sync.
+		TFType:               "aws_opensearchserverless_security_policy",
+		CloudFormationType:   "AWS::OpenSearchServerless::SecurityPolicy",
+		Slug:                 "opensearchserverless_security_policy",
+		SkipProjectTagFilter: true,
+		SDKLister:            listOSSSecurityPolicyIdentifiers,
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return identifier
+			}
+			return parts[1] + "/" + parts[0]
+		},
+		NameHintFromProperties: nameOrIdentifier("Name"),
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return map[string]string{"name": identifier}
+			}
+			return map[string]string{
+				"type": parts[0],
+				"name": parts[1],
+			}
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
 }
 
 // passthroughImportID is the common ImportIDFromIdentifier used by every

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -2240,6 +2240,85 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		NativeIDsFromProperties: snsSubscriptionNativeIDs,
 		TagsFromProperties:      emptyTagsExtractor,
 	},
+
+	// =====================================================================
+	// IAM RolePolicy — SDKLister-listed, global, untaggable (Phase A.2 / #466)
+	// =====================================================================
+	{
+		// AWS::IAM::RolePolicy's CC ListResources returns
+		// UnsupportedActionException — inline role policies live under a
+		// parent IAM role rather than as top-level resources, so CC has
+		// no LIST handler. CC GetResource IS supported and keyed on the
+		// compound primary identifier [PolicyName, RoleName] (verified
+		// against the public CFN schema:
+		//   https://schema.cloudformation.us-east-1.amazonaws.com/aws-iam-rolepolicy.json
+		// `primaryIdentifier: [/properties/PolicyName, /properties/RoleName]`).
+		// IAM is global; IsGlobal=true mirrors aws_iam_service_linked_role
+		// and the rest of the IAM bucket.
+		//
+		// The SDKLister walks iam:ListRoles (paginated) and, for each
+		// non-SLR role, iam:ListRolePolicies (paginated). It emits the
+		// CC compound identifier "<PolicyName>|<RoleName>" — the
+		// framework joins compound primary-identifier parts with `|` in
+		// the order declared by the schema.
+		//
+		// Terraform's import format for aws_iam_role_policy is
+		// `<role_name>:<role_policy_name>` (verified against
+		// terraform-provider-aws main website/docs/r/iam_role_policy.html.markdown
+		// per the Import section:
+		//   "% terraform import aws_iam_role_policy.example
+		//    role_of_mypolicy_name:mypolicy_name"
+		// ). The rewrite SWAPS the CC `<PolicyName>|<RoleName>` to the
+		// TF `<RoleName>:<PolicyName>` form. When the identifier is
+		// malformed (defensive — no `|`), fall through verbatim so a
+		// downstream `terraform import` surfaces a clear "wrong format"
+		// error rather than a silent mis-import.
+		//
+		// The CFN schema has no Tags property — inline role policies are
+		// untaggable in AWS provider 6.x. SkipProjectTagFilter +
+		// emptyTagsExtractor matches the existing untaggableAWS /
+		// NON_TAGGABLE_AWS allowlist entry (which already lists this
+		// type — only the SDKLister wiring is new in #466).
+		//
+		// No ARN rule in arn_rules.go: inline IAM policies have no ARN
+		// of their own (only the parent role's ARN is reachable, and
+		// that routes to aws_iam_role). Discovery is SDKLister-only.
+		TFType:               "aws_iam_role_policy",
+		CloudFormationType:   "AWS::IAM::RolePolicy",
+		Slug:                 "iam_role_policy",
+		IsGlobal:             true,
+		SkipProjectTagFilter: true,
+		SDKLister:            listIAMRolePolicyIdentifiers,
+		// ImportID rewrite: CC `<PolicyName>|<RoleName>` → TF
+		// `<RoleName>:<PolicyName>` (swap halves, join with `:`).
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return identifier
+			}
+			return parts[1] + ":" + parts[0]
+		},
+		// NameHint: prefer the CFN-surfaced PolicyName (the human-
+		// meaningful inline-policy suffix), falling back to the compound
+		// identifier verbatim. The CC properties payload echoes
+		// PolicyName + RoleName on GetResource.
+		NameHintFromProperties: nameOrIdentifier("PolicyName"),
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				// Defensive: a malformed identifier (no `|`) almost
+				// certainly means an upstream bug — emit just the
+				// policy-name half so downstream readers can spot the
+				// drift rather than receive a half-populated map.
+				return map[string]string{"policy_name": identifier}
+			}
+			return map[string]string{
+				"policy_name": parts[0],
+				"role_name":   parts[1],
+			}
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
 }
 
 // passthroughImportID is the common ImportIDFromIdentifier used by every

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -328,6 +328,72 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		TagsFromProperties:     tagsFromKey("Tags"),
 	},
 	{
+		// AWS::EC2::SecurityGroupIngress — CFN schema has no Tags
+		// property (verified via describe-type us-east-1: properties
+		// = [Id, CidrIp, CidrIpv6, Description, FromPort, GroupId,
+		// GroupName, IpProtocol, SourcePrefixListId, …]; primary
+		// identifier = `/properties/Id` returning `sgr-XXXXX`).
+		// SkipProjectTagFilter bypasses both the RGT cache short-
+		// circuit (RGT may surface `ec2:security-group-rule/…` ARNs
+		// but can't disambiguate ingress vs egress — they share the
+		// `security-group-rule` ARN resource-type segment) and the
+		// post-fetch Project-tag filter.
+		//
+		// Terraform import format is the bare `sgr-XXXXX` ID
+		// (verified against terraform-provider-aws main:
+		// website/docs/r/vpc_security_group_ingress_rule.html.markdown
+		// — `terraform import aws_vpc_security_group_ingress_rule.example sgr-…`).
+		// Passthrough ImportIDFromIdentifier.
+		//
+		// No arnRule for `ec2:security-group-rule` — the ARN
+		// resource-type segment is identical for ingress and egress,
+		// so we'd misroute half the time. SkipProjectTagFilter=true
+		// makes the cache fallback path always run, so the missing
+		// arnRule is correct rather than a gap.
+		TFType:                 "aws_vpc_security_group_ingress_rule",
+		CloudFormationType:     "AWS::EC2::SecurityGroupIngress",
+		Slug:                   "vpc_security_group_ingress_rule",
+		SkipProjectTagFilter:   true,
+		ImportIDFromIdentifier: passthroughImportID,
+		NameHintFromProperties: passthroughIdentifierName,
+		NativeIDsFromProperties: func(identifier string, props map[string]any) map[string]string {
+			out := map[string]string{"security_group_rule_id": identifier}
+			if gid := extractString(props, "GroupId"); gid != "" {
+				out["security_group_id"] = gid
+			}
+			return out
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
+	{
+		// AWS::EC2::SecurityGroupEgress — mirror of the ingress entry
+		// above. CFN schema has no Tags property (verified via
+		// describe-type us-east-1: properties = [CidrIp, CidrIpv6,
+		// Description, FromPort, ToPort, IpProtocol,
+		// DestinationSecurityGroupId, Id, DestinationPrefixListId,
+		// GroupId]; primary identifier = `/properties/Id` returning
+		// `sgr-XXXXX`).
+		//
+		// Terraform import format is the bare `sgr-XXXXX` ID
+		// (verified against terraform-provider-aws main:
+		// website/docs/r/vpc_security_group_egress_rule.html.markdown).
+		// Passthrough ImportIDFromIdentifier.
+		TFType:                 "aws_vpc_security_group_egress_rule",
+		CloudFormationType:     "AWS::EC2::SecurityGroupEgress",
+		Slug:                   "vpc_security_group_egress_rule",
+		SkipProjectTagFilter:   true,
+		ImportIDFromIdentifier: passthroughImportID,
+		NameHintFromProperties: passthroughIdentifierName,
+		NativeIDsFromProperties: func(identifier string, props map[string]any) map[string]string {
+			out := map[string]string{"security_group_rule_id": identifier}
+			if gid := extractString(props, "GroupId"); gid != "" {
+				out["security_group_id"] = gid
+			}
+			return out
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
+	{
 		TFType:                 "aws_internet_gateway",
 		CloudFormationType:     "AWS::EC2::InternetGateway",
 		Slug:                   "internet_gateway",

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -2445,6 +2445,68 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		},
 		TagsFromProperties: emptyTagsExtractor,
 	},
+
+	// =====================================================================
+	// API Gateway V2 ApiMapping — SDKLister-listed, untaggable (Phase A.5 / #466)
+	// =====================================================================
+	{
+		// AWS::ApiGatewayV2::ApiMapping's CC ListResources returns
+		// UnsupportedActionException — API mappings are sub-resources of
+		// a parent custom domain name, so CC has no LIST handler. CC
+		// GetResource IS supported and keyed on the compound primary
+		// identifier [ApiMappingId, DomainName] (verified against the
+		// public CFN schema:
+		//   https://schema.cloudformation.us-east-1.amazonaws.com/aws-apigatewayv2-apimapping.json
+		// `primaryIdentifier: [/properties/ApiMappingId, /properties/DomainName]`).
+		//
+		// The SDKLister walks apigatewayv2:GetDomainNames (paginated)
+		// and for each domain calls apigatewayv2:GetApiMappings
+		// (paginated, requires DomainName). Emits
+		// "<ApiMappingId>|<DomainName>" — framework joins compound
+		// primary-identifier parts with `|` in schema-declared order.
+		//
+		// Terraform's import format is `<api_mapping_id>/<domain_name>`
+		// (verified against terraform-provider-aws v6.x docs
+		// website/docs/r/apigatewayv2_api_mapping.html.markdown — Import
+		// section example: "1122334/ws-api.example.com"). The rewrite
+		// is a single `|` → `/` swap because the CC identifier order
+		// already matches the TF identifier order.
+		//
+		// The CFN schema has no Tags property — API mappings are
+		// sub-resources of the parent domain (which carries the tags).
+		// SkipProjectTagFilter + emptyTagsExtractor matches the existing
+		// untaggableAWS / NON_TAGGABLE_AWS allowlist entry (which
+		// already lists this type — only the SDKLister wiring is new in
+		// #466).
+		TFType:               "aws_apigatewayv2_api_mapping",
+		CloudFormationType:   "AWS::ApiGatewayV2::ApiMapping",
+		Slug:                 "apigatewayv2_api_mapping",
+		SkipProjectTagFilter: true,
+		SDKLister:            listAPIGatewayV2ApiMappingIdentifiers,
+		// ImportID rewrite: CC `<ApiMappingId>|<DomainName>` → TF
+		// `<ApiMappingId>/<DomainName>` (same halves, swap `|` for `/`).
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			return strings.Replace(identifier, "|", "/", 1)
+		},
+		// NameHint: prefer the CFN-surfaced ApiMappingKey (the
+		// human-facing URL prefix, e.g. "v1" or "" for the root
+		// mapping). Empty-string ApiMappingKey is a valid AWS state
+		// (root mapping), and nameOrIdentifier falls through to the
+		// compound identifier in that case so the UI never renders an
+		// empty NameHint.
+		NameHintFromProperties: nameOrIdentifier("ApiMappingKey"),
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return map[string]string{"api_mapping_id": identifier}
+			}
+			return map[string]string{
+				"api_mapping_id": parts[0],
+				"domain_name":    parts[1],
+			}
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
 }
 
 // passthroughImportID is the common ImportIDFromIdentifier used by every

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -2319,6 +2319,76 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		},
 		TagsFromProperties: emptyTagsExtractor,
 	},
+
+	// =====================================================================
+	// OpenSearch Serverless AccessPolicy — SDKLister-listed, untaggable (Phase A.3 / #466)
+	// =====================================================================
+	{
+		// AWS::OpenSearchServerless::AccessPolicy's CC ListResources
+		// returns UnsupportedActionException — the service has no LIST
+		// handler exposed through CloudControl, but CC GetResource IS
+		// supported and keyed on the compound primary identifier [Type,
+		// Name] (verified against the public CFN schema:
+		//   https://schema.cloudformation.us-east-1.amazonaws.com/aws-opensearchserverless-accesspolicy.json
+		// `primaryIdentifier: [/properties/Type, /properties/Name]`).
+		//
+		// The SDKLister calls aoss:ListAccessPolicies once per
+		// AccessPolicyType (today only "data") and concatenates the
+		// per-type Name + Type pairs into "<Type>|<Name>" — the
+		// framework joins compound primary-identifier parts with `|` in
+		// schema-declared order.
+		//
+		// Terraform's import format is `<name>/<type>` (verified
+		// against terraform-provider-aws main
+		// website/docs/r/opensearchserverless_access_policy.html.markdown
+		// per the Import section:
+		//   "% terraform import aws_opensearchserverless_access_policy.example
+		//    example/data"
+		// ). The rewrite SWAPS the CC `<Type>|<Name>` halves and joins
+		// them with `/` to produce `<Name>/<Type>`. When the identifier
+		// is malformed (defensive — no `|`), fall through verbatim so a
+		// downstream `terraform import` surfaces a clear "wrong format"
+		// error.
+		//
+		// The CFN schema has no Tags property — OSS access policies are
+		// untaggable in AWS provider 6.x. SkipProjectTagFilter +
+		// emptyTagsExtractor matches the existing untaggableAWS /
+		// NON_TAGGABLE_AWS allowlist entry (which already lists this
+		// type — only the SDKLister wiring is new in #466).
+		//
+		// No ARN rule in arn_rules.go: OSS access policies are not
+		// surfaced via Resource Groups Tagging API today (the SDK has
+		// no ListTagsForResource for access policies), so RGT cache
+		// hits never apply; discovery is SDKLister-only.
+		TFType:               "aws_opensearchserverless_access_policy",
+		CloudFormationType:   "AWS::OpenSearchServerless::AccessPolicy",
+		Slug:                 "opensearchserverless_access_policy",
+		SkipProjectTagFilter: true,
+		SDKLister:            listOSSAccessPolicyIdentifiers,
+		// ImportID rewrite: CC `<Type>|<Name>` → TF `<Name>/<Type>`
+		// (swap halves, join with `/`).
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return identifier
+			}
+			return parts[1] + "/" + parts[0]
+		},
+		// NameHint: prefer the Name from properties (the customer-
+		// facing policy name); fall back to the identifier verbatim.
+		NameHintFromProperties: nameOrIdentifier("Name"),
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			parts := strings.SplitN(identifier, "|", 2)
+			if len(parts) != 2 {
+				return map[string]string{"name": identifier}
+			}
+			return map[string]string{
+				"type": parts[0],
+				"name": parts[1],
+			}
+		},
+		TagsFromProperties: emptyTagsExtractor,
+	},
 }
 
 // passthroughImportID is the common ImportIDFromIdentifier used by every

--- a/cmd/insideout-import/awsdiscover/sdkonly_s3.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_s3.go
@@ -217,10 +217,11 @@ var sdkOnlySubresourceTypeConfigs = []sdkOnlySubresourceConfig{
 	// import ID we cannot prove is correct would cause silent terraform
 	// import failures downstream. The replacement resources
 	// `aws_vpc_security_group_ingress_rule` /
-	// `aws_vpc_security_group_egress_rule` (which carry real-ARN-shape
-	// security_group_rule_id values returned by EC2) are the supported
-	// path forward for in-preset SG-rule discovery — tracked as a
-	// follow-up to #456.
+	// `aws_vpc_security_group_egress_rule` (which carry real
+	// security_group_rule_id (`sgr-XXXXX`) values returned by EC2) are
+	// the supported path forward, and they ride the unified Cloud
+	// Control discoverer (cloudControlTypeConfigs in
+	// cloudcontrol_types.go) — see #460.
 	// =====================================================================
 
 	{

--- a/pkg/composer/imported/category.go
+++ b/pkg/composer/imported/category.go
@@ -157,6 +157,7 @@ var categoryByTFType = map[string]string{
 	"aws_opensearch_domain":                              CategoryDataStorage,
 	"aws_opensearchserverless_access_policy":             CategorySecurity,
 	"aws_opensearchserverless_collection":                CategoryDataStorage,
+	"aws_opensearchserverless_security_policy":           CategorySecurity,
 	"aws_rds_cluster":                                    CategoryDataStorage,
 	"aws_resourceexplorer2_index":                        CategoryObservability,
 	"aws_resourceexplorer2_view":                         CategoryObservability,

--- a/pkg/composer/imported/category.go
+++ b/pkg/composer/imported/category.go
@@ -81,6 +81,7 @@ var categoryByTFType = map[string]string{
 	"aws_api_gateway_resource":                           CategoryNetworkSecurity,
 	"aws_api_gateway_stage":                              CategoryNetworkSecurity,
 	"aws_apigatewayv2_api":                               CategoryNetworkSecurity,
+	"aws_apigatewayv2_api_mapping":                       CategoryNetworkSecurity,
 	"aws_apigatewayv2_authorizer":                        CategoryNetworkSecurity,
 	"aws_apigatewayv2_domain_name":                       CategoryNetworkSecurity,
 	"aws_apigatewayv2_integration":                       CategoryNetworkSecurity,

--- a/pkg/composer/imported/category.go
+++ b/pkg/composer/imported/category.go
@@ -155,6 +155,7 @@ var categoryByTFType = map[string]string{
 	"aws_network_acl":                                    CategoryNetworkSecurity,
 	"aws_network_interface":                              CategoryNetworkSecurity,
 	"aws_opensearch_domain":                              CategoryDataStorage,
+	"aws_opensearchserverless_access_policy":             CategorySecurity,
 	"aws_opensearchserverless_collection":                CategoryDataStorage,
 	"aws_rds_cluster":                                    CategoryDataStorage,
 	"aws_resourceexplorer2_index":                        CategoryObservability,

--- a/pkg/composer/imported/category.go
+++ b/pkg/composer/imported/category.go
@@ -131,6 +131,7 @@ var categoryByTFType = map[string]string{
 	"aws_iam_instance_profile":                           CategorySecurity,
 	"aws_iam_policy":                                     CategorySecurity,
 	"aws_iam_role":                                       CategorySecurity,
+	"aws_iam_role_policy":                                CategorySecurity,
 	"aws_iam_role_policy_attachment":                     CategorySecurity,
 	"aws_iam_service_linked_role":                        CategorySecurity,
 	"aws_iam_user":                                       CategorySecurity,

--- a/pkg/composer/imported/category.go
+++ b/pkg/composer/imported/category.go
@@ -182,6 +182,8 @@ var categoryByTFType = map[string]string{
 	"aws_vpc":                                            CategoryNetworkSecurity,
 	"aws_vpc_dhcp_options":                               CategoryNetworkSecurity,
 	"aws_vpc_endpoint":                                   CategoryNetworkSecurity,
+	"aws_vpc_security_group_egress_rule":                 CategoryNetworkSecurity,
+	"aws_vpc_security_group_ingress_rule":                CategoryNetworkSecurity,
 	"aws_wafv2_web_acl":                                  CategorySecurity,
 	"aws_wafv2_web_acl_association":                      CategorySecurity,
 

--- a/pkg/composer/imported/testdata/category.golden
+++ b/pkg/composer/imported/testdata/category.golden
@@ -77,6 +77,7 @@ aws_nat_gateway	Network Security
 aws_network_acl	Network Security
 aws_network_interface	Network Security
 aws_opensearch_domain	Data Storage
+aws_opensearchserverless_access_policy	Security
 aws_opensearchserverless_collection	Data Storage
 aws_rds_cluster	Data Storage
 aws_resourceexplorer2_index	Observability

--- a/pkg/composer/imported/testdata/category.golden
+++ b/pkg/composer/imported/testdata/category.golden
@@ -79,6 +79,7 @@ aws_network_interface	Network Security
 aws_opensearch_domain	Data Storage
 aws_opensearchserverless_access_policy	Security
 aws_opensearchserverless_collection	Data Storage
+aws_opensearchserverless_security_policy	Security
 aws_rds_cluster	Data Storage
 aws_resourceexplorer2_index	Observability
 aws_resourceexplorer2_view	Observability

--- a/pkg/composer/imported/testdata/category.golden
+++ b/pkg/composer/imported/testdata/category.golden
@@ -3,6 +3,7 @@ aws_api_gateway_deployment	Network Security
 aws_api_gateway_resource	Network Security
 aws_api_gateway_stage	Network Security
 aws_apigatewayv2_api	Network Security
+aws_apigatewayv2_api_mapping	Network Security
 aws_apigatewayv2_authorizer	Network Security
 aws_apigatewayv2_domain_name	Network Security
 aws_apigatewayv2_integration	Network Security

--- a/pkg/composer/imported/testdata/category.golden
+++ b/pkg/composer/imported/testdata/category.golden
@@ -104,6 +104,8 @@ aws_subnet	Network Security
 aws_vpc	Network Security
 aws_vpc_dhcp_options	Network Security
 aws_vpc_endpoint	Network Security
+aws_vpc_security_group_egress_rule	Network Security
+aws_vpc_security_group_ingress_rule	Network Security
 aws_wafv2_web_acl	Security
 aws_wafv2_web_acl_association	Security
 google_api_gateway_api	Network Security

--- a/pkg/composer/imported/testdata/category.golden
+++ b/pkg/composer/imported/testdata/category.golden
@@ -53,6 +53,7 @@ aws_iam_group	Security
 aws_iam_instance_profile	Security
 aws_iam_policy	Security
 aws_iam_role	Security
+aws_iam_role_policy	Security
 aws_iam_role_policy_attachment	Security
 aws_iam_service_linked_role	Security
 aws_iam_user	Security

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -1443,6 +1443,21 @@
       "purpose": "Cloud Control ListResources for AWS::OpenSearchServerless::Collection (cache-miss fallback when RGT prefetch is unavailable)"
     },
     {
+      "service": "opensearchserverless_security_policy",
+      "iam_action": "aoss:GetSecurityPolicy",
+      "purpose": "Cloud Control GetResource for aws_opensearchserverless_security_policy delegates to aoss:GetSecurityPolicy"
+    },
+    {
+      "service": "opensearchserverless_security_policy",
+      "iam_action": "aoss:ListSecurityPolicies",
+      "purpose": "SDKLister enumeration: walk OSS security policies per type (encryption / network) — CC ListResources unsupported for AWS::OpenSearchServerless::SecurityPolicy"
+    },
+    {
+      "service": "opensearchserverless_security_policy",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::OpenSearchServerless::SecurityPolicy (#466 SDKLister branch)"
+    },
+    {
       "service": "resource_explorer_2",
       "iam_action": "resource-explorer-2:Search",
       "purpose": "broad enumeration of unsupported resource types (--include-unsupported, gap #6)"

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -1403,6 +1403,21 @@
       "purpose": "Cloud Control GetResource delegate for the Tags property"
     },
     {
+      "service": "opensearchserverless_access_policy",
+      "iam_action": "aoss:GetAccessPolicy",
+      "purpose": "Cloud Control GetResource for aws_opensearchserverless_access_policy delegates to aoss:GetAccessPolicy"
+    },
+    {
+      "service": "opensearchserverless_access_policy",
+      "iam_action": "aoss:ListAccessPolicies",
+      "purpose": "SDKLister enumeration: walk OSS access policies per type (CC ListResources unsupported for AWS::OpenSearchServerless::AccessPolicy)"
+    },
+    {
+      "service": "opensearchserverless_access_policy",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::OpenSearchServerless::AccessPolicy (#466 SDKLister branch)"
+    },
+    {
       "service": "opensearchserverless_collection",
       "iam_action": "aoss:BatchGetCollection",
       "purpose": "DiscoverByID: fetch collection details by id"

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -1848,6 +1848,36 @@
       "purpose": "list per-region VPC endpoints; skip State=deleted/deleting tombstones (server-side tag:Project filter when project is set; tags inline)"
     },
     {
+      "service": "vpc_security_group_egress_rule",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::EC2::SecurityGroupEgress (#460 unified discoverer; primary identifier sgr-XXXXX)"
+    },
+    {
+      "service": "vpc_security_group_egress_rule",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::EC2::SecurityGroupEgress (SkipProjectTagFilter=true; CFN schema has no Tags property so the RGT cache short-circuit is bypassed)"
+    },
+    {
+      "service": "vpc_security_group_egress_rule",
+      "iam_action": "ec2:DescribeSecurityGroupRules",
+      "purpose": "Cloud Control delegate for GetResource / ListResources on AWS::EC2::SecurityGroupEgress"
+    },
+    {
+      "service": "vpc_security_group_ingress_rule",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::EC2::SecurityGroupIngress (#460 unified discoverer; primary identifier sgr-XXXXX)"
+    },
+    {
+      "service": "vpc_security_group_ingress_rule",
+      "iam_action": "cloudcontrol:ListResources",
+      "purpose": "Cloud Control ListResources for AWS::EC2::SecurityGroupIngress (SkipProjectTagFilter=true; CFN schema has no Tags property so the RGT cache short-circuit is bypassed)"
+    },
+    {
+      "service": "vpc_security_group_ingress_rule",
+      "iam_action": "ec2:DescribeSecurityGroupRules",
+      "purpose": "Cloud Control delegate for GetResource / ListResources on AWS::EC2::SecurityGroupIngress"
+    },
+    {
       "service": "wafv2_web_acl",
       "iam_action": "cloudcontrol:GetResource",
       "purpose": "Cloud Control GetResource for AWS::WAFv2::WebACL (#412 ParentLister branch)"

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -83,6 +83,16 @@
       "purpose": "Cloud Control ListResources for AWS::ApiGatewayV2::Api (cache-miss fallback when RGT prefetch is unavailable)"
     },
     {
+      "service": "apigatewayv2_api_mapping",
+      "iam_action": "apigateway:GET",
+      "purpose": "Cloud Control GetResource for aws_apigatewayv2_api_mapping delegates to apigateway:GET (GET /domainnames/*/apimappings/*); also covers SDKLister enumeration (GET /domainnames, GET /domainnames/*/apimappings) — CC ListResources unsupported for AWS::ApiGatewayV2::ApiMapping"
+    },
+    {
+      "service": "apigatewayv2_api_mapping",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::ApiGatewayV2::ApiMapping (#466 SDKLister branch)"
+    },
+    {
       "service": "apigatewayv2_authorizer",
       "iam_action": "apigateway:GET",
       "purpose": "Cloud Control GetResource for aws_apigatewayv2_authorizer delegates to apigateway:GET (GET /apis/*/authorizers/*); also covers parent enumeration (GET /apis) to fan ListResources out per ApiId"

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -968,6 +968,26 @@
       "purpose": "list IAM roles (paginated)"
     },
     {
+      "service": "iam_role_policy",
+      "iam_action": "cloudcontrol:GetResource",
+      "purpose": "Cloud Control GetResource for AWS::IAM::RolePolicy (#466 SDKLister branch — global service)"
+    },
+    {
+      "service": "iam_role_policy",
+      "iam_action": "iam:GetRolePolicy",
+      "purpose": "Cloud Control GetResource for aws_iam_role_policy delegates to iam:GetRolePolicy"
+    },
+    {
+      "service": "iam_role_policy",
+      "iam_action": "iam:ListRolePolicies",
+      "purpose": "SDKLister enumeration: per-role inline-policy fan-out (CC ListResources unsupported for AWS::IAM::RolePolicy)"
+    },
+    {
+      "service": "iam_role_policy",
+      "iam_action": "iam:ListRoles",
+      "purpose": "SDKLister enumeration: walk IAM roles to seed the per-role inline-policy fan-out (CC ListResources unsupported)"
+    },
+    {
       "service": "iam_role_policy_attachment",
       "iam_action": "iam:ListAttachedRolePolicies",
       "purpose": "SDK-only sub-resource discoverer (#14k2 / #456): per-role ListAttachedRolePolicies; one TF resource per (role_name, policy_arn) attached managed-policy pair; multi-emit FetchItems"

--- a/pkg/insideout-import/permissions/permissions_test.go
+++ b/pkg/insideout-import/permissions/permissions_test.go
@@ -70,6 +70,7 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_iam_instance_profile":                           "iam_instance_profile",
 	"aws_iam_policy":                                     "iam_policy",
 	"aws_iam_role":                                       "iam_role",
+	"aws_iam_role_policy":                                "iam_role_policy",
 	"aws_iam_role_policy_attachment":                     "iam_role_policy_attachment",
 	"aws_iam_service_linked_role":                        "iam_service_linked_role",
 	"aws_iam_user":                                       "iam_user",

--- a/pkg/insideout-import/permissions/permissions_test.go
+++ b/pkg/insideout-import/permissions/permissions_test.go
@@ -94,6 +94,7 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_network_acl":                                    "network_acl",
 	"aws_network_interface":                              "network_interface",
 	"aws_opensearch_domain":                              "opensearch_domain",
+	"aws_opensearchserverless_access_policy":             "opensearchserverless_access_policy",
 	"aws_opensearchserverless_collection":                "opensearchserverless_collection",
 	"aws_resourceexplorer2_index":                        "resourceexplorer2_index",
 	"aws_resourceexplorer2_view":                         "resourceexplorer2_view",

--- a/pkg/insideout-import/permissions/permissions_test.go
+++ b/pkg/insideout-import/permissions/permissions_test.go
@@ -96,6 +96,7 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_opensearch_domain":                              "opensearch_domain",
 	"aws_opensearchserverless_access_policy":             "opensearchserverless_access_policy",
 	"aws_opensearchserverless_collection":                "opensearchserverless_collection",
+	"aws_opensearchserverless_security_policy":           "opensearchserverless_security_policy",
 	"aws_resourceexplorer2_index":                        "resourceexplorer2_index",
 	"aws_resourceexplorer2_view":                         "resourceexplorer2_view",
 	"aws_route53_zone":                                   "route53_zone",

--- a/pkg/insideout-import/permissions/permissions_test.go
+++ b/pkg/insideout-import/permissions/permissions_test.go
@@ -22,6 +22,7 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_api_gateway_resource":                           "api_gateway_resource",
 	"aws_api_gateway_stage":                              "api_gateway_stage",
 	"aws_apigatewayv2_api":                               "apigatewayv2_api",
+	"aws_apigatewayv2_api_mapping":                       "apigatewayv2_api_mapping",
 	"aws_apigatewayv2_authorizer":                        "apigatewayv2_authorizer",
 	"aws_apigatewayv2_domain_name":                       "apigatewayv2_domain_name",
 	"aws_apigatewayv2_integration":                       "apigatewayv2_integration",

--- a/pkg/insideout-import/permissions/permissions_test.go
+++ b/pkg/insideout-import/permissions/permissions_test.go
@@ -120,6 +120,8 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_vpc":                                            "vpc",
 	"aws_vpc_dhcp_options":                               "vpc_dhcp_options",
 	"aws_vpc_endpoint":                                   "vpc_endpoint",
+	"aws_vpc_security_group_egress_rule":                 "vpc_security_group_egress_rule",
+	"aws_vpc_security_group_ingress_rule":                "vpc_security_group_ingress_rule",
 	"aws_wafv2_web_acl":                                  "wafv2_web_acl",
 	"aws_wafv2_web_acl_association":                      "wafv2_web_acl_association",
 }

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -126,6 +126,8 @@ var awsTypes = []string{
 	"aws_vpc",
 	"aws_vpc_dhcp_options",
 	"aws_vpc_endpoint",
+	"aws_vpc_security_group_egress_rule",
+	"aws_vpc_security_group_ingress_rule",
 	"aws_wafv2_web_acl",
 	"aws_wafv2_web_acl_association",
 }

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -76,6 +76,7 @@ var awsTypes = []string{
 	"aws_iam_instance_profile",
 	"aws_iam_policy",
 	"aws_iam_role",
+	"aws_iam_role_policy",
 	"aws_iam_role_policy_attachment",
 	"aws_iam_service_linked_role",
 	"aws_iam_user",

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -102,6 +102,7 @@ var awsTypes = []string{
 	"aws_opensearch_domain",
 	"aws_opensearchserverless_access_policy",
 	"aws_opensearchserverless_collection",
+	"aws_opensearchserverless_security_policy",
 	"aws_resourceexplorer2_index",
 	"aws_resourceexplorer2_view",
 	"aws_route53_zone",

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -28,6 +28,7 @@ var awsTypes = []string{
 	"aws_api_gateway_resource",
 	"aws_api_gateway_stage",
 	"aws_apigatewayv2_api",
+	"aws_apigatewayv2_api_mapping",
 	"aws_apigatewayv2_authorizer",
 	"aws_apigatewayv2_domain_name",
 	"aws_apigatewayv2_integration",

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -100,6 +100,7 @@ var awsTypes = []string{
 	"aws_network_acl",
 	"aws_network_interface",
 	"aws_opensearch_domain",
+	"aws_opensearchserverless_access_policy",
 	"aws_opensearchserverless_collection",
 	"aws_resourceexplorer2_index",
 	"aws_resourceexplorer2_view",

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -95,6 +95,7 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_network_acl",
 		"aws_network_interface",
 		"aws_opensearch_domain",
+		"aws_opensearchserverless_access_policy",
 		"aws_opensearchserverless_collection",
 		"aws_resourceexplorer2_index",
 		"aws_resourceexplorer2_view",

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -71,6 +71,7 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_iam_instance_profile",
 		"aws_iam_policy",
 		"aws_iam_role",
+		"aws_iam_role_policy",
 		"aws_iam_role_policy_attachment",
 		"aws_iam_service_linked_role",
 		"aws_iam_user",

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -121,6 +121,8 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_vpc",
 		"aws_vpc_dhcp_options",
 		"aws_vpc_endpoint",
+		"aws_vpc_security_group_egress_rule",
+		"aws_vpc_security_group_ingress_rule",
 		"aws_wafv2_web_acl",
 		"aws_wafv2_web_acl_association",
 	}

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -97,6 +97,7 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_opensearch_domain",
 		"aws_opensearchserverless_access_policy",
 		"aws_opensearchserverless_collection",
+		"aws_opensearchserverless_security_policy",
 		"aws_resourceexplorer2_index",
 		"aws_resourceexplorer2_view",
 		"aws_route53_zone",

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -23,6 +23,7 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_api_gateway_resource",
 		"aws_api_gateway_stage",
 		"aws_apigatewayv2_api",
+		"aws_apigatewayv2_api_mapping",
 		"aws_apigatewayv2_authorizer",
 		"aws_apigatewayv2_domain_name",
 		"aws_apigatewayv2_integration",


### PR DESCRIPTION
Closes #466. Closes #460.

## Summary

- **Phase A (4 commits)**: Reinstates 4 of the 6 AWS types dropped from #465 — those whose CC `ListResources` returns `UnsupportedActionException` but CC `GetResource` works. Each registered via `cloudControlConfig.SDKLister` (Bundle 14b precedent, `aws_iam_service_linked_role`): native-SDK enumerator emits compound identifiers; framework's per-item CC GetResource fan-out handles the rest.
  - `aws_iam_role_policy` — CC `<PolicyName>\|<RoleName>` → TF `<role>:<policy>` (swap)
  - `aws_opensearchserverless_access_policy` — CC `<Type>\|<Name>` → TF `<name>/<type>` (swap)
  - `aws_opensearchserverless_security_policy` — same shape as above
  - `aws_apigatewayv2_api_mapping` — CC `<ApiMappingId>\|<DomainName>` → TF `<id>/<domain>` (first-pipe-only)
- **Phase B (2 commits)**: Closes #460 — migrates `aws/ec2/main.tf` from legacy `aws_security_group_rule` (synthetic `sgrule-<hash>` ID, not CFN-modelable) to `aws_vpc_security_group_ingress_rule` (real `sgr-XXXXX` ID, CC-feasible). Registers `aws_vpc_security_group_{ingress,egress}_rule` for discovery via standard CC pattern.
- **Coverage**: closes the last in-preset AWS discovery gap → 70/70 = 100% in-preset registered.

## Test plan

- [x] `go test ./... -race` — 982 passed in 8 packages (changed pkgs)
- [x] `terraform fmt -check -recursive` + 4 lint scripts all PASS
- [x] `terraform validate` on `aws/ec2` — Success
- [x] Live smoke on AWS cust2 (`141812438321 / io-h3a-v495cjgt / us-east-1`) — exit 0, 0 rgt-warns, 0 UnsupportedAction for new types; 10 ingress + 8 egress SG rule emissions, 5 iam_role_policy + 2 oss_security_policy emissions, real CC IDs surfaced

## Review notes

- /review findings: P0 0, P1 0, P2 2 (both deferred — meaningful semantic changes), P3 trivial doc-comment fixed inline
- qa-professor findings: P1 0; P2 6 — all addressed inline in commit 7 (test tighteners)
- All new SDKLister tests record + assert pagination markers by position; sentinel errors checked via `errors.Is`; #255 contract pinned with `got != nil` AND `len == 0`

## Pre-flight verified out-of-scope (separate follow-up)

Two of the 6 originally-dropped types remain CC-infeasible — `aws cloudcontrol get-resource` pre-flight returns:

- `AWS::Bedrock::ModelInvocationLoggingConfiguration` → `TypeNotFoundException` (CC doesn't know this type at all; neither LIST nor GET supported)
- `AWS::ServiceDiscovery::PrivateDnsNamespace` → `UnsupportedActionException` on **READ** (not just LIST)

These need a non-CC discoverer pattern (native SDK end-to-end, like the gcpdiscover Bundle 11 inspector) — separate branch/PR.

## Deferred (out of scope; tracked for follow-up)

- **Framework: `SkipProjectTagFilter` third state.** New SG rule types are CFN-untaggable but AWS-API-taggable + RGT-surfaced. The current binary flag forces account-wide scan; a third state ("use RGT cache, bypass CC post-fetch tag filter") would let these project-scope correctly. Existing trade-off documented at `cloudcontrol_discoverer.go:108-111`.
- **SDKLister inner-loop error soft-fail.** Today, a per-role / per-domain SDK error in `listIAMRolePolicyIdentifiers` / `listAPIGatewayV2ApiMappingIdentifiers` aborts the whole region. Should soft-fail via ServiceWarn and continue (matches per-item GetResource posture). Test comment now pins the current contract explicitly.
- **Bedrock + ServiceDiscovery PrivateDnsNamespace via non-CC discoverer.** Picking up in a stacked branch.