### PR TITLE
feat(imported): extend MetricsBinding registry — 96 total (#482)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -22,8 +22,8 @@ and is checked in lockstep with the runtime registries. See the
 
 ## Summary
 
-- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 45% MetricsAvailable · 39% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 63% MetricsAvailable · 89% AgentEditable
+- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 50% MetricsAvailable · 39% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 67% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
@@ -70,7 +70,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_ebs_volume` | ✓ | ✓ | – | ✓ | – |
 | `aws_ecs_cluster` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_ecs_cluster_capacity_providers` | ✓ | ✓ | – | – | – |
-| `aws_eip` | ✓ | ✓ | – | – | – |
+| `aws_eip` | ✓ | ✓ | – | ✓ | – |
 | `aws_eks_access_entry` | ✓ | ✓ | – | – | – |
 | `aws_eks_addon` | ✓ | ✓ | – | – | – |
 | `aws_eks_cluster` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -87,14 +87,14 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_iam_role_policy` | ✓ | ✓ | – | – | – |
 | `aws_iam_role_policy_attachment` | ✓ | ✓ | ✓ | – | – |
 | `aws_iam_service_linked_role` | ✓ | ✓ | – | – | – |
-| `aws_iam_user` | ✓ | ✓ | – | – | – |
+| `aws_iam_user` | ✓ | ✓ | – | ✓ | – |
 | `aws_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_internet_gateway` | ✓ | ✓ | – | ✓ | – |
 | `aws_key_pair` | ✓ | ✓ | – | – | – |
 | `aws_kms_alias` | ✓ | ✓ | – | – | – |
 | `aws_kms_key` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_lambda_alias` | ✓ | ✓ | – | – | – |
-| `aws_lambda_event_source_mapping` | ✓ | ✓ | – | – | – |
+| `aws_lambda_event_source_mapping` | ✓ | ✓ | – | ✓ | – |
 | `aws_lambda_function` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_lambda_function_url` | ✓ | ✓ | – | ✓ | – |
 | `aws_lambda_permission` | ✓ | ✓ | – | – | – |
@@ -106,7 +106,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_msk_configuration` | ✓ | ✓ | – | – | – |
 | `aws_nat_gateway` | ✓ | ✓ | – | ✓ | – |
 | `aws_network_acl` | ✓ | ✓ | – | – | – |
-| `aws_network_interface` | ✓ | ✓ | – | – | – |
+| `aws_network_interface` | ✓ | ✓ | – | ✓ | – |
 | `aws_opensearch_domain` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_opensearchserverless_access_policy` | ✓ | ✓ | – | – | – |
 | `aws_opensearchserverless_collection` | ✓ | ✓ | – | – | – |
@@ -127,9 +127,9 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_security_group` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_service_discovery_private_dns_namespace` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_sns_topic` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `aws_sns_topic_subscription` | ✓ | ✓ | – | – | – |
+| `aws_sns_topic_subscription` | ✓ | ✓ | – | ✓ | – |
 | `aws_sqs_queue` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `aws_ssm_parameter` | ✓ | ✓ | – | – | – |
+| `aws_ssm_parameter` | ✓ | ✓ | – | ✓ | – |
 | `aws_subnet` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_vpc` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_vpc_dhcp_options` | ✓ | ✓ | – | – | – |
@@ -151,7 +151,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_cloudbuild_trigger` | ✓ | ✓ | – | ✓ | ✓ |
 | `google_cloudfunctions2_function` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_cloudfunctions2_function_iam_member` | ✓ | ✓ | – | – | – |
-| `google_compute_address` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_compute_address` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_backend_service` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_firewall` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_forwarding_rule` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -178,7 +178,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_logging_project_sink` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_monitoring_alert_policy` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_monitoring_dashboard` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_monitoring_notification_channel` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_monitoring_notification_channel` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_project_iam_member` | ✓ | ✓ | – | – | – |
 | `google_project_service` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_pubsub_subscription` | ✓ | ✓ | ✓ | ✓ | ✓ |

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -92,6 +92,14 @@ var seededTypes = []string{
 	"google_compute_health_check",
 	"google_api_gateway_gateway",
 	"google_cloudbuild_trigger",
+	"aws_eip",
+	"aws_network_interface",
+	"aws_ssm_parameter",
+	"aws_sns_topic_subscription",
+	"aws_lambda_event_source_mapping",
+	"aws_iam_user",
+	"google_compute_address",
+	"google_monitoring_notification_channel",
 }
 
 // seededBindings mirrors the registrations performed by init(). Used
@@ -716,6 +724,63 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "trigger_id",
 		DimensionFrom:  "id",
 		DefaultMetrics: []string{"cloudbuild.googleapis.com/build_count", "cloudbuild.googleapis.com/build/duration"},
+	},
+	"aws_eip": {
+		Service:        "ec2",
+		Action:         "get-metrics",
+		DimensionKey:   "AllocationId",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"NetworkIn", "NetworkOut", "NetworkPacketsIn", "NetworkPacketsOut"},
+	},
+	"aws_network_interface": {
+		Service:        "ec2",
+		Action:         "get-metrics",
+		DimensionKey:   "NetworkInterfaceId",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"NetworkIn", "NetworkOut", "NetworkPacketsIn", "NetworkPacketsOut"},
+	},
+	"aws_ssm_parameter": {
+		Service:        "ssm",
+		Action:         "get-metrics",
+		DimensionKey:   "ParameterName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"GetParameter", "PutParameter", "DescribeParameters"},
+	},
+	"aws_sns_topic_subscription": {
+		Service:        "sns",
+		Action:         "get-metrics",
+		DimensionKey:   "TopicName",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"NumberOfNotificationsDelivered", "NumberOfNotificationsFailed", "NumberOfNotificationsFilteredOut"},
+	},
+	"aws_lambda_event_source_mapping": {
+		Service:        "lambda",
+		Action:         "get-metrics",
+		DimensionKey:   "EventSourceMappingArn",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"PollerInvocations", "OffsetLag", "IteratorAge"},
+	},
+	"aws_iam_user": {
+		// IAM metrics are CloudTrail-only — registered so consumers can
+		// route policy queries; DefaultMetrics intentionally empty.
+		Service:       "iam",
+		Action:        "get-metrics",
+		DimensionKey:  "UserName",
+		DimensionFrom: "name",
+	},
+	"google_compute_address": {
+		Service:        "compute",
+		Action:         "timeseries-list",
+		DimensionKey:   "address_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"compute.googleapis.com/instance/network/sent_bytes_count", "compute.googleapis.com/instance/network/received_bytes_count"},
+	},
+	"google_monitoring_notification_channel": {
+		Service:        "monitoring",
+		Action:         "timeseries-list",
+		DimensionKey:   "channel_id",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"monitoring.googleapis.com/notification_channel/sent_count", "monitoring.googleapis.com/notification_channel/error_count"},
 	},
 }
 

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -31,14 +31,15 @@ func reseed(t *testing.T) {
 var emptyDefaultMetricsAllowed = map[string]bool{
 	"aws_iam_role":           true,
 	"aws_iam_policy":         true,
+	"aws_iam_user":           true,
 	"google_service_account": true,
 }
 
 func TestSeededBindings(t *testing.T) {
 	reseed(t)
 
-	require.GreaterOrEqual(t, len(RegisteredTypes()), 88,
-		"expected at least 88 seeded types, got %d", len(RegisteredTypes()))
+	require.GreaterOrEqual(t, len(RegisteredTypes()), 96,
+		"expected at least 96 seeded types, got %d", len(RegisteredTypes()))
 
 	for _, tfType := range seededTypes {
 		tfType := tfType


### PR DESCRIPTION
Extends `pkg/imported/bindings` from 88 to 96 seeded MetricsBinding entries.

## New types (+8)

AWS:
- `aws_eip` (EC2 — Elastic IP)
- `aws_network_interface` (EC2 ENI)
- `aws_ssm_parameter` (SSM Parameter Store)
- `aws_sns_topic_subscription` (SNS subscription delivery)
- `aws_lambda_event_source_mapping` (Lambda ESM)
- `aws_iam_user` (CloudTrail-only — empty DefaultMetrics; added to `emptyDefaultMetricsAllowed`)

GCP:
- `google_compute_address` (reserved compute address)
- `google_monitoring_notification_channel` (alerting delivery)

## Notes

- `seededTypes` slice + `seededBindings` map both updated.
- `seed_test.go` count threshold bumped 88 → 96.
- `SUPPORTED_RESOURCES.md` regenerated (`go run ./cmd/imported-codegen supported-resources --output SUPPORTED_RESOURCES.md`).
- Tests: `go test ./pkg/imported/bindings/... -count=1` and `go test ./cmd/imported-codegen/... -count=1` both green.
- PR stacked on `feat/imported-bindings-seed-v12` (#545).