### PR TITLE
feat(imported): DriftSemantic Bundle D2 — 5 more policy files

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -22,8 +22,8 @@ and is checked in lockstep with the runtime registries. See the
 
 ## Summary
 
-- **AWS:** 109 types · 100% Discoverable · 86% Enrichable · 3% DriftDetectable · 0% MetricsAvailable · 6% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 13% Enrichable · 4% DriftDetectable · 0% MetricsAvailable · 65% AgentEditable
+- **AWS:** 109 types · 100% Discoverable · 86% Enrichable · 6% DriftDetectable · 0% MetricsAvailable · 6% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 13% Enrichable · 7% DriftDetectable · 0% MetricsAvailable · 65% AgentEditable
 
 ## AWS
 
@@ -53,7 +53,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_cloudfront_origin_access_identity` | ✓ | ✓ | – | – | – |
 | `aws_cloudwatch_dashboard` | ✓ | ✓ | – | – | – |
 | `aws_cloudwatch_event_rule` | ✓ | ✓ | – | – | – |
-| `aws_cloudwatch_log_group` | ✓ | ✓ | – | – | ✓ |
+| `aws_cloudwatch_log_group` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_cloudwatch_log_resource_policy` | ✓ | ✓ | – | – | – |
 | `aws_cloudwatch_log_stream` | ✓ | ✓ | – | – | – |
 | `aws_cloudwatch_metric_alarm` | ✓ | ✓ | – | – | – |
@@ -122,13 +122,13 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_s3_bucket_public_access_block` | ✓ | – | – | – | – |
 | `aws_s3_bucket_server_side_encryption_configuration` | ✓ | – | – | – | – |
 | `aws_s3_bucket_versioning` | ✓ | – | – | – | – |
-| `aws_secretsmanager_secret` | ✓ | ✓ | – | – | ✓ |
+| `aws_secretsmanager_secret` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_secretsmanager_secret_rotation` | ✓ | ✓ | – | – | – |
 | `aws_security_group` | ✓ | ✓ | – | – | – |
 | `aws_service_discovery_private_dns_namespace` | ✓ | – | – | – | – |
 | `aws_sns_topic` | ✓ | ✓ | – | – | – |
 | `aws_sns_topic_subscription` | ✓ | ✓ | – | – | – |
-| `aws_sqs_queue` | ✓ | ✓ | – | – | ✓ |
+| `aws_sqs_queue` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_ssm_parameter` | ✓ | ✓ | – | – | – |
 | `aws_subnet` | ✓ | ✓ | – | – | – |
 | `aws_vpc` | ✓ | ✓ | – | – | – |
@@ -160,7 +160,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_health_check` | ✓ | – | – | – | – |
 | `google_compute_instance` | ✓ | – | – | – | ✓ |
 | `google_compute_managed_ssl_certificate` | ✓ | – | – | – | – |
-| `google_compute_network` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_network` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_resource_policy` | ✓ | – | – | – | – |
 | `google_compute_router` | ✓ | – | – | – | ✓ |
 | `google_compute_security_policy` | ✓ | – | – | – | ✓ |
@@ -184,7 +184,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_pubsub_subscription` | ✓ | ✓ | – | – | ✓ |
 | `google_pubsub_topic` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_redis_instance` | ✓ | – | – | – | ✓ |
