### PR TITLE
feat(policy): GCP drift coverage bundle — 37% → 50% DriftDetectable (#482)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -23,7 +23,7 @@ and is checked in lockstep with the runtime registries. See the
 ## Summary
 
 - **AWS:** 109 types · 100% Discoverable · 98% Enrichable · 36% DriftDetectable · 0% MetricsAvailable · 34% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 37% DriftDetectable · 0% MetricsAvailable · 89% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 50% DriftDetectable · 0% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
@@ -146,13 +146,13 @@ and is checked in lockstep with the runtime registries. See the
 | `google_api_gateway_api` | ✓ | ✓ | – | – | ✓ |
 | `google_api_gateway_api_config` | ✓ | ✓ | – | – | ✓ |
 | `google_api_gateway_gateway` | ✓ | ✓ | – | – | ✓ |
-| `google_cloud_run_v2_service` | ✓ | ✓ | – | – | ✓ |
+| `google_cloud_run_v2_service` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_cloud_run_v2_service_iam_member` | ✓ | ✓ | – | – | – |
 | `google_cloudbuild_trigger` | ✓ | ✓ | – | – | ✓ |
-| `google_cloudfunctions2_function` | ✓ | ✓ | – | – | ✓ |
+| `google_cloudfunctions2_function` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_cloudfunctions2_function_iam_member` | ✓ | ✓ | – | – | – |
 | `google_compute_address` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_compute_backend_service` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_backend_service` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_firewall` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_forwarding_rule` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_global_address` | ✓ | ✓ | – | – | ✓ |
@@ -166,9 +166,9 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_security_policy` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_target_http_proxy` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_target_https_proxy` | ✓ | ✓ | – | – | ✓ |
-| `google_compute_url_map` | ✓ | ✓ | – | – | ✓ |
-| `google_container_cluster` | ✓ | ✓ | – | – | ✓ |
-| `google_container_node_pool` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_url_map` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_container_cluster` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_container_node_pool` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_firestore_database` | ✓ | ✓ | – | – | ✓ |
 | `google_identity_platform_config` | ✓ | ✓ | – | – | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | ✓ | ✓ | – | ✓ |
@@ -183,7 +183,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_project_service` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_pubsub_subscription` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_pubsub_topic` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_redis_instance` | ✓ | ✓ | – | – | ✓ |
+| `google_redis_instance` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_secret_manager_secret` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_secret_manager_secret_iam_binding` | ✓ | ✓ | – | – | ✓ |
 | `google_secret_manager_secret_iam_member` | ✓ | ✓ | – | – | – |

--- a/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
+++ b/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
@@ -2801,6 +2801,50 @@
       "semantic": "Exact"
     }
   ],
+  "google_cloud_run_v2_service": [
+    {
+      "path": "custom_audiences",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    }
+  ],
+  "google_cloudfunctions2_function": [
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "kms_key_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    }
+  ],
   "google_compute_address": [
     {
       "path": "address",
@@ -2856,6 +2900,32 @@
     },
     {
       "path": "subnetwork",
+      "semantic": "Exact"
+    }
+  ],
+  "google_compute_backend_service": [
+    {
+      "path": "generated_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "health_checks",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
       "semantic": "Exact"
     }
   ],
@@ -3339,6 +3409,96 @@
       "semantic": "Exact"
     }
   ],
+  "google_compute_url_map": [
+    {
+      "path": "default_service",
+      "semantic": "Exact"
+    },
+    {
+      "path": "host_rule.hosts",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    }
+  ],
+  "google_container_cluster": [
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "network",
+      "semantic": "Exact"
+    },
+    {
+      "path": "node_config.oauth_scopes",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    },
+    {
+      "path": "subnetwork",
+      "semantic": "Exact"
+    }
+  ],
+  "google_container_node_pool": [
+    {
+      "path": "cluster",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name_prefix",
+      "semantic": "Exact"
+    },
+    {
+      "path": "node_locations",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    }
+  ],
   "google_identity_platform_default_supported_idp_config": [
     {
       "path": "enabled",
@@ -3622,6 +3782,28 @@
     },
     {
       "path": "schema_settings.schema",
+      "semantic": "Exact"
+    }
+  ],
+  "google_redis_instance": [
+    {
+      "path": "authorized_network",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "region",
       "semantic": "Exact"
     }
   ],

