### PR TITLE
feat(policy): GCP drift coverage bundle 3 — 63% → 76% (#482)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -23,7 +23,7 @@ and is checked in lockstep with the runtime registries. See the
 ## Summary
 
 - **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 8% MetricsAvailable · 39% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 11% MetricsAvailable · 89% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 76% DriftDetectable · 11% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
@@ -144,19 +144,19 @@ and is checked in lockstep with the runtime registries. See the
 | TF Type | Discoverable | Enrichable | DriftDetectable | MetricsAvailable | AgentEditable |
 |---|---|---|---|---|---|
 | `google_api_gateway_api` | ✓ | ✓ | – | – | ✓ |
-| `google_api_gateway_api_config` | ✓ | ✓ | – | – | ✓ |
-| `google_api_gateway_gateway` | ✓ | ✓ | – | – | ✓ |
+| `google_api_gateway_api_config` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_api_gateway_gateway` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_cloud_run_v2_service` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_cloud_run_v2_service_iam_member` | ✓ | ✓ | – | – | – |
-| `google_cloudbuild_trigger` | ✓ | ✓ | – | – | ✓ |
+| `google_cloudbuild_trigger` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_cloudfunctions2_function` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_cloudfunctions2_function_iam_member` | ✓ | ✓ | – | – | – |
 | `google_compute_address` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_backend_service` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_firewall` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_forwarding_rule` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_compute_global_address` | ✓ | ✓ | – | – | ✓ |
-| `google_compute_global_forwarding_rule` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_global_address` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_compute_global_forwarding_rule` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_health_check` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_instance` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_managed_ssl_certificate` | ✓ | ✓ | – | – | ✓ |
@@ -165,11 +165,11 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_router` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_security_policy` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_target_http_proxy` | ✓ | ✓ | – | – | ✓ |
-| `google_compute_target_https_proxy` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_target_https_proxy` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_url_map` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_container_cluster` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_container_node_pool` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_firestore_database` | ✓ | ✓ | – | – | ✓ |
+| `google_firestore_database` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_identity_platform_config` | ✓ | ✓ | – | – | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key` | ✓ | ✓ | ✓ | – | ✓ |

--- a/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
+++ b/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
@@ -3745,6 +3745,74 @@
       "semantic": "Exact"
     }
   ],
+  "google_api_gateway_api_config": [
+    {
+      "path": "api",
+      "semantic": "Exact"
+    },
+    {
+      "path": "api_config_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "api_config_id_prefix",
+      "semantic": "Exact"
+    },
+    {
+      "path": "display_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "service_config_id",
+      "semantic": "Exact"
+    }
+  ],
+  "google_api_gateway_gateway": [
+    {
+      "path": "api_config",
+      "semantic": "Exact"
+    },
+    {
+      "path": "default_hostname",
+      "semantic": "Exact"
+    },
+    {
+      "path": "display_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "gateway_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "region",
+      "semantic": "Exact"
+    }
+  ],
   "google_cloud_run_v2_service": [
     {
       "path": "custom_audiences",
@@ -3764,6 +3832,80 @@
     },
     {
       "path": "project",
+      "semantic": "Exact"
+    }
+  ],
+  "google_cloudbuild_trigger": [
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "disabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "filename",
+      "semantic": "Exact"
+    },
+    {
+      "path": "filter",
+      "semantic": "Exact"
+    },
+    {
+      "path": "github.name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "github.owner",
+      "semantic": "Exact"
+    },
+    {
+      "path": "github.pull_request.branch",
+      "semantic": "Exact"
+    },
+    {
+      "path": "github.push.branch",
+      "semantic": "Exact"
+    },
+    {
+      "path": "github.push.tag",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ignored_files",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "include_build_logs",
+      "semantic": "Exact"
+    },
+    {
+      "path": "included_files",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "service_account",
+      "semantic": "Exact"
+    },
+    {
+      "path": "trigger_id",
       "semantic": "Exact"
     }
   ],
@@ -4034,6 +4176,106 @@
     },
     {
       "path": "service_label",
+      "semantic": "Exact"
+    },
+    {
+      "path": "subnetwork",
+      "semantic": "Exact"
+    },
+    {
+      "path": "target",
+      "semantic": "Exact"
+    }
+  ],
+  "google_compute_global_address": [
+    {
+      "path": "address",
+      "semantic": "Exact"
+    },
+    {
+      "path": "address_type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ip_version",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "network",
+      "semantic": "Exact"
+    },
+    {
+      "path": "prefix_length",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "purpose",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    }
+  ],
+  "google_compute_global_forwarding_rule": [
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ip_address",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ip_protocol",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ip_version",
+      "semantic": "Exact"
+    },
+    {
+      "path": "load_balancing_scheme",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "network",
+      "semantic": "Exact"
+    },
+    {
+      "path": "port_range",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
       "semantic": "Exact"
     },
     {
@@ -4391,6 +4633,68 @@
       "semantic": "Exact"
     }
   ],
