### PR TITLE
feat(imported/labels): curated display-label + iconKey overrides

### DIFF
--- a/cmd/imported-codegen/emit_labels_test.go
+++ b/cmd/imported-codegen/emit_labels_test.go
@@ -79,13 +79,20 @@ func TestBuildLabelsMap_KnownEntries(t *testing.T) {
 		wantLabel   string
 		wantIconKey string
 	}{
-		// Default-rule cases (skeleton labels package has an empty
-		// override registry, so every entry exercises the default
-		// path).
-		{tfType: "aws_s3_bucket", wantLabel: "S3 Bucket", wantIconKey: "s3_bucket"},
-		{tfType: "aws_dynamodb_table", wantLabel: "Dynamodb Table", wantIconKey: "dynamodb_table"},
-		{tfType: "google_pubsub_topic", wantLabel: "Pubsub Topic", wantIconKey: "pubsub_topic"},
-		{tfType: "google_compute_network", wantLabel: "Compute Network", wantIconKey: "compute_network"},
+		// Curated-override cases — these strings ship in
+		// luthersystems/reliable's components/import/serviceMeta.ts and
+		// are pinned by the per-cloud overrides in
+		// pkg/imported/labels/overrides.go. A regression in either the
+		// override registration or the emit-pipeline lookup chain
+		// surfaces here. The exhaustive override list is asserted by
+		// the labels package's own TestCuratedOverrides_LockReliableCopy.
+		{tfType: "aws_s3_bucket", wantLabel: "Bucket (S3)", wantIconKey: "s3"},
+		{tfType: "aws_dynamodb_table", wantLabel: "Table (DynamoDB)", wantIconKey: "ddb"},
+		{tfType: "google_pubsub_topic", wantLabel: "Pub/Sub topic", wantIconKey: "pubsub"},
+		// Default-rule case — google_compute_network is in the
+		// SupportedDiscoverTypes set but the override file pins
+		// "VPC network" / "vpc" against reliable's serviceMeta.ts.
+		{tfType: "google_compute_network", wantLabel: "VPC network", wantIconKey: "vpc"},
 	}
 	for _, tc := range cases {
 		entry, ok := got[tc.tfType]

--- a/pkg/imported/labels/labels_test.go
+++ b/pkg/imported/labels/labels_test.go
@@ -176,6 +176,82 @@ func TestRegisteredTypesSortedAndStable(t *testing.T) {
 	}
 }
 
