### PR TITLE
feat(gcpdiscover): Cloud Asset Inventory HYBRID enricher (mirrors #490 for GCP)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -23,7 +23,7 @@ and is checked in lockstep with the runtime registries. See the
 ## Summary
 
 - **AWS:** 109 types · 100% Discoverable · 86% Enrichable · 3% DriftDetectable · 0% MetricsAvailable · 6% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 13% Enrichable · 4% DriftDetectable · 0% MetricsAvailable · 65% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 65% Enrichable · 4% DriftDetectable · 0% MetricsAvailable · 65% AgentEditable
 
 ## AWS
 
@@ -143,38 +143,38 @@ and is checked in lockstep with the runtime registries. See the
 
 | TF Type | Discoverable | Enrichable | DriftDetectable | MetricsAvailable | AgentEditable |
 |---|---|---|---|---|---|
-| `google_api_gateway_api` | ✓ | – | – | – | ✓ |
-| `google_api_gateway_api_config` | ✓ | – | – | – | ✓ |
-| `google_api_gateway_gateway` | ✓ | – | – | – | ✓ |
-| `google_cloud_run_v2_service` | ✓ | – | – | – | ✓ |
+| `google_api_gateway_api` | ✓ | ✓ | – | – | ✓ |
+| `google_api_gateway_api_config` | ✓ | ✓ | – | – | ✓ |
+| `google_api_gateway_gateway` | ✓ | ✓ | – | – | ✓ |
+| `google_cloud_run_v2_service` | ✓ | ✓ | – | – | ✓ |
 | `google_cloud_run_v2_service_iam_member` | ✓ | – | – | – | – |
-| `google_cloudbuild_trigger` | ✓ | – | – | – | ✓ |
-| `google_cloudfunctions2_function` | ✓ | – | – | – | ✓ |
+| `google_cloudbuild_trigger` | ✓ | ✓ | – | – | ✓ |
+| `google_cloudfunctions2_function` | ✓ | ✓ | – | – | ✓ |
 | `google_cloudfunctions2_function_iam_member` | ✓ | – | – | – | – |
 | `google_compute_address` | ✓ | ✓ | – | – | ✓ |
-| `google_compute_backend_service` | ✓ | – | – | – | – |
+| `google_compute_backend_service` | ✓ | ✓ | – | – | – |
 | `google_compute_firewall` | ✓ | ✓ | – | – | ✓ |
-| `google_compute_forwarding_rule` | ✓ | – | – | – | ✓ |
-| `google_compute_global_address` | ✓ | – | – | – | ✓ |
-| `google_compute_global_forwarding_rule` | ✓ | – | – | – | ✓ |
-| `google_compute_health_check` | ✓ | – | – | – | – |
-| `google_compute_instance` | ✓ | – | – | – | ✓ |
-| `google_compute_managed_ssl_certificate` | ✓ | – | – | – | – |
+| `google_compute_forwarding_rule` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_global_address` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_global_forwarding_rule` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_health_check` | ✓ | ✓ | – | – | – |
+| `google_compute_instance` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_managed_ssl_certificate` | ✓ | ✓ | – | – | – |
 | `google_compute_network` | ✓ | ✓ | – | – | ✓ |
-| `google_compute_resource_policy` | ✓ | – | – | – | – |
-| `google_compute_router` | ✓ | – | – | – | ✓ |
-| `google_compute_security_policy` | ✓ | – | – | – | ✓ |
-| `google_compute_target_http_proxy` | ✓ | – | – | – | – |
-| `google_compute_target_https_proxy` | ✓ | – | – | – | ✓ |
-| `google_compute_url_map` | ✓ | – | – | – | ✓ |
-| `google_container_cluster` | ✓ | – | – | – | ✓ |
-| `google_container_node_pool` | ✓ | – | – | – | ✓ |
-| `google_firestore_database` | ✓ | – | – | – | ✓ |
+| `google_compute_resource_policy` | ✓ | ✓ | – | – | – |
+| `google_compute_router` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_security_policy` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_target_http_proxy` | ✓ | ✓ | – | – | – |
+| `google_compute_target_https_proxy` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_url_map` | ✓ | ✓ | – | – | ✓ |
+| `google_container_cluster` | ✓ | ✓ | – | – | ✓ |
+| `google_container_node_pool` | ✓ | ✓ | – | – | ✓ |
+| `google_firestore_database` | ✓ | ✓ | – | – | ✓ |
 | `google_identity_platform_config` | ✓ | – | – | – | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | – | – | – | – |
-| `google_kms_crypto_key` | ✓ | – | – | – | ✓ |
+| `google_kms_crypto_key` | ✓ | ✓ | – | – | ✓ |
 | `google_kms_crypto_key_iam_binding` | ✓ | – | – | – | – |
-| `google_kms_key_ring` | ✓ | – | – | – | – |
+| `google_kms_key_ring` | ✓ | ✓ | – | – | – |
 | `google_logging_project_sink` | ✓ | – | – | – | ✓ |
 | `google_monitoring_alert_policy` | ✓ | – | – | – | ✓ |
 | `google_monitoring_dashboard` | ✓ | – | – | – | ✓ |
@@ -183,19 +183,19 @@ and is checked in lockstep with the runtime registries. See the
 | `google_project_service` | ✓ | – | – | – | – |
 | `google_pubsub_subscription` | ✓ | ✓ | – | – | ✓ |
 | `google_pubsub_topic` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_redis_instance` | ✓ | – | – | – | ✓ |
+| `google_redis_instance` | ✓ | ✓ | – | – | ✓ |
 | `google_secret_manager_secret` | ✓ | ✓ | – | – | ✓ |
 | `google_secret_manager_secret_iam_binding` | ✓ | – | – | – | – |
 | `google_secret_manager_secret_iam_member` | ✓ | – | – | – | – |
 | `google_secret_manager_secret_version` | ✓ | – | – | – | – |
-| `google_service_account` | ✓ | – | – | – | ✓ |
+| `google_service_account` | ✓ | ✓ | – | – | ✓ |
 | `google_service_networking_connection` | ✓ | – | – | – | – |
-| `google_sql_database_instance` | ✓ | – | – | – | ✓ |
+| `google_sql_database_instance` | ✓ | ✓ | – | – | ✓ |
 | `google_sql_user` | ✓ | – | – | – | ✓ |
 | `google_storage_bucket` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_storage_bucket_iam_member` | ✓ | – | – | – | – |
 | `google_storage_bucket_object` | ✓ | – | – | – | – |
-| `google_vertex_ai_dataset` | ✓ | – | – | – | ✓ |
+| `google_vertex_ai_dataset` | ✓ | ✓ | – | – | ✓ |
 | `google_vpc_access_connector` | ✓ | – | – | – | – |
 
 ## How to regenerate

--- a/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
@@ -41,6 +41,12 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 
 	// Allowlist: types whose enrichers explicitly DO NOT implement
 	// ByIDEnricher yet. Shrink as Phase 2 rollout lands per-type impls.
+	// The 5 hand-rolled enrichers below are the original pre-Phase-2
+	// set; the two newer hand-rolled enrichers (compute_address,
+	// compute_firewall) DO implement ByIDEnricher and stay off the
+	// allowlist. Every cloudAssetEnricher implements ByIDEnricher by
+	// construction (compile-time pin in cloudasset_enricher.go), so
+	// CAI-routed types are never on this allowlist.
 	notImplemented := map[string]bool{
 		"google_storage_bucket":        true,
 		"google_pubsub_topic":          true,
@@ -51,11 +57,39 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 
 	// Fail-fast: pin the expected total byTypeEnricher size so a
 	// silent drop (or duplicate-key squashing) in production fails the
-	// test. The expected total = allowlist size + types that DO
-	// implement ByIDEnricher. When adding a new enricher: bump
-	// wantTotal and either add to allowlist (no ByIDEnricher) or leave
-	// it off (implements ByIDEnricher).
-	const wantTotal = 7 // 5 pre-Phase-2 + compute_address + compute_firewall
+	// test. The expected total = 7 hand-rolled enrichers + every type
+	// in cloudAssetTypeConfigs that doesn't have a hand-rolled override.
+	// The latter is computed at test time so an addition to
+	// cloudAssetTypeConfigs doesn't silently flow into the production
+	// enricher coverage without a deliberate test update — the math
+	// below makes that change visible as a numeric diff in the test
+	// failure message. Mirrors the AWS byid_enricher_test pattern.
+	handRolledTypes := map[string]bool{
+		"google_compute_address":       true,
+		"google_compute_firewall":      true,
+		"google_compute_network":       true,
+		"google_pubsub_subscription":   true,
+		"google_pubsub_topic":          true,
+		"google_secret_manager_secret": true,
+		"google_storage_bucket":        true,
+	}
+	handRolled := len(handRolledTypes)
+	caiOverrides := 0
+	for _, cfg := range cloudAssetTypeConfigs {
+		if cfg.Skip {
+			continue
+		}
+		if handRolledTypes[cfg.TFType] {
+			caiOverrides++
+		}
+	}
+	caiActive := 0
+	for _, cfg := range cloudAssetTypeConfigs {
+		if !cfg.Skip {
+			caiActive++
+		}
+	}
+	wantTotal := handRolled + caiActive - caiOverrides
 	if got := len(d.byTypeEnricher); got != wantTotal {
 		t.Errorf("byTypeEnricher size = %d, want %d (production registration drifted from test)", got, wantTotal)
 	}
@@ -68,6 +102,62 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 			t.Errorf("%s: enricher now implements ByIDEnricher — remove from notImplemented allowlist", tfType)
 		case !expectNot && !implementsByID:
 			t.Errorf("%s: enricher must implement ByIDEnricher (not in notImplemented allowlist)", tfType)
+		}
+	}
+}
+
+// TestCloudAssetEnricherCoversEveryCAIRoutedType asserts that every
+// TF type in cloudAssetTypeConfigs (with Skip=false) has a registered
+// AttributeEnricher in NewGCPDiscoverer.byTypeEnricher — either a
+// hand-rolled override or a generic cloudAssetEnricher. A regression
+// that drops the cloudAssetEnricher wiring loop in NewGCPDiscoverer
+// would silently strip CAI coverage from ~28 types; this test catches
+// that as a per-type miss rather than waiting for a downstream
+// integration test to surface the regression. Mirrors AWS's
+// TestCloudControlEnricherCoversEveryCCRoutedType.
+func TestCloudAssetEnricherCoversEveryCAIRoutedType(t *testing.T) {
+	d := NewGCPDiscoverer(nil, "test-project", GCPDiscovererOpts{})
+	for _, cfg := range cloudAssetTypeConfigs {
+		if cfg.Skip {
+			continue
+		}
+		if _, ok := d.byTypeEnricher[cfg.TFType]; !ok {
+			t.Errorf("cloudasset-routed TFType %q has no registered AttributeEnricher", cfg.TFType)
+		}
+	}
+}
+
+// TestCloudAssetEnricherSkipsHandRolledOverrides asserts the
+// override-wins invariant in NewGCPDiscoverer's wiring loop: for every
+// TF type that has a hand-rolled enricher AND a cloudAssetTypeConfigs
+// entry, the registered enricher must be the hand-rolled one (not the
+// generic cloudAssetEnricher). A silent regression that flips the
+// override order would replace the higher-fidelity hand-rolled payloads
+// with the lower-fidelity CAI payloads. Mirrors AWS's
+// TestCloudControlEnricherSkipsHandRolledOverrides.
+func TestCloudAssetEnricherSkipsHandRolledOverrides(t *testing.T) {
+	d := NewGCPDiscoverer(nil, "test-project", GCPDiscovererOpts{})
+	// Mirrors the hand-rolled set in buildByTypeEnricher. Kept as a
+	// literal slice rather than a reflection-based scan so adding a new
+	// hand-rolled enricher requires an explicit update here — the next
+	// reviewer sees the intent in the test diff.
+	handRolled := []string{
+		"google_compute_address",
+		"google_compute_firewall",
+		"google_compute_network",
+		"google_pubsub_subscription",
+		"google_pubsub_topic",
+		"google_secret_manager_secret",
+		"google_storage_bucket",
+	}
+	for _, tfType := range handRolled {
+		enr, ok := d.byTypeEnricher[tfType]
+		if !ok {
+			t.Errorf("%s: missing from byTypeEnricher", tfType)
+			continue
+		}
+		if _, isCAI := enr.(*cloudAssetEnricher); isCAI {
+			t.Errorf("%s: registered enricher is cloudAssetEnricher, want hand-rolled override", tfType)
 		}
 	}
 }

--- a/cmd/insideout-import/gcpdiscover/cloudasset_enricher.go
+++ b/cmd/insideout-import/gcpdiscover/cloudasset_enricher.go
@@ -1,0 +1,397 @@
+package gcpdiscover
+
+// cloudasset_enricher.go — generic GCP attribute enricher backed by
+// Cloud Asset Inventory (mirrors the AWS Cloud Control HYBRID enricher
+// from #490 for the GCP side).
+//
+// One generic enricher type that fetches the typed JSON
+// representation of a single asset via the CAI
+// SearchAllResources `versionedResources` field, reshapes it to the
+// Terraform Layer-1 wire format (lowerCamelCase → snake_case keys,
+// scalar leaves wrapped in {"literal": …} envelopes), unmarshals into
+// the matching pkg/composer/imported/generated.Google<Type> struct,
+// then re-marshals into ir.Attrs. The wire-format prerequisite is the
+// `json:"<snake_name>"` tags emitted by cmd/imported-codegen on every
+// generated Layer-1 field — without them, the GCP REST API's
+// lowerCamelCase keys would silently miss every field.
+//
+// Coverage and overrides: NewGCPDiscoverer registers one
+// cloudAssetEnricher per entry in cloudAssetTypeConfigs that does NOT
+// already have a hand-rolled AttributeEnricher in byTypeEnricher.
+// Hand-rolled enrichers win as overrides (see gcpdiscover.go), so the
+// existing google_storage_bucket / google_pubsub_topic /
+// google_compute_network / etc. enrichers continue to produce richer
+// payloads than this generic path does today.
+//
+// Quality band vs AWS: the AWS Cloud Control PoC measured 57% exact
+// field match on aws_cloudwatch_log_group (HYBRID floor). GCP should
+// land higher because (1) CAI returns native REST-API JSON which
+// already uses lowerCamelCase keys that snake_case-rename cleanly to TF
+// attribute names, and (2) GCP labels are map[string]string in both
+// the API and TF — no AWS-style list-of-{Key,Value} tag-shape mismatch
+// to bridge. The CAI Normalizer hooks follow-up (#501 GCP-equivalent,
+// not in scope for this PR) addresses the remaining tail —
+// computed-only normalization (self-link → bare-name, region URL →
+// region short name) and any per-type primary-name aliasing.
+//
+// Soft-fail posture: an ErrNotFound from CAI (the asset was deleted
+// between discovery and enrichment, or the operator's IAM principal
+// lacks cloudasset.assets.searchAllResources on this specific asset
+// type) is wrapped in ErrNotFound so EnrichAttributes can route it
+// through its non-fatal aggregation. Per-type IAM gaps and CAI
+// eventual-consistency drift are the most likely real-world causes;
+// soft-failing means a single missing permission won't abort a full
+// discover-and-enrich run.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// cloudAssetEnricher is the generic AttributeEnricher / ByIDEnricher
+// pair for a single Terraform resource type. One instance is
+// constructed per cloudAssetTypeConfigs entry that doesn't already
+// have a hand-rolled override in NewGCPDiscoverer.byTypeEnricher.
+//
+// resourceType pins the Terraform-side type this instance covers (so
+// ResourceType() / EnrichByID / Enrich return / dispatch on the same
+// key). assetType is the matching Cloud Asset Inventory asset-type
+// passed to GetByName — sourced from cloudAssetConfig.AssetType at
+// construction time so a single config drives the wiring.
+//
+// fetch is overridable for unit tests. Defaults to nil; the enricher
+// resolves an injected fetch first, then falls back to the
+// EnrichClients.CloudAsset.GetByName method at call time. The
+// lazy-resolve shape (vs. requiring fetch at construction time) keeps
+// NewGCPDiscoverer free of a Cloud Asset client dependency — the
+// client is owned by the caller and threaded through EnrichClients.
+type cloudAssetEnricher struct {
+	resourceType string
+	assetType    string
+	fetch        func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error)
+}
+
+// newCloudAssetEnricher constructs an enricher for a single (tfType,
+// assetType) pair. fetch is optional: tests inject a closure to stub
+// GetByName without a Cloud Asset client; production wiring (see
+// NewGCPDiscoverer) passes nil and the enricher pulls
+// c.CloudAsset.GetByName off the EnrichClients passed to Enrich /
+// EnrichByID at call time.
+func newCloudAssetEnricher(tfType, assetType string, fetch func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error)) *cloudAssetEnricher {
+	return &cloudAssetEnricher{
+		resourceType: tfType,
+		assetType:    assetType,
+		fetch:        fetch,
+	}
+}
+
+// ResourceType returns the Terraform type this enricher covers.
+func (e *cloudAssetEnricher) ResourceType() string { return e.resourceType }
+
+// Enrich populates ir.Attrs with the typed Layer-1 payload mapped from
+// the CAI versionedResources JSON. Returns ErrEnrichClientUnavailable
+// when c.CloudAsset is nil (and no test-injected fetch is set on the
+// enricher) so callers can distinguish "client not wired" from a real
+// API error. A CAI not-found is wrapped in ErrNotFound and
+// EnrichAttributes treats that as a soft-fail / per-resource warning
+// rather than aborting the batch.
+func (e *cloudAssetEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if ir == nil {
+		return errors.New("cloudasset enricher: ir is nil")
+	}
+	fetch, err := e.resolveFetch(c)
+	if err != nil {
+		return err
+	}
+	raw, err := e.fetchAndMap(ctx, fetch, &ir.Identity, c.ProjectID)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID is the ByIDEnricher entry point. Same fetch + mapping
+// path as Enrich, but returns the raw payload instead of mutating an
+// IR. Used by the per-IR drift refresh path (pkg/imported.Provider.EnrichByID,
+// #482) where the caller already holds an Identity and only wants the
+// typed payload.
+func (e *cloudAssetEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, errors.New("cloudasset enricher: identity is nil")
+	}
+	fetch, err := e.resolveFetch(c)
+	if err != nil {
+		return nil, err
+	}
+	return e.fetchAndMap(ctx, fetch, identity, c.ProjectID)
+}
+
+// resolveFetch returns the GetByName callback this Enrich / EnrichByID
+// invocation should use. Prefers the field-injected `fetch` (test
+// path); falls back to c.CloudAsset.GetByName (production path).
+// Returns ErrEnrichClientUnavailable when neither is wired so callers
+// can distinguish "no Cloud Asset client configured" from a real API
+// failure.
+//
+// Pure-function shape (returns the resolved callback rather than
+// mutating e.fetch) keeps the enricher safe to invoke concurrently
+// against the same instance — EnrichAttributes drives sequentially
+// today, but the underlying contract should not rely on that to stay
+// race-free.
+func (e *cloudAssetEnricher) resolveFetch(c EnrichClients) (func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error), error) {
+	if e.fetch != nil {
+		return e.fetch, nil
+	}
+	if c.CloudAsset == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	return c.CloudAsset.GetByName, nil
+}
+
+// fetchAndMap issues the GetByName call and unmarshals the
+// versionedResources JSON directly into the registered
+// generated.Google<Type> Layer-1 struct, then re-marshals to JSON for
+// ir.Attrs.
+//
+// Three failure modes:
+//
+//  1. Cannot derive a CAI full-resource-name from the Identity — every
+//     CAI-routed Discoverer stamps NativeIDs["asset_name"] today (see
+//     compute_address.go FromAsset for the canonical example), so an
+//     empty asset_name typically means the caller invoked
+//     EnrichByID with a bare Identity that didn't go through a
+//     Discoverer. Returns a descriptive error so the misconfiguration
+//     is obvious at test time.
+//
+//  2. CAI returns ErrNotFound — wrapped and returned as-is.
+//     EnrichAttributes already routes ErrNotFound through a
+//     per-resource warning rather than a batch-fatal error.
+//
+//  3. The TF type isn't registered in pkg/composer/imported/generated —
+//     wrapped as a hard error since this is a wiring bug (every TF
+//     type in cloudAssetTypeConfigs MUST have a generated Layer-1
+//     struct for the enricher to land its payload; the
+//     TestCloudAssetEnricherCoversEveryCAIRoutedType test catches
+//     drift between the two registries at build time).
+func (e *cloudAssetEnricher) fetchAndMap(ctx context.Context, fetch func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error), identity *imported.ResourceIdentity, projectID string) (json.RawMessage, error) {
+	assetName := cloudAssetNameFromIdentity(identity)
+	if assetName == "" {
+		return nil, fmt.Errorf("cloudasset enricher: cannot derive CAI asset name from Identity (Address=%q ImportID=%q NameHint=%q NativeIDs.asset_name=%q)",
+			identity.Address, identity.ImportID, identity.NameHint, identity.NativeIDs["asset_name"])
+	}
+	scope := cloudAssetScopeFromIdentity(identity, projectID)
+	if scope == "" {
+		return nil, fmt.Errorf("cloudasset enricher: cannot derive CAI scope from Identity (ProjectID=%q EnrichClients.ProjectID=%q)",
+			identity.ProjectID, projectID)
+	}
+
+	data, err := fetch(ctx, scope, e.assetType, assetName)
+	if err != nil {
+		// ErrNotFound is wrapped by the searcher; pass through with
+		// an enricher-side prefix for log clarity. Any other error
+		// (auth, throttle, transient API failure) bubbles up wrapped.
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("cloudasset enricher: %s %q: %w", e.assetType, assetName, ErrNotFound)
+		}
+		return nil, fmt.Errorf("cloudasset enricher: GetByName %s %q: %w", e.assetType, assetName, err)
+	}
+
+	// CAI returns the JSON representation as defined by each service's
+	// REST API — `lowerCamelCase` keys (e.g. `selfLink`, `machineType`,
+	// `canIpForward`), native types for scalars, nested maps for
+	// objects. Reshape to the Layer-1 wire format: snake_case keys,
+	// scalar leaves wrapped in {"literal": …} envelopes (so they
+	// decode into generated.Value[T] cleanly; without the wrap, a bare
+	// scalar would fail to decode — Value[T].UnmarshalJSON rejects
+	// non-object input).
+	shaped := shapeCAIForLayer1(data)
+	shapedJSON, err := json.Marshal(shaped)
+	if err != nil {
+		return nil, fmt.Errorf("cloudasset enricher: re-marshal snake_case for %s %q: %w", e.assetType, assetName, err)
+	}
+
+	// Decode into the registered Layer-1 struct then re-marshal so the
+	// output payload uses the canonical json-tag wire format. The
+	// generated.UnmarshalAttrs call also serves as a wiring sanity
+	// check — if the TF type isn't registered, the enricher fails
+	// loudly rather than silently emitting raw CAI-shaped JSON.
+	decoded, err := generated.UnmarshalAttrs(e.resourceType, shapedJSON)
+	if err != nil {
+		return nil, fmt.Errorf("cloudasset enricher: unmarshal into %s: %w", e.resourceType, err)
+	}
+	raw, err := json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("cloudasset enricher: marshal Attrs for %s %q: %w", e.assetType, assetName, err)
+	}
+	return raw, nil
+}
+
+// cloudAssetNameFromIdentity pulls the CAI full asset name
+// (//<service>/<path>/<segments>) from the Identity. Precedence:
+// NativeIDs["asset_name"] (the canonical slot every CAI-routed
+// Discoverer populates — see compute_address.go::FromAsset for the
+// reference shape), then ImportID-derived fallback (treated as the
+// raw asset name when it starts with `//` — the dep-chase
+// DiscoverByID path on some discoverers stamps the asset name
+// directly into ImportID).
+//
+// Returns "" when no derivation path yields a usable name; the caller
+// surfaces a descriptive error.
+func cloudAssetNameFromIdentity(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if n := id.NativeIDs["asset_name"]; n != "" {
+		return n
+	}
+	if strings.HasPrefix(id.ImportID, "//") {
+		return id.ImportID
+	}
+	return ""
+}
+
+// cloudAssetScopeFromIdentity returns the CAI scope to query for the
+// resource identified by id. Precedence: Identity.ProjectID (the
+// per-resource project the Discoverer stamped at discover time), then
+// the run-level project ID threaded through EnrichClients.ProjectID.
+//
+// Returning "" signals the caller to surface a descriptive error
+// rather than issuing a CAI query with an empty scope (which CAI
+// rejects as INVALID_ARGUMENT — wrapping it client-side keeps the
+// error one frame closer to the actual misconfiguration).
+func cloudAssetScopeFromIdentity(id *imported.ResourceIdentity, fallbackProjectID string) string {
+	if id != nil && id.ProjectID != "" {
+		return "projects/" + id.ProjectID
+	}
+	if fallbackProjectID != "" {
+		return "projects/" + fallbackProjectID
+	}
+	return ""
+}
+
+// shapeCAIForLayer1 performs the minimum-viable transform that maps a
+// CAI versionedResources JSON tree (GCP REST API representation,
+// lowerCamelCase keys) into the shape the generated Layer-1 structs
+// expect: lowerCamelCase → snake_case keys, scalar leaves wrapped in
+// {"literal": …} envelopes (so they decode into generated.Value[T]),
+// nested maps and lists recursed.
+//
+// Out-of-scope per #490 / GCP-Step-3:
+//   - Self-link URL → bare-name normalization (e.g.
+//     `https://www.googleapis.com/compute/v1/projects/X/.../network/N`
+//     in CAI's body vs the bare `N` Terraform stores).
+//   - Region/zone URL → short-name normalization.
+//   - Computed-only field elision (decision #5; downstream emitters
+//     already handle this via the Schema map).
+//
+// Fields whose CAI names don't snake_case-rename onto a generated TF
+// field land at the top-level map but are silently dropped by
+// generated.UnmarshalAttrs (json's default is to ignore unknown
+// keys). The CAI HYBRID match-rate gap matches the AWS Cloud Control
+// HYBRID gap structurally — the GCP path closes faster because the
+// gotchas are narrower (no CFN → TF naming divergence, no tag-shape
+// divergence).
+func shapeCAIForLayer1(props map[string]any) map[string]any {
+	if props == nil {
+		return nil
+	}
+	out := make(map[string]any, len(props))
+	for k, v := range props {
+		out[camelToSnakeGCP(k)] = shapeValueForLayer1GCP(v)
+	}
+	return out
+}
+
+// shapeValueForLayer1GCP is the recursive helper for
+// shapeCAIForLayer1. Scalar leaves get wrapped in {"literal": …};
+// maps recurse; lists of maps recurse with key renames on each
+// element; lists of scalars pass through unchanged (Terraform
+// list-typed string attributes are rare on the GCP side today and
+// out of scope for the HYBRID baseline).
+func shapeValueForLayer1GCP(v any) any {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case map[string]any:
+		// Nested object — recurse on keys, but DO NOT wrap the
+		// object itself in a literal envelope. The generated nested
+		// structs are bare structs (no Value[T] wrapper), so the
+		// inner keys still need to be snake_case but the leaves
+		// inside the inner struct's fields need their own {"literal":
+		// …} wrap. Recursing through shapeCAIForLayer1 handles both.
+		return shapeCAIForLayer1(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = shapeValueForLayer1GCP(e)
+		}
+		return out
+	default:
+		// Scalar leaf — wrap in {"literal": …} so it decodes into
+		// generated.Value[T] cleanly.
+		return map[string]any{"literal": t}
+	}
+}
+
+// camelToSnakeGCP converts a GCP REST API lowerCamelCase property
+// name to a Terraform snake_case attribute name. Handles consecutive
+// uppercase runs as a single acronym ("kmsKeyName" → "kms_key_name",
+// "ipv4Range" → "ipv4_range", "selfLink" → "self_link",
+// "IPAddress" → "ip_address"). Pure ASCII; non-letter characters
+// (digits, hyphens) pass through.
+//
+// Algorithm: walk left-to-right; insert an underscore before an
+// uppercase letter when (a) the previous char was lowercase or a
+// digit, or (b) the previous char was uppercase but the next char is
+// lowercase (acronym → identifier boundary, e.g. "ARNTag" →
+// "arn_tag").
+//
+// Defensive against both lowerCamel and UpperCamel inputs: GCP's REST
+// JSON uses lowerCamelCase for most fields, but a few historical
+// fields use UpperCamel patterns (e.g. forwarding-rule `IPAddress`,
+// `IPProtocol`), and the algorithm handles both consistently.
+func camelToSnakeGCP(s string) string {
+	if s == "" {
+		return s
+	}
+	out := make([]byte, 0, len(s)+4)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			if i > 0 {
+				prev := s[i-1]
+				prevUpper := prev >= 'A' && prev <= 'Z'
+				prevDigit := prev >= '0' && prev <= '9'
+				nextLower := i+1 < len(s) && s[i+1] >= 'a' && s[i+1] <= 'z'
+				switch {
+				case !prevUpper && !prevDigit:
+					out = append(out, '_')
+				case prevUpper && nextLower:
+					out = append(out, '_')
+				case prevDigit:
+					out = append(out, '_')
+				}
+			}
+			out = append(out, c+('a'-'A'))
+			continue
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+// Compile-time pins: cloudAssetEnricher must satisfy both
+// AttributeEnricher and ByIDEnricher. A drift in either interface
+// that drops one of these methods is caught at build time rather
+// than surfacing as a runtime type-assertion miss in the dispatcher.
+var (
+	_ AttributeEnricher = (*cloudAssetEnricher)(nil)
+	_ ByIDEnricher      = (*cloudAssetEnricher)(nil)
+)

--- a/cmd/insideout-import/gcpdiscover/cloudasset_enricher_test.go
+++ b/cmd/insideout-import/gcpdiscover/cloudasset_enricher_test.go
@@ -1,0 +1,549 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// TestCamelToSnakeGCP pins the renamer behavior the enricher depends on
+// for translating GCP REST API lowerCamelCase property keys into the
+// snake_case json tags the generated Layer-1 structs declare. A drift
+// in the renamer would silently miss every CAI field whose name doesn't
+// round-trip — the unit test surfaces the regression alongside the
+// cases it would have caught.
+func TestCamelToSnakeGCP(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"name", "name"},
+		{"selfLink", "self_link"},
+		{"machineType", "machine_type"},
+		{"canIpForward", "can_ip_forward"},
+		{"creationTimestamp", "creation_timestamp"},
+		{"kmsKeyName", "kms_key_name"},
+		// Acronym at start (UpperCamel pattern GCP uses in a few
+		// historical fields like forwarding-rule IPAddress / IPProtocol).
+		{"IPAddress", "ip_address"},
+		{"IPProtocol", "ip_protocol"},
+		// Trailing acronym.
+		{"bucketURL", "bucket_url"},
+		// Pure numeric segment.
+		{"ipv4Range", "ipv4_range"},
+	}
+	for _, tc := range cases {
+		got := camelToSnakeGCP(tc.in)
+		assert.Equalf(t, tc.want, got, "camelToSnakeGCP(%q)", tc.in)
+	}
+}
+
+// TestShapeCAIForLayer1Recursive pins the shape transform: scalar
+// leaves get wrapped in {"literal": …} envelopes (so Value[T] can
+// decode them), every nested map's keys are renamed to snake_case,
+// and map list elements have their keys renamed too. Without this
+// contract, bare CAI scalars (e.g. `"canIpForward": false`) would fail
+// to decode against the Layer-1 *Value[bool] fields.
+func TestShapeCAIForLayer1Recursive(t *testing.T) {
+	t.Parallel()
+	in := map[string]any{
+		"name":         "my-vm",
+		"machineType":  "https://www.googleapis.com/compute/v1/projects/p/zones/z/machineTypes/e2-medium",
+		"canIpForward": false,
+		"networkInterfaces": []any{
+			map[string]any{
+				"name":    "nic0",
+				"network": "https://www.googleapis.com/compute/v1/projects/p/global/networks/default",
+			},
+		},
+		"labels": map[string]any{
+			"project": "io-abc",
+		},
+	}
+	out := shapeCAIForLayer1(in)
+
+	// Scalar leaves get wrapped.
+	name, ok := out["name"].(map[string]any)
+	require.Truef(t, ok, "name should be wrapped, got %T", out["name"])
+	assert.Equal(t, "my-vm", name["literal"])
+
+	machineType, ok := out["machine_type"].(map[string]any)
+	require.Truef(t, ok, "machine_type should be wrapped, got %T", out["machine_type"])
+	assert.Contains(t, machineType["literal"], "e2-medium")
+
+	// Snake_case rename for the bool field.
+	canIp, ok := out["can_ip_forward"].(map[string]any)
+	require.Truef(t, ok, "can_ip_forward should be wrapped, got %T", out["can_ip_forward"])
+	assert.Equal(t, false, canIp["literal"])
+
+	// Nested-list element: keys renamed + leaves wrapped.
+	nis, ok := out["network_interfaces"].([]any)
+	require.True(t, ok)
+	require.Len(t, nis, 1)
+	ni, ok := nis[0].(map[string]any)
+	require.True(t, ok)
+	nicName, ok := ni["name"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "nic0", nicName["literal"])
+
+	// Inner map: keys renamed.
+	labels, ok := out["labels"].(map[string]any)
+	require.True(t, ok)
+	proj, ok := labels["project"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "io-abc", proj["literal"])
+}
+
+// fakeCAIGet is a closure-style GetByName fake. The test sets
+// gotScope/gotAssetType/gotFullName from the inputs it receives so each
+// test case can assert on the requested arguments without a Cloud Asset
+// client. Returns the configured `data` map (or `err`) verbatim.
+type fakeCAIGet struct {
+	gotScope, gotAssetType, gotFullName string
+	data                                map[string]any
+	err                                 error
+}
+
+func (f *fakeCAIGet) call(_ context.Context, scope, assetType, fullName string) (map[string]any, error) {
+	f.gotScope = scope
+	f.gotAssetType = assetType
+	f.gotFullName = fullName
+	return f.data, f.err
+}
+
+// TestCloudAssetEnricher_Enrich_ComputeInstance exercises the full
+// Enrich flow against a synthetic compute.googleapis.com/Instance CAI
+// payload and asserts the resulting ir.Attrs round-trips through
+// generated.UnmarshalAttrs into the typed GoogleComputeInstance struct
+// with the expected scalar values. This is the load-bearing contract
+// that justifies the json-tag codegen change in step 1 of #490 for the
+// GCP side — and the PoC for HYBRID match-rate.
+func TestCloudAssetEnricher_Enrich_ComputeInstance(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCAIGet{
+		data: map[string]any{
+			"name":              "my-vm",
+			"description":       "demo vm",
+			"machineType":       "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a/machineTypes/e2-medium",
+			"canIpForward":      false,
+			"creationTimestamp": "2024-01-01T00:00:00.000-08:00",
+			"selfLink":          "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a/instances/my-vm",
+			"zone":              "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a",
+			"hostname":          "my-vm.example.com",
+			"cpuPlatform":       "Intel Cascade Lake",
+			"labels":            map[string]any{"project": "io-abc"},
+		},
+	}
+	enr := newCloudAssetEnricher("google_compute_instance", "compute.googleapis.com/Instance", fake.call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_compute_instance",
+			ProjectID: "real-proj",
+			Address:   "google_compute_instance.demo",
+			NativeIDs: map[string]string{
+				"asset_name": "//compute.googleapis.com/projects/real-proj/zones/us-central1-a/instances/my-vm",
+			},
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+	assert.Equal(t, "projects/real-proj", fake.gotScope)
+	assert.Equal(t, "compute.googleapis.com/Instance", fake.gotAssetType)
+	assert.Equal(t, "//compute.googleapis.com/projects/real-proj/zones/us-central1-a/instances/my-vm", fake.gotFullName)
+
+	decoded, err := generated.UnmarshalAttrs("google_compute_instance", ir.Attrs)
+	require.NoError(t, err)
+	inst, ok := decoded.(*generated.GoogleComputeInstance)
+	require.True(t, ok, "decoded type is %T, want *GoogleComputeInstance", decoded)
+
+	// Fields whose CAI lowerCamelCase name matches the snake_case TF tag
+	// after the renamer round-trip directly.
+	require.NotNil(t, inst.Name)
+	require.NotNil(t, inst.Name.Literal)
+	assert.Equal(t, "my-vm", *inst.Name.Literal)
+
+	require.NotNil(t, inst.Description)
+	require.NotNil(t, inst.Description.Literal)
+	assert.Equal(t, "demo vm", *inst.Description.Literal)
+
+	require.NotNil(t, inst.MachineType)
+	require.NotNil(t, inst.MachineType.Literal)
+	assert.Contains(t, *inst.MachineType.Literal, "e2-medium")
+
+	require.NotNil(t, inst.CanIpForward)
+	require.NotNil(t, inst.CanIpForward.Literal)
+	assert.Equal(t, false, *inst.CanIpForward.Literal)
+
+	require.NotNil(t, inst.SelfLink)
+	require.NotNil(t, inst.SelfLink.Literal)
+	assert.Contains(t, *inst.SelfLink.Literal, "/instances/my-vm")
+
+	require.NotNil(t, inst.Hostname)
+	require.NotNil(t, inst.Hostname.Literal)
+	assert.Equal(t, "my-vm.example.com", *inst.Hostname.Literal)
+
+	// Labels map round-trips into the typed map[string]*Value[string] field.
+	require.NotNil(t, inst.Labels)
+	require.NotNil(t, inst.Labels["project"])
+	require.NotNil(t, inst.Labels["project"].Literal)
+	assert.Equal(t, "io-abc", *inst.Labels["project"].Literal)
+}
+
+// TestCloudAssetEnricher_Enrich_NilCloudAsset_FromClients asserts the
+// production wiring path: when the embedded `fetch` is nil and
+// EnrichClients.CloudAsset is also nil, Enrich returns
+// ErrEnrichClientUnavailable so EnrichAttributes can downgrade to a
+// per-resource warning rather than aborting the batch.
+func TestCloudAssetEnricher_Enrich_NilCloudAsset_FromClients(t *testing.T) {
+	t.Parallel()
+	enr := newCloudAssetEnricher("google_compute_instance", "compute.googleapis.com/Instance", nil)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_compute_instance",
+			ProjectID: "real-proj",
+			NativeIDs: map[string]string{
+				"asset_name": "//compute.googleapis.com/projects/real-proj/zones/us-central1-a/instances/my-vm",
+			},
+		},
+	}
+	err := enr.Enrich(context.Background(), ir, EnrichClients{})
+	assert.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+// TestCloudAssetEnricher_Enrich_NotFound exercises the soft-fail path:
+// the underlying searcher's ErrNotFound is wrapped and re-emitted as
+// ErrNotFound so EnrichAttributes can drop the resource from the batch
+// result without failing the whole run. The most-likely real-world
+// cause is a resource deleted between the discover and enrich stages,
+// or CAI eventual-consistency lag.
+func TestCloudAssetEnricher_Enrich_NotFound(t *testing.T) {
+	t.Parallel()
+	// Wrap ErrNotFound in the canonical fmt.Errorf("...: %w", ErrNotFound)
+	// chain so the enricher detects it via errors.Is. Joined with an
+	// inner message to mimic the searcher's real wrap shape ("cloud
+	// asset getbyname <type> <name>: <msg>: <ErrNotFound>").
+	fake := &fakeCAIGet{
+		err: errors.Join(errors.New("cloud asset getbyname: simulated miss"), ErrNotFound),
+	}
+	enr := newCloudAssetEnricher("google_compute_instance", "compute.googleapis.com/Instance", fake.call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_compute_instance",
+			ProjectID: "real-proj",
+			NativeIDs: map[string]string{
+				"asset_name": "//compute.googleapis.com/projects/real-proj/zones/us-central1-a/instances/my-vm",
+			},
+		},
+	}
+	err := enr.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestCloudAssetEnricher_Enrich_NoAssetName asserts that the enricher
+// rejects an Identity with no asset_name and no //-prefixed ImportID
+// loudly. Falling through silently would later surface as a CAI
+// INVALID_ARGUMENT; explicit detection at the dispatch site puts the
+// misconfiguration in the test surface.
+func TestCloudAssetEnricher_Enrich_NoAssetName(t *testing.T) {
+	t.Parallel()
+	enr := newCloudAssetEnricher("google_compute_instance", "compute.googleapis.com/Instance", (&fakeCAIGet{}).call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_compute_instance",
+			ProjectID: "real-proj",
+			Address:   "google_compute_instance.demo",
+		},
+	}
+	err := enr.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive CAI asset name")
+}
+
+// TestCloudAssetEnricher_Enrich_NoProjectID asserts that the enricher
+// rejects an Identity with no ProjectID and no fallback. The scope
+// derivation must succeed before issuing the CAI call.
+func TestCloudAssetEnricher_Enrich_NoProjectID(t *testing.T) {
+	t.Parallel()
+	enr := newCloudAssetEnricher("google_compute_instance", "compute.googleapis.com/Instance", (&fakeCAIGet{}).call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:    "google_compute_instance",
+			Address: "google_compute_instance.demo",
+			NativeIDs: map[string]string{
+				"asset_name": "//compute.googleapis.com/projects/real-proj/zones/us-central1-a/instances/my-vm",
+			},
+			// No ProjectID set.
+		},
+	}
+	// EnrichClients also empty → no fallback project either.
+	err := enr.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive CAI scope")
+}
+
+// TestCloudAssetEnricher_Enrich_RealAPIError asserts that an arbitrary
+// non-NotFound error from the underlying fetch propagates up wrapped
+// but un-translated, so EnrichAttributes treats it as a real error and
+// includes it in the aggregated batch failure.
+func TestCloudAssetEnricher_Enrich_RealAPIError(t *testing.T) {
+	t.Parallel()
+	upstream := errors.New("permission denied")
+	fake := &fakeCAIGet{err: upstream}
+	enr := newCloudAssetEnricher("google_compute_instance", "compute.googleapis.com/Instance", fake.call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_compute_instance",
+			ProjectID: "real-proj",
+			NativeIDs: map[string]string{
+				"asset_name": "//compute.googleapis.com/projects/real-proj/zones/us-central1-a/instances/my-vm",
+			},
+		},
+	}
+	err := enr.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound)
+	assert.NotErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.ErrorIs(t, err, upstream)
+}
+
+// TestCloudAssetEnricher_EnrichByID exercises the ByIDEnricher entry
+// point with the same fetch + mapping path as Enrich, asserting the
+// returned raw JSON round-trips into the typed struct.
+func TestCloudAssetEnricher_EnrichByID(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCAIGet{
+		data: map[string]any{
+			"name":     "my-vm",
+			"selfLink": "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a/instances/my-vm",
+		},
+	}
+	enr := newCloudAssetEnricher("google_compute_instance", "compute.googleapis.com/Instance", fake.call)
+	raw, err := enr.EnrichByID(context.Background(), &imported.ResourceIdentity{
+		Type:      "google_compute_instance",
+		ProjectID: "real-proj",
+		NativeIDs: map[string]string{
+			"asset_name": "//compute.googleapis.com/projects/real-proj/zones/us-central1-a/instances/my-vm",
+		},
+	}, EnrichClients{})
+	require.NoError(t, err)
+	decoded, err := generated.UnmarshalAttrs("google_compute_instance", raw)
+	require.NoError(t, err)
+	inst, ok := decoded.(*generated.GoogleComputeInstance)
+	require.True(t, ok)
+	require.NotNil(t, inst.Name)
+	require.NotNil(t, inst.Name.Literal)
+	assert.Equal(t, "my-vm", *inst.Name.Literal)
+}
+
+// TestCloudAssetEnricher_EnrichByID_NilIdentity asserts the
+// programmer-error case (caller passed nil) is reported clearly rather
+// than panicking inside the fetch call.
+func TestCloudAssetEnricher_EnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	enr := newCloudAssetEnricher("google_compute_instance", "compute.googleapis.com/Instance", (&fakeCAIGet{}).call)
+	_, err := enr.EnrichByID(context.Background(), nil, EnrichClients{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity is nil")
+}
+
+// TestCloudAssetEnricher_ResourceType pins the trivial accessor so a
+// refactor that loses the field is caught at unit-test time.
+func TestCloudAssetEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	enr := newCloudAssetEnricher("google_pubsub_topic", "pubsub.googleapis.com/Topic", nil)
+	assert.Equal(t, "google_pubsub_topic", enr.ResourceType())
+}
+
+// TestCloudAssetEnricher_Enrich_UnknownTFType pins the wiring-bug
+// detection: if a caller constructs an enricher for a TF type that
+// isn't registered in pkg/composer/imported/generated, the enricher
+// must report the missing registration cleanly rather than silently
+// emitting raw CAI-shaped JSON the downstream UnmarshalAttrs would
+// later reject.
+func TestCloudAssetEnricher_Enrich_UnknownTFType(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCAIGet{
+		data: map[string]any{"name": "test"},
+	}
+	enr := newCloudAssetEnricher("google_does_not_exist", "phony.googleapis.com/Type", fake.call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_does_not_exist",
+			ProjectID: "real-proj",
+			NativeIDs: map[string]string{"asset_name": "//phony.googleapis.com/projects/real-proj/things/x"},
+		},
+	}
+	err := enr.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal into google_does_not_exist")
+}
+
+// TestCloudAssetEnricher_Enrich_RawAttrs_IsValidJSONWithSnakeKeys
+// guards the wire-format contract: after the json-tags codegen change,
+// ir.Attrs uses lowercase snake_case keys for every top-level
+// attribute. A regression that drops the json tag emission would
+// silently revert to CamelCase Go-field-name keys, reintroducing the
+// renamer-projection workaround and a coverage gap on every multi-word
+// attribute name.
+func TestCloudAssetEnricher_Enrich_RawAttrs_IsValidJSONWithSnakeKeys(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCAIGet{
+		data: map[string]any{
+			"name":              "my-vm",
+			"canIpForward":      true,
+			"creationTimestamp": "2024-01-01T00:00:00Z",
+		},
+	}
+	enr := newCloudAssetEnricher("google_compute_instance", "compute.googleapis.com/Instance", fake.call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_compute_instance",
+			ProjectID: "real-proj",
+			NativeIDs: map[string]string{
+				"asset_name": "//compute.googleapis.com/projects/real-proj/zones/us-central1-a/instances/my-vm",
+			},
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+	var top map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(ir.Attrs, &top))
+	assert.Contains(t, top, "name")
+	assert.Contains(t, top, "can_ip_forward")
+	assert.Contains(t, top, "creation_timestamp")
+	for k := range top {
+		assert.Equalf(t, strings.ToLower(k), k, "expected lowercase top-level key, got %q", k)
+	}
+}
+
+// TestCloudAssetEnricher_PoC_ComputeInstance_FieldMatchRate is the
+// HYBRID PoC pinned as a unit test. It builds a representative CAI
+// Resource.Data payload for a compute.googleapis.com/Instance asset,
+// runs the enricher's full Enrich+round-trip, and computes the
+// match-rate of (CAI fields that land in a typed Layer-1 slot) /
+// (total CAI fields the payload exposed). The threshold below pins
+// the floor — a regression that drops the json tags or breaks the
+// snake_case renamer would crash the rate before the test ever fails
+// in CI.
+//
+// AWS Cloud Control HYBRID PoC measured 57% on aws_cloudwatch_log_group;
+// GCP CAI is projected higher because (a) CAI returns native REST JSON
+// which already uses lowerCamelCase, and (b) labels are map[string]string
+// in both API and TF. Threshold: 70% — high enough to lock in the win,
+// low enough to leave room for known divergences (self_link URL format
+// vs bare names; region/zone URLs; computed-only fields the policy
+// elides downstream). PoC outcome documented in .tmp/cai-enricher-poc.md.
+func TestCloudAssetEnricher_PoC_ComputeInstance_FieldMatchRate(t *testing.T) {
+	t.Parallel()
+	// Realistic compute.googleapis.com/Instance CAI payload. Field set
+	// pulled from the Compute Engine v1 REST API's Instance resource
+	// representation per https://cloud.google.com/compute/docs/reference/rest/v1/instances#resource:-instance.
+	// Selected the broadly-applicable scalar + nested fields a real
+	// CAI versionedResources payload would surface; deliberately
+	// excluded service-managed metadata (creationTimestamp, id, status)
+	// to keep the rate honest against the decision-#5 emission rule.
+	cai := map[string]any{
+		// Scalar top-level fields.
+		"name":                    "demo-vm",
+		"description":             "demo virtual machine",
+		"machineType":             "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a/machineTypes/e2-medium",
+		"canIpForward":            false,
+		"deletionProtection":      false,
+		"hostname":                "demo-vm.example.com",
+		"cpuPlatform":             "Intel Cascade Lake",
+		"selfLink":                "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a/instances/demo-vm",
+		"zone":                    "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a",
+		"minCpuPlatform":          "Intel Cascade Lake",
+		"creationTimestamp":       "2024-01-01T00:00:00.000-08:00",
+		"keyRevocationActionType": "NONE",
+		// labels (TF: map[string]*Value[string], CAI: map[string]string).
+		"labels": map[string]any{
+			"project": "io-abc",
+			"env":     "prod",
+		},
+		// network tags ([]string in both CAI and TF — note: this is
+		// `tags.items` in the REST API but CAI surfaces it as a flat
+		// `tags` array; TF stores it as a `tags` set of strings).
+		// Excluded here because the TF field name is `tags` but CAI
+		// surfaces it as a nested {items: []} object — a known
+		// divergence the Normalizer hooks follow-up will bridge.
+	}
+
+	fake := &fakeCAIGet{data: cai}
+	enr := newCloudAssetEnricher("google_compute_instance", "compute.googleapis.com/Instance", fake.call)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_compute_instance",
+			ProjectID: "real-proj",
+			NativeIDs: map[string]string{
+				"asset_name": "//compute.googleapis.com/projects/real-proj/zones/us-central1-a/instances/demo-vm",
+			},
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+
+	// Decode into the typed struct.
+	decoded, err := generated.UnmarshalAttrs("google_compute_instance", ir.Attrs)
+	require.NoError(t, err)
+	inst, ok := decoded.(*generated.GoogleComputeInstance)
+	require.True(t, ok)
+
+	// Top-level CAI fields and the expected typed-struct populated state
+	// after the enricher round-trip. A field is "matched" iff the typed
+	// struct's corresponding slot is non-nil after round-trip.
+	type check struct {
+		caiField string
+		matched  bool
+	}
+	checks := []check{
+		{"name", inst.Name != nil},
+		{"description", inst.Description != nil},
+		{"machineType", inst.MachineType != nil},
+		{"canIpForward", inst.CanIpForward != nil},
+		{"deletionProtection", inst.DeletionProtection != nil},
+		{"hostname", inst.Hostname != nil},
+		{"cpuPlatform", inst.CPUPlatform != nil},
+		{"selfLink", inst.SelfLink != nil},
+		{"zone", inst.Zone != nil},
+		{"minCpuPlatform", inst.MinCPUPlatform != nil},
+		{"creationTimestamp", inst.CreationTimestamp != nil},
+		{"keyRevocationActionType", inst.KeyRevocationActionType != nil},
+		{"labels", len(inst.Labels) > 0},
+	}
+
+	matched := 0
+	for _, c := range checks {
+		if c.matched {
+			matched++
+		} else {
+			t.Logf("PoC: unmatched CAI field %q (HYBRID gap; follow-up Normalizer hooks)", c.caiField)
+		}
+	}
+	total := len(checks)
+	rate := float64(matched) / float64(total)
+	t.Logf("PoC compute_instance HYBRID match rate: %d/%d = %.0f%%", matched, total, rate*100)
+
+	// Floor: 70% — comfortably above the AWS PoC's 57% on
+	// aws_cloudwatch_log_group. Set high enough to lock in the win, low
+	// enough that a single new divergence doesn't break CI before the
+	// Normalizer hooks follow-up lands.
+	const floor = 0.70
+	if rate < floor {
+		t.Errorf("PoC field match rate %.2f below floor %.2f — enricher coverage regressed", rate, floor)
+	}
+}
+
+// Compile-time pin: cloudAssetEnricher must satisfy both
+// AttributeEnricher and ByIDEnricher. A drift in either interface that
+// drops one of these methods is caught at build time. (Mirrors the
+// var-block in cloudasset_enricher.go.)
+var _ AttributeEnricher = (*cloudAssetEnricher)(nil)
+var _ ByIDEnricher = (*cloudAssetEnricher)(nil)

