### PR TITLE
fix(ci): trigger workflows on PRs targeting feat/mega-bundle-* branches (#482)

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, "feat/mega-bundle-*"]
 
 jobs:
   discover:


### PR DESCRIPTION
## Summary

Stacks on **#515**. Workflow simplification: stacked PRs targeting \`feat/mega-bundle-*\` branches were previously CI-dormant because \`terraform-validate.yml\` only triggers on PRs to \`main\`. Without CI, stacked reviews are blind.

This adds \`feat/mega-bundle-*\` to the \`on.pull_request.branches\` filter — single 1-line change in \`.github/workflows/terraform-validate.yml\`. Push triggers (\`on.push.branches\`) intentionally unchanged.

## Why it matters

The current PR stack has 5+ open PRs (#525, #526, #527, #528, #529) all sitting at 0 CI checks until they retarget to main. Reviewers can't validate stacked work without merging blind. This fix lights up CI on every stacked PR.

## Test plan

- [x] YAML parses (\`python3 -c "yaml.safe_load(...)"\`)
- [ ] CI green on this PR (will exercise the new branch trigger)

## Related

- Builds on #515.