### PR TITLE
feat(imported): EnrichmentStatus signal + display-vs-address docs

### DIFF
--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -147,14 +147,27 @@ func (g *GCPDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.Imp
 		err := enr.Enrich(ctx, &irs[i], clients)
 		switch {
 		case err == nil:
+			// Per-type enrichers marshal Attrs atomically today, so
+			// a nil return means Full. The Partial state is reserved
+			// for a future multi-call enricher (see issue #471).
+			irs[i].Identity.EnrichmentStatus = imported.EnrichmentStatusFull
+			irs[i].Identity.EnrichErrors = nil
 			emitter.ItemFound(enrichServiceSlug, irs[i].Identity.Location, irs[i].Identity.Type, irs[i].Identity.ImportID)
 		case errors.Is(err, ErrEnrichClientUnavailable):
 			// Client-side configuration failure — surface as a
 			// warn but don't accumulate as an error. Mirrors the
-			// nonCAIDiscovererHasLister warn semantics.
+			// nonCAIDiscovererHasLister warn semantics. The typed
+			// signal on Identity lets downstream consumers
+			// distinguish this from a happy Identity-only IR
+			// (issue #471).
+			irs[i].Identity.EnrichmentStatus = imported.EnrichmentStatusFailed
+			irs[i].Identity.EnrichErrors = append(irs[i].Identity.EnrichErrors, err.Error())
 			emitter.ServiceWarn(enrichServiceSlug, "", fmt.Sprintf("%s/%s: %v", irs[i].Identity.Type, irs[i].Identity.Address, err))
 		default:
-			errs = append(errs, fmt.Errorf("enrich %s/%s: %w", irs[i].Identity.Type, irs[i].Identity.Address, err))
+			wrapped := fmt.Errorf("enrich %s/%s: %w", irs[i].Identity.Type, irs[i].Identity.Address, err)
+			irs[i].Identity.EnrichmentStatus = imported.EnrichmentStatusFailed
+			irs[i].Identity.EnrichErrors = append(irs[i].Identity.EnrichErrors, wrapped.Error())
+			errs = append(errs, wrapped)
 		}
 	}
 	if len(errs) > 0 {

--- a/cmd/insideout-import/gcpdiscover/enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/enrich_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,6 +50,16 @@ func TestEnrichAttributes_SkipsUnregisteredTypes(t *testing.T) {
 	// Only the storage_bucket got enriched.
 	assert.Empty(t, irs[0].Attrs, "google_pubsub_topic has no enricher; Attrs must remain empty")
 	assert.NotEmpty(t, irs[1].Attrs, "google_storage_bucket Attrs must be populated")
+
+	// EnrichmentStatus is the typed signal added in #471. Types
+	// without a registered enricher stay at the empty/unknown state;
+	// the dispatched type lands on Full and has no EnrichErrors.
+	assert.Equal(t, imported.EnrichmentStatusUnknown, irs[0].Identity.EnrichmentStatus,
+		"unregistered type must keep EnrichmentStatus at Unknown")
+	assert.Empty(t, irs[0].Identity.EnrichErrors)
+	assert.Equal(t, imported.EnrichmentStatusFull, irs[1].Identity.EnrichmentStatus,
+		"successfully enriched IR must be marked Full")
+	assert.Empty(t, irs[1].Identity.EnrichErrors)
 }
 
 func TestEnrichAttributes_DeterministicOrder(t *testing.T) {
@@ -66,6 +77,16 @@ func TestEnrichAttributes_DeterministicOrder(t *testing.T) {
 	require.NoError(t, g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, nil))
 	assert.Equal(t, []string{"a", "m", "z"}, enr.calls,
 		"enrich must dispatch in sorted (type, address) order regardless of input order")
+
+	// Guard against an idx-vs-i writeback bug: each IR must be marked
+	// Full at its original input position, not at the sorted-dispatch
+	// position. A regression here (e.g. `for i := range irs` instead
+	// of `for _, i := range idx`) would still pass the dispatch-order
+	// assertion above but corrupt the per-IR EnrichmentStatus.
+	for i, ir := range irs {
+		assert.Equal(t, imported.EnrichmentStatusFull, ir.Identity.EnrichmentStatus,
+			"irs[%d] (ImportID=%q) must be Full at its original input position", i, ir.Identity.ImportID)
+	}
 }
 
 func TestEnrichAttributes_AccumulatesErrors(t *testing.T) {
@@ -89,6 +110,26 @@ func TestEnrichAttributes_AccumulatesErrors(t *testing.T) {
 	// whack-a-mole.
 	assert.Contains(t, err.Error(), "a")
 	assert.Contains(t, err.Error(), "b")
+
+	// Each failed IR carries the typed Failed status plus a per-pass
+	// error string so downstream consumers (#471) can render the row
+	// as needs-attention without grep-ing the joined error.
+	for i, ir := range irs {
+		assert.Equal(t, imported.EnrichmentStatusFailed, ir.Identity.EnrichmentStatus,
+			"irs[%d] must be marked Failed after enricher error", i)
+		require.Len(t, ir.Identity.EnrichErrors, 1, "irs[%d] EnrichErrors must hold one entry", i)
+		// The orchestrator stores the *wrapped* error (the
+		// `fmt.Errorf("enrich %s/%s: %w", ...)` form that goes into
+		// the joined return), not the bare per-enricher error. Pin
+		// the prefix + Address so a regression to err.Error() would
+		// fail; pin ImportID because the fake error embeds it.
+		assert.True(t, strings.HasPrefix(ir.Identity.EnrichErrors[0], "enrich "),
+			"irs[%d] EnrichErrors[0] must carry the orchestrator's wrap prefix, got %q", i, ir.Identity.EnrichErrors[0])
+		assert.Contains(t, ir.Identity.EnrichErrors[0], ir.Identity.Address,
+			"irs[%d] EnrichErrors must include the Address (proves the wrap path, not bare err.Error())", i)
+		assert.Contains(t, ir.Identity.EnrichErrors[0], ir.Identity.ImportID,
+			"irs[%d] EnrichErrors must mention the resource it failed on", i)
+	}
 }
 
 func TestEnrichAttributes_DowngradesClientUnavailable(t *testing.T) {
@@ -111,6 +152,15 @@ func TestEnrichAttributes_DowngradesClientUnavailable(t *testing.T) {
 	require.Len(t, warns, 1, "exactly one ServiceWarn must be emitted for the unavailable client")
 	assert.Contains(t, warns[0].Message, "google_storage_bucket")
 	assert.Contains(t, warns[0].Message, "client unavailable")
+
+	// The downgraded warn still sets EnrichmentStatus=Failed on the IR
+	// so downstream consumers can distinguish it from a happy
+	// Identity-only IR. The sentinel error text is preserved in
+	// EnrichErrors for triage (#471).
+	assert.Equal(t, imported.EnrichmentStatusFailed, irs[0].Identity.EnrichmentStatus,
+		"unavailable-client IR must be marked Failed even though no err is returned")
+	require.Len(t, irs[0].Identity.EnrichErrors, 1)
+	assert.Contains(t, irs[0].Identity.EnrichErrors[0], "client unavailable")
 }
 
 func TestEnrichAttributes_EmitsItemFoundOnSuccess(t *testing.T) {
@@ -119,8 +169,21 @@ func TestEnrichAttributes_EmitsItemFoundOnSuccess(t *testing.T) {
 	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"google_storage_bucket": enr}}
 
 	rec := &recordingEmitter{}
+	// Pre-populate stale Failed-status + EnrichErrors on the IR to
+	// simulate a re-run after a prior failed enrich pass. The
+	// orchestrator must reset both on success — otherwise a recovered
+	// resource would still carry needs-attention markers indefinitely.
+	// Pins the explicit `EnrichErrors = nil` clear at enrich.go's
+	// success branch (#471).
 	irs := []imported.ImportedResource{
-		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "b1", Address: "google_storage_bucket.b1", Location: "us"}},
+		{Identity: imported.ResourceIdentity{
+			Type:             "google_storage_bucket",
+			ImportID:         "b1",
+			Address:          "google_storage_bucket.b1",
+			Location:         "us",
+			EnrichmentStatus: imported.EnrichmentStatusFailed,
+			EnrichErrors:     []string{"stale prior-pass error"},
+		}},
 	}
 	require.NoError(t, g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, rec))
 	events := rec.snapshot()