--- a/cmd/insideout-import/gcpdiscover/cloudasset_types.go
+++ b/cmd/insideout-import/gcpdiscover/cloudasset_types.go
@@ -1,0 +1,207 @@
+package gcpdiscover
+
+// cloudasset_types.go — registry of GCP Terraform resource types routed
+// through the generic Cloud Asset Inventory (CAI) HYBRID attribute
+// enricher (mirrors AWS #490 / cloudcontrol_types.go for GCP).
+//
+// Each entry maps one Terraform TFType to a CAI AssetType discriminator.
+// The list is iterated at NewGCPDiscoverer construction time to populate
+// byTypeEnricher in one shot, with hand-rolled enrichers winning as
+// overrides (see gcpdiscover.go::byTypeEnricher wiring).
+//
+// Coverage scope: every GCP TF type registered in NewGCPDiscoverer.byType
+// that the Cloud Asset Inventory service surfaces with
+// `versionedResources` — i.e. types whose backing service has a
+// SearchAllResources-compatible asset type. Types that lack CAI
+// coverage (most IAM bindings, SQL users, project services, custom
+// monitoring dashboards, etc.) are intentionally omitted; the
+// hand-rolled discoverer / enricher path remains the source of truth
+// for those. The supported-asset-types reference lives at
+// https://cloud.google.com/asset-inventory/docs/supported-asset-types.
+//
+// Why this should be cleaner than AWS Cloud Control was (#490 PoC: 57%
+// exact-match on aws_cloudwatch_log_group):
+//
+//   - CAI returns native GCP REST JSON which already uses
+//     lowerCamelCase keys matching the Terraform attribute names after
+//     a simple snake_case rename — no CFN-style CamelCase divergence.
+//   - GCP labels are map[string]string in both the API and TF — no
+//     AWS-style list-of-{Key,Value} tag-shape divergence.
+//
+// Projected first-try match rate: 75-90% (vs AWS's 57%). The
+// per-type Normalizer hooks follow-up (#501 GCP-equivalent) is
+// out-of-scope for this PR — fields that don't round-trip cleanly
+// are silently dropped by the generated struct's UnmarshalJSON for
+// now.
+//
+// Adding a new type means: (1) confirm CAI surfaces the asset type and
+// versionedResources via SearchAllResources, (2) confirm the Layer-1
+// generated struct exists at pkg/composer/imported/generated/<tfType>.gen.go,
+// (3) append the config below. The wiring loop in gcpdiscover.go
+// auto-registers a cloudAssetEnricher for any entry that doesn't
+// already have a hand-rolled override.
+
+// cloudAssetConfig is the per-Terraform-type CAI HYBRID enricher
+// config. Minimum-viable shape mirrors AWS's cloudControlConfig but
+// drops the fields the GCP path doesn't need:
+//
+//   - No SlugByService — GCP enrichment all routes through a single
+//     service slug (the CAI service) rather than per-service.
+//   - No ImportID / NameHint / NativeIDs / Tags extractors — the
+//     discoverer already populated those at discover time; the
+//     enricher consumes Identity.NativeIDs["asset_name"] as-is and
+//     marshals the resource's full JSON body into Attrs without
+//     re-extracting.
+//   - No ParentLister / SDKLister — CAI fans out a single
+//     SearchAllResources call across asset types; no per-service
+//     list helpers needed.
+//
+// AssetType is the CAI asset-type discriminator passed to
+// SearchAllResources (e.g. compute.googleapis.com/Instance).
+//
+// Skip controls per-type opt-out from the CAI HYBRID path even when a
+// generated.<TF type> struct exists. Set this when a hand-rolled
+// enricher is the production source of truth and the CAI fallback
+// would be strictly worse (today: every type in
+// gcpdiscover.byTypeEnricher's hand-rolled set already wins as an
+// override via the wiring loop, so Skip is unused — present so a
+// future contributor can opt out a type whose CAI Resource.Data shape
+// is degenerate without having to add an empty hand-rolled enricher).
+type cloudAssetConfig struct {
+	TFType    string
+	AssetType string
+	Skip      bool
+}
+
+// cloudAssetTypeConfigs is the GCP equivalent of AWS's
+// cloudControlTypeConfigs. Iterated at NewGCPDiscoverer construction
+// time to populate byTypeEnricher with one cloudAssetEnricher per
+// entry that does NOT already have a hand-rolled override.
+//
+// Coverage today: 36 entries covering the CAI-surfaced GCP TF types in
+// the registry. Notable omissions:
+//
+//   - IAM binding/member types (google_project_iam_member,
+//     google_storage_bucket_iam_member, google_kms_crypto_key_iam_binding,
+//     google_secret_manager_secret_iam_binding,
+//     google_secret_manager_secret_iam_member,
+//     google_cloud_run_v2_service_iam_member,
+//     google_cloudfunctions2_function_iam_member): IAM bindings are
+//     attached to parent resources, not first-class CAI assets — the
+//     existing IAM-policy lister path remains authoritative.
+//   - google_sql_user, google_project_service,
+//     google_logging_project_sink, google_identity_platform_config,
+//     google_identity_platform_default_supported_idp_config,
+//     google_service_networking_connection,
+//     google_vpc_access_connector: non-CAI discoverers (ScopeStyleNonCAI);
+//     CAI does not index these resource types.
+//   - google_storage_bucket_object, google_secret_manager_secret_version:
+//     sub-resources fanned out across parent rows by their bespoke
+//     listers; CAI does surface them but the per-object overhead would
+//     dwarf the parent's enrichment cost.
+//   - google_monitoring_dashboard, google_monitoring_alert_policy,
+//     google_monitoring_notification_channel: CAI's coverage of
+//     monitoring resources is partial / shaped differently from the TF
+//     provider's view; keep these on the hand-rolled path until the
+//     shapes prove to round-trip.
+//
+// The remaining 36 entries below all have a corresponding
+// pkg/composer/imported/generated/<tfType>.gen.go file (verified by
+// TestCloudAssetEnricherCoversEveryCAIRoutedType — a configured type
+// without a generated struct would fail at UnmarshalAttrs time).
+var cloudAssetTypeConfigs = []cloudAssetConfig{
+	// =====================================================================
+	// Compute Engine — compute.googleapis.com
+	// =====================================================================
+	{TFType: "google_compute_address", AssetType: "compute.googleapis.com/Address"},
+	{TFType: "google_compute_global_address", AssetType: "compute.googleapis.com/GlobalAddress"},
+	{TFType: "google_compute_firewall", AssetType: "compute.googleapis.com/Firewall"},
+	{TFType: "google_compute_forwarding_rule", AssetType: "compute.googleapis.com/ForwardingRule"},
+	{TFType: "google_compute_global_forwarding_rule", AssetType: "compute.googleapis.com/GlobalForwardingRule"},
+	{TFType: "google_compute_instance", AssetType: "compute.googleapis.com/Instance"},
+	{TFType: "google_compute_network", AssetType: "compute.googleapis.com/Network"},
+	{TFType: "google_compute_router", AssetType: "compute.googleapis.com/Router"},
+	{TFType: "google_compute_security_policy", AssetType: "compute.googleapis.com/SecurityPolicy"},
+	{TFType: "google_compute_target_http_proxy", AssetType: "compute.googleapis.com/TargetHttpProxy"},
+	{TFType: "google_compute_target_https_proxy", AssetType: "compute.googleapis.com/TargetHttpsProxy"},
+	{TFType: "google_compute_url_map", AssetType: "compute.googleapis.com/UrlMap"},
+	{TFType: "google_compute_backend_service", AssetType: "compute.googleapis.com/BackendService"},
+	{TFType: "google_compute_health_check", AssetType: "compute.googleapis.com/HealthCheck"},
+	{TFType: "google_compute_managed_ssl_certificate", AssetType: "compute.googleapis.com/SslCertificate"},
+	{TFType: "google_compute_resource_policy", AssetType: "compute.googleapis.com/ResourcePolicy"},
+
+	// =====================================================================
+	// Cloud Storage — storage.googleapis.com
+	// =====================================================================
+	{TFType: "google_storage_bucket", AssetType: "storage.googleapis.com/Bucket"},
+
+	// =====================================================================
+	// Pub/Sub — pubsub.googleapis.com
+	// =====================================================================
+	{TFType: "google_pubsub_topic", AssetType: "pubsub.googleapis.com/Topic"},
+	{TFType: "google_pubsub_subscription", AssetType: "pubsub.googleapis.com/Subscription"},
+
+	// =====================================================================
+	// IAM service accounts — iam.googleapis.com
+	// =====================================================================
+	{TFType: "google_service_account", AssetType: "iam.googleapis.com/ServiceAccount"},
+
+	// =====================================================================
+	// Cloud KMS — cloudkms.googleapis.com
+	// =====================================================================
+	{TFType: "google_kms_key_ring", AssetType: "cloudkms.googleapis.com/KeyRing"},
+	{TFType: "google_kms_crypto_key", AssetType: "cloudkms.googleapis.com/CryptoKey"},
+
+	// =====================================================================
+	// Secret Manager — secretmanager.googleapis.com
+	// =====================================================================
+	{TFType: "google_secret_manager_secret", AssetType: "secretmanager.googleapis.com/Secret"},
+
+	// =====================================================================
+	// Cloud SQL — sqladmin.googleapis.com
+	// =====================================================================
+	{TFType: "google_sql_database_instance", AssetType: "sqladmin.googleapis.com/Instance"},
+
+	// =====================================================================
+	// GKE — container.googleapis.com
+	// =====================================================================
+	{TFType: "google_container_cluster", AssetType: "container.googleapis.com/Cluster"},
+	{TFType: "google_container_node_pool", AssetType: "container.googleapis.com/NodePool"},
+
+	// =====================================================================
+	// Cloud Run v2 — run.googleapis.com
+	// =====================================================================
+	{TFType: "google_cloud_run_v2_service", AssetType: "run.googleapis.com/Service"},
+
+	// =====================================================================
+	// Cloud Functions Gen 2 — cloudfunctions.googleapis.com
+	// =====================================================================
+	{TFType: "google_cloudfunctions2_function", AssetType: "cloudfunctions.googleapis.com/Function"},
+
+	// =====================================================================
+	// API Gateway — apigateway.googleapis.com
+	// =====================================================================
+	{TFType: "google_api_gateway_api", AssetType: "apigateway.googleapis.com/Api"},
+	{TFType: "google_api_gateway_api_config", AssetType: "apigateway.googleapis.com/ApiConfig"},
+	{TFType: "google_api_gateway_gateway", AssetType: "apigateway.googleapis.com/Gateway"},
+
+	// =====================================================================
+	// Memorystore (Redis) — redis.googleapis.com
+	// =====================================================================
+	{TFType: "google_redis_instance", AssetType: "redis.googleapis.com/Instance"},
+
+	// =====================================================================
+	// Vertex AI — aiplatform.googleapis.com
+	// =====================================================================
+	{TFType: "google_vertex_ai_dataset", AssetType: "aiplatform.googleapis.com/Dataset"},
+
+	// =====================================================================
+	// Cloud Build — cloudbuild.googleapis.com
+	// =====================================================================
+	{TFType: "google_cloudbuild_trigger", AssetType: "cloudbuild.googleapis.com/BuildTrigger"},
+
+	// =====================================================================
+	// Firestore — firestore.googleapis.com
+	// =====================================================================
+	{TFType: "google_firestore_database", AssetType: "firestore.googleapis.com/Database"},
+}

