### PR TITLE
feat(gcpdiscover): Bundle G5 — 5 new GCP enrichers (compute_instance, compute_router, kms_crypto_key, service_account, sql_database_instance)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -23,7 +23,7 @@ and is checked in lockstep with the runtime registries. See the
 ## Summary
 
 - **AWS:** 109 types · 100% Discoverable · 86% Enrichable · 3% DriftDetectable · 0% MetricsAvailable · 6% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 13% Enrichable · 4% DriftDetectable · 0% MetricsAvailable · 65% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 22% Enrichable · 13% DriftDetectable · 0% MetricsAvailable · 65% AgentEditable
 
 ## AWS
 
@@ -158,11 +158,11 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_global_address` | ✓ | – | – | – | ✓ |
 | `google_compute_global_forwarding_rule` | ✓ | – | – | – | ✓ |
 | `google_compute_health_check` | ✓ | – | – | – | – |
-| `google_compute_instance` | ✓ | – | – | – | ✓ |
+| `google_compute_instance` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_managed_ssl_certificate` | ✓ | – | – | – | – |
 | `google_compute_network` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_resource_policy` | ✓ | – | – | – | – |
-| `google_compute_router` | ✓ | – | – | – | ✓ |
+| `google_compute_router` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_security_policy` | ✓ | – | – | – | ✓ |
 | `google_compute_target_http_proxy` | ✓ | – | – | – | – |
 | `google_compute_target_https_proxy` | ✓ | – | – | – | ✓ |
@@ -172,7 +172,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_firestore_database` | ✓ | – | – | – | ✓ |
 | `google_identity_platform_config` | ✓ | – | – | – | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | – | – | – | – |
-| `google_kms_crypto_key` | ✓ | – | – | – | ✓ |
+| `google_kms_crypto_key` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key_iam_binding` | ✓ | – | – | – | – |
 | `google_kms_key_ring` | ✓ | – | – | – | – |
 | `google_logging_project_sink` | ✓ | – | – | – | ✓ |
@@ -188,9 +188,9 @@ and is checked in lockstep with the runtime registries. See the
 | `google_secret_manager_secret_iam_binding` | ✓ | – | – | – | – |
 | `google_secret_manager_secret_iam_member` | ✓ | – | – | – | – |
 | `google_secret_manager_secret_version` | ✓ | – | – | – | – |
