### PR TITLE
feat(imported): Cloud Control HYBRID enricher — steps 1+2 (json tags + generic wiring)

### DIFF
--- a/cmd/imported-codegen/templates/type.gen.go.tmpl
+++ b/cmd/imported-codegen/templates/type.gen.go.tmpl
@@ -8,7 +8,7 @@ import "reflect"
 // `{{.TFType}}` Terraform resource.
 type {{.GoName}} struct {
 {{- range .Fields}}
-	{{.GoName}} {{.GoType}} {{backtick}}tf:"{{.TFName}}{{if .BlockKind}},{{.BlockKind}}{{end}}"{{backtick}}
+	{{.GoName}} {{.GoType}} {{backtick}}tf:"{{.TFName}}{{if .BlockKind}},{{.BlockKind}}{{end}}" json:"{{.TFName}},omitempty"{{backtick}}
 {{- end}}
 }
 
@@ -16,7 +16,7 @@ type {{.GoName}} struct {
 // {{.GoName}} is a nested-block type used by the parent resource.
 type {{.GoName}} struct {
 {{- range .Fields}}
-	{{.GoName}} {{.GoType}} {{backtick}}tf:"{{.TFName}}{{if .BlockKind}},{{.BlockKind}}{{end}}"{{backtick}}
+	{{.GoName}} {{.GoType}} {{backtick}}tf:"{{.TFName}}{{if .BlockKind}},{{.BlockKind}}{{end}}" json:"{{.TFName}},omitempty"{{backtick}}
 {{- end}}
 }
 {{end}}

--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -190,27 +190,48 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 	for _, soCfg := range sdkOnlySubresourceTypeConfigs {
 		byType[soCfg.TFType] = newSDKOnlySubresourceDiscoverer(soCfg, cfg, maxConcurrency)
 	}
+	// Per-type SDK attribute enrichers (#457). Each entry is a sibling
+	// to the byType discoverer of the same name and populates ir.Attrs
+	// (the typed Layer 1 payload). Types without an entry here are
+	// silently skipped by EnrichAttributes — the full enricher rollout
+	// follows the existing per-type ordering one PR at a time. Mirrors
+	// gcpdiscover.GCPDiscoverer (presets#403).
+	//
+	// Hand-rolled enrichers win as overrides over the generic Cloud
+	// Control fallback below — they produce strictly more correct
+	// payloads today (primary-name field aliasing, ARN normalization,
+	// tag-overlay fetches), per the PoC report in
+	// .tmp/cloud-control-enricher-poc.md. The Cloud Control enricher
+	// fills in the long tail of CC-routed types that have no hand-rolled
+	// override.
+	byTypeEnricher := map[string]AttributeEnricher{
+		"aws_cloudwatch_log_group":  newCloudWatchLogGroupEnricher(),
+		"aws_dynamodb_table":        newDynamoDBTableEnricher(),
+		"aws_secretsmanager_secret": newSecretsManagerSecretEnricher(),
+	}
+	// HYBRID Cloud Control fallback (#490 steps 1+2): register one
+	// cloudControlEnricher for every TF type in cloudControlTypeConfigs
+	// that doesn't already have a hand-rolled override above. Hand-rolled
+	// wins; the loop iterates the same config the discoverer uses so the
+	// enricher coverage stays in lockstep with the listing coverage.
+	//
+	// The enricher's GetResource callback defaults to nil and is
+	// resolved at Enrich time from EnrichClients.CloudControl. Callers
+	// constructing EnrichClients without a CloudControl client see a
+	// per-resource ErrEnrichClientUnavailable warning (not a batch-fatal
+	// error) so a partial-credentials run still produces useful output
+	// from the hand-rolled enrichers.
+	for _, ccCfg := range cloudControlTypeConfigs {
+		if _, has := byTypeEnricher[ccCfg.TFType]; has {
+			continue
+		}
+		byTypeEnricher[ccCfg.TFType] = newCloudControlEnricher(ccCfg.TFType, ccCfg.CloudFormationType, nil)
+	}
 	return &AWSDiscoverer{
-		defaultRegion: cfg.Region,
-		byType:        byType,
-		rgtPrefetcher: newRealRGTPrefetcher(cfg),
-		// Per-type SDK attribute enrichers (#457). Each entry is a sibling
-		// to the byType discoverer of the same name and populates ir.Attrs
-		// (the typed Layer 1 payload). Types without an entry here are
-		// silently skipped by EnrichAttributes — the full enricher rollout
-		// follows the existing per-type ordering one PR at a time. Mirrors
-		// gcpdiscover.GCPDiscoverer (presets#403).
-		//
-		// aws_s3_bucket follows once presets bundle #461 lands the Layer
-		// 1 typed struct in pkg/composer/imported/generated. The S3
-		// enricher infrastructure (EnrichClients.S3 field, codegen
-		// support) is in place already so the wiring there is a one-line
-		// registration.
-		byTypeEnricher: map[string]AttributeEnricher{
-			"aws_cloudwatch_log_group":  newCloudWatchLogGroupEnricher(),
-			"aws_dynamodb_table":        newDynamoDBTableEnricher(),
-			"aws_secretsmanager_secret": newSecretsManagerSecretEnricher(),
-		},
+		defaultRegion:  cfg.Region,
+		byType:         byType,
+		rgtPrefetcher:  newRealRGTPrefetcher(cfg),
+		byTypeEnricher: byTypeEnricher,
 	}
 }
 

--- a/cmd/insideout-import/awsdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/awsdiscover/byid_enricher_test.go
@@ -49,11 +49,27 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 
 	// Fail-fast: pin the expected total byTypeEnricher size so a
 	// silent drop (or duplicate-key squashing) in production fails the
-	// test. The expected total = allowlist size + types that DO
-	// implement ByIDEnricher. When adding a new enricher: bump
-	// wantTotal and either add to allowlist (no ByIDEnricher) or leave
-	// it off (implements ByIDEnricher).
-	const wantTotal = 3 // dynamodb_table + cloudwatch_log_group + secretsmanager_secret
+	// test. The expected total = 3 hand-rolled enrichers
+	// (cloudwatch_log_group, dynamodb_table, secretsmanager_secret) +
+	// every type in cloudControlTypeConfigs that doesn't have a
+	// hand-rolled override. The latter is computed at test time so an
+	// addition to cloudControlTypeConfigs doesn't silently flow into
+	// the production enricher coverage without a deliberate test
+	// update — the math below makes that change visible as a numeric
+	// diff in the test failure message.
+	handRolled := 3
+	ccOverrides := 0
+	handRolledTypes := map[string]bool{
+		"aws_cloudwatch_log_group":  true,
+		"aws_dynamodb_table":        true,
+		"aws_secretsmanager_secret": true,
+	}
+	for _, ccCfg := range cloudControlTypeConfigs {
+		if handRolledTypes[ccCfg.TFType] {
+			ccOverrides++
+		}
+	}
+	wantTotal := handRolled + len(cloudControlTypeConfigs) - ccOverrides
 	if got := len(d.byTypeEnricher); got != wantTotal {
 		t.Errorf("byTypeEnricher size = %d, want %d (production registration drifted from test)", got, wantTotal)
 	}
@@ -66,6 +82,54 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 			t.Errorf("%s: enricher now implements ByIDEnricher — remove from notImplemented allowlist", tfType)
 		case !expectNot && !implementsByID:
 			t.Errorf("%s: enricher must implement ByIDEnricher (not in notImplemented allowlist)", tfType)
+		}
+	}
+}
+
+// TestCloudControlEnricherCoversEveryCCRoutedType asserts that every
+// TF type in cloudControlTypeConfigs has a registered AttributeEnricher
+// in NewAWSDiscoverer.byTypeEnricher — either a hand-rolled override
+// (3 types today) or a generic cloudControlEnricher. A regression that
+// drops the cloudControlEnricher wiring loop in NewAWSDiscoverer would
+// silently strip Cloud Control coverage from ~91 types; this test
+// catches that as a per-type miss rather than waiting for a downstream
+// integration test to surface the regression.
+func TestCloudControlEnricherCoversEveryCCRoutedType(t *testing.T) {
+	d := NewAWSDiscoverer(aws.Config{})
+	for _, ccCfg := range cloudControlTypeConfigs {
+		if _, ok := d.byTypeEnricher[ccCfg.TFType]; !ok {
+			t.Errorf("cloudcontrol-routed TFType %q has no registered AttributeEnricher", ccCfg.TFType)
+		}
+	}
+}
+
+// TestCloudControlEnricherSkipsHandRolledOverrides asserts the
+// override-wins invariant in NewAWSDiscoverer's wiring loop: for every
+// TF type that has a hand-rolled enricher AND a cloudControlTypeConfigs
+// entry, the registered enricher must be the hand-rolled one (not the
+// generic cloudControlEnricher). A silent regression that flips the
+// override order would replace the higher-fidelity hand-rolled payloads
+// with the lower-fidelity Cloud Control payloads (the PoC quantified
+// the quality gap at 57% on log groups).
+func TestCloudControlEnricherSkipsHandRolledOverrides(t *testing.T) {
+	d := NewAWSDiscoverer(aws.Config{})
+	// Mirrors the hand-rolled set in NewAWSDiscoverer.byTypeEnricher.
+	// Kept as a literal slice rather than a reflection-based scan so
+	// adding a new hand-rolled enricher requires an explicit update
+	// here — the next reviewer sees the intent in the test diff.
+	handRolled := []string{
+		"aws_cloudwatch_log_group",
+		"aws_dynamodb_table",
+		"aws_secretsmanager_secret",
+	}
+	for _, tfType := range handRolled {
+		enr, ok := d.byTypeEnricher[tfType]
+		if !ok {
+			t.Errorf("%s: missing from byTypeEnricher", tfType)
+			continue
+		}
+		if _, isCC := enr.(*cloudControlEnricher); isCC {
+			t.Errorf("%s: registered enricher is cloudControlEnricher, want hand-rolled override", tfType)
 		}
 	}
 }

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_enricher.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_enricher.go
@@ -1,0 +1,360 @@
+package awsdiscover
+
+// cloudcontrol_enricher.go — generic AWS attribute enricher backed by
+// Cloud Control API (issue #490, HYBRID adoption — steps 1+2).
+//
+// One generic enricher type that calls
+// cloudcontrol.GetResource(TypeName, Identifier) and unmarshals the
+// resulting Properties JSON blob (CloudFormation schema shape) directly
+// into the matching pkg/composer/imported/generated.AWS<Type> Layer-1
+// struct, then re-marshals into ir.Attrs. The wire-format prerequisite
+// is the `json:"<snake_name>"` tags emitted by cmd/imported-codegen on
+// every generated Layer-1 field (step 1 of this PR) — without them, the
+// CloudFormation CamelCase keys would silently miss every field.
+//
+// Coverage and overrides: NewAWSDiscoverer registers one
+// cloudControlEnricher per entry in cloudControlTypeConfigs that does
+// NOT already have a hand-rolled AttributeEnricher in byTypeEnricher.
+// Hand-rolled enrichers win as overrides (see awsdiscover.go), so the
+// existing aws_cloudwatch_log_group / aws_dynamodb_table /
+// aws_secretsmanager_secret enrichers continue to produce richer
+// payloads than this generic path does today.
+//
+// Quality band: the PoC (.tmp/cloud-control-enricher-poc.md) quantified
+// aws_cloudwatch_log_group at 57% exact field match. Two systemic
+// gotchas the PoC identified — primary-name CFN-vs-TF divergence
+// (LogGroupName/BucketName/QueueName vs Terraform's `name`) and
+// computed-only field normalization (e.g. ARN trailing-`:*` strip) —
+// are addressed in follow-up Step 3 (Normalizer hooks) which is NOT in
+// scope for this PR. Fields that don't map are silently absent on the
+// enriched payload, which is the design contract (decision #5 elides
+// computed-only fields downstream anyway).
+//
+// Soft-fail posture: a NoSuchResource error from Cloud Control (the
+// resource was deleted between discovery and enrichment, or the
+// operator's IAM principal lacks read permission on this specific
+// CFN type) is wrapped in ErrNotFound so EnrichAttributes can route it
+// through its non-fatal aggregation. Per-type IAM gaps are the most
+// likely real-world cause; soft-failing means a single missing
+// permission won't abort a full discover-and-enrich run.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// cloudControlGetResourceFn is the narrow GetResource RPC interface
+// satisfied by both the real *cloudcontrol.Client and any in-test fake.
+// Identical signature to the GetResource method on cloudControlClient
+// in cloudcontrol_discoverer.go; declared separately so the enricher
+// can be exercised against a closure-style fake without dragging in the
+// listing-side interface the discoverer needs.
+type cloudControlGetResourceFn func(ctx context.Context, in *cloudcontrol.GetResourceInput, opts ...func(*cloudcontrol.Options)) (*cloudcontrol.GetResourceOutput, error)
+
+// cloudControlEnricher is the generic AttributeEnricher / ByIDEnricher
+// pair for a single Terraform resource type. One instance is constructed
+// per cloudControlTypeConfigs entry that doesn't already have a
+// hand-rolled override in NewAWSDiscoverer.byTypeEnricher.
+//
+// resourceType pins the Terraform-side type this instance covers
+// (so ResourceType() / EnrichByID / Enrich return / dispatch on the
+// same key). cfnType is the matching CloudFormation type passed to
+// cloudcontrol.GetResource — sourced from cloudControlConfig.CloudFormationType
+// at construction time so a single map drives both the discoverer and
+// the enricher wiring.
+//
+// get is overridable for unit tests. Defaults to a real
+// *cloudcontrol.Client constructed by NewAWSDiscoverer from the shared
+// aws.Config; tests inject a closure to synthesize GetResource
+// responses without an AWS account.
+type cloudControlEnricher struct {
+	resourceType string
+	cfnType      string
+	get          cloudControlGetResourceFn
+}
+
+// newCloudControlEnricher constructs an enricher for a single
+// (tfType, cfnType) pair. get is optional: tests inject a closure to
+// stub GetResource without an AWS account; production wiring (see
+// NewAWSDiscoverer) passes nil and the enricher pulls
+// c.CloudControl.GetResource off the EnrichClients passed to Enrich /
+// EnrichByID at call time. The lazy-resolve shape (vs. requiring get
+// at construction time) keeps NewAWSDiscoverer free of an
+// aws.Config-derived *cloudcontrol.Client — that client is owned by
+// the caller and threaded through EnrichClients alongside the other
+// SDK clients.
+func newCloudControlEnricher(tfType, cfnType string, get cloudControlGetResourceFn) *cloudControlEnricher {
+	return &cloudControlEnricher{
+		resourceType: tfType,
+		cfnType:      cfnType,
+		get:          get,
+	}
+}
+
+// ResourceType returns the Terraform type this enricher covers.
+func (e *cloudControlEnricher) ResourceType() string { return e.resourceType }
+
+// Enrich populates ir.Attrs with the typed Layer-1 payload mapped from
+// the CloudFormation properties blob. Returns
+// ErrEnrichClientUnavailable when c.CloudControl is nil (and no
+// test-injected get callback is set on the enricher) so callers can
+// distinguish "client not wired" from a real API error. A Cloud
+// Control NoSuchResource (or absent-equivalent) is wrapped in
+// ErrNotFound and EnrichAttributes treats that as a soft-fail /
+// per-resource warning rather than aborting the batch.
+func (e *cloudControlEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if ir == nil {
+		return errors.New("cloudcontrol enricher: ir is nil")
+	}
+	get, err := e.resolveGet(c)
+	if err != nil {
+		return err
+	}
+	raw, err := e.fetchAndMap(ctx, get, &ir.Identity)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID is the ByIDEnricher entry point. Same SDK + mapping path
+// as Enrich, but returns the raw payload instead of mutating an IR.
+// Used by the per-IR drift refresh path (pkg/imported.Provider.EnrichByID,
+// #482) where the caller already holds an Identity and only wants the
+// typed payload.
+func (e *cloudControlEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, errors.New("cloudcontrol enricher: identity is nil")
+	}
+	get, err := e.resolveGet(c)
+	if err != nil {
+		return nil, err
+	}
+	return e.fetchAndMap(ctx, get, identity)
+}
+
+// resolveGet returns the GetResource callback this Enrich / EnrichByID
+// invocation should use. Prefers the field-injected `get` (test path);
+// falls back to c.CloudControl.GetResource (production path). Returns
+// ErrEnrichClientUnavailable when neither is wired so callers can
+// distinguish "no Cloud Control client configured" from a real API
+// failure.
+//
+// Pure-function shape (returns the resolved callback rather than
+// mutating e.get) keeps the enricher safe to invoke concurrently
+// against the same instance — EnrichAttributes drives sequentially
+// today, but the underlying contract should not rely on that to stay
+// race-free.
+func (e *cloudControlEnricher) resolveGet(c EnrichClients) (cloudControlGetResourceFn, error) {
+	if e.get != nil {
+		return e.get, nil
+	}
+	if c.CloudControl == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	return c.CloudControl.GetResource, nil
+}
+
+// fetchAndMap issues the GetResource call and unmarshals the
+// CloudFormation properties blob directly into the registered
+// generated.AWS<Type> Layer-1 struct, then re-marshals to JSON for
+// ir.Attrs. Three failure modes:
+//
+//  1. Cannot derive an identifier from the Identity (no ImportID and no
+//     NameHint) — programmer error or a discoverer that didn't stamp
+//     either; returns a wrapped error so callers can spot the
+//     misconfiguration at test time.
+//  2. Cloud Control returns NoSuchResource / equivalent — wrapped in
+//     ErrNotFound. EnrichAttributes already routes ErrNotFound through
+//     a per-resource warning rather than a batch-fatal error.
+//  3. The TF type isn't registered in pkg/composer/imported/generated —
+//     wrapped as a hard error since this is a wiring bug (every TF type
+//     in cloudControlTypeConfigs MUST have a generated Layer-1 struct
+//     for the enricher to land its payload).
+//
+// CloudFormation returns the properties payload as CamelCase keys; the
+// json-tag-driven unmarshal pivots on the lowercase-snake_case JSON tags
+// emitted by cmd/imported-codegen. Without the json tags (step 1 of
+// this PR), every CamelCase key would silently land at an empty field.
+//
+// Computed-only fields the CFN payload includes (e.g. Arn) flow through
+// to the generated struct's matching field; downstream emitters decide
+// whether to elide them per decision #5 (pkg/composer/imported/policy/).
+// Fields whose CFN names don't snake_case-rename onto a Layer-1 field —
+// notably primary-name properties like LogGroupName / BucketName /
+// QueueName whose TF equivalent is just `name` — are silently dropped
+// today. Step 3 (Normalizer hooks) will rename those before unmarshal.
+func (e *cloudControlEnricher) fetchAndMap(ctx context.Context, get cloudControlGetResourceFn, identity *imported.ResourceIdentity) (json.RawMessage, error) {
+	identifier := identity.ImportID
+	if identifier == "" {
+		identifier = identity.NameHint
+	}
+	if identifier == "" {
+		return nil, fmt.Errorf("cloudcontrol enricher: cannot derive identifier from Identity (Address=%q)", identity.Address)
+	}
+	out, err := get(ctx, &cloudcontrol.GetResourceInput{
+		TypeName:   aws.String(e.cfnType),
+		Identifier: aws.String(identifier),
+	})
+	if err != nil {
+		if isCloudControlNotFound(err) {
+			return nil, fmt.Errorf("cloudcontrol enricher: %s %q: %w", e.cfnType, identifier, ErrNotFound)
+		}
+		return nil, fmt.Errorf("cloudcontrol enricher: GetResource %s %q: %w", e.cfnType, identifier, err)
+	}
+	if out == nil || out.ResourceDescription == nil || out.ResourceDescription.Properties == nil {
+		return nil, fmt.Errorf("cloudcontrol enricher: empty response for %s %q: %w", e.cfnType, identifier, ErrNotFound)
+	}
+
+	// Convert CamelCase property keys to snake_case so the json tags on
+	// the registered Layer-1 struct can match. The unmarshal would
+	// otherwise silently drop every CamelCase property (json tags are
+	// snake_case; the case-insensitive matcher in encoding/json does
+	// not bridge underscore-vs-no-underscore differences). Scalar
+	// leaves are wrapped in {"literal": …} envelopes so the resulting
+	// payload unmarshals into the generated.Value[T] type the Layer-1
+	// struct fields use; without the wrap, a bare CFN scalar fails to
+	// decode (Value[T].UnmarshalJSON rejects non-object input).
+	var props map[string]any
+	if err := json.Unmarshal([]byte(*out.ResourceDescription.Properties), &props); err != nil {
+		return nil, fmt.Errorf("cloudcontrol enricher: parse properties for %s %q: %w", e.cfnType, identifier, err)
+	}
+	shaped := shapeCFNForLayer1(props)
+	shapedJSON, err := json.Marshal(shaped)
+	if err != nil {
+		return nil, fmt.Errorf("cloudcontrol enricher: re-marshal snake_case for %s %q: %w", e.cfnType, identifier, err)
+	}
+
+	// Decode into the registered Layer-1 struct then re-marshal so the
+	// output payload uses the canonical json-tag wire format. The
+	// generated.UnmarshalAttrs call also serves as a wiring sanity
+	// check — if the TF type isn't registered, the enricher fails
+	// loudly rather than silently emitting raw CFN-shaped JSON.
+	decoded, err := generated.UnmarshalAttrs(e.resourceType, shapedJSON)
+	if err != nil {
+		return nil, fmt.Errorf("cloudcontrol enricher: unmarshal into %s: %w", e.resourceType, err)
+	}
+	raw, err := json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("cloudcontrol enricher: marshal Attrs for %s %q: %w", e.cfnType, identifier, err)
+	}
+	return raw, nil
+}
+
+// shapeCFNForLayer1 performs the minimum-viable transform that maps a
+// CloudFormation property tree into the shape the generated Layer-1
+// structs expect: CamelCase → snake_case keys, scalar leaves wrapped
+// in {"literal": …} envelopes (so they decode into generated.Value[T]),
+// nested maps and lists recursed.
+//
+// Out-of-scope per #490 Step 3:
+//   - Tag-list-of-{Key,Value} → flat tag map (CFN's most common tag
+//     shape vs Terraform's map shape).
+//   - Primary-name aliasing (LogGroupName → name, BucketName → bucket,
+//     etc.) — type-specific and tracked in the Normalizer hooks
+//     follow-up.
+//   - Computed-only field normalization (e.g. strip trailing `:*` from
+//     log-group ARN).
+//
+// Fields whose CFN names don't snake_case-rename onto a generated TF
+// field land at the top-level map but are silently dropped by
+// generated.UnmarshalAttrs (json's default is to ignore unknown
+// keys). The PoC report (.tmp/cloud-control-enricher-poc.md)
+// quantifies this as the 43% gap on aws_cloudwatch_log_group — the
+// remaining 57% is what this PR delivers as the HYBRID baseline.
+func shapeCFNForLayer1(props map[string]any) map[string]any {
+	if props == nil {
+		return nil
+	}
+	out := make(map[string]any, len(props))
+	for k, v := range props {
+		out[camelToSnake(k)] = shapeValueForLayer1(v)
+	}
+	return out
+}
+
+// shapeValueForLayer1 is the recursive helper for shapeCFNForLayer1.
+// Scalar leaves get wrapped in {"literal": …}; maps recurse; lists of
+// maps recurse with key renames on each element; lists of scalars
+// pass through unchanged (Terraform list-typed attributes are rare
+// today and out of scope for the HYBRID baseline).
+func shapeValueForLayer1(v any) any {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case map[string]any:
+		// Nested CFN object — recurse on keys, but DO NOT wrap the
+		// object itself in a literal envelope. The generated nested
+		// structs are bare structs (no Value[T] wrapper), so the
+		// inner keys still need to be snake_case but the leaves
+		// inside the inner struct's fields need their own
+		// {"literal": …} wrap. Recursing through shapeCFNForLayer1
+		// handles both.
+		return shapeCFNForLayer1(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = shapeValueForLayer1(e)
+		}
+		return out
+	default:
+		// Scalar leaf — wrap in {"literal": …} so it decodes into
+		// generated.Value[T] cleanly.
+		return map[string]any{"literal": t}
+	}
+}
+
+// camelToSnake converts a CloudFormation CamelCase property name to a
+// Terraform snake_case attribute name. Handles consecutive uppercase
+// runs as a single acronym ("ARN" → "arn", "KmsKeyId" → "kms_key_id",
+// "LogGroupName" → "log_group_name"). Pure ASCII; non-letter
+// characters pass through.
+//
+// Algorithm: walk left-to-right; insert an underscore before an
+// uppercase letter when (a) the previous char was lowercase, or
+// (b) the previous char was uppercase but the next char is lowercase
+// (acronym → identifier boundary, e.g. "ARNTag" → "arn_tag").
+func camelToSnake(s string) string {
+	if s == "" {
+		return s
+	}
+	out := make([]byte, 0, len(s)+4)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			if i > 0 {
+				prev := s[i-1]
+				prevUpper := prev >= 'A' && prev <= 'Z'
+				nextLower := i+1 < len(s) && s[i+1] >= 'a' && s[i+1] <= 'z'
+				switch {
+				case !prevUpper:
+					out = append(out, '_')
+				case prevUpper && nextLower:
+					out = append(out, '_')
+				}
+			}
+			out = append(out, c+('a'-'A'))
+			continue
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+// Compile-time pins: cloudControlEnricher must satisfy both
+// AttributeEnricher and ByIDEnricher. A drift in either interface that
+// drops one of these methods is caught at build time rather than
+// surfacing as a runtime type-assertion miss in the dispatcher.
+var (
+	_ AttributeEnricher = (*cloudControlEnricher)(nil)
+	_ ByIDEnricher      = (*cloudControlEnricher)(nil)
+)

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_enricher_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_enricher_test.go
@@ -1,0 +1,390 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	cctypes "github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// TestCamelToSnake pins the renamer behavior the enricher depends on
+// for translating CloudFormation CamelCase property keys into the
+// snake_case json tags the generated Layer-1 structs declare. A drift
+// in the renamer here would silently miss every CFN field whose name
+// doesn't round-trip — the unit test surfaces the regression
+// alongside the cases it would have caught.
+func TestCamelToSnake(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"Arn", "arn"},
+		{"ARN", "arn"},
+		{"Name", "name"},
+		{"LogGroupName", "log_group_name"},
+		{"KmsKeyId", "kms_key_id"},
+		{"RetentionInDays", "retention_in_days"},
+		{"LogGroupClass", "log_group_class"},
+		{"ARNTag", "arn_tag"},
+		// Acronym at end stays one run.
+		{"BucketARN", "bucket_arn"},
+		{"FIFOQueue", "fifo_queue"},
+		{"KMSMasterKeyId", "kms_master_key_id"},
+		// Non-letters pass through.
+		{"Field_With_Underscore", "field__with__underscore"},
+	}
+	for _, tc := range cases {
+		got := camelToSnake(tc.in)
+		assert.Equalf(t, tc.want, got, "camelToSnake(%q)", tc.in)
+	}
+}
+
+// TestShapeCFNForLayer1Recursive pins the shape transform: scalar
+// leaves get wrapped in {"literal": …} envelopes (so Value[T] can
+// decode them), every nested map's keys are renamed to snake_case,
+// and map list elements have their keys renamed too. Without this
+// contract, bare CFN scalars (`"RetentionInDays": 30`) would fail to
+// decode against the Layer-1 *Value[int64] fields.
+func TestShapeCFNForLayer1Recursive(t *testing.T) {
+	t.Parallel()
+	in := map[string]any{
+		"LogGroupName":    "/aws/lambda/demo",
+		"RetentionInDays": float64(30),
+		"Encryption": map[string]any{
+			"KmsMasterKeyId": "arn:aws:kms:...",
+		},
+		"Tags": []any{
+			map[string]any{"Key": "Project", "Value": "io-abc"},
+		},
+	}
+	out := shapeCFNForLayer1(in)
+
+	// Scalar leaves get wrapped in {"literal": …}.
+	require.Contains(t, out, "log_group_name")
+	logName, ok := out["log_group_name"].(map[string]any)
+	require.Truef(t, ok, "log_group_name should be wrapped, got %T", out["log_group_name"])
+	assert.Equal(t, "/aws/lambda/demo", logName["literal"])
+
+	rid, ok := out["retention_in_days"].(map[string]any)
+	require.Truef(t, ok, "retention_in_days should be wrapped, got %T", out["retention_in_days"])
+	assert.Equal(t, float64(30), rid["literal"])
+
+	// Nested map: keys recursed, leaves wrapped.
+	require.Contains(t, out, "encryption")
+	enc, ok := out["encryption"].(map[string]any)
+	require.True(t, ok)
+	kmsKey, ok := enc["kms_master_key_id"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "arn:aws:kms:...", kmsKey["literal"])
+
+	// List of map elements: each element gets recursive key rename
+	// plus leaf wrap.
+	require.Contains(t, out, "tags")
+	tags, ok := out["tags"].([]any)
+	require.True(t, ok)
+	require.Len(t, tags, 1)
+	tagEntry, ok := tags[0].(map[string]any)
+	require.True(t, ok)
+	keyLit, ok := tagEntry["key"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Project", keyLit["literal"])
+}
+
+// fakeCCGet is a closure-style GetResource fake. The test sets `got` to
+// the input it received so each test case can assert on the requested
+// TypeName / Identifier without an AWS account.
+type fakeCCGet struct {
+	gotInput *cloudcontrol.GetResourceInput
+	props    string // raw JSON for Properties; "" → nil Properties
+	err      error
+}
+
+func (f *fakeCCGet) call(_ context.Context, in *cloudcontrol.GetResourceInput, _ ...func(*cloudcontrol.Options)) (*cloudcontrol.GetResourceOutput, error) {
+	f.gotInput = in
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.props == "" {
+		return &cloudcontrol.GetResourceOutput{}, nil
+	}
+	return &cloudcontrol.GetResourceOutput{
+		ResourceDescription: &cctypes.ResourceDescription{
+			Identifier: aws.String("test"),
+			Properties: aws.String(f.props),
+		},
+	}, nil
+}
+
+// TestCloudControlEnricher_Enrich_LogGroup exercises the full Enrich
+// flow against a synthetic AWS::Logs::LogGroup CFN payload and asserts
+// the resulting ir.Attrs round-trips through generated.UnmarshalAttrs
+// into the typed AWSCloudwatchLogGroup struct with the expected values
+// — the load-bearing contract that justifies the json-tag codegen
+// change in step 1 of #490.
+func TestCloudControlEnricher_Enrich_LogGroup(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{
+		props: `{
+			"Arn": "arn:aws:logs:us-east-1:123:log-group:/aws/lambda/demo",
+			"LogGroupName": "/aws/lambda/demo",
+			"RetentionInDays": 30,
+			"KmsKeyId": "arn:aws:kms:us-east-1:123:key/abc",
+			"LogGroupClass": "STANDARD"
+		}`,
+	}
+	enr := newCloudControlEnricher("aws_cloudwatch_log_group", "AWS::Logs::LogGroup", fake.call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_cloudwatch_log_group",
+			ImportID: "/aws/lambda/demo",
+			Address:  "aws_cloudwatch_log_group.demo",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+	require.NotNil(t, fake.gotInput)
+	assert.Equal(t, "AWS::Logs::LogGroup", aws.ToString(fake.gotInput.TypeName))
+	assert.Equal(t, "/aws/lambda/demo", aws.ToString(fake.gotInput.Identifier))
+
+	decoded, err := generated.UnmarshalAttrs("aws_cloudwatch_log_group", ir.Attrs)
+	require.NoError(t, err)
+	lg, ok := decoded.(*generated.AWSCloudwatchLogGroup)
+	require.True(t, ok, "decoded type is %T, want *AWSCloudwatchLogGroup", decoded)
+	// Fields whose CFN name matches the snake_case TF tag round-trip
+	// directly. (The "primary name" CFN-vs-TF divergence — LogGroupName
+	// vs Terraform's `name` — is deliberately not addressed in this PR;
+	// step 3 Normalizer hooks will handle it.)
+	require.NotNil(t, lg.ARN)
+	require.NotNil(t, lg.ARN.Literal)
+	assert.Equal(t, "arn:aws:logs:us-east-1:123:log-group:/aws/lambda/demo", *lg.ARN.Literal)
+	require.NotNil(t, lg.RetentionInDays)
+	require.NotNil(t, lg.RetentionInDays.Literal)
+	assert.Equal(t, int64(30), *lg.RetentionInDays.Literal)
+	require.NotNil(t, lg.KMSKeyID)
+	require.NotNil(t, lg.KMSKeyID.Literal)
+	assert.Equal(t, "arn:aws:kms:us-east-1:123:key/abc", *lg.KMSKeyID.Literal)
+	require.NotNil(t, lg.LogGroupClass)
+	require.NotNil(t, lg.LogGroupClass.Literal)
+	assert.Equal(t, "STANDARD", *lg.LogGroupClass.Literal)
+	// Name field is left empty because CFN calls it LogGroupName — the
+	// renamer produces "log_group_name", which doesn't match any field
+	// on the generated struct. This is the known 43% gap from the PoC;
+	// step 3 (Normalizer hooks) addresses it.
+	assert.Nil(t, lg.Name)
+}
+
+// TestCloudControlEnricher_Enrich_NilCloudControl_FromClients asserts
+// the production wiring path: when the embedded `get` is nil and
+// EnrichClients.CloudControl is also nil, Enrich returns
+// ErrEnrichClientUnavailable so EnrichAttributes can downgrade to a
+// per-resource warning rather than aborting the batch. This is the
+// "discover ran without --enable-cloud-control-enrich" path.
+func TestCloudControlEnricher_Enrich_NilCloudControl_FromClients(t *testing.T) {
+	t.Parallel()
+	enr := newCloudControlEnricher("aws_cloudwatch_log_group", "AWS::Logs::LogGroup", nil)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_cloudwatch_log_group",
+			ImportID: "/aws/lambda/demo",
+		},
+	}
+	err := enr.Enrich(context.Background(), ir, EnrichClients{})
+	assert.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+// TestCloudControlEnricher_Enrich_NotFound exercises the soft-fail path:
+// Cloud Control's ResourceNotFoundException is wrapped in ErrNotFound so
+// EnrichAttributes can drop the resource from the batch result without
+// failing the whole run. The most-likely real-world cause is a resource
+// deleted between the discover and enrich stages, or a per-CFN-type IAM
+// permission gap.
+func TestCloudControlEnricher_Enrich_NotFound(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{
+		err: &cctypes.ResourceNotFoundException{Message: aws.String("missing")},
+	}
+	enr := newCloudControlEnricher("aws_cloudwatch_log_group", "AWS::Logs::LogGroup", fake.call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_cloudwatch_log_group",
+			ImportID: "/aws/lambda/demo",
+		},
+	}
+	err := enr.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestCloudControlEnricher_Enrich_EmptyResponse exercises the
+// defensive-empty-response branch: the SDK returned no error but the
+// ResourceDescription / Properties is nil. Treated as ErrNotFound so
+// the dispatcher routes through the same soft-fail path; a hard error
+// here would be inappropriate (the operator didn't mis-call the API —
+// the SDK shape itself is unexpected for a successful response).
+func TestCloudControlEnricher_Enrich_EmptyResponse(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{} // no error, no Properties
+	enr := newCloudControlEnricher("aws_cloudwatch_log_group", "AWS::Logs::LogGroup", fake.call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_cloudwatch_log_group",
+			ImportID: "/aws/lambda/demo",
+		},
+	}
+	err := enr.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestCloudControlEnricher_Enrich_NoIdentifier asserts that the
+// enricher rejects an Identity with no ImportID and no NameHint
+// loudly. Falling through silently would later surface as an
+// uninformative empty-payload error; explicit detection at the
+// dispatch site puts the misconfiguration in the test surface.
+func TestCloudControlEnricher_Enrich_NoIdentifier(t *testing.T) {
+	t.Parallel()
+	enr := newCloudControlEnricher("aws_cloudwatch_log_group", "AWS::Logs::LogGroup", (&fakeCCGet{}).call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:    "aws_cloudwatch_log_group",
+			Address: "aws_cloudwatch_log_group.demo",
+		},
+	}
+	err := enr.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive identifier")
+}
+
+// TestCloudControlEnricher_Enrich_RealAPIError asserts that an
+// arbitrary SDK error (not NotFound / not InvalidRequest) propagates
+// up wrapped but un-translated, so EnrichAttributes treats it as a
+// real error and includes it in the aggregated batch failure.
+func TestCloudControlEnricher_Enrich_RealAPIError(t *testing.T) {
+	t.Parallel()
+	upstream := errors.New("throttled")
+	fake := &fakeCCGet{err: upstream}
+	enr := newCloudControlEnricher("aws_cloudwatch_log_group", "AWS::Logs::LogGroup", fake.call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_cloudwatch_log_group",
+			ImportID: "/aws/lambda/demo",
+		},
+	}
+	err := enr.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound)
+	assert.NotErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.ErrorIs(t, err, upstream)
+}
+
+// TestCloudControlEnricher_EnrichByID exercises the ByIDEnricher entry
+// point with the same SDK + mapping path as Enrich, asserting the
+// returned raw JSON round-trips into the typed struct.
+func TestCloudControlEnricher_EnrichByID(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{
+		props: `{
+			"Arn": "arn:aws:logs:us-east-1:123:log-group:/aws/lambda/demo",
+			"RetentionInDays": 7
+		}`,
+	}
+	enr := newCloudControlEnricher("aws_cloudwatch_log_group", "AWS::Logs::LogGroup", fake.call)
+	raw, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type:     "aws_cloudwatch_log_group",
+		ImportID: "/aws/lambda/demo",
+	}, EnrichClients{})
+	require.NoError(t, err)
+	decoded, err := generated.UnmarshalAttrs("aws_cloudwatch_log_group", raw)
+	require.NoError(t, err)
+	lg, ok := decoded.(*generated.AWSCloudwatchLogGroup)
+	require.True(t, ok)
+	require.NotNil(t, lg.RetentionInDays)
+	require.NotNil(t, lg.RetentionInDays.Literal)
+	assert.Equal(t, int64(7), *lg.RetentionInDays.Literal)
+}
+
+// TestCloudControlEnricher_EnrichByID_NilIdentity asserts the
+// programmer-error case (caller passed nil) is reported clearly rather
+// than panicking inside the SDK call.
+func TestCloudControlEnricher_EnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	enr := newCloudControlEnricher("aws_cloudwatch_log_group", "AWS::Logs::LogGroup", (&fakeCCGet{}).call)
+	_, err := enr.EnrichByID(context.Background(), nil, EnrichClients{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity is nil")
+}
+
+// TestCloudControlEnricher_ResourceType pins the trivial accessor so a
+// refactor that loses the field is caught at unit-test time.
+func TestCloudControlEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	enr := newCloudControlEnricher("aws_sqs_queue", "AWS::SQS::Queue", nil)
+	assert.Equal(t, "aws_sqs_queue", enr.ResourceType())
+}
+
+// TestCloudControlEnricher_Enrich_UnknownTFType pins the wiring-bug
+// detection: if a caller constructs an enricher for a TF type that
+// isn't registered in pkg/composer/imported/generated (e.g. because
+// the codegen hasn't run for it yet), the enricher must report the
+// missing registration cleanly rather than silently emitting raw CFN
+// JSON the downstream UnmarshalAttrs would later reject.
+func TestCloudControlEnricher_Enrich_UnknownTFType(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{
+		props: `{"Name": "test"}`,
+	}
+	enr := newCloudControlEnricher("aws_does_not_exist", "AWS::Phony::Type", fake.call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_does_not_exist",
+			ImportID: "test",
+		},
+	}
+	err := enr.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal into aws_does_not_exist")
+}
+
+// TestCloudControlEnricher_Enrich_RawAttrs_IsValidJSONWithSnakeKeys
+// guards the wire-format contract: after step 1 of #490 (json tags on
+// every generated Layer-1 field), ir.Attrs uses lowercase snake_case
+// keys for every top-level attribute. A regression that drops the
+// json tag emission would silently revert to CamelCase Go-field-name
+// keys, which would re-introduce the renamer-projection workaround
+// from the PoC and the 43% coverage gap on primary-name fields.
+func TestCloudControlEnricher_Enrich_RawAttrs_IsValidJSONWithSnakeKeys(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{
+		props: `{"Arn":"x","RetentionInDays":7}`,
+	}
+	enr := newCloudControlEnricher("aws_cloudwatch_log_group", "AWS::Logs::LogGroup", fake.call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_cloudwatch_log_group",
+			ImportID: "/aws/lambda/demo",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+	var top map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(ir.Attrs, &top))
+	// Snake_case keys present.
+	assert.Contains(t, top, "arn")
+	assert.Contains(t, top, "retention_in_days")
+	// Verify lower-case-only — a CamelCase regression would land
+	// "Arn" / "RetentionInDays" instead. A bare Contains() check
+	// against "arn" would also match "Arn" because json key access
+	// is case-sensitive only on the map side; check key bytes directly.
+	for k := range top {
+		assert.Equalf(t, strings.ToLower(k), k, "expected lowercase top-level key, got %q", k)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -137,7 +138,15 @@ type EnrichClients struct {
 	DynamoDB       *dynamodb.Client
 	CloudWatchLogs *cloudwatchlogs.Client
 	SecretsManager *secretsmanager.Client
-	AccountID      string
+	// CloudControl is the shared client for the generic Cloud Control
+	// enricher (#490 HYBRID). One client is reused across every
+	// cloudControlEnricher registered in NewAWSDiscoverer.byTypeEnricher
+	// — the SDK client is stateless over an aws.Config so a single
+	// instance serves every CFN type. Nil is tolerated and surfaces as
+	// ErrEnrichClientUnavailable at Enrich time; EnrichAttributes
+	// downgrades that to a per-resource ServiceWarn.
+	CloudControl *cloudcontrol.Client
+	AccountID    string
 }
 
 // ErrEnrichClientUnavailable signals that the SDK client an enricher

--- a/pkg/composer/imported/generated/aws_cloudwatch_log_group.gen.go
+++ b/pkg/composer/imported/generated/aws_cloudwatch_log_group.gen.go
@@ -7,16 +7,16 @@ import "reflect"
 // AWSCloudwatchLogGroup is the generated Layer 1 typed model for the
 // `aws_cloudwatch_log_group` Terraform resource.
 type AWSCloudwatchLogGroup struct {
-	ARN             *Value[string]            `tf:"arn"`
-	ID              *Value[string]            `tf:"id"`
-	KMSKeyID        *Value[string]            `tf:"kms_key_id"`
-	LogGroupClass   *Value[string]            `tf:"log_group_class"`
-	Name            *Value[string]            `tf:"name"`
-	NamePrefix      *Value[string]            `tf:"name_prefix"`
-	RetentionInDays *Value[int64]             `tf:"retention_in_days"`
-	SkipDestroy     *Value[bool]              `tf:"skip_destroy"`
-	Tags            map[string]*Value[string] `tf:"tags"`
-	TagsAll         map[string]*Value[string] `tf:"tags_all"`
+	ARN             *Value[string]            `tf:"arn" json:"arn,omitempty"`
+	ID              *Value[string]            `tf:"id" json:"id,omitempty"`
+	KMSKeyID        *Value[string]            `tf:"kms_key_id" json:"kms_key_id,omitempty"`
+	LogGroupClass   *Value[string]            `tf:"log_group_class" json:"log_group_class,omitempty"`
+	Name            *Value[string]            `tf:"name" json:"name,omitempty"`
+	NamePrefix      *Value[string]            `tf:"name_prefix" json:"name_prefix,omitempty"`
+	RetentionInDays *Value[int64]             `tf:"retention_in_days" json:"retention_in_days,omitempty"`
+	SkipDestroy     *Value[bool]              `tf:"skip_destroy" json:"skip_destroy,omitempty"`
+	Tags            map[string]*Value[string] `tf:"tags" json:"tags,omitempty"`
+	TagsAll         map[string]*Value[string] `tf:"tags_all" json:"tags_all,omitempty"`
 }
 
 // AWSCloudwatchLogGroupSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/aws_dynamodb_table.gen.go
+++ b/pkg/composer/imported/generated/aws_dynamodb_table.gen.go
@@ -7,121 +7,121 @@ import "reflect"
 // AWSDynamodbTable is the generated Layer 1 typed model for the
 // `aws_dynamodb_table` Terraform resource.
 type AWSDynamodbTable struct {
-	ARN                       *Value[string]                         `tf:"arn"`
-	BillingMode               *Value[string]                         `tf:"billing_mode"`
-	DeletionProtectionEnabled *Value[bool]                           `tf:"deletion_protection_enabled"`
-	HashKey                   *Value[string]                         `tf:"hash_key"`
-	ID                        *Value[string]                         `tf:"id"`
-	Name                      *Value[string]                         `tf:"name"`
-	RangeKey                  *Value[string]                         `tf:"range_key"`
-	ReadCapacity              *Value[float64]                        `tf:"read_capacity"`
-	RestoreDateTime           *Value[string]                         `tf:"restore_date_time"`
-	RestoreSourceName         *Value[string]                         `tf:"restore_source_name"`
-	RestoreSourceTableARN     *Value[string]                         `tf:"restore_source_table_arn"`
-	RestoreToLatestTime       *Value[bool]                           `tf:"restore_to_latest_time"`
-	StreamARN                 *Value[string]                         `tf:"stream_arn"`
-	StreamEnabled             *Value[bool]                           `tf:"stream_enabled"`
-	StreamLabel               *Value[string]                         `tf:"stream_label"`
-	StreamViewType            *Value[string]                         `tf:"stream_view_type"`
-	TableClass                *Value[string]                         `tf:"table_class"`
-	Tags                      map[string]*Value[string]              `tf:"tags"`
-	TagsAll                   map[string]*Value[string]              `tf:"tags_all"`
-	WriteCapacity             *Value[float64]                        `tf:"write_capacity"`
-	Attribute                 []AWSDynamodbTableAttribute            `tf:"attribute,blocks"`
-	GlobalSecondaryIndex      []AWSDynamodbTableGlobalSecondaryIndex `tf:"global_secondary_index,blocks"`
-	ImportTable               []AWSDynamodbTableImportTable          `tf:"import_table,blocks"`
-	LocalSecondaryIndex       []AWSDynamodbTableLocalSecondaryIndex  `tf:"local_secondary_index,blocks"`
-	PointInTimeRecovery       []AWSDynamodbTablePointInTimeRecovery  `tf:"point_in_time_recovery,blocks"`
-	Replica                   []AWSDynamodbTableReplica              `tf:"replica,blocks"`
-	ServerSideEncryption      []AWSDynamodbTableServerSideEncryption `tf:"server_side_encryption,blocks"`
-	Timeouts                  *AWSDynamodbTableTimeouts              `tf:"timeouts,block"`
-	TTL                       []AWSDynamodbTableTTL                  `tf:"ttl,blocks"`
+	ARN                       *Value[string]                         `tf:"arn" json:"arn,omitempty"`
+	BillingMode               *Value[string]                         `tf:"billing_mode" json:"billing_mode,omitempty"`
+	DeletionProtectionEnabled *Value[bool]                           `tf:"deletion_protection_enabled" json:"deletion_protection_enabled,omitempty"`
+	HashKey                   *Value[string]                         `tf:"hash_key" json:"hash_key,omitempty"`
+	ID                        *Value[string]                         `tf:"id" json:"id,omitempty"`
+	Name                      *Value[string]                         `tf:"name" json:"name,omitempty"`
+	RangeKey                  *Value[string]                         `tf:"range_key" json:"range_key,omitempty"`
+	ReadCapacity              *Value[float64]                        `tf:"read_capacity" json:"read_capacity,omitempty"`
+	RestoreDateTime           *Value[string]                         `tf:"restore_date_time" json:"restore_date_time,omitempty"`
+	RestoreSourceName         *Value[string]                         `tf:"restore_source_name" json:"restore_source_name,omitempty"`
+	RestoreSourceTableARN     *Value[string]                         `tf:"restore_source_table_arn" json:"restore_source_table_arn,omitempty"`
+	RestoreToLatestTime       *Value[bool]                           `tf:"restore_to_latest_time" json:"restore_to_latest_time,omitempty"`
+	StreamARN                 *Value[string]                         `tf:"stream_arn" json:"stream_arn,omitempty"`
+	StreamEnabled             *Value[bool]                           `tf:"stream_enabled" json:"stream_enabled,omitempty"`
+	StreamLabel               *Value[string]                         `tf:"stream_label" json:"stream_label,omitempty"`
+	StreamViewType            *Value[string]                         `tf:"stream_view_type" json:"stream_view_type,omitempty"`
+	TableClass                *Value[string]                         `tf:"table_class" json:"table_class,omitempty"`
+	Tags                      map[string]*Value[string]              `tf:"tags" json:"tags,omitempty"`
+	TagsAll                   map[string]*Value[string]              `tf:"tags_all" json:"tags_all,omitempty"`
+	WriteCapacity             *Value[float64]                        `tf:"write_capacity" json:"write_capacity,omitempty"`
+	Attribute                 []AWSDynamodbTableAttribute            `tf:"attribute,blocks" json:"attribute,omitempty"`
+	GlobalSecondaryIndex      []AWSDynamodbTableGlobalSecondaryIndex `tf:"global_secondary_index,blocks" json:"global_secondary_index,omitempty"`
+	ImportTable               []AWSDynamodbTableImportTable          `tf:"import_table,blocks" json:"import_table,omitempty"`
+	LocalSecondaryIndex       []AWSDynamodbTableLocalSecondaryIndex  `tf:"local_secondary_index,blocks" json:"local_secondary_index,omitempty"`
+	PointInTimeRecovery       []AWSDynamodbTablePointInTimeRecovery  `tf:"point_in_time_recovery,blocks" json:"point_in_time_recovery,omitempty"`
+	Replica                   []AWSDynamodbTableReplica              `tf:"replica,blocks" json:"replica,omitempty"`
+	ServerSideEncryption      []AWSDynamodbTableServerSideEncryption `tf:"server_side_encryption,blocks" json:"server_side_encryption,omitempty"`
+	Timeouts                  *AWSDynamodbTableTimeouts              `tf:"timeouts,block" json:"timeouts,omitempty"`
+	TTL                       []AWSDynamodbTableTTL                  `tf:"ttl,blocks" json:"ttl,omitempty"`
 }
 
 // AWSDynamodbTableAttribute is a nested-block type used by the parent resource.
 type AWSDynamodbTableAttribute struct {
-	Name  *Value[string] `tf:"name"`
-	Type_ *Value[string] `tf:"type"`
+	Name  *Value[string] `tf:"name" json:"name,omitempty"`
+	Type_ *Value[string] `tf:"type" json:"type,omitempty"`
 }
 
 // AWSDynamodbTableGlobalSecondaryIndex is a nested-block type used by the parent resource.
 type AWSDynamodbTableGlobalSecondaryIndex struct {
-	HashKey          *Value[string]   `tf:"hash_key"`
-	Name             *Value[string]   `tf:"name"`
-	NonKeyAttributes []*Value[string] `tf:"non_key_attributes"`
-	ProjectionType   *Value[string]   `tf:"projection_type"`
-	RangeKey         *Value[string]   `tf:"range_key"`
-	ReadCapacity     *Value[float64]  `tf:"read_capacity"`
-	WriteCapacity    *Value[float64]  `tf:"write_capacity"`
+	HashKey          *Value[string]   `tf:"hash_key" json:"hash_key,omitempty"`
+	Name             *Value[string]   `tf:"name" json:"name,omitempty"`
+	NonKeyAttributes []*Value[string] `tf:"non_key_attributes" json:"non_key_attributes,omitempty"`
+	ProjectionType   *Value[string]   `tf:"projection_type" json:"projection_type,omitempty"`
+	RangeKey         *Value[string]   `tf:"range_key" json:"range_key,omitempty"`
+	ReadCapacity     *Value[float64]  `tf:"read_capacity" json:"read_capacity,omitempty"`
+	WriteCapacity    *Value[float64]  `tf:"write_capacity" json:"write_capacity,omitempty"`
 }
 
 // AWSDynamodbTableImportTable is a nested-block type used by the parent resource.
 type AWSDynamodbTableImportTable struct {
-	InputCompressionType *Value[string]                                  `tf:"input_compression_type"`
-	InputFormat          *Value[string]                                  `tf:"input_format"`
-	InputFormatOptions   []AWSDynamodbTableImportTableInputFormatOptions `tf:"input_format_options,blocks"`
-	S3BucketSource       []AWSDynamodbTableImportTableS3BucketSource     `tf:"s3_bucket_source,blocks"`
+	InputCompressionType *Value[string]                                  `tf:"input_compression_type" json:"input_compression_type,omitempty"`
+	InputFormat          *Value[string]                                  `tf:"input_format" json:"input_format,omitempty"`
+	InputFormatOptions   []AWSDynamodbTableImportTableInputFormatOptions `tf:"input_format_options,blocks" json:"input_format_options,omitempty"`
+	S3BucketSource       []AWSDynamodbTableImportTableS3BucketSource     `tf:"s3_bucket_source,blocks" json:"s3_bucket_source,omitempty"`
 }
 
 // AWSDynamodbTableImportTableInputFormatOptions is a nested-block type used by the parent resource.
 type AWSDynamodbTableImportTableInputFormatOptions struct {
-	CSV []AWSDynamodbTableImportTableInputFormatOptionsCSV `tf:"csv,blocks"`
+	CSV []AWSDynamodbTableImportTableInputFormatOptionsCSV `tf:"csv,blocks" json:"csv,omitempty"`
 }
 
 // AWSDynamodbTableImportTableInputFormatOptionsCSV is a nested-block type used by the parent resource.
 type AWSDynamodbTableImportTableInputFormatOptionsCSV struct {
-	Delimiter  *Value[string]   `tf:"delimiter"`
-	HeaderList []*Value[string] `tf:"header_list"`
+	Delimiter  *Value[string]   `tf:"delimiter" json:"delimiter,omitempty"`
+	HeaderList []*Value[string] `tf:"header_list" json:"header_list,omitempty"`
 }
 
 // AWSDynamodbTableImportTableS3BucketSource is a nested-block type used by the parent resource.
 type AWSDynamodbTableImportTableS3BucketSource struct {
-	Bucket      *Value[string] `tf:"bucket"`
-	BucketOwner *Value[string] `tf:"bucket_owner"`
-	KeyPrefix   *Value[string] `tf:"key_prefix"`
+	Bucket      *Value[string] `tf:"bucket" json:"bucket,omitempty"`
+	BucketOwner *Value[string] `tf:"bucket_owner" json:"bucket_owner,omitempty"`
+	KeyPrefix   *Value[string] `tf:"key_prefix" json:"key_prefix,omitempty"`
 }
 
 // AWSDynamodbTableLocalSecondaryIndex is a nested-block type used by the parent resource.
 type AWSDynamodbTableLocalSecondaryIndex struct {
-	Name             *Value[string]   `tf:"name"`
-	NonKeyAttributes []*Value[string] `tf:"non_key_attributes"`
-	ProjectionType   *Value[string]   `tf:"projection_type"`
-	RangeKey         *Value[string]   `tf:"range_key"`
+	Name             *Value[string]   `tf:"name" json:"name,omitempty"`
+	NonKeyAttributes []*Value[string] `tf:"non_key_attributes" json:"non_key_attributes,omitempty"`
+	ProjectionType   *Value[string]   `tf:"projection_type" json:"projection_type,omitempty"`
+	RangeKey         *Value[string]   `tf:"range_key" json:"range_key,omitempty"`
 }
 
 // AWSDynamodbTablePointInTimeRecovery is a nested-block type used by the parent resource.
 type AWSDynamodbTablePointInTimeRecovery struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // AWSDynamodbTableReplica is a nested-block type used by the parent resource.
 type AWSDynamodbTableReplica struct {
-	ARN                 *Value[string] `tf:"arn"`
-	KMSKeyARN           *Value[string] `tf:"kms_key_arn"`
-	PointInTimeRecovery *Value[bool]   `tf:"point_in_time_recovery"`
-	PropagateTags       *Value[bool]   `tf:"propagate_tags"`
-	RegionName          *Value[string] `tf:"region_name"`
-	StreamARN           *Value[string] `tf:"stream_arn"`
-	StreamLabel         *Value[string] `tf:"stream_label"`
+	ARN                 *Value[string] `tf:"arn" json:"arn,omitempty"`
+	KMSKeyARN           *Value[string] `tf:"kms_key_arn" json:"kms_key_arn,omitempty"`
+	PointInTimeRecovery *Value[bool]   `tf:"point_in_time_recovery" json:"point_in_time_recovery,omitempty"`
+	PropagateTags       *Value[bool]   `tf:"propagate_tags" json:"propagate_tags,omitempty"`
+	RegionName          *Value[string] `tf:"region_name" json:"region_name,omitempty"`
+	StreamARN           *Value[string] `tf:"stream_arn" json:"stream_arn,omitempty"`
+	StreamLabel         *Value[string] `tf:"stream_label" json:"stream_label,omitempty"`
 }
 
 // AWSDynamodbTableServerSideEncryption is a nested-block type used by the parent resource.
 type AWSDynamodbTableServerSideEncryption struct {
-	Enabled   *Value[bool]   `tf:"enabled"`
-	KMSKeyARN *Value[string] `tf:"kms_key_arn"`
+	Enabled   *Value[bool]   `tf:"enabled" json:"enabled,omitempty"`
+	KMSKeyARN *Value[string] `tf:"kms_key_arn" json:"kms_key_arn,omitempty"`
 }
 
 // AWSDynamodbTableTTL is a nested-block type used by the parent resource.
 type AWSDynamodbTableTTL struct {
-	AttributeName *Value[string] `tf:"attribute_name"`
-	Enabled       *Value[bool]   `tf:"enabled"`
+	AttributeName *Value[string] `tf:"attribute_name" json:"attribute_name,omitempty"`
+	Enabled       *Value[bool]   `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // AWSDynamodbTableTimeouts is a nested-block type used by the parent resource.
 type AWSDynamodbTableTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // AWSDynamodbTableSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/aws_lambda_function.gen.go
+++ b/pkg/composer/imported/generated/aws_lambda_function.gen.go
@@ -7,114 +7,114 @@ import "reflect"
 // AWSLambdaFunction is the generated Layer 1 typed model for the
 // `aws_lambda_function` Terraform resource.
 type AWSLambdaFunction struct {
-	Architectures                  []*Value[string]                    `tf:"architectures"`
-	ARN                            *Value[string]                      `tf:"arn"`
-	CodeSHA256                     *Value[string]                      `tf:"code_sha256"`
-	CodeSigningConfigARN           *Value[string]                      `tf:"code_signing_config_arn"`
-	Description                    *Value[string]                      `tf:"description"`
-	Filename                       *Value[string]                      `tf:"filename"`
-	FunctionName                   *Value[string]                      `tf:"function_name"`
-	Handler                        *Value[string]                      `tf:"handler"`
-	ID                             *Value[string]                      `tf:"id"`
-	ImageURI                       *Value[string]                      `tf:"image_uri"`
-	InvokeARN                      *Value[string]                      `tf:"invoke_arn"`
-	KMSKeyARN                      *Value[string]                      `tf:"kms_key_arn"`
-	LastModified                   *Value[string]                      `tf:"last_modified"`
-	Layers                         []*Value[string]                    `tf:"layers"`
-	MemorySize                     *Value[int64]                       `tf:"memory_size"`
-	PackageType                    *Value[string]                      `tf:"package_type"`
-	Publish                        *Value[bool]                        `tf:"publish"`
-	QualifiedARN                   *Value[string]                      `tf:"qualified_arn"`
-	QualifiedInvokeARN             *Value[string]                      `tf:"qualified_invoke_arn"`
-	ReplaceSecurityGroupsOnDestroy *Value[bool]                        `tf:"replace_security_groups_on_destroy"`
-	ReplacementSecurityGroupIDS    []*Value[string]                    `tf:"replacement_security_group_ids"`
-	ReservedConcurrentExecutions   *Value[int64]                       `tf:"reserved_concurrent_executions"`
-	Role                           *Value[string]                      `tf:"role"`
-	Runtime                        *Value[string]                      `tf:"runtime"`
-	S3Bucket                       *Value[string]                      `tf:"s3_bucket"`
-	S3Key                          *Value[string]                      `tf:"s3_key"`
-	S3ObjectVersion                *Value[string]                      `tf:"s3_object_version"`
-	SigningJobARN                  *Value[string]                      `tf:"signing_job_arn"`
-	SigningProfileVersionARN       *Value[string]                      `tf:"signing_profile_version_arn"`
-	SkipDestroy                    *Value[bool]                        `tf:"skip_destroy"`
-	SourceCodeHash                 *Value[string]                      `tf:"source_code_hash"`
-	SourceCodeSize                 *Value[int64]                       `tf:"source_code_size"`
-	Tags                           map[string]*Value[string]           `tf:"tags"`
-	TagsAll                        map[string]*Value[string]           `tf:"tags_all"`
-	Timeout                        *Value[int64]                       `tf:"timeout"`
-	Version                        *Value[string]                      `tf:"version"`
-	DeadLetterConfig               []AWSLambdaFunctionDeadLetterConfig `tf:"dead_letter_config,blocks"`
-	Environment                    []AWSLambdaFunctionEnvironment      `tf:"environment,blocks"`
-	EphemeralStorage               []AWSLambdaFunctionEphemeralStorage `tf:"ephemeral_storage,blocks"`
-	FileSystemConfig               []AWSLambdaFunctionFileSystemConfig `tf:"file_system_config,blocks"`
-	ImageConfig                    []AWSLambdaFunctionImageConfig      `tf:"image_config,blocks"`
-	LoggingConfig                  []AWSLambdaFunctionLoggingConfig    `tf:"logging_config,blocks"`
-	SnapStart                      []AWSLambdaFunctionSnapStart        `tf:"snap_start,blocks"`
-	Timeouts                       *AWSLambdaFunctionTimeouts          `tf:"timeouts,block"`
-	TracingConfig                  []AWSLambdaFunctionTracingConfig    `tf:"tracing_config,blocks"`
-	VPCConfig                      []AWSLambdaFunctionVPCConfig        `tf:"vpc_config,blocks"`
+	Architectures                  []*Value[string]                    `tf:"architectures" json:"architectures,omitempty"`
+	ARN                            *Value[string]                      `tf:"arn" json:"arn,omitempty"`
+	CodeSHA256                     *Value[string]                      `tf:"code_sha256" json:"code_sha256,omitempty"`
+	CodeSigningConfigARN           *Value[string]                      `tf:"code_signing_config_arn" json:"code_signing_config_arn,omitempty"`
+	Description                    *Value[string]                      `tf:"description" json:"description,omitempty"`
+	Filename                       *Value[string]                      `tf:"filename" json:"filename,omitempty"`
+	FunctionName                   *Value[string]                      `tf:"function_name" json:"function_name,omitempty"`
+	Handler                        *Value[string]                      `tf:"handler" json:"handler,omitempty"`
+	ID                             *Value[string]                      `tf:"id" json:"id,omitempty"`
+	ImageURI                       *Value[string]                      `tf:"image_uri" json:"image_uri,omitempty"`
+	InvokeARN                      *Value[string]                      `tf:"invoke_arn" json:"invoke_arn,omitempty"`
+	KMSKeyARN                      *Value[string]                      `tf:"kms_key_arn" json:"kms_key_arn,omitempty"`
+	LastModified                   *Value[string]                      `tf:"last_modified" json:"last_modified,omitempty"`
+	Layers                         []*Value[string]                    `tf:"layers" json:"layers,omitempty"`
+	MemorySize                     *Value[int64]                       `tf:"memory_size" json:"memory_size,omitempty"`
+	PackageType                    *Value[string]                      `tf:"package_type" json:"package_type,omitempty"`
+	Publish                        *Value[bool]                        `tf:"publish" json:"publish,omitempty"`
+	QualifiedARN                   *Value[string]                      `tf:"qualified_arn" json:"qualified_arn,omitempty"`
+	QualifiedInvokeARN             *Value[string]                      `tf:"qualified_invoke_arn" json:"qualified_invoke_arn,omitempty"`
+	ReplaceSecurityGroupsOnDestroy *Value[bool]                        `tf:"replace_security_groups_on_destroy" json:"replace_security_groups_on_destroy,omitempty"`
+	ReplacementSecurityGroupIDS    []*Value[string]                    `tf:"replacement_security_group_ids" json:"replacement_security_group_ids,omitempty"`
+	ReservedConcurrentExecutions   *Value[int64]                       `tf:"reserved_concurrent_executions" json:"reserved_concurrent_executions,omitempty"`
+	Role                           *Value[string]                      `tf:"role" json:"role,omitempty"`
+	Runtime                        *Value[string]                      `tf:"runtime" json:"runtime,omitempty"`
+	S3Bucket                       *Value[string]                      `tf:"s3_bucket" json:"s3_bucket,omitempty"`
+	S3Key                          *Value[string]                      `tf:"s3_key" json:"s3_key,omitempty"`
+	S3ObjectVersion                *Value[string]                      `tf:"s3_object_version" json:"s3_object_version,omitempty"`
+	SigningJobARN                  *Value[string]                      `tf:"signing_job_arn" json:"signing_job_arn,omitempty"`
+	SigningProfileVersionARN       *Value[string]                      `tf:"signing_profile_version_arn" json:"signing_profile_version_arn,omitempty"`
+	SkipDestroy                    *Value[bool]                        `tf:"skip_destroy" json:"skip_destroy,omitempty"`
+	SourceCodeHash                 *Value[string]                      `tf:"source_code_hash" json:"source_code_hash,omitempty"`
+	SourceCodeSize                 *Value[int64]                       `tf:"source_code_size" json:"source_code_size,omitempty"`
+	Tags                           map[string]*Value[string]           `tf:"tags" json:"tags,omitempty"`
+	TagsAll                        map[string]*Value[string]           `tf:"tags_all" json:"tags_all,omitempty"`
+	Timeout                        *Value[int64]                       `tf:"timeout" json:"timeout,omitempty"`
+	Version                        *Value[string]                      `tf:"version" json:"version,omitempty"`
+	DeadLetterConfig               []AWSLambdaFunctionDeadLetterConfig `tf:"dead_letter_config,blocks" json:"dead_letter_config,omitempty"`
+	Environment                    []AWSLambdaFunctionEnvironment      `tf:"environment,blocks" json:"environment,omitempty"`
+	EphemeralStorage               []AWSLambdaFunctionEphemeralStorage `tf:"ephemeral_storage,blocks" json:"ephemeral_storage,omitempty"`
+	FileSystemConfig               []AWSLambdaFunctionFileSystemConfig `tf:"file_system_config,blocks" json:"file_system_config,omitempty"`
+	ImageConfig                    []AWSLambdaFunctionImageConfig      `tf:"image_config,blocks" json:"image_config,omitempty"`
+	LoggingConfig                  []AWSLambdaFunctionLoggingConfig    `tf:"logging_config,blocks" json:"logging_config,omitempty"`
+	SnapStart                      []AWSLambdaFunctionSnapStart        `tf:"snap_start,blocks" json:"snap_start,omitempty"`
+	Timeouts                       *AWSLambdaFunctionTimeouts          `tf:"timeouts,block" json:"timeouts,omitempty"`
+	TracingConfig                  []AWSLambdaFunctionTracingConfig    `tf:"tracing_config,blocks" json:"tracing_config,omitempty"`
+	VPCConfig                      []AWSLambdaFunctionVPCConfig        `tf:"vpc_config,blocks" json:"vpc_config,omitempty"`
 }
 
 // AWSLambdaFunctionDeadLetterConfig is a nested-block type used by the parent resource.
 type AWSLambdaFunctionDeadLetterConfig struct {
-	TargetARN *Value[string] `tf:"target_arn"`
+	TargetARN *Value[string] `tf:"target_arn" json:"target_arn,omitempty"`
 }
 
 // AWSLambdaFunctionEnvironment is a nested-block type used by the parent resource.
 type AWSLambdaFunctionEnvironment struct {
-	Variables map[string]*Value[string] `tf:"variables"`
+	Variables map[string]*Value[string] `tf:"variables" json:"variables,omitempty"`
 }
 
 // AWSLambdaFunctionEphemeralStorage is a nested-block type used by the parent resource.
 type AWSLambdaFunctionEphemeralStorage struct {
-	Size *Value[float64] `tf:"size"`
+	Size *Value[float64] `tf:"size" json:"size,omitempty"`
 }
 
 // AWSLambdaFunctionFileSystemConfig is a nested-block type used by the parent resource.
 type AWSLambdaFunctionFileSystemConfig struct {
-	ARN            *Value[string] `tf:"arn"`
-	LocalMountPath *Value[string] `tf:"local_mount_path"`
+	ARN            *Value[string] `tf:"arn" json:"arn,omitempty"`
+	LocalMountPath *Value[string] `tf:"local_mount_path" json:"local_mount_path,omitempty"`
 }
 
 // AWSLambdaFunctionImageConfig is a nested-block type used by the parent resource.
 type AWSLambdaFunctionImageConfig struct {
-	Command          []*Value[string] `tf:"command"`
-	EntryPoint       []*Value[string] `tf:"entry_point"`
-	WorkingDirectory *Value[string]   `tf:"working_directory"`
+	Command          []*Value[string] `tf:"command" json:"command,omitempty"`
+	EntryPoint       []*Value[string] `tf:"entry_point" json:"entry_point,omitempty"`
+	WorkingDirectory *Value[string]   `tf:"working_directory" json:"working_directory,omitempty"`
 }
 
 // AWSLambdaFunctionLoggingConfig is a nested-block type used by the parent resource.
 type AWSLambdaFunctionLoggingConfig struct {
-	ApplicationLogLevel *Value[string] `tf:"application_log_level"`
-	LogFormat           *Value[string] `tf:"log_format"`
-	LogGroup            *Value[string] `tf:"log_group"`
-	SystemLogLevel      *Value[string] `tf:"system_log_level"`
+	ApplicationLogLevel *Value[string] `tf:"application_log_level" json:"application_log_level,omitempty"`
+	LogFormat           *Value[string] `tf:"log_format" json:"log_format,omitempty"`
+	LogGroup            *Value[string] `tf:"log_group" json:"log_group,omitempty"`
+	SystemLogLevel      *Value[string] `tf:"system_log_level" json:"system_log_level,omitempty"`
 }
 
 // AWSLambdaFunctionSnapStart is a nested-block type used by the parent resource.
 type AWSLambdaFunctionSnapStart struct {
-	ApplyOn            *Value[string] `tf:"apply_on"`
-	OptimizationStatus *Value[string] `tf:"optimization_status"`
+	ApplyOn            *Value[string] `tf:"apply_on" json:"apply_on,omitempty"`
+	OptimizationStatus *Value[string] `tf:"optimization_status" json:"optimization_status,omitempty"`
 }
 
 // AWSLambdaFunctionTimeouts is a nested-block type used by the parent resource.
 type AWSLambdaFunctionTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // AWSLambdaFunctionTracingConfig is a nested-block type used by the parent resource.
 type AWSLambdaFunctionTracingConfig struct {
-	Mode *Value[string] `tf:"mode"`
+	Mode *Value[string] `tf:"mode" json:"mode,omitempty"`
 }
 
 // AWSLambdaFunctionVPCConfig is a nested-block type used by the parent resource.
 type AWSLambdaFunctionVPCConfig struct {
-	IPV6AllowedForDualStack *Value[bool]     `tf:"ipv6_allowed_for_dual_stack"`
-	SecurityGroupIDS        []*Value[string] `tf:"security_group_ids"`
-	SubnetIDS               []*Value[string] `tf:"subnet_ids"`
-	VPCID                   *Value[string]   `tf:"vpc_id"`
+	IPV6AllowedForDualStack *Value[bool]     `tf:"ipv6_allowed_for_dual_stack" json:"ipv6_allowed_for_dual_stack,omitempty"`
+	SecurityGroupIDS        []*Value[string] `tf:"security_group_ids" json:"security_group_ids,omitempty"`
+	SubnetIDS               []*Value[string] `tf:"subnet_ids" json:"subnet_ids,omitempty"`
+	VPCID                   *Value[string]   `tf:"vpc_id" json:"vpc_id,omitempty"`
 }
 
 // AWSLambdaFunctionSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/aws_s3_bucket.gen.go
+++ b/pkg/composer/imported/generated/aws_s3_bucket.gen.go
@@ -7,214 +7,214 @@ import "reflect"
 // AWSS3Bucket is the generated Layer 1 typed model for the
 // `aws_s3_bucket` Terraform resource.
 type AWSS3Bucket struct {
-	AccelerationStatus                *Value[string]                                 `tf:"acceleration_status"`
-	ACL                               *Value[string]                                 `tf:"acl"`
-	ARN                               *Value[string]                                 `tf:"arn"`
-	Bucket                            *Value[string]                                 `tf:"bucket"`
-	BucketDomainName                  *Value[string]                                 `tf:"bucket_domain_name"`
-	BucketPrefix                      *Value[string]                                 `tf:"bucket_prefix"`
-	BucketRegionalDomainName          *Value[string]                                 `tf:"bucket_regional_domain_name"`
-	ForceDestroy                      *Value[bool]                                   `tf:"force_destroy"`
-	HostedZoneID                      *Value[string]                                 `tf:"hosted_zone_id"`
-	ID                                *Value[string]                                 `tf:"id"`
-	ObjectLockEnabled                 *Value[bool]                                   `tf:"object_lock_enabled"`
-	Policy                            *Value[string]                                 `tf:"policy"`
-	Region                            *Value[string]                                 `tf:"region"`
-	RequestPayer                      *Value[string]                                 `tf:"request_payer"`
-	Tags                              map[string]*Value[string]                      `tf:"tags"`
-	TagsAll                           map[string]*Value[string]                      `tf:"tags_all"`
-	WebsiteDomain                     *Value[string]                                 `tf:"website_domain"`
-	WebsiteEndpoint                   *Value[string]                                 `tf:"website_endpoint"`
-	CorsRule                          []AWSS3BucketCorsRule                          `tf:"cors_rule,blocks"`
-	Grant                             []AWSS3BucketGrant                             `tf:"grant,blocks"`
-	LifecycleRule                     []AWSS3BucketLifecycleRule                     `tf:"lifecycle_rule,blocks"`
-	Logging                           []AWSS3BucketLogging                           `tf:"logging,blocks"`
-	ObjectLockConfiguration           []AWSS3BucketObjectLockConfiguration           `tf:"object_lock_configuration,blocks"`
-	ReplicationConfiguration          []AWSS3BucketReplicationConfiguration          `tf:"replication_configuration,blocks"`
-	ServerSideEncryptionConfiguration []AWSS3BucketServerSideEncryptionConfiguration `tf:"server_side_encryption_configuration,blocks"`
-	Timeouts                          *AWSS3BucketTimeouts                           `tf:"timeouts,block"`
-	Versioning                        []AWSS3BucketVersioning                        `tf:"versioning,blocks"`
-	Website                           []AWSS3BucketWebsite                           `tf:"website,blocks"`
+	AccelerationStatus                *Value[string]                                 `tf:"acceleration_status" json:"acceleration_status,omitempty"`
+	ACL                               *Value[string]                                 `tf:"acl" json:"acl,omitempty"`
+	ARN                               *Value[string]                                 `tf:"arn" json:"arn,omitempty"`
+	Bucket                            *Value[string]                                 `tf:"bucket" json:"bucket,omitempty"`
+	BucketDomainName                  *Value[string]                                 `tf:"bucket_domain_name" json:"bucket_domain_name,omitempty"`
+	BucketPrefix                      *Value[string]                                 `tf:"bucket_prefix" json:"bucket_prefix,omitempty"`
+	BucketRegionalDomainName          *Value[string]                                 `tf:"bucket_regional_domain_name" json:"bucket_regional_domain_name,omitempty"`
+	ForceDestroy                      *Value[bool]                                   `tf:"force_destroy" json:"force_destroy,omitempty"`
+	HostedZoneID                      *Value[string]                                 `tf:"hosted_zone_id" json:"hosted_zone_id,omitempty"`
+	ID                                *Value[string]                                 `tf:"id" json:"id,omitempty"`
+	ObjectLockEnabled                 *Value[bool]                                   `tf:"object_lock_enabled" json:"object_lock_enabled,omitempty"`
+	Policy                            *Value[string]                                 `tf:"policy" json:"policy,omitempty"`
+	Region                            *Value[string]                                 `tf:"region" json:"region,omitempty"`
+	RequestPayer                      *Value[string]                                 `tf:"request_payer" json:"request_payer,omitempty"`
+	Tags                              map[string]*Value[string]                      `tf:"tags" json:"tags,omitempty"`
+	TagsAll                           map[string]*Value[string]                      `tf:"tags_all" json:"tags_all,omitempty"`
+	WebsiteDomain                     *Value[string]                                 `tf:"website_domain" json:"website_domain,omitempty"`
+	WebsiteEndpoint                   *Value[string]                                 `tf:"website_endpoint" json:"website_endpoint,omitempty"`
+	CorsRule                          []AWSS3BucketCorsRule                          `tf:"cors_rule,blocks" json:"cors_rule,omitempty"`
+	Grant                             []AWSS3BucketGrant                             `tf:"grant,blocks" json:"grant,omitempty"`
+	LifecycleRule                     []AWSS3BucketLifecycleRule                     `tf:"lifecycle_rule,blocks" json:"lifecycle_rule,omitempty"`
+	Logging                           []AWSS3BucketLogging                           `tf:"logging,blocks" json:"logging,omitempty"`
+	ObjectLockConfiguration           []AWSS3BucketObjectLockConfiguration           `tf:"object_lock_configuration,blocks" json:"object_lock_configuration,omitempty"`
+	ReplicationConfiguration          []AWSS3BucketReplicationConfiguration          `tf:"replication_configuration,blocks" json:"replication_configuration,omitempty"`
+	ServerSideEncryptionConfiguration []AWSS3BucketServerSideEncryptionConfiguration `tf:"server_side_encryption_configuration,blocks" json:"server_side_encryption_configuration,omitempty"`
+	Timeouts                          *AWSS3BucketTimeouts                           `tf:"timeouts,block" json:"timeouts,omitempty"`
+	Versioning                        []AWSS3BucketVersioning                        `tf:"versioning,blocks" json:"versioning,omitempty"`
+	Website                           []AWSS3BucketWebsite                           `tf:"website,blocks" json:"website,omitempty"`
 }
 
 // AWSS3BucketCorsRule is a nested-block type used by the parent resource.
 type AWSS3BucketCorsRule struct {
-	AllowedHeaders []*Value[string] `tf:"allowed_headers"`
-	AllowedMethods []*Value[string] `tf:"allowed_methods"`
-	AllowedOrigins []*Value[string] `tf:"allowed_origins"`
-	ExposeHeaders  []*Value[string] `tf:"expose_headers"`
-	MaxAgeSeconds  *Value[int64]    `tf:"max_age_seconds"`
+	AllowedHeaders []*Value[string] `tf:"allowed_headers" json:"allowed_headers,omitempty"`
+	AllowedMethods []*Value[string] `tf:"allowed_methods" json:"allowed_methods,omitempty"`
+	AllowedOrigins []*Value[string] `tf:"allowed_origins" json:"allowed_origins,omitempty"`
+	ExposeHeaders  []*Value[string] `tf:"expose_headers" json:"expose_headers,omitempty"`
+	MaxAgeSeconds  *Value[int64]    `tf:"max_age_seconds" json:"max_age_seconds,omitempty"`
 }
 
 // AWSS3BucketGrant is a nested-block type used by the parent resource.
 type AWSS3BucketGrant struct {
-	ID          *Value[string]   `tf:"id"`
-	Permissions []*Value[string] `tf:"permissions"`
-	Type_       *Value[string]   `tf:"type"`
-	URI         *Value[string]   `tf:"uri"`
+	ID          *Value[string]   `tf:"id" json:"id,omitempty"`
+	Permissions []*Value[string] `tf:"permissions" json:"permissions,omitempty"`
+	Type_       *Value[string]   `tf:"type" json:"type,omitempty"`
+	URI         *Value[string]   `tf:"uri" json:"uri,omitempty"`
 }
 
 // AWSS3BucketLifecycleRule is a nested-block type used by the parent resource.
 type AWSS3BucketLifecycleRule struct {
-	AbortIncompleteMultipartUploadDays *Value[float64]                                       `tf:"abort_incomplete_multipart_upload_days"`
-	Enabled                            *Value[bool]                                          `tf:"enabled"`
-	ID                                 *Value[string]                                        `tf:"id"`
-	Prefix                             *Value[string]                                        `tf:"prefix"`
-	Tags                               map[string]*Value[string]                             `tf:"tags"`
-	Expiration                         []AWSS3BucketLifecycleRuleExpiration                  `tf:"expiration,blocks"`
-	NoncurrentVersionExpiration        []AWSS3BucketLifecycleRuleNoncurrentVersionExpiration `tf:"noncurrent_version_expiration,blocks"`
-	NoncurrentVersionTransition        []AWSS3BucketLifecycleRuleNoncurrentVersionTransition `tf:"noncurrent_version_transition,blocks"`
-	Transition                         []AWSS3BucketLifecycleRuleTransition                  `tf:"transition,blocks"`
+	AbortIncompleteMultipartUploadDays *Value[float64]                                       `tf:"abort_incomplete_multipart_upload_days" json:"abort_incomplete_multipart_upload_days,omitempty"`
+	Enabled                            *Value[bool]                                          `tf:"enabled" json:"enabled,omitempty"`
+	ID                                 *Value[string]                                        `tf:"id" json:"id,omitempty"`
+	Prefix                             *Value[string]                                        `tf:"prefix" json:"prefix,omitempty"`
+	Tags                               map[string]*Value[string]                             `tf:"tags" json:"tags,omitempty"`
+	Expiration                         []AWSS3BucketLifecycleRuleExpiration                  `tf:"expiration,blocks" json:"expiration,omitempty"`
+	NoncurrentVersionExpiration        []AWSS3BucketLifecycleRuleNoncurrentVersionExpiration `tf:"noncurrent_version_expiration,blocks" json:"noncurrent_version_expiration,omitempty"`
+	NoncurrentVersionTransition        []AWSS3BucketLifecycleRuleNoncurrentVersionTransition `tf:"noncurrent_version_transition,blocks" json:"noncurrent_version_transition,omitempty"`
+	Transition                         []AWSS3BucketLifecycleRuleTransition                  `tf:"transition,blocks" json:"transition,omitempty"`
 }
 
 // AWSS3BucketLifecycleRuleExpiration is a nested-block type used by the parent resource.
 type AWSS3BucketLifecycleRuleExpiration struct {
-	Date                      *Value[string]  `tf:"date"`
-	Days                      *Value[float64] `tf:"days"`
-	ExpiredObjectDeleteMarker *Value[bool]    `tf:"expired_object_delete_marker"`
+	Date                      *Value[string]  `tf:"date" json:"date,omitempty"`
+	Days                      *Value[float64] `tf:"days" json:"days,omitempty"`
+	ExpiredObjectDeleteMarker *Value[bool]    `tf:"expired_object_delete_marker" json:"expired_object_delete_marker,omitempty"`
 }
 
 // AWSS3BucketLifecycleRuleNoncurrentVersionExpiration is a nested-block type used by the parent resource.
 type AWSS3BucketLifecycleRuleNoncurrentVersionExpiration struct {
-	Days *Value[float64] `tf:"days"`
+	Days *Value[float64] `tf:"days" json:"days,omitempty"`
 }
 
 // AWSS3BucketLifecycleRuleNoncurrentVersionTransition is a nested-block type used by the parent resource.
 type AWSS3BucketLifecycleRuleNoncurrentVersionTransition struct {
-	Days         *Value[float64] `tf:"days"`
-	StorageClass *Value[string]  `tf:"storage_class"`
+	Days         *Value[float64] `tf:"days" json:"days,omitempty"`
+	StorageClass *Value[string]  `tf:"storage_class" json:"storage_class,omitempty"`
 }
 
 // AWSS3BucketLifecycleRuleTransition is a nested-block type used by the parent resource.
 type AWSS3BucketLifecycleRuleTransition struct {
-	Date         *Value[string]  `tf:"date"`
-	Days         *Value[float64] `tf:"days"`
-	StorageClass *Value[string]  `tf:"storage_class"`
+	Date         *Value[string]  `tf:"date" json:"date,omitempty"`
+	Days         *Value[float64] `tf:"days" json:"days,omitempty"`
+	StorageClass *Value[string]  `tf:"storage_class" json:"storage_class,omitempty"`
 }
 
 // AWSS3BucketLogging is a nested-block type used by the parent resource.
 type AWSS3BucketLogging struct {
-	TargetBucket *Value[string] `tf:"target_bucket"`
-	TargetPrefix *Value[string] `tf:"target_prefix"`
+	TargetBucket *Value[string] `tf:"target_bucket" json:"target_bucket,omitempty"`
+	TargetPrefix *Value[string] `tf:"target_prefix" json:"target_prefix,omitempty"`
 }
 
 // AWSS3BucketObjectLockConfiguration is a nested-block type used by the parent resource.
 type AWSS3BucketObjectLockConfiguration struct {
-	ObjectLockEnabled *Value[string]                           `tf:"object_lock_enabled"`
-	Rule              []AWSS3BucketObjectLockConfigurationRule `tf:"rule,blocks"`
+	ObjectLockEnabled *Value[string]                           `tf:"object_lock_enabled" json:"object_lock_enabled,omitempty"`
+	Rule              []AWSS3BucketObjectLockConfigurationRule `tf:"rule,blocks" json:"rule,omitempty"`
 }
 
 // AWSS3BucketObjectLockConfigurationRule is a nested-block type used by the parent resource.
 type AWSS3BucketObjectLockConfigurationRule struct {
-	DefaultRetention []AWSS3BucketObjectLockConfigurationRuleDefaultRetention `tf:"default_retention,blocks"`
+	DefaultRetention []AWSS3BucketObjectLockConfigurationRuleDefaultRetention `tf:"default_retention,blocks" json:"default_retention,omitempty"`
 }
 
 // AWSS3BucketObjectLockConfigurationRuleDefaultRetention is a nested-block type used by the parent resource.
 type AWSS3BucketObjectLockConfigurationRuleDefaultRetention struct {
-	Days  *Value[float64] `tf:"days"`
-	Mode  *Value[string]  `tf:"mode"`
-	Years *Value[float64] `tf:"years"`
+	Days  *Value[float64] `tf:"days" json:"days,omitempty"`
+	Mode  *Value[string]  `tf:"mode" json:"mode,omitempty"`
+	Years *Value[float64] `tf:"years" json:"years,omitempty"`
 }
 
 // AWSS3BucketReplicationConfiguration is a nested-block type used by the parent resource.
 type AWSS3BucketReplicationConfiguration struct {
-	Role  *Value[string]                             `tf:"role"`
-	Rules []AWSS3BucketReplicationConfigurationRules `tf:"rules,blocks"`
+	Role  *Value[string]                             `tf:"role" json:"role,omitempty"`
+	Rules []AWSS3BucketReplicationConfigurationRules `tf:"rules,blocks" json:"rules,omitempty"`
 }
 
 // AWSS3BucketReplicationConfigurationRules is a nested-block type used by the parent resource.
 type AWSS3BucketReplicationConfigurationRules struct {
-	DeleteMarkerReplicationStatus *Value[string]                                                    `tf:"delete_marker_replication_status"`
-	ID                            *Value[string]                                                    `tf:"id"`
-	Prefix                        *Value[string]                                                    `tf:"prefix"`
-	Priority                      *Value[float64]                                                   `tf:"priority"`
-	Status                        *Value[string]                                                    `tf:"status"`
-	Destination                   []AWSS3BucketReplicationConfigurationRulesDestination             `tf:"destination,blocks"`
-	Filter                        []AWSS3BucketReplicationConfigurationRulesFilter                  `tf:"filter,blocks"`
-	SourceSelectionCriteria       []AWSS3BucketReplicationConfigurationRulesSourceSelectionCriteria `tf:"source_selection_criteria,blocks"`
+	DeleteMarkerReplicationStatus *Value[string]                                                    `tf:"delete_marker_replication_status" json:"delete_marker_replication_status,omitempty"`
+	ID                            *Value[string]                                                    `tf:"id" json:"id,omitempty"`
+	Prefix                        *Value[string]                                                    `tf:"prefix" json:"prefix,omitempty"`
+	Priority                      *Value[float64]                                                   `tf:"priority" json:"priority,omitempty"`
+	Status                        *Value[string]                                                    `tf:"status" json:"status,omitempty"`
+	Destination                   []AWSS3BucketReplicationConfigurationRulesDestination             `tf:"destination,blocks" json:"destination,omitempty"`
+	Filter                        []AWSS3BucketReplicationConfigurationRulesFilter                  `tf:"filter,blocks" json:"filter,omitempty"`
+	SourceSelectionCriteria       []AWSS3BucketReplicationConfigurationRulesSourceSelectionCriteria `tf:"source_selection_criteria,blocks" json:"source_selection_criteria,omitempty"`
 }
 
 // AWSS3BucketReplicationConfigurationRulesDestination is a nested-block type used by the parent resource.
 type AWSS3BucketReplicationConfigurationRulesDestination struct {
-	AccountID                *Value[string]                                                                `tf:"account_id"`
-	Bucket                   *Value[string]                                                                `tf:"bucket"`
-	ReplicaKMSKeyID          *Value[string]                                                                `tf:"replica_kms_key_id"`
-	StorageClass             *Value[string]                                                                `tf:"storage_class"`
-	AccessControlTranslation []AWSS3BucketReplicationConfigurationRulesDestinationAccessControlTranslation `tf:"access_control_translation,blocks"`
-	Metrics                  []AWSS3BucketReplicationConfigurationRulesDestinationMetrics                  `tf:"metrics,blocks"`
-	ReplicationTime          []AWSS3BucketReplicationConfigurationRulesDestinationReplicationTime          `tf:"replication_time,blocks"`
+	AccountID                *Value[string]                                                                `tf:"account_id" json:"account_id,omitempty"`
+	Bucket                   *Value[string]                                                                `tf:"bucket" json:"bucket,omitempty"`
+	ReplicaKMSKeyID          *Value[string]                                                                `tf:"replica_kms_key_id" json:"replica_kms_key_id,omitempty"`
+	StorageClass             *Value[string]                                                                `tf:"storage_class" json:"storage_class,omitempty"`
+	AccessControlTranslation []AWSS3BucketReplicationConfigurationRulesDestinationAccessControlTranslation `tf:"access_control_translation,blocks" json:"access_control_translation,omitempty"`
+	Metrics                  []AWSS3BucketReplicationConfigurationRulesDestinationMetrics                  `tf:"metrics,blocks" json:"metrics,omitempty"`
+	ReplicationTime          []AWSS3BucketReplicationConfigurationRulesDestinationReplicationTime          `tf:"replication_time,blocks" json:"replication_time,omitempty"`
 }
 
 // AWSS3BucketReplicationConfigurationRulesDestinationAccessControlTranslation is a nested-block type used by the parent resource.
 type AWSS3BucketReplicationConfigurationRulesDestinationAccessControlTranslation struct {
-	Owner *Value[string] `tf:"owner"`
+	Owner *Value[string] `tf:"owner" json:"owner,omitempty"`
 }
 
 // AWSS3BucketReplicationConfigurationRulesDestinationMetrics is a nested-block type used by the parent resource.
 type AWSS3BucketReplicationConfigurationRulesDestinationMetrics struct {
-	Minutes *Value[float64] `tf:"minutes"`
-	Status  *Value[string]  `tf:"status"`
+	Minutes *Value[float64] `tf:"minutes" json:"minutes,omitempty"`
+	Status  *Value[string]  `tf:"status" json:"status,omitempty"`
 }
 
 // AWSS3BucketReplicationConfigurationRulesDestinationReplicationTime is a nested-block type used by the parent resource.
 type AWSS3BucketReplicationConfigurationRulesDestinationReplicationTime struct {
-	Minutes *Value[float64] `tf:"minutes"`
-	Status  *Value[string]  `tf:"status"`
+	Minutes *Value[float64] `tf:"minutes" json:"minutes,omitempty"`
+	Status  *Value[string]  `tf:"status" json:"status,omitempty"`
 }
 
 // AWSS3BucketReplicationConfigurationRulesFilter is a nested-block type used by the parent resource.
 type AWSS3BucketReplicationConfigurationRulesFilter struct {
-	Prefix *Value[string]            `tf:"prefix"`
-	Tags   map[string]*Value[string] `tf:"tags"`
+	Prefix *Value[string]            `tf:"prefix" json:"prefix,omitempty"`
+	Tags   map[string]*Value[string] `tf:"tags" json:"tags,omitempty"`
 }
 
 // AWSS3BucketReplicationConfigurationRulesSourceSelectionCriteria is a nested-block type used by the parent resource.
 type AWSS3BucketReplicationConfigurationRulesSourceSelectionCriteria struct {
-	SSEKMSEncryptedObjects []AWSS3BucketReplicationConfigurationRulesSourceSelectionCriteriaSSEKMSEncryptedObjects `tf:"sse_kms_encrypted_objects,blocks"`
+	SSEKMSEncryptedObjects []AWSS3BucketReplicationConfigurationRulesSourceSelectionCriteriaSSEKMSEncryptedObjects `tf:"sse_kms_encrypted_objects,blocks" json:"sse_kms_encrypted_objects,omitempty"`
 }
 
 // AWSS3BucketReplicationConfigurationRulesSourceSelectionCriteriaSSEKMSEncryptedObjects is a nested-block type used by the parent resource.
 type AWSS3BucketReplicationConfigurationRulesSourceSelectionCriteriaSSEKMSEncryptedObjects struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // AWSS3BucketServerSideEncryptionConfiguration is a nested-block type used by the parent resource.
 type AWSS3BucketServerSideEncryptionConfiguration struct {
-	Rule []AWSS3BucketServerSideEncryptionConfigurationRule `tf:"rule,blocks"`
+	Rule []AWSS3BucketServerSideEncryptionConfigurationRule `tf:"rule,blocks" json:"rule,omitempty"`
 }
 
 // AWSS3BucketServerSideEncryptionConfigurationRule is a nested-block type used by the parent resource.
 type AWSS3BucketServerSideEncryptionConfigurationRule struct {
-	BucketKeyEnabled                   *Value[bool]                                                                         `tf:"bucket_key_enabled"`
-	ApplyServerSideEncryptionByDefault []AWSS3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault `tf:"apply_server_side_encryption_by_default,blocks"`
+	BucketKeyEnabled                   *Value[bool]                                                                         `tf:"bucket_key_enabled" json:"bucket_key_enabled,omitempty"`
+	ApplyServerSideEncryptionByDefault []AWSS3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault `tf:"apply_server_side_encryption_by_default,blocks" json:"apply_server_side_encryption_by_default,omitempty"`
 }
 
 // AWSS3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault is a nested-block type used by the parent resource.
 type AWSS3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault struct {
-	KMSMasterKeyID *Value[string] `tf:"kms_master_key_id"`
-	SSEAlgorithm   *Value[string] `tf:"sse_algorithm"`
+	KMSMasterKeyID *Value[string] `tf:"kms_master_key_id" json:"kms_master_key_id,omitempty"`
+	SSEAlgorithm   *Value[string] `tf:"sse_algorithm" json:"sse_algorithm,omitempty"`
 }
 
 // AWSS3BucketTimeouts is a nested-block type used by the parent resource.
 type AWSS3BucketTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Read   *Value[string] `tf:"read"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Read   *Value[string] `tf:"read" json:"read,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // AWSS3BucketVersioning is a nested-block type used by the parent resource.
 type AWSS3BucketVersioning struct {
-	Enabled   *Value[bool] `tf:"enabled"`
-	MFADelete *Value[bool] `tf:"mfa_delete"`
+	Enabled   *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
+	MFADelete *Value[bool] `tf:"mfa_delete" json:"mfa_delete,omitempty"`
 }
 
 // AWSS3BucketWebsite is a nested-block type used by the parent resource.
 type AWSS3BucketWebsite struct {
-	ErrorDocument         *Value[string] `tf:"error_document"`
-	IndexDocument         *Value[string] `tf:"index_document"`
-	RedirectAllRequestsTo *Value[string] `tf:"redirect_all_requests_to"`
-	RoutingRules          *Value[string] `tf:"routing_rules"`
+	ErrorDocument         *Value[string] `tf:"error_document" json:"error_document,omitempty"`
+	IndexDocument         *Value[string] `tf:"index_document" json:"index_document,omitempty"`
+	RedirectAllRequestsTo *Value[string] `tf:"redirect_all_requests_to" json:"redirect_all_requests_to,omitempty"`
+	RoutingRules          *Value[string] `tf:"routing_rules" json:"routing_rules,omitempty"`
 }
 
 // AWSS3BucketSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/aws_secretsmanager_secret.gen.go
+++ b/pkg/composer/imported/generated/aws_secretsmanager_secret.gen.go
@@ -7,27 +7,27 @@ import "reflect"
 // AWSSecretsmanagerSecret is the generated Layer 1 typed model for the
 // `aws_secretsmanager_secret` Terraform resource.
 type AWSSecretsmanagerSecret struct {
-	ARN                         *Value[string]                   `tf:"arn"`
-	Description                 *Value[string]                   `tf:"description"`
-	ForceOverwriteReplicaSecret *Value[bool]                     `tf:"force_overwrite_replica_secret"`
-	ID                          *Value[string]                   `tf:"id"`
-	KMSKeyID                    *Value[string]                   `tf:"kms_key_id"`
-	Name                        *Value[string]                   `tf:"name"`
-	NamePrefix                  *Value[string]                   `tf:"name_prefix"`
-	Policy                      *Value[string]                   `tf:"policy"`
-	RecoveryWindowInDays        *Value[float64]                  `tf:"recovery_window_in_days"`
-	Tags                        map[string]*Value[string]        `tf:"tags"`
-	TagsAll                     map[string]*Value[string]        `tf:"tags_all"`
-	Replica                     []AWSSecretsmanagerSecretReplica `tf:"replica,blocks"`
+	ARN                         *Value[string]                   `tf:"arn" json:"arn,omitempty"`
+	Description                 *Value[string]                   `tf:"description" json:"description,omitempty"`
+	ForceOverwriteReplicaSecret *Value[bool]                     `tf:"force_overwrite_replica_secret" json:"force_overwrite_replica_secret,omitempty"`
+	ID                          *Value[string]                   `tf:"id" json:"id,omitempty"`
+	KMSKeyID                    *Value[string]                   `tf:"kms_key_id" json:"kms_key_id,omitempty"`
+	Name                        *Value[string]                   `tf:"name" json:"name,omitempty"`
+	NamePrefix                  *Value[string]                   `tf:"name_prefix" json:"name_prefix,omitempty"`
+	Policy                      *Value[string]                   `tf:"policy" json:"policy,omitempty"`
+	RecoveryWindowInDays        *Value[float64]                  `tf:"recovery_window_in_days" json:"recovery_window_in_days,omitempty"`
+	Tags                        map[string]*Value[string]        `tf:"tags" json:"tags,omitempty"`
+	TagsAll                     map[string]*Value[string]        `tf:"tags_all" json:"tags_all,omitempty"`
+	Replica                     []AWSSecretsmanagerSecretReplica `tf:"replica,blocks" json:"replica,omitempty"`
 }
 
 // AWSSecretsmanagerSecretReplica is a nested-block type used by the parent resource.
 type AWSSecretsmanagerSecretReplica struct {
-	KMSKeyID         *Value[string] `tf:"kms_key_id"`
-	LastAccessedDate *Value[string] `tf:"last_accessed_date"`
-	Region           *Value[string] `tf:"region"`
-	Status           *Value[string] `tf:"status"`
-	StatusMessage    *Value[string] `tf:"status_message"`
+	KMSKeyID         *Value[string] `tf:"kms_key_id" json:"kms_key_id,omitempty"`
+	LastAccessedDate *Value[string] `tf:"last_accessed_date" json:"last_accessed_date,omitempty"`
+	Region           *Value[string] `tf:"region" json:"region,omitempty"`
+	Status           *Value[string] `tf:"status" json:"status,omitempty"`
+	StatusMessage    *Value[string] `tf:"status_message" json:"status_message,omitempty"`
 }
 
 // AWSSecretsmanagerSecretSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/aws_sqs_queue.gen.go
+++ b/pkg/composer/imported/generated/aws_sqs_queue.gen.go
@@ -7,28 +7,28 @@ import "reflect"
 // AWSSQSQueue is the generated Layer 1 typed model for the
 // `aws_sqs_queue` Terraform resource.
 type AWSSQSQueue struct {
-	ARN                          *Value[string]            `tf:"arn"`
-	ContentBasedDeduplication    *Value[bool]              `tf:"content_based_deduplication"`
-	DeduplicationScope           *Value[string]            `tf:"deduplication_scope"`
-	DelaySeconds                 *Value[int64]             `tf:"delay_seconds"`
-	FIFOQueue                    *Value[bool]              `tf:"fifo_queue"`
-	FIFOThroughputLimit          *Value[string]            `tf:"fifo_throughput_limit"`
-	ID                           *Value[string]            `tf:"id"`
-	KMSDataKeyReusePeriodSeconds *Value[int64]             `tf:"kms_data_key_reuse_period_seconds"`
-	KMSMasterKeyID               *Value[string]            `tf:"kms_master_key_id"`
-	MaxMessageSize               *Value[int64]             `tf:"max_message_size"`
-	MessageRetentionSeconds      *Value[int64]             `tf:"message_retention_seconds"`
-	Name                         *Value[string]            `tf:"name"`
-	NamePrefix                   *Value[string]            `tf:"name_prefix"`
-	Policy                       *Value[string]            `tf:"policy"`
-	ReceiveWaitTimeSeconds       *Value[int64]             `tf:"receive_wait_time_seconds"`
-	RedriveAllowPolicy           *Value[string]            `tf:"redrive_allow_policy"`
-	RedrivePolicy                *Value[string]            `tf:"redrive_policy"`
-	SQSManagedSSEEnabled         *Value[bool]              `tf:"sqs_managed_sse_enabled"`
-	Tags                         map[string]*Value[string] `tf:"tags"`
-	TagsAll                      map[string]*Value[string] `tf:"tags_all"`
-	URL                          *Value[string]            `tf:"url"`
-	VisibilityTimeoutSeconds     *Value[int64]             `tf:"visibility_timeout_seconds"`
+	ARN                          *Value[string]            `tf:"arn" json:"arn,omitempty"`
+	ContentBasedDeduplication    *Value[bool]              `tf:"content_based_deduplication" json:"content_based_deduplication,omitempty"`
+	DeduplicationScope           *Value[string]            `tf:"deduplication_scope" json:"deduplication_scope,omitempty"`
+	DelaySeconds                 *Value[int64]             `tf:"delay_seconds" json:"delay_seconds,omitempty"`
+	FIFOQueue                    *Value[bool]              `tf:"fifo_queue" json:"fifo_queue,omitempty"`
+	FIFOThroughputLimit          *Value[string]            `tf:"fifo_throughput_limit" json:"fifo_throughput_limit,omitempty"`
+	ID                           *Value[string]            `tf:"id" json:"id,omitempty"`
+	KMSDataKeyReusePeriodSeconds *Value[int64]             `tf:"kms_data_key_reuse_period_seconds" json:"kms_data_key_reuse_period_seconds,omitempty"`
+	KMSMasterKeyID               *Value[string]            `tf:"kms_master_key_id" json:"kms_master_key_id,omitempty"`
+	MaxMessageSize               *Value[int64]             `tf:"max_message_size" json:"max_message_size,omitempty"`
+	MessageRetentionSeconds      *Value[int64]             `tf:"message_retention_seconds" json:"message_retention_seconds,omitempty"`
+	Name                         *Value[string]            `tf:"name" json:"name,omitempty"`
+	NamePrefix                   *Value[string]            `tf:"name_prefix" json:"name_prefix,omitempty"`
+	Policy                       *Value[string]            `tf:"policy" json:"policy,omitempty"`
+	ReceiveWaitTimeSeconds       *Value[int64]             `tf:"receive_wait_time_seconds" json:"receive_wait_time_seconds,omitempty"`
+	RedriveAllowPolicy           *Value[string]            `tf:"redrive_allow_policy" json:"redrive_allow_policy,omitempty"`
+	RedrivePolicy                *Value[string]            `tf:"redrive_policy" json:"redrive_policy,omitempty"`
+	SQSManagedSSEEnabled         *Value[bool]              `tf:"sqs_managed_sse_enabled" json:"sqs_managed_sse_enabled,omitempty"`
+	Tags                         map[string]*Value[string] `tf:"tags" json:"tags,omitempty"`
+	TagsAll                      map[string]*Value[string] `tf:"tags_all" json:"tags_all,omitempty"`
+	URL                          *Value[string]            `tf:"url" json:"url,omitempty"`
+	VisibilityTimeoutSeconds     *Value[int64]             `tf:"visibility_timeout_seconds" json:"visibility_timeout_seconds,omitempty"`
 }
 
 // AWSSQSQueueSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_api_gateway_api.gen.go
+++ b/pkg/composer/imported/generated/google_api_gateway_api.gen.go
@@ -7,24 +7,24 @@ import "reflect"
 // GoogleAPIGatewayAPI is the generated Layer 1 typed model for the
 // `google_api_gateway_api` Terraform resource.
 type GoogleAPIGatewayAPI struct {
-	APIID           *Value[string]               `tf:"api_id"`
-	CreateTime      *Value[string]               `tf:"create_time"`
-	DisplayName     *Value[string]               `tf:"display_name"`
-	EffectiveLabels map[string]*Value[string]    `tf:"effective_labels"`
-	ID              *Value[string]               `tf:"id"`
-	Labels          map[string]*Value[string]    `tf:"labels"`
-	ManagedService  *Value[string]               `tf:"managed_service"`
-	Name            *Value[string]               `tf:"name"`
-	Project         *Value[string]               `tf:"project"`
-	TerraformLabels map[string]*Value[string]    `tf:"terraform_labels"`
-	Timeouts        *GoogleAPIGatewayAPITimeouts `tf:"timeouts,block"`
+	APIID           *Value[string]               `tf:"api_id" json:"api_id,omitempty"`
+	CreateTime      *Value[string]               `tf:"create_time" json:"create_time,omitempty"`
+	DisplayName     *Value[string]               `tf:"display_name" json:"display_name,omitempty"`
+	EffectiveLabels map[string]*Value[string]    `tf:"effective_labels" json:"effective_labels,omitempty"`
+	ID              *Value[string]               `tf:"id" json:"id,omitempty"`
+	Labels          map[string]*Value[string]    `tf:"labels" json:"labels,omitempty"`
+	ManagedService  *Value[string]               `tf:"managed_service" json:"managed_service,omitempty"`
+	Name            *Value[string]               `tf:"name" json:"name,omitempty"`
+	Project         *Value[string]               `tf:"project" json:"project,omitempty"`
+	TerraformLabels map[string]*Value[string]    `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	Timeouts        *GoogleAPIGatewayAPITimeouts `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleAPIGatewayAPITimeouts is a nested-block type used by the parent resource.
 type GoogleAPIGatewayAPITimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleAPIGatewayAPISchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_api_gateway_api_config.gen.go
+++ b/pkg/composer/imported/generated/google_api_gateway_api_config.gen.go
@@ -7,74 +7,74 @@ import "reflect"
 // GoogleAPIGatewayAPIConfig is the generated Layer 1 typed model for the
 // `google_api_gateway_api_config` Terraform resource.
 type GoogleAPIGatewayAPIConfig struct {
-	API                   *Value[string]                                   `tf:"api"`
-	APIConfigID           *Value[string]                                   `tf:"api_config_id"`
-	APIConfigIDPrefix     *Value[string]                                   `tf:"api_config_id_prefix"`
-	DisplayName           *Value[string]                                   `tf:"display_name"`
-	EffectiveLabels       map[string]*Value[string]                        `tf:"effective_labels"`
-	ID                    *Value[string]                                   `tf:"id"`
-	Labels                map[string]*Value[string]                        `tf:"labels"`
-	Name                  *Value[string]                                   `tf:"name"`
-	Project               *Value[string]                                   `tf:"project"`
-	ServiceConfigID       *Value[string]                                   `tf:"service_config_id"`
-	TerraformLabels       map[string]*Value[string]                        `tf:"terraform_labels"`
-	GatewayConfig         []GoogleAPIGatewayAPIConfigGatewayConfig         `tf:"gateway_config,blocks"`
-	GRPCServices          []GoogleAPIGatewayAPIConfigGRPCServices          `tf:"grpc_services,blocks"`
-	ManagedServiceConfigs []GoogleAPIGatewayAPIConfigManagedServiceConfigs `tf:"managed_service_configs,blocks"`
-	OpenapiDocuments      []GoogleAPIGatewayAPIConfigOpenapiDocuments      `tf:"openapi_documents,blocks"`
-	Timeouts              *GoogleAPIGatewayAPIConfigTimeouts               `tf:"timeouts,block"`
+	API                   *Value[string]                                   `tf:"api" json:"api,omitempty"`
+	APIConfigID           *Value[string]                                   `tf:"api_config_id" json:"api_config_id,omitempty"`
+	APIConfigIDPrefix     *Value[string]                                   `tf:"api_config_id_prefix" json:"api_config_id_prefix,omitempty"`
+	DisplayName           *Value[string]                                   `tf:"display_name" json:"display_name,omitempty"`
+	EffectiveLabels       map[string]*Value[string]                        `tf:"effective_labels" json:"effective_labels,omitempty"`
+	ID                    *Value[string]                                   `tf:"id" json:"id,omitempty"`
+	Labels                map[string]*Value[string]                        `tf:"labels" json:"labels,omitempty"`
+	Name                  *Value[string]                                   `tf:"name" json:"name,omitempty"`
+	Project               *Value[string]                                   `tf:"project" json:"project,omitempty"`
+	ServiceConfigID       *Value[string]                                   `tf:"service_config_id" json:"service_config_id,omitempty"`
+	TerraformLabels       map[string]*Value[string]                        `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	GatewayConfig         []GoogleAPIGatewayAPIConfigGatewayConfig         `tf:"gateway_config,blocks" json:"gateway_config,omitempty"`
+	GRPCServices          []GoogleAPIGatewayAPIConfigGRPCServices          `tf:"grpc_services,blocks" json:"grpc_services,omitempty"`
+	ManagedServiceConfigs []GoogleAPIGatewayAPIConfigManagedServiceConfigs `tf:"managed_service_configs,blocks" json:"managed_service_configs,omitempty"`
+	OpenapiDocuments      []GoogleAPIGatewayAPIConfigOpenapiDocuments      `tf:"openapi_documents,blocks" json:"openapi_documents,omitempty"`
+	Timeouts              *GoogleAPIGatewayAPIConfigTimeouts               `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleAPIGatewayAPIConfigGRPCServices is a nested-block type used by the parent resource.
 type GoogleAPIGatewayAPIConfigGRPCServices struct {
-	FileDescriptorSet []GoogleAPIGatewayAPIConfigGRPCServicesFileDescriptorSet `tf:"file_descriptor_set,blocks"`
-	Source            []GoogleAPIGatewayAPIConfigGRPCServicesSource            `tf:"source,blocks"`
+	FileDescriptorSet []GoogleAPIGatewayAPIConfigGRPCServicesFileDescriptorSet `tf:"file_descriptor_set,blocks" json:"file_descriptor_set,omitempty"`
+	Source            []GoogleAPIGatewayAPIConfigGRPCServicesSource            `tf:"source,blocks" json:"source,omitempty"`
 }
 
 // GoogleAPIGatewayAPIConfigGRPCServicesFileDescriptorSet is a nested-block type used by the parent resource.
 type GoogleAPIGatewayAPIConfigGRPCServicesFileDescriptorSet struct {
-	Contents *Value[string] `tf:"contents"`
-	Path     *Value[string] `tf:"path"`
+	Contents *Value[string] `tf:"contents" json:"contents,omitempty"`
+	Path     *Value[string] `tf:"path" json:"path,omitempty"`
 }
 
 // GoogleAPIGatewayAPIConfigGRPCServicesSource is a nested-block type used by the parent resource.
 type GoogleAPIGatewayAPIConfigGRPCServicesSource struct {
-	Contents *Value[string] `tf:"contents"`
-	Path     *Value[string] `tf:"path"`
+	Contents *Value[string] `tf:"contents" json:"contents,omitempty"`
+	Path     *Value[string] `tf:"path" json:"path,omitempty"`
 }
 
 // GoogleAPIGatewayAPIConfigGatewayConfig is a nested-block type used by the parent resource.
 type GoogleAPIGatewayAPIConfigGatewayConfig struct {
-	BackendConfig []GoogleAPIGatewayAPIConfigGatewayConfigBackendConfig `tf:"backend_config,blocks"`
+	BackendConfig []GoogleAPIGatewayAPIConfigGatewayConfigBackendConfig `tf:"backend_config,blocks" json:"backend_config,omitempty"`
 }
 
 // GoogleAPIGatewayAPIConfigGatewayConfigBackendConfig is a nested-block type used by the parent resource.
 type GoogleAPIGatewayAPIConfigGatewayConfigBackendConfig struct {
-	GoogleServiceAccount *Value[string] `tf:"google_service_account"`
+	GoogleServiceAccount *Value[string] `tf:"google_service_account" json:"google_service_account,omitempty"`
 }
 
 // GoogleAPIGatewayAPIConfigManagedServiceConfigs is a nested-block type used by the parent resource.
 type GoogleAPIGatewayAPIConfigManagedServiceConfigs struct {
-	Contents *Value[string] `tf:"contents"`
-	Path     *Value[string] `tf:"path"`
+	Contents *Value[string] `tf:"contents" json:"contents,omitempty"`
+	Path     *Value[string] `tf:"path" json:"path,omitempty"`
 }
 
 // GoogleAPIGatewayAPIConfigOpenapiDocuments is a nested-block type used by the parent resource.
 type GoogleAPIGatewayAPIConfigOpenapiDocuments struct {
-	Document []GoogleAPIGatewayAPIConfigOpenapiDocumentsDocument `tf:"document,blocks"`
+	Document []GoogleAPIGatewayAPIConfigOpenapiDocumentsDocument `tf:"document,blocks" json:"document,omitempty"`
 }
 
 // GoogleAPIGatewayAPIConfigOpenapiDocumentsDocument is a nested-block type used by the parent resource.
 type GoogleAPIGatewayAPIConfigOpenapiDocumentsDocument struct {
-	Contents *Value[string] `tf:"contents"`
-	Path     *Value[string] `tf:"path"`
+	Contents *Value[string] `tf:"contents" json:"contents,omitempty"`
+	Path     *Value[string] `tf:"path" json:"path,omitempty"`
 }
 
 // GoogleAPIGatewayAPIConfigTimeouts is a nested-block type used by the parent resource.
 type GoogleAPIGatewayAPIConfigTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleAPIGatewayAPIConfigSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_api_gateway_gateway.gen.go
+++ b/pkg/composer/imported/generated/google_api_gateway_gateway.gen.go
@@ -7,25 +7,25 @@ import "reflect"
 // GoogleAPIGatewayGateway is the generated Layer 1 typed model for the
 // `google_api_gateway_gateway` Terraform resource.
 type GoogleAPIGatewayGateway struct {
-	APIConfig       *Value[string]                   `tf:"api_config"`
-	DefaultHostname *Value[string]                   `tf:"default_hostname"`
-	DisplayName     *Value[string]                   `tf:"display_name"`
-	EffectiveLabels map[string]*Value[string]        `tf:"effective_labels"`
-	GatewayID       *Value[string]                   `tf:"gateway_id"`
-	ID              *Value[string]                   `tf:"id"`
-	Labels          map[string]*Value[string]        `tf:"labels"`
-	Name            *Value[string]                   `tf:"name"`
-	Project         *Value[string]                   `tf:"project"`
-	Region          *Value[string]                   `tf:"region"`
-	TerraformLabels map[string]*Value[string]        `tf:"terraform_labels"`
-	Timeouts        *GoogleAPIGatewayGatewayTimeouts `tf:"timeouts,block"`
+	APIConfig       *Value[string]                   `tf:"api_config" json:"api_config,omitempty"`
+	DefaultHostname *Value[string]                   `tf:"default_hostname" json:"default_hostname,omitempty"`
+	DisplayName     *Value[string]                   `tf:"display_name" json:"display_name,omitempty"`
+	EffectiveLabels map[string]*Value[string]        `tf:"effective_labels" json:"effective_labels,omitempty"`
+	GatewayID       *Value[string]                   `tf:"gateway_id" json:"gateway_id,omitempty"`
+	ID              *Value[string]                   `tf:"id" json:"id,omitempty"`
+	Labels          map[string]*Value[string]        `tf:"labels" json:"labels,omitempty"`
+	Name            *Value[string]                   `tf:"name" json:"name,omitempty"`
+	Project         *Value[string]                   `tf:"project" json:"project,omitempty"`
+	Region          *Value[string]                   `tf:"region" json:"region,omitempty"`
+	TerraformLabels map[string]*Value[string]        `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	Timeouts        *GoogleAPIGatewayGatewayTimeouts `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleAPIGatewayGatewayTimeouts is a nested-block type used by the parent resource.
 type GoogleAPIGatewayGatewayTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleAPIGatewayGatewaySchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_cloud_run_v2_service.gen.go
+++ b/pkg/composer/imported/generated/google_cloud_run_v2_service.gen.go
@@ -7,306 +7,306 @@ import "reflect"
 // GoogleCloudRunV2Service is the generated Layer 1 typed model for the
 // `google_cloud_run_v2_service` Terraform resource.
 type GoogleCloudRunV2Service struct {
-	Annotations           map[string]*Value[string]                    `tf:"annotations"`
-	Client                *Value[string]                               `tf:"client"`
-	ClientVersion         *Value[string]                               `tf:"client_version"`
-	Conditions            []GoogleCloudRunV2ServiceConditions          `tf:"conditions"`
-	CreateTime            *Value[string]                               `tf:"create_time"`
-	Creator               *Value[string]                               `tf:"creator"`
-	CustomAudiences       []*Value[string]                             `tf:"custom_audiences"`
-	DeleteTime            *Value[string]                               `tf:"delete_time"`
-	DeletionProtection    *Value[bool]                                 `tf:"deletion_protection"`
-	Description           *Value[string]                               `tf:"description"`
-	EffectiveAnnotations  map[string]*Value[string]                    `tf:"effective_annotations"`
-	EffectiveLabels       map[string]*Value[string]                    `tf:"effective_labels"`
-	Etag                  *Value[string]                               `tf:"etag"`
-	ExpireTime            *Value[string]                               `tf:"expire_time"`
-	Generation            *Value[string]                               `tf:"generation"`
-	ID                    *Value[string]                               `tf:"id"`
-	Ingress               *Value[string]                               `tf:"ingress"`
-	InvokerIAMDisabled    *Value[bool]                                 `tf:"invoker_iam_disabled"`
-	Labels                map[string]*Value[string]                    `tf:"labels"`
-	LastModifier          *Value[string]                               `tf:"last_modifier"`
-	LatestCreatedRevision *Value[string]                               `tf:"latest_created_revision"`
-	LatestReadyRevision   *Value[string]                               `tf:"latest_ready_revision"`
-	LaunchStage           *Value[string]                               `tf:"launch_stage"`
-	Location              *Value[string]                               `tf:"location"`
-	Name                  *Value[string]                               `tf:"name"`
-	ObservedGeneration    *Value[string]                               `tf:"observed_generation"`
-	Project               *Value[string]                               `tf:"project"`
-	Reconciling           *Value[bool]                                 `tf:"reconciling"`
-	TerminalCondition     []GoogleCloudRunV2ServiceTerminalCondition   `tf:"terminal_condition"`
-	TerraformLabels       map[string]*Value[string]                    `tf:"terraform_labels"`
-	TrafficStatuses       []GoogleCloudRunV2ServiceTrafficStatuses     `tf:"traffic_statuses"`
-	Uid                   *Value[string]                               `tf:"uid"`
-	UpdateTime            *Value[string]                               `tf:"update_time"`
-	URI                   *Value[string]                               `tf:"uri"`
-	BinaryAuthorization   []GoogleCloudRunV2ServiceBinaryAuthorization `tf:"binary_authorization,blocks"`
-	Scaling               []GoogleCloudRunV2ServiceScaling             `tf:"scaling,blocks"`
-	Template              []GoogleCloudRunV2ServiceTemplate            `tf:"template,blocks"`
-	Timeouts              *GoogleCloudRunV2ServiceTimeouts             `tf:"timeouts,block"`
-	Traffic               []GoogleCloudRunV2ServiceTraffic             `tf:"traffic,blocks"`
+	Annotations           map[string]*Value[string]                    `tf:"annotations" json:"annotations,omitempty"`
+	Client                *Value[string]                               `tf:"client" json:"client,omitempty"`
+	ClientVersion         *Value[string]                               `tf:"client_version" json:"client_version,omitempty"`
+	Conditions            []GoogleCloudRunV2ServiceConditions          `tf:"conditions" json:"conditions,omitempty"`
+	CreateTime            *Value[string]                               `tf:"create_time" json:"create_time,omitempty"`
+	Creator               *Value[string]                               `tf:"creator" json:"creator,omitempty"`
+	CustomAudiences       []*Value[string]                             `tf:"custom_audiences" json:"custom_audiences,omitempty"`
+	DeleteTime            *Value[string]                               `tf:"delete_time" json:"delete_time,omitempty"`
+	DeletionProtection    *Value[bool]                                 `tf:"deletion_protection" json:"deletion_protection,omitempty"`
+	Description           *Value[string]                               `tf:"description" json:"description,omitempty"`
+	EffectiveAnnotations  map[string]*Value[string]                    `tf:"effective_annotations" json:"effective_annotations,omitempty"`
+	EffectiveLabels       map[string]*Value[string]                    `tf:"effective_labels" json:"effective_labels,omitempty"`
+	Etag                  *Value[string]                               `tf:"etag" json:"etag,omitempty"`
+	ExpireTime            *Value[string]                               `tf:"expire_time" json:"expire_time,omitempty"`
+	Generation            *Value[string]                               `tf:"generation" json:"generation,omitempty"`
+	ID                    *Value[string]                               `tf:"id" json:"id,omitempty"`
+	Ingress               *Value[string]                               `tf:"ingress" json:"ingress,omitempty"`
+	InvokerIAMDisabled    *Value[bool]                                 `tf:"invoker_iam_disabled" json:"invoker_iam_disabled,omitempty"`
+	Labels                map[string]*Value[string]                    `tf:"labels" json:"labels,omitempty"`
+	LastModifier          *Value[string]                               `tf:"last_modifier" json:"last_modifier,omitempty"`
+	LatestCreatedRevision *Value[string]                               `tf:"latest_created_revision" json:"latest_created_revision,omitempty"`
+	LatestReadyRevision   *Value[string]                               `tf:"latest_ready_revision" json:"latest_ready_revision,omitempty"`
+	LaunchStage           *Value[string]                               `tf:"launch_stage" json:"launch_stage,omitempty"`
+	Location              *Value[string]                               `tf:"location" json:"location,omitempty"`
+	Name                  *Value[string]                               `tf:"name" json:"name,omitempty"`
+	ObservedGeneration    *Value[string]                               `tf:"observed_generation" json:"observed_generation,omitempty"`
+	Project               *Value[string]                               `tf:"project" json:"project,omitempty"`
+	Reconciling           *Value[bool]                                 `tf:"reconciling" json:"reconciling,omitempty"`
+	TerminalCondition     []GoogleCloudRunV2ServiceTerminalCondition   `tf:"terminal_condition" json:"terminal_condition,omitempty"`
+	TerraformLabels       map[string]*Value[string]                    `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	TrafficStatuses       []GoogleCloudRunV2ServiceTrafficStatuses     `tf:"traffic_statuses" json:"traffic_statuses,omitempty"`
+	Uid                   *Value[string]                               `tf:"uid" json:"uid,omitempty"`
+	UpdateTime            *Value[string]                               `tf:"update_time" json:"update_time,omitempty"`
+	URI                   *Value[string]                               `tf:"uri" json:"uri,omitempty"`
+	BinaryAuthorization   []GoogleCloudRunV2ServiceBinaryAuthorization `tf:"binary_authorization,blocks" json:"binary_authorization,omitempty"`
+	Scaling               []GoogleCloudRunV2ServiceScaling             `tf:"scaling,blocks" json:"scaling,omitempty"`
+	Template              []GoogleCloudRunV2ServiceTemplate            `tf:"template,blocks" json:"template,omitempty"`
+	Timeouts              *GoogleCloudRunV2ServiceTimeouts             `tf:"timeouts,block" json:"timeouts,omitempty"`
+	Traffic               []GoogleCloudRunV2ServiceTraffic             `tf:"traffic,blocks" json:"traffic,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceBinaryAuthorization is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceBinaryAuthorization struct {
-	BreakglassJustification *Value[string] `tf:"breakglass_justification"`
-	Policy                  *Value[string] `tf:"policy"`
-	UseDefault              *Value[bool]   `tf:"use_default"`
+	BreakglassJustification *Value[string] `tf:"breakglass_justification" json:"breakglass_justification,omitempty"`
+	Policy                  *Value[string] `tf:"policy" json:"policy,omitempty"`
+	UseDefault              *Value[bool]   `tf:"use_default" json:"use_default,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceConditions is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceConditions struct {
-	ExecutionReason    *Value[string] `tf:"execution_reason"`
-	LastTransitionTime *Value[string] `tf:"last_transition_time"`
-	Message            *Value[string] `tf:"message"`
-	Reason             *Value[string] `tf:"reason"`
-	RevisionReason     *Value[string] `tf:"revision_reason"`
-	Severity           *Value[string] `tf:"severity"`
-	State              *Value[string] `tf:"state"`
-	Type_              *Value[string] `tf:"type"`
+	ExecutionReason    *Value[string] `tf:"execution_reason" json:"execution_reason,omitempty"`
+	LastTransitionTime *Value[string] `tf:"last_transition_time" json:"last_transition_time,omitempty"`
+	Message            *Value[string] `tf:"message" json:"message,omitempty"`
+	Reason             *Value[string] `tf:"reason" json:"reason,omitempty"`
+	RevisionReason     *Value[string] `tf:"revision_reason" json:"revision_reason,omitempty"`
+	Severity           *Value[string] `tf:"severity" json:"severity,omitempty"`
+	State              *Value[string] `tf:"state" json:"state,omitempty"`
+	Type_              *Value[string] `tf:"type" json:"type,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceScaling is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceScaling struct {
-	MinInstanceCount *Value[int64] `tf:"min_instance_count"`
+	MinInstanceCount *Value[int64] `tf:"min_instance_count" json:"min_instance_count,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplate is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplate struct {
-	Annotations                   map[string]*Value[string]                   `tf:"annotations"`
-	EncryptionKey                 *Value[string]                              `tf:"encryption_key"`
-	ExecutionEnvironment          *Value[string]                              `tf:"execution_environment"`
-	Labels                        map[string]*Value[string]                   `tf:"labels"`
-	MaxInstanceRequestConcurrency *Value[int64]                               `tf:"max_instance_request_concurrency"`
-	Revision                      *Value[string]                              `tf:"revision"`
-	ServiceAccount                *Value[string]                              `tf:"service_account"`
-	SessionAffinity               *Value[bool]                                `tf:"session_affinity"`
-	Timeout                       *Value[string]                              `tf:"timeout"`
-	Containers                    []GoogleCloudRunV2ServiceTemplateContainers `tf:"containers,blocks"`
-	Scaling                       []GoogleCloudRunV2ServiceTemplateScaling    `tf:"scaling,blocks"`
-	Volumes                       []GoogleCloudRunV2ServiceTemplateVolumes    `tf:"volumes,blocks"`
-	VPCAccess                     []GoogleCloudRunV2ServiceTemplateVPCAccess  `tf:"vpc_access,blocks"`
+	Annotations                   map[string]*Value[string]                   `tf:"annotations" json:"annotations,omitempty"`
+	EncryptionKey                 *Value[string]                              `tf:"encryption_key" json:"encryption_key,omitempty"`
+	ExecutionEnvironment          *Value[string]                              `tf:"execution_environment" json:"execution_environment,omitempty"`
+	Labels                        map[string]*Value[string]                   `tf:"labels" json:"labels,omitempty"`
+	MaxInstanceRequestConcurrency *Value[int64]                               `tf:"max_instance_request_concurrency" json:"max_instance_request_concurrency,omitempty"`
+	Revision                      *Value[string]                              `tf:"revision" json:"revision,omitempty"`
+	ServiceAccount                *Value[string]                              `tf:"service_account" json:"service_account,omitempty"`
+	SessionAffinity               *Value[bool]                                `tf:"session_affinity" json:"session_affinity,omitempty"`
+	Timeout                       *Value[string]                              `tf:"timeout" json:"timeout,omitempty"`
+	Containers                    []GoogleCloudRunV2ServiceTemplateContainers `tf:"containers,blocks" json:"containers,omitempty"`
+	Scaling                       []GoogleCloudRunV2ServiceTemplateScaling    `tf:"scaling,blocks" json:"scaling,omitempty"`
+	Volumes                       []GoogleCloudRunV2ServiceTemplateVolumes    `tf:"volumes,blocks" json:"volumes,omitempty"`
+	VPCAccess                     []GoogleCloudRunV2ServiceTemplateVPCAccess  `tf:"vpc_access,blocks" json:"vpc_access,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainers is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainers struct {
-	Args          []*Value[string]                                         `tf:"args"`
-	Command       []*Value[string]                                         `tf:"command"`
-	DependsOn     []*Value[string]                                         `tf:"depends_on"`
-	Image         *Value[string]                                           `tf:"image"`
-	Name          *Value[string]                                           `tf:"name"`
-	WorkingDir    *Value[string]                                           `tf:"working_dir"`
-	Env           []GoogleCloudRunV2ServiceTemplateContainersEnv           `tf:"env,blocks"`
-	LivenessProbe []GoogleCloudRunV2ServiceTemplateContainersLivenessProbe `tf:"liveness_probe,blocks"`
-	Ports         []GoogleCloudRunV2ServiceTemplateContainersPorts         `tf:"ports,blocks"`
-	Resources     []GoogleCloudRunV2ServiceTemplateContainersResources     `tf:"resources,blocks"`
-	StartupProbe  []GoogleCloudRunV2ServiceTemplateContainersStartupProbe  `tf:"startup_probe,blocks"`
-	VolumeMounts  []GoogleCloudRunV2ServiceTemplateContainersVolumeMounts  `tf:"volume_mounts,blocks"`
+	Args          []*Value[string]                                         `tf:"args" json:"args,omitempty"`
+	Command       []*Value[string]                                         `tf:"command" json:"command,omitempty"`
+	DependsOn     []*Value[string]                                         `tf:"depends_on" json:"depends_on,omitempty"`
+	Image         *Value[string]                                           `tf:"image" json:"image,omitempty"`
+	Name          *Value[string]                                           `tf:"name" json:"name,omitempty"`
+	WorkingDir    *Value[string]                                           `tf:"working_dir" json:"working_dir,omitempty"`
+	Env           []GoogleCloudRunV2ServiceTemplateContainersEnv           `tf:"env,blocks" json:"env,omitempty"`
+	LivenessProbe []GoogleCloudRunV2ServiceTemplateContainersLivenessProbe `tf:"liveness_probe,blocks" json:"liveness_probe,omitempty"`
+	Ports         []GoogleCloudRunV2ServiceTemplateContainersPorts         `tf:"ports,blocks" json:"ports,omitempty"`
+	Resources     []GoogleCloudRunV2ServiceTemplateContainersResources     `tf:"resources,blocks" json:"resources,omitempty"`
+	StartupProbe  []GoogleCloudRunV2ServiceTemplateContainersStartupProbe  `tf:"startup_probe,blocks" json:"startup_probe,omitempty"`
+	VolumeMounts  []GoogleCloudRunV2ServiceTemplateContainersVolumeMounts  `tf:"volume_mounts,blocks" json:"volume_mounts,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersEnv is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersEnv struct {
-	Name        *Value[string]                                            `tf:"name"`
-	Value       *Value[string]                                            `tf:"value"`
-	ValueSource []GoogleCloudRunV2ServiceTemplateContainersEnvValueSource `tf:"value_source,blocks"`
+	Name        *Value[string]                                            `tf:"name" json:"name,omitempty"`
+	Value       *Value[string]                                            `tf:"value" json:"value,omitempty"`
+	ValueSource []GoogleCloudRunV2ServiceTemplateContainersEnvValueSource `tf:"value_source,blocks" json:"value_source,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersEnvValueSource is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersEnvValueSource struct {
-	SecretKeyRef []GoogleCloudRunV2ServiceTemplateContainersEnvValueSourceSecretKeyRef `tf:"secret_key_ref,blocks"`
+	SecretKeyRef []GoogleCloudRunV2ServiceTemplateContainersEnvValueSourceSecretKeyRef `tf:"secret_key_ref,blocks" json:"secret_key_ref,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersEnvValueSourceSecretKeyRef is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersEnvValueSourceSecretKeyRef struct {
-	Secret  *Value[string] `tf:"secret"`
-	Version *Value[string] `tf:"version"`
+	Secret  *Value[string] `tf:"secret" json:"secret,omitempty"`
+	Version *Value[string] `tf:"version" json:"version,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersLivenessProbe is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersLivenessProbe struct {
-	FailureThreshold    *Value[float64]                                                   `tf:"failure_threshold"`
-	InitialDelaySeconds *Value[int64]                                                     `tf:"initial_delay_seconds"`
-	PeriodSeconds       *Value[int64]                                                     `tf:"period_seconds"`
-	TimeoutSeconds      *Value[int64]                                                     `tf:"timeout_seconds"`
-	GRPC                []GoogleCloudRunV2ServiceTemplateContainersLivenessProbeGRPC      `tf:"grpc,blocks"`
-	HTTPGet             []GoogleCloudRunV2ServiceTemplateContainersLivenessProbeHTTPGet   `tf:"http_get,blocks"`
-	TCPSocket           []GoogleCloudRunV2ServiceTemplateContainersLivenessProbeTCPSocket `tf:"tcp_socket,blocks"`
+	FailureThreshold    *Value[float64]                                                   `tf:"failure_threshold" json:"failure_threshold,omitempty"`
+	InitialDelaySeconds *Value[int64]                                                     `tf:"initial_delay_seconds" json:"initial_delay_seconds,omitempty"`
+	PeriodSeconds       *Value[int64]                                                     `tf:"period_seconds" json:"period_seconds,omitempty"`
+	TimeoutSeconds      *Value[int64]                                                     `tf:"timeout_seconds" json:"timeout_seconds,omitempty"`
+	GRPC                []GoogleCloudRunV2ServiceTemplateContainersLivenessProbeGRPC      `tf:"grpc,blocks" json:"grpc,omitempty"`
+	HTTPGet             []GoogleCloudRunV2ServiceTemplateContainersLivenessProbeHTTPGet   `tf:"http_get,blocks" json:"http_get,omitempty"`
+	TCPSocket           []GoogleCloudRunV2ServiceTemplateContainersLivenessProbeTCPSocket `tf:"tcp_socket,blocks" json:"tcp_socket,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersLivenessProbeGRPC is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersLivenessProbeGRPC struct {
-	Port    *Value[int64]  `tf:"port"`
-	Service *Value[string] `tf:"service"`
+	Port    *Value[int64]  `tf:"port" json:"port,omitempty"`
+	Service *Value[string] `tf:"service" json:"service,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersLivenessProbeHTTPGet is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersLivenessProbeHTTPGet struct {
-	Path        *Value[string]                                                             `tf:"path"`
-	Port        *Value[int64]                                                              `tf:"port"`
-	HTTPHeaders []GoogleCloudRunV2ServiceTemplateContainersLivenessProbeHTTPGetHTTPHeaders `tf:"http_headers,blocks"`
+	Path        *Value[string]                                                             `tf:"path" json:"path,omitempty"`
+	Port        *Value[int64]                                                              `tf:"port" json:"port,omitempty"`
+	HTTPHeaders []GoogleCloudRunV2ServiceTemplateContainersLivenessProbeHTTPGetHTTPHeaders `tf:"http_headers,blocks" json:"http_headers,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersLivenessProbeHTTPGetHTTPHeaders is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersLivenessProbeHTTPGetHTTPHeaders struct {
-	Name  *Value[string] `tf:"name"`
-	Value *Value[string] `tf:"value"`
+	Name  *Value[string] `tf:"name" json:"name,omitempty"`
+	Value *Value[string] `tf:"value" json:"value,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersLivenessProbeTCPSocket is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersLivenessProbeTCPSocket struct {
-	Port *Value[int64] `tf:"port"`
+	Port *Value[int64] `tf:"port" json:"port,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersPorts is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersPorts struct {
-	ContainerPort *Value[float64] `tf:"container_port"`
-	Name          *Value[string]  `tf:"name"`
+	ContainerPort *Value[float64] `tf:"container_port" json:"container_port,omitempty"`
+	Name          *Value[string]  `tf:"name" json:"name,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersResources is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersResources struct {
-	CPUIdle         *Value[bool]              `tf:"cpu_idle"`
-	Limits          map[string]*Value[string] `tf:"limits"`
-	StartupCPUBoost *Value[bool]              `tf:"startup_cpu_boost"`
+	CPUIdle         *Value[bool]              `tf:"cpu_idle" json:"cpu_idle,omitempty"`
+	Limits          map[string]*Value[string] `tf:"limits" json:"limits,omitempty"`
+	StartupCPUBoost *Value[bool]              `tf:"startup_cpu_boost" json:"startup_cpu_boost,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersStartupProbe is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersStartupProbe struct {
-	FailureThreshold    *Value[float64]                                                  `tf:"failure_threshold"`
-	InitialDelaySeconds *Value[int64]                                                    `tf:"initial_delay_seconds"`
-	PeriodSeconds       *Value[int64]                                                    `tf:"period_seconds"`
-	TimeoutSeconds      *Value[int64]                                                    `tf:"timeout_seconds"`
-	GRPC                []GoogleCloudRunV2ServiceTemplateContainersStartupProbeGRPC      `tf:"grpc,blocks"`
-	HTTPGet             []GoogleCloudRunV2ServiceTemplateContainersStartupProbeHTTPGet   `tf:"http_get,blocks"`
-	TCPSocket           []GoogleCloudRunV2ServiceTemplateContainersStartupProbeTCPSocket `tf:"tcp_socket,blocks"`
+	FailureThreshold    *Value[float64]                                                  `tf:"failure_threshold" json:"failure_threshold,omitempty"`
+	InitialDelaySeconds *Value[int64]                                                    `tf:"initial_delay_seconds" json:"initial_delay_seconds,omitempty"`
+	PeriodSeconds       *Value[int64]                                                    `tf:"period_seconds" json:"period_seconds,omitempty"`
+	TimeoutSeconds      *Value[int64]                                                    `tf:"timeout_seconds" json:"timeout_seconds,omitempty"`
+	GRPC                []GoogleCloudRunV2ServiceTemplateContainersStartupProbeGRPC      `tf:"grpc,blocks" json:"grpc,omitempty"`
+	HTTPGet             []GoogleCloudRunV2ServiceTemplateContainersStartupProbeHTTPGet   `tf:"http_get,blocks" json:"http_get,omitempty"`
+	TCPSocket           []GoogleCloudRunV2ServiceTemplateContainersStartupProbeTCPSocket `tf:"tcp_socket,blocks" json:"tcp_socket,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersStartupProbeGRPC is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersStartupProbeGRPC struct {
-	Port    *Value[int64]  `tf:"port"`
-	Service *Value[string] `tf:"service"`
+	Port    *Value[int64]  `tf:"port" json:"port,omitempty"`
+	Service *Value[string] `tf:"service" json:"service,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersStartupProbeHTTPGet is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersStartupProbeHTTPGet struct {
-	Path        *Value[string]                                                            `tf:"path"`
-	Port        *Value[int64]                                                             `tf:"port"`
-	HTTPHeaders []GoogleCloudRunV2ServiceTemplateContainersStartupProbeHTTPGetHTTPHeaders `tf:"http_headers,blocks"`
+	Path        *Value[string]                                                            `tf:"path" json:"path,omitempty"`
+	Port        *Value[int64]                                                             `tf:"port" json:"port,omitempty"`
+	HTTPHeaders []GoogleCloudRunV2ServiceTemplateContainersStartupProbeHTTPGetHTTPHeaders `tf:"http_headers,blocks" json:"http_headers,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersStartupProbeHTTPGetHTTPHeaders is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersStartupProbeHTTPGetHTTPHeaders struct {
-	Name  *Value[string] `tf:"name"`
-	Value *Value[string] `tf:"value"`
+	Name  *Value[string] `tf:"name" json:"name,omitempty"`
+	Value *Value[string] `tf:"value" json:"value,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersStartupProbeTCPSocket is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersStartupProbeTCPSocket struct {
-	Port *Value[int64] `tf:"port"`
+	Port *Value[int64] `tf:"port" json:"port,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateContainersVolumeMounts is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateContainersVolumeMounts struct {
-	MountPath *Value[string] `tf:"mount_path"`
-	Name      *Value[string] `tf:"name"`
+	MountPath *Value[string] `tf:"mount_path" json:"mount_path,omitempty"`
+	Name      *Value[string] `tf:"name" json:"name,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateScaling is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateScaling struct {
-	MaxInstanceCount *Value[int64] `tf:"max_instance_count"`
-	MinInstanceCount *Value[int64] `tf:"min_instance_count"`
+	MaxInstanceCount *Value[int64] `tf:"max_instance_count" json:"max_instance_count,omitempty"`
+	MinInstanceCount *Value[int64] `tf:"min_instance_count" json:"min_instance_count,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateVPCAccess is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateVPCAccess struct {
-	Connector         *Value[string]                                              `tf:"connector"`
-	Egress            *Value[string]                                              `tf:"egress"`
-	NetworkInterfaces []GoogleCloudRunV2ServiceTemplateVPCAccessNetworkInterfaces `tf:"network_interfaces,blocks"`
+	Connector         *Value[string]                                              `tf:"connector" json:"connector,omitempty"`
+	Egress            *Value[string]                                              `tf:"egress" json:"egress,omitempty"`
+	NetworkInterfaces []GoogleCloudRunV2ServiceTemplateVPCAccessNetworkInterfaces `tf:"network_interfaces,blocks" json:"network_interfaces,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateVPCAccessNetworkInterfaces is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateVPCAccessNetworkInterfaces struct {
-	Network    *Value[string]   `tf:"network"`
-	Subnetwork *Value[string]   `tf:"subnetwork"`
-	Tags       []*Value[string] `tf:"tags"`
+	Network    *Value[string]   `tf:"network" json:"network,omitempty"`
+	Subnetwork *Value[string]   `tf:"subnetwork" json:"subnetwork,omitempty"`
+	Tags       []*Value[string] `tf:"tags" json:"tags,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateVolumes is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateVolumes struct {
-	Name             *Value[string]                                           `tf:"name"`
-	CloudSqlInstance []GoogleCloudRunV2ServiceTemplateVolumesCloudSqlInstance `tf:"cloud_sql_instance,blocks"`
-	GCS              []GoogleCloudRunV2ServiceTemplateVolumesGCS              `tf:"gcs,blocks"`
-	Nfs              []GoogleCloudRunV2ServiceTemplateVolumesNfs              `tf:"nfs,blocks"`
-	Secret           []GoogleCloudRunV2ServiceTemplateVolumesSecret           `tf:"secret,blocks"`
+	Name             *Value[string]                                           `tf:"name" json:"name,omitempty"`
+	CloudSqlInstance []GoogleCloudRunV2ServiceTemplateVolumesCloudSqlInstance `tf:"cloud_sql_instance,blocks" json:"cloud_sql_instance,omitempty"`
+	GCS              []GoogleCloudRunV2ServiceTemplateVolumesGCS              `tf:"gcs,blocks" json:"gcs,omitempty"`
+	Nfs              []GoogleCloudRunV2ServiceTemplateVolumesNfs              `tf:"nfs,blocks" json:"nfs,omitempty"`
+	Secret           []GoogleCloudRunV2ServiceTemplateVolumesSecret           `tf:"secret,blocks" json:"secret,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateVolumesCloudSqlInstance is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateVolumesCloudSqlInstance struct {
-	Instances []*Value[string] `tf:"instances"`
+	Instances []*Value[string] `tf:"instances" json:"instances,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateVolumesGCS is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateVolumesGCS struct {
-	Bucket   *Value[string] `tf:"bucket"`
-	ReadOnly *Value[bool]   `tf:"read_only"`
+	Bucket   *Value[string] `tf:"bucket" json:"bucket,omitempty"`
+	ReadOnly *Value[bool]   `tf:"read_only" json:"read_only,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateVolumesNfs is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateVolumesNfs struct {
-	Path     *Value[string] `tf:"path"`
-	ReadOnly *Value[bool]   `tf:"read_only"`
-	Server   *Value[string] `tf:"server"`
+	Path     *Value[string] `tf:"path" json:"path,omitempty"`
+	ReadOnly *Value[bool]   `tf:"read_only" json:"read_only,omitempty"`
+	Server   *Value[string] `tf:"server" json:"server,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateVolumesSecret is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateVolumesSecret struct {
-	DefaultMode *Value[float64]                                     `tf:"default_mode"`
-	Secret      *Value[string]                                      `tf:"secret"`
-	Items       []GoogleCloudRunV2ServiceTemplateVolumesSecretItems `tf:"items,blocks"`
+	DefaultMode *Value[float64]                                     `tf:"default_mode" json:"default_mode,omitempty"`
+	Secret      *Value[string]                                      `tf:"secret" json:"secret,omitempty"`
+	Items       []GoogleCloudRunV2ServiceTemplateVolumesSecretItems `tf:"items,blocks" json:"items,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTemplateVolumesSecretItems is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTemplateVolumesSecretItems struct {
-	Mode    *Value[float64] `tf:"mode"`
-	Path    *Value[string]  `tf:"path"`
-	Version *Value[string]  `tf:"version"`
+	Mode    *Value[float64] `tf:"mode" json:"mode,omitempty"`
+	Path    *Value[string]  `tf:"path" json:"path,omitempty"`
+	Version *Value[string]  `tf:"version" json:"version,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTerminalCondition is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTerminalCondition struct {
-	ExecutionReason    *Value[string] `tf:"execution_reason"`
-	LastTransitionTime *Value[string] `tf:"last_transition_time"`
-	Message            *Value[string] `tf:"message"`
-	Reason             *Value[string] `tf:"reason"`
-	RevisionReason     *Value[string] `tf:"revision_reason"`
-	Severity           *Value[string] `tf:"severity"`
-	State              *Value[string] `tf:"state"`
-	Type_              *Value[string] `tf:"type"`
+	ExecutionReason    *Value[string] `tf:"execution_reason" json:"execution_reason,omitempty"`
+	LastTransitionTime *Value[string] `tf:"last_transition_time" json:"last_transition_time,omitempty"`
+	Message            *Value[string] `tf:"message" json:"message,omitempty"`
+	Reason             *Value[string] `tf:"reason" json:"reason,omitempty"`
+	RevisionReason     *Value[string] `tf:"revision_reason" json:"revision_reason,omitempty"`
+	Severity           *Value[string] `tf:"severity" json:"severity,omitempty"`
+	State              *Value[string] `tf:"state" json:"state,omitempty"`
+	Type_              *Value[string] `tf:"type" json:"type,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTimeouts is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTraffic is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTraffic struct {
-	Percent  *Value[float64] `tf:"percent"`
-	Revision *Value[string]  `tf:"revision"`
-	Tag      *Value[string]  `tf:"tag"`
-	Type_    *Value[string]  `tf:"type"`
+	Percent  *Value[float64] `tf:"percent" json:"percent,omitempty"`
+	Revision *Value[string]  `tf:"revision" json:"revision,omitempty"`
+	Tag      *Value[string]  `tf:"tag" json:"tag,omitempty"`
+	Type_    *Value[string]  `tf:"type" json:"type,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceTrafficStatuses is a nested-block type used by the parent resource.
 type GoogleCloudRunV2ServiceTrafficStatuses struct {
-	Percent  *Value[float64] `tf:"percent"`
-	Revision *Value[string]  `tf:"revision"`
-	Tag      *Value[string]  `tf:"tag"`
-	Type_    *Value[string]  `tf:"type"`
-	URI      *Value[string]  `tf:"uri"`
+	Percent  *Value[float64] `tf:"percent" json:"percent,omitempty"`
+	Revision *Value[string]  `tf:"revision" json:"revision,omitempty"`
+	Tag      *Value[string]  `tf:"tag" json:"tag,omitempty"`
+	Type_    *Value[string]  `tf:"type" json:"type,omitempty"`
+	URI      *Value[string]  `tf:"uri" json:"uri,omitempty"`
 }
 
 // GoogleCloudRunV2ServiceSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_cloudbuild_trigger.gen.go
+++ b/pkg/composer/imported/generated/google_cloudbuild_trigger.gen.go
@@ -7,305 +7,305 @@ import "reflect"
 // GoogleCloudbuildTrigger is the generated Layer 1 typed model for the
 // `google_cloudbuild_trigger` Terraform resource.
 type GoogleCloudbuildTrigger struct {
-	CreateTime                   *Value[string]                                        `tf:"create_time"`
-	Description                  *Value[string]                                        `tf:"description"`
-	Disabled                     *Value[bool]                                          `tf:"disabled"`
-	Filename                     *Value[string]                                        `tf:"filename"`
-	Filter                       *Value[string]                                        `tf:"filter"`
-	ID                           *Value[string]                                        `tf:"id"`
-	IgnoredFiles                 []*Value[string]                                      `tf:"ignored_files"`
-	IncludeBuildLogs             *Value[string]                                        `tf:"include_build_logs"`
-	IncludedFiles                []*Value[string]                                      `tf:"included_files"`
-	Location                     *Value[string]                                        `tf:"location"`
-	Name                         *Value[string]                                        `tf:"name"`
-	Project                      *Value[string]                                        `tf:"project"`
-	ServiceAccount               *Value[string]                                        `tf:"service_account"`
-	Substitutions                map[string]*Value[string]                             `tf:"substitutions"`
-	Tags                         []*Value[string]                                      `tf:"tags"`
-	TriggerID                    *Value[string]                                        `tf:"trigger_id"`
-	ApprovalConfig               []GoogleCloudbuildTriggerApprovalConfig               `tf:"approval_config,blocks"`
-	BitbucketServerTriggerConfig []GoogleCloudbuildTriggerBitbucketServerTriggerConfig `tf:"bitbucket_server_trigger_config,blocks"`
-	Build                        []GoogleCloudbuildTriggerBuild                        `tf:"build,blocks"`
-	GitFileSource                []GoogleCloudbuildTriggerGitFileSource                `tf:"git_file_source,blocks"`
-	Github                       []GoogleCloudbuildTriggerGithub                       `tf:"github,blocks"`
-	PubsubConfig                 []GoogleCloudbuildTriggerPubsubConfig                 `tf:"pubsub_config,blocks"`
-	RepositoryEventConfig        []GoogleCloudbuildTriggerRepositoryEventConfig        `tf:"repository_event_config,blocks"`
-	SourceToBuild                []GoogleCloudbuildTriggerSourceToBuild                `tf:"source_to_build,blocks"`
-	Timeouts                     *GoogleCloudbuildTriggerTimeouts                      `tf:"timeouts,block"`
-	TriggerTemplate              []GoogleCloudbuildTriggerTriggerTemplate              `tf:"trigger_template,blocks"`
-	WebhookConfig                []GoogleCloudbuildTriggerWebhookConfig                `tf:"webhook_config,blocks"`
+	CreateTime                   *Value[string]                                        `tf:"create_time" json:"create_time,omitempty"`
+	Description                  *Value[string]                                        `tf:"description" json:"description,omitempty"`
+	Disabled                     *Value[bool]                                          `tf:"disabled" json:"disabled,omitempty"`
+	Filename                     *Value[string]                                        `tf:"filename" json:"filename,omitempty"`
+	Filter                       *Value[string]                                        `tf:"filter" json:"filter,omitempty"`
+	ID                           *Value[string]                                        `tf:"id" json:"id,omitempty"`
+	IgnoredFiles                 []*Value[string]                                      `tf:"ignored_files" json:"ignored_files,omitempty"`
+	IncludeBuildLogs             *Value[string]                                        `tf:"include_build_logs" json:"include_build_logs,omitempty"`
+	IncludedFiles                []*Value[string]                                      `tf:"included_files" json:"included_files,omitempty"`
+	Location                     *Value[string]                                        `tf:"location" json:"location,omitempty"`
+	Name                         *Value[string]                                        `tf:"name" json:"name,omitempty"`
+	Project                      *Value[string]                                        `tf:"project" json:"project,omitempty"`
+	ServiceAccount               *Value[string]                                        `tf:"service_account" json:"service_account,omitempty"`
+	Substitutions                map[string]*Value[string]                             `tf:"substitutions" json:"substitutions,omitempty"`
+	Tags                         []*Value[string]                                      `tf:"tags" json:"tags,omitempty"`
+	TriggerID                    *Value[string]                                        `tf:"trigger_id" json:"trigger_id,omitempty"`
+	ApprovalConfig               []GoogleCloudbuildTriggerApprovalConfig               `tf:"approval_config,blocks" json:"approval_config,omitempty"`
+	BitbucketServerTriggerConfig []GoogleCloudbuildTriggerBitbucketServerTriggerConfig `tf:"bitbucket_server_trigger_config,blocks" json:"bitbucket_server_trigger_config,omitempty"`
+	Build                        []GoogleCloudbuildTriggerBuild                        `tf:"build,blocks" json:"build,omitempty"`
+	GitFileSource                []GoogleCloudbuildTriggerGitFileSource                `tf:"git_file_source,blocks" json:"git_file_source,omitempty"`
+	Github                       []GoogleCloudbuildTriggerGithub                       `tf:"github,blocks" json:"github,omitempty"`
+	PubsubConfig                 []GoogleCloudbuildTriggerPubsubConfig                 `tf:"pubsub_config,blocks" json:"pubsub_config,omitempty"`
+	RepositoryEventConfig        []GoogleCloudbuildTriggerRepositoryEventConfig        `tf:"repository_event_config,blocks" json:"repository_event_config,omitempty"`
+	SourceToBuild                []GoogleCloudbuildTriggerSourceToBuild                `tf:"source_to_build,blocks" json:"source_to_build,omitempty"`
+	Timeouts                     *GoogleCloudbuildTriggerTimeouts                      `tf:"timeouts,block" json:"timeouts,omitempty"`
+	TriggerTemplate              []GoogleCloudbuildTriggerTriggerTemplate              `tf:"trigger_template,blocks" json:"trigger_template,omitempty"`
+	WebhookConfig                []GoogleCloudbuildTriggerWebhookConfig                `tf:"webhook_config,blocks" json:"webhook_config,omitempty"`
 }
 
 // GoogleCloudbuildTriggerApprovalConfig is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerApprovalConfig struct {
-	ApprovalRequired *Value[bool] `tf:"approval_required"`
+	ApprovalRequired *Value[bool] `tf:"approval_required" json:"approval_required,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBitbucketServerTriggerConfig is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBitbucketServerTriggerConfig struct {
-	BitbucketServerConfigResource *Value[string]                                                   `tf:"bitbucket_server_config_resource"`
-	ProjectKey                    *Value[string]                                                   `tf:"project_key"`
-	RepoSlug                      *Value[string]                                                   `tf:"repo_slug"`
-	PullRequest                   []GoogleCloudbuildTriggerBitbucketServerTriggerConfigPullRequest `tf:"pull_request,blocks"`
-	Push                          []GoogleCloudbuildTriggerBitbucketServerTriggerConfigPush        `tf:"push,blocks"`
+	BitbucketServerConfigResource *Value[string]                                                   `tf:"bitbucket_server_config_resource" json:"bitbucket_server_config_resource,omitempty"`
+	ProjectKey                    *Value[string]                                                   `tf:"project_key" json:"project_key,omitempty"`
+	RepoSlug                      *Value[string]                                                   `tf:"repo_slug" json:"repo_slug,omitempty"`
+	PullRequest                   []GoogleCloudbuildTriggerBitbucketServerTriggerConfigPullRequest `tf:"pull_request,blocks" json:"pull_request,omitempty"`
+	Push                          []GoogleCloudbuildTriggerBitbucketServerTriggerConfigPush        `tf:"push,blocks" json:"push,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBitbucketServerTriggerConfigPullRequest is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBitbucketServerTriggerConfigPullRequest struct {
-	Branch         *Value[string] `tf:"branch"`
-	CommentControl *Value[string] `tf:"comment_control"`
-	InvertRegex    *Value[bool]   `tf:"invert_regex"`
+	Branch         *Value[string] `tf:"branch" json:"branch,omitempty"`
+	CommentControl *Value[string] `tf:"comment_control" json:"comment_control,omitempty"`
+	InvertRegex    *Value[bool]   `tf:"invert_regex" json:"invert_regex,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBitbucketServerTriggerConfigPush is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBitbucketServerTriggerConfigPush struct {
-	Branch      *Value[string] `tf:"branch"`
-	InvertRegex *Value[bool]   `tf:"invert_regex"`
-	Tag         *Value[string] `tf:"tag"`
+	Branch      *Value[string] `tf:"branch" json:"branch,omitempty"`
+	InvertRegex *Value[bool]   `tf:"invert_regex" json:"invert_regex,omitempty"`
+	Tag         *Value[string] `tf:"tag" json:"tag,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuild is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuild struct {
-	Images           []*Value[string]                               `tf:"images"`
-	LogsBucket       *Value[string]                                 `tf:"logs_bucket"`
-	QueueTTL         *Value[string]                                 `tf:"queue_ttl"`
-	Substitutions    map[string]*Value[string]                      `tf:"substitutions"`
-	Tags             []*Value[string]                               `tf:"tags"`
-	Timeout          *Value[string]                                 `tf:"timeout"`
-	Artifacts        []GoogleCloudbuildTriggerBuildArtifacts        `tf:"artifacts,blocks"`
-	AvailableSecrets []GoogleCloudbuildTriggerBuildAvailableSecrets `tf:"available_secrets,blocks"`
-	Options          []GoogleCloudbuildTriggerBuildOptions          `tf:"options,blocks"`
-	Secret           []GoogleCloudbuildTriggerBuildSecret           `tf:"secret,blocks"`
-	Source           []GoogleCloudbuildTriggerBuildSource           `tf:"source,blocks"`
-	Step             []GoogleCloudbuildTriggerBuildStep             `tf:"step,blocks"`
+	Images           []*Value[string]                               `tf:"images" json:"images,omitempty"`
+	LogsBucket       *Value[string]                                 `tf:"logs_bucket" json:"logs_bucket,omitempty"`
+	QueueTTL         *Value[string]                                 `tf:"queue_ttl" json:"queue_ttl,omitempty"`
+	Substitutions    map[string]*Value[string]                      `tf:"substitutions" json:"substitutions,omitempty"`
+	Tags             []*Value[string]                               `tf:"tags" json:"tags,omitempty"`
+	Timeout          *Value[string]                                 `tf:"timeout" json:"timeout,omitempty"`
+	Artifacts        []GoogleCloudbuildTriggerBuildArtifacts        `tf:"artifacts,blocks" json:"artifacts,omitempty"`
+	AvailableSecrets []GoogleCloudbuildTriggerBuildAvailableSecrets `tf:"available_secrets,blocks" json:"available_secrets,omitempty"`
+	Options          []GoogleCloudbuildTriggerBuildOptions          `tf:"options,blocks" json:"options,omitempty"`
+	Secret           []GoogleCloudbuildTriggerBuildSecret           `tf:"secret,blocks" json:"secret,omitempty"`
+	Source           []GoogleCloudbuildTriggerBuildSource           `tf:"source,blocks" json:"source,omitempty"`
+	Step             []GoogleCloudbuildTriggerBuildStep             `tf:"step,blocks" json:"step,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildArtifacts is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildArtifacts struct {
-	Images         []*Value[string]                                      `tf:"images"`
-	MavenArtifacts []GoogleCloudbuildTriggerBuildArtifactsMavenArtifacts `tf:"maven_artifacts,blocks"`
-	NpmPackages    []GoogleCloudbuildTriggerBuildArtifactsNpmPackages    `tf:"npm_packages,blocks"`
-	Objects        []GoogleCloudbuildTriggerBuildArtifactsObjects        `tf:"objects,blocks"`
-	PythonPackages []GoogleCloudbuildTriggerBuildArtifactsPythonPackages `tf:"python_packages,blocks"`
+	Images         []*Value[string]                                      `tf:"images" json:"images,omitempty"`
+	MavenArtifacts []GoogleCloudbuildTriggerBuildArtifactsMavenArtifacts `tf:"maven_artifacts,blocks" json:"maven_artifacts,omitempty"`
+	NpmPackages    []GoogleCloudbuildTriggerBuildArtifactsNpmPackages    `tf:"npm_packages,blocks" json:"npm_packages,omitempty"`
+	Objects        []GoogleCloudbuildTriggerBuildArtifactsObjects        `tf:"objects,blocks" json:"objects,omitempty"`
+	PythonPackages []GoogleCloudbuildTriggerBuildArtifactsPythonPackages `tf:"python_packages,blocks" json:"python_packages,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildArtifactsMavenArtifacts is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildArtifactsMavenArtifacts struct {
-	ArtifactID *Value[string] `tf:"artifact_id"`
-	GroupID    *Value[string] `tf:"group_id"`
-	Path       *Value[string] `tf:"path"`
-	Repository *Value[string] `tf:"repository"`
-	Version    *Value[string] `tf:"version"`
+	ArtifactID *Value[string] `tf:"artifact_id" json:"artifact_id,omitempty"`
+	GroupID    *Value[string] `tf:"group_id" json:"group_id,omitempty"`
+	Path       *Value[string] `tf:"path" json:"path,omitempty"`
+	Repository *Value[string] `tf:"repository" json:"repository,omitempty"`
+	Version    *Value[string] `tf:"version" json:"version,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildArtifactsNpmPackages is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildArtifactsNpmPackages struct {
-	PackagePath *Value[string] `tf:"package_path"`
-	Repository  *Value[string] `tf:"repository"`
+	PackagePath *Value[string] `tf:"package_path" json:"package_path,omitempty"`
+	Repository  *Value[string] `tf:"repository" json:"repository,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildArtifactsObjects is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildArtifactsObjects struct {
-	Location *Value[string]                                       `tf:"location"`
-	Paths    []*Value[string]                                     `tf:"paths"`
-	Timing   []GoogleCloudbuildTriggerBuildArtifactsObjectsTiming `tf:"timing"`
+	Location *Value[string]                                       `tf:"location" json:"location,omitempty"`
+	Paths    []*Value[string]                                     `tf:"paths" json:"paths,omitempty"`
+	Timing   []GoogleCloudbuildTriggerBuildArtifactsObjectsTiming `tf:"timing" json:"timing,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildArtifactsObjectsTiming is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildArtifactsObjectsTiming struct {
-	EndTime   *Value[string] `tf:"end_time"`
-	StartTime *Value[string] `tf:"start_time"`
+	EndTime   *Value[string] `tf:"end_time" json:"end_time,omitempty"`
+	StartTime *Value[string] `tf:"start_time" json:"start_time,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildArtifactsPythonPackages is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildArtifactsPythonPackages struct {
-	Paths      []*Value[string] `tf:"paths"`
-	Repository *Value[string]   `tf:"repository"`
+	Paths      []*Value[string] `tf:"paths" json:"paths,omitempty"`
+	Repository *Value[string]   `tf:"repository" json:"repository,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildAvailableSecrets is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildAvailableSecrets struct {
-	SecretManager []GoogleCloudbuildTriggerBuildAvailableSecretsSecretManager `tf:"secret_manager,blocks"`
+	SecretManager []GoogleCloudbuildTriggerBuildAvailableSecretsSecretManager `tf:"secret_manager,blocks" json:"secret_manager,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildAvailableSecretsSecretManager is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildAvailableSecretsSecretManager struct {
-	Env         *Value[string] `tf:"env"`
-	VersionName *Value[string] `tf:"version_name"`
+	Env         *Value[string] `tf:"env" json:"env,omitempty"`
+	VersionName *Value[string] `tf:"version_name" json:"version_name,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildOptions is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildOptions struct {
-	DiskSizeGb            *Value[float64]                              `tf:"disk_size_gb"`
-	DynamicSubstitutions  *Value[bool]                                 `tf:"dynamic_substitutions"`
-	Env                   []*Value[string]                             `tf:"env"`
-	LogStreamingOption    *Value[string]                               `tf:"log_streaming_option"`
-	Logging               *Value[string]                               `tf:"logging"`
-	MachineType           *Value[string]                               `tf:"machine_type"`
-	RequestedVerifyOption *Value[string]                               `tf:"requested_verify_option"`
-	SecretEnv             []*Value[string]                             `tf:"secret_env"`
-	SourceProvenanceHash  []*Value[string]                             `tf:"source_provenance_hash"`
-	SubstitutionOption    *Value[string]                               `tf:"substitution_option"`
-	WorkerPool            *Value[string]                               `tf:"worker_pool"`
-	Volumes               []GoogleCloudbuildTriggerBuildOptionsVolumes `tf:"volumes,blocks"`
+	DiskSizeGb            *Value[float64]                              `tf:"disk_size_gb" json:"disk_size_gb,omitempty"`
+	DynamicSubstitutions  *Value[bool]                                 `tf:"dynamic_substitutions" json:"dynamic_substitutions,omitempty"`
+	Env                   []*Value[string]                             `tf:"env" json:"env,omitempty"`
+	LogStreamingOption    *Value[string]                               `tf:"log_streaming_option" json:"log_streaming_option,omitempty"`
+	Logging               *Value[string]                               `tf:"logging" json:"logging,omitempty"`
+	MachineType           *Value[string]                               `tf:"machine_type" json:"machine_type,omitempty"`
+	RequestedVerifyOption *Value[string]                               `tf:"requested_verify_option" json:"requested_verify_option,omitempty"`
+	SecretEnv             []*Value[string]                             `tf:"secret_env" json:"secret_env,omitempty"`
+	SourceProvenanceHash  []*Value[string]                             `tf:"source_provenance_hash" json:"source_provenance_hash,omitempty"`
+	SubstitutionOption    *Value[string]                               `tf:"substitution_option" json:"substitution_option,omitempty"`
+	WorkerPool            *Value[string]                               `tf:"worker_pool" json:"worker_pool,omitempty"`
+	Volumes               []GoogleCloudbuildTriggerBuildOptionsVolumes `tf:"volumes,blocks" json:"volumes,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildOptionsVolumes is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildOptionsVolumes struct {
-	Name *Value[string] `tf:"name"`
-	Path *Value[string] `tf:"path"`
+	Name *Value[string] `tf:"name" json:"name,omitempty"`
+	Path *Value[string] `tf:"path" json:"path,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildSecret is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildSecret struct {
-	KMSKeyName *Value[string]            `tf:"kms_key_name"`
-	SecretEnv  map[string]*Value[string] `tf:"secret_env"`
+	KMSKeyName *Value[string]            `tf:"kms_key_name" json:"kms_key_name,omitempty"`
+	SecretEnv  map[string]*Value[string] `tf:"secret_env" json:"secret_env,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildSource is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildSource struct {
-	RepoSource    []GoogleCloudbuildTriggerBuildSourceRepoSource    `tf:"repo_source,blocks"`
-	StorageSource []GoogleCloudbuildTriggerBuildSourceStorageSource `tf:"storage_source,blocks"`
+	RepoSource    []GoogleCloudbuildTriggerBuildSourceRepoSource    `tf:"repo_source,blocks" json:"repo_source,omitempty"`
+	StorageSource []GoogleCloudbuildTriggerBuildSourceStorageSource `tf:"storage_source,blocks" json:"storage_source,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildSourceRepoSource is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildSourceRepoSource struct {
-	BranchName    *Value[string]            `tf:"branch_name"`
-	CommitSHA     *Value[string]            `tf:"commit_sha"`
-	Dir           *Value[string]            `tf:"dir"`
-	InvertRegex   *Value[bool]              `tf:"invert_regex"`
-	ProjectID     *Value[string]            `tf:"project_id"`
-	RepoName      *Value[string]            `tf:"repo_name"`
-	Substitutions map[string]*Value[string] `tf:"substitutions"`
-	TagName       *Value[string]            `tf:"tag_name"`
+	BranchName    *Value[string]            `tf:"branch_name" json:"branch_name,omitempty"`
+	CommitSHA     *Value[string]            `tf:"commit_sha" json:"commit_sha,omitempty"`
+	Dir           *Value[string]            `tf:"dir" json:"dir,omitempty"`
+	InvertRegex   *Value[bool]              `tf:"invert_regex" json:"invert_regex,omitempty"`
+	ProjectID     *Value[string]            `tf:"project_id" json:"project_id,omitempty"`
+	RepoName      *Value[string]            `tf:"repo_name" json:"repo_name,omitempty"`
+	Substitutions map[string]*Value[string] `tf:"substitutions" json:"substitutions,omitempty"`
+	TagName       *Value[string]            `tf:"tag_name" json:"tag_name,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildSourceStorageSource is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildSourceStorageSource struct {
-	Bucket     *Value[string] `tf:"bucket"`
-	Generation *Value[string] `tf:"generation"`
-	Object     *Value[string] `tf:"object"`
+	Bucket     *Value[string] `tf:"bucket" json:"bucket,omitempty"`
+	Generation *Value[string] `tf:"generation" json:"generation,omitempty"`
+	Object     *Value[string] `tf:"object" json:"object,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildStep is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildStep struct {
-	AllowExitCodes []*Value[float64]                         `tf:"allow_exit_codes"`
-	AllowFailure   *Value[bool]                              `tf:"allow_failure"`
-	Args           []*Value[string]                          `tf:"args"`
-	Dir            *Value[string]                            `tf:"dir"`
-	Entrypoint     *Value[string]                            `tf:"entrypoint"`
-	Env            []*Value[string]                          `tf:"env"`
-	ID             *Value[string]                            `tf:"id"`
-	Name           *Value[string]                            `tf:"name"`
-	Script         *Value[string]                            `tf:"script"`
-	SecretEnv      []*Value[string]                          `tf:"secret_env"`
-	Timeout        *Value[string]                            `tf:"timeout"`
-	Timing         *Value[string]                            `tf:"timing"`
-	WaitFor        []*Value[string]                          `tf:"wait_for"`
-	Volumes        []GoogleCloudbuildTriggerBuildStepVolumes `tf:"volumes,blocks"`
+	AllowExitCodes []*Value[float64]                         `tf:"allow_exit_codes" json:"allow_exit_codes,omitempty"`
+	AllowFailure   *Value[bool]                              `tf:"allow_failure" json:"allow_failure,omitempty"`
+	Args           []*Value[string]                          `tf:"args" json:"args,omitempty"`
+	Dir            *Value[string]                            `tf:"dir" json:"dir,omitempty"`
+	Entrypoint     *Value[string]                            `tf:"entrypoint" json:"entrypoint,omitempty"`
+	Env            []*Value[string]                          `tf:"env" json:"env,omitempty"`
+	ID             *Value[string]                            `tf:"id" json:"id,omitempty"`
+	Name           *Value[string]                            `tf:"name" json:"name,omitempty"`
+	Script         *Value[string]                            `tf:"script" json:"script,omitempty"`
+	SecretEnv      []*Value[string]                          `tf:"secret_env" json:"secret_env,omitempty"`
+	Timeout        *Value[string]                            `tf:"timeout" json:"timeout,omitempty"`
+	Timing         *Value[string]                            `tf:"timing" json:"timing,omitempty"`
+	WaitFor        []*Value[string]                          `tf:"wait_for" json:"wait_for,omitempty"`
+	Volumes        []GoogleCloudbuildTriggerBuildStepVolumes `tf:"volumes,blocks" json:"volumes,omitempty"`
 }
 
 // GoogleCloudbuildTriggerBuildStepVolumes is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerBuildStepVolumes struct {
-	Name *Value[string] `tf:"name"`
-	Path *Value[string] `tf:"path"`
+	Name *Value[string] `tf:"name" json:"name,omitempty"`
+	Path *Value[string] `tf:"path" json:"path,omitempty"`
 }
 
 // GoogleCloudbuildTriggerGitFileSource is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerGitFileSource struct {
-	BitbucketServerConfig  *Value[string] `tf:"bitbucket_server_config"`
-	GithubEnterpriseConfig *Value[string] `tf:"github_enterprise_config"`
-	Path                   *Value[string] `tf:"path"`
-	RepoType               *Value[string] `tf:"repo_type"`
-	Repository             *Value[string] `tf:"repository"`
-	Revision               *Value[string] `tf:"revision"`
-	URI                    *Value[string] `tf:"uri"`
+	BitbucketServerConfig  *Value[string] `tf:"bitbucket_server_config" json:"bitbucket_server_config,omitempty"`
+	GithubEnterpriseConfig *Value[string] `tf:"github_enterprise_config" json:"github_enterprise_config,omitempty"`
+	Path                   *Value[string] `tf:"path" json:"path,omitempty"`
+	RepoType               *Value[string] `tf:"repo_type" json:"repo_type,omitempty"`
+	Repository             *Value[string] `tf:"repository" json:"repository,omitempty"`
+	Revision               *Value[string] `tf:"revision" json:"revision,omitempty"`
+	URI                    *Value[string] `tf:"uri" json:"uri,omitempty"`
 }
 
 // GoogleCloudbuildTriggerGithub is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerGithub struct {
-	EnterpriseConfigResourceName *Value[string]                             `tf:"enterprise_config_resource_name"`
-	Name                         *Value[string]                             `tf:"name"`
-	Owner                        *Value[string]                             `tf:"owner"`
-	PullRequest                  []GoogleCloudbuildTriggerGithubPullRequest `tf:"pull_request,blocks"`
-	Push                         []GoogleCloudbuildTriggerGithubPush        `tf:"push,blocks"`
+	EnterpriseConfigResourceName *Value[string]                             `tf:"enterprise_config_resource_name" json:"enterprise_config_resource_name,omitempty"`
+	Name                         *Value[string]                             `tf:"name" json:"name,omitempty"`
+	Owner                        *Value[string]                             `tf:"owner" json:"owner,omitempty"`
+	PullRequest                  []GoogleCloudbuildTriggerGithubPullRequest `tf:"pull_request,blocks" json:"pull_request,omitempty"`
+	Push                         []GoogleCloudbuildTriggerGithubPush        `tf:"push,blocks" json:"push,omitempty"`
 }
 
 // GoogleCloudbuildTriggerGithubPullRequest is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerGithubPullRequest struct {
-	Branch         *Value[string] `tf:"branch"`
-	CommentControl *Value[string] `tf:"comment_control"`
-	InvertRegex    *Value[bool]   `tf:"invert_regex"`
+	Branch         *Value[string] `tf:"branch" json:"branch,omitempty"`
+	CommentControl *Value[string] `tf:"comment_control" json:"comment_control,omitempty"`
+	InvertRegex    *Value[bool]   `tf:"invert_regex" json:"invert_regex,omitempty"`
 }
 
 // GoogleCloudbuildTriggerGithubPush is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerGithubPush struct {
-	Branch      *Value[string] `tf:"branch"`
-	InvertRegex *Value[bool]   `tf:"invert_regex"`
-	Tag         *Value[string] `tf:"tag"`
+	Branch      *Value[string] `tf:"branch" json:"branch,omitempty"`
+	InvertRegex *Value[bool]   `tf:"invert_regex" json:"invert_regex,omitempty"`
+	Tag         *Value[string] `tf:"tag" json:"tag,omitempty"`
 }
 
 // GoogleCloudbuildTriggerPubsubConfig is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerPubsubConfig struct {
-	ServiceAccountEmail *Value[string] `tf:"service_account_email"`
-	State               *Value[string] `tf:"state"`
-	Subscription        *Value[string] `tf:"subscription"`
-	Topic               *Value[string] `tf:"topic"`
+	ServiceAccountEmail *Value[string] `tf:"service_account_email" json:"service_account_email,omitempty"`
+	State               *Value[string] `tf:"state" json:"state,omitempty"`
+	Subscription        *Value[string] `tf:"subscription" json:"subscription,omitempty"`
+	Topic               *Value[string] `tf:"topic" json:"topic,omitempty"`
 }
 
 // GoogleCloudbuildTriggerRepositoryEventConfig is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerRepositoryEventConfig struct {
-	Repository  *Value[string]                                            `tf:"repository"`
-	PullRequest []GoogleCloudbuildTriggerRepositoryEventConfigPullRequest `tf:"pull_request,blocks"`
-	Push        []GoogleCloudbuildTriggerRepositoryEventConfigPush        `tf:"push,blocks"`
+	Repository  *Value[string]                                            `tf:"repository" json:"repository,omitempty"`
+	PullRequest []GoogleCloudbuildTriggerRepositoryEventConfigPullRequest `tf:"pull_request,blocks" json:"pull_request,omitempty"`
+	Push        []GoogleCloudbuildTriggerRepositoryEventConfigPush        `tf:"push,blocks" json:"push,omitempty"`
 }
 
 // GoogleCloudbuildTriggerRepositoryEventConfigPullRequest is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerRepositoryEventConfigPullRequest struct {
-	Branch         *Value[string] `tf:"branch"`
-	CommentControl *Value[string] `tf:"comment_control"`
-	InvertRegex    *Value[bool]   `tf:"invert_regex"`
+	Branch         *Value[string] `tf:"branch" json:"branch,omitempty"`
+	CommentControl *Value[string] `tf:"comment_control" json:"comment_control,omitempty"`
+	InvertRegex    *Value[bool]   `tf:"invert_regex" json:"invert_regex,omitempty"`
 }
 
 // GoogleCloudbuildTriggerRepositoryEventConfigPush is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerRepositoryEventConfigPush struct {
-	Branch      *Value[string] `tf:"branch"`
-	InvertRegex *Value[bool]   `tf:"invert_regex"`
-	Tag         *Value[string] `tf:"tag"`
+	Branch      *Value[string] `tf:"branch" json:"branch,omitempty"`
+	InvertRegex *Value[bool]   `tf:"invert_regex" json:"invert_regex,omitempty"`
+	Tag         *Value[string] `tf:"tag" json:"tag,omitempty"`
 }
 
 // GoogleCloudbuildTriggerSourceToBuild is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerSourceToBuild struct {
-	BitbucketServerConfig  *Value[string] `tf:"bitbucket_server_config"`
-	GithubEnterpriseConfig *Value[string] `tf:"github_enterprise_config"`
-	Ref                    *Value[string] `tf:"ref"`
-	RepoType               *Value[string] `tf:"repo_type"`
-	Repository             *Value[string] `tf:"repository"`
-	URI                    *Value[string] `tf:"uri"`
+	BitbucketServerConfig  *Value[string] `tf:"bitbucket_server_config" json:"bitbucket_server_config,omitempty"`
+	GithubEnterpriseConfig *Value[string] `tf:"github_enterprise_config" json:"github_enterprise_config,omitempty"`
+	Ref                    *Value[string] `tf:"ref" json:"ref,omitempty"`
+	RepoType               *Value[string] `tf:"repo_type" json:"repo_type,omitempty"`
+	Repository             *Value[string] `tf:"repository" json:"repository,omitempty"`
+	URI                    *Value[string] `tf:"uri" json:"uri,omitempty"`
 }
 
 // GoogleCloudbuildTriggerTimeouts is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleCloudbuildTriggerTriggerTemplate is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerTriggerTemplate struct {
-	BranchName  *Value[string] `tf:"branch_name"`
-	CommitSHA   *Value[string] `tf:"commit_sha"`
-	Dir         *Value[string] `tf:"dir"`
-	InvertRegex *Value[bool]   `tf:"invert_regex"`
-	ProjectID   *Value[string] `tf:"project_id"`
-	RepoName    *Value[string] `tf:"repo_name"`
-	TagName     *Value[string] `tf:"tag_name"`
+	BranchName  *Value[string] `tf:"branch_name" json:"branch_name,omitempty"`
+	CommitSHA   *Value[string] `tf:"commit_sha" json:"commit_sha,omitempty"`
+	Dir         *Value[string] `tf:"dir" json:"dir,omitempty"`
+	InvertRegex *Value[bool]   `tf:"invert_regex" json:"invert_regex,omitempty"`
+	ProjectID   *Value[string] `tf:"project_id" json:"project_id,omitempty"`
+	RepoName    *Value[string] `tf:"repo_name" json:"repo_name,omitempty"`
+	TagName     *Value[string] `tf:"tag_name" json:"tag_name,omitempty"`
 }
 
 // GoogleCloudbuildTriggerWebhookConfig is a nested-block type used by the parent resource.
 type GoogleCloudbuildTriggerWebhookConfig struct {
-	Secret *Value[string] `tf:"secret"`
-	State  *Value[string] `tf:"state"`
+	Secret *Value[string] `tf:"secret" json:"secret,omitempty"`
+	State  *Value[string] `tf:"state" json:"state,omitempty"`
 }
 
 // GoogleCloudbuildTriggerSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_cloudfunctions2_function.gen.go
+++ b/pkg/composer/imported/generated/google_cloudfunctions2_function.gen.go
@@ -7,37 +7,37 @@ import "reflect"
 // GoogleCloudfunctions2Function is the generated Layer 1 typed model for the
 // `google_cloudfunctions2_function` Terraform resource.
 type GoogleCloudfunctions2Function struct {
-	Description     *Value[string]                               `tf:"description"`
-	EffectiveLabels map[string]*Value[string]                    `tf:"effective_labels"`
-	Environment     *Value[string]                               `tf:"environment"`
-	ID              *Value[string]                               `tf:"id"`
-	KMSKeyName      *Value[string]                               `tf:"kms_key_name"`
-	Labels          map[string]*Value[string]                    `tf:"labels"`
-	Location        *Value[string]                               `tf:"location"`
-	Name            *Value[string]                               `tf:"name"`
-	Project         *Value[string]                               `tf:"project"`
-	State           *Value[string]                               `tf:"state"`
-	TerraformLabels map[string]*Value[string]                    `tf:"terraform_labels"`
-	UpdateTime      *Value[string]                               `tf:"update_time"`
-	URL             *Value[string]                               `tf:"url"`
-	BuildConfig     []GoogleCloudfunctions2FunctionBuildConfig   `tf:"build_config,blocks"`
-	EventTrigger    []GoogleCloudfunctions2FunctionEventTrigger  `tf:"event_trigger,blocks"`
-	ServiceConfig   []GoogleCloudfunctions2FunctionServiceConfig `tf:"service_config,blocks"`
-	Timeouts        *GoogleCloudfunctions2FunctionTimeouts       `tf:"timeouts,block"`
+	Description     *Value[string]                               `tf:"description" json:"description,omitempty"`
+	EffectiveLabels map[string]*Value[string]                    `tf:"effective_labels" json:"effective_labels,omitempty"`
+	Environment     *Value[string]                               `tf:"environment" json:"environment,omitempty"`
+	ID              *Value[string]                               `tf:"id" json:"id,omitempty"`
+	KMSKeyName      *Value[string]                               `tf:"kms_key_name" json:"kms_key_name,omitempty"`
+	Labels          map[string]*Value[string]                    `tf:"labels" json:"labels,omitempty"`
+	Location        *Value[string]                               `tf:"location" json:"location,omitempty"`
+	Name            *Value[string]                               `tf:"name" json:"name,omitempty"`
+	Project         *Value[string]                               `tf:"project" json:"project,omitempty"`
+	State           *Value[string]                               `tf:"state" json:"state,omitempty"`
+	TerraformLabels map[string]*Value[string]                    `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	UpdateTime      *Value[string]                               `tf:"update_time" json:"update_time,omitempty"`
+	URL             *Value[string]                               `tf:"url" json:"url,omitempty"`
+	BuildConfig     []GoogleCloudfunctions2FunctionBuildConfig   `tf:"build_config,blocks" json:"build_config,omitempty"`
+	EventTrigger    []GoogleCloudfunctions2FunctionEventTrigger  `tf:"event_trigger,blocks" json:"event_trigger,omitempty"`
+	ServiceConfig   []GoogleCloudfunctions2FunctionServiceConfig `tf:"service_config,blocks" json:"service_config,omitempty"`
+	Timeouts        *GoogleCloudfunctions2FunctionTimeouts       `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleCloudfunctions2FunctionBuildConfig is a nested-block type used by the parent resource.
 type GoogleCloudfunctions2FunctionBuildConfig struct {
-	Build                 *Value[string]                                                  `tf:"build"`
-	DockerRepository      *Value[string]                                                  `tf:"docker_repository"`
-	EntryPoint            *Value[string]                                                  `tf:"entry_point"`
-	EnvironmentVariables  map[string]*Value[string]                                       `tf:"environment_variables"`
-	Runtime               *Value[string]                                                  `tf:"runtime"`
-	ServiceAccount        *Value[string]                                                  `tf:"service_account"`
-	WorkerPool            *Value[string]                                                  `tf:"worker_pool"`
-	AutomaticUpdatePolicy []GoogleCloudfunctions2FunctionBuildConfigAutomaticUpdatePolicy `tf:"automatic_update_policy,blocks"`
-	OnDeployUpdatePolicy  []GoogleCloudfunctions2FunctionBuildConfigOnDeployUpdatePolicy  `tf:"on_deploy_update_policy,blocks"`
-	Source                []GoogleCloudfunctions2FunctionBuildConfigSource                `tf:"source,blocks"`
+	Build                 *Value[string]                                                  `tf:"build" json:"build,omitempty"`
+	DockerRepository      *Value[string]                                                  `tf:"docker_repository" json:"docker_repository,omitempty"`
+	EntryPoint            *Value[string]                                                  `tf:"entry_point" json:"entry_point,omitempty"`
+	EnvironmentVariables  map[string]*Value[string]                                       `tf:"environment_variables" json:"environment_variables,omitempty"`
+	Runtime               *Value[string]                                                  `tf:"runtime" json:"runtime,omitempty"`
+	ServiceAccount        *Value[string]                                                  `tf:"service_account" json:"service_account,omitempty"`
+	WorkerPool            *Value[string]                                                  `tf:"worker_pool" json:"worker_pool,omitempty"`
+	AutomaticUpdatePolicy []GoogleCloudfunctions2FunctionBuildConfigAutomaticUpdatePolicy `tf:"automatic_update_policy,blocks" json:"automatic_update_policy,omitempty"`
+	OnDeployUpdatePolicy  []GoogleCloudfunctions2FunctionBuildConfigOnDeployUpdatePolicy  `tf:"on_deploy_update_policy,blocks" json:"on_deploy_update_policy,omitempty"`
+	Source                []GoogleCloudfunctions2FunctionBuildConfigSource                `tf:"source,blocks" json:"source,omitempty"`
 }
 
 // GoogleCloudfunctions2FunctionBuildConfigAutomaticUpdatePolicy is a nested-block type used by the parent resource.
@@ -46,99 +46,99 @@ type GoogleCloudfunctions2FunctionBuildConfigAutomaticUpdatePolicy struct {
 
 // GoogleCloudfunctions2FunctionBuildConfigOnDeployUpdatePolicy is a nested-block type used by the parent resource.
 type GoogleCloudfunctions2FunctionBuildConfigOnDeployUpdatePolicy struct {
-	RuntimeVersion *Value[string] `tf:"runtime_version"`
+	RuntimeVersion *Value[string] `tf:"runtime_version" json:"runtime_version,omitempty"`
 }
 
 // GoogleCloudfunctions2FunctionBuildConfigSource is a nested-block type used by the parent resource.
 type GoogleCloudfunctions2FunctionBuildConfigSource struct {
-	RepoSource    []GoogleCloudfunctions2FunctionBuildConfigSourceRepoSource    `tf:"repo_source,blocks"`
-	StorageSource []GoogleCloudfunctions2FunctionBuildConfigSourceStorageSource `tf:"storage_source,blocks"`
+	RepoSource    []GoogleCloudfunctions2FunctionBuildConfigSourceRepoSource    `tf:"repo_source,blocks" json:"repo_source,omitempty"`
+	StorageSource []GoogleCloudfunctions2FunctionBuildConfigSourceStorageSource `tf:"storage_source,blocks" json:"storage_source,omitempty"`
 }
 
 // GoogleCloudfunctions2FunctionBuildConfigSourceRepoSource is a nested-block type used by the parent resource.
 type GoogleCloudfunctions2FunctionBuildConfigSourceRepoSource struct {
-	BranchName  *Value[string] `tf:"branch_name"`
-	CommitSHA   *Value[string] `tf:"commit_sha"`
-	Dir         *Value[string] `tf:"dir"`
-	InvertRegex *Value[bool]   `tf:"invert_regex"`
-	ProjectID   *Value[string] `tf:"project_id"`
-	RepoName    *Value[string] `tf:"repo_name"`
-	TagName     *Value[string] `tf:"tag_name"`
+	BranchName  *Value[string] `tf:"branch_name" json:"branch_name,omitempty"`
+	CommitSHA   *Value[string] `tf:"commit_sha" json:"commit_sha,omitempty"`
+	Dir         *Value[string] `tf:"dir" json:"dir,omitempty"`
+	InvertRegex *Value[bool]   `tf:"invert_regex" json:"invert_regex,omitempty"`
+	ProjectID   *Value[string] `tf:"project_id" json:"project_id,omitempty"`
+	RepoName    *Value[string] `tf:"repo_name" json:"repo_name,omitempty"`
+	TagName     *Value[string] `tf:"tag_name" json:"tag_name,omitempty"`
 }
 
 // GoogleCloudfunctions2FunctionBuildConfigSourceStorageSource is a nested-block type used by the parent resource.
 type GoogleCloudfunctions2FunctionBuildConfigSourceStorageSource struct {
-	Bucket     *Value[string]  `tf:"bucket"`
-	Generation *Value[float64] `tf:"generation"`
-	Object     *Value[string]  `tf:"object"`
+	Bucket     *Value[string]  `tf:"bucket" json:"bucket,omitempty"`
+	Generation *Value[float64] `tf:"generation" json:"generation,omitempty"`
+	Object     *Value[string]  `tf:"object" json:"object,omitempty"`
 }
 
 // GoogleCloudfunctions2FunctionEventTrigger is a nested-block type used by the parent resource.
 type GoogleCloudfunctions2FunctionEventTrigger struct {
-	EventType           *Value[string]                                          `tf:"event_type"`
-	PubsubTopic         *Value[string]                                          `tf:"pubsub_topic"`
-	RetryPolicy         *Value[string]                                          `tf:"retry_policy"`
-	ServiceAccountEmail *Value[string]                                          `tf:"service_account_email"`
-	Trigger             *Value[string]                                          `tf:"trigger"`
-	TriggerRegion       *Value[string]                                          `tf:"trigger_region"`
-	EventFilters        []GoogleCloudfunctions2FunctionEventTriggerEventFilters `tf:"event_filters,blocks"`
+	EventType           *Value[string]                                          `tf:"event_type" json:"event_type,omitempty"`
+	PubsubTopic         *Value[string]                                          `tf:"pubsub_topic" json:"pubsub_topic,omitempty"`
+	RetryPolicy         *Value[string]                                          `tf:"retry_policy" json:"retry_policy,omitempty"`
+	ServiceAccountEmail *Value[string]                                          `tf:"service_account_email" json:"service_account_email,omitempty"`
+	Trigger             *Value[string]                                          `tf:"trigger" json:"trigger,omitempty"`
+	TriggerRegion       *Value[string]                                          `tf:"trigger_region" json:"trigger_region,omitempty"`
+	EventFilters        []GoogleCloudfunctions2FunctionEventTriggerEventFilters `tf:"event_filters,blocks" json:"event_filters,omitempty"`
 }
 
 // GoogleCloudfunctions2FunctionEventTriggerEventFilters is a nested-block type used by the parent resource.
 type GoogleCloudfunctions2FunctionEventTriggerEventFilters struct {
-	Attribute *Value[string] `tf:"attribute"`
-	Operator  *Value[string] `tf:"operator"`
-	Value     *Value[string] `tf:"value"`
+	Attribute *Value[string] `tf:"attribute" json:"attribute,omitempty"`
+	Operator  *Value[string] `tf:"operator" json:"operator,omitempty"`
+	Value     *Value[string] `tf:"value" json:"value,omitempty"`
 }
 
 // GoogleCloudfunctions2FunctionServiceConfig is a nested-block type used by the parent resource.
 type GoogleCloudfunctions2FunctionServiceConfig struct {
-	AllTrafficOnLatestRevision    *Value[bool]                                                           `tf:"all_traffic_on_latest_revision"`
-	AvailableCPU                  *Value[string]                                                         `tf:"available_cpu"`
-	AvailableMemory               *Value[string]                                                         `tf:"available_memory"`
-	EnvironmentVariables          map[string]*Value[string]                                              `tf:"environment_variables"`
-	GcfURI                        *Value[string]                                                         `tf:"gcf_uri"`
-	IngressSettings               *Value[string]                                                         `tf:"ingress_settings"`
-	MaxInstanceCount              *Value[int64]                                                          `tf:"max_instance_count"`
-	MaxInstanceRequestConcurrency *Value[int64]                                                          `tf:"max_instance_request_concurrency"`
-	MinInstanceCount              *Value[int64]                                                          `tf:"min_instance_count"`
-	Service                       *Value[string]                                                         `tf:"service"`
-	ServiceAccountEmail           *Value[string]                                                         `tf:"service_account_email"`
-	TimeoutSeconds                *Value[int64]                                                          `tf:"timeout_seconds"`
-	URI                           *Value[string]                                                         `tf:"uri"`
-	VPCConnector                  *Value[string]                                                         `tf:"vpc_connector"`
-	VPCConnectorEgressSettings    *Value[string]                                                         `tf:"vpc_connector_egress_settings"`
-	SecretEnvironmentVariables    []GoogleCloudfunctions2FunctionServiceConfigSecretEnvironmentVariables `tf:"secret_environment_variables,blocks"`
-	SecretVolumes                 []GoogleCloudfunctions2FunctionServiceConfigSecretVolumes              `tf:"secret_volumes,blocks"`
+	AllTrafficOnLatestRevision    *Value[bool]                                                           `tf:"all_traffic_on_latest_revision" json:"all_traffic_on_latest_revision,omitempty"`
+	AvailableCPU                  *Value[string]                                                         `tf:"available_cpu" json:"available_cpu,omitempty"`
+	AvailableMemory               *Value[string]                                                         `tf:"available_memory" json:"available_memory,omitempty"`
+	EnvironmentVariables          map[string]*Value[string]                                              `tf:"environment_variables" json:"environment_variables,omitempty"`
+	GcfURI                        *Value[string]                                                         `tf:"gcf_uri" json:"gcf_uri,omitempty"`
+	IngressSettings               *Value[string]                                                         `tf:"ingress_settings" json:"ingress_settings,omitempty"`
+	MaxInstanceCount              *Value[int64]                                                          `tf:"max_instance_count" json:"max_instance_count,omitempty"`
+	MaxInstanceRequestConcurrency *Value[int64]                                                          `tf:"max_instance_request_concurrency" json:"max_instance_request_concurrency,omitempty"`
+	MinInstanceCount              *Value[int64]                                                          `tf:"min_instance_count" json:"min_instance_count,omitempty"`
+	Service                       *Value[string]                                                         `tf:"service" json:"service,omitempty"`
+	ServiceAccountEmail           *Value[string]                                                         `tf:"service_account_email" json:"service_account_email,omitempty"`
+	TimeoutSeconds                *Value[int64]                                                          `tf:"timeout_seconds" json:"timeout_seconds,omitempty"`
+	URI                           *Value[string]                                                         `tf:"uri" json:"uri,omitempty"`
+	VPCConnector                  *Value[string]                                                         `tf:"vpc_connector" json:"vpc_connector,omitempty"`
+	VPCConnectorEgressSettings    *Value[string]                                                         `tf:"vpc_connector_egress_settings" json:"vpc_connector_egress_settings,omitempty"`
+	SecretEnvironmentVariables    []GoogleCloudfunctions2FunctionServiceConfigSecretEnvironmentVariables `tf:"secret_environment_variables,blocks" json:"secret_environment_variables,omitempty"`
+	SecretVolumes                 []GoogleCloudfunctions2FunctionServiceConfigSecretVolumes              `tf:"secret_volumes,blocks" json:"secret_volumes,omitempty"`
 }
 
 // GoogleCloudfunctions2FunctionServiceConfigSecretEnvironmentVariables is a nested-block type used by the parent resource.
 type GoogleCloudfunctions2FunctionServiceConfigSecretEnvironmentVariables struct {
-	Key       *Value[string] `tf:"key"`
-	ProjectID *Value[string] `tf:"project_id"`
-	Secret    *Value[string] `tf:"secret"`
-	Version   *Value[string] `tf:"version"`
+	Key       *Value[string] `tf:"key" json:"key,omitempty"`
+	ProjectID *Value[string] `tf:"project_id" json:"project_id,omitempty"`
+	Secret    *Value[string] `tf:"secret" json:"secret,omitempty"`
+	Version   *Value[string] `tf:"version" json:"version,omitempty"`
 }
 
 // GoogleCloudfunctions2FunctionServiceConfigSecretVolumes is a nested-block type used by the parent resource.
 type GoogleCloudfunctions2FunctionServiceConfigSecretVolumes struct {
-	MountPath *Value[string]                                                    `tf:"mount_path"`
-	ProjectID *Value[string]                                                    `tf:"project_id"`
-	Secret    *Value[string]                                                    `tf:"secret"`
-	Versions  []GoogleCloudfunctions2FunctionServiceConfigSecretVolumesVersions `tf:"versions,blocks"`
+	MountPath *Value[string]                                                    `tf:"mount_path" json:"mount_path,omitempty"`
+	ProjectID *Value[string]                                                    `tf:"project_id" json:"project_id,omitempty"`
+	Secret    *Value[string]                                                    `tf:"secret" json:"secret,omitempty"`
+	Versions  []GoogleCloudfunctions2FunctionServiceConfigSecretVolumesVersions `tf:"versions,blocks" json:"versions,omitempty"`
 }
 
 // GoogleCloudfunctions2FunctionServiceConfigSecretVolumesVersions is a nested-block type used by the parent resource.
 type GoogleCloudfunctions2FunctionServiceConfigSecretVolumesVersions struct {
-	Path    *Value[string] `tf:"path"`
-	Version *Value[string] `tf:"version"`
+	Path    *Value[string] `tf:"path" json:"path,omitempty"`
+	Version *Value[string] `tf:"version" json:"version,omitempty"`
 }
 
 // GoogleCloudfunctions2FunctionTimeouts is a nested-block type used by the parent resource.
 type GoogleCloudfunctions2FunctionTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleCloudfunctions2FunctionSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_compute_address.gen.go
+++ b/pkg/composer/imported/generated/google_compute_address.gen.go
@@ -7,35 +7,35 @@ import "reflect"
 // GoogleComputeAddress is the generated Layer 1 typed model for the
 // `google_compute_address` Terraform resource.
 type GoogleComputeAddress struct {
-	Address           *Value[string]                `tf:"address"`
-	AddressType       *Value[string]                `tf:"address_type"`
-	CreationTimestamp *Value[string]                `tf:"creation_timestamp"`
-	Description       *Value[string]                `tf:"description"`
-	EffectiveLabels   map[string]*Value[string]     `tf:"effective_labels"`
-	ID                *Value[string]                `tf:"id"`
-	IpVersion         *Value[string]                `tf:"ip_version"`
-	IPV6EndpointType  *Value[string]                `tf:"ipv6_endpoint_type"`
-	LabelFingerprint  *Value[string]                `tf:"label_fingerprint"`
-	Labels            map[string]*Value[string]     `tf:"labels"`
-	Name              *Value[string]                `tf:"name"`
-	Network           *Value[string]                `tf:"network"`
-	NetworkTier       *Value[string]                `tf:"network_tier"`
-	PrefixLength      *Value[float64]               `tf:"prefix_length"`
-	Project           *Value[string]                `tf:"project"`
-	Purpose           *Value[string]                `tf:"purpose"`
-	Region            *Value[string]                `tf:"region"`
-	SelfLink          *Value[string]                `tf:"self_link"`
-	Subnetwork        *Value[string]                `tf:"subnetwork"`
-	TerraformLabels   map[string]*Value[string]     `tf:"terraform_labels"`
-	Users             []*Value[string]              `tf:"users"`
-	Timeouts          *GoogleComputeAddressTimeouts `tf:"timeouts,block"`
+	Address           *Value[string]                `tf:"address" json:"address,omitempty"`
+	AddressType       *Value[string]                `tf:"address_type" json:"address_type,omitempty"`
+	CreationTimestamp *Value[string]                `tf:"creation_timestamp" json:"creation_timestamp,omitempty"`
+	Description       *Value[string]                `tf:"description" json:"description,omitempty"`
+	EffectiveLabels   map[string]*Value[string]     `tf:"effective_labels" json:"effective_labels,omitempty"`
+	ID                *Value[string]                `tf:"id" json:"id,omitempty"`
+	IpVersion         *Value[string]                `tf:"ip_version" json:"ip_version,omitempty"`
+	IPV6EndpointType  *Value[string]                `tf:"ipv6_endpoint_type" json:"ipv6_endpoint_type,omitempty"`
+	LabelFingerprint  *Value[string]                `tf:"label_fingerprint" json:"label_fingerprint,omitempty"`
+	Labels            map[string]*Value[string]     `tf:"labels" json:"labels,omitempty"`
+	Name              *Value[string]                `tf:"name" json:"name,omitempty"`
+	Network           *Value[string]                `tf:"network" json:"network,omitempty"`
+	NetworkTier       *Value[string]                `tf:"network_tier" json:"network_tier,omitempty"`
+	PrefixLength      *Value[float64]               `tf:"prefix_length" json:"prefix_length,omitempty"`
+	Project           *Value[string]                `tf:"project" json:"project,omitempty"`
+	Purpose           *Value[string]                `tf:"purpose" json:"purpose,omitempty"`
+	Region            *Value[string]                `tf:"region" json:"region,omitempty"`
+	SelfLink          *Value[string]                `tf:"self_link" json:"self_link,omitempty"`
+	Subnetwork        *Value[string]                `tf:"subnetwork" json:"subnetwork,omitempty"`
+	TerraformLabels   map[string]*Value[string]     `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	Users             []*Value[string]              `tf:"users" json:"users,omitempty"`
+	Timeouts          *GoogleComputeAddressTimeouts `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleComputeAddressTimeouts is a nested-block type used by the parent resource.
 type GoogleComputeAddressTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleComputeAddressSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_compute_firewall.gen.go
+++ b/pkg/composer/imported/generated/google_compute_firewall.gen.go
@@ -7,51 +7,51 @@ import "reflect"
 // GoogleComputeFirewall is the generated Layer 1 typed model for the
 // `google_compute_firewall` Terraform resource.
 type GoogleComputeFirewall struct {
-	CreationTimestamp     *Value[string]                   `tf:"creation_timestamp"`
-	Description           *Value[string]                   `tf:"description"`
-	DestinationRanges     []*Value[string]                 `tf:"destination_ranges"`
-	Direction             *Value[string]                   `tf:"direction"`
-	Disabled              *Value[bool]                     `tf:"disabled"`
-	EnableLogging         *Value[bool]                     `tf:"enable_logging"`
-	ID                    *Value[string]                   `tf:"id"`
-	Name                  *Value[string]                   `tf:"name"`
-	Network               *Value[string]                   `tf:"network"`
-	Priority              *Value[float64]                  `tf:"priority"`
-	Project               *Value[string]                   `tf:"project"`
-	SelfLink              *Value[string]                   `tf:"self_link"`
-	SourceRanges          []*Value[string]                 `tf:"source_ranges"`
-	SourceServiceAccounts []*Value[string]                 `tf:"source_service_accounts"`
-	SourceTags            []*Value[string]                 `tf:"source_tags"`
-	TargetServiceAccounts []*Value[string]                 `tf:"target_service_accounts"`
-	TargetTags            []*Value[string]                 `tf:"target_tags"`
-	Allow                 []GoogleComputeFirewallAllow     `tf:"allow,blocks"`
-	Deny                  []GoogleComputeFirewallDeny      `tf:"deny,blocks"`
-	LogConfig             []GoogleComputeFirewallLogConfig `tf:"log_config,blocks"`
-	Timeouts              *GoogleComputeFirewallTimeouts   `tf:"timeouts,block"`
+	CreationTimestamp     *Value[string]                   `tf:"creation_timestamp" json:"creation_timestamp,omitempty"`
+	Description           *Value[string]                   `tf:"description" json:"description,omitempty"`
+	DestinationRanges     []*Value[string]                 `tf:"destination_ranges" json:"destination_ranges,omitempty"`
+	Direction             *Value[string]                   `tf:"direction" json:"direction,omitempty"`
+	Disabled              *Value[bool]                     `tf:"disabled" json:"disabled,omitempty"`
+	EnableLogging         *Value[bool]                     `tf:"enable_logging" json:"enable_logging,omitempty"`
+	ID                    *Value[string]                   `tf:"id" json:"id,omitempty"`
+	Name                  *Value[string]                   `tf:"name" json:"name,omitempty"`
+	Network               *Value[string]                   `tf:"network" json:"network,omitempty"`
+	Priority              *Value[float64]                  `tf:"priority" json:"priority,omitempty"`
+	Project               *Value[string]                   `tf:"project" json:"project,omitempty"`
+	SelfLink              *Value[string]                   `tf:"self_link" json:"self_link,omitempty"`
+	SourceRanges          []*Value[string]                 `tf:"source_ranges" json:"source_ranges,omitempty"`
+	SourceServiceAccounts []*Value[string]                 `tf:"source_service_accounts" json:"source_service_accounts,omitempty"`
+	SourceTags            []*Value[string]                 `tf:"source_tags" json:"source_tags,omitempty"`
+	TargetServiceAccounts []*Value[string]                 `tf:"target_service_accounts" json:"target_service_accounts,omitempty"`
+	TargetTags            []*Value[string]                 `tf:"target_tags" json:"target_tags,omitempty"`
+	Allow                 []GoogleComputeFirewallAllow     `tf:"allow,blocks" json:"allow,omitempty"`
+	Deny                  []GoogleComputeFirewallDeny      `tf:"deny,blocks" json:"deny,omitempty"`
+	LogConfig             []GoogleComputeFirewallLogConfig `tf:"log_config,blocks" json:"log_config,omitempty"`
+	Timeouts              *GoogleComputeFirewallTimeouts   `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleComputeFirewallAllow is a nested-block type used by the parent resource.
 type GoogleComputeFirewallAllow struct {
-	Ports    []*Value[string] `tf:"ports"`
-	Protocol *Value[string]   `tf:"protocol"`
+	Ports    []*Value[string] `tf:"ports" json:"ports,omitempty"`
+	Protocol *Value[string]   `tf:"protocol" json:"protocol,omitempty"`
 }
 
 // GoogleComputeFirewallDeny is a nested-block type used by the parent resource.
 type GoogleComputeFirewallDeny struct {
-	Ports    []*Value[string] `tf:"ports"`
-	Protocol *Value[string]   `tf:"protocol"`
+	Ports    []*Value[string] `tf:"ports" json:"ports,omitempty"`
+	Protocol *Value[string]   `tf:"protocol" json:"protocol,omitempty"`
 }
 
 // GoogleComputeFirewallLogConfig is a nested-block type used by the parent resource.
 type GoogleComputeFirewallLogConfig struct {
-	Metadata *Value[string] `tf:"metadata"`
+	Metadata *Value[string] `tf:"metadata" json:"metadata,omitempty"`
 }
 
 // GoogleComputeFirewallTimeouts is a nested-block type used by the parent resource.
 type GoogleComputeFirewallTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleComputeFirewallSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_compute_forwarding_rule.gen.go
+++ b/pkg/composer/imported/generated/google_compute_forwarding_rule.gen.go
@@ -7,56 +7,56 @@ import "reflect"
 // GoogleComputeForwardingRule is the generated Layer 1 typed model for the
 // `google_compute_forwarding_rule` Terraform resource.
 type GoogleComputeForwardingRule struct {
-	AllPorts                      *Value[bool]                                               `tf:"all_ports"`
-	AllowGlobalAccess             *Value[bool]                                               `tf:"allow_global_access"`
-	AllowPscGlobalAccess          *Value[bool]                                               `tf:"allow_psc_global_access"`
-	BackendService                *Value[string]                                             `tf:"backend_service"`
-	BaseForwardingRule            *Value[string]                                             `tf:"base_forwarding_rule"`
-	CreationTimestamp             *Value[string]                                             `tf:"creation_timestamp"`
-	Description                   *Value[string]                                             `tf:"description"`
-	EffectiveLabels               map[string]*Value[string]                                  `tf:"effective_labels"`
-	ForwardingRuleID              *Value[float64]                                            `tf:"forwarding_rule_id"`
-	ID                            *Value[string]                                             `tf:"id"`
-	IpAddress                     *Value[string]                                             `tf:"ip_address"`
-	IpProtocol                    *Value[string]                                             `tf:"ip_protocol"`
-	IpVersion                     *Value[string]                                             `tf:"ip_version"`
-	IsMirroringCollector          *Value[bool]                                               `tf:"is_mirroring_collector"`
-	LabelFingerprint              *Value[string]                                             `tf:"label_fingerprint"`
-	Labels                        map[string]*Value[string]                                  `tf:"labels"`
-	LoadBalancingScheme           *Value[string]                                             `tf:"load_balancing_scheme"`
-	Name                          *Value[string]                                             `tf:"name"`
-	Network                       *Value[string]                                             `tf:"network"`
-	NetworkTier                   *Value[string]                                             `tf:"network_tier"`
-	NoAutomateDNSZone             *Value[bool]                                               `tf:"no_automate_dns_zone"`
-	PortRange                     *Value[string]                                             `tf:"port_range"`
-	Ports                         []*Value[string]                                           `tf:"ports"`
-	Project                       *Value[string]                                             `tf:"project"`
-	PscConnectionID               *Value[string]                                             `tf:"psc_connection_id"`
-	PscConnectionStatus           *Value[string]                                             `tf:"psc_connection_status"`
-	RecreateClosedPsc             *Value[bool]                                               `tf:"recreate_closed_psc"`
-	Region                        *Value[string]                                             `tf:"region"`
-	SelfLink                      *Value[string]                                             `tf:"self_link"`
-	ServiceLabel                  *Value[string]                                             `tf:"service_label"`
-	ServiceName                   *Value[string]                                             `tf:"service_name"`
-	SourceIpRanges                []*Value[string]                                           `tf:"source_ip_ranges"`
-	Subnetwork                    *Value[string]                                             `tf:"subnetwork"`
-	Target                        *Value[string]                                             `tf:"target"`
-	TerraformLabels               map[string]*Value[string]                                  `tf:"terraform_labels"`
-	ServiceDirectoryRegistrations []GoogleComputeForwardingRuleServiceDirectoryRegistrations `tf:"service_directory_registrations,blocks"`
-	Timeouts                      *GoogleComputeForwardingRuleTimeouts                       `tf:"timeouts,block"`
+	AllPorts                      *Value[bool]                                               `tf:"all_ports" json:"all_ports,omitempty"`
+	AllowGlobalAccess             *Value[bool]                                               `tf:"allow_global_access" json:"allow_global_access,omitempty"`
+	AllowPscGlobalAccess          *Value[bool]                                               `tf:"allow_psc_global_access" json:"allow_psc_global_access,omitempty"`
+	BackendService                *Value[string]                                             `tf:"backend_service" json:"backend_service,omitempty"`
+	BaseForwardingRule            *Value[string]                                             `tf:"base_forwarding_rule" json:"base_forwarding_rule,omitempty"`
+	CreationTimestamp             *Value[string]                                             `tf:"creation_timestamp" json:"creation_timestamp,omitempty"`
+	Description                   *Value[string]                                             `tf:"description" json:"description,omitempty"`
+	EffectiveLabels               map[string]*Value[string]                                  `tf:"effective_labels" json:"effective_labels,omitempty"`
+	ForwardingRuleID              *Value[float64]                                            `tf:"forwarding_rule_id" json:"forwarding_rule_id,omitempty"`
+	ID                            *Value[string]                                             `tf:"id" json:"id,omitempty"`
+	IpAddress                     *Value[string]                                             `tf:"ip_address" json:"ip_address,omitempty"`
+	IpProtocol                    *Value[string]                                             `tf:"ip_protocol" json:"ip_protocol,omitempty"`
+	IpVersion                     *Value[string]                                             `tf:"ip_version" json:"ip_version,omitempty"`
+	IsMirroringCollector          *Value[bool]                                               `tf:"is_mirroring_collector" json:"is_mirroring_collector,omitempty"`
+	LabelFingerprint              *Value[string]                                             `tf:"label_fingerprint" json:"label_fingerprint,omitempty"`
+	Labels                        map[string]*Value[string]                                  `tf:"labels" json:"labels,omitempty"`
+	LoadBalancingScheme           *Value[string]                                             `tf:"load_balancing_scheme" json:"load_balancing_scheme,omitempty"`
+	Name                          *Value[string]                                             `tf:"name" json:"name,omitempty"`
+	Network                       *Value[string]                                             `tf:"network" json:"network,omitempty"`
+	NetworkTier                   *Value[string]                                             `tf:"network_tier" json:"network_tier,omitempty"`
+	NoAutomateDNSZone             *Value[bool]                                               `tf:"no_automate_dns_zone" json:"no_automate_dns_zone,omitempty"`
+	PortRange                     *Value[string]                                             `tf:"port_range" json:"port_range,omitempty"`
+	Ports                         []*Value[string]                                           `tf:"ports" json:"ports,omitempty"`
+	Project                       *Value[string]                                             `tf:"project" json:"project,omitempty"`
+	PscConnectionID               *Value[string]                                             `tf:"psc_connection_id" json:"psc_connection_id,omitempty"`
+	PscConnectionStatus           *Value[string]                                             `tf:"psc_connection_status" json:"psc_connection_status,omitempty"`
+	RecreateClosedPsc             *Value[bool]                                               `tf:"recreate_closed_psc" json:"recreate_closed_psc,omitempty"`
+	Region                        *Value[string]                                             `tf:"region" json:"region,omitempty"`
+	SelfLink                      *Value[string]                                             `tf:"self_link" json:"self_link,omitempty"`
+	ServiceLabel                  *Value[string]                                             `tf:"service_label" json:"service_label,omitempty"`
+	ServiceName                   *Value[string]                                             `tf:"service_name" json:"service_name,omitempty"`
+	SourceIpRanges                []*Value[string]                                           `tf:"source_ip_ranges" json:"source_ip_ranges,omitempty"`
+	Subnetwork                    *Value[string]                                             `tf:"subnetwork" json:"subnetwork,omitempty"`
+	Target                        *Value[string]                                             `tf:"target" json:"target,omitempty"`
+	TerraformLabels               map[string]*Value[string]                                  `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	ServiceDirectoryRegistrations []GoogleComputeForwardingRuleServiceDirectoryRegistrations `tf:"service_directory_registrations,blocks" json:"service_directory_registrations,omitempty"`
+	Timeouts                      *GoogleComputeForwardingRuleTimeouts                       `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleComputeForwardingRuleServiceDirectoryRegistrations is a nested-block type used by the parent resource.
 type GoogleComputeForwardingRuleServiceDirectoryRegistrations struct {
-	Namespace *Value[string] `tf:"namespace"`
-	Service   *Value[string] `tf:"service"`
+	Namespace *Value[string] `tf:"namespace" json:"namespace,omitempty"`
+	Service   *Value[string] `tf:"service" json:"service,omitempty"`
 }
 
 // GoogleComputeForwardingRuleTimeouts is a nested-block type used by the parent resource.
 type GoogleComputeForwardingRuleTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleComputeForwardingRuleSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_compute_global_address.gen.go
+++ b/pkg/composer/imported/generated/google_compute_global_address.gen.go
@@ -7,30 +7,30 @@ import "reflect"
 // GoogleComputeGlobalAddress is the generated Layer 1 typed model for the
 // `google_compute_global_address` Terraform resource.
 type GoogleComputeGlobalAddress struct {
-	Address           *Value[string]                      `tf:"address"`
-	AddressType       *Value[string]                      `tf:"address_type"`
-	CreationTimestamp *Value[string]                      `tf:"creation_timestamp"`
-	Description       *Value[string]                      `tf:"description"`
-	EffectiveLabels   map[string]*Value[string]           `tf:"effective_labels"`
-	ID                *Value[string]                      `tf:"id"`
-	IpVersion         *Value[string]                      `tf:"ip_version"`
-	LabelFingerprint  *Value[string]                      `tf:"label_fingerprint"`
-	Labels            map[string]*Value[string]           `tf:"labels"`
-	Name              *Value[string]                      `tf:"name"`
-	Network           *Value[string]                      `tf:"network"`
-	PrefixLength      *Value[float64]                     `tf:"prefix_length"`
-	Project           *Value[string]                      `tf:"project"`
-	Purpose           *Value[string]                      `tf:"purpose"`
-	SelfLink          *Value[string]                      `tf:"self_link"`
-	TerraformLabels   map[string]*Value[string]           `tf:"terraform_labels"`
-	Timeouts          *GoogleComputeGlobalAddressTimeouts `tf:"timeouts,block"`
+	Address           *Value[string]                      `tf:"address" json:"address,omitempty"`
+	AddressType       *Value[string]                      `tf:"address_type" json:"address_type,omitempty"`
+	CreationTimestamp *Value[string]                      `tf:"creation_timestamp" json:"creation_timestamp,omitempty"`
+	Description       *Value[string]                      `tf:"description" json:"description,omitempty"`
+	EffectiveLabels   map[string]*Value[string]           `tf:"effective_labels" json:"effective_labels,omitempty"`
+	ID                *Value[string]                      `tf:"id" json:"id,omitempty"`
+	IpVersion         *Value[string]                      `tf:"ip_version" json:"ip_version,omitempty"`
+	LabelFingerprint  *Value[string]                      `tf:"label_fingerprint" json:"label_fingerprint,omitempty"`
+	Labels            map[string]*Value[string]           `tf:"labels" json:"labels,omitempty"`
+	Name              *Value[string]                      `tf:"name" json:"name,omitempty"`
+	Network           *Value[string]                      `tf:"network" json:"network,omitempty"`
+	PrefixLength      *Value[float64]                     `tf:"prefix_length" json:"prefix_length,omitempty"`
+	Project           *Value[string]                      `tf:"project" json:"project,omitempty"`
+	Purpose           *Value[string]                      `tf:"purpose" json:"purpose,omitempty"`
+	SelfLink          *Value[string]                      `tf:"self_link" json:"self_link,omitempty"`
+	TerraformLabels   map[string]*Value[string]           `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	Timeouts          *GoogleComputeGlobalAddressTimeouts `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleComputeGlobalAddressTimeouts is a nested-block type used by the parent resource.
 type GoogleComputeGlobalAddressTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleComputeGlobalAddressSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_compute_global_forwarding_rule.gen.go
+++ b/pkg/composer/imported/generated/google_compute_global_forwarding_rule.gen.go
@@ -7,56 +7,56 @@ import "reflect"
 // GoogleComputeGlobalForwardingRule is the generated Layer 1 typed model for the
 // `google_compute_global_forwarding_rule` Terraform resource.
 type GoogleComputeGlobalForwardingRule struct {
-	BaseForwardingRule            *Value[string]                                                   `tf:"base_forwarding_rule"`
-	Description                   *Value[string]                                                   `tf:"description"`
-	EffectiveLabels               map[string]*Value[string]                                        `tf:"effective_labels"`
-	ID                            *Value[string]                                                   `tf:"id"`
-	IpAddress                     *Value[string]                                                   `tf:"ip_address"`
-	IpProtocol                    *Value[string]                                                   `tf:"ip_protocol"`
-	IpVersion                     *Value[string]                                                   `tf:"ip_version"`
-	LabelFingerprint              *Value[string]                                                   `tf:"label_fingerprint"`
-	Labels                        map[string]*Value[string]                                        `tf:"labels"`
-	LoadBalancingScheme           *Value[string]                                                   `tf:"load_balancing_scheme"`
-	Name                          *Value[string]                                                   `tf:"name"`
-	Network                       *Value[string]                                                   `tf:"network"`
-	NoAutomateDNSZone             *Value[bool]                                                     `tf:"no_automate_dns_zone"`
-	PortRange                     *Value[string]                                                   `tf:"port_range"`
-	Project                       *Value[string]                                                   `tf:"project"`
-	PscConnectionID               *Value[string]                                                   `tf:"psc_connection_id"`
-	PscConnectionStatus           *Value[string]                                                   `tf:"psc_connection_status"`
-	SelfLink                      *Value[string]                                                   `tf:"self_link"`
-	SourceIpRanges                []*Value[string]                                                 `tf:"source_ip_ranges"`
-	Subnetwork                    *Value[string]                                                   `tf:"subnetwork"`
-	Target                        *Value[string]                                                   `tf:"target"`
-	TerraformLabels               map[string]*Value[string]                                        `tf:"terraform_labels"`
-	MetadataFilters               []GoogleComputeGlobalForwardingRuleMetadataFilters               `tf:"metadata_filters,blocks"`
-	ServiceDirectoryRegistrations []GoogleComputeGlobalForwardingRuleServiceDirectoryRegistrations `tf:"service_directory_registrations,blocks"`
-	Timeouts                      *GoogleComputeGlobalForwardingRuleTimeouts                       `tf:"timeouts,block"`
+	BaseForwardingRule            *Value[string]                                                   `tf:"base_forwarding_rule" json:"base_forwarding_rule,omitempty"`
+	Description                   *Value[string]                                                   `tf:"description" json:"description,omitempty"`
+	EffectiveLabels               map[string]*Value[string]                                        `tf:"effective_labels" json:"effective_labels,omitempty"`
+	ID                            *Value[string]                                                   `tf:"id" json:"id,omitempty"`
+	IpAddress                     *Value[string]                                                   `tf:"ip_address" json:"ip_address,omitempty"`
+	IpProtocol                    *Value[string]                                                   `tf:"ip_protocol" json:"ip_protocol,omitempty"`
+	IpVersion                     *Value[string]                                                   `tf:"ip_version" json:"ip_version,omitempty"`
+	LabelFingerprint              *Value[string]                                                   `tf:"label_fingerprint" json:"label_fingerprint,omitempty"`
+	Labels                        map[string]*Value[string]                                        `tf:"labels" json:"labels,omitempty"`
+	LoadBalancingScheme           *Value[string]                                                   `tf:"load_balancing_scheme" json:"load_balancing_scheme,omitempty"`
+	Name                          *Value[string]                                                   `tf:"name" json:"name,omitempty"`
+	Network                       *Value[string]                                                   `tf:"network" json:"network,omitempty"`
+	NoAutomateDNSZone             *Value[bool]                                                     `tf:"no_automate_dns_zone" json:"no_automate_dns_zone,omitempty"`
+	PortRange                     *Value[string]                                                   `tf:"port_range" json:"port_range,omitempty"`
+	Project                       *Value[string]                                                   `tf:"project" json:"project,omitempty"`
+	PscConnectionID               *Value[string]                                                   `tf:"psc_connection_id" json:"psc_connection_id,omitempty"`
+	PscConnectionStatus           *Value[string]                                                   `tf:"psc_connection_status" json:"psc_connection_status,omitempty"`
+	SelfLink                      *Value[string]                                                   `tf:"self_link" json:"self_link,omitempty"`
+	SourceIpRanges                []*Value[string]                                                 `tf:"source_ip_ranges" json:"source_ip_ranges,omitempty"`
+	Subnetwork                    *Value[string]                                                   `tf:"subnetwork" json:"subnetwork,omitempty"`
+	Target                        *Value[string]                                                   `tf:"target" json:"target,omitempty"`
+	TerraformLabels               map[string]*Value[string]                                        `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	MetadataFilters               []GoogleComputeGlobalForwardingRuleMetadataFilters               `tf:"metadata_filters,blocks" json:"metadata_filters,omitempty"`
+	ServiceDirectoryRegistrations []GoogleComputeGlobalForwardingRuleServiceDirectoryRegistrations `tf:"service_directory_registrations,blocks" json:"service_directory_registrations,omitempty"`
+	Timeouts                      *GoogleComputeGlobalForwardingRuleTimeouts                       `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleComputeGlobalForwardingRuleMetadataFilters is a nested-block type used by the parent resource.
 type GoogleComputeGlobalForwardingRuleMetadataFilters struct {
-	FilterMatchCriteria *Value[string]                                                 `tf:"filter_match_criteria"`
-	FilterLabels        []GoogleComputeGlobalForwardingRuleMetadataFiltersFilterLabels `tf:"filter_labels,blocks"`
+	FilterMatchCriteria *Value[string]                                                 `tf:"filter_match_criteria" json:"filter_match_criteria,omitempty"`
+	FilterLabels        []GoogleComputeGlobalForwardingRuleMetadataFiltersFilterLabels `tf:"filter_labels,blocks" json:"filter_labels,omitempty"`
 }
 
 // GoogleComputeGlobalForwardingRuleMetadataFiltersFilterLabels is a nested-block type used by the parent resource.
 type GoogleComputeGlobalForwardingRuleMetadataFiltersFilterLabels struct {
-	Name  *Value[string] `tf:"name"`
-	Value *Value[string] `tf:"value"`
+	Name  *Value[string] `tf:"name" json:"name,omitempty"`
+	Value *Value[string] `tf:"value" json:"value,omitempty"`
 }
 
 // GoogleComputeGlobalForwardingRuleServiceDirectoryRegistrations is a nested-block type used by the parent resource.
 type GoogleComputeGlobalForwardingRuleServiceDirectoryRegistrations struct {
-	Namespace              *Value[string] `tf:"namespace"`
-	ServiceDirectoryRegion *Value[string] `tf:"service_directory_region"`
+	Namespace              *Value[string] `tf:"namespace" json:"namespace,omitempty"`
+	ServiceDirectoryRegion *Value[string] `tf:"service_directory_region" json:"service_directory_region,omitempty"`
 }
 
 // GoogleComputeGlobalForwardingRuleTimeouts is a nested-block type used by the parent resource.
 type GoogleComputeGlobalForwardingRuleTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleComputeGlobalForwardingRuleSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_compute_instance.gen.go
+++ b/pkg/composer/imported/generated/google_compute_instance.gen.go
@@ -7,233 +7,233 @@ import "reflect"
 // GoogleComputeInstance is the generated Layer 1 typed model for the
 // `google_compute_instance` Terraform resource.
 type GoogleComputeInstance struct {
-	AllowStoppingForUpdate     *Value[bool]                                      `tf:"allow_stopping_for_update"`
-	CanIpForward               *Value[bool]                                      `tf:"can_ip_forward"`
-	CPUPlatform                *Value[string]                                    `tf:"cpu_platform"`
-	CreationTimestamp          *Value[string]                                    `tf:"creation_timestamp"`
-	CurrentStatus              *Value[string]                                    `tf:"current_status"`
-	DeletionProtection         *Value[bool]                                      `tf:"deletion_protection"`
-	Description                *Value[string]                                    `tf:"description"`
-	DesiredStatus              *Value[string]                                    `tf:"desired_status"`
-	EffectiveLabels            map[string]*Value[string]                         `tf:"effective_labels"`
-	EnableDisplay              *Value[bool]                                      `tf:"enable_display"`
-	Hostname                   *Value[string]                                    `tf:"hostname"`
-	ID                         *Value[string]                                    `tf:"id"`
-	InstanceID                 *Value[string]                                    `tf:"instance_id"`
-	KeyRevocationActionType    *Value[string]                                    `tf:"key_revocation_action_type"`
-	LabelFingerprint           *Value[string]                                    `tf:"label_fingerprint"`
-	Labels                     map[string]*Value[string]                         `tf:"labels"`
-	MachineType                *Value[string]                                    `tf:"machine_type"`
-	Metadata                   map[string]*Value[string]                         `tf:"metadata"`
-	MetadataFingerprint        *Value[string]                                    `tf:"metadata_fingerprint"`
-	MetadataStartupScript      *Value[string]                                    `tf:"metadata_startup_script"`
-	MinCPUPlatform             *Value[string]                                    `tf:"min_cpu_platform"`
-	Name                       *Value[string]                                    `tf:"name"`
-	Project                    *Value[string]                                    `tf:"project"`
-	ResourcePolicies           []*Value[string]                                  `tf:"resource_policies"`
-	SelfLink                   *Value[string]                                    `tf:"self_link"`
-	Tags                       []*Value[string]                                  `tf:"tags"`
-	TagsFingerprint            *Value[string]                                    `tf:"tags_fingerprint"`
-	TerraformLabels            map[string]*Value[string]                         `tf:"terraform_labels"`
-	Zone                       *Value[string]                                    `tf:"zone"`
-	AdvancedMachineFeatures    []GoogleComputeInstanceAdvancedMachineFeatures    `tf:"advanced_machine_features,blocks"`
-	AttachedDisk               []GoogleComputeInstanceAttachedDisk               `tf:"attached_disk,blocks"`
-	BootDisk                   []GoogleComputeInstanceBootDisk                   `tf:"boot_disk,blocks"`
-	ConfidentialInstanceConfig []GoogleComputeInstanceConfidentialInstanceConfig `tf:"confidential_instance_config,blocks"`
-	GuestAccelerator           []GoogleComputeInstanceGuestAccelerator           `tf:"guest_accelerator,blocks"`
-	NetworkInterface           []GoogleComputeInstanceNetworkInterface           `tf:"network_interface,blocks"`
-	NetworkPerformanceConfig   []GoogleComputeInstanceNetworkPerformanceConfig   `tf:"network_performance_config,blocks"`
-	Params                     []GoogleComputeInstanceParams                     `tf:"params,blocks"`
-	ReservationAffinity        []GoogleComputeInstanceReservationAffinity        `tf:"reservation_affinity,blocks"`
-	Scheduling                 []GoogleComputeInstanceScheduling                 `tf:"scheduling,blocks"`
-	ScratchDisk                []GoogleComputeInstanceScratchDisk                `tf:"scratch_disk,blocks"`
-	ServiceAccount             []GoogleComputeInstanceServiceAccount             `tf:"service_account,blocks"`
-	ShieldedInstanceConfig     []GoogleComputeInstanceShieldedInstanceConfig     `tf:"shielded_instance_config,blocks"`
-	Timeouts                   *GoogleComputeInstanceTimeouts                    `tf:"timeouts,block"`
+	AllowStoppingForUpdate     *Value[bool]                                      `tf:"allow_stopping_for_update" json:"allow_stopping_for_update,omitempty"`
+	CanIpForward               *Value[bool]                                      `tf:"can_ip_forward" json:"can_ip_forward,omitempty"`
+	CPUPlatform                *Value[string]                                    `tf:"cpu_platform" json:"cpu_platform,omitempty"`
+	CreationTimestamp          *Value[string]                                    `tf:"creation_timestamp" json:"creation_timestamp,omitempty"`
+	CurrentStatus              *Value[string]                                    `tf:"current_status" json:"current_status,omitempty"`
+	DeletionProtection         *Value[bool]                                      `tf:"deletion_protection" json:"deletion_protection,omitempty"`
+	Description                *Value[string]                                    `tf:"description" json:"description,omitempty"`
+	DesiredStatus              *Value[string]                                    `tf:"desired_status" json:"desired_status,omitempty"`
+	EffectiveLabels            map[string]*Value[string]                         `tf:"effective_labels" json:"effective_labels,omitempty"`
+	EnableDisplay              *Value[bool]                                      `tf:"enable_display" json:"enable_display,omitempty"`
+	Hostname                   *Value[string]                                    `tf:"hostname" json:"hostname,omitempty"`
+	ID                         *Value[string]                                    `tf:"id" json:"id,omitempty"`
+	InstanceID                 *Value[string]                                    `tf:"instance_id" json:"instance_id,omitempty"`
+	KeyRevocationActionType    *Value[string]                                    `tf:"key_revocation_action_type" json:"key_revocation_action_type,omitempty"`
+	LabelFingerprint           *Value[string]                                    `tf:"label_fingerprint" json:"label_fingerprint,omitempty"`
+	Labels                     map[string]*Value[string]                         `tf:"labels" json:"labels,omitempty"`
+	MachineType                *Value[string]                                    `tf:"machine_type" json:"machine_type,omitempty"`
+	Metadata                   map[string]*Value[string]                         `tf:"metadata" json:"metadata,omitempty"`
+	MetadataFingerprint        *Value[string]                                    `tf:"metadata_fingerprint" json:"metadata_fingerprint,omitempty"`
+	MetadataStartupScript      *Value[string]                                    `tf:"metadata_startup_script" json:"metadata_startup_script,omitempty"`
+	MinCPUPlatform             *Value[string]                                    `tf:"min_cpu_platform" json:"min_cpu_platform,omitempty"`
+	Name                       *Value[string]                                    `tf:"name" json:"name,omitempty"`
+	Project                    *Value[string]                                    `tf:"project" json:"project,omitempty"`
+	ResourcePolicies           []*Value[string]                                  `tf:"resource_policies" json:"resource_policies,omitempty"`
+	SelfLink                   *Value[string]                                    `tf:"self_link" json:"self_link,omitempty"`
+	Tags                       []*Value[string]                                  `tf:"tags" json:"tags,omitempty"`
+	TagsFingerprint            *Value[string]                                    `tf:"tags_fingerprint" json:"tags_fingerprint,omitempty"`
+	TerraformLabels            map[string]*Value[string]                         `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	Zone                       *Value[string]                                    `tf:"zone" json:"zone,omitempty"`
+	AdvancedMachineFeatures    []GoogleComputeInstanceAdvancedMachineFeatures    `tf:"advanced_machine_features,blocks" json:"advanced_machine_features,omitempty"`
+	AttachedDisk               []GoogleComputeInstanceAttachedDisk               `tf:"attached_disk,blocks" json:"attached_disk,omitempty"`
+	BootDisk                   []GoogleComputeInstanceBootDisk                   `tf:"boot_disk,blocks" json:"boot_disk,omitempty"`
+	ConfidentialInstanceConfig []GoogleComputeInstanceConfidentialInstanceConfig `tf:"confidential_instance_config,blocks" json:"confidential_instance_config,omitempty"`
+	GuestAccelerator           []GoogleComputeInstanceGuestAccelerator           `tf:"guest_accelerator,blocks" json:"guest_accelerator,omitempty"`
+	NetworkInterface           []GoogleComputeInstanceNetworkInterface           `tf:"network_interface,blocks" json:"network_interface,omitempty"`
+	NetworkPerformanceConfig   []GoogleComputeInstanceNetworkPerformanceConfig   `tf:"network_performance_config,blocks" json:"network_performance_config,omitempty"`
+	Params                     []GoogleComputeInstanceParams                     `tf:"params,blocks" json:"params,omitempty"`
+	ReservationAffinity        []GoogleComputeInstanceReservationAffinity        `tf:"reservation_affinity,blocks" json:"reservation_affinity,omitempty"`
+	Scheduling                 []GoogleComputeInstanceScheduling                 `tf:"scheduling,blocks" json:"scheduling,omitempty"`
+	ScratchDisk                []GoogleComputeInstanceScratchDisk                `tf:"scratch_disk,blocks" json:"scratch_disk,omitempty"`
+	ServiceAccount             []GoogleComputeInstanceServiceAccount             `tf:"service_account,blocks" json:"service_account,omitempty"`
+	ShieldedInstanceConfig     []GoogleComputeInstanceShieldedInstanceConfig     `tf:"shielded_instance_config,blocks" json:"shielded_instance_config,omitempty"`
+	Timeouts                   *GoogleComputeInstanceTimeouts                    `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleComputeInstanceAdvancedMachineFeatures is a nested-block type used by the parent resource.
 type GoogleComputeInstanceAdvancedMachineFeatures struct {
-	EnableNestedVirtualization *Value[bool]    `tf:"enable_nested_virtualization"`
-	ThreadsPerCore             *Value[float64] `tf:"threads_per_core"`
-	TurboMode                  *Value[string]  `tf:"turbo_mode"`
-	VisibleCoreCount           *Value[int64]   `tf:"visible_core_count"`
+	EnableNestedVirtualization *Value[bool]    `tf:"enable_nested_virtualization" json:"enable_nested_virtualization,omitempty"`
+	ThreadsPerCore             *Value[float64] `tf:"threads_per_core" json:"threads_per_core,omitempty"`
+	TurboMode                  *Value[string]  `tf:"turbo_mode" json:"turbo_mode,omitempty"`
+	VisibleCoreCount           *Value[int64]   `tf:"visible_core_count" json:"visible_core_count,omitempty"`
 }
 
 // GoogleComputeInstanceAttachedDisk is a nested-block type used by the parent resource.
 type GoogleComputeInstanceAttachedDisk struct {
-	DeviceName              *Value[string] `tf:"device_name"`
-	DiskEncryptionKeyRaw    *Value[string] `tf:"disk_encryption_key_raw"`
-	DiskEncryptionKeySHA256 *Value[string] `tf:"disk_encryption_key_sha256"`
-	KMSKeySelfLink          *Value[string] `tf:"kms_key_self_link"`
-	Mode                    *Value[string] `tf:"mode"`
-	Source                  *Value[string] `tf:"source"`
+	DeviceName              *Value[string] `tf:"device_name" json:"device_name,omitempty"`
+	DiskEncryptionKeyRaw    *Value[string] `tf:"disk_encryption_key_raw" json:"disk_encryption_key_raw,omitempty"`
+	DiskEncryptionKeySHA256 *Value[string] `tf:"disk_encryption_key_sha256" json:"disk_encryption_key_sha256,omitempty"`
+	KMSKeySelfLink          *Value[string] `tf:"kms_key_self_link" json:"kms_key_self_link,omitempty"`
+	Mode                    *Value[string] `tf:"mode" json:"mode,omitempty"`
+	Source                  *Value[string] `tf:"source" json:"source,omitempty"`
 }
 
 // GoogleComputeInstanceBootDisk is a nested-block type used by the parent resource.
 type GoogleComputeInstanceBootDisk struct {
-	AutoDelete              *Value[bool]                                    `tf:"auto_delete"`
-	DeviceName              *Value[string]                                  `tf:"device_name"`
-	DiskEncryptionKeyRaw    *Value[string]                                  `tf:"disk_encryption_key_raw"`
-	DiskEncryptionKeySHA256 *Value[string]                                  `tf:"disk_encryption_key_sha256"`
-	Interface_              *Value[string]                                  `tf:"interface"`
-	KMSKeySelfLink          *Value[string]                                  `tf:"kms_key_self_link"`
-	Mode                    *Value[string]                                  `tf:"mode"`
-	Source                  *Value[string]                                  `tf:"source"`
-	InitializeParams        []GoogleComputeInstanceBootDiskInitializeParams `tf:"initialize_params,blocks"`
+	AutoDelete              *Value[bool]                                    `tf:"auto_delete" json:"auto_delete,omitempty"`
+	DeviceName              *Value[string]                                  `tf:"device_name" json:"device_name,omitempty"`
+	DiskEncryptionKeyRaw    *Value[string]                                  `tf:"disk_encryption_key_raw" json:"disk_encryption_key_raw,omitempty"`
+	DiskEncryptionKeySHA256 *Value[string]                                  `tf:"disk_encryption_key_sha256" json:"disk_encryption_key_sha256,omitempty"`
+	Interface_              *Value[string]                                  `tf:"interface" json:"interface,omitempty"`
+	KMSKeySelfLink          *Value[string]                                  `tf:"kms_key_self_link" json:"kms_key_self_link,omitempty"`
+	Mode                    *Value[string]                                  `tf:"mode" json:"mode,omitempty"`
+	Source                  *Value[string]                                  `tf:"source" json:"source,omitempty"`
+	InitializeParams        []GoogleComputeInstanceBootDiskInitializeParams `tf:"initialize_params,blocks" json:"initialize_params,omitempty"`
 }
 
 // GoogleComputeInstanceBootDiskInitializeParams is a nested-block type used by the parent resource.
 type GoogleComputeInstanceBootDiskInitializeParams struct {
-	EnableConfidentialCompute *Value[bool]              `tf:"enable_confidential_compute"`
-	Image                     *Value[string]            `tf:"image"`
-	Labels                    map[string]*Value[string] `tf:"labels"`
-	ProvisionedIops           *Value[float64]           `tf:"provisioned_iops"`
-	ProvisionedThroughput     *Value[float64]           `tf:"provisioned_throughput"`
-	ResourceManagerTags       map[string]*Value[string] `tf:"resource_manager_tags"`
-	ResourcePolicies          []*Value[string]          `tf:"resource_policies"`
-	Size                      *Value[float64]           `tf:"size"`
-	StoragePool               *Value[string]            `tf:"storage_pool"`
-	Type_                     *Value[string]            `tf:"type"`
+	EnableConfidentialCompute *Value[bool]              `tf:"enable_confidential_compute" json:"enable_confidential_compute,omitempty"`
+	Image                     *Value[string]            `tf:"image" json:"image,omitempty"`
+	Labels                    map[string]*Value[string] `tf:"labels" json:"labels,omitempty"`
+	ProvisionedIops           *Value[float64]           `tf:"provisioned_iops" json:"provisioned_iops,omitempty"`
+	ProvisionedThroughput     *Value[float64]           `tf:"provisioned_throughput" json:"provisioned_throughput,omitempty"`
+	ResourceManagerTags       map[string]*Value[string] `tf:"resource_manager_tags" json:"resource_manager_tags,omitempty"`
+	ResourcePolicies          []*Value[string]          `tf:"resource_policies" json:"resource_policies,omitempty"`
+	Size                      *Value[float64]           `tf:"size" json:"size,omitempty"`
+	StoragePool               *Value[string]            `tf:"storage_pool" json:"storage_pool,omitempty"`
+	Type_                     *Value[string]            `tf:"type" json:"type,omitempty"`
 }
 
 // GoogleComputeInstanceConfidentialInstanceConfig is a nested-block type used by the parent resource.
 type GoogleComputeInstanceConfidentialInstanceConfig struct {
-	ConfidentialInstanceType  *Value[string] `tf:"confidential_instance_type"`
-	EnableConfidentialCompute *Value[bool]   `tf:"enable_confidential_compute"`
+	ConfidentialInstanceType  *Value[string] `tf:"confidential_instance_type" json:"confidential_instance_type,omitempty"`
+	EnableConfidentialCompute *Value[bool]   `tf:"enable_confidential_compute" json:"enable_confidential_compute,omitempty"`
 }
 
 // GoogleComputeInstanceGuestAccelerator is a nested-block type used by the parent resource.
 type GoogleComputeInstanceGuestAccelerator struct {
-	Count *Value[float64] `tf:"count"`
-	Type_ *Value[string]  `tf:"type"`
+	Count *Value[float64] `tf:"count" json:"count,omitempty"`
+	Type_ *Value[string]  `tf:"type" json:"type,omitempty"`
 }
 
 // GoogleComputeInstanceNetworkInterface is a nested-block type used by the parent resource.
 type GoogleComputeInstanceNetworkInterface struct {
-	InternalIPV6PrefixLength *Value[float64]                                         `tf:"internal_ipv6_prefix_length"`
-	IPV6AccessType           *Value[string]                                          `tf:"ipv6_access_type"`
-	IPV6Address              *Value[string]                                          `tf:"ipv6_address"`
-	Name                     *Value[string]                                          `tf:"name"`
-	Network                  *Value[string]                                          `tf:"network"`
-	NetworkIp                *Value[string]                                          `tf:"network_ip"`
-	NicType                  *Value[string]                                          `tf:"nic_type"`
-	QueueCount               *Value[int64]                                           `tf:"queue_count"`
-	StackType                *Value[string]                                          `tf:"stack_type"`
-	Subnetwork               *Value[string]                                          `tf:"subnetwork"`
-	SubnetworkProject        *Value[string]                                          `tf:"subnetwork_project"`
-	AccessConfig             []GoogleComputeInstanceNetworkInterfaceAccessConfig     `tf:"access_config,blocks"`
-	AliasIpRange             []GoogleComputeInstanceNetworkInterfaceAliasIpRange     `tf:"alias_ip_range,blocks"`
-	IPV6AccessConfig         []GoogleComputeInstanceNetworkInterfaceIPV6AccessConfig `tf:"ipv6_access_config,blocks"`
+	InternalIPV6PrefixLength *Value[float64]                                         `tf:"internal_ipv6_prefix_length" json:"internal_ipv6_prefix_length,omitempty"`
+	IPV6AccessType           *Value[string]                                          `tf:"ipv6_access_type" json:"ipv6_access_type,omitempty"`
+	IPV6Address              *Value[string]                                          `tf:"ipv6_address" json:"ipv6_address,omitempty"`
+	Name                     *Value[string]                                          `tf:"name" json:"name,omitempty"`
+	Network                  *Value[string]                                          `tf:"network" json:"network,omitempty"`
+	NetworkIp                *Value[string]                                          `tf:"network_ip" json:"network_ip,omitempty"`
+	NicType                  *Value[string]                                          `tf:"nic_type" json:"nic_type,omitempty"`
+	QueueCount               *Value[int64]                                           `tf:"queue_count" json:"queue_count,omitempty"`
+	StackType                *Value[string]                                          `tf:"stack_type" json:"stack_type,omitempty"`
+	Subnetwork               *Value[string]                                          `tf:"subnetwork" json:"subnetwork,omitempty"`
+	SubnetworkProject        *Value[string]                                          `tf:"subnetwork_project" json:"subnetwork_project,omitempty"`
+	AccessConfig             []GoogleComputeInstanceNetworkInterfaceAccessConfig     `tf:"access_config,blocks" json:"access_config,omitempty"`
+	AliasIpRange             []GoogleComputeInstanceNetworkInterfaceAliasIpRange     `tf:"alias_ip_range,blocks" json:"alias_ip_range,omitempty"`
+	IPV6AccessConfig         []GoogleComputeInstanceNetworkInterfaceIPV6AccessConfig `tf:"ipv6_access_config,blocks" json:"ipv6_access_config,omitempty"`
 }
 
 // GoogleComputeInstanceNetworkInterfaceAccessConfig is a nested-block type used by the parent resource.
 type GoogleComputeInstanceNetworkInterfaceAccessConfig struct {
-	NatIp               *Value[string] `tf:"nat_ip"`
-	NetworkTier         *Value[string] `tf:"network_tier"`
-	PublicPtrDomainName *Value[string] `tf:"public_ptr_domain_name"`
+	NatIp               *Value[string] `tf:"nat_ip" json:"nat_ip,omitempty"`
+	NetworkTier         *Value[string] `tf:"network_tier" json:"network_tier,omitempty"`
+	PublicPtrDomainName *Value[string] `tf:"public_ptr_domain_name" json:"public_ptr_domain_name,omitempty"`
 }
 
 // GoogleComputeInstanceNetworkInterfaceAliasIpRange is a nested-block type used by the parent resource.
 type GoogleComputeInstanceNetworkInterfaceAliasIpRange struct {
-	IpCIDRRange         *Value[string] `tf:"ip_cidr_range"`
-	SubnetworkRangeName *Value[string] `tf:"subnetwork_range_name"`
+	IpCIDRRange         *Value[string] `tf:"ip_cidr_range" json:"ip_cidr_range,omitempty"`
+	SubnetworkRangeName *Value[string] `tf:"subnetwork_range_name" json:"subnetwork_range_name,omitempty"`
 }
 
 // GoogleComputeInstanceNetworkInterfaceIPV6AccessConfig is a nested-block type used by the parent resource.
 type GoogleComputeInstanceNetworkInterfaceIPV6AccessConfig struct {
-	ExternalIPV6             *Value[string] `tf:"external_ipv6"`
-	ExternalIPV6PrefixLength *Value[string] `tf:"external_ipv6_prefix_length"`
-	Name                     *Value[string] `tf:"name"`
-	NetworkTier              *Value[string] `tf:"network_tier"`
-	PublicPtrDomainName      *Value[string] `tf:"public_ptr_domain_name"`
+	ExternalIPV6             *Value[string] `tf:"external_ipv6" json:"external_ipv6,omitempty"`
+	ExternalIPV6PrefixLength *Value[string] `tf:"external_ipv6_prefix_length" json:"external_ipv6_prefix_length,omitempty"`
+	Name                     *Value[string] `tf:"name" json:"name,omitempty"`
+	NetworkTier              *Value[string] `tf:"network_tier" json:"network_tier,omitempty"`
+	PublicPtrDomainName      *Value[string] `tf:"public_ptr_domain_name" json:"public_ptr_domain_name,omitempty"`
 }
 
 // GoogleComputeInstanceNetworkPerformanceConfig is a nested-block type used by the parent resource.
 type GoogleComputeInstanceNetworkPerformanceConfig struct {
-	TotalEgressBandwidthTier *Value[string] `tf:"total_egress_bandwidth_tier"`
+	TotalEgressBandwidthTier *Value[string] `tf:"total_egress_bandwidth_tier" json:"total_egress_bandwidth_tier,omitempty"`
 }
 
 // GoogleComputeInstanceParams is a nested-block type used by the parent resource.
 type GoogleComputeInstanceParams struct {
-	ResourceManagerTags map[string]*Value[string] `tf:"resource_manager_tags"`
+	ResourceManagerTags map[string]*Value[string] `tf:"resource_manager_tags" json:"resource_manager_tags,omitempty"`
 }
 
 // GoogleComputeInstanceReservationAffinity is a nested-block type used by the parent resource.
 type GoogleComputeInstanceReservationAffinity struct {
-	Type_               *Value[string]                                                `tf:"type"`
-	SpecificReservation []GoogleComputeInstanceReservationAffinitySpecificReservation `tf:"specific_reservation,blocks"`
+	Type_               *Value[string]                                                `tf:"type" json:"type,omitempty"`
+	SpecificReservation []GoogleComputeInstanceReservationAffinitySpecificReservation `tf:"specific_reservation,blocks" json:"specific_reservation,omitempty"`
 }
 
 // GoogleComputeInstanceReservationAffinitySpecificReservation is a nested-block type used by the parent resource.
 type GoogleComputeInstanceReservationAffinitySpecificReservation struct {
-	Key    *Value[string]   `tf:"key"`
-	Values []*Value[string] `tf:"values"`
+	Key    *Value[string]   `tf:"key" json:"key,omitempty"`
+	Values []*Value[string] `tf:"values" json:"values,omitempty"`
 }
 
 // GoogleComputeInstanceScheduling is a nested-block type used by the parent resource.
 type GoogleComputeInstanceScheduling struct {
-	AutomaticRestart          *Value[bool]                                             `tf:"automatic_restart"`
-	InstanceTerminationAction *Value[string]                                           `tf:"instance_termination_action"`
-	MinNodeCpus               *Value[int64]                                            `tf:"min_node_cpus"`
-	OnHostMaintenance         *Value[string]                                           `tf:"on_host_maintenance"`
-	Preemptible               *Value[bool]                                             `tf:"preemptible"`
-	ProvisioningModel         *Value[string]                                           `tf:"provisioning_model"`
-	LocalSsdRecoveryTimeout   []GoogleComputeInstanceSchedulingLocalSsdRecoveryTimeout `tf:"local_ssd_recovery_timeout,blocks"`
-	MaxRunDuration            []GoogleComputeInstanceSchedulingMaxRunDuration          `tf:"max_run_duration,blocks"`
-	NodeAffinities            []GoogleComputeInstanceSchedulingNodeAffinities          `tf:"node_affinities,blocks"`
-	OnInstanceStopAction      []GoogleComputeInstanceSchedulingOnInstanceStopAction    `tf:"on_instance_stop_action,blocks"`
+	AutomaticRestart          *Value[bool]                                             `tf:"automatic_restart" json:"automatic_restart,omitempty"`
+	InstanceTerminationAction *Value[string]                                           `tf:"instance_termination_action" json:"instance_termination_action,omitempty"`
+	MinNodeCpus               *Value[int64]                                            `tf:"min_node_cpus" json:"min_node_cpus,omitempty"`
+	OnHostMaintenance         *Value[string]                                           `tf:"on_host_maintenance" json:"on_host_maintenance,omitempty"`
+	Preemptible               *Value[bool]                                             `tf:"preemptible" json:"preemptible,omitempty"`
+	ProvisioningModel         *Value[string]                                           `tf:"provisioning_model" json:"provisioning_model,omitempty"`
+	LocalSsdRecoveryTimeout   []GoogleComputeInstanceSchedulingLocalSsdRecoveryTimeout `tf:"local_ssd_recovery_timeout,blocks" json:"local_ssd_recovery_timeout,omitempty"`
+	MaxRunDuration            []GoogleComputeInstanceSchedulingMaxRunDuration          `tf:"max_run_duration,blocks" json:"max_run_duration,omitempty"`
+	NodeAffinities            []GoogleComputeInstanceSchedulingNodeAffinities          `tf:"node_affinities,blocks" json:"node_affinities,omitempty"`
+	OnInstanceStopAction      []GoogleComputeInstanceSchedulingOnInstanceStopAction    `tf:"on_instance_stop_action,blocks" json:"on_instance_stop_action,omitempty"`
 }
 
 // GoogleComputeInstanceSchedulingLocalSsdRecoveryTimeout is a nested-block type used by the parent resource.
 type GoogleComputeInstanceSchedulingLocalSsdRecoveryTimeout struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[float64] `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[float64] `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeInstanceSchedulingMaxRunDuration is a nested-block type used by the parent resource.
 type GoogleComputeInstanceSchedulingMaxRunDuration struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[float64] `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[float64] `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeInstanceSchedulingNodeAffinities is a nested-block type used by the parent resource.
 type GoogleComputeInstanceSchedulingNodeAffinities struct {
-	Key      *Value[string]   `tf:"key"`
-	Operator *Value[string]   `tf:"operator"`
-	Values   []*Value[string] `tf:"values"`
+	Key      *Value[string]   `tf:"key" json:"key,omitempty"`
+	Operator *Value[string]   `tf:"operator" json:"operator,omitempty"`
+	Values   []*Value[string] `tf:"values" json:"values,omitempty"`
 }
 
 // GoogleComputeInstanceSchedulingOnInstanceStopAction is a nested-block type used by the parent resource.
 type GoogleComputeInstanceSchedulingOnInstanceStopAction struct {
-	DiscardLocalSsd *Value[bool] `tf:"discard_local_ssd"`
+	DiscardLocalSsd *Value[bool] `tf:"discard_local_ssd" json:"discard_local_ssd,omitempty"`
 }
 
 // GoogleComputeInstanceScratchDisk is a nested-block type used by the parent resource.
 type GoogleComputeInstanceScratchDisk struct {
-	DeviceName *Value[string]  `tf:"device_name"`
-	Interface_ *Value[string]  `tf:"interface"`
-	Size       *Value[float64] `tf:"size"`
+	DeviceName *Value[string]  `tf:"device_name" json:"device_name,omitempty"`
+	Interface_ *Value[string]  `tf:"interface" json:"interface,omitempty"`
+	Size       *Value[float64] `tf:"size" json:"size,omitempty"`
 }
 
 // GoogleComputeInstanceServiceAccount is a nested-block type used by the parent resource.
 type GoogleComputeInstanceServiceAccount struct {
-	Email  *Value[string]   `tf:"email"`
-	Scopes []*Value[string] `tf:"scopes"`
+	Email  *Value[string]   `tf:"email" json:"email,omitempty"`
+	Scopes []*Value[string] `tf:"scopes" json:"scopes,omitempty"`
 }
 
 // GoogleComputeInstanceShieldedInstanceConfig is a nested-block type used by the parent resource.
 type GoogleComputeInstanceShieldedInstanceConfig struct {
-	EnableIntegrityMonitoring *Value[bool] `tf:"enable_integrity_monitoring"`
-	EnableSecureBoot          *Value[bool] `tf:"enable_secure_boot"`
-	EnableVtpm                *Value[bool] `tf:"enable_vtpm"`
+	EnableIntegrityMonitoring *Value[bool] `tf:"enable_integrity_monitoring" json:"enable_integrity_monitoring,omitempty"`
+	EnableSecureBoot          *Value[bool] `tf:"enable_secure_boot" json:"enable_secure_boot,omitempty"`
+	EnableVtpm                *Value[bool] `tf:"enable_vtpm" json:"enable_vtpm,omitempty"`
 }
 
 // GoogleComputeInstanceTimeouts is a nested-block type used by the parent resource.
 type GoogleComputeInstanceTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleComputeInstanceSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_compute_network.gen.go
+++ b/pkg/composer/imported/generated/google_compute_network.gen.go
@@ -7,28 +7,28 @@ import "reflect"
 // GoogleComputeNetwork is the generated Layer 1 typed model for the
 // `google_compute_network` Terraform resource.
 type GoogleComputeNetwork struct {
-	AutoCreateSubnetworks                 *Value[bool]                  `tf:"auto_create_subnetworks"`
-	DeleteDefaultRoutesOnCreate           *Value[bool]                  `tf:"delete_default_routes_on_create"`
-	Description                           *Value[string]                `tf:"description"`
-	EnableUlaInternalIPV6                 *Value[bool]                  `tf:"enable_ula_internal_ipv6"`
-	GatewayIPV4                           *Value[string]                `tf:"gateway_ipv4"`
-	ID                                    *Value[string]                `tf:"id"`
-	InternalIPV6Range                     *Value[string]                `tf:"internal_ipv6_range"`
-	Mtu                                   *Value[float64]               `tf:"mtu"`
-	Name                                  *Value[string]                `tf:"name"`
-	NetworkFirewallPolicyEnforcementOrder *Value[string]                `tf:"network_firewall_policy_enforcement_order"`
-	NumericID                             *Value[string]                `tf:"numeric_id"`
-	Project                               *Value[string]                `tf:"project"`
-	RoutingMode                           *Value[string]                `tf:"routing_mode"`
-	SelfLink                              *Value[string]                `tf:"self_link"`
-	Timeouts                              *GoogleComputeNetworkTimeouts `tf:"timeouts,block"`
+	AutoCreateSubnetworks                 *Value[bool]                  `tf:"auto_create_subnetworks" json:"auto_create_subnetworks,omitempty"`
+	DeleteDefaultRoutesOnCreate           *Value[bool]                  `tf:"delete_default_routes_on_create" json:"delete_default_routes_on_create,omitempty"`
+	Description                           *Value[string]                `tf:"description" json:"description,omitempty"`
+	EnableUlaInternalIPV6                 *Value[bool]                  `tf:"enable_ula_internal_ipv6" json:"enable_ula_internal_ipv6,omitempty"`
+	GatewayIPV4                           *Value[string]                `tf:"gateway_ipv4" json:"gateway_ipv4,omitempty"`
+	ID                                    *Value[string]                `tf:"id" json:"id,omitempty"`
+	InternalIPV6Range                     *Value[string]                `tf:"internal_ipv6_range" json:"internal_ipv6_range,omitempty"`
+	Mtu                                   *Value[float64]               `tf:"mtu" json:"mtu,omitempty"`
+	Name                                  *Value[string]                `tf:"name" json:"name,omitempty"`
+	NetworkFirewallPolicyEnforcementOrder *Value[string]                `tf:"network_firewall_policy_enforcement_order" json:"network_firewall_policy_enforcement_order,omitempty"`
+	NumericID                             *Value[string]                `tf:"numeric_id" json:"numeric_id,omitempty"`
+	Project                               *Value[string]                `tf:"project" json:"project,omitempty"`
+	RoutingMode                           *Value[string]                `tf:"routing_mode" json:"routing_mode,omitempty"`
+	SelfLink                              *Value[string]                `tf:"self_link" json:"self_link,omitempty"`
+	Timeouts                              *GoogleComputeNetworkTimeouts `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleComputeNetworkTimeouts is a nested-block type used by the parent resource.
 type GoogleComputeNetworkTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleComputeNetworkSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_compute_router.gen.go
+++ b/pkg/composer/imported/generated/google_compute_router.gen.go
@@ -7,40 +7,40 @@ import "reflect"
 // GoogleComputeRouter is the generated Layer 1 typed model for the
 // `google_compute_router` Terraform resource.
 type GoogleComputeRouter struct {
-	CreationTimestamp           *Value[string]               `tf:"creation_timestamp"`
-	Description                 *Value[string]               `tf:"description"`
-	EncryptedInterconnectRouter *Value[bool]                 `tf:"encrypted_interconnect_router"`
-	ID                          *Value[string]               `tf:"id"`
-	Name                        *Value[string]               `tf:"name"`
-	Network                     *Value[string]               `tf:"network"`
-	Project                     *Value[string]               `tf:"project"`
-	Region                      *Value[string]               `tf:"region"`
-	SelfLink                    *Value[string]               `tf:"self_link"`
-	Bgp                         []GoogleComputeRouterBgp     `tf:"bgp,blocks"`
-	Timeouts                    *GoogleComputeRouterTimeouts `tf:"timeouts,block"`
+	CreationTimestamp           *Value[string]               `tf:"creation_timestamp" json:"creation_timestamp,omitempty"`
+	Description                 *Value[string]               `tf:"description" json:"description,omitempty"`
+	EncryptedInterconnectRouter *Value[bool]                 `tf:"encrypted_interconnect_router" json:"encrypted_interconnect_router,omitempty"`
+	ID                          *Value[string]               `tf:"id" json:"id,omitempty"`
+	Name                        *Value[string]               `tf:"name" json:"name,omitempty"`
+	Network                     *Value[string]               `tf:"network" json:"network,omitempty"`
+	Project                     *Value[string]               `tf:"project" json:"project,omitempty"`
+	Region                      *Value[string]               `tf:"region" json:"region,omitempty"`
+	SelfLink                    *Value[string]               `tf:"self_link" json:"self_link,omitempty"`
+	Bgp                         []GoogleComputeRouterBgp     `tf:"bgp,blocks" json:"bgp,omitempty"`
+	Timeouts                    *GoogleComputeRouterTimeouts `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleComputeRouterBgp is a nested-block type used by the parent resource.
 type GoogleComputeRouterBgp struct {
-	AdvertiseMode      *Value[string]                             `tf:"advertise_mode"`
-	AdvertisedGroups   []*Value[string]                           `tf:"advertised_groups"`
-	Asn                *Value[float64]                            `tf:"asn"`
-	IdentifierRange    *Value[string]                             `tf:"identifier_range"`
-	KeepaliveInterval  *Value[float64]                            `tf:"keepalive_interval"`
-	AdvertisedIpRanges []GoogleComputeRouterBgpAdvertisedIpRanges `tf:"advertised_ip_ranges,blocks"`
+	AdvertiseMode      *Value[string]                             `tf:"advertise_mode" json:"advertise_mode,omitempty"`
+	AdvertisedGroups   []*Value[string]                           `tf:"advertised_groups" json:"advertised_groups,omitempty"`
+	Asn                *Value[float64]                            `tf:"asn" json:"asn,omitempty"`
+	IdentifierRange    *Value[string]                             `tf:"identifier_range" json:"identifier_range,omitempty"`
+	KeepaliveInterval  *Value[float64]                            `tf:"keepalive_interval" json:"keepalive_interval,omitempty"`
+	AdvertisedIpRanges []GoogleComputeRouterBgpAdvertisedIpRanges `tf:"advertised_ip_ranges,blocks" json:"advertised_ip_ranges,omitempty"`
 }
 
 // GoogleComputeRouterBgpAdvertisedIpRanges is a nested-block type used by the parent resource.
 type GoogleComputeRouterBgpAdvertisedIpRanges struct {
-	Description *Value[string] `tf:"description"`
-	Range_      *Value[string] `tf:"range"`
+	Description *Value[string] `tf:"description" json:"description,omitempty"`
+	Range_      *Value[string] `tf:"range" json:"range,omitempty"`
 }
 
 // GoogleComputeRouterTimeouts is a nested-block type used by the parent resource.
 type GoogleComputeRouterTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleComputeRouterSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_compute_security_policy.gen.go
+++ b/pkg/composer/imported/generated/google_compute_security_policy.gen.go
@@ -7,142 +7,142 @@ import "reflect"
 // GoogleComputeSecurityPolicy is the generated Layer 1 typed model for the
 // `google_compute_security_policy` Terraform resource.
 type GoogleComputeSecurityPolicy struct {
-	Description              *Value[string]                                        `tf:"description"`
-	Fingerprint              *Value[string]                                        `tf:"fingerprint"`
-	ID                       *Value[string]                                        `tf:"id"`
-	Name                     *Value[string]                                        `tf:"name"`
-	Project                  *Value[string]                                        `tf:"project"`
-	SelfLink                 *Value[string]                                        `tf:"self_link"`
-	Type_                    *Value[string]                                        `tf:"type"`
-	AdaptiveProtectionConfig []GoogleComputeSecurityPolicyAdaptiveProtectionConfig `tf:"adaptive_protection_config,blocks"`
-	AdvancedOptionsConfig    []GoogleComputeSecurityPolicyAdvancedOptionsConfig    `tf:"advanced_options_config,blocks"`
-	RecaptchaOptionsConfig   []GoogleComputeSecurityPolicyRecaptchaOptionsConfig   `tf:"recaptcha_options_config,blocks"`
-	Rule                     []GoogleComputeSecurityPolicyRule                     `tf:"rule,blocks"`
-	Timeouts                 *GoogleComputeSecurityPolicyTimeouts                  `tf:"timeouts,block"`
+	Description              *Value[string]                                        `tf:"description" json:"description,omitempty"`
+	Fingerprint              *Value[string]                                        `tf:"fingerprint" json:"fingerprint,omitempty"`
+	ID                       *Value[string]                                        `tf:"id" json:"id,omitempty"`
+	Name                     *Value[string]                                        `tf:"name" json:"name,omitempty"`
+	Project                  *Value[string]                                        `tf:"project" json:"project,omitempty"`
+	SelfLink                 *Value[string]                                        `tf:"self_link" json:"self_link,omitempty"`
+	Type_                    *Value[string]                                        `tf:"type" json:"type,omitempty"`
+	AdaptiveProtectionConfig []GoogleComputeSecurityPolicyAdaptiveProtectionConfig `tf:"adaptive_protection_config,blocks" json:"adaptive_protection_config,omitempty"`
+	AdvancedOptionsConfig    []GoogleComputeSecurityPolicyAdvancedOptionsConfig    `tf:"advanced_options_config,blocks" json:"advanced_options_config,omitempty"`
+	RecaptchaOptionsConfig   []GoogleComputeSecurityPolicyRecaptchaOptionsConfig   `tf:"recaptcha_options_config,blocks" json:"recaptcha_options_config,omitempty"`
+	Rule                     []GoogleComputeSecurityPolicyRule                     `tf:"rule,blocks" json:"rule,omitempty"`
+	Timeouts                 *GoogleComputeSecurityPolicyTimeouts                  `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyAdaptiveProtectionConfig is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyAdaptiveProtectionConfig struct {
-	Layer7DdosDefenseConfig []GoogleComputeSecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfig `tf:"layer_7_ddos_defense_config,blocks"`
+	Layer7DdosDefenseConfig []GoogleComputeSecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfig `tf:"layer_7_ddos_defense_config,blocks" json:"layer_7_ddos_defense_config,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfig is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfig struct {
-	Enable         *Value[bool]   `tf:"enable"`
-	RuleVisibility *Value[string] `tf:"rule_visibility"`
+	Enable         *Value[bool]   `tf:"enable" json:"enable,omitempty"`
+	RuleVisibility *Value[string] `tf:"rule_visibility" json:"rule_visibility,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyAdvancedOptionsConfig is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyAdvancedOptionsConfig struct {
-	JSONParsing          *Value[string]                                                     `tf:"json_parsing"`
-	LogLevel             *Value[string]                                                     `tf:"log_level"`
-	UserIpRequestHeaders []*Value[string]                                                   `tf:"user_ip_request_headers"`
-	JSONCustomConfig     []GoogleComputeSecurityPolicyAdvancedOptionsConfigJSONCustomConfig `tf:"json_custom_config,blocks"`
+	JSONParsing          *Value[string]                                                     `tf:"json_parsing" json:"json_parsing,omitempty"`
+	LogLevel             *Value[string]                                                     `tf:"log_level" json:"log_level,omitempty"`
+	UserIpRequestHeaders []*Value[string]                                                   `tf:"user_ip_request_headers" json:"user_ip_request_headers,omitempty"`
+	JSONCustomConfig     []GoogleComputeSecurityPolicyAdvancedOptionsConfigJSONCustomConfig `tf:"json_custom_config,blocks" json:"json_custom_config,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyAdvancedOptionsConfigJSONCustomConfig is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyAdvancedOptionsConfigJSONCustomConfig struct {
-	ContentTypes []*Value[string] `tf:"content_types"`
+	ContentTypes []*Value[string] `tf:"content_types" json:"content_types,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRecaptchaOptionsConfig is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRecaptchaOptionsConfig struct {
-	RedirectSiteKey *Value[string] `tf:"redirect_site_key"`
+	RedirectSiteKey *Value[string] `tf:"redirect_site_key" json:"redirect_site_key,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRule is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRule struct {
-	Action           *Value[string]                                    `tf:"action"`
-	Description      *Value[string]                                    `tf:"description"`
-	Preview          *Value[bool]                                      `tf:"preview"`
-	Priority         *Value[float64]                                   `tf:"priority"`
-	HeaderAction     []GoogleComputeSecurityPolicyRuleHeaderAction     `tf:"header_action,blocks"`
-	Match            []GoogleComputeSecurityPolicyRuleMatch            `tf:"match,blocks"`
-	RateLimitOptions []GoogleComputeSecurityPolicyRuleRateLimitOptions `tf:"rate_limit_options,blocks"`
-	RedirectOptions  []GoogleComputeSecurityPolicyRuleRedirectOptions  `tf:"redirect_options,blocks"`
+	Action           *Value[string]                                    `tf:"action" json:"action,omitempty"`
+	Description      *Value[string]                                    `tf:"description" json:"description,omitempty"`
+	Preview          *Value[bool]                                      `tf:"preview" json:"preview,omitempty"`
+	Priority         *Value[float64]                                   `tf:"priority" json:"priority,omitempty"`
+	HeaderAction     []GoogleComputeSecurityPolicyRuleHeaderAction     `tf:"header_action,blocks" json:"header_action,omitempty"`
+	Match            []GoogleComputeSecurityPolicyRuleMatch            `tf:"match,blocks" json:"match,omitempty"`
+	RateLimitOptions []GoogleComputeSecurityPolicyRuleRateLimitOptions `tf:"rate_limit_options,blocks" json:"rate_limit_options,omitempty"`
+	RedirectOptions  []GoogleComputeSecurityPolicyRuleRedirectOptions  `tf:"redirect_options,blocks" json:"redirect_options,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRuleHeaderAction is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRuleHeaderAction struct {
-	RequestHeadersToAdds []GoogleComputeSecurityPolicyRuleHeaderActionRequestHeadersToAdds `tf:"request_headers_to_adds,blocks"`
+	RequestHeadersToAdds []GoogleComputeSecurityPolicyRuleHeaderActionRequestHeadersToAdds `tf:"request_headers_to_adds,blocks" json:"request_headers_to_adds,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRuleHeaderActionRequestHeadersToAdds is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRuleHeaderActionRequestHeadersToAdds struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRuleMatch is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRuleMatch struct {
-	VersionedExpr *Value[string]                                    `tf:"versioned_expr"`
-	Config        []GoogleComputeSecurityPolicyRuleMatchConfig      `tf:"config,blocks"`
-	Expr          []GoogleComputeSecurityPolicyRuleMatchExpr        `tf:"expr,blocks"`
-	ExprOptions   []GoogleComputeSecurityPolicyRuleMatchExprOptions `tf:"expr_options,blocks"`
+	VersionedExpr *Value[string]                                    `tf:"versioned_expr" json:"versioned_expr,omitempty"`
+	Config        []GoogleComputeSecurityPolicyRuleMatchConfig      `tf:"config,blocks" json:"config,omitempty"`
+	Expr          []GoogleComputeSecurityPolicyRuleMatchExpr        `tf:"expr,blocks" json:"expr,omitempty"`
+	ExprOptions   []GoogleComputeSecurityPolicyRuleMatchExprOptions `tf:"expr_options,blocks" json:"expr_options,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRuleMatchConfig is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRuleMatchConfig struct {
-	SrcIpRanges []*Value[string] `tf:"src_ip_ranges"`
+	SrcIpRanges []*Value[string] `tf:"src_ip_ranges" json:"src_ip_ranges,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRuleMatchExpr is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRuleMatchExpr struct {
-	Expression *Value[string] `tf:"expression"`
+	Expression *Value[string] `tf:"expression" json:"expression,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRuleMatchExprOptions is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRuleMatchExprOptions struct {
-	RecaptchaOptions []GoogleComputeSecurityPolicyRuleMatchExprOptionsRecaptchaOptions `tf:"recaptcha_options,blocks"`
+	RecaptchaOptions []GoogleComputeSecurityPolicyRuleMatchExprOptionsRecaptchaOptions `tf:"recaptcha_options,blocks" json:"recaptcha_options,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRuleMatchExprOptionsRecaptchaOptions is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRuleMatchExprOptionsRecaptchaOptions struct {
-	ActionTokenSiteKeys  []*Value[string] `tf:"action_token_site_keys"`
-	SessionTokenSiteKeys []*Value[string] `tf:"session_token_site_keys"`
+	ActionTokenSiteKeys  []*Value[string] `tf:"action_token_site_keys" json:"action_token_site_keys,omitempty"`
+	SessionTokenSiteKeys []*Value[string] `tf:"session_token_site_keys" json:"session_token_site_keys,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRuleRateLimitOptions is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRuleRateLimitOptions struct {
-	BanDurationSec        *Value[float64]                                                        `tf:"ban_duration_sec"`
-	ConformAction         *Value[string]                                                         `tf:"conform_action"`
-	EnforceOnKey          *Value[string]                                                         `tf:"enforce_on_key"`
-	EnforceOnKeyName      *Value[string]                                                         `tf:"enforce_on_key_name"`
-	ExceedAction          *Value[string]                                                         `tf:"exceed_action"`
-	BanThreshold          []GoogleComputeSecurityPolicyRuleRateLimitOptionsBanThreshold          `tf:"ban_threshold,blocks"`
-	ExceedRedirectOptions []GoogleComputeSecurityPolicyRuleRateLimitOptionsExceedRedirectOptions `tf:"exceed_redirect_options,blocks"`
-	RateLimitThreshold    []GoogleComputeSecurityPolicyRuleRateLimitOptionsRateLimitThreshold    `tf:"rate_limit_threshold,blocks"`
+	BanDurationSec        *Value[float64]                                                        `tf:"ban_duration_sec" json:"ban_duration_sec,omitempty"`
+	ConformAction         *Value[string]                                                         `tf:"conform_action" json:"conform_action,omitempty"`
+	EnforceOnKey          *Value[string]                                                         `tf:"enforce_on_key" json:"enforce_on_key,omitempty"`
+	EnforceOnKeyName      *Value[string]                                                         `tf:"enforce_on_key_name" json:"enforce_on_key_name,omitempty"`
+	ExceedAction          *Value[string]                                                         `tf:"exceed_action" json:"exceed_action,omitempty"`
+	BanThreshold          []GoogleComputeSecurityPolicyRuleRateLimitOptionsBanThreshold          `tf:"ban_threshold,blocks" json:"ban_threshold,omitempty"`
+	ExceedRedirectOptions []GoogleComputeSecurityPolicyRuleRateLimitOptionsExceedRedirectOptions `tf:"exceed_redirect_options,blocks" json:"exceed_redirect_options,omitempty"`
+	RateLimitThreshold    []GoogleComputeSecurityPolicyRuleRateLimitOptionsRateLimitThreshold    `tf:"rate_limit_threshold,blocks" json:"rate_limit_threshold,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRuleRateLimitOptionsBanThreshold is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRuleRateLimitOptionsBanThreshold struct {
-	Count       *Value[float64] `tf:"count"`
-	IntervalSec *Value[float64] `tf:"interval_sec"`
+	Count       *Value[float64] `tf:"count" json:"count,omitempty"`
+	IntervalSec *Value[float64] `tf:"interval_sec" json:"interval_sec,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRuleRateLimitOptionsExceedRedirectOptions is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRuleRateLimitOptionsExceedRedirectOptions struct {
-	Target *Value[string] `tf:"target"`
-	Type_  *Value[string] `tf:"type"`
+	Target *Value[string] `tf:"target" json:"target,omitempty"`
+	Type_  *Value[string] `tf:"type" json:"type,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRuleRateLimitOptionsRateLimitThreshold is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRuleRateLimitOptionsRateLimitThreshold struct {
-	Count       *Value[float64] `tf:"count"`
-	IntervalSec *Value[float64] `tf:"interval_sec"`
+	Count       *Value[float64] `tf:"count" json:"count,omitempty"`
+	IntervalSec *Value[float64] `tf:"interval_sec" json:"interval_sec,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyRuleRedirectOptions is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyRuleRedirectOptions struct {
-	Target *Value[string] `tf:"target"`
-	Type_  *Value[string] `tf:"type"`
+	Target *Value[string] `tf:"target" json:"target,omitempty"`
+	Type_  *Value[string] `tf:"type" json:"type,omitempty"`
 }
 
 // GoogleComputeSecurityPolicyTimeouts is a nested-block type used by the parent resource.
 type GoogleComputeSecurityPolicyTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleComputeSecurityPolicySchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_compute_target_https_proxy.gen.go
+++ b/pkg/composer/imported/generated/google_compute_target_https_proxy.gen.go
@@ -7,31 +7,31 @@ import "reflect"
 // GoogleComputeTargetHTTPSProxy is the generated Layer 1 typed model for the
 // `google_compute_target_https_proxy` Terraform resource.
 type GoogleComputeTargetHTTPSProxy struct {
-	CertificateManagerCertificates []*Value[string]                       `tf:"certificate_manager_certificates"`
-	CertificateMap                 *Value[string]                         `tf:"certificate_map"`
-	CreationTimestamp              *Value[string]                         `tf:"creation_timestamp"`
-	Description                    *Value[string]                         `tf:"description"`
-	HTTPKeepAliveTimeoutSec        *Value[float64]                        `tf:"http_keep_alive_timeout_sec"`
-	ID                             *Value[string]                         `tf:"id"`
-	Name                           *Value[string]                         `tf:"name"`
-	Project                        *Value[string]                         `tf:"project"`
-	ProxyBind                      *Value[bool]                           `tf:"proxy_bind"`
-	ProxyID                        *Value[float64]                        `tf:"proxy_id"`
-	QuicOverride                   *Value[string]                         `tf:"quic_override"`
-	SelfLink                       *Value[string]                         `tf:"self_link"`
-	ServerTLSPolicy                *Value[string]                         `tf:"server_tls_policy"`
-	SSLCertificates                []*Value[string]                       `tf:"ssl_certificates"`
-	SSLPolicy                      *Value[string]                         `tf:"ssl_policy"`
-	TLSEarlyData                   *Value[string]                         `tf:"tls_early_data"`
-	URLMap                         *Value[string]                         `tf:"url_map"`
-	Timeouts                       *GoogleComputeTargetHTTPSProxyTimeouts `tf:"timeouts,block"`
+	CertificateManagerCertificates []*Value[string]                       `tf:"certificate_manager_certificates" json:"certificate_manager_certificates,omitempty"`
+	CertificateMap                 *Value[string]                         `tf:"certificate_map" json:"certificate_map,omitempty"`
+	CreationTimestamp              *Value[string]                         `tf:"creation_timestamp" json:"creation_timestamp,omitempty"`
+	Description                    *Value[string]                         `tf:"description" json:"description,omitempty"`
+	HTTPKeepAliveTimeoutSec        *Value[float64]                        `tf:"http_keep_alive_timeout_sec" json:"http_keep_alive_timeout_sec,omitempty"`
+	ID                             *Value[string]                         `tf:"id" json:"id,omitempty"`
+	Name                           *Value[string]                         `tf:"name" json:"name,omitempty"`
+	Project                        *Value[string]                         `tf:"project" json:"project,omitempty"`
+	ProxyBind                      *Value[bool]                           `tf:"proxy_bind" json:"proxy_bind,omitempty"`
+	ProxyID                        *Value[float64]                        `tf:"proxy_id" json:"proxy_id,omitempty"`
+	QuicOverride                   *Value[string]                         `tf:"quic_override" json:"quic_override,omitempty"`
+	SelfLink                       *Value[string]                         `tf:"self_link" json:"self_link,omitempty"`
+	ServerTLSPolicy                *Value[string]                         `tf:"server_tls_policy" json:"server_tls_policy,omitempty"`
+	SSLCertificates                []*Value[string]                       `tf:"ssl_certificates" json:"ssl_certificates,omitempty"`
+	SSLPolicy                      *Value[string]                         `tf:"ssl_policy" json:"ssl_policy,omitempty"`
+	TLSEarlyData                   *Value[string]                         `tf:"tls_early_data" json:"tls_early_data,omitempty"`
+	URLMap                         *Value[string]                         `tf:"url_map" json:"url_map,omitempty"`
+	Timeouts                       *GoogleComputeTargetHTTPSProxyTimeouts `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleComputeTargetHTTPSProxyTimeouts is a nested-block type used by the parent resource.
 type GoogleComputeTargetHTTPSProxyTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleComputeTargetHTTPSProxySchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_compute_url_map.gen.go
+++ b/pkg/composer/imported/generated/google_compute_url_map.gen.go
@@ -7,655 +7,655 @@ import "reflect"
 // GoogleComputeURLMap is the generated Layer 1 typed model for the
 // `google_compute_url_map` Terraform resource.
 type GoogleComputeURLMap struct {
-	CreationTimestamp  *Value[string]                          `tf:"creation_timestamp"`
-	DefaultService     *Value[string]                          `tf:"default_service"`
-	Description        *Value[string]                          `tf:"description"`
-	Fingerprint        *Value[string]                          `tf:"fingerprint"`
-	ID                 *Value[string]                          `tf:"id"`
-	MapID              *Value[float64]                         `tf:"map_id"`
-	Name               *Value[string]                          `tf:"name"`
-	Project            *Value[string]                          `tf:"project"`
-	SelfLink           *Value[string]                          `tf:"self_link"`
-	DefaultRouteAction []GoogleComputeURLMapDefaultRouteAction `tf:"default_route_action,blocks"`
-	DefaultURLRedirect []GoogleComputeURLMapDefaultURLRedirect `tf:"default_url_redirect,blocks"`
-	HeaderAction       []GoogleComputeURLMapHeaderAction       `tf:"header_action,blocks"`
-	HostRule           []GoogleComputeURLMapHostRule           `tf:"host_rule,blocks"`
-	PathMatcher        []GoogleComputeURLMapPathMatcher        `tf:"path_matcher,blocks"`
-	Test               []GoogleComputeURLMapTest               `tf:"test,blocks"`
-	Timeouts           *GoogleComputeURLMapTimeouts            `tf:"timeouts,block"`
+	CreationTimestamp  *Value[string]                          `tf:"creation_timestamp" json:"creation_timestamp,omitempty"`
+	DefaultService     *Value[string]                          `tf:"default_service" json:"default_service,omitempty"`
+	Description        *Value[string]                          `tf:"description" json:"description,omitempty"`
+	Fingerprint        *Value[string]                          `tf:"fingerprint" json:"fingerprint,omitempty"`
+	ID                 *Value[string]                          `tf:"id" json:"id,omitempty"`
+	MapID              *Value[float64]                         `tf:"map_id" json:"map_id,omitempty"`
+	Name               *Value[string]                          `tf:"name" json:"name,omitempty"`
+	Project            *Value[string]                          `tf:"project" json:"project,omitempty"`
+	SelfLink           *Value[string]                          `tf:"self_link" json:"self_link,omitempty"`
+	DefaultRouteAction []GoogleComputeURLMapDefaultRouteAction `tf:"default_route_action,blocks" json:"default_route_action,omitempty"`
+	DefaultURLRedirect []GoogleComputeURLMapDefaultURLRedirect `tf:"default_url_redirect,blocks" json:"default_url_redirect,omitempty"`
+	HeaderAction       []GoogleComputeURLMapHeaderAction       `tf:"header_action,blocks" json:"header_action,omitempty"`
+	HostRule           []GoogleComputeURLMapHostRule           `tf:"host_rule,blocks" json:"host_rule,omitempty"`
+	PathMatcher        []GoogleComputeURLMapPathMatcher        `tf:"path_matcher,blocks" json:"path_matcher,omitempty"`
+	Test               []GoogleComputeURLMapTest               `tf:"test,blocks" json:"test,omitempty"`
+	Timeouts           *GoogleComputeURLMapTimeouts            `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteAction is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteAction struct {
-	CorsPolicy              []GoogleComputeURLMapDefaultRouteActionCorsPolicy              `tf:"cors_policy,blocks"`
-	FaultInjectionPolicy    []GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicy    `tf:"fault_injection_policy,blocks"`
-	RequestMirrorPolicy     []GoogleComputeURLMapDefaultRouteActionRequestMirrorPolicy     `tf:"request_mirror_policy,blocks"`
-	RetryPolicy             []GoogleComputeURLMapDefaultRouteActionRetryPolicy             `tf:"retry_policy,blocks"`
-	Timeout                 []GoogleComputeURLMapDefaultRouteActionTimeout                 `tf:"timeout,blocks"`
-	URLRewrite              []GoogleComputeURLMapDefaultRouteActionURLRewrite              `tf:"url_rewrite,blocks"`
-	WeightedBackendServices []GoogleComputeURLMapDefaultRouteActionWeightedBackendServices `tf:"weighted_backend_services,blocks"`
+	CorsPolicy              []GoogleComputeURLMapDefaultRouteActionCorsPolicy              `tf:"cors_policy,blocks" json:"cors_policy,omitempty"`
+	FaultInjectionPolicy    []GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicy    `tf:"fault_injection_policy,blocks" json:"fault_injection_policy,omitempty"`
+	RequestMirrorPolicy     []GoogleComputeURLMapDefaultRouteActionRequestMirrorPolicy     `tf:"request_mirror_policy,blocks" json:"request_mirror_policy,omitempty"`
+	RetryPolicy             []GoogleComputeURLMapDefaultRouteActionRetryPolicy             `tf:"retry_policy,blocks" json:"retry_policy,omitempty"`
+	Timeout                 []GoogleComputeURLMapDefaultRouteActionTimeout                 `tf:"timeout,blocks" json:"timeout,omitempty"`
+	URLRewrite              []GoogleComputeURLMapDefaultRouteActionURLRewrite              `tf:"url_rewrite,blocks" json:"url_rewrite,omitempty"`
+	WeightedBackendServices []GoogleComputeURLMapDefaultRouteActionWeightedBackendServices `tf:"weighted_backend_services,blocks" json:"weighted_backend_services,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionCorsPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionCorsPolicy struct {
-	AllowCredentials   *Value[bool]     `tf:"allow_credentials"`
-	AllowHeaders       []*Value[string] `tf:"allow_headers"`
-	AllowMethods       []*Value[string] `tf:"allow_methods"`
-	AllowOriginRegexes []*Value[string] `tf:"allow_origin_regexes"`
-	AllowOrigins       []*Value[string] `tf:"allow_origins"`
-	Disabled           *Value[bool]     `tf:"disabled"`
-	ExposeHeaders      []*Value[string] `tf:"expose_headers"`
-	MaxAge             *Value[int64]    `tf:"max_age"`
+	AllowCredentials   *Value[bool]     `tf:"allow_credentials" json:"allow_credentials,omitempty"`
+	AllowHeaders       []*Value[string] `tf:"allow_headers" json:"allow_headers,omitempty"`
+	AllowMethods       []*Value[string] `tf:"allow_methods" json:"allow_methods,omitempty"`
+	AllowOriginRegexes []*Value[string] `tf:"allow_origin_regexes" json:"allow_origin_regexes,omitempty"`
+	AllowOrigins       []*Value[string] `tf:"allow_origins" json:"allow_origins,omitempty"`
+	Disabled           *Value[bool]     `tf:"disabled" json:"disabled,omitempty"`
+	ExposeHeaders      []*Value[string] `tf:"expose_headers" json:"expose_headers,omitempty"`
+	MaxAge             *Value[int64]    `tf:"max_age" json:"max_age,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicy struct {
-	Abort []GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicyAbort `tf:"abort,blocks"`
-	Delay []GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicyDelay `tf:"delay,blocks"`
+	Abort []GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicyAbort `tf:"abort,blocks" json:"abort,omitempty"`
+	Delay []GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicyDelay `tf:"delay,blocks" json:"delay,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicyAbort is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicyAbort struct {
-	HTTPStatus *Value[float64] `tf:"http_status"`
-	Percentage *Value[float64] `tf:"percentage"`
+	HTTPStatus *Value[float64] `tf:"http_status" json:"http_status,omitempty"`
+	Percentage *Value[float64] `tf:"percentage" json:"percentage,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicyDelay is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicyDelay struct {
-	Percentage *Value[float64]                                                            `tf:"percentage"`
-	FixedDelay []GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicyDelayFixedDelay `tf:"fixed_delay,blocks"`
+	Percentage *Value[float64]                                                            `tf:"percentage" json:"percentage,omitempty"`
+	FixedDelay []GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicyDelayFixedDelay `tf:"fixed_delay,blocks" json:"fixed_delay,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicyDelayFixedDelay is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionFaultInjectionPolicyDelayFixedDelay struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[string]  `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[string]  `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionRequestMirrorPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionRequestMirrorPolicy struct {
-	BackendService *Value[string] `tf:"backend_service"`
+	BackendService *Value[string] `tf:"backend_service" json:"backend_service,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionRetryPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionRetryPolicy struct {
-	NumRetries      *Value[float64]                                                 `tf:"num_retries"`
-	RetryConditions []*Value[string]                                                `tf:"retry_conditions"`
-	PerTryTimeout   []GoogleComputeURLMapDefaultRouteActionRetryPolicyPerTryTimeout `tf:"per_try_timeout,blocks"`
+	NumRetries      *Value[float64]                                                 `tf:"num_retries" json:"num_retries,omitempty"`
+	RetryConditions []*Value[string]                                                `tf:"retry_conditions" json:"retry_conditions,omitempty"`
+	PerTryTimeout   []GoogleComputeURLMapDefaultRouteActionRetryPolicyPerTryTimeout `tf:"per_try_timeout,blocks" json:"per_try_timeout,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionRetryPolicyPerTryTimeout is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionRetryPolicyPerTryTimeout struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[string]  `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[string]  `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionTimeout is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionTimeout struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[string]  `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[string]  `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionURLRewrite is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionURLRewrite struct {
-	HostRewrite       *Value[string] `tf:"host_rewrite"`
-	PathPrefixRewrite *Value[string] `tf:"path_prefix_rewrite"`
+	HostRewrite       *Value[string] `tf:"host_rewrite" json:"host_rewrite,omitempty"`
+	PathPrefixRewrite *Value[string] `tf:"path_prefix_rewrite" json:"path_prefix_rewrite,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionWeightedBackendServices is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionWeightedBackendServices struct {
-	BackendService *Value[string]                                                             `tf:"backend_service"`
-	Weight         *Value[float64]                                                            `tf:"weight"`
-	HeaderAction   []GoogleComputeURLMapDefaultRouteActionWeightedBackendServicesHeaderAction `tf:"header_action,blocks"`
+	BackendService *Value[string]                                                             `tf:"backend_service" json:"backend_service,omitempty"`
+	Weight         *Value[float64]                                                            `tf:"weight" json:"weight,omitempty"`
+	HeaderAction   []GoogleComputeURLMapDefaultRouteActionWeightedBackendServicesHeaderAction `tf:"header_action,blocks" json:"header_action,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionWeightedBackendServicesHeaderAction is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionWeightedBackendServicesHeaderAction struct {
-	RequestHeadersToRemove  []*Value[string]                                                                               `tf:"request_headers_to_remove"`
-	ResponseHeadersToRemove []*Value[string]                                                                               `tf:"response_headers_to_remove"`
-	RequestHeadersToAdd     []GoogleComputeURLMapDefaultRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks"`
-	ResponseHeadersToAdd    []GoogleComputeURLMapDefaultRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks"`
+	RequestHeadersToRemove  []*Value[string]                                                                               `tf:"request_headers_to_remove" json:"request_headers_to_remove,omitempty"`
+	ResponseHeadersToRemove []*Value[string]                                                                               `tf:"response_headers_to_remove" json:"response_headers_to_remove,omitempty"`
+	RequestHeadersToAdd     []GoogleComputeURLMapDefaultRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks" json:"request_headers_to_add,omitempty"`
+	ResponseHeadersToAdd    []GoogleComputeURLMapDefaultRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks" json:"response_headers_to_add,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapDefaultURLRedirect is a nested-block type used by the parent resource.
 type GoogleComputeURLMapDefaultURLRedirect struct {
-	HostRedirect         *Value[string] `tf:"host_redirect"`
-	HTTPSRedirect        *Value[bool]   `tf:"https_redirect"`
-	PathRedirect         *Value[string] `tf:"path_redirect"`
-	PrefixRedirect       *Value[string] `tf:"prefix_redirect"`
-	RedirectResponseCode *Value[string] `tf:"redirect_response_code"`
-	StripQuery           *Value[bool]   `tf:"strip_query"`
+	HostRedirect         *Value[string] `tf:"host_redirect" json:"host_redirect,omitempty"`
+	HTTPSRedirect        *Value[bool]   `tf:"https_redirect" json:"https_redirect,omitempty"`
+	PathRedirect         *Value[string] `tf:"path_redirect" json:"path_redirect,omitempty"`
+	PrefixRedirect       *Value[string] `tf:"prefix_redirect" json:"prefix_redirect,omitempty"`
+	RedirectResponseCode *Value[string] `tf:"redirect_response_code" json:"redirect_response_code,omitempty"`
+	StripQuery           *Value[bool]   `tf:"strip_query" json:"strip_query,omitempty"`
 }
 
 // GoogleComputeURLMapHeaderAction is a nested-block type used by the parent resource.
 type GoogleComputeURLMapHeaderAction struct {
-	RequestHeadersToRemove  []*Value[string]                                      `tf:"request_headers_to_remove"`
-	ResponseHeadersToRemove []*Value[string]                                      `tf:"response_headers_to_remove"`
-	RequestHeadersToAdd     []GoogleComputeURLMapHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks"`
-	ResponseHeadersToAdd    []GoogleComputeURLMapHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks"`
+	RequestHeadersToRemove  []*Value[string]                                      `tf:"request_headers_to_remove" json:"request_headers_to_remove,omitempty"`
+	ResponseHeadersToRemove []*Value[string]                                      `tf:"response_headers_to_remove" json:"response_headers_to_remove,omitempty"`
+	RequestHeadersToAdd     []GoogleComputeURLMapHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks" json:"request_headers_to_add,omitempty"`
+	ResponseHeadersToAdd    []GoogleComputeURLMapHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks" json:"response_headers_to_add,omitempty"`
 }
 
 // GoogleComputeURLMapHeaderActionRequestHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapHeaderActionRequestHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapHeaderActionResponseHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapHeaderActionResponseHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapHostRule is a nested-block type used by the parent resource.
 type GoogleComputeURLMapHostRule struct {
-	Description *Value[string]   `tf:"description"`
-	Hosts       []*Value[string] `tf:"hosts"`
-	PathMatcher *Value[string]   `tf:"path_matcher"`
+	Description *Value[string]   `tf:"description" json:"description,omitempty"`
+	Hosts       []*Value[string] `tf:"hosts" json:"hosts,omitempty"`
+	PathMatcher *Value[string]   `tf:"path_matcher" json:"path_matcher,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcher is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcher struct {
-	DefaultService     *Value[string]                                     `tf:"default_service"`
-	Description        *Value[string]                                     `tf:"description"`
-	Name               *Value[string]                                     `tf:"name"`
-	DefaultRouteAction []GoogleComputeURLMapPathMatcherDefaultRouteAction `tf:"default_route_action,blocks"`
-	DefaultURLRedirect []GoogleComputeURLMapPathMatcherDefaultURLRedirect `tf:"default_url_redirect,blocks"`
-	HeaderAction       []GoogleComputeURLMapPathMatcherHeaderAction       `tf:"header_action,blocks"`
-	PathRule           []GoogleComputeURLMapPathMatcherPathRule           `tf:"path_rule,blocks"`
-	RouteRules         []GoogleComputeURLMapPathMatcherRouteRules         `tf:"route_rules,blocks"`
+	DefaultService     *Value[string]                                     `tf:"default_service" json:"default_service,omitempty"`
+	Description        *Value[string]                                     `tf:"description" json:"description,omitempty"`
+	Name               *Value[string]                                     `tf:"name" json:"name,omitempty"`
+	DefaultRouteAction []GoogleComputeURLMapPathMatcherDefaultRouteAction `tf:"default_route_action,blocks" json:"default_route_action,omitempty"`
+	DefaultURLRedirect []GoogleComputeURLMapPathMatcherDefaultURLRedirect `tf:"default_url_redirect,blocks" json:"default_url_redirect,omitempty"`
+	HeaderAction       []GoogleComputeURLMapPathMatcherHeaderAction       `tf:"header_action,blocks" json:"header_action,omitempty"`
+	PathRule           []GoogleComputeURLMapPathMatcherPathRule           `tf:"path_rule,blocks" json:"path_rule,omitempty"`
+	RouteRules         []GoogleComputeURLMapPathMatcherRouteRules         `tf:"route_rules,blocks" json:"route_rules,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteAction is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteAction struct {
-	CorsPolicy              []GoogleComputeURLMapPathMatcherDefaultRouteActionCorsPolicy              `tf:"cors_policy,blocks"`
-	FaultInjectionPolicy    []GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicy    `tf:"fault_injection_policy,blocks"`
-	RequestMirrorPolicy     []GoogleComputeURLMapPathMatcherDefaultRouteActionRequestMirrorPolicy     `tf:"request_mirror_policy,blocks"`
-	RetryPolicy             []GoogleComputeURLMapPathMatcherDefaultRouteActionRetryPolicy             `tf:"retry_policy,blocks"`
-	Timeout                 []GoogleComputeURLMapPathMatcherDefaultRouteActionTimeout                 `tf:"timeout,blocks"`
-	URLRewrite              []GoogleComputeURLMapPathMatcherDefaultRouteActionURLRewrite              `tf:"url_rewrite,blocks"`
-	WeightedBackendServices []GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServices `tf:"weighted_backend_services,blocks"`
+	CorsPolicy              []GoogleComputeURLMapPathMatcherDefaultRouteActionCorsPolicy              `tf:"cors_policy,blocks" json:"cors_policy,omitempty"`
+	FaultInjectionPolicy    []GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicy    `tf:"fault_injection_policy,blocks" json:"fault_injection_policy,omitempty"`
+	RequestMirrorPolicy     []GoogleComputeURLMapPathMatcherDefaultRouteActionRequestMirrorPolicy     `tf:"request_mirror_policy,blocks" json:"request_mirror_policy,omitempty"`
+	RetryPolicy             []GoogleComputeURLMapPathMatcherDefaultRouteActionRetryPolicy             `tf:"retry_policy,blocks" json:"retry_policy,omitempty"`
+	Timeout                 []GoogleComputeURLMapPathMatcherDefaultRouteActionTimeout                 `tf:"timeout,blocks" json:"timeout,omitempty"`
+	URLRewrite              []GoogleComputeURLMapPathMatcherDefaultRouteActionURLRewrite              `tf:"url_rewrite,blocks" json:"url_rewrite,omitempty"`
+	WeightedBackendServices []GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServices `tf:"weighted_backend_services,blocks" json:"weighted_backend_services,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionCorsPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionCorsPolicy struct {
-	AllowCredentials   *Value[bool]     `tf:"allow_credentials"`
-	AllowHeaders       []*Value[string] `tf:"allow_headers"`
-	AllowMethods       []*Value[string] `tf:"allow_methods"`
-	AllowOriginRegexes []*Value[string] `tf:"allow_origin_regexes"`
-	AllowOrigins       []*Value[string] `tf:"allow_origins"`
-	Disabled           *Value[bool]     `tf:"disabled"`
-	ExposeHeaders      []*Value[string] `tf:"expose_headers"`
-	MaxAge             *Value[int64]    `tf:"max_age"`
+	AllowCredentials   *Value[bool]     `tf:"allow_credentials" json:"allow_credentials,omitempty"`
+	AllowHeaders       []*Value[string] `tf:"allow_headers" json:"allow_headers,omitempty"`
+	AllowMethods       []*Value[string] `tf:"allow_methods" json:"allow_methods,omitempty"`
+	AllowOriginRegexes []*Value[string] `tf:"allow_origin_regexes" json:"allow_origin_regexes,omitempty"`
+	AllowOrigins       []*Value[string] `tf:"allow_origins" json:"allow_origins,omitempty"`
+	Disabled           *Value[bool]     `tf:"disabled" json:"disabled,omitempty"`
+	ExposeHeaders      []*Value[string] `tf:"expose_headers" json:"expose_headers,omitempty"`
+	MaxAge             *Value[int64]    `tf:"max_age" json:"max_age,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicy struct {
-	Abort []GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicyAbort `tf:"abort,blocks"`
-	Delay []GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicyDelay `tf:"delay,blocks"`
+	Abort []GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicyAbort `tf:"abort,blocks" json:"abort,omitempty"`
+	Delay []GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicyDelay `tf:"delay,blocks" json:"delay,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicyAbort is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicyAbort struct {
-	HTTPStatus *Value[float64] `tf:"http_status"`
-	Percentage *Value[float64] `tf:"percentage"`
+	HTTPStatus *Value[float64] `tf:"http_status" json:"http_status,omitempty"`
+	Percentage *Value[float64] `tf:"percentage" json:"percentage,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicyDelay is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicyDelay struct {
-	Percentage *Value[float64]                                                                       `tf:"percentage"`
-	FixedDelay []GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicyDelayFixedDelay `tf:"fixed_delay,blocks"`
+	Percentage *Value[float64]                                                                       `tf:"percentage" json:"percentage,omitempty"`
+	FixedDelay []GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicyDelayFixedDelay `tf:"fixed_delay,blocks" json:"fixed_delay,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicyDelayFixedDelay is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionFaultInjectionPolicyDelayFixedDelay struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[string]  `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[string]  `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionRequestMirrorPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionRequestMirrorPolicy struct {
-	BackendService *Value[string] `tf:"backend_service"`
+	BackendService *Value[string] `tf:"backend_service" json:"backend_service,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionRetryPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionRetryPolicy struct {
-	NumRetries      *Value[float64]                                                            `tf:"num_retries"`
-	RetryConditions []*Value[string]                                                           `tf:"retry_conditions"`
-	PerTryTimeout   []GoogleComputeURLMapPathMatcherDefaultRouteActionRetryPolicyPerTryTimeout `tf:"per_try_timeout,blocks"`
+	NumRetries      *Value[float64]                                                            `tf:"num_retries" json:"num_retries,omitempty"`
+	RetryConditions []*Value[string]                                                           `tf:"retry_conditions" json:"retry_conditions,omitempty"`
+	PerTryTimeout   []GoogleComputeURLMapPathMatcherDefaultRouteActionRetryPolicyPerTryTimeout `tf:"per_try_timeout,blocks" json:"per_try_timeout,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionRetryPolicyPerTryTimeout is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionRetryPolicyPerTryTimeout struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[string]  `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[string]  `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionTimeout is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionTimeout struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[string]  `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[string]  `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionURLRewrite is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionURLRewrite struct {
-	HostRewrite       *Value[string] `tf:"host_rewrite"`
-	PathPrefixRewrite *Value[string] `tf:"path_prefix_rewrite"`
+	HostRewrite       *Value[string] `tf:"host_rewrite" json:"host_rewrite,omitempty"`
+	PathPrefixRewrite *Value[string] `tf:"path_prefix_rewrite" json:"path_prefix_rewrite,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServices is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServices struct {
-	BackendService *Value[string]                                                                        `tf:"backend_service"`
-	Weight         *Value[float64]                                                                       `tf:"weight"`
-	HeaderAction   []GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServicesHeaderAction `tf:"header_action,blocks"`
+	BackendService *Value[string]                                                                        `tf:"backend_service" json:"backend_service,omitempty"`
+	Weight         *Value[float64]                                                                       `tf:"weight" json:"weight,omitempty"`
+	HeaderAction   []GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServicesHeaderAction `tf:"header_action,blocks" json:"header_action,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServicesHeaderAction is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServicesHeaderAction struct {
-	RequestHeadersToRemove  []*Value[string]                                                                                          `tf:"request_headers_to_remove"`
-	ResponseHeadersToRemove []*Value[string]                                                                                          `tf:"response_headers_to_remove"`
-	RequestHeadersToAdd     []GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks"`
-	ResponseHeadersToAdd    []GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks"`
+	RequestHeadersToRemove  []*Value[string]                                                                                          `tf:"request_headers_to_remove" json:"request_headers_to_remove,omitempty"`
+	ResponseHeadersToRemove []*Value[string]                                                                                          `tf:"response_headers_to_remove" json:"response_headers_to_remove,omitempty"`
+	RequestHeadersToAdd     []GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks" json:"request_headers_to_add,omitempty"`
+	ResponseHeadersToAdd    []GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks" json:"response_headers_to_add,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherDefaultURLRedirect is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherDefaultURLRedirect struct {
-	HostRedirect         *Value[string] `tf:"host_redirect"`
-	HTTPSRedirect        *Value[bool]   `tf:"https_redirect"`
-	PathRedirect         *Value[string] `tf:"path_redirect"`
-	PrefixRedirect       *Value[string] `tf:"prefix_redirect"`
-	RedirectResponseCode *Value[string] `tf:"redirect_response_code"`
-	StripQuery           *Value[bool]   `tf:"strip_query"`
+	HostRedirect         *Value[string] `tf:"host_redirect" json:"host_redirect,omitempty"`
+	HTTPSRedirect        *Value[bool]   `tf:"https_redirect" json:"https_redirect,omitempty"`
+	PathRedirect         *Value[string] `tf:"path_redirect" json:"path_redirect,omitempty"`
+	PrefixRedirect       *Value[string] `tf:"prefix_redirect" json:"prefix_redirect,omitempty"`
+	RedirectResponseCode *Value[string] `tf:"redirect_response_code" json:"redirect_response_code,omitempty"`
+	StripQuery           *Value[bool]   `tf:"strip_query" json:"strip_query,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherHeaderAction is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherHeaderAction struct {
-	RequestHeadersToRemove  []*Value[string]                                                 `tf:"request_headers_to_remove"`
-	ResponseHeadersToRemove []*Value[string]                                                 `tf:"response_headers_to_remove"`
-	RequestHeadersToAdd     []GoogleComputeURLMapPathMatcherHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks"`
-	ResponseHeadersToAdd    []GoogleComputeURLMapPathMatcherHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks"`
+	RequestHeadersToRemove  []*Value[string]                                                 `tf:"request_headers_to_remove" json:"request_headers_to_remove,omitempty"`
+	ResponseHeadersToRemove []*Value[string]                                                 `tf:"response_headers_to_remove" json:"response_headers_to_remove,omitempty"`
+	RequestHeadersToAdd     []GoogleComputeURLMapPathMatcherHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks" json:"request_headers_to_add,omitempty"`
+	ResponseHeadersToAdd    []GoogleComputeURLMapPathMatcherHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks" json:"response_headers_to_add,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherHeaderActionRequestHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherHeaderActionRequestHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherHeaderActionResponseHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherHeaderActionResponseHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRule is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRule struct {
-	Paths       []*Value[string]                                    `tf:"paths"`
-	Service     *Value[string]                                      `tf:"service"`
-	RouteAction []GoogleComputeURLMapPathMatcherPathRuleRouteAction `tf:"route_action,blocks"`
-	URLRedirect []GoogleComputeURLMapPathMatcherPathRuleURLRedirect `tf:"url_redirect,blocks"`
+	Paths       []*Value[string]                                    `tf:"paths" json:"paths,omitempty"`
+	Service     *Value[string]                                      `tf:"service" json:"service,omitempty"`
+	RouteAction []GoogleComputeURLMapPathMatcherPathRuleRouteAction `tf:"route_action,blocks" json:"route_action,omitempty"`
+	URLRedirect []GoogleComputeURLMapPathMatcherPathRuleURLRedirect `tf:"url_redirect,blocks" json:"url_redirect,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteAction is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteAction struct {
-	CorsPolicy              []GoogleComputeURLMapPathMatcherPathRuleRouteActionCorsPolicy              `tf:"cors_policy,blocks"`
-	FaultInjectionPolicy    []GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicy    `tf:"fault_injection_policy,blocks"`
-	RequestMirrorPolicy     []GoogleComputeURLMapPathMatcherPathRuleRouteActionRequestMirrorPolicy     `tf:"request_mirror_policy,blocks"`
-	RetryPolicy             []GoogleComputeURLMapPathMatcherPathRuleRouteActionRetryPolicy             `tf:"retry_policy,blocks"`
-	Timeout                 []GoogleComputeURLMapPathMatcherPathRuleRouteActionTimeout                 `tf:"timeout,blocks"`
-	URLRewrite              []GoogleComputeURLMapPathMatcherPathRuleRouteActionURLRewrite              `tf:"url_rewrite,blocks"`
-	WeightedBackendServices []GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServices `tf:"weighted_backend_services,blocks"`
+	CorsPolicy              []GoogleComputeURLMapPathMatcherPathRuleRouteActionCorsPolicy              `tf:"cors_policy,blocks" json:"cors_policy,omitempty"`
+	FaultInjectionPolicy    []GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicy    `tf:"fault_injection_policy,blocks" json:"fault_injection_policy,omitempty"`
+	RequestMirrorPolicy     []GoogleComputeURLMapPathMatcherPathRuleRouteActionRequestMirrorPolicy     `tf:"request_mirror_policy,blocks" json:"request_mirror_policy,omitempty"`
+	RetryPolicy             []GoogleComputeURLMapPathMatcherPathRuleRouteActionRetryPolicy             `tf:"retry_policy,blocks" json:"retry_policy,omitempty"`
+	Timeout                 []GoogleComputeURLMapPathMatcherPathRuleRouteActionTimeout                 `tf:"timeout,blocks" json:"timeout,omitempty"`
+	URLRewrite              []GoogleComputeURLMapPathMatcherPathRuleRouteActionURLRewrite              `tf:"url_rewrite,blocks" json:"url_rewrite,omitempty"`
+	WeightedBackendServices []GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServices `tf:"weighted_backend_services,blocks" json:"weighted_backend_services,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionCorsPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionCorsPolicy struct {
-	AllowCredentials   *Value[bool]     `tf:"allow_credentials"`
-	AllowHeaders       []*Value[string] `tf:"allow_headers"`
-	AllowMethods       []*Value[string] `tf:"allow_methods"`
-	AllowOriginRegexes []*Value[string] `tf:"allow_origin_regexes"`
-	AllowOrigins       []*Value[string] `tf:"allow_origins"`
-	Disabled           *Value[bool]     `tf:"disabled"`
-	ExposeHeaders      []*Value[string] `tf:"expose_headers"`
-	MaxAge             *Value[int64]    `tf:"max_age"`
+	AllowCredentials   *Value[bool]     `tf:"allow_credentials" json:"allow_credentials,omitempty"`
+	AllowHeaders       []*Value[string] `tf:"allow_headers" json:"allow_headers,omitempty"`
+	AllowMethods       []*Value[string] `tf:"allow_methods" json:"allow_methods,omitempty"`
+	AllowOriginRegexes []*Value[string] `tf:"allow_origin_regexes" json:"allow_origin_regexes,omitempty"`
+	AllowOrigins       []*Value[string] `tf:"allow_origins" json:"allow_origins,omitempty"`
+	Disabled           *Value[bool]     `tf:"disabled" json:"disabled,omitempty"`
+	ExposeHeaders      []*Value[string] `tf:"expose_headers" json:"expose_headers,omitempty"`
+	MaxAge             *Value[int64]    `tf:"max_age" json:"max_age,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicy struct {
-	Abort []GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicyAbort `tf:"abort,blocks"`
-	Delay []GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicyDelay `tf:"delay,blocks"`
+	Abort []GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicyAbort `tf:"abort,blocks" json:"abort,omitempty"`
+	Delay []GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicyDelay `tf:"delay,blocks" json:"delay,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicyAbort is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicyAbort struct {
-	HTTPStatus *Value[float64] `tf:"http_status"`
-	Percentage *Value[float64] `tf:"percentage"`
+	HTTPStatus *Value[float64] `tf:"http_status" json:"http_status,omitempty"`
+	Percentage *Value[float64] `tf:"percentage" json:"percentage,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicyDelay is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicyDelay struct {
-	Percentage *Value[float64]                                                                        `tf:"percentage"`
-	FixedDelay []GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicyDelayFixedDelay `tf:"fixed_delay,blocks"`
+	Percentage *Value[float64]                                                                        `tf:"percentage" json:"percentage,omitempty"`
+	FixedDelay []GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicyDelayFixedDelay `tf:"fixed_delay,blocks" json:"fixed_delay,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicyDelayFixedDelay is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionFaultInjectionPolicyDelayFixedDelay struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[string]  `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[string]  `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionRequestMirrorPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionRequestMirrorPolicy struct {
-	BackendService *Value[string] `tf:"backend_service"`
+	BackendService *Value[string] `tf:"backend_service" json:"backend_service,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionRetryPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionRetryPolicy struct {
-	NumRetries      *Value[float64]                                                             `tf:"num_retries"`
-	RetryConditions []*Value[string]                                                            `tf:"retry_conditions"`
-	PerTryTimeout   []GoogleComputeURLMapPathMatcherPathRuleRouteActionRetryPolicyPerTryTimeout `tf:"per_try_timeout,blocks"`
+	NumRetries      *Value[float64]                                                             `tf:"num_retries" json:"num_retries,omitempty"`
+	RetryConditions []*Value[string]                                                            `tf:"retry_conditions" json:"retry_conditions,omitempty"`
+	PerTryTimeout   []GoogleComputeURLMapPathMatcherPathRuleRouteActionRetryPolicyPerTryTimeout `tf:"per_try_timeout,blocks" json:"per_try_timeout,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionRetryPolicyPerTryTimeout is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionRetryPolicyPerTryTimeout struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[string]  `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[string]  `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionTimeout is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionTimeout struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[string]  `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[string]  `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionURLRewrite is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionURLRewrite struct {
-	HostRewrite       *Value[string] `tf:"host_rewrite"`
-	PathPrefixRewrite *Value[string] `tf:"path_prefix_rewrite"`
+	HostRewrite       *Value[string] `tf:"host_rewrite" json:"host_rewrite,omitempty"`
+	PathPrefixRewrite *Value[string] `tf:"path_prefix_rewrite" json:"path_prefix_rewrite,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServices is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServices struct {
-	BackendService *Value[string]                                                                         `tf:"backend_service"`
-	Weight         *Value[float64]                                                                        `tf:"weight"`
-	HeaderAction   []GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServicesHeaderAction `tf:"header_action,blocks"`
+	BackendService *Value[string]                                                                         `tf:"backend_service" json:"backend_service,omitempty"`
+	Weight         *Value[float64]                                                                        `tf:"weight" json:"weight,omitempty"`
+	HeaderAction   []GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServicesHeaderAction `tf:"header_action,blocks" json:"header_action,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServicesHeaderAction is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServicesHeaderAction struct {
-	RequestHeadersToRemove  []*Value[string]                                                                                           `tf:"request_headers_to_remove"`
-	ResponseHeadersToRemove []*Value[string]                                                                                           `tf:"response_headers_to_remove"`
-	RequestHeadersToAdd     []GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks"`
-	ResponseHeadersToAdd    []GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks"`
+	RequestHeadersToRemove  []*Value[string]                                                                                           `tf:"request_headers_to_remove" json:"request_headers_to_remove,omitempty"`
+	ResponseHeadersToRemove []*Value[string]                                                                                           `tf:"response_headers_to_remove" json:"response_headers_to_remove,omitempty"`
+	RequestHeadersToAdd     []GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks" json:"request_headers_to_add,omitempty"`
+	ResponseHeadersToAdd    []GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks" json:"response_headers_to_add,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherPathRuleURLRedirect is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherPathRuleURLRedirect struct {
-	HostRedirect         *Value[string] `tf:"host_redirect"`
-	HTTPSRedirect        *Value[bool]   `tf:"https_redirect"`
-	PathRedirect         *Value[string] `tf:"path_redirect"`
-	PrefixRedirect       *Value[string] `tf:"prefix_redirect"`
-	RedirectResponseCode *Value[string] `tf:"redirect_response_code"`
-	StripQuery           *Value[bool]   `tf:"strip_query"`
+	HostRedirect         *Value[string] `tf:"host_redirect" json:"host_redirect,omitempty"`
+	HTTPSRedirect        *Value[bool]   `tf:"https_redirect" json:"https_redirect,omitempty"`
+	PathRedirect         *Value[string] `tf:"path_redirect" json:"path_redirect,omitempty"`
+	PrefixRedirect       *Value[string] `tf:"prefix_redirect" json:"prefix_redirect,omitempty"`
+	RedirectResponseCode *Value[string] `tf:"redirect_response_code" json:"redirect_response_code,omitempty"`
+	StripQuery           *Value[bool]   `tf:"strip_query" json:"strip_query,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRules is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRules struct {
-	Priority     *Value[float64]                                        `tf:"priority"`
-	Service      *Value[string]                                         `tf:"service"`
-	HeaderAction []GoogleComputeURLMapPathMatcherRouteRulesHeaderAction `tf:"header_action,blocks"`
-	MatchRules   []GoogleComputeURLMapPathMatcherRouteRulesMatchRules   `tf:"match_rules,blocks"`
-	RouteAction  []GoogleComputeURLMapPathMatcherRouteRulesRouteAction  `tf:"route_action,blocks"`
-	URLRedirect  []GoogleComputeURLMapPathMatcherRouteRulesURLRedirect  `tf:"url_redirect,blocks"`
+	Priority     *Value[float64]                                        `tf:"priority" json:"priority,omitempty"`
+	Service      *Value[string]                                         `tf:"service" json:"service,omitempty"`
+	HeaderAction []GoogleComputeURLMapPathMatcherRouteRulesHeaderAction `tf:"header_action,blocks" json:"header_action,omitempty"`
+	MatchRules   []GoogleComputeURLMapPathMatcherRouteRulesMatchRules   `tf:"match_rules,blocks" json:"match_rules,omitempty"`
+	RouteAction  []GoogleComputeURLMapPathMatcherRouteRulesRouteAction  `tf:"route_action,blocks" json:"route_action,omitempty"`
+	URLRedirect  []GoogleComputeURLMapPathMatcherRouteRulesURLRedirect  `tf:"url_redirect,blocks" json:"url_redirect,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesHeaderAction is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesHeaderAction struct {
-	RequestHeadersToRemove  []*Value[string]                                                           `tf:"request_headers_to_remove"`
-	ResponseHeadersToRemove []*Value[string]                                                           `tf:"response_headers_to_remove"`
-	RequestHeadersToAdd     []GoogleComputeURLMapPathMatcherRouteRulesHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks"`
-	ResponseHeadersToAdd    []GoogleComputeURLMapPathMatcherRouteRulesHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks"`
+	RequestHeadersToRemove  []*Value[string]                                                           `tf:"request_headers_to_remove" json:"request_headers_to_remove,omitempty"`
+	ResponseHeadersToRemove []*Value[string]                                                           `tf:"response_headers_to_remove" json:"response_headers_to_remove,omitempty"`
+	RequestHeadersToAdd     []GoogleComputeURLMapPathMatcherRouteRulesHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks" json:"request_headers_to_add,omitempty"`
+	ResponseHeadersToAdd    []GoogleComputeURLMapPathMatcherRouteRulesHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks" json:"response_headers_to_add,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesHeaderActionRequestHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesHeaderActionRequestHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesHeaderActionResponseHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesHeaderActionResponseHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesMatchRules is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesMatchRules struct {
-	FullPathMatch         *Value[string]                                                            `tf:"full_path_match"`
-	IgnoreCase            *Value[bool]                                                              `tf:"ignore_case"`
-	PathTemplateMatch     *Value[string]                                                            `tf:"path_template_match"`
-	PrefixMatch           *Value[string]                                                            `tf:"prefix_match"`
-	RegexMatch            *Value[string]                                                            `tf:"regex_match"`
-	HeaderMatches         []GoogleComputeURLMapPathMatcherRouteRulesMatchRulesHeaderMatches         `tf:"header_matches,blocks"`
-	MetadataFilters       []GoogleComputeURLMapPathMatcherRouteRulesMatchRulesMetadataFilters       `tf:"metadata_filters,blocks"`
-	QueryParameterMatches []GoogleComputeURLMapPathMatcherRouteRulesMatchRulesQueryParameterMatches `tf:"query_parameter_matches,blocks"`
+	FullPathMatch         *Value[string]                                                            `tf:"full_path_match" json:"full_path_match,omitempty"`
+	IgnoreCase            *Value[bool]                                                              `tf:"ignore_case" json:"ignore_case,omitempty"`
+	PathTemplateMatch     *Value[string]                                                            `tf:"path_template_match" json:"path_template_match,omitempty"`
+	PrefixMatch           *Value[string]                                                            `tf:"prefix_match" json:"prefix_match,omitempty"`
+	RegexMatch            *Value[string]                                                            `tf:"regex_match" json:"regex_match,omitempty"`
+	HeaderMatches         []GoogleComputeURLMapPathMatcherRouteRulesMatchRulesHeaderMatches         `tf:"header_matches,blocks" json:"header_matches,omitempty"`
+	MetadataFilters       []GoogleComputeURLMapPathMatcherRouteRulesMatchRulesMetadataFilters       `tf:"metadata_filters,blocks" json:"metadata_filters,omitempty"`
+	QueryParameterMatches []GoogleComputeURLMapPathMatcherRouteRulesMatchRulesQueryParameterMatches `tf:"query_parameter_matches,blocks" json:"query_parameter_matches,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesMatchRulesHeaderMatches is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesMatchRulesHeaderMatches struct {
-	ExactMatch   *Value[string]                                                              `tf:"exact_match"`
-	HeaderName   *Value[string]                                                              `tf:"header_name"`
-	InvertMatch  *Value[bool]                                                                `tf:"invert_match"`
-	PrefixMatch  *Value[string]                                                              `tf:"prefix_match"`
-	PresentMatch *Value[bool]                                                                `tf:"present_match"`
-	RegexMatch   *Value[string]                                                              `tf:"regex_match"`
-	SuffixMatch  *Value[string]                                                              `tf:"suffix_match"`
-	RangeMatch   []GoogleComputeURLMapPathMatcherRouteRulesMatchRulesHeaderMatchesRangeMatch `tf:"range_match,blocks"`
+	ExactMatch   *Value[string]                                                              `tf:"exact_match" json:"exact_match,omitempty"`
+	HeaderName   *Value[string]                                                              `tf:"header_name" json:"header_name,omitempty"`
+	InvertMatch  *Value[bool]                                                                `tf:"invert_match" json:"invert_match,omitempty"`
+	PrefixMatch  *Value[string]                                                              `tf:"prefix_match" json:"prefix_match,omitempty"`
+	PresentMatch *Value[bool]                                                                `tf:"present_match" json:"present_match,omitempty"`
+	RegexMatch   *Value[string]                                                              `tf:"regex_match" json:"regex_match,omitempty"`
+	SuffixMatch  *Value[string]                                                              `tf:"suffix_match" json:"suffix_match,omitempty"`
+	RangeMatch   []GoogleComputeURLMapPathMatcherRouteRulesMatchRulesHeaderMatchesRangeMatch `tf:"range_match,blocks" json:"range_match,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesMatchRulesHeaderMatchesRangeMatch is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesMatchRulesHeaderMatchesRangeMatch struct {
-	RangeEnd   *Value[float64] `tf:"range_end"`
-	RangeStart *Value[float64] `tf:"range_start"`
+	RangeEnd   *Value[float64] `tf:"range_end" json:"range_end,omitempty"`
+	RangeStart *Value[float64] `tf:"range_start" json:"range_start,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesMatchRulesMetadataFilters is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesMatchRulesMetadataFilters struct {
-	FilterMatchCriteria *Value[string]                                                                  `tf:"filter_match_criteria"`
-	FilterLabels        []GoogleComputeURLMapPathMatcherRouteRulesMatchRulesMetadataFiltersFilterLabels `tf:"filter_labels,blocks"`
+	FilterMatchCriteria *Value[string]                                                                  `tf:"filter_match_criteria" json:"filter_match_criteria,omitempty"`
+	FilterLabels        []GoogleComputeURLMapPathMatcherRouteRulesMatchRulesMetadataFiltersFilterLabels `tf:"filter_labels,blocks" json:"filter_labels,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesMatchRulesMetadataFiltersFilterLabels is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesMatchRulesMetadataFiltersFilterLabels struct {
-	Name  *Value[string] `tf:"name"`
-	Value *Value[string] `tf:"value"`
+	Name  *Value[string] `tf:"name" json:"name,omitempty"`
+	Value *Value[string] `tf:"value" json:"value,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesMatchRulesQueryParameterMatches is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesMatchRulesQueryParameterMatches struct {
-	ExactMatch   *Value[string] `tf:"exact_match"`
-	Name         *Value[string] `tf:"name"`
-	PresentMatch *Value[bool]   `tf:"present_match"`
-	RegexMatch   *Value[string] `tf:"regex_match"`
+	ExactMatch   *Value[string] `tf:"exact_match" json:"exact_match,omitempty"`
+	Name         *Value[string] `tf:"name" json:"name,omitempty"`
+	PresentMatch *Value[bool]   `tf:"present_match" json:"present_match,omitempty"`
+	RegexMatch   *Value[string] `tf:"regex_match" json:"regex_match,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteAction is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteAction struct {
-	CorsPolicy              []GoogleComputeURLMapPathMatcherRouteRulesRouteActionCorsPolicy              `tf:"cors_policy,blocks"`
-	FaultInjectionPolicy    []GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicy    `tf:"fault_injection_policy,blocks"`
-	RequestMirrorPolicy     []GoogleComputeURLMapPathMatcherRouteRulesRouteActionRequestMirrorPolicy     `tf:"request_mirror_policy,blocks"`
-	RetryPolicy             []GoogleComputeURLMapPathMatcherRouteRulesRouteActionRetryPolicy             `tf:"retry_policy,blocks"`
-	Timeout                 []GoogleComputeURLMapPathMatcherRouteRulesRouteActionTimeout                 `tf:"timeout,blocks"`
-	URLRewrite              []GoogleComputeURLMapPathMatcherRouteRulesRouteActionURLRewrite              `tf:"url_rewrite,blocks"`
-	WeightedBackendServices []GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServices `tf:"weighted_backend_services,blocks"`
+	CorsPolicy              []GoogleComputeURLMapPathMatcherRouteRulesRouteActionCorsPolicy              `tf:"cors_policy,blocks" json:"cors_policy,omitempty"`
+	FaultInjectionPolicy    []GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicy    `tf:"fault_injection_policy,blocks" json:"fault_injection_policy,omitempty"`
+	RequestMirrorPolicy     []GoogleComputeURLMapPathMatcherRouteRulesRouteActionRequestMirrorPolicy     `tf:"request_mirror_policy,blocks" json:"request_mirror_policy,omitempty"`
+	RetryPolicy             []GoogleComputeURLMapPathMatcherRouteRulesRouteActionRetryPolicy             `tf:"retry_policy,blocks" json:"retry_policy,omitempty"`
+	Timeout                 []GoogleComputeURLMapPathMatcherRouteRulesRouteActionTimeout                 `tf:"timeout,blocks" json:"timeout,omitempty"`
+	URLRewrite              []GoogleComputeURLMapPathMatcherRouteRulesRouteActionURLRewrite              `tf:"url_rewrite,blocks" json:"url_rewrite,omitempty"`
+	WeightedBackendServices []GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServices `tf:"weighted_backend_services,blocks" json:"weighted_backend_services,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionCorsPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionCorsPolicy struct {
-	AllowCredentials   *Value[bool]     `tf:"allow_credentials"`
-	AllowHeaders       []*Value[string] `tf:"allow_headers"`
-	AllowMethods       []*Value[string] `tf:"allow_methods"`
-	AllowOriginRegexes []*Value[string] `tf:"allow_origin_regexes"`
-	AllowOrigins       []*Value[string] `tf:"allow_origins"`
-	Disabled           *Value[bool]     `tf:"disabled"`
-	ExposeHeaders      []*Value[string] `tf:"expose_headers"`
-	MaxAge             *Value[int64]    `tf:"max_age"`
+	AllowCredentials   *Value[bool]     `tf:"allow_credentials" json:"allow_credentials,omitempty"`
+	AllowHeaders       []*Value[string] `tf:"allow_headers" json:"allow_headers,omitempty"`
+	AllowMethods       []*Value[string] `tf:"allow_methods" json:"allow_methods,omitempty"`
+	AllowOriginRegexes []*Value[string] `tf:"allow_origin_regexes" json:"allow_origin_regexes,omitempty"`
+	AllowOrigins       []*Value[string] `tf:"allow_origins" json:"allow_origins,omitempty"`
+	Disabled           *Value[bool]     `tf:"disabled" json:"disabled,omitempty"`
+	ExposeHeaders      []*Value[string] `tf:"expose_headers" json:"expose_headers,omitempty"`
+	MaxAge             *Value[int64]    `tf:"max_age" json:"max_age,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicy struct {
-	Abort []GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicyAbort `tf:"abort,blocks"`
-	Delay []GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicyDelay `tf:"delay,blocks"`
+	Abort []GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicyAbort `tf:"abort,blocks" json:"abort,omitempty"`
+	Delay []GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicyDelay `tf:"delay,blocks" json:"delay,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicyAbort is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicyAbort struct {
-	HTTPStatus *Value[float64] `tf:"http_status"`
-	Percentage *Value[float64] `tf:"percentage"`
+	HTTPStatus *Value[float64] `tf:"http_status" json:"http_status,omitempty"`
+	Percentage *Value[float64] `tf:"percentage" json:"percentage,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicyDelay is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicyDelay struct {
-	Percentage *Value[float64]                                                                          `tf:"percentage"`
-	FixedDelay []GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicyDelayFixedDelay `tf:"fixed_delay,blocks"`
+	Percentage *Value[float64]                                                                          `tf:"percentage" json:"percentage,omitempty"`
+	FixedDelay []GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicyDelayFixedDelay `tf:"fixed_delay,blocks" json:"fixed_delay,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicyDelayFixedDelay is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionFaultInjectionPolicyDelayFixedDelay struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[string]  `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[string]  `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionRequestMirrorPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionRequestMirrorPolicy struct {
-	BackendService *Value[string] `tf:"backend_service"`
+	BackendService *Value[string] `tf:"backend_service" json:"backend_service,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionRetryPolicy is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionRetryPolicy struct {
-	NumRetries      *Value[float64]                                                               `tf:"num_retries"`
-	RetryConditions []*Value[string]                                                              `tf:"retry_conditions"`
-	PerTryTimeout   []GoogleComputeURLMapPathMatcherRouteRulesRouteActionRetryPolicyPerTryTimeout `tf:"per_try_timeout,blocks"`
+	NumRetries      *Value[float64]                                                               `tf:"num_retries" json:"num_retries,omitempty"`
+	RetryConditions []*Value[string]                                                              `tf:"retry_conditions" json:"retry_conditions,omitempty"`
+	PerTryTimeout   []GoogleComputeURLMapPathMatcherRouteRulesRouteActionRetryPolicyPerTryTimeout `tf:"per_try_timeout,blocks" json:"per_try_timeout,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionRetryPolicyPerTryTimeout is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionRetryPolicyPerTryTimeout struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[string]  `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[string]  `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionTimeout is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionTimeout struct {
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[string]  `tf:"seconds"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[string]  `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionURLRewrite is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionURLRewrite struct {
-	HostRewrite         *Value[string] `tf:"host_rewrite"`
-	PathPrefixRewrite   *Value[string] `tf:"path_prefix_rewrite"`
-	PathTemplateRewrite *Value[string] `tf:"path_template_rewrite"`
+	HostRewrite         *Value[string] `tf:"host_rewrite" json:"host_rewrite,omitempty"`
+	PathPrefixRewrite   *Value[string] `tf:"path_prefix_rewrite" json:"path_prefix_rewrite,omitempty"`
+	PathTemplateRewrite *Value[string] `tf:"path_template_rewrite" json:"path_template_rewrite,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServices is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServices struct {
-	BackendService *Value[string]                                                                           `tf:"backend_service"`
-	Weight         *Value[float64]                                                                          `tf:"weight"`
-	HeaderAction   []GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServicesHeaderAction `tf:"header_action,blocks"`
+	BackendService *Value[string]                                                                           `tf:"backend_service" json:"backend_service,omitempty"`
+	Weight         *Value[float64]                                                                          `tf:"weight" json:"weight,omitempty"`
+	HeaderAction   []GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServicesHeaderAction `tf:"header_action,blocks" json:"header_action,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServicesHeaderAction is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServicesHeaderAction struct {
-	RequestHeadersToRemove  []*Value[string]                                                                                             `tf:"request_headers_to_remove"`
-	ResponseHeadersToRemove []*Value[string]                                                                                             `tf:"response_headers_to_remove"`
-	RequestHeadersToAdd     []GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks"`
-	ResponseHeadersToAdd    []GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks"`
+	RequestHeadersToRemove  []*Value[string]                                                                                             `tf:"request_headers_to_remove" json:"request_headers_to_remove,omitempty"`
+	ResponseHeadersToRemove []*Value[string]                                                                                             `tf:"response_headers_to_remove" json:"response_headers_to_remove,omitempty"`
+	RequestHeadersToAdd     []GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd  `tf:"request_headers_to_add,blocks" json:"request_headers_to_add,omitempty"`
+	ResponseHeadersToAdd    []GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd `tf:"response_headers_to_add,blocks" json:"response_headers_to_add,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServicesHeaderActionRequestHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesRouteActionWeightedBackendServicesHeaderActionResponseHeadersToAdd struct {
-	HeaderName  *Value[string] `tf:"header_name"`
-	HeaderValue *Value[string] `tf:"header_value"`
-	Replace     *Value[bool]   `tf:"replace"`
+	HeaderName  *Value[string] `tf:"header_name" json:"header_name,omitempty"`
+	HeaderValue *Value[string] `tf:"header_value" json:"header_value,omitempty"`
+	Replace     *Value[bool]   `tf:"replace" json:"replace,omitempty"`
 }
 
 // GoogleComputeURLMapPathMatcherRouteRulesURLRedirect is a nested-block type used by the parent resource.
 type GoogleComputeURLMapPathMatcherRouteRulesURLRedirect struct {
-	HostRedirect         *Value[string] `tf:"host_redirect"`
-	HTTPSRedirect        *Value[bool]   `tf:"https_redirect"`
-	PathRedirect         *Value[string] `tf:"path_redirect"`
-	PrefixRedirect       *Value[string] `tf:"prefix_redirect"`
-	RedirectResponseCode *Value[string] `tf:"redirect_response_code"`
-	StripQuery           *Value[bool]   `tf:"strip_query"`
+	HostRedirect         *Value[string] `tf:"host_redirect" json:"host_redirect,omitempty"`
+	HTTPSRedirect        *Value[bool]   `tf:"https_redirect" json:"https_redirect,omitempty"`
+	PathRedirect         *Value[string] `tf:"path_redirect" json:"path_redirect,omitempty"`
+	PrefixRedirect       *Value[string] `tf:"prefix_redirect" json:"prefix_redirect,omitempty"`
+	RedirectResponseCode *Value[string] `tf:"redirect_response_code" json:"redirect_response_code,omitempty"`
+	StripQuery           *Value[bool]   `tf:"strip_query" json:"strip_query,omitempty"`
 }
 
 // GoogleComputeURLMapTest is a nested-block type used by the parent resource.
 type GoogleComputeURLMapTest struct {
-	Description *Value[string] `tf:"description"`
-	Host        *Value[string] `tf:"host"`
-	Path        *Value[string] `tf:"path"`
-	Service     *Value[string] `tf:"service"`
+	Description *Value[string] `tf:"description" json:"description,omitempty"`
+	Host        *Value[string] `tf:"host" json:"host,omitempty"`
+	Path        *Value[string] `tf:"path" json:"path,omitempty"`
+	Service     *Value[string] `tf:"service" json:"service,omitempty"`
 }
 
 // GoogleComputeURLMapTimeouts is a nested-block type used by the parent resource.
 type GoogleComputeURLMapTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleComputeURLMapSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_container_cluster.gen.go
+++ b/pkg/composer/imported/generated/google_container_cluster.gen.go
@@ -7,1058 +7,1058 @@ import "reflect"
 // GoogleContainerCluster is the generated Layer 1 typed model for the
 // `google_container_cluster` Terraform resource.
 type GoogleContainerCluster struct {
-	AllowNetAdmin                        *Value[bool]                                           `tf:"allow_net_admin"`
-	ClusterIPV4CIDR                      *Value[string]                                         `tf:"cluster_ipv4_cidr"`
-	DatapathProvider                     *Value[string]                                         `tf:"datapath_provider"`
-	DefaultMaxPodsPerNode                *Value[float64]                                        `tf:"default_max_pods_per_node"`
-	DeletionProtection                   *Value[bool]                                           `tf:"deletion_protection"`
-	Description                          *Value[string]                                         `tf:"description"`
-	EffectiveLabels                      map[string]*Value[string]                              `tf:"effective_labels"`
-	EnableAutopilot                      *Value[bool]                                           `tf:"enable_autopilot"`
-	EnableCiliumClusterwideNetworkPolicy *Value[bool]                                           `tf:"enable_cilium_clusterwide_network_policy"`
-	EnableIntranodeVisibility            *Value[bool]                                           `tf:"enable_intranode_visibility"`
-	EnableKubernetesAlpha                *Value[bool]                                           `tf:"enable_kubernetes_alpha"`
-	EnableL4IlbSubsetting                *Value[bool]                                           `tf:"enable_l4_ilb_subsetting"`
-	EnableLegacyAbac                     *Value[bool]                                           `tf:"enable_legacy_abac"`
-	EnableMultiNetworking                *Value[bool]                                           `tf:"enable_multi_networking"`
-	EnableShieldedNodes                  *Value[bool]                                           `tf:"enable_shielded_nodes"`
-	EnableTpu                            *Value[bool]                                           `tf:"enable_tpu"`
-	Endpoint                             *Value[string]                                         `tf:"endpoint"`
-	ID                                   *Value[string]                                         `tf:"id"`
-	InitialNodeCount                     *Value[int64]                                          `tf:"initial_node_count"`
-	LabelFingerprint                     *Value[string]                                         `tf:"label_fingerprint"`
-	Location                             *Value[string]                                         `tf:"location"`
-	LoggingService                       *Value[string]                                         `tf:"logging_service"`
-	MasterVersion                        *Value[string]                                         `tf:"master_version"`
-	MinMasterVersion                     *Value[string]                                         `tf:"min_master_version"`
-	MonitoringService                    *Value[string]                                         `tf:"monitoring_service"`
-	Name                                 *Value[string]                                         `tf:"name"`
-	Network                              *Value[string]                                         `tf:"network"`
-	NetworkingMode                       *Value[string]                                         `tf:"networking_mode"`
-	NodeLocations                        []*Value[string]                                       `tf:"node_locations"`
-	NodeVersion                          *Value[string]                                         `tf:"node_version"`
-	Operation                            *Value[string]                                         `tf:"operation"`
-	PrivateIPV6GoogleAccess              *Value[string]                                         `tf:"private_ipv6_google_access"`
-	Project                              *Value[string]                                         `tf:"project"`
-	RemoveDefaultNodePool                *Value[bool]                                           `tf:"remove_default_node_pool"`
-	ResourceLabels                       map[string]*Value[string]                              `tf:"resource_labels"`
-	SelfLink                             *Value[string]                                         `tf:"self_link"`
-	ServicesIPV4CIDR                     *Value[string]                                         `tf:"services_ipv4_cidr"`
-	Subnetwork                           *Value[string]                                         `tf:"subnetwork"`
-	TerraformLabels                      map[string]*Value[string]                              `tf:"terraform_labels"`
-	TpuIPV4CIDRBlock                     *Value[string]                                         `tf:"tpu_ipv4_cidr_block"`
-	AddonsConfig                         []GoogleContainerClusterAddonsConfig                   `tf:"addons_config,blocks"`
-	AuthenticatorGroupsConfig            []GoogleContainerClusterAuthenticatorGroupsConfig      `tf:"authenticator_groups_config,blocks"`
-	BinaryAuthorization                  []GoogleContainerClusterBinaryAuthorization            `tf:"binary_authorization,blocks"`
-	ClusterAutoscaling                   []GoogleContainerClusterClusterAutoscaling             `tf:"cluster_autoscaling,blocks"`
-	ConfidentialNodes                    []GoogleContainerClusterConfidentialNodes              `tf:"confidential_nodes,blocks"`
-	CostManagementConfig                 []GoogleContainerClusterCostManagementConfig           `tf:"cost_management_config,blocks"`
-	DatabaseEncryption                   []GoogleContainerClusterDatabaseEncryption             `tf:"database_encryption,blocks"`
-	DefaultSnatStatus                    []GoogleContainerClusterDefaultSnatStatus              `tf:"default_snat_status,blocks"`
-	DNSConfig                            []GoogleContainerClusterDNSConfig                      `tf:"dns_config,blocks"`
-	EnableK8sBetaApis                    []GoogleContainerClusterEnableK8sBetaApis              `tf:"enable_k8s_beta_apis,blocks"`
-	Fleet                                []GoogleContainerClusterFleet                          `tf:"fleet,blocks"`
-	GatewayAPIConfig                     []GoogleContainerClusterGatewayAPIConfig               `tf:"gateway_api_config,blocks"`
-	IdentityServiceConfig                []GoogleContainerClusterIdentityServiceConfig          `tf:"identity_service_config,blocks"`
-	IpAllocationPolicy                   []GoogleContainerClusterIpAllocationPolicy             `tf:"ip_allocation_policy,blocks"`
-	LoggingConfig                        []GoogleContainerClusterLoggingConfig                  `tf:"logging_config,blocks"`
-	MaintenancePolicy                    []GoogleContainerClusterMaintenancePolicy              `tf:"maintenance_policy,blocks"`
-	MasterAuth                           []GoogleContainerClusterMasterAuth                     `tf:"master_auth,blocks"`
-	MasterAuthorizedNetworksConfig       []GoogleContainerClusterMasterAuthorizedNetworksConfig `tf:"master_authorized_networks_config,blocks"`
-	MeshCertificates                     []GoogleContainerClusterMeshCertificates               `tf:"mesh_certificates,blocks"`
-	MonitoringConfig                     []GoogleContainerClusterMonitoringConfig               `tf:"monitoring_config,blocks"`
-	NetworkPolicy                        []GoogleContainerClusterNetworkPolicy                  `tf:"network_policy,blocks"`
-	NodeConfig                           []GoogleContainerClusterNodeConfig                     `tf:"node_config,blocks"`
-	NodePool                             []GoogleContainerClusterNodePool                       `tf:"node_pool,blocks"`
-	NodePoolAutoConfig                   []GoogleContainerClusterNodePoolAutoConfig             `tf:"node_pool_auto_config,blocks"`
-	NodePoolDefaults                     []GoogleContainerClusterNodePoolDefaults               `tf:"node_pool_defaults,blocks"`
-	NotificationConfig                   []GoogleContainerClusterNotificationConfig             `tf:"notification_config,blocks"`
-	PrivateClusterConfig                 []GoogleContainerClusterPrivateClusterConfig           `tf:"private_cluster_config,blocks"`
-	ReleaseChannel                       []GoogleContainerClusterReleaseChannel                 `tf:"release_channel,blocks"`
-	ResourceUsageExportConfig            []GoogleContainerClusterResourceUsageExportConfig      `tf:"resource_usage_export_config,blocks"`
-	SecretManagerConfig                  []GoogleContainerClusterSecretManagerConfig            `tf:"secret_manager_config,blocks"`
-	SecurityPostureConfig                []GoogleContainerClusterSecurityPostureConfig          `tf:"security_posture_config,blocks"`
-	ServiceExternalIpsConfig             []GoogleContainerClusterServiceExternalIpsConfig       `tf:"service_external_ips_config,blocks"`
-	Timeouts                             *GoogleContainerClusterTimeouts                        `tf:"timeouts,block"`
-	VerticalPodAutoscaling               []GoogleContainerClusterVerticalPodAutoscaling         `tf:"vertical_pod_autoscaling,blocks"`
-	WorkloadIdentityConfig               []GoogleContainerClusterWorkloadIdentityConfig         `tf:"workload_identity_config,blocks"`
+	AllowNetAdmin                        *Value[bool]                                           `tf:"allow_net_admin" json:"allow_net_admin,omitempty"`
+	ClusterIPV4CIDR                      *Value[string]                                         `tf:"cluster_ipv4_cidr" json:"cluster_ipv4_cidr,omitempty"`
+	DatapathProvider                     *Value[string]                                         `tf:"datapath_provider" json:"datapath_provider,omitempty"`
+	DefaultMaxPodsPerNode                *Value[float64]                                        `tf:"default_max_pods_per_node" json:"default_max_pods_per_node,omitempty"`
+	DeletionProtection                   *Value[bool]                                           `tf:"deletion_protection" json:"deletion_protection,omitempty"`
+	Description                          *Value[string]                                         `tf:"description" json:"description,omitempty"`
+	EffectiveLabels                      map[string]*Value[string]                              `tf:"effective_labels" json:"effective_labels,omitempty"`
+	EnableAutopilot                      *Value[bool]                                           `tf:"enable_autopilot" json:"enable_autopilot,omitempty"`
+	EnableCiliumClusterwideNetworkPolicy *Value[bool]                                           `tf:"enable_cilium_clusterwide_network_policy" json:"enable_cilium_clusterwide_network_policy,omitempty"`
+	EnableIntranodeVisibility            *Value[bool]                                           `tf:"enable_intranode_visibility" json:"enable_intranode_visibility,omitempty"`
+	EnableKubernetesAlpha                *Value[bool]                                           `tf:"enable_kubernetes_alpha" json:"enable_kubernetes_alpha,omitempty"`
+	EnableL4IlbSubsetting                *Value[bool]                                           `tf:"enable_l4_ilb_subsetting" json:"enable_l4_ilb_subsetting,omitempty"`
+	EnableLegacyAbac                     *Value[bool]                                           `tf:"enable_legacy_abac" json:"enable_legacy_abac,omitempty"`
+	EnableMultiNetworking                *Value[bool]                                           `tf:"enable_multi_networking" json:"enable_multi_networking,omitempty"`
+	EnableShieldedNodes                  *Value[bool]                                           `tf:"enable_shielded_nodes" json:"enable_shielded_nodes,omitempty"`
+	EnableTpu                            *Value[bool]                                           `tf:"enable_tpu" json:"enable_tpu,omitempty"`
+	Endpoint                             *Value[string]                                         `tf:"endpoint" json:"endpoint,omitempty"`
+	ID                                   *Value[string]                                         `tf:"id" json:"id,omitempty"`
+	InitialNodeCount                     *Value[int64]                                          `tf:"initial_node_count" json:"initial_node_count,omitempty"`
+	LabelFingerprint                     *Value[string]                                         `tf:"label_fingerprint" json:"label_fingerprint,omitempty"`
+	Location                             *Value[string]                                         `tf:"location" json:"location,omitempty"`
+	LoggingService                       *Value[string]                                         `tf:"logging_service" json:"logging_service,omitempty"`
+	MasterVersion                        *Value[string]                                         `tf:"master_version" json:"master_version,omitempty"`
+	MinMasterVersion                     *Value[string]                                         `tf:"min_master_version" json:"min_master_version,omitempty"`
+	MonitoringService                    *Value[string]                                         `tf:"monitoring_service" json:"monitoring_service,omitempty"`
+	Name                                 *Value[string]                                         `tf:"name" json:"name,omitempty"`
+	Network                              *Value[string]                                         `tf:"network" json:"network,omitempty"`
+	NetworkingMode                       *Value[string]                                         `tf:"networking_mode" json:"networking_mode,omitempty"`
+	NodeLocations                        []*Value[string]                                       `tf:"node_locations" json:"node_locations,omitempty"`
+	NodeVersion                          *Value[string]                                         `tf:"node_version" json:"node_version,omitempty"`
+	Operation                            *Value[string]                                         `tf:"operation" json:"operation,omitempty"`
+	PrivateIPV6GoogleAccess              *Value[string]                                         `tf:"private_ipv6_google_access" json:"private_ipv6_google_access,omitempty"`
+	Project                              *Value[string]                                         `tf:"project" json:"project,omitempty"`
+	RemoveDefaultNodePool                *Value[bool]                                           `tf:"remove_default_node_pool" json:"remove_default_node_pool,omitempty"`
+	ResourceLabels                       map[string]*Value[string]                              `tf:"resource_labels" json:"resource_labels,omitempty"`
+	SelfLink                             *Value[string]                                         `tf:"self_link" json:"self_link,omitempty"`
+	ServicesIPV4CIDR                     *Value[string]                                         `tf:"services_ipv4_cidr" json:"services_ipv4_cidr,omitempty"`
+	Subnetwork                           *Value[string]                                         `tf:"subnetwork" json:"subnetwork,omitempty"`
+	TerraformLabels                      map[string]*Value[string]                              `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	TpuIPV4CIDRBlock                     *Value[string]                                         `tf:"tpu_ipv4_cidr_block" json:"tpu_ipv4_cidr_block,omitempty"`
+	AddonsConfig                         []GoogleContainerClusterAddonsConfig                   `tf:"addons_config,blocks" json:"addons_config,omitempty"`
+	AuthenticatorGroupsConfig            []GoogleContainerClusterAuthenticatorGroupsConfig      `tf:"authenticator_groups_config,blocks" json:"authenticator_groups_config,omitempty"`
+	BinaryAuthorization                  []GoogleContainerClusterBinaryAuthorization            `tf:"binary_authorization,blocks" json:"binary_authorization,omitempty"`
+	ClusterAutoscaling                   []GoogleContainerClusterClusterAutoscaling             `tf:"cluster_autoscaling,blocks" json:"cluster_autoscaling,omitempty"`
+	ConfidentialNodes                    []GoogleContainerClusterConfidentialNodes              `tf:"confidential_nodes,blocks" json:"confidential_nodes,omitempty"`
+	CostManagementConfig                 []GoogleContainerClusterCostManagementConfig           `tf:"cost_management_config,blocks" json:"cost_management_config,omitempty"`
+	DatabaseEncryption                   []GoogleContainerClusterDatabaseEncryption             `tf:"database_encryption,blocks" json:"database_encryption,omitempty"`
+	DefaultSnatStatus                    []GoogleContainerClusterDefaultSnatStatus              `tf:"default_snat_status,blocks" json:"default_snat_status,omitempty"`
+	DNSConfig                            []GoogleContainerClusterDNSConfig                      `tf:"dns_config,blocks" json:"dns_config,omitempty"`
+	EnableK8sBetaApis                    []GoogleContainerClusterEnableK8sBetaApis              `tf:"enable_k8s_beta_apis,blocks" json:"enable_k8s_beta_apis,omitempty"`
+	Fleet                                []GoogleContainerClusterFleet                          `tf:"fleet,blocks" json:"fleet,omitempty"`
+	GatewayAPIConfig                     []GoogleContainerClusterGatewayAPIConfig               `tf:"gateway_api_config,blocks" json:"gateway_api_config,omitempty"`
+	IdentityServiceConfig                []GoogleContainerClusterIdentityServiceConfig          `tf:"identity_service_config,blocks" json:"identity_service_config,omitempty"`
+	IpAllocationPolicy                   []GoogleContainerClusterIpAllocationPolicy             `tf:"ip_allocation_policy,blocks" json:"ip_allocation_policy,omitempty"`
+	LoggingConfig                        []GoogleContainerClusterLoggingConfig                  `tf:"logging_config,blocks" json:"logging_config,omitempty"`
+	MaintenancePolicy                    []GoogleContainerClusterMaintenancePolicy              `tf:"maintenance_policy,blocks" json:"maintenance_policy,omitempty"`
+	MasterAuth                           []GoogleContainerClusterMasterAuth                     `tf:"master_auth,blocks" json:"master_auth,omitempty"`
+	MasterAuthorizedNetworksConfig       []GoogleContainerClusterMasterAuthorizedNetworksConfig `tf:"master_authorized_networks_config,blocks" json:"master_authorized_networks_config,omitempty"`
+	MeshCertificates                     []GoogleContainerClusterMeshCertificates               `tf:"mesh_certificates,blocks" json:"mesh_certificates,omitempty"`
+	MonitoringConfig                     []GoogleContainerClusterMonitoringConfig               `tf:"monitoring_config,blocks" json:"monitoring_config,omitempty"`
+	NetworkPolicy                        []GoogleContainerClusterNetworkPolicy                  `tf:"network_policy,blocks" json:"network_policy,omitempty"`
+	NodeConfig                           []GoogleContainerClusterNodeConfig                     `tf:"node_config,blocks" json:"node_config,omitempty"`
+	NodePool                             []GoogleContainerClusterNodePool                       `tf:"node_pool,blocks" json:"node_pool,omitempty"`
+	NodePoolAutoConfig                   []GoogleContainerClusterNodePoolAutoConfig             `tf:"node_pool_auto_config,blocks" json:"node_pool_auto_config,omitempty"`
+	NodePoolDefaults                     []GoogleContainerClusterNodePoolDefaults               `tf:"node_pool_defaults,blocks" json:"node_pool_defaults,omitempty"`
+	NotificationConfig                   []GoogleContainerClusterNotificationConfig             `tf:"notification_config,blocks" json:"notification_config,omitempty"`
+	PrivateClusterConfig                 []GoogleContainerClusterPrivateClusterConfig           `tf:"private_cluster_config,blocks" json:"private_cluster_config,omitempty"`
+	ReleaseChannel                       []GoogleContainerClusterReleaseChannel                 `tf:"release_channel,blocks" json:"release_channel,omitempty"`
+	ResourceUsageExportConfig            []GoogleContainerClusterResourceUsageExportConfig      `tf:"resource_usage_export_config,blocks" json:"resource_usage_export_config,omitempty"`
+	SecretManagerConfig                  []GoogleContainerClusterSecretManagerConfig            `tf:"secret_manager_config,blocks" json:"secret_manager_config,omitempty"`
+	SecurityPostureConfig                []GoogleContainerClusterSecurityPostureConfig          `tf:"security_posture_config,blocks" json:"security_posture_config,omitempty"`
+	ServiceExternalIpsConfig             []GoogleContainerClusterServiceExternalIpsConfig       `tf:"service_external_ips_config,blocks" json:"service_external_ips_config,omitempty"`
+	Timeouts                             *GoogleContainerClusterTimeouts                        `tf:"timeouts,block" json:"timeouts,omitempty"`
+	VerticalPodAutoscaling               []GoogleContainerClusterVerticalPodAutoscaling         `tf:"vertical_pod_autoscaling,blocks" json:"vertical_pod_autoscaling,omitempty"`
+	WorkloadIdentityConfig               []GoogleContainerClusterWorkloadIdentityConfig         `tf:"workload_identity_config,blocks" json:"workload_identity_config,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfig struct {
-	CloudrunConfig                   []GoogleContainerClusterAddonsConfigCloudrunConfig                   `tf:"cloudrun_config,blocks"`
-	ConfigConnectorConfig            []GoogleContainerClusterAddonsConfigConfigConnectorConfig            `tf:"config_connector_config,blocks"`
-	DNSCacheConfig                   []GoogleContainerClusterAddonsConfigDNSCacheConfig                   `tf:"dns_cache_config,blocks"`
-	GcePersistentDiskCsiDriverConfig []GoogleContainerClusterAddonsConfigGcePersistentDiskCsiDriverConfig `tf:"gce_persistent_disk_csi_driver_config,blocks"`
-	GCPFilestoreCsiDriverConfig      []GoogleContainerClusterAddonsConfigGCPFilestoreCsiDriverConfig      `tf:"gcp_filestore_csi_driver_config,blocks"`
-	GCSFuseCsiDriverConfig           []GoogleContainerClusterAddonsConfigGCSFuseCsiDriverConfig           `tf:"gcs_fuse_csi_driver_config,blocks"`
-	GKEBackupAgentConfig             []GoogleContainerClusterAddonsConfigGKEBackupAgentConfig             `tf:"gke_backup_agent_config,blocks"`
-	HorizontalPodAutoscaling         []GoogleContainerClusterAddonsConfigHorizontalPodAutoscaling         `tf:"horizontal_pod_autoscaling,blocks"`
-	HTTPLoadBalancing                []GoogleContainerClusterAddonsConfigHTTPLoadBalancing                `tf:"http_load_balancing,blocks"`
-	NetworkPolicyConfig              []GoogleContainerClusterAddonsConfigNetworkPolicyConfig              `tf:"network_policy_config,blocks"`
-	RayOperatorConfig                []GoogleContainerClusterAddonsConfigRayOperatorConfig                `tf:"ray_operator_config,blocks"`
-	StatefulHaConfig                 []GoogleContainerClusterAddonsConfigStatefulHaConfig                 `tf:"stateful_ha_config,blocks"`
+	CloudrunConfig                   []GoogleContainerClusterAddonsConfigCloudrunConfig                   `tf:"cloudrun_config,blocks" json:"cloudrun_config,omitempty"`
+	ConfigConnectorConfig            []GoogleContainerClusterAddonsConfigConfigConnectorConfig            `tf:"config_connector_config,blocks" json:"config_connector_config,omitempty"`
+	DNSCacheConfig                   []GoogleContainerClusterAddonsConfigDNSCacheConfig                   `tf:"dns_cache_config,blocks" json:"dns_cache_config,omitempty"`
+	GcePersistentDiskCsiDriverConfig []GoogleContainerClusterAddonsConfigGcePersistentDiskCsiDriverConfig `tf:"gce_persistent_disk_csi_driver_config,blocks" json:"gce_persistent_disk_csi_driver_config,omitempty"`
+	GCPFilestoreCsiDriverConfig      []GoogleContainerClusterAddonsConfigGCPFilestoreCsiDriverConfig      `tf:"gcp_filestore_csi_driver_config,blocks" json:"gcp_filestore_csi_driver_config,omitempty"`
+	GCSFuseCsiDriverConfig           []GoogleContainerClusterAddonsConfigGCSFuseCsiDriverConfig           `tf:"gcs_fuse_csi_driver_config,blocks" json:"gcs_fuse_csi_driver_config,omitempty"`
+	GKEBackupAgentConfig             []GoogleContainerClusterAddonsConfigGKEBackupAgentConfig             `tf:"gke_backup_agent_config,blocks" json:"gke_backup_agent_config,omitempty"`
+	HorizontalPodAutoscaling         []GoogleContainerClusterAddonsConfigHorizontalPodAutoscaling         `tf:"horizontal_pod_autoscaling,blocks" json:"horizontal_pod_autoscaling,omitempty"`
+	HTTPLoadBalancing                []GoogleContainerClusterAddonsConfigHTTPLoadBalancing                `tf:"http_load_balancing,blocks" json:"http_load_balancing,omitempty"`
+	NetworkPolicyConfig              []GoogleContainerClusterAddonsConfigNetworkPolicyConfig              `tf:"network_policy_config,blocks" json:"network_policy_config,omitempty"`
+	RayOperatorConfig                []GoogleContainerClusterAddonsConfigRayOperatorConfig                `tf:"ray_operator_config,blocks" json:"ray_operator_config,omitempty"`
+	StatefulHaConfig                 []GoogleContainerClusterAddonsConfigStatefulHaConfig                 `tf:"stateful_ha_config,blocks" json:"stateful_ha_config,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigCloudrunConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigCloudrunConfig struct {
-	Disabled         *Value[bool]   `tf:"disabled"`
-	LoadBalancerType *Value[string] `tf:"load_balancer_type"`
+	Disabled         *Value[bool]   `tf:"disabled" json:"disabled,omitempty"`
+	LoadBalancerType *Value[string] `tf:"load_balancer_type" json:"load_balancer_type,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigConfigConnectorConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigConfigConnectorConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigDNSCacheConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigDNSCacheConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigGCPFilestoreCsiDriverConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigGCPFilestoreCsiDriverConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigGCSFuseCsiDriverConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigGCSFuseCsiDriverConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigGKEBackupAgentConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigGKEBackupAgentConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigGcePersistentDiskCsiDriverConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigGcePersistentDiskCsiDriverConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigHTTPLoadBalancing is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigHTTPLoadBalancing struct {
-	Disabled *Value[bool] `tf:"disabled"`
+	Disabled *Value[bool] `tf:"disabled" json:"disabled,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigHorizontalPodAutoscaling is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigHorizontalPodAutoscaling struct {
-	Disabled *Value[bool] `tf:"disabled"`
+	Disabled *Value[bool] `tf:"disabled" json:"disabled,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigNetworkPolicyConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigNetworkPolicyConfig struct {
-	Disabled *Value[bool] `tf:"disabled"`
+	Disabled *Value[bool] `tf:"disabled" json:"disabled,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigRayOperatorConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigRayOperatorConfig struct {
-	Enabled                    *Value[bool]                                                                    `tf:"enabled"`
-	RayClusterLoggingConfig    []GoogleContainerClusterAddonsConfigRayOperatorConfigRayClusterLoggingConfig    `tf:"ray_cluster_logging_config,blocks"`
-	RayClusterMonitoringConfig []GoogleContainerClusterAddonsConfigRayOperatorConfigRayClusterMonitoringConfig `tf:"ray_cluster_monitoring_config,blocks"`
+	Enabled                    *Value[bool]                                                                    `tf:"enabled" json:"enabled,omitempty"`
+	RayClusterLoggingConfig    []GoogleContainerClusterAddonsConfigRayOperatorConfigRayClusterLoggingConfig    `tf:"ray_cluster_logging_config,blocks" json:"ray_cluster_logging_config,omitempty"`
+	RayClusterMonitoringConfig []GoogleContainerClusterAddonsConfigRayOperatorConfigRayClusterMonitoringConfig `tf:"ray_cluster_monitoring_config,blocks" json:"ray_cluster_monitoring_config,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigRayOperatorConfigRayClusterLoggingConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigRayOperatorConfigRayClusterLoggingConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigRayOperatorConfigRayClusterMonitoringConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigRayOperatorConfigRayClusterMonitoringConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterAddonsConfigStatefulHaConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAddonsConfigStatefulHaConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterAuthenticatorGroupsConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterAuthenticatorGroupsConfig struct {
-	SecurityGroup *Value[string] `tf:"security_group"`
+	SecurityGroup *Value[string] `tf:"security_group" json:"security_group,omitempty"`
 }
 
 // GoogleContainerClusterBinaryAuthorization is a nested-block type used by the parent resource.
 type GoogleContainerClusterBinaryAuthorization struct {
-	Enabled        *Value[bool]   `tf:"enabled"`
-	EvaluationMode *Value[string] `tf:"evaluation_mode"`
+	Enabled        *Value[bool]   `tf:"enabled" json:"enabled,omitempty"`
+	EvaluationMode *Value[string] `tf:"evaluation_mode" json:"evaluation_mode,omitempty"`
 }
 
 // GoogleContainerClusterClusterAutoscaling is a nested-block type used by the parent resource.
 type GoogleContainerClusterClusterAutoscaling struct {
-	AutoProvisioningLocations []*Value[string]                                                   `tf:"auto_provisioning_locations"`
-	AutoscalingProfile        *Value[string]                                                     `tf:"autoscaling_profile"`
-	Enabled                   *Value[bool]                                                       `tf:"enabled"`
-	AutoProvisioningDefaults  []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaults `tf:"auto_provisioning_defaults,blocks"`
-	ResourceLimits            []GoogleContainerClusterClusterAutoscalingResourceLimits           `tf:"resource_limits,blocks"`
+	AutoProvisioningLocations []*Value[string]                                                   `tf:"auto_provisioning_locations" json:"auto_provisioning_locations,omitempty"`
+	AutoscalingProfile        *Value[string]                                                     `tf:"autoscaling_profile" json:"autoscaling_profile,omitempty"`
+	Enabled                   *Value[bool]                                                       `tf:"enabled" json:"enabled,omitempty"`
+	AutoProvisioningDefaults  []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaults `tf:"auto_provisioning_defaults,blocks" json:"auto_provisioning_defaults,omitempty"`
+	ResourceLimits            []GoogleContainerClusterClusterAutoscalingResourceLimits           `tf:"resource_limits,blocks" json:"resource_limits,omitempty"`
 }
 
 // GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaults is a nested-block type used by the parent resource.
 type GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaults struct {
-	BootDiskKMSKey         *Value[string]                                                                           `tf:"boot_disk_kms_key"`
-	DiskSize               *Value[int64]                                                                            `tf:"disk_size"`
-	DiskType               *Value[string]                                                                           `tf:"disk_type"`
-	ImageType              *Value[string]                                                                           `tf:"image_type"`
-	MinCPUPlatform         *Value[string]                                                                           `tf:"min_cpu_platform"`
-	OauthScopes            []*Value[string]                                                                         `tf:"oauth_scopes"`
-	ServiceAccount         *Value[string]                                                                           `tf:"service_account"`
-	Management             []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsManagement             `tf:"management,blocks"`
-	ShieldedInstanceConfig []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsShieldedInstanceConfig `tf:"shielded_instance_config,blocks"`
-	UpgradeSettings        []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsUpgradeSettings        `tf:"upgrade_settings,blocks"`
+	BootDiskKMSKey         *Value[string]                                                                           `tf:"boot_disk_kms_key" json:"boot_disk_kms_key,omitempty"`
+	DiskSize               *Value[int64]                                                                            `tf:"disk_size" json:"disk_size,omitempty"`
+	DiskType               *Value[string]                                                                           `tf:"disk_type" json:"disk_type,omitempty"`
+	ImageType              *Value[string]                                                                           `tf:"image_type" json:"image_type,omitempty"`
+	MinCPUPlatform         *Value[string]                                                                           `tf:"min_cpu_platform" json:"min_cpu_platform,omitempty"`
+	OauthScopes            []*Value[string]                                                                         `tf:"oauth_scopes" json:"oauth_scopes,omitempty"`
+	ServiceAccount         *Value[string]                                                                           `tf:"service_account" json:"service_account,omitempty"`
+	Management             []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsManagement             `tf:"management,blocks" json:"management,omitempty"`
+	ShieldedInstanceConfig []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsShieldedInstanceConfig `tf:"shielded_instance_config,blocks" json:"shielded_instance_config,omitempty"`
+	UpgradeSettings        []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsUpgradeSettings        `tf:"upgrade_settings,blocks" json:"upgrade_settings,omitempty"`
 }
 
 // GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsManagement is a nested-block type used by the parent resource.
 type GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsManagement struct {
-	AutoRepair     *Value[bool]                                                                               `tf:"auto_repair"`
-	AutoUpgrade    *Value[bool]                                                                               `tf:"auto_upgrade"`
-	UpgradeOptions []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsManagementUpgradeOptions `tf:"upgrade_options"`
+	AutoRepair     *Value[bool]                                                                               `tf:"auto_repair" json:"auto_repair,omitempty"`
+	AutoUpgrade    *Value[bool]                                                                               `tf:"auto_upgrade" json:"auto_upgrade,omitempty"`
+	UpgradeOptions []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsManagementUpgradeOptions `tf:"upgrade_options" json:"upgrade_options,omitempty"`
 }
 
 // GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsManagementUpgradeOptions is a nested-block type used by the parent resource.
 type GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsManagementUpgradeOptions struct {
-	AutoUpgradeStartTime *Value[string] `tf:"auto_upgrade_start_time"`
-	Description          *Value[string] `tf:"description"`
+	AutoUpgradeStartTime *Value[string] `tf:"auto_upgrade_start_time" json:"auto_upgrade_start_time,omitempty"`
+	Description          *Value[string] `tf:"description" json:"description,omitempty"`
 }
 
 // GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsShieldedInstanceConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsShieldedInstanceConfig struct {
-	EnableIntegrityMonitoring *Value[bool] `tf:"enable_integrity_monitoring"`
-	EnableSecureBoot          *Value[bool] `tf:"enable_secure_boot"`
+	EnableIntegrityMonitoring *Value[bool] `tf:"enable_integrity_monitoring" json:"enable_integrity_monitoring,omitempty"`
+	EnableSecureBoot          *Value[bool] `tf:"enable_secure_boot" json:"enable_secure_boot,omitempty"`
 }
 
 // GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsUpgradeSettings is a nested-block type used by the parent resource.
 type GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsUpgradeSettings struct {
-	MaxSurge          *Value[int64]                                                                                      `tf:"max_surge"`
-	MaxUnavailable    *Value[int64]                                                                                      `tf:"max_unavailable"`
-	Strategy          *Value[string]                                                                                     `tf:"strategy"`
-	BlueGreenSettings []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsUpgradeSettingsBlueGreenSettings `tf:"blue_green_settings,blocks"`
+	MaxSurge          *Value[int64]                                                                                      `tf:"max_surge" json:"max_surge,omitempty"`
+	MaxUnavailable    *Value[int64]                                                                                      `tf:"max_unavailable" json:"max_unavailable,omitempty"`
+	Strategy          *Value[string]                                                                                     `tf:"strategy" json:"strategy,omitempty"`
+	BlueGreenSettings []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsUpgradeSettingsBlueGreenSettings `tf:"blue_green_settings,blocks" json:"blue_green_settings,omitempty"`
 }
 
 // GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsUpgradeSettingsBlueGreenSettings is a nested-block type used by the parent resource.
 type GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsUpgradeSettingsBlueGreenSettings struct {
-	NodePoolSoakDuration  *Value[string]                                                                                                          `tf:"node_pool_soak_duration"`
-	StandardRolloutPolicy []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsUpgradeSettingsBlueGreenSettingsStandardRolloutPolicy `tf:"standard_rollout_policy,blocks"`
+	NodePoolSoakDuration  *Value[string]                                                                                                          `tf:"node_pool_soak_duration" json:"node_pool_soak_duration,omitempty"`
+	StandardRolloutPolicy []GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsUpgradeSettingsBlueGreenSettingsStandardRolloutPolicy `tf:"standard_rollout_policy,blocks" json:"standard_rollout_policy,omitempty"`
 }
 
 // GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsUpgradeSettingsBlueGreenSettingsStandardRolloutPolicy is a nested-block type used by the parent resource.
 type GoogleContainerClusterClusterAutoscalingAutoProvisioningDefaultsUpgradeSettingsBlueGreenSettingsStandardRolloutPolicy struct {
-	BatchNodeCount    *Value[int64]   `tf:"batch_node_count"`
-	BatchPercentage   *Value[float64] `tf:"batch_percentage"`
-	BatchSoakDuration *Value[string]  `tf:"batch_soak_duration"`
+	BatchNodeCount    *Value[int64]   `tf:"batch_node_count" json:"batch_node_count,omitempty"`
+	BatchPercentage   *Value[float64] `tf:"batch_percentage" json:"batch_percentage,omitempty"`
+	BatchSoakDuration *Value[string]  `tf:"batch_soak_duration" json:"batch_soak_duration,omitempty"`
 }
 
 // GoogleContainerClusterClusterAutoscalingResourceLimits is a nested-block type used by the parent resource.
 type GoogleContainerClusterClusterAutoscalingResourceLimits struct {
-	Maximum      *Value[float64] `tf:"maximum"`
-	Minimum      *Value[float64] `tf:"minimum"`
-	ResourceType *Value[string]  `tf:"resource_type"`
+	Maximum      *Value[float64] `tf:"maximum" json:"maximum,omitempty"`
+	Minimum      *Value[float64] `tf:"minimum" json:"minimum,omitempty"`
+	ResourceType *Value[string]  `tf:"resource_type" json:"resource_type,omitempty"`
 }
 
 // GoogleContainerClusterConfidentialNodes is a nested-block type used by the parent resource.
 type GoogleContainerClusterConfidentialNodes struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterCostManagementConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterCostManagementConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterDNSConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterDNSConfig struct {
-	AdditiveVPCScopeDNSDomain *Value[string] `tf:"additive_vpc_scope_dns_domain"`
-	ClusterDNS                *Value[string] `tf:"cluster_dns"`
-	ClusterDNSDomain          *Value[string] `tf:"cluster_dns_domain"`
-	ClusterDNSScope           *Value[string] `tf:"cluster_dns_scope"`
+	AdditiveVPCScopeDNSDomain *Value[string] `tf:"additive_vpc_scope_dns_domain" json:"additive_vpc_scope_dns_domain,omitempty"`
+	ClusterDNS                *Value[string] `tf:"cluster_dns" json:"cluster_dns,omitempty"`
+	ClusterDNSDomain          *Value[string] `tf:"cluster_dns_domain" json:"cluster_dns_domain,omitempty"`
+	ClusterDNSScope           *Value[string] `tf:"cluster_dns_scope" json:"cluster_dns_scope,omitempty"`
 }
 
 // GoogleContainerClusterDatabaseEncryption is a nested-block type used by the parent resource.
 type GoogleContainerClusterDatabaseEncryption struct {
-	KeyName *Value[string] `tf:"key_name"`
-	State   *Value[string] `tf:"state"`
+	KeyName *Value[string] `tf:"key_name" json:"key_name,omitempty"`
+	State   *Value[string] `tf:"state" json:"state,omitempty"`
 }
 
 // GoogleContainerClusterDefaultSnatStatus is a nested-block type used by the parent resource.
 type GoogleContainerClusterDefaultSnatStatus struct {
-	Disabled *Value[bool] `tf:"disabled"`
+	Disabled *Value[bool] `tf:"disabled" json:"disabled,omitempty"`
 }
 
 // GoogleContainerClusterEnableK8sBetaApis is a nested-block type used by the parent resource.
 type GoogleContainerClusterEnableK8sBetaApis struct {
-	EnabledApis []*Value[string] `tf:"enabled_apis"`
+	EnabledApis []*Value[string] `tf:"enabled_apis" json:"enabled_apis,omitempty"`
 }
 
 // GoogleContainerClusterFleet is a nested-block type used by the parent resource.
 type GoogleContainerClusterFleet struct {
-	Membership         *Value[string] `tf:"membership"`
-	MembershipID       *Value[string] `tf:"membership_id"`
-	MembershipLocation *Value[string] `tf:"membership_location"`
-	PreRegistered      *Value[bool]   `tf:"pre_registered"`
-	Project            *Value[string] `tf:"project"`
+	Membership         *Value[string] `tf:"membership" json:"membership,omitempty"`
+	MembershipID       *Value[string] `tf:"membership_id" json:"membership_id,omitempty"`
+	MembershipLocation *Value[string] `tf:"membership_location" json:"membership_location,omitempty"`
+	PreRegistered      *Value[bool]   `tf:"pre_registered" json:"pre_registered,omitempty"`
+	Project            *Value[string] `tf:"project" json:"project,omitempty"`
 }
 
 // GoogleContainerClusterGatewayAPIConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterGatewayAPIConfig struct {
-	Channel *Value[string] `tf:"channel"`
+	Channel *Value[string] `tf:"channel" json:"channel,omitempty"`
 }
 
 // GoogleContainerClusterIdentityServiceConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterIdentityServiceConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterIpAllocationPolicy is a nested-block type used by the parent resource.
 type GoogleContainerClusterIpAllocationPolicy struct {
-	ClusterIPV4CIDRBlock       *Value[string]                                                       `tf:"cluster_ipv4_cidr_block"`
-	ClusterSecondaryRangeName  *Value[string]                                                       `tf:"cluster_secondary_range_name"`
-	ServicesIPV4CIDRBlock      *Value[string]                                                       `tf:"services_ipv4_cidr_block"`
-	ServicesSecondaryRangeName *Value[string]                                                       `tf:"services_secondary_range_name"`
-	StackType                  *Value[string]                                                       `tf:"stack_type"`
-	AdditionalPodRangesConfig  []GoogleContainerClusterIpAllocationPolicyAdditionalPodRangesConfig  `tf:"additional_pod_ranges_config,blocks"`
-	PodCIDROverprovisionConfig []GoogleContainerClusterIpAllocationPolicyPodCIDROverprovisionConfig `tf:"pod_cidr_overprovision_config,blocks"`
+	ClusterIPV4CIDRBlock       *Value[string]                                                       `tf:"cluster_ipv4_cidr_block" json:"cluster_ipv4_cidr_block,omitempty"`
+	ClusterSecondaryRangeName  *Value[string]                                                       `tf:"cluster_secondary_range_name" json:"cluster_secondary_range_name,omitempty"`
+	ServicesIPV4CIDRBlock      *Value[string]                                                       `tf:"services_ipv4_cidr_block" json:"services_ipv4_cidr_block,omitempty"`
+	ServicesSecondaryRangeName *Value[string]                                                       `tf:"services_secondary_range_name" json:"services_secondary_range_name,omitempty"`
+	StackType                  *Value[string]                                                       `tf:"stack_type" json:"stack_type,omitempty"`
+	AdditionalPodRangesConfig  []GoogleContainerClusterIpAllocationPolicyAdditionalPodRangesConfig  `tf:"additional_pod_ranges_config,blocks" json:"additional_pod_ranges_config,omitempty"`
+	PodCIDROverprovisionConfig []GoogleContainerClusterIpAllocationPolicyPodCIDROverprovisionConfig `tf:"pod_cidr_overprovision_config,blocks" json:"pod_cidr_overprovision_config,omitempty"`
 }
 
 // GoogleContainerClusterIpAllocationPolicyAdditionalPodRangesConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterIpAllocationPolicyAdditionalPodRangesConfig struct {
-	PodRangeNames []*Value[string] `tf:"pod_range_names"`
+	PodRangeNames []*Value[string] `tf:"pod_range_names" json:"pod_range_names,omitempty"`
 }
 
 // GoogleContainerClusterIpAllocationPolicyPodCIDROverprovisionConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterIpAllocationPolicyPodCIDROverprovisionConfig struct {
-	Disabled *Value[bool] `tf:"disabled"`
+	Disabled *Value[bool] `tf:"disabled" json:"disabled,omitempty"`
 }
 
 // GoogleContainerClusterLoggingConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterLoggingConfig struct {
-	EnableComponents []*Value[string] `tf:"enable_components"`
+	EnableComponents []*Value[string] `tf:"enable_components" json:"enable_components,omitempty"`
 }
 
 // GoogleContainerClusterMaintenancePolicy is a nested-block type used by the parent resource.
 type GoogleContainerClusterMaintenancePolicy struct {
-	DailyMaintenanceWindow []GoogleContainerClusterMaintenancePolicyDailyMaintenanceWindow `tf:"daily_maintenance_window,blocks"`
-	MaintenanceExclusion   []GoogleContainerClusterMaintenancePolicyMaintenanceExclusion   `tf:"maintenance_exclusion,blocks"`
-	RecurringWindow        []GoogleContainerClusterMaintenancePolicyRecurringWindow        `tf:"recurring_window,blocks"`
+	DailyMaintenanceWindow []GoogleContainerClusterMaintenancePolicyDailyMaintenanceWindow `tf:"daily_maintenance_window,blocks" json:"daily_maintenance_window,omitempty"`
+	MaintenanceExclusion   []GoogleContainerClusterMaintenancePolicyMaintenanceExclusion   `tf:"maintenance_exclusion,blocks" json:"maintenance_exclusion,omitempty"`
+	RecurringWindow        []GoogleContainerClusterMaintenancePolicyRecurringWindow        `tf:"recurring_window,blocks" json:"recurring_window,omitempty"`
 }
 
 // GoogleContainerClusterMaintenancePolicyDailyMaintenanceWindow is a nested-block type used by the parent resource.
 type GoogleContainerClusterMaintenancePolicyDailyMaintenanceWindow struct {
-	Duration  *Value[string] `tf:"duration"`
-	StartTime *Value[string] `tf:"start_time"`
+	Duration  *Value[string] `tf:"duration" json:"duration,omitempty"`
+	StartTime *Value[string] `tf:"start_time" json:"start_time,omitempty"`
 }
 
 // GoogleContainerClusterMaintenancePolicyMaintenanceExclusion is a nested-block type used by the parent resource.
 type GoogleContainerClusterMaintenancePolicyMaintenanceExclusion struct {
-	EndTime          *Value[string]                                                                `tf:"end_time"`
-	ExclusionName    *Value[string]                                                                `tf:"exclusion_name"`
-	StartTime        *Value[string]                                                                `tf:"start_time"`
-	ExclusionOptions []GoogleContainerClusterMaintenancePolicyMaintenanceExclusionExclusionOptions `tf:"exclusion_options,blocks"`
+	EndTime          *Value[string]                                                                `tf:"end_time" json:"end_time,omitempty"`
+	ExclusionName    *Value[string]                                                                `tf:"exclusion_name" json:"exclusion_name,omitempty"`
+	StartTime        *Value[string]                                                                `tf:"start_time" json:"start_time,omitempty"`
+	ExclusionOptions []GoogleContainerClusterMaintenancePolicyMaintenanceExclusionExclusionOptions `tf:"exclusion_options,blocks" json:"exclusion_options,omitempty"`
 }
 
 // GoogleContainerClusterMaintenancePolicyMaintenanceExclusionExclusionOptions is a nested-block type used by the parent resource.
 type GoogleContainerClusterMaintenancePolicyMaintenanceExclusionExclusionOptions struct {
-	Scope *Value[string] `tf:"scope"`
+	Scope *Value[string] `tf:"scope" json:"scope,omitempty"`
 }
 
 // GoogleContainerClusterMaintenancePolicyRecurringWindow is a nested-block type used by the parent resource.
 type GoogleContainerClusterMaintenancePolicyRecurringWindow struct {
-	EndTime    *Value[string] `tf:"end_time"`
-	Recurrence *Value[string] `tf:"recurrence"`
-	StartTime  *Value[string] `tf:"start_time"`
+	EndTime    *Value[string] `tf:"end_time" json:"end_time,omitempty"`
+	Recurrence *Value[string] `tf:"recurrence" json:"recurrence,omitempty"`
+	StartTime  *Value[string] `tf:"start_time" json:"start_time,omitempty"`
 }
 
 // GoogleContainerClusterMasterAuth is a nested-block type used by the parent resource.
 type GoogleContainerClusterMasterAuth struct {
-	ClientCertificate       *Value[string]                                            `tf:"client_certificate"`
-	ClientKey               *Value[string]                                            `tf:"client_key"`
-	ClusterCaCertificate    *Value[string]                                            `tf:"cluster_ca_certificate"`
-	ClientCertificateConfig []GoogleContainerClusterMasterAuthClientCertificateConfig `tf:"client_certificate_config,blocks"`
+	ClientCertificate       *Value[string]                                            `tf:"client_certificate" json:"client_certificate,omitempty"`
+	ClientKey               *Value[string]                                            `tf:"client_key" json:"client_key,omitempty"`
+	ClusterCaCertificate    *Value[string]                                            `tf:"cluster_ca_certificate" json:"cluster_ca_certificate,omitempty"`
+	ClientCertificateConfig []GoogleContainerClusterMasterAuthClientCertificateConfig `tf:"client_certificate_config,blocks" json:"client_certificate_config,omitempty"`
 }
 
 // GoogleContainerClusterMasterAuthClientCertificateConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterMasterAuthClientCertificateConfig struct {
-	IssueClientCertificate *Value[bool] `tf:"issue_client_certificate"`
+	IssueClientCertificate *Value[bool] `tf:"issue_client_certificate" json:"issue_client_certificate,omitempty"`
 }
 
 // GoogleContainerClusterMasterAuthorizedNetworksConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterMasterAuthorizedNetworksConfig struct {
-	GCPPublicCidrsAccessEnabled *Value[bool]                                                     `tf:"gcp_public_cidrs_access_enabled"`
-	CIDRBlocks                  []GoogleContainerClusterMasterAuthorizedNetworksConfigCIDRBlocks `tf:"cidr_blocks,blocks"`
+	GCPPublicCidrsAccessEnabled *Value[bool]                                                     `tf:"gcp_public_cidrs_access_enabled" json:"gcp_public_cidrs_access_enabled,omitempty"`
+	CIDRBlocks                  []GoogleContainerClusterMasterAuthorizedNetworksConfigCIDRBlocks `tf:"cidr_blocks,blocks" json:"cidr_blocks,omitempty"`
 }
 
 // GoogleContainerClusterMasterAuthorizedNetworksConfigCIDRBlocks is a nested-block type used by the parent resource.
 type GoogleContainerClusterMasterAuthorizedNetworksConfigCIDRBlocks struct {
-	CIDRBlock   *Value[string] `tf:"cidr_block"`
-	DisplayName *Value[string] `tf:"display_name"`
+	CIDRBlock   *Value[string] `tf:"cidr_block" json:"cidr_block,omitempty"`
+	DisplayName *Value[string] `tf:"display_name" json:"display_name,omitempty"`
 }
 
 // GoogleContainerClusterMeshCertificates is a nested-block type used by the parent resource.
 type GoogleContainerClusterMeshCertificates struct {
-	EnableCertificates *Value[bool] `tf:"enable_certificates"`
+	EnableCertificates *Value[bool] `tf:"enable_certificates" json:"enable_certificates,omitempty"`
 }
 
 // GoogleContainerClusterMonitoringConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterMonitoringConfig struct {
-	EnableComponents                    []*Value[string]                                                            `tf:"enable_components"`
-	AdvancedDatapathObservabilityConfig []GoogleContainerClusterMonitoringConfigAdvancedDatapathObservabilityConfig `tf:"advanced_datapath_observability_config,blocks"`
-	ManagedPrometheus                   []GoogleContainerClusterMonitoringConfigManagedPrometheus                   `tf:"managed_prometheus,blocks"`
+	EnableComponents                    []*Value[string]                                                            `tf:"enable_components" json:"enable_components,omitempty"`
+	AdvancedDatapathObservabilityConfig []GoogleContainerClusterMonitoringConfigAdvancedDatapathObservabilityConfig `tf:"advanced_datapath_observability_config,blocks" json:"advanced_datapath_observability_config,omitempty"`
+	ManagedPrometheus                   []GoogleContainerClusterMonitoringConfigManagedPrometheus                   `tf:"managed_prometheus,blocks" json:"managed_prometheus,omitempty"`
 }
 
 // GoogleContainerClusterMonitoringConfigAdvancedDatapathObservabilityConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterMonitoringConfigAdvancedDatapathObservabilityConfig struct {
-	EnableMetrics *Value[bool] `tf:"enable_metrics"`
-	EnableRelay   *Value[bool] `tf:"enable_relay"`
+	EnableMetrics *Value[bool] `tf:"enable_metrics" json:"enable_metrics,omitempty"`
+	EnableRelay   *Value[bool] `tf:"enable_relay" json:"enable_relay,omitempty"`
 }
 
 // GoogleContainerClusterMonitoringConfigManagedPrometheus is a nested-block type used by the parent resource.
 type GoogleContainerClusterMonitoringConfigManagedPrometheus struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterNetworkPolicy is a nested-block type used by the parent resource.
 type GoogleContainerClusterNetworkPolicy struct {
-	Enabled  *Value[bool]   `tf:"enabled"`
-	Provider *Value[string] `tf:"provider"`
+	Enabled  *Value[bool]   `tf:"enabled" json:"enabled,omitempty"`
+	Provider *Value[string] `tf:"provider" json:"provider,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfig struct {
-	BootDiskKMSKey                 *Value[string]                                                   `tf:"boot_disk_kms_key"`
-	DiskSizeGb                     *Value[float64]                                                  `tf:"disk_size_gb"`
-	DiskType                       *Value[string]                                                   `tf:"disk_type"`
-	EffectiveTaints                []GoogleContainerClusterNodeConfigEffectiveTaints                `tf:"effective_taints"`
-	EnableConfidentialStorage      *Value[bool]                                                     `tf:"enable_confidential_storage"`
-	ImageType                      *Value[string]                                                   `tf:"image_type"`
-	Labels                         map[string]*Value[string]                                        `tf:"labels"`
-	LocalSsdCount                  *Value[int64]                                                    `tf:"local_ssd_count"`
-	LoggingVariant                 *Value[string]                                                   `tf:"logging_variant"`
-	MachineType                    *Value[string]                                                   `tf:"machine_type"`
-	Metadata                       map[string]*Value[string]                                        `tf:"metadata"`
-	MinCPUPlatform                 *Value[string]                                                   `tf:"min_cpu_platform"`
-	NodeGroup                      *Value[string]                                                   `tf:"node_group"`
-	OauthScopes                    []*Value[string]                                                 `tf:"oauth_scopes"`
-	Preemptible                    *Value[bool]                                                     `tf:"preemptible"`
-	ResourceLabels                 map[string]*Value[string]                                        `tf:"resource_labels"`
-	ResourceManagerTags            map[string]*Value[string]                                        `tf:"resource_manager_tags"`
-	ServiceAccount                 *Value[string]                                                   `tf:"service_account"`
-	Spot                           *Value[bool]                                                     `tf:"spot"`
-	StoragePools                   []*Value[string]                                                 `tf:"storage_pools"`
-	Tags                           []*Value[string]                                                 `tf:"tags"`
-	AdvancedMachineFeatures        []GoogleContainerClusterNodeConfigAdvancedMachineFeatures        `tf:"advanced_machine_features,blocks"`
-	ConfidentialNodes              []GoogleContainerClusterNodeConfigConfidentialNodes              `tf:"confidential_nodes,blocks"`
-	ContainerdConfig               []GoogleContainerClusterNodeConfigContainerdConfig               `tf:"containerd_config,blocks"`
-	EphemeralStorageLocalSsdConfig []GoogleContainerClusterNodeConfigEphemeralStorageLocalSsdConfig `tf:"ephemeral_storage_local_ssd_config,blocks"`
-	FastSocket                     []GoogleContainerClusterNodeConfigFastSocket                     `tf:"fast_socket,blocks"`
-	GcfsConfig                     []GoogleContainerClusterNodeConfigGcfsConfig                     `tf:"gcfs_config,blocks"`
-	GuestAccelerator               []GoogleContainerClusterNodeConfigGuestAccelerator               `tf:"guest_accelerator,blocks"`
-	Gvnic                          []GoogleContainerClusterNodeConfigGvnic                          `tf:"gvnic,blocks"`
-	HostMaintenancePolicy          []GoogleContainerClusterNodeConfigHostMaintenancePolicy          `tf:"host_maintenance_policy,blocks"`
-	KubeletConfig                  []GoogleContainerClusterNodeConfigKubeletConfig                  `tf:"kubelet_config,blocks"`
-	LinuxNodeConfig                []GoogleContainerClusterNodeConfigLinuxNodeConfig                `tf:"linux_node_config,blocks"`
-	LocalNvmeSsdBlockConfig        []GoogleContainerClusterNodeConfigLocalNvmeSsdBlockConfig        `tf:"local_nvme_ssd_block_config,blocks"`
-	ReservationAffinity            []GoogleContainerClusterNodeConfigReservationAffinity            `tf:"reservation_affinity,blocks"`
-	SecondaryBootDisks             []GoogleContainerClusterNodeConfigSecondaryBootDisks             `tf:"secondary_boot_disks,blocks"`
-	ShieldedInstanceConfig         []GoogleContainerClusterNodeConfigShieldedInstanceConfig         `tf:"shielded_instance_config,blocks"`
-	SoleTenantConfig               []GoogleContainerClusterNodeConfigSoleTenantConfig               `tf:"sole_tenant_config,blocks"`
-	Taint                          []GoogleContainerClusterNodeConfigTaint                          `tf:"taint,blocks"`
-	WorkloadMetadataConfig         []GoogleContainerClusterNodeConfigWorkloadMetadataConfig         `tf:"workload_metadata_config,blocks"`
+	BootDiskKMSKey                 *Value[string]                                                   `tf:"boot_disk_kms_key" json:"boot_disk_kms_key,omitempty"`
+	DiskSizeGb                     *Value[float64]                                                  `tf:"disk_size_gb" json:"disk_size_gb,omitempty"`
+	DiskType                       *Value[string]                                                   `tf:"disk_type" json:"disk_type,omitempty"`
+	EffectiveTaints                []GoogleContainerClusterNodeConfigEffectiveTaints                `tf:"effective_taints" json:"effective_taints,omitempty"`
+	EnableConfidentialStorage      *Value[bool]                                                     `tf:"enable_confidential_storage" json:"enable_confidential_storage,omitempty"`
+	ImageType                      *Value[string]                                                   `tf:"image_type" json:"image_type,omitempty"`
+	Labels                         map[string]*Value[string]                                        `tf:"labels" json:"labels,omitempty"`
+	LocalSsdCount                  *Value[int64]                                                    `tf:"local_ssd_count" json:"local_ssd_count,omitempty"`
+	LoggingVariant                 *Value[string]                                                   `tf:"logging_variant" json:"logging_variant,omitempty"`
+	MachineType                    *Value[string]                                                   `tf:"machine_type" json:"machine_type,omitempty"`
+	Metadata                       map[string]*Value[string]                                        `tf:"metadata" json:"metadata,omitempty"`
+	MinCPUPlatform                 *Value[string]                                                   `tf:"min_cpu_platform" json:"min_cpu_platform,omitempty"`
+	NodeGroup                      *Value[string]                                                   `tf:"node_group" json:"node_group,omitempty"`
+	OauthScopes                    []*Value[string]                                                 `tf:"oauth_scopes" json:"oauth_scopes,omitempty"`
+	Preemptible                    *Value[bool]                                                     `tf:"preemptible" json:"preemptible,omitempty"`
+	ResourceLabels                 map[string]*Value[string]                                        `tf:"resource_labels" json:"resource_labels,omitempty"`
+	ResourceManagerTags            map[string]*Value[string]                                        `tf:"resource_manager_tags" json:"resource_manager_tags,omitempty"`
+	ServiceAccount                 *Value[string]                                                   `tf:"service_account" json:"service_account,omitempty"`
+	Spot                           *Value[bool]                                                     `tf:"spot" json:"spot,omitempty"`
+	StoragePools                   []*Value[string]                                                 `tf:"storage_pools" json:"storage_pools,omitempty"`
+	Tags                           []*Value[string]                                                 `tf:"tags" json:"tags,omitempty"`
+	AdvancedMachineFeatures        []GoogleContainerClusterNodeConfigAdvancedMachineFeatures        `tf:"advanced_machine_features,blocks" json:"advanced_machine_features,omitempty"`
+	ConfidentialNodes              []GoogleContainerClusterNodeConfigConfidentialNodes              `tf:"confidential_nodes,blocks" json:"confidential_nodes,omitempty"`
+	ContainerdConfig               []GoogleContainerClusterNodeConfigContainerdConfig               `tf:"containerd_config,blocks" json:"containerd_config,omitempty"`
+	EphemeralStorageLocalSsdConfig []GoogleContainerClusterNodeConfigEphemeralStorageLocalSsdConfig `tf:"ephemeral_storage_local_ssd_config,blocks" json:"ephemeral_storage_local_ssd_config,omitempty"`
+	FastSocket                     []GoogleContainerClusterNodeConfigFastSocket                     `tf:"fast_socket,blocks" json:"fast_socket,omitempty"`
+	GcfsConfig                     []GoogleContainerClusterNodeConfigGcfsConfig                     `tf:"gcfs_config,blocks" json:"gcfs_config,omitempty"`
+	GuestAccelerator               []GoogleContainerClusterNodeConfigGuestAccelerator               `tf:"guest_accelerator,blocks" json:"guest_accelerator,omitempty"`
+	Gvnic                          []GoogleContainerClusterNodeConfigGvnic                          `tf:"gvnic,blocks" json:"gvnic,omitempty"`
+	HostMaintenancePolicy          []GoogleContainerClusterNodeConfigHostMaintenancePolicy          `tf:"host_maintenance_policy,blocks" json:"host_maintenance_policy,omitempty"`
+	KubeletConfig                  []GoogleContainerClusterNodeConfigKubeletConfig                  `tf:"kubelet_config,blocks" json:"kubelet_config,omitempty"`
+	LinuxNodeConfig                []GoogleContainerClusterNodeConfigLinuxNodeConfig                `tf:"linux_node_config,blocks" json:"linux_node_config,omitempty"`
+	LocalNvmeSsdBlockConfig        []GoogleContainerClusterNodeConfigLocalNvmeSsdBlockConfig        `tf:"local_nvme_ssd_block_config,blocks" json:"local_nvme_ssd_block_config,omitempty"`
+	ReservationAffinity            []GoogleContainerClusterNodeConfigReservationAffinity            `tf:"reservation_affinity,blocks" json:"reservation_affinity,omitempty"`
+	SecondaryBootDisks             []GoogleContainerClusterNodeConfigSecondaryBootDisks             `tf:"secondary_boot_disks,blocks" json:"secondary_boot_disks,omitempty"`
+	ShieldedInstanceConfig         []GoogleContainerClusterNodeConfigShieldedInstanceConfig         `tf:"shielded_instance_config,blocks" json:"shielded_instance_config,omitempty"`
+	SoleTenantConfig               []GoogleContainerClusterNodeConfigSoleTenantConfig               `tf:"sole_tenant_config,blocks" json:"sole_tenant_config,omitempty"`
+	Taint                          []GoogleContainerClusterNodeConfigTaint                          `tf:"taint,blocks" json:"taint,omitempty"`
+	WorkloadMetadataConfig         []GoogleContainerClusterNodeConfigWorkloadMetadataConfig         `tf:"workload_metadata_config,blocks" json:"workload_metadata_config,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigAdvancedMachineFeatures is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigAdvancedMachineFeatures struct {
-	EnableNestedVirtualization *Value[bool]    `tf:"enable_nested_virtualization"`
-	ThreadsPerCore             *Value[float64] `tf:"threads_per_core"`
+	EnableNestedVirtualization *Value[bool]    `tf:"enable_nested_virtualization" json:"enable_nested_virtualization,omitempty"`
+	ThreadsPerCore             *Value[float64] `tf:"threads_per_core" json:"threads_per_core,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigConfidentialNodes is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigConfidentialNodes struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigContainerdConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigContainerdConfig struct {
-	PrivateRegistryAccessConfig []GoogleContainerClusterNodeConfigContainerdConfigPrivateRegistryAccessConfig `tf:"private_registry_access_config,blocks"`
+	PrivateRegistryAccessConfig []GoogleContainerClusterNodeConfigContainerdConfigPrivateRegistryAccessConfig `tf:"private_registry_access_config,blocks" json:"private_registry_access_config,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigContainerdConfigPrivateRegistryAccessConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigContainerdConfigPrivateRegistryAccessConfig struct {
-	Enabled                          *Value[bool]                                                                                                  `tf:"enabled"`
-	CertificateAuthorityDomainConfig []GoogleContainerClusterNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig `tf:"certificate_authority_domain_config,blocks"`
+	Enabled                          *Value[bool]                                                                                                  `tf:"enabled" json:"enabled,omitempty"`
+	CertificateAuthorityDomainConfig []GoogleContainerClusterNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig `tf:"certificate_authority_domain_config,blocks" json:"certificate_authority_domain_config,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig struct {
-	Fqdns                             []*Value[string]                                                                                                                               `tf:"fqdns"`
-	GCPSecretManagerCertificateConfig []GoogleContainerClusterNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig `tf:"gcp_secret_manager_certificate_config,blocks"`
+	Fqdns                             []*Value[string]                                                                                                                               `tf:"fqdns" json:"fqdns,omitempty"`
+	GCPSecretManagerCertificateConfig []GoogleContainerClusterNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig `tf:"gcp_secret_manager_certificate_config,blocks" json:"gcp_secret_manager_certificate_config,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig struct {
-	SecretURI *Value[string] `tf:"secret_uri"`
+	SecretURI *Value[string] `tf:"secret_uri" json:"secret_uri,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigEffectiveTaints is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigEffectiveTaints struct {
-	Effect *Value[string] `tf:"effect"`
-	Key    *Value[string] `tf:"key"`
-	Value  *Value[string] `tf:"value"`
+	Effect *Value[string] `tf:"effect" json:"effect,omitempty"`
+	Key    *Value[string] `tf:"key" json:"key,omitempty"`
+	Value  *Value[string] `tf:"value" json:"value,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigEphemeralStorageLocalSsdConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigEphemeralStorageLocalSsdConfig struct {
-	LocalSsdCount *Value[int64] `tf:"local_ssd_count"`
+	LocalSsdCount *Value[int64] `tf:"local_ssd_count" json:"local_ssd_count,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigFastSocket is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigFastSocket struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigGcfsConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigGcfsConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigGuestAccelerator is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigGuestAccelerator struct {
-	Count                       *Value[float64]                                                               `tf:"count"`
-	GpuPartitionSize            *Value[string]                                                                `tf:"gpu_partition_size"`
-	Type_                       *Value[string]                                                                `tf:"type"`
-	GpuDriverInstallationConfig []GoogleContainerClusterNodeConfigGuestAcceleratorGpuDriverInstallationConfig `tf:"gpu_driver_installation_config,blocks"`
-	GpuSharingConfig            []GoogleContainerClusterNodeConfigGuestAcceleratorGpuSharingConfig            `tf:"gpu_sharing_config,blocks"`
+	Count                       *Value[float64]                                                               `tf:"count" json:"count,omitempty"`
+	GpuPartitionSize            *Value[string]                                                                `tf:"gpu_partition_size" json:"gpu_partition_size,omitempty"`
+	Type_                       *Value[string]                                                                `tf:"type" json:"type,omitempty"`
+	GpuDriverInstallationConfig []GoogleContainerClusterNodeConfigGuestAcceleratorGpuDriverInstallationConfig `tf:"gpu_driver_installation_config,blocks" json:"gpu_driver_installation_config,omitempty"`
+	GpuSharingConfig            []GoogleContainerClusterNodeConfigGuestAcceleratorGpuSharingConfig            `tf:"gpu_sharing_config,blocks" json:"gpu_sharing_config,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigGuestAcceleratorGpuDriverInstallationConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigGuestAcceleratorGpuDriverInstallationConfig struct {
-	GpuDriverVersion *Value[string] `tf:"gpu_driver_version"`
+	GpuDriverVersion *Value[string] `tf:"gpu_driver_version" json:"gpu_driver_version,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigGuestAcceleratorGpuSharingConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigGuestAcceleratorGpuSharingConfig struct {
-	GpuSharingStrategy     *Value[string] `tf:"gpu_sharing_strategy"`
-	MaxSharedClientsPerGpu *Value[int64]  `tf:"max_shared_clients_per_gpu"`
+	GpuSharingStrategy     *Value[string] `tf:"gpu_sharing_strategy" json:"gpu_sharing_strategy,omitempty"`
+	MaxSharedClientsPerGpu *Value[int64]  `tf:"max_shared_clients_per_gpu" json:"max_shared_clients_per_gpu,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigGvnic is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigGvnic struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigHostMaintenancePolicy is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigHostMaintenancePolicy struct {
-	MaintenanceInterval *Value[string] `tf:"maintenance_interval"`
+	MaintenanceInterval *Value[string] `tf:"maintenance_interval" json:"maintenance_interval,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigKubeletConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigKubeletConfig struct {
-	CPUCfsQuota                        *Value[bool]    `tf:"cpu_cfs_quota"`
-	CPUCfsQuotaPeriod                  *Value[string]  `tf:"cpu_cfs_quota_period"`
-	CPUManagerPolicy                   *Value[string]  `tf:"cpu_manager_policy"`
-	InsecureKubeletReadonlyPortEnabled *Value[string]  `tf:"insecure_kubelet_readonly_port_enabled"`
-	PodPidsLimit                       *Value[float64] `tf:"pod_pids_limit"`
+	CPUCfsQuota                        *Value[bool]    `tf:"cpu_cfs_quota" json:"cpu_cfs_quota,omitempty"`
+	CPUCfsQuotaPeriod                  *Value[string]  `tf:"cpu_cfs_quota_period" json:"cpu_cfs_quota_period,omitempty"`
+	CPUManagerPolicy                   *Value[string]  `tf:"cpu_manager_policy" json:"cpu_manager_policy,omitempty"`
+	InsecureKubeletReadonlyPortEnabled *Value[string]  `tf:"insecure_kubelet_readonly_port_enabled" json:"insecure_kubelet_readonly_port_enabled,omitempty"`
+	PodPidsLimit                       *Value[float64] `tf:"pod_pids_limit" json:"pod_pids_limit,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigLinuxNodeConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigLinuxNodeConfig struct {
-	CgroupMode      *Value[string]                                                   `tf:"cgroup_mode"`
-	Sysctls         map[string]*Value[string]                                        `tf:"sysctls"`
-	HugepagesConfig []GoogleContainerClusterNodeConfigLinuxNodeConfigHugepagesConfig `tf:"hugepages_config,blocks"`
+	CgroupMode      *Value[string]                                                   `tf:"cgroup_mode" json:"cgroup_mode,omitempty"`
+	Sysctls         map[string]*Value[string]                                        `tf:"sysctls" json:"sysctls,omitempty"`
+	HugepagesConfig []GoogleContainerClusterNodeConfigLinuxNodeConfigHugepagesConfig `tf:"hugepages_config,blocks" json:"hugepages_config,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigLinuxNodeConfigHugepagesConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigLinuxNodeConfigHugepagesConfig struct {
-	HugepageSize1g *Value[float64] `tf:"hugepage_size_1g"`
-	HugepageSize2m *Value[float64] `tf:"hugepage_size_2m"`
+	HugepageSize1g *Value[float64] `tf:"hugepage_size_1g" json:"hugepage_size_1g,omitempty"`
+	HugepageSize2m *Value[float64] `tf:"hugepage_size_2m" json:"hugepage_size_2m,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigLocalNvmeSsdBlockConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigLocalNvmeSsdBlockConfig struct {
-	LocalSsdCount *Value[int64] `tf:"local_ssd_count"`
+	LocalSsdCount *Value[int64] `tf:"local_ssd_count" json:"local_ssd_count,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigReservationAffinity is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigReservationAffinity struct {
-	ConsumeReservationType *Value[string]   `tf:"consume_reservation_type"`
-	Key                    *Value[string]   `tf:"key"`
-	Values                 []*Value[string] `tf:"values"`
+	ConsumeReservationType *Value[string]   `tf:"consume_reservation_type" json:"consume_reservation_type,omitempty"`
+	Key                    *Value[string]   `tf:"key" json:"key,omitempty"`
+	Values                 []*Value[string] `tf:"values" json:"values,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigSecondaryBootDisks is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigSecondaryBootDisks struct {
-	DiskImage *Value[string] `tf:"disk_image"`
-	Mode      *Value[string] `tf:"mode"`
+	DiskImage *Value[string] `tf:"disk_image" json:"disk_image,omitempty"`
+	Mode      *Value[string] `tf:"mode" json:"mode,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigShieldedInstanceConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigShieldedInstanceConfig struct {
-	EnableIntegrityMonitoring *Value[bool] `tf:"enable_integrity_monitoring"`
-	EnableSecureBoot          *Value[bool] `tf:"enable_secure_boot"`
+	EnableIntegrityMonitoring *Value[bool] `tf:"enable_integrity_monitoring" json:"enable_integrity_monitoring,omitempty"`
+	EnableSecureBoot          *Value[bool] `tf:"enable_secure_boot" json:"enable_secure_boot,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigSoleTenantConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigSoleTenantConfig struct {
-	NodeAffinity []GoogleContainerClusterNodeConfigSoleTenantConfigNodeAffinity `tf:"node_affinity,blocks"`
+	NodeAffinity []GoogleContainerClusterNodeConfigSoleTenantConfigNodeAffinity `tf:"node_affinity,blocks" json:"node_affinity,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigSoleTenantConfigNodeAffinity is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigSoleTenantConfigNodeAffinity struct {
-	Key      *Value[string]   `tf:"key"`
-	Operator *Value[string]   `tf:"operator"`
-	Values   []*Value[string] `tf:"values"`
+	Key      *Value[string]   `tf:"key" json:"key,omitempty"`
+	Operator *Value[string]   `tf:"operator" json:"operator,omitempty"`
+	Values   []*Value[string] `tf:"values" json:"values,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigTaint is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigTaint struct {
-	Effect *Value[string] `tf:"effect"`
-	Key    *Value[string] `tf:"key"`
-	Value  *Value[string] `tf:"value"`
+	Effect *Value[string] `tf:"effect" json:"effect,omitempty"`
+	Key    *Value[string] `tf:"key" json:"key,omitempty"`
+	Value  *Value[string] `tf:"value" json:"value,omitempty"`
 }
 
 // GoogleContainerClusterNodeConfigWorkloadMetadataConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodeConfigWorkloadMetadataConfig struct {
-	Mode *Value[string] `tf:"mode"`
+	Mode *Value[string] `tf:"mode" json:"mode,omitempty"`
 }
 
 // GoogleContainerClusterNodePool is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePool struct {
-	InitialNodeCount         *Value[int64]                                      `tf:"initial_node_count"`
-	InstanceGroupUrls        []*Value[string]                                   `tf:"instance_group_urls"`
-	ManagedInstanceGroupUrls []*Value[string]                                   `tf:"managed_instance_group_urls"`
-	MaxPodsPerNode           *Value[int64]                                      `tf:"max_pods_per_node"`
-	Name                     *Value[string]                                     `tf:"name"`
-	NamePrefix               *Value[string]                                     `tf:"name_prefix"`
-	NodeCount                *Value[int64]                                      `tf:"node_count"`
-	NodeLocations            []*Value[string]                                   `tf:"node_locations"`
-	Version                  *Value[string]                                     `tf:"version"`
-	Autoscaling              []GoogleContainerClusterNodePoolAutoscaling        `tf:"autoscaling,blocks"`
-	Management               []GoogleContainerClusterNodePoolManagement         `tf:"management,blocks"`
-	NetworkConfig            []GoogleContainerClusterNodePoolNetworkConfig      `tf:"network_config,blocks"`
-	NodeConfig               []GoogleContainerClusterNodePoolNodeConfig         `tf:"node_config,blocks"`
-	PlacementPolicy          []GoogleContainerClusterNodePoolPlacementPolicy    `tf:"placement_policy,blocks"`
-	QueuedProvisioning       []GoogleContainerClusterNodePoolQueuedProvisioning `tf:"queued_provisioning,blocks"`
-	UpgradeSettings          []GoogleContainerClusterNodePoolUpgradeSettings    `tf:"upgrade_settings,blocks"`
+	InitialNodeCount         *Value[int64]                                      `tf:"initial_node_count" json:"initial_node_count,omitempty"`
+	InstanceGroupUrls        []*Value[string]                                   `tf:"instance_group_urls" json:"instance_group_urls,omitempty"`
+	ManagedInstanceGroupUrls []*Value[string]                                   `tf:"managed_instance_group_urls" json:"managed_instance_group_urls,omitempty"`
+	MaxPodsPerNode           *Value[int64]                                      `tf:"max_pods_per_node" json:"max_pods_per_node,omitempty"`
+	Name                     *Value[string]                                     `tf:"name" json:"name,omitempty"`
+	NamePrefix               *Value[string]                                     `tf:"name_prefix" json:"name_prefix,omitempty"`
+	NodeCount                *Value[int64]                                      `tf:"node_count" json:"node_count,omitempty"`
+	NodeLocations            []*Value[string]                                   `tf:"node_locations" json:"node_locations,omitempty"`
+	Version                  *Value[string]                                     `tf:"version" json:"version,omitempty"`
+	Autoscaling              []GoogleContainerClusterNodePoolAutoscaling        `tf:"autoscaling,blocks" json:"autoscaling,omitempty"`
+	Management               []GoogleContainerClusterNodePoolManagement         `tf:"management,blocks" json:"management,omitempty"`
+	NetworkConfig            []GoogleContainerClusterNodePoolNetworkConfig      `tf:"network_config,blocks" json:"network_config,omitempty"`
+	NodeConfig               []GoogleContainerClusterNodePoolNodeConfig         `tf:"node_config,blocks" json:"node_config,omitempty"`
+	PlacementPolicy          []GoogleContainerClusterNodePoolPlacementPolicy    `tf:"placement_policy,blocks" json:"placement_policy,omitempty"`
+	QueuedProvisioning       []GoogleContainerClusterNodePoolQueuedProvisioning `tf:"queued_provisioning,blocks" json:"queued_provisioning,omitempty"`
+	UpgradeSettings          []GoogleContainerClusterNodePoolUpgradeSettings    `tf:"upgrade_settings,blocks" json:"upgrade_settings,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolAutoConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolAutoConfig struct {
-	ResourceManagerTags map[string]*Value[string]                                   `tf:"resource_manager_tags"`
-	NetworkTags         []GoogleContainerClusterNodePoolAutoConfigNetworkTags       `tf:"network_tags,blocks"`
-	NodeKubeletConfig   []GoogleContainerClusterNodePoolAutoConfigNodeKubeletConfig `tf:"node_kubelet_config,blocks"`
+	ResourceManagerTags map[string]*Value[string]                                   `tf:"resource_manager_tags" json:"resource_manager_tags,omitempty"`
+	NetworkTags         []GoogleContainerClusterNodePoolAutoConfigNetworkTags       `tf:"network_tags,blocks" json:"network_tags,omitempty"`
+	NodeKubeletConfig   []GoogleContainerClusterNodePoolAutoConfigNodeKubeletConfig `tf:"node_kubelet_config,blocks" json:"node_kubelet_config,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolAutoConfigNetworkTags is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolAutoConfigNetworkTags struct {
-	Tags []*Value[string] `tf:"tags"`
+	Tags []*Value[string] `tf:"tags" json:"tags,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolAutoConfigNodeKubeletConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolAutoConfigNodeKubeletConfig struct {
-	InsecureKubeletReadonlyPortEnabled *Value[string] `tf:"insecure_kubelet_readonly_port_enabled"`
+	InsecureKubeletReadonlyPortEnabled *Value[string] `tf:"insecure_kubelet_readonly_port_enabled" json:"insecure_kubelet_readonly_port_enabled,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolAutoscaling is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolAutoscaling struct {
-	LocationPolicy    *Value[string] `tf:"location_policy"`
-	MaxNodeCount      *Value[int64]  `tf:"max_node_count"`
-	MinNodeCount      *Value[int64]  `tf:"min_node_count"`
-	TotalMaxNodeCount *Value[int64]  `tf:"total_max_node_count"`
-	TotalMinNodeCount *Value[int64]  `tf:"total_min_node_count"`
+	LocationPolicy    *Value[string] `tf:"location_policy" json:"location_policy,omitempty"`
+	MaxNodeCount      *Value[int64]  `tf:"max_node_count" json:"max_node_count,omitempty"`
+	MinNodeCount      *Value[int64]  `tf:"min_node_count" json:"min_node_count,omitempty"`
+	TotalMaxNodeCount *Value[int64]  `tf:"total_max_node_count" json:"total_max_node_count,omitempty"`
+	TotalMinNodeCount *Value[int64]  `tf:"total_min_node_count" json:"total_min_node_count,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolDefaults is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolDefaults struct {
-	NodeConfigDefaults []GoogleContainerClusterNodePoolDefaultsNodeConfigDefaults `tf:"node_config_defaults,blocks"`
+	NodeConfigDefaults []GoogleContainerClusterNodePoolDefaultsNodeConfigDefaults `tf:"node_config_defaults,blocks" json:"node_config_defaults,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolDefaultsNodeConfigDefaults is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolDefaultsNodeConfigDefaults struct {
-	InsecureKubeletReadonlyPortEnabled *Value[string]                                                             `tf:"insecure_kubelet_readonly_port_enabled"`
-	LoggingVariant                     *Value[string]                                                             `tf:"logging_variant"`
-	ContainerdConfig                   []GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfig `tf:"containerd_config,blocks"`
-	GcfsConfig                         []GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsGcfsConfig       `tf:"gcfs_config,blocks"`
+	InsecureKubeletReadonlyPortEnabled *Value[string]                                                             `tf:"insecure_kubelet_readonly_port_enabled" json:"insecure_kubelet_readonly_port_enabled,omitempty"`
+	LoggingVariant                     *Value[string]                                                             `tf:"logging_variant" json:"logging_variant,omitempty"`
+	ContainerdConfig                   []GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfig `tf:"containerd_config,blocks" json:"containerd_config,omitempty"`
+	GcfsConfig                         []GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsGcfsConfig       `tf:"gcfs_config,blocks" json:"gcfs_config,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfig struct {
-	PrivateRegistryAccessConfig []GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfigPrivateRegistryAccessConfig `tf:"private_registry_access_config,blocks"`
+	PrivateRegistryAccessConfig []GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfigPrivateRegistryAccessConfig `tf:"private_registry_access_config,blocks" json:"private_registry_access_config,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfigPrivateRegistryAccessConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfigPrivateRegistryAccessConfig struct {
-	Enabled                          *Value[bool]                                                                                                                          `tf:"enabled"`
-	CertificateAuthorityDomainConfig []GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig `tf:"certificate_authority_domain_config,blocks"`
+	Enabled                          *Value[bool]                                                                                                                          `tf:"enabled" json:"enabled,omitempty"`
+	CertificateAuthorityDomainConfig []GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig `tf:"certificate_authority_domain_config,blocks" json:"certificate_authority_domain_config,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig struct {
-	Fqdns                             []*Value[string]                                                                                                                                                       `tf:"fqdns"`
-	GCPSecretManagerCertificateConfig []GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig `tf:"gcp_secret_manager_certificate_config,blocks"`
+	Fqdns                             []*Value[string]                                                                                                                                                       `tf:"fqdns" json:"fqdns,omitempty"`
+	GCPSecretManagerCertificateConfig []GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig `tf:"gcp_secret_manager_certificate_config,blocks" json:"gcp_secret_manager_certificate_config,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig struct {
-	SecretURI *Value[string] `tf:"secret_uri"`
+	SecretURI *Value[string] `tf:"secret_uri" json:"secret_uri,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsGcfsConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolDefaultsNodeConfigDefaultsGcfsConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolManagement is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolManagement struct {
-	AutoRepair  *Value[bool] `tf:"auto_repair"`
-	AutoUpgrade *Value[bool] `tf:"auto_upgrade"`
+	AutoRepair  *Value[bool] `tf:"auto_repair" json:"auto_repair,omitempty"`
+	AutoUpgrade *Value[bool] `tf:"auto_upgrade" json:"auto_upgrade,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNetworkConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNetworkConfig struct {
-	CreatePodRange               *Value[bool]                                                              `tf:"create_pod_range"`
-	EnablePrivateNodes           *Value[bool]                                                              `tf:"enable_private_nodes"`
-	PodIPV4CIDRBlock             *Value[string]                                                            `tf:"pod_ipv4_cidr_block"`
-	PodRange                     *Value[string]                                                            `tf:"pod_range"`
-	AdditionalNodeNetworkConfigs []GoogleContainerClusterNodePoolNetworkConfigAdditionalNodeNetworkConfigs `tf:"additional_node_network_configs,blocks"`
-	AdditionalPodNetworkConfigs  []GoogleContainerClusterNodePoolNetworkConfigAdditionalPodNetworkConfigs  `tf:"additional_pod_network_configs,blocks"`
-	NetworkPerformanceConfig     []GoogleContainerClusterNodePoolNetworkConfigNetworkPerformanceConfig     `tf:"network_performance_config,blocks"`
-	PodCIDROverprovisionConfig   []GoogleContainerClusterNodePoolNetworkConfigPodCIDROverprovisionConfig   `tf:"pod_cidr_overprovision_config,blocks"`
+	CreatePodRange               *Value[bool]                                                              `tf:"create_pod_range" json:"create_pod_range,omitempty"`
+	EnablePrivateNodes           *Value[bool]                                                              `tf:"enable_private_nodes" json:"enable_private_nodes,omitempty"`
+	PodIPV4CIDRBlock             *Value[string]                                                            `tf:"pod_ipv4_cidr_block" json:"pod_ipv4_cidr_block,omitempty"`
+	PodRange                     *Value[string]                                                            `tf:"pod_range" json:"pod_range,omitempty"`
+	AdditionalNodeNetworkConfigs []GoogleContainerClusterNodePoolNetworkConfigAdditionalNodeNetworkConfigs `tf:"additional_node_network_configs,blocks" json:"additional_node_network_configs,omitempty"`
+	AdditionalPodNetworkConfigs  []GoogleContainerClusterNodePoolNetworkConfigAdditionalPodNetworkConfigs  `tf:"additional_pod_network_configs,blocks" json:"additional_pod_network_configs,omitempty"`
+	NetworkPerformanceConfig     []GoogleContainerClusterNodePoolNetworkConfigNetworkPerformanceConfig     `tf:"network_performance_config,blocks" json:"network_performance_config,omitempty"`
+	PodCIDROverprovisionConfig   []GoogleContainerClusterNodePoolNetworkConfigPodCIDROverprovisionConfig   `tf:"pod_cidr_overprovision_config,blocks" json:"pod_cidr_overprovision_config,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNetworkConfigAdditionalNodeNetworkConfigs is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNetworkConfigAdditionalNodeNetworkConfigs struct {
-	Network    *Value[string] `tf:"network"`
-	Subnetwork *Value[string] `tf:"subnetwork"`
+	Network    *Value[string] `tf:"network" json:"network,omitempty"`
+	Subnetwork *Value[string] `tf:"subnetwork" json:"subnetwork,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNetworkConfigAdditionalPodNetworkConfigs is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNetworkConfigAdditionalPodNetworkConfigs struct {
-	MaxPodsPerNode    *Value[int64]  `tf:"max_pods_per_node"`
-	SecondaryPodRange *Value[string] `tf:"secondary_pod_range"`
-	Subnetwork        *Value[string] `tf:"subnetwork"`
+	MaxPodsPerNode    *Value[int64]  `tf:"max_pods_per_node" json:"max_pods_per_node,omitempty"`
+	SecondaryPodRange *Value[string] `tf:"secondary_pod_range" json:"secondary_pod_range,omitempty"`
+	Subnetwork        *Value[string] `tf:"subnetwork" json:"subnetwork,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNetworkConfigNetworkPerformanceConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNetworkConfigNetworkPerformanceConfig struct {
-	TotalEgressBandwidthTier *Value[string] `tf:"total_egress_bandwidth_tier"`
+	TotalEgressBandwidthTier *Value[string] `tf:"total_egress_bandwidth_tier" json:"total_egress_bandwidth_tier,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNetworkConfigPodCIDROverprovisionConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNetworkConfigPodCIDROverprovisionConfig struct {
-	Disabled *Value[bool] `tf:"disabled"`
+	Disabled *Value[bool] `tf:"disabled" json:"disabled,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfig struct {
-	BootDiskKMSKey                 *Value[string]                                                           `tf:"boot_disk_kms_key"`
-	DiskSizeGb                     *Value[float64]                                                          `tf:"disk_size_gb"`
-	DiskType                       *Value[string]                                                           `tf:"disk_type"`
-	EffectiveTaints                []GoogleContainerClusterNodePoolNodeConfigEffectiveTaints                `tf:"effective_taints"`
-	EnableConfidentialStorage      *Value[bool]                                                             `tf:"enable_confidential_storage"`
-	ImageType                      *Value[string]                                                           `tf:"image_type"`
-	Labels                         map[string]*Value[string]                                                `tf:"labels"`
-	LocalSsdCount                  *Value[int64]                                                            `tf:"local_ssd_count"`
-	LoggingVariant                 *Value[string]                                                           `tf:"logging_variant"`
-	MachineType                    *Value[string]                                                           `tf:"machine_type"`
-	Metadata                       map[string]*Value[string]                                                `tf:"metadata"`
-	MinCPUPlatform                 *Value[string]                                                           `tf:"min_cpu_platform"`
-	NodeGroup                      *Value[string]                                                           `tf:"node_group"`
-	OauthScopes                    []*Value[string]                                                         `tf:"oauth_scopes"`
-	Preemptible                    *Value[bool]                                                             `tf:"preemptible"`
-	ResourceLabels                 map[string]*Value[string]                                                `tf:"resource_labels"`
-	ResourceManagerTags            map[string]*Value[string]                                                `tf:"resource_manager_tags"`
-	ServiceAccount                 *Value[string]                                                           `tf:"service_account"`
-	Spot                           *Value[bool]                                                             `tf:"spot"`
-	StoragePools                   []*Value[string]                                                         `tf:"storage_pools"`
-	Tags                           []*Value[string]                                                         `tf:"tags"`
-	AdvancedMachineFeatures        []GoogleContainerClusterNodePoolNodeConfigAdvancedMachineFeatures        `tf:"advanced_machine_features,blocks"`
-	ConfidentialNodes              []GoogleContainerClusterNodePoolNodeConfigConfidentialNodes              `tf:"confidential_nodes,blocks"`
-	ContainerdConfig               []GoogleContainerClusterNodePoolNodeConfigContainerdConfig               `tf:"containerd_config,blocks"`
-	EphemeralStorageLocalSsdConfig []GoogleContainerClusterNodePoolNodeConfigEphemeralStorageLocalSsdConfig `tf:"ephemeral_storage_local_ssd_config,blocks"`
-	FastSocket                     []GoogleContainerClusterNodePoolNodeConfigFastSocket                     `tf:"fast_socket,blocks"`
-	GcfsConfig                     []GoogleContainerClusterNodePoolNodeConfigGcfsConfig                     `tf:"gcfs_config,blocks"`
-	GuestAccelerator               []GoogleContainerClusterNodePoolNodeConfigGuestAccelerator               `tf:"guest_accelerator,blocks"`
-	Gvnic                          []GoogleContainerClusterNodePoolNodeConfigGvnic                          `tf:"gvnic,blocks"`
-	HostMaintenancePolicy          []GoogleContainerClusterNodePoolNodeConfigHostMaintenancePolicy          `tf:"host_maintenance_policy,blocks"`
-	KubeletConfig                  []GoogleContainerClusterNodePoolNodeConfigKubeletConfig                  `tf:"kubelet_config,blocks"`
-	LinuxNodeConfig                []GoogleContainerClusterNodePoolNodeConfigLinuxNodeConfig                `tf:"linux_node_config,blocks"`
-	LocalNvmeSsdBlockConfig        []GoogleContainerClusterNodePoolNodeConfigLocalNvmeSsdBlockConfig        `tf:"local_nvme_ssd_block_config,blocks"`
-	ReservationAffinity            []GoogleContainerClusterNodePoolNodeConfigReservationAffinity            `tf:"reservation_affinity,blocks"`
-	SecondaryBootDisks             []GoogleContainerClusterNodePoolNodeConfigSecondaryBootDisks             `tf:"secondary_boot_disks,blocks"`
-	ShieldedInstanceConfig         []GoogleContainerClusterNodePoolNodeConfigShieldedInstanceConfig         `tf:"shielded_instance_config,blocks"`
-	SoleTenantConfig               []GoogleContainerClusterNodePoolNodeConfigSoleTenantConfig               `tf:"sole_tenant_config,blocks"`
-	Taint                          []GoogleContainerClusterNodePoolNodeConfigTaint                          `tf:"taint,blocks"`
-	WorkloadMetadataConfig         []GoogleContainerClusterNodePoolNodeConfigWorkloadMetadataConfig         `tf:"workload_metadata_config,blocks"`
+	BootDiskKMSKey                 *Value[string]                                                           `tf:"boot_disk_kms_key" json:"boot_disk_kms_key,omitempty"`
+	DiskSizeGb                     *Value[float64]                                                          `tf:"disk_size_gb" json:"disk_size_gb,omitempty"`
+	DiskType                       *Value[string]                                                           `tf:"disk_type" json:"disk_type,omitempty"`
+	EffectiveTaints                []GoogleContainerClusterNodePoolNodeConfigEffectiveTaints                `tf:"effective_taints" json:"effective_taints,omitempty"`
+	EnableConfidentialStorage      *Value[bool]                                                             `tf:"enable_confidential_storage" json:"enable_confidential_storage,omitempty"`
+	ImageType                      *Value[string]                                                           `tf:"image_type" json:"image_type,omitempty"`
+	Labels                         map[string]*Value[string]                                                `tf:"labels" json:"labels,omitempty"`
+	LocalSsdCount                  *Value[int64]                                                            `tf:"local_ssd_count" json:"local_ssd_count,omitempty"`
+	LoggingVariant                 *Value[string]                                                           `tf:"logging_variant" json:"logging_variant,omitempty"`
+	MachineType                    *Value[string]                                                           `tf:"machine_type" json:"machine_type,omitempty"`
+	Metadata                       map[string]*Value[string]                                                `tf:"metadata" json:"metadata,omitempty"`
+	MinCPUPlatform                 *Value[string]                                                           `tf:"min_cpu_platform" json:"min_cpu_platform,omitempty"`
+	NodeGroup                      *Value[string]                                                           `tf:"node_group" json:"node_group,omitempty"`
+	OauthScopes                    []*Value[string]                                                         `tf:"oauth_scopes" json:"oauth_scopes,omitempty"`
+	Preemptible                    *Value[bool]                                                             `tf:"preemptible" json:"preemptible,omitempty"`
+	ResourceLabels                 map[string]*Value[string]                                                `tf:"resource_labels" json:"resource_labels,omitempty"`
+	ResourceManagerTags            map[string]*Value[string]                                                `tf:"resource_manager_tags" json:"resource_manager_tags,omitempty"`
+	ServiceAccount                 *Value[string]                                                           `tf:"service_account" json:"service_account,omitempty"`
+	Spot                           *Value[bool]                                                             `tf:"spot" json:"spot,omitempty"`
+	StoragePools                   []*Value[string]                                                         `tf:"storage_pools" json:"storage_pools,omitempty"`
+	Tags                           []*Value[string]                                                         `tf:"tags" json:"tags,omitempty"`
+	AdvancedMachineFeatures        []GoogleContainerClusterNodePoolNodeConfigAdvancedMachineFeatures        `tf:"advanced_machine_features,blocks" json:"advanced_machine_features,omitempty"`
+	ConfidentialNodes              []GoogleContainerClusterNodePoolNodeConfigConfidentialNodes              `tf:"confidential_nodes,blocks" json:"confidential_nodes,omitempty"`
+	ContainerdConfig               []GoogleContainerClusterNodePoolNodeConfigContainerdConfig               `tf:"containerd_config,blocks" json:"containerd_config,omitempty"`
+	EphemeralStorageLocalSsdConfig []GoogleContainerClusterNodePoolNodeConfigEphemeralStorageLocalSsdConfig `tf:"ephemeral_storage_local_ssd_config,blocks" json:"ephemeral_storage_local_ssd_config,omitempty"`
+	FastSocket                     []GoogleContainerClusterNodePoolNodeConfigFastSocket                     `tf:"fast_socket,blocks" json:"fast_socket,omitempty"`
+	GcfsConfig                     []GoogleContainerClusterNodePoolNodeConfigGcfsConfig                     `tf:"gcfs_config,blocks" json:"gcfs_config,omitempty"`
+	GuestAccelerator               []GoogleContainerClusterNodePoolNodeConfigGuestAccelerator               `tf:"guest_accelerator,blocks" json:"guest_accelerator,omitempty"`
+	Gvnic                          []GoogleContainerClusterNodePoolNodeConfigGvnic                          `tf:"gvnic,blocks" json:"gvnic,omitempty"`
+	HostMaintenancePolicy          []GoogleContainerClusterNodePoolNodeConfigHostMaintenancePolicy          `tf:"host_maintenance_policy,blocks" json:"host_maintenance_policy,omitempty"`
+	KubeletConfig                  []GoogleContainerClusterNodePoolNodeConfigKubeletConfig                  `tf:"kubelet_config,blocks" json:"kubelet_config,omitempty"`
+	LinuxNodeConfig                []GoogleContainerClusterNodePoolNodeConfigLinuxNodeConfig                `tf:"linux_node_config,blocks" json:"linux_node_config,omitempty"`
+	LocalNvmeSsdBlockConfig        []GoogleContainerClusterNodePoolNodeConfigLocalNvmeSsdBlockConfig        `tf:"local_nvme_ssd_block_config,blocks" json:"local_nvme_ssd_block_config,omitempty"`
+	ReservationAffinity            []GoogleContainerClusterNodePoolNodeConfigReservationAffinity            `tf:"reservation_affinity,blocks" json:"reservation_affinity,omitempty"`
+	SecondaryBootDisks             []GoogleContainerClusterNodePoolNodeConfigSecondaryBootDisks             `tf:"secondary_boot_disks,blocks" json:"secondary_boot_disks,omitempty"`
+	ShieldedInstanceConfig         []GoogleContainerClusterNodePoolNodeConfigShieldedInstanceConfig         `tf:"shielded_instance_config,blocks" json:"shielded_instance_config,omitempty"`
+	SoleTenantConfig               []GoogleContainerClusterNodePoolNodeConfigSoleTenantConfig               `tf:"sole_tenant_config,blocks" json:"sole_tenant_config,omitempty"`
+	Taint                          []GoogleContainerClusterNodePoolNodeConfigTaint                          `tf:"taint,blocks" json:"taint,omitempty"`
+	WorkloadMetadataConfig         []GoogleContainerClusterNodePoolNodeConfigWorkloadMetadataConfig         `tf:"workload_metadata_config,blocks" json:"workload_metadata_config,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigAdvancedMachineFeatures is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigAdvancedMachineFeatures struct {
-	EnableNestedVirtualization *Value[bool]    `tf:"enable_nested_virtualization"`
-	ThreadsPerCore             *Value[float64] `tf:"threads_per_core"`
+	EnableNestedVirtualization *Value[bool]    `tf:"enable_nested_virtualization" json:"enable_nested_virtualization,omitempty"`
+	ThreadsPerCore             *Value[float64] `tf:"threads_per_core" json:"threads_per_core,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigConfidentialNodes is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigConfidentialNodes struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigContainerdConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigContainerdConfig struct {
-	PrivateRegistryAccessConfig []GoogleContainerClusterNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfig `tf:"private_registry_access_config,blocks"`
+	PrivateRegistryAccessConfig []GoogleContainerClusterNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfig `tf:"private_registry_access_config,blocks" json:"private_registry_access_config,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfig struct {
-	Enabled                          *Value[bool]                                                                                                          `tf:"enabled"`
-	CertificateAuthorityDomainConfig []GoogleContainerClusterNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig `tf:"certificate_authority_domain_config,blocks"`
+	Enabled                          *Value[bool]                                                                                                          `tf:"enabled" json:"enabled,omitempty"`
+	CertificateAuthorityDomainConfig []GoogleContainerClusterNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig `tf:"certificate_authority_domain_config,blocks" json:"certificate_authority_domain_config,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig struct {
-	Fqdns                             []*Value[string]                                                                                                                                       `tf:"fqdns"`
-	GCPSecretManagerCertificateConfig []GoogleContainerClusterNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig `tf:"gcp_secret_manager_certificate_config,blocks"`
+	Fqdns                             []*Value[string]                                                                                                                                       `tf:"fqdns" json:"fqdns,omitempty"`
+	GCPSecretManagerCertificateConfig []GoogleContainerClusterNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig `tf:"gcp_secret_manager_certificate_config,blocks" json:"gcp_secret_manager_certificate_config,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig struct {
-	SecretURI *Value[string] `tf:"secret_uri"`
+	SecretURI *Value[string] `tf:"secret_uri" json:"secret_uri,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigEffectiveTaints is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigEffectiveTaints struct {
-	Effect *Value[string] `tf:"effect"`
-	Key    *Value[string] `tf:"key"`
-	Value  *Value[string] `tf:"value"`
+	Effect *Value[string] `tf:"effect" json:"effect,omitempty"`
+	Key    *Value[string] `tf:"key" json:"key,omitempty"`
+	Value  *Value[string] `tf:"value" json:"value,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigEphemeralStorageLocalSsdConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigEphemeralStorageLocalSsdConfig struct {
-	LocalSsdCount *Value[int64] `tf:"local_ssd_count"`
+	LocalSsdCount *Value[int64] `tf:"local_ssd_count" json:"local_ssd_count,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigFastSocket is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigFastSocket struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigGcfsConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigGcfsConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigGuestAccelerator is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigGuestAccelerator struct {
-	Count                       *Value[float64]                                                                       `tf:"count"`
-	GpuPartitionSize            *Value[string]                                                                        `tf:"gpu_partition_size"`
-	Type_                       *Value[string]                                                                        `tf:"type"`
-	GpuDriverInstallationConfig []GoogleContainerClusterNodePoolNodeConfigGuestAcceleratorGpuDriverInstallationConfig `tf:"gpu_driver_installation_config,blocks"`
-	GpuSharingConfig            []GoogleContainerClusterNodePoolNodeConfigGuestAcceleratorGpuSharingConfig            `tf:"gpu_sharing_config,blocks"`
+	Count                       *Value[float64]                                                                       `tf:"count" json:"count,omitempty"`
+	GpuPartitionSize            *Value[string]                                                                        `tf:"gpu_partition_size" json:"gpu_partition_size,omitempty"`
+	Type_                       *Value[string]                                                                        `tf:"type" json:"type,omitempty"`
+	GpuDriverInstallationConfig []GoogleContainerClusterNodePoolNodeConfigGuestAcceleratorGpuDriverInstallationConfig `tf:"gpu_driver_installation_config,blocks" json:"gpu_driver_installation_config,omitempty"`
+	GpuSharingConfig            []GoogleContainerClusterNodePoolNodeConfigGuestAcceleratorGpuSharingConfig            `tf:"gpu_sharing_config,blocks" json:"gpu_sharing_config,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigGuestAcceleratorGpuDriverInstallationConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigGuestAcceleratorGpuDriverInstallationConfig struct {
-	GpuDriverVersion *Value[string] `tf:"gpu_driver_version"`
+	GpuDriverVersion *Value[string] `tf:"gpu_driver_version" json:"gpu_driver_version,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigGuestAcceleratorGpuSharingConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigGuestAcceleratorGpuSharingConfig struct {
-	GpuSharingStrategy     *Value[string] `tf:"gpu_sharing_strategy"`
-	MaxSharedClientsPerGpu *Value[int64]  `tf:"max_shared_clients_per_gpu"`
+	GpuSharingStrategy     *Value[string] `tf:"gpu_sharing_strategy" json:"gpu_sharing_strategy,omitempty"`
+	MaxSharedClientsPerGpu *Value[int64]  `tf:"max_shared_clients_per_gpu" json:"max_shared_clients_per_gpu,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigGvnic is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigGvnic struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigHostMaintenancePolicy is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigHostMaintenancePolicy struct {
-	MaintenanceInterval *Value[string] `tf:"maintenance_interval"`
+	MaintenanceInterval *Value[string] `tf:"maintenance_interval" json:"maintenance_interval,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigKubeletConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigKubeletConfig struct {
-	CPUCfsQuota                        *Value[bool]    `tf:"cpu_cfs_quota"`
-	CPUCfsQuotaPeriod                  *Value[string]  `tf:"cpu_cfs_quota_period"`
-	CPUManagerPolicy                   *Value[string]  `tf:"cpu_manager_policy"`
-	InsecureKubeletReadonlyPortEnabled *Value[string]  `tf:"insecure_kubelet_readonly_port_enabled"`
-	PodPidsLimit                       *Value[float64] `tf:"pod_pids_limit"`
+	CPUCfsQuota                        *Value[bool]    `tf:"cpu_cfs_quota" json:"cpu_cfs_quota,omitempty"`
+	CPUCfsQuotaPeriod                  *Value[string]  `tf:"cpu_cfs_quota_period" json:"cpu_cfs_quota_period,omitempty"`
+	CPUManagerPolicy                   *Value[string]  `tf:"cpu_manager_policy" json:"cpu_manager_policy,omitempty"`
+	InsecureKubeletReadonlyPortEnabled *Value[string]  `tf:"insecure_kubelet_readonly_port_enabled" json:"insecure_kubelet_readonly_port_enabled,omitempty"`
+	PodPidsLimit                       *Value[float64] `tf:"pod_pids_limit" json:"pod_pids_limit,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigLinuxNodeConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigLinuxNodeConfig struct {
-	CgroupMode      *Value[string]                                                           `tf:"cgroup_mode"`
-	Sysctls         map[string]*Value[string]                                                `tf:"sysctls"`
-	HugepagesConfig []GoogleContainerClusterNodePoolNodeConfigLinuxNodeConfigHugepagesConfig `tf:"hugepages_config,blocks"`
+	CgroupMode      *Value[string]                                                           `tf:"cgroup_mode" json:"cgroup_mode,omitempty"`
+	Sysctls         map[string]*Value[string]                                                `tf:"sysctls" json:"sysctls,omitempty"`
+	HugepagesConfig []GoogleContainerClusterNodePoolNodeConfigLinuxNodeConfigHugepagesConfig `tf:"hugepages_config,blocks" json:"hugepages_config,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigLinuxNodeConfigHugepagesConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigLinuxNodeConfigHugepagesConfig struct {
-	HugepageSize1g *Value[float64] `tf:"hugepage_size_1g"`
-	HugepageSize2m *Value[float64] `tf:"hugepage_size_2m"`
+	HugepageSize1g *Value[float64] `tf:"hugepage_size_1g" json:"hugepage_size_1g,omitempty"`
+	HugepageSize2m *Value[float64] `tf:"hugepage_size_2m" json:"hugepage_size_2m,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigLocalNvmeSsdBlockConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigLocalNvmeSsdBlockConfig struct {
-	LocalSsdCount *Value[int64] `tf:"local_ssd_count"`
+	LocalSsdCount *Value[int64] `tf:"local_ssd_count" json:"local_ssd_count,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigReservationAffinity is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigReservationAffinity struct {
-	ConsumeReservationType *Value[string]   `tf:"consume_reservation_type"`
-	Key                    *Value[string]   `tf:"key"`
-	Values                 []*Value[string] `tf:"values"`
+	ConsumeReservationType *Value[string]   `tf:"consume_reservation_type" json:"consume_reservation_type,omitempty"`
+	Key                    *Value[string]   `tf:"key" json:"key,omitempty"`
+	Values                 []*Value[string] `tf:"values" json:"values,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigSecondaryBootDisks is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigSecondaryBootDisks struct {
-	DiskImage *Value[string] `tf:"disk_image"`
-	Mode      *Value[string] `tf:"mode"`
+	DiskImage *Value[string] `tf:"disk_image" json:"disk_image,omitempty"`
+	Mode      *Value[string] `tf:"mode" json:"mode,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigShieldedInstanceConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigShieldedInstanceConfig struct {
-	EnableIntegrityMonitoring *Value[bool] `tf:"enable_integrity_monitoring"`
-	EnableSecureBoot          *Value[bool] `tf:"enable_secure_boot"`
+	EnableIntegrityMonitoring *Value[bool] `tf:"enable_integrity_monitoring" json:"enable_integrity_monitoring,omitempty"`
+	EnableSecureBoot          *Value[bool] `tf:"enable_secure_boot" json:"enable_secure_boot,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigSoleTenantConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigSoleTenantConfig struct {
-	NodeAffinity []GoogleContainerClusterNodePoolNodeConfigSoleTenantConfigNodeAffinity `tf:"node_affinity,blocks"`
+	NodeAffinity []GoogleContainerClusterNodePoolNodeConfigSoleTenantConfigNodeAffinity `tf:"node_affinity,blocks" json:"node_affinity,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigSoleTenantConfigNodeAffinity is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigSoleTenantConfigNodeAffinity struct {
-	Key      *Value[string]   `tf:"key"`
-	Operator *Value[string]   `tf:"operator"`
-	Values   []*Value[string] `tf:"values"`
+	Key      *Value[string]   `tf:"key" json:"key,omitempty"`
+	Operator *Value[string]   `tf:"operator" json:"operator,omitempty"`
+	Values   []*Value[string] `tf:"values" json:"values,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigTaint is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigTaint struct {
-	Effect *Value[string] `tf:"effect"`
-	Key    *Value[string] `tf:"key"`
-	Value  *Value[string] `tf:"value"`
+	Effect *Value[string] `tf:"effect" json:"effect,omitempty"`
+	Key    *Value[string] `tf:"key" json:"key,omitempty"`
+	Value  *Value[string] `tf:"value" json:"value,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolNodeConfigWorkloadMetadataConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolNodeConfigWorkloadMetadataConfig struct {
-	Mode *Value[string] `tf:"mode"`
+	Mode *Value[string] `tf:"mode" json:"mode,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolPlacementPolicy is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolPlacementPolicy struct {
-	PolicyName  *Value[string] `tf:"policy_name"`
-	TpuTopology *Value[string] `tf:"tpu_topology"`
-	Type_       *Value[string] `tf:"type"`
+	PolicyName  *Value[string] `tf:"policy_name" json:"policy_name,omitempty"`
+	TpuTopology *Value[string] `tf:"tpu_topology" json:"tpu_topology,omitempty"`
+	Type_       *Value[string] `tf:"type" json:"type,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolQueuedProvisioning is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolQueuedProvisioning struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolUpgradeSettings is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolUpgradeSettings struct {
-	MaxSurge          *Value[int64]                                                    `tf:"max_surge"`
-	MaxUnavailable    *Value[int64]                                                    `tf:"max_unavailable"`
-	Strategy          *Value[string]                                                   `tf:"strategy"`
-	BlueGreenSettings []GoogleContainerClusterNodePoolUpgradeSettingsBlueGreenSettings `tf:"blue_green_settings,blocks"`
+	MaxSurge          *Value[int64]                                                    `tf:"max_surge" json:"max_surge,omitempty"`
+	MaxUnavailable    *Value[int64]                                                    `tf:"max_unavailable" json:"max_unavailable,omitempty"`
+	Strategy          *Value[string]                                                   `tf:"strategy" json:"strategy,omitempty"`
+	BlueGreenSettings []GoogleContainerClusterNodePoolUpgradeSettingsBlueGreenSettings `tf:"blue_green_settings,blocks" json:"blue_green_settings,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolUpgradeSettingsBlueGreenSettings is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolUpgradeSettingsBlueGreenSettings struct {
-	NodePoolSoakDuration  *Value[string]                                                                        `tf:"node_pool_soak_duration"`
-	StandardRolloutPolicy []GoogleContainerClusterNodePoolUpgradeSettingsBlueGreenSettingsStandardRolloutPolicy `tf:"standard_rollout_policy,blocks"`
+	NodePoolSoakDuration  *Value[string]                                                                        `tf:"node_pool_soak_duration" json:"node_pool_soak_duration,omitempty"`
+	StandardRolloutPolicy []GoogleContainerClusterNodePoolUpgradeSettingsBlueGreenSettingsStandardRolloutPolicy `tf:"standard_rollout_policy,blocks" json:"standard_rollout_policy,omitempty"`
 }
 
 // GoogleContainerClusterNodePoolUpgradeSettingsBlueGreenSettingsStandardRolloutPolicy is a nested-block type used by the parent resource.
 type GoogleContainerClusterNodePoolUpgradeSettingsBlueGreenSettingsStandardRolloutPolicy struct {
-	BatchNodeCount    *Value[int64]   `tf:"batch_node_count"`
-	BatchPercentage   *Value[float64] `tf:"batch_percentage"`
-	BatchSoakDuration *Value[string]  `tf:"batch_soak_duration"`
+	BatchNodeCount    *Value[int64]   `tf:"batch_node_count" json:"batch_node_count,omitempty"`
+	BatchPercentage   *Value[float64] `tf:"batch_percentage" json:"batch_percentage,omitempty"`
+	BatchSoakDuration *Value[string]  `tf:"batch_soak_duration" json:"batch_soak_duration,omitempty"`
 }
 
 // GoogleContainerClusterNotificationConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterNotificationConfig struct {
-	Pubsub []GoogleContainerClusterNotificationConfigPubsub `tf:"pubsub,blocks"`
+	Pubsub []GoogleContainerClusterNotificationConfigPubsub `tf:"pubsub,blocks" json:"pubsub,omitempty"`
 }
 
 // GoogleContainerClusterNotificationConfigPubsub is a nested-block type used by the parent resource.
 type GoogleContainerClusterNotificationConfigPubsub struct {
-	Enabled *Value[bool]                                           `tf:"enabled"`
-	Topic   *Value[string]                                         `tf:"topic"`
-	Filter  []GoogleContainerClusterNotificationConfigPubsubFilter `tf:"filter,blocks"`
+	Enabled *Value[bool]                                           `tf:"enabled" json:"enabled,omitempty"`
+	Topic   *Value[string]                                         `tf:"topic" json:"topic,omitempty"`
+	Filter  []GoogleContainerClusterNotificationConfigPubsubFilter `tf:"filter,blocks" json:"filter,omitempty"`
 }
 
 // GoogleContainerClusterNotificationConfigPubsubFilter is a nested-block type used by the parent resource.
 type GoogleContainerClusterNotificationConfigPubsubFilter struct {
-	EventType []*Value[string] `tf:"event_type"`
+	EventType []*Value[string] `tf:"event_type" json:"event_type,omitempty"`
 }
 
 // GoogleContainerClusterPrivateClusterConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterPrivateClusterConfig struct {
-	EnablePrivateEndpoint     *Value[bool]                                                         `tf:"enable_private_endpoint"`
-	EnablePrivateNodes        *Value[bool]                                                         `tf:"enable_private_nodes"`
-	MasterIPV4CIDRBlock       *Value[string]                                                       `tf:"master_ipv4_cidr_block"`
-	PeeringName               *Value[string]                                                       `tf:"peering_name"`
-	PrivateEndpoint           *Value[string]                                                       `tf:"private_endpoint"`
-	PrivateEndpointSubnetwork *Value[string]                                                       `tf:"private_endpoint_subnetwork"`
-	PublicEndpoint            *Value[string]                                                       `tf:"public_endpoint"`
-	MasterGlobalAccessConfig  []GoogleContainerClusterPrivateClusterConfigMasterGlobalAccessConfig `tf:"master_global_access_config,blocks"`
+	EnablePrivateEndpoint     *Value[bool]                                                         `tf:"enable_private_endpoint" json:"enable_private_endpoint,omitempty"`
+	EnablePrivateNodes        *Value[bool]                                                         `tf:"enable_private_nodes" json:"enable_private_nodes,omitempty"`
+	MasterIPV4CIDRBlock       *Value[string]                                                       `tf:"master_ipv4_cidr_block" json:"master_ipv4_cidr_block,omitempty"`
+	PeeringName               *Value[string]                                                       `tf:"peering_name" json:"peering_name,omitempty"`
+	PrivateEndpoint           *Value[string]                                                       `tf:"private_endpoint" json:"private_endpoint,omitempty"`
+	PrivateEndpointSubnetwork *Value[string]                                                       `tf:"private_endpoint_subnetwork" json:"private_endpoint_subnetwork,omitempty"`
+	PublicEndpoint            *Value[string]                                                       `tf:"public_endpoint" json:"public_endpoint,omitempty"`
+	MasterGlobalAccessConfig  []GoogleContainerClusterPrivateClusterConfigMasterGlobalAccessConfig `tf:"master_global_access_config,blocks" json:"master_global_access_config,omitempty"`
 }
 
 // GoogleContainerClusterPrivateClusterConfigMasterGlobalAccessConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterPrivateClusterConfigMasterGlobalAccessConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterReleaseChannel is a nested-block type used by the parent resource.
 type GoogleContainerClusterReleaseChannel struct {
-	Channel *Value[string] `tf:"channel"`
+	Channel *Value[string] `tf:"channel" json:"channel,omitempty"`
 }
 
 // GoogleContainerClusterResourceUsageExportConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterResourceUsageExportConfig struct {
-	EnableNetworkEgressMetering       *Value[bool]                                                         `tf:"enable_network_egress_metering"`
-	EnableResourceConsumptionMetering *Value[bool]                                                         `tf:"enable_resource_consumption_metering"`
-	BigqueryDestination               []GoogleContainerClusterResourceUsageExportConfigBigqueryDestination `tf:"bigquery_destination,blocks"`
+	EnableNetworkEgressMetering       *Value[bool]                                                         `tf:"enable_network_egress_metering" json:"enable_network_egress_metering,omitempty"`
+	EnableResourceConsumptionMetering *Value[bool]                                                         `tf:"enable_resource_consumption_metering" json:"enable_resource_consumption_metering,omitempty"`
+	BigqueryDestination               []GoogleContainerClusterResourceUsageExportConfigBigqueryDestination `tf:"bigquery_destination,blocks" json:"bigquery_destination,omitempty"`
 }
 
 // GoogleContainerClusterResourceUsageExportConfigBigqueryDestination is a nested-block type used by the parent resource.
 type GoogleContainerClusterResourceUsageExportConfigBigqueryDestination struct {
-	DatasetID *Value[string] `tf:"dataset_id"`
+	DatasetID *Value[string] `tf:"dataset_id" json:"dataset_id,omitempty"`
 }
 
 // GoogleContainerClusterSecretManagerConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterSecretManagerConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterSecurityPostureConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterSecurityPostureConfig struct {
-	Mode              *Value[string] `tf:"mode"`
-	VulnerabilityMode *Value[string] `tf:"vulnerability_mode"`
+	Mode              *Value[string] `tf:"mode" json:"mode,omitempty"`
+	VulnerabilityMode *Value[string] `tf:"vulnerability_mode" json:"vulnerability_mode,omitempty"`
 }
 
 // GoogleContainerClusterServiceExternalIpsConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterServiceExternalIpsConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterTimeouts is a nested-block type used by the parent resource.
 type GoogleContainerClusterTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Read   *Value[string] `tf:"read"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Read   *Value[string] `tf:"read" json:"read,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleContainerClusterVerticalPodAutoscaling is a nested-block type used by the parent resource.
 type GoogleContainerClusterVerticalPodAutoscaling struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerClusterWorkloadIdentityConfig is a nested-block type used by the parent resource.
 type GoogleContainerClusterWorkloadIdentityConfig struct {
-	WorkloadPool *Value[string] `tf:"workload_pool"`
+	WorkloadPool *Value[string] `tf:"workload_pool" json:"workload_pool,omitempty"`
 }
 
 // GoogleContainerClusterSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_container_node_pool.gen.go
+++ b/pkg/composer/imported/generated/google_container_node_pool.gen.go
@@ -7,316 +7,316 @@ import "reflect"
 // GoogleContainerNodePool is the generated Layer 1 typed model for the
 // `google_container_node_pool` Terraform resource.
 type GoogleContainerNodePool struct {
-	Cluster                  *Value[string]                              `tf:"cluster"`
-	ID                       *Value[string]                              `tf:"id"`
-	InitialNodeCount         *Value[int64]                               `tf:"initial_node_count"`
-	InstanceGroupUrls        []*Value[string]                            `tf:"instance_group_urls"`
-	Location                 *Value[string]                              `tf:"location"`
-	ManagedInstanceGroupUrls []*Value[string]                            `tf:"managed_instance_group_urls"`
-	MaxPodsPerNode           *Value[int64]                               `tf:"max_pods_per_node"`
-	Name                     *Value[string]                              `tf:"name"`
-	NamePrefix               *Value[string]                              `tf:"name_prefix"`
-	NodeCount                *Value[int64]                               `tf:"node_count"`
-	NodeLocations            []*Value[string]                            `tf:"node_locations"`
-	Operation                *Value[string]                              `tf:"operation"`
-	Project                  *Value[string]                              `tf:"project"`
-	Version                  *Value[string]                              `tf:"version"`
-	Autoscaling              []GoogleContainerNodePoolAutoscaling        `tf:"autoscaling,blocks"`
-	Management               []GoogleContainerNodePoolManagement         `tf:"management,blocks"`
-	NetworkConfig            []GoogleContainerNodePoolNetworkConfig      `tf:"network_config,blocks"`
-	NodeConfig               []GoogleContainerNodePoolNodeConfig         `tf:"node_config,blocks"`
-	PlacementPolicy          []GoogleContainerNodePoolPlacementPolicy    `tf:"placement_policy,blocks"`
-	QueuedProvisioning       []GoogleContainerNodePoolQueuedProvisioning `tf:"queued_provisioning,blocks"`
-	Timeouts                 *GoogleContainerNodePoolTimeouts            `tf:"timeouts,block"`
-	UpgradeSettings          []GoogleContainerNodePoolUpgradeSettings    `tf:"upgrade_settings,blocks"`
+	Cluster                  *Value[string]                              `tf:"cluster" json:"cluster,omitempty"`
+	ID                       *Value[string]                              `tf:"id" json:"id,omitempty"`
+	InitialNodeCount         *Value[int64]                               `tf:"initial_node_count" json:"initial_node_count,omitempty"`
+	InstanceGroupUrls        []*Value[string]                            `tf:"instance_group_urls" json:"instance_group_urls,omitempty"`
+	Location                 *Value[string]                              `tf:"location" json:"location,omitempty"`
+	ManagedInstanceGroupUrls []*Value[string]                            `tf:"managed_instance_group_urls" json:"managed_instance_group_urls,omitempty"`
+	MaxPodsPerNode           *Value[int64]                               `tf:"max_pods_per_node" json:"max_pods_per_node,omitempty"`
+	Name                     *Value[string]                              `tf:"name" json:"name,omitempty"`
+	NamePrefix               *Value[string]                              `tf:"name_prefix" json:"name_prefix,omitempty"`
+	NodeCount                *Value[int64]                               `tf:"node_count" json:"node_count,omitempty"`
+	NodeLocations            []*Value[string]                            `tf:"node_locations" json:"node_locations,omitempty"`
+	Operation                *Value[string]                              `tf:"operation" json:"operation,omitempty"`
+	Project                  *Value[string]                              `tf:"project" json:"project,omitempty"`
+	Version                  *Value[string]                              `tf:"version" json:"version,omitempty"`
+	Autoscaling              []GoogleContainerNodePoolAutoscaling        `tf:"autoscaling,blocks" json:"autoscaling,omitempty"`
+	Management               []GoogleContainerNodePoolManagement         `tf:"management,blocks" json:"management,omitempty"`
+	NetworkConfig            []GoogleContainerNodePoolNetworkConfig      `tf:"network_config,blocks" json:"network_config,omitempty"`
+	NodeConfig               []GoogleContainerNodePoolNodeConfig         `tf:"node_config,blocks" json:"node_config,omitempty"`
+	PlacementPolicy          []GoogleContainerNodePoolPlacementPolicy    `tf:"placement_policy,blocks" json:"placement_policy,omitempty"`
+	QueuedProvisioning       []GoogleContainerNodePoolQueuedProvisioning `tf:"queued_provisioning,blocks" json:"queued_provisioning,omitempty"`
+	Timeouts                 *GoogleContainerNodePoolTimeouts            `tf:"timeouts,block" json:"timeouts,omitempty"`
+	UpgradeSettings          []GoogleContainerNodePoolUpgradeSettings    `tf:"upgrade_settings,blocks" json:"upgrade_settings,omitempty"`
 }
 
 // GoogleContainerNodePoolAutoscaling is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolAutoscaling struct {
-	LocationPolicy    *Value[string] `tf:"location_policy"`
-	MaxNodeCount      *Value[int64]  `tf:"max_node_count"`
-	MinNodeCount      *Value[int64]  `tf:"min_node_count"`
-	TotalMaxNodeCount *Value[int64]  `tf:"total_max_node_count"`
-	TotalMinNodeCount *Value[int64]  `tf:"total_min_node_count"`
+	LocationPolicy    *Value[string] `tf:"location_policy" json:"location_policy,omitempty"`
+	MaxNodeCount      *Value[int64]  `tf:"max_node_count" json:"max_node_count,omitempty"`
+	MinNodeCount      *Value[int64]  `tf:"min_node_count" json:"min_node_count,omitempty"`
+	TotalMaxNodeCount *Value[int64]  `tf:"total_max_node_count" json:"total_max_node_count,omitempty"`
+	TotalMinNodeCount *Value[int64]  `tf:"total_min_node_count" json:"total_min_node_count,omitempty"`
 }
 
 // GoogleContainerNodePoolManagement is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolManagement struct {
-	AutoRepair  *Value[bool] `tf:"auto_repair"`
-	AutoUpgrade *Value[bool] `tf:"auto_upgrade"`
+	AutoRepair  *Value[bool] `tf:"auto_repair" json:"auto_repair,omitempty"`
+	AutoUpgrade *Value[bool] `tf:"auto_upgrade" json:"auto_upgrade,omitempty"`
 }
 
 // GoogleContainerNodePoolNetworkConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNetworkConfig struct {
-	CreatePodRange               *Value[bool]                                                       `tf:"create_pod_range"`
-	EnablePrivateNodes           *Value[bool]                                                       `tf:"enable_private_nodes"`
-	PodIPV4CIDRBlock             *Value[string]                                                     `tf:"pod_ipv4_cidr_block"`
-	PodRange                     *Value[string]                                                     `tf:"pod_range"`
-	AdditionalNodeNetworkConfigs []GoogleContainerNodePoolNetworkConfigAdditionalNodeNetworkConfigs `tf:"additional_node_network_configs,blocks"`
-	AdditionalPodNetworkConfigs  []GoogleContainerNodePoolNetworkConfigAdditionalPodNetworkConfigs  `tf:"additional_pod_network_configs,blocks"`
-	NetworkPerformanceConfig     []GoogleContainerNodePoolNetworkConfigNetworkPerformanceConfig     `tf:"network_performance_config,blocks"`
-	PodCIDROverprovisionConfig   []GoogleContainerNodePoolNetworkConfigPodCIDROverprovisionConfig   `tf:"pod_cidr_overprovision_config,blocks"`
+	CreatePodRange               *Value[bool]                                                       `tf:"create_pod_range" json:"create_pod_range,omitempty"`
+	EnablePrivateNodes           *Value[bool]                                                       `tf:"enable_private_nodes" json:"enable_private_nodes,omitempty"`
+	PodIPV4CIDRBlock             *Value[string]                                                     `tf:"pod_ipv4_cidr_block" json:"pod_ipv4_cidr_block,omitempty"`
+	PodRange                     *Value[string]                                                     `tf:"pod_range" json:"pod_range,omitempty"`
+	AdditionalNodeNetworkConfigs []GoogleContainerNodePoolNetworkConfigAdditionalNodeNetworkConfigs `tf:"additional_node_network_configs,blocks" json:"additional_node_network_configs,omitempty"`
+	AdditionalPodNetworkConfigs  []GoogleContainerNodePoolNetworkConfigAdditionalPodNetworkConfigs  `tf:"additional_pod_network_configs,blocks" json:"additional_pod_network_configs,omitempty"`
+	NetworkPerformanceConfig     []GoogleContainerNodePoolNetworkConfigNetworkPerformanceConfig     `tf:"network_performance_config,blocks" json:"network_performance_config,omitempty"`
+	PodCIDROverprovisionConfig   []GoogleContainerNodePoolNetworkConfigPodCIDROverprovisionConfig   `tf:"pod_cidr_overprovision_config,blocks" json:"pod_cidr_overprovision_config,omitempty"`
 }
 
 // GoogleContainerNodePoolNetworkConfigAdditionalNodeNetworkConfigs is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNetworkConfigAdditionalNodeNetworkConfigs struct {
-	Network    *Value[string] `tf:"network"`
-	Subnetwork *Value[string] `tf:"subnetwork"`
+	Network    *Value[string] `tf:"network" json:"network,omitempty"`
+	Subnetwork *Value[string] `tf:"subnetwork" json:"subnetwork,omitempty"`
 }
 
 // GoogleContainerNodePoolNetworkConfigAdditionalPodNetworkConfigs is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNetworkConfigAdditionalPodNetworkConfigs struct {
-	MaxPodsPerNode    *Value[int64]  `tf:"max_pods_per_node"`
-	SecondaryPodRange *Value[string] `tf:"secondary_pod_range"`
-	Subnetwork        *Value[string] `tf:"subnetwork"`
+	MaxPodsPerNode    *Value[int64]  `tf:"max_pods_per_node" json:"max_pods_per_node,omitempty"`
+	SecondaryPodRange *Value[string] `tf:"secondary_pod_range" json:"secondary_pod_range,omitempty"`
+	Subnetwork        *Value[string] `tf:"subnetwork" json:"subnetwork,omitempty"`
 }
 
 // GoogleContainerNodePoolNetworkConfigNetworkPerformanceConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNetworkConfigNetworkPerformanceConfig struct {
-	TotalEgressBandwidthTier *Value[string] `tf:"total_egress_bandwidth_tier"`
+	TotalEgressBandwidthTier *Value[string] `tf:"total_egress_bandwidth_tier" json:"total_egress_bandwidth_tier,omitempty"`
 }
 
 // GoogleContainerNodePoolNetworkConfigPodCIDROverprovisionConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNetworkConfigPodCIDROverprovisionConfig struct {
-	Disabled *Value[bool] `tf:"disabled"`
+	Disabled *Value[bool] `tf:"disabled" json:"disabled,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfig struct {
-	BootDiskKMSKey                 *Value[string]                                                    `tf:"boot_disk_kms_key"`
-	DiskSizeGb                     *Value[float64]                                                   `tf:"disk_size_gb"`
-	DiskType                       *Value[string]                                                    `tf:"disk_type"`
-	EffectiveTaints                []GoogleContainerNodePoolNodeConfigEffectiveTaints                `tf:"effective_taints"`
-	EnableConfidentialStorage      *Value[bool]                                                      `tf:"enable_confidential_storage"`
-	ImageType                      *Value[string]                                                    `tf:"image_type"`
-	Labels                         map[string]*Value[string]                                         `tf:"labels"`
-	LocalSsdCount                  *Value[int64]                                                     `tf:"local_ssd_count"`
-	LoggingVariant                 *Value[string]                                                    `tf:"logging_variant"`
-	MachineType                    *Value[string]                                                    `tf:"machine_type"`
-	Metadata                       map[string]*Value[string]                                         `tf:"metadata"`
-	MinCPUPlatform                 *Value[string]                                                    `tf:"min_cpu_platform"`
-	NodeGroup                      *Value[string]                                                    `tf:"node_group"`
-	OauthScopes                    []*Value[string]                                                  `tf:"oauth_scopes"`
-	Preemptible                    *Value[bool]                                                      `tf:"preemptible"`
-	ResourceLabels                 map[string]*Value[string]                                         `tf:"resource_labels"`
-	ResourceManagerTags            map[string]*Value[string]                                         `tf:"resource_manager_tags"`
-	ServiceAccount                 *Value[string]                                                    `tf:"service_account"`
-	Spot                           *Value[bool]                                                      `tf:"spot"`
-	StoragePools                   []*Value[string]                                                  `tf:"storage_pools"`
-	Tags                           []*Value[string]                                                  `tf:"tags"`
-	AdvancedMachineFeatures        []GoogleContainerNodePoolNodeConfigAdvancedMachineFeatures        `tf:"advanced_machine_features,blocks"`
-	ConfidentialNodes              []GoogleContainerNodePoolNodeConfigConfidentialNodes              `tf:"confidential_nodes,blocks"`
-	ContainerdConfig               []GoogleContainerNodePoolNodeConfigContainerdConfig               `tf:"containerd_config,blocks"`
-	EphemeralStorageLocalSsdConfig []GoogleContainerNodePoolNodeConfigEphemeralStorageLocalSsdConfig `tf:"ephemeral_storage_local_ssd_config,blocks"`
-	FastSocket                     []GoogleContainerNodePoolNodeConfigFastSocket                     `tf:"fast_socket,blocks"`
-	GcfsConfig                     []GoogleContainerNodePoolNodeConfigGcfsConfig                     `tf:"gcfs_config,blocks"`
-	GuestAccelerator               []GoogleContainerNodePoolNodeConfigGuestAccelerator               `tf:"guest_accelerator,blocks"`
-	Gvnic                          []GoogleContainerNodePoolNodeConfigGvnic                          `tf:"gvnic,blocks"`
-	HostMaintenancePolicy          []GoogleContainerNodePoolNodeConfigHostMaintenancePolicy          `tf:"host_maintenance_policy,blocks"`
-	KubeletConfig                  []GoogleContainerNodePoolNodeConfigKubeletConfig                  `tf:"kubelet_config,blocks"`
-	LinuxNodeConfig                []GoogleContainerNodePoolNodeConfigLinuxNodeConfig                `tf:"linux_node_config,blocks"`
-	LocalNvmeSsdBlockConfig        []GoogleContainerNodePoolNodeConfigLocalNvmeSsdBlockConfig        `tf:"local_nvme_ssd_block_config,blocks"`
-	ReservationAffinity            []GoogleContainerNodePoolNodeConfigReservationAffinity            `tf:"reservation_affinity,blocks"`
-	SecondaryBootDisks             []GoogleContainerNodePoolNodeConfigSecondaryBootDisks             `tf:"secondary_boot_disks,blocks"`
-	ShieldedInstanceConfig         []GoogleContainerNodePoolNodeConfigShieldedInstanceConfig         `tf:"shielded_instance_config,blocks"`
-	SoleTenantConfig               []GoogleContainerNodePoolNodeConfigSoleTenantConfig               `tf:"sole_tenant_config,blocks"`
-	Taint                          []GoogleContainerNodePoolNodeConfigTaint                          `tf:"taint,blocks"`
-	WorkloadMetadataConfig         []GoogleContainerNodePoolNodeConfigWorkloadMetadataConfig         `tf:"workload_metadata_config,blocks"`
+	BootDiskKMSKey                 *Value[string]                                                    `tf:"boot_disk_kms_key" json:"boot_disk_kms_key,omitempty"`
+	DiskSizeGb                     *Value[float64]                                                   `tf:"disk_size_gb" json:"disk_size_gb,omitempty"`
+	DiskType                       *Value[string]                                                    `tf:"disk_type" json:"disk_type,omitempty"`
+	EffectiveTaints                []GoogleContainerNodePoolNodeConfigEffectiveTaints                `tf:"effective_taints" json:"effective_taints,omitempty"`
+	EnableConfidentialStorage      *Value[bool]                                                      `tf:"enable_confidential_storage" json:"enable_confidential_storage,omitempty"`
+	ImageType                      *Value[string]                                                    `tf:"image_type" json:"image_type,omitempty"`
+	Labels                         map[string]*Value[string]                                         `tf:"labels" json:"labels,omitempty"`
+	LocalSsdCount                  *Value[int64]                                                     `tf:"local_ssd_count" json:"local_ssd_count,omitempty"`
+	LoggingVariant                 *Value[string]                                                    `tf:"logging_variant" json:"logging_variant,omitempty"`
+	MachineType                    *Value[string]                                                    `tf:"machine_type" json:"machine_type,omitempty"`
+	Metadata                       map[string]*Value[string]                                         `tf:"metadata" json:"metadata,omitempty"`
+	MinCPUPlatform                 *Value[string]                                                    `tf:"min_cpu_platform" json:"min_cpu_platform,omitempty"`
+	NodeGroup                      *Value[string]                                                    `tf:"node_group" json:"node_group,omitempty"`
+	OauthScopes                    []*Value[string]                                                  `tf:"oauth_scopes" json:"oauth_scopes,omitempty"`
+	Preemptible                    *Value[bool]                                                      `tf:"preemptible" json:"preemptible,omitempty"`
+	ResourceLabels                 map[string]*Value[string]                                         `tf:"resource_labels" json:"resource_labels,omitempty"`
+	ResourceManagerTags            map[string]*Value[string]                                         `tf:"resource_manager_tags" json:"resource_manager_tags,omitempty"`
+	ServiceAccount                 *Value[string]                                                    `tf:"service_account" json:"service_account,omitempty"`
+	Spot                           *Value[bool]                                                      `tf:"spot" json:"spot,omitempty"`
+	StoragePools                   []*Value[string]                                                  `tf:"storage_pools" json:"storage_pools,omitempty"`
+	Tags                           []*Value[string]                                                  `tf:"tags" json:"tags,omitempty"`
+	AdvancedMachineFeatures        []GoogleContainerNodePoolNodeConfigAdvancedMachineFeatures        `tf:"advanced_machine_features,blocks" json:"advanced_machine_features,omitempty"`
+	ConfidentialNodes              []GoogleContainerNodePoolNodeConfigConfidentialNodes              `tf:"confidential_nodes,blocks" json:"confidential_nodes,omitempty"`
+	ContainerdConfig               []GoogleContainerNodePoolNodeConfigContainerdConfig               `tf:"containerd_config,blocks" json:"containerd_config,omitempty"`
+	EphemeralStorageLocalSsdConfig []GoogleContainerNodePoolNodeConfigEphemeralStorageLocalSsdConfig `tf:"ephemeral_storage_local_ssd_config,blocks" json:"ephemeral_storage_local_ssd_config,omitempty"`
+	FastSocket                     []GoogleContainerNodePoolNodeConfigFastSocket                     `tf:"fast_socket,blocks" json:"fast_socket,omitempty"`
+	GcfsConfig                     []GoogleContainerNodePoolNodeConfigGcfsConfig                     `tf:"gcfs_config,blocks" json:"gcfs_config,omitempty"`
+	GuestAccelerator               []GoogleContainerNodePoolNodeConfigGuestAccelerator               `tf:"guest_accelerator,blocks" json:"guest_accelerator,omitempty"`
+	Gvnic                          []GoogleContainerNodePoolNodeConfigGvnic                          `tf:"gvnic,blocks" json:"gvnic,omitempty"`
+	HostMaintenancePolicy          []GoogleContainerNodePoolNodeConfigHostMaintenancePolicy          `tf:"host_maintenance_policy,blocks" json:"host_maintenance_policy,omitempty"`
+	KubeletConfig                  []GoogleContainerNodePoolNodeConfigKubeletConfig                  `tf:"kubelet_config,blocks" json:"kubelet_config,omitempty"`
+	LinuxNodeConfig                []GoogleContainerNodePoolNodeConfigLinuxNodeConfig                `tf:"linux_node_config,blocks" json:"linux_node_config,omitempty"`
+	LocalNvmeSsdBlockConfig        []GoogleContainerNodePoolNodeConfigLocalNvmeSsdBlockConfig        `tf:"local_nvme_ssd_block_config,blocks" json:"local_nvme_ssd_block_config,omitempty"`
+	ReservationAffinity            []GoogleContainerNodePoolNodeConfigReservationAffinity            `tf:"reservation_affinity,blocks" json:"reservation_affinity,omitempty"`
+	SecondaryBootDisks             []GoogleContainerNodePoolNodeConfigSecondaryBootDisks             `tf:"secondary_boot_disks,blocks" json:"secondary_boot_disks,omitempty"`
+	ShieldedInstanceConfig         []GoogleContainerNodePoolNodeConfigShieldedInstanceConfig         `tf:"shielded_instance_config,blocks" json:"shielded_instance_config,omitempty"`
+	SoleTenantConfig               []GoogleContainerNodePoolNodeConfigSoleTenantConfig               `tf:"sole_tenant_config,blocks" json:"sole_tenant_config,omitempty"`
+	Taint                          []GoogleContainerNodePoolNodeConfigTaint                          `tf:"taint,blocks" json:"taint,omitempty"`
+	WorkloadMetadataConfig         []GoogleContainerNodePoolNodeConfigWorkloadMetadataConfig         `tf:"workload_metadata_config,blocks" json:"workload_metadata_config,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigAdvancedMachineFeatures is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigAdvancedMachineFeatures struct {
-	EnableNestedVirtualization *Value[bool]    `tf:"enable_nested_virtualization"`
-	ThreadsPerCore             *Value[float64] `tf:"threads_per_core"`
+	EnableNestedVirtualization *Value[bool]    `tf:"enable_nested_virtualization" json:"enable_nested_virtualization,omitempty"`
+	ThreadsPerCore             *Value[float64] `tf:"threads_per_core" json:"threads_per_core,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigConfidentialNodes is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigConfidentialNodes struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigContainerdConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigContainerdConfig struct {
-	PrivateRegistryAccessConfig []GoogleContainerNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfig `tf:"private_registry_access_config,blocks"`
+	PrivateRegistryAccessConfig []GoogleContainerNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfig `tf:"private_registry_access_config,blocks" json:"private_registry_access_config,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfig struct {
-	Enabled                          *Value[bool]                                                                                                   `tf:"enabled"`
-	CertificateAuthorityDomainConfig []GoogleContainerNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig `tf:"certificate_authority_domain_config,blocks"`
+	Enabled                          *Value[bool]                                                                                                   `tf:"enabled" json:"enabled,omitempty"`
+	CertificateAuthorityDomainConfig []GoogleContainerNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig `tf:"certificate_authority_domain_config,blocks" json:"certificate_authority_domain_config,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfig struct {
-	Fqdns                             []*Value[string]                                                                                                                                `tf:"fqdns"`
-	GCPSecretManagerCertificateConfig []GoogleContainerNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig `tf:"gcp_secret_manager_certificate_config,blocks"`
+	Fqdns                             []*Value[string]                                                                                                                                `tf:"fqdns" json:"fqdns,omitempty"`
+	GCPSecretManagerCertificateConfig []GoogleContainerNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig `tf:"gcp_secret_manager_certificate_config,blocks" json:"gcp_secret_manager_certificate_config,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigContainerdConfigPrivateRegistryAccessConfigCertificateAuthorityDomainConfigGCPSecretManagerCertificateConfig struct {
-	SecretURI *Value[string] `tf:"secret_uri"`
+	SecretURI *Value[string] `tf:"secret_uri" json:"secret_uri,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigEffectiveTaints is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigEffectiveTaints struct {
-	Effect *Value[string] `tf:"effect"`
-	Key    *Value[string] `tf:"key"`
-	Value  *Value[string] `tf:"value"`
+	Effect *Value[string] `tf:"effect" json:"effect,omitempty"`
+	Key    *Value[string] `tf:"key" json:"key,omitempty"`
+	Value  *Value[string] `tf:"value" json:"value,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigEphemeralStorageLocalSsdConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigEphemeralStorageLocalSsdConfig struct {
-	LocalSsdCount *Value[int64] `tf:"local_ssd_count"`
+	LocalSsdCount *Value[int64] `tf:"local_ssd_count" json:"local_ssd_count,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigFastSocket is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigFastSocket struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigGcfsConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigGcfsConfig struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigGuestAccelerator is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigGuestAccelerator struct {
-	Count                       *Value[float64]                                                                `tf:"count"`
-	GpuPartitionSize            *Value[string]                                                                 `tf:"gpu_partition_size"`
-	Type_                       *Value[string]                                                                 `tf:"type"`
-	GpuDriverInstallationConfig []GoogleContainerNodePoolNodeConfigGuestAcceleratorGpuDriverInstallationConfig `tf:"gpu_driver_installation_config,blocks"`
-	GpuSharingConfig            []GoogleContainerNodePoolNodeConfigGuestAcceleratorGpuSharingConfig            `tf:"gpu_sharing_config,blocks"`
+	Count                       *Value[float64]                                                                `tf:"count" json:"count,omitempty"`
+	GpuPartitionSize            *Value[string]                                                                 `tf:"gpu_partition_size" json:"gpu_partition_size,omitempty"`
+	Type_                       *Value[string]                                                                 `tf:"type" json:"type,omitempty"`
+	GpuDriverInstallationConfig []GoogleContainerNodePoolNodeConfigGuestAcceleratorGpuDriverInstallationConfig `tf:"gpu_driver_installation_config,blocks" json:"gpu_driver_installation_config,omitempty"`
+	GpuSharingConfig            []GoogleContainerNodePoolNodeConfigGuestAcceleratorGpuSharingConfig            `tf:"gpu_sharing_config,blocks" json:"gpu_sharing_config,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigGuestAcceleratorGpuDriverInstallationConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigGuestAcceleratorGpuDriverInstallationConfig struct {
-	GpuDriverVersion *Value[string] `tf:"gpu_driver_version"`
+	GpuDriverVersion *Value[string] `tf:"gpu_driver_version" json:"gpu_driver_version,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigGuestAcceleratorGpuSharingConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigGuestAcceleratorGpuSharingConfig struct {
-	GpuSharingStrategy     *Value[string] `tf:"gpu_sharing_strategy"`
-	MaxSharedClientsPerGpu *Value[int64]  `tf:"max_shared_clients_per_gpu"`
+	GpuSharingStrategy     *Value[string] `tf:"gpu_sharing_strategy" json:"gpu_sharing_strategy,omitempty"`
+	MaxSharedClientsPerGpu *Value[int64]  `tf:"max_shared_clients_per_gpu" json:"max_shared_clients_per_gpu,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigGvnic is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigGvnic struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigHostMaintenancePolicy is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigHostMaintenancePolicy struct {
-	MaintenanceInterval *Value[string] `tf:"maintenance_interval"`
+	MaintenanceInterval *Value[string] `tf:"maintenance_interval" json:"maintenance_interval,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigKubeletConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigKubeletConfig struct {
-	CPUCfsQuota                        *Value[bool]    `tf:"cpu_cfs_quota"`
-	CPUCfsQuotaPeriod                  *Value[string]  `tf:"cpu_cfs_quota_period"`
-	CPUManagerPolicy                   *Value[string]  `tf:"cpu_manager_policy"`
-	InsecureKubeletReadonlyPortEnabled *Value[string]  `tf:"insecure_kubelet_readonly_port_enabled"`
-	PodPidsLimit                       *Value[float64] `tf:"pod_pids_limit"`
+	CPUCfsQuota                        *Value[bool]    `tf:"cpu_cfs_quota" json:"cpu_cfs_quota,omitempty"`
+	CPUCfsQuotaPeriod                  *Value[string]  `tf:"cpu_cfs_quota_period" json:"cpu_cfs_quota_period,omitempty"`
+	CPUManagerPolicy                   *Value[string]  `tf:"cpu_manager_policy" json:"cpu_manager_policy,omitempty"`
+	InsecureKubeletReadonlyPortEnabled *Value[string]  `tf:"insecure_kubelet_readonly_port_enabled" json:"insecure_kubelet_readonly_port_enabled,omitempty"`
+	PodPidsLimit                       *Value[float64] `tf:"pod_pids_limit" json:"pod_pids_limit,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigLinuxNodeConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigLinuxNodeConfig struct {
-	CgroupMode      *Value[string]                                                    `tf:"cgroup_mode"`
-	Sysctls         map[string]*Value[string]                                         `tf:"sysctls"`
-	HugepagesConfig []GoogleContainerNodePoolNodeConfigLinuxNodeConfigHugepagesConfig `tf:"hugepages_config,blocks"`
+	CgroupMode      *Value[string]                                                    `tf:"cgroup_mode" json:"cgroup_mode,omitempty"`
+	Sysctls         map[string]*Value[string]                                         `tf:"sysctls" json:"sysctls,omitempty"`
+	HugepagesConfig []GoogleContainerNodePoolNodeConfigLinuxNodeConfigHugepagesConfig `tf:"hugepages_config,blocks" json:"hugepages_config,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigLinuxNodeConfigHugepagesConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigLinuxNodeConfigHugepagesConfig struct {
-	HugepageSize1g *Value[float64] `tf:"hugepage_size_1g"`
-	HugepageSize2m *Value[float64] `tf:"hugepage_size_2m"`
+	HugepageSize1g *Value[float64] `tf:"hugepage_size_1g" json:"hugepage_size_1g,omitempty"`
+	HugepageSize2m *Value[float64] `tf:"hugepage_size_2m" json:"hugepage_size_2m,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigLocalNvmeSsdBlockConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigLocalNvmeSsdBlockConfig struct {
-	LocalSsdCount *Value[int64] `tf:"local_ssd_count"`
+	LocalSsdCount *Value[int64] `tf:"local_ssd_count" json:"local_ssd_count,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigReservationAffinity is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigReservationAffinity struct {
-	ConsumeReservationType *Value[string]   `tf:"consume_reservation_type"`
-	Key                    *Value[string]   `tf:"key"`
-	Values                 []*Value[string] `tf:"values"`
+	ConsumeReservationType *Value[string]   `tf:"consume_reservation_type" json:"consume_reservation_type,omitempty"`
+	Key                    *Value[string]   `tf:"key" json:"key,omitempty"`
+	Values                 []*Value[string] `tf:"values" json:"values,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigSecondaryBootDisks is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigSecondaryBootDisks struct {
-	DiskImage *Value[string] `tf:"disk_image"`
-	Mode      *Value[string] `tf:"mode"`
+	DiskImage *Value[string] `tf:"disk_image" json:"disk_image,omitempty"`
+	Mode      *Value[string] `tf:"mode" json:"mode,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigShieldedInstanceConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigShieldedInstanceConfig struct {
-	EnableIntegrityMonitoring *Value[bool] `tf:"enable_integrity_monitoring"`
-	EnableSecureBoot          *Value[bool] `tf:"enable_secure_boot"`
+	EnableIntegrityMonitoring *Value[bool] `tf:"enable_integrity_monitoring" json:"enable_integrity_monitoring,omitempty"`
+	EnableSecureBoot          *Value[bool] `tf:"enable_secure_boot" json:"enable_secure_boot,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigSoleTenantConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigSoleTenantConfig struct {
-	NodeAffinity []GoogleContainerNodePoolNodeConfigSoleTenantConfigNodeAffinity `tf:"node_affinity,blocks"`
+	NodeAffinity []GoogleContainerNodePoolNodeConfigSoleTenantConfigNodeAffinity `tf:"node_affinity,blocks" json:"node_affinity,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigSoleTenantConfigNodeAffinity is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigSoleTenantConfigNodeAffinity struct {
-	Key      *Value[string]   `tf:"key"`
-	Operator *Value[string]   `tf:"operator"`
-	Values   []*Value[string] `tf:"values"`
+	Key      *Value[string]   `tf:"key" json:"key,omitempty"`
+	Operator *Value[string]   `tf:"operator" json:"operator,omitempty"`
+	Values   []*Value[string] `tf:"values" json:"values,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigTaint is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigTaint struct {
-	Effect *Value[string] `tf:"effect"`
-	Key    *Value[string] `tf:"key"`
-	Value  *Value[string] `tf:"value"`
+	Effect *Value[string] `tf:"effect" json:"effect,omitempty"`
+	Key    *Value[string] `tf:"key" json:"key,omitempty"`
+	Value  *Value[string] `tf:"value" json:"value,omitempty"`
 }
 
 // GoogleContainerNodePoolNodeConfigWorkloadMetadataConfig is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolNodeConfigWorkloadMetadataConfig struct {
-	Mode *Value[string] `tf:"mode"`
+	Mode *Value[string] `tf:"mode" json:"mode,omitempty"`
 }
 
 // GoogleContainerNodePoolPlacementPolicy is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolPlacementPolicy struct {
-	PolicyName  *Value[string] `tf:"policy_name"`
-	TpuTopology *Value[string] `tf:"tpu_topology"`
-	Type_       *Value[string] `tf:"type"`
+	PolicyName  *Value[string] `tf:"policy_name" json:"policy_name,omitempty"`
+	TpuTopology *Value[string] `tf:"tpu_topology" json:"tpu_topology,omitempty"`
+	Type_       *Value[string] `tf:"type" json:"type,omitempty"`
 }
 
 // GoogleContainerNodePoolQueuedProvisioning is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolQueuedProvisioning struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleContainerNodePoolTimeouts is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleContainerNodePoolUpgradeSettings is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolUpgradeSettings struct {
-	MaxSurge          *Value[int64]                                             `tf:"max_surge"`
-	MaxUnavailable    *Value[int64]                                             `tf:"max_unavailable"`
-	Strategy          *Value[string]                                            `tf:"strategy"`
-	BlueGreenSettings []GoogleContainerNodePoolUpgradeSettingsBlueGreenSettings `tf:"blue_green_settings,blocks"`
+	MaxSurge          *Value[int64]                                             `tf:"max_surge" json:"max_surge,omitempty"`
+	MaxUnavailable    *Value[int64]                                             `tf:"max_unavailable" json:"max_unavailable,omitempty"`
+	Strategy          *Value[string]                                            `tf:"strategy" json:"strategy,omitempty"`
+	BlueGreenSettings []GoogleContainerNodePoolUpgradeSettingsBlueGreenSettings `tf:"blue_green_settings,blocks" json:"blue_green_settings,omitempty"`
 }
 
 // GoogleContainerNodePoolUpgradeSettingsBlueGreenSettings is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolUpgradeSettingsBlueGreenSettings struct {
-	NodePoolSoakDuration  *Value[string]                                                                 `tf:"node_pool_soak_duration"`
-	StandardRolloutPolicy []GoogleContainerNodePoolUpgradeSettingsBlueGreenSettingsStandardRolloutPolicy `tf:"standard_rollout_policy,blocks"`
+	NodePoolSoakDuration  *Value[string]                                                                 `tf:"node_pool_soak_duration" json:"node_pool_soak_duration,omitempty"`
+	StandardRolloutPolicy []GoogleContainerNodePoolUpgradeSettingsBlueGreenSettingsStandardRolloutPolicy `tf:"standard_rollout_policy,blocks" json:"standard_rollout_policy,omitempty"`
 }
 
 // GoogleContainerNodePoolUpgradeSettingsBlueGreenSettingsStandardRolloutPolicy is a nested-block type used by the parent resource.
 type GoogleContainerNodePoolUpgradeSettingsBlueGreenSettingsStandardRolloutPolicy struct {
-	BatchNodeCount    *Value[int64]   `tf:"batch_node_count"`
-	BatchPercentage   *Value[float64] `tf:"batch_percentage"`
-	BatchSoakDuration *Value[string]  `tf:"batch_soak_duration"`
+	BatchNodeCount    *Value[int64]   `tf:"batch_node_count" json:"batch_node_count,omitempty"`
+	BatchPercentage   *Value[float64] `tf:"batch_percentage" json:"batch_percentage,omitempty"`
+	BatchSoakDuration *Value[string]  `tf:"batch_soak_duration" json:"batch_soak_duration,omitempty"`
 }
 
 // GoogleContainerNodePoolSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_firestore_database.gen.go
+++ b/pkg/composer/imported/generated/google_firestore_database.gen.go
@@ -7,38 +7,38 @@ import "reflect"
 // GoogleFirestoreDatabase is the generated Layer 1 typed model for the
 // `google_firestore_database` Terraform resource.
 type GoogleFirestoreDatabase struct {
-	AppEngineIntegrationMode      *Value[string]                      `tf:"app_engine_integration_mode"`
-	ConcurrencyMode               *Value[string]                      `tf:"concurrency_mode"`
-	CreateTime                    *Value[string]                      `tf:"create_time"`
-	DeleteProtectionState         *Value[string]                      `tf:"delete_protection_state"`
-	DeletionPolicy                *Value[string]                      `tf:"deletion_policy"`
-	EarliestVersionTime           *Value[string]                      `tf:"earliest_version_time"`
-	Etag                          *Value[string]                      `tf:"etag"`
-	ID                            *Value[string]                      `tf:"id"`
-	KeyPrefix                     *Value[string]                      `tf:"key_prefix"`
-	LocationID                    *Value[string]                      `tf:"location_id"`
-	Name                          *Value[string]                      `tf:"name"`
-	PointInTimeRecoveryEnablement *Value[string]                      `tf:"point_in_time_recovery_enablement"`
-	Project                       *Value[string]                      `tf:"project"`
-	Type_                         *Value[string]                      `tf:"type"`
-	Uid                           *Value[string]                      `tf:"uid"`
-	UpdateTime                    *Value[string]                      `tf:"update_time"`
-	VersionRetentionPeriod        *Value[string]                      `tf:"version_retention_period"`
-	CmekConfig                    []GoogleFirestoreDatabaseCmekConfig `tf:"cmek_config,blocks"`
-	Timeouts                      *GoogleFirestoreDatabaseTimeouts    `tf:"timeouts,block"`
+	AppEngineIntegrationMode      *Value[string]                      `tf:"app_engine_integration_mode" json:"app_engine_integration_mode,omitempty"`
+	ConcurrencyMode               *Value[string]                      `tf:"concurrency_mode" json:"concurrency_mode,omitempty"`
+	CreateTime                    *Value[string]                      `tf:"create_time" json:"create_time,omitempty"`
+	DeleteProtectionState         *Value[string]                      `tf:"delete_protection_state" json:"delete_protection_state,omitempty"`
+	DeletionPolicy                *Value[string]                      `tf:"deletion_policy" json:"deletion_policy,omitempty"`
+	EarliestVersionTime           *Value[string]                      `tf:"earliest_version_time" json:"earliest_version_time,omitempty"`
+	Etag                          *Value[string]                      `tf:"etag" json:"etag,omitempty"`
+	ID                            *Value[string]                      `tf:"id" json:"id,omitempty"`
+	KeyPrefix                     *Value[string]                      `tf:"key_prefix" json:"key_prefix,omitempty"`
+	LocationID                    *Value[string]                      `tf:"location_id" json:"location_id,omitempty"`
+	Name                          *Value[string]                      `tf:"name" json:"name,omitempty"`
+	PointInTimeRecoveryEnablement *Value[string]                      `tf:"point_in_time_recovery_enablement" json:"point_in_time_recovery_enablement,omitempty"`
+	Project                       *Value[string]                      `tf:"project" json:"project,omitempty"`
+	Type_                         *Value[string]                      `tf:"type" json:"type,omitempty"`
+	Uid                           *Value[string]                      `tf:"uid" json:"uid,omitempty"`
+	UpdateTime                    *Value[string]                      `tf:"update_time" json:"update_time,omitempty"`
+	VersionRetentionPeriod        *Value[string]                      `tf:"version_retention_period" json:"version_retention_period,omitempty"`
+	CmekConfig                    []GoogleFirestoreDatabaseCmekConfig `tf:"cmek_config,blocks" json:"cmek_config,omitempty"`
+	Timeouts                      *GoogleFirestoreDatabaseTimeouts    `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleFirestoreDatabaseCmekConfig is a nested-block type used by the parent resource.
 type GoogleFirestoreDatabaseCmekConfig struct {
-	ActiveKeyVersion []*Value[string] `tf:"active_key_version"`
-	KMSKeyName       *Value[string]   `tf:"kms_key_name"`
+	ActiveKeyVersion []*Value[string] `tf:"active_key_version" json:"active_key_version,omitempty"`
+	KMSKeyName       *Value[string]   `tf:"kms_key_name" json:"kms_key_name,omitempty"`
 }
 
 // GoogleFirestoreDatabaseTimeouts is a nested-block type used by the parent resource.
 type GoogleFirestoreDatabaseTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleFirestoreDatabaseSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_identity_platform_config.gen.go
+++ b/pkg/composer/imported/generated/google_identity_platform_config.gen.go
@@ -7,157 +7,157 @@ import "reflect"
 // GoogleIdentityPlatformConfig is the generated Layer 1 typed model for the
 // `google_identity_platform_config` Terraform resource.
 type GoogleIdentityPlatformConfig struct {
-	AuthorizedDomains        []*Value[string]                                `tf:"authorized_domains"`
-	AutodeleteAnonymousUsers *Value[bool]                                    `tf:"autodelete_anonymous_users"`
-	ID                       *Value[string]                                  `tf:"id"`
-	Name                     *Value[string]                                  `tf:"name"`
-	Project                  *Value[string]                                  `tf:"project"`
-	BlockingFunctions        []GoogleIdentityPlatformConfigBlockingFunctions `tf:"blocking_functions,blocks"`
-	Client                   []GoogleIdentityPlatformConfigClient            `tf:"client,blocks"`
-	MFA                      []GoogleIdentityPlatformConfigMFA               `tf:"mfa,blocks"`
-	Monitoring               []GoogleIdentityPlatformConfigMonitoring        `tf:"monitoring,blocks"`
-	MultiTenant              []GoogleIdentityPlatformConfigMultiTenant       `tf:"multi_tenant,blocks"`
-	Quota                    []GoogleIdentityPlatformConfigQuota             `tf:"quota,blocks"`
-	SignIn                   []GoogleIdentityPlatformConfigSignIn            `tf:"sign_in,blocks"`
-	SMSRegionConfig          []GoogleIdentityPlatformConfigSMSRegionConfig   `tf:"sms_region_config,blocks"`
-	Timeouts                 *GoogleIdentityPlatformConfigTimeouts           `tf:"timeouts,block"`
+	AuthorizedDomains        []*Value[string]                                `tf:"authorized_domains" json:"authorized_domains,omitempty"`
+	AutodeleteAnonymousUsers *Value[bool]                                    `tf:"autodelete_anonymous_users" json:"autodelete_anonymous_users,omitempty"`
+	ID                       *Value[string]                                  `tf:"id" json:"id,omitempty"`
+	Name                     *Value[string]                                  `tf:"name" json:"name,omitempty"`
+	Project                  *Value[string]                                  `tf:"project" json:"project,omitempty"`
+	BlockingFunctions        []GoogleIdentityPlatformConfigBlockingFunctions `tf:"blocking_functions,blocks" json:"blocking_functions,omitempty"`
+	Client                   []GoogleIdentityPlatformConfigClient            `tf:"client,blocks" json:"client,omitempty"`
+	MFA                      []GoogleIdentityPlatformConfigMFA               `tf:"mfa,blocks" json:"mfa,omitempty"`
+	Monitoring               []GoogleIdentityPlatformConfigMonitoring        `tf:"monitoring,blocks" json:"monitoring,omitempty"`
+	MultiTenant              []GoogleIdentityPlatformConfigMultiTenant       `tf:"multi_tenant,blocks" json:"multi_tenant,omitempty"`
+	Quota                    []GoogleIdentityPlatformConfigQuota             `tf:"quota,blocks" json:"quota,omitempty"`
+	SignIn                   []GoogleIdentityPlatformConfigSignIn            `tf:"sign_in,blocks" json:"sign_in,omitempty"`
+	SMSRegionConfig          []GoogleIdentityPlatformConfigSMSRegionConfig   `tf:"sms_region_config,blocks" json:"sms_region_config,omitempty"`
+	Timeouts                 *GoogleIdentityPlatformConfigTimeouts           `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigBlockingFunctions is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigBlockingFunctions struct {
-	ForwardInboundCredentials []GoogleIdentityPlatformConfigBlockingFunctionsForwardInboundCredentials `tf:"forward_inbound_credentials,blocks"`
-	Triggers                  []GoogleIdentityPlatformConfigBlockingFunctionsTriggers                  `tf:"triggers,blocks"`
+	ForwardInboundCredentials []GoogleIdentityPlatformConfigBlockingFunctionsForwardInboundCredentials `tf:"forward_inbound_credentials,blocks" json:"forward_inbound_credentials,omitempty"`
+	Triggers                  []GoogleIdentityPlatformConfigBlockingFunctionsTriggers                  `tf:"triggers,blocks" json:"triggers,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigBlockingFunctionsForwardInboundCredentials is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigBlockingFunctionsForwardInboundCredentials struct {
-	AccessToken  *Value[bool] `tf:"access_token"`
-	IDToken      *Value[bool] `tf:"id_token"`
-	RefreshToken *Value[bool] `tf:"refresh_token"`
+	AccessToken  *Value[bool] `tf:"access_token" json:"access_token,omitempty"`
+	IDToken      *Value[bool] `tf:"id_token" json:"id_token,omitempty"`
+	RefreshToken *Value[bool] `tf:"refresh_token" json:"refresh_token,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigBlockingFunctionsTriggers is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigBlockingFunctionsTriggers struct {
-	EventType   *Value[string] `tf:"event_type"`
-	FunctionURI *Value[string] `tf:"function_uri"`
-	UpdateTime  *Value[string] `tf:"update_time"`
+	EventType   *Value[string] `tf:"event_type" json:"event_type,omitempty"`
+	FunctionURI *Value[string] `tf:"function_uri" json:"function_uri,omitempty"`
+	UpdateTime  *Value[string] `tf:"update_time" json:"update_time,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigClient is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigClient struct {
-	APIKey            *Value[string]                                  `tf:"api_key"`
-	FirebaseSubdomain *Value[string]                                  `tf:"firebase_subdomain"`
-	Permissions       []GoogleIdentityPlatformConfigClientPermissions `tf:"permissions,blocks"`
+	APIKey            *Value[string]                                  `tf:"api_key" json:"api_key,omitempty"`
+	FirebaseSubdomain *Value[string]                                  `tf:"firebase_subdomain" json:"firebase_subdomain,omitempty"`
+	Permissions       []GoogleIdentityPlatformConfigClientPermissions `tf:"permissions,blocks" json:"permissions,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigClientPermissions is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigClientPermissions struct {
-	DisabledUserDeletion *Value[bool] `tf:"disabled_user_deletion"`
-	DisabledUserSignup   *Value[bool] `tf:"disabled_user_signup"`
+	DisabledUserDeletion *Value[bool] `tf:"disabled_user_deletion" json:"disabled_user_deletion,omitempty"`
+	DisabledUserSignup   *Value[bool] `tf:"disabled_user_signup" json:"disabled_user_signup,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigMFA is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigMFA struct {
-	EnabledProviders []*Value[string]                                 `tf:"enabled_providers"`
-	State            *Value[string]                                   `tf:"state"`
-	ProviderConfigs  []GoogleIdentityPlatformConfigMFAProviderConfigs `tf:"provider_configs,blocks"`
+	EnabledProviders []*Value[string]                                 `tf:"enabled_providers" json:"enabled_providers,omitempty"`
+	State            *Value[string]                                   `tf:"state" json:"state,omitempty"`
+	ProviderConfigs  []GoogleIdentityPlatformConfigMFAProviderConfigs `tf:"provider_configs,blocks" json:"provider_configs,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigMFAProviderConfigs is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigMFAProviderConfigs struct {
-	State              *Value[string]                                                     `tf:"state"`
-	TotpProviderConfig []GoogleIdentityPlatformConfigMFAProviderConfigsTotpProviderConfig `tf:"totp_provider_config,blocks"`
+	State              *Value[string]                                                     `tf:"state" json:"state,omitempty"`
+	TotpProviderConfig []GoogleIdentityPlatformConfigMFAProviderConfigsTotpProviderConfig `tf:"totp_provider_config,blocks" json:"totp_provider_config,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigMFAProviderConfigsTotpProviderConfig is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigMFAProviderConfigsTotpProviderConfig struct {
-	AdjacentIntervals *Value[float64] `tf:"adjacent_intervals"`
+	AdjacentIntervals *Value[float64] `tf:"adjacent_intervals" json:"adjacent_intervals,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigMonitoring is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigMonitoring struct {
-	RequestLogging []GoogleIdentityPlatformConfigMonitoringRequestLogging `tf:"request_logging,blocks"`
+	RequestLogging []GoogleIdentityPlatformConfigMonitoringRequestLogging `tf:"request_logging,blocks" json:"request_logging,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigMonitoringRequestLogging is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigMonitoringRequestLogging struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigMultiTenant is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigMultiTenant struct {
-	AllowTenants          *Value[bool]   `tf:"allow_tenants"`
-	DefaultTenantLocation *Value[string] `tf:"default_tenant_location"`
+	AllowTenants          *Value[bool]   `tf:"allow_tenants" json:"allow_tenants,omitempty"`
+	DefaultTenantLocation *Value[string] `tf:"default_tenant_location" json:"default_tenant_location,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigQuota is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigQuota struct {
-	SignUpQuotaConfig []GoogleIdentityPlatformConfigQuotaSignUpQuotaConfig `tf:"sign_up_quota_config,blocks"`
+	SignUpQuotaConfig []GoogleIdentityPlatformConfigQuotaSignUpQuotaConfig `tf:"sign_up_quota_config,blocks" json:"sign_up_quota_config,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigQuotaSignUpQuotaConfig is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigQuotaSignUpQuotaConfig struct {
-	Quota         *Value[float64] `tf:"quota"`
-	QuotaDuration *Value[string]  `tf:"quota_duration"`
-	StartTime     *Value[string]  `tf:"start_time"`
+	Quota         *Value[float64] `tf:"quota" json:"quota,omitempty"`
+	QuotaDuration *Value[string]  `tf:"quota_duration" json:"quota_duration,omitempty"`
+	StartTime     *Value[string]  `tf:"start_time" json:"start_time,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigSMSRegionConfig is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigSMSRegionConfig struct {
-	AllowByDefault []GoogleIdentityPlatformConfigSMSRegionConfigAllowByDefault `tf:"allow_by_default,blocks"`
-	AllowlistOnly  []GoogleIdentityPlatformConfigSMSRegionConfigAllowlistOnly  `tf:"allowlist_only,blocks"`
+	AllowByDefault []GoogleIdentityPlatformConfigSMSRegionConfigAllowByDefault `tf:"allow_by_default,blocks" json:"allow_by_default,omitempty"`
+	AllowlistOnly  []GoogleIdentityPlatformConfigSMSRegionConfigAllowlistOnly  `tf:"allowlist_only,blocks" json:"allowlist_only,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigSMSRegionConfigAllowByDefault is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigSMSRegionConfigAllowByDefault struct {
-	DisallowedRegions []*Value[string] `tf:"disallowed_regions"`
+	DisallowedRegions []*Value[string] `tf:"disallowed_regions" json:"disallowed_regions,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigSMSRegionConfigAllowlistOnly is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigSMSRegionConfigAllowlistOnly struct {
-	AllowedRegions []*Value[string] `tf:"allowed_regions"`
+	AllowedRegions []*Value[string] `tf:"allowed_regions" json:"allowed_regions,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigSignIn is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigSignIn struct {
-	AllowDuplicateEmails *Value[bool]                                    `tf:"allow_duplicate_emails"`
-	HashConfig           []GoogleIdentityPlatformConfigSignInHashConfig  `tf:"hash_config"`
-	Anonymous            []GoogleIdentityPlatformConfigSignInAnonymous   `tf:"anonymous,blocks"`
-	Email                []GoogleIdentityPlatformConfigSignInEmail       `tf:"email,blocks"`
-	PhoneNumber          []GoogleIdentityPlatformConfigSignInPhoneNumber `tf:"phone_number,blocks"`
+	AllowDuplicateEmails *Value[bool]                                    `tf:"allow_duplicate_emails" json:"allow_duplicate_emails,omitempty"`
+	HashConfig           []GoogleIdentityPlatformConfigSignInHashConfig  `tf:"hash_config" json:"hash_config,omitempty"`
+	Anonymous            []GoogleIdentityPlatformConfigSignInAnonymous   `tf:"anonymous,blocks" json:"anonymous,omitempty"`
+	Email                []GoogleIdentityPlatformConfigSignInEmail       `tf:"email,blocks" json:"email,omitempty"`
+	PhoneNumber          []GoogleIdentityPlatformConfigSignInPhoneNumber `tf:"phone_number,blocks" json:"phone_number,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigSignInAnonymous is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigSignInAnonymous struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigSignInEmail is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigSignInEmail struct {
-	Enabled          *Value[bool] `tf:"enabled"`
-	PasswordRequired *Value[bool] `tf:"password_required"`
+	Enabled          *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
+	PasswordRequired *Value[bool] `tf:"password_required" json:"password_required,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigSignInHashConfig is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigSignInHashConfig struct {
-	Algorithm     *Value[string]  `tf:"algorithm"`
-	MemoryCost    *Value[float64] `tf:"memory_cost"`
-	Rounds        *Value[float64] `tf:"rounds"`
-	SaltSeparator *Value[string]  `tf:"salt_separator"`
-	SignerKey     *Value[string]  `tf:"signer_key"`
+	Algorithm     *Value[string]  `tf:"algorithm" json:"algorithm,omitempty"`
+	MemoryCost    *Value[float64] `tf:"memory_cost" json:"memory_cost,omitempty"`
+	Rounds        *Value[float64] `tf:"rounds" json:"rounds,omitempty"`
+	SaltSeparator *Value[string]  `tf:"salt_separator" json:"salt_separator,omitempty"`
+	SignerKey     *Value[string]  `tf:"signer_key" json:"signer_key,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigSignInPhoneNumber is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigSignInPhoneNumber struct {
-	Enabled          *Value[bool]              `tf:"enabled"`
-	TestPhoneNumbers map[string]*Value[string] `tf:"test_phone_numbers"`
+	Enabled          *Value[bool]              `tf:"enabled" json:"enabled,omitempty"`
+	TestPhoneNumbers map[string]*Value[string] `tf:"test_phone_numbers" json:"test_phone_numbers,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigTimeouts is a nested-block type used by the parent resource.
 type GoogleIdentityPlatformConfigTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleIdentityPlatformConfigSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_kms_crypto_key.gen.go
+++ b/pkg/composer/imported/generated/google_kms_crypto_key.gen.go
@@ -7,40 +7,40 @@ import "reflect"
 // GoogleKMSCryptoKey is the generated Layer 1 typed model for the
 // `google_kms_crypto_key` Terraform resource.
 type GoogleKMSCryptoKey struct {
-	CryptoKeyBackend           *Value[string]                      `tf:"crypto_key_backend"`
-	DestroyScheduledDuration   *Value[string]                      `tf:"destroy_scheduled_duration"`
-	EffectiveLabels            map[string]*Value[string]           `tf:"effective_labels"`
-	ID                         *Value[string]                      `tf:"id"`
-	ImportOnly                 *Value[bool]                        `tf:"import_only"`
-	KeyRing                    *Value[string]                      `tf:"key_ring"`
-	Labels                     map[string]*Value[string]           `tf:"labels"`
-	Name                       *Value[string]                      `tf:"name"`
-	Primary                    []GoogleKMSCryptoKeyPrimary         `tf:"primary"`
-	Purpose                    *Value[string]                      `tf:"purpose"`
-	RotationPeriod             *Value[string]                      `tf:"rotation_period"`
-	SkipInitialVersionCreation *Value[bool]                        `tf:"skip_initial_version_creation"`
-	TerraformLabels            map[string]*Value[string]           `tf:"terraform_labels"`
-	Timeouts                   *GoogleKMSCryptoKeyTimeouts         `tf:"timeouts,block"`
-	VersionTemplate            []GoogleKMSCryptoKeyVersionTemplate `tf:"version_template,blocks"`
+	CryptoKeyBackend           *Value[string]                      `tf:"crypto_key_backend" json:"crypto_key_backend,omitempty"`
+	DestroyScheduledDuration   *Value[string]                      `tf:"destroy_scheduled_duration" json:"destroy_scheduled_duration,omitempty"`
+	EffectiveLabels            map[string]*Value[string]           `tf:"effective_labels" json:"effective_labels,omitempty"`
+	ID                         *Value[string]                      `tf:"id" json:"id,omitempty"`
+	ImportOnly                 *Value[bool]                        `tf:"import_only" json:"import_only,omitempty"`
+	KeyRing                    *Value[string]                      `tf:"key_ring" json:"key_ring,omitempty"`
+	Labels                     map[string]*Value[string]           `tf:"labels" json:"labels,omitempty"`
+	Name                       *Value[string]                      `tf:"name" json:"name,omitempty"`
+	Primary                    []GoogleKMSCryptoKeyPrimary         `tf:"primary" json:"primary,omitempty"`
+	Purpose                    *Value[string]                      `tf:"purpose" json:"purpose,omitempty"`
+	RotationPeriod             *Value[string]                      `tf:"rotation_period" json:"rotation_period,omitempty"`
+	SkipInitialVersionCreation *Value[bool]                        `tf:"skip_initial_version_creation" json:"skip_initial_version_creation,omitempty"`
+	TerraformLabels            map[string]*Value[string]           `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	Timeouts                   *GoogleKMSCryptoKeyTimeouts         `tf:"timeouts,block" json:"timeouts,omitempty"`
+	VersionTemplate            []GoogleKMSCryptoKeyVersionTemplate `tf:"version_template,blocks" json:"version_template,omitempty"`
 }
 
 // GoogleKMSCryptoKeyPrimary is a nested-block type used by the parent resource.
 type GoogleKMSCryptoKeyPrimary struct {
-	Name  *Value[string] `tf:"name"`
-	State *Value[string] `tf:"state"`
+	Name  *Value[string] `tf:"name" json:"name,omitempty"`
+	State *Value[string] `tf:"state" json:"state,omitempty"`
 }
 
 // GoogleKMSCryptoKeyTimeouts is a nested-block type used by the parent resource.
 type GoogleKMSCryptoKeyTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleKMSCryptoKeyVersionTemplate is a nested-block type used by the parent resource.
 type GoogleKMSCryptoKeyVersionTemplate struct {
-	Algorithm       *Value[string] `tf:"algorithm"`
-	ProtectionLevel *Value[string] `tf:"protection_level"`
+	Algorithm       *Value[string] `tf:"algorithm" json:"algorithm,omitempty"`
+	ProtectionLevel *Value[string] `tf:"protection_level" json:"protection_level,omitempty"`
 }
 
 // GoogleKMSCryptoKeySchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_kms_key_ring.gen.go
+++ b/pkg/composer/imported/generated/google_kms_key_ring.gen.go
@@ -7,17 +7,17 @@ import "reflect"
 // GoogleKMSKeyRing is the generated Layer 1 typed model for the
 // `google_kms_key_ring` Terraform resource.
 type GoogleKMSKeyRing struct {
-	ID       *Value[string]            `tf:"id"`
-	Location *Value[string]            `tf:"location"`
-	Name     *Value[string]            `tf:"name"`
-	Project  *Value[string]            `tf:"project"`
-	Timeouts *GoogleKMSKeyRingTimeouts `tf:"timeouts,block"`
+	ID       *Value[string]            `tf:"id" json:"id,omitempty"`
+	Location *Value[string]            `tf:"location" json:"location,omitempty"`
+	Name     *Value[string]            `tf:"name" json:"name,omitempty"`
+	Project  *Value[string]            `tf:"project" json:"project,omitempty"`
+	Timeouts *GoogleKMSKeyRingTimeouts `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleKMSKeyRingTimeouts is a nested-block type used by the parent resource.
 type GoogleKMSKeyRingTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
 }
 
 // GoogleKMSKeyRingSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_logging_project_sink.gen.go
+++ b/pkg/composer/imported/generated/google_logging_project_sink.gen.go
@@ -7,31 +7,31 @@ import "reflect"
 // GoogleLoggingProjectSink is the generated Layer 1 typed model for the
 // `google_logging_project_sink` Terraform resource.
 type GoogleLoggingProjectSink struct {
-	CustomWriterIdentity *Value[string]                            `tf:"custom_writer_identity"`
-	Description          *Value[string]                            `tf:"description"`
-	Destination          *Value[string]                            `tf:"destination"`
-	Disabled             *Value[bool]                              `tf:"disabled"`
-	Filter               *Value[string]                            `tf:"filter"`
-	ID                   *Value[string]                            `tf:"id"`
-	Name                 *Value[string]                            `tf:"name"`
-	Project              *Value[string]                            `tf:"project"`
-	UniqueWriterIdentity *Value[bool]                              `tf:"unique_writer_identity"`
-	WriterIdentity       *Value[string]                            `tf:"writer_identity"`
-	BigqueryOptions      []GoogleLoggingProjectSinkBigqueryOptions `tf:"bigquery_options,blocks"`
-	Exclusions           []GoogleLoggingProjectSinkExclusions      `tf:"exclusions,blocks"`
+	CustomWriterIdentity *Value[string]                            `tf:"custom_writer_identity" json:"custom_writer_identity,omitempty"`
+	Description          *Value[string]                            `tf:"description" json:"description,omitempty"`
+	Destination          *Value[string]                            `tf:"destination" json:"destination,omitempty"`
+	Disabled             *Value[bool]                              `tf:"disabled" json:"disabled,omitempty"`
+	Filter               *Value[string]                            `tf:"filter" json:"filter,omitempty"`
+	ID                   *Value[string]                            `tf:"id" json:"id,omitempty"`
+	Name                 *Value[string]                            `tf:"name" json:"name,omitempty"`
+	Project              *Value[string]                            `tf:"project" json:"project,omitempty"`
+	UniqueWriterIdentity *Value[bool]                              `tf:"unique_writer_identity" json:"unique_writer_identity,omitempty"`
+	WriterIdentity       *Value[string]                            `tf:"writer_identity" json:"writer_identity,omitempty"`
+	BigqueryOptions      []GoogleLoggingProjectSinkBigqueryOptions `tf:"bigquery_options,blocks" json:"bigquery_options,omitempty"`
+	Exclusions           []GoogleLoggingProjectSinkExclusions      `tf:"exclusions,blocks" json:"exclusions,omitempty"`
 }
 
 // GoogleLoggingProjectSinkBigqueryOptions is a nested-block type used by the parent resource.
 type GoogleLoggingProjectSinkBigqueryOptions struct {
-	UsePartitionedTables *Value[bool] `tf:"use_partitioned_tables"`
+	UsePartitionedTables *Value[bool] `tf:"use_partitioned_tables" json:"use_partitioned_tables,omitempty"`
 }
 
 // GoogleLoggingProjectSinkExclusions is a nested-block type used by the parent resource.
 type GoogleLoggingProjectSinkExclusions struct {
-	Description *Value[string] `tf:"description"`
-	Disabled    *Value[bool]   `tf:"disabled"`
-	Filter      *Value[string] `tf:"filter"`
-	Name        *Value[string] `tf:"name"`
+	Description *Value[string] `tf:"description" json:"description,omitempty"`
+	Disabled    *Value[bool]   `tf:"disabled" json:"disabled,omitempty"`
+	Filter      *Value[string] `tf:"filter" json:"filter,omitempty"`
+	Name        *Value[string] `tf:"name" json:"name,omitempty"`
 }
 
 // GoogleLoggingProjectSinkSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_monitoring_alert_policy.gen.go
+++ b/pkg/composer/imported/generated/google_monitoring_alert_policy.gen.go
@@ -7,170 +7,170 @@ import "reflect"
 // GoogleMonitoringAlertPolicy is the generated Layer 1 typed model for the
 // `google_monitoring_alert_policy` Terraform resource.
 type GoogleMonitoringAlertPolicy struct {
-	Combiner             *Value[string]                              `tf:"combiner"`
-	CreationRecord       []GoogleMonitoringAlertPolicyCreationRecord `tf:"creation_record"`
-	DisplayName          *Value[string]                              `tf:"display_name"`
-	Enabled              *Value[bool]                                `tf:"enabled"`
-	ID                   *Value[string]                              `tf:"id"`
-	Name                 *Value[string]                              `tf:"name"`
-	NotificationChannels []*Value[string]                            `tf:"notification_channels"`
-	Project              *Value[string]                              `tf:"project"`
-	Severity             *Value[string]                              `tf:"severity"`
-	UserLabels           map[string]*Value[string]                   `tf:"user_labels"`
-	AlertStrategy        []GoogleMonitoringAlertPolicyAlertStrategy  `tf:"alert_strategy,blocks"`
-	Conditions           []GoogleMonitoringAlertPolicyConditions     `tf:"conditions,blocks"`
-	Documentation        []GoogleMonitoringAlertPolicyDocumentation  `tf:"documentation,blocks"`
-	Timeouts             *GoogleMonitoringAlertPolicyTimeouts        `tf:"timeouts,block"`
+	Combiner             *Value[string]                              `tf:"combiner" json:"combiner,omitempty"`
+	CreationRecord       []GoogleMonitoringAlertPolicyCreationRecord `tf:"creation_record" json:"creation_record,omitempty"`
+	DisplayName          *Value[string]                              `tf:"display_name" json:"display_name,omitempty"`
+	Enabled              *Value[bool]                                `tf:"enabled" json:"enabled,omitempty"`
+	ID                   *Value[string]                              `tf:"id" json:"id,omitempty"`
+	Name                 *Value[string]                              `tf:"name" json:"name,omitempty"`
+	NotificationChannels []*Value[string]                            `tf:"notification_channels" json:"notification_channels,omitempty"`
+	Project              *Value[string]                              `tf:"project" json:"project,omitempty"`
+	Severity             *Value[string]                              `tf:"severity" json:"severity,omitempty"`
+	UserLabels           map[string]*Value[string]                   `tf:"user_labels" json:"user_labels,omitempty"`
+	AlertStrategy        []GoogleMonitoringAlertPolicyAlertStrategy  `tf:"alert_strategy,blocks" json:"alert_strategy,omitempty"`
+	Conditions           []GoogleMonitoringAlertPolicyConditions     `tf:"conditions,blocks" json:"conditions,omitempty"`
+	Documentation        []GoogleMonitoringAlertPolicyDocumentation  `tf:"documentation,blocks" json:"documentation,omitempty"`
+	Timeouts             *GoogleMonitoringAlertPolicyTimeouts        `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyAlertStrategy is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyAlertStrategy struct {
-	AutoClose                   *Value[string]                                                        `tf:"auto_close"`
-	NotificationPrompts         []*Value[string]                                                      `tf:"notification_prompts"`
-	NotificationChannelStrategy []GoogleMonitoringAlertPolicyAlertStrategyNotificationChannelStrategy `tf:"notification_channel_strategy,blocks"`
-	NotificationRateLimit       []GoogleMonitoringAlertPolicyAlertStrategyNotificationRateLimit       `tf:"notification_rate_limit,blocks"`
+	AutoClose                   *Value[string]                                                        `tf:"auto_close" json:"auto_close,omitempty"`
+	NotificationPrompts         []*Value[string]                                                      `tf:"notification_prompts" json:"notification_prompts,omitempty"`
+	NotificationChannelStrategy []GoogleMonitoringAlertPolicyAlertStrategyNotificationChannelStrategy `tf:"notification_channel_strategy,blocks" json:"notification_channel_strategy,omitempty"`
+	NotificationRateLimit       []GoogleMonitoringAlertPolicyAlertStrategyNotificationRateLimit       `tf:"notification_rate_limit,blocks" json:"notification_rate_limit,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyAlertStrategyNotificationChannelStrategy is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyAlertStrategyNotificationChannelStrategy struct {
-	NotificationChannelNames []*Value[string] `tf:"notification_channel_names"`
-	RenotifyInterval         *Value[string]   `tf:"renotify_interval"`
+	NotificationChannelNames []*Value[string] `tf:"notification_channel_names" json:"notification_channel_names,omitempty"`
+	RenotifyInterval         *Value[string]   `tf:"renotify_interval" json:"renotify_interval,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyAlertStrategyNotificationRateLimit is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyAlertStrategyNotificationRateLimit struct {
-	Period *Value[string] `tf:"period"`
+	Period *Value[string] `tf:"period" json:"period,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyConditions is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyConditions struct {
-	DisplayName                      *Value[string]                                                          `tf:"display_name"`
-	Name                             *Value[string]                                                          `tf:"name"`
-	ConditionAbsent                  []GoogleMonitoringAlertPolicyConditionsConditionAbsent                  `tf:"condition_absent,blocks"`
-	ConditionMatchedLog              []GoogleMonitoringAlertPolicyConditionsConditionMatchedLog              `tf:"condition_matched_log,blocks"`
-	ConditionMonitoringQueryLanguage []GoogleMonitoringAlertPolicyConditionsConditionMonitoringQueryLanguage `tf:"condition_monitoring_query_language,blocks"`
-	ConditionPrometheusQueryLanguage []GoogleMonitoringAlertPolicyConditionsConditionPrometheusQueryLanguage `tf:"condition_prometheus_query_language,blocks"`
-	ConditionThreshold               []GoogleMonitoringAlertPolicyConditionsConditionThreshold               `tf:"condition_threshold,blocks"`
+	DisplayName                      *Value[string]                                                          `tf:"display_name" json:"display_name,omitempty"`
+	Name                             *Value[string]                                                          `tf:"name" json:"name,omitempty"`
+	ConditionAbsent                  []GoogleMonitoringAlertPolicyConditionsConditionAbsent                  `tf:"condition_absent,blocks" json:"condition_absent,omitempty"`
+	ConditionMatchedLog              []GoogleMonitoringAlertPolicyConditionsConditionMatchedLog              `tf:"condition_matched_log,blocks" json:"condition_matched_log,omitempty"`
+	ConditionMonitoringQueryLanguage []GoogleMonitoringAlertPolicyConditionsConditionMonitoringQueryLanguage `tf:"condition_monitoring_query_language,blocks" json:"condition_monitoring_query_language,omitempty"`
+	ConditionPrometheusQueryLanguage []GoogleMonitoringAlertPolicyConditionsConditionPrometheusQueryLanguage `tf:"condition_prometheus_query_language,blocks" json:"condition_prometheus_query_language,omitempty"`
+	ConditionThreshold               []GoogleMonitoringAlertPolicyConditionsConditionThreshold               `tf:"condition_threshold,blocks" json:"condition_threshold,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyConditionsConditionAbsent is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyConditionsConditionAbsent struct {
-	Duration     *Value[string]                                                     `tf:"duration"`
-	Filter       *Value[string]                                                     `tf:"filter"`
-	Aggregations []GoogleMonitoringAlertPolicyConditionsConditionAbsentAggregations `tf:"aggregations,blocks"`
-	Trigger      []GoogleMonitoringAlertPolicyConditionsConditionAbsentTrigger      `tf:"trigger,blocks"`
+	Duration     *Value[string]                                                     `tf:"duration" json:"duration,omitempty"`
+	Filter       *Value[string]                                                     `tf:"filter" json:"filter,omitempty"`
+	Aggregations []GoogleMonitoringAlertPolicyConditionsConditionAbsentAggregations `tf:"aggregations,blocks" json:"aggregations,omitempty"`
+	Trigger      []GoogleMonitoringAlertPolicyConditionsConditionAbsentTrigger      `tf:"trigger,blocks" json:"trigger,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyConditionsConditionAbsentAggregations is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyConditionsConditionAbsentAggregations struct {
-	AlignmentPeriod    *Value[string]   `tf:"alignment_period"`
-	CrossSeriesReducer *Value[string]   `tf:"cross_series_reducer"`
-	GroupByFields      []*Value[string] `tf:"group_by_fields"`
-	PerSeriesAligner   *Value[string]   `tf:"per_series_aligner"`
+	AlignmentPeriod    *Value[string]   `tf:"alignment_period" json:"alignment_period,omitempty"`
+	CrossSeriesReducer *Value[string]   `tf:"cross_series_reducer" json:"cross_series_reducer,omitempty"`
+	GroupByFields      []*Value[string] `tf:"group_by_fields" json:"group_by_fields,omitempty"`
+	PerSeriesAligner   *Value[string]   `tf:"per_series_aligner" json:"per_series_aligner,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyConditionsConditionAbsentTrigger is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyConditionsConditionAbsentTrigger struct {
-	Count   *Value[float64] `tf:"count"`
-	Percent *Value[float64] `tf:"percent"`
+	Count   *Value[float64] `tf:"count" json:"count,omitempty"`
+	Percent *Value[float64] `tf:"percent" json:"percent,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyConditionsConditionMatchedLog is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyConditionsConditionMatchedLog struct {
-	Filter          *Value[string]            `tf:"filter"`
-	LabelExtractors map[string]*Value[string] `tf:"label_extractors"`
+	Filter          *Value[string]            `tf:"filter" json:"filter,omitempty"`
+	LabelExtractors map[string]*Value[string] `tf:"label_extractors" json:"label_extractors,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyConditionsConditionMonitoringQueryLanguage is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyConditionsConditionMonitoringQueryLanguage struct {
-	Duration              *Value[string]                                                                 `tf:"duration"`
-	EvaluationMissingData *Value[string]                                                                 `tf:"evaluation_missing_data"`
-	Query                 *Value[string]                                                                 `tf:"query"`
-	Trigger               []GoogleMonitoringAlertPolicyConditionsConditionMonitoringQueryLanguageTrigger `tf:"trigger,blocks"`
+	Duration              *Value[string]                                                                 `tf:"duration" json:"duration,omitempty"`
+	EvaluationMissingData *Value[string]                                                                 `tf:"evaluation_missing_data" json:"evaluation_missing_data,omitempty"`
+	Query                 *Value[string]                                                                 `tf:"query" json:"query,omitempty"`
+	Trigger               []GoogleMonitoringAlertPolicyConditionsConditionMonitoringQueryLanguageTrigger `tf:"trigger,blocks" json:"trigger,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyConditionsConditionMonitoringQueryLanguageTrigger is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyConditionsConditionMonitoringQueryLanguageTrigger struct {
-	Count   *Value[float64] `tf:"count"`
-	Percent *Value[float64] `tf:"percent"`
+	Count   *Value[float64] `tf:"count" json:"count,omitempty"`
+	Percent *Value[float64] `tf:"percent" json:"percent,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyConditionsConditionPrometheusQueryLanguage is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyConditionsConditionPrometheusQueryLanguage struct {
-	AlertRule          *Value[string]            `tf:"alert_rule"`
-	Duration           *Value[string]            `tf:"duration"`
-	EvaluationInterval *Value[string]            `tf:"evaluation_interval"`
-	Labels             map[string]*Value[string] `tf:"labels"`
-	Query              *Value[string]            `tf:"query"`
-	RuleGroup          *Value[string]            `tf:"rule_group"`
+	AlertRule          *Value[string]            `tf:"alert_rule" json:"alert_rule,omitempty"`
+	Duration           *Value[string]            `tf:"duration" json:"duration,omitempty"`
+	EvaluationInterval *Value[string]            `tf:"evaluation_interval" json:"evaluation_interval,omitempty"`
+	Labels             map[string]*Value[string] `tf:"labels" json:"labels,omitempty"`
+	Query              *Value[string]            `tf:"query" json:"query,omitempty"`
+	RuleGroup          *Value[string]            `tf:"rule_group" json:"rule_group,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyConditionsConditionThreshold is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyConditionsConditionThreshold struct {
-	Comparison              *Value[string]                                                                   `tf:"comparison"`
-	DenominatorFilter       *Value[string]                                                                   `tf:"denominator_filter"`
-	Duration                *Value[string]                                                                   `tf:"duration"`
-	EvaluationMissingData   *Value[string]                                                                   `tf:"evaluation_missing_data"`
-	Filter                  *Value[string]                                                                   `tf:"filter"`
-	ThresholdValue          *Value[float64]                                                                  `tf:"threshold_value"`
-	Aggregations            []GoogleMonitoringAlertPolicyConditionsConditionThresholdAggregations            `tf:"aggregations,blocks"`
-	DenominatorAggregations []GoogleMonitoringAlertPolicyConditionsConditionThresholdDenominatorAggregations `tf:"denominator_aggregations,blocks"`
-	ForecastOptions         []GoogleMonitoringAlertPolicyConditionsConditionThresholdForecastOptions         `tf:"forecast_options,blocks"`
-	Trigger                 []GoogleMonitoringAlertPolicyConditionsConditionThresholdTrigger                 `tf:"trigger,blocks"`
+	Comparison              *Value[string]                                                                   `tf:"comparison" json:"comparison,omitempty"`
+	DenominatorFilter       *Value[string]                                                                   `tf:"denominator_filter" json:"denominator_filter,omitempty"`
+	Duration                *Value[string]                                                                   `tf:"duration" json:"duration,omitempty"`
+	EvaluationMissingData   *Value[string]                                                                   `tf:"evaluation_missing_data" json:"evaluation_missing_data,omitempty"`
+	Filter                  *Value[string]                                                                   `tf:"filter" json:"filter,omitempty"`
+	ThresholdValue          *Value[float64]                                                                  `tf:"threshold_value" json:"threshold_value,omitempty"`
+	Aggregations            []GoogleMonitoringAlertPolicyConditionsConditionThresholdAggregations            `tf:"aggregations,blocks" json:"aggregations,omitempty"`
+	DenominatorAggregations []GoogleMonitoringAlertPolicyConditionsConditionThresholdDenominatorAggregations `tf:"denominator_aggregations,blocks" json:"denominator_aggregations,omitempty"`
+	ForecastOptions         []GoogleMonitoringAlertPolicyConditionsConditionThresholdForecastOptions         `tf:"forecast_options,blocks" json:"forecast_options,omitempty"`
+	Trigger                 []GoogleMonitoringAlertPolicyConditionsConditionThresholdTrigger                 `tf:"trigger,blocks" json:"trigger,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyConditionsConditionThresholdAggregations is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyConditionsConditionThresholdAggregations struct {
-	AlignmentPeriod    *Value[string]   `tf:"alignment_period"`
-	CrossSeriesReducer *Value[string]   `tf:"cross_series_reducer"`
-	GroupByFields      []*Value[string] `tf:"group_by_fields"`
-	PerSeriesAligner   *Value[string]   `tf:"per_series_aligner"`
+	AlignmentPeriod    *Value[string]   `tf:"alignment_period" json:"alignment_period,omitempty"`
+	CrossSeriesReducer *Value[string]   `tf:"cross_series_reducer" json:"cross_series_reducer,omitempty"`
+	GroupByFields      []*Value[string] `tf:"group_by_fields" json:"group_by_fields,omitempty"`
+	PerSeriesAligner   *Value[string]   `tf:"per_series_aligner" json:"per_series_aligner,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyConditionsConditionThresholdDenominatorAggregations is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyConditionsConditionThresholdDenominatorAggregations struct {
-	AlignmentPeriod    *Value[string]   `tf:"alignment_period"`
-	CrossSeriesReducer *Value[string]   `tf:"cross_series_reducer"`
-	GroupByFields      []*Value[string] `tf:"group_by_fields"`
-	PerSeriesAligner   *Value[string]   `tf:"per_series_aligner"`
+	AlignmentPeriod    *Value[string]   `tf:"alignment_period" json:"alignment_period,omitempty"`
+	CrossSeriesReducer *Value[string]   `tf:"cross_series_reducer" json:"cross_series_reducer,omitempty"`
+	GroupByFields      []*Value[string] `tf:"group_by_fields" json:"group_by_fields,omitempty"`
+	PerSeriesAligner   *Value[string]   `tf:"per_series_aligner" json:"per_series_aligner,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyConditionsConditionThresholdForecastOptions is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyConditionsConditionThresholdForecastOptions struct {
-	ForecastHorizon *Value[string] `tf:"forecast_horizon"`
+	ForecastHorizon *Value[string] `tf:"forecast_horizon" json:"forecast_horizon,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyConditionsConditionThresholdTrigger is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyConditionsConditionThresholdTrigger struct {
-	Count   *Value[float64] `tf:"count"`
-	Percent *Value[float64] `tf:"percent"`
+	Count   *Value[float64] `tf:"count" json:"count,omitempty"`
+	Percent *Value[float64] `tf:"percent" json:"percent,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyCreationRecord is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyCreationRecord struct {
-	MutateTime *Value[string] `tf:"mutate_time"`
-	MutatedBy  *Value[string] `tf:"mutated_by"`
+	MutateTime *Value[string] `tf:"mutate_time" json:"mutate_time,omitempty"`
+	MutatedBy  *Value[string] `tf:"mutated_by" json:"mutated_by,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyDocumentation is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyDocumentation struct {
-	Content  *Value[string]                                  `tf:"content"`
-	MimeType *Value[string]                                  `tf:"mime_type"`
-	Subject  *Value[string]                                  `tf:"subject"`
-	Links    []GoogleMonitoringAlertPolicyDocumentationLinks `tf:"links,blocks"`
+	Content  *Value[string]                                  `tf:"content" json:"content,omitempty"`
+	MimeType *Value[string]                                  `tf:"mime_type" json:"mime_type,omitempty"`
+	Subject  *Value[string]                                  `tf:"subject" json:"subject,omitempty"`
+	Links    []GoogleMonitoringAlertPolicyDocumentationLinks `tf:"links,blocks" json:"links,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyDocumentationLinks is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyDocumentationLinks struct {
-	DisplayName *Value[string] `tf:"display_name"`
-	URL         *Value[string] `tf:"url"`
+	DisplayName *Value[string] `tf:"display_name" json:"display_name,omitempty"`
+	URL         *Value[string] `tf:"url" json:"url,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicyTimeouts is a nested-block type used by the parent resource.
 type GoogleMonitoringAlertPolicyTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleMonitoringAlertPolicySchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_monitoring_dashboard.gen.go
+++ b/pkg/composer/imported/generated/google_monitoring_dashboard.gen.go
@@ -7,17 +7,17 @@ import "reflect"
 // GoogleMonitoringDashboard is the generated Layer 1 typed model for the
 // `google_monitoring_dashboard` Terraform resource.
 type GoogleMonitoringDashboard struct {
-	DashboardJSON *Value[string]                     `tf:"dashboard_json"`
-	ID            *Value[string]                     `tf:"id"`
-	Project       *Value[string]                     `tf:"project"`
-	Timeouts      *GoogleMonitoringDashboardTimeouts `tf:"timeouts,block"`
+	DashboardJSON *Value[string]                     `tf:"dashboard_json" json:"dashboard_json,omitempty"`
+	ID            *Value[string]                     `tf:"id" json:"id,omitempty"`
+	Project       *Value[string]                     `tf:"project" json:"project,omitempty"`
+	Timeouts      *GoogleMonitoringDashboardTimeouts `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleMonitoringDashboardTimeouts is a nested-block type used by the parent resource.
 type GoogleMonitoringDashboardTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleMonitoringDashboardSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_monitoring_notification_channel.gen.go
+++ b/pkg/composer/imported/generated/google_monitoring_notification_channel.gen.go
@@ -7,33 +7,33 @@ import "reflect"
 // GoogleMonitoringNotificationChannel is the generated Layer 1 typed model for the
 // `google_monitoring_notification_channel` Terraform resource.
 type GoogleMonitoringNotificationChannel struct {
-	Description        *Value[string]                                       `tf:"description"`
-	DisplayName        *Value[string]                                       `tf:"display_name"`
-	Enabled            *Value[bool]                                         `tf:"enabled"`
-	ForceDelete        *Value[bool]                                         `tf:"force_delete"`
-	ID                 *Value[string]                                       `tf:"id"`
-	Labels             map[string]*Value[string]                            `tf:"labels"`
-	Name               *Value[string]                                       `tf:"name"`
-	Project            *Value[string]                                       `tf:"project"`
-	Type_              *Value[string]                                       `tf:"type"`
-	UserLabels         map[string]*Value[string]                            `tf:"user_labels"`
-	VerificationStatus *Value[string]                                       `tf:"verification_status"`
-	SensitiveLabels    []GoogleMonitoringNotificationChannelSensitiveLabels `tf:"sensitive_labels,blocks"`
-	Timeouts           *GoogleMonitoringNotificationChannelTimeouts         `tf:"timeouts,block"`
+	Description        *Value[string]                                       `tf:"description" json:"description,omitempty"`
+	DisplayName        *Value[string]                                       `tf:"display_name" json:"display_name,omitempty"`
+	Enabled            *Value[bool]                                         `tf:"enabled" json:"enabled,omitempty"`
+	ForceDelete        *Value[bool]                                         `tf:"force_delete" json:"force_delete,omitempty"`
+	ID                 *Value[string]                                       `tf:"id" json:"id,omitempty"`
+	Labels             map[string]*Value[string]                            `tf:"labels" json:"labels,omitempty"`
+	Name               *Value[string]                                       `tf:"name" json:"name,omitempty"`
+	Project            *Value[string]                                       `tf:"project" json:"project,omitempty"`
+	Type_              *Value[string]                                       `tf:"type" json:"type,omitempty"`
+	UserLabels         map[string]*Value[string]                            `tf:"user_labels" json:"user_labels,omitempty"`
+	VerificationStatus *Value[string]                                       `tf:"verification_status" json:"verification_status,omitempty"`
+	SensitiveLabels    []GoogleMonitoringNotificationChannelSensitiveLabels `tf:"sensitive_labels,blocks" json:"sensitive_labels,omitempty"`
+	Timeouts           *GoogleMonitoringNotificationChannelTimeouts         `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleMonitoringNotificationChannelSensitiveLabels is a nested-block type used by the parent resource.
 type GoogleMonitoringNotificationChannelSensitiveLabels struct {
-	AuthToken  *Value[string] `tf:"auth_token"`
-	Password   *Value[string] `tf:"password"`
-	ServiceKey *Value[string] `tf:"service_key"`
+	AuthToken  *Value[string] `tf:"auth_token" json:"auth_token,omitempty"`
+	Password   *Value[string] `tf:"password" json:"password,omitempty"`
+	ServiceKey *Value[string] `tf:"service_key" json:"service_key,omitempty"`
 }
 
 // GoogleMonitoringNotificationChannelTimeouts is a nested-block type used by the parent resource.
 type GoogleMonitoringNotificationChannelTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleMonitoringNotificationChannelSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_pubsub_subscription.gen.go
+++ b/pkg/composer/imported/generated/google_pubsub_subscription.gen.go
@@ -7,99 +7,99 @@ import "reflect"
 // GooglePubsubSubscription is the generated Layer 1 typed model for the
 // `google_pubsub_subscription` Terraform resource.
 type GooglePubsubSubscription struct {
-	AckDeadlineSeconds        *Value[int64]                                `tf:"ack_deadline_seconds"`
-	EffectiveLabels           map[string]*Value[string]                    `tf:"effective_labels"`
-	EnableExactlyOnceDelivery *Value[bool]                                 `tf:"enable_exactly_once_delivery"`
-	EnableMessageOrdering     *Value[bool]                                 `tf:"enable_message_ordering"`
-	Filter                    *Value[string]                               `tf:"filter"`
-	ID                        *Value[string]                               `tf:"id"`
-	Labels                    map[string]*Value[string]                    `tf:"labels"`
-	MessageRetentionDuration  *Value[string]                               `tf:"message_retention_duration"`
-	Name                      *Value[string]                               `tf:"name"`
-	Project                   *Value[string]                               `tf:"project"`
-	RetainAckedMessages       *Value[bool]                                 `tf:"retain_acked_messages"`
-	TerraformLabels           map[string]*Value[string]                    `tf:"terraform_labels"`
-	Topic                     *Value[string]                               `tf:"topic"`
-	BigqueryConfig            []GooglePubsubSubscriptionBigqueryConfig     `tf:"bigquery_config,blocks"`
-	CloudStorageConfig        []GooglePubsubSubscriptionCloudStorageConfig `tf:"cloud_storage_config,blocks"`
-	DeadLetterPolicy          []GooglePubsubSubscriptionDeadLetterPolicy   `tf:"dead_letter_policy,blocks"`
-	ExpirationPolicy          []GooglePubsubSubscriptionExpirationPolicy   `tf:"expiration_policy,blocks"`
-	PushConfig                []GooglePubsubSubscriptionPushConfig         `tf:"push_config,blocks"`
-	RetryPolicy               []GooglePubsubSubscriptionRetryPolicy        `tf:"retry_policy,blocks"`
-	Timeouts                  *GooglePubsubSubscriptionTimeouts            `tf:"timeouts,block"`
+	AckDeadlineSeconds        *Value[int64]                                `tf:"ack_deadline_seconds" json:"ack_deadline_seconds,omitempty"`
+	EffectiveLabels           map[string]*Value[string]                    `tf:"effective_labels" json:"effective_labels,omitempty"`
+	EnableExactlyOnceDelivery *Value[bool]                                 `tf:"enable_exactly_once_delivery" json:"enable_exactly_once_delivery,omitempty"`
+	EnableMessageOrdering     *Value[bool]                                 `tf:"enable_message_ordering" json:"enable_message_ordering,omitempty"`
+	Filter                    *Value[string]                               `tf:"filter" json:"filter,omitempty"`
+	ID                        *Value[string]                               `tf:"id" json:"id,omitempty"`
+	Labels                    map[string]*Value[string]                    `tf:"labels" json:"labels,omitempty"`
+	MessageRetentionDuration  *Value[string]                               `tf:"message_retention_duration" json:"message_retention_duration,omitempty"`
+	Name                      *Value[string]                               `tf:"name" json:"name,omitempty"`
+	Project                   *Value[string]                               `tf:"project" json:"project,omitempty"`
+	RetainAckedMessages       *Value[bool]                                 `tf:"retain_acked_messages" json:"retain_acked_messages,omitempty"`
+	TerraformLabels           map[string]*Value[string]                    `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	Topic                     *Value[string]                               `tf:"topic" json:"topic,omitempty"`
+	BigqueryConfig            []GooglePubsubSubscriptionBigqueryConfig     `tf:"bigquery_config,blocks" json:"bigquery_config,omitempty"`
+	CloudStorageConfig        []GooglePubsubSubscriptionCloudStorageConfig `tf:"cloud_storage_config,blocks" json:"cloud_storage_config,omitempty"`
+	DeadLetterPolicy          []GooglePubsubSubscriptionDeadLetterPolicy   `tf:"dead_letter_policy,blocks" json:"dead_letter_policy,omitempty"`
+	ExpirationPolicy          []GooglePubsubSubscriptionExpirationPolicy   `tf:"expiration_policy,blocks" json:"expiration_policy,omitempty"`
+	PushConfig                []GooglePubsubSubscriptionPushConfig         `tf:"push_config,blocks" json:"push_config,omitempty"`
+	RetryPolicy               []GooglePubsubSubscriptionRetryPolicy        `tf:"retry_policy,blocks" json:"retry_policy,omitempty"`
+	Timeouts                  *GooglePubsubSubscriptionTimeouts            `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GooglePubsubSubscriptionBigqueryConfig is a nested-block type used by the parent resource.
 type GooglePubsubSubscriptionBigqueryConfig struct {
-	DropUnknownFields   *Value[bool]   `tf:"drop_unknown_fields"`
-	ServiceAccountEmail *Value[string] `tf:"service_account_email"`
-	Table               *Value[string] `tf:"table"`
-	UseTableSchema      *Value[bool]   `tf:"use_table_schema"`
-	UseTopicSchema      *Value[bool]   `tf:"use_topic_schema"`
-	WriteMetadata       *Value[bool]   `tf:"write_metadata"`
+	DropUnknownFields   *Value[bool]   `tf:"drop_unknown_fields" json:"drop_unknown_fields,omitempty"`
+	ServiceAccountEmail *Value[string] `tf:"service_account_email" json:"service_account_email,omitempty"`
+	Table               *Value[string] `tf:"table" json:"table,omitempty"`
+	UseTableSchema      *Value[bool]   `tf:"use_table_schema" json:"use_table_schema,omitempty"`
+	UseTopicSchema      *Value[bool]   `tf:"use_topic_schema" json:"use_topic_schema,omitempty"`
+	WriteMetadata       *Value[bool]   `tf:"write_metadata" json:"write_metadata,omitempty"`
 }
 
 // GooglePubsubSubscriptionCloudStorageConfig is a nested-block type used by the parent resource.
 type GooglePubsubSubscriptionCloudStorageConfig struct {
-	Bucket                 *Value[string]                                         `tf:"bucket"`
-	FilenameDatetimeFormat *Value[string]                                         `tf:"filename_datetime_format"`
-	FilenamePrefix         *Value[string]                                         `tf:"filename_prefix"`
-	FilenameSuffix         *Value[string]                                         `tf:"filename_suffix"`
-	MaxBytes               *Value[int64]                                          `tf:"max_bytes"`
-	MaxDuration            *Value[string]                                         `tf:"max_duration"`
-	MaxMessages            *Value[int64]                                          `tf:"max_messages"`
-	ServiceAccountEmail    *Value[string]                                         `tf:"service_account_email"`
-	State                  *Value[string]                                         `tf:"state"`
-	AvroConfig             []GooglePubsubSubscriptionCloudStorageConfigAvroConfig `tf:"avro_config,blocks"`
+	Bucket                 *Value[string]                                         `tf:"bucket" json:"bucket,omitempty"`
+	FilenameDatetimeFormat *Value[string]                                         `tf:"filename_datetime_format" json:"filename_datetime_format,omitempty"`
+	FilenamePrefix         *Value[string]                                         `tf:"filename_prefix" json:"filename_prefix,omitempty"`
+	FilenameSuffix         *Value[string]                                         `tf:"filename_suffix" json:"filename_suffix,omitempty"`
+	MaxBytes               *Value[int64]                                          `tf:"max_bytes" json:"max_bytes,omitempty"`
+	MaxDuration            *Value[string]                                         `tf:"max_duration" json:"max_duration,omitempty"`
+	MaxMessages            *Value[int64]                                          `tf:"max_messages" json:"max_messages,omitempty"`
+	ServiceAccountEmail    *Value[string]                                         `tf:"service_account_email" json:"service_account_email,omitempty"`
+	State                  *Value[string]                                         `tf:"state" json:"state,omitempty"`
+	AvroConfig             []GooglePubsubSubscriptionCloudStorageConfigAvroConfig `tf:"avro_config,blocks" json:"avro_config,omitempty"`
 }
 
 // GooglePubsubSubscriptionCloudStorageConfigAvroConfig is a nested-block type used by the parent resource.
 type GooglePubsubSubscriptionCloudStorageConfigAvroConfig struct {
-	UseTopicSchema *Value[bool] `tf:"use_topic_schema"`
-	WriteMetadata  *Value[bool] `tf:"write_metadata"`
+	UseTopicSchema *Value[bool] `tf:"use_topic_schema" json:"use_topic_schema,omitempty"`
+	WriteMetadata  *Value[bool] `tf:"write_metadata" json:"write_metadata,omitempty"`
 }
 
 // GooglePubsubSubscriptionDeadLetterPolicy is a nested-block type used by the parent resource.
 type GooglePubsubSubscriptionDeadLetterPolicy struct {
-	DeadLetterTopic     *Value[string] `tf:"dead_letter_topic"`
-	MaxDeliveryAttempts *Value[int64]  `tf:"max_delivery_attempts"`
+	DeadLetterTopic     *Value[string] `tf:"dead_letter_topic" json:"dead_letter_topic,omitempty"`
+	MaxDeliveryAttempts *Value[int64]  `tf:"max_delivery_attempts" json:"max_delivery_attempts,omitempty"`
 }
 
 // GooglePubsubSubscriptionExpirationPolicy is a nested-block type used by the parent resource.
 type GooglePubsubSubscriptionExpirationPolicy struct {
-	TTL *Value[string] `tf:"ttl"`
+	TTL *Value[string] `tf:"ttl" json:"ttl,omitempty"`
 }
 
 // GooglePubsubSubscriptionPushConfig is a nested-block type used by the parent resource.
 type GooglePubsubSubscriptionPushConfig struct {
-	Attributes   map[string]*Value[string]                     `tf:"attributes"`
-	PushEndpoint *Value[string]                                `tf:"push_endpoint"`
-	NoWrapper    []GooglePubsubSubscriptionPushConfigNoWrapper `tf:"no_wrapper,blocks"`
-	OIDCToken    []GooglePubsubSubscriptionPushConfigOIDCToken `tf:"oidc_token,blocks"`
+	Attributes   map[string]*Value[string]                     `tf:"attributes" json:"attributes,omitempty"`
+	PushEndpoint *Value[string]                                `tf:"push_endpoint" json:"push_endpoint,omitempty"`
+	NoWrapper    []GooglePubsubSubscriptionPushConfigNoWrapper `tf:"no_wrapper,blocks" json:"no_wrapper,omitempty"`
+	OIDCToken    []GooglePubsubSubscriptionPushConfigOIDCToken `tf:"oidc_token,blocks" json:"oidc_token,omitempty"`
 }
 
 // GooglePubsubSubscriptionPushConfigNoWrapper is a nested-block type used by the parent resource.
 type GooglePubsubSubscriptionPushConfigNoWrapper struct {
-	WriteMetadata *Value[bool] `tf:"write_metadata"`
+	WriteMetadata *Value[bool] `tf:"write_metadata" json:"write_metadata,omitempty"`
 }
 
 // GooglePubsubSubscriptionPushConfigOIDCToken is a nested-block type used by the parent resource.
 type GooglePubsubSubscriptionPushConfigOIDCToken struct {
-	Audience            *Value[string] `tf:"audience"`
-	ServiceAccountEmail *Value[string] `tf:"service_account_email"`
+	Audience            *Value[string] `tf:"audience" json:"audience,omitempty"`
+	ServiceAccountEmail *Value[string] `tf:"service_account_email" json:"service_account_email,omitempty"`
 }
 
 // GooglePubsubSubscriptionRetryPolicy is a nested-block type used by the parent resource.
 type GooglePubsubSubscriptionRetryPolicy struct {
-	MaximumBackoff *Value[string] `tf:"maximum_backoff"`
-	MinimumBackoff *Value[string] `tf:"minimum_backoff"`
+	MaximumBackoff *Value[string] `tf:"maximum_backoff" json:"maximum_backoff,omitempty"`
+	MinimumBackoff *Value[string] `tf:"minimum_backoff" json:"minimum_backoff,omitempty"`
 }
 
 // GooglePubsubSubscriptionTimeouts is a nested-block type used by the parent resource.
 type GooglePubsubSubscriptionTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GooglePubsubSubscriptionSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_pubsub_topic.gen.go
+++ b/pkg/composer/imported/generated/google_pubsub_topic.gen.go
@@ -7,43 +7,43 @@ import "reflect"
 // GooglePubsubTopic is the generated Layer 1 typed model for the
 // `google_pubsub_topic` Terraform resource.
 type GooglePubsubTopic struct {
-	EffectiveLabels             map[string]*Value[string]                      `tf:"effective_labels"`
-	ID                          *Value[string]                                 `tf:"id"`
-	KMSKeyName                  *Value[string]                                 `tf:"kms_key_name"`
-	Labels                      map[string]*Value[string]                      `tf:"labels"`
-	MessageRetentionDuration    *Value[string]                                 `tf:"message_retention_duration"`
-	Name                        *Value[string]                                 `tf:"name"`
-	Project                     *Value[string]                                 `tf:"project"`
-	TerraformLabels             map[string]*Value[string]                      `tf:"terraform_labels"`
-	IngestionDataSourceSettings []GooglePubsubTopicIngestionDataSourceSettings `tf:"ingestion_data_source_settings,blocks"`
-	MessageStoragePolicy        []GooglePubsubTopicMessageStoragePolicy        `tf:"message_storage_policy,blocks"`
-	SchemaSettings              []GooglePubsubTopicSchemaSettings              `tf:"schema_settings,blocks"`
-	Timeouts                    *GooglePubsubTopicTimeouts                     `tf:"timeouts,block"`
+	EffectiveLabels             map[string]*Value[string]                      `tf:"effective_labels" json:"effective_labels,omitempty"`
+	ID                          *Value[string]                                 `tf:"id" json:"id,omitempty"`
+	KMSKeyName                  *Value[string]                                 `tf:"kms_key_name" json:"kms_key_name,omitempty"`
+	Labels                      map[string]*Value[string]                      `tf:"labels" json:"labels,omitempty"`
+	MessageRetentionDuration    *Value[string]                                 `tf:"message_retention_duration" json:"message_retention_duration,omitempty"`
+	Name                        *Value[string]                                 `tf:"name" json:"name,omitempty"`
+	Project                     *Value[string]                                 `tf:"project" json:"project,omitempty"`
+	TerraformLabels             map[string]*Value[string]                      `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	IngestionDataSourceSettings []GooglePubsubTopicIngestionDataSourceSettings `tf:"ingestion_data_source_settings,blocks" json:"ingestion_data_source_settings,omitempty"`
+	MessageStoragePolicy        []GooglePubsubTopicMessageStoragePolicy        `tf:"message_storage_policy,blocks" json:"message_storage_policy,omitempty"`
+	SchemaSettings              []GooglePubsubTopicSchemaSettings              `tf:"schema_settings,blocks" json:"schema_settings,omitempty"`
+	Timeouts                    *GooglePubsubTopicTimeouts                     `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GooglePubsubTopicIngestionDataSourceSettings is a nested-block type used by the parent resource.
 type GooglePubsubTopicIngestionDataSourceSettings struct {
-	AWSKinesis           []GooglePubsubTopicIngestionDataSourceSettingsAWSKinesis           `tf:"aws_kinesis,blocks"`
-	CloudStorage         []GooglePubsubTopicIngestionDataSourceSettingsCloudStorage         `tf:"cloud_storage,blocks"`
-	PlatformLogsSettings []GooglePubsubTopicIngestionDataSourceSettingsPlatformLogsSettings `tf:"platform_logs_settings,blocks"`
+	AWSKinesis           []GooglePubsubTopicIngestionDataSourceSettingsAWSKinesis           `tf:"aws_kinesis,blocks" json:"aws_kinesis,omitempty"`
+	CloudStorage         []GooglePubsubTopicIngestionDataSourceSettingsCloudStorage         `tf:"cloud_storage,blocks" json:"cloud_storage,omitempty"`
+	PlatformLogsSettings []GooglePubsubTopicIngestionDataSourceSettingsPlatformLogsSettings `tf:"platform_logs_settings,blocks" json:"platform_logs_settings,omitempty"`
 }
 
 // GooglePubsubTopicIngestionDataSourceSettingsAWSKinesis is a nested-block type used by the parent resource.
 type GooglePubsubTopicIngestionDataSourceSettingsAWSKinesis struct {
-	AWSRoleARN        *Value[string] `tf:"aws_role_arn"`
-	ConsumerARN       *Value[string] `tf:"consumer_arn"`
-	GCPServiceAccount *Value[string] `tf:"gcp_service_account"`
-	StreamARN         *Value[string] `tf:"stream_arn"`
+	AWSRoleARN        *Value[string] `tf:"aws_role_arn" json:"aws_role_arn,omitempty"`
+	ConsumerARN       *Value[string] `tf:"consumer_arn" json:"consumer_arn,omitempty"`
+	GCPServiceAccount *Value[string] `tf:"gcp_service_account" json:"gcp_service_account,omitempty"`
+	StreamARN         *Value[string] `tf:"stream_arn" json:"stream_arn,omitempty"`
 }
 
 // GooglePubsubTopicIngestionDataSourceSettingsCloudStorage is a nested-block type used by the parent resource.
 type GooglePubsubTopicIngestionDataSourceSettingsCloudStorage struct {
-	Bucket                  *Value[string]                                                             `tf:"bucket"`
-	MatchGlob               *Value[string]                                                             `tf:"match_glob"`
-	MinimumObjectCreateTime *Value[string]                                                             `tf:"minimum_object_create_time"`
-	AvroFormat              []GooglePubsubTopicIngestionDataSourceSettingsCloudStorageAvroFormat       `tf:"avro_format,blocks"`
-	PubsubAvroFormat        []GooglePubsubTopicIngestionDataSourceSettingsCloudStoragePubsubAvroFormat `tf:"pubsub_avro_format,blocks"`
-	TextFormat              []GooglePubsubTopicIngestionDataSourceSettingsCloudStorageTextFormat       `tf:"text_format,blocks"`
+	Bucket                  *Value[string]                                                             `tf:"bucket" json:"bucket,omitempty"`
+	MatchGlob               *Value[string]                                                             `tf:"match_glob" json:"match_glob,omitempty"`
+	MinimumObjectCreateTime *Value[string]                                                             `tf:"minimum_object_create_time" json:"minimum_object_create_time,omitempty"`
+	AvroFormat              []GooglePubsubTopicIngestionDataSourceSettingsCloudStorageAvroFormat       `tf:"avro_format,blocks" json:"avro_format,omitempty"`
+	PubsubAvroFormat        []GooglePubsubTopicIngestionDataSourceSettingsCloudStoragePubsubAvroFormat `tf:"pubsub_avro_format,blocks" json:"pubsub_avro_format,omitempty"`
+	TextFormat              []GooglePubsubTopicIngestionDataSourceSettingsCloudStorageTextFormat       `tf:"text_format,blocks" json:"text_format,omitempty"`
 }
 
 // GooglePubsubTopicIngestionDataSourceSettingsCloudStorageAvroFormat is a nested-block type used by the parent resource.
@@ -56,30 +56,30 @@ type GooglePubsubTopicIngestionDataSourceSettingsCloudStoragePubsubAvroFormat st
 
 // GooglePubsubTopicIngestionDataSourceSettingsCloudStorageTextFormat is a nested-block type used by the parent resource.
 type GooglePubsubTopicIngestionDataSourceSettingsCloudStorageTextFormat struct {
-	Delimiter *Value[string] `tf:"delimiter"`
+	Delimiter *Value[string] `tf:"delimiter" json:"delimiter,omitempty"`
 }
 
 // GooglePubsubTopicIngestionDataSourceSettingsPlatformLogsSettings is a nested-block type used by the parent resource.
 type GooglePubsubTopicIngestionDataSourceSettingsPlatformLogsSettings struct {
-	Severity *Value[string] `tf:"severity"`
+	Severity *Value[string] `tf:"severity" json:"severity,omitempty"`
 }
 
 // GooglePubsubTopicMessageStoragePolicy is a nested-block type used by the parent resource.
 type GooglePubsubTopicMessageStoragePolicy struct {
-	AllowedPersistenceRegions []*Value[string] `tf:"allowed_persistence_regions"`
+	AllowedPersistenceRegions []*Value[string] `tf:"allowed_persistence_regions" json:"allowed_persistence_regions,omitempty"`
 }
 
 // GooglePubsubTopicSchemaSettings is a nested-block type used by the parent resource.
 type GooglePubsubTopicSchemaSettings struct {
-	Encoding *Value[string] `tf:"encoding"`
-	Schema   *Value[string] `tf:"schema"`
+	Encoding *Value[string] `tf:"encoding" json:"encoding,omitempty"`
+	Schema   *Value[string] `tf:"schema" json:"schema,omitempty"`
 }
 
 // GooglePubsubTopicTimeouts is a nested-block type used by the parent resource.
 type GooglePubsubTopicTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GooglePubsubTopicSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_redis_instance.gen.go
+++ b/pkg/composer/imported/generated/google_redis_instance.gen.go
@@ -7,104 +7,104 @@ import "reflect"
 // GoogleRedisInstance is the generated Layer 1 typed model for the
 // `google_redis_instance` Terraform resource.
 type GoogleRedisInstance struct {
-	AlternativeLocationID  *Value[string]                           `tf:"alternative_location_id"`
-	AuthEnabled            *Value[bool]                             `tf:"auth_enabled"`
-	AuthString             *Value[string]                           `tf:"auth_string"`
-	AuthorizedNetwork      *Value[string]                           `tf:"authorized_network"`
-	ConnectMode            *Value[string]                           `tf:"connect_mode"`
-	CreateTime             *Value[string]                           `tf:"create_time"`
-	CurrentLocationID      *Value[string]                           `tf:"current_location_id"`
-	CustomerManagedKey     *Value[string]                           `tf:"customer_managed_key"`
-	DisplayName            *Value[string]                           `tf:"display_name"`
-	EffectiveLabels        map[string]*Value[string]                `tf:"effective_labels"`
-	Host                   *Value[string]                           `tf:"host"`
-	ID                     *Value[string]                           `tf:"id"`
-	Labels                 map[string]*Value[string]                `tf:"labels"`
-	LocationID             *Value[string]                           `tf:"location_id"`
-	MaintenanceSchedule    []GoogleRedisInstanceMaintenanceSchedule `tf:"maintenance_schedule"`
-	MaintenanceVersion     *Value[string]                           `tf:"maintenance_version"`
-	MemorySizeGb           *Value[float64]                          `tf:"memory_size_gb"`
-	Name                   *Value[string]                           `tf:"name"`
-	Nodes                  []GoogleRedisInstanceNodes               `tf:"nodes"`
-	PersistenceIAMIdentity *Value[string]                           `tf:"persistence_iam_identity"`
-	Port                   *Value[int64]                            `tf:"port"`
-	Project                *Value[string]                           `tf:"project"`
-	ReadEndpoint           *Value[string]                           `tf:"read_endpoint"`
-	ReadEndpointPort       *Value[float64]                          `tf:"read_endpoint_port"`
-	ReadReplicasMode       *Value[string]                           `tf:"read_replicas_mode"`
-	RedisConfigs           map[string]*Value[string]                `tf:"redis_configs"`
-	RedisVersion           *Value[string]                           `tf:"redis_version"`
-	Region                 *Value[string]                           `tf:"region"`
-	ReplicaCount           *Value[int64]                            `tf:"replica_count"`
-	ReservedIpRange        *Value[string]                           `tf:"reserved_ip_range"`
-	SecondaryIpRange       *Value[string]                           `tf:"secondary_ip_range"`
-	ServerCaCerts          []GoogleRedisInstanceServerCaCerts       `tf:"server_ca_certs"`
-	TerraformLabels        map[string]*Value[string]                `tf:"terraform_labels"`
-	Tier                   *Value[string]                           `tf:"tier"`
-	TransitEncryptionMode  *Value[string]                           `tf:"transit_encryption_mode"`
-	MaintenancePolicy      []GoogleRedisInstanceMaintenancePolicy   `tf:"maintenance_policy,blocks"`
-	PersistenceConfig      []GoogleRedisInstancePersistenceConfig   `tf:"persistence_config,blocks"`
-	Timeouts               *GoogleRedisInstanceTimeouts             `tf:"timeouts,block"`
+	AlternativeLocationID  *Value[string]                           `tf:"alternative_location_id" json:"alternative_location_id,omitempty"`
+	AuthEnabled            *Value[bool]                             `tf:"auth_enabled" json:"auth_enabled,omitempty"`
+	AuthString             *Value[string]                           `tf:"auth_string" json:"auth_string,omitempty"`
+	AuthorizedNetwork      *Value[string]                           `tf:"authorized_network" json:"authorized_network,omitempty"`
+	ConnectMode            *Value[string]                           `tf:"connect_mode" json:"connect_mode,omitempty"`
+	CreateTime             *Value[string]                           `tf:"create_time" json:"create_time,omitempty"`
+	CurrentLocationID      *Value[string]                           `tf:"current_location_id" json:"current_location_id,omitempty"`
+	CustomerManagedKey     *Value[string]                           `tf:"customer_managed_key" json:"customer_managed_key,omitempty"`
+	DisplayName            *Value[string]                           `tf:"display_name" json:"display_name,omitempty"`
+	EffectiveLabels        map[string]*Value[string]                `tf:"effective_labels" json:"effective_labels,omitempty"`
+	Host                   *Value[string]                           `tf:"host" json:"host,omitempty"`
+	ID                     *Value[string]                           `tf:"id" json:"id,omitempty"`
+	Labels                 map[string]*Value[string]                `tf:"labels" json:"labels,omitempty"`
+	LocationID             *Value[string]                           `tf:"location_id" json:"location_id,omitempty"`
+	MaintenanceSchedule    []GoogleRedisInstanceMaintenanceSchedule `tf:"maintenance_schedule" json:"maintenance_schedule,omitempty"`
+	MaintenanceVersion     *Value[string]                           `tf:"maintenance_version" json:"maintenance_version,omitempty"`
+	MemorySizeGb           *Value[float64]                          `tf:"memory_size_gb" json:"memory_size_gb,omitempty"`
+	Name                   *Value[string]                           `tf:"name" json:"name,omitempty"`
+	Nodes                  []GoogleRedisInstanceNodes               `tf:"nodes" json:"nodes,omitempty"`
+	PersistenceIAMIdentity *Value[string]                           `tf:"persistence_iam_identity" json:"persistence_iam_identity,omitempty"`
+	Port                   *Value[int64]                            `tf:"port" json:"port,omitempty"`
+	Project                *Value[string]                           `tf:"project" json:"project,omitempty"`
+	ReadEndpoint           *Value[string]                           `tf:"read_endpoint" json:"read_endpoint,omitempty"`
+	ReadEndpointPort       *Value[float64]                          `tf:"read_endpoint_port" json:"read_endpoint_port,omitempty"`
+	ReadReplicasMode       *Value[string]                           `tf:"read_replicas_mode" json:"read_replicas_mode,omitempty"`
+	RedisConfigs           map[string]*Value[string]                `tf:"redis_configs" json:"redis_configs,omitempty"`
+	RedisVersion           *Value[string]                           `tf:"redis_version" json:"redis_version,omitempty"`
+	Region                 *Value[string]                           `tf:"region" json:"region,omitempty"`
+	ReplicaCount           *Value[int64]                            `tf:"replica_count" json:"replica_count,omitempty"`
+	ReservedIpRange        *Value[string]                           `tf:"reserved_ip_range" json:"reserved_ip_range,omitempty"`
+	SecondaryIpRange       *Value[string]                           `tf:"secondary_ip_range" json:"secondary_ip_range,omitempty"`
+	ServerCaCerts          []GoogleRedisInstanceServerCaCerts       `tf:"server_ca_certs" json:"server_ca_certs,omitempty"`
+	TerraformLabels        map[string]*Value[string]                `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	Tier                   *Value[string]                           `tf:"tier" json:"tier,omitempty"`
+	TransitEncryptionMode  *Value[string]                           `tf:"transit_encryption_mode" json:"transit_encryption_mode,omitempty"`
+	MaintenancePolicy      []GoogleRedisInstanceMaintenancePolicy   `tf:"maintenance_policy,blocks" json:"maintenance_policy,omitempty"`
+	PersistenceConfig      []GoogleRedisInstancePersistenceConfig   `tf:"persistence_config,blocks" json:"persistence_config,omitempty"`
+	Timeouts               *GoogleRedisInstanceTimeouts             `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleRedisInstanceMaintenancePolicy is a nested-block type used by the parent resource.
 type GoogleRedisInstanceMaintenancePolicy struct {
-	CreateTime              *Value[string]                                                `tf:"create_time"`
-	Description             *Value[string]                                                `tf:"description"`
-	UpdateTime              *Value[string]                                                `tf:"update_time"`
-	WeeklyMaintenanceWindow []GoogleRedisInstanceMaintenancePolicyWeeklyMaintenanceWindow `tf:"weekly_maintenance_window,blocks"`
+	CreateTime              *Value[string]                                                `tf:"create_time" json:"create_time,omitempty"`
+	Description             *Value[string]                                                `tf:"description" json:"description,omitempty"`
+	UpdateTime              *Value[string]                                                `tf:"update_time" json:"update_time,omitempty"`
+	WeeklyMaintenanceWindow []GoogleRedisInstanceMaintenancePolicyWeeklyMaintenanceWindow `tf:"weekly_maintenance_window,blocks" json:"weekly_maintenance_window,omitempty"`
 }
 
 // GoogleRedisInstanceMaintenancePolicyWeeklyMaintenanceWindow is a nested-block type used by the parent resource.
 type GoogleRedisInstanceMaintenancePolicyWeeklyMaintenanceWindow struct {
-	Day       *Value[string]                                                         `tf:"day"`
-	Duration  *Value[string]                                                         `tf:"duration"`
-	StartTime []GoogleRedisInstanceMaintenancePolicyWeeklyMaintenanceWindowStartTime `tf:"start_time,blocks"`
+	Day       *Value[string]                                                         `tf:"day" json:"day,omitempty"`
+	Duration  *Value[string]                                                         `tf:"duration" json:"duration,omitempty"`
+	StartTime []GoogleRedisInstanceMaintenancePolicyWeeklyMaintenanceWindowStartTime `tf:"start_time,blocks" json:"start_time,omitempty"`
 }
 
 // GoogleRedisInstanceMaintenancePolicyWeeklyMaintenanceWindowStartTime is a nested-block type used by the parent resource.
 type GoogleRedisInstanceMaintenancePolicyWeeklyMaintenanceWindowStartTime struct {
-	Hours   *Value[float64] `tf:"hours"`
-	Minutes *Value[float64] `tf:"minutes"`
-	Nanos   *Value[float64] `tf:"nanos"`
-	Seconds *Value[float64] `tf:"seconds"`
+	Hours   *Value[float64] `tf:"hours" json:"hours,omitempty"`
+	Minutes *Value[float64] `tf:"minutes" json:"minutes,omitempty"`
+	Nanos   *Value[float64] `tf:"nanos" json:"nanos,omitempty"`
+	Seconds *Value[float64] `tf:"seconds" json:"seconds,omitempty"`
 }
 
 // GoogleRedisInstanceMaintenanceSchedule is a nested-block type used by the parent resource.
 type GoogleRedisInstanceMaintenanceSchedule struct {
-	EndTime              *Value[string] `tf:"end_time"`
-	ScheduleDeadlineTime *Value[string] `tf:"schedule_deadline_time"`
-	StartTime            *Value[string] `tf:"start_time"`
+	EndTime              *Value[string] `tf:"end_time" json:"end_time,omitempty"`
+	ScheduleDeadlineTime *Value[string] `tf:"schedule_deadline_time" json:"schedule_deadline_time,omitempty"`
+	StartTime            *Value[string] `tf:"start_time" json:"start_time,omitempty"`
 }
 
 // GoogleRedisInstanceNodes is a nested-block type used by the parent resource.
 type GoogleRedisInstanceNodes struct {
-	ID   *Value[string] `tf:"id"`
-	Zone *Value[string] `tf:"zone"`
+	ID   *Value[string] `tf:"id" json:"id,omitempty"`
+	Zone *Value[string] `tf:"zone" json:"zone,omitempty"`
 }
 
 // GoogleRedisInstancePersistenceConfig is a nested-block type used by the parent resource.
 type GoogleRedisInstancePersistenceConfig struct {
-	PersistenceMode      *Value[string] `tf:"persistence_mode"`
-	RdbNextSnapshotTime  *Value[string] `tf:"rdb_next_snapshot_time"`
-	RdbSnapshotPeriod    *Value[string] `tf:"rdb_snapshot_period"`
-	RdbSnapshotStartTime *Value[string] `tf:"rdb_snapshot_start_time"`
+	PersistenceMode      *Value[string] `tf:"persistence_mode" json:"persistence_mode,omitempty"`
+	RdbNextSnapshotTime  *Value[string] `tf:"rdb_next_snapshot_time" json:"rdb_next_snapshot_time,omitempty"`
+	RdbSnapshotPeriod    *Value[string] `tf:"rdb_snapshot_period" json:"rdb_snapshot_period,omitempty"`
+	RdbSnapshotStartTime *Value[string] `tf:"rdb_snapshot_start_time" json:"rdb_snapshot_start_time,omitempty"`
 }
 
 // GoogleRedisInstanceServerCaCerts is a nested-block type used by the parent resource.
 type GoogleRedisInstanceServerCaCerts struct {
-	Cert            *Value[string] `tf:"cert"`
-	CreateTime      *Value[string] `tf:"create_time"`
-	ExpireTime      *Value[string] `tf:"expire_time"`
-	SerialNumber    *Value[string] `tf:"serial_number"`
-	SHA1Fingerprint *Value[string] `tf:"sha1_fingerprint"`
+	Cert            *Value[string] `tf:"cert" json:"cert,omitempty"`
+	CreateTime      *Value[string] `tf:"create_time" json:"create_time,omitempty"`
+	ExpireTime      *Value[string] `tf:"expire_time" json:"expire_time,omitempty"`
+	SerialNumber    *Value[string] `tf:"serial_number" json:"serial_number,omitempty"`
+	SHA1Fingerprint *Value[string] `tf:"sha1_fingerprint" json:"sha1_fingerprint,omitempty"`
 }
 
 // GoogleRedisInstanceTimeouts is a nested-block type used by the parent resource.
 type GoogleRedisInstanceTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleRedisInstanceSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_secret_manager_secret.gen.go
+++ b/pkg/composer/imported/generated/google_secret_manager_secret.gen.go
@@ -7,74 +7,74 @@ import "reflect"
 // GoogleSecretManagerSecret is the generated Layer 1 typed model for the
 // `google_secret_manager_secret` Terraform resource.
 type GoogleSecretManagerSecret struct {
-	Annotations          map[string]*Value[string]              `tf:"annotations"`
-	CreateTime           *Value[string]                         `tf:"create_time"`
-	EffectiveAnnotations map[string]*Value[string]              `tf:"effective_annotations"`
-	EffectiveLabels      map[string]*Value[string]              `tf:"effective_labels"`
-	ExpireTime           *Value[string]                         `tf:"expire_time"`
-	ID                   *Value[string]                         `tf:"id"`
-	Labels               map[string]*Value[string]              `tf:"labels"`
-	Name                 *Value[string]                         `tf:"name"`
-	Project              *Value[string]                         `tf:"project"`
-	SecretID             *Value[string]                         `tf:"secret_id"`
-	TerraformLabels      map[string]*Value[string]              `tf:"terraform_labels"`
-	TTL                  *Value[string]                         `tf:"ttl"`
-	VersionAliases       map[string]*Value[string]              `tf:"version_aliases"`
-	VersionDestroyTTL    *Value[string]                         `tf:"version_destroy_ttl"`
-	Replication          []GoogleSecretManagerSecretReplication `tf:"replication,blocks"`
-	Rotation             []GoogleSecretManagerSecretRotation    `tf:"rotation,blocks"`
-	Timeouts             *GoogleSecretManagerSecretTimeouts     `tf:"timeouts,block"`
-	Topics               []GoogleSecretManagerSecretTopics      `tf:"topics,blocks"`
+	Annotations          map[string]*Value[string]              `tf:"annotations" json:"annotations,omitempty"`
+	CreateTime           *Value[string]                         `tf:"create_time" json:"create_time,omitempty"`
+	EffectiveAnnotations map[string]*Value[string]              `tf:"effective_annotations" json:"effective_annotations,omitempty"`
+	EffectiveLabels      map[string]*Value[string]              `tf:"effective_labels" json:"effective_labels,omitempty"`
+	ExpireTime           *Value[string]                         `tf:"expire_time" json:"expire_time,omitempty"`
+	ID                   *Value[string]                         `tf:"id" json:"id,omitempty"`
+	Labels               map[string]*Value[string]              `tf:"labels" json:"labels,omitempty"`
+	Name                 *Value[string]                         `tf:"name" json:"name,omitempty"`
+	Project              *Value[string]                         `tf:"project" json:"project,omitempty"`
+	SecretID             *Value[string]                         `tf:"secret_id" json:"secret_id,omitempty"`
+	TerraformLabels      map[string]*Value[string]              `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	TTL                  *Value[string]                         `tf:"ttl" json:"ttl,omitempty"`
+	VersionAliases       map[string]*Value[string]              `tf:"version_aliases" json:"version_aliases,omitempty"`
+	VersionDestroyTTL    *Value[string]                         `tf:"version_destroy_ttl" json:"version_destroy_ttl,omitempty"`
+	Replication          []GoogleSecretManagerSecretReplication `tf:"replication,blocks" json:"replication,omitempty"`
+	Rotation             []GoogleSecretManagerSecretRotation    `tf:"rotation,blocks" json:"rotation,omitempty"`
+	Timeouts             *GoogleSecretManagerSecretTimeouts     `tf:"timeouts,block" json:"timeouts,omitempty"`
+	Topics               []GoogleSecretManagerSecretTopics      `tf:"topics,blocks" json:"topics,omitempty"`
 }
 
 // GoogleSecretManagerSecretReplication is a nested-block type used by the parent resource.
 type GoogleSecretManagerSecretReplication struct {
-	Auto        []GoogleSecretManagerSecretReplicationAuto        `tf:"auto,blocks"`
-	UserManaged []GoogleSecretManagerSecretReplicationUserManaged `tf:"user_managed,blocks"`
+	Auto        []GoogleSecretManagerSecretReplicationAuto        `tf:"auto,blocks" json:"auto,omitempty"`
+	UserManaged []GoogleSecretManagerSecretReplicationUserManaged `tf:"user_managed,blocks" json:"user_managed,omitempty"`
 }
 
 // GoogleSecretManagerSecretReplicationAuto is a nested-block type used by the parent resource.
 type GoogleSecretManagerSecretReplicationAuto struct {
-	CustomerManagedEncryption []GoogleSecretManagerSecretReplicationAutoCustomerManagedEncryption `tf:"customer_managed_encryption,blocks"`
+	CustomerManagedEncryption []GoogleSecretManagerSecretReplicationAutoCustomerManagedEncryption `tf:"customer_managed_encryption,blocks" json:"customer_managed_encryption,omitempty"`
 }
 
 // GoogleSecretManagerSecretReplicationAutoCustomerManagedEncryption is a nested-block type used by the parent resource.
 type GoogleSecretManagerSecretReplicationAutoCustomerManagedEncryption struct {
-	KMSKeyName *Value[string] `tf:"kms_key_name"`
+	KMSKeyName *Value[string] `tf:"kms_key_name" json:"kms_key_name,omitempty"`
 }
 
 // GoogleSecretManagerSecretReplicationUserManaged is a nested-block type used by the parent resource.
 type GoogleSecretManagerSecretReplicationUserManaged struct {
-	Replicas []GoogleSecretManagerSecretReplicationUserManagedReplicas `tf:"replicas,blocks"`
+	Replicas []GoogleSecretManagerSecretReplicationUserManagedReplicas `tf:"replicas,blocks" json:"replicas,omitempty"`
 }
 
 // GoogleSecretManagerSecretReplicationUserManagedReplicas is a nested-block type used by the parent resource.
 type GoogleSecretManagerSecretReplicationUserManagedReplicas struct {
-	Location                  *Value[string]                                                                     `tf:"location"`
-	CustomerManagedEncryption []GoogleSecretManagerSecretReplicationUserManagedReplicasCustomerManagedEncryption `tf:"customer_managed_encryption,blocks"`
+	Location                  *Value[string]                                                                     `tf:"location" json:"location,omitempty"`
+	CustomerManagedEncryption []GoogleSecretManagerSecretReplicationUserManagedReplicasCustomerManagedEncryption `tf:"customer_managed_encryption,blocks" json:"customer_managed_encryption,omitempty"`
 }
 
 // GoogleSecretManagerSecretReplicationUserManagedReplicasCustomerManagedEncryption is a nested-block type used by the parent resource.
 type GoogleSecretManagerSecretReplicationUserManagedReplicasCustomerManagedEncryption struct {
-	KMSKeyName *Value[string] `tf:"kms_key_name"`
+	KMSKeyName *Value[string] `tf:"kms_key_name" json:"kms_key_name,omitempty"`
 }
 
 // GoogleSecretManagerSecretRotation is a nested-block type used by the parent resource.
 type GoogleSecretManagerSecretRotation struct {
-	NextRotationTime *Value[string] `tf:"next_rotation_time"`
-	RotationPeriod   *Value[string] `tf:"rotation_period"`
+	NextRotationTime *Value[string] `tf:"next_rotation_time" json:"next_rotation_time,omitempty"`
+	RotationPeriod   *Value[string] `tf:"rotation_period" json:"rotation_period,omitempty"`
 }
 
 // GoogleSecretManagerSecretTimeouts is a nested-block type used by the parent resource.
 type GoogleSecretManagerSecretTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleSecretManagerSecretTopics is a nested-block type used by the parent resource.
 type GoogleSecretManagerSecretTopics struct {
-	Name *Value[string] `tf:"name"`
+	Name *Value[string] `tf:"name" json:"name,omitempty"`
 }
 
 // GoogleSecretManagerSecretSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_service_account.gen.go
+++ b/pkg/composer/imported/generated/google_service_account.gen.go
@@ -7,23 +7,23 @@ import "reflect"
 // GoogleServiceAccount is the generated Layer 1 typed model for the
 // `google_service_account` Terraform resource.
 type GoogleServiceAccount struct {
-	AccountID                 *Value[string]                `tf:"account_id"`
-	CreateIgnoreAlreadyExists *Value[bool]                  `tf:"create_ignore_already_exists"`
-	Description               *Value[string]                `tf:"description"`
-	Disabled                  *Value[bool]                  `tf:"disabled"`
-	DisplayName               *Value[string]                `tf:"display_name"`
-	Email                     *Value[string]                `tf:"email"`
-	ID                        *Value[string]                `tf:"id"`
-	Member                    *Value[string]                `tf:"member"`
-	Name                      *Value[string]                `tf:"name"`
-	Project                   *Value[string]                `tf:"project"`
-	UniqueID                  *Value[string]                `tf:"unique_id"`
-	Timeouts                  *GoogleServiceAccountTimeouts `tf:"timeouts,block"`
+	AccountID                 *Value[string]                `tf:"account_id" json:"account_id,omitempty"`
+	CreateIgnoreAlreadyExists *Value[bool]                  `tf:"create_ignore_already_exists" json:"create_ignore_already_exists,omitempty"`
+	Description               *Value[string]                `tf:"description" json:"description,omitempty"`
+	Disabled                  *Value[bool]                  `tf:"disabled" json:"disabled,omitempty"`
+	DisplayName               *Value[string]                `tf:"display_name" json:"display_name,omitempty"`
+	Email                     *Value[string]                `tf:"email" json:"email,omitempty"`
+	ID                        *Value[string]                `tf:"id" json:"id,omitempty"`
+	Member                    *Value[string]                `tf:"member" json:"member,omitempty"`
+	Name                      *Value[string]                `tf:"name" json:"name,omitempty"`
+	Project                   *Value[string]                `tf:"project" json:"project,omitempty"`
+	UniqueID                  *Value[string]                `tf:"unique_id" json:"unique_id,omitempty"`
+	Timeouts                  *GoogleServiceAccountTimeouts `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleServiceAccountTimeouts is a nested-block type used by the parent resource.
 type GoogleServiceAccountTimeouts struct {
-	Create *Value[string] `tf:"create"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
 }
 
 // GoogleServiceAccountSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_sql_database_instance.gen.go
+++ b/pkg/composer/imported/generated/google_sql_database_instance.gen.go
@@ -7,230 +7,230 @@ import "reflect"
 // GoogleSqlDatabaseInstance is the generated Layer 1 typed model for the
 // `google_sql_database_instance` Terraform resource.
 type GoogleSqlDatabaseInstance struct {
-	AvailableMaintenanceVersions []*Value[string]                                `tf:"available_maintenance_versions"`
-	ConnectionName               *Value[string]                                  `tf:"connection_name"`
-	DatabaseVersion              *Value[string]                                  `tf:"database_version"`
-	DeletionProtection           *Value[bool]                                    `tf:"deletion_protection"`
-	DNSName                      *Value[string]                                  `tf:"dns_name"`
-	EncryptionKeyName            *Value[string]                                  `tf:"encryption_key_name"`
-	FirstIpAddress               *Value[string]                                  `tf:"first_ip_address"`
-	ID                           *Value[string]                                  `tf:"id"`
-	InstanceType                 *Value[string]                                  `tf:"instance_type"`
-	IpAddress                    []GoogleSqlDatabaseInstanceIpAddress            `tf:"ip_address"`
-	MaintenanceVersion           *Value[string]                                  `tf:"maintenance_version"`
-	MasterInstanceName           *Value[string]                                  `tf:"master_instance_name"`
-	Name                         *Value[string]                                  `tf:"name"`
-	PrivateIpAddress             *Value[string]                                  `tf:"private_ip_address"`
-	Project                      *Value[string]                                  `tf:"project"`
-	PscServiceAttachmentLink     *Value[string]                                  `tf:"psc_service_attachment_link"`
-	PublicIpAddress              *Value[string]                                  `tf:"public_ip_address"`
-	Region                       *Value[string]                                  `tf:"region"`
-	RootPassword                 *Value[string]                                  `tf:"root_password"`
-	SelfLink                     *Value[string]                                  `tf:"self_link"`
-	ServerCaCert                 []GoogleSqlDatabaseInstanceServerCaCert         `tf:"server_ca_cert"`
-	ServiceAccountEmailAddress   *Value[string]                                  `tf:"service_account_email_address"`
-	Clone                        []GoogleSqlDatabaseInstanceClone                `tf:"clone,blocks"`
-	ReplicaConfiguration         []GoogleSqlDatabaseInstanceReplicaConfiguration `tf:"replica_configuration,blocks"`
-	RestoreBackupContext         []GoogleSqlDatabaseInstanceRestoreBackupContext `tf:"restore_backup_context,blocks"`
-	Settings                     []GoogleSqlDatabaseInstanceSettings             `tf:"settings,blocks"`
-	Timeouts                     *GoogleSqlDatabaseInstanceTimeouts              `tf:"timeouts,block"`
+	AvailableMaintenanceVersions []*Value[string]                                `tf:"available_maintenance_versions" json:"available_maintenance_versions,omitempty"`
+	ConnectionName               *Value[string]                                  `tf:"connection_name" json:"connection_name,omitempty"`
+	DatabaseVersion              *Value[string]                                  `tf:"database_version" json:"database_version,omitempty"`
+	DeletionProtection           *Value[bool]                                    `tf:"deletion_protection" json:"deletion_protection,omitempty"`
+	DNSName                      *Value[string]                                  `tf:"dns_name" json:"dns_name,omitempty"`
+	EncryptionKeyName            *Value[string]                                  `tf:"encryption_key_name" json:"encryption_key_name,omitempty"`
+	FirstIpAddress               *Value[string]                                  `tf:"first_ip_address" json:"first_ip_address,omitempty"`
+	ID                           *Value[string]                                  `tf:"id" json:"id,omitempty"`
+	InstanceType                 *Value[string]                                  `tf:"instance_type" json:"instance_type,omitempty"`
+	IpAddress                    []GoogleSqlDatabaseInstanceIpAddress            `tf:"ip_address" json:"ip_address,omitempty"`
+	MaintenanceVersion           *Value[string]                                  `tf:"maintenance_version" json:"maintenance_version,omitempty"`
+	MasterInstanceName           *Value[string]                                  `tf:"master_instance_name" json:"master_instance_name,omitempty"`
+	Name                         *Value[string]                                  `tf:"name" json:"name,omitempty"`
+	PrivateIpAddress             *Value[string]                                  `tf:"private_ip_address" json:"private_ip_address,omitempty"`
+	Project                      *Value[string]                                  `tf:"project" json:"project,omitempty"`
+	PscServiceAttachmentLink     *Value[string]                                  `tf:"psc_service_attachment_link" json:"psc_service_attachment_link,omitempty"`
+	PublicIpAddress              *Value[string]                                  `tf:"public_ip_address" json:"public_ip_address,omitempty"`
+	Region                       *Value[string]                                  `tf:"region" json:"region,omitempty"`
+	RootPassword                 *Value[string]                                  `tf:"root_password" json:"root_password,omitempty"`
+	SelfLink                     *Value[string]                                  `tf:"self_link" json:"self_link,omitempty"`
+	ServerCaCert                 []GoogleSqlDatabaseInstanceServerCaCert         `tf:"server_ca_cert" json:"server_ca_cert,omitempty"`
+	ServiceAccountEmailAddress   *Value[string]                                  `tf:"service_account_email_address" json:"service_account_email_address,omitempty"`
+	Clone                        []GoogleSqlDatabaseInstanceClone                `tf:"clone,blocks" json:"clone,omitempty"`
+	ReplicaConfiguration         []GoogleSqlDatabaseInstanceReplicaConfiguration `tf:"replica_configuration,blocks" json:"replica_configuration,omitempty"`
+	RestoreBackupContext         []GoogleSqlDatabaseInstanceRestoreBackupContext `tf:"restore_backup_context,blocks" json:"restore_backup_context,omitempty"`
+	Settings                     []GoogleSqlDatabaseInstanceSettings             `tf:"settings,blocks" json:"settings,omitempty"`
+	Timeouts                     *GoogleSqlDatabaseInstanceTimeouts              `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceClone is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceClone struct {
-	AllocatedIpRange   *Value[string]   `tf:"allocated_ip_range"`
-	DatabaseNames      []*Value[string] `tf:"database_names"`
-	PointInTime        *Value[string]   `tf:"point_in_time"`
-	PreferredZone      *Value[string]   `tf:"preferred_zone"`
-	SourceInstanceName *Value[string]   `tf:"source_instance_name"`
+	AllocatedIpRange   *Value[string]   `tf:"allocated_ip_range" json:"allocated_ip_range,omitempty"`
+	DatabaseNames      []*Value[string] `tf:"database_names" json:"database_names,omitempty"`
+	PointInTime        *Value[string]   `tf:"point_in_time" json:"point_in_time,omitempty"`
+	PreferredZone      *Value[string]   `tf:"preferred_zone" json:"preferred_zone,omitempty"`
+	SourceInstanceName *Value[string]   `tf:"source_instance_name" json:"source_instance_name,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceIpAddress is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceIpAddress struct {
-	IpAddress    *Value[string] `tf:"ip_address"`
-	TimeToRetire *Value[string] `tf:"time_to_retire"`
-	Type_        *Value[string] `tf:"type"`
+	IpAddress    *Value[string] `tf:"ip_address" json:"ip_address,omitempty"`
+	TimeToRetire *Value[string] `tf:"time_to_retire" json:"time_to_retire,omitempty"`
+	Type_        *Value[string] `tf:"type" json:"type,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceReplicaConfiguration is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceReplicaConfiguration struct {
-	CaCertificate           *Value[string]  `tf:"ca_certificate"`
-	ClientCertificate       *Value[string]  `tf:"client_certificate"`
-	ClientKey               *Value[string]  `tf:"client_key"`
-	ConnectRetryInterval    *Value[float64] `tf:"connect_retry_interval"`
-	DumpFilePath            *Value[string]  `tf:"dump_file_path"`
-	FailoverTarget          *Value[bool]    `tf:"failover_target"`
-	MasterHeartbeatPeriod   *Value[int64]   `tf:"master_heartbeat_period"`
-	Password                *Value[string]  `tf:"password"`
-	SSLCipher               *Value[string]  `tf:"ssl_cipher"`
-	Username                *Value[string]  `tf:"username"`
-	VerifyServerCertificate *Value[bool]    `tf:"verify_server_certificate"`
+	CaCertificate           *Value[string]  `tf:"ca_certificate" json:"ca_certificate,omitempty"`
+	ClientCertificate       *Value[string]  `tf:"client_certificate" json:"client_certificate,omitempty"`
+	ClientKey               *Value[string]  `tf:"client_key" json:"client_key,omitempty"`
+	ConnectRetryInterval    *Value[float64] `tf:"connect_retry_interval" json:"connect_retry_interval,omitempty"`
+	DumpFilePath            *Value[string]  `tf:"dump_file_path" json:"dump_file_path,omitempty"`
+	FailoverTarget          *Value[bool]    `tf:"failover_target" json:"failover_target,omitempty"`
+	MasterHeartbeatPeriod   *Value[int64]   `tf:"master_heartbeat_period" json:"master_heartbeat_period,omitempty"`
+	Password                *Value[string]  `tf:"password" json:"password,omitempty"`
+	SSLCipher               *Value[string]  `tf:"ssl_cipher" json:"ssl_cipher,omitempty"`
+	Username                *Value[string]  `tf:"username" json:"username,omitempty"`
+	VerifyServerCertificate *Value[bool]    `tf:"verify_server_certificate" json:"verify_server_certificate,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceRestoreBackupContext is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceRestoreBackupContext struct {
-	BackupRunID *Value[float64] `tf:"backup_run_id"`
-	InstanceID  *Value[string]  `tf:"instance_id"`
-	Project     *Value[string]  `tf:"project"`
+	BackupRunID *Value[float64] `tf:"backup_run_id" json:"backup_run_id,omitempty"`
+	InstanceID  *Value[string]  `tf:"instance_id" json:"instance_id,omitempty"`
+	Project     *Value[string]  `tf:"project" json:"project,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceServerCaCert is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceServerCaCert struct {
-	Cert            *Value[string] `tf:"cert"`
-	CommonName      *Value[string] `tf:"common_name"`
-	CreateTime      *Value[string] `tf:"create_time"`
-	ExpirationTime  *Value[string] `tf:"expiration_time"`
-	SHA1Fingerprint *Value[string] `tf:"sha1_fingerprint"`
+	Cert            *Value[string] `tf:"cert" json:"cert,omitempty"`
+	CommonName      *Value[string] `tf:"common_name" json:"common_name,omitempty"`
+	CreateTime      *Value[string] `tf:"create_time" json:"create_time,omitempty"`
+	ExpirationTime  *Value[string] `tf:"expiration_time" json:"expiration_time,omitempty"`
+	SHA1Fingerprint *Value[string] `tf:"sha1_fingerprint" json:"sha1_fingerprint,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettings is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettings struct {
-	ActivationPolicy          *Value[string]                                              `tf:"activation_policy"`
-	AvailabilityType          *Value[string]                                              `tf:"availability_type"`
-	Collation                 *Value[string]                                              `tf:"collation"`
-	ConnectorEnforcement      *Value[string]                                              `tf:"connector_enforcement"`
-	DeletionProtectionEnabled *Value[bool]                                                `tf:"deletion_protection_enabled"`
-	DiskAutoresize            *Value[bool]                                                `tf:"disk_autoresize"`
-	DiskAutoresizeLimit       *Value[float64]                                             `tf:"disk_autoresize_limit"`
-	DiskSize                  *Value[int64]                                               `tf:"disk_size"`
-	DiskType                  *Value[string]                                              `tf:"disk_type"`
-	Edition                   *Value[string]                                              `tf:"edition"`
-	EnableDataplexIntegration *Value[bool]                                                `tf:"enable_dataplex_integration"`
-	EnableGoogleMlIntegration *Value[bool]                                                `tf:"enable_google_ml_integration"`
-	PricingPlan               *Value[string]                                              `tf:"pricing_plan"`
-	Tier                      *Value[string]                                              `tf:"tier"`
-	TimeZone                  *Value[string]                                              `tf:"time_zone"`
-	UserLabels                map[string]*Value[string]                                   `tf:"user_labels"`
-	Version                   *Value[int64]                                               `tf:"version"`
-	ActiveDirectoryConfig     []GoogleSqlDatabaseInstanceSettingsActiveDirectoryConfig    `tf:"active_directory_config,blocks"`
-	AdvancedMachineFeatures   []GoogleSqlDatabaseInstanceSettingsAdvancedMachineFeatures  `tf:"advanced_machine_features,blocks"`
-	BackupConfiguration       []GoogleSqlDatabaseInstanceSettingsBackupConfiguration      `tf:"backup_configuration,blocks"`
-	DataCacheConfig           []GoogleSqlDatabaseInstanceSettingsDataCacheConfig          `tf:"data_cache_config,blocks"`
-	DatabaseFlags             []GoogleSqlDatabaseInstanceSettingsDatabaseFlags            `tf:"database_flags,blocks"`
-	DenyMaintenancePeriod     []GoogleSqlDatabaseInstanceSettingsDenyMaintenancePeriod    `tf:"deny_maintenance_period,blocks"`
-	InsightsConfig            []GoogleSqlDatabaseInstanceSettingsInsightsConfig           `tf:"insights_config,blocks"`
-	IpConfiguration           []GoogleSqlDatabaseInstanceSettingsIpConfiguration          `tf:"ip_configuration,blocks"`
-	LocationPreference        []GoogleSqlDatabaseInstanceSettingsLocationPreference       `tf:"location_preference,blocks"`
-	MaintenanceWindow         []GoogleSqlDatabaseInstanceSettingsMaintenanceWindow        `tf:"maintenance_window,blocks"`
-	PasswordValidationPolicy  []GoogleSqlDatabaseInstanceSettingsPasswordValidationPolicy `tf:"password_validation_policy,blocks"`
-	SqlServerAuditConfig      []GoogleSqlDatabaseInstanceSettingsSqlServerAuditConfig     `tf:"sql_server_audit_config,blocks"`
+	ActivationPolicy          *Value[string]                                              `tf:"activation_policy" json:"activation_policy,omitempty"`
+	AvailabilityType          *Value[string]                                              `tf:"availability_type" json:"availability_type,omitempty"`
+	Collation                 *Value[string]                                              `tf:"collation" json:"collation,omitempty"`
+	ConnectorEnforcement      *Value[string]                                              `tf:"connector_enforcement" json:"connector_enforcement,omitempty"`
+	DeletionProtectionEnabled *Value[bool]                                                `tf:"deletion_protection_enabled" json:"deletion_protection_enabled,omitempty"`
+	DiskAutoresize            *Value[bool]                                                `tf:"disk_autoresize" json:"disk_autoresize,omitempty"`
+	DiskAutoresizeLimit       *Value[float64]                                             `tf:"disk_autoresize_limit" json:"disk_autoresize_limit,omitempty"`
+	DiskSize                  *Value[int64]                                               `tf:"disk_size" json:"disk_size,omitempty"`
+	DiskType                  *Value[string]                                              `tf:"disk_type" json:"disk_type,omitempty"`
+	Edition                   *Value[string]                                              `tf:"edition" json:"edition,omitempty"`
+	EnableDataplexIntegration *Value[bool]                                                `tf:"enable_dataplex_integration" json:"enable_dataplex_integration,omitempty"`
+	EnableGoogleMlIntegration *Value[bool]                                                `tf:"enable_google_ml_integration" json:"enable_google_ml_integration,omitempty"`
+	PricingPlan               *Value[string]                                              `tf:"pricing_plan" json:"pricing_plan,omitempty"`
+	Tier                      *Value[string]                                              `tf:"tier" json:"tier,omitempty"`
+	TimeZone                  *Value[string]                                              `tf:"time_zone" json:"time_zone,omitempty"`
+	UserLabels                map[string]*Value[string]                                   `tf:"user_labels" json:"user_labels,omitempty"`
+	Version                   *Value[int64]                                               `tf:"version" json:"version,omitempty"`
+	ActiveDirectoryConfig     []GoogleSqlDatabaseInstanceSettingsActiveDirectoryConfig    `tf:"active_directory_config,blocks" json:"active_directory_config,omitempty"`
+	AdvancedMachineFeatures   []GoogleSqlDatabaseInstanceSettingsAdvancedMachineFeatures  `tf:"advanced_machine_features,blocks" json:"advanced_machine_features,omitempty"`
+	BackupConfiguration       []GoogleSqlDatabaseInstanceSettingsBackupConfiguration      `tf:"backup_configuration,blocks" json:"backup_configuration,omitempty"`
+	DataCacheConfig           []GoogleSqlDatabaseInstanceSettingsDataCacheConfig          `tf:"data_cache_config,blocks" json:"data_cache_config,omitempty"`
+	DatabaseFlags             []GoogleSqlDatabaseInstanceSettingsDatabaseFlags            `tf:"database_flags,blocks" json:"database_flags,omitempty"`
+	DenyMaintenancePeriod     []GoogleSqlDatabaseInstanceSettingsDenyMaintenancePeriod    `tf:"deny_maintenance_period,blocks" json:"deny_maintenance_period,omitempty"`
+	InsightsConfig            []GoogleSqlDatabaseInstanceSettingsInsightsConfig           `tf:"insights_config,blocks" json:"insights_config,omitempty"`
+	IpConfiguration           []GoogleSqlDatabaseInstanceSettingsIpConfiguration          `tf:"ip_configuration,blocks" json:"ip_configuration,omitempty"`
+	LocationPreference        []GoogleSqlDatabaseInstanceSettingsLocationPreference       `tf:"location_preference,blocks" json:"location_preference,omitempty"`
+	MaintenanceWindow         []GoogleSqlDatabaseInstanceSettingsMaintenanceWindow        `tf:"maintenance_window,blocks" json:"maintenance_window,omitempty"`
+	PasswordValidationPolicy  []GoogleSqlDatabaseInstanceSettingsPasswordValidationPolicy `tf:"password_validation_policy,blocks" json:"password_validation_policy,omitempty"`
+	SqlServerAuditConfig      []GoogleSqlDatabaseInstanceSettingsSqlServerAuditConfig     `tf:"sql_server_audit_config,blocks" json:"sql_server_audit_config,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsActiveDirectoryConfig is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsActiveDirectoryConfig struct {
-	Domain *Value[string] `tf:"domain"`
+	Domain *Value[string] `tf:"domain" json:"domain,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsAdvancedMachineFeatures is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsAdvancedMachineFeatures struct {
-	ThreadsPerCore *Value[float64] `tf:"threads_per_core"`
+	ThreadsPerCore *Value[float64] `tf:"threads_per_core" json:"threads_per_core,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsBackupConfiguration is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsBackupConfiguration struct {
-	BinaryLogEnabled            *Value[bool]                                                                  `tf:"binary_log_enabled"`
-	Enabled                     *Value[bool]                                                                  `tf:"enabled"`
-	Location                    *Value[string]                                                                `tf:"location"`
-	PointInTimeRecoveryEnabled  *Value[bool]                                                                  `tf:"point_in_time_recovery_enabled"`
-	StartTime                   *Value[string]                                                                `tf:"start_time"`
-	TransactionLogRetentionDays *Value[float64]                                                               `tf:"transaction_log_retention_days"`
-	BackupRetentionSettings     []GoogleSqlDatabaseInstanceSettingsBackupConfigurationBackupRetentionSettings `tf:"backup_retention_settings,blocks"`
+	BinaryLogEnabled            *Value[bool]                                                                  `tf:"binary_log_enabled" json:"binary_log_enabled,omitempty"`
+	Enabled                     *Value[bool]                                                                  `tf:"enabled" json:"enabled,omitempty"`
+	Location                    *Value[string]                                                                `tf:"location" json:"location,omitempty"`
+	PointInTimeRecoveryEnabled  *Value[bool]                                                                  `tf:"point_in_time_recovery_enabled" json:"point_in_time_recovery_enabled,omitempty"`
+	StartTime                   *Value[string]                                                                `tf:"start_time" json:"start_time,omitempty"`
+	TransactionLogRetentionDays *Value[float64]                                                               `tf:"transaction_log_retention_days" json:"transaction_log_retention_days,omitempty"`
+	BackupRetentionSettings     []GoogleSqlDatabaseInstanceSettingsBackupConfigurationBackupRetentionSettings `tf:"backup_retention_settings,blocks" json:"backup_retention_settings,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsBackupConfigurationBackupRetentionSettings is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsBackupConfigurationBackupRetentionSettings struct {
-	RetainedBackups *Value[float64] `tf:"retained_backups"`
-	RetentionUnit   *Value[string]  `tf:"retention_unit"`
+	RetainedBackups *Value[float64] `tf:"retained_backups" json:"retained_backups,omitempty"`
+	RetentionUnit   *Value[string]  `tf:"retention_unit" json:"retention_unit,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsDataCacheConfig is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsDataCacheConfig struct {
-	DataCacheEnabled *Value[bool] `tf:"data_cache_enabled"`
+	DataCacheEnabled *Value[bool] `tf:"data_cache_enabled" json:"data_cache_enabled,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsDatabaseFlags is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsDatabaseFlags struct {
-	Name  *Value[string] `tf:"name"`
-	Value *Value[string] `tf:"value"`
+	Name  *Value[string] `tf:"name" json:"name,omitempty"`
+	Value *Value[string] `tf:"value" json:"value,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsDenyMaintenancePeriod is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsDenyMaintenancePeriod struct {
-	EndDate   *Value[string] `tf:"end_date"`
-	StartDate *Value[string] `tf:"start_date"`
-	Time      *Value[string] `tf:"time"`
+	EndDate   *Value[string] `tf:"end_date" json:"end_date,omitempty"`
+	StartDate *Value[string] `tf:"start_date" json:"start_date,omitempty"`
+	Time      *Value[string] `tf:"time" json:"time,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsInsightsConfig is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsInsightsConfig struct {
-	QueryInsightsEnabled  *Value[bool]    `tf:"query_insights_enabled"`
-	QueryPlansPerMinute   *Value[float64] `tf:"query_plans_per_minute"`
-	QueryStringLength     *Value[float64] `tf:"query_string_length"`
-	RecordApplicationTags *Value[bool]    `tf:"record_application_tags"`
-	RecordClientAddress   *Value[bool]    `tf:"record_client_address"`
+	QueryInsightsEnabled  *Value[bool]    `tf:"query_insights_enabled" json:"query_insights_enabled,omitempty"`
+	QueryPlansPerMinute   *Value[float64] `tf:"query_plans_per_minute" json:"query_plans_per_minute,omitempty"`
+	QueryStringLength     *Value[float64] `tf:"query_string_length" json:"query_string_length,omitempty"`
+	RecordApplicationTags *Value[bool]    `tf:"record_application_tags" json:"record_application_tags,omitempty"`
+	RecordClientAddress   *Value[bool]    `tf:"record_client_address" json:"record_client_address,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsIpConfiguration is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsIpConfiguration struct {
-	AllocatedIpRange                        *Value[string]                                                       `tf:"allocated_ip_range"`
-	EnablePrivatePathForGoogleCloudServices *Value[bool]                                                         `tf:"enable_private_path_for_google_cloud_services"`
-	IPV4Enabled                             *Value[bool]                                                         `tf:"ipv4_enabled"`
-	PrivateNetwork                          *Value[string]                                                       `tf:"private_network"`
-	ServerCaMode                            *Value[string]                                                       `tf:"server_ca_mode"`
-	SSLMode                                 *Value[string]                                                       `tf:"ssl_mode"`
-	AuthorizedNetworks                      []GoogleSqlDatabaseInstanceSettingsIpConfigurationAuthorizedNetworks `tf:"authorized_networks,blocks"`
-	PscConfig                               []GoogleSqlDatabaseInstanceSettingsIpConfigurationPscConfig          `tf:"psc_config,blocks"`
+	AllocatedIpRange                        *Value[string]                                                       `tf:"allocated_ip_range" json:"allocated_ip_range,omitempty"`
+	EnablePrivatePathForGoogleCloudServices *Value[bool]                                                         `tf:"enable_private_path_for_google_cloud_services" json:"enable_private_path_for_google_cloud_services,omitempty"`
+	IPV4Enabled                             *Value[bool]                                                         `tf:"ipv4_enabled" json:"ipv4_enabled,omitempty"`
+	PrivateNetwork                          *Value[string]                                                       `tf:"private_network" json:"private_network,omitempty"`
+	ServerCaMode                            *Value[string]                                                       `tf:"server_ca_mode" json:"server_ca_mode,omitempty"`
+	SSLMode                                 *Value[string]                                                       `tf:"ssl_mode" json:"ssl_mode,omitempty"`
+	AuthorizedNetworks                      []GoogleSqlDatabaseInstanceSettingsIpConfigurationAuthorizedNetworks `tf:"authorized_networks,blocks" json:"authorized_networks,omitempty"`
+	PscConfig                               []GoogleSqlDatabaseInstanceSettingsIpConfigurationPscConfig          `tf:"psc_config,blocks" json:"psc_config,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsIpConfigurationAuthorizedNetworks is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsIpConfigurationAuthorizedNetworks struct {
-	ExpirationTime *Value[string] `tf:"expiration_time"`
-	Name           *Value[string] `tf:"name"`
-	Value          *Value[string] `tf:"value"`
+	ExpirationTime *Value[string] `tf:"expiration_time" json:"expiration_time,omitempty"`
+	Name           *Value[string] `tf:"name" json:"name,omitempty"`
+	Value          *Value[string] `tf:"value" json:"value,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsIpConfigurationPscConfig is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsIpConfigurationPscConfig struct {
-	AllowedConsumerProjects []*Value[string] `tf:"allowed_consumer_projects"`
-	PscEnabled              *Value[bool]     `tf:"psc_enabled"`
+	AllowedConsumerProjects []*Value[string] `tf:"allowed_consumer_projects" json:"allowed_consumer_projects,omitempty"`
+	PscEnabled              *Value[bool]     `tf:"psc_enabled" json:"psc_enabled,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsLocationPreference is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsLocationPreference struct {
-	FollowGaeApplication *Value[string] `tf:"follow_gae_application"`
-	SecondaryZone        *Value[string] `tf:"secondary_zone"`
-	Zone                 *Value[string] `tf:"zone"`
+	FollowGaeApplication *Value[string] `tf:"follow_gae_application" json:"follow_gae_application,omitempty"`
+	SecondaryZone        *Value[string] `tf:"secondary_zone" json:"secondary_zone,omitempty"`
+	Zone                 *Value[string] `tf:"zone" json:"zone,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsMaintenanceWindow is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsMaintenanceWindow struct {
-	Day         *Value[float64] `tf:"day"`
-	Hour        *Value[float64] `tf:"hour"`
-	UpdateTrack *Value[string]  `tf:"update_track"`
+	Day         *Value[float64] `tf:"day" json:"day,omitempty"`
+	Hour        *Value[float64] `tf:"hour" json:"hour,omitempty"`
+	UpdateTrack *Value[string]  `tf:"update_track" json:"update_track,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsPasswordValidationPolicy is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsPasswordValidationPolicy struct {
-	Complexity                *Value[string]  `tf:"complexity"`
-	DisallowUsernameSubstring *Value[bool]    `tf:"disallow_username_substring"`
-	EnablePasswordPolicy      *Value[bool]    `tf:"enable_password_policy"`
-	MinLength                 *Value[int64]   `tf:"min_length"`
-	PasswordChangeInterval    *Value[string]  `tf:"password_change_interval"`
-	ReuseInterval             *Value[float64] `tf:"reuse_interval"`
+	Complexity                *Value[string]  `tf:"complexity" json:"complexity,omitempty"`
+	DisallowUsernameSubstring *Value[bool]    `tf:"disallow_username_substring" json:"disallow_username_substring,omitempty"`
+	EnablePasswordPolicy      *Value[bool]    `tf:"enable_password_policy" json:"enable_password_policy,omitempty"`
+	MinLength                 *Value[int64]   `tf:"min_length" json:"min_length,omitempty"`
+	PasswordChangeInterval    *Value[string]  `tf:"password_change_interval" json:"password_change_interval,omitempty"`
+	ReuseInterval             *Value[float64] `tf:"reuse_interval" json:"reuse_interval,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSettingsSqlServerAuditConfig is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceSettingsSqlServerAuditConfig struct {
-	Bucket            *Value[string] `tf:"bucket"`
-	RetentionInterval *Value[string] `tf:"retention_interval"`
-	UploadInterval    *Value[string] `tf:"upload_interval"`
+	Bucket            *Value[string] `tf:"bucket" json:"bucket,omitempty"`
+	RetentionInterval *Value[string] `tf:"retention_interval" json:"retention_interval,omitempty"`
+	UploadInterval    *Value[string] `tf:"upload_interval" json:"upload_interval,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceTimeouts is a nested-block type used by the parent resource.
 type GoogleSqlDatabaseInstanceTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleSqlDatabaseInstanceSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_sql_user.gen.go
+++ b/pkg/composer/imported/generated/google_sql_user.gen.go
@@ -7,45 +7,45 @@ import "reflect"
 // GoogleSqlUser is the generated Layer 1 typed model for the
 // `google_sql_user` Terraform resource.
 type GoogleSqlUser struct {
-	DeletionPolicy       *Value[string]                      `tf:"deletion_policy"`
-	Host                 *Value[string]                      `tf:"host"`
-	ID                   *Value[string]                      `tf:"id"`
-	Instance             *Value[string]                      `tf:"instance"`
-	Name                 *Value[string]                      `tf:"name"`
-	Password             *Value[string]                      `tf:"password"`
-	Project              *Value[string]                      `tf:"project"`
-	SqlServerUserDetails []GoogleSqlUserSqlServerUserDetails `tf:"sql_server_user_details"`
-	Type_                *Value[string]                      `tf:"type"`
-	PasswordPolicy       []GoogleSqlUserPasswordPolicy       `tf:"password_policy,blocks"`
-	Timeouts             *GoogleSqlUserTimeouts              `tf:"timeouts,block"`
+	DeletionPolicy       *Value[string]                      `tf:"deletion_policy" json:"deletion_policy,omitempty"`
+	Host                 *Value[string]                      `tf:"host" json:"host,omitempty"`
+	ID                   *Value[string]                      `tf:"id" json:"id,omitempty"`
+	Instance             *Value[string]                      `tf:"instance" json:"instance,omitempty"`
+	Name                 *Value[string]                      `tf:"name" json:"name,omitempty"`
+	Password             *Value[string]                      `tf:"password" json:"password,omitempty"`
+	Project              *Value[string]                      `tf:"project" json:"project,omitempty"`
+	SqlServerUserDetails []GoogleSqlUserSqlServerUserDetails `tf:"sql_server_user_details" json:"sql_server_user_details,omitempty"`
+	Type_                *Value[string]                      `tf:"type" json:"type,omitempty"`
+	PasswordPolicy       []GoogleSqlUserPasswordPolicy       `tf:"password_policy,blocks" json:"password_policy,omitempty"`
+	Timeouts             *GoogleSqlUserTimeouts              `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleSqlUserPasswordPolicy is a nested-block type used by the parent resource.
 type GoogleSqlUserPasswordPolicy struct {
-	AllowedFailedAttempts      *Value[float64]                     `tf:"allowed_failed_attempts"`
-	EnableFailedAttemptsCheck  *Value[bool]                        `tf:"enable_failed_attempts_check"`
-	EnablePasswordVerification *Value[bool]                        `tf:"enable_password_verification"`
-	PasswordExpirationDuration *Value[string]                      `tf:"password_expiration_duration"`
-	Status                     []GoogleSqlUserPasswordPolicyStatus `tf:"status"`
+	AllowedFailedAttempts      *Value[float64]                     `tf:"allowed_failed_attempts" json:"allowed_failed_attempts,omitempty"`
+	EnableFailedAttemptsCheck  *Value[bool]                        `tf:"enable_failed_attempts_check" json:"enable_failed_attempts_check,omitempty"`
+	EnablePasswordVerification *Value[bool]                        `tf:"enable_password_verification" json:"enable_password_verification,omitempty"`
+	PasswordExpirationDuration *Value[string]                      `tf:"password_expiration_duration" json:"password_expiration_duration,omitempty"`
+	Status                     []GoogleSqlUserPasswordPolicyStatus `tf:"status" json:"status,omitempty"`
 }
 
 // GoogleSqlUserPasswordPolicyStatus is a nested-block type used by the parent resource.
 type GoogleSqlUserPasswordPolicyStatus struct {
-	Locked                 *Value[bool]   `tf:"locked"`
-	PasswordExpirationTime *Value[string] `tf:"password_expiration_time"`
+	Locked                 *Value[bool]   `tf:"locked" json:"locked,omitempty"`
+	PasswordExpirationTime *Value[string] `tf:"password_expiration_time" json:"password_expiration_time,omitempty"`
 }
 
 // GoogleSqlUserSqlServerUserDetails is a nested-block type used by the parent resource.
 type GoogleSqlUserSqlServerUserDetails struct {
-	Disabled    *Value[bool]     `tf:"disabled"`
-	ServerRoles []*Value[string] `tf:"server_roles"`
+	Disabled    *Value[bool]     `tf:"disabled" json:"disabled,omitempty"`
+	ServerRoles []*Value[string] `tf:"server_roles" json:"server_roles,omitempty"`
 }
 
 // GoogleSqlUserTimeouts is a nested-block type used by the parent resource.
 type GoogleSqlUserTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleSqlUserSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_storage_bucket.gen.go
+++ b/pkg/composer/imported/generated/google_storage_bucket.gen.go
@@ -7,132 +7,132 @@ import "reflect"
 // GoogleStorageBucket is the generated Layer 1 typed model for the
 // `google_storage_bucket` Terraform resource.
 type GoogleStorageBucket struct {
-	DefaultEventBasedHold    *Value[bool]                               `tf:"default_event_based_hold"`
-	EffectiveLabels          map[string]*Value[string]                  `tf:"effective_labels"`
-	EnableObjectRetention    *Value[bool]                               `tf:"enable_object_retention"`
-	ForceDestroy             *Value[bool]                               `tf:"force_destroy"`
-	ID                       *Value[string]                             `tf:"id"`
-	Labels                   map[string]*Value[string]                  `tf:"labels"`
-	Location                 *Value[string]                             `tf:"location"`
-	Name                     *Value[string]                             `tf:"name"`
-	Project                  *Value[string]                             `tf:"project"`
-	ProjectNumber            *Value[float64]                            `tf:"project_number"`
-	PublicAccessPrevention   *Value[string]                             `tf:"public_access_prevention"`
-	RequesterPays            *Value[bool]                               `tf:"requester_pays"`
-	Rpo                      *Value[string]                             `tf:"rpo"`
-	SelfLink                 *Value[string]                             `tf:"self_link"`
-	StorageClass             *Value[string]                             `tf:"storage_class"`
-	TerraformLabels          map[string]*Value[string]                  `tf:"terraform_labels"`
-	UniformBucketLevelAccess *Value[bool]                               `tf:"uniform_bucket_level_access"`
-	URL                      *Value[string]                             `tf:"url"`
-	Autoclass                []GoogleStorageBucketAutoclass             `tf:"autoclass,blocks"`
-	Cors                     []GoogleStorageBucketCors                  `tf:"cors,blocks"`
-	CustomPlacementConfig    []GoogleStorageBucketCustomPlacementConfig `tf:"custom_placement_config,blocks"`
-	Encryption               []GoogleStorageBucketEncryption            `tf:"encryption,blocks"`
-	HierarchicalNamespace    []GoogleStorageBucketHierarchicalNamespace `tf:"hierarchical_namespace,blocks"`
-	LifecycleRule            []GoogleStorageBucketLifecycleRule         `tf:"lifecycle_rule,blocks"`
-	Logging                  []GoogleStorageBucketLogging               `tf:"logging,blocks"`
-	RetentionPolicy          []GoogleStorageBucketRetentionPolicy       `tf:"retention_policy,blocks"`
-	SoftDeletePolicy         []GoogleStorageBucketSoftDeletePolicy      `tf:"soft_delete_policy,blocks"`
-	Timeouts                 *GoogleStorageBucketTimeouts               `tf:"timeouts,block"`
-	Versioning               []GoogleStorageBucketVersioning            `tf:"versioning,blocks"`
-	Website                  []GoogleStorageBucketWebsite               `tf:"website,blocks"`
+	DefaultEventBasedHold    *Value[bool]                               `tf:"default_event_based_hold" json:"default_event_based_hold,omitempty"`
+	EffectiveLabels          map[string]*Value[string]                  `tf:"effective_labels" json:"effective_labels,omitempty"`
+	EnableObjectRetention    *Value[bool]                               `tf:"enable_object_retention" json:"enable_object_retention,omitempty"`
+	ForceDestroy             *Value[bool]                               `tf:"force_destroy" json:"force_destroy,omitempty"`
+	ID                       *Value[string]                             `tf:"id" json:"id,omitempty"`
+	Labels                   map[string]*Value[string]                  `tf:"labels" json:"labels,omitempty"`
+	Location                 *Value[string]                             `tf:"location" json:"location,omitempty"`
+	Name                     *Value[string]                             `tf:"name" json:"name,omitempty"`
+	Project                  *Value[string]                             `tf:"project" json:"project,omitempty"`
+	ProjectNumber            *Value[float64]                            `tf:"project_number" json:"project_number,omitempty"`
+	PublicAccessPrevention   *Value[string]                             `tf:"public_access_prevention" json:"public_access_prevention,omitempty"`
+	RequesterPays            *Value[bool]                               `tf:"requester_pays" json:"requester_pays,omitempty"`
+	Rpo                      *Value[string]                             `tf:"rpo" json:"rpo,omitempty"`
+	SelfLink                 *Value[string]                             `tf:"self_link" json:"self_link,omitempty"`
+	StorageClass             *Value[string]                             `tf:"storage_class" json:"storage_class,omitempty"`
+	TerraformLabels          map[string]*Value[string]                  `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	UniformBucketLevelAccess *Value[bool]                               `tf:"uniform_bucket_level_access" json:"uniform_bucket_level_access,omitempty"`
+	URL                      *Value[string]                             `tf:"url" json:"url,omitempty"`
+	Autoclass                []GoogleStorageBucketAutoclass             `tf:"autoclass,blocks" json:"autoclass,omitempty"`
+	Cors                     []GoogleStorageBucketCors                  `tf:"cors,blocks" json:"cors,omitempty"`
+	CustomPlacementConfig    []GoogleStorageBucketCustomPlacementConfig `tf:"custom_placement_config,blocks" json:"custom_placement_config,omitempty"`
+	Encryption               []GoogleStorageBucketEncryption            `tf:"encryption,blocks" json:"encryption,omitempty"`
+	HierarchicalNamespace    []GoogleStorageBucketHierarchicalNamespace `tf:"hierarchical_namespace,blocks" json:"hierarchical_namespace,omitempty"`
+	LifecycleRule            []GoogleStorageBucketLifecycleRule         `tf:"lifecycle_rule,blocks" json:"lifecycle_rule,omitempty"`
+	Logging                  []GoogleStorageBucketLogging               `tf:"logging,blocks" json:"logging,omitempty"`
+	RetentionPolicy          []GoogleStorageBucketRetentionPolicy       `tf:"retention_policy,blocks" json:"retention_policy,omitempty"`
+	SoftDeletePolicy         []GoogleStorageBucketSoftDeletePolicy      `tf:"soft_delete_policy,blocks" json:"soft_delete_policy,omitempty"`
+	Timeouts                 *GoogleStorageBucketTimeouts               `tf:"timeouts,block" json:"timeouts,omitempty"`
+	Versioning               []GoogleStorageBucketVersioning            `tf:"versioning,blocks" json:"versioning,omitempty"`
+	Website                  []GoogleStorageBucketWebsite               `tf:"website,blocks" json:"website,omitempty"`
 }
 
 // GoogleStorageBucketAutoclass is a nested-block type used by the parent resource.
 type GoogleStorageBucketAutoclass struct {
-	Enabled              *Value[bool]   `tf:"enabled"`
-	TerminalStorageClass *Value[string] `tf:"terminal_storage_class"`
+	Enabled              *Value[bool]   `tf:"enabled" json:"enabled,omitempty"`
+	TerminalStorageClass *Value[string] `tf:"terminal_storage_class" json:"terminal_storage_class,omitempty"`
 }
 
 // GoogleStorageBucketCors is a nested-block type used by the parent resource.
 type GoogleStorageBucketCors struct {
-	MaxAgeSeconds  *Value[int64]    `tf:"max_age_seconds"`
-	Method         []*Value[string] `tf:"method"`
-	Origin         []*Value[string] `tf:"origin"`
-	ResponseHeader []*Value[string] `tf:"response_header"`
+	MaxAgeSeconds  *Value[int64]    `tf:"max_age_seconds" json:"max_age_seconds,omitempty"`
+	Method         []*Value[string] `tf:"method" json:"method,omitempty"`
+	Origin         []*Value[string] `tf:"origin" json:"origin,omitempty"`
+	ResponseHeader []*Value[string] `tf:"response_header" json:"response_header,omitempty"`
 }
 
 // GoogleStorageBucketCustomPlacementConfig is a nested-block type used by the parent resource.
 type GoogleStorageBucketCustomPlacementConfig struct {
-	DataLocations []*Value[string] `tf:"data_locations"`
+	DataLocations []*Value[string] `tf:"data_locations" json:"data_locations,omitempty"`
 }
 
 // GoogleStorageBucketEncryption is a nested-block type used by the parent resource.
 type GoogleStorageBucketEncryption struct {
-	DefaultKMSKeyName *Value[string] `tf:"default_kms_key_name"`
+	DefaultKMSKeyName *Value[string] `tf:"default_kms_key_name" json:"default_kms_key_name,omitempty"`
 }
 
 // GoogleStorageBucketHierarchicalNamespace is a nested-block type used by the parent resource.
 type GoogleStorageBucketHierarchicalNamespace struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleStorageBucketLifecycleRule is a nested-block type used by the parent resource.
 type GoogleStorageBucketLifecycleRule struct {
-	Action    []GoogleStorageBucketLifecycleRuleAction    `tf:"action,blocks"`
-	Condition []GoogleStorageBucketLifecycleRuleCondition `tf:"condition,blocks"`
+	Action    []GoogleStorageBucketLifecycleRuleAction    `tf:"action,blocks" json:"action,omitempty"`
+	Condition []GoogleStorageBucketLifecycleRuleCondition `tf:"condition,blocks" json:"condition,omitempty"`
 }
 
 // GoogleStorageBucketLifecycleRuleAction is a nested-block type used by the parent resource.
 type GoogleStorageBucketLifecycleRuleAction struct {
-	StorageClass *Value[string] `tf:"storage_class"`
-	Type_        *Value[string] `tf:"type"`
+	StorageClass *Value[string] `tf:"storage_class" json:"storage_class,omitempty"`
+	Type_        *Value[string] `tf:"type" json:"type,omitempty"`
 }
 
 // GoogleStorageBucketLifecycleRuleCondition is a nested-block type used by the parent resource.
 type GoogleStorageBucketLifecycleRuleCondition struct {
-	Age                               *Value[float64]  `tf:"age"`
-	CreatedBefore                     *Value[string]   `tf:"created_before"`
-	CustomTimeBefore                  *Value[string]   `tf:"custom_time_before"`
-	DaysSinceCustomTime               *Value[float64]  `tf:"days_since_custom_time"`
-	DaysSinceNoncurrentTime           *Value[float64]  `tf:"days_since_noncurrent_time"`
-	MatchesPrefix                     []*Value[string] `tf:"matches_prefix"`
-	MatchesStorageClass               []*Value[string] `tf:"matches_storage_class"`
-	MatchesSuffix                     []*Value[string] `tf:"matches_suffix"`
-	NoncurrentTimeBefore              *Value[string]   `tf:"noncurrent_time_before"`
-	NumNewerVersions                  *Value[float64]  `tf:"num_newer_versions"`
-	SendAgeIfZero                     *Value[bool]     `tf:"send_age_if_zero"`
-	SendDaysSinceCustomTimeIfZero     *Value[bool]     `tf:"send_days_since_custom_time_if_zero"`
-	SendDaysSinceNoncurrentTimeIfZero *Value[bool]     `tf:"send_days_since_noncurrent_time_if_zero"`
-	SendNumNewerVersionsIfZero        *Value[bool]     `tf:"send_num_newer_versions_if_zero"`
-	WithState                         *Value[string]   `tf:"with_state"`
+	Age                               *Value[float64]  `tf:"age" json:"age,omitempty"`
+	CreatedBefore                     *Value[string]   `tf:"created_before" json:"created_before,omitempty"`
+	CustomTimeBefore                  *Value[string]   `tf:"custom_time_before" json:"custom_time_before,omitempty"`
+	DaysSinceCustomTime               *Value[float64]  `tf:"days_since_custom_time" json:"days_since_custom_time,omitempty"`
+	DaysSinceNoncurrentTime           *Value[float64]  `tf:"days_since_noncurrent_time" json:"days_since_noncurrent_time,omitempty"`
+	MatchesPrefix                     []*Value[string] `tf:"matches_prefix" json:"matches_prefix,omitempty"`
+	MatchesStorageClass               []*Value[string] `tf:"matches_storage_class" json:"matches_storage_class,omitempty"`
+	MatchesSuffix                     []*Value[string] `tf:"matches_suffix" json:"matches_suffix,omitempty"`
+	NoncurrentTimeBefore              *Value[string]   `tf:"noncurrent_time_before" json:"noncurrent_time_before,omitempty"`
+	NumNewerVersions                  *Value[float64]  `tf:"num_newer_versions" json:"num_newer_versions,omitempty"`
+	SendAgeIfZero                     *Value[bool]     `tf:"send_age_if_zero" json:"send_age_if_zero,omitempty"`
+	SendDaysSinceCustomTimeIfZero     *Value[bool]     `tf:"send_days_since_custom_time_if_zero" json:"send_days_since_custom_time_if_zero,omitempty"`
+	SendDaysSinceNoncurrentTimeIfZero *Value[bool]     `tf:"send_days_since_noncurrent_time_if_zero" json:"send_days_since_noncurrent_time_if_zero,omitempty"`
+	SendNumNewerVersionsIfZero        *Value[bool]     `tf:"send_num_newer_versions_if_zero" json:"send_num_newer_versions_if_zero,omitempty"`
+	WithState                         *Value[string]   `tf:"with_state" json:"with_state,omitempty"`
 }
 
 // GoogleStorageBucketLogging is a nested-block type used by the parent resource.
 type GoogleStorageBucketLogging struct {
-	LogBucket       *Value[string] `tf:"log_bucket"`
-	LogObjectPrefix *Value[string] `tf:"log_object_prefix"`
+	LogBucket       *Value[string] `tf:"log_bucket" json:"log_bucket,omitempty"`
+	LogObjectPrefix *Value[string] `tf:"log_object_prefix" json:"log_object_prefix,omitempty"`
 }
 
 // GoogleStorageBucketRetentionPolicy is a nested-block type used by the parent resource.
 type GoogleStorageBucketRetentionPolicy struct {
-	IsLocked        *Value[bool]  `tf:"is_locked"`
-	RetentionPeriod *Value[int64] `tf:"retention_period"`
+	IsLocked        *Value[bool]  `tf:"is_locked" json:"is_locked,omitempty"`
+	RetentionPeriod *Value[int64] `tf:"retention_period" json:"retention_period,omitempty"`
 }
 
 // GoogleStorageBucketSoftDeletePolicy is a nested-block type used by the parent resource.
 type GoogleStorageBucketSoftDeletePolicy struct {
-	EffectiveTime            *Value[string] `tf:"effective_time"`
-	RetentionDurationSeconds *Value[int64]  `tf:"retention_duration_seconds"`
+	EffectiveTime            *Value[string] `tf:"effective_time" json:"effective_time,omitempty"`
+	RetentionDurationSeconds *Value[int64]  `tf:"retention_duration_seconds" json:"retention_duration_seconds,omitempty"`
 }
 
 // GoogleStorageBucketTimeouts is a nested-block type used by the parent resource.
 type GoogleStorageBucketTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Read   *Value[string] `tf:"read"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Read   *Value[string] `tf:"read" json:"read,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleStorageBucketVersioning is a nested-block type used by the parent resource.
 type GoogleStorageBucketVersioning struct {
-	Enabled *Value[bool] `tf:"enabled"`
+	Enabled *Value[bool] `tf:"enabled" json:"enabled,omitempty"`
 }
 
 // GoogleStorageBucketWebsite is a nested-block type used by the parent resource.
 type GoogleStorageBucketWebsite struct {
-	MainPageSuffix *Value[string] `tf:"main_page_suffix"`
-	NotFoundPage   *Value[string] `tf:"not_found_page"`
+	MainPageSuffix *Value[string] `tf:"main_page_suffix" json:"main_page_suffix,omitempty"`
+	NotFoundPage   *Value[string] `tf:"not_found_page" json:"not_found_page,omitempty"`
 }
 
 // GoogleStorageBucketSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported/generated/google_vertex_ai_dataset.gen.go
+++ b/pkg/composer/imported/generated/google_vertex_ai_dataset.gen.go
@@ -7,31 +7,31 @@ import "reflect"
 // GoogleVertexAiDataset is the generated Layer 1 typed model for the
 // `google_vertex_ai_dataset` Terraform resource.
 type GoogleVertexAiDataset struct {
-	CreateTime        *Value[string]                        `tf:"create_time"`
-	DisplayName       *Value[string]                        `tf:"display_name"`
-	EffectiveLabels   map[string]*Value[string]             `tf:"effective_labels"`
-	ID                *Value[string]                        `tf:"id"`
-	Labels            map[string]*Value[string]             `tf:"labels"`
-	MetadataSchemaURI *Value[string]                        `tf:"metadata_schema_uri"`
-	Name              *Value[string]                        `tf:"name"`
-	Project           *Value[string]                        `tf:"project"`
-	Region            *Value[string]                        `tf:"region"`
-	TerraformLabels   map[string]*Value[string]             `tf:"terraform_labels"`
-	UpdateTime        *Value[string]                        `tf:"update_time"`
-	EncryptionSpec    []GoogleVertexAiDatasetEncryptionSpec `tf:"encryption_spec,blocks"`
-	Timeouts          *GoogleVertexAiDatasetTimeouts        `tf:"timeouts,block"`
+	CreateTime        *Value[string]                        `tf:"create_time" json:"create_time,omitempty"`
+	DisplayName       *Value[string]                        `tf:"display_name" json:"display_name,omitempty"`
+	EffectiveLabels   map[string]*Value[string]             `tf:"effective_labels" json:"effective_labels,omitempty"`
+	ID                *Value[string]                        `tf:"id" json:"id,omitempty"`
+	Labels            map[string]*Value[string]             `tf:"labels" json:"labels,omitempty"`
+	MetadataSchemaURI *Value[string]                        `tf:"metadata_schema_uri" json:"metadata_schema_uri,omitempty"`
+	Name              *Value[string]                        `tf:"name" json:"name,omitempty"`
+	Project           *Value[string]                        `tf:"project" json:"project,omitempty"`
+	Region            *Value[string]                        `tf:"region" json:"region,omitempty"`
+	TerraformLabels   map[string]*Value[string]             `tf:"terraform_labels" json:"terraform_labels,omitempty"`
+	UpdateTime        *Value[string]                        `tf:"update_time" json:"update_time,omitempty"`
+	EncryptionSpec    []GoogleVertexAiDatasetEncryptionSpec `tf:"encryption_spec,blocks" json:"encryption_spec,omitempty"`
+	Timeouts          *GoogleVertexAiDatasetTimeouts        `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // GoogleVertexAiDatasetEncryptionSpec is a nested-block type used by the parent resource.
 type GoogleVertexAiDatasetEncryptionSpec struct {
-	KMSKeyName *Value[string] `tf:"kms_key_name"`
+	KMSKeyName *Value[string] `tf:"kms_key_name" json:"kms_key_name,omitempty"`
 }
 
 // GoogleVertexAiDatasetTimeouts is a nested-block type used by the parent resource.
 type GoogleVertexAiDatasetTimeouts struct {
-	Create *Value[string] `tf:"create"`
-	Delete *Value[string] `tf:"delete"`
-	Update *Value[string] `tf:"update"`
+	Create *Value[string] `tf:"create" json:"create,omitempty"`
+	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // GoogleVertexAiDatasetSchema describes provider metadata for each attribute / nested

--- a/pkg/composer/imported_compose_test.go
+++ b/pkg/composer/imported_compose_test.go
@@ -44,7 +44,7 @@ func TestComposeStackWithIssues_ProvenanceTags(t *testing.T) {
 					Address: "aws_sqs_queue.q", ImportID: "https://sqs/.../q",
 				},
 				Tier:  imported.TierImportedFlat,
-				Attrs: []byte(`{"Name":{"Literal":"q"}}`),
+				Attrs: []byte(`{"name":{"literal":"q"}}`),
 			},
 		},
 	})
@@ -222,7 +222,7 @@ func TestComposeStackWithIssues_ProvenanceSkippedAdvisory(t *testing.T) {
 					Address: "aws_sqs_queue.q1", ImportID: "1",
 				},
 				Tier:  imported.TierImportedFlat,
-				Attrs: []byte(`{"Name":{"Literal":"q1"}}`),
+				Attrs: []byte(`{"name":{"literal":"q1"}}`),
 			},
 			{
 				Identity: imported.ResourceIdentity{
@@ -230,7 +230,7 @@ func TestComposeStackWithIssues_ProvenanceSkippedAdvisory(t *testing.T) {
 					Address: "aws_sqs_queue.q2", ImportID: "2",
 				},
 				Tier:  imported.TierImportedFlat,
-				Attrs: []byte(`{"Name":{"Literal":"q2"}}`),
+				Attrs: []byte(`{"name":{"literal":"q2"}}`),
 			},
 			{
 				Identity: imported.ResourceIdentity{
@@ -278,7 +278,7 @@ func TestComposeStackWithIssues_Imported_AWS(t *testing.T) {
 					ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders-DLQ",
 				},
 				Tier:  imported.TierImportedFlat,
-				Attrs: []byte(`{"Name":{"Literal":"orders-DLQ"}}`),
+				Attrs: []byte(`{"name":{"literal":"orders-DLQ"}}`),
 			},
 			{
 				Identity: imported.ResourceIdentity{
@@ -351,7 +351,7 @@ func TestComposeStackWithIssues_Imported_GCP(t *testing.T) {
 					ImportID: "projects/demo-project-12345/topics/events",
 				},
 				Tier:  imported.TierImportedFlat,
-				Attrs: []byte(`{"Name":{"Literal":"events"}}`),
+				Attrs: []byte(`{"name":{"literal":"events"}}`),
 			},
 		},
 	})

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -40,7 +40,7 @@ func TestEmitImportedTF_TypedAWS(t *testing.T) {
 			ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders-DLQ",
 		},
 		Tier:  imported.TierImportedFlat,
-		Attrs: []byte(`{"Name":{"Literal":"orders-DLQ"},"FIFOQueue":{"Literal":false}}`),
+		Attrs: []byte(`{"name":{"literal":"orders-DLQ"},"fifo_queue":{"literal":false}}`),
 	}
 	out, used := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
 	require.NotNil(t, out)
@@ -70,7 +70,7 @@ func TestEmitImportedTF_TypedGCP(t *testing.T) {
 			ImportID: "projects/my-project/topics/events",
 		},
 		Tier:  imported.TierImportedFlat,
-		Attrs: []byte(`{"Name":{"Literal":"events"}}`),
+		Attrs: []byte(`{"name":{"literal":"events"}}`),
 	}
 	out, used := EmitImportedTF("gcp", []imported.ImportedResource{ir}, EmitImportedOpts{})
 	require.NotNil(t, out)
@@ -270,12 +270,12 @@ func TestEmitImportedTF_CloudFiltering(t *testing.T) {
 		{
 			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.x", ImportID: "x"},
 			Tier:     imported.TierImportedFlat,
-			Attrs:    []byte(`{"Name":{"Literal":"x"}}`),
+			Attrs:    []byte(`{"name":{"literal":"x"}}`),
 		},
 		{
 			Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_pubsub_topic", Address: "google_pubsub_topic.y", ImportID: "y"},
 			Tier:     imported.TierImportedFlat,
-			Attrs:    []byte(`{"Name":{"Literal":"y"}}`),
+			Attrs:    []byte(`{"name":{"literal":"y"}}`),
 		},
 	}
 	out, used := EmitImportedTF("aws", irs, EmitImportedOpts{})
@@ -292,7 +292,7 @@ func TestEmitImportedTF_DeterministicOrder(t *testing.T) {
 		return imported.ImportedResource{
 			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: addr, ImportID: importID},
 			Tier:     imported.TierImportedFlat,
-			Attrs:    []byte(`{"Name":{"Literal":"x"}}`),
+			Attrs:    []byte(`{"name":{"literal":"x"}}`),
 		}
 	}
 	// Adversarial set: prefix-overlapping addresses ("b", "b_1"),
@@ -470,7 +470,7 @@ func TestEmitImportedTF_TypedDecodeFailureDropsRecord(t *testing.T) {
 			Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.good", ImportID: "good",
 		},
 		Tier:  imported.TierImportedFlat,
-		Attrs: []byte(`{"Name":{"Literal":"good"}}`),
+		Attrs: []byte(`{"name":{"literal":"good"}}`),
 	}
 	bad := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{
@@ -624,17 +624,17 @@ func TestEmitImportedTF_ProvenanceTags(t *testing.T) {
 	awsIR := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "x"},
 		Tier:     imported.TierImportedFlat,
-		Attrs:    []byte(`{"Name":{"Literal":"q"}}`),
+		Attrs:    []byte(`{"name":{"literal":"q"}}`),
 	}
 	gcpIR := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_storage_bucket", Address: "google_storage_bucket.b", ImportID: "b"},
 		Tier:     imported.TierImportedFlat,
-		Attrs:    []byte(`{"Name":{"Literal":"b"}}`),
+		Attrs:    []byte(`{"name":{"literal":"b"}}`),
 	}
 	gcpVPC := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_compute_network", Address: "google_compute_network.vpc", ImportID: "vpc"},
 		Tier:     imported.TierImportedFlat,
-		Attrs:    []byte(`{"Name":{"Literal":"vpc"}}`),
+		Attrs:    []byte(`{"name":{"literal":"vpc"}}`),
 	}
 
 	opts := EmitImportedOpts{
@@ -674,7 +674,7 @@ func TestEmitImportedTF_ProvenanceDisabled(t *testing.T) {
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "x"},
 		Tier:     imported.TierImportedFlat,
-		Attrs:    []byte(`{"Name":{"Literal":"q"}}`),
+		Attrs:    []byte(`{"name":{"literal":"q"}}`),
 	}
 	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
 	s := string(out)

--- a/pkg/composer/imported_provenance_test.go
+++ b/pkg/composer/imported_provenance_test.go
@@ -128,7 +128,7 @@ func TestInjectProvenance_AWSTypedAttrsExisting(t *testing.T) {
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q"},
 		Tier:     imported.TierImportedFlat,
-		Attrs:    []byte(`{"Name":{"Literal":"q"},"Tags":{"Owner":{"Literal":"team-payments"}}}`),
+		Attrs:    []byte(`{"name":{"literal":"q"},"tags":{"Owner":{"literal":"team-payments"}}}`),
 	}
 	body, _, err := emitTestBody(t, ir)
 	require.NoError(t, err)
@@ -154,7 +154,7 @@ func TestInjectProvenance_GCPTypedAttrsExisting(t *testing.T) {
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_storage_bucket", Address: "google_storage_bucket.docs"},
 		Tier:     imported.TierImportedFlat,
-		Attrs:    []byte(`{"Name":{"Literal":"docs"},"Labels":{"team":{"Literal":"docs"}}}`),
+		Attrs:    []byte(`{"name":{"literal":"docs"},"labels":{"team":{"literal":"docs"}}}`),
 	}
 	body, _, err := emitTestBody(t, ir)
 	require.NoError(t, err)
@@ -323,7 +323,7 @@ func TestInjectProvenance_GCPUntaggableType(t *testing.T) {
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_compute_network", Address: "google_compute_network.vpc"},
 		Tier:     imported.TierImportedFlat,
-		Attrs:    []byte(`{"Name":{"Literal":"vpc"}}`),
+		Attrs:    []byte(`{"name":{"literal":"vpc"}}`),
 	}
 	body, _, err := emitTestBody(t, ir)
 	require.NoError(t, err)
@@ -338,7 +338,7 @@ func TestInjectProvenance_NoExistingTags(t *testing.T) {
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q"},
 		Tier:     imported.TierImportedFlat,
-		Attrs:    []byte(`{"Name":{"Literal":"q"}}`),
+		Attrs:    []byte(`{"name":{"literal":"q"}}`),
 	}
 	body, _, err := emitTestBody(t, ir)
 	require.NoError(t, err)
@@ -383,7 +383,7 @@ func TestInjectProvenance_Deterministic(t *testing.T) {
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q"},
 		Tier:     imported.TierImportedFlat,
-		Attrs:    []byte(`{"Name":{"Literal":"q"}}`),
+		Attrs:    []byte(`{"name":{"literal":"q"}}`),
 	}
 	body, _, err := emitTestBody(t, ir)
 	require.NoError(t, err)
@@ -406,7 +406,7 @@ func TestInjectProvenance_DoubleInjectionNests(t *testing.T) {
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q"},
 		Tier:     imported.TierImportedFlat,
-		Attrs:    []byte(`{"Name":{"Literal":"q"}}`),
+		Attrs:    []byte(`{"name":{"literal":"q"}}`),
 	}
 	body, _, err := emitTestBody(t, ir)
 	require.NoError(t, err)

--- a/pkg/composer/imported_validate_test.go
+++ b/pkg/composer/imported_validate_test.go
@@ -384,7 +384,7 @@ func TestValidateProvenanceConflicts_GCPTagFromTypedAttrs(t *testing.T) {
 		{
 			Identity: imported.ResourceIdentity{Cloud: "gcp", Type: "google_storage_bucket", Address: "google_storage_bucket.b", ImportID: "b"},
 			Tier:     imported.TierImportedFlat,
-			Attrs:    []byte(`{"Name":{"Literal":"b"},"Labels":{"insideout-import-project":{"Literal":"io-other"}}}`),
+			Attrs:    []byte(`{"name":{"literal":"b"},"labels":{"insideout-import-project":{"literal":"io-other"}}}`),
 		},
 	}
 	issues := ValidateProvenanceConflicts("gcp", irs, ProvenanceOpts{ImportProjectID: "io-1"})

--- a/pkg/imported/aws/provider_test.go
+++ b/pkg/imported/aws/provider_test.go
@@ -63,9 +63,16 @@ func TestProvider_Capabilities_Enrichable(t *testing.T) {
 	if got := p.Capabilities("aws_dynamodb_table"); !got.Enrichable {
 		t.Errorf("aws_dynamodb_table: Enrichable should be true, got %+v", got)
 	}
-	// aws_vpc is in the registry but has no enricher yet — Enrichable=false.
-	if got := p.Capabilities("aws_vpc"); got.Enrichable {
-		t.Errorf("aws_vpc: Enrichable should be false (no enricher), got %+v", got)
+	// aws_apigatewayv2_stage is a Bucket-C hand-rolled discoverer that
+	// is NOT in cloudControlTypeConfigs (CC returns
+	// UnsupportedActionException for AWS::ApiGatewayV2::Stage READ) and
+	// has no hand-rolled AttributeEnricher today, so it is the
+	// canonical "registered for discovery, not enriched" sample.
+	// Replaced the prior aws_vpc reference after #490 wired a generic
+	// cloudControlEnricher to every CC-routed type — aws_vpc now has a
+	// (generic) enricher.
+	if got := p.Capabilities("aws_apigatewayv2_stage"); got.Enrichable {
+		t.Errorf("aws_apigatewayv2_stage: Enrichable should be false (no enricher), got %+v", got)
 	}
 	// Unknown type: all flags false.
 	if got := p.Capabilities("aws_bogus_unknown"); got.Discoverable || got.Enrichable {
@@ -229,8 +236,13 @@ func TestProvider_EnrichByID_NoEnricher(t *testing.T) {
 	d := awsdiscover.NewAWSDiscoverer(awssdk.Config{})
 	p := awsprov.NewProvider(d, nil)
 
-	// aws_vpc has no enricher registered → ErrEnrichByIDNotImplemented.
-	id := &composerimported.ResourceIdentity{Type: "aws_vpc", ImportID: "vpc-123"}
+	// aws_apigatewayv2_stage is a Bucket-C hand-rolled discoverer that
+	// has no AttributeEnricher today (and is not in
+	// cloudControlTypeConfigs, so #490's generic CC enricher loop does
+	// not register one either) → ErrEnrichByIDNotImplemented.
+	// Replaced the prior aws_vpc reference after #490 wired a generic
+	// cloudControlEnricher for every CC-routed type.
+	id := &composerimported.ResourceIdentity{Type: "aws_apigatewayv2_stage", ImportID: "api/stage"}
 	_, err := p.EnrichByID(context.Background(), id, imp.Clients{AWS: awsprov.Clients{}})
 	if !errors.Is(err, imp.ErrEnrichByIDNotImplemented) {
 		t.Errorf("EnrichByID for non-enriched type: err = %v, want ErrEnrichByIDNotImplemented", err)


### PR DESCRIPTION
## Summary

HYBRID-adoption portion of #490 (unified Cloud Control AWS enricher) — **steps 1+2 only**. Steps 3 (Normalizer hooks) and 4 (retire hand-rolled overrides) are deferred to follow-up issues.

- **Step 1 — `json:` tags on every generated Layer-1 field.** Extends the `imported-codegen` template to emit `json:\"<snake_name>,omitempty\"` alongside the existing `tf:\"<snake_name>\"`. Without the json tags, JSON marshal/unmarshal on the generated structs pivots on Go field names (e.g. `FIFOQueue`), which forced any caller decoding a CloudFormation-shaped payload to project through a reflection workaround (see PoC in `.tmp/cloud-control-enricher-poc.{go,md}`). With the tags, the canonical wire format is lowercase snake_case keys matching the Terraform attribute names.
- **Step 2 — generic `cloudControlEnricher`** type that implements both `AttributeEnricher` and `ByIDEnricher`. Calls `cloudcontrol.GetResource`, unmarshals the Properties JSON (CFN schema shape) into the matching `generated.AWS<Type>` struct via a CamelCase→snake_case + literal-envelope transform, then re-marshals into `ir.Attrs`. `NewAWSDiscoverer` registers one `cloudControlEnricher` per entry in `cloudControlTypeConfigs` that doesn't already have a hand-rolled override (3 today: `cloudwatch_log_group`, `dynamodb_table`, `secretsmanager_secret`). Hand-rolled enrichers win as overrides.

## Coverage delta

| | Before | After |
|--|--|--|
| AWS types enriched | 3/109 (3%) | ~94/109 (86%) |
| Hand-rolled overrides preserved | 3 | 3 |
| Generic CC enrichers registered | 0 | 91 |

The PoC quantified per-type quality at **57% exact field match** on `aws_cloudwatch_log_group`. Types whose primary-name property differs from the TF attribute (`LogGroupName`→`name`, `BucketName`→`bucket`, …) and fields whose CFN values need normalization (e.g. trailing-`:*` strip on log-group ARN) are silently absent on the enriched payload today. Step 3 (Normalizer hooks) closes the remaining 43% gap.

## Wire-format change

Pinning tests across `pkg/composer/imported_*_test.go` were hard-coded to the old Go-field-name JSON keys (`{\"Name\":{\"Literal\":...}}`). Updated to the canonical snake_case + lowercase-literal form (`{\"name\":{\"literal\":...}}`). The HCL round-trip path (`UnmarshalAttrs → MarshalHCL`) is unaffected — the marshaling pivots on the `tf:` tag, which is unchanged.

## What this PR does NOT do

- **Step 3 — Normalizer hooks.** No `cloudControlConfig.Normalizer` field, no shared `renameIdentifierField` / `flattenTagList` / `trimARNStar` helpers. Tracked in a follow-up issue (filed alongside this PR).
- **Step 4 — Retire hand-rolled enrichers.** Explicit no-op for this PR. The 3 hand-rolled enrichers (`dynamodb_table`, `cloudwatch_log_group`, `secretsmanager_secret`) continue to win as overrides and produce higher-fidelity payloads than the generic CC path.

## Checklist (from #490)

- [x] Step 1 — `json:` tags on every generated Layer-1 field (cmd/imported-codegen template + 53 .gen.go regen)
- [x] Step 2 — `cloudControlEnricher` type + `EnrichClients.CloudControl` field + `NewAWSDiscoverer` wiring loop
- [ ] Step 3 — Normalizer hooks (deferred to follow-up issue)
- [ ] Step 4 — Retire hand-rolled overrides (deferred to follow-up issue)

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -count=1 -short` — 5258 passed
- [x] `go test -race ./cmd/insideout-import/awsdiscover/... ./pkg/composer/... -count=1 -short` — clean
- [x] `go vet ./...` — no issues
- [x] `make verify-gen` — generated files regenerate identically (passes after commit)
- [x] New unit coverage: `cloudcontrol_enricher_test.go` (camel→snake renamer, shape transform, full Enrich flow, NotFound soft-fail, nil-client downgrade, EnrichByID parity, unknown-TF-type wiring guard, snake-case wire-format pin)
- [x] Updated `byid_enricher_test.go` to assert the override-wins invariant and full CC coverage

Refs #490