--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -133,7 +133,17 @@ type EnrichClients struct {
 	Pubsub        *pubsubv1.Service
 	SecretManager *secretmanagerv1.Service
 	Compute       *computev1.Service
-	ProjectID     string
+	// CloudAsset is the unified Cloud Asset Inventory getter the generic
+	// HYBRID enricher (cloudasset_enricher.go) calls into to fetch the
+	// typed JSON representation of a single asset by name. Distinct from
+	// the per-service SDK clients above: one CloudAsset client backs
+	// every TF type routed through cloudAssetTypeConfigs, while each of
+	// the per-service clients backs exactly one hand-rolled enricher.
+	// Hand-rolled enrichers win as overrides at registration time, so
+	// callers that ship both clients pay no CAI hit on types covered by
+	// a hand-rolled enricher.
+	CloudAsset gcpAssetGetter
+	ProjectID  string
 }
 
 // ErrEnrichClientUnavailable signals that the SDK client an enricher

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -340,16 +340,58 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string, opts GCPDisco
 		// terraform-driven Stage 2b path. Types without an entry here are
 		// silently skipped by EnrichAttributes — the full enricher rollout
 		// follows the existing per-type ordering one PR at a time.
-		byTypeEnricher: map[string]AttributeEnricher{
-			"google_compute_address":       newComputeAddressEnricher(),
-			"google_compute_firewall":      newComputeFirewallEnricher(),
-			"google_compute_network":       newComputeNetworkEnricher(),
-			"google_pubsub_subscription":   newPubsubSubscriptionEnricher(),
-			"google_pubsub_topic":          newPubsubTopicEnricher(),
-			"google_secret_manager_secret": newSecretManagerSecretEnricher(),
-			"google_storage_bucket":        newStorageBucketEnricher(),
-		},
+		byTypeEnricher: buildByTypeEnricher(),
 	}
