### PR TITLE
docs(imported): SUPPORTED_RESOURCES.md capabilities matrix

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -310,6 +310,19 @@ jobs:
           cache: true
       - run: make verify-gen
 
+  # Re-renders SUPPORTED_RESOURCES.md from the capabilities matrix and
+  # fails if the committed copy is stale (#492). Cheap pure-Go gate; no
+  # provider schemas or terraform required.
+  verify-supported-resources:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: make verify-supported-resources
+
   # Single aggregator status for branch protection to require. Lets the
   # matrix jobs above grow/shrink without updating the protection rule.
   ci-gate:
@@ -325,6 +338,7 @@ jobs:
       - go-vet
       - go-test
       - verify-gen
+      - verify-supported-resources
       - verify-phantom-schema
       - tflint
     if: always()

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,16 @@ verify-gen: gen-imported ## Fail if regenerating produces a diff (CI gate).
 	    exit 1; \
 	fi
 
+SUPPORTED_RESOURCES_MD := SUPPORTED_RESOURCES.md
+
+.PHONY: regen-supported-resources
+regen-supported-resources: ## Regenerate SUPPORTED_RESOURCES.md from the capabilities matrix.
+	$(GO) run ./cmd/imported-codegen supported-resources --output $(SUPPORTED_RESOURCES_MD)
+
+.PHONY: verify-supported-resources
+verify-supported-resources: ## Fail if SUPPORTED_RESOURCES.md is stale (CI gate, #492).
+	$(GO) run ./cmd/imported-codegen supported-resources --check --output $(SUPPORTED_RESOURCES_MD)
+
 .PHONY: test
 test: ## Run go test -race for the whole module.
 	$(GO) test -race ./...

--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -1,598 +1,211 @@
 # Supported Resources
 
-This document lists all cloud resources supported by InsideOut, with two
-orthogonal axes:
+Per-type Capabilities matrix for every cloud resource the InsideOut
+discovery + composition pipeline supports. Five orthogonal axes:
 
-- **Insideout-managed** — resource types declared in preset modules under
-  `aws/<module>/` or `gcp/<module>/`. These are the types InsideOut creates
-  on-apply when composing a stack.
-- **Importable** — resource types the discovery framework
-  (`cmd/insideout-import/<cloud>discover/` + `pkg/insideout-import/registry/`)
-  can detect, ingest, and re-render as Terraform.
+- **Discoverable** — the discovery registry can list resources of
+  this type from a live cloud account.
+- **Enrichable** — at least one `AttributeEnricher` is registered
+  in the per-cloud discoverer (fetches extended attributes beyond
+  the bare list call).
+- **DriftDetectable** — the curated `policy.Map` for this type has
+  at least one field with a non-empty `DriftSemantic` axis.
+- **MetricsAvailable** — the metrics bindings registry exposes a
+  default metric surface for this type.
+- **AgentEditable** — at least one field in the curated `policy.Map`
+  carries `EditChatSafe` or `EditRequiresApproval` — i.e. an agent
+  may write to it through the policy-gated edit path.
 
-A resource is **Both** when it's preset-declared and importable, **Preset-only**
-when InsideOut creates it but discovery doesn't yet see it, **Registry-only**
-when discovery sees it but no preset module declares it (typically because
-the type is produced by a wrapped registry module like
-`terraform-aws-modules/vpc/aws`).
+This document is generated from `cmd/imported-codegen capabilities`
+and is checked in lockstep with the runtime registries. See the
+`How to regenerate` section at the bottom for the regen command.
 
-Coverage summary (last updated 2026-05-14):
+## Summary
 
-| Cloud | Preset-declared | Importable | Both | Preset-only | Registry-only |
-|-------|----------------:|-----------:|-----:|------------:|--------------:|
-| AWS | 70 | 109 | 70 | 0 | 39 |
-| GCP | 47 | 54 | 47 | 0 | 7 |
+- **AWS:** 109 types · 100% Discoverable · 3% Enrichable · 0% DriftDetectable · 0% MetricsAvailable · 6% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 13% Enrichable · 0% DriftDetectable · 0% MetricsAvailable · 65% AgentEditable
 
 ## AWS
 
