### PR TITLE
feat(imported): extend MetricsBinding registry — 40 total (#482)

### DIFF
--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -36,6 +36,14 @@ var seededTypes = []string{
 	"google_compute_backend_service",
 	"google_vertex_ai_dataset",
 	"google_logging_project_sink",
+	"aws_vpc",
+	"aws_route53_zone",
+	"aws_kms_key",
+	"aws_iam_role",
+	"aws_cloudwatch_metric_alarm",
+	"google_compute_network",
+	"google_kms_crypto_key",
+	"google_service_account",
 }
 
 // seededBindings mirrors the registrations performed by init(). Used
@@ -265,6 +273,64 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "sink_name",
 		DimensionFrom:  "name",
 		DefaultMetrics: []string{"logging.googleapis.com/exports/byte_count", "logging.googleapis.com/exports/log_entry_count"},
+	},
+	"aws_vpc": {
+		Service:        "vpc",
+		Action:         "get-metrics",
+		DimensionKey:   "VpcId",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"network-bytes-in", "network-bytes-out"},
+	},
+	"aws_route53_zone": {
+		Service:        "route53",
+		Action:         "get-metrics",
+		DimensionKey:   "HostedZoneId",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"DNSQueries"},
+	},
+	"aws_kms_key": {
+		Service:        "kms",
+		Action:         "get-metrics",
+		DimensionKey:   "KeyId",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"SecondsUntilKeyMaterialExpiration"},
+	},
+	"aws_iam_role": {
+		// IAM metrics are CloudTrail-only — registered so consumers can
+		// route policy queries; DefaultMetrics intentionally empty.
+		Service:       "iam",
+		Action:        "get-metrics",
+		DimensionKey:  "RoleName",
+		DimensionFrom: "name",
+	},
+	"aws_cloudwatch_metric_alarm": {
+		Service:        "cloudwatch",
+		Action:         "get-metrics",
+		DimensionKey:   "AlarmName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"StateValue"},
+	},
+	"google_compute_network": {
+		Service:        "compute",
+		Action:         "timeseries-list",
+		DimensionKey:   "network_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"networking.googleapis.com/vpc_flow/ingress_bytes_count", "networking.googleapis.com/vpc_flow/egress_bytes_count"},
+	},
+	"google_kms_crypto_key": {
+		Service:        "cloudkms",
+		Action:         "timeseries-list",
+		DimensionKey:   "crypto_key_id",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"cloudkms.googleapis.com/key/sign_request_count", "cloudkms.googleapis.com/key/verify_request_count"},
+	},
+	"google_service_account": {
+		// IAM-style: registered for routing only; DefaultMetrics
+		// intentionally empty (mirrors aws_iam_role).
+		Service:       "iam",
+		Action:        "timeseries-list",
+		DimensionKey:  "unique_id",
+		DimensionFrom: "name",
 	},
 }
 

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -21,11 +21,23 @@ func reseed(t *testing.T) {
 	regMu.Unlock()
 }
 
+// emptyDefaultMetricsAllowed lists tfTypes that are intentionally
+// registered with an empty DefaultMetrics — typically IAM-style
+// types whose metrics are CloudTrail-only / audit-log-only and which
+// only need to appear in the registry so downstream consumers can
+// route policy queries. Per bindings.go, an entry with empty
+// DefaultMetrics means "use consumer defaults" and is distinct from
+// "type isn't bound at all".
+var emptyDefaultMetricsAllowed = map[string]bool{
+	"aws_iam_role":           true,
+	"google_service_account": true,
+}
+
 func TestSeededBindings(t *testing.T) {
 	reseed(t)
 
-	require.GreaterOrEqual(t, len(RegisteredTypes()), 32,
-		"expected at least 32 seeded types, got %d", len(RegisteredTypes()))
+	require.GreaterOrEqual(t, len(RegisteredTypes()), 40,
+		"expected at least 40 seeded types, got %d", len(RegisteredTypes()))
 
 	for _, tfType := range seededTypes {
 		tfType := tfType
@@ -38,7 +50,12 @@ func TestSeededBindings(t *testing.T) {
 			assert.NotEmpty(t, b.Action, "%s: Action empty", tfType)
 			assert.NotEmpty(t, b.DimensionKey, "%s: DimensionKey empty", tfType)
 			assert.NotEmpty(t, b.DimensionFrom, "%s: DimensionFrom empty", tfType)
-			assert.NotEmpty(t, b.DefaultMetrics, "%s: DefaultMetrics empty", tfType)
+			if emptyDefaultMetricsAllowed[tfType] {
+				assert.Empty(t, b.DefaultMetrics,
+					"%s: listed in emptyDefaultMetricsAllowed but DefaultMetrics is non-empty — remove from allowlist", tfType)
+			} else {
+				assert.NotEmpty(t, b.DefaultMetrics, "%s: DefaultMetrics empty", tfType)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Stacks on **#528**. MetricsBinding entries 32 → **40/163 (~25%)**.

### New (8) — network + IAM + identity
- AWS (5): \`aws_vpc\`, \`aws_route53_zone\`, \`aws_kms_key\`, \`aws_iam_role\`, \`aws_cloudwatch_metric_alarm\`
- GCP (3): \`google_compute_network\`, \`google_kms_crypto_key\`, \`google_service_account\`

\`aws_iam_role\` and \`google_service_account\` register with empty \`DefaultMetrics\` per spec — IAM-style resources have CloudTrail-only metrics; the test allowlists them via \`emptyDefaultMetricsAllowed\` (valid per \`bindings.go\` contract — empty = "use consumer defaults").

## Test plan

- [x] \`go test ./pkg/imported/bindings/...\` → 48 passed
- [x] \`go test ./cmd/... ./pkg/composer/imported/... ./pkg/imported/...\` → 3325 passed
- [ ] CI green (dormant until #515 merges and stack retargets to main)

## Related

- Stacks on #528 → #525 → #515.