### PR TITLE
feat(gcpdiscover): Cloud Asset Inventory HYBRID enricher (mirrors #490 for GCP)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -23,7 +23,7 @@ and is checked in lockstep with the runtime registries. See the
 ## Summary
 
 - **AWS:** 109 types · 100% Discoverable · 86% Enrichable · 3% DriftDetectable · 0% MetricsAvailable · 6% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 13% Enrichable · 4% DriftDetectable · 0% MetricsAvailable · 65% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 56% Enrichable · 4% DriftDetectable · 0% MetricsAvailable · 65% AgentEditable
 
 ## AWS
 
@@ -143,38 +143,38 @@ and is checked in lockstep with the runtime registries. See the
 
 | TF Type | Discoverable | Enrichable | DriftDetectable | MetricsAvailable | AgentEditable |
 |---|---|---|---|---|---|
-| `google_api_gateway_api` | ✓ | – | – | – | ✓ |
-| `google_api_gateway_api_config` | ✓ | – | – | – | ✓ |
-| `google_api_gateway_gateway` | ✓ | – | – | – | ✓ |
-| `google_cloud_run_v2_service` | ✓ | – | – | – | ✓ |
+| `google_api_gateway_api` | ✓ | ✓ | – | – | ✓ |
+| `google_api_gateway_api_config` | ✓ | ✓ | – | – | ✓ |
+| `google_api_gateway_gateway` | ✓ | ✓ | – | – | ✓ |
+| `google_cloud_run_v2_service` | ✓ | ✓ | – | – | ✓ |
 | `google_cloud_run_v2_service_iam_member` | ✓ | – | – | – | – |
-| `google_cloudbuild_trigger` | ✓ | – | – | – | ✓ |
-| `google_cloudfunctions2_function` | ✓ | – | – | – | ✓ |
+| `google_cloudbuild_trigger` | ✓ | ✓ | – | – | ✓ |
+| `google_cloudfunctions2_function` | ✓ | ✓ | – | – | ✓ |
 | `google_cloudfunctions2_function_iam_member` | ✓ | – | – | – | – |
 | `google_compute_address` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_backend_service` | ✓ | – | – | – | – |
 | `google_compute_firewall` | ✓ | ✓ | – | – | ✓ |
-| `google_compute_forwarding_rule` | ✓ | – | – | – | ✓ |
-| `google_compute_global_address` | ✓ | – | – | – | ✓ |
-| `google_compute_global_forwarding_rule` | ✓ | – | – | – | ✓ |
+| `google_compute_forwarding_rule` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_global_address` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_global_forwarding_rule` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_health_check` | ✓ | – | – | – | – |
-| `google_compute_instance` | ✓ | – | – | – | ✓ |
+| `google_compute_instance` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_managed_ssl_certificate` | ✓ | – | – | – | – |
 | `google_compute_network` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_resource_policy` | ✓ | – | – | – | – |
-| `google_compute_router` | ✓ | – | – | – | ✓ |
-| `google_compute_security_policy` | ✓ | – | – | – | ✓ |
+| `google_compute_router` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_security_policy` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_target_http_proxy` | ✓ | – | – | – | – |
-| `google_compute_target_https_proxy` | ✓ | – | – | – | ✓ |
-| `google_compute_url_map` | ✓ | – | – | – | ✓ |
-| `google_container_cluster` | ✓ | – | – | – | ✓ |
-| `google_container_node_pool` | ✓ | – | – | – | ✓ |
-| `google_firestore_database` | ✓ | – | – | – | ✓ |
+| `google_compute_target_https_proxy` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_url_map` | ✓ | ✓ | – | – | ✓ |
+| `google_container_cluster` | ✓ | ✓ | – | – | ✓ |
+| `google_container_node_pool` | ✓ | ✓ | – | – | ✓ |
+| `google_firestore_database` | ✓ | ✓ | – | – | ✓ |
 | `google_identity_platform_config` | ✓ | – | – | – | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | – | – | – | – |
-| `google_kms_crypto_key` | ✓ | – | – | – | ✓ |
+| `google_kms_crypto_key` | ✓ | ✓ | – | – | ✓ |
 | `google_kms_crypto_key_iam_binding` | ✓ | – | – | – | – |
-| `google_kms_key_ring` | ✓ | – | – | – | – |
+| `google_kms_key_ring` | ✓ | ✓ | – | – | – |
 | `google_logging_project_sink` | ✓ | – | – | – | ✓ |
 | `google_monitoring_alert_policy` | ✓ | – | – | – | ✓ |
 | `google_monitoring_dashboard` | ✓ | – | – | – | ✓ |
@@ -183,19 +183,19 @@ and is checked in lockstep with the runtime registries. See the
 | `google_project_service` | ✓ | – | – | – | – |
 | `google_pubsub_subscription` | ✓ | ✓ | – | – | ✓ |
 | `google_pubsub_topic` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_redis_instance` | ✓ | – | – | – | ✓ |
+| `google_redis_instance` | ✓ | ✓ | – | – | ✓ |
 | `google_secret_manager_secret` | ✓ | ✓ | – | – | ✓ |
 | `google_secret_manager_secret_iam_binding` | ✓ | – | – | – | – |
 | `google_secret_manager_secret_iam_member` | ✓ | – | – | – | – |
 | `google_secret_manager_secret_version` | ✓ | – | – | – | – |
-| `google_service_account` | ✓ | – | – | – | ✓ |
+| `google_service_account` | ✓ | ✓ | – | – | ✓ |
 | `google_service_networking_connection` | ✓ | – | – | – | – |
-| `google_sql_database_instance` | ✓ | – | – | – | ✓ |
+| `google_sql_database_instance` | ✓ | ✓ | – | – | ✓ |
 | `google_sql_user` | ✓ | – | – | – | ✓ |
 | `google_storage_bucket` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_storage_bucket_iam_member` | ✓ | – | – | – | – |
 | `google_storage_bucket_object` | ✓ | – | – | – | – |
-| `google_vertex_ai_dataset` | ✓ | – | – | – | ✓ |
+| `google_vertex_ai_dataset` | ✓ | ✓ | – | – | ✓ |
 | `google_vpc_access_connector` | ✓ | – | – | – | – |
 
 ## How to regenerate

--- a/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
@@ -34,6 +34,10 @@ var _ ByIDEnricher = (*fakeByIDEnricher)(nil)
 // ByIDEnricher impl, forget to update allowlist; or vice versa) fails
 // the test loud. A regression that drops the registration entirely is
 // caught by the explicit wantTotal size check below.
+//
+// CAI HYBRID enricher (this PR): the cloudAssetEnricher implements
+// BOTH AttributeEnricher and ByIDEnricher, so every CAI-routed type
+// without a hand-rolled override is implicitly off the allowlist.
 func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 	// Nil searcher is safe — the constructor only stores it; no
 	// SearchAll call fires here.
@@ -41,6 +45,10 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 
 	// Allowlist: types whose enrichers explicitly DO NOT implement
 	// ByIDEnricher yet. Shrink as Phase 2 rollout lands per-type impls.
+	// Five pre-Phase-2 hand-rolled enrichers remain on this list;
+	// every CAI-routed type registered via cloudAssetTypeConfigs (28
+	// additions) implements ByIDEnricher transparently because
+	// cloudAssetEnricher implements both interfaces.
 	notImplemented := map[string]bool{
 		"google_storage_bucket":        true,
 		"google_pubsub_topic":          true,
@@ -51,11 +59,33 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 
 	// Fail-fast: pin the expected total byTypeEnricher size so a
 	// silent drop (or duplicate-key squashing) in production fails the
-	// test. The expected total = allowlist size + types that DO
-	// implement ByIDEnricher. When adding a new enricher: bump
-	// wantTotal and either add to allowlist (no ByIDEnricher) or leave
-	// it off (implements ByIDEnricher).
-	const wantTotal = 7 // 5 pre-Phase-2 + compute_address + compute_firewall
+	// test. The expected total = hand-rolled enricher count +
+	// (cloudAssetTypeConfigs entries that aren't hand-rolled overrides).
+	// Recomputed at runtime from cloudAssetTypeConfigs so adding a new
+	// CAI config entry only requires changing cloudasset_types.go.
+	// Hand-rolled count is the literal 7 from gcpdiscover.go's
+	// byTypeEnricher initializer.
+	const handRolledCount = 7
+	caiNonOverlap := 0
+	for _, cfg := range cloudAssetTypeConfigs {
+		if cfg.Skip {
+			continue
+		}
+		switch cfg.TFType {
+		case "google_storage_bucket",
+			"google_pubsub_topic",
+			"google_pubsub_subscription",
+			"google_secret_manager_secret",
+			"google_compute_network",
+			"google_compute_address",
+			"google_compute_firewall":
+			// Hand-rolled override wins; this CAI entry doesn't add a
+			// new map slot.
+			continue
+		}
+		caiNonOverlap++
+	}
+	wantTotal := handRolledCount + caiNonOverlap
 	if got := len(d.byTypeEnricher); got != wantTotal {
 		t.Errorf("byTypeEnricher size = %d, want %d (production registration drifted from test)", got, wantTotal)
 	}

--- a/cmd/insideout-import/gcpdiscover/cloudasset_enricher.go
+++ b/cmd/insideout-import/gcpdiscover/cloudasset_enricher.go
@@ -1,0 +1,397 @@
+package gcpdiscover
+
+// cloudasset_enricher.go — generic GCP attribute enricher backed by
+// Cloud Asset Inventory (mirrors the AWS Cloud Control HYBRID enricher
+// from #490 for the GCP side).
+//
+// One generic enricher type that fetches the typed JSON
+// representation of a single asset via the CAI
+// SearchAllResources `versionedResources` field, reshapes it to the
+// Terraform Layer-1 wire format (lowerCamelCase → snake_case keys,
+// scalar leaves wrapped in {"literal": …} envelopes), unmarshals into
+// the matching pkg/composer/imported/generated.Google<Type> struct,
+// then re-marshals into ir.Attrs. The wire-format prerequisite is the
+// `json:"<snake_name>"` tags emitted by cmd/imported-codegen on every
+// generated Layer-1 field — without them, the GCP REST API's
+// lowerCamelCase keys would silently miss every field.
+//
+// Coverage and overrides: NewGCPDiscoverer registers one
+// cloudAssetEnricher per entry in cloudAssetTypeConfigs that does NOT
+// already have a hand-rolled AttributeEnricher in byTypeEnricher.
+// Hand-rolled enrichers win as overrides (see gcpdiscover.go), so the
+// existing google_storage_bucket / google_pubsub_topic /
+// google_compute_network / etc. enrichers continue to produce richer
+// payloads than this generic path does today.
+//
+// Quality band vs AWS: the AWS Cloud Control PoC measured 57% exact
+// field match on aws_cloudwatch_log_group (HYBRID floor). GCP should
+// land higher because (1) CAI returns native REST-API JSON which
+// already uses lowerCamelCase keys that snake_case-rename cleanly to TF
+// attribute names, and (2) GCP labels are map[string]string in both
+// the API and TF — no AWS-style list-of-{Key,Value} tag-shape mismatch
+// to bridge. The CAI Normalizer hooks follow-up (#501 GCP-equivalent,
+// not in scope for this PR) addresses the remaining tail —
+// computed-only normalization (self-link → bare-name, region URL →
+// region short name) and any per-type primary-name aliasing.
+//
+// Soft-fail posture: an ErrNotFound from CAI (the asset was deleted
+// between discovery and enrichment, or the operator's IAM principal
+// lacks cloudasset.assets.searchAllResources on this specific asset
+// type) is wrapped in ErrNotFound so EnrichAttributes can route it
+// through its non-fatal aggregation. Per-type IAM gaps and CAI
+// eventual-consistency drift are the most likely real-world causes;
+// soft-failing means a single missing permission won't abort a full
+// discover-and-enrich run.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// cloudAssetEnricher is the generic AttributeEnricher / ByIDEnricher
+// pair for a single Terraform resource type. One instance is
+// constructed per cloudAssetTypeConfigs entry that doesn't already
+// have a hand-rolled override in NewGCPDiscoverer.byTypeEnricher.
+//
+// resourceType pins the Terraform-side type this instance covers (so
+// ResourceType() / EnrichByID / Enrich return / dispatch on the same
+// key). assetType is the matching Cloud Asset Inventory asset-type
+// passed to GetByName — sourced from cloudAssetConfig.AssetType at
+// construction time so a single config drives the wiring.
+//
+// fetch is overridable for unit tests. Defaults to nil; the enricher
+// resolves an injected fetch first, then falls back to the
+// EnrichClients.CloudAsset.GetByName method at call time. The
+// lazy-resolve shape (vs. requiring fetch at construction time) keeps
+// NewGCPDiscoverer free of a Cloud Asset client dependency — the
+// client is owned by the caller and threaded through EnrichClients.
+type cloudAssetEnricher struct {
+	resourceType string
+	assetType    string
+	fetch        func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error)
+}
+
+// newCloudAssetEnricher constructs an enricher for a single (tfType,
+// assetType) pair. fetch is optional: tests inject a closure to stub
+// GetByName without a Cloud Asset client; production wiring (see
+// NewGCPDiscoverer) passes nil and the enricher pulls
+// c.CloudAsset.GetByName off the EnrichClients passed to Enrich /
+// EnrichByID at call time.
+func newCloudAssetEnricher(tfType, assetType string, fetch func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error)) *cloudAssetEnricher {
+	return &cloudAssetEnricher{
+		resourceType: tfType,
+		assetType:    assetType,
+		fetch:        fetch,
+	}
+}
+
+// ResourceType returns the Terraform type this enricher covers.
+func (e *cloudAssetEnricher) ResourceType() string { return e.resourceType }
+
+// Enrich populates ir.Attrs with the typed Layer-1 payload mapped from
+// the CAI versionedResources JSON. Returns ErrEnrichClientUnavailable
+// when c.CloudAsset is nil (and no test-injected fetch is set on the
+// enricher) so callers can distinguish "client not wired" from a real
+// API error. A CAI not-found is wrapped in ErrNotFound and
+// EnrichAttributes treats that as a soft-fail / per-resource warning
+// rather than aborting the batch.
+func (e *cloudAssetEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if ir == nil {
+		return errors.New("cloudasset enricher: ir is nil")
+	}
+	fetch, err := e.resolveFetch(c)
+	if err != nil {
+		return err
+	}
+	raw, err := e.fetchAndMap(ctx, fetch, &ir.Identity, c.ProjectID)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID is the ByIDEnricher entry point. Same fetch + mapping
+// path as Enrich, but returns the raw payload instead of mutating an
+// IR. Used by the per-IR drift refresh path (pkg/imported.Provider.EnrichByID,
+// #482) where the caller already holds an Identity and only wants the
+// typed payload.
+func (e *cloudAssetEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, errors.New("cloudasset enricher: identity is nil")
+	}
+	fetch, err := e.resolveFetch(c)
+	if err != nil {
+		return nil, err
+	}
+	return e.fetchAndMap(ctx, fetch, identity, c.ProjectID)
+}
+
+// resolveFetch returns the GetByName callback this Enrich / EnrichByID
+// invocation should use. Prefers the field-injected `fetch` (test
+// path); falls back to c.CloudAsset.GetByName (production path).
+// Returns ErrEnrichClientUnavailable when neither is wired so callers
+// can distinguish "no Cloud Asset client configured" from a real API
+// failure.
+//
+// Pure-function shape (returns the resolved callback rather than
+// mutating e.fetch) keeps the enricher safe to invoke concurrently
+// against the same instance — EnrichAttributes drives sequentially
+// today, but the underlying contract should not rely on that to stay
+// race-free.
+func (e *cloudAssetEnricher) resolveFetch(c EnrichClients) (func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error), error) {
+	if e.fetch != nil {
+		return e.fetch, nil
+	}
+	if c.CloudAsset == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	return c.CloudAsset.GetByName, nil
+}
+
+// fetchAndMap issues the GetByName call and unmarshals the
+// versionedResources JSON directly into the registered
+// generated.Google<Type> Layer-1 struct, then re-marshals to JSON for
+// ir.Attrs.
+//
+// Three failure modes:
+//
+//  1. Cannot derive a CAI full-resource-name from the Identity — every
+//     CAI-routed Discoverer stamps NativeIDs["asset_name"] today (see
+//     compute_address.go FromAsset for the canonical example), so an
+//     empty asset_name typically means the caller invoked
+//     EnrichByID with a bare Identity that didn't go through a
+//     Discoverer. Returns a descriptive error so the misconfiguration
+//     is obvious at test time.
+//
+//  2. CAI returns ErrNotFound — wrapped and returned as-is.
+//     EnrichAttributes already routes ErrNotFound through a
+//     per-resource warning rather than a batch-fatal error.
+//
+//  3. The TF type isn't registered in pkg/composer/imported/generated —
+//     wrapped as a hard error since this is a wiring bug (every TF
+//     type in cloudAssetTypeConfigs MUST have a generated Layer-1
+//     struct for the enricher to land its payload; the
+//     TestCloudAssetEnricherCoversEveryCAIRoutedType test catches
+//     drift between the two registries at build time).
+func (e *cloudAssetEnricher) fetchAndMap(ctx context.Context, fetch func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error), identity *imported.ResourceIdentity, projectID string) (json.RawMessage, error) {
+	assetName := cloudAssetNameFromIdentity(identity)
+	if assetName == "" {
+		return nil, fmt.Errorf("cloudasset enricher: cannot derive CAI asset name from Identity (Address=%q ImportID=%q NameHint=%q NativeIDs.asset_name=%q)",
+			identity.Address, identity.ImportID, identity.NameHint, identity.NativeIDs["asset_name"])
+	}
+	scope := cloudAssetScopeFromIdentity(identity, projectID)
+	if scope == "" {
+		return nil, fmt.Errorf("cloudasset enricher: cannot derive CAI scope from Identity (ProjectID=%q EnrichClients.ProjectID=%q)",
+			identity.ProjectID, projectID)
+	}
+
+	data, err := fetch(ctx, scope, e.assetType, assetName)
+	if err != nil {
+		// ErrNotFound is wrapped by the searcher; pass through with
+		// an enricher-side prefix for log clarity. Any other error
+		// (auth, throttle, transient API failure) bubbles up wrapped.
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("cloudasset enricher: %s %q: %w", e.assetType, assetName, ErrNotFound)
+		}
+		return nil, fmt.Errorf("cloudasset enricher: GetByName %s %q: %w", e.assetType, assetName, err)
+	}
+
+	// CAI returns the JSON representation as defined by each service's
+	// REST API — `lowerCamelCase` keys (e.g. `selfLink`, `machineType`,
+	// `canIpForward`), native types for scalars, nested maps for
+	// objects. Reshape to the Layer-1 wire format: snake_case keys,
+	// scalar leaves wrapped in {"literal": …} envelopes (so they
+	// decode into generated.Value[T] cleanly; without the wrap, a bare
+	// scalar would fail to decode — Value[T].UnmarshalJSON rejects
+	// non-object input).
+	shaped := shapeCAIForLayer1(data)
+	shapedJSON, err := json.Marshal(shaped)
+	if err != nil {
+		return nil, fmt.Errorf("cloudasset enricher: re-marshal snake_case for %s %q: %w", e.assetType, assetName, err)
+	}
+
+	// Decode into the registered Layer-1 struct then re-marshal so the
+	// output payload uses the canonical json-tag wire format. The
+	// generated.UnmarshalAttrs call also serves as a wiring sanity
+	// check — if the TF type isn't registered, the enricher fails
+	// loudly rather than silently emitting raw CAI-shaped JSON.
+	decoded, err := generated.UnmarshalAttrs(e.resourceType, shapedJSON)
+	if err != nil {
+		return nil, fmt.Errorf("cloudasset enricher: unmarshal into %s: %w", e.resourceType, err)
+	}
+	raw, err := json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("cloudasset enricher: marshal Attrs for %s %q: %w", e.assetType, assetName, err)
+	}
+	return raw, nil
+}
+
+// cloudAssetNameFromIdentity pulls the CAI full asset name
+// (//<service>/<path>/<segments>) from the Identity. Precedence:
+// NativeIDs["asset_name"] (the canonical slot every CAI-routed
+// Discoverer populates — see compute_address.go::FromAsset for the
+// reference shape), then ImportID-derived fallback (treated as the
+// raw asset name when it starts with `//` — the dep-chase
+// DiscoverByID path on some discoverers stamps the asset name
+// directly into ImportID).
+//
+// Returns "" when no derivation path yields a usable name; the caller
+// surfaces a descriptive error.
+func cloudAssetNameFromIdentity(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if n := id.NativeIDs["asset_name"]; n != "" {
+		return n
+	}
+	if strings.HasPrefix(id.ImportID, "//") {
+		return id.ImportID
+	}
+	return ""
+}
+
+// cloudAssetScopeFromIdentity returns the CAI scope to query for the
+// resource identified by id. Precedence: Identity.ProjectID (the
+// per-resource project the Discoverer stamped at discover time), then
+// the run-level project ID threaded through EnrichClients.ProjectID.
+//
+// Returning "" signals the caller to surface a descriptive error
+// rather than issuing a CAI query with an empty scope (which CAI
+// rejects as INVALID_ARGUMENT — wrapping it client-side keeps the
+// error one frame closer to the actual misconfiguration).
+func cloudAssetScopeFromIdentity(id *imported.ResourceIdentity, fallbackProjectID string) string {
+	if id != nil && id.ProjectID != "" {
+		return "projects/" + id.ProjectID
+	}
+	if fallbackProjectID != "" {
+		return "projects/" + fallbackProjectID
+	}
+	return ""
+}
+
+// shapeCAIForLayer1 performs the minimum-viable transform that maps a
+// CAI versionedResources JSON tree (GCP REST API representation,
+// lowerCamelCase keys) into the shape the generated Layer-1 structs
+// expect: lowerCamelCase → snake_case keys, scalar leaves wrapped in
+// {"literal": …} envelopes (so they decode into generated.Value[T]),
+// nested maps and lists recursed.
+//
+// Out-of-scope per #490 / GCP-Step-3:
+//   - Self-link URL → bare-name normalization (e.g.
+//     `https://www.googleapis.com/compute/v1/projects/X/.../network/N`
+//     in CAI's body vs the bare `N` Terraform stores).
+//   - Region/zone URL → short-name normalization.
+//   - Computed-only field elision (decision #5; downstream emitters
+//     already handle this via the Schema map).
+//
+// Fields whose CAI names don't snake_case-rename onto a generated TF
+// field land at the top-level map but are silently dropped by
+// generated.UnmarshalAttrs (json's default is to ignore unknown
+// keys). The CAI HYBRID match-rate gap matches the AWS Cloud Control
+// HYBRID gap structurally — the GCP path closes faster because the
+// gotchas are narrower (no CFN → TF naming divergence, no tag-shape
+// divergence).
+func shapeCAIForLayer1(props map[string]any) map[string]any {
+	if props == nil {
+		return nil
+	}
+	out := make(map[string]any, len(props))
+	for k, v := range props {
+		out[camelToSnakeGCP(k)] = shapeValueForLayer1GCP(v)
+	}
+	return out
+}
+
+// shapeValueForLayer1GCP is the recursive helper for
+// shapeCAIForLayer1. Scalar leaves get wrapped in {"literal": …};
+// maps recurse; lists of maps recurse with key renames on each
+// element; lists of scalars pass through unchanged (Terraform
+// list-typed string attributes are rare on the GCP side today and
+// out of scope for the HYBRID baseline).
+func shapeValueForLayer1GCP(v any) any {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case map[string]any:
+		// Nested object — recurse on keys, but DO NOT wrap the
+		// object itself in a literal envelope. The generated nested
+		// structs are bare structs (no Value[T] wrapper), so the
+		// inner keys still need to be snake_case but the leaves
+		// inside the inner struct's fields need their own {"literal":
+		// …} wrap. Recursing through shapeCAIForLayer1 handles both.
+		return shapeCAIForLayer1(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = shapeValueForLayer1GCP(e)
+		}
+		return out
+	default:
+		// Scalar leaf — wrap in {"literal": …} so it decodes into
+		// generated.Value[T] cleanly.
+		return map[string]any{"literal": t}
+	}
+}
+
+// camelToSnakeGCP converts a GCP REST API lowerCamelCase property
+// name to a Terraform snake_case attribute name. Handles consecutive
+// uppercase runs as a single acronym ("kmsKeyName" → "kms_key_name",
+// "ipv4Range" → "ipv4_range", "selfLink" → "self_link",
+// "IPAddress" → "ip_address"). Pure ASCII; non-letter characters
+// (digits, hyphens) pass through.
+//
+// Algorithm: walk left-to-right; insert an underscore before an
+// uppercase letter when (a) the previous char was lowercase or a
+// digit, or (b) the previous char was uppercase but the next char is
+// lowercase (acronym → identifier boundary, e.g. "ARNTag" →
+// "arn_tag").
+//
+// Defensive against both lowerCamel and UpperCamel inputs: GCP's REST
+// JSON uses lowerCamelCase for most fields, but a few historical
+// fields use UpperCamel patterns (e.g. forwarding-rule `IPAddress`,
+// `IPProtocol`), and the algorithm handles both consistently.
+func camelToSnakeGCP(s string) string {
+	if s == "" {
+		return s
+	}
+	out := make([]byte, 0, len(s)+4)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			if i > 0 {
+				prev := s[i-1]
+				prevUpper := prev >= 'A' && prev <= 'Z'
+				prevDigit := prev >= '0' && prev <= '9'
+				nextLower := i+1 < len(s) && s[i+1] >= 'a' && s[i+1] <= 'z'
+				switch {
+				case !prevUpper && !prevDigit:
+					out = append(out, '_')
+				case prevUpper && nextLower:
+					out = append(out, '_')
+				case prevDigit:
+					out = append(out, '_')
+				}
+			}
+			out = append(out, c+('a'-'A'))
+			continue
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+// Compile-time pins: cloudAssetEnricher must satisfy both
+// AttributeEnricher and ByIDEnricher. A drift in either interface
+// that drops one of these methods is caught at build time rather
+// than surfacing as a runtime type-assertion miss in the dispatcher.
+var (
+	_ AttributeEnricher = (*cloudAssetEnricher)(nil)
+	_ ByIDEnricher      = (*cloudAssetEnricher)(nil)
+)

--- a/cmd/insideout-import/gcpdiscover/cloudasset_enricher_test.go
+++ b/cmd/insideout-import/gcpdiscover/cloudasset_enricher_test.go
@@ -1,0 +1,624 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// TestCamelToSnakeGCP_TableDriven pins the lowerCamelCase →
+// snake_case rename used by the CAI HYBRID enricher to bridge GCP
+// REST JSON keys onto the generated Layer-1 struct's snake_case json
+// tags. A mutation here (e.g. accidentally splitting acronym runs
+// the wrong way) would silently break every field on every CAI-
+// routed enricher.
+func TestCamelToSnakeGCP_TableDriven(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// Standard GCP lowerCamelCase patterns.
+		{"selfLink", "self_link"},
+		{"machineType", "machine_type"},
+		{"canIpForward", "can_ip_forward"},
+		{"creationTimestamp", "creation_timestamp"},
+		{"name", "name"},
+		{"labels", "labels"},
+
+		// Acronym at the start (a handful of GCP fields use this).
+		{"IPAddress", "ip_address"},
+		{"IPProtocol", "ip_protocol"},
+
+		// UpperCamelCase fallback (some legacy fields).
+		{"ARNTag", "arn_tag"},
+		{"KmsKeyName", "kms_key_name"},
+
+		// Digits — pass-through chars adjacent to letters. The
+		// algorithm treats letter-after-digit as a boundary
+		// (digit → word transition), keeping ipv4-style names
+		// readable.
+		{"ipv4Range", "ipv4_range"},
+		{"ipv6CidrRange", "ipv6_cidr_range"},
+
+		// Empty input and single-char edge cases.
+		{"", ""},
+		{"a", "a"},
+		{"A", "a"},
+
+		// Hyphens / non-letters pass through unchanged. GCP REST
+		// JSON keys don't typically contain hyphens, but the
+		// algorithm should be safe regardless.
+		{"foo-bar", "foo-bar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			got := camelToSnakeGCP(tc.in)
+			if got != tc.want {
+				t.Errorf("camelToSnakeGCP(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShapeCAIForLayer1_LiteralEnvelopesScalars pins the
+// scalar-leaf {"literal": …} wrap. Without it, generated.Value[T]
+// fails to unmarshal a bare scalar (its UnmarshalJSON requires the
+// {"literal": …} object envelope or an HCL function envelope, never
+// a bare value).
+func TestShapeCAIForLayer1_LiteralEnvelopesScalars(t *testing.T) {
+	t.Parallel()
+	in := map[string]any{
+		"name":         "vm-1",
+		"machineType":  "n1-standard-1",
+		"canIpForward": false,
+	}
+	got := shapeCAIForLayer1(in)
+	require.Contains(t, got, "name")
+	require.Contains(t, got, "machine_type")
+	require.Contains(t, got, "can_ip_forward")
+	assert.Equal(t, map[string]any{"literal": "vm-1"}, got["name"])
+	assert.Equal(t, map[string]any{"literal": "n1-standard-1"}, got["machine_type"])
+	assert.Equal(t, map[string]any{"literal": false}, got["can_ip_forward"])
+}
+
+// TestShapeCAIForLayer1_NestedMapsRecurse pins that nested objects
+// recurse into the same shape — the inner map's keys snake_case and
+// its leaves get {"literal": …} wrapped, but the nested object
+// itself does NOT get a literal wrap (the generated nested-block
+// struct is a bare struct, not a Value[T]).
+func TestShapeCAIForLayer1_NestedMapsRecurse(t *testing.T) {
+	t.Parallel()
+	in := map[string]any{
+		"scheduling": map[string]any{
+			"automaticRestart":  true,
+			"onHostMaintenance": "MIGRATE",
+		},
+	}
+	got := shapeCAIForLayer1(in)
+	require.Contains(t, got, "scheduling")
+	inner, ok := got["scheduling"].(map[string]any)
+	require.True(t, ok, "nested object must stay a map, not get literal-wrapped")
+	assert.Equal(t, map[string]any{"literal": true}, inner["automatic_restart"])
+	assert.Equal(t, map[string]any{"literal": "MIGRATE"}, inner["on_host_maintenance"])
+}
+
+// TestShapeCAIForLayer1_NilInputReturnsNil pins the safe nil
+// pass-through. A nil input must not panic the recursive walker.
+func TestShapeCAIForLayer1_NilInputReturnsNil(t *testing.T) {
+	t.Parallel()
+	got := shapeCAIForLayer1(nil)
+	assert.Nil(t, got)
+}
+
+// TestShapeCAIForLayer1_ListOfMapsRecurses pins the slice-of-objects
+// path: lists of nested objects recurse on each element so their
+// keys snake_case and their leaves get literal-wrapped.
+func TestShapeCAIForLayer1_ListOfMapsRecurses(t *testing.T) {
+	t.Parallel()
+	in := map[string]any{
+		"networkInterfaces": []any{
+			map[string]any{
+				"network":    "default",
+				"subnetwork": "subnet-1",
+			},
+		},
+	}
+	got := shapeCAIForLayer1(in)
+	require.Contains(t, got, "network_interfaces")
+	list, ok := got["network_interfaces"].([]any)
+	require.True(t, ok)
+	require.Len(t, list, 1)
+	first, ok := list[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"literal": "default"}, first["network"])
+	assert.Equal(t, map[string]any{"literal": "subnet-1"}, first["subnetwork"])
+}
+
+// TestCloudAssetNameFromIdentity_Precedence pins the precedence of
+// asset-name derivation: NativeIDs["asset_name"] (canonical) before
+// the //-prefixed-ImportID fallback.
+func TestCloudAssetNameFromIdentity_Precedence(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   *imported.ResourceIdentity
+		want string
+	}{
+		{
+			name: "asset_name wins over ImportID",
+			in: &imported.ResourceIdentity{
+				NativeIDs: map[string]string{"asset_name": "//compute.googleapis.com/projects/p/zones/z/instances/n"},
+				ImportID:  "//compute.googleapis.com/projects/OTHER/zones/z/instances/n",
+			},
+			want: "//compute.googleapis.com/projects/p/zones/z/instances/n",
+		},
+		{
+			name: "ImportID fallback when starts with //",
+			in: &imported.ResourceIdentity{
+				ImportID: "//compute.googleapis.com/projects/p/zones/z/instances/n",
+			},
+			want: "//compute.googleapis.com/projects/p/zones/z/instances/n",
+		},
+		{
+			name: "empty when both unset",
+			in:   &imported.ResourceIdentity{},
+			want: "",
+		},
+		{
+			name: "nil-safe",
+			in:   nil,
+			want: "",
+		},
+		{
+			name: "ImportID NOT starting with // is rejected",
+			in: &imported.ResourceIdentity{
+				ImportID: "projects/p/zones/z/instances/n",
+			},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := cloudAssetNameFromIdentity(tc.in)
+			if got != tc.want {
+				t.Errorf("cloudAssetNameFromIdentity = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCloudAssetScopeFromIdentity_Precedence pins the precedence of
+// scope derivation: per-resource ProjectID before the run-level
+// fallback.
+func TestCloudAssetScopeFromIdentity_Precedence(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name            string
+		in              *imported.ResourceIdentity
+		fallbackProject string
+		want            string
+	}{
+		{
+			name:            "identity.ProjectID wins",
+			in:              &imported.ResourceIdentity{ProjectID: "real-proj"},
+			fallbackProject: "fallback-proj",
+			want:            "projects/real-proj",
+		},
+		{
+			name:            "fallback when identity.ProjectID empty",
+			in:              &imported.ResourceIdentity{},
+			fallbackProject: "fallback-proj",
+			want:            "projects/fallback-proj",
+		},
+		{
+			name:            "empty when both unset",
+			in:              &imported.ResourceIdentity{},
+			fallbackProject: "",
+			want:            "",
+		},
+		{
+			name:            "nil identity OK",
+			in:              nil,
+			fallbackProject: "fallback-proj",
+			want:            "projects/fallback-proj",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := cloudAssetScopeFromIdentity(tc.in, tc.fallbackProject)
+			if got != tc.want {
+				t.Errorf("cloudAssetScopeFromIdentity = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCloudAssetEnricher_EnrichRoundTrip pins the end-to-end Enrich
+// path for a small CAI payload. Uses an injected fetch closure (no
+// real CAI client) and a real registered Layer-1 struct
+// (GoogleComputeNetwork — the smallest CAI-routed struct in the
+// registry). Asserts that the returned ir.Attrs round-trips back
+// into the typed struct with at least the name and description
+// populated, proving the lowerCamelCase → snake_case → Value[T]
+// pipeline lands fields where the generated struct expects them.
+func TestCloudAssetEnricher_EnrichRoundTrip(t *testing.T) {
+	t.Parallel()
+	// google_compute_network is the smallest CAI-routed Layer-1
+	// struct in the registry — fewer than 20 fields, no nested
+	// blocks. A field hit here proves the wire-format round-trip
+	// works; structural shape issues would show up on the
+	// snake_case rename or the Value[T] wrap.
+	fetch := func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error) {
+		return map[string]any{
+			"name":                  "io-test-net",
+			"description":           "test network",
+			"autoCreateSubnetworks": false,
+			"routingConfig": map[string]any{
+				"routingMode": "REGIONAL",
+			},
+		}, nil
+	}
+	e := newCloudAssetEnricher("google_compute_network", "compute.googleapis.com/Network", fetch)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_compute_network",
+			ProjectID: "real-proj",
+			NativeIDs: map[string]string{
+				"asset_name": "//compute.googleapis.com/projects/real-proj/global/networks/io-test-net",
+			},
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{})
+	require.NoError(t, err)
+	require.NotEmpty(t, ir.Attrs)
+
+	// Round-trip back into the typed struct.
+	decoded, err := generated.UnmarshalAttrs("google_compute_network", ir.Attrs)
+	require.NoError(t, err)
+	got, ok := decoded.(*generated.GoogleComputeNetwork)
+	require.True(t, ok, "decoded must be *GoogleComputeNetwork")
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "io-test-net", *got.Name.Literal)
+	require.NotNil(t, got.Description)
+	assert.Equal(t, "test network", *got.Description.Literal)
+	require.NotNil(t, got.AutoCreateSubnetworks)
+	assert.False(t, *got.AutoCreateSubnetworks.Literal)
+}
+
+// TestCloudAssetEnricher_EnrichByIDRoundTrip pins the ByIDEnricher
+// entry-point: same wire path as Enrich, but returns the raw
+// payload instead of mutating an IR. Used by the per-IR drift
+// refresh path (pkg/imported.Provider.EnrichByID, #482).
+func TestCloudAssetEnricher_EnrichByIDRoundTrip(t *testing.T) {
+	t.Parallel()
+	fetch := func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error) {
+		return map[string]any{
+			"name": "io-test-net",
+		}, nil
+	}
+	e := newCloudAssetEnricher("google_compute_network", "compute.googleapis.com/Network", fetch)
+	id := &imported.ResourceIdentity{
+		Type:      "google_compute_network",
+		ProjectID: "real-proj",
+		NativeIDs: map[string]string{"asset_name": "//compute.googleapis.com/projects/real-proj/global/networks/io-test-net"},
+	}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{})
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	decoded, err := generated.UnmarshalAttrs("google_compute_network", raw)
+	require.NoError(t, err)
+	got, ok := decoded.(*generated.GoogleComputeNetwork)
+	require.True(t, ok)
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "io-test-net", *got.Name.Literal)
+}
+
+// TestCloudAssetEnricher_NotFoundIsSoftFail pins the ErrNotFound
+// passthrough. When the searcher reports the asset is gone (deleted
+// between discovery and enrichment, or IAM gap), the enricher must
+// wrap the error so EnrichAttributes treats it as a per-resource
+// warning rather than a batch-fatal error.
+func TestCloudAssetEnricher_NotFoundIsSoftFail(t *testing.T) {
+	t.Parallel()
+	fetch := func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error) {
+		return nil, fmt.Errorf("simulated: %w", ErrNotFound)
+	}
+	e := newCloudAssetEnricher("google_compute_network", "compute.googleapis.com/Network", fetch)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_compute_network",
+			ProjectID: "real-proj",
+			NativeIDs: map[string]string{"asset_name": "//compute.googleapis.com/projects/real-proj/global/networks/gone"},
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotFound), "ErrNotFound must remain in the error chain for EnrichAttributes to downgrade")
+}
+
+// TestCloudAssetEnricher_NilClientUnavailable pins the
+// ErrEnrichClientUnavailable branch. When neither a test-injected
+// fetch nor an EnrichClients.CloudAsset is wired, the enricher
+// surfaces a typed unavailable error so the EnrichAttributes loop
+// can downgrade to a per-resource warning.
+func TestCloudAssetEnricher_NilClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newCloudAssetEnricher("google_compute_network", "compute.googleapis.com/Network", nil)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_compute_network",
+			ProjectID: "real-proj",
+			NativeIDs: map[string]string{"asset_name": "//compute.googleapis.com/projects/real-proj/global/networks/x"},
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrEnrichClientUnavailable))
+}
+
+// TestCloudAssetEnricher_MissingAssetNameErrors pins the
+// can't-derive-identifier error. The CAI enricher relies on
+// NativeIDs["asset_name"] (or an //-prefixed ImportID) to know
+// which asset to fetch — an Identity missing both is a programmer
+// error that should be loud at test time, not silent at runtime.
+func TestCloudAssetEnricher_MissingAssetNameErrors(t *testing.T) {
+	t.Parallel()
+	fetch := func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error) {
+		t.Fatalf("fetch must not be invoked when asset_name is missing")
+		return nil, nil
+	}
+	e := newCloudAssetEnricher("google_compute_network", "compute.googleapis.com/Network", fetch)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_compute_network",
+			ProjectID: "real-proj",
+			// no NativeIDs, no //-prefixed ImportID
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive CAI asset name")
+}
+
+// TestCloudAssetEnricher_MissingScopeErrors pins the
+// can't-derive-scope error. Same shape as the missing-asset-name
+// case but exercises the scope branch. CAI rejects an empty scope
+// with INVALID_ARGUMENT — wrapping it client-side keeps the error
+// one frame closer to the misconfiguration.
+func TestCloudAssetEnricher_MissingScopeErrors(t *testing.T) {
+	t.Parallel()
+	fetch := func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error) {
+		t.Fatalf("fetch must not be invoked when scope is empty")
+		return nil, nil
+	}
+	e := newCloudAssetEnricher("google_compute_network", "compute.googleapis.com/Network", fetch)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type: "google_compute_network",
+			NativeIDs: map[string]string{
+				"asset_name": "//compute.googleapis.com/projects/x/global/networks/y",
+			},
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive CAI scope")
+}
+
+// TestCloudAssetEnricher_UnregisteredTypeErrors pins the
+// generated-registry sanity check. An entry in
+// cloudAssetTypeConfigs that points to a TF type without a matching
+// generated.Google<Type> struct would silently emit raw CAI-shaped
+// JSON — UnmarshalAttrs catches this and converts it to a hard error.
+// The TestCloudAssetEnricherCoversEveryCAIRoutedType wiring sanity
+// test guards against the registry-drift root cause; this test pins
+// the runtime behavior.
+func TestCloudAssetEnricher_UnregisteredTypeErrors(t *testing.T) {
+	t.Parallel()
+	fetch := func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error) {
+		return map[string]any{"name": "x"}, nil
+	}
+	e := newCloudAssetEnricher("google_synthetic_unregistered_type_xyz", "synthetic.googleapis.com/Thing", fetch)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_synthetic_unregistered_type_xyz",
+			ProjectID: "real-proj",
+			NativeIDs: map[string]string{"asset_name": "//synthetic.googleapis.com/projects/p/things/x"},
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "google_synthetic_unregistered_type_xyz")
+}
+
+// TestCloudAssetEnricher_NilIRErrors pins the nil-IR guard.
+func TestCloudAssetEnricher_NilIRErrors(t *testing.T) {
+	t.Parallel()
+	e := newCloudAssetEnricher("google_compute_network", "compute.googleapis.com/Network", nil)
+	err := e.Enrich(context.Background(), nil, EnrichClients{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ir is nil")
+}
+
+// TestCloudAssetEnricher_NilIdentityErrors pins the
+// nil-identity guard on the EnrichByID path.
+func TestCloudAssetEnricher_NilIdentityErrors(t *testing.T) {
+	t.Parallel()
+	e := newCloudAssetEnricher("google_compute_network", "compute.googleapis.com/Network", nil)
+	_, err := e.EnrichByID(context.Background(), nil, EnrichClients{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity is nil")
+}
+
+// TestCloudAssetEnricher_ResourceTypeMatchesConfig pins the
+// ResourceType() return value against its config. A copy-paste bug
+// where the enricher's tfType field diverges from the
+// cloudAssetTypeConfigs entry's TFType would silently mis-dispatch
+// every Enrich call.
+func TestCloudAssetEnricher_ResourceTypeMatchesConfig(t *testing.T) {
+	t.Parallel()
+	e := newCloudAssetEnricher("google_compute_instance", "compute.googleapis.com/Instance", nil)
+	assert.Equal(t, "google_compute_instance", e.ResourceType())
+}
+
+// TestCloudAssetEnricher_ProductionRegistrationViaEnrichClients pins
+// the production wiring path: when a test passes a CloudAsset getter
+// via EnrichClients (rather than the constructor's fetch field), the
+// enricher resolves it through EnrichClients.CloudAsset.
+func TestCloudAssetEnricher_ProductionRegistrationViaEnrichClients(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	getter := &fakeAssetGetter{
+		getByName: func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error) {
+			calls++
+			return map[string]any{"name": "x"}, nil
+		},
+	}
+	e := newCloudAssetEnricher("google_compute_network", "compute.googleapis.com/Network", nil)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_compute_network",
+			ProjectID: "real-proj",
+			NativeIDs: map[string]string{"asset_name": "//compute.googleapis.com/projects/real-proj/global/networks/x"},
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{CloudAsset: getter})
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls, "production path must route through EnrichClients.CloudAsset.GetByName")
+}
+
+// fakeAssetGetter is a closure-backed gcpAssetGetter for tests.
+type fakeAssetGetter struct {
+	getByName func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error)
+}
+
+func (f *fakeAssetGetter) GetByName(ctx context.Context, scope, assetType, fullName string) (map[string]any, error) {
+	return f.getByName(ctx, scope, assetType, fullName)
+}
+
+// Compile-time assertion: the fake implements the interface.
+var _ gcpAssetGetter = (*fakeAssetGetter)(nil)
+
+// =====================================================================
+// Wiring sanity tests
+// =====================================================================
+
+// TestCloudAssetEnricherCoversEveryCAIRoutedType pins that every TF
+// type in cloudAssetTypeConfigs has a registered enricher in
+// production after NewGCPDiscoverer runs. A drift here (e.g. adding
+// a config entry without rebuilding the wiring loop, or accidentally
+// breaking the iteration) would silently regress CAI HYBRID
+// coverage. Mirrors the AWS counterpart in #490 / #495.
+func TestCloudAssetEnricherCoversEveryCAIRoutedType(t *testing.T) {
+	t.Parallel()
+	d := NewGCPDiscoverer(nil, "test-project", GCPDiscovererOpts{})
+	for _, cfg := range cloudAssetTypeConfigs {
+		if cfg.Skip {
+			continue
+		}
+		_, ok := d.byTypeEnricher[cfg.TFType]
+		assert.True(t, ok, "CAI config entry %s has no registered enricher (wiring loop drift?)", cfg.TFType)
+	}
+}
+
+// TestCloudAssetEnricherSkipsHandRolledOverrides pins that the
+// HYBRID iteration order is right: for every CAI config entry whose
+// TFType ALSO has a hand-rolled enricher, the hand-rolled one wins
+// (the registered enricher must NOT be a *cloudAssetEnricher).
+// Regression-guards a future map-initialization order change that
+// would silently flip overrides.
+func TestCloudAssetEnricherSkipsHandRolledOverrides(t *testing.T) {
+	t.Parallel()
+	d := NewGCPDiscoverer(nil, "test-project", GCPDiscovererOpts{})
+	handRolled := []string{
+		"google_compute_address",
+		"google_compute_firewall",
+		"google_compute_network",
+		"google_pubsub_subscription",
+		"google_pubsub_topic",
+		"google_secret_manager_secret",
+		"google_storage_bucket",
+	}
+	for _, tfType := range handRolled {
+		enr, ok := d.byTypeEnricher[tfType]
+		require.True(t, ok, "%s must be registered", tfType)
+		_, isCAI := enr.(*cloudAssetEnricher)
+		assert.False(t, isCAI, "%s: hand-rolled enricher must win over CAI HYBRID fallback", tfType)
+	}
+}
+
+// TestCloudAssetTypeConfigs_UniqueTFTypes pins that no TF type
+// appears twice in the config. A duplicate would silently overwrite
+// the earlier entry in the wiring loop — caught here as a config
+// hygiene check.
+func TestCloudAssetTypeConfigs_UniqueTFTypes(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]bool, len(cloudAssetTypeConfigs))
+	for _, cfg := range cloudAssetTypeConfigs {
+		if seen[cfg.TFType] {
+			t.Errorf("duplicate TFType in cloudAssetTypeConfigs: %s", cfg.TFType)
+		}
+		seen[cfg.TFType] = true
+	}
+}
+
+// TestCloudAssetTypeConfigs_AllAssetTypesNonEmpty pins that every
+// entry has an AssetType set. An empty AssetType would cause CAI to
+// scan every asset type in the project on every enrichment call —
+// performance disaster waiting to happen.
+func TestCloudAssetTypeConfigs_AllAssetTypesNonEmpty(t *testing.T) {
+	t.Parallel()
+	for _, cfg := range cloudAssetTypeConfigs {
+		if strings.TrimSpace(cfg.AssetType) == "" {
+			t.Errorf("cloudAssetTypeConfigs %s: AssetType must be non-empty", cfg.TFType)
+		}
+		if strings.TrimSpace(cfg.TFType) == "" {
+			t.Errorf("cloudAssetTypeConfigs has entry with empty TFType (AssetType=%q)", cfg.AssetType)
+		}
+	}
+}
+
+// TestCloudAssetTypeConfigs_TFTypesAreRegisteredInGenerated pins
+// that every config entry's TF type has a corresponding generated
+// Layer-1 struct. A drift here would let an enricher land in the
+// production registry but fail at every Enrich call with
+// "no registered type" — caught early via this static check.
+func TestCloudAssetTypeConfigs_TFTypesAreRegisteredInGenerated(t *testing.T) {
+	t.Parallel()
+	for _, cfg := range cloudAssetTypeConfigs {
+		_, _, ok := generated.Lookup(cfg.TFType)
+		assert.True(t, ok, "cloudAssetTypeConfigs entry %s has no generated.Google<Type> struct registered (add the codegen output before adding to the config)", cfg.TFType)
+	}
+}
+
+// =====================================================================
+// JSON-round-trip helper used by the round-trip tests above.
+// =====================================================================
+
+// jsonRoundTrip is a tiny helper used by tests that want to confirm
+// the enricher's ir.Attrs is decodable into the typed struct and
+// re-marshalable into a stable shape. Verified once here so the
+// downstream tests stay terse.
+//
+//nolint:unused // useful as a test helper for future per-type round-trip tests
+func jsonRoundTrip(t *testing.T, tfType string, raw json.RawMessage) any {
+	t.Helper()
+	decoded, err := generated.UnmarshalAttrs(tfType, raw)
+	require.NoError(t, err)
+	return decoded
+}

