### PR TITLE
refactor(imported): doc-sweep Riley -> summary/agent (in-repo, wire-pinned const deferred)

### DIFF
--- a/cmd/imported-codegen/emit_capabilities.go
+++ b/cmd/imported-codegen/emit_capabilities.go
@@ -112,8 +112,8 @@ func hasMetricsBinding(tfType string) bool {
 // These are the two Edit policies that route through an interactive
 // agent's write path; the other three (Never, RelationshipOnly,
 // SystemOnly) disallow direct agent scalar edits. Agent-name-agnostic
-// so the per-product naming (Riley today) can rotate without
-// flipping the codegen output.
+// so the per-product naming can rotate without flipping the codegen
+// output.
 func isAgentEditable(tfType string) bool {
 	m, ok := policy.Lookup(tfType)
 	if !ok {

--- a/cmd/imported-codegen/main.go
+++ b/cmd/imported-codegen/main.go
@@ -35,7 +35,7 @@
 //	capabilities [--output <path>]
 //	        Emit a per-type Capabilities matrix JSON
 //	        ({discoverable, enrichable, driftDetectable,
-//	         metricsAvailable, rileyEditable}) computed from the
+//	         metricsAvailable, agentEditable}) computed from the
 //	        upstream registries (presets#482).
 //
 //	dependencies [--output <path>]

--- a/cmd/insideout-import/main.go
+++ b/cmd/insideout-import/main.go
@@ -4,7 +4,7 @@
 // Subcommands:
 //
 //	adopt     Emit `import {}` blocks against an already-known preset stack.
-//	          Customer/Riley supplies (target address, cloud import ID) pairs;
+//	          Customer / interactive agent supplies (target address, cloud import ID) pairs;
 //	          the CLI writes imports.tf next to the stack and (optionally)
 //	          runs `terraform plan -json` to verify the plan is import-only.
 //	          See cmd/insideout-import/README.md.

--- a/cmd/insideout-import/manifest.go
+++ b/cmd/insideout-import/manifest.go
@@ -92,8 +92,8 @@ func writeFileAtomic(path string, body []byte, perm os.FileMode) (rerr error) {
 // running discover repeatedly.
 func writeManifest(dir, cloud string, resources []imported.ImportedResource) (string, int, error) {
 	// json.MarshalIndent of a nil slice writes "null"; downstream
-	// consumers (Reliable, Riley) cannot range over null. Force an empty
-	// slice so the on-disk manifest is always a JSON array.
+	// consumers (Reliable, the interactive agent) cannot range over null.
+	// Force an empty slice so the on-disk manifest is always a JSON array.
 	if resources == nil {
 		resources = []imported.ImportedResource{}
 	}
@@ -136,7 +136,7 @@ func writeManifest(dir, cloud string, resources []imported.ImportedResource) (st
 // file by hand can jump to the failing position. A literal `null` top-level
 // is rejected explicitly: writeManifest's invariant is that an empty
 // resource set serializes as `[]`, never `null`, and downstream consumers
-// (Reliable, Riley, the depchase loop) cannot range over null.
+// (Reliable, the interactive agent, the depchase loop) cannot range over null.
 //
 // Returns ([]ImportedResource, nil) on success — never a nil slice with no
 // error: an empty manifest decodes to a zero-length slice.
@@ -248,8 +248,8 @@ func writeUnsupportedManifest(dir string, resources []UnsupportedResource, trunc
 // Why graph.json is a sibling of imported.json (rather than
 // embedded): the wizard picker reads them separately on different
 // stages of the import flow, and an embedded edges slice would force
-// every imported.json reader (composer, validators, riley, etc.) to
-// know the dependency-graph schema. Persisting as a sibling keeps
+// every imported.json reader (composer, validators, the interactive
+// agent, etc.) to know the dependency-graph schema. Persisting as a sibling keeps
 // imported.json's wire shape unchanged and lets graph.json evolve
 // independently.
 func writeGraphManifest(dir string, edges []depchase.GraphEdge) (string, int, error) {
@@ -297,8 +297,8 @@ func writeGraphManifest(dir string, edges []depchase.GraphEdge) (string, int, er
 // Why summary.json is a sibling of imported.json (rather than embedded):
 // the aggregate's wire shape evolves independently of the per-resource
 // IR — adding a new aggregate bucket (e.g. byCloud) shouldn't require
-// every imported.json reader (composer, validators, riley) to know the
-// summary schema. Keeping it as a sibling matches the same rationale
+// every imported.json reader (composer, validators, the interactive
+// agent) to know the summary schema. Keeping it as a sibling matches the same rationale
 // behind unsupported.json (#296) and graph.json (#297).
 func writeSummary(dir string, summary imported.DiscoverySummary) (string, error) {
 	body, err := json.MarshalIndent(summary, "", "  ")

--- a/cmd/insideout-import/manifest_test.go
+++ b/cmd/insideout-import/manifest_test.go
@@ -309,8 +309,8 @@ func TestWriteManifest_EmptyInputWritesJSONArrayNotNull(t *testing.T) {
 	}
 	body, _ := os.ReadFile(path)
 	// json.MarshalIndent of a nil slice writes "null", which downstream
-	// consumers (Reliable, Riley) cannot range over. Pin that the writer
-	// emits an empty JSON array even on empty input.
+	// consumers (Reliable, the interactive agent) cannot range over. Pin
+	// that the writer emits an empty JSON array even on empty input.
 	if strings.TrimSpace(string(body)) == "null" {
 		t.Errorf("manifest must be `[]` not `null` for empty input; got: %s", body)
 	}

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -57,7 +57,7 @@ type Files map[string][]byte
 // ComposeStackResult is the aggregated output of ComposeStackWithIssues.
 // Files is the composed stack (same map as ComposeStack returns); Issues is
 // the deduped list of pre-plan validator findings (missing required vars,
-// type mismatches, wiring drift, etc.) that callers like the InsideOut backend/Riley
+// type mismatches, wiring drift, etc.) that callers like the InsideOut backend/interactive-agent
 // surface for same-turn correction.
 type ComposeStackResult struct {
 	Files  Files
@@ -942,7 +942,7 @@ func renderRequiredProviders(m map[string]*tfconfig.ProviderRequirement) string 
 // validateRequiredIssues returns a structured ValidationIssue per missing
 // required variable, instead of short-circuiting on the first miss. This lets
 // the composer aggregate every missing-input across all selected modules into
-// a single Result.Issues list, so callers like the InsideOut backend/Riley can correct
+// a single Result.Issues list, so callers like the InsideOut backend/interactive-agent can correct
 // every gap in one round-trip.
 func validateRequiredIssues(vars []*tfconfig.Variable, wired WiredInputs, vals map[string]any, module string) []ValidationIssue {
 	var out []ValidationIssue

--- a/pkg/composer/compose_result_test.go
+++ b/pkg/composer/compose_result_test.go
@@ -38,7 +38,7 @@ func TestComposeStackWithIssues_GreenPath(t *testing.T) {
 // multiple selected modules are missing required inputs simultaneously and
 // asserts every miss surfaces as a structured issue (rather than the legacy
 // path's first-failure error). This is the same-turn-correction property
-// The InsideOut backend/Riley relies on.
+// The InsideOut backend/interactive-agent relies on.
 func TestComposeStackWithIssues_AggregatesAcrossModules(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/composer/imported/generated/doc.go
+++ b/pkg/composer/imported/generated/doc.go
@@ -14,7 +14,7 @@
 //
 // Importing this package registers every supported resource type via the
 // init() side effects in the generated files. Consumers (composer, validators,
-// Riley's edit path) discover types through the registry rather than naming
-// the structs directly, so adding a type does not require touching call
-// sites.
+// the interactive agent's edit path) discover types through the registry
+// rather than naming the structs directly, so adding a type does not require
+// touching call sites.
 package generated

--- a/pkg/composer/imported/generated/schema.go
+++ b/pkg/composer/imported/generated/schema.go
@@ -8,8 +8,8 @@ package generated
 //     destroys and recreates.
 //   - ReplacementMayReplace — plan-time-only behavior (e.g. shrinking
 //     storage). Static schemas do not expose this state; the codegen never
-//     emits it. Runtime callers (Riley's planner) may set it on a copy of
-//     the FieldSchema after inspecting a concrete plan.
+//     emits it. Runtime callers (the interactive agent's planner) may set it
+//     on a copy of the FieldSchema after inspecting a concrete plan.
 //   - ReplacementUnknown — the schema does not expose force_new for this
 //     attribute (typically nested-block fields in newer provider schemas).
 type ReplacementBehavior string
@@ -22,9 +22,10 @@ const (
 )
 
 // FieldSchema captures the per-attribute provider metadata that the
-// composer, validators, and Riley's edit path need to make decisions about
-// a field without re-reading the original provider schema. One FieldSchema
-// per attribute is emitted into the generated <Type>Schema map.
+// composer, validators, and the interactive agent's edit path need to make
+// decisions about a field without re-reading the original provider schema.
+// One FieldSchema per attribute is emitted into the generated <Type>Schema
+// map.
 //
 // Composer emission rule (per docs/managed-resource-tiers.md lines 167-171):
 // emit configurable fields (Required or Optional) from the desired model;

--- a/pkg/composer/imported/identity.go
+++ b/pkg/composer/imported/identity.go
@@ -4,7 +4,7 @@ package imported
 // populated a resource's Attrs payload. Empty string is the implicit
 // "unknown" state — used at pre-enrich call sites and for resource types
 // that have no registered enricher (Identity-only IRs). Downstream
-// consumers (the Reliable importer wizard, future Riley management views)
+// consumers (the Reliable importer wizard, future interactive-agent management views)
 // read this to surface partial-data warnings without grep-ing the
 // enricher's warn log; see issue #471 for the live-verification context
 // that motivated adding a typed signal.

--- a/pkg/composer/imported/policy/aws_dynamodb_table.policy.go
+++ b/pkg/composer/imported/policy/aws_dynamodb_table.policy.go
@@ -7,10 +7,11 @@ package policy
 // against silent drift.
 //
 // Coverage decision (slice #1346 / presets bundle #461 follow-up): only
-// the configurable surface that Riley can sensibly reason about is
-// curated. Computed-only fields (arn, id, stream_arn, stream_label) are
-// surfaced as Identity / Never / UIVisible so the diff screen can render
-// them as read-only context without making them Riley-editable.
+// the configurable surface that the interactive agent can sensibly
+// reason about is curated. Computed-only fields (arn, id, stream_arn,
+// stream_label) are surfaced as Identity / Never / UIVisible so the
+// diff screen can render them as read-only context without making
+// them agent-editable.
 //
 // Identity vs Wiring on top-level: `name` is the table's primary key
 // and is `AlwaysReplace`; `hash_key` and `range_key` are the partition
@@ -56,8 +57,8 @@ var awsDynamodbTablePolicy = Map{
 
 	// Tuning — capacity and storage ------------------------------------
 	"billing_mode": {
-		// Provisioned vs on-demand — reversible in-place. Riley should
-		// be able to propose the flip for cost optimization.
+		// Provisioned vs on-demand — reversible in-place. The interactive
+		// agent should be able to propose the flip for cost optimization.
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
 		Edit: EditChatSafe,
 	},
@@ -81,7 +82,7 @@ var awsDynamodbTablePolicy = Map{
 		Edit: EditChatSafe,
 	},
 	"deletion_protection_enabled": {
-		// Safety flag — Riley can propose flipping it, UI shows the change.
+		// Safety flag — the interactive agent can propose flipping it, UI shows the change.
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditChatSafe,
 	},
@@ -114,8 +115,8 @@ var awsDynamodbTablePolicy = Map{
 		Edit: EditChatSafe,
 	},
 	"server_side_encryption.kms_key_arn": {
-		// KMS key is a cross-resource wiring relationship — Riley edits
-		// the relationship, the composer's graph resolver owns the ARN.
+		// KMS key is a cross-resource wiring relationship — the interactive
+		// agent edits the relationship, the composer's graph resolver owns the ARN.
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeMayReplace,
 	},

--- a/pkg/composer/imported/policy/aws_lambda_function.policy.go
+++ b/pkg/composer/imported/policy/aws_lambda_function.policy.go
@@ -122,7 +122,7 @@ var awsLambdaFunctionPolicy = Map{
 	},
 
 	// Sensitive: environment variables routinely contain credentials.
-	// Hidden from Riley; only system code reads/writes them.
+	// Hidden from the interactive agent; only system code reads/writes them.
 	"environment.variables": {
 		Role: RoleTuning, Pillar: PillarSecurity,
 		Visibility: VisibilityHidden, Edit: EditSystemOnly,

--- a/pkg/composer/imported/policy/aws_s3_bucket.policy.go
+++ b/pkg/composer/imported/policy/aws_s3_bucket.policy.go
@@ -10,7 +10,7 @@ package policy
 // curated. Computed-only fields (arn, bucket_domain_name, hosted_zone_id,
 // region, website_domain, website_endpoint, id) are surfaced as
 // Identity / Never / UIVisible so the diff screen can render them as
-// read-only context without making them Riley-editable.
+// read-only context without making them agent-editable.
 //
 // Identity vs Wiring on top-level: `bucket` is the S3 primary key and
 // is `AlwaysReplace`, which the composer's drift comparator depends on
@@ -78,8 +78,8 @@ var awsS3BucketPolicy = Map{
 
 	// Wiring — bucket policy doc ---------------------------------------
 	"policy": {
-		// IAM-style JSON document. Riley can propose changes but apply
-		// requires explicit approval against the diff.
+		// IAM-style JSON document. The interactive agent can propose
+		// changes but apply requires explicit approval against the diff.
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
 		Edit: EditRequiresApproval,
 	},

--- a/pkg/composer/imported/policy/aws_secretsmanager_secret.policy.go
+++ b/pkg/composer/imported/policy/aws_secretsmanager_secret.policy.go
@@ -28,8 +28,8 @@ var awsSecretsmanagerSecretPolicy = Map{
 		Edit: EditRequiresApproval,
 	},
 
-	// Resource policy is an IAM JSON document — visible to Riley but
-	// each change requires explicit confirmation against the plan.
+	// Resource policy is an IAM JSON document — visible to the interactive
+	// agent but each change requires explicit confirmation against the plan.
 	"policy": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
 		Edit: EditRequiresApproval,

--- a/pkg/composer/imported/policy/axes.go
+++ b/pkg/composer/imported/policy/axes.go
@@ -8,15 +8,16 @@ type FieldRole string
 const (
 	// RoleIdentity is what makes a resource itself: arn, id, name, region.
 	// Identity fields are visible for context and diffs but never edited
-	// by Riley.
+	// by the interactive agent.
 	RoleIdentity FieldRole = "Identity"
 	// RoleWiring is a cross-reference to another managed resource:
 	// kms_key_id, subnet_ids, role_arn, redrive_policy. The composer's
-	// graph resolver owns these; Riley edits them through proposed graph
-	// changes, never as raw scalars.
+	// graph resolver owns these; the interactive agent edits them through
+	// proposed graph changes, never as raw scalars.
 	RoleWiring FieldRole = "Wiring"
-	// RoleTuning is everything else — knobs Riley can plausibly turn:
-	// visibility_timeout_seconds, retention_in_days, lifecycle rules.
+	// RoleTuning is everything else — knobs the interactive agent can
+	// plausibly turn: visibility_timeout_seconds, retention_in_days,
+	// lifecycle rules.
 	RoleTuning FieldRole = "Tuning"
 )
 
@@ -59,15 +60,19 @@ func (p FieldPillar) Valid() bool {
 type VisibilityPolicy string
 
 const (
-	// VisibilityHidden — invisible to Riley and the UI. The composer
-	// still round-trips the value because Layer 1 preserves it; only
-	// system code may inspect it.
+	// VisibilityHidden — invisible to the interactive agent and the UI.
+	// The composer still round-trips the value because Layer 1 preserves
+	// it; only system code may inspect it.
 	VisibilityHidden VisibilityPolicy = "Hidden"
-	// VisibilityRileyVisible — Riley can read the field in chat context
-	// and propose changes (subject to EditPolicy).
+	// VisibilityRileyVisible — the interactive agent can read the field
+	// in chat context and propose changes (subject to EditPolicy). The
+	// "Riley" naming on this const + wire-format string is pinned by
+	// downstream TypeScript consumers (luthersystems/reliable, etc.);
+	// renaming is a coordinated cross-repo change tracked separately
+	// from the in-repo doc-sweep in #489.
 	VisibilityRileyVisible VisibilityPolicy = "RileyVisible"
 	// VisibilityUIVisible — exposed in the product UI / diff screens for
-	// a human operator. Implies Riley-visible.
+	// a human operator. Implies agent-visible.
 	VisibilityUIVisible VisibilityPolicy = "UIVisible"
 )
 
@@ -87,11 +92,11 @@ func (v VisibilityPolicy) Valid() bool {
 // full matrix; in short:
 //
 //   - EditNever — readable but immutable from any flow.
-//   - EditChatSafe — Riley may change it through normal chat.
-//   - EditRequiresApproval — Riley proposes; user must confirm against
-//     the concrete plan.
-//   - EditRelationshipOnly — Riley cannot scalar-edit; the graph
-//     resolver / composer manages the value.
+//   - EditChatSafe — the interactive agent may change it through normal chat.
+//   - EditRequiresApproval — the interactive agent proposes; user must
+//     confirm against the concrete plan.
+//   - EditRelationshipOnly — the interactive agent cannot scalar-edit;
+//     the graph resolver / composer manages the value.
 //   - EditSystemOnly — only importer / composer system code writes here
 //     (tags, labels, provenance).
 type EditPolicy string
@@ -119,13 +124,13 @@ func (e EditPolicy) Valid() bool {
 type SensitivityPolicy string
 
 const (
-	// SensitivityPublic — safe to show in Riley context and diffs.
+	// SensitivityPublic — safe to show in agent context and diffs.
 	SensitivityPublic SensitivityPolicy = "Public"
 	// SensitivityRedacted — show existence and change metadata but not
 	// raw values.
 	SensitivityRedacted SensitivityPolicy = "Redacted"
-	// SensitivitySensitive — hidden from Riley and raw diffs; only
-	// system code may retain the value.
+	// SensitivitySensitive — hidden from the interactive agent and raw
+	// diffs; only system code may retain the value.
 	SensitivitySensitive SensitivityPolicy = "Sensitive"
 )
 

--- a/pkg/composer/imported/policy/coverage_test.go
+++ b/pkg/composer/imported/policy/coverage_test.go
@@ -106,7 +106,7 @@ func TestRegisteredTypes_CoveredSetExact(t *testing.T) {
 // independently populated (via WantedGoogle/WantedAWS driving codegen
 // vs. hand-authored *.policy.go files), so a curator adding to
 // WantedGoogle but forgetting the policy file would silently leave the
-// new type with no axes — the wizard / Riley would fall back to default
+// new type with no axes — the wizard / interactive agent would fall back to default
 // behavior, defeating the bundle's purpose.
 //
 // Symmetric to TestRegisteredTypes_PhaseSetExact, which guards the

--- a/pkg/composer/imported/policy/doc.go
+++ b/pkg/composer/imported/policy/doc.go
@@ -19,7 +19,7 @@
 // resource type, registered through init() side effects. Adding or
 // expanding a policy is a reviewed code change — never a runtime
 // configuration. New generated provider fields default hidden,
-// system-owned, and not Riley-editable until a reviewed policy PR
+// system-owned, and not agent-editable until a reviewed policy PR
 // explicitly adds them. See docs/managed-resource-tiers.md decision #43.
 //
 // Consumers (composer emission #148, server-side validateImportedResources

--- a/pkg/composer/imported/policy/google_compute_instance.policy.go
+++ b/pkg/composer/imported/policy/google_compute_instance.policy.go
@@ -49,7 +49,7 @@ var googleComputeInstancePolicy = Map{
 	},
 	// NB: `tags` on compute_instance is NOT labels — it's the GCE network
 	// tags list that drives firewall source_tags / target_tags, so the
-	// wizard / Riley need to see them. Intentionally uncurated until
+	// wizard / interactive agent need to see them. Intentionally uncurated until
 	// lint.go's tagAttrSuffixes can exempt this case (separate follow-up);
 	// curating with tagPolicy() would mark it SystemOnly+Hidden, which is
 	// wrong, and any non-SystemOnly curation trips CodeTagFieldNotSystemOnly.
@@ -149,7 +149,7 @@ var googleComputeInstancePolicy = Map{
 	},
 
 	// Metadata: kv map that legitimately carries SSH keys, env config, and
-	// user data scripts. Visible to Riley + UI (operators need to see it),
+	// user data scripts. Visible to the interactive agent + UI (operators need to see it),
 	// edits require approval (instance-impacting), values redacted (may
 	// contain credentials).
 	"metadata": {

--- a/pkg/composer/imported/policy/google_monitoring_dashboard.policy.go
+++ b/pkg/composer/imported/policy/google_monitoring_dashboard.policy.go
@@ -11,8 +11,8 @@ var googleMonitoringDashboardPolicy = Map{
 	},
 
 	// Tuning — entire payload is the JSON document. Treated as a single
-	// authored blob; Riley can edit via chat-safe JSON edits but the
-	// composer / wizard owns large refactors.
+	// authored blob; the interactive agent can edit via chat-safe JSON
+	// edits but the composer / wizard owns large refactors.
 	"dashboard_json": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
 	},

--- a/pkg/composer/imported/policy/lint.go
+++ b/pkg/composer/imported/policy/lint.go
@@ -30,7 +30,7 @@ const (
 	CodeWiringChatEditable          = "wiring_chat_editable"           // Wiring fields can't be ChatSafe (#33)
 	CodeTagFieldNotSystemOnly       = "tag_field_not_system_only"      // tags/labels/annotations must be SystemOnly
 	CodeIdentityEditable            = "identity_editable"              // top-level identity attrs must be Edit=Never
-	CodeHiddenChatEditable          = "hidden_chat_editable"           // Riley can't edit what it can't see
+	CodeHiddenChatEditable          = "hidden_chat_editable"           // the interactive agent can't edit what it can't see
 	CodeSensitiveChatEditable       = "sensitive_chat_editable"        // Sensitive values must not flow through chat
 	CodeIdentitySensitive           = "identity_sensitive"             // Identity fields are not sensitive values
 )
@@ -168,10 +168,10 @@ func lintEntry(tfType, path string, fp FieldPolicy) []Issue {
 			"Role=Wiring is incompatible with Edit=ChatSafe; use RelationshipOnly, RequiresApproval, or Never (decision #33)")
 	}
 
-	// Riley cannot edit what it cannot see.
+	// The interactive agent cannot edit what it cannot see.
 	if fp.Visibility == VisibilityHidden && fp.Edit == EditChatSafe {
 		add(CodeHiddenChatEditable,
-			"Visibility=Hidden is incompatible with Edit=ChatSafe; Riley cannot edit what it cannot see")
+			"Visibility=Hidden is incompatible with Edit=ChatSafe; the interactive agent cannot edit what it cannot see")
 	}
 
 	// Sensitive values must not flow through chat. RequiresApproval

--- a/pkg/composer/imported/policy/policy.go
+++ b/pkg/composer/imported/policy/policy.go
@@ -25,10 +25,10 @@ type Map map[string]FieldPolicy
 
 // tagPolicy is the uniform treatment for tag- and label-shaped
 // attributes (tags, tags_all, labels, effective_labels,
-// terraform_labels, annotations, effective_annotations). Riley never
-// authors these; the importer / composer system writes them and the
-// diff layer redacts user-set values during display. Used by every
-// curated map.
+// terraform_labels, annotations, effective_annotations). The interactive
+// agent never authors these; the importer / composer system writes them
+// and the diff layer redacts user-set values during display. Used by
+// every curated map.
 func tagPolicy() FieldPolicy {
 	return FieldPolicy{
 		Role:        RoleTuning,
@@ -40,7 +40,7 @@ func tagPolicy() FieldPolicy {
 
 // timeoutsPolicy is the uniform treatment for the singleton timeouts
 // block present on most resources (create / update / delete / read).
-// Treated as system-owned operational metadata, hidden from Riley.
+// Treated as system-owned operational metadata, hidden from the interactive agent.
 func timeoutsPolicy() FieldPolicy {
 	return FieldPolicy{
 		Role:       RoleTuning,

--- a/pkg/composer/imported/policy/projection_test.go
+++ b/pkg/composer/imported/policy/projection_test.go
@@ -65,7 +65,7 @@ func TestVisibleFieldsFor_StorageBucket_AcceptanceA(t *testing.T) {
 
 	set := pathSet(views)
 
-	// Curated UI/Riley-visible entries are present.
+	// Curated UI/agent-visible entries are present.
 	for _, p := range []string{
 		"name", "project", "location", "self_link", "url", "id",
 		"storage_class", "force_destroy", "encryption.default_kms_key_name",

--- a/pkg/composer/imported/resource.go
+++ b/pkg/composer/imported/resource.go
@@ -37,16 +37,16 @@ type ImportedResource struct {
 
 	// Attributes is the current desired provider attributes as an opaque
 	// bag (Phase 1 / wire-compatible shape). The composer emits HCL from
-	// this state. Riley's chat edits update the values here through the
-	// model write path; FieldEdits records audit/conflict metadata only —
-	// the composer does not emit from FieldEdits.
+	// this state. Interactive-agent chat edits update the values here
+	// through the model write path; FieldEdits records audit/conflict
+	// metadata only — the composer does not emit from FieldEdits.
 	Attributes map[string]any `json:"attributes,omitempty"`
 
 	// FieldEdits is audit/conflict metadata for changes made via the model
 	// write path since the last successful `terraform apply`. The edited
 	// values are already reflected in Attributes; this map exists to detect
-	// conflicts between Riley's pending edits and independent cloud changes
-	// at re-import time. Cleared when an apply succeeds.
+	// conflicts between the interactive agent's pending edits and independent
+	// cloud changes at re-import time. Cleared when an apply succeeds.
 	FieldEdits map[string]FieldEdit `json:"field_edits,omitempty"`
 
 	// Attrs is the typed Layer 1 attribute payload for this resource,

--- a/pkg/composer/validate_module_graph_test.go
+++ b/pkg/composer/validate_module_graph_test.go
@@ -145,8 +145,9 @@ func TestValidateValueTypes_FlagsStringForNumber(t *testing.T) {
 		if iss.Field == "gcp_gke.node_count" {
 			require.Equal(t, "invalid_type", iss.Code)
 			require.Contains(t, iss.Reason, "number")
-			// Lock the offending value into the issue payload so Riley
-			// has the diagnostic it needs without re-resolving the IR.
+			// Lock the offending value into the issue payload so the
+			// interactive agent has the diagnostic it needs without
+			// re-resolving the IR.
 			require.NotEmpty(t, iss.Value,
 				"invalid_type issues must carry the offending value via issueValue()")
 			require.Contains(t, iss.Value, "oops",

--- a/pkg/composer/wiring_graph_test.go
+++ b/pkg/composer/wiring_graph_test.go
@@ -89,7 +89,7 @@ func TestExtractImportedEdges_PlainScalarsIgnored(t *testing.T) {
 
 // TestExtractImportedEdges_MultiSegmentTraversals pins the Variables()
 // contract for non-bare traversals: index access, deep attribute chains,
-// and repeated references. Each shape is what Riley wiring is allowed
+// and repeated references. Each shape is what agent wiring is allowed
 // to emit through a RawExpr value — a regression in classifyTraversal's
 // `len(tr) < 3` early-return or in HCL's traversal classification would
 // silently drop edges otherwise.
@@ -338,7 +338,7 @@ func TestExtractModuleToResourceEdges_RealResourceRef(t *testing.T) {
 	t.Parallel()
 
 	// Direct resource references in a module input do produce edges.
-	// This case is rare today (Riley wiring uses module outputs), but
+	// This case is rare today (agent wiring uses module outputs), but
 	// the validator must not regress when typed-wiring edits land.
 	blocks := []ModuleBlock{
 		{

--- a/pkg/imported/aws/provider.go
+++ b/pkg/imported/aws/provider.go
@@ -292,8 +292,8 @@ func (p *Provider) CompareDrift(tfType string, snapshot, live imp.Attrs) []imp.F
 
 // AgentContext returns a one-line-per-IR summary sorted by Address.
 // Conservative format: `<address> (<type>)`. The downstream interactive
-// agent (Riley today) layers richer formatting on top; this is the
-// cross-cloud baseline.
+// agent layers richer formatting on top; this is the cross-cloud
+// baseline.
 //
 // Sort key is Identity.Address — sorting the formatted output strings
 // is equivalent today (since the format starts with the Address), but

--- a/pkg/imported/provider.go
+++ b/pkg/imported/provider.go
@@ -110,7 +110,7 @@ type Provider interface {
 	// one line per IR of the form "<address> (<type>)". Stable
 	// ordering across calls — sorted by Identity.Address.
 	//
-	// Agent-name-agnostic on purpose: the per-product naming
-	// (Riley today) can rotate without flipping the interface.
+	// Agent-name-agnostic on purpose: the per-product naming can rotate
+	// without flipping the interface.
 	AgentContext(irs []composerimported.ImportedResource) []string
 }

--- a/pkg/imported/types.go
+++ b/pkg/imported/types.go
@@ -53,9 +53,10 @@ type Attrs = json.RawMessage
 //     values an agent can author through normal chat / proposal
 //     flows). Agent-name-agnostic: the field reflects the policy
 //     surface, not which agent product is wired up downstream.
-//     The long-standing "Riley" naming on policy.VisibilityPolicy /
-//     EditPolicy constants is wire-format-pinned and rotates via a
-//     coordinated cross-repo rename, tracked separately.
+//     The long-standing per-product naming on policy.VisibilityPolicy /
+//     EditPolicy constants (e.g. VisibilityRileyVisible = "RileyVisible")
+//     is wire-format-pinned and rotates via a coordinated cross-repo
+//     rename, tracked separately (see #489).
 type Capabilities struct {
 	Discoverable     bool
 	Enrichable       bool

--- a/pkg/observability/extractors/extractors.go
+++ b/pkg/observability/extractors/extractors.go
@@ -229,7 +229,7 @@ func getFloat64(m map[string]any, key string) (float64, bool) {
 // full resource name. The GCP SDK returns fields like Instance.MachineType
 // (`https://www.googleapis.com/compute/v1/projects/foo/zones/us-central1-a/machineTypes/e2-medium`)
 // and Instance.Zone (`https://www.googleapis.com/compute/v1/projects/foo/zones/us-central1-a`)
-// as full URLs; what the UI and Riley actually want is the basename.
+// as full URLs; what the UI and the interactive agent actually want is the basename.
 //
 // Also works for Cloud Run / Memorystore service names
 // (`projects/foo/locations/us-central1/services/bar` → `bar`).


### PR DESCRIPTION
## Summary

In-repo doc-comment sweep for the Riley -> agent-agnostic rename
(issue #489). Replaces ~50 "Riley" / "riley" references in doc comments
across `pkg/`, `cmd/`, and `tests/` with context-appropriate
alternatives ("the interactive agent", "agent-visible", "agent-editable",
etc.) so the source reads as product-agnostic.

- 29 files touched, all doc-comment-only edits
- 0 Go identifier renames (no internal-only identifier needed renaming
  — every Go symbol carrying the "Riley" name is on the public wire)
- No exported API changes, no wire-format changes
- `go build ./...`, `go test ./... -short`, and `make verify-gen` all
  green
- Codegen subcommands (`gen`, `policy-ts`, `capabilities`,
  `drift-fields`, `labels`, `dependencies`) produce identical output —
  no generated `*.gen.go` or `*.policy.ts` testdata changed, as expected
  since none of the doc comments are emitted into generated artifacts

## Deferred (intentional, out of scope for this PR)

The following identifiers carry "Riley" in their name AND in their wire
value (TypeScript string constants in luthersystems/reliable consume
them), so renaming them in-repo would break downstream consumers. They
are explicitly left alone and tracked for a coordinated cross-repo
rename:

- `pkg/composer/imported/policy/axes.go::VisibilityRileyVisible
  VisibilityPolicy = "RileyVisible"` — TS consumers reference both the
  identifier and the string value
- `pkg/composer/imported/tier.go::SourceRiley Source = "riley"` —
  appears in serialized JSON (FieldEdit.Source) as `"riley"`
- The matching golden test data at
  `pkg/composer/imported/policy/testdata/known_paths.golden` and
  `cmd/imported-codegen/testdata/policy_ts/*.ts`, which embed the wire
  string `"RileyVisible"`
- The lint-error message in `lint.go` already updated; the test-case
  typo `"RileyVisable"` in `axes_test.go` is intentionally kept since
  it pins the typo-rejection test for the live wire-pinned const

Two doc-comment touches near the wire-pinned const explicitly call this
out so the next reader knows why those identifiers haven't moved
(`pkg/composer/imported/policy/axes.go::VisibilityRileyVisible`
godoc; `pkg/imported/types.go::Capabilities` godoc).

Refs #489