### PR TITLE
feat(policy): drift-tag depth pass — 19 GCP/AWS policies

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -23,7 +23,7 @@ and is checked in lockstep with the runtime registries. See the
 ## Summary
 
 - **AWS:** 109 types · 100% Discoverable · 100% Enrichable · 100% DriftDetectable · 8% MetricsAvailable · 91% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 63% DriftDetectable · 11% MetricsAvailable · 89% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 87% DriftDetectable · 11% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
@@ -143,34 +143,34 @@ and is checked in lockstep with the runtime registries. See the
 
 | TF Type | Discoverable | Enrichable | DriftDetectable | MetricsAvailable | AgentEditable |
 |---|---|---|---|---|---|
-| `google_api_gateway_api` | ✓ | ✓ | – | – | ✓ |
-| `google_api_gateway_api_config` | ✓ | ✓ | – | – | ✓ |
-| `google_api_gateway_gateway` | ✓ | ✓ | – | – | ✓ |
+| `google_api_gateway_api` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_api_gateway_api_config` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_api_gateway_gateway` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_cloud_run_v2_service` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_cloud_run_v2_service_iam_member` | ✓ | ✓ | – | – | – |
-| `google_cloudbuild_trigger` | ✓ | ✓ | – | – | ✓ |
+| `google_cloudbuild_trigger` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_cloudfunctions2_function` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_cloudfunctions2_function_iam_member` | ✓ | ✓ | – | – | – |
 | `google_compute_address` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_backend_service` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_firewall` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_forwarding_rule` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_compute_global_address` | ✓ | ✓ | – | – | ✓ |
-| `google_compute_global_forwarding_rule` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_global_address` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_compute_global_forwarding_rule` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_health_check` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_instance` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_compute_managed_ssl_certificate` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_managed_ssl_certificate` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_network` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_compute_resource_policy` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_resource_policy` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_router` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_security_policy` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_compute_target_http_proxy` | ✓ | ✓ | – | – | ✓ |
-| `google_compute_target_https_proxy` | ✓ | ✓ | – | – | ✓ |
+| `google_compute_target_http_proxy` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_compute_target_https_proxy` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_compute_url_map` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_container_cluster` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_container_node_pool` | ✓ | ✓ | ✓ | – | ✓ |
-| `google_firestore_database` | ✓ | ✓ | – | – | ✓ |
-| `google_identity_platform_config` | ✓ | ✓ | – | – | ✓ |
+| `google_firestore_database` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_identity_platform_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key_iam_binding` | ✓ | ✓ | – | – | ✓ |
@@ -191,7 +191,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_service_account` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_service_networking_connection` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_sql_database_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_sql_user` | ✓ | ✓ | – | – | ✓ |
+| `google_sql_user` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_storage_bucket` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_storage_bucket_iam_member` | ✓ | ✓ | – | – | – |
 | `google_storage_bucket_object` | ✓ | ✓ | ✓ | – | ✓ |

--- a/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
+++ b/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
@@ -7197,13 +7197,131 @@
       "semantic": "Exact"
     }
   ],
+  "google_api_gateway_api": [
+    {
+      "path": "api_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "display_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "managed_service",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    }
+  ],
+  "google_api_gateway_api_config": [
+    {
+      "path": "api",
+      "semantic": "Exact"
+    },
+    {
+      "path": "api_config_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "api_config_id_prefix",
+      "semantic": "Exact"
+    },
+    {
+      "path": "display_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "gateway_config.backend_config.google_service_account",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "service_config_id",
+      "semantic": "Exact"
+    }
+  ],
+  "google_api_gateway_gateway": [
+    {
+      "path": "api_config",
+      "semantic": "Exact"
+    },
+    {
+      "path": "default_hostname",
+      "semantic": "Exact"
+    },
+    {
+      "path": "display_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "gateway_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "region",
+      "semantic": "Exact"
+    }
+  ],
   "google_cloud_run_v2_service": [
     {
       "path": "custom_audiences",
       "semantic": "WholeList"
     },
     {
+      "path": "deletion_protection",
+      "semantic": "Exact"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
       "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ingress",
+      "semantic": "Exact"
+    },
+    {
+      "path": "invoker_iam_disabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "launch_stage",
       "semantic": "Exact"
     },
     {
@@ -7216,6 +7334,92 @@
     },
     {
       "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "template.containers.image",
+      "semantic": "Exact"
+    },
+    {
+      "path": "template.execution_environment",
+      "semantic": "Exact"
+    },
+    {
+      "path": "template.max_instance_request_concurrency",
+      "semantic": "Exact"
+    },
+    {
+      "path": "template.scaling.max_instance_count",
+      "semantic": "Exact"
+    },
+    {
+      "path": "template.scaling.min_instance_count",
+      "semantic": "Exact"
+    },
+    {
+      "path": "template.service_account",
+      "semantic": "Exact"
+    },
+    {
+      "path": "template.timeout",
+      "semantic": "Exact"
+    },
+    {
+      "path": "template.vpc_access.connector",
+      "semantic": "Exact"
+    }
+  ],
+  "google_cloudbuild_trigger": [
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "disabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "filename",
+      "semantic": "Exact"
+    },
+    {
+      "path": "filter",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ignored_files",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "include_build_logs",
+      "semantic": "Exact"
+    },
+    {
+      "path": "included_files",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "service_account",
+      "semantic": "Exact"
+    },
+    {
+      "path": "trigger_id",
       "semantic": "Exact"
     }
   ],
