### PR TITLE
feat(imported): DriftSemantic Bundle D1 — first 5 policy files

### DIFF
--- a/cmd/imported-codegen/emit_drift_fields_test.go
+++ b/cmd/imported-codegen/emit_drift_fields_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -95,5 +96,43 @@ func TestBuildDriftFieldsMap_NoEmptySemanticEntries(t *testing.T) {
 				t.Errorf("%s: path %q has empty DriftSemantic (must be filtered out)", tfType, r.Path)
 			}
 		}
+	}
+}
+
+// TestRunDriftFields_GoldenFile pins the byte-for-byte contents of the
+// emitted drift-fields JSON against testdata/drift_fields/drift-fields.json.
+//
+// The golden is the canonical record of which curated fields participate
+// in drift detection — the downstream comparator + reliable UI both key
+// off this set. Adding or removing a DriftSemantic axis on any curated
+// FieldPolicy entry will fail this test; the right response is to
+// regenerate the golden and re-review:
+//
+//	go run ./cmd/imported-codegen drift-fields \
+//	    --output cmd/imported-codegen/testdata/drift_fields/drift-fields.json
+//
+// Bundle D1 (#491) seeded the golden with the first 5 curated types;
+// each follow-up bundle (D2..D9) will append entries and refresh the
+// golden via the command above.
+func TestRunDriftFields_GoldenFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "drift-fields.json")
+
+	if code := runDriftFields([]string{"--output", out}); code != 0 {
+		t.Fatalf("runDriftFields exit code = %d, want 0", code)
+	}
+
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read emitted: %v", err)
+	}
+	goldenPath := filepath.Join("testdata", "drift_fields", "drift-fields.json")
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden %s: %v — refresh via the doc-comment command above", goldenPath, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("emitted drift-fields.json drifts from %s — refresh the golden or fix the regression", goldenPath)
 	}
 }

