### PR TITLE
feat(imported): Phase 2 Bundle 1 — 2 AWS + 2 GCP enrichers

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -207,7 +207,9 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 		// support) is in place already so the wiring there is a one-line
 		// registration.
 		byTypeEnricher: map[string]AttributeEnricher{
-			"aws_dynamodb_table": newDynamoDBTableEnricher(),
+			"aws_cloudwatch_log_group":  newCloudWatchLogGroupEnricher(),
+			"aws_dynamodb_table":        newDynamoDBTableEnricher(),
+			"aws_secretsmanager_secret": newSecretsManagerSecretEnricher(),
 		},
 	}
 }
@@ -224,8 +226,8 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 var serviceSlugByTFType = map[string]string{
 	// Bucket C — hand-rolled. Slugs must match the per-discoverer
 	// ServiceStart/Finish strings inside each *.go file.
-	"aws_apigatewayv2_stage": "apigatewayv2_stage",
-	"aws_bedrock_guardrail":  "bedrock_guardrail",
+	"aws_apigatewayv2_stage":                             "apigatewayv2_stage",
+	"aws_bedrock_guardrail":                              "bedrock_guardrail",
 	"aws_bedrock_model_invocation_logging_configuration": "bedrock_model_invocation_logging_configuration",
 	"aws_resourceexplorer2_index":                        "resourceexplorer2_index",
 	"aws_resourceexplorer2_view":                         "resourceexplorer2_view",

--- a/cmd/insideout-import/awsdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/awsdiscover/byid_enricher_test.go
@@ -28,15 +28,14 @@ func (fakeByIDEnricher) EnrichByID(ctx context.Context, identity *imported.Resou
 // observe beyond the compile.
 var _ ByIDEnricher = (*fakeByIDEnricher)(nil)
 
-// TestExistingEnrichersDoNotImplementByID confirms the additive
-// nature of ByIDEnricher: the 1 existing enricher (aws_dynamodb_table)
-// implements only AttributeEnricher today. The test pins against the
-// REAL production registration in NewAWSDiscoverer — not a hand-rolled
-// map — so when Phase 2 PRs add real EnrichByID impls, the allowlist
-// must shrink in lockstep with the production registration. A
-// production-only change (add a ByIDEnricher impl, forget to update
-// allowlist) fails the test loud. A regression that drops the
-// registration entirely is caught by the size sanity check below.
+// TestExistingEnrichersDoNotImplementByID pins the per-type
+// ByIDEnricher implementation status against the REAL production
+// registration in NewAWSDiscoverer. As Phase 2 PRs add real
+// EnrichByID impls, the allowlist must shrink in lockstep with the
+// production registration. A production-only change (add a
+// ByIDEnricher impl, forget to update allowlist; or vice versa) fails
+// the test loud. A regression that drops the registration entirely is
+// caught by the explicit wantTotal size check below.
 func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 	// Empty aws.Config is safe — the constructor only stores closures
 	// and per-type discoverer/enricher structs; no SDK calls fire.
@@ -48,13 +47,15 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 		"aws_dynamodb_table": true,
 	}
 
-	// Fail-fast: if the constructor silently dropped the registration,
-	// the for-range below iterates zero times and reports a green
-	// non-test. Pin the expected size to the allowlist length so a
-	// "silent drop in production, allowlist untouched" regression
-	// fails loud.
-	if got, want := len(d.byTypeEnricher), len(notImplemented); got != want {
-		t.Errorf("byTypeEnricher size = %d, want %d (production registration and notImplemented allowlist drifted)", got, want)
+	// Fail-fast: pin the expected total byTypeEnricher size so a
+	// silent drop (or duplicate-key squashing) in production fails the
+	// test. The expected total = allowlist size + types that DO
+	// implement ByIDEnricher. When adding a new enricher: bump
+	// wantTotal and either add to allowlist (no ByIDEnricher) or leave
+	// it off (implements ByIDEnricher).
+	const wantTotal = 3 // dynamodb_table + cloudwatch_log_group + secretsmanager_secret
+	if got := len(d.byTypeEnricher); got != wantTotal {
+		t.Errorf("byTypeEnricher size = %d, want %d (production registration drifted from test)", got, wantTotal)
 	}
 
 	for tfType, enr := range d.byTypeEnricher {

--- a/cmd/insideout-import/awsdiscover/cloudwatch_log_group_enrich.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatch_log_group_enrich.go
@@ -1,0 +1,299 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// cloudwatchLogGroupTFType is the registered Terraform type for the
+// CloudWatch log-group enricher. Kept as a constant so the registry /
+// ResourceType() stay in lockstep.
+const cloudwatchLogGroupTFType = "aws_cloudwatch_log_group"
+
+// cloudwatchLogGroupEnricher implements both AttributeEnricher and
+// ByIDEnricher for aws_cloudwatch_log_group. The pair shares a private
+// fetchAndMap helper so the SDK call + struct mapping lives in exactly
+// one place; the two methods differ only in how they package the
+// resulting payload (mutating ir.Attrs vs returning the raw JSON).
+//
+// SDK shape: CloudWatchLogs has no DescribeLogGroup (singular) — the
+// only read path is DescribeLogGroups with a name-prefix filter, so the
+// fetch issues a single Limit=10 call and filters the response slice
+// for an exact LogGroupName match. The prefix filter is permissive
+// (returns "foo", "foo-bar", "foo-1"), so the post-filter step is
+// load-bearing. Tags are a separate overlay fetched via
+// ListTagsForResource keyed on the ARN.
+//
+// Sensitive fields: none on this resource. Decision #36 redaction is
+// downstream's concern.
+type cloudwatchLogGroupEnricher struct {
+	// fetch is overridable for tests. Defaults to a real
+	// DescribeLogGroups call against the cloudwatchlogs.Client in
+	// EnrichClients. Returns (nil, nil) for a not-found log group so
+	// callers can branch cleanly on the not-found case without
+	// type-asserting on the SDK exception. Any other error is a real
+	// API failure and bubbles up unchanged.
+	fetch func(ctx context.Context, c *cloudwatchlogs.Client, name string) (*cwltypes.LogGroup, error)
+
+	// fetchTags is the tag-overlay hook. Best-effort: a fetch error
+	// logs nothing and the tags map is omitted from the payload.
+	fetchTags func(ctx context.Context, c *cloudwatchlogs.Client, arn string) (map[string]string, error)
+}
+
+func newCloudWatchLogGroupEnricher() *cloudwatchLogGroupEnricher {
+	return &cloudwatchLogGroupEnricher{
+		fetch:     defaultCloudWatchLogGroupFetch,
+		fetchTags: defaultCloudWatchLogGroupFetchTags,
+	}
+}
+
+func (cloudwatchLogGroupEnricher) ResourceType() string { return cloudwatchLogGroupTFType }
+
+// Enrich populates ir.Attrs with a typed AWSCloudwatchLogGroup payload
+// for the log group identified by ir.Identity. Returns
+// ErrEnrichClientUnavailable if EnrichClients.CloudWatchLogs is nil;
+// any other error reflects a real CloudWatch Logs API failure on the
+// load-bearing DescribeLogGroups call. Tags overlay failures are
+// downgraded to a silently-omitted Tags map; the resource is still
+// emitted.
+func (e cloudwatchLogGroupEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if c.CloudWatchLogs == nil {
+		return ErrEnrichClientUnavailable
+	}
+	name := cloudwatchLogGroupNameForEnrich(ir)
+	if name == "" {
+		return fmt.Errorf("cloudwatch_log_group: cannot derive log group name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			ir.Identity.Address, ir.Identity.ImportID, ir.Identity.NameHint)
+	}
+	lg, err := e.fetch(ctx, c.CloudWatchLogs, name)
+	if err != nil {
+		return fmt.Errorf("cloudwatch_log_group: describe %q: %w", name, err)
+	}
+	if lg == nil {
+		return fmt.Errorf("cloudwatch_log_group: %q: %w", name, ErrNotFound)
+	}
+
+	// Stamp ARN on Identity.NativeIDs BEFORE the tags overlay so the
+	// overlay can key off the canonical (no trailing :*) ARN. The TF
+	// resource's `arn` attribute uses the no-trailing-colon-star form
+	// (LogGroupArn), which is what ListTagsForResource also wants.
+	arn := pickLogGroupARN(lg)
+	if arn != "" {
+		if ir.Identity.NativeIDs == nil {
+			ir.Identity.NativeIDs = map[string]string{}
+		}
+		ir.Identity.NativeIDs["arn"] = arn
+	}
+
+	typed := mapCloudWatchLogGroup(lg)
+
+	// Overlay: tags — ListTagsForResource. Soft-fail (silently omit).
+	if arn != "" {
+		if tags, terr := e.fetchTags(ctx, c.CloudWatchLogs, arn); terr == nil && len(tags) > 0 {
+			m := map[string]*generated.Value[string]{}
+			for k, v := range tags {
+				m[k] = generated.LiteralOf(v)
+			}
+			typed.Tags = m
+		}
+	}
+
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return fmt.Errorf("cloudwatch_log_group: marshal Attrs: %w", err)
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID is the ByIDEnricher entry point. Mirrors Enrich's SDK call
+// + mapping path via fetchAndMap, but returns the raw JSON payload
+// instead of mutating an *ImportedResource. Used by the per-IR drift
+// refresh path (pkg/imported.Provider.EnrichByID, #482) where the
+// caller already holds an Identity and only wants the typed payload.
+//
+// Tags overlay failures are soft-failed identically to Enrich; the
+// caller cannot distinguish "no tags" from "tags fetch denied" from
+// the returned JSON alone, matching the AttributeEnricher contract.
+func (e cloudwatchLogGroupEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, errors.New("cloudwatch_log_group: identity is nil")
+	}
+	if c.CloudWatchLogs == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	// Reuse the same name-derivation helper. ResourceIdentity is the
+	// only field the helper reads, so wrap it in a synthetic IR.
+	ir := &imported.ImportedResource{Identity: *identity}
+	name := cloudwatchLogGroupNameForEnrich(ir)
+	if name == "" {
+		return nil, fmt.Errorf("cloudwatch_log_group: cannot derive log group name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			identity.Address, identity.ImportID, identity.NameHint)
+	}
+	typed, err := e.fetchAndMap(ctx, c.CloudWatchLogs, name)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("cloudwatch_log_group: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// fetchAndMap issues the DescribeLogGroups call + tag overlay and
+// returns the populated typed struct. Shared between Enrich and
+// EnrichByID so the SDK-call layout lives in one place. Does NOT
+// mutate any Identity — Enrich does that stamping itself before
+// calling out to fetchAndMap is unnecessary because Enrich needs the
+// raw LogGroup for the ARN-stamp step. Hence Enrich keeps its own
+// inline call sequence rather than going through this helper; this
+// helper exists for the EnrichByID-only path where there is no
+// ImportedResource to mutate.
+func (e cloudwatchLogGroupEnricher) fetchAndMap(ctx context.Context, c *cloudwatchlogs.Client, name string) (*generated.AWSCloudwatchLogGroup, error) {
+	lg, err := e.fetch(ctx, c, name)
+	if err != nil {
+		return nil, fmt.Errorf("cloudwatch_log_group: describe %q: %w", name, err)
+	}
+	if lg == nil {
+		return nil, fmt.Errorf("cloudwatch_log_group: %q: %w", name, ErrNotFound)
+	}
+	typed := mapCloudWatchLogGroup(lg)
+	if arn := pickLogGroupARN(lg); arn != "" {
+		if tags, terr := e.fetchTags(ctx, c, arn); terr == nil && len(tags) > 0 {
+			m := map[string]*generated.Value[string]{}
+			for k, v := range tags {
+				m[k] = generated.LiteralOf(v)
+			}
+			typed.Tags = m
+		}
+	}
+	return typed, nil
+}
+
+// cloudwatchLogGroupNameForEnrich pulls the log-group name from the
+// identifiers the CloudControl discoverer populates. Order of
+// preference matches dynamodbTableNameForEnrich:
+//
+//  1. Identity.NameHint — explicit name set by nameOrIdentifier in
+//     cloudControlTypeConfigs.
+//  2. Identity.NativeIDs["name"] — fallback if a future config
+//     populates the NativeIDs bag instead.
+//  3. Identity.ImportID — last resort; CloudControl emits the log
+//     group name as the Identifier, so this is usually the same as
+//     NameHint anyway.
+func cloudwatchLogGroupNameForEnrich(ir *imported.ImportedResource) string {
+	if s := strings.TrimSpace(ir.Identity.NameHint); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(ir.Identity.NativeIDs["name"]); s != "" {
+		return s
+	}
+	return strings.TrimSpace(ir.Identity.ImportID)
+}
+
+// pickLogGroupARN prefers the newer LogGroupArn (no trailing ":*") over
+// the older Arn alias (trailing ":*"). The TF resource's `arn`
+// attribute is the no-trailing-colon-star form, matching what
+// ListTagsForResource expects on its ResourceArn input, so pick that
+// one whenever it's set. Falls back to Arn (with trailing ":*"
+// stripped) for older API responses that only populate the legacy
+// field.
+func pickLogGroupARN(lg *cwltypes.LogGroup) string {
+	if lg == nil {
+		return ""
+	}
+	if lg.LogGroupArn != nil && *lg.LogGroupArn != "" {
+		return *lg.LogGroupArn
+	}
+	if lg.Arn != nil && *lg.Arn != "" {
+		return strings.TrimSuffix(*lg.Arn, ":*")
+	}
+	return ""
+}
+
+// mapCloudWatchLogGroup is the pure-mapping helper: copy the SDK
+// LogGroup fields into the typed AWSCloudwatchLogGroup. Skips the
+// TF-input-only fields (NamePrefix, SkipDestroy) and the computed
+// mirror (TagsAll) per the AttributeEnricher contract; Tags is
+// overlaid by the caller from ListTagsForResource.
+func mapCloudWatchLogGroup(lg *cwltypes.LogGroup) *generated.AWSCloudwatchLogGroup {
+	out := &generated.AWSCloudwatchLogGroup{}
+	if arn := pickLogGroupARN(lg); arn != "" {
+		out.ARN = generated.LiteralOf(arn)
+	}
+	if lg.LogGroupName != nil && *lg.LogGroupName != "" {
+		out.Name = generated.LiteralOf(*lg.LogGroupName)
+		// TF state stores the name as the resource id.
+		out.ID = generated.LiteralOf(*lg.LogGroupName)
+	}
+	if lg.KmsKeyId != nil && *lg.KmsKeyId != "" {
+		out.KMSKeyID = generated.LiteralOf(*lg.KmsKeyId)
+	}
+	if cls := string(lg.LogGroupClass); cls != "" {
+		out.LogGroupClass = generated.LiteralOf(cls)
+	}
+	if lg.RetentionInDays != nil {
+		out.RetentionInDays = generated.LiteralOf(int64(*lg.RetentionInDays))
+	}
+	return out
+}
+
+// defaultCloudWatchLogGroupFetch is the production fetch path: a
+// single DescribeLogGroups call with a name-prefix filter, then a
+// post-filter for the exact LogGroupName match. Returns (nil, nil) on
+// not-found so the caller can branch cleanly without type-asserting
+// the SDK exception (CloudWatchLogs returns an empty slice for
+// no-match — typed ResourceNotFoundException is rarely raised by this
+// endpoint).
+func defaultCloudWatchLogGroupFetch(ctx context.Context, c *cloudwatchlogs.Client, name string) (*cwltypes.LogGroup, error) {
+	out, err := c.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String(name),
+		Limit:              aws.Int32(10),
+	})
+	if err != nil {
+		// Surface typed not-found explicitly as (nil, nil) so the
+		// enricher can wrap it in ErrNotFound at the call site
+		// without leaking the SDK error type.
+		var nfe *cwltypes.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if out == nil {
+		return nil, nil
+	}
+	for i := range out.LogGroups {
+		if out.LogGroups[i].LogGroupName != nil && *out.LogGroups[i].LogGroupName == name {
+			return &out.LogGroups[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// defaultCloudWatchLogGroupFetchTags is the production tag-overlay
+// fetch path. Returns the raw map; the caller (Enrich / fetchAndMap)
+// projects it into the typed payload. CloudWatchLogs' tag-set is
+// capped at 50 per resource by the service, so a single call covers
+// every realistic case (no pagination).
+func defaultCloudWatchLogGroupFetchTags(ctx context.Context, c *cloudwatchlogs.Client, arn string) (map[string]string, error) {
+	out, err := c.ListTagsForResource(ctx, &cloudwatchlogs.ListTagsForResourceInput{ResourceArn: aws.String(arn)})
+	if err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return nil, nil
+	}
+	return out.Tags, nil
+}

--- a/cmd/insideout-import/awsdiscover/cloudwatch_log_group_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatch_log_group_enrich_test.go
@@ -1,0 +1,436 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// newTestCloudWatchLogGroupEnricher builds a cloudwatchLogGroupEnricher
+// with fake fetch closures wired in. Mirrors newTestDynamoDBEnricher.
+// Passing nil for tags defaults to "no tags" so a single test can stub
+// only the describe path.
+func newTestCloudWatchLogGroupEnricher(
+	describe func(ctx context.Context, c *cloudwatchlogs.Client, name string) (*cwltypes.LogGroup, error),
+	tags func(ctx context.Context, c *cloudwatchlogs.Client, arn string) (map[string]string, error),
+) cloudwatchLogGroupEnricher {
+	if tags == nil {
+		tags = func(context.Context, *cloudwatchlogs.Client, string) (map[string]string, error) {
+			return nil, nil
+		}
+	}
+	return cloudwatchLogGroupEnricher{
+		fetch:     describe,
+		fetchTags: tags,
+	}
+}
+
+// decodeLogGroupAttrs round-trips ir.Attrs through UnmarshalAttrs and
+// returns the typed AWSCloudwatchLogGroup. Mirrors decodeAttrs in the
+// dynamodb test file.
+func decodeLogGroupAttrs(t *testing.T, ir *imported.ImportedResource) *generated.AWSCloudwatchLogGroup {
+	t.Helper()
+	require.NotEmpty(t, ir.Attrs, "Attrs must be populated before decode")
+	decoded, err := generated.UnmarshalAttrs("aws_cloudwatch_log_group", ir.Attrs)
+	require.NoError(t, err)
+	lg, ok := decoded.(*generated.AWSCloudwatchLogGroup)
+	require.True(t, ok, "decoded type must be *AWSCloudwatchLogGroup, got %T", decoded)
+	return lg
+}
+
+func TestCloudwatchLogGroupEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	enr := newCloudWatchLogGroupEnricher()
+	assert.Equal(t, "aws_cloudwatch_log_group", enr.ResourceType())
+}
+
+// Compile-time pin: cloudwatchLogGroupEnricher must satisfy both
+// AttributeEnricher and ByIDEnricher. Captures the Phase-2 contract;
+// dropping either method on a refactor fails the build, not a test.
+var (
+	_ AttributeEnricher = (*cloudwatchLogGroupEnricher)(nil)
+	_ ByIDEnricher      = (*cloudwatchLogGroupEnricher)(nil)
+)
+
+func TestCloudwatchLogGroupEnricher_NilClientReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	enr := cloudwatchLogGroupEnricher{}
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", ImportID: "lg1", NameHint: "lg1"},
+	}, EnrichClients{CloudWatchLogs: nil})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestCloudwatchLogGroupEnricher_EnrichByID_NilClientReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	enr := cloudwatchLogGroupEnricher{}
+	_, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type: "aws_cloudwatch_log_group", NameHint: "lg1",
+	}, EnrichClients{CloudWatchLogs: nil})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestCloudwatchLogGroupEnricher_EnrichByID_NilIdentityReturnsError(t *testing.T) {
+	t.Parallel()
+	enr := cloudwatchLogGroupEnricher{}
+	_, err := enr.EnrichByID(context.Background(), nil, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity is nil")
+}
+
+func TestCloudwatchLogGroupEnricher_NameDerivation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		label string
+		ir    imported.ImportedResource
+		want  string
+	}{
+		{
+			label: "NameHint wins",
+			ir: imported.ImportedResource{Identity: imported.ResourceIdentity{
+				NameHint:  "from-name-hint",
+				ImportID:  "from-import-id",
+				NativeIDs: map[string]string{"name": "from-native"},
+			}},
+			want: "from-name-hint",
+		},
+		{
+			label: "NativeIDs[name] is fallback",
+			ir: imported.ImportedResource{Identity: imported.ResourceIdentity{
+				NativeIDs: map[string]string{"name": "from-native"},
+				ImportID:  "from-import-id",
+			}},
+			want: "from-native",
+		},
+		{
+			label: "ImportID is last resort",
+			ir: imported.ImportedResource{Identity: imported.ResourceIdentity{
+				ImportID: "from-import-id",
+			}},
+			want: "from-import-id",
+		},
+		{
+			label: "empty everywhere -> empty",
+			ir:    imported.ImportedResource{Identity: imported.ResourceIdentity{}},
+			want:  "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			assert.Equal(t, tc.want, cloudwatchLogGroupNameForEnrich(&tc.ir))
+		})
+	}
+}
+
+func TestCloudwatchLogGroupEnricher_NoNameReturnsError(t *testing.T) {
+	t.Parallel()
+	enr := newCloudWatchLogGroupEnricher()
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group"},
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "cannot derive log group name"))
+}
+
+func TestCloudwatchLogGroupEnricher_DescribeError_Propagates(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("AccessDeniedException")
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return nil, wantErr
+		}, nil)
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "lg1"},
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestCloudwatchLogGroupEnricher_NotFoundReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	// Fetch returns (nil, nil) for "no matching log group" — the
+	// enricher wraps that as ErrNotFound so the by-ID caller can
+	// distinguish "missing" from "API failure".
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return nil, nil
+		}, nil)
+
+	// Enrich path.
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "missing"},
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	// EnrichByID path.
+	raw, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type: "aws_cloudwatch_log_group", NameHint: "missing",
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Empty(t, raw)
+}
+
+func TestCloudwatchLogGroupEnricher_BasicMapping(t *testing.T) {
+	t.Parallel()
+	lg := &cwltypes.LogGroup{
+		LogGroupName:    aws.String("/aws/lambda/orders"),
+		LogGroupArn:     aws.String("arn:aws:logs:us-east-1:012345678901:log-group:/aws/lambda/orders"),
+		Arn:             aws.String("arn:aws:logs:us-east-1:012345678901:log-group:/aws/lambda/orders:*"),
+		KmsKeyId:        aws.String("arn:aws:kms:us-east-1:012345678901:key/abc"),
+		LogGroupClass:   cwltypes.LogGroupClassInfrequentAccess,
+		RetentionInDays: aws.Int32(30),
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		}, nil)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_cloudwatch_log_group",
+			Address:  "aws_cloudwatch_log_group.orders",
+			NameHint: "/aws/lambda/orders",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}, AccountID: "012345678901"}))
+
+	// ARN promoted onto NativeIDs from LogGroupArn (no trailing :*).
+	assert.Equal(t,
+		"arn:aws:logs:us-east-1:012345678901:log-group:/aws/lambda/orders",
+		ir.Identity.NativeIDs["arn"],
+		"enricher must stamp the canonical (no-trailing-:* ) LogGroupArn onto NativeIDs[arn] for tag-overlay use",
+	)
+
+	out := decodeLogGroupAttrs(t, ir)
+
+	require.NotNil(t, out.Name)
+	assert.Equal(t, "/aws/lambda/orders", *out.Name.Literal)
+	require.NotNil(t, out.ID)
+	assert.Equal(t, "/aws/lambda/orders", *out.ID.Literal, "id must mirror name per TF state semantics")
+	require.NotNil(t, out.ARN)
+	assert.Equal(t,
+		"arn:aws:logs:us-east-1:012345678901:log-group:/aws/lambda/orders",
+		*out.ARN.Literal,
+		"arn attribute must be the no-trailing-:* form",
+	)
+	require.NotNil(t, out.KMSKeyID)
+	assert.Equal(t, "arn:aws:kms:us-east-1:012345678901:key/abc", *out.KMSKeyID.Literal)
+	require.NotNil(t, out.LogGroupClass)
+	assert.Equal(t, string(cwltypes.LogGroupClassInfrequentAccess), *out.LogGroupClass.Literal)
+	require.NotNil(t, out.RetentionInDays)
+	assert.Equal(t, int64(30), *out.RetentionInDays.Literal)
+
+	// Skipped fields: NamePrefix, SkipDestroy, TagsAll never populated.
+	assert.Nil(t, out.NamePrefix, "name_prefix is TF-input-only — must not be set from SDK")
+	assert.Nil(t, out.SkipDestroy, "skip_destroy is TF-input-only — must not be set from SDK")
+	assert.Empty(t, out.TagsAll, "tags_all is a computed mirror — enricher must not populate")
+
+	// No tags fetched → Tags must be absent.
+	assert.Empty(t, out.Tags, "tags must be absent when fetchTags returns no tags")
+}
+
+func TestCloudwatchLogGroupEnricher_ARNFallbackFromLegacyArn(t *testing.T) {
+	t.Parallel()
+	// Older API responses only populate the legacy Arn field (with the
+	// trailing :*). The picker must strip the suffix to produce the TF
+	// `arn` form.
+	lg := &cwltypes.LogGroup{
+		LogGroupName: aws.String("legacy"),
+		Arn:          aws.String("arn:aws:logs:us-east-1:012345678901:log-group:legacy:*"),
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		}, nil)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "legacy"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}}))
+
+	assert.Equal(t,
+		"arn:aws:logs:us-east-1:012345678901:log-group:legacy",
+		ir.Identity.NativeIDs["arn"],
+		"legacy Arn fallback must have trailing :* stripped",
+	)
+	out := decodeLogGroupAttrs(t, ir)
+	require.NotNil(t, out.ARN)
+	assert.Equal(t, "arn:aws:logs:us-east-1:012345678901:log-group:legacy", *out.ARN.Literal)
+}
+
+func TestCloudwatchLogGroupEnricher_TagsOverlayHappy(t *testing.T) {
+	t.Parallel()
+	lg := &cwltypes.LogGroup{
+		LogGroupName: aws.String("tagged"),
+		LogGroupArn:  aws.String("arn:aws:logs:us-east-1:012345678901:log-group:tagged"),
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		},
+		func(_ context.Context, _ *cloudwatchlogs.Client, arn string) (map[string]string, error) {
+			assert.Equal(t, "arn:aws:logs:us-east-1:012345678901:log-group:tagged", arn,
+				"tags overlay must be keyed off the stamped ARN")
+			return map[string]string{
+				"Env":  "prod",
+				"Team": "payments",
+			}, nil
+		})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "tagged"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}}))
+
+	out := decodeLogGroupAttrs(t, ir)
+	require.NotNil(t, out.Tags)
+	require.NotNil(t, out.Tags["Env"])
+	assert.Equal(t, "prod", *out.Tags["Env"].Literal)
+	require.NotNil(t, out.Tags["Team"])
+	assert.Equal(t, "payments", *out.Tags["Team"].Literal)
+}
+
+func TestCloudwatchLogGroupEnricher_TagsOverlaySoftFailOnError(t *testing.T) {
+	t.Parallel()
+	// Tags-fetch errors must NOT cause Enrich to fail — the describe
+	// is the load-bearing call; tags is best-effort.
+	lg := &cwltypes.LogGroup{
+		LogGroupName: aws.String("t"),
+		LogGroupArn:  aws.String("arn:aws:logs:us-east-1:012345678901:log-group:t"),
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		},
+		func(context.Context, *cloudwatchlogs.Client, string) (map[string]string, error) {
+			return nil, errors.New("AccessDeniedException")
+		})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "t"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}}),
+		"tags-fetch error must be downgraded; only describe failure is fatal")
+	require.NotEmpty(t, ir.Attrs)
+	out := decodeLogGroupAttrs(t, ir)
+	assert.Empty(t, out.Tags, "tags must be absent when fetchTags errors")
+}
+
+func TestCloudwatchLogGroupEnricher_OmitsOptionalFieldsWhenUnset(t *testing.T) {
+	t.Parallel()
+	// Bare-minimum log group: SDK returns only the name. KMS, retention,
+	// class must all be absent in the typed payload (vs zero-valued)
+	// so decision-#34 clean HCL doesn't emit drifty defaults.
+	lg := &cwltypes.LogGroup{
+		LogGroupName: aws.String("minimal"),
+		LogGroupArn:  aws.String("arn:aws:logs:us-east-1:012345678901:log-group:minimal"),
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		}, nil)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "minimal"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}}))
+
+	out := decodeLogGroupAttrs(t, ir)
+	assert.Nil(t, out.KMSKeyID, "kms_key_id must be absent when SDK returns no KmsKeyId")
+	assert.Nil(t, out.RetentionInDays, "retention_in_days must be absent when SDK returns nil RetentionInDays")
+	assert.Nil(t, out.LogGroupClass, "log_group_class must be absent when SDK returns empty class")
+}
+
+func TestCloudwatchLogGroupEnricher_EnrichByID_HappyPath(t *testing.T) {
+	t.Parallel()
+	lg := &cwltypes.LogGroup{
+		LogGroupName:    aws.String("byid"),
+		LogGroupArn:     aws.String("arn:aws:logs:us-east-1:012345678901:log-group:byid"),
+		RetentionInDays: aws.Int32(7),
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		},
+		func(context.Context, *cloudwatchlogs.Client, string) (map[string]string, error) {
+			return map[string]string{"K": "V"}, nil
+		})
+
+	raw, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type:     "aws_cloudwatch_log_group",
+		NameHint: "byid",
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	// EnrichByID must return the same JSON shape Enrich writes into
+	// ir.Attrs — decode via the canonical UnmarshalAttrs path.
+	decoded, err := generated.UnmarshalAttrs("aws_cloudwatch_log_group", raw)
+	require.NoError(t, err)
+	out, ok := decoded.(*generated.AWSCloudwatchLogGroup)
+	require.True(t, ok)
+	require.NotNil(t, out.Name)
+	assert.Equal(t, "byid", *out.Name.Literal)
+	require.NotNil(t, out.RetentionInDays)
+	assert.Equal(t, int64(7), *out.RetentionInDays.Literal)
+	require.NotNil(t, out.Tags["K"])
+	assert.Equal(t, "V", *out.Tags["K"].Literal)
+}
+
+func TestCloudwatchLogGroupEnricher_EnrichByID_NoNameReturnsError(t *testing.T) {
+	t.Parallel()
+	enr := newCloudWatchLogGroupEnricher()
+	_, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type: "aws_cloudwatch_log_group",
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive log group name")
+}
+
+// Sanity pin: the raw JSON shape from Enrich and EnrichByID must be
+// byte-identical for the same fixture. If a future refactor splits
+// the mapping into divergent paths, this catches it.
+func TestCloudwatchLogGroupEnricher_EnrichAndEnrichByIDProduceSameJSON(t *testing.T) {
+	t.Parallel()
+	lg := &cwltypes.LogGroup{
+		LogGroupName:    aws.String("same"),
+		LogGroupArn:     aws.String("arn:aws:logs:us-east-1:012345678901:log-group:same"),
+		RetentionInDays: aws.Int32(14),
+		LogGroupClass:   cwltypes.LogGroupClassStandard,
+	}
+	tagFn := func(context.Context, *cloudwatchlogs.Client, string) (map[string]string, error) {
+		return map[string]string{"Tier": "gold"}, nil
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		}, tagFn)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "same"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}}))
+
+	raw, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type: "aws_cloudwatch_log_group", NameHint: "same",
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.NoError(t, err)
+
+	// Compare via round-trip-normalized JSON so map-key ordering
+	// doesn't cause a false negative.
+	var a, b any
+	require.NoError(t, json.Unmarshal(ir.Attrs, &a))
+	require.NoError(t, json.Unmarshal(raw, &b))
+	assert.Equal(t, a, b, "Enrich and EnrichByID must produce equivalent JSON payloads")
+}

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -22,8 +22,10 @@ import (
 	"sort"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -131,9 +133,11 @@ type ByIDEnricher interface {
 // Empty is tolerated when no enricher uses it (today: DynamoDB doesn't
 // need it because TableArn comes back in DescribeTable directly).
 type EnrichClients struct {
-	S3        *s3.Client
-	DynamoDB  *dynamodb.Client
-	AccountID string
+	S3             *s3.Client
+	DynamoDB       *dynamodb.Client
+	CloudWatchLogs *cloudwatchlogs.Client
+	SecretsManager *secretsmanager.Client
+	AccountID      string
 }
 
 // ErrEnrichClientUnavailable signals that the SDK client an enricher

--- a/cmd/insideout-import/awsdiscover/secretsmanager_secret_enrich.go
+++ b/cmd/insideout-import/awsdiscover/secretsmanager_secret_enrich.go
@@ -1,0 +1,290 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// secretsmanagerSecretTFType is the registered Terraform type for the
+// Secrets Manager Secret enricher. Kept as a constant so the registry /
+// ResourceType() stay in lockstep.
+const secretsmanagerSecretTFType = "aws_secretsmanager_secret"
+
+// secretsmanagerSecretEnricher implements AttributeEnricher and
+// ByIDEnricher for aws_secretsmanager_secret. Pairs with the Cloud-
+// Control-routed (or sdkonly) secrets_manager discoverer.
+//
+// Unlike DynamoDB — where TF surface aggregates four SDK calls — a
+// single DescribeSecret returns every field the Layer 1 typed model
+// needs: top-level attributes (Name, Description, KmsKeyId), tags
+// (inline Tags []Tag), and replicas (inline ReplicationStatus []*).
+// One fetch hook is therefore enough; no soft-fail overlay is needed.
+//
+// **Computed-only / TF-input-only fields skipped per decision #5:**
+//   - `arn` (Computed) — stamped on ir.Identity.NativeIDs["arn"]
+//     instead, matching the DynamoDB TableArn pattern.
+//   - `id` (Optional+Computed alias for ARN).
+//   - `tags_all` (Computed; provider merges defaults at plan time).
+//   - `force_overwrite_replica_secret` (TF-input only; no API source).
+//   - `name_prefix` (TF-input only; provider derives Name from it).
+//   - `recovery_window_in_days` (TF-input only; delete-time parameter
+//     consumed by DeleteSecret, with no Describe-side reflection).
+//   - `policy` (no field on DescribeSecretOutput; the resource policy
+//     lives behind a separate GetResourcePolicy call that this
+//     bundle's single-call contract does not include).
+//
+// Sensitive fields: the secret *value* lives behind GetSecretValue,
+// which we never call — only metadata is enriched. Decision #36
+// redaction is downstream's concern.
+type secretsmanagerSecretEnricher struct {
+	// fetch is overridable for tests. Defaults to a real DescribeSecret
+	// call against the secretsmanager.Client in EnrichClients. Tests
+	// inject a fake by constructing the enricher with a custom fetch —
+	// keeps the enricher hermetically testable without spinning up an
+	// HTTP server for the SDK client.
+	fetch func(ctx context.Context, c *secretsmanager.Client, secretID string) (*secretsmanager.DescribeSecretOutput, error)
+}
+
+// newSecretsManagerSecretEnricher returns the production-wired enricher.
+// AWSDiscoverer's byTypeEnricher map registers this under
+// "aws_secretsmanager_secret".
+func newSecretsManagerSecretEnricher() AttributeEnricher {
+	return &secretsmanagerSecretEnricher{fetch: defaultSecretsManagerSecretFetch}
+}
+
+func (secretsmanagerSecretEnricher) ResourceType() string { return secretsmanagerSecretTFType }
+
+// Enrich populates ir.Attrs with a typed AWSSecretsmanagerSecret
+// payload for the secret identified by ir.Identity. Returns
+// ErrEnrichClientUnavailable if EnrichClients.SecretsManager is nil;
+// any other error reflects a real Secrets Manager API failure on the
+// load-bearing DescribeSecret call.
+func (e secretsmanagerSecretEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if c.SecretsManager == nil {
+		return ErrEnrichClientUnavailable
+	}
+	secretID := secretsmanagerSecretIDForEnrich(&ir.Identity)
+	if secretID == "" {
+		return fmt.Errorf("secretsmanager_secret: cannot derive secret id from Identity (Address=%q ImportID=%q NameHint=%q)",
+			ir.Identity.Address, ir.Identity.ImportID, ir.Identity.NameHint)
+	}
+	out, err := e.fetch(ctx, c.SecretsManager, secretID)
+	if err != nil {
+		// Map typed not-found onto ErrNotFound so dispatchers / drift
+		// flows can distinguish a deleted secret from a real API
+		// failure. Mirrors the cloudcontrol_discoverer.go pattern.
+		var notFound *smtypes.ResourceNotFoundException
+		if errors.As(err, &notFound) {
+			return fmt.Errorf("secretsmanager_secret %q: %w", secretID, ErrNotFound)
+		}
+		return fmt.Errorf("secretsmanager_secret: describe %q: %w", secretID, err)
+	}
+	if out == nil {
+		return fmt.Errorf("secretsmanager_secret: describe %q: empty response", secretID)
+	}
+
+	// Stamp ARN on Identity.NativeIDs so downstream consumers don't
+	// have to round-trip back to the SDK for the ARN. The pure-
+	// mapping helper does NOT touch ir.Identity per the
+	// AttributeEnricher contract; this is the only place the enricher
+	// writes to it.
+	if arn := aws.ToString(out.ARN); arn != "" {
+		if ir.Identity.NativeIDs == nil {
+			ir.Identity.NativeIDs = map[string]string{}
+		}
+		ir.Identity.NativeIDs["arn"] = arn
+	}
+
+	typed := mapSecretsmanagerSecret(out)
+
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return fmt.Errorf("secretsmanager_secret: marshal Attrs: %w", err)
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID fetches the typed AWSSecretsmanagerSecret payload for the
+// secret named by identity and returns it as the json.RawMessage shape
+// that would land in ImportedResource.Attrs. Shares the SDK call +
+// mapping with Enrich via the private mapSecretsmanagerSecret helper so
+// the two paths cannot drift out of sync.
+//
+// EnrichByID does not mutate identity (callers passing a pointer get
+// the same struct back unchanged) — the ARN that Enrich stamps onto
+// NativeIDs is intentionally NOT stamped here, since the per-IR drift
+// refresh path expects the identity to be authoritative input, not a
+// destination.
+func (e secretsmanagerSecretEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.SecretsManager == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if identity == nil {
+		return nil, fmt.Errorf("secretsmanager_secret: nil identity")
+	}
+	secretID := secretsmanagerSecretIDForEnrich(identity)
+	if secretID == "" {
+		return nil, fmt.Errorf("secretsmanager_secret: cannot derive secret id from Identity (Address=%q ImportID=%q NameHint=%q)",
+			identity.Address, identity.ImportID, identity.NameHint)
+	}
+	out, err := e.fetch(ctx, c.SecretsManager, secretID)
+	if err != nil {
+		var notFound *smtypes.ResourceNotFoundException
+		if errors.As(err, &notFound) {
+			return nil, fmt.Errorf("secretsmanager_secret %q: %w", secretID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("secretsmanager_secret: describe %q: %w", secretID, err)
+	}
+	if out == nil {
+		return nil, fmt.Errorf("secretsmanager_secret: describe %q: empty response", secretID)
+	}
+	typed := mapSecretsmanagerSecret(out)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("secretsmanager_secret: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// secretsmanagerSecretIDForEnrich derives the SecretId argument for
+// DescribeSecret. Secrets Manager's DescribeSecret accepts either the
+// secret's bare name or its full ARN, so the order of preference
+// favors the most-fully-qualified identifier the discoverer is likely
+// to have populated:
+//
+//  1. Identity.ImportID — the per-service discoverer's
+//     passthroughImportID emits the secret ARN as the Identifier for
+//     Secrets Manager, so this is the load-bearing source.
+//  2. Identity.NameHint — explicit secret name set by the discoverer
+//     (or by a caller refreshing a single row via EnrichByID).
+//  3. Identity.NativeIDs["name"] — last-resort fallback if a future
+//     config populates the NativeIDs bag instead.
+//
+// Distinct from dynamodb_table's NameHint-first ordering because
+// DescribeSecret can take an ARN directly and the discoverer's
+// ImportID is the ARN — preferring ImportID avoids an unnecessary
+// fall-through.
+func secretsmanagerSecretIDForEnrich(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if s := strings.TrimSpace(id.ImportID); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(id.NameHint); s != "" {
+		return s
+	}
+	return strings.TrimSpace(id.NativeIDs["name"])
+}
+
+// defaultSecretsManagerSecretFetch is the production fetch path: a
+// single DescribeSecret call.
+func defaultSecretsManagerSecretFetch(ctx context.Context, c *secretsmanager.Client, secretID string) (*secretsmanager.DescribeSecretOutput, error) {
+	out, err := c.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{SecretId: aws.String(secretID)})
+	if err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return nil, errors.New("describe secret: nil output")
+	}
+	return out, nil
+}
+
+// mapSecretsmanagerSecret is the pure-mapping helper shared by Enrich
+// and EnrichByID. Hand-rolled (no enrichgen) because the Layer 1 typed
+// surface and the SDK DescribeSecretOutput shape are stable and the
+// special cases (skip-default-KMS-key, replication-block lift) are
+// short enough to inline. Mirrors the dynamodb_table_enrich.gen.go
+// shape so future readers can pattern-match.
+//
+// Decision-#34 cleanliness: every field is emitted only when present
+// on the API response, so the resulting HCL does not contain
+// "field = null" noise.
+func mapSecretsmanagerSecret(out *secretsmanager.DescribeSecretOutput) *generated.AWSSecretsmanagerSecret {
+	typed := &generated.AWSSecretsmanagerSecret{}
+
+	if name := aws.ToString(out.Name); name != "" {
+		typed.Name = generated.LiteralOf(name)
+	}
+	if desc := aws.ToString(out.Description); desc != "" {
+		typed.Description = generated.LiteralOf(desc)
+	}
+	// Skip the AWS-owned default key. The Secrets Manager API returns
+	// `KmsKeyId == ""` when the secret uses the AWS-managed default
+	// key (`alias/aws/secretsmanager`); emitting that as an explicit
+	// literal would diff against TF state where the field is left
+	// unset. Matches the DynamoDB SSE "absent when default" guard.
+	if k := aws.ToString(out.KmsKeyId); k != "" {
+		typed.KMSKeyID = generated.LiteralOf(k)
+	}
+
+	// Tags — DescribeSecretOutput already carries them inline, so no
+	// overlay call is needed.
+	if len(out.Tags) > 0 {
+		m := map[string]*generated.Value[string]{}
+		for _, t := range out.Tags {
+			if t.Key != nil {
+				m[*t.Key] = generated.LiteralOf(aws.ToString(t.Value))
+			}
+		}
+		if len(m) > 0 {
+			typed.Tags = m
+		}
+	}
+
+	// Replica blocks come from ReplicationStatus. The TF schema's
+	// `replica` block is Optional in input but each entry's fields
+	// here are downstream of the actual replication state, so the
+	// block list reflects observed state.
+	if len(out.ReplicationStatus) > 0 {
+		blocks := make([]generated.AWSSecretsmanagerSecretReplica, 0, len(out.ReplicationStatus))
+		for i := range out.ReplicationStatus {
+			blocks = append(blocks, enrichAWSSecretsmanagerSecretReplica(&out.ReplicationStatus[i]))
+		}
+		if len(blocks) > 0 {
+			typed.Replica = blocks
+		}
+	}
+
+	return typed
+}
+
+// enrichAWSSecretsmanagerSecretReplica lifts a single ReplicationStatus
+// entry into a Layer 1 replica block. Like the parent helper, every
+// field is emitted only when present so the resulting HCL stays
+// decision-#34 clean.
+func enrichAWSSecretsmanagerSecretReplica(r *smtypes.ReplicationStatusType) generated.AWSSecretsmanagerSecretReplica {
+	out := generated.AWSSecretsmanagerSecretReplica{}
+	if r == nil {
+		return out
+	}
+	if region := aws.ToString(r.Region); region != "" {
+		out.Region = generated.LiteralOf(region)
+	}
+	if k := aws.ToString(r.KmsKeyId); k != "" {
+		out.KMSKeyID = generated.LiteralOf(k)
+	}
+	if r.LastAccessedDate != nil {
+		// RFC3339 — matches what the AWS provider records in TF
+		// state for *_date fields.
+		out.LastAccessedDate = generated.LiteralOf(r.LastAccessedDate.UTC().Format("2006-01-02T15:04:05Z"))
+	}
+	if s := string(r.Status); s != "" {
+		out.Status = generated.LiteralOf(s)
+	}
+	if msg := aws.ToString(r.StatusMessage); msg != "" {
+		out.StatusMessage = generated.LiteralOf(msg)
+	}
+	return out
+}

--- a/cmd/insideout-import/awsdiscover/secretsmanager_secret_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/secretsmanager_secret_enrich_test.go
@@ -1,0 +1,469 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// newTestSecretsManagerSecretEnricher builds a secretsmanagerSecretEnricher
+// with a fake DescribeSecret fetch wired in. Mirrors the
+// newTestDynamoDBEnricher pattern so the two test files read alike.
+func newTestSecretsManagerSecretEnricher(
+	describe func(ctx context.Context, c *secretsmanager.Client, id string) (*secretsmanager.DescribeSecretOutput, error),
+) secretsmanagerSecretEnricher {
+	return secretsmanagerSecretEnricher{fetch: describe}
+}
+
+// decodeSecretsmanagerAttrs round-trips ir.Attrs through UnmarshalAttrs
+// and returns the typed AWSSecretsmanagerSecret. Mirrors the GCP-side
+// decoded-typed assertion pattern.
+func decodeSecretsmanagerAttrs(t *testing.T, ir *imported.ImportedResource) *generated.AWSSecretsmanagerSecret {
+	t.Helper()
+	require.NotEmpty(t, ir.Attrs, "Attrs must be populated before decode")
+	decoded, err := generated.UnmarshalAttrs("aws_secretsmanager_secret", ir.Attrs)
+	require.NoError(t, err)
+	sec, ok := decoded.(*generated.AWSSecretsmanagerSecret)
+	require.True(t, ok, "decoded type must be *AWSSecretsmanagerSecret, got %T", decoded)
+	return sec
+}
+
+// decodeSecretsmanagerRaw is the EnrichByID counterpart: the helper
+// returns json.RawMessage directly (no IR mutation), so the round-trip
+// goes through UnmarshalAttrs on the raw bytes.
+func decodeSecretsmanagerRaw(t *testing.T, raw json.RawMessage) *generated.AWSSecretsmanagerSecret {
+	t.Helper()
+	require.NotEmpty(t, raw, "EnrichByID must return a non-empty payload")
+	decoded, err := generated.UnmarshalAttrs("aws_secretsmanager_secret", raw)
+	require.NoError(t, err)
+	sec, ok := decoded.(*generated.AWSSecretsmanagerSecret)
+	require.True(t, ok, "decoded type must be *AWSSecretsmanagerSecret, got %T", decoded)
+	return sec
+}
+
+func TestSecretsmanagerSecretEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	enr := newSecretsManagerSecretEnricher()
+	assert.Equal(t, "aws_secretsmanager_secret", enr.ResourceType())
+}
+
+func TestSecretsmanagerSecretEnricher_ImplementsByIDEnricher(t *testing.T) {
+	t.Parallel()
+	// Compile-time guarantee that the production constructor returns
+	// something satisfying both interfaces. Phase 2 contract: every new
+	// enricher must implement ByIDEnricher.
+	var _ AttributeEnricher = newSecretsManagerSecretEnricher()
+	enr := newSecretsManagerSecretEnricher()
+	_, ok := enr.(ByIDEnricher)
+	assert.True(t, ok, "secretsmanagerSecretEnricher must implement ByIDEnricher per Phase 2 contract")
+}
+
+func TestSecretsmanagerSecretEnricher_NilClientReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	enr := secretsmanagerSecretEnricher{}
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_secretsmanager_secret",
+			ImportID: "arn:aws:secretsmanager:us-east-1:012345678901:secret:foo-AbCdEf",
+			NameHint: "foo",
+		},
+	}, EnrichClients{SecretsManager: nil})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestSecretsmanagerSecretEnricher_EnrichByID_NilClientReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	enr := secretsmanagerSecretEnricher{}
+	_, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type:     "aws_secretsmanager_secret",
+		ImportID: "arn:aws:secretsmanager:us-east-1:012345678901:secret:foo-AbCdEf",
+	}, EnrichClients{SecretsManager: nil})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestSecretsmanagerSecretEnricher_SecretIDDerivation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		label string
+		id    imported.ResourceIdentity
+		want  string
+	}{
+		{
+			label: "ImportID wins (typically the ARN from the discoverer)",
+			id: imported.ResourceIdentity{
+				ImportID:  "arn:aws:secretsmanager:us-east-1:012345678901:secret:foo-AbCdEf",
+				NameHint:  "foo",
+				NativeIDs: map[string]string{"name": "foo-native"},
+			},
+			want: "arn:aws:secretsmanager:us-east-1:012345678901:secret:foo-AbCdEf",
+		},
+		{
+			label: "NameHint is fallback when ImportID missing",
+			id: imported.ResourceIdentity{
+				NameHint:  "from-name-hint",
+				NativeIDs: map[string]string{"name": "from-native"},
+			},
+			want: "from-name-hint",
+		},
+		{
+			label: "NativeIDs[name] is last resort",
+			id: imported.ResourceIdentity{
+				NativeIDs: map[string]string{"name": "from-native"},
+			},
+			want: "from-native",
+		},
+		{
+			label: "empty everywhere → empty",
+			id:    imported.ResourceIdentity{},
+			want:  "",
+		},
+		{
+			label: "nil identity → empty",
+			id:    imported.ResourceIdentity{}, // sentinel below
+			want:  "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.label, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, secretsmanagerSecretIDForEnrich(&tc.id))
+		})
+	}
+	// Cover the nil-pointer guard explicitly.
+	assert.Equal(t, "", secretsmanagerSecretIDForEnrich(nil), "nil identity must yield empty id")
+}
+
+func TestSecretsmanagerSecretEnricher_DescribeError_Propagates(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("AccessDenied")
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return nil, wantErr
+		},
+	)
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret", ImportID: "foo"},
+	}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestSecretsmanagerSecretEnricher_NotFoundMapsToErrNotFound(t *testing.T) {
+	t.Parallel()
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return nil, &smtypes.ResourceNotFoundException{Message: aws.String("Secrets Manager can't find the specified secret.")}
+		},
+	)
+	t.Run("Enrich", func(t *testing.T) {
+		t.Parallel()
+		err := enr.Enrich(context.Background(), &imported.ImportedResource{
+			Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret", ImportID: "missing"},
+		}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNotFound, "typed ResourceNotFoundException must map onto ErrNotFound")
+	})
+	t.Run("EnrichByID", func(t *testing.T) {
+		t.Parallel()
+		_, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+			Type:     "aws_secretsmanager_secret",
+			ImportID: "missing",
+		}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+}
+
+func TestSecretsmanagerSecretEnricher_NoIDReturnsError(t *testing.T) {
+	t.Parallel()
+	enr := newSecretsManagerSecretEnricher()
+	t.Run("Enrich", func(t *testing.T) {
+		t.Parallel()
+		err := enr.Enrich(context.Background(), &imported.ImportedResource{
+			Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret"},
+		}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "cannot derive secret id"))
+	})
+	t.Run("EnrichByID", func(t *testing.T) {
+		t.Parallel()
+		byID, ok := enr.(ByIDEnricher)
+		require.True(t, ok)
+		_, err := byID.EnrichByID(context.Background(), &imported.ResourceIdentity{
+			Type: "aws_secretsmanager_secret",
+		}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "cannot derive secret id"))
+	})
+	t.Run("EnrichByID_NilIdentity", func(t *testing.T) {
+		t.Parallel()
+		byID, ok := enr.(ByIDEnricher)
+		require.True(t, ok)
+		_, err := byID.EnrichByID(context.Background(), nil,
+			EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "nil identity"))
+	})
+}
+
+func TestSecretsmanagerSecretEnricher_BasicMapping(t *testing.T) {
+	t.Parallel()
+	const (
+		secretARN  = "arn:aws:secretsmanager:us-east-1:012345678901:secret:db-creds-AbCdEf"
+		secretName = "db-creds"
+		kmsKey     = "arn:aws:kms:us-east-1:012345678901:key/abc"
+	)
+	out := &secretsmanager.DescribeSecretOutput{
+		ARN:         aws.String(secretARN),
+		Name:        aws.String(secretName),
+		Description: aws.String("Production DB credentials"),
+		KmsKeyId:    aws.String(kmsKey),
+		Tags: []smtypes.Tag{
+			{Key: aws.String("Env"), Value: aws.String("prod")},
+			{Key: aws.String("Project"), Value: aws.String("payments")},
+		},
+	}
+	enr := newTestSecretsManagerSecretEnricher(
+		func(_ context.Context, _ *secretsmanager.Client, gotID string) (*secretsmanager.DescribeSecretOutput, error) {
+			// Enrich must pass through ImportID (the ARN) as SecretId
+			// per the documented preference order. Pinning here
+			// prevents a regression where the helper accidentally falls
+			// through to NameHint first and downstream consumers stop
+			// resolving by ARN.
+			assert.Equal(t, secretARN, gotID, "Enrich must hand DescribeSecret the ARN from ImportID")
+			return out, nil
+		},
+	)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_secretsmanager_secret",
+			Address:  "aws_secretsmanager_secret.db_creds",
+			ImportID: secretARN,
+			NameHint: secretName,
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{SecretsManager: &secretsmanager.Client{}}))
+
+	// ARN promoted onto NativeIDs (mirrors DynamoDB TableArn pattern).
+	assert.Equal(t, secretARN, ir.Identity.NativeIDs["arn"],
+		"enricher must stamp ARN onto Identity.NativeIDs[arn]")
+
+	sec := decodeSecretsmanagerAttrs(t, ir)
+	require.NotNil(t, sec.Name)
+	assert.Equal(t, secretName, *sec.Name.Literal)
+	require.NotNil(t, sec.Description)
+	assert.Equal(t, "Production DB credentials", *sec.Description.Literal)
+	require.NotNil(t, sec.KMSKeyID)
+	assert.Equal(t, kmsKey, *sec.KMSKeyID.Literal)
+
+	require.NotNil(t, sec.Tags)
+	require.NotNil(t, sec.Tags["Env"])
+	assert.Equal(t, "prod", *sec.Tags["Env"].Literal)
+	require.NotNil(t, sec.Tags["Project"])
+	assert.Equal(t, "payments", *sec.Tags["Project"].Literal)
+
+	// Computed-only / TF-input-only fields must not appear in the
+	// payload — decision #5.
+	assert.Nil(t, sec.ARN, "arn is Computed; the enricher must NOT emit it on the typed payload (lives on Identity.NativeIDs)")
+	assert.Nil(t, sec.ID, "id is Computed; the enricher must not emit it")
+	assert.Nil(t, sec.TagsAll, "tags_all is Computed; the enricher must not emit it")
+	assert.Nil(t, sec.RecoveryWindowInDays, "recovery_window_in_days is delete-time-only; the enricher must not emit it")
+	assert.Nil(t, sec.ForceOverwriteReplicaSecret, "force_overwrite_replica_secret is TF-input-only; the enricher must not emit it")
+	assert.Nil(t, sec.NamePrefix, "name_prefix is TF-input-only; the enricher must not emit it")
+	assert.Nil(t, sec.Policy, "policy lives behind GetResourcePolicy; the single-call enricher must not emit it")
+	assert.Empty(t, sec.Replica, "replica must be absent when ReplicationStatus is empty")
+}
+
+func TestSecretsmanagerSecretEnricher_TagsAbsent(t *testing.T) {
+	t.Parallel()
+	out := &secretsmanager.DescribeSecretOutput{
+		ARN:  aws.String("arn:aws:secretsmanager:us-east-1:012345678901:secret:plain-AbCdEf"),
+		Name: aws.String("plain"),
+	}
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return out, nil
+		},
+	)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret", ImportID: "plain"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{SecretsManager: &secretsmanager.Client{}}))
+	sec := decodeSecretsmanagerAttrs(t, ir)
+	assert.Empty(t, sec.Tags, "tags must be absent when the API returns no tags (decision #34: no empty maps)")
+}
+
+func TestSecretsmanagerSecretEnricher_DefaultKMSKeyOmitsField(t *testing.T) {
+	t.Parallel()
+	// DescribeSecret returns KmsKeyId == "" when the secret uses the
+	// AWS-managed default key. Emitting "" or
+	// "alias/aws/secretsmanager" would diff against TF state where the
+	// field is left unset.
+	out := &secretsmanager.DescribeSecretOutput{
+		ARN:      aws.String("arn:aws:secretsmanager:us-east-1:012345678901:secret:default-key-AbCdEf"),
+		Name:     aws.String("default-key"),
+		KmsKeyId: aws.String(""),
+	}
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return out, nil
+		},
+	)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret", ImportID: "default-key"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{SecretsManager: &secretsmanager.Client{}}))
+	sec := decodeSecretsmanagerAttrs(t, ir)
+	assert.Nil(t, sec.KMSKeyID, "kms_key_id must be absent when the API reports the AWS-managed default key")
+}
+
+func TestSecretsmanagerSecretEnricher_ReplicaBlocks(t *testing.T) {
+	t.Parallel()
+	lastAccessed := time.Date(2025, 3, 14, 15, 9, 26, 0, time.UTC)
+	out := &secretsmanager.DescribeSecretOutput{
+		ARN:  aws.String("arn:aws:secretsmanager:us-east-1:012345678901:secret:multi-region-AbCdEf"),
+		Name: aws.String("multi-region"),
+		ReplicationStatus: []smtypes.ReplicationStatusType{
+			{
+				Region:           aws.String("us-west-2"),
+				KmsKeyId:         aws.String("arn:aws:kms:us-west-2:012345678901:key/west"),
+				Status:           smtypes.StatusTypeInSync,
+				LastAccessedDate: &lastAccessed,
+			},
+			{
+				Region:        aws.String("eu-west-1"),
+				Status:        smtypes.StatusTypeInProgress,
+				StatusMessage: aws.String("Replicating"),
+			},
+		},
+	}
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return out, nil
+		},
+	)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret", ImportID: "multi-region"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{SecretsManager: &secretsmanager.Client{}}))
+	sec := decodeSecretsmanagerAttrs(t, ir)
+	require.Len(t, sec.Replica, 2)
+
+	require.NotNil(t, sec.Replica[0].Region)
+	assert.Equal(t, "us-west-2", *sec.Replica[0].Region.Literal)
+	require.NotNil(t, sec.Replica[0].KMSKeyID)
+	assert.Equal(t, "arn:aws:kms:us-west-2:012345678901:key/west", *sec.Replica[0].KMSKeyID.Literal)
+	require.NotNil(t, sec.Replica[0].Status)
+	assert.Equal(t, string(smtypes.StatusTypeInSync), *sec.Replica[0].Status.Literal)
+	require.NotNil(t, sec.Replica[0].LastAccessedDate)
+	assert.Equal(t, "2025-03-14T15:09:26Z", *sec.Replica[0].LastAccessedDate.Literal)
+	assert.Nil(t, sec.Replica[0].StatusMessage, "status_message must be absent when the API omits it")
+
+	require.NotNil(t, sec.Replica[1].Region)
+	assert.Equal(t, "eu-west-1", *sec.Replica[1].Region.Literal)
+	assert.Nil(t, sec.Replica[1].KMSKeyID, "kms_key_id must be absent for in-progress replica with no key reported")
+	require.NotNil(t, sec.Replica[1].Status)
+	assert.Equal(t, string(smtypes.StatusTypeInProgress), *sec.Replica[1].Status.Literal)
+	require.NotNil(t, sec.Replica[1].StatusMessage)
+	assert.Equal(t, "Replicating", *sec.Replica[1].StatusMessage.Literal)
+}
+
+func TestSecretsmanagerSecretEnricher_EnrichByID_BasicMapping(t *testing.T) {
+	t.Parallel()
+	const secretARN = "arn:aws:secretsmanager:us-east-1:012345678901:secret:db-creds-AbCdEf"
+	out := &secretsmanager.DescribeSecretOutput{
+		ARN:         aws.String(secretARN),
+		Name:        aws.String("db-creds"),
+		Description: aws.String("Production DB credentials"),
+	}
+	enr := newTestSecretsManagerSecretEnricher(
+		func(_ context.Context, _ *secretsmanager.Client, gotID string) (*secretsmanager.DescribeSecretOutput, error) {
+			assert.Equal(t, secretARN, gotID)
+			return out, nil
+		},
+	)
+	byID, ok := AttributeEnricher(enr).(ByIDEnricher)
+	require.True(t, ok)
+	identity := &imported.ResourceIdentity{
+		Type:     "aws_secretsmanager_secret",
+		ImportID: secretARN,
+	}
+	raw, err := byID.EnrichByID(context.Background(), identity,
+		EnrichClients{SecretsManager: &secretsmanager.Client{}})
+	require.NoError(t, err)
+	sec := decodeSecretsmanagerRaw(t, raw)
+	require.NotNil(t, sec.Name)
+	assert.Equal(t, "db-creds", *sec.Name.Literal)
+	require.NotNil(t, sec.Description)
+	assert.Equal(t, "Production DB credentials", *sec.Description.Literal)
+
+	// EnrichByID must NOT mutate the caller's identity — the per-IR
+	// drift refresh path expects identity to be authoritative input.
+	assert.Empty(t, identity.NativeIDs,
+		"EnrichByID must not stamp NativeIDs onto the caller's identity")
+}
+
+func TestSecretsmanagerSecretEnricher_EnrichByID_DescribeError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("AccessDenied")
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return nil, wantErr
+		},
+	)
+	byID, ok := AttributeEnricher(enr).(ByIDEnricher)
+	require.True(t, ok)
+	_, err := byID.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type:     "aws_secretsmanager_secret",
+		ImportID: "foo",
+	}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestSecretsmanagerSecretEnricher_NilDescribeOutputErrors(t *testing.T) {
+	t.Parallel()
+	// Defense-in-depth: a fetch hook returning (nil, nil) (e.g. a
+	// future overlay-source helper that bails out silently) must not
+	// crash the enricher — it should surface a clear error.
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return nil, nil
+		},
+	)
+	t.Run("Enrich", func(t *testing.T) {
+		t.Parallel()
+		err := enr.Enrich(context.Background(), &imported.ImportedResource{
+			Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret", ImportID: "x"},
+		}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "empty response"))
+	})
+	t.Run("EnrichByID", func(t *testing.T) {
+		t.Parallel()
+		byID, ok := AttributeEnricher(enr).(ByIDEnricher)
+		require.True(t, ok)
+		_, err := byID.EnrichByID(context.Background(), &imported.ResourceIdentity{
+			Type:     "aws_secretsmanager_secret",
+			ImportID: "x",
+		}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "empty response"))
+	})
+}