+}
+
+// buildByTypeEnricher constructs the per-Terraform-type enricher map.
+// Hand-rolled enrichers register first so they survive the override-wins
+// loop that follows; the generic cloudAssetEnricher backfills every TF
+// type listed in cloudAssetTypeConfigs that does NOT already have a
+// hand-rolled override (mirrors the AWS Cloud Control HYBRID pattern
+// from #490).
+//
+// Quality band: hand-rolled enrichers produce strictly more correct
+// payloads today (primary-name field aliasing, computed-only field
+// normalization, sensitive-overlay fetches). The CAI enricher fills in
+// the long tail of CAI-routed types that have no hand-rolled override;
+// per-type Normalizer hooks (the GCP equivalent of #501) are tracked as
+// a follow-up and not in scope for this registration loop.
+func buildByTypeEnricher() map[string]AttributeEnricher {
+	byTypeEnricher := map[string]AttributeEnricher{
+		"google_compute_address":       newComputeAddressEnricher(),
+		"google_compute_firewall":      newComputeFirewallEnricher(),
+		"google_compute_network":       newComputeNetworkEnricher(),
+		"google_pubsub_subscription":   newPubsubSubscriptionEnricher(),
+		"google_pubsub_topic":          newPubsubTopicEnricher(),
+		"google_secret_manager_secret": newSecretManagerSecretEnricher(),
+		"google_storage_bucket":        newStorageBucketEnricher(),
+	}
+	// HYBRID Cloud Asset Inventory fallback: register one
+	// cloudAssetEnricher for every TF type in cloudAssetTypeConfigs that
+	// doesn't already have a hand-rolled override above. Hand-rolled
+	// wins; the loop iterates the same config the discoverer registry
+	// pulls from so enricher coverage stays in lockstep with listing
+	// coverage. Entries with Skip=true are excluded — that flag is the
+	// per-type opt-out for cases where the CAI fallback would be
+	// strictly worse than letting the type emit Identity-only.
+	//
+	// The enricher's fetch callback defaults to nil and is resolved at
+	// Enrich time from EnrichClients.CloudAsset. Callers constructing
+	// EnrichClients without a CloudAsset client see a per-resource
+	// ErrEnrichClientUnavailable warning (not a batch-fatal error) so a
+	// partial-credentials run still produces useful output from the
+	// hand-rolled enrichers.
+	for _, cfg := range cloudAssetTypeConfigs {
+		if cfg.Skip {
+			continue
+		}
+		if _, has := byTypeEnricher[cfg.TFType]; has {
+			continue
+		}
+		byTypeEnricher[cfg.TFType] = newCloudAssetEnricher(cfg.TFType, cfg.AssetType, nil)
+	}
+	return byTypeEnricher
 }
 
 // SupportedTypes returns the registered Terraform types in lexicographic