@@ -7301,6 +7505,38 @@
   ],
   "google_compute_backend_service": [
     {
+      "path": "affinity_cookie_ttl_sec",
+      "semantic": "Exact"
+    },
+    {
+      "path": "compression_mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "connection_draining_timeout_sec",
+      "semantic": "Exact"
+    },
+    {
+      "path": "custom_request_headers",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "custom_response_headers",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "edge_security_policy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "enable_cdn",
+      "semantic": "Exact"
+    },
+    {
       "path": "generated_id",
       "semantic": "Exact"
     },
@@ -7313,7 +7549,23 @@
       "semantic": "Exact"
     },
     {
+      "path": "ip_address_selection_policy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "load_balancing_scheme",
+      "semantic": "Exact"
+    },
+    {
+      "path": "locality_lb_policy",
+      "semantic": "Exact"
+    },
+    {
       "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "port_name",
       "semantic": "Exact"
     },
     {
@@ -7321,7 +7573,27 @@
       "semantic": "Exact"
     },
     {
+      "path": "protocol",
+      "semantic": "Exact"
+    },
+    {
+      "path": "security_policy",
+      "semantic": "Exact"
+    },
+    {
       "path": "self_link",
+      "semantic": "Exact"
+    },
+    {
+      "path": "service_lb_policy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "session_affinity",
+      "semantic": "Exact"
+    },
+    {
+      "path": "timeout_sec",
       "semantic": "Exact"
     }
   ],
@@ -7486,6 +7758,106 @@
     },
     {
       "path": "service_label",
+      "semantic": "Exact"
+    },
+    {
+      "path": "subnetwork",
+      "semantic": "Exact"
+    },
+    {
+      "path": "target",
+      "semantic": "Exact"
+    }
+  ],
+  "google_compute_global_address": [
+    {
+      "path": "address",
+      "semantic": "Exact"
+    },
+    {
+      "path": "address_type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ip_version",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "network",
+      "semantic": "Exact"
+    },
+    {
+      "path": "prefix_length",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "purpose",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    }
+  ],
+  "google_compute_global_forwarding_rule": [
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ip_address",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ip_protocol",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ip_version",
+      "semantic": "Exact"
+    },
+    {
+      "path": "load_balancing_scheme",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "network",
+      "semantic": "Exact"
+    },
+    {
+      "path": "port_range",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
       "semantic": "Exact"
     },
     {
@@ -7701,6 +8073,44 @@
       "semantic": "Exact"
     }
   ],
