### PR TITLE
feat(imported): seed MetricsBinding registry — 8 high-value types (#482)

### DIFF
--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -1,0 +1,83 @@
+package bindings
+
+// seededTypes captures the tfTypes registered by init() below, so that
+// tests which intentionally wipe the live registry (via resetForTest)
+// can still assert on the seeded set. Read-only after init().
+var seededTypes = []string{
+	"aws_s3_bucket",
+	"aws_dynamodb_table",
+	"aws_lambda_function",
+	"aws_sqs_queue",
+	"aws_lb",
+	"google_storage_bucket",
+	"google_pubsub_topic",
+	"google_cloud_run_v2_service",
+}
+
+// seededBindings mirrors the registrations performed by init(). Used
+// by seed_test.go to assert each entry's fields independent of the
+// live registry state (which other tests mutate via resetForTest).
+var seededBindings = map[string]ComponentMetricsBinding{
+	"aws_s3_bucket": {
+		Service:        "s3",
+		Action:         "get-metrics",
+		DimensionKey:   "BucketName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"NumberOfObjects", "BucketSizeBytes"},
+	},
+	"aws_dynamodb_table": {
+		Service:        "dynamodb",
+		Action:         "get-metrics",
+		DimensionKey:   "TableName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"ConsumedReadCapacityUnits", "ConsumedWriteCapacityUnits", "UserErrors"},
+	},
+	"aws_lambda_function": {
+		Service:        "lambda",
+		Action:         "get-metrics",
+		DimensionKey:   "FunctionName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"Invocations", "Errors", "Duration", "Throttles"},
+	},
+	"aws_sqs_queue": {
+		Service:        "sqs",
+		Action:         "get-metrics",
+		DimensionKey:   "QueueName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"NumberOfMessagesSent", "NumberOfMessagesReceived", "ApproximateNumberOfMessagesVisible"},
+	},
+	"aws_lb": {
+		Service:        "elb",
+		Action:         "get-metrics",
+		DimensionKey:   "LoadBalancer",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"RequestCount", "TargetResponseTime", "HTTPCode_Target_5XX_Count"},
+	},
+	"google_storage_bucket": {
+		Service:        "storage",
+		Action:         "timeseries-list",
+		DimensionKey:   "bucket_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"storage.googleapis.com/storage/total_bytes", "storage.googleapis.com/storage/object_count"},
+	},
+	"google_pubsub_topic": {
+		Service:        "pubsub",
+		Action:         "timeseries-list",
+		DimensionKey:   "topic_id",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"pubsub.googleapis.com/topic/send_message_operation_count", "pubsub.googleapis.com/topic/byte_cost"},
+	},
+	"google_cloud_run_v2_service": {
+		Service:        "run",
+		Action:         "timeseries-list",
+		DimensionKey:   "service_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"run.googleapis.com/request_count", "run.googleapis.com/request_latencies"},
+	},
+}
+
+func init() {
+	for _, t := range seededTypes {
+		Register(t, seededBindings[t])
+	}
+}

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -1,0 +1,44 @@
+package bindings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// reseed wipes the live registry and re-applies the package's seeded
+// registrations from seededBindings. Necessary because the existing
+// resetForTest-style tests mutate the live registry, so we cannot
+// rely on init()'s state surviving when our test runs.
+func reseed(t *testing.T) {
+	t.Helper()
+	regMu.Lock()
+	registry = map[string]ComponentMetricsBinding{}
+	for tfType, b := range seededBindings {
+		registry[tfType] = b
+	}
+	regMu.Unlock()
+}
+
+func TestSeededBindings(t *testing.T) {
+	reseed(t)
+
+	require.GreaterOrEqual(t, len(RegisteredTypes()), 8,
+		"expected at least 8 seeded types, got %d", len(RegisteredTypes()))
+
+	for _, tfType := range seededTypes {
+		tfType := tfType
+		t.Run(tfType, func(t *testing.T) {
+			t.Parallel()
+			b, ok := Binding(tfType)
+			require.True(t, ok, "Binding(%q) ok=false", tfType)
+			assert.NotEqual(t, ComponentMetricsBinding{}, b, "Binding(%q) returned zero value", tfType)
+			assert.NotEmpty(t, b.Service, "%s: Service empty", tfType)
+			assert.NotEmpty(t, b.Action, "%s: Action empty", tfType)
+			assert.NotEmpty(t, b.DimensionKey, "%s: DimensionKey empty", tfType)
+			assert.NotEmpty(t, b.DimensionFrom, "%s: DimensionFrom empty", tfType)
+			assert.NotEmpty(t, b.DefaultMetrics, "%s: DefaultMetrics empty", tfType)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

First MetricsBinding entries ever registered. Stacks on **#515** (mega-bundle).

The framework added `pkg/imported/bindings` in the skeleton but no per-type entries were ever wired. This PR seeds 8 high-value types so `Provider.MetricsBinding(tfType)` returns non-zero on the resources most commonly used for dashboards.

| TF Type | Service | Dimension | Default metrics |
|---|---|---|---|
| `aws_s3_bucket` | s3 | BucketName | NumberOfObjects, BucketSizeBytes |
| `aws_dynamodb_table` | dynamodb | TableName | ConsumedReadCapacityUnits, ConsumedWriteCapacityUnits, UserErrors |
| `aws_lambda_function` | lambda | FunctionName | Invocations, Errors, Duration, Throttles |
| `aws_sqs_queue` | sqs | QueueName | NumberOfMessagesSent, NumberOfMessagesReceived, ApproximateNumberOfMessagesVisible |
| `aws_lb` | elb | LoadBalancer | RequestCount, TargetResponseTime, HTTPCode_Target_5XX_Count |
| `google_storage_bucket` | storage | bucket_name | storage.googleapis.com/storage/total_bytes, /object_count |
| `google_pubsub_topic` | pubsub | topic_id | pubsub.googleapis.com/topic/send_message_operation_count, /byte_cost |
| `google_cloud_run_v2_service` | run | service_name | run.googleapis.com/request_count, /request_latencies |

## Coverage

MetricsBinding: **0 → 8/163 (~5%)**.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./pkg/imported/bindings/...\` → 16 passed
- [x] \`go test ./cmd/... ./pkg/composer/imported/... ./pkg/imported/...\` → 3230 passed
- [ ] CI green

## Related

- Builds on #515.
- Closes the MetricsBinding-seeding portion of #482.