### PR TITLE
feat(policy): add awsTagDriftPolicy() mirroring gcpLabelDriftPolicy (#568)

### DIFF
--- a/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
+++ b/cmd/imported-codegen/testdata/drift_fields/drift-fields.json
@@ -1657,6 +1657,14 @@
     {
       "path": "skip_destroy",
       "semantic": "Exact"
+    },
+    {
+      "path": "tags",
+      "semantic": "LabelFilter"
+    },
+    {
+      "path": "tags_all",
+      "semantic": "LabelFilter"
     }
   ],
   "aws_cloudwatch_log_resource_policy": [
@@ -2783,6 +2791,14 @@
       "semantic": "Exact"
     },
     {
+      "path": "tags",
+      "semantic": "LabelFilter"
+    },
+    {
+      "path": "tags_all",
+      "semantic": "LabelFilter"
+    },
+    {
       "path": "timezone",
       "semantic": "Exact"
     },
@@ -3059,6 +3075,14 @@
     {
       "path": "table_class",
       "semantic": "Exact"
+    },
+    {
+      "path": "tags",
+      "semantic": "LabelFilter"
+    },
+    {
+      "path": "tags_all",
+      "semantic": "LabelFilter"
     },
     {
       "path": "ttl.attribute_name",
@@ -7419,6 +7443,14 @@
       "semantic": "Exact"
     },
     {
+      "path": "tags",
+      "semantic": "LabelFilter"
+    },
+    {
+      "path": "tags_all",
+      "semantic": "LabelFilter"
+    },
+    {
       "path": "versioning.enabled",
       "semantic": "Exact"
     },
