### PR TITLE
feat(imported): framework skeleton — DriftSemantic + ByIDEnricher + labels/bindings registries

### DIFF
--- a/cmd/insideout-import/awsdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/awsdiscover/byid_enricher_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
 // fakeByIDEnricher is a minimal type that satisfies ByIDEnricher.
-// It exists only to assert that the interface compiles and is
-// satisfiable — no production code implements ByIDEnricher yet
+// It exists only to back the compile-time `var _ ByIDEnricher`
+// assertion below — no production code implements ByIDEnricher yet
 // (Phase 2 enricher rollout PRs add real impls one per type).
 type fakeByIDEnricher struct{}
 
@@ -21,42 +23,40 @@ func (fakeByIDEnricher) EnrichByID(ctx context.Context, identity *imported.Resou
 }
 
 // Compile-time assertion. If ByIDEnricher's shape drifts, this fails
-// at build time, not at runtime.
+// at build time. This is the load-bearing shape lock — no runtime
+// "fake calls itself" test is needed because there is nothing to
+// observe beyond the compile.
 var _ ByIDEnricher = (*fakeByIDEnricher)(nil)
-
-func TestByIDEnricher_FakeImplementation(t *testing.T) {
-	var e ByIDEnricher = fakeByIDEnricher{}
-	if got, want := e.ResourceType(), "aws_test_fake"; got != want {
-		t.Errorf("ResourceType() = %q, want %q", got, want)
-	}
-	raw, err := e.EnrichByID(t.Context(), &imported.ResourceIdentity{Type: "aws_test_fake"}, EnrichClients{})
-	if err != nil {
-		t.Fatalf("EnrichByID returned err: %v", err)
-	}
-	if string(raw) != "{}" {
-		t.Errorf("EnrichByID payload = %q, want %q", string(raw), "{}")
-	}
-}
 
 // TestExistingEnrichersDoNotImplementByID confirms the additive
 // nature of ByIDEnricher: the 1 existing enricher (aws_dynamodb_table)
-// implements only AttributeEnricher today. When Phase 2 PRs land
-// real EnrichByID impls, this test's allowlist shrinks. The test
-// fails loud if a future PR claims to add EnrichByID but forgets
-// to update the allowlist — i.e. ByIDEnricher coverage is observable.
+// implements only AttributeEnricher today. The test pins against the
+// REAL production registration in NewAWSDiscoverer — not a hand-rolled
+// map — so when Phase 2 PRs add real EnrichByID impls, the allowlist
+// must shrink in lockstep with the production registration. A
+// production-only change (add a ByIDEnricher impl, forget to update
+// allowlist) fails the test loud. A regression that drops the
+// registration entirely is caught by the size sanity check below.
 func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
-	// Construct the discoverer with a stub aws.Config; we only need
-	// access to byTypeEnricher, not to make real SDK calls.
-	d := &AWSDiscoverer{
-		byTypeEnricher: map[string]AttributeEnricher{
-			"aws_dynamodb_table": newDynamoDBTableEnricher(),
-		},
-	}
+	// Empty aws.Config is safe — the constructor only stores closures
+	// and per-type discoverer/enricher structs; no SDK calls fire.
+	d := NewAWSDiscoverer(aws.Config{})
+
 	// Allowlist: types whose enrichers explicitly DO NOT implement
 	// ByIDEnricher yet. Shrink as Phase 2 rollout lands per-type impls.
 	notImplemented := map[string]bool{
 		"aws_dynamodb_table": true,
 	}
