### PR TITLE
feat(policy): GCP drift coverage bundle 2 — 50% → 63% (#482)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -23,7 +23,7 @@ and is checked in lockstep with the runtime registries. See the
 ## Summary
 
 - **AWS:** 109 types · 100% Discoverable · 98% Enrichable · 36% DriftDetectable · 0% MetricsAvailable · 34% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 50% DriftDetectable · 0% MetricsAvailable · 89% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 0% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
@@ -163,7 +163,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_network` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_resource_policy` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_router` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_compute_security_policy` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_security_policy` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_target_http_proxy` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_target_https_proxy` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_url_map` | ✓ | ✓ | ✓ | – | ✓ |
@@ -174,11 +174,11 @@ and is checked in lockstep with the runtime registries. See the
 | `google_identity_platform_default_supported_idp_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key_iam_binding` | ✓ | ✓ | – | – | ✓ |
-| `google_kms_key_ring` | ✓ | ✓ | – | – | – |
-| `google_logging_project_sink` | ✓ | ✓ | – | – | ✓ |
-| `google_monitoring_alert_policy` | ✓ | ✓ | – | – | ✓ |
-| `google_monitoring_dashboard` | ✓ | ✓ | – | – | ✓ |
-| `google_monitoring_notification_channel` | ✓ | ✓ | – | – | ✓ |
+| `google_kms_key_ring` | ✓ | ✓ | ✓ | – | – |
+| `google_logging_project_sink` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_monitoring_alert_policy` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_monitoring_dashboard` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_monitoring_notification_channel` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_project_iam_member` | ✓ | ✓ | – | – | – |
 | `google_project_service` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_pubsub_subscription` | ✓ | ✓ | ✓ | – | ✓ |
@@ -195,7 +195,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_storage_bucket` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_storage_bucket_iam_member` | ✓ | ✓ | – | – | – |
 | `google_storage_bucket_object` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_vertex_ai_dataset` | ✓ | ✓ | – | – | ✓ |
+| `google_vertex_ai_dataset` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_vpc_access_connector` | ✓ | ✓ | ✓ | – | ✓ |
 
 ## How to regenerate

--- a/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
+++ b/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
@@ -3409,6 +3409,44 @@
       "semantic": "Exact"
     }
   ],
+  "google_compute_security_policy": [
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "rule.action",
+      "semantic": "Exact"
+    },
+    {
+      "path": "rule.match.config.src_ip_ranges",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "rule.match.versioned_expr",
+      "semantic": "Exact"
+    },
+    {
+      "path": "rule.priority",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    },
+    {
+      "path": "type",
+      "semantic": "Exact"
+    }
+  ],
   "google_compute_url_map": [
     {
       "path": "default_service",
@@ -3564,6 +3602,120 @@
     },
     {
       "path": "version_template.protection_level",
+      "semantic": "Exact"
+    }
+  ],
+  "google_kms_key_ring": [
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    }
+  ],
+  "google_logging_project_sink": [
+    {
+      "path": "destination",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "writer_identity",
+      "semantic": "Exact"
+    }
+  ],
+  "google_monitoring_alert_policy": [
+    {
+      "path": "combiner",
+      "semantic": "Exact"
+    },
+    {
+      "path": "display_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "notification_channels",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "severity",
+      "semantic": "Exact"
+    }
+  ],
+  "google_monitoring_dashboard": [
+    {
+      "path": "dashboard_json",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    }
+  ],
+  "google_monitoring_notification_channel": [
+    {
+      "path": "display_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "enabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "type",
       "semantic": "Exact"
     }
   ],
@@ -4302,6 +4454,36 @@
     },
     {
       "path": "temporary_hold",
+      "semantic": "Exact"
+    }
+  ],
+  "google_vertex_ai_dataset": [
+    {
+      "path": "display_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "encryption_spec.kms_key_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "metadata_schema_uri",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "region",
       "semantic": "Exact"
     }
   ],

--- a/pkg/composer/imported/policy/google_compute_security_policy.policy.go
+++ b/pkg/composer/imported/policy/google_compute_security_policy.policy.go
@@ -1,13 +1,30 @@
 package policy
 
+// googleComputeSecurityPolicyPolicy curates Layer 2 for
+// `google_compute_security_policy` (Cloud Armor). Identity scalars +
+// `type` (CLOUD_ARMOR vs CLOUD_ARMOR_EDGE) are DriftSemanticExact.
+// `rule.match.config.src_ip_ranges` is set-membership; element order
+// is irrelevant on the provider side and a missing CIDR is a missing
+// rule — DriftSemanticWholeList. Per-rule sub-scalars (priority /
+// action / versioned_expr) are exact-compare candidates today.
 var googleComputeSecurityPolicyPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — top-level policy knobs.
@@ -16,17 +33,21 @@ var googleComputeSecurityPolicyPolicy = Map{
 	},
 	"type": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — rule block (priority + action + match selectors).
 	"rule.priority": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"rule.action": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"rule.description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
@@ -36,11 +57,13 @@ var googleComputeSecurityPolicyPolicy = Map{
 	},
 	"rule.match.versioned_expr": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"rule.match.config.src_ip_ranges": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"rule.match.expr.expression": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,

--- a/pkg/composer/imported/policy/google_kms_key_ring.policy.go
+++ b/pkg/composer/imported/policy/google_kms_key_ring.policy.go
@@ -1,16 +1,30 @@
 package policy
 
+// googleKmsKeyRingPolicy curates Layer 2 for `google_kms_key_ring`.
+// Identity scalars (name / id / project / location) are tagged
+// DriftSemanticExact — KMS keyrings are singleton-ish (cannot be
+// deleted once created), so any drift on these identity leaves is a
+// re-parenting event that must be flagged. There are no list-valued
+// curated fields on the keyring surface; WholeList does not apply.
 var googleKmsKeyRingPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"location": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/google_logging_project_sink.policy.go
+++ b/pkg/composer/imported/policy/google_logging_project_sink.policy.go
@@ -1,12 +1,24 @@
 package policy
 
+// googleLoggingProjectSinkPolicy curates Layer 2 for
+// `google_logging_project_sink`. Identity scalars + the `destination`
+// wiring leaf are tagged DriftSemanticExact so re-pointing of the sink
+// destination surfaces. The sink has no list-valued curated fields
+// (filter is a single CEL expression); WholeList does not apply.
 var googleLoggingProjectSinkPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — destination is a managed resource reference
@@ -14,7 +26,8 @@ var googleLoggingProjectSinkPolicy = Map{
 	// pubsub.googleapis.com/topics/<t>, etc.).
 	"destination": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — filter expression + enabled state.
@@ -42,6 +55,7 @@ var googleLoggingProjectSinkPolicy = Map{
 	// writer_identity is the computed SA email — read-only.
 	"writer_identity": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 	// NB: google_logging_project_sink has no `timeouts` block per the
 	// provider schema — sink ops are synchronous from the Cloud Logging

--- a/pkg/composer/imported/policy/google_monitoring_alert_policy.policy.go
+++ b/pkg/composer/imported/policy/google_monitoring_alert_policy.policy.go
@@ -1,33 +1,51 @@
 package policy
 
+// googleMonitoringAlertPolicyPolicy curates Layer 2 for
+// `google_monitoring_alert_policy`. Identity scalars + the
+// `combiner` / `enabled` tuning scalars are DriftSemanticExact;
+// `notification_channels` is a list of managed channel references
+// where set-membership drift is the actionable signal but per-element
+// removal is not independently meaningful — DriftSemanticWholeList.
 var googleMonitoringAlertPolicyPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"display_name": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — notification channels are managed resources.
 	"notification_channels": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 
 	// Tuning — combiner + enable + severity.
 	"combiner": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"enabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"severity": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Conditions block — match conditions are core alert semantics.

--- a/pkg/composer/imported/policy/google_monitoring_dashboard.policy.go
+++ b/pkg/composer/imported/policy/google_monitoring_dashboard.policy.go
@@ -1,13 +1,23 @@
 package policy
 
+// googleMonitoringDashboardPolicy curates Layer 2 for
+// `google_monitoring_dashboard`. Identity scalars are DriftSemanticExact.
+// `dashboard_json` is the entire authored payload — exact-compare is the
+// right comparator (any change in the JSON body is meaningful), even
+// though the value is structured; per-leaf comparators inside the JSON
+// document are a future-comparator concern, not a WholeList one.
 var googleMonitoringDashboardPolicy = Map{
 	// Identity. Dashboards have no top-level `name` field in the schema —
 	// the dashboard's user-facing label lives inside dashboard_json's
 	// displayName property. `id` is the provider-assigned resource ID.
-	"id": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — entire payload is the JSON document. Treated as a single
@@ -15,6 +25,7 @@ var googleMonitoringDashboardPolicy = Map{
 	// edits but the composer / wizard owns large refactors.
 	"dashboard_json": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/google_monitoring_notification_channel.policy.go
+++ b/pkg/composer/imported/policy/google_monitoring_notification_channel.policy.go
@@ -1,24 +1,40 @@
 package policy
 
+// googleMonitoringNotificationChannelPolicy curates Layer 2 for
+// `google_monitoring_notification_channel`. Identity scalars and the
+// `type` (channel kind: email/slack/pagerduty/pubsub/etc.) carry
+// DriftSemanticExact — kind change is force-replace, drift signals
+// re-creation. No curated list-valued leaves on this resource;
+// `labels` / `sensitive_labels` are config bags handled by tagPolicy().
 var googleMonitoringNotificationChannelPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"display_name": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"type": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — enable / description.
 	"enabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,

--- a/pkg/composer/imported/policy/google_vertex_ai_dataset.policy.go
+++ b/pkg/composer/imported/policy/google_vertex_ai_dataset.policy.go
@@ -1,29 +1,48 @@
 package policy
 
+// googleVertexAIDatasetPolicy curates Layer 2 for
+// `google_vertex_ai_dataset`. Identity scalars (name/id/project/region)
+// plus the CMEK wiring leaf (`encryption_spec.kms_key_name`) are tagged
+// DriftSemanticExact — re-keying or re-parenting a dataset is a
+// force-replace event and drift must surface. No curated list-shaped
+// leaves on this resource; WholeList does not apply.
 var googleVertexAIDatasetPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"region": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"display_name": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"metadata_schema_uri": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — CMEK.
 	"encryption_spec.kms_key_name": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Labels


### PR DESCRIPTION
## Summary

Stacks on **#521**. GCP DriftDetectable **50% (27/54) → 63% (34/54)** via DriftSemantic axes on 7 more GCP types.

| TF Type | Notable additions |
|---|---|
| \`google_kms_key_ring\` | identity Exact |
| \`google_logging_project_sink\` | identity + \`destination\` Exact |
| \`google_monitoring_alert_policy\` | identity + tuning Exact; \`notification_channels\` WholeList |
| \`google_monitoring_dashboard\` | id/project + \`dashboard_json\` Exact |
| \`google_monitoring_notification_channel\` | identity + \`type\`/\`enabled\` Exact |
| \`google_compute_security_policy\` | identity + rule scalars Exact; \`rule.match.config.src_ip_ranges\` WholeList |
| \`google_vertex_ai_dataset\` | identity + CMEK wiring Exact |

## Coverage

- **GCP DriftDetectable:** 50% → **63%** (34/54).

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./cmd/... ./pkg/composer/imported/... ./pkg/imported/...\` → 3221 passed
- [ ] CI green

## Related

- Stacks on #521.