-| `google_secret_manager_secret` | ✓ | ✓ | – | – | ✓ |
+| `google_secret_manager_secret` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_secret_manager_secret_iam_binding` | ✓ | – | – | – | – |
 | `google_secret_manager_secret_iam_member` | ✓ | – | – | – | – |
 | `google_secret_manager_secret_version` | ✓ | – | – | – | – |

--- a/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
+++ b/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
@@ -1,4 +1,30 @@
 {
+  "aws_cloudwatch_log_group": [
+    {
+      "path": "arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "kms_key_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "log_group_class",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "retention_in_days",
+      "semantic": "Exact"
+    },
+    {
+      "path": "skip_destroy",
+      "semantic": "Exact"
+    }
+  ],
   "aws_dynamodb_table": [
     {
       "path": "arn",
@@ -429,6 +455,148 @@
       "semantic": "Exact"
     }
   ],
+  "aws_secretsmanager_secret": [
+    {
+      "path": "arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "kms_key_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "policy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "recovery_window_in_days",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replica.kms_key_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replica.region",
+      "semantic": "Exact"
+    }
+  ],
+  "aws_sqs_queue": [
+    {
+      "path": "arn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "content_based_deduplication",
+      "semantic": "Exact"
+    },
+    {
+      "path": "delay_seconds",
+      "semantic": "Exact"
+    },
+    {
+      "path": "fifo_queue",
+      "semantic": "Exact"
+    },
+    {
+      "path": "kms_master_key_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "max_message_size",
+      "semantic": "Exact"
+    },
+    {
+      "path": "message_retention_seconds",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "receive_wait_time_seconds",
+      "semantic": "Exact"
+    },
+    {
+      "path": "redrive_policy.deadLetterTargetArn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "redrive_policy.maxReceiveCount",
+      "semantic": "Exact"
+    },
+    {
+      "path": "sqs_managed_sse_enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "visibility_timeout_seconds",
+      "semantic": "Exact"
+    }
+  ],
+  "google_compute_network": [
+    {
+      "path": "auto_create_subnetworks",
+      "semantic": "Exact"
+    },
+    {
+      "path": "delete_default_routes_on_create",
+      "semantic": "Exact"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "enable_ula_internal_ipv6",
+      "semantic": "Exact"
+    },
+    {
+      "path": "gateway_ipv4",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "mtu",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "network_firewall_policy_enforcement_order",
+      "semantic": "Exact"
+    },
+    {
+      "path": "numeric_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "routing_mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    }
+  ],
   "google_pubsub_topic": [
     {
       "path": "id",
@@ -496,6 +664,60 @@
     },
     {
       "path": "schema_settings.schema",
+      "semantic": "Exact"
+    }
+  ],
+  "google_secret_manager_secret": [
+    {
+      "path": "expire_time",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replication.auto.customer_managed_encryption.kms_key_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replication.user_managed.replicas.customer_managed_encryption.kms_key_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replication.user_managed.replicas.location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "rotation.next_rotation_time",
+      "semantic": "Exact"
+    },
+    {
+      "path": "rotation.rotation_period",
+      "semantic": "Exact"
+    },
+    {
+      "path": "secret_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "topics.name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ttl",
+      "semantic": "Exact"
+    },
+    {
+      "path": "version_destroy_ttl",
       "semantic": "Exact"
     }
   ],

--- a/pkg/composer/imported/policy/aws_cloudwatch_log_group.policy.go
+++ b/pkg/composer/imported/policy/aws_cloudwatch_log_group.policy.go
@@ -1,27 +1,46 @@
 package policy
 
+// awsCloudwatchLogGroupPolicy curates Layer 2 for `aws_cloudwatch_log_group`.
+//
+// Bundle D2 (#491): DriftSemantic axis is curated on every non-tag entry.
+// All curated leaves are scalar (ARN, name, KMS key ARN, retention days,
+// log group class, skip_destroy bool) — DriftSemanticExact is the
+// meaningful comparison. There are no list-valued or map-valued curated
+// fields here, so WholeList / LabelFilter do not apply. Tag bags stay
+// DriftSemanticNone (tagPolicy() zero value) — provider noise on tags is
+// filtered at a higher layer.
 var awsCloudwatchLogGroupPolicy = Map{
 	// Identity
-	"arn":  {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"arn": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 
 	// Wiring
 	"kms_key_id": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"retention_in_days": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"log_group_class": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
-		ChangeRisk: ChangeMayReplace,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"skip_destroy": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"tags":     tagPolicy(),

--- a/pkg/composer/imported/policy/aws_secretsmanager_secret.policy.go
+++ b/pkg/composer/imported/policy/aws_secretsmanager_secret.policy.go
@@ -1,38 +1,65 @@
 package policy
 
+// awsSecretsmanagerSecretPolicy curates Layer 2 for `aws_secretsmanager_secret`.
+//
+// Bundle D2 (#491): DriftSemantic axis is curated on every non-tag,
+// non-timeouts entry. All curated fields here are metadata about the
+// secret (ARN/name identity, KMS encryption wiring, replication targets,
+// IAM resource policy, recovery window, description) — none of them
+// carry the secret material itself. The actual secret payload lives on
+// `aws_secretsmanager_secret_version.secret_string` (a separate
+// resource) and is not curated in this map, so the Sensitive-leak
+// concern that gates `aws_lambda_function.environment.variables` does
+// not arise. All curated leaves are scalar; DriftSemanticExact is the
+// meaningful comparison for each. Tag bags stay DriftSemanticNone
+// (tagPolicy() zero value).
 var awsSecretsmanagerSecretPolicy = Map{
 	// Identity
-	"arn":  {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
+	"arn": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 
 	// Wiring (encryption + replication targets)
 	"kms_key_id": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"replica.region": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"replica.kms_key_id": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"recovery_window_in_days": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Resource policy is an IAM JSON document — visible to the interactive
 	// agent but each change requires explicit confirmation against the plan.
+	// Exact comparison surfaces canonicalization-induced churn intentionally;
+	// the diff screen renders the doc with structural diff.
 	"policy": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"tags":     tagPolicy(),

--- a/pkg/composer/imported/policy/aws_sqs_queue.policy.go
+++ b/pkg/composer/imported/policy/aws_sqs_queue.policy.go
@@ -4,51 +4,78 @@ package policy
 // docs/managed-resource-tiers.md "Layer 2 — hand-curated field policy
 // map" verbatim, with arn added as a UI-visible identity attribute and
 // the JSON projection rules registered for redrive_policy subpaths.
+//
+// Bundle D2 (#491): DriftSemantic axis is curated on every non-tag
+// entry. All curated leaves are scalar — DriftSemanticExact is the
+// meaningful comparison for each.
+//
+// Note: the redrive_policy.* paths declare the intended drift semantic
+// but will not surface a signal through the current pkg/drift/imported
+// comparator because redrive_policy is a JSON-encoded string in state
+// (see projection.go limitation note — the comparator's resolvePath
+// walks map nodes, not JSON-encoded string parents). The DriftSemantic
+// declaration is intentionally still curated here so when the
+// comparator gains JSON-projection traversal (parallel to the
+// projection.go follow-up), these paths light up without a re-curation
+// sweep. Tag bags stay DriftSemanticNone (tagPolicy() zero value).
 var awsSQSQueuePolicy = Map{
 	"arn": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"name": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"kms_master_key_id": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"redrive_policy.deadLetterTargetArn": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"redrive_policy.maxReceiveCount": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"sqs_managed_sse_enabled": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
 		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"visibility_timeout_seconds": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"delay_seconds": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"receive_wait_time_seconds": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"message_retention_seconds": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"max_message_size": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"fifo_queue": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"content_based_deduplication": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"tags":     tagPolicy(),
 	"tags_all": tagPolicy(),

--- a/pkg/composer/imported/policy/google_compute_network.policy.go
+++ b/pkg/composer/imported/policy/google_compute_network.policy.go
@@ -1,45 +1,73 @@
 package policy
 
+// googleComputeNetworkPolicy curates Layer 2 for `google_compute_network`.
+//
+// Bundle D2 (#491): DriftSemantic axis is curated on every non-timeouts
+// entry. All curated leaves are scalar (network identity, routing knobs,
+// MTU, boolean flags, description) — DriftSemanticExact is the
+// meaningful comparison for each. `google_compute_network` has no
+// labels and no list-valued curated fields, so neither WholeList nor
+// LabelFilter applies. The `timeouts` singleton is system-owned
+// operational metadata and stays DriftSemanticNone via timeoutsPolicy().
 var googleComputeNetworkPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"numeric_id": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"gateway_ipv4": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — networking semantics
 	"auto_create_subnetworks": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"routing_mode": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"mtu": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"delete_default_routes_on_create": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"enable_ula_internal_ipv6": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"network_firewall_policy_enforcement_order": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// google_compute_network has no labels and no timeouts on the

--- a/pkg/composer/imported/policy/google_secret_manager_secret.policy.go
+++ b/pkg/composer/imported/policy/google_secret_manager_secret.policy.go
@@ -1,51 +1,87 @@
 package policy
 
+// googleSecretManagerSecretPolicy curates Layer 2 for
+// `google_secret_manager_secret`.
+//
+// Bundle D2 (#491): DriftSemantic axis is curated on every non-label,
+// non-timeouts entry. As with `aws_secretsmanager_secret`, all curated
+// fields here are metadata (identity, replication wiring, rotation
+// schedule); the secret material lives on
+// `google_secret_manager_secret_version.secret_data` (a separate
+// resource) and is not curated here, so the Sensitive-leak concern
+// that gates `aws_lambda_function.environment.variables` does not
+// arise. All curated leaves are scalar — DriftSemanticExact applies
+// uniformly. Label and annotation bags stay DriftSemanticNone
+// (tagPolicy() zero value); user-author label LabelFilter coverage
+// is deferred to the comparator's redacted-mode follow-up (axes.go).
 var googleSecretManagerSecretPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"secret_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"secret_id": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — replication targets and CMEK
 	"replication.auto.customer_managed_encryption.kms_key_name": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"replication.user_managed.replicas.location": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"replication.user_managed.replicas.customer_managed_encryption.kms_key_name": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"topics.name": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — lifecycle / rotation knobs
 	"expire_time": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ttl": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"version_destroy_ttl": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"rotation.rotation_period": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"rotation.next_rotation_time": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
-	// Labels and annotations — system-owned.
+	// Labels and annotations — system-owned. DriftSemantic stays None
+	// (tagPolicy() zero value); user-author label drift coverage is the
+	// LabelFilter follow-up tracked alongside the axes.go redacted-mode
+	// work.
 	"labels":                tagPolicy(),
 	"effective_labels":      tagPolicy(),
 	"terraform_labels":      tagPolicy(),

--- a/pkg/drift/imported/compare_curated_test.go
+++ b/pkg/drift/imported/compare_curated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Bundle D1 (#491) curated-policy fixture tests.
+// Bundle D1 + D2 (#491) curated-policy fixture tests.
 //
 // These tests exercise the production policy.Map entries registered for
 // the five tfTypes in the bundle, end-to-end through Compare(). Each
@@ -260,6 +260,221 @@ func TestCompare_Curated_GooglePubsubTopic(t *testing.T) {
 
 	// kms_key_name is identical on both sides → not in drift output.
 	assert.NotContains(t, idx, "kms_key_name")
+}
+
+// --- Bundle D2 (#491) ------------------------------------------------
+
+// TestCompare_Curated_AWSCloudwatchLogGroup_Exact exercises an Exact
+// retention drift on aws_cloudwatch_log_group. Tag drift must stay
+// invisible (tagPolicy() leaves DriftSemantic=None).
+func TestCompare_Curated_AWSCloudwatchLogGroup_Exact(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"arn": "arn:aws:logs:us-east-1:111:log-group:/aws/lambda/fn:*",
+		"name": "/aws/lambda/fn",
+		"kms_key_id": "arn:aws:kms:us-east-1:111:key/abc",
+		"retention_in_days": 14,
+		"log_group_class": "STANDARD",
+		"skip_destroy": false,
+		"tags": {"team": "infra"}
+	}`)
+	live := json.RawMessage(`{
+		"arn": "arn:aws:logs:us-east-1:111:log-group:/aws/lambda/fn:*",
+		"name": "/aws/lambda/fn",
+		"kms_key_id": "arn:aws:kms:us-east-1:111:key/abc",
+		"retention_in_days": 90,
+		"log_group_class": "STANDARD",
+		"skip_destroy": false,
+		"tags": {"team": "platform"}
+	}`)
+	got := Compare("aws_cloudwatch_log_group", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "retention_in_days",
+		"expected retention_in_days mismatch; got fields: %v", keysOf(idx))
+	assert.Equal(t, float64(14), idx["retention_in_days"].Snapshot)
+	assert.Equal(t, float64(90), idx["retention_in_days"].Cloud)
+
+	// kms_key_id is identical → no mismatch.
+	assert.NotContains(t, idx, "kms_key_id")
+	// tags use tagPolicy() (DriftSemantic=None) → never emitted.
+	assert.NotContains(t, idx, "tags")
+}
+
+// TestCompare_Curated_AWSSecretsmanagerSecret_Exact exercises an Exact
+// drift on the rotation-window knob and confirms the resource policy
+// JSON document diff also surfaces. The secret payload lives on a
+// separate resource (aws_secretsmanager_secret_version) and is not
+// curated on this map, so no Sensitive-leak path applies here.
+func TestCompare_Curated_AWSSecretsmanagerSecret_Exact(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"arn": "arn:aws:secretsmanager:us-east-1:111:secret:db-creds-AbCdEf",
+		"name": "db-creds",
+		"kms_key_id": "arn:aws:kms:us-east-1:111:key/abc",
+		"description": "primary db credentials",
+		"recovery_window_in_days": 30,
+		"policy": "{\"Version\":\"2012-10-17\",\"Statement\":[]}",
+		"tags": {"team": "infra"}
+	}`)
+	live := json.RawMessage(`{
+		"arn": "arn:aws:secretsmanager:us-east-1:111:secret:db-creds-AbCdEf",
+		"name": "db-creds",
+		"kms_key_id": "arn:aws:kms:us-east-1:111:key/abc",
+		"description": "primary db credentials",
+		"recovery_window_in_days": 7,
+		"policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"*\"}]}",
+		"tags": {"team": "infra"}
+	}`)
+	got := Compare("aws_secretsmanager_secret", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "recovery_window_in_days")
+	assert.Equal(t, float64(30), idx["recovery_window_in_days"].Snapshot)
+	assert.Equal(t, float64(7), idx["recovery_window_in_days"].Cloud)
+
+	require.Contains(t, idx, "policy",
+		"expected resource-policy JSON diff to surface as an Exact mismatch")
+
+	// Identity / wiring values are equal → no mismatch.
+	assert.NotContains(t, idx, "kms_key_id")
+	assert.NotContains(t, idx, "arn")
+}
+
+// TestCompare_Curated_AWSSQSQueue_Exact exercises an Exact drift on a
+// flat scalar (visibility_timeout_seconds) and confirms the equal
+// kms_master_key_id wiring leaf does not surface. The redrive_policy.*
+// JSON-projection paths intentionally do not produce a signal through
+// the current comparator (see policy file comment) — this test pins
+// that observable behavior so a future projection-aware comparator
+// refactor surfaces here as an intentional diff.
+func TestCompare_Curated_AWSSQSQueue_Exact(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"arn": "arn:aws:sqs:us-east-1:111:work-queue",
+		"name": "work-queue",
+		"kms_master_key_id": "alias/aws/sqs",
+		"visibility_timeout_seconds": 30,
+		"delay_seconds": 0,
+		"message_retention_seconds": 345600,
+		"max_message_size": 262144,
+		"fifo_queue": false,
+		"content_based_deduplication": false,
+		"redrive_policy": "{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:111:dlq\",\"maxReceiveCount\":5}",
+		"tags": {"team": "infra"}
+	}`)
+	live := json.RawMessage(`{
+		"arn": "arn:aws:sqs:us-east-1:111:work-queue",
+		"name": "work-queue",
+		"kms_master_key_id": "alias/aws/sqs",
+		"visibility_timeout_seconds": 120,
+		"delay_seconds": 0,
+		"message_retention_seconds": 345600,
+		"max_message_size": 262144,
+		"fifo_queue": false,
+		"content_based_deduplication": false,
+		"redrive_policy": "{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:111:dlq\",\"maxReceiveCount\":5}",
+		"tags": {"team": "infra"}
+	}`)
+	got := Compare("aws_sqs_queue", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "visibility_timeout_seconds")
+	assert.Equal(t, float64(30), idx["visibility_timeout_seconds"].Snapshot)
+	assert.Equal(t, float64(120), idx["visibility_timeout_seconds"].Cloud)
+
+	// Wiring / identity equal → no mismatch.
+	assert.NotContains(t, idx, "kms_master_key_id")
+	assert.NotContains(t, idx, "arn")
+
+	// JSON-projection paths: the parent is a JSON-encoded string, not a
+	// nested map. Pin current behavior — these do not surface today.
+	assert.NotContains(t, idx, "redrive_policy.deadLetterTargetArn",
+		"redrive_policy JSON projection should not surface through the "+
+			"current comparator; if this fails, projection-aware traversal "+
+			"has landed and the policy file comment needs updating")
+	assert.NotContains(t, idx, "redrive_policy.maxReceiveCount")
+}
+
+// TestCompare_Curated_GoogleSecretManagerSecret_Exact exercises an
+// Exact drift on the rotation-period knob and confirms that label
+// drift stays invisible (tagPolicy() leaves DriftSemantic=None). As
+// with the AWS counterpart, the secret payload lives on a separate
+// resource (google_secret_manager_secret_version) — no
+// Sensitive-leak path applies here.
+func TestCompare_Curated_GoogleSecretManagerSecret_Exact(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"name": "projects/p/secrets/api-key",
+		"secret_id": "api-key",
+		"project": "p",
+		"rotation": {
+			"rotation_period": "2592000s",
+			"next_rotation_time": "2026-06-01T00:00:00Z"
+		},
+		"ttl": "7776000s",
+		"labels": {"env": "prod", "goog-managed-by": "tf"}
+	}`)
+	live := json.RawMessage(`{
+		"name": "projects/p/secrets/api-key",
+		"secret_id": "api-key",
+		"project": "p",
+		"rotation": {
+			"rotation_period": "604800s",
+			"next_rotation_time": "2026-06-01T00:00:00Z"
+		},
+		"ttl": "7776000s",
+		"labels": {"env": "staging", "goog-managed-by": "tf"}
+	}`)
+	got := Compare("google_secret_manager_secret", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "rotation.rotation_period")
+	assert.Equal(t, "2592000s", idx["rotation.rotation_period"].Snapshot)
+	assert.Equal(t, "604800s", idx["rotation.rotation_period"].Cloud)
+
+	// Identity / TTL identical → no mismatch.
+	assert.NotContains(t, idx, "project")
+	assert.NotContains(t, idx, "ttl")
+	// Labels use tagPolicy() → DriftSemantic=None → never emitted.
+	assert.NotContains(t, idx, "labels")
+}
+
+// TestCompare_Curated_GoogleComputeNetwork_Exact exercises an Exact
+// drift on routing_mode and confirms identical identity fields don't
+// surface. google_compute_network has no labels and no list-valued
+// curated fields, so neither LabelFilter nor WholeList comes into play.
+func TestCompare_Curated_GoogleComputeNetwork_Exact(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"name": "vpc-prod",
+		"self_link": "https://www.googleapis.com/compute/v1/projects/p/global/networks/vpc-prod",
+		"project": "p",
+		"auto_create_subnetworks": false,
+		"routing_mode": "REGIONAL",
+		"mtu": 1460,
+		"description": "production VPC"
+	}`)
+	live := json.RawMessage(`{
+		"name": "vpc-prod",
+		"self_link": "https://www.googleapis.com/compute/v1/projects/p/global/networks/vpc-prod",
+		"project": "p",
+		"auto_create_subnetworks": false,
+		"routing_mode": "GLOBAL",
+		"mtu": 1460,
+		"description": "production VPC"
+	}`)
+	got := Compare("google_compute_network", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "routing_mode")
+	assert.Equal(t, "REGIONAL", idx["routing_mode"].Snapshot)
+	assert.Equal(t, "GLOBAL", idx["routing_mode"].Cloud)
+
+	// Identity / unchanged knobs → no mismatch.
+	assert.NotContains(t, idx, "project")
+	assert.NotContains(t, idx, "mtu")
+	assert.NotContains(t, idx, "description")
 }
 
 // keysOf returns the sorted key set of m for diagnostic logging.