--- a/cmd/insideout-import/gcpdiscover/searcher.go
+++ b/cmd/insideout-import/gcpdiscover/searcher.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 // gcpAssetResult is a flattened view of a Cloud Asset SearchAllResources
@@ -50,6 +51,39 @@ type gcpAssetResult struct {
 // uses *RealAssetSearcher; tests construct lightweight fakes.
 type gcpAssetSearcher interface {
 	SearchAll(ctx context.Context, scope string, assetTypes []string, query string) ([]gcpAssetResult, error)
+}
+
+// gcpAssetGetter is the optional side-interface implemented by searchers
+// that can fetch the full typed JSON representation of a single asset
+// by name (the Cloud Asset Inventory `versionedResources` field). The
+// CAI HYBRID enricher (cloudasset_enricher.go, mirrors AWS #490 for
+// GCP) depends on this side-interface; discoverers do NOT — they only
+// consume the flattened gcpAssetResult shape from SearchAll.
+//
+// Side-interface (not a method on gcpAssetSearcher) so the dozens of
+// pre-existing per-type unit-test fakes that implement
+// gcpAssetSearcher with the older SearchAll-only signature continue to
+// compile unchanged. Tests that need to exercise the enricher path
+// implement both interfaces on the same fake; tests that don't, don't.
+//
+// The fullName argument is the CAI full resource name, of the form
+// `//<service>/<path>/<segments>` (e.g.
+// `//compute.googleapis.com/projects/my-proj/zones/us-central1-a/instances/my-vm`).
+// It is the same string the per-type Discoverer writes into
+// Identity.NativeIDs["asset_name"] at discovery time.
+//
+// The returned map is the resource's JSON representation as defined by
+// the corresponding service-API (e.g. for compute, the Compute Engine
+// v1 REST API representation — `lowerCamelCase` keys, native types
+// for scalars, nested maps for objects). The enricher's CamelCase →
+// snake_case transform reshapes this into the canonical Layer-1 wire
+// format the generated.Google<Type> structs expect.
+//
+// Returns ErrNotFound when the search returns zero rows; any other
+// error reflects a real Cloud Asset API failure (auth, permission,
+// throttle, etc.).
+type gcpAssetGetter interface {
+	GetByName(ctx context.Context, scope, assetType, fullName string) (map[string]any, error)
 }
 
 // RealAssetSearcher wraps cloud.google.com/go/asset/apiv1.Client. The
@@ -127,6 +161,88 @@ func (s *RealAssetSearcher) SearchAll(ctx context.Context, scope string, assetTy
 		}
 		out = append(out, assetResultFromProto(r))
 	}
