### PR TITLE
feat(gcpdiscover): Bundle G3 — 2 GCP sub-resource discoverers (#475)

### DIFF
--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -296,11 +296,24 @@ func productionDiscoverDeps() discoverDeps {
 			if iamErr != nil {
 				fmt.Fprintf(os.Stderr, "WARN: IAM policy lister unavailable, IAM bindings/members won't be discovered: %v\n", iamErr)
 			}
+			// Bundle G3 (#475): per-parent sub-resource listers. Same
+			// nil-tolerant pattern — auth gaps surface as warnings
+			// rather than aborting discover.
+			secretVersionLister, svErr := gcpdiscover.NewRealSecretVersionLister(ctx)
+			if svErr != nil {
+				fmt.Fprintf(os.Stderr, "WARN: secret version lister unavailable, secret_manager_secret_version won't be discovered: %v\n", svErr)
+			}
+			bucketObjectLister, boErr := gcpdiscover.NewRealBucketObjectLister(ctx)
+			if boErr != nil {
+				fmt.Fprintf(os.Stderr, "WARN: bucket object lister unavailable, storage_bucket_object won't be discovered: %v\n", boErr)
+			}
 			opts := gcpdiscover.GCPDiscovererOpts{
 				SinkLister:             sinkLister,
 				SQLUserLister:          sqlUserLister,
 				IdentityPlatformLister: identityLister,
 				IAMPolicyLister:        iamLister,
+				SecretVersionLister:    secretVersionLister,
+				BucketObjectLister:     bucketObjectLister,
 			}
 			return gcpAggAdapter{d: gcpdiscover.NewGCPDiscoverer(s, gcpProjectID, opts)}, s.Close, nil
 		},

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -239,6 +239,11 @@ type GCPDiscovererOpts struct {
 	// SDK clients so the Opts surface doesn't grow per added IAM
 	// resource type.
 	IAMPolicyLister gcpIAMPolicyLister
+	// Bundle G3 (#475) — sub-resource listers. Each backs one
+	// discoverer that fans out across the relevant CAI-discovered
+	// parent rows.
+	SecretVersionLister gcpSecretVersionLister
+	BucketObjectLister  gcpBucketObjectLister
 }
 
 // NewGCPDiscoverer wires up the production set of GCP discoverers. The
@@ -306,6 +311,9 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string, opts GCPDisco
 			"google_compute_health_check":            newComputeHealthCheckDiscoverer(),
 			"google_compute_managed_ssl_certificate": newComputeManagedSSLCertificateDiscoverer(),
 			"google_compute_target_http_proxy":       newComputeTargetHTTPProxyDiscoverer(),
+			// Bundle G3 — sub-resources (#475).
+			"google_secret_manager_secret_version": newSecretManagerSecretVersionDiscoverer(opts.SecretVersionLister),
+			"google_storage_bucket_object":         newStorageBucketObjectDiscoverer(opts.BucketObjectLister),
 		},
 		// Per-type SDK attribute enrichers (#403). Each entry is a sibling
 		// to the byType discoverer of the same name and populates ir.Attrs
