### PR TITLE
AWS discovery: non-CC discoverers for bedrock logging + private DNS namespaces

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -149,6 +149,15 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 		"aws_bedrock_model_invocation_logging_configuration": newBedrockModelInvocationLoggingConfigurationDiscoverer(cfg, maxConcurrency),
 		"aws_resourceexplorer2_index":                        newResourceExplorer2IndexDiscoverer(cfg, maxConcurrency),
 		"aws_resourceexplorer2_view":                         newResourceExplorer2ViewDiscoverer(cfg, maxConcurrency),
+		// Bucket C non-CC (#466 follow-up): Cloud Control returns
+		// UnsupportedActionException on READ for
+		// AWS::ServiceDiscovery::PrivateDnsNamespace; neither the
+		// unified cloudControlDiscoverer nor SDKLister can resolve
+		// the type. Native servicediscovery SDK end-to-end with a
+		// Route53 GetHostedZone hop to recover the VPC id (TF
+		// import format is "<namespace_id>:<vpc_id>"; the
+		// servicediscovery SDK never surfaces VpcId).
+		"aws_service_discovery_private_dns_namespace": newServiceDiscoveryPrivateDNSNamespaceDiscoverer(cfg, maxConcurrency),
 	}
 	// Cloud Control-routed types (#406): each entry in
 	// cloudControlTypeConfigs becomes one cloudControlDiscoverer
@@ -195,6 +204,7 @@ var serviceSlugByTFType = map[string]string{
 	"aws_bedrock_model_invocation_logging_configuration": "bedrock_model_invocation_logging_configuration",
 	"aws_resourceexplorer2_index":                        "resourceexplorer2_index",
 	"aws_resourceexplorer2_view":                         "resourceexplorer2_view",
+	"aws_service_discovery_private_dns_namespace":        "service_discovery_private_dns_namespace",
 }
 
 // ServiceSlug returns the progress-event slug for a Terraform resource

--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -137,10 +137,18 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 	// quirk, #336). Everything else is registered below via the
 	// cloudControlTypeConfigs loop.
 	byType := map[string]Discoverer{
-		"aws_apigatewayv2_stage":      newAPIGatewayV2StageDiscoverer(cfg, maxConcurrency),
-		"aws_bedrock_guardrail":       newBedrockGuardrailDiscoverer(cfg, maxConcurrency),
-		"aws_resourceexplorer2_index": newResourceExplorer2IndexDiscoverer(cfg, maxConcurrency),
-		"aws_resourceexplorer2_view":  newResourceExplorer2ViewDiscoverer(cfg, maxConcurrency),
+		"aws_apigatewayv2_stage": newAPIGatewayV2StageDiscoverer(cfg, maxConcurrency),
+		"aws_bedrock_guardrail":  newBedrockGuardrailDiscoverer(cfg, maxConcurrency),
+		// Bucket C non-CC (#466 follow-up): Cloud Control does not
+		// know the CFN type
+		// AWS::Bedrock::ModelInvocationLoggingConfiguration
+		// (TypeNotFoundException on `cloudcontrol get-resource`).
+		// Native bedrock SDK end-to-end is the only working path;
+		// the framework's per-item fan-out through CC GetResource
+		// cannot rescue it.
+		"aws_bedrock_model_invocation_logging_configuration": newBedrockModelInvocationLoggingConfigurationDiscoverer(cfg, maxConcurrency),
+		"aws_resourceexplorer2_index":                        newResourceExplorer2IndexDiscoverer(cfg, maxConcurrency),
+		"aws_resourceexplorer2_view":                         newResourceExplorer2ViewDiscoverer(cfg, maxConcurrency),
 	}
 	// Cloud Control-routed types (#406): each entry in
 	// cloudControlTypeConfigs becomes one cloudControlDiscoverer
@@ -182,10 +190,11 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 var serviceSlugByTFType = map[string]string{
 	// Bucket C — hand-rolled. Slugs must match the per-discoverer
 	// ServiceStart/Finish strings inside each *.go file.
-	"aws_apigatewayv2_stage":      "apigatewayv2_stage",
-	"aws_bedrock_guardrail":       "bedrock_guardrail",
-	"aws_resourceexplorer2_index": "resourceexplorer2_index",
-	"aws_resourceexplorer2_view":  "resourceexplorer2_view",
+	"aws_apigatewayv2_stage": "apigatewayv2_stage",
+	"aws_bedrock_guardrail":  "bedrock_guardrail",
+	"aws_bedrock_model_invocation_logging_configuration": "bedrock_model_invocation_logging_configuration",
+	"aws_resourceexplorer2_index":                        "resourceexplorer2_index",
+	"aws_resourceexplorer2_view":                         "resourceexplorer2_view",
 }
 
 // ServiceSlug returns the progress-event slug for a Terraform resource

--- a/cmd/insideout-import/awsdiscover/bedrock_model_invocation_logging_configuration.go
+++ b/cmd/insideout-import/awsdiscover/bedrock_model_invocation_logging_configuration.go
@@ -1,0 +1,229 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
+	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// Bucket C, hand-rolled (#466 follow-up): Cloud Control returns
+// TypeNotFoundException for AWS::Bedrock::ModelInvocationLoggingConfiguration
+// on `aws cloudcontrol get-resource`; the CFN registry does not know the
+// type at all on cust2. The native bedrock SDK is the only working path.
+//
+// The TF type aws_bedrock_model_invocation_logging_configuration is a
+// per-region account singleton: each region has zero-or-one configuration.
+// Terraform's import id is the region string per the v6.x provider docs
+// (website/docs/r/bedrock_model_invocation_logging_configuration.html.markdown).
+const (
+	bedrockModelInvocationLoggingConfigurationTFType = "aws_bedrock_model_invocation_logging_configuration"
+	bedrockModelInvocationLoggingConfigurationSlug   = "bedrock_model_invocation_logging_configuration"
+)
+
+// bedrockModelInvocationLoggingConfigurationClient is the narrow subset of
+// the bedrock control-plane SDK the singleton discoverer uses.
+// GetModelInvocationLoggingConfiguration is unique among bedrock APIs in
+// that it takes no input — the API key is implicit (the account + region
+// resolved by the SDK client).
+type bedrockModelInvocationLoggingConfigurationClient interface {
+	GetModelInvocationLoggingConfiguration(ctx context.Context, in *bedrock.GetModelInvocationLoggingConfigurationInput, opts ...func(*bedrock.Options)) (*bedrock.GetModelInvocationLoggingConfigurationOutput, error)
+}
+
+type bedrockModelInvocationLoggingConfigurationDiscoverer struct {
+	new func(region string) bedrockModelInvocationLoggingConfigurationClient
+	// maxConcurrency is kept for constructor-shape parity with the other
+	// hand-rolled discoverers but unused: this discoverer issues exactly
+	// one SDK call per region with no per-item fan-out.
+	maxConcurrency int
+}
+
+func newBedrockModelInvocationLoggingConfigurationDiscoverer(cfg aws.Config, maxConcurrency int) Discoverer {
+	if maxConcurrency <= 0 {
+		maxConcurrency = DefaultMaxConcurrency
+	}
+	return &bedrockModelInvocationLoggingConfigurationDiscoverer{
+		new: func(region string) bedrockModelInvocationLoggingConfigurationClient {
+			return bedrock.NewFromConfig(cfg, func(o *bedrock.Options) {
+				if region != "" {
+					o.Region = region
+				}
+			})
+		},
+		maxConcurrency: maxConcurrency,
+	}
+}
+
+func (d *bedrockModelInvocationLoggingConfigurationDiscoverer) ResourceType() string {
+	return bedrockModelInvocationLoggingConfigurationTFType
+}
+
+// Discover walks args.Regions and calls GetModelInvocationLoggingConfiguration
+// once per region. Three response shapes are possible against the live API:
+//
+//   - 200 OK with non-nil LoggingConfig → configured. Emit ONE
+//     ImportedResource keyed on the region.
+//   - 200 OK with nil LoggingConfig → unconfigured. Emit nothing
+//     (not an error — singleton genuinely absent).
+//   - ResourceNotFoundException → unconfigured. Emit nothing (older
+//     SDK / region behavior may surface absence as a typed not-found
+//     instead of a nil payload).
+//   - Any other error → ServiceWarn + skip the region. Mirrors the
+//     fail-open posture in bedrock_guardrail (transient errors during a
+//     multi-region scan should not abort the whole run).
+//
+// The resource carries no tags (untaggable in AWS provider 6.x — pinned
+// in pkg/composer/imported_provenance.go::untaggableAWS), so this
+// discoverer does not run the post-fetch tag filter and emits an empty
+// (non-nil) Tags map per the #255 contract.
+//
+// The Project tag filter is also skipped — there are no tags to filter
+// on. Operators who scope to one project on a shared account will see
+// the same singleton emitted for every project run; downstream Phase 2
+// merge logic dedupes on Identity.ImportID (the region) so this is
+// load-bearing-correct, not over-emitting.
+func (d *bedrockModelInvocationLoggingConfigurationDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
+	book := addressBook{}
+	const slug = bedrockModelInvocationLoggingConfigurationSlug
+	var imps []imported.ImportedResource
+
+	for _, region := range args.Regions {
+		regionStart := time.Now()
+		args.Emitter.ServiceStart(slug, region)
+		regionCount := 0
+		client := d.new(region)
+
+		out, err := client.GetModelInvocationLoggingConfiguration(ctx, &bedrock.GetModelInvocationLoggingConfigurationInput{})
+		if err != nil {
+			var notFound *bedrocktypes.ResourceNotFoundException
+			if errors.As(err, &notFound) {
+				// Unconfigured (typed not-found shape). Not an error.
+				args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
+				continue
+			}
+			// Any other error: warn and move on. A throttling or
+			// AccessDenied response on one region must not abort the
+			// whole scan — operator can re-run with --regions to retry
+			// once the credential is fixed.
+			args.Emitter.ServiceWarn(slug, region, fmt.Sprintf("GetModelInvocationLoggingConfiguration: %v", err))
+			args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
+			continue
+		}
+		if out.LoggingConfig == nil {
+			// Empty-state shape: success with nil payload. Treat
+			// identical to ResourceNotFoundException — no resource.
+			args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
+			continue
+		}
+
+		// Configured. Build the singleton ImportedResource keyed on
+		// region. NativeIDs surface the downstream resources the
+		// logging config references (log group, S3 bucket) so the
+		// importer wizard can present "this is wired to <log-group>"
+		// without requiring a second discover pass on those types.
+		native := map[string]string{"region": region}
+		lc := out.LoggingConfig
+		if lc.CloudWatchConfig != nil {
+			if lg := aws.ToString(lc.CloudWatchConfig.LogGroupName); lg != "" {
+				native["cloud_watch_log_group_name"] = lg
+			}
+			if roleArn := aws.ToString(lc.CloudWatchConfig.RoleArn); roleArn != "" {
+				native["cloud_watch_role_arn"] = roleArn
+			}
+		}
+		if lc.S3Config != nil {
+			if b := aws.ToString(lc.S3Config.BucketName); b != "" {
+				native["s3_bucket_name"] = b
+			}
+			if p := aws.ToString(lc.S3Config.KeyPrefix); p != "" {
+				native["s3_key_prefix"] = p
+			}
+		}
+
+		nameHint := region + "-bedrock-logging"
+		// Non-nil empty tags map: this resource is untaggable in AWS
+		// provider 6.x, but the #255 JSON-shape contract requires a
+		// non-nil tags map on the wire.
+		tags := map[string]string{}
+		imps = append(imps, makeImportedResource(
+			book,
+			bedrockModelInvocationLoggingConfigurationTFType,
+			nameHint,
+			region,
+			region,
+			args.AccountID,
+			native,
+			tags,
+		))
+		args.Emitter.ItemFound(slug, region, bedrockModelInvocationLoggingConfigurationTFType, region)
+		regionCount++
+		args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
+	}
+	return imps, nil
+}
+
+// DiscoverByID resolves the per-region singleton by region string. The
+// terraform import id is the region itself, so id == region for any
+// well-formed call. Issues one GetModelInvocationLoggingConfiguration
+// call to verify the singleton exists.
+func (d *bedrockModelInvocationLoggingConfigurationDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return imported.ImportedResource{}, fmt.Errorf("bedrock_model_invocation_logging_configuration: empty id: %w", ErrNotSupported)
+	}
+	// The import id IS the region. If the caller passes a different
+	// region argument, the id wins — that's the terraform contract.
+	if strings.ContainsAny(id, " :/,") {
+		return imported.ImportedResource{}, fmt.Errorf("bedrock_model_invocation_logging_configuration: id %q is not a region: %w", id, ErrNotSupported)
+	}
+	target := id
+	client := d.new(target)
+	out, err := client.GetModelInvocationLoggingConfiguration(ctx, &bedrock.GetModelInvocationLoggingConfigurationInput{})
+	if err != nil {
+		var notFound *bedrocktypes.ResourceNotFoundException
+		if errors.As(err, &notFound) {
+			return imported.ImportedResource{}, fmt.Errorf("aws_bedrock_model_invocation_logging_configuration %q: %w", target, ErrNotFound)
+		}
+		return imported.ImportedResource{}, fmt.Errorf("GetModelInvocationLoggingConfiguration: %w", err)
+	}
+	if out.LoggingConfig == nil {
+		return imported.ImportedResource{}, fmt.Errorf("aws_bedrock_model_invocation_logging_configuration %q: %w", target, ErrNotFound)
+	}
+	native := map[string]string{"region": target}
+	lc := out.LoggingConfig
+	if lc.CloudWatchConfig != nil {
+		if lg := aws.ToString(lc.CloudWatchConfig.LogGroupName); lg != "" {
+			native["cloud_watch_log_group_name"] = lg
+		}
+		if roleArn := aws.ToString(lc.CloudWatchConfig.RoleArn); roleArn != "" {
+			native["cloud_watch_role_arn"] = roleArn
+		}
+	}
+	if lc.S3Config != nil {
+		if b := aws.ToString(lc.S3Config.BucketName); b != "" {
+			native["s3_bucket_name"] = b
+		}
+		if p := aws.ToString(lc.S3Config.KeyPrefix); p != "" {
+			native["s3_key_prefix"] = p
+		}
+	}
+	nameHint := target + "-bedrock-logging"
+	return makeImportedResource(
+		addressBook{},
+		bedrockModelInvocationLoggingConfigurationTFType,
+		nameHint,
+		target,
+		target,
+		accountID,
+		native,
+		nil,
+	), nil
+}