@@ -7651,6 +7683,14 @@
     {
       "path": "replica.region",
       "semantic": "Exact"
+    },
+    {
+      "path": "tags",
+      "semantic": "LabelFilter"
+    },
+    {
+      "path": "tags_all",
+      "semantic": "LabelFilter"
     }
   ],
   "aws_secretsmanager_secret_rotation": [
@@ -8081,6 +8121,14 @@
     {
       "path": "sqs_managed_sse_enabled",
       "semantic": "Exact"
+    },
+    {
+      "path": "tags",
+      "semantic": "LabelFilter"
+    },
+    {
+      "path": "tags_all",
+      "semantic": "LabelFilter"
     },
     {
       "path": "url",

--- a/pkg/composer/imported/policy/aws_cloudwatch_log_group.policy.go
+++ b/pkg/composer/imported/policy/aws_cloudwatch_log_group.policy.go
@@ -6,9 +6,15 @@ package policy
 // All curated leaves are scalar (ARN, name, KMS key ARN, retention days,
 // log group class, skip_destroy bool) — DriftSemanticExact is the
 // meaningful comparison. There are no list-valued or map-valued curated
-// fields here, so WholeList / LabelFilter do not apply. Tag bags stay
-// DriftSemanticNone (tagPolicy() zero value) — provider noise on tags is
-// filtered at a higher layer.
+// fields here, so WholeList / LabelFilter do not apply.
+//
+// #568: `tags` / `tags_all` adopt awsTagDriftPolicy() so user-set tags
+// (notably the canonical `Project` tag that the InsideOut inspector
+// uses to attribute resources — CLAUDE.md "Project tag is required on
+// every taggable AWS resource") surface as `tags.<key>` per-key drift
+// when stripped out-of-band. Log groups are a stable resource with
+// low tag-churn, so noise-vs-signal trades favor surfacing user-set
+// tag drift here.
 var awsCloudwatchLogGroupPolicy = Map{
 	// Identity
 	"arn": {
@@ -43,8 +49,12 @@ var awsCloudwatchLogGroupPolicy = Map{
 		DriftSemantic: DriftSemanticExact,
 	},
 
-	"tags":     tagPolicy(),
-	"tags_all": tagPolicy(),
+	// Tags — adopt awsTagDriftPolicy() so user-set tag drift (esp.
+	// the Project tag used by the InsideOut inspector) surfaces as
+	// per-key `tags.<key>` mismatches with AWS-managed prefixes
+	// (`aws:`, `eks:`, etc.) filtered out (#568).
+	"tags":     awsTagDriftPolicy(),
+	"tags_all": awsTagDriftPolicy(),
 }
 
 func init() {

--- a/pkg/composer/imported/policy/aws_db_instance.policy.go
+++ b/pkg/composer/imported/policy/aws_db_instance.policy.go
@@ -424,9 +424,14 @@ var awsDbInstancePolicy = Map{
 		DriftSemantic: DriftSemanticExact,
 	},
 
-	// Tags --------------------------------------------------------------
-	"tags":     tagPolicy(),
-	"tags_all": tagPolicy(),
+	// Tags — adopt awsTagDriftPolicy() (#568): user-set tag drift
+	// surfaces as per-key `tags.<key>` mismatches; AWS-managed
+	// prefixes are filtered. RDS instances are long-lived
+	// customer-owned infra where the canonical `Project` /
+	// `Environment` tags drive cost attribution and InsideOut
+	// inspector grouping — stripping them must surface as drift.
+	"tags":     awsTagDriftPolicy(),
+	"tags_all": awsTagDriftPolicy(),
 
 	// timeouts singleton ------------------------------------------------
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/aws_dynamodb_table.policy.go
+++ b/pkg/composer/imported/policy/aws_dynamodb_table.policy.go
@@ -296,9 +296,14 @@ var awsDynamodbTablePolicy = Map{
 		DriftSemantic: DriftSemanticExact,
 	},
 
-	// Tags (system-managed bag) ----------------------------------------
-	"tags":     tagPolicy(),
-	"tags_all": tagPolicy(),
+	// Tags — adopt awsTagDriftPolicy() (#568): user-set tag drift
+	// surfaces as per-key `tags.<key>` mismatches; AWS-managed
+	// prefixes (`aws:`, `eks:`, etc.) are filtered. DynamoDB tables
+	// are stable user-owned resources where the canonical `Project`
+	// tag drives InsideOut inspector attribution — stripping it
+	// out-of-band must surface as drift.
+	"tags":     awsTagDriftPolicy(),
+	"tags_all": awsTagDriftPolicy(),
 
 	// timeouts singleton — system-owned operational metadata -----------
 	"timeouts": timeoutsPolicy(),

--- a/pkg/composer/imported/policy/aws_s3_bucket.policy.go
+++ b/pkg/composer/imported/policy/aws_s3_bucket.policy.go
@@ -23,8 +23,15 @@ package policy
 // renamed-out-of-band bucket still surfaces. Configurable scalars use
 // Exact; the cross-resource wiring leaves (KMS key ARN, target bucket,
 // replication role) also use Exact — a value diff there is real drift,
-// not provider noise. Tag bags stay DriftSemanticNone (tagPolicy() zero
-// value) because they're system-managed.
+// not provider noise.
+//
+// #568: `tags` / `tags_all` adopt awsTagDriftPolicy() so user-set
+// tags (notably the canonical `Project` tag the InsideOut inspector
+// uses to attribute resources — CLAUDE.md "Project tag is required on
+// every taggable AWS resource") surface as per-key `tags.<key>` drift
+// when stripped out-of-band. AWS-managed prefixes (`aws:`, `eks:`,
+// `kubernetes.io/`, etc.) are filtered. S3 buckets are stable,
+// low-churn, customer-owned — the right shape for tag drift.
 //
 // Depth-pass extras (#482 follow-up): adds a curated sub-set of the
 // deprecated nested-config sub-paths the AWS v4+ provider keeps for
@@ -283,11 +290,11 @@ var awsS3BucketPolicy = Map{
 		DriftSemantic: DriftSemanticExact,
 	},
 
-	// Tags (system-managed bag) ----------------------------------------
-	// DriftSemantic stays None — tag drift is provider noise; the diff
-	// surface filters tags at a higher layer.
-	"tags":     tagPolicy(),
-	"tags_all": tagPolicy(),
+	// Tags — adopt awsTagDriftPolicy() (#568): user-set tag drift
+	// surfaces as per-key `tags.<key>` mismatches; AWS-managed
+	// prefixes (`aws:`, `eks:`, `kubernetes.io/`, etc.) are filtered.
+	"tags":     awsTagDriftPolicy(),
+	"tags_all": awsTagDriftPolicy(),
 }
 
 func init() {

--- a/pkg/composer/imported/policy/aws_secretsmanager_secret.policy.go
+++ b/pkg/composer/imported/policy/aws_secretsmanager_secret.policy.go
@@ -11,8 +11,12 @@ package policy
 // resource) and is not curated in this map, so the Sensitive-leak
 // concern that gates `aws_lambda_function.environment.variables` does
 // not arise. All curated leaves are scalar; DriftSemanticExact is the
-// meaningful comparison for each. Tag bags stay DriftSemanticNone
-// (tagPolicy() zero value).
+// meaningful comparison for each.
+//
+// #568: `tags` / `tags_all` adopt awsTagDriftPolicy() — symmetric
+// with google_secret_manager_secret's gcpLabelDriftPolicy() adoption.
+// User-set tag drift surfaces as per-key `tags.<key>` mismatches;
+// AWS-managed prefixes are filtered.
 var awsSecretsmanagerSecretPolicy = Map{
 	// Identity
 	"arn": {
@@ -62,8 +66,10 @@ var awsSecretsmanagerSecretPolicy = Map{
 		DriftSemantic: DriftSemanticExact,
 	},
 
-	"tags":     tagPolicy(),
-	"tags_all": tagPolicy(),
+	// Tags — awsTagDriftPolicy() (#568): per-key user-tag drift
+	// surfaces; AWS-managed prefixes filtered.
+	"tags":     awsTagDriftPolicy(),
+	"tags_all": awsTagDriftPolicy(),
 }
 
 func init() {

--- a/pkg/composer/imported/policy/aws_sqs_queue.policy.go
+++ b/pkg/composer/imported/policy/aws_sqs_queue.policy.go
@@ -138,8 +138,13 @@ var awsSQSQueuePolicy = Map{
 		Role: RoleTuning, Visibility: VisibilityRileyVisible, Edit: EditChatSafe,
 		DriftSemantic: DriftSemanticExact,
 	},
-	"tags":     tagPolicy(),
-	"tags_all": tagPolicy(),
+	// Tags — adopt awsTagDriftPolicy() (#568): user-set tag drift
+	// surfaces as per-key `tags.<key>` mismatches; AWS-managed
+	// prefixes are filtered. SQS queues are low-churn messaging
+	// infra where the canonical `Project` tag drives InsideOut
+	// inspector attribution — stripping it must surface as drift.
+	"tags":     awsTagDriftPolicy(),
+	"tags_all": awsTagDriftPolicy(),
 }
 
 func init() {

--- a/pkg/composer/imported/policy/axes_test.go
+++ b/pkg/composer/imported/policy/axes_test.go
@@ -159,4 +159,41 @@ func TestSharedPolicies(t *testing.T) {
 		Visibility: VisibilityHidden,
 		Edit:       EditSystemOnly,
 	}, timeoutsPolicy())
+	assert.Equal(t, FieldPolicy{
+		Role:                     RoleTuning,
+		Visibility:               VisibilityHidden,
+		Edit:                     EditSystemOnly,
+		Sensitivity:              SensitivityRedacted,
+		DriftSemantic:            DriftSemanticLabelFilter,
+		LabelDriftIgnorePrefixes: gcpLabelDriftIgnorePrefixes,
+	}, gcpLabelDriftPolicy())
+	// AWS parallel — #568. Tag prefixes live in TagDriftIgnorePrefixes
+	// (not LabelDriftIgnorePrefixes) so the helper reads naturally
+	// against the AWS-tag axis name; the comparator unions both
+	// fields before filtering keys.
+	assert.Equal(t, FieldPolicy{
+		Role:                   RoleTuning,
+		Visibility:             VisibilityHidden,
+		Edit:                   EditSystemOnly,
+		Sensitivity:            SensitivityRedacted,
+		DriftSemantic:          DriftSemanticLabelFilter,
+		TagDriftIgnorePrefixes: awsTagDriftIgnorePrefixes,
+	}, awsTagDriftPolicy())
+}
+
+// TestAWSTagDriftIgnorePrefixes pins the canonical AWS-managed prefix
+// set so a silent edit to the slice surfaces as a test failure rather
+// than altering the drift surface across every adopting policy at once.
+// The set is referenced from CLAUDE.md / #568; bump the assertion here
+// and the docstring in lockstep when extending it.
+func TestAWSTagDriftIgnorePrefixes(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []string{
+		"aws:",
+		"eks:",
+		"elasticbeanstalk:",
+		"kubernetes.io/",
+		"InsideOut",
+		"insideout-",
+	}, awsTagDriftIgnorePrefixes)
 }

--- a/pkg/composer/imported/policy/policy.go
+++ b/pkg/composer/imported/policy/policy.go
@@ -16,6 +16,15 @@ package policy
 // (the zero value) falls back to a built-in GCP-noise default of
 // {"goog-", "goog_"} so existing policies that pre-date this knob keep
 // the historical behavior.
+//
+// TagDriftIgnorePrefixes is the AWS-side parallel to
+// LabelDriftIgnorePrefixes — same shape, same semantics, separate
+// field so each cloud's helper (gcpLabelDriftPolicy /
+// awsTagDriftPolicy) reads naturally at the call site. The comparator
+// in pkg/drift/imported unions both lists before filtering keys, so a
+// curator who wants both Google and AWS prefixes filtered on a
+// cross-cloud synthetic policy can populate both fields. Empty
+// (the zero value) contributes nothing to the filter set.
 type FieldPolicy struct {
 	Role                     FieldRole
 	Pillar                   FieldPillar
@@ -25,6 +34,7 @@ type FieldPolicy struct {
 	ChangeRisk               ChangeRiskPolicy
 	DriftSemantic            DriftSemantic
 	LabelDriftIgnorePrefixes []string
+	TagDriftIgnorePrefixes   []string
 	Rationale                string
 }
 
@@ -104,5 +114,84 @@ func gcpLabelDriftPolicy() FieldPolicy {
 		Sensitivity:              SensitivityRedacted,
 		DriftSemantic:            DriftSemanticLabelFilter,
 		LabelDriftIgnorePrefixes: gcpLabelDriftIgnorePrefixes,
+	}
+}
+
+// awsTagDriftIgnorePrefixes is the canonical set of AWS tag-key
+// prefixes that must be filtered out of AWS tag drift on both
+// snapshot and live sides before per-key comparison:
+//
+//   - "aws:" — the reserved AWS-system prefix
+//     (https://docs.aws.amazon.com/tag-editor/latest/userguide/tagging.html).
+//     AWS-internal services write keys like
+//     `aws:cloudformation:stack-name`, `aws:autoscaling:groupName`,
+//     `aws:ec2spot:fleet-request-id`. Terraform does not own these and
+//     the AWS API rejects attempts to set them — drift on this prefix
+//     is always noise.
+//   - "eks:" — EKS-managed tags propagated onto cluster-owned
+//     resources (e.g. `eks:cluster-name`, `eks:nodegroup-name`).
+//     The EKS control plane writes these on managed node groups,
+//     fargate profiles, launch templates, and downstream ASGs; they
+//     reappear after every reconcile loop.
+//   - "elasticbeanstalk:" — Elastic Beanstalk environment tags
+//     (e.g. `elasticbeanstalk:environment-name`,
+//     `elasticbeanstalk:environment-id`) auto-applied to every
+//     resource a Beanstalk environment provisions.
+//   - "kubernetes.io/" — the Kubernetes-on-AWS convention used by
+//     in-tree cloud providers and AWS Load Balancer Controller to
+//     mark cluster-owned EBS volumes, ENIs, security groups, target
+//     groups, and subnets (e.g. `kubernetes.io/cluster/<name>`,
+//     `kubernetes.io/role/elb`). The controller re-applies them on
+//     every reconcile.
+//   - "InsideOut" / "insideout-" — the importer / composer's own
+//     provenance tags (mirror of gcpLabelDriftIgnorePrefixes's
+//     "insideout-import" entry). Both casings are listed because
+//     AWS tag keys are case-sensitive and historical exports have
+//     used mixed casing.
+//
+// Used by awsTagDriftPolicy() and any per-type policy that opts into
+// curated tag drift. Symmetric with gcpLabelDriftIgnorePrefixes so the
+// drift comparator's filter behavior is policy-author authored rather
+// than baked into compare.go.
+var awsTagDriftIgnorePrefixes = []string{
+	"aws:",
+	"eks:",
+	"elasticbeanstalk:",
+	"kubernetes.io/",
+	"InsideOut",
+	"insideout-",
+}
+
+// awsTagDriftPolicy is the uniform treatment for AWS `tags` / `tags_all`
+// map attributes that we want curated drift on. Same axes as
+// tagPolicy() — system-owned, redacted from display — but
+// DriftSemantic=LabelFilter with the canonical AWS-managed prefix set
+// so the comparator emits one per-key `tags.<key>` mismatch for each
+// user-curated tag that diverges between snapshot and live.
+//
+// Use this in lieu of tagPolicy() on any AWS type whose user-set
+// tags are part of the drift signal — most notably the canonical
+// `Project = <project>` tag that the downstream InsideOut inspector
+// uses to attribute resources (CLAUDE.md "Project tag is required
+// on every taggable AWS resource"). Out-of-band tag removal is
+// invisible to drift detection without this; an operator stripping
+// `Project` silently breaks attribution (#81 backstory, #568).
+//
+// Adopting awsTagDriftPolicy() is policy-author opt-in rather than a
+// global flip so types with no useful tag-drift surface can stay on
+// tagPolicy() and types like aws_autoscaling_group whose tags churn
+// from EKS / Karpenter / ASG-internal writes don't generate noise.
+//
+// Mirrors gcpLabelDriftPolicy() — same shape, AWS-flavored prefix
+// set, system-owned semantics. See awsTagDriftIgnorePrefixes for the
+// rationale on each filter prefix.
+func awsTagDriftPolicy() FieldPolicy {
+	return FieldPolicy{
+		Role:                   RoleTuning,
+		Visibility:             VisibilityHidden,
+		Edit:                   EditSystemOnly,
+		Sensitivity:            SensitivityRedacted,
+		DriftSemantic:          DriftSemanticLabelFilter,
+		TagDriftIgnorePrefixes: awsTagDriftIgnorePrefixes,
 	}
 }

--- a/pkg/drift/imported/compare.go
+++ b/pkg/drift/imported/compare.go
@@ -116,7 +116,7 @@ func Compare(tfType string, snapshot, live json.RawMessage) []FieldMismatch {
 				out = append(out, m)
 			}
 		case policy.DriftSemanticLabelFilter:
-			out = append(out, compareLabelFilter(path, entry.LabelDriftIgnorePrefixes, snapAttrs, liveAttrs)...)
+			out = append(out, compareLabelFilter(path, mergePrefixes(entry.LabelDriftIgnorePrefixes, entry.TagDriftIgnorePrefixes), snapAttrs, liveAttrs)...)
 		default:
 			// Unknown DriftSemantic — be conservative and skip. The
 			// policy lint enforces Valid() at registration, so an
@@ -234,6 +234,29 @@ func coerceList(v any) []any {
 // untouched policy keeps the same behavior after the per-policy
 // prefix knob lands.
 var defaultLabelDriftIgnorePrefixes = []string{"goog-", "goog_"}
+
+// mergePrefixes unions a FieldPolicy's GCP-flavored
+// LabelDriftIgnorePrefixes with its AWS-flavored TagDriftIgnorePrefixes.
+// Both fields populate the same filter set on a DriftSemanticLabelFilter
+// entry; keeping them as separate fields lets each cloud's helper
+// (gcpLabelDriftPolicy / awsTagDriftPolicy) read naturally at the
+// call site while the comparator stays cloud-agnostic. Order is
+// label-prefixes first, then tag-prefixes; the comparator does a
+// HasPrefix scan, so order only affects micro-perf, not correctness.
+// nil/empty inputs are ignored; if both are empty the result is nil
+// and compareLabelFilter falls back to defaultLabelDriftIgnorePrefixes.
+func mergePrefixes(label, tag []string) []string {
+	if len(label) == 0 {
+		return tag
+	}
+	if len(tag) == 0 {
+		return label
+	}
+	out := make([]string, 0, len(label)+len(tag))
+	out = append(out, label...)
+	out = append(out, tag...)
+	return out
+}
 
 // compareLabelFilter resolves path in both maps, filters keys whose
 // name has any of the ignorePrefixes on both sides, and emits ONE

--- a/pkg/drift/imported/compare_curated_test.go
+++ b/pkg/drift/imported/compare_curated_test.go
@@ -39,8 +39,9 @@ func fieldsByPath(t *testing.T, got []FieldMismatch) map[string]FieldMismatch {
 
 // TestCompare_Curated_AWSS3Bucket exercises the curated drift surface
 // for aws_s3_bucket: a versioning flip and a server-side-encryption
-// algorithm change must surface as Exact mismatches; tag drift must
-// stay invisible (tagPolicy() leaves DriftSemantic=None).
+// algorithm change must surface as Exact mismatches; user-set tag
+// drift surfaces as a per-key `tags.<key>` mismatch since aws_s3_bucket
+// adopts awsTagDriftPolicy() (#568).
 func TestCompare_Curated_AWSS3Bucket(t *testing.T) {
 	t.Parallel()
 	snap := json.RawMessage(`{
@@ -85,9 +86,18 @@ func TestCompare_Curated_AWSS3Bucket(t *testing.T) {
 	if _, ok := idx["server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm"]; !ok {
 		t.Errorf("expected sse_algorithm mismatch; got fields: %v", keysOf(idx))
 	}
-	// tags drift must NOT appear — tagPolicy() leaves DriftSemantic=None.
+	// Whole-map `tags` field must NOT appear — awsTagDriftPolicy()
+	// uses DriftSemanticLabelFilter which emits per-key entries instead.
 	if _, ok := idx["tags"]; ok {
-		t.Error("tag drift must stay invisible (tagPolicy keeps DriftSemantic=None)")
+		t.Error("whole-map tag drift must not appear — LabelFilter emits per-key entries")
+	}
+	// Per-key user-tag drift MUST surface as tags.team (no AWS-managed
+	// prefix on `team`, so it survives the filter).
+	if _, ok := idx["tags.team"]; !ok {
+		t.Errorf("expected tags.team per-key mismatch; got fields: %v", keysOf(idx))
+	} else {
+		assert.Equal(t, "infra", idx["tags.team"].Snapshot)
+		assert.Equal(t, "platform", idx["tags.team"].Cloud)
 	}
 }
 
@@ -349,8 +359,13 @@ func TestCompare_Curated_AWSCloudwatchLogGroup_Exact(t *testing.T) {
 
 	// kms_key_id is identical → no mismatch.
 	assert.NotContains(t, idx, "kms_key_id")
-	// tags use tagPolicy() (DriftSemantic=None) → never emitted.
+	// Whole-map `tags` is not emitted (LabelFilter is per-key only).
 	assert.NotContains(t, idx, "tags")
+	// User-set tag drift surfaces per-key under awsTagDriftPolicy() (#568).
+	require.Contains(t, idx, "tags.team",
+		"expected per-key tags.team mismatch under awsTagDriftPolicy()")
+	assert.Equal(t, "infra", idx["tags.team"].Snapshot)
+	assert.Equal(t, "platform", idx["tags.team"].Cloud)
 }
 
 // TestCompare_Curated_AWSSecretsmanagerSecret_Exact exercises an Exact
@@ -1279,4 +1294,115 @@ func keysOf(m map[string]FieldMismatch) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// TestCompare_Curated_AWSTags_AWSManagedPrefixIgnored pins the
+// awsTagDriftPolicy() ignore-prefix filter end-to-end against a real
+// curated type (aws_s3_bucket). An AWS-managed tag whose key carries
+// the reserved `aws:` prefix (e.g. `aws:cloudformation:stack-name`)
+// MUST NOT surface as drift even when it differs across snapshot and
+// live, because Terraform doesn't own it and the AWS API rejects
+// attempts to set it (#568).
+func TestCompare_Curated_AWSTags_AWSManagedPrefixIgnored(t *testing.T) {
+	t.Parallel()
+	// User-set tags identical on both sides; only AWS-managed-prefix
+	// keys differ across snap/live. Nothing should surface.
+	snap := json.RawMessage(`{
+		"arn": "arn:aws:s3:::my-bucket",
+		"bucket": "my-bucket",
+		"tags": {
+			"Project": "io-abc123",
+			"Environment": "prod",
+			"aws:cloudformation:stack-name": "managed-by-cfn-A",
+			"eks:cluster-name": "old-cluster",
+			"elasticbeanstalk:environment-name": "old-env",
+			"kubernetes.io/cluster/foo": "owned"
+		},
+		"tags_all": {
+			"Project": "io-abc123",
+			"Environment": "prod",
+			"aws:cloudformation:stack-name": "managed-by-cfn-A"
+		}
+	}`)
+	live := json.RawMessage(`{
+		"arn": "arn:aws:s3:::my-bucket",
+		"bucket": "my-bucket",
+		"tags": {
+			"Project": "io-abc123",
+			"Environment": "prod",
+			"aws:cloudformation:stack-name": "managed-by-cfn-B",
+			"eks:cluster-name": "new-cluster",
+			"elasticbeanstalk:environment-name": "new-env",
+			"kubernetes.io/cluster/foo": "shared"
+		},
+		"tags_all": {
+			"Project": "io-abc123",
+			"Environment": "prod",
+			"aws:cloudformation:stack-name": "managed-by-cfn-B"
+		}
+	}`)
+	got := Compare("aws_s3_bucket", snap, live)
+	idx := fieldsByPath(t, got)
+
+	for key := range idx {
+		// No tag-key drift may appear — every differing key matches
+		// an awsTagDriftIgnorePrefixes entry and must be filtered.
+		if len(key) >= 5 && key[:5] == "tags." {
+			t.Errorf("AWS-managed prefix tag must not surface as drift; got %q (snapshot=%v cloud=%v)",
+				key, idx[key].Snapshot, idx[key].Cloud)
+		}
+		if len(key) >= 9 && key[:9] == "tags_all." {
+			t.Errorf("AWS-managed prefix tag must not surface as drift; got %q (snapshot=%v cloud=%v)",
+				key, idx[key].Snapshot, idx[key].Cloud)
+		}
+	}
+}
+
+// TestCompare_Curated_AWSTags_UserManagedKeyDriftSurfaced pins the
+// positive case: a user-set tag (no AWS-managed prefix) whose value
+// differs between snap and live MUST surface as a per-key
+// `tags.<key>` mismatch via awsTagDriftPolicy()'s LabelFilter
+// semantic. This is the load-bearing assertion for #568 — an
+// operator stripping the `Project` tag out-of-band must not slip
+// past drift detection (CLAUDE.md "Project tag is required on
+// every taggable AWS resource" — backstory in #81).
+func TestCompare_Curated_AWSTags_UserManagedKeyDriftSurfaced(t *testing.T) {
+	t.Parallel()
+	// `Project` differs (the canonical InsideOut attribution tag);
+	// `Environment` differs; AWS-managed prefix `aws:...` is noise.
+	snap := json.RawMessage(`{
+		"arn": "arn:aws:s3:::my-bucket",
+		"bucket": "my-bucket",
+		"tags": {
+			"Project": "io-abc123",
+			"Environment": "prod",
+			"aws:cloudformation:stack-name": "cfn-noise"
+		}
+	}`)
+	live := json.RawMessage(`{
+		"arn": "arn:aws:s3:::my-bucket",
+		"bucket": "my-bucket",
+		"tags": {
+			"Environment": "staging",
+			"aws:cloudformation:stack-name": "cfn-noise-different"
+		}
+	}`)
+	got := Compare("aws_s3_bucket", snap, live)
+	idx := fieldsByPath(t, got)
+
+	// Project tag stripped → per-key mismatch with empty Cloud side.
+	require.Contains(t, idx, "tags.Project",
+		"expected stripped-Project to surface as tags.Project drift; got fields: %v", keysOf(idx))
+	assert.Equal(t, "io-abc123", idx["tags.Project"].Snapshot)
+	assert.Equal(t, "", idx["tags.Project"].Cloud)
+
+	// Environment changed → per-key mismatch with both sides set.
+	require.Contains(t, idx, "tags.Environment",
+		"expected Environment value-change to surface as tags.Environment drift; got fields: %v", keysOf(idx))
+	assert.Equal(t, "prod", idx["tags.Environment"].Snapshot)
+	assert.Equal(t, "staging", idx["tags.Environment"].Cloud)
+
+	// AWS-managed prefix key MUST NOT surface even though the value differs.
+	assert.NotContains(t, idx, "tags.aws:cloudformation:stack-name",
+		"aws:* prefix tag must be filtered; surfacing it would be noise")
 }

--- a/pkg/drift/imported/compare_test.go
+++ b/pkg/drift/imported/compare_test.go
@@ -282,6 +282,55 @@ func TestCompare_DriftSemanticLabelFilter_PerPolicyPrefixes(t *testing.T) {
 	})
 }
 
+func TestCompare_DriftSemanticLabelFilter_TagDriftIgnorePrefixes(t *testing.T) {
+	// AWS-side parallel to the LabelDriftIgnorePrefixes test above:
+	// a policy populates TagDriftIgnorePrefixes (the field
+	// awsTagDriftPolicy() uses) and the comparator must respect it.
+	// Symmetric semantics — same filter behavior, separate field so
+	// each cloud's helper reads naturally at the call site (#568).
+	tfType := registerSyntheticPolicy(t, policy.Map{
+		"tags": {
+			DriftSemantic:          policy.DriftSemanticLabelFilter,
+			TagDriftIgnorePrefixes: []string{"aws:", "eks:", "kubernetes.io/"},
+		},
+	})
+
+	t.Run("aws-managed prefix keys filtered, user keys match -> no mismatch", func(t *testing.T) {
+		snap := json.RawMessage(`{"tags":{"Project":"prod","Owner":"team"}}`)
+		live := json.RawMessage(`{"tags":{"Project":"prod","Owner":"team","aws:cloudformation:stack-name":"x","eks:cluster-name":"c1","kubernetes.io/cluster/foo":"owned"}}`)
+		got := Compare(tfType, snap, live)
+		assert.Empty(t, got, "aws-prefix / eks: / kubernetes.io/ keys must be filtered before compare")
+	})
+
+	t.Run("user-key drift emits per-key mismatch, aws-prefix noise filtered", func(t *testing.T) {
+		snap := json.RawMessage(`{"tags":{"Project":"prod","aws:cloudformation:stack-name":"x"}}`)
+		live := json.RawMessage(`{"tags":{"Project":"staging","aws:cloudformation:stack-name":"y"}}`)
+		got := Compare(tfType, snap, live)
+		require.Len(t, got, 1, "expected one per-key mismatch on tags.Project")
+		assert.Equal(t, "tags.Project", got[0].Field)
+		assert.Equal(t, "prod", got[0].Snapshot)
+		assert.Equal(t, "staging", got[0].Cloud)
+	})
+}
+
+func TestCompare_DriftSemanticLabelFilter_UnionsBothPrefixFields(t *testing.T) {
+	// A policy can populate both LabelDriftIgnorePrefixes (GCP-style)
+	// and TagDriftIgnorePrefixes (AWS-style) — the comparator unions
+	// them before filtering. Exercised here so a future refactor that
+	// drops one of the fields surfaces immediately.
+	tfType := registerSyntheticPolicy(t, policy.Map{
+		"tags": {
+			DriftSemantic:            policy.DriftSemanticLabelFilter,
+			LabelDriftIgnorePrefixes: []string{"goog-"},
+			TagDriftIgnorePrefixes:   []string{"aws:"},
+		},
+	})
+	snap := json.RawMessage(`{"tags":{"Project":"p","goog-x":"a","aws:y":"b"}}`)
+	live := json.RawMessage(`{"tags":{"Project":"p","goog-x":"different","aws:y":"different"}}`)
+	got := Compare(tfType, snap, live)
+	assert.Empty(t, got, "both goog-* and aws:* keys must be filtered when both prefix fields are set")
+}
+
 func TestCompare_DriftSemanticLabelFilter_NestedPath(t *testing.T) {
 	// A label-shaped attribute nested inside a singleton block — the
 	// per-key Field must use the policy path as its parent so the


### PR DESCRIPTION
Closes #568.

## Summary

- Adds `awsTagDriftPolicy()` — the AWS-side parallel to `gcpLabelDriftPolicy()` — so user-set AWS tags become a curated drift signal. The canonical motivator: an operator stripping the `Project = <project>` tag out-of-band currently slips past drift detection, silently breaking InsideOut inspector attribution (`CLAUDE.md` "Project tag is required" / #81 backstory).
- New `FieldPolicy.TagDriftIgnorePrefixes` field — separate from the GCP-named `LabelDriftIgnorePrefixes` so each cloud's helper reads naturally at the call site; the comparator unions both fields before filtering keys, so cross-cloud synthetic policies can populate both.
- Initial opt-in adopters (6 AWS types): `aws_s3_bucket`, `aws_dynamodb_table`, `aws_db_instance`, `aws_sqs_queue`, `aws_secretsmanager_secret` (symmetric with `google_secret_manager_secret`), `aws_cloudwatch_log_group`.

## Decision: AWS ignore-prefix set

- `aws:` — reserved AWS-system prefix (e.g. `aws:cloudformation:stack-name`, `aws:autoscaling:groupName`). Terraform does not own these; the AWS API rejects attempts to set them.
- `eks:` — EKS-managed tags propagated onto cluster-owned resources (`eks:cluster-name`, `eks:nodegroup-name`).
- `elasticbeanstalk:` — Beanstalk environment tags auto-applied across the environment.
- `kubernetes.io/` — K8s on AWS convention (cloud provider + AWS Load Balancer Controller), e.g. `kubernetes.io/cluster/<name>`, `kubernetes.io/role/elb`.
- `InsideOut` / `insideout-` — composer / importer provenance (mirror of GCP's `insideout-import`); both casings since AWS tag keys are case-sensitive.

Per-policy adoption is intentional: noisy types (e.g. `aws_autoscaling_group` where EKS / Karpenter / ASG-internal writes churn the tag bag) stay on `tagPolicy()`. Further adopters can land in follow-up PRs without infrastructure changes.

## Files touched

- `pkg/composer/imported/policy/policy.go` — helper, prefix set, struct field
- `pkg/composer/imported/policy/axes_test.go` — `TestSharedPolicies` extended + new `TestAWSTagDriftIgnorePrefixes`
- 6 `aws_*.policy.go` files — adopt `awsTagDriftPolicy()` on `tags` / `tags_all`
- `pkg/drift/imported/compare.go` — `mergePrefixes(label, tag)` helper; LabelFilter dispatch consults both fields
- `pkg/drift/imported/compare_test.go` — new `TestCompare_DriftSemanticLabelFilter_TagDriftIgnorePrefixes` + `TestCompare_DriftSemanticLabelFilter_UnionsBothPrefixFields`
- `pkg/drift/imported/compare_curated_test.go` — `TestCompare_Curated_AWSS3Bucket` + `TestCompare_Curated_AWSCloudwatchLogGroup_Exact` updated for per-key tag emission; new `TestCompare_Curated_AWSTags_AWSManagedPrefixIgnored` + `TestCompare_Curated_AWSTags_UserManagedKeyDriftSurfaced`
- `cmd/imported-codegen/testdata/drift_fields/drift-fields.json` — regenerated (+48 lines for the six adopters)

## Test plan

- [x] `go test ./pkg/composer/imported/policy/... ./pkg/drift/imported/... ./cmd/imported-codegen/...` — 874 pass
- [x] `go test ./...` — 5181 pass across 36 packages
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `drift-fields.json` golden regenerated and diff verified (6 types × 2 paths × LabelFilter)