### PR TITLE
feat(gcpdiscover): Bundle G6 — 6 new GCP hand-rolled enrichers

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -23,7 +23,7 @@ and is checked in lockstep with the runtime registries. See the
 ## Summary
 
 - **AWS:** 109 types · 100% Discoverable · 86% Enrichable · 3% DriftDetectable · 0% MetricsAvailable · 6% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 56% Enrichable · 4% DriftDetectable · 0% MetricsAvailable · 65% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 67% Enrichable · 4% DriftDetectable · 0% MetricsAvailable · 65% AgentEditable
 
 ## AWS
 
@@ -170,15 +170,15 @@ and is checked in lockstep with the runtime registries. See the
 | `google_container_cluster` | ✓ | ✓ | – | – | ✓ |
 | `google_container_node_pool` | ✓ | ✓ | – | – | ✓ |
 | `google_firestore_database` | ✓ | ✓ | – | – | ✓ |
-| `google_identity_platform_config` | ✓ | – | – | – | ✓ |
+| `google_identity_platform_config` | ✓ | ✓ | – | – | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | – | – | – | – |
 | `google_kms_crypto_key` | ✓ | ✓ | – | – | ✓ |
 | `google_kms_crypto_key_iam_binding` | ✓ | – | – | – | – |
 | `google_kms_key_ring` | ✓ | ✓ | – | – | – |
-| `google_logging_project_sink` | ✓ | – | – | – | ✓ |
-| `google_monitoring_alert_policy` | ✓ | – | – | – | ✓ |
-| `google_monitoring_dashboard` | ✓ | – | – | – | ✓ |
-| `google_monitoring_notification_channel` | ✓ | – | – | – | ✓ |
+| `google_logging_project_sink` | ✓ | ✓ | – | – | ✓ |
+| `google_monitoring_alert_policy` | ✓ | ✓ | – | – | ✓ |
+| `google_monitoring_dashboard` | ✓ | ✓ | – | – | ✓ |
+| `google_monitoring_notification_channel` | ✓ | ✓ | – | – | ✓ |
 | `google_project_iam_member` | ✓ | – | – | – | – |
 | `google_project_service` | ✓ | – | – | – | – |
 | `google_pubsub_subscription` | ✓ | ✓ | – | – | ✓ |
@@ -191,7 +191,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_service_account` | ✓ | ✓ | – | – | ✓ |
 | `google_service_networking_connection` | ✓ | – | – | – | – |
 | `google_sql_database_instance` | ✓ | ✓ | – | – | ✓ |
-| `google_sql_user` | ✓ | – | – | – | ✓ |
+| `google_sql_user` | ✓ | ✓ | – | – | ✓ |
 | `google_storage_bucket` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_storage_bucket_iam_member` | ✓ | – | – | – | – |
 | `google_storage_bucket_object` | ✓ | – | – | – | – |

--- a/cmd/insideout-import/gcpdiscover/api_errors.go
+++ b/cmd/insideout-import/gcpdiscover/api_errors.go
@@ -1,0 +1,33 @@
+package gcpdiscover
+
+import (
+	"errors"
+	"net/http"
+
+	"google.golang.org/api/googleapi"
+)
+
+// isGoogleAPINotFound reports whether err is a *googleapi.Error with
+// HTTP 404. Shared by every gcpdiscover enricher that needs to translate
+// upstream 404s into the package-level ErrNotFound sentinel.
+//
+// Background: the hand-rolled enrichers in this package previously
+// declared a per-service helper each (isSQLAdminNotFound,
+// isMonitoringNotFound, isMonitoringDashboardNotFound,
+// isIdentityToolkitNotFound, isLoggingNotFound, ...). They all had
+// byte-identical bodies — `errors.As` against `*googleapi.Error` and a
+// `Code == 404` check — because every google.golang.org/api/<service>/v<n>
+// client surfaces 404s through the same googleapi.Error type.
+// Centralizing the check here eliminates the duplication for the six
+// G6-bundle enrichers (sql_user, logging_project_sink,
+// monitoring_alert_policy, monitoring_dashboard,
+// monitoring_notification_channel, identity_platform_config); the
+// pre-existing duplicates in older enricher files are left in place
+// (scope discipline — migrating them is a separate follow-up).
+func isGoogleAPINotFound(err error) bool {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return gerr.Code == http.StatusNotFound
+	}
+	return false
+}