+
+	// Fail-fast: if the constructor silently dropped the registration,
+	// the for-range below iterates zero times and reports a green
+	// non-test. Pin the expected size to the allowlist length so a
+	// "silent drop in production, allowlist untouched" regression
+	// fails loud.
+	if got, want := len(d.byTypeEnricher), len(notImplemented); got != want {
+		t.Errorf("byTypeEnricher size = %d, want %d (production registration and notImplemented allowlist drifted)", got, want)
+	}
+
 	for tfType, enr := range d.byTypeEnricher {
 		_, implementsByID := enr.(ByIDEnricher)
 		expectNot := notImplemented[tfType]

--- a/cmd/insideout-import/awsdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/awsdiscover/byid_enricher_test.go
@@ -1,0 +1,70 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// fakeByIDEnricher is a minimal type that satisfies ByIDEnricher.
+// It exists only to assert that the interface compiles and is
+// satisfiable — no production code implements ByIDEnricher yet
+// (Phase 2 enricher rollout PRs add real impls one per type).
+type fakeByIDEnricher struct{}
+
+func (fakeByIDEnricher) ResourceType() string { return "aws_test_fake" }
+
+func (fakeByIDEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, clients EnrichClients) (json.RawMessage, error) {
+	return json.RawMessage(`{}`), nil
+}
+
+// Compile-time assertion. If ByIDEnricher's shape drifts, this fails
+// at build time, not at runtime.
+var _ ByIDEnricher = (*fakeByIDEnricher)(nil)
+
+func TestByIDEnricher_FakeImplementation(t *testing.T) {
+	var e ByIDEnricher = fakeByIDEnricher{}
+	if got, want := e.ResourceType(), "aws_test_fake"; got != want {
+		t.Errorf("ResourceType() = %q, want %q", got, want)
+	}
+	raw, err := e.EnrichByID(t.Context(), &imported.ResourceIdentity{Type: "aws_test_fake"}, EnrichClients{})
+	if err != nil {
+		t.Fatalf("EnrichByID returned err: %v", err)
+	}
+	if string(raw) != "{}" {
+		t.Errorf("EnrichByID payload = %q, want %q", string(raw), "{}")
+	}
+}
+
+// TestExistingEnrichersDoNotImplementByID confirms the additive
+// nature of ByIDEnricher: the 1 existing enricher (aws_dynamodb_table)
+// implements only AttributeEnricher today. When Phase 2 PRs land
+// real EnrichByID impls, this test's allowlist shrinks. The test
+// fails loud if a future PR claims to add EnrichByID but forgets
+// to update the allowlist — i.e. ByIDEnricher coverage is observable.
+func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
+	// Construct the discoverer with a stub aws.Config; we only need
+	// access to byTypeEnricher, not to make real SDK calls.
+	d := &AWSDiscoverer{
+		byTypeEnricher: map[string]AttributeEnricher{
+			"aws_dynamodb_table": newDynamoDBTableEnricher(),
+		},
+	}
+	// Allowlist: types whose enrichers explicitly DO NOT implement
+	// ByIDEnricher yet. Shrink as Phase 2 rollout lands per-type impls.
+	notImplemented := map[string]bool{
+		"aws_dynamodb_table": true,
+	}
+	for tfType, enr := range d.byTypeEnricher {
+		_, implementsByID := enr.(ByIDEnricher)
+		expectNot := notImplemented[tfType]
+		switch {
+		case expectNot && implementsByID:
+			t.Errorf("%s: enricher now implements ByIDEnricher — remove from notImplemented allowlist", tfType)
+		case !expectNot && !implementsByID:
+			t.Errorf("%s: enricher must implement ByIDEnricher (not in notImplemented allowlist)", tfType)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -16,6 +16,7 @@ package awsdiscover
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -71,6 +72,45 @@ type AttributeEnricher interface {
 	// ErrEnrichClientUnavailable so callers can distinguish "not
 	// configured" from "real API error".
 	Enrich(ctx context.Context, ir *imported.ImportedResource, clients EnrichClients) error
+}
+
+// ByIDEnricher is an optional sibling to AttributeEnricher that fetches
+// a single resource's typed Layer 1 payload from its ResourceIdentity
+// alone — used by the per-IR drift refresh path that the eventual
+// pkg/imported.Provider.EnrichByID exposes (presets#482). Implementing
+// this interface is purely additive: enrichers that satisfy only
+// AttributeEnricher continue to work unchanged for the batch enrichment
+// flow; the by-ID dispatcher type-asserts at call time and downgrades
+// gracefully when the assertion fails.
+//
+// The shape diverges from Enrich for two reasons:
+//
+//   - The caller starts from an Identity that hasn't been produced by
+//     the corresponding Discoverer (e.g. a UI refresh on a single row),
+//     so there is no pre-existing *ImportedResource to mutate.
+//   - The caller wants only the raw typed payload (returned as the
+//     same json.RawMessage shape that lands in ImportedResource.Attrs),
+//     so it can drive its own comparator without going through the
+//     batch progress / aggregation machinery.
+//
+// Implementations must not mutate identity. They may issue the same
+// SDK calls as the AttributeEnricher implementation for the same type;
+// in the common case Enrich and EnrichByID share a private helper that
+// does the SDK call and emits the typed struct, and the two methods
+// differ only in how they package the result.
+type ByIDEnricher interface {
+	// ResourceType returns the Terraform type this enricher covers.
+	// Must match the registered Discoverer / AttributeEnricher of the
+	// same type.
+	ResourceType() string
+
+	// EnrichByID fetches the typed Layer 1 payload for the resource
+	// named by identity and returns it as the json.RawMessage that
+	// would land in ImportedResource.Attrs. A nil required client on
+	// clients is reported as ErrEnrichClientUnavailable so callers
+	// can distinguish "not configured" from "real API error". A
+	// not-found resource is reported as ErrNotFound.
+	EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, clients EnrichClients) (json.RawMessage, error)
 }
 
 // EnrichClients bundles the AWS SDK clients per-type enrichers dispatch

--- a/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 // fakeByIDEnricher is a minimal type that satisfies ByIDEnricher.
-// It exists only to assert that the interface compiles and is
-// satisfiable — no production code implements ByIDEnricher yet
+// It exists only to back the compile-time `var _ ByIDEnricher`
+// assertion below — no production code implements ByIDEnricher yet
 // (Phase 2 enricher rollout PRs add real impls one per type).
 type fakeByIDEnricher struct{}
 
@@ -21,40 +21,25 @@ func (fakeByIDEnricher) EnrichByID(ctx context.Context, identity *imported.Resou
 }
 
 // Compile-time assertion. If ByIDEnricher's shape drifts, this fails
-// at build time, not at runtime.
+// at build time. This is the load-bearing shape lock — no runtime
+// "fake calls itself" test is needed because there is nothing to
+// observe beyond the compile.
 var _ ByIDEnricher = (*fakeByIDEnricher)(nil)
-
-func TestByIDEnricher_FakeImplementation(t *testing.T) {
-	var e ByIDEnricher = fakeByIDEnricher{}
-	if got, want := e.ResourceType(), "google_test_fake"; got != want {
-		t.Errorf("ResourceType() = %q, want %q", got, want)
-	}
-	raw, err := e.EnrichByID(t.Context(), &imported.ResourceIdentity{Type: "google_test_fake"}, EnrichClients{})
-	if err != nil {
-		t.Fatalf("EnrichByID returned err: %v", err)
-	}
-	if string(raw) != "{}" {
-		t.Errorf("EnrichByID payload = %q, want %q", string(raw), "{}")
-	}
-}
 
 // TestExistingEnrichersDoNotImplementByID confirms the additive
 // nature of ByIDEnricher: the 5 existing enrichers today implement
-// only AttributeEnricher. When Phase 2 PRs land real EnrichByID
-// impls, this test's allowlist shrinks. The test fails loud if a
-// future PR claims to add EnrichByID but forgets to update the
-// allowlist — i.e. ByIDEnricher coverage is observable.
+// only AttributeEnricher. The test pins against the REAL production
+// registration in NewGCPDiscoverer — not a hand-rolled map — so when
+// Phase 2 PRs add real EnrichByID impls, the allowlist must shrink
+// in lockstep with the production registration. A production-only
+// change (add a ByIDEnricher impl, forget to update allowlist) fails
+// the test loud. A regression that drops the registration entirely
+// is caught by the size sanity check below.
 func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
-	// Mirror the production registration (gcpdiscover.go:343-349) so
-	// the test exercises real enrichers without needing a full
-	// GCPDiscoverer construction.
-	enrichers := map[string]AttributeEnricher{
-		"google_storage_bucket":        newStorageBucketEnricher(),
-		"google_pubsub_topic":          newPubsubTopicEnricher(),
-		"google_pubsub_subscription":   newPubsubSubscriptionEnricher(),
-		"google_secret_manager_secret": newSecretManagerSecretEnricher(),
-		"google_compute_network":       newComputeNetworkEnricher(),
-	}
+	// Nil searcher is safe — the constructor only stores it; no
+	// SearchAll call fires here.
+	d := NewGCPDiscoverer(nil, "test-project", GCPDiscovererOpts{})
+
 	// Allowlist: types whose enrichers explicitly DO NOT implement
 	// ByIDEnricher yet. Shrink as Phase 2 rollout lands per-type impls.
 	notImplemented := map[string]bool{
@@ -64,7 +49,17 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 		"google_secret_manager_secret": true,
 		"google_compute_network":       true,
 	}
-	for tfType, enr := range enrichers {
+
+	// Fail-fast: if the constructor silently dropped the registration,
+	// the for-range below iterates zero times and reports a green
+	// non-test. Pin the expected size to the allowlist length so a
+	// "silent drop in production, allowlist untouched" regression
+	// fails loud.
+	if got, want := len(d.byTypeEnricher), len(notImplemented); got != want {
+		t.Errorf("byTypeEnricher size = %d, want %d (production registration and notImplemented allowlist drifted)", got, want)
+	}
+
+	for tfType, enr := range d.byTypeEnricher {
 		_, implementsByID := enr.(ByIDEnricher)
 		expectNot := notImplemented[tfType]
 		switch {

--- a/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
@@ -1,0 +1,77 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// fakeByIDEnricher is a minimal type that satisfies ByIDEnricher.
+// It exists only to assert that the interface compiles and is
+// satisfiable — no production code implements ByIDEnricher yet
+// (Phase 2 enricher rollout PRs add real impls one per type).
+type fakeByIDEnricher struct{}
+
+func (fakeByIDEnricher) ResourceType() string { return "google_test_fake" }
+
+func (fakeByIDEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, clients EnrichClients) (json.RawMessage, error) {
+	return json.RawMessage(`{}`), nil
+}
+
+// Compile-time assertion. If ByIDEnricher's shape drifts, this fails
+// at build time, not at runtime.
+var _ ByIDEnricher = (*fakeByIDEnricher)(nil)
+
+func TestByIDEnricher_FakeImplementation(t *testing.T) {
+	var e ByIDEnricher = fakeByIDEnricher{}
+	if got, want := e.ResourceType(), "google_test_fake"; got != want {
+		t.Errorf("ResourceType() = %q, want %q", got, want)
+	}
+	raw, err := e.EnrichByID(t.Context(), &imported.ResourceIdentity{Type: "google_test_fake"}, EnrichClients{})
+	if err != nil {
+		t.Fatalf("EnrichByID returned err: %v", err)
+	}
+	if string(raw) != "{}" {
+		t.Errorf("EnrichByID payload = %q, want %q", string(raw), "{}")
+	}
+}
+
+// TestExistingEnrichersDoNotImplementByID confirms the additive
+// nature of ByIDEnricher: the 5 existing enrichers today implement
+// only AttributeEnricher. When Phase 2 PRs land real EnrichByID
+// impls, this test's allowlist shrinks. The test fails loud if a
+// future PR claims to add EnrichByID but forgets to update the
+// allowlist — i.e. ByIDEnricher coverage is observable.
+func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
+	// Mirror the production registration (gcpdiscover.go:343-349) so
+	// the test exercises real enrichers without needing a full
+	// GCPDiscoverer construction.
+	enrichers := map[string]AttributeEnricher{
+		"google_storage_bucket":        newStorageBucketEnricher(),
+		"google_pubsub_topic":          newPubsubTopicEnricher(),
+		"google_pubsub_subscription":   newPubsubSubscriptionEnricher(),
+		"google_secret_manager_secret": newSecretManagerSecretEnricher(),
+		"google_compute_network":       newComputeNetworkEnricher(),
+	}
+	// Allowlist: types whose enrichers explicitly DO NOT implement
+	// ByIDEnricher yet. Shrink as Phase 2 rollout lands per-type impls.
+	notImplemented := map[string]bool{
+		"google_storage_bucket":        true,
+		"google_pubsub_topic":          true,
+		"google_pubsub_subscription":   true,
+		"google_secret_manager_secret": true,
+		"google_compute_network":       true,
+	}
+	for tfType, enr := range enrichers {
+		_, implementsByID := enr.(ByIDEnricher)
+		expectNot := notImplemented[tfType]
+		switch {
+		case expectNot && implementsByID:
+			t.Errorf("%s: enricher now implements ByIDEnricher — remove from notImplemented allowlist", tfType)
+		case !expectNot && !implementsByID:
+			t.Errorf("%s: enricher must implement ByIDEnricher (not in notImplemented allowlist)", tfType)
+		}
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -2,6 +2,7 @@ package gcpdiscover
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -69,6 +70,50 @@ type AttributeEnricher interface {
 	// so callers can distinguish "not configured" from "real API
 	// error".
 	Enrich(ctx context.Context, ir *imported.ImportedResource, clients EnrichClients) error
+}
+
+// ByIDEnricher is an optional sibling to AttributeEnricher that fetches
+// a single resource's typed Layer 1 payload from its ResourceIdentity
+// alone — used by the per-IR drift refresh path that the eventual
+// pkg/imported.Provider.EnrichByID exposes (presets#482). Implementing
+// this interface is purely additive: enrichers that satisfy only
+// AttributeEnricher continue to work unchanged for the batch enrichment
+// flow; the by-ID dispatcher type-asserts at call time and downgrades
+// gracefully when the assertion fails.
+//
+// Mirrors awsdiscover.ByIDEnricher (same name, same shape, per-cloud
+// EnrichClients). The two clouds are deliberately kept symmetric so
+// the unified pkg/imported.Provider in presets#482 can dispatch
+// through identical interface shapes.
+//
+// The shape diverges from Enrich for two reasons:
+//
+//   - The caller starts from an Identity that hasn't been produced by
+//     the corresponding Discoverer (e.g. a UI refresh on a single row),
+//     so there is no pre-existing *ImportedResource to mutate.
+//   - The caller wants only the raw typed payload (returned as the
+//     same json.RawMessage shape that lands in ImportedResource.Attrs),
+//     so it can drive its own comparator without going through the
+//     batch progress / aggregation machinery.
+//
+// Implementations must not mutate identity. In the common case Enrich
+// and EnrichByID share a private helper that does the SDK call and
+// emits the typed struct; the two methods differ only in how they
+// package the result.
+type ByIDEnricher interface {
+	// ResourceType returns the Terraform type this enricher covers.
+	// Must match the registered Discoverer / AttributeEnricher of the
+	// same type.
+	ResourceType() string
+
+	// EnrichByID fetches the typed Layer 1 payload for the resource
+	// named by identity and returns it as the json.RawMessage that
+	// would land in ImportedResource.Attrs. A nil required client on
+	// clients is reported as ErrEnrichClientUnavailable so callers
+	// can distinguish "not configured" from "real API error". A
+	// not-found resource is reported as ErrNotFound (sentinel
+	// declared in gcpdiscover.go).
+	EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, clients EnrichClients) (json.RawMessage, error)
 }
 
 // EnrichClients bundles the cloud SDK clients per-type enrichers

--- a/pkg/composer/imported/policy/axes.go
+++ b/pkg/composer/imported/policy/axes.go
@@ -167,3 +167,52 @@ func (c ChangeRiskPolicy) Valid() bool {
 	}
 	return false
 }
+
+// DriftSemantic classifies how the comparator should interpret a
+// curated field when computing drift between a sealed snapshot and a
+// fresh live read. The skeleton ships the enum and an additive field
+// on FieldPolicy; the comparator that consumes the value lives in
+// the eventual pkg/drift/imported package (presets#482).
+//
+// The empty string is intentionally valid and means "no drift
+// comparison" — that is, the field is informational only for drift
+// purposes. Every existing policy file in pkg/composer/imported/policy
+// pre-dates this axis, so leaving it unset must not be a lint
+// failure.
+//
+// Form note: DriftSemanticLabelFilter eventually carries a key-prefix
+// parameter (e.g. ignore `goog-*` labels). The skeleton declares the
+// const but defers the wire format for the parameter to presets#482
+// — likely either a sibling DriftFilter string field on FieldPolicy
+// or an encoded suffix on the value, decided when the comparator
+// lands and the real use cases are concrete.
+type DriftSemantic string
+
+const (
+	// DriftSemanticNone — the comparator skips this field. Default
+	// for every uncurated field.
+	DriftSemanticNone DriftSemantic = ""
+	// DriftSemanticExact — exact equality between snapshot and live.
+	DriftSemanticExact DriftSemantic = "Exact"
+	// DriftSemanticWholeList — list-valued field compared as a whole
+	// (order-sensitive). Used for fields like GCS lifecycle_rule
+	// where per-element diffs are not meaningful.
+	DriftSemanticWholeList DriftSemantic = "WholeList"
+	// DriftSemanticLabelFilter — map-valued field compared after
+	// filtering out keys matching a prefix (e.g. `goog-*` labels
+	// the provider auto-populates). The prefix wire format is
+	// deferred to presets#482.
+	DriftSemanticLabelFilter DriftSemantic = "LabelFilter"
+)
+
+// Valid reports whether d is one of the known drift-semantic consts.
+// The empty string is valid and treated as DriftSemanticNone so that
+// existing policy files (all of which pre-date this axis) lint
+// cleanly without a sweep.
+func (d DriftSemantic) Valid() bool {
+	switch d {
+	case DriftSemanticNone, DriftSemanticExact, DriftSemanticWholeList, DriftSemanticLabelFilter:
+		return true
+	}
+	return false
+}

--- a/pkg/composer/imported/policy/axes_test.go
+++ b/pkg/composer/imported/policy/axes_test.go
@@ -133,9 +133,9 @@ func TestDriftSemantic_Valid(t *testing.T) {
 		{DriftSemanticExact, true},
 		{DriftSemanticWholeList, true},
 		{DriftSemanticLabelFilter, true},
-		{"exact", false},             // case-sensitive
-		{"whole_list", false},        // snake-case rejected
-		{"LabelFilter:goog-", false}, // parameter wire format is deferred to presets#482; raw const-only for now
+		{"exact", false},        // case-sensitive
+		{"whole_list", false},   // snake-case rejected
+		{"LabelFilter ", false}, // trailing space (parallel to VisibilityPolicy's "Hidden " probe)
 		{"unknown", false},
 	}
 	for _, tc := range cases {

--- a/pkg/composer/imported/policy/axes_test.go
+++ b/pkg/composer/imported/policy/axes_test.go
@@ -120,6 +120,29 @@ func TestChangeRiskPolicy_Valid(t *testing.T) {
 	}
 }
 
+func TestDriftSemantic_Valid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   DriftSemantic
+		want bool
+	}{
+		// Empty string is intentionally valid — pre-existing policy
+		// files leave this axis unset and must continue to lint
+		// cleanly with the new field present.
+		{DriftSemanticNone, true},
+		{DriftSemanticExact, true},
+		{DriftSemanticWholeList, true},
+		{DriftSemanticLabelFilter, true},
+		{"exact", false},             // case-sensitive
+		{"whole_list", false},        // snake-case rejected
+		{"LabelFilter:goog-", false}, // parameter wire format is deferred to presets#482; raw const-only for now
+		{"unknown", false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, tc.in.Valid(), "DriftSemantic(%q).Valid()", string(tc.in))
+	}
+}
+
 func TestSharedPolicies(t *testing.T) {
 	t.Parallel()
 	// Whole-struct equality: these constructors are baked into every

--- a/pkg/composer/imported/policy/policy.go
+++ b/pkg/composer/imported/policy/policy.go
@@ -9,13 +9,14 @@ package policy
 // Rationale is a human-readable note used by the lint to gate
 // visible-and-Sensitive entries. Most policies leave it empty.
 type FieldPolicy struct {
-	Role        FieldRole
-	Pillar      FieldPillar
-	Visibility  VisibilityPolicy
-	Edit        EditPolicy
-	Sensitivity SensitivityPolicy
-	ChangeRisk  ChangeRiskPolicy
-	Rationale   string
+	Role          FieldRole
+	Pillar        FieldPillar
+	Visibility    VisibilityPolicy
+	Edit          EditPolicy
+	Sensitivity   SensitivityPolicy
+	ChangeRisk    ChangeRiskPolicy
+	DriftSemantic DriftSemantic
+	Rationale     string
 }
 
 // Map is a curated field policy keyed by Terraform attribute path. See

--- a/pkg/imported/bindings/bindings.go
+++ b/pkg/imported/bindings/bindings.go
@@ -14,6 +14,7 @@ package bindings
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 )
 
@@ -88,14 +89,6 @@ func RegisteredTypes() []string {
 	for t := range registry {
 		out = append(out, t)
 	}
-	// Insertion-sort to keep the package dependency-light (the
-	// registry is small — at most ~163 entries even at full preset
-	// coverage — so sort.Strings would be overkill and would pull a
-	// stdlib package the rest of the file doesn't need).
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j-1] > out[j]; j-- {
-			out[j-1], out[j] = out[j], out[j-1]
-		}
-	}
+	sort.Strings(out)
 	return out
 }