--- a/cmd/insideout-import/awsdiscover/bedrock_model_invocation_logging_configuration.go
+++ b/cmd/insideout-import/awsdiscover/bedrock_model_invocation_logging_configuration.go
@@ -216,6 +216,8 @@ func (d *bedrockModelInvocationLoggingConfigurationDiscoverer) DiscoverByID(ctx 
 		}
 	}
 	nameHint := target + "-bedrock-logging"
+	// Tags: non-nil empty map mirrors the Discover path's #255 contract
+	// for the dep-chase consumer.
 	return makeImportedResource(
 		addressBook{},
 		bedrockModelInvocationLoggingConfigurationTFType,
@@ -224,6 +226,6 @@ func (d *bedrockModelInvocationLoggingConfigurationDiscoverer) DiscoverByID(ctx 
 		target,
 		accountID,
 		native,
-		nil,
+		map[string]string{},
 	), nil
 }

--- a/cmd/insideout-import/awsdiscover/bedrock_model_invocation_logging_configuration_test.go
+++ b/cmd/insideout-import/awsdiscover/bedrock_model_invocation_logging_configuration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -95,6 +96,13 @@ func TestBedrockMILCDiscover_ConfiguredEmitsOnePerRegion(t *testing.T) {
 		}
 		if ir.Identity.Tags == nil {
 			t.Error("Tags is nil; must be non-nil empty per #255 JSON-shape contract")
+		}
+		// NameHint format pin: a regression changing the synthesis
+		// (e.g. region alone, or a different suffix) would silently
+		// re-key every downstream consumer addressing this singleton.
+		wantName := ir.Identity.Region + "-bedrock-logging"
+		if ir.Identity.NameHint != wantName {
+			t.Errorf("NameHint=%q, want %q (synthesis pin)", ir.Identity.NameHint, wantName)
 		}
 		if ir.Identity.NativeIDs["region"] != ir.Identity.Region {
 			t.Errorf("NativeIDs[region]=%q, want %q", ir.Identity.NativeIDs["region"], ir.Identity.Region)
@@ -214,6 +222,58 @@ func TestBedrockMILCDiscover_OtherErrorWarnsAndContinues(t *testing.T) {
 	}
 	if warns[0].Service != bedrockModelInvocationLoggingConfigurationSlug {
 		t.Errorf("warn.service=%q, want %s", warns[0].Service, bedrockModelInvocationLoggingConfigurationSlug)
+	}
+	// Warn message must preserve the underlying SDK error detail —
+	// a regression that swallowed the cause in a generic message
+	// would survive a presence-only check.
+	if !strings.Contains(warns[0].Message, "AccessDenied") {
+		t.Errorf("warn message=%q, want underlying AccessDenied detail preserved", warns[0].Message)
+	}
+	// ServiceFinish must still close the bracket on the warn-and-continue
+	// path; otherwise per-region timing telemetry corrupts.
+	var finishes int
+	for _, e := range rec.snapshot() {
+		if e.Kind == "service_finish" && e.Region == "us-east-1" {
+			finishes++
+		}
+	}
+	if finishes != 1 {
+		t.Errorf("us-east-1 service_finish count=%d on warn path, want 1", finishes)
+	}
+}
+
+// TestBedrockMILCDiscover_ResourceNotFoundEmitsServiceFinish pins that
+// the typed RNF branch closes the per-region bracket (SUT line 109).
+// A regression that returned early without ServiceFinish would corrupt
+// timing telemetry; previously only the configured + nil-payload
+// paths were covered.
+func TestBedrockMILCDiscover_ResourceNotFoundEmitsServiceFinish(t *testing.T) {
+	t.Parallel()
+	fake := &fakeBedrockMILCClient{
+		err:      &bedrocktypes.ResourceNotFoundException{Message: aws.String("no config")},
+		regionID: "us-east-1",
+	}
+	d := &bedrockModelInvocationLoggingConfigurationDiscoverer{
+		new: func(_ string) bedrockModelInvocationLoggingConfigurationClient { return fake },
+	}
+	rec := &recordingEmitter{}
+	_, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions: []string{"us-east-1"}, AccountID: "123", Emitter: rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var starts, finishes int
+	for _, e := range rec.snapshot() {
+		switch e.Kind {
+		case "service_start":
+			starts++
+		case "service_finish":
+			finishes++
+		}
+	}
+	if starts != 1 || finishes != 1 {
+		t.Errorf("RNF path: starts=%d finishes=%d, want 1 each", starts, finishes)
 	}
 }
 
