### PR TITLE
feat(policy): GCP drift coverage bundle 4 — 76% → 89% (#482)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -23,7 +23,7 @@ and is checked in lockstep with the runtime registries. See the
 ## Summary
 
 - **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 8% MetricsAvailable · 39% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 76% DriftDetectable · 11% MetricsAvailable · 89% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 89% DriftDetectable · 11% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
@@ -143,14 +143,14 @@ and is checked in lockstep with the runtime registries. See the
 
 | TF Type | Discoverable | Enrichable | DriftDetectable | MetricsAvailable | AgentEditable |
 |---|---|---|---|---|---|
-| `google_api_gateway_api` | ✓ | ✓ | – | – | ✓ |
+| `google_api_gateway_api` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_api_gateway_api_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_api_gateway_gateway` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_cloud_run_v2_service` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_cloud_run_v2_service_iam_member` | ✓ | ✓ | – | – | – |
+| `google_cloud_run_v2_service_iam_member` | ✓ | ✓ | ✓ | – | – |
 | `google_cloudbuild_trigger` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_cloudfunctions2_function` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_cloudfunctions2_function_iam_member` | ✓ | ✓ | – | – | – |
+| `google_cloudfunctions2_function_iam_member` | ✓ | ✓ | ✓ | – | – |
 | `google_compute_address` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_backend_service` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_firewall` | ✓ | ✓ | ✓ | – | ✓ |
@@ -159,12 +159,12 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_global_forwarding_rule` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_health_check` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_instance` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_compute_managed_ssl_certificate` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_managed_ssl_certificate` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_network` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_compute_resource_policy` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_resource_policy` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_router` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_security_policy` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_compute_target_http_proxy` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_target_http_proxy` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_target_https_proxy` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_url_map` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_container_cluster` | ✓ | ✓ | ✓ | – | ✓ |
@@ -173,7 +173,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_identity_platform_config` | ✓ | ✓ | – | – | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_kms_crypto_key_iam_binding` | ✓ | ✓ | – | – | ✓ |
+| `google_kms_crypto_key_iam_binding` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_key_ring` | ✓ | ✓ | ✓ | – | – |
 | `google_logging_project_sink` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_monitoring_alert_policy` | ✓ | ✓ | ✓ | – | ✓ |

--- a/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
+++ b/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
@@ -3745,6 +3745,32 @@
       "semantic": "Exact"
     }
   ],
+  "google_api_gateway_api": [
+    {
+      "path": "api_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "display_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "managed_service",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    }
+  ],
   "google_api_gateway_api_config": [
     {
       "path": "api",
@@ -3832,6 +3858,32 @@
     },
     {
       "path": "project",
+      "semantic": "Exact"
+    }
+  ],
+  "google_cloud_run_v2_service_iam_member": [
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "member",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "role",
       "semantic": "Exact"
     }
   ],
@@ -3928,6 +3980,32 @@
     },
     {
       "path": "project",
+      "semantic": "Exact"
+    }
+  ],
+  "google_cloudfunctions2_function_iam_member": [
+    {
+      "path": "cloud_function",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "member",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "role",
       "semantic": "Exact"
     }
   ],
@@ -4491,6 +4569,36 @@
       "semantic": "Exact"
     }
   ],
+  "google_compute_managed_ssl_certificate": [
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "managed.domains",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    },
+    {
+      "path": "subject_alternative_names",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "type",
+      "semantic": "Exact"
+    }
+  ],
   "google_compute_network": [
     {
       "path": "auto_create_subnetworks",
@@ -4538,6 +4646,28 @@
     },
     {
       "path": "routing_mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    }
+  ],
+  "google_compute_resource_policy": [
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "region",
       "semantic": "Exact"
     },
     {
@@ -4630,6 +4760,28 @@
     },
     {
       "path": "type",
+      "semantic": "Exact"
+    }
+  ],
+  "google_compute_target_http_proxy": [
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    },
+    {
+      "path": "url_map",
       "semantic": "Exact"
     }
   ],
@@ -4896,6 +5048,24 @@
     },
     {
       "path": "version_template.protection_level",
+      "semantic": "Exact"
+    }
+  ],
+  "google_kms_crypto_key_iam_binding": [
+    {
+      "path": "crypto_key_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "members",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "role",
       "semantic": "Exact"
     }
   ],