### PR DESCRIPTION
## Summary

Bundle D2 of #491 — curates the `DriftSemantic` axis on the next 5
policy files in `pkg/composer/imported/policy/`, following the D1
conventions:

- scalar fields → `DriftSemanticExact`
- list fields → `DriftSemanticWholeList`
- tag/label maps → `DriftSemanticNone` (via `tagPolicy()` zero value)
- informational / computed → `DriftSemanticNone`

### Files covered (5/5)

- `aws_cloudwatch_log_group.policy.go`
- `aws_secretsmanager_secret.policy.go`
- `aws_sqs_queue.policy.go`
- `google_secret_manager_secret.policy.go`
- `google_compute_network.policy.go`

### Notable curator calls

- **Both `*_secret` resources are metadata-only on this map.** The
  secret payload lives on the separate `*_secret_version` resource
  and is not curated here, so the Sensitive-leak concern that gates
  `aws_lambda_function.environment.variables` (D1) does not apply.
- **`aws_sqs_queue.redrive_policy.*` is forward-curated.** The
  comparator's `resolvePath` walks map nodes and does not decode
  JSON-encoded string parents today (see `policy/projection.go`
  limitation note). The `redrive_policy.*` projection paths declare
  `DriftSemanticExact` so they light up automatically when the
  comparator gains projection-aware traversal — the new SQS test
  pins the current "no signal" behavior so the regression is visible
  if/when that lands.