+  "google_compute_target_https_proxy": [
+    {
+      "path": "certificate_manager_certificates",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "certificate_map",
+      "semantic": "Exact"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "http_keep_alive_timeout_sec",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "proxy_bind",
+      "semantic": "Exact"
+    },
+    {
+      "path": "quic_override",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    },
+    {
+      "path": "server_tls_policy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ssl_certificates",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "ssl_policy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "tls_early_data",
+      "semantic": "Exact"
+    },
+    {
+      "path": "url_map",
+      "semantic": "Exact"
+    }
+  ],
   "google_compute_url_map": [
     {
       "path": "default_service",
@@ -4478,6 +4782,52 @@
     },
     {
       "path": "project",
+      "semantic": "Exact"
+    }
+  ],
+  "google_firestore_database": [
+    {
+      "path": "app_engine_integration_mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "concurrency_mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "delete_protection_state",
+      "semantic": "Exact"
+    },
+    {
+      "path": "deletion_policy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "location_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "point_in_time_recovery_enablement",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "version_retention_period",
       "semantic": "Exact"
     }
   ],

--- a/pkg/composer/imported/policy/google_api_gateway_api_config.policy.go
+++ b/pkg/composer/imported/policy/google_api_gateway_api_config.policy.go
@@ -1,32 +1,45 @@
 package policy
 
