### PR TITLE
feat(imported): extend MetricsBinding registry — 72 total (#482)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -22,8 +22,8 @@ and is checked in lockstep with the runtime registries. See the
 
 ## Summary
 
-- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 33% MetricsAvailable · 39% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 43% MetricsAvailable · 89% AgentEditable
+- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 37% MetricsAvailable · 39% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 50% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
@@ -32,7 +32,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_acm_certificate` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_api_gateway_deployment` | ✓ | ✓ | – | – | – |
 | `aws_api_gateway_resource` | ✓ | ✓ | – | – | – |
-| `aws_api_gateway_stage` | ✓ | ✓ | – | – | – |
+| `aws_api_gateway_stage` | ✓ | ✓ | – | ✓ | – |
 | `aws_apigatewayv2_api` | ✓ | ✓ | – | ✓ | – |
 | `aws_apigatewayv2_api_mapping` | ✓ | ✓ | – | – | – |
 | `aws_apigatewayv2_authorizer` | ✓ | ✓ | – | – | – |
@@ -45,7 +45,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_backup_plan` | ✓ | ✓ | – | – | – |
 | `aws_backup_selection` | ✓ | ✓ | – | – | – |
 | `aws_backup_vault` | ✓ | ✓ | – | ✓ | – |
-| `aws_bedrock_guardrail` | ✓ | ✓ | ✓ | – | ✓ |
+| `aws_bedrock_guardrail` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_bedrock_model_invocation_logging_configuration` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_cloudfront_distribution` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_cloudfront_function` | ✓ | ✓ | – | – | – |
@@ -60,7 +60,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_cognito_identity_provider` | ✓ | ✓ | – | – | – |
 | `aws_cognito_resource_server` | ✓ | ✓ | – | – | – |
 | `aws_cognito_user_pool` | ✓ | ✓ | – | ✓ | – |
-| `aws_cognito_user_pool_client` | ✓ | ✓ | – | – | – |
+| `aws_cognito_user_pool_client` | ✓ | ✓ | – | ✓ | – |
 | `aws_cognito_user_pool_domain` | ✓ | ✓ | – | – | – |
 | `aws_db_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_db_parameter_group` | ✓ | ✓ | – | – | – |
@@ -74,7 +74,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_eks_access_entry` | ✓ | ✓ | – | – | – |
 | `aws_eks_addon` | ✓ | ✓ | – | – | – |
 | `aws_eks_cluster` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `aws_eks_fargate_profile` | ✓ | ✓ | – | – | – |
+| `aws_eks_fargate_profile` | ✓ | ✓ | – | ✓ | – |
 | `aws_eks_node_group` | ✓ | ✓ | – | ✓ | – |
 | `aws_eks_pod_identity_association` | ✓ | ✓ | – | – | – |
 | `aws_elasticache_parameter_group` | ✓ | ✓ | – | – | – |
@@ -156,7 +156,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_firewall` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_forwarding_rule` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_global_address` | ✓ | ✓ | – | – | ✓ |
-| `google_compute_global_forwarding_rule` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_global_forwarding_rule` | ✓ | ✓ | – | ✓ | ✓ |
 | `google_compute_health_check` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_managed_ssl_certificate` | ✓ | ✓ | – | – | ✓ |
@@ -166,15 +166,15 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_security_policy` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_target_http_proxy` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_target_https_proxy` | ✓ | ✓ | – | – | ✓ |
-| `google_compute_url_map` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_compute_url_map` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_container_cluster` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_container_node_pool` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_container_node_pool` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_firestore_database` | ✓ | ✓ | – | ✓ | ✓ |
 | `google_identity_platform_config` | ✓ | ✓ | – | – | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_kms_crypto_key_iam_binding` | ✓ | ✓ | – | – | ✓ |
-| `google_kms_key_ring` | ✓ | ✓ | ✓ | – | – |
+| `google_kms_key_ring` | ✓ | ✓ | ✓ | ✓ | – |
 | `google_logging_project_sink` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_monitoring_alert_policy` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_monitoring_dashboard` | ✓ | ✓ | ✓ | – | ✓ |

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -68,6 +68,14 @@ var seededTypes = []string{
 	"google_compute_security_policy",
 	"google_compute_router",
 	"google_firestore_database",
+	"aws_api_gateway_stage",
+	"aws_bedrock_guardrail",
+	"aws_cognito_user_pool_client",
+	"aws_eks_fargate_profile",
+	"google_compute_global_forwarding_rule",
+	"google_compute_url_map",
+	"google_container_node_pool",
+	"google_kms_key_ring",
 }
 
 // seededBindings mirrors the registrations performed by init(). Used
@@ -524,6 +532,62 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "database_id",
 		DimensionFrom:  "name",
 		DefaultMetrics: []string{"firestore.googleapis.com/document/read_count", "firestore.googleapis.com/document/write_count", "firestore.googleapis.com/document/delete_count"},
+	},
+	"aws_api_gateway_stage": {
+		Service:        "apigateway",
+		Action:         "get-metrics",
+		DimensionKey:   "Stage",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"Count", "4XXError", "5XXError", "Latency", "IntegrationLatency"},
+	},
+	"aws_bedrock_guardrail": {
+		Service:        "bedrock",
+		Action:         "get-metrics",
+		DimensionKey:   "GuardrailId",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"InvocationLatency", "InvocationClientErrors", "InvocationServerErrors", "InvocationThrottles"},
+	},
+	"aws_cognito_user_pool_client": {
+		Service:        "cognito",
+		Action:         "get-metrics",
+		DimensionKey:   "UserPoolClient",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"SignInSuccesses", "SignUpSuccesses", "TokenRefreshSuccesses"},
+	},
+	"aws_eks_fargate_profile": {
+		Service:        "eks",
+		Action:         "get-metrics",
+		DimensionKey:   "FargateProfileName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"pod_cpu_utilization", "pod_memory_utilization", "pod_network_rx_bytes", "pod_network_tx_bytes"},
+	},
+	"google_compute_global_forwarding_rule": {
+		Service:        "loadbalancing",
+		Action:         "timeseries-list",
+		DimensionKey:   "forwarding_rule_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"loadbalancing.googleapis.com/https/request_count", "loadbalancing.googleapis.com/https/request_bytes_count", "loadbalancing.googleapis.com/https/total_latencies"},
+	},
+	"google_compute_url_map": {
+		Service:        "loadbalancing",
+		Action:         "timeseries-list",
+		DimensionKey:   "url_map_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"loadbalancing.googleapis.com/https/request_count", "loadbalancing.googleapis.com/https/backend_latencies"},
+	},
+	"google_container_node_pool": {
+		Service:        "container",
+		Action:         "timeseries-list",
+		DimensionKey:   "node_pool_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"kubernetes.io/node/cpu/allocatable_utilization", "kubernetes.io/node/memory/allocatable_utilization", "kubernetes.io/node/ephemeral_storage/used_bytes"},
+	},
+	"google_kms_key_ring": {
+		Service:        "cloudkms",
+		Action:         "timeseries-list",
+		DimensionKey:   "key_ring_id",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"cloudkms.googleapis.com/key/sign_request_count", "cloudkms.googleapis.com/key/verify_request_count"},
 	},
 }
 

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -37,8 +37,8 @@ var emptyDefaultMetricsAllowed = map[string]bool{
 func TestSeededBindings(t *testing.T) {
 	reseed(t)
 
-	require.GreaterOrEqual(t, len(RegisteredTypes()), 64,
-		"expected at least 64 seeded types, got %d", len(RegisteredTypes()))
+	require.GreaterOrEqual(t, len(RegisteredTypes()), 72,
+		"expected at least 72 seeded types, got %d", len(RegisteredTypes()))
 
 	for _, tfType := range seededTypes {
 		tfType := tfType


### PR DESCRIPTION
Stacked on top of #539 (`feat/imported-bindings-seed-v9`). Extends the
`pkg/imported/bindings` seed registry from **64 → 72** entries by adding
MetricsBinding coverage for eight more Terraform types.

## New bindings (8)

AWS (4):
- `aws_api_gateway_stage` — REST API Gateway stage (Count, 4XXError, 5XXError, Latency, IntegrationLatency)
- `aws_bedrock_guardrail` — Bedrock guardrail invocation metrics
- `aws_cognito_user_pool_client` — Cognito per-client auth metrics
- `aws_eks_fargate_profile` — EKS Fargate ContainerInsights pod metrics

GCP (4):
- `google_compute_global_forwarding_rule` — HTTPS LB request count / latency
- `google_compute_url_map` — HTTPS LB request count / backend latency
- `google_container_node_pool` — GKE node CPU/memory/storage utilization
- `google_kms_key_ring` — Cloud KMS keyring sign/verify request count

## Verification

- `go test ./pkg/imported/bindings/... -count=1` — 80 passed
- `go test ./cmd/imported-codegen/... -count=1` — 247 passed
- `SUPPORTED_RESOURCES.md` regenerated via `go run ./cmd/imported-codegen supported-resources`; summary now reads **AWS 37% MetricsAvailable / GCP 50% MetricsAvailable** (was 33% / 43%)
- Eight new rows flip from `–` to `✓` in the MetricsAvailable column

## Lane discipline

Only touches:
- `pkg/imported/bindings/seed.go`
- `pkg/imported/bindings/seed_test.go` (count bump 64 → 72)
- `SUPPORTED_RESOURCES.md`