### PR TITLE
feat(awsdiscover): add Cloud Control Normalizer hook (#501)

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -259,7 +259,11 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 		if _, has := byTypeEnricher[ccCfg.TFType]; has {
 			continue
 		}
-		byTypeEnricher[ccCfg.TFType] = newCloudControlEnricher(ccCfg.TFType, ccCfg.CloudFormationType, nil)
+		// #501 — pass through the per-type Normalizer (nil for types
+		// whose CFN shape already matches the camelToSnake projection).
+		byTypeEnricher[ccCfg.TFType] = newCloudControlEnricherWithNormalizer(
+			ccCfg.TFType, ccCfg.CloudFormationType, nil, ccCfg.Normalizer,
+		)
 	}
 	return &AWSDiscoverer{
 		defaultRegion:  cfg.Region,

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
@@ -121,6 +121,19 @@ type cloudControlConfig struct {
 	TagsFromProperties      func(props map[string]any) map[string]string
 	ParentLister            func(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error)
 	SDKLister               func(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error)
+	// Normalizer, when non-nil, transforms the Cloud Control raw JSON
+	// response before the generic CC→TF mapping step. Use for per-type
+	// shape adjustments that CloudFormation does differently from
+	// Terraform (e.g. ARN suffixes, tag list flattening, field renames).
+	// Returning an error fails the fetch with the original error wrapped.
+	//
+	// Consumed by the generic cloudControlEnricher (#501) — the discoverer
+	// itself reads properties via the PascalCase extractors and does NOT
+	// invoke the Normalizer. The Normalizer's purpose is to feed the
+	// Layer-1 unmarshal in the enricher, which the camelToSnake renamer
+	// alone cannot do for cases like list-of-{Key,Value} tags vs the
+	// generated `map[string]*Value[string]` Tags field.
+	Normalizer func(json.RawMessage) (json.RawMessage, error)
 }
 
 // cloudControlDiscoverer is the generic per-type Discoverer that routes

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_enricher.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_enricher.go
@@ -79,6 +79,13 @@ type cloudControlEnricher struct {
 	resourceType string
 	cfnType      string
 	get          cloudControlGetResourceFn
+	// normalizer, when non-nil, runs on the raw Cloud Control properties
+	// JSON before the generic camelToSnake / Layer-1 unmarshal pipeline
+	// (#501). Sourced from cloudControlConfig.Normalizer at registration
+	// time; see cloudcontrol_normalizers.go for composable helpers
+	// (chain, renameField, flattenTagList, trimARNStar). A nil normalizer
+	// is a no-op — the existing generic path runs unchanged.
+	normalizer Normalizer
 }
 
 // newCloudControlEnricher constructs an enricher for a single
@@ -96,6 +103,20 @@ func newCloudControlEnricher(tfType, cfnType string, get cloudControlGetResource
 		resourceType: tfType,
 		cfnType:      cfnType,
 		get:          get,
+	}
+}
+
+// newCloudControlEnricherWithNormalizer is the #501 variant that wires a
+// per-type Normalizer alongside the (tfType, cfnType, get) trio. Used by
+// NewAWSDiscoverer to thread cloudControlConfig.Normalizer through into
+// the enricher; tests use it directly to exercise the normalizer path
+// without dragging in the discoverer registration.
+func newCloudControlEnricherWithNormalizer(tfType, cfnType string, get cloudControlGetResourceFn, n Normalizer) *cloudControlEnricher {
+	return &cloudControlEnricher{
+		resourceType: tfType,
+		cfnType:      cfnType,
+		get:          get,
+		normalizer:   n,
 	}
 }
 
@@ -215,6 +236,23 @@ func (e *cloudControlEnricher) fetchAndMap(ctx context.Context, get cloudControl
 		return nil, fmt.Errorf("cloudcontrol enricher: empty response for %s %q: %w", e.cfnType, identifier, ErrNotFound)
 	}
 
+	// #501 — Per-type Normalizer runs on the raw Cloud Control JSON
+	// before camelToSnake / Layer-1 unmarshal. The helpers in
+	// cloudcontrol_normalizers.go bridge the shape gaps the generic
+	// renamer can't close on its own (flat tag maps vs lists of
+	// {Key,Value}, primary-name aliases like LogGroupName → Name,
+	// trailing-:* ARN trimming). Returning an error fails the fetch
+	// with the original error wrapped so soft-fail dispatchers can
+	// distinguish a normalizer failure from a real API error.
+	rawProps := json.RawMessage(*out.ResourceDescription.Properties)
+	if e.normalizer != nil {
+		normalized, err := e.normalizer(rawProps)
+		if err != nil {
+			return nil, fmt.Errorf("cloudcontrol enricher: normalize %s %q: %w", e.cfnType, identifier, err)
+		}
+		rawProps = normalized
+	}
+
 	// Convert CamelCase property keys to snake_case so the json tags on
 	// the registered Layer-1 struct can match. The unmarshal would
 	// otherwise silently drop every CamelCase property (json tags are
