### PR TITLE
feat(policy): curate DriftSemantic on IAM binding/member fields (#491)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -23,7 +23,7 @@ and is checked in lockstep with the runtime registries. See the
 ## Summary
 
 - **AWS:** 127 types · 86% Discoverable · 86% Enrichable · 100% DriftDetectable · 69% MetricsAvailable · 91% AgentEditable
-- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 87% DriftDetectable · 89% MetricsAvailable · 89% AgentEditable
+- **GCP:** 54 types · 100% Discoverable · 100% Enrichable · 100% DriftDetectable · 89% MetricsAvailable · 89% AgentEditable
 
 ## AWS
 
@@ -165,10 +165,10 @@ and is checked in lockstep with the runtime registries. See the
 | `google_api_gateway_api_config` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_api_gateway_gateway` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_cloud_run_v2_service` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_cloud_run_v2_service_iam_member` | ✓ | ✓ | – | – | – |
+| `google_cloud_run_v2_service_iam_member` | ✓ | ✓ | ✓ | – | – |
 | `google_cloudbuild_trigger` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_cloudfunctions2_function` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_cloudfunctions2_function_iam_member` | ✓ | ✓ | – | – | – |
+| `google_cloudfunctions2_function_iam_member` | ✓ | ✓ | ✓ | – | – |
 | `google_compute_address` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_backend_service` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_compute_firewall` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -191,27 +191,27 @@ and is checked in lockstep with the runtime registries. See the
 | `google_identity_platform_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_kms_crypto_key_iam_binding` | ✓ | ✓ | – | – | ✓ |
+| `google_kms_crypto_key_iam_binding` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_key_ring` | ✓ | ✓ | ✓ | ✓ | – |
 | `google_logging_project_sink` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_monitoring_alert_policy` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_monitoring_dashboard` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_monitoring_notification_channel` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_project_iam_member` | ✓ | ✓ | – | ✓ | – |
+| `google_project_iam_member` | ✓ | ✓ | ✓ | ✓ | – |
 | `google_project_service` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_pubsub_subscription` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_pubsub_topic` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_redis_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_secret_manager_secret` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_secret_manager_secret_iam_binding` | ✓ | ✓ | – | – | ✓ |
-| `google_secret_manager_secret_iam_member` | ✓ | ✓ | – | ✓ | – |
+| `google_secret_manager_secret_iam_binding` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_secret_manager_secret_iam_member` | ✓ | ✓ | ✓ | ✓ | – |
 | `google_secret_manager_secret_version` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_service_account` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_service_networking_connection` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_sql_database_instance` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_sql_user` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_storage_bucket` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_storage_bucket_iam_member` | ✓ | ✓ | – | ✓ | – |
+| `google_storage_bucket_iam_member` | ✓ | ✓ | ✓ | ✓ | – |
 | `google_storage_bucket_object` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_vertex_ai_dataset` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_vpc_access_connector` | ✓ | ✓ | ✓ | ✓ | ✓ |

--- a/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
+++ b/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
@@ -8781,6 +8781,28 @@
       "semantic": "Exact"
     }
   ],
+  "google_cloud_run_v2_service_iam_member": [
+    {
+      "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "member",
+      "semantic": "Exact"
+    },
+    {
+      "path": "name",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "role",
+      "semantic": "Exact"
+    }
+  ],
   "google_cloudbuild_trigger": [
     {
       "path": "description",
@@ -8854,6 +8876,28 @@
     },
     {
       "path": "project",
+      "semantic": "Exact"
+    }
+  ],
+  "google_cloudfunctions2_function_iam_member": [
+    {
+      "path": "cloud_function",
+      "semantic": "Exact"
+    },
+    {
+      "path": "location",
+      "semantic": "Exact"
+    },
+    {
+      "path": "member",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "role",
       "semantic": "Exact"
     }
   ],
@@ -10097,6 +10141,20 @@
       "semantic": "Exact"
     }
   ],
+  "google_kms_crypto_key_iam_binding": [
+    {
+      "path": "crypto_key_id",
+      "semantic": "Exact"
+    },
+    {
+      "path": "members",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "role",
+      "semantic": "Exact"
+    }
+  ],
   "google_kms_key_ring": [
     {
       "path": "id",
@@ -10228,6 +10286,20 @@
     },
     {
       "path": "type",
+      "semantic": "Exact"
+    }
+  ],
+  "google_project_iam_member": [
+    {
+      "path": "member",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "role",
       "semantic": "Exact"
     }
   ],
@@ -10590,6 +10662,42 @@
     },
     {
       "path": "version_destroy_ttl",
+      "semantic": "Exact"
+    }
+  ],
+  "google_secret_manager_secret_iam_binding": [
+    {
+      "path": "members",
+      "semantic": "WholeList"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "role",
+      "semantic": "Exact"
+    },
+    {
+      "path": "secret_id",
+      "semantic": "Exact"
+    }
+  ],
+  "google_secret_manager_secret_iam_member": [
+    {
+      "path": "member",
+      "semantic": "Exact"
+    },
+    {
+      "path": "project",
+      "semantic": "Exact"
+    },
+    {
+      "path": "role",
+      "semantic": "Exact"
+    },
+    {
+      "path": "secret_id",
       "semantic": "Exact"
     }
   ],
@@ -10990,6 +11098,20 @@
     },
     {
       "path": "website.not_found_page",
+      "semantic": "Exact"
+    }
+  ],
+  "google_storage_bucket_iam_member": [
+    {
+      "path": "bucket",
+      "semantic": "Exact"
+    },
+    {
+      "path": "member",
+      "semantic": "Exact"
+    },
+    {
+      "path": "role",
       "semantic": "Exact"
     }
   ],

--- a/pkg/composer/imported/policy/coverage_test.go
+++ b/pkg/composer/imported/policy/coverage_test.go
@@ -500,27 +500,25 @@ func isCovered(tfType string) bool {
 // system-owned, leaving nothing for the comparator to meaningfully
 // drift-check.
 //
-// The entries fall into two categories:
+// As of #491 the IAM-binding / membership types
+// (*_iam_binding, *_iam_member, project_iam_member) are NO LONGER
+// exempt — their role + member + condition fields are Exact (and the
+// `members` list on *_iam_binding is WholeList) so that an out-of-band
+// IAM edit surfaces as a real security-pillar drift event rather than
+// being swallowed by the audit-log-only contract that predated the
+// drift bundle.
 //
-//  1. IAM-binding / membership types (*_iam_binding, *_iam_member,
-//     project_iam_member). Every field is part of the
-//     (parent × role × member) identity tuple — the only mutable
-//     surface is `members`/`member`, which is RequiresApproval-gated
-//     at edit time; drift-detection on it would be redundant with the
-//     audit-log trail and would flood the UI with operator-driven
-//     deltas. Drift comparison stays opt-out here.
-//
-//  2. GCP networking / proxy / certificate primitives
-//     (compute_global_address, compute_global_forwarding_rule,
-//     compute_target_http_proxy, compute_target_https_proxy,
-//     compute_managed_ssl_certificate, compute_resource_policy,
-//     identity_platform_config, firestore_database, sql_user,
-//     api_gateway_*, cloudbuild_trigger). These have Identity-only
-//     fields plus ChangeAlwaysReplace tuning fields where the
-//     provider treats every value change as destroy/recreate — drift
-//     on these is captured at the resource-existence level (the
-//     resource itself drifts as "present vs absent"), and per-field
-//     drift would re-litigate the same delta in a noisier shape.
+// The remaining entries are GCP networking / proxy / certificate
+// primitives (compute_global_address, compute_global_forwarding_rule,
+// compute_target_http_proxy, compute_target_https_proxy,
+// compute_managed_ssl_certificate, compute_resource_policy,
+// identity_platform_config, firestore_database, sql_user,
+// api_gateway_*, cloudbuild_trigger). These have Identity-only
+// fields plus ChangeAlwaysReplace tuning fields where the provider
+// treats every value change as destroy/recreate — drift on these is
+// captured at the resource-existence level (the resource itself
+// drifts as "present vs absent"), and per-field drift would
+// re-litigate the same delta in a noisier shape.
 //
 // To remove an entry: tag at least one field with a DriftSemantic
 // value (Exact / WholeList / LabelFilter) in the relevant *.policy.go
@@ -531,15 +529,6 @@ func isCovered(tfType string) bool {
 // key still appears in policy.RegisteredTypes() — removing a policy
 // elsewhere must also remove its exempt entry.
 var driftMinimalExempt = map[string]bool{
-	// --- IAM membership types (identity tuple + RequiresApproval members) ---
-	"google_cloud_run_v2_service_iam_member":     true,
-	"google_cloudfunctions2_function_iam_member": true,
-	"google_kms_crypto_key_iam_binding":          true,
-	"google_project_iam_member":                  true,
-	"google_secret_manager_secret_iam_binding":   true,
-	"google_secret_manager_secret_iam_member":    true,
-	"google_storage_bucket_iam_member":           true,
-
 	// --- GCP API Gateway (every field ChangeAlwaysReplace or Identity) ---
 	"google_api_gateway_api":        true,
 	"google_api_gateway_api_config": true,

--- a/pkg/composer/imported/policy/google_cloud_run_v2_service_iam_member.policy.go
+++ b/pkg/composer/imported/policy/google_cloud_run_v2_service_iam_member.policy.go
@@ -4,14 +4,41 @@ package policy
 // the google_cloud_run_v2_service_iam_member resource. The (name ×
 // location × role × member) tuple is identity; all fields are
 // non-editable since the row is replaced rather than mutated.
+//
+// Drift bundle (#491): role + member are Exact — an out-of-band IAM
+// edit that flips either is a real security event. project / location
+// / name are also Exact for completeness; identical identity on both
+// sides simply does not surface a mismatch. id and etag are TF /
+// provider scaffolding and stay DriftSemantic=None to avoid noise on
+// every refresh.
 var googleCloudRunV2ServiceIAMMemberPolicy = Map{
-	"id":       {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"etag":     {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"name":     {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"location": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"project":  {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":     {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"member":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"etag": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"name": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"location": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"project": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"role": {
+		Role: RoleIdentity, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"member": {
+		Role: RoleIdentity, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
 }
 
 func init() {

--- a/pkg/composer/imported/policy/google_cloudfunctions2_function_iam_member.policy.go
+++ b/pkg/composer/imported/policy/google_cloudfunctions2_function_iam_member.policy.go
@@ -5,14 +5,39 @@ package policy
 // Identical shape to google_cloud_run_v2_service_iam_member — Cloud
 // Functions Gen-2 and Cloud Run v2 share the IAM-member resource
 // schema modulo the `cloud_function` name field.
+//
+// Drift bundle (#491): role + member are Exact — an out-of-band IAM
+// edit that flips either is a real security event. cloud_function /
+// project / location are also Exact for completeness. id / etag stay
+// DriftSemantic=None.
 var googleCloudfunctions2FunctionIAMMemberPolicy = Map{
-	"id":             {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"etag":           {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"cloud_function": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"location":       {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"project":        {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":           {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"member":         {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"etag": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"cloud_function": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"location": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"project": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"role": {
+		Role: RoleIdentity, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"member": {
+		Role: RoleIdentity, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
 }
 
 func init() {

--- a/pkg/composer/imported/policy/google_kms_crypto_key_iam_binding.policy.go
+++ b/pkg/composer/imported/policy/google_kms_crypto_key_iam_binding.policy.go
@@ -5,12 +5,32 @@ package policy
 // RoleIdentity multi-valued field; cumulatively the (crypto_key_id ×
 // role) tuple is replacement-causing, but the members list itself is
 // edited InPlace by the IAM policy (the provider PATCHes the binding).
+//
+// Drift bundle (#491): role is Exact; members is WholeList (order-
+// insensitive set semantics, but a missing-or-extra principal is a
+// real security event that must surface as one mismatch rather than
+// per-element noise — mirrors the aws_iam_role.managed_policy_arns
+// pattern). crypto_key_id is Exact for completeness; id / etag stay
+// DriftSemantic=None.
 var googleKMSCryptoKeyIAMBindingPolicy = Map{
-	"id":            {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"etag":          {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"crypto_key_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":          {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"members":       {Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval, ChangeRisk: ChangeInPlace},
+	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"etag": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"crypto_key_id": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"role": {
+		Role: RoleIdentity, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"members": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
+		Edit:          EditRequiresApproval,
+		ChangeRisk:    ChangeInPlace,
+		DriftSemantic: DriftSemanticWholeList,
+	},
 }
 
 func init() {

--- a/pkg/composer/imported/policy/google_project_iam_member.policy.go
+++ b/pkg/composer/imported/policy/google_project_iam_member.policy.go
@@ -8,13 +8,29 @@ package policy
 // deliberately omitted: the discoverer flattens conditional bindings
 // into separate rows, so a condition block surfaces as additional
 // rows rather than as an editable nested struct here.
+//
+// Drift bundle (#491): role + member are Exact — an out-of-band IAM
+// edit that flips either is a project-scope security event. project
+// is also Exact for completeness. id / etag stay DriftSemantic=None.
 var googleProjectIAMMemberPolicy = Map{
 	// Identity.
-	"id":      {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"etag":    {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"project": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":    {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"member":  {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"etag": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"project": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"role": {
+		Role: RoleIdentity, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"member": {
+		Role: RoleIdentity, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
 }
 
 func init() {

--- a/pkg/composer/imported/policy/google_secret_manager_secret_iam_binding.policy.go
+++ b/pkg/composer/imported/policy/google_secret_manager_secret_iam_binding.policy.go
@@ -4,13 +4,36 @@ package policy
 // for the google_secret_manager_secret_iam_binding resource. The
 // `members` list is edited InPlace by the IAM policy PATCH; the
 // (secret_id × role) tuple is identity.
+//
+// Drift bundle (#491): role is Exact; members is WholeList (mirrors
+// the google_kms_crypto_key_iam_binding pattern — a missing-or-extra
+// principal is a real security event surfaced as one mismatch).
+// project + secret_id are Exact for completeness; id / etag stay
+// DriftSemantic=None.
 var googleSecretManagerSecretIAMBindingPolicy = Map{
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"etag":      {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"project":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"secret_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"members":   {Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditRequiresApproval, ChangeRisk: ChangeInPlace},
+	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"etag": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"project": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"secret_id": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"role": {
+		Role: RoleIdentity, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"members": {
+		Role: RoleTuning, Pillar: PillarSecurity, Visibility: VisibilityUIVisible,
+		Edit:          EditRequiresApproval,
+		ChangeRisk:    ChangeInPlace,
+		DriftSemantic: DriftSemanticWholeList,
+	},
 }
 
 func init() {

--- a/pkg/composer/imported/policy/google_secret_manager_secret_iam_member.policy.go
+++ b/pkg/composer/imported/policy/google_secret_manager_secret_iam_member.policy.go
@@ -5,13 +5,34 @@ package policy
 // `secret_id` field is treated as identity even though it appears as
 // a top-level attribute on this child resource — identityAttrLeaves
 // names it explicitly.
+//
+// Drift bundle (#491): role + member are Exact — an out-of-band IAM
+// edit that flips either is a real security event. project +
+// secret_id are Exact for completeness. id / etag stay
+// DriftSemantic=None.
 var googleSecretManagerSecretIAMMemberPolicy = Map{
-	"id":        {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"etag":      {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"project":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"secret_id": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":      {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"member":    {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"etag": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"project": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"secret_id": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"role": {
+		Role: RoleIdentity, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"member": {
+		Role: RoleIdentity, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
 }
 
 func init() {

--- a/pkg/composer/imported/policy/google_storage_bucket_iam_member.policy.go
+++ b/pkg/composer/imported/policy/google_storage_bucket_iam_member.policy.go
@@ -4,12 +4,29 @@ package policy
 // google_storage_bucket_iam_member resource. Mirrors the
 // google_project_iam_member policy shape — IAM-binding resources have
 // a small, fully-identity surface.
+//
+// Drift bundle (#491): role + member are Exact — an out-of-band IAM
+// edit that flips either is a real security event (especially for a
+// publicly-readable GCS bucket). bucket is Exact for completeness;
+// id / etag stay DriftSemantic=None.
 var googleStorageBucketIAMMemberPolicy = Map{
-	"id":     {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"etag":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
-	"bucket": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"role":   {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
-	"member": {Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever, ChangeRisk: ChangeAlwaysReplace},
+	"id":   {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"etag": {Role: RoleIdentity, Visibility: VisibilityRileyVisible, Edit: EditNever},
+	"bucket": {
+		Role: RoleIdentity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"role": {
+		Role: RoleIdentity, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
+	"member": {
+		Role: RoleIdentity, Pillar: PillarSecurity, Visibility: VisibilityUIVisible, Edit: EditNever,
+		ChangeRisk:    ChangeAlwaysReplace,
+		DriftSemantic: DriftSemanticExact,
+	},
 }
 
 func init() {

--- a/pkg/composer/imported/policy/testdata/known_paths.golden
+++ b/pkg/composer/imported/policy/testdata/known_paths.golden
@@ -2378,10 +2378,10 @@ google_cloud_run_v2_service	traffic.type	Tuning	Reliability	UIVisible	ChatSafe
 google_cloud_run_v2_service_iam_member	etag	Identity		RileyVisible	Never		
 google_cloud_run_v2_service_iam_member	id	Identity		RileyVisible	Never		
 google_cloud_run_v2_service_iam_member	location	Identity		UIVisible	Never		AlwaysReplace
-google_cloud_run_v2_service_iam_member	member	Identity		UIVisible	Never		AlwaysReplace
+google_cloud_run_v2_service_iam_member	member	Identity	Security	UIVisible	Never		AlwaysReplace
 google_cloud_run_v2_service_iam_member	name	Identity		UIVisible	Never		AlwaysReplace
 google_cloud_run_v2_service_iam_member	project	Identity		UIVisible	Never		AlwaysReplace
-google_cloud_run_v2_service_iam_member	role	Identity		UIVisible	Never		AlwaysReplace
+google_cloud_run_v2_service_iam_member	role	Identity	Security	UIVisible	Never		AlwaysReplace
 google_cloudbuild_trigger	approval_config.approval_required	Tuning	Reliability	UIVisible	RequiresApproval		
 google_cloudbuild_trigger	description	Tuning		RileyVisible	ChatSafe		
 google_cloudbuild_trigger	disabled	Tuning	Reliability	UIVisible	ChatSafe		
@@ -2445,9 +2445,9 @@ google_cloudfunctions2_function_iam_member	cloud_function	Identity		UIVisible	Ne
 google_cloudfunctions2_function_iam_member	etag	Identity		RileyVisible	Never		
 google_cloudfunctions2_function_iam_member	id	Identity		RileyVisible	Never		
 google_cloudfunctions2_function_iam_member	location	Identity		UIVisible	Never		AlwaysReplace
-google_cloudfunctions2_function_iam_member	member	Identity		UIVisible	Never		AlwaysReplace
+google_cloudfunctions2_function_iam_member	member	Identity	Security	UIVisible	Never		AlwaysReplace
 google_cloudfunctions2_function_iam_member	project	Identity		UIVisible	Never		AlwaysReplace
-google_cloudfunctions2_function_iam_member	role	Identity		UIVisible	Never		AlwaysReplace
+google_cloudfunctions2_function_iam_member	role	Identity	Security	UIVisible	Never		AlwaysReplace
 google_compute_address	address	Tuning		UIVisible	Never		AlwaysReplace
 google_compute_address	address_type	Tuning		RileyVisible	Never		AlwaysReplace
 google_compute_address	description	Tuning		RileyVisible	ChatSafe		
@@ -2844,7 +2844,7 @@ google_kms_crypto_key_iam_binding	crypto_key_id	Identity		UIVisible	Never		Alway
 google_kms_crypto_key_iam_binding	etag	Identity		RileyVisible	Never		
 google_kms_crypto_key_iam_binding	id	Identity		RileyVisible	Never		
 google_kms_crypto_key_iam_binding	members	Tuning	Security	UIVisible	RequiresApproval		InPlace
-google_kms_crypto_key_iam_binding	role	Identity		UIVisible	Never		AlwaysReplace
+google_kms_crypto_key_iam_binding	role	Identity	Security	UIVisible	Never		AlwaysReplace
 google_kms_key_ring	id	Identity		RileyVisible	Never		
 google_kms_key_ring	location	Identity		UIVisible	Never		AlwaysReplace
 google_kms_key_ring	name	Identity		UIVisible	Never		
@@ -2898,9 +2898,9 @@ google_monitoring_notification_channel	type	Identity		UIVisible	Never		AlwaysRep
 google_monitoring_notification_channel	user_labels	Tuning		Hidden	SystemOnly	Redacted	
 google_project_iam_member	etag	Identity		RileyVisible	Never		
 google_project_iam_member	id	Identity		RileyVisible	Never		
-google_project_iam_member	member	Identity		UIVisible	Never		AlwaysReplace
+google_project_iam_member	member	Identity	Security	UIVisible	Never		AlwaysReplace
 google_project_iam_member	project	Identity		UIVisible	Never		AlwaysReplace
-google_project_iam_member	role	Identity		UIVisible	Never		AlwaysReplace
+google_project_iam_member	role	Identity	Security	UIVisible	Never		AlwaysReplace
 google_project_service	disable_dependent_services	Tuning		RileyVisible	ChatSafe		
 google_project_service	disable_on_destroy	Tuning		RileyVisible	ChatSafe		
 google_project_service	id	Identity		RileyVisible	Never		
@@ -3019,13 +3019,13 @@ google_secret_manager_secret_iam_binding	etag	Identity		RileyVisible	Never
 google_secret_manager_secret_iam_binding	id	Identity		RileyVisible	Never		
 google_secret_manager_secret_iam_binding	members	Tuning	Security	UIVisible	RequiresApproval		InPlace
 google_secret_manager_secret_iam_binding	project	Identity		UIVisible	Never		AlwaysReplace
-google_secret_manager_secret_iam_binding	role	Identity		UIVisible	Never		AlwaysReplace
+google_secret_manager_secret_iam_binding	role	Identity	Security	UIVisible	Never		AlwaysReplace
 google_secret_manager_secret_iam_binding	secret_id	Identity		UIVisible	Never		AlwaysReplace
 google_secret_manager_secret_iam_member	etag	Identity		RileyVisible	Never		
 google_secret_manager_secret_iam_member	id	Identity		RileyVisible	Never		
-google_secret_manager_secret_iam_member	member	Identity		UIVisible	Never		AlwaysReplace
+google_secret_manager_secret_iam_member	member	Identity	Security	UIVisible	Never		AlwaysReplace
 google_secret_manager_secret_iam_member	project	Identity		UIVisible	Never		AlwaysReplace
-google_secret_manager_secret_iam_member	role	Identity		UIVisible	Never		AlwaysReplace
+google_secret_manager_secret_iam_member	role	Identity	Security	UIVisible	Never		AlwaysReplace
 google_secret_manager_secret_iam_member	secret_id	Identity		UIVisible	Never		AlwaysReplace
 google_secret_manager_secret_version	create_time	Identity		RileyVisible	Never		
 google_secret_manager_secret_version	deletion_policy	Tuning	Reliability	RileyVisible	ChatSafe		
@@ -3143,8 +3143,8 @@ google_storage_bucket	website.not_found_page	Tuning		RileyVisible	ChatSafe
 google_storage_bucket_iam_member	bucket	Identity		UIVisible	Never		AlwaysReplace
 google_storage_bucket_iam_member	etag	Identity		RileyVisible	Never		
 google_storage_bucket_iam_member	id	Identity		RileyVisible	Never		
-google_storage_bucket_iam_member	member	Identity		UIVisible	Never		AlwaysReplace
-google_storage_bucket_iam_member	role	Identity		UIVisible	Never		AlwaysReplace
+google_storage_bucket_iam_member	member	Identity	Security	UIVisible	Never		AlwaysReplace
+google_storage_bucket_iam_member	role	Identity	Security	UIVisible	Never		AlwaysReplace
 google_storage_bucket_object	bucket	Wiring	Reliability	UIVisible	RelationshipOnly		AlwaysReplace
 google_storage_bucket_object	cache_control	Tuning	Performance	RileyVisible	ChatSafe		
 google_storage_bucket_object	content	Tuning		Hidden	SystemOnly	Redacted	

--- a/pkg/drift/imported/compare_curated_test.go
+++ b/pkg/drift/imported/compare_curated_test.go
@@ -793,6 +793,299 @@ func TestCompare_Curated_GoogleComputeHealthCheck_Exact(t *testing.T) {
 	assert.NotContains(t, idx, "unhealthy_threshold")
 }
 
+// --- Bundle D4 / IAM-binding curation (#491) -----------------------------
+//
+// Each IAM binding/member type is the (parent × role × member) tuple plus
+// a `members` list (binding-flavoured) or a singleton `member` scalar
+// (member-flavoured). Pre-#491 every field carried DriftSemantic=None,
+// so an out-of-band IAM edit slipped past the curated comparator
+// entirely. Bundle D4 flips the role / member / members fields onto
+// the comparator so a flipped role binding or a deleted/added principal
+// surfaces as a security-pillar drift signal.
+//
+// The subtests below pin: (1) role / member flips on each *_iam_member
+// type emit one Exact mismatch each, (2) the WholeList shape on
+// *_iam_binding `members` collapses a per-element change into a single
+// list mismatch (no per-element fan-out), and (3) identical tuples
+// emit zero mismatches so unchanged bindings stay quiet.
+
+// TestCompare_Curated_GoogleProjectIAMMember_Exact exercises the
+// canonical project-scope IAM member curation: a role flip emits one
+// Exact mismatch on `role`, and an identical binding emits nothing.
+func TestCompare_Curated_GoogleProjectIAMMember_Exact(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"id": "p/roles/storage.admin/user:dev@example.com",
+		"etag": "BwAbCdEf=",
+		"project": "p",
+		"role": "roles/storage.admin",
+		"member": "user:dev@example.com"
+	}`)
+	live := json.RawMessage(`{
+		"id": "p/roles/storage.objectViewer/user:dev@example.com",
+		"etag": "BwAbCdEf=",
+		"project": "p",
+		"role": "roles/storage.objectViewer",
+		"member": "user:dev@example.com"
+	}`)
+	got := Compare("google_project_iam_member", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "role",
+		"expected role mismatch; got fields: %v", keysOf(idx))
+	assert.Equal(t, "roles/storage.admin", idx["role"].Snapshot)
+	assert.Equal(t, "roles/storage.objectViewer", idx["role"].Cloud)
+
+	// Identity / member identical → no mismatch.
+	assert.NotContains(t, idx, "project")
+	assert.NotContains(t, idx, "member")
+	// id/etag are DriftSemantic=None → never emitted.
+	assert.NotContains(t, idx, "id")
+	assert.NotContains(t, idx, "etag")
+
+	// Identical binding on both sides → no mismatch at all.
+	got2 := Compare("google_project_iam_member", snap, snap)
+	assert.Empty(t, got2, "identical IAM binding must emit no drift")
+}
+
+// TestCompare_Curated_GoogleStorageBucketIAMMember_Exact exercises a
+// member flip (e.g. an out-of-band edit pointing the binding at a
+// different principal) — Exact mismatch on `member`, identity unchanged.
+func TestCompare_Curated_GoogleStorageBucketIAMMember_Exact(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"id": "b/my-bucket/roles/storage.objectViewer/user:reader-A@example.com",
+		"etag": "BwAbCdEf=",
+		"bucket": "my-bucket",
+		"role": "roles/storage.objectViewer",
+		"member": "user:reader-A@example.com"
+	}`)
+	live := json.RawMessage(`{
+		"id": "b/my-bucket/roles/storage.objectViewer/user:reader-B@example.com",
+		"etag": "BwAbCdEf=",
+		"bucket": "my-bucket",
+		"role": "roles/storage.objectViewer",
+		"member": "user:reader-B@example.com"
+	}`)
+	got := Compare("google_storage_bucket_iam_member", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "member",
+		"expected member mismatch; got fields: %v", keysOf(idx))
+	assert.Equal(t, "user:reader-A@example.com", idx["member"].Snapshot)
+	assert.Equal(t, "user:reader-B@example.com", idx["member"].Cloud)
+
+	// Identity / role unchanged → no mismatch.
+	assert.NotContains(t, idx, "bucket")
+	assert.NotContains(t, idx, "role")
+	assert.NotContains(t, idx, "id")
+	assert.NotContains(t, idx, "etag")
+}
+
+// TestCompare_Curated_GoogleCloudRunV2ServiceIAMMember_Exact exercises
+// a role flip on the Cloud Run v2 IAM-member type.
+func TestCompare_Curated_GoogleCloudRunV2ServiceIAMMember_Exact(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"id": "projects/p/locations/us-east1/services/api/roles/run.invoker/user:caller@example.com",
+		"etag": "BwAbCdEf=",
+		"name": "api",
+		"location": "us-east1",
+		"project": "p",
+		"role": "roles/run.invoker",
+		"member": "user:caller@example.com"
+	}`)
+	live := json.RawMessage(`{
+		"id": "projects/p/locations/us-east1/services/api/roles/run.developer/user:caller@example.com",
+		"etag": "BwAbCdEf=",
+		"name": "api",
+		"location": "us-east1",
+		"project": "p",
+		"role": "roles/run.developer",
+		"member": "user:caller@example.com"
+	}`)
+	got := Compare("google_cloud_run_v2_service_iam_member", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "role")
+	assert.Equal(t, "roles/run.invoker", idx["role"].Snapshot)
+	assert.Equal(t, "roles/run.developer", idx["role"].Cloud)
+
+	// Identity tuple unchanged → no mismatch.
+	assert.NotContains(t, idx, "name")
+	assert.NotContains(t, idx, "location")
+	assert.NotContains(t, idx, "project")
+	assert.NotContains(t, idx, "member")
+}
+
+// TestCompare_Curated_GoogleCloudfunctions2FunctionIAMMember_Exact
+// exercises a member flip on the Cloud Functions Gen-2 IAM-member type.
+func TestCompare_Curated_GoogleCloudfunctions2FunctionIAMMember_Exact(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"id": "projects/p/locations/us-east1/functions/fn/roles/cloudfunctions.invoker/serviceAccount:caller-A@p.iam.gserviceaccount.com",
+		"etag": "BwAbCdEf=",
+		"cloud_function": "projects/p/locations/us-east1/functions/fn",
+		"location": "us-east1",
+		"project": "p",
+		"role": "roles/cloudfunctions.invoker",
+		"member": "serviceAccount:caller-A@p.iam.gserviceaccount.com"
+	}`)
+	live := json.RawMessage(`{
+		"id": "projects/p/locations/us-east1/functions/fn/roles/cloudfunctions.invoker/serviceAccount:caller-B@p.iam.gserviceaccount.com",
+		"etag": "BwAbCdEf=",
+		"cloud_function": "projects/p/locations/us-east1/functions/fn",
+		"location": "us-east1",
+		"project": "p",
+		"role": "roles/cloudfunctions.invoker",
+		"member": "serviceAccount:caller-B@p.iam.gserviceaccount.com"
+	}`)
+	got := Compare("google_cloudfunctions2_function_iam_member", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "member")
+	assert.Equal(t, "serviceAccount:caller-A@p.iam.gserviceaccount.com", idx["member"].Snapshot)
+	assert.Equal(t, "serviceAccount:caller-B@p.iam.gserviceaccount.com", idx["member"].Cloud)
+
+	// Identity / role unchanged → no mismatch.
+	assert.NotContains(t, idx, "cloud_function")
+	assert.NotContains(t, idx, "location")
+	assert.NotContains(t, idx, "project")
+	assert.NotContains(t, idx, "role")
+}
+
+// TestCompare_Curated_GoogleSecretManagerSecretIAMMember_Exact
+// exercises a role flip on the Secret Manager IAM-member type.
+func TestCompare_Curated_GoogleSecretManagerSecretIAMMember_Exact(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"id": "projects/p/secrets/api-key/roles/secretmanager.secretAccessor/serviceAccount:reader@p.iam.gserviceaccount.com",
+		"etag": "BwAbCdEf=",
+		"project": "p",
+		"secret_id": "api-key",
+		"role": "roles/secretmanager.secretAccessor",
+		"member": "serviceAccount:reader@p.iam.gserviceaccount.com"
+	}`)
+	live := json.RawMessage(`{
+		"id": "projects/p/secrets/api-key/roles/secretmanager.admin/serviceAccount:reader@p.iam.gserviceaccount.com",
+		"etag": "BwAbCdEf=",
+		"project": "p",
+		"secret_id": "api-key",
+		"role": "roles/secretmanager.admin",
+		"member": "serviceAccount:reader@p.iam.gserviceaccount.com"
+	}`)
+	got := Compare("google_secret_manager_secret_iam_member", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "role")
+	assert.Equal(t, "roles/secretmanager.secretAccessor", idx["role"].Snapshot)
+	assert.Equal(t, "roles/secretmanager.admin", idx["role"].Cloud)
+
+	// Identity / member unchanged → no mismatch.
+	assert.NotContains(t, idx, "project")
+	assert.NotContains(t, idx, "secret_id")
+	assert.NotContains(t, idx, "member")
+}
+
+// TestCompare_Curated_GoogleKMSCryptoKeyIAMBinding_WholeList exercises
+// the `members` WholeList collapse on the KMS-key IAM-binding type: a
+// single added principal emits ONE `members` mismatch with both sides
+// as []any, not a per-element fan-out. Also confirms a role flip emits
+// an Exact mismatch alongside.
+func TestCompare_Curated_GoogleKMSCryptoKeyIAMBinding_WholeList(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"id": "projects/p/locations/global/keyRings/kr/cryptoKeys/k/roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		"etag": "BwAbCdEf=",
+		"crypto_key_id": "projects/p/locations/global/keyRings/kr/cryptoKeys/k",
+		"role": "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		"members": [
+			"serviceAccount:writer@p.iam.gserviceaccount.com",
+			"serviceAccount:reader@p.iam.gserviceaccount.com"
+		]
+	}`)
+	live := json.RawMessage(`{
+		"id": "projects/p/locations/global/keyRings/kr/cryptoKeys/k/roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		"etag": "BwAbCdEf=",
+		"crypto_key_id": "projects/p/locations/global/keyRings/kr/cryptoKeys/k",
+		"role": "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		"members": [
+			"serviceAccount:writer@p.iam.gserviceaccount.com",
+			"serviceAccount:reader@p.iam.gserviceaccount.com",
+			"serviceAccount:unauthorized@p.iam.gserviceaccount.com"
+		]
+	}`)
+	got := Compare("google_kms_crypto_key_iam_binding", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "members",
+		"expected single members WholeList mismatch; got: %v", keysOf(idx))
+	assert.IsType(t, []any{}, idx["members"].Snapshot,
+		"WholeList output must be a []any, not a raw scalar")
+	assert.IsType(t, []any{}, idx["members"].Cloud)
+
+	// No per-element fan-out under the members path.
+	assert.NotContains(t, idx, "members.0")
+	assert.NotContains(t, idx, "members.1")
+	assert.NotContains(t, idx, "members.2")
+
+	// Identity / role unchanged → no mismatch.
+	assert.NotContains(t, idx, "crypto_key_id")
+	assert.NotContains(t, idx, "role")
+
+	// Identical binding on both sides → no mismatch at all.
+	got2 := Compare("google_kms_crypto_key_iam_binding", snap, snap)
+	assert.Empty(t, got2, "identical IAM binding must emit no drift")
+}
+
+// TestCompare_Curated_GoogleSecretManagerSecretIAMBinding_WholeList
+// exercises the `members` WholeList collapse alongside a role flip on
+// the Secret Manager IAM-binding type.
+func TestCompare_Curated_GoogleSecretManagerSecretIAMBinding_WholeList(t *testing.T) {
+	t.Parallel()
+	snap := json.RawMessage(`{
+		"id": "projects/p/secrets/api-key/roles/secretmanager.secretAccessor",
+		"etag": "BwAbCdEf=",
+		"project": "p",
+		"secret_id": "api-key",
+		"role": "roles/secretmanager.secretAccessor",
+		"members": [
+			"serviceAccount:reader-A@p.iam.gserviceaccount.com",
+			"serviceAccount:reader-B@p.iam.gserviceaccount.com"
+		]
+	}`)
+	live := json.RawMessage(`{
+		"id": "projects/p/secrets/api-key/roles/secretmanager.admin",
+		"etag": "BwAbCdEf=",
+		"project": "p",
+		"secret_id": "api-key",
+		"role": "roles/secretmanager.admin",
+		"members": [
+			"serviceAccount:reader-A@p.iam.gserviceaccount.com"
+		]
+	}`)
+	got := Compare("google_secret_manager_secret_iam_binding", snap, live)
+	idx := fieldsByPath(t, got)
+
+	require.Contains(t, idx, "role",
+		"expected role Exact mismatch; got: %v", keysOf(idx))
+	assert.Equal(t, "roles/secretmanager.secretAccessor", idx["role"].Snapshot)
+	assert.Equal(t, "roles/secretmanager.admin", idx["role"].Cloud)
+
+	require.Contains(t, idx, "members",
+		"expected members WholeList mismatch; got: %v", keysOf(idx))
+	assert.IsType(t, []any{}, idx["members"].Snapshot)
+	assert.IsType(t, []any{}, idx["members"].Cloud)
+
+	// No per-element fan-out under members.
+	assert.NotContains(t, idx, "members.0")
+	assert.NotContains(t, idx, "members.1")
+
+	// Identity unchanged → no mismatch.
+	assert.NotContains(t, idx, "project")
+	assert.NotContains(t, idx, "secret_id")
+}
+
 // keysOf returns the sorted key set of m for diagnostic logging.
 func keysOf(m map[string]FieldMismatch) []string {
 	out := make([]string, 0, len(m))


### PR DESCRIPTION
## Summary

Closes #491.

Sets `DriftSemantic: DriftSemanticExact` on `member`, `role`, `project`, `location`, `name`, and other identity-tuple leaves across the 7 remaining stub `google_*_iam_{binding,member}` policy files. `role` and `member` additionally pick up `Pillar: PillarSecurity` — an out-of-band IAM edit on these is a real security event the comparator must surface, not refresh noise.

The two `*_iam_binding` types (`google_kms_crypto_key_iam_binding`, `google_secret_manager_secret_iam_binding`) get `DriftSemantic: DriftSemanticWholeList` on `members`. The provider PATCHes the principals list in place; collapsing a missing-or-extra principal into one mismatch (rather than per-element fan-out) mirrors the `aws_iam_role.managed_policy_arns` pattern.

Files curated:
- `google_cloud_run_v2_service_iam_member`
- `google_cloudfunctions2_function_iam_member`
- `google_kms_crypto_key_iam_binding`
- `google_project_iam_member`
- `google_secret_manager_secret_iam_binding`
- `google_secret_manager_secret_iam_member`
- `google_storage_bucket_iam_member`

`id` and `etag` stay `DriftSemanticNone` (TF / provider scaffolding — comparing them generates noise on every refresh).

Removes the 7 entries from `driftMinimalExempt` in `pkg/composer/imported/policy/coverage_test.go` and rewrites the header comment block to reflect the new IAM-included scope. Regenerates `cmd/imported-codegen/testdata/drift_fields/drift-fields.json`, `pkg/composer/imported/policy/testdata/known_paths.golden`, and `SUPPORTED_RESOURCES.md` (GCP DriftDetectable coverage advances 87% → 100%).

Adds inline `TestCompare_Curated_*` subtests for each of the 7 types in `pkg/drift/imported/compare_curated_test.go` covering role flips, member flips, WholeList collapse on `members`, and the no-drift case for identical bindings.

## Deferred

The bucket plan also mentioned "decide AWS tags drift policy" — that work is orthogonal (GCP has a `gcpLabelDriftPolicy()` LabelFilter adoption; AWS `tagPolicy()` still leaves `DriftSemantic=None`). Spun out to #568 so this PR stays scoped to IAM-binding curation.

## Test plan

- [x] `go test ./pkg/composer/imported/policy/... ./pkg/drift/imported/... ./cmd/imported-codegen/...` (839 tests pass locally)
- [x] `go test ./pkg/... ./cmd/...` (5257 tests pass locally, 34 packages)
- [x] `go build ./... && go vet ./...`
- [x] `verify-supported-resources` CI job (regen committed)
- [ ] Reviewer: confirm IAM binding `etag` staying `DriftSemanticNone` is correct (current call: yes — it changes on every server-side write and isn't useful drift signal)