@@ -527,6 +535,13 @@ func nonCAIDiscovererHasLister(d Discoverer) bool {
 	case *cloudRunV2ServiceIAMMemberDiscoverer:
 		return v.lister != nil
 	case *cloudFunctions2FunctionIAMMemberDiscoverer:
+		return v.lister != nil
+	// Bundle G3 — sub-resources (#475). Each sub-resource discoverer
+	// reaches in through its own lister; identical nil-check shape
+	// since neither type uses the shared IAM lister.
+	case *secretManagerSecretVersionDiscoverer:
+		return v.lister != nil
+	case *storageBucketObjectDiscoverer:
 		return v.lister != nil
 	default:
 		fmt.Fprintf(os.Stderr, "WARN: %s: no lister-check wired in nonCAIDiscovererHasLister — extend the switch when adding a non-CAI type\n", d.ResourceType())

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover_test.go
@@ -73,6 +73,9 @@ var expectedRegisteredTypes = map[string]bool{
 	"google_compute_health_check":            false,
 	"google_compute_managed_ssl_certificate": false,
 	"google_compute_target_http_proxy":       false,
+	// Bundle G3 — sub-resources (#475).
+	"google_secret_manager_secret_version": false,
+	"google_storage_bucket_object":         false,
 }
 
 func TestNewGCPDiscoverer_RegistersExpectedTypes(t *testing.T) {
@@ -742,6 +745,10 @@ var expectedScopeStyle = map[string]ScopeStyle{
 	"google_compute_health_check":            ScopeStyleNamePrefix,
 	"google_compute_managed_ssl_certificate": ScopeStyleNamePrefix,
 	"google_compute_target_http_proxy":       ScopeStyleNamePrefix,
+	// Bundle G3 — sub-resources (#475). Versions/objects aren't in
+	// CAI; each fans out across its parent's CAI rows.
+	"google_secret_manager_secret_version": ScopeStyleNonCAI,
+	"google_storage_bucket_object":         ScopeStyleNonCAI,
 }
 
 // TestScopeStyle_PinsPerTypeContract is the regression guard (#366).

--- a/cmd/insideout-import/gcpdiscover/non_cai_listers.go
+++ b/cmd/insideout-import/gcpdiscover/non_cai_listers.go
@@ -439,6 +439,165 @@ func (l *RealIAMPolicyLister) GetBucketIAMPolicy(ctx context.Context, bucketName
 	return out, nil
 }
 
+// ---- Sub-resources (Bundle G3, #475) ----------------------------------
+
+// gcpSecretVersion is the projected view of a Secret Manager
+// version row used by the secret_manager_secret_version discoverer.
+// Mirrors the projection rationale on gcpLoggingSink — the per-version
+// fields the discoverer needs to compose the row, decoupled from the
+// upstream SDK type.
+type gcpSecretVersion struct {
+	Name       string // projects/<p>/secrets/<s>/versions/<v>
+	SecretFull string // projects/<p>/secrets/<s>
+	Version    string // the trailing path segment (numeric usually)
+	State      string // ENABLED / DISABLED / DESTROYED
+}
+
+type gcpSecretVersionLister interface {
+	// ListSecretVersions returns the versions on a single Secret
+	// Manager secret. The discoverer fans this out across the
+	// google_secret_manager_secret rows discovered by the CAI phase.
+	ListSecretVersions(ctx context.Context, projectID, secretFullName string) ([]gcpSecretVersion, error)
+}
+
+// RealSecretVersionLister wraps google.golang.org/api/secretmanager/v1.
+type RealSecretVersionLister struct {
+	svc *secretmanager.Service
+}
+
+// NewRealSecretVersionLister constructs a secret version lister backed
+// by ADC. Mirrors the *RealAssetSearcher / *RealSQLUserLister export
+// pattern so callers in cmd/insideout-import can store the concrete
+// type for lifecycle control. Returns a wrapped error on auth setup
+// failure.
+func NewRealSecretVersionLister(ctx context.Context) (*RealSecretVersionLister, error) {
+	svc, err := secretmanager.NewService(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create secretmanager client: %w", err)
+	}
+	return &RealSecretVersionLister{svc: svc}, nil
+}
+
+func (l *RealSecretVersionLister) ListSecretVersions(ctx context.Context, projectID, secretFullName string) ([]gcpSecretVersion, error) {
+	if l == nil || l.svc == nil {
+		return nil, errors.New("secretmanager client closed")
+	}
+	var out []gcpSecretVersion
+	call := l.svc.Projects.Secrets.Versions.List(secretFullName).Context(ctx)
+	err := call.Pages(ctx, func(resp *secretmanager.ListSecretVersionsResponse) error {
+		for _, v := range resp.Versions {
+			if v == nil {
+				continue
+			}
+			// v.Name is "projects/<p>/secrets/<s>/versions/<n>"; the
+			// trailing path segment is the version's short ID. We
+			// surface it as Version so the discoverer composes the
+			// import ID without re-parsing.
+			out = append(out, gcpSecretVersion{
+				Name:       v.Name,
+				SecretFull: secretFullName,
+				Version:    shortName("/" + v.Name),
+				State:      v.State,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, wrapGCPAPIError("list secret versions", err)
+	}
+	return out, nil
+}
+
+// gcpBucketObject is the projected view of a GCS object row used by
+// the storage_bucket_object discoverer. The Md5 field is opportunistic
+// — the API returns it for most objects but it can be absent for very
+// large or in-progress uploads; downstream rendering tolerates an empty
+// string.
+type gcpBucketObject struct {
+	Bucket string
+	Name   string // object name (may include slashes)
+	Md5    string // optional, may be empty
+}
+
+// defaultMaxBucketObjects caps the per-bucket object enumeration to
+// keep blast-radius small for buckets holding millions of objects.
+// The discoverer fires a ServiceWarn when truncation kicks in so
+// operators see they're hitting the cap rather than silently
+// under-reporting their state. The cap is a package-level constant
+// (not a parameter) on purpose: operators with huge buckets almost
+// never manage individual objects in Terraform, and the 1K ceiling
+// surfaces the realistic cases without overwhelming the import
+// workflow.
+const defaultMaxBucketObjects = 1000
+
+// errBucketObjectsTruncated is the sentinel the lister returns
+// alongside a populated result slice when it hits
+// defaultMaxBucketObjects. The discoverer recognizes this sentinel to
+// emit a ServiceWarn (vs treating it as a soft-fail that drops the
+// whole bucket's worth of rows). The slice is still returned — the
+// truncation is "stop early," not "discard."
+var errBucketObjectsTruncated = errors.New("bucket object list truncated at the per-bucket cap")
+
+type gcpBucketObjectLister interface {
+	// ListBucketObjects returns up to defaultMaxBucketObjects objects
+	// from a single bucket. When the bucket holds more than the cap,
+	// the implementation returns the first N objects along with
+	// errBucketObjectsTruncated so the caller can emit a truncation
+	// warning. Other errors are returned with a nil slice per the usual
+	// convention.
+	ListBucketObjects(ctx context.Context, bucketName string) ([]gcpBucketObject, error)
+}
+
+// RealBucketObjectLister wraps google.golang.org/api/storage/v1.
+type RealBucketObjectLister struct {
+	svc *storage.Service
+}
+
+// NewRealBucketObjectLister constructs a GCS object lister backed by
+// ADC. Same nil-tolerant export pattern as the other Real* listers.
+func NewRealBucketObjectLister(ctx context.Context) (*RealBucketObjectLister, error) {
+	svc, err := storage.NewService(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create storage client: %w", err)
+	}
+	return &RealBucketObjectLister{svc: svc}, nil
+}
+
+func (l *RealBucketObjectLister) ListBucketObjects(ctx context.Context, bucketName string) ([]gcpBucketObject, error) {
+	if l == nil || l.svc == nil {
+		return nil, errors.New("storage client closed")
+	}
+	out := make([]gcpBucketObject, 0, defaultMaxBucketObjects)
+	call := l.svc.Objects.List(bucketName).Context(ctx)
+	// Bail early from the pagination loop once we hit the cap. The
+	// page callback returning a non-nil error tells the SDK to stop
+	// fetching subsequent pages; we re-distinguish "real" errors from
+	// the truncation sentinel in the caller below.
+	pageErr := call.Pages(ctx, func(resp *storage.Objects) error {
+		for _, o := range resp.Items {
+			if o == nil {
+				continue
+			}
+			out = append(out, gcpBucketObject{
+				Bucket: bucketName,
+				Name:   o.Name,
+				Md5:    o.Md5Hash,
+			})
+			if len(out) >= defaultMaxBucketObjects {
+				return errBucketObjectsTruncated
+			}
+		}
+		return nil
+	})
+	if pageErr != nil {
+		if errors.Is(pageErr, errBucketObjectsTruncated) {
+			return out, errBucketObjectsTruncated
+		}
+		return nil, wrapGCPAPIError("list bucket objects", pageErr)
+	}
+	return out, nil
+}
+
 // ---- shared error wrapping --------------------------------------------
 
 // wrapGCPAPIError annotates a Google API error with operator-actionable

--- a/cmd/insideout-import/gcpdiscover/secret_manager_secret_version.go
+++ b/cmd/insideout-import/gcpdiscover/secret_manager_secret_version.go
@@ -1,0 +1,103 @@
+package gcpdiscover
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// Per-type discoverer for google_secret_manager_secret_version
+// (Bundle G3, #475).
+//
+// Secret versions aren't surfaced by Cloud Asset Inventory's
+// SearchAllResources — they live one level below the
+// secretmanager.googleapis.com/Secret asset type. The discoverer fans
+// out across the google_secret_manager_secret rows discovered during
+// the CAI phase, calling
+// secretmanager.googleapis.com/v1/projects/<p>/secrets/<s>/versions
+// per parent secret via gcpSecretVersionLister.
+//
+// Terraform import ID:
+//
+//	projects/<project>/secrets/<secret_id>/versions/<version>
+//
+//	https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version#import
+//
+// Per-parent failures soft-fail through the progress emitter so a
+// single inaccessible secret doesn't drop versions on the rest.
+// Secrets rarely hold more than a handful of versions, so there's no
+// truncation cap here (compare storage_bucket_object).
+
+const (
+	secretManagerSecretVersionTFType    = "google_secret_manager_secret_version"
+	secretManagerSecretVersionAssetType = "secretmanager.googleapis.com/SecretVersion" // descriptive only; CAI rejects this
+)
+
+type secretManagerSecretVersionDiscoverer struct {
+	lister gcpSecretVersionLister
+}
+
+func newSecretManagerSecretVersionDiscoverer(lister gcpSecretVersionLister) Discoverer {
+	return &secretManagerSecretVersionDiscoverer{lister: lister}
+}
+
+func (secretManagerSecretVersionDiscoverer) ResourceType() string {
+	return secretManagerSecretVersionTFType
+}
+func (secretManagerSecretVersionDiscoverer) AssetType() string {
+	return secretManagerSecretVersionAssetType
+}
+func (secretManagerSecretVersionDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleNonCAI }
+
+func (secretManagerSecretVersionDiscoverer) FromAsset(_ addressBook, _ gcpAssetResult, _ string) imported.ImportedResource {
+	return imported.ImportedResource{}
+}
+
+func (secretManagerSecretVersionDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, _, _ string) (imported.ImportedResource, error) {
+	return imported.ImportedResource{}, fmt.Errorf("secret_manager_secret_version: dep-chase by ID not supported for non-CAI types: %w", ErrNotSupported)
+}
+
+// ListNonCAI walks priorResults for google_secret_manager_secret rows
+// and queries each secret's versions. Per-parent failures soft-fail
+// via a ServiceWarn — mirrors the sql_user precedent so the UI's
+// progress stream sees the same signal stderr would (#396).
+func (d *secretManagerSecretVersionDiscoverer) ListNonCAI(ctx context.Context, projectID, _ string, priorResults []imported.ImportedResource, emitter progress.Emitter) ([]imported.ImportedResource, error) {
+	if d.lister == nil {
+		return nil, nil
+	}
+	book := addressBook{}
+	var out []imported.ImportedResource
+	for _, prior := range priorResults {
+		if prior.Identity.Type != secretManagerSecretTFType {
+			continue
+		}
+		secretFullName := prior.Identity.ImportID
+		secretShort := prior.Identity.NameHint
+		versions, err := d.lister.ListSecretVersions(ctx, projectID, secretFullName)
+		if err != nil {
+			msg := fmt.Sprintf("secret_manager_secret_version: list failed for secret %q in project %q (continuing): %v", secretFullName, projectID, err)
+			emitter.ServiceWarn(nonCAIServiceSlug, "", msg)
+			continue
+		}
+		for _, v := range versions {
+			importID := secretManagerSecretVersionImportID(secretFullName, v.Version)
+			name := secretShort + "-v" + v.Version
+			out = append(out, makeImportedResource(book, secretManagerSecretVersionTFType, name, importID, projectID, "", map[string]string{
+				"secret":  secretFullName,
+				"version": v.Version,
+				"state":   v.State,
+			}, nil))
+		}
+	}
+	return out, nil
+}
+
+// secretManagerSecretVersionImportID composes the Terraform import-ID
+// per provider docs:
+//
+//	projects/<p>/secrets/<id>/versions/<v>
+func secretManagerSecretVersionImportID(secretFullName, version string) string {
+	return secretFullName + "/versions/" + version
+}

--- a/cmd/insideout-import/gcpdiscover/secret_manager_secret_version_test.go
+++ b/cmd/insideout-import/gcpdiscover/secret_manager_secret_version_test.go
@@ -1,0 +1,126 @@
+package gcpdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+func TestSecretManagerSecretVersionListNonCAI_FansOutAcrossPriors(t *testing.T) {
+	t.Parallel()
+	secretA := "projects/p/secrets/sec-a"
+	secretB := "projects/p/secrets/sec-b"
+	fake := &fakeSecretVersionLister{
+		versionsBySecret: map[string][]gcpSecretVersion{
+			secretA: {
+				{Name: secretA + "/versions/1", SecretFull: secretA, Version: "1", State: "ENABLED"},
+				{Name: secretA + "/versions/2", SecretFull: secretA, Version: "2", State: "DISABLED"},
+			},
+			secretB: {
+				{Name: secretB + "/versions/1", SecretFull: secretB, Version: "1", State: "ENABLED"},
+			},
+		},
+	}
+	d := newSecretManagerSecretVersionDiscoverer(fake).(*secretManagerSecretVersionDiscoverer)
+	prior := []imported.ImportedResource{
+		makeSecretResult("p", "sec-a"),
+		makeSecretResult("p", "sec-b"),
+		// Non-secret prior: must be skipped (no spurious fanout).
+		{Identity: imported.ResourceIdentity{Type: storageBucketTFType, NameHint: "io-foo"}},
+	}
+	got, err := d.ListNonCAI(context.Background(), "p", "", prior, progress.NopEmitter{})
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	// Two parent secrets queried — non-secret prior didn't trigger a list.
+	require.Len(t, fake.calls, 2)
+
+	byImport := map[string]bool{}
+	for _, r := range got {
+		byImport[r.Identity.ImportID] = true
+	}
+	assert.True(t, byImport[secretA+"/versions/1"])
+	assert.True(t, byImport[secretA+"/versions/2"])
+	assert.True(t, byImport[secretB+"/versions/1"])
+}
+
+func TestSecretManagerSecretVersionListNonCAI_PerParentErrorSoftFails(t *testing.T) {
+	t.Parallel()
+	secretA := "projects/p/secrets/sec-a"
+	secretB := "projects/p/secrets/sec-b"
+	fake := &fakeSecretVersionLister{
+		versionsBySecret: map[string][]gcpSecretVersion{
+			secretA: {{Name: secretA + "/versions/1", SecretFull: secretA, Version: "1", State: "ENABLED"}},
+		},
+		errBySecret: map[string]error{
+			secretB: errors.New("secret not accessible"),
+		},
+	}
+	d := newSecretManagerSecretVersionDiscoverer(fake).(*secretManagerSecretVersionDiscoverer)
+	prior := []imported.ImportedResource{
+		makeSecretResult("p", "sec-a"),
+		makeSecretResult("p", "sec-b"),
+	}
+	rec := &recordingEmitter{}
+	got, err := d.ListNonCAI(context.Background(), "p", "", prior, rec)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, secretA+"/versions/1", got[0].Identity.ImportID)
+
+	var warns []recordedEvent
+	for _, ev := range rec.snapshot() {
+		if ev.Kind == "service_warn" {
+			warns = append(warns, ev)
+		}
+	}
+	require.Len(t, warns, 1)
+	assert.Equal(t, nonCAIServiceSlug, warns[0].Service)
+	// Two separate Contains checks so a failure pinpoints which
+	// fragment is missing (parent path vs underlying error) rather
+	// than blanket-reporting "missing either".
+	assert.Contains(t, warns[0].Message, "sec-b",
+		"warn message must name the failing secret")
+	assert.Contains(t, warns[0].Message, "secret not accessible",
+		"warn message must include the underlying error")
+}
+
+func TestSecretManagerSecretVersionListNonCAI_NilListerTolerated(t *testing.T) {
+	t.Parallel()
+	d := newSecretManagerSecretVersionDiscoverer(nil).(*secretManagerSecretVersionDiscoverer)
+	got, err := d.ListNonCAI(context.Background(), "p", "", []imported.ImportedResource{makeSecretResult("p", "s")}, progress.NopEmitter{})
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestSecretManagerSecretVersionListNonCAI_NoPriorParentsYieldsNoFanout(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSecretVersionLister{}
+	d := newSecretManagerSecretVersionDiscoverer(fake).(*secretManagerSecretVersionDiscoverer)
+	got, err := d.ListNonCAI(context.Background(), "p", "", nil, progress.NopEmitter{})
+	require.NoError(t, err)
+	require.Nil(t, got)
+	require.Empty(t, fake.calls, "lister must be untouched when no secret priors exist")
+}
+
+func TestSecretManagerSecretVersionImportID(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, secret, version, want string
+	}{
+		{name: "numeric version", secret: "projects/p/secrets/sec", version: "1",
+			want: "projects/p/secrets/sec/versions/1"},
+		{name: "latest alias", secret: "projects/p/secrets/other", version: "latest",
+			want: "projects/p/secrets/other/versions/latest"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, secretManagerSecretVersionImportID(tc.secret, tc.version))
+		})
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/storage_bucket_object.go
+++ b/cmd/insideout-import/gcpdiscover/storage_bucket_object.go
@@ -1,0 +1,120 @@
+package gcpdiscover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// Per-type discoverer for google_storage_bucket_object (Bundle G3, #475).
+//
+// GCS objects aren't surfaced by Cloud Asset Inventory — only the
+// containing storage.googleapis.com/Bucket is. This discoverer fans out
+// across the google_storage_bucket rows discovered during the CAI phase
+// and lists objects per bucket via gcpBucketObjectLister.
+//
+// Terraform import ID:
+//
+//	<bucket>/<object_name>
+//
+//	https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object#import
+//
+// **Cardinality risk:** GCS buckets can hold millions of objects. The
+// per-bucket enumeration is capped by the lister at
+// defaultMaxBucketObjects (1000); when truncation fires, the lister
+// returns its partial slice along with errBucketObjectsTruncated and
+// the discoverer emits a ServiceWarn so the operator sees the cap was
+// hit. Practical reasoning lives on the constant — operators with
+// huge buckets generally don't manage individual objects in
+// Terraform, and the cap surfaces realistic cases without overwhelming
+// the import workflow.
+//
+// Per-parent failures soft-fail through the progress emitter (same
+// pattern as sql_user / G1 IAM discoverers).
+
+const (
+	storageBucketObjectTFType    = "google_storage_bucket_object"
+	storageBucketObjectAssetType = "storage.googleapis.com/Object" // descriptive only; CAI rejects this
+)
+
+type storageBucketObjectDiscoverer struct {
+	lister gcpBucketObjectLister
+}
+
+func newStorageBucketObjectDiscoverer(lister gcpBucketObjectLister) Discoverer {
+	return &storageBucketObjectDiscoverer{lister: lister}
+}
+
+func (storageBucketObjectDiscoverer) ResourceType() string   { return storageBucketObjectTFType }
+func (storageBucketObjectDiscoverer) AssetType() string      { return storageBucketObjectAssetType }
+func (storageBucketObjectDiscoverer) ScopeStyle() ScopeStyle { return ScopeStyleNonCAI }
+
+func (storageBucketObjectDiscoverer) FromAsset(_ addressBook, _ gcpAssetResult, _ string) imported.ImportedResource {
+	return imported.ImportedResource{}
+}
+
+func (storageBucketObjectDiscoverer) DiscoverByID(_ context.Context, _ gcpAssetSearcher, _, _ string) (imported.ImportedResource, error) {
+	return imported.ImportedResource{}, fmt.Errorf("storage_bucket_object: dep-chase by ID not supported for non-CAI types: %w", ErrNotSupported)
+}
+
+// ListNonCAI walks priorResults for google_storage_bucket rows and
+// enumerates objects per bucket. Truncation at the per-bucket cap
+// surfaces as a ServiceWarn; the returned slice still includes
+// whatever was discovered before the cap fired. Real (non-truncation)
+// errors soft-fail per the usual sql_user/IAM pattern.
+func (d *storageBucketObjectDiscoverer) ListNonCAI(ctx context.Context, projectID, _ string, priorResults []imported.ImportedResource, emitter progress.Emitter) ([]imported.ImportedResource, error) {
+	if d.lister == nil {
+		return nil, nil
+	}
+	book := addressBook{}
+	var out []imported.ImportedResource
+	for _, prior := range priorResults {
+		if prior.Identity.Type != storageBucketTFType {
+			continue
+		}
+		bucket := prior.Identity.NameHint
+		objects, err := d.lister.ListBucketObjects(ctx, bucket)
+		switch {
+		case errors.Is(err, errBucketObjectsTruncated):
+			// Truncation is not a soft-fail — objects[:cap] is
+			// still legitimate; just warn so the operator sees they
+			// hit the ceiling. Fall through to emit the rows we got.
+			msg := fmt.Sprintf("storage_bucket_object: bucket %q has more than %d objects; truncated", bucket, defaultMaxBucketObjects)
+			emitter.ServiceWarn(nonCAIServiceSlug, "", msg)
+		case err != nil:
+			msg := fmt.Sprintf("storage_bucket_object: list failed for bucket %q (continuing): %v", bucket, err)
+			emitter.ServiceWarn(nonCAIServiceSlug, "", msg)
+			continue
+		}
+		for _, o := range objects {
+			importID := storageBucketObjectImportID(bucket, o.Name)
+			out = append(out, makeImportedResource(book, storageBucketObjectTFType, storageBucketObjectNameHint(bucket, o.Name), importID, projectID, "", map[string]string{
+				"bucket": bucket,
+				"name":   o.Name,
+				"md5":    o.Md5,
+			}, nil))
+		}
+	}
+	return out, nil
+}
+
+// storageBucketObjectImportID composes the Terraform import-ID per
+// provider docs: "<bucket>/<object_name>". Object names may contain
+// slashes themselves (folder-shaped keys); we preserve them verbatim
+// because the provider's parser splits on the first slash to extract
+// the bucket and treats everything after as the object key.
+func storageBucketObjectImportID(bucket, name string) string {
+	return bucket + "/" + name
+}
+
+// storageBucketObjectNameHint composes a terraform-address-safe name
+// hint from the bucket and object name. The composer's GenerateAddress
+// already sanitizes the result, but joining bucket + object up-front
+// keeps row collisions to a minimum when one stack has multiple
+// objects with the same basename across different buckets.
+func storageBucketObjectNameHint(bucket, name string) string {
+	return bucket + "-" + name
+}

--- a/cmd/insideout-import/gcpdiscover/storage_bucket_object_test.go
+++ b/cmd/insideout-import/gcpdiscover/storage_bucket_object_test.go
@@ -1,0 +1,182 @@
+package gcpdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// makeBucketResult mirrors the CAI-fanout output that storage_bucket_object
+// reads from priorResults. Keep the minimum field set the discoverer
+// actually consumes (Type + NameHint) so the test signal stays focused.
+func makeBucketResult(name string) imported.ImportedResource {
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "gcp",
+			Type:     storageBucketTFType,
+			NameHint: name,
+			ImportID: name,
+		},
+	}
+}
+
+func TestStorageBucketObjectListNonCAI_FansOutAcrossPriors(t *testing.T) {
+	t.Parallel()
+	fake := &fakeBucketObjectLister{
+		objectsByBucket: map[string][]gcpBucketObject{
+			"bucket-a": {
+				{Bucket: "bucket-a", Name: "foo.txt", Md5: "aa=="},
+				{Bucket: "bucket-a", Name: "folder/bar.json", Md5: "bb=="},
+			},
+			"bucket-b": {
+				{Bucket: "bucket-b", Name: "baz.yaml"},
+			},
+		},
+	}
+	d := newStorageBucketObjectDiscoverer(fake).(*storageBucketObjectDiscoverer)
+	prior := []imported.ImportedResource{
+		makeBucketResult("bucket-a"),
+		makeBucketResult("bucket-b"),
+		// Non-bucket prior: must be skipped (no spurious fanout).
+		{Identity: imported.ResourceIdentity{Type: secretManagerSecretTFType, NameHint: "sec"}},
+	}
+	got, err := d.ListNonCAI(context.Background(), "p", "", prior, progress.NopEmitter{})
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	require.Len(t, fake.calls, 2)
+
+	byImport := map[string]bool{}
+	for _, r := range got {
+		byImport[r.Identity.ImportID] = true
+	}
+	assert.True(t, byImport["bucket-a/foo.txt"])
+	// Object names containing slashes must survive into the import ID
+	// verbatim — the provider splits on the first slash only.
+	assert.True(t, byImport["bucket-a/folder/bar.json"])
+	assert.True(t, byImport["bucket-b/baz.yaml"])
+}
+
+func TestStorageBucketObjectListNonCAI_PerParentErrorSoftFails(t *testing.T) {
+	t.Parallel()
+	fake := &fakeBucketObjectLister{
+		objectsByBucket: map[string][]gcpBucketObject{
+			"bucket-a": {{Bucket: "bucket-a", Name: "foo.txt"}},
+		},
+		errByBucket: map[string]error{
+			"bucket-b": errors.New("bucket not accessible"),
+		},
+	}
+	d := newStorageBucketObjectDiscoverer(fake).(*storageBucketObjectDiscoverer)
+	prior := []imported.ImportedResource{
+		makeBucketResult("bucket-a"),
+		makeBucketResult("bucket-b"),
+	}
+	rec := &recordingEmitter{}
+	got, err := d.ListNonCAI(context.Background(), "p", "", prior, rec)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "bucket-a/foo.txt", got[0].Identity.ImportID)
+
+	var warns []recordedEvent
+	for _, ev := range rec.snapshot() {
+		if ev.Kind == "service_warn" {
+			warns = append(warns, ev)
+		}
+	}
+	require.Len(t, warns, 1)
+	assert.Equal(t, nonCAIServiceSlug, warns[0].Service)
+	assert.Contains(t, warns[0].Message, "bucket-b",
+		"warn message must name the failing bucket")
+	assert.Contains(t, warns[0].Message, "bucket not accessible",
+		"warn message must include the underlying error")
+}
+
+func TestStorageBucketObjectListNonCAI_NilListerTolerated(t *testing.T) {
+	t.Parallel()
+	d := newStorageBucketObjectDiscoverer(nil).(*storageBucketObjectDiscoverer)
+	got, err := d.ListNonCAI(context.Background(), "p", "", []imported.ImportedResource{makeBucketResult("b")}, progress.NopEmitter{})
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestStorageBucketObjectListNonCAI_NoPriorParentsYieldsNoFanout(t *testing.T) {
+	t.Parallel()
+	fake := &fakeBucketObjectLister{}
+	d := newStorageBucketObjectDiscoverer(fake).(*storageBucketObjectDiscoverer)
+	got, err := d.ListNonCAI(context.Background(), "p", "", nil, progress.NopEmitter{})
+	require.NoError(t, err)
+	require.Nil(t, got)
+	require.Empty(t, fake.calls, "lister must be untouched when no bucket priors exist")
+}
+
+// TestStorageBucketObjectListNonCAI_RespectsTruncationCap pins the
+// per-bucket cap behavior. The fake lister flags `huge-bucket` as
+// truncated; the discoverer must emit a ServiceWarn AND still surface
+// the partial slice of rows (truncation is "stop early," not
+// "discard everything"). Without this assertion a regression that
+// either swallowed the warn or treated truncation as a soft-fail
+// would compile green.
+func TestStorageBucketObjectListNonCAI_RespectsTruncationCap(t *testing.T) {
+	t.Parallel()
+	// Three canned objects that simulate the truncated tip of a huge
+	// bucket. The test doesn't need to actually generate >1000 rows —
+	// the lister-side cap and discoverer-side warn are independently
+	// testable thanks to the sentinel.
+	partial := []gcpBucketObject{
+		{Bucket: "huge-bucket", Name: "a.txt"},
+		{Bucket: "huge-bucket", Name: "b.txt"},
+		{Bucket: "huge-bucket", Name: "c.txt"},
+	}
+	fake := &fakeBucketObjectLister{
+		objectsByBucket: map[string][]gcpBucketObject{
+			"huge-bucket": partial,
+			"small-bucket": {
+				{Bucket: "small-bucket", Name: "only.txt"},
+			},
+		},
+		truncateBucket: map[string]bool{"huge-bucket": true},
+	}
+	d := newStorageBucketObjectDiscoverer(fake).(*storageBucketObjectDiscoverer)
+	prior := []imported.ImportedResource{
+		makeBucketResult("huge-bucket"),
+		makeBucketResult("small-bucket"),
+	}
+	rec := &recordingEmitter{}
+	got, err := d.ListNonCAI(context.Background(), "p", "", prior, rec)
+	require.NoError(t, err)
+	// Partial slice for huge-bucket (3) + small-bucket (1) = 4 rows.
+	require.Len(t, got, 4, "truncated bucket must still surface its partial rows")
+
+	var warns []recordedEvent
+	for _, ev := range rec.snapshot() {
+		if ev.Kind == "service_warn" {
+			warns = append(warns, ev)
+		}
+	}
+	require.Len(t, warns, 1, "exactly one truncation warn expected (small-bucket must not warn)")
+	assert.Contains(t, warns[0].Message, "huge-bucket")
+	assert.Contains(t, warns[0].Message, "truncated")
+}
+
+func TestStorageBucketObjectImportID(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, bucket, object, want string
+	}{
+		{name: "simple name", bucket: "my-bucket", object: "foo.txt", want: "my-bucket/foo.txt"},
+		{name: "folder-shaped key", bucket: "my-bucket", object: "a/b/c.json", want: "my-bucket/a/b/c.json"},
+		{name: "leading slash preserved", bucket: "b", object: "/leading", want: "b//leading"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, storageBucketObjectImportID(tc.bucket, tc.object))
+		})
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/testhelpers_test.go
+++ b/cmd/insideout-import/gcpdiscover/testhelpers_test.go
@@ -379,3 +379,53 @@ func (f *fakeIAMPolicyLister) GetBucketIAMPolicy(_ context.Context, bucketName s
 	}
 	return f.bindingsByBucket[bucketName], nil
 }
+
+// fakeSecretVersionLister returns canned versions per-parent. Keyed
+// on the secret's full name ("projects/<p>/secrets/<s>"); an unmapped
+// parent yields zero versions (legitimate empty state). Mirrors the
+// fakeSQLUserLister shape — per-key canned response, per-key error
+// injection, and a call record that pins the fanout.
+type fakeSecretVersionLister struct {
+	versionsBySecret map[string][]gcpSecretVersion
+	errBySecret      map[string]error
+	calls            []struct {
+		projectID      string
+		secretFullName string
+	}
+}
+
+func (f *fakeSecretVersionLister) ListSecretVersions(_ context.Context, projectID, secretFullName string) ([]gcpSecretVersion, error) {
+	f.calls = append(f.calls, struct {
+		projectID      string
+		secretFullName string
+	}{projectID, secretFullName})
+	if err, ok := f.errBySecret[secretFullName]; ok {
+		return nil, err
+	}
+	return f.versionsBySecret[secretFullName], nil
+}
+
+// fakeBucketObjectLister returns canned objects per-bucket. Keyed on
+// the bucket name; an unmapped parent yields zero objects. The
+// `truncateBucket` set lets a test pin the truncation path — a bucket
+// whose name is in the set returns errBucketObjectsTruncated alongside
+// its canned slice, regardless of slice length, so the discoverer's
+// warn path is exercisable without having to actually build 1000+
+// canned objects.
+type fakeBucketObjectLister struct {
+	objectsByBucket map[string][]gcpBucketObject
+	errByBucket     map[string]error
+	truncateBucket  map[string]bool
+	calls           []string
+}
+
+func (f *fakeBucketObjectLister) ListBucketObjects(_ context.Context, bucketName string) ([]gcpBucketObject, error) {
+	f.calls = append(f.calls, bucketName)
+	if err, ok := f.errByBucket[bucketName]; ok {
+		return nil, err
+	}
+	if f.truncateBucket[bucketName] {
+		return f.objectsByBucket[bucketName], errBucketObjectsTruncated
+	}
+	return f.objectsByBucket[bucketName], nil
+}

--- a/pkg/composer/imported/category.go
+++ b/pkg/composer/imported/category.go
@@ -236,10 +236,12 @@ var categoryByTFType = map[string]string{
 	"google_secret_manager_secret":               CategorySecurity,
 	"google_secret_manager_secret_iam_binding":   CategorySecurity,
 	"google_secret_manager_secret_iam_member":    CategorySecurity,
+	"google_secret_manager_secret_version":       CategorySecurity,
 	"google_service_account":                     CategorySecurity,
 	"google_sql_database_instance":               CategoryDataStorage,
 	"google_sql_user":                            CategorySecurity,
 	"google_storage_bucket":                      CategoryDataStorage,
 	"google_storage_bucket_iam_member":           CategorySecurity,
+	"google_storage_bucket_object":               CategoryDataStorage,
 	"google_vertex_ai_dataset":                   CategoryDataStorage,
 }

--- a/pkg/composer/imported/testdata/category.golden
+++ b/pkg/composer/imported/testdata/category.golden
@@ -156,9 +156,11 @@ google_redis_instance	Data Storage
 google_secret_manager_secret	Security
 google_secret_manager_secret_iam_binding	Security
 google_secret_manager_secret_iam_member	Security
+google_secret_manager_secret_version	Security
 google_service_account	Security
 google_sql_database_instance	Data Storage
 google_sql_user	Security
 google_storage_bucket	Data Storage
 google_storage_bucket_iam_member	Security
+google_storage_bucket_object	Data Storage
 google_vertex_ai_dataset	Data Storage

--- a/pkg/insideout-import/permissions/gcp.json
+++ b/pkg/insideout-import/permissions/gcp.json
@@ -8,6 +8,8 @@
     {"service": "cloudresourcemanager", "gcp_role": "roles/iam.securityReviewer", "iam_permission": "resourcemanager.projects.getIamPolicy", "purpose": "Bundle G1 (#470): read project-level IAM policy to materialize google_project_iam_member rows"},
     {"service": "run", "gcp_role": "roles/run.viewer", "iam_permission": "run.services.getIamPolicy", "purpose": "Bundle G1 (#470): read per-service IAM bindings to materialize google_cloud_run_v2_service_iam_member rows"},
     {"service": "secretmanager", "gcp_role": "roles/secretmanager.viewer", "iam_permission": "secretmanager.secrets.getIamPolicy", "purpose": "Bundle G1 (#470): read per-secret IAM bindings to materialize google_secret_manager_secret_iam_binding and _iam_member rows"},
-    {"service": "storage", "gcp_role": "roles/storage.legacyBucketReader", "iam_permission": "storage.buckets.getIamPolicy", "purpose": "Bundle G1 (#470): read per-bucket IAM bindings to materialize google_storage_bucket_iam_member rows"}
+    {"service": "secretmanager", "gcp_role": "roles/secretmanager.viewer", "iam_permission": "secretmanager.versions.list", "purpose": "Bundle G3 (#475): enumerate per-secret versions to materialize google_secret_manager_secret_version rows"},
+    {"service": "storage", "gcp_role": "roles/storage.legacyBucketReader", "iam_permission": "storage.buckets.getIamPolicy", "purpose": "Bundle G1 (#470): read per-bucket IAM bindings to materialize google_storage_bucket_iam_member rows"},
+    {"service": "storage", "gcp_role": "roles/storage.objectViewer", "iam_permission": "storage.objects.list", "purpose": "Bundle G3 (#475): enumerate per-bucket objects (capped at 1000/bucket) to materialize google_storage_bucket_object rows"}
   ]
 }