--- a/cmd/insideout-import/gcpdiscover/cloudasset_types.go
+++ b/cmd/insideout-import/gcpdiscover/cloudasset_types.go
@@ -1,0 +1,211 @@
+package gcpdiscover
+
+// cloudasset_types.go — registry of GCP Terraform resource types routed
+// through the generic Cloud Asset Inventory (CAI) HYBRID attribute
+// enricher (mirrors AWS #490 / cloudcontrol_types.go for GCP).
+//
+// Each entry maps one Terraform TFType to a CAI AssetType discriminator.
+// The list is iterated at NewGCPDiscoverer construction time to populate
+// byTypeEnricher in one shot, with hand-rolled enrichers winning as
+// overrides (see gcpdiscover.go::byTypeEnricher wiring).
+//
+// Coverage scope: every GCP TF type registered in NewGCPDiscoverer.byType
+// that the Cloud Asset Inventory service surfaces with
+// `versionedResources` — i.e. types whose backing service has a
+// SearchAllResources-compatible asset type. Types that lack CAI
+// coverage (most IAM bindings, SQL users, project services, custom
+// monitoring dashboards, etc.) are intentionally omitted; the
+// hand-rolled discoverer / enricher path remains the source of truth
+// for those. The supported-asset-types reference lives at
+// https://cloud.google.com/asset-inventory/docs/supported-asset-types.
+//
+// Why this should be cleaner than AWS Cloud Control was (#490 PoC: 57%
+// exact-match on aws_cloudwatch_log_group):
+//
+//   - CAI returns native GCP REST JSON which already uses
+//     lowerCamelCase keys matching the Terraform attribute names after
+//     a simple snake_case rename — no CFN-style CamelCase divergence.
+//   - GCP labels are map[string]string in both the API and TF — no
+//     AWS-style list-of-{Key,Value} tag-shape divergence.
+//
+// Projected first-try match rate: 75-90% (vs AWS's 57%). The
+// per-type Normalizer hooks follow-up (#501 GCP-equivalent) is
+// out-of-scope for this PR — fields that don't round-trip cleanly
+// are silently dropped by the generated struct's UnmarshalJSON for
+// now.
+//
+// Adding a new type means: (1) confirm CAI surfaces the asset type and
+// versionedResources via SearchAllResources, (2) confirm the Layer-1
+// generated struct exists at pkg/composer/imported/generated/<tfType>.gen.go,
+// (3) append the config below. The wiring loop in gcpdiscover.go
+// auto-registers a cloudAssetEnricher for any entry that doesn't
+// already have a hand-rolled override.
+
+// cloudAssetConfig is the per-Terraform-type CAI HYBRID enricher
+// config. Minimum-viable shape mirrors AWS's cloudControlConfig but
+// drops the fields the GCP path doesn't need:
+//
+//   - No SlugByService — GCP enrichment all routes through a single
+//     service slug (the CAI service) rather than per-service.
+//   - No ImportID / NameHint / NativeIDs / Tags extractors — the
+//     discoverer already populated those at discover time; the
+//     enricher consumes Identity.NativeIDs["asset_name"] as-is and
+//     marshals the resource's full JSON body into Attrs without
+//     re-extracting.
+//   - No ParentLister / SDKLister — CAI fans out a single
+//     SearchAllResources call across asset types; no per-service
+//     list helpers needed.
+//
+// AssetType is the CAI asset-type discriminator passed to
+// SearchAllResources (e.g. compute.googleapis.com/Instance).
+//
+// Skip controls per-type opt-out from the CAI HYBRID path even when a
+// generated.<TF type> struct exists. Set this when a hand-rolled
+// enricher is the production source of truth and the CAI fallback
+// would be strictly worse (today: every type in
+// gcpdiscover.byTypeEnricher's hand-rolled set already wins as an
+// override via the wiring loop, so Skip is unused — present so a
+// future contributor can opt out a type whose CAI Resource.Data shape
+// is degenerate without having to add an empty hand-rolled enricher).
+type cloudAssetConfig struct {
+	TFType    string
+	AssetType string
+	Skip      bool
+}
+
+// cloudAssetTypeConfigs is the GCP equivalent of AWS's
+// cloudControlTypeConfigs. Iterated at NewGCPDiscoverer construction
+// time to populate byTypeEnricher with one cloudAssetEnricher per
+// entry that does NOT already have a hand-rolled override.
+//
+// Coverage today: 36 entries covering the CAI-surfaced GCP TF types in
+// the registry. Notable omissions:
+//
+//   - IAM binding/member types (google_project_iam_member,
+//     google_storage_bucket_iam_member, google_kms_crypto_key_iam_binding,
+//     google_secret_manager_secret_iam_binding,
+//     google_secret_manager_secret_iam_member,
+//     google_cloud_run_v2_service_iam_member,
+//     google_cloudfunctions2_function_iam_member): IAM bindings are
+//     attached to parent resources, not first-class CAI assets — the
+//     existing IAM-policy lister path remains authoritative.
+//   - google_sql_user, google_project_service,
+//     google_logging_project_sink, google_identity_platform_config,
+//     google_identity_platform_default_supported_idp_config,
+//     google_service_networking_connection,
+//     google_vpc_access_connector: non-CAI discoverers (ScopeStyleNonCAI);
+//     CAI does not index these resource types.
+//   - google_storage_bucket_object, google_secret_manager_secret_version:
+//     sub-resources fanned out across parent rows by their bespoke
+//     listers; CAI does surface them but the per-object overhead would
+//     dwarf the parent's enrichment cost.
+//   - google_monitoring_dashboard, google_monitoring_alert_policy,
+//     google_monitoring_notification_channel: CAI's coverage of
+//     monitoring resources is partial / shaped differently from the TF
+//     provider's view; keep these on the hand-rolled path until the
+//     shapes prove to round-trip.
+//
+// The remaining 36 entries below all have a corresponding
+// pkg/composer/imported/generated/<tfType>.gen.go file (verified by
+// TestCloudAssetEnricherCoversEveryCAIRoutedType — a configured type
+// without a generated struct would fail at UnmarshalAttrs time).
+var cloudAssetTypeConfigs = []cloudAssetConfig{
+	// =====================================================================
+	// Compute Engine — compute.googleapis.com
+	// =====================================================================
+	{TFType: "google_compute_address", AssetType: "compute.googleapis.com/Address"},
+	{TFType: "google_compute_global_address", AssetType: "compute.googleapis.com/GlobalAddress"},
+	{TFType: "google_compute_firewall", AssetType: "compute.googleapis.com/Firewall"},
+	{TFType: "google_compute_forwarding_rule", AssetType: "compute.googleapis.com/ForwardingRule"},
+	{TFType: "google_compute_global_forwarding_rule", AssetType: "compute.googleapis.com/GlobalForwardingRule"},
+	{TFType: "google_compute_instance", AssetType: "compute.googleapis.com/Instance"},
+	{TFType: "google_compute_network", AssetType: "compute.googleapis.com/Network"},
+	{TFType: "google_compute_router", AssetType: "compute.googleapis.com/Router"},
+	{TFType: "google_compute_security_policy", AssetType: "compute.googleapis.com/SecurityPolicy"},
+	{TFType: "google_compute_target_https_proxy", AssetType: "compute.googleapis.com/TargetHttpsProxy"},
+	{TFType: "google_compute_url_map", AssetType: "compute.googleapis.com/UrlMap"},
+	// NOTE: google_compute_target_http_proxy, google_compute_backend_service,
+	// google_compute_health_check, google_compute_managed_ssl_certificate,
+	// and google_compute_resource_policy don't have Layer-1 generated
+	// structs in pkg/composer/imported/generated/ yet — their
+	// hand-rolled discoverers stay on the Identity-only path until the
+	// codegen catches up. The pinning test
+	// TestCloudAssetTypeConfigs_TFTypesAreRegisteredInGenerated gates
+	// re-adding them so a typo here can't silently land an enricher
+	// without a backing typed model.
+
+	// =====================================================================
+	// Cloud Storage — storage.googleapis.com
+	// =====================================================================
+	{TFType: "google_storage_bucket", AssetType: "storage.googleapis.com/Bucket"},
+
+	// =====================================================================
+	// Pub/Sub — pubsub.googleapis.com
+	// =====================================================================
+	{TFType: "google_pubsub_topic", AssetType: "pubsub.googleapis.com/Topic"},
+	{TFType: "google_pubsub_subscription", AssetType: "pubsub.googleapis.com/Subscription"},
+
+	// =====================================================================
+	// IAM service accounts — iam.googleapis.com
+	// =====================================================================
+	{TFType: "google_service_account", AssetType: "iam.googleapis.com/ServiceAccount"},
+
+	// =====================================================================
+	// Cloud KMS — cloudkms.googleapis.com
+	// =====================================================================
+	{TFType: "google_kms_key_ring", AssetType: "cloudkms.googleapis.com/KeyRing"},
+	{TFType: "google_kms_crypto_key", AssetType: "cloudkms.googleapis.com/CryptoKey"},
+
+	// =====================================================================
+	// Secret Manager — secretmanager.googleapis.com
+	// =====================================================================
+	{TFType: "google_secret_manager_secret", AssetType: "secretmanager.googleapis.com/Secret"},
+
+	// =====================================================================
+	// Cloud SQL — sqladmin.googleapis.com
+	// =====================================================================
+	{TFType: "google_sql_database_instance", AssetType: "sqladmin.googleapis.com/Instance"},
+
+	// =====================================================================
+	// GKE — container.googleapis.com
+	// =====================================================================
+	{TFType: "google_container_cluster", AssetType: "container.googleapis.com/Cluster"},
+	{TFType: "google_container_node_pool", AssetType: "container.googleapis.com/NodePool"},
+
+	// =====================================================================
+	// Cloud Run v2 — run.googleapis.com
+	// =====================================================================
+	{TFType: "google_cloud_run_v2_service", AssetType: "run.googleapis.com/Service"},
+
+	// =====================================================================
+	// Cloud Functions Gen 2 — cloudfunctions.googleapis.com
+	// =====================================================================
+	{TFType: "google_cloudfunctions2_function", AssetType: "cloudfunctions.googleapis.com/Function"},
+
+	// =====================================================================
+	// API Gateway — apigateway.googleapis.com
+	// =====================================================================
+	{TFType: "google_api_gateway_api", AssetType: "apigateway.googleapis.com/Api"},
+	{TFType: "google_api_gateway_api_config", AssetType: "apigateway.googleapis.com/ApiConfig"},
+	{TFType: "google_api_gateway_gateway", AssetType: "apigateway.googleapis.com/Gateway"},
+
+	// =====================================================================
+	// Memorystore (Redis) — redis.googleapis.com
+	// =====================================================================
+	{TFType: "google_redis_instance", AssetType: "redis.googleapis.com/Instance"},
+
+	// =====================================================================
+	// Vertex AI — aiplatform.googleapis.com
+	// =====================================================================
+	{TFType: "google_vertex_ai_dataset", AssetType: "aiplatform.googleapis.com/Dataset"},
+
+	// =====================================================================
+	// Cloud Build — cloudbuild.googleapis.com
+	// =====================================================================
+	{TFType: "google_cloudbuild_trigger", AssetType: "cloudbuild.googleapis.com/BuildTrigger"},
+
+	// =====================================================================
+	// Firestore — firestore.googleapis.com
+	// =====================================================================
+	{TFType: "google_firestore_database", AssetType: "firestore.googleapis.com/Database"},
+}