--- a/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
@@ -26,15 +26,14 @@ func (fakeByIDEnricher) EnrichByID(ctx context.Context, identity *imported.Resou
 // observe beyond the compile.
 var _ ByIDEnricher = (*fakeByIDEnricher)(nil)
 
-// TestExistingEnrichersDoNotImplementByID confirms the additive
-// nature of ByIDEnricher: the 5 existing enrichers today implement
-// only AttributeEnricher. The test pins against the REAL production
-// registration in NewGCPDiscoverer — not a hand-rolled map — so when
-// Phase 2 PRs add real EnrichByID impls, the allowlist must shrink
-// in lockstep with the production registration. A production-only
-// change (add a ByIDEnricher impl, forget to update allowlist) fails
-// the test loud. A regression that drops the registration entirely
-// is caught by the size sanity check below.
+// TestExistingEnrichersDoNotImplementByID pins the per-type
+// ByIDEnricher implementation status against the REAL production
+// registration in NewGCPDiscoverer. As Phase 2 PRs add real
+// EnrichByID impls, the allowlist must shrink in lockstep with the
+// production registration. A production-only change (add a
+// ByIDEnricher impl, forget to update allowlist; or vice versa) fails
+// the test loud. A regression that drops the registration entirely is
+// caught by the explicit wantTotal size check below.
 func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 	// Nil searcher is safe — the constructor only stores it; no
 	// SearchAll call fires here.
@@ -50,13 +49,15 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 		"google_compute_network":       true,
 	}
 
