### PR TITLE
feat(policy): GCP drift coverage bundle 5 — 89% → 100% (#482)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -23,7 +23,7 @@ and is checked in lockstep with the runtime registries. See the
 ## Summary
 
 - **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 8% MetricsAvailable · 39% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 89% DriftDetectable · 11% MetricsAvailable · 89% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 100% DriftDetectable · 11% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
@@ -170,7 +170,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_container_cluster` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_container_node_pool` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_firestore_database` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_identity_platform_config` | ✓ | ✓ | – | – | ✓ |
+| `google_identity_platform_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key_iam_binding` | ✓ | ✓ | ✓ | – | ✓ |
@@ -179,21 +179,21 @@ and is checked in lockstep with the runtime registries. See the
 | `google_monitoring_alert_policy` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_monitoring_dashboard` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_monitoring_notification_channel` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_project_iam_member` | ✓ | ✓ | – | – | – |
+| `google_project_iam_member` | ✓ | ✓ | ✓ | – | – |
 | `google_project_service` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_pubsub_subscription` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_pubsub_topic` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_redis_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_secret_manager_secret` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_secret_manager_secret_iam_binding` | ✓ | ✓ | – | – | ✓ |
-| `google_secret_manager_secret_iam_member` | ✓ | ✓ | – | – | – |
+| `google_secret_manager_secret_iam_binding` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_secret_manager_secret_iam_member` | ✓ | ✓ | ✓ | – | – |
 | `google_secret_manager_secret_version` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_service_account` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_service_networking_connection` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_sql_database_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_sql_user` | ✓ | ✓ | – | – | ✓ |
+| `google_sql_user` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_storage_bucket` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_storage_bucket_iam_member` | ✓ | ✓ | – | – | – |
+| `google_storage_bucket_iam_member` | ✓ | ✓ | ✓ | – | – |
 | `google_storage_bucket_object` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_vertex_ai_dataset` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_vpc_access_connector` | ✓ | ✓ | ✓ | – | ✓ |

--- a/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
+++ b/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
@@ -4983,6 +4983,28 @@
       "semantic": "Exact"
     }
   ],
+  "google_identity_platform_config": [
+    {
+      "path": "authorized_domains",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "autodelete_anonymous_users",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    }
+  ],
   "google_identity_platform_default_supported_idp_config": [
     {
       "path": "enabled",
@@ -5180,6 +5202,24 @@
     },
     {
       "path": "type",
+      "semantic": "Exact"
+    }
+  ],
+  "google_project_iam_member": [
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "member",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "role",
       "semantic": "Exact"
     }
   ],
@@ -5477,6 +5517,50 @@
       "semantic": "Exact"
     }
   ],
+  "google_secret_manager_secret_iam_binding": [
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "members",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "role",
+      "semantic": "Exact"
+    },
+    {
+      "path": "secret_id",
+      "semantic": "Exact"
+    }
+  ],
+  "google_secret_manager_secret_iam_member": [
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "member",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "role",
+      "semantic": "Exact"
+    },
+    {
+      "path": "secret_id",
+      "semantic": "Exact"
+    }
+  ],
   "google_secret_manager_secret_version": [
     {
       "path": "deletion_policy",
@@ -5729,6 +5813,32 @@
       "semantic": "Exact"
     }
   ],
+  "google_sql_user": [
+    {
+      "path": "host",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "instance",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "type",
+      "semantic": "Exact"
+    }
+  ],
   "google_storage_bucket": [
     {
       "path": "autoclass.enabled",
@@ -5848,6 +5958,24 @@
     },
     {
       "path": "website.not_found_page",
+      "semantic": "Exact"
+    }
+  ],
+  "google_storage_bucket_iam_member": [
+    {
+      "path": "bucket",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "member",
+      "semantic": "Exact"
+    },
+    {
+      "path": "role",
       "semantic": "Exact"
     }
   ],

--- a/pkg/composer/imported/policy/google_identity_platform_config.policy.go
+++ b/pkg/composer/imported/policy/google_identity_platform_config.policy.go
@@ -4,22 +4,22 @@ var googleIdentityPlatformConfigPolicy = Map{
 	// Identity. The Config is a project-scoped singleton named
 	// projects/<p>/config; both `name` (full path) and `id` are
 	// provider-computed.
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — authorized domains and auto-delete behavior are the
 	// primary operator-facing knobs.
 	"authorized_domains": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit: EditRequiresApproval, DriftSemantic: DriftSemanticWholeList,
 	},
 	"autodelete_anonymous_users": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit: EditChatSafe, DriftSemantic: DriftSemanticExact,
 	},
 
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/google_project_iam_member.policy.go
+++ b/pkg/composer/imported/policy/google_project_iam_member.policy.go
@@ -10,11 +10,11 @@ package policy
 // rows rather than as an editable nested struct here.
 var googleProjectIAMMemberPolicy = Map{
 	// Identity.
-	"id":      {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"id":      {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"etag":    {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"project": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":    {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"member":  {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"project": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"role":    {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"member":  {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
 }
 
 func init() {

--- a/pkg/composer/imported/policy/google_secret_manager_secret_iam_binding.policy.go
+++ b/pkg/composer/imported/policy/google_secret_manager_secret_iam_binding.policy.go
@@ -5,12 +5,12 @@ package policy
 // `members` list is edited InPlace by the IAM policy PATCH; the
 // (secret_id × role) tuple is identity.
 var googleSecretManagerSecretIAMBindingPolicy = Map{
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"etag":      {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"project":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"secret_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"members":   {Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval, ChangeRisk: ChangeInPlace},
+	"project":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"secret_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"role":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"members":   {Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval, ChangeRisk: ChangeInPlace, DriftSemantic: DriftSemanticWholeList},
 }
 
 func init() {

--- a/pkg/composer/imported/policy/google_secret_manager_secret_iam_member.policy.go
+++ b/pkg/composer/imported/policy/google_secret_manager_secret_iam_member.policy.go
@@ -6,12 +6,12 @@ package policy
 // a top-level attribute on this child resource — identityAttrLeaves
 // names it explicitly.
 var googleSecretManagerSecretIAMMemberPolicy = Map{
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"etag":      {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"project":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"secret_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"member":    {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"project":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"secret_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"role":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"member":    {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
 }
 
 func init() {

--- a/pkg/composer/imported/policy/google_sql_user.policy.go
+++ b/pkg/composer/imported/policy/google_sql_user.policy.go
@@ -2,27 +2,27 @@ package policy
 
 var googleSqlUserPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
+	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact,
 	},
 	"host": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — parent instance.
 	"instance": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — user type.
 	"type": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact,
 	},
 	"deletion_policy": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,

--- a/pkg/composer/imported/policy/google_storage_bucket_iam_member.policy.go
+++ b/pkg/composer/imported/policy/google_storage_bucket_iam_member.policy.go
@@ -5,11 +5,11 @@ package policy
 // google_project_iam_member policy shape — IAM-binding resources have
 // a small, fully-identity surface.
 var googleStorageBucketIAMMemberPolicy = Map{
-	"id":     {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"id":     {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever, DriftSemantic: DriftSemanticExact},
 	"etag":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"bucket": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"member": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"bucket": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"role":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
+	"member": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace, DriftSemantic: DriftSemanticExact},
 }
 
 func init() {


### PR DESCRIPTION
## Summary

Final batch in the GCP drift-tagging series. Adds `DriftSemantic` axis to the last 6 untagged GCP policies, lifting GCP **DriftDetectable from 89% → 100%**.

Stacked on #531.

## Types tagged

- `google_identity_platform_config` (incl. `authorized_domains` WholeList)
- `google_project_iam_member`
- `google_secret_manager_secret_iam_binding` (`members` WholeList)
- `google_secret_manager_secret_iam_member`
- `google_sql_user`
- `google_storage_bucket_iam_member`

## Semantics

- `DriftSemanticExact` on scalar identity / wiring fields (project, role, member, name, instance, type, host).
- `DriftSemanticWholeList` on list-shaped fields where the set is compared as a whole (`authorized_domains`, IAM `members`).

## Coverage delta

- **GCP DriftDetectable:** 89% → **100%** (54/54 types).
- AWS unchanged at 42%.

This closes out the GCP drift-tagging series — every GCP type in the registry now has at least one DriftSemantic-tagged field.

## Test plan

- [x] `go test ./pkg/composer/imported/policy/... -count=1` — 295 passed.
- [x] `go test ./cmd/imported-codegen/... -count=1` — 247 passed.
- [x] `UPDATE_GOLDEN=1 go test ./pkg/composer/imported/policy/...` regenerated goldens.
- [x] `drift-fields.json` and `SUPPORTED_RESOURCES.md` regenerated.