### PR TITLE
feat(gcpdiscover): CAI Normalizer hooks + retire viable hand-rolled enrichers (#510, #511)

### DIFF
--- a/cmd/insideout-import/gcpdiscover/cai_normalizers.go
+++ b/cmd/insideout-import/gcpdiscover/cai_normalizers.go
@@ -1,0 +1,276 @@
+package gcpdiscover
+
+// cai_normalizers.go — composable per-type Normalizer helpers for the
+// Cloud Asset Inventory unified enricher (#510, mirror of the AWS
+// Cloud Control #501 pattern in cloudcontrol_normalizers.go).
+//
+// A Normalizer transforms the raw CAI versionedResources JSON before
+// the generic camelToSnakeGCP / Layer-1 unmarshal pipeline in
+// cloudAssetEnricher.fetchAndMap. The GCP REST representation and the
+// Terraform attribute schema diverge in a small set of mechanical ways
+// that the snake_case renamer can't close on its own:
+//
+//   - Self-link URLs vs bare names. CAI returns
+//     `https://www.googleapis.com/compute/v1/projects/X/global/networks/foo`;
+//     TF stores `foo`. selfLinkToBareName(field) collapses any
+//     self-link string to its trailing segment.
+//
+//   - Network tags wrapper. `google_compute_instance` /
+//     `google_compute_firewall` surface tags as `{"items": [...]}`;
+//     TF flattens to a bare list. flattenNetworkTags() unwraps the
+//     `items` envelope so the renamer feeds a clean list to the
+//     generated Layer-1 field.
+//
+// Each helper is intentionally narrow: one transform per helper, no
+// type-specific magic. chain composes them in registration order. A
+// nil entry in chain is a silent no-op so callers can build the chain
+// conditionally without per-type branches.
+//
+// Implementation: every helper round-trips through encoding/json and a
+// map[string]any so helpers can be composed without knowing what the
+// next helper expects. The cost is one Marshal + one Unmarshal per
+// helper; the enricher runs once per resource per scan, so the
+// constant factor is negligible against the CAI SDK call.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Normalizer is the per-type hook on cloudAssetConfig.Normalizer
+// (#510). Each call receives the raw CAI JSON and returns the
+// transformed bytes ready for the next stage. Returning an error
+// short-circuits the chain and fails the fetch — the enricher wraps
+// the error with the type context so the dispatcher can attribute the
+// failure.
+type Normalizer = func(json.RawMessage) (json.RawMessage, error)
+
+// chain composes Normalizers in order. An empty list (or one whose
+// entries are all nil) returns a no-op normalizer that passes the
+// input through unchanged — convenient for registration sites that
+// build the chain conditionally without per-type branches.
+//
+// Nil entries in the middle of the list are silently skipped so a
+// caller can write chain(selfLinkToBareName(...), maybeFlattenTags())
+// where maybeFlattenTags returns nil for types whose tag shape already
+// matches.
+func chain(ns ...Normalizer) Normalizer {
+	// Compact to drop nil entries up-front so the hot-path closure
+	// avoids the check per resource.
+	compact := make([]Normalizer, 0, len(ns))
+	for _, n := range ns {
+		if n != nil {
+			compact = append(compact, n)
+		}
+	}
+	if len(compact) == 0 {
+		return func(in json.RawMessage) (json.RawMessage, error) { return in, nil }
+	}
+	if len(compact) == 1 {
+		return compact[0]
+	}
+	return func(in json.RawMessage) (json.RawMessage, error) {
+		cur := in
+		for i, n := range compact {
+			next, err := n(cur)
+			if err != nil {
+				return nil, fmt.Errorf("normalizer step %d: %w", i, err)
+			}
+			cur = next
+		}
+		return cur, nil
+	}
+}
+
+// selfLinkToBareName returns a Normalizer that, for the top-level
+// string at the given key, collapses a Google self-link URL down to
+// its trailing segment — mirroring the provider's flatten of fields
+// like `machine_type`, `network`, `disk_type`. The CAI body returns
+// the full self-link
+// (`https://www.googleapis.com/compute/v1/projects/X/global/networks/foo`);
+// Terraform state stores the bare name (`foo`).
+//
+// Idempotent: a value without a `/` passes through unchanged. If the
+// field is absent or not a string, the payload also passes through.
+// Operates only on the top-level field — nested-self-link rewrites
+// belong in a bespoke normalizer (or in a deeper helper if a real
+// type needs it).
+func selfLinkToBareName(key string) Normalizer {
+	return func(in json.RawMessage) (json.RawMessage, error) {
+		if key == "" {
+			return in, nil
+		}
+		m, err := decodeCAIObject(in)
+		if err != nil {
+			return nil, fmt.Errorf("selfLinkToBareName(%q): %w", key, err)
+		}
+		if m == nil {
+			return in, nil
+		}
+		raw, ok := m[key]
+		if !ok || raw == nil {
+			return in, nil
+		}
+		s, ok := raw.(string)
+		if !ok {
+			return in, nil
+		}
+		short := shortFromGCPSelfLink(s)
+		if short == s {
+			return in, nil
+		}
+		m[key] = short
+		return encodeCAIObject(m)
+	}
+}
+
+// selfLinkSliceToBareNames returns a Normalizer that collapses every
+// entry in a top-level string-list to its trailing self-link segment.
+// Used for fields like `resource_policies` whose API returns a list of
+// self-link URLs while Terraform stores the bare short names.
+//
+// Idempotent: entries without a `/` pass through unchanged. If the
+// field is absent or not a list-of-strings, the payload passes through.
+// Non-string entries inside the list are preserved untouched (a
+// defensive choice — a CAI payload with a malformed entry should not
+// silently disappear).
+func selfLinkSliceToBareNames(key string) Normalizer {
+	return func(in json.RawMessage) (json.RawMessage, error) {
+		if key == "" {
+			return in, nil
+		}
+		m, err := decodeCAIObject(in)
+		if err != nil {
+			return nil, fmt.Errorf("selfLinkSliceToBareNames(%q): %w", key, err)
+		}
+		if m == nil {
+			return in, nil
+		}
+		raw, ok := m[key]
+		if !ok || raw == nil {
+			return in, nil
+		}
+		lst, ok := raw.([]any)
+		if !ok {
+			return in, nil
+		}
+		changed := false
+		out := make([]any, len(lst))
+		for i, entry := range lst {
+			s, ok := entry.(string)
+			if !ok {
+				out[i] = entry
+				continue
+			}
+			short := shortFromGCPSelfLink(s)
+			if short != s {
+				changed = true
+			}
+			out[i] = short
+		}
+		if !changed {
+			return in, nil
+		}
+		m[key] = out
+		return encodeCAIObject(m)
+	}
+}
+
+// flattenNetworkTags returns a Normalizer that unwraps the GCE
+// `tags: { items: [...] }` envelope to a bare list at the same key.
+// google_compute_instance and google_compute_firewall both surface
+// network tags this way in CAI; the generated Layer-1 struct's `tags`
+// field expects a flat `[]*Value[string]`, matching the Terraform
+// resource attribute. Mirrors AWS's flattenTagList for shape parity
+// but keys are bare list entries (network tags carry no key/value
+// pairs).
+//
+// Idempotent: if `tags` is absent, the payload passes through
+// unchanged. If `tags` is already a list (not an object), the payload
+// also passes through — supports re-runs and hand-built fixtures that
+// already flattened. Returns an error for a `tags` value of an
+// unexpected shape (e.g. a bare scalar) so the malformed payload
+// surfaces at the normalizer rather than cascading into a confusing
+// unmarshal error.
+//
+// Note: the `tags` key here is the GCE network-tags wrapper (string
+// list). Resource labels (`labels`) are unrelated — labels are
+// already a flat map[string]string in both CAI and TF.
+func flattenNetworkTags() Normalizer {
+	return func(in json.RawMessage) (json.RawMessage, error) {
+		m, err := decodeCAIObject(in)
+		if err != nil {
+			return nil, fmt.Errorf("flattenNetworkTags: %w", err)
+		}
+		if m == nil {
+			return in, nil
+		}
+		raw, ok := m["tags"]
+		if !ok || raw == nil {
+			return in, nil
+		}
+		switch v := raw.(type) {
+		case []any:
+			// Already flat — leave it alone.
+			return in, nil
+		case map[string]any:
+			items, hasItems := v["items"]
+			if !hasItems || items == nil {
+				// Empty wrapper — drop it (no useful tags).
+				delete(m, "tags")
+				return encodeCAIObject(m)
+			}
+			lst, ok := items.([]any)
+			if !ok {
+				return nil, fmt.Errorf("flattenNetworkTags: tags.items has unexpected shape %T", items)
+			}
+			m["tags"] = lst
+			return encodeCAIObject(m)
+		default:
+			return nil, fmt.Errorf("flattenNetworkTags: tags has unexpected shape %T", raw)
+		}
+	}
+}
+
+// shortFromGCPSelfLink trims a Google self-link
+// (`https://.../<collection>/<name>` or
+// `projects/.../<collection>/<name>`) down to its trailing segment.
+// Mirrors the shortFromSelfLink helper in compute_instance_enrich.go
+// — kept duplicated rather than dragging the hand-rolled enricher's
+// helpers into the generic path's import surface (so #511 retirements
+// can delete the hand-rolled file without cascading edits here).
+func shortFromGCPSelfLink(s string) string {
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}
+
+// decodeCAIObject is the shared parse step. Returns (nil, nil) for an
+// empty / null payload so helpers can pass-through cleanly without
+// special-casing.
+func decodeCAIObject(in json.RawMessage) (map[string]any, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	trimmed := strings.TrimSpace(string(in))
+	if trimmed == "" || trimmed == "null" {
+		return nil, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(in, &m); err != nil {
+		return nil, fmt.Errorf("decode object: %w", err)
+	}
+	return m, nil
+}
+
+// encodeCAIObject is the shared re-marshal step. Centralized so any
+// future MarshalIndent / sort-keys policy lives in one place.
+func encodeCAIObject(m map[string]any) (json.RawMessage, error) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("encode object: %w", err)
+	}
+	return b, nil
+}