@@ -336,6 +396,19 @@ func TestBedrockMILCDiscoverByID_AcceptsRegion(t *testing.T) {
 	if got.Identity.NativeIDs["s3_bucket_name"] != "b" {
 		t.Errorf("NativeIDs[s3_bucket_name]=%q", got.Identity.NativeIDs["s3_bucket_name"])
 	}
+	// #255 JSON-shape parity with Discover: DiscoverByID must also
+	// emit a non-nil empty Tags map for the dep-chase consumer (just
+	// fixed in this PR to be uniform with the Discover path).
+	if got.Identity.Tags == nil {
+		t.Fatal("Tags is nil on DiscoverByID; must be non-nil empty per #255 (parity with Discover)")
+	}
+	b, err := json.Marshal(got.Identity.Tags)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "{}" {
+		t.Errorf("json.Marshal(Tags)=%q, want %q", string(b), "{}")
+	}
 }
 
 func TestBedrockMILCDiscoverByID_NotFoundShapes(t *testing.T) {
@@ -348,7 +421,6 @@ func TestBedrockMILCDiscoverByID_NotFoundShapes(t *testing.T) {
 		{"nil_payload", &fakeBedrockMILCClient{out: &bedrock.GetModelInvocationLoggingConfigurationOutput{LoggingConfig: nil}}},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			d := &bedrockModelInvocationLoggingConfigurationDiscoverer{

--- a/cmd/insideout-import/awsdiscover/bedrock_model_invocation_logging_configuration_test.go
+++ b/cmd/insideout-import/awsdiscover/bedrock_model_invocation_logging_configuration_test.go
@@ -1,0 +1,382 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
+	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
+)
+
+type fakeBedrockMILCClient struct {
+	mu       sync.Mutex
+	calls    []string // region order across multiple-instance fakes via the per-region constructor
+	out      *bedrock.GetModelInvocationLoggingConfigurationOutput
+	err      error
+	regionID string
+}
+
+func (f *fakeBedrockMILCClient) GetModelInvocationLoggingConfiguration(_ context.Context, _ *bedrock.GetModelInvocationLoggingConfigurationInput, _ ...func(*bedrock.Options)) (*bedrock.GetModelInvocationLoggingConfigurationOutput, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, f.regionID)
+	f.mu.Unlock()
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.out, nil
+}
+
+// configuredLoggingConfig returns a non-nil LoggingConfig matching the
+// shape the live API returns when the singleton is set: typically both
+// CloudWatch and S3 destinations are populated.
+func configuredLoggingConfig(logGroup, roleArn, bucket, prefix string) *bedrocktypes.LoggingConfig {
+	out := &bedrocktypes.LoggingConfig{}
+	if logGroup != "" || roleArn != "" {
+		out.CloudWatchConfig = &bedrocktypes.CloudWatchConfig{
+			LogGroupName: aws.String(logGroup),
+			RoleArn:      aws.String(roleArn),
+		}
+	}
+	if bucket != "" || prefix != "" {
+		out.S3Config = &bedrocktypes.S3Config{
+			BucketName: aws.String(bucket),
+			KeyPrefix:  aws.String(prefix),
+		}
+	}
+	return out
+}
+
+// TestBedrockMILCDiscover_ConfiguredEmitsOnePerRegion pins the happy path:
+// each region whose GetModelInvocationLoggingConfiguration response carries
+// a non-nil LoggingConfig emits exactly one ImportedResource keyed by region,
+// and the NativeIDs surface the wired CloudWatch + S3 destinations.
+func TestBedrockMILCDiscover_ConfiguredEmitsOnePerRegion(t *testing.T) {
+	t.Parallel()
+	fakes := map[string]*fakeBedrockMILCClient{
+		"us-east-1": {
+			out: &bedrock.GetModelInvocationLoggingConfigurationOutput{
+				LoggingConfig: configuredLoggingConfig("/aws/bedrock/invocations", "arn:aws:iam::123:role/bedrock-logs", "my-logs-bucket", "bedrock/"),
+			},
+			regionID: "us-east-1",
+		},
+		"eu-west-1": {
+			out: &bedrock.GetModelInvocationLoggingConfigurationOutput{
+				LoggingConfig: configuredLoggingConfig("/aws/bedrock/invocations-eu", "", "", ""),
+			},
+			regionID: "eu-west-1",
+		},
+	}
+	d := &bedrockModelInvocationLoggingConfigurationDiscoverer{
+		new: func(region string) bedrockModelInvocationLoggingConfigurationClient { return fakes[region] },
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (one per configured region)", len(got))
+	}
+	byRegion := map[string]int{}
+	for _, ir := range got {
+		byRegion[ir.Identity.Region]++
+		if ir.Identity.ImportID != ir.Identity.Region {
+			t.Errorf("ImportID=%q, want %q (TF import id is the region string)", ir.Identity.ImportID, ir.Identity.Region)
+		}
+		if ir.Identity.Type != bedrockModelInvocationLoggingConfigurationTFType {
+			t.Errorf("Type=%q", ir.Identity.Type)
+		}
+		if ir.Identity.Tags == nil {
+			t.Error("Tags is nil; must be non-nil empty per #255 JSON-shape contract")
+		}
+		if ir.Identity.NativeIDs["region"] != ir.Identity.Region {
+			t.Errorf("NativeIDs[region]=%q, want %q", ir.Identity.NativeIDs["region"], ir.Identity.Region)
+		}
+	}
+	for _, region := range []string{"us-east-1", "eu-west-1"} {
+		if byRegion[region] != 1 {
+			t.Errorf("region=%s: got %d imps, want 1", region, byRegion[region])
+		}
+	}
+
+	// us-east-1 had S3+CW; verify both NativeIDs populated.
+	for _, ir := range got {
+		if ir.Identity.Region == "us-east-1" {
+			if ir.Identity.NativeIDs["cloud_watch_log_group_name"] != "/aws/bedrock/invocations" {
+				t.Errorf("cloud_watch_log_group_name=%q", ir.Identity.NativeIDs["cloud_watch_log_group_name"])
+			}
+			if ir.Identity.NativeIDs["s3_bucket_name"] != "my-logs-bucket" {
+				t.Errorf("s3_bucket_name=%q", ir.Identity.NativeIDs["s3_bucket_name"])
+			}
+		}
+	}
+}
+
+// TestBedrockMILCDiscover_NilLoggingConfigEmitsNothing pins the
+// "unconfigured" empty-state contract: a 200 OK with LoggingConfig == nil
+// must NOT emit a resource — the singleton genuinely doesn't exist in
+// that region. Mirrors the SDK behavior observed against live accounts
+// where no model-invocation logging has been turned on.
+func TestBedrockMILCDiscover_NilLoggingConfigEmitsNothing(t *testing.T) {
+	t.Parallel()
+	fake := &fakeBedrockMILCClient{
+		out:      &bedrock.GetModelInvocationLoggingConfigurationOutput{LoggingConfig: nil},
+		regionID: "us-east-1",
+	}
+	d := &bedrockModelInvocationLoggingConfigurationDiscoverer{
+		new: func(_ string) bedrockModelInvocationLoggingConfigurationClient { return fake },
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("len=%d, want 0 (LoggingConfig=nil means unconfigured)", len(got))
+	}
+}
+
+// TestBedrockMILCDiscover_ResourceNotFoundEmitsNothing pins the typed
+// not-found branch: bedrock SDK may return ResourceNotFoundException
+// instead of a nil payload for the empty state in some
+// region/version combos. Both code paths must collapse to "no resource."
+func TestBedrockMILCDiscover_ResourceNotFoundEmitsNothing(t *testing.T) {
+	t.Parallel()
+	fake := &fakeBedrockMILCClient{
+		err:      &bedrocktypes.ResourceNotFoundException{Message: aws.String("no config")},
+		regionID: "us-east-1",
+	}
+	d := &bedrockModelInvocationLoggingConfigurationDiscoverer{
+		new: func(_ string) bedrockModelInvocationLoggingConfigurationClient { return fake },
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("len=%d, want 0 (RNF is the unconfigured shape)", len(got))
+	}
+}
+
+// TestBedrockMILCDiscover_OtherErrorWarnsAndContinues pins the fail-open
+// posture: a non-RNF error against one region must not abort the whole
+// multi-region scan. The error surfaces as ServiceWarn so the operator
+// sees what went wrong without losing the rest of the discover output.
+func TestBedrockMILCDiscover_OtherErrorWarnsAndContinues(t *testing.T) {
+	t.Parallel()
+	fakes := map[string]*fakeBedrockMILCClient{
+		"us-east-1": {err: errors.New("AccessDenied"), regionID: "us-east-1"},
+		"eu-west-1": {
+			out: &bedrock.GetModelInvocationLoggingConfigurationOutput{
+				LoggingConfig: configuredLoggingConfig("/aws/bedrock/eu", "", "", ""),
+			},
+			regionID: "eu-west-1",
+		},
+	}
+	d := &bedrockModelInvocationLoggingConfigurationDiscoverer{
+		new: func(region string) bedrockModelInvocationLoggingConfigurationClient { return fakes[region] },
+	}
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Identity.Region != "eu-west-1" {
+		t.Fatalf("got %d imps, want 1 from eu-west-1", len(got))
+	}
+	var warns []recordedEvent
+	for _, e := range rec.snapshot() {
+		if e.Kind == "service_warn" {
+			warns = append(warns, e)
+		}
+	}
+	if len(warns) != 1 {
+		t.Fatalf("warns=%d, want 1", len(warns))
+	}
+	if warns[0].Region != "us-east-1" {
+		t.Errorf("warn.region=%q, want us-east-1", warns[0].Region)
+	}
+	if warns[0].Service != bedrockModelInvocationLoggingConfigurationSlug {
+		t.Errorf("warn.service=%q, want %s", warns[0].Service, bedrockModelInvocationLoggingConfigurationSlug)
+	}
+}
+
+// TestBedrockMILCDiscover_EmitsServiceStartFinish_PerRegion pins the
+// per-region progress contract: every region issued ServiceStart and
+// ServiceFinish exactly once, and ServiceFinish.count reflects emit count.
+func TestBedrockMILCDiscover_EmitsServiceStartFinish_PerRegion(t *testing.T) {
+	t.Parallel()
+	fakes := map[string]*fakeBedrockMILCClient{
+		"us-east-1": {
+			out: &bedrock.GetModelInvocationLoggingConfigurationOutput{
+				LoggingConfig: configuredLoggingConfig("/aws/bedrock/east", "", "", ""),
+			},
+			regionID: "us-east-1",
+		},
+		"eu-west-1": {
+			out:      &bedrock.GetModelInvocationLoggingConfigurationOutput{LoggingConfig: nil},
+			regionID: "eu-west-1",
+		},
+	}
+	d := &bedrockModelInvocationLoggingConfigurationDiscoverer{
+		new: func(region string) bedrockModelInvocationLoggingConfigurationClient { return fakes[region] },
+	}
+	rec := &recordingEmitter{}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	starts := map[string]int{}
+	finishes := map[string]int{}
+	finishCount := map[string]int{}
+	for _, e := range rec.snapshot() {
+		switch e.Kind {
+		case "service_start":
+			if e.Service != bedrockModelInvocationLoggingConfigurationSlug {
+				t.Errorf("service_start.service=%q, want %s", e.Service, bedrockModelInvocationLoggingConfigurationSlug)
+			}
+			starts[e.Region]++
+		case "service_finish":
+			finishes[e.Region]++
+			finishCount[e.Region] = e.Count
+		}
+	}
+	for _, region := range []string{"us-east-1", "eu-west-1"} {
+		if starts[region] != 1 {
+			t.Errorf("region=%s: service_start count=%d, want 1", region, starts[region])
+		}
+		if finishes[region] != 1 {
+			t.Errorf("region=%s: service_finish count=%d, want 1", region, finishes[region])
+		}
+	}
+	if finishCount["us-east-1"] != 1 {
+		t.Errorf("us-east-1 service_finish.count=%d, want 1", finishCount["us-east-1"])
+	}
+	if finishCount["eu-west-1"] != 0 {
+		t.Errorf("eu-west-1 service_finish.count=%d, want 0 (unconfigured)", finishCount["eu-west-1"])
+	}
+}
+
+// TestBedrockMILCDiscover_TagsJSONShape pins the #255 contract:
+// Identity.Tags must marshal to a JSON object literal (`{}`), not
+// JSON `null`. This resource is untaggable in AWS provider 6.x so the
+// map is always empty — but it must be non-nil.
+func TestBedrockMILCDiscover_TagsJSONShape(t *testing.T) {
+	t.Parallel()
+	fake := &fakeBedrockMILCClient{
+		out: &bedrock.GetModelInvocationLoggingConfigurationOutput{
+			LoggingConfig: configuredLoggingConfig("/aws/bedrock/east", "", "", ""),
+		},
+		regionID: "us-east-1",
+	}
+	d := &bedrockModelInvocationLoggingConfigurationDiscoverer{
+		new: func(_ string) bedrockModelInvocationLoggingConfigurationClient { return fake },
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1", len(got))
+	}
+	if got[0].Identity.Tags == nil {
+		t.Fatal("Tags is nil; #255 requires non-nil empty map")
+	}
+	b, err := json.Marshal(got[0].Identity.Tags)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "{}" {
+		t.Errorf("json.Marshal(Tags)=%q, want %q", string(b), "{}")
+	}
+}
+
+func TestBedrockMILCDiscoverByID_AcceptsRegion(t *testing.T) {
+	t.Parallel()
+	fake := &fakeBedrockMILCClient{
+		out: &bedrock.GetModelInvocationLoggingConfigurationOutput{
+			LoggingConfig: configuredLoggingConfig("/aws/bedrock/east", "arn:aws:iam::123:role/r", "b", "p/"),
+		},
+	}
+	d := &bedrockModelInvocationLoggingConfigurationDiscoverer{
+		new: func(_ string) bedrockModelInvocationLoggingConfigurationClient { return fake },
+	}
+	got, err := d.DiscoverByID(context.Background(), "us-east-1", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.ImportID != "us-east-1" {
+		t.Errorf("ImportID=%q, want us-east-1", got.Identity.ImportID)
+	}
+	if got.Identity.NativeIDs["region"] != "us-east-1" {
+		t.Errorf("NativeIDs[region]=%q", got.Identity.NativeIDs["region"])
+	}
+	if got.Identity.NativeIDs["s3_bucket_name"] != "b" {
+		t.Errorf("NativeIDs[s3_bucket_name]=%q", got.Identity.NativeIDs["s3_bucket_name"])
+	}
+}
+
+func TestBedrockMILCDiscoverByID_NotFoundShapes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		fake *fakeBedrockMILCClient
+	}{
+		{"rnf_error", &fakeBedrockMILCClient{err: &bedrocktypes.ResourceNotFoundException{}}},
+		{"nil_payload", &fakeBedrockMILCClient{out: &bedrock.GetModelInvocationLoggingConfigurationOutput{LoggingConfig: nil}}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := &bedrockModelInvocationLoggingConfigurationDiscoverer{
+				new: func(_ string) bedrockModelInvocationLoggingConfigurationClient { return tc.fake },
+			}
+			_, err := d.DiscoverByID(context.Background(), "us-east-1", "us-east-1", "123")
+			if !errors.Is(err, ErrNotFound) {
+				t.Errorf("err=%v, want ErrNotFound", err)
+			}
+		})
+	}
+}
+
+func TestBedrockMILCDiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &bedrockModelInvocationLoggingConfigurationDiscoverer{
+		new: func(_ string) bedrockModelInvocationLoggingConfigurationClient { return &fakeBedrockMILCClient{} },
+	}
+	cases := []string{
+		"",
+		"us-east-1/extra",
+		"us east 1",
+		"arn:aws:bedrock:us-east-1:123:foo",
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/servicediscovery_private_dns_namespace.go
+++ b/cmd/insideout-import/awsdiscover/servicediscovery_private_dns_namespace.go
@@ -120,12 +120,15 @@ func (d *serviceDiscoveryPrivateDNSNamespaceDiscoverer) Discover(ctx context.Con
 	const slug = serviceDiscoveryPrivateDNSNamespaceSlug
 	var imps []imported.ImportedResource
 
+	// Route53 is global — one client serves every AWS region. Hoist
+	// outside the per-region loop so we don't rebuild it per iteration.
+	r53 := d.newR53()
+
 	for _, region := range args.Regions {
 		regionStart := time.Now()
 		args.Emitter.ServiceStart(slug, region)
 		regionCount := 0
 		client := d.newSD(region)
-		r53 := d.newR53()
 
 		type summary struct {
 			id   string
@@ -190,7 +193,6 @@ func (d *serviceDiscoveryPrivateDNSNamespaceDiscoverer) Discover(ctx context.Con
 		g, gctx := errgroup.WithContext(ctx)
 		g.SetLimit(limit)
 		for _, c := range candidates {
-			c := c
 			g.Go(func() error {
 				if err := gctx.Err(); err != nil {
 					return err
@@ -397,6 +399,9 @@ func (d *serviceDiscoveryPrivateDNSNamespaceDiscoverer) DiscoverByID(ctx context
 	if hostedZoneID != "" {
 		native["hosted_zone_id"] = hostedZoneID
 	}
+	// Tags: non-nil empty map mirrors the Discover path's #255 contract
+	// for the dep-chase consumer (Discover refetches tags; DiscoverByID
+	// skips that hop to stay lightweight).
 	return makeImportedResource(
 		addressBook{},
 		serviceDiscoveryPrivateDNSNamespaceTFType,
@@ -405,7 +410,7 @@ func (d *serviceDiscoveryPrivateDNSNamespaceDiscoverer) DiscoverByID(ctx context
 		region,
 		accountID,
 		native,
-		nil,
+		map[string]string{},
 	), nil
 }
 

--- a/cmd/insideout-import/awsdiscover/servicediscovery_private_dns_namespace.go
+++ b/cmd/insideout-import/awsdiscover/servicediscovery_private_dns_namespace.go
@@ -1,0 +1,433 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	"github.com/aws/aws-sdk-go-v2/service/servicediscovery"
+	sdtypes "github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// Bucket C, hand-rolled (#466 follow-up): Cloud Control returns
+// UnsupportedActionException on READ for
+// AWS::ServiceDiscovery::PrivateDnsNamespace, so neither the unified
+// cloudControlDiscoverer nor SDKLister can resolve a namespace's
+// properties. Native servicediscovery SDK end-to-end is the only path.
+//
+// Terraform's import id is "<namespace_id>:<vpc_id>" per the v6.x
+// provider docs
+// (website/docs/r/service_discovery_private_dns_namespace.html.markdown).
+// The servicediscovery SDK does NOT surface VpcId on either the
+// ListNamespaces summary or the GetNamespace response — the field is
+// captured at namespace-create time but only retrievable via the
+// associated Route53 private hosted zone, whose ID lives in
+// Namespace.Properties.DnsProperties.HostedZoneId. We chase the VPC ID
+// via Route53 GetHostedZone (one extra call per namespace) so the
+// emitted import id matches the terraform provider's expected shape.
+const (
+	serviceDiscoveryPrivateDNSNamespaceTFType = "aws_service_discovery_private_dns_namespace"
+	serviceDiscoveryPrivateDNSNamespaceSlug   = "service_discovery_private_dns_namespace"
+	// vpcIDPlaceholderUnknown is emitted when Route53 GetHostedZone
+	// returns no VPC associations for a private namespace's hosted
+	// zone — surfaces a structurally-valid but operator-unactionable
+	// import id rather than silently dropping the row. The discoverer
+	// also issues a ServiceWarn alongside so the operator sees why the
+	// resulting `terraform import` will fail.
+	vpcIDPlaceholderUnknown = "UNKNOWN"
+)
+
+// serviceDiscoveryPrivateDNSNamespaceClient is the narrow subset of the
+// Cloud Map (servicediscovery) SDK the discoverer uses. ListNamespaces
+// supports a server-side TYPE=DNS_PRIVATE filter, so we never see
+// HTTP or public-DNS namespaces in the response — no client-side type
+// filter needed.
+type serviceDiscoveryPrivateDNSNamespaceClient interface {
+	ListNamespaces(ctx context.Context, in *servicediscovery.ListNamespacesInput, opts ...func(*servicediscovery.Options)) (*servicediscovery.ListNamespacesOutput, error)
+	GetNamespace(ctx context.Context, in *servicediscovery.GetNamespaceInput, opts ...func(*servicediscovery.Options)) (*servicediscovery.GetNamespaceOutput, error)
+	ListTagsForResource(ctx context.Context, in *servicediscovery.ListTagsForResourceInput, opts ...func(*servicediscovery.Options)) (*servicediscovery.ListTagsForResourceOutput, error)
+}
+
+// route53HostedZoneClient is the narrow subset of the Route53 SDK we
+// use to recover the VPC ID associated with a private DNS namespace's
+// hosted zone. Route53 is a global API — the same client serves every
+// AWS region.
+type route53HostedZoneClient interface {
+	GetHostedZone(ctx context.Context, in *route53.GetHostedZoneInput, opts ...func(*route53.Options)) (*route53.GetHostedZoneOutput, error)
+}
+
+type serviceDiscoveryPrivateDNSNamespaceDiscoverer struct {
+	newSD          func(region string) serviceDiscoveryPrivateDNSNamespaceClient
+	newR53         func() route53HostedZoneClient
+	maxConcurrency int
+}
+
+func newServiceDiscoveryPrivateDNSNamespaceDiscoverer(cfg aws.Config, maxConcurrency int) Discoverer {
+	if maxConcurrency <= 0 {
+		maxConcurrency = DefaultMaxConcurrency
+	}
+	return &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD: func(region string) serviceDiscoveryPrivateDNSNamespaceClient {
+			return servicediscovery.NewFromConfig(cfg, func(o *servicediscovery.Options) {
+				if region != "" {
+					o.Region = region
+				}
+			})
+		},
+		newR53: func() route53HostedZoneClient {
+			return route53.NewFromConfig(cfg)
+		},
+		maxConcurrency: maxConcurrency,
+	}
+}
+
+func (d *serviceDiscoveryPrivateDNSNamespaceDiscoverer) ResourceType() string {
+	return serviceDiscoveryPrivateDNSNamespaceTFType
+}
+
+// Discover paginates ListNamespaces with a TYPE=DNS_PRIVATE filter per
+// region, then fans out per-namespace under a bounded errgroup to:
+//
+//   - Fetch tags via ListTagsForResource(ResourceARN=ns.Arn).
+//   - Recover the VPC ID by calling Route53 GetHostedZone on the
+//     namespace's HostedZoneId (extracted from Namespace.Properties
+//     via GetNamespace, since ListNamespaces' summary does NOT carry
+//     the hosted zone reliably).
+//
+// Tag-based project filter: the legacy Project=<project> back-compat
+// check + operator-supplied TagSelectors AND on top. Mirrors the
+// bedrock_guardrail posture.
+//
+// Failure modes inside the per-namespace fan-out are fail-open at the
+// item level: a tag-fetch error skips that one namespace with a stderr
+// warn rather than aborting the region; a Route53 hop error emits the
+// namespace with vpc_id="UNKNOWN" and surfaces a ServiceWarn so the
+// operator sees the gap. ListNamespaces / GetNamespace failures at the
+// region level abort that region and surface as the outer error.
+func (d *serviceDiscoveryPrivateDNSNamespaceDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
+	args.Emitter = emitterOrNop(args.Emitter)
+	book := addressBook{}
+	const slug = serviceDiscoveryPrivateDNSNamespaceSlug
+	var imps []imported.ImportedResource
+
+	for _, region := range args.Regions {
+		regionStart := time.Now()
+		args.Emitter.ServiceStart(slug, region)
+		regionCount := 0
+		client := d.newSD(region)
+		r53 := d.newR53()
+
+		type summary struct {
+			id   string
+			arn  string
+			name string
+		}
+		var candidates []summary
+
+		input := &servicediscovery.ListNamespacesInput{
+			Filters: []sdtypes.NamespaceFilter{{
+				Name:   sdtypes.NamespaceFilterNameType,
+				Values: []string{string(sdtypes.NamespaceTypeDnsPrivate)},
+			}},
+		}
+		for {
+			out, err := client.ListNamespaces(ctx, input)
+			if err != nil {
+				args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
+				return nil, fmt.Errorf("ListNamespaces (region=%s): %w", region, err)
+			}
+			for i := range out.Namespaces {
+				n := &out.Namespaces[i]
+				// Server-side TYPE filter already pins DNS_PRIVATE, but
+				// belt-and-braces against an API regression: only
+				// surface DNS_PRIVATE rows.
+				if n.Type != sdtypes.NamespaceTypeDnsPrivate {
+					continue
+				}
+				name := aws.ToString(n.Name)
+				if args.Project != "" && !strings.HasPrefix(name, args.Project) {
+					continue
+				}
+				candidates = append(candidates, summary{
+					id:   aws.ToString(n.Id),
+					arn:  aws.ToString(n.Arn),
+					name: name,
+				})
+			}
+			if out.NextToken == nil || *out.NextToken == "" {
+				break
+			}
+			input.NextToken = out.NextToken
+		}
+
+		type resolved struct {
+			id           string
+			arn          string
+			name         string
+			hostedZoneID string
+			vpcID        string
+			tags         map[string]string
+			vpcWarn      string // non-empty when VPC resolution fell back to UNKNOWN
+		}
+		var (
+			mu sync.Mutex
+			ok []resolved
+		)
+		limit := d.maxConcurrency
+		if limit <= 0 {
+			limit = DefaultMaxConcurrency
+		}
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(limit)
+		for _, c := range candidates {
+			c := c
+			g.Go(func() error {
+				if err := gctx.Err(); err != nil {
+					return err
+				}
+				// Step 1: GetNamespace to recover HostedZoneId. The
+				// ListNamespaces summary does not always populate
+				// Properties on every region/version combo, so we
+				// always re-fetch.
+				gnOut, err := client.GetNamespace(gctx, &servicediscovery.GetNamespaceInput{Id: aws.String(c.id)})
+				if err != nil {
+					if cerr := gctx.Err(); cerr != nil {
+						return cerr
+					}
+					// One-namespace GetNamespace failure: warn +
+					// skip this namespace, do not abort the region.
+					var nf *sdtypes.NamespaceNotFound
+					if !errors.As(err, &nf) {
+						fmt.Fprintf(os.Stderr, "discover: WARN: service_discovery_private_dns_namespace %s: GetNamespace (region=%s): %v\n", c.name, region, err)
+					}
+					return nil
+				}
+				ns := gnOut.Namespace
+				if ns == nil {
+					return nil
+				}
+				hostedZoneID := ""
+				if ns.Properties != nil && ns.Properties.DnsProperties != nil {
+					hostedZoneID = aws.ToString(ns.Properties.DnsProperties.HostedZoneId)
+				}
+
+				// Step 2: ListTagsForResource for this namespace ARN.
+				var tags map[string]string
+				if c.arn != "" {
+					tagsOut, err := client.ListTagsForResource(gctx, &servicediscovery.ListTagsForResourceInput{ResourceARN: aws.String(c.arn)})
+					if err != nil {
+						if cerr := gctx.Err(); cerr != nil {
+							return cerr
+						}
+						fmt.Fprintf(os.Stderr, "discover: WARN: service_discovery_private_dns_namespace %s: ListTagsForResource (region=%s): %v\n", c.name, region, err)
+						// Skip this namespace — tag filter cannot
+						// be evaluated without tags.
+						return nil
+					}
+					tags = make(map[string]string, len(tagsOut.Tags))
+					for _, t := range tagsOut.Tags {
+						tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+					}
+				} else {
+					tags = map[string]string{}
+				}
+
+				// Step 3: Route53 GetHostedZone to recover the VPC
+				// ID. Private hosted zones can have multiple VPC
+				// associations; the TF resource only stores one
+				// (the "primary" used at create time). Pick the
+				// first VPC entry deterministically — alphabetic by
+				// VPCId — so re-discovery doesn't churn the import
+				// id on accounts with multi-VPC associations.
+				vpcID := vpcIDPlaceholderUnknown
+				warn := ""
+				if hostedZoneID != "" {
+					hzOut, err := r53.GetHostedZone(gctx, &route53.GetHostedZoneInput{Id: aws.String(hostedZoneID)})
+					if err != nil {
+						if cerr := gctx.Err(); cerr != nil {
+							return cerr
+						}
+						warn = fmt.Sprintf("Route53 GetHostedZone for namespace %s (zone=%s): %v", c.name, hostedZoneID, err)
+					} else if len(hzOut.VPCs) > 0 {
+						ids := make([]string, 0, len(hzOut.VPCs))
+						for _, v := range hzOut.VPCs {
+							if id := aws.ToString(v.VPCId); id != "" {
+								ids = append(ids, id)
+							}
+						}
+						if len(ids) > 0 {
+							sort.Strings(ids)
+							vpcID = ids[0]
+						} else {
+							warn = fmt.Sprintf("Route53 GetHostedZone for namespace %s (zone=%s): no VPC associations on response", c.name, hostedZoneID)
+						}
+					} else {
+						warn = fmt.Sprintf("Route53 GetHostedZone for namespace %s (zone=%s): empty VPCs slice", c.name, hostedZoneID)
+					}
+				} else {
+					warn = fmt.Sprintf("namespace %s has no DnsProperties.HostedZoneId; cannot resolve VPC", c.name)
+				}
+
+				mu.Lock()
+				ok = append(ok, resolved{
+					id:           c.id,
+					arn:          c.arn,
+					name:         c.name,
+					hostedZoneID: hostedZoneID,
+					vpcID:        vpcID,
+					tags:         tags,
+					vpcWarn:      warn,
+				})
+				mu.Unlock()
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
+			return nil, err
+		}
+
+		sort.Slice(ok, func(i, j int) bool { return ok[i].id < ok[j].id })
+
+		for _, r := range ok {
+			// Legacy Project=<project> back-compat filter (matches
+			// bedrock_guardrail / apigatewayv2_stage posture).
+			if args.Project != "" && r.tags["Project"] != args.Project {
+				continue
+			}
+			if !MatchesAll(r.tags, args.TagSelectors) {
+				continue
+			}
+			if r.vpcWarn != "" {
+				args.Emitter.ServiceWarn(slug, region, r.vpcWarn)
+			}
+			importID := r.id + ":" + r.vpcID
+			native := map[string]string{
+				"namespace_id": r.id,
+				"arn":          r.arn,
+				"vpc_id":       r.vpcID,
+			}
+			if r.hostedZoneID != "" {
+				native["hosted_zone_id"] = r.hostedZoneID
+			}
+			imps = append(imps, makeImportedResource(
+				book,
+				serviceDiscoveryPrivateDNSNamespaceTFType,
+				r.name,
+				importID,
+				region,
+				args.AccountID,
+				native,
+				r.tags,
+			))
+			args.Emitter.ItemFound(slug, region, serviceDiscoveryPrivateDNSNamespaceTFType, importID)
+			regionCount++
+		}
+		args.Emitter.ServiceFinish(slug, region, regionCount, time.Since(regionStart))
+	}
+	return imps, nil
+}
+
+// DiscoverByID resolves a private DNS namespace by its terraform import
+// id "<namespace_id>:<vpc_id>" or a bare namespace id. Issues a single
+// GetNamespace call to verify existence; tags are not refetched (dep-
+// chase doesn't need them).
+func (d *serviceDiscoveryPrivateDNSNamespaceDiscoverer) DiscoverByID(ctx context.Context, id, region, accountID string) (imported.ImportedResource, error) {
+	nsID, vpcID, err := serviceDiscoveryPrivateDNSNamespaceIDParts(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
+	client := d.newSD(region)
+	out, err := client.GetNamespace(ctx, &servicediscovery.GetNamespaceInput{Id: aws.String(nsID)})
+	if err != nil {
+		var nf *sdtypes.NamespaceNotFound
+		if errors.As(err, &nf) {
+			return imported.ImportedResource{}, fmt.Errorf("aws_service_discovery_private_dns_namespace %q: %w", nsID, ErrNotFound)
+		}
+		return imported.ImportedResource{}, fmt.Errorf("GetNamespace: %w", err)
+	}
+	ns := out.Namespace
+	if ns == nil {
+		return imported.ImportedResource{}, fmt.Errorf("aws_service_discovery_private_dns_namespace %q: %w", nsID, ErrNotFound)
+	}
+	if ns.Type != sdtypes.NamespaceTypeDnsPrivate {
+		return imported.ImportedResource{}, fmt.Errorf("namespace %q is not DNS_PRIVATE (got %q): %w", nsID, string(ns.Type), ErrNotSupported)
+	}
+	hostedZoneID := ""
+	if ns.Properties != nil && ns.Properties.DnsProperties != nil {
+		hostedZoneID = aws.ToString(ns.Properties.DnsProperties.HostedZoneId)
+	}
+	// Best-effort VPC resolution when the caller didn't provide one.
+	if vpcID == "" {
+		vpcID = vpcIDPlaceholderUnknown
+		if hostedZoneID != "" {
+			r53 := d.newR53()
+			hzOut, err := r53.GetHostedZone(ctx, &route53.GetHostedZoneInput{Id: aws.String(hostedZoneID)})
+			if err == nil && len(hzOut.VPCs) > 0 {
+				ids := make([]string, 0, len(hzOut.VPCs))
+				for _, v := range hzOut.VPCs {
+					if id := aws.ToString(v.VPCId); id != "" {
+						ids = append(ids, id)
+					}
+				}
+				if len(ids) > 0 {
+					sort.Strings(ids)
+					vpcID = ids[0]
+				}
+			}
+		}
+	}
+	name := aws.ToString(ns.Name)
+	importID := nsID + ":" + vpcID
+	native := map[string]string{
+		"namespace_id": nsID,
+		"arn":          aws.ToString(ns.Arn),
+		"vpc_id":       vpcID,
+	}
+	if hostedZoneID != "" {
+		native["hosted_zone_id"] = hostedZoneID
+	}
+	return makeImportedResource(
+		addressBook{},
+		serviceDiscoveryPrivateDNSNamespaceTFType,
+		name,
+		importID,
+		region,
+		accountID,
+		native,
+		nil,
+	), nil
+}
+
+// serviceDiscoveryPrivateDNSNamespaceIDParts splits an import id of the
+// form "<namespace_id>:<vpc_id>" into its two parts. A bare namespace
+// id (no colon) returns (id, "") so DiscoverByID can fall back to
+// Route53 VPC resolution. Anything that contains a slash, space, or
+// more than one colon is rejected with ErrNotSupported.
+func serviceDiscoveryPrivateDNSNamespaceIDParts(id string) (string, string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", "", fmt.Errorf("service_discovery_private_dns_namespace: empty id: %w", ErrNotSupported)
+	}
+	if strings.ContainsAny(id, " /,") {
+		return "", "", fmt.Errorf("service_discovery_private_dns_namespace: unrecognized id %q: %w", id, ErrNotSupported)
+	}
+	if !strings.Contains(id, ":") {
+		return id, "", nil
+	}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("service_discovery_private_dns_namespace: id %q is not <namespace_id>:<vpc_id>: %w", id, ErrNotSupported)
+	}
+	return parts[0], parts[1], nil
+}

--- a/cmd/insideout-import/awsdiscover/servicediscovery_private_dns_namespace_test.go
+++ b/cmd/insideout-import/awsdiscover/servicediscovery_private_dns_namespace_test.go
@@ -1,0 +1,621 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/aws/aws-sdk-go-v2/service/servicediscovery"
+	sdtypes "github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
+)
+
+// fakeSDClient is the per-region servicediscovery fake. Inputs are
+// recorded for paginator-threading assertions; outputs are pulled from
+// per-call maps so different namespaces can return different responses.
+type fakeSDClient struct {
+	pages []servicediscovery.ListNamespacesOutput
+	// nsByID maps namespace.Id → GetNamespaceOutput, letting tests
+	// configure HostedZoneId per namespace.
+	nsByID map[string]*servicediscovery.GetNamespaceOutput
+	// tagsByARN maps namespace.Arn → tag list (mirrors the SDK shape).
+	tagsByARN map[string][]sdtypes.Tag
+	tagsErr   map[string]error
+	getNsErr  map[string]error
+
+	mu        sync.Mutex
+	listCalls []servicediscovery.ListNamespacesInput
+	tagCalls  []string
+	getCalls  []string
+	listErr   error
+}
+
+func (f *fakeSDClient) ListNamespaces(_ context.Context, in *servicediscovery.ListNamespacesInput, _ ...func(*servicediscovery.Options)) (*servicediscovery.ListNamespacesOutput, error) {
+	f.mu.Lock()
+	f.listCalls = append(f.listCalls, *in)
+	idx := len(f.listCalls) - 1
+	f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if idx >= len(f.pages) {
+		return &servicediscovery.ListNamespacesOutput{}, nil
+	}
+	out := f.pages[idx]
+	return &out, nil
+}
+
+func (f *fakeSDClient) GetNamespace(_ context.Context, in *servicediscovery.GetNamespaceInput, _ ...func(*servicediscovery.Options)) (*servicediscovery.GetNamespaceOutput, error) {
+	id := aws.ToString(in.Id)
+	f.mu.Lock()
+	f.getCalls = append(f.getCalls, id)
+	f.mu.Unlock()
+	if err, ok := f.getNsErr[id]; ok {
+		return nil, err
+	}
+	if out, ok := f.nsByID[id]; ok {
+		return out, nil
+	}
+	return nil, &sdtypes.NamespaceNotFound{}
+}
+
+func (f *fakeSDClient) ListTagsForResource(_ context.Context, in *servicediscovery.ListTagsForResourceInput, _ ...func(*servicediscovery.Options)) (*servicediscovery.ListTagsForResourceOutput, error) {
+	arn := aws.ToString(in.ResourceARN)
+	f.mu.Lock()
+	f.tagCalls = append(f.tagCalls, arn)
+	f.mu.Unlock()
+	if err, ok := f.tagsErr[arn]; ok {
+		return nil, err
+	}
+	return &servicediscovery.ListTagsForResourceOutput{Tags: f.tagsByARN[arn]}, nil
+}
+
+// fakeR53Client is the Route53 fake. VPC associations are keyed by
+// hosted zone id.
+type fakeR53Client struct {
+	vpcsByZone map[string][]r53types.VPC
+	errByZone  map[string]error
+
+	mu    sync.Mutex
+	calls []string
+}
+
+func (f *fakeR53Client) GetHostedZone(_ context.Context, in *route53.GetHostedZoneInput, _ ...func(*route53.Options)) (*route53.GetHostedZoneOutput, error) {
+	id := aws.ToString(in.Id)
+	f.mu.Lock()
+	f.calls = append(f.calls, id)
+	f.mu.Unlock()
+	if err, ok := f.errByZone[id]; ok {
+		return nil, err
+	}
+	return &route53.GetHostedZoneOutput{
+		HostedZone: &r53types.HostedZone{Id: aws.String(id)},
+		VPCs:       f.vpcsByZone[id],
+	}, nil
+}
+
+// sdNamespaceSummary returns a NamespaceSummary populated to mirror
+// what ListNamespaces emits for a private DNS namespace.
+func sdNamespaceSummary(id, arn, name string) sdtypes.NamespaceSummary {
+	return sdtypes.NamespaceSummary{
+		Id:   aws.String(id),
+		Arn:  aws.String(arn),
+		Name: aws.String(name),
+		Type: sdtypes.NamespaceTypeDnsPrivate,
+	}
+}
+
+func sdNamespaceWithHostedZone(id, arn, name, hostedZoneID string) *servicediscovery.GetNamespaceOutput {
+	return &servicediscovery.GetNamespaceOutput{
+		Namespace: &sdtypes.Namespace{
+			Id:   aws.String(id),
+			Arn:  aws.String(arn),
+			Name: aws.String(name),
+			Type: sdtypes.NamespaceTypeDnsPrivate,
+			Properties: &sdtypes.NamespaceProperties{
+				DnsProperties: &sdtypes.DnsProperties{HostedZoneId: aws.String(hostedZoneID)},
+			},
+		},
+	}
+}
+
+func sdTag(k, v string) sdtypes.Tag {
+	return sdtypes.Tag{Key: aws.String(k), Value: aws.String(v)}
+}
+
+func r53VPC(id string) r53types.VPC {
+	return r53types.VPC{VPCId: aws.String(id)}
+}
+
+// TestSDPrivateDNSNSDiscover_HappyPath pins the canonical flow: the
+// ListNamespaces filter is set to TYPE=DNS_PRIVATE, prefix filter
+// gates downstream GetNamespace/ListTagsForResource/GetHostedZone
+// calls to project-prefixed names, and the emitted ImportedResource's
+// import id is "<namespace_id>:<vpc_id>" with VPC sourced from
+// Route53.
+func TestSDPrivateDNSNSDiscover_HappyPath(t *testing.T) {
+	t.Parallel()
+	sd := &fakeSDClient{
+		pages: []servicediscovery.ListNamespacesOutput{{
+			Namespaces: []sdtypes.NamespaceSummary{
+				sdNamespaceSummary("ns-aaa", "arn:aws:servicediscovery:us-east-1:123:namespace/ns-aaa", "io-foo-internal"),
+				sdNamespaceSummary("ns-bbb", "arn:aws:servicediscovery:us-east-1:123:namespace/ns-bbb", "other-foo"),
+				sdNamespaceSummary("ns-ccc", "arn:aws:servicediscovery:us-east-1:123:namespace/ns-ccc", "io-foo-svc"),
+			},
+		}},
+		nsByID: map[string]*servicediscovery.GetNamespaceOutput{
+			"ns-aaa": sdNamespaceWithHostedZone("ns-aaa", "arn:aws:servicediscovery:us-east-1:123:namespace/ns-aaa", "io-foo-internal", "Z111"),
+			"ns-ccc": sdNamespaceWithHostedZone("ns-ccc", "arn:aws:servicediscovery:us-east-1:123:namespace/ns-ccc", "io-foo-svc", "Z333"),
+		},
+		tagsByARN: map[string][]sdtypes.Tag{
+			"arn:aws:servicediscovery:us-east-1:123:namespace/ns-aaa": {sdTag("Project", "io-foo")},
+			"arn:aws:servicediscovery:us-east-1:123:namespace/ns-ccc": {sdTag("Project", "io-foo")},
+		},
+	}
+	r53 := &fakeR53Client{
+		vpcsByZone: map[string][]r53types.VPC{
+			"Z111": {r53VPC("vpc-aaa")},
+			"Z333": {r53VPC("vpc-zzz"), r53VPC("vpc-aaa")},
+		},
+	}
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:          func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return sd },
+		newR53:         func() route53HostedZoneClient { return r53 },
+		maxConcurrency: 4,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (prefix filter drops other-foo)", len(got))
+	}
+	// ListNamespaces must carry the TYPE=DNS_PRIVATE filter.
+	if len(sd.listCalls) == 0 {
+		t.Fatal("no ListNamespaces calls")
+	}
+	if len(sd.listCalls[0].Filters) != 1 ||
+		sd.listCalls[0].Filters[0].Name != sdtypes.NamespaceFilterNameType ||
+		len(sd.listCalls[0].Filters[0].Values) != 1 ||
+		sd.listCalls[0].Filters[0].Values[0] != string(sdtypes.NamespaceTypeDnsPrivate) {
+		t.Errorf("ListNamespaces.Filters=%v, want TYPE=DNS_PRIVATE", sd.listCalls[0].Filters)
+	}
+	// Prefix filter must gate GetNamespace + ListTagsForResource to
+	// the 2 matching rows (not 3).
+	if len(sd.getCalls) != 2 {
+		t.Errorf("GetNamespace calls=%d, want 2 (prefix-gated)", len(sd.getCalls))
+	}
+	if len(sd.tagCalls) != 2 {
+		t.Errorf("ListTagsForResource calls=%d, want 2 (prefix-gated)", len(sd.tagCalls))
+	}
+	for _, ir := range got {
+		if !strings.Contains(ir.Identity.ImportID, ":") {
+			t.Errorf("ImportID=%q missing colon separator", ir.Identity.ImportID)
+		}
+		parts := strings.Split(ir.Identity.ImportID, ":")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			t.Errorf("ImportID=%q malformed", ir.Identity.ImportID)
+		}
+		if ir.Identity.NativeIDs["namespace_id"] != parts[0] {
+			t.Errorf("namespace_id=%q, want %q (left half of import id)", ir.Identity.NativeIDs["namespace_id"], parts[0])
+		}
+		if ir.Identity.NativeIDs["vpc_id"] != parts[1] {
+			t.Errorf("vpc_id=%q, want %q (right half of import id)", ir.Identity.NativeIDs["vpc_id"], parts[1])
+		}
+		if ir.Identity.NativeIDs["hosted_zone_id"] == "" {
+			t.Errorf("hosted_zone_id missing on emit for %s", ir.Identity.NameHint)
+		}
+	}
+	// Multi-VPC zone Z333 should pick lexicographically-first VPC (vpc-aaa)
+	// so re-discovery is stable regardless of API ordering.
+	for _, ir := range got {
+		if ir.Identity.NativeIDs["namespace_id"] == "ns-ccc" {
+			if ir.Identity.NativeIDs["vpc_id"] != "vpc-aaa" {
+				t.Errorf("ns-ccc: vpc_id=%q, want vpc-aaa (sorted-first across {vpc-zzz, vpc-aaa})", ir.Identity.NativeIDs["vpc_id"])
+			}
+		}
+	}
+}
+
+// TestSDPrivateDNSNSDiscover_PaginatesUntilNoToken pins the
+// ListNamespaces paginator: every page's NextToken threads into the
+// next request, and the loop terminates only when NextToken is nil
+// or "".
+func TestSDPrivateDNSNSDiscover_PaginatesUntilNoToken(t *testing.T) {
+	t.Parallel()
+	sd := &fakeSDClient{
+		pages: []servicediscovery.ListNamespacesOutput{
+			{
+				Namespaces: []sdtypes.NamespaceSummary{sdNamespaceSummary("ns-a", "arn:1", "io-foo-a")},
+				NextToken:  aws.String("tok1"),
+			},
+			{
+				Namespaces: []sdtypes.NamespaceSummary{sdNamespaceSummary("ns-b", "arn:2", "io-foo-b")},
+				NextToken:  aws.String("tok2"),
+			},
+			{Namespaces: []sdtypes.NamespaceSummary{sdNamespaceSummary("ns-c", "arn:3", "io-foo-c")}}, // terminal
+		},
+		nsByID: map[string]*servicediscovery.GetNamespaceOutput{
+			"ns-a": sdNamespaceWithHostedZone("ns-a", "arn:1", "io-foo-a", "Z1"),
+			"ns-b": sdNamespaceWithHostedZone("ns-b", "arn:2", "io-foo-b", "Z2"),
+			"ns-c": sdNamespaceWithHostedZone("ns-c", "arn:3", "io-foo-c", "Z3"),
+		},
+		tagsByARN: map[string][]sdtypes.Tag{
+			"arn:1": {sdTag("Project", "io-foo")},
+			"arn:2": {sdTag("Project", "io-foo")},
+			"arn:3": {sdTag("Project", "io-foo")},
+		},
+	}
+	r53 := &fakeR53Client{vpcsByZone: map[string][]r53types.VPC{
+		"Z1": {r53VPC("vpc-1")},
+		"Z2": {r53VPC("vpc-2")},
+		"Z3": {r53VPC("vpc-3")},
+	}}
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:          func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return sd },
+		newR53:         func() route53HostedZoneClient { return r53 },
+		maxConcurrency: 4,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len=%d, want 3 (paginated)", len(got))
+	}
+	if len(sd.listCalls) < 3 {
+		t.Fatalf("expected at least 3 ListNamespaces calls; got %d", len(sd.listCalls))
+	}
+	if sd.listCalls[1].NextToken == nil || *sd.listCalls[1].NextToken != "tok1" {
+		t.Errorf("call[1].NextToken=%v, want tok1", sd.listCalls[1].NextToken)
+	}
+	if sd.listCalls[2].NextToken == nil || *sd.listCalls[2].NextToken != "tok2" {
+		t.Errorf("call[2].NextToken=%v, want tok2", sd.listCalls[2].NextToken)
+	}
+}
+
+// TestSDPrivateDNSNSDiscover_TagsErrorSkipsNamespace pins the
+// fail-open posture on per-namespace tag errors: a throttled
+// ListTagsForResource skips that one namespace, leaves the rest
+// of the region's results intact.
+func TestSDPrivateDNSNSDiscover_TagsErrorSkipsNamespace(t *testing.T) {
+	t.Parallel()
+	sd := &fakeSDClient{
+		pages: []servicediscovery.ListNamespacesOutput{{
+			Namespaces: []sdtypes.NamespaceSummary{
+				sdNamespaceSummary("ns-good", "arn:good", "io-foo-good"),
+				sdNamespaceSummary("ns-bad", "arn:bad", "io-foo-bad"),
+			},
+		}},
+		nsByID: map[string]*servicediscovery.GetNamespaceOutput{
+			"ns-good": sdNamespaceWithHostedZone("ns-good", "arn:good", "io-foo-good", "Zgood"),
+			"ns-bad":  sdNamespaceWithHostedZone("ns-bad", "arn:bad", "io-foo-bad", "Zbad"),
+		},
+		tagsByARN: map[string][]sdtypes.Tag{
+			"arn:good": {sdTag("Project", "io-foo")},
+		},
+		tagsErr: map[string]error{
+			"arn:bad": errors.New("Throttling"),
+		},
+	}
+	r53 := &fakeR53Client{vpcsByZone: map[string][]r53types.VPC{
+		"Zgood": {r53VPC("vpc-good")},
+		"Zbad":  {r53VPC("vpc-bad")},
+	}}
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:          func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return sd },
+		newR53:         func() route53HostedZoneClient { return r53 },
+		maxConcurrency: 4,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Identity.NameHint != "io-foo-good" {
+		t.Fatalf("got=%+v, want single io-foo-good", got)
+	}
+}
+
+// TestSDPrivateDNSNSDiscover_NoVPCEmitsUnknownAndWarn pins the
+// graceful-degradation contract: when Route53 returns no VPCs (or an
+// error) for a namespace's hosted zone, the discoverer still emits
+// the row with vpc_id=UNKNOWN and surfaces a ServiceWarn so the
+// operator sees the unresolvable import.
+func TestSDPrivateDNSNSDiscover_NoVPCEmitsUnknownAndWarn(t *testing.T) {
+	t.Parallel()
+	sd := &fakeSDClient{
+		pages: []servicediscovery.ListNamespacesOutput{{
+			Namespaces: []sdtypes.NamespaceSummary{
+				sdNamespaceSummary("ns-1", "arn:1", "io-foo-orphan"),
+			},
+		}},
+		nsByID: map[string]*servicediscovery.GetNamespaceOutput{
+			"ns-1": sdNamespaceWithHostedZone("ns-1", "arn:1", "io-foo-orphan", "Z-empty"),
+		},
+		tagsByARN: map[string][]sdtypes.Tag{
+			"arn:1": {sdTag("Project", "io-foo")},
+		},
+	}
+	r53 := &fakeR53Client{
+		vpcsByZone: map[string][]r53types.VPC{
+			"Z-empty": {}, // private zone with no VPC associations
+		},
+	}
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:          func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return sd },
+		newR53:         func() route53HostedZoneClient { return r53 },
+		maxConcurrency: 4,
+	}
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (still emit with UNKNOWN VPC)", len(got))
+	}
+	if got[0].Identity.NativeIDs["vpc_id"] != vpcIDPlaceholderUnknown {
+		t.Errorf("vpc_id=%q, want %q", got[0].Identity.NativeIDs["vpc_id"], vpcIDPlaceholderUnknown)
+	}
+	if !strings.HasSuffix(got[0].Identity.ImportID, ":"+vpcIDPlaceholderUnknown) {
+		t.Errorf("ImportID=%q, want suffix :%s", got[0].Identity.ImportID, vpcIDPlaceholderUnknown)
+	}
+	var warns []recordedEvent
+	for _, e := range rec.snapshot() {
+		if e.Kind == "service_warn" {
+			warns = append(warns, e)
+		}
+	}
+	if len(warns) != 1 {
+		t.Fatalf("warns=%d, want 1", len(warns))
+	}
+	if warns[0].Region != "us-east-1" || warns[0].Service != serviceDiscoveryPrivateDNSNamespaceSlug {
+		t.Errorf("warn=%+v, want region=us-east-1 service=%s", warns[0], serviceDiscoveryPrivateDNSNamespaceSlug)
+	}
+}
+
+// TestSDPrivateDNSNSDiscover_ListErrorAbortsRegion pins region-fatal
+// failure semantics: a ListNamespaces error surfaces as the outer
+// error (not a per-item warn), preserving the bedrock_guardrail /
+// apigatewayv2_stage shape.
+func TestSDPrivateDNSNSDiscover_ListErrorAbortsRegion(t *testing.T) {
+	t.Parallel()
+	sd := &fakeSDClient{listErr: errors.New("AccessDenied")}
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:          func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return sd },
+		newR53:         func() route53HostedZoneClient { return &fakeR53Client{} },
+		maxConcurrency: 4,
+	}
+	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "AccessDenied") {
+		t.Errorf("err=%v, want wrapped AccessDenied", err)
+	}
+}
+
+func TestSDPrivateDNSNSDiscover_EmitsServiceStartFinish_PerRegion(t *testing.T) {
+	t.Parallel()
+	sdByRegion := map[string]*fakeSDClient{
+		"us-east-1": {
+			pages: []servicediscovery.ListNamespacesOutput{{
+				Namespaces: []sdtypes.NamespaceSummary{sdNamespaceSummary("ns-east", "arn:east", "io-foo-east")},
+			}},
+			nsByID: map[string]*servicediscovery.GetNamespaceOutput{
+				"ns-east": sdNamespaceWithHostedZone("ns-east", "arn:east", "io-foo-east", "Zeast"),
+			},
+			tagsByARN: map[string][]sdtypes.Tag{"arn:east": {sdTag("Project", "io-foo")}},
+		},
+		"eu-west-1": {
+			pages: []servicediscovery.ListNamespacesOutput{{
+				Namespaces: []sdtypes.NamespaceSummary{sdNamespaceSummary("ns-west", "arn:west", "io-foo-west")},
+			}},
+			nsByID: map[string]*servicediscovery.GetNamespaceOutput{
+				"ns-west": sdNamespaceWithHostedZone("ns-west", "arn:west", "io-foo-west", "Zwest"),
+			},
+			tagsByARN: map[string][]sdtypes.Tag{"arn:west": {sdTag("Project", "io-foo")}},
+		},
+	}
+	r53 := &fakeR53Client{vpcsByZone: map[string][]r53types.VPC{
+		"Zeast": {r53VPC("vpc-east")},
+		"Zwest": {r53VPC("vpc-west")},
+	}}
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:          func(region string) serviceDiscoveryPrivateDNSNamespaceClient { return sdByRegion[region] },
+		newR53:         func() route53HostedZoneClient { return r53 },
+		maxConcurrency: 4,
+	}
+	rec := &recordingEmitter{}
+	if _, err := d.Discover(context.Background(), DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+		Emitter:   rec,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	starts := map[string]int{}
+	finishes := map[string]int{}
+	for _, e := range rec.snapshot() {
+		switch e.Kind {
+		case "service_start":
+			if e.Service != serviceDiscoveryPrivateDNSNamespaceSlug {
+				t.Errorf("service_start.service=%q, want %s", e.Service, serviceDiscoveryPrivateDNSNamespaceSlug)
+			}
+			starts[e.Region]++
+		case "service_finish":
+			finishes[e.Region]++
+		}
+	}
+	for _, region := range []string{"us-east-1", "eu-west-1"} {
+		if starts[region] != 1 {
+			t.Errorf("region=%s: service_start count=%d, want 1", region, starts[region])
+		}
+		if finishes[region] != 1 {
+			t.Errorf("region=%s: service_finish count=%d, want 1", region, finishes[region])
+		}
+	}
+}
+
+// TestSDPrivateDNSNSDiscover_EmptyProjectReturnsAll mirrors the
+// bedrock_guardrail empty-Project contract: no prefix filter means
+// every namespace surfaces, and tag fetches fan out across all of
+// them.
+func TestSDPrivateDNSNSDiscover_EmptyProjectReturnsAll(t *testing.T) {
+	t.Parallel()
+	sd := &fakeSDClient{
+		pages: []servicediscovery.ListNamespacesOutput{{
+			Namespaces: []sdtypes.NamespaceSummary{
+				sdNamespaceSummary("ns-1", "arn:1", "alpha"),
+				sdNamespaceSummary("ns-2", "arn:2", "beta"),
+			},
+		}},
+		nsByID: map[string]*servicediscovery.GetNamespaceOutput{
+			"ns-1": sdNamespaceWithHostedZone("ns-1", "arn:1", "alpha", "Z1"),
+			"ns-2": sdNamespaceWithHostedZone("ns-2", "arn:2", "beta", "Z2"),
+		},
+		tagsByARN: map[string][]sdtypes.Tag{
+			"arn:1": {},
+			"arn:2": {},
+		},
+	}
+	r53 := &fakeR53Client{vpcsByZone: map[string][]r53types.VPC{
+		"Z1": {r53VPC("vpc-1")},
+		"Z2": {r53VPC("vpc-2")},
+	}}
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:          func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return sd },
+		newR53:         func() route53HostedZoneClient { return r53 },
+		maxConcurrency: 4,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "", Regions: []string{"us-east-1"}, AccountID: "123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2 (no prefix filter)", len(got))
+	}
+	if len(sd.tagCalls) != 2 {
+		t.Errorf("ListTagsForResource calls=%d, want 2 (no prefix gate)", len(sd.tagCalls))
+	}
+}
+
+func TestSDPrivateDNSNSDiscoverByID_AcceptsImportID(t *testing.T) {
+	t.Parallel()
+	sd := &fakeSDClient{
+		nsByID: map[string]*servicediscovery.GetNamespaceOutput{
+			"ns-1": sdNamespaceWithHostedZone("ns-1", "arn:1", "io-foo-svc", "Z1"),
+		},
+	}
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:  func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return sd },
+		newR53: func() route53HostedZoneClient { return &fakeR53Client{} },
+	}
+	got, err := d.DiscoverByID(context.Background(), "ns-1:vpc-123", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.ImportID != "ns-1:vpc-123" {
+		t.Errorf("ImportID=%q, want ns-1:vpc-123 (caller-supplied vpc wins)", got.Identity.ImportID)
+	}
+	if got.Identity.NativeIDs["namespace_id"] != "ns-1" {
+		t.Errorf("namespace_id=%q", got.Identity.NativeIDs["namespace_id"])
+	}
+	if got.Identity.NativeIDs["vpc_id"] != "vpc-123" {
+		t.Errorf("vpc_id=%q", got.Identity.NativeIDs["vpc_id"])
+	}
+}
+
+func TestSDPrivateDNSNSDiscoverByID_BareIDResolvesVPCViaRoute53(t *testing.T) {
+	t.Parallel()
+	sd := &fakeSDClient{
+		nsByID: map[string]*servicediscovery.GetNamespaceOutput{
+			"ns-1": sdNamespaceWithHostedZone("ns-1", "arn:1", "io-foo-svc", "Z1"),
+		},
+	}
+	r53 := &fakeR53Client{vpcsByZone: map[string][]r53types.VPC{"Z1": {r53VPC("vpc-resolved")}}}
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:  func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return sd },
+		newR53: func() route53HostedZoneClient { return r53 },
+	}
+	got, err := d.DiscoverByID(context.Background(), "ns-1", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity.NativeIDs["vpc_id"] != "vpc-resolved" {
+		t.Errorf("vpc_id=%q, want vpc-resolved (route53 hop on bare-id)", got.Identity.NativeIDs["vpc_id"])
+	}
+	if got.Identity.ImportID != "ns-1:vpc-resolved" {
+		t.Errorf("ImportID=%q, want ns-1:vpc-resolved", got.Identity.ImportID)
+	}
+}
+
+func TestSDPrivateDNSNSDiscoverByID_NotFound(t *testing.T) {
+	t.Parallel()
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:  func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return &fakeSDClient{} },
+		newR53: func() route53HostedZoneClient { return &fakeR53Client{} },
+	}
+	_, err := d.DiscoverByID(context.Background(), "ns-missing", "us-east-1", "123")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestSDPrivateDNSNSDiscoverByID_RejectsWrongNamespaceType(t *testing.T) {
+	t.Parallel()
+	sd := &fakeSDClient{
+		nsByID: map[string]*servicediscovery.GetNamespaceOutput{
+			"ns-pub": {
+				Namespace: &sdtypes.Namespace{
+					Id:   aws.String("ns-pub"),
+					Type: sdtypes.NamespaceTypeDnsPublic,
+				},
+			},
+		},
+	}
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:  func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return sd },
+		newR53: func() route53HostedZoneClient { return &fakeR53Client{} },
+	}
+	_, err := d.DiscoverByID(context.Background(), "ns-pub:vpc-1", "us-east-1", "123")
+	if !errors.Is(err, ErrNotSupported) {
+		t.Errorf("err=%v, want ErrNotSupported (wrong namespace type)", err)
+	}
+}
+
+func TestSDPrivateDNSNSDiscoverByID_UnsupportedID(t *testing.T) {
+	t.Parallel()
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:  func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return &fakeSDClient{} },
+		newR53: func() route53HostedZoneClient { return &fakeR53Client{} },
+	}
+	cases := []string{
+		"",
+		"a:b:c", // too many colons
+		"a/b",   // slash
+		"ns:",   // empty vpc half
+		":vpc",  // empty ns half
+		"ns vpc",
+	}
+	for _, id := range cases {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotSupported) {
+			t.Errorf("id=%q: err=%v, want ErrNotSupported", id, err)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/servicediscovery_private_dns_namespace_test.go
+++ b/cmd/insideout-import/awsdiscover/servicediscovery_private_dns_namespace_test.go
@@ -3,6 +3,8 @@ package awsdiscover
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -274,6 +276,11 @@ func TestSDPrivateDNSNSDiscover_PaginatesUntilNoToken(t *testing.T) {
 	if len(sd.listCalls) < 3 {
 		t.Fatalf("expected at least 3 ListNamespaces calls; got %d", len(sd.listCalls))
 	}
+	// First call MUST start with nil NextToken — a regression that sent
+	// a stale token on the first call would refetch the wrong page.
+	if sd.listCalls[0].NextToken != nil {
+		t.Errorf("call[0].NextToken=%v, want nil (first call must start unpaginated)", aws.ToString(sd.listCalls[0].NextToken))
+	}
 	if sd.listCalls[1].NextToken == nil || *sd.listCalls[1].NextToken != "tok1" {
 		t.Errorf("call[1].NextToken=%v, want tok1", sd.listCalls[1].NextToken)
 	}
@@ -315,12 +322,29 @@ func TestSDPrivateDNSNSDiscover_TagsErrorSkipsNamespace(t *testing.T) {
 		newR53:         func() route53HostedZoneClient { return r53 },
 		maxConcurrency: 4,
 	}
+	// Capture stderr so we can pin that the tag-fetch failure surfaces
+	// as an operator-visible warn (the SUT writes to os.Stderr in the
+	// in-errgroup tag-error path; mutation that silently swallows the
+	// error would otherwise survive).
+	origStderr := os.Stderr
+	rPipe, wPipe, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatalf("os.Pipe: %v", pipeErr)
+	}
+	os.Stderr = wPipe
 	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
+	wPipe.Close()
+	os.Stderr = origStderr
+	stderrBytes, _ := io.ReadAll(rPipe)
+	stderr := string(stderrBytes)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(got) != 1 || got[0].Identity.NameHint != "io-foo-good" {
 		t.Fatalf("got=%+v, want single io-foo-good", got)
+	}
+	if !strings.Contains(stderr, "io-foo-bad") || !strings.Contains(stderr, "ListTagsForResource") {
+		t.Errorf("stderr=%q, want warn naming the bad namespace + the failing SDK op", stderr)
 	}
 }
 
