### PR TITLE
feat(imported): extend MetricsBinding registry — 8 more types (16 total, #482)

### DIFF
--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -9,9 +9,17 @@ var seededTypes = []string{
 	"aws_lambda_function",
 	"aws_sqs_queue",
 	"aws_lb",
+	"aws_rds_cluster",
+	"aws_db_instance",
+	"aws_sns_topic",
+	"aws_cloudwatch_log_group",
+	"aws_secretsmanager_secret",
 	"google_storage_bucket",
 	"google_pubsub_topic",
 	"google_cloud_run_v2_service",
+	"google_sql_database_instance",
+	"google_redis_instance",
+	"google_pubsub_subscription",
 }
 
 // seededBindings mirrors the registrations performed by init(). Used
@@ -53,6 +61,41 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionFrom:  "name",
 		DefaultMetrics: []string{"RequestCount", "TargetResponseTime", "HTTPCode_Target_5XX_Count"},
 	},
+	"aws_rds_cluster": {
+		Service:        "rds",
+		Action:         "get-metrics",
+		DimensionKey:   "DBClusterIdentifier",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"CPUUtilization", "DatabaseConnections", "FreeableMemory"},
+	},
+	"aws_db_instance": {
+		Service:        "rds",
+		Action:         "get-metrics",
+		DimensionKey:   "DBInstanceIdentifier",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"CPUUtilization", "DatabaseConnections", "FreeableMemory", "FreeStorageSpace"},
+	},
+	"aws_sns_topic": {
+		Service:        "sns",
+		Action:         "get-metrics",
+		DimensionKey:   "TopicName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"NumberOfMessagesPublished", "NumberOfNotificationsDelivered", "NumberOfNotificationsFailed"},
+	},
+	"aws_cloudwatch_log_group": {
+		Service:        "logs",
+		Action:         "get-metrics",
+		DimensionKey:   "LogGroupName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"IncomingBytes", "IncomingLogEvents"},
+	},
+	"aws_secretsmanager_secret": {
+		Service:        "secretsmanager",
+		Action:         "get-metrics",
+		DimensionKey:   "SecretName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"Errors"},
+	},
 	"google_storage_bucket": {
 		Service:        "storage",
 		Action:         "timeseries-list",
@@ -73,6 +116,27 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "service_name",
 		DimensionFrom:  "name",
 		DefaultMetrics: []string{"run.googleapis.com/request_count", "run.googleapis.com/request_latencies"},
+	},
+	"google_sql_database_instance": {
+		Service:        "cloudsql",
+		Action:         "timeseries-list",
+		DimensionKey:   "database_id",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"cloudsql.googleapis.com/database/cpu/utilization", "cloudsql.googleapis.com/database/memory/utilization", "cloudsql.googleapis.com/database/disk/utilization"},
+	},
+	"google_redis_instance": {
+		Service:        "redis",
+		Action:         "timeseries-list",
+		DimensionKey:   "instance_id",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"redis.googleapis.com/clients/connected", "redis.googleapis.com/memory/usage_ratio"},
+	},
+	"google_pubsub_subscription": {
+		Service:        "pubsub",
+		Action:         "timeseries-list",
+		DimensionKey:   "subscription_id",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"pubsub.googleapis.com/subscription/num_undelivered_messages", "pubsub.googleapis.com/subscription/oldest_unacked_message_age"},
 	},
 }
 

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -24,8 +24,8 @@ func reseed(t *testing.T) {
 func TestSeededBindings(t *testing.T) {
 	reseed(t)
 
-	require.GreaterOrEqual(t, len(RegisteredTypes()), 8,
-		"expected at least 8 seeded types, got %d", len(RegisteredTypes()))
+	require.GreaterOrEqual(t, len(RegisteredTypes()), 16,
+		"expected at least 16 seeded types, got %d", len(RegisteredTypes()))
 
 	for _, tfType := range seededTypes {
 		tfType := tfType


### PR DESCRIPTION
## Summary

Stacks on **#520** (bindings seed v2). 8 → **16/163 (~10%)** MetricsBinding entries.

### AWS additions (5)
- \`aws_rds_cluster\` — rds / DBClusterIdentifier / CPUUtilization, DatabaseConnections, FreeableMemory
- \`aws_db_instance\` — rds / DBInstanceIdentifier / CPUUtilization, DatabaseConnections, FreeableMemory, FreeStorageSpace
- \`aws_sns_topic\` — sns / TopicName / NumberOfMessagesPublished, NumberOfNotificationsDelivered, NumberOfNotificationsFailed
- \`aws_cloudwatch_log_group\` — logs / LogGroupName / IncomingBytes, IncomingLogEvents
- \`aws_secretsmanager_secret\` — secretsmanager / SecretName / Errors

### GCP additions (3)
- \`google_sql_database_instance\` — cloudsql / database_id / cpu/utilization, memory/utilization, disk/utilization
- \`google_redis_instance\` — redis / instance_id / clients/connected, memory/usage_ratio
- \`google_pubsub_subscription\` — pubsub / subscription_id / num_undelivered_messages, oldest_unacked_message_age

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./pkg/imported/bindings/...\` → 24 passed
- [x] \`go test ./cmd/... ./pkg/composer/imported/... ./pkg/imported/...\` → 3238 passed
- [ ] CI green

## Related

- Stacks on #520.