### PR TITLE
feat(awsdiscover): aws_s3_bucket enricher

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -201,14 +201,17 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 		// follows the existing per-type ordering one PR at a time. Mirrors
 		// gcpdiscover.GCPDiscoverer (presets#403).
 		//
-		// aws_s3_bucket follows once presets bundle #461 lands the Layer
-		// 1 typed struct in pkg/composer/imported/generated. The S3
-		// enricher infrastructure (EnrichClients.S3 field, codegen
-		// support) is in place already so the wiring there is a one-line
-		// registration.
+		// (#493) S3 enricher landed: aws_s3_bucket is wired below via
+		// newS3BucketEnricher(). The hand-rolled enricher is the
+		// reliable path; once the Cloud Control unified enricher (#490)
+		// proves out S3 coverage, this registration can flip to the
+		// unified path and s3_bucket_enrich.go can be retired (the
+		// framework preserves the override capability for any per-type
+		// quirk the unified path doesn't model).
 		byTypeEnricher: map[string]AttributeEnricher{
 			"aws_cloudwatch_log_group":  newCloudWatchLogGroupEnricher(),
 			"aws_dynamodb_table":        newDynamoDBTableEnricher(),
+			"aws_s3_bucket":             newS3BucketEnricher(),
 			"aws_secretsmanager_secret": newSecretsManagerSecretEnricher(),
 		},
 	}

--- a/cmd/insideout-import/awsdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/awsdiscover/byid_enricher_test.go
@@ -53,7 +53,7 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 	// implement ByIDEnricher. When adding a new enricher: bump
 	// wantTotal and either add to allowlist (no ByIDEnricher) or leave
 	// it off (implements ByIDEnricher).
-	const wantTotal = 3 // dynamodb_table + cloudwatch_log_group + secretsmanager_secret
+	const wantTotal = 4 // dynamodb_table + cloudwatch_log_group + secretsmanager_secret + s3_bucket
 	if got := len(d.byTypeEnricher); got != wantTotal {
 		t.Errorf("byTypeEnricher size = %d, want %d (production registration drifted from test)", got, wantTotal)
 	}