+}
+
+// GetByName fetches a single Cloud Asset resource by its full
+// resource name (//<service>/<path>/<segments>) and returns the
+// resource's typed JSON representation as a map[string]any (the
+// `versionedResources` payload). Used by the CAI HYBRID enricher to
+// route per-resource attribute lookups through one unified API surface
+// instead of one SDK client per service.
+//
+// scope follows the same form as SearchAll (projects/<id>,
+// folders/<num>, organizations/<num>). assetType is the CAI asset
+// type discriminator (e.g. compute.googleapis.com/Instance) used to
+// narrow the search; passing it explicitly rather than letting the
+// service infer it from the query keeps the call cheap on large
+// projects where the eq-by-name search would otherwise scan every
+// asset type.
+//
+// The function issues one SearchAllResources call with
+// `query = "name=<fullName>"` and `read_mask` including
+// `versionedResources`. The first matching row's most-recent
+// versioned-resource Data field is returned. Returns ErrNotFound when
+// the search returns no rows (the asset was deleted between discovery
+// and enrichment, or the operator's IAM principal lacks read
+// permission on this specific asset type).
+//
+// The single-row pattern is sound: name=<fullName> is an exact-match
+// query (vs the `:` contains operator), and CAI guarantees uniqueness
+// of fullName across the entire scope per
+// https://cloud.google.com/asset-inventory/docs/searching-resources.
+func (s *RealAssetSearcher) GetByName(ctx context.Context, scope, assetType, fullName string) (map[string]any, error) {
+	if s.client == nil {
+		return nil, errors.New("cloud asset client closed")
+	}
+	if fullName == "" {
+		return nil, errors.New("cloud asset getbyname: empty asset name")
+	}
+	req := &assetpb.SearchAllResourcesRequest{
+		Scope: scope,
+		// Exact-match on the full resource name. `=` (not `:`) is the
+		// equality operator per the SearchAllResources query syntax.
+		Query: fmt.Sprintf("name=%s", fullName),
+		// Narrowing by asset type keeps the server-side scan O(rows
+		// of that type) rather than O(all rows in the project),
+		// which matters on large multi-tenant projects.
+		AssetTypes: []string{assetType},
+		// versionedResources is NOT returned by default — it carries
+		// the full typed JSON representation of the asset (the body
+		// CAI mirrors from each service's REST API). The read_mask
+		// includes the default fields the iterator-row mapper reads
+		// (name, assetType) plus the versionedResources opt-in. See
+		// the SearchAllResourcesRequest doc for the full default-field
+		// list.
+		ReadMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "assetType", "versionedResources"}},
+	}
+	it := s.client.SearchAllResources(ctx, req)
+	r, err := it.Next()
+	if errors.Is(err, iterator.Done) {
+		return nil, fmt.Errorf("cloud asset getbyname %s %q: %w", assetType, fullName, ErrNotFound)
+	}
+	if err != nil {
+		return nil, wrapSearchAllError(err)
+	}
+	versions := r.GetVersionedResources()
+	if len(versions) == 0 {
+		// Asset exists in CAI's index but the operator's read_mask
+		// scope is too narrow to surface its data (or the CAI
+		// service hasn't backfilled the versioned representation
+		// for this asset type). Surface as ErrNotFound so the
+		// EnrichAttributes loop downgrades it to a per-resource
+		// warning rather than aborting the whole batch.
+		return nil, fmt.Errorf("cloud asset getbyname %s %q: no versioned resources: %w", assetType, fullName, ErrNotFound)
+	}
+	// Cloud Asset returns versioned resources in chronological order
+	// (oldest first per the API contract); the most recent version is
+	// the last element, which is the one we want for current-state
+	// drift comparison.
+	latest := versions[len(versions)-1]
+	data := latest.GetResource()
+	if data == nil {
+		return nil, fmt.Errorf("cloud asset getbyname %s %q: nil resource data: %w", assetType, fullName, ErrNotFound)
+	}
+	return data.AsMap(), nil
 }
 
 // wrapSearchAllError annotates a Cloud Asset SearchAllResources error