--- a/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
+++ b/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
@@ -1,0 +1,624 @@
+{
+  "aws_dynamodb_table": [
+    {
+      "path": "arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "attribute.name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "attribute.type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "billing_mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "deletion_protection_enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "global_secondary_index.hash_key",
+      "semantic": "Exact"
+    },
+    {
+      "path": "global_secondary_index.name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "global_secondary_index.non_key_attributes",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "global_secondary_index.projection_type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "global_secondary_index.range_key",
+      "semantic": "Exact"
+    },
+    {
+      "path": "global_secondary_index.read_capacity",
+      "semantic": "Exact"
+    },
+    {
+      "path": "global_secondary_index.write_capacity",
+      "semantic": "Exact"
+    },
+    {
+      "path": "hash_key",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "local_secondary_index.name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "local_secondary_index.non_key_attributes",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "local_secondary_index.projection_type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "local_secondary_index.range_key",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "point_in_time_recovery.enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "range_key",
+      "semantic": "Exact"
+    },
+    {
+      "path": "read_capacity",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replica.arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replica.kms_key_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replica.point_in_time_recovery",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replica.propagate_tags",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replica.region_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replica.stream_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replica.stream_label",
+      "semantic": "Exact"
+    },
+    {
+      "path": "restore_date_time",
+      "semantic": "Exact"
+    },
+    {
+      "path": "restore_source_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "restore_source_table_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "restore_to_latest_time",
+      "semantic": "Exact"
+    },
+    {
+      "path": "server_side_encryption.enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "server_side_encryption.kms_key_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "stream_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "stream_enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "stream_label",
+      "semantic": "Exact"
+    },
+    {
+      "path": "stream_view_type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "table_class",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ttl.attribute_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ttl.enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "write_capacity",
+      "semantic": "Exact"
+    }
+  ],
+  "aws_lambda_function": [
+    {
+      "path": "architectures",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "code_signing_config_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "dead_letter_config.target_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ephemeral_storage.size",
+      "semantic": "Exact"
+    },
+    {
+      "path": "file_system_config.arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "file_system_config.local_mount_path",
+      "semantic": "Exact"
+    },
+    {
+      "path": "function_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "handler",
+      "semantic": "Exact"
+    },
+    {
+      "path": "image_config.command",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "image_config.entry_point",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "image_config.working_directory",
+      "semantic": "Exact"
+    },
+    {
+      "path": "invoke_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "kms_key_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "layers",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "logging_config.application_log_level",
+      "semantic": "Exact"
+    },
+    {
+      "path": "logging_config.log_format",
+      "semantic": "Exact"
+    },
+    {
+      "path": "logging_config.log_group",
+      "semantic": "Exact"
+    },
+    {
+      "path": "logging_config.system_log_level",
+      "semantic": "Exact"
+    },
+    {
+      "path": "memory_size",
+      "semantic": "Exact"
+    },
+    {
+      "path": "package_type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "publish",
+      "semantic": "Exact"
+    },
+    {
+      "path": "qualified_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "qualified_invoke_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replacement_security_group_ids",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "reserved_concurrent_executions",
+      "semantic": "Exact"
+    },
+    {
+      "path": "role",
+      "semantic": "Exact"
+    },
+    {
+      "path": "runtime",
+      "semantic": "Exact"
+    },
+    {
+      "path": "s3_bucket",
+      "semantic": "Exact"
+    },
+    {
+      "path": "s3_key",
+      "semantic": "Exact"
+    },
+    {
+      "path": "s3_object_version",
+      "semantic": "Exact"
+    },
+    {
+      "path": "snap_start.apply_on",
+      "semantic": "Exact"
+    },
+    {
+      "path": "timeout",
+      "semantic": "Exact"
+    },
+    {
+      "path": "tracing_config.mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "version",
+      "semantic": "Exact"
+    },
+    {
+      "path": "vpc_config.security_group_ids",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "vpc_config.subnet_ids",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "vpc_config.vpc_id",
+      "semantic": "Exact"
+    }
+  ],
+  "aws_s3_bucket": [
+    {
+      "path": "acceleration_status",
+      "semantic": "Exact"
+    },
+    {
+      "path": "acl",
+      "semantic": "Exact"
+    },
+    {
+      "path": "arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "bucket",
+      "semantic": "Exact"
+    },
+    {
+      "path": "bucket_domain_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "bucket_prefix",
+      "semantic": "Exact"
+    },
+    {
+      "path": "bucket_regional_domain_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "force_destroy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "hosted_zone_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "logging.target_bucket",
+      "semantic": "Exact"
+    },
+    {
+      "path": "logging.target_prefix",
+      "semantic": "Exact"
+    },
+    {
+      "path": "object_lock_configuration.object_lock_enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "object_lock_enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "policy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "region",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replication_configuration.role",
+      "semantic": "Exact"
+    },
+    {
+      "path": "request_payer",
+      "semantic": "Exact"
+    },
+    {
+      "path": "server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.kms_master_key_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm",
+      "semantic": "Exact"
+    },
+    {
+      "path": "server_side_encryption_configuration.rule.bucket_key_enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "versioning.enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "versioning.mfa_delete",
+      "semantic": "Exact"
+    },
+    {
+      "path": "website_domain",
+      "semantic": "Exact"
+    },
+    {
+      "path": "website_endpoint",
+      "semantic": "Exact"
+    }
+  ],
+  "google_pubsub_topic": [
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ingestion_data_source_settings.aws_kinesis.aws_role_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ingestion_data_source_settings.aws_kinesis.consumer_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ingestion_data_source_settings.aws_kinesis.gcp_service_account",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ingestion_data_source_settings.aws_kinesis.stream_arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ingestion_data_source_settings.cloud_storage.bucket",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ingestion_data_source_settings.cloud_storage.match_glob",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ingestion_data_source_settings.cloud_storage.minimum_object_create_time",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ingestion_data_source_settings.cloud_storage.text_format.delimiter",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ingestion_data_source_settings.platform_logs_settings.severity",
+      "semantic": "Exact"
+    },
+    {
+      "path": "kms_key_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "message_retention_duration",
+      "semantic": "Exact"
+    },
+    {
+      "path": "message_storage_policy.allowed_persistence_regions",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "schema_settings.encoding",
+      "semantic": "Exact"
+    },
+    {
+      "path": "schema_settings.schema",
+      "semantic": "Exact"
+    }
+  ],
+  "google_storage_bucket": [
+    {
+      "path": "autoclass.enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "cors.max_age_seconds",
+      "semantic": "Exact"
+    },
+    {
+      "path": "cors.method",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "cors.origin",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "cors.response_header",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "encryption.default_kms_key_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "force_destroy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "lifecycle_rule.action.storage_class",
+      "semantic": "Exact"
+    },
+    {
+      "path": "lifecycle_rule.action.type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "lifecycle_rule.condition.age",
+      "semantic": "Exact"
+    },
+    {
+      "path": "lifecycle_rule.condition.with_state",
+      "semantic": "Exact"
+    },
+    {
+      "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "logging.log_bucket",
+      "semantic": "Exact"
+    },
+    {
+      "path": "logging.log_object_prefix",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "public_access_prevention",
+      "semantic": "Exact"
+    },
+    {
+      "path": "requester_pays",
+      "semantic": "Exact"
+    },
+    {
+      "path": "retention_policy.is_locked",
+      "semantic": "Exact"
+    },
+    {
+      "path": "retention_policy.retention_period",
+      "semantic": "Exact"
+    },
+    {
+      "path": "rpo",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    },
+    {
+      "path": "soft_delete_policy.retention_duration_seconds",
+      "semantic": "Exact"
+    },
+    {
+      "path": "storage_class",
+      "semantic": "Exact"
+    },
+    {
+      "path": "uniform_bucket_level_access",
+      "semantic": "Exact"
+    },
+    {
+      "path": "url",
+      "semantic": "Exact"
+    },
+    {
+      "path": "versioning.enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "website.main_page_suffix",
+      "semantic": "Exact"
+    },
+    {
+      "path": "website.not_found_page",
+      "semantic": "Exact"
+    }
+  ]
+}

