### PR TITLE
feat(imported): extend MetricsBinding registry — 128 total (#482)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -22,8 +22,8 @@ and is checked in lockstep with the runtime registries. See the
 
 ## Summary
 
-- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 66% MetricsAvailable · 39% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 80% MetricsAvailable · 89% AgentEditable
+- **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 42% DriftDetectable · 71% MetricsAvailable · 39% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 85% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
@@ -36,7 +36,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_apigatewayv2_api` | ✓ | ✓ | – | ✓ | – |
 | `aws_apigatewayv2_api_mapping` | ✓ | ✓ | – | – | – |
 | `aws_apigatewayv2_authorizer` | ✓ | ✓ | – | ✓ | – |
-| `aws_apigatewayv2_domain_name` | ✓ | ✓ | – | – | – |
+| `aws_apigatewayv2_domain_name` | ✓ | ✓ | – | ✓ | – |
 | `aws_apigatewayv2_integration` | ✓ | ✓ | – | ✓ | – |
 | `aws_apigatewayv2_route` | ✓ | ✓ | – | ✓ | – |
 | `aws_apigatewayv2_stage` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -71,7 +71,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_ecs_cluster` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_ecs_cluster_capacity_providers` | ✓ | ✓ | – | – | – |
 | `aws_eip` | ✓ | ✓ | – | ✓ | – |
-| `aws_eks_access_entry` | ✓ | ✓ | – | – | – |
+| `aws_eks_access_entry` | ✓ | ✓ | – | ✓ | – |
 | `aws_eks_addon` | ✓ | ✓ | – | ✓ | – |
 | `aws_eks_cluster` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_eks_fargate_profile` | ✓ | ✓ | – | ✓ | – |
@@ -91,7 +91,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_internet_gateway` | ✓ | ✓ | – | ✓ | – |
 | `aws_key_pair` | ✓ | ✓ | – | – | – |
-| `aws_kms_alias` | ✓ | ✓ | – | – | – |
+| `aws_kms_alias` | ✓ | ✓ | – | ✓ | – |
 | `aws_kms_key` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_lambda_alias` | ✓ | ✓ | – | ✓ | – |
 | `aws_lambda_event_source_mapping` | ✓ | ✓ | – | ✓ | – |
@@ -103,7 +103,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_lb_listener` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_lb_target_group` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_msk_cluster` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `aws_msk_configuration` | ✓ | ✓ | – | – | – |
+| `aws_msk_configuration` | ✓ | ✓ | – | ✓ | – |
 | `aws_nat_gateway` | ✓ | ✓ | – | ✓ | – |
 | `aws_network_acl` | ✓ | ✓ | – | ✓ | – |
 | `aws_network_interface` | ✓ | ✓ | – | ✓ | – |
@@ -116,7 +116,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_route53_zone` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_route_table` | ✓ | ✓ | – | ✓ | – |
 | `aws_s3_bucket` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `aws_s3_bucket_lifecycle_configuration` | ✓ | ✓ | ✓ | – | ✓ |
+| `aws_s3_bucket_lifecycle_configuration` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_s3_bucket_ownership_controls` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_s3_bucket_policy` | ✓ | ✓ | – | – | – |
 | `aws_s3_bucket_public_access_block` | ✓ | ✓ | ✓ | – | ✓ |
@@ -161,7 +161,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_managed_ssl_certificate` | ✓ | ✓ | – | ✓ | ✓ |
 | `google_compute_network` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_compute_resource_policy` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_resource_policy` | ✓ | ✓ | – | ✓ | ✓ |
 | `google_compute_router` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_security_policy` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_target_http_proxy` | ✓ | ✓ | – | ✓ | ✓ |
@@ -191,9 +191,9 @@ and is checked in lockstep with the runtime registries. See the
 | `google_service_account` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_service_networking_connection` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_sql_database_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_sql_user` | ✓ | ✓ | – | – | ✓ |
+| `google_sql_user` | ✓ | ✓ | – | ✓ | ✓ |
 | `google_storage_bucket` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_storage_bucket_iam_member` | ✓ | ✓ | – | – | – |
+| `google_storage_bucket_iam_member` | ✓ | ✓ | – | ✓ | – |
 | `google_storage_bucket_object` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_vertex_ai_dataset` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_vpc_access_connector` | ✓ | ✓ | ✓ | ✓ | ✓ |

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -124,6 +124,14 @@ var seededTypes = []string{
 	"google_api_gateway_api",
 	"google_api_gateway_api_config",
 	"google_project_iam_member",
+	"aws_s3_bucket_lifecycle_configuration",
+	"aws_apigatewayv2_domain_name",
+	"aws_kms_alias",
+	"aws_msk_configuration",
+	"aws_eks_access_entry",
+	"google_compute_resource_policy",
+	"google_sql_user",
+	"google_storage_bucket_iam_member",
 }
 
 // seededBindings mirrors the registrations performed by init(). Used
@@ -982,6 +990,74 @@ var seededBindings = map[string]ComponentMetricsBinding{
 	"google_project_iam_member": {
 		// IAM-style: registered for routing only; DefaultMetrics
 		// intentionally empty (mirrors aws_iam_role).
+		Service:       "iam",
+		Action:        "timeseries-list",
+		DimensionKey:  "member",
+		DimensionFrom: "id",
+	},
+	"aws_s3_bucket_lifecycle_configuration": {
+		// Lifecycle config has no per-config metrics — rolls up to
+		// the parent bucket's NumberOfObjects / BucketSizeBytes
+		// so consumers can correlate transitions with object-count
+		// changes scoped to BucketName.
+		Service:        "s3",
+		Action:         "get-metrics",
+		DimensionKey:   "BucketName",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"NumberOfObjects", "BucketSizeBytes"},
+	},
+	"aws_apigatewayv2_domain_name": {
+		Service:        "apigateway",
+		Action:         "get-metrics",
+		DimensionKey:   "DomainName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"Count", "4xx", "5xx", "Latency"},
+	},
+	"aws_kms_alias": {
+		// Aliases are pointers to a KMS key — no per-alias metrics;
+		// registered for routing only so consumers can resolve
+		// alias → key and pull the underlying key's metrics.
+		Service:       "kms",
+		Action:        "get-metrics",
+		DimensionKey:  "AliasName",
+		DimensionFrom: "name",
+	},
+	"aws_msk_configuration": {
+		// Config objects (Kafka broker config bundles) have no
+		// per-config CloudWatch metrics — they're applied to clusters
+		// at create-time. Registered for routing only.
+		Service:       "kafka",
+		Action:        "get-metrics",
+		DimensionKey:  "ConfigurationArn",
+		DimensionFrom: "id",
+	},
+	"aws_eks_access_entry": {
+		// IAM-style: an EKS access entry is an RBAC binding between
+		// an IAM principal and a cluster — no per-entry metrics.
+		// Registered for routing only.
+		Service:       "eks",
+		Action:        "get-metrics",
+		DimensionKey:  "PrincipalArn",
+		DimensionFrom: "id",
+	},
+	"google_compute_resource_policy": {
+		Service:        "compute",
+		Action:         "timeseries-list",
+		DimensionKey:   "policy_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"compute.googleapis.com/snapshot/total_storage_bytes", "compute.googleapis.com/snapshot/disk_size_bytes"},
+	},
+	"google_sql_user": {
+		// IAM-style: a Cloud SQL user is a DB grant — no per-user
+		// time-series. Registered for routing only.
+		Service:       "cloudsql",
+		Action:        "timeseries-list",
+		DimensionKey:  "user_name",
+		DimensionFrom: "name",
+	},
+	"google_storage_bucket_iam_member": {
+		// IAM-style: IAM member bindings have no per-binding metrics.
+		// Registered for routing only.
 		Service:       "iam",
 		Action:        "timeseries-list",
 		DimensionKey:  "member",

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -29,22 +29,27 @@ func reseed(t *testing.T) {
 // DefaultMetrics means "use consumer defaults" and is distinct from
 // "type isn't bound at all".
 var emptyDefaultMetricsAllowed = map[string]bool{
-	"aws_iam_role":                   true,
-	"aws_iam_policy":                 true,
-	"aws_iam_user":                   true,
-	"aws_iam_group":                  true,
-	"aws_iam_instance_profile":       true,
-	"aws_iam_role_policy":            true,
-	"aws_iam_role_policy_attachment": true,
-	"google_service_account":         true,
-	"google_project_iam_member":      true,
+	"aws_iam_role":                    true,
+	"aws_iam_policy":                  true,
+	"aws_iam_user":                    true,
+	"aws_iam_group":                   true,
+	"aws_iam_instance_profile":        true,
+	"aws_iam_role_policy":             true,
+	"aws_iam_role_policy_attachment":  true,
+	"google_service_account":          true,
+	"google_project_iam_member":       true,
+	"aws_kms_alias":                   true,
+	"aws_msk_configuration":           true,
+	"aws_eks_access_entry":            true,
+	"google_sql_user":                 true,
+	"google_storage_bucket_iam_member": true,
 }
 
 func TestSeededBindings(t *testing.T) {
 	reseed(t)
 
-	require.GreaterOrEqual(t, len(RegisteredTypes()), 120,
-		"expected at least 120 seeded types, got %d", len(RegisteredTypes()))
+	require.GreaterOrEqual(t, len(RegisteredTypes()), 128,
+		"expected at least 128 seeded types, got %d", len(RegisteredTypes()))
 
 	for _, tfType := range seededTypes {
 		tfType := tfType


### PR DESCRIPTION
## Summary

Extends `pkg/imported/bindings` from 120 → 128 entries (+8).

**8 new types** (5 AWS + 3 GCP):

- `aws_s3_bucket_lifecycle_configuration` — rolls up to bucket-scope NumberOfObjects/BucketSizeBytes
- `aws_apigatewayv2_domain_name` — DomainName-scoped Count/4xx/5xx/Latency
- `aws_kms_alias` — IAM-style (alias → key resolution, routing only)
- `aws_msk_configuration` — IAM-style (config bundle, no per-config metrics)
- `aws_eks_access_entry` — IAM-style (RBAC binding, no metrics)
- `google_compute_resource_policy` — snapshot schedule storage metrics
- `google_sql_user` — IAM-style (DB grant, no metrics)
- `google_storage_bucket_iam_member` — IAM-style (binding, no metrics)

The 5 IAM-style additions ship with empty DefaultMetrics and are added to `emptyDefaultMetricsAllowed` in `seed_test.go`.

Bumps test count gate 120 → 128 and regenerates `SUPPORTED_RESOURCES.md` (AWS MetricsAvailable 66% → 71%, GCP 80% → 85%).

## Test plan

- [x] `go test ./pkg/imported/bindings/... -count=1`
- [x] `go test ./cmd/imported-codegen/... -count=1`
- [x] Regenerated `SUPPORTED_RESOURCES.md` matches checked-in copy