### PR TITLE
feat(composer): pure ComputePresetDefaults overlay + safe VPC HCL defaults (#393)

### DIFF
--- a/aws/vpc/variables.tf
+++ b/aws/vpc/variables.tf
@@ -45,25 +45,26 @@ variable "az_count" {
 }
 
 variable "enable_nat_gateway" {
-  description = "Enable NAT gateways so private subnets can reach the public internet. Set false only for public-only VPCs (no private workloads). Topology (one vs one-per-AZ) is controlled by single_nat_gateway."
+  description = "Enable NAT gateways so private subnets can reach the public internet. Required for stacks with private workloads (EKS/ECS/RDS/ElastiCache/OpenSearch/EC2 node groups); leave false for public-only VPCs. Topology (one vs one-per-AZ) is controlled by single_nat_gateway. The InsideOut composer's mapper sets this explicitly based on selected components (#393) — the HCL default here is a backstop, not the source of truth."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "single_nat_gateway" {
   description = <<-EOT
     Provision exactly one NAT gateway (in the first public subnet / first AZ) shared by all private subnets,
-    instead of one NAT gateway per AZ. Defaults to true for cost.
+    instead of one NAT gateway per AZ. Defaults to false (one-per-AZ) for availability, matching the
+    upstream terraform-aws-modules/vpc/aws default.
 
-    - true (default): cheapest, ~1/N the NAT cost, but (a) single point of failure if that AZ goes down
-      and (b) every stack in the account lands its NAT in the first AZ — accounts running multiple stacks
-      can exhaust the per-AZ NAT gateway quota (default 5) before running out of the VPC quota.
-    - false: one NAT gateway per AZ (as bounded by az_count). ~N× cost, no per-AZ SPOF, spreads NAT
+    - false (default): one NAT gateway per AZ (as bounded by az_count). ~N× cost, no per-AZ SPOF, spreads NAT
       quota usage across AZs. Recommended once an account runs more than a handful of concurrent VPCs
       or whenever AZ-level availability is a requirement.
+    - true: cheapest, ~1/N the NAT cost, but (a) single point of failure if that AZ goes down
+      and (b) every stack in the account lands its NAT in the first AZ — accounts running multiple stacks
+      can exhaust the per-AZ NAT gateway quota (default 5) before running out of the VPC quota.
   EOT
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "enable_private_subnets" {

--- a/pkg/composer/defaults.go
+++ b/pkg/composer/defaults.go
@@ -115,11 +115,12 @@ func (c *Client) PresetDefaults() (map[string]map[string]any, error) {
 //     lose the user-vs-default distinction.
 //
 // Provenance is automatic — given the original cfg and the overlay:
-//   - A field present in overlay but zero in cfg was default-derived.
-//   - A field non-zero in cfg but absent from overlay was user-authored.
-//   - A field non-zero in both is user-authored equal-to-default and is
-//     preserved (unlike a reconstructive `PristineCopy` approach which would
-//     strip it).
+//   - A field zero in cfg, populated in overlay → default-derived.
+//   - A field non-zero in cfg → always user-authored (the overlay never echoes
+//     it back), including the case where the user explicitly set it equal to
+//     the default. A reconstructive `PristineCopy` approach would strip that
+//     case; this one preserves it because the overlay decision is per-field
+//     zero-check, not value-comparison.
 //
 // Backfill semantics, type coercion, and the silent-skip behavior on
 // unmappable types or HCL variables without a Config field are identical to

--- a/pkg/composer/defaults.go
+++ b/pkg/composer/defaults.go
@@ -101,6 +101,95 @@ func (c *Client) PresetDefaults() (map[string]map[string]any, error) {
 	return out, nil
 }
 
+// ComputePresetDefaults returns the overlay of statically-resolvable HCL
+// defaults that would fill the zero/nil leaf fields of cfg, for every key in
+// `selected` that has a preset module under the cloud indicated by comps.Cloud
+// (defaulting to "aws"). It does NOT mutate cfg. The returned overlay is a
+// sparse Config — only fields that defaults would write are populated.
+//
+// Callers can:
+//   - Apply the overlay: MergeConfigs(&cfg, &overlay) — same effect as the
+//     legacy ApplyPresetDefaults.
+//   - Display the overlay as "preset defaults" without touching user state.
+//   - Persist `cfg` as the user's pristine intent and merge on read; never
+//     lose the user-vs-default distinction.
+//
+// Provenance is automatic — given the original cfg and the overlay:
+//   - A field present in overlay but zero in cfg was default-derived.
+//   - A field non-zero in cfg but absent from overlay was user-authored.
+//   - A field non-zero in both is user-authored equal-to-default and is
+//     preserved (unlike a reconstructive `PristineCopy` approach which would
+//     strip it).
+//
+// Backfill semantics, type coercion, and the silent-skip behavior on
+// unmappable types or HCL variables without a Config field are identical to
+// ApplyPresetDefaults — see that function's doc comment for the full table.
+//
+// Returns an error only on HCL-parse / FS failures; missing presets or
+// unmappable values are silently skipped.
+func (c *Client) ComputePresetDefaults(cfg Config, comps *Components, selected []ComponentKey) (Config, error) {
+	var out Config
+	if c.presets == nil {
+		return out, ErrNoPresetFS
+	}
+	cloud := "aws"
+	if comps != nil && comps.Cloud != "" {
+		cloud = strings.ToLower(comps.Cloud)
+	}
+
+	// Build a JSON-tag → struct-field-index map for Config's nested *struct
+	// fields, so we can look up which Config field matches a given
+	// ComponentKey (whose string form equals the JSON tag, e.g. "aws_ec2").
+	// cfg and out share the same Config type, so one index serves both.
+	cfgVal := reflect.ValueOf(&cfg).Elem()
+	outVal := reflect.ValueOf(&out).Elem()
+	cfgType := cfgVal.Type()
+	tagIndex := map[string]int{}
+	for i := 0; i < cfgType.NumField(); i++ {
+		ft := cfgType.Field(i)
+		if ft.Type.Kind() != reflect.Ptr || ft.Type.Elem().Kind() != reflect.Struct {
+			continue
+		}
+		tag := jsonTagName(ft.Tag.Get("json"))
+		if tag != "" {
+			tagIndex[tag] = i
+		}
+	}
+
+	for _, key := range selected {
+		fieldIdx, ok := tagIndex[string(key)]
+		if !ok {
+			continue
+		}
+		path := GetPresetPath(cloud, key, comps)
+		files, err := c.GetPresetFiles(path)
+		if err != nil {
+			// Missing preset module: not an error, just nothing to fill.
+			continue
+		}
+		defaults, err := ModuleDefaults(files)
+		if err != nil {
+			return out, fmt.Errorf("composer: reading defaults for %s: %w", path, err)
+		}
+		if len(defaults) == 0 {
+			continue
+		}
+
+		// Leaf zero-check reads cfg's inner struct (may be nil → all fields
+		// treated as zero); writes go into out's parallel inner struct,
+		// allocated on demand.
+		cfgInner := cfgVal.Field(fieldIdx)
+		outInner := outVal.Field(fieldIdx)
+		outInner.Set(reflect.New(outInner.Type().Elem()))
+		filled := overlayStructFromDefaults(cfgInner, outInner.Elem(), defaults)
+		if !filled {
+			// Nothing landed; revert to nil so the field stays omitempty.
+			outInner.Set(reflect.Zero(outInner.Type()))
+		}
+	}
+	return out, nil
+}
+
 // ApplyPresetDefaults backfills cfg with statically-resolvable HCL defaults
 // for every key in `selected` that has a preset module under the cloud
 // indicated by comps.Cloud (defaulting to "aws"). It is the typed-Config
@@ -108,6 +197,11 @@ func (c *Client) PresetDefaults() (map[string]map[string]any, error) {
 // "preset path → variable → value" map, this function lifts those values into
 // the matching nested *struct fields of Config, performing snake_case ↔
 // camelCase JSON-tag matching and per-field type coercion.
+//
+// New code should prefer ComputePresetDefaults, which returns the overlay
+// without mutating cfg — preserving the user-vs-default distinction the
+// in-place mutation otherwise loses. This wrapper is preserved for the
+// existing cross-repo consumer (luthersystems/reliable#1435).
 //
 // Backfill semantics — a Config field is filled ONLY when its current value
 // is the zero value for its type (per reflect.Value.IsZero):
@@ -142,66 +236,14 @@ func (c *Client) PresetDefaults() (map[string]map[string]any, error) {
 // Returns an error only on HCL-parse / FS failures; missing presets or
 // unmappable values are silently skipped.
 func (c *Client) ApplyPresetDefaults(cfg *Config, comps *Components, selected []ComponentKey) error {
-	if c.presets == nil {
-		return ErrNoPresetFS
-	}
 	if cfg == nil {
 		return fmt.Errorf("composer: ApplyPresetDefaults requires a non-nil *Config")
 	}
-	cloud := "aws"
-	if comps != nil && comps.Cloud != "" {
-		cloud = strings.ToLower(comps.Cloud)
+	overlay, err := c.ComputePresetDefaults(*cfg, comps, selected)
+	if err != nil {
+		return err
 	}
-
-	// Build a JSON-tag → struct-field-index map for Config's nested *struct
-	// fields, so we can look up which Config field matches a given
-	// ComponentKey (whose string form equals the JSON tag, e.g. "aws_ec2").
-	cfgVal := reflect.ValueOf(cfg).Elem()
-	cfgType := cfgVal.Type()
-	tagIndex := map[string]int{}
-	for i := 0; i < cfgType.NumField(); i++ {
-		ft := cfgType.Field(i)
-		if ft.Type.Kind() != reflect.Ptr || ft.Type.Elem().Kind() != reflect.Struct {
-			continue
-		}
-		tag := jsonTagName(ft.Tag.Get("json"))
-		if tag != "" {
-			tagIndex[tag] = i
-		}
-	}
-
-	for _, key := range selected {
-		fieldIdx, ok := tagIndex[string(key)]
-		if !ok {
-			continue
-		}
-		path := GetPresetPath(cloud, key, comps)
-		files, err := c.GetPresetFiles(path)
-		if err != nil {
-			// Missing preset module: not an error, just nothing to fill.
-			continue
-		}
-		defaults, err := ModuleDefaults(files)
-		if err != nil {
-			return fmt.Errorf("composer: reading defaults for %s: %w", path, err)
-		}
-		if len(defaults) == 0 {
-			continue
-		}
-
-		fieldVal := cfgVal.Field(fieldIdx)
-		// Allocate the inner struct on demand.
-		allocated := false
-		if fieldVal.IsNil() {
-			fieldVal.Set(reflect.New(fieldVal.Type().Elem()))
-			allocated = true
-		}
-		filled := backfillStruct(fieldVal.Elem(), defaults)
-		if allocated && !filled {
-			// Nothing landed; revert to nil so the field stays omitempty.
-			fieldVal.Set(reflect.Zero(fieldVal.Type()))
-		}
-	}
+	MergeConfigs(cfg, &overlay)
 	return nil
 }
 
@@ -287,16 +329,32 @@ func overlayZero(dst, src reflect.Value) bool {
 	return filled
 }
 
-// backfillStruct walks fields of dst (which must be a struct value) and for
-// each zero-valued field looks up the HCL default by snake_case-ified JSON
-// tag. Returns true if at least one field was successfully set.
-func backfillStruct(dst reflect.Value, defaults map[string]any) bool {
+// overlayStructFromDefaults walks fields of dst (a struct value) and for each
+// field that is zero-valued IN src, looks up the HCL default by snake_case-
+// ified JSON tag and sets it in dst.
+//
+// src is the *struct field on the original Config (may be nil); when nil,
+// every field is treated as zero — the overlay then carries every default the
+// preset emits. When non-nil, only fields zero in src are populated in dst, so
+// the overlay never echoes user-authored values back as if they were defaults.
+//
+// dst is the parallel *struct field on the output Config, already dereferenced
+// to its inner struct value. Returns true if at least one field landed.
+func overlayStructFromDefaults(src, dst reflect.Value, defaults map[string]any) bool {
+	srcNil := src.Kind() == reflect.Ptr && src.IsNil()
+	var srcStruct reflect.Value
+	if !srcNil {
+		srcStruct = src.Elem()
+	}
 	t := dst.Type()
 	filled := false
 	for i := 0; i < t.NumField(); i++ {
 		ft := t.Field(i)
-		fv := dst.Field(i)
-		if !fv.CanSet() || !fv.IsZero() {
+		dv := dst.Field(i)
+		if !dv.CanSet() {
+			continue
+		}
+		if !srcNil && !srcStruct.Field(i).IsZero() {
 			continue
 		}
 		tag := jsonTagName(ft.Tag.Get("json"))
@@ -312,7 +370,7 @@ func backfillStruct(dst reflect.Value, defaults map[string]any) bool {
 		if !ok {
 			continue
 		}
-		fv.Set(coerced)
+		dv.Set(coerced)
 		filled = true
 	}
 	return filled

--- a/pkg/composer/defaults_test.go
+++ b/pkg/composer/defaults_test.go
@@ -169,8 +169,14 @@ func TestPresetDefaults_EmbeddedFS_KnownVPCSamples(t *testing.T) {
 	assert.Equal(t, "us-east-1", vpc["region"])
 	assert.Equal(t, "10.1.0.0/16", vpc["vpc_cidr"])
 	assert.Equal(t, int64(2), vpc["az_count"])
-	assert.Equal(t, true, vpc["enable_nat_gateway"])
-	assert.Equal(t, true, vpc["single_nat_gateway"])
+	// enable_nat_gateway and single_nat_gateway HCL defaults flipped
+	// true→false in #393 (aws/vpc/variables.tf). The InsideOut composer's
+	// mapper now sets enable_nat_gateway explicitly based on selected
+	// components, so the HCL default is a safe backstop rather than the
+	// source of truth. single_nat_gateway=false matches the upstream
+	// terraform-aws-modules/vpc/aws default.
+	assert.Equal(t, false, vpc["enable_nat_gateway"])
+	assert.Equal(t, false, vpc["single_nat_gateway"])
 	assert.Equal(t, true, vpc["enable_private_subnets"])
 
 	// `environment` has no default in aws/vpc — must be absent.
@@ -417,6 +423,192 @@ func TestApplyPresetDefaults_GCPRoute(t *testing.T) {
 	// the assertion is just that selecting a GCP key with cloud=gcp doesn't
 	// route to the AWS preset tree or panic.
 	_ = cfg
+}
+
+// TestComputePresetDefaults_ReturnsOverlayOnly pins the core contract of the
+// pure variant (#393): user-authored fields stay zero in the overlay; only
+// fields the legacy ApplyPresetDefaults would have backfilled are populated.
+// This is the invariant downstream callers rely on to distinguish "user-set"
+// from "default-backfilled" without comparing against a separate baseline.
+func TestComputePresetDefaults_ReturnsOverlayOnly(t *testing.T) {
+	c := New()
+	cfg := Config{
+		AWSEC2: &struct {
+			InstanceType          string `json:"instanceType,omitempty"`
+			NumServers            string `json:"numServers,omitempty"`
+			NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
+			DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
+			UserData              string `json:"userData,omitempty"`
+			UserDataURL           string `json:"userDataURL,omitempty"`
+			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
+			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
+			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+		}{
+			InstanceType: "m6i.large", // user-set: must NOT echo into overlay
+		},
+	}
+
+	overlay, err := c.ComputePresetDefaults(cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+	require.NoError(t, err)
+	require.NotNil(t, overlay.AWSEC2, "selected component with at least one resolvable default must allocate the overlay sub-struct")
+
+	// User-authored field absent from overlay (zero in overlay).
+	assert.Empty(t, overlay.AWSEC2.InstanceType,
+		"user-authored field must NOT be echoed back through the overlay (#393 provenance contract)")
+
+	// Default-only fields present in overlay.
+	require.NotNil(t, overlay.AWSEC2.EnableInstanceConnect,
+		"*bool field with HCL default = false must be populated in the overlay")
+	assert.False(t, *overlay.AWSEC2.EnableInstanceConnect)
+	assert.NotNil(t, overlay.AWSEC2.CustomIngressPorts,
+		"list default of [] must produce a non-nil empty slice in the overlay")
+	assert.Equal(t, []int{}, overlay.AWSEC2.CustomIngressPorts)
+}
+
+// TestComputePresetDefaults_DoesNotMutateInput pins the non-mutating contract:
+// passing cfg by value must leave the caller's *struct sub-fields untouched.
+// Also verifies the wrapper ApplyPresetDefaults produces the same end state
+// as ComputePresetDefaults + MergeConfigs, so the back-compat surface holds.
+func TestComputePresetDefaults_DoesNotMutateInput(t *testing.T) {
+	c := New()
+	build := func() *Config {
+		return &Config{
+			AWSEC2: &struct {
+				InstanceType          string `json:"instanceType,omitempty"`
+				NumServers            string `json:"numServers,omitempty"`
+				NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
+				DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
+				UserData              string `json:"userData,omitempty"`
+				UserDataURL           string `json:"userDataURL,omitempty"`
+				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
+				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
+				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			}{
+				InstanceType: "m6i.large",
+			},
+		}
+	}
+	pureInput := build()
+	originalEnable := pureInput.AWSEC2.EnableInstanceConnect // captured before call (was nil)
+
+	overlay, err := c.ComputePresetDefaults(*pureInput, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+	require.NoError(t, err)
+
+	// Caller's *Config sub-fields stay untouched.
+	assert.Equal(t, "m6i.large", pureInput.AWSEC2.InstanceType)
+	assert.Equal(t, originalEnable, pureInput.AWSEC2.EnableInstanceConnect,
+		"ComputePresetDefaults must not mutate the caller's nested *bool pointers")
+
+	// Compare against the wrapper end state.
+	wrappedInput := build()
+	require.NoError(t, c.ApplyPresetDefaults(wrappedInput, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2}))
+
+	// Manually apply the overlay to a fresh copy and confirm shape parity.
+	merged := build()
+	MergeConfigs(merged, &overlay)
+	assert.Equal(t, wrappedInput.AWSEC2.InstanceType, merged.AWSEC2.InstanceType)
+	require.NotNil(t, wrappedInput.AWSEC2.EnableInstanceConnect)
+	require.NotNil(t, merged.AWSEC2.EnableInstanceConnect)
+	assert.Equal(t, *wrappedInput.AWSEC2.EnableInstanceConnect, *merged.AWSEC2.EnableInstanceConnect,
+		"wrapper end state must match ComputePresetDefaults + MergeConfigs")
+}
+
+// TestComputePresetDefaults_NilNestedStructInInput_AllocatesInOverlay mirrors
+// the existing TestApplyPresetDefaults_AllocatesNilNestedStruct (defaults_test.go:290)
+// for the pure variant: a nil inner *struct on the input becomes an allocated,
+// populated inner *struct on the overlay.
+func TestComputePresetDefaults_NilNestedStructInInput_AllocatesInOverlay(t *testing.T) {
+	c := New()
+	overlay, err := c.ComputePresetDefaults(Config{}, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+	require.NoError(t, err)
+	require.NotNil(t, overlay.AWSEC2,
+		"selected component with at least one resolvable default must allocate the inner struct on the overlay")
+	assert.Equal(t, "t3.medium", overlay.AWSEC2.InstanceType)
+}
+
+// TestComputePresetDefaults_UnselectedComponentsAbsentFromOverlay pins the
+// scope rule: only the selected components contribute to the overlay.
+func TestComputePresetDefaults_UnselectedComponentsAbsentFromOverlay(t *testing.T) {
+	c := New()
+	overlay, err := c.ComputePresetDefaults(Config{}, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+	require.NoError(t, err)
+	assert.Nil(t, overlay.AWSRDS, "unselected component must stay nil in the overlay")
+}
+
+// TestComputePresetDefaults_NoPresetFS_Errors pins that a Client without an
+// embedded preset FS returns ErrNoPresetFS without panicking. Mirror of
+// TestApplyPresetDefaults_NoPresetFS (defaults_test.go:382).
+func TestComputePresetDefaults_NoPresetFS_Errors(t *testing.T) {
+	c := &Client{}
+	_, err := c.ComputePresetDefaults(Config{}, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+	require.ErrorIs(t, err, ErrNoPresetFS)
+}
+
+// TestComputePresetDefaults_NamingMismatch_LeavesNilAndZero mirrors the
+// allocated-but-empty revert for the pure variant: when a selected component's
+// preset has no fields that map to any Config tag, the overlay's inner struct
+// must stay nil (rather than ship an allocated empty struct that would leak
+// through json:",omitempty").
+func TestComputePresetDefaults_NamingMismatch_LeavesNilAndZero(t *testing.T) {
+	c := New()
+	overlay, err := c.ComputePresetDefaults(Config{}, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSCloudWatchLogs})
+	require.NoError(t, err, "naming mismatch must not error")
+	assert.Nil(t, overlay.AWSCloudWatchLogs,
+		"selected component whose preset declares no fields matching any Config tag must leave the inner struct nil in the overlay")
+}
+
+// TestComputePresetDefaults_ProvenanceDistinguishesUserSetEqualToDefault is the
+// provenance witness called out in #393's design: when the user explicitly
+// sets a field to the same value as the HCL default, the overlay still
+// populates that field, but the caller's cfg is non-zero — so a downstream
+// consumer comparing "field non-zero in cfg AND would-be-populated in overlay"
+// can correctly tag this as user-authored-equal-to-default (and preserve it).
+//
+// This is the trap the rejected `PristineCopy` design fell into: it would
+// strip explicit-equal-to-default fields by treating them as backfilled.
+func TestComputePresetDefaults_ProvenanceDistinguishesUserSetEqualToDefault(t *testing.T) {
+	c := New()
+	falseVal := false
+	cfg := Config{
+		AWSEC2: &struct {
+			InstanceType          string `json:"instanceType,omitempty"`
+			NumServers            string `json:"numServers,omitempty"`
+			NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
+			DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
+			UserData              string `json:"userData,omitempty"`
+			UserDataURL           string `json:"userDataURL,omitempty"`
+			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
+			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
+			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+		}{
+			EnableInstanceConnect: &falseVal, // user explicitly set to the same value as HCL default
+		},
+	}
+
+	overlay, err := c.ComputePresetDefaults(cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+	require.NoError(t, err)
+
+	// User-authored value preserved in cfg.
+	require.NotNil(t, cfg.AWSEC2.EnableInstanceConnect)
+	assert.False(t, *cfg.AWSEC2.EnableInstanceConnect)
+
+	// Overlay does NOT populate this field — it's non-zero in cfg, so the
+	// overlay treats it as user-authored and leaves it nil. (The field is
+	// gated by the per-leaf zero-check, not "would the default match".)
+	require.NotNil(t, overlay.AWSEC2, "other AWSEC2 defaults still populate the overlay")
+	assert.Nil(t, overlay.AWSEC2.EnableInstanceConnect,
+		"user-authored *bool (non-nil pointer) must NOT be echoed back as a default in the overlay")
+
+	// Wrapper end state: MergeConfigs respects the user's pointer (it's
+	// non-zero), so the merged state keeps the user's &false. This is the
+	// invariant a future `PristineCopy`-style reconstruction would violate.
+	merged := &Config{
+		AWSEC2: cfg.AWSEC2, // simulate caller's persisted state
+	}
+	MergeConfigs(merged, &overlay)
+	require.NotNil(t, merged.AWSEC2.EnableInstanceConnect)
+	assert.False(t, *merged.AWSEC2.EnableInstanceConnect,
+		"user-authored-equal-to-default must survive overlay merge unchanged")
 }
 
 func TestMergeConfigs_NilGuards(t *testing.T) {

--- a/pkg/composer/defaults_test.go
+++ b/pkg/composer/defaults_test.go
@@ -544,6 +544,38 @@ func TestComputePresetDefaults_NoPresetFS_Errors(t *testing.T) {
 	require.ErrorIs(t, err, ErrNoPresetFS)
 }
 
+// TestComputePresetDefaults_DegenerateInputs pins the corner-case input
+// shapes a caller can legitimately pass: empty selection (no work to do)
+// and nil Components (defaults cloud to "aws" per the function contract,
+// then processes the selection normally). None of these should panic.
+func TestComputePresetDefaults_DegenerateInputs(t *testing.T) {
+	c := New()
+
+	t.Run("empty selected slice → no inner structs populated", func(t *testing.T) {
+		overlay, err := c.ComputePresetDefaults(Config{}, &Components{Cloud: "aws"}, nil)
+		require.NoError(t, err)
+		assert.Nil(t, overlay.AWSEC2, "empty selection: selection loop ran zero iterations, no allocation should land")
+		assert.Nil(t, overlay.AWSRDS)
+	})
+
+	t.Run("nil comps + selected key → defaults cloud to aws and still processes", func(t *testing.T) {
+		// Per the documented contract: "every key in `selected` that has a
+		// preset module under the cloud indicated by comps.Cloud (defaulting
+		// to "aws")". nil comps must not panic; selection still runs.
+		overlay, err := c.ComputePresetDefaults(Config{}, nil, []ComponentKey{KeyAWSEC2})
+		require.NoError(t, err)
+		require.NotNil(t, overlay.AWSEC2, "nil comps must default cloud to aws and process the selected key normally")
+		assert.Equal(t, "t3.medium", overlay.AWSEC2.InstanceType)
+	})
+
+	t.Run("nil comps + empty selection → no-op clean return", func(t *testing.T) {
+		overlay, err := c.ComputePresetDefaults(Config{}, nil, nil)
+		require.NoError(t, err)
+		assert.Nil(t, overlay.AWSEC2)
+		assert.Nil(t, overlay.AWSRDS)
+	})
+}
+
 // TestComputePresetDefaults_NamingMismatch_LeavesNilAndZero mirrors the
 // allocated-but-empty revert for the pure variant: when a selected component's
 // preset has no fields that map to any Config tag, the overlay's inner struct
@@ -557,58 +589,88 @@ func TestComputePresetDefaults_NamingMismatch_LeavesNilAndZero(t *testing.T) {
 		"selected component whose preset declares no fields matching any Config tag must leave the inner struct nil in the overlay")
 }
 
-// TestComputePresetDefaults_ProvenanceDistinguishesUserSetEqualToDefault is the
-// provenance witness called out in #393's design: when the user explicitly
-// sets a field to the same value as the HCL default, the overlay still
-// populates that field, but the caller's cfg is non-zero — so a downstream
-// consumer comparing "field non-zero in cfg AND would-be-populated in overlay"
-// can correctly tag this as user-authored-equal-to-default (and preserve it).
+// TestComputePresetDefaults_ProvenanceDistinguishesUserSetEqualToDefault is
+// the provenance witness called out in #393's design. The witness is a
+// two-call differential against the same caller intent split only by
+// whether the user explicitly authored the field equal to its HCL default:
 //
-// This is the trap the rejected `PristineCopy` design fell into: it would
-// strip explicit-equal-to-default fields by treating them as backfilled.
+//  1. cfg with EnableInstanceConnect = nil (user didn't author it) →
+//     overlay populates EnableInstanceConnect = &false.
+//  2. cfg with EnableInstanceConnect = &false (user authored equal-to-
+//     default) → overlay leaves EnableInstanceConnect = nil.
+//
+// The pair only differs at the witnessed leaf, so the overlay differing
+// at exactly that leaf demonstrates provenance: ComputePresetDefaults
+// distinguishes "would have been filled in" from "user authored equal-
+// to-default" without comparing values. A reconstructive PristineCopy
+// approach (the rejected alternative) would populate the same overlay in
+// both cases (because the post-state matches the default in both), and
+// the differential would collapse — that's the bug this test catches.
 func TestComputePresetDefaults_ProvenanceDistinguishesUserSetEqualToDefault(t *testing.T) {
 	c := New()
 	falseVal := false
-	cfg := Config{
-		AWSEC2: &struct {
-			InstanceType          string `json:"instanceType,omitempty"`
-			NumServers            string `json:"numServers,omitempty"`
-			NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
-			DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
-			UserData              string `json:"userData,omitempty"`
-			UserDataURL           string `json:"userDataURL,omitempty"`
-			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
-			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
-			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
-		}{
-			EnableInstanceConnect: &falseVal, // user explicitly set to the same value as HCL default
-		},
+
+	mkCfg := func(enable *bool) Config {
+		return Config{
+			AWSEC2: &struct {
+				InstanceType          string `json:"instanceType,omitempty"`
+				NumServers            string `json:"numServers,omitempty"`
+				NumCoresPerServer     string `json:"numCoresPerServer,omitempty"`
+				DiskSizePerServer     string `json:"diskSizePerServer,omitempty"`
+				UserData              string `json:"userData,omitempty"`
+				UserDataURL           string `json:"userDataURL,omitempty"`
+				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
+				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
+				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			}{
+				EnableInstanceConnect: enable,
+			},
+		}
 	}
 
-	overlay, err := c.ComputePresetDefaults(cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+	// Call 1: user did NOT author EnableInstanceConnect.
+	cfgUnset := mkCfg(nil)
+	overlayUnset, err := c.ComputePresetDefaults(cfgUnset, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
 	require.NoError(t, err)
+	require.NotNil(t, overlayUnset.AWSEC2, "default-only overlay must populate the inner *struct")
+	require.NotNil(t, overlayUnset.AWSEC2.EnableInstanceConnect,
+		"when user didn't author, overlay populates EnableInstanceConnect from the HCL default")
+	assert.False(t, *overlayUnset.AWSEC2.EnableInstanceConnect)
 
-	// User-authored value preserved in cfg.
-	require.NotNil(t, cfg.AWSEC2.EnableInstanceConnect)
-	assert.False(t, *cfg.AWSEC2.EnableInstanceConnect)
+	// Call 2: user explicitly authored EnableInstanceConnect = &false (equal
+	// to the HCL default). The whole point of the test is that this
+	// *contracted* state — overlay leaf nil — differs from Call 1 — overlay
+	// leaf &false. The differential is the provenance signal.
+	cfgEqualToDefault := mkCfg(&falseVal)
+	overlayEqualToDefault, err := c.ComputePresetDefaults(cfgEqualToDefault, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+	require.NoError(t, err)
+	require.NotNil(t, overlayEqualToDefault.AWSEC2, "other AWSEC2 defaults still populate the overlay")
+	assert.Nil(t, overlayEqualToDefault.AWSEC2.EnableInstanceConnect,
+		"user-authored *bool (non-nil pointer) must NOT be populated in the overlay — that's the provenance signal that distinguishes user-set-equal-to-default from default-backfilled")
 
-	// Overlay does NOT populate this field — it's non-zero in cfg, so the
-	// overlay treats it as user-authored and leaves it nil. (The field is
-	// gated by the per-leaf zero-check, not "would the default match".)
-	require.NotNil(t, overlay.AWSEC2, "other AWSEC2 defaults still populate the overlay")
-	assert.Nil(t, overlay.AWSEC2.EnableInstanceConnect,
-		"user-authored *bool (non-nil pointer) must NOT be echoed back as a default in the overlay")
+	// Caller's cfg is untouched in both cases.
+	assert.Nil(t, cfgUnset.AWSEC2.EnableInstanceConnect, "cfg passed by value but inner *struct is shared; ComputePresetDefaults must not mutate it")
+	require.NotNil(t, cfgEqualToDefault.AWSEC2.EnableInstanceConnect)
+	assert.False(t, *cfgEqualToDefault.AWSEC2.EnableInstanceConnect)
 
-	// Wrapper end state: MergeConfigs respects the user's pointer (it's
-	// non-zero), so the merged state keeps the user's &false. This is the
-	// invariant a future `PristineCopy`-style reconstruction would violate.
-	merged := &Config{
-		AWSEC2: cfg.AWSEC2, // simulate caller's persisted state
-	}
-	MergeConfigs(merged, &overlay)
-	require.NotNil(t, merged.AWSEC2.EnableInstanceConnect)
-	assert.False(t, *merged.AWSEC2.EnableInstanceConnect,
-		"user-authored-equal-to-default must survive overlay merge unchanged")
+	// End-state via MergeConfigs: both overlays merged onto a fresh persisted
+	// shape produce the same EnableInstanceConnect value (&false), but for
+	// different reasons. The provenance distinction is preserved in the
+	// overlay shape — callers that want to know "did the user author this?"
+	// have it without value comparison.
+	mergedUnset := &Config{}
+	MergeConfigs(mergedUnset, &overlayUnset)
+	require.NotNil(t, mergedUnset.AWSEC2)
+	require.NotNil(t, mergedUnset.AWSEC2.EnableInstanceConnect)
+	assert.False(t, *mergedUnset.AWSEC2.EnableInstanceConnect)
+
+	// PristineCopy-regression guard: if a future change accidentally
+	// populated the overlay in Call 2 (because the default would have matched),
+	// the differential below collapses and this assertion fires.
+	assert.NotEqual(t,
+		overlayUnset.AWSEC2.EnableInstanceConnect == nil,
+		overlayEqualToDefault.AWSEC2.EnableInstanceConnect == nil,
+		"overlay leaf must differ between user-unset and user-set-equal-to-default — the differential is the provenance signal")
 }
 
 func TestMergeConfigs_NilGuards(t *testing.T) {

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -143,6 +143,17 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+		// Explicit NAT=true when private subnets are needed and the user
+		// hasn't authored AWSVPC.EnableNATGateway (#393). Without this, the
+		// HCL default (which #393 flips from true to false in
+		// aws/vpc/variables.tf so a stale-true backfill can no longer wedge a
+		// Public-VPC stack) would silently disable NAT on Private-VPC stacks
+		// that didn't set the field. Tfvars now record the mapper's
+		// decision rather than rely on the preset's HCL default.
+		if _, alreadySet := vals["enable_nat_gateway"]; !alreadySet && stackNeedsPrivateSubnets(comps) {
+			vals["enable_nat_gateway"] = true
+		}
+
 		// NAT-vs-private-subnets coercion (#389). If private subnets were
 		// disabled above (Public VPC with no downstream consumers), NAT must
 		// be off too — the upstream terraform-aws-modules/vpc/aws plans

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -110,7 +110,11 @@ func TestBuildModuleValues_VPC_PublicPrivateMode(t *testing.T) {
 
 	// Each "keeps private subnets" test verifies that enable_private_subnets
 	// is NOT set to false (i.e. the key is absent, so the preset default of
-	// true takes effect). We also check that enable_nat_gateway is absent.
+	// true takes effect) AND that the mapper explicitly emits
+	// enable_nat_gateway=true. Pre-#393 the mapper left enable_nat_gateway
+	// unset and the HCL default (true) flowed through; post-#393 the HCL
+	// default is false (the trap that motivated #393), so the mapper records
+	// its decision in tfvars rather than relying on the preset's HCL value.
 	keepsCases := []struct {
 		name  string
 		comps *Components
@@ -129,21 +133,26 @@ func TestBuildModuleValues_VPC_PublicPrivateMode(t *testing.T) {
 			require.NoError(t, err)
 			assertVPCCaseRan(t, vals)
 			_, hasPrivate := vals["enable_private_subnets"]
-			_, hasNat := vals["enable_nat_gateway"]
 			assert.False(t, hasPrivate, "should not disable private subnets when %s needs them", tc.name)
-			assert.False(t, hasNat, "should not disable NAT when %s needs it", tc.name)
+			assert.Equal(t, true, vals["enable_nat_gateway"],
+				"#393: mapper must explicitly emit enable_nat_gateway=true when %s needs private subnets and no user override", tc.name)
 		})
 	}
 
 	t.Run("Private VPC uses preset defaults (no override)", func(t *testing.T) {
+		// A bare "Private VPC" with no downstream consumers doesn't actually
+		// need NAT (no compute or DB to give internet access to). The mapper
+		// leaves both keys unset and the HCL default (false post-#393)
+		// applies. Adding a consumer flips on the explicit NAT=true branch —
+		// covered by the keepsCases loop above.
 		comps := &Components{AWSVPC: "Private VPC"}
 		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, nil, "test", "us-east-1")
 		require.NoError(t, err)
 		assertVPCCaseRan(t, vals)
 		_, hasPrivate := vals["enable_private_subnets"]
 		_, hasNat := vals["enable_nat_gateway"]
-		assert.False(t, hasPrivate, "Private VPC should not override enable_private_subnets (preset default is true)")
-		assert.False(t, hasNat, "Private VPC should not override enable_nat_gateway (preset default is true)")
+		assert.False(t, hasPrivate, "Private VPC should not override enable_private_subnets")
+		assert.False(t, hasNat, "Private VPC with no consumers should not emit enable_nat_gateway (HCL default applies)")
 	})
 
 	t.Run("empty AWSVPC uses preset defaults", func(t *testing.T) {
@@ -155,6 +164,32 @@ func TestBuildModuleValues_VPC_PublicPrivateMode(t *testing.T) {
 		_, hasNat := vals["enable_nat_gateway"]
 		assert.False(t, hasPrivate)
 		assert.False(t, hasNat)
+	})
+
+	t.Run("Private VPC + EKS with default cfg emits explicit NAT=true (#393)", func(t *testing.T) {
+		// Pre-#393 this case relied on the HCL default (true) flowing through;
+		// post-#393 the HCL default is false, so the mapper must explicitly
+		// emit enable_nat_gateway=true to keep the deploy from silently
+		// losing NAT. Direct symptom of the trap that motivated #393.
+		comps := &Components{AWSVPC: "Private VPC", AWSEKS: boolPtr(true)}
+		cfg := &Config{Region: "us-east-1"} // no AWSVPC sub-struct
+		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.NoError(t, err)
+		assertVPCCaseRan(t, vals)
+		assert.Equal(t, true, vals["enable_nat_gateway"],
+			"mapper must explicitly emit enable_nat_gateway=true when private subnets are needed and the user hasn't authored AWSVPC.EnableNATGateway (#393)")
+	})
+
+	t.Run("user-authored AWSVPC.EnableNATGateway=false wins over #393 explicit-true branch", func(t *testing.T) {
+		// Regression guard: the #393 explicit-true branch must NOT clobber a
+		// user who deliberately set EnableNATGateway=false. The fail-fast
+		// branch at mapper.go:120-127 catches the truly inconsistent
+		// "false + needs private subnets" combination and rejects with an
+		// error before vals is returned.
+		comps := &Components{AWSVPC: "Private VPC", AWSEKS: boolPtr(true)}
+		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
+		_, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.Error(t, err, "user-authored EnableNATGateway=false + EKS must fail-fast at the mapper, NOT be silently overridden to true by the #393 branch")
 	})
 }
 

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -190,6 +190,11 @@ func TestBuildModuleValues_VPC_PublicPrivateMode(t *testing.T) {
 		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
 		_, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
 		require.Error(t, err, "user-authored EnableNATGateway=false + EKS must fail-fast at the mapper, NOT be silently overridden to true by the #393 branch")
+		// Pin the specific fail-fast at mapper.go:120-127; a future
+		// refactor returning a different error from a different code path
+		// would still satisfy require.Error and silently weaken this gate.
+		assert.Contains(t, err.Error(), "AWSVPC.EnableNATGateway=false is incompatible",
+			"must surface the specific #389 fail-fast, not some other error path")
 	})
 }
 


### PR DESCRIPTION
## Summary

Closes #393. Three coordinated changes that close the persistent-stale-NAT trap surfaced in reliable session `sess_v2_CnqUJ6NRJnLC` v9.

- **API:** split `ApplyPresetDefaults` into a pure `ComputePresetDefaults(cfg Config, comps, selected) (Config, error)` that returns the overlay. The original signature is preserved as a thin wrapper for the cross-repo consumer (luthersystems/reliable#1435). Provenance falls out automatically — a field zero in cfg and populated in overlay is default-derived; a field non-zero in cfg is always preserved (even when set equal to the default, which the rejected `PristineCopy` design would have stripped).
- **Mapper:** `mapper.go::KeyAWSVPC` now explicitly emits `enable_nat_gateway=true` when private subnets are needed and the user hasn't authored the field. Pre-#393 this relied on the HCL default flowing through; post-flip the HCL default is `false`, so the mapper records its decision in tfvars rather than depending on the HCL value.
- **HCL:** flip `aws/vpc/variables.tf` `enable_nat_gateway` and `single_nat_gateway` defaults `true` → `false`, matching the upstream `terraform-aws-modules/vpc/aws` defaults. Safe because the mapper change always emits explicit NAT=true for stacks that need it.

## Why this shape (Option B)

A previous draft proposed a `PristineCopy(cfg)` helper that re-ran defaults on a fresh zero `Config` and diffed the result to "undo" backfilled fields. That approach is reconstructive (computes user-state by elimination) and has a real bug: when the user explicitly sets a field to match the default, `PristineCopy` strips it, losing intent. The cleaner shape: don't mutate in the first place. Return an **overlay**. Provenance becomes a per-field zero-check rather than a value-comparison, which sidesteps the explicit-equal-to-default trap. The provenance witness test (`TestComputePresetDefaults_ProvenanceDistinguishesUserSetEqualToDefault`) is a two-call differential that pins this — the kind of regression that would re-introduce `PristineCopy` semantics breaks the differential.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./pkg/composer/... -race -count=1` — 1689 pass.
- [x] `terraform fmt -check -recursive` clean.
- [x] All 4 lint scripts pass (`lint-project-tag.sh`, `lint-project-label.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`).
- [x] `terraform init && terraform validate` on `aws/vpc` standalone clean.

## Review notes

- `/review`: 0 P0, 0 P1; P2/P3 findings either addressed or documented in commit 52ae5af.
- `qa-professor`: 2 P1 findings (provenance witness too weak, fail-fast not pinning specific error) — both fixed in 52ae5af. Drive-by P2s (degenerate-input edge cases, docstring rewording) also fixed.

## Notes for reviewers

- The HCL flip on `single_nat_gateway` (`true → false`) changes deploy topology for **bare** "Private VPC" stacks whose cfg doesn't author the field — those now get one NAT per AZ instead of one shared. The variable's own docstring already recommended `false` for multi-AZ availability, and the upstream module defaults to `false` too. Composer-driven stacks pass through the mapper, which honors `cfg.AWSVPC.SingleNATGateway` when set.
- Existing `TestApplyPresetDefaults_*` (7 funcs) all pass unchanged via the wrapper.
- Cross-repo follow-up: luthersystems/reliable#1435 can now use `ComputePresetDefaults` to keep `cfg` pristine in persistence rather than reverse-engineering defaults from a mutated state.