+  "google_compute_managed_ssl_certificate": [
+    {
+      "path": "certificate_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "managed.domains",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    },
+    {
+      "path": "subject_alternative_names",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "type",
+      "semantic": "Exact"
+    }
+  ],
   "google_compute_network": [
     {
       "path": "auto_create_subnetworks",
@@ -7748,6 +8158,32 @@
     },
     {
       "path": "routing_mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    }
+  ],
+  "google_compute_resource_policy": [
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "region",
       "semantic": "Exact"
     },
     {
@@ -7843,6 +8279,106 @@
       "semantic": "Exact"
     }
   ],
+  "google_compute_target_http_proxy": [
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "http_keep_alive_timeout_sec",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "proxy_bind",
+      "semantic": "Exact"
+    },
+    {
+      "path": "proxy_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    },
+    {
+      "path": "url_map",
+      "semantic": "Exact"
+    }
+  ],
+  "google_compute_target_https_proxy": [
+    {
+      "path": "certificate_manager_certificates",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "certificate_map",
+      "semantic": "Exact"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "http_keep_alive_timeout_sec",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "proxy_bind",
+      "semantic": "Exact"
+    },
+    {
+      "path": "quic_override",
+      "semantic": "Exact"
+    },
+    {
+      "path": "self_link",
+      "semantic": "Exact"
+    },
+    {
+      "path": "server_tls_policy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "ssl_certificates",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "ssl_policy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "tls_early_data",
+      "semantic": "Exact"
+    },
+    {
+      "path": "url_map",
+      "semantic": "Exact"
+    }
+  ],
   "google_compute_url_map": [
     {
       "path": "default_service",
@@ -7871,11 +8407,51 @@
   ],
   "google_container_cluster": [
     {
+      "path": "database_encryption.key_name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "database_encryption.state",
+      "semantic": "Exact"
+    },
+    {
+      "path": "datapath_provider",
+      "semantic": "Exact"
+    },
+    {
+      "path": "deletion_protection",
+      "semantic": "Exact"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
+      "path": "enable_autopilot",
+      "semantic": "Exact"
+    },
+    {
+      "path": "enable_intranode_visibility",
+      "semantic": "Exact"
+    },
+    {
+      "path": "enable_legacy_abac",
+      "semantic": "Exact"
+    },
+    {
+      "path": "enable_shielded_nodes",
+      "semantic": "Exact"
+    },
+    {
       "path": "id",
       "semantic": "Exact"
     },
     {
       "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "min_master_version",
       "semantic": "Exact"
     },
     {
@@ -7887,11 +8463,31 @@
       "semantic": "Exact"
     },
     {
+      "path": "networking_mode",
+      "semantic": "Exact"
+    },
+    {
       "path": "node_config.oauth_scopes",
       "semantic": "WholeList"
     },
     {
+      "path": "node_version",
+      "semantic": "Exact"
+    },
+    {
+      "path": "private_cluster_config.enable_private_endpoint",
+      "semantic": "Exact"
+    },
+    {
+      "path": "private_cluster_config.enable_private_nodes",
+      "semantic": "Exact"
+    },
+    {
       "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "release_channel.channel",
       "semantic": "Exact"
     },
     {
@@ -7900,6 +8496,10 @@
     },
     {
       "path": "subnetwork",
+      "semantic": "Exact"
+    },
+    {
+      "path": "workload_identity_config.workload_pool",
       "semantic": "Exact"
     }
   ],
@@ -7913,7 +8513,15 @@
       "semantic": "Exact"
     },
     {
+      "path": "initial_node_count",
+      "semantic": "Exact"
+    },
+    {
       "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "max_pods_per_node",
       "semantic": "Exact"
     },
     {
@@ -7925,8 +8533,84 @@
       "semantic": "Exact"
     },
     {
+      "path": "node_count",
+      "semantic": "Exact"
+    },
+    {
       "path": "node_locations",
       "semantic": "WholeList"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "version",
+      "semantic": "Exact"
+    }
+  ],
+  "google_firestore_database": [
+    {
+      "path": "app_engine_integration_mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "concurrency_mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "delete_protection_state",
+      "semantic": "Exact"
+    },
+    {
+      "path": "deletion_policy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "location_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "point_in_time_recovery_enablement",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "type",
+      "semantic": "Exact"
+    },
+    {
+      "path": "version_retention_period",
+      "semantic": "Exact"
+    }
+  ],
+  "google_identity_platform_config": [
+    {
+      "path": "authorized_domains",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "autodelete_anonymous_users",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
     },
     {
       "path": "project",
@@ -8021,7 +8705,23 @@
   ],
   "google_logging_project_sink": [
     {
+      "path": "custom_writer_identity",
+      "semantic": "Exact"
+    },
+    {
+      "path": "description",
+      "semantic": "Exact"
+    },
+    {
       "path": "destination",
+      "semantic": "Exact"
+    },
+    {
+      "path": "disabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "filter",
       "semantic": "Exact"
     },
     {
@@ -8034,6 +8734,10 @@
     },
     {
       "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "unique_writer_identity",
       "semantic": "Exact"
     },
     {
@@ -8335,11 +9039,39 @@
   ],
   "google_redis_instance": [
     {
+      "path": "alternative_location_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "auth_enabled",
+      "semantic": "Exact"
+    },
+    {
       "path": "authorized_network",
       "semantic": "Exact"
     },
     {
+      "path": "connect_mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "customer_managed_key",
+      "semantic": "Exact"
+    },
+    {
+      "path": "display_name",
+      "semantic": "Exact"
+    },
+    {
       "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "location_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "memory_size_gb",
       "semantic": "Exact"
     },
     {
@@ -8351,7 +9083,35 @@
       "semantic": "Exact"
     },
     {
+      "path": "read_replicas_mode",
+      "semantic": "Exact"
+    },
+    {
+      "path": "redis_version",
+      "semantic": "Exact"
+    },
+    {
       "path": "region",
+      "semantic": "Exact"
+    },
+    {
+      "path": "replica_count",
+      "semantic": "Exact"
+    },
+    {
+      "path": "reserved_ip_range",
+      "semantic": "Exact"
+    },
+    {
+      "path": "secondary_ip_range",
+      "semantic": "Exact"
+    },
+    {
+      "path": "tier",
+      "semantic": "Exact"
+    },
+    {
+      "path": "transit_encryption_mode",
       "semantic": "Exact"
     }
   ],
@@ -8658,6 +9418,40 @@
     },
     {
       "path": "settings.tier",
+      "semantic": "Exact"
+    }
+  ],
+  "google_sql_user": [
+    {
+      "path": "deletion_policy",
+      "semantic": "Exact"
+    },
+    {
+      "path": "host",
+      "semantic": "Exact"
+    },
+    {
+      "path": "id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "instance",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "sql_server_user_details.disabled",
+      "semantic": "Exact"
+    },
+    {
+      "path": "type",
       "semantic": "Exact"
     }
   ],