-	// Fail-fast: if the constructor silently dropped the registration,
-	// the for-range below iterates zero times and reports a green
-	// non-test. Pin the expected size to the allowlist length so a
-	// "silent drop in production, allowlist untouched" regression
-	// fails loud.
-	if got, want := len(d.byTypeEnricher), len(notImplemented); got != want {
-		t.Errorf("byTypeEnricher size = %d, want %d (production registration and notImplemented allowlist drifted)", got, want)
+	// Fail-fast: pin the expected total byTypeEnricher size so a
+	// silent drop (or duplicate-key squashing) in production fails the
+	// test. The expected total = allowlist size + types that DO
+	// implement ByIDEnricher. When adding a new enricher: bump
+	// wantTotal and either add to allowlist (no ByIDEnricher) or leave
+	// it off (implements ByIDEnricher).
+	const wantTotal = 7 // 5 pre-Phase-2 + compute_address + compute_firewall
+	if got := len(d.byTypeEnricher); got != wantTotal {
+		t.Errorf("byTypeEnricher size = %d, want %d (production registration drifted from test)", got, wantTotal)
 	}
 
 	for tfType, enr := range d.byTypeEnricher {

--- a/cmd/insideout-import/gcpdiscover/compute_address_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/compute_address_enrich.go
@@ -1,0 +1,246 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	computev1 "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// computeAddressEnricher implements AttributeEnricher AND ByIDEnricher
+// for google_compute_address. Pairs with computeAddressDiscoverer.
+//
+// Compute API quirk: Addresses.Get takes (project, region, address) as
+// three separate positional string parameters, not a single fully-
+// qualified name. The enricher pulls the region from Identity.Location
+// (the discoverer always populates it for regional addresses; the
+// global slug is filtered out and handled by computeGlobalAddressEnricher
+// — see compute_address.go FromAsset), the short name from
+// Identity.NameHint / NativeIDs["name"] / ImportID, and the project
+// from EnrichClients.ProjectID (which the orchestrator threads through
+// from the run-level project ID).
+//
+// Mapping rationale matches compute_network_enrich.gen.go: pure
+// computed-only TF attributes (creation_timestamp, effective_labels,
+// id, label_fingerprint, self_link, terraform_labels, users) are NOT
+// populated per the decision-#5 composer emission rule — the generated
+// HCL is consumed by `import {} + resource {}` blocks where computed
+// fields are filled by the provider on first refresh. The `goog-` /
+// `goog_` label prefix filter mirrors pubsub_topic / storage_bucket so
+// system-managed labels don't leak into the user-editable HCL surface.
+type computeAddressEnricher struct {
+	// fetch is overridable for tests. Defaults to a real Addresses.Get
+	// call against the computev1.Service in EnrichClients. Tests
+	// inject a fake by constructing the enricher with a custom fetch
+	// — keeps the enricher hermetically testable without spinning up
+	// an HTTP server for the compute client.
+	fetch func(ctx context.Context, svc *computev1.Service, project, region, name string) (*computev1.Address, error)
+}
+
+func newComputeAddressEnricher() AttributeEnricher {
+	return &computeAddressEnricher{fetch: defaultComputeAddressFetch}
+}
+
+// Compile-time assertion that this enricher satisfies both interfaces.
+// Phase 2 contract: every new enricher implements ByIDEnricher in
+// addition to AttributeEnricher.
+var (
+	_ AttributeEnricher = (*computeAddressEnricher)(nil)
+	_ ByIDEnricher      = (*computeAddressEnricher)(nil)
+)
+
+func (computeAddressEnricher) ResourceType() string { return computeAddressTFType }
+
+// Enrich populates ir.Attrs with a typed GoogleComputeAddress payload
+// for the address identified by ir.Identity. Returns
+// ErrEnrichClientUnavailable if EnrichClients.Compute is nil; any
+// other error reflects a real Compute API failure.
+func (e computeAddressEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchTyped(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID is the sibling entry-point for the per-IR refresh path:
+// it accepts a bare Identity (no surrounding ImportedResource) and
+// returns the same json.RawMessage shape Enrich would write into
+// ir.Attrs. A 404 from the compute API is translated to ErrNotFound
+// so callers can distinguish "resource removed since last discover"
+// from a real API failure.
+func (e computeAddressEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("compute_address: nil identity")
+	}
+	return e.fetchTyped(ctx, identity, c)
+}
+
+// fetchTyped is the shared helper between Enrich and EnrichByID. It
+// performs the client-availability check, derives the (project,
+// region, name) triple, fires the SDK call, and marshals the typed
+// payload. Keeping the two entry-points thin around this helper means
+// the two surfaces stay in lockstep — every new validation or error
+// translation lands once.
+func (e computeAddressEnricher) fetchTyped(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.Compute == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if c.ProjectID == "" {
+		return nil, fmt.Errorf("compute_address: EnrichClients.ProjectID required (compute API uses project+region+name positional args)")
+	}
+	region, name := computeAddressRegionAndNameForEnrich(id)
+	if region == "" || name == "" {
+		return nil, fmt.Errorf("compute_address: cannot derive region/name from Identity (Address=%q ImportID=%q Location=%q NameHint=%q NativeIDs.name=%q)",
+			id.Address, id.ImportID, id.Location, id.NameHint, id.NativeIDs["name"])
+	}
+	a, err := e.fetch(ctx, c.Compute, c.ProjectID, region, name)
+	if err != nil {
+		if isComputeNotFound(err) {
+			return nil, fmt.Errorf("compute_address: %s/%s/%s: %w", c.ProjectID, region, name, ErrNotFound)
+		}
+		return nil, fmt.Errorf("compute_address: get %s/%s/%s: %w", c.ProjectID, region, name, err)
+	}
+	typed := mapComputeAddress(a, c.ProjectID, region)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("compute_address: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// computeAddressRegionAndNameForEnrich pulls (region, name) from the
+// Identity. Precedence: NameHint + Location (the canonical fields the
+// discoverer populates), NativeIDs["name"] + NativeIDs["region"]
+// fallback, and finally the ImportID
+// (projects/<p>/regions/<r>/addresses/<n>) parsed as a last resort.
+// Returns ("", "") if no derivation path yields both values — caller
+// surfaces a descriptive error.
+func computeAddressRegionAndNameForEnrich(id *imported.ResourceIdentity) (string, string) {
+	name := id.NameHint
+	if name == "" {
+		name = id.NativeIDs["name"]
+	}
+	region := id.Location
+	if region == "" {
+		region = id.NativeIDs["region"]
+	}
+	if name != "" && region != "" {
+		return region, name
+	}
+	if id.ImportID != "" {
+		r, n, err := computeAddressPartsFromID(id.ImportID)
+		if err == nil {
+			if name == "" {
+				name = n
+			}
+			if region == "" {
+				region = r
+			}
+		}
+	}
+	return region, name
+}
+
+// defaultComputeAddressFetch is the production fetch path: a single
+// Addresses.Get call. Context cancellation is honored via the
+// standard tooling-API ctx wiring.
+func defaultComputeAddressFetch(ctx context.Context, svc *computev1.Service, project, region, name string) (*computev1.Address, error) {
+	return svc.Addresses.Get(project, region, name).Context(ctx).Do()
+}
+
+// isComputeNotFound reports whether err is a googleapi.Error with HTTP
+// 404. The compute API returns a structured *googleapi.Error on every
+// REST call; treating that as the not-found signal keeps the
+// EnrichByID contract precise (ErrNotFound is reserved for confirmed
+// absence — any other 4xx / 5xx falls through to a wrapped error).
+func isComputeNotFound(err error) bool {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return gerr.Code == http.StatusNotFound
+	}
+	return false
+}
+
+// mapComputeAddress converts a *computev1.Address into the typed
+// Layer-1 *generated.GoogleComputeAddress model. Hand-rolled (not
+// enrichgen-emitted) because compute_address is small and has no
+// nested-block fields — the cost/benefit of a 30-line override
+// snippet under cmd/enrichgen exceeds the cost of maintaining this
+// directly. If the field count grows or nested blocks land, migrate
+// to enrichgen and follow the compute_network pattern.
+//
+// Computed-only TF fields skipped per decision #5:
+//
+//	creation_timestamp, effective_labels, id, label_fingerprint,
+//	self_link, terraform_labels, users.
+//
+// Region is taken from the function argument (the value the
+// discoverer already extracted into Identity.Location) rather than
+// parsed from b.Region — that field is a self-link URL the API
+// returns, and re-parsing it here would duplicate the discoverer's
+// extraction work.
+func mapComputeAddress(b *computev1.Address, projectID, region string) *generated.GoogleComputeAddress {
+	out := &generated.GoogleComputeAddress{}
+	if b.Address != "" {
+		out.Address = generated.LiteralOf(b.Address)
+	}
+	if b.AddressType != "" {
+		out.AddressType = generated.LiteralOf(b.AddressType)
+	}
+	if b.Description != "" {
+		out.Description = generated.LiteralOf(b.Description)
+	}
+	if b.IpVersion != "" {
+		out.IpVersion = generated.LiteralOf(b.IpVersion)
+	}
+	if b.Ipv6EndpointType != "" {
+		out.IPV6EndpointType = generated.LiteralOf(b.Ipv6EndpointType)
+	}
+	if len(b.Labels) > 0 {
+		labels := map[string]*generated.Value[string]{}
+		for k, v := range b.Labels {
+			if strings.HasPrefix(k, "goog-") || strings.HasPrefix(k, "goog_") {
+				continue
+			}
+			labels[k] = generated.LiteralOf(v)
+		}
+		if len(labels) > 0 {
+			out.Labels = labels
+		}
+	}
+	if b.Name != "" {
+		out.Name = generated.LiteralOf(b.Name)
+	}
+	if b.Network != "" {
+		out.Network = generated.LiteralOf(b.Network)
+	}
+	if b.NetworkTier != "" {
+		out.NetworkTier = generated.LiteralOf(b.NetworkTier)
+	}
+	if b.PrefixLength != 0 {
+		out.PrefixLength = generated.LiteralOf(float64(b.PrefixLength))
+	}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if b.Purpose != "" {
+		out.Purpose = generated.LiteralOf(b.Purpose)
+	}
+	if region != "" {
+		out.Region = generated.LiteralOf(region)
+	}
+	if b.Subnetwork != "" {
+		out.Subnetwork = generated.LiteralOf(b.Subnetwork)
+	}
+	return out
+}

--- a/cmd/insideout-import/gcpdiscover/compute_address_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/compute_address_enrich_test.go
@@ -1,0 +1,580 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	computev1 "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// TestMapComputeAddress_Minimal pins the smallest non-trivial mapping:
+// only the Name field populated. Every Optional+Computed scalar must
+// stay nil so the generated HCL surface matches "import block fills
+// the computed-only fields on first refresh."
+func TestMapComputeAddress_Minimal(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Address{Name: "lb-ip"}
+	got := mapComputeAddress(src, "my-project", "us-central1")
+
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "lb-ip", *got.Name.Literal)
+	require.NotNil(t, got.Project)
+	assert.Equal(t, "my-project", *got.Project.Literal)
+	require.NotNil(t, got.Region)
+	assert.Equal(t, "us-central1", *got.Region.Literal,
+		"region must come from the argument (the value the discoverer extracted into Identity.Location), not from the b.Region URL")
+
+	// Optional scalars stay nil on a basic address.
+	assert.Nil(t, got.Address)
+	assert.Nil(t, got.AddressType)
+	assert.Nil(t, got.Description)
+	assert.Nil(t, got.IpVersion)
+	assert.Nil(t, got.IPV6EndpointType)
+	assert.Nil(t, got.Labels)
+	assert.Nil(t, got.Network)
+	assert.Nil(t, got.NetworkTier)
+	assert.Nil(t, got.PrefixLength)
+	assert.Nil(t, got.Purpose)
+	assert.Nil(t, got.Subnetwork)
+
+	// Pure computed-only fields must NOT be populated (decision #5).
+	assert.Nil(t, got.CreationTimestamp, "creation_timestamp is computed-only")
+	assert.Nil(t, got.EffectiveLabels, "effective_labels is computed-only")
+	assert.Nil(t, got.ID, "id is computed-only")
+	assert.Nil(t, got.LabelFingerprint, "label_fingerprint is computed-only")
+	assert.Nil(t, got.SelfLink, "self_link is computed-only")
+	assert.Nil(t, got.TerraformLabels, "terraform_labels is computed-only")
+	assert.Empty(t, got.Users, "users is computed-only")
+	assert.Nil(t, got.Timeouts, "timeouts is a TF-only sentinel")
+}
+
+// TestMapComputeAddress_FullyPopulated covers every user-editable
+// field. Includes the int64-to-float64 cast on prefix_length and the
+// goog-managed-label filter.
+func TestMapComputeAddress_FullyPopulated(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Address{
+		Address:          "10.0.0.5",
+		AddressType:      "INTERNAL",
+		Description:      "Internal LB front-end",
+		IpVersion:        "IPV4",
+		Ipv6EndpointType: "",
+		Labels: map[string]string{
+			"team":          "platform",
+			"env":           "prod",
+			"goog-managed":  "true",
+			"goog_internal": "ignore-me",
+		},
+		Name:         "internal-lb-ip",
+		Network:      "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/vpc-prod",
+		NetworkTier:  "PREMIUM",
+		PrefixLength: 29,
+		Purpose:      "GCE_ENDPOINT",
+		Subnetwork:   "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/private",
+	}
+	got := mapComputeAddress(src, "my-project", "us-central1")
+
+	require.NotNil(t, got.Address)
+	assert.Equal(t, "10.0.0.5", *got.Address.Literal)
+	require.NotNil(t, got.AddressType)
+	assert.Equal(t, "INTERNAL", *got.AddressType.Literal)
+	require.NotNil(t, got.Description)
+	assert.Equal(t, "Internal LB front-end", *got.Description.Literal)
+	require.NotNil(t, got.IpVersion)
+	assert.Equal(t, "IPV4", *got.IpVersion.Literal)
+	require.NotNil(t, got.Network)
+	assert.Contains(t, *got.Network.Literal, "vpc-prod")
+	require.NotNil(t, got.NetworkTier)
+	assert.Equal(t, "PREMIUM", *got.NetworkTier.Literal)
+	require.NotNil(t, got.PrefixLength)
+	assert.Equal(t, float64(29), *got.PrefixLength.Literal,
+		"engine must cast int64 API prefix_length to *Value[float64] (the typed schema's chosen shape)")
+	require.NotNil(t, got.Purpose)
+	assert.Equal(t, "GCE_ENDPOINT", *got.Purpose.Literal)
+	require.NotNil(t, got.Subnetwork)
+	assert.Contains(t, *got.Subnetwork.Literal, "private")
+
+	// goog-managed labels stripped, user labels preserved.
+	require.NotNil(t, got.Labels)
+	assert.Len(t, got.Labels, 2, "goog-* and goog_* labels must be filtered out")
+	assert.Equal(t, "platform", *got.Labels["team"].Literal)
+	assert.Equal(t, "prod", *got.Labels["env"].Literal)
+	_, hasGoogManaged := got.Labels["goog-managed"]
+	assert.False(t, hasGoogManaged, "goog- prefix must be stripped")
+	_, hasGoogInternal := got.Labels["goog_internal"]
+	assert.False(t, hasGoogInternal, "goog_ prefix must be stripped")
+}
+
+// TestMapComputeAddress_IPv6EndpointType covers the IPv6-only path
+// since the FullyPopulated case leaves Ipv6EndpointType blank.
+func TestMapComputeAddress_IPv6EndpointType(t *testing.T) {
+	t.Parallel()
+	got := mapComputeAddress(&computev1.Address{
+		Name:             "v6-vm",
+		Ipv6EndpointType: "VM",
+	}, "p", "us-central1")
+	require.NotNil(t, got.IPV6EndpointType)
+	assert.Equal(t, "VM", *got.IPV6EndpointType.Literal)
+}
+
+// TestMapComputeAddress_LabelsAllGoogStripped covers the labels-map-
+// empty-after-filter branch. An address whose labels map contains
+// ONLY goog-managed entries must leave got.Labels nil (not an empty
+// map) so the emit layer can omit the attribute entirely.
+func TestMapComputeAddress_LabelsAllGoogStripped(t *testing.T) {
+	t.Parallel()
+	got := mapComputeAddress(&computev1.Address{
+		Name:   "n",
+		Labels: map[string]string{"goog-managed": "true"},
+	}, "p", "r")
+	assert.Nil(t, got.Labels, "all-goog map must collapse to nil so the emit layer omits the attribute")
+}
+
+// TestComputeAddressRegionAndNameForEnrich_Precedence pins the
+// precedence chain in derivation. NameHint+Location win over
+// NativeIDs win over ImportID parsing.
+func TestComputeAddressRegionAndNameForEnrich_Precedence(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		desc       string
+		id         imported.ResourceIdentity
+		wantRegion string
+		wantName   string
+	}{
+		{
+			desc: "NameHint+Location_preferred",
+			id: imported.ResourceIdentity{
+				NameHint:  "lb-ip",
+				Location:  "us-central1",
+				NativeIDs: map[string]string{"name": "stale", "region": "us-east1"},
+				ImportID:  "projects/p/regions/europe-west1/addresses/older",
+			},
+			wantRegion: "us-central1",
+			wantName:   "lb-ip",
+		},
+		{
+			desc: "NativeIDs_fallback_when_canonical_empty",
+			id: imported.ResourceIdentity{
+				NativeIDs: map[string]string{"name": "lb-ip", "region": "us-central1"},
+			},
+			wantRegion: "us-central1",
+			wantName:   "lb-ip",
+		},
+		{
+			desc: "ImportID_last_resort",
+			id: imported.ResourceIdentity{
+				ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+			},
+			wantRegion: "us-central1",
+			wantName:   "lb-ip",
+		},
+		{
+			desc: "ImportID_fills_only_missing_slot",
+			id: imported.ResourceIdentity{
+				NameHint: "lb-ip",
+				ImportID: "projects/p/regions/us-central1/addresses/other-name",
+			},
+			wantRegion: "us-central1",
+			wantName:   "lb-ip",
+		},
+		{
+			desc:       "all_empty_yields_empty",
+			id:         imported.ResourceIdentity{},
+			wantRegion: "",
+			wantName:   "",
+		},
+		{
+			desc: "global_importid_rejected_by_parts_parser",
+			id: imported.ResourceIdentity{
+				ImportID: "projects/p/global/addresses/global-ip",
+			},
+			wantRegion: "",
+			wantName:   "",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			gotRegion, gotName := computeAddressRegionAndNameForEnrich(&tc.id)
+			assert.Equal(t, tc.wantRegion, gotRegion)
+			assert.Equal(t, tc.wantName, gotName)
+		})
+	}
+}
+
+// TestComputeAddressEnrich_ClientUnavailable: nil Compute client must
+// return ErrEnrichClientUnavailable; ir.Attrs must remain empty so
+// the orchestrator can downgrade to a per-resource warn.
+func TestComputeAddressEnrich_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newComputeAddressEnricher()
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "google_compute_address",
+			ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+			Address:  "google_compute_address.lb_ip",
+			Location: "us-central1",
+			NameHint: "lb-ip",
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: nil, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Empty(t, ir.Attrs)
+}
+
+// TestComputeAddressEnrich_ProjectIDRequired pins the compute-API
+// quirk: Addresses.Get is positional (project, region, name), not a
+// single fully-qualified name, so ProjectID on EnrichClients is
+// structurally required even when Identity.ImportID encodes the
+// project.
+func TestComputeAddressEnrich_ProjectIDRequired(t *testing.T) {
+	t.Parallel()
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Address, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "google_compute_address",
+			ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+			Location: "us-central1",
+			NameHint: "lb-ip",
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "EnrichClients.ProjectID required")
+}
+
+// TestComputeAddressEnrich_RegionOrNameMissing covers the
+// undeducible-Identity branch. The error must mention every input
+// slot it consulted so a UI consumer can patch the right field.
+func TestComputeAddressEnrich_RegionOrNameMissing(t *testing.T) {
+	t.Parallel()
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Address, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "google_compute_address"},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive region/name")
+}
+
+// TestComputeAddressEnrich_FetchError pins the wrap shape on a real
+// API error (something other than 404). The wrapped error must carry
+// the (project/region/name) triple for triage and wrap the underlying
+// error so callers can errors.Is into the SDK error type.
+func TestComputeAddressEnrich_FetchError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("403 forbidden")
+	var gotProject, gotRegion, gotName string
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, project, region, name string) (*computev1.Address, error) {
+			gotProject, gotRegion, gotName = project, region, name
+			return nil, wantErr
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "google_compute_address",
+			ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+			Address:  "google_compute_address.lb_ip",
+			Location: "us-central1",
+			NameHint: "lb-ip",
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), "my-project/us-central1/lb-ip")
+	assert.Equal(t, "my-project", gotProject, "fetch must receive ProjectID from EnrichClients, not from Identity")
+	assert.Equal(t, "us-central1", gotRegion)
+	assert.Equal(t, "lb-ip", gotName)
+}
+
+// TestComputeAddressEnrich_PopulatesAttrs is the happy-path end-to-
+// end check: fake fetch returns a fully-populated Address, the
+// enricher writes typed JSON into ir.Attrs, and a UnmarshalAttrs
+// round-trip reproduces the field values.
+func TestComputeAddressEnrich_PopulatesAttrs(t *testing.T) {
+	t.Parallel()
+	addr := &computev1.Address{
+		Address:      "10.0.0.5",
+		AddressType:  "INTERNAL",
+		Description:  "Internal LB",
+		Name:         "lb-ip",
+		NetworkTier:  "PREMIUM",
+		PrefixLength: 29,
+		Purpose:      "GCE_ENDPOINT",
+		Subnetwork:   "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/private",
+	}
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, project, region, name string) (*computev1.Address, error) {
+			assert.Equal(t, "my-project", project)
+			assert.Equal(t, "us-central1", region)
+			assert.Equal(t, "lb-ip", name)
+			return addr, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "google_compute_address",
+			ImportID: "projects/my-project/regions/us-central1/addresses/lb-ip",
+			Address:  "google_compute_address.lb_ip",
+			Location: "us-central1",
+			NameHint: "lb-ip",
+		},
+	}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"}))
+
+	decoded, err := generated.UnmarshalAttrs("google_compute_address", ir.Attrs)
+	require.NoError(t, err)
+	ca, ok := decoded.(*generated.GoogleComputeAddress)
+	require.True(t, ok)
+	require.NotNil(t, ca.Name)
+	assert.Equal(t, "lb-ip", *ca.Name.Literal)
+	require.NotNil(t, ca.AddressType)
+	assert.Equal(t, "INTERNAL", *ca.AddressType.Literal)
+	require.NotNil(t, ca.PrefixLength)
+	assert.Equal(t, float64(29), *ca.PrefixLength.Literal)
+	require.NotNil(t, ca.Region)
+	assert.Equal(t, "us-central1", *ca.Region.Literal)
+}
+
+// TestComputeAddressEnrich_RoundTripThroughEmitImportedTF — decision-
+// #34 contract. Critical assertions: every populated field appears at
+// the top level (no nested-block emission for compute_address), and
+// the computed-only fields stay absent from the emitted HCL.
+func TestComputeAddressEnrich_RoundTripThroughEmitImportedTF(t *testing.T) {
+	t.Parallel()
+	addr := &computev1.Address{
+		Address:      "10.0.0.5",
+		AddressType:  "INTERNAL",
+		Description:  "Internal LB",
+		Name:         "lb-ip",
+		NetworkTier:  "PREMIUM",
+		PrefixLength: 29,
+		Purpose:      "GCE_ENDPOINT",
+		Subnetwork:   "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/private",
+	}
+	typed := mapComputeAddress(addr, "my-project", "us-central1")
+	raw, err := json.Marshal(typed)
+	require.NoError(t, err)
+
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "gcp", Type: "google_compute_address",
+			Address:  "google_compute_address.lb_ip",
+			ImportID: "projects/my-project/regions/us-central1/addresses/lb-ip",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: raw,
+	}
+	out, used := composer.EmitImportedTF("gcp", []imported.ImportedResource{ir}, composer.EmitImportedOpts{})
+	require.NotNil(t, out)
+	require.True(t, used["gcp"])
+	s := string(out)
+
+	assert.Contains(t, s, `resource "google_compute_address" "lb_ip"`)
+	assert.Regexp(t, `(?m)^\s*name\s+=\s+"lb-ip"`, s)
+	assert.Regexp(t, `(?m)^\s*project\s+=\s+"my-project"`, s)
+	assert.Regexp(t, `(?m)^\s*region\s+=\s+"us-central1"`, s)
+	assert.Regexp(t, `(?m)^\s*address\s+=\s+"10\.0\.0\.5"`, s)
+	assert.Regexp(t, `(?m)^\s*address_type\s+=\s+"INTERNAL"`, s)
+	assert.Regexp(t, `(?m)^\s*network_tier\s+=\s+"PREMIUM"`, s)
+	assert.Regexp(t, `(?m)^\s*purpose\s+=\s+"GCE_ENDPOINT"`, s)
+	assert.Regexp(t, `(?m)^\s*prefix_length\s+=\s+29`, s)
+
+	// Computed-only fields must NOT appear in emitted HCL.
+	for _, computed := range []string{"creation_timestamp", "label_fingerprint", "self_link", "effective_labels", "terraform_labels"} {
+		assert.NotContains(t, s, computed, "computed-only field %q must not appear", computed)
+	}
+}
+
+// ---------------------------------------------------------------
+// ByIDEnricher tests.
+// ---------------------------------------------------------------
+
+// TestComputeAddressEnrichByID_NilIdentity confirms the EnrichByID
+// surface gives a clean error on a nil identity (the dispatcher in
+// pkg/imported should never call with nil, but a defensive check
+// keeps the failure mode obvious if it does).
+func TestComputeAddressEnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newComputeAddressEnricher().(*computeAddressEnricher)
+	raw, err := e.EnrichByID(context.Background(), nil, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Nil(t, raw)
+	assert.Contains(t, err.Error(), "nil identity")
+}
+
+// TestComputeAddressEnrichByID_ClientUnavailable mirrors the Enrich
+// equivalent: the by-ID surface must report the same sentinel so the
+// per-IR refresh dispatcher can distinguish "not configured" from a
+// real API error.
+func TestComputeAddressEnrichByID_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newComputeAddressEnricher().(*computeAddressEnricher)
+	id := &imported.ResourceIdentity{
+		Type: "google_compute_address", NameHint: "lb-ip", Location: "us-central1",
+		ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+	}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{Compute: nil, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Nil(t, raw)
+}
+
+// TestComputeAddressEnrichByID_NotFound pins the 404-to-ErrNotFound
+// translation. The compute API surfaces a *googleapi.Error with
+// Code = 404 on a deleted-since-discover row; per the ByIDEnricher
+// contract that must become ErrNotFound so the caller can prune the
+// row from its UI without surfacing an alarming "API error".
+func TestComputeAddressEnrichByID_NotFound(t *testing.T) {
+	t.Parallel()
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Address, error) {
+			return nil, &googleapi.Error{Code: http.StatusNotFound, Message: "not found"}
+		},
+	}
+	id := &imported.ResourceIdentity{
+		Type: "google_compute_address", NameHint: "lb-ip", Location: "us-central1",
+		ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+	}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrNotFound)
+	assert.Nil(t, raw)
+}
+
+// TestComputeAddressEnrichByID_NonNotFoundErrorPassesThrough — a
+// non-404 googleapi error (e.g. 500 or 403) MUST NOT be confused
+// with ErrNotFound. The wrapper passes the original error through so
+// the caller can errors.As back to *googleapi.Error if it cares.
+func TestComputeAddressEnrichByID_NonNotFoundErrorPassesThrough(t *testing.T) {
+	t.Parallel()
+	upstream := &googleapi.Error{Code: http.StatusForbidden, Message: "denied"}
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Address, error) {
+			return nil, upstream
+		},
+	}
+	id := &imported.ResourceIdentity{
+		Type: "google_compute_address", NameHint: "lb-ip", Location: "us-central1",
+		ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+	}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound, "403 must NOT be classified as ErrNotFound")
+	var gerr *googleapi.Error
+	require.True(t, errors.As(err, &gerr), "underlying googleapi.Error must be preserved for caller inspection")
+	assert.Equal(t, http.StatusForbidden, gerr.Code)
+	assert.Nil(t, raw)
+}
+
+// TestComputeAddressEnrichByID_HappyPath confirms EnrichByID returns
+// the exact JSON shape Enrich would have written into ir.Attrs.
+// Pin via byte-equality so a future divergence between the two
+// entry-points is caught loud.
+func TestComputeAddressEnrichByID_HappyPath(t *testing.T) {
+	t.Parallel()
+	addr := &computev1.Address{
+		Address:     "10.0.0.5",
+		AddressType: "INTERNAL",
+		Name:        "lb-ip",
+		Purpose:     "GCE_ENDPOINT",
+	}
+	mkFetch := func() func(context.Context, *computev1.Service, string, string, string) (*computev1.Address, error) {
+		return func(_ context.Context, _ *computev1.Service, project, region, name string) (*computev1.Address, error) {
+			assert.Equal(t, "my-project", project)
+			assert.Equal(t, "us-central1", region)
+			assert.Equal(t, "lb-ip", name)
+			return addr, nil
+		}
+	}
+	enrichEnr := computeAddressEnricher{fetch: mkFetch()}
+	byIDEnr := computeAddressEnricher{fetch: mkFetch()}
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "google_compute_address",
+			ImportID: "projects/my-project/regions/us-central1/addresses/lb-ip",
+			Address:  "google_compute_address.lb_ip",
+			Location: "us-central1",
+			NameHint: "lb-ip",
+		},
+	}
+	require.NoError(t, enrichEnr.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"}))
+
+	id := &imported.ResourceIdentity{
+		Type:     "google_compute_address",
+		ImportID: "projects/my-project/regions/us-central1/addresses/lb-ip",
+		Address:  "google_compute_address.lb_ip",
+		Location: "us-central1",
+		NameHint: "lb-ip",
+	}
+	raw, err := byIDEnr.EnrichByID(context.Background(), id, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.NoError(t, err)
+	assert.JSONEq(t, string(ir.Attrs), string(raw),
+		"EnrichByID must return the same JSON shape Enrich writes into ir.Attrs")
+}
+
+// TestComputeAddressEnrichByID_DerivesFromImportIDOnly confirms the
+// caller can pass an Identity that only carries ImportID (the
+// pkg/imported.Provider refresh path can construct one from a TF
+// address alone) and the enricher still derives (region, name).
+func TestComputeAddressEnrichByID_DerivesFromImportIDOnly(t *testing.T) {
+	t.Parallel()
+	var gotRegion, gotName string
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, region, name string) (*computev1.Address, error) {
+			gotRegion, gotName = region, name
+			return &computev1.Address{Name: name}, nil
+		},
+	}
+	id := &imported.ResourceIdentity{
+		Type:     "google_compute_address",
+		ImportID: "projects/my-project/regions/europe-west4/addresses/eu-lb-ip",
+	}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.NoError(t, err)
+	assert.NotNil(t, raw)
+	assert.Equal(t, "europe-west4", gotRegion)
+	assert.Equal(t, "eu-lb-ip", gotName)
+}
+
+// TestIsComputeNotFound_Predicate is a direct unit on the helper so a
+// future change to its error-classification logic (e.g. accepting
+// gRPC NotFound too) doesn't have to be inferred from a fetch-level
+// integration test.
+func TestIsComputeNotFound_Predicate(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		desc string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain_error", errors.New("boom"), false},
+		{"googleapi_404", &googleapi.Error{Code: http.StatusNotFound}, true},
+		{"googleapi_403", &googleapi.Error{Code: http.StatusForbidden}, false},
+		{"googleapi_500", &googleapi.Error{Code: http.StatusInternalServerError}, false},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			assert.Equal(t, tc.want, isComputeNotFound(tc.err))
+		})
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/compute_firewall_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/compute_firewall_enrich.go
@@ -1,0 +1,244 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	computev1 "google.golang.org/api/compute/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// computeFirewallEnricher implements AttributeEnricher and ByIDEnricher
+// for google_compute_firewall. Pairs with computeFirewallDiscoverer.
+//
+// Hand-rolled (no .gen.go partner) because the firewall API surface
+// is small, the Allow/Deny nested-block conversion is straightforward,
+// and the SDK→TF field renames (Allowed→Allow, Denied→Deny,
+// IPProtocol→Protocol, LogConfig.Enable→top-level EnableLogging) are
+// all one-off translations that don't justify dragging the codegen
+// scaffolding in.
+//
+// Compute API quirk — same as compute_network: Firewalls.Get takes
+// (project, name) as two positional arguments, not a single
+// fully-qualified resource name. The enricher derives the short
+// firewall name from the Identity and pairs it with
+// EnrichClients.ProjectID.
+//
+// EnableLogging vs LogConfig: the TF resource exposes both a top-level
+// `enable_logging` attribute and a `log_config { metadata = ... }`
+// nested block. The SDK collapses both into FirewallLogConfig.Enable
+// (bool) + FirewallLogConfig.Metadata (string), so the enricher splits
+// them back apart on the way out.
+type computeFirewallEnricher struct {
+	fetch func(ctx context.Context, svc *computev1.Service, project, name string) (*computev1.Firewall, error)
+}
+
+func newComputeFirewallEnricher() AttributeEnricher {
+	return &computeFirewallEnricher{fetch: defaultComputeFirewallFetch}
+}
+
+func (computeFirewallEnricher) ResourceType() string { return computeFirewallTFType }
+
+// Enrich populates ir.Attrs with a typed GoogleComputeFirewall payload.
+// Returns ErrEnrichClientUnavailable if EnrichClients.Compute is nil;
+// any other error reflects a real Compute API failure.
+func (e computeFirewallEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchAndMap(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID fetches a single firewall by Identity and returns the
+// typed payload as json.RawMessage. Same shared fetch+map helper as
+// Enrich; differs only in how the result is packaged.
+func (e computeFirewallEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("compute_firewall: nil Identity")
+	}
+	return e.fetchAndMap(ctx, identity, c)
+}
+
+// fetchAndMap is the shared body for Enrich + EnrichByID. Validates
+// the clients, derives the firewall name, calls the SDK, and marshals
+// the typed payload. Centralizes error wrapping so the two entry
+// points stay in lockstep.
+func (e computeFirewallEnricher) fetchAndMap(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.Compute == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if c.ProjectID == "" {
+		return nil, fmt.Errorf("compute_firewall: EnrichClients.ProjectID required (compute API uses project+name positional args)")
+	}
+	name := computeFirewallShortNameForEnrich(id)
+	if name == "" {
+		return nil, fmt.Errorf("compute_firewall: cannot derive firewall name from Identity (Address=%q ImportID=%q NativeIDs.name=%q NativeIDs.asset_name=%q)",
+			id.Address, id.ImportID, id.NativeIDs["name"], id.NativeIDs["asset_name"])
+	}
+	fw, err := e.fetch(ctx, c.Compute, c.ProjectID, name)
+	if err != nil {
+		return nil, fmt.Errorf("compute_firewall: get %s/%s: %w", c.ProjectID, name, err)
+	}
+	typed := mapComputeFirewall(fw, c.ProjectID)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("compute_firewall: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// computeFirewallShortNameForEnrich extracts the short firewall name
+// from the Identity. Precedence: NameHint, NativeIDs["name"],
+// NativeIDs["asset_name"], ImportID. computeFirewallNameFromID
+// (compute_firewall.go) already handles every accepted shape.
+func computeFirewallShortNameForEnrich(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if n := id.NameHint; n != "" {
+		return n
+	}
+	if n := id.NativeIDs["name"]; n != "" {
+		return n
+	}
+	if asset := id.NativeIDs["asset_name"]; asset != "" {
+		if name, err := computeFirewallNameFromID(asset); err == nil {
+			return name
+		}
+	}
+	if id.ImportID != "" {
+		if name, err := computeFirewallNameFromID(id.ImportID); err == nil {
+			return name
+		}
+	}
+	return ""
+}
+
+func defaultComputeFirewallFetch(ctx context.Context, svc *computev1.Service, project, name string) (*computev1.Firewall, error) {
+	return svc.Firewalls.Get(project, name).Context(ctx).Do()
+}
+
+// mapComputeFirewall converts the raw SDK Firewall struct into the
+// typed Layer-1 GoogleComputeFirewall model. Decision-#5 computed-only
+// fields (creation_timestamp, self_link, id) are populated for round-
+// trip parity with the SDK response — the emit layer drops them when
+// they're tagged Computed=true in the schema.
+func mapComputeFirewall(b *computev1.Firewall, projectID string) *generated.GoogleComputeFirewall {
+	out := &generated.GoogleComputeFirewall{}
+
+	if b.Name != "" {
+		out.Name = generated.LiteralOf(b.Name)
+	}
+	if b.Network != "" {
+		out.Network = generated.LiteralOf(b.Network)
+	}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if b.Description != "" {
+		out.Description = generated.LiteralOf(b.Description)
+	}
+	if b.Direction != "" {
+		out.Direction = generated.LiteralOf(b.Direction)
+	}
+	if b.Priority != 0 {
+		out.Priority = generated.LiteralOf(float64(b.Priority))
+	}
+	if b.Disabled {
+		out.Disabled = generated.LiteralOf(b.Disabled)
+	}
+
+	if len(b.SourceRanges) > 0 {
+		out.SourceRanges = stringSliceToValues(b.SourceRanges)
+	}
+	if len(b.DestinationRanges) > 0 {
+		out.DestinationRanges = stringSliceToValues(b.DestinationRanges)
+	}
+	if len(b.SourceTags) > 0 {
+		out.SourceTags = stringSliceToValues(b.SourceTags)
+	}
+	if len(b.TargetTags) > 0 {
+		out.TargetTags = stringSliceToValues(b.TargetTags)
+	}
+	if len(b.SourceServiceAccounts) > 0 {
+		out.SourceServiceAccounts = stringSliceToValues(b.SourceServiceAccounts)
+	}
+	if len(b.TargetServiceAccounts) > 0 {
+		out.TargetServiceAccounts = stringSliceToValues(b.TargetServiceAccounts)
+	}
+
+	// Computed-only fields: populated for round-trip parity; the emit
+	// layer drops them based on schema Computed=true.
+	if b.CreationTimestamp != "" {
+		out.CreationTimestamp = generated.LiteralOf(b.CreationTimestamp)
+	}
+	if b.SelfLink != "" {
+		out.SelfLink = generated.LiteralOf(b.SelfLink)
+	}
+
+	if len(b.Allowed) > 0 {
+		out.Allow = make([]generated.GoogleComputeFirewallAllow, 0, len(b.Allowed))
+		for _, a := range b.Allowed {
+			if a == nil {
+				continue
+			}
+			out.Allow = append(out.Allow, mapComputeFirewallAllow(a))
+		}
+	}
+	if len(b.Denied) > 0 {
+		out.Deny = make([]generated.GoogleComputeFirewallDeny, 0, len(b.Denied))
+		for _, d := range b.Denied {
+			if d == nil {
+				continue
+			}
+			out.Deny = append(out.Deny, mapComputeFirewallDeny(d))
+		}
+	}
+
+	if b.LogConfig != nil {
+		// LogConfig.Enable lives on the top-level TF attribute
+		// `enable_logging` (not nested under log_config in the typed
+		// schema), so split it out here.
+		if b.LogConfig.Enable {
+			out.EnableLogging = generated.LiteralOf(b.LogConfig.Enable)
+		}
+		// Emit the nested block only when there's something to put in
+		// it. An all-default LogConfig (Enable=false, Metadata="")
+		// would render as an empty `log_config {}` block, which the
+		// provider permits but is noise.
+		if b.LogConfig.Metadata != "" {
+			out.LogConfig = []generated.GoogleComputeFirewallLogConfig{{
+				Metadata: generated.LiteralOf(b.LogConfig.Metadata),
+			}}
+		}
+	}
+
+	return out
+}
+
+func mapComputeFirewallAllow(a *computev1.FirewallAllowed) generated.GoogleComputeFirewallAllow {
+	out := generated.GoogleComputeFirewallAllow{}
+	if a.IPProtocol != "" {
+		out.Protocol = generated.LiteralOf(a.IPProtocol)
+	}
+	if len(a.Ports) > 0 {
+		out.Ports = stringSliceToValues(a.Ports)
+	}
+	return out
+}
+
+func mapComputeFirewallDeny(d *computev1.FirewallDenied) generated.GoogleComputeFirewallDeny {
+	out := generated.GoogleComputeFirewallDeny{}
+	if d.IPProtocol != "" {
+		out.Protocol = generated.LiteralOf(d.IPProtocol)
+	}
+	if len(d.Ports) > 0 {
+		out.Ports = stringSliceToValues(d.Ports)
+	}
+	return out
+}

--- a/cmd/insideout-import/gcpdiscover/compute_firewall_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/compute_firewall_enrich_test.go
@@ -1,0 +1,512 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	computev1 "google.golang.org/api/compute/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// compile-time: the enricher must satisfy BOTH interfaces.
+var (
+	_ AttributeEnricher = (*computeFirewallEnricher)(nil)
+	_ ByIDEnricher      = (*computeFirewallEnricher)(nil)
+)
+
+// firewallIdentity is the standard Identity used by happy-path tests
+// in this file. Mirrors what computeFirewallDiscoverer.FromAsset would
+// produce.
+func firewallIdentity() imported.ResourceIdentity {
+	return imported.ResourceIdentity{
+		Cloud:    "gcp",
+		Type:     "google_compute_firewall",
+		NameHint: "allow-ssh",
+		Address:  "google_compute_firewall.allow_ssh",
+		ImportID: "projects/my-project/global/firewalls/allow-ssh",
+		NativeIDs: map[string]string{
+			"name":       "allow-ssh",
+			"asset_name": "//compute.googleapis.com/projects/my-project/global/firewalls/allow-ssh",
+			"self_link":  "https://www.googleapis.com/compute/v1/projects/my-project/global/firewalls/allow-ssh",
+		},
+	}
+}
+
+// TestMapComputeFirewall_Minimal pins the smallest non-trivial shape:
+// name + network only, with everything else absent.
+func TestMapComputeFirewall_Minimal(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:    "allow-ssh",
+		Network: "projects/my-project/global/networks/default",
+	}
+	got := mapComputeFirewall(src, "my-project")
+
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "allow-ssh", *got.Name.Literal)
+	require.NotNil(t, got.Network)
+	assert.Equal(t, "projects/my-project/global/networks/default", *got.Network.Literal)
+	require.NotNil(t, got.Project)
+	assert.Equal(t, "my-project", *got.Project.Literal)
+
+	// All other fields untouched.
+	assert.Nil(t, got.Description)
+	assert.Nil(t, got.Direction)
+	assert.Nil(t, got.Priority)
+	assert.Nil(t, got.Disabled)
+	assert.Nil(t, got.SourceRanges)
+	assert.Nil(t, got.DestinationRanges)
+	assert.Nil(t, got.SourceTags)
+	assert.Nil(t, got.TargetTags)
+	assert.Nil(t, got.SourceServiceAccounts)
+	assert.Nil(t, got.TargetServiceAccounts)
+	assert.Empty(t, got.Allow)
+	assert.Empty(t, got.Deny)
+	assert.Empty(t, got.LogConfig)
+	assert.Nil(t, got.EnableLogging)
+	assert.Nil(t, got.CreationTimestamp)
+	assert.Nil(t, got.SelfLink)
+	assert.Nil(t, got.Timeouts)
+}
+
+// TestMapComputeFirewall_AllowOnly covers a typical ingress allow rule
+// (the most common firewall shape).
+func TestMapComputeFirewall_AllowOnly(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:         "allow-ssh",
+		Network:      "global/networks/default",
+		Direction:    "INGRESS",
+		Priority:     1000,
+		SourceRanges: []string{"0.0.0.0/0"},
+		TargetTags:   []string{"ssh-allowed"},
+		Allowed: []*computev1.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"22"}},
+		},
+	}
+	got := mapComputeFirewall(src, "my-project")
+
+	require.NotNil(t, got.Direction)
+	assert.Equal(t, "INGRESS", *got.Direction.Literal)
+	require.NotNil(t, got.Priority)
+	assert.Equal(t, float64(1000), *got.Priority.Literal,
+		"engine must cast int64 API priority to *Value[float64] (the typed schema's chosen shape)")
+	require.Len(t, got.SourceRanges, 1)
+	assert.Equal(t, "0.0.0.0/0", *got.SourceRanges[0].Literal)
+	require.Len(t, got.TargetTags, 1)
+	assert.Equal(t, "ssh-allowed", *got.TargetTags[0].Literal)
+
+	require.Len(t, got.Allow, 1)
+	require.NotNil(t, got.Allow[0].Protocol)
+	assert.Equal(t, "tcp", *got.Allow[0].Protocol.Literal,
+		"FirewallAllowed.IPProtocol must map to Allow.Protocol (TF rename)")
+	require.Len(t, got.Allow[0].Ports, 1)
+	assert.Equal(t, "22", *got.Allow[0].Ports[0].Literal)
+	assert.Empty(t, got.Deny, "deny block must stay empty when no Denied rules")
+}
+
+// TestMapComputeFirewall_DenyOnly covers a deny rule + EGRESS
+// direction + destination_ranges (the inverse-of-allow flow).
+func TestMapComputeFirewall_DenyOnly(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:              "deny-egress-bad-ip",
+		Network:           "global/networks/default",
+		Direction:         "EGRESS",
+		Priority:          500,
+		DestinationRanges: []string{"10.0.0.0/8", "192.168.0.0/16"},
+		Denied: []*computev1.FirewallDenied{
+			{IPProtocol: "all"},
+		},
+	}
+	got := mapComputeFirewall(src, "my-project")
+
+	require.NotNil(t, got.Direction)
+	assert.Equal(t, "EGRESS", *got.Direction.Literal)
+	require.Len(t, got.DestinationRanges, 2)
+	assert.Equal(t, "10.0.0.0/8", *got.DestinationRanges[0].Literal)
+	assert.Equal(t, "192.168.0.0/16", *got.DestinationRanges[1].Literal)
+
+	assert.Empty(t, got.Allow, "allow block must stay empty when no Allowed rules")
+	require.Len(t, got.Deny, 1)
+	require.NotNil(t, got.Deny[0].Protocol)
+	assert.Equal(t, "all", *got.Deny[0].Protocol.Literal)
+	assert.Nil(t, got.Deny[0].Ports, "Deny.Ports must be nil when SDK Ports is empty")
+}
+
+// TestMapComputeFirewall_MixedAllowDeny exercises the multi-rule
+// translation: 2 allow rules + 1 deny rule, each with multiple ports.
+func TestMapComputeFirewall_MixedAllowDeny(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:    "mixed-fw",
+		Network: "global/networks/default",
+		Allowed: []*computev1.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+			{IPProtocol: "udp", Ports: []string{"53"}},
+		},
+		Denied: []*computev1.FirewallDenied{
+			{IPProtocol: "icmp"},
+		},
+	}
+	got := mapComputeFirewall(src, "my-project")
+
+	require.Len(t, got.Allow, 2)
+	assert.Equal(t, "tcp", *got.Allow[0].Protocol.Literal)
+	require.Len(t, got.Allow[0].Ports, 2)
+	assert.Equal(t, "80", *got.Allow[0].Ports[0].Literal)
+	assert.Equal(t, "443", *got.Allow[0].Ports[1].Literal)
+	assert.Equal(t, "udp", *got.Allow[1].Protocol.Literal)
+	require.Len(t, got.Allow[1].Ports, 1)
+	assert.Equal(t, "53", *got.Allow[1].Ports[0].Literal)
+
+	require.Len(t, got.Deny, 1)
+	assert.Equal(t, "icmp", *got.Deny[0].Protocol.Literal)
+}
+
+// TestMapComputeFirewall_LogConfigEnabled pins the LogConfig split:
+// FirewallLogConfig.Enable becomes top-level EnableLogging;
+// FirewallLogConfig.Metadata becomes a log_config{} block.
+func TestMapComputeFirewall_LogConfigEnabled(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:    "audit-fw",
+		Network: "global/networks/default",
+		LogConfig: &computev1.FirewallLogConfig{
+			Enable:   true,
+			Metadata: "INCLUDE_ALL_METADATA",
+		},
+	}
+	got := mapComputeFirewall(src, "my-project")
+
+	require.NotNil(t, got.EnableLogging,
+		"FirewallLogConfig.Enable must become top-level enable_logging (not nested under log_config)")
+	assert.True(t, *got.EnableLogging.Literal)
+	require.Len(t, got.LogConfig, 1)
+	require.NotNil(t, got.LogConfig[0].Metadata)
+	assert.Equal(t, "INCLUDE_ALL_METADATA", *got.LogConfig[0].Metadata.Literal)
+}
+
+// TestMapComputeFirewall_LogConfigAbsent confirms the EnableLogging /
+// LogConfig fields stay nil when the API returns no LogConfig at all.
+func TestMapComputeFirewall_LogConfigAbsent(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:    "no-log-fw",
+		Network: "global/networks/default",
+	}
+	got := mapComputeFirewall(src, "my-project")
+	assert.Nil(t, got.EnableLogging)
+	assert.Empty(t, got.LogConfig)
+}
+
+// TestMapComputeFirewall_LogConfigEnableOnly covers an enable-only
+// LogConfig (no metadata). The TF top-level attr must populate, but the
+// nested block stays empty — emitting `log_config {}` with all defaults
+// is noise.
+func TestMapComputeFirewall_LogConfigEnableOnly(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:      "enable-only-fw",
+		Network:   "global/networks/default",
+		LogConfig: &computev1.FirewallLogConfig{Enable: true},
+	}
+	got := mapComputeFirewall(src, "my-project")
+	require.NotNil(t, got.EnableLogging)
+	assert.True(t, *got.EnableLogging.Literal)
+	assert.Empty(t, got.LogConfig, "no Metadata → no log_config{} block")
+}
+
+// TestMapComputeFirewall_ComputedRoundTrip populates computed-only
+// fields (creation_timestamp, self_link) on the typed struct. The emit
+// layer is responsible for dropping them based on Computed=true in
+// GoogleComputeFirewallSchema.
+func TestMapComputeFirewall_ComputedRoundTrip(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:              "fw",
+		Network:           "global/networks/default",
+		CreationTimestamp: "2024-01-02T03:04:05Z",
+		SelfLink:          "https://www.googleapis.com/compute/v1/projects/p/global/firewalls/fw",
+	}
+	got := mapComputeFirewall(src, "p")
+	require.NotNil(t, got.CreationTimestamp)
+	assert.Equal(t, "2024-01-02T03:04:05Z", *got.CreationTimestamp.Literal)
+	require.NotNil(t, got.SelfLink)
+	assert.Contains(t, *got.SelfLink.Literal, "/firewalls/fw")
+}
+
+// Enricher contract tests --------------------------------------------
+
+func TestComputeFirewallEnrich_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newComputeFirewallEnricher()
+	ir := &imported.ImportedResource{Identity: firewallIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: nil})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Empty(t, ir.Attrs)
+}
+
+// TestComputeFirewallEnrichByID_ClientUnavailable mirrors the
+// AttributeEnricher contract on the ByID entry point.
+func TestComputeFirewallEnrichByID_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newComputeFirewallEnricher().(ByIDEnricher)
+	id := firewallIdentity()
+	raw, err := e.EnrichByID(context.Background(), &id, EnrichClients{Compute: nil})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Nil(t, raw)
+}
+
+func TestComputeFirewallEnrich_ProjectIDRequired(t *testing.T) {
+	t.Parallel()
+	e := computeFirewallEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _ string) (*computev1.Firewall, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: firewallIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "EnrichClients.ProjectID required")
+}
+
+func TestComputeFirewallEnrich_NameMissing(t *testing.T) {
+	t.Parallel()
+	e := computeFirewallEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _ string) (*computev1.Firewall, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "google_compute_firewall"},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive firewall name")
+}
+
+func TestComputeFirewallEnrich_FetchError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("404 not found")
+	var gotProject, gotName string
+	e := computeFirewallEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, project, name string) (*computev1.Firewall, error) {
+			gotProject, gotName = project, name
+			return nil, wantErr
+		},
+	}
+	ir := &imported.ImportedResource{Identity: firewallIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), "my-project/allow-ssh")
+	assert.Equal(t, "my-project", gotProject, "fetch must receive ProjectID from EnrichClients, not Identity")
+	assert.Equal(t, "allow-ssh", gotName)
+}
+
+// TestComputeFirewallEnrich_PopulatesAttrs is the happy path: a
+// mixed-rule firewall flows through Enrich and decodes cleanly via
+// generated.UnmarshalAttrs.
+func TestComputeFirewallEnrich_PopulatesAttrs(t *testing.T) {
+	t.Parallel()
+	fw := &computev1.Firewall{
+		Name:         "allow-ssh",
+		Network:      "projects/my-project/global/networks/default",
+		Direction:    "INGRESS",
+		Priority:     1000,
+		SourceRanges: []string{"0.0.0.0/0"},
+		TargetTags:   []string{"ssh-allowed"},
+		Allowed: []*computev1.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"22"}},
+		},
+		LogConfig: &computev1.FirewallLogConfig{Enable: true, Metadata: "INCLUDE_ALL_METADATA"},
+	}
+	e := computeFirewallEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, project, name string) (*computev1.Firewall, error) {
+			assert.Equal(t, "my-project", project)
+			assert.Equal(t, "allow-ssh", name)
+			return fw, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: firewallIdentity()}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"}))
+
+	decoded, err := generated.UnmarshalAttrs("google_compute_firewall", ir.Attrs)
+	require.NoError(t, err)
+	gf, ok := decoded.(*generated.GoogleComputeFirewall)
+	require.True(t, ok)
+	require.NotNil(t, gf.Name)
+	assert.Equal(t, "allow-ssh", *gf.Name.Literal)
+	require.NotNil(t, gf.Direction)
+	assert.Equal(t, "INGRESS", *gf.Direction.Literal)
+	require.Len(t, gf.Allow, 1)
+	assert.Equal(t, "tcp", *gf.Allow[0].Protocol.Literal)
+	require.NotNil(t, gf.EnableLogging)
+	assert.True(t, *gf.EnableLogging.Literal)
+	require.Len(t, gf.LogConfig, 1)
+	assert.Equal(t, "INCLUDE_ALL_METADATA", *gf.LogConfig[0].Metadata.Literal)
+}
+
+// TestComputeFirewallEnrichByID_PopulatesAttrs validates the ByID
+// entry point returns the same JSON shape ir.Attrs gets via Enrich.
+// Shared fetchAndMap helper guarantees parity — this test is the
+// black-box pin.
+func TestComputeFirewallEnrichByID_PopulatesAttrs(t *testing.T) {
+	t.Parallel()
+	fw := &computev1.Firewall{
+		Name:    "allow-ssh",
+		Network: "global/networks/default",
+		Allowed: []*computev1.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"22"}},
+		},
+	}
+	e := computeFirewallEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, project, name string) (*computev1.Firewall, error) {
+			assert.Equal(t, "my-project", project)
+			assert.Equal(t, "allow-ssh", name)
+			return fw, nil
+		},
+	}
+	id := firewallIdentity()
+	raw, err := e.EnrichByID(context.Background(), &id, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	// Result decodes through the same UnmarshalAttrs path that Enrich
+	// would use.
+	decoded, err := generated.UnmarshalAttrs("google_compute_firewall", raw)
+	require.NoError(t, err)
+	gf, ok := decoded.(*generated.GoogleComputeFirewall)
+	require.True(t, ok)
+	require.NotNil(t, gf.Name)
+	assert.Equal(t, "allow-ssh", *gf.Name.Literal)
+	require.Len(t, gf.Allow, 1)
+	assert.Equal(t, "tcp", *gf.Allow[0].Protocol.Literal)
+}
+
+// TestComputeFirewallEnrichByID_NilIdentity guards against a nil
+// pointer from a misbehaving caller (the dispatcher is responsible
+// for non-nil, but defense-in-depth).
+func TestComputeFirewallEnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newComputeFirewallEnricher().(ByIDEnricher)
+	raw, err := e.EnrichByID(context.Background(), nil, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Nil(t, raw)
+	assert.Contains(t, err.Error(), "nil Identity")
+}
+
+// TestComputeFirewallEnrich_EnrichAndByIDProduceIdenticalAttrs locks
+// in the contract that Enrich and EnrichByID, given the same inputs,
+// emit byte-identical JSON. If a future change splits the two paths,
+// this guards against silent divergence.
+func TestComputeFirewallEnrich_EnrichAndByIDProduceIdenticalAttrs(t *testing.T) {
+	t.Parallel()
+	fw := &computev1.Firewall{
+		Name:    "allow-ssh",
+		Network: "global/networks/default",
+		Allowed: []*computev1.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"22", "443"}},
+		},
+		Denied: []*computev1.FirewallDenied{
+			{IPProtocol: "icmp"},
+		},
+		LogConfig: &computev1.FirewallLogConfig{Enable: true, Metadata: "INCLUDE_ALL_METADATA"},
+	}
+	mk := func() computeFirewallEnricher {
+		return computeFirewallEnricher{
+			fetch: func(_ context.Context, _ *computev1.Service, _, _ string) (*computev1.Firewall, error) {
+				return fw, nil
+			},
+		}
+	}
+	c := EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"}
+
+	ir := &imported.ImportedResource{Identity: firewallIdentity()}
+	require.NoError(t, mk().Enrich(context.Background(), ir, c))
+
+	id := firewallIdentity()
+	raw, err := mk().EnrichByID(context.Background(), &id, c)
+	require.NoError(t, err)
+
+	// Compare JSON shapes structurally so a future field-order shuffle
+	// in encoding/json doesn't false-fail. (json.Marshal is stable for
+	// the same struct shape, but the structural compare is the load-
+	// bearing assertion either way.)
+	var a, b map[string]any
+	require.NoError(t, json.Unmarshal(ir.Attrs, &a))
+	require.NoError(t, json.Unmarshal(raw, &b))
+	assert.Equal(t, a, b, "Enrich and EnrichByID must produce identical typed payloads")
+}
+
+// TestComputeFirewallShortNameForEnrich pins the Identity → name
+// precedence: NameHint > NativeIDs["name"] > NativeIDs["asset_name"]
+// > ImportID.
+func TestComputeFirewallShortNameForEnrich(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		id   imported.ResourceIdentity
+		want string
+	}{
+		{
+			name: "name_hint_wins",
+			id: imported.ResourceIdentity{
+				NameHint:  "from-hint",
+				NativeIDs: map[string]string{"name": "from-native"},
+				ImportID:  "projects/p/global/firewalls/from-import",
+			},
+			want: "from-hint",
+		},
+		{
+			name: "native_id_name_beats_asset",
+			id: imported.ResourceIdentity{
+				NativeIDs: map[string]string{
+					"name":       "from-native",
+					"asset_name": "//compute.googleapis.com/projects/p/global/firewalls/from-asset",
+				},
+				ImportID: "projects/p/global/firewalls/from-import",
+			},
+			want: "from-native",
+		},
+		{
+			name: "asset_name_beats_import_id",
+			id: imported.ResourceIdentity{
+				NativeIDs: map[string]string{
+					"asset_name": "//compute.googleapis.com/projects/p/global/firewalls/from-asset",
+				},
+				ImportID: "projects/p/global/firewalls/from-import",
+			},
+			want: "from-asset",
+		},
+		{
+			name: "import_id_fallback",
+			id: imported.ResourceIdentity{
+				ImportID: "projects/p/global/firewalls/from-import",
+			},
+			want: "from-import",
+		},
+		{
+			name: "nothing_yields_empty",
+			id:   imported.ResourceIdentity{},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			id := tc.id
+			assert.Equal(t, tc.want, computeFirewallShortNameForEnrich(&id))
+		})
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -327,7 +327,7 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string, opts GCPDisco
 			// child configs, Service Networking peering connections,
 			// Serverless VPC Access connectors, and Compute resource
 			// policies (snapshot schedules / placement policies).