--- a/pkg/imported/bindings/bindings.go
+++ b/pkg/imported/bindings/bindings.go
@@ -1,0 +1,101 @@
+// Package bindings is the registry of per-Terraform-type metrics
+// bindings — the data needed to translate an imported resource's
+// identity into a CloudWatch / Cloud Monitoring time-series query.
+// It is the upstream half of the metric-binding gap noted in
+// presets#482: pkg/observability already binds metrics by
+// composer.ComponentKey, but a TF-type-keyed map is what the
+// downstream pkg/imported.Provider.MetricsBinding(tfType) method
+// dispatches against.
+//
+// The registry starts empty in this skeleton (presets#TBD). Per-type
+// PRs in the enricher rollout register bindings opportunistically;
+// types without a binding return (zero, false) from Binding(tfType).
+package bindings
+
+import (
+	"fmt"
+	"sync"
+)
+
+// ComponentMetricsBinding describes the metrics surface for a single
+// imported Terraform resource type. Field semantics mirror
+// presets#482's `imported.ComponentMetricsBinding`:
+//
+//   - Service / Action — opaque pair the consumer interprets (e.g.
+//     "s3" / "get-metrics" routes to a service-specific handler in
+//     the downstream consumer; presets does not interpret these
+//     strings, it only ferries them).
+//   - DimensionKey — the CloudWatch / Cloud Monitoring dimension
+//     name (e.g. "BucketName"). What the cloud API expects.
+//   - DimensionFrom — the field on imported.ResourceIdentity that
+//     supplies the dimension value. Typically a key in
+//     Identity.ProviderIdentity or Identity.NativeIDs.
+//   - DefaultMetrics — the metric names the consumer should fetch
+//     when no per-call override is supplied.
+//
+// Empty fields are tolerated — the consumer treats absent fields as
+// "no default" and falls back to its own configuration. Registration
+// is the source of truth, not a contract for completeness.
+type ComponentMetricsBinding struct {
+	Service        string
+	Action         string
+	DimensionKey   string
+	DimensionFrom  string
+	DefaultMetrics []string
+}
+
+var (
+	regMu    sync.RWMutex
+	registry = map[string]ComponentMetricsBinding{}
+)
+
+// Register pins a ComponentMetricsBinding for tfType. Panics on
+// duplicate registration for the same key (mirrors the policy
+// package's Register contract — a duplicate means two files compete
+// for the same key, which is always a bug). Panics on empty tfType.
+func Register(tfType string, b ComponentMetricsBinding) {
+	if tfType == "" {
+		panic("bindings.Register: empty tfType")
+	}
+	regMu.Lock()
+	defer regMu.Unlock()
+	if _, ok := registry[tfType]; ok {
+		panic(fmt.Sprintf("bindings.Register: duplicate registration for %q", tfType))
+	}
+	registry[tfType] = b
+}
+
+// Binding returns the registered ComponentMetricsBinding for tfType.
+// The bool reports whether an entry exists; callers must not treat a
+// zero-value binding (no entry) as "no metrics" without checking ok —
+// a registered binding with empty DefaultMetrics is also valid and
+// means "use consumer defaults", distinct from "type isn't bound at
+// all".
+func Binding(tfType string) (ComponentMetricsBinding, bool) {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	b, ok := registry[tfType]
+	return b, ok
+}
+
+// RegisteredTypes returns the sorted set of tfTypes with a registered
+// binding. Used by the eventual codegen subcommand to enumerate the
+// registry for downstream consumers.
+func RegisteredTypes() []string {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	out := make([]string, 0, len(registry))
+	for t := range registry {
+		out = append(out, t)
+	}
+	// Insertion-sort to keep the package dependency-light (the
+	// registry is small — at most ~163 entries even at full preset
+	// coverage — so sort.Strings would be overkill and would pull a
+	// stdlib package the rest of the file doesn't need).
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}