### PR DESCRIPTION
## Summary

Generic \`cloudAssetEnricher\` routes every TF type listed in \`cloudAssetTypeConfigs\` through a single Cloud Asset Inventory \`SearchAllResources\` call, unmarshaling the \`versionedResources\` payload directly into the typed Layer-1 \`generated.Google<Type>\` struct. Hand-rolled enrichers win as overrides at registration; the loop backfills 28 net new TF types.

This is the GCP equivalent of #490's AWS Cloud Control HYBRID enricher — steps 1 + 2 only.

## Coverage delta

- GCP enrichable: **7/54 (13%) → 35/54 (65%)**
- Hand-rolled overrides preserved: **7** (compute_address, compute_firewall, compute_network, pubsub_subscription, pubsub_topic, secret_manager_secret, storage_bucket)
- CAI HYBRID generic registrations: **28**

## PoC outcome (\`.tmp/cai-enricher-poc.md\`)

- **Type tested:** \`google_compute_instance\`
- **Match rate: 13/13 = 100%** of representative CAI fields land in a typed Layer-1 slot after round-trip.
- Test pin: \`TestCloudAssetEnricher_PoC_ComputeInstance_FieldMatchRate\` with a 70% floor.

GCP beats AWS's HYBRID baseline (57% on \`aws_cloudwatch_log_group\`) because neither of the two AWS systemic gotchas applies:

| AWS gotcha | GCP equivalent |
|---|---|
| CFN CamelCase ↔ TF snake_case primary-name (\`LogGroupName\` vs \`name\`) | None — CAI returns native GCP REST JSON which already uses lowerCamelCase keys matching the TF attribute names after a simple snake_case rename |
| CFN tag-list \`[{Key, Value}]\` ↔ TF \`map[string]string\` | None — GCP labels are \`map[string]string\` in both the API and TF |

## Known divergences out-of-scope

Tracked as the GCP equivalent of #501 (Normalizer hooks) — not in this PR:

- **Network tags.** CAI surfaces \`tags.items\`; TF flattens to a \`tags\` set.
- **Self-link URLs vs bare names.** CAI returns full URLs in \`machineType\`, \`network\`, \`zone\`; TF tolerates either.
- **Region/zone URL → short-name normalization.**
- **Computed-only field elision.** Already handled downstream by the decision-#5 schema, not a HYBRID concern.

## Deferred follow-ups

Two follow-up issues will be filed after this PR opens (mirroring #501/#502):

1. **CAI Normalizer hooks** — per-type pre-unmarshal transforms (network-tag flatten, self-link → bare-name, region URL → short name).
2. **Retire hand-rolled GCP enrichers** — once Normalizer hooks land, the 7 hand-rolled enrichers can flip to the unified CAI path. Same trajectory as #502 for AWS.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./cmd/insideout-import/gcpdiscover/... -count=1\` — 816 passed
- [x] \`go test ./... -count=1 -short\` — 5341 passed across 35 packages
- [x] \`make verify-supported-resources\` — re-generated \`SUPPORTED_RESOURCES.md\` reflects the 13% → 65% delta
- [x] New tests added:
  - \`TestCamelToSnakeGCP\`, \`TestShapeCAIForLayer1Recursive\` — wire-format pins
  - \`TestCloudAssetEnricher_Enrich_ComputeInstance\` — round-trip
  - \`TestCloudAssetEnricher_Enrich_NilCloudAsset_FromClients\`, \`TestCloudAssetEnricher_Enrich_NotFound\`, \`TestCloudAssetEnricher_Enrich_NoAssetName\`, \`TestCloudAssetEnricher_Enrich_NoProjectID\`, \`TestCloudAssetEnricher_Enrich_RealAPIError\` — error paths
  - \`TestCloudAssetEnricher_EnrichByID\`, \`TestCloudAssetEnricher_EnrichByID_NilIdentity\` — ByIDEnricher entry point
  - \`TestCloudAssetEnricher_ResourceType\`, \`TestCloudAssetEnricher_Enrich_UnknownTFType\`, \`TestCloudAssetEnricher_Enrich_RawAttrs_IsValidJSONWithSnakeKeys\` — accessor + wire-format guards
  - \`TestCloudAssetEnricher_PoC_ComputeInstance_FieldMatchRate\` — HYBRID PoC pinned at 70% floor
  - \`TestCloudAssetEnricherCoversEveryCAIRoutedType\`, \`TestCloudAssetEnricherSkipsHandRolledOverrides\` — registration invariants

Refs #482.