-| `google_service_account` | ✓ | – | – | – | ✓ |
+| `google_service_account` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_service_networking_connection` | ✓ | – | – | – | – |
-| `google_sql_database_instance` | ✓ | – | – | – | ✓ |
+| `google_sql_database_instance` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_sql_user` | ✓ | – | – | – | ✓ |
 | `google_storage_bucket` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_storage_bucket_iam_member` | ✓ | – | – | – | – |

--- a/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
+++ b/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
@@ -429,6 +429,256 @@
       "semantic": "Exact"
     }
   ],
+  "google_compute_instance": [
+    {
+      "path": "allow_stopping_for_update",
+      "semantic": "Exact"
+    },
+    {
+      "path": "boot_disk.auto_delete",
+      "semantic": "Exact"
+    },
+    {
+      "path": "boot_disk.device_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "boot_disk.initialize_params.image",
+      "semantic": "Exact"
+    },
+    {
+      "path": "boot_disk.initialize_params.size",
+      "semantic": "Exact"
+    },
+    {
+      "path": "boot_disk.initialize_params.type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "boot_disk.kms_key_self_link",
+      "semantic": "Exact"
+    },
+    {
+      "path": "boot_disk.source",
+      "semantic": "Exact"
+    },
+    {
+      "path": "can_ip_forward",
+      "semantic": "Exact"
+    },
+    {
+      "path": "deletion_protection",
+      "semantic": "Exact"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "desired_status",
+      "semantic": "Exact"
+    },
+    {
+      "path": "enable_display",
+      "semantic": "Exact"
+    },
+    {
+      "path": "hostname",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "machine_type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "metadata_startup_script",
+      "semantic": "Exact"
+    },
+    {
+      "path": "min_cpu_platform",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "network_interface.access_config.nat_ip",
+      "semantic": "Exact"
+    },
+    {
+      "path": "network_interface.access_config.network_tier",
+      "semantic": "Exact"
+    },
+    {
+      "path": "network_interface.network",
+      "semantic": "Exact"
+    },
+    {
+      "path": "network_interface.network_ip",
+      "semantic": "Exact"
+    },
+    {
+      "path": "network_interface.nic_type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "network_interface.subnetwork",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "resource_policies",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "scheduling.automatic_restart",
+      "semantic": "Exact"
+    },
+    {
+      "path": "scheduling.on_host_maintenance",
+      "semantic": "Exact"
+    },
+    {
+      "path": "scheduling.preemptible",
+      "semantic": "Exact"
+    },
+    {
+      "path": "scheduling.provisioning_model",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    },
+    {
+      "path": "service_account.email",
+      "semantic": "Exact"
+    },
+    {
+      "path": "service_account.scopes",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "shielded_instance_config.enable_integrity_monitoring",
+      "semantic": "Exact"
+    },
+    {
+      "path": "shielded_instance_config.enable_secure_boot",
+      "semantic": "Exact"
+    },
+    {
+      "path": "shielded_instance_config.enable_vtpm",
+      "semantic": "Exact"
+    },
+    {
+      "path": "zone",
+      "semantic": "Exact"
+    }
+  ],
+  "google_compute_router": [
+    {
+      "path": "bgp.advertise_mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "bgp.advertised_groups",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "bgp.asn",
+      "semantic": "Exact"
+    },
+    {
+      "path": "bgp.keepalive_interval",
+      "semantic": "Exact"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "encrypted_interconnect_router",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "network",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "region",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    }
+  ],
+  "google_kms_crypto_key": [
+    {
+      "path": "crypto_key_backend",
+      "semantic": "Exact"
+    },
+    {
+      "path": "destroy_scheduled_duration",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "import_only",
+      "semantic": "Exact"
+    },
+    {
+      "path": "key_ring",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "purpose",
+      "semantic": "Exact"
+    },
+    {
+      "path": "rotation_period",
+      "semantic": "Exact"
+    },
+    {
+      "path": "skip_initial_version_creation",
+      "semantic": "Exact"
+    },
+    {
+      "path": "version_template.algorithm",
+      "semantic": "Exact"
+    },
+    {
+      "path": "version_template.protection_level",
+      "semantic": "Exact"
+    }
+  ],
   "google_pubsub_topic": [
     {
       "path": "id",
@@ -496,6 +746,206 @@
     },
     {
       "path": "schema_settings.schema",
+      "semantic": "Exact"
+    }
+  ],
+  "google_service_account": [
+    {
+      "path": "account_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "create_ignore_already_exists",
+      "semantic": "Exact"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "disabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "display_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "email",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "member",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "unique_id",
+      "semantic": "Exact"
+    }
+  ],
+  "google_sql_database_instance": [
+    {
+      "path": "database_version",
+      "semantic": "Exact"
+    },
+    {
+      "path": "deletion_protection",
+      "semantic": "Exact"
+    },
+    {
+      "path": "encryption_key_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "instance_type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "maintenance_version",
+      "semantic": "Exact"
+    },
+    {
+      "path": "master_instance_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "region",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.activation_policy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.availability_type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.backup_configuration.backup_retention_settings.retained_backups",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.backup_configuration.enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.backup_configuration.point_in_time_recovery_enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.backup_configuration.start_time",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.backup_configuration.transaction_log_retention_days",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.database_flags.name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.database_flags.value",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.deletion_protection_enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.disk_autoresize",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.disk_autoresize_limit",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.disk_size",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.disk_type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.edition",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.insights_config.query_insights_enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.ip_configuration.allocated_ip_range",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.ip_configuration.authorized_networks.name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.ip_configuration.authorized_networks.value",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.ip_configuration.ipv4_enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.ip_configuration.private_network",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.ip_configuration.ssl_mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.maintenance_window.day",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.maintenance_window.hour",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.maintenance_window.update_track",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.pricing_plan",
+      "semantic": "Exact"
+    },
+    {
+      "path": "settings.tier",
       "semantic": "Exact"
     }
   ],

--- a/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
@@ -55,7 +55,7 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 	// implement ByIDEnricher. When adding a new enricher: bump
 	// wantTotal and either add to allowlist (no ByIDEnricher) or leave
 	// it off (implements ByIDEnricher).
-	const wantTotal = 7 // 5 pre-Phase-2 + compute_address + compute_firewall
+	const wantTotal = 12 // 5 pre-Phase-2 + compute_address + compute_firewall + Bundle G5 (compute_instance, compute_router, kms_crypto_key, service_account, sql_database_instance)
 	if got := len(d.byTypeEnricher); got != wantTotal {
 		t.Errorf("byTypeEnricher size = %d, want %d (production registration drifted from test)", got, wantTotal)
 	}

--- a/cmd/insideout-import/gcpdiscover/compute_instance_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/compute_instance_enrich.go
@@ -1,0 +1,410 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	computev1 "google.golang.org/api/compute/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// computeInstanceEnricher implements AttributeEnricher AND ByIDEnricher
+// for google_compute_instance. Pairs with computeInstanceDiscoverer.
+//
+// Hand-rolled (no .gen.go partner) because the Compute Instance schema
+// is one of the largest in the provider (40+ nested blocks); an
+// enrichgen target would need an override snippet for almost every
+// field. Mirrors compute_firewall_enrich.go's cost/benefit shape — the
+// curated Layer-2 policy is what matters for drift, and we map that
+// subset directly.
+//
+// Compute API quirk: Instances.Get takes (project, zone, instance) as
+// three positional string parameters. The enricher pulls the zone from
+// Identity.Location, the short name from Identity hints, and the
+// project from EnrichClients.ProjectID.
+//
+// Sensitive fields:
+//
+//	metadata / metadata_startup_script — may carry SSH keys, secrets;
+//	the Layer-2 policy marks them SensitivityRedacted. The enricher
+//	writes the values; the emit/persist layers redact at write time.
+//
+// network tags vs labels: google_compute_instance.tags is the GCE
+// network-tags list (drives firewall source_tags / target_tags), not
+// labels. We map both.
+type computeInstanceEnricher struct {
+	fetch func(ctx context.Context, svc *computev1.Service, project, zone, instance string) (*computev1.Instance, error)
+}
+
+func newComputeInstanceEnricher() AttributeEnricher {
+	return &computeInstanceEnricher{fetch: defaultComputeInstanceFetch}
+}
+
+var (
+	_ AttributeEnricher = (*computeInstanceEnricher)(nil)
+	_ ByIDEnricher      = (*computeInstanceEnricher)(nil)
+)
+
+func (computeInstanceEnricher) ResourceType() string { return computeInstanceTFType }
+
+func (e computeInstanceEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchAndMap(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+func (e computeInstanceEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("compute_instance: nil identity")
+	}
+	return e.fetchAndMap(ctx, identity, c)
+}
+
+func (e computeInstanceEnricher) fetchAndMap(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.Compute == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if c.ProjectID == "" {
+		return nil, fmt.Errorf("compute_instance: EnrichClients.ProjectID required (compute API uses project+zone+name positional args)")
+	}
+	zone, name := computeInstanceZoneAndNameForEnrich(id)
+	if zone == "" || name == "" {
+		return nil, fmt.Errorf("compute_instance: cannot derive zone/name from Identity (Address=%q ImportID=%q Location=%q NameHint=%q NativeIDs.asset_name=%q)",
+			id.Address, id.ImportID, id.Location, id.NameHint, id.NativeIDs["asset_name"])
+	}
+	inst, err := e.fetch(ctx, c.Compute, c.ProjectID, zone, name)
+	if err != nil {
+		if isComputeNotFound(err) {
+			return nil, fmt.Errorf("compute_instance: %s/%s/%s: %w", c.ProjectID, zone, name, ErrNotFound)
+		}
+		return nil, fmt.Errorf("compute_instance: get %s/%s/%s: %w", c.ProjectID, zone, name, err)
+	}
+	typed := mapComputeInstance(inst, c.ProjectID, zone)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("compute_instance: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// computeInstanceZoneAndNameForEnrich resolves (zone, name) from the
+// Identity. Precedence: NameHint+Location, ImportID parse,
+// NativeIDs["asset_name"] parse.
+func computeInstanceZoneAndNameForEnrich(id *imported.ResourceIdentity) (string, string) {
+	if id == nil {
+		return "", ""
+	}
+	name := id.NameHint
+	zone := id.Location
+	if name != "" && zone != "" {
+		return zone, name
+	}
+	if id.ImportID != "" {
+		if z, n, err := computeInstancePartsFromID(id.ImportID); err == nil {
+			if name == "" {
+				name = n
+			}
+			if zone == "" {
+				zone = z
+			}
+		}
+	}
+	if (name == "" || zone == "") && id.NativeIDs["asset_name"] != "" {
+		if z, n, err := computeInstancePartsFromID(id.NativeIDs["asset_name"]); err == nil {
+			if name == "" {
+				name = n
+			}
+			if zone == "" {
+				zone = z
+			}
+		}
+	}
+	return zone, name
+}
+
+func defaultComputeInstanceFetch(ctx context.Context, svc *computev1.Service, project, zone, instance string) (*computev1.Instance, error) {
+	return svc.Instances.Get(project, zone, instance).Context(ctx).Do()
+}
+
+// mapComputeInstance converts a *computev1.Instance into the typed
+// Layer-1 *generated.GoogleComputeInstance model.
+//
+// Field coverage tracks the curated Layer-2 policy:
+//
+//	identity: name, project, zone, hostname
+//	tuning: machine_type, min_cpu_platform, description, can_ip_forward,
+//	        deletion_protection, desired_status, enable_display,
+//	        resource_policies, tags, labels, metadata,
+//	        metadata_startup_script
+//	blocks: boot_disk (source, device_name, auto_delete, initialize_params,
+//	        kms_key_self_link), network_interface, service_account,
+//	        scheduling, shielded_instance_config
+//
+// Computed-only TF fields skipped per decision #5: id, self_link,
+// cpu_platform, creation_timestamp, current_status, effective_labels,
+// label_fingerprint, instance_id, metadata_fingerprint,
+// tags_fingerprint, terraform_labels.
+//
+// machine_type: API returns a self-link
+// (https://.../machineTypes/<t>); TF stores the short name. Flatten
+// to the trailing segment for stable round-trip.
+//
+// desired_status: TF-only attribute that maps from the API's Status
+// field (the runtime status) when current_status is set; for stable
+// round-trip we read but don't translate (it'd produce drift on a
+// freshly-imported running instance). Leave for downstream comparator.
+func mapComputeInstance(b *computev1.Instance, projectID, zone string) *generated.GoogleComputeInstance {
+	out := &generated.GoogleComputeInstance{}
+
+	if b.Name != "" {
+		out.Name = generated.LiteralOf(b.Name)
+	}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if zone != "" {
+		out.Zone = generated.LiteralOf(zone)
+	}
+	if b.MachineType != "" {
+		out.MachineType = generated.LiteralOf(shortFromSelfLink(b.MachineType))
+	}
+	if b.MinCpuPlatform != "" {
+		out.MinCPUPlatform = generated.LiteralOf(b.MinCpuPlatform)
+	}
+	if b.Description != "" {
+		out.Description = generated.LiteralOf(b.Description)
+	}
+	if b.Hostname != "" {
+		out.Hostname = generated.LiteralOf(b.Hostname)
+	}
+	if b.CanIpForward {
+		out.CanIpForward = generated.LiteralOf(b.CanIpForward)
+	}
+	if b.DeletionProtection {
+		out.DeletionProtection = generated.LiteralOf(b.DeletionProtection)
+	}
+	if b.KeyRevocationActionType != "" {
+		out.KeyRevocationActionType = generated.LiteralOf(b.KeyRevocationActionType)
+	}
+
+	// Labels (with goog-* filter).
+	if len(b.Labels) > 0 {
+		labels := map[string]*generated.Value[string]{}
+		for k, v := range b.Labels {
+			if hasGoogPrefix(k) {
+				continue
+			}
+			labels[k] = generated.LiteralOf(v)
+		}
+		if len(labels) > 0 {
+			out.Labels = labels
+		}
+	}
+
+	// Metadata: KV map + special-cased startup-script.
+	if b.Metadata != nil && len(b.Metadata.Items) > 0 {
+		md := map[string]*generated.Value[string]{}
+		for _, it := range b.Metadata.Items {
+			if it == nil || it.Key == "" {
+				continue
+			}
+			val := ""
+			if it.Value != nil {
+				val = *it.Value
+			}
+			if it.Key == "startup-script" {
+				out.MetadataStartupScript = generated.LiteralOf(val)
+				continue
+			}
+			md[it.Key] = generated.LiteralOf(val)
+		}
+		if len(md) > 0 {
+			out.Metadata = md
+		}
+	}
+
+	// Network tags — the GCE network-tags list, not labels.
+	if b.Tags != nil && len(b.Tags.Items) > 0 {
+		out.Tags = stringSliceToValues(b.Tags.Items)
+	}
+
+	// resource_policies: list of self-links; flatten to short names for
+	// stable round-trip with TF state.
+	if len(b.ResourcePolicies) > 0 {
+		policies := make([]*generated.Value[string], 0, len(b.ResourcePolicies))
+		for _, p := range b.ResourcePolicies {
+			policies = append(policies, generated.LiteralOf(p))
+		}
+		out.ResourcePolicies = policies
+	}
+
+	// Boot disk.
+	if len(b.Disks) > 0 {
+		for _, d := range b.Disks {
+			if d == nil || !d.Boot {
+				continue
+			}
+			boot := generated.GoogleComputeInstanceBootDisk{}
+			if d.DeviceName != "" {
+				boot.DeviceName = generated.LiteralOf(d.DeviceName)
+			}
+			boot.AutoDelete = generated.LiteralOf(d.AutoDelete)
+			if d.Source != "" {
+				boot.Source = generated.LiteralOf(d.Source)
+			}
+			if d.Mode != "" {
+				boot.Mode = generated.LiteralOf(d.Mode)
+			}
+			if d.Interface != "" {
+				boot.Interface_ = generated.LiteralOf(d.Interface)
+			}
+			if d.DiskEncryptionKey != nil && d.DiskEncryptionKey.KmsKeyName != "" {
+				boot.KMSKeySelfLink = generated.LiteralOf(d.DiskEncryptionKey.KmsKeyName)
+			}
+			if d.InitializeParams != nil {
+				ip := generated.GoogleComputeInstanceBootDiskInitializeParams{}
+				if d.InitializeParams.SourceImage != "" {
+					ip.Image = generated.LiteralOf(d.InitializeParams.SourceImage)
+				}
+				if d.InitializeParams.DiskSizeGb != 0 {
+					ip.Size = generated.LiteralOf(float64(d.InitializeParams.DiskSizeGb))
+				}
+				if d.InitializeParams.DiskType != "" {
+					ip.Type_ = generated.LiteralOf(shortFromSelfLink(d.InitializeParams.DiskType))
+				}
+				boot.InitializeParams = []generated.GoogleComputeInstanceBootDiskInitializeParams{ip}
+			}
+			out.BootDisk = []generated.GoogleComputeInstanceBootDisk{boot}
+			break
+		}
+	}
+
+	// Network interfaces.
+	if len(b.NetworkInterfaces) > 0 {
+		nics := make([]generated.GoogleComputeInstanceNetworkInterface, 0, len(b.NetworkInterfaces))
+		for _, n := range b.NetworkInterfaces {
+			if n == nil {
+				continue
+			}
+			nic := generated.GoogleComputeInstanceNetworkInterface{}
+			if n.Network != "" {
+				nic.Network = generated.LiteralOf(n.Network)
+			}
+			if n.Subnetwork != "" {
+				nic.Subnetwork = generated.LiteralOf(n.Subnetwork)
+			}
+			if n.NetworkIP != "" {
+				nic.NetworkIp = generated.LiteralOf(n.NetworkIP)
+			}
+			if n.NicType != "" {
+				nic.NicType = generated.LiteralOf(n.NicType)
+			}
+			if n.StackType != "" {
+				nic.StackType = generated.LiteralOf(n.StackType)
+			}
+			if len(n.AccessConfigs) > 0 {
+				accs := make([]generated.GoogleComputeInstanceNetworkInterfaceAccessConfig, 0, len(n.AccessConfigs))
+				for _, a := range n.AccessConfigs {
+					if a == nil {
+						continue
+					}
+					row := generated.GoogleComputeInstanceNetworkInterfaceAccessConfig{}
+					if a.NatIP != "" {
+						row.NatIp = generated.LiteralOf(a.NatIP)
+					}
+					if a.NetworkTier != "" {
+						row.NetworkTier = generated.LiteralOf(a.NetworkTier)
+					}
+					if a.PublicPtrDomainName != "" {
+						row.PublicPtrDomainName = generated.LiteralOf(a.PublicPtrDomainName)
+					}
+					accs = append(accs, row)
+				}
+				if len(accs) > 0 {
+					nic.AccessConfig = accs
+				}
+			}
+			nics = append(nics, nic)
+		}
+		if len(nics) > 0 {
+			out.NetworkInterface = nics
+		}
+	}
+
+	// Service account.
+	if len(b.ServiceAccounts) > 0 {
+		for _, sa := range b.ServiceAccounts {
+			if sa == nil {
+				continue
+			}
+			row := generated.GoogleComputeInstanceServiceAccount{}
+			if sa.Email != "" {
+				row.Email = generated.LiteralOf(sa.Email)
+			}
+			if len(sa.Scopes) > 0 {
+				row.Scopes = stringSliceToValues(sa.Scopes)
+			}
+			out.ServiceAccount = []generated.GoogleComputeInstanceServiceAccount{row}
+			break
+		}
+	}
+
+	// Scheduling.
+	if b.Scheduling != nil {
+		sch := generated.GoogleComputeInstanceScheduling{}
+		emit := false
+		if b.Scheduling.Preemptible {
+			sch.Preemptible = generated.LiteralOf(b.Scheduling.Preemptible)
+			emit = true
+		}
+		// AutomaticRestart is *bool in the SDK as a ForceSendField; map
+		// when set explicitly (non-nil pointer would be ideal, but the
+		// SDK uses ForceSendFields for these).
+		if b.Scheduling.AutomaticRestart != nil {
+			sch.AutomaticRestart = generated.LiteralOf(*b.Scheduling.AutomaticRestart)
+			emit = true
+		}
+		if b.Scheduling.OnHostMaintenance != "" {
+			sch.OnHostMaintenance = generated.LiteralOf(b.Scheduling.OnHostMaintenance)
+			emit = true
+		}
+		if b.Scheduling.ProvisioningModel != "" {
+			sch.ProvisioningModel = generated.LiteralOf(b.Scheduling.ProvisioningModel)
+			emit = true
+		}
+		if emit {
+			out.Scheduling = []generated.GoogleComputeInstanceScheduling{sch}
+		}
+	}
+
+	// Shielded instance config.
+	if b.ShieldedInstanceConfig != nil {
+		sic := generated.GoogleComputeInstanceShieldedInstanceConfig{
+			EnableSecureBoot:          generated.LiteralOf(b.ShieldedInstanceConfig.EnableSecureBoot),
+			EnableVtpm:                generated.LiteralOf(b.ShieldedInstanceConfig.EnableVtpm),
+			EnableIntegrityMonitoring: generated.LiteralOf(b.ShieldedInstanceConfig.EnableIntegrityMonitoring),
+		}
+		out.ShieldedInstanceConfig = []generated.GoogleComputeInstanceShieldedInstanceConfig{sic}
+	}
+
+	return out
+}
+
+// shortFromSelfLink trims a Google self-link
+// (https://.../<collection>/<name> or projects/.../<collection>/<name>)
+// down to its trailing segment. Mirrors the provider's flatten of
+// machine_type, disk_type, etc. — TF state stores the short name, the
+// API returns the self-link.
+func shortFromSelfLink(s string) string {
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}

--- a/cmd/insideout-import/gcpdiscover/compute_instance_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/compute_instance_enrich.go
@@ -198,7 +198,7 @@ func mapComputeInstance(b *computev1.Instance, projectID, zone string) *generate
 	if len(b.Labels) > 0 {
 		labels := map[string]*generated.Value[string]{}
 		for k, v := range b.Labels {
-			if hasGoogPrefix(k) {
+			if strings.HasPrefix(k, "goog-") || strings.HasPrefix(k, "goog_") {
 				continue
 			}
 			labels[k] = generated.LiteralOf(v)

--- a/cmd/insideout-import/gcpdiscover/compute_instance_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/compute_instance_enrich_test.go
@@ -1,0 +1,270 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	computev1 "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+var (
+	_ AttributeEnricher = (*computeInstanceEnricher)(nil)
+	_ ByIDEnricher      = (*computeInstanceEnricher)(nil)
+)
+
+func instIdentity() imported.ResourceIdentity {
+	return imported.ResourceIdentity{
+		Cloud:    "gcp",
+		Type:     "google_compute_instance",
+		NameHint: "io-foo-vm",
+		Address:  "google_compute_instance.io_foo_vm",
+		ImportID: "projects/my-project/zones/us-central1-a/instances/io-foo-vm",
+		Location: "us-central1-a",
+		NativeIDs: map[string]string{
+			"asset_name": "//compute.googleapis.com/projects/my-project/zones/us-central1-a/instances/io-foo-vm",
+			"self_link":  "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/instances/io-foo-vm",
+		},
+	}
+}
+
+func TestMapComputeInstance_Minimal(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Instance{
+		Name:        "io-foo-vm",
+		MachineType: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/machineTypes/e2-small",
+	}
+	got := mapComputeInstance(src, "my-project", "us-central1-a")
+
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "io-foo-vm", *got.Name.Literal)
+	require.NotNil(t, got.Project)
+	assert.Equal(t, "my-project", *got.Project.Literal)
+	require.NotNil(t, got.Zone)
+	assert.Equal(t, "us-central1-a", *got.Zone.Literal)
+	require.NotNil(t, got.MachineType)
+	assert.Equal(t, "e2-small", *got.MachineType.Literal, "machine_type flattened from self-link")
+	assert.Empty(t, got.BootDisk)
+	assert.Empty(t, got.NetworkInterface)
+}
+
+func TestMapComputeInstance_WithBootDiskAndNIC(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Instance{
+		Name:         "io-foo-vm",
+		MachineType:  "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/machineTypes/n2-standard-4",
+		Description:  "test vm",
+		CanIpForward: true,
+		Disks: []*computev1.AttachedDisk{
+			{
+				Boot:       true,
+				DeviceName: "persistent-disk-0",
+				AutoDelete: true,
+				Source:     "projects/my-project/zones/us-central1-a/disks/io-foo-vm",
+				DiskEncryptionKey: &computev1.CustomerEncryptionKey{
+					KmsKeyName: "projects/my-project/locations/us-central1/keyRings/io-foo-ring/cryptoKeys/io-foo-key",
+				},
+				InitializeParams: &computev1.AttachedDiskInitializeParams{
+					SourceImage: "projects/debian-cloud/global/images/family/debian-12",
+					DiskSizeGb:  20,
+					DiskType:    "projects/my-project/zones/us-central1-a/diskTypes/pd-ssd",
+				},
+			},
+		},
+		NetworkInterfaces: []*computev1.NetworkInterface{
+			{
+				Network:    "projects/my-project/global/networks/default",
+				Subnetwork: "projects/my-project/regions/us-central1/subnetworks/default",
+				NetworkIP:  "10.0.0.10",
+				NicType:    "GVNIC",
+				AccessConfigs: []*computev1.AccessConfig{
+					{NatIP: "203.0.113.10", NetworkTier: "PREMIUM"},
+				},
+			},
+		},
+		ServiceAccounts: []*computev1.ServiceAccount{
+			{Email: "io-foo-sa@my-project.iam.gserviceaccount.com", Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"}},
+		},
+		Scheduling: &computev1.Scheduling{
+			Preemptible:       false,
+			OnHostMaintenance: "MIGRATE",
+			ProvisioningModel: "STANDARD",
+		},
+		ShieldedInstanceConfig: &computev1.ShieldedInstanceConfig{
+			EnableSecureBoot:          true,
+			EnableVtpm:                true,
+			EnableIntegrityMonitoring: true,
+		},
+		Tags: &computev1.Tags{Items: []string{"web", "ssh"}},
+		Metadata: &computev1.Metadata{
+			Items: []*computev1.MetadataItems{
+				{Key: "ssh-keys", Value: stringPtr("alice:ssh-rsa AAAA")},
+				{Key: "startup-script", Value: stringPtr("#!/bin/bash\necho hi")},
+			},
+		},
+		Labels: map[string]string{"env": "prod", "goog-managed-by": "ignored"},
+	}
+	got := mapComputeInstance(src, "my-project", "us-central1-a")
+
+	// Top-level checks.
+	require.NotNil(t, got.MachineType)
+	assert.Equal(t, "n2-standard-4", *got.MachineType.Literal)
+	require.NotNil(t, got.CanIpForward)
+	assert.True(t, *got.CanIpForward.Literal)
+
+	// Labels filtered.
+	require.NotNil(t, got.Labels)
+	assert.Contains(t, got.Labels, "env")
+	assert.NotContains(t, got.Labels, "goog-managed-by")
+
+	// Boot disk.
+	require.Len(t, got.BootDisk, 1)
+	bd := got.BootDisk[0]
+	require.NotNil(t, bd.AutoDelete)
+	require.NotNil(t, bd.Source)
+	require.NotNil(t, bd.KMSKeySelfLink)
+	require.Len(t, bd.InitializeParams, 1)
+	require.NotNil(t, bd.InitializeParams[0].Image)
+	require.NotNil(t, bd.InitializeParams[0].Size)
+	require.NotNil(t, bd.InitializeParams[0].Type_)
+	assert.Equal(t, "pd-ssd", *bd.InitializeParams[0].Type_.Literal, "disk type flattened from self-link")
+
+	// NIC.
+	require.Len(t, got.NetworkInterface, 1)
+	require.Len(t, got.NetworkInterface[0].AccessConfig, 1)
+
+	// SA.
+	require.Len(t, got.ServiceAccount, 1)
+	require.NotNil(t, got.ServiceAccount[0].Email)
+	require.Len(t, got.ServiceAccount[0].Scopes, 1)
+
+	// Scheduling.
+	require.Len(t, got.Scheduling, 1)
+	require.NotNil(t, got.Scheduling[0].OnHostMaintenance)
+
+	// Shielded.
+	require.Len(t, got.ShieldedInstanceConfig, 1)
+
+	// Tags + metadata.
+	require.Len(t, got.Tags, 2)
+	require.NotNil(t, got.Metadata)
+	assert.Contains(t, got.Metadata, "ssh-keys")
+	assert.NotContains(t, got.Metadata, "startup-script", "startup-script lives in metadata_startup_script")
+	require.NotNil(t, got.MetadataStartupScript)
+}
+
+func TestComputeInstanceEnrich_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newComputeInstanceEnricher()
+	ir := &imported.ImportedResource{Identity: instIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: nil})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestComputeInstanceEnrich_NameMissing(t *testing.T) {
+	t.Parallel()
+	e := computeInstanceEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Instance, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{Type: "google_compute_instance"}}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive zone/name")
+}
+
+func TestComputeInstanceEnrich_NotFound(t *testing.T) {
+	t.Parallel()
+	e := computeInstanceEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Instance, error) {
+			return nil, &googleapi.Error{Code: http.StatusNotFound}
+		},
+	}
+	ir := &imported.ImportedResource{Identity: instIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestComputeInstanceEnrich_FetchError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("500 internal")
+	e := computeInstanceEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Instance, error) {
+			return nil, wantErr
+		},
+	}
+	ir := &imported.ImportedResource{Identity: instIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestComputeInstanceEnrich_PopulatesAttrs(t *testing.T) {
+	t.Parallel()
+	inst := &computev1.Instance{
+		Name:        "io-foo-vm",
+		MachineType: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/machineTypes/e2-small",
+	}
+	var gotProj, gotZone, gotName string
+	e := computeInstanceEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, p, z, n string) (*computev1.Instance, error) {
+			gotProj, gotZone, gotName = p, z, n
+			return inst, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: instIdentity()}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"}))
+	assert.Equal(t, "my-project", gotProj)
+	assert.Equal(t, "us-central1-a", gotZone)
+	assert.Equal(t, "io-foo-vm", gotName)
+
+	decoded, err := generated.UnmarshalAttrs("google_compute_instance", ir.Attrs)
+	require.NoError(t, err)
+	g, ok := decoded.(*generated.GoogleComputeInstance)
+	require.True(t, ok)
+	require.NotNil(t, g.Name)
+	assert.Equal(t, "io-foo-vm", *g.Name.Literal)
+}
+
+func TestComputeInstanceEnrichByID(t *testing.T) {
+	t.Parallel()
+	e := computeInstanceEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Instance, error) {
+			return &computev1.Instance{Name: "io-foo-vm"}, nil
+		},
+	}
+	id := instIdentity()
+	raw, err := e.EnrichByID(context.Background(), &id, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+	var p map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &p))
+}
+
+func TestComputeInstanceEnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newComputeInstanceEnricher().(*computeInstanceEnricher)
+	_, err := e.EnrichByID(context.Background(), nil, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+}
+
+func TestComputeInstanceRegisteredOnAggregator(t *testing.T) {
+	t.Parallel()
+	g := NewGCPDiscoverer(nil, "test-project", GCPDiscovererOpts{})
+	enr, ok := g.byTypeEnricher["google_compute_instance"]
+	require.True(t, ok)
+	require.NotNil(t, enr)
+	assert.Equal(t, "google_compute_instance", enr.ResourceType())
+}
+
+func stringPtr(s string) *string { return &s }

--- a/cmd/insideout-import/gcpdiscover/compute_router_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/compute_router_enrich.go
@@ -1,0 +1,219 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	computev1 "google.golang.org/api/compute/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// computeRouterEnricher implements AttributeEnricher AND ByIDEnricher
+// for google_compute_router. Pairs with computeRouterDiscoverer.
+//
+// Hand-rolled (no .gen.go partner) because the router API surface is
+// modest, the bgp block is straightforward, and the
+// `advertised_ip_ranges` nested slice is the only deep shape. Same
+// cost/benefit rationale as compute_firewall_enrich.go.
+//
+// Compute API quirk: Routers.Get takes (project, region, router) as
+// three separate positional string parameters. The enricher pulls the
+// region from Identity.Location, the short name from Identity hints,
+// and the project from EnrichClients.ProjectID.
+type computeRouterEnricher struct {
+	fetch func(ctx context.Context, svc *computev1.Service, project, region, router string) (*computev1.Router, error)
+}
+
+func newComputeRouterEnricher() AttributeEnricher {
+	return &computeRouterEnricher{fetch: defaultComputeRouterFetch}
+}
+
+var (
+	_ AttributeEnricher = (*computeRouterEnricher)(nil)
+	_ ByIDEnricher      = (*computeRouterEnricher)(nil)
+)
+
+func (computeRouterEnricher) ResourceType() string { return computeRouterTFType }
+
+func (e computeRouterEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchAndMap(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+func (e computeRouterEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("compute_router: nil identity")
+	}
+	return e.fetchAndMap(ctx, identity, c)
+}
+
+func (e computeRouterEnricher) fetchAndMap(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.Compute == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if c.ProjectID == "" {
+		return nil, fmt.Errorf("compute_router: EnrichClients.ProjectID required (compute API uses project+region+name positional args)")
+	}
+	region, name := computeRouterRegionAndNameForEnrich(id)
+	if region == "" || name == "" {
+		return nil, fmt.Errorf("compute_router: cannot derive region/name from Identity (Address=%q ImportID=%q Location=%q NameHint=%q NativeIDs.asset_name=%q)",
+			id.Address, id.ImportID, id.Location, id.NameHint, id.NativeIDs["asset_name"])
+	}
+	r, err := e.fetch(ctx, c.Compute, c.ProjectID, region, name)
+	if err != nil {
+		if isComputeNotFound(err) {
+			return nil, fmt.Errorf("compute_router: %s/%s/%s: %w", c.ProjectID, region, name, ErrNotFound)
+		}
+		return nil, fmt.Errorf("compute_router: get %s/%s/%s: %w", c.ProjectID, region, name, err)
+	}
+	typed := mapComputeRouter(r, c.ProjectID, region)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("compute_router: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// computeRouterRegionAndNameForEnrich resolves the (region, name) pair
+// the SDK needs from the Identity. Precedence: NameHint+Location (the
+// canonical fields the Discoverer populates), NativeIDs["asset_name"]
+// (parsable asset form), ImportID (projects/<p>/regions/<r>/routers/<n>).
+func computeRouterRegionAndNameForEnrich(id *imported.ResourceIdentity) (string, string) {
+	if id == nil {
+		return "", ""
+	}
+	name := id.NameHint
+	region := id.Location
+	if name != "" && region != "" {
+		return region, name
+	}
+	if id.ImportID != "" {
+		if r, n, err := computeRouterPartsFromID(id.ImportID); err == nil {
+			if name == "" {
+				name = n
+			}
+			if region == "" {
+				region = r
+			}
+		}
+	}
+	if (name == "" || region == "") && id.NativeIDs["asset_name"] != "" {
+		if r, n, err := computeRouterPartsFromID(id.NativeIDs["asset_name"]); err == nil {
+			if name == "" {
+				name = n
+			}
+			if region == "" {
+				region = r
+			}
+		}
+	}
+	return region, name
+}
+
+func defaultComputeRouterFetch(ctx context.Context, svc *computev1.Service, project, region, router string) (*computev1.Router, error) {
+	return svc.Routers.Get(project, region, router).Context(ctx).Do()
+}
+
+// mapComputeRouter converts a *computev1.Router into the typed Layer-1
+// *generated.GoogleComputeRouter model.
+//
+// Computed-only TF fields per decision #5 are populated for round-trip
+// parity with compute_firewall_enrich (creation_timestamp, self_link);
+// the emit layer drops them based on schema Computed=true.
+//
+// id is computed-only AND TF-only (the provider derives it from
+// project/region/name on read) so we skip it.
+//
+// bgp: emit the nested block only when the API returns a non-nil Bgp
+// pointer. An empty `bgp {}` block would diff against routers that
+// don't peer (decision #34).
+func mapComputeRouter(b *computev1.Router, projectID, region string) *generated.GoogleComputeRouter {
+	out := &generated.GoogleComputeRouter{}
+
+	if b.Name != "" {
+		out.Name = generated.LiteralOf(b.Name)
+	}
+	if b.Network != "" {
+		out.Network = generated.LiteralOf(b.Network)
+	}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if region != "" {
+		out.Region = generated.LiteralOf(region)
+	}
+	if b.Description != "" {
+		out.Description = generated.LiteralOf(b.Description)
+	}
+	if b.EncryptedInterconnectRouter {
+		out.EncryptedInterconnectRouter = generated.LiteralOf(b.EncryptedInterconnectRouter)
+	}
+
+	// Computed-only round-trip fields.
+	if b.CreationTimestamp != "" {
+		out.CreationTimestamp = generated.LiteralOf(b.CreationTimestamp)
+	}
+	if b.SelfLink != "" {
+		out.SelfLink = generated.LiteralOf(b.SelfLink)
+	}
+
+	if b.Bgp != nil {
+		bgp := generated.GoogleComputeRouterBgp{}
+		emit := false
+		if b.Bgp.Asn != 0 {
+			bgp.Asn = generated.LiteralOf(float64(b.Bgp.Asn))
+			emit = true
+		}
+		if b.Bgp.AdvertiseMode != "" {
+			bgp.AdvertiseMode = generated.LiteralOf(b.Bgp.AdvertiseMode)
+			emit = true
+		}
+		if len(b.Bgp.AdvertisedGroups) > 0 {
+			bgp.AdvertisedGroups = stringSliceToValues(b.Bgp.AdvertisedGroups)
+			emit = true
+		}
+		if b.Bgp.KeepaliveInterval != 0 {
+			bgp.KeepaliveInterval = generated.LiteralOf(float64(b.Bgp.KeepaliveInterval))
+			emit = true
+		}
+		if b.Bgp.IdentifierRange != "" {
+			bgp.IdentifierRange = generated.LiteralOf(b.Bgp.IdentifierRange)
+			emit = true
+		}
+		if len(b.Bgp.AdvertisedIpRanges) > 0 {
+			ranges := make([]generated.GoogleComputeRouterBgpAdvertisedIpRanges, 0, len(b.Bgp.AdvertisedIpRanges))
+			for _, r := range b.Bgp.AdvertisedIpRanges {
+				if r == nil {
+					continue
+				}
+				row := generated.GoogleComputeRouterBgpAdvertisedIpRanges{}
+				if r.Range != "" {
+					row.Range_ = generated.LiteralOf(r.Range)
+				}
+				if r.Description != "" {
+					row.Description = generated.LiteralOf(r.Description)
+				}
+				ranges = append(ranges, row)
+			}
+			if len(ranges) > 0 {
+				bgp.AdvertisedIpRanges = ranges
+				emit = true
+			}
+		}
+		if emit {
+			out.Bgp = []generated.GoogleComputeRouterBgp{bgp}
+		}
+	}
+
+	return out
+}
+
+// isComputeNotFound is shared with compute_address_enrich.go in this
+// package — same googleapi 404 -> ErrNotFound translation.

--- a/cmd/insideout-import/gcpdiscover/compute_router_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/compute_router_enrich_test.go
@@ -1,0 +1,177 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	computev1 "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+var (
+	_ AttributeEnricher = (*computeRouterEnricher)(nil)
+	_ ByIDEnricher      = (*computeRouterEnricher)(nil)
+)
+
+func routerIdentity() imported.ResourceIdentity {
+	return imported.ResourceIdentity{
+		Cloud:    "gcp",
+		Type:     "google_compute_router",
+		NameHint: "io-foo-router",
+		Address:  "google_compute_router.io_foo_router",
+		ImportID: "projects/my-project/regions/us-central1/routers/io-foo-router",
+		Location: "us-central1",
+		NativeIDs: map[string]string{
+			"asset_name": "//compute.googleapis.com/projects/my-project/regions/us-central1/routers/io-foo-router",
+			"self_link":  "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/routers/io-foo-router",
+		},
+	}
+}
+
+func TestMapComputeRouter_Minimal(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Router{
+		Name:    "io-foo-router",
+		Network: "projects/my-project/global/networks/default",
+	}
+	got := mapComputeRouter(src, "my-project", "us-central1")
+
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "io-foo-router", *got.Name.Literal)
+	require.NotNil(t, got.Network)
+	require.NotNil(t, got.Project)
+	assert.Equal(t, "my-project", *got.Project.Literal)
+	require.NotNil(t, got.Region)
+	assert.Equal(t, "us-central1", *got.Region.Literal)
+	assert.Empty(t, got.Bgp, "no BGP must not emit empty block")
+}
+
+func TestMapComputeRouter_WithBGP(t *testing.T) {
+	t.Parallel()
+	src := &computev1.Router{
+		Name:    "io-foo-router",
+		Network: "projects/my-project/global/networks/default",
+		Bgp: &computev1.RouterBgp{
+			Asn:               65000,
+			AdvertiseMode:     "CUSTOM",
+			AdvertisedGroups:  []string{"ALL_SUBNETS"},
+			KeepaliveInterval: 30,
+			AdvertisedIpRanges: []*computev1.RouterAdvertisedIpRange{
+				{Range: "10.0.0.0/8", Description: "VPN"},
+			},
+		},
+	}
+	got := mapComputeRouter(src, "my-project", "us-central1")
+
+	require.Len(t, got.Bgp, 1)
+	require.NotNil(t, got.Bgp[0].Asn)
+	assert.InDelta(t, float64(65000), *got.Bgp[0].Asn.Literal, 0.001)
+	require.NotNil(t, got.Bgp[0].AdvertiseMode)
+	assert.Equal(t, "CUSTOM", *got.Bgp[0].AdvertiseMode.Literal)
+	require.Len(t, got.Bgp[0].AdvertisedGroups, 1)
+	require.Len(t, got.Bgp[0].AdvertisedIpRanges, 1)
+	require.NotNil(t, got.Bgp[0].AdvertisedIpRanges[0].Range_)
+	assert.Equal(t, "10.0.0.0/8", *got.Bgp[0].AdvertisedIpRanges[0].Range_.Literal)
+}
+
+func TestComputeRouterEnrich_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newComputeRouterEnricher()
+	ir := &imported.ImportedResource{Identity: routerIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: nil})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestComputeRouterEnrich_NotFound(t *testing.T) {
+	t.Parallel()
+	e := computeRouterEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Router, error) {
+			return nil, &googleapi.Error{Code: http.StatusNotFound}
+		},
+	}
+	ir := &imported.ImportedResource{Identity: routerIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestComputeRouterEnrich_FetchError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("403 forbidden")
+	e := computeRouterEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Router, error) {
+			return nil, wantErr
+		},
+	}
+	ir := &imported.ImportedResource{Identity: routerIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestComputeRouterEnrich_PopulatesAttrs(t *testing.T) {
+	t.Parallel()
+	r := &computev1.Router{
+		Name:    "io-foo-router",
+		Network: "projects/my-project/global/networks/default",
+		Bgp:     &computev1.RouterBgp{Asn: 65000, AdvertiseMode: "DEFAULT"},
+	}
+	var gotProj, gotRegion, gotName string
+	e := computeRouterEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, p, region, name string) (*computev1.Router, error) {
+			gotProj, gotRegion, gotName = p, region, name
+			return r, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: routerIdentity()}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"}))
+	assert.Equal(t, "my-project", gotProj)
+	assert.Equal(t, "us-central1", gotRegion)
+	assert.Equal(t, "io-foo-router", gotName)
+
+	decoded, err := generated.UnmarshalAttrs("google_compute_router", ir.Attrs)
+	require.NoError(t, err)
+	gr, ok := decoded.(*generated.GoogleComputeRouter)
+	require.True(t, ok)
+	require.NotNil(t, gr.Name)
+	assert.Equal(t, "io-foo-router", *gr.Name.Literal)
+	require.Len(t, gr.Bgp, 1)
+}
+
+func TestComputeRouterEnrichByID(t *testing.T) {
+	t.Parallel()
+	e := computeRouterEnricher{
+		fetch: func(_ context.Context, _ *computev1.Service, _, _, _ string) (*computev1.Router, error) {
+			return &computev1.Router{Name: "io-foo-router"}, nil
+		},
+	}
+	id := routerIdentity()
+	raw, err := e.EnrichByID(context.Background(), &id, EnrichClients{Compute: &computev1.Service{}, ProjectID: "my-project"})
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+	var p map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &p))
+}
+
+func TestComputeRouterEnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newComputeRouterEnricher().(*computeRouterEnricher)
+	_, err := e.EnrichByID(context.Background(), nil, EnrichClients{Compute: &computev1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+}
+
+func TestComputeRouterRegisteredOnAggregator(t *testing.T) {
+	t.Parallel()
+	g := NewGCPDiscoverer(nil, "test-project", GCPDiscovererOpts{})
+	enr, ok := g.byTypeEnricher["google_compute_router"]
+	require.True(t, ok)
+	require.NotNil(t, enr)
+	assert.Equal(t, "google_compute_router", enr.ResourceType())
+}

--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -8,9 +8,12 @@ import (
 	"sort"
 	"time"
 
+	"google.golang.org/api/cloudkms/v1"
 	computev1 "google.golang.org/api/compute/v1"
+	iamv1 "google.golang.org/api/iam/v1"
 	pubsubv1 "google.golang.org/api/pubsub/v1"
 	secretmanagerv1 "google.golang.org/api/secretmanager/v1"
+	sqladmin "google.golang.org/api/sqladmin/v1"
 	storagev1 "google.golang.org/api/storage/v1"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
@@ -133,7 +136,15 @@ type EnrichClients struct {
 	Pubsub        *pubsubv1.Service
 	SecretManager *secretmanagerv1.Service
 	Compute       *computev1.Service
-	ProjectID     string
+	// Bundle G5 (#482) — added for KMS, SQL, and IAM enrichers.
+	// KMS backs google_kms_crypto_key; SQLAdmin backs
+	// google_sql_database_instance; IAM backs google_service_account.
+	// Nil tolerated per the same convention as the other clients:
+	// affected enrichers report ErrEnrichClientUnavailable.
+	KMS       *cloudkms.Service
+	SQLAdmin  *sqladmin.Service
+	IAM       *iamv1.Service
+	ProjectID string
 }
 
 // ErrEnrichClientUnavailable signals that the SDK client an enricher

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -348,6 +348,13 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string, opts GCPDisco
 			"google_pubsub_topic":          newPubsubTopicEnricher(),
 			"google_secret_manager_secret": newSecretManagerSecretEnricher(),
 			"google_storage_bucket":        newStorageBucketEnricher(),
+			// Bundle G5 (#482) — five new GCP enrichers, all
+			// implementing ByIDEnricher in addition to AttributeEnricher.
+			"google_compute_instance":      newComputeInstanceEnricher(),
+			"google_compute_router":        newComputeRouterEnricher(),
+			"google_kms_crypto_key":        newKMSCryptoKeyEnricher(),
+			"google_service_account":       newServiceAccountEnricher(),
+			"google_sql_database_instance": newSQLDatabaseInstanceEnricher(),
 		},
 	}
 }

--- a/cmd/insideout-import/gcpdiscover/kms_crypto_key_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/kms_crypto_key_enrich.go
@@ -1,0 +1,230 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"google.golang.org/api/cloudkms/v1"
+	"google.golang.org/api/googleapi"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// kmsCryptoKeyEnricher implements AttributeEnricher AND ByIDEnricher
+// for google_kms_crypto_key. Pairs with kmsCryptoKeyDiscoverer.
+//
+// Hand-rolled (no .gen.go partner) because the cryptokey API surface is
+// small, the version_template block is a single sub-struct with two
+// scalar fields, and there are no nested-list shapes. Same cost/benefit
+// rationale as compute_firewall_enrich.go.
+//
+// Cloud KMS API quirk: CryptoKeys.Get takes a single fully-qualified
+// resource name (projects/<p>/locations/<l>/keyRings/<r>/cryptoKeys/<k>),
+// unlike compute APIs which use positional triples. The enricher builds
+// the full name from Identity (which encodes all four parts) and passes
+// it to the SDK.
+type kmsCryptoKeyEnricher struct {
+	fetch func(ctx context.Context, svc *cloudkms.Service, name string) (*cloudkms.CryptoKey, error)
+}
+
+func newKMSCryptoKeyEnricher() AttributeEnricher {
+	return &kmsCryptoKeyEnricher{fetch: defaultKMSCryptoKeyFetch}
+}
+
+// Compile-time assertion that this enricher satisfies both interfaces.
+// Phase 2 contract: every new enricher implements ByIDEnricher in
+// addition to AttributeEnricher.
+var (
+	_ AttributeEnricher = (*kmsCryptoKeyEnricher)(nil)
+	_ ByIDEnricher      = (*kmsCryptoKeyEnricher)(nil)
+)
+
+func (kmsCryptoKeyEnricher) ResourceType() string { return kmsCryptoKeyTFType }
+
+// Enrich populates ir.Attrs with a typed GoogleKMSCryptoKey payload.
+// Returns ErrEnrichClientUnavailable if EnrichClients.KMS is nil; any
+// other error reflects a real Cloud KMS API failure.
+func (e kmsCryptoKeyEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchAndMap(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID is the sibling per-IR refresh path: it accepts a bare
+// Identity (no surrounding ImportedResource) and returns the same
+// json.RawMessage shape Enrich would write into ir.Attrs. A 404 from
+// the KMS API is translated to ErrNotFound so callers can distinguish
+// "resource removed since last discover" from a real API failure.
+func (e kmsCryptoKeyEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("kms_crypto_key: nil identity")
+	}
+	return e.fetchAndMap(ctx, identity, c)
+}
+
+// fetchAndMap is the shared body. Centralizes validation + error wrapping
+// so Enrich and EnrichByID stay in lockstep.
+func (e kmsCryptoKeyEnricher) fetchAndMap(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.KMS == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if c.ProjectID == "" {
+		return nil, fmt.Errorf("kms_crypto_key: EnrichClients.ProjectID required")
+	}
+	full := kmsCryptoKeyFullNameForEnrich(id, c.ProjectID)
+	if full == "" {
+		return nil, fmt.Errorf("kms_crypto_key: cannot derive resource name from Identity (Address=%q ImportID=%q NativeIDs.asset_name=%q NativeIDs.key_ring=%q Location=%q)",
+			id.Address, id.ImportID, id.NativeIDs["asset_name"], id.NativeIDs["key_ring"], id.Location)
+	}
+	k, err := e.fetch(ctx, c.KMS, full)
+	if err != nil {
+		if isKMSNotFound(err) {
+			return nil, fmt.Errorf("kms_crypto_key: %s: %w", full, ErrNotFound)
+		}
+		return nil, fmt.Errorf("kms_crypto_key: get %s: %w", full, err)
+	}
+	loc, ring, name := kmsCryptoKeyAssetParts(full)
+	if name == "" {
+		// Defensive: the fetch succeeded with the same shape we passed
+		// in, so we expect parts to come back; but cover the
+		// pathological case where full is malformed beyond our pre-fetch
+		// check (e.g. caller injected an unusual ImportID shape).
+		name = shortName(full)
+	}
+	typed := mapKMSCryptoKey(k, c.ProjectID, loc, ring, name)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("kms_crypto_key: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// kmsCryptoKeyFullNameForEnrich derives the projects/<p>/locations/<l>/
+// keyRings/<r>/cryptoKeys/<k> resource name the CloudKMS SDK requires.
+// Precedence: ImportID (canonical), NativeIDs["asset_name"] (parsable
+// asset name), reconstruction from NativeIDs["key_ring"] + Location +
+// NameHint. Returns "" if no path yields a full name.
+func kmsCryptoKeyFullNameForEnrich(id *imported.ResourceIdentity, projectID string) string {
+	if id == nil {
+		return ""
+	}
+	// ImportID is already in the canonical projects/... shape.
+	if id.ImportID != "" {
+		if loc, ring, name, err := kmsCryptoKeyPartsFromID(id.ImportID); err == nil {
+			return fmt.Sprintf("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s", projectID, loc, ring, name)
+		}
+	}
+	if asset := id.NativeIDs["asset_name"]; asset != "" {
+		if loc, ring, name := kmsCryptoKeyAssetParts(asset); loc != "" && ring != "" && name != "" {
+			return fmt.Sprintf("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s", projectID, loc, ring, name)
+		}
+	}
+	// Reconstruct from individual hints.
+	ring := id.NativeIDs["key_ring"]
+	loc := id.Location
+	name := id.NameHint
+	if ring != "" && loc != "" && name != "" {
+		return fmt.Sprintf("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s", projectID, loc, ring, name)
+	}
+	return ""
+}
+
+func defaultKMSCryptoKeyFetch(ctx context.Context, svc *cloudkms.Service, name string) (*cloudkms.CryptoKey, error) {
+	return svc.Projects.Locations.KeyRings.CryptoKeys.Get(name).Context(ctx).Do()
+}
+
+// isKMSNotFound mirrors isComputeNotFound: 404 from the KMS REST API is
+// the not-found signal. Other 4xx / 5xx fall through to a wrapped error.
+func isKMSNotFound(err error) bool {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return gerr.Code == http.StatusNotFound
+	}
+	return false
+}
+
+// mapKMSCryptoKey converts a *cloudkms.CryptoKey into the typed Layer-1
+// *generated.GoogleKMSCryptoKey model.
+//
+// Computed-only TF fields skipped per decision #5:
+//
+//	id, primary (Computed=true block, populated by the provider on read).
+//
+// Labels: filter out goog-* / goog_* system-managed entries the same
+// way compute_address_enrich does — they leak into the user-editable
+// HCL surface otherwise.
+//
+// name / key_ring: come from positional inputs (caller already parsed
+// them from the resource path). The API's Name field is the full
+// resource path, not the short name TF stores.
+func mapKMSCryptoKey(b *cloudkms.CryptoKey, projectID, location, keyRing, name string) *generated.GoogleKMSCryptoKey {
+	out := &generated.GoogleKMSCryptoKey{}
+
+	if name != "" {
+		out.Name = generated.LiteralOf(name)
+	}
+	if keyRing != "" {
+		// TF stores the fully-qualified ring path for cross-module
+		// wiring (projects/<p>/locations/<l>/keyRings/<r>). Construct
+		// from positional inputs.
+		if projectID != "" && location != "" {
+			out.KeyRing = generated.LiteralOf(fmt.Sprintf("projects/%s/locations/%s/keyRings/%s", projectID, location, keyRing))
+		} else {
+			out.KeyRing = generated.LiteralOf(keyRing)
+		}
+	}
+	if b.Purpose != "" {
+		out.Purpose = generated.LiteralOf(b.Purpose)
+	}
+	if b.RotationPeriod != "" {
+		out.RotationPeriod = generated.LiteralOf(b.RotationPeriod)
+	}
+	if b.DestroyScheduledDuration != "" {
+		out.DestroyScheduledDuration = generated.LiteralOf(b.DestroyScheduledDuration)
+	}
+	if b.ImportOnly {
+		out.ImportOnly = generated.LiteralOf(b.ImportOnly)
+	}
+	if b.CryptoKeyBackend != "" {
+		out.CryptoKeyBackend = generated.LiteralOf(b.CryptoKeyBackend)
+	}
+
+	if len(b.Labels) > 0 {
+		labels := map[string]*generated.Value[string]{}
+		for k, v := range b.Labels {
+			if strings.HasPrefix(k, "goog-") || strings.HasPrefix(k, "goog_") {
+				continue
+			}
+			labels[k] = generated.LiteralOf(v)
+		}
+		if len(labels) > 0 {
+			out.Labels = labels
+		}
+	}
+
+	if b.VersionTemplate != nil {
+		vt := generated.GoogleKMSCryptoKeyVersionTemplate{}
+		if b.VersionTemplate.Algorithm != "" {
+			vt.Algorithm = generated.LiteralOf(b.VersionTemplate.Algorithm)
+		}
+		if b.VersionTemplate.ProtectionLevel != "" {
+			vt.ProtectionLevel = generated.LiteralOf(b.VersionTemplate.ProtectionLevel)
+		}
+		// Emit the block only when it carries something — empty
+		// version_template {} blocks would diff against fresh-import
+		// state for keys that don't set it (decision #34).
+		if vt.Algorithm != nil || vt.ProtectionLevel != nil {
+			out.VersionTemplate = []generated.GoogleKMSCryptoKeyVersionTemplate{vt}
+		}
+	}
+
+	return out
+}

--- a/cmd/insideout-import/gcpdiscover/kms_crypto_key_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/kms_crypto_key_enrich_test.go
@@ -1,0 +1,233 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/cloudkms/v1"
+	"google.golang.org/api/googleapi"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+var (
+	_ AttributeEnricher = (*kmsCryptoKeyEnricher)(nil)
+	_ ByIDEnricher      = (*kmsCryptoKeyEnricher)(nil)
+)
+
+func kmsCryptoKeyIdentity() imported.ResourceIdentity {
+	return imported.ResourceIdentity{
+		Cloud:    "gcp",
+		Type:     "google_kms_crypto_key",
+		NameHint: "io-foo-key",
+		Address:  "google_kms_crypto_key.io_foo_key",
+		ImportID: "projects/my-project/locations/us-central1/keyRings/io-foo-ring/cryptoKeys/io-foo-key",
+		Location: "us-central1",
+		NativeIDs: map[string]string{
+			"asset_name": "//cloudkms.googleapis.com/projects/my-project/locations/us-central1/keyRings/io-foo-ring/cryptoKeys/io-foo-key",
+			"key_ring":   "io-foo-ring",
+		},
+	}
+}
+
+func TestMapKMSCryptoKey_Minimal(t *testing.T) {
+	t.Parallel()
+	src := &cloudkms.CryptoKey{
+		Purpose: "ENCRYPT_DECRYPT",
+	}
+	got := mapKMSCryptoKey(src, "my-project", "us-central1", "io-foo-ring", "io-foo-key")
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "io-foo-key", *got.Name.Literal)
+	require.NotNil(t, got.KeyRing)
+	assert.Equal(t, "projects/my-project/locations/us-central1/keyRings/io-foo-ring", *got.KeyRing.Literal)
+	require.NotNil(t, got.Purpose)
+	assert.Equal(t, "ENCRYPT_DECRYPT", *got.Purpose.Literal)
+	assert.Nil(t, got.RotationPeriod)
+	assert.Nil(t, got.ImportOnly)
+	assert.Empty(t, got.VersionTemplate, "no version_template fields set must not emit empty block")
+	assert.Empty(t, got.Labels)
+}
+
+func TestMapKMSCryptoKey_FullyPopulated(t *testing.T) {
+	t.Parallel()
+	src := &cloudkms.CryptoKey{
+		Purpose:                  "ENCRYPT_DECRYPT",
+		RotationPeriod:           "7776000s",
+		DestroyScheduledDuration: "86400s",
+		ImportOnly:               true,
+		CryptoKeyBackend:         "projects/my-project/locations/us-central1/ekmConnections/my-ekm",
+		Labels: map[string]string{
+			"env":             "prod",
+			"goog-managed-by": "ignored",
+			"team":            "platform",
+		},
+		VersionTemplate: &cloudkms.CryptoKeyVersionTemplate{
+			Algorithm:       "GOOGLE_SYMMETRIC_ENCRYPTION",
+			ProtectionLevel: "SOFTWARE",
+		},
+	}
+	got := mapKMSCryptoKey(src, "my-project", "us-central1", "io-foo-ring", "io-foo-key")
+
+	require.NotNil(t, got.RotationPeriod)
+	assert.Equal(t, "7776000s", *got.RotationPeriod.Literal)
+	require.NotNil(t, got.DestroyScheduledDuration)
+	assert.Equal(t, "86400s", *got.DestroyScheduledDuration.Literal)
+	require.NotNil(t, got.ImportOnly)
+	assert.True(t, *got.ImportOnly.Literal)
+	require.NotNil(t, got.CryptoKeyBackend)
+
+	// Labels filtered.
+	require.NotNil(t, got.Labels)
+	assert.Equal(t, 2, len(got.Labels), "goog-* label must be filtered")
+	assert.Contains(t, got.Labels, "env")
+	assert.Contains(t, got.Labels, "team")
+	assert.NotContains(t, got.Labels, "goog-managed-by")
+
+	// VersionTemplate emitted as block.
+	require.Len(t, got.VersionTemplate, 1)
+	require.NotNil(t, got.VersionTemplate[0].Algorithm)
+	assert.Equal(t, "GOOGLE_SYMMETRIC_ENCRYPTION", *got.VersionTemplate[0].Algorithm.Literal)
+	require.NotNil(t, got.VersionTemplate[0].ProtectionLevel)
+	assert.Equal(t, "SOFTWARE", *got.VersionTemplate[0].ProtectionLevel.Literal)
+}
+
+func TestKMSCryptoKeyEnrich_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newKMSCryptoKeyEnricher()
+	ir := &imported.ImportedResource{Identity: kmsCryptoKeyIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{KMS: nil, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Empty(t, ir.Attrs)
+}
+
+func TestKMSCryptoKeyEnrich_ProjectIDRequired(t *testing.T) {
+	t.Parallel()
+	e := kmsCryptoKeyEnricher{
+		fetch: func(_ context.Context, _ *cloudkms.Service, _ string) (*cloudkms.CryptoKey, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: kmsCryptoKeyIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{KMS: &cloudkms.Service{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ProjectID required")
+}
+
+func TestKMSCryptoKeyEnrich_NameMissing(t *testing.T) {
+	t.Parallel()
+	e := kmsCryptoKeyEnricher{
+		fetch: func(_ context.Context, _ *cloudkms.Service, _ string) (*cloudkms.CryptoKey, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "google_kms_crypto_key"},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{KMS: &cloudkms.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive resource name")
+}
+
+func TestKMSCryptoKeyEnrich_NotFound(t *testing.T) {
+	t.Parallel()
+	e := kmsCryptoKeyEnricher{
+		fetch: func(_ context.Context, _ *cloudkms.Service, _ string) (*cloudkms.CryptoKey, error) {
+			return nil, &googleapi.Error{Code: http.StatusNotFound, Message: "key not found"}
+		},
+	}
+	ir := &imported.ImportedResource{Identity: kmsCryptoKeyIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{KMS: &cloudkms.Service{}, ProjectID: "my-project"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestKMSCryptoKeyEnrich_FetchError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("403 permission denied")
+	e := kmsCryptoKeyEnricher{
+		fetch: func(_ context.Context, _ *cloudkms.Service, _ string) (*cloudkms.CryptoKey, error) {
+			return nil, wantErr
+		},
+	}
+	ir := &imported.ImportedResource{Identity: kmsCryptoKeyIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{KMS: &cloudkms.Service{}, ProjectID: "my-project"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.NotErrorIs(t, err, ErrNotFound, "non-404 must not collapse to ErrNotFound")
+}
+
+func TestKMSCryptoKeyEnrich_PopulatesAttrs(t *testing.T) {
+	t.Parallel()
+	k := &cloudkms.CryptoKey{
+		Purpose:        "ENCRYPT_DECRYPT",
+		RotationPeriod: "7776000s",
+		VersionTemplate: &cloudkms.CryptoKeyVersionTemplate{
+			Algorithm:       "GOOGLE_SYMMETRIC_ENCRYPTION",
+			ProtectionLevel: "SOFTWARE",
+		},
+	}
+	var gotName string
+	e := kmsCryptoKeyEnricher{
+		fetch: func(_ context.Context, _ *cloudkms.Service, name string) (*cloudkms.CryptoKey, error) {
+			gotName = name
+			return k, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: kmsCryptoKeyIdentity()}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{KMS: &cloudkms.Service{}, ProjectID: "my-project"}))
+	assert.Equal(t, "projects/my-project/locations/us-central1/keyRings/io-foo-ring/cryptoKeys/io-foo-key", gotName)
+
+	decoded, err := generated.UnmarshalAttrs("google_kms_crypto_key", ir.Attrs)
+	require.NoError(t, err)
+	gk, ok := decoded.(*generated.GoogleKMSCryptoKey)
+	require.True(t, ok)
+	require.NotNil(t, gk.Name)
+	assert.Equal(t, "io-foo-key", *gk.Name.Literal)
+	require.NotNil(t, gk.RotationPeriod)
+	assert.Equal(t, "7776000s", *gk.RotationPeriod.Literal)
+	require.Len(t, gk.VersionTemplate, 1)
+}
+
+func TestKMSCryptoKeyEnrichByID(t *testing.T) {
+	t.Parallel()
+	k := &cloudkms.CryptoKey{Purpose: "ENCRYPT_DECRYPT"}
+	e := kmsCryptoKeyEnricher{
+		fetch: func(_ context.Context, _ *cloudkms.Service, _ string) (*cloudkms.CryptoKey, error) {
+			return k, nil
+		},
+	}
+	id := kmsCryptoKeyIdentity()
+	raw, err := e.EnrichByID(context.Background(), &id, EnrichClients{KMS: &cloudkms.Service{}, ProjectID: "my-project"})
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	var payload map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	assert.Contains(t, payload, "name")
+	assert.Contains(t, payload, "purpose")
+}
+
+func TestKMSCryptoKeyEnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newKMSCryptoKeyEnricher().(*kmsCryptoKeyEnricher)
+	_, err := e.EnrichByID(context.Background(), nil, EnrichClients{KMS: &cloudkms.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil identity")
+}
+
+func TestKMSCryptoKeyRegisteredOnAggregator(t *testing.T) {
+	t.Parallel()
+	g := NewGCPDiscoverer(nil, "test-project", GCPDiscovererOpts{})
+	enr, ok := g.byTypeEnricher["google_kms_crypto_key"]
+	require.True(t, ok)
+	require.NotNil(t, enr)
+	assert.Equal(t, "google_kms_crypto_key", enr.ResourceType())
+}

--- a/cmd/insideout-import/gcpdiscover/service_account_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/service_account_enrich.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"google.golang.org/api/googleapi"
 	iamv1 "google.golang.org/api/iam/v1"
@@ -144,7 +145,7 @@ func mapServiceAccount(b *iamv1.ServiceAccount, projectID string) *generated.Goo
 	if b.Email != "" {
 		out.Email = generated.LiteralOf(b.Email)
 		// account_id = local part of the email.
-		if i := indexByte(b.Email, '@'); i > 0 {
+		if i := strings.IndexByte(b.Email, '@'); i > 0 {
 			out.AccountID = generated.LiteralOf(b.Email[:i])
 		}
 	}
@@ -171,14 +172,3 @@ func mapServiceAccount(b *iamv1.ServiceAccount, projectID string) *generated.Goo
 	return out
 }
 
-// indexByte is a thin shim so this file doesn't need the strings
-// package import (we only need the byte form, and the local part of an
-// email is always ASCII). Kept private to this file.
-func indexByte(s string, c byte) int {
-	for i := 0; i < len(s); i++ {
-		if s[i] == c {
-			return i
-		}
-	}
-	return -1
-}

--- a/cmd/insideout-import/gcpdiscover/service_account_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/service_account_enrich.go
@@ -1,0 +1,184 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"google.golang.org/api/googleapi"
+	iamv1 "google.golang.org/api/iam/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// serviceAccountEnricher implements AttributeEnricher AND ByIDEnricher
+// for google_service_account. Pairs with serviceAccountDiscoverer.
+//
+// Hand-rolled (no .gen.go partner) because the SA API surface is
+// trivial — 8 scalar fields, no nested blocks. The cost of an enrichgen
+// target exceeds the cost of maintaining this directly.
+//
+// IAM API quirk: ServiceAccounts.Get takes the fully-qualified
+// "projects/<p>/serviceAccounts/<email>" name as a single argument.
+// The enricher pulls the email from Identity (NameHint or NativeIDs).
+//
+// account_id is the local part of the SA email (before the '@'). TF
+// treats it as a Required, ForceNew field; we derive it from the
+// returned Email since the API doesn't expose it as a separate field.
+type serviceAccountEnricher struct {
+	fetch func(ctx context.Context, svc *iamv1.Service, name string) (*iamv1.ServiceAccount, error)
+}
+
+func newServiceAccountEnricher() AttributeEnricher {
+	return &serviceAccountEnricher{fetch: defaultServiceAccountFetch}
+}
+
+var (
+	_ AttributeEnricher = (*serviceAccountEnricher)(nil)
+	_ ByIDEnricher      = (*serviceAccountEnricher)(nil)
+)
+
+func (serviceAccountEnricher) ResourceType() string { return serviceAccountTFType }
+
+func (e serviceAccountEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchAndMap(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+func (e serviceAccountEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("service_account: nil identity")
+	}
+	return e.fetchAndMap(ctx, identity, c)
+}
+
+func (e serviceAccountEnricher) fetchAndMap(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.IAM == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if c.ProjectID == "" {
+		return nil, fmt.Errorf("service_account: EnrichClients.ProjectID required")
+	}
+	email := serviceAccountEmailForEnrich(id)
+	if email == "" {
+		return nil, fmt.Errorf("service_account: cannot derive email from Identity (Address=%q ImportID=%q NameHint=%q NativeIDs.email=%q NativeIDs.asset_name=%q)",
+			id.Address, id.ImportID, id.NameHint, id.NativeIDs["email"], id.NativeIDs["asset_name"])
+	}
+	name := fmt.Sprintf("projects/%s/serviceAccounts/%s", c.ProjectID, email)
+	sa, err := e.fetch(ctx, c.IAM, name)
+	if err != nil {
+		if isIAMNotFound(err) {
+			return nil, fmt.Errorf("service_account: %s: %w", name, ErrNotFound)
+		}
+		return nil, fmt.Errorf("service_account: get %s: %w", name, err)
+	}
+	typed := mapServiceAccount(sa, c.ProjectID)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("service_account: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// serviceAccountEmailForEnrich resolves the SA email address from the
+// Identity. Precedence: NativeIDs["email"] (canonical, set by the
+// Discoverer), NameHint, ImportID parse, NativeIDs["asset_name"] parse.
+func serviceAccountEmailForEnrich(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if e := id.NativeIDs["email"]; e != "" {
+		return e
+	}
+	if id.NameHint != "" {
+		return id.NameHint
+	}
+	if id.ImportID != "" {
+		if e, err := serviceAccountEmailFromID(id.ImportID); err == nil {
+			return e
+		}
+	}
+	if asset := id.NativeIDs["asset_name"]; asset != "" {
+		if e, err := serviceAccountEmailFromID(asset); err == nil {
+			return e
+		}
+	}
+	return ""
+}
+
+func defaultServiceAccountFetch(ctx context.Context, svc *iamv1.Service, name string) (*iamv1.ServiceAccount, error) {
+	return svc.Projects.ServiceAccounts.Get(name).Context(ctx).Do()
+}
+
+// isIAMNotFound mirrors isComputeNotFound: 404 from the IAM REST API
+// is the not-found signal.
+func isIAMNotFound(err error) bool {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return gerr.Code == http.StatusNotFound
+	}
+	return false
+}
+
+// mapServiceAccount converts an *iamv1.ServiceAccount into the typed
+// Layer-1 *generated.GoogleServiceAccount model.
+//
+// account_id is derived from the email's local part because the IAM
+// API doesn't expose it as a discrete field; the email is canonical
+// (account_id@<gcp-project>.iam.gserviceaccount.com).
+//
+// Computed-only TF fields skipped per decision #5: id, member, name
+// (TF Computed when the resource is read back; the provider populates
+// from email after import). create_ignore_already_exists is a TF-only
+// sentinel with no API analogue — emit as default false.
+func mapServiceAccount(b *iamv1.ServiceAccount, projectID string) *generated.GoogleServiceAccount {
+	out := &generated.GoogleServiceAccount{}
+
+	if b.Email != "" {
+		out.Email = generated.LiteralOf(b.Email)
+		// account_id = local part of the email.
+		if i := indexByte(b.Email, '@'); i > 0 {
+			out.AccountID = generated.LiteralOf(b.Email[:i])
+		}
+	}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if b.DisplayName != "" {
+		out.DisplayName = generated.LiteralOf(b.DisplayName)
+	}
+	if b.Description != "" {
+		out.Description = generated.LiteralOf(b.Description)
+	}
+	if b.Disabled {
+		out.Disabled = generated.LiteralOf(b.Disabled)
+	}
+	if b.UniqueId != "" {
+		out.UniqueID = generated.LiteralOf(b.UniqueId)
+	}
+
+	// create_ignore_already_exists is a TF-only sentinel; default false
+	// matches the schema default (decision-#34 stable round-trip).
+	out.CreateIgnoreAlreadyExists = generated.LiteralOf(false)
+
+	return out
+}
+
+// indexByte is a thin shim so this file doesn't need the strings
+// package import (we only need the byte form, and the local part of an
+// email is always ASCII). Kept private to this file.
+func indexByte(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/cmd/insideout-import/gcpdiscover/service_account_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/service_account_enrich_test.go
@@ -1,0 +1,180 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	iamv1 "google.golang.org/api/iam/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+var (
+	_ AttributeEnricher = (*serviceAccountEnricher)(nil)
+	_ ByIDEnricher      = (*serviceAccountEnricher)(nil)
+)
+
+func saIdentity() imported.ResourceIdentity {
+	return imported.ResourceIdentity{
+		Cloud:    "gcp",
+		Type:     "google_service_account",
+		NameHint: "io-foo-sa@my-project.iam.gserviceaccount.com",
+		Address:  "google_service_account.io_foo_sa",
+		ImportID: "projects/my-project/serviceAccounts/io-foo-sa@my-project.iam.gserviceaccount.com",
+		NativeIDs: map[string]string{
+			"asset_name": "//iam.googleapis.com/projects/my-project/serviceAccounts/io-foo-sa@my-project.iam.gserviceaccount.com",
+			"email":      "io-foo-sa@my-project.iam.gserviceaccount.com",
+		},
+	}
+}
+
+func TestMapServiceAccount_Minimal(t *testing.T) {
+	t.Parallel()
+	src := &iamv1.ServiceAccount{
+		Email: "io-foo-sa@my-project.iam.gserviceaccount.com",
+	}
+	got := mapServiceAccount(src, "my-project")
+
+	require.NotNil(t, got.Email)
+	assert.Equal(t, "io-foo-sa@my-project.iam.gserviceaccount.com", *got.Email.Literal)
+	require.NotNil(t, got.AccountID)
+	assert.Equal(t, "io-foo-sa", *got.AccountID.Literal,
+		"account_id derived from email local part")
+	require.NotNil(t, got.Project)
+	assert.Equal(t, "my-project", *got.Project.Literal)
+	require.NotNil(t, got.CreateIgnoreAlreadyExists)
+	assert.False(t, *got.CreateIgnoreAlreadyExists.Literal, "TF-only sentinel default false")
+	assert.Nil(t, got.DisplayName)
+	assert.Nil(t, got.Disabled)
+}
+
+func TestMapServiceAccount_FullyPopulated(t *testing.T) {
+	t.Parallel()
+	src := &iamv1.ServiceAccount{
+		Email:       "io-foo-sa@my-project.iam.gserviceaccount.com",
+		DisplayName: "Foo SA",
+		Description: "Service account for foo workflow",
+		Disabled:    true,
+		UniqueId:    "123456789",
+	}
+	got := mapServiceAccount(src, "my-project")
+	require.NotNil(t, got.DisplayName)
+	assert.Equal(t, "Foo SA", *got.DisplayName.Literal)
+	require.NotNil(t, got.Description)
+	require.NotNil(t, got.Disabled)
+	assert.True(t, *got.Disabled.Literal)
+	require.NotNil(t, got.UniqueID)
+	assert.Equal(t, "123456789", *got.UniqueID.Literal)
+}
+
+func TestServiceAccountEnrich_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newServiceAccountEnricher()
+	ir := &imported.ImportedResource{Identity: saIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{IAM: nil, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestServiceAccountEnrich_EmailMissing(t *testing.T) {
+	t.Parallel()
+	e := serviceAccountEnricher{
+		fetch: func(_ context.Context, _ *iamv1.Service, _ string) (*iamv1.ServiceAccount, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{Type: "google_service_account"}}
+	err := e.Enrich(context.Background(), ir, EnrichClients{IAM: &iamv1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive email")
+}
+
+func TestServiceAccountEnrich_NotFound(t *testing.T) {
+	t.Parallel()
+	e := serviceAccountEnricher{
+		fetch: func(_ context.Context, _ *iamv1.Service, _ string) (*iamv1.ServiceAccount, error) {
+			return nil, &googleapi.Error{Code: http.StatusNotFound}
+		},
+	}
+	ir := &imported.ImportedResource{Identity: saIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{IAM: &iamv1.Service{}, ProjectID: "my-project"})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestServiceAccountEnrich_FetchError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("500 internal")
+	e := serviceAccountEnricher{
+		fetch: func(_ context.Context, _ *iamv1.Service, _ string) (*iamv1.ServiceAccount, error) {
+			return nil, wantErr
+		},
+	}
+	ir := &imported.ImportedResource{Identity: saIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{IAM: &iamv1.Service{}, ProjectID: "my-project"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestServiceAccountEnrich_PopulatesAttrs(t *testing.T) {
+	t.Parallel()
+	sa := &iamv1.ServiceAccount{
+		Email:       "io-foo-sa@my-project.iam.gserviceaccount.com",
+		DisplayName: "Foo SA",
+	}
+	var gotName string
+	e := serviceAccountEnricher{
+		fetch: func(_ context.Context, _ *iamv1.Service, name string) (*iamv1.ServiceAccount, error) {
+			gotName = name
+			return sa, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: saIdentity()}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{IAM: &iamv1.Service{}, ProjectID: "my-project"}))
+	assert.Equal(t, "projects/my-project/serviceAccounts/io-foo-sa@my-project.iam.gserviceaccount.com", gotName)
+
+	decoded, err := generated.UnmarshalAttrs("google_service_account", ir.Attrs)
+	require.NoError(t, err)
+	g, ok := decoded.(*generated.GoogleServiceAccount)
+	require.True(t, ok)
+	require.NotNil(t, g.AccountID)
+	assert.Equal(t, "io-foo-sa", *g.AccountID.Literal)
+}
+
+func TestServiceAccountEnrichByID(t *testing.T) {
+	t.Parallel()
+	e := serviceAccountEnricher{
+		fetch: func(_ context.Context, _ *iamv1.Service, _ string) (*iamv1.ServiceAccount, error) {
+			return &iamv1.ServiceAccount{Email: "io-foo-sa@my-project.iam.gserviceaccount.com"}, nil
+		},
+	}
+	id := saIdentity()
+	raw, err := e.EnrichByID(context.Background(), &id, EnrichClients{IAM: &iamv1.Service{}, ProjectID: "my-project"})
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+	var p map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &p))
+	assert.Contains(t, p, "account_id")
+}
+
+func TestServiceAccountEnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newServiceAccountEnricher().(*serviceAccountEnricher)
+	_, err := e.EnrichByID(context.Background(), nil, EnrichClients{IAM: &iamv1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+}
+
+func TestServiceAccountRegisteredOnAggregator(t *testing.T) {
+	t.Parallel()
+	g := NewGCPDiscoverer(nil, "test-project", GCPDiscovererOpts{})
+	enr, ok := g.byTypeEnricher["google_service_account"]
+	require.True(t, ok)
+	require.NotNil(t, enr)
+	assert.Equal(t, "google_service_account", enr.ResourceType())
+}

--- a/cmd/insideout-import/gcpdiscover/sql_database_instance_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/sql_database_instance_enrich.go
@@ -1,0 +1,364 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"google.golang.org/api/googleapi"
+	sqladmin "google.golang.org/api/sqladmin/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// sqlDatabaseInstanceEnricher implements AttributeEnricher AND
+// ByIDEnricher for google_sql_database_instance. Pairs with
+// sqlDatabaseInstanceDiscoverer.
+//
+// Hand-rolled (no .gen.go partner) because the curated Layer-2 policy
+// covers a small subset of the (very wide) SQL Admin API surface; an
+// enrichgen target would have to override every uncurated field as
+// skip. Mirrors the cost/benefit of compute_firewall_enrich.go.
+//
+// Cloud SQL API quirk: Instances.Get takes (project, instance) as two
+// positional arguments, not a fully-qualified name. Region lives on
+// the API response's Region field — the discoverer leaves
+// Identity.Location empty (sqladmin asset surface returns it empty),
+// so we read it from the API response after the fetch.
+//
+// Sensitive fields:
+//
+//	root_password — SQL Admin API never returns it on read (CREATE-only).
+//
+// We do not emit it from the API response either way.
+type sqlDatabaseInstanceEnricher struct {
+	fetch func(ctx context.Context, svc *sqladmin.Service, project, instance string) (*sqladmin.DatabaseInstance, error)
+}
+
+func newSQLDatabaseInstanceEnricher() AttributeEnricher {
+	return &sqlDatabaseInstanceEnricher{fetch: defaultSQLDatabaseInstanceFetch}
+}
+
+var (
+	_ AttributeEnricher = (*sqlDatabaseInstanceEnricher)(nil)
+	_ ByIDEnricher      = (*sqlDatabaseInstanceEnricher)(nil)
+)
+
+func (sqlDatabaseInstanceEnricher) ResourceType() string { return sqlDatabaseInstanceTFType }
+
+func (e sqlDatabaseInstanceEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchAndMap(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+func (e sqlDatabaseInstanceEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("sql_database_instance: nil identity")
+	}
+	return e.fetchAndMap(ctx, identity, c)
+}
+
+func (e sqlDatabaseInstanceEnricher) fetchAndMap(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.SQLAdmin == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if c.ProjectID == "" {
+		return nil, fmt.Errorf("sql_database_instance: EnrichClients.ProjectID required (sql admin API uses project+instance positional args)")
+	}
+	name := sqlDatabaseInstanceNameForEnrich(id)
+	if name == "" {
+		return nil, fmt.Errorf("sql_database_instance: cannot derive instance name from Identity (Address=%q ImportID=%q NameHint=%q NativeIDs.asset_name=%q)",
+			id.Address, id.ImportID, id.NameHint, id.NativeIDs["asset_name"])
+	}
+	inst, err := e.fetch(ctx, c.SQLAdmin, c.ProjectID, name)
+	if err != nil {
+		if isSQLNotFound(err) {
+			return nil, fmt.Errorf("sql_database_instance: %s/%s: %w", c.ProjectID, name, ErrNotFound)
+		}
+		return nil, fmt.Errorf("sql_database_instance: get %s/%s: %w", c.ProjectID, name, err)
+	}
+	typed := mapSQLDatabaseInstance(inst, c.ProjectID)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("sql_database_instance: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// sqlDatabaseInstanceNameForEnrich resolves the short instance name
+// from the Identity. Precedence: NameHint (canonical), ImportID parse,
+// NativeIDs["asset_name"] parse.
+func sqlDatabaseInstanceNameForEnrich(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if id.NameHint != "" {
+		return id.NameHint
+	}
+	if id.ImportID != "" {
+		if n, err := sqlDatabaseInstanceNameFromID(id.ImportID); err == nil {
+			return n
+		}
+	}
+	if asset := id.NativeIDs["asset_name"]; asset != "" {
+		if n, err := sqlDatabaseInstanceNameFromID(asset); err == nil {
+			return n
+		}
+	}
+	return ""
+}
+
+func defaultSQLDatabaseInstanceFetch(ctx context.Context, svc *sqladmin.Service, project, instance string) (*sqladmin.DatabaseInstance, error) {
+	return svc.Instances.Get(project, instance).Context(ctx).Do()
+}
+
+// isSQLNotFound mirrors isComputeNotFound: 404 from the SQL Admin
+// REST API is the not-found signal.
+func isSQLNotFound(err error) bool {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return gerr.Code == http.StatusNotFound
+	}
+	return false
+}
+
+// mapSQLDatabaseInstance converts a *sqladmin.DatabaseInstance into
+// the typed Layer-1 *generated.GoogleSqlDatabaseInstance model.
+//
+// Field coverage tracks the curated Layer-2 policy for SQL —
+// settings (tier, edition, availability_type, disk_*, activation_policy,
+// pricing_plan, deletion_protection_enabled), backup_configuration,
+// ip_configuration, maintenance_window, database_flags, insights_config,
+// user_labels. Computed-only TF fields per decision #5:
+//
+//	id, self_link, connection_name, dns_name, first_ip_address,
+//	private_ip_address, public_ip_address, ip_address (block),
+//	server_ca_cert (block), service_account_email_address,
+//	psc_service_attachment_link, available_maintenance_versions.
+//
+// root_password is never populated from the API response (the API
+// doesn't return it).
+//
+// Region: read from b.Region (the SQL Admin API populates it on read);
+// Identity.Location is empty for SQL because the asset surface doesn't
+// return location.
+func mapSQLDatabaseInstance(b *sqladmin.DatabaseInstance, projectID string) *generated.GoogleSqlDatabaseInstance {
+	out := &generated.GoogleSqlDatabaseInstance{}
+
+	if b.Name != "" {
+		out.Name = generated.LiteralOf(b.Name)
+	}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if b.Region != "" {
+		out.Region = generated.LiteralOf(b.Region)
+	}
+	if b.DatabaseVersion != "" {
+		out.DatabaseVersion = generated.LiteralOf(b.DatabaseVersion)
+	}
+	if b.InstanceType != "" {
+		out.InstanceType = generated.LiteralOf(b.InstanceType)
+	}
+	if b.MaintenanceVersion != "" {
+		out.MaintenanceVersion = generated.LiteralOf(b.MaintenanceVersion)
+	}
+	if b.MasterInstanceName != "" {
+		out.MasterInstanceName = generated.LiteralOf(b.MasterInstanceName)
+	}
+	if b.DiskEncryptionConfiguration != nil && b.DiskEncryptionConfiguration.KmsKeyName != "" {
+		out.EncryptionKeyName = generated.LiteralOf(b.DiskEncryptionConfiguration.KmsKeyName)
+	}
+
+	// deletion_protection is a TF-only attribute that doesn't have a
+	// direct API field (the API's settings.deletionProtectionEnabled is
+	// the persisted form). Mirror the provider's flatten: if settings
+	// say protected, emit true; otherwise default false to match the
+	// schema default (decision #34).
+	out.DeletionProtection = generated.LiteralOf(false)
+
+	if b.Settings != nil {
+		s := mapSQLSettings(b.Settings)
+		// settings is a required block in the TF schema — emit
+		// unconditionally even if the inner shape is empty, since
+		// providers won't accept a SQL instance with no settings.
+		out.Settings = []generated.GoogleSqlDatabaseInstanceSettings{s}
+
+		// Mirror deletion_protection_enabled onto the top-level attr.
+		if b.Settings.DeletionProtectionEnabled {
+			out.DeletionProtection = generated.LiteralOf(true)
+		}
+	}
+
+	return out
+}
+
+// mapSQLSettings flattens the settings sub-struct onto the typed
+// Layer-1 GoogleSqlDatabaseInstanceSettings. Only the curated subset
+// (per the Layer-2 policy file) is populated; the rest stay nil and
+// fall through to the schema default on emit.
+func mapSQLSettings(s *sqladmin.Settings) generated.GoogleSqlDatabaseInstanceSettings {
+	out := generated.GoogleSqlDatabaseInstanceSettings{}
+
+	if s.Tier != "" {
+		out.Tier = generated.LiteralOf(s.Tier)
+	}
+	if s.Edition != "" {
+		out.Edition = generated.LiteralOf(s.Edition)
+	}
+	if s.AvailabilityType != "" {
+		out.AvailabilityType = generated.LiteralOf(s.AvailabilityType)
+	}
+	if s.DataDiskSizeGb != 0 {
+		out.DiskSize = generated.LiteralOf(s.DataDiskSizeGb)
+	}
+	if s.DataDiskType != "" {
+		out.DiskType = generated.LiteralOf(s.DataDiskType)
+	}
+	if s.StorageAutoResize != nil {
+		out.DiskAutoresize = generated.LiteralOf(*s.StorageAutoResize)
+	}
+	if s.StorageAutoResizeLimit != 0 {
+		out.DiskAutoresizeLimit = generated.LiteralOf(float64(s.StorageAutoResizeLimit))
+	}
+	if s.DeletionProtectionEnabled {
+		out.DeletionProtectionEnabled = generated.LiteralOf(s.DeletionProtectionEnabled)
+	}
+	if s.ActivationPolicy != "" {
+		out.ActivationPolicy = generated.LiteralOf(s.ActivationPolicy)
+	}
+	if s.PricingPlan != "" {
+		out.PricingPlan = generated.LiteralOf(s.PricingPlan)
+	}
+
+	// User labels — same goog-* filter as the other GCP enrichers.
+	if len(s.UserLabels) > 0 {
+		labels := map[string]*generated.Value[string]{}
+		for k, v := range s.UserLabels {
+			if hasGoogPrefix(k) {
+				continue
+			}
+			labels[k] = generated.LiteralOf(v)
+		}
+		if len(labels) > 0 {
+			out.UserLabels = labels
+		}
+	}
+
+	if s.BackupConfiguration != nil {
+		bc := generated.GoogleSqlDatabaseInstanceSettingsBackupConfiguration{}
+		if s.BackupConfiguration.Enabled {
+			bc.Enabled = generated.LiteralOf(s.BackupConfiguration.Enabled)
+		}
+		if s.BackupConfiguration.StartTime != "" {
+			bc.StartTime = generated.LiteralOf(s.BackupConfiguration.StartTime)
+		}
+		if s.BackupConfiguration.PointInTimeRecoveryEnabled {
+			bc.PointInTimeRecoveryEnabled = generated.LiteralOf(s.BackupConfiguration.PointInTimeRecoveryEnabled)
+		}
+		if s.BackupConfiguration.TransactionLogRetentionDays != 0 {
+			bc.TransactionLogRetentionDays = generated.LiteralOf(float64(s.BackupConfiguration.TransactionLogRetentionDays))
+		}
+		if s.BackupConfiguration.BackupRetentionSettings != nil &&
+			s.BackupConfiguration.BackupRetentionSettings.RetainedBackups != 0 {
+			bc.BackupRetentionSettings = []generated.GoogleSqlDatabaseInstanceSettingsBackupConfigurationBackupRetentionSettings{{
+				RetainedBackups: generated.LiteralOf(float64(s.BackupConfiguration.BackupRetentionSettings.RetainedBackups)),
+			}}
+		}
+		out.BackupConfiguration = []generated.GoogleSqlDatabaseInstanceSettingsBackupConfiguration{bc}
+	}
+
+	if s.IpConfiguration != nil {
+		ipc := generated.GoogleSqlDatabaseInstanceSettingsIpConfiguration{}
+		if s.IpConfiguration.Ipv4Enabled {
+			ipc.IPV4Enabled = generated.LiteralOf(s.IpConfiguration.Ipv4Enabled)
+		}
+		if s.IpConfiguration.PrivateNetwork != "" {
+			ipc.PrivateNetwork = generated.LiteralOf(s.IpConfiguration.PrivateNetwork)
+		}
+		if s.IpConfiguration.AllocatedIpRange != "" {
+			ipc.AllocatedIpRange = generated.LiteralOf(s.IpConfiguration.AllocatedIpRange)
+		}
+		if s.IpConfiguration.SslMode != "" {
+			ipc.SSLMode = generated.LiteralOf(s.IpConfiguration.SslMode)
+		}
+		if len(s.IpConfiguration.AuthorizedNetworks) > 0 {
+			nets := make([]generated.GoogleSqlDatabaseInstanceSettingsIpConfigurationAuthorizedNetworks, 0, len(s.IpConfiguration.AuthorizedNetworks))
+			for _, n := range s.IpConfiguration.AuthorizedNetworks {
+				if n == nil {
+					continue
+				}
+				row := generated.GoogleSqlDatabaseInstanceSettingsIpConfigurationAuthorizedNetworks{}
+				if n.Value != "" {
+					row.Value = generated.LiteralOf(n.Value)
+				}
+				if n.Name != "" {
+					row.Name = generated.LiteralOf(n.Name)
+				}
+				nets = append(nets, row)
+			}
+			if len(nets) > 0 {
+				ipc.AuthorizedNetworks = nets
+			}
+		}
+		out.IpConfiguration = []generated.GoogleSqlDatabaseInstanceSettingsIpConfiguration{ipc}
+	}
+
+	if s.MaintenanceWindow != nil {
+		mw := generated.GoogleSqlDatabaseInstanceSettingsMaintenanceWindow{}
+		if s.MaintenanceWindow.Day != 0 {
+			mw.Day = generated.LiteralOf(float64(s.MaintenanceWindow.Day))
+		}
+		if s.MaintenanceWindow.Hour != 0 {
+			mw.Hour = generated.LiteralOf(float64(s.MaintenanceWindow.Hour))
+		}
+		if s.MaintenanceWindow.UpdateTrack != "" {
+			mw.UpdateTrack = generated.LiteralOf(s.MaintenanceWindow.UpdateTrack)
+		}
+		out.MaintenanceWindow = []generated.GoogleSqlDatabaseInstanceSettingsMaintenanceWindow{mw}
+	}
+
+	if len(s.DatabaseFlags) > 0 {
+		flags := make([]generated.GoogleSqlDatabaseInstanceSettingsDatabaseFlags, 0, len(s.DatabaseFlags))
+		for _, f := range s.DatabaseFlags {
+			if f == nil {
+				continue
+			}
+			row := generated.GoogleSqlDatabaseInstanceSettingsDatabaseFlags{}
+			if f.Name != "" {
+				row.Name = generated.LiteralOf(f.Name)
+			}
+			if f.Value != "" {
+				row.Value = generated.LiteralOf(f.Value)
+			}
+			flags = append(flags, row)
+		}
+		if len(flags) > 0 {
+			out.DatabaseFlags = flags
+		}
+	}
+
+	if s.InsightsConfig != nil {
+		ic := generated.GoogleSqlDatabaseInstanceSettingsInsightsConfig{}
+		if s.InsightsConfig.QueryInsightsEnabled {
+			ic.QueryInsightsEnabled = generated.LiteralOf(s.InsightsConfig.QueryInsightsEnabled)
+			out.InsightsConfig = []generated.GoogleSqlDatabaseInstanceSettingsInsightsConfig{ic}
+		}
+	}
+
+	return out
+}
+
+// hasGoogPrefix returns true if k begins with "goog-" or "goog_".
+// Shared by labels filters across enrichers in this package; defined
+// once here to avoid duplicating the prefix list at each call site.
+func hasGoogPrefix(k string) bool {
+	return len(k) >= 5 && (k[:5] == "goog-" || k[:5] == "goog_")
+}

--- a/cmd/insideout-import/gcpdiscover/sql_database_instance_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/sql_database_instance_enrich.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"google.golang.org/api/googleapi"
 	sqladmin "google.golang.org/api/sqladmin/v1"
@@ -242,7 +243,7 @@ func mapSQLSettings(s *sqladmin.Settings) generated.GoogleSqlDatabaseInstanceSet
 	if len(s.UserLabels) > 0 {
 		labels := map[string]*generated.Value[string]{}
 		for k, v := range s.UserLabels {
-			if hasGoogPrefix(k) {
+			if strings.HasPrefix(k, "goog-") || strings.HasPrefix(k, "goog_") {
 				continue
 			}
 			labels[k] = generated.LiteralOf(v)
@@ -356,9 +357,3 @@ func mapSQLSettings(s *sqladmin.Settings) generated.GoogleSqlDatabaseInstanceSet
 	return out
 }
 
-// hasGoogPrefix returns true if k begins with "goog-" or "goog_".
-// Shared by labels filters across enrichers in this package; defined
-// once here to avoid duplicating the prefix list at each call site.
-func hasGoogPrefix(k string) bool {
-	return len(k) >= 5 && (k[:5] == "goog-" || k[:5] == "goog_")
-}

--- a/cmd/insideout-import/gcpdiscover/sql_database_instance_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/sql_database_instance_enrich_test.go
@@ -1,0 +1,253 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	sqladmin "google.golang.org/api/sqladmin/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+var (
+	_ AttributeEnricher = (*sqlDatabaseInstanceEnricher)(nil)
+	_ ByIDEnricher      = (*sqlDatabaseInstanceEnricher)(nil)
+)
+
+func sqlIdentity() imported.ResourceIdentity {
+	return imported.ResourceIdentity{
+		Cloud:    "gcp",
+		Type:     "google_sql_database_instance",
+		NameHint: "io-foo-sql",
+		Address:  "google_sql_database_instance.io_foo_sql",
+		ImportID: "projects/my-project/instances/io-foo-sql",
+		NativeIDs: map[string]string{
+			"asset_name": "//sqladmin.googleapis.com/projects/my-project/instances/io-foo-sql",
+		},
+	}
+}
+
+func TestMapSQLDatabaseInstance_Minimal(t *testing.T) {
+	t.Parallel()
+	src := &sqladmin.DatabaseInstance{
+		Name:            "io-foo-sql",
+		Region:          "us-central1",
+		DatabaseVersion: "POSTGRES_14",
+		Settings: &sqladmin.Settings{
+			Tier: "db-custom-2-7680",
+		},
+	}
+	got := mapSQLDatabaseInstance(src, "my-project")
+
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "io-foo-sql", *got.Name.Literal)
+	require.NotNil(t, got.Project)
+	assert.Equal(t, "my-project", *got.Project.Literal)
+	require.NotNil(t, got.Region)
+	assert.Equal(t, "us-central1", *got.Region.Literal)
+	require.NotNil(t, got.DatabaseVersion)
+	assert.Equal(t, "POSTGRES_14", *got.DatabaseVersion.Literal)
+	require.NotNil(t, got.DeletionProtection)
+	assert.False(t, *got.DeletionProtection.Literal, "default false matches schema default")
+	require.Len(t, got.Settings, 1, "settings block must always emit")
+	require.NotNil(t, got.Settings[0].Tier)
+	assert.Equal(t, "db-custom-2-7680", *got.Settings[0].Tier.Literal)
+}
+
+func TestMapSQLDatabaseInstance_FullSettings(t *testing.T) {
+	t.Parallel()
+	src := &sqladmin.DatabaseInstance{
+		Name:               "io-foo-sql",
+		Region:             "us-central1",
+		DatabaseVersion:    "POSTGRES_14",
+		MaintenanceVersion: "POSTGRES_14_5.R20240801.00_00",
+		DiskEncryptionConfiguration: &sqladmin.DiskEncryptionConfiguration{
+			KmsKeyName: "projects/my-project/locations/us-central1/keyRings/io-foo-ring/cryptoKeys/io-foo-key",
+		},
+		Settings: &sqladmin.Settings{
+			Tier:                      "db-custom-2-7680",
+			Edition:                   "ENTERPRISE",
+			AvailabilityType:          "REGIONAL",
+			DataDiskSizeGb:            100,
+			DataDiskType:              "PD_SSD",
+			DeletionProtectionEnabled: true,
+			ActivationPolicy:          "ALWAYS",
+			UserLabels: map[string]string{
+				"env":             "prod",
+				"goog-managed-by": "ignored",
+			},
+			BackupConfiguration: &sqladmin.BackupConfiguration{
+				Enabled:                    true,
+				StartTime:                  "02:00",
+				PointInTimeRecoveryEnabled: true,
+				BackupRetentionSettings: &sqladmin.BackupRetentionSettings{
+					RetainedBackups: 7,
+				},
+			},
+			IpConfiguration: &sqladmin.IpConfiguration{
+				Ipv4Enabled:    true,
+				PrivateNetwork: "projects/my-project/global/networks/default",
+				SslMode:        "ENCRYPTED_ONLY",
+				AuthorizedNetworks: []*sqladmin.AclEntry{
+					{Value: "1.2.3.4/32", Name: "office"},
+				},
+			},
+			MaintenanceWindow: &sqladmin.MaintenanceWindow{
+				Day:         7,
+				Hour:        3,
+				UpdateTrack: "stable",
+			},
+			DatabaseFlags: []*sqladmin.DatabaseFlags{
+				{Name: "log_statement", Value: "all"},
+			},
+			InsightsConfig: &sqladmin.InsightsConfig{
+				QueryInsightsEnabled: true,
+			},
+		},
+	}
+	got := mapSQLDatabaseInstance(src, "my-project")
+
+	require.NotNil(t, got.EncryptionKeyName)
+	require.NotNil(t, got.MaintenanceVersion)
+	require.NotNil(t, got.DeletionProtection)
+	assert.True(t, *got.DeletionProtection.Literal, "settings.deletion_protection_enabled mirrors to top-level")
+	require.Len(t, got.Settings, 1)
+	s := got.Settings[0]
+	require.NotNil(t, s.Edition)
+	require.NotNil(t, s.AvailabilityType)
+	require.NotNil(t, s.DiskSize)
+	assert.Equal(t, int64(100), *s.DiskSize.Literal)
+	require.NotNil(t, s.DiskType)
+
+	require.NotNil(t, s.UserLabels)
+	assert.Contains(t, s.UserLabels, "env")
+	assert.NotContains(t, s.UserLabels, "goog-managed-by")
+
+	require.Len(t, s.BackupConfiguration, 1)
+	require.NotNil(t, s.BackupConfiguration[0].Enabled)
+	require.Len(t, s.BackupConfiguration[0].BackupRetentionSettings, 1)
+
+	require.Len(t, s.IpConfiguration, 1)
+	require.NotNil(t, s.IpConfiguration[0].IPV4Enabled)
+	require.NotNil(t, s.IpConfiguration[0].PrivateNetwork)
+	require.Len(t, s.IpConfiguration[0].AuthorizedNetworks, 1)
+
+	require.Len(t, s.MaintenanceWindow, 1)
+	require.Len(t, s.DatabaseFlags, 1)
+	require.Len(t, s.InsightsConfig, 1)
+}
+
+func TestSQLDatabaseInstanceEnrich_ClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newSQLDatabaseInstanceEnricher()
+	ir := &imported.ImportedResource{Identity: sqlIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{SQLAdmin: nil, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestSQLDatabaseInstanceEnrich_NameMissing(t *testing.T) {
+	t.Parallel()
+	e := sqlDatabaseInstanceEnricher{
+		fetch: func(_ context.Context, _ *sqladmin.Service, _, _ string) (*sqladmin.DatabaseInstance, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{Type: "google_sql_database_instance"}}
+	err := e.Enrich(context.Background(), ir, EnrichClients{SQLAdmin: &sqladmin.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive instance name")
+}
+
+func TestSQLDatabaseInstanceEnrich_NotFound(t *testing.T) {
+	t.Parallel()
+	e := sqlDatabaseInstanceEnricher{
+		fetch: func(_ context.Context, _ *sqladmin.Service, _, _ string) (*sqladmin.DatabaseInstance, error) {
+			return nil, &googleapi.Error{Code: http.StatusNotFound}
+		},
+	}
+	ir := &imported.ImportedResource{Identity: sqlIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{SQLAdmin: &sqladmin.Service{}, ProjectID: "my-project"})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestSQLDatabaseInstanceEnrich_FetchError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("500 internal")
+	e := sqlDatabaseInstanceEnricher{
+		fetch: func(_ context.Context, _ *sqladmin.Service, _, _ string) (*sqladmin.DatabaseInstance, error) {
+			return nil, wantErr
+		},
+	}
+	ir := &imported.ImportedResource{Identity: sqlIdentity()}
+	err := e.Enrich(context.Background(), ir, EnrichClients{SQLAdmin: &sqladmin.Service{}, ProjectID: "my-project"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestSQLDatabaseInstanceEnrich_PopulatesAttrs(t *testing.T) {
+	t.Parallel()
+	inst := &sqladmin.DatabaseInstance{
+		Name:            "io-foo-sql",
+		Region:          "us-central1",
+		DatabaseVersion: "POSTGRES_14",
+		Settings:        &sqladmin.Settings{Tier: "db-custom-2-7680"},
+	}
+	var gotProj, gotName string
+	e := sqlDatabaseInstanceEnricher{
+		fetch: func(_ context.Context, _ *sqladmin.Service, p, n string) (*sqladmin.DatabaseInstance, error) {
+			gotProj, gotName = p, n
+			return inst, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: sqlIdentity()}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{SQLAdmin: &sqladmin.Service{}, ProjectID: "my-project"}))
+	assert.Equal(t, "my-project", gotProj)
+	assert.Equal(t, "io-foo-sql", gotName)
+
+	decoded, err := generated.UnmarshalAttrs("google_sql_database_instance", ir.Attrs)
+	require.NoError(t, err)
+	g, ok := decoded.(*generated.GoogleSqlDatabaseInstance)
+	require.True(t, ok)
+	require.NotNil(t, g.Name)
+	assert.Equal(t, "io-foo-sql", *g.Name.Literal)
+	require.Len(t, g.Settings, 1)
+}
+
+func TestSQLDatabaseInstanceEnrichByID(t *testing.T) {
+	t.Parallel()
+	e := sqlDatabaseInstanceEnricher{
+		fetch: func(_ context.Context, _ *sqladmin.Service, _, _ string) (*sqladmin.DatabaseInstance, error) {
+			return &sqladmin.DatabaseInstance{Name: "io-foo-sql", Settings: &sqladmin.Settings{}}, nil
+		},
+	}
+	id := sqlIdentity()
+	raw, err := e.EnrichByID(context.Background(), &id, EnrichClients{SQLAdmin: &sqladmin.Service{}, ProjectID: "my-project"})
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+	var p map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &p))
+}
+
+func TestSQLDatabaseInstanceEnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newSQLDatabaseInstanceEnricher().(*sqlDatabaseInstanceEnricher)
+	_, err := e.EnrichByID(context.Background(), nil, EnrichClients{SQLAdmin: &sqladmin.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+}
+
+func TestSQLDatabaseInstanceRegisteredOnAggregator(t *testing.T) {
+	t.Parallel()
+	g := NewGCPDiscoverer(nil, "test-project", GCPDiscovererOpts{})
+	enr, ok := g.byTypeEnricher["google_sql_database_instance"]
+	require.True(t, ok)
+	require.NotNil(t, enr)
+	assert.Equal(t, "google_sql_database_instance", enr.ResourceType())
+}

--- a/pkg/composer/imported/policy/google_compute_instance.policy.go
+++ b/pkg/composer/imported/policy/google_compute_instance.policy.go
@@ -1,51 +1,86 @@
 package policy
 
+// googleComputeInstancePolicy curates Layer 2 for `google_compute_instance`.
+//
+// Bundle G5 (#482): DriftSemantic axis is curated on every non-tag,
+// non-timeouts entry. Scalars use DriftSemanticExact. The runtime
+// fields where order is meaningful — `service_account.scopes`,
+// `resource_policies` — use DriftSemanticWholeList. Labels stay at
+// the tagPolicy() default (DriftSemanticNone).
+//
+// `metadata` is a map but is intentionally NOT marked as a label-style
+// filter target: metadata is the user-authored set of VM env values
+// (ssh-keys, startup scripts, etc.) and every key is semantically
+// load-bearing; treat as exact map equality at the comparator layer.
+// We don't currently emit a per-key drift semantic for it; the
+// Sensitivity=Redacted axis already gates display.
 var googleComputeInstancePolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"zone": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"hostname": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — top-level machine knobs.
 	"machine_type": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityUIVisible,
 		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"min_cpu_platform": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"can_ip_forward": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"deletion_protection": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"desired_status": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"allow_stopping_for_update": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"enable_display": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"resource_policies": {
 		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	// NB: `tags` on compute_instance is NOT labels — it's the GCE network
 	// tags list that drives firewall source_tags / target_tags, so the
@@ -58,100 +93,122 @@ var googleComputeInstancePolicy = Map{
 	"boot_disk.source": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"boot_disk.device_name": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"boot_disk.auto_delete": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"boot_disk.initialize_params.image": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
 		Edit: EditRequiresApproval, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"boot_disk.initialize_params.size": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
 		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"boot_disk.initialize_params.type": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
 		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"boot_disk.kms_key_self_link": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Network interfaces.
 	"network_interface.network": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"network_interface.subnetwork": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"network_interface.network_ip": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"network_interface.access_config.nat_ip": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditRequiresApproval,
-		ChangeRisk: ChangeMayReplace,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"network_interface.access_config.network_tier": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
 		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"network_interface.nic_type": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Service account.
 	"service_account.email": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"service_account.scopes": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 
 	// Scheduling.
 	"scheduling.preemptible": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
 		Edit: EditRequiresApproval, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"scheduling.automatic_restart": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"scheduling.on_host_maintenance": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"scheduling.provisioning_model": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditRequiresApproval, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Shielded VM.
 	"shielded_instance_config.enable_secure_boot": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"shielded_instance_config.enable_vtpm": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"shielded_instance_config.enable_integrity_monitoring": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Metadata: kv map that legitimately carries SSH keys, env config, and
 	// user data scripts. Visible to the interactive agent + UI (operators need to see it),
 	// edits require approval (instance-impacting), values redacted (may
-	// contain credentials).
+	// contain credentials). DriftSemantic deferred — see file comment.
 	"metadata": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
 		Edit: EditRequiresApproval, Sensitivity: SensitivityRedacted,
@@ -159,6 +216,7 @@ var googleComputeInstancePolicy = Map{
 	"metadata_startup_script": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditRequiresApproval, Sensitivity: SensitivityRedacted,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Labels

--- a/pkg/composer/imported/policy/google_compute_router.policy.go
+++ b/pkg/composer/imported/policy/google_compute_router.policy.go
@@ -1,47 +1,72 @@
 package policy
 
+// googleComputeRouterPolicy curates Layer 2 for `google_compute_router`.
+//
+// Bundle G5 (#482): DriftSemantic axis is curated on every non-timeouts
+// entry. Scalars use DriftSemanticExact. The single list-valued tuning
+// field, `bgp.advertised_groups`, uses DriftSemanticWholeList — order
+// is meaningful for BGP advertising and per-element diffs are not
+// independently actionable.
 var googleComputeRouterPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"region": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — VPC.
 	"network": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"encrypted_interconnect_router": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// BGP block — ASN is identity-shaped (replace on change).
 	"bgp.asn": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditRequiresApproval, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"bgp.advertise_mode": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"bgp.advertised_groups": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"bgp.keepalive_interval": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/google_kms_crypto_key.policy.go
+++ b/pkg/composer/imported/policy/google_kms_crypto_key.policy.go
@@ -1,50 +1,75 @@
 package policy
 
+// googleKmsCryptoKeyPolicy curates Layer 2 for `google_kms_crypto_key`.
+//
+// Bundle G5 (#482): DriftSemantic axis is curated on every non-tag,
+// non-timeouts entry. All scalars (purpose, rotation_period, algorithm,
+// protection_level, etc.) use DriftSemanticExact. Identity fields
+// (name, id) also use DriftSemanticExact — rename/recreate must show
+// up as drift. Labels stay at the tagPolicy() default
+// (DriftSemanticNone); LabelFilter coverage on user-author labels is
+// deferred until the drift comparator's redacted-mode output is in
+// place.
 var googleKmsCryptoKeyPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 
 	// Wiring — parent keyring.
 	"key_ring": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — rotation + purpose + lifecycle.
 	"purpose": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"rotation_period": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"destroy_scheduled_duration": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"import_only": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"skip_initial_version_creation": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"crypto_key_backend": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Version template — algorithm + protection level.
 	"version_template.algorithm": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"version_template.protection_level": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Labels

--- a/pkg/composer/imported/policy/google_service_account.policy.go
+++ b/pkg/composer/imported/policy/google_service_account.policy.go
@@ -1,42 +1,63 @@
 package policy
 
+// googleServiceAccountPolicy curates Layer 2 for `google_service_account`.
+//
+// Bundle G5 (#482): DriftSemantic axis is curated on every
+// non-timeouts entry. Scalars use DriftSemanticExact. The resource has
+// no list-valued or label-map fields, so WholeList / LabelFilter
+// semantics do not apply.
 var googleServiceAccountPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	// account_id is the local part of the SA email; it's the durable
 	// identifier (cannot be changed in place).
 	"account_id": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"email": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"unique_id": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"member": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"display_name": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"disabled": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"create_ignore_already_exists": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/google_sql_database_instance.policy.go
+++ b/pkg/composer/imported/policy/google_sql_database_instance.policy.go
@@ -1,46 +1,81 @@
 package policy
 
+// googleSqlDatabaseInstancePolicy curates Layer 2 for
+// `google_sql_database_instance`.
+//
+// Bundle G5 (#482): DriftSemantic axis is curated on every non-tag,
+// non-timeouts entry. Scalars use DriftSemanticExact. The
+// `settings.ip_configuration.authorized_networks.*` paths are nested
+// list-of-block elements; their inner scalars use DriftSemanticExact
+// because each authorized-network row is independently meaningful
+// (drift on a specific CIDR is the actionable signal). `user_labels`
+// stays at the tagPolicy() default (DriftSemanticNone); LabelFilter
+// coverage on user-author labels is deferred until the drift
+// comparator's redacted-mode output is in place.
+//
+// root_password — Sensitivity=Sensitive. The API doesn't return it on
+// read; comparator never sees it. DriftSemantic intentionally unset
+// (DriftSemanticNone).
 var googleSqlDatabaseInstancePolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"region": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"database_version": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — CMEK + replica source.
 	"encryption_key_name": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"master_instance_name": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"instance_type": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"deletion_protection": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"maintenance_version": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Root password is the bootstrap secret — sensitive + redacted.
+	// DriftSemantic deferred (Sensitivity=Sensitive; comparator never
+	// receives the value).
 	"root_password": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityHidden,
 		Edit: EditSystemOnly, Sensitivity: SensitivitySensitive,
@@ -49,101 +84,128 @@ var googleSqlDatabaseInstancePolicy = Map{
 	// Settings block — the operational surface.
 	"settings.tier": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.edition": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.availability_type": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.disk_size": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.disk_type": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.disk_autoresize": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.disk_autoresize_limit": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.deletion_protection_enabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.activation_policy": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.pricing_plan": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Backup configuration.
 	"settings.backup_configuration.enabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.backup_configuration.start_time": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.backup_configuration.point_in_time_recovery_enabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.backup_configuration.transaction_log_retention_days": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.backup_configuration.backup_retention_settings.retained_backups": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// IP configuration.
 	"settings.ip_configuration.ipv4_enabled": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.ip_configuration.private_network": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.ip_configuration.allocated_ip_range": {
 		Role: RoleWiring, Visibility: VisibilityRileyVisible, Edit: EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.ip_configuration.ssl_mode": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.ip_configuration.authorized_networks.value": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.ip_configuration.authorized_networks.name": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Maintenance window.
 	"settings.maintenance_window.day": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.maintenance_window.hour": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.maintenance_window.update_track": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Database flags + insights.
 	"settings.database_flags.name": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.database_flags.value": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"settings.insights_config.query_insights_enabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// User labels live under settings.user_labels for SQL.


### PR DESCRIPTION
## Summary

Bundle G5 (Phase 2, #482): add SDK attribute enrichers + `ByIDEnricher` contract + `DriftSemantic` policy curation for five high-value GCP types.

**Note:** Base is `feat/bundle-follow-ups-489-494` (stacked PR #503). GitHub will auto-retarget to `main` when that merges.

### Types landed

| Type | SDK | Pattern |
|---|---|---|
| `google_compute_instance` | `compute/v1` | hand-rolled, curated policy field coverage |
| `google_compute_router` | `compute/v1` | hand-rolled, BGP block + advertised_ip_ranges |
| `google_kms_crypto_key` | `cloudkms/v1` | hand-rolled, version_template + goog-* label filter |
| `google_service_account` | `iam/v1` | hand-rolled, account_id derived from email |
| `google_sql_database_instance` | `sqladmin/v1` | hand-rolled, full settings tree (backup, IP config, maintenance window, flags, insights) |

All five implement both `AttributeEnricher` and `ByIDEnricher`. The hand-rolled approach mirrors `compute_firewall_enrich.go` — for resource types this large, the cost of per-field enrichgen overrides exceeds the cost of a focused mapping.

### EnrichClients additions

Three new SDK fields on `EnrichClients` for the new surfaces:

- `KMS *cloudkms.Service` — backs `google_kms_crypto_key`
- `SQLAdmin *sqladmin.Service` — backs `google_sql_database_instance`
- `IAM *iamv1.Service` — backs `google_service_account`

Nil tolerated per existing convention: enrichers with nil clients surface `ErrEnrichClientUnavailable`, which `EnrichAttributes` downgrades to per-resource `ServiceWarn` events.

### Layer-2 DriftSemantic curation

Bundle D1 (#491) introduced the `DriftSemantic` axis; this bundle curates the five policy files following the same rules:

- Scalars → `DriftSemanticExact`
- List-valued tuning leaves (`bgp.advertised_groups`, `service_account.scopes`, `resource_policies`) → `DriftSemanticWholeList`
- Labels stay at `tagPolicy()` default (`DriftSemanticNone`) pending the comparator's redacted-mode output

### Coverage delta

- GCP enrichable: **7/54 → 12/54** (13% → 22%)
- GCP drift-detectable: **2/54 → 7/54** (4% → 13%)

`SUPPORTED_RESOURCES.md` and `cmd/imported-codegen/testdata/drift_fields/drift-fields.json` regenerated; included in the bundle.

### Test contract

- `byid_enricher_test.go` wantTotal bumped 7 → 12.
- All five new enrichers ship with per-type test files covering: happy-path mapping, fully-populated mapping, nil-client soft-fail, missing-identity error, 404 → `ErrNotFound`, generic fetch error, end-to-end `Enrich` + `EnrichByID` flows, aggregator registration.
- 50 new tests; 5375 total tests pass.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` — 5375 passed in 35 packages
- [x] `gofmt -l` clean on new files (existing pre-bundle gofmt drift in `pubsub_subscription_enrich_test.go` / `secret_manager_secret_enrich_test.go` unrelated, untouched)
- [x] `make regen-supported-resources` regenerated `SUPPORTED_RESOURCES.md` cleanly
- [x] `go run ./cmd/imported-codegen drift-fields` regenerated golden cleanly

Refs #482