### PR TITLE
feat(imported): enrich AgentContext with per-type policy blocks

### DIFF
--- a/pkg/imported/agentcontext.go
+++ b/pkg/imported/agentcontext.go
@@ -80,7 +80,13 @@ func RenderAgentContext(irs []composerimported.ImportedResource) []string {
 			continue
 		}
 		lines = append(lines, fmt.Sprintf("== Imported.%s ==", tfType))
-		lines = append(lines, typeBlock)
+		// typeBlock is a pre-joined multi-line string from
+		// buildTypeBlock. Split it so each output entry is
+		// genuinely a single line — callers strings.Join'ing with
+		// "\n" still produce the same result, but downstream
+		// consumers iterating line-by-line don't get surprised by
+		// embedded newlines.
+		lines = append(lines, strings.Split(typeBlock, "\n")...)
 		lines = append(lines, "instances:")
 		lines = append(lines, renderInstanceLines(tfType, instances)...)
 		lines = append(lines, "== End ==")
@@ -104,9 +110,12 @@ var (
 
 // ResetAgentContextCacheForTest clears the type-block cache. Test-only;
 // exported so per-cloud or cross-package tests that pin exact block
-// content can ensure a fresh build. Not safe for production hot paths
-// — concurrent reads during reset race against ongoing renders, which
-// is acceptable for a test seam but would corrupt a live cache.
+// content can ensure a fresh build. Holds the write lock for the
+// duration so individual ops are sequenced — but in-flight renders
+// that already passed the cache check will race their writes against
+// the cleared state, which is acceptable for a test seam (tests
+// don't issue concurrent loads against a freshly reset cache) and
+// would not be acceptable in a live cache.
 func ResetAgentContextCacheForTest() {
 	typeBlockMu.Lock()
 	defer typeBlockMu.Unlock()
@@ -116,12 +125,15 @@ func ResetAgentContextCacheForTest() {
 // groupByType buckets the imported list by ResourceIdentity.Type and
 // stably sorts each bucket's instances by Address. Entries with an
 // empty type are dropped — they correspond to malformed import rows
-// (the per-cloud importer always populates Type).
+// (the per-cloud importer always populates Type). Drops are logged
+// so a malformed row doesn't silently vanish from the prompt.
 func groupByType(irs []composerimported.ImportedResource) map[string][]composerimported.ImportedResource {
 	out := map[string][]composerimported.ImportedResource{}
 	for _, ir := range irs {
 		t := strings.TrimSpace(ir.Identity.Type)
 		if t == "" {
+			log.Printf("[imported/agentctx] groupByType: dropping IR with empty Identity.Type address=%q",
+				ir.Identity.Address)
 			continue
 		}
 		out[t] = append(out[t], ir)
@@ -137,6 +149,14 @@ func groupByType(irs []composerimported.ImportedResource) map[string][]composeri
 // getOrBuildTypeBlock returns the cached per-type policy summary,
 // building it on first request. Returns "" when no policy is registered
 // for the type — callers drop the block entirely in that case.
+//
+// Concurrent first-misses for the same type may each call
+// buildTypeBlock and then both write the result back — deliberately
+// tolerated. buildTypeBlock is pure over the registered policy map
+// (which policy.Register treats as immutable), so the two computed
+// results are bit-identical and the second write is a no-op semantically.
+// Trading rare duplicate work for a simpler locking shape than a
+// per-key sync.Once / single-flight.
 func getOrBuildTypeBlock(tfType string) string {
 	typeBlockMu.RLock()
 	if cached, ok := typeBlockCache[tfType]; ok {
@@ -211,24 +231,18 @@ func buildTypeBlock(tfType string) string {
 	}
 
 	// Invariant audit: the policy map promises Visible ∪ SystemOwned
-	// covers every curated path. Without this loop a path that was
+	// covers every curated path. Without this check a path that was
 	// curated but landed in neither bucket above (e.g. an illegal
 	// Hidden + EditChatSafe combination if policy drifts) would be
 	// silently lost from the prompt. Log noisily if any are seen.
-	for path := range polMap {
-		seen := false
-		for _, l := range [][]string{editableChatSafe, editableApproval, readOnly, systemOwned} {
-			for _, p := range l {
-				if p == path {
-					seen = true
-					break
-				}
-			}
-			if seen {
-				break
-			}
+	bucketed := make(map[string]bool, len(polMap))
+	for _, l := range [][]string{editableChatSafe, editableApproval, readOnly, systemOwned} {
+		for _, p := range l {
+			bucketed[p] = true
 		}
-		if !seen {
+	}
+	for path := range polMap {
+		if !bucketed[path] {
 			log.Printf("[imported/agentctx] path=%q in type=%q is curated but not bucketed — policy invariant drift? omitting from prompt", path, tfType)
 		}
 	}
@@ -278,6 +292,7 @@ func renderInstanceLines(tfType string, instances []composerimported.ImportedRes
 	for _, ir := range instances {
 		address := strings.TrimSpace(ir.Identity.Address)
 		if address == "" {
+			log.Printf("[imported/agentctx] renderInstanceLines: dropping IR with empty Address type=%s", tfType)
 			continue
 		}
 		lines = append(lines, fmt.Sprintf("  %s:", address))
@@ -314,10 +329,18 @@ func renderInstanceLines(tfType string, instances []composerimported.ImportedRes
 // falls back to ir.Attributes (the Phase-1 opaque bag) so legacy
 // fixtures still project. Returns an empty map (not nil) when both
 // are absent so callers can pass it through unchecked.
+//
+// A malformed Attrs payload is logged and degraded to the legacy
+// fallback rather than swallowed silently — production breakage in
+// the typed-payload writer should be visible to operators even
+// though the renderer keeps going.
 func decodeAttrs(ir composerimported.ImportedResource) map[string]any {
 	if len(ir.Attrs) > 0 {
 		var typed map[string]any
-		if err := json.Unmarshal(ir.Attrs, &typed); err == nil && typed != nil {
+		if err := json.Unmarshal(ir.Attrs, &typed); err != nil {
+			log.Printf("[imported/agentctx] decodeAttrs unmarshal err address=%s type=%s: %v — falling back to legacy Attributes",
+				ir.Identity.Address, ir.Identity.Type, err)
+		} else if typed != nil {
 			return typed
 		}
 	}

--- a/pkg/imported/agentcontext.go
+++ b/pkg/imported/agentcontext.go
@@ -1,0 +1,346 @@
+package imported
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"sync"
+
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+)
+
+// RenderAgentContext is the shared cross-cloud renderer used by per-cloud
+// Provider.AgentContext implementations to produce the per-Terraform-type
+// policy block + per-instance value rows an interactive agent reads at
+// chat-context build time. See issue #517 for the design rationale —
+// upstream consumers (luthersystems/reliable, umbrella #1479) previously
+// carried this rendering downstream; moving it here makes
+// Provider.AgentContext a true drop-in.
+//
+// Output shape, per registered type, in stable type-name order:
+//
+//	== Imported.<type> ==
+//	editable_chat_safe: [<paths>]
+//	editable_with_approval: [<paths>]
+//	read_only: [<paths>]
+//	system_owned: [<paths>]
+//	# sensitive fields omitted entirely
+//	instances:
+//	  <address>:
+//	    project: <project>           // identity slot, GCP-style
+//	    location: <location>         // identity slot
+//	    <path>: <current-value>      // per VisibleFieldsFor projection
+//	    ...
+//	== End ==
+//
+// Sort order:
+//   - Outer: Terraform type ascending.
+//   - Inner: Identity.Address ascending within each type.
+//
+// Unregistered types (no policy registered in
+// pkg/composer/imported/policy) are skipped — emitting a half-rendered
+// block with no policy summary would teach the agent nothing while
+// burning context tokens. A log line is emitted per skipped type so
+// the omission is traceable in production.
+//
+// Empty input returns nil. Callers compose this into a larger context
+// section and elide the section header when the slice is empty.
+//
+// Provenance gating (filtering IRs to only those owned by the current
+// import project) is NOT this helper's concern — callers filter before
+// calling. This helper assumes its input is already the agent-visible
+// set.
+func RenderAgentContext(irs []composerimported.ImportedResource) []string {
+	if len(irs) == 0 {
+		return nil
+	}
+	byType := groupByType(irs)
+	if len(byType) == 0 {
+		return nil
+	}
+
+	types := make([]string, 0, len(byType))
+	for t := range byType {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+
+	var lines []string
+	for _, tfType := range types {
+		instances := byType[tfType]
+		typeBlock := getOrBuildTypeBlock(tfType)
+		if typeBlock == "" {
+			// Unregistered type — no policy curated, no edit grammar
+			// to teach. Skip rather than emit a half-context block.
+			log.Printf("[imported/agentctx] no policy registered for type=%s — skipping (%d instances dropped from prompt)",
+				tfType, len(instances))
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("== Imported.%s ==", tfType))
+		lines = append(lines, typeBlock)
+		lines = append(lines, "instances:")
+		lines = append(lines, renderInstanceLines(tfType, instances)...)
+		lines = append(lines, "== End ==")
+	}
+	return lines
+}
+
+// typeBlockCache memoises rendered per-type policy summaries. The key
+// is the Terraform type name; the registered policy map is treated as
+// immutable for the process lifetime (policy.Register panics on
+// duplicate Register), so a single entry per type is correct.
+//
+// A future schema bump in pkg/composer/imported/policy invalidates this
+// cache only on a redeploy of the binary — the policy package is a
+// compile-time dependency, so cache resets across deploys naturally.
+// No runtime invalidation hook needed.
+var (
+	typeBlockMu    sync.RWMutex
+	typeBlockCache = map[string]string{}
+)
+
+// ResetAgentContextCacheForTest clears the type-block cache. Test-only;
+// exported so per-cloud or cross-package tests that pin exact block
+// content can ensure a fresh build. Not safe for production hot paths
+// — concurrent reads during reset race against ongoing renders, which
+// is acceptable for a test seam but would corrupt a live cache.
+func ResetAgentContextCacheForTest() {
+	typeBlockMu.Lock()
+	defer typeBlockMu.Unlock()
+	typeBlockCache = map[string]string{}
+}
+
+// groupByType buckets the imported list by ResourceIdentity.Type and
+// stably sorts each bucket's instances by Address. Entries with an
+// empty type are dropped — they correspond to malformed import rows
+// (the per-cloud importer always populates Type).
+func groupByType(irs []composerimported.ImportedResource) map[string][]composerimported.ImportedResource {
+	out := map[string][]composerimported.ImportedResource{}
+	for _, ir := range irs {
+		t := strings.TrimSpace(ir.Identity.Type)
+		if t == "" {
+			continue
+		}
+		out[t] = append(out[t], ir)
+	}
+	for t := range out {
+		sort.Slice(out[t], func(i, j int) bool {
+			return out[t][i].Identity.Address < out[t][j].Identity.Address
+		})
+	}
+	return out
+}
+
+// getOrBuildTypeBlock returns the cached per-type policy summary,
+// building it on first request. Returns "" when no policy is registered
+// for the type — callers drop the block entirely in that case.
+func getOrBuildTypeBlock(tfType string) string {
+	typeBlockMu.RLock()
+	if cached, ok := typeBlockCache[tfType]; ok {
+		typeBlockMu.RUnlock()
+		return cached
+	}
+	typeBlockMu.RUnlock()
+
+	built := buildTypeBlock(tfType)
+
+	typeBlockMu.Lock()
+	typeBlockCache[tfType] = built
+	typeBlockMu.Unlock()
+	return built
+}
+
+// buildTypeBlock renders the per-type policy summary used inside each
+// == Imported.<type> == block. Four buckets, corresponding to the four
+// classes an interactive agent needs to reason about:
+//
+//   - editable_chat_safe: ChatSafe + RelationshipOnly fields the agent
+//     may write through. RelationshipOnly is included because the agent
+//     can't scalar-edit it but should see it for graph reasoning —
+//     wiring intent rides through a different write path.
+//   - editable_with_approval: RequiresApproval fields the agent should
+//     describe but NOT write directly — human confirmation required.
+//   - read_only: Identity / EditNever fields the agent can reference
+//     but cannot change.
+//   - system_owned: Visibility=Hidden / EditSystemOnly fields the
+//     agent should not surface at all (logged for prompt-stack
+//     auditing only).
+//
+// Sensitive fields (Sensitivity=SensitivitySensitive after schema
+// resolution) are omitted from all four buckets — the agent never
+// sees them. If a user asks about a sensitive field, the agent says
+// it can't see that data.
+func buildTypeBlock(tfType string) string {
+	polMap, ok := policy.Lookup(tfType)
+	if !ok {
+		return ""
+	}
+	// Empty attrs map: we only want the policy labels, not resolved
+	// values. The projection helpers walk paths against attrs to
+	// fill CurrentValue; an empty map gives us label-only views.
+	emptyAttrs := map[string]any{}
+
+	editableChatSafe := []string{}
+	editableApproval := []string{}
+	readOnly := []string{}
+	systemOwned := []string{}
+
+	for _, fv := range policy.EditableFieldsFor(tfType, emptyAttrs) {
+		switch fv.Edit {
+		case policy.EditChatSafe, policy.EditRelationshipOnly:
+			editableChatSafe = append(editableChatSafe, fv.Path)
+		case policy.EditRequiresApproval:
+			editableApproval = append(editableApproval, fv.Path)
+		}
+	}
+	for _, fv := range policy.VisibleFieldsFor(tfType, emptyAttrs) {
+		if fv.Edit == policy.EditNever {
+			readOnly = append(readOnly, fv.Path)
+		}
+	}
+	for _, fv := range policy.SystemOwnedFieldsFor(tfType, emptyAttrs) {
+		// Skip sensitive entries — omitted entirely from the
+		// agent's context per the slice decision.
+		if fv.Sensitivity == policy.SensitivitySensitive {
+			continue
+		}
+		systemOwned = append(systemOwned, fv.Path)
+	}
+
+	// Invariant audit: the policy map promises Visible ∪ SystemOwned
+	// covers every curated path. Without this loop a path that was
+	// curated but landed in neither bucket above (e.g. an illegal
+	// Hidden + EditChatSafe combination if policy drifts) would be
+	// silently lost from the prompt. Log noisily if any are seen.
+	for path := range polMap {
+		seen := false
+		for _, l := range [][]string{editableChatSafe, editableApproval, readOnly, systemOwned} {
+			for _, p := range l {
+				if p == path {
+					seen = true
+					break
+				}
+			}
+			if seen {
+				break
+			}
+		}
+		if !seen {
+			log.Printf("[imported/agentctx] path=%q in type=%q is curated but not bucketed — policy invariant drift? omitting from prompt", path, tfType)
+		}
+	}
+
+	sort.Strings(editableChatSafe)
+	sort.Strings(editableApproval)
+	sort.Strings(readOnly)
+	sort.Strings(systemOwned)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "editable_chat_safe: %s\n", fmtFieldList(editableChatSafe))
+	fmt.Fprintf(&b, "editable_with_approval: %s\n", fmtFieldList(editableApproval))
+	fmt.Fprintf(&b, "read_only: %s\n", fmtFieldList(readOnly))
+	fmt.Fprintf(&b, "system_owned: %s\n", fmtFieldList(systemOwned))
+	b.WriteString("# sensitive fields omitted entirely\n")
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// fmtFieldList renders a sorted field list as a bracketed comma-list.
+// Empty input renders as "[]" so the slot is always visible — the
+// agent reading the prompt sees the policy boundary explicitly rather
+// than inferring it from absence.
+func fmtFieldList(fields []string) string {
+	if len(fields) == 0 {
+		return "[]"
+	}
+	return "[" + strings.Join(fields, ", ") + "]"
+}
+
+// renderInstanceLines renders one indented block per imported resource
+// instance under the type's `instances:` slot. Each block shows the
+// canonical address + a compact value listing filtered through
+// policy.VisibleFieldsFor (identity + observable read-only fields +
+// current editable values — sensitive already filtered by the
+// projection layer).
+//
+// CurrentValue is rendered via JSON marshaling for stable formatting
+// across scalar / list / map shapes. nil values are skipped — they
+// represent paths that exist in the curated policy but aren't present
+// in this instance's attrs (e.g. unset versioning block).
+//
+// The project + location identity slots are printed before the
+// projected fields and deduped via the seen map so a policy path
+// named "project" or "location" doesn't double-print.
+func renderInstanceLines(tfType string, instances []composerimported.ImportedResource) []string {
+	var lines []string
+	for _, ir := range instances {
+		address := strings.TrimSpace(ir.Identity.Address)
+		if address == "" {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("  %s:", address))
+
+		if pid := strings.TrimSpace(ir.Identity.ProjectID); pid != "" {
+			lines = append(lines, fmt.Sprintf("    project: %s", pid))
+		}
+		if loc := strings.TrimSpace(ir.Identity.Location); loc != "" {
+			lines = append(lines, fmt.Sprintf("    location: %s", loc))
+		}
+
+		attrs := decodeAttrs(ir)
+		seen := map[string]bool{
+			"project":  true, // already printed via identity above
+			"location": true,
+		}
+		for _, fv := range policy.VisibleFieldsFor(tfType, attrs) {
+			if seen[fv.Path] {
+				continue
+			}
+			seen[fv.Path] = true
+			val := renderFieldValue(fv.CurrentValue)
+			if val == "" {
+				continue
+			}
+			lines = append(lines, fmt.Sprintf("    %s: %s", fv.Path, val))
+		}
+	}
+	return lines
+}
+
+// decodeAttrs returns the attribute map used for policy projection.
+// Prefers ir.Attrs (the typed Layer-1 JSON payload) when present;
+// falls back to ir.Attributes (the Phase-1 opaque bag) so legacy
+// fixtures still project. Returns an empty map (not nil) when both
+// are absent so callers can pass it through unchecked.
+func decodeAttrs(ir composerimported.ImportedResource) map[string]any {
+	if len(ir.Attrs) > 0 {
+		var typed map[string]any
+		if err := json.Unmarshal(ir.Attrs, &typed); err == nil && typed != nil {
+			return typed
+		}
+	}
+	if ir.Attributes != nil {
+		return ir.Attributes
+	}
+	return map[string]any{}
+}
+
+// renderFieldValue formats a resolved CurrentValue for the prompt.
+// Strings render bare; lists / maps / numbers / bools fall back to
+// JSON for a stable shape. nil renders as empty so the caller can
+// skip the line.
+func renderFieldValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/pkg/imported/agentcontext_test.go
+++ b/pkg/imported/agentcontext_test.go
@@ -344,8 +344,14 @@ func TestRenderAgentContext_UnregisteredTypeIsSkipped(t *testing.T) {
 // surfaces through repeated RenderAgentContext calls; we don't expose
 // getOrBuildTypeBlock directly so the test exercises the public
 // surface.
+//
+// Intentionally NOT t.Parallel(): the package-level type-block cache
+// is shared, and a neighbouring parallel test calling
+// ResetAgentContextCacheForTest mid-test would race the assertion
+// that "the second call hits the cache" — both calls would rebuild
+// and the round-trip would still pass (they're deterministic) but
+// the test would no longer be exercising the cache path it claims to.
 func TestRenderAgentContext_TypeBlockCaching(t *testing.T) {
-	t.Parallel()
 	imp.ResetAgentContextCacheForTest()
 
 	irs := []composerimported.ImportedResource{

--- a/pkg/imported/agentcontext_test.go
+++ b/pkg/imported/agentcontext_test.go
@@ -1,0 +1,377 @@
+package imported_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+
+	// Side-effect imports populate the policy registry. The renderer
+	// reads from policy.Lookup, so without these the tests would
+	// register zero types and every block would be skipped.
+	_ "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
+)
+
+// makeGCSImport constructs a minimal-but-representative GCS bucket
+// ImportedResource. Mirrors the fixture shape from reliable's
+// imported_context_test.go (the implementation this package's
+// RenderAgentContext was ported from), so a policy categorisation
+// change here surfaces the same regression in both repos.
+func makeGCSImport(address, project, location, storageClass string, versioning bool) composerimported.ImportedResource {
+	ir := composerimported.ImportedResource{
+		Identity: composerimported.ResourceIdentity{
+			Cloud:     "gcp",
+			Type:      "google_storage_bucket",
+			Address:   address,
+			ProjectID: project,
+			Location:  location,
+		},
+	}
+	attrs := map[string]any{
+		"name":          strings.TrimPrefix(address, "google_storage_bucket."),
+		"project":       project,
+		"location":      location,
+		"storage_class": storageClass,
+		"versioning": map[string]any{
+			"enabled": versioning,
+		},
+		"force_destroy": false,
+	}
+	b, _ := json.Marshal(attrs)
+	ir.Attrs = b
+	return ir
+}
+
+// makePubSubImport builds a google_pubsub_topic IR with a minimal
+// typed Attrs payload — name + project + message_retention_duration —
+// enough for the value projection to render at least one field row.
+func makePubSubImport(address, project string) composerimported.ImportedResource {
+	ir := composerimported.ImportedResource{
+		Identity: composerimported.ResourceIdentity{
+			Cloud:     "gcp",
+			Type:      "google_pubsub_topic",
+			Address:   address,
+			ProjectID: project,
+		},
+	}
+	attrs := map[string]any{
+		"name":                       strings.TrimPrefix(address, "google_pubsub_topic."),
+		"project":                    project,
+		"message_retention_duration": "86400s",
+	}
+	b, _ := json.Marshal(attrs)
+	ir.Attrs = b
+	return ir
+}
+
+// makeS3Import builds an aws_s3_bucket IR with a minimal typed Attrs
+// payload, intentionally similar in shape to makeGCSImport so a single
+// regression in the renderer surfaces in both clouds' tests.
+func makeS3Import(address, region string) composerimported.ImportedResource {
+	ir := composerimported.ImportedResource{
+		Identity: composerimported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_s3_bucket",
+			Address:  address,
+			Location: region,
+		},
+	}
+	attrs := map[string]any{
+		"bucket":        strings.TrimPrefix(address, "aws_s3_bucket."),
+		"region":        region,
+		"force_destroy": false,
+	}
+	b, _ := json.Marshal(attrs)
+	ir.Attrs = b
+	return ir
+}
+
+// makeDynamoImport builds an aws_dynamodb_table IR with a minimal
+// typed Attrs payload — name + billing_mode + hash_key.
+func makeDynamoImport(address, region string) composerimported.ImportedResource {
+	ir := composerimported.ImportedResource{
+		Identity: composerimported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_dynamodb_table",
+			Address:  address,
+			Location: region,
+		},
+	}
+	attrs := map[string]any{
+		"name":         strings.TrimPrefix(address, "aws_dynamodb_table."),
+		"region":       region,
+		"billing_mode": "PAY_PER_REQUEST",
+		"hash_key":     "id",
+	}
+	b, _ := json.Marshal(attrs)
+	ir.Attrs = b
+	return ir
+}
+
+// TestRenderAgentContext_GCSBucketBlock locks the rendered shape of
+// the per-type block + per-instance values for the slice's canonical
+// GCS fixture. Mirrors reliable's imported_context_test.go to keep
+// the cross-repo contract pinned.
+func TestRenderAgentContext_GCSBucketBlock(t *testing.T) {
+	t.Parallel()
+	imp.ResetAgentContextCacheForTest()
+
+	irs := []composerimported.ImportedResource{
+		makeGCSImport("google_storage_bucket.io_prod_uploads", "my-prod-12345", "US", "STANDARD", true),
+	}
+	lines := imp.RenderAgentContext(irs)
+	if len(lines) == 0 {
+		t.Fatal("non-empty imports must render at least one line")
+	}
+	got := strings.Join(lines, "\n")
+
+	wantSubstrings := []string{
+		"== Imported.google_storage_bucket ==",
+		"editable_chat_safe:",
+		"editable_with_approval:",
+		"read_only:",
+		"system_owned:",
+		"# sensitive fields omitted entirely",
+		"instances:",
+		"  google_storage_bucket.io_prod_uploads:",
+		"    project: my-prod-12345",
+		"    location: US",
+		"    storage_class: STANDARD",
+		"    versioning.enabled: true",
+		"== End ==",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered output missing substring %q\n--- got ---\n%s", want, got)
+		}
+	}
+
+	// Policy categorisation lock — same assertions reliable's test
+	// makes. These pin the curated policy decisions for the GCS
+	// bucket fixture; a future drift in policy categorisation will
+	// fail here loudly.
+	chatSafe := mustGrepLine(t, lines, "editable_chat_safe:")
+	for _, want := range []string{"storage_class", "versioning.enabled"} {
+		if !strings.Contains(chatSafe, want) {
+			t.Errorf("editable_chat_safe missing %q: %s", want, chatSafe)
+		}
+	}
+	approval := mustGrepLine(t, lines, "editable_with_approval:")
+	if !strings.Contains(approval, "force_destroy") {
+		t.Errorf("editable_with_approval missing force_destroy: %s", approval)
+	}
+	systemOwned := mustGrepLine(t, lines, "system_owned:")
+	if !strings.Contains(systemOwned, "labels") {
+		t.Errorf("system_owned missing labels: %s", systemOwned)
+	}
+}
+
+// TestRenderAgentContext_PubSubTopicBlock covers a second GCP type to
+// confirm the renderer doesn't accidentally hardcode GCS-specific
+// shape decisions.
+func TestRenderAgentContext_PubSubTopicBlock(t *testing.T) {
+	t.Parallel()
+	imp.ResetAgentContextCacheForTest()
+
+	irs := []composerimported.ImportedResource{
+		makePubSubImport("google_pubsub_topic.events", "my-prod-12345"),
+	}
+	lines := imp.RenderAgentContext(irs)
+	if len(lines) == 0 {
+		t.Fatal("non-empty imports must render at least one line")
+	}
+	got := strings.Join(lines, "\n")
+	for _, want := range []string{
+		"== Imported.google_pubsub_topic ==",
+		"  google_pubsub_topic.events:",
+		"    project: my-prod-12345",
+		"== End ==",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered output missing substring %q\n--- got ---\n%s", want, got)
+		}
+	}
+}
+
+// TestRenderAgentContext_S3BucketBlock confirms AWS coverage works
+// the same way as GCP — same renderer, distinct policy, identity
+// surface differs (region vs ProjectID/Location).
+func TestRenderAgentContext_S3BucketBlock(t *testing.T) {
+	t.Parallel()
+	imp.ResetAgentContextCacheForTest()
+
+	irs := []composerimported.ImportedResource{
+		makeS3Import("aws_s3_bucket.io_prod_uploads", "us-east-1"),
+	}
+	lines := imp.RenderAgentContext(irs)
+	if len(lines) == 0 {
+		t.Fatal("non-empty imports must render at least one line")
+	}
+	got := strings.Join(lines, "\n")
+	for _, want := range []string{
+		"== Imported.aws_s3_bucket ==",
+		"editable_chat_safe:",
+		"editable_with_approval:",
+		"read_only:",
+		"system_owned:",
+		"instances:",
+		"  aws_s3_bucket.io_prod_uploads:",
+		"    location: us-east-1",
+		"== End ==",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered output missing substring %q\n--- got ---\n%s", want, got)
+		}
+	}
+}
+
+// TestRenderAgentContext_DynamoDBBlock covers a second AWS type so
+// the AWS half of the cross-cloud coverage isn't single-type.
+func TestRenderAgentContext_DynamoDBBlock(t *testing.T) {
+	t.Parallel()
+	imp.ResetAgentContextCacheForTest()
+
+	irs := []composerimported.ImportedResource{
+		makeDynamoImport("aws_dynamodb_table.events", "us-east-1"),
+	}
+	lines := imp.RenderAgentContext(irs)
+	if len(lines) == 0 {
+		t.Fatal("non-empty imports must render at least one line")
+	}
+	got := strings.Join(lines, "\n")
+	for _, want := range []string{
+		"== Imported.aws_dynamodb_table ==",
+		"  aws_dynamodb_table.events:",
+		"    location: us-east-1",
+		"== End ==",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered output missing substring %q\n--- got ---\n%s", want, got)
+		}
+	}
+}
+
+// TestRenderAgentContext_MultipleTypesStableOrder — two types in one
+// call, given in reverse alphabetical order, must render in
+// alphabetical type order.
+func TestRenderAgentContext_MultipleTypesStableOrder(t *testing.T) {
+	t.Parallel()
+	imp.ResetAgentContextCacheForTest()
+
+	irs := []composerimported.ImportedResource{
+		// google_storage_bucket sorts AFTER google_pubsub_topic.
+		makeGCSImport("google_storage_bucket.bucket1", "p1", "US", "STANDARD", false),
+		makePubSubImport("google_pubsub_topic.topic1", "p1"),
+	}
+	lines := imp.RenderAgentContext(irs)
+	got := strings.Join(lines, "\n")
+
+	pubIdx := strings.Index(got, "== Imported.google_pubsub_topic ==")
+	bucketIdx := strings.Index(got, "== Imported.google_storage_bucket ==")
+	if pubIdx < 0 || bucketIdx < 0 {
+		t.Fatalf("both type headers must appear; got:\n%s", got)
+	}
+	if pubIdx >= bucketIdx {
+		t.Errorf("types must render in alphabetical order; pubIdx=%d bucketIdx=%d", pubIdx, bucketIdx)
+	}
+}
+
+// TestRenderAgentContext_MultipleInstancesSameType — two instances
+// of the same type share ONE type-block (cached + structurally
+// identical) and render in alphabetical address order even when the
+// input order is reversed.
+func TestRenderAgentContext_MultipleInstancesSameType(t *testing.T) {
+	t.Parallel()
+	imp.ResetAgentContextCacheForTest()
+
+	irs := []composerimported.ImportedResource{
+		makeGCSImport("google_storage_bucket.zzz_archive", "p1", "US", "ARCHIVE", false),
+		makeGCSImport("google_storage_bucket.aaa_uploads", "p1", "US", "STANDARD", true),
+	}
+	lines := imp.RenderAgentContext(irs)
+	got := strings.Join(lines, "\n")
+
+	if c := strings.Count(got, "== Imported.google_storage_bucket =="); c != 1 {
+		t.Errorf("identical types must share a single block header; got %d", c)
+	}
+
+	aIdx := strings.Index(got, "  google_storage_bucket.aaa_uploads:")
+	zIdx := strings.Index(got, "  google_storage_bucket.zzz_archive:")
+	if aIdx < 0 || zIdx < 0 {
+		t.Fatalf("both addresses must render; got:\n%s", got)
+	}
+	if aIdx >= zIdx {
+		t.Errorf("addresses must render in alphabetical order; aIdx=%d zIdx=%d", aIdx, zIdx)
+	}
+}
+
+// TestRenderAgentContext_EmptyInputs — nil + empty produce nil so
+// the caller can elide the wrapping section cleanly.
+func TestRenderAgentContext_EmptyInputs(t *testing.T) {
+	t.Parallel()
+	if got := imp.RenderAgentContext(nil); got != nil {
+		t.Errorf("RenderAgentContext(nil) = %v, want nil", got)
+	}
+	if got := imp.RenderAgentContext([]composerimported.ImportedResource{}); got != nil {
+		t.Errorf("RenderAgentContext([]) = %v, want nil", got)
+	}
+}
+
+// TestRenderAgentContext_UnregisteredTypeIsSkipped — a type with no
+// policy renders no content; the prompt stays clean rather than
+// emitting a half-empty block.
+func TestRenderAgentContext_UnregisteredTypeIsSkipped(t *testing.T) {
+	t.Parallel()
+	imp.ResetAgentContextCacheForTest()
+
+	ir := composerimported.ImportedResource{
+		Identity: composerimported.ResourceIdentity{
+			Cloud:   "gcp",
+			Type:    "google_compute_made_up_type_not_in_policy",
+			Address: "google_compute_made_up_type_not_in_policy.foo",
+		},
+	}
+	lines := imp.RenderAgentContext([]composerimported.ImportedResource{ir})
+	if len(lines) != 0 {
+		t.Errorf("unregistered types must render no content; got %d lines: %v", len(lines), lines)
+	}
+}
+
+// TestRenderAgentContext_TypeBlockCaching — second call for the same
+// type returns the cached string verbatim. The renderer's cache
+// surfaces through repeated RenderAgentContext calls; we don't expose
+// getOrBuildTypeBlock directly so the test exercises the public
+// surface.
+func TestRenderAgentContext_TypeBlockCaching(t *testing.T) {
+	t.Parallel()
+	imp.ResetAgentContextCacheForTest()
+
+	irs := []composerimported.ImportedResource{
+		makeGCSImport("google_storage_bucket.a", "p", "US", "STANDARD", false),
+	}
+	first := imp.RenderAgentContext(irs)
+	second := imp.RenderAgentContext(irs)
+	if strings.Join(first, "\n") != strings.Join(second, "\n") {
+		t.Errorf("cached type block must round-trip identically")
+	}
+}
+
+// mustGrepLine returns the single line containing `needle`, failing
+// the test if zero or multiple matches are found. Used by the table
+// assertions so a failure names the precise per-bucket line rather
+// than dumping the whole prompt.
+func mustGrepLine(t *testing.T, lines []string, needle string) string {
+	t.Helper()
+	var matches []string
+	for _, l := range lines {
+		if strings.Contains(l, needle) {
+			matches = append(matches, l)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one line containing %q; got %d: %v", needle, len(matches), matches)
+	}
+	return matches[0]
+}

--- a/pkg/imported/aws/provider.go
+++ b/pkg/imported/aws/provider.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"sort"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
@@ -290,28 +289,14 @@ func (p *Provider) CompareDrift(tfType string, snapshot, live imp.Attrs) []imp.F
 	return p.comparer(tfType, snapshot, live)
 }
 
-// AgentContext returns a one-line-per-IR summary sorted by Address.
-// Conservative format: `<address> (<type>)`. The downstream interactive
-// agent layers richer formatting on top; this is the cross-cloud
-// baseline.
-//
-// Sort key is Identity.Address — sorting the formatted output strings
-// is equivalent today (since the format starts with the Address), but
-// pinning on the source field decouples the contract from the format.
+// AgentContext returns the per-Terraform-type policy block + per-instance
+// value rows an interactive agent reads at chat-context build time. The
+// rendering is cloud-agnostic — everything it touches (policy.Lookup,
+// VisibleFieldsFor, ir.Identity, ir.Attrs) is cross-cloud — so the
+// AWS impl delegates to the shared imp.RenderAgentContext helper.
+// See that helper's doc for the output shape and ordering rules (#517).
 func (p *Provider) AgentContext(irs []imported.ImportedResource) []string {
-	if len(irs) == 0 {
-		return nil
-	}
-	sorted := make([]imported.ImportedResource, len(irs))
-	copy(sorted, irs)
-	sort.SliceStable(sorted, func(i, j int) bool {
-		return sorted[i].Identity.Address < sorted[j].Identity.Address
-	})
-	out := make([]string, 0, len(sorted))
-	for _, ir := range sorted {
-		out = append(out, fmt.Sprintf("%s (%s)", ir.Identity.Address, ir.Identity.Type))
-	}
-	return out
+	return imp.RenderAgentContext(irs)
 }
 
 // init registers the AWS Provider constructor with the top-level

--- a/pkg/imported/aws/provider_test.go
+++ b/pkg/imported/aws/provider_test.go
@@ -3,6 +3,7 @@ package aws_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -173,22 +174,33 @@ func TestProvider_CanonicalAddress(t *testing.T) {
 func TestProvider_AgentContext(t *testing.T) {
 	t.Parallel()
 	p := awsprov.NewProvider(nil, nil)
+	imp.ResetAgentContextCacheForTest()
 
 	if got := p.AgentContext(nil); got != nil {
 		t.Errorf("AgentContext(nil) = %v, want nil", got)
 	}
 
+	// Two registered AWS types, given in reverse alphabetical type
+	// order. The shared renderer (see pkg/imported/agentcontext.go)
+	// emits per-type blocks in stable Terraform-type-name order, so
+	// the dynamodb block must come before the s3 block in the output.
 	irs := []composerimported.ImportedResource{
 		{Identity: composerimported.ResourceIdentity{Type: "aws_s3_bucket", Address: "aws_s3_bucket.z"}},
-		{Identity: composerimported.ResourceIdentity{Type: "aws_iam_role", Address: "aws_iam_role.a"}},
+		{Identity: composerimported.ResourceIdentity{Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.a"}},
 	}
 	got := p.AgentContext(irs)
-	if len(got) != 2 {
-		t.Fatalf("expected 2 lines, got %d", len(got))
+	if len(got) == 0 {
+		t.Fatal("AgentContext returned no lines for registered types")
 	}
-	// Sorted by line — aws_iam_role.a (...) sorts before aws_s3_bucket.z (...)
-	if got[0] >= got[1] {
-		t.Errorf("AgentContext not sorted: %v", got)
+	joined := strings.Join(got, "\n")
+
+	dynIdx := strings.Index(joined, "== Imported.aws_dynamodb_table ==")
+	s3Idx := strings.Index(joined, "== Imported.aws_s3_bucket ==")
+	if dynIdx < 0 || s3Idx < 0 {
+		t.Fatalf("AgentContext missing expected type headers:\n%s", joined)
+	}
+	if dynIdx >= s3Idx {
+		t.Errorf("type blocks must render in alphabetical order; dynIdx=%d s3Idx=%d", dynIdx, s3Idx)
 	}
 }
 

--- a/pkg/imported/gcp/provider.go
+++ b/pkg/imported/gcp/provider.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"sort"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
@@ -233,23 +232,13 @@ func (p *Provider) CompareDrift(tfType string, snapshot, live imp.Attrs) []imp.F
 	return p.comparer(tfType, snapshot, live)
 }
 
-// AgentContext returns a one-line-per-IR summary sorted by Address —
-// see aws.Provider.AgentContext for the contract; this is the
-// one-for-one mirror.
+// AgentContext returns the per-Terraform-type policy block + per-instance
+// value rows an interactive agent reads at chat-context build time —
+// see imp.RenderAgentContext for the output shape and ordering rules.
+// The GCP impl mirrors the AWS impl: both delegate to the shared
+// helper because the rendering is cloud-agnostic (#517).
 func (p *Provider) AgentContext(irs []imported.ImportedResource) []string {
-	if len(irs) == 0 {
-		return nil
-	}
-	sorted := make([]imported.ImportedResource, len(irs))
-	copy(sorted, irs)
-	sort.SliceStable(sorted, func(i, j int) bool {
-		return sorted[i].Identity.Address < sorted[j].Identity.Address
-	})
-	out := make([]string, 0, len(sorted))
-	for _, ir := range sorted {
-		out = append(out, fmt.Sprintf("%s (%s)", ir.Identity.Address, ir.Identity.Type))
-	}
-	return out
+	return imp.RenderAgentContext(irs)
 }
 
 // init registers the GCP Provider constructor with the top-level

--- a/pkg/imported/gcp/provider_test.go
+++ b/pkg/imported/gcp/provider_test.go
@@ -3,6 +3,7 @@ package gcp_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
@@ -143,21 +144,34 @@ func TestProvider_CanonicalAddress(t *testing.T) {
 func TestProvider_AgentContext(t *testing.T) {
 	t.Parallel()
 	p := gcpprov.NewProvider(nil, nil)
+	imp.ResetAgentContextCacheForTest()
 
 	if got := p.AgentContext(nil); got != nil {
 		t.Errorf("AgentContext(nil) = %v, want nil", got)
 	}
 
+	// Two registered GCP types, given in reverse alphabetical type
+	// order. The shared renderer (see pkg/imported/agentcontext.go)
+	// emits per-type blocks in stable Terraform-type-name order, so
+	// the pubsub block must come before the storage_bucket block in
+	// the output.
 	irs := []composerimported.ImportedResource{
 		{Identity: composerimported.ResourceIdentity{Type: "google_storage_bucket", Address: "google_storage_bucket.z"}},
 		{Identity: composerimported.ResourceIdentity{Type: "google_pubsub_topic", Address: "google_pubsub_topic.a"}},
 	}
 	got := p.AgentContext(irs)
-	if len(got) != 2 {
-		t.Fatalf("expected 2 lines, got %d", len(got))
+	if len(got) == 0 {
+		t.Fatal("AgentContext returned no lines for registered types")
 	}
-	if got[0] >= got[1] {
-		t.Errorf("AgentContext not sorted: %v", got)
+	joined := strings.Join(got, "\n")
+
+	pubIdx := strings.Index(joined, "== Imported.google_pubsub_topic ==")
+	bucketIdx := strings.Index(joined, "== Imported.google_storage_bucket ==")
+	if pubIdx < 0 || bucketIdx < 0 {
+		t.Fatalf("AgentContext missing expected type headers:\n%s", joined)
+	}
+	if pubIdx >= bucketIdx {
+		t.Errorf("type blocks must render in alphabetical order; pubIdx=%d bucketIdx=%d", pubIdx, bucketIdx)
 	}
 }
 

--- a/pkg/imported/provider.go
+++ b/pkg/imported/provider.go
@@ -104,11 +104,33 @@ type Provider interface {
 	// DriftSemantic tags.
 	CompareDrift(tfType string, snapshot, live Attrs) []FieldMismatch
 
-	// AgentContext returns a short, human-readable summary line
-	// per imported resource, suitable for inclusion in an
-	// interactive-agent chat-context prompt. Conservative format:
-	// one line per IR of the form "<address> (<type>)". Stable
-	// ordering across calls — sorted by Identity.Address.
+	// AgentContext returns the per-Terraform-type policy block +
+	// per-instance value rows for inclusion in an interactive-agent
+	// chat-context prompt. Per registered type, in stable type-name
+	// order, the renderer emits:
+	//
+	//   == Imported.<type> ==
+	//   editable_chat_safe: [<paths>]
+	//   editable_with_approval: [<paths>]
+	//   read_only: [<paths>]
+	//   system_owned: [<paths>]
+	//   # sensitive fields omitted entirely
+	//   instances:
+	//     <address>:
+	//       project: <project>           // GCP identity slot
+	//       location: <location>         // identity slot
+	//       <path>: <current-value>      // per VisibleFieldsFor
+	//   == End ==
+	//
+	// Instances within each type sort by Identity.Address. Types
+	// without a registered policy in pkg/composer/imported/policy
+	// are skipped entirely — emitting a half-rendered block with
+	// no policy summary would teach the agent nothing while burning
+	// context tokens.
+	//
+	// Both per-cloud Provider impls delegate to the shared
+	// RenderAgentContext helper because the rendering is
+	// cloud-agnostic.
 	//
 	// Agent-name-agnostic on purpose: the per-product naming can rotate
 	// without flipping the interface.

--- a/pkg/imported/provider_test.go
+++ b/pkg/imported/provider_test.go
@@ -7,6 +7,7 @@ import (
 	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
 	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+
 	// Side-effect imports populate the Provider registry.
 	_ "github.com/luthersystems/insideout-terraform-presets/pkg/imported/aws"
 	_ "github.com/luthersystems/insideout-terraform-presets/pkg/imported/gcp"


### PR DESCRIPTION
## Summary
- New `pkg/imported/agentcontext.go` with `RenderAgentContext` shared helper that emits per-Terraform-type policy blocks (`editable_chat_safe` / `editable_with_approval` / `read_only` / `system_owned`) + per-instance value rows, replacing the previous one-line-per-IR `<address> (<type>)` format.
- Per-cloud `Provider.AgentContext` impls (`pkg/imported/aws`, `pkg/imported/gcp`) delegate to the shared helper.
- Interface doc on `pkg/imported/provider.go` updated to describe the new block format.
- Golden tests in `pkg/imported/agentcontext_test.go` cover four registered types (two AWS, two GCP), unregistered-type skipping, multi-type + multi-instance stable ordering, the empty-input contract, and cache round-trip.

## Why
Downstream `luthersystems/reliable` (umbrella reliable#1479) is blocked on adopting `Provider.AgentContext` because the upstream thin format loses ~80% of the prompt-context payload the chat agent depends on. Rather than carry a duplicate renderer in reliable, move the rendering here so reliable's adoption is a true drop-in.

The new shape, per registered type, in stable type-name order:

```
== Imported.<type> ==
editable_chat_safe: [<paths>]
editable_with_approval: [<paths>]
read_only: [<paths>]
system_owned: [<paths>]
# sensitive fields omitted entirely
instances:
  <address>:
    project: <project>
    location: <location>
    <path>: <current-value>
== End ==
```

Sensitive fields are filtered out of every bucket. Types with no registered policy are skipped entirely (with a log line) — emitting half-rendered blocks would teach the agent nothing while burning context tokens. Type-block memoisation keeps cost O(1) per type per process.

## Test plan
- [x] `go test ./pkg/imported/... -count=1` — 94 passed across 7 packages
- [x] `go test ./...` — 5534 passed across 35 packages
- [x] `go vet ./...` — clean
- [x] `gofmt -l pkg/imported/` — clean
- [x] `goimports -l pkg/imported/` — clean
- [ ] Reliable will bump its pin to this commit on its integration branch (separate PR).

## Review notes
- `/review` findings (self-review against P0/P1/P2/P3 rubric): 0 P0; 1 P1 (decodeAttrs silent error drop — fixed); 4 P2 drive-bys (invariant-audit O(N²), groupByType + renderInstanceLines silent drops, concurrent-build doc — all fixed); 2 P3 nits (typeBlock newline split, ResetCache doc — fixed). All resolved in the follow-up commit.
- qa-professor self-pass on tests: dropped `t.Parallel()` from `TestRenderAgentContext_TypeBlockCaching` to avoid a race against neighbouring cache resets. Helper `mustGrepLine` calls `t.Helper()`.

Closes #517