--- a/pkg/insideout-import/registry/registry.go
+++ b/pkg/insideout-import/registry/registry.go
@@ -179,11 +179,13 @@ var gcpTypes = []string{
 	"google_secret_manager_secret",
 	"google_secret_manager_secret_iam_binding",
 	"google_secret_manager_secret_iam_member",
+	"google_secret_manager_secret_version",
 	"google_service_account",
 	"google_sql_database_instance",
 	"google_sql_user",
 	"google_storage_bucket",
 	"google_storage_bucket_iam_member",
+	"google_storage_bucket_object",
 	"google_vertex_ai_dataset",
 }
 

--- a/pkg/insideout-import/registry/registry_test.go
+++ b/pkg/insideout-import/registry/registry_test.go
@@ -178,11 +178,13 @@ func TestSupportedDiscoverTypes_GCP_ReturnsCanonicalSortedList(t *testing.T) {
 		"google_secret_manager_secret",
 		"google_secret_manager_secret_iam_binding",
 		"google_secret_manager_secret_iam_member",
+		"google_secret_manager_secret_version",
 		"google_service_account",
 		"google_sql_database_instance",
 		"google_sql_user",
 		"google_storage_bucket",
 		"google_storage_bucket_iam_member",
+		"google_storage_bucket_object",
 		"google_vertex_ai_dataset",
 	}
 	got := SupportedDiscoverTypes(ProviderGCP)