--- a/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
+++ b/cmd/insideout-import/gcpdiscover/byid_enricher_test.go
@@ -63,9 +63,9 @@ func TestExistingEnrichersDoNotImplementByID(t *testing.T) {
 	// (cloudAssetTypeConfigs entries that aren't hand-rolled overrides).
 	// Recomputed at runtime from cloudAssetTypeConfigs so adding a new
 	// CAI config entry only requires changing cloudasset_types.go.
-	// Hand-rolled count is the literal 7 from gcpdiscover.go's
-	// byTypeEnricher initializer.
-	const handRolledCount = 7
+	// Hand-rolled count is the literal 13 from gcpdiscover.go's
+	// byTypeEnricher initializer (7 pre-G6 + 6 Bundle G6 entries).
+	const handRolledCount = 13
 	caiNonOverlap := 0
 	for _, cfg := range cloudAssetTypeConfigs {
 		if cfg.Skip {

--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -144,17 +144,22 @@ type ByIDEnricher interface {
 // override return ErrEnrichClientUnavailable when this is nil, which
 // the EnrichAttributes loop downgrades to a per-resource warning.
 type EnrichClients struct {
-	Storage             *storagev1.Service
-	Pubsub              *pubsubv1.Service
-	SecretManager       *secretmanagerv1.Service
-	Compute             *computev1.Service
-	SQLAdmin            *sqladminv1.Service
-	Logging             *loggingv2.Service
-	IdentityToolkit     *identitytoolkitv2.Service
-	Monitoring          *monitoringv3.Service
-	MonitoringDashboard *monitoringv1.Service
-	CloudAsset          gcpAssetGetter
-	ProjectID           string
+	Storage         *storagev1.Service
+	Pubsub          *pubsubv1.Service
+	SecretManager   *secretmanagerv1.Service
+	Compute         *computev1.Service
+	SQLAdmin        *sqladminv1.Service
+	Logging         *loggingv2.Service
+	IdentityToolkit *identitytoolkitv2.Service
+	Monitoring      *monitoringv3.Service
+	// MonitoringV1 is the Cloud Monitoring v1 SDK service. Used for
+	// dashboards (v1 schema); v3 (the Monitoring field above) covers
+	// AlertPolicies, NotificationChannels, etc. — the two SDK packages
+	// expose disjoint resource families and the dashboards-only client
+	// is kept as a separate field so the wiring is explicit.
+	MonitoringV1 *monitoringv1.Service
+	CloudAsset   gcpAssetGetter
+	ProjectID    string
 }
 
 // ErrEnrichClientUnavailable signals that the SDK client an enricher

--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -9,8 +9,13 @@ import (
 	"time"
 
 	computev1 "google.golang.org/api/compute/v1"
+	identitytoolkitv2 "google.golang.org/api/identitytoolkit/v2"
+	loggingv2 "google.golang.org/api/logging/v2"
+	monitoringv1 "google.golang.org/api/monitoring/v1"
+	monitoringv3 "google.golang.org/api/monitoring/v3"
 	pubsubv1 "google.golang.org/api/pubsub/v1"
 	secretmanagerv1 "google.golang.org/api/secretmanager/v1"
+	sqladminv1 "google.golang.org/api/sqladmin/v1"
 	storagev1 "google.golang.org/api/storage/v1"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
@@ -139,12 +144,17 @@ type ByIDEnricher interface {
 // override return ErrEnrichClientUnavailable when this is nil, which
 // the EnrichAttributes loop downgrades to a per-resource warning.
 type EnrichClients struct {
-	Storage       *storagev1.Service
-	Pubsub        *pubsubv1.Service
-	SecretManager *secretmanagerv1.Service
-	Compute       *computev1.Service
-	CloudAsset    gcpAssetGetter
-	ProjectID     string
+	Storage             *storagev1.Service
+	Pubsub              *pubsubv1.Service
+	SecretManager       *secretmanagerv1.Service
+	Compute             *computev1.Service
+	SQLAdmin            *sqladminv1.Service
+	Logging             *loggingv2.Service
+	IdentityToolkit     *identitytoolkitv2.Service
+	Monitoring          *monitoringv3.Service
+	MonitoringDashboard *monitoringv1.Service
+	CloudAsset          gcpAssetGetter
+	ProjectID           string
 }
 
 // ErrEnrichClientUnavailable signals that the SDK client an enricher

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -356,6 +356,13 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string, opts GCPDisco
 			"google_pubsub_topic":          newPubsubTopicEnricher(),
 			"google_secret_manager_secret": newSecretManagerSecretEnricher(),
 			"google_storage_bucket":        newStorageBucketEnricher(),
+			// Bundle G6 — 6 hand-rolled enrichers (issue #494).
+			"google_sql_user":                        newSQLUserEnricher(),
+			"google_logging_project_sink":            newLoggingProjectSinkEnricher(),
+			"google_identity_platform_config":        newIdentityPlatformConfigEnricher(),
+			"google_monitoring_alert_policy":         newMonitoringAlertPolicyEnricher(),
+			"google_monitoring_dashboard":            newMonitoringDashboardEnricher(),
+			"google_monitoring_notification_channel": newMonitoringNotificationChannelEnricher(),
 		},
 	}
 	// HYBRID Cloud Asset Inventory fallback (mirrors AWS #490 steps 1+2):

--- a/cmd/insideout-import/gcpdiscover/identity_platform_config_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/identity_platform_config_enrich.go
@@ -63,12 +63,21 @@ func (e identityPlatformConfigEnricher) EnrichByID(ctx context.Context, identity
 	return e.fetchTyped(ctx, identity, c)
 }
 
-func (e identityPlatformConfigEnricher) fetchTyped(ctx context.Context, _ *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+func (e identityPlatformConfigEnricher) fetchTyped(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
 	if c.IdentityToolkit == nil {
 		return nil, ErrEnrichClientUnavailable
 	}
 	if c.ProjectID == "" {
 		return nil, fmt.Errorf("identity_platform_config: EnrichClients.ProjectID required (singleton resource name is projects/<p>/config)")
+	}
+	// Identity Platform's Config is a project-scoped singleton: the
+	// provider's import shape is the project ID itself. When the caller
+	// supplies both an Identity.ImportID and a Clients.ProjectID they
+	// MUST agree — otherwise we'd silently fetch the wrong project's
+	// config and write it under this resource's identity. Surface the
+	// mismatch instead of guessing.
+	if id != nil && id.ImportID != "" && id.ImportID != c.ProjectID {
+		return nil, fmt.Errorf("identity_platform_config: project mismatch: Identity.ImportID=%q vs EnrichClients.ProjectID=%q", id.ImportID, c.ProjectID)
 	}
 	fullName := fmt.Sprintf("projects/%s/config", c.ProjectID)
 	cfg, err := e.fetch(ctx, c.IdentityToolkit, fullName)

--- a/cmd/insideout-import/gcpdiscover/identity_platform_config_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/identity_platform_config_enrich.go
@@ -3,11 +3,8 @@ package gcpdiscover
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 
-	"google.golang.org/api/googleapi"
 	identitytoolkitv2 "google.golang.org/api/identitytoolkit/v2"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -82,7 +79,7 @@ func (e identityPlatformConfigEnricher) fetchTyped(ctx context.Context, id *impo
 	fullName := fmt.Sprintf("projects/%s/config", c.ProjectID)
 	cfg, err := e.fetch(ctx, c.IdentityToolkit, fullName)
 	if err != nil {
-		if isIdentityToolkitNotFound(err) {
+		if isGoogleAPINotFound(err) {
 			return nil, fmt.Errorf("identity_platform_config: %s: %w", fullName, ErrNotFound)
 		}
 		return nil, fmt.Errorf("identity_platform_config: get %s: %w", fullName, err)
@@ -97,14 +94,6 @@ func (e identityPlatformConfigEnricher) fetchTyped(ctx context.Context, id *impo
 
 func defaultIdentityPlatformConfigFetch(ctx context.Context, svc *identitytoolkitv2.Service, name string) (*identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Config, error) {
 	return svc.Projects.GetConfig(name).Context(ctx).Do()
-}
-
-func isIdentityToolkitNotFound(err error) bool {
-	var gerr *googleapi.Error
-	if errors.As(err, &gerr) {
-		return gerr.Code == http.StatusNotFound
-	}
-	return false
 }
 
 // mapIdentityPlatformConfig converts the SDK Config struct into the

--- a/cmd/insideout-import/gcpdiscover/identity_platform_config_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/identity_platform_config_enrich.go
@@ -1,0 +1,187 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"google.golang.org/api/googleapi"
+	identitytoolkitv2 "google.golang.org/api/identitytoolkit/v2"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// identityPlatformConfigEnricher implements AttributeEnricher AND
+// ByIDEnricher for google_identity_platform_config. Pairs with
+// identityPlatformConfigDiscoverer.
+//
+// Identity Platform's Config is a project-scoped singleton named
+// `projects/<p>/config`. GetConfig takes that fully-qualified name. The
+// discoverer puts the ImportID = projectID (per provider import shape),
+// so the enricher reconstructs the full name from c.ProjectID at call
+// time.
+//
+// Mapping covers the field families exposed in the provider's resource
+// schema (sign_in, notification, monitoring, multi_tenant, blocking_functions,
+// authorized_domains, autodelete_anonymous_users). Some nested blocks
+// have a deeper structure than we map exhaustively (e.g. the SDK's
+// SignInConfig.HashConfig has six fields, the SDK's Notification has
+// many sub-templates) — those are left for a follow-up enrichgen pass
+// since the field count grows quickly. The mapper covers the
+// commonly-set top-level blocks; partial coverage > no coverage.
+type identityPlatformConfigEnricher struct {
+	fetch func(ctx context.Context, svc *identitytoolkitv2.Service, name string) (*identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Config, error)
+}
+
+func newIdentityPlatformConfigEnricher() AttributeEnricher {
+	return &identityPlatformConfigEnricher{fetch: defaultIdentityPlatformConfigFetch}
+}
+
+var (
+	_ AttributeEnricher = (*identityPlatformConfigEnricher)(nil)
+	_ ByIDEnricher      = (*identityPlatformConfigEnricher)(nil)
+)
+
+func (identityPlatformConfigEnricher) ResourceType() string { return identityPlatformConfigTFType }
+
+func (e identityPlatformConfigEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchTyped(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+func (e identityPlatformConfigEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("identity_platform_config: nil identity")
+	}
+	return e.fetchTyped(ctx, identity, c)
+}
+
+func (e identityPlatformConfigEnricher) fetchTyped(ctx context.Context, _ *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.IdentityToolkit == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if c.ProjectID == "" {
+		return nil, fmt.Errorf("identity_platform_config: EnrichClients.ProjectID required (singleton resource name is projects/<p>/config)")
+	}
+	fullName := fmt.Sprintf("projects/%s/config", c.ProjectID)
+	cfg, err := e.fetch(ctx, c.IdentityToolkit, fullName)
+	if err != nil {
+		if isIdentityToolkitNotFound(err) {
+			return nil, fmt.Errorf("identity_platform_config: %s: %w", fullName, ErrNotFound)
+		}
+		return nil, fmt.Errorf("identity_platform_config: get %s: %w", fullName, err)
+	}
+	typed := mapIdentityPlatformConfig(cfg, c.ProjectID)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("identity_platform_config: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+func defaultIdentityPlatformConfigFetch(ctx context.Context, svc *identitytoolkitv2.Service, name string) (*identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Config, error) {
+	return svc.Projects.GetConfig(name).Context(ctx).Do()
+}
+
+func isIdentityToolkitNotFound(err error) bool {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return gerr.Code == http.StatusNotFound
+	}
+	return false
+}
+
+// mapIdentityPlatformConfig converts the SDK Config struct into the
+// typed Layer-1 model. Coverage is deliberately partial — the deeper
+// SignIn / Notification / Mfa sub-structures have many fields that
+// rarely round-trip cleanly without a full enrichgen pass.
+func mapIdentityPlatformConfig(c *identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Config, projectID string) *generated.GoogleIdentityPlatformConfig {
+	out := &generated.GoogleIdentityPlatformConfig{}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if c == nil {
+		return out
+	}
+	if c.AutodeleteAnonymousUsers {
+		out.AutodeleteAnonymousUsers = generated.LiteralOf(true)
+	}
+	if len(c.AuthorizedDomains) > 0 {
+		domains := make([]*generated.Value[string], 0, len(c.AuthorizedDomains))
+		for _, d := range c.AuthorizedDomains {
+			domains = append(domains, generated.LiteralOf(d))
+		}
+		out.AuthorizedDomains = domains
+	}
+	if c.MultiTenant != nil {
+		mt := generated.GoogleIdentityPlatformConfigMultiTenant{}
+		populated := false
+		if c.MultiTenant.AllowTenants {
+			mt.AllowTenants = generated.LiteralOf(true)
+			populated = true
+		}
+		if c.MultiTenant.DefaultTenantLocation != "" {
+			mt.DefaultTenantLocation = generated.LiteralOf(c.MultiTenant.DefaultTenantLocation)
+			populated = true
+		}
+		if populated {
+			out.MultiTenant = []generated.GoogleIdentityPlatformConfigMultiTenant{mt}
+		}
+	}
+	if c.Monitoring != nil && c.Monitoring.RequestLogging != nil {
+		rl := generated.GoogleIdentityPlatformConfigMonitoringRequestLogging{}
+		if c.Monitoring.RequestLogging.Enabled {
+			rl.Enabled = generated.LiteralOf(true)
+		}
+		mon := generated.GoogleIdentityPlatformConfigMonitoring{
+			RequestLogging: []generated.GoogleIdentityPlatformConfigMonitoringRequestLogging{rl},
+		}
+		out.Monitoring = []generated.GoogleIdentityPlatformConfigMonitoring{mon}
+	}
+	if c.SignIn != nil {
+		si := generated.GoogleIdentityPlatformConfigSignIn{}
+		populated := false
+		if c.SignIn.AllowDuplicateEmails {
+			si.AllowDuplicateEmails = generated.LiteralOf(true)
+			populated = true
+		}
+		if c.SignIn.Anonymous != nil {
+			anon := generated.GoogleIdentityPlatformConfigSignInAnonymous{}
+			if c.SignIn.Anonymous.Enabled {
+				anon.Enabled = generated.LiteralOf(true)
+			}
+			si.Anonymous = []generated.GoogleIdentityPlatformConfigSignInAnonymous{anon}
+			populated = true
+		}
+		if c.SignIn.Email != nil {
+			email := generated.GoogleIdentityPlatformConfigSignInEmail{}
+			if c.SignIn.Email.Enabled {
+				email.Enabled = generated.LiteralOf(true)
+			}
+			if c.SignIn.Email.PasswordRequired {
+				email.PasswordRequired = generated.LiteralOf(true)
+			}
+			si.Email = []generated.GoogleIdentityPlatformConfigSignInEmail{email}
+			populated = true
+		}
+		if c.SignIn.PhoneNumber != nil {
+			phone := generated.GoogleIdentityPlatformConfigSignInPhoneNumber{}
+			if c.SignIn.PhoneNumber.Enabled {
+				phone.Enabled = generated.LiteralOf(true)
+			}
+			si.PhoneNumber = []generated.GoogleIdentityPlatformConfigSignInPhoneNumber{phone}
+			populated = true
+		}
+		if populated {
+			out.SignIn = []generated.GoogleIdentityPlatformConfigSignIn{si}
+		}
+	}
+	return out
+}

--- a/cmd/insideout-import/gcpdiscover/identity_platform_config_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/identity_platform_config_enrich_test.go
@@ -1,0 +1,153 @@
+package gcpdiscover
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	identitytoolkitv2 "google.golang.org/api/identitytoolkit/v2"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+func TestIdentityPlatformConfigEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "google_identity_platform_config", newIdentityPlatformConfigEnricher().ResourceType())
+}
+
+func TestIdentityPlatformConfigEnricher_NilClient_ReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newIdentityPlatformConfigEnricher()
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: identityPlatformConfigTFType, ImportID: "my-project"},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{IdentityToolkit: nil, ProjectID: "my-project"})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Empty(t, ir.Attrs)
+}
+
+func TestIdentityPlatformConfigEnricher_ProjectIDRequired(t *testing.T) {
+	t.Parallel()
+	e := &identityPlatformConfigEnricher{
+		fetch: func(_ context.Context, _ *identitytoolkitv2.Service, _ string) (*identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Config, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: identityPlatformConfigTFType},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{IdentityToolkit: &identitytoolkitv2.Service{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ProjectID required")
+}
+
+func TestIdentityPlatformConfigEnricher_NotFound_ReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	e := &identityPlatformConfigEnricher{
+		fetch: func(_ context.Context, _ *identitytoolkitv2.Service, _ string) (*identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Config, error) {
+			return nil, &googleapi.Error{Code: http.StatusNotFound, Message: "not found"}
+		},
+	}
+	id := &imported.ResourceIdentity{Type: identityPlatformConfigTFType, ImportID: "my-project"}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{IdentityToolkit: &identitytoolkitv2.Service{}, ProjectID: "my-project"})
+	require.ErrorIs(t, err, ErrNotFound)
+	assert.Nil(t, raw)
+}
+
+func TestIdentityPlatformConfigEnricher_HappyPath(t *testing.T) {
+	t.Parallel()
+	cfg := &identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Config{
+		AuthorizedDomains:        []string{"example.com", "myapp.dev"},
+		AutodeleteAnonymousUsers: true,
+		MultiTenant: &identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2MultiTenantConfig{
+			AllowTenants:          true,
+			DefaultTenantLocation: "organizations/123",
+		},
+		Monitoring: &identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2MonitoringConfig{
+			RequestLogging: &identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2RequestLogging{Enabled: true},
+		},
+		SignIn: &identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2SignInConfig{
+			AllowDuplicateEmails: true,
+			Anonymous:            &identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Anonymous{Enabled: true},
+			Email: &identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Email{
+				Enabled: true, PasswordRequired: true,
+			},
+			PhoneNumber: &identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2PhoneNumber{Enabled: true},
+		},
+	}
+	var gotName string
+	e := &identityPlatformConfigEnricher{
+		fetch: func(_ context.Context, _ *identitytoolkitv2.Service, name string) (*identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Config, error) {
+			gotName = name
+			return cfg, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: identityPlatformConfigTFType, ImportID: "my-project"},
+	}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{IdentityToolkit: &identitytoolkitv2.Service{}, ProjectID: "my-project"}))
+	assert.Equal(t, "projects/my-project/config", gotName)
+
+	decoded, err := generated.UnmarshalAttrs("google_identity_platform_config", ir.Attrs)
+	require.NoError(t, err)
+	ic, ok := decoded.(*generated.GoogleIdentityPlatformConfig)
+	require.True(t, ok)
+	require.NotNil(t, ic.AutodeleteAnonymousUsers)
+	assert.True(t, *ic.AutodeleteAnonymousUsers.Literal)
+	require.Len(t, ic.AuthorizedDomains, 2)
+	require.Len(t, ic.MultiTenant, 1)
+	require.NotNil(t, ic.MultiTenant[0].AllowTenants)
+	assert.True(t, *ic.MultiTenant[0].AllowTenants.Literal)
+	require.Len(t, ic.Monitoring, 1)
+	require.Len(t, ic.Monitoring[0].RequestLogging, 1)
+	require.NotNil(t, ic.Monitoring[0].RequestLogging[0].Enabled)
+	assert.True(t, *ic.Monitoring[0].RequestLogging[0].Enabled.Literal)
+	require.Len(t, ic.SignIn, 1)
+	require.NotNil(t, ic.SignIn[0].AllowDuplicateEmails)
+	require.Len(t, ic.SignIn[0].Anonymous, 1)
+	require.Len(t, ic.SignIn[0].Email, 1)
+	require.NotNil(t, ic.SignIn[0].Email[0].PasswordRequired)
+}
+
+func TestIdentityPlatformConfigEnricher_EnrichByID_MirrorsEnrich(t *testing.T) {
+	t.Parallel()
+	cfg := &identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Config{
+		AutodeleteAnonymousUsers: true,
+	}
+	mkFetch := func() func(context.Context, *identitytoolkitv2.Service, string) (*identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Config, error) {
+		return func(_ context.Context, _ *identitytoolkitv2.Service, _ string) (*identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Config, error) {
+			return cfg, nil
+		}
+	}
+	enrichE := &identityPlatformConfigEnricher{fetch: mkFetch()}
+	byIDE := &identityPlatformConfigEnricher{fetch: mkFetch()}
+
+	id := imported.ResourceIdentity{Type: identityPlatformConfigTFType, ImportID: "p"}
+	ir := &imported.ImportedResource{Identity: id}
+	require.NoError(t, enrichE.Enrich(context.Background(), ir, EnrichClients{IdentityToolkit: &identitytoolkitv2.Service{}, ProjectID: "p"}))
+
+	raw, err := byIDE.EnrichByID(context.Background(), &id, EnrichClients{IdentityToolkit: &identitytoolkitv2.Service{}, ProjectID: "p"})
+	require.NoError(t, err)
+	assert.JSONEq(t, string(ir.Attrs), string(raw))
+}
+
+func TestIdentityPlatformConfigEnricher_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newIdentityPlatformConfigEnricher().(*identityPlatformConfigEnricher)
+	_, err := e.EnrichByID(context.Background(), nil, EnrichClients{IdentityToolkit: &identitytoolkitv2.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil identity")
+}
+
+func TestMapIdentityPlatformConfig_NilSafe(t *testing.T) {
+	t.Parallel()
+	got := mapIdentityPlatformConfig(nil, "p")
+	require.NotNil(t, got)
+	require.NotNil(t, got.Project)
+	assert.Equal(t, "p", *got.Project.Literal)
+}

--- a/cmd/insideout-import/gcpdiscover/identity_platform_config_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/identity_platform_config_enrich_test.go
@@ -144,6 +144,26 @@ func TestIdentityPlatformConfigEnricher_NilIdentity(t *testing.T) {
 	assert.Contains(t, err.Error(), "nil identity")
 }
 
+func TestIdentityPlatformConfigEnricher_ProjectMismatch_Surfaces(t *testing.T) {
+	t.Parallel()
+	// Identity.ImportID is the provider's import shape for this
+	// singleton — it must equal Clients.ProjectID. If they disagree we
+	// surface the mismatch instead of silently fetching the wrong
+	// project's config under this Identity.
+	e := &identityPlatformConfigEnricher{
+		fetch: func(_ context.Context, _ *identitytoolkitv2.Service, _ string) (*identitytoolkitv2.GoogleCloudIdentitytoolkitAdminV2Config, error) {
+			t.Fatal("fetch must not be called on a project mismatch")
+			return nil, nil
+		},
+	}
+	id := &imported.ResourceIdentity{Type: identityPlatformConfigTFType, ImportID: "wrong-project"}
+	_, err := e.EnrichByID(context.Background(), id, EnrichClients{IdentityToolkit: &identitytoolkitv2.Service{}, ProjectID: "right-project"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project mismatch")
+	assert.Contains(t, err.Error(), "wrong-project")
+	assert.Contains(t, err.Error(), "right-project")
+}
+
 func TestMapIdentityPlatformConfig_NilSafe(t *testing.T) {
 	t.Parallel()
 	got := mapIdentityPlatformConfig(nil, "p")

--- a/cmd/insideout-import/gcpdiscover/logging_project_sink_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/logging_project_sink_enrich.go
@@ -1,0 +1,170 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"google.golang.org/api/googleapi"
+	loggingv2 "google.golang.org/api/logging/v2"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// loggingProjectSinkEnricher implements AttributeEnricher AND
+// ByIDEnricher for google_logging_project_sink. Pairs with
+// loggingProjectSinkDiscoverer.
+//
+// Sinks.Get takes a single fully-qualified resource name of the form
+// `projects/<p>/sinks/<n>`. The discoverer stores only the short sink
+// name in NameHint / ImportID (the provider import shape), so the
+// enricher constructs the full name from c.ProjectID + name at call
+// time.
+//
+// Mapping rationale: writer_identity is computed-only in the TF schema
+// but is structurally a real identity the user needs to grant IAM
+// roles to, so it is populated for visibility. unique_writer_identity
+// is not a returned API field — the provider uses it as an input
+// signal only — so it is left nil on Get.
+//
+// Computed-only fields skipped per decision #5: id, project.
+type loggingProjectSinkEnricher struct {
+	fetch func(ctx context.Context, svc *loggingv2.Service, sinkName string) (*loggingv2.LogSink, error)
+}
+
+func newLoggingProjectSinkEnricher() AttributeEnricher {
+	return &loggingProjectSinkEnricher{fetch: defaultLoggingProjectSinkFetch}
+}
+
+var (
+	_ AttributeEnricher = (*loggingProjectSinkEnricher)(nil)
+	_ ByIDEnricher      = (*loggingProjectSinkEnricher)(nil)
+)
+
+func (loggingProjectSinkEnricher) ResourceType() string { return loggingProjectSinkTFType }
+
+func (e loggingProjectSinkEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchTyped(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+func (e loggingProjectSinkEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("logging_project_sink: nil identity")
+	}
+	return e.fetchTyped(ctx, identity, c)
+}
+
+func (e loggingProjectSinkEnricher) fetchTyped(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.Logging == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if c.ProjectID == "" {
+		return nil, fmt.Errorf("logging_project_sink: EnrichClients.ProjectID required to construct sinkName")
+	}
+	name := loggingProjectSinkNameForEnrich(id)
+	if name == "" {
+		return nil, fmt.Errorf("logging_project_sink: cannot derive sink name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			id.Address, id.ImportID, id.NameHint)
+	}
+	fullName := fmt.Sprintf("projects/%s/sinks/%s", c.ProjectID, name)
+	s, err := e.fetch(ctx, c.Logging, fullName)
+	if err != nil {
+		if isLoggingNotFound(err) {
+			return nil, fmt.Errorf("logging_project_sink: %s: %w", fullName, ErrNotFound)
+		}
+		return nil, fmt.Errorf("logging_project_sink: get %s: %w", fullName, err)
+	}
+	typed := mapLoggingProjectSink(s)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("logging_project_sink: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// loggingProjectSinkNameForEnrich pulls the short sink name from the
+// Identity. Precedence: NameHint, ImportID (which is the sink short
+// name for this resource per provider docs).
+func loggingProjectSinkNameForEnrich(id *imported.ResourceIdentity) string {
+	if id.NameHint != "" {
+		return id.NameHint
+	}
+	return id.ImportID
+}
+
+func defaultLoggingProjectSinkFetch(ctx context.Context, svc *loggingv2.Service, sinkName string) (*loggingv2.LogSink, error) {
+	return svc.Sinks.Get(sinkName).Context(ctx).Do()
+}
+
+func isLoggingNotFound(err error) bool {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return gerr.Code == http.StatusNotFound
+	}
+	return false
+}
+
+// mapLoggingProjectSink converts a *loggingv2.LogSink into the typed
+// Layer-1 *generated.GoogleLoggingProjectSink model.
+func mapLoggingProjectSink(s *loggingv2.LogSink) *generated.GoogleLoggingProjectSink {
+	out := &generated.GoogleLoggingProjectSink{}
+	if s.Name != "" {
+		out.Name = generated.LiteralOf(s.Name)
+	}
+	if s.Destination != "" {
+		out.Destination = generated.LiteralOf(s.Destination)
+	}
+	if s.Filter != "" {
+		out.Filter = generated.LiteralOf(s.Filter)
+	}
+	if s.Description != "" {
+		out.Description = generated.LiteralOf(s.Description)
+	}
+	if s.Disabled {
+		out.Disabled = generated.LiteralOf(true)
+	}
+	if s.WriterIdentity != "" {
+		out.WriterIdentity = generated.LiteralOf(s.WriterIdentity)
+	}
+	if s.BigqueryOptions != nil {
+		opts := generated.GoogleLoggingProjectSinkBigqueryOptions{}
+		if s.BigqueryOptions.UsePartitionedTables {
+			opts.UsePartitionedTables = generated.LiteralOf(true)
+		}
+		out.BigqueryOptions = []generated.GoogleLoggingProjectSinkBigqueryOptions{opts}
+	}
+	if len(s.Exclusions) > 0 {
+		exclusions := make([]generated.GoogleLoggingProjectSinkExclusions, 0, len(s.Exclusions))
+		for _, x := range s.Exclusions {
+			if x == nil {
+				continue
+			}
+			ex := generated.GoogleLoggingProjectSinkExclusions{}
+			if x.Name != "" {
+				ex.Name = generated.LiteralOf(x.Name)
+			}
+			if x.Filter != "" {
+				ex.Filter = generated.LiteralOf(x.Filter)
+			}
+			if x.Description != "" {
+				ex.Description = generated.LiteralOf(x.Description)
+			}
+			if x.Disabled {
+				ex.Disabled = generated.LiteralOf(true)
+			}
+			exclusions = append(exclusions, ex)
+		}
+		if len(exclusions) > 0 {
+			out.Exclusions = exclusions
+		}
+	}
+	return out
+}

--- a/cmd/insideout-import/gcpdiscover/logging_project_sink_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/logging_project_sink_enrich.go
@@ -3,11 +3,8 @@ package gcpdiscover
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 
-	"google.golang.org/api/googleapi"
 	loggingv2 "google.golang.org/api/logging/v2"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -77,7 +74,7 @@ func (e loggingProjectSinkEnricher) fetchTyped(ctx context.Context, id *imported
 	fullName := fmt.Sprintf("projects/%s/sinks/%s", c.ProjectID, name)
 	s, err := e.fetch(ctx, c.Logging, fullName)
 	if err != nil {
-		if isLoggingNotFound(err) {
+		if isGoogleAPINotFound(err) {
 			return nil, fmt.Errorf("logging_project_sink: %s: %w", fullName, ErrNotFound)
 		}
 		return nil, fmt.Errorf("logging_project_sink: get %s: %w", fullName, err)
@@ -102,14 +99,6 @@ func loggingProjectSinkNameForEnrich(id *imported.ResourceIdentity) string {
 
 func defaultLoggingProjectSinkFetch(ctx context.Context, svc *loggingv2.Service, sinkName string) (*loggingv2.LogSink, error) {
 	return svc.Sinks.Get(sinkName).Context(ctx).Do()
-}
-
-func isLoggingNotFound(err error) bool {
-	var gerr *googleapi.Error
-	if errors.As(err, &gerr) {
-		return gerr.Code == http.StatusNotFound
-	}
-	return false
 }
 
 // mapLoggingProjectSink converts a *loggingv2.LogSink into the typed

--- a/cmd/insideout-import/gcpdiscover/logging_project_sink_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/logging_project_sink_enrich_test.go
@@ -1,0 +1,153 @@
+package gcpdiscover
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	loggingv2 "google.golang.org/api/logging/v2"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+func TestLoggingProjectSinkEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "google_logging_project_sink", newLoggingProjectSinkEnricher().ResourceType())
+}
+
+func TestLoggingProjectSinkEnricher_NilClient_ReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newLoggingProjectSinkEnricher()
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: loggingProjectSinkTFType, NameHint: "errors-sink"},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Logging: nil, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Empty(t, ir.Attrs)
+}
+
+func TestLoggingProjectSinkEnricher_ProjectIDRequired(t *testing.T) {
+	t.Parallel()
+	e := &loggingProjectSinkEnricher{
+		fetch: func(_ context.Context, _ *loggingv2.Service, _ string) (*loggingv2.LogSink, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: loggingProjectSinkTFType, NameHint: "errors-sink"},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Logging: &loggingv2.Service{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ProjectID required")
+}
+
+func TestLoggingProjectSinkEnricher_NotFound_ReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	e := &loggingProjectSinkEnricher{
+		fetch: func(_ context.Context, _ *loggingv2.Service, _ string) (*loggingv2.LogSink, error) {
+			return nil, &googleapi.Error{Code: http.StatusNotFound, Message: "not found"}
+		},
+	}
+	id := &imported.ResourceIdentity{Type: loggingProjectSinkTFType, NameHint: "errors-sink"}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{Logging: &loggingv2.Service{}, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrNotFound)
+	assert.Nil(t, raw)
+}
+
+func TestLoggingProjectSinkEnricher_HappyPath(t *testing.T) {
+	t.Parallel()
+	sink := &loggingv2.LogSink{
+		Name:           "errors-sink",
+		Destination:    "storage.googleapis.com/my-bucket",
+		Filter:         "severity>=ERROR",
+		Description:    "All errors to GCS",
+		Disabled:       false,
+		WriterIdentity: "serviceAccount:p-12345@gcp-sa-logging.iam.gserviceaccount.com",
+		Exclusions: []*loggingv2.LogExclusion{
+			{Name: "no-debug", Filter: "severity=DEBUG", Disabled: true, Description: "drop debugs"},
+		},
+		BigqueryOptions: &loggingv2.BigQueryOptions{UsePartitionedTables: true},
+	}
+	var gotFullName string
+	e := &loggingProjectSinkEnricher{
+		fetch: func(_ context.Context, _ *loggingv2.Service, n string) (*loggingv2.LogSink, error) {
+			gotFullName = n
+			return sink, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: loggingProjectSinkTFType, NameHint: "errors-sink"},
+	}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{Logging: &loggingv2.Service{}, ProjectID: "my-project"}))
+	assert.Equal(t, "projects/my-project/sinks/errors-sink", gotFullName)
+
+	decoded, err := generated.UnmarshalAttrs("google_logging_project_sink", ir.Attrs)
+	require.NoError(t, err)
+	ls, ok := decoded.(*generated.GoogleLoggingProjectSink)
+	require.True(t, ok)
+	require.NotNil(t, ls.Name)
+	assert.Equal(t, "errors-sink", *ls.Name.Literal)
+	require.NotNil(t, ls.Destination)
+	assert.Contains(t, *ls.Destination.Literal, "storage.googleapis.com/my-bucket")
+	require.NotNil(t, ls.Filter)
+	assert.Equal(t, "severity>=ERROR", *ls.Filter.Literal)
+	require.NotNil(t, ls.WriterIdentity)
+	assert.Contains(t, *ls.WriterIdentity.Literal, "gserviceaccount")
+	require.Len(t, ls.Exclusions, 1)
+	require.NotNil(t, ls.Exclusions[0].Disabled)
+	assert.True(t, *ls.Exclusions[0].Disabled.Literal)
+	require.Len(t, ls.BigqueryOptions, 1)
+	require.NotNil(t, ls.BigqueryOptions[0].UsePartitionedTables)
+	assert.True(t, *ls.BigqueryOptions[0].UsePartitionedTables.Literal)
+}
+
+func TestLoggingProjectSinkEnricher_EnrichByID_MirrorsEnrich(t *testing.T) {
+	t.Parallel()
+	sink := &loggingv2.LogSink{Name: "errors-sink", Destination: "gs", Filter: "x"}
+	mkFetch := func() func(context.Context, *loggingv2.Service, string) (*loggingv2.LogSink, error) {
+		return func(_ context.Context, _ *loggingv2.Service, _ string) (*loggingv2.LogSink, error) {
+			return sink, nil
+		}
+	}
+	enrichE := &loggingProjectSinkEnricher{fetch: mkFetch()}
+	byIDE := &loggingProjectSinkEnricher{fetch: mkFetch()}
+
+	id := imported.ResourceIdentity{Type: loggingProjectSinkTFType, NameHint: "errors-sink"}
+	ir := &imported.ImportedResource{Identity: id}
+	require.NoError(t, enrichE.Enrich(context.Background(), ir, EnrichClients{Logging: &loggingv2.Service{}, ProjectID: "p"}))
+
+	raw, err := byIDE.EnrichByID(context.Background(), &id, EnrichClients{Logging: &loggingv2.Service{}, ProjectID: "p"})
+	require.NoError(t, err)
+	assert.JSONEq(t, string(ir.Attrs), string(raw))
+}
+
+func TestLoggingProjectSinkEnricher_NonNotFoundErrorPassesThrough(t *testing.T) {
+	t.Parallel()
+	upstream := &googleapi.Error{Code: http.StatusForbidden, Message: "denied"}
+	e := &loggingProjectSinkEnricher{
+		fetch: func(_ context.Context, _ *loggingv2.Service, _ string) (*loggingv2.LogSink, error) {
+			return nil, upstream
+		},
+	}
+	id := &imported.ResourceIdentity{Type: loggingProjectSinkTFType, NameHint: "n"}
+	_, err := e.EnrichByID(context.Background(), id, EnrichClients{Logging: &loggingv2.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound)
+	var gerr *googleapi.Error
+	require.True(t, errors.As(err, &gerr))
+	assert.Equal(t, http.StatusForbidden, gerr.Code)
+}
+
+func TestLoggingProjectSinkEnricher_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newLoggingProjectSinkEnricher().(*loggingProjectSinkEnricher)
+	_, err := e.EnrichByID(context.Background(), nil, EnrichClients{Logging: &loggingv2.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil identity")
+}

--- a/cmd/insideout-import/gcpdiscover/monitoring_alert_policy_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/monitoring_alert_policy_enrich.go
@@ -1,0 +1,238 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"google.golang.org/api/googleapi"
+	monitoringv3 "google.golang.org/api/monitoring/v3"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// monitoringAlertPolicyEnricher implements AttributeEnricher AND
+// ByIDEnricher for google_monitoring_alert_policy. Pairs with
+// monitoringAlertPolicyDiscoverer.
+//
+// AlertPolicies.Get takes a single fully-qualified name of the form
+// `projects/<p>/alertPolicies/<id>`. The discoverer puts that exact
+// string in ImportID and the short id in NameHint, so the enricher
+// uses ImportID directly (falling back to constructing it).
+//
+// Mapping covers the top-level attributes (display_name, combiner,
+// enabled, notification_channels, user_labels, severity) and the
+// commonly-used nested blocks (documentation, alert_strategy). The
+// deeply-nested conditions block is mapped at the display-name level
+// only — the full condition tree (threshold, absent, prometheus_query)
+// has many sub-fields whose hand-roll cost is high relative to the
+// value-add vs. a follow-up enrichgen pass. Partial coverage > none.
+//
+// Computed-only fields skipped per decision #5: id, name, creation_record.
+type monitoringAlertPolicyEnricher struct {
+	fetch func(ctx context.Context, svc *monitoringv3.Service, name string) (*monitoringv3.AlertPolicy, error)
+}
+
+func newMonitoringAlertPolicyEnricher() AttributeEnricher {
+	return &monitoringAlertPolicyEnricher{fetch: defaultMonitoringAlertPolicyFetch}
+}
+
+var (
+	_ AttributeEnricher = (*monitoringAlertPolicyEnricher)(nil)
+	_ ByIDEnricher      = (*monitoringAlertPolicyEnricher)(nil)
+)
+
+func (monitoringAlertPolicyEnricher) ResourceType() string {
+	return monitoringAlertPolicyTFType
+}
+
+func (e monitoringAlertPolicyEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchTyped(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+func (e monitoringAlertPolicyEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("monitoring_alert_policy: nil identity")
+	}
+	return e.fetchTyped(ctx, identity, c)
+}
+
+func (e monitoringAlertPolicyEnricher) fetchTyped(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.Monitoring == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	fullName := monitoringAlertPolicyNameForEnrich(id, c.ProjectID)
+	if fullName == "" {
+		return nil, fmt.Errorf("monitoring_alert_policy: cannot derive resource name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			id.Address, id.ImportID, id.NameHint)
+	}
+	p, err := e.fetch(ctx, c.Monitoring, fullName)
+	if err != nil {
+		if isMonitoringNotFound(err) {
+			return nil, fmt.Errorf("monitoring_alert_policy: %s: %w", fullName, ErrNotFound)
+		}
+		return nil, fmt.Errorf("monitoring_alert_policy: get %s: %w", fullName, err)
+	}
+	typed := mapMonitoringAlertPolicy(p, c.ProjectID)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("monitoring_alert_policy: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// monitoringAlertPolicyNameForEnrich returns the fully-qualified
+// `projects/<p>/alertPolicies/<id>` resource name from the Identity.
+// Precedence: ImportID (canonical), then NameHint + projectID.
+func monitoringAlertPolicyNameForEnrich(id *imported.ResourceIdentity, projectID string) string {
+	if id.ImportID != "" {
+		return id.ImportID
+	}
+	if id.NameHint != "" && projectID != "" {
+		return fmt.Sprintf("projects/%s/alertPolicies/%s", projectID, id.NameHint)
+	}
+	return ""
+}
+
+func defaultMonitoringAlertPolicyFetch(ctx context.Context, svc *monitoringv3.Service, name string) (*monitoringv3.AlertPolicy, error) {
+	return svc.Projects.AlertPolicies.Get(name).Context(ctx).Do()
+}
+
+func isMonitoringNotFound(err error) bool {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return gerr.Code == http.StatusNotFound
+	}
+	return false
+}
+
+func mapMonitoringAlertPolicy(p *monitoringv3.AlertPolicy, projectID string) *generated.GoogleMonitoringAlertPolicy {
+	out := &generated.GoogleMonitoringAlertPolicy{}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if p == nil {
+		return out
+	}
+	if p.DisplayName != "" {
+		out.DisplayName = generated.LiteralOf(p.DisplayName)
+	}
+	if p.Combiner != "" {
+		out.Combiner = generated.LiteralOf(p.Combiner)
+	}
+	if p.Enabled {
+		out.Enabled = generated.LiteralOf(true)
+	}
+	if p.Severity != "" {
+		out.Severity = generated.LiteralOf(p.Severity)
+	}
+	if len(p.NotificationChannels) > 0 {
+		chs := make([]*generated.Value[string], 0, len(p.NotificationChannels))
+		for _, c := range p.NotificationChannels {
+			chs = append(chs, generated.LiteralOf(c))
+		}
+		out.NotificationChannels = chs
+	}
+	if len(p.UserLabels) > 0 {
+		labels := map[string]*generated.Value[string]{}
+		for k, v := range p.UserLabels {
+			if strings.HasPrefix(k, "goog-") || strings.HasPrefix(k, "goog_") {
+				continue
+			}
+			labels[k] = generated.LiteralOf(v)
+		}
+		if len(labels) > 0 {
+			out.UserLabels = labels
+		}
+	}
+	if p.Documentation != nil {
+		doc := generated.GoogleMonitoringAlertPolicyDocumentation{}
+		populated := false
+		if p.Documentation.Content != "" {
+			doc.Content = generated.LiteralOf(p.Documentation.Content)
+			populated = true
+		}
+		if p.Documentation.MimeType != "" {
+			doc.MimeType = generated.LiteralOf(p.Documentation.MimeType)
+			populated = true
+		}
+		if p.Documentation.Subject != "" {
+			doc.Subject = generated.LiteralOf(p.Documentation.Subject)
+			populated = true
+		}
+		if len(p.Documentation.Links) > 0 {
+			links := make([]generated.GoogleMonitoringAlertPolicyDocumentationLinks, 0, len(p.Documentation.Links))
+			for _, l := range p.Documentation.Links {
+				if l == nil {
+					continue
+				}
+				link := generated.GoogleMonitoringAlertPolicyDocumentationLinks{}
+				if l.DisplayName != "" {
+					link.DisplayName = generated.LiteralOf(l.DisplayName)
+				}
+				if l.Url != "" {
+					link.URL = generated.LiteralOf(l.Url)
+				}
+				links = append(links, link)
+			}
+			if len(links) > 0 {
+				doc.Links = links
+			}
+			populated = true
+		}
+		if populated {
+			out.Documentation = []generated.GoogleMonitoringAlertPolicyDocumentation{doc}
+		}
+	}
+	if p.AlertStrategy != nil {
+		strat := generated.GoogleMonitoringAlertPolicyAlertStrategy{}
+		populated := false
+		if p.AlertStrategy.AutoClose != "" {
+			strat.AutoClose = generated.LiteralOf(p.AlertStrategy.AutoClose)
+			populated = true
+		}
+		if len(p.AlertStrategy.NotificationPrompts) > 0 {
+			prompts := make([]*generated.Value[string], 0, len(p.AlertStrategy.NotificationPrompts))
+			for _, np := range p.AlertStrategy.NotificationPrompts {
+				prompts = append(prompts, generated.LiteralOf(np))
+			}
+			strat.NotificationPrompts = prompts
+			populated = true
+		}
+		if p.AlertStrategy.NotificationRateLimit != nil && p.AlertStrategy.NotificationRateLimit.Period != "" {
+			strat.NotificationRateLimit = []generated.GoogleMonitoringAlertPolicyAlertStrategyNotificationRateLimit{
+				{Period: generated.LiteralOf(p.AlertStrategy.NotificationRateLimit.Period)},
+			}
+			populated = true
+		}
+		if populated {
+			out.AlertStrategy = []generated.GoogleMonitoringAlertPolicyAlertStrategy{strat}
+		}
+	}
+	if len(p.Conditions) > 0 {
+		conds := make([]generated.GoogleMonitoringAlertPolicyConditions, 0, len(p.Conditions))
+		for _, c := range p.Conditions {
+			if c == nil {
+				continue
+			}
+			cond := generated.GoogleMonitoringAlertPolicyConditions{}
+			if c.DisplayName != "" {
+				cond.DisplayName = generated.LiteralOf(c.DisplayName)
+			}
+			conds = append(conds, cond)
+		}
+		if len(conds) > 0 {
+			out.Conditions = conds
+		}
+	}
+	return out
+}

--- a/cmd/insideout-import/gcpdiscover/monitoring_alert_policy_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/monitoring_alert_policy_enrich.go
@@ -3,12 +3,9 @@ package gcpdiscover
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 
-	"google.golang.org/api/googleapi"
 	monitoringv3 "google.golang.org/api/monitoring/v3"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -77,7 +74,7 @@ func (e monitoringAlertPolicyEnricher) fetchTyped(ctx context.Context, id *impor
 	}
 	p, err := e.fetch(ctx, c.Monitoring, fullName)
 	if err != nil {
-		if isMonitoringNotFound(err) {
+		if isGoogleAPINotFound(err) {
 			return nil, fmt.Errorf("monitoring_alert_policy: %s: %w", fullName, ErrNotFound)
 		}
 		return nil, fmt.Errorf("monitoring_alert_policy: get %s: %w", fullName, err)
@@ -105,14 +102,6 @@ func monitoringAlertPolicyNameForEnrich(id *imported.ResourceIdentity, projectID
 
 func defaultMonitoringAlertPolicyFetch(ctx context.Context, svc *monitoringv3.Service, name string) (*monitoringv3.AlertPolicy, error) {
 	return svc.Projects.AlertPolicies.Get(name).Context(ctx).Do()
-}
-
-func isMonitoringNotFound(err error) bool {
-	var gerr *googleapi.Error
-	if errors.As(err, &gerr) {
-		return gerr.Code == http.StatusNotFound
-	}
-	return false
 }
 
 func mapMonitoringAlertPolicy(p *monitoringv3.AlertPolicy, projectID string) *generated.GoogleMonitoringAlertPolicy {

--- a/cmd/insideout-import/gcpdiscover/monitoring_alert_policy_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/monitoring_alert_policy_enrich_test.go
@@ -1,0 +1,190 @@
+package gcpdiscover
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	monitoringv3 "google.golang.org/api/monitoring/v3"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+func TestMonitoringAlertPolicyEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "google_monitoring_alert_policy", newMonitoringAlertPolicyEnricher().ResourceType())
+}
+
+func TestMonitoringAlertPolicyEnricher_NilClient_ReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newMonitoringAlertPolicyEnricher()
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type: monitoringAlertPolicyTFType, ImportID: "projects/p/alertPolicies/1",
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Monitoring: nil, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Empty(t, ir.Attrs)
+}
+
+func TestMonitoringAlertPolicyEnricher_NotFound_ReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	e := &monitoringAlertPolicyEnricher{
+		fetch: func(_ context.Context, _ *monitoringv3.Service, _ string) (*monitoringv3.AlertPolicy, error) {
+			return nil, &googleapi.Error{Code: http.StatusNotFound, Message: "not found"}
+		},
+	}
+	id := &imported.ResourceIdentity{Type: monitoringAlertPolicyTFType, ImportID: "projects/p/alertPolicies/1"}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{Monitoring: &monitoringv3.Service{}, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrNotFound)
+	assert.Nil(t, raw)
+}
+
+func TestMonitoringAlertPolicyEnricher_HappyPath(t *testing.T) {
+	t.Parallel()
+	policy := &monitoringv3.AlertPolicy{
+		DisplayName:          "CPU > 90%",
+		Combiner:             "OR",
+		Enabled:              true,
+		Severity:             "WARNING",
+		NotificationChannels: []string{"projects/p/notificationChannels/123"},
+		UserLabels:           map[string]string{"team": "platform", "goog-managed": "true"},
+		Documentation: &monitoringv3.Documentation{
+			Content:  "Look at CPU dashboard",
+			MimeType: "text/markdown",
+			Subject:  "[ALERT] CPU",
+			Links: []*monitoringv3.Link{
+				{DisplayName: "Runbook", Url: "https://example.com/runbook"},
+			},
+		},
+		AlertStrategy: &monitoringv3.AlertStrategy{
+			AutoClose:             "1800s",
+			NotificationPrompts:   []string{"OPENED"},
+			NotificationRateLimit: &monitoringv3.NotificationRateLimit{Period: "300s"},
+		},
+		Conditions: []*monitoringv3.Condition{
+			{DisplayName: "VM Instance - CPU utilization > 0.9"},
+		},
+	}
+	var gotName string
+	e := &monitoringAlertPolicyEnricher{
+		fetch: func(_ context.Context, _ *monitoringv3.Service, n string) (*monitoringv3.AlertPolicy, error) {
+			gotName = n
+			return policy, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type: monitoringAlertPolicyTFType, ImportID: "projects/my-project/alertPolicies/123",
+		},
+	}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{Monitoring: &monitoringv3.Service{}, ProjectID: "my-project"}))
+	assert.Equal(t, "projects/my-project/alertPolicies/123", gotName)
+
+	decoded, err := generated.UnmarshalAttrs("google_monitoring_alert_policy", ir.Attrs)
+	require.NoError(t, err)
+	ap, ok := decoded.(*generated.GoogleMonitoringAlertPolicy)
+	require.True(t, ok)
+	require.NotNil(t, ap.DisplayName)
+	assert.Equal(t, "CPU > 90%", *ap.DisplayName.Literal)
+	require.NotNil(t, ap.Combiner)
+	assert.Equal(t, "OR", *ap.Combiner.Literal)
+	require.NotNil(t, ap.Enabled)
+	assert.True(t, *ap.Enabled.Literal)
+	require.NotNil(t, ap.Severity)
+	assert.Equal(t, "WARNING", *ap.Severity.Literal)
+	require.Len(t, ap.NotificationChannels, 1)
+	// goog-* filtered out of user_labels
+	require.Len(t, ap.UserLabels, 1)
+	_, hasGoog := ap.UserLabels["goog-managed"]
+	assert.False(t, hasGoog)
+	require.Len(t, ap.Documentation, 1)
+	require.NotNil(t, ap.Documentation[0].Content)
+	require.Len(t, ap.Documentation[0].Links, 1)
+	require.NotNil(t, ap.Documentation[0].Links[0].URL)
+	assert.Equal(t, "https://example.com/runbook", *ap.Documentation[0].Links[0].URL.Literal)
+	require.Len(t, ap.AlertStrategy, 1)
+	require.NotNil(t, ap.AlertStrategy[0].AutoClose)
+	require.Len(t, ap.AlertStrategy[0].NotificationRateLimit, 1)
+	require.Len(t, ap.Conditions, 1)
+	require.NotNil(t, ap.Conditions[0].DisplayName)
+}
+
+func TestMonitoringAlertPolicyEnricher_NameFromHint(t *testing.T) {
+	t.Parallel()
+	var gotName string
+	e := &monitoringAlertPolicyEnricher{
+		fetch: func(_ context.Context, _ *monitoringv3.Service, n string) (*monitoringv3.AlertPolicy, error) {
+			gotName = n
+			return &monitoringv3.AlertPolicy{DisplayName: "x"}, nil
+		},
+	}
+	id := &imported.ResourceIdentity{Type: monitoringAlertPolicyTFType, NameHint: "policy-abc"}
+	_, err := e.EnrichByID(context.Background(), id, EnrichClients{Monitoring: &monitoringv3.Service{}, ProjectID: "p"})
+	require.NoError(t, err)
+	assert.Equal(t, "projects/p/alertPolicies/policy-abc", gotName)
+}
+
+func TestMonitoringAlertPolicyEnricher_EnrichByID_MirrorsEnrich(t *testing.T) {
+	t.Parallel()
+	policy := &monitoringv3.AlertPolicy{DisplayName: "x", Combiner: "OR"}
+	mkFetch := func() func(context.Context, *monitoringv3.Service, string) (*monitoringv3.AlertPolicy, error) {
+		return func(_ context.Context, _ *monitoringv3.Service, _ string) (*monitoringv3.AlertPolicy, error) {
+			return policy, nil
+		}
+	}
+	enrichE := &monitoringAlertPolicyEnricher{fetch: mkFetch()}
+	byIDE := &monitoringAlertPolicyEnricher{fetch: mkFetch()}
+
+	id := imported.ResourceIdentity{Type: monitoringAlertPolicyTFType, ImportID: "projects/p/alertPolicies/1"}
+	ir := &imported.ImportedResource{Identity: id}
+	require.NoError(t, enrichE.Enrich(context.Background(), ir, EnrichClients{Monitoring: &monitoringv3.Service{}, ProjectID: "p"}))
+
+	raw, err := byIDE.EnrichByID(context.Background(), &id, EnrichClients{Monitoring: &monitoringv3.Service{}, ProjectID: "p"})
+	require.NoError(t, err)
+	assert.JSONEq(t, string(ir.Attrs), string(raw))
+}
+
+func TestMonitoringAlertPolicyEnricher_NonNotFoundErrorPassesThrough(t *testing.T) {
+	t.Parallel()
+	upstream := &googleapi.Error{Code: http.StatusForbidden}
+	e := &monitoringAlertPolicyEnricher{
+		fetch: func(_ context.Context, _ *monitoringv3.Service, _ string) (*monitoringv3.AlertPolicy, error) {
+			return nil, upstream
+		},
+	}
+	id := &imported.ResourceIdentity{Type: monitoringAlertPolicyTFType, ImportID: "projects/p/alertPolicies/1"}
+	_, err := e.EnrichByID(context.Background(), id, EnrichClients{Monitoring: &monitoringv3.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound)
+	var gerr *googleapi.Error
+	require.True(t, errors.As(err, &gerr))
+}
+
+func TestMonitoringAlertPolicyEnricher_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newMonitoringAlertPolicyEnricher().(*monitoringAlertPolicyEnricher)
+	_, err := e.EnrichByID(context.Background(), nil, EnrichClients{Monitoring: &monitoringv3.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil identity")
+}
+
+func TestMonitoringAlertPolicyEnricher_CannotDeriveName(t *testing.T) {
+	t.Parallel()
+	e := &monitoringAlertPolicyEnricher{
+		fetch: func(_ context.Context, _ *monitoringv3.Service, _ string) (*monitoringv3.AlertPolicy, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{Type: monitoringAlertPolicyTFType}}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Monitoring: &monitoringv3.Service{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive resource name")
+}

--- a/cmd/insideout-import/gcpdiscover/monitoring_dashboard_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/monitoring_dashboard_enrich.go
@@ -121,9 +121,25 @@ func isMonitoringDashboardNotFound(err error) bool {
 // mapMonitoringDashboard converts a *monitoringv1.Dashboard into the
 // typed Layer-1 *generated.GoogleMonitoringDashboard. The dashboard
 // content is serialized to JSON and stored in the dashboard_json
-// attribute. Outer-schema fields (Name, Etag) are zeroed before
-// marshalling so the JSON shape matches what the provider's own read
-// produces.
+// attribute. Outer-schema fields (Name, Etag) are stripped from the
+// JSON payload so the shape matches what the provider's own read
+// produces — `name` is the resource's fully-qualified ID and `etag`
+// is provider-managed concurrency metadata, neither belongs inside
+// the inner dashboard_json blob. DisplayName is deliberately KEPT
+// because the provider's dashboard_json contract includes it as the
+// canonical display label.
+//
+// Implementation note: we deliberately go through a JSON round-trip
+// (Marshal → unmarshal into a map → delete outer-schema keys →
+// re-Marshal) instead of a `clone := *d` shallow copy. The SDK
+// Dashboard struct holds pointer fields for its layout variants
+// (GridLayout, MosaicLayout, RowLayout, ColumnLayout) and a slice of
+// pointer-valued labels; a shallow struct copy would share those
+// pointers with the caller, so any future code that mutated the
+// clone's nested layout fields would corrupt the upstream SDK
+// response. Marshalling through a map breaks that aliasing completely
+// at the cost of a single extra encode/decode pass per dashboard
+// (dashboards are small and rate-limited).
 func mapMonitoringDashboard(d *monitoringv1.Dashboard, projectID string) (*generated.GoogleMonitoringDashboard, error) {
 	out := &generated.GoogleMonitoringDashboard{}
 	if projectID != "" {
@@ -132,15 +148,27 @@ func mapMonitoringDashboard(d *monitoringv1.Dashboard, projectID string) (*gener
 	if d == nil {
 		return out, nil
 	}
-	// Clone the dashboard so we can strip TF-outer-schema fields
-	// without mutating the caller's copy.
-	clone := *d
-	clone.Name = ""
-	clone.Etag = ""
-	clone.ServerResponse = googleapi.ServerResponse{}
-	payload, err := json.Marshal(&clone)
+	rawIn, err := json.Marshal(d)
 	if err != nil {
-		return nil, fmt.Errorf("marshal dashboard payload: %w", err)
+		return nil, fmt.Errorf("marshal dashboard for round-trip: %w", err)
+	}
+	// Decode into a map so we can strip outer-schema keys without
+	// sharing any pointer state with the caller's *monitoringv1.Dashboard.
+	asMap := map[string]json.RawMessage{}
+	if err := json.Unmarshal(rawIn, &asMap); err != nil {
+		return nil, fmt.Errorf("unmarshal dashboard for round-trip: %w", err)
+	}
+	// TF provider's monitoring_dashboard resource hoists `name`
+	// (fully-qualified ID) out and never surfaces `etag`. Strip both
+	// so dashboard_json matches what the provider reads back.
+	// google.golang.org/api SDKs do NOT include the ServerResponse
+	// field in their JSON output (no JSON tag), so no explicit delete
+	// is required for it.
+	delete(asMap, "name")
+	delete(asMap, "etag")
+	payload, err := json.Marshal(asMap)
+	if err != nil {
+		return nil, fmt.Errorf("remarshal dashboard payload: %w", err)
 	}
 	if len(payload) > 0 && string(payload) != "{}" {
 		out.DashboardJSON = generated.LiteralOf(string(payload))

--- a/cmd/insideout-import/gcpdiscover/monitoring_dashboard_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/monitoring_dashboard_enrich.go
@@ -1,0 +1,149 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"google.golang.org/api/googleapi"
+	monitoringv1 "google.golang.org/api/monitoring/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// monitoringDashboardEnricher implements AttributeEnricher AND
+// ByIDEnricher for google_monitoring_dashboard. Pairs with
+// monitoringDashboardDiscoverer.
+//
+// Dashboards live in google.golang.org/api/monitoring/v1 — separate
+// from monitoring/v3 (where AlertPolicies / NotificationChannels live).
+// Projects.Dashboards.Get takes a fully-qualified name of the form
+// `projects/<p>/dashboards/<id>`. The discoverer puts that string in
+// ImportID and the short id in NameHint.
+//
+// Mapping rationale: the TF schema is unusual — it stores the entire
+// dashboard layout as a single `dashboard_json` string attribute
+// (everything except project / labels is opaque to TF). So the enricher
+// marshals the SDK Dashboard struct back to JSON (minus the fields TF
+// derives from its outer schema — project / etag / name) and writes
+// that string into dashboard_json. This matches what the provider
+// itself does on read.
+//
+// Computed-only TF fields skipped per decision #5: id.
+type monitoringDashboardEnricher struct {
+	fetch func(ctx context.Context, svc *monitoringv1.Service, name string) (*monitoringv1.Dashboard, error)
+}
+
+func newMonitoringDashboardEnricher() AttributeEnricher {
+	return &monitoringDashboardEnricher{fetch: defaultMonitoringDashboardFetch}
+}
+
+var (
+	_ AttributeEnricher = (*monitoringDashboardEnricher)(nil)
+	_ ByIDEnricher      = (*monitoringDashboardEnricher)(nil)
+)
+
+func (monitoringDashboardEnricher) ResourceType() string {
+	return monitoringDashboardTFType
+}
+
+func (e monitoringDashboardEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchTyped(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+func (e monitoringDashboardEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("monitoring_dashboard: nil identity")
+	}
+	return e.fetchTyped(ctx, identity, c)
+}
+
+func (e monitoringDashboardEnricher) fetchTyped(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.MonitoringDashboard == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	fullName := monitoringDashboardNameForEnrich(id, c.ProjectID)
+	if fullName == "" {
+		return nil, fmt.Errorf("monitoring_dashboard: cannot derive resource name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			id.Address, id.ImportID, id.NameHint)
+	}
+	d, err := e.fetch(ctx, c.MonitoringDashboard, fullName)
+	if err != nil {
+		if isMonitoringDashboardNotFound(err) {
+			return nil, fmt.Errorf("monitoring_dashboard: %s: %w", fullName, ErrNotFound)
+		}
+		return nil, fmt.Errorf("monitoring_dashboard: get %s: %w", fullName, err)
+	}
+	typed, err := mapMonitoringDashboard(d, c.ProjectID)
+	if err != nil {
+		return nil, fmt.Errorf("monitoring_dashboard: build typed Attrs: %w", err)
+	}
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("monitoring_dashboard: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// monitoringDashboardNameForEnrich returns the fully-qualified
+// `projects/<p>/dashboards/<id>` resource name. Precedence: ImportID,
+// then NameHint + projectID.
+func monitoringDashboardNameForEnrich(id *imported.ResourceIdentity, projectID string) string {
+	if id.ImportID != "" {
+		return id.ImportID
+	}
+	if id.NameHint != "" && projectID != "" {
+		return fmt.Sprintf("projects/%s/dashboards/%s", projectID, id.NameHint)
+	}
+	return ""
+}
+
+func defaultMonitoringDashboardFetch(ctx context.Context, svc *monitoringv1.Service, name string) (*monitoringv1.Dashboard, error) {
+	return svc.Projects.Dashboards.Get(name).Context(ctx).Do()
+}
+
+func isMonitoringDashboardNotFound(err error) bool {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return gerr.Code == http.StatusNotFound
+	}
+	return false
+}
+
+// mapMonitoringDashboard converts a *monitoringv1.Dashboard into the
+// typed Layer-1 *generated.GoogleMonitoringDashboard. The dashboard
+// content is serialized to JSON and stored in the dashboard_json
+// attribute. Outer-schema fields (Name, Etag) are zeroed before
+// marshalling so the JSON shape matches what the provider's own read
+// produces.
+func mapMonitoringDashboard(d *monitoringv1.Dashboard, projectID string) (*generated.GoogleMonitoringDashboard, error) {
+	out := &generated.GoogleMonitoringDashboard{}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if d == nil {
+		return out, nil
+	}
+	// Clone the dashboard so we can strip TF-outer-schema fields
+	// without mutating the caller's copy.
+	clone := *d
+	clone.Name = ""
+	clone.Etag = ""
+	clone.ServerResponse = googleapi.ServerResponse{}
+	payload, err := json.Marshal(&clone)
+	if err != nil {
+		return nil, fmt.Errorf("marshal dashboard payload: %w", err)
+	}
+	if len(payload) > 0 && string(payload) != "{}" {
+		out.DashboardJSON = generated.LiteralOf(string(payload))
+	}
+	return out, nil
+}

--- a/cmd/insideout-import/gcpdiscover/monitoring_dashboard_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/monitoring_dashboard_enrich.go
@@ -3,11 +3,8 @@ package gcpdiscover
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 
-	"google.golang.org/api/googleapi"
 	monitoringv1 "google.golang.org/api/monitoring/v1"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -67,7 +64,7 @@ func (e monitoringDashboardEnricher) EnrichByID(ctx context.Context, identity *i
 }
 
 func (e monitoringDashboardEnricher) fetchTyped(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
-	if c.MonitoringDashboard == nil {
+	if c.MonitoringV1 == nil {
 		return nil, ErrEnrichClientUnavailable
 	}
 	fullName := monitoringDashboardNameForEnrich(id, c.ProjectID)
@@ -75,9 +72,9 @@ func (e monitoringDashboardEnricher) fetchTyped(ctx context.Context, id *importe
 		return nil, fmt.Errorf("monitoring_dashboard: cannot derive resource name from Identity (Address=%q ImportID=%q NameHint=%q)",
 			id.Address, id.ImportID, id.NameHint)
 	}
-	d, err := e.fetch(ctx, c.MonitoringDashboard, fullName)
+	d, err := e.fetch(ctx, c.MonitoringV1, fullName)
 	if err != nil {
-		if isMonitoringDashboardNotFound(err) {
+		if isGoogleAPINotFound(err) {
 			return nil, fmt.Errorf("monitoring_dashboard: %s: %w", fullName, ErrNotFound)
 		}
 		return nil, fmt.Errorf("monitoring_dashboard: get %s: %w", fullName, err)
@@ -108,14 +105,6 @@ func monitoringDashboardNameForEnrich(id *imported.ResourceIdentity, projectID s
 
 func defaultMonitoringDashboardFetch(ctx context.Context, svc *monitoringv1.Service, name string) (*monitoringv1.Dashboard, error) {
 	return svc.Projects.Dashboards.Get(name).Context(ctx).Do()
-}
-
-func isMonitoringDashboardNotFound(err error) bool {
-	var gerr *googleapi.Error
-	if errors.As(err, &gerr) {
-		return gerr.Code == http.StatusNotFound
-	}
-	return false
 }
 
 // mapMonitoringDashboard converts a *monitoringv1.Dashboard into the

--- a/cmd/insideout-import/gcpdiscover/monitoring_dashboard_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/monitoring_dashboard_enrich_test.go
@@ -26,7 +26,7 @@ func TestMonitoringDashboardEnricher_NilClient_ReturnsClientUnavailable(t *testi
 	ir := &imported.ImportedResource{
 		Identity: imported.ResourceIdentity{Type: monitoringDashboardTFType, ImportID: "projects/p/dashboards/1"},
 	}
-	err := e.Enrich(context.Background(), ir, EnrichClients{MonitoringDashboard: nil, ProjectID: "p"})
+	err := e.Enrich(context.Background(), ir, EnrichClients{MonitoringV1: nil, ProjectID: "p"})
 	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
 	assert.Empty(t, ir.Attrs)
 }
@@ -39,7 +39,7 @@ func TestMonitoringDashboardEnricher_NotFound_ReturnsErrNotFound(t *testing.T) {
 		},
 	}
 	id := &imported.ResourceIdentity{Type: monitoringDashboardTFType, ImportID: "projects/p/dashboards/1"}
-	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}, ProjectID: "p"})
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{MonitoringV1: &monitoringv1.Service{}, ProjectID: "p"})
 	require.ErrorIs(t, err, ErrNotFound)
 	assert.Nil(t, raw)
 }
@@ -65,7 +65,7 @@ func TestMonitoringDashboardEnricher_HappyPath(t *testing.T) {
 	ir := &imported.ImportedResource{
 		Identity: imported.ResourceIdentity{Type: monitoringDashboardTFType, ImportID: "projects/my-project/dashboards/abc"},
 	}
-	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}, ProjectID: "my-project"}))
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{MonitoringV1: &monitoringv1.Service{}, ProjectID: "my-project"}))
 	assert.Equal(t, "projects/my-project/dashboards/abc", gotName)
 
 	decoded, err := generated.UnmarshalAttrs("google_monitoring_dashboard", ir.Attrs)
@@ -96,7 +96,7 @@ func TestMonitoringDashboardEnricher_NameFromHint(t *testing.T) {
 		},
 	}
 	id := &imported.ResourceIdentity{Type: monitoringDashboardTFType, NameHint: "dash-abc"}
-	_, err := e.EnrichByID(context.Background(), id, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}, ProjectID: "p"})
+	_, err := e.EnrichByID(context.Background(), id, EnrichClients{MonitoringV1: &monitoringv1.Service{}, ProjectID: "p"})
 	require.NoError(t, err)
 	assert.Equal(t, "projects/p/dashboards/dash-abc", gotName)
 }
@@ -114,9 +114,9 @@ func TestMonitoringDashboardEnricher_EnrichByID_MirrorsEnrich(t *testing.T) {
 
 	id := imported.ResourceIdentity{Type: monitoringDashboardTFType, ImportID: "projects/p/dashboards/1"}
 	ir := &imported.ImportedResource{Identity: id}
-	require.NoError(t, enrichE.Enrich(context.Background(), ir, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}, ProjectID: "p"}))
+	require.NoError(t, enrichE.Enrich(context.Background(), ir, EnrichClients{MonitoringV1: &monitoringv1.Service{}, ProjectID: "p"}))
 
-	raw, err := byIDE.EnrichByID(context.Background(), &id, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}, ProjectID: "p"})
+	raw, err := byIDE.EnrichByID(context.Background(), &id, EnrichClients{MonitoringV1: &monitoringv1.Service{}, ProjectID: "p"})
 	require.NoError(t, err)
 	assert.JSONEq(t, string(ir.Attrs), string(raw))
 }
@@ -124,7 +124,7 @@ func TestMonitoringDashboardEnricher_EnrichByID_MirrorsEnrich(t *testing.T) {
 func TestMonitoringDashboardEnricher_NilIdentity(t *testing.T) {
 	t.Parallel()
 	e := newMonitoringDashboardEnricher().(*monitoringDashboardEnricher)
-	_, err := e.EnrichByID(context.Background(), nil, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}, ProjectID: "p"})
+	_, err := e.EnrichByID(context.Background(), nil, EnrichClients{MonitoringV1: &monitoringv1.Service{}, ProjectID: "p"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nil identity")
 }
@@ -138,7 +138,7 @@ func TestMonitoringDashboardEnricher_CannotDeriveName(t *testing.T) {
 		},
 	}
 	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{Type: monitoringDashboardTFType}}
-	err := e.Enrich(context.Background(), ir, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}})
+	err := e.Enrich(context.Background(), ir, EnrichClients{MonitoringV1: &monitoringv1.Service{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot derive resource name")
 }

--- a/cmd/insideout-import/gcpdiscover/monitoring_dashboard_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/monitoring_dashboard_enrich_test.go
@@ -1,0 +1,144 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	monitoringv1 "google.golang.org/api/monitoring/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+func TestMonitoringDashboardEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "google_monitoring_dashboard", newMonitoringDashboardEnricher().ResourceType())
+}
+
+func TestMonitoringDashboardEnricher_NilClient_ReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newMonitoringDashboardEnricher()
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: monitoringDashboardTFType, ImportID: "projects/p/dashboards/1"},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{MonitoringDashboard: nil, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Empty(t, ir.Attrs)
+}
+
+func TestMonitoringDashboardEnricher_NotFound_ReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	e := &monitoringDashboardEnricher{
+		fetch: func(_ context.Context, _ *monitoringv1.Service, _ string) (*monitoringv1.Dashboard, error) {
+			return nil, &googleapi.Error{Code: http.StatusNotFound, Message: "not found"}
+		},
+	}
+	id := &imported.ResourceIdentity{Type: monitoringDashboardTFType, ImportID: "projects/p/dashboards/1"}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrNotFound)
+	assert.Nil(t, raw)
+}
+
+func TestMonitoringDashboardEnricher_HappyPath(t *testing.T) {
+	t.Parallel()
+	dashboard := &monitoringv1.Dashboard{
+		DisplayName: "Prod Overview",
+		Name:        "projects/my-project/dashboards/abc",
+		Etag:        "etag-foo",
+		Labels:      map[string]string{"team": "platform"},
+		GridLayout: &monitoringv1.GridLayout{
+			Columns: 12,
+		},
+	}
+	var gotName string
+	e := &monitoringDashboardEnricher{
+		fetch: func(_ context.Context, _ *monitoringv1.Service, n string) (*monitoringv1.Dashboard, error) {
+			gotName = n
+			return dashboard, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: monitoringDashboardTFType, ImportID: "projects/my-project/dashboards/abc"},
+	}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}, ProjectID: "my-project"}))
+	assert.Equal(t, "projects/my-project/dashboards/abc", gotName)
+
+	decoded, err := generated.UnmarshalAttrs("google_monitoring_dashboard", ir.Attrs)
+	require.NoError(t, err)
+	d, ok := decoded.(*generated.GoogleMonitoringDashboard)
+	require.True(t, ok)
+	require.NotNil(t, d.Project)
+	assert.Equal(t, "my-project", *d.Project.Literal)
+	require.NotNil(t, d.DashboardJSON)
+	// dashboard_json must contain displayName and not the stripped Name / Etag.
+	js := *d.DashboardJSON.Literal
+	assert.Contains(t, js, `"displayName":"Prod Overview"`)
+	assert.NotContains(t, js, `"name":"projects/my-project/dashboards/abc"`)
+	assert.NotContains(t, js, `"etag":"etag-foo"`)
+	// Round-trip JSON parse.
+	var roundTrip map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(js), &roundTrip))
+	assert.Equal(t, "Prod Overview", roundTrip["displayName"])
+}
+
+func TestMonitoringDashboardEnricher_NameFromHint(t *testing.T) {
+	t.Parallel()
+	var gotName string
+	e := &monitoringDashboardEnricher{
+		fetch: func(_ context.Context, _ *monitoringv1.Service, n string) (*monitoringv1.Dashboard, error) {
+			gotName = n
+			return &monitoringv1.Dashboard{DisplayName: "x"}, nil
+		},
+	}
+	id := &imported.ResourceIdentity{Type: monitoringDashboardTFType, NameHint: "dash-abc"}
+	_, err := e.EnrichByID(context.Background(), id, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}, ProjectID: "p"})
+	require.NoError(t, err)
+	assert.Equal(t, "projects/p/dashboards/dash-abc", gotName)
+}
+
+func TestMonitoringDashboardEnricher_EnrichByID_MirrorsEnrich(t *testing.T) {
+	t.Parallel()
+	dash := &monitoringv1.Dashboard{DisplayName: "x"}
+	mkFetch := func() func(context.Context, *monitoringv1.Service, string) (*monitoringv1.Dashboard, error) {
+		return func(_ context.Context, _ *monitoringv1.Service, _ string) (*monitoringv1.Dashboard, error) {
+			return dash, nil
+		}
+	}
+	enrichE := &monitoringDashboardEnricher{fetch: mkFetch()}
+	byIDE := &monitoringDashboardEnricher{fetch: mkFetch()}
+
+	id := imported.ResourceIdentity{Type: monitoringDashboardTFType, ImportID: "projects/p/dashboards/1"}
+	ir := &imported.ImportedResource{Identity: id}
+	require.NoError(t, enrichE.Enrich(context.Background(), ir, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}, ProjectID: "p"}))
+
+	raw, err := byIDE.EnrichByID(context.Background(), &id, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}, ProjectID: "p"})
+	require.NoError(t, err)
+	assert.JSONEq(t, string(ir.Attrs), string(raw))
+}
+
+func TestMonitoringDashboardEnricher_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newMonitoringDashboardEnricher().(*monitoringDashboardEnricher)
+	_, err := e.EnrichByID(context.Background(), nil, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil identity")
+}
+
+func TestMonitoringDashboardEnricher_CannotDeriveName(t *testing.T) {
+	t.Parallel()
+	e := &monitoringDashboardEnricher{
+		fetch: func(_ context.Context, _ *monitoringv1.Service, _ string) (*monitoringv1.Dashboard, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{Type: monitoringDashboardTFType}}
+	err := e.Enrich(context.Background(), ir, EnrichClients{MonitoringDashboard: &monitoringv1.Service{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive resource name")
+}

--- a/cmd/insideout-import/gcpdiscover/monitoring_notification_channel_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/monitoring_notification_channel_enrich.go
@@ -73,7 +73,7 @@ func (e monitoringNotificationChannelEnricher) fetchTyped(ctx context.Context, i
 	}
 	ch, err := e.fetch(ctx, c.Monitoring, fullName)
 	if err != nil {
-		if isMonitoringNotFound(err) {
+		if isGoogleAPINotFound(err) {
 			return nil, fmt.Errorf("monitoring_notification_channel: %s: %w", fullName, ErrNotFound)
 		}
 		return nil, fmt.Errorf("monitoring_notification_channel: get %s: %w", fullName, err)
@@ -121,8 +121,19 @@ func mapMonitoringNotificationChannel(ch *monitoringv3.NotificationChannel, proj
 		out.Enabled = generated.LiteralOf(true)
 	}
 	if len(ch.Labels) > 0 {
-		// `labels` is the channel's functional configuration. Pass it
-		// through unfiltered — these aren't system labels.
+		// `labels` is the channel's functional configuration (e.g.
+		// email channels carry `email_address` here; PagerDuty
+		// channels carry the integration key; webhook channels carry
+		// the URL). Some of those values are sensitive — service
+		// keys, webhook URLs — but per decision #36 the enricher
+		// writes them verbatim into the typed Attrs. Redaction is
+		// the emit layer's job, not the enricher's, because the
+		// enricher and the emitter can disagree about which keys
+		// are sensitive (varies by channel type) and centralizing
+		// that policy at emit time avoids duplicating the rule.
+		// These are NOT system / goog-managed labels, so the
+		// goog-* prefix filter applied to UserLabels below does not
+		// apply here.
 		labels := map[string]*generated.Value[string]{}
 		for k, v := range ch.Labels {
 			labels[k] = generated.LiteralOf(v)

--- a/cmd/insideout-import/gcpdiscover/monitoring_notification_channel_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/monitoring_notification_channel_enrich.go
@@ -1,0 +1,145 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	monitoringv3 "google.golang.org/api/monitoring/v3"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// monitoringNotificationChannelEnricher implements AttributeEnricher
+// AND ByIDEnricher for google_monitoring_notification_channel. Pairs
+// with monitoringNotificationChannelDiscoverer.
+//
+// NotificationChannels.Get takes a single fully-qualified name of the
+// form `projects/<p>/notificationChannels/<id>`. The discoverer puts
+// that string in ImportID and the short id in NameHint.
+//
+// Mapping note on labels vs. user_labels: the TF schema has TWO maps
+// — `labels` (the channel's configuration parameters, e.g. email_address
+// for email channels, channel_name for slack) and `user_labels`
+// (free-form organizing labels). Both come from the SDK as
+// map[string]string. The goog-* prefix filter applies to user_labels
+// only; the `labels` map carries the channel's functional configuration
+// and must not be filtered.
+//
+// Computed-only fields skipped per decision #5: id, name, verification_status.
+type monitoringNotificationChannelEnricher struct {
+	fetch func(ctx context.Context, svc *monitoringv3.Service, name string) (*monitoringv3.NotificationChannel, error)
+}
+
+func newMonitoringNotificationChannelEnricher() AttributeEnricher {
+	return &monitoringNotificationChannelEnricher{fetch: defaultMonitoringNotificationChannelFetch}
+}
+
+var (
+	_ AttributeEnricher = (*monitoringNotificationChannelEnricher)(nil)
+	_ ByIDEnricher      = (*monitoringNotificationChannelEnricher)(nil)
+)
+
+func (monitoringNotificationChannelEnricher) ResourceType() string {
+	return monitoringNotificationChannelTFType
+}
+
+func (e monitoringNotificationChannelEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchTyped(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+func (e monitoringNotificationChannelEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("monitoring_notification_channel: nil identity")
+	}
+	return e.fetchTyped(ctx, identity, c)
+}
+
+func (e monitoringNotificationChannelEnricher) fetchTyped(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.Monitoring == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	fullName := monitoringNotificationChannelNameForEnrich(id, c.ProjectID)
+	if fullName == "" {
+		return nil, fmt.Errorf("monitoring_notification_channel: cannot derive resource name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			id.Address, id.ImportID, id.NameHint)
+	}
+	ch, err := e.fetch(ctx, c.Monitoring, fullName)
+	if err != nil {
+		if isMonitoringNotFound(err) {
+			return nil, fmt.Errorf("monitoring_notification_channel: %s: %w", fullName, ErrNotFound)
+		}
+		return nil, fmt.Errorf("monitoring_notification_channel: get %s: %w", fullName, err)
+	}
+	typed := mapMonitoringNotificationChannel(ch, c.ProjectID)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("monitoring_notification_channel: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+func monitoringNotificationChannelNameForEnrich(id *imported.ResourceIdentity, projectID string) string {
+	if id.ImportID != "" {
+		return id.ImportID
+	}
+	if id.NameHint != "" && projectID != "" {
+		return fmt.Sprintf("projects/%s/notificationChannels/%s", projectID, id.NameHint)
+	}
+	return ""
+}
+
+func defaultMonitoringNotificationChannelFetch(ctx context.Context, svc *monitoringv3.Service, name string) (*monitoringv3.NotificationChannel, error) {
+	return svc.Projects.NotificationChannels.Get(name).Context(ctx).Do()
+}
+
+func mapMonitoringNotificationChannel(ch *monitoringv3.NotificationChannel, projectID string) *generated.GoogleMonitoringNotificationChannel {
+	out := &generated.GoogleMonitoringNotificationChannel{}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if ch == nil {
+		return out
+	}
+	if ch.DisplayName != "" {
+		out.DisplayName = generated.LiteralOf(ch.DisplayName)
+	}
+	if ch.Description != "" {
+		out.Description = generated.LiteralOf(ch.Description)
+	}
+	if ch.Type != "" {
+		out.Type_ = generated.LiteralOf(ch.Type)
+	}
+	if ch.Enabled {
+		out.Enabled = generated.LiteralOf(true)
+	}
+	if len(ch.Labels) > 0 {
+		// `labels` is the channel's functional configuration. Pass it
+		// through unfiltered — these aren't system labels.
+		labels := map[string]*generated.Value[string]{}
+		for k, v := range ch.Labels {
+			labels[k] = generated.LiteralOf(v)
+		}
+		out.Labels = labels
+	}
+	if len(ch.UserLabels) > 0 {
+		ul := map[string]*generated.Value[string]{}
+		for k, v := range ch.UserLabels {
+			if strings.HasPrefix(k, "goog-") || strings.HasPrefix(k, "goog_") {
+				continue
+			}
+			ul[k] = generated.LiteralOf(v)
+		}
+		if len(ul) > 0 {
+			out.UserLabels = ul
+		}
+	}
+	return out
+}

--- a/cmd/insideout-import/gcpdiscover/monitoring_notification_channel_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/monitoring_notification_channel_enrich_test.go
@@ -1,0 +1,134 @@
+package gcpdiscover
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	monitoringv3 "google.golang.org/api/monitoring/v3"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+func TestMonitoringNotificationChannelEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "google_monitoring_notification_channel", newMonitoringNotificationChannelEnricher().ResourceType())
+}
+
+func TestMonitoringNotificationChannelEnricher_NilClient_ReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newMonitoringNotificationChannelEnricher()
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: monitoringNotificationChannelTFType, ImportID: "projects/p/notificationChannels/1"},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{Monitoring: nil, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Empty(t, ir.Attrs)
+}
+
+func TestMonitoringNotificationChannelEnricher_NotFound_ReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	e := &monitoringNotificationChannelEnricher{
+		fetch: func(_ context.Context, _ *monitoringv3.Service, _ string) (*monitoringv3.NotificationChannel, error) {
+			return nil, &googleapi.Error{Code: http.StatusNotFound, Message: "not found"}
+		},
+	}
+	id := &imported.ResourceIdentity{Type: monitoringNotificationChannelTFType, ImportID: "projects/p/notificationChannels/1"}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{Monitoring: &monitoringv3.Service{}, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrNotFound)
+	assert.Nil(t, raw)
+}
+
+func TestMonitoringNotificationChannelEnricher_HappyPath(t *testing.T) {
+	t.Parallel()
+	ch := &monitoringv3.NotificationChannel{
+		DisplayName: "Pager",
+		Description: "On-call team",
+		Type:        "email",
+		Enabled:     true,
+		Labels:      map[string]string{"email_address": "oncall@example.com"},
+		UserLabels:  map[string]string{"team": "platform", "goog-managed": "true", "goog_internal": "x"},
+	}
+	var gotName string
+	e := &monitoringNotificationChannelEnricher{
+		fetch: func(_ context.Context, _ *monitoringv3.Service, n string) (*monitoringv3.NotificationChannel, error) {
+			gotName = n
+			return ch, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type: monitoringNotificationChannelTFType, ImportID: "projects/my-project/notificationChannels/123",
+		},
+	}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{Monitoring: &monitoringv3.Service{}, ProjectID: "my-project"}))
+	assert.Equal(t, "projects/my-project/notificationChannels/123", gotName)
+
+	decoded, err := generated.UnmarshalAttrs("google_monitoring_notification_channel", ir.Attrs)
+	require.NoError(t, err)
+	nc, ok := decoded.(*generated.GoogleMonitoringNotificationChannel)
+	require.True(t, ok)
+	require.NotNil(t, nc.DisplayName)
+	assert.Equal(t, "Pager", *nc.DisplayName.Literal)
+	require.NotNil(t, nc.Type_)
+	assert.Equal(t, "email", *nc.Type_.Literal)
+	require.NotNil(t, nc.Enabled)
+	assert.True(t, *nc.Enabled.Literal)
+	// `labels` map: functional config, no filtering.
+	require.NotNil(t, nc.Labels)
+	require.Contains(t, nc.Labels, "email_address")
+	// user_labels: goog-* filtered.
+	require.NotNil(t, nc.UserLabels)
+	assert.Len(t, nc.UserLabels, 1)
+	_, hasGoog := nc.UserLabels["goog-managed"]
+	assert.False(t, hasGoog)
+	_, hasGoogU := nc.UserLabels["goog_internal"]
+	assert.False(t, hasGoogU)
+}
+
+func TestMonitoringNotificationChannelEnricher_NameFromHint(t *testing.T) {
+	t.Parallel()
+	var gotName string
+	e := &monitoringNotificationChannelEnricher{
+		fetch: func(_ context.Context, _ *monitoringv3.Service, n string) (*monitoringv3.NotificationChannel, error) {
+			gotName = n
+			return &monitoringv3.NotificationChannel{DisplayName: "x"}, nil
+		},
+	}
+	id := &imported.ResourceIdentity{Type: monitoringNotificationChannelTFType, NameHint: "ch-abc"}
+	_, err := e.EnrichByID(context.Background(), id, EnrichClients{Monitoring: &monitoringv3.Service{}, ProjectID: "p"})
+	require.NoError(t, err)
+	assert.Equal(t, "projects/p/notificationChannels/ch-abc", gotName)
+}
+
+func TestMonitoringNotificationChannelEnricher_EnrichByID_MirrorsEnrich(t *testing.T) {
+	t.Parallel()
+	ch := &monitoringv3.NotificationChannel{DisplayName: "x", Type: "email"}
+	mkFetch := func() func(context.Context, *monitoringv3.Service, string) (*monitoringv3.NotificationChannel, error) {
+		return func(_ context.Context, _ *monitoringv3.Service, _ string) (*monitoringv3.NotificationChannel, error) {
+			return ch, nil
+		}
+	}
+	enrichE := &monitoringNotificationChannelEnricher{fetch: mkFetch()}
+	byIDE := &monitoringNotificationChannelEnricher{fetch: mkFetch()}
+
+	id := imported.ResourceIdentity{Type: monitoringNotificationChannelTFType, ImportID: "projects/p/notificationChannels/1"}
+	ir := &imported.ImportedResource{Identity: id}
+	require.NoError(t, enrichE.Enrich(context.Background(), ir, EnrichClients{Monitoring: &monitoringv3.Service{}, ProjectID: "p"}))
+
+	raw, err := byIDE.EnrichByID(context.Background(), &id, EnrichClients{Monitoring: &monitoringv3.Service{}, ProjectID: "p"})
+	require.NoError(t, err)
+	assert.JSONEq(t, string(ir.Attrs), string(raw))
+}
+
+func TestMonitoringNotificationChannelEnricher_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newMonitoringNotificationChannelEnricher().(*monitoringNotificationChannelEnricher)
+	_, err := e.EnrichByID(context.Background(), nil, EnrichClients{Monitoring: &monitoringv3.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil identity")
+}

--- a/cmd/insideout-import/gcpdiscover/sql_user_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/sql_user_enrich.go
@@ -1,0 +1,219 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"google.golang.org/api/googleapi"
+	sqladminv1 "google.golang.org/api/sqladmin/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// sqlUserEnricher implements AttributeEnricher AND ByIDEnricher for
+// google_sql_user. Pairs with sqlUserDiscoverer.
+//
+// SQL Admin API quirk: Users.Get takes (project, instance, name) as
+// three positional parameters. The discoverer puts the instance ID into
+// Identity.NativeIDs["instance"] and the user's short name into
+// Identity.NameHint, so the enricher pulls (project, instance, name)
+// from those slots (or falls back to parsing the ImportID, which
+// follows the <instance>/<host>/<name> or <instance>/<name> shape).
+//
+// Mapping rationale matches the compute_address pattern: computed-only
+// TF attributes (id) are NOT populated per the decision-#5 composer
+// emission rule. The password attribute is sensitive in the TF schema
+// and the SQL Admin API does not echo it back on Get — but we strip it
+// defensively anyway. The sql_server_user_details nested block is
+// populated when the user is a SQL Server user (the API returns
+// SqlserverUserDetails only for that flavor).
+type sqlUserEnricher struct {
+	// fetch is overridable for tests. Defaults to a real Users.Get
+	// call against the sqladminv1.Service in EnrichClients.
+	fetch func(ctx context.Context, svc *sqladminv1.Service, project, instance, name string) (*sqladminv1.User, error)
+}
+
+func newSQLUserEnricher() AttributeEnricher {
+	return &sqlUserEnricher{fetch: defaultSQLUserFetch}
+}
+
+// Compile-time assertions.
+var (
+	_ AttributeEnricher = (*sqlUserEnricher)(nil)
+	_ ByIDEnricher      = (*sqlUserEnricher)(nil)
+)
+
+func (sqlUserEnricher) ResourceType() string { return sqlUserTFType }
+
+// Enrich populates ir.Attrs with a typed GoogleSqlUser payload for the
+// user identified by ir.Identity. Returns ErrEnrichClientUnavailable
+// if EnrichClients.SQLAdmin is nil.
+func (e sqlUserEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	raw, err := e.fetchTyped(ctx, &ir.Identity, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID is the sibling entry-point for the per-IR refresh path.
+func (e sqlUserEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("sql_user: nil identity")
+	}
+	return e.fetchTyped(ctx, identity, c)
+}
+
+func (e sqlUserEnricher) fetchTyped(ctx context.Context, id *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.SQLAdmin == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if c.ProjectID == "" {
+		return nil, fmt.Errorf("sql_user: EnrichClients.ProjectID required (sqladmin Users.Get uses project+instance+name positional args)")
+	}
+	instance, name := sqlUserInstanceAndNameForEnrich(id)
+	if instance == "" || name == "" {
+		return nil, fmt.Errorf("sql_user: cannot derive instance/name from Identity (Address=%q ImportID=%q NameHint=%q NativeIDs.instance=%q)",
+			id.Address, id.ImportID, id.NameHint, id.NativeIDs["instance"])
+	}
+	u, err := e.fetch(ctx, c.SQLAdmin, c.ProjectID, instance, name)
+	if err != nil {
+		if isSQLAdminNotFound(err) {
+			return nil, fmt.Errorf("sql_user: %s/%s/%s: %w", c.ProjectID, instance, name, ErrNotFound)
+		}
+		return nil, fmt.Errorf("sql_user: get %s/%s/%s: %w", c.ProjectID, instance, name, err)
+	}
+	typed := mapSQLUser(u, c.ProjectID, instance, name)
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("sql_user: marshal Attrs: %w", err)
+	}
+	return raw, nil
+}
+
+// sqlUserInstanceAndNameForEnrich pulls (instance, name) from the
+// Identity. Precedence: NameHint + NativeIDs["instance"], then the
+// ImportID parsed via the <instance>/<host>/<name> or <instance>/<name>
+// provider shape.
+func sqlUserInstanceAndNameForEnrich(id *imported.ResourceIdentity) (string, string) {
+	name := id.NameHint
+	instance := id.NativeIDs["instance"]
+	if name != "" && instance != "" {
+		return instance, name
+	}
+	if id.ImportID != "" {
+		i, n := parseSQLUserImportID(id.ImportID)
+		if instance == "" {
+			instance = i
+		}
+		if name == "" {
+			name = n
+		}
+	}
+	return instance, name
+}
+
+// parseSQLUserImportID parses the provider's <instance>/<host>/<name>
+// or <instance>/<name> import shape. Returns ("", "") if the shape
+// doesn't match.
+func parseSQLUserImportID(id string) (instance, name string) {
+	// Strategy: split by "/". 2 segments → instance/name. 3 segments →
+	// instance/host/name.
+	first := 0
+	for i := 0; i < len(id); i++ {
+		if id[i] == '/' {
+			first = i
+			break
+		}
+	}
+	if first == 0 {
+		return "", ""
+	}
+	instance = id[:first]
+	rest := id[first+1:]
+	// Find the LAST slash in rest — name is everything after it; if
+	// no slash, rest is the name directly.
+	last := -1
+	for i := 0; i < len(rest); i++ {
+		if rest[i] == '/' {
+			last = i
+		}
+	}
+	if last < 0 {
+		name = rest
+	} else {
+		name = rest[last+1:]
+	}
+	return instance, name
+}
+
+// defaultSQLUserFetch is the production fetch path.
+func defaultSQLUserFetch(ctx context.Context, svc *sqladminv1.Service, project, instance, name string) (*sqladminv1.User, error) {
+	return svc.Users.Get(project, instance, name).Context(ctx).Do()
+}
+
+// isSQLAdminNotFound reports whether err is a googleapi.Error with
+// HTTP 404.
+func isSQLAdminNotFound(err error) bool {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return gerr.Code == http.StatusNotFound
+	}
+	return false
+}
+
+// mapSQLUser converts a *sqladminv1.User into the typed Layer-1
+// *generated.GoogleSqlUser model. Hand-rolled (not enrichgen-emitted).
+//
+// Computed-only TF fields skipped per decision #5: id.
+//
+// Password is always stripped: the API never echoes it back on Get
+// even when set, and it is a sensitive field per TF schema. Per
+// decision #36 the enricher could write a placeholder; we instead
+// leave it nil so the emit layer omits the attribute entirely (the
+// user re-supplies the password on first apply through a Terraform
+// variable).
+//
+// Instance and Name come from the function arguments (the values the
+// caller already derived from Identity) rather than from u.Instance /
+// u.Name — the API can return either of those as empty depending on
+// the response shape, and re-deriving here would be redundant.
+func mapSQLUser(u *sqladminv1.User, projectID, instance, name string) *generated.GoogleSqlUser {
+	out := &generated.GoogleSqlUser{}
+	if name != "" {
+		out.Name = generated.LiteralOf(name)
+	}
+	if instance != "" {
+		out.Instance = generated.LiteralOf(instance)
+	}
+	if projectID != "" {
+		out.Project = generated.LiteralOf(projectID)
+	}
+	if u.Host != "" {
+		out.Host = generated.LiteralOf(u.Host)
+	}
+	if u.Type != "" {
+		out.Type_ = generated.LiteralOf(u.Type)
+	}
+	// Password intentionally left nil — see docstring.
+	if u.SqlserverUserDetails != nil {
+		details := generated.GoogleSqlUserSqlServerUserDetails{}
+		if u.SqlserverUserDetails.Disabled {
+			details.Disabled = generated.LiteralOf(true)
+		}
+		if len(u.SqlserverUserDetails.ServerRoles) > 0 {
+			roles := make([]*generated.Value[string], 0, len(u.SqlserverUserDetails.ServerRoles))
+			for _, r := range u.SqlserverUserDetails.ServerRoles {
+				roles = append(roles, generated.LiteralOf(r))
+			}
+			details.ServerRoles = roles
+		}
+		out.SqlServerUserDetails = []generated.GoogleSqlUserSqlServerUserDetails{details}
+	}
+	return out
+}

--- a/cmd/insideout-import/gcpdiscover/sql_user_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/sql_user_enrich.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"google.golang.org/api/googleapi"
 	sqladminv1 "google.golang.org/api/sqladmin/v1"
@@ -18,11 +19,16 @@ import (
 // google_sql_user. Pairs with sqlUserDiscoverer.
 //
 // SQL Admin API quirk: Users.Get takes (project, instance, name) as
-// three positional parameters. The discoverer puts the instance ID into
+// three positional parameters AND a separate optional host query param
+// — the Cloud SQL API distinguishes users by the (name, host) tuple, so
+// two `appuser` rows with different hosts (e.g. `%` vs `10.0.0.1`) are
+// distinct entities. The discoverer puts the instance ID into
 // Identity.NativeIDs["instance"] and the user's short name into
-// Identity.NameHint, so the enricher pulls (project, instance, name)
-// from those slots (or falls back to parsing the ImportID, which
-// follows the <instance>/<host>/<name> or <instance>/<name> shape).
+// Identity.NameHint; host is parsed from the ImportID (provider import
+// shape: <instance>/<host>/<name> or <instance>/<name>). The enricher
+// pulls (project, instance, host, name) from those slots and threads
+// host through to the SDK call via .Host(host) so the Get hits the
+// correct row.
 //
 // Mapping rationale matches the compute_address pattern: computed-only
 // TF attributes (id) are NOT populated per the decision-#5 composer
@@ -33,8 +39,9 @@ import (
 // SqlserverUserDetails only for that flavor).
 type sqlUserEnricher struct {
 	// fetch is overridable for tests. Defaults to a real Users.Get
-	// call against the sqladminv1.Service in EnrichClients.
-	fetch func(ctx context.Context, svc *sqladminv1.Service, project, instance, name string) (*sqladminv1.User, error)
+	// call against the sqladminv1.Service in EnrichClients. host may
+	// be empty (no .Host(...) filter applied).
+	fetch func(ctx context.Context, svc *sqladminv1.Service, project, instance, host, name string) (*sqladminv1.User, error)
 }
 
 func newSQLUserEnricher() AttributeEnricher {
@@ -76,12 +83,12 @@ func (e sqlUserEnricher) fetchTyped(ctx context.Context, id *imported.ResourceId
 	if c.ProjectID == "" {
 		return nil, fmt.Errorf("sql_user: EnrichClients.ProjectID required (sqladmin Users.Get uses project+instance+name positional args)")
 	}
-	instance, name := sqlUserInstanceAndNameForEnrich(id)
+	instance, host, name := sqlUserInstanceHostNameForEnrich(id)
 	if instance == "" || name == "" {
 		return nil, fmt.Errorf("sql_user: cannot derive instance/name from Identity (Address=%q ImportID=%q NameHint=%q NativeIDs.instance=%q)",
 			id.Address, id.ImportID, id.NameHint, id.NativeIDs["instance"])
 	}
-	u, err := e.fetch(ctx, c.SQLAdmin, c.ProjectID, instance, name)
+	u, err := e.fetch(ctx, c.SQLAdmin, c.ProjectID, instance, host, name)
 	if err != nil {
 		if isSQLAdminNotFound(err) {
 			return nil, fmt.Errorf("sql_user: %s/%s/%s: %w", c.ProjectID, instance, name, ErrNotFound)
@@ -96,65 +103,70 @@ func (e sqlUserEnricher) fetchTyped(ctx context.Context, id *imported.ResourceId
 	return raw, nil
 }
 
-// sqlUserInstanceAndNameForEnrich pulls (instance, name) from the
-// Identity. Precedence: NameHint + NativeIDs["instance"], then the
-// ImportID parsed via the <instance>/<host>/<name> or <instance>/<name>
-// provider shape.
-func sqlUserInstanceAndNameForEnrich(id *imported.ResourceIdentity) (string, string) {
-	name := id.NameHint
-	instance := id.NativeIDs["instance"]
-	if name != "" && instance != "" {
-		return instance, name
-	}
+// sqlUserInstanceHostNameForEnrich pulls (instance, host, name) from
+// the Identity. Precedence: NameHint + NativeIDs["instance"] for
+// instance and name; host is parsed from the ImportID when present
+// (the discoverer does not currently populate a NativeIDs["host"]
+// slot, but if it ever does it will take precedence here). The
+// ImportID is also consulted to backfill instance/name when the slots
+// are empty (provider shape: <instance>/<host>/<name> or
+// <instance>/<name>).
+func sqlUserInstanceHostNameForEnrich(id *imported.ResourceIdentity) (instance, host, name string) {
+	name = id.NameHint
+	instance = id.NativeIDs["instance"]
+	host = id.NativeIDs["host"]
 	if id.ImportID != "" {
-		i, n := parseSQLUserImportID(id.ImportID)
+		i, h, n := parseSQLUserImportID(id.ImportID)
 		if instance == "" {
 			instance = i
+		}
+		if host == "" {
+			host = h
 		}
 		if name == "" {
 			name = n
 		}
 	}
-	return instance, name
+	return instance, host, name
 }
 
 // parseSQLUserImportID parses the provider's <instance>/<host>/<name>
-// or <instance>/<name> import shape. Returns ("", "") if the shape
-// doesn't match.
-func parseSQLUserImportID(id string) (instance, name string) {
-	// Strategy: split by "/". 2 segments → instance/name. 3 segments →
-	// instance/host/name.
-	first := 0
-	for i := 0; i < len(id); i++ {
-		if id[i] == '/' {
-			first = i
-			break
-		}
+// or <instance>/<name> import shape. Returns:
+//   - 1 segment  → ("", "", segment)         — treat as bare name with
+//     no instance/host (caller surfaces a "cannot derive instance"
+//     error via the empty-instance guard).
+//   - 2 segments → (instance, "", name)
+//   - 3 segments → (instance, host, name)    — host preserved so the
+//     SDK call can disambiguate same-named users across hosts.
+//
+// Empty strings round-trip — leading/trailing slashes yield empty
+// segments, which the caller's empty-name / empty-instance guard
+// surfaces as a "cannot derive" error.
+func parseSQLUserImportID(id string) (instance, host, name string) {
+	if id == "" {
+		return "", "", ""
 	}
-	if first == 0 {
-		return "", ""
+	parts := strings.SplitN(id, "/", 3)
+	switch len(parts) {
+	case 1:
+		return "", "", parts[0]
+	case 2:
+		return parts[0], "", parts[1]
+	default: // 3
+		return parts[0], parts[1], parts[2]
 	}
-	instance = id[:first]
-	rest := id[first+1:]
-	// Find the LAST slash in rest — name is everything after it; if
-	// no slash, rest is the name directly.
-	last := -1
-	for i := 0; i < len(rest); i++ {
-		if rest[i] == '/' {
-			last = i
-		}
-	}
-	if last < 0 {
-		name = rest
-	} else {
-		name = rest[last+1:]
-	}
-	return instance, name
 }
 
-// defaultSQLUserFetch is the production fetch path.
-func defaultSQLUserFetch(ctx context.Context, svc *sqladminv1.Service, project, instance, name string) (*sqladminv1.User, error) {
-	return svc.Users.Get(project, instance, name).Context(ctx).Do()
+// defaultSQLUserFetch is the production fetch path. host may be empty;
+// when set it is threaded through Users.Get via the Host() option to
+// disambiguate same-named users across hosts (Cloud SQL distinguishes
+// users by (name, host)).
+func defaultSQLUserFetch(ctx context.Context, svc *sqladminv1.Service, project, instance, host, name string) (*sqladminv1.User, error) {
+	call := svc.Users.Get(project, instance, name)
+	if host != "" {
+		call = call.Host(host)
+	}
+	return call.Context(ctx).Do()
 }
 
 // isSQLAdminNotFound reports whether err is a googleapi.Error with

--- a/cmd/insideout-import/gcpdiscover/sql_user_enrich.go
+++ b/cmd/insideout-import/gcpdiscover/sql_user_enrich.go
@@ -3,12 +3,9 @@ package gcpdiscover
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 
-	"google.golang.org/api/googleapi"
 	sqladminv1 "google.golang.org/api/sqladmin/v1"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -90,7 +87,7 @@ func (e sqlUserEnricher) fetchTyped(ctx context.Context, id *imported.ResourceId
 	}
 	u, err := e.fetch(ctx, c.SQLAdmin, c.ProjectID, instance, host, name)
 	if err != nil {
-		if isSQLAdminNotFound(err) {
+		if isGoogleAPINotFound(err) {
 			return nil, fmt.Errorf("sql_user: %s/%s/%s: %w", c.ProjectID, instance, name, ErrNotFound)
 		}
 		return nil, fmt.Errorf("sql_user: get %s/%s/%s: %w", c.ProjectID, instance, name, err)
@@ -167,16 +164,6 @@ func defaultSQLUserFetch(ctx context.Context, svc *sqladminv1.Service, project, 
 		call = call.Host(host)
 	}
 	return call.Context(ctx).Do()
-}
-
-// isSQLAdminNotFound reports whether err is a googleapi.Error with
-// HTTP 404.
-func isSQLAdminNotFound(err error) bool {
-	var gerr *googleapi.Error
-	if errors.As(err, &gerr) {
-		return gerr.Code == http.StatusNotFound
-	}
-	return false
 }
 
 // mapSQLUser converts a *sqladminv1.User into the typed Layer-1

--- a/cmd/insideout-import/gcpdiscover/sql_user_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/sql_user_enrich_test.go
@@ -1,0 +1,222 @@
+package gcpdiscover
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	sqladminv1 "google.golang.org/api/sqladmin/v1"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+func TestSQLUserEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "google_sql_user", newSQLUserEnricher().ResourceType())
+}
+
+func TestSQLUserEnricher_NilClient_ReturnsClientUnavailable(t *testing.T) {
+	t.Parallel()
+	e := newSQLUserEnricher()
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      sqlUserTFType,
+			NameHint:  "appuser",
+			NativeIDs: map[string]string{"instance": "db1"},
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{SQLAdmin: nil, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+	assert.Empty(t, ir.Attrs)
+}
+
+func TestSQLUserEnricher_ProjectIDRequired(t *testing.T) {
+	t.Parallel()
+	e := &sqlUserEnricher{
+		fetch: func(_ context.Context, _ *sqladminv1.Service, _, _, _ string) (*sqladminv1.User, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type: sqlUserTFType, NameHint: "appuser",
+			NativeIDs: map[string]string{"instance": "db1"},
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{SQLAdmin: &sqladminv1.Service{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ProjectID required")
+}
+
+func TestSQLUserEnricher_NotFound_ReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	e := &sqlUserEnricher{
+		fetch: func(_ context.Context, _ *sqladminv1.Service, _, _, _ string) (*sqladminv1.User, error) {
+			return nil, &googleapi.Error{Code: http.StatusNotFound, Message: "not found"}
+		},
+	}
+	id := &imported.ResourceIdentity{
+		Type: sqlUserTFType, NameHint: "appuser",
+		NativeIDs: map[string]string{"instance": "db1"},
+	}
+	raw, err := e.EnrichByID(context.Background(), id, EnrichClients{SQLAdmin: &sqladminv1.Service{}, ProjectID: "p"})
+	require.ErrorIs(t, err, ErrNotFound)
+	assert.Nil(t, raw)
+}
+
+func TestSQLUserEnricher_HappyPath(t *testing.T) {
+	t.Parallel()
+	user := &sqladminv1.User{
+		Host: "%",
+		Type: "BUILT_IN",
+		// Password should NOT propagate even when set on the API
+		// (it never does in practice, but defend in depth).
+		Password: "secret",
+	}
+	e := &sqlUserEnricher{
+		fetch: func(_ context.Context, _ *sqladminv1.Service, project, instance, name string) (*sqladminv1.User, error) {
+			assert.Equal(t, "my-project", project)
+			assert.Equal(t, "db1", instance)
+			assert.Equal(t, "appuser", name)
+			return user, nil
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type: sqlUserTFType, NameHint: "appuser",
+			NativeIDs: map[string]string{"instance": "db1"},
+		},
+	}
+	require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{SQLAdmin: &sqladminv1.Service{}, ProjectID: "my-project"}))
+
+	decoded, err := generated.UnmarshalAttrs("google_sql_user", ir.Attrs)
+	require.NoError(t, err)
+	su, ok := decoded.(*generated.GoogleSqlUser)
+	require.True(t, ok)
+	require.NotNil(t, su.Name)
+	assert.Equal(t, "appuser", *su.Name.Literal)
+	require.NotNil(t, su.Instance)
+	assert.Equal(t, "db1", *su.Instance.Literal)
+	require.NotNil(t, su.Project)
+	assert.Equal(t, "my-project", *su.Project.Literal)
+	require.NotNil(t, su.Host)
+	assert.Equal(t, "%", *su.Host.Literal)
+	require.NotNil(t, su.Type_)
+	assert.Equal(t, "BUILT_IN", *su.Type_.Literal)
+	assert.Nil(t, su.Password, "password must be stripped on enrich")
+}
+
+func TestSQLUserEnricher_EnrichByID_MirrorsEnrich(t *testing.T) {
+	t.Parallel()
+	user := &sqladminv1.User{Host: "%", Type: "BUILT_IN"}
+	mkFetch := func() func(context.Context, *sqladminv1.Service, string, string, string) (*sqladminv1.User, error) {
+		return func(_ context.Context, _ *sqladminv1.Service, _, _, _ string) (*sqladminv1.User, error) {
+			return user, nil
+		}
+	}
+	enrichE := &sqlUserEnricher{fetch: mkFetch()}
+	byIDE := &sqlUserEnricher{fetch: mkFetch()}
+
+	id := imported.ResourceIdentity{
+		Type: sqlUserTFType, NameHint: "appuser",
+		NativeIDs: map[string]string{"instance": "db1"},
+	}
+	ir := &imported.ImportedResource{Identity: id}
+	require.NoError(t, enrichE.Enrich(context.Background(), ir, EnrichClients{SQLAdmin: &sqladminv1.Service{}, ProjectID: "p"}))
+
+	raw, err := byIDE.EnrichByID(context.Background(), &id, EnrichClients{SQLAdmin: &sqladminv1.Service{}, ProjectID: "p"})
+	require.NoError(t, err)
+	assert.JSONEq(t, string(ir.Attrs), string(raw))
+}
+
+func TestSQLUserEnricher_DerivesFromImportID(t *testing.T) {
+	t.Parallel()
+	var gotInstance, gotName string
+	e := &sqlUserEnricher{
+		fetch: func(_ context.Context, _ *sqladminv1.Service, _, instance, name string) (*sqladminv1.User, error) {
+			gotInstance, gotName = instance, name
+			return &sqladminv1.User{}, nil
+		},
+	}
+	for _, tc := range []struct {
+		name        string
+		importID    string
+		wantInst    string
+		wantUser    string
+	}{
+		{"instance/host/name", "db1/%/appuser", "db1", "appuser"},
+		{"instance/name", "db1/appuser", "db1", "appuser"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			id := &imported.ResourceIdentity{
+				Type:     sqlUserTFType,
+				ImportID: tc.importID,
+			}
+			_, err := e.EnrichByID(context.Background(), id, EnrichClients{SQLAdmin: &sqladminv1.Service{}, ProjectID: "p"})
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantInst, gotInstance)
+			assert.Equal(t, tc.wantUser, gotName)
+		})
+	}
+}
+
+func TestSQLUserEnricher_NilIdentity(t *testing.T) {
+	t.Parallel()
+	e := newSQLUserEnricher().(*sqlUserEnricher)
+	raw, err := e.EnrichByID(context.Background(), nil, EnrichClients{SQLAdmin: &sqladminv1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Nil(t, raw)
+	assert.Contains(t, err.Error(), "nil identity")
+}
+
+func TestSQLUserEnricher_NonNotFoundErrorPassesThrough(t *testing.T) {
+	t.Parallel()
+	upstream := &googleapi.Error{Code: http.StatusForbidden, Message: "denied"}
+	e := &sqlUserEnricher{
+		fetch: func(_ context.Context, _ *sqladminv1.Service, _, _, _ string) (*sqladminv1.User, error) {
+			return nil, upstream
+		},
+	}
+	id := &imported.ResourceIdentity{Type: sqlUserTFType, NameHint: "u", NativeIDs: map[string]string{"instance": "db1"}}
+	_, err := e.EnrichByID(context.Background(), id, EnrichClients{SQLAdmin: &sqladminv1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound)
+	var gerr *googleapi.Error
+	require.True(t, errors.As(err, &gerr))
+	assert.Equal(t, http.StatusForbidden, gerr.Code)
+}
+
+func TestMapSQLUser_SqlServerDetails(t *testing.T) {
+	t.Parallel()
+	got := mapSQLUser(&sqladminv1.User{
+		SqlserverUserDetails: &sqladminv1.SqlServerUserDetails{
+			Disabled:    true,
+			ServerRoles: []string{"sysadmin", "dbcreator"},
+		},
+	}, "p", "db1", "u")
+	require.Len(t, got.SqlServerUserDetails, 1)
+	require.NotNil(t, got.SqlServerUserDetails[0].Disabled)
+	assert.True(t, *got.SqlServerUserDetails[0].Disabled.Literal)
+	require.Len(t, got.SqlServerUserDetails[0].ServerRoles, 2)
+	assert.Equal(t, "sysadmin", *got.SqlServerUserDetails[0].ServerRoles[0].Literal)
+}
+
+func TestSQLUserEnricher_CannotDeriveInstanceOrName(t *testing.T) {
+	t.Parallel()
+	e := &sqlUserEnricher{
+		fetch: func(_ context.Context, _ *sqladminv1.Service, _, _, _ string) (*sqladminv1.User, error) {
+			t.Fatal("fetch must not be called")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{Type: sqlUserTFType}}
+	err := e.Enrich(context.Background(), ir, EnrichClients{SQLAdmin: &sqladminv1.Service{}, ProjectID: "p"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive instance/name")
+}

--- a/cmd/insideout-import/gcpdiscover/sql_user_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/sql_user_enrich_test.go
@@ -38,7 +38,7 @@ func TestSQLUserEnricher_NilClient_ReturnsClientUnavailable(t *testing.T) {
 func TestSQLUserEnricher_ProjectIDRequired(t *testing.T) {
 	t.Parallel()
 	e := &sqlUserEnricher{
-		fetch: func(_ context.Context, _ *sqladminv1.Service, _, _, _ string) (*sqladminv1.User, error) {
+		fetch: func(_ context.Context, _ *sqladminv1.Service, _, _, _, _ string) (*sqladminv1.User, error) {
 			t.Fatal("fetch must not be called")
 			return nil, nil
 		},
@@ -57,7 +57,7 @@ func TestSQLUserEnricher_ProjectIDRequired(t *testing.T) {
 func TestSQLUserEnricher_NotFound_ReturnsErrNotFound(t *testing.T) {
 	t.Parallel()
 	e := &sqlUserEnricher{
-		fetch: func(_ context.Context, _ *sqladminv1.Service, _, _, _ string) (*sqladminv1.User, error) {
+		fetch: func(_ context.Context, _ *sqladminv1.Service, _, _, _, _ string) (*sqladminv1.User, error) {
 			return nil, &googleapi.Error{Code: http.StatusNotFound, Message: "not found"}
 		},
 	}
@@ -80,10 +80,13 @@ func TestSQLUserEnricher_HappyPath(t *testing.T) {
 		Password: "secret",
 	}
 	e := &sqlUserEnricher{
-		fetch: func(_ context.Context, _ *sqladminv1.Service, project, instance, name string) (*sqladminv1.User, error) {
+		fetch: func(_ context.Context, _ *sqladminv1.Service, project, instance, host, name string) (*sqladminv1.User, error) {
 			assert.Equal(t, "my-project", project)
 			assert.Equal(t, "db1", instance)
 			assert.Equal(t, "appuser", name)
+			// No NativeIDs.host or ImportID host segment provided →
+			// fetch host stays empty.
+			assert.Empty(t, host)
 			return user, nil
 		},
 	}
@@ -115,8 +118,8 @@ func TestSQLUserEnricher_HappyPath(t *testing.T) {
 func TestSQLUserEnricher_EnrichByID_MirrorsEnrich(t *testing.T) {
 	t.Parallel()
 	user := &sqladminv1.User{Host: "%", Type: "BUILT_IN"}
-	mkFetch := func() func(context.Context, *sqladminv1.Service, string, string, string) (*sqladminv1.User, error) {
-		return func(_ context.Context, _ *sqladminv1.Service, _, _, _ string) (*sqladminv1.User, error) {
+	mkFetch := func() func(context.Context, *sqladminv1.Service, string, string, string, string) (*sqladminv1.User, error) {
+		return func(_ context.Context, _ *sqladminv1.Service, _, _, _, _ string) (*sqladminv1.User, error) {
 			return user, nil
 		}
 	}
@@ -137,23 +140,26 @@ func TestSQLUserEnricher_EnrichByID_MirrorsEnrich(t *testing.T) {
 
 func TestSQLUserEnricher_DerivesFromImportID(t *testing.T) {
 	t.Parallel()
-	var gotInstance, gotName string
+	var gotInstance, gotHost, gotName string
 	e := &sqlUserEnricher{
-		fetch: func(_ context.Context, _ *sqladminv1.Service, _, instance, name string) (*sqladminv1.User, error) {
-			gotInstance, gotName = instance, name
+		fetch: func(_ context.Context, _ *sqladminv1.Service, _, instance, host, name string) (*sqladminv1.User, error) {
+			gotInstance, gotHost, gotName = instance, host, name
 			return &sqladminv1.User{}, nil
 		},
 	}
 	for _, tc := range []struct {
-		name        string
-		importID    string
-		wantInst    string
-		wantUser    string
+		name     string
+		importID string
+		wantInst string
+		wantHost string
+		wantUser string
 	}{
-		{"instance/host/name", "db1/%/appuser", "db1", "appuser"},
-		{"instance/name", "db1/appuser", "db1", "appuser"},
+		{"instance/host/name", "db1/%/appuser", "db1", "%", "appuser"},
+		{"instance/name", "db1/appuser", "db1", "", "appuser"},
+		{"instance/specifichost/name", "db1/10.0.0.1/appuser", "db1", "10.0.0.1", "appuser"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			gotInstance, gotHost, gotName = "", "", ""
 			id := &imported.ResourceIdentity{
 				Type:     sqlUserTFType,
 				ImportID: tc.importID,
@@ -161,7 +167,34 @@ func TestSQLUserEnricher_DerivesFromImportID(t *testing.T) {
 			_, err := e.EnrichByID(context.Background(), id, EnrichClients{SQLAdmin: &sqladminv1.Service{}, ProjectID: "p"})
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantInst, gotInstance)
+			assert.Equal(t, tc.wantHost, gotHost, "host must be preserved across the SDK call so users on different hosts don't collide")
 			assert.Equal(t, tc.wantUser, gotName)
+		})
+	}
+}
+
+func TestParseSQLUserImportID(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name                            string
+		in                              string
+		wantInst, wantHost, wantName    string
+	}{
+		{"empty", "", "", "", ""},
+		{"single segment treated as bare name", "appuser", "", "", "appuser"},
+		{"two segments", "db1/appuser", "db1", "", "appuser"},
+		{"three segments preserve host", "db1/%/appuser", "db1", "%", "appuser"},
+		{"three segments specific host", "db1/10.0.0.1/appuser", "db1", "10.0.0.1", "appuser"},
+		{"leading slash yields empty instance", "/appuser", "", "", "appuser"},
+		{"trailing slash yields empty name", "db1/appuser/", "db1", "appuser", ""},
+		{"three segments preserve embedded slashes via SplitN", "db1/host/name/with/extra", "db1", "host", "name/with/extra"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			instance, host, name := parseSQLUserImportID(tc.in)
+			assert.Equal(t, tc.wantInst, instance)
+			assert.Equal(t, tc.wantHost, host)
+			assert.Equal(t, tc.wantName, name)
 		})
 	}
 }
@@ -179,7 +212,7 @@ func TestSQLUserEnricher_NonNotFoundErrorPassesThrough(t *testing.T) {
 	t.Parallel()
 	upstream := &googleapi.Error{Code: http.StatusForbidden, Message: "denied"}
 	e := &sqlUserEnricher{
-		fetch: func(_ context.Context, _ *sqladminv1.Service, _, _, _ string) (*sqladminv1.User, error) {
+		fetch: func(_ context.Context, _ *sqladminv1.Service, _, _, _, _ string) (*sqladminv1.User, error) {
 			return nil, upstream
 		},
 	}
@@ -210,7 +243,7 @@ func TestMapSQLUser_SqlServerDetails(t *testing.T) {
 func TestSQLUserEnricher_CannotDeriveInstanceOrName(t *testing.T) {
 	t.Parallel()
 	e := &sqlUserEnricher{
-		fetch: func(_ context.Context, _ *sqladminv1.Service, _, _, _ string) (*sqladminv1.User, error) {
+		fetch: func(_ context.Context, _ *sqladminv1.Service, _, _, _, _ string) (*sqladminv1.User, error) {
 			t.Fatal("fetch must not be called")
 			return nil, nil
 		},

--- a/cmd/insideout-import/gcpdiscover/sql_user_enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/sql_user_enrich_test.go
@@ -176,9 +176,9 @@ func TestSQLUserEnricher_DerivesFromImportID(t *testing.T) {
 func TestParseSQLUserImportID(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
-		name                            string
-		in                              string
-		wantInst, wantHost, wantName    string
+		name                         string
+		in                           string
+		wantInst, wantHost, wantName string
 	}{
 		{"empty", "", "", "", ""},
 		{"single segment treated as bare name", "appuser", "", "", "appuser"},

--- a/pkg/imported/gcp/provider_test.go
+++ b/pkg/imported/gcp/provider_test.go
@@ -55,9 +55,9 @@ func TestProvider_Capabilities_Enrichable(t *testing.T) {
 	if got := p.Capabilities("google_storage_bucket"); !got.Enrichable {
 		t.Errorf("google_storage_bucket: Enrichable should be true, got %+v", got)
 	}
-	// google_sql_user is in the registry but no enricher.
-	if got := p.Capabilities("google_sql_user"); got.Enrichable {
-		t.Errorf("google_sql_user: Enrichable should be false, got %+v", got)
+	// google_project_iam_member is in the registry but no enricher.
+	if got := p.Capabilities("google_project_iam_member"); got.Enrichable {
+		t.Errorf("google_project_iam_member: Enrichable should be false, got %+v", got)
 	}
 }
 
@@ -198,7 +198,7 @@ func TestProvider_EnrichByID_NoEnricher(t *testing.T) {
 	d := gcpdiscover.NewGCPDiscoverer(nil, "test-project", gcpdiscover.GCPDiscovererOpts{})
 	p := gcpprov.NewProvider(d, nil)
 
-	id := &composerimported.ResourceIdentity{Type: "google_sql_user", ImportID: "u/v"}
+	id := &composerimported.ResourceIdentity{Type: "google_project_iam_member", ImportID: "p roles/x"}
 	_, err := p.EnrichByID(context.Background(), id, imp.Clients{GCP: gcpprov.Clients{}})
 	if !errors.Is(err, imp.ErrEnrichByIDNotImplemented) {
 		t.Errorf("EnrichByID for non-enriched type: err = %v, want ErrEnrichByIDNotImplemented", err)


### PR DESCRIPTION
## Summary

Adds 6 hand-rolled GCP enrichers, mirroring Bundle G5's pattern:

- `google_sql_user` (sqladmin/v1)
- `google_logging_project_sink` (logging/v2)
- `google_identity_platform_config` (identitytoolkit/v2)
- `google_monitoring_alert_policy` (monitoring/v3)
- `google_monitoring_dashboard` (monitoring/v1 — dashboards live in v1, NOT v3)
- `google_monitoring_notification_channel` (monitoring/v3)

All implement both `AttributeEnricher` and `ByIDEnricher`. Function-field test injection, soft-fail overlays, `goog-*` label filtering — same shape as G5.

## Coverage delta

- GCP enrichable: **30/54 (56%) → 36/54 (67%)**
- Combined with PR #505 (Bundle G5, 5 hand-rolled) once it lands: 41/54 (76%).

The 90% target requires Layer-1 codegen expansion + additional hand-rolling (~15 more types per cloud). Tracked separately.

## EnrichClients additions

- `SQLAdmin *sqladminv1.Service`
- `Logging *loggingv2.Service`
- `IdentityToolkit *identitytoolkitv2.Service`
- `Monitoring *monitoringv3.Service`
- `MonitoringV1 *monitoringv1.Service` (used for dashboards — v1 schema is disjoint from v3)

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/insideout-import/gcpdiscover/... -count=1` (912 tests)
- [x] `go test ./pkg/composer/imported/... -count=1 -short` (374 tests)
- [x] `go test ./... -count=1 -short`
- [x] SUPPORTED_RESOURCES.md regen reflects 67%

## Partial mapping caveats (documented inline)

- `google_identity_platform_config` — deep SignIn/Notification/Mfa subtrees left for follow-up
- `google_monitoring_alert_policy` — conditions block mapped at display_name level; full condition tree (threshold/MQL/PromQL) is rarely needed for import
- `google_sql_user` — `password` stripped (API never echoes; user re-supplies on apply)
- `google_monitoring_dashboard` — layout serialized to `dashboard_json` string (matches provider read behavior)

## /review pass — fixes applied in this PR

**P1 (must-fix, all addressed):**
- sql_user host preservation: parser now returns `(instance, host, name)` and the fetch threads host through Users.Get via `.Host(host)` so same-named users across hosts (e.g. `%` vs `10.0.0.1`) don't collide.
- sql_user parser rewrite: replaced index-arithmetic with `strings.SplitN(id, "/", 3)`; added edge-case table-driven coverage (empty input, leading/trailing slash, embedded slashes).
- monitoring_dashboard pointer aliasing: switched from `clone := *d` (which shares pointer-valued layout fields) to a JSON round-trip via `map[string]json.RawMessage` so the inner-dashboard JSON is fully decoupled from the SDK response.
- identity_platform_config project mismatch guard: fetchTyped now surfaces a clear error when `Identity.ImportID` and `Clients.ProjectID` disagree instead of silently fetching the wrong project's singleton.

**P2 drive-bys (small/localized fixes applied):**
- Centralized `isGoogleAPINotFound` helper in `api_errors.go`; migrated the 6 G6 enrichers off their per-service duplicates.
- Renamed `EnrichClients.MonitoringDashboard` → `MonitoringV1` with an inline comment clarifying the v1/v3 SDK split.
- notification-channel labels doc-comment: spells out decision #36 (sensitive value redaction is the emitter's job, not the enricher's).

## Deferred follow-ups

- **P2 monitoring_alert_policy conditions partial coverage** — substantive work to map the full condition tree (threshold / MQL / PromQL / metric-absence) is out-of-scope for this PR; tracked as a Layer-1 codegen expansion task.
- **P2 marshal-error test branches / EnrichByID-precedence tests / SignIn full coverage list** — low-value additions; deferred unless QA surfaces a need.
- **Migrate older enrichers off per-service `is*NotFound` helpers** — `api_errors.go` is in place; older enricher files (compute_address, pubsub_topic, etc.) still ship their own duplicates and can be migrated in a follow-up commit.
- **P3 nits** — all deferred as low-value follow-ups.

Refs #482 (Phase 2 capstone target).