--- a/pkg/imported/bindings/bindings_test.go
+++ b/pkg/imported/bindings/bindings_test.go
@@ -1,0 +1,103 @@
+package bindings
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func resetForTest(t *testing.T) {
+	t.Helper()
+	regMu.Lock()
+	defer regMu.Unlock()
+	registry = map[string]ComponentMetricsBinding{}
+}
+
+func TestEmptyLookup(t *testing.T) {
+	resetForTest(t)
+	if _, ok := Binding("aws_s3_bucket"); ok {
+		t.Errorf("Binding on empty registry returned ok=true")
+	}
+}
+
+func TestRegisterAndLookup(t *testing.T) {
+	resetForTest(t)
+	want := ComponentMetricsBinding{
+		Service:        "s3",
+		Action:         "get-metrics",
+		DimensionKey:   "BucketName",
+		DimensionFrom:  "ImportID",
+		DefaultMetrics: []string{"NumberOfObjects", "BucketSizeBytes"},
+	}
+	Register("aws_s3_bucket", want)
+	got, ok := Binding("aws_s3_bucket")
+	if !ok {
+		t.Fatal("Binding returned ok=false after Register")
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Binding = %#v, want %#v", got, want)
+	}
+}
+
+func TestRegisteredZeroValueIsDistinctFromAbsent(t *testing.T) {
+	resetForTest(t)
+	// A registered zero-value binding is a valid "use consumer
+	// defaults" entry — must report ok=true, distinct from absent.
+	Register("aws_dynamodb_table", ComponentMetricsBinding{})
+	got, ok := Binding("aws_dynamodb_table")
+	if !ok {
+		t.Fatal("registered zero-value binding reported ok=false")
+	}
+	if !reflect.DeepEqual(got, ComponentMetricsBinding{}) {
+		t.Errorf("zero-value lookup = %#v, want empty", got)
+	}
+	// Absent type stays ok=false.
+	if _, ok := Binding("aws_s3_bucket"); ok {
+		t.Error("absent type reported ok=true")
+	}
+}
+
+func TestRegisterEmptyTypePanics(t *testing.T) {
+	resetForTest(t)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on empty tfType")
+		}
+	}()
+	Register("", ComponentMetricsBinding{})
+}
+
+func TestRegisterDuplicatePanics(t *testing.T) {
+	resetForTest(t)
+	Register("aws_s3_bucket", ComponentMetricsBinding{Service: "s3"})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on duplicate registration")
+		}
+	}()
+	Register("aws_s3_bucket", ComponentMetricsBinding{Service: "s3-again"})
+}
+
+func TestRegisteredTypesSorted(t *testing.T) {
+	resetForTest(t)
+	Register("google_pubsub_topic", ComponentMetricsBinding{})
+	Register("aws_s3_bucket", ComponentMetricsBinding{})
+	Register("aws_dynamodb_table", ComponentMetricsBinding{})
+	got := RegisteredTypes()
+	want := []string{"aws_dynamodb_table", "aws_s3_bucket", "google_pubsub_topic"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RegisteredTypes() = %v, want %v", got, want)
+	}
+}
+
+func TestConcurrentRegisterReadSafety(t *testing.T) {
+	resetForTest(t)
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			_, _ = Binding("aws_s3_bucket")
+		})
+	}
+	Register("aws_s3_bucket", ComponentMetricsBinding{Service: "s3"})
+	wg.Wait()
+}

