### PR TITLE
feat(imported): extend MetricsBinding registry — 64 total (#482)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -22,18 +22,18 @@ and is checked in lockstep with the runtime registries. See the
 
 ## Summary
 
-- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 28% MetricsAvailable · 39% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 37% MetricsAvailable · 89% AgentEditable
+- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 33% MetricsAvailable · 39% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 43% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
 | TF Type | Discoverable | Enrichable | DriftDetectable | MetricsAvailable | AgentEditable |
 |---|---|---|---|---|---|
-| `aws_acm_certificate` | ✓ | ✓ | ✓ | – | ✓ |
+| `aws_acm_certificate` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_api_gateway_deployment` | ✓ | ✓ | – | – | – |
 | `aws_api_gateway_resource` | ✓ | ✓ | – | – | – |
 | `aws_api_gateway_stage` | ✓ | ✓ | – | – | – |
-| `aws_apigatewayv2_api` | ✓ | ✓ | – | – | – |
+| `aws_apigatewayv2_api` | ✓ | ✓ | – | ✓ | – |
 | `aws_apigatewayv2_api_mapping` | ✓ | ✓ | – | – | – |
 | `aws_apigatewayv2_authorizer` | ✓ | ✓ | – | – | – |
 | `aws_apigatewayv2_domain_name` | ✓ | ✓ | – | – | – |
@@ -44,7 +44,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_autoscaling_group_tag` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_backup_plan` | ✓ | ✓ | – | – | – |
 | `aws_backup_selection` | ✓ | ✓ | – | – | – |
-| `aws_backup_vault` | ✓ | ✓ | – | – | – |
+| `aws_backup_vault` | ✓ | ✓ | – | ✓ | – |
 | `aws_bedrock_guardrail` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_bedrock_model_invocation_logging_configuration` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_cloudfront_distribution` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -52,7 +52,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_cloudfront_monitoring_subscription` | ✓ | ✓ | – | – | – |
 | `aws_cloudfront_origin_access_identity` | ✓ | ✓ | – | – | – |
 | `aws_cloudwatch_dashboard` | ✓ | ✓ | – | – | – |
-| `aws_cloudwatch_event_rule` | ✓ | ✓ | ✓ | – | ✓ |
+| `aws_cloudwatch_event_rule` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_cloudwatch_log_group` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_cloudwatch_log_resource_policy` | ✓ | ✓ | – | – | – |
 | `aws_cloudwatch_log_stream` | ✓ | ✓ | – | – | – |
@@ -82,7 +82,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_elasticache_subnet_group` | ✓ | ✓ | – | – | – |
 | `aws_iam_group` | ✓ | ✓ | – | – | – |
 | `aws_iam_instance_profile` | ✓ | ✓ | – | – | – |
-| `aws_iam_policy` | ✓ | ✓ | ✓ | – | ✓ |
+| `aws_iam_policy` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_iam_role` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_iam_role_policy` | ✓ | ✓ | – | – | – |
 | `aws_iam_role_policy_attachment` | ✓ | ✓ | ✓ | – | – |
@@ -162,14 +162,14 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_managed_ssl_certificate` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_network` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_resource_policy` | ✓ | ✓ | – | – | ✓ |
-| `google_compute_router` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_compute_security_policy` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_compute_router` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `google_compute_security_policy` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_target_http_proxy` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_target_https_proxy` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_url_map` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_container_cluster` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_container_node_pool` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_firestore_database` | ✓ | ✓ | – | – | ✓ |
+| `google_firestore_database` | ✓ | ✓ | – | ✓ | ✓ |
 | `google_identity_platform_config` | ✓ | ✓ | – | – | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key` | ✓ | ✓ | ✓ | ✓ | ✓ |

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -60,6 +60,14 @@ var seededTypes = []string{
 	"aws_vpc_endpoint",
 	"google_compute_forwarding_rule",
 	"google_vpc_access_connector",
+	"aws_acm_certificate",
+	"aws_apigatewayv2_api",
+	"aws_backup_vault",
+	"aws_cloudwatch_event_rule",
+	"aws_iam_policy",
+	"google_compute_security_policy",
+	"google_compute_router",
+	"google_firestore_database",
 }
 
 // seededBindings mirrors the registrations performed by init(). Used
@@ -459,6 +467,63 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "connector_name",
 		DimensionFrom:  "name",
 		DefaultMetrics: []string{"vpcaccess.googleapis.com/connector/sent_bytes_count", "vpcaccess.googleapis.com/connector/received_bytes_count", "vpcaccess.googleapis.com/connector/instances"},
+	},
+	"aws_acm_certificate": {
+		Service:        "acm",
+		Action:         "get-metrics",
+		DimensionKey:   "CertificateArn",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"DaysToExpiry"},
+	},
+	"aws_apigatewayv2_api": {
+		Service:        "apigateway",
+		Action:         "get-metrics",
+		DimensionKey:   "ApiId",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"Count", "4xx", "5xx", "Latency", "IntegrationLatency"},
+	},
+	"aws_backup_vault": {
+		Service:        "backup",
+		Action:         "get-metrics",
+		DimensionKey:   "BackupVaultName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"NumberOfBackupJobsCompleted", "NumberOfBackupJobsFailed", "NumberOfBackupJobsExpired"},
+	},
+	"aws_cloudwatch_event_rule": {
+		Service:        "events",
+		Action:         "get-metrics",
+		DimensionKey:   "RuleName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"Invocations", "FailedInvocations", "TriggeredRules"},
+	},
+	"aws_iam_policy": {
+		// IAM metrics are CloudTrail-only — registered so consumers can
+		// route policy queries; DefaultMetrics intentionally empty.
+		Service:       "iam",
+		Action:        "get-metrics",
+		DimensionKey:  "PolicyArn",
+		DimensionFrom: "id",
+	},
+	"google_compute_security_policy": {
+		Service:        "networksecurity",
+		Action:         "timeseries-list",
+		DimensionKey:   "policy_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"networksecurity.googleapis.com/https/request_count", "networksecurity.googleapis.com/https/dropped_request_count"},
+	},
+	"google_compute_router": {
+		Service:        "compute",
+		Action:         "timeseries-list",
+		DimensionKey:   "router_id",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"router.googleapis.com/nat/sent_bytes_count", "router.googleapis.com/nat/received_bytes_count"},
+	},
+	"google_firestore_database": {
+		Service:        "firestore",
+		Action:         "timeseries-list",
+		DimensionKey:   "database_id",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"firestore.googleapis.com/document/read_count", "firestore.googleapis.com/document/write_count", "firestore.googleapis.com/document/delete_count"},
 	},
 }
 

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -30,14 +30,15 @@ func reseed(t *testing.T) {
 // "type isn't bound at all".
 var emptyDefaultMetricsAllowed = map[string]bool{
 	"aws_iam_role":           true,
+	"aws_iam_policy":         true,
 	"google_service_account": true,
 }
 
 func TestSeededBindings(t *testing.T) {
 	reseed(t)
 
-	require.GreaterOrEqual(t, len(RegisteredTypes()), 56,
-		"expected at least 56 seeded types, got %d", len(RegisteredTypes()))
+	require.GreaterOrEqual(t, len(RegisteredTypes()), 64,
+		"expected at least 64 seeded types, got %d", len(RegisteredTypes()))
 
 	for _, tfType := range seededTypes {
 		tfType := tfType


### PR DESCRIPTION
## Summary

Extends the seeded MetricsBinding registry from 56 to 64 entries (+8).

Stacked on top of #536 (`feat/imported-bindings-seed-v8`).

### New bindings (8)

AWS (5):
- `aws_acm_certificate` — CW `acm` namespace, DimensionKey `CertificateArn` (DaysToExpiry)
- `aws_apigatewayv2_api` — CW `apigateway`, DimensionKey `ApiId` (Count, 4xx, 5xx, Latency, IntegrationLatency)
- `aws_backup_vault` — CW `backup`, DimensionKey `BackupVaultName` (NumberOfBackupJobsCompleted/Failed/Expired)
- `aws_cloudwatch_event_rule` — CW `events`, DimensionKey `RuleName` (Invocations, FailedInvocations, TriggeredRules)
- `aws_iam_policy` — IAM audit-log only, empty DefaultMetrics (mirrors `aws_iam_role` pattern); added to `emptyDefaultMetricsAllowed`

GCP (3):
- `google_compute_security_policy` — Cloud Armor `networksecurity`, DimensionKey `policy_name` (request_count, dropped_request_count)
- `google_compute_router` — `compute`, DimensionKey `router_id` (router/nat sent/received_bytes_count)
- `google_firestore_database` — `firestore`, DimensionKey `database_id` (read/write/delete_count)

### Changes

- `pkg/imported/bindings/seed.go` — +8 entries in `seededTypes` and `seededBindings`
- `pkg/imported/bindings/seed_test.go` — bumped threshold 56 → 64; added `aws_iam_policy` to `emptyDefaultMetricsAllowed`
- `SUPPORTED_RESOURCES.md` — regenerated via `go run ./cmd/imported-codegen supported-resources --output SUPPORTED_RESOURCES.md`; AWS MetricsAvailable 28% → 33%, GCP 37% → 43%

## Test plan

- [x] `go test ./pkg/imported/bindings/... -count=1` — 72 passed
- [x] `go test ./cmd/imported-codegen/... -count=1` — 247 passed
- [x] `SUPPORTED_RESOURCES.md` regenerated cleanly with no diff drift