@@ -385,6 +409,113 @@ func TestSDPrivateDNSNSDiscover_NoVPCEmitsUnknownAndWarn(t *testing.T) {
 	if warns[0].Region != "us-east-1" || warns[0].Service != serviceDiscoveryPrivateDNSNamespaceSlug {
 		t.Errorf("warn=%+v, want region=us-east-1 service=%s", warns[0], serviceDiscoveryPrivateDNSNamespaceSlug)
 	}
+	if !strings.Contains(warns[0].Message, "Route53") || !strings.Contains(warns[0].Message, "Z-empty") {
+		t.Errorf("warn message=%q, want substrings: Route53, Z-empty", warns[0].Message)
+	}
+}
+
+// TestSDPrivateDNSNSDiscover_Route53ErrorEmitsUnknown pins the
+// Route53-failure branch (distinct from the empty-VPCs branch covered
+// above): a GetHostedZone error surfaces as vpc_id=UNKNOWN + ServiceWarn
+// rather than aborting the region or silently emitting a wrong import id.
+func TestSDPrivateDNSNSDiscover_Route53ErrorEmitsUnknown(t *testing.T) {
+	t.Parallel()
+	sd := &fakeSDClient{
+		pages: []servicediscovery.ListNamespacesOutput{{
+			Namespaces: []sdtypes.NamespaceSummary{
+				sdNamespaceSummary("ns-1", "arn:1", "io-foo-throttled"),
+			},
+		}},
+		nsByID: map[string]*servicediscovery.GetNamespaceOutput{
+			"ns-1": sdNamespaceWithHostedZone("ns-1", "arn:1", "io-foo-throttled", "Z-throttle"),
+		},
+		tagsByARN: map[string][]sdtypes.Tag{
+			"arn:1": {sdTag("Project", "io-foo")},
+		},
+	}
+	r53 := &fakeR53Client{errByZone: map[string]error{"Z-throttle": errors.New("Throttling: Route53")}}
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:          func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return sd },
+		newR53:         func() route53HostedZoneClient { return r53 },
+		maxConcurrency: 4,
+	}
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123", Emitter: rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1 (emit with UNKNOWN VPC despite r53 failure)", len(got))
+	}
+	if got[0].Identity.NativeIDs["vpc_id"] != vpcIDPlaceholderUnknown {
+		t.Errorf("vpc_id=%q, want %q", got[0].Identity.NativeIDs["vpc_id"], vpcIDPlaceholderUnknown)
+	}
+	var warns []recordedEvent
+	for _, e := range rec.snapshot() {
+		if e.Kind == "service_warn" {
+			warns = append(warns, e)
+		}
+	}
+	if len(warns) != 1 {
+		t.Fatalf("warns=%d, want 1", len(warns))
+	}
+	if !strings.Contains(warns[0].Message, "Throttling") {
+		t.Errorf("warn=%q, want Route53 error detail preserved", warns[0].Message)
+	}
+}
+
+// TestSDPrivateDNSNSDiscover_SortsByNamespaceID pins the deterministic
+// output ordering: SUT sorts the post-fan-out result by namespace id
+// before emitting. errgroup completion order is non-deterministic; a
+// regression that drops the sort would surface as flaky CI assertions
+// downstream.
+func TestSDPrivateDNSNSDiscover_SortsByNamespaceID(t *testing.T) {
+	t.Parallel()
+	shuffled := []sdtypes.NamespaceSummary{
+		sdNamespaceSummary("ns-zzz", "arn:zzz", "io-foo-zzz"),
+		sdNamespaceSummary("ns-aaa", "arn:aaa", "io-foo-aaa"),
+		sdNamespaceSummary("ns-mmm", "arn:mmm", "io-foo-mmm"),
+	}
+	sd := &fakeSDClient{
+		pages: []servicediscovery.ListNamespacesOutput{{Namespaces: shuffled}},
+		nsByID: map[string]*servicediscovery.GetNamespaceOutput{
+			"ns-zzz": sdNamespaceWithHostedZone("ns-zzz", "arn:zzz", "io-foo-zzz", "Zzzz"),
+			"ns-aaa": sdNamespaceWithHostedZone("ns-aaa", "arn:aaa", "io-foo-aaa", "Zaaa"),
+			"ns-mmm": sdNamespaceWithHostedZone("ns-mmm", "arn:mmm", "io-foo-mmm", "Zmmm"),
+		},
+		tagsByARN: map[string][]sdtypes.Tag{
+			"arn:zzz": {sdTag("Project", "io-foo")},
+			"arn:aaa": {sdTag("Project", "io-foo")},
+			"arn:mmm": {sdTag("Project", "io-foo")},
+		},
+	}
+	r53 := &fakeR53Client{vpcsByZone: map[string][]r53types.VPC{
+		"Zzzz": {r53VPC("vpc-z")},
+		"Zaaa": {r53VPC("vpc-a")},
+		"Zmmm": {r53VPC("vpc-m")},
+	}}
+	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
+		newSD:          func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return sd },
+		newR53:         func() route53HostedZoneClient { return r53 },
+		maxConcurrency: 4,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len=%d, want 3", len(got))
+	}
+	wantOrder := []string{"io-foo-aaa", "io-foo-mmm", "io-foo-zzz"}
+	for i, want := range wantOrder {
+		if got[i].Identity.NameHint != want {
+			t.Errorf("position %d: NameHint=%q, want %q (SUT must sort by namespace_id before emit)", i, got[i].Identity.NameHint, want)
+		}
+	}
 }
 
 // TestSDPrivateDNSNSDiscover_ListErrorAbortsRegion pins region-fatal