--- a/pkg/composer/imported/policy/google_api_gateway_api.policy.go
+++ b/pkg/composer/imported/policy/google_api_gateway_api.policy.go
@@ -2,24 +2,27 @@ package policy
 
 var googleAPIGatewayAPIPolicy = Map{
 	// Identity
-	"name":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":     {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"api_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"name":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"id":     {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"api_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"create_time": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
 	},
 	"managed_service": {
 		Role: RoleIdentity, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditNever,
+		Edit:          EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"display_name": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Labels

--- a/pkg/composer/imported/policy/google_cloud_run_v2_service_iam_member.policy.go
+++ b/pkg/composer/imported/policy/google_cloud_run_v2_service_iam_member.policy.go
@@ -5,13 +5,13 @@ package policy
 // location × role × member) tuple is identity; all fields are
 // non-editable since the row is replaced rather than mutated.
 var googleCloudRunV2ServiceIAMMemberPolicy = Map{
-	"id":       {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"id":       {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"etag":     {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"name":     {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"location": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"project":  {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":     {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"member":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"name":     {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"location": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"project":  {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"role":     {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"member":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
 }
 
 func init() {

--- a/pkg/composer/imported/policy/google_cloudfunctions2_function_iam_member.policy.go
+++ b/pkg/composer/imported/policy/google_cloudfunctions2_function_iam_member.policy.go
@@ -6,13 +6,13 @@ package policy
 // Functions Gen-2 and Cloud Run v2 share the IAM-member resource
 // schema modulo the `cloud_function` name field.
 var googleCloudfunctions2FunctionIAMMemberPolicy = Map{
-	"id":             {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"id":             {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"etag":           {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"cloud_function": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"location":       {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"project":        {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":           {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"member":         {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"cloud_function": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"location":       {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"project":        {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"role":           {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"member":         {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
 }
 
 func init() {

--- a/pkg/composer/imported/policy/google_compute_managed_ssl_certificate.policy.go
+++ b/pkg/composer/imported/policy/google_compute_managed_ssl_certificate.policy.go
@@ -2,17 +2,19 @@ package policy
 
 var googleComputeManagedSslCertificatePolicy = Map{
 	// Identity
-	"name":           {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":             {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link":      {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name":           {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"id":             {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"self_link":      {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"certificate_id": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"type": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
@@ -21,7 +23,8 @@ var googleComputeManagedSslCertificatePolicy = Map{
 	},
 	"subject_alternative_names": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditNever,
+		Edit:          EditNever,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"expire_time": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
@@ -35,6 +38,7 @@ var googleComputeManagedSslCertificatePolicy = Map{
 	"managed.domains": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/google_compute_resource_policy.policy.go
+++ b/pkg/composer/imported/policy/google_compute_resource_policy.policy.go
@@ -2,16 +2,18 @@ package policy
 
 var googleComputeResourcePolicyPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"region": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning

--- a/pkg/composer/imported/policy/google_compute_target_http_proxy.policy.go
+++ b/pkg/composer/imported/policy/google_compute_target_http_proxy.policy.go
@@ -2,19 +2,21 @@ package policy
 
 var googleComputeTargetHttpProxyPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"proxy_id": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
 
 	// Wiring — URL map is the routing target.
 	"url_map": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning

--- a/pkg/composer/imported/policy/google_kms_crypto_key_iam_binding.policy.go
+++ b/pkg/composer/imported/policy/google_kms_crypto_key_iam_binding.policy.go
@@ -6,11 +6,11 @@ package policy
 // role) tuple is replacement-causing, but the members list itself is
 // edited InPlace by the IAM policy (the provider PATCHes the binding).
 var googleKMSCryptoKeyIAMBindingPolicy = Map{
-	"id":            {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"id":            {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"etag":          {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"crypto_key_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":          {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"members":       {Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval, ChangeRisk: ChangeInPlace},
+	"crypto_key_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"role":          {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"members":       {Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval, ChangeRisk: ChangeInPlace, DriftSemantic: DriftSemanticWholeList},
 }
 
 func init() {


### PR DESCRIPTION
## Summary

Stacks on **#526**. Final GCP drift push: **76% → 89%** (48/54) via DriftSemantic axes on 7 more GCP types.

| TF Type | Notable additions |
|---|---|
| \`google_api_gateway_api\` | identity Exact |
| \`google_cloud_run_v2_service_iam_member\` | identity Exact |
| \`google_cloudfunctions2_function_iam_member\` | identity Exact |
| \`google_compute_managed_ssl_certificate\` | identity Exact; \`subject_alternative_names\` + \`managed.domains\` WholeList |
| \`google_compute_resource_policy\` | identity + schedule scalars Exact |
| \`google_compute_target_http_proxy\` | identity + url_map Exact |
| \`google_kms_crypto_key_iam_binding\` | identity Exact; \`members\` WholeList |

## Coverage

GCP DriftDetectable: 76% → **89%** (48/54). AWS DriftDetectable unchanged.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./pkg/composer/imported/... ./pkg/imported/...\` → 602 passed
- [ ] CI green (dormant until #515 + #526 merge — but if #530 lands first, this PR's CI will fire on push to origin)

## Related

- Stacks on #526 → #515.