### PR TITLE
feat(imported): unified Provider abstraction — Phase 1 + 2 + 3 bundled (#482)

### DIFF
--- a/cmd/imported-codegen/emit_capabilities.go
+++ b/cmd/imported-codegen/emit_capabilities.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/bindings"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
+)
+
+// capabilityRow is one row of the capabilities matrix. JSON tags use
+// lowerCamelCase to match the downstream TS consumer shape verbatim
+// (same wire convention as labelEntry).
+type capabilityRow struct {
+	Discoverable     bool `json:"discoverable"`
+	Enrichable       bool `json:"enrichable"`
+	DriftDetectable  bool `json:"driftDetectable"`
+	MetricsAvailable bool `json:"metricsAvailable"`
+	RileyEditable    bool `json:"rileyEditable"`
+}
+
+// runCapabilities is the `capabilities` subcommand: emit a per-type
+// matrix of the five Capabilities flags consumed by
+// pkg/imported.Provider. The matrix is computed from the same upstream
+// registries the runtime Provider impls dispatch against (registry +
+// awsdiscover/gcpdiscover enricher maps + policy registry + bindings
+// registry) so codegen output stays in lockstep with runtime behavior
+// without a separate manual maintenance burden.
+//
+// Default destination is stdout; --output <path> writes to a file.
+func runCapabilities(args []string) int {
+	fs := flag.NewFlagSet("capabilities", flag.ExitOnError)
+	out := fs.String("output", "", "path to write JSON to (default: stdout)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	return writeJSONOutput(*out, buildCapabilitiesMap())
+}
+
+// buildCapabilitiesMap is the pure-data half of runCapabilities. Exposed
+// for unit tests so they can assert on the matrix without going through
+// the CLI surface.
+//
+// Construction note: NewAWSDiscoverer(aws.Config{}) /
+// NewGCPDiscoverer(nil, "", GCPDiscovererOpts{}) only allocate per-type
+// discoverer / enricher structs and the byTypeEnricher map. No SDK calls
+// fire and no network is touched — this is the same pattern the
+// awsdiscover.TestExistingEnrichersDoNotImplementByID test uses.
+func buildCapabilitiesMap() map[string]capabilityRow {
+	awsTypes := registry.SupportedDiscoverTypes(registry.ProviderAWS)
+	gcpTypes := registry.SupportedDiscoverTypes(registry.ProviderGCP)
+
+	awsDisc := awsdiscover.NewAWSDiscoverer(aws.Config{})
+	gcpDisc := gcpdiscover.NewGCPDiscoverer(nil, "", gcpdiscover.GCPDiscovererOpts{})
+
+	awsEnrichable := stringSet(awsDisc.EnricherTypes())
+	gcpEnrichable := stringSet(gcpDisc.EnricherTypes())
+
+	all := unionDiscoverTypes()
+	out := make(map[string]capabilityRow, len(all))
+
+	awsSet := stringSet(awsTypes)
+	gcpSet := stringSet(gcpTypes)
+
+	for _, t := range all {
+		row := capabilityRow{
+			Discoverable:     contains(awsSet, t) || contains(gcpSet, t),
+			Enrichable:       contains(awsEnrichable, t) || contains(gcpEnrichable, t),
+			DriftDetectable:  hasDriftSemantic(t),
+			MetricsAvailable: hasMetricsBinding(t),
+			RileyEditable:    isRileyEditable(t),
+		}
+		out[t] = row
+	}
+	return out
+}
+
+// hasDriftSemantic reports whether the curated policy.Map for tfType
+// (if any) contains at least one entry with a non-empty DriftSemantic
+// axis. Per the comparator contract in pkg/composer/imported/policy/
+// axes.go, empty DriftSemantic == "no drift comparison for this field";
+// a type is DriftDetectable when at least one curated field opts in.
+func hasDriftSemantic(tfType string) bool {
+	m, ok := policy.Lookup(tfType)
+	if !ok {
+		return false
+	}
+	for _, fp := range m {
+		if fp.DriftSemantic != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasMetricsBinding reports whether the bindings registry has an
+// entry for tfType. Mirrors the pkg/imported.Provider.MetricsBinding
+// contract: a registered binding (even one with empty DefaultMetrics)
+// is "metrics available — use consumer defaults"; an absent entry is
+// "no metrics surface".
+func hasMetricsBinding(tfType string) bool {
+	_, ok := bindings.Binding(tfType)
+	return ok
+}
+
+// isRileyEditable reports whether at least one field in the curated
+// policy.Map for tfType has Edit == EditChatSafe or EditRequiresApproval.
+// These are the two Edit policies that route through Riley's write
+// path; the other three (Never, RelationshipOnly, SystemOnly) all
+// disallow direct Riley scalar edits.
+func isRileyEditable(tfType string) bool {
+	m, ok := policy.Lookup(tfType)
+	if !ok {
+		return false
+	}
+	for _, fp := range m {
+		switch fp.Edit {
+		case policy.EditChatSafe, policy.EditRequiresApproval:
+			return true
+		}
+	}
+	return false
+}
+
+// stringSet builds a set from a slice for O(1) membership checks.
+// Used in buildCapabilitiesMap to avoid quadratic scans across the
+// AWS/GCP supported-types lists.
+func stringSet(ss []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(ss))
+	for _, s := range ss {
+		out[s] = struct{}{}
+	}
+	return out
+}
+
+func contains(set map[string]struct{}, s string) bool {
+	_, ok := set[s]
+	return ok
+}

--- a/cmd/imported-codegen/emit_capabilities.go
+++ b/cmd/imported-codegen/emit_capabilities.go
@@ -20,7 +20,7 @@ type capabilityRow struct {
 	Enrichable       bool `json:"enrichable"`
 	DriftDetectable  bool `json:"driftDetectable"`
 	MetricsAvailable bool `json:"metricsAvailable"`
-	RileyEditable    bool `json:"rileyEditable"`
+	AgentEditable    bool `json:"agentEditable"`
 }
 
 // runCapabilities is the `capabilities` subcommand: emit a per-type
@@ -72,7 +72,7 @@ func buildCapabilitiesMap() map[string]capabilityRow {
 			Enrichable:       contains(awsEnrichable, t) || contains(gcpEnrichable, t),
 			DriftDetectable:  hasDriftSemantic(t),
 			MetricsAvailable: hasMetricsBinding(t),
-			RileyEditable:    isRileyEditable(t),
+			AgentEditable:    isAgentEditable(t),
 		}
 		out[t] = row
 	}
@@ -107,12 +107,14 @@ func hasMetricsBinding(tfType string) bool {
 	return ok
 }
 
-// isRileyEditable reports whether at least one field in the curated
+// isAgentEditable reports whether at least one field in the curated
 // policy.Map for tfType has Edit == EditChatSafe or EditRequiresApproval.
-// These are the two Edit policies that route through Riley's write
-// path; the other three (Never, RelationshipOnly, SystemOnly) all
-// disallow direct Riley scalar edits.
-func isRileyEditable(tfType string) bool {
+// These are the two Edit policies that route through an interactive
+// agent's write path; the other three (Never, RelationshipOnly,
+// SystemOnly) disallow direct agent scalar edits. Agent-name-agnostic
+// so the per-product naming (Riley today) can rotate without
+// flipping the codegen output.
+func isAgentEditable(tfType string) bool {
 	m, ok := policy.Lookup(tfType)
 	if !ok {
 		return false

--- a/cmd/imported-codegen/emit_capabilities_test.go
+++ b/cmd/imported-codegen/emit_capabilities_test.go
@@ -90,7 +90,7 @@ func TestBuildCapabilitiesMap_KnownEntries(t *testing.T) {
 	// At least one curated policy on each cloud declares ChatSafe /
 	// RequiresApproval edits — pick one well-known type per cloud to
 	// pin the wiring. If a future curation pass downgrades every
-	// field on these types to non-Riley-editable, the test will fail
+	// field on these types to non-agent-editable, the test will fail
 	// loud; update the fixture to a different type that still
 	// carries editable fields.
 	for _, tfType := range []string{
@@ -104,6 +104,28 @@ func TestBuildCapabilitiesMap_KnownEntries(t *testing.T) {
 		}
 		if !row.AgentEditable {
 			t.Errorf("%s: AgentEditable = false, want true (curated policy has ChatSafe / RequiresApproval entries)", tfType)
+		}
+	}
+
+	// Pin Enrichable for the Bundle 1 enricher types so a regression
+	// that drops Enrichable from the row (e.g., a typo collapsing it
+	// to always-false) fails loud. These types have registered
+	// AttributeEnrichers in NewAWSDiscoverer / NewGCPDiscoverer.
+	for _, tfType := range []string{
+		"aws_cloudwatch_log_group",
+		"aws_secretsmanager_secret",
+		"aws_dynamodb_table",
+		"google_compute_address",
+		"google_compute_firewall",
+		"google_storage_bucket",
+	} {
+		row, ok := got[tfType]
+		if !ok {
+			t.Errorf("%s: missing from emitted capabilities map", tfType)
+			continue
+		}
+		if !row.Enrichable {
+			t.Errorf("%s: Enrichable = false, want true (type has registered AttributeEnricher)", tfType)
 		}
 	}
 }

--- a/cmd/imported-codegen/emit_capabilities_test.go
+++ b/cmd/imported-codegen/emit_capabilities_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRunCapabilities_EmitsValidJSON pins that the capabilities
+// subcommand writes JSON that round-trips through Unmarshal into the
+// expected map[string]capabilityRow shape. Catches accidental shape
+// drift at unit-test time.
+func TestRunCapabilities_EmitsValidJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "capabilities.json")
+
+	if code := runCapabilities([]string{"--output", out}); code != 0 {
+		t.Fatalf("runCapabilities exit code = %d, want 0", code)
+	}
+
+	buf, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var got map[string]capabilityRow
+	if err := json.Unmarshal(buf, &got); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, buf)
+	}
+	if len(got) == 0 {
+		t.Fatal("emitted capabilities map is empty — registry returned nothing")
+	}
+}
+
+// TestRunCapabilities_DeterministicOrdering pins golden-file
+// stability: back-to-back runs must produce byte-identical output.
+func TestRunCapabilities_DeterministicOrdering(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.json")
+	b := filepath.Join(dir, "b.json")
+
+	if code := runCapabilities([]string{"--output", a}); code != 0 {
+		t.Fatalf("first run exit code = %d, want 0", code)
+	}
+	if code := runCapabilities([]string{"--output", b}); code != 0 {
+		t.Fatalf("second run exit code = %d, want 0", code)
+	}
+
+	aBuf, err := os.ReadFile(a)
+	if err != nil {
+		t.Fatalf("read a: %v", err)
+	}
+	bBuf, err := os.ReadFile(b)
+	if err != nil {
+		t.Fatalf("read b: %v", err)
+	}
+	if string(aBuf) != string(bBuf) {
+		t.Fatal("two runs produced different output — non-deterministic ordering somewhere in the emit chain")
+	}
+}
+
+// TestBuildCapabilitiesMap_KnownEntries pins fixture-driven shape
+// checks against the runtime registries. Loose contracts so the test
+// stays stable as the per-type curation rolls out — assert
+// Discoverable==true for known-registered types and
+// RileyEditable==true for at least one curated AWS+GCP policy.
+func TestBuildCapabilitiesMap_KnownEntries(t *testing.T) {
+	t.Parallel()
+	got := buildCapabilitiesMap()
+
+	// Every type in the registry is Discoverable by construction.
+	for _, tfType := range []string{
+		"aws_s3_bucket",
+		"aws_lambda_function",
+		"google_pubsub_topic",
+		"google_compute_network",
+	} {
+		row, ok := got[tfType]
+		if !ok {
+			t.Errorf("%s: missing from emitted capabilities map", tfType)
+			continue
+		}
+		if !row.Discoverable {
+			t.Errorf("%s: Discoverable = false, want true (type is in registry)", tfType)
+		}
+	}
+
+	// At least one curated policy on each cloud declares ChatSafe /
+	// RequiresApproval edits — pick one well-known type per cloud to
+	// pin the wiring. If a future curation pass downgrades every
+	// field on these types to non-Riley-editable, the test will fail
+	// loud; update the fixture to a different type that still
+	// carries editable fields.
+	for _, tfType := range []string{
+		"aws_s3_bucket",
+		"google_storage_bucket",
+	} {
+		row, ok := got[tfType]
+		if !ok {
+			t.Errorf("%s: missing from emitted capabilities map", tfType)
+			continue
+		}
+		if !row.RileyEditable {
+			t.Errorf("%s: RileyEditable = false, want true (curated policy has ChatSafe / RequiresApproval entries)", tfType)
+		}
+	}
+}
+
+// TestBuildCapabilitiesMap_UnknownTypeIsAbsent pins the contract that
+// types not in registry.SupportedDiscoverTypes don't accidentally
+// appear in the matrix. Catches the regression where one of the
+// registries (policy / bindings) leaks an entry whose tfType is
+// outside the discover surface.
+func TestBuildCapabilitiesMap_UnknownTypeIsAbsent(t *testing.T) {
+	t.Parallel()
+	got := buildCapabilitiesMap()
+	if _, ok := got["aws_bogus_nonexistent_type"]; ok {
+		t.Error("nonexistent type leaked into capabilities map")
+	}
+}

--- a/cmd/imported-codegen/emit_capabilities_test.go
+++ b/cmd/imported-codegen/emit_capabilities_test.go
@@ -65,7 +65,7 @@ func TestRunCapabilities_DeterministicOrdering(t *testing.T) {
 // checks against the runtime registries. Loose contracts so the test
 // stays stable as the per-type curation rolls out — assert
 // Discoverable==true for known-registered types and
-// RileyEditable==true for at least one curated AWS+GCP policy.
+// AgentEditable==true for at least one curated AWS+GCP policy.
 func TestBuildCapabilitiesMap_KnownEntries(t *testing.T) {
 	t.Parallel()
 	got := buildCapabilitiesMap()
@@ -102,8 +102,8 @@ func TestBuildCapabilitiesMap_KnownEntries(t *testing.T) {
 			t.Errorf("%s: missing from emitted capabilities map", tfType)
 			continue
 		}
-		if !row.RileyEditable {
-			t.Errorf("%s: RileyEditable = false, want true (curated policy has ChatSafe / RequiresApproval entries)", tfType)
+		if !row.AgentEditable {
+			t.Errorf("%s: AgentEditable = false, want true (curated policy has ChatSafe / RequiresApproval entries)", tfType)
 		}
 	}
 }

--- a/cmd/imported-codegen/emit_dependencies.go
+++ b/cmd/imported-codegen/emit_dependencies.go
@@ -1,0 +1,147 @@
+// emit_dependencies.go is the `dependencies` subcommand for the
+// imported-codegen pipeline (presets#482, Codegen pipeline expansion).
+//
+// Scope (v1): emit an edge-list mapping each Layer-1 typed resource
+// to the other TF types it references via cross-resource fields. The
+// initial implementation uses a hand-curated map of TF-tag → target-
+// type to detect references — see crossRefMap below for the list. This
+// avoids the brittleness of guessing target types from field names
+// like `id` or `arn` alone (e.g. `aws_lambda_function.role` is an IAM
+// role ARN; `aws_lambda_function.kms_key_arn` is a KMS key) while
+// staying simple enough to extend by appending to one map.
+//
+// Phase 3 doesn't ship a full dependency-graph consumer — this is
+// informational scaffolding. Expansion follows real consumer demand:
+// when a UI consumer needs an edge that isn't in crossRefMap, add
+// the field-name entry and bump the golden test.
+package main
+
+import (
+	"flag"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// crossRefMap is the hand-curated set of (Terraform-tag-name →
+// target-TF-type) pairs the v1 dependency-emitter recognizes. Each
+// entry says: "any *Value[string] (or []*Value[string]) field with this
+// tf tag, on any Layer-1 typed struct, references a resource of type
+// <target>".
+//
+// The map is intentionally small and conservative — only well-known,
+// unambiguous cross-resource references. False-positive edges are
+// worse than missing edges because they propagate into the eventual
+// UI graph; missing edges can be filled in later by appending entries.
+//
+// To extend: add the field-name (the lowercase tf-tag, exactly as
+// declared on the generated struct's `tf:"<name>"`) and the target
+// TF type. The emitter handles `*Value[string]` and `[]*Value[string]`
+// shapes automatically; nested-block tags are not currently scanned
+// (callers usually want the top-level wiring, not nested doc fields).
+var crossRefMap = map[string]string{
+	// GCP — compute graph
+	"network":    "google_compute_network",
+	"subnetwork": "google_compute_network",
+	// GCP — KMS
+	"kms_key_name": "google_kms_crypto_key",
+	// AWS — IAM
+	"role":     "aws_iam_role",
+	"role_arn": "aws_iam_role",
+	// AWS — KMS
+	"kms_key_arn":       "aws_kms_key",
+	"kms_key_id":        "aws_kms_key",
+	"kms_master_key_id": "aws_kms_key",
+	// AWS — VPC primitives
+	"vpc_id":    "aws_vpc",
+	"subnet_id": "aws_subnet",
+}
+
+// runDependencies is the `dependencies` subcommand: walk every Layer-1
+// typed struct registered in pkg/composer/imported/generated and emit
+// a sorted edge-list keyed by TF type. The result is a deterministic
+// JSON object — empty arrays are emitted for types with no recognized
+// references so consumers can distinguish "scanned but no edges" from
+// "not scanned".
+//
+// Default destination is stdout; --output <path> writes to a file.
+func runDependencies(args []string) int {
+	fs := flag.NewFlagSet("dependencies", flag.ExitOnError)
+	out := fs.String("output", "", "path to write JSON to (default: stdout)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	return writeJSONOutput(*out, buildDependenciesMap())
+}
+
+// buildDependenciesMap is the pure-data half of runDependencies.
+// Returns a map from tfType to a sorted, deduped list of target tf
+// types it references. Types with no recognized refs emit an empty
+// slice (not nil) so the JSON shape is `[]`, not `null` — matches the
+// "every slice marshals to an array, never null" rule documented in
+// pkg/observability/discovery/CONTRIBUTING.md / issue #255.
+func buildDependenciesMap() map[string][]string {
+	tfTypes := generated.RegisteredTypes()
+	out := make(map[string][]string, len(tfTypes))
+	for _, t := range tfTypes {
+		goType, _, ok := generated.Lookup(t)
+		if !ok {
+			out[t] = []string{}
+			continue
+		}
+		out[t] = inferEdges(goType)
+	}
+	return out
+}
+
+// inferEdges walks the top-level fields of a Layer-1 typed struct and
+// returns the sorted, deduped set of target TF types its tf-tagged
+// fields reference per crossRefMap. Nested-block fields are skipped —
+// the v1 contract is top-level wiring only.
+//
+// Recognized field shapes:
+//   - *Value[string]  (scalar reference, e.g. Network)
+//   - []*Value[string] (list-of-refs, e.g. Subnetworks)
+//
+// Other shapes (maps, nested structs, ints, bools) are skipped: none
+// of them carry cross-resource refs in the curated crossRefMap.
+func inferEdges(goType reflect.Type) []string {
+	// generated.Lookup returns the element type; nothing to deref.
+	if goType.Kind() == reflect.Pointer {
+		goType = goType.Elem()
+	}
+	if goType.Kind() != reflect.Struct {
+		return []string{}
+	}
+	seen := map[string]struct{}{}
+	for i := 0; i < goType.NumField(); i++ {
+		f := goType.Field(i)
+		tag := f.Tag.Get("tf")
+		if tag == "" {
+			continue
+		}
+		// Skip nested blocks: their tf tag carries a "block" / "blocks"
+		// suffix (e.g. `tf:"timeouts,block"`). The v1 emitter only
+		// scans top-level scalar / list fields.
+		if strings.Contains(tag, ",block") {
+			continue
+		}
+		name := tag
+		if i := strings.Index(name, ","); i >= 0 {
+			name = name[:i]
+		}
+		target, ok := crossRefMap[name]
+		if !ok {
+			continue
+		}
+		seen[target] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for t := range seen {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/imported-codegen/emit_dependencies.go
+++ b/cmd/imported-codegen/emit_dependencies.go
@@ -44,7 +44,7 @@ import (
 var crossRefMap = map[string]string{
 	// GCP — compute graph
 	"network":    "google_compute_network",
-	"subnetwork": "google_compute_network",
+	"subnetwork": "google_compute_subnetwork",
 	// GCP — KMS
 	"kms_key_name": "google_kms_crypto_key",
 	// AWS — IAM

--- a/cmd/imported-codegen/emit_dependencies_test.go
+++ b/cmd/imported-codegen/emit_dependencies_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestRunDependencies_EmitsValidJSON pins that the dependencies
+// subcommand writes JSON that round-trips through Unmarshal into the
+// expected shape (map[string][]string with no nil values).
+func TestRunDependencies_EmitsValidJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "dependencies.json")
+
+	if code := runDependencies([]string{"--output", out}); code != 0 {
+		t.Fatalf("runDependencies exit code = %d, want 0", code)
+	}
+
+	buf, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var got map[string][]string
+	if err := json.Unmarshal(buf, &got); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, buf)
+	}
+	if len(got) == 0 {
+		t.Fatal("emitted dependencies map is empty — generated.RegisteredTypes returned nothing")
+	}
+	// Every entry must be a non-nil slice (possibly empty) — never null.
+	// Pins the "marshal as [] not null" rule documented in
+	// pkg/observability/discovery/CONTRIBUTING.md.
+	for tfType, edges := range got {
+		if edges == nil {
+			t.Errorf("%s: edges == nil, must be empty slice []", tfType)
+		}
+	}
+}
+
+// TestRunDependencies_DeterministicOrdering pins golden-file
+// stability for the dependencies emitter.
+func TestRunDependencies_DeterministicOrdering(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.json")
+	b := filepath.Join(dir, "b.json")
+
+	if code := runDependencies([]string{"--output", a}); code != 0 {
+		t.Fatalf("first run exit code = %d, want 0", code)
+	}
+	if code := runDependencies([]string{"--output", b}); code != 0 {
+		t.Fatalf("second run exit code = %d, want 0", code)
+	}
+
+	aBuf, err := os.ReadFile(a)
+	if err != nil {
+		t.Fatalf("read a: %v", err)
+	}
+	bBuf, err := os.ReadFile(b)
+	if err != nil {
+		t.Fatalf("read b: %v", err)
+	}
+	if string(aBuf) != string(bBuf) {
+		t.Fatal("two runs produced different output — non-deterministic ordering somewhere in the emit chain")
+	}
+}
+
+// TestBuildDependenciesMap_KnownEdges pins fixture-driven shape
+// checks for the v1 edges curated in crossRefMap. The Layer-1
+// generated structs that carry these fields are stable across
+// codegen runs, so the edges they produce are stable too. If
+// crossRefMap grows, add a fixture entry here.
+func TestBuildDependenciesMap_KnownEdges(t *testing.T) {
+	t.Parallel()
+	got := buildDependenciesMap()
+
+	cases := []struct {
+		tfType string
+		want   []string
+	}{
+		// google_compute_address has both `network` and `subnetwork`
+		// fields (both point at google_compute_network per crossRefMap).
+		// The deduped edge list is one entry.
+		{tfType: "google_compute_address", want: []string{"google_compute_network"}},
+		// aws_lambda_function has a `role` field (IAM role) and a
+		// `kms_key_arn` field (KMS key).
+		{tfType: "aws_lambda_function", want: []string{"aws_iam_role", "aws_kms_key"}},
+	}
+	for _, tc := range cases {
+		gotEdges, ok := got[tc.tfType]
+		if !ok {
+			t.Errorf("%s: missing from emitted dependencies map", tc.tfType)
+			continue
+		}
+		// Both sides are already sorted by construction, but copy
+		// before mutating for safety.
+		gotCopy := append([]string(nil), gotEdges...)
+		wantCopy := append([]string(nil), tc.want...)
+		sort.Strings(gotCopy)
+		sort.Strings(wantCopy)
+		if !stringSliceEqual(gotCopy, wantCopy) {
+			t.Errorf("%s: edges = %v, want %v", tc.tfType, gotEdges, tc.want)
+		}
+	}
+}
+
+// TestBuildDependenciesMap_EmptySliceNotNil pins #255: types with no
+// recognized refs emit []string{} (marshal to `[]`), not nil
+// (marshal to `null`).
+func TestBuildDependenciesMap_EmptySliceNotNil(t *testing.T) {
+	t.Parallel()
+	got := buildDependenciesMap()
+	for tfType, edges := range got {
+		if edges == nil {
+			t.Errorf("%s: edges == nil, want non-nil (possibly empty) slice", tfType)
+		}
+	}
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/imported-codegen/emit_dependencies_test.go
+++ b/cmd/imported-codegen/emit_dependencies_test.go
@@ -83,9 +83,11 @@ func TestBuildDependenciesMap_KnownEdges(t *testing.T) {
 		want   []string
 	}{
 		// google_compute_address has both `network` and `subnetwork`
-		// fields (both point at google_compute_network per crossRefMap).
-		// The deduped edge list is one entry.
-		{tfType: "google_compute_address", want: []string{"google_compute_network"}},
+		// fields. The crossRefMap maps `network` → google_compute_network
+		// and `subnetwork` → google_compute_subnetwork (subnetworks are a
+		// distinct resource type from networks — qa-professor caught the
+		// earlier draft pinning both to the same target).
+		{tfType: "google_compute_address", want: []string{"google_compute_network", "google_compute_subnetwork"}},
 		// aws_lambda_function has a `role` field (IAM role) and a
 		// `kms_key_arn` field (KMS key).
 		{tfType: "aws_lambda_function", want: []string{"aws_iam_role", "aws_kms_key"}},

--- a/cmd/imported-codegen/emit_drift_fields.go
+++ b/cmd/imported-codegen/emit_drift_fields.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"flag"
+	"sort"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+)
+
+// driftField is one entry in the per-type drift-fields list. The JSON
+// tags use lowerCamelCase to match the downstream TS consumer's wire
+// shape (same convention as labelEntry / capabilityRow).
+type driftField struct {
+	Path     string `json:"path"`
+	Semantic string `json:"semantic"`
+}
+
+// runDriftFields is the `drift-fields` subcommand: emit a per-type
+// list of field paths (with their DriftSemantic axis values) that the
+// curator has opted into drift detection. Mirrors the comparator's
+// dispatch surface: the eventual pkg/drift/imported package iterates
+// the same set of paths for each tfType when computing CompareDrift.
+//
+// Output is sorted by tfType, then by field path within each type, so
+// the emitted JSON is byte-stable across runs.
+//
+// Default destination is stdout; --output <path> writes to a file.
+func runDriftFields(args []string) int {
+	fs := flag.NewFlagSet("drift-fields", flag.ExitOnError)
+	out := fs.String("output", "", "path to write JSON to (default: stdout)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	return writeJSONOutput(*out, buildDriftFieldsMap())
+}
+
+// buildDriftFieldsMap is the pure-data half of runDriftFields. Returns
+// a map from tfType to its sorted-by-path slice of driftField entries.
+// Types with no curated DriftSemantic entries are omitted entirely
+// (rather than emitted with `[]`) — the comparator dispatch surface is
+// "types that have at least one drift-detectable field"; an empty
+// entry would be indistinguishable from "registered but uncurated"
+// and would mislead downstream consumers.
+func buildDriftFieldsMap() map[string][]driftField {
+	registered := policy.RegisteredTypes()
+	out := map[string][]driftField{}
+	for _, tfType := range registered {
+		m, ok := policy.Lookup(tfType)
+		if !ok {
+			continue
+		}
+		rows := collectDriftFields(m)
+		if len(rows) == 0 {
+			continue
+		}
+		out[tfType] = rows
+	}
+	return out
+}
+
+// collectDriftFields projects a Layer-2 policy.Map down to the subset
+// of entries with a non-empty DriftSemantic axis, sorted by path.
+// Empty DriftSemantic == "no drift comparison" per axes.go, so those
+// entries are filtered out before sort.
+func collectDriftFields(m policy.Map) []driftField {
+	paths := make([]string, 0, len(m))
+	for p, fp := range m {
+		if fp.DriftSemantic == "" {
+			continue
+		}
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	out := make([]driftField, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, driftField{
+			Path:     p,
+			Semantic: string(m[p].DriftSemantic),
+		})
+	}
+	return out
+}

--- a/cmd/imported-codegen/emit_drift_fields_test.go
+++ b/cmd/imported-codegen/emit_drift_fields_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestRunDriftFields_EmitsValidJSON pins that the drift-fields
+// subcommand writes JSON that round-trips through Unmarshal into the
+// expected map[string][]driftField shape.
+func TestRunDriftFields_EmitsValidJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "drift-fields.json")
+
+	if code := runDriftFields([]string{"--output", out}); code != 0 {
+		t.Fatalf("runDriftFields exit code = %d, want 0", code)
+	}
+
+	buf, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var got map[string][]driftField
+	if err := json.Unmarshal(buf, &got); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, buf)
+	}
+	// Empty result is currently legitimate (skeleton state: no
+	// policy.Map entries with non-empty DriftSemantic yet). Don't
+	// fail on len==0 — just round-trip the JSON shape.
+	_ = got
+}
+
+// TestRunDriftFields_DeterministicOrdering pins golden-file
+// stability for the drift-fields emitter.
+func TestRunDriftFields_DeterministicOrdering(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.json")
+	b := filepath.Join(dir, "b.json")
+
+	if code := runDriftFields([]string{"--output", a}); code != 0 {
+		t.Fatalf("first run exit code = %d, want 0", code)
+	}
+	if code := runDriftFields([]string{"--output", b}); code != 0 {
+		t.Fatalf("second run exit code = %d, want 0", code)
+	}
+
+	aBuf, err := os.ReadFile(a)
+	if err != nil {
+		t.Fatalf("read a: %v", err)
+	}
+	bBuf, err := os.ReadFile(b)
+	if err != nil {
+		t.Fatalf("read b: %v", err)
+	}
+	if string(aBuf) != string(bBuf) {
+		t.Fatal("two runs produced different output — non-deterministic ordering somewhere in the emit chain")
+	}
+}
+
+// TestBuildDriftFieldsMap_PerTypeSortedByPath pins the
+// within-type sort contract: each emitted []driftField is sorted by
+// path. Empty maps (skeleton state) trivially satisfy this; once
+// curated DriftSemantic entries land, this catches accidental insert
+// order leakage.
+func TestBuildDriftFieldsMap_PerTypeSortedByPath(t *testing.T) {
+	t.Parallel()
+	got := buildDriftFieldsMap()
+	for tfType, rows := range got {
+		paths := make([]string, len(rows))
+		for i, r := range rows {
+			paths[i] = r.Path
+		}
+		if !sort.StringsAreSorted(paths) {
+			t.Errorf("%s: paths not sorted: %v", tfType, paths)
+		}
+	}
+}
+
+// TestBuildDriftFieldsMap_NoEmptySemanticEntries pins the contract
+// that empty-DriftSemantic entries are filtered out — every emitted
+// row carries a non-empty semantic string. Catches a regression where
+// the filter is bypassed and the "no drift comparison" sentinel leaks
+// into the output.
+func TestBuildDriftFieldsMap_NoEmptySemanticEntries(t *testing.T) {
+	t.Parallel()
+	got := buildDriftFieldsMap()
+	for tfType, rows := range got {
+		for _, r := range rows {
+			if r.Semantic == "" {
+				t.Errorf("%s: path %q has empty DriftSemantic (must be filtered out)", tfType, r.Path)
+			}
+		}
+	}
+}

--- a/cmd/imported-codegen/emit_labels.go
+++ b/cmd/imported-codegen/emit_labels.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/labels"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
+)
+
+// labelEntry is one row of the labels subcommand's output. The JSON
+// tags are lowerCamelCase so the emitted JSON matches the shape
+// downstream consumers (TS UIs) expect verbatim — no per-consumer
+// rename pass required.
+type labelEntry struct {
+	Label   string `json:"label"`
+	IconKey string `json:"iconKey"`
+}
+
+// runLabels is the `labels` subcommand: emit a deterministic JSON
+// object mapping every supported TF type (AWS ∪ GCP) to its display
+// label and icon key. Falls back to labels.Label / labels.IconKey's
+// default rule for types without a curated override, so the emitted
+// map covers the full registry surface even when the override map is
+// empty (the skeleton state). Output is sorted by key for golden-file
+// stability.
+//
+// Default destination is stdout; --output <path> writes to a file.
+func runLabels(args []string) int {
+	fs := flag.NewFlagSet("labels", flag.ExitOnError)
+	out := fs.String("output", "", "path to write JSON to (default: stdout)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	return writeJSONOutput(*out, buildLabelsMap())
+}
+
+// buildLabelsMap is the pure-data half of runLabels — exposed for the
+// unit test to assert shape without going through the CLI.
+func buildLabelsMap() map[string]labelEntry {
+	types := unionDiscoverTypes()
+	m := make(map[string]labelEntry, len(types))
+	for _, t := range types {
+		m[t] = labelEntry{
+			Label:   labels.Label(t),
+			IconKey: labels.IconKey(t),
+		}
+	}
+	return m
+}
+
+// unionDiscoverTypes returns the deduped, sorted union of AWS and GCP
+// supported discover types. Shared helper for every subcommand that
+// iterates "every TF type the discover pipeline supports".
+func unionDiscoverTypes() []string {
+	seen := map[string]struct{}{}
+	for _, t := range registry.SupportedDiscoverTypes(registry.ProviderAWS) {
+		seen[t] = struct{}{}
+	}
+	for _, t := range registry.SupportedDiscoverTypes(registry.ProviderGCP) {
+		seen[t] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for t := range seen {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// writeJSONOutput marshals v as deterministic indented JSON and writes
+// it to outPath (stdout when empty). Shared by every JSON-emitting
+// subcommand in this group for byte-for-byte parity across runs.
+//
+// json.Marshal sorts map keys deterministically when the map's keys are
+// strings, so callers can pass map[string]any directly without a
+// per-call sort pass.
+func writeJSONOutput(outPath string, v any) int {
+	buf, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "marshal json: %v\n", err)
+		return 1
+	}
+	// Final newline matches `jq` / golden-file convention.
+	buf = append(buf, '\n')
+
+	if outPath == "" {
+		if _, err := os.Stdout.Write(buf); err != nil {
+			fmt.Fprintf(os.Stderr, "write stdout: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if err := os.WriteFile(outPath, buf, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "write %s: %v\n", outPath, err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/imported-codegen/emit_labels_test.go
+++ b/cmd/imported-codegen/emit_labels_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestRunLabels_EmitsValidJSON pins that the labels subcommand writes
+// JSON that round-trips through Unmarshal into the expected shape.
+// Catches accidental formatting drift (e.g. missing trailing newline,
+// non-deterministic key order) at unit-test time instead of waiting
+// for a downstream golden-file diff.
+func TestRunLabels_EmitsValidJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "labels.json")
+
+	if code := runLabels([]string{"--output", out}); code != 0 {
+		t.Fatalf("runLabels exit code = %d, want 0", code)
+	}
+
+	buf, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var got map[string]labelEntry
+	if err := json.Unmarshal(buf, &got); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, buf)
+	}
+	if len(got) == 0 {
+		t.Fatal("emitted labels map is empty — registry returned nothing")
+	}
+}
+
+// TestRunLabels_DeterministicOrdering pins the golden-file-stability
+// contract: two back-to-back runs must produce byte-identical output.
+// Catches any path in the emit chain that picks up non-deterministic
+// ordering (map iteration, time.Now, etc.).
+func TestRunLabels_DeterministicOrdering(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.json")
+	b := filepath.Join(dir, "b.json")
+
+	if code := runLabels([]string{"--output", a}); code != 0 {
+		t.Fatalf("first run exit code = %d, want 0", code)
+	}
+	if code := runLabels([]string{"--output", b}); code != 0 {
+		t.Fatalf("second run exit code = %d, want 0", code)
+	}
+
+	aBuf, err := os.ReadFile(a)
+	if err != nil {
+		t.Fatalf("read a: %v", err)
+	}
+	bBuf, err := os.ReadFile(b)
+	if err != nil {
+		t.Fatalf("read b: %v", err)
+	}
+	if string(aBuf) != string(bBuf) {
+		t.Fatal("two runs produced different output — non-deterministic ordering somewhere in the emit chain")
+	}
+}
+
+// TestBuildLabelsMap_KnownEntries pins a small fixture: a handful of
+// well-known registered types appear in the emitted map and resolve
+// to the expected default-rule labels. Catches regressions in the
+// label-emit pipeline (e.g. accidentally returning the type name
+// verbatim instead of the humanized form).
+func TestBuildLabelsMap_KnownEntries(t *testing.T) {
+	t.Parallel()
+	got := buildLabelsMap()
+
+	cases := []struct {
+		tfType      string
+		wantLabel   string
+		wantIconKey string
+	}{
+		// Default-rule cases (skeleton labels package has an empty
+		// override registry, so every entry exercises the default
+		// path).
+		{tfType: "aws_s3_bucket", wantLabel: "S3 Bucket", wantIconKey: "s3_bucket"},
+		{tfType: "aws_dynamodb_table", wantLabel: "Dynamodb Table", wantIconKey: "dynamodb_table"},
+		{tfType: "google_pubsub_topic", wantLabel: "Pubsub Topic", wantIconKey: "pubsub_topic"},
+		{tfType: "google_compute_network", wantLabel: "Compute Network", wantIconKey: "compute_network"},
+	}
+	for _, tc := range cases {
+		entry, ok := got[tc.tfType]
+		if !ok {
+			t.Errorf("%s: missing from emitted labels map", tc.tfType)
+			continue
+		}
+		if entry.Label != tc.wantLabel {
+			t.Errorf("%s: Label = %q, want %q", tc.tfType, entry.Label, tc.wantLabel)
+		}
+		if entry.IconKey != tc.wantIconKey {
+			t.Errorf("%s: IconKey = %q, want %q", tc.tfType, entry.IconKey, tc.wantIconKey)
+		}
+	}
+}
+
+// TestUnionDiscoverTypes_SortedAndDeduped pins the shared helper's
+// guarantee that the union slice is sorted and contains no duplicates.
+// Downstream subcommands depend on this for deterministic output.
+func TestUnionDiscoverTypes_SortedAndDeduped(t *testing.T) {
+	t.Parallel()
+	got := unionDiscoverTypes()
+	if len(got) == 0 {
+		t.Fatal("union is empty — registry returned nothing")
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Error("union is not sorted")
+	}
+	seen := map[string]struct{}{}
+	for _, t2 := range got {
+		if _, dup := seen[t2]; dup {
+			t.Errorf("duplicate entry: %q", t2)
+		}
+		seen[t2] = struct{}{}
+	}
+}

--- a/cmd/imported-codegen/main.go
+++ b/cmd/imported-codegen/main.go
@@ -27,6 +27,27 @@
 //	        for consumer repos and mirrors
 //	        pkg/composer/imported/policy/<type>.policy.go.
 //
+//	labels [--output <path>]
+//	        Emit a JSON object mapping every supported TF type to
+//	        {label, iconKey}. Falls back to the default labeling rule
+//	        for types without a curated override (presets#482).
+//
+//	capabilities [--output <path>]
+//	        Emit a per-type Capabilities matrix JSON
+//	        ({discoverable, enrichable, driftDetectable,
+//	         metricsAvailable, rileyEditable}) computed from the
+//	        upstream registries (presets#482).
+//
+//	dependencies [--output <path>]
+//	        Emit a per-type cross-resource ref edge-list JSON computed
+//	        from a hand-curated tf-tag → target-type map applied to the
+//	        Layer-1 generated structs (presets#482, v1 scope).
+//
+//	drift-fields [--output <path>]
+//	        Emit a per-type list of (path, DriftSemantic) entries for
+//	        every curated policy.Map field with a non-empty drift axis
+//	        (presets#482).
+//
 // Default subcommand is `gen` so plain `imported-codegen --aws-schema=...`
 // works.
 package main
@@ -55,6 +76,14 @@ func main() {
 			os.Exit(runZod(os.Args[2:]))
 		case "policy-ts":
 			os.Exit(runPolicyTS(os.Args[2:]))
+		case "labels":
+			os.Exit(runLabels(os.Args[2:]))
+		case "capabilities":
+			os.Exit(runCapabilities(os.Args[2:]))
+		case "dependencies":
+			os.Exit(runDependencies(os.Args[2:]))
+		case "drift-fields":
+			os.Exit(runDriftFields(os.Args[2:]))
 		case "-h", "--help":
 			usage()
 			return
@@ -67,10 +96,14 @@ func usage() {
 	fmt.Fprintln(os.Stderr, `imported-codegen: generate Layer 1 typed structs from terraform provider schemas.
 
 Subcommands:
-  gen        (default) generate <type>.gen.go files
-  filter     strip a full ProviderSchemas dump to wanted types only
-  zod        generate <type>.ts (Zod schema + metadata) for TS consumers
-  policy-ts  generate <type>.policy.ts (Layer-2 policy projection) for TS consumers
+  gen           (default) generate <type>.gen.go files
+  filter        strip a full ProviderSchemas dump to wanted types only
+  zod           generate <type>.ts (Zod schema + metadata) for TS consumers
+  policy-ts     generate <type>.policy.ts (Layer-2 policy projection) for TS consumers
+  labels        emit per-type display label + iconKey JSON (presets#482)
+  capabilities  emit per-type Capabilities matrix JSON (presets#482)
+  dependencies  emit per-type cross-resource ref edge-list JSON (presets#482)
+  drift-fields  emit per-type DriftSemantic field list JSON (presets#482)
 
 Run 'imported-codegen <subcommand> --help' for subcommand flags.`)
 }
@@ -378,4 +411,3 @@ func (f typesFilter) unknownAgainst(wants ...[]string) []string {
 	sort.Strings(unknown)
 	return unknown
 }
-

--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -207,7 +207,9 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 		// support) is in place already so the wiring there is a one-line
 		// registration.
 		byTypeEnricher: map[string]AttributeEnricher{
-			"aws_dynamodb_table": newDynamoDBTableEnricher(),
+			"aws_cloudwatch_log_group":  newCloudWatchLogGroupEnricher(),
+			"aws_dynamodb_table":        newDynamoDBTableEnricher(),
+			"aws_secretsmanager_secret": newSecretsManagerSecretEnricher(),
 		},
 	}
 }
@@ -224,8 +226,8 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 var serviceSlugByTFType = map[string]string{
 	// Bucket C — hand-rolled. Slugs must match the per-discoverer
 	// ServiceStart/Finish strings inside each *.go file.
-	"aws_apigatewayv2_stage": "apigatewayv2_stage",
-	"aws_bedrock_guardrail":  "bedrock_guardrail",
+	"aws_apigatewayv2_stage":                             "apigatewayv2_stage",
+	"aws_bedrock_guardrail":                              "bedrock_guardrail",
 	"aws_bedrock_model_invocation_logging_configuration": "bedrock_model_invocation_logging_configuration",
 	"aws_resourceexplorer2_index":                        "resourceexplorer2_index",
 	"aws_resourceexplorer2_view":                         "resourceexplorer2_view",

--- a/cmd/insideout-import/awsdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/awsdiscover/byid_enricher_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
 // fakeByIDEnricher is a minimal type that satisfies ByIDEnricher.
-// It exists only to assert that the interface compiles and is
-// satisfiable — no production code implements ByIDEnricher yet
+// It exists only to back the compile-time `var _ ByIDEnricher`
+// assertion below — no production code implements ByIDEnricher yet
 // (Phase 2 enricher rollout PRs add real impls one per type).
 type fakeByIDEnricher struct{}
 
@@ -21,42 +23,40 @@ func (fakeByIDEnricher) EnrichByID(ctx context.Context, identity *imported.Resou
 }
 
 // Compile-time assertion. If ByIDEnricher's shape drifts, this fails
-// at build time, not at runtime.
+// at build time. This is the load-bearing shape lock — no runtime
+// "fake calls itself" test is needed because there is nothing to
+// observe beyond the compile.
 var _ ByIDEnricher = (*fakeByIDEnricher)(nil)
-
-func TestByIDEnricher_FakeImplementation(t *testing.T) {
-	var e ByIDEnricher = fakeByIDEnricher{}
-	if got, want := e.ResourceType(), "aws_test_fake"; got != want {
-		t.Errorf("ResourceType() = %q, want %q", got, want)
-	}
-	raw, err := e.EnrichByID(t.Context(), &imported.ResourceIdentity{Type: "aws_test_fake"}, EnrichClients{})
-	if err != nil {
-		t.Fatalf("EnrichByID returned err: %v", err)
-	}
-	if string(raw) != "{}" {
-		t.Errorf("EnrichByID payload = %q, want %q", string(raw), "{}")
-	}
-}
 
 // TestExistingEnrichersDoNotImplementByID confirms the additive
 // nature of ByIDEnricher: the 1 existing enricher (aws_dynamodb_table)
-// implements only AttributeEnricher today. When Phase 2 PRs land
-// real EnrichByID impls, this test's allowlist shrinks. The test
-// fails loud if a future PR claims to add EnrichByID but forgets
-// to update the allowlist — i.e. ByIDEnricher coverage is observable.
+// implements only AttributeEnricher today. The test pins against the
+// REAL production registration in NewAWSDiscoverer — not a hand-rolled
+// map — so when Phase 2 PRs add real EnrichByID impls, the allowlist
+// must shrink in lockstep with the production registration. A
+// production-only change (add a ByIDEnricher impl, forget to update
+// allowlist) fails the test loud. A regression that drops the
+// registration entirely is caught by the size sanity check below.
 func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
-	// Construct the discoverer with a stub aws.Config; we only need
-	// access to byTypeEnricher, not to make real SDK calls.
-	d := &AWSDiscoverer{
-		byTypeEnricher: map[string]AttributeEnricher{
-			"aws_dynamodb_table": newDynamoDBTableEnricher(),
-		},
-	}
+	// Empty aws.Config is safe — the constructor only stores closures
+	// and per-type discoverer/enricher structs; no SDK calls fire.
+	d := NewAWSDiscoverer(aws.Config{})
+
 	// Allowlist: types whose enrichers explicitly DO NOT implement
 	// ByIDEnricher yet. Shrink as Phase 2 rollout lands per-type impls.
 	notImplemented := map[string]bool{
 		"aws_dynamodb_table": true,
 	}
+
+	// Fail-fast: if the constructor silently dropped the registration,
+	// the for-range below iterates zero times and reports a green
+	// non-test. Pin the expected size to the allowlist length so a
+	// "silent drop in production, allowlist untouched" regression
+	// fails loud.
+	if got, want := len(d.byTypeEnricher), len(notImplemented); got != want {
+		t.Errorf("byTypeEnricher size = %d, want %d (production registration and notImplemented allowlist drifted)", got, want)
+	}
+
 	for tfType, enr := range d.byTypeEnricher {
 		_, implementsByID := enr.(ByIDEnricher)
 		expectNot := notImplemented[tfType]

--- a/cmd/insideout-import/awsdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/awsdiscover/byid_enricher_test.go
@@ -28,15 +28,14 @@ func (fakeByIDEnricher) EnrichByID(ctx context.Context, identity *imported.Resou
 // observe beyond the compile.
 var _ ByIDEnricher = (*fakeByIDEnricher)(nil)
 
-// TestExistingEnrichersDoNotImplementByID confirms the additive
-// nature of ByIDEnricher: the 1 existing enricher (aws_dynamodb_table)
-// implements only AttributeEnricher today. The test pins against the
-// REAL production registration in NewAWSDiscoverer — not a hand-rolled
-// map — so when Phase 2 PRs add real EnrichByID impls, the allowlist
-// must shrink in lockstep with the production registration. A
-// production-only change (add a ByIDEnricher impl, forget to update
-// allowlist) fails the test loud. A regression that drops the
-// registration entirely is caught by the size sanity check below.
+// TestExistingEnrichersDoNotImplementByID pins the per-type
+// ByIDEnricher implementation status against the REAL production
+// registration in NewAWSDiscoverer. As Phase 2 PRs add real
+// EnrichByID impls, the allowlist must shrink in lockstep with the
+// production registration. A production-only change (add a
+// ByIDEnricher impl, forget to update allowlist; or vice versa) fails
+// the test loud. A regression that drops the registration entirely is
+// caught by the explicit wantTotal size check below.
 func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 	// Empty aws.Config is safe — the constructor only stores closures
 	// and per-type discoverer/enricher structs; no SDK calls fire.
@@ -48,13 +47,15 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 		"aws_dynamodb_table": true,
 	}
 
-	// Fail-fast: if the constructor silently dropped the registration,
-	// the for-range below iterates zero times and reports a green
-	// non-test. Pin the expected size to the allowlist length so a
-	// "silent drop in production, allowlist untouched" regression
-	// fails loud.
-	if got, want := len(d.byTypeEnricher), len(notImplemented); got != want {
-		t.Errorf("byTypeEnricher size = %d, want %d (production registration and notImplemented allowlist drifted)", got, want)
+	// Fail-fast: pin the expected total byTypeEnricher size so a
+	// silent drop (or duplicate-key squashing) in production fails the
+	// test. The expected total = allowlist size + types that DO
+	// implement ByIDEnricher. When adding a new enricher: bump
+	// wantTotal and either add to allowlist (no ByIDEnricher) or leave
+	// it off (implements ByIDEnricher).
+	const wantTotal = 3 // dynamodb_table + cloudwatch_log_group + secretsmanager_secret
+	if got := len(d.byTypeEnricher); got != wantTotal {
+		t.Errorf("byTypeEnricher size = %d, want %d (production registration drifted from test)", got, wantTotal)
 	}
 
 	for tfType, enr := range d.byTypeEnricher {

--- a/cmd/insideout-import/awsdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/awsdiscover/byid_enricher_test.go
@@ -1,0 +1,70 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// fakeByIDEnricher is a minimal type that satisfies ByIDEnricher.
+// It exists only to assert that the interface compiles and is
+// satisfiable — no production code implements ByIDEnricher yet
+// (Phase 2 enricher rollout PRs add real impls one per type).
+type fakeByIDEnricher struct{}
+
+func (fakeByIDEnricher) ResourceType() string { return "aws_test_fake" }
+
+func (fakeByIDEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, clients EnrichClients) (json.RawMessage, error) {
+	return json.RawMessage(`{}`), nil
+}
+
+// Compile-time assertion. If ByIDEnricher's shape drifts, this fails
+// at build time, not at runtime.
+var _ ByIDEnricher = (*fakeByIDEnricher)(nil)
+
+func TestByIDEnricher_FakeImplementation(t *testing.T) {
+	var e ByIDEnricher = fakeByIDEnricher{}
+	if got, want := e.ResourceType(), "aws_test_fake"; got != want {
+		t.Errorf("ResourceType() = %q, want %q", got, want)
+	}
+	raw, err := e.EnrichByID(t.Context(), &imported.ResourceIdentity{Type: "aws_test_fake"}, EnrichClients{})
+	if err != nil {
+		t.Fatalf("EnrichByID returned err: %v", err)
+	}
+	if string(raw) != "{}" {
+		t.Errorf("EnrichByID payload = %q, want %q", string(raw), "{}")
+	}
+}
+
+// TestExistingEnrichersDoNotImplementByID confirms the additive
+// nature of ByIDEnricher: the 1 existing enricher (aws_dynamodb_table)
+// implements only AttributeEnricher today. When Phase 2 PRs land
+// real EnrichByID impls, this test's allowlist shrinks. The test
+// fails loud if a future PR claims to add EnrichByID but forgets
+// to update the allowlist — i.e. ByIDEnricher coverage is observable.
+func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
+	// Construct the discoverer with a stub aws.Config; we only need
+	// access to byTypeEnricher, not to make real SDK calls.
+	d := &AWSDiscoverer{
+		byTypeEnricher: map[string]AttributeEnricher{
+			"aws_dynamodb_table": newDynamoDBTableEnricher(),
+		},
+	}
+	// Allowlist: types whose enrichers explicitly DO NOT implement
+	// ByIDEnricher yet. Shrink as Phase 2 rollout lands per-type impls.
+	notImplemented := map[string]bool{
+		"aws_dynamodb_table": true,
+	}
+	for tfType, enr := range d.byTypeEnricher {
+		_, implementsByID := enr.(ByIDEnricher)
+		expectNot := notImplemented[tfType]
+		switch {
+		case expectNot && implementsByID:
+			t.Errorf("%s: enricher now implements ByIDEnricher — remove from notImplemented allowlist", tfType)
+		case !expectNot && !implementsByID:
+			t.Errorf("%s: enricher must implement ByIDEnricher (not in notImplemented allowlist)", tfType)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudwatch_log_group_enrich.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatch_log_group_enrich.go
@@ -1,0 +1,299 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// cloudwatchLogGroupTFType is the registered Terraform type for the
+// CloudWatch log-group enricher. Kept as a constant so the registry /
+// ResourceType() stay in lockstep.
+const cloudwatchLogGroupTFType = "aws_cloudwatch_log_group"
+
+// cloudwatchLogGroupEnricher implements both AttributeEnricher and
+// ByIDEnricher for aws_cloudwatch_log_group. The pair shares a private
+// fetchAndMap helper so the SDK call + struct mapping lives in exactly
+// one place; the two methods differ only in how they package the
+// resulting payload (mutating ir.Attrs vs returning the raw JSON).
+//
+// SDK shape: CloudWatchLogs has no DescribeLogGroup (singular) — the
+// only read path is DescribeLogGroups with a name-prefix filter, so the
+// fetch issues a single Limit=10 call and filters the response slice
+// for an exact LogGroupName match. The prefix filter is permissive
+// (returns "foo", "foo-bar", "foo-1"), so the post-filter step is
+// load-bearing. Tags are a separate overlay fetched via
+// ListTagsForResource keyed on the ARN.
+//
+// Sensitive fields: none on this resource. Decision #36 redaction is
+// downstream's concern.
+type cloudwatchLogGroupEnricher struct {
+	// fetch is overridable for tests. Defaults to a real
+	// DescribeLogGroups call against the cloudwatchlogs.Client in
+	// EnrichClients. Returns (nil, nil) for a not-found log group so
+	// callers can branch cleanly on the not-found case without
+	// type-asserting on the SDK exception. Any other error is a real
+	// API failure and bubbles up unchanged.
+	fetch func(ctx context.Context, c *cloudwatchlogs.Client, name string) (*cwltypes.LogGroup, error)
+
+	// fetchTags is the tag-overlay hook. Best-effort: a fetch error
+	// logs nothing and the tags map is omitted from the payload.
+	fetchTags func(ctx context.Context, c *cloudwatchlogs.Client, arn string) (map[string]string, error)
+}
+
+func newCloudWatchLogGroupEnricher() *cloudwatchLogGroupEnricher {
+	return &cloudwatchLogGroupEnricher{
+		fetch:     defaultCloudWatchLogGroupFetch,
+		fetchTags: defaultCloudWatchLogGroupFetchTags,
+	}
+}
+
+func (cloudwatchLogGroupEnricher) ResourceType() string { return cloudwatchLogGroupTFType }
+
+// Enrich populates ir.Attrs with a typed AWSCloudwatchLogGroup payload
+// for the log group identified by ir.Identity. Returns
+// ErrEnrichClientUnavailable if EnrichClients.CloudWatchLogs is nil;
+// any other error reflects a real CloudWatch Logs API failure on the
+// load-bearing DescribeLogGroups call. Tags overlay failures are
+// downgraded to a silently-omitted Tags map; the resource is still
+// emitted.
+func (e cloudwatchLogGroupEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if c.CloudWatchLogs == nil {
+		return ErrEnrichClientUnavailable
+	}
+	name := cloudwatchLogGroupNameForEnrich(ir)
+	if name == "" {
+		return fmt.Errorf("cloudwatch_log_group: cannot derive log group name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			ir.Identity.Address, ir.Identity.ImportID, ir.Identity.NameHint)
+	}
+	lg, err := e.fetch(ctx, c.CloudWatchLogs, name)
+	if err != nil {
+		return fmt.Errorf("cloudwatch_log_group: describe %q: %w", name, err)
+	}
+	if lg == nil {
+		return fmt.Errorf("cloudwatch_log_group: %q: %w", name, ErrNotFound)
+	}
+
+	// Stamp ARN on Identity.NativeIDs BEFORE the tags overlay so the
+	// overlay can key off the canonical (no trailing :*) ARN. The TF
+	// resource's `arn` attribute uses the no-trailing-colon-star form
+	// (LogGroupArn), which is what ListTagsForResource also wants.
+	arn := pickLogGroupARN(lg)
+	if arn != "" {
+		if ir.Identity.NativeIDs == nil {
+			ir.Identity.NativeIDs = map[string]string{}
+		}
+		ir.Identity.NativeIDs["arn"] = arn
+	}
+
+	typed := mapCloudWatchLogGroup(lg)
+
+	// Overlay: tags — ListTagsForResource. Soft-fail (silently omit).
+	if arn != "" {
+		if tags, terr := e.fetchTags(ctx, c.CloudWatchLogs, arn); terr == nil && len(tags) > 0 {
+			m := map[string]*generated.Value[string]{}
+			for k, v := range tags {
+				m[k] = generated.LiteralOf(v)
+			}
+			typed.Tags = m
+		}
+	}
+
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return fmt.Errorf("cloudwatch_log_group: marshal Attrs: %w", err)
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID is the ByIDEnricher entry point. Mirrors Enrich's SDK call
+// + mapping path via fetchAndMap, but returns the raw JSON payload
+// instead of mutating an *ImportedResource. Used by the per-IR drift
+// refresh path (pkg/imported.Provider.EnrichByID, #482) where the
+// caller already holds an Identity and only wants the typed payload.
+//
+// Tags overlay failures are soft-failed identically to Enrich; the
+// caller cannot distinguish "no tags" from "tags fetch denied" from
+// the returned JSON alone, matching the AttributeEnricher contract.
+func (e cloudwatchLogGroupEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, errors.New("cloudwatch_log_group: identity is nil")
+	}
+	if c.CloudWatchLogs == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	// Reuse the same name-derivation helper. ResourceIdentity is the
+	// only field the helper reads, so wrap it in a synthetic IR.
+	ir := &imported.ImportedResource{Identity: *identity}
+	name := cloudwatchLogGroupNameForEnrich(ir)
+	if name == "" {
+		return nil, fmt.Errorf("cloudwatch_log_group: cannot derive log group name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			identity.Address, identity.ImportID, identity.NameHint)
+	}
+	typed, err := e.fetchAndMap(ctx, c.CloudWatchLogs, name)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("cloudwatch_log_group: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// fetchAndMap issues the DescribeLogGroups call + tag overlay and
+// returns the populated typed struct. Shared between Enrich and
+// EnrichByID so the SDK-call layout lives in one place. Does NOT
+// mutate any Identity — Enrich does that stamping itself before
+// calling out to fetchAndMap is unnecessary because Enrich needs the
+// raw LogGroup for the ARN-stamp step. Hence Enrich keeps its own
+// inline call sequence rather than going through this helper; this
+// helper exists for the EnrichByID-only path where there is no
+// ImportedResource to mutate.
+func (e cloudwatchLogGroupEnricher) fetchAndMap(ctx context.Context, c *cloudwatchlogs.Client, name string) (*generated.AWSCloudwatchLogGroup, error) {
+	lg, err := e.fetch(ctx, c, name)
+	if err != nil {
+		return nil, fmt.Errorf("cloudwatch_log_group: describe %q: %w", name, err)
+	}
+	if lg == nil {
+		return nil, fmt.Errorf("cloudwatch_log_group: %q: %w", name, ErrNotFound)
+	}
+	typed := mapCloudWatchLogGroup(lg)
+	if arn := pickLogGroupARN(lg); arn != "" {
+		if tags, terr := e.fetchTags(ctx, c, arn); terr == nil && len(tags) > 0 {
+			m := map[string]*generated.Value[string]{}
+			for k, v := range tags {
+				m[k] = generated.LiteralOf(v)
+			}
+			typed.Tags = m
+		}
+	}
+	return typed, nil
+}
+
+// cloudwatchLogGroupNameForEnrich pulls the log-group name from the
+// identifiers the CloudControl discoverer populates. Order of
+// preference matches dynamodbTableNameForEnrich:
+//
+//  1. Identity.NameHint — explicit name set by nameOrIdentifier in
+//     cloudControlTypeConfigs.
+//  2. Identity.NativeIDs["name"] — fallback if a future config
+//     populates the NativeIDs bag instead.
+//  3. Identity.ImportID — last resort; CloudControl emits the log
+//     group name as the Identifier, so this is usually the same as
+//     NameHint anyway.
+func cloudwatchLogGroupNameForEnrich(ir *imported.ImportedResource) string {
+	if s := strings.TrimSpace(ir.Identity.NameHint); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(ir.Identity.NativeIDs["name"]); s != "" {
+		return s
+	}
+	return strings.TrimSpace(ir.Identity.ImportID)
+}
+
+// pickLogGroupARN prefers the newer LogGroupArn (no trailing ":*") over
+// the older Arn alias (trailing ":*"). The TF resource's `arn`
+// attribute is the no-trailing-colon-star form, matching what
+// ListTagsForResource expects on its ResourceArn input, so pick that
+// one whenever it's set. Falls back to Arn (with trailing ":*"
+// stripped) for older API responses that only populate the legacy
+// field.
+func pickLogGroupARN(lg *cwltypes.LogGroup) string {
+	if lg == nil {
+		return ""
+	}
+	if lg.LogGroupArn != nil && *lg.LogGroupArn != "" {
+		return *lg.LogGroupArn
+	}
+	if lg.Arn != nil && *lg.Arn != "" {
+		return strings.TrimSuffix(*lg.Arn, ":*")
+	}
+	return ""
+}
+
+// mapCloudWatchLogGroup is the pure-mapping helper: copy the SDK
+// LogGroup fields into the typed AWSCloudwatchLogGroup. Skips the
+// TF-input-only fields (NamePrefix, SkipDestroy) and the computed
+// mirror (TagsAll) per the AttributeEnricher contract; Tags is
+// overlaid by the caller from ListTagsForResource.
+func mapCloudWatchLogGroup(lg *cwltypes.LogGroup) *generated.AWSCloudwatchLogGroup {
+	out := &generated.AWSCloudwatchLogGroup{}
+	if arn := pickLogGroupARN(lg); arn != "" {
+		out.ARN = generated.LiteralOf(arn)
+	}
+	if lg.LogGroupName != nil && *lg.LogGroupName != "" {
+		out.Name = generated.LiteralOf(*lg.LogGroupName)
+		// TF state stores the name as the resource id.
+		out.ID = generated.LiteralOf(*lg.LogGroupName)
+	}
+	if lg.KmsKeyId != nil && *lg.KmsKeyId != "" {
+		out.KMSKeyID = generated.LiteralOf(*lg.KmsKeyId)
+	}
+	if cls := string(lg.LogGroupClass); cls != "" {
+		out.LogGroupClass = generated.LiteralOf(cls)
+	}
+	if lg.RetentionInDays != nil {
+		out.RetentionInDays = generated.LiteralOf(int64(*lg.RetentionInDays))
+	}
+	return out
+}
+
+// defaultCloudWatchLogGroupFetch is the production fetch path: a
+// single DescribeLogGroups call with a name-prefix filter, then a
+// post-filter for the exact LogGroupName match. Returns (nil, nil) on
+// not-found so the caller can branch cleanly without type-asserting
+// the SDK exception (CloudWatchLogs returns an empty slice for
+// no-match — typed ResourceNotFoundException is rarely raised by this
+// endpoint).
+func defaultCloudWatchLogGroupFetch(ctx context.Context, c *cloudwatchlogs.Client, name string) (*cwltypes.LogGroup, error) {
+	out, err := c.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String(name),
+		Limit:              aws.Int32(10),
+	})
+	if err != nil {
+		// Surface typed not-found explicitly as (nil, nil) so the
+		// enricher can wrap it in ErrNotFound at the call site
+		// without leaking the SDK error type.
+		var nfe *cwltypes.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if out == nil {
+		return nil, nil
+	}
+	for i := range out.LogGroups {
+		if out.LogGroups[i].LogGroupName != nil && *out.LogGroups[i].LogGroupName == name {
+			return &out.LogGroups[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// defaultCloudWatchLogGroupFetchTags is the production tag-overlay
+// fetch path. Returns the raw map; the caller (Enrich / fetchAndMap)
+// projects it into the typed payload. CloudWatchLogs' tag-set is
+// capped at 50 per resource by the service, so a single call covers
+// every realistic case (no pagination).
+func defaultCloudWatchLogGroupFetchTags(ctx context.Context, c *cloudwatchlogs.Client, arn string) (map[string]string, error) {
+	out, err := c.ListTagsForResource(ctx, &cloudwatchlogs.ListTagsForResourceInput{ResourceArn: aws.String(arn)})
+	if err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return nil, nil
+	}
+	return out.Tags, nil
+}

--- a/cmd/insideout-import/awsdiscover/cloudwatch_log_group_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudwatch_log_group_enrich_test.go
@@ -1,0 +1,436 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// newTestCloudWatchLogGroupEnricher builds a cloudwatchLogGroupEnricher
+// with fake fetch closures wired in. Mirrors newTestDynamoDBEnricher.
+// Passing nil for tags defaults to "no tags" so a single test can stub
+// only the describe path.
+func newTestCloudWatchLogGroupEnricher(
+	describe func(ctx context.Context, c *cloudwatchlogs.Client, name string) (*cwltypes.LogGroup, error),
+	tags func(ctx context.Context, c *cloudwatchlogs.Client, arn string) (map[string]string, error),
+) cloudwatchLogGroupEnricher {
+	if tags == nil {
+		tags = func(context.Context, *cloudwatchlogs.Client, string) (map[string]string, error) {
+			return nil, nil
+		}
+	}
+	return cloudwatchLogGroupEnricher{
+		fetch:     describe,
+		fetchTags: tags,
+	}
+}
+
+// decodeLogGroupAttrs round-trips ir.Attrs through UnmarshalAttrs and
+// returns the typed AWSCloudwatchLogGroup. Mirrors decodeAttrs in the
+// dynamodb test file.
+func decodeLogGroupAttrs(t *testing.T, ir *imported.ImportedResource) *generated.AWSCloudwatchLogGroup {
+	t.Helper()
+	require.NotEmpty(t, ir.Attrs, "Attrs must be populated before decode")
+	decoded, err := generated.UnmarshalAttrs("aws_cloudwatch_log_group", ir.Attrs)
+	require.NoError(t, err)
+	lg, ok := decoded.(*generated.AWSCloudwatchLogGroup)
+	require.True(t, ok, "decoded type must be *AWSCloudwatchLogGroup, got %T", decoded)
+	return lg
+}
+
+func TestCloudwatchLogGroupEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	enr := newCloudWatchLogGroupEnricher()
+	assert.Equal(t, "aws_cloudwatch_log_group", enr.ResourceType())
+}
+
+// Compile-time pin: cloudwatchLogGroupEnricher must satisfy both
+// AttributeEnricher and ByIDEnricher. Captures the Phase-2 contract;
+// dropping either method on a refactor fails the build, not a test.
+var (
+	_ AttributeEnricher = (*cloudwatchLogGroupEnricher)(nil)
+	_ ByIDEnricher      = (*cloudwatchLogGroupEnricher)(nil)
+)
+
+func TestCloudwatchLogGroupEnricher_NilClientReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	enr := cloudwatchLogGroupEnricher{}
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", ImportID: "lg1", NameHint: "lg1"},
+	}, EnrichClients{CloudWatchLogs: nil})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestCloudwatchLogGroupEnricher_EnrichByID_NilClientReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	enr := cloudwatchLogGroupEnricher{}
+	_, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type: "aws_cloudwatch_log_group", NameHint: "lg1",
+	}, EnrichClients{CloudWatchLogs: nil})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestCloudwatchLogGroupEnricher_EnrichByID_NilIdentityReturnsError(t *testing.T) {
+	t.Parallel()
+	enr := cloudwatchLogGroupEnricher{}
+	_, err := enr.EnrichByID(context.Background(), nil, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity is nil")
+}
+
+func TestCloudwatchLogGroupEnricher_NameDerivation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		label string
+		ir    imported.ImportedResource
+		want  string
+	}{
+		{
+			label: "NameHint wins",
+			ir: imported.ImportedResource{Identity: imported.ResourceIdentity{
+				NameHint:  "from-name-hint",
+				ImportID:  "from-import-id",
+				NativeIDs: map[string]string{"name": "from-native"},
+			}},
+			want: "from-name-hint",
+		},
+		{
+			label: "NativeIDs[name] is fallback",
+			ir: imported.ImportedResource{Identity: imported.ResourceIdentity{
+				NativeIDs: map[string]string{"name": "from-native"},
+				ImportID:  "from-import-id",
+			}},
+			want: "from-native",
+		},
+		{
+			label: "ImportID is last resort",
+			ir: imported.ImportedResource{Identity: imported.ResourceIdentity{
+				ImportID: "from-import-id",
+			}},
+			want: "from-import-id",
+		},
+		{
+			label: "empty everywhere -> empty",
+			ir:    imported.ImportedResource{Identity: imported.ResourceIdentity{}},
+			want:  "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			assert.Equal(t, tc.want, cloudwatchLogGroupNameForEnrich(&tc.ir))
+		})
+	}
+}
+
+func TestCloudwatchLogGroupEnricher_NoNameReturnsError(t *testing.T) {
+	t.Parallel()
+	enr := newCloudWatchLogGroupEnricher()
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group"},
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "cannot derive log group name"))
+}
+
+func TestCloudwatchLogGroupEnricher_DescribeError_Propagates(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("AccessDeniedException")
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return nil, wantErr
+		}, nil)
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "lg1"},
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestCloudwatchLogGroupEnricher_NotFoundReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	// Fetch returns (nil, nil) for "no matching log group" — the
+	// enricher wraps that as ErrNotFound so the by-ID caller can
+	// distinguish "missing" from "API failure".
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return nil, nil
+		}, nil)
+
+	// Enrich path.
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "missing"},
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	// EnrichByID path.
+	raw, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type: "aws_cloudwatch_log_group", NameHint: "missing",
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Empty(t, raw)
+}
+
+func TestCloudwatchLogGroupEnricher_BasicMapping(t *testing.T) {
+	t.Parallel()
+	lg := &cwltypes.LogGroup{
+		LogGroupName:    aws.String("/aws/lambda/orders"),
+		LogGroupArn:     aws.String("arn:aws:logs:us-east-1:012345678901:log-group:/aws/lambda/orders"),
+		Arn:             aws.String("arn:aws:logs:us-east-1:012345678901:log-group:/aws/lambda/orders:*"),
+		KmsKeyId:        aws.String("arn:aws:kms:us-east-1:012345678901:key/abc"),
+		LogGroupClass:   cwltypes.LogGroupClassInfrequentAccess,
+		RetentionInDays: aws.Int32(30),
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		}, nil)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_cloudwatch_log_group",
+			Address:  "aws_cloudwatch_log_group.orders",
+			NameHint: "/aws/lambda/orders",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}, AccountID: "012345678901"}))
+
+	// ARN promoted onto NativeIDs from LogGroupArn (no trailing :*).
+	assert.Equal(t,
+		"arn:aws:logs:us-east-1:012345678901:log-group:/aws/lambda/orders",
+		ir.Identity.NativeIDs["arn"],
+		"enricher must stamp the canonical (no-trailing-:* ) LogGroupArn onto NativeIDs[arn] for tag-overlay use",
+	)
+
+	out := decodeLogGroupAttrs(t, ir)
+
+	require.NotNil(t, out.Name)
+	assert.Equal(t, "/aws/lambda/orders", *out.Name.Literal)
+	require.NotNil(t, out.ID)
+	assert.Equal(t, "/aws/lambda/orders", *out.ID.Literal, "id must mirror name per TF state semantics")
+	require.NotNil(t, out.ARN)
+	assert.Equal(t,
+		"arn:aws:logs:us-east-1:012345678901:log-group:/aws/lambda/orders",
+		*out.ARN.Literal,
+		"arn attribute must be the no-trailing-:* form",
+	)
+	require.NotNil(t, out.KMSKeyID)
+	assert.Equal(t, "arn:aws:kms:us-east-1:012345678901:key/abc", *out.KMSKeyID.Literal)
+	require.NotNil(t, out.LogGroupClass)
+	assert.Equal(t, string(cwltypes.LogGroupClassInfrequentAccess), *out.LogGroupClass.Literal)
+	require.NotNil(t, out.RetentionInDays)
+	assert.Equal(t, int64(30), *out.RetentionInDays.Literal)
+
+	// Skipped fields: NamePrefix, SkipDestroy, TagsAll never populated.
+	assert.Nil(t, out.NamePrefix, "name_prefix is TF-input-only — must not be set from SDK")
+	assert.Nil(t, out.SkipDestroy, "skip_destroy is TF-input-only — must not be set from SDK")
+	assert.Empty(t, out.TagsAll, "tags_all is a computed mirror — enricher must not populate")
+
+	// No tags fetched → Tags must be absent.
+	assert.Empty(t, out.Tags, "tags must be absent when fetchTags returns no tags")
+}
+
+func TestCloudwatchLogGroupEnricher_ARNFallbackFromLegacyArn(t *testing.T) {
+	t.Parallel()
+	// Older API responses only populate the legacy Arn field (with the
+	// trailing :*). The picker must strip the suffix to produce the TF
+	// `arn` form.
+	lg := &cwltypes.LogGroup{
+		LogGroupName: aws.String("legacy"),
+		Arn:          aws.String("arn:aws:logs:us-east-1:012345678901:log-group:legacy:*"),
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		}, nil)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "legacy"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}}))
+
+	assert.Equal(t,
+		"arn:aws:logs:us-east-1:012345678901:log-group:legacy",
+		ir.Identity.NativeIDs["arn"],
+		"legacy Arn fallback must have trailing :* stripped",
+	)
+	out := decodeLogGroupAttrs(t, ir)
+	require.NotNil(t, out.ARN)
+	assert.Equal(t, "arn:aws:logs:us-east-1:012345678901:log-group:legacy", *out.ARN.Literal)
+}
+
+func TestCloudwatchLogGroupEnricher_TagsOverlayHappy(t *testing.T) {
+	t.Parallel()
+	lg := &cwltypes.LogGroup{
+		LogGroupName: aws.String("tagged"),
+		LogGroupArn:  aws.String("arn:aws:logs:us-east-1:012345678901:log-group:tagged"),
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		},
+		func(_ context.Context, _ *cloudwatchlogs.Client, arn string) (map[string]string, error) {
+			assert.Equal(t, "arn:aws:logs:us-east-1:012345678901:log-group:tagged", arn,
+				"tags overlay must be keyed off the stamped ARN")
+			return map[string]string{
+				"Env":  "prod",
+				"Team": "payments",
+			}, nil
+		})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "tagged"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}}))
+
+	out := decodeLogGroupAttrs(t, ir)
+	require.NotNil(t, out.Tags)
+	require.NotNil(t, out.Tags["Env"])
+	assert.Equal(t, "prod", *out.Tags["Env"].Literal)
+	require.NotNil(t, out.Tags["Team"])
+	assert.Equal(t, "payments", *out.Tags["Team"].Literal)
+}
+
+func TestCloudwatchLogGroupEnricher_TagsOverlaySoftFailOnError(t *testing.T) {
+	t.Parallel()
+	// Tags-fetch errors must NOT cause Enrich to fail — the describe
+	// is the load-bearing call; tags is best-effort.
+	lg := &cwltypes.LogGroup{
+		LogGroupName: aws.String("t"),
+		LogGroupArn:  aws.String("arn:aws:logs:us-east-1:012345678901:log-group:t"),
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		},
+		func(context.Context, *cloudwatchlogs.Client, string) (map[string]string, error) {
+			return nil, errors.New("AccessDeniedException")
+		})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "t"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}}),
+		"tags-fetch error must be downgraded; only describe failure is fatal")
+	require.NotEmpty(t, ir.Attrs)
+	out := decodeLogGroupAttrs(t, ir)
+	assert.Empty(t, out.Tags, "tags must be absent when fetchTags errors")
+}
+
+func TestCloudwatchLogGroupEnricher_OmitsOptionalFieldsWhenUnset(t *testing.T) {
+	t.Parallel()
+	// Bare-minimum log group: SDK returns only the name. KMS, retention,
+	// class must all be absent in the typed payload (vs zero-valued)
+	// so decision-#34 clean HCL doesn't emit drifty defaults.
+	lg := &cwltypes.LogGroup{
+		LogGroupName: aws.String("minimal"),
+		LogGroupArn:  aws.String("arn:aws:logs:us-east-1:012345678901:log-group:minimal"),
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		}, nil)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "minimal"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}}))
+
+	out := decodeLogGroupAttrs(t, ir)
+	assert.Nil(t, out.KMSKeyID, "kms_key_id must be absent when SDK returns no KmsKeyId")
+	assert.Nil(t, out.RetentionInDays, "retention_in_days must be absent when SDK returns nil RetentionInDays")
+	assert.Nil(t, out.LogGroupClass, "log_group_class must be absent when SDK returns empty class")
+}
+
+func TestCloudwatchLogGroupEnricher_EnrichByID_HappyPath(t *testing.T) {
+	t.Parallel()
+	lg := &cwltypes.LogGroup{
+		LogGroupName:    aws.String("byid"),
+		LogGroupArn:     aws.String("arn:aws:logs:us-east-1:012345678901:log-group:byid"),
+		RetentionInDays: aws.Int32(7),
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		},
+		func(context.Context, *cloudwatchlogs.Client, string) (map[string]string, error) {
+			return map[string]string{"K": "V"}, nil
+		})
+
+	raw, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type:     "aws_cloudwatch_log_group",
+		NameHint: "byid",
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	// EnrichByID must return the same JSON shape Enrich writes into
+	// ir.Attrs — decode via the canonical UnmarshalAttrs path.
+	decoded, err := generated.UnmarshalAttrs("aws_cloudwatch_log_group", raw)
+	require.NoError(t, err)
+	out, ok := decoded.(*generated.AWSCloudwatchLogGroup)
+	require.True(t, ok)
+	require.NotNil(t, out.Name)
+	assert.Equal(t, "byid", *out.Name.Literal)
+	require.NotNil(t, out.RetentionInDays)
+	assert.Equal(t, int64(7), *out.RetentionInDays.Literal)
+	require.NotNil(t, out.Tags["K"])
+	assert.Equal(t, "V", *out.Tags["K"].Literal)
+}
+
+func TestCloudwatchLogGroupEnricher_EnrichByID_NoNameReturnsError(t *testing.T) {
+	t.Parallel()
+	enr := newCloudWatchLogGroupEnricher()
+	_, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type: "aws_cloudwatch_log_group",
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive log group name")
+}
+
+// Sanity pin: the raw JSON shape from Enrich and EnrichByID must be
+// byte-identical for the same fixture. If a future refactor splits
+// the mapping into divergent paths, this catches it.
+func TestCloudwatchLogGroupEnricher_EnrichAndEnrichByIDProduceSameJSON(t *testing.T) {
+	t.Parallel()
+	lg := &cwltypes.LogGroup{
+		LogGroupName:    aws.String("same"),
+		LogGroupArn:     aws.String("arn:aws:logs:us-east-1:012345678901:log-group:same"),
+		RetentionInDays: aws.Int32(14),
+		LogGroupClass:   cwltypes.LogGroupClassStandard,
+	}
+	tagFn := func(context.Context, *cloudwatchlogs.Client, string) (map[string]string, error) {
+		return map[string]string{"Tier": "gold"}, nil
+	}
+	enr := newTestCloudWatchLogGroupEnricher(
+		func(context.Context, *cloudwatchlogs.Client, string) (*cwltypes.LogGroup, error) {
+			return lg, nil
+		}, tagFn)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "same"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}}))
+
+	raw, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type: "aws_cloudwatch_log_group", NameHint: "same",
+	}, EnrichClients{CloudWatchLogs: &cloudwatchlogs.Client{}})
+	require.NoError(t, err)
+
+	// Compare via round-trip-normalized JSON so map-key ordering
+	// doesn't cause a false negative.
+	var a, b any
+	require.NoError(t, json.Unmarshal(ir.Attrs, &a))
+	require.NoError(t, json.Unmarshal(raw, &b))
+	assert.Equal(t, a, b, "Enrich and EnrichByID must produce equivalent JSON payloads")
+}

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -16,6 +16,7 @@ package awsdiscover
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -71,6 +72,45 @@ type AttributeEnricher interface {
 	// ErrEnrichClientUnavailable so callers can distinguish "not
 	// configured" from "real API error".
 	Enrich(ctx context.Context, ir *imported.ImportedResource, clients EnrichClients) error
+}
+
+// ByIDEnricher is an optional sibling to AttributeEnricher that fetches
+// a single resource's typed Layer 1 payload from its ResourceIdentity
+// alone — used by the per-IR drift refresh path that the eventual
+// pkg/imported.Provider.EnrichByID exposes (presets#482). Implementing
+// this interface is purely additive: enrichers that satisfy only
+// AttributeEnricher continue to work unchanged for the batch enrichment
+// flow; the by-ID dispatcher type-asserts at call time and downgrades
+// gracefully when the assertion fails.
+//
+// The shape diverges from Enrich for two reasons:
+//
+//   - The caller starts from an Identity that hasn't been produced by
+//     the corresponding Discoverer (e.g. a UI refresh on a single row),
+//     so there is no pre-existing *ImportedResource to mutate.
+//   - The caller wants only the raw typed payload (returned as the
+//     same json.RawMessage shape that lands in ImportedResource.Attrs),
+//     so it can drive its own comparator without going through the
+//     batch progress / aggregation machinery.
+//
+// Implementations must not mutate identity. They may issue the same
+// SDK calls as the AttributeEnricher implementation for the same type;
+// in the common case Enrich and EnrichByID share a private helper that
+// does the SDK call and emits the typed struct, and the two methods
+// differ only in how they package the result.
+type ByIDEnricher interface {
+	// ResourceType returns the Terraform type this enricher covers.
+	// Must match the registered Discoverer / AttributeEnricher of the
+	// same type.
+	ResourceType() string
+
+	// EnrichByID fetches the typed Layer 1 payload for the resource
+	// named by identity and returns it as the json.RawMessage that
+	// would land in ImportedResource.Attrs. A nil required client on
+	// clients is reported as ErrEnrichClientUnavailable so callers
+	// can distinguish "not configured" from "real API error". A
+	// not-found resource is reported as ErrNotFound.
+	EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, clients EnrichClients) (json.RawMessage, error)
 }
 
 // EnrichClients bundles the AWS SDK clients per-type enrichers dispatch

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -22,8 +22,10 @@ import (
 	"sort"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -131,9 +133,11 @@ type ByIDEnricher interface {
 // Empty is tolerated when no enricher uses it (today: DynamoDB doesn't
 // need it because TableArn comes back in DescribeTable directly).
 type EnrichClients struct {
-	S3        *s3.Client
-	DynamoDB  *dynamodb.Client
-	AccountID string
+	S3             *s3.Client
+	DynamoDB       *dynamodb.Client
+	CloudWatchLogs *cloudwatchlogs.Client
+	SecretsManager *secretsmanager.Client
+	AccountID      string
 }
 
 // ErrEnrichClientUnavailable signals that the SDK client an enricher

--- a/cmd/insideout-import/awsdiscover/provider_export.go
+++ b/cmd/insideout-import/awsdiscover/provider_export.go
@@ -1,0 +1,81 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// EnricherTypes returns the sorted list of Terraform types that have a
+// registered AttributeEnricher on this AWSDiscoverer. Used by the
+// pkg/imported.Provider AWS impl to expose per-type Capabilities
+// without poking the unexported byTypeEnricher map directly.
+//
+// Distinct from SupportedTypes (which lists discoverers, not enrichers).
+// A type appearing in SupportedTypes but not EnricherTypes is
+// Identity-only — Discover populates Identity, no attribute enrichment.
+func (a *AWSDiscoverer) EnricherTypes() []string {
+	out := make([]string, 0, len(a.byTypeEnricher))
+	for t := range a.byTypeEnricher {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// HasEnricher reports whether tfType has a registered
+// AttributeEnricher. Equivalent to checking membership in
+// EnricherTypes() but O(1).
+func (a *AWSDiscoverer) HasEnricher(tfType string) bool {
+	_, ok := a.byTypeEnricher[tfType]
+	return ok
+}
+
+// HasByIDEnricher reports whether tfType has a registered enricher
+// that satisfies the ByIDEnricher interface. ByIDEnricher is an
+// optional extension of AttributeEnricher used by the per-IR drift
+// refresh path; a type with HasEnricher==true but HasByIDEnricher==
+// false supports batch enrichment but not single-identity refresh.
+func (a *AWSDiscoverer) HasByIDEnricher(tfType string) bool {
+	enr, ok := a.byTypeEnricher[tfType]
+	if !ok {
+		return false
+	}
+	_, ok = enr.(ByIDEnricher)
+	return ok
+}
+
+// EnrichByID dispatches a per-identity attribute fetch to the
+// registered ByIDEnricher for tfType. Returns the raw json.RawMessage
+// payload that would land in ir.Attrs.
+//
+// Error cases:
+//   - No enricher registered: ErrNotSupported.
+//   - Enricher registered but does not satisfy ByIDEnricher:
+//     ErrNotSupported (the caller — pkg/imported.Provider — wraps it
+//     as ErrEnrichByIDNotImplemented for cross-cloud uniformity).
+//   - Required SDK client nil on clients: ErrEnrichClientUnavailable
+//     (propagated unchanged from the per-type enricher).
+//
+// identity must not be nil — the per-type enrichers dereference fields
+// on it. tfType is taken from identity.Type for consistency, but the
+// orchestrator may also pass an explicit type when refreshing an
+// identity whose Type field has been corrupted; today the signature
+// requires identity to carry the type itself.
+func (a *AWSDiscoverer) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, clients EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("awsdiscover.EnrichByID: nil identity")
+	}
+	enr, ok := a.byTypeEnricher[identity.Type]
+	if !ok {
+		return nil, fmt.Errorf("no enricher registered for %q: %w", identity.Type, ErrNotSupported)
+	}
+	byID, ok := enr.(ByIDEnricher)
+	if !ok {
+		return nil, fmt.Errorf("enricher for %q does not implement ByIDEnricher: %w", identity.Type, ErrNotSupported)
+	}
+	return byID.EnrichByID(ctx, identity, clients)
+}

--- a/cmd/insideout-import/awsdiscover/secretsmanager_secret_enrich.go
+++ b/cmd/insideout-import/awsdiscover/secretsmanager_secret_enrich.go
@@ -1,0 +1,290 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// secretsmanagerSecretTFType is the registered Terraform type for the
+// Secrets Manager Secret enricher. Kept as a constant so the registry /
+// ResourceType() stay in lockstep.
+const secretsmanagerSecretTFType = "aws_secretsmanager_secret"
+
+// secretsmanagerSecretEnricher implements AttributeEnricher and
+// ByIDEnricher for aws_secretsmanager_secret. Pairs with the Cloud-
+// Control-routed (or sdkonly) secrets_manager discoverer.
+//
+// Unlike DynamoDB — where TF surface aggregates four SDK calls — a
+// single DescribeSecret returns every field the Layer 1 typed model
+// needs: top-level attributes (Name, Description, KmsKeyId), tags
+// (inline Tags []Tag), and replicas (inline ReplicationStatus []*).
+// One fetch hook is therefore enough; no soft-fail overlay is needed.
+//
+// **Computed-only / TF-input-only fields skipped per decision #5:**
+//   - `arn` (Computed) — stamped on ir.Identity.NativeIDs["arn"]
+//     instead, matching the DynamoDB TableArn pattern.
+//   - `id` (Optional+Computed alias for ARN).
+//   - `tags_all` (Computed; provider merges defaults at plan time).
+//   - `force_overwrite_replica_secret` (TF-input only; no API source).
+//   - `name_prefix` (TF-input only; provider derives Name from it).
+//   - `recovery_window_in_days` (TF-input only; delete-time parameter
+//     consumed by DeleteSecret, with no Describe-side reflection).
+//   - `policy` (no field on DescribeSecretOutput; the resource policy
+//     lives behind a separate GetResourcePolicy call that this
+//     bundle's single-call contract does not include).
+//
+// Sensitive fields: the secret *value* lives behind GetSecretValue,
+// which we never call — only metadata is enriched. Decision #36
+// redaction is downstream's concern.
+type secretsmanagerSecretEnricher struct {
+	// fetch is overridable for tests. Defaults to a real DescribeSecret
+	// call against the secretsmanager.Client in EnrichClients. Tests
+	// inject a fake by constructing the enricher with a custom fetch —
+	// keeps the enricher hermetically testable without spinning up an
+	// HTTP server for the SDK client.
+	fetch func(ctx context.Context, c *secretsmanager.Client, secretID string) (*secretsmanager.DescribeSecretOutput, error)
+}
+
+// newSecretsManagerSecretEnricher returns the production-wired enricher.
+// AWSDiscoverer's byTypeEnricher map registers this under
+// "aws_secretsmanager_secret".
+func newSecretsManagerSecretEnricher() AttributeEnricher {
+	return &secretsmanagerSecretEnricher{fetch: defaultSecretsManagerSecretFetch}
+}
+
+func (secretsmanagerSecretEnricher) ResourceType() string { return secretsmanagerSecretTFType }
+
+// Enrich populates ir.Attrs with a typed AWSSecretsmanagerSecret
+// payload for the secret identified by ir.Identity. Returns
+// ErrEnrichClientUnavailable if EnrichClients.SecretsManager is nil;
+// any other error reflects a real Secrets Manager API failure on the
+// load-bearing DescribeSecret call.
+func (e secretsmanagerSecretEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if c.SecretsManager == nil {
+		return ErrEnrichClientUnavailable
+	}
+	secretID := secretsmanagerSecretIDForEnrich(&ir.Identity)
+	if secretID == "" {
+		return fmt.Errorf("secretsmanager_secret: cannot derive secret id from Identity (Address=%q ImportID=%q NameHint=%q)",
+			ir.Identity.Address, ir.Identity.ImportID, ir.Identity.NameHint)
+	}
+	out, err := e.fetch(ctx, c.SecretsManager, secretID)
+	if err != nil {
+		// Map typed not-found onto ErrNotFound so dispatchers / drift
+		// flows can distinguish a deleted secret from a real API
+		// failure. Mirrors the cloudcontrol_discoverer.go pattern.
+		var notFound *smtypes.ResourceNotFoundException
+		if errors.As(err, &notFound) {
+			return fmt.Errorf("secretsmanager_secret %q: %w", secretID, ErrNotFound)
+		}
+		return fmt.Errorf("secretsmanager_secret: describe %q: %w", secretID, err)
+	}
+	if out == nil {
+		return fmt.Errorf("secretsmanager_secret: describe %q: empty response", secretID)
+	}
+
+	// Stamp ARN on Identity.NativeIDs so downstream consumers don't
+	// have to round-trip back to the SDK for the ARN. The pure-
+	// mapping helper does NOT touch ir.Identity per the
+	// AttributeEnricher contract; this is the only place the enricher
+	// writes to it.
+	if arn := aws.ToString(out.ARN); arn != "" {
+		if ir.Identity.NativeIDs == nil {
+			ir.Identity.NativeIDs = map[string]string{}
+		}
+		ir.Identity.NativeIDs["arn"] = arn
+	}
+
+	typed := mapSecretsmanagerSecret(out)
+
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return fmt.Errorf("secretsmanager_secret: marshal Attrs: %w", err)
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID fetches the typed AWSSecretsmanagerSecret payload for the
+// secret named by identity and returns it as the json.RawMessage shape
+// that would land in ImportedResource.Attrs. Shares the SDK call +
+// mapping with Enrich via the private mapSecretsmanagerSecret helper so
+// the two paths cannot drift out of sync.
+//
+// EnrichByID does not mutate identity (callers passing a pointer get
+// the same struct back unchanged) — the ARN that Enrich stamps onto
+// NativeIDs is intentionally NOT stamped here, since the per-IR drift
+// refresh path expects the identity to be authoritative input, not a
+// destination.
+func (e secretsmanagerSecretEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.SecretsManager == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if identity == nil {
+		return nil, fmt.Errorf("secretsmanager_secret: nil identity")
+	}
+	secretID := secretsmanagerSecretIDForEnrich(identity)
+	if secretID == "" {
+		return nil, fmt.Errorf("secretsmanager_secret: cannot derive secret id from Identity (Address=%q ImportID=%q NameHint=%q)",
+			identity.Address, identity.ImportID, identity.NameHint)
+	}
+	out, err := e.fetch(ctx, c.SecretsManager, secretID)
+	if err != nil {
+		var notFound *smtypes.ResourceNotFoundException
+		if errors.As(err, &notFound) {
+			return nil, fmt.Errorf("secretsmanager_secret %q: %w", secretID, ErrNotFound)
+		}
+		return nil, fmt.Errorf("secretsmanager_secret: describe %q: %w", secretID, err)
+	}
+	if out == nil {
+		return nil, fmt.Errorf("secretsmanager_secret: describe %q: empty response", secretID)
+	}
+	typed := mapSecretsmanagerSecret(out)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("secretsmanager_secret: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// secretsmanagerSecretIDForEnrich derives the SecretId argument for
+// DescribeSecret. Secrets Manager's DescribeSecret accepts either the
+// secret's bare name or its full ARN, so the order of preference
+// favors the most-fully-qualified identifier the discoverer is likely
+// to have populated:
+//
+//  1. Identity.ImportID — the per-service discoverer's
+//     passthroughImportID emits the secret ARN as the Identifier for
+//     Secrets Manager, so this is the load-bearing source.
+//  2. Identity.NameHint — explicit secret name set by the discoverer
+//     (or by a caller refreshing a single row via EnrichByID).
+//  3. Identity.NativeIDs["name"] — last-resort fallback if a future
+//     config populates the NativeIDs bag instead.
+//
+// Distinct from dynamodb_table's NameHint-first ordering because
+// DescribeSecret can take an ARN directly and the discoverer's
+// ImportID is the ARN — preferring ImportID avoids an unnecessary
+// fall-through.
+func secretsmanagerSecretIDForEnrich(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if s := strings.TrimSpace(id.ImportID); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(id.NameHint); s != "" {
+		return s
+	}
+	return strings.TrimSpace(id.NativeIDs["name"])
+}
+
+// defaultSecretsManagerSecretFetch is the production fetch path: a
+// single DescribeSecret call.
+func defaultSecretsManagerSecretFetch(ctx context.Context, c *secretsmanager.Client, secretID string) (*secretsmanager.DescribeSecretOutput, error) {
+	out, err := c.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{SecretId: aws.String(secretID)})
+	if err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return nil, errors.New("describe secret: nil output")
+	}
+	return out, nil
+}
+
+// mapSecretsmanagerSecret is the pure-mapping helper shared by Enrich
+// and EnrichByID. Hand-rolled (no enrichgen) because the Layer 1 typed
+// surface and the SDK DescribeSecretOutput shape are stable and the
+// special cases (skip-default-KMS-key, replication-block lift) are
+// short enough to inline. Mirrors the dynamodb_table_enrich.gen.go
+// shape so future readers can pattern-match.
+//
+// Decision-#34 cleanliness: every field is emitted only when present
+// on the API response, so the resulting HCL does not contain
+// "field = null" noise.
+func mapSecretsmanagerSecret(out *secretsmanager.DescribeSecretOutput) *generated.AWSSecretsmanagerSecret {
+	typed := &generated.AWSSecretsmanagerSecret{}
+
+	if name := aws.ToString(out.Name); name != "" {
+		typed.Name = generated.LiteralOf(name)
+	}
+	if desc := aws.ToString(out.Description); desc != "" {
+		typed.Description = generated.LiteralOf(desc)
+	}
+	// Skip the AWS-owned default key. The Secrets Manager API returns
+	// `KmsKeyId == ""` when the secret uses the AWS-managed default
+	// key (`alias/aws/secretsmanager`); emitting that as an explicit
+	// literal would diff against TF state where the field is left
+	// unset. Matches the DynamoDB SSE "absent when default" guard.
+	if k := aws.ToString(out.KmsKeyId); k != "" {
+		typed.KMSKeyID = generated.LiteralOf(k)
+	}
+
+	// Tags — DescribeSecretOutput already carries them inline, so no
+	// overlay call is needed.
+	if len(out.Tags) > 0 {
+		m := map[string]*generated.Value[string]{}
+		for _, t := range out.Tags {
+			if t.Key != nil {
+				m[*t.Key] = generated.LiteralOf(aws.ToString(t.Value))
+			}
+		}
+		if len(m) > 0 {
+			typed.Tags = m
+		}
+	}
+
+	// Replica blocks come from ReplicationStatus. The TF schema's
+	// `replica` block is Optional in input but each entry's fields
+	// here are downstream of the actual replication state, so the
+	// block list reflects observed state.
+	if len(out.ReplicationStatus) > 0 {
+		blocks := make([]generated.AWSSecretsmanagerSecretReplica, 0, len(out.ReplicationStatus))
+		for i := range out.ReplicationStatus {
+			blocks = append(blocks, enrichAWSSecretsmanagerSecretReplica(&out.ReplicationStatus[i]))
+		}
+		if len(blocks) > 0 {
+			typed.Replica = blocks
+		}
+	}
+
+	return typed
+}
+
+// enrichAWSSecretsmanagerSecretReplica lifts a single ReplicationStatus
+// entry into a Layer 1 replica block. Like the parent helper, every
+// field is emitted only when present so the resulting HCL stays
+// decision-#34 clean.
+func enrichAWSSecretsmanagerSecretReplica(r *smtypes.ReplicationStatusType) generated.AWSSecretsmanagerSecretReplica {
+	out := generated.AWSSecretsmanagerSecretReplica{}
+	if r == nil {
+		return out
+	}
+	if region := aws.ToString(r.Region); region != "" {
+		out.Region = generated.LiteralOf(region)
+	}
+	if k := aws.ToString(r.KmsKeyId); k != "" {
+		out.KMSKeyID = generated.LiteralOf(k)
+	}
+	if r.LastAccessedDate != nil {
+		// RFC3339 — matches what the AWS provider records in TF
+		// state for *_date fields.
+		out.LastAccessedDate = generated.LiteralOf(r.LastAccessedDate.UTC().Format("2006-01-02T15:04:05Z"))
+	}
+	if s := string(r.Status); s != "" {
+		out.Status = generated.LiteralOf(s)
+	}
+	if msg := aws.ToString(r.StatusMessage); msg != "" {
+		out.StatusMessage = generated.LiteralOf(msg)
+	}
+	return out
+}

--- a/cmd/insideout-import/awsdiscover/secretsmanager_secret_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/secretsmanager_secret_enrich_test.go
@@ -1,0 +1,469 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// newTestSecretsManagerSecretEnricher builds a secretsmanagerSecretEnricher
+// with a fake DescribeSecret fetch wired in. Mirrors the
+// newTestDynamoDBEnricher pattern so the two test files read alike.
+func newTestSecretsManagerSecretEnricher(
+	describe func(ctx context.Context, c *secretsmanager.Client, id string) (*secretsmanager.DescribeSecretOutput, error),
+) secretsmanagerSecretEnricher {
+	return secretsmanagerSecretEnricher{fetch: describe}
+}
+
+// decodeSecretsmanagerAttrs round-trips ir.Attrs through UnmarshalAttrs
+// and returns the typed AWSSecretsmanagerSecret. Mirrors the GCP-side
+// decoded-typed assertion pattern.
+func decodeSecretsmanagerAttrs(t *testing.T, ir *imported.ImportedResource) *generated.AWSSecretsmanagerSecret {
+	t.Helper()
+	require.NotEmpty(t, ir.Attrs, "Attrs must be populated before decode")
+	decoded, err := generated.UnmarshalAttrs("aws_secretsmanager_secret", ir.Attrs)
+	require.NoError(t, err)
+	sec, ok := decoded.(*generated.AWSSecretsmanagerSecret)
+	require.True(t, ok, "decoded type must be *AWSSecretsmanagerSecret, got %T", decoded)
+	return sec
+}
+
+// decodeSecretsmanagerRaw is the EnrichByID counterpart: the helper
+// returns json.RawMessage directly (no IR mutation), so the round-trip
+// goes through UnmarshalAttrs on the raw bytes.
+func decodeSecretsmanagerRaw(t *testing.T, raw json.RawMessage) *generated.AWSSecretsmanagerSecret {
+	t.Helper()
+	require.NotEmpty(t, raw, "EnrichByID must return a non-empty payload")
+	decoded, err := generated.UnmarshalAttrs("aws_secretsmanager_secret", raw)
+	require.NoError(t, err)
+	sec, ok := decoded.(*generated.AWSSecretsmanagerSecret)
+	require.True(t, ok, "decoded type must be *AWSSecretsmanagerSecret, got %T", decoded)
+	return sec
+}
+
+func TestSecretsmanagerSecretEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	enr := newSecretsManagerSecretEnricher()
+	assert.Equal(t, "aws_secretsmanager_secret", enr.ResourceType())
+}
+
+func TestSecretsmanagerSecretEnricher_ImplementsByIDEnricher(t *testing.T) {
+	t.Parallel()
+	// Compile-time guarantee that the production constructor returns
+	// something satisfying both interfaces. Phase 2 contract: every new
+	// enricher must implement ByIDEnricher.
+	var _ AttributeEnricher = newSecretsManagerSecretEnricher()
+	enr := newSecretsManagerSecretEnricher()
+	_, ok := enr.(ByIDEnricher)
+	assert.True(t, ok, "secretsmanagerSecretEnricher must implement ByIDEnricher per Phase 2 contract")
+}
+
+func TestSecretsmanagerSecretEnricher_NilClientReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	enr := secretsmanagerSecretEnricher{}
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_secretsmanager_secret",
+			ImportID: "arn:aws:secretsmanager:us-east-1:012345678901:secret:foo-AbCdEf",
+			NameHint: "foo",
+		},
+	}, EnrichClients{SecretsManager: nil})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestSecretsmanagerSecretEnricher_EnrichByID_NilClientReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	enr := secretsmanagerSecretEnricher{}
+	_, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type:     "aws_secretsmanager_secret",
+		ImportID: "arn:aws:secretsmanager:us-east-1:012345678901:secret:foo-AbCdEf",
+	}, EnrichClients{SecretsManager: nil})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestSecretsmanagerSecretEnricher_SecretIDDerivation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		label string
+		id    imported.ResourceIdentity
+		want  string
+	}{
+		{
+			label: "ImportID wins (typically the ARN from the discoverer)",
+			id: imported.ResourceIdentity{
+				ImportID:  "arn:aws:secretsmanager:us-east-1:012345678901:secret:foo-AbCdEf",
+				NameHint:  "foo",
+				NativeIDs: map[string]string{"name": "foo-native"},
+			},
+			want: "arn:aws:secretsmanager:us-east-1:012345678901:secret:foo-AbCdEf",
+		},
+		{
+			label: "NameHint is fallback when ImportID missing",
+			id: imported.ResourceIdentity{
+				NameHint:  "from-name-hint",
+				NativeIDs: map[string]string{"name": "from-native"},
+			},
+			want: "from-name-hint",
+		},
+		{
+			label: "NativeIDs[name] is last resort",
+			id: imported.ResourceIdentity{
+				NativeIDs: map[string]string{"name": "from-native"},
+			},
+			want: "from-native",
+		},
+		{
+			label: "empty everywhere → empty",
+			id:    imported.ResourceIdentity{},
+			want:  "",
+		},
+		{
+			label: "nil identity → empty",
+			id:    imported.ResourceIdentity{}, // sentinel below
+			want:  "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.label, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, secretsmanagerSecretIDForEnrich(&tc.id))
+		})
+	}
+	// Cover the nil-pointer guard explicitly.
+	assert.Equal(t, "", secretsmanagerSecretIDForEnrich(nil), "nil identity must yield empty id")
+}
+
+func TestSecretsmanagerSecretEnricher_DescribeError_Propagates(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("AccessDenied")
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return nil, wantErr
+		},
+	)
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret", ImportID: "foo"},
+	}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestSecretsmanagerSecretEnricher_NotFoundMapsToErrNotFound(t *testing.T) {
+	t.Parallel()
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return nil, &smtypes.ResourceNotFoundException{Message: aws.String("Secrets Manager can't find the specified secret.")}
+		},
+	)
+	t.Run("Enrich", func(t *testing.T) {
+		t.Parallel()
+		err := enr.Enrich(context.Background(), &imported.ImportedResource{
+			Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret", ImportID: "missing"},
+		}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNotFound, "typed ResourceNotFoundException must map onto ErrNotFound")
+	})
+	t.Run("EnrichByID", func(t *testing.T) {
+		t.Parallel()
+		_, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+			Type:     "aws_secretsmanager_secret",
+			ImportID: "missing",
+		}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+}
+
+func TestSecretsmanagerSecretEnricher_NoIDReturnsError(t *testing.T) {
+	t.Parallel()
+	enr := newSecretsManagerSecretEnricher()
+	t.Run("Enrich", func(t *testing.T) {
+		t.Parallel()
+		err := enr.Enrich(context.Background(), &imported.ImportedResource{
+			Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret"},
+		}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "cannot derive secret id"))
+	})
+	t.Run("EnrichByID", func(t *testing.T) {
+		t.Parallel()
+		byID, ok := enr.(ByIDEnricher)
+		require.True(t, ok)
+		_, err := byID.EnrichByID(context.Background(), &imported.ResourceIdentity{
+			Type: "aws_secretsmanager_secret",
+		}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "cannot derive secret id"))
+	})
+	t.Run("EnrichByID_NilIdentity", func(t *testing.T) {
+		t.Parallel()
+		byID, ok := enr.(ByIDEnricher)
+		require.True(t, ok)
+		_, err := byID.EnrichByID(context.Background(), nil,
+			EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "nil identity"))
+	})
+}
+
+func TestSecretsmanagerSecretEnricher_BasicMapping(t *testing.T) {
+	t.Parallel()
+	const (
+		secretARN  = "arn:aws:secretsmanager:us-east-1:012345678901:secret:db-creds-AbCdEf"
+		secretName = "db-creds"
+		kmsKey     = "arn:aws:kms:us-east-1:012345678901:key/abc"
+	)
+	out := &secretsmanager.DescribeSecretOutput{
+		ARN:         aws.String(secretARN),
+		Name:        aws.String(secretName),
+		Description: aws.String("Production DB credentials"),
+		KmsKeyId:    aws.String(kmsKey),
+		Tags: []smtypes.Tag{
+			{Key: aws.String("Env"), Value: aws.String("prod")},
+			{Key: aws.String("Project"), Value: aws.String("payments")},
+		},
+	}
+	enr := newTestSecretsManagerSecretEnricher(
+		func(_ context.Context, _ *secretsmanager.Client, gotID string) (*secretsmanager.DescribeSecretOutput, error) {
+			// Enrich must pass through ImportID (the ARN) as SecretId
+			// per the documented preference order. Pinning here
+			// prevents a regression where the helper accidentally falls
+			// through to NameHint first and downstream consumers stop
+			// resolving by ARN.
+			assert.Equal(t, secretARN, gotID, "Enrich must hand DescribeSecret the ARN from ImportID")
+			return out, nil
+		},
+	)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_secretsmanager_secret",
+			Address:  "aws_secretsmanager_secret.db_creds",
+			ImportID: secretARN,
+			NameHint: secretName,
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{SecretsManager: &secretsmanager.Client{}}))
+
+	// ARN promoted onto NativeIDs (mirrors DynamoDB TableArn pattern).
+	assert.Equal(t, secretARN, ir.Identity.NativeIDs["arn"],
+		"enricher must stamp ARN onto Identity.NativeIDs[arn]")
+
+	sec := decodeSecretsmanagerAttrs(t, ir)
+	require.NotNil(t, sec.Name)
+	assert.Equal(t, secretName, *sec.Name.Literal)
+	require.NotNil(t, sec.Description)
+	assert.Equal(t, "Production DB credentials", *sec.Description.Literal)
+	require.NotNil(t, sec.KMSKeyID)
+	assert.Equal(t, kmsKey, *sec.KMSKeyID.Literal)
+
+	require.NotNil(t, sec.Tags)
+	require.NotNil(t, sec.Tags["Env"])
+	assert.Equal(t, "prod", *sec.Tags["Env"].Literal)
+	require.NotNil(t, sec.Tags["Project"])
+	assert.Equal(t, "payments", *sec.Tags["Project"].Literal)
+
+	// Computed-only / TF-input-only fields must not appear in the
+	// payload — decision #5.
+	assert.Nil(t, sec.ARN, "arn is Computed; the enricher must NOT emit it on the typed payload (lives on Identity.NativeIDs)")
+	assert.Nil(t, sec.ID, "id is Computed; the enricher must not emit it")
+	assert.Nil(t, sec.TagsAll, "tags_all is Computed; the enricher must not emit it")
+	assert.Nil(t, sec.RecoveryWindowInDays, "recovery_window_in_days is delete-time-only; the enricher must not emit it")
+	assert.Nil(t, sec.ForceOverwriteReplicaSecret, "force_overwrite_replica_secret is TF-input-only; the enricher must not emit it")
+	assert.Nil(t, sec.NamePrefix, "name_prefix is TF-input-only; the enricher must not emit it")
+	assert.Nil(t, sec.Policy, "policy lives behind GetResourcePolicy; the single-call enricher must not emit it")
+	assert.Empty(t, sec.Replica, "replica must be absent when ReplicationStatus is empty")
+}
+
+func TestSecretsmanagerSecretEnricher_TagsAbsent(t *testing.T) {
+	t.Parallel()
+	out := &secretsmanager.DescribeSecretOutput{
+		ARN:  aws.String("arn:aws:secretsmanager:us-east-1:012345678901:secret:plain-AbCdEf"),
+		Name: aws.String("plain"),
+	}
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return out, nil
+		},
+	)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret", ImportID: "plain"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{SecretsManager: &secretsmanager.Client{}}))
+	sec := decodeSecretsmanagerAttrs(t, ir)
+	assert.Empty(t, sec.Tags, "tags must be absent when the API returns no tags (decision #34: no empty maps)")
+}
+
+func TestSecretsmanagerSecretEnricher_DefaultKMSKeyOmitsField(t *testing.T) {
+	t.Parallel()
+	// DescribeSecret returns KmsKeyId == "" when the secret uses the
+	// AWS-managed default key. Emitting "" or
+	// "alias/aws/secretsmanager" would diff against TF state where the
+	// field is left unset.
+	out := &secretsmanager.DescribeSecretOutput{
+		ARN:      aws.String("arn:aws:secretsmanager:us-east-1:012345678901:secret:default-key-AbCdEf"),
+		Name:     aws.String("default-key"),
+		KmsKeyId: aws.String(""),
+	}
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return out, nil
+		},
+	)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret", ImportID: "default-key"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{SecretsManager: &secretsmanager.Client{}}))
+	sec := decodeSecretsmanagerAttrs(t, ir)
+	assert.Nil(t, sec.KMSKeyID, "kms_key_id must be absent when the API reports the AWS-managed default key")
+}
+
+func TestSecretsmanagerSecretEnricher_ReplicaBlocks(t *testing.T) {
+	t.Parallel()
+	lastAccessed := time.Date(2025, 3, 14, 15, 9, 26, 0, time.UTC)
+	out := &secretsmanager.DescribeSecretOutput{
+		ARN:  aws.String("arn:aws:secretsmanager:us-east-1:012345678901:secret:multi-region-AbCdEf"),
+		Name: aws.String("multi-region"),
+		ReplicationStatus: []smtypes.ReplicationStatusType{
+			{
+				Region:           aws.String("us-west-2"),
+				KmsKeyId:         aws.String("arn:aws:kms:us-west-2:012345678901:key/west"),
+				Status:           smtypes.StatusTypeInSync,
+				LastAccessedDate: &lastAccessed,
+			},
+			{
+				Region:        aws.String("eu-west-1"),
+				Status:        smtypes.StatusTypeInProgress,
+				StatusMessage: aws.String("Replicating"),
+			},
+		},
+	}
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return out, nil
+		},
+	)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret", ImportID: "multi-region"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{SecretsManager: &secretsmanager.Client{}}))
+	sec := decodeSecretsmanagerAttrs(t, ir)
+	require.Len(t, sec.Replica, 2)
+
+	require.NotNil(t, sec.Replica[0].Region)
+	assert.Equal(t, "us-west-2", *sec.Replica[0].Region.Literal)
+	require.NotNil(t, sec.Replica[0].KMSKeyID)
+	assert.Equal(t, "arn:aws:kms:us-west-2:012345678901:key/west", *sec.Replica[0].KMSKeyID.Literal)
+	require.NotNil(t, sec.Replica[0].Status)
+	assert.Equal(t, string(smtypes.StatusTypeInSync), *sec.Replica[0].Status.Literal)
+	require.NotNil(t, sec.Replica[0].LastAccessedDate)
+	assert.Equal(t, "2025-03-14T15:09:26Z", *sec.Replica[0].LastAccessedDate.Literal)
+	assert.Nil(t, sec.Replica[0].StatusMessage, "status_message must be absent when the API omits it")
+
+	require.NotNil(t, sec.Replica[1].Region)
+	assert.Equal(t, "eu-west-1", *sec.Replica[1].Region.Literal)
+	assert.Nil(t, sec.Replica[1].KMSKeyID, "kms_key_id must be absent for in-progress replica with no key reported")
+	require.NotNil(t, sec.Replica[1].Status)
+	assert.Equal(t, string(smtypes.StatusTypeInProgress), *sec.Replica[1].Status.Literal)
+	require.NotNil(t, sec.Replica[1].StatusMessage)
+	assert.Equal(t, "Replicating", *sec.Replica[1].StatusMessage.Literal)
+}
+
+func TestSecretsmanagerSecretEnricher_EnrichByID_BasicMapping(t *testing.T) {
+	t.Parallel()
+	const secretARN = "arn:aws:secretsmanager:us-east-1:012345678901:secret:db-creds-AbCdEf"
+	out := &secretsmanager.DescribeSecretOutput{
+		ARN:         aws.String(secretARN),
+		Name:        aws.String("db-creds"),
+		Description: aws.String("Production DB credentials"),
+	}
+	enr := newTestSecretsManagerSecretEnricher(
+		func(_ context.Context, _ *secretsmanager.Client, gotID string) (*secretsmanager.DescribeSecretOutput, error) {
+			assert.Equal(t, secretARN, gotID)
+			return out, nil
+		},
+	)
+	byID, ok := AttributeEnricher(enr).(ByIDEnricher)
+	require.True(t, ok)
+	identity := &imported.ResourceIdentity{
+		Type:     "aws_secretsmanager_secret",
+		ImportID: secretARN,
+	}
+	raw, err := byID.EnrichByID(context.Background(), identity,
+		EnrichClients{SecretsManager: &secretsmanager.Client{}})
+	require.NoError(t, err)
+	sec := decodeSecretsmanagerRaw(t, raw)
+	require.NotNil(t, sec.Name)
+	assert.Equal(t, "db-creds", *sec.Name.Literal)
+	require.NotNil(t, sec.Description)
+	assert.Equal(t, "Production DB credentials", *sec.Description.Literal)
+
+	// EnrichByID must NOT mutate the caller's identity — the per-IR
+	// drift refresh path expects identity to be authoritative input.
+	assert.Empty(t, identity.NativeIDs,
+		"EnrichByID must not stamp NativeIDs onto the caller's identity")
+}
+
+func TestSecretsmanagerSecretEnricher_EnrichByID_DescribeError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("AccessDenied")
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return nil, wantErr
+		},
+	)
+	byID, ok := AttributeEnricher(enr).(ByIDEnricher)
+	require.True(t, ok)
+	_, err := byID.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type:     "aws_secretsmanager_secret",
+		ImportID: "foo",
+	}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestSecretsmanagerSecretEnricher_NilDescribeOutputErrors(t *testing.T) {
+	t.Parallel()
+	// Defense-in-depth: a fetch hook returning (nil, nil) (e.g. a
+	// future overlay-source helper that bails out silently) must not
+	// crash the enricher — it should surface a clear error.
+	enr := newTestSecretsManagerSecretEnricher(
+		func(context.Context, *secretsmanager.Client, string) (*secretsmanager.DescribeSecretOutput, error) {
+			return nil, nil
+		},
+	)
+	t.Run("Enrich", func(t *testing.T) {
+		t.Parallel()
+		err := enr.Enrich(context.Background(), &imported.ImportedResource{
+			Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret", ImportID: "x"},
+		}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "empty response"))
+	})
+	t.Run("EnrichByID", func(t *testing.T) {
+		t.Parallel()
+		byID, ok := AttributeEnricher(enr).(ByIDEnricher)
+		require.True(t, ok)
+		_, err := byID.EnrichByID(context.Background(), &imported.ResourceIdentity{
+			Type:     "aws_secretsmanager_secret",
+			ImportID: "x",
+		}, EnrichClients{SecretsManager: &secretsmanager.Client{}})
+		require.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "empty response"))
+	})
+}

--- a/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
@@ -26,15 +26,14 @@ func (fakeByIDEnricher) EnrichByID(ctx context.Context, identity *imported.Resou
 // observe beyond the compile.
 var _ ByIDEnricher = (*fakeByIDEnricher)(nil)
 
-// TestExistingEnrichersDoNotImplementByID confirms the additive
-// nature of ByIDEnricher: the 5 existing enrichers today implement
-// only AttributeEnricher. The test pins against the REAL production
-// registration in NewGCPDiscoverer — not a hand-rolled map — so when
-// Phase 2 PRs add real EnrichByID impls, the allowlist must shrink
-// in lockstep with the production registration. A production-only
-// change (add a ByIDEnricher impl, forget to update allowlist) fails
-// the test loud. A regression that drops the registration entirely
-// is caught by the size sanity check below.
+// TestExistingEnrichersDoNotImplementByID pins the per-type
+// ByIDEnricher implementation status against the REAL production
+// registration in NewGCPDiscoverer. As Phase 2 PRs add real
+// EnrichByID impls, the allowlist must shrink in lockstep with the
+// production registration. A production-only change (add a
+// ByIDEnricher impl, forget to update allowlist; or vice versa) fails
+// the test loud. A regression that drops the registration entirely is
+// caught by the explicit wantTotal size check below.
 func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 	// Nil searcher is safe — the constructor only stores it; no
 	// SearchAll call fires here.
@@ -50,13 +49,15 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 		"google_compute_network":       true,
 	}
 
-	// Fail-fast: if the constructor silently dropped the registration,
-	// the for-range below iterates zero times and reports a green
-	// non-test. Pin the expected size to the allowlist length so a
-	// "silent drop in production, allowlist untouched" regression
-	// fails loud.
-	if got, want := len(d.byTypeEnricher), len(notImplemented); got != want {
-		t.Errorf("byTypeEnricher size = %d, want %d (production registration and notImplemented allowlist drifted)", got, want)
+	// Fail-fast: pin the expected total byTypeEnricher size so a
+	// silent drop (or duplicate-key squashing) in production fails the
+	// test. The expected total = allowlist size + types that DO
+	// implement ByIDEnricher. When adding a new enricher: bump
+	// wantTotal and either add to allowlist (no ByIDEnricher) or leave
+	// it off (implements ByIDEnricher).
+	const wantTotal = 7 // 5 pre-Phase-2 + compute_address + compute_firewall
+	if got := len(d.byTypeEnricher); got != wantTotal {
+		t.Errorf("byTypeEnricher size = %d, want %d (production registration drifted from test)", got, wantTotal)
 	}
 
 	for tfType, enr := range d.byTypeEnricher {

--- a/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 // fakeByIDEnricher is a minimal type that satisfies ByIDEnricher.
-// It exists only to assert that the interface compiles and is
-// satisfiable — no production code implements ByIDEnricher yet
+// It exists only to back the compile-time `var _ ByIDEnricher`
+// assertion below — no production code implements ByIDEnricher yet
 // (Phase 2 enricher rollout PRs add real impls one per type).
 type fakeByIDEnricher struct{}
 
@@ -21,40 +21,25 @@ func (fakeByIDEnricher) EnrichByID(ctx context.Context, identity *imported.Resou
 }
 
 // Compile-time assertion. If ByIDEnricher's shape drifts, this fails
-// at build time, not at runtime.
+// at build time. This is the load-bearing shape lock — no runtime
+// "fake calls itself" test is needed because there is nothing to
+// observe beyond the compile.
 var _ ByIDEnricher = (*fakeByIDEnricher)(nil)
-
-func TestByIDEnricher_FakeImplementation(t *testing.T) {
-	var e ByIDEnricher = fakeByIDEnricher{}
-	if got, want := e.ResourceType(), "google_test_fake"; got != want {
-		t.Errorf("ResourceType() = %q, want %q", got, want)
-	}
-	raw, err := e.EnrichByID(t.Context(), &imported.ResourceIdentity{Type: "google_test_fake"}, EnrichClients{})
-	if err != nil {
-		t.Fatalf("EnrichByID returned err: %v", err)
-	}
-	if string(raw) != "{}" {
-		t.Errorf("EnrichByID payload = %q, want %q", string(raw), "{}")
-	}
-}
 
 // TestExistingEnrichersDoNotImplementByID confirms the additive
 // nature of ByIDEnricher: the 5 existing enrichers today implement
-// only AttributeEnricher. When Phase 2 PRs land real EnrichByID
-// impls, this test's allowlist shrinks. The test fails loud if a
-// future PR claims to add EnrichByID but forgets to update the
-// allowlist — i.e. ByIDEnricher coverage is observable.
+// only AttributeEnricher. The test pins against the REAL production
+// registration in NewGCPDiscoverer — not a hand-rolled map — so when
+// Phase 2 PRs add real EnrichByID impls, the allowlist must shrink
+// in lockstep with the production registration. A production-only
+// change (add a ByIDEnricher impl, forget to update allowlist) fails
+// the test loud. A regression that drops the registration entirely
+// is caught by the size sanity check below.
 func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
-	// Mirror the production registration (gcpdiscover.go:343-349) so
-	// the test exercises real enrichers without needing a full
-	// GCPDiscoverer construction.
-	enrichers := map[string]AttributeEnricher{
-		"google_storage_bucket":        newStorageBucketEnricher(),
-		"google_pubsub_topic":          newPubsubTopicEnricher(),
-		"google_pubsub_subscription":   newPubsubSubscriptionEnricher(),
-		"google_secret_manager_secret": newSecretManagerSecretEnricher(),
-		"google_compute_network":       newComputeNetworkEnricher(),
-	}
+	// Nil searcher is safe — the constructor only stores it; no
+	// SearchAll call fires here.
+	d := NewGCPDiscoverer(nil, "test-project", GCPDiscovererOpts{})
+
 	// Allowlist: types whose enrichers explicitly DO NOT implement
 	// ByIDEnricher yet. Shrink as Phase 2 rollout lands per-type impls.
 	notImplemented := map[string]bool{
@@ -64,7 +49,17 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 		"google_secret_manager_secret": true,
 		"google_compute_network":       true,
 	}
-	for tfType, enr := range enrichers {
+
+	// Fail-fast: if the constructor silently dropped the registration,
+	// the for-range below iterates zero times and reports a green
+	// non-test. Pin the expected size to the allowlist length so a
+	// "silent drop in production, allowlist untouched" regression
+	// fails loud.
+	if got, want := len(d.byTypeEnricher), len(notImplemented); got != want {
+		t.Errorf("byTypeEnricher size = %d, want %d (production registration and notImplemented allowlist drifted)", got, want)
+	}
+
+	for tfType, enr := range d.byTypeEnricher {
 		_, implementsByID := enr.(ByIDEnricher)
 		expectNot := notImplemented[tfType]
 		switch {

--- a/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
@@ -1,0 +1,77 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// fakeByIDEnricher is a minimal type that satisfies ByIDEnricher.
+// It exists only to assert that the interface compiles and is
+// satisfiable — no production code implements ByIDEnricher yet
+// (Phase 2 enricher rollout PRs add real impls one per type).
+type fakeByIDEnricher struct{}
+
+func (fakeByIDEnricher) ResourceType() string { return "google_test_fake" }
+
+func (fakeByIDEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, clients EnrichClients) (json.RawMessage, error) {
+	return json.RawMessage(`{}`), nil
+}
+
+// Compile-time assertion. If ByIDEnricher's shape drifts, this fails
+// at build time, not at runtime.
+var _ ByIDEnricher = (*fakeByIDEnricher)(nil)
+
+func TestByIDEnricher_FakeImplementation(t *testing.T) {
+	var e ByIDEnricher = fakeByIDEnricher{}
+	if got, want := e.ResourceType(), "google_test_fake"; got != want {
+		t.Errorf("ResourceType() = %q, want %q", got, want)
+	}
+	raw, err := e.EnrichByID(t.Context(), &imported.ResourceIdentity{Type: "google_test_fake"}, EnrichClients{})
+	if err != nil {
+		t.Fatalf("EnrichByID returned err: %v", err)
+	}
+	if string(raw) != "{}" {
+		t.Errorf("EnrichByID payload = %q, want %q", string(raw), "{}")
+	}
+}
+
+// TestExistingEnrichersDoNotImplementByID confirms the additive
+// nature of ByIDEnricher: the 5 existing enrichers today implement
+// only AttributeEnricher. When Phase 2 PRs land real EnrichByID
+// impls, this test's allowlist shrinks. The test fails loud if a
+// future PR claims to add EnrichByID but forgets to update the
+// allowlist — i.e. ByIDEnricher coverage is observable.
+func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
+	// Mirror the production registration (gcpdiscover.go:343-349) so
+	// the test exercises real enrichers without needing a full
+	// GCPDiscoverer construction.
+	enrichers := map[string]AttributeEnricher{
+		"google_storage_bucket":        newStorageBucketEnricher(),
+		"google_pubsub_topic":          newPubsubTopicEnricher(),
+		"google_pubsub_subscription":   newPubsubSubscriptionEnricher(),
+		"google_secret_manager_secret": newSecretManagerSecretEnricher(),
+		"google_compute_network":       newComputeNetworkEnricher(),
+	}
+	// Allowlist: types whose enrichers explicitly DO NOT implement
+	// ByIDEnricher yet. Shrink as Phase 2 rollout lands per-type impls.
+	notImplemented := map[string]bool{
+		"google_storage_bucket":        true,
+		"google_pubsub_topic":          true,
+		"google_pubsub_subscription":   true,
+		"google_secret_manager_secret": true,
+		"google_compute_network":       true,
+	}
+	for tfType, enr := range enrichers {
+		_, implementsByID := enr.(ByIDEnricher)
+		expectNot := notImplemented[tfType]
+		switch {
+		case expectNot && implementsByID:
+			t.Errorf("%s: enricher now implements ByIDEnricher — remove from notImplemented allowlist", tfType)
+		case !expectNot && !implementsByID:
+			t.Errorf("%s: enricher must implement ByIDEnricher (not in notImplemented allowlist)", tfType)
+		}
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/compute_address_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/compute_address_enrich.go
@@ -1,0 +1,246 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	computev1 "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// computeAddressEnricher implements AttributeEnricher AND ByIDEnricher
+// for google_compute_address. Pairs with computeAddressDiscoverer.
+//
+// Compute API quirk: Addresses.Get takes (project, region, address) as
+// three separate positional string parameters, not a single fully-
+// qualified name. The enricher pulls the region from Identity.Location
+// (the discoverer always populates it for regional addresses; the
+// global slug is filtered out and handled by computeGlobalAddressEnricher
+// — see compute_address.go FromAsset), the short name from
+// Identity.NameHint / NativeIDs["name"] / ImportID, and the project
+// from EnrichClients.ProjectID (which the orchestrator threads through
+// from the run-level project ID).
+//
+// Mapping rationale matches compute_network_enrich.gen.go: pure
+// computed-only TF attributes (creation_timestamp, effective_labels,
+// id, label_fingerprint, self_link, terraform_labels, users) are NOT
+// populated per the decision-#5 composer emission rule — the generated
+// HCL is consumed by `import {} + resource {}` blocks where computed
+// fields are filled by the provider on first refresh. The `goog-` /
+// `goog_` label prefix filter mirrors pubsub_topic / storage_bucket so
+// system-managed labels don't leak into the user-editable HCL surface.
+type computeAddressEnricher struct {
+	// fetch is overridable for tests. Defaults to a real Addresses.Get
+	// call against the computev1.Service in EnrichClients. Tests
+	// inject a fake by constructing the enricher with a custom fetch
+	// — keeps the enricher hermetically testable without spinning up
+	// an HTTP server for the compute client.
+	fetch func(ctx context.Context, svc *computev1.Service, project, region, name string) (*computev1.Address, error)
+}
+
+func newComputeAddressEnricher() AttributeEnricher {
+	return &computeAddressEnricher{fetch: defaultComputeAddressFetch}
+}
+
+// Compile-time assertion that this enricher satisfies both interfaces.
+// Phase 2 contract: every new enricher implements ByIDEnricher in
+// addition to AttributeEnricher.
+var (
+	_ AttributeEnricher = (*computeAddressEnricher)(nil)
+	_ ByIDEnricher      = (*computeAddressEnricher)(nil)
+)
+
+func (computeAddressEnricher) ResourceType() string { return computeAddressTFType }
+
+// Enrich populates ir.Attrs with a typed GoogleComputeAddress payload
+// for the address identified by ir.Identity. Returns
+// ErrEnrichClientUnavailable if EnrichClients.Compute is nil; any
+// other error reflects a real Compute API failure.
+func (e computeAddressEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchTyped(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID is the sibling entry-point for the per-IR refresh path:
+// it accepts a bare Identity (no surrounding ImportedResource) and
+// returns the same json.RawMessage shape Enrich would write into
+// ir.Attrs. A 404 from the compute API is translated to ErrNotFound
+// so callers can distinguish "resource removed since last discover"
+// from a real API failure.
+func (e computeAddressEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("compute_address: nil identity")
+	}
+	return e.fetchTyped(ctx, identity, c)
+}
+
+// fetchTyped is the shared helper between Enrich and EnrichByID. It
+// performs the client-availability check, derives the (project,
+// region, name) triple, fires the SDK call, and marshals the typed
+// payload. Keeping the two entry-points thin around this helper means
+// the two surfaces stay in lockstep — every new validation or error
+// translation lands once.
+func (e computeAddressEnricher) fetchTyped(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.Compute == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if c.ProjectID == "" {
+		return nil, fmt.Errorf("compute_address: EnrichClients.ProjectID required (compute API uses project+region+name positional args)")
+	}
+	region, name := computeAddressRegionAndNameForEnrich(id)
+	if region == "" || name == "" {
+		return nil, fmt.Errorf("compute_address: cannot derive region/name from Identity (Address=%q ImportID=%q Location=%q NameHint=%q NativeIDs.name=%q)",
+			id.Address, id.ImportID, id.Location, id.NameHint, id.NativeIDs["name"])
+	}
+	a, err := e.fetch(ctx, c.Compute, c.ProjectID, region, name)
+	if err != nil {
+		if isComputeNotFound(err) {
+			return nil, fmt.Errorf("compute_address: %s/%s/%s: %w", c.ProjectID, region, name, ErrNotFound)
+		}
+		return nil, fmt.Errorf("compute_address: get %s/%s/%s: %w", c.ProjectID, region, name, err)
+	}
+	typed := mapComputeAddress(a, c.ProjectID, region)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("compute_address: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// computeAddressRegionAndNameForEnrich pulls (region, name) from the
+// Identity. Precedence: NameHint + Location (the canonical fields the
+// discoverer populates), NativeIDs["name"] + NativeIDs["region"]
+// fallback, and finally the ImportID
+// (projects/<p>/regions/<r>/addresses/<n>) parsed as a last resort.
+// Returns ("", "") if no derivation path yields both values — caller
+// surfaces a descriptive error.
+func computeAddressRegionAndNameForEnrich(id *imported.ResourceIdentity) (string, string) {
+	name := id.NameHint
+	if name == "" {
+		name = id.NativeIDs["name"]
+	}
+	region := id.Location
+	if region == "" {
+		region = id.NativeIDs["region"]
+	}
+	if name != "" && region != "" {
+		return region, name
+	}
+	if id.ImportID != "" {
+		r, n, err := computeAddressPartsFromID(id.ImportID)
+		if err == nil {
+			if name == "" {
+				name = n
+			}
+			if region == "" {
+				region = r
+			}
+		}
+	}
+	return region, name
+}
+
+// defaultComputeAddressFetch is the production fetch path: a single
+// Addresses.Get call. Context cancellation is honored via the
+// standard tooling-API ctx wiring.
+func defaultComputeAddressFetch(ctx context.Context, svc *computev1.Service, project, region, name string) (*computev1.Address, error) {
+	return svc.Addresses.Get(project, region, name).Context(ctx).Do()
+}
+
+// isComputeNotFound reports whether err is a googleapi.Error with HTTP
+// 404. The compute API returns a structured *googleapi.Error on every
+// REST call; treating that as the not-found signal keeps the
+// EnrichByID contract precise (ErrNotFound is reserved for confirmed
+// absence — any other 4xx / 5xx falls through to a wrapped error).
+func isComputeNotFound(err error) bool {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return gerr.Code == http.StatusNotFound
+	}
+	return false
+}
+
+// mapComputeAddress converts a *computev1.Address into the typed
+// Layer-1 *generated.GoogleComputeAddress model. Hand-rolled (not
+// enrichgen-emitted) because compute_address is small and has no
+// nested-block fields — the cost/benefit of a 30-line override
+// snippet under cmd/enrichgen exceeds the cost of maintaining this
+// directly. If the field count grows or nested blocks land, migrate
+// to enrichgen and follow the compute_network pattern.
+//
+// Computed-only TF fields skipped per decision #5:
+//
+//	creation_timestamp, effective_labels, id, label_fingerprint,
+//	self_link, terraform_labels, users.
+//
+// Region is taken from the function argument (the value the
+// discoverer already extracted into Identity.Location) rather than
+// parsed from b.Region — that field is a self-link URL the API
+// returns, and re-parsing it here would duplicate the discoverer's
+// extraction work.
+func mapComputeAddress(b *computev1.Address, projectID, region string) *generated.GoogleComputeAddress {
+	out := &generated.GoogleComputeAddress{}
+	if b.Address != "" {
+		out.Address = generated.LiteralOf(b.Address)
+	}
+	if b.AddressType != "" {
+		out.AddressType = generated.LiteralOf(b.AddressType)
+	}
+	if b.Description != "" {
+		out.Description = generated.LiteralOf(b.Description)
+	}
+	if b.IpVersion != "" {
+		out.IpVersion = generated.LiteralOf(b.IpVersion)
+	}
+	if b.Ipv6EndpointType != "" {
+		out.IPV6EndpointType = generated.LiteralOf(b.Ipv6EndpointType)
+	}
+	if len(b.Labels) > 0 {
+		labels := map[string]*generated.Value[string]{}
+		for k, v := range b.Labels {
+			if strings.HasPrefix(k, "goog-") || strings.HasPrefix(k, "goog_") {
+				continue
+			}
+			labels[k] = generated.LiteralOf(v)
+		}
+		if len(labels) > 0 {
+			out.Labels = labels
+		}
+	}
+	if b.Name != "" {
+		out.Name = generated.LiteralOf(b.Name)
+	}
+	if b.Network != "" {
+		out.Network = generated.LiteralOf(b.Network)
+	}
+	if b.NetworkTier != "" {
+		out.NetworkTier = generated.LiteralOf(b.NetworkTier)
+	}
+	if b.PrefixLength != 0 {
+		out.PrefixLength = generated.LiteralOf(float64(b.PrefixLength))
+	}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if b.Purpose != "" {
+		out.Purpose = generated.LiteralOf(b.Purpose)
+	}
+	if region != "" {
+		out.Region = generated.LiteralOf(region)
+	}
+	if b.Subnetwork != "" {
+		out.Subnetwork = generated.LiteralOf(b.Subnetwork)
+	}
+	return out
+}

--- a/cmd/insideout-import/gcpdiscover/compute_address_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/compute_address_enrich_test.go
@@ -1,0 +1,580 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	computev1 "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// TestMapComputeAddress_Minimal pins the smallest non-trivial mapping:
+// only the Name field populated. Every Optional+Computed scalar must
+// stay nil so the generated HCL surface matches "import block fills
+// the computed-only fields on first refresh."
+func TestMapComputeAddress_Minimal(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Address{Name: "lb-ip"}
+	got := mapComputeAddress(src, "my-project", "us-central1")
+
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "lb-ip", *got.Name.Literal)
+	require.NotNil(t, got.Project)
+	assert.Equal(t, "my-project", *got.Project.Literal)
+	require.NotNil(t, got.Region)
+	assert.Equal(t, "us-central1", *got.Region.Literal,
+		"region must come from the argument (the value the discoverer extracted into Identity.Location), not from the b.Region URL")
+
+	// Optional scalars stay nil on a basic address.
+	assert.Nil(t, got.Address)
+	assert.Nil(t, got.AddressType)
+	assert.Nil(t, got.Description)
+	assert.Nil(t, got.IpVersion)
+	assert.Nil(t, got.IPV6EndpointType)
+	assert.Nil(t, got.Labels)
+	assert.Nil(t, got.Network)
+	assert.Nil(t, got.NetworkTier)
+	assert.Nil(t, got.PrefixLength)
+	assert.Nil(t, got.Purpose)
+	assert.Nil(t, got.Subnetwork)
+
+	// Pure computed-only fields must NOT be populated (decision #5).
+	assert.Nil(t, got.CreationTimestamp, "creation_timestamp is computed-only")
+	assert.Nil(t, got.EffectiveLabels, "effective_labels is computed-only")
+	assert.Nil(t, got.ID, "id is computed-only")
+	assert.Nil(t, got.LabelFingerprint, "label_fingerprint is computed-only")
+	assert.Nil(t, got.SelfLink, "self_link is computed-only")
+	assert.Nil(t, got.TerraformLabels, "terraform_labels is computed-only")
+	assert.Empty(t, got.Users, "users is computed-only")
+	assert.Nil(t, got.Timeouts, "timeouts is a TF-only sentinel")
+}
+
+// TestMapComputeAddress_FullyPopulated covers every user-editable
+// field. Includes the int64-to-float64 cast on prefix_length and the
+// goog-managed-label filter.
+func TestMapComputeAddress_FullyPopulated(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Address{
+		Address:          "10.0.0.5",
+		AddressType:      "INTERNAL",
+		Description:      "Internal LB front-end",
+		IpVersion:        "IPV4",
+		Ipv6EndpointType: "",
+		Labels: map[string]string{
+			"team":          "platform",
+			"env":           "prod",
+			"goog-managed":  "true",
+			"goog_internal": "ignore-me",
+		},
+		Name:         "internal-lb-ip",
+		Network:      "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/vpc-prod",
+		NetworkTier:  "PREMIUM",
+		PrefixLength: 29,
+		Purpose:      "GCE_ENDPOINT",
+		Subnetwork:   "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/private",
+	}
+	got := mapComputeAddress(src, "my-project", "us-central1")
+
+	require.NotNil(t, got.Address)
+	assert.Equal(t, "10.0.0.5", *got.Address.Literal)
+	require.NotNil(t, got.AddressType)
+	assert.Equal(t, "INTERNAL", *got.AddressType.Literal)
+	require.NotNil(t, got.Description)
+	assert.Equal(t, "Internal LB front-end", *got.Description.Literal)
+	require.NotNil(t, got.IpVersion)
+	assert.Equal(t, "IPV4", *got.IpVersion.Literal)
+	require.NotNil(t, got.Network)
+	assert.Contains(t, *got.Network.Literal, "vpc-prod")
+	require.NotNil(t, got.NetworkTier)
+	assert.Equal(t, "PREMIUM", *got.NetworkTier.Literal)
+	require.NotNil(t, got.PrefixLength)
+	assert.Equal(t, float64(29), *got.PrefixLength.Literal,
+		"engine must cast int64 API prefix_length to *Value[float64] (the typed schema's chosen shape)")
+	require.NotNil(t, got.Purpose)
+	assert.Equal(t, "GCE_ENDPOINT", *got.Purpose.Literal)
+	require.NotNil(t, got.Subnetwork)
+	assert.Contains(t, *got.Subnetwork.Literal, "private")
+
+	// goog-managed labels stripped, user labels preserved.
+	require.NotNil(t, got.Labels)
+	assert.Len(t, got.Labels, 2, "goog-* and goog_* labels must be filtered out")
+	assert.Equal(t, "platform", *got.Labels["team"].Literal)
+	assert.Equal(t, "prod", *got.Labels["env"].Literal)
+	_, hasGoogManaged := got.Labels["goog-managed"]
+	assert.False(t, hasGoogManaged, "goog- prefix must be stripped")
+	_, hasGoogInternal := got.Labels["goog_internal"]
+	assert.False(t, hasGoogInternal, "goog_ prefix must be stripped")
+}
+
+// TestMapComputeAddress_IPv6EndpointType covers the IPv6-only path
+// since the FullyPopulated case leaves Ipv6EndpointType blank.
+func TestMapComputeAddress_IPv6EndpointType(t *testing.T) {
+	t.Parallel()
+	got := mapComputeAddress(&computev1.Address{
+		Name:             "v6-vm",
+		Ipv6EndpointType: "VM",
+	}, "p", "us-central1")
+	require.NotNil(t, got.IPV6EndpointType)
+	assert.Equal(t, "VM", *got.IPV6EndpointType.Literal)
+}
+
+// TestMapComputeAddress_LabelsAllGoogStripped covers the labels-map-
+// empty-after-filter branch. An address whose labels map contains
+// ONLY goog-managed entries must leave got.Labels nil (not an empty
+// map) so the emit layer can omit the attribute entirely.
+func TestMapComputeAddress_LabelsAllGoogStripped(t *testing.T) {
+	t.Parallel()
+	got := mapComputeAddress(&computev1.Address{
+		Name:   "n",
+		Labels: map[string]string{"goog-managed": "true"},
+	}, "p", "r")
+	assert.Nil(t, got.Labels, "all-goog map must collapse to nil so the emit layer omits the attribute")
+}
+
+// TestComputeAddressRegionAndNameForEnrich_Precedence pins the
+// precedence chain in derivation. NameHint+Location win over
+// NativeIDs win over ImportID parsing.
+func TestComputeAddressRegionAndNameForEnrich_Precedence(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		desc       string
+		id         imported.ResourceIdentity
+		wantRegion string
+		wantName   string
+	}{
+		{
+			desc: "NameHint+Location_preferred",
+			id: imported.ResourceIdentity{
+				NameHint:  "lb-ip",
+				Location:  "us-central1",
+				NativeIDs: map[string]string{"name": "stale", "region": "us-east1"},
+				ImportID:  "projects/p/regions/europe-west1/addresses/older",
+			},
+			wantRegion: "us-central1",
+			wantName:   "lb-ip",
+		},
+		{
+			desc: "NativeIDs_fallback_when_canonical_empty",
+			id: imported.ResourceIdentity{
+				NativeIDs: map[string]string{"name": "lb-ip", "region": "us-central1"},
+			},
+			wantRegion: "us-central1",
+			wantName:   "lb-ip",
+		},
+		{
+			desc: "ImportID_last_resort",
+			id: imported.ResourceIdentity{
+				ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+			},
+			wantRegion: "us-central1",
+			wantName:   "lb-ip",
+		},
+		{
+			desc: "ImportID_fills_only_missing_slot",
+			id: imported.ResourceIdentity{
+				NameHint: "lb-ip",
+				ImportID: "projects/p/regions/us-central1/addresses/other-name",
+			},
+			wantRegion: "us-central1",
+			wantName:   "lb-ip",
+		},
+		{
+			desc:       "all_empty_yields_empty",
+			id:         imported.ResourceIdentity{},
+			wantRegion: "",
+			wantName:   "",
+		},
+		{
+			desc: "global_importid_rejected_by_parts_parser",
+			id: imported.ResourceIdentity{
+				ImportID: "projects/p/global/addresses/global-ip",
+			},
+			wantRegion: "",
+			wantName:   "",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			gotRegion, gotName := computeAddressRegionAndNameForEnrich(&tc.id)
+			assert.Equal(t, tc.wantRegion, gotRegion)
+			assert.Equal(t, tc.wantName, gotName)
+		})
+	}
+}
+
+// TestComputeAddressEnrich_ClientUnavailable: nil Compute client must
+// return ErrEnrichClientUnavailable; ir.Attrs must remain empty so
+// the orchestrator can downgrade to a per-resource warn.
+func TestComputeAddressEnrich_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newComputeAddressEnricher()
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "google_compute_address",
+			ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+			Address:  "google_compute_address.lb_ip",
+			Location: "us-central1",
+			NameHint: "lb-ip",
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: nil, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Empty(t, ir.Attrs)
+}
+
+// TestComputeAddressEnrich_ProjectIDRequired pins the compute-API
+// quirk: Addresses.Get is positional (project, region, name), not a
+// single fully-qualified name, so ProjectID on EnrichClients is
+// structurally required even when Identity.ImportID encodes the
+// project.
+func TestComputeAddressEnrich_ProjectIDRequired(t *testing.T) {
+	t.Parallel()
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Address, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "google_compute_address",
+			ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+			Location: "us-central1",
+			NameHint: "lb-ip",
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "EnrichClients.ProjectID required")
+}
+
+// TestComputeAddressEnrich_RegionOrNameMissing covers the
+// undeducible-Identity branch. The error must mention every input
+// slot it consulted so a UI consumer can patch the right field.
+func TestComputeAddressEnrich_RegionOrNameMissing(t *testing.T) {
+	t.Parallel()
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Address, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "google_compute_address"},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive region/name")
+}
+
+// TestComputeAddressEnrich_FetchError pins the wrap shape on a real
+// API error (something other than 404). The wrapped error must carry
+// the (project/region/name) triple for triage and wrap the underlying
+// error so callers can errors.Is into the SDK error type.
+func TestComputeAddressEnrich_FetchError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("403 forbidden")
+	var gotProject, gotRegion, gotName string
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, project, region, name string) (*computev1.Address, error) {
+			gotProject, gotRegion, gotName = project, region, name
+			return nil, wantErr
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "google_compute_address",
+			ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+			Address:  "google_compute_address.lb_ip",
+			Location: "us-central1",
+			NameHint: "lb-ip",
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), "my-project/us-central1/lb-ip")
+	assert.Equal(t, "my-project", gotProject, "fetch must receive ProjectID from EnrichClients, not from Identity")
+	assert.Equal(t, "us-central1", gotRegion)
+	assert.Equal(t, "lb-ip", gotName)
+}
+
+// TestComputeAddressEnrich_PopulatesAttrs is the happy-path end-to-
+// end check: fake fetch returns a fully-populated Address, the
+// enricher writes typed JSON into ir.Attrs, and a UnmarshalAttrs
+// round-trip reproduces the field values.
+func TestComputeAddressEnrich_PopulatesAttrs(t *testing.T) {
+	t.Parallel()
+	addr := &computev1.Address{
+		Address:      "10.0.0.5",
+		AddressType:  "INTERNAL",
+		Description:  "Internal LB",
+		Name:         "lb-ip",
+		NetworkTier:  "PREMIUM",
+		PrefixLength: 29,
+		Purpose:      "GCE_ENDPOINT",
+		Subnetwork:   "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/private",
+	}
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, project, region, name string) (*computev1.Address, error) {
+			assert.Equal(t, "my-project", project)
+			assert.Equal(t, "us-central1", region)
+			assert.Equal(t, "lb-ip", name)
+			return addr, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "google_compute_address",
+			ImportID: "projects/my-project/regions/us-central1/addresses/lb-ip",
+			Address:  "google_compute_address.lb_ip",
+			Location: "us-central1",
+			NameHint: "lb-ip",
+		},
+	}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"}))
+
+	decoded, err := generated.UnmarshalAttrs("google_compute_address", ir.Attrs)
+	require.NoError(t, err)
+	ca, ok := decoded.(*generated.GoogleComputeAddress)
+	require.True(t, ok)
+	require.NotNil(t, ca.Name)
+	assert.Equal(t, "lb-ip", *ca.Name.Literal)
+	require.NotNil(t, ca.AddressType)
+	assert.Equal(t, "INTERNAL", *ca.AddressType.Literal)
+	require.NotNil(t, ca.PrefixLength)
+	assert.Equal(t, float64(29), *ca.PrefixLength.Literal)
+	require.NotNil(t, ca.Region)
+	assert.Equal(t, "us-central1", *ca.Region.Literal)
+}
+
+// TestComputeAddressEnrich_RoundTripThroughEmitImportedTF — decision-
+// #34 contract. Critical assertions: every populated field appears at
+// the top level (no nested-block emission for compute_address), and
+// the computed-only fields stay absent from the emitted HCL.
+func TestComputeAddressEnrich_RoundTripThroughEmitImportedTF(t *testing.T) {
+	t.Parallel()
+	addr := &computev1.Address{
+		Address:      "10.0.0.5",
+		AddressType:  "INTERNAL",
+		Description:  "Internal LB",
+		Name:         "lb-ip",
+		NetworkTier:  "PREMIUM",
+		PrefixLength: 29,
+		Purpose:      "GCE_ENDPOINT",
+		Subnetwork:   "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/private",
+	}
+	typed := mapComputeAddress(addr, "my-project", "us-central1")
+	raw, err := json.Marshal(typed)
+	require.NoError(t, err)
+
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "gcp", Type: "google_compute_address",
+			Address:  "google_compute_address.lb_ip",
+			ImportID: "projects/my-project/regions/us-central1/addresses/lb-ip",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: raw,
+	}
+	out, used := composer.EmitImportedTF("gcp", []imported.ImportedResource{ir}, composer.EmitImportedOpts{})
+	require.NotNil(t, out)
+	require.True(t, used["gcp"])
+	s := string(out)
+
+	assert.Contains(t, s, `resource "google_compute_address" "lb_ip"`)
+	assert.Regexp(t, `(?m)^\s*name\s+=\s+"lb-ip"`, s)
+	assert.Regexp(t, `(?m)^\s*project\s+=\s+"my-project"`, s)
+	assert.Regexp(t, `(?m)^\s*region\s+=\s+"us-central1"`, s)
+	assert.Regexp(t, `(?m)^\s*address\s+=\s+"10\.0\.0\.5"`, s)
+	assert.Regexp(t, `(?m)^\s*address_type\s+=\s+"INTERNAL"`, s)
+	assert.Regexp(t, `(?m)^\s*network_tier\s+=\s+"PREMIUM"`, s)
+	assert.Regexp(t, `(?m)^\s*purpose\s+=\s+"GCE_ENDPOINT"`, s)
+	assert.Regexp(t, `(?m)^\s*prefix_length\s+=\s+29`, s)
+
+	// Computed-only fields must NOT appear in emitted HCL.
+	for _, computed := range []string{"creation_timestamp", "label_fingerprint", "self_link", "effective_labels", "terraform_labels"} {
+		assert.NotContains(t, s, computed, "computed-only field %q must not appear", computed)
+	}
+}
+
+// ---------------------------------------------------------------
+// ByIDEnricher tests.
+// ---------------------------------------------------------------
+
+// TestComputeAddressEnrichByID_NilIdentity confirms the EnrichByID
+// surface gives a clean error on a nil identity (the dispatcher in
+// pkg/imported should never call with nil, but a defensive check
+// keeps the failure mode obvious if it does).
+func TestComputeAddressEnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newComputeAddressEnricher().(*computeAddressEnricher)
+	raw, err := e.EnrichByID(context.Background(), nil, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Nil(t, raw)
+	assert.Contains(t, err.Error(), "nil identity")
+}
+
+// TestComputeAddressEnrichByID_ClientUnavailable mirrors the Enrich
+// equivalent: the by-ID surface must report the same sentinel so the
+// per-IR refresh dispatcher can distinguish "not configured" from a
+// real API error.
+func TestComputeAddressEnrichByID_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newComputeAddressEnricher().(*computeAddressEnricher)
+	id := &imported.ResourceIdentity{
+		Type: "google_compute_address", NameHint: "lb-ip", Location: "us-central1",
+		ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+	}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{Compute: nil, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Nil(t, raw)
+}
+
+// TestComputeAddressEnrichByID_NotFound pins the 404-to-ErrNotFound
+// translation. The compute API surfaces a *googleapi.Error with
+// Code = 404 on a deleted-since-discover row; per the ByIDEnricher
+// contract that must become ErrNotFound so the caller can prune the
+// row from its UI without surfacing an alarming "API error".
+func TestComputeAddressEnrichByID_NotFound(t *testing.T) {
+	t.Parallel()
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Address, error) {
+			return nil, &googleapi.Error{Code: http.StatusNotFound, Message: "not found"}
+		},
+	}
+	id := &imported.ResourceIdentity{
+		Type: "google_compute_address", NameHint: "lb-ip", Location: "us-central1",
+		ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+	}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrNotFound)
+	assert.Nil(t, raw)
+}
+
+// TestComputeAddressEnrichByID_NonNotFoundErrorPassesThrough — a
+// non-404 googleapi error (e.g. 500 or 403) MUST NOT be confused
+// with ErrNotFound. The wrapper passes the original error through so
+// the caller can errors.As back to *googleapi.Error if it cares.
+func TestComputeAddressEnrichByID_NonNotFoundErrorPassesThrough(t *testing.T) {
+	t.Parallel()
+	upstream := &googleapi.Error{Code: http.StatusForbidden, Message: "denied"}
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Address, error) {
+			return nil, upstream
+		},
+	}
+	id := &imported.ResourceIdentity{
+		Type: "google_compute_address", NameHint: "lb-ip", Location: "us-central1",
+		ImportID: "projects/p/regions/us-central1/addresses/lb-ip",
+	}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound, "403 must NOT be classified as ErrNotFound")
+	var gerr *googleapi.Error
+	require.True(t, errors.As(err, &gerr), "underlying googleapi.Error must be preserved for caller inspection")
+	assert.Equal(t, http.StatusForbidden, gerr.Code)
+	assert.Nil(t, raw)
+}
+
+// TestComputeAddressEnrichByID_HappyPath confirms EnrichByID returns
+// the exact JSON shape Enrich would have written into ir.Attrs.
+// Pin via byte-equality so a future divergence between the two
+// entry-points is caught loud.
+func TestComputeAddressEnrichByID_HappyPath(t *testing.T) {
+	t.Parallel()
+	addr := &computev1.Address{
+		Address:     "10.0.0.5",
+		AddressType: "INTERNAL",
+		Name:        "lb-ip",
+		Purpose:     "GCE_ENDPOINT",
+	}
+	mkFetch := func() func(context.Context, *computev1.Service, string, string, string) (*computev1.Address, error) {
+		return func(_ context.Context, _ *computev1.Service, project, region, name string) (*computev1.Address, error) {
+			assert.Equal(t, "my-project", project)
+			assert.Equal(t, "us-central1", region)
+			assert.Equal(t, "lb-ip", name)
+			return addr, nil
+		}
+	}
+	enrichEnr := computeAddressEnricher{fetch: mkFetch()}
+	byIDEnr := computeAddressEnricher{fetch: mkFetch()}
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "google_compute_address",
+			ImportID: "projects/my-project/regions/us-central1/addresses/lb-ip",
+			Address:  "google_compute_address.lb_ip",
+			Location: "us-central1",
+			NameHint: "lb-ip",
+		},
+	}
+	require.NoError(t, enrichEnr.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"}))
+
+	id := &imported.ResourceIdentity{
+		Type:     "google_compute_address",
+		ImportID: "projects/my-project/regions/us-central1/addresses/lb-ip",
+		Address:  "google_compute_address.lb_ip",
+		Location: "us-central1",
+		NameHint: "lb-ip",
+	}
+	raw, err := byIDEnr.EnrichByID(context.Background(), id, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.NoError(t, err)
+	assert.JSONEq(t, string(ir.Attrs), string(raw),
+		"EnrichByID must return the same JSON shape Enrich writes into ir.Attrs")
+}
+
+// TestComputeAddressEnrichByID_DerivesFromImportIDOnly confirms the
+// caller can pass an Identity that only carries ImportID (the
+// pkg/imported.Provider refresh path can construct one from a TF
+// address alone) and the enricher still derives (region, name).
+func TestComputeAddressEnrichByID_DerivesFromImportIDOnly(t *testing.T) {
+	t.Parallel()
+	var gotRegion, gotName string
+	e := computeAddressEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, region, name string) (*computev1.Address, error) {
+			gotRegion, gotName = region, name
+			return &computev1.Address{Name: name}, nil
+		},
+	}
+	id := &imported.ResourceIdentity{
+		Type:     "google_compute_address",
+		ImportID: "projects/my-project/regions/europe-west4/addresses/eu-lb-ip",
+	}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.NoError(t, err)
+	assert.NotNil(t, raw)
+	assert.Equal(t, "europe-west4", gotRegion)
+	assert.Equal(t, "eu-lb-ip", gotName)
+}
+
+// TestIsComputeNotFound_Predicate is a direct unit on the helper so a
+// future change to its error-classification logic (e.g. accepting
+// gRPC NotFound too) doesn't have to be inferred from a fetch-level
+// integration test.
+func TestIsComputeNotFound_Predicate(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		desc string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain_error", errors.New("boom"), false},
+		{"googleapi_404", &googleapi.Error{Code: http.StatusNotFound}, true},
+		{"googleapi_403", &googleapi.Error{Code: http.StatusForbidden}, false},
+		{"googleapi_500", &googleapi.Error{Code: http.StatusInternalServerError}, false},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			assert.Equal(t, tc.want, isComputeNotFound(tc.err))
+		})
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/compute_firewall_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/compute_firewall_enrich.go
@@ -1,0 +1,244 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	computev1 "google.golang.org/api/compute/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// computeFirewallEnricher implements AttributeEnricher and ByIDEnricher
+// for google_compute_firewall. Pairs with computeFirewallDiscoverer.
+//
+// Hand-rolled (no .gen.go partner) because the firewall API surface
+// is small, the Allow/Deny nested-block conversion is straightforward,
+// and the SDK→TF field renames (Allowed→Allow, Denied→Deny,
+// IPProtocol→Protocol, LogConfig.Enable→top-level EnableLogging) are
+// all one-off translations that don't justify dragging the codegen
+// scaffolding in.
+//
+// Compute API quirk — same as compute_network: Firewalls.Get takes
+// (project, name) as two positional arguments, not a single
+// fully-qualified resource name. The enricher derives the short
+// firewall name from the Identity and pairs it with
+// EnrichClients.ProjectID.
+//
+// EnableLogging vs LogConfig: the TF resource exposes both a top-level
+// `enable_logging` attribute and a `log_config { metadata = ... }`
+// nested block. The SDK collapses both into FirewallLogConfig.Enable
+// (bool) + FirewallLogConfig.Metadata (string), so the enricher splits
+// them back apart on the way out.
+type computeFirewallEnricher struct {
+	fetch func(ctx context.Context, svc *computev1.Service, project, name string) (*computev1.Firewall, error)
+}
+
+func newComputeFirewallEnricher() AttributeEnricher {
+	return &computeFirewallEnricher{fetch: defaultComputeFirewallFetch}
+}
+
+func (computeFirewallEnricher) ResourceType() string { return computeFirewallTFType }
+
+// Enrich populates ir.Attrs with a typed GoogleComputeFirewall payload.
+// Returns ErrEnrichClientUnavailable if EnrichClients.Compute is nil;
+// any other error reflects a real Compute API failure.
+func (e computeFirewallEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchAndMap(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID fetches a single firewall by Identity and returns the
+// typed payload as json.RawMessage. Same shared fetch+map helper as
+// Enrich; differs only in how the result is packaged.
+func (e computeFirewallEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("compute_firewall: nil Identity")
+	}
+	return e.fetchAndMap(ctx, identity, c)
+}
+
+// fetchAndMap is the shared body for Enrich + EnrichByID. Validates
+// the clients, derives the firewall name, calls the SDK, and marshals
+// the typed payload. Centralizes error wrapping so the two entry
+// points stay in lockstep.
+func (e computeFirewallEnricher) fetchAndMap(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.Compute == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if c.ProjectID == "" {
+		return nil, fmt.Errorf("compute_firewall: EnrichClients.ProjectID required (compute API uses project+name positional args)")
+	}
+	name := computeFirewallShortNameForEnrich(id)
+	if name == "" {
+		return nil, fmt.Errorf("compute_firewall: cannot derive firewall name from Identity (Address=%q ImportID=%q NativeIDs.name=%q NativeIDs.asset_name=%q)",
+			id.Address, id.ImportID, id.NativeIDs["name"], id.NativeIDs["asset_name"])
+	}
+	fw, err := e.fetch(ctx, c.Compute, c.ProjectID, name)
+	if err != nil {
+		return nil, fmt.Errorf("compute_firewall: get %s/%s: %w", c.ProjectID, name, err)
+	}
+	typed := mapComputeFirewall(fw, c.ProjectID)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("compute_firewall: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// computeFirewallShortNameForEnrich extracts the short firewall name
+// from the Identity. Precedence: NameHint, NativeIDs["name"],
+// NativeIDs["asset_name"], ImportID. computeFirewallNameFromID
+// (compute_firewall.go) already handles every accepted shape.
+func computeFirewallShortNameForEnrich(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if n := id.NameHint; n != "" {
+		return n
+	}
+	if n := id.NativeIDs["name"]; n != "" {
+		return n
+	}
+	if asset := id.NativeIDs["asset_name"]; asset != "" {
+		if name, err := computeFirewallNameFromID(asset); err == nil {
+			return name
+		}
+	}
+	if id.ImportID != "" {
+		if name, err := computeFirewallNameFromID(id.ImportID); err == nil {
+			return name
+		}
+	}
+	return ""
+}
+
+func defaultComputeFirewallFetch(ctx context.Context, svc *computev1.Service, project, name string) (*computev1.Firewall, error) {
+	return svc.Firewalls.Get(project, name).Context(ctx).Do()
+}
+
+// mapComputeFirewall converts the raw SDK Firewall struct into the
+// typed Layer-1 GoogleComputeFirewall model. Decision-#5 computed-only
+// fields (creation_timestamp, self_link, id) are populated for round-
+// trip parity with the SDK response — the emit layer drops them when
+// they're tagged Computed=true in the schema.
+func mapComputeFirewall(b *computev1.Firewall, projectID string) *generated.GoogleComputeFirewall {
+	out := &generated.GoogleComputeFirewall{}
+
+	if b.Name != "" {
+		out.Name = generated.LiteralOf(b.Name)
+	}
+	if b.Network != "" {
+		out.Network = generated.LiteralOf(b.Network)
+	}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if b.Description != "" {
+		out.Description = generated.LiteralOf(b.Description)
+	}
+	if b.Direction != "" {
+		out.Direction = generated.LiteralOf(b.Direction)
+	}
+	if b.Priority != 0 {
+		out.Priority = generated.LiteralOf(float64(b.Priority))
+	}
+	if b.Disabled {
+		out.Disabled = generated.LiteralOf(b.Disabled)
+	}
+
+	if len(b.SourceRanges) > 0 {
+		out.SourceRanges = stringSliceToValues(b.SourceRanges)
+	}
+	if len(b.DestinationRanges) > 0 {
+		out.DestinationRanges = stringSliceToValues(b.DestinationRanges)
+	}
+	if len(b.SourceTags) > 0 {
+		out.SourceTags = stringSliceToValues(b.SourceTags)
+	}
+	if len(b.TargetTags) > 0 {
+		out.TargetTags = stringSliceToValues(b.TargetTags)
+	}
+	if len(b.SourceServiceAccounts) > 0 {
+		out.SourceServiceAccounts = stringSliceToValues(b.SourceServiceAccounts)
+	}
+	if len(b.TargetServiceAccounts) > 0 {
+		out.TargetServiceAccounts = stringSliceToValues(b.TargetServiceAccounts)
+	}
+
+	// Computed-only fields: populated for round-trip parity; the emit
+	// layer drops them based on schema Computed=true.
+	if b.CreationTimestamp != "" {
+		out.CreationTimestamp = generated.LiteralOf(b.CreationTimestamp)
+	}
+	if b.SelfLink != "" {
+		out.SelfLink = generated.LiteralOf(b.SelfLink)
+	}
+
+	if len(b.Allowed) > 0 {
+		out.Allow = make([]generated.GoogleComputeFirewallAllow, 0, len(b.Allowed))
+		for _, a := range b.Allowed {
+			if a == nil {
+				continue
+			}
+			out.Allow = append(out.Allow, mapComputeFirewallAllow(a))
+		}
+	}
+	if len(b.Denied) > 0 {
+		out.Deny = make([]generated.GoogleComputeFirewallDeny, 0, len(b.Denied))
+		for _, d := range b.Denied {
+			if d == nil {
+				continue
+			}
+			out.Deny = append(out.Deny, mapComputeFirewallDeny(d))
+		}
+	}
+
+	if b.LogConfig != nil {
+		// LogConfig.Enable lives on the top-level TF attribute
+		// `enable_logging` (not nested under log_config in the typed
+		// schema), so split it out here.
+		if b.LogConfig.Enable {
+			out.EnableLogging = generated.LiteralOf(b.LogConfig.Enable)
+		}
+		// Emit the nested block only when there's something to put in
+		// it. An all-default LogConfig (Enable=false, Metadata="")
+		// would render as an empty `log_config {}` block, which the
+		// provider permits but is noise.
+		if b.LogConfig.Metadata != "" {
+			out.LogConfig = []generated.GoogleComputeFirewallLogConfig{{
+				Metadata: generated.LiteralOf(b.LogConfig.Metadata),
+			}}
+		}
+	}
+
+	return out
+}
+
+func mapComputeFirewallAllow(a *computev1.FirewallAllowed) generated.GoogleComputeFirewallAllow {
+	out := generated.GoogleComputeFirewallAllow{}
+	if a.IPProtocol != "" {
+		out.Protocol = generated.LiteralOf(a.IPProtocol)
+	}
+	if len(a.Ports) > 0 {
+		out.Ports = stringSliceToValues(a.Ports)
+	}
+	return out
+}
+
+func mapComputeFirewallDeny(d *computev1.FirewallDenied) generated.GoogleComputeFirewallDeny {
+	out := generated.GoogleComputeFirewallDeny{}
+	if d.IPProtocol != "" {
+		out.Protocol = generated.LiteralOf(d.IPProtocol)
+	}
+	if len(d.Ports) > 0 {
+		out.Ports = stringSliceToValues(d.Ports)
+	}
+	return out
+}

--- a/cmd/insideout-import/gcpdiscover/compute_firewall_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/compute_firewall_enrich_test.go
@@ -1,0 +1,512 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	computev1 "google.golang.org/api/compute/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// compile-time: the enricher must satisfy BOTH interfaces.
+var (
+	_ AttributeEnricher = (*computeFirewallEnricher)(nil)
+	_ ByIDEnricher      = (*computeFirewallEnricher)(nil)
+)
+
+// firewallIdentity is the standard Identity used by happy-path tests
+// in this file. Mirrors what computeFirewallDiscoverer.FromAsset would
+// produce.
+func firewallIdentity() imported.ResourceIdentity {
+	return imported.ResourceIdentity{
+		Cloud:    "gcp",
+		Type:     "google_compute_firewall",
+		NameHint: "allow-ssh",
+		Address:  "google_compute_firewall.allow_ssh",
+		ImportID: "projects/my-project/global/firewalls/allow-ssh",
+		NativeIDs: map[string]string{
+			"name":       "allow-ssh",
+			"asset_name": "//compute.googleapis.com/projects/my-project/global/firewalls/allow-ssh",
+			"self_link":  "https://www.googleapis.com/compute/v1/projects/my-project/global/firewalls/allow-ssh",
+		},
+	}
+}
+
+// TestMapComputeFirewall_Minimal pins the smallest non-trivial shape:
+// name + network only, with everything else absent.
+func TestMapComputeFirewall_Minimal(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:    "allow-ssh",
+		Network: "projects/my-project/global/networks/default",
+	}
+	got := mapComputeFirewall(src, "my-project")
+
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "allow-ssh", *got.Name.Literal)
+	require.NotNil(t, got.Network)
+	assert.Equal(t, "projects/my-project/global/networks/default", *got.Network.Literal)
+	require.NotNil(t, got.Project)
+	assert.Equal(t, "my-project", *got.Project.Literal)
+
+	// All other fields untouched.
+	assert.Nil(t, got.Description)
+	assert.Nil(t, got.Direction)
+	assert.Nil(t, got.Priority)
+	assert.Nil(t, got.Disabled)
+	assert.Nil(t, got.SourceRanges)
+	assert.Nil(t, got.DestinationRanges)
+	assert.Nil(t, got.SourceTags)
+	assert.Nil(t, got.TargetTags)
+	assert.Nil(t, got.SourceServiceAccounts)
+	assert.Nil(t, got.TargetServiceAccounts)
+	assert.Empty(t, got.Allow)
+	assert.Empty(t, got.Deny)
+	assert.Empty(t, got.LogConfig)
+	assert.Nil(t, got.EnableLogging)
+	assert.Nil(t, got.CreationTimestamp)
+	assert.Nil(t, got.SelfLink)
+	assert.Nil(t, got.Timeouts)
+}
+
+// TestMapComputeFirewall_AllowOnly covers a typical ingress allow rule
+// (the most common firewall shape).
+func TestMapComputeFirewall_AllowOnly(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:         "allow-ssh",
+		Network:      "global/networks/default",
+		Direction:    "INGRESS",
+		Priority:     1000,
+		SourceRanges: []string{"0.0.0.0/0"},
+		TargetTags:   []string{"ssh-allowed"},
+		Allowed: []*computev1.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"22"}},
+		},
+	}
+	got := mapComputeFirewall(src, "my-project")
+
+	require.NotNil(t, got.Direction)
+	assert.Equal(t, "INGRESS", *got.Direction.Literal)
+	require.NotNil(t, got.Priority)
+	assert.Equal(t, float64(1000), *got.Priority.Literal,
+		"engine must cast int64 API priority to *Value[float64] (the typed schema's chosen shape)")
+	require.Len(t, got.SourceRanges, 1)
+	assert.Equal(t, "0.0.0.0/0", *got.SourceRanges[0].Literal)
+	require.Len(t, got.TargetTags, 1)
+	assert.Equal(t, "ssh-allowed", *got.TargetTags[0].Literal)
+
+	require.Len(t, got.Allow, 1)
+	require.NotNil(t, got.Allow[0].Protocol)
+	assert.Equal(t, "tcp", *got.Allow[0].Protocol.Literal,
+		"FirewallAllowed.IPProtocol must map to Allow.Protocol (TF rename)")
+	require.Len(t, got.Allow[0].Ports, 1)
+	assert.Equal(t, "22", *got.Allow[0].Ports[0].Literal)
+	assert.Empty(t, got.Deny, "deny block must stay empty when no Denied rules")
+}
+
+// TestMapComputeFirewall_DenyOnly covers a deny rule + EGRESS
+// direction + destination_ranges (the inverse-of-allow flow).
+func TestMapComputeFirewall_DenyOnly(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:              "deny-egress-bad-ip",
+		Network:           "global/networks/default",
+		Direction:         "EGRESS",
+		Priority:          500,
+		DestinationRanges: []string{"10.0.0.0/8", "192.168.0.0/16"},
+		Denied: []*computev1.FirewallDenied{
+			{IPProtocol: "all"},
+		},
+	}
+	got := mapComputeFirewall(src, "my-project")
+
+	require.NotNil(t, got.Direction)
+	assert.Equal(t, "EGRESS", *got.Direction.Literal)
+	require.Len(t, got.DestinationRanges, 2)
+	assert.Equal(t, "10.0.0.0/8", *got.DestinationRanges[0].Literal)
+	assert.Equal(t, "192.168.0.0/16", *got.DestinationRanges[1].Literal)
+
+	assert.Empty(t, got.Allow, "allow block must stay empty when no Allowed rules")
+	require.Len(t, got.Deny, 1)
+	require.NotNil(t, got.Deny[0].Protocol)
+	assert.Equal(t, "all", *got.Deny[0].Protocol.Literal)
+	assert.Nil(t, got.Deny[0].Ports, "Deny.Ports must be nil when SDK Ports is empty")
+}
+
+// TestMapComputeFirewall_MixedAllowDeny exercises the multi-rule
+// translation: 2 allow rules + 1 deny rule, each with multiple ports.
+func TestMapComputeFirewall_MixedAllowDeny(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:    "mixed-fw",
+		Network: "global/networks/default",
+		Allowed: []*computev1.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+			{IPProtocol: "udp", Ports: []string{"53"}},
+		},
+		Denied: []*computev1.FirewallDenied{
+			{IPProtocol: "icmp"},
+		},
+	}
+	got := mapComputeFirewall(src, "my-project")
+
+	require.Len(t, got.Allow, 2)
+	assert.Equal(t, "tcp", *got.Allow[0].Protocol.Literal)
+	require.Len(t, got.Allow[0].Ports, 2)
+	assert.Equal(t, "80", *got.Allow[0].Ports[0].Literal)
+	assert.Equal(t, "443", *got.Allow[0].Ports[1].Literal)
+	assert.Equal(t, "udp", *got.Allow[1].Protocol.Literal)
+	require.Len(t, got.Allow[1].Ports, 1)
+	assert.Equal(t, "53", *got.Allow[1].Ports[0].Literal)
+
+	require.Len(t, got.Deny, 1)
+	assert.Equal(t, "icmp", *got.Deny[0].Protocol.Literal)
+}
+
+// TestMapComputeFirewall_LogConfigEnabled pins the LogConfig split:
+// FirewallLogConfig.Enable becomes top-level EnableLogging;
+// FirewallLogConfig.Metadata becomes a log_config{} block.
+func TestMapComputeFirewall_LogConfigEnabled(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:    "audit-fw",
+		Network: "global/networks/default",
+		LogConfig: &computev1.FirewallLogConfig{
+			Enable:   true,
+			Metadata: "INCLUDE_ALL_METADATA",
+		},
+	}
+	got := mapComputeFirewall(src, "my-project")
+
+	require.NotNil(t, got.EnableLogging,
+		"FirewallLogConfig.Enable must become top-level enable_logging (not nested under log_config)")
+	assert.True(t, *got.EnableLogging.Literal)
+	require.Len(t, got.LogConfig, 1)
+	require.NotNil(t, got.LogConfig[0].Metadata)
+	assert.Equal(t, "INCLUDE_ALL_METADATA", *got.LogConfig[0].Metadata.Literal)
+}
+
+// TestMapComputeFirewall_LogConfigAbsent confirms the EnableLogging /
+// LogConfig fields stay nil when the API returns no LogConfig at all.
+func TestMapComputeFirewall_LogConfigAbsent(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:    "no-log-fw",
+		Network: "global/networks/default",
+	}
+	got := mapComputeFirewall(src, "my-project")
+	assert.Nil(t, got.EnableLogging)
+	assert.Empty(t, got.LogConfig)
+}
+
+// TestMapComputeFirewall_LogConfigEnableOnly covers an enable-only
+// LogConfig (no metadata). The TF top-level attr must populate, but the
+// nested block stays empty — emitting `log_config {}` with all defaults
+// is noise.
+func TestMapComputeFirewall_LogConfigEnableOnly(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:      "enable-only-fw",
+		Network:   "global/networks/default",
+		LogConfig: &computev1.FirewallLogConfig{Enable: true},
+	}
+	got := mapComputeFirewall(src, "my-project")
+	require.NotNil(t, got.EnableLogging)
+	assert.True(t, *got.EnableLogging.Literal)
+	assert.Empty(t, got.LogConfig, "no Metadata → no log_config{} block")
+}
+
+// TestMapComputeFirewall_ComputedRoundTrip populates computed-only
+// fields (creation_timestamp, self_link) on the typed struct. The emit
+// layer is responsible for dropping them based on Computed=true in
+// GoogleComputeFirewallSchema.
+func TestMapComputeFirewall_ComputedRoundTrip(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Firewall{
+		Name:              "fw",
+		Network:           "global/networks/default",
+		CreationTimestamp: "2024-01-02T03:04:05Z",
+		SelfLink:          "https://www.googleapis.com/compute/v1/projects/p/global/firewalls/fw",
+	}
+	got := mapComputeFirewall(src, "p")
+	require.NotNil(t, got.CreationTimestamp)
+	assert.Equal(t, "2024-01-02T03:04:05Z", *got.CreationTimestamp.Literal)
+	require.NotNil(t, got.SelfLink)
+	assert.Contains(t, *got.SelfLink.Literal, "/firewalls/fw")
+}
+
+// Enricher contract tests --------------------------------------------
+
+func TestComputeFirewallEnrich_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newComputeFirewallEnricher()
+	ir := &imported.ImportedResource{Identity: firewallIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: nil})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Empty(t, ir.Attrs)
+}
+
+// TestComputeFirewallEnrichByID_ClientUnavailable mirrors the
+// AttributeEnricher contract on the ByID entry point.
+func TestComputeFirewallEnrichByID_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newComputeFirewallEnricher().(ByIDEnricher)
+	id := firewallIdentity()
+	raw, err := e.EnrichByID(context.Background(), &id, EnrichClients{Compute: nil})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Nil(t, raw)
+}
+
+func TestComputeFirewallEnrich_ProjectIDRequired(t *testing.T) {
+	t.Parallel()
+	e := computeFirewallEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _ string) (*computev1.Firewall, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: firewallIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "EnrichClients.ProjectID required")
+}
+
+func TestComputeFirewallEnrich_NameMissing(t *testing.T) {
+	t.Parallel()
+	e := computeFirewallEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _ string) (*computev1.Firewall, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "google_compute_firewall"},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive firewall name")
+}
+
+func TestComputeFirewallEnrich_FetchError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("404 not found")
+	var gotProject, gotName string
+	e := computeFirewallEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, project, name string) (*computev1.Firewall, error) {
+			gotProject, gotName = project, name
+			return nil, wantErr
+		},
+	}
+	ir := &imported.ImportedResource{Identity: firewallIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), "my-project/allow-ssh")
+	assert.Equal(t, "my-project", gotProject, "fetch must receive ProjectID from EnrichClients, not Identity")
+	assert.Equal(t, "allow-ssh", gotName)
+}
+
+// TestComputeFirewallEnrich_PopulatesAttrs is the happy path: a
+// mixed-rule firewall flows through Enrich and decodes cleanly via
+// generated.UnmarshalAttrs.
+func TestComputeFirewallEnrich_PopulatesAttrs(t *testing.T) {
+	t.Parallel()
+	fw := &computev1.Firewall{
+		Name:         "allow-ssh",
+		Network:      "projects/my-project/global/networks/default",
+		Direction:    "INGRESS",
+		Priority:     1000,
+		SourceRanges: []string{"0.0.0.0/0"},
+		TargetTags:   []string{"ssh-allowed"},
+		Allowed: []*computev1.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"22"}},
+		},
+		LogConfig: &computev1.FirewallLogConfig{Enable: true, Metadata: "INCLUDE_ALL_METADATA"},
+	}
+	e := computeFirewallEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, project, name string) (*computev1.Firewall, error) {
+			assert.Equal(t, "my-project", project)
+			assert.Equal(t, "allow-ssh", name)
+			return fw, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: firewallIdentity()}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"}))
+
+	decoded, err := generated.UnmarshalAttrs("google_compute_firewall", ir.Attrs)
+	require.NoError(t, err)
+	gf, ok := decoded.(*generated.GoogleComputeFirewall)
+	require.True(t, ok)
+	require.NotNil(t, gf.Name)
+	assert.Equal(t, "allow-ssh", *gf.Name.Literal)
+	require.NotNil(t, gf.Direction)
+	assert.Equal(t, "INGRESS", *gf.Direction.Literal)
+	require.Len(t, gf.Allow, 1)
+	assert.Equal(t, "tcp", *gf.Allow[0].Protocol.Literal)
+	require.NotNil(t, gf.EnableLogging)
+	assert.True(t, *gf.EnableLogging.Literal)
+	require.Len(t, gf.LogConfig, 1)
+	assert.Equal(t, "INCLUDE_ALL_METADATA", *gf.LogConfig[0].Metadata.Literal)
+}
+
+// TestComputeFirewallEnrichByID_PopulatesAttrs validates the ByID
+// entry point returns the same JSON shape ir.Attrs gets via Enrich.
+// Shared fetchAndMap helper guarantees parity — this test is the
+// black-box pin.
+func TestComputeFirewallEnrichByID_PopulatesAttrs(t *testing.T) {
+	t.Parallel()
+	fw := &computev1.Firewall{
+		Name:    "allow-ssh",
+		Network: "global/networks/default",
+		Allowed: []*computev1.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"22"}},
+		},
+	}
+	e := computeFirewallEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, project, name string) (*computev1.Firewall, error) {
+			assert.Equal(t, "my-project", project)
+			assert.Equal(t, "allow-ssh", name)
+			return fw, nil
+		},
+	}
+	id := firewallIdentity()
+	raw, err := e.EnrichByID(context.Background(), &id, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	// Result decodes through the same UnmarshalAttrs path that Enrich
+	// would use.
+	decoded, err := generated.UnmarshalAttrs("google_compute_firewall", raw)
+	require.NoError(t, err)
+	gf, ok := decoded.(*generated.GoogleComputeFirewall)
+	require.True(t, ok)
+	require.NotNil(t, gf.Name)
+	assert.Equal(t, "allow-ssh", *gf.Name.Literal)
+	require.Len(t, gf.Allow, 1)
+	assert.Equal(t, "tcp", *gf.Allow[0].Protocol.Literal)
+}
+
+// TestComputeFirewallEnrichByID_NilIdentity guards against a nil
+// pointer from a misbehaving caller (the dispatcher is responsible
+// for non-nil, but defense-in-depth).
+func TestComputeFirewallEnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newComputeFirewallEnricher().(ByIDEnricher)
+	raw, err := e.EnrichByID(context.Background(), nil, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Nil(t, raw)
+	assert.Contains(t, err.Error(), "nil Identity")
+}
+
+// TestComputeFirewallEnrich_EnrichAndByIDProduceIdenticalAttrs locks
+// in the contract that Enrich and EnrichByID, given the same inputs,
+// emit byte-identical JSON. If a future change splits the two paths,
+// this guards against silent divergence.
+func TestComputeFirewallEnrich_EnrichAndByIDProduceIdenticalAttrs(t *testing.T) {
+	t.Parallel()
+	fw := &computev1.Firewall{
+		Name:    "allow-ssh",
+		Network: "global/networks/default",
+		Allowed: []*computev1.FirewallAllowed{
+			{IPProtocol: "tcp", Ports: []string{"22", "443"}},
+		},
+		Denied: []*computev1.FirewallDenied{
+			{IPProtocol: "icmp"},
+		},
+		LogConfig: &computev1.FirewallLogConfig{Enable: true, Metadata: "INCLUDE_ALL_METADATA"},
+	}
+	mk := func() computeFirewallEnricher {
+		return computeFirewallEnricher{
+			fetch: func(_ context.Context, _ *computev1.Service, _, _ string) (*computev1.Firewall, error) {
+				return fw, nil
+			},
+		}
+	}
+	c := EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"}
+
+	ir := &imported.ImportedResource{Identity: firewallIdentity()}
+	require.NoError(t, mk().Enrich(context.Background(), ir, c))
+
+	id := firewallIdentity()
+	raw, err := mk().EnrichByID(context.Background(), &id, c)
+	require.NoError(t, err)
+
+	// Compare JSON shapes structurally so a future field-order shuffle
+	// in encoding/json doesn't false-fail. (json.Marshal is stable for
+	// the same struct shape, but the structural compare is the load-
+	// bearing assertion either way.)
+	var a, b map[string]any
+	require.NoError(t, json.Unmarshal(ir.Attrs, &a))
+	require.NoError(t, json.Unmarshal(raw, &b))
+	assert.Equal(t, a, b, "Enrich and EnrichByID must produce identical typed payloads")
+}
+
+// TestComputeFirewallShortNameForEnrich pins the Identity → name
+// precedence: NameHint > NativeIDs["name"] > NativeIDs["asset_name"]
+// > ImportID.
+func TestComputeFirewallShortNameForEnrich(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		id   imported.ResourceIdentity
+		want string
+	}{
+		{
+			name: "name_hint_wins",
+			id: imported.ResourceIdentity{
+				NameHint:  "from-hint",
+				NativeIDs: map[string]string{"name": "from-native"},
+				ImportID:  "projects/p/global/firewalls/from-import",
+			},
+			want: "from-hint",
+		},
+		{
+			name: "native_id_name_beats_asset",
+			id: imported.ResourceIdentity{
+				NativeIDs: map[string]string{
+					"name":       "from-native",
+					"asset_name": "//compute.googleapis.com/projects/p/global/firewalls/from-asset",
+				},
+				ImportID: "projects/p/global/firewalls/from-import",
+			},
+			want: "from-native",
+		},
+		{
+			name: "asset_name_beats_import_id",
+			id: imported.ResourceIdentity{
+				NativeIDs: map[string]string{
+					"asset_name": "//compute.googleapis.com/projects/p/global/firewalls/from-asset",
+				},
+				ImportID: "projects/p/global/firewalls/from-import",
+			},
+			want: "from-asset",
+		},
+		{
+			name: "import_id_fallback",
+			id: imported.ResourceIdentity{
+				ImportID: "projects/p/global/firewalls/from-import",
+			},
+			want: "from-import",
+		},
+		{
+			name: "nothing_yields_empty",
+			id:   imported.ResourceIdentity{},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			id := tc.id
+			assert.Equal(t, tc.want, computeFirewallShortNameForEnrich(&id))
+		})
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -2,6 +2,7 @@ package gcpdiscover
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -69,6 +70,50 @@ type AttributeEnricher interface {
 	// so callers can distinguish "not configured" from "real API
 	// error".
 	Enrich(ctx context.Context, ir *imported.ImportedResource, clients EnrichClients) error
+}
+
+// ByIDEnricher is an optional sibling to AttributeEnricher that fetches
+// a single resource's typed Layer 1 payload from its ResourceIdentity
+// alone — used by the per-IR drift refresh path that the eventual
+// pkg/imported.Provider.EnrichByID exposes (presets#482). Implementing
+// this interface is purely additive: enrichers that satisfy only
+// AttributeEnricher continue to work unchanged for the batch enrichment
+// flow; the by-ID dispatcher type-asserts at call time and downgrades
+// gracefully when the assertion fails.
+//
+// Mirrors awsdiscover.ByIDEnricher (same name, same shape, per-cloud
+// EnrichClients). The two clouds are deliberately kept symmetric so
+// the unified pkg/imported.Provider in presets#482 can dispatch
+// through identical interface shapes.
+//
+// The shape diverges from Enrich for two reasons:
+//
+//   - The caller starts from an Identity that hasn't been produced by
+//     the corresponding Discoverer (e.g. a UI refresh on a single row),
+//     so there is no pre-existing *ImportedResource to mutate.
+//   - The caller wants only the raw typed payload (returned as the
+//     same json.RawMessage shape that lands in ImportedResource.Attrs),
+//     so it can drive its own comparator without going through the
+//     batch progress / aggregation machinery.
+//
+// Implementations must not mutate identity. In the common case Enrich
+// and EnrichByID share a private helper that does the SDK call and
+// emits the typed struct; the two methods differ only in how they
+// package the result.
+type ByIDEnricher interface {
+	// ResourceType returns the Terraform type this enricher covers.
+	// Must match the registered Discoverer / AttributeEnricher of the
+	// same type.
+	ResourceType() string
+
+	// EnrichByID fetches the typed Layer 1 payload for the resource
+	// named by identity and returns it as the json.RawMessage that
+	// would land in ImportedResource.Attrs. A nil required client on
+	// clients is reported as ErrEnrichClientUnavailable so callers
+	// can distinguish "not configured" from "real API error". A
+	// not-found resource is reported as ErrNotFound (sentinel
+	// declared in gcpdiscover.go).
+	EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, clients EnrichClients) (json.RawMessage, error)
 }
 
 // EnrichClients bundles the cloud SDK clients per-type enrichers

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -327,7 +327,7 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string, opts GCPDisco
 			// child configs, Service Networking peering connections,
 			// Serverless VPC Access connectors, and Compute resource
 			// policies (snapshot schedules / placement policies).
-			"google_project_service": newProjectServiceDiscoverer(opts.ProjectServiceLister),
+			"google_project_service":                                newProjectServiceDiscoverer(opts.ProjectServiceLister),
 			"google_identity_platform_default_supported_idp_config": newIdentityPlatformDefaultSupportedIdpConfigDiscoverer(opts.DefaultSupportedIdpConfigLister),
 			"google_service_networking_connection":                  newServiceNetworkingConnectionDiscoverer(opts.ServiceNetworkingConnectionLister),
 			"google_vpc_access_connector":                           newVPCAccessConnectorDiscoverer(opts.VPCAccessConnectorLister),
@@ -341,11 +341,13 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string, opts GCPDisco
 		// silently skipped by EnrichAttributes — the full enricher rollout
 		// follows the existing per-type ordering one PR at a time.
 		byTypeEnricher: map[string]AttributeEnricher{
-			"google_storage_bucket":        newStorageBucketEnricher(),
-			"google_pubsub_topic":          newPubsubTopicEnricher(),
-			"google_pubsub_subscription":   newPubsubSubscriptionEnricher(),
-			"google_secret_manager_secret": newSecretManagerSecretEnricher(),
+			"google_compute_address":       newComputeAddressEnricher(),
+			"google_compute_firewall":      newComputeFirewallEnricher(),
 			"google_compute_network":       newComputeNetworkEnricher(),
+			"google_pubsub_subscription":   newPubsubSubscriptionEnricher(),
+			"google_pubsub_topic":          newPubsubTopicEnricher(),
+			"google_secret_manager_secret": newSecretManagerSecretEnricher(),
+			"google_storage_bucket":        newStorageBucketEnricher(),
 		},
 	}
 }

--- a/cmd/insideout-import/gcpdiscover/provider_export.go
+++ b/cmd/insideout-import/gcpdiscover/provider_export.go
@@ -1,0 +1,67 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// EnricherTypes returns the sorted list of Terraform types that have a
+// registered AttributeEnricher on this GCPDiscoverer. Used by the
+// pkg/imported.Provider GCP impl to expose per-type Capabilities
+// without poking the unexported byTypeEnricher map directly.
+//
+// Distinct from SupportedTypes (which lists discoverers, not enrichers).
+// A type appearing in SupportedTypes but not EnricherTypes is
+// Identity-only — Discover populates Identity, no attribute enrichment.
+func (g *GCPDiscoverer) EnricherTypes() []string {
+	out := make([]string, 0, len(g.byTypeEnricher))
+	for t := range g.byTypeEnricher {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// HasEnricher reports whether tfType has a registered
+// AttributeEnricher.
+func (g *GCPDiscoverer) HasEnricher(tfType string) bool {
+	_, ok := g.byTypeEnricher[tfType]
+	return ok
+}
+
+// HasByIDEnricher reports whether tfType has a registered enricher
+// that satisfies the ByIDEnricher interface. ByIDEnricher is an
+// optional extension of AttributeEnricher used by the per-IR drift
+// refresh path; a type with HasEnricher==true but HasByIDEnricher==
+// false supports batch enrichment but not single-identity refresh.
+func (g *GCPDiscoverer) HasByIDEnricher(tfType string) bool {
+	enr, ok := g.byTypeEnricher[tfType]
+	if !ok {
+		return false
+	}
+	_, ok = enr.(ByIDEnricher)
+	return ok
+}
+
+// EnrichByID dispatches a per-identity attribute fetch to the
+// registered ByIDEnricher for identity.Type. See the AWS-side
+// awsdiscover.EnrichByID for the full contract — this is the GCP
+// parity.
+func (g *GCPDiscoverer) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, clients EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("gcpdiscover.EnrichByID: nil identity")
+	}
+	enr, ok := g.byTypeEnricher[identity.Type]
+	if !ok {
+		return nil, fmt.Errorf("no enricher registered for %q: %w", identity.Type, ErrNotSupported)
+	}
+	byID, ok := enr.(ByIDEnricher)
+	if !ok {
+		return nil, fmt.Errorf("enricher for %q does not implement ByIDEnricher: %w", identity.Type, ErrNotSupported)
+	}
+	return byID.EnrichByID(ctx, identity, clients)
+}

--- a/pkg/composer/imported/policy/axes.go
+++ b/pkg/composer/imported/policy/axes.go
@@ -167,3 +167,52 @@ func (c ChangeRiskPolicy) Valid() bool {
 	}
 	return false
 }
+
+// DriftSemantic classifies how the comparator should interpret a
+// curated field when computing drift between a sealed snapshot and a
+// fresh live read. The skeleton ships the enum and an additive field
+// on FieldPolicy; the comparator that consumes the value lives in
+// the eventual pkg/drift/imported package (presets#482).
+//
+// The empty string is intentionally valid and means "no drift
+// comparison" — that is, the field is informational only for drift
+// purposes. Every existing policy file in pkg/composer/imported/policy
+// pre-dates this axis, so leaving it unset must not be a lint
+// failure.
+//
+// Form note: DriftSemanticLabelFilter eventually carries a key-prefix
+// parameter (e.g. ignore `goog-*` labels). The skeleton declares the
+// const but defers the wire format for the parameter to presets#482
+// — likely either a sibling DriftFilter string field on FieldPolicy
+// or an encoded suffix on the value, decided when the comparator
+// lands and the real use cases are concrete.
+type DriftSemantic string
+
+const (
+	// DriftSemanticNone — the comparator skips this field. Default
+	// for every uncurated field.
+	DriftSemanticNone DriftSemantic = ""
+	// DriftSemanticExact — exact equality between snapshot and live.
+	DriftSemanticExact DriftSemantic = "Exact"
+	// DriftSemanticWholeList — list-valued field compared as a whole
+	// (order-sensitive). Used for fields like GCS lifecycle_rule
+	// where per-element diffs are not meaningful.
+	DriftSemanticWholeList DriftSemantic = "WholeList"
+	// DriftSemanticLabelFilter — map-valued field compared after
+	// filtering out keys matching a prefix (e.g. `goog-*` labels
+	// the provider auto-populates). The prefix wire format is
+	// deferred to presets#482.
+	DriftSemanticLabelFilter DriftSemantic = "LabelFilter"
+)
+
+// Valid reports whether d is one of the known drift-semantic consts.
+// The empty string is valid and treated as DriftSemanticNone so that
+// existing policy files (all of which pre-date this axis) lint
+// cleanly without a sweep.
+func (d DriftSemantic) Valid() bool {
+	switch d {
+	case DriftSemanticNone, DriftSemanticExact, DriftSemanticWholeList, DriftSemanticLabelFilter:
+		return true
+	}
+	return false
+}

--- a/pkg/composer/imported/policy/axes_test.go
+++ b/pkg/composer/imported/policy/axes_test.go
@@ -133,9 +133,9 @@ func TestDriftSemantic_Valid(t *testing.T) {
 		{DriftSemanticExact, true},
 		{DriftSemanticWholeList, true},
 		{DriftSemanticLabelFilter, true},
-		{"exact", false},             // case-sensitive
-		{"whole_list", false},        // snake-case rejected
-		{"LabelFilter:goog-", false}, // parameter wire format is deferred to presets#482; raw const-only for now
+		{"exact", false},        // case-sensitive
+		{"whole_list", false},   // snake-case rejected
+		{"LabelFilter ", false}, // trailing space (parallel to VisibilityPolicy's "Hidden " probe)
 		{"unknown", false},
 	}
 	for _, tc := range cases {

--- a/pkg/composer/imported/policy/axes_test.go
+++ b/pkg/composer/imported/policy/axes_test.go
@@ -120,6 +120,29 @@ func TestChangeRiskPolicy_Valid(t *testing.T) {
 	}
 }
 
+func TestDriftSemantic_Valid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   DriftSemantic
+		want bool
+	}{
+		// Empty string is intentionally valid — pre-existing policy
+		// files leave this axis unset and must continue to lint
+		// cleanly with the new field present.
+		{DriftSemanticNone, true},
+		{DriftSemanticExact, true},
+		{DriftSemanticWholeList, true},
+		{DriftSemanticLabelFilter, true},
+		{"exact", false},             // case-sensitive
+		{"whole_list", false},        // snake-case rejected
+		{"LabelFilter:goog-", false}, // parameter wire format is deferred to presets#482; raw const-only for now
+		{"unknown", false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, tc.in.Valid(), "DriftSemantic(%q).Valid()", string(tc.in))
+	}
+}
+
 func TestSharedPolicies(t *testing.T) {
 	t.Parallel()
 	// Whole-struct equality: these constructors are baked into every

--- a/pkg/composer/imported/policy/policy.go
+++ b/pkg/composer/imported/policy/policy.go
@@ -9,13 +9,14 @@ package policy
 // Rationale is a human-readable note used by the lint to gate
 // visible-and-Sensitive entries. Most policies leave it empty.
 type FieldPolicy struct {
-	Role        FieldRole
-	Pillar      FieldPillar
-	Visibility  VisibilityPolicy
-	Edit        EditPolicy
-	Sensitivity SensitivityPolicy
-	ChangeRisk  ChangeRiskPolicy
-	Rationale   string
+	Role          FieldRole
+	Pillar        FieldPillar
+	Visibility    VisibilityPolicy
+	Edit          EditPolicy
+	Sensitivity   SensitivityPolicy
+	ChangeRisk    ChangeRiskPolicy
+	DriftSemantic DriftSemantic
+	Rationale     string
 }
 
 // Map is a curated field policy keyed by Terraform attribute path. See

--- a/pkg/drift/imported/compare.go
+++ b/pkg/drift/imported/compare.go
@@ -1,0 +1,266 @@
+// Package imported is the generic curated-field drift comparator for
+// sealed snapshot vs. live cloud read. It is the engine behind the
+// eventual pkg/imported.Provider.CompareDrift method (issue #482).
+//
+// # Why this lives here
+//
+// The comparator is policy-driven: per-cloud presets declare a
+// FieldPolicy map in pkg/composer/imported/policy, and each curated
+// entry carries a DriftSemantic axis (Exact / WholeList / LabelFilter /
+// None — see policy/axes.go). Compare walks the registered policy for
+// a Terraform type and dispatches on DriftSemantic to decide whether a
+// per-field value diverged between snapshot and live, returning a
+// deterministic []FieldMismatch.
+//
+// Compare deliberately treats both inputs as best-effort observational
+// data — malformed JSON, missing fields, and unregistered types all
+// resolve to nil rather than an error. Drift reporting is a downstream
+// signal, never an apply gate.
+//
+// # Path resolution
+//
+// FieldPolicy keys use dotted-path syntax matching
+// pkg/composer/imported/policy/path.go's grammar (without bracket
+// suffixes — Compare does not interpret list indices). At each
+// segment the resolver:
+//
+//   - takes the map key when the current node is map[string]any
+//   - auto-unwraps a singleton list (one-element []any) — Terraform's
+//     block-shaped attributes serialize as [{...}] in state JSON, and
+//     the policy paths are authored against the logical flat shape
+//     (e.g. "versioning.enabled" — see google_storage_bucket.policy.go).
+//   - stops with a missing-value signal otherwise.
+//
+// When both sides of the compare resolve identically (including both
+// absent → both nil), no mismatch is reported.
+package imported
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+)
+
+// FieldMismatch is a type alias for pkg/imported.FieldMismatch so
+// Compare's output drops straight into Provider.CompareDrift without
+// a per-element conversion at the call site. The alias direction
+// (drift → imported) is safe: pkg/imported does not import this
+// package, only the per-cloud Provider impls do.
+type FieldMismatch = imp.FieldMismatch
+
+// Compare reports the curated-field drift between a sealed snapshot
+// and a fresh live read for tfType. Dispatch is driven by the
+// FieldPolicy.DriftSemantic axis on each policy entry:
+//
+//   - DriftSemanticNone — field skipped (default for uncurated
+//     fields).
+//   - DriftSemanticExact — exact equality between snapshot[path] and
+//     live[path], via reflect.DeepEqual.
+//   - DriftSemanticWholeList — list-valued field compared as a whole
+//     (order-sensitive), via reflect.DeepEqual after coercion to
+//     []any.
+//   - DriftSemanticLabelFilter — map-valued field compared after
+//     filtering out keys with a "goog-" or "goog_" prefix (the only
+//     auto-populated label namespace today). Per-policy filter prefix
+//     support is documented in axes.go and is a follow-up; the
+//     current behavior is fixed to the GCP label-noise case.
+//
+// Types without a registered policy return nil (no fields curated →
+// no drift signal). Malformed JSON in either Attrs returns nil — this
+// is observability, not validation.
+//
+// Output is sorted by Field for deterministic golden tests.
+func Compare(tfType string, snapshot, live json.RawMessage) []FieldMismatch {
+	policyMap, ok := policy.Lookup(tfType)
+	if !ok {
+		return nil
+	}
+	snapAttrs, ok := decodeAttrs(snapshot)
+	if !ok {
+		return nil
+	}
+	liveAttrs, ok := decodeAttrs(live)
+	if !ok {
+		return nil
+	}
+	var out []FieldMismatch
+	for path, entry := range policyMap {
+		switch entry.DriftSemantic {
+		case policy.DriftSemanticNone:
+			continue
+		case policy.DriftSemanticExact:
+			if m, ok := compareExact(path, snapAttrs, liveAttrs); ok {
+				out = append(out, m)
+			}
+		case policy.DriftSemanticWholeList:
+			if m, ok := compareWholeList(path, snapAttrs, liveAttrs); ok {
+				out = append(out, m)
+			}
+		case policy.DriftSemanticLabelFilter:
+			if m, ok := compareLabelFilter(path, snapAttrs, liveAttrs); ok {
+				out = append(out, m)
+			}
+		default:
+			// Unknown DriftSemantic — be conservative and skip. The
+			// policy lint enforces Valid() at registration, so an
+			// unknown value reaching here means a runtime hand-built
+			// map; emitting noise would be worse than silence.
+			continue
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Field < out[j].Field })
+	return out
+}
+
+// decodeAttrs parses a json.RawMessage into a map[string]any. A nil
+// or empty input decodes to an empty map (treated as "no attrs",
+// still compareable). Returns ok=false only on a parse error or on a
+// non-object top level, which propagates as "no drift signal" per
+// the best-effort contract.
+func decodeAttrs(raw json.RawMessage) (map[string]any, bool) {
+	if len(raw) == 0 {
+		return map[string]any{}, true
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, false
+	}
+	if m == nil {
+		return map[string]any{}, true
+	}
+	return m, true
+}
+
+// resolvePath walks dotted-path segments into a map[string]any,
+// auto-unwrapping single-element list nodes (terraform's
+// block-as-singleton-list state shape). Returns (value, true) when
+// the full path resolves, or (nil, false) when any segment misses.
+func resolvePath(path string, m map[string]any) (any, bool) {
+	if path == "" {
+		return nil, false
+	}
+	segs := strings.Split(path, ".")
+	var cur any = m
+	for _, seg := range segs {
+		// Auto-unwrap a singleton list — Terraform serializes block
+		// fields as [{...}] in state; policy paths are authored
+		// against the logical flat object.
+		if lst, ok := cur.([]any); ok {
+			if len(lst) != 1 {
+				return nil, false
+			}
+			cur = lst[0]
+		}
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		next, present := obj[seg]
+		if !present {
+			return nil, false
+		}
+		cur = next
+	}
+	return cur, true
+}
+
+// compareExact resolves path in both maps and emits a mismatch iff
+// the values diverge. Both-absent / equal-values → no mismatch.
+func compareExact(path string, snap, live map[string]any) (FieldMismatch, bool) {
+	sv, sOK := resolvePath(path, snap)
+	lv, lOK := resolvePath(path, live)
+	if !sOK && !lOK {
+		return FieldMismatch{}, false
+	}
+	if sOK && lOK && reflect.DeepEqual(sv, lv) {
+		return FieldMismatch{}, false
+	}
+	return FieldMismatch{Field: path, Snapshot: sv, Cloud: lv}, true
+}
+
+// compareWholeList resolves path in both maps and compares as lists.
+// Both sides are coerced to []any first; a non-list value (or
+// absence) on one side and a list on the other → mismatch.
+func compareWholeList(path string, snap, live map[string]any) (FieldMismatch, bool) {
+	sv, sOK := resolvePath(path, snap)
+	lv, lOK := resolvePath(path, live)
+	if !sOK && !lOK {
+		return FieldMismatch{}, false
+	}
+	sList := coerceList(sv)
+	lList := coerceList(lv)
+	// Treat absence as nil-list; equal nil-lists → no mismatch.
+	if reflect.DeepEqual(sList, lList) {
+		return FieldMismatch{}, false
+	}
+	return FieldMismatch{Field: path, Snapshot: sList, Cloud: lList}, true
+}
+
+// coerceList returns v as []any. A nil or non-list value yields nil
+// (which DeepEqual compares as equal to other nil []any).
+func coerceList(v any) []any {
+	if v == nil {
+		return nil
+	}
+	if lst, ok := v.([]any); ok {
+		return lst
+	}
+	// Defensive: wrap a single object as a 1-element list so the
+	// compare degrades to "we have something vs you have something"
+	// rather than spuriously matching the nil-list branch.
+	return []any{v}
+}
+
+// compareLabelFilter resolves path in both maps, filters auto-populated
+// goog-* / goog_* keys on both sides, and compares the residue. A
+// non-map value on either side (e.g. nil) is treated as an empty map
+// for the purpose of filtering — equal empties → no mismatch.
+func compareLabelFilter(path string, snap, live map[string]any) (FieldMismatch, bool) {
+	sv, sOK := resolvePath(path, snap)
+	lv, lOK := resolvePath(path, live)
+	if !sOK && !lOK {
+		return FieldMismatch{}, false
+	}
+	sMap := filterAutoLabels(coerceMap(sv))
+	lMap := filterAutoLabels(coerceMap(lv))
+	if reflect.DeepEqual(sMap, lMap) {
+		return FieldMismatch{}, false
+	}
+	return FieldMismatch{Field: path, Snapshot: sMap, Cloud: lMap}, true
+}
+
+// coerceMap returns v as map[string]any. A nil or non-map value yields
+// an empty (non-nil) map so filterAutoLabels can iterate uniformly.
+func coerceMap(v any) map[string]any {
+	if v == nil {
+		return map[string]any{}
+	}
+	if m, ok := v.(map[string]any); ok {
+		return m
+	}
+	return map[string]any{}
+}
+
+// filterAutoLabels returns a copy of m with any "goog-" / "goog_"
+// prefixed keys removed. These are GCP's auto-populated label
+// namespace (e.g. goog-managed-by, goog_terraform_provisioned) and
+// drift on them is provider noise, not user-actionable.
+//
+// Future: per-policy filter-prefix support is documented in
+// axes.go's DriftSemanticLabelFilter comment. When that lands the
+// caller will pass the prefix; for now the rule is fixed to the
+// goog-* namespace.
+func filterAutoLabels(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if strings.HasPrefix(k, "goog-") || strings.HasPrefix(k, "goog_") {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/drift/imported/compare_test.go
+++ b/pkg/drift/imported/compare_test.go
@@ -1,0 +1,294 @@
+package imported
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+)
+
+// synthetic tfType counter — each subtest registers under a fresh name
+// so the process-wide policy registry never sees a duplicate (the
+// registry's unregister helper is unexported, so we rely on uniqueness
+// instead).
+var synthCounter atomic.Uint64
+
+// registerSyntheticPolicy installs m under a fresh tfType name and
+// returns the name. Tests address the registry through this helper so
+// the production per-cloud policy files stay untouched.
+func registerSyntheticPolicy(t *testing.T, m policy.Map) string {
+	t.Helper()
+	n := synthCounter.Add(1)
+	name := fmt.Sprintf("_drift_test_synthetic_%d", n)
+	policy.Register(name, m)
+	return name
+}
+
+func TestCompare_NoRegisteredPolicy(t *testing.T) {
+	// A tfType we never register → nil.
+	got := Compare("_drift_test_never_registered", json.RawMessage(`{"a":1}`), json.RawMessage(`{"a":2}`))
+	assert.Nil(t, got)
+}
+
+func TestCompare_EmptyPolicy(t *testing.T) {
+	tfType := registerSyntheticPolicy(t, policy.Map{})
+	got := Compare(tfType, json.RawMessage(`{"a":1}`), json.RawMessage(`{"a":2}`))
+	assert.Nil(t, got)
+}
+
+func TestCompare_MalformedJSON(t *testing.T) {
+	tfType := registerSyntheticPolicy(t, policy.Map{
+		"versioning.enabled": {DriftSemantic: policy.DriftSemanticExact},
+	})
+	cases := []struct {
+		name           string
+		snapshot, live json.RawMessage
+	}{
+		{"snapshot bad", json.RawMessage(`{not json`), json.RawMessage(`{"versioning":{"enabled":true}}`)},
+		{"live bad", json.RawMessage(`{"versioning":{"enabled":true}}`), json.RawMessage(`{"oops"`)},
+		{"both bad", json.RawMessage(`xxx`), json.RawMessage(`yyy`)},
+		{"non-object top-level", json.RawMessage(`123`), json.RawMessage(`456`)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Compare(tfType, tc.snapshot, tc.live)
+			assert.Nil(t, got)
+		})
+	}
+}
+
+func TestCompare_DriftSemanticNone_AlwaysSkipped(t *testing.T) {
+	tfType := registerSyntheticPolicy(t, policy.Map{
+		"name":          {DriftSemantic: policy.DriftSemanticNone},
+		"uncurated_too": {}, // empty DriftSemantic — implicit DriftSemanticNone
+	})
+	snap := json.RawMessage(`{"name":"foo","uncurated_too":"x"}`)
+	live := json.RawMessage(`{"name":"bar","uncurated_too":"y"}`)
+	got := Compare(tfType, snap, live)
+	assert.Nil(t, got, "DriftSemanticNone fields must never produce mismatches")
+}
+
+func TestCompare_DriftSemanticExact(t *testing.T) {
+	tfType := registerSyntheticPolicy(t, policy.Map{
+		"versioning.enabled": {DriftSemantic: policy.DriftSemanticExact},
+		"storage_class":      {DriftSemantic: policy.DriftSemanticExact},
+	})
+
+	t.Run("identical", func(t *testing.T) {
+		snap := json.RawMessage(`{"versioning":{"enabled":true},"storage_class":"STANDARD"}`)
+		live := json.RawMessage(`{"versioning":{"enabled":true},"storage_class":"STANDARD"}`)
+		got := Compare(tfType, snap, live)
+		assert.Empty(t, got)
+	})
+
+	t.Run("nested-scalar mismatch", func(t *testing.T) {
+		snap := json.RawMessage(`{"versioning":{"enabled":true},"storage_class":"STANDARD"}`)
+		live := json.RawMessage(`{"versioning":{"enabled":false},"storage_class":"STANDARD"}`)
+		got := Compare(tfType, snap, live)
+		require.Len(t, got, 1)
+		assert.Equal(t, "versioning.enabled", got[0].Field)
+		assert.Equal(t, true, got[0].Snapshot)
+		assert.Equal(t, false, got[0].Cloud)
+	})
+
+	t.Run("top-level-scalar mismatch", func(t *testing.T) {
+		snap := json.RawMessage(`{"versioning":{"enabled":true},"storage_class":"STANDARD"}`)
+		live := json.RawMessage(`{"versioning":{"enabled":true},"storage_class":"NEARLINE"}`)
+		got := Compare(tfType, snap, live)
+		require.Len(t, got, 1)
+		assert.Equal(t, "storage_class", got[0].Field)
+	})
+
+	t.Run("both absent → no mismatch", func(t *testing.T) {
+		snap := json.RawMessage(`{}`)
+		live := json.RawMessage(`{}`)
+		got := Compare(tfType, snap, live)
+		assert.Empty(t, got)
+	})
+
+	t.Run("one side absent → mismatch", func(t *testing.T) {
+		snap := json.RawMessage(`{"storage_class":"STANDARD"}`)
+		live := json.RawMessage(`{}`)
+		got := Compare(tfType, snap, live)
+		require.Len(t, got, 1)
+		assert.Equal(t, "storage_class", got[0].Field)
+		assert.Equal(t, "STANDARD", got[0].Snapshot)
+		assert.Nil(t, got[0].Cloud)
+	})
+
+	t.Run("singleton-list auto-unwrap on nested block", func(t *testing.T) {
+		// Terraform serializes block fields as [{...}] — the resolver
+		// must auto-unwrap one-element lists so "versioning.enabled"
+		// keeps resolving against the on-disk shape.
+		snap := json.RawMessage(`{"versioning":[{"enabled":true}]}`)
+		live := json.RawMessage(`{"versioning":[{"enabled":false}]}`)
+		got := Compare(tfType, snap, live)
+		require.Len(t, got, 1)
+		assert.Equal(t, "versioning.enabled", got[0].Field)
+	})
+}
+
+func TestCompare_DriftSemanticWholeList(t *testing.T) {
+	tfType := registerSyntheticPolicy(t, policy.Map{
+		"lifecycle_rule": {DriftSemantic: policy.DriftSemanticWholeList},
+	})
+
+	rule := func(age int, cls string) string {
+		return fmt.Sprintf(`{"action":{"type":"SetStorageClass","storage_class":%q},"condition":{"age":%d}}`, cls, age)
+	}
+
+	t.Run("matching list → no mismatch", func(t *testing.T) {
+		body := fmt.Sprintf(`{"lifecycle_rule":[%s,%s]}`, rule(30, "NEARLINE"), rule(90, "COLDLINE"))
+		got := Compare(tfType, json.RawMessage(body), json.RawMessage(body))
+		assert.Empty(t, got)
+	})
+
+	t.Run("differing list → mismatch", func(t *testing.T) {
+		snap := fmt.Sprintf(`{"lifecycle_rule":[%s]}`, rule(30, "NEARLINE"))
+		live := fmt.Sprintf(`{"lifecycle_rule":[%s]}`, rule(60, "NEARLINE"))
+		got := Compare(tfType, json.RawMessage(snap), json.RawMessage(live))
+		require.Len(t, got, 1)
+		assert.Equal(t, "lifecycle_rule", got[0].Field)
+		// Snapshot/Cloud must be lists, not raw objects.
+		assert.IsType(t, []any{}, got[0].Snapshot)
+		assert.IsType(t, []any{}, got[0].Cloud)
+	})
+
+	t.Run("order-sensitive", func(t *testing.T) {
+		snap := fmt.Sprintf(`{"lifecycle_rule":[%s,%s]}`, rule(30, "NEARLINE"), rule(90, "COLDLINE"))
+		live := fmt.Sprintf(`{"lifecycle_rule":[%s,%s]}`, rule(90, "COLDLINE"), rule(30, "NEARLINE"))
+		got := Compare(tfType, json.RawMessage(snap), json.RawMessage(live))
+		require.Len(t, got, 1, "WholeList must be order-sensitive")
+	})
+
+	t.Run("empty-list both sides → no mismatch", func(t *testing.T) {
+		body := `{"lifecycle_rule":[]}`
+		got := Compare(tfType, json.RawMessage(body), json.RawMessage(body))
+		assert.Empty(t, got)
+	})
+
+	t.Run("absent both sides → no mismatch", func(t *testing.T) {
+		got := Compare(tfType, json.RawMessage(`{}`), json.RawMessage(`{}`))
+		assert.Empty(t, got)
+	})
+}
+
+func TestCompare_DriftSemanticLabelFilter(t *testing.T) {
+	tfType := registerSyntheticPolicy(t, policy.Map{
+		"labels": {DriftSemantic: policy.DriftSemanticLabelFilter},
+	})
+
+	t.Run("goog-* keys filtered, user keys match → no mismatch", func(t *testing.T) {
+		snap := json.RawMessage(`{"labels":{"env":"prod","team":"infra"}}`)
+		live := json.RawMessage(`{"labels":{"env":"prod","team":"infra","goog-managed-by":"composer","goog_terraform_provisioned":"true"}}`)
+		got := Compare(tfType, snap, live)
+		assert.Empty(t, got, "goog-/goog_ prefixed keys must be filtered before compare")
+	})
+
+	t.Run("user-key drift detected even when goog-* noise is present", func(t *testing.T) {
+		snap := json.RawMessage(`{"labels":{"env":"prod","goog-managed-by":"x"}}`)
+		live := json.RawMessage(`{"labels":{"env":"staging","goog-managed-by":"y"}}`)
+		got := Compare(tfType, snap, live)
+		require.Len(t, got, 1)
+		assert.Equal(t, "labels", got[0].Field)
+		assert.Equal(t, map[string]any{"env": "prod"}, got[0].Snapshot)
+		assert.Equal(t, map[string]any{"env": "staging"}, got[0].Cloud)
+	})
+
+	t.Run("absent both sides → no mismatch", func(t *testing.T) {
+		got := Compare(tfType, json.RawMessage(`{}`), json.RawMessage(`{}`))
+		assert.Empty(t, got)
+	})
+
+	t.Run("only goog-* keys → empty after filter → no mismatch", func(t *testing.T) {
+		snap := json.RawMessage(`{"labels":{"goog-a":"1"}}`)
+		live := json.RawMessage(`{"labels":{"goog_b":"2"}}`)
+		got := Compare(tfType, snap, live)
+		assert.Empty(t, got)
+	})
+}
+
+func TestCompare_SortedOutput(t *testing.T) {
+	// Multiple fields with mismatches must come back sorted by Field
+	// — the underlying map iteration is non-deterministic; the
+	// sort.Slice in Compare is what holds the golden contract.
+	tfType := registerSyntheticPolicy(t, policy.Map{
+		"zeta":  {DriftSemantic: policy.DriftSemanticExact},
+		"alpha": {DriftSemantic: policy.DriftSemanticExact},
+		"mike":  {DriftSemantic: policy.DriftSemanticExact},
+	})
+	snap := json.RawMessage(`{"alpha":1,"mike":2,"zeta":3}`)
+	live := json.RawMessage(`{"alpha":10,"mike":20,"zeta":30}`)
+	got := Compare(tfType, snap, live)
+	require.Len(t, got, 3)
+	assert.Equal(t, "alpha", got[0].Field)
+	assert.Equal(t, "mike", got[1].Field)
+	assert.Equal(t, "zeta", got[2].Field)
+}
+
+func TestCompare_MixedSemantics(t *testing.T) {
+	// One policy with several axes at once — exercises the dispatch
+	// switch end-to-end and confirms None entries never leak into
+	// output even when their value differs.
+	tfType := registerSyntheticPolicy(t, policy.Map{
+		"name":               {}, // None
+		"versioning.enabled": {DriftSemantic: policy.DriftSemanticExact},
+		"lifecycle_rule":     {DriftSemantic: policy.DriftSemanticWholeList},
+		"labels":             {DriftSemantic: policy.DriftSemanticLabelFilter},
+	})
+	snap := json.RawMessage(`{
+		"name": "bucket-a",
+		"versioning": {"enabled": true},
+		"lifecycle_rule": [{"action":{"type":"Delete"},"condition":{"age":7}}],
+		"labels": {"env":"prod","goog-managed-by":"x"}
+	}`)
+	live := json.RawMessage(`{
+		"name": "bucket-b",
+		"versioning": {"enabled": false},
+		"lifecycle_rule": [{"action":{"type":"Delete"},"condition":{"age":30}}],
+		"labels": {"env":"staging","goog_managed_by":"y"}
+	}`)
+	got := Compare(tfType, snap, live)
+	require.Len(t, got, 3)
+	// Sorted: labels, lifecycle_rule, versioning.enabled
+	assert.Equal(t, "labels", got[0].Field)
+	assert.Equal(t, "lifecycle_rule", got[1].Field)
+	assert.Equal(t, "versioning.enabled", got[2].Field)
+}
+
+func TestResolvePath(t *testing.T) {
+	// Direct exercise of the path resolver — covers shapes that
+	// Compare exercises indirectly via the Exact path.
+	cases := []struct {
+		name    string
+		path    string
+		in      string
+		wantVal any
+		wantOK  bool
+	}{
+		{"flat scalar", "a", `{"a":"x"}`, "x", true},
+		{"nested map", "a.b", `{"a":{"b":"x"}}`, "x", true},
+		{"singleton-list unwrap", "a.b", `{"a":[{"b":"x"}]}`, "x", true},
+		{"multi-element list stops", "a.b", `{"a":[{"b":"x"},{"b":"y"}]}`, nil, false},
+		{"missing leaf", "a.b", `{"a":{}}`, nil, false},
+		{"missing root", "a.b", `{}`, nil, false},
+		{"empty path", "", `{"a":"x"}`, nil, false},
+		{"into scalar", "a.b", `{"a":"scalar"}`, nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var m map[string]any
+			require.NoError(t, json.Unmarshal([]byte(tc.in), &m))
+			got, ok := resolvePath(tc.path, m)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantVal, got)
+			}
+		})
+	}
+}

--- a/pkg/imported/aws/clients.go
+++ b/pkg/imported/aws/clients.go
@@ -1,0 +1,23 @@
+// Package aws is the AWS-side pkg/imported.Provider implementation.
+// It depends on cmd/insideout-import/awsdiscover for the live cloud
+// dispatch; the top-level pkg/imported package does NOT import this
+// package — see pkg/imported package doc for the dependency direction.
+package aws
+
+import (
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+)
+
+// Clients carries the AWS-side SDK client bundle this Provider
+// dispatches against. Re-exported as a type alias from
+// awsdiscover.EnrichClients so callers depending on pkg/imported/aws
+// see one canonical name. The aws Provider unwraps a
+// pkg/imported.Clients{AWS: <*Clients>} into this concrete shape
+// before threading it through to awsdiscover.
+//
+// Construct one per discover run; the SDK clients are stateless
+// wrappers over an aws.Config. A nil field is tolerated: per-type
+// enrichers whose required client is nil return
+// awsdiscover.ErrEnrichClientUnavailable, which the Provider surfaces
+// as imported.ErrEnrichClientUnavailable on the cross-cloud boundary.
+type Clients = awsdiscover.EnrichClients

--- a/pkg/imported/aws/provider.go
+++ b/pkg/imported/aws/provider.go
@@ -70,7 +70,9 @@ func (p *Provider) SupportedTypes() []string {
 //	Enrichable       — discoverer has a registered AttributeEnricher
 //	DriftDetectable  — a policy.Map is registered AND a comparator is wired
 //	MetricsAvailable — bindings.Binding returns ok
-//	RileyEditable    — false today (no policy axis is wired through yet)
+//	AgentEditable    — at least one curated field is EditChatSafe or
+//	                   EditRequiresApproval (the EditPolicy values an
+//	                   interactive agent can author through)
 //
 // All flags are false for an unknown tfType.
 func (p *Provider) Capabilities(tfType string) imp.Capabilities {
@@ -80,10 +82,27 @@ func (p *Provider) Capabilities(tfType string) imp.Capabilities {
 	if p.d != nil {
 		c.Enrichable = p.d.HasEnricher(tfType)
 	}
-	_, hasPolicy := policy.Lookup(tfType)
+	pol, hasPolicy := policy.Lookup(tfType)
 	c.DriftDetectable = hasPolicy && p.comparer != nil
 	_, c.MetricsAvailable = bindings.Binding(tfType)
+	c.AgentEditable = hasAgentEditableField(pol)
 	return c
+}
+
+// hasAgentEditableField reports whether the curated policy carries at
+// least one entry an interactive agent can author through — i.e.
+// EditChatSafe (no human gate) or EditRequiresApproval (agent
+// proposes, human confirms). EditNever / EditRelationshipOnly /
+// EditSystemOnly do not count: those edits don't traverse an
+// agent-write path. An empty policy returns false.
+func hasAgentEditableField(pol policy.Map) bool {
+	for _, fp := range pol {
+		switch fp.Edit {
+		case policy.EditChatSafe, policy.EditRequiresApproval:
+			return true
+		}
+	}
+	return false
 }
 
 // isDiscoverable returns true when tfType appears in the canonical

--- a/pkg/imported/aws/provider.go
+++ b/pkg/imported/aws/provider.go
@@ -251,11 +251,14 @@ func (p *Provider) EnrichByID(ctx context.Context, identity *imported.ResourceId
 }
 
 // unwrapAWSClients pulls the typed AWS bundle out of the cloud-agnostic
-// Clients union. Returns ErrClientsWrongCloud when the GCP slot is set
-// (cross-cloud misroute) and ErrEnrichClientUnavailable when the AWS
-// slot is nil.
+// Clients union. Returns ErrClientsWrongCloud when the GCP slot is
+// populated (the caller has misrouted GCP clients to an AWS provider —
+// reported regardless of whether the AWS slot is also set, because both-
+// set is itself a bug worth flagging loudly). Returns
+// ErrEnrichClientUnavailable when neither slot is set, or when the AWS
+// slot is a nil pointer.
 func unwrapAWSClients(c imp.Clients) (Clients, error) {
-	if c.GCP != nil && c.AWS == nil {
+	if c.GCP != nil {
 		return Clients{}, imp.ErrClientsWrongCloud
 	}
 	if c.AWS == nil {
@@ -287,19 +290,27 @@ func (p *Provider) CompareDrift(tfType string, snapshot, live imp.Attrs) []imp.F
 	return p.comparer(tfType, snapshot, live)
 }
 
-// RileyContext returns a one-line-per-IR summary sorted by Address.
-// Conservative format: `<address> (<type>)`. The downstream consumer
-// (Riley's chat surface) layers richer formatting on top; this is
-// the cross-cloud baseline.
-func (p *Provider) RileyContext(irs []imported.ImportedResource) []string {
+// AgentContext returns a one-line-per-IR summary sorted by Address.
+// Conservative format: `<address> (<type>)`. The downstream interactive
+// agent (Riley today) layers richer formatting on top; this is the
+// cross-cloud baseline.
+//
+// Sort key is Identity.Address — sorting the formatted output strings
+// is equivalent today (since the format starts with the Address), but
+// pinning on the source field decouples the contract from the format.
+func (p *Provider) AgentContext(irs []imported.ImportedResource) []string {
 	if len(irs) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(irs))
-	for _, ir := range irs {
+	sorted := make([]imported.ImportedResource, len(irs))
+	copy(sorted, irs)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Identity.Address < sorted[j].Identity.Address
+	})
+	out := make([]string, 0, len(sorted))
+	for _, ir := range sorted {
 		out = append(out, fmt.Sprintf("%s (%s)", ir.Identity.Address, ir.Identity.Type))
 	}
-	sort.Strings(out)
 	return out
 }
 
@@ -308,7 +319,7 @@ func (p *Provider) RileyContext(irs []imported.ImportedResource) []string {
 // default drift comparator wired (pkg/drift/imported.Compare) but no
 // live AWSDiscoverer — so static introspection (SupportedTypes,
 // Capabilities, LabelFor, PolicyFor, MetricsBinding, StableID,
-// CanonicalAddress, CompareDrift, RileyContext) works out of the box;
+// CanonicalAddress, CompareDrift, AgentContext) works out of the box;
 // callers needing Discover / Enrich must construct via NewProvider
 // with a real *awsdiscover.AWSDiscoverer.
 func init() {

--- a/pkg/imported/aws/provider.go
+++ b/pkg/imported/aws/provider.go
@@ -1,0 +1,299 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+	driftimp "github.com/luthersystems/insideout-terraform-presets/pkg/drift/imported"
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/bindings"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/labels"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
+)
+
+// DriftComparator is the cross-cloud signature pkg/drift/imported is
+// expected to satisfy with its `Compare(tfType, snap, live) []FieldMismatch`
+// function. The Provider stays decoupled from that package by accepting
+// the function at construction time. nil is tolerated and means "no
+// drift comparator wired" — CompareDrift returns nil for every type in
+// that case, and Capabilities reports DriftDetectable=false.
+//
+// The signature is duplicated rather than imported because importing
+// the comparator package here would create a circular dependency
+// (pkg/drift/imported in turn needs pkg/imported.FieldMismatch). The
+// comparator and the Provider agree on the shape; the wire-up site
+// (typically main.go in a downstream binary) closes the loop.
+type DriftComparator func(tfType string, snapshot, live imp.Attrs) []imp.FieldMismatch
+
+// Provider is the AWS-side pkg/imported.Provider implementation.
+// Construct via NewProvider with a live awsdiscover.AWSDiscoverer; the
+// zero-value Provider satisfies the static-introspection half of the
+// interface (Capabilities reports the live-cloud flags as false) and
+// is what ProviderFor returns for callers that only need labels /
+// policy / metrics introspection.
+type Provider struct {
+	d        *awsdiscover.AWSDiscoverer
+	comparer DriftComparator
+}
+
+// Compile-time check: *Provider satisfies imp.Provider.
+var _ imp.Provider = (*Provider)(nil)
+
+// NewProvider wires up an AWS Provider with the given discoverer and
+// drift comparator. Either may be nil: a nil discoverer leaves the
+// Provider in static-introspection mode (Discover/Enrich return
+// ErrEnrichClientUnavailable); a nil comparator disables drift
+// detection (CompareDrift returns nil for every type).
+func NewProvider(d *awsdiscover.AWSDiscoverer, comparer DriftComparator) *Provider {
+	return &Provider{d: d, comparer: comparer}
+}
+
+// SupportedTypes returns the canonical sorted list of AWS types from
+// the registry package. Pinned to registry.SupportedDiscoverTypes
+// rather than the live discoverer's SupportedTypes so the Provider's
+// type surface stays consistent even when constructed without a
+// discoverer (zero-state mode).
+func (p *Provider) SupportedTypes() []string {
+	return registry.SupportedDiscoverTypes(registry.ProviderAWS)
+}
+
+// Capabilities reports the per-type feature surface for tfType.
+//
+//	Discoverable     — type is in registry.SupportedDiscoverTypes("aws")
+//	Enrichable       — discoverer has a registered AttributeEnricher
+//	DriftDetectable  — a policy.Map is registered AND a comparator is wired
+//	MetricsAvailable — bindings.Binding returns ok
+//	RileyEditable    — false today (no policy axis is wired through yet)
+//
+// All flags are false for an unknown tfType.
+func (p *Provider) Capabilities(tfType string) imp.Capabilities {
+	c := imp.Capabilities{
+		Discoverable: isDiscoverable(tfType),
+	}
+	if p.d != nil {
+		c.Enrichable = p.d.HasEnricher(tfType)
+	}
+	_, hasPolicy := policy.Lookup(tfType)
+	c.DriftDetectable = hasPolicy && p.comparer != nil
+	_, c.MetricsAvailable = bindings.Binding(tfType)
+	return c
+}
+
+// isDiscoverable returns true when tfType appears in the canonical
+// AWS registry. Linear scan over a small slice is fine — the
+// registry is ~109 entries and Capabilities is not on any hot path.
+func isDiscoverable(tfType string) bool {
+	return slices.Contains(registry.SupportedDiscoverTypes(registry.ProviderAWS), tfType)
+}
+
+// LabelFor returns the display label and icon-asset key for tfType.
+// Delegates to pkg/imported/labels (which falls back to the default
+// rule when no curated override is registered).
+func (p *Provider) LabelFor(tfType string) (string, string) {
+	return labels.Label(tfType), labels.IconKey(tfType)
+}
+
+// PolicyFor returns the curated FieldPolicy map for tfType.
+func (p *Provider) PolicyFor(tfType string) (policy.Map, bool) {
+	return policy.Lookup(tfType)
+}
+
+// MetricsBinding returns the registered ComponentMetricsBinding for
+// tfType.
+func (p *Provider) MetricsBinding(tfType string) (imp.ComponentMetricsBinding, bool) {
+	return bindings.Binding(tfType)
+}
+
+// StableID returns a deterministic identifier for the resource named
+// by identity. Precedence:
+//
+//  1. ARN from NativeIDs (canonical for most AWS types)
+//  2. ImportID
+//  3. Address
+//  4. Empty when identity is nil
+//
+// The ARN is preferred because it survives Address renames and is the
+// natural cross-tool join key on AWS. ImportID is the fallback for
+// types whose import key isn't an ARN (e.g. S3 bucket name).
+func (p *Provider) StableID(identity *imported.ResourceIdentity) string {
+	if identity == nil {
+		return ""
+	}
+	if arn := identity.NativeIDs["arn"]; arn != "" {
+		return arn
+	}
+	if identity.ImportID != "" {
+		return identity.ImportID
+	}
+	return identity.Address
+}
+
+// CanonicalAddress returns identity.Address when set, else
+// regenerates one via imported.GenerateAddress.
+func (p *Provider) CanonicalAddress(identity *imported.ResourceIdentity) string {
+	if identity == nil {
+		return ""
+	}
+	if identity.Address != "" {
+		return identity.Address
+	}
+	return imported.GenerateAddress(*identity, nil)
+}
+
+// Discover delegates to the underlying AWSDiscoverer.DiscoverTypes.
+// The clients union must carry clients.AWS as a *Clients (alias of
+// awsdiscover.EnrichClients); a nil discoverer or absent AWS bundle
+// returns ErrEnrichClientUnavailable.
+//
+// opts maps onto awsdiscover.DiscoverArgs:
+//   - Project    → Project (stack project name)
+//   - Regions    → Regions
+//   - TagSelectors → TagSelectors (translated to awsdiscover.TagSelector)
+//   - AccountID  → AccountID
+//
+// Progress emission is suppressed (NopEmitter) — consumers that want
+// streaming progress construct AWSDiscoverer directly and call
+// DiscoverTypes with their own Emitter. The Provider's job is
+// per-type static introspection plus one-shot live calls; streaming
+// belongs on the caller.
+func (p *Provider) Discover(ctx context.Context, types []string, clients imp.Clients, opts imp.DiscoverOpts) ([]imported.ImportedResource, error) {
+	if p.d == nil {
+		return nil, imp.ErrEnrichClientUnavailable
+	}
+	args := awsdiscover.DiscoverArgs{
+		Project:      opts.Project,
+		Regions:      opts.Regions,
+		TagSelectors: toAWSTagSelectors(opts.TagSelectors),
+		AccountID:    opts.AccountID,
+		Emitter:      progress.NopEmitter{},
+	}
+	return p.d.DiscoverTypes(ctx, types, args)
+}
+
+// toAWSTagSelectors converts the cloud-agnostic TagSelector slice into
+// the awsdiscover-specific shape.
+func toAWSTagSelectors(in []imp.TagSelector) []awsdiscover.TagSelector {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]awsdiscover.TagSelector, len(in))
+	for i, s := range in {
+		out[i] = awsdiscover.TagSelector{Key: s.Key, Value: s.Value}
+	}
+	return out
+}
+
+// EnrichAttributes delegates to AWSDiscoverer.EnrichAttributes. The
+// clients union must carry clients.AWS as a *Clients; absent bundle
+// returns ErrEnrichClientUnavailable.
+func (p *Provider) EnrichAttributes(ctx context.Context, irs []imported.ImportedResource, clients imp.Clients) error {
+	if p.d == nil {
+		return imp.ErrEnrichClientUnavailable
+	}
+	aws, err := unwrapAWSClients(clients)
+	if err != nil {
+		return err
+	}
+	return p.d.EnrichAttributes(ctx, irs, aws, progress.NopEmitter{})
+}
+
+// EnrichByID delegates to AWSDiscoverer.EnrichByID, mapping the
+// awsdiscover-specific ErrNotSupported / ErrEnrichClientUnavailable
+// onto the cross-cloud sentinels.
+func (p *Provider) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, clients imp.Clients) (imp.Attrs, error) {
+	if p.d == nil {
+		return nil, imp.ErrEnrichClientUnavailable
+	}
+	if identity == nil {
+		return nil, fmt.Errorf("aws.Provider.EnrichByID: nil identity")
+	}
+	aws, err := unwrapAWSClients(clients)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := p.d.EnrichByID(ctx, identity, aws)
+	switch {
+	case err == nil:
+		return imp.Attrs(raw), nil
+	case errors.Is(err, awsdiscover.ErrNotSupported):
+		return nil, fmt.Errorf("%w: %s", imp.ErrEnrichByIDNotImplemented, identity.Type)
+	case errors.Is(err, awsdiscover.ErrEnrichClientUnavailable):
+		return nil, fmt.Errorf("%w: %s", imp.ErrEnrichClientUnavailable, identity.Type)
+	default:
+		return nil, err
+	}
+}
+
+// unwrapAWSClients pulls the typed AWS bundle out of the cloud-agnostic
+// Clients union. Returns ErrClientsWrongCloud when the GCP slot is set
+// (cross-cloud misroute) and ErrEnrichClientUnavailable when the AWS
+// slot is nil.
+func unwrapAWSClients(c imp.Clients) (Clients, error) {
+	if c.GCP != nil && c.AWS == nil {
+		return Clients{}, imp.ErrClientsWrongCloud
+	}
+	if c.AWS == nil {
+		return Clients{}, imp.ErrEnrichClientUnavailable
+	}
+	switch v := c.AWS.(type) {
+	case Clients:
+		return v, nil
+	case *Clients:
+		if v == nil {
+			return Clients{}, imp.ErrEnrichClientUnavailable
+		}
+		return *v, nil
+	default:
+		return Clients{}, fmt.Errorf("aws.Provider: Clients.AWS has unexpected type %T", c.AWS)
+	}
+}
+
+// CompareDrift delegates to the wired DriftComparator. Returns nil
+// when no comparator is wired (the Provider was constructed with a
+// nil DriftComparator) or when the comparator returns nil. A
+// well-defined "no drift" result is still nil; consumers branch on
+// Capabilities(tfType).DriftDetectable to distinguish "no drift
+// support" from "drift support, no mismatches".
+func (p *Provider) CompareDrift(tfType string, snapshot, live imp.Attrs) []imp.FieldMismatch {
+	if p.comparer == nil {
+		return nil
+	}
+	return p.comparer(tfType, snapshot, live)
+}
+
+// RileyContext returns a one-line-per-IR summary sorted by Address.
+// Conservative format: `<address> (<type>)`. The downstream consumer
+// (Riley's chat surface) layers richer formatting on top; this is
+// the cross-cloud baseline.
+func (p *Provider) RileyContext(irs []imported.ImportedResource) []string {
+	if len(irs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(irs))
+	for _, ir := range irs {
+		out = append(out, fmt.Sprintf("%s (%s)", ir.Identity.Address, ir.Identity.Type))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// init registers the AWS Provider constructor with the top-level
+// imported package. ProviderFor("aws") returns a Provider with the
+// default drift comparator wired (pkg/drift/imported.Compare) but no
+// live AWSDiscoverer — so static introspection (SupportedTypes,
+// Capabilities, LabelFor, PolicyFor, MetricsBinding, StableID,
+// CanonicalAddress, CompareDrift, RileyContext) works out of the box;
+// callers needing Discover / Enrich must construct via NewProvider
+// with a real *awsdiscover.AWSDiscoverer.
+func init() {
+	imp.Register("aws", func() imp.Provider {
+		return NewProvider(nil, driftimp.Compare)
+	})
+}

--- a/pkg/imported/aws/provider_test.go
+++ b/pkg/imported/aws/provider_test.go
@@ -1,0 +1,346 @@
+package aws_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	composer_imported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+	awsprov "github.com/luthersystems/insideout-terraform-presets/pkg/imported/aws"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
+)
+
+func TestNewProvider_NilDiscoverer_StaticIntrospection(t *testing.T) {
+	t.Parallel()
+	p := awsprov.NewProvider(nil, nil)
+
+	// Static introspection works without a discoverer.
+	types := p.SupportedTypes()
+	want := registry.SupportedDiscoverTypes("aws")
+	if len(types) != len(want) {
+		t.Errorf("SupportedTypes len = %d, want %d", len(types), len(want))
+	}
+
+	// Capabilities: a known AWS type should report Discoverable=true even
+	// without a discoverer (the discoverable flag comes from the registry).
+	caps := p.Capabilities("aws_s3_bucket")
+	if !caps.Discoverable {
+		t.Error("aws_s3_bucket should be Discoverable from the registry")
+	}
+	// Without a discoverer, Enrichable is false.
+	if caps.Enrichable {
+		t.Error("Enrichable should be false without a discoverer")
+	}
+
+	// LabelFor falls back to the default rule.
+	lbl, icon := p.LabelFor("aws_s3_bucket")
+	if lbl == "" || icon == "" {
+		t.Errorf("LabelFor(aws_s3_bucket) = (%q, %q); both should be non-empty", lbl, icon)
+	}
+
+	// Live calls return ErrEnrichClientUnavailable without a discoverer.
+	if _, err := p.Discover(context.Background(), nil, imp.Clients{}, imp.DiscoverOpts{}); !errors.Is(err, imp.ErrEnrichClientUnavailable) {
+		t.Errorf("Discover with nil discoverer: err = %v, want ErrEnrichClientUnavailable", err)
+	}
+	if err := p.EnrichAttributes(context.Background(), nil, imp.Clients{}); !errors.Is(err, imp.ErrEnrichClientUnavailable) {
+		t.Errorf("EnrichAttributes with nil discoverer: err = %v, want ErrEnrichClientUnavailable", err)
+	}
+	if _, err := p.EnrichByID(context.Background(), nil, imp.Clients{}); !errors.Is(err, imp.ErrEnrichClientUnavailable) {
+		t.Errorf("EnrichByID with nil discoverer: err = %v, want ErrEnrichClientUnavailable", err)
+	}
+}
+
+func TestProvider_Capabilities_Enrichable(t *testing.T) {
+	t.Parallel()
+	d := awsdiscover.NewAWSDiscoverer(awssdk.Config{})
+	p := awsprov.NewProvider(d, nil)
+
+	// aws_dynamodb_table has a registered enricher (Bundle 1).
+	if got := p.Capabilities("aws_dynamodb_table"); !got.Enrichable {
+		t.Errorf("aws_dynamodb_table: Enrichable should be true, got %+v", got)
+	}
+	// aws_vpc is in the registry but has no enricher yet — Enrichable=false.
+	if got := p.Capabilities("aws_vpc"); got.Enrichable {
+		t.Errorf("aws_vpc: Enrichable should be false (no enricher), got %+v", got)
+	}
+	// Unknown type: all flags false.
+	if got := p.Capabilities("aws_bogus_unknown"); got.Discoverable || got.Enrichable {
+		t.Errorf("unknown type: should be all false, got %+v", got)
+	}
+}
+
+func TestProvider_Capabilities_DriftDetectable(t *testing.T) {
+	t.Parallel()
+	d := awsdiscover.NewAWSDiscoverer(awssdk.Config{})
+
+	// Without a comparator, DriftDetectable is always false.
+	p := awsprov.NewProvider(d, nil)
+	if got := p.Capabilities("aws_dynamodb_table"); got.DriftDetectable {
+		t.Errorf("Without comparator, DriftDetectable should be false; got %+v", got)
+	}
+
+	// With a comparator, DriftDetectable depends on policy registration.
+	noopComparer := func(string, imp.Attrs, imp.Attrs) []imp.FieldMismatch { return nil }
+	pWithCmp := awsprov.NewProvider(d, noopComparer)
+	// aws_dynamodb_table has a registered policy.
+	if got := pWithCmp.Capabilities("aws_dynamodb_table"); !got.DriftDetectable {
+		t.Errorf("With comparator + policy, DriftDetectable should be true; got %+v", got)
+	}
+	// aws_vpc has no policy registered today.
+	if got := pWithCmp.Capabilities("aws_vpc"); got.DriftDetectable {
+		t.Errorf("aws_vpc has no policy; DriftDetectable should be false; got %+v", got)
+	}
+}
+
+func TestProvider_StableID(t *testing.T) {
+	t.Parallel()
+	p := awsprov.NewProvider(nil, nil)
+
+	if got := p.StableID(nil); got != "" {
+		t.Errorf("StableID(nil) = %q, want \"\"", got)
+	}
+
+	// ARN-bearing identity.
+	id := &composer_imported.ResourceIdentity{
+		Type:      "aws_s3_bucket",
+		Address:   "aws_s3_bucket.b",
+		ImportID:  "my-bucket",
+		NativeIDs: map[string]string{"arn": "arn:aws:s3:::my-bucket"},
+	}
+	if got := p.StableID(id); got != "arn:aws:s3:::my-bucket" {
+		t.Errorf("StableID arn-bearing = %q", got)
+	}
+
+	// ImportID fallback when no ARN.
+	id2 := &composer_imported.ResourceIdentity{
+		Type:     "aws_iam_role",
+		Address:  "aws_iam_role.r",
+		ImportID: "my-role",
+	}
+	if got := p.StableID(id2); got != "my-role" {
+		t.Errorf("StableID ImportID fallback = %q", got)
+	}
+
+	// Address fallback when no ARN or ImportID.
+	id3 := &composer_imported.ResourceIdentity{
+		Type:    "aws_iam_role",
+		Address: "aws_iam_role.r",
+	}
+	if got := p.StableID(id3); got != "aws_iam_role.r" {
+		t.Errorf("StableID address fallback = %q", got)
+	}
+}
+
+func TestProvider_CanonicalAddress(t *testing.T) {
+	t.Parallel()
+	p := awsprov.NewProvider(nil, nil)
+
+	if got := p.CanonicalAddress(nil); got != "" {
+		t.Errorf("CanonicalAddress(nil) = %q, want \"\"", got)
+	}
+
+	// Address set → returned unchanged.
+	id := &composer_imported.ResourceIdentity{
+		Type:    "aws_s3_bucket",
+		Address: "aws_s3_bucket.mybucket",
+	}
+	if got := p.CanonicalAddress(id); got != "aws_s3_bucket.mybucket" {
+		t.Errorf("CanonicalAddress with Address = %q, want unchanged", got)
+	}
+
+	// Address empty → regenerated from NameHint via imported.GenerateAddress.
+	id2 := &composer_imported.ResourceIdentity{
+		Type:     "aws_s3_bucket",
+		NameHint: "MyBucket",
+	}
+	got := p.CanonicalAddress(id2)
+	if got == "" || got == "aws_s3_bucket." {
+		t.Errorf("CanonicalAddress with empty Address returned %q", got)
+	}
+}
+
+func TestProvider_RileyContext(t *testing.T) {
+	t.Parallel()
+	p := awsprov.NewProvider(nil, nil)
+
+	if got := p.RileyContext(nil); got != nil {
+		t.Errorf("RileyContext(nil) = %v, want nil", got)
+	}
+
+	irs := []composer_imported.ImportedResource{
+		{Identity: composer_imported.ResourceIdentity{Type: "aws_s3_bucket", Address: "aws_s3_bucket.z"}},
+		{Identity: composer_imported.ResourceIdentity{Type: "aws_iam_role", Address: "aws_iam_role.a"}},
+	}
+	got := p.RileyContext(irs)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(got))
+	}
+	// Sorted by line — aws_iam_role.a (...) sorts before aws_s3_bucket.z (...)
+	if got[0] >= got[1] {
+		t.Errorf("RileyContext not sorted: %v", got)
+	}
+}
+
+func TestProvider_CompareDrift(t *testing.T) {
+	t.Parallel()
+
+	// No comparator wired → nil.
+	p := awsprov.NewProvider(nil, nil)
+	if got := p.CompareDrift("aws_s3_bucket", nil, nil); got != nil {
+		t.Errorf("CompareDrift with nil comparer = %v, want nil", got)
+	}
+
+	// With a comparator → delegated.
+	want := []imp.FieldMismatch{{Field: "x", Snapshot: 1, Cloud: 2}}
+	cmp := func(tfType string, snap, live imp.Attrs) []imp.FieldMismatch {
+		return want
+	}
+	p2 := awsprov.NewProvider(nil, cmp)
+	got := p2.CompareDrift("aws_s3_bucket", nil, nil)
+	if len(got) != 1 || got[0].Field != "x" {
+		t.Errorf("CompareDrift delegate = %v, want %v", got, want)
+	}
+}
+
+func TestProvider_PolicyAndMetrics(t *testing.T) {
+	t.Parallel()
+	p := awsprov.NewProvider(nil, nil)
+
+	// PolicyFor: aws_dynamodb_table has a curated policy.
+	if _, ok := p.PolicyFor("aws_dynamodb_table"); !ok {
+		t.Error("aws_dynamodb_table should have a registered policy")
+	}
+	// Unknown type: no policy.
+	if _, ok := p.PolicyFor("aws_bogus_unknown"); ok {
+		t.Error("unknown type should not have a policy")
+	}
+
+	// MetricsBinding: zero registered today, all bool-false (test pinned to
+	// the registry contract, not specific data).
+	_, _ = p.MetricsBinding("aws_s3_bucket")
+}
+
+func TestProvider_EnrichByID_NoEnricher(t *testing.T) {
+	t.Parallel()
+	d := awsdiscover.NewAWSDiscoverer(awssdk.Config{})
+	p := awsprov.NewProvider(d, nil)
+
+	// aws_vpc has no enricher registered → ErrEnrichByIDNotImplemented.
+	id := &composer_imported.ResourceIdentity{Type: "aws_vpc", ImportID: "vpc-123"}
+	_, err := p.EnrichByID(context.Background(), id, imp.Clients{AWS: awsprov.Clients{}})
+	if !errors.Is(err, imp.ErrEnrichByIDNotImplemented) {
+		t.Errorf("EnrichByID for non-enriched type: err = %v, want ErrEnrichByIDNotImplemented", err)
+	}
+}
+
+func TestProvider_EnrichByID_HasByIDEnricher(t *testing.T) {
+	t.Parallel()
+	d := awsdiscover.NewAWSDiscoverer(awssdk.Config{})
+	p := awsprov.NewProvider(d, nil)
+
+	// aws_cloudwatch_log_group is registered AND implements ByIDEnricher
+	// per byid_enricher_test.go. With nil clients on EnrichClients it
+	// should surface ErrEnrichClientUnavailable from the underlying
+	// enricher — that's the expected path for a no-creds test.
+	id := &composer_imported.ResourceIdentity{
+		Type:     "aws_cloudwatch_log_group",
+		Region:   "us-east-1",
+		ImportID: "/aws/lambda/test",
+	}
+	_, err := p.EnrichByID(context.Background(), id, imp.Clients{AWS: awsprov.Clients{}})
+	// The exact error depends on the enricher implementation; we accept
+	// either ErrEnrichClientUnavailable (downgraded path) or some other
+	// wrapped error. The key contract is: NOT ErrEnrichByIDNotImplemented
+	// (the enricher exists and implements the interface).
+	if errors.Is(err, imp.ErrEnrichByIDNotImplemented) {
+		t.Errorf("aws_cloudwatch_log_group should implement ByIDEnricher; got ErrEnrichByIDNotImplemented")
+	}
+}
+
+func TestProvider_EnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	d := awsdiscover.NewAWSDiscoverer(awssdk.Config{})
+	p := awsprov.NewProvider(d, nil)
+	_, err := p.EnrichByID(context.Background(), nil, imp.Clients{AWS: awsprov.Clients{}})
+	if err == nil {
+		t.Error("expected error for nil identity")
+	}
+}
+
+func TestProvider_Discover_WrongCloud(t *testing.T) {
+	t.Parallel()
+	d := awsdiscover.NewAWSDiscoverer(awssdk.Config{})
+	p := awsprov.NewProvider(d, nil)
+
+	// GCP clients on AWS provider → EnrichAttributes returns
+	// ErrClientsWrongCloud. (Discover does not unwrap clients today —
+	// the AWSDiscoverer doesn't take EnrichClients on Discover — so
+	// we test the EnrichAttributes path.)
+	err := p.EnrichAttributes(context.Background(), nil, imp.Clients{GCP: struct{}{}})
+	if !errors.Is(err, imp.ErrClientsWrongCloud) {
+		t.Errorf("AWS provider with GCP clients: err = %v, want ErrClientsWrongCloud", err)
+	}
+}
+
+func TestProvider_Discover_PassesThrough(t *testing.T) {
+	t.Parallel()
+	d := awsdiscover.NewAWSDiscoverer(awssdk.Config{Region: "us-east-1"})
+	p := awsprov.NewProvider(d, nil)
+
+	// Empty types and no real cloud creds — the call should return
+	// an error from the underlying discoverer rather than panic. We
+	// can't drive the SDK without credentials, so the assertion here
+	// is: no panic, error path returns something inspectable.
+	_, err := p.Discover(context.Background(), []string{"aws_bogus"}, imp.Clients{AWS: awsprov.Clients{}}, imp.DiscoverOpts{Project: "test"})
+	if err == nil {
+		t.Error("expected error for unknown type, got nil")
+	}
+}
+
+// TestProvider_CapabilitiesParity tests that for every registered type,
+// Capabilities(t).Enrichable agrees with what EnrichByID actually does.
+// Specifically: types with Enrichable=true should NOT return
+// ErrEnrichByIDNotImplemented (they may return other errors due to
+// nil SDK clients, but the enricher is present).
+func TestProvider_CapabilitiesParity(t *testing.T) {
+	t.Parallel()
+	d := awsdiscover.NewAWSDiscoverer(awssdk.Config{})
+	p := awsprov.NewProvider(d, nil)
+
+	for _, tfType := range p.SupportedTypes() {
+		caps := p.Capabilities(tfType)
+		id := &composer_imported.ResourceIdentity{
+			Type:     tfType,
+			Region:   "us-east-1",
+			ImportID: "test-id",
+		}
+		_, err := p.EnrichByID(context.Background(), id, imp.Clients{AWS: awsprov.Clients{}})
+
+		notImpl := errors.Is(err, imp.ErrEnrichByIDNotImplemented)
+		if caps.Enrichable && notImpl {
+			// Enrichable=true but no ByIDEnricher — that's an
+			// allowed state today (aws_dynamodb_table per
+			// byid_enricher_test.go). The parity contract we
+			// enforce is the WEAKER one: Enrichable=false MUST
+			// imply ErrEnrichByIDNotImplemented.
+			continue
+		}
+		if !caps.Enrichable && !notImpl {
+			t.Errorf("%s: Enrichable=false but EnrichByID returned %v; want ErrEnrichByIDNotImplemented", tfType, err)
+		}
+	}
+}
+
+func TestProvider_EnrichByID_RawMessageRoundtrip(t *testing.T) {
+	t.Parallel()
+	// Ensure Attrs is a json.RawMessage at the type level.
+	var a imp.Attrs = json.RawMessage(`{"k":1}`)
+	if string(a) != `{"k":1}` {
+		t.Errorf("Attrs round-trip: got %q", string(a))
+	}
+}

--- a/pkg/imported/aws/provider_test.go
+++ b/pkg/imported/aws/provider_test.go
@@ -9,7 +9,7 @@ import (
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
-	composer_imported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
 	awsprov "github.com/luthersystems/insideout-terraform-presets/pkg/imported/aws"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
@@ -106,7 +106,7 @@ func TestProvider_StableID(t *testing.T) {
 	}
 
 	// ARN-bearing identity.
-	id := &composer_imported.ResourceIdentity{
+	id := &composerimported.ResourceIdentity{
 		Type:      "aws_s3_bucket",
 		Address:   "aws_s3_bucket.b",
 		ImportID:  "my-bucket",
@@ -117,7 +117,7 @@ func TestProvider_StableID(t *testing.T) {
 	}
 
 	// ImportID fallback when no ARN.
-	id2 := &composer_imported.ResourceIdentity{
+	id2 := &composerimported.ResourceIdentity{
 		Type:     "aws_iam_role",
 		Address:  "aws_iam_role.r",
 		ImportID: "my-role",
@@ -127,7 +127,7 @@ func TestProvider_StableID(t *testing.T) {
 	}
 
 	// Address fallback when no ARN or ImportID.
-	id3 := &composer_imported.ResourceIdentity{
+	id3 := &composerimported.ResourceIdentity{
 		Type:    "aws_iam_role",
 		Address: "aws_iam_role.r",
 	}
@@ -145,7 +145,7 @@ func TestProvider_CanonicalAddress(t *testing.T) {
 	}
 
 	// Address set → returned unchanged.
-	id := &composer_imported.ResourceIdentity{
+	id := &composerimported.ResourceIdentity{
 		Type:    "aws_s3_bucket",
 		Address: "aws_s3_bucket.mybucket",
 	}
@@ -154,7 +154,7 @@ func TestProvider_CanonicalAddress(t *testing.T) {
 	}
 
 	// Address empty → regenerated from NameHint via imported.GenerateAddress.
-	id2 := &composer_imported.ResourceIdentity{
+	id2 := &composerimported.ResourceIdentity{
 		Type:     "aws_s3_bucket",
 		NameHint: "MyBucket",
 	}
@@ -164,25 +164,25 @@ func TestProvider_CanonicalAddress(t *testing.T) {
 	}
 }
 
-func TestProvider_RileyContext(t *testing.T) {
+func TestProvider_AgentContext(t *testing.T) {
 	t.Parallel()
 	p := awsprov.NewProvider(nil, nil)
 
-	if got := p.RileyContext(nil); got != nil {
-		t.Errorf("RileyContext(nil) = %v, want nil", got)
+	if got := p.AgentContext(nil); got != nil {
+		t.Errorf("AgentContext(nil) = %v, want nil", got)
 	}
 
-	irs := []composer_imported.ImportedResource{
-		{Identity: composer_imported.ResourceIdentity{Type: "aws_s3_bucket", Address: "aws_s3_bucket.z"}},
-		{Identity: composer_imported.ResourceIdentity{Type: "aws_iam_role", Address: "aws_iam_role.a"}},
+	irs := []composerimported.ImportedResource{
+		{Identity: composerimported.ResourceIdentity{Type: "aws_s3_bucket", Address: "aws_s3_bucket.z"}},
+		{Identity: composerimported.ResourceIdentity{Type: "aws_iam_role", Address: "aws_iam_role.a"}},
 	}
-	got := p.RileyContext(irs)
+	got := p.AgentContext(irs)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(got))
 	}
 	// Sorted by line — aws_iam_role.a (...) sorts before aws_s3_bucket.z (...)
 	if got[0] >= got[1] {
-		t.Errorf("RileyContext not sorted: %v", got)
+		t.Errorf("AgentContext not sorted: %v", got)
 	}
 }
 
@@ -231,7 +231,7 @@ func TestProvider_EnrichByID_NoEnricher(t *testing.T) {
 	p := awsprov.NewProvider(d, nil)
 
 	// aws_vpc has no enricher registered → ErrEnrichByIDNotImplemented.
-	id := &composer_imported.ResourceIdentity{Type: "aws_vpc", ImportID: "vpc-123"}
+	id := &composerimported.ResourceIdentity{Type: "aws_vpc", ImportID: "vpc-123"}
 	_, err := p.EnrichByID(context.Background(), id, imp.Clients{AWS: awsprov.Clients{}})
 	if !errors.Is(err, imp.ErrEnrichByIDNotImplemented) {
 		t.Errorf("EnrichByID for non-enriched type: err = %v, want ErrEnrichByIDNotImplemented", err)
@@ -247,7 +247,7 @@ func TestProvider_EnrichByID_HasByIDEnricher(t *testing.T) {
 	// per byid_enricher_test.go. With nil clients on EnrichClients it
 	// should surface ErrEnrichClientUnavailable from the underlying
 	// enricher — that's the expected path for a no-creds test.
-	id := &composer_imported.ResourceIdentity{
+	id := &composerimported.ResourceIdentity{
 		Type:     "aws_cloudwatch_log_group",
 		Region:   "us-east-1",
 		ImportID: "/aws/lambda/test",
@@ -314,7 +314,7 @@ func TestProvider_CapabilitiesParity(t *testing.T) {
 
 	for _, tfType := range p.SupportedTypes() {
 		caps := p.Capabilities(tfType)
-		id := &composer_imported.ResourceIdentity{
+		id := &composerimported.ResourceIdentity{
 			Type:     tfType,
 			Region:   "us-east-1",
 			ImportID: "test-id",

--- a/pkg/imported/aws/provider_test.go
+++ b/pkg/imported/aws/provider_test.go
@@ -2,7 +2,6 @@ package aws_test
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
@@ -302,15 +301,32 @@ func TestProvider_Discover_PassesThrough(t *testing.T) {
 	}
 }
 
-// TestProvider_CapabilitiesParity tests that for every registered type,
-// Capabilities(t).Enrichable agrees with what EnrichByID actually does.
-// Specifically: types with Enrichable=true should NOT return
-// ErrEnrichByIDNotImplemented (they may return other errors due to
-// nil SDK clients, but the enricher is present).
+// TestProvider_CapabilitiesParity pins bidirectional agreement between
+// Capabilities(t).Enrichable and the EnrichByID dispatch result:
+//
+//   - Enrichable=false ⇒ EnrichByID returns ErrEnrichByIDNotImplemented.
+//     If a type isn't enrichable, the by-ID path must NOT silently work.
+//   - Enrichable=true AND tfType not in enrichableNoByID ⇒ EnrichByID
+//     must NOT return ErrEnrichByIDNotImplemented (it may return other
+//     errors from nil SDK clients, but the by-ID dispatcher must
+//     resolve to a real impl).
+//
+// The enrichableNoByID exemption list pins the known state where a
+// type has an AttributeEnricher but not a ByIDEnricher today
+// (aws_dynamodb_table per byid_enricher_test.go's notImplemented
+// allowlist). When Phase 2 lands a real ByIDEnricher for dynamodb,
+// drop the entry — the test will then guard that direction too.
 func TestProvider_CapabilitiesParity(t *testing.T) {
 	t.Parallel()
 	d := awsdiscover.NewAWSDiscoverer(awssdk.Config{})
 	p := awsprov.NewProvider(d, nil)
+
+	// Types whose AttributeEnricher exists but doesn't satisfy
+	// ByIDEnricher yet. Mirrors notImplemented in
+	// cmd/insideout-import/awsdiscover/byid_enricher_test.go.
+	enrichableNoByID := map[string]bool{
+		"aws_dynamodb_table": true,
+	}
 
 	for _, tfType := range p.SupportedTypes() {
 		caps := p.Capabilities(tfType)
@@ -322,25 +338,12 @@ func TestProvider_CapabilitiesParity(t *testing.T) {
 		_, err := p.EnrichByID(context.Background(), id, imp.Clients{AWS: awsprov.Clients{}})
 
 		notImpl := errors.Is(err, imp.ErrEnrichByIDNotImplemented)
-		if caps.Enrichable && notImpl {
-			// Enrichable=true but no ByIDEnricher — that's an
-			// allowed state today (aws_dynamodb_table per
-			// byid_enricher_test.go). The parity contract we
-			// enforce is the WEAKER one: Enrichable=false MUST
-			// imply ErrEnrichByIDNotImplemented.
-			continue
-		}
-		if !caps.Enrichable && !notImpl {
-			t.Errorf("%s: Enrichable=false but EnrichByID returned %v; want ErrEnrichByIDNotImplemented", tfType, err)
-		}
-	}
-}
 
-func TestProvider_EnrichByID_RawMessageRoundtrip(t *testing.T) {
-	t.Parallel()
-	// Ensure Attrs is a json.RawMessage at the type level.
-	var a imp.Attrs = json.RawMessage(`{"k":1}`)
-	if string(a) != `{"k":1}` {
-		t.Errorf("Attrs round-trip: got %q", string(a))
+		switch {
+		case !caps.Enrichable && !notImpl:
+			t.Errorf("%s: Enrichable=false but EnrichByID returned %v; want ErrEnrichByIDNotImplemented", tfType, err)
+		case caps.Enrichable && notImpl && !enrichableNoByID[tfType]:
+			t.Errorf("%s: Enrichable=true but EnrichByID returned ErrEnrichByIDNotImplemented (add to enrichableNoByID exemption if intentional, else wire ByIDEnricher impl)", tfType)
+		}
 	}
 }

--- a/pkg/imported/bindings/bindings.go
+++ b/pkg/imported/bindings/bindings.go
@@ -14,6 +14,7 @@ package bindings
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 )
 
@@ -88,14 +89,6 @@ func RegisteredTypes() []string {
 	for t := range registry {
 		out = append(out, t)
 	}
-	// Insertion-sort to keep the package dependency-light (the
-	// registry is small — at most ~163 entries even at full preset
-	// coverage — so sort.Strings would be overkill and would pull a
-	// stdlib package the rest of the file doesn't need).
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j-1] > out[j]; j-- {
-			out[j-1], out[j] = out[j], out[j-1]
-		}
-	}
+	sort.Strings(out)
 	return out
 }

--- a/pkg/imported/bindings/bindings.go
+++ b/pkg/imported/bindings/bindings.go
@@ -1,0 +1,101 @@
+// Package bindings is the registry of per-Terraform-type metrics
+// bindings — the data needed to translate an imported resource's
+// identity into a CloudWatch / Cloud Monitoring time-series query.
+// It is the upstream half of the metric-binding gap noted in
+// presets#482: pkg/observability already binds metrics by
+// composer.ComponentKey, but a TF-type-keyed map is what the
+// downstream pkg/imported.Provider.MetricsBinding(tfType) method
+// dispatches against.
+//
+// The registry starts empty in this skeleton (presets#TBD). Per-type
+// PRs in the enricher rollout register bindings opportunistically;
+// types without a binding return (zero, false) from Binding(tfType).
+package bindings
+
+import (
+	"fmt"
+	"sync"
+)
+
+// ComponentMetricsBinding describes the metrics surface for a single
+// imported Terraform resource type. Field semantics mirror
+// presets#482's `imported.ComponentMetricsBinding`:
+//
+//   - Service / Action — opaque pair the consumer interprets (e.g.
+//     "s3" / "get-metrics" routes to a service-specific handler in
+//     the downstream consumer; presets does not interpret these
+//     strings, it only ferries them).
+//   - DimensionKey — the CloudWatch / Cloud Monitoring dimension
+//     name (e.g. "BucketName"). What the cloud API expects.
+//   - DimensionFrom — the field on imported.ResourceIdentity that
+//     supplies the dimension value. Typically a key in
+//     Identity.ProviderIdentity or Identity.NativeIDs.
+//   - DefaultMetrics — the metric names the consumer should fetch
+//     when no per-call override is supplied.
+//
+// Empty fields are tolerated — the consumer treats absent fields as
+// "no default" and falls back to its own configuration. Registration
+// is the source of truth, not a contract for completeness.
+type ComponentMetricsBinding struct {
+	Service        string
+	Action         string
+	DimensionKey   string
+	DimensionFrom  string
+	DefaultMetrics []string
+}
+
+var (
+	regMu    sync.RWMutex
+	registry = map[string]ComponentMetricsBinding{}
+)
+
+// Register pins a ComponentMetricsBinding for tfType. Panics on
+// duplicate registration for the same key (mirrors the policy
+// package's Register contract — a duplicate means two files compete
+// for the same key, which is always a bug). Panics on empty tfType.
+func Register(tfType string, b ComponentMetricsBinding) {
+	if tfType == "" {
+		panic("bindings.Register: empty tfType")
+	}
+	regMu.Lock()
+	defer regMu.Unlock()
+	if _, ok := registry[tfType]; ok {
+		panic(fmt.Sprintf("bindings.Register: duplicate registration for %q", tfType))
+	}
+	registry[tfType] = b
+}
+
+// Binding returns the registered ComponentMetricsBinding for tfType.
+// The bool reports whether an entry exists; callers must not treat a
+// zero-value binding (no entry) as "no metrics" without checking ok —
+// a registered binding with empty DefaultMetrics is also valid and
+// means "use consumer defaults", distinct from "type isn't bound at
+// all".
+func Binding(tfType string) (ComponentMetricsBinding, bool) {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	b, ok := registry[tfType]
+	return b, ok
+}
+
+// RegisteredTypes returns the sorted set of tfTypes with a registered
+// binding. Used by the eventual codegen subcommand to enumerate the
+// registry for downstream consumers.
+func RegisteredTypes() []string {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	out := make([]string, 0, len(registry))
+	for t := range registry {
+		out = append(out, t)
+	}
+	// Insertion-sort to keep the package dependency-light (the
+	// registry is small — at most ~163 entries even at full preset
+	// coverage — so sort.Strings would be overkill and would pull a
+	// stdlib package the rest of the file doesn't need).
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}

--- a/pkg/imported/bindings/bindings_test.go
+++ b/pkg/imported/bindings/bindings_test.go
@@ -1,0 +1,103 @@
+package bindings
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func resetForTest(t *testing.T) {
+	t.Helper()
+	regMu.Lock()
+	defer regMu.Unlock()
+	registry = map[string]ComponentMetricsBinding{}
+}
+
+func TestEmptyLookup(t *testing.T) {
+	resetForTest(t)
+	if _, ok := Binding("aws_s3_bucket"); ok {
+		t.Errorf("Binding on empty registry returned ok=true")
+	}
+}
+
+func TestRegisterAndLookup(t *testing.T) {
+	resetForTest(t)
+	want := ComponentMetricsBinding{
+		Service:        "s3",
+		Action:         "get-metrics",
+		DimensionKey:   "BucketName",
+		DimensionFrom:  "ImportID",
+		DefaultMetrics: []string{"NumberOfObjects", "BucketSizeBytes"},
+	}
+	Register("aws_s3_bucket", want)
+	got, ok := Binding("aws_s3_bucket")
+	if !ok {
+		t.Fatal("Binding returned ok=false after Register")
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Binding = %#v, want %#v", got, want)
+	}
+}
+
+func TestRegisteredZeroValueIsDistinctFromAbsent(t *testing.T) {
+	resetForTest(t)
+	// A registered zero-value binding is a valid "use consumer
+	// defaults" entry — must report ok=true, distinct from absent.
+	Register("aws_dynamodb_table", ComponentMetricsBinding{})
+	got, ok := Binding("aws_dynamodb_table")
+	if !ok {
+		t.Fatal("registered zero-value binding reported ok=false")
+	}
+	if !reflect.DeepEqual(got, ComponentMetricsBinding{}) {
+		t.Errorf("zero-value lookup = %#v, want empty", got)
+	}
+	// Absent type stays ok=false.
+	if _, ok := Binding("aws_s3_bucket"); ok {
+		t.Error("absent type reported ok=true")
+	}
+}
+
+func TestRegisterEmptyTypePanics(t *testing.T) {
+	resetForTest(t)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on empty tfType")
+		}
+	}()
+	Register("", ComponentMetricsBinding{})
+}
+
+func TestRegisterDuplicatePanics(t *testing.T) {
+	resetForTest(t)
+	Register("aws_s3_bucket", ComponentMetricsBinding{Service: "s3"})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on duplicate registration")
+		}
+	}()
+	Register("aws_s3_bucket", ComponentMetricsBinding{Service: "s3-again"})
+}
+
+func TestRegisteredTypesSorted(t *testing.T) {
+	resetForTest(t)
+	Register("google_pubsub_topic", ComponentMetricsBinding{})
+	Register("aws_s3_bucket", ComponentMetricsBinding{})
+	Register("aws_dynamodb_table", ComponentMetricsBinding{})
+	got := RegisteredTypes()
+	want := []string{"aws_dynamodb_table", "aws_s3_bucket", "google_pubsub_topic"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RegisteredTypes() = %v, want %v", got, want)
+	}
+}
+
+func TestConcurrentRegisterReadSafety(t *testing.T) {
+	resetForTest(t)
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			_, _ = Binding("aws_s3_bucket")
+		})
+	}
+	Register("aws_s3_bucket", ComponentMetricsBinding{Service: "s3"})
+	wg.Wait()
+}

--- a/pkg/imported/bindings/bindings_test.go
+++ b/pkg/imported/bindings/bindings_test.go
@@ -1,7 +1,9 @@
 package bindings
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -51,8 +53,21 @@ func TestRegisteredZeroValueIsDistinctFromAbsent(t *testing.T) {
 	if !reflect.DeepEqual(got, ComponentMetricsBinding{}) {
 		t.Errorf("zero-value lookup = %#v, want empty", got)
 	}
+	// Partial-zero: Service set but DefaultMetrics nil. A regression
+	// that switches Binding's bool from "exists in map" to "has any
+	// non-zero field" / "DefaultMetrics non-empty" would break this
+	// case while the all-zero case above continues to pass.
+	partial := ComponentMetricsBinding{Service: "s3"}
+	Register("aws_s3_bucket", partial)
+	gotPartial, okPartial := Binding("aws_s3_bucket")
+	if !okPartial {
+		t.Fatal("partial-zero binding (Service-only) reported ok=false")
+	}
+	if !reflect.DeepEqual(gotPartial, partial) {
+		t.Errorf("partial-zero lookup = %#v, want %#v", gotPartial, partial)
+	}
 	// Absent type stays ok=false.
-	if _, ok := Binding("aws_s3_bucket"); ok {
+	if _, ok := Binding("aws_lambda_function"); ok {
 		t.Error("absent type reported ok=true")
 	}
 }
@@ -60,8 +75,12 @@ func TestRegisteredZeroValueIsDistinctFromAbsent(t *testing.T) {
 func TestRegisterEmptyTypePanics(t *testing.T) {
 	resetForTest(t)
 	defer func() {
-		if r := recover(); r == nil {
+		r := recover()
+		if r == nil {
 			t.Fatal("expected panic on empty tfType")
+		}
+		if msg := fmt.Sprint(r); !strings.Contains(msg, "empty tfType") {
+			t.Errorf("panic = %q, want substring %q", msg, "empty tfType")
 		}
 	}()
 	Register("", ComponentMetricsBinding{})
@@ -71,8 +90,12 @@ func TestRegisterDuplicatePanics(t *testing.T) {
 	resetForTest(t)
 	Register("aws_s3_bucket", ComponentMetricsBinding{Service: "s3"})
 	defer func() {
-		if r := recover(); r == nil {
+		r := recover()
+		if r == nil {
 			t.Fatal("expected panic on duplicate registration")
+		}
+		if msg := fmt.Sprint(r); !strings.Contains(msg, "duplicate registration") {
+			t.Errorf("panic = %q, want substring %q", msg, "duplicate registration")
 		}
 	}()
 	Register("aws_s3_bucket", ComponentMetricsBinding{Service: "s3-again"})
@@ -92,6 +115,11 @@ func TestRegisteredTypesSorted(t *testing.T) {
 
 func TestConcurrentRegisterReadSafety(t *testing.T) {
 	resetForTest(t)
+	// Race-detector smoke test: 32 concurrent readers against a writer
+	// must not panic, deadlock, or trigger the race detector. This test
+	// is only meaningfully assertive under `go test -race` — without it
+	// the test still runs (and verifies no deadlock / panic), but data
+	// races would go undetected. CI is expected to run with -race.
 	var wg sync.WaitGroup
 	for range 32 {
 		wg.Go(func() {

--- a/pkg/imported/closure/closure.go
+++ b/pkg/imported/closure/closure.go
@@ -1,0 +1,192 @@
+// Package closure computes the transitive dependency closure of a set
+// of imported resources. The UI's "auto-include" feature lets a user
+// pick a single ImportedResource (e.g. an aws_lambda_function) and
+// expects the wizard to surface every resource that lambda transitively
+// references — its IAM role, security groups, subnets, log groups,
+// etc. — so the user can confirm the bundle in one step instead of
+// hunting each reference manually.
+//
+// The walker is intentionally identity-driven rather than schema-aware:
+// it scans every Attrs field (decoded as opaque map[string]any) for
+// string leaves that match the known cross-resource identifier shapes
+// of any resource in `all` (ARN, GCP self-link, Terraform import ID,
+// Terraform address). This keeps closure decoupled from the per-type
+// codegen surface in pkg/composer/imported/generated, and means closure
+// "just works" for any resource type whose Attrs JSON happens to carry
+// a reference string — no per-type plumbing.
+//
+// Cycles are tolerated via a visited-set; the loop is bounded by
+// maxIterations as belt-and-suspenders against degenerate inputs.
+package closure
+
+import (
+	"encoding/json"
+	"sort"
+
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// maxIterations bounds the closure walk. Each iteration drains the
+// queue, so for any non-pathological reference graph the loop converges
+// in a handful of passes. The bound exists to defend against accidental
+// cycles in callers' Attrs payloads (e.g. a self-referential ARN), not
+// to truncate legitimate closures — a thousand transitively-referenced
+// resources is already orders of magnitude beyond any realistic stack.
+const maxIterations = 1000
+
+// DependencyClosure returns picked plus every transitively-referenced
+// ImportedResource from `all` that picked depends on. Used by the UI's
+// "auto-include" feature so a user can pick `aws_lambda_function` and
+// the closure walker automatically pulls in its IAM role / security
+// group / subnet references.
+//
+// Edge detection: walks each picked resource's Attrs (json.RawMessage)
+// for string fields that look like cross-resource references — ARN,
+// GCP self-link, or a known TF-id shape — and matches them against
+// the Identity of every resource in `all`. The matched resource is
+// added to the closure and its Attrs are walked in turn, until a fixed
+// point is reached.
+//
+// Closure is order-stable: the returned slice is sorted by
+// Identity.Address. Cycles are tolerated (visited-set dedup).
+// Resources in `picked` that aren't in `all` are still returned (a
+// picked resource is in the closure by definition) and participate in
+// the walk so their references resolve against `all`.
+func DependencyClosure(
+	picked, all []composerimported.ImportedResource,
+) []composerimported.ImportedResource {
+	if len(picked) == 0 {
+		return nil
+	}
+
+	// Build the reverse index from any plausible cross-resource
+	// identifier shape (ARN, self_link, import ID, address) back to
+	// the resource that owns it. Duplicate keys across resources are
+	// resolved first-write-wins — the inputs are nominally unique by
+	// Address, and an accidental collision on a non-address key is
+	// indistinguishable from a real reference at this layer.
+	index := buildIndex(all)
+
+	// visited tracks every Address we've added to closure (or picked
+	// without an Address — those are keyed by their pointer-identity
+	// via the keyForResource fallback).
+	visited := make(map[string]struct{}, len(picked)+len(all))
+	closure := make([]composerimported.ImportedResource, 0, len(picked))
+	queue := make([]composerimported.ImportedResource, 0, len(picked))
+
+	for _, p := range picked {
+		k := keyForResource(p)
+		if _, seen := visited[k]; seen {
+			continue
+		}
+		visited[k] = struct{}{}
+		closure = append(closure, p)
+		queue = append(queue, p)
+	}
+
+	for i := 0; i < maxIterations && len(queue) > 0; i++ {
+		next := queue
+		queue = make([]composerimported.ImportedResource, 0, len(next))
+		for _, r := range next {
+			for _, ref := range extractReferences(r.Attrs) {
+				dep, ok := index[ref]
+				if !ok {
+					continue
+				}
+				k := keyForResource(dep)
+				if _, seen := visited[k]; seen {
+					continue
+				}
+				visited[k] = struct{}{}
+				closure = append(closure, dep)
+				queue = append(queue, dep)
+			}
+		}
+	}
+
+	sort.SliceStable(closure, func(i, j int) bool {
+		return closure[i].Identity.Address < closure[j].Identity.Address
+	})
+	return closure
+}
+
+// buildIndex maps every plausible cross-resource identifier on each
+// resource in `all` back to the resource. Keys with empty strings are
+// skipped — they would otherwise collide trivially across resources.
+func buildIndex(
+	all []composerimported.ImportedResource,
+) map[string]composerimported.ImportedResource {
+	idx := make(map[string]composerimported.ImportedResource, len(all)*2)
+	add := func(k string, r composerimported.ImportedResource) {
+		if k == "" {
+			return
+		}
+		if _, exists := idx[k]; exists {
+			return
+		}
+		idx[k] = r
+	}
+	for _, r := range all {
+		add(r.Identity.ImportID, r)
+		add(r.Identity.Address, r)
+		add(r.Identity.NativeIDs["arn"], r)
+		add(r.Identity.NativeIDs["self_link"], r)
+		add(r.Identity.NativeIDs["selfLink"], r)
+		add(r.Identity.NativeIDs["url"], r)
+		add(r.Identity.NativeIDs["name"], r)
+		add(r.Identity.NativeIDs["id"], r)
+	}
+	return idx
+}
+
+// extractReferences walks an Attrs JSON payload and returns every
+// string leaf. Malformed or empty Attrs yields nil — the walker is
+// tolerant; a single bad payload does not abort the closure.
+func extractReferences(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil
+	}
+	var out []string
+	walkStrings(v, &out)
+	return out
+}
+
+// walkStrings recursively collects every string leaf from a decoded
+// JSON value. Numbers, bools, and nulls are ignored; map keys are
+// ignored (only values can be references in our model).
+func walkStrings(v any, out *[]string) {
+	switch t := v.(type) {
+	case string:
+		if t != "" {
+			*out = append(*out, t)
+		}
+	case []any:
+		for _, e := range t {
+			walkStrings(e, out)
+		}
+	case map[string]any:
+		for _, e := range t {
+			walkStrings(e, out)
+		}
+	}
+}
+
+// keyForResource returns a stable de-duplication key for an
+// ImportedResource. Address is preferred (it's the canonical immutable
+// identifier per ResourceIdentity docs); ImportID is the second-best
+// fallback for resources that haven't had an Address generated; a
+// concatenation of Type+NameHint is the last-resort fallback to keep
+// otherwise-anonymous picked-but-not-in-all resources distinguishable.
+func keyForResource(r composerimported.ImportedResource) string {
+	if r.Identity.Address != "" {
+		return "addr:" + r.Identity.Address
+	}
+	if r.Identity.ImportID != "" {
+		return "import:" + r.Identity.ImportID
+	}
+	return "tnh:" + r.Identity.Type + "/" + r.Identity.NameHint
+}

--- a/pkg/imported/closure/closure_test.go
+++ b/pkg/imported/closure/closure_test.go
@@ -1,0 +1,303 @@
+package closure_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/closure"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mkResource is a small helper that fabricates an ImportedResource with
+// the minimum fields needed for closure tests: an Address (for sorting
+// + identity), an ARN in NativeIDs (the most common reference shape),
+// and an Attrs payload carrying outgoing reference strings.
+func mkResource(
+	t *testing.T, address, arn string, refs ...string,
+) composerimported.ImportedResource {
+	t.Helper()
+	attrs := map[string]any{}
+	for i, ref := range refs {
+		// Mix scalar, slice, and nested-map carriers so the test
+		// exercises walkStrings's three branches.
+		switch i % 3 {
+		case 0:
+			attrs["role_arn_"+itoa(i)] = ref
+		case 1:
+			attrs["subnet_ids_"+itoa(i)] = []any{ref}
+		case 2:
+			attrs["nested_"+itoa(i)] = map[string]any{"target": ref}
+		}
+	}
+	raw, err := json.Marshal(attrs)
+	require.NoError(t, err)
+
+	r := composerimported.ImportedResource{
+		Identity: composerimported.ResourceIdentity{
+			Address: address,
+			Type:    "aws_dummy",
+		},
+		Attrs: raw,
+	}
+	if arn != "" {
+		r.Identity.NativeIDs = map[string]string{"arn": arn}
+		r.Identity.ImportID = arn
+	}
+	return r
+}
+
+func itoa(i int) string {
+	const digits = "0123456789"
+	if i == 0 {
+		return "0"
+	}
+	var out []byte
+	for i > 0 {
+		out = append([]byte{digits[i%10]}, out...)
+		i /= 10
+	}
+	return string(out)
+}
+
+func addresses(rs []composerimported.ImportedResource) []string {
+	if rs == nil {
+		return nil
+	}
+	out := make([]string, len(rs))
+	for i, r := range rs {
+		out[i] = r.Identity.Address
+	}
+	return out
+}
+
+func TestDependencyClosure(t *testing.T) {
+	t.Parallel()
+
+	const (
+		arnA = "arn:aws:iam::123:role/A"
+		arnB = "arn:aws:iam::123:role/B"
+		arnC = "arn:aws:iam::123:role/C"
+		arnD = "arn:aws:iam::123:role/D"
+	)
+
+	type setup struct {
+		picked []composerimported.ImportedResource
+		all    []composerimported.ImportedResource
+	}
+
+	tests := []struct {
+		name string
+		give setup
+		// wantAddresses is the expected sorted list of Identity.Address
+		// values in the returned closure.
+		wantAddresses []string
+	}{
+		{
+			name:          "empty picked yields empty closure",
+			give:          setup{},
+			wantAddresses: nil,
+		},
+		{
+			name: "picked with no deps returns just picked, sorted",
+			give: setup{
+				picked: []composerimported.ImportedResource{
+					mkResource(t, "aws_dummy.b", arnB),
+					mkResource(t, "aws_dummy.a", arnA),
+				},
+				all: []composerimported.ImportedResource{
+					mkResource(t, "aws_dummy.a", arnA),
+					mkResource(t, "aws_dummy.b", arnB),
+				},
+			},
+			wantAddresses: []string{"aws_dummy.a", "aws_dummy.b"},
+		},
+		{
+			name: "single ARN reference pulls in the referenced resource",
+			give: func() setup {
+				a := mkResource(t, "aws_dummy.a", arnA, arnB)
+				b := mkResource(t, "aws_dummy.b", arnB)
+				return setup{
+					picked: []composerimported.ImportedResource{a},
+					all:    []composerimported.ImportedResource{a, b},
+				}
+			}(),
+			wantAddresses: []string{"aws_dummy.a", "aws_dummy.b"},
+		},
+		{
+			name: "transitive chain A -> B -> C is fully closed",
+			give: func() setup {
+				a := mkResource(t, "aws_dummy.a", arnA, arnB)
+				b := mkResource(t, "aws_dummy.b", arnB, arnC)
+				c := mkResource(t, "aws_dummy.c", arnC)
+				return setup{
+					picked: []composerimported.ImportedResource{a},
+					all:    []composerimported.ImportedResource{a, b, c},
+				}
+			}(),
+			wantAddresses: []string{"aws_dummy.a", "aws_dummy.b", "aws_dummy.c"},
+		},
+		{
+			name: "cycle A -> B -> A terminates without infinite loop",
+			give: func() setup {
+				a := mkResource(t, "aws_dummy.a", arnA, arnB)
+				b := mkResource(t, "aws_dummy.b", arnB, arnA)
+				return setup{
+					picked: []composerimported.ImportedResource{a},
+					all:    []composerimported.ImportedResource{a, b},
+				}
+			}(),
+			wantAddresses: []string{"aws_dummy.a", "aws_dummy.b"},
+		},
+		{
+			name: "reference to resource not in all is ignored",
+			give: func() setup {
+				// A references arnB, but B is missing from `all`.
+				a := mkResource(t, "aws_dummy.a", arnA, arnB)
+				return setup{
+					picked: []composerimported.ImportedResource{a},
+					all:    []composerimported.ImportedResource{a},
+				}
+			}(),
+			wantAddresses: []string{"aws_dummy.a"},
+		},
+		{
+			name: "multiple picked elements with overlapping deps are deduped",
+			give: func() setup {
+				a := mkResource(t, "aws_dummy.a", arnA, arnC)
+				b := mkResource(t, "aws_dummy.b", arnB, arnC)
+				c := mkResource(t, "aws_dummy.c", arnC)
+				return setup{
+					picked: []composerimported.ImportedResource{a, b},
+					all:    []composerimported.ImportedResource{a, b, c},
+				}
+			}(),
+			wantAddresses: []string{"aws_dummy.a", "aws_dummy.b", "aws_dummy.c"},
+		},
+		{
+			name: "picked resource not in all is retained at head of closure",
+			give: func() setup {
+				// A is picked but only present in `picked`. Its
+				// dependency B is in `all`.
+				a := mkResource(t, "aws_dummy.a", arnA, arnB)
+				b := mkResource(t, "aws_dummy.b", arnB)
+				return setup{
+					picked: []composerimported.ImportedResource{a},
+					all:    []composerimported.ImportedResource{b},
+				}
+			}(),
+			wantAddresses: []string{"aws_dummy.a", "aws_dummy.b"},
+		},
+		{
+			name: "diamond A -> {B,C} -> D is closed without duplicates",
+			give: func() setup {
+				a := mkResource(t, "aws_dummy.a", arnA, arnB, arnC)
+				b := mkResource(t, "aws_dummy.b", arnB, arnD)
+				c := mkResource(t, "aws_dummy.c", arnC, arnD)
+				d := mkResource(t, "aws_dummy.d", arnD)
+				return setup{
+					picked: []composerimported.ImportedResource{a},
+					all:    []composerimported.ImportedResource{a, b, c, d},
+				}
+			}(),
+			wantAddresses: []string{
+				"aws_dummy.a", "aws_dummy.b", "aws_dummy.c", "aws_dummy.d",
+			},
+		},
+		{
+			name: "malformed Attrs is tolerated and yields no edges",
+			give: func() setup {
+				a := composerimported.ImportedResource{
+					Identity: composerimported.ResourceIdentity{
+						Address: "aws_dummy.a",
+						Type:    "aws_dummy",
+					},
+					Attrs: json.RawMessage(`{not valid json`),
+				}
+				return setup{
+					picked: []composerimported.ImportedResource{a},
+					all:    []composerimported.ImportedResource{a},
+				}
+			}(),
+			wantAddresses: []string{"aws_dummy.a"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := closure.DependencyClosure(tc.give.picked, tc.give.all)
+			assert.Equal(t, tc.wantAddresses, addresses(got))
+		})
+	}
+}
+
+// TestDependencyClosure_MatchByAddress verifies that a reference
+// pointing at a resource's Address (not just its ARN/self-link) is
+// resolved. This is the path used by Layer-1 typed Attrs that record
+// cross-references as Terraform addresses rather than cloud identifiers.
+func TestDependencyClosure_MatchByAddress(t *testing.T) {
+	t.Parallel()
+
+	b := composerimported.ImportedResource{
+		Identity: composerimported.ResourceIdentity{
+			Address: "aws_dummy.b",
+			Type:    "aws_dummy",
+		},
+	}
+	// A references B by Address.
+	aAttrs, err := json.Marshal(map[string]any{"depends_on": "aws_dummy.b"})
+	require.NoError(t, err)
+	a := composerimported.ImportedResource{
+		Identity: composerimported.ResourceIdentity{
+			Address: "aws_dummy.a",
+			Type:    "aws_dummy",
+		},
+		Attrs: aAttrs,
+	}
+
+	got := closure.DependencyClosure(
+		[]composerimported.ImportedResource{a},
+		[]composerimported.ImportedResource{a, b},
+	)
+	assert.Equal(t, []string{"aws_dummy.a", "aws_dummy.b"}, addresses(got))
+}
+
+// TestDependencyClosure_MatchBySelfLink verifies the GCP path: a
+// reference recorded as a self_link in NativeIDs is resolved.
+func TestDependencyClosure_MatchBySelfLink(t *testing.T) {
+	t.Parallel()
+
+	const selfLink = "https://www.googleapis.com/compute/v1/projects/p/regions/r/subnetworks/s"
+
+	subnet := composerimported.ImportedResource{
+		Identity: composerimported.ResourceIdentity{
+			Address: "google_compute_subnetwork.s",
+			Type:    "google_compute_subnetwork",
+			NativeIDs: map[string]string{
+				"self_link": selfLink,
+			},
+		},
+	}
+	consumerAttrs, err := json.Marshal(map[string]any{"subnetwork": selfLink})
+	require.NoError(t, err)
+	consumer := composerimported.ImportedResource{
+		Identity: composerimported.ResourceIdentity{
+			Address: "google_compute_instance.c",
+			Type:    "google_compute_instance",
+		},
+		Attrs: consumerAttrs,
+	}
+
+	got := closure.DependencyClosure(
+		[]composerimported.ImportedResource{consumer},
+		[]composerimported.ImportedResource{consumer, subnet},
+	)
+	assert.Equal(t,
+		[]string{"google_compute_instance.c", "google_compute_subnetwork.s"},
+		addresses(got),
+	)
+}

--- a/pkg/imported/errors.go
+++ b/pkg/imported/errors.go
@@ -1,0 +1,31 @@
+package imported
+
+import "errors"
+
+// ErrUnknownCloud signals that ProviderFor was called with a cloud
+// string that does not match any registered Provider impl. Today the
+// only valid values are "aws" and "gcp"; this sentinel exists so
+// callers can branch on a typed error rather than string-matching.
+var ErrUnknownCloud = errors.New("imported: unknown cloud")
+
+// ErrEnrichByIDNotImplemented signals that the per-type enricher for
+// the requested Terraform type does not satisfy the ByIDEnricher
+// contract. Distinct from ErrEnrichClientUnavailable (which means a
+// required SDK client is nil on the Clients union) and from a real
+// API error: callers can downgrade this to "skip drift refresh for
+// this type" without losing the batch.
+var ErrEnrichByIDNotImplemented = errors.New("imported: EnrichByID not implemented for this type")
+
+// ErrEnrichClientUnavailable signals that the SDK client a per-type
+// enricher needs is nil on the Clients union. Same downgrade
+// semantics as the per-cloud awsdiscover.ErrEnrichClientUnavailable
+// / gcpdiscover.ErrEnrichClientUnavailable — surface as a per-
+// resource warning rather than a batch-fatal error.
+var ErrEnrichClientUnavailable = errors.New("imported: required SDK client unavailable on Clients")
+
+// ErrClientsWrongCloud signals that the Clients union carried the
+// wrong cloud's bundle for the Provider being dispatched against
+// (e.g. AWS Provider received Clients{GCP: ...}). Callers wire
+// Clients correctly at construction time; this sentinel exists so
+// runtime guards in the per-cloud impls have a typed return path.
+var ErrClientsWrongCloud = errors.New("imported: Clients union carries the wrong cloud")

--- a/pkg/imported/gcp/clients.go
+++ b/pkg/imported/gcp/clients.go
@@ -1,0 +1,15 @@
+// Package gcp is the GCP-side pkg/imported.Provider implementation.
+// It depends on cmd/insideout-import/gcpdiscover for the live cloud
+// dispatch; the top-level pkg/imported package does NOT import this
+// package — see pkg/imported package doc for the dependency direction.
+package gcp
+
+import (
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
+)
+
+// Clients carries the GCP-side SDK client bundle this Provider
+// dispatches against. Re-exported as a type alias from
+// gcpdiscover.EnrichClients — see pkg/imported/aws.Clients for the
+// AWS-side parity rationale.
+type Clients = gcpdiscover.EnrichClients

--- a/pkg/imported/gcp/provider.go
+++ b/pkg/imported/gcp/provider.go
@@ -1,0 +1,241 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+	driftimp "github.com/luthersystems/insideout-terraform-presets/pkg/drift/imported"
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/bindings"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/labels"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
+)
+
+// DriftComparator mirrors aws.DriftComparator — see that type's doc
+// for the rationale (decouples Provider from pkg/drift/imported to
+// avoid an import cycle).
+type DriftComparator func(tfType string, snapshot, live imp.Attrs) []imp.FieldMismatch
+
+// Provider is the GCP-side pkg/imported.Provider implementation. See
+// pkg/imported/aws.Provider for the cross-cloud parity.
+type Provider struct {
+	d        *gcpdiscover.GCPDiscoverer
+	comparer DriftComparator
+}
+
+// Compile-time check.
+var _ imp.Provider = (*Provider)(nil)
+
+// NewProvider wires up a GCP Provider. Nil discoverer leaves the
+// Provider in static-introspection mode; nil comparer disables drift.
+func NewProvider(d *gcpdiscover.GCPDiscoverer, comparer DriftComparator) *Provider {
+	return &Provider{d: d, comparer: comparer}
+}
+
+// SupportedTypes returns the canonical sorted GCP type list.
+func (p *Provider) SupportedTypes() []string {
+	return registry.SupportedDiscoverTypes(registry.ProviderGCP)
+}
+
+// Capabilities — see pkg/imported/aws.Provider.Capabilities for the
+// full semantics; the GCP impl is a one-for-one mirror.
+func (p *Provider) Capabilities(tfType string) imp.Capabilities {
+	c := imp.Capabilities{
+		Discoverable: isDiscoverable(tfType),
+	}
+	if p.d != nil {
+		c.Enrichable = p.d.HasEnricher(tfType)
+	}
+	_, hasPolicy := policy.Lookup(tfType)
+	c.DriftDetectable = hasPolicy && p.comparer != nil
+	_, c.MetricsAvailable = bindings.Binding(tfType)
+	return c
+}
+
+func isDiscoverable(tfType string) bool {
+	return slices.Contains(registry.SupportedDiscoverTypes(registry.ProviderGCP), tfType)
+}
+
+// LabelFor returns the display label and icon-asset key for tfType.
+func (p *Provider) LabelFor(tfType string) (string, string) {
+	return labels.Label(tfType), labels.IconKey(tfType)
+}
+
+// PolicyFor returns the curated FieldPolicy map for tfType.
+func (p *Provider) PolicyFor(tfType string) (policy.Map, bool) {
+	return policy.Lookup(tfType)
+}
+
+// MetricsBinding returns the registered ComponentMetricsBinding for
+// tfType.
+func (p *Provider) MetricsBinding(tfType string) (imp.ComponentMetricsBinding, bool) {
+	return bindings.Binding(tfType)
+}
+
+// StableID returns the deterministic identifier for identity.
+// Precedence on GCP:
+//
+//  1. self_link from NativeIDs (canonical for most google_* types)
+//  2. ImportID
+//  3. Address
+//  4. Empty when identity is nil
+//
+// self_link is the GCP equivalent of an AWS ARN — it survives Address
+// renames and is the natural cross-tool join key.
+func (p *Provider) StableID(identity *imported.ResourceIdentity) string {
+	if identity == nil {
+		return ""
+	}
+	if sl := identity.NativeIDs["self_link"]; sl != "" {
+		return sl
+	}
+	if identity.ImportID != "" {
+		return identity.ImportID
+	}
+	return identity.Address
+}
+
+// CanonicalAddress returns identity.Address when set, else
+// regenerates one via imported.GenerateAddress.
+func (p *Provider) CanonicalAddress(identity *imported.ResourceIdentity) string {
+	if identity == nil {
+		return ""
+	}
+	if identity.Address != "" {
+		return identity.Address
+	}
+	return imported.GenerateAddress(*identity, nil)
+}
+
+// Discover delegates to the underlying GCPDiscoverer.DiscoverTypes.
+// opts maps onto gcpdiscover.DiscoverArgs (which lacks AccountID;
+// the real GCP project ID lives on the GCPDiscoverer itself, set at
+// construction time). opts.ProjectID is ignored when the underlying
+// discoverer was constructed with one — see NewGCPDiscoverer.
+func (p *Provider) Discover(ctx context.Context, types []string, clients imp.Clients, opts imp.DiscoverOpts) ([]imported.ImportedResource, error) {
+	if p.d == nil {
+		return nil, imp.ErrEnrichClientUnavailable
+	}
+	args := gcpdiscover.DiscoverArgs{
+		Project:      opts.Project,
+		Regions:      opts.Regions,
+		TagSelectors: toGCPTagSelectors(opts.TagSelectors),
+		Emitter:      progress.NopEmitter{},
+	}
+	return p.d.DiscoverTypes(ctx, types, args)
+}
+
+func toGCPTagSelectors(in []imp.TagSelector) []gcpdiscover.TagSelector {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]gcpdiscover.TagSelector, len(in))
+	for i, s := range in {
+		out[i] = gcpdiscover.TagSelector{Key: s.Key, Value: s.Value}
+	}
+	return out
+}
+
+// EnrichAttributes delegates to GCPDiscoverer.EnrichAttributes.
+func (p *Provider) EnrichAttributes(ctx context.Context, irs []imported.ImportedResource, clients imp.Clients) error {
+	if p.d == nil {
+		return imp.ErrEnrichClientUnavailable
+	}
+	gcp, err := unwrapGCPClients(clients)
+	if err != nil {
+		return err
+	}
+	return p.d.EnrichAttributes(ctx, irs, gcp, progress.NopEmitter{})
+}
+
+// EnrichByID delegates to GCPDiscoverer.EnrichByID, mapping the
+// gcpdiscover-specific ErrNotSupported / ErrEnrichClientUnavailable
+// onto the cross-cloud sentinels.
+func (p *Provider) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, clients imp.Clients) (imp.Attrs, error) {
+	if p.d == nil {
+		return nil, imp.ErrEnrichClientUnavailable
+	}
+	if identity == nil {
+		return nil, fmt.Errorf("gcp.Provider.EnrichByID: nil identity")
+	}
+	gcp, err := unwrapGCPClients(clients)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := p.d.EnrichByID(ctx, identity, gcp)
+	switch {
+	case err == nil:
+		return imp.Attrs(raw), nil
+	case errors.Is(err, gcpdiscover.ErrNotSupported):
+		return nil, fmt.Errorf("%w: %s", imp.ErrEnrichByIDNotImplemented, identity.Type)
+	case errors.Is(err, gcpdiscover.ErrEnrichClientUnavailable):
+		return nil, fmt.Errorf("%w: %s", imp.ErrEnrichClientUnavailable, identity.Type)
+	default:
+		return nil, err
+	}
+}
+
+// unwrapGCPClients pulls the typed GCP bundle out of the cloud-agnostic
+// Clients union. Returns ErrClientsWrongCloud when the AWS slot is set
+// (cross-cloud misroute) and ErrEnrichClientUnavailable when the GCP
+// slot is nil.
+func unwrapGCPClients(c imp.Clients) (Clients, error) {
+	if c.AWS != nil && c.GCP == nil {
+		return Clients{}, imp.ErrClientsWrongCloud
+	}
+	if c.GCP == nil {
+		return Clients{}, imp.ErrEnrichClientUnavailable
+	}
+	switch v := c.GCP.(type) {
+	case Clients:
+		return v, nil
+	case *Clients:
+		if v == nil {
+			return Clients{}, imp.ErrEnrichClientUnavailable
+		}
+		return *v, nil
+	default:
+		return Clients{}, fmt.Errorf("gcp.Provider: Clients.GCP has unexpected type %T", c.GCP)
+	}
+}
+
+// CompareDrift delegates to the wired DriftComparator. Returns nil
+// when no comparator is wired.
+func (p *Provider) CompareDrift(tfType string, snapshot, live imp.Attrs) []imp.FieldMismatch {
+	if p.comparer == nil {
+		return nil
+	}
+	return p.comparer(tfType, snapshot, live)
+}
+
+// RileyContext returns a one-line-per-IR summary sorted by Address.
+func (p *Provider) RileyContext(irs []imported.ImportedResource) []string {
+	if len(irs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(irs))
+	for _, ir := range irs {
+		out = append(out, fmt.Sprintf("%s (%s)", ir.Identity.Address, ir.Identity.Type))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// init registers the GCP Provider constructor with the top-level
+// imported package. ProviderFor("gcp") returns a Provider with the
+// default drift comparator wired (pkg/drift/imported.Compare) but no
+// live GCPDiscoverer — so static introspection works out of the box;
+// callers needing Discover / Enrich must construct via NewProvider
+// with a real *gcpdiscover.GCPDiscoverer.
+func init() {
+	imp.Register("gcp", func() imp.Provider {
+		return NewProvider(nil, driftimp.Compare)
+	})
+}

--- a/pkg/imported/gcp/provider.go
+++ b/pkg/imported/gcp/provider.go
@@ -198,11 +198,14 @@ func (p *Provider) EnrichByID(ctx context.Context, identity *imported.ResourceId
 }
 
 // unwrapGCPClients pulls the typed GCP bundle out of the cloud-agnostic
-// Clients union. Returns ErrClientsWrongCloud when the AWS slot is set
-// (cross-cloud misroute) and ErrEnrichClientUnavailable when the GCP
-// slot is nil.
+// Clients union. Returns ErrClientsWrongCloud when the AWS slot is
+// populated (the caller has misrouted AWS clients to a GCP provider —
+// reported regardless of whether the GCP slot is also set, because both-
+// set is itself a bug worth flagging loudly). Returns
+// ErrEnrichClientUnavailable when neither slot is set, or when the GCP
+// slot is a nil pointer.
 func unwrapGCPClients(c imp.Clients) (Clients, error) {
-	if c.AWS != nil && c.GCP == nil {
+	if c.AWS != nil {
 		return Clients{}, imp.ErrClientsWrongCloud
 	}
 	if c.GCP == nil {
@@ -230,16 +233,22 @@ func (p *Provider) CompareDrift(tfType string, snapshot, live imp.Attrs) []imp.F
 	return p.comparer(tfType, snapshot, live)
 }
 
-// RileyContext returns a one-line-per-IR summary sorted by Address.
-func (p *Provider) RileyContext(irs []imported.ImportedResource) []string {
+// AgentContext returns a one-line-per-IR summary sorted by Address —
+// see aws.Provider.AgentContext for the contract; this is the
+// one-for-one mirror.
+func (p *Provider) AgentContext(irs []imported.ImportedResource) []string {
 	if len(irs) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(irs))
-	for _, ir := range irs {
+	sorted := make([]imported.ImportedResource, len(irs))
+	copy(sorted, irs)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Identity.Address < sorted[j].Identity.Address
+	})
+	out := make([]string, 0, len(sorted))
+	for _, ir := range sorted {
 		out = append(out, fmt.Sprintf("%s (%s)", ir.Identity.Address, ir.Identity.Type))
 	}
-	sort.Strings(out)
 	return out
 }
 

--- a/pkg/imported/gcp/provider.go
+++ b/pkg/imported/gcp/provider.go
@@ -53,10 +53,25 @@ func (p *Provider) Capabilities(tfType string) imp.Capabilities {
 	if p.d != nil {
 		c.Enrichable = p.d.HasEnricher(tfType)
 	}
-	_, hasPolicy := policy.Lookup(tfType)
+	pol, hasPolicy := policy.Lookup(tfType)
 	c.DriftDetectable = hasPolicy && p.comparer != nil
 	_, c.MetricsAvailable = bindings.Binding(tfType)
+	c.AgentEditable = hasAgentEditableField(pol)
 	return c
+}
+
+// hasAgentEditableField mirrors aws.hasAgentEditableField. See that
+// function's doc for the semantics; the two are identical so a future
+// follow-up could lift this into pkg/imported/policy as a shared
+// helper without affecting either Provider impl.
+func hasAgentEditableField(pol policy.Map) bool {
+	for _, fp := range pol {
+		switch fp.Edit {
+		case policy.EditChatSafe, policy.EditRequiresApproval:
+			return true
+		}
+	}
+	return false
 }
 
 func isDiscoverable(tfType string) bool {

--- a/pkg/imported/gcp/provider_test.go
+++ b/pkg/imported/gcp/provider_test.go
@@ -1,0 +1,253 @@
+package gcp_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
+	composer_imported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+	gcpprov "github.com/luthersystems/insideout-terraform-presets/pkg/imported/gcp"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
+)
+
+func TestNewProvider_NilDiscoverer_StaticIntrospection(t *testing.T) {
+	t.Parallel()
+	p := gcpprov.NewProvider(nil, nil)
+
+	types := p.SupportedTypes()
+	want := registry.SupportedDiscoverTypes("gcp")
+	if len(types) != len(want) {
+		t.Errorf("SupportedTypes len = %d, want %d", len(types), len(want))
+	}
+
+	caps := p.Capabilities("google_storage_bucket")
+	if !caps.Discoverable {
+		t.Error("google_storage_bucket should be Discoverable from the registry")
+	}
+	if caps.Enrichable {
+		t.Error("Enrichable should be false without a discoverer")
+	}
+
+	lbl, icon := p.LabelFor("google_storage_bucket")
+	if lbl == "" || icon == "" {
+		t.Errorf("LabelFor(google_storage_bucket) = (%q, %q); both should be non-empty", lbl, icon)
+	}
+
+	if _, err := p.Discover(context.Background(), nil, imp.Clients{}, imp.DiscoverOpts{}); !errors.Is(err, imp.ErrEnrichClientUnavailable) {
+		t.Errorf("Discover with nil discoverer: err = %v, want ErrEnrichClientUnavailable", err)
+	}
+	if err := p.EnrichAttributes(context.Background(), nil, imp.Clients{}); !errors.Is(err, imp.ErrEnrichClientUnavailable) {
+		t.Errorf("EnrichAttributes with nil discoverer: err = %v, want ErrEnrichClientUnavailable", err)
+	}
+	if _, err := p.EnrichByID(context.Background(), nil, imp.Clients{}); !errors.Is(err, imp.ErrEnrichClientUnavailable) {
+		t.Errorf("EnrichByID with nil discoverer: err = %v, want ErrEnrichClientUnavailable", err)
+	}
+}
+
+func TestProvider_Capabilities_Enrichable(t *testing.T) {
+	t.Parallel()
+	d := gcpdiscover.NewGCPDiscoverer(nil, "test-project", gcpdiscover.GCPDiscovererOpts{})
+	p := gcpprov.NewProvider(d, nil)
+
+	// google_storage_bucket has a registered enricher.
+	if got := p.Capabilities("google_storage_bucket"); !got.Enrichable {
+		t.Errorf("google_storage_bucket: Enrichable should be true, got %+v", got)
+	}
+	// google_sql_user is in the registry but no enricher.
+	if got := p.Capabilities("google_sql_user"); got.Enrichable {
+		t.Errorf("google_sql_user: Enrichable should be false, got %+v", got)
+	}
+}
+
+func TestProvider_Capabilities_DriftDetectable(t *testing.T) {
+	t.Parallel()
+	d := gcpdiscover.NewGCPDiscoverer(nil, "test-project", gcpdiscover.GCPDiscovererOpts{})
+
+	p := gcpprov.NewProvider(d, nil)
+	if got := p.Capabilities("google_storage_bucket"); got.DriftDetectable {
+		t.Errorf("Without comparator, DriftDetectable should be false; got %+v", got)
+	}
+
+	noopComparer := func(string, imp.Attrs, imp.Attrs) []imp.FieldMismatch { return nil }
+	pWithCmp := gcpprov.NewProvider(d, noopComparer)
+	// google_storage_bucket has a registered policy.
+	if got := pWithCmp.Capabilities("google_storage_bucket"); !got.DriftDetectable {
+		t.Errorf("With comparator + policy, DriftDetectable should be true; got %+v", got)
+	}
+}
+
+func TestProvider_StableID(t *testing.T) {
+	t.Parallel()
+	p := gcpprov.NewProvider(nil, nil)
+
+	if got := p.StableID(nil); got != "" {
+		t.Errorf("StableID(nil) = %q, want \"\"", got)
+	}
+
+	// self_link-bearing identity.
+	id := &composer_imported.ResourceIdentity{
+		Type:      "google_storage_bucket",
+		Address:   "google_storage_bucket.b",
+		ImportID:  "my-bucket",
+		NativeIDs: map[string]string{"self_link": "https://www.googleapis.com/storage/v1/b/my-bucket"},
+	}
+	if got := p.StableID(id); got != "https://www.googleapis.com/storage/v1/b/my-bucket" {
+		t.Errorf("StableID self_link-bearing = %q", got)
+	}
+
+	id2 := &composer_imported.ResourceIdentity{
+		Type:     "google_pubsub_topic",
+		Address:  "google_pubsub_topic.t",
+		ImportID: "projects/p/topics/t",
+	}
+	if got := p.StableID(id2); got != "projects/p/topics/t" {
+		t.Errorf("StableID ImportID fallback = %q", got)
+	}
+
+	id3 := &composer_imported.ResourceIdentity{
+		Type:    "google_pubsub_topic",
+		Address: "google_pubsub_topic.t",
+	}
+	if got := p.StableID(id3); got != "google_pubsub_topic.t" {
+		t.Errorf("StableID address fallback = %q", got)
+	}
+}
+
+func TestProvider_CanonicalAddress(t *testing.T) {
+	t.Parallel()
+	p := gcpprov.NewProvider(nil, nil)
+
+	if got := p.CanonicalAddress(nil); got != "" {
+		t.Errorf("CanonicalAddress(nil) = %q, want \"\"", got)
+	}
+
+	id := &composer_imported.ResourceIdentity{
+		Type:    "google_storage_bucket",
+		Address: "google_storage_bucket.mybucket",
+	}
+	if got := p.CanonicalAddress(id); got != "google_storage_bucket.mybucket" {
+		t.Errorf("CanonicalAddress unchanged = %q", got)
+	}
+
+	id2 := &composer_imported.ResourceIdentity{
+		Type:     "google_storage_bucket",
+		NameHint: "MyBucket",
+	}
+	if got := p.CanonicalAddress(id2); got == "" || got == "google_storage_bucket." {
+		t.Errorf("CanonicalAddress regenerated empty: %q", got)
+	}
+}
+
+func TestProvider_RileyContext(t *testing.T) {
+	t.Parallel()
+	p := gcpprov.NewProvider(nil, nil)
+
+	if got := p.RileyContext(nil); got != nil {
+		t.Errorf("RileyContext(nil) = %v, want nil", got)
+	}
+
+	irs := []composer_imported.ImportedResource{
+		{Identity: composer_imported.ResourceIdentity{Type: "google_storage_bucket", Address: "google_storage_bucket.z"}},
+		{Identity: composer_imported.ResourceIdentity{Type: "google_pubsub_topic", Address: "google_pubsub_topic.a"}},
+	}
+	got := p.RileyContext(irs)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(got))
+	}
+	if got[0] >= got[1] {
+		t.Errorf("RileyContext not sorted: %v", got)
+	}
+}
+
+func TestProvider_CompareDrift(t *testing.T) {
+	t.Parallel()
+
+	p := gcpprov.NewProvider(nil, nil)
+	if got := p.CompareDrift("google_storage_bucket", nil, nil); got != nil {
+		t.Errorf("CompareDrift with nil comparer = %v, want nil", got)
+	}
+
+	want := []imp.FieldMismatch{{Field: "x", Snapshot: 1, Cloud: 2}}
+	cmp := func(tfType string, snap, live imp.Attrs) []imp.FieldMismatch {
+		return want
+	}
+	p2 := gcpprov.NewProvider(nil, cmp)
+	got := p2.CompareDrift("google_storage_bucket", nil, nil)
+	if len(got) != 1 || got[0].Field != "x" {
+		t.Errorf("CompareDrift delegate = %v, want %v", got, want)
+	}
+}
+
+func TestProvider_PolicyAndMetrics(t *testing.T) {
+	t.Parallel()
+	p := gcpprov.NewProvider(nil, nil)
+
+	if _, ok := p.PolicyFor("google_storage_bucket"); !ok {
+		t.Error("google_storage_bucket should have a registered policy")
+	}
+	if _, ok := p.PolicyFor("google_bogus_unknown"); ok {
+		t.Error("unknown type should not have a policy")
+	}
+	_, _ = p.MetricsBinding("google_storage_bucket")
+}
+
+func TestProvider_EnrichByID_NoEnricher(t *testing.T) {
+	t.Parallel()
+	d := gcpdiscover.NewGCPDiscoverer(nil, "test-project", gcpdiscover.GCPDiscovererOpts{})
+	p := gcpprov.NewProvider(d, nil)
+
+	id := &composer_imported.ResourceIdentity{Type: "google_sql_user", ImportID: "u/v"}
+	_, err := p.EnrichByID(context.Background(), id, imp.Clients{GCP: gcpprov.Clients{}})
+	if !errors.Is(err, imp.ErrEnrichByIDNotImplemented) {
+		t.Errorf("EnrichByID for non-enriched type: err = %v, want ErrEnrichByIDNotImplemented", err)
+	}
+}
+
+func TestProvider_EnrichAttributes_WrongCloud(t *testing.T) {
+	t.Parallel()
+	d := gcpdiscover.NewGCPDiscoverer(nil, "test-project", gcpdiscover.GCPDiscovererOpts{})
+	p := gcpprov.NewProvider(d, nil)
+
+	err := p.EnrichAttributes(context.Background(), nil, imp.Clients{AWS: struct{}{}})
+	if !errors.Is(err, imp.ErrClientsWrongCloud) {
+		t.Errorf("GCP provider with AWS clients: err = %v, want ErrClientsWrongCloud", err)
+	}
+}
+
+func TestProvider_CapabilitiesParity(t *testing.T) {
+	t.Parallel()
+	d := gcpdiscover.NewGCPDiscoverer(nil, "test-project", gcpdiscover.GCPDiscovererOpts{})
+	p := gcpprov.NewProvider(d, nil)
+
+	for _, tfType := range p.SupportedTypes() {
+		caps := p.Capabilities(tfType)
+		id := &composer_imported.ResourceIdentity{
+			Type:     tfType,
+			ImportID: "test-id",
+		}
+		_, err := p.EnrichByID(context.Background(), id, imp.Clients{GCP: gcpprov.Clients{}})
+
+		notImpl := errors.Is(err, imp.ErrEnrichByIDNotImplemented)
+		if caps.Enrichable && notImpl {
+			// Same weaker parity as AWS — Enrichable=true with no
+			// ByIDEnricher is an allowed transitional state for
+			// types whose enricher hasn't yet been extended.
+			continue
+		}
+		if !caps.Enrichable && !notImpl {
+			t.Errorf("%s: Enrichable=false but EnrichByID returned %v; want ErrEnrichByIDNotImplemented", tfType, err)
+		}
+	}
+}
+
+func TestProvider_EnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	d := gcpdiscover.NewGCPDiscoverer(nil, "test-project", gcpdiscover.GCPDiscovererOpts{})
+	p := gcpprov.NewProvider(d, nil)
+	_, err := p.EnrichByID(context.Background(), nil, imp.Clients{GCP: gcpprov.Clients{}})
+	if err == nil {
+		t.Error("expected error for nil identity")
+	}
+}

--- a/pkg/imported/gcp/provider_test.go
+++ b/pkg/imported/gcp/provider_test.go
@@ -216,10 +216,27 @@ func TestProvider_EnrichAttributes_WrongCloud(t *testing.T) {
 	}
 }
 
+// TestProvider_CapabilitiesParity — see aws/provider_test.go for the
+// full doc; the GCP enrichableNoByID exemption mirrors the 5 pre-Phase-2
+// GCP enrichers that satisfy AttributeEnricher but not ByIDEnricher
+// yet. Bundle 1's compute_address / compute_firewall implement both, so
+// they're NOT in the exemption list — the strong parity direction
+// guards them.
 func TestProvider_CapabilitiesParity(t *testing.T) {
 	t.Parallel()
 	d := gcpdiscover.NewGCPDiscoverer(nil, "test-project", gcpdiscover.GCPDiscovererOpts{})
 	p := gcpprov.NewProvider(d, nil)
+
+	// Types whose AttributeEnricher exists but doesn't satisfy
+	// ByIDEnricher yet. Mirrors notImplemented in
+	// cmd/insideout-import/gcpdiscover/byid_enricher_test.go.
+	enrichableNoByID := map[string]bool{
+		"google_storage_bucket":        true,
+		"google_pubsub_topic":          true,
+		"google_pubsub_subscription":   true,
+		"google_secret_manager_secret": true,
+		"google_compute_network":       true,
+	}
 
 	for _, tfType := range p.SupportedTypes() {
 		caps := p.Capabilities(tfType)
@@ -230,14 +247,12 @@ func TestProvider_CapabilitiesParity(t *testing.T) {
 		_, err := p.EnrichByID(context.Background(), id, imp.Clients{GCP: gcpprov.Clients{}})
 
 		notImpl := errors.Is(err, imp.ErrEnrichByIDNotImplemented)
-		if caps.Enrichable && notImpl {
-			// Same weaker parity as AWS — Enrichable=true with no
-			// ByIDEnricher is an allowed transitional state for
-			// types whose enricher hasn't yet been extended.
-			continue
-		}
-		if !caps.Enrichable && !notImpl {
+
+		switch {
+		case !caps.Enrichable && !notImpl:
 			t.Errorf("%s: Enrichable=false but EnrichByID returned %v; want ErrEnrichByIDNotImplemented", tfType, err)
+		case caps.Enrichable && notImpl && !enrichableNoByID[tfType]:
+			t.Errorf("%s: Enrichable=true but EnrichByID returned ErrEnrichByIDNotImplemented (add to enrichableNoByID exemption if intentional, else wire ByIDEnricher impl)", tfType)
 		}
 	}
 }

--- a/pkg/imported/gcp/provider_test.go
+++ b/pkg/imported/gcp/provider_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
-	composer_imported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
 	gcpprov "github.com/luthersystems/insideout-terraform-presets/pkg/imported/gcp"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
@@ -87,7 +87,7 @@ func TestProvider_StableID(t *testing.T) {
 	}
 
 	// self_link-bearing identity.
-	id := &composer_imported.ResourceIdentity{
+	id := &composerimported.ResourceIdentity{
 		Type:      "google_storage_bucket",
 		Address:   "google_storage_bucket.b",
 		ImportID:  "my-bucket",
@@ -97,7 +97,7 @@ func TestProvider_StableID(t *testing.T) {
 		t.Errorf("StableID self_link-bearing = %q", got)
 	}
 
-	id2 := &composer_imported.ResourceIdentity{
+	id2 := &composerimported.ResourceIdentity{
 		Type:     "google_pubsub_topic",
 		Address:  "google_pubsub_topic.t",
 		ImportID: "projects/p/topics/t",
@@ -106,7 +106,7 @@ func TestProvider_StableID(t *testing.T) {
 		t.Errorf("StableID ImportID fallback = %q", got)
 	}
 
-	id3 := &composer_imported.ResourceIdentity{
+	id3 := &composerimported.ResourceIdentity{
 		Type:    "google_pubsub_topic",
 		Address: "google_pubsub_topic.t",
 	}
@@ -123,7 +123,7 @@ func TestProvider_CanonicalAddress(t *testing.T) {
 		t.Errorf("CanonicalAddress(nil) = %q, want \"\"", got)
 	}
 
-	id := &composer_imported.ResourceIdentity{
+	id := &composerimported.ResourceIdentity{
 		Type:    "google_storage_bucket",
 		Address: "google_storage_bucket.mybucket",
 	}
@@ -131,7 +131,7 @@ func TestProvider_CanonicalAddress(t *testing.T) {
 		t.Errorf("CanonicalAddress unchanged = %q", got)
 	}
 
-	id2 := &composer_imported.ResourceIdentity{
+	id2 := &composerimported.ResourceIdentity{
 		Type:     "google_storage_bucket",
 		NameHint: "MyBucket",
 	}
@@ -140,24 +140,24 @@ func TestProvider_CanonicalAddress(t *testing.T) {
 	}
 }
 
-func TestProvider_RileyContext(t *testing.T) {
+func TestProvider_AgentContext(t *testing.T) {
 	t.Parallel()
 	p := gcpprov.NewProvider(nil, nil)
 
-	if got := p.RileyContext(nil); got != nil {
-		t.Errorf("RileyContext(nil) = %v, want nil", got)
+	if got := p.AgentContext(nil); got != nil {
+		t.Errorf("AgentContext(nil) = %v, want nil", got)
 	}
 
-	irs := []composer_imported.ImportedResource{
-		{Identity: composer_imported.ResourceIdentity{Type: "google_storage_bucket", Address: "google_storage_bucket.z"}},
-		{Identity: composer_imported.ResourceIdentity{Type: "google_pubsub_topic", Address: "google_pubsub_topic.a"}},
+	irs := []composerimported.ImportedResource{
+		{Identity: composerimported.ResourceIdentity{Type: "google_storage_bucket", Address: "google_storage_bucket.z"}},
+		{Identity: composerimported.ResourceIdentity{Type: "google_pubsub_topic", Address: "google_pubsub_topic.a"}},
 	}
-	got := p.RileyContext(irs)
+	got := p.AgentContext(irs)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(got))
 	}
 	if got[0] >= got[1] {
-		t.Errorf("RileyContext not sorted: %v", got)
+		t.Errorf("AgentContext not sorted: %v", got)
 	}
 }
 
@@ -198,7 +198,7 @@ func TestProvider_EnrichByID_NoEnricher(t *testing.T) {
 	d := gcpdiscover.NewGCPDiscoverer(nil, "test-project", gcpdiscover.GCPDiscovererOpts{})
 	p := gcpprov.NewProvider(d, nil)
 
-	id := &composer_imported.ResourceIdentity{Type: "google_sql_user", ImportID: "u/v"}
+	id := &composerimported.ResourceIdentity{Type: "google_sql_user", ImportID: "u/v"}
 	_, err := p.EnrichByID(context.Background(), id, imp.Clients{GCP: gcpprov.Clients{}})
 	if !errors.Is(err, imp.ErrEnrichByIDNotImplemented) {
 		t.Errorf("EnrichByID for non-enriched type: err = %v, want ErrEnrichByIDNotImplemented", err)
@@ -223,7 +223,7 @@ func TestProvider_CapabilitiesParity(t *testing.T) {
 
 	for _, tfType := range p.SupportedTypes() {
 		caps := p.Capabilities(tfType)
-		id := &composer_imported.ResourceIdentity{
+		id := &composerimported.ResourceIdentity{
 			Type:     tfType,
 			ImportID: "test-id",
 		}

--- a/pkg/imported/labels/labels.go
+++ b/pkg/imported/labels/labels.go
@@ -1,0 +1,151 @@
+// Package labels is the registry of human-friendly display labels and
+// icon keys for imported Terraform resource types. It is the upstream
+// half of luthersystems/reliable's serviceMeta.ts surface — the
+// downstream consumer fetches this via the eventual codegen
+// `imported-codegen labels` subcommand (presets#482) and pins UI strings
+// to the registry instead of hand-maintaining a parallel map.
+//
+// Two-step lookup:
+//
+//  1. The override map (Register) wins. Per-type files in the per-cloud
+//     packages add entries on init() when the default rule produces a
+//     worse label than the curated one — e.g. "Queue (SQS)" over the
+//     default "Sqs Queue".
+//  2. Otherwise the default rule strips the cloud prefix and humanizes
+//     the remainder ("aws_s3_bucket" → "S3 Bucket", "google_pubsub_topic"
+//     → "Pubsub Topic"). Same for icon keys minus the title-casing.
+//
+// The registry starts empty in this skeleton (presets#TBD). Per-type
+// PRs in the enricher rollout populate entries opportunistically.
+package labels
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+var (
+	regMu  sync.RWMutex
+	labels = map[string]entry{}
+)
+
+type entry struct {
+	Label   string
+	IconKey string
+}
+
+// Register pins an override (label, iconKey) pair for tfType. Either
+// or both of label/iconKey may be empty, in which case the default
+// rule fills the empty side at lookup time. Panics on duplicate
+// registration for the same tfType (mirrors the policy package's
+// Register contract — a duplicate means two files compete for the
+// same key, which is always a bug).
+func Register(tfType, label, iconKey string) {
+	if tfType == "" {
+		panic("labels.Register: empty tfType")
+	}
+	regMu.Lock()
+	defer regMu.Unlock()
+	if _, ok := labels[tfType]; ok {
+		panic(fmt.Sprintf("labels.Register: duplicate registration for %q", tfType))
+	}
+	labels[tfType] = entry{Label: label, IconKey: iconKey}
+}
+
+// Label returns the human-readable display label for tfType. Returns
+// the registered override if one is set, else the default rule
+// applied to the type name (strip cloud prefix → humanize words).
+func Label(tfType string) string {
+	regMu.RLock()
+	e, ok := labels[tfType]
+	regMu.RUnlock()
+	if ok && e.Label != "" {
+		return e.Label
+	}
+	return defaultLabel(tfType)
+}
+
+// IconKey returns the icon-asset key for tfType. Returns the
+// registered override if one is set, else the type name minus the
+// cloud prefix ("aws_s3_bucket" → "s3_bucket").
+func IconKey(tfType string) string {
+	regMu.RLock()
+	e, ok := labels[tfType]
+	regMu.RUnlock()
+	if ok && e.IconKey != "" {
+		return e.IconKey
+	}
+	return defaultIconKey(tfType)
+}
+
+// RegisteredTypes returns the sorted set of tfTypes with an override
+// entry. Used by the eventual codegen subcommand to enumerate the
+// override map for downstream consumers.
+func RegisteredTypes() []string {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	out := make([]string, 0, len(labels))
+	for t := range labels {
+		out = append(out, t)
+	}
+	// Sort in place — small slice, stdlib sort is fine but we avoid
+	// importing sort here to keep the skeleton dependency-light.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+// defaultLabel produces "S3 Bucket" from "aws_s3_bucket" — strips the
+// cloud prefix and title-cases every underscore-delimited word.
+func defaultLabel(tfType string) string {
+	core := stripCloudPrefix(tfType)
+	if core == "" {
+		return tfType
+	}
+	parts := strings.Split(core, "_")
+	for i, p := range parts {
+		parts[i] = titleCase(p)
+	}
+	return strings.Join(parts, " ")
+}
+
+// defaultIconKey produces "s3_bucket" from "aws_s3_bucket".
+func defaultIconKey(tfType string) string {
+	core := stripCloudPrefix(tfType)
+	if core == "" {
+		return tfType
+	}
+	return core
+}
+
+// stripCloudPrefix removes the leading "aws_" or "google_" segment
+// from tfType. Returns the input unchanged for inputs that don't
+// match a known prefix (the codegen contract is that registered
+// types always carry one — defensive return is for unit-test
+// edge cases).
+func stripCloudPrefix(tfType string) string {
+	for _, p := range []string{"aws_", "google_"} {
+		if after, ok := strings.CutPrefix(tfType, p); ok {
+			return after
+		}
+	}
+	return tfType
+}
+
+// titleCase upper-cases the first rune of s and leaves the rest as-is.
+// Avoids importing strings.Title (deprecated) and golang.org/x/text/cases
+// (an extra module dependency for a one-liner).
+func titleCase(s string) string {
+	if s == "" {
+		return ""
+	}
+	first := s[0]
+	if first >= 'a' && first <= 'z' {
+		first -= 'a' - 'A'
+	}
+	return string(first) + s[1:]
+}

--- a/pkg/imported/labels/labels.go
+++ b/pkg/imported/labels/labels.go
@@ -21,13 +21,14 @@ package labels
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 )
 
 var (
-	regMu  sync.RWMutex
-	labels = map[string]entry{}
+	regMu    sync.RWMutex
+	registry = map[string]entry{}
 )
 
 type entry struct {
@@ -47,10 +48,10 @@ func Register(tfType, label, iconKey string) {
 	}
 	regMu.Lock()
 	defer regMu.Unlock()
-	if _, ok := labels[tfType]; ok {
+	if _, ok := registry[tfType]; ok {
 		panic(fmt.Sprintf("labels.Register: duplicate registration for %q", tfType))
 	}
-	labels[tfType] = entry{Label: label, IconKey: iconKey}
+	registry[tfType] = entry{Label: label, IconKey: iconKey}
 }
 
 // Label returns the human-readable display label for tfType. Returns
@@ -58,7 +59,7 @@ func Register(tfType, label, iconKey string) {
 // applied to the type name (strip cloud prefix → humanize words).
 func Label(tfType string) string {
 	regMu.RLock()
-	e, ok := labels[tfType]
+	e, ok := registry[tfType]
 	regMu.RUnlock()
 	if ok && e.Label != "" {
 		return e.Label
@@ -71,7 +72,7 @@ func Label(tfType string) string {
 // cloud prefix ("aws_s3_bucket" → "s3_bucket").
 func IconKey(tfType string) string {
 	regMu.RLock()
-	e, ok := labels[tfType]
+	e, ok := registry[tfType]
 	regMu.RUnlock()
 	if ok && e.IconKey != "" {
 		return e.IconKey
@@ -85,17 +86,11 @@ func IconKey(tfType string) string {
 func RegisteredTypes() []string {
 	regMu.RLock()
 	defer regMu.RUnlock()
-	out := make([]string, 0, len(labels))
-	for t := range labels {
+	out := make([]string, 0, len(registry))
+	for t := range registry {
 		out = append(out, t)
 	}
-	// Sort in place — small slice, stdlib sort is fine but we avoid
-	// importing sort here to keep the skeleton dependency-light.
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j-1] > out[j]; j-- {
-			out[j-1], out[j] = out[j], out[j-1]
-		}
-	}
+	sort.Strings(out)
 	return out
 }
 

--- a/pkg/imported/labels/labels_test.go
+++ b/pkg/imported/labels/labels_test.go
@@ -1,6 +1,8 @@
 package labels
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -11,7 +13,7 @@ func resetForTest(t *testing.T) {
 	t.Helper()
 	regMu.Lock()
 	defer regMu.Unlock()
-	labels = map[string]entry{}
+	registry = map[string]entry{}
 }
 
 func TestDefaultLabel(t *testing.T) {
@@ -26,6 +28,10 @@ func TestDefaultLabel(t *testing.T) {
 		{"google_pubsub_topic", "Pubsub Topic"},
 		// No known cloud prefix → defensive passthrough.
 		{"unknown_type", "Unknown Type"},
+		// Edge: cloud prefix only, nothing after. Exercises the
+		// `core == ""` defensive branch in defaultLabel.
+		{"aws_", "aws_"},
+		{"google_", "google_"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.tfType, func(t *testing.T) {
@@ -71,22 +77,45 @@ func TestRegisterOverridesDefault(t *testing.T) {
 }
 
 func TestRegisterPartialOverride(t *testing.T) {
-	resetForTest(t)
 	// Empty label → default rule fills it; iconKey override wins.
-	Register("aws_s3_bucket", "", "s3")
-	if got, want := Label("aws_s3_bucket"), "S3 Bucket"; got != want {
-		t.Errorf("Label empty-override fallthrough = %q, want %q", got, want)
-	}
-	if got, want := IconKey("aws_s3_bucket"), "s3"; got != want {
-		t.Errorf("IconKey override = %q, want %q", got, want)
-	}
+	t.Run("empty_label_iconKey_set", func(t *testing.T) {
+		resetForTest(t)
+		Register("aws_s3_bucket", "", "s3")
+		if got, want := Label("aws_s3_bucket"), "S3 Bucket"; got != want {
+			t.Errorf("Label empty-override fallthrough = %q, want %q", got, want)
+		}
+		if got, want := IconKey("aws_s3_bucket"), "s3"; got != want {
+			t.Errorf("IconKey override = %q, want %q", got, want)
+		}
+	})
+	// Symmetric: empty iconKey → default rule fills it; label
+	// override wins. This case nails the IconKey-side fallthrough
+	// guard (`if ok && e.IconKey != ""`) that would otherwise be
+	// invisible to a partial-override test on the label side only.
+	t.Run("label_set_empty_iconKey", func(t *testing.T) {
+		resetForTest(t)
+		Register("aws_xyz", "Custom Label", "")
+		if got, want := Label("aws_xyz"), "Custom Label"; got != want {
+			t.Errorf("Label override = %q, want %q", got, want)
+		}
+		if got, want := IconKey("aws_xyz"), "xyz"; got != want {
+			t.Errorf("IconKey empty-override fallthrough = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestRegisterEmptyTypePanics(t *testing.T) {
 	resetForTest(t)
 	defer func() {
-		if r := recover(); r == nil {
+		r := recover()
+		if r == nil {
 			t.Fatal("expected panic on empty tfType")
+		}
+		// Pin the discriminator substring so a regression that
+		// merges this panic with the duplicate-registration panic
+		// fails the test.
+		if msg := fmt.Sprint(r); !strings.Contains(msg, "empty tfType") {
+			t.Errorf("panic = %q, want substring %q", msg, "empty tfType")
 		}
 	}()
 	Register("", "x", "y")
@@ -96,8 +125,12 @@ func TestRegisterDuplicatePanics(t *testing.T) {
 	resetForTest(t)
 	Register("aws_s3_bucket", "A", "a")
 	defer func() {
-		if r := recover(); r == nil {
+		r := recover()
+		if r == nil {
 			t.Fatal("expected panic on duplicate registration")
+		}
+		if msg := fmt.Sprint(r); !strings.Contains(msg, "duplicate registration") {
+			t.Errorf("panic = %q, want substring %q", msg, "duplicate registration")
 		}
 	}()
 	Register("aws_s3_bucket", "B", "b")
@@ -118,11 +151,38 @@ func TestRegisteredTypesSortedAndStable(t *testing.T) {
 			t.Errorf("RegisteredTypes()[%d] = %q, want %q", i, got[i], want[i])
 		}
 	}
+	// Stable across calls: same registry state, same result, and
+	// the returned slice must not be backed by a shared mutable
+	// buffer (mutating got must not change a subsequent call's
+	// result).
+	got2 := RegisteredTypes()
+	if len(got2) != len(got) {
+		t.Fatalf("second call len = %d, want %d", len(got2), len(got))
+	}
+	for i := range got2 {
+		if got2[i] != got[i] {
+			t.Errorf("second call [%d] = %q, want %q", i, got2[i], got[i])
+		}
+	}
+	// Stomp the first result and verify the second is unaffected
+	// (returns must be independent slices).
+	for i := range got {
+		got[i] = "STOMPED"
+	}
+	for i := range got2 {
+		if got2[i] == "STOMPED" {
+			t.Errorf("second call slice aliases first: got2[%d] = %q", i, got2[i])
+		}
+	}
 }
 
 func TestConcurrentRegisterReadSafety(t *testing.T) {
 	resetForTest(t)
-	// Smoke test: 32 readers + 1 writer must not race or deadlock.
+	// Race-detector smoke test: 32 concurrent readers against a writer
+	// must not panic, deadlock, or trigger the race detector. This test
+	// is only meaningfully assertive under `go test -race` — without it
+	// the test still runs (and verifies no deadlock / panic), but data
+	// races would go undetected. CI is expected to run with -race.
 	var wg sync.WaitGroup
 	for range 32 {
 		wg.Go(func() {

--- a/pkg/imported/labels/labels_test.go
+++ b/pkg/imported/labels/labels_test.go
@@ -1,0 +1,134 @@
+package labels
+
+import (
+	"sync"
+	"testing"
+)
+
+// resetForTest clears the registry between tests. Not exported —
+// production code never resets the registry; only tests do.
+func resetForTest(t *testing.T) {
+	t.Helper()
+	regMu.Lock()
+	defer regMu.Unlock()
+	labels = map[string]entry{}
+}
+
+func TestDefaultLabel(t *testing.T) {
+	resetForTest(t)
+	cases := []struct {
+		tfType string
+		want   string
+	}{
+		{"aws_s3_bucket", "S3 Bucket"},
+		{"aws_dynamodb_table", "Dynamodb Table"},
+		{"google_storage_bucket", "Storage Bucket"},
+		{"google_pubsub_topic", "Pubsub Topic"},
+		// No known cloud prefix → defensive passthrough.
+		{"unknown_type", "Unknown Type"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tfType, func(t *testing.T) {
+			if got := Label(tc.tfType); got != tc.want {
+				t.Errorf("Label(%q) = %q, want %q", tc.tfType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultIconKey(t *testing.T) {
+	resetForTest(t)
+	cases := []struct {
+		tfType string
+		want   string
+	}{
+		{"aws_s3_bucket", "s3_bucket"},
+		{"google_pubsub_topic", "pubsub_topic"},
+		{"unknown_type", "unknown_type"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tfType, func(t *testing.T) {
+			if got := IconKey(tc.tfType); got != tc.want {
+				t.Errorf("IconKey(%q) = %q, want %q", tc.tfType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRegisterOverridesDefault(t *testing.T) {
+	resetForTest(t)
+	Register("aws_sqs_queue", "Queue (SQS)", "sqs")
+	if got, want := Label("aws_sqs_queue"), "Queue (SQS)"; got != want {
+		t.Errorf("Label override = %q, want %q", got, want)
+	}
+	if got, want := IconKey("aws_sqs_queue"), "sqs"; got != want {
+		t.Errorf("IconKey override = %q, want %q", got, want)
+	}
+	// Unregistered types fall through to default rule.
+	if got, want := Label("aws_s3_bucket"), "S3 Bucket"; got != want {
+		t.Errorf("Label fallthrough = %q, want %q", got, want)
+	}
+}
+
+func TestRegisterPartialOverride(t *testing.T) {
+	resetForTest(t)
+	// Empty label → default rule fills it; iconKey override wins.
+	Register("aws_s3_bucket", "", "s3")
+	if got, want := Label("aws_s3_bucket"), "S3 Bucket"; got != want {
+		t.Errorf("Label empty-override fallthrough = %q, want %q", got, want)
+	}
+	if got, want := IconKey("aws_s3_bucket"), "s3"; got != want {
+		t.Errorf("IconKey override = %q, want %q", got, want)
+	}
+}
+
+func TestRegisterEmptyTypePanics(t *testing.T) {
+	resetForTest(t)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on empty tfType")
+		}
+	}()
+	Register("", "x", "y")
+}
+
+func TestRegisterDuplicatePanics(t *testing.T) {
+	resetForTest(t)
+	Register("aws_s3_bucket", "A", "a")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on duplicate registration")
+		}
+	}()
+	Register("aws_s3_bucket", "B", "b")
+}
+
+func TestRegisteredTypesSortedAndStable(t *testing.T) {
+	resetForTest(t)
+	Register("google_pubsub_topic", "Topic", "topic")
+	Register("aws_s3_bucket", "Bucket", "s3")
+	Register("aws_dynamodb_table", "Table", "ddb")
+	got := RegisteredTypes()
+	want := []string{"aws_dynamodb_table", "aws_s3_bucket", "google_pubsub_topic"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("RegisteredTypes()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestConcurrentRegisterReadSafety(t *testing.T) {
+	resetForTest(t)
+	// Smoke test: 32 readers + 1 writer must not race or deadlock.
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			_ = Label("aws_s3_bucket")
+		})
+	}
+	Register("aws_s3_bucket", "Bucket", "s3")
+	wg.Wait()
+}

--- a/pkg/imported/provider.go
+++ b/pkg/imported/provider.go
@@ -1,0 +1,113 @@
+package imported
+
+import (
+	"context"
+
+	composer_imported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+)
+
+// Provider is the cloud-agnostic facade every consumer of imported
+// resources dispatches through. One implementation per cloud
+// (pkg/imported/aws, pkg/imported/gcp); construct via ProviderFor or
+// the per-cloud package's NewProvider.
+//
+// The interface bundles every per-Terraform-type concern a consumer
+// needs — static introspection (SupportedTypes, Capabilities, labels,
+// policy, metrics), identity-shape helpers, live cloud interaction
+// (Discover/Enrich), and the compare + render helpers. See issue #482
+// for the full design rationale: this surface replaces ~2,200 LOC of
+// hand-rolled per-type dispatch in the downstream consumer.
+//
+// Methods are grouped by category in the interface declaration; all
+// methods are safe to call concurrently per the per-cloud impls.
+type Provider interface {
+	// SupportedTypes returns the sorted, deterministic list of
+	// Terraform resource types this Provider knows about. Matches
+	// pkg/insideout-import/registry.SupportedDiscoverTypes(cloud).
+	SupportedTypes() []string
+
+	// Capabilities reports the per-type feature surface for tfType.
+	// Returns a zero-valued Capabilities (all false) for unknown
+	// types — consumers branch on the bools rather than checking
+	// the type against SupportedTypes() separately.
+	Capabilities(tfType string) Capabilities
+
+	// LabelFor returns the human-readable display label and the
+	// icon-asset key for tfType. Falls back to the default rule
+	// (humanized cloud-prefix-stripped type name) when no curated
+	// override is registered. See pkg/imported/labels.
+	LabelFor(tfType string) (label, iconKey string)
+
+	// PolicyFor returns the curated FieldPolicy map for tfType, or
+	// (nil, false) when no policy is registered. The map is keyed
+	// by attribute path (see pkg/composer/imported/policy.path
+	// grammar); a nil map signals an Identity-only type whose
+	// attribute surface is not curated.
+	PolicyFor(tfType string) (policy.Map, bool)
+
+	// MetricsBinding returns the ComponentMetricsBinding for
+	// tfType, or (zero, false) when no binding is registered. See
+	// pkg/imported/bindings. Consumers gate the metrics tab on the
+	// boolean — a zero binding with ok==true is valid and means
+	// "use consumer defaults", distinct from "no metrics surface".
+	MetricsBinding(tfType string) (ComponentMetricsBinding, bool)
+
+	// StableID returns a deterministic, collision-resistant
+	// identifier for the resource named by identity. Used for
+	// dedupe keys, audit log entries, and stable URL paths in the
+	// downstream UI. Distinct from Address (which is the
+	// Terraform-state-form key) — StableID is opaque and may
+	// outlive an Address rename.
+	StableID(identity *composer_imported.ResourceIdentity) string
+
+	// CanonicalAddress returns the Terraform resource address
+	// (`<type>.<label>`) for identity, regenerating it from the
+	// underlying NameHint / NativeIDs when identity.Address is
+	// empty. Equivalent to imported.GenerateAddress for a fresh
+	// identity; round-trips identity.Address when set.
+	CanonicalAddress(identity *composer_imported.ResourceIdentity) string
+
+	// Discover enumerates resources of the named types from the
+	// caller's cloud account/project. The clients union must
+	// carry the appropriate cloud-side SDK client bundle; the
+	// opts struct supplies filters and scope. Returns one
+	// ImportedResource per matched cloud resource, with
+	// Identity populated and Tier=TierImportedFlat,
+	// Source=SourceImporter.
+	Discover(ctx context.Context, types []string, clients Clients, opts DiscoverOpts) ([]composer_imported.ImportedResource, error)
+
+	// EnrichAttributes populates ir.Attrs in place for every
+	// resource whose Identity.Type has a registered enricher.
+	// Resources of types without an enricher are left untouched.
+	// Errors are accumulated per-resource and returned as a
+	// joined error; ErrEnrichClientUnavailable failures are
+	// downgraded internally (the per-cloud impls surface them as
+	// progress warnings without failing the batch).
+	EnrichAttributes(ctx context.Context, irs []composer_imported.ImportedResource, clients Clients) error
+
+	// EnrichByID fetches the typed Layer-1 Attrs payload for a
+	// single resource named by identity. Used by the per-IR drift
+	// refresh path. Returns ErrEnrichByIDNotImplemented when the
+	// per-type enricher does not satisfy the ByIDEnricher
+	// contract; callers downgrade that to "skip drift refresh for
+	// this type" rather than treating it as a hard error.
+	EnrichByID(ctx context.Context, identity *composer_imported.ResourceIdentity, clients Clients) (Attrs, error)
+
+	// CompareDrift diffs snapshot against live attrs for tfType
+	// and returns the list of mismatched fields. Returns nil
+	// when no drift is detected and when no comparator is
+	// registered for tfType (consumers check
+	// Capabilities(tfType).DriftDetectable to distinguish the two
+	// cases). Field-level semantics (whole-list compare, label-
+	// filter, etc.) come from the per-type policy's
+	// DriftSemantic tags.
+	CompareDrift(tfType string, snapshot, live Attrs) []FieldMismatch
+
+	// RileyContext returns a short, human-readable summary line
+	// per imported resource, suitable for inclusion in a Riley
+	// chat-context prompt. Conservative format: one line per IR
+	// of the form "<address> (<type>)". Stable ordering across
+	// calls — sorted by Identity.Address.
+	RileyContext(irs []composer_imported.ImportedResource) []string
+}

--- a/pkg/imported/provider.go
+++ b/pkg/imported/provider.go
@@ -3,7 +3,7 @@ package imported
 import (
 	"context"
 
-	composer_imported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
 )
 
@@ -59,14 +59,14 @@ type Provider interface {
 	// downstream UI. Distinct from Address (which is the
 	// Terraform-state-form key) — StableID is opaque and may
 	// outlive an Address rename.
-	StableID(identity *composer_imported.ResourceIdentity) string
+	StableID(identity *composerimported.ResourceIdentity) string
 
 	// CanonicalAddress returns the Terraform resource address
 	// (`<type>.<label>`) for identity, regenerating it from the
 	// underlying NameHint / NativeIDs when identity.Address is
 	// empty. Equivalent to imported.GenerateAddress for a fresh
 	// identity; round-trips identity.Address when set.
-	CanonicalAddress(identity *composer_imported.ResourceIdentity) string
+	CanonicalAddress(identity *composerimported.ResourceIdentity) string
 
 	// Discover enumerates resources of the named types from the
 	// caller's cloud account/project. The clients union must
@@ -75,7 +75,7 @@ type Provider interface {
 	// ImportedResource per matched cloud resource, with
 	// Identity populated and Tier=TierImportedFlat,
 	// Source=SourceImporter.
-	Discover(ctx context.Context, types []string, clients Clients, opts DiscoverOpts) ([]composer_imported.ImportedResource, error)
+	Discover(ctx context.Context, types []string, clients Clients, opts DiscoverOpts) ([]composerimported.ImportedResource, error)
 
 	// EnrichAttributes populates ir.Attrs in place for every
 	// resource whose Identity.Type has a registered enricher.
@@ -84,7 +84,7 @@ type Provider interface {
 	// joined error; ErrEnrichClientUnavailable failures are
 	// downgraded internally (the per-cloud impls surface them as
 	// progress warnings without failing the batch).
-	EnrichAttributes(ctx context.Context, irs []composer_imported.ImportedResource, clients Clients) error
+	EnrichAttributes(ctx context.Context, irs []composerimported.ImportedResource, clients Clients) error
 
 	// EnrichByID fetches the typed Layer-1 Attrs payload for a
 	// single resource named by identity. Used by the per-IR drift
@@ -92,7 +92,7 @@ type Provider interface {
 	// per-type enricher does not satisfy the ByIDEnricher
 	// contract; callers downgrade that to "skip drift refresh for
 	// this type" rather than treating it as a hard error.
-	EnrichByID(ctx context.Context, identity *composer_imported.ResourceIdentity, clients Clients) (Attrs, error)
+	EnrichByID(ctx context.Context, identity *composerimported.ResourceIdentity, clients Clients) (Attrs, error)
 
 	// CompareDrift diffs snapshot against live attrs for tfType
 	// and returns the list of mismatched fields. Returns nil
@@ -104,10 +104,13 @@ type Provider interface {
 	// DriftSemantic tags.
 	CompareDrift(tfType string, snapshot, live Attrs) []FieldMismatch
 
-	// RileyContext returns a short, human-readable summary line
-	// per imported resource, suitable for inclusion in a Riley
-	// chat-context prompt. Conservative format: one line per IR
-	// of the form "<address> (<type>)". Stable ordering across
-	// calls — sorted by Identity.Address.
-	RileyContext(irs []composer_imported.ImportedResource) []string
+	// AgentContext returns a short, human-readable summary line
+	// per imported resource, suitable for inclusion in an
+	// interactive-agent chat-context prompt. Conservative format:
+	// one line per IR of the form "<address> (<type>)". Stable
+	// ordering across calls — sorted by Identity.Address.
+	//
+	// Agent-name-agnostic on purpose: the per-product naming
+	// (Riley today) can rotate without flipping the interface.
+	AgentContext(irs []composerimported.ImportedResource) []string
 }

--- a/pkg/imported/provider_test.go
+++ b/pkg/imported/provider_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	composer_imported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
 	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
 	// Side-effect imports populate the Provider registry.
@@ -21,26 +21,26 @@ type stubProvider struct {
 	name string
 }
 
-func (s *stubProvider) SupportedTypes() []string                { return []string{"stub_type"} }
-func (s *stubProvider) Capabilities(string) imp.Capabilities    { return imp.Capabilities{} }
-func (s *stubProvider) LabelFor(string) (string, string)        { return "", "" }
-func (s *stubProvider) PolicyFor(string) (policy.Map, bool)     { return nil, false }
+func (s *stubProvider) SupportedTypes() []string             { return []string{"stub_type"} }
+func (s *stubProvider) Capabilities(string) imp.Capabilities { return imp.Capabilities{} }
+func (s *stubProvider) LabelFor(string) (string, string)     { return "", "" }
+func (s *stubProvider) PolicyFor(string) (policy.Map, bool)  { return nil, false }
 func (s *stubProvider) MetricsBinding(string) (imp.ComponentMetricsBinding, bool) {
 	return imp.ComponentMetricsBinding{}, false
 }
-func (s *stubProvider) StableID(*composer_imported.ResourceIdentity) string         { return "" }
-func (s *stubProvider) CanonicalAddress(*composer_imported.ResourceIdentity) string { return "" }
-func (s *stubProvider) Discover(context.Context, []string, imp.Clients, imp.DiscoverOpts) ([]composer_imported.ImportedResource, error) {
+func (s *stubProvider) StableID(*composerimported.ResourceIdentity) string         { return "" }
+func (s *stubProvider) CanonicalAddress(*composerimported.ResourceIdentity) string { return "" }
+func (s *stubProvider) Discover(context.Context, []string, imp.Clients, imp.DiscoverOpts) ([]composerimported.ImportedResource, error) {
 	return nil, nil
 }
-func (s *stubProvider) EnrichAttributes(context.Context, []composer_imported.ImportedResource, imp.Clients) error {
+func (s *stubProvider) EnrichAttributes(context.Context, []composerimported.ImportedResource, imp.Clients) error {
 	return nil
 }
-func (s *stubProvider) EnrichByID(context.Context, *composer_imported.ResourceIdentity, imp.Clients) (imp.Attrs, error) {
+func (s *stubProvider) EnrichByID(context.Context, *composerimported.ResourceIdentity, imp.Clients) (imp.Attrs, error) {
 	return nil, nil
 }
 func (s *stubProvider) CompareDrift(string, imp.Attrs, imp.Attrs) []imp.FieldMismatch { return nil }
-func (s *stubProvider) RileyContext([]composer_imported.ImportedResource) []string    { return nil }
+func (s *stubProvider) AgentContext([]composerimported.ImportedResource) []string     { return nil }
 
 // Compile-time interface satisfaction check.
 var _ imp.Provider = (*stubProvider)(nil)
@@ -70,7 +70,7 @@ func TestProviderInterfaceShape(t *testing.T) {
 		t.Errorf("EnrichByID stub returned err: %v", err)
 	}
 	_ = p.CompareDrift("x", nil, nil)
-	_ = p.RileyContext(nil)
+	_ = p.AgentContext(nil)
 }
 
 func TestErrUnknownCloud(t *testing.T) {

--- a/pkg/imported/provider_test.go
+++ b/pkg/imported/provider_test.go
@@ -1,0 +1,82 @@
+package imported_test
+
+import (
+	"context"
+	"testing"
+
+	composer_imported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+	// Side-effect imports populate the Provider registry.
+	_ "github.com/luthersystems/insideout-terraform-presets/pkg/imported/aws"
+	_ "github.com/luthersystems/insideout-terraform-presets/pkg/imported/gcp"
+)
+
+// stubProvider is a minimal Provider used to exercise the interface
+// shape and the registry. It carries no cloud-side state and returns
+// zero values for every method — the goal is to lock the interface
+// shape, not to test live behavior (the per-cloud provider tests
+// cover that).
+type stubProvider struct {
+	name string
+}
+
+func (s *stubProvider) SupportedTypes() []string                { return []string{"stub_type"} }
+func (s *stubProvider) Capabilities(string) imp.Capabilities    { return imp.Capabilities{} }
+func (s *stubProvider) LabelFor(string) (string, string)        { return "", "" }
+func (s *stubProvider) PolicyFor(string) (policy.Map, bool)     { return nil, false }
+func (s *stubProvider) MetricsBinding(string) (imp.ComponentMetricsBinding, bool) {
+	return imp.ComponentMetricsBinding{}, false
+}
+func (s *stubProvider) StableID(*composer_imported.ResourceIdentity) string         { return "" }
+func (s *stubProvider) CanonicalAddress(*composer_imported.ResourceIdentity) string { return "" }
+func (s *stubProvider) Discover(context.Context, []string, imp.Clients, imp.DiscoverOpts) ([]composer_imported.ImportedResource, error) {
+	return nil, nil
+}
+func (s *stubProvider) EnrichAttributes(context.Context, []composer_imported.ImportedResource, imp.Clients) error {
+	return nil
+}
+func (s *stubProvider) EnrichByID(context.Context, *composer_imported.ResourceIdentity, imp.Clients) (imp.Attrs, error) {
+	return nil, nil
+}
+func (s *stubProvider) CompareDrift(string, imp.Attrs, imp.Attrs) []imp.FieldMismatch { return nil }
+func (s *stubProvider) RileyContext([]composer_imported.ImportedResource) []string    { return nil }
+
+// Compile-time interface satisfaction check.
+var _ imp.Provider = (*stubProvider)(nil)
+
+func TestProviderInterfaceShape(t *testing.T) {
+	t.Parallel()
+
+	var p imp.Provider = &stubProvider{name: "stub"}
+
+	// Exercise every method to lock the shape.
+	if got := p.SupportedTypes(); len(got) != 1 || got[0] != "stub_type" {
+		t.Errorf("SupportedTypes: got %v", got)
+	}
+	_ = p.Capabilities("x")
+	_, _ = p.LabelFor("x")
+	_, _ = p.PolicyFor("x")
+	_, _ = p.MetricsBinding("x")
+	_ = p.StableID(nil)
+	_ = p.CanonicalAddress(nil)
+	if _, err := p.Discover(context.Background(), nil, imp.Clients{}, imp.DiscoverOpts{}); err != nil {
+		t.Errorf("Discover stub returned err: %v", err)
+	}
+	if err := p.EnrichAttributes(context.Background(), nil, imp.Clients{}); err != nil {
+		t.Errorf("EnrichAttributes stub returned err: %v", err)
+	}
+	if _, err := p.EnrichByID(context.Background(), nil, imp.Clients{}); err != nil {
+		t.Errorf("EnrichByID stub returned err: %v", err)
+	}
+	_ = p.CompareDrift("x", nil, nil)
+	_ = p.RileyContext(nil)
+}
+
+func TestErrUnknownCloud(t *testing.T) {
+	t.Parallel()
+
+	if _, err := imp.ProviderFor("does-not-exist"); err == nil {
+		t.Fatal("expected error for unknown cloud")
+	}
+}

--- a/pkg/imported/registry.go
+++ b/pkg/imported/registry.go
@@ -2,6 +2,8 @@ package imported
 
 import (
 	"fmt"
+	"sort"
+	"sync"
 )
 
 // ProviderConstructor builds a Provider for one cloud. Per-cloud
@@ -20,12 +22,20 @@ import (
 // the same downgrade-friendly contract used elsewhere.
 type ProviderConstructor func() Provider
 
-var providerRegistry = map[string]ProviderConstructor{}
+var (
+	registryMu       sync.RWMutex
+	providerRegistry = map[string]ProviderConstructor{}
+)
 
 // Register pins a ProviderConstructor for a cloud string. Called
 // from per-cloud package init() functions; callers outside the
 // per-cloud packages should not invoke this directly. Panics on
 // duplicate registration to surface accidental double-init.
+//
+// Concurrency: in production Register is called at init() time
+// before any ProviderFor calls — sequentially — so the mutex is a
+// defense-in-depth measure for the (currently hypothetical) case
+// where a runtime Register lands and races with ProviderFor.
 func Register(cloud string, ctor ProviderConstructor) {
 	if cloud == "" {
 		panic("imported.Register: empty cloud")
@@ -33,6 +43,8 @@ func Register(cloud string, ctor ProviderConstructor) {
 	if ctor == nil {
 		panic("imported.Register: nil constructor")
 	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
 	if _, dup := providerRegistry[cloud]; dup {
 		panic(fmt.Sprintf("imported.Register: duplicate registration for %q", cloud))
 	}
@@ -49,7 +61,9 @@ func Register(cloud string, ctor ProviderConstructor) {
 // pkg/imported/gcp.NewProvider, passing the appropriate
 // AWSDiscoverer / GCPDiscoverer.
 func ProviderFor(cloud string) (Provider, error) {
+	registryMu.RLock()
 	ctor, ok := providerRegistry[cloud]
+	registryMu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrUnknownCloud, cloud)
 	}
@@ -60,17 +74,12 @@ func ProviderFor(cloud string) (Provider, error) {
 // registered Provider. Used by tests and by the eventual codegen
 // pipeline to enumerate the cloud surface.
 func RegisteredClouds() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
 	out := make([]string, 0, len(providerRegistry))
 	for k := range providerRegistry {
 		out = append(out, k)
 	}
-	// Sort to keep the surface deterministic without a sort import
-	// at the call site. Bubble-sort because the slice is tiny
-	// (2 entries today, never expected to exceed ~5).
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j-1] > out[j]; j-- {
-			out[j-1], out[j] = out[j], out[j-1]
-		}
-	}
+	sort.Strings(out)
 	return out
 }

--- a/pkg/imported/registry.go
+++ b/pkg/imported/registry.go
@@ -1,0 +1,76 @@
+package imported
+
+import (
+	"fmt"
+)
+
+// ProviderConstructor builds a Provider for one cloud. Per-cloud
+// packages register their constructor via Register from an init();
+// ProviderFor dispatches on the cloud string at call time.
+//
+// The constructor takes no arguments so registration can happen at
+// import time. Per-cloud Provider impls that need cloud-side state
+// (e.g. a default aws.Config or a Cloud Asset searcher) accept the
+// state on their own NewProvider entry point — those use cases
+// construct the Provider directly rather than going through
+// ProviderFor. ProviderFor returns the zero-state Provider that
+// satisfies the static-introspection half of the interface (every
+// method except Discover/EnrichAttributes/EnrichByID); the live-cloud
+// methods on the zero Provider return ErrEnrichClientUnavailable per
+// the same downgrade-friendly contract used elsewhere.
+type ProviderConstructor func() Provider
+
+var providerRegistry = map[string]ProviderConstructor{}
+
+// Register pins a ProviderConstructor for a cloud string. Called
+// from per-cloud package init() functions; callers outside the
+// per-cloud packages should not invoke this directly. Panics on
+// duplicate registration to surface accidental double-init.
+func Register(cloud string, ctor ProviderConstructor) {
+	if cloud == "" {
+		panic("imported.Register: empty cloud")
+	}
+	if ctor == nil {
+		panic("imported.Register: nil constructor")
+	}
+	if _, dup := providerRegistry[cloud]; dup {
+		panic(fmt.Sprintf("imported.Register: duplicate registration for %q", cloud))
+	}
+	providerRegistry[cloud] = ctor
+}
+
+// ProviderFor returns the Provider for the named cloud, or
+// (nil, ErrUnknownCloud) when no impl is registered. Valid cloud
+// strings today: "aws", "gcp". The returned Provider is in the
+// zero-state — it satisfies the static-introspection half of the
+// interface without holding any cloud-side SDK handles. Callers
+// that need live cloud interaction should construct the per-cloud
+// Provider directly via pkg/imported/aws.NewProvider /
+// pkg/imported/gcp.NewProvider, passing the appropriate
+// AWSDiscoverer / GCPDiscoverer.
+func ProviderFor(cloud string) (Provider, error) {
+	ctor, ok := providerRegistry[cloud]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownCloud, cloud)
+	}
+	return ctor(), nil
+}
+
+// RegisteredClouds returns the sorted list of cloud strings with a
+// registered Provider. Used by tests and by the eventual codegen
+// pipeline to enumerate the cloud surface.
+func RegisteredClouds() []string {
+	out := make([]string, 0, len(providerRegistry))
+	for k := range providerRegistry {
+		out = append(out, k)
+	}
+	// Sort to keep the surface deterministic without a sort import
+	// at the call site. Bubble-sort because the slice is tiny
+	// (2 entries today, never expected to exceed ~5).
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}

--- a/pkg/imported/registry_test.go
+++ b/pkg/imported/registry_test.go
@@ -1,0 +1,115 @@
+package imported_test
+
+import (
+	"errors"
+	"testing"
+
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+	// Side-effect imports populate the Provider registry.
+	_ "github.com/luthersystems/insideout-terraform-presets/pkg/imported/aws"
+	_ "github.com/luthersystems/insideout-terraform-presets/pkg/imported/gcp"
+)
+
+func TestProviderFor_AWS(t *testing.T) {
+	t.Parallel()
+	p, err := imp.ProviderFor("aws")
+	if err != nil {
+		t.Fatalf("ProviderFor(aws): %v", err)
+	}
+	if p == nil {
+		t.Fatal("ProviderFor(aws): returned nil Provider with nil error")
+	}
+	// Smoke: SupportedTypes returns the AWS type list.
+	types := p.SupportedTypes()
+	if len(types) == 0 {
+		t.Fatal("SupportedTypes() returned empty for AWS")
+	}
+	// Sanity: the list looks like AWS types, not GCP types.
+	if got := types[0]; len(got) < 4 || got[:4] != "aws_" {
+		t.Errorf("first AWS type %q does not look AWS-shaped", got)
+	}
+}
+
+func TestProviderFor_GCP(t *testing.T) {
+	t.Parallel()
+	p, err := imp.ProviderFor("gcp")
+	if err != nil {
+		t.Fatalf("ProviderFor(gcp): %v", err)
+	}
+	if p == nil {
+		t.Fatal("ProviderFor(gcp): returned nil Provider with nil error")
+	}
+	types := p.SupportedTypes()
+	if len(types) == 0 {
+		t.Fatal("SupportedTypes() returned empty for GCP")
+	}
+	if got := types[0]; len(got) < 7 || got[:7] != "google_" {
+		t.Errorf("first GCP type %q does not look GCP-shaped", got)
+	}
+}
+
+func TestProviderFor_Unknown(t *testing.T) {
+	t.Parallel()
+	_, err := imp.ProviderFor("azure")
+	if err == nil {
+		t.Fatal("expected error for unknown cloud")
+	}
+	if !errors.Is(err, imp.ErrUnknownCloud) {
+		t.Errorf("expected ErrUnknownCloud, got %v", err)
+	}
+}
+
+func TestRegisteredClouds(t *testing.T) {
+	t.Parallel()
+	clouds := imp.RegisteredClouds()
+	if len(clouds) < 2 {
+		t.Fatalf("expected at least 2 registered clouds, got %v", clouds)
+	}
+	want := map[string]bool{"aws": false, "gcp": false}
+	for _, c := range clouds {
+		if _, ok := want[c]; ok {
+			want[c] = true
+		}
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("expected %q in RegisteredClouds, got %v", k, clouds)
+		}
+	}
+	// Sorted.
+	for i := 1; i < len(clouds); i++ {
+		if clouds[i-1] > clouds[i] {
+			t.Errorf("RegisteredClouds not sorted: %v", clouds)
+		}
+	}
+}
+
+func TestRegisterPanicsOnDuplicate(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on duplicate registration")
+		}
+	}()
+	imp.Register("aws", func() imp.Provider { return nil })
+}
+
+func TestRegisterPanicsOnEmptyCloud(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on empty cloud")
+		}
+	}()
+	imp.Register("", func() imp.Provider { return nil })
+}
+
+func TestRegisterPanicsOnNilCtor(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on nil ctor")
+		}
+	}()
+	imp.Register("synthetic-cloud", nil)
+}

--- a/pkg/imported/snapshot/snapshot.go
+++ b/pkg/imported/snapshot/snapshot.go
@@ -1,0 +1,144 @@
+// Package snapshot is the sealed-envelope serialization layer for a
+// slice of imported resources as it rides inside the downstream
+// stack_versions.imported column.
+//
+// The envelope format is intentionally minimal:
+//
+//	{"version": 1, "resources": [<ImportedResource>, ...]}
+//
+// The bare slice form ([{...}, {...}]) is still accepted on decode for
+// backward compatibility with v0 callers — the legacy storage shape
+// used by the first cut of #144 — but every emit goes through the
+// versioned envelope.
+//
+// Byte-stable output: MarshalSnapshot sorts the input by
+// Identity.Address before serializing so the same logical slice
+// produces an identical byte stream on every call. Downstream change
+// detection in stack_versions compares envelopes for equality; non-
+// deterministic field ordering would manufacture spurious "imported
+// changed" rows.
+package snapshot
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// CurrentVersion is the envelope version this package emits and the
+// highest version it can decode. Bump when adding fields that older
+// readers cannot ignore (e.g. a top-level field whose absence changes
+// semantics, not a per-resource additive field that round-trips through
+// json.RawMessage). Additive struct fields on ImportedResource itself
+// do NOT require a version bump — they ride along inside the
+// "resources" array via encoding/json's standard struct decode.
+const CurrentVersion = 1
+
+// ErrUnsupportedVersion is returned by UnmarshalSnapshot for an
+// envelope whose version is higher than CurrentVersion. The error
+// payload includes the offending version so the caller can log it
+// without re-decoding the envelope.
+var ErrUnsupportedVersion = errors.New("snapshot: unsupported envelope version")
+
+// envelopeV1 is the wire shape of a v1 snapshot. The version field is
+// always populated on emit; the resources slice is the
+// Address-sorted list.
+type envelopeV1 struct {
+	Version   int                                 `json:"version"`
+	Resources []composerimported.ImportedResource `json:"resources"`
+}
+
+// MarshalSnapshot serializes a slice of imported resources into the
+// sealed envelope format consumed by stack_versions.imported in the
+// downstream backend. The returned byte slice round-trips through
+// UnmarshalSnapshot to the original irs (modulo Address-sorted order,
+// which is intentional). The returned version is always CurrentVersion;
+// it's surfaced explicitly so callers don't have to re-decode the
+// envelope to learn the version they just emitted.
+func MarshalSnapshot(
+	irs []composerimported.ImportedResource,
+) ([]byte, int, error) {
+	// Defensive copy so we don't mutate the caller's slice ordering.
+	// nil-in / nil-out is preserved as len-0 — both round-trip to the
+	// same envelope.
+	sorted := make([]composerimported.ImportedResource, len(irs))
+	copy(sorted, irs)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Identity.Address < sorted[j].Identity.Address
+	})
+
+	env := envelopeV1{
+		Version:   CurrentVersion,
+		Resources: sorted,
+	}
+	out, err := json.Marshal(env)
+	if err != nil {
+		return nil, 0, fmt.Errorf("snapshot: marshal envelope: %w", err)
+	}
+	return out, CurrentVersion, nil
+}
+
+// UnmarshalSnapshot reverses MarshalSnapshot. Returns
+// ErrUnsupportedVersion (wrapped via fmt.Errorf) when version >
+// CurrentVersion. A v0 envelope (no version byte — the legacy JSON
+// array of ImportedResource) is treated as version 0 for backward
+// compatibility; the returned version is 0 in that case.
+func UnmarshalSnapshot(
+	raw []byte,
+) ([]composerimported.ImportedResource, int, error) {
+	if len(raw) == 0 {
+		return nil, 0, nil
+	}
+
+	// Sniff array-vs-object by skipping leading whitespace and
+	// peeking the first non-space byte. encoding/json accepts the
+	// same forms, so this matches the decode surface exactly.
+	first := firstNonSpaceByte(raw)
+	switch first {
+	case '[':
+		var legacy []composerimported.ImportedResource
+		if err := json.Unmarshal(raw, &legacy); err != nil {
+			return nil, 0, fmt.Errorf("snapshot: decode v0 array: %w", err)
+		}
+		return legacy, 0, nil
+	case '{':
+		// Decode just the version first so we can fail fast on an
+		// unsupported envelope before paying the cost of decoding
+		// every resource into the typed struct shape.
+		var probe struct {
+			Version int `json:"version"`
+		}
+		if err := json.Unmarshal(raw, &probe); err != nil {
+			return nil, 0, fmt.Errorf("snapshot: decode envelope version: %w", err)
+		}
+		if probe.Version > CurrentVersion {
+			return nil, probe.Version, fmt.Errorf("%w: got %d, max %d",
+				ErrUnsupportedVersion, probe.Version, CurrentVersion)
+		}
+		var env envelopeV1
+		if err := json.Unmarshal(raw, &env); err != nil {
+			return nil, probe.Version, fmt.Errorf("snapshot: decode envelope: %w", err)
+		}
+		return env.Resources, env.Version, nil
+	default:
+		return nil, 0, fmt.Errorf("snapshot: unexpected leading byte %q", first)
+	}
+}
+
+// firstNonSpaceByte returns the first non-whitespace byte from raw, or
+// 0 if raw is all whitespace. Whitespace per the JSON spec: space,
+// tab, CR, LF.
+func firstNonSpaceByte(raw []byte) byte {
+	for _, b := range raw {
+		switch b {
+		case ' ', '\t', '\r', '\n':
+			continue
+		default:
+			return b
+		}
+	}
+	return 0
+}

--- a/pkg/imported/snapshot/snapshot_test.go
+++ b/pkg/imported/snapshot/snapshot_test.go
@@ -1,0 +1,210 @@
+package snapshot_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/snapshot"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixture returns a small, deterministic slice of ImportedResource
+// ordered NOT by Address — the round-trip / byte-stable tests rely on
+// MarshalSnapshot doing the sort itself.
+func fixture() []composerimported.ImportedResource {
+	return []composerimported.ImportedResource{
+		{
+			Identity: composerimported.ResourceIdentity{
+				Cloud:   "aws",
+				Type:    "aws_sqs_queue",
+				Address: "aws_sqs_queue.zeta",
+			},
+			Tier: composerimported.TierImportedFlat,
+		},
+		{
+			Identity: composerimported.ResourceIdentity{
+				Cloud:   "aws",
+				Type:    "aws_s3_bucket",
+				Address: "aws_s3_bucket.alpha",
+			},
+			Tier: composerimported.TierImportedConformant,
+		},
+		{
+			Identity: composerimported.ResourceIdentity{
+				Cloud:   "gcp",
+				Type:    "google_storage_bucket",
+				Address: "google_storage_bucket.middle",
+			},
+		},
+	}
+}
+
+func sortedAddresses(rs []composerimported.ImportedResource) []string {
+	out := make([]string, len(rs))
+	for i, r := range rs {
+		out[i] = r.Identity.Address
+	}
+	return out
+}
+
+// TestMarshalSnapshot_RoundTrip verifies that MarshalSnapshot followed
+// by UnmarshalSnapshot returns the original resources sorted by
+// Address.
+func TestMarshalSnapshot_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	irs := fixture()
+	raw, version, err := snapshot.MarshalSnapshot(irs)
+	require.NoError(t, err)
+	require.Equal(t, snapshot.CurrentVersion, version)
+
+	got, gotVersion, err := snapshot.UnmarshalSnapshot(raw)
+	require.NoError(t, err)
+	require.Equal(t, snapshot.CurrentVersion, gotVersion)
+	require.Len(t, got, len(irs))
+
+	assert.Equal(t, []string{
+		"aws_s3_bucket.alpha",
+		"aws_sqs_queue.zeta",
+		"google_storage_bucket.middle",
+	}, sortedAddresses(got))
+}
+
+// TestMarshalSnapshot_ByteStable verifies that marshaling the same
+// slice twice produces byte-identical output. The downstream stack
+// versions table compares envelopes byte-wise to detect drift; any
+// non-determinism here would manufacture spurious "imported changed"
+// rows.
+func TestMarshalSnapshot_ByteStable(t *testing.T) {
+	t.Parallel()
+
+	irs := fixture()
+	first, _, err := snapshot.MarshalSnapshot(irs)
+	require.NoError(t, err)
+
+	second, _, err := snapshot.MarshalSnapshot(irs)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second),
+		"snapshot output must be byte-identical across calls")
+
+	// Also verify that an unrelated permutation of the input yields
+	// the same output — MarshalSnapshot sorts internally.
+	permuted := []composerimported.ImportedResource{
+		irs[1], irs[2], irs[0],
+	}
+	third, _, err := snapshot.MarshalSnapshot(permuted)
+	require.NoError(t, err)
+	assert.Equal(t, string(first), string(third),
+		"snapshot output must be invariant under input permutation")
+}
+
+// TestMarshalSnapshot_NilInput verifies that nil and empty-slice
+// inputs both round-trip to a valid empty envelope. The downstream
+// reader treats an empty resources list as "no imported resources" —
+// a hard error here would block initial bootstrapping of a stack with
+// no imports yet.
+func TestMarshalSnapshot_NilInput(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"nil", "empty"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var in []composerimported.ImportedResource
+			if name == "empty" {
+				in = []composerimported.ImportedResource{}
+			}
+			raw, version, err := snapshot.MarshalSnapshot(in)
+			require.NoError(t, err)
+			require.Equal(t, snapshot.CurrentVersion, version)
+
+			got, gotVersion, err := snapshot.UnmarshalSnapshot(raw)
+			require.NoError(t, err)
+			require.Equal(t, snapshot.CurrentVersion, gotVersion)
+			assert.Empty(t, got)
+		})
+	}
+}
+
+// TestUnmarshalSnapshot_V0Legacy verifies that a hand-crafted JSON
+// array (the v0 storage shape from #144 cut 1) decodes as a v0
+// envelope. The returned version is 0; the resources are the raw
+// array contents in original order (no implicit sort).
+func TestUnmarshalSnapshot_V0Legacy(t *testing.T) {
+	t.Parallel()
+
+	legacy := []composerimported.ImportedResource{
+		{Identity: composerimported.ResourceIdentity{Address: "aws_sqs_queue.zeta"}},
+		{Identity: composerimported.ResourceIdentity{Address: "aws_s3_bucket.alpha"}},
+	}
+	raw, err := json.Marshal(legacy)
+	require.NoError(t, err)
+
+	got, version, err := snapshot.UnmarshalSnapshot(raw)
+	require.NoError(t, err)
+	assert.Equal(t, 0, version)
+	require.Len(t, got, 2)
+	// Order is preserved — v0 decode is a passthrough.
+	assert.Equal(t, "aws_sqs_queue.zeta", got[0].Identity.Address)
+	assert.Equal(t, "aws_s3_bucket.alpha", got[1].Identity.Address)
+}
+
+// TestUnmarshalSnapshot_UnsupportedVersion verifies that an envelope
+// claiming a version higher than CurrentVersion returns the sentinel
+// error. The version field is also returned so the caller can log it
+// without re-decoding the envelope.
+func TestUnmarshalSnapshot_UnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{"version":99,"resources":[]}`)
+	got, version, err := snapshot.UnmarshalSnapshot(raw)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, snapshot.ErrUnsupportedVersion),
+		"expected ErrUnsupportedVersion, got %v", err)
+	assert.Equal(t, 99, version)
+	assert.Nil(t, got)
+}
+
+// TestUnmarshalSnapshot_LeadingWhitespace verifies that the
+// array-vs-object sniff tolerates leading whitespace — encoding/json
+// accepts it, so UnmarshalSnapshot must too.
+func TestUnmarshalSnapshot_LeadingWhitespace(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte("  \n\t{\"version\":1,\"resources\":[]}")
+	got, version, err := snapshot.UnmarshalSnapshot(raw)
+	require.NoError(t, err)
+	assert.Equal(t, 1, version)
+	assert.Empty(t, got)
+}
+
+// TestUnmarshalSnapshot_Empty verifies that nil and zero-length inputs
+// return cleanly without error — useful for callers that may pass an
+// uninitialized stack_versions.imported column.
+func TestUnmarshalSnapshot_Empty(t *testing.T) {
+	t.Parallel()
+
+	got, version, err := snapshot.UnmarshalSnapshot(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, version)
+	assert.Nil(t, got)
+
+	got, version, err = snapshot.UnmarshalSnapshot([]byte{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, version)
+	assert.Nil(t, got)
+}
+
+// TestUnmarshalSnapshot_BadLeadingByte verifies that a payload that
+// is neither array nor object yields a parse error rather than panic.
+func TestUnmarshalSnapshot_BadLeadingByte(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := snapshot.UnmarshalSnapshot([]byte("garbage"))
+	require.Error(t, err)
+}

--- a/pkg/imported/snapshot/snapshot_test.go
+++ b/pkg/imported/snapshot/snapshot_test.go
@@ -15,30 +15,64 @@ import (
 // fixture returns a small, deterministic slice of ImportedResource
 // ordered NOT by Address — the round-trip / byte-stable tests rely on
 // MarshalSnapshot doing the sort itself.
+//
+// Every non-trivial field on Identity is populated on at least one
+// row so the round-trip test exercises the full struct shape, not
+// just Address. A regression that drops Attrs / NativeIDs /
+// ProviderConfig / Region from the envelope is caught loud.
 func fixture() []composerimported.ImportedResource {
 	return []composerimported.ImportedResource{
 		{
 			Identity: composerimported.ResourceIdentity{
-				Cloud:   "aws",
-				Type:    "aws_sqs_queue",
-				Address: "aws_sqs_queue.zeta",
+				Cloud:           "aws",
+				Type:            "aws_sqs_queue",
+				Address:         "aws_sqs_queue.zeta",
+				NameHint:        "zeta-queue",
+				ProviderConfig:  "aws",
+				ProviderSource:  "hashicorp/aws",
+				ProviderVersion: "6.0.0",
+				SchemaVersion:   "v1",
+				AccountID:       "123456789012",
+				Region:          "us-east-1",
+				ImportID:        "https://sqs.us-east-1.amazonaws.com/123456789012/zeta-queue",
+				NativeIDs: map[string]string{
+					"arn":  "arn:aws:sqs:us-east-1:123456789012:zeta-queue",
+					"name": "zeta-queue",
+					"url":  "https://sqs.us-east-1.amazonaws.com/123456789012/zeta-queue",
+				},
+				Tags: map[string]string{"Project": "demo", "Env": "dev"},
 			},
-			Tier: composerimported.TierImportedFlat,
+			Tier:       composerimported.TierImportedFlat,
+			Source:     composerimported.SourceImporter,
+			Attrs:      []byte(`{"name":"zeta-queue","fifo_queue":true,"delay_seconds":0}`),
+			Attributes: map[string]any{"name": "zeta-queue", "fifo_queue": true},
+			WeakLocked: true,
 		},
 		{
 			Identity: composerimported.ResourceIdentity{
-				Cloud:   "aws",
-				Type:    "aws_s3_bucket",
-				Address: "aws_s3_bucket.alpha",
+				Cloud:    "aws",
+				Type:     "aws_s3_bucket",
+				Address:  "aws_s3_bucket.alpha",
+				NameHint: "alpha-bucket",
+				ImportID: "alpha-bucket",
+				NativeIDs: map[string]string{
+					"arn":  "arn:aws:s3:::alpha-bucket",
+					"name": "alpha-bucket",
+				},
 			},
-			Tier: composerimported.TierImportedConformant,
+			Tier:   composerimported.TierImportedConformant,
+			Source: composerimported.SourceImporter,
+			Attrs:  []byte(`{"bucket":"alpha-bucket"}`),
 		},
 		{
 			Identity: composerimported.ResourceIdentity{
-				Cloud:   "gcp",
-				Type:    "google_storage_bucket",
-				Address: "google_storage_bucket.middle",
+				Cloud:     "gcp",
+				Type:      "google_storage_bucket",
+				Address:   "google_storage_bucket.middle",
+				ProjectID: "demo-project",
+				Location:  "US",
 			},
+			// Default zero Tier on this row — round-trip should preserve it.
 		},
 	}
 }
@@ -72,6 +106,67 @@ func TestMarshalSnapshot_RoundTrip(t *testing.T) {
 		"aws_sqs_queue.zeta",
 		"google_storage_bucket.middle",
 	}, sortedAddresses(got))
+
+	// Field-level round-trip pin: every populated Identity field and
+	// the per-resource Attrs / Tier / Source / WeakLocked must survive
+	// the round-trip. A regression that drops any field from the
+	// envelope fails here loud (instead of silently producing a
+	// snapshot that's missing data downstream).
+	expectedSorted := make([]composerimported.ImportedResource, len(irs))
+	copy(expectedSorted, irs)
+	sortByAddress(expectedSorted)
+	for i := range got {
+		assertImportedResourceEqual(t, expectedSorted[i], got[i])
+	}
+}
+
+// sortByAddress is the sort that MarshalSnapshot performs internally;
+// the test mirrors it so per-field comparisons line up.
+func sortByAddress(rs []composerimported.ImportedResource) {
+	sortStable(rs, func(a, b composerimported.ImportedResource) bool {
+		return a.Identity.Address < b.Identity.Address
+	})
+}
+
+// sortStable is a tiny generic stable sort so the test doesn't take a
+// dep on `sort` directly here.
+func sortStable[T any](s []T, less func(a, b T) bool) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && less(s[j], s[j-1]); j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}
+
+// assertImportedResourceEqual pins every Identity field plus
+// Attrs / Tier / Source / WeakLocked across the round-trip. Uses
+// field-by-field assertions so a failure points at the specific
+// dropped field, not a wall of struct diff output.
+func assertImportedResourceEqual(t *testing.T, want, got composerimported.ImportedResource) {
+	t.Helper()
+	assert.Equal(t, want.Identity.Cloud, got.Identity.Cloud, "Cloud")
+	assert.Equal(t, want.Identity.Type, got.Identity.Type, "Type")
+	assert.Equal(t, want.Identity.Address, got.Identity.Address, "Address")
+	assert.Equal(t, want.Identity.NameHint, got.Identity.NameHint, "NameHint")
+	assert.Equal(t, want.Identity.ProviderConfig, got.Identity.ProviderConfig, "ProviderConfig")
+	assert.Equal(t, want.Identity.ProviderSource, got.Identity.ProviderSource, "ProviderSource")
+	assert.Equal(t, want.Identity.ProviderVersion, got.Identity.ProviderVersion, "ProviderVersion")
+	assert.Equal(t, want.Identity.SchemaVersion, got.Identity.SchemaVersion, "SchemaVersion")
+	assert.Equal(t, want.Identity.AccountID, got.Identity.AccountID, "AccountID")
+	assert.Equal(t, want.Identity.ProjectID, got.Identity.ProjectID, "ProjectID")
+	assert.Equal(t, want.Identity.Region, got.Identity.Region, "Region")
+	assert.Equal(t, want.Identity.Location, got.Identity.Location, "Location")
+	assert.Equal(t, want.Identity.ImportID, got.Identity.ImportID, "ImportID")
+	assert.Equal(t, want.Identity.NativeIDs, got.Identity.NativeIDs, "NativeIDs")
+	assert.Equal(t, want.Identity.Tags, got.Identity.Tags, "Tags")
+	assert.Equal(t, want.Tier, got.Tier, "Tier")
+	assert.Equal(t, want.Source, got.Source, "Source")
+	assert.Equal(t, want.WeakLocked, got.WeakLocked, "WeakLocked")
+	// Attrs is json.RawMessage — assert byte-equality on the JSON
+	// payload to catch silent semantic changes (whitespace re-emits
+	// would also fail; that's intentional — the envelope is supposed
+	// to round-trip Attrs verbatim).
+	assert.Equal(t, string(want.Attrs), string(got.Attrs), "Attrs")
 }
 
 // TestMarshalSnapshot_ByteStable verifies that marshaling the same

--- a/pkg/imported/types.go
+++ b/pkg/imported/types.go
@@ -1,0 +1,132 @@
+// Package imported is the cloud-agnostic registry of imported-resource
+// concerns. It exposes the Provider interface every cloud implements,
+// plus the small set of value types (Capabilities, FieldMismatch,
+// Clients, DiscoverOpts) that ferry data across the boundary without
+// dragging cloud-specific dependencies into callers.
+//
+// Architecture: this package defines the contract; per-cloud
+// implementations live under pkg/imported/aws and pkg/imported/gcp.
+// The dependency direction is one-way — per-cloud packages import
+// pkg/imported, never the reverse — so the top-level package can be
+// pulled in by consumers (e.g. luthersystems/reliable's importer
+// wizard) without forcing them to install AWS or GCP SDKs they don't
+// need. The Clients struct uses untyped any fields rather than typed
+// cloud-specific pointers for the same reason; per-cloud Provider
+// impls type-assert to their concrete shape internally.
+//
+// See issue #482 for the full design and motivation: this Provider
+// surface replaces ~2,200 LOC of hand-rolled per-type dispatch in the
+// downstream reliable repo with a single registry-driven entry point.
+package imported
+
+import (
+	"encoding/json"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/bindings"
+)
+
+// Attrs is the JSON payload of a typed Layer-1 resource attribute set.
+// Matches the shape stored on pkg/composer/imported.ImportedResource.Attrs;
+// expressing it as a type alias rather than re-declaring the underlying
+// json.RawMessage keeps a single source of truth and avoids a no-op
+// conversion at the producer/consumer boundary.
+type Attrs = json.RawMessage
+
+// Capabilities reports the per-type feature surface a Provider
+// supports for a given Terraform resource type. The five flags are
+// independent so a consumer can degrade individual UI affordances
+// (e.g. hide the metrics tab) when a type is partially supported
+// without having to special-case the whole type.
+//
+//   - Discoverable: the cloud-side discoverer can enumerate
+//     resources of this type from an account/project scope.
+//   - Enrichable: a per-type AttributeEnricher populates the typed
+//     Layer-1 ir.Attrs payload for this type.
+//   - DriftDetectable: a per-type drift comparator exists for this
+//     type (the comparator package owns this; Capabilities just
+//     reports whether one is registered).
+//   - MetricsAvailable: a ComponentMetricsBinding is registered for
+//     this type in pkg/imported/bindings.
+//   - RileyEditable: at least one field policy for this type is
+//     editable through the Riley write path. False today for
+//     every type; populated once policy.FieldPolicy.Edit semantics
+//     are wired through.
+type Capabilities struct {
+	Discoverable     bool
+	Enrichable       bool
+	DriftDetectable  bool
+	MetricsAvailable bool
+	RileyEditable    bool
+}
+
+// ComponentMetricsBinding is the per-type CloudWatch / Cloud
+// Monitoring binding the metrics tab dispatches against. Re-exported
+// as a type alias from pkg/imported/bindings so callers depending on
+// pkg/imported see one canonical name without an extra import.
+type ComponentMetricsBinding = bindings.ComponentMetricsBinding
+
+// FieldMismatch describes a single drifted attribute returned by
+// Provider.CompareDrift. Snapshot is the value carried in the sealed
+// snapshot (what Terraform expects); Cloud is the value the live
+// cloud API reported. Field is the dot-and-bracket attribute path
+// (see pkg/composer/imported/policy.path grammar).
+//
+// The Snapshot / Cloud fields are typed `any` because the comparator
+// returns whatever shape the typed Attrs payload decoded into —
+// scalar values (string, bool, float64), maps, and slices all
+// surface here. Downstream consumers JSON-marshal the mismatch list
+// for SSE delivery to the UI; the typed `any` round-trips through
+// json.Marshal cleanly.
+type FieldMismatch struct {
+	Field    string
+	Snapshot any
+	Cloud    any
+}
+
+// Clients is a tagged union carrying cloud-specific SDK client
+// bundles. Per-cloud Provider impls type-assert the appropriate
+// field to their concrete EnrichClients-shaped struct (defined under
+// pkg/imported/aws and pkg/imported/gcp). The fields are typed `any`
+// rather than typed pointers to keep this package import-free of
+// cloud-specific dependencies — see the package doc.
+//
+// Exactly one of AWS / GCP should be populated per call; passing
+// both is undefined behavior. A nil field for the cloud being
+// dispatched to is surfaced by the per-cloud Provider as
+// ErrEnrichClientUnavailable (or its discover-time equivalent).
+type Clients struct {
+	AWS any
+	GCP any
+}
+
+// DiscoverOpts bundles the inputs the Provider.Discover call needs
+// beyond the live SDK clients. Each field is optional; per-cloud
+// Provider impls map these onto their existing DiscoverArgs shape.
+//
+//   - Project: stack project name used for server-side
+//     labels.project / tag filtering. Empty disables the filter.
+//   - Regions: AWS regions or GCP locations to scope the scan.
+//     Empty falls back to the per-cloud default (configured region
+//     for AWS; no location clause for GCP).
+//   - TagSelectors: operator-supplied AND-conjunction of
+//     key=value tag/label clauses. Empty disables tag filtering.
+//   - AccountID: AWS account ID (resolved out-of-band via STS).
+//     Ignored on GCP.
+//   - ProjectID: GCP project ID (the real project ID, not the
+//     stack project name). Ignored on AWS.
+type DiscoverOpts struct {
+	Project      string
+	Regions      []string
+	TagSelectors []TagSelector
+	AccountID    string
+	ProjectID    string
+}
+
+// TagSelector is a single operator-supplied tag/label equality
+// clause. Mirrors awsdiscover.TagSelector / gcpdiscover.TagSelector
+// — declared here at the cloud-agnostic boundary so callers can
+// construct DiscoverOpts without importing a cloud-specific package.
+type TagSelector struct {
+	Key   string
+	Value string
+}

--- a/pkg/imported/types.go
+++ b/pkg/imported/types.go
@@ -47,16 +47,21 @@ type Attrs = json.RawMessage
 //     reports whether one is registered).
 //   - MetricsAvailable: a ComponentMetricsBinding is registered for
 //     this type in pkg/imported/bindings.
-//   - RileyEditable: at least one field policy for this type is
-//     editable through the Riley write path. False today for
-//     every type; populated once policy.FieldPolicy.Edit semantics
-//     are wired through.
+//   - AgentEditable: at least one field policy for this type is
+//     editable through an interactive-agent write path
+//     (EditChatSafe or EditRequiresApproval — the two EditPolicy
+//     values an agent can author through normal chat / proposal
+//     flows). Agent-name-agnostic: the field reflects the policy
+//     surface, not which agent product is wired up downstream.
+//     The long-standing "Riley" naming on policy.VisibilityPolicy /
+//     EditPolicy constants is wire-format-pinned and rotates via a
+//     coordinated cross-repo rename, tracked separately.
 type Capabilities struct {
 	Discoverable     bool
 	Enrichable       bool
 	DriftDetectable  bool
 	MetricsAvailable bool
-	RileyEditable    bool
+	AgentEditable    bool
 }
 
 // ComponentMetricsBinding is the per-type CloudWatch / Cloud


### PR DESCRIPTION
## Summary

Consolidates the three previously-stacked phases of #482's registry-driven `imported.Provider` rollout into a single PR targeting `main`. Supersedes the now-redundant stacked PRs #485 (Phase 1) and #487 (Phase 2 Bundle 1).

The full delivery covers the upstream half of issue #482 — `luthersystems/reliable` can dispatch every per-type concern (discover, enrich, drift, policy, label, metric, capability, dependency closure, stable ID, canonical address) through a single `Provider` interface.

### Phase 1 — framework skeleton (commits 9fdf335 + cef2aed)
- `DriftSemantic` axis on `FieldPolicy` (None / Exact / WholeList / LabelFilter)
- `ByIDEnricher` optional sibling interface in awsdiscover + gcpdiscover (mirrors `io.WriterTo` next to `io.Reader`)
- `pkg/imported/labels` + `pkg/imported/bindings` registries (default rule + override map for labels; ComponentMetricsBinding registry)

### Phase 2 — Bundle 1 enrichers (commit 75bc022)
- `aws_cloudwatch_log_group` — `DescribeLogGroups` + `ListTagsForResource` overlay
- `aws_secretsmanager_secret` — single `DescribeSecret` call (tags + replicas inline)
- `google_compute_address` — `Addresses.Get(project, region, name)`
- `google_compute_firewall` — `Firewalls.Get(project, name)` with nested Allow/Deny flattening
- All 4 implement BOTH `AttributeEnricher` and `ByIDEnricher` behind a shared `fetchAndMap` helper

### Phase 3 — capstone framework
- `pkg/imported.Provider` interface (12 methods) + `Capabilities`, `FieldMismatch`, tagged-union `Clients`
- `pkg/imported/{aws,gcp}` per-cloud Provider impls — thin facades over the discoverers
- `pkg/drift/imported` generic comparator driven by `FieldPolicy.DriftSemantic`
- `pkg/imported/closure` — `DependencyClosure(picked, all)` transitive walker
- `pkg/imported/snapshot` — `MarshalSnapshot` / `UnmarshalSnapshot` (v0/v1 envelope)
- 4 new `cmd/imported-codegen` subcommands: `labels`, `capabilities`, `dependencies`, `drift-fields`
- `provider_export.go` accessors on `AWSDiscoverer` / `GCPDiscoverer` so the Provider can introspect their unexported `byTypeEnricher` map

### Late addition — `RileyEditable` → `AgentEditable`
Renamed the new `Capabilities` flag for agent-name-agnostic durability, and **wired the computation** (was always-false in the original capstone commit). A field is now `AgentEditable` when the curated policy has at least one entry with `Edit ∈ {EditChatSafe, EditRequiresApproval}`. The long-standing `Riley` naming in `policy.VisibilityPolicy` strings stays put (wire-format pinned to `luthersystems/reliable`) — cross-repo rename tracked in #489.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` → **5257 tests pass** across 35 packages (full suite)
- [x] `go test -race ./pkg/imported/... ./pkg/composer/imported/policy/...` → race-detector clean
- [x] `gofmt -l` clean across touched files
- [x] CI runs against `main` base on push

## Review notes

- **No deferred items in this PR** — every method on the Provider interface has a real implementation; `AgentEditable` now computes from policy.
- **Stacked-PR history preserved** — all 4 commits visible in `git log origin/main..HEAD`.
- `pkg/imported.Clients` is a tagged union via `any` fields (`AWS any`, `GCP any`) to avoid import cycles; per-cloud impls type-assert with `ErrClientsWrongCloud` on mismatch.
- `FieldMismatch` is a type alias from `pkg/drift/imported` so `Compare` output passes through `Provider.CompareDrift` with zero conversion.
- Static-introspection mode: `NewProvider(nil, comparer)` produces a Provider with the introspection methods working but live methods returning `ErrEnrichClientUnavailable`. This is what `ProviderFor(\"aws\"|\"gcp\")` returns.

## Eureka investigations

Sub-agent reports saved to `.tmp/` (not committed):

- `.tmp/terraformer-feasibility.md` — **Do not adopt.** Archived 2026-03-16; only does ID listing (attribute population is runtime gRPC to `terraform-provider-aws`). Coverage gap concentrated on growth-edge services.
- `.tmp/cloud-control-enricher-poc.md` (pending sub-agent completion) — Evaluating whether AWS Cloud Control's `GetResource` can unify ~94 AWS enrichers. **94 of 109 AWS types already routed through Cloud Control for discovery** — same machinery should work for enrichment. Tracked in #490.

## Deferred follow-ups (filed as issues)

- #489 — Cross-repo `Riley` → `Agent` rename in `policy.VisibilityRileyVisible` and downstream consumers
- #490 — Unified Cloud Control enricher (replaces ~94 hand-rolled enrichers if PoC confirms schema match)
- #491 — Curate `DriftSemantic` tags across the 42 existing policy files
- #492 — Regenerate `SUPPORTED_RESOURCES.md` with Capabilities matrix
- #493 — `aws_s3_bucket` enricher wire-up (close the stale #461 deferral)
- #494 — Extend `cmd/enrichgen` to emit paginator-list scaffolding

## Stacked-PR cleanup

- #485 (Phase 1 skeleton) — now redundant; closure requested in comment.
- #487 (Phase 2 Bundle 1) — now redundant; closure requested in comment.

Both have a closure-request comment pointing at this PR. The commits are preserved in this PR's git history — no work is lost on close.

Closes #482, closes #484, closes #486.