+// googleAPIGatewayAPIConfigPolicy curates Layer 2 for `google_api_gateway_api_config`.
+//
+// Bundle D3 (#482): DriftSemantic axis added — all curated leaves are
+// scalar (string IDs, parent API self-link, display_name, spec
+// document path/contents) and use DriftSemanticExact. Spec payloads
+// themselves are opaque blobs from the caller's perspective; the
+// comparator surfaces any change as a whole-field diff.
 var googleAPIGatewayAPIConfigPolicy = Map{
 	// Identity
-	"name":          {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":            {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"api_config_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"name":          {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"id":            {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"api_config_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
 	"api_config_id_prefix": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"service_config_id": {
 		Role: RoleIdentity, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditNever,
+		Edit:          EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — parent API.
 	"api": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"display_name": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Spec / config payloads — operator-controlled, sensitivity not

--- a/pkg/composer/imported/policy/google_api_gateway_gateway.policy.go
+++ b/pkg/composer/imported/policy/google_api_gateway_gateway.policy.go
@@ -1,32 +1,44 @@
 package policy
 
+// googleAPIGatewayGatewayPolicy curates Layer 2 for `google_api_gateway_gateway`.
+//
+// Bundle D3 (#482): DriftSemantic axis added — all curated leaves are
+// scalar (string IDs, region, default_hostname, parent api_config
+// self-link, display_name) and use DriftSemanticExact. No list-valued
+// curated fields.
 var googleAPIGatewayGatewayPolicy = Map{
 	// Identity
-	"name":       {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":         {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"gateway_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"name":       {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"id":         {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"gateway_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"region": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"default_hostname": {
 		Role: RoleIdentity, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditNever,
+		Edit:          EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — parent api_config.
 	"api_config": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"display_name": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Labels

--- a/pkg/composer/imported/policy/google_cloudbuild_trigger.policy.go
+++ b/pkg/composer/imported/policy/google_cloudbuild_trigger.policy.go
@@ -1,49 +1,68 @@
 package policy
 
+// googleCloudbuildTriggerPolicy curates Layer 2 for `google_cloudbuild_trigger`.
+//
+// Bundle D3 (#482): DriftSemantic axis added — scalar identity (name,
+// project, location, trigger_id) + scalar config (filename, disabled,
+// service_account, github wiring) use DriftSemanticExact. List-valued
+// path filters (ignored_files, included_files) use DriftSemanticWholeList
+// — order is irrelevant on the provider side but per-element diffs are
+// not independently actionable (a missing glob is a missing filter rule).
 var googleCloudbuildTriggerPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"location": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"trigger_id": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — service account for build execution.
 	"service_account": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — top-level.
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"disabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"filename": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"filter": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"include_build_logs": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ignored_files": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"included_files": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	// NB: `tags` on cloudbuild_trigger is NOT labels — it's a free-text
 	// set of operator annotations (per provider docs). Same lint
@@ -65,18 +84,23 @@ var googleCloudbuildTriggerPolicy = Map{
 	// GitHub trigger source.
 	"github.owner": {
 		Role: RoleWiring, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"github.name": {
 		Role: RoleWiring, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"github.push.branch": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"github.push.tag": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"github.pull_request.branch": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Webhook trigger source.

--- a/pkg/composer/imported/policy/google_compute_global_address.policy.go
+++ b/pkg/composer/imported/policy/google_compute_global_address.policy.go
@@ -1,44 +1,59 @@
 package policy
 
+// googleComputeGlobalAddressPolicy curates Layer 2 for `google_compute_global_address`.
+//
+// Bundle D3 (#482): DriftSemantic axis added — all curated leaves are
+// scalar (IDs, network self-link, address, address_type, purpose,
+// ip_version, prefix_length, description) and use DriftSemanticExact.
+// No list-valued curated fields.
 var googleComputeGlobalAddressPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — VPC association for INTERNAL purpose.
 	"network": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"address": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"address_type": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"purpose": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ip_version": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"prefix_length": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Labels

--- a/pkg/composer/imported/policy/google_compute_global_forwarding_rule.policy.go
+++ b/pkg/composer/imported/policy/google_compute_global_forwarding_rule.policy.go
@@ -1,52 +1,72 @@
 package policy
 
+// googleComputeGlobalForwardingRulePolicy curates Layer 2 for
+// `google_compute_global_forwarding_rule`.
+//
+// Bundle D3 (#482): DriftSemantic axis added — all curated leaves are
+// scalar (IDs, target proxy self-link, network/subnetwork self-links,
+// IP address, protocol, version, port_range, load_balancing_scheme)
+// and use DriftSemanticExact. No list-valued curated fields.
 var googleComputeGlobalForwardingRulePolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — target proxy + VPC.
 	"target": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"network": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"subnetwork": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditRelationshipOnly,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ip_address": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ip_protocol": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ip_version": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"port_range": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditRequiresApproval,
-		ChangeRisk: ChangeMayReplace,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"load_balancing_scheme": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Labels

--- a/pkg/composer/imported/policy/google_compute_target_https_proxy.policy.go
+++ b/pkg/composer/imported/policy/google_compute_target_https_proxy.policy.go
@@ -1,58 +1,80 @@
 package policy
 
+// googleComputeTargetHttpsProxyPolicy curates Layer 2 for `google_compute_target_https_proxy`.
+//
+// Bundle D3 (#482): DriftSemantic axis added — scalar identity, scalar
+// wiring (url_map, certificate_map, ssl_policy, server_tls_policy),
+// and scalar tuning use DriftSemanticExact. The list-valued
+// `ssl_certificates` / `certificate_manager_certificates` use
+// DriftSemanticWholeList — element order is irrelevant on the
+// provider side, but a missing certificate ref breaks TLS for any
+// SNI hostname it served, so the comparator surfaces the list as a
+// whole.
 var googleComputeTargetHttpsProxyPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — URL map + certificates + policies.
 	"url_map": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ssl_certificates": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"certificate_manager_certificates": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"certificate_map": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ssl_policy": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"server_tls_policy": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"quic_override": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"proxy_bind": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"http_keep_alive_timeout_sec": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"tls_early_data": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/google_firestore_database.policy.go
+++ b/pkg/composer/imported/policy/google_firestore_database.policy.go
@@ -1,46 +1,63 @@
 package policy
 
+// googleFirestoreDatabasePolicy curates Layer 2 for `google_firestore_database`.
+//
+// Bundle D3 (#482): DriftSemantic axis added — all curated leaves are
+// scalar (IDs, location_id, type/mode enums, PITR / retention /
+// delete-protection knobs) and use DriftSemanticExact. No list-valued
+// curated fields — Firestore database is a project-singleton with no
+// label or selector lists.
 var googleFirestoreDatabasePolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"location_id": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — type + mode.
 	"type": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		Edit:          EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"concurrency_mode": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"app_engine_integration_mode": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Backup + PITR — security/reliability axis.
 	"point_in_time_recovery_enablement": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"version_retention_period": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"delete_protection_state": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"deletion_policy": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"timeouts": timeoutsPolicy(),


### PR DESCRIPTION
## Summary

Stacks on **#515**. GCP DriftDetectable **63% → 76%** via DriftSemantic axes on 7 more GCP types.

| TF Type | Notable additions |
|---|---|
| \`google_cloudbuild_trigger\` | identity/wiring scalar tuning Exact; \`ignored_files\`/\`included_files\` WholeList |
| \`google_api_gateway_api_config\` | Exact on identity scalars |
| \`google_api_gateway_gateway\` | Exact on identity scalars |
| \`google_compute_target_https_proxy\` | \`ssl_certificates\`/\`certificate_manager_certificates\` WholeList |
| \`google_compute_global_forwarding_rule\` | Exact on identity + protocol/port scalars |
| \`google_compute_global_address\` | Exact on identity + address_type/purpose |
| \`google_firestore_database\` | Exact on location/type/database_id |

## Coverage

GCP DriftDetectable: 63% → **76%** (41/54)

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./pkg/composer/imported/... ./pkg/imported/... -count=1\` → 602 passed
- [ ] CI green

## Related

- Stacks on #515.