--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -128,11 +128,22 @@ type ByIDEnricher interface {
 // string field — google.golang.org/api/storage/v1.Bucket reports
 // only ProjectNumber (uint64), so the enricher pulls the string
 // project ID from here to populate the TF `project` attribute.
+//
+// CloudAsset is the optional Cloud Asset Inventory getter that backs
+// the CAI HYBRID enricher (cloudasset_enricher.go, mirrors AWS #490 for
+// GCP). One unified getter fronts every TF type registered in
+// cloudAssetTypeConfigs whose Layer-1 codegen has shipped — far fewer
+// per-service SDK clients than the hand-rolled enrichment path needed
+// pre-HYBRID. Nil tolerated: types whose hand-rolled enricher wins as
+// an override don't need this client; types without a hand-rolled
+// override return ErrEnrichClientUnavailable when this is nil, which
+// the EnrichAttributes loop downgrades to a per-resource warning.
 type EnrichClients struct {
 	Storage       *storagev1.Service
 	Pubsub        *pubsubv1.Service
 	SecretManager *secretmanagerv1.Service
 	Compute       *computev1.Service
+	CloudAsset    gcpAssetGetter
 	ProjectID     string
 }
 

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -263,8 +263,16 @@ type GCPDiscovererOpts struct {
 // the corresponding non-CAI discoverers are exercised — nil is
 // tolerated so unit tests that only walk CAI types don't have to wire
 // up mock listers.
+//
+// byTypeEnricher is populated in two passes. The hand-rolled map below
+// is the first pass — per-type enrichers that own their resource type
+// outright and produce richer payloads than the generic CAI HYBRID
+// path can. The second pass iterates cloudAssetTypeConfigs and
+// registers a generic cloudAssetEnricher for every entry that ISN'T
+// already in the hand-rolled map (hand-rolled wins). Mirrors the AWS
+// Cloud Control HYBRID pattern from #490.
 func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string, opts GCPDiscovererOpts) *GCPDiscoverer {
-	return &GCPDiscoverer{
+	d := &GCPDiscoverer{
 		searcher:  searcher,
 		projectID: projectID,
 		byType: map[string]Discoverer{
@@ -350,6 +358,29 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string, opts GCPDisco
 			"google_storage_bucket":        newStorageBucketEnricher(),
 		},
 	}
+	// HYBRID Cloud Asset Inventory fallback (mirrors AWS #490 steps 1+2):
+	// register one cloudAssetEnricher for every TF type in
+	// cloudAssetTypeConfigs that doesn't already have a hand-rolled
+	// override above. Hand-rolled wins; the loop iterates the same
+	// config the CAI types registry uses so the enricher coverage stays
+	// in lockstep.
+	//
+	// The enricher's GetByName callback defaults to nil and is resolved
+	// at Enrich time from EnrichClients.CloudAsset. Callers constructing
+	// EnrichClients without a CloudAsset client see a per-resource
+	// ErrEnrichClientUnavailable warning (not a batch-fatal error) so a
+	// partial-credentials run still produces useful output from the
+	// hand-rolled enrichers.
+	for _, cfg := range cloudAssetTypeConfigs {
+		if cfg.Skip {
+			continue
+		}
+		if _, has := d.byTypeEnricher[cfg.TFType]; has {
+			continue
+		}
+		d.byTypeEnricher[cfg.TFType] = newCloudAssetEnricher(cfg.TFType, cfg.AssetType, nil)
+	}
+	return d
 }
 
 // SupportedTypes returns the registered Terraform types in lexicographic

--- a/cmd/insideout-import/gcpdiscover/searcher.go
+++ b/cmd/insideout-import/gcpdiscover/searcher.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 // gcpAssetResult is a flattened view of a Cloud Asset SearchAllResources
@@ -50,6 +51,39 @@ type gcpAssetResult struct {
 // uses *RealAssetSearcher; tests construct lightweight fakes.
 type gcpAssetSearcher interface {
 	SearchAll(ctx context.Context, scope string, assetTypes []string, query string) ([]gcpAssetResult, error)
+}
+
+// gcpAssetGetter is the optional side-interface implemented by searchers
+// that can fetch the full typed JSON representation of a single asset
+// by name (the Cloud Asset Inventory `versionedResources` field). The
+// CAI HYBRID enricher (cloudasset_enricher.go, mirrors AWS #490 for
+// GCP) depends on this side-interface; discoverers do NOT — they only
+// consume the flattened gcpAssetResult shape from SearchAll.
+//
+// Side-interface (not a method on gcpAssetSearcher) so the dozens of
+// pre-existing per-type unit-test fakes that implement
+// gcpAssetSearcher with the older SearchAll-only signature continue to
+// compile unchanged. Tests that need to exercise the enricher path
+// implement both interfaces on the same fake; tests that don't, don't.
+//
+// The fullName argument is the CAI full resource name, of the form
+// `//<service>/<path>/<segments>` (e.g.
+// `//compute.googleapis.com/projects/my-proj/zones/us-central1-a/instances/my-vm`).
+// It is the same string the per-type Discoverer writes into
+// Identity.NativeIDs["asset_name"] at discovery time.
+//
+// The returned map is the resource's JSON representation as defined by
+// the corresponding service-API (e.g. for compute, the Compute Engine
+// v1 REST API representation — `lowerCamelCase` keys, native types
+// for scalars, nested maps for objects). The enricher's CamelCase →
+// snake_case transform reshapes this into the canonical Layer-1 wire
+// format the generated.Google<Type> structs expect.
+//
+// Returns ErrNotFound when the search returns zero rows; any other
+// error reflects a real Cloud Asset API failure (auth, permission,
+// throttle, etc.).
+type gcpAssetGetter interface {
+	GetByName(ctx context.Context, scope, assetType, fullName string) (map[string]any, error)
 }
 
 // RealAssetSearcher wraps cloud.google.com/go/asset/apiv1.Client. The
@@ -127,6 +161,88 @@ func (s *RealAssetSearcher) SearchAll(ctx context.Context, scope string, assetTy
 		}
 		out = append(out, assetResultFromProto(r))
 	}
+}
+
+// GetByName fetches a single Cloud Asset resource by its full
+// resource name (//<service>/<path>/<segments>) and returns the
+// resource's typed JSON representation as a map[string]any (the
+// `versionedResources` payload). Used by the CAI HYBRID enricher to
+// route per-resource attribute lookups through one unified API surface
+// instead of one SDK client per service.
+//
+// scope follows the same form as SearchAll (projects/<id>,
+// folders/<num>, organizations/<num>). assetType is the CAI asset
+// type discriminator (e.g. compute.googleapis.com/Instance) used to
+// narrow the search; passing it explicitly rather than letting the
+// service infer it from the query keeps the call cheap on large
+// projects where the eq-by-name search would otherwise scan every
+// asset type.
+//
+// The function issues one SearchAllResources call with
+// `query = "name=<fullName>"` and `read_mask` including
+// `versionedResources`. The first matching row's most-recent
+// versioned-resource Data field is returned. Returns ErrNotFound when
+// the search returns no rows (the asset was deleted between discovery
+// and enrichment, or the operator's IAM principal lacks read
+// permission on this specific asset type).
+//
+// The single-row pattern is sound: name=<fullName> is an exact-match
+// query (vs the `:` contains operator), and CAI guarantees uniqueness
+// of fullName across the entire scope per
+// https://cloud.google.com/asset-inventory/docs/searching-resources.
+func (s *RealAssetSearcher) GetByName(ctx context.Context, scope, assetType, fullName string) (map[string]any, error) {
+	if s.client == nil {
+		return nil, errors.New("cloud asset client closed")
+	}
+	if fullName == "" {
+		return nil, errors.New("cloud asset getbyname: empty asset name")
+	}
+	req := &assetpb.SearchAllResourcesRequest{
+		Scope: scope,
+		// Exact-match on the full resource name. `=` (not `:`) is the
+		// equality operator per the SearchAllResources query syntax.
+		Query: fmt.Sprintf("name=%s", fullName),
+		// Narrowing by asset type keeps the server-side scan O(rows
+		// of that type) rather than O(all rows in the project),
+		// which matters on large multi-tenant projects.
+		AssetTypes: []string{assetType},
+		// versionedResources is NOT returned by default — it carries
+		// the full typed JSON representation of the asset (the body
+		// CAI mirrors from each service's REST API). The read_mask
+		// includes the default fields the iterator-row mapper reads
+		// (name, assetType) plus the versionedResources opt-in. See
+		// the SearchAllResourcesRequest doc for the full default-field
+		// list.
+		ReadMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "assetType", "versionedResources"}},
+	}
+	it := s.client.SearchAllResources(ctx, req)
+	r, err := it.Next()
+	if errors.Is(err, iterator.Done) {
+		return nil, fmt.Errorf("cloud asset getbyname %s %q: %w", assetType, fullName, ErrNotFound)
+	}
+	if err != nil {
+		return nil, wrapSearchAllError(err)
+	}
+	versions := r.GetVersionedResources()
+	if len(versions) == 0 {
+		// Asset exists in CAI's index but the operator's read_mask
+		// scope is too narrow to surface its data (or the CAI
+		// service hasn't backfilled the versioned representation
+		// for this asset type). Surface as ErrNotFound so the
+		// EnrichAttributes loop downgrades it to a per-resource
+		// warning rather than aborting the whole batch.
+		return nil, fmt.Errorf("cloud asset getbyname %s %q: no versioned resources: %w", assetType, fullName, ErrNotFound)
+	}
+	// Cloud Asset returns versioned resources in chronological order
+	// (oldest first per the API contract); the most recent version is
+	// the last element, which is the one we want for current-state
+	// drift comparison.
+	latest := versions[len(versions)-1]
+	data := latest.GetResource()
+	if data == nil {
+		return nil, fmt.Errorf("cloud asset getbyname %s %q: nil resource data: %w", assetType, fullName, ErrNotFound)
+	}
+	return data.AsMap(), nil
 }
 
 // wrapSearchAllError annotates a Cloud Asset SearchAllResources error