-Every directly-declared AWS resource type is also importable via the
-discovery registry — there are no preset-only gaps. The Registry-only
-subsection captures the types emitted by wrapped community modules
-(`terraform-aws-modules/vpc/aws` and `terraform-aws-modules/eks/aws`),
-plus auxiliary types the discovery pipeline can ingest even though no
-preset creates them directly.
-
-### `aws/alb`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudwatch_metric_alarm` | Both |
-| `aws_lb` | Both |
-| `aws_lb_listener` | Both |
-| `aws_lb_target_group` | Both |
-| `aws_s3_bucket` | Both |
-| `aws_s3_bucket_lifecycle_configuration` | Both |
-| `aws_s3_bucket_policy` | Both |
-| `aws_s3_bucket_public_access_block` | Both |
-| `aws_security_group` | Both |
-
-### `aws/apigateway`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_apigatewayv2_api` | Both |
-| `aws_apigatewayv2_api_mapping` | Both |
-| `aws_apigatewayv2_domain_name` | Both |
-| `aws_apigatewayv2_stage` | Both |
-| `aws_cloudwatch_metric_alarm` | Both |
-
-### `aws/backups`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_backup_plan` | Both |
-| `aws_backup_selection` | Both |
-| `aws_backup_vault` | Both |
-| `aws_iam_role` | Both |
-| `aws_iam_role_policy_attachment` | Both |
-
-### `aws/bastion`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudwatch_metric_alarm` | Both |
-| `aws_iam_instance_profile` | Both |
-| `aws_iam_role` | Both |
-| `aws_iam_role_policy_attachment` | Both |
-| `aws_instance` | Both |
-| `aws_security_group` | Both |
-
-### `aws/bedrock`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_bedrock_guardrail` | Both |
-| `aws_bedrock_model_invocation_logging_configuration` | Both |
-| `aws_cloudwatch_log_group` | Both |
-| `aws_iam_role` | Both |
-| `aws_iam_role_policy` | Both |
-| `aws_opensearchserverless_access_policy` | Both |
-
-### `aws/cloudfront`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudfront_distribution` | Both |
-| `aws_cloudfront_monitoring_subscription` | Both |
-| `aws_cloudfront_origin_access_identity` | Both |
-| `aws_s3_bucket` | Both |
-| `aws_s3_bucket_policy` | Both |
-| `aws_s3_bucket_public_access_block` | Both |
-
-### `aws/cloudwatchlogs`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudwatch_log_group` | Both |
-| `aws_cloudwatch_log_stream` | Both |
-| `aws_iam_policy` | Both |
-| `aws_iam_role` | Both |
-| `aws_iam_role_policy_attachment` | Both |
-
-### `aws/cloudwatchmonitoring`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudwatch_dashboard` | Both |
-| `aws_cloudwatch_metric_alarm` | Both |
-| `aws_sns_topic` | Both |
-| `aws_sns_topic_subscription` | Both |
-
-### `aws/codepipeline`
-
-Placeholder — CodePipeline CI/CD; no resources declared yet.
-
-### `aws/cognito`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cognito_identity_provider` | Both |
-| `aws_cognito_user_pool` | Both |
-| `aws_cognito_user_pool_client` | Both |
-| `aws_cognito_user_pool_domain` | Both |
-
-### `aws/composer`
-
-Placeholder — stack composer/scaffolding helper; no resources declared.
-
-### `aws/datadog`
-
-Placeholder — Datadog observability integration; no resources declared yet.
-
-### `aws/dynamodb`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudwatch_metric_alarm` | Both |
-| `aws_dynamodb_contributor_insights` | Both |
-| `aws_dynamodb_table` | Both |
-
-### `aws/ec2`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudwatch_metric_alarm` | Both |
-| `aws_iam_instance_profile` | Both |
-| `aws_iam_role` | Both |
-| `aws_iam_role_policy_attachment` | Both |
-| `aws_instance` | Both |
-| `aws_key_pair` | Both |
-| `aws_security_group` | Both |
-| `aws_vpc_security_group_ingress_rule` | Both |
-
-### `aws/ecs`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudwatch_metric_alarm` | Both |
-| `aws_ecs_cluster` | Both |
-| `aws_ecs_cluster_capacity_providers` | Both |
-| `aws_service_discovery_private_dns_namespace` | Both |
-
-### `aws/eks_nodegroup`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_autoscaling_group_tag` | Both |
-| `aws_cloudwatch_metric_alarm` | Both |
-| `aws_eks_addon` | Both |
-| `aws_eks_node_group` | Both |
-| `aws_iam_role` | Both |
-| `aws_iam_role_policy_attachment` | Both |
-| `aws_iam_service_linked_role` | Both |
-
-### `aws/elasticache`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudwatch_log_group` | Both |
-| `aws_cloudwatch_metric_alarm` | Both |
-| `aws_elasticache_parameter_group` | Both |
-| `aws_elasticache_replication_group` | Both |
-| `aws_elasticache_subnet_group` | Both |
-| `aws_security_group` | Both |
-
-### `aws/githubactions`
-
-Placeholder — GitHub Actions OIDC; no resources declared yet.
-
-### `aws/grafana`
-
-Placeholder — Amazon Managed Grafana; no resources declared yet.
-
-### `aws/inspector`
-
-Placeholder — AWS Inspector; no `*.tf` files yet.
-
-### `aws/kms`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_kms_alias` | Both |
-| `aws_kms_key` | Both |
-
-### `aws/lambda`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudwatch_log_group` | Both |
-| `aws_cloudwatch_metric_alarm` | Both |
-| `aws_iam_role` | Both |
-| `aws_iam_role_policy_attachment` | Both |
-| `aws_lambda_function` | Both |
-| `aws_security_group` | Both |
-
-### `aws/msk`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudwatch_log_group` | Both |
-| `aws_cloudwatch_metric_alarm` | Both |
-| `aws_iam_service_linked_role` | Both |
-| `aws_msk_cluster` | Both |
-| `aws_msk_configuration` | Both |
-| `aws_security_group` | Both |
-
-### `aws/opensearch`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudwatch_log_group` | Both |
-| `aws_cloudwatch_log_resource_policy` | Both |
-| `aws_cloudwatch_metric_alarm` | Both |
-| `aws_iam_service_linked_role` | Both |
-| `aws_opensearch_domain` | Both |
-| `aws_opensearchserverless_collection` | Both |
-| `aws_opensearchserverless_security_policy` | Both |
-| `aws_security_group` | Both |
-
-### `aws/rds`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudwatch_metric_alarm` | Both |
-| `aws_db_instance` | Both |
-| `aws_db_subnet_group` | Both |
-| `aws_iam_role` | Both |
-| `aws_iam_role_policy_attachment` | Both |
-| `aws_security_group` | Both |
-
-### `aws/resource`
-
-Wraps registry module: `terraform-aws-modules/eks/aws` ~> 21.0 (EKS cluster control plane)
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_iam_role` | Both |
-| `aws_iam_role_policy_attachment` | Both |
-
-### `aws/s3`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_s3_bucket` | Both |
-| `aws_s3_bucket_lifecycle_configuration` | Both |
-| `aws_s3_bucket_ownership_controls` | Both |
-| `aws_s3_bucket_public_access_block` | Both |
-| `aws_s3_bucket_server_side_encryption_configuration` | Both |
-| `aws_s3_bucket_versioning` | Both |
-
-### `aws/secretsmanager`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_secretsmanager_secret` | Both |
-
-### `aws/splunk`
-
-Placeholder — Splunk log forwarding; no resources declared yet.
-
-### `aws/sqs`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_cloudwatch_metric_alarm` | Both |
-| `aws_sqs_queue` | Both |
-
-### `aws/vpc`
-
-Wraps registry module: `terraform-aws-modules/vpc/aws` ~> 6.0
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_vpc_endpoint` | Both |
-
-### `aws/waf`
-
-| TF type | Coverage |
-|---------|----------|
-| `aws_wafv2_web_acl` | Both |
-| `aws_wafv2_web_acl_association` | Both |
-
-### Registry-only AWS types
-
-Importable types that no preset module declares directly. Most are
-emitted by wrapped community modules (VPC primitives from
-`terraform-aws-modules/vpc/aws`, EKS control-plane resources from
-`terraform-aws-modules/eks/aws`), or are auxiliary discovery surfaces
-(account-scoped singletons, classic API Gateway, route53, etc.).
-
-| TF type | Origin (typical) |
-|---------|------------------|
-| `aws_acm_certificate` | ACM (discovery-only) |
-| `aws_api_gateway_deployment` | REST API Gateway v1 (discovery-only) |
-| `aws_api_gateway_resource` | REST API Gateway v1 (discovery-only) |
-| `aws_api_gateway_stage` | REST API Gateway v1 (discovery-only) |
-| `aws_apigatewayv2_authorizer` | HTTP/WebSocket API authorizer (discovery-only) |
-| `aws_apigatewayv2_integration` | HTTP/WebSocket API integration (discovery-only) |
-| `aws_apigatewayv2_route` | HTTP/WebSocket API route (discovery-only) |
-| `aws_autoscaling_group` | EKS node group ASG (via terraform-aws-modules/eks) |
-| `aws_cloudfront_function` | CloudFront edge function (discovery-only) |
-| `aws_cloudwatch_event_rule` | EventBridge rule (discovery-only) |
-| `aws_cognito_resource_server` | Cognito OAuth resource server (discovery-only) |
-| `aws_db_parameter_group` | RDS parameter group (discovery-only) |
-| `aws_ebs_volume` | EC2/EKS-attached EBS volumes (discovery-only) |
-| `aws_eip` | Elastic IP — emitted by VPC NAT gateway |
-| `aws_eks_access_entry` | EKS access entry (via terraform-aws-modules/eks) |
-| `aws_eks_cluster` | EKS control plane (via terraform-aws-modules/eks) |
-| `aws_eks_fargate_profile` | EKS Fargate profile (via terraform-aws-modules/eks) |
-| `aws_eks_pod_identity_association` | EKS pod identity (via terraform-aws-modules/eks) |
-| `aws_iam_group` | IAM group (discovery-only) |
-| `aws_iam_user` | IAM user (discovery-only) |
-| `aws_internet_gateway` | VPC IGW (via terraform-aws-modules/vpc) |
-| `aws_lambda_alias` | Lambda alias (discovery-only) |
-| `aws_lambda_event_source_mapping` | Lambda event source mapping (discovery-only) |
-| `aws_lambda_function_url` | Lambda function URL (discovery-only) |
-| `aws_lambda_permission` | Lambda permission (discovery-only) |
-| `aws_launch_template` | EKS managed node group launch template |
-| `aws_nat_gateway` | VPC NAT gateway (via terraform-aws-modules/vpc) |
-| `aws_network_acl` | VPC NACL (via terraform-aws-modules/vpc) |
-| `aws_network_interface` | ENI (discovery-only) |
-| `aws_resourceexplorer2_index` | Resource Explorer index (discovery-only) |
-| `aws_resourceexplorer2_view` | Resource Explorer view (discovery-only) |
-| `aws_route53_zone` | Route53 hosted zone (discovery-only) |
-| `aws_route_table` | VPC route table (via terraform-aws-modules/vpc) |
-| `aws_secretsmanager_secret_rotation` | Secrets Manager rotation (discovery-only) |
-| `aws_ssm_parameter` | SSM parameter (discovery-only) |
-| `aws_subnet` | VPC subnet (via terraform-aws-modules/vpc) |
-| `aws_vpc` | VPC (via terraform-aws-modules/vpc) |
-| `aws_vpc_dhcp_options` | VPC DHCP options (via terraform-aws-modules/vpc) |
-| `aws_vpc_security_group_egress_rule` | SG egress rule (via various wrappers, discovery) |
-
-### Preset-only AWS types
-
-None — every preset-declared AWS resource type is also registered in
-the discovery registry.
+| TF Type | Discoverable | Enrichable | DriftDetectable | MetricsAvailable | AgentEditable |
+|---|---|---|---|---|---|
+| `aws_acm_certificate` | ✓ | – | – | – | – |
+| `aws_api_gateway_deployment` | ✓ | – | – | – | – |
+| `aws_api_gateway_resource` | ✓ | – | – | – | – |
+| `aws_api_gateway_stage` | ✓ | – | – | – | – |
+| `aws_apigatewayv2_api` | ✓ | – | – | – | – |
+| `aws_apigatewayv2_api_mapping` | ✓ | – | – | – | – |
+| `aws_apigatewayv2_authorizer` | ✓ | – | – | – | – |
+| `aws_apigatewayv2_domain_name` | ✓ | – | – | – | – |
+| `aws_apigatewayv2_integration` | ✓ | – | – | – | – |
+| `aws_apigatewayv2_route` | ✓ | – | – | – | – |
+| `aws_apigatewayv2_stage` | ✓ | – | – | – | – |
+| `aws_autoscaling_group` | ✓ | – | – | – | – |
+| `aws_autoscaling_group_tag` | ✓ | – | – | – | – |
+| `aws_backup_plan` | ✓ | – | – | – | – |
+| `aws_backup_selection` | ✓ | – | – | – | – |
+| `aws_backup_vault` | ✓ | – | – | – | – |
+| `aws_bedrock_guardrail` | ✓ | – | – | – | – |
+| `aws_bedrock_model_invocation_logging_configuration` | ✓ | – | – | – | – |
+| `aws_cloudfront_distribution` | ✓ | – | – | – | – |
+| `aws_cloudfront_function` | ✓ | – | – | – | – |
+| `aws_cloudfront_monitoring_subscription` | ✓ | – | – | – | – |
+| `aws_cloudfront_origin_access_identity` | ✓ | – | – | – | – |
+| `aws_cloudwatch_dashboard` | ✓ | – | – | – | – |
+| `aws_cloudwatch_event_rule` | ✓ | – | – | – | – |
+| `aws_cloudwatch_log_group` | ✓ | ✓ | – | – | ✓ |
+| `aws_cloudwatch_log_resource_policy` | ✓ | – | – | – | – |
+| `aws_cloudwatch_log_stream` | ✓ | – | – | – | – |
+| `aws_cloudwatch_metric_alarm` | ✓ | – | – | – | – |
+| `aws_cognito_identity_provider` | ✓ | – | – | – | – |
+| `aws_cognito_resource_server` | ✓ | – | – | – | – |
+| `aws_cognito_user_pool` | ✓ | – | – | – | – |
+| `aws_cognito_user_pool_client` | ✓ | – | – | – | – |
+| `aws_cognito_user_pool_domain` | ✓ | – | – | – | – |
+| `aws_db_instance` | ✓ | – | – | – | – |
+| `aws_db_parameter_group` | ✓ | – | – | – | – |
+| `aws_db_subnet_group` | ✓ | – | – | – | – |
+| `aws_dynamodb_contributor_insights` | ✓ | – | – | – | – |
+| `aws_dynamodb_table` | ✓ | ✓ | – | – | ✓ |
+| `aws_ebs_volume` | ✓ | – | – | – | – |
+| `aws_ecs_cluster` | ✓ | – | – | – | – |
+| `aws_ecs_cluster_capacity_providers` | ✓ | – | – | – | – |
+| `aws_eip` | ✓ | – | – | – | – |
+| `aws_eks_access_entry` | ✓ | – | – | – | – |
+| `aws_eks_addon` | ✓ | – | – | – | – |
+| `aws_eks_cluster` | ✓ | – | – | – | – |
+| `aws_eks_fargate_profile` | ✓ | – | – | – | – |
+| `aws_eks_node_group` | ✓ | – | – | – | – |
+| `aws_eks_pod_identity_association` | ✓ | – | – | – | – |
+| `aws_elasticache_parameter_group` | ✓ | – | – | – | – |
+| `aws_elasticache_replication_group` | ✓ | – | – | – | – |
+| `aws_elasticache_subnet_group` | ✓ | – | – | – | – |
+| `aws_iam_group` | ✓ | – | – | – | – |
+| `aws_iam_instance_profile` | ✓ | – | – | – | – |
+| `aws_iam_policy` | ✓ | – | – | – | – |
+| `aws_iam_role` | ✓ | – | – | – | – |
+| `aws_iam_role_policy` | ✓ | – | – | – | – |
+| `aws_iam_role_policy_attachment` | ✓ | – | – | – | – |
+| `aws_iam_service_linked_role` | ✓ | – | – | – | – |
+| `aws_iam_user` | ✓ | – | – | – | – |
+| `aws_instance` | ✓ | – | – | – | – |
+| `aws_internet_gateway` | ✓ | – | – | – | – |
+| `aws_key_pair` | ✓ | – | – | – | – |
+| `aws_kms_alias` | ✓ | – | – | – | – |
+| `aws_kms_key` | ✓ | – | – | – | – |
+| `aws_lambda_alias` | ✓ | – | – | – | – |
+| `aws_lambda_event_source_mapping` | ✓ | – | – | – | – |
+| `aws_lambda_function` | ✓ | – | – | – | ✓ |
+| `aws_lambda_function_url` | ✓ | – | – | – | – |
+| `aws_lambda_permission` | ✓ | – | – | – | – |
+| `aws_launch_template` | ✓ | – | – | – | – |
+| `aws_lb` | ✓ | – | – | – | – |
+| `aws_lb_listener` | ✓ | – | – | – | – |
+| `aws_lb_target_group` | ✓ | – | – | – | – |
+| `aws_msk_cluster` | ✓ | – | – | – | – |
+| `aws_msk_configuration` | ✓ | – | – | – | – |
+| `aws_nat_gateway` | ✓ | – | – | – | – |
+| `aws_network_acl` | ✓ | – | – | – | – |
+| `aws_network_interface` | ✓ | – | – | – | – |
+| `aws_opensearch_domain` | ✓ | – | – | – | – |
+| `aws_opensearchserverless_access_policy` | ✓ | – | – | – | – |
+| `aws_opensearchserverless_collection` | ✓ | – | – | – | – |
+| `aws_opensearchserverless_security_policy` | ✓ | – | – | – | – |
+| `aws_resourceexplorer2_index` | ✓ | – | – | – | – |
+| `aws_resourceexplorer2_view` | ✓ | – | – | – | – |
+| `aws_route53_zone` | ✓ | – | – | – | – |
+| `aws_route_table` | ✓ | – | – | – | – |
+| `aws_s3_bucket` | ✓ | – | – | – | ✓ |
+| `aws_s3_bucket_lifecycle_configuration` | ✓ | – | – | – | – |
+| `aws_s3_bucket_ownership_controls` | ✓ | – | – | – | – |
+| `aws_s3_bucket_policy` | ✓ | – | – | – | – |
+| `aws_s3_bucket_public_access_block` | ✓ | – | – | – | – |
+| `aws_s3_bucket_server_side_encryption_configuration` | ✓ | – | – | – | – |
+| `aws_s3_bucket_versioning` | ✓ | – | – | – | – |
+| `aws_secretsmanager_secret` | ✓ | ✓ | – | – | ✓ |
+| `aws_secretsmanager_secret_rotation` | ✓ | – | – | – | – |
+| `aws_security_group` | ✓ | – | – | – | – |
+| `aws_service_discovery_private_dns_namespace` | ✓ | – | – | – | – |
+| `aws_sns_topic` | ✓ | – | – | – | – |
+| `aws_sns_topic_subscription` | ✓ | – | – | – | – |
+| `aws_sqs_queue` | ✓ | – | – | – | ✓ |
+| `aws_ssm_parameter` | ✓ | – | – | – | – |
+| `aws_subnet` | ✓ | – | – | – | – |
+| `aws_vpc` | ✓ | – | – | – | – |
+| `aws_vpc_dhcp_options` | ✓ | – | – | – | – |
+| `aws_vpc_endpoint` | ✓ | – | – | – | – |
+| `aws_vpc_security_group_egress_rule` | ✓ | – | – | – | – |
+| `aws_vpc_security_group_ingress_rule` | ✓ | – | – | – | – |
+| `aws_wafv2_web_acl` | ✓ | – | – | – | – |
+| `aws_wafv2_web_acl_association` | ✓ | – | – | – | – |
 
 ## GCP
 
-After Bundle G4 the GCP catalog reached full parity — every preset-
-declared GCP resource type is also importable via the discovery
-registry. The Registry-only subsection captures types emitted by the
-wrapped community modules (`terraform-google-modules/network/google`,
-`terraform-google-modules/kubernetes-engine/google`, and
-`GoogleCloudPlatform/sql-db/google`).
-
-### `gcp/api_gateway`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_api_gateway_api` | Both |
-| `google_api_gateway_api_config` | Both |
-| `google_api_gateway_gateway` | Both |
-| `google_monitoring_alert_policy` | Both |
-| `google_project_service` | Both |
-
-### `gcp/backups`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_compute_resource_policy` | Both |
-| `google_storage_bucket` | Both |
-
-### `gcp/bastion`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_compute_firewall` | Both |
-| `google_compute_instance` | Both |
-| `google_monitoring_alert_policy` | Both |
-| `google_project_iam_member` | Both |
-| `google_service_account` | Both |
-
-### `gcp/cloud_armor`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_compute_security_policy` | Both |
-
-### `gcp/cloud_build`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_cloudbuild_trigger` | Both |
-| `google_project_iam_member` | Both |
-| `google_project_service` | Both |
-| `google_secret_manager_secret` | Both |
-| `google_secret_manager_secret_iam_member` | Both |
-| `google_secret_manager_secret_version` | Both |
-| `google_service_account` | Both |
-
-### `gcp/cloud_functions`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_cloudfunctions2_function` | Both |
-| `google_cloudfunctions2_function_iam_member` | Both |
-| `google_monitoring_alert_policy` | Both |
-| `google_storage_bucket` | Both |
-| `google_storage_bucket_object` | Both |
-
-### `gcp/cloud_logging`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_logging_project_sink` | Both |
-| `google_storage_bucket` | Both |
-| `google_storage_bucket_iam_member` | Both |
-
-### `gcp/cloud_monitoring`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_monitoring_dashboard` | Both |
-| `google_monitoring_notification_channel` | Both |
-
-### `gcp/cloud_run`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_cloud_run_v2_service` | Both |
-| `google_cloud_run_v2_service_iam_member` | Both |
-| `google_monitoring_alert_policy` | Both |
-
-### `gcp/cloudsql`
-
-Wraps registry module: `GoogleCloudPlatform/sql-db/google//modules/{postgresql,mysql}` ~> 21.0
-
-| TF type | Coverage |
-|---------|----------|
-| `google_compute_global_address` | Both |
-| `google_monitoring_alert_policy` | Both |
-| `google_service_networking_connection` | Both |
-
-### `gcp/compute`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_compute_instance` | Both |
-| `google_monitoring_alert_policy` | Both |
-
-### `gcp/firestore`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_firestore_database` | Both |
-| `google_monitoring_alert_policy` | Both |
-
-### `gcp/gcs`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_storage_bucket` | Both |
-
-### `gcp/gke`
-
-Wraps registry module: `terraform-google-modules/kubernetes-engine/google//modules/private-cluster` ~> 33.0
-
-| TF type | Coverage |
-|---------|----------|
-| `google_monitoring_alert_policy` | Both |
-
-### `gcp/identity_platform`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_identity_platform_config` | Both |
-| `google_identity_platform_default_supported_idp_config` | Both |
-| `google_project_service` | Both |
-
-### `gcp/kms`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_kms_crypto_key` | Both |
-| `google_kms_crypto_key_iam_binding` | Both |
-| `google_kms_key_ring` | Both |
-
-### `gcp/loadbalancer`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_compute_backend_service` | Both |
-| `google_compute_global_address` | Both |
-| `google_compute_global_forwarding_rule` | Both |
-| `google_compute_health_check` | Both |
-| `google_compute_managed_ssl_certificate` | Both |
-| `google_compute_target_http_proxy` | Both |
-| `google_compute_target_https_proxy` | Both |
-| `google_compute_url_map` | Both |
-| `google_monitoring_alert_policy` | Both |
-
-### `gcp/memorystore`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_monitoring_alert_policy` | Both |
-| `google_redis_instance` | Both |
-
-### `gcp/pubsub`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_monitoring_alert_policy` | Both |
-| `google_pubsub_subscription` | Both |
-| `google_pubsub_topic` | Both |
-
-### `gcp/secretmanager`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_secret_manager_secret` | Both |
-| `google_secret_manager_secret_iam_binding` | Both |
-| `google_secret_manager_secret_version` | Both |
-
-### `gcp/vertex_ai`
-
-| TF type | Coverage |
-|---------|----------|
-| `google_vertex_ai_dataset` | Both |
-
-### `gcp/vpc`
-
-Wraps registry module: `terraform-google-modules/network/google` ~> 9.0 + `terraform-google-modules/cloud-nat/google` ~> 5.0
-
-| TF type | Coverage |
-|---------|----------|
-| `google_compute_firewall` | Both |
-| `google_compute_router` | Both |
-| `google_vpc_access_connector` | Both |
-
-### Registry-only GCP types
-
-Importable types that no preset module declares directly. All seven
-are emitted by the wrapped community modules listed above.
-
-| TF type | Origin (typical) |
-|---------|------------------|
-| `google_compute_address` | VPC regional address (via terraform-google-modules/cloud-nat) |
-| `google_compute_forwarding_rule` | regional forwarding rule (discovery-only) |
-| `google_compute_network` | VPC network (via terraform-google-modules/network) |
-| `google_container_cluster` | GKE cluster (via terraform-google-modules/kubernetes-engine) |
-| `google_container_node_pool` | GKE node pool (via terraform-google-modules/kubernetes-engine) |
-| `google_sql_database_instance` | Cloud SQL instance (via GoogleCloudPlatform/sql-db) |
-| `google_sql_user` | Cloud SQL user (via GoogleCloudPlatform/sql-db) |
-
-### Preset-only GCP types
-
-None — Bundle G4 closed the last gaps. Every preset-declared GCP
-resource type is registered in the discovery registry.
+| TF Type | Discoverable | Enrichable | DriftDetectable | MetricsAvailable | AgentEditable |
+|---|---|---|---|---|---|
+| `google_api_gateway_api` | ✓ | – | – | – | ✓ |
+| `google_api_gateway_api_config` | ✓ | – | – | – | ✓ |
+| `google_api_gateway_gateway` | ✓ | – | – | – | ✓ |
+| `google_cloud_run_v2_service` | ✓ | – | – | – | ✓ |
+| `google_cloud_run_v2_service_iam_member` | ✓ | – | – | – | – |
+| `google_cloudbuild_trigger` | ✓ | – | – | – | ✓ |
+| `google_cloudfunctions2_function` | ✓ | – | – | – | ✓ |
+| `google_cloudfunctions2_function_iam_member` | ✓ | – | – | – | – |
+| `google_compute_address` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_backend_service` | ✓ | – | – | – | – |
+| `google_compute_firewall` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_forwarding_rule` | ✓ | – | – | – | ✓ |
+| `google_compute_global_address` | ✓ | – | – | – | ✓ |
+| `google_compute_global_forwarding_rule` | ✓ | – | – | – | ✓ |
+| `google_compute_health_check` | ✓ | – | – | – | – |
+| `google_compute_instance` | ✓ | – | – | – | ✓ |
+| `google_compute_managed_ssl_certificate` | ✓ | – | – | – | – |
+| `google_compute_network` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_resource_policy` | ✓ | – | – | – | – |
+| `google_compute_router` | ✓ | – | – | – | ✓ |
+| `google_compute_security_policy` | ✓ | – | – | – | ✓ |
+| `google_compute_target_http_proxy` | ✓ | – | – | – | – |
+| `google_compute_target_https_proxy` | ✓ | – | – | – | ✓ |
+| `google_compute_url_map` | ✓ | – | – | – | ✓ |
+| `google_container_cluster` | ✓ | – | – | – | ✓ |
+| `google_container_node_pool` | ✓ | – | – | – | ✓ |
+| `google_firestore_database` | ✓ | – | – | – | ✓ |
+| `google_identity_platform_config` | ✓ | – | – | – | ✓ |
+| `google_identity_platform_default_supported_idp_config` | ✓ | – | – | – | – |
+| `google_kms_crypto_key` | ✓ | – | – | – | ✓ |
+| `google_kms_crypto_key_iam_binding` | ✓ | – | – | – | – |
+| `google_kms_key_ring` | ✓ | – | – | – | – |
+| `google_logging_project_sink` | ✓ | – | – | – | ✓ |
+| `google_monitoring_alert_policy` | ✓ | – | – | – | ✓ |
+| `google_monitoring_dashboard` | ✓ | – | – | – | ✓ |
+| `google_monitoring_notification_channel` | ✓ | – | – | – | ✓ |
+| `google_project_iam_member` | ✓ | – | – | – | – |
+| `google_project_service` | ✓ | – | – | – | – |
+| `google_pubsub_subscription` | ✓ | ✓ | – | – | ✓ |
+| `google_pubsub_topic` | ✓ | ✓ | – | – | ✓ |
+| `google_redis_instance` | ✓ | – | – | – | ✓ |
+| `google_secret_manager_secret` | ✓ | ✓ | – | – | ✓ |
+| `google_secret_manager_secret_iam_binding` | ✓ | – | – | – | – |
+| `google_secret_manager_secret_iam_member` | ✓ | – | – | – | – |
+| `google_secret_manager_secret_version` | ✓ | – | – | – | – |
+| `google_service_account` | ✓ | – | – | – | ✓ |
+| `google_service_networking_connection` | ✓ | – | – | – | – |
+| `google_sql_database_instance` | ✓ | – | – | – | ✓ |
+| `google_sql_user` | ✓ | – | – | – | ✓ |
+| `google_storage_bucket` | ✓ | ✓ | – | – | ✓ |
+| `google_storage_bucket_iam_member` | ✓ | – | – | – | – |
+| `google_storage_bucket_object` | ✓ | – | – | – | – |
+| `google_vertex_ai_dataset` | ✓ | – | – | – | ✓ |
+| `google_vpc_access_connector` | ✓ | – | – | – | – |
 
 ## How to regenerate
 
-This doc is updated by hand after each bundle that adds discoverers or
-presets. The accurate source-of-truth is:
-
-- Importable: `pkg/insideout-import/registry/registry.go::{awsTypes,gcpTypes}`
-- Preset-declared: grep `^resource "` across `aws/**/*.tf` and `gcp/**/*.tf`
-  (excluding `_shared/` and `_*/` dirs, and excluding `random_*` / `time_*`
-  provider helper resources that are not part of AWS/GCP coverage).
-
-To check parity in CI, run:
-
 ```bash
-go test ./pkg/insideout-import/registry/...
+make regen-supported-resources
+# or, directly:
+go run ./cmd/imported-codegen supported-resources --output SUPPORTED_RESOURCES.md
 ```
 