--- a/pkg/composer/imported/policy/aws_iam_instance_profile.policy.go
+++ b/pkg/composer/imported/policy/aws_iam_instance_profile.policy.go
@@ -44,6 +44,9 @@ var awsIamInstanceProfilePolicy = Map{
 	},
 	"create_date": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		// Arrival-time-dependent — drift on this is a re-creation, which
+		// `arn` / `unique_id` already surface; keep DriftSemanticNone so
+		// the comparator doesn't double-count.
 	},
 
 	// Wiring — bound IAM role ------------------------------------------

--- a/pkg/composer/imported/policy/google_api_gateway_api.policy.go
+++ b/pkg/composer/imported/policy/google_api_gateway_api.policy.go
@@ -1,25 +1,42 @@
 package policy
 
+// googleAPIGatewayAPIPolicy curates Layer 2 for
+// `google_api_gateway_api`. All curated leaves are scalar (api_id,
+// project, managed_service backing reference, display_name), so
+// DriftSemanticExact is the meaningful comparison. create_time is
+// arrival-time-dependent and stays DriftSemanticNone.
 var googleAPIGatewayAPIPolicy = Map{
 	// Identity
-	"name":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":     {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"api_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"api_id": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"create_time": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
 	},
 	"managed_service": {
 		Role: RoleIdentity, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditNever,
+		Edit:          EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"display_name": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Labels

--- a/pkg/composer/imported/policy/google_api_gateway_api_config.policy.go
+++ b/pkg/composer/imported/policy/google_api_gateway_api_config.policy.go
@@ -1,32 +1,53 @@
 package policy
 
+// googleAPIGatewayAPIConfigPolicy curates Layer 2 for
+// `google_api_gateway_api_config`. Scalar identity/wiring/spec fields
+// use DriftSemanticExact so a re-parented config or a swapped backend
+// SA shows up in drift. Spec-blob `*.contents` payloads stay
+// DriftSemanticNone — they are opaque base64 blobs that the
+// comparator can't meaningfully diff per-leaf today (deferred to
+// presets#482's content-aware comparator).
 var googleAPIGatewayAPIConfigPolicy = Map{
 	// Identity
-	"name":          {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":            {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"api_config_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"api_config_id": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"api_config_id_prefix": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"service_config_id": {
 		Role: RoleIdentity, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditNever,
+		Edit:          EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — parent API.
 	"api": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"display_name": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Spec / config payloads — operator-controlled, sensitivity not
@@ -59,6 +80,7 @@ var googleAPIGatewayAPIConfigPolicy = Map{
 	"gateway_config.backend_config.google_service_account": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Labels

--- a/pkg/composer/imported/policy/google_api_gateway_gateway.policy.go
+++ b/pkg/composer/imported/policy/google_api_gateway_gateway.policy.go
@@ -1,32 +1,51 @@
 package policy
 
+// googleAPIGatewayGatewayPolicy curates Layer 2 for
+// `google_api_gateway_gateway`. All curated leaves are scalar
+// (gateway_id, project, region, parent api_config, display_name,
+// default_hostname), so DriftSemanticExact is the meaningful
+// comparison across the surface.
 var googleAPIGatewayGatewayPolicy = Map{
 	// Identity
-	"name":       {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":         {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"gateway_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"gateway_id": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"region": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"default_hostname": {
 		Role: RoleIdentity, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditNever,
+		Edit:          EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — parent api_config.
 	"api_config": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"display_name": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Labels

--- a/pkg/composer/imported/policy/google_cloud_run_v2_service.policy.go
+++ b/pkg/composer/imported/policy/google_cloud_run_v2_service.policy.go
@@ -30,20 +30,25 @@ var googleCloudRunV2ServicePolicy = Map{
 	// Tuning — top-level
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ingress": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"launch_stage": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"invoker_iam_disabled": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"deletion_protection": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"custom_audiences": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
@@ -54,7 +59,8 @@ var googleCloudRunV2ServicePolicy = Map{
 	// Template — image + scaling + concurrency are the core knobs.
 	"template.containers.image": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"template.containers.name": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
@@ -80,26 +86,33 @@ var googleCloudRunV2ServicePolicy = Map{
 	},
 	"template.scaling.min_instance_count": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"template.scaling.max_instance_count": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"template.max_instance_request_concurrency": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"template.timeout": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"template.service_account": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"template.execution_environment": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"template.vpc_access.connector": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"template.vpc_access.egress": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,

--- a/pkg/composer/imported/policy/google_cloudbuild_trigger.policy.go
+++ b/pkg/composer/imported/policy/google_cloudbuild_trigger.policy.go
@@ -1,49 +1,73 @@
 package policy
 
+// googleCloudbuildTriggerPolicy curates Layer 2 for
+// `google_cloudbuild_trigger`. Scalar identity / wiring / spec fields
+// use DriftSemanticExact so re-parenting (project/location), SA
+// rotation, and build-config changes (filename/filter/disabled) show
+// up in drift. The list-valued `ignored_files` / `included_files`
+// use DriftSemanticWholeList — the authored glob set is the
+// meaningful drift signal regardless of order.
 var googleCloudbuildTriggerPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"location": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"trigger_id": {
 		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — service account for build execution.
 	"service_account": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — top-level.
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"disabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"filename": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"filter": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"include_build_logs": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ignored_files": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"included_files": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	// NB: `tags` on cloudbuild_trigger is NOT labels — it's a free-text
 	// set of operator annotations (per provider docs). Same lint

--- a/pkg/composer/imported/policy/google_compute_backend_service.policy.go
+++ b/pkg/composer/imported/policy/google_compute_backend_service.policy.go
@@ -40,70 +40,87 @@ var googleComputeBackendServicePolicy = Map{
 	},
 	"security_policy": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"edge_security_policy": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"service_lb_policy": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"protocol": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"load_balancing_scheme": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"port_name": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"timeout_sec": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"connection_draining_timeout_sec": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"session_affinity": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"affinity_cookie_ttl_sec": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"locality_lb_policy": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"enable_cdn": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"compression_mode": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"custom_request_headers": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"custom_response_headers": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"ip_address_selection_policy": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"creation_timestamp": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,

--- a/pkg/composer/imported/policy/google_compute_global_address.policy.go
+++ b/pkg/composer/imported/policy/google_compute_global_address.policy.go
@@ -1,44 +1,65 @@
 package policy
 
+// googleComputeGlobalAddressPolicy curates Layer 2 for
+// `google_compute_global_address`. All curated leaves are scalar so
+// DriftSemanticExact is the meaningful comparison; label bags stay
+// DriftSemanticNone (tagPolicy() zero value).
 var googleComputeGlobalAddressPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — VPC association for INTERNAL purpose.
 	"network": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"address": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"address_type": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"purpose": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ip_version": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"prefix_length": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Labels

--- a/pkg/composer/imported/policy/google_compute_global_forwarding_rule.policy.go
+++ b/pkg/composer/imported/policy/google_compute_global_forwarding_rule.policy.go
@@ -1,52 +1,76 @@
 package policy
 
+// googleComputeGlobalForwardingRulePolicy curates Layer 2 for
+// `google_compute_global_forwarding_rule`. All curated leaves are
+// scalar (target/network/subnetwork self-links, IP addr/proto/version,
+// port range, LB scheme), so DriftSemanticExact is the meaningful
+// comparison across the surface.
 var googleComputeGlobalForwardingRulePolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — target proxy + VPC.
 	"target": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"network": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"subnetwork": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ip_address": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ip_protocol": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ip_version": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"port_range": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditRequiresApproval,
-		ChangeRisk: ChangeMayReplace,
+		ChangeRisk:    ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"load_balancing_scheme": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Labels

--- a/pkg/composer/imported/policy/google_compute_managed_ssl_certificate.policy.go
+++ b/pkg/composer/imported/policy/google_compute_managed_ssl_certificate.policy.go
@@ -1,27 +1,48 @@
 package policy
 
+// googleComputeManagedSslCertificatePolicy curates Layer 2 for
+// `google_compute_managed_ssl_certificate`. Identity + spec scalars use
+// DriftSemanticExact; the list-valued `subject_alternative_names` and
+// `managed.domains` use DriftSemanticWholeList — the authored SAN /
+// domain set is the meaningful drift signal regardless of order.
 var googleComputeManagedSslCertificatePolicy = Map{
 	// Identity
-	"name":           {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":             {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link":      {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"certificate_id": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"certificate_id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"type": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"subject_alternative_names": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditNever,
+		Edit:          EditNever,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"expire_time": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
@@ -35,6 +56,7 @@ var googleComputeManagedSslCertificatePolicy = Map{
 	"managed.domains": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/google_compute_resource_policy.policy.go
+++ b/pkg/composer/imported/policy/google_compute_resource_policy.policy.go
@@ -1,22 +1,38 @@
 package policy
 
+// googleComputeResourcePolicyPolicy curates Layer 2 for
+// `google_compute_resource_policy`. All curated leaves are scalar
+// (name, region, description), so DriftSemanticExact is the
+// meaningful comparison.
 var googleComputeResourcePolicyPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"region": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/google_compute_target_http_proxy.policy.go
+++ b/pkg/composer/imported/policy/google_compute_target_http_proxy.policy.go
@@ -1,33 +1,55 @@
 package policy
 
+// googleComputeTargetHttpProxyPolicy curates Layer 2 for
+// `google_compute_target_http_proxy`. All curated leaves are scalar
+// (URL-map self-link, description, keep-alive timeout, proxy_bind),
+// so DriftSemanticExact is the meaningful comparison across the
+// surface.
 var googleComputeTargetHttpProxyPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
-	"proxy_id": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"proxy_id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 
 	// Wiring — URL map is the routing target.
 	"url_map": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"http_keep_alive_timeout_sec": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"proxy_bind": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/google_compute_target_https_proxy.policy.go
+++ b/pkg/composer/imported/policy/google_compute_target_https_proxy.policy.go
@@ -1,58 +1,86 @@
 package policy
 
+// googleComputeTargetHttpsProxyPolicy curates Layer 2 for
+// `google_compute_target_https_proxy`. Scalar identity, URL-map
+// wiring, single-cert wiring, and tuning knobs use DriftSemanticExact.
+// The list-valued `ssl_certificates` and
+// `certificate_manager_certificates` cert sets use DriftSemanticWholeList
+// — the authored cert binding is the meaningful drift signal
+// regardless of order.
 var googleComputeTargetHttpsProxyPolicy = Map{
 	// Identity
-	"name":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"self_link": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"self_link": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — URL map + certificates + policies.
 	"url_map": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ssl_certificates": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"certificate_manager_certificates": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"certificate_map": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"ssl_policy": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"server_tls_policy": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"quic_override": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"proxy_bind": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"http_keep_alive_timeout_sec": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"tls_early_data": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/google_container_cluster.policy.go
+++ b/pkg/composer/imported/policy/google_container_cluster.policy.go
@@ -50,42 +50,52 @@ var googleContainerClusterPolicy = Map{
 	// Tuning — top-level cluster knobs.
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"min_master_version": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"node_version": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"enable_autopilot": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityUIVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"enable_shielded_nodes": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"enable_intranode_visibility": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"enable_legacy_abac": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"deletion_protection": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"networking_mode": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"datapath_provider": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"initial_node_count": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
@@ -145,11 +155,13 @@ var googleContainerClusterPolicy = Map{
 	// Private cluster.
 	"private_cluster_config.enable_private_nodes": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"private_cluster_config.enable_private_endpoint": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"private_cluster_config.master_ipv4_cidr_block": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
@@ -165,23 +177,27 @@ var googleContainerClusterPolicy = Map{
 	// Encryption at rest (etcd).
 	"database_encryption.state": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"database_encryption.key_name": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Workload identity.
 	"workload_identity_config.workload_pool": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Release channel.
 	"release_channel.channel": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Labels — system-owned. resource_labels is the GKE-canonical name;

--- a/pkg/composer/imported/policy/google_container_node_pool.policy.go
+++ b/pkg/composer/imported/policy/google_container_node_pool.policy.go
@@ -46,17 +46,21 @@ var googleContainerNodePoolPolicy = Map{
 	"initial_node_count": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"node_count": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"max_pods_per_node": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityRileyVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"version": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"node_locations": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,

--- a/pkg/composer/imported/policy/google_firestore_database.policy.go
+++ b/pkg/composer/imported/policy/google_firestore_database.policy.go
@@ -1,46 +1,66 @@
 package policy
 
+// googleFirestoreDatabasePolicy curates Layer 2 for
+// `google_firestore_database`. All curated leaves are scalar
+// (database id, location, type/mode enums, PITR toggle, retention,
+// delete-protection), so DriftSemanticExact is the meaningful
+// comparison across the surface.
 var googleFirestoreDatabasePolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"location_id": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — type + mode.
 	"type": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"concurrency_mode": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"app_engine_integration_mode": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Backup + PITR — security/reliability axis.
 	"point_in_time_recovery_enablement": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"version_retention_period": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"delete_protection_state": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"deletion_policy": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/google_identity_platform_config.policy.go
+++ b/pkg/composer/imported/policy/google_identity_platform_config.policy.go
@@ -1,25 +1,40 @@
 package policy
 
+// googleIdentityPlatformConfigPolicy curates Layer 2 for
+// `google_identity_platform_config`. Identity scalars use
+// DriftSemanticExact; the auto-delete toggle is scalar so it uses
+// DriftSemanticExact too. The list-valued `authorized_domains` uses
+// DriftSemanticWholeList — the authored allow-list is the meaningful
+// drift signal (a removed domain = a security drift).
 var googleIdentityPlatformConfigPolicy = Map{
 	// Identity. The Config is a project-scoped singleton named
 	// projects/<p>/config; both `name` (full path) and `id` are
 	// provider-computed.
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — authorized domains and auto-delete behavior are the
 	// primary operator-facing knobs.
 	"authorized_domains": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticWholeList,
 	},
 	"autodelete_anonymous_users": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditChatSafe,
+		Edit:          EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/google_logging_project_sink.policy.go
+++ b/pkg/composer/imported/policy/google_logging_project_sink.policy.go
@@ -33,13 +33,16 @@ var googleLoggingProjectSinkPolicy = Map{
 	// Tuning — filter expression + enabled state.
 	"filter": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"description": {
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"disabled": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Writer identity controls whether the sink gets a unique service
@@ -47,10 +50,12 @@ var googleLoggingProjectSinkPolicy = Map{
 	"unique_writer_identity": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
 		Edit: EditRequiresApproval, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"custom_writer_identity": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityRileyVisible,
-		Edit: EditRelationshipOnly,
+		Edit:          EditRelationshipOnly,
+		DriftSemantic: DriftSemanticExact,
 	},
 	// writer_identity is the computed SA email — read-only.
 	"writer_identity": {

--- a/pkg/composer/imported/policy/google_redis_instance.policy.go
+++ b/pkg/composer/imported/policy/google_redis_instance.policy.go
@@ -29,6 +29,7 @@ var googleRedisInstancePolicy = Map{
 	},
 	"display_name": {
 		Role: RoleTuning, Visibility: VisibilityUIVisible, Edit: EditChatSafe,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — VPC + CMEK.
@@ -41,58 +42,71 @@ var googleRedisInstancePolicy = Map{
 	"customer_managed_key": {
 		Role: RoleWiring, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"reserved_ip_range": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"secondary_ip_range": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditNever,
+		Edit:          EditNever,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — sizing + tier + version.
 	"tier": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"memory_size_gb": {
 		Role: RoleTuning, Pillar: PillarPerformance, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"redis_version": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"replica_count": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"read_replicas_mode": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"connect_mode": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"location_id": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"alternative_location_id": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Security knobs.
 	"auth_enabled": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"transit_encryption_mode": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
 		Edit: EditRequiresApproval, ChangeRisk: ChangeMayReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	// auth_string is the generated AUTH token — sensitive bootstrap secret.
 	"auth_string": {

--- a/pkg/composer/imported/policy/google_sql_user.policy.go
+++ b/pkg/composer/imported/policy/google_sql_user.policy.go
@@ -1,32 +1,49 @@
 package policy
 
+// googleSqlUserPolicy curates Layer 2 for `google_sql_user`. All
+// curated leaves are scalar (user name, host, parent instance,
+// user-type enum, deletion policy, sql_server disabled toggle), so
+// DriftSemanticExact is the meaningful comparison. The `password`
+// bootstrap secret stays DriftSemanticNone — sensitive value, the
+// comparator never sees the cleartext.
 var googleSqlUserPolicy = Map{
 	// Identity
-	"name": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever},
-	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"id": {
+		Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever,
+		DriftSemantic: DriftSemanticExact,
+	},
 	"project": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"host": {
 		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
-		ChangeRisk: ChangeAlwaysReplace,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Wiring — parent instance.
 	"instance": {
 		Role: RoleWiring, Pillar: PillarReliability, Visibility: VisibilityUIVisible,
 		Edit: EditRelationshipOnly, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Tuning — user type.
 	"type": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
 		Edit: EditNever, ChangeRisk: ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
 	},
 	"deletion_policy": {
 		Role: RoleTuning, Pillar: PillarReliability, Visibility: VisibilityRileyVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	// Password is a bootstrap secret. The provider stores it sensitively
@@ -40,7 +57,8 @@ var googleSqlUserPolicy = Map{
 	// Single-row curation for the most commonly-tuned knob.
 	"sql_server_user_details.disabled": {
 		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
-		Edit: EditRequiresApproval,
+		Edit:          EditRequiresApproval,
+		DriftSemantic: DriftSemanticExact,
 	},
 
 	"timeouts": timeoutsPolicy(),


### PR DESCRIPTION
## Summary

Adds `DriftSemantic` tags to under-tagged policy files so drift detection surfaces meaningful drift on spec/wiring fields rather than only on identity scalars.

- Bumps GCP DriftDetectable coverage from **63% → 87%** (no change to the type registry — this only enriches existing policies)
- 19 files enriched (18 GCP + 1 AWS); IAM-binding types skipped per their header rationale (identity tuple is the entire schema)
- List-valued fields (cert sets, SAN lists, custom headers, authorized_domains, ignored/included_files) use `DriftSemanticWholeList`; scalars use `DriftSemanticExact`
- Regenerates `cmd/imported-codegen/testdata/drift_fields/drift-fields.json` and `SUPPORTED_RESOURCES.md`

Lane discipline: only `pkg/composer/imported/policy/*.policy.go` + the two regenerated artifacts. No edits to `cmd/imported-codegen/config.go`, `pkg/insideout-import/registry/registry.go`, or any generated code.

## Test plan

- [x] `go test ./pkg/composer/imported/policy/... -count=1` (447 passing)
- [x] `go test ./cmd/imported-codegen/... -count=1` (770 passing combined)
- [x] `go build ./...`
- [x] `UPDATE_GOLDEN=1 go test ./pkg/composer/imported/policy/...` (golden unchanged — known_paths.golden schema does not include DriftSemantic)
- [x] Regenerated drift-fields.json and SUPPORTED_RESOURCES.md

Refs presets#482.