@@ -393,18 +524,34 @@ func TestSDPrivateDNSNSDiscover_NoVPCEmitsUnknownAndWarn(t *testing.T) {
 // apigatewayv2_stage shape.
 func TestSDPrivateDNSNSDiscover_ListErrorAbortsRegion(t *testing.T) {
 	t.Parallel()
-	sd := &fakeSDClient{listErr: errors.New("AccessDenied")}
+	sentinel := errors.New("AccessDenied: servicediscovery:ListNamespaces")
+	sd := &fakeSDClient{listErr: sentinel}
 	d := &serviceDiscoveryPrivateDNSNamespaceDiscoverer{
 		newSD:          func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return sd },
 		newR53:         func() route53HostedZoneClient { return &fakeR53Client{} },
 		maxConcurrency: 4,
 	}
-	_, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
-	if err == nil {
-		t.Fatal("expected error")
+	rec := &recordingEmitter{}
+	_, err := d.Discover(context.Background(), DiscoverArgs{
+		Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123", Emitter: rec,
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err does not wrap sentinel; got %v", err)
 	}
-	if !strings.Contains(err.Error(), "AccessDenied") {
-		t.Errorf("err=%v, want wrapped AccessDenied", err)
+	// ServiceFinish must still close the bracket on the abort path so
+	// timing telemetry isn't corrupted (cloudControlDiscoverer
+	// precedent).
+	var starts, finishes int
+	for _, e := range rec.snapshot() {
+		switch e.Kind {
+		case "service_start":
+			starts++
+		case "service_finish":
+			finishes++
+		}
+	}
+	if starts != 1 || finishes != 1 {
+		t.Errorf("abort path: starts=%d finishes=%d, want 1 each", starts, finishes)
 	}
 }
 
@@ -570,9 +717,16 @@ func TestSDPrivateDNSNSDiscoverByID_NotFound(t *testing.T) {
 		newSD:  func(_ string) serviceDiscoveryPrivateDNSNamespaceClient { return &fakeSDClient{} },
 		newR53: func() route53HostedZoneClient { return &fakeR53Client{} },
 	}
-	_, err := d.DiscoverByID(context.Background(), "ns-missing", "us-east-1", "123")
-	if !errors.Is(err, ErrNotFound) {
-		t.Errorf("err=%v, want ErrNotFound", err)
+	// Cover both shapes the caller can submit:
+	//   bare namespace-id (no colon) — triggers post-fetch r53 hop
+	//   "<ns>:<vpc>" — caller supplied vpc, no r53 hop
+	// Both must surface NamespaceNotFound as ErrNotFound so dep-chase
+	// can recognize the "resource gone" condition uniformly.
+	for _, id := range []string{"ns-missing", "ns-missing:vpc-stale"} {
+		_, err := d.DiscoverByID(context.Background(), id, "us-east-1", "123")
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("id=%q: err=%v, want ErrNotFound", id, err)
+		}
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/acm v1.38.3
+	github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3
+	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2
 	github.com/aws/aws-sdk-go-v2/service/backup v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.53.2
@@ -50,8 +52,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.118.2
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7
+	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.39.28
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.71.5
@@ -93,8 +97,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
-	github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.23 // indirect

--- a/go.sum
+++ b/go.sum
@@ -154,10 +154,14 @@ github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6 h1:v4Gii9Pxx4bvvN
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6/go.mod h1:W/WhNWo1nbW+wVQTw8681WzAj6yTOvGLl8GLWNEWC2I=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12 h1:kOX5fCUb0BSMNHbRm7icw/dEyTjiYCLczIYglbYFJnI=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12/go.mod h1:n8ixkV2383DfuJhsCMVdfeSfYWqJhO2uadau9wrta9U=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7 h1:twRRMmtSITnt/rrp+D7UDLzE5pKMZe759aalkUdN+OY=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.62.7/go.mod h1:ztM1lr+sRoCAI8336ZUvlRPbToue0d3gE/wd6jomSJ8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1 h1:mxuT1xE+dI54NW3RkNjP8DUT5HXqbkiAFvfdyDFwE5c=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7 h1:JUGKqUnJHbXpS8uyuICP/zpQ+vXUIXW2zTEqjMLCqrY=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7/go.mod h1:l/cqI7ujYqBuTR6Ll13d9/gG/uUdlVzJ1UDltEEBTOo=
+github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.39.28 h1:wd35f7+1mwPV22PENB9ZnWjdvYcDrfytyVspMo02JYQ=
+github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.39.28/go.mod h1:1lUDU6qw3e5FKsegwe+hZZJJXUjg8/L/szYUgVih8yM=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 h1:TdJ+HdzOBhU8+iVAOGUTU63VXopcumCOF1paFulHWZc=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.11/go.mod h1:R82ZRExE/nheo0N+T8zHPcLRTcH8MGsnR3BiVGX0TwI=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27 h1:QgaWXVmNDxv/U/3UIHfGb7ohvtFgerf/bYcYylj4i8E=

--- a/pkg/composer/imported/category.go
+++ b/pkg/composer/imported/category.go
@@ -93,6 +93,7 @@ var categoryByTFType = map[string]string{
 	"aws_backup_selection":                               CategoryDataStorage,
 	"aws_backup_vault":                                   CategoryDataStorage,
 	"aws_bedrock_guardrail":                              CategorySecurity,
+	"aws_bedrock_model_invocation_logging_configuration": CategoryObservability,
 	"aws_cloudfront_distribution":                        CategoryNetworkSecurity,
 	"aws_cloudfront_function":                            CategoryNetworkSecurity,
 	"aws_cloudfront_monitoring_subscription":             CategoryNetworkSecurity,

--- a/pkg/composer/imported/category.go
+++ b/pkg/composer/imported/category.go
@@ -175,6 +175,7 @@ var categoryByTFType = map[string]string{
 	"aws_secretsmanager_secret":                          CategorySecurity,
 	"aws_secretsmanager_secret_rotation":                 CategorySecurity,
 	"aws_security_group":                                 CategoryNetworkSecurity,
+	"aws_service_discovery_private_dns_namespace":        CategoryNetworkSecurity,
 	"aws_sns_topic":                                      CategoryEvents,
 	"aws_sns_topic_subscription":                         CategoryEvents,
 	"aws_sqs_queue":                                      CategoryEvents,

--- a/pkg/composer/imported/testdata/category.golden
+++ b/pkg/composer/imported/testdata/category.golden
@@ -97,6 +97,7 @@ aws_s3_bucket_versioning	Data Storage
 aws_secretsmanager_secret	Security
 aws_secretsmanager_secret_rotation	Security
 aws_security_group	Network Security
+aws_service_discovery_private_dns_namespace	Network Security
 aws_sns_topic	Events
 aws_sns_topic_subscription	Events
 aws_sqs_queue	Events

--- a/pkg/composer/imported/testdata/category.golden
+++ b/pkg/composer/imported/testdata/category.golden
@@ -15,6 +15,7 @@ aws_backup_plan	Data Storage
 aws_backup_selection	Data Storage
 aws_backup_vault	Data Storage
 aws_bedrock_guardrail	Security
+aws_bedrock_model_invocation_logging_configuration	Observability
 aws_cloudfront_distribution	Network Security
 aws_cloudfront_function	Network Security
 aws_cloudfront_monitoring_subscription	Network Security

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -253,6 +253,11 @@
       "purpose": "fetch tags per guardrail"
     },
     {
+      "service": "bedrock_model_invocation_logging_configuration",
+      "iam_action": "bedrock:GetModelInvocationLoggingConfiguration",
+      "purpose": "fetch the per-region model-invocation logging singleton (Cloud Control does not know AWS::Bedrock::ModelInvocationLoggingConfiguration; native SDK only)"
+    },
+    {
       "service": "cloudfront_distribution",
       "iam_action": "cloudcontrol:GetResource",
       "purpose": "Cloud Control GetResource for AWS::CloudFront::Distribution (#406 unified discoverer)"

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -1693,6 +1693,26 @@
       "purpose": "list per-region security groups (server-side tag:Project filter when project is set; tags inline)"
     },
     {
+      "service": "service_discovery_private_dns_namespace",
+      "iam_action": "route53:GetHostedZone",
+      "purpose": "recover the VPC id associated with a private DNS namespace's hosted zone (servicediscovery SDK does not surface VpcId; TF import id is <namespace_id>:<vpc_id>)"
+    },
+    {
+      "service": "service_discovery_private_dns_namespace",
+      "iam_action": "servicediscovery:GetNamespace",
+      "purpose": "fetch per-namespace properties (HostedZoneId) for downstream Route53 VPC resolution"
+    },
+    {
+      "service": "service_discovery_private_dns_namespace",
+      "iam_action": "servicediscovery:ListNamespaces",
+      "purpose": "list per-region private DNS namespaces (server-side TYPE=DNS_PRIVATE filter; Cloud Control READ is unsupported)"
+    },
+    {
+      "service": "service_discovery_private_dns_namespace",
+      "iam_action": "servicediscovery:ListTagsForResource",
+      "purpose": "fetch tags per namespace for tag selectors and Identity.Tags"
+    },
+    {
       "service": "sns_topic",
       "iam_action": "cloudcontrol:GetResource",
       "purpose": "fetch per-topic properties for tag extraction"

--- a/pkg/insideout-import/permissions/permissions_test.go
+++ b/pkg/insideout-import/permissions/permissions_test.go
@@ -113,6 +113,7 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_secretsmanager_secret":                          "secretsmanager",
 	"aws_secretsmanager_secret_rotation":                 "secretsmanager_secret_rotation",
 	"aws_security_group":                                 "security_group",
+	"aws_service_discovery_private_dns_namespace":        "service_discovery_private_dns_namespace",
 	"aws_sns_topic":                                      "sns_topic",
 	"aws_sns_topic_subscription":                         "sns_topic_subscription",
 	"aws_sqs_queue":                                      "sqs",

--- a/pkg/insideout-import/permissions/permissions_test.go
+++ b/pkg/insideout-import/permissions/permissions_test.go
@@ -34,6 +34,7 @@ var awsTFTypeToServiceSlug = map[string]string{
 	"aws_backup_selection":                               "backup_selection",
 	"aws_backup_vault":                                   "backup_vault",
 	"aws_bedrock_guardrail":                              "bedrock_guardrail",
+	"aws_bedrock_model_invocation_logging_configuration": "bedrock_model_invocation_logging_configuration",
 	"aws_cloudfront_distribution":                        "cloudfront_distribution",
 	"aws_cloudfront_function":                            "cloudfront_function",
 	"aws_cloudfront_monitoring_subscription":             "cloudfront_monitoring_subscription",

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -40,6 +40,7 @@ var awsTypes = []string{
 	"aws_backup_selection",
 	"aws_backup_vault",
 	"aws_bedrock_guardrail",
+	"aws_bedrock_model_invocation_logging_configuration",
 	"aws_cloudfront_distribution",
 	"aws_cloudfront_function",
 	"aws_cloudfront_monitoring_subscription",

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -119,6 +119,7 @@ var awsTypes = []string{
 	"aws_secretsmanager_secret",
 	"aws_secretsmanager_secret_rotation",
 	"aws_security_group",
+	"aws_service_discovery_private_dns_namespace",
 	"aws_sns_topic",
 	"aws_sns_topic_subscription",
 	"aws_sqs_queue",

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -35,6 +35,7 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_backup_selection",
 		"aws_backup_vault",
 		"aws_bedrock_guardrail",
+		"aws_bedrock_model_invocation_logging_configuration",
 		"aws_cloudfront_distribution",
 		"aws_cloudfront_function",
 		"aws_cloudfront_monitoring_subscription",

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -114,6 +114,7 @@ func TestSupportedDiscoverTypes_AWS_ReturnsCanonicalSortedList(t *testing.T) {
 		"aws_secretsmanager_secret",
 		"aws_secretsmanager_secret_rotation",
 		"aws_security_group",
+		"aws_service_discovery_private_dns_namespace",
 		"aws_sns_topic",
 		"aws_sns_topic_subscription",
 		"aws_sqs_queue",


### PR DESCRIPTION
Follow-up to PR #467 (merged): closes the bedrock + service-discovery-private-DNS-namespace deferral from #466 by adding hand-rolled non-CloudControl discoverers.

## Summary

- Two AWS types verified CC-infeasible during PR #467 pre-flight against cust2 — neither has a working CC `GetResource`, so SDKLister can't help (the framework's per-item fan-out is CC-based). Native SDK end-to-end is the only path:
  - `aws_bedrock_model_invocation_logging_configuration` — `AWS::Bedrock::ModelInvocationLoggingConfiguration` returns `TypeNotFoundException` (type unknown to CC registry). Per-region account-singleton; TF import id = `<region>`.
  - `aws_service_discovery_private_dns_namespace` — `AWS::ServiceDiscovery::PrivateDnsNamespace` returns `UnsupportedActionException` on READ. List+tag pattern; VPC ID resolved via Route53 `GetHostedZone` hop (deterministic — `sort.Strings` + first VPC). TF import id = `<namespace_id>:<vpc_id>`.
- Bucket-C hand-rolled pattern, mirroring `bedrock_guardrail.go` / `apigatewayv2_stage.go`. Both registered in `awsdiscover.go::byType` + `serviceSlugByTFType`.

## Test plan

- [x] `go test ./... -race`: 2022 passed in 14 packages
- [x] `terraform fmt -check -recursive` + 4 lint scripts all PASS
- [x] Live smoke on AWS cust2 (`141812438321 / io-h3a-v495cjgt / us-east-1`): exit 0, 451 resources, 0 unsupported, 0 errors. Both new types emit 0 (test account has neither configured — expected zero-state); discoverers ran without UnsupportedAction.

## Review notes

- /review: P0 0, P1 0, P2 5 (4 drive-by addressed inline: Tags non-nil in DiscoverByID, hoist Route53 client, drop redundant loop-var shadow, errors.Is). 1 deferred follow-up: Route53 throttling under deep fan-out (semaphore tuning).
- qa-professor: P1 0 after fixes; P2 5 all addressed (NameHint pin, errors.Is on abort, first-call-nil pagination assertion, stderr capture on tag-error, ServiceFinish on all bedrock exit paths, deterministic sort test, colon-form NotFound, Route53-error branch coverage, warn-message substring pins). P3s skipped.
- New SDK dep: `aws-sdk-go-v2/service/route53` (audited; bounded in go.sum). 5 new permission rows: `bedrock:GetModelInvocationLoggingConfiguration`, `servicediscovery:ListNamespaces/GetNamespace/ListTagsForResource`, `route53:GetHostedZone`.

## Deferred (follow-up)

- Route53 throttling defensive semaphore for accounts with many private namespaces (current per-namespace fan-out uses the generic `maxConcurrency=8` default; Route53 enforces tighter account-wide caps).
- `bedrock_model_invocation_logging_configuration` discoverer's `maxConcurrency` field is documented dead — kept for constructor-shape parity; a future refactor could introduce a non-concurrent Discoverer constructor for true singletons.