-The registry's go test pins the lists; preset-declared types are validated by
-the per-module `terraform validate` jobs.
+CI runs `make verify-supported-resources`, which re-renders the
+document and fails the build if the committed copy is out of
+date.

--- a/cmd/imported-codegen/emit_resources_doc.go
+++ b/cmd/imported-codegen/emit_resources_doc.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// runSupportedResources is the `supported-resources` subcommand: render
+// SUPPORTED_RESOURCES.md from the capabilities matrix. The Markdown is a
+// pure projection of buildCapabilitiesMap() — the same data the
+// `capabilities` subcommand emits as JSON — so the two outputs stay
+// in lockstep by construction. (presets#492)
+//
+// Flags:
+//
+//	--output <path>   Path to read/write. Required.
+//	--check           Read the file at --output, regenerate to memory,
+//	                  exit non-zero with a diff hint if they differ. Used
+//	                  by CI to gate against stale committed copies.
+func runSupportedResources(args []string) int {
+	fs := flag.NewFlagSet("supported-resources", flag.ExitOnError)
+	out := fs.String("output", "", "path to write/read the Markdown file (required)")
+	check := fs.Bool("check", false, "read --output, regenerate to memory, exit non-zero if they differ")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if strings.TrimSpace(*out) == "" {
+		fmt.Fprintln(os.Stderr, "supported-resources: --output is required")
+		return 2
+	}
+
+	rendered := renderSupportedResources(buildCapabilitiesMap())
+
+	if *check {
+		existing, err := os.ReadFile(*out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "supported-resources: read %s: %v\n", *out, err)
+			return 1
+		}
+		if string(existing) != rendered {
+			fmt.Fprintf(os.Stderr, "supported-resources: %s is out of date.\n", *out)
+			fmt.Fprintln(os.Stderr, "Run: go run ./cmd/imported-codegen supported-resources --output "+*out)
+			return 1
+		}
+		return 0
+	}
+
+	if err := os.WriteFile(*out, []byte(rendered), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "supported-resources: write %s: %v\n", *out, err)
+		return 1
+	}
+	return 0
+}
+
+// renderSupportedResources renders the capabilities matrix as a
+// Markdown document. The output is deterministic — keys are sorted
+// within each cloud section and AWS appears before GCP. Exposed for
+// unit tests so they can assert on the Markdown without going through
+// the CLI surface.
+//
+// Cloud assignment uses the canonical TF type prefix (`aws_*` vs
+// `google_*`). Every type in the capabilities matrix has one of those
+// two prefixes today — the function ignores any other prefix to keep
+// the renderer total (no panics on future additions); if a third
+// provider is added, extend the prefix switch below.
+func renderSupportedResources(caps map[string]capabilityRow) string {
+	awsTypes, gcpTypes := splitCloudTypes(caps)
+
+	var b bytes.Buffer
+	b.WriteString("# Supported Resources\n\n")
+	b.WriteString("Per-type Capabilities matrix for every cloud resource the InsideOut\n")
+	b.WriteString("discovery + composition pipeline supports. Five orthogonal axes:\n\n")
+	b.WriteString("- **Discoverable** — the discovery registry can list resources of\n")
+	b.WriteString("  this type from a live cloud account.\n")
+	b.WriteString("- **Enrichable** — at least one `AttributeEnricher` is registered\n")
+	b.WriteString("  in the per-cloud discoverer (fetches extended attributes beyond\n")
+	b.WriteString("  the bare list call).\n")
+	b.WriteString("- **DriftDetectable** — the curated `policy.Map` for this type has\n")
+	b.WriteString("  at least one field with a non-empty `DriftSemantic` axis.\n")
+	b.WriteString("- **MetricsAvailable** — the metrics bindings registry exposes a\n")
+	b.WriteString("  default metric surface for this type.\n")
+	b.WriteString("- **AgentEditable** — at least one field in the curated `policy.Map`\n")
+	b.WriteString("  carries `EditChatSafe` or `EditRequiresApproval` — i.e. an agent\n")
+	b.WriteString("  may write to it through the policy-gated edit path.\n\n")
+	b.WriteString("This document is generated from `cmd/imported-codegen capabilities`\n")
+	b.WriteString("and is checked in lockstep with the runtime registries. See the\n")
+	b.WriteString("`How to regenerate` section at the bottom for the regen command.\n\n")
+
+	b.WriteString("## Summary\n\n")
+	writeSummaryLine(&b, "AWS", awsTypes, caps)
+	writeSummaryLine(&b, "GCP", gcpTypes, caps)
+	b.WriteString("\n")
+
+	writeCloudSection(&b, "AWS", awsTypes, caps)
+	writeCloudSection(&b, "GCP", gcpTypes, caps)
+
+	b.WriteString("## How to regenerate\n\n")
+	b.WriteString("```bash\n")
+	b.WriteString("make regen-supported-resources\n")
+	b.WriteString("# or, directly:\n")
+	b.WriteString("go run ./cmd/imported-codegen supported-resources --output SUPPORTED_RESOURCES.md\n")
+	b.WriteString("```\n\n")
+	b.WriteString("CI runs `make verify-supported-resources`, which re-renders the\n")
+	b.WriteString("document and fails the build if the committed copy is out of\n")
+	b.WriteString("date.\n")
+
+	return b.String()
+}
+
+// splitCloudTypes partitions the capabilities map into per-cloud sorted
+// slices. Types that don't match a known cloud prefix are dropped — see
+// renderSupportedResources for the prefix-switch rationale.
+func splitCloudTypes(caps map[string]capabilityRow) (aws, gcp []string) {
+	for t := range caps {
+		switch {
+		case strings.HasPrefix(t, "aws_"):
+			aws = append(aws, t)
+		case strings.HasPrefix(t, "google_"):
+			gcp = append(gcp, t)
+		}
+	}
+	sort.Strings(aws)
+	sort.Strings(gcp)
+	return aws, gcp
+}
+
+// writeSummaryLine writes one bullet of per-cloud counts to b. The
+// percentages are rounded to the nearest integer for readability;
+// callers wanting raw counts can inspect the per-row matrix below.
+func writeSummaryLine(b *bytes.Buffer, cloud string, types []string, caps map[string]capabilityRow) {
+	if len(types) == 0 {
+		fmt.Fprintf(b, "- **%s:** 0 types\n", cloud)
+		return
+	}
+	var disc, enr, drift, met, ag int
+	for _, t := range types {
+		row := caps[t]
+		if row.Discoverable {
+			disc++
+		}
+		if row.Enrichable {
+			enr++
+		}
+		if row.DriftDetectable {
+			drift++
+		}
+		if row.MetricsAvailable {
+			met++
+		}
+		if row.AgentEditable {
+			ag++
+		}
+	}
+	n := len(types)
+	fmt.Fprintf(b,
+		"- **%s:** %d types · %d%% Discoverable · %d%% Enrichable · %d%% DriftDetectable · %d%% MetricsAvailable · %d%% AgentEditable\n",
+		cloud, n, pct(disc, n), pct(enr, n), pct(drift, n), pct(met, n), pct(ag, n),
+	)
+}
+
+// writeCloudSection writes the per-cloud Markdown table to b.
+func writeCloudSection(b *bytes.Buffer, cloud string, types []string, caps map[string]capabilityRow) {
+	fmt.Fprintf(b, "## %s\n\n", cloud)
+	if len(types) == 0 {
+		b.WriteString("_No resource types registered for this cloud._\n\n")
+		return
+	}
+	b.WriteString("| TF Type | Discoverable | Enrichable | DriftDetectable | MetricsAvailable | AgentEditable |\n")
+	b.WriteString("|---|---|---|---|---|---|\n")
+	for _, t := range types {
+		row := caps[t]
+		fmt.Fprintf(b,
+			"| `%s` | %s | %s | %s | %s | %s |\n",
+			t,
+			cell(row.Discoverable),
+			cell(row.Enrichable),
+			cell(row.DriftDetectable),
+			cell(row.MetricsAvailable),
+			cell(row.AgentEditable),
+		)
+	}
+	b.WriteString("\n")
+}
+
+// cell renders a single boolean as the Markdown table cell content.
+// "✓" for true, "–" (en-dash) for false — same convention as the
+// downstream UI's capabilities chip, so a reader of the doc and a
+// reader of the UI see the same glyphs.
+func cell(v bool) string {
+	if v {
+		return "✓"
+	}
+	return "–"
+}
+
+// pct returns 100*num/den rounded to the nearest integer. Returns 0 on
+// den == 0 to keep the renderer total in the no-types-for-cloud case.
+func pct(num, den int) int {
+	if den == 0 {
+		return 0
+	}
+	// +den/2 implements round-half-up without pulling in math.
+	return (num*100 + den/2) / den
+}