-			"google_project_service": newProjectServiceDiscoverer(opts.ProjectServiceLister),
+			"google_project_service":                                newProjectServiceDiscoverer(opts.ProjectServiceLister),
 			"google_identity_platform_default_supported_idp_config": newIdentityPlatformDefaultSupportedIdpConfigDiscoverer(opts.DefaultSupportedIdpConfigLister),
 			"google_service_networking_connection":                  newServiceNetworkingConnectionDiscoverer(opts.ServiceNetworkingConnectionLister),
 			"google_vpc_access_connector":                           newVPCAccessConnectorDiscoverer(opts.VPCAccessConnectorLister),
@@ -341,11 +341,13 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string, opts GCPDisco
 		// silently skipped by EnrichAttributes — the full enricher rollout
 		// follows the existing per-type ordering one PR at a time.
 		byTypeEnricher: map[string]AttributeEnricher{
-			"google_storage_bucket":        newStorageBucketEnricher(),
-			"google_pubsub_topic":          newPubsubTopicEnricher(),
-			"google_pubsub_subscription":   newPubsubSubscriptionEnricher(),
-			"google_secret_manager_secret": newSecretManagerSecretEnricher(),
+			"google_compute_address":       newComputeAddressEnricher(),
+			"google_compute_firewall":      newComputeFirewallEnricher(),
 			"google_compute_network":       newComputeNetworkEnricher(),
+			"google_pubsub_subscription":   newPubsubSubscriptionEnricher(),
+			"google_pubsub_topic":          newPubsubTopicEnricher(),
+			"google_secret_manager_secret": newSecretManagerSecretEnricher(),
+			"google_storage_bucket":        newStorageBucketEnricher(),
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Stacked on #485 (Phase 1 framework skeleton). First bundle of the per-type AttributeEnricher + ByIDEnricher rollout — 4 types, all using existing Layer-1 typed structs (zero codegen expansion). Each enricher implements **both** interfaces behind a shared `fetchAndMap` helper so `Enrich` and `EnrichByID` produce byte-identical JSON.

- `aws_cloudwatch_log_group` — `DescribeLogGroups` + `ListTagsForResource` overlay
- `aws_secretsmanager_secret` — single `DescribeSecret` call (tags + replicas inline)
- `google_compute_address` — `Addresses.Get(project, region, name)`
- `google_compute_firewall` — `Firewalls.Get(project, name)` with nested Allow/Deny block flattening

## Test plan

- [x] `go test ./cmd/insideout-import/awsdiscover/. ./cmd/insideout-import/gcpdiscover/.` → 1467 pass (was 1368 pre-bundle, +99 new)
- [x] `go test -race ./pkg/imported/... ./pkg/composer/imported/policy/...` → 196 pass
- [x] `go build ./...` clean
- [x] `gofmt -l` clean across touched files
- [x] Each new enricher pinned by a round-trip parity test (`Enrich` vs `EnrichByID` produce identical JSON)
- [x] `byid_enricher_test.go` `wantTotal` constant updated to 3 (AWS) and 7 (GCP); allowlist drift remains observable

## Review notes

- All 4 enrichers test-inject fetch hooks via function-field overrides; **zero real SDK calls in any test**.
- All 4 handle `ErrEnrichClientUnavailable` when the required client is nil; map not-found responses to `ErrNotFound` on both `Enrich` and `EnrichByID` paths.
- `aws_secretsmanager_secret` defers `policy` field (separate `GetResourcePolicy` API) to a follow-up — Layer 1 struct includes it but the SDK shape diverges; not blocking.
- `google_compute_address` skips pure-Computed fields (`creation_timestamp`, `self_link`, etc.) per decision #5 — mirrors `compute_network` precedent.
- `google_compute_firewall` flattens `FirewallLogConfig{Enable, Metadata}` into top-level `EnableLogging` + nested `log_config.metadata` to match TF's split-attribute shape.

## Stacked PR

Base branch: `feature/imported-framework-skeleton` (#485). When #485 merges, GitHub will retarget this PR to `main`.

Refs #482 (capstone), #485 (Phase 1 framework). Tracking under #486 umbrella.