@@ -132,6 +195,14 @@ func TestEnrichAttributes_EmitsItemFoundOnSuccess(t *testing.T) {
 		"ServiceFinish must fire once per call, regardless of per-item outcomes")
 	assert.Equal(t, 1, len(filterEvents(events, "service_start")),
 		"ServiceStart must fire exactly once per call")
+
+	// Happy path: typed signal flips to Full and the stale
+	// EnrichErrors must be cleared so the row no longer renders as
+	// needs-attention (#471).
+	assert.Equal(t, imported.EnrichmentStatusFull, irs[0].Identity.EnrichmentStatus,
+		"successful enrich must overwrite a prior Failed status")
+	assert.Nil(t, irs[0].Identity.EnrichErrors,
+		"successful enrich must clear stale EnrichErrors")
 }
 
 // filterEvents returns the subset of recorded events whose Kind matches

--- a/pkg/composer/imported/address.go
+++ b/pkg/composer/imported/address.go
@@ -30,6 +30,18 @@ const (
 // resource type. If id.Type is empty (after trimming whitespace), the
 // function returns "" so callers can detect the misuse.
 //
+// Address vs display name (issue #471): the returned `<label>` is the
+// Terraform-safe sanitized form of id.NameHint (or the next non-empty
+// source in the precedence list). Per normalizeLabel: lowercase ASCII,
+// `[^a-z0-9_]` collapsed to `_`, repeated `_` merged, prefixed with
+// `r_` if it doesn't start with a letter, capped to maxLabelLen. A
+// GCS bucket named `b9043cd2-tfstate` therefore round-trips to
+// `google_storage_bucket.b9043cd2_tfstate` here — same resource, two
+// strings. UI consumers that surface a user-visible name should keep
+// id.NameHint around for display (e.g. "Bucket b9043cd2-tfstate → TF:
+// google_storage_bucket.b9043cd2_tfstate") and use the address only
+// for the TF-state form and `import {}` blocks.
+//
 // Algorithm (per docs/managed-resource-tiers.md lines 528-544):
 //
 //  1. Pick the first non-empty name hint from id.NameHint, NativeIDs["name"],

--- a/pkg/composer/imported/identity.go
+++ b/pkg/composer/imported/identity.go
@@ -1,5 +1,39 @@
 package imported
 
+// EnrichmentStatus reports whether the per-type AttributeEnricher fully
+// populated a resource's Attrs payload. Empty string is the implicit
+// "unknown" state — used at pre-enrich call sites and for resource types
+// that have no registered enricher (Identity-only IRs). Downstream
+// consumers (the Reliable importer wizard, future Riley management views)
+// read this to surface partial-data warnings without grep-ing the
+// enricher's warn log; see issue #471 for the live-verification context
+// that motivated adding a typed signal.
+type EnrichmentStatus string
+
+const (
+	// EnrichmentStatusUnknown is the zero / not-yet-enriched state. The
+	// enricher orchestrator never writes this value — it represents
+	// "no enrich pass has touched this IR yet" (pre-enrich call sites,
+	// or resource types without a registered AttributeEnricher).
+	// Downstream consumers should treat it equivalently to a bare empty
+	// string per the JSON `omitempty` tag.
+	EnrichmentStatusUnknown EnrichmentStatus = ""
+	// EnrichmentStatusFull indicates the enricher populated every
+	// attribute it knows how to fetch. The IR's Attrs is authoritative.
+	EnrichmentStatusFull EnrichmentStatus = "full"
+	// EnrichmentStatusPartial indicates the enricher populated some
+	// attributes but at least one fetch failed. Reserved for future
+	// multi-call enrichers (e.g. bucket-ACL-plus-policy); current
+	// per-type enrichers marshal Attrs atomically and so never set
+	// Partial. TODO(#471): wire this when a multi-call enricher lands.
+	EnrichmentStatusPartial EnrichmentStatus = "partial"
+	// EnrichmentStatusFailed indicates no attributes could be populated
+	// (client unavailable, name underivable, fetch error, marshal
+	// error). The IR's Attrs is empty; consumers should treat it as
+	// Identity-only and surface the EnrichErrors strings for triage.
+	EnrichmentStatusFailed EnrichmentStatus = "failed"
+)
+
 // ResourceIdentity separates Terraform's stable address from cloud-side
 // correlation identifiers. Address is immutable after import; renaming is a
 // future explicit migration operation using `moved {}` blocks, not an ordinary
@@ -15,9 +49,22 @@ type ResourceIdentity struct {
 	Type string `json:"type,omitempty"`
 	// Address is the immutable Terraform resource address (e.g.
 	// "aws_sqs_queue.dlq"). Generated once via GenerateAddress and frozen.
+	//
+	// The label portion (after the dot) is the sanitized form of
+	// NameHint per address.go::normalizeLabel: lowercase ASCII,
+	// `[^a-z0-9_]` collapsed to `_`, repeated `_` merged, leading
+	// non-letter prefixed with `r_`, capped to maxLabelLen. A bucket
+	// named `b9043cd2-tfstate` therefore appears here as
+	// `google_storage_bucket.b9043cd2_tfstate`. UI consumers that
+	// surface a user-readable name should display NameHint alongside
+	// (or instead of) Address when the two differ, and use Address
+	// only for the TF-state/import-block form.
 	Address string `json:"address,omitempty"`
 	// NameHint is the original human-readable name source preserved for
-	// audit and display.
+	// audit and display. May contain characters that are illegal in a
+	// Terraform label (hyphens, uppercase, dots) — Address holds the
+	// sanitized form. See the Address field comment for the
+	// relationship.
 	NameHint string `json:"name_hint,omitempty"`
 	// ProviderConfig identifies the provider alias used by emitted HCL,
 	// e.g. "aws.imported" or "google.imported".
@@ -51,4 +98,20 @@ type ResourceIdentity struct {
 	// consumers (#291 tag selectors, #289 gap-#6 DiscoverySummary.byTag)
 	// rely on the nil-vs-empty distinction.
 	Tags map[string]string `json:"tags,omitempty"`
+
+	// EnrichmentStatus reports whether the per-type enricher fully
+	// populated this resource's Attrs. Empty == not-yet-enriched (the
+	// discoverer hasn't run the enrich pass, or no enricher is
+	// registered for this type — Identity-only IR). Set by the
+	// EnrichAttributes orchestrator; per-type enrichers do not write
+	// this directly. Downstream consumers (Reliable wizard, future
+	// management views) read this to surface partial-data warnings
+	// without grep-ing the enricher's warn log. Added for issue #471.
+	EnrichmentStatus EnrichmentStatus `json:"enrichment_status,omitempty"`
+	// EnrichErrors carries the per-attribute (or per-pass) error
+	// messages when EnrichmentStatus != Full. Nil when Full or Unknown.
+	// Verbose enough for triage but PII-free — error messages from the
+	// cloud SDK pass through verbatim (no auth tokens, no full URLs
+	// beyond the resource identifier).
+	EnrichErrors []string `json:"enrich_errors,omitempty"`
 }


### PR DESCRIPTION
## Summary

Two soft-priority polish items from #471, surfaced during the Reliable importer wizard's live verification ([reliable#1346](https://github.com/luthersystems/reliable/issues/1346)):

- **`EnrichmentStatus` + `EnrichErrors` on `ResourceIdentity`.** Adds a typed signal so downstream consumers (Reliable wizard, future Riley management views) can distinguish a happy IR from a partial/failed-enrich IR without grep-ing the warn log. The gcpdiscover `EnrichAttributes` orchestrator writes `Full` on success (clearing any stale `EnrichErrors`), `Failed` on enricher error or `ErrEnrichClientUnavailable`, and leaves `Unknown` for types with no registered enricher. `Partial` is reserved for a future multi-call enricher — today's per-type enrichers marshal `Attrs` atomically.
- **Documents the address-vs-displayname distinction** (option (a) from the issue). `Address` is the Terraform-safe sanitized form of `NameHint` per `normalizeLabel` (`b9043cd2-tfstate` → `google_storage_bucket.b9043cd2_tfstate`). Doc comments on `ResourceIdentity.Address`, `ResourceIdentity.NameHint`, and `GenerateAddress` now make the relationship explicit so the wizard team can render both forms when they differ. No new `DisplayName` field — `NameHint` already serves the role.

Both changes are additive and backwards-compatible: new JSON keys are `omitempty`, the new constants are exported, and no existing API behavior changes. AWS enrichers don't exist yet (`cmd/insideout-import/awsdiscover/` is Identity-only), so no AWS-side touch in this PR; the new fields are forward-compatible for when AWS enrichers land.

## Test plan

- [x] `go test -count=1 ./...` — 4800 tests pass across 27 packages
- [x] `go vet ./pkg/composer/imported/... ./cmd/insideout-import/gcpdiscover/...` clean
- [x] `terraform fmt -check -recursive` passes
- [x] All ten repo lint scripts pass (`lint-project-tag`, `lint-project-label`, `lint-sensitive-for-each`, `lint-foreach-unknown-keys`, `lint-labelless-name-prefix`, `lint-gcp-project-pin`, `lint-no-root-only-blocks`, `lint-shared-no-cloud-providers`, `lint-enrichgen-override-citations`, `lint-phantom-computed-fields`)
- [x] qa-professor review of the test additions, with all five findings addressed:
  - Pre-populate stale `EnrichErrors`/`Failed` on the success IR to pin the explicit `EnrichErrors = nil` clear
  - Strengthened the wrap assertion (`HasPrefix("enrich ")` + `Contains(Address)`) so a regression from `wrapped.Error()` → `err.Error()` fails the test
  - Asserted per-IR mutation order on the deterministic-order test to guard against an `idx`-vs-`i` writeback bug
  - Added a named `EnrichmentStatusUnknown` constant for the zero state instead of an anonymous `EnrichmentStatus("")` cast
  - Added a `TODO(#471)` reference next to the unused `Partial` constant so future readers see it as design-deferred, not missing-by-bug

Closes #471