--- a/cmd/insideout-import/awsdiscover/s3_bucket_enrich.go
+++ b/cmd/insideout-import/awsdiscover/s3_bucket_enrich.go
@@ -1,0 +1,738 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// s3BucketTFType is the registered Terraform type for the S3 bucket
+// enricher. Kept as a constant so the registry / ResourceType() stay
+// in lockstep.
+const s3BucketTFType = "aws_s3_bucket"
+
+// s3BucketEnricher implements both AttributeEnricher and ByIDEnricher
+// for aws_s3_bucket (#493). Pairs with the Cloud-Control-routed S3
+// bucket discoverer registered in cloudControlTypeConfigs.
+//
+// **Multi-source overlay**: S3 has the largest overlay surface in the
+// AWS-side enricher family — a single GetBucket* call returns only one
+// configuration sub-resource at a time, so populating the typed
+// AWSS3Bucket payload aggregates ~10 SDK calls (HeadBucket for
+// existence/region, plus one Get* per configurable block). Following
+// the dynamodb_table multi-overlay pattern, each overlay has its own
+// function-field hook so tests can inject failures per sub-resource
+// without spinning up a fake HTTP server. The load-bearing call is
+// HeadBucket: if the bucket does not exist or we can't see it,
+// nothing else matters and Enrich fails fast. Every other Get*
+// failure is downgraded — we emit whatever succeeded.
+//
+// **Soft-fail discipline**: per the issue's "more specific about
+// which error codes mean 'not configured'" guidance, we use
+// isS3NotSetError (sdkonly_helpers.go) to distinguish the service-
+// native "feature not configured" codes (NoSuchBucketPolicy,
+// NoSuchCorsConfiguration, NoSuchLifecycleConfiguration,
+// ServerSideEncryptionConfigurationNotFoundError, NoSuchTagSet,
+// NoSuchWebsiteConfiguration, ObjectLockConfigurationNotFoundError)
+// from real failures (AccessDenied, ThrottlingException, service
+// outage). The two are handled identically at the typed-payload
+// level (the block is omitted), but the distinction is preserved so
+// future work could route real failures through a per-resource warn
+// list. Today both shapes downgrade silently.
+//
+// **#490 follow-up**: the issue's "Alternative" section notes that
+// the Cloud Control unified enricher (#490) could collapse this
+// hand-rolled file into a 0-line override once Cloud Control proves
+// out for S3. This file stays as the reliable path until that lands;
+// after #490, the registration in NewAWSDiscoverer can flip to the
+// unified enricher and this file can be retired (the framework
+// preserves the override capability for any per-type quirk the
+// unified path doesn't model).
+//
+// Sensitive fields: none on this resource (the bucket policy lives
+// in the `policy` field as a JSON document — decision #36 redaction
+// is downstream's concern).
+type s3BucketEnricher struct {
+	// fetchHead is the load-bearing existence probe. Returns the
+	// HeadBucket response (carries BucketRegion when the SDK auto-
+	// discovers the bucket's region) or an error. A typed NotFound /
+	// NoSuchBucket is wrapped as ErrNotFound at the call site; other
+	// errors bubble up unchanged. Overridable for tests.
+	fetchHead func(ctx context.Context, c *s3.Client, bucket string) (*s3.HeadBucketOutput, error)
+
+	// All fetch* hooks below are best-effort overlays. Each returns
+	// (response, nil) when the sub-resource is configured, (nil, nil)
+	// when the service-native "not set" code is observed, and (nil,
+	// err) for any other failure. The Enrich path treats both nil
+	// responses and real errors as "block omitted" — see soft-fail
+	// discipline note above for the rationale.
+	fetchEncryption func(ctx context.Context, c *s3.Client, bucket string) (*s3types.ServerSideEncryptionConfiguration, error)
+	fetchVersioning func(ctx context.Context, c *s3.Client, bucket string) (*s3.GetBucketVersioningOutput, error)
+	fetchLifecycle  func(ctx context.Context, c *s3.Client, bucket string) ([]s3types.LifecycleRule, error)
+	fetchLogging    func(ctx context.Context, c *s3.Client, bucket string) (*s3types.LoggingEnabled, error)
+	fetchCors       func(ctx context.Context, c *s3.Client, bucket string) ([]s3types.CORSRule, error)
+	fetchPolicy     func(ctx context.Context, c *s3.Client, bucket string) (*string, error)
+	fetchWebsite    func(ctx context.Context, c *s3.Client, bucket string) (*s3.GetBucketWebsiteOutput, error)
+	fetchTags       func(ctx context.Context, c *s3.Client, bucket string) ([]s3types.Tag, error)
+	fetchObjectLock func(ctx context.Context, c *s3.Client, bucket string) (*s3types.ObjectLockConfiguration, error)
+}
+
+// newS3BucketEnricher returns the production-wired enricher.
+// AWSDiscoverer's byTypeEnricher map registers this under "aws_s3_bucket".
+func newS3BucketEnricher() *s3BucketEnricher {
+	return &s3BucketEnricher{
+		fetchHead:       defaultS3BucketFetchHead,
+		fetchEncryption: defaultS3BucketFetchEncryption,
+		fetchVersioning: defaultS3BucketFetchVersioning,
+		fetchLifecycle:  defaultS3BucketFetchLifecycle,
+		fetchLogging:    defaultS3BucketFetchLogging,
+		fetchCors:       defaultS3BucketFetchCors,
+		fetchPolicy:     defaultS3BucketFetchPolicy,
+		fetchWebsite:    defaultS3BucketFetchWebsite,
+		fetchTags:       defaultS3BucketFetchTags,
+		fetchObjectLock: defaultS3BucketFetchObjectLock,
+	}
+}
+
+func (s3BucketEnricher) ResourceType() string { return s3BucketTFType }
+
+// Enrich populates ir.Attrs with a typed AWSS3Bucket payload for the
+// bucket identified by ir.Identity. Returns ErrEnrichClientUnavailable
+// if EnrichClients.S3 is nil; ErrNotFound if HeadBucket reports the
+// bucket as missing; any other error reflects a real S3 API failure
+// on the load-bearing HeadBucket call. Per-block overlay failures
+// (encryption / versioning / lifecycle / logging / cors / policy /
+// website / tags / object_lock) are downgraded to omitted blocks —
+// the resource is still emitted with whatever succeeded.
+func (e s3BucketEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if c.S3 == nil {
+		return ErrEnrichClientUnavailable
+	}
+	bucket := s3BucketNameForEnrich(&ir.Identity)
+	if bucket == "" {
+		return fmt.Errorf("s3_bucket: cannot derive bucket name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			ir.Identity.Address, ir.Identity.ImportID, ir.Identity.NameHint)
+	}
+
+	typed, err := e.fetchAndMap(ctx, c.S3, bucket)
+	if err != nil {
+		return err
+	}
+
+	// Stamp ARN + region onto Identity.NativeIDs so downstream
+	// consumers don't have to round-trip back to the SDK. The pure-
+	// mapping helper does not touch ir.Identity per the
+	// AttributeEnricher contract; this is the only place the enricher
+	// writes to it.
+	if typed.ARN != nil && typed.ARN.Literal != nil && *typed.ARN.Literal != "" {
+		if ir.Identity.NativeIDs == nil {
+			ir.Identity.NativeIDs = map[string]string{}
+		}
+		ir.Identity.NativeIDs["arn"] = *typed.ARN.Literal
+	}
+	if typed.Region != nil && typed.Region.Literal != nil && *typed.Region.Literal != "" {
+		if ir.Identity.NativeIDs == nil {
+			ir.Identity.NativeIDs = map[string]string{}
+		}
+		ir.Identity.NativeIDs["region"] = *typed.Region.Literal
+	}
+
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return fmt.Errorf("s3_bucket: marshal Attrs: %w", err)
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID fetches the typed AWSS3Bucket payload for the bucket
+// named by identity and returns it as the json.RawMessage shape that
+// would land in ImportedResource.Attrs. Shares the SDK call + mapping
+// with Enrich via the private fetchAndMap helper so the two paths
+// cannot drift out of sync. Does not mutate identity — the ARN /
+// region that Enrich stamps onto NativeIDs is intentionally NOT
+// stamped here, since the per-IR drift refresh path expects the
+// identity to be authoritative input, not a destination.
+func (e s3BucketEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.S3 == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if identity == nil {
+		return nil, errors.New("s3_bucket: identity is nil")
+	}
+	bucket := s3BucketNameForEnrich(identity)
+	if bucket == "" {
+		return nil, fmt.Errorf("s3_bucket: cannot derive bucket name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			identity.Address, identity.ImportID, identity.NameHint)
+	}
+	typed, err := e.fetchAndMap(ctx, c.S3, bucket)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("s3_bucket: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// fetchAndMap issues the HeadBucket existence probe + all overlays
+// and returns the populated typed struct. Shared between Enrich and
+// EnrichByID so the SDK-call layout lives in one place. HeadBucket
+// failures are propagated; overlay failures are downgraded.
+//
+// For standard S3 buckets, the ARN is deterministic from the name
+// (`arn:aws:s3:::<bucket>`), so we synthesize it whenever
+// HeadBucket doesn't return one (HeadBucket's BucketArn field is
+// directory-bucket-only).
+func (e s3BucketEnricher) fetchAndMap(ctx context.Context, c *s3.Client, bucket string) (*generated.AWSS3Bucket, error) {
+	head, err := e.fetchHead(ctx, c, bucket)
+	if err != nil {
+		// HeadBucket surfaces a not-found bucket as a generic 404 with
+		// ErrorCode "NotFound" or "NoSuchBucket" — both via the typed
+		// NotFound shape or via the smithy.APIError code. Map either
+		// onto ErrNotFound so drift / dispatch flows can distinguish a
+		// deleted bucket from a real API failure.
+		var notFound *s3types.NotFound
+		if errors.As(err, &notFound) || isS3NotSetError(err, "NotFound", "NoSuchBucket") {
+			return nil, fmt.Errorf("s3_bucket %q: %w", bucket, ErrNotFound)
+		}
+		return nil, fmt.Errorf("s3_bucket: head %q: %w", bucket, err)
+	}
+
+	typed := mapS3Bucket(bucket, head)
+
+	// Encryption — GetBucketEncryption. Soft-fail.
+	if sse, ferr := e.fetchEncryption(ctx, c, bucket); ferr == nil && sse != nil {
+		if block := mapS3SSE(sse); block != nil {
+			typed.ServerSideEncryptionConfiguration = []generated.AWSS3BucketServerSideEncryptionConfiguration{*block}
+		}
+	}
+
+	// Versioning — GetBucketVersioning. Soft-fail. Absent when Status
+	// and MFADelete are both empty (matches the bucket-versioning
+	// sub-resource "never configured" semantic from sdkonly_s3.go).
+	if v, ferr := e.fetchVersioning(ctx, c, bucket); ferr == nil && v != nil {
+		if block := mapS3Versioning(v); block != nil {
+			typed.Versioning = []generated.AWSS3BucketVersioning{*block}
+		}
+	}
+
+	// Lifecycle — GetBucketLifecycleConfiguration. Soft-fail.
+	if rules, ferr := e.fetchLifecycle(ctx, c, bucket); ferr == nil && len(rules) > 0 {
+		typed.LifecycleRule = mapS3LifecycleRules(rules)
+	}
+
+	// Logging — GetBucketLogging. Soft-fail.
+	if lg, ferr := e.fetchLogging(ctx, c, bucket); ferr == nil && lg != nil {
+		if block := mapS3Logging(lg); block != nil {
+			typed.Logging = []generated.AWSS3BucketLogging{*block}
+		}
+	}
+
+	// CORS — GetBucketCors. Soft-fail.
+	if rules, ferr := e.fetchCors(ctx, c, bucket); ferr == nil && len(rules) > 0 {
+		typed.CorsRule = mapS3CorsRules(rules)
+	}
+
+	// Policy — GetBucketPolicy. Soft-fail.
+	if p, ferr := e.fetchPolicy(ctx, c, bucket); ferr == nil && p != nil && *p != "" {
+		typed.Policy = generated.LiteralOf(*p)
+	}
+
+	// Website — GetBucketWebsite. Soft-fail.
+	if w, ferr := e.fetchWebsite(ctx, c, bucket); ferr == nil && w != nil {
+		if block := mapS3Website(w); block != nil {
+			typed.Website = []generated.AWSS3BucketWebsite{*block}
+		}
+	}
+
+	// Tags — GetBucketTagging. Soft-fail.
+	if tags, ferr := e.fetchTags(ctx, c, bucket); ferr == nil && len(tags) > 0 {
+		m := map[string]*generated.Value[string]{}
+		for _, t := range tags {
+			if t.Key != nil {
+				m[*t.Key] = generated.LiteralOf(aws.ToString(t.Value))
+			}
+		}
+		if len(m) > 0 {
+			typed.Tags = m
+		}
+	}
+
+	// Object Lock — GetObjectLockConfiguration. Soft-fail. Also
+	// mirrors `object_lock_enabled` (top-level bool) since the SDK's
+	// ObjectLockEnabled enum is the only reliable signal — HeadBucket
+	// does not surface it.
+	if ol, ferr := e.fetchObjectLock(ctx, c, bucket); ferr == nil && ol != nil {
+		if block := mapS3ObjectLock(ol); block != nil {
+			typed.ObjectLockConfiguration = []generated.AWSS3BucketObjectLockConfiguration{*block}
+		}
+		if string(ol.ObjectLockEnabled) == string(s3types.ObjectLockEnabledEnabled) {
+			typed.ObjectLockEnabled = generated.LiteralOf(true)
+		}
+	}
+
+	return typed, nil
+}
+
+// s3BucketNameForEnrich pulls the bucket name from the identifiers
+// the discoverer populates. Order of preference mirrors
+// dynamodb_table_enrich.go:
+//
+//  1. Identity.NameHint — explicit bucket name set by
+//     nameOrIdentifier("BucketName") in cloudControlTypeConfigs.
+//  2. Identity.NativeIDs["bucket"] — set by the SDK-only sub-resource
+//     discoverers (sdkonly_s3.go) for cross-resource lookups.
+//  3. Identity.NativeIDs["name"] — generic fallback.
+//  4. Identity.ImportID — last resort.
+func s3BucketNameForEnrich(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if s := strings.TrimSpace(id.NameHint); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(id.NativeIDs["bucket"]); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(id.NativeIDs["name"]); s != "" {
+		return s
+	}
+	return strings.TrimSpace(id.ImportID)
+}
+
+// mapS3Bucket builds the typed top-level surface from the bucket
+// name + HeadBucket response. ARN is synthesized from the bucket
+// name when HeadBucket does not return one (standard S3 buckets do
+// not carry the BucketArn field — it's directory-bucket-only). The
+// ARN follows the canonical `arn:aws:s3:::<bucket>` form per the AWS
+// S3 ARN reference.
+func mapS3Bucket(bucket string, head *s3.HeadBucketOutput) *generated.AWSS3Bucket {
+	out := &generated.AWSS3Bucket{}
+	out.Bucket = generated.LiteralOf(bucket)
+	// TF state stores the bucket name as the resource id.
+	out.ID = generated.LiteralOf(bucket)
+
+	// ARN: directory buckets carry BucketArn; standard buckets do
+	// not. Synthesize the standard form when missing — the inspector
+	// downstream keys off this string.
+	arn := aws.ToString(head.BucketArn)
+	if arn == "" {
+		arn = fmt.Sprintf("arn:aws:s3:::%s", bucket)
+	}
+	out.ARN = generated.LiteralOf(arn)
+
+	if region := aws.ToString(head.BucketRegion); region != "" {
+		out.Region = generated.LiteralOf(region)
+	}
+
+	return out
+}
+
+// mapS3SSE projects a ServerSideEncryptionConfiguration into the
+// typed block. Returns nil when the configuration has no usable
+// rules.
+func mapS3SSE(sse *s3types.ServerSideEncryptionConfiguration) *generated.AWSS3BucketServerSideEncryptionConfiguration {
+	if sse == nil || len(sse.Rules) == 0 {
+		return nil
+	}
+	rules := make([]generated.AWSS3BucketServerSideEncryptionConfigurationRule, 0, len(sse.Rules))
+	for i := range sse.Rules {
+		r := sse.Rules[i]
+		rule := generated.AWSS3BucketServerSideEncryptionConfigurationRule{}
+		if r.BucketKeyEnabled != nil {
+			rule.BucketKeyEnabled = generated.LiteralOf(*r.BucketKeyEnabled)
+		}
+		if r.ApplyServerSideEncryptionByDefault != nil {
+			apply := generated.AWSS3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault{}
+			if alg := string(r.ApplyServerSideEncryptionByDefault.SSEAlgorithm); alg != "" {
+				apply.SSEAlgorithm = generated.LiteralOf(alg)
+			}
+			if k := aws.ToString(r.ApplyServerSideEncryptionByDefault.KMSMasterKeyID); k != "" {
+				apply.KMSMasterKeyID = generated.LiteralOf(k)
+			}
+			rule.ApplyServerSideEncryptionByDefault = []generated.AWSS3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault{apply}
+		}
+		rules = append(rules, rule)
+	}
+	return &generated.AWSS3BucketServerSideEncryptionConfiguration{Rule: rules}
+}
+
+// mapS3Versioning projects GetBucketVersioning output into the typed
+// block. Returns nil when neither Status nor MFADelete is set —
+// matching the "never configured" semantic from sdkonly_s3.go's
+// fetchS3BucketVersioning.
+func mapS3Versioning(v *s3.GetBucketVersioningOutput) *generated.AWSS3BucketVersioning {
+	if v == nil || (v.Status == "" && v.MFADelete == "") {
+		return nil
+	}
+	block := generated.AWSS3BucketVersioning{}
+	// TF's `enabled` bool maps from Status == "Enabled".
+	block.Enabled = generated.LiteralOf(v.Status == s3types.BucketVersioningStatusEnabled)
+	// TF's `mfa_delete` bool maps from MFADelete == "Enabled".
+	if v.MFADelete != "" {
+		block.MFADelete = generated.LiteralOf(v.MFADelete == s3types.MFADeleteStatusEnabled)
+	}
+	return &block
+}
+
+// mapS3LifecycleRules projects a slice of LifecycleRule into the
+// typed block list. The legacy `aws_s3_bucket` resource only carries
+// a subset of the modern `aws_s3_bucket_lifecycle_configuration`
+// surface — fields not on the Layer 1 typed model are intentionally
+// skipped (e.g. Filter.And, ObjectSizeGreaterThan, …) per the
+// typed-struct-is-truth contract.
+func mapS3LifecycleRules(rules []s3types.LifecycleRule) []generated.AWSS3BucketLifecycleRule {
+	out := make([]generated.AWSS3BucketLifecycleRule, 0, len(rules))
+	for i := range rules {
+		r := rules[i]
+		block := generated.AWSS3BucketLifecycleRule{}
+		if r.ID != nil && *r.ID != "" {
+			block.ID = generated.LiteralOf(*r.ID)
+		}
+		// Status -> Enabled bool.
+		block.Enabled = generated.LiteralOf(r.Status == s3types.ExpirationStatusEnabled)
+		if r.Prefix != nil && *r.Prefix != "" {
+			block.Prefix = generated.LiteralOf(*r.Prefix)
+		}
+		if r.AbortIncompleteMultipartUpload != nil && r.AbortIncompleteMultipartUpload.DaysAfterInitiation != nil {
+			block.AbortIncompleteMultipartUploadDays = generated.LiteralOf(float64(*r.AbortIncompleteMultipartUpload.DaysAfterInitiation))
+		}
+		if r.Filter != nil && r.Filter.Tag != nil && r.Filter.Tag.Key != nil {
+			block.Tags = map[string]*generated.Value[string]{
+				*r.Filter.Tag.Key: generated.LiteralOf(aws.ToString(r.Filter.Tag.Value)),
+			}
+		}
+		if r.Expiration != nil {
+			exp := generated.AWSS3BucketLifecycleRuleExpiration{}
+			if r.Expiration.Date != nil {
+				exp.Date = generated.LiteralOf(r.Expiration.Date.UTC().Format("2006-01-02T15:04:05Z"))
+			}
+			if r.Expiration.Days != nil {
+				exp.Days = generated.LiteralOf(float64(*r.Expiration.Days))
+			}
+			if r.Expiration.ExpiredObjectDeleteMarker != nil {
+				exp.ExpiredObjectDeleteMarker = generated.LiteralOf(*r.Expiration.ExpiredObjectDeleteMarker)
+			}
+			block.Expiration = []generated.AWSS3BucketLifecycleRuleExpiration{exp}
+		}
+		if r.NoncurrentVersionExpiration != nil && r.NoncurrentVersionExpiration.NoncurrentDays != nil {
+			block.NoncurrentVersionExpiration = []generated.AWSS3BucketLifecycleRuleNoncurrentVersionExpiration{{
+				Days: generated.LiteralOf(float64(*r.NoncurrentVersionExpiration.NoncurrentDays)),
+			}}
+		}
+		if len(r.NoncurrentVersionTransitions) > 0 {
+			ts := make([]generated.AWSS3BucketLifecycleRuleNoncurrentVersionTransition, 0, len(r.NoncurrentVersionTransitions))
+			for j := range r.NoncurrentVersionTransitions {
+				t := r.NoncurrentVersionTransitions[j]
+				e := generated.AWSS3BucketLifecycleRuleNoncurrentVersionTransition{}
+				if t.NoncurrentDays != nil {
+					e.Days = generated.LiteralOf(float64(*t.NoncurrentDays))
+				}
+				if sc := string(t.StorageClass); sc != "" {
+					e.StorageClass = generated.LiteralOf(sc)
+				}
+				ts = append(ts, e)
+			}
+			block.NoncurrentVersionTransition = ts
+		}
+		if len(r.Transitions) > 0 {
+			ts := make([]generated.AWSS3BucketLifecycleRuleTransition, 0, len(r.Transitions))
+			for j := range r.Transitions {
+				t := r.Transitions[j]
+				e := generated.AWSS3BucketLifecycleRuleTransition{}
+				if t.Date != nil {
+					e.Date = generated.LiteralOf(t.Date.UTC().Format("2006-01-02T15:04:05Z"))
+				}
+				if t.Days != nil {
+					e.Days = generated.LiteralOf(float64(*t.Days))
+				}
+				if sc := string(t.StorageClass); sc != "" {
+					e.StorageClass = generated.LiteralOf(sc)
+				}
+				ts = append(ts, e)
+			}
+			block.Transition = ts
+		}
+		out = append(out, block)
+	}
+	return out
+}
+
+// mapS3Logging projects a LoggingEnabled into the typed block.
+// Returns nil when TargetBucket is empty.
+func mapS3Logging(lg *s3types.LoggingEnabled) *generated.AWSS3BucketLogging {
+	if lg == nil || lg.TargetBucket == nil || *lg.TargetBucket == "" {
+		return nil
+	}
+	block := generated.AWSS3BucketLogging{
+		TargetBucket: generated.LiteralOf(*lg.TargetBucket),
+	}
+	if lg.TargetPrefix != nil && *lg.TargetPrefix != "" {
+		block.TargetPrefix = generated.LiteralOf(*lg.TargetPrefix)
+	}
+	return &block
+}
+
+// mapS3CorsRules projects a slice of CORSRule into typed blocks.
+func mapS3CorsRules(rules []s3types.CORSRule) []generated.AWSS3BucketCorsRule {
+	out := make([]generated.AWSS3BucketCorsRule, 0, len(rules))
+	for i := range rules {
+		r := rules[i]
+		block := generated.AWSS3BucketCorsRule{}
+		block.AllowedMethods = literalStringSlice(r.AllowedMethods)
+		block.AllowedOrigins = literalStringSlice(r.AllowedOrigins)
+		if len(r.AllowedHeaders) > 0 {
+			block.AllowedHeaders = literalStringSlice(r.AllowedHeaders)
+		}
+		if len(r.ExposeHeaders) > 0 {
+			block.ExposeHeaders = literalStringSlice(r.ExposeHeaders)
+		}
+		if r.MaxAgeSeconds != nil {
+			block.MaxAgeSeconds = generated.LiteralOf(int64(*r.MaxAgeSeconds))
+		}
+		out = append(out, block)
+	}
+	return out
+}
+
+// mapS3Website projects a GetBucketWebsite response into the typed
+// block. Returns nil when neither index nor error document nor
+// redirect is set — matches the "never configured" semantic.
+func mapS3Website(w *s3.GetBucketWebsiteOutput) *generated.AWSS3BucketWebsite {
+	if w == nil {
+		return nil
+	}
+	populated := false
+	block := generated.AWSS3BucketWebsite{}
+	if w.IndexDocument != nil && w.IndexDocument.Suffix != nil && *w.IndexDocument.Suffix != "" {
+		block.IndexDocument = generated.LiteralOf(*w.IndexDocument.Suffix)
+		populated = true
+	}
+	if w.ErrorDocument != nil && w.ErrorDocument.Key != nil && *w.ErrorDocument.Key != "" {
+		block.ErrorDocument = generated.LiteralOf(*w.ErrorDocument.Key)
+		populated = true
+	}
+	if w.RedirectAllRequestsTo != nil && w.RedirectAllRequestsTo.HostName != nil && *w.RedirectAllRequestsTo.HostName != "" {
+		// TF's redirect_all_requests_to is a string of "<host>" or
+		// "<protocol>://<host>" depending on whether protocol is set.
+		host := *w.RedirectAllRequestsTo.HostName
+		if proto := string(w.RedirectAllRequestsTo.Protocol); proto != "" {
+			host = proto + "://" + host
+		}
+		block.RedirectAllRequestsTo = generated.LiteralOf(host)
+		populated = true
+	}
+	if !populated {
+		return nil
+	}
+	return &block
+}
+
+// mapS3ObjectLock projects an ObjectLockConfiguration into the typed
+// block. Returns nil when neither ObjectLockEnabled nor a Rule is
+// set.
+func mapS3ObjectLock(ol *s3types.ObjectLockConfiguration) *generated.AWSS3BucketObjectLockConfiguration {
+	if ol == nil {
+		return nil
+	}
+	block := generated.AWSS3BucketObjectLockConfiguration{}
+	populated := false
+	if s := string(ol.ObjectLockEnabled); s != "" {
+		block.ObjectLockEnabled = generated.LiteralOf(s)
+		populated = true
+	}
+	if ol.Rule != nil && ol.Rule.DefaultRetention != nil {
+		dr := ol.Rule.DefaultRetention
+		ret := generated.AWSS3BucketObjectLockConfigurationRuleDefaultRetention{}
+		if m := string(dr.Mode); m != "" {
+			ret.Mode = generated.LiteralOf(m)
+		}
+		if dr.Days != nil {
+			ret.Days = generated.LiteralOf(float64(*dr.Days))
+		}
+		if dr.Years != nil {
+			ret.Years = generated.LiteralOf(float64(*dr.Years))
+		}
+		block.Rule = []generated.AWSS3BucketObjectLockConfigurationRule{{
+			DefaultRetention: []generated.AWSS3BucketObjectLockConfigurationRuleDefaultRetention{ret},
+		}}
+		populated = true
+	}
+	if !populated {
+		return nil
+	}
+	return &block
+}
+
+// literalStringSlice projects a slice of plain strings into the
+// []*Value[string] shape the Layer 1 typed model uses for list
+// attributes.
+func literalStringSlice(in []string) []*generated.Value[string] {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*generated.Value[string], 0, len(in))
+	for _, s := range in {
+		out = append(out, generated.LiteralOf(s))
+	}
+	return out
+}
+
+// defaultS3BucketFetchHead is the production HeadBucket call.
+func defaultS3BucketFetchHead(ctx context.Context, c *s3.Client, bucket string) (*s3.HeadBucketOutput, error) {
+	out, err := c.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return nil, errors.New("head bucket: nil output")
+	}
+	return out, nil
+}
+
+// defaultS3BucketFetchEncryption is the production encryption fetch.
+// Returns (nil, nil) when the bucket has no encryption configuration.
+func defaultS3BucketFetchEncryption(ctx context.Context, c *s3.Client, bucket string) (*s3types.ServerSideEncryptionConfiguration, error) {
+	out, err := c.GetBucketEncryption(ctx, &s3.GetBucketEncryptionInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		if isS3NotSetError(err, "ServerSideEncryptionConfigurationNotFoundError", "NoSuchEncryptionConfiguration") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if out == nil {
+		return nil, nil
+	}
+	return out.ServerSideEncryptionConfiguration, nil
+}
+
+// defaultS3BucketFetchVersioning is the production versioning fetch.
+// GetBucketVersioning has no NotFound code: AWS treats "versioning
+// never set" as a successful response with empty Status / MFADelete.
+func defaultS3BucketFetchVersioning(ctx context.Context, c *s3.Client, bucket string) (*s3.GetBucketVersioningOutput, error) {
+	return c.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{Bucket: aws.String(bucket)})
+}
+
+// defaultS3BucketFetchLifecycle is the production lifecycle fetch.
+// Returns (nil, nil) when the bucket has no lifecycle configuration.
+func defaultS3BucketFetchLifecycle(ctx context.Context, c *s3.Client, bucket string) ([]s3types.LifecycleRule, error) {
+	out, err := c.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		if isS3NotSetError(err, "NoSuchLifecycleConfiguration") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if out == nil {
+		return nil, nil
+	}
+	return out.Rules, nil
+}
+
+// defaultS3BucketFetchLogging is the production logging fetch.
+// GetBucketLogging returns success with LoggingEnabled=nil when
+// logging is not configured.
+func defaultS3BucketFetchLogging(ctx context.Context, c *s3.Client, bucket string) (*s3types.LoggingEnabled, error) {
+	out, err := c.GetBucketLogging(ctx, &s3.GetBucketLoggingInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return nil, nil
+	}
+	return out.LoggingEnabled, nil
+}
+
+// defaultS3BucketFetchCors is the production CORS fetch.
+// Returns (nil, nil) when the bucket has no CORS configuration.
+func defaultS3BucketFetchCors(ctx context.Context, c *s3.Client, bucket string) ([]s3types.CORSRule, error) {
+	out, err := c.GetBucketCors(ctx, &s3.GetBucketCorsInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		if isS3NotSetError(err, "NoSuchCORSConfiguration") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if out == nil {
+		return nil, nil
+	}
+	return out.CORSRules, nil
+}
+
+// defaultS3BucketFetchPolicy is the production policy fetch.
+// Returns (nil, nil) when the bucket has no policy.
+func defaultS3BucketFetchPolicy(ctx context.Context, c *s3.Client, bucket string) (*string, error) {
+	out, err := c.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		if isS3NotSetError(err, "NoSuchBucketPolicy") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if out == nil {
+		return nil, nil
+	}
+	return out.Policy, nil
+}
+
+// defaultS3BucketFetchWebsite is the production website fetch.
+// Returns (nil, nil) when the bucket has no website configuration.
+func defaultS3BucketFetchWebsite(ctx context.Context, c *s3.Client, bucket string) (*s3.GetBucketWebsiteOutput, error) {
+	out, err := c.GetBucketWebsite(ctx, &s3.GetBucketWebsiteInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		if isS3NotSetError(err, "NoSuchWebsiteConfiguration") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if out == nil {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// defaultS3BucketFetchTags is the production tags fetch.
+// Returns (nil, nil) when the bucket has no tag set.
+func defaultS3BucketFetchTags(ctx context.Context, c *s3.Client, bucket string) ([]s3types.Tag, error) {
+	out, err := c.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		if isS3NotSetError(err, "NoSuchTagSet") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if out == nil {
+		return nil, nil
+	}
+	return out.TagSet, nil
+}
+
+// defaultS3BucketFetchObjectLock is the production object-lock fetch.
+// Returns (nil, nil) when the bucket has no object-lock configuration.
+// Note the SDK operation is named GetObjectLockConfiguration (not
+// GetBucketObjectLockConfiguration); the naming asymmetry is a
+// historical S3 API quirk.
+func defaultS3BucketFetchObjectLock(ctx context.Context, c *s3.Client, bucket string) (*s3types.ObjectLockConfiguration, error) {
+	out, err := c.GetObjectLockConfiguration(ctx, &s3.GetObjectLockConfigurationInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		if isS3NotSetError(err, "ObjectLockConfigurationNotFoundError") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if out == nil {
+		return nil, nil
+	}
+	return out.ObjectLockConfiguration, nil
+}

--- a/cmd/insideout-import/awsdiscover/s3_bucket_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/s3_bucket_enrich_test.go
@@ -1,0 +1,919 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// s3FetchHooks bundles the optional fetch closures for newTestS3Enricher
+// so a single test can stub only the overlays it cares about without
+// listing nil-default placeholders for the rest. Mirrors the per-
+// closure parameter list used by newTestDynamoDBEnricher but in
+// struct form because S3 has too many overlays for a positional
+// signature to stay readable.
+type s3FetchHooks struct {
+	head       func(ctx context.Context, c *s3.Client, bucket string) (*s3.HeadBucketOutput, error)
+	encryption func(ctx context.Context, c *s3.Client, bucket string) (*s3types.ServerSideEncryptionConfiguration, error)
+	versioning func(ctx context.Context, c *s3.Client, bucket string) (*s3.GetBucketVersioningOutput, error)
+	lifecycle  func(ctx context.Context, c *s3.Client, bucket string) ([]s3types.LifecycleRule, error)
+	logging    func(ctx context.Context, c *s3.Client, bucket string) (*s3types.LoggingEnabled, error)
+	cors       func(ctx context.Context, c *s3.Client, bucket string) ([]s3types.CORSRule, error)
+	policy     func(ctx context.Context, c *s3.Client, bucket string) (*string, error)
+	website    func(ctx context.Context, c *s3.Client, bucket string) (*s3.GetBucketWebsiteOutput, error)
+	tags       func(ctx context.Context, c *s3.Client, bucket string) ([]s3types.Tag, error)
+	objectLock func(ctx context.Context, c *s3.Client, bucket string) (*s3types.ObjectLockConfiguration, error)
+}
+
+// newTestS3Enricher builds an s3BucketEnricher with the supplied
+// hooks; any nil hook defaults to "absent" (returns nil, nil) so a
+// test can stub only the overlays it exercises.
+func newTestS3Enricher(h s3FetchHooks) s3BucketEnricher {
+	if h.head == nil {
+		h.head = func(context.Context, *s3.Client, string) (*s3.HeadBucketOutput, error) {
+			return &s3.HeadBucketOutput{}, nil
+		}
+	}
+	if h.encryption == nil {
+		h.encryption = func(context.Context, *s3.Client, string) (*s3types.ServerSideEncryptionConfiguration, error) {
+			return nil, nil
+		}
+	}
+	if h.versioning == nil {
+		h.versioning = func(context.Context, *s3.Client, string) (*s3.GetBucketVersioningOutput, error) {
+			return nil, nil
+		}
+	}
+	if h.lifecycle == nil {
+		h.lifecycle = func(context.Context, *s3.Client, string) ([]s3types.LifecycleRule, error) {
+			return nil, nil
+		}
+	}
+	if h.logging == nil {
+		h.logging = func(context.Context, *s3.Client, string) (*s3types.LoggingEnabled, error) {
+			return nil, nil
+		}
+	}
+	if h.cors == nil {
+		h.cors = func(context.Context, *s3.Client, string) ([]s3types.CORSRule, error) {
+			return nil, nil
+		}
+	}
+	if h.policy == nil {
+		h.policy = func(context.Context, *s3.Client, string) (*string, error) {
+			return nil, nil
+		}
+	}
+	if h.website == nil {
+		h.website = func(context.Context, *s3.Client, string) (*s3.GetBucketWebsiteOutput, error) {
+			return nil, nil
+		}
+	}
+	if h.tags == nil {
+		h.tags = func(context.Context, *s3.Client, string) ([]s3types.Tag, error) {
+			return nil, nil
+		}
+	}
+	if h.objectLock == nil {
+		h.objectLock = func(context.Context, *s3.Client, string) (*s3types.ObjectLockConfiguration, error) {
+			return nil, nil
+		}
+	}
+	return s3BucketEnricher{
+		fetchHead:       h.head,
+		fetchEncryption: h.encryption,
+		fetchVersioning: h.versioning,
+		fetchLifecycle:  h.lifecycle,
+		fetchLogging:    h.logging,
+		fetchCors:       h.cors,
+		fetchPolicy:     h.policy,
+		fetchWebsite:    h.website,
+		fetchTags:       h.tags,
+		fetchObjectLock: h.objectLock,
+	}
+}
+
+// decodeS3BucketAttrs round-trips ir.Attrs through UnmarshalAttrs and
+// returns the typed AWSS3Bucket. Mirrors decodeAttrs in the dynamodb
+// test file.
+func decodeS3BucketAttrs(t *testing.T, ir *imported.ImportedResource) *generated.AWSS3Bucket {
+	t.Helper()
+	require.NotEmpty(t, ir.Attrs, "Attrs must be populated before decode")
+	decoded, err := generated.UnmarshalAttrs("aws_s3_bucket", ir.Attrs)
+	require.NoError(t, err)
+	b, ok := decoded.(*generated.AWSS3Bucket)
+	require.True(t, ok, "decoded type must be *AWSS3Bucket, got %T", decoded)
+	return b
+}
+
+// stubAPIError implements smithy.APIError so test fixtures can
+// reproduce service-native "feature not configured" error codes
+// without dragging in a fake transport. Mirrors what the S3 SDK
+// surfaces on the wire for codes like NoSuchBucketPolicy.
+type stubAPIError struct{ code string }
+
+func (e *stubAPIError) Error() string                 { return e.code }
+func (e *stubAPIError) ErrorCode() string             { return e.code }
+func (e *stubAPIError) ErrorMessage() string          { return e.code }
+func (e *stubAPIError) ErrorFault() smithy.ErrorFault { return smithy.FaultClient }
+
+var _ smithy.APIError = (*stubAPIError)(nil)
+
+func TestS3BucketEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	enr := newS3BucketEnricher()
+	assert.Equal(t, "aws_s3_bucket", enr.ResourceType())
+}
+
+// Compile-time pin: s3BucketEnricher must satisfy both
+// AttributeEnricher and ByIDEnricher. Captures the contract; dropping
+// either method on a refactor fails the build, not a test.
+var (
+	_ AttributeEnricher = (*s3BucketEnricher)(nil)
+	_ ByIDEnricher      = (*s3BucketEnricher)(nil)
+)
+
+func TestS3BucketEnricher_NilClientReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	enr := s3BucketEnricher{}
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "b"},
+	}, EnrichClients{S3: nil})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestS3BucketEnricher_EnrichByID_NilClientReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	enr := s3BucketEnricher{}
+	_, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type: "aws_s3_bucket", NameHint: "b",
+	}, EnrichClients{S3: nil})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestS3BucketEnricher_EnrichByID_NilIdentityReturnsError(t *testing.T) {
+	t.Parallel()
+	enr := s3BucketEnricher{}
+	_, err := enr.EnrichByID(context.Background(), nil, EnrichClients{S3: &s3.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity is nil")
+}
+
+func TestS3BucketEnricher_NameDerivation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		label string
+		id    imported.ResourceIdentity
+		want  string
+	}{
+		{
+			label: "NameHint wins",
+			id: imported.ResourceIdentity{
+				NameHint:  "from-name-hint",
+				ImportID:  "from-import-id",
+				NativeIDs: map[string]string{"bucket": "from-bucket"},
+			},
+			want: "from-name-hint",
+		},
+		{
+			label: "NativeIDs[bucket] is preferred fallback",
+			id: imported.ResourceIdentity{
+				NativeIDs: map[string]string{"bucket": "from-bucket", "name": "from-native"},
+				ImportID:  "from-import-id",
+			},
+			want: "from-bucket",
+		},
+		{
+			label: "NativeIDs[name] is second fallback",
+			id: imported.ResourceIdentity{
+				NativeIDs: map[string]string{"name": "from-native"},
+				ImportID:  "from-import-id",
+			},
+			want: "from-native",
+		},
+		{
+			label: "ImportID is last resort",
+			id: imported.ResourceIdentity{
+				ImportID: "from-import-id",
+			},
+			want: "from-import-id",
+		},
+		{
+			label: "empty everywhere -> empty",
+			id:    imported.ResourceIdentity{},
+			want:  "",
+		},
+		{
+			label: "nil identity -> empty",
+			id:    imported.ResourceIdentity{},
+			want:  "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			assert.Equal(t, tc.want, s3BucketNameForEnrich(&tc.id))
+		})
+	}
+
+	// Explicit nil-pointer guard.
+	assert.Equal(t, "", s3BucketNameForEnrich(nil))
+}
+
+func TestS3BucketEnricher_NoBucketNameReturnsError(t *testing.T) {
+	t.Parallel()
+	enr := newS3BucketEnricher()
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket"},
+	}, EnrichClients{S3: &s3.Client{}})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "cannot derive bucket name"))
+}
+
+func TestS3BucketEnricher_EnrichByID_NoBucketNameReturnsError(t *testing.T) {
+	t.Parallel()
+	enr := newS3BucketEnricher()
+	_, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type: "aws_s3_bucket",
+	}, EnrichClients{S3: &s3.Client{}})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "cannot derive bucket name"))
+}
+
+func TestS3BucketEnricher_HeadError_Propagates(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("AccessDenied")
+	enr := newTestS3Enricher(s3FetchHooks{
+		head: func(context.Context, *s3.Client, string) (*s3.HeadBucketOutput, error) {
+			return nil, wantErr
+		},
+	})
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "b"},
+	}, EnrichClients{S3: &s3.Client{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestS3BucketEnricher_HeadNotFound_ReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	// Typed NotFound error path.
+	enr := newTestS3Enricher(s3FetchHooks{
+		head: func(context.Context, *s3.Client, string) (*s3.HeadBucketOutput, error) {
+			return nil, &s3types.NotFound{}
+		},
+	})
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "gone"},
+	}, EnrichClients{S3: &s3.Client{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestS3BucketEnricher_HeadNoSuchBucketCode_ReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	// Some SDK paths surface NoSuchBucket as a generic APIError code
+	// rather than the typed NotFound; the enricher must collapse both
+	// onto ErrNotFound.
+	enr := newTestS3Enricher(s3FetchHooks{
+		head: func(context.Context, *s3.Client, string) (*s3.HeadBucketOutput, error) {
+			return nil, &stubAPIError{code: "NoSuchBucket"}
+		},
+	})
+	_, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type: "aws_s3_bucket", NameHint: "gone",
+	}, EnrichClients{S3: &s3.Client{}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestS3BucketEnricher_BasicMapping(t *testing.T) {
+	t.Parallel()
+	enr := newTestS3Enricher(s3FetchHooks{
+		head: func(context.Context, *s3.Client, string) (*s3.HeadBucketOutput, error) {
+			return &s3.HeadBucketOutput{
+				BucketRegion: aws.String("us-east-1"),
+			}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_s3_bucket",
+			Address:  "aws_s3_bucket.orders",
+			NameHint: "orders",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}, AccountID: "012345678901"}))
+
+	// Stamps on NativeIDs (synthesized ARN, region from HeadBucket).
+	assert.Equal(t, "arn:aws:s3:::orders", ir.Identity.NativeIDs["arn"])
+	assert.Equal(t, "us-east-1", ir.Identity.NativeIDs["region"])
+
+	b := decodeS3BucketAttrs(t, ir)
+	require.NotNil(t, b.Bucket)
+	assert.Equal(t, "orders", *b.Bucket.Literal)
+	require.NotNil(t, b.ID)
+	assert.Equal(t, "orders", *b.ID.Literal, "id must mirror bucket name per TF state semantics")
+	require.NotNil(t, b.ARN)
+	assert.Equal(t, "arn:aws:s3:::orders", *b.ARN.Literal)
+	require.NotNil(t, b.Region)
+	assert.Equal(t, "us-east-1", *b.Region.Literal)
+
+	// All overlay blocks must be absent when their hooks return nil.
+	assert.Empty(t, b.ServerSideEncryptionConfiguration, "sse block must be absent when fetchEncryption returns nil")
+	assert.Empty(t, b.Versioning, "versioning block must be absent when fetchVersioning returns nil")
+	assert.Empty(t, b.LifecycleRule, "lifecycle_rule must be absent when fetchLifecycle returns nil")
+	assert.Empty(t, b.Logging, "logging block must be absent when fetchLogging returns nil")
+	assert.Empty(t, b.CorsRule, "cors_rule must be absent when fetchCors returns nil")
+	assert.Nil(t, b.Policy, "policy must be absent when fetchPolicy returns nil")
+	assert.Empty(t, b.Website, "website block must be absent when fetchWebsite returns nil")
+	assert.Empty(t, b.Tags, "tags must be absent when fetchTags returns nil")
+	assert.Empty(t, b.ObjectLockConfiguration, "object_lock_configuration must be absent when fetchObjectLock returns nil")
+	assert.Nil(t, b.ObjectLockEnabled, "object_lock_enabled must be absent when fetchObjectLock returns nil")
+}
+
+func TestS3BucketEnricher_HeadBucketArnRespected(t *testing.T) {
+	t.Parallel()
+	// Directory buckets carry a real BucketArn — the enricher must
+	// use it rather than synthesizing the standard form.
+	enr := newTestS3Enricher(s3FetchHooks{
+		head: func(context.Context, *s3.Client, string) (*s3.HeadBucketOutput, error) {
+			return &s3.HeadBucketOutput{
+				BucketArn:    aws.String("arn:aws:s3express:us-east-1:012345678901:bucket/dir-bucket"),
+				BucketRegion: aws.String("us-east-1"),
+			}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "dir-bucket"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	require.NotNil(t, b.ARN)
+	assert.Equal(t, "arn:aws:s3express:us-east-1:012345678901:bucket/dir-bucket", *b.ARN.Literal)
+}
+
+func TestS3BucketEnricher_EncryptionOverlayHappy(t *testing.T) {
+	t.Parallel()
+	enr := newTestS3Enricher(s3FetchHooks{
+		encryption: func(context.Context, *s3.Client, string) (*s3types.ServerSideEncryptionConfiguration, error) {
+			return &s3types.ServerSideEncryptionConfiguration{
+				Rules: []s3types.ServerSideEncryptionRule{{
+					BucketKeyEnabled: aws.Bool(true),
+					ApplyServerSideEncryptionByDefault: &s3types.ServerSideEncryptionByDefault{
+						SSEAlgorithm:   s3types.ServerSideEncryptionAwsKms,
+						KMSMasterKeyID: aws.String("arn:aws:kms:us-east-1:012345678901:key/abc"),
+					},
+				}},
+			}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "encrypted"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	require.Len(t, b.ServerSideEncryptionConfiguration, 1)
+	require.Len(t, b.ServerSideEncryptionConfiguration[0].Rule, 1)
+	r := b.ServerSideEncryptionConfiguration[0].Rule[0]
+	require.NotNil(t, r.BucketKeyEnabled)
+	assert.True(t, *r.BucketKeyEnabled.Literal)
+	require.Len(t, r.ApplyServerSideEncryptionByDefault, 1)
+	apply := r.ApplyServerSideEncryptionByDefault[0]
+	require.NotNil(t, apply.SSEAlgorithm)
+	assert.Equal(t, string(s3types.ServerSideEncryptionAwsKms), *apply.SSEAlgorithm.Literal)
+	require.NotNil(t, apply.KMSMasterKeyID)
+	assert.Equal(t, "arn:aws:kms:us-east-1:012345678901:key/abc", *apply.KMSMasterKeyID.Literal)
+}
+
+func TestS3BucketEnricher_EncryptionNotConfigured_SoftFails(t *testing.T) {
+	t.Parallel()
+	// Service-native "feature not configured" error code -> block absent.
+	enr := newTestS3Enricher(s3FetchHooks{
+		encryption: func(context.Context, *s3.Client, string) (*s3types.ServerSideEncryptionConfiguration, error) {
+			return nil, &stubAPIError{code: "ServerSideEncryptionConfigurationNotFoundError"}
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "plain"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	assert.Empty(t, b.ServerSideEncryptionConfiguration)
+}
+
+func TestS3BucketEnricher_VersioningOverlay(t *testing.T) {
+	t.Parallel()
+	enr := newTestS3Enricher(s3FetchHooks{
+		versioning: func(context.Context, *s3.Client, string) (*s3.GetBucketVersioningOutput, error) {
+			return &s3.GetBucketVersioningOutput{
+				Status:    s3types.BucketVersioningStatusEnabled,
+				MFADelete: s3types.MFADeleteStatusDisabled,
+			}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "v"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	require.Len(t, b.Versioning, 1)
+	require.NotNil(t, b.Versioning[0].Enabled)
+	assert.True(t, *b.Versioning[0].Enabled.Literal)
+	require.NotNil(t, b.Versioning[0].MFADelete)
+	assert.False(t, *b.Versioning[0].MFADelete.Literal)
+}
+
+func TestS3BucketEnricher_VersioningNeverConfigured_Absent(t *testing.T) {
+	t.Parallel()
+	// Empty Status + empty MFADelete -> "never configured", block absent.
+	enr := newTestS3Enricher(s3FetchHooks{
+		versioning: func(context.Context, *s3.Client, string) (*s3.GetBucketVersioningOutput, error) {
+			return &s3.GetBucketVersioningOutput{}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "fresh"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	assert.Empty(t, b.Versioning,
+		"versioning block must be absent when Status and MFADelete are both empty")
+}
+
+func TestS3BucketEnricher_LifecycleOverlay(t *testing.T) {
+	t.Parallel()
+	enr := newTestS3Enricher(s3FetchHooks{
+		lifecycle: func(context.Context, *s3.Client, string) ([]s3types.LifecycleRule, error) {
+			return []s3types.LifecycleRule{
+				{
+					ID:     aws.String("rule-1"),
+					Status: s3types.ExpirationStatusEnabled,
+					Prefix: aws.String("logs/"),
+					Expiration: &s3types.LifecycleExpiration{
+						Days: aws.Int32(30),
+					},
+					Transitions: []s3types.Transition{{
+						Days:         aws.Int32(7),
+						StorageClass: s3types.TransitionStorageClassStandardIa,
+					}},
+					NoncurrentVersionExpiration: &s3types.NoncurrentVersionExpiration{
+						NoncurrentDays: aws.Int32(60),
+					},
+					AbortIncompleteMultipartUpload: &s3types.AbortIncompleteMultipartUpload{
+						DaysAfterInitiation: aws.Int32(7),
+					},
+				},
+				{
+					ID:     aws.String("rule-2-disabled"),
+					Status: s3types.ExpirationStatusDisabled,
+				},
+			}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "lc"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	require.Len(t, b.LifecycleRule, 2)
+
+	r1 := b.LifecycleRule[0]
+	require.NotNil(t, r1.ID)
+	assert.Equal(t, "rule-1", *r1.ID.Literal)
+	require.NotNil(t, r1.Enabled)
+	assert.True(t, *r1.Enabled.Literal)
+	require.NotNil(t, r1.Prefix)
+	assert.Equal(t, "logs/", *r1.Prefix.Literal)
+	require.NotNil(t, r1.AbortIncompleteMultipartUploadDays)
+	assert.Equal(t, float64(7), *r1.AbortIncompleteMultipartUploadDays.Literal)
+	require.Len(t, r1.Expiration, 1)
+	require.NotNil(t, r1.Expiration[0].Days)
+	assert.Equal(t, float64(30), *r1.Expiration[0].Days.Literal)
+	require.Len(t, r1.Transition, 1)
+	require.NotNil(t, r1.Transition[0].Days)
+	assert.Equal(t, float64(7), *r1.Transition[0].Days.Literal)
+	require.NotNil(t, r1.Transition[0].StorageClass)
+	assert.Equal(t, string(s3types.TransitionStorageClassStandardIa), *r1.Transition[0].StorageClass.Literal)
+	require.Len(t, r1.NoncurrentVersionExpiration, 1)
+	require.NotNil(t, r1.NoncurrentVersionExpiration[0].Days)
+	assert.Equal(t, float64(60), *r1.NoncurrentVersionExpiration[0].Days.Literal)
+
+	r2 := b.LifecycleRule[1]
+	require.NotNil(t, r2.Enabled)
+	assert.False(t, *r2.Enabled.Literal, "rule with Disabled status must surface Enabled=false")
+}
+
+func TestS3BucketEnricher_LifecycleDateTransitionFormat(t *testing.T) {
+	t.Parallel()
+	// Transition.Date / Expiration.Date should be RFC3339 with Z suffix.
+	when := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	enr := newTestS3Enricher(s3FetchHooks{
+		lifecycle: func(context.Context, *s3.Client, string) ([]s3types.LifecycleRule, error) {
+			return []s3types.LifecycleRule{{
+				Status:     s3types.ExpirationStatusEnabled,
+				Expiration: &s3types.LifecycleExpiration{Date: &when},
+				Transitions: []s3types.Transition{{
+					Date:         &when,
+					StorageClass: s3types.TransitionStorageClassGlacier,
+				}},
+			}}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "date"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	require.Len(t, b.LifecycleRule, 1)
+	require.Len(t, b.LifecycleRule[0].Expiration, 1)
+	require.NotNil(t, b.LifecycleRule[0].Expiration[0].Date)
+	assert.Equal(t, "2024-01-02T03:04:05Z", *b.LifecycleRule[0].Expiration[0].Date.Literal)
+	require.Len(t, b.LifecycleRule[0].Transition, 1)
+	require.NotNil(t, b.LifecycleRule[0].Transition[0].Date)
+	assert.Equal(t, "2024-01-02T03:04:05Z", *b.LifecycleRule[0].Transition[0].Date.Literal)
+}
+
+func TestS3BucketEnricher_LoggingOverlay(t *testing.T) {
+	t.Parallel()
+	enr := newTestS3Enricher(s3FetchHooks{
+		logging: func(context.Context, *s3.Client, string) (*s3types.LoggingEnabled, error) {
+			return &s3types.LoggingEnabled{
+				TargetBucket: aws.String("logs-bucket"),
+				TargetPrefix: aws.String("access/"),
+			}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "src"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	require.Len(t, b.Logging, 1)
+	require.NotNil(t, b.Logging[0].TargetBucket)
+	assert.Equal(t, "logs-bucket", *b.Logging[0].TargetBucket.Literal)
+	require.NotNil(t, b.Logging[0].TargetPrefix)
+	assert.Equal(t, "access/", *b.Logging[0].TargetPrefix.Literal)
+}
+
+func TestS3BucketEnricher_LoggingNilTargetBucket_Absent(t *testing.T) {
+	t.Parallel()
+	// LoggingEnabled with empty TargetBucket means logging is not
+	// actually configured — the block must be absent.
+	enr := newTestS3Enricher(s3FetchHooks{
+		logging: func(context.Context, *s3.Client, string) (*s3types.LoggingEnabled, error) {
+			return &s3types.LoggingEnabled{}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "x"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	assert.Empty(t, b.Logging)
+}
+
+func TestS3BucketEnricher_CorsOverlay(t *testing.T) {
+	t.Parallel()
+	enr := newTestS3Enricher(s3FetchHooks{
+		cors: func(context.Context, *s3.Client, string) ([]s3types.CORSRule, error) {
+			return []s3types.CORSRule{{
+				AllowedMethods: []string{"GET", "HEAD"},
+				AllowedOrigins: []string{"https://example.com"},
+				AllowedHeaders: []string{"Authorization"},
+				ExposeHeaders:  []string{"ETag"},
+				MaxAgeSeconds:  aws.Int32(300),
+			}}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "cors"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	require.Len(t, b.CorsRule, 1)
+	require.Len(t, b.CorsRule[0].AllowedMethods, 2)
+	assert.Equal(t, "GET", *b.CorsRule[0].AllowedMethods[0].Literal)
+	require.Len(t, b.CorsRule[0].AllowedOrigins, 1)
+	assert.Equal(t, "https://example.com", *b.CorsRule[0].AllowedOrigins[0].Literal)
+	require.Len(t, b.CorsRule[0].AllowedHeaders, 1)
+	assert.Equal(t, "Authorization", *b.CorsRule[0].AllowedHeaders[0].Literal)
+	require.Len(t, b.CorsRule[0].ExposeHeaders, 1)
+	assert.Equal(t, "ETag", *b.CorsRule[0].ExposeHeaders[0].Literal)
+	require.NotNil(t, b.CorsRule[0].MaxAgeSeconds)
+	assert.Equal(t, int64(300), *b.CorsRule[0].MaxAgeSeconds.Literal)
+}
+
+func TestS3BucketEnricher_PolicyOverlay(t *testing.T) {
+	t.Parallel()
+	doc := `{"Version":"2012-10-17","Statement":[]}`
+	enr := newTestS3Enricher(s3FetchHooks{
+		policy: func(context.Context, *s3.Client, string) (*string, error) {
+			return &doc, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "p"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	require.NotNil(t, b.Policy)
+	assert.Equal(t, doc, *b.Policy.Literal)
+}
+
+func TestS3BucketEnricher_WebsiteOverlay(t *testing.T) {
+	t.Parallel()
+	enr := newTestS3Enricher(s3FetchHooks{
+		website: func(context.Context, *s3.Client, string) (*s3.GetBucketWebsiteOutput, error) {
+			return &s3.GetBucketWebsiteOutput{
+				IndexDocument: &s3types.IndexDocument{Suffix: aws.String("index.html")},
+				ErrorDocument: &s3types.ErrorDocument{Key: aws.String("404.html")},
+			}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "w"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	require.Len(t, b.Website, 1)
+	require.NotNil(t, b.Website[0].IndexDocument)
+	assert.Equal(t, "index.html", *b.Website[0].IndexDocument.Literal)
+	require.NotNil(t, b.Website[0].ErrorDocument)
+	assert.Equal(t, "404.html", *b.Website[0].ErrorDocument.Literal)
+}
+
+func TestS3BucketEnricher_WebsiteRedirectOnly(t *testing.T) {
+	t.Parallel()
+	enr := newTestS3Enricher(s3FetchHooks{
+		website: func(context.Context, *s3.Client, string) (*s3.GetBucketWebsiteOutput, error) {
+			return &s3.GetBucketWebsiteOutput{
+				RedirectAllRequestsTo: &s3types.RedirectAllRequestsTo{
+					HostName: aws.String("example.com"),
+					Protocol: s3types.ProtocolHttps,
+				},
+			}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "r"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	require.Len(t, b.Website, 1)
+	require.NotNil(t, b.Website[0].RedirectAllRequestsTo)
+	assert.Equal(t, "https://example.com", *b.Website[0].RedirectAllRequestsTo.Literal)
+}
+
+func TestS3BucketEnricher_WebsiteEmpty_Absent(t *testing.T) {
+	t.Parallel()
+	enr := newTestS3Enricher(s3FetchHooks{
+		website: func(context.Context, *s3.Client, string) (*s3.GetBucketWebsiteOutput, error) {
+			return &s3.GetBucketWebsiteOutput{}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "wempty"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	assert.Empty(t, b.Website)
+}
+
+func TestS3BucketEnricher_TagsOverlay(t *testing.T) {
+	t.Parallel()
+	enr := newTestS3Enricher(s3FetchHooks{
+		tags: func(context.Context, *s3.Client, string) ([]s3types.Tag, error) {
+			return []s3types.Tag{
+				{Key: aws.String("Env"), Value: aws.String("prod")},
+				{Key: aws.String("Team"), Value: aws.String("payments")},
+			}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "tagged"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	require.NotNil(t, b.Tags)
+	require.NotNil(t, b.Tags["Env"])
+	assert.Equal(t, "prod", *b.Tags["Env"].Literal)
+	require.NotNil(t, b.Tags["Team"])
+	assert.Equal(t, "payments", *b.Tags["Team"].Literal)
+}
+
+func TestS3BucketEnricher_ObjectLockOverlay(t *testing.T) {
+	t.Parallel()
+	enr := newTestS3Enricher(s3FetchHooks{
+		objectLock: func(context.Context, *s3.Client, string) (*s3types.ObjectLockConfiguration, error) {
+			return &s3types.ObjectLockConfiguration{
+				ObjectLockEnabled: s3types.ObjectLockEnabledEnabled,
+				Rule: &s3types.ObjectLockRule{
+					DefaultRetention: &s3types.DefaultRetention{
+						Mode: s3types.ObjectLockRetentionModeGovernance,
+						Days: aws.Int32(30),
+					},
+				},
+			}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "ol"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	b := decodeS3BucketAttrs(t, ir)
+	require.Len(t, b.ObjectLockConfiguration, 1)
+	require.NotNil(t, b.ObjectLockConfiguration[0].ObjectLockEnabled)
+	assert.Equal(t, string(s3types.ObjectLockEnabledEnabled), *b.ObjectLockConfiguration[0].ObjectLockEnabled.Literal)
+	require.Len(t, b.ObjectLockConfiguration[0].Rule, 1)
+	require.Len(t, b.ObjectLockConfiguration[0].Rule[0].DefaultRetention, 1)
+	dr := b.ObjectLockConfiguration[0].Rule[0].DefaultRetention[0]
+	require.NotNil(t, dr.Mode)
+	assert.Equal(t, string(s3types.ObjectLockRetentionModeGovernance), *dr.Mode.Literal)
+	require.NotNil(t, dr.Days)
+	assert.Equal(t, float64(30), *dr.Days.Literal)
+
+	// Top-level mirror.
+	require.NotNil(t, b.ObjectLockEnabled)
+	assert.True(t, *b.ObjectLockEnabled.Literal)
+}
+
+// TestS3BucketEnricher_OverlaysSoftFailOnError exercises the
+// soft-fail discipline: every overlay error (real or service-native
+// "not configured") must downgrade to an absent block; only the
+// load-bearing HeadBucket failure is fatal.
+func TestS3BucketEnricher_OverlaysSoftFailOnError(t *testing.T) {
+	t.Parallel()
+	apiErr := errors.New("AccessDeniedException")
+	notSetErr := &stubAPIError{code: "NoSuchBucketPolicy"}
+	enr := newTestS3Enricher(s3FetchHooks{
+		// Head succeeds — we want to reach the overlays.
+		encryption: func(context.Context, *s3.Client, string) (*s3types.ServerSideEncryptionConfiguration, error) {
+			return nil, apiErr
+		},
+		versioning: func(context.Context, *s3.Client, string) (*s3.GetBucketVersioningOutput, error) {
+			return nil, apiErr
+		},
+		lifecycle: func(context.Context, *s3.Client, string) ([]s3types.LifecycleRule, error) {
+			return nil, apiErr
+		},
+		logging: func(context.Context, *s3.Client, string) (*s3types.LoggingEnabled, error) {
+			return nil, apiErr
+		},
+		cors: func(context.Context, *s3.Client, string) ([]s3types.CORSRule, error) {
+			return nil, apiErr
+		},
+		policy: func(context.Context, *s3.Client, string) (*string, error) {
+			return nil, notSetErr
+		},
+		website: func(context.Context, *s3.Client, string) (*s3.GetBucketWebsiteOutput, error) {
+			return nil, apiErr
+		},
+		tags: func(context.Context, *s3.Client, string) ([]s3types.Tag, error) {
+			return nil, apiErr
+		},
+		objectLock: func(context.Context, *s3.Client, string) (*s3types.ObjectLockConfiguration, error) {
+			return nil, apiErr
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "x"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}),
+		"overlay errors must be downgraded; only head failure is fatal")
+	require.NotEmpty(t, ir.Attrs)
+	b := decodeS3BucketAttrs(t, ir)
+	assert.Empty(t, b.ServerSideEncryptionConfiguration)
+	assert.Empty(t, b.Versioning)
+	assert.Empty(t, b.LifecycleRule)
+	assert.Empty(t, b.Logging)
+	assert.Empty(t, b.CorsRule)
+	assert.Nil(t, b.Policy)
+	assert.Empty(t, b.Website)
+	assert.Empty(t, b.Tags)
+	assert.Empty(t, b.ObjectLockConfiguration)
+}
+
+func TestS3BucketEnricher_EnrichByID_HappyPath(t *testing.T) {
+	t.Parallel()
+	enr := newTestS3Enricher(s3FetchHooks{
+		head: func(context.Context, *s3.Client, string) (*s3.HeadBucketOutput, error) {
+			return &s3.HeadBucketOutput{
+				BucketRegion: aws.String("eu-west-1"),
+			}, nil
+		},
+		tags: func(context.Context, *s3.Client, string) ([]s3types.Tag, error) {
+			return []s3types.Tag{{Key: aws.String("K"), Value: aws.String("V")}}, nil
+		},
+	})
+	raw, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type: "aws_s3_bucket", NameHint: "byid",
+	}, EnrichClients{S3: &s3.Client{}})
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	decoded, err := generated.UnmarshalAttrs("aws_s3_bucket", raw)
+	require.NoError(t, err)
+	b, ok := decoded.(*generated.AWSS3Bucket)
+	require.True(t, ok)
+	require.NotNil(t, b.Bucket)
+	assert.Equal(t, "byid", *b.Bucket.Literal)
+	require.NotNil(t, b.Region)
+	assert.Equal(t, "eu-west-1", *b.Region.Literal)
+	require.NotNil(t, b.Tags["K"])
+	assert.Equal(t, "V", *b.Tags["K"].Literal)
+}
+
+// TestS3BucketEnricher_EnrichAndEnrichByIDProduceSameJSON pins the
+// shape contract: the raw JSON from Enrich (written into ir.Attrs)
+// and EnrichByID (returned directly) must be byte-equivalent for the
+// same fixture. Mirrors the cloudwatch-log-group sanity pin.
+func TestS3BucketEnricher_EnrichAndEnrichByIDProduceSameJSON(t *testing.T) {
+	t.Parallel()
+	hooks := s3FetchHooks{
+		head: func(context.Context, *s3.Client, string) (*s3.HeadBucketOutput, error) {
+			return &s3.HeadBucketOutput{BucketRegion: aws.String("us-west-2")}, nil
+		},
+		versioning: func(context.Context, *s3.Client, string) (*s3.GetBucketVersioningOutput, error) {
+			return &s3.GetBucketVersioningOutput{Status: s3types.BucketVersioningStatusEnabled}, nil
+		},
+		tags: func(context.Context, *s3.Client, string) ([]s3types.Tag, error) {
+			return []s3types.Tag{{Key: aws.String("Tier"), Value: aws.String("gold")}}, nil
+		},
+	}
+	enr := newTestS3Enricher(hooks)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "same"},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+
+	raw, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type: "aws_s3_bucket", NameHint: "same",
+	}, EnrichClients{S3: &s3.Client{}})
+	require.NoError(t, err)
+
+	// Compare via round-trip-normalized JSON so map-key ordering doesn't
+	// cause a false negative.
+	var a, b any
+	require.NoError(t, json.Unmarshal(ir.Attrs, &a))
+	require.NoError(t, json.Unmarshal(raw, &b))
+	assert.Equal(t, a, b, "Enrich and EnrichByID must produce equivalent JSON payloads")
+}
+
+// TestS3BucketEnricher_RegisteredInProductionDiscoverer pins that
+// NewAWSDiscoverer wires up the S3 enricher. Mirrors the dynamodb
+// production-registration pin.
+func TestS3BucketEnricher_RegisteredInProductionDiscoverer(t *testing.T) {
+	t.Parallel()
+	a := NewAWSDiscoverer(awsDummyConfig())
+	require.NotNil(t, a.byTypeEnricher, "byTypeEnricher must be initialized")
+	enr, ok := a.byTypeEnricher["aws_s3_bucket"]
+	require.True(t, ok, "aws_s3_bucket must be registered in NewAWSDiscoverer")
+	assert.Equal(t, "aws_s3_bucket", enr.ResourceType())
+	_, isByID := enr.(ByIDEnricher)
+	assert.True(t, isByID, "s3 enricher must satisfy ByIDEnricher")
+}
+
+// TestS3BucketEnricher_IsS3NotSetError_PinsCodes locks the service-
+// native "feature not configured" error codes the production fetchers
+// rely on. If a future AWS SDK rename changes a code, this fails
+// loudly — any deployed enricher's overlay would otherwise silently
+// start surfacing real errors. Locking the codes here keeps the
+// upgrade signal loud.
+func TestS3BucketEnricher_IsS3NotSetError_PinsCodes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		code    string
+		matches []string
+	}{
+		{"NoSuchBucketPolicy", []string{"NoSuchBucketPolicy"}},
+		{"NoSuchCORSConfiguration", []string{"NoSuchCORSConfiguration"}},
+		{"NoSuchLifecycleConfiguration", []string{"NoSuchLifecycleConfiguration"}},
+		{"NoSuchTagSet", []string{"NoSuchTagSet"}},
+		{"NoSuchWebsiteConfiguration", []string{"NoSuchWebsiteConfiguration"}},
+		{"ServerSideEncryptionConfigurationNotFoundError", []string{"ServerSideEncryptionConfigurationNotFoundError"}},
+		{"ObjectLockConfigurationNotFoundError", []string{"ObjectLockConfigurationNotFoundError"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.code, func(t *testing.T) {
+			err := &stubAPIError{code: tc.code}
+			assert.True(t, isS3NotSetError(err, tc.matches...),
+				"code %q must be recognized by isS3NotSetError", tc.code)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds the hand-rolled `aws_s3_bucket` attribute enricher and registers it
in `NewAWSDiscoverer.byTypeEnricher` (#493). Implements both
`AttributeEnricher` and `ByIDEnricher` so per-IR drift refresh works.

- **Load-bearing call:** `HeadBucket` (existence + region).
  `NotFound` / `NoSuchBucket` collapse to `ErrNotFound`.
- **Nine soft-fail overlays:** `GetBucketEncryption`,
  `GetBucketVersioning`, `GetBucketLifecycleConfiguration`,
  `GetBucketLogging`, `GetBucketCors`, `GetBucketPolicy`,
  `GetBucketWebsite`, `GetBucketTagging`,
  `GetObjectLockConfiguration`. Service-native "feature not
  configured" codes (NoSuchBucketPolicy, NoSuchCORSConfiguration,
  NoSuchLifecycleConfiguration,
  ServerSideEncryptionConfigurationNotFoundError, NoSuchTagSet,
  NoSuchWebsiteConfiguration,
  ObjectLockConfigurationNotFoundError) are recognised via the
  existing `isS3NotSetError` helper and downgraded identically to
  real errors at the typed-payload level.
- **Function-field injection** for each SDK hook keeps the test
  file hermetic; mirrors `dynamodb_table_enrich.go`'s pattern. New
  `s3FetchHooks` struct-of-closures keeps call sites readable now
  that S3 has too many overlays for a positional signature.
- **`wantTotal`** in `byid_enricher_test.go` bumped from 3 → 4;
  the S3 entry implements `ByIDEnricher` and does NOT appear in
  the `notImplemented` allowlist.

`EnrichClients.S3` was already in place from prior infrastructure; no
wiring changes were needed there.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./cmd/insideout-import/awsdiscover/... -count=1` (724 passing)
- [x] `go test ./cmd/insideout-import/awsdiscover/... -count=1 -race -run S3Bucket`
- [x] Full repo `go test ./... -count=1` (5301 passing)

## Follow-ups

- **#490** Cloud Control unified enricher: once #490 proves out S3
  coverage, this hand-rolled file can be retired as an override
  (per the issue's "Bucket C / sdkonly stays-hand-rolled" framing).
  The registration in `NewAWSDiscoverer` can flip to the unified
  path in a one-line change at that point.
- **#495 (#494)** fetcher scaffolding: per the task brief, the S3
  SDK hooks were intentionally written inline (matching
  `dynamodb_table_enrich.go`) rather than depending on the in-flight
  fetcher framework. A future PR can migrate these hooks to the
  scaffolding once both PRs have landed.

Closes #493