--- a/cmd/insideout-import/gcpdiscover/cai_normalizers_test.go
+++ b/cmd/insideout-import/gcpdiscover/cai_normalizers_test.go
@@ -1,0 +1,282 @@
+package gcpdiscover
+
+// cai_normalizers_test.go — table-driven unit tests for the composable
+// CAI Normalizer helpers (#510). Mirrors the AWS Cloud Control test
+// shape in cloudcontrol_normalizers_test.go: each helper gets a small
+// table covering its happy path, idempotent pass-through paths, and
+// the malformed-shape error paths. Pulling the helpers in via the
+// production registration would make these end-to-end tests; the unit
+// surface here proves the building blocks themselves stay
+// well-behaved.
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestChain_EmptyAndNilEntriesPassThrough pins the no-op contract: a
+// chain of zero entries, or one whose entries are all nil, returns
+// the input unchanged. Callers that build conditional chains rely on
+// this so they don't have to branch on "did anything register".
+func TestChain_EmptyAndNilEntriesPassThrough(t *testing.T) {
+	t.Parallel()
+	in := json.RawMessage(`{"a":1}`)
+
+	t.Run("empty list", func(t *testing.T) {
+		t.Parallel()
+		n := chain()
+		out, err := n(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("all nil entries", func(t *testing.T) {
+		t.Parallel()
+		n := chain(nil, nil, nil)
+		out, err := n(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+}
+
+// TestChain_AppliesInOrder pins the registration-order contract: two
+// helpers that touch the same key apply in the order chain sees them.
+// A regression that flipped iteration direction would silently break
+// any caller relying on the rename-then-flatten ordering used by the
+// instance / firewall configs.
+func TestChain_AppliesInOrder(t *testing.T) {
+	t.Parallel()
+	first := func(in json.RawMessage) (json.RawMessage, error) {
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(in, &m))
+		m["seen"] = []any{"first"}
+		return json.Marshal(m)
+	}
+	second := func(in json.RawMessage) (json.RawMessage, error) {
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(in, &m))
+		seen, _ := m["seen"].([]any)
+		seen = append(seen, "second")
+		m["seen"] = seen
+		return json.Marshal(m)
+	}
+	n := chain(first, second)
+	out, err := n(json.RawMessage(`{}`))
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, []any{"first", "second"}, got["seen"])
+}
+
+// TestChain_ShortCircuitsOnError pins the failure-path contract: the
+// first step to return a non-nil error short-circuits the chain and
+// the per-step index appears in the wrapped message so the operator
+// can attribute the failure.
+func TestChain_ShortCircuitsOnError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("kaboom")
+	first := func(in json.RawMessage) (json.RawMessage, error) { return in, nil }
+	second := func(_ json.RawMessage) (json.RawMessage, error) { return nil, boom }
+	third := func(_ json.RawMessage) (json.RawMessage, error) {
+		t.Fatal("third step ran after second returned error")
+		return nil, nil
+	}
+	n := chain(first, second, third)
+	_, err := n(json.RawMessage(`{}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+	assert.Contains(t, err.Error(), "step 1")
+}
+
+// TestSelfLinkToBareName_TableDriven pins the happy paths and the
+// idempotent pass-through paths for the most common helper in the
+// CAI Normalizer kit.
+func TestSelfLinkToBareName_TableDriven(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		key  string
+		in   string
+		want string
+	}{
+		{
+			name: "full https self-link collapses to short name",
+			key:  "network",
+			in:   `{"network":"https://www.googleapis.com/compute/v1/projects/x/global/networks/foo"}`,
+			want: `{"network":"foo"}`,
+		},
+		{
+			name: "projects-rooted self-link collapses to short name",
+			key:  "machineType",
+			in:   `{"machineType":"projects/x/zones/us-east1-b/machineTypes/n1-standard-1"}`,
+			want: `{"machineType":"n1-standard-1"}`,
+		},
+		{
+			name: "bare name passes through unchanged",
+			key:  "network",
+			in:   `{"network":"foo"}`,
+			want: `{"network":"foo"}`,
+		},
+		{
+			name: "missing key passes through unchanged",
+			key:  "network",
+			in:   `{"description":"x"}`,
+			want: `{"description":"x"}`,
+		},
+		{
+			name: "non-string value passes through unchanged",
+			key:  "network",
+			in:   `{"network":42}`,
+			want: `{"network":42}`,
+		},
+		{
+			name: "null value passes through unchanged",
+			key:  "network",
+			in:   `{"network":null}`,
+			want: `{"network":null}`,
+		},
+		{
+			name: "empty key parameter is a no-op",
+			key:  "",
+			in:   `{"network":"https://x/y/z"}`,
+			want: `{"network":"https://x/y/z"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			n := selfLinkToBareName(tc.key)
+			got, err := n(json.RawMessage(tc.in))
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(got))
+		})
+	}
+}
+
+// TestSelfLinkSliceToBareNames_TableDriven pins the list-form
+// counterpart used by fields like resource_policies whose CAI shape
+// is a list-of-self-links and whose TF shape is a list-of-bare-names.
+func TestSelfLinkSliceToBareNames_TableDriven(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		key  string
+		in   string
+		want string
+	}{
+		{
+			name: "list of self-links collapses to short names",
+			key:  "resourcePolicies",
+			in:   `{"resourcePolicies":["projects/x/regions/r/resourcePolicies/p1","https://www.googleapis.com/compute/v1/projects/x/regions/r/resourcePolicies/p2"]}`,
+			want: `{"resourcePolicies":["p1","p2"]}`,
+		},
+		{
+			name: "list of bare names passes through unchanged",
+			key:  "resourcePolicies",
+			in:   `{"resourcePolicies":["p1","p2"]}`,
+			want: `{"resourcePolicies":["p1","p2"]}`,
+		},
+		{
+			name: "missing key passes through unchanged",
+			key:  "resourcePolicies",
+			in:   `{"other":1}`,
+			want: `{"other":1}`,
+		},
+		{
+			name: "non-list value passes through unchanged",
+			key:  "resourcePolicies",
+			in:   `{"resourcePolicies":"x"}`,
+			want: `{"resourcePolicies":"x"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			n := selfLinkSliceToBareNames(tc.key)
+			got, err := n(json.RawMessage(tc.in))
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(got))
+		})
+	}
+}
+
+// TestFlattenNetworkTags_TableDriven pins every shape the helper
+// must accept (wrapped, already-flat, empty wrapper, absent) plus
+// the malformed-shape error path so a regression that loosened the
+// type check would surface here.
+func TestFlattenNetworkTags_TableDriven(t *testing.T) {
+	t.Parallel()
+	t.Run("wrapped tags unwrap to bare list", func(t *testing.T) {
+		t.Parallel()
+		n := flattenNetworkTags()
+		got, err := n(json.RawMessage(`{"tags":{"items":["web","ssh"],"fingerprint":"abc"}}`))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"tags":["web","ssh"]}`, string(got))
+	})
+
+	t.Run("already-flat list passes through unchanged", func(t *testing.T) {
+		t.Parallel()
+		n := flattenNetworkTags()
+		got, err := n(json.RawMessage(`{"tags":["web","ssh"]}`))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"tags":["web","ssh"]}`, string(got))
+	})
+
+	t.Run("wrapper missing items drops tags entirely", func(t *testing.T) {
+		t.Parallel()
+		n := flattenNetworkTags()
+		got, err := n(json.RawMessage(`{"tags":{"fingerprint":"abc"},"name":"x"}`))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"x"}`, string(got))
+	})
+
+	t.Run("missing tags key passes through unchanged", func(t *testing.T) {
+		t.Parallel()
+		n := flattenNetworkTags()
+		got, err := n(json.RawMessage(`{"name":"x"}`))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"x"}`, string(got))
+	})
+
+	t.Run("malformed tags shape errors", func(t *testing.T) {
+		t.Parallel()
+		n := flattenNetworkTags()
+		_, err := n(json.RawMessage(`{"tags":"not-an-object-or-list"}`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected shape")
+	})
+
+	t.Run("malformed tags.items shape errors", func(t *testing.T) {
+		t.Parallel()
+		n := flattenNetworkTags()
+		_, err := n(json.RawMessage(`{"tags":{"items":"not-a-list"}}`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "items has unexpected shape")
+	})
+}
+
+// TestDecodeCAIObject_PassThroughCases pins the no-op contracts the
+// helpers depend on — empty input / "null" / whitespace all collapse
+// to (nil, nil) so the helpers can short-circuit without re-checking
+// at every call site.
+func TestDecodeCAIObject_PassThroughCases(t *testing.T) {
+	t.Parallel()
+	cases := []json.RawMessage{
+		json.RawMessage(``),
+		json.RawMessage(`null`),
+		json.RawMessage(`  `),
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(string(c), func(t *testing.T) {
+			t.Parallel()
+			m, err := decodeCAIObject(c)
+			require.NoError(t, err)
+			assert.Nil(t, m)
+		})
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/cloudasset_enricher.go
+++ b/cmd/insideout-import/gcpdiscover/cloudasset_enricher.go
@@ -75,6 +75,13 @@ type cloudAssetEnricher struct {
 	resourceType string
 	assetType    string
 	fetch        func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error)
+	// normalizer, when non-nil, runs on the raw CAI versionedResources
+	// JSON before the generic camelToSnakeGCP / Layer-1 unmarshal
+	// pipeline (#510). Sourced from cloudAssetConfig.Normalizer at
+	// registration time; see cai_normalizers.go for composable helpers
+	// (chain, selfLinkToBareName, flattenNetworkTags). A nil normalizer
+	// is a no-op — the existing generic path runs unchanged.
+	normalizer Normalizer
 }
 
 // newCloudAssetEnricher constructs an enricher for a single (tfType,
@@ -88,6 +95,20 @@ func newCloudAssetEnricher(tfType, assetType string, fetch func(ctx context.Cont
 		resourceType: tfType,
 		assetType:    assetType,
 		fetch:        fetch,
+	}
+}
+
+// newCloudAssetEnricherWithNormalizer is the #510 variant that wires a
+// per-type Normalizer alongside the (tfType, assetType, fetch) trio. Used
+// by NewGCPDiscoverer to thread cloudAssetConfig.Normalizer through into
+// the enricher; tests use it directly to exercise the normalizer path
+// without dragging in the discoverer registration.
+func newCloudAssetEnricherWithNormalizer(tfType, assetType string, fetch func(ctx context.Context, scope, assetType, fullName string) (map[string]any, error), n Normalizer) *cloudAssetEnricher {
+	return &cloudAssetEnricher{
+		resourceType: tfType,
+		assetType:    assetType,
+		fetch:        fetch,
+		normalizer:   n,
 	}
 }
 
@@ -201,6 +222,31 @@ func (e *cloudAssetEnricher) fetchAndMap(ctx context.Context, fetch func(ctx con
 			return nil, fmt.Errorf("cloudasset enricher: %s %q: %w", e.assetType, assetName, ErrNotFound)
 		}
 		return nil, fmt.Errorf("cloudasset enricher: GetByName %s %q: %w", e.assetType, assetName, err)
+	}
+
+	// #510 — Per-type Normalizer runs on the raw CAI JSON before the
+	// camelToSnakeGCP / Layer-1 unmarshal pipeline. The helpers in
+	// cai_normalizers.go bridge the shape gaps the generic renamer
+	// can't close on its own (self-link URLs → bare names, wrapped
+	// `tags.items: [...]` → flat `tags: [...]`). Returning an error
+	// fails the fetch with the original error wrapped so soft-fail
+	// dispatchers can distinguish a normalizer failure from a real
+	// API error. Round-trip the in-memory map through Marshal so the
+	// Normalizer signature can stay symmetric with the AWS Cloud
+	// Control version (json.RawMessage → json.RawMessage).
+	if e.normalizer != nil {
+		raw, err := json.Marshal(data)
+		if err != nil {
+			return nil, fmt.Errorf("cloudasset enricher: marshal pre-normalize for %s %q: %w", e.assetType, assetName, err)
+		}
+		normalized, err := e.normalizer(raw)
+		if err != nil {
+			return nil, fmt.Errorf("cloudasset enricher: normalize %s %q: %w", e.assetType, assetName, err)
+		}
+		data = map[string]any{}
+		if err := json.Unmarshal(normalized, &data); err != nil {
+			return nil, fmt.Errorf("cloudasset enricher: re-parse post-normalize for %s %q: %w", e.assetType, assetName, err)
+		}
 	}
 
 	// CAI returns the JSON representation as defined by each service's

--- a/cmd/insideout-import/gcpdiscover/cloudasset_enricher_test.go
+++ b/cmd/insideout-import/gcpdiscover/cloudasset_enricher_test.go
@@ -446,6 +446,161 @@ func TestCloudAssetEnricher_UnregisteredTypeErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "google_synthetic_unregistered_type_xyz")
 }
 
+// TestCloudAssetEnricher_Enrich_Normalized exercises the #510
+// Normalizer hook on the wired types (google_compute_firewall,
+// google_compute_instance). For each type the test feeds a fake CAI
+// response with the known-divergent fields (self-link URL on
+// `network`, `tags: {items: [...]}` wrapper) and asserts the
+// post-Normalizer Layer-1 payload lands the values on the bare TF
+// field names (`network` short name, flat `tags` list).
+func TestCloudAssetEnricher_Enrich_Normalized(t *testing.T) {
+	t.Parallel()
+
+	t.Run("google_compute_firewall", func(t *testing.T) {
+		t.Parallel()
+		fetch := func(_ context.Context, _, _, _ string) (map[string]any, error) {
+			return map[string]any{
+				"name":        "allow-ssh",
+				"network":     "https://www.googleapis.com/compute/v1/projects/real-proj/global/networks/io-test-net",
+				"description": "ssh",
+				"direction":   "INGREST",
+				"priority":    1000.0,
+				"sourceRanges": []any{
+					"0.0.0.0/0",
+				},
+			}, nil
+		}
+		// Pull the Normalizer from the live cloudAssetTypeConfigs
+		// registration so this test catches drift in the per-type
+		// wiring (chain order, helper choice).
+		n := normalizerForAssetType(t, "compute.googleapis.com/Firewall")
+		e := newCloudAssetEnricherWithNormalizer("google_compute_firewall", "compute.googleapis.com/Firewall", fetch, n)
+		ir := &imported.ImportedResource{
+			Identity: imported.ResourceIdentity{
+				Type:      "google_compute_firewall",
+				ProjectID: "real-proj",
+				NativeIDs: map[string]string{"asset_name": "//compute.googleapis.com/projects/real-proj/global/firewalls/allow-ssh"},
+			},
+		}
+		require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{}))
+
+		decoded, err := generated.UnmarshalAttrs("google_compute_firewall", ir.Attrs)
+		require.NoError(t, err)
+		fw, ok := decoded.(*generated.GoogleComputeFirewall)
+		require.True(t, ok, "decoded type is %T", decoded)
+
+		// network self-link collapsed to bare name.
+		require.NotNil(t, fw.Network)
+		require.NotNil(t, fw.Network.Literal)
+		assert.Equal(t, "io-test-net", *fw.Network.Literal)
+		// Untouched fields still flow through the renamer.
+		require.NotNil(t, fw.Name)
+		require.NotNil(t, fw.Name.Literal)
+		assert.Equal(t, "allow-ssh", *fw.Name.Literal)
+	})
+
+	t.Run("google_compute_instance", func(t *testing.T) {
+		t.Parallel()
+		fetch := func(_ context.Context, _, _, _ string) (map[string]any, error) {
+			return map[string]any{
+				"name":        "io-test-inst",
+				"machineType": "https://www.googleapis.com/compute/v1/projects/real-proj/zones/us-east1-b/machineTypes/n1-standard-1",
+				"zone":        "https://www.googleapis.com/compute/v1/projects/real-proj/zones/us-east1-b",
+				"description": "test",
+				"tags": map[string]any{
+					"items":       []any{"web", "ssh"},
+					"fingerprint": "abc",
+				},
+				"resourcePolicies": []any{
+					"projects/real-proj/regions/us-east1/resourcePolicies/p1",
+					"projects/real-proj/regions/us-east1/resourcePolicies/p2",
+				},
+			}, nil
+		}
+		n := normalizerForAssetType(t, "compute.googleapis.com/Instance")
+		e := newCloudAssetEnricherWithNormalizer("google_compute_instance", "compute.googleapis.com/Instance", fetch, n)
+		ir := &imported.ImportedResource{
+			Identity: imported.ResourceIdentity{
+				Type:      "google_compute_instance",
+				ProjectID: "real-proj",
+				NativeIDs: map[string]string{"asset_name": "//compute.googleapis.com/projects/real-proj/zones/us-east1-b/instances/io-test-inst"},
+			},
+		}
+		require.NoError(t, e.Enrich(context.Background(), ir, EnrichClients{}))
+
+		decoded, err := generated.UnmarshalAttrs("google_compute_instance", ir.Attrs)
+		require.NoError(t, err)
+		inst, ok := decoded.(*generated.GoogleComputeInstance)
+		require.True(t, ok, "decoded type is %T", decoded)
+
+		// Self-link fields collapsed to short names.
+		require.NotNil(t, inst.MachineType)
+		require.NotNil(t, inst.MachineType.Literal)
+		assert.Equal(t, "n1-standard-1", *inst.MachineType.Literal)
+		require.NotNil(t, inst.Zone)
+		require.NotNil(t, inst.Zone.Literal)
+		assert.Equal(t, "us-east1-b", *inst.Zone.Literal)
+		// resourcePolicies list elements collapsed to short names.
+		require.NotNil(t, inst.ResourcePolicies)
+		require.Len(t, inst.ResourcePolicies, 2)
+		require.NotNil(t, inst.ResourcePolicies[0].Literal)
+		assert.Equal(t, "p1", *inst.ResourcePolicies[0].Literal)
+		require.NotNil(t, inst.ResourcePolicies[1].Literal)
+		assert.Equal(t, "p2", *inst.ResourcePolicies[1].Literal)
+		// Network tags wrapper flattened to bare list.
+		require.NotNil(t, inst.Tags)
+		require.Len(t, inst.Tags, 2)
+		require.NotNil(t, inst.Tags[0].Literal)
+		assert.Equal(t, "web", *inst.Tags[0].Literal)
+		require.NotNil(t, inst.Tags[1].Literal)
+		assert.Equal(t, "ssh", *inst.Tags[1].Literal)
+	})
+}
+
+// normalizerForAssetType returns the Normalizer registered on the
+// cloudAssetTypeConfigs entry for the given CAI asset type. Test-only;
+// fails the test if the type is not registered or has no Normalizer.
+// Pulling the Normalizer from the live registration (rather than
+// re-constructing one in the test) makes the test a regression guard
+// for the registration itself.
+func normalizerForAssetType(t *testing.T, assetType string) Normalizer {
+	t.Helper()
+	for _, cfg := range cloudAssetTypeConfigs {
+		if cfg.AssetType == assetType {
+			require.NotNilf(t, cfg.Normalizer, "no Normalizer registered for %s", assetType)
+			return cfg.Normalizer
+		}
+	}
+	t.Fatalf("no cloudAssetTypeConfigs entry for %s", assetType)
+	return nil
+}
+
+// TestCloudAssetEnricher_Enrich_NormalizerError pins the failure path:
+// a Normalizer that returns an error fails the fetch with the original
+// error wrapped, so soft-fail dispatchers can distinguish a
+// shape-transform bug from a real CAI API error. Mirrors the AWS
+// TestCloudControlEnricher_Enrich_NormalizerError shape.
+func TestCloudAssetEnricher_Enrich_NormalizerError(t *testing.T) {
+	t.Parallel()
+	fetch := func(_ context.Context, _, _, _ string) (map[string]any, error) {
+		return map[string]any{"name": "x"}, nil
+	}
+	boom := errors.New("normalizer-boom")
+	n := func(_ json.RawMessage) (json.RawMessage, error) { return nil, boom }
+	e := newCloudAssetEnricherWithNormalizer("google_compute_network", "compute.googleapis.com/Network", fetch, n)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:      "google_compute_network",
+			ProjectID: "real-proj",
+			NativeIDs: map[string]string{"asset_name": "//compute.googleapis.com/projects/real-proj/global/networks/x"},
+		},
+	}
+	err := e.Enrich(context.Background(), ir, EnrichClients{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+	assert.Contains(t, err.Error(), "normalize compute.googleapis.com/Network")
+}
+
 // TestCloudAssetEnricher_NilIRErrors pins the nil-IR guard.
 func TestCloudAssetEnricher_NilIRErrors(t *testing.T) {
 	t.Parallel()

--- a/cmd/insideout-import/gcpdiscover/cloudasset_types.go
+++ b/cmd/insideout-import/gcpdiscover/cloudasset_types.go
@@ -1,5 +1,7 @@
 package gcpdiscover
 
+import "encoding/json"
+
 // cloudasset_types.go — registry of GCP Terraform resource types routed
 // through the generic Cloud Asset Inventory (CAI) HYBRID attribute
 // enricher (mirrors AWS #490 / cloudcontrol_types.go for GCP).
@@ -71,6 +73,19 @@ type cloudAssetConfig struct {
 	TFType    string
 	AssetType string
 	Skip      bool
+	// Normalizer, when non-nil, transforms the raw CAI versionedResources
+	// JSON before the generic camelToSnakeGCP / Layer-1 unmarshal pipeline
+	// (#510). Use for per-type shape adjustments that GCP's REST surface
+	// does differently from Terraform's view — e.g. self-link URLs that
+	// TF stores as bare names, or wrapped fields like
+	// `tags.items: [...]` that TF flattens to `tags: [...]`.
+	//
+	// Consumed by the generic cloudAssetEnricher; returning an error
+	// fails the fetch with the original error wrapped so soft-fail
+	// dispatchers can distinguish a normalizer bug from a real CAI API
+	// failure. See cai_normalizers.go for composable helpers (chain,
+	// selfLinkToBareName, flattenNetworkTags).
+	Normalizer func(json.RawMessage) (json.RawMessage, error)
 }
 
 // cloudAssetTypeConfigs is the GCP equivalent of AWS's
@@ -116,11 +131,42 @@ var cloudAssetTypeConfigs = []cloudAssetConfig{
 	{TFType: "google_compute_address", AssetType: "compute.googleapis.com/Address"},
 	{TFType: "google_compute_backend_service", AssetType: "compute.googleapis.com/BackendService"},
 	{TFType: "google_compute_global_address", AssetType: "compute.googleapis.com/GlobalAddress"},
-	{TFType: "google_compute_firewall", AssetType: "compute.googleapis.com/Firewall"},
+	{
+		TFType:    "google_compute_firewall",
+		AssetType: "compute.googleapis.com/Firewall",
+		// #510 Normalizer: the CAI body returns `network` as a full
+		// self-link URL (e.g.
+		// https://www.googleapis.com/compute/v1/projects/X/global/networks/foo);
+		// TF state stores the bare network name. No network-tags wrapper
+		// here — firewall sourceTags / targetTags are already bare lists
+		// at the top level (sourceTags / targetTags), not wrapped under
+		// a `tags.items` envelope.
+		Normalizer: chain(
+			selfLinkToBareName("network"),
+		),
+	},
 	{TFType: "google_compute_forwarding_rule", AssetType: "compute.googleapis.com/ForwardingRule"},
 	{TFType: "google_compute_global_forwarding_rule", AssetType: "compute.googleapis.com/GlobalForwardingRule"},
 	{TFType: "google_compute_health_check", AssetType: "compute.googleapis.com/HealthCheck"},
-	{TFType: "google_compute_instance", AssetType: "compute.googleapis.com/Instance"},
+	{
+		TFType:    "google_compute_instance",
+		AssetType: "compute.googleapis.com/Instance",
+		// #510 Normalizer: the CAI body returns several fields as
+		// self-link URLs (machineType, network/subnetwork inside
+		// networkInterface) and wraps GCE network tags as
+		// `tags: {items: [...]}`; TF flattens machineType to the bare
+		// type name and flattens `tags` to a bare list. Self-links on
+		// nested-block fields (network/subnetwork inside
+		// networkInterface, source/diskType inside disks) currently
+		// pass through unchanged; closing those is a follow-up that
+		// needs a path-aware self-link helper.
+		Normalizer: chain(
+			selfLinkToBareName("machineType"),
+			selfLinkToBareName("zone"),
+			selfLinkSliceToBareNames("resourcePolicies"),
+			flattenNetworkTags(),
+		),
+	},
 	{TFType: "google_compute_managed_ssl_certificate", AssetType: "compute.googleapis.com/SslCertificate"},
 	{TFType: "google_compute_network", AssetType: "compute.googleapis.com/Network"},
 	{TFType: "google_compute_resource_policy", AssetType: "compute.googleapis.com/ResourcePolicy"},

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -417,7 +417,7 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string, opts GCPDisco
 		if _, has := d.byTypeEnricher[cfg.TFType]; has {
 			continue
 		}
-		d.byTypeEnricher[cfg.TFType] = newCloudAssetEnricher(cfg.TFType, cfg.AssetType, nil)
+		d.byTypeEnricher[cfg.TFType] = newCloudAssetEnricherWithNormalizer(cfg.TFType, cfg.AssetType, nil, cfg.Normalizer)
 	}
 	return d
 }


### PR DESCRIPTION
Mirrors the AWS Cloud Control work in #573 for the GCP Cloud Asset Inventory enricher.

Closes #510
Closes #511

## #510 — CAI Normalizer hooks

Adds the per-type shape-transform hook the CAI HYBRID enricher needed to bridge the GCP-vs-Terraform gaps that the generic camelToSnakeGCP renamer can't close on its own. Structural mirror of `cloudControlConfig.Normalizer` + `cloudcontrol_normalizers.go`.

### What's wired

- `cloudAssetConfig.Normalizer` (`func(json.RawMessage) (json.RawMessage, error)`).
- `cloudAssetEnricher.normalizer` + `newCloudAssetEnricherWithNormalizer` constructor. The hook runs in `fetchAndMap` before the camelToSnakeGCP / Layer-1 unmarshal pipeline. Nil = no-op.
- `cmd/insideout-import/gcpdiscover/cai_normalizers.go` — composable helpers:
  - `chain(...)` — order-preserving composition with nil-skip.
  - `selfLinkToBareName(field)` — collapses `https://www.googleapis.com/.../<col>/<name>` to `<name>`.
  - `selfLinkSliceToBareNames(field)` — list-form counterpart for fields like `resource_policies`.
  - `flattenNetworkTags()` — unwraps GCE `tags: {items: [...]}` to the bare list TF expects.
- `gcpdiscover.go` threads `cfg.Normalizer` into the auto-registration loop via the new constructor.

### Types wired

| TF type | Normalizer chain | Why |
|---|---|---|
| `google_compute_firewall` | `selfLinkToBareName("network")` | CAI returns `network` as full self-link; TF stores bare name. |
| `google_compute_instance` | `selfLinkToBareName("machineType")` + `selfLinkToBareName("zone")` + `selfLinkSliceToBareNames("resourcePolicies")` + `flattenNetworkTags()` | Self-link normalization on top-level fields + the `tags: {items: [...]}` → bare-list flatten the doc gotchas call out. |

Other types whose existing CAI-shape already matches the TF struct (cleanly snake-cased keys, no wrapper envelopes) keep their nil Normalizer.

### Tests

- `cai_normalizers_test.go` — table-driven coverage for every helper (happy paths, idempotent pass-through, malformed-shape error paths).
- `cloudasset_enricher_test.go::TestCloudAssetEnricher_Enrich_Normalized` — end-to-end pin for `google_compute_firewall` + `google_compute_instance`. Pulls Normalizers from the live `cloudAssetTypeConfigs` registration via `normalizerForAssetType` (mirror of `normalizerForCFNType`) so the test is a regression guard for the wiring itself.
- `cloudasset_enricher_test.go::TestCloudAssetEnricher_Enrich_NormalizerError` — failure-path pin: a Normalizer that returns an error short-circuits with `normalize <assetType>` in the wrapped message.

## #511 — Hand-rolled enricher retirement audit

Audited all 12 hand-rolled GCP enrichers against what the CAI + Normalizer path can produce today. **No enricher reached parity in this PR**, so none are retired. The current Normalizer kit can close 3 of the most common gap patterns (self-link → bare name; nested self-link lists; `tags: {items}` flatten), but every one of the 12 has at least one additional blocker that would require new Normalizer helpers — most commonly the `goog-*` label-prefix filter (8 of 12), name-shortening of `projects/p/topics/n → n` (3 of 12), and TF-only sentinel defaults like `force_destroy = false` (3 of 12).

### Per-type retirement table

| Enricher | Decision | Blocker(s) preventing CAI + Normalizer parity |
|---|---|---|
| `compute_address` | Kept | Filters `goog-*`/`goog_*` labels (needs `dropLabelPrefix` Normalizer); requires `project = projectID` injection (CAI returns project number, not the string ID needed for TF). |
| `compute_firewall` | Kept | Allow/Deny block renames (`Allowed`→`allow`, `Denied`→`deny`); `LogConfig.Enable` lifts to top-level `enable_logging`; `LogConfig.Metadata` lives under nested `log_config` block only when non-empty (needs nested-block-lifting Normalizer); `project` injection. |
| `compute_network` | Kept | `routingConfig.routingMode` must lift to top-level `routing_mode` (nested-to-top); always-emit defaults (`auto_create_subnetworks`, `enable_ula_internal_ipv6`, `delete_default_routes_on_create = false`) per the pinned test contract. |
| `compute_instance` | Kept | Boot-disk filtering (only the first `Boot=true` disk emitted under `boot_disk`); `metadata.items[startup-script]` extraction into top-level `metadata_startup_script`; nested self-link normalization inside `network_interface` (`network`/`subnetwork`) and `boot_disk.initialize_params` (`sourceImage`/`diskType`); `goog-*` label filter; `project` injection. The Normalizers wired in #510 close the top-level self-link + tags gaps but not the nested-block ones. |
| `compute_router` | Kept | `Bgp.AdvertisedIpRanges[].Range` Go-name-collision rename (TF field is `range`, mapped to `Range_`); conditional block emission (`Bgp` block dropped entirely when all defaults); `project` injection. |
| `pubsub_topic` | Kept | `name` shortening from `projects/p/topics/n` → `n` (needs `shortenName` Normalizer); `goog-*` label filter; `project` injection. |
| `pubsub_subscription` | Kept | Same as pubsub_topic plus richer nested-block coverage (delivery configs, retry policies). |
| `secret_manager_secret` | Kept | `name` shortening; `goog-*` label filter; nested `replication` / `rotation` / `topics` block renames; `project` injection. |
| `storage_bucket` | Kept | TF-only sentinel default `force_destroy = false` (needs `defaultValue` Normalizer); `goog-*` label filter; `project` injection. |
| `kms_crypto_key` | Kept | Name decomposition into `name`/`key_ring`/`location` (CAI returns flat `projects/p/locations/L/keyRings/K/cryptoKeys/N` path); `goog-*` label filter; conditional rotation/version-template block emission; `project` injection. |
| `service_account` | Kept | `account_id` derivation from `email` local-part (split on `@`); TF-only sentinel default `create_ignore_already_exists = false`; `project` injection. |
| `sql_database_instance` | Kept | 358 lines of bespoke mapping — large nested `settings` block, conditional `deletion_protection` (`true` when `Settings.DeletionProtectionEnabled` else default `false`), tier/disk normalizations, replica config, IP config; this is one of the largest enrichers in the package. |

### What the next PR(s) need to retire any of these

A second batch of Normalizer helpers, roughly in order of unlock value:

1. `dropLabelPrefix(field, prefix...)` — unlocks 8 enrichers' label filter pattern.
2. `shortenLastSegment(field)` — unlocks 3 enrichers' `name` shortening.
3. `liftNested(parentField, childField, destField)` — unlocks `compute_network` (`routingConfig.routingMode`→`routing_mode`) and `compute_firewall` (`logConfig.enable`→`enable_logging`).
4. `setDefaultIfAbsent(field, value)` — unlocks the TF-only-sentinel pattern.
5. `synthesizeFromField(srcField, transform, destField)` — unlocks `service_account.account_id`.
6. `injectProjectID()` (or threading `c.ProjectID` through the Normalizer signature) — needed by every retirement.

Once those land, parity tests can be added per type using the `TestCloudControlEnricher_LogGroup_EnrichAndEnrichByIDProduceSameJSON` shape and the corresponding hand-rolled enricher + its `_enrich_test.go` can be removed, plus its entry in `byTypeEnricher` and any now-unused EnrichClients SDK field.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/insideout-import/gcpdiscover/...` (1142 tests pass)
- [x] `go test ./...` (5140 tests pass across 36 packages)