+// TestCuratedOverrides_LockReliableCopy pins every curated
+// (label, iconKey) override registered by overrides.go against the
+// exact strings shipping today in luthersystems/reliable's
+// components/import/serviceMeta.ts (label) and the iconPath SVG
+// basenames it pairs with each type.
+//
+// Why this test isn't a fixture: every row is a deliberate product
+// copy choice the team has shipped to users. A future edit that wants
+// to change a label must therefore touch this test file — a loud
+// signal, with the change visible in the diff a reviewer will see.
+// Drift between this test and overrides.go indicates one of:
+//   - someone added/changed a curated override without updating the
+//     reliable consumer (this test fails),
+//   - reliable changed product copy first and the upstream override
+//     hasn't been bumped (catch on a parity-check follow-up — not in
+//     this test's scope, since the override file IS the upstream
+//     source of truth post-Surface-D-migration).
+//
+// Note: this test resets and re-runs registerCuratedOverrides() rather
+// than reading the production registry directly. Sibling tests in this
+// file wipe the registry via resetForTest(); without the reset+repopulate
+// we'd see whatever the last sibling test left behind, which would be
+// brittle to test-ordering.
+func TestCuratedOverrides_LockReliableCopy(t *testing.T) {
+	resetForTest(t)
+	registerCuratedOverrides()
+
+	cases := []struct {
+		tfType      string
+		wantLabel   string
+		wantIconKey string
+	}{
+		// AWS — importable today.
+		{"aws_sqs_queue", "Queue (SQS)", "sqs"},
+		{"aws_dynamodb_table", "Table (DynamoDB)", "ddb"},
+		{"aws_cloudwatch_log_group", "Log group (CloudWatch)", "cw"},
+		{"aws_secretsmanager_secret", "Secret (Secrets Manager)", "secretsmanager"},
+		{"aws_lambda_function", "Function (Lambda)", "lambda"},
+
+		// AWS — surfaced unsupported.
+		{"aws_iam_role", "IAM role", "aws"},
+		{"aws_iam_policy", "IAM policy", "aws"},
+		{"aws_kms_key", "KMS key", "kms"},
+		{"aws_s3_bucket", "Bucket (S3)", "s3"},
+		{"aws_vpc", "Virtual private cloud (VPC)", "vpc"},
+		{"aws_subnet", "Subnet", "vpc"},
+		{"aws_security_group", "Security group", "vpc"},
+		{"aws_eks_cluster", "Kubernetes cluster (EKS)", "eks"},
+		{"aws_eks_node_group", "EKS node group", "eks"},
+		{"aws_lb", "Load balancer (ALB)", "alb"},
+		{"aws_cloudfront_distribution", "CDN (CloudFront)", "cdn"},
+		{"aws_instance", "EC2 instance", "ec2"},
+
+		// GCP — importable today.
+		{"google_pubsub_topic", "Pub/Sub topic", "pubsub"},
+		{"google_pubsub_subscription", "Pub/Sub subscription", "pubsub"},
+		{"google_storage_bucket", "Cloud Storage bucket", "gcs"},
+		{"google_secret_manager_secret", "Secret (Secret Manager)", "secret_manager"},
+		{"google_compute_network", "VPC network", "vpc"},
+
+		// GCP — surfaced unsupported.
+		{"google_sql_database_instance", "Cloud SQL instance", "cloudsql"},
+		{"google_container_cluster", "Kubernetes cluster (GKE)", "gke"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tfType, func(t *testing.T) {
+			if got := Label(tc.tfType); got != tc.wantLabel {
+				t.Errorf("Label(%q) = %q, want %q", tc.tfType, got, tc.wantLabel)
+			}
+			if got := IconKey(tc.tfType); got != tc.wantIconKey {
+				t.Errorf("IconKey(%q) = %q, want %q", tc.tfType, got, tc.wantIconKey)
+			}
+		})
+	}
+}
+
 func TestConcurrentRegisterReadSafety(t *testing.T) {
 	resetForTest(t)
 	// Race-detector smoke test: 32 concurrent readers against a writer

--- a/pkg/imported/labels/overrides.go
+++ b/pkg/imported/labels/overrides.go
@@ -1,0 +1,87 @@
+// overrides.go centralises the curated display-label + icon-key
+// overrides that diverge from the default humanise-snake-case rule in
+// labels.go.
+//
+// Why this file exists: every entry below pins a string that has
+// already shipped in luthersystems/reliable's
+// components/import/serviceMeta.ts (the hand-maintained UI copy table
+// that the upstream codegen will replace). Without these overrides the
+// reliable Surface D consumer migration (reliable#1479 / reliable PR
+// #1538) would regress user-visible product copy — "DynamoDB" would
+// become "Dynamodb", "Pub/Sub" would become "Pubsub", "S3 bucket"
+// would become "S3 Bucket", and so on.
+//
+// Authoring rules:
+//   - Only override types that (a) are present in registry's
+//     SupportedDiscoverTypes (AWS or GCP), and (b) need a label or icon
+//     key that the default rule cannot produce.
+//   - Match reliable's serviceMeta.ts label string verbatim. The
+//     capitalisation, vendor brand spelling, and second-word case are
+//     deliberate product copy choices — the labels_test.go cases lock
+//     them in so a future driveby edit fails loudly.
+//   - Icon keys are the lowercase semantic identifier matching
+//     serviceMeta.ts's SVG basenames (so a downstream consumer can map
+//     iconKey → /aws-icons/<iconKey>.svg / /gcp-icons/<iconKey>.svg
+//     without a second lookup table). Where reliable's serviceMeta.ts
+//     uses a tile icon different from its category (e.g. amber
+//     ImportedTile genericIcon kinds), that's a tile-level concern that
+//     stays in the reliable repo — this file only pins the canonical
+//     per-type icon asset key.
+//
+// Future curation for types reliable doesn't have today can land in
+// follow-up PRs as those types become user-visible.
+package labels
+
+func init() {
+	registerCuratedOverrides()
+}
+
+// registerCuratedOverrides is the body of init(), factored out so the
+// label-locking test can re-run it after a resetForTest() wipe. Adding
+// a new override means: extend this function AND the test table in
+// TestCuratedOverrides_LockReliableCopy. The two stay in lockstep by
+// design — a missing test row is the loud signal a label change
+// happened without consumer-side coordination.
+//
+// NOTE: reliable's serviceMeta.ts also carries entries for
+// `aws_rds_cluster` and `google_compute_subnetwork`, which are NOT in
+// registry.SupportedDiscoverTypes today. They are tracked as a
+// follow-up (either add to upstream registry, or drop from reliable
+// on the consumer-side swap). Registering them here would silently
+// expand the emitted labels map beyond the discover-supported set
+// and confuse downstream consumers that key off it.
+func registerCuratedOverrides() {
+	// AWS — importable today (matching serviceMeta.ts "importable today" section).
+	Register("aws_sqs_queue", "Queue (SQS)", "sqs")
+	Register("aws_dynamodb_table", "Table (DynamoDB)", "ddb")
+	Register("aws_cloudwatch_log_group", "Log group (CloudWatch)", "cw")
+	Register("aws_secretsmanager_secret", "Secret (Secrets Manager)", "secretsmanager")
+	Register("aws_lambda_function", "Function (Lambda)", "lambda")
+
+	// AWS — surfaced unsupported (matching serviceMeta.ts
+	// "surfaced unsupported" section; reliable renders these as
+	// disabled tiles in the import wizard).
+	Register("aws_iam_role", "IAM role", "aws")
+	Register("aws_iam_policy", "IAM policy", "aws")
+	Register("aws_kms_key", "KMS key", "kms")
+	Register("aws_s3_bucket", "Bucket (S3)", "s3")
+	Register("aws_vpc", "Virtual private cloud (VPC)", "vpc")
+	Register("aws_subnet", "Subnet", "vpc")
+	Register("aws_security_group", "Security group", "vpc")
+	Register("aws_eks_cluster", "Kubernetes cluster (EKS)", "eks")
+	Register("aws_eks_node_group", "EKS node group", "eks")
+	Register("aws_lb", "Load balancer (ALB)", "alb")
+	Register("aws_cloudfront_distribution", "CDN (CloudFront)", "cdn")
+	Register("aws_instance", "EC2 instance", "ec2")
+
+	// GCP — importable today.
+	Register("google_pubsub_topic", "Pub/Sub topic", "pubsub")
+	Register("google_pubsub_subscription", "Pub/Sub subscription", "pubsub")
+	Register("google_storage_bucket", "Cloud Storage bucket", "gcs")
+	Register("google_secret_manager_secret", "Secret (Secret Manager)", "secret_manager")
+	Register("google_compute_network", "VPC network", "vpc")
+
+	// GCP — surfaced unsupported.
+	Register("google_sql_database_instance", "Cloud SQL instance", "cloudsql")
+	Register("google_container_cluster", "Kubernetes cluster (GKE)", "gke")
+}


### PR DESCRIPTION
## Summary

Populates the empty `pkg/imported/labels` override registry (skeleton-only since #485) with the 24 curated entries shipping today in [`luthersystems/reliable`'s `components/import/serviceMeta.ts`](https://github.com/luthersystems/reliable/blob/main/components/import/serviceMeta.ts). Without these overrides the `imported-labels` emitter produces humanised snake-case defaults that diverge from reliable's user-facing product copy.

| tfType | default rule | curated override |
|---|---|---|
| `aws_s3_bucket` | `S3 Bucket` | `Bucket (S3)` |
| `aws_dynamodb_table` | `Dynamodb Table` | `Table (DynamoDB)` |
| `aws_sqs_queue` | `Sqs Queue` | `Queue (SQS)` |
| `google_pubsub_topic` | `Pubsub Topic` | `Pub/Sub topic` |
| `google_storage_bucket` | `Storage Bucket` | `Cloud Storage bucket` |
| `google_secret_manager_secret` | `Secret Manager Secret` | `Secret (Secret Manager)` |
| _… + 18 more_ | | |

The capitalisation (`DynamoDB` not `Dynamodb`), vendor brand spelling (`Pub/Sub` not `Pubsub`), and lowercase-second-word (`bucket` not `Bucket`) are deliberate product copy choices that have shipped to users for many releases.

## Why now

Unblocks Surface D of [`luthersystems/reliable#1479`](https://github.com/luthersystems/reliable/issues/1479). The reliable scaffolding PR [luthersystems/reliable#1538](https://github.com/luthersystems/reliable/pull/1538) wires `imported-labels.json` into reliable's regen pipeline but explicitly **gates the consumer-side migration on this upstream label curation** — swapping `serviceMeta.ts` over to read the JSON today would regress every shipped product label.

After this PR merges and reliable bumps its presets pin, the Surface D consumer swap (`components/import/serviceMeta.ts`, `components/stack/ImportedTile.tsx::iconKindForType`) can land as a pure data swap with zero copy regression.

## Changes

| File | Change |
|---|---|
| `pkg/imported/labels/overrides.go` (new) | 24 `Register()` calls factored into `registerCuratedOverrides()` (called from `init()`). The factoring lets the locking test re-run the registrations after `resetForTest()` wipes the registry. |
| `pkg/imported/labels/labels_test.go` | New `TestCuratedOverrides_LockReliableCopy` — table-driven, asserts every override against reliable's `serviceMeta.ts` string verbatim. Cases live in the test file (not a fixture) so a future label change requires a code edit visible in the diff. |
| `cmd/imported-codegen/emit_labels_test.go` | Update `TestBuildLabelsMap_KnownEntries` — `aws_s3_bucket`, `aws_dynamodb_table`, `google_pubsub_topic`, `google_compute_network` now assert curated strings instead of the skeleton-era default-rule output. |

### iconKey strategy

`iconKey` values match the SVG basenames `serviceMeta.ts` already uses (`s3`, `sqs`, `ddb`, `cw`, `secretsmanager`, `lambda`, `kms`, `vpc`, `eks`, `alb`, `cdn`, `ec2`, `aws`, `pubsub`, `gcs`, `secret_manager`, `cloudsql`, `gke`). Downstream consumers can map `iconKey` → `/aws-icons/<iconKey>.svg` / `/gcp-icons/<iconKey>.svg` without a second lookup table.

The amber `GenericIconKind` tile palette in reliable's `ImportedTile.tsx` (e.g. mapping `google_storage_bucket` → `"s3"`) is a separate tile-level concern that stays in reliable — this PR pins the canonical per-type icon **asset** key, not the tile glyph.

## Out of scope

Two types in `serviceMeta.ts` are **not** registered here because they aren't in `registry.SupportedDiscoverTypes`:

- `aws_rds_cluster` (upstream has `aws_db_instance`/`aws_db_parameter_group`/`aws_db_subnet_group` instead)
- `google_compute_subnetwork`

Tracked as a follow-up: either register upstream (and add to discover/policy pipelines) or drop from reliable on the Surface D consumer swap. Registering them here would silently expand the emitted labels map beyond the discover-supported set and confuse consumers that key off it.

Other curation for types reliable doesn't have today can land in follow-up PRs as those types become user-visible.

## Test plan

- [x] `go test ./...` — full suite passes on top of `origin/main`
- [x] `go build ./...` — clean
- [x] `golangci-lint run ./pkg/imported/labels/...` — clean (the two pre-existing `staticcheck` warnings on `cmd/imported-codegen/typemap.go` / `typemap_zod.go` predate this PR)
- [x] `TestCuratedOverrides_LockReliableCopy` covers every registered override
- [x] `TestBuildLabelsMap_KnownEntries` updated to lock the codegen pipeline against the curated strings
- [ ] Follow-up: bump presets pin in reliable, swap `serviceMeta.ts` consumer (separate reliable PR)

Refs `luthersystems/reliable#1479`, `luthersystems/reliable#1538`