--- a/pkg/composer/imported/policy/aws_dynamodb_table.policy.go
+++ b/pkg/composer/imported/policy/aws_dynamodb_table.policy.go
@@ -23,35 +23,51 @@ package policy
 //   - google_storage_bucket.policy.go — older GCP reference
 //   - aws_dynamodb_table.gen.go — Layer 1 typed struct (every leaf
 //     enumerated here has a corresponding tf-tagged field there)
+//
+// Bundle D1 (#491): DriftSemantic axis is curated across all non-tag,
+// non-timeouts entries. Scalar attributes (ARNs, names, modes,
+// capacities, booleans) use DriftSemanticExact. The schema-shaped nested
+// blocks (`attribute`, `local_secondary_index`, `global_secondary_index`,
+// `replica`) are addressed as dotted leaves, not as whole lists — the
+// curator already enumerated the leaves and each one is a scalar; per-
+// leaf Exact compare is the right granularity (whole-list compare would
+// drop the per-field diff specificity).
 var awsDynamodbTablePolicy = Map{
 	// Identity ----------------------------------------------------------
 	"arn": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"id": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"name": {
 		// Table name is the primary key — changing it recreates the
 		// resource. The drift comparator depends on AlwaysReplace.
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"hash_key": {
 		// Partition key — part of the primary-key schema, recreate.
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"range_key": {
 		// Sort key — same recreate semantics as hash_key.
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"stream_arn": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"stream_label": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — capacity and storage ------------------------------------
@@ -59,65 +75,79 @@ var awsDynamodbTablePolicy = Map{
 		// Provisioned vs on-demand — reversible in-place. Riley should
 		// be able to propose the flip for cost optimization.
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"read_capacity": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"write_capacity": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"table_class": {
 		// STANDARD vs STANDARD_INFREQUENT_ACCESS — cost optimization knob.
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — backups and protection ----------------------------------
 	"point_in_time_recovery.enabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"deletion_protection_enabled": {
 		// Safety flag — Riley can propose flipping it, UI shows the change.
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// TTL --------------------------------------------------------------
 	"ttl.enabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ttl.attribute_name": {
 		// The TTL attribute name references a schema column — wiring,
 		// not a free-form tuning knob.
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Streams ----------------------------------------------------------
 	"stream_enabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"stream_view_type": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Server-side encryption -------------------------------------------
 	"server_side_encryption.enabled": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"server_side_encryption.kms_key_arn": {
 		// KMS key is a cross-resource wiring relationship — Riley edits
 		// the relationship, the composer's graph resolver owns the ARN.
+		// Exact equality: a different ARN is real security drift.
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeMayReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Attribute schema (primary-key + index column declarations) -------
@@ -125,11 +155,13 @@ var awsDynamodbTablePolicy = Map{
 	// range_key, GSI, or LSI. Schema changes force replacement.
 	"attribute.name": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"attribute.type": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Local secondary indexes (LSIs) -----------------------------------
@@ -137,20 +169,31 @@ var awsDynamodbTablePolicy = Map{
 	// after the fact — provider replaces the table.
 	"local_secondary_index.name": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditRequiresApproval,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"local_secondary_index.projection_type": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		Edit:          EditRequiresApproval,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"local_secondary_index.range_key": {
 		// LSI sort key references an `attribute.name` — wiring.
 		Role: RoleWiring, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"local_secondary_index.non_key_attributes": {
+		// List-valued non_key_attributes — order matters for the
+		// provider's diff and a per-element diff is not meaningfully
+		// scoped to a specific column, so compare the whole list.
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		Edit:          EditRequiresApproval,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 
 	// Global secondary indexes (GSIs) ----------------------------------
@@ -158,74 +201,98 @@ var awsDynamodbTablePolicy = Map{
 	// changes are heavier — gate behind RequiresApproval.
 	"global_secondary_index.name": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		Edit:          EditRequiresApproval,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"global_secondary_index.hash_key": {
 		Role: RoleWiring, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeMayReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"global_secondary_index.range_key": {
 		Role: RoleWiring, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeMayReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"global_secondary_index.projection_type": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		Edit:          EditRequiresApproval,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"global_secondary_index.non_key_attributes": {
+		// Same WholeList rationale as the LSI variant.
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		Edit:          EditRequiresApproval,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"global_secondary_index.read_capacity": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"global_secondary_index.write_capacity": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Replicas (multi-region tables) -----------------------------------
 	"replica.region_name": {
 		// Region selection is a cross-resource wiring decision.
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"replica.kms_key_arn": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"replica.point_in_time_recovery": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"replica.propagate_tags": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"replica.arn": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"replica.stream_arn": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"replica.stream_label": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Restore (write-once inputs at create) ----------------------------
 	"restore_source_table_arn": {
 		// Source table ARN is a cross-resource wiring reference.
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"restore_source_name": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"restore_date_time": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"restore_to_latest_time": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tags (system-managed bag) ----------------------------------------

--- a/pkg/composer/imported/policy/aws_lambda_function.policy.go
+++ b/pkg/composer/imported/policy/aws_lambda_function.policy.go
@@ -1,131 +1,200 @@
 package policy
 
+// awsLambdaFunctionPolicy curates Layer 2 for `aws_lambda_function`.
+//
+// Bundle D1 (#491): DriftSemantic axis is curated on every non-tag,
+// non-timeouts entry. Scalar attributes (ARNs, runtime/handler, memory
+// and timeout knobs) use DriftSemanticExact. List-valued attributes
+// (`layers`, `architectures`, `vpc_config.security_group_ids`,
+// `vpc_config.subnet_ids`, `replacement_security_group_ids`, the
+// image_config command/entry_point) use DriftSemanticWholeList — order
+// is provider-visible and the per-element shape is opaque scalars, so
+// whole-list compare is the meaningful granularity. The sensitive
+// `environment.variables` map stays DriftSemanticNone: per the Layer 2
+// contract, raw values for Sensitive fields must never flow through the
+// drift output (FieldMismatch.Snapshot / .Cloud would leak the secret).
 var awsLambdaFunctionPolicy = Map{
 	// Identity
-	"arn":                  {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"function_name":        {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"version":              {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"qualified_arn":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"invoke_arn":           {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"qualified_invoke_arn": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"arn": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"function_name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"version": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"qualified_arn": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"invoke_arn": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"qualified_invoke_arn": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 
 	// Wiring — required role and supporting cross-references
 	"role": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"kms_key_arn": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"code_signing_config_arn": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"dead_letter_config.target_arn": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"file_system_config.arn": {
 		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"file_system_config.local_mount_path": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"logging_config.log_group": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"vpc_config.security_group_ids": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"vpc_config.subnet_ids": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"vpc_config.vpc_id": {
 		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"layers": {
 		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"replacement_security_group_ids": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"s3_bucket": {
 		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"s3_key": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"s3_object_version": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — runtime configuration
 	"runtime": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"handler": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"memory_size": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"timeout": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"architectures": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
-		ChangeRisk: ChangeMayReplace,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"package_type": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"reserved_concurrent_executions": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"publish": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — nested blocks
 	"ephemeral_storage.size": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"tracing_config.mode": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"snap_start.apply_on": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"image_config.command": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"image_config.entry_point": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"image_config.working_directory": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"logging_config.application_log_level": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"logging_config.system_log_level": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"logging_config.log_format": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Sensitive: environment variables routinely contain credentials.
 	// Hidden from Riley; only system code reads/writes them.
+	//
+	// DriftSemantic stays None: drift output carries raw Snapshot/Cloud
+	// values, and Sensitive values must not flow through that channel.
+	// Once the drift surface gains a redaction mode (axes.go follow-up),
+	// this can move to a redacted-LabelFilter or similar.
 	"environment.variables": {
 		Role: RoleTuning, Pillar: PillarSecurity,
-		Visibility: VisibilityHidden, Edit: EditSystemOnly,
+		Visibility:  VisibilityHidden,
+		Edit:        EditSystemOnly,
 		Sensitivity: SensitivitySensitive,
 	},
 

--- a/pkg/composer/imported/policy/aws_s3_bucket.policy.go
+++ b/pkg/composer/imported/policy/aws_s3_bucket.policy.go
@@ -17,119 +17,163 @@ package policy
 // to surface the recreate-vs-update warning. `bucket_prefix` shares
 // that semantic (Terraform picks one or the other; either way changing
 // it forces replacement).
+//
+// Bundle D1 (#491): DriftSemantic axis is curated on every non-tag,
+// non-timeouts entry. Identity ARNs / IDs use Exact equality so a
+// renamed-out-of-band bucket still surfaces. Configurable scalars use
+// Exact; the cross-resource wiring leaves (KMS key ARN, target bucket,
+// replication role) also use Exact — a value diff there is real drift,
+// not provider noise. Tag bags stay DriftSemanticNone (tagPolicy() zero
+// value) because they're system-managed.
 var awsS3BucketPolicy = Map{
 	// Identity ----------------------------------------------------------
 	"arn": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"bucket": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"bucket_prefix": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"id": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"region": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"bucket_domain_name": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"bucket_regional_domain_name": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"hosted_zone_id": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"website_domain": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"website_endpoint": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — top-level knobs -----------------------------------------
 	"acceleration_status": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"acl": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"force_destroy": {
 		// Destructive flag — UI-visible so the management view shows it,
 		// but only system code (the importer + composer) writes it.
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditSystemOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"object_lock_enabled": {
 		// Top-level boolean — set once at bucket creation; flipping it
 		// after the fact requires replacement.
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"request_payer": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — bucket policy doc ---------------------------------------
 	"policy": {
 		// IAM-style JSON document. Riley can propose changes but apply
-		// requires explicit approval against the diff.
+		// requires explicit approval against the diff. Exact comparison
+		// here means whitespace / key-order changes from the provider's
+		// canonicalization will surface; that's intentional, the diff
+		// screen renders the doc with structural diff.
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Versioning --------------------------------------------------------
 	"versioning.enabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"versioning.mfa_delete": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Logging -----------------------------------------------------------
 	"logging.target_bucket": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"logging.target_prefix": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Object lock -------------------------------------------------------
 	"object_lock_configuration.object_lock_enabled": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		Edit:          EditRequiresApproval,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Replication -------------------------------------------------------
 	"replication_configuration.role": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Server-side encryption -------------------------------------------
 	"server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.kms_master_key_id": {
+		// KMS key ARN is a scalar identifier — Exact equality. A diff
+		// here means the bucket's default encryption key changed out of
+		// band, which is a real security signal.
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeMayReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"server_side_encryption_configuration.rule.bucket_key_enabled": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tags (system-managed bag) ----------------------------------------
+	// DriftSemantic stays None — tag drift is provider noise; the diff
+	// surface filters tags at a higher layer.
 	"tags":     tagPolicy(),
 	"tags_all": tagPolicy(),
 }

--- a/pkg/composer/imported/policy/google_pubsub_topic.policy.go
+++ b/pkg/composer/imported/policy/google_pubsub_topic.policy.go
@@ -1,65 +1,97 @@
 package policy
 
+// googlePubsubTopicPolicy curates Layer 2 for `google_pubsub_topic`.
+//
+// Bundle D1 (#491): DriftSemantic axis is curated on every non-tag,
+// non-timeouts entry. Scalars use DriftSemanticExact. The single
+// list-valued tuning leaf, `message_storage_policy.allowed_persistence_regions`,
+// uses DriftSemanticWholeList — the provider returns the residency
+// regions in an authored order and a whole-list diff is the meaningful
+// signal. Labels stay at the tagPolicy() default (DriftSemanticNone);
+// LabelFilter coverage on user-author labels is deferred until the
+// drift comparator's redacted-mode output is in place (axes.go
+// follow-up referenced in aws_lambda_function).
 var googlePubsubTopicPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — encryption + ingestion data sources
 	"kms_key_name": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ingestion_data_source_settings.aws_kinesis.aws_role_arn": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ingestion_data_source_settings.aws_kinesis.consumer_arn": {
 		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ingestion_data_source_settings.aws_kinesis.gcp_service_account": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ingestion_data_source_settings.aws_kinesis.stream_arn": {
 		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ingestion_data_source_settings.cloud_storage.bucket": {
 		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"schema_settings.schema": {
 		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"message_retention_duration": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"message_storage_policy.allowed_persistence_regions": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"schema_settings.encoding": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ingestion_data_source_settings.cloud_storage.match_glob": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ingestion_data_source_settings.cloud_storage.minimum_object_create_time": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ingestion_data_source_settings.cloud_storage.text_format.delimiter": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ingestion_data_source_settings.platform_logs_settings.severity": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
-	// Labels — system-owned.
+	// Labels — system-owned. DriftSemantic deferred (see file comment).
 	"labels":           tagPolicy(),
 	"effective_labels": tagPolicy(),
 	"terraform_labels": tagPolicy(),

--- a/pkg/composer/imported/policy/google_storage_bucket.policy.go
+++ b/pkg/composer/imported/policy/google_storage_bucket.policy.go
@@ -1,110 +1,168 @@
 package policy
 
+// googleStorageBucketPolicy curates Layer 2 for `google_storage_bucket`.
+//
+// Bundle D1 (#491): DriftSemantic axis is curated on every non-tag,
+// non-timeouts entry. Scalars (name, project, location, storage_class,
+// encryption KMS key, etc.) use DriftSemanticExact. The CORS and
+// lifecycle leaves enumerated here are flat scalars within the
+// repeated block — per-leaf Exact is the right granularity, matching
+// the pattern used by aws_dynamodb_table for repeated-block leaves.
+// The label maps use the tagPolicy() default (DriftSemanticNone) — the
+// label-bag drift problem (filtering goog-*) is handled at a higher
+// surface; per-field LabelFilter on `labels` is the natural next step
+// when we promote label drift detection into the comparator, and is
+// deferred to a follow-up.
 var googleStorageBucketPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"url":       {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"url": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"location": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring (encryption + cross-bucket logging target)
 	"encryption.default_kms_key_name": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"logging.log_bucket": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"logging.log_object_prefix": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — class and access
 	"storage_class": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"force_destroy": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"requester_pays": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"uniform_bucket_level_access": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"public_access_prevention": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		Edit:          EditRequiresApproval,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — versioning, lifecycle, retention
 	"versioning.enabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"lifecycle_rule.action.type": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"lifecycle_rule.action.storage_class": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"lifecycle_rule.condition.age": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"lifecycle_rule.condition.with_state": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"retention_policy.retention_period": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"retention_policy.is_locked": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		Edit:          EditRequiresApproval,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"soft_delete_policy.retention_duration_seconds": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
-	// CORS
+	// CORS — `cors.method`, `cors.origin`, `cors.response_header` are
+	// list-shaped leaves on each cors block; whole-list compare keeps
+	// the ordering signal.
 	"cors.method": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"cors.origin": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"cors.response_header": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"cors.max_age_seconds": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Website + autoclass + rpo
 	"website.main_page_suffix": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"website.not_found_page": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"autoclass.enabled": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"rpo": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
-	// Labels — uniformly system-owned.
+	// Labels — uniformly system-owned. DriftSemantic stays None for
+	// now (tagPolicy() default); the goog-* filtering needed for GCP
+	// label drift is exercised via DriftSemanticLabelFilter on policies
+	// that have a curated label-drift signal.
 	"labels":           tagPolicy(),
 	"effective_labels": tagPolicy(),
 	"terraform_labels": tagPolicy(),

--- a/pkg/drift/imported/compare_curated_test.go
+++ b/pkg/drift/imported/compare_curated_test.go
@@ -1,0 +1,272 @@
+package imported
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Bundle D1 (#491) curated-policy fixture tests.
+//
+// These tests exercise the production policy.Map entries registered for
+// the five tfTypes in the bundle, end-to-end through Compare(). Each
+// test asserts a *useful* drift signal: a single fixture-driven scalar
+// diff under a curated path, plus the absence of a signal for
+// uncurated or DriftSemanticNone fields.
+//
+// The fixtures live inline rather than under testdata/ — the inputs are
+// small enough that inlining keeps the cause/effect of each subtest
+// visible to a reviewer without a cross-file jump. If a future bundle
+// grows large fixtures, promote them to testdata/<tfType>.snap.json
+// alongside this file.
+
+// fieldsByPath projects a []FieldMismatch to a map keyed by Field for
+// O(1) assertion lookups in the subtests. The Compare contract already
+// sorts by Field, so the projection is order-independent.
+func fieldsByPath(t *testing.T, got []FieldMismatch) map[string]FieldMismatch {
+	t.Helper()
+	out := make(map[string]FieldMismatch, len(got))
+	for _, m := range got {
+		if _, dup := out[m.Field]; dup {
+			t.Fatalf("Compare returned duplicate field %q — sort/dispatch bug?", m.Field)
+		}
+		out[m.Field] = m
+	}
+	return out
+}
+
+// TestCompare_Curated_AWSS3Bucket exercises the curated drift surface
+// for aws_s3_bucket: a versioning flip and a server-side-encryption
+// algorithm change must surface as Exact mismatches; tag drift must
+// stay invisible (tagPolicy() leaves DriftSemantic=None).
+func TestCompare_Curated_AWSS3Bucket(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"arn": "arn:aws:s3:::my-bucket",
+		"bucket": "my-bucket",
+		"versioning": {"enabled": true, "mfa_delete": false},
+		"server_side_encryption_configuration": {
+			"rule": {
+				"apply_server_side_encryption_by_default": {
+					"sse_algorithm": "aws:kms",
+					"kms_master_key_id": "arn:aws:kms:us-east-1:111:key/abc"
+				},
+				"bucket_key_enabled": true
+			}
+		},
+		"tags": {"team": "infra"}
+	}`)
+	live := json.RawMessage(`{
+		"arn": "arn:aws:s3:::my-bucket",
+		"bucket": "my-bucket",
+		"versioning": {"enabled": false, "mfa_delete": false},
+		"server_side_encryption_configuration": {
+			"rule": {
+				"apply_server_side_encryption_by_default": {
+					"sse_algorithm": "AES256",
+					"kms_master_key_id": "arn:aws:kms:us-east-1:111:key/abc"
+				},
+				"bucket_key_enabled": true
+			}
+		},
+		"tags": {"team": "platform"}
+	}`)
+	got := Compare("aws_s3_bucket", snap, live)
+	idx := fieldsByPath(t, got)
+
+	if _, ok := idx["versioning.enabled"]; !ok {
+		t.Errorf("expected versioning.enabled mismatch; got fields: %v", keysOf(idx))
+	} else {
+		assert.Equal(t, true, idx["versioning.enabled"].Snapshot)
+		assert.Equal(t, false, idx["versioning.enabled"].Cloud)
+	}
+	if _, ok := idx["server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm"]; !ok {
+		t.Errorf("expected sse_algorithm mismatch; got fields: %v", keysOf(idx))
+	}
+	// tags drift must NOT appear — tagPolicy() leaves DriftSemantic=None.
+	if _, ok := idx["tags"]; ok {
+		t.Error("tag drift must stay invisible (tagPolicy keeps DriftSemantic=None)")
+	}
+}
+
+// TestCompare_Curated_AWSDynamoDBTable exercises capacity scaling and a
+// WholeList diff on a GSI's non_key_attributes.
+func TestCompare_Curated_AWSDynamoDBTable(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"arn": "arn:aws:dynamodb:us-east-1:111:table/Users",
+		"name": "Users",
+		"billing_mode": "PROVISIONED",
+		"read_capacity": 5,
+		"write_capacity": 5,
+		"point_in_time_recovery": {"enabled": true},
+		"global_secondary_index": {
+			"name": "EmailIdx",
+			"hash_key": "email",
+			"projection_type": "INCLUDE",
+			"non_key_attributes": ["created_at", "status"]
+		}
+	}`)
+	live := json.RawMessage(`{
+		"arn": "arn:aws:dynamodb:us-east-1:111:table/Users",
+		"name": "Users",
+		"billing_mode": "PROVISIONED",
+		"read_capacity": 25,
+		"write_capacity": 5,
+		"point_in_time_recovery": {"enabled": true},
+		"global_secondary_index": {
+			"name": "EmailIdx",
+			"hash_key": "email",
+			"projection_type": "INCLUDE",
+			"non_key_attributes": ["created_at", "status", "team"]
+		}
+	}`)
+	got := Compare("aws_dynamodb_table", snap, live)
+	idx := fieldsByPath(t, got)
+
+	if m, ok := idx["read_capacity"]; !ok {
+		t.Errorf("expected read_capacity mismatch; got fields: %v", keysOf(idx))
+	} else {
+		// JSON numbers decode to float64.
+		assert.Equal(t, float64(5), m.Snapshot)
+		assert.Equal(t, float64(25), m.Cloud)
+	}
+	gsiNKA, ok := idx["global_secondary_index.non_key_attributes"]
+	require.True(t, ok, "expected non_key_attributes WholeList mismatch")
+	assert.IsType(t, []any{}, gsiNKA.Snapshot,
+		"WholeList output must be a []any, not a raw object")
+	assert.IsType(t, []any{}, gsiNKA.Cloud)
+}
+
+// TestCompare_Curated_AWSLambdaFunction covers an Exact mismatch on
+// memory_size, a WholeList mismatch on layers (ordered list of
+// versioned ARNs), and confirms environment.variables stays out of the
+// drift output (Sensitive must not leak).
+func TestCompare_Curated_AWSLambdaFunction(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"arn": "arn:aws:lambda:us-east-1:111:function:fn",
+		"function_name": "fn",
+		"runtime": "nodejs20.x",
+		"memory_size": 512,
+		"timeout": 30,
+		"layers": ["arn:aws:lambda:us-east-1:111:layer:libA:3", "arn:aws:lambda:us-east-1:111:layer:libB:1"],
+		"environment": {"variables": {"API_KEY": "super-secret"}}
+	}`)
+	live := json.RawMessage(`{
+		"arn": "arn:aws:lambda:us-east-1:111:function:fn",
+		"function_name": "fn",
+		"runtime": "nodejs20.x",
+		"memory_size": 1024,
+		"timeout": 30,
+		"layers": ["arn:aws:lambda:us-east-1:111:layer:libA:4", "arn:aws:lambda:us-east-1:111:layer:libB:1"],
+		"environment": {"variables": {"API_KEY": "different-secret"}}
+	}`)
+	got := Compare("aws_lambda_function", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "memory_size")
+	assert.Equal(t, float64(512), idx["memory_size"].Snapshot)
+	assert.Equal(t, float64(1024), idx["memory_size"].Cloud)
+
+	require.Contains(t, idx, "layers")
+	assert.IsType(t, []any{}, idx["layers"].Snapshot)
+
+	// environment.variables must NOT appear — Sensitive must not flow
+	// through drift output.
+	assert.NotContains(t, idx, "environment.variables",
+		"Sensitive environment.variables must not appear in drift output")
+}
+
+// TestCompare_Curated_GoogleStorageBucket covers an Exact mismatch on
+// uniform_bucket_level_access and a WholeList mismatch on cors.origin
+// (whose ordering matters for the provider's diff).
+func TestCompare_Curated_GoogleStorageBucket(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"name": "my-bucket",
+		"location": "US",
+		"storage_class": "STANDARD",
+		"uniform_bucket_level_access": true,
+		"versioning": {"enabled": true},
+		"cors": {
+			"method": ["GET", "HEAD"],
+			"origin": ["https://app.example.com"],
+			"max_age_seconds": 3600
+		},
+		"labels": {"env": "prod", "goog-managed-by": "tf"}
+	}`)
+	live := json.RawMessage(`{
+		"name": "my-bucket",
+		"location": "US",
+		"storage_class": "STANDARD",
+		"uniform_bucket_level_access": false,
+		"versioning": {"enabled": true},
+		"cors": {
+			"method": ["GET", "HEAD"],
+			"origin": ["https://app.example.com", "https://admin.example.com"],
+			"max_age_seconds": 3600
+		},
+		"labels": {"env": "prod", "goog-managed-by": "tf"}
+	}`)
+	got := Compare("google_storage_bucket", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "uniform_bucket_level_access")
+	assert.Equal(t, true, idx["uniform_bucket_level_access"].Snapshot)
+	assert.Equal(t, false, idx["uniform_bucket_level_access"].Cloud)
+
+	require.Contains(t, idx, "cors.origin")
+	assert.IsType(t, []any{}, idx["cors.origin"].Snapshot)
+
+	// `labels` uses tagPolicy() → DriftSemantic=None → never emitted.
+	assert.NotContains(t, idx, "labels")
+}
+
+// TestCompare_Curated_GooglePubsubTopic covers an Exact mismatch on
+// message_retention_duration and a WholeList mismatch on
+// message_storage_policy.allowed_persistence_regions.
+func TestCompare_Curated_GooglePubsubTopic(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"name": "projects/p/topics/orders",
+		"project": "p",
+		"message_retention_duration": "604800s",
+		"message_storage_policy": {
+			"allowed_persistence_regions": ["us-central1", "us-east1"]
+		},
+		"kms_key_name": "projects/p/locations/global/keyRings/r/cryptoKeys/k"
+	}`)
+	live := json.RawMessage(`{
+		"name": "projects/p/topics/orders",
+		"project": "p",
+		"message_retention_duration": "86400s",
+		"message_storage_policy": {
+			"allowed_persistence_regions": ["us-east1"]
+		},
+		"kms_key_name": "projects/p/locations/global/keyRings/r/cryptoKeys/k"
+	}`)
+	got := Compare("google_pubsub_topic", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "message_retention_duration")
+	assert.Equal(t, "604800s", idx["message_retention_duration"].Snapshot)
+	assert.Equal(t, "86400s", idx["message_retention_duration"].Cloud)
+
+	require.Contains(t, idx, "message_storage_policy.allowed_persistence_regions")
+	assert.IsType(t, []any{}, idx["message_storage_policy.allowed_persistence_regions"].Snapshot)
+
+	// kms_key_name is identical on both sides → not in drift output.
+	assert.NotContains(t, idx, "kms_key_name")
+}
+
+// keysOf returns the sorted key set of m for diagnostic logging.
+func keysOf(m map[string]FieldMismatch) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Bundle D1 of issue #491 — curate the `DriftSemantic` axis on the first 5 of 42 `.policy.go` files under `pkg/composer/imported/policy/`. With these changes the `pkg/drift/imported.Compare` engine produces meaningful `FieldMismatch` output for the curated types (previously every type returned nil because no entry had a non-empty `DriftSemantic`).

## Files curated in this bundle

- `aws_s3_bucket.policy.go` — `Exact` across all leaves
- `aws_dynamodb_table.policy.go` — `Exact` + `WholeList` on `global_secondary_index.non_key_attributes` and `local_secondary_index.non_key_attributes`
- `aws_lambda_function.policy.go` — `Exact` + `WholeList` on `layers`, `architectures`, `vpc_config.security_group_ids`, `vpc_config.subnet_ids`, `replacement_security_group_ids`, `image_config.command`, `image_config.entry_point`. The sensitive `environment.variables` field stays `None` — raw secret values must not flow through `FieldMismatch.Snapshot/.Cloud`.
- `google_storage_bucket.policy.go` — `Exact` + `WholeList` on `cors.method`, `cors.origin`, `cors.response_header`
- `google_pubsub_topic.policy.go` — `Exact` + `WholeList` on `message_storage_policy.allowed_persistence_regions`

Label/tag-bag fields (`labels`, `effective_labels`, `terraform_labels`, `tags`, `tags_all`) keep the `tagPolicy()` default (`DriftSemanticNone`). `timeouts` keeps the `timeoutsPolicy()` default. Label-bag drift handled via `DriftSemanticLabelFilter` is deferred until the drift comparator gains a redacted-output mode (axes.go follow-up referenced inline).

## Tests

- `pkg/drift/imported/compare_curated_test.go` — five new fixture-driven tests (one per file) that drive the production `Compare(<tfType>, snap, live)` path and assert:
  - the expected drift fields appear with the correct semantic shape (scalar `Exact` vs `[]any` `WholeList`)
  - tag/sensitive fields stay invisible
  - matching values do not appear in output
- `cmd/imported-codegen/emit_drift_fields_test.go` — new byte-for-byte golden gate against `testdata/drift_fields/drift-fields.json`. The golden is the canonical record of which curated fields participate in drift detection; refresh procedure documented in the test's doc-comment.

All 387 tests in `pkg/composer/imported/policy/...`, `pkg/drift/imported/...`, `cmd/imported-codegen/...` pass; full `go test ./...` is green (5262 tests).

## Bundle progress for #491

The issue covers all 42 `.policy.go` files at ~5 files per bundle. Remaining bundles (37 files):

- [ ] **D2** — AWS: `aws_cloudwatch_log_group`, `aws_secretsmanager_secret`, `aws_sqs_queue`; GCP: `google_secret_manager_secret`, `google_service_account`
- [ ] **D3** — GCP compute (1): `google_compute_address`, `google_compute_global_address`, `google_compute_firewall`, `google_compute_network`, `google_compute_router`
- [ ] **D4** — GCP compute (2): `google_compute_forwarding_rule`, `google_compute_global_forwarding_rule`, `google_compute_url_map`, `google_compute_target_https_proxy`, `google_compute_security_policy`
- [ ] **D5** — GCP compute (3) + KMS: `google_compute_instance`, `google_kms_key_ring`, `google_kms_crypto_key`, `google_container_cluster`, `google_container_node_pool`
- [ ] **D6** — GCP API gateway + Cloud Run/Build: `google_api_gateway_api`, `google_api_gateway_api_config`, `google_api_gateway_gateway`, `google_cloud_run_v2_service`, `google_cloudbuild_trigger`
- [ ] **D7** — GCP functions / datastores: `google_cloudfunctions2_function`, `google_firestore_database`, `google_identity_platform_config`, `google_sql_database_instance`, `google_sql_user`
- [ ] **D8** — GCP monitoring/logging: `google_logging_project_sink`, `google_monitoring_alert_policy`, `google_monitoring_dashboard`, `google_monitoring_notification_channel`, `google_pubsub_subscription`
- [ ] **D9** — GCP misc tail: `google_redis_instance`, `google_vertex_ai_dataset` (only 2 files — final bundle is short)

Refs #491