### PR TITLE
feat(imported): extend MetricsBinding registry — 88 total (#482)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -22,8 +22,8 @@ and is checked in lockstep with the runtime registries. See the
 
 ## Summary
 
-- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 40% MetricsAvailable · 39% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 57% MetricsAvailable · 89% AgentEditable
+- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 45% MetricsAvailable · 39% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 63% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
@@ -48,7 +48,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_bedrock_guardrail` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_bedrock_model_invocation_logging_configuration` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_cloudfront_distribution` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `aws_cloudfront_function` | ✓ | ✓ | – | – | – |
+| `aws_cloudfront_function` | ✓ | ✓ | – | ✓ | – |
 | `aws_cloudfront_monitoring_subscription` | ✓ | ✓ | – | – | – |
 | `aws_cloudfront_origin_access_identity` | ✓ | ✓ | – | – | – |
 | `aws_cloudwatch_dashboard` | ✓ | ✓ | – | – | – |
@@ -89,7 +89,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_iam_service_linked_role` | ✓ | ✓ | – | – | – |
 | `aws_iam_user` | ✓ | ✓ | – | – | – |
 | `aws_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `aws_internet_gateway` | ✓ | ✓ | – | – | – |
+| `aws_internet_gateway` | ✓ | ✓ | – | ✓ | – |
 | `aws_key_pair` | ✓ | ✓ | – | – | – |
 | `aws_kms_alias` | ✓ | ✓ | – | – | – |
 | `aws_kms_key` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -124,20 +124,20 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_s3_bucket_versioning` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_secretsmanager_secret` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_secretsmanager_secret_rotation` | ✓ | ✓ | ✓ | – | ✓ |
-| `aws_security_group` | ✓ | ✓ | ✓ | – | ✓ |
+| `aws_security_group` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_service_discovery_private_dns_namespace` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_sns_topic` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_sns_topic_subscription` | ✓ | ✓ | – | – | – |
 | `aws_sqs_queue` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_ssm_parameter` | ✓ | ✓ | – | – | – |
-| `aws_subnet` | ✓ | ✓ | ✓ | – | ✓ |
+| `aws_subnet` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_vpc` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_vpc_dhcp_options` | ✓ | ✓ | – | – | – |
 | `aws_vpc_endpoint` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_vpc_security_group_egress_rule` | ✓ | ✓ | – | – | – |
 | `aws_vpc_security_group_ingress_rule` | ✓ | ✓ | – | – | – |
 | `aws_wafv2_web_acl` | ✓ | ✓ | – | ✓ | – |
-| `aws_wafv2_web_acl_association` | ✓ | ✓ | ✓ | – | – |
+| `aws_wafv2_web_acl_association` | ✓ | ✓ | ✓ | ✓ | – |
 
 ## GCP
 
@@ -145,10 +145,10 @@ and is checked in lockstep with the runtime registries. See the
 |---|---|---|---|---|---|
 | `google_api_gateway_api` | ✓ | ✓ | – | – | ✓ |
 | `google_api_gateway_api_config` | ✓ | ✓ | – | – | ✓ |
-| `google_api_gateway_gateway` | ✓ | ✓ | – | – | ✓ |
+| `google_api_gateway_gateway` | ✓ | ✓ | – | ✓ | ✓ |
 | `google_cloud_run_v2_service` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_cloud_run_v2_service_iam_member` | ✓ | ✓ | – | – | – |
-| `google_cloudbuild_trigger` | ✓ | ✓ | – | – | ✓ |
+| `google_cloudbuild_trigger` | ✓ | ✓ | – | ✓ | ✓ |
 | `google_cloudfunctions2_function` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_cloudfunctions2_function_iam_member` | ✓ | ✓ | – | – | – |
 | `google_compute_address` | ✓ | ✓ | ✓ | – | ✓ |
@@ -157,7 +157,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_forwarding_rule` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_global_address` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_global_forwarding_rule` | ✓ | ✓ | – | ✓ | ✓ |
-| `google_compute_health_check` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_compute_health_check` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_managed_ssl_certificate` | ✓ | ✓ | – | – | ✓ |
 | `google_compute_network` | ✓ | ✓ | ✓ | ✓ | ✓ |

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -84,6 +84,14 @@ var seededTypes = []string{
 	"google_project_service",
 	"google_compute_target_https_proxy",
 	"google_compute_target_http_proxy",
+	"aws_security_group",
+	"aws_subnet",
+	"aws_internet_gateway",
+	"aws_cloudfront_function",
+	"aws_wafv2_web_acl_association",
+	"google_compute_health_check",
+	"google_api_gateway_gateway",
+	"google_cloudbuild_trigger",
 }
 
 // seededBindings mirrors the registrations performed by init(). Used
@@ -652,6 +660,62 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "target_proxy_name",
 		DimensionFrom:  "name",
 		DefaultMetrics: []string{"loadbalancing.googleapis.com/https/request_count", "loadbalancing.googleapis.com/https/request_bytes_count"},
+	},
+	"aws_security_group": {
+		Service:        "vpc",
+		Action:         "get-metrics",
+		DimensionKey:   "GroupId",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"AllowedFlowsCount", "DeniedFlowsCount"},
+	},
+	"aws_subnet": {
+		Service:        "vpc",
+		Action:         "get-metrics",
+		DimensionKey:   "Subnet",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"BytesIn", "BytesOut", "PacketsIn", "PacketsOut"},
+	},
+	"aws_internet_gateway": {
+		Service:        "vpc",
+		Action:         "get-metrics",
+		DimensionKey:   "InternetGatewayId",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"BytesIn", "BytesOut", "PacketsIn", "PacketsOut"},
+	},
+	"aws_cloudfront_function": {
+		Service:        "cloudfront",
+		Action:         "get-metrics",
+		DimensionKey:   "FunctionName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"FunctionInvocations", "FunctionExecutionErrors", "FunctionValidationErrors", "FunctionComputeUtilization"},
+	},
+	"aws_wafv2_web_acl_association": {
+		Service:        "wafv2",
+		Action:         "get-metrics",
+		DimensionKey:   "WebACL",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"AllowedRequests", "BlockedRequests", "CountedRequests"},
+	},
+	"google_compute_health_check": {
+		Service:        "loadbalancing",
+		Action:         "timeseries-list",
+		DimensionKey:   "health_check_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"loadbalancing.googleapis.com/https/backend_request_count", "monitoring.googleapis.com/uptime_check/check_passed"},
+	},
+	"google_api_gateway_gateway": {
+		Service:        "apigateway",
+		Action:         "timeseries-list",
+		DimensionKey:   "gateway_id",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"apigateway.googleapis.com/gateway/request_count", "apigateway.googleapis.com/gateway/request_latencies"},
+	},
+	"google_cloudbuild_trigger": {
+		Service:        "cloudbuild",
+		Action:         "timeseries-list",
+		DimensionKey:   "trigger_id",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"cloudbuild.googleapis.com/build_count", "cloudbuild.googleapis.com/build/duration"},
 	},
 }
 

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -37,8 +37,8 @@ var emptyDefaultMetricsAllowed = map[string]bool{
 func TestSeededBindings(t *testing.T) {
 	reseed(t)
 
-	require.GreaterOrEqual(t, len(RegisteredTypes()), 80,
-		"expected at least 80 seeded types, got %d", len(RegisteredTypes()))
+	require.GreaterOrEqual(t, len(RegisteredTypes()), 88,
+		"expected at least 88 seeded types, got %d", len(RegisteredTypes()))
 
 	for _, tfType := range seededTypes {
 		tfType := tfType


### PR DESCRIPTION
## Summary
Extends `pkg/imported/bindings` from 80 to 88 entries (+8) — fifth incremental seed PR for #482.

Added bindings (5 AWS, 3 GCP):

**AWS**
- `aws_security_group` (vpc / VPC flow log metrics)
- `aws_subnet` (vpc / subnet flow metrics)
- `aws_internet_gateway` (vpc / IGW flow metrics)
- `aws_cloudfront_function` (cloudfront / function metrics)
- `aws_wafv2_web_acl_association` (wafv2 / WebACL metrics)

**GCP**
- `google_compute_health_check` (loadbalancing / backend & uptime check)
- `google_api_gateway_gateway` (apigateway / request count + latencies)
- `google_cloudbuild_trigger` (cloudbuild / build count + duration)

`SUPPORTED_RESOURCES.md` regenerated — MetricsAvailable: AWS 40%→45%, GCP 57%→63%.

## Test plan
- [x] `go test ./pkg/imported/bindings/... -count=1` (96 passed)
- [x] `go test ./cmd/imported-codegen/... -count=1` (247 passed)
- [x] SUPPORTED_RESOURCES.md regen clean

Stacked on top of #544 — merge that one first.