- **`google_compute_network`** has no labels and no list-valued curated
  fields, so neither LabelFilter nor WholeList applies — all leaves are
  Exact.

### Test coverage

Five new fixture-driven tests in
`pkg/drift/imported/compare_curated_test.go`, one per file. Each
asserts:

1. a deliberate scalar diff surfaces under the expected curated path,
2. identical wiring / identity values do not surface, and
3. tag/label drift does not surface (`DriftSemantic=None`).

### Codegen

`cmd/imported-codegen/testdata/drift_fields/drift-fields.json`
regenerated with the new per-type entries (sorted by tfType, then by
path within each type — byte-stable across runs).

### Running #491 progress checklist

- [x] D1 — `aws_s3_bucket`, `aws_dynamodb_table`, `aws_lambda_function`,
  `google_storage_bucket`, `google_pubsub_topic` (merged in #503)
- [x] **D2 — this PR** (5 files above)
- [ ] D3 — 5 more files (sketch: `aws_iam_role`, `aws_kms_key`,
  `aws_ecs_cluster`, `aws_ecs_service`, `aws_route53_zone`)
- [ ] D4 — 5 more files (sketch: `aws_route53_record`,
  `aws_apigateway_v2_api`, `google_bigquery_dataset`,
  `google_cloud_run_service`, `google_pubsub_subscription`)
- [ ] D5 — 5 more files
- [ ] D6 — 5 more files
- [ ] D7 — 5 more files
- [ ] D8 — 5 more files
- [ ] D9 — remaining tail files

Total D coverage after this PR: **10 / ~42 files (24%)**. Remaining
files (~32) split into 7 more bundles of ~5.

(G5 — five GCP enricher + DriftSemantic curation on
`google_compute_instance`, `google_compute_router`,
`google_kms_crypto_key`, `google_service_account`,
`google_sql_database_instance` — is concurrent work on a separate
branch and does not overlap with this bundle.)

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/composer/imported/policy/... -count=1` (169 passed)
- [x] `go test ./pkg/drift/imported/... -count=1` (5 new D2 tests pass + all D1 tests still green)
- [x] `go test ./cmd/imported-codegen/... -count=1` (golden regenerated, tests green)
- [x] Full repo `go test ./... -short` clean (5330 tests, 35 packages)
- [x] `terraform fmt -check -recursive` clean
- [x] No overlap with concurrent Bundle G5 policy files

Refs #491