--- a/pkg/imported/bindings/bindings_test.go
+++ b/pkg/imported/bindings/bindings_test.go
@@ -1,7 +1,9 @@
 package bindings
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -51,8 +53,21 @@ func TestRegisteredZeroValueIsDistinctFromAbsent(t *testing.T) {
 	if !reflect.DeepEqual(got, ComponentMetricsBinding{}) {
 		t.Errorf("zero-value lookup = %#v, want empty", got)
 	}
+	// Partial-zero: Service set but DefaultMetrics nil. A regression
+	// that switches Binding's bool from "exists in map" to "has any
+	// non-zero field" / "DefaultMetrics non-empty" would break this
+	// case while the all-zero case above continues to pass.
+	partial := ComponentMetricsBinding{Service: "s3"}
+	Register("aws_s3_bucket", partial)
+	gotPartial, okPartial := Binding("aws_s3_bucket")
+	if !okPartial {
+		t.Fatal("partial-zero binding (Service-only) reported ok=false")
+	}
+	if !reflect.DeepEqual(gotPartial, partial) {
+		t.Errorf("partial-zero lookup = %#v, want %#v", gotPartial, partial)
+	}
 	// Absent type stays ok=false.
-	if _, ok := Binding("aws_s3_bucket"); ok {
+	if _, ok := Binding("aws_lambda_function"); ok {
 		t.Error("absent type reported ok=true")
 	}
 }
@@ -60,8 +75,12 @@ func TestRegisteredZeroValueIsDistinctFromAbsent(t *testing.T) {
 func TestRegisterEmptyTypePanics(t *testing.T) {
 	resetForTest(t)
 	defer func() {
-		if r := recover(); r == nil {
+		r := recover()
+		if r == nil {
 			t.Fatal("expected panic on empty tfType")
+		}
+		if msg := fmt.Sprint(r); !strings.Contains(msg, "empty tfType") {
+			t.Errorf("panic = %q, want substring %q", msg, "empty tfType")
 		}
 	}()
 	Register("", ComponentMetricsBinding{})
@@ -71,8 +90,12 @@ func TestRegisterDuplicatePanics(t *testing.T) {
 	resetForTest(t)
 	Register("aws_s3_bucket", ComponentMetricsBinding{Service: "s3"})
 	defer func() {
-		if r := recover(); r == nil {
+		r := recover()
+		if r == nil {
 			t.Fatal("expected panic on duplicate registration")
+		}
+		if msg := fmt.Sprint(r); !strings.Contains(msg, "duplicate registration") {
+			t.Errorf("panic = %q, want substring %q", msg, "duplicate registration")
 		}
 	}()
 	Register("aws_s3_bucket", ComponentMetricsBinding{Service: "s3-again"})
@@ -92,6 +115,11 @@ func TestRegisteredTypesSorted(t *testing.T) {
 
 func TestConcurrentRegisterReadSafety(t *testing.T) {
 	resetForTest(t)
+	// Race-detector smoke test: 32 concurrent readers against a writer
+	// must not panic, deadlock, or trigger the race detector. This test
+	// is only meaningfully assertive under `go test -race` — without it
+	// the test still runs (and verifies no deadlock / panic), but data
+	// races would go undetected. CI is expected to run with -race.
 	var wg sync.WaitGroup
 	for range 32 {
 		wg.Go(func() {

--- a/pkg/imported/labels/labels.go
+++ b/pkg/imported/labels/labels.go
@@ -1,0 +1,151 @@
+// Package labels is the registry of human-friendly display labels and
+// icon keys for imported Terraform resource types. It is the upstream
+// half of luthersystems/reliable's serviceMeta.ts surface — the
+// downstream consumer fetches this via the eventual codegen
+// `imported-codegen labels` subcommand (presets#482) and pins UI strings
+// to the registry instead of hand-maintaining a parallel map.
+//
+// Two-step lookup:
+//
+//  1. The override map (Register) wins. Per-type files in the per-cloud
+//     packages add entries on init() when the default rule produces a
+//     worse label than the curated one — e.g. "Queue (SQS)" over the
+//     default "Sqs Queue".
+//  2. Otherwise the default rule strips the cloud prefix and humanizes
+//     the remainder ("aws_s3_bucket" → "S3 Bucket", "google_pubsub_topic"
+//     → "Pubsub Topic"). Same for icon keys minus the title-casing.
+//
+// The registry starts empty in this skeleton (presets#TBD). Per-type
+// PRs in the enricher rollout populate entries opportunistically.
+package labels
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+var (
+	regMu  sync.RWMutex
+	labels = map[string]entry{}
+)
+
+type entry struct {
+	Label   string
+	IconKey string
+}
+
+// Register pins an override (label, iconKey) pair for tfType. Either
+// or both of label/iconKey may be empty, in which case the default
+// rule fills the empty side at lookup time. Panics on duplicate
+// registration for the same tfType (mirrors the policy package's
+// Register contract — a duplicate means two files compete for the
+// same key, which is always a bug).
+func Register(tfType, label, iconKey string) {
+	if tfType == "" {
+		panic("labels.Register: empty tfType")
+	}
+	regMu.Lock()
+	defer regMu.Unlock()
+	if _, ok := labels[tfType]; ok {
+		panic(fmt.Sprintf("labels.Register: duplicate registration for %q", tfType))
+	}
+	labels[tfType] = entry{Label: label, IconKey: iconKey}
+}
+
+// Label returns the human-readable display label for tfType. Returns
+// the registered override if one is set, else the default rule
+// applied to the type name (strip cloud prefix → humanize words).
+func Label(tfType string) string {
+	regMu.RLock()
+	e, ok := labels[tfType]
+	regMu.RUnlock()
+	if ok && e.Label != "" {
+		return e.Label
+	}
+	return defaultLabel(tfType)
+}
+
+// IconKey returns the icon-asset key for tfType. Returns the
+// registered override if one is set, else the type name minus the
+// cloud prefix ("aws_s3_bucket" → "s3_bucket").
+func IconKey(tfType string) string {
+	regMu.RLock()
+	e, ok := labels[tfType]
+	regMu.RUnlock()
+	if ok && e.IconKey != "" {
+		return e.IconKey
+	}
+	return defaultIconKey(tfType)
+}
+
+// RegisteredTypes returns the sorted set of tfTypes with an override
+// entry. Used by the eventual codegen subcommand to enumerate the
+// override map for downstream consumers.
+func RegisteredTypes() []string {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	out := make([]string, 0, len(labels))
+	for t := range labels {
+		out = append(out, t)
+	}
+	// Sort in place — small slice, stdlib sort is fine but we avoid
+	// importing sort here to keep the skeleton dependency-light.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+// defaultLabel produces "S3 Bucket" from "aws_s3_bucket" — strips the
+// cloud prefix and title-cases every underscore-delimited word.
+func defaultLabel(tfType string) string {
+	core := stripCloudPrefix(tfType)
+	if core == "" {
+		return tfType
+	}
+	parts := strings.Split(core, "_")
+	for i, p := range parts {
+		parts[i] = titleCase(p)
+	}
+	return strings.Join(parts, " ")
+}
+
+// defaultIconKey produces "s3_bucket" from "aws_s3_bucket".
+func defaultIconKey(tfType string) string {
+	core := stripCloudPrefix(tfType)
+	if core == "" {
+		return tfType
+	}
+	return core
+}
+
+// stripCloudPrefix removes the leading "aws_" or "google_" segment
+// from tfType. Returns the input unchanged for inputs that don't
+// match a known prefix (the codegen contract is that registered
+// types always carry one — defensive return is for unit-test
+// edge cases).
+func stripCloudPrefix(tfType string) string {
+	for _, p := range []string{"aws_", "google_"} {
+		if after, ok := strings.CutPrefix(tfType, p); ok {
+			return after
+		}
+	}
+	return tfType
+}
+
+// titleCase upper-cases the first rune of s and leaves the rest as-is.
+// Avoids importing strings.Title (deprecated) and golang.org/x/text/cases
+// (an extra module dependency for a one-liner).
+func titleCase(s string) string {
+	if s == "" {
+		return ""
+	}
+	first := s[0]
+	if first >= 'a' && first <= 'z' {
+		first -= 'a' - 'A'
+	}
+	return string(first) + s[1:]
+}

--- a/pkg/imported/labels/labels.go
+++ b/pkg/imported/labels/labels.go
@@ -21,13 +21,14 @@ package labels
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 )
 
 var (
-	regMu  sync.RWMutex
-	labels = map[string]entry{}
+	regMu    sync.RWMutex
+	registry = map[string]entry{}
 )
 
 type entry struct {
@@ -47,10 +48,10 @@ func Register(tfType, label, iconKey string) {
 	}
 	regMu.Lock()
 	defer regMu.Unlock()
-	if _, ok := labels[tfType]; ok {
+	if _, ok := registry[tfType]; ok {
 		panic(fmt.Sprintf("labels.Register: duplicate registration for %q", tfType))
 	}
-	labels[tfType] = entry{Label: label, IconKey: iconKey}
+	registry[tfType] = entry{Label: label, IconKey: iconKey}
 }
 
 // Label returns the human-readable display label for tfType. Returns
@@ -58,7 +59,7 @@ func Register(tfType, label, iconKey string) {
 // applied to the type name (strip cloud prefix → humanize words).
 func Label(tfType string) string {
 	regMu.RLock()
-	e, ok := labels[tfType]
+	e, ok := registry[tfType]
 	regMu.RUnlock()
 	if ok && e.Label != "" {
 		return e.Label
@@ -71,7 +72,7 @@ func Label(tfType string) string {
 // cloud prefix ("aws_s3_bucket" → "s3_bucket").
 func IconKey(tfType string) string {
 	regMu.RLock()
-	e, ok := labels[tfType]
+	e, ok := registry[tfType]
 	regMu.RUnlock()
 	if ok && e.IconKey != "" {
 		return e.IconKey
@@ -85,17 +86,11 @@ func IconKey(tfType string) string {
 func RegisteredTypes() []string {
 	regMu.RLock()
 	defer regMu.RUnlock()
-	out := make([]string, 0, len(labels))
-	for t := range labels {
+	out := make([]string, 0, len(registry))
+	for t := range registry {
 		out = append(out, t)
 	}
-	// Sort in place — small slice, stdlib sort is fine but we avoid
-	// importing sort here to keep the skeleton dependency-light.
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j-1] > out[j]; j-- {
-			out[j-1], out[j] = out[j], out[j-1]
-		}
-	}
+	sort.Strings(out)
 	return out
 }
 

--- a/pkg/imported/labels/labels_test.go
+++ b/pkg/imported/labels/labels_test.go
@@ -1,6 +1,8 @@
 package labels
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -11,7 +13,7 @@ func resetForTest(t *testing.T) {
 	t.Helper()
 	regMu.Lock()
 	defer regMu.Unlock()
-	labels = map[string]entry{}
+	registry = map[string]entry{}
 }
 
 func TestDefaultLabel(t *testing.T) {
@@ -26,6 +28,10 @@ func TestDefaultLabel(t *testing.T) {
 		{"google_pubsub_topic", "Pubsub Topic"},
 		// No known cloud prefix → defensive passthrough.
 		{"unknown_type", "Unknown Type"},
+		// Edge: cloud prefix only, nothing after. Exercises the
+		// `core == ""` defensive branch in defaultLabel.
+		{"aws_", "aws_"},
+		{"google_", "google_"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.tfType, func(t *testing.T) {
@@ -71,22 +77,45 @@ func TestRegisterOverridesDefault(t *testing.T) {
 }
 
 func TestRegisterPartialOverride(t *testing.T) {
-	resetForTest(t)
 	// Empty label → default rule fills it; iconKey override wins.
-	Register("aws_s3_bucket", "", "s3")
-	if got, want := Label("aws_s3_bucket"), "S3 Bucket"; got != want {
-		t.Errorf("Label empty-override fallthrough = %q, want %q", got, want)
-	}
-	if got, want := IconKey("aws_s3_bucket"), "s3"; got != want {
-		t.Errorf("IconKey override = %q, want %q", got, want)
-	}
+	t.Run("empty_label_iconKey_set", func(t *testing.T) {
+		resetForTest(t)
+		Register("aws_s3_bucket", "", "s3")
+		if got, want := Label("aws_s3_bucket"), "S3 Bucket"; got != want {
+			t.Errorf("Label empty-override fallthrough = %q, want %q", got, want)
+		}
+		if got, want := IconKey("aws_s3_bucket"), "s3"; got != want {
+			t.Errorf("IconKey override = %q, want %q", got, want)
+		}
+	})
+	// Symmetric: empty iconKey → default rule fills it; label
+	// override wins. This case nails the IconKey-side fallthrough
+	// guard (`if ok && e.IconKey != ""`) that would otherwise be
+	// invisible to a partial-override test on the label side only.
+	t.Run("label_set_empty_iconKey", func(t *testing.T) {
+		resetForTest(t)
+		Register("aws_xyz", "Custom Label", "")
+		if got, want := Label("aws_xyz"), "Custom Label"; got != want {
+			t.Errorf("Label override = %q, want %q", got, want)
+		}
+		if got, want := IconKey("aws_xyz"), "xyz"; got != want {
+			t.Errorf("IconKey empty-override fallthrough = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestRegisterEmptyTypePanics(t *testing.T) {
 	resetForTest(t)
 	defer func() {
-		if r := recover(); r == nil {
+		r := recover()
+		if r == nil {
 			t.Fatal("expected panic on empty tfType")
+		}
+		// Pin the discriminator substring so a regression that
+		// merges this panic with the duplicate-registration panic
+		// fails the test.
+		if msg := fmt.Sprint(r); !strings.Contains(msg, "empty tfType") {
+			t.Errorf("panic = %q, want substring %q", msg, "empty tfType")
 		}
 	}()
 	Register("", "x", "y")
@@ -96,8 +125,12 @@ func TestRegisterDuplicatePanics(t *testing.T) {
 	resetForTest(t)
 	Register("aws_s3_bucket", "A", "a")
 	defer func() {
-		if r := recover(); r == nil {
+		r := recover()
+		if r == nil {
 			t.Fatal("expected panic on duplicate registration")
+		}
+		if msg := fmt.Sprint(r); !strings.Contains(msg, "duplicate registration") {
+			t.Errorf("panic = %q, want substring %q", msg, "duplicate registration")
 		}
 	}()
 	Register("aws_s3_bucket", "B", "b")
@@ -118,11 +151,38 @@ func TestRegisteredTypesSortedAndStable(t *testing.T) {
 			t.Errorf("RegisteredTypes()[%d] = %q, want %q", i, got[i], want[i])
 		}
 	}
+	// Stable across calls: same registry state, same result, and
+	// the returned slice must not be backed by a shared mutable
+	// buffer (mutating got must not change a subsequent call's
+	// result).
+	got2 := RegisteredTypes()
+	if len(got2) != len(got) {
+		t.Fatalf("second call len = %d, want %d", len(got2), len(got))
+	}
+	for i := range got2 {
+		if got2[i] != got[i] {
+			t.Errorf("second call [%d] = %q, want %q", i, got2[i], got[i])
+		}
+	}
+	// Stomp the first result and verify the second is unaffected
+	// (returns must be independent slices).
+	for i := range got {
+		got[i] = "STOMPED"
+	}
+	for i := range got2 {
+		if got2[i] == "STOMPED" {
+			t.Errorf("second call slice aliases first: got2[%d] = %q", i, got2[i])
+		}
+	}
 }
 
 func TestConcurrentRegisterReadSafety(t *testing.T) {
 	resetForTest(t)
-	// Smoke test: 32 readers + 1 writer must not race or deadlock.
+	// Race-detector smoke test: 32 concurrent readers against a writer
+	// must not panic, deadlock, or trigger the race detector. This test
+	// is only meaningfully assertive under `go test -race` — without it
+	// the test still runs (and verifies no deadlock / panic), but data
+	// races would go undetected. CI is expected to run with -race.
 	var wg sync.WaitGroup
 	for range 32 {
 		wg.Go(func() {

--- a/pkg/imported/labels/labels_test.go
+++ b/pkg/imported/labels/labels_test.go
@@ -1,0 +1,134 @@
+package labels
+
+import (
+	"sync"
+	"testing"
+)
+
+// resetForTest clears the registry between tests. Not exported —
+// production code never resets the registry; only tests do.
+func resetForTest(t *testing.T) {
+	t.Helper()
+	regMu.Lock()
+	defer regMu.Unlock()
+	labels = map[string]entry{}
+}
+
+func TestDefaultLabel(t *testing.T) {
+	resetForTest(t)
+	cases := []struct {
+		tfType string
+		want   string
+	}{
+		{"aws_s3_bucket", "S3 Bucket"},
+		{"aws_dynamodb_table", "Dynamodb Table"},
+		{"google_storage_bucket", "Storage Bucket"},
+		{"google_pubsub_topic", "Pubsub Topic"},
+		// No known cloud prefix → defensive passthrough.
+		{"unknown_type", "Unknown Type"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tfType, func(t *testing.T) {
+			if got := Label(tc.tfType); got != tc.want {
+				t.Errorf("Label(%q) = %q, want %q", tc.tfType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultIconKey(t *testing.T) {
+	resetForTest(t)
+	cases := []struct {
+		tfType string
+		want   string
+	}{
+		{"aws_s3_bucket", "s3_bucket"},
+		{"google_pubsub_topic", "pubsub_topic"},
+		{"unknown_type", "unknown_type"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tfType, func(t *testing.T) {
+			if got := IconKey(tc.tfType); got != tc.want {
+				t.Errorf("IconKey(%q) = %q, want %q", tc.tfType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRegisterOverridesDefault(t *testing.T) {
+	resetForTest(t)
+	Register("aws_sqs_queue", "Queue (SQS)", "sqs")
+	if got, want := Label("aws_sqs_queue"), "Queue (SQS)"; got != want {
+		t.Errorf("Label override = %q, want %q", got, want)
+	}
+	if got, want := IconKey("aws_sqs_queue"), "sqs"; got != want {
+		t.Errorf("IconKey override = %q, want %q", got, want)
+	}
+	// Unregistered types fall through to default rule.
+	if got, want := Label("aws_s3_bucket"), "S3 Bucket"; got != want {
+		t.Errorf("Label fallthrough = %q, want %q", got, want)
+	}
+}
+
+func TestRegisterPartialOverride(t *testing.T) {
+	resetForTest(t)
+	// Empty label → default rule fills it; iconKey override wins.
+	Register("aws_s3_bucket", "", "s3")
+	if got, want := Label("aws_s3_bucket"), "S3 Bucket"; got != want {
+		t.Errorf("Label empty-override fallthrough = %q, want %q", got, want)
+	}
+	if got, want := IconKey("aws_s3_bucket"), "s3"; got != want {
+		t.Errorf("IconKey override = %q, want %q", got, want)
+	}
+}
+
+func TestRegisterEmptyTypePanics(t *testing.T) {
+	resetForTest(t)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on empty tfType")
+		}
+	}()
+	Register("", "x", "y")
+}
+
+func TestRegisterDuplicatePanics(t *testing.T) {
+	resetForTest(t)
+	Register("aws_s3_bucket", "A", "a")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on duplicate registration")
+		}
+	}()
+	Register("aws_s3_bucket", "B", "b")
+}
+
+func TestRegisteredTypesSortedAndStable(t *testing.T) {
+	resetForTest(t)
+	Register("google_pubsub_topic", "Topic", "topic")
+	Register("aws_s3_bucket", "Bucket", "s3")
+	Register("aws_dynamodb_table", "Table", "ddb")
+	got := RegisteredTypes()
+	want := []string{"aws_dynamodb_table", "aws_s3_bucket", "google_pubsub_topic"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("RegisteredTypes()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestConcurrentRegisterReadSafety(t *testing.T) {
+	resetForTest(t)
+	// Smoke test: 32 readers + 1 writer must not race or deadlock.
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			_ = Label("aws_s3_bucket")
+		})
+	}
+	Register("aws_s3_bucket", "Bucket", "s3")
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Phase 1 of a 3-phase rollout toward #482. Locks the minimal shape every subsequent enricher PR will populate, so the per-type rollout doesn't accumulate retrofit debt against the eventual Provider surface. ~300 LOC impl + ~500 LOC tests; purely additive, every existing policy file and enricher stays backward-compatible via zero-value defaults.

- `pkg/composer/imported/policy`: new `DriftSemantic` typed-string axis on `FieldPolicy` (None/Exact/WholeList/LabelFilter). Label-filter wire format deferred to #482 proper.
- `cmd/insideout-import/{aws,gcp}discover`: optional `ByIDEnricher` sibling interface (mirrors `io.WriterTo` next to `io.Reader` — type-assert at dispatch time).
- `pkg/imported/labels`: registry with default rule (strip cloud prefix + humanize) + override map.
- `pkg/imported/bindings`: registry of per-TF-type `ComponentMetricsBinding{Service, Action, DimensionKey, DimensionFrom, DefaultMetrics}`.

## Test plan

- [x] `go test -race ./pkg/imported/... ./pkg/composer/imported/policy/...` → 196 pass
- [x] `go test ./cmd/insideout-import/awsdiscover/. ./cmd/insideout-import/gcpdiscover/.` → 1368 pass
- [x] `go build ./...` clean
- [x] `gofmt -l` clean across touched files
- [x] Existing 42 `.policy.go` files compile + lint unchanged with new `DriftSemantic` field

## Review notes

- `/review` findings: all P0/P1 resolved on the local branch before push. Drive-by P2s addressed (replaced hand-rolled insertion sort with `sort.Strings`, renamed package var `labels` → `registry` to avoid shadowing package name, added `-race` comment on concurrent tests).
- qa-professor findings: all P1 + drive-by P2 addressed in commit `cef2aed`:
  - Removed tautological `TestByIDEnricher_FakeImplementation` runtime tests (compile-time `var _ ByIDEnricher` is the load-bearing assertion).
  - Added size sanity check on `TestExistingEnrichersDoNotImplementByID` so a silent drop of a production registration fails loud.
  - Split `TestRegisterPartialOverride` into symmetric label / iconKey subtests.
  - Added partial-zero binding case to `TestRegisteredZeroValueIsDistinctFromAbsent`.
  - Added `core == ""` defensive-branch coverage in `TestDefaultLabel`.
  - Replaced speculative `"LabelFilter:goog-"` probe with a trailing-space case parallel to existing axis probes.
  - Pinned panic-message substring on empty-tfType / duplicate-registration tests.
  - Added second-call stability + non-aliasing checks on `TestRegisteredTypesSortedAndStable`.
- No deferred items.

Closes #484.

## What this PR does NOT do

- No `pkg/imported.Provider` interface — #482 capstone.
- No per-type enricher impls — Phase 2 rollout bundles, separate umbrella ticket.
- No `aws_s3_bucket` `byTypeEnricher` wire-up — needs an actual `s3_bucket_enrich.go` impl (Phase 2 Bundle A1).
- No codegen subcommands (labels / capabilities / dependencies / drift-fields) — #482 capstone.
- No drift comparator — #482 capstone, driven by `DriftSemantic`.
- No `SUPPORTED_RESOURCES.md` capabilities matrix — #482 capstone.

Refs #482 (capstone), Bundle G1–G4 cadence (#470, #473, #475, #478).