--- a/cmd/imported-codegen/emit_resources_doc_test.go
+++ b/cmd/imported-codegen/emit_resources_doc_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRenderSupportedResources_FixtureMatrix pins the Markdown shape on
+// a tiny synthetic fixture: 2 AWS + 1 GCP type, mixed boolean values.
+// Locks the header text, summary line wording, per-cloud table headers,
+// glyphs (✓ / –), and the "How to regenerate" footer in one place so a
+// future renderer refactor either preserves every load-bearing piece
+// or flips this test loud.
+func TestRenderSupportedResources_FixtureMatrix(t *testing.T) {
+	t.Parallel()
+	caps := map[string]capabilityRow{
+		"aws_s3_bucket": {
+			Discoverable: true, Enrichable: true, DriftDetectable: false,
+			MetricsAvailable: false, AgentEditable: true,
+		},
+		"aws_lambda_function": {
+			Discoverable: true, Enrichable: false, DriftDetectable: false,
+			MetricsAvailable: true, AgentEditable: false,
+		},
+		"google_storage_bucket": {
+			Discoverable: true, Enrichable: true, DriftDetectable: true,
+			MetricsAvailable: false, AgentEditable: true,
+		},
+	}
+	got := renderSupportedResources(caps)
+
+	// Header sanity.
+	if !strings.HasPrefix(got, "# Supported Resources\n") {
+		t.Errorf("output should start with the H1 header, got first 32 bytes = %q", got[:min(32, len(got))])
+	}
+
+	// Each axis name appears in the doc — locks the human-readable
+	// glossary section.
+	for _, axis := range []string{"Discoverable", "Enrichable", "DriftDetectable", "MetricsAvailable", "AgentEditable"} {
+		if !strings.Contains(got, axis) {
+			t.Errorf("output missing axis name %q", axis)
+		}
+	}
+
+	// AWS section appears before GCP section. Order matters because
+	// the downstream UI sorts cloud sections AWS-first.
+	awsIdx := strings.Index(got, "## AWS")
+	gcpIdx := strings.Index(got, "## GCP")
+	if awsIdx < 0 || gcpIdx < 0 {
+		t.Fatalf("missing per-cloud sections: awsIdx=%d gcpIdx=%d", awsIdx, gcpIdx)
+	}
+	if awsIdx > gcpIdx {
+		t.Error("GCP section appears before AWS section — order is wrong")
+	}
+
+	// AWS rows must be sorted by TF type (aws_lambda_function < aws_s3_bucket).
+	lambdaIdx := strings.Index(got, "`aws_lambda_function`")
+	s3Idx := strings.Index(got, "`aws_s3_bucket`")
+	if lambdaIdx < 0 || s3Idx < 0 {
+		t.Fatalf("missing AWS rows: lambda=%d s3=%d", lambdaIdx, s3Idx)
+	}
+	if lambdaIdx > s3Idx {
+		t.Error("AWS rows are not sorted by TF type")
+	}
+
+	// Glyphs: aws_s3_bucket has Discoverable=true, Enrichable=true,
+	// DriftDetectable=false, MetricsAvailable=false, AgentEditable=true
+	// → row should be "| ✓ | ✓ | – | – | ✓ |".
+	wantS3Row := "| `aws_s3_bucket` | ✓ | ✓ | – | – | ✓ |"
+	if !strings.Contains(got, wantS3Row) {
+		t.Errorf("aws_s3_bucket row mismatch — want substring %q\n--- full doc ---\n%s", wantS3Row, got)
+	}
+
+	// Summary line — both clouds use the rounded percentages branch.
+	// AWS: 2 types, 100% Discoverable, 50% Enrichable, 0% Drift, 50% Metrics, 50% Agent.
+	wantAWSSummary := "**AWS:** 2 types · 100% Discoverable · 50% Enrichable · 0% DriftDetectable · 50% MetricsAvailable · 50% AgentEditable"
+	if !strings.Contains(got, wantAWSSummary) {
+		t.Errorf("AWS summary line mismatch — want substring %q", wantAWSSummary)
+	}
+
+	// Footer documents the regen command.
+	if !strings.Contains(got, "make regen-supported-resources") {
+		t.Error("footer missing the canonical regen command")
+	}
+	if !strings.Contains(got, "go run ./cmd/imported-codegen supported-resources --output SUPPORTED_RESOURCES.md") {
+		t.Error("footer missing the direct go-run regen command")
+	}
+}
+
+// TestRenderSupportedResources_DropsUnknownCloud pins that the renderer
+// gracefully ignores types that don't match a known cloud prefix
+// instead of routing them into one section or panicking. Future-proof
+// against a third provider showing up in the discover registry.
+func TestRenderSupportedResources_DropsUnknownCloud(t *testing.T) {
+	t.Parallel()
+	caps := map[string]capabilityRow{
+		"aws_s3_bucket":           {Discoverable: true},
+		"google_storage_bucket":   {Discoverable: true},
+		"azurerm_storage_account": {Discoverable: true},
+	}
+	got := renderSupportedResources(caps)
+	if strings.Contains(got, "azurerm_storage_account") {
+		t.Error("unknown-prefix type should not appear in output until a cloud section is added for it")
+	}
+	// Counts in the summary line should not include the dropped type.
+	if !strings.Contains(got, "**AWS:** 1 types") {
+		t.Error("AWS summary count should be 1")
+	}
+	if !strings.Contains(got, "**GCP:** 1 types") {
+		t.Error("GCP summary count should be 1")
+	}
+}
+
+// TestRenderSupportedResources_EmptyCloud pins the empty-cloud branch:
+// a cloud with zero registered types renders a "no types" placeholder
+// and a zero-count summary line rather than an empty table that would
+// produce broken Markdown.
+func TestRenderSupportedResources_EmptyCloud(t *testing.T) {
+	t.Parallel()
+	caps := map[string]capabilityRow{
+		"aws_s3_bucket": {Discoverable: true},
+	}
+	got := renderSupportedResources(caps)
+	if !strings.Contains(got, "## GCP") {
+		t.Fatal("GCP section header should appear even when empty")
+	}
+	if !strings.Contains(got, "_No resource types registered for this cloud._") {
+		t.Error("empty cloud should render the no-types placeholder")
+	}
+	if !strings.Contains(got, "**GCP:** 0 types") {
+		t.Error("empty cloud summary should report 0 types")
+	}
+}
+
+// TestRunSupportedResources_WriteAndCheckRoundtrip pins the
+// write→check loop a developer (or CI) runs: writing the file then
+// running --check should exit zero, and tampering with the file should
+// flip --check to non-zero.
+func TestRunSupportedResources_WriteAndCheckRoundtrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "SUPPORTED_RESOURCES.md")
+
+	if code := runSupportedResources([]string{"--output", out}); code != 0 {
+		t.Fatalf("first write: runSupportedResources exit = %d, want 0", code)
+	}
+
+	if code := runSupportedResources([]string{"--check", "--output", out}); code != 0 {
+		t.Fatalf("--check on freshly-written file: exit = %d, want 0", code)
+	}
+
+	// Tamper with the file and confirm --check trips.
+	buf, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read for tamper: %v", err)
+	}
+	tampered := append(buf, []byte("\n<!-- accidental hand-edit -->\n")...)
+	if err := os.WriteFile(out, tampered, 0o644); err != nil {
+		t.Fatalf("write tampered: %v", err)
+	}
+	if code := runSupportedResources([]string{"--check", "--output", out}); code == 0 {
+		t.Error("--check on tampered file: exit = 0, want non-zero")
+	}
+}
+
+// TestRunSupportedResources_RequiresOutput pins that the subcommand
+// rejects an empty --output flag rather than silently writing nowhere.
+// This is a user-experience guard — accidentally omitting --output
+// would otherwise produce a confusing "wrote 0 bytes" or panic.
+func TestRunSupportedResources_RequiresOutput(t *testing.T) {
+	t.Parallel()
+	if code := runSupportedResources([]string{}); code == 0 {
+		t.Error("expected non-zero exit when --output is omitted")
+	}
+	if code := runSupportedResources([]string{"--output", ""}); code == 0 {
+		t.Error("expected non-zero exit when --output is empty")
+	}
+}
+
+// TestRunSupportedResources_CheckAgainstMissingFile pins the --check
+// failure mode when the target file does not exist (e.g. a contributor
+// deleted SUPPORTED_RESOURCES.md and pushed). --check should fail loud
+// rather than silently regenerating a fresh copy.
+func TestRunSupportedResources_CheckAgainstMissingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "does-not-exist.md")
+	if code := runSupportedResources([]string{"--check", "--output", out}); code == 0 {
+		t.Error("expected non-zero exit when --check is run against a missing file")
+	}
+}
+
+// TestSplitCloudTypes_Sorted pins the split helper's sort guarantee.
+// Downstream rendering depends on it for deterministic table row order.
+func TestSplitCloudTypes_Sorted(t *testing.T) {
+	t.Parallel()
+	caps := map[string]capabilityRow{
+		"aws_zzz":   {},
+		"aws_aaa":   {},
+		"aws_mmm":   {},
+		"google_z":  {},
+		"google_a":  {},
+		"unknown_x": {},
+	}
+	aws, gcp := splitCloudTypes(caps)
+	if got, want := aws, []string{"aws_aaa", "aws_mmm", "aws_zzz"}; !equalSlices(got, want) {
+		t.Errorf("aws = %v, want %v", got, want)
+	}
+	if got, want := gcp, []string{"google_a", "google_z"}; !equalSlices(got, want) {
+		t.Errorf("gcp = %v, want %v", got, want)
+	}
+}
+
+// TestPct pins the rounding contract on the per-cloud summary counts.
+func TestPct(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		num, den, want int
+	}{
+		{0, 0, 0},   // empty cloud branch
+		{0, 10, 0},  // nothing flagged
+		{10, 10, 100},
+		{1, 3, 33},   // round down
+		{2, 3, 67},   // round up
+		{1, 2, 50},
+	}
+	for _, tc := range cases {
+		if got := pct(tc.num, tc.den); got != tc.want {
+			t.Errorf("pct(%d,%d) = %d, want %d", tc.num, tc.den, got, tc.want)
+		}
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/imported-codegen/main.go
+++ b/cmd/imported-codegen/main.go
@@ -48,6 +48,12 @@
 //	        every curated policy.Map field with a non-empty drift axis
 //	        (presets#482).
 //
+//	supported-resources --output <path> [--check]
+//	        Render SUPPORTED_RESOURCES.md from the same capabilities map
+//	        the `capabilities` subcommand emits as JSON. --check
+//	        regenerates to memory and exits non-zero on diff for CI
+//	        gating (presets#492).
+//
 // Default subcommand is `gen` so plain `imported-codegen --aws-schema=...`
 // works.
 package main
@@ -84,6 +90,8 @@ func main() {
 			os.Exit(runDependencies(os.Args[2:]))
 		case "drift-fields":
 			os.Exit(runDriftFields(os.Args[2:]))
+		case "supported-resources":
+			os.Exit(runSupportedResources(os.Args[2:]))
 		case "-h", "--help":
 			usage()
 			return
@@ -104,6 +112,7 @@ Subcommands:
   capabilities  emit per-type Capabilities matrix JSON (presets#482)
   dependencies  emit per-type cross-resource ref edge-list JSON (presets#482)
   drift-fields  emit per-type DriftSemantic field list JSON (presets#482)
+  supported-resources  render SUPPORTED_RESOURCES.md from the capabilities matrix (presets#492)
 
 Run 'imported-codegen <subcommand> --help' for subcommand flags.`)
 }


### PR DESCRIPTION
## Summary

- Replace the hand-maintained 3-state Coverage column in `SUPPORTED_RESOURCES.md` with a per-type Capabilities matrix (Discoverable / Enrichable / DriftDetectable / MetricsAvailable / AgentEditable) generated from the same `buildCapabilitiesMap()` the `imported-codegen capabilities` subcommand emits as JSON — so the Markdown and JSON outputs stay in lockstep by construction.
- Add `cmd/imported-codegen supported-resources --output <path> [--check]` subcommand. `--check` regenerates to memory and exits non-zero on diff for CI gating.
- Add `make regen-supported-resources` for one-command regen and `make verify-supported-resources` + a matching `verify-supported-resources` CI job (wired into the `ci-gate` aggregator) that fails the build if the committed doc is stale.
- Unit tests cover the renderer (fixture matrix, empty-cloud branch, unknown-prefix drop), the write/--check roundtrip, the required `--output` flag, the missing-file `--check` failure mode, and the rounding helper.

## Acceptance criteria

- [x] Regen is reproducible via a single command (`make regen-supported-resources`).
- [x] CI gate verifies the committed file matches the regenerated output — drift fails the build (`verify-supported-resources` job).
- [x] Matrix matches `imported-codegen capabilities` JSON output 1:1 (verified by cross-running both against the live registry).

## Test plan

- [x] `go test ./cmd/imported-codegen/... -count=1` passes (183 tests).
- [x] `go build ./...` and `go vet ./...` clean.
- [x] `make verify-supported-resources` exits 0 on the committed file.
- [x] Tampering with `SUPPORTED_RESOURCES.md` and re-running the verify target exits non-zero with a diff hint.

Closes #492