### PR TITLE
feat(imported): extend MetricsBinding registry — 56 total (#482)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -22,8 +22,8 @@ and is checked in lockstep with the runtime registries. See the
 
 ## Summary
 
-- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 23% MetricsAvailable · 39% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 33% MetricsAvailable · 89% AgentEditable
+- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 28% MetricsAvailable · 39% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 37% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
@@ -39,7 +39,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_apigatewayv2_domain_name` | ✓ | ✓ | – | – | – |
 | `aws_apigatewayv2_integration` | ✓ | ✓ | – | – | – |
 | `aws_apigatewayv2_route` | ✓ | ✓ | – | – | – |
-| `aws_apigatewayv2_stage` | ✓ | ✓ | ✓ | – | ✓ |
+| `aws_apigatewayv2_stage` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_autoscaling_group` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_autoscaling_group_tag` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_backup_plan` | ✓ | ✓ | – | – | – |
@@ -59,7 +59,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_cloudwatch_metric_alarm` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_cognito_identity_provider` | ✓ | ✓ | – | – | – |
 | `aws_cognito_resource_server` | ✓ | ✓ | – | – | – |
-| `aws_cognito_user_pool` | ✓ | ✓ | – | – | – |
+| `aws_cognito_user_pool` | ✓ | ✓ | – | ✓ | – |
 | `aws_cognito_user_pool_client` | ✓ | ✓ | – | – | – |
 | `aws_cognito_user_pool_domain` | ✓ | ✓ | – | – | – |
 | `aws_db_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -67,7 +67,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_db_subnet_group` | ✓ | ✓ | – | – | – |
 | `aws_dynamodb_contributor_insights` | ✓ | ✓ | ✓ | – | – |
 | `aws_dynamodb_table` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `aws_ebs_volume` | ✓ | ✓ | – | – | – |
+| `aws_ebs_volume` | ✓ | ✓ | – | ✓ | – |
 | `aws_ecs_cluster` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_ecs_cluster_capacity_providers` | ✓ | ✓ | – | – | – |
 | `aws_eip` | ✓ | ✓ | – | – | – |
@@ -75,7 +75,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_eks_addon` | ✓ | ✓ | – | – | – |
 | `aws_eks_cluster` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_eks_fargate_profile` | ✓ | ✓ | – | – | – |
-| `aws_eks_node_group` | ✓ | ✓ | – | – | – |
+| `aws_eks_node_group` | ✓ | ✓ | – | ✓ | – |
 | `aws_eks_pod_identity_association` | ✓ | ✓ | – | – | – |
 | `aws_elasticache_parameter_group` | ✓ | ✓ | – | – | – |
 | `aws_elasticache_replication_group` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -100,7 +100,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_lambda_permission` | ✓ | ✓ | – | – | – |
 | `aws_launch_template` | ✓ | ✓ | – | – | – |
 | `aws_lb` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `aws_lb_listener` | ✓ | ✓ | ✓ | – | ✓ |
+| `aws_lb_listener` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_lb_target_group` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_msk_cluster` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_msk_configuration` | ✓ | ✓ | – | – | – |
@@ -133,7 +133,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_subnet` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_vpc` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_vpc_dhcp_options` | ✓ | ✓ | – | – | – |
-| `aws_vpc_endpoint` | ✓ | ✓ | ✓ | – | ✓ |
+| `aws_vpc_endpoint` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_vpc_security_group_egress_rule` | ✓ | ✓ | – | – | – |
 | `aws_vpc_security_group_ingress_rule` | ✓ | ✓ | – | – | – |
 | `aws_wafv2_web_acl` | ✓ | ✓ | – | ✓ | – |
@@ -154,7 +154,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_address` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_backend_service` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_firewall` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_compute_forwarding_rule` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_compute_forwarding_rule` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_global_address` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_global_forwarding_rule` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_health_check` | ✓ | ✓ | ✓ | – | ✓ |
@@ -196,7 +196,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_storage_bucket_iam_member` | ✓ | ✓ | – | – | – |
 | `google_storage_bucket_object` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_vertex_ai_dataset` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_vpc_access_connector` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_vpc_access_connector` | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 ## How to regenerate
 

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -52,6 +52,14 @@ var seededTypes = []string{
 	"google_cloudfunctions2_function",
 	"google_monitoring_alert_policy",
 	"google_secret_manager_secret",
+	"aws_apigatewayv2_stage",
+	"aws_cognito_user_pool",
+	"aws_ebs_volume",
+	"aws_eks_node_group",
+	"aws_lb_listener",
+	"aws_vpc_endpoint",
+	"google_compute_forwarding_rule",
+	"google_vpc_access_connector",
 }
 
 // seededBindings mirrors the registrations performed by init(). Used
@@ -395,6 +403,62 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "secret_id",
 		DimensionFrom:  "name",
 		DefaultMetrics: []string{"secretmanager.googleapis.com/secret/access_count", "secretmanager.googleapis.com/secret/version_count"},
+	},
+	"aws_apigatewayv2_stage": {
+		Service:        "apigateway",
+		Action:         "get-metrics",
+		DimensionKey:   "Stage",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"Count", "4xx", "5xx", "Latency", "IntegrationLatency"},
+	},
+	"aws_cognito_user_pool": {
+		Service:        "cognito",
+		Action:         "get-metrics",
+		DimensionKey:   "UserPool",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"SignInSuccesses", "SignUpSuccesses", "TokenRefreshSuccesses", "FederationSuccesses"},
+	},
+	"aws_ebs_volume": {
+		Service:        "ebs",
+		Action:         "get-metrics",
+		DimensionKey:   "VolumeId",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"VolumeReadOps", "VolumeWriteOps", "VolumeQueueLength", "VolumeIdleTime"},
+	},
+	"aws_eks_node_group": {
+		Service:        "eks",
+		Action:         "get-metrics",
+		DimensionKey:   "NodegroupName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"node_cpu_utilization", "node_memory_utilization", "node_filesystem_utilization"},
+	},
+	"aws_lb_listener": {
+		Service:        "elb",
+		Action:         "get-metrics",
+		DimensionKey:   "Listener",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"RequestCount", "HTTPCode_ELB_4XX_Count", "HTTPCode_ELB_5XX_Count"},
+	},
+	"aws_vpc_endpoint": {
+		Service:        "vpc",
+		Action:         "get-metrics",
+		DimensionKey:   "VpcEndpointId",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"BytesProcessed", "PacketsDropped", "ActiveConnections"},
+	},
+	"google_compute_forwarding_rule": {
+		Service:        "loadbalancing",
+		Action:         "timeseries-list",
+		DimensionKey:   "forwarding_rule_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"loadbalancing.googleapis.com/l3/internal/ingress_bytes_count", "loadbalancing.googleapis.com/l3/internal/egress_bytes_count"},
+	},
+	"google_vpc_access_connector": {
+		Service:        "vpcaccess",
+		Action:         "timeseries-list",
+		DimensionKey:   "connector_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"vpcaccess.googleapis.com/connector/sent_bytes_count", "vpcaccess.googleapis.com/connector/received_bytes_count", "vpcaccess.googleapis.com/connector/instances"},
 	},
 }
 

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -36,8 +36,8 @@ var emptyDefaultMetricsAllowed = map[string]bool{
 func TestSeededBindings(t *testing.T) {
 	reseed(t)
 
-	require.GreaterOrEqual(t, len(RegisteredTypes()), 48,
-		"expected at least 48 seeded types, got %d", len(RegisteredTypes()))
+	require.GreaterOrEqual(t, len(RegisteredTypes()), 56,
+		"expected at least 56 seeded types, got %d", len(RegisteredTypes()))
 
 	for _, tfType := range seededTypes {
 		tfType := tfType


### PR DESCRIPTION
## Summary

Extends `pkg/imported/bindings` from 48 -> 56 entries (+8) with CloudWatch / Cloud Monitoring metric defaults for additional resource types.

New types:

**AWS**
- `aws_apigatewayv2_stage` — Count, 4xx, 5xx, Latency, IntegrationLatency
- `aws_cognito_user_pool` — SignInSuccesses, SignUpSuccesses, TokenRefreshSuccesses, FederationSuccesses
- `aws_ebs_volume` — VolumeReadOps, VolumeWriteOps, VolumeQueueLength, VolumeIdleTime
- `aws_eks_node_group` — node_cpu_utilization, node_memory_utilization, node_filesystem_utilization
- `aws_lb_listener` — RequestCount, HTTPCode_ELB_4XX_Count, HTTPCode_ELB_5XX_Count
- `aws_vpc_endpoint` — BytesProcessed, PacketsDropped, ActiveConnections

**GCP**
- `google_compute_forwarding_rule` — l3/internal ingress/egress bytes
- `google_vpc_access_connector` — connector sent/received bytes, instances

`SUPPORTED_RESOURCES.md` regenerated; AWS MetricsAvailable% 23 -> 28, GCP 33 -> 37.

Stacked on #533.

Closes part of #482.

## Test plan

- [x] `go test ./pkg/imported/bindings/... -count=1`
- [x] `go test ./cmd/imported-codegen/... -count=1`
- [x] `SUPPORTED_RESOURCES.md` regenerated and committed