### PR TITLE
fix(composer): emit *.imported provider aliases unconditionally (#562)

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -764,7 +764,12 @@ func generateProvidersTF(in providersTFInput) []byte {
 	gcpProjectID := in.GCPProjectID
 	selected := in.Selected
 	discovered := in.Discovered
-	importedClouds := in.ImportedClouds
+	// in.ImportedClouds is intentionally unused: as of issue #562 the
+	// `aws.imported` / `google.imported` / `google-beta.imported` alias
+	// blocks are emitted unconditionally for the matching cloud rather
+	// than gated on the current compose's Imported list. The field stays
+	// on providersTFInput for backwards compatibility with callers; a
+	// follow-up PR will retire it once the public API is audited.
 	// Seed required_providers with the cloud's base entry, then union the
 	// child-module discoveries on top. Discovered entries win on conflict.
 	required := map[string]*tfconfig.ProviderRequirement{}
@@ -778,16 +783,13 @@ func generateProvidersTF(in providersTFInput) []byte {
 		// minors. Hard-bumping to ">= 5.16" guarantees the safety net
 		// emitted below is always honored.
 		required["google"] = &tfconfig.ProviderRequirement{Source: "hashicorp/google", VersionConstraints: []string{">= 5.16"}}
-		// google-beta is pulled in either because a child module's
-		// required_providers declared it (already captured in
-		// `discovered`) or because the imported resource set carries
-		// google-beta types and we need the `google-beta.imported`
-		// alias. Declare it explicitly here so the alias block below
-		// doesn't fail required_providers resolution when the only
-		// google-beta consumer is the imported alias.
-		if importedClouds[ProvidersUsedKeyGCPBeta] {
-			required["google-beta"] = &tfconfig.ProviderRequirement{Source: "hashicorp/google-beta", VersionConstraints: []string{">= 5.16"}}
-		}
+		// google-beta is part of every GCP stack's provider set so the
+		// `google-beta.imported` alias block below always resolves —
+		// even when the current compose's Imported list is empty but
+		// terraform state still references the alias (issue #562).
+		// google-beta only ships with GCP-cloud composes; the outer
+		// `switch cloud` keeps it out of AWS stacks.
+		required["google-beta"] = &tfconfig.ProviderRequirement{Source: "hashicorp/google-beta", VersionConstraints: []string{">= 5.16"}}
 		maps.Copy(required, discovered)
 
 		// default_labels is a safety net so every GCP resource in the
@@ -809,30 +811,32 @@ func generateProvidersTF(in providersTFInput) []byte {
 		b.WriteString(renderRequiredProviders(required))
 		b.WriteString("  }\n}\n\n")
 		fmt.Fprintf(&b, "provider \"google\" {\n  region = %q%s\n}\n", region, gcpDefaultLabels)
-		if importedClouds["gcp"] {
-			b.WriteString("\n")
-			// google.imported drives Terraform's import {} for previously
-			// existing GCP resources. project is rendered as a literal —
-			// the root stack does not declare var.gcp_project_id, and the
-			// project ID is known at compose time. No default_labels:
-			// imported resources keep any pre-existing labels untouched.
-			// An empty gcpProjectID still emits an empty literal: the
-			// gcp_project_id_required ValidationIssue surfaces the real
-			// fix to the caller before apply.
-			fmt.Fprintf(&b, "provider \"google\" {\n  alias   = \"imported\"\n  region  = %q\n  project = %q\n}\n", region, gcpProjectID)
-		}
-		if importedClouds[ProvidersUsedKeyGCPBeta] {
-			b.WriteString("\n")
-			// google-beta.imported is the alias used by imported
-			// resources whose schema lives in hashicorp/google-beta —
-			// most notably the API Gateway family. Mirrors the
-			// google.imported alias above (no default_labels) so the
-			// imported resources don't inherit the session's
-			// project label. EmitImportedTF flips importedClouds
-			// ["gcp-beta"] to true whenever any rendered resource
-			// carries provider = google-beta.imported.
-			fmt.Fprintf(&b, "provider \"google-beta\" {\n  alias   = \"imported\"\n  region  = %q\n  project = %q\n}\n", region, gcpProjectID)
-		}
+		b.WriteString("\n")
+		// google.imported drives Terraform's import {} for previously
+		// existing GCP resources. project is rendered as a literal —
+		// the root stack does not declare var.gcp_project_id, and the
+		// project ID is known at compose time. No default_labels:
+		// imported resources keep any pre-existing labels untouched.
+		// An empty gcpProjectID still emits an empty literal: the
+		// gcp_project_id_required ValidationIssue surfaces the real
+		// fix to the caller before apply.
+		//
+		// Emitted unconditionally for every GCP stack (issue #562):
+		// terraform state from a prior compose may still reference
+		// `google.imported` even when the current compose's Imported
+		// list is empty (drift-correction recompose, re-import flow,
+		// etc.). Omitting the alias block then crashes `terraform
+		// plan` with "Provider configuration not present".
+		fmt.Fprintf(&b, "provider \"google\" {\n  alias   = \"imported\"\n  region  = %q\n  project = %q\n}\n", region, gcpProjectID)
+		b.WriteString("\n")
+		// google-beta.imported is the alias used by imported
+		// resources whose schema lives in hashicorp/google-beta —
+		// most notably the API Gateway family. Mirrors the
+		// google.imported alias above (no default_labels) so the
+		// imported resources don't inherit the session's
+		// project label. Emitted unconditionally for the same
+		// reason as google.imported above (issue #562).
+		fmt.Fprintf(&b, "provider \"google-beta\" {\n  alias   = \"imported\"\n  region  = %q\n  project = %q\n}\n", region, gcpProjectID)
 		return []byte(b.String())
 
 	default: // aws
@@ -902,10 +906,15 @@ variable "external_id" {
 		// session and must not silently inherit the stack's Project tag.
 		// Provenance tagging is system-owned and re-emitted in the resource
 		// body via merge() instead (issue #153).
-		if importedClouds["aws"] {
-			b.WriteString("\n")
-			fmt.Fprintf(&b, "provider \"aws\" {\n  alias  = \"imported\"\n  region = %q%s\n}\n", region, awsDynamicAssumeRole)
-		}
+		//
+		// Emitted unconditionally for every AWS stack (issue #562):
+		// terraform state from a prior compose may still reference
+		// `aws.imported` even when the current compose's Imported list is
+		// empty (drift-correction recompose, re-import flow, etc.).
+		// Omitting the alias block then crashes `terraform plan` with
+		// "Provider configuration not present".
+		b.WriteString("\n")
+		fmt.Fprintf(&b, "provider \"aws\" {\n  alias  = \"imported\"\n  region = %q%s\n}\n", region, awsDynamicAssumeRole)
 
 		return []byte(b.String())
 	}

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -291,7 +291,14 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 			"nil and empty `selected` must produce identical providers.tf")
 	})
 
-	t.Run("gcp imported routes through google.imported alias", func(t *testing.T) {
+	t.Run("gcp imported alias pins the project id literal", func(t *testing.T) {
+		// As of issue #562, both google.imported and google-beta.imported
+		// are emitted unconditionally for every GCP stack — so the
+		// ImportedClouds input no longer gates emission. What this test
+		// still pins is the literal interpolation of GCPProjectID into
+		// both alias blocks' `project = ...` argument (twice, once per
+		// alias). Without that, the imported resources route to the
+		// wrong project at apply time.
 		got := string(generateProvidersTF(providersTFInput{
 			Cloud:          "gcp",
 			Region:         "us-central1",
@@ -300,21 +307,22 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 			Discovered:     map[string]*tfconfig.ProviderRequirement{},
 			ImportedClouds: map[string]bool{"gcp": true},
 		}))
-		require.Contains(t, got, `alias   = "imported"`,
-			"google.imported alias must be declared when ImportedClouds[gcp] is set")
-		require.Contains(t, got, `project = "demo-project-12345"`,
-			"google.imported alias must pin the real project id")
-		require.NotContains(t, got, "google-beta",
-			"google-beta provider must NOT appear when only `gcp` (not `gcp-beta`) is imported")
+		require.Equal(t, 2, strings.Count(got, `alias   = "imported"`),
+			"both google.imported and google-beta.imported aliases must be declared")
+		require.Equal(t, 2, strings.Count(got, `project = "demo-project-12345"`),
+			"both google.imported and google-beta.imported must pin the real project id")
 	})
 
 	t.Run("gcp-beta imported emits google-beta.imported alias", func(t *testing.T) {
-		// The EmitImportedTF caller flips importedClouds["gcp-beta"]
-		// to true whenever any rendered resource carries
-		// `provider = google-beta.imported`. Verify the round-trip
-		// from that signal: providers.tf must declare both the
-		// google-beta provider in required_providers AND the
-		// google-beta.imported alias block.
+		// Pins the round-trip: when ImportedClouds carries both `gcp`
+		// and `gcp-beta` (the historical signal from EmitImportedTF
+		// when a resource uses `provider = google-beta.imported`),
+		// providers.tf declares hashicorp/google-beta in
+		// required_providers AND the google-beta.imported alias block.
+		// As of issue #562 those declarations are unconditional for
+		// every GCP stack, so the ImportedClouds input is informational
+		// only — this test stays as a guard against regressing the
+		// emitted HCL shape.
 		got := string(generateProvidersTF(providersTFInput{
 			Cloud:        "gcp",
 			Region:       "us-central1",
@@ -327,7 +335,7 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 			},
 		}))
 		require.Contains(t, got, `hashicorp/google-beta`,
-			"required_providers must declare hashicorp/google-beta when gcp-beta imports present")
+			"required_providers must declare hashicorp/google-beta")
 		require.Contains(t, got, `provider "google-beta" {`,
 			"google-beta provider alias block must be declared")
 		require.Contains(t, got, `alias   = "imported"`,
@@ -339,12 +347,20 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 			"both google.imported and google-beta.imported must pin the project id")
 	})
 
-	t.Run("gcp without imports does not declare beta provider", func(t *testing.T) {
-		// Regression guard: a GCP stack whose imported set is empty
-		// must NOT pull in google-beta required_providers. This
-		// caught a pre-merge bug where the beta required-provider
-		// entry was unconditionally emitted, blocking
-		// `terraform init` for stacks that never used google-beta.
+	t.Run("gcp stack without imports declares both google providers with imported aliases (issue #562)", func(t *testing.T) {
+		// Regression guard for issue #562: a GCP stack whose Imported
+		// list is empty must STILL declare hashicorp/google,
+		// hashicorp/google-beta, and both `.imported` alias blocks —
+		// because terraform state from a prior compose may still
+		// reference those aliases. Omitting them crashes
+		// `terraform plan` with "Provider configuration not present".
+		//
+		// This replaces an earlier guard ("gcp without imports does
+		// not declare beta provider") whose literal assertion was the
+		// opposite. The deeper invariant that earlier test was
+		// guarding — no cross-cloud provider contamination — is now
+		// pinned directly by the two cross-cloud separation tests
+		// below.
 		got := string(generateProvidersTF(providersTFInput{
 			Cloud:        "gcp",
 			Region:       "us-central1",
@@ -352,17 +368,80 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 			Selected:     map[ComponentKey]bool{},
 			Discovered:   map[string]*tfconfig.ProviderRequirement{},
 		}))
-		require.NotContains(t, got, "hashicorp/google-beta",
-			"google-beta must not appear in required_providers when no imports use it")
-		require.NotContains(t, got, `provider "google-beta"`,
-			"google-beta provider block must not be emitted when no imports use it")
-		// Positive anchor: the test is otherwise all negatives — a
-		// regression that dropped every provider block would still
-		// pass. Pin that the base google provider remains declared.
 		require.Contains(t, got, "hashicorp/google",
-			"base google provider must remain declared even without imports")
+			"base google provider must be declared")
+		require.Contains(t, got, "hashicorp/google-beta",
+			"google-beta must be declared unconditionally for GCP stacks (#562)")
 		require.Contains(t, got, `provider "google" {`,
-			"base google provider block must remain emitted even without imports")
+			"base google provider block must be emitted")
+		require.Contains(t, got, `provider "google-beta" {`,
+			"google-beta provider alias block must be emitted unconditionally (#562)")
+		require.Equal(t, 2, strings.Count(got, `alias   = "imported"`),
+			"both google.imported and google-beta.imported alias blocks must be emitted unconditionally (#562)")
+	})
+
+	t.Run("aws stack does not pull in any google providers (cross-cloud separation)", func(t *testing.T) {
+		// Inherits the deeper invariant from the pre-#562 "gcp without
+		// imports does not declare beta provider" guard: a stack's
+		// providers.tf must never drag in a cloud's providers if the
+		// stack isn't targeting that cloud. This is structurally
+		// guaranteed by `switch cloud` in generateProvidersTF; this
+		// test pins it so the structure cannot regress silently.
+		got := string(generateProvidersTF(providersTFInput{
+			Cloud:      "aws",
+			Region:     "us-east-1",
+			Selected:   map[ComponentKey]bool{},
+			Discovered: map[string]*tfconfig.ProviderRequirement{},
+		}))
+		require.NotContains(t, got, "hashicorp/google",
+			"AWS stacks must not pull in hashicorp/google")
+		require.NotContains(t, got, "hashicorp/google-beta",
+			"AWS stacks must not pull in hashicorp/google-beta")
+		require.NotContains(t, got, `provider "google"`,
+			"AWS stacks must not emit any google provider block")
+		require.NotContains(t, got, `provider "google-beta"`,
+			"AWS stacks must not emit any google-beta provider block")
+	})
+
+	t.Run("gcp stack does not pull in any aws provider (cross-cloud separation)", func(t *testing.T) {
+		got := string(generateProvidersTF(providersTFInput{
+			Cloud:        "gcp",
+			Region:       "us-central1",
+			GCPProjectID: "demo-project-12345",
+			Selected:     map[ComponentKey]bool{},
+			Discovered:   map[string]*tfconfig.ProviderRequirement{},
+		}))
+		require.NotContains(t, got, "hashicorp/aws",
+			"GCP stacks must not pull in hashicorp/aws")
+		require.NotContains(t, got, `provider "aws"`,
+			"GCP stacks must not emit any aws provider block")
+	})
+
+	t.Run("aws stack without imports still declares aws.imported alias (issue #562)", func(t *testing.T) {
+		// Regression guard for issue #562 (AWS side): a stack whose
+		// Imported list is empty must STILL declare aws.imported,
+		// because terraform state from a prior compose may still
+		// reference the alias. Omitting it crashes `terraform plan`
+		// with "Provider configuration not present" — the original
+		// failure mode reported on reliable session sess_v2_CnqUJ6NRJnLC.
+		//
+		// Note the AWS alias template uses a two-space gap
+		// (`alias  = "imported"`) while the GCP templates use three
+		// spaces (`alias   = "imported"`) — they're indented to align
+		// with `region` / `region ` respectively. Assertions below
+		// match the AWS spacing.
+		got := string(generateProvidersTF(providersTFInput{
+			Cloud:      "aws",
+			Region:     "us-east-1",
+			Selected:   map[ComponentKey]bool{},
+			Discovered: map[string]*tfconfig.ProviderRequirement{},
+		}))
+		require.Contains(t, got, "hashicorp/aws",
+			"base aws provider must be declared")
+		require.Contains(t, got, `provider "aws" {`,
+			"base aws provider block must be emitted")
+		require.Contains(t, got, `alias  = "imported"`,
+			"aws.imported alias block must be emitted unconditionally (#562)")
 	})
 }
 

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -20,24 +20,46 @@ func writeOutputs(t *testing.T, files Files, dir string) {
 }
 
 // assertProviderBlocksHaveDefaultTags splits providers.tf by `provider "aws" {`