@@ -225,7 +263,7 @@ func (e *cloudControlEnricher) fetchAndMap(ctx context.Context, get cloudControl
 	// struct fields use; without the wrap, a bare CFN scalar fails to
 	// decode (Value[T].UnmarshalJSON rejects non-object input).
 	var props map[string]any
-	if err := json.Unmarshal([]byte(*out.ResourceDescription.Properties), &props); err != nil {
+	if err := json.Unmarshal([]byte(rawProps), &props); err != nil {
 		return nil, fmt.Errorf("cloudcontrol enricher: parse properties for %s %q: %w", e.cfnType, identifier, err)
 	}
 	shaped := shapeCFNForLayer1(props)
@@ -282,6 +320,17 @@ func shapeCFNForLayer1(props map[string]any) map[string]any {
 	return out
 }
 
+// verbatimMarkerKey is the sentinel key produced by Normalizer helpers
+// (#501) that need a sub-tree of the payload to bypass the
+// CFN-CamelCase → snake_case rename while still benefiting from the
+// scalar-leaf {"literal": …} wrap. The flattenTagList helper uses it:
+// CFN tags arrive as list-of-{Key,Value}; the flat map shape the
+// generated `Tags map[string]*Value[string]` field expects has
+// user-data keys (tag NAMES) that must NOT be snake-cased. A map
+// whose only key is verbatimMarkerKey is unwrapped by shapeValueForLayer1
+// and the inner tree is leaf-wrapped without renaming any keys.
+const verbatimMarkerKey = "__verbatim__"
+
 // shapeValueForLayer1 is the recursive helper for shapeCFNForLayer1.
 // Scalar leaves get wrapped in {"literal": …}; maps recurse; lists of
 // maps recurse with key renames on each element; lists of scalars
@@ -292,6 +341,13 @@ func shapeValueForLayer1(v any) any {
 	case nil:
 		return nil
 	case map[string]any:
+		// Verbatim sub-tree (#501) — a Normalizer helper wrapped the
+		// payload to opt out of key renaming. Unwrap and leaf-wrap
+		// without recursing through shapeCFNForLayer1 (which would
+		// camelToSnake the user-data keys).
+		if inner, ok := t[verbatimMarkerKey]; ok && len(t) == 1 {
+			return wrapLeavesVerbatim(inner)
+		}
 		// Nested CFN object — recurse on keys, but DO NOT wrap the
 		// object itself in a literal envelope. The generated nested
 		// structs are bare structs (no Value[T] wrapper), so the
@@ -309,6 +365,34 @@ func shapeValueForLayer1(v any) any {
 	default:
 		// Scalar leaf — wrap in {"literal": …} so it decodes into
 		// generated.Value[T] cleanly.
+		return map[string]any{"literal": t}
+	}
+}
+
+// wrapLeavesVerbatim mirrors shapeValueForLayer1 but preserves map
+// keys exactly as-is — used inside a verbatim sub-tree (#501) where
+// the keys are user data (tag names) and the surrounding snake_case
+// rename would corrupt them. Nested maps recurse with key-preservation
+// too; scalar leaves still get the {"literal": …} envelope so the
+// outer struct's *Value[T] field (or map[string]*Value[T] field)
+// decodes cleanly.
+func wrapLeavesVerbatim(v any) any {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, vv := range t {
+			out[k] = wrapLeavesVerbatim(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = wrapLeavesVerbatim(e)
+		}
+		return out
+	default:
 		return map[string]any{"literal": t}
 	}
 }

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_enricher_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_enricher_test.go
@@ -355,6 +355,205 @@ func TestCloudControlEnricher_Enrich_UnknownTFType(t *testing.T) {
 	assert.Contains(t, err.Error(), "unmarshal into aws_does_not_exist")
 }
 
+// TestCloudControlEnricher_Enrich_Normalized exercises the #501
+// Normalizer hook on the three currently-wired types
+// (aws_cloudwatch_log_group, aws_s3_bucket, aws_sqs_queue). For each
+// type the test feeds a fake CFN-shaped response with the
+// known-divergent fields (primary-name, list-of-{Key,Value} Tags,
+// trailing-:* ARN where applicable) and asserts the post-Normalizer
+// Layer-1 payload lands the values on the bare TF field names
+// (`name` / `bucket`) and the flat `tags` map.
+func TestCloudControlEnricher_Enrich_Normalized(t *testing.T) {
+	t.Parallel()
+
+	t.Run("aws_cloudwatch_log_group", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakeCCGet{
+			props: `{
+				"Arn": "arn:aws:logs:us-east-1:123:log-group:/aws/lambda/demo:*",
+				"LogGroupName": "/aws/lambda/demo",
+				"RetentionInDays": 30,
+				"KmsKeyId": "arn:aws:kms:us-east-1:123:key/abc",
+				"Tags": [
+					{"Key": "Project", "Value": "io-abc"},
+					{"Key": "Env", "Value": "prod"}
+				]
+			}`,
+		}
+		// Mirror the production wiring: pull the Normalizer from
+		// cloudControlTypeConfigs so this test would catch any
+		// registration drift.
+		n := normalizerForCFNType(t, "AWS::Logs::LogGroup")
+		enr := newCloudControlEnricherWithNormalizer("aws_cloudwatch_log_group", "AWS::Logs::LogGroup", fake.call, n)
+		ir := &imported.ImportedResource{
+			Identity: imported.ResourceIdentity{
+				Type:     "aws_cloudwatch_log_group",
+				ImportID: "/aws/lambda/demo",
+			},
+		}
+		require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+
+		decoded, err := generated.UnmarshalAttrs("aws_cloudwatch_log_group", ir.Attrs)
+		require.NoError(t, err)
+		lg, ok := decoded.(*generated.AWSCloudwatchLogGroup)
+		require.True(t, ok, "decoded type is %T", decoded)
+
+		// Primary-name field: CFN LogGroupName → TF name.
+		require.NotNil(t, lg.Name)
+		require.NotNil(t, lg.Name.Literal)
+		assert.Equal(t, "/aws/lambda/demo", *lg.Name.Literal)
+		// ARN trailing-:* stripped.
+		require.NotNil(t, lg.ARN)
+		require.NotNil(t, lg.ARN.Literal)
+		assert.Equal(t, "arn:aws:logs:us-east-1:123:log-group:/aws/lambda/demo", *lg.ARN.Literal)
+		// Tags landed as flat map.
+		require.NotNil(t, lg.Tags)
+		require.Contains(t, lg.Tags, "Project")
+		require.NotNil(t, lg.Tags["Project"].Literal)
+		assert.Equal(t, "io-abc", *lg.Tags["Project"].Literal)
+		require.Contains(t, lg.Tags, "Env")
+		require.NotNil(t, lg.Tags["Env"].Literal)
+		assert.Equal(t, "prod", *lg.Tags["Env"].Literal)
+		// Untouched fields still flow through the renamer.
+		require.NotNil(t, lg.RetentionInDays)
+		require.NotNil(t, lg.RetentionInDays.Literal)
+		assert.Equal(t, int64(30), *lg.RetentionInDays.Literal)
+	})
+
+	t.Run("aws_s3_bucket", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakeCCGet{
+			props: `{
+				"Arn": "arn:aws:s3:::my-bucket",
+				"BucketName": "my-bucket",
+				"Tags": [
+					{"Key": "Project", "Value": "io-abc"}
+				]
+			}`,
+		}
+		n := normalizerForCFNType(t, "AWS::S3::Bucket")
+		enr := newCloudControlEnricherWithNormalizer("aws_s3_bucket", "AWS::S3::Bucket", fake.call, n)
+		ir := &imported.ImportedResource{
+			Identity: imported.ResourceIdentity{
+				Type:     "aws_s3_bucket",
+				ImportID: "my-bucket",
+			},
+		}
+		require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+
+		decoded, err := generated.UnmarshalAttrs("aws_s3_bucket", ir.Attrs)
+		require.NoError(t, err)
+		b, ok := decoded.(*generated.AWSS3Bucket)
+		require.True(t, ok, "decoded type is %T", decoded)
+
+		// Primary-name: CFN BucketName → TF bucket.
+		require.NotNil(t, b.Bucket)
+		require.NotNil(t, b.Bucket.Literal)
+		assert.Equal(t, "my-bucket", *b.Bucket.Literal)
+		// ARN passes through unchanged (S3 ARN has no :* suffix).
+		require.NotNil(t, b.ARN)
+		require.NotNil(t, b.ARN.Literal)
+		assert.Equal(t, "arn:aws:s3:::my-bucket", *b.ARN.Literal)
+		// Tags landed as flat map.
+		require.NotNil(t, b.Tags)
+		require.Contains(t, b.Tags, "Project")
+		require.NotNil(t, b.Tags["Project"].Literal)
+		assert.Equal(t, "io-abc", *b.Tags["Project"].Literal)
+	})
+
+	t.Run("aws_sqs_queue", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakeCCGet{
+			props: `{
+				"Arn": "arn:aws:sqs:us-east-1:123:my-queue",
+				"QueueName": "my-queue",
+				"MessageRetentionPeriod": 345600,
+				"VisibilityTimeout": 30,
+				"DelaySeconds": 0,
+				"FifoQueue": false,
+				"Tags": [
+					{"Key": "Project", "Value": "io-abc"}
+				]
+			}`,
+		}
+		n := normalizerForCFNType(t, "AWS::SQS::Queue")
+		enr := newCloudControlEnricherWithNormalizer("aws_sqs_queue", "AWS::SQS::Queue", fake.call, n)
+		ir := &imported.ImportedResource{
+			Identity: imported.ResourceIdentity{
+				Type:     "aws_sqs_queue",
+				ImportID: "https://sqs.us-east-1.amazonaws.com/123/my-queue",
+			},
+		}
+		require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+
+		decoded, err := generated.UnmarshalAttrs("aws_sqs_queue", ir.Attrs)
+		require.NoError(t, err)
+		q, ok := decoded.(*generated.AWSSQSQueue)
+		require.True(t, ok, "decoded type is %T", decoded)
+
+		// Primary-name: CFN QueueName → TF name.
+		require.NotNil(t, q.Name)
+		require.NotNil(t, q.Name.Literal)
+		assert.Equal(t, "my-queue", *q.Name.Literal)
+		// Seconds-suffix renames.
+		require.NotNil(t, q.MessageRetentionSeconds)
+		require.NotNil(t, q.MessageRetentionSeconds.Literal)
+		assert.Equal(t, int64(345600), *q.MessageRetentionSeconds.Literal)
+		require.NotNil(t, q.VisibilityTimeoutSeconds)
+		require.NotNil(t, q.VisibilityTimeoutSeconds.Literal)
+		assert.Equal(t, int64(30), *q.VisibilityTimeoutSeconds.Literal)
+		// Untouched fields still flow through the renamer.
+		require.NotNil(t, q.DelaySeconds)
+		require.NotNil(t, q.DelaySeconds.Literal)
+		assert.Equal(t, int64(0), *q.DelaySeconds.Literal)
+		// Tags landed as flat map.
+		require.NotNil(t, q.Tags)
+		require.Contains(t, q.Tags, "Project")
+		require.NotNil(t, q.Tags["Project"].Literal)
+		assert.Equal(t, "io-abc", *q.Tags["Project"].Literal)
+	})
+}
+
+// normalizerForCFNType returns the Normalizer registered on the
+// cloudControlTypeConfigs entry for the given CFN type. Test-only;
+// fails the test if the type is not registered or has no Normalizer.
+// Pulling the Normalizer from the live registration (rather than
+// re-constructing one in the test) makes the test a regression guard
+// for the registration itself.
+func normalizerForCFNType(t *testing.T, cfnType string) Normalizer {
+	t.Helper()
+	for _, cfg := range cloudControlTypeConfigs {
+		if cfg.CloudFormationType == cfnType {
+			require.NotNilf(t, cfg.Normalizer, "no Normalizer registered for %s", cfnType)
+			return cfg.Normalizer
+		}
+	}
+	t.Fatalf("no cloudControlTypeConfigs entry for %s", cfnType)
+	return nil
+}
+
+// TestCloudControlEnricher_Enrich_NormalizerError pins the failure
+// path: a Normalizer that returns an error fails the fetch with the
+// original error wrapped, so soft-fail dispatchers can distinguish a
+// shape-transform bug from a real Cloud Control API error.
+func TestCloudControlEnricher_Enrich_NormalizerError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{props: `{"Arn":"x"}`}
+	boom := errors.New("normalizer-boom")
+	n := func(_ json.RawMessage) (json.RawMessage, error) { return nil, boom }
+	enr := newCloudControlEnricherWithNormalizer("aws_cloudwatch_log_group", "AWS::Logs::LogGroup", fake.call, n)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_cloudwatch_log_group",
+			ImportID: "/aws/x",
+		},
+	}
+	err := enr.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+	assert.Contains(t, err.Error(), "normalize AWS::Logs::LogGroup")
+}
+
 // TestCloudControlEnricher_Enrich_RawAttrs_IsValidJSONWithSnakeKeys
 // guards the wire-format contract: after step 1 of #490 (json tags on
 // every generated Layer-1 field), ir.Attrs uses lowercase snake_case

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers.go
@@ -1,0 +1,272 @@
+package awsdiscover
+
+// cloudcontrol_normalizers.go — composable per-type Normalizer helpers
+// for the Cloud Control unified enricher (#501, partially addresses
+// #490 step 3).
+//
+// A Normalizer transforms the raw Cloud Control GetResource properties
+// JSON before the generic camelToSnake / Layer-1 unmarshal pipeline in
+// cloudControlEnricher.fetchAndMap. CloudFormation and Terraform
+// schemas diverge in a handful of mechanical ways the renamer can't
+// close on its own:
+//
+//   - Primary-name field aliases. CFN names the primary identifier
+//     after the resource ("LogGroupName", "BucketName", "QueueName")
+//     while Terraform uses the bare "name" / "bucket" alias.
+//     renameField("LogGroupName", "Name") rewrites the JSON key.
+//
+//   - Tag shape. CFN serializes tags as a list of {Key, Value} objects;
+//     Terraform's generated Layer-1 struct uses
+//     map[string]*Value[string]. flattenTagList("Tags") collapses the
+//     list into the flat map shape.
+//
+//   - Trailing-:* on certain ARNs. CFN's AWS::Logs::LogGroup.Arn
+//     includes a `:*` log-stream wildcard suffix that the Terraform
+//     `arn` attribute drops. trimARNStar("Arn") strips it.
+//
+// Each helper is intentionally narrow: one transform per helper, no
+// type-specific magic. chain composes them in registration order. A
+// nil-entry in chain is a silent no-op so callers can conditionally
+// build the chain at registration time without per-type branches.
+//
+// Implementation: every helper round-trips through encoding/json and a
+// map[string]any so the helpers can be composed without knowing what
+// the next helper expects. The cost is one Marshal + one Unmarshal per
+// helper; the enricher path runs once per resource per scan, so the
+// constant factor is negligible against the GetResource SDK call.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Normalizer is the per-type hook on cloudControlConfig.Normalizer
+// (#501). Each call receives the raw Cloud Control JSON and returns
+// the transformed bytes ready for the next stage. Returning an error
+// short-circuits the chain and fails the fetch — the enricher wraps
+// the error with the type context so dispatcher can attribute the
+// failure.
+type Normalizer = func(json.RawMessage) (json.RawMessage, error)
+
+// chain composes Normalizers in order. An empty list (or one whose
+// entries are all nil) returns a no-op normalizer that passes the
+// input through unchanged — convenient for registration sites that
+// build the chain conditionally without per-type branches.
+//
+// Nil entries in the middle of the list are silently skipped so a
+// caller can write chain(renameField(...), maybeFlattenTags()) where
+// maybeFlattenTags returns nil for types whose tag shape already
+// matches.
+func chain(ns ...Normalizer) Normalizer {
+	// Compact to drop nil entries up-front so the hot-path closure
+	// avoids the check per resource.
+	compact := make([]Normalizer, 0, len(ns))
+	for _, n := range ns {
+		if n != nil {
+			compact = append(compact, n)
+		}
+	}
+	if len(compact) == 0 {
+		return func(in json.RawMessage) (json.RawMessage, error) { return in, nil }
+	}
+	if len(compact) == 1 {
+		return compact[0]
+	}
+	return func(in json.RawMessage) (json.RawMessage, error) {
+		cur := in
+		for i, n := range compact {
+			next, err := n(cur)
+			if err != nil {
+				return nil, fmt.Errorf("normalizer step %d: %w", i, err)
+			}
+			cur = next
+		}
+		return cur, nil
+	}
+}
+
+// renameField returns a Normalizer that renames a top-level JSON key
+// from `from` to `to`. Idempotent: if `from` is absent, the payload
+// passes through unchanged. If `to` is already present, the existing
+// value wins (the rename is a no-op rather than an overwrite) — this
+// matches the "rename only what's there" intent and avoids clobbering
+// a hand-shaped payload.
+//
+// Operates only on the top-level object. Nested-field renames are
+// out of scope for the #501 baseline; if a per-type case needs nested
+// renames, write a bespoke normalizer for it rather than extending
+// this helper to a path-DSL.
+func renameField(from, to string) Normalizer {
+	return func(in json.RawMessage) (json.RawMessage, error) {
+		if from == "" || to == "" || from == to {
+			return in, nil
+		}
+		m, err := decodeObject(in)
+		if err != nil {
+			return nil, fmt.Errorf("renameField(%q, %q): %w", from, to, err)
+		}
+		if m == nil {
+			return in, nil
+		}
+		v, ok := m[from]
+		if !ok {
+			return in, nil
+		}
+		if _, exists := m[to]; exists {
+			// Target already populated — leave both in place rather
+			// than guess which one is authoritative. Downstream
+			// unmarshal will pick `to` (the snake-case-renamed key
+			// matches the json tag) and silently drop `from`.
+			return in, nil
+		}
+		delete(m, from)
+		m[to] = v
+		return encodeObject(m)
+	}
+}
+
+// flattenTagList returns a Normalizer that collapses a CloudFormation
+// list-of-{Key,Value} tag set at the given top-level key into the
+// shape the generated `Tags map[string]*Value[string]` field expects.
+// Skips entries with a non-string Key or a missing Value (a defensive
+// choice — a CFN payload with a malformed tag entry would otherwise
+// propagate noise into the typed payload).
+//
+// If the key is absent, the payload passes through unchanged. If the
+// key is present but the value is already an object (not a list),
+// the payload also passes through — this makes the helper idempotent
+// in case a prior normalizer already flattened it.
+//
+// Returns an error if the key holds a value of an unexpected shape
+// (e.g. a bare scalar). Surfacing the malformed shape at the
+// normalizer surface beats letting it cascade into a confusing
+// unmarshal error later.
+//
+// **Verbatim sub-tree:** the flat map is wrapped under the
+// shapeValueForLayer1 verbatim marker (see verbatimMarkerKey in
+// cloudcontrol_enricher.go). Tag *keys* are user data (resource
+// names like "Project", "Environment"); applying the
+// CFN-CamelCase → snake_case rename to them would corrupt them
+// (lowercase / underscore-mangle the operator-chosen identifiers).
+// The verbatim wrapper opts the sub-tree out of key renaming while
+// still benefiting from the scalar-leaf {"literal": …} wrap.
+func flattenTagList(key string) Normalizer {
+	return func(in json.RawMessage) (json.RawMessage, error) {
+		if key == "" {
+			return in, nil
+		}
+		m, err := decodeObject(in)
+		if err != nil {
+			return nil, fmt.Errorf("flattenTagList(%q): %w", key, err)
+		}
+		if m == nil {
+			return in, nil
+		}
+		raw, ok := m[key]
+		if !ok || raw == nil {
+			return in, nil
+		}
+		switch v := raw.(type) {
+		case []any:
+			flat := make(map[string]any, len(v))
+			for _, entry := range v {
+				obj, ok := entry.(map[string]any)
+				if !ok {
+					continue
+				}
+				k, ok := obj["Key"].(string)
+				if !ok || k == "" {
+					continue
+				}
+				// Value may legitimately be "" — preserve it.
+				flat[k] = obj["Value"]
+			}
+			m[key] = map[string]any{verbatimMarkerKey: flat}
+			return encodeObject(m)
+		case map[string]any:
+			// Already-shaped: either upstream already wrapped under
+			// the verbatim marker (re-run case) — pass through
+			// unchanged — or a bare flat map slipped in without the
+			// wrapper (e.g. an upstream test fixture or a hand-built
+			// payload). In the bare case, wrap it now so the
+			// downstream shape transform doesn't corrupt the
+			// user-data keys.
+			if _, wrapped := v[verbatimMarkerKey]; wrapped && len(v) == 1 {
+				return in, nil
+			}
+			m[key] = map[string]any{verbatimMarkerKey: v}
+			return encodeObject(m)
+		default:
+			return nil, fmt.Errorf("flattenTagList(%q): unexpected shape %T", key, raw)
+		}
+	}
+}
+
+// trimARNStar returns a Normalizer that strips a trailing `:*` suffix
+// from a top-level string field at the given key. CloudFormation's
+// AWS::Logs::LogGroup.Arn includes the `:*` log-stream wildcard
+// suffix that the Terraform `arn` attribute drops; other ARN-bearing
+// CFN types may surface the same pattern.
+//
+// Idempotent: if the field is absent, not a string, or has no `:*`
+// suffix, the payload passes through unchanged. Operates only on the
+// top-level field — nested-ARN normalization is out of scope.
+func trimARNStar(key string) Normalizer {
+	return func(in json.RawMessage) (json.RawMessage, error) {
+		if key == "" {
+			return in, nil
+		}
+		m, err := decodeObject(in)
+		if err != nil {
+			return nil, fmt.Errorf("trimARNStar(%q): %w", key, err)
+		}
+		if m == nil {
+			return in, nil
+		}
+		raw, ok := m[key]
+		if !ok || raw == nil {
+			return in, nil
+		}
+		s, ok := raw.(string)
+		if !ok {
+			return in, nil
+		}
+		trimmed := strings.TrimSuffix(s, ":*")
+		if trimmed == s {
+			return in, nil
+		}
+		m[key] = trimmed
+		return encodeObject(m)
+	}
+}
+
+// decodeObject is the shared parse step. Returns (nil, nil) for an
+// empty / null payload so helpers can pass-through cleanly without
+// special-casing.
+func decodeObject(in json.RawMessage) (map[string]any, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	// Cheap pre-check: a "null" payload decodes to a nil map. Surface
+	// that as (nil, nil) so helpers preserve the input untouched.
+	trimmed := strings.TrimSpace(string(in))
+	if trimmed == "" || trimmed == "null" {
+		return nil, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(in, &m); err != nil {
+		return nil, fmt.Errorf("decode object: %w", err)
+	}
+	return m, nil
+}
+
+// encodeObject is the shared re-marshal step. Centralized so any
+// future MarshalIndent / sort-keys policy lives in one place.
+func encodeObject(m map[string]any) (json.RawMessage, error) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("encode object: %w", err)
+	}
+	return b, nil
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers_test.go
@@ -1,0 +1,346 @@
+package awsdiscover
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// asMap parses a JSON-encoded object payload for assertion comparison.
+// Keeps test bodies focused on the post-normalize shape rather than
+// on Unmarshal boilerplate.
+func asMap(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	if len(raw) == 0 {
+		return nil
+	}
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+	return m
+}
+
+// TestChain pins the composition contract: nil-friendly construction,
+// in-order application, and error short-circuit. The empty / all-nil
+// chain is the no-op fallback that registration sites lean on when
+// building a chain conditionally.
+func TestChain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty chain is identity", func(t *testing.T) {
+		t.Parallel()
+		n := chain()
+		in := json.RawMessage(`{"X":1}`)
+		out, err := n(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"X":1}`, string(out))
+	})
+
+	t.Run("all-nil chain is identity", func(t *testing.T) {
+		t.Parallel()
+		n := chain(nil, nil)
+		in := json.RawMessage(`{"X":1}`)
+		out, err := n(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"X":1}`, string(out))
+	})
+
+	t.Run("single non-nil collapses to itself", func(t *testing.T) {
+		t.Parallel()
+		n := chain(nil, renameField("X", "Y"), nil)
+		out, err := n(json.RawMessage(`{"X":1}`))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"Y":1}`, string(out))
+	})
+
+	t.Run("multi-step ordered application", func(t *testing.T) {
+		t.Parallel()
+		n := chain(
+			renameField("A", "B"),
+			renameField("B", "C"),
+		)
+		out, err := n(json.RawMessage(`{"A":42}`))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"C":42}`, string(out))
+	})
+
+	t.Run("error short-circuits with step index", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("boom")
+		failing := func(_ json.RawMessage) (json.RawMessage, error) { return nil, boom }
+		n := chain(renameField("A", "B"), failing, renameField("B", "C"))
+		_, err := n(json.RawMessage(`{"A":1}`))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, boom)
+		assert.Contains(t, err.Error(), "normalizer step 1")
+	})
+}
+
+// TestRenameField pins the rename contract: absent source is a no-op,
+// already-present target is a no-op (no clobber), identity rename is
+// a no-op, and a malformed payload surfaces as an error.
+func TestRenameField(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renames present field", func(t *testing.T) {
+		t.Parallel()
+		out, err := renameField("LogGroupName", "Name")(json.RawMessage(`{"LogGroupName":"/aws/x","Arn":"a"}`))
+		require.NoError(t, err)
+		m := asMap(t, out)
+		assert.Equal(t, "/aws/x", m["Name"])
+		assert.NotContains(t, m, "LogGroupName")
+		assert.Equal(t, "a", m["Arn"])
+	})
+
+	t.Run("absent source is no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Arn":"a"}`)
+		out, err := renameField("LogGroupName", "Name")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"Arn":"a"}`, string(out))
+	})
+
+	t.Run("preserves target when both present", func(t *testing.T) {
+		t.Parallel()
+		// Target wins — the rename leaves both intact so a hand-shaped
+		// payload upstream is never silently clobbered.
+		out, err := renameField("LogGroupName", "Name")(json.RawMessage(`{"LogGroupName":"a","Name":"b"}`))
+		require.NoError(t, err)
+		m := asMap(t, out)
+		assert.Equal(t, "a", m["LogGroupName"])
+		assert.Equal(t, "b", m["Name"])
+	})
+
+	t.Run("identity rename is no-op", func(t *testing.T) {
+		t.Parallel()
+		out, err := renameField("Name", "Name")(json.RawMessage(`{"Name":"x"}`))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"Name":"x"}`, string(out))
+	})
+
+	t.Run("empty args are no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"X":1}`)
+		out, err := renameField("", "Y")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"X":1}`, string(out))
+		out, err = renameField("X", "")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"X":1}`, string(out))
+	})
+
+	t.Run("malformed JSON returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := renameField("A", "B")(json.RawMessage(`{not json`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "renameField")
+	})
+
+	t.Run("null payload is no-op", func(t *testing.T) {
+		t.Parallel()
+		out, err := renameField("A", "B")(json.RawMessage(`null`))
+		require.NoError(t, err)
+		assert.Equal(t, "null", string(out))
+	})
+
+	t.Run("empty payload is no-op", func(t *testing.T) {
+		t.Parallel()
+		out, err := renameField("A", "B")(json.RawMessage(``))
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(out))
+	})
+}
+
+// TestFlattenTagList pins the tag-list flatten contract: list of
+// {Key,Value} collapses to a flat map, absent or already-flat input
+// is a no-op, and a malformed shape surfaces as an error.
+func TestFlattenTagList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("flattens list of Key/Value pairs", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Tags":[{"Key":"Project","Value":"io-abc"},{"Key":"Env","Value":"prod"}]}`)
+		out, err := flattenTagList("Tags")(in)
+		require.NoError(t, err)
+		m := asMap(t, out)
+		// flattenTagList wraps the flat map under the verbatim
+		// marker (see #501 — tag keys are user data and must not be
+		// CamelCase-rewritten by the downstream shape transform).
+		wrapper, ok := m["Tags"].(map[string]any)
+		require.True(t, ok, "Tags should be a map, got %T", m["Tags"])
+		tagsAny, ok := wrapper["__verbatim__"]
+		require.True(t, ok, "Tags should be under __verbatim__ wrapper")
+		tags, ok := tagsAny.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "io-abc", tags["Project"])
+		assert.Equal(t, "prod", tags["Env"])
+	})
+
+	t.Run("empty list flattens to empty map under verbatim wrapper", func(t *testing.T) {
+		t.Parallel()
+		out, err := flattenTagList("Tags")(json.RawMessage(`{"Tags":[]}`))
+		require.NoError(t, err)
+		m := asMap(t, out)
+		wrapper, ok := m["Tags"].(map[string]any)
+		require.True(t, ok)
+		tagsAny, ok := wrapper["__verbatim__"]
+		require.True(t, ok)
+		tags, ok := tagsAny.(map[string]any)
+		require.True(t, ok)
+		assert.Len(t, tags, 0)
+	})
+
+	t.Run("absent key is no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Arn":"a"}`)
+		out, err := flattenTagList("Tags")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"Arn":"a"}`, string(out))
+	})
+
+	t.Run("bare-flat shape gets verbatim wrapper", func(t *testing.T) {
+		t.Parallel()
+		// A bare flat tag map (no wrapper) is wrapped so the
+		// downstream shape transform doesn't corrupt the user-data
+		// keys. Catches the case where a hand-built payload or a
+		// prior pass produced a map without the verbatim marker.
+		in := json.RawMessage(`{"Tags":{"Project":"io-abc"}}`)
+		out, err := flattenTagList("Tags")(in)
+		require.NoError(t, err)
+		m := asMap(t, out)
+		wrapper, ok := m["Tags"].(map[string]any)
+		require.True(t, ok)
+		tags, ok := wrapper["__verbatim__"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "io-abc", tags["Project"])
+	})
+
+	t.Run("already-wrapped is no-op (idempotent)", func(t *testing.T) {
+		t.Parallel()
+		// Already wrapped under the verbatim marker — passes through
+		// unchanged so chain composition is safe to re-apply.
+		in := json.RawMessage(`{"Tags":{"__verbatim__":{"Project":"io-abc"}}}`)
+		out, err := flattenTagList("Tags")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"Tags":{"__verbatim__":{"Project":"io-abc"}}}`, string(out))
+	})
+
+	t.Run("skips malformed entries", func(t *testing.T) {
+		t.Parallel()
+		// Missing Key, non-string Key, and a non-object entry are
+		// silently dropped — defensive against partial payloads.
+		in := json.RawMessage(`{"Tags":[
+			{"Key":"OK","Value":"yes"},
+			{"Value":"no-key"},
+			{"Key":"","Value":"empty-key"},
+			"bare-string",
+			{"Key":"AlsoOK","Value":""}
+		]}`)
+		out, err := flattenTagList("Tags")(in)
+		require.NoError(t, err)
+		m := asMap(t, out)
+		wrapper, ok := m["Tags"].(map[string]any)
+		require.True(t, ok)
+		tags, ok := wrapper["__verbatim__"].(map[string]any)
+		require.True(t, ok)
+		assert.Len(t, tags, 2)
+		assert.Equal(t, "yes", tags["OK"])
+		// Empty Value preserved.
+		assert.Equal(t, "", tags["AlsoOK"])
+	})
+
+	t.Run("unexpected shape errors", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Tags":"oops"}`)
+		_, err := flattenTagList("Tags")(in)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected shape")
+	})
+
+	t.Run("malformed JSON returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := flattenTagList("Tags")(json.RawMessage(`{not json`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "flattenTagList")
+	})
+
+	t.Run("empty key is no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"X":1}`)
+		out, err := flattenTagList("")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"X":1}`, string(out))
+	})
+
+	t.Run("null payload is no-op", func(t *testing.T) {
+		t.Parallel()
+		out, err := flattenTagList("Tags")(json.RawMessage(`null`))
+		require.NoError(t, err)
+		assert.Equal(t, "null", string(out))
+	})
+}
+
+// TestTrimARNStar pins the trim contract: trailing ":*" stripped,
+// absent or non-string field is a no-op, no-suffix string is a no-op,
+// and a malformed payload errors.
+func TestTrimARNStar(t *testing.T) {
+	t.Parallel()
+
+	t.Run("strips trailing colon-star", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Arn":"arn:aws:logs:us-east-1:123:log-group:/aws/x:*"}`)
+		out, err := trimARNStar("Arn")(in)
+		require.NoError(t, err)
+		m := asMap(t, out)
+		assert.Equal(t, "arn:aws:logs:us-east-1:123:log-group:/aws/x", m["Arn"])
+	})
+
+	t.Run("no suffix is no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Arn":"arn:aws:logs:us-east-1:123:log-group:/aws/x"}`)
+		out, err := trimARNStar("Arn")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"Arn":"arn:aws:logs:us-east-1:123:log-group:/aws/x"}`, string(out))
+	})
+
+	t.Run("absent key is no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"X":1}`)
+		out, err := trimARNStar("Arn")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"X":1}`, string(out))
+	})
+
+	t.Run("non-string value is no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Arn":123}`)
+		out, err := trimARNStar("Arn")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"Arn":123}`, string(out))
+	})
+
+	t.Run("null value is no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Arn":null}`)
+		out, err := trimARNStar("Arn")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"Arn":null}`, string(out))
+	})
+
+	t.Run("malformed JSON returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := trimARNStar("Arn")(json.RawMessage(`{not json`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "trimARNStar")
+	})
+
+	t.Run("empty key is no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"X":1}`)
+		out, err := trimARNStar("")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"X":1}`, string(out))
+	})
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -164,6 +164,20 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 			return map[string]string{"arn": arn}
 		},
 		TagsFromProperties: tagsFromKey("Tags"),
+		// #501 Normalizer: CFN AWS::SQS::Queue uses primary-name
+		// `QueueName` (TF: `name`), seconds-suffix-elided
+		// `MessageRetentionPeriod` (TF: `message_retention_seconds`)
+		// and `VisibilityTimeout` (TF: `visibility_timeout_seconds`),
+		// and a list-of-{Key,Value} `Tags` shape (TF:
+		// map[string]*Value[string]). The renames + tag-list flatten
+		// land the values on the right Layer-1 fields after the
+		// camelToSnake projection.
+		Normalizer: chain(
+			renameField("QueueName", "Name"),
+			renameField("MessageRetentionPeriod", "MessageRetentionSeconds"),
+			renameField("VisibilityTimeout", "VisibilityTimeoutSeconds"),
+			flattenTagList("Tags"),
+		),
 	},
 
 	// =====================================================================
@@ -197,6 +211,20 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		NameHintFromProperties:  nameOrIdentifier("LogGroupName"),
 		NativeIDsFromProperties: arnUnderKey("Arn"),
 		TagsFromProperties:      tagsFromKey("Tags"),
+		// #501 Normalizer: CFN AWS::Logs::LogGroup uses primary-name
+		// `LogGroupName` (TF: `name`), an `Arn` that includes the
+		// trailing `:*` log-stream wildcard (TF strips it), and a
+		// list-of-{Key,Value} `Tags` shape (TF: map shape). NOTE: a
+		// hand-rolled enricher in byTypeEnricher currently overrides
+		// the Cloud Control generic path for this type, so the
+		// normalizer is dormant at runtime — staged here so Bucket C
+		// can compare the generic-path payload to the hand-rolled
+		// output and decide whether to retire the override.
+		Normalizer: chain(
+			renameField("LogGroupName", "Name"),
+			trimARNStar("Arn"),
+			flattenTagList("Tags"),
+		),
 	},
 	{
 		TFType:                  "aws_cloudwatch_event_rule",
@@ -276,6 +304,19 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		NameHintFromProperties:  nameOrIdentifier("BucketName"),
 		NativeIDsFromProperties: arnUnderKey("Arn"),
 		TagsFromProperties:      tagsFromKey("Tags"),
+		// #501 Normalizer: CFN AWS::S3::Bucket uses primary-name
+		// `BucketName` (TF: `bucket`) and a list-of-{Key,Value}
+		// `Tags` shape (TF: map shape). NOTE: a hand-rolled enricher
+		// in byTypeEnricher currently overrides the Cloud Control
+		// generic path for this type — see issue #493 / the s3
+		// multi-overlay note. The normalizer is staged here so
+		// Bucket C can compare the generic-path payload to the
+		// hand-rolled output and decide whether to retire the
+		// override.
+		Normalizer: chain(
+			renameField("BucketName", "Bucket"),
+			flattenTagList("Tags"),
+		),
 	},
 	{
 		TFType:                  "aws_dynamodb_table",


### PR DESCRIPTION
## Summary

- Add per-type `Normalizer` field on `cloudControlConfig` that runs post-fetch / pre-map inside the unified `cloudControlEnricher` — closes the CFN-vs-TF shape gap that the generic `camelToSnake` projection cannot bridge on its own (primary-name aliases, list-of-`{Key,Value}` tags, trailing-`:*` ARNs).
- New composable helpers in `cloudcontrol_normalizers.go`: `chain`, `renameField`, `flattenTagList`, `trimARNStar`. Each is a single-purpose `json.RawMessage` round-trip; `chain` is nil-friendly so registration sites can build conditional chains.
- Wired Normalizers for three target types (`aws_sqs_queue`, `aws_cloudwatch_log_group`, `aws_s3_bucket`). Only `aws_sqs_queue` is live at runtime — the other two still have hand-rolled `*_enrich.go` overrides in `byTypeEnricher` and are staged for Bucket C to compare.
- Tag keys (user-data) are protected from the downstream `camelToSnake` shape transform via a `verbatimMarkerKey = "__verbatim__"` sentinel that `shapeValueForLayer1` unwraps and leaf-wraps verbatim.

Closes #501. Partially addresses #490 (Step 3 of the HYBRID adoption — `LogGroupName`-style primary-name rename and ARN normalization).

## Bucket C — Hand-rolled vs Normalizer payload comparison

For the three wired types, here is how the Normalizer-path output compares to the existing `*_enrich.go` output. This drives Bucket C's retire decision.

### `aws_cloudwatch_log_group`

- **Hand-rolled** (`cloudwatch_log_group_enrich.go`): `DescribeLogGroups` (name-prefix + post-filter) + `ListTagsForResource` overlay. Maps: `arn` (prefers `LogGroupArn` over legacy `Arn:*` form), `id`, `name`, `kms_key_id`, `log_group_class`, `retention_in_days`, `tags`.
- **Normalizer path** (Cloud Control `GetResource`): `arn` (via `trimARNStar`), `name` (via `renameField LogGroupName→Name`), `kms_key_id`, `log_group_class`, `retention_in_days`, `tags` (via `flattenTagList`). **Missing relative to hand-rolled:** `id` (which the hand-rolled enricher synthesizes as `name`). The two payloads are otherwise equivalent on the field set covered by the generated Layer-1 struct. Retire decision: viable to retire the hand-rolled enricher if `id`-synth is added to the Normalizer path (trivial — could be a generic per-type post-rename) or if downstream consumers treat `name` as the id source.

### `aws_s3_bucket`

- **Hand-rolled** (`s3_bucket_enrich.go`): ~10 SDK calls — `HeadBucket` + `GetBucketEncryption` + `GetBucketVersioning` + `GetBucketLifecycleConfiguration` + `GetBucketLogging` + `GetBucketCors` + `GetBucketPolicy` + `GetBucketWebsite` + `GetBucketTagging` + `GetBucketObjectLockConfiguration`. Populates the rich nested blocks (`server_side_encryption_configuration`, `versioning`, `lifecycle_rule`, `logging`, `cors_rule`, `policy`, `website`, `object_lock_configuration`).
- **Normalizer path**: single `GetResource AWS::S3::Bucket` returns the CFN-shaped payload covering `arn`, `bucket` (via `renameField BucketName→Bucket`), `tags` (via `flattenTagList`), plus whatever CFN exposes in its schema for the nested blocks. **Significantly less rich** than the hand-rolled path: CFN's `AWS::S3::Bucket` schema covers fewer sub-resource configurations than the dedicated S3 `GetBucket*` APIs (notably tagging arrives via the typed CFN `Tags` only when explicitly set on the bucket via the CFN-managed path). Retire decision: NOT recommended — the hand-rolled enricher's multi-overlay surface is materially more complete. The Normalizer is staged here so Bucket C can pin the gap quantitatively before deciding.

### `aws_sqs_queue`

- **Hand-rolled**: none. The generic Cloud Control enricher already handles this type via the `byTypeEnricher` fallback registration.
- **Normalizer path**: `arn`, `name` (`QueueName→Name`), `message_retention_seconds` (`MessageRetentionPeriod→MessageRetentionSeconds`), `visibility_timeout_seconds` (`VisibilityTimeout→VisibilityTimeoutSeconds`), `delay_seconds`, `fifo_queue`, `kms_master_key_id`, `tags` (`flattenTagList`). **This is the only retire-relevant comparison that is no-op** (no hand-rolled to retire) — it lifts the Cloud Control payload's coverage on this type meaningfully without introducing an override.

## Test plan

- [x] `go test ./cmd/insideout-import/awsdiscover/...` — 930 passed
- [x] `go test ./...` — 5275 passed across 35 packages
- [x] `go build ./...` — succeeds
- [x] `go vet ./...` — clean
- [x] Per-helper unit tests in `cloudcontrol_normalizers_test.go` (empty input, present input, idempotent re-runs, error paths)
- [x] End-to-end subtests in `cloudcontrol_enricher_test.go` for each of the 3 wired types using `normalizerForCFNType` to pull the live registration (regression guards both wiring + transform)
- [x] Normalizer error-propagation test asserts wrapped error surfaces the type context