### PR TITLE
feat(imported): extend MetricsBinding registry — 80 total (#482)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -22,8 +22,8 @@ and is checked in lockstep with the runtime registries. See the
 
 ## Summary
 
-- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 37% MetricsAvailable · 39% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 50% MetricsAvailable · 89% AgentEditable
+- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 40% MetricsAvailable · 39% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 57% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
@@ -37,12 +37,12 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_apigatewayv2_api_mapping` | ✓ | ✓ | – | – | – |
 | `aws_apigatewayv2_authorizer` | ✓ | ✓ | – | – | – |
 | `aws_apigatewayv2_domain_name` | ✓ | ✓ | – | – | – |
-| `aws_apigatewayv2_integration` | ✓ | ✓ | – | – | – |
-| `aws_apigatewayv2_route` | ✓ | ✓ | – | – | – |
+| `aws_apigatewayv2_integration` | ✓ | ✓ | – | ✓ | – |
+| `aws_apigatewayv2_route` | ✓ | ✓ | – | ✓ | – |
 | `aws_apigatewayv2_stage` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_autoscaling_group` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_autoscaling_group_tag` | ✓ | ✓ | ✓ | – | ✓ |
-| `aws_backup_plan` | ✓ | ✓ | – | – | – |
+| `aws_backup_plan` | ✓ | ✓ | – | ✓ | – |
 | `aws_backup_selection` | ✓ | ✓ | – | – | – |
 | `aws_backup_vault` | ✓ | ✓ | – | ✓ | – |
 | `aws_bedrock_guardrail` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -96,7 +96,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_lambda_alias` | ✓ | ✓ | – | – | – |
 | `aws_lambda_event_source_mapping` | ✓ | ✓ | – | – | – |
 | `aws_lambda_function` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `aws_lambda_function_url` | ✓ | ✓ | – | – | – |
+| `aws_lambda_function_url` | ✓ | ✓ | – | ✓ | – |
 | `aws_lambda_permission` | ✓ | ✓ | – | – | – |
 | `aws_launch_template` | ✓ | ✓ | – | – | – |
 | `aws_lb` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -153,7 +153,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_cloudfunctions2_function_iam_member` | ✓ | ✓ | – | – | – |
 | `google_compute_address` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_backend_service` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_compute_firewall` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_compute_firewall` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_forwarding_rule` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_global_address` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_global_forwarding_rule` | ✓ | ✓ | – | ✓ | ✓ |
@@ -164,8 +164,8 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_resource_policy` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_router` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_security_policy` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_compute_target_http_proxy` | ✓ | ✓ | – | – | ✓ |
-| `google_compute_target_https_proxy` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_target_http_proxy` | ✓ | ✓ | – | ✓ | ✓ |
+| `google_compute_target_https_proxy` | ✓ | ✓ | – | ✓ | ✓ |
 | `google_compute_url_map` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_container_cluster` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_container_node_pool` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -180,7 +180,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_monitoring_dashboard` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_monitoring_notification_channel` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_project_iam_member` | ✓ | ✓ | – | – | – |
-| `google_project_service` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_project_service` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_pubsub_subscription` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_pubsub_topic` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_redis_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -76,6 +76,14 @@ var seededTypes = []string{
 	"google_compute_url_map",
 	"google_container_node_pool",
 	"google_kms_key_ring",
+	"aws_backup_plan",
+	"aws_lambda_function_url",
+	"aws_apigatewayv2_route",
+	"aws_apigatewayv2_integration",
+	"google_compute_firewall",
+	"google_project_service",
+	"google_compute_target_https_proxy",
+	"google_compute_target_http_proxy",
 }
 
 // seededBindings mirrors the registrations performed by init(). Used
@@ -588,6 +596,62 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "key_ring_id",
 		DimensionFrom:  "name",
 		DefaultMetrics: []string{"cloudkms.googleapis.com/key/sign_request_count", "cloudkms.googleapis.com/key/verify_request_count"},
+	},
+	"aws_backup_plan": {
+		Service:        "backup",
+		Action:         "get-metrics",
+		DimensionKey:   "BackupPlanArn",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"NumberOfBackupJobsCompleted", "NumberOfBackupJobsFailed", "NumberOfBackupJobsExpired"},
+	},
+	"aws_lambda_function_url": {
+		Service:        "lambda",
+		Action:         "get-metrics",
+		DimensionKey:   "FunctionName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"UrlRequestCount", "Url4xx", "Url5xx", "UrlRequestLatency"},
+	},
+	"aws_apigatewayv2_route": {
+		Service:        "apigateway",
+		Action:         "get-metrics",
+		DimensionKey:   "ApiId",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"Count", "4xx", "5xx", "Latency"},
+	},
+	"aws_apigatewayv2_integration": {
+		Service:        "apigateway",
+		Action:         "get-metrics",
+		DimensionKey:   "ApiId",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"IntegrationLatency", "Count", "4xx", "5xx"},
+	},
+	"google_compute_firewall": {
+		Service:        "compute",
+		Action:         "timeseries-list",
+		DimensionKey:   "firewall_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"firewallinsights.googleapis.com/subnet/firewall_hit_count", "firewallinsights.googleapis.com/vm/firewall_hit_count"},
+	},
+	"google_project_service": {
+		Service:        "serviceusage",
+		Action:         "timeseries-list",
+		DimensionKey:   "service",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"serviceruntime.googleapis.com/api/request_count", "serviceruntime.googleapis.com/api/request_latencies"},
+	},
+	"google_compute_target_https_proxy": {
+		Service:        "loadbalancing",
+		Action:         "timeseries-list",
+		DimensionKey:   "target_proxy_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"loadbalancing.googleapis.com/https/request_count", "loadbalancing.googleapis.com/https/request_bytes_count", "loadbalancing.googleapis.com/https/total_latencies"},
+	},
+	"google_compute_target_http_proxy": {
+		Service:        "loadbalancing",
+		Action:         "timeseries-list",
+		DimensionKey:   "target_proxy_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"loadbalancing.googleapis.com/https/request_count", "loadbalancing.googleapis.com/https/request_bytes_count"},
 	},
 }
 

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -37,8 +37,8 @@ var emptyDefaultMetricsAllowed = map[string]bool{
 func TestSeededBindings(t *testing.T) {
 	reseed(t)
 
-	require.GreaterOrEqual(t, len(RegisteredTypes()), 72,
-		"expected at least 72 seeded types, got %d", len(RegisteredTypes()))
+	require.GreaterOrEqual(t, len(RegisteredTypes()), 80,
+		"expected at least 80 seeded types, got %d", len(RegisteredTypes()))
 
 	for _, tfType := range seededTypes {
 		tfType := tfType


### PR DESCRIPTION
## Summary

Extends `pkg/imported/bindings` from 72 to 80 entries (+8), continuing the metric-binding rollout for issue #482. Each new entry binds a Terraform resource type to its CloudWatch / Cloud Monitoring metrics surface (Service / Action / DimensionKey / DimensionFrom / DefaultMetrics).

## New bindings (8)

**AWS (4):**
- `aws_backup_plan` — backup / `BackupPlanArn` / NumberOfBackupJobs{Completed,Failed,Expired}
- `aws_lambda_function_url` — lambda / `FunctionName` / Url{RequestCount,4xx,5xx,RequestLatency}
- `aws_apigatewayv2_route` — apigateway / `ApiId` / Count, 4xx, 5xx, Latency
- `aws_apigatewayv2_integration` — apigateway / `ApiId` / IntegrationLatency, Count, 4xx, 5xx

**GCP (4):**
- `google_compute_firewall` — compute / `firewall_name` / firewallinsights subnet+vm hit_count
- `google_project_service` — serviceusage / `service` / serviceruntime request_count + latencies
- `google_compute_target_https_proxy` — loadbalancing / `target_proxy_name` / https request/bytes/latencies
- `google_compute_target_http_proxy` — loadbalancing / `target_proxy_name` / https request/bytes

## Coverage delta

- AWS: 37% -> 40% MetricsAvailable
- GCP: 50% -> 57% MetricsAvailable

## Test plan
- [x] `go test ./pkg/imported/bindings/... -count=1` (88 tests pass)
- [x] `go test ./cmd/imported-codegen/... -count=1` (247 tests pass)
- [x] `go build ./...` clean
- [x] `SUPPORTED_RESOURCES.md` regenerated via `go run ./cmd/imported-codegen supported-resources --output SUPPORTED_RESOURCES.md`
- [x] `seed_test.go` count assertion bumped 72 -> 80