### PR DESCRIPTION
## Summary

Implements the HYBRID-adoption portion of the GCP CAI enricher (mirrors AWS #490 Cloud Control HYBRID enricher for the GCP side). Steps 1+2 only — per-type Normalizer hooks (Step 3) and retiring hand-rolled enrichers (Step 4) are deferred to follow-up issues.

**Coverage delta: GCP enrichable 7/54 (13%) → 30/54 (56%)** (per the `SUPPORTED_RESOURCES.md` capabilities matrix). Hand-rolled enrichers continue to win as overrides (7 today: `compute_address`, `compute_firewall`, `compute_network`, `pubsub_subscription`, `pubsub_topic`, `secret_manager_secret`, `storage_bucket`).

## What changed

### Step 1 — TF type ↔ CAI asset-type config map

New file `cmd/insideout-import/gcpdiscover/cloudasset_types.go` declares `cloudAssetTypeConfigs`, a 30-entry registry mapping GCP Terraform types to their Cloud Asset Inventory asset-type discriminators. Coverage spans the CAI-surfaced types in `NewGCPDiscoverer.byType` whose Layer-1 codegen has already shipped under `pkg/composer/imported/generated/`.

Excluded:
- CAI-unsurfaced types (IAM bindings, SQL users, project services, identity platform configs, sub-resources fanned out across parents) — stay on the hand-rolled discoverer path.
- Types lacking a generated struct (`compute_target_http_proxy`, `compute_backend_service`, `compute_health_check`, `compute_managed_ssl_certificate`, `compute_resource_policy`) — wait for the codegen to catch up.

### Step 2 — generic `cloudAssetEnricher` (AttributeEnricher + ByIDEnricher)

New file `cmd/insideout-import/gcpdiscover/cloudasset_enricher.go`. One generic enricher type per `cloudAssetTypeConfigs` entry. Calls CAI `SearchAllResources` with `read_mask` including `versionedResources`, reshapes `lowerCamelCase` keys to `snake_case` and wraps scalar leaves in `{\"literal\": ...}` envelopes, unmarshals into the matching `generated.Google<Type>` struct, re-marshals into `ir.Attrs`.

`NewGCPDiscoverer` wires one `cloudAssetEnricher` per `cloudAssetTypeConfigs` entry that doesn't already have a hand-rolled override. Hand-rolled wins.

### Searcher contract

`RealAssetSearcher` gains a `GetByName(ctx, scope, assetType, fullName)` method that returns the `versionedResources.Data` field as `map[string]any`. Exposed via a new `gcpAssetGetter` side-interface (not extending `gcpAssetSearcher`) so the dozens of pre-existing per-type unit-test fakes continue to compile unchanged. `EnrichClients` gains a matching `CloudAsset gcpAssetGetter` field.

## Why GCP should ship cleaner than AWS Cloud Control

The AWS Cloud Control PoC quantified per-type quality at 57% exact field match on `aws_cloudwatch_log_group`. Two systemic gotchas dominated:

1. **CFN CamelCase ↔ TF snake_case rename had a primary-name aliasing gap** (LogGroupName → name, BucketName → bucket).
2. **CFN tag-list `[{Key, Value}]` ↔ TF tag map** (AWS-specific tag-shape divergence).

Neither applies to GCP:

1. CAI returns native GCP REST JSON which already uses `lowerCamelCase` keys that snake_case-rename cleanly to TF attribute names — no CFN-style CamelCase divergence. Primary-name fields are just `name` on both sides.
2. GCP labels are `map[string]string` in both the REST API and TF provider schema. No reshape needed.

Projected first-try match rate: 75-90% (vs AWS's 57%). The PoC report at `.tmp/cai-enricher-poc.md` documents the structural round-trip and the two GCP-side gotchas the Normalizer hooks follow-up will address (self-link URLs vs bare names, region URL → region short name).

## Out of scope (deferred follow-ups)

- **Per-type Normalizer hooks** for self-link → bare-name translation and region-URL → region short-name (the GCP equivalent of #501).
- **Retiring hand-rolled GCP enrichers** as CAI coverage proves out (the GCP equivalent of #502).
- **Wiring `EnrichClients.CloudAsset` construction** in the discover orchestrator's production path (matches the AWS posture in #490 — type wired, orchestrator wiring follows in a separate PR).

## Test plan

- [x] 29 new tests in `cloudasset_enricher_test.go` (renamer, shape transformer, identity derivation, failure modes, wiring sanity).
- [x] `TestExistingEnrichersDoNotImplementByID` `wantTotal` pin recomputes at runtime from `cloudAssetTypeConfigs` so adding a new CAI config entry only requires changing `cloudasset_types.go`.
- [x] Full `gcpdiscover` package: 848 tests pass.
- [x] Full repo test suite: 5373 tests pass across 35 packages.
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `gofmt -l` clean.
- [x] `make verify-gen` passes.
- [x] `make verify-supported-resources` passes (after regen).

## Refs

Refs #482 (Phase 2 capstone — hand-rolled enrichers remain as overrides per the HYBRID pattern; this is NOT a `Closes`).