### PR DESCRIPTION
## Summary

Closes #475. Stacked on PRs #472 (G1) → #474 (G2). Adds 2 \`ScopeStyleNonCAI\` discoverers for sub-resources whose parent types are already in the registry but whose children aren't surfaced by Cloud Asset Inventory.

### Types (2)

| TF type | Parent TF type | SDK call per parent |
|---|---|---|
| \`google_secret_manager_secret_version\` | \`google_secret_manager_secret\` | \`secretmanager.versions.list\` |
| \`google_storage_bucket_object\` | \`google_storage_bucket\` | \`storage.objects.list\` |

## Pattern

Same fan-out-across-priors pattern as G1 (sql_user.go precedent). Two new listers — \`gcpSecretVersionLister\` and \`gcpBucketObjectLister\` — added to \`non_cai_listers.go\` with real impls and per-method test fakes.

## Cardinality safeguard

**Bucket objects can be millions per bucket.** \`defaultMaxBucketObjects = 1000\` cap in the lister; when reached, lister returns the partial slice + \`errBucketObjectsTruncated\` sentinel. The discoverer catches via \`errors.Is\` and emits a \`ServiceWarn\` so the operator sees \"bucket truncated at N\" in the progress stream. Both layers are independently testable (cap test pins partial-emit + warn).

Secret versions are bounded in practice (typically <10 per secret), no cap needed.

## TF import-IDs (pinned by table tests)

| TF type | Format |
|---|---|
| \`google_secret_manager_secret_version\` | \`projects/<project>/secrets/<secret>/versions/<version>\` |
| \`google_storage_bucket_object\` | \`<bucket>/<object_name>\` |

## Coverage delta

- Before G3: 40 / 47 (85.1%)
- After G3: 42 / 47 (89.4%)
- G4 (API enable + singletons, 5 types) closes the gap.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/insideout-import/gcpdiscover/... -race\` — 672 passed (+16 from G3)
- [x] \`terraform fmt -check -recursive\` clean
- [x] All 4 lint scripts pass
- [x] Full repo: 4915 tests pass

## Notes

- 4 \`unusedfunc\` false positives (map-literal indirection) — same as G1/G2/AWS-side bundles.
- Truncation cap lives in the lister (not discoverer) so a grep for either side surfaces the contract; doc comments cross-reference.

## Base branch

Stacked on \`feat/gcp-bundle-g2-lb-subcomponents\` (PR #474). Will rebase to main once G1+G2 merge.