-// and asserts that (1) exactly wantBlocks provider "aws" blocks exist, and
-// (2) each block declares a default_tags block with Project = var.project and
-// managed-by = "insideout". Split-and-check proves placement per block (a
-// regression dropping default_tags from the alias block would otherwise slip
-// past a global strings.Count), and regex matches tolerate whitespace-only
-// formatting changes from terraform fmt. Note this locks the HCL surface of
-// the provider blocks — it does not prove rendered resources inherit the tag
+// and asserts that (1) exactly wantBlocks tag-bearing provider "aws" blocks
+// exist, and (2) each tag-bearing block declares a default_tags block with
+// Project = var.project and managed-by = "insideout".
+//
+// The `aws.imported` alias block (always emitted as of issue #562) is
+// excluded from both the count and the per-block check: by design it omits
+// default_tags so imported resources don't silently inherit the session's
+// Project tag (compose.go aws.imported header, issue #153). Callers express
+// wantBlocks as "tag-bearing AWS provider blocks I expect" and don't need to
+// adjust as the unconditional-imported block comes and goes.
+//
+// Split-and-check proves placement per block (a regression dropping
+// default_tags from the alias block would otherwise slip past a global
+// strings.Count), and regex matches tolerate whitespace-only formatting
+// changes from terraform fmt. Note this locks the HCL surface of the
+// provider blocks — it does not prove rendered resources inherit the tag
 // at terraform apply, which requires a plan-json round-trip.
 func assertProviderBlocksHaveDefaultTags(t *testing.T, prov string, wantBlocks int) {
 	t.Helper()
 	chunks := strings.Split(prov, `provider "aws" {`)
-	require.Len(t, chunks, wantBlocks+1,
-		"expected %d provider \"aws\" blocks, got %d. prov:\n%s",
-		wantBlocks, len(chunks)-1, prov)
+	// chunks[0] is the file prefix before the first split point; skip it.
+	// For each remaining chunk, route blocks that declare the `imported`
+	// alias into a separate bucket so their (intentional) missing
+	// default_tags doesn't trip the per-block assertion.
+	var tagged []string
+	var importedCount int
+	for _, chunk := range chunks[1:] {
+		if strings.Contains(chunk, `alias  = "imported"`) {
+			importedCount++
+			continue
+		}
+		tagged = append(tagged, chunk)
+	}
+	require.Len(t, tagged, wantBlocks,
+		"expected %d tag-bearing provider \"aws\" blocks, got %d (plus %d imported-alias blocks). prov:\n%s",
+		wantBlocks, len(tagged), importedCount, prov)
 	defaultTagsRe := regexp.MustCompile(`default_tags\s*\{`)
 	projectRe := regexp.MustCompile(`Project\s*=\s*var\.project`)
 	managedByRe := regexp.MustCompile(`managed-by\s*=\s*"insideout"`)
-	for i, chunk := range chunks[1:] {
+	for i, chunk := range tagged {
 		require.Regexpf(t, defaultTagsRe, chunk,
 			"provider block #%d missing default_tags. chunk:\n%s", i+1, chunk)
 		require.Regexpf(t, projectRe, chunk,

--- a/pkg/composer/imported_compose_test.go
+++ b/pkg/composer/imported_compose_test.go
@@ -381,8 +381,17 @@ func TestComposeStackWithIssues_Imported_GCP(t *testing.T) {
 
 // TestComposeStackWithIssues_Imported_MissingBlocksApply pins the safety
 // invariant from issue #148 task #9: TierImportedMissing without an
-// operator-chosen Remediation must surface a validation issue, must NOT
-// emit a resource block, and must NOT declare the imported provider alias.
+// operator-chosen Remediation must surface a validation issue and must NOT
+// emit a resource block.
+//
+// Note (issue #562): the aws.imported provider alias is now emitted
+// unconditionally for every AWS stack, so we no longer assert its absence
+// here. The original "no imported alias when blocked" assertion existed to
+// guard a downstream-symptom of the missing-remediation path; the symptom
+// is now intentionally absent because the alias declaration no longer
+// depends on the Imported list. We instead assert the alias IS present —
+// proving the missing-remediation path doesn't accidentally suppress the
+// unconditional emit.
 func TestComposeStackWithIssues_Imported_MissingBlocksApply(t *testing.T) {
 	t.Parallel()
 
@@ -420,7 +429,7 @@ func TestComposeStackWithIssues_Imported_MissingBlocksApply(t *testing.T) {
 		"no imported.tf should be emitted when only blocked records are present")
 
 	providersTF := string(res.Files["/providers.tf"])
-	assertImportedAliasNotDeclared(t, providersTF, "aws")
+	assertImportedAliasDeclared(t, providersTF, "aws")
 }
 
 // TestComposeStackWithIssues_Imported_StrictValidateEscalates pins that
@@ -464,10 +473,18 @@ func TestComposeStackWithIssues_Imported_StrictValidateEscalates(t *testing.T) {
 		"the structured issue code must be present in res.Issues")
 }
 
-// TestComposeStack_NoImportedKeepsExistingBehavior pins backward
-// compatibility: the historical (Files, error) entry point with no Imported
-// list emits no imported.tf and no aws.imported alias, byte-identical to
-// pre-#148 behavior.
+// TestComposeStack_NoImportedKeepsExistingBehavior pins the surviving
+// portion of pre-#148 backward compatibility: the historical
+// (Files, error) entry point with no Imported list still emits no
+// imported.tf.
+//
+// Previously this test also asserted "no aws.imported alias" — that part
+// of the historical behavior is intentionally changed by issue #562, which
+// makes the aws.imported provider alias unconditional for every AWS stack
+// so that terraform state from a prior compose can't crash `terraform
+// plan` with "Provider configuration not present" when the current
+// compose's Imported list happens to be empty. The flipped assertion
+// below pins the new invariant.
 func TestComposeStack_NoImportedKeepsExistingBehavior(t *testing.T) {
 	t.Parallel()
 
@@ -485,7 +502,7 @@ func TestComposeStack_NoImportedKeepsExistingBehavior(t *testing.T) {
 	assert.False(t, hasImportedTF,
 		"composes without Imported must not produce imported.tf")
 	providers := string(files["/providers.tf"])
-	assertImportedAliasNotDeclared(t, providers, "aws")
+	assertImportedAliasDeclared(t, providers, "aws")
 }
 
 // TestImportedResource_EveryTierBranchExercised acts as a CI gate ensuring
@@ -574,12 +591,6 @@ func assertImportedAliasDeclared(t *testing.T, providersTF, cloud string) {
 		"imported provider alias for %q must be declared:\n%s", cloud, providersTF)
 }
 
-// assertImportedAliasNotDeclared asserts no imported alias block exists.
-func assertImportedAliasNotDeclared(t *testing.T, providersTF, cloud string) {
-	t.Helper()
-	assert.NotRegexp(t, importedAliasBlockPattern(cloud), providersTF,
-		"unexpected imported alias for %q in providers.tf:\n%s", cloud, providersTF)
-}
 
 // hasProviderAttr reports whether the imported alias block for cloud contains
 // `<name> = <value>` (whitespace-tolerant).


### PR DESCRIPTION
## Summary

- `terraform plan` was crashing with `Provider configuration not present` when state still referenced `aws.imported` / `google.imported` / `google-beta.imported` but the current compose's `Imported` list was empty (drift-correction recompose, re-import flow that picked different resources, etc.).
- `generateProvidersTF` decided whether to emit the three alias blocks purely from the `importedClouds` map populated by the current compose's `opts.Imported` — no `.tfstate` introspection, no merge across prior composes — so empty `Imported` produced no alias block, which the stale state reference then couldn't resolve.
- Emit the alias blocks **unconditionally** for the matching cloud: AWS stacks always declare `aws.imported`; GCP stacks always declare both `google.imported` and `google-beta.imported` (and unconditionally pin `hashicorp/google-beta` in `required_providers`). Cross-cloud separation preserved by the existing `switch cloud` — GCP providers never leak into AWS stacks and vice versa.
- `providersTFInput.ImportedClouds` field becomes unused; left in place with a comment flagging it for a follow-up cleanup PR (avoids public-API churn in this PR).

## Test plan

- [x] `go test ./pkg/composer/...` — 1692 pass (was 1686+6 failed; new test count covers the new invariants and adjusts the helpers/tests that codified the old conditional behavior)
- [x] `go test ./...` — 5019 pass across all 27 packages
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] 4 new subtests in `TestGenerateProvidersTF_DiscoveryUnion`:
    - `gcp stack without imports declares both google providers with imported aliases (issue #562)`
    - `aws stack does not pull in any google providers (cross-cloud separation)`
    - `gcp stack does not pull in any aws provider (cross-cloud separation)`
    - `aws stack without imports still declares aws.imported alias (issue #562)`
- [x] `assertProviderBlocksHaveDefaultTags` helper updated to skip imported-alias blocks transparently (they omit `default_tags` by design per #153)
- [x] `assertImportedAliasNotDeclared` callsites in `TestComposeStack_NoImportedKeepsExistingBehavior` and `TestComposeStackWithIssues_Imported_MissingBlocksApply` flipped to `assertImportedAliasDeclared`; dead helper dropped
- [ ] **Downstream verification** (post-merge): re-run the failing plan on reliable session `sess_v2_CnqUJ6NRJnLC` (Oracle job `pcs-647e1dd9-qmr78`) once a release including this fix is pinned in reliable's `go.mod`. Coordinate with [reliable#1544](https://github.com/luthersystems/reliable/issues/1544) (`newImportDraft` replace-vs-merge) — either alone unsticks the immediate crash; both should land for full correctness.

## Out of scope (deferred)

- `providersTFInput.ImportedClouds` field cleanup — becomes dead after this PR. Open a follow-up to drop the field and the callsite plumbing once this lands.

Closes #562