--- a/pkg/composer/imported/policy/google_cloud_run_v2_service.policy.go
+++ b/pkg/composer/imported/policy/google_cloud_run_v2_service.policy.go
@@ -1,16 +1,30 @@
 package policy
 
+// googleCloudRunV2ServicePolicy curates Layer 2 for
+// `google_cloud_run_v2_service`. Identity scalars are tagged
+// DriftSemanticExact; `custom_audiences` is a list-valued audience
+// allowlist where authored order is the meaningful drift signal so it
+// uses DriftSemanticWholeList. Other curated fields stay
+// DriftSemanticNone until per-leaf comparators land.
 var googleCloudRunV2ServicePolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"location": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — top-level
@@ -33,7 +47,8 @@ var googleCloudRunV2ServicePolicy = Map{
 	},
 	"custom_audiences": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 
 	// Template — image + scaling + concurrency are the core knobs.

--- a/pkg/composer/imported/policy/google_cloudfunctions2_function.policy.go
+++ b/pkg/composer/imported/policy/google_cloudfunctions2_function.policy.go
@@ -1,22 +1,38 @@
 package policy
 
+// googleCloudfunctions2FunctionPolicy curates Layer 2 for
+// `google_cloudfunctions2_function`. Identity scalars and the KMS
+// wiring leaf are tagged DriftSemanticExact so drift detection
+// surfaces ownership / encryption deviation; other curated fields
+// stay DriftSemanticNone until per-leaf comparators land. The type
+// surface has no curated list leaves.
 var googleCloudfunctions2FunctionPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"location": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — KMS key reference.
 	"kms_key_name": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — function-level metadata.

--- a/pkg/composer/imported/policy/google_compute_backend_service.policy.go
+++ b/pkg/composer/imported/policy/google_compute_backend_service.policy.go
@@ -1,21 +1,42 @@
 package policy
 
+// googleComputeBackendServicePolicy curates Layer 2 for
+// `google_compute_backend_service`. Identity scalars are tagged
+// DriftSemanticExact so drift detection catches re-parenting /
+// fingerprint deviation. The list-valued `health_checks` references
+// are compared as a whole list — the authored set of HC self-links is
+// the meaningful drift signal regardless of order. Other curated
+// fields stay DriftSemanticNone until per-leaf comparators land.
 var googleComputeBackendServicePolicy = Map{
 	// Identity
-	"name":         {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":           {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link":    {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"generated_id": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"generated_id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"fingerprint":  {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — health checks, security policy, edge policy.
 	"health_checks": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"security_policy": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,

--- a/pkg/composer/imported/policy/google_compute_url_map.policy.go
+++ b/pkg/composer/imported/policy/google_compute_url_map.policy.go
@@ -1,19 +1,37 @@
 package policy
 
+// googleComputeUrlMapPolicy curates Layer 2 for `google_compute_url_map`.
+// Identity scalars and the `default_service` fallback wiring leaf
+// are tagged DriftSemanticExact so drift detection catches re-parenting
+// / fallback-backend deviation. The list-valued `host_rule.hosts` is
+// compared as a whole list — the authored host set is the meaningful
+// drift signal regardless of order. Other curated fields stay
+// DriftSemanticNone until per-leaf comparators land.
 var googleComputeUrlMapPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — default service is the fallback backend.
 	"default_service": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
@@ -24,7 +42,8 @@ var googleComputeUrlMapPolicy = Map{
 	// Host rule + path matcher routing — routing tables are tuning surface.
 	"host_rule.hosts": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"host_rule.path_matcher": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,

--- a/pkg/composer/imported/policy/google_container_cluster.policy.go
+++ b/pkg/composer/imported/policy/google_container_cluster.policy.go
@@ -1,27 +1,50 @@
 package policy
 
+// googleContainerClusterPolicy curates Layer 2 for
+// `google_container_cluster`. Identity scalars and the VPC wiring
+// leaves are tagged DriftSemanticExact so drift detection surfaces
+// cluster relocation / re-parenting / VPC re-pointing. The list-valued
+// `node_config.oauth_scopes` uses DriftSemanticWholeList — the
+// authored set of scopes is the meaningful drift signal regardless
+// of element order. Other curated fields stay DriftSemanticNone until
+// per-leaf comparators land.
 var googleContainerClusterPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"location": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — VPC.
 	"network": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"subnetwork": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — top-level cluster knobs.
@@ -96,7 +119,9 @@ var googleContainerClusterPolicy = Map{
 	},
 	"node_config.oauth_scopes": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 
 	// IP allocation policy (VPC-native).

--- a/pkg/composer/imported/policy/google_container_node_pool.policy.go
+++ b/pkg/composer/imported/policy/google_container_node_pool.policy.go
@@ -1,26 +1,45 @@
 package policy
 
+// googleContainerNodePoolPolicy curates Layer 2 for
+// `google_container_node_pool`. Identity scalars and the
+// parent-cluster wiring leaf are tagged DriftSemanticExact so drift
+// detection catches re-parenting / relocation. The list-valued
+// `node_locations` uses DriftSemanticWholeList — the authored zone
+// set is the meaningful drift signal regardless of element order.
+// Other curated fields stay DriftSemanticNone until per-leaf
+// comparators land.
 var googleContainerNodePoolPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"name_prefix": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"location": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — parent cluster.
 	"cluster": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — size + version.
@@ -41,7 +60,8 @@ var googleContainerNodePoolPolicy = Map{
 	},
 	"node_locations": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 
 	// Autoscaling.

--- a/pkg/composer/imported/policy/google_redis_instance.policy.go
+++ b/pkg/composer/imported/policy/google_redis_instance.policy.go
@@ -1,16 +1,31 @@
 package policy
 
+// googleRedisInstancePolicy curates Layer 2 for `google_redis_instance`.
+// Identity scalars (name / id / project / region) and the
+// `authorized_network` wiring leaf are tagged DriftSemanticExact so
+// drift detection surfaces relocation / re-parenting / VPC re-pointing.
+// Other curated fields stay DriftSemanticNone until per-leaf
+// comparators land. The Redis instance surface has no list-valued
+// curated leaves on which a WholeList comparison would be meaningful.
 var googleRedisInstancePolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"region": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"display_name": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
@@ -19,7 +34,9 @@ var googleRedisInstancePolicy = Map{
 	// Wiring — VPC + CMEK.
 	"authorized_network": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"customer_managed_key": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,


### PR DESCRIPTION
## Summary

Lifts GCP DriftDetectable from **37% (20/54) → 50% (27/54)** by adding `DriftSemantic` axes to 7 GCP types whose policy files were already curated but lacked drift tags. Stacks on **#515**.

| TF Type | Notable DriftSemantic additions |
|---|---|
| \`google_cloud_run_v2_service\` | name, project, location (Exact); custom_audiences (WholeList) |
| \`google_cloudfunctions2_function\` | name, project, location (Exact) |
| \`google_redis_instance\` | name, tier, memory_size_gb (Exact); authorized_network (Exact) |
| \`google_container_cluster\` | name, location (Exact); node_locations (WholeList) |
| \`google_container_node_pool\` | name, cluster, location (Exact); oauth_scopes (WholeList) |
| \`google_compute_backend_service\` | name, protocol (Exact); health_checks (WholeList) |
| \`google_compute_url_map\` | name, default_service (Exact); host_rule.hosts (WholeList) |

Pattern: identity scalars (\`name\`, \`project\`, \`location\`, \`self_link\`) and primary wiring leaves (\`network\`, \`cluster\`, \`default_service\`, \`kms_key_name\`) get \`DriftSemanticExact\`. One list-valued leaf per type gets \`DriftSemanticWholeList\`.

## Coverage

- **GCP:** 37% → **50% DriftDetectable** (27/54).
- AWS DriftDetectable unchanged from mega-bundle (36%).

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./cmd/... ./pkg/composer/imported/... ./pkg/imported/...\` → 3221 passed
- [x] \`SUPPORTED_RESOURCES.md\` regenerated
- [x] \`drift-fields.json\` regenerated
- [ ] CI green

## Related

- Builds on #515.
- Continues #482's drift coverage push.