### PR TITLE
feat: add aws/route53 preset module (#140)

### DIFF
--- a/aws/route53/main.tf
+++ b/aws/route53/main.tf
@@ -1,0 +1,136 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Module overview
+# -----------------------------------------------------------------------------
+# Owns a Route 53 public or private hosted zone (either created here or
+# looked up by ID) plus two flavours of records:
+#
+#   - `var.records`  — plain CNAME / A / AAAA / TXT / MX / SRV / NS / etc.
+#                      records with explicit TTL and values.
+#   - `var.aliases`  — A/AAAA alias records that point at an AWS service
+#                      endpoint (ALB, CloudFront, API Gateway, etc.). Alias
+#                      records have no TTL and require the target's hosted
+#                      zone ID.
+#
+# Scoping (issue #140 v1):
+#   - DNSSEC, cross-account delegation, vanity domain registration, and
+#     full ACM-cert issuance flows are out of scope for v1. ACM DNS-validation
+#     plumbing belongs in a future `aws/acm` preset (or a follow-up
+#     iteration of this module).
+
+module "name" {
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
+  luther_project = var.project
+  aws_region     = var.region
+  luther_env     = var.environment
+  org_name       = "luthersystems"
+  component      = "insideout"
+  subcomponent   = "dns"
+  resource       = "dns"
+}
+
+# -----------------------------------------------------------------------------
+# Hosted zone — either create or look up
+# -----------------------------------------------------------------------------
+# Exactly one of these resolves at any time:
+#   - create_zone=true  -> aws_route53_zone.this is created
+#   - create_zone=false -> data.aws_route53_zone.existing is queried
+#
+# Downstream resources reference local.zone_id, which selects the right
+# source based on create_zone.
+
+resource "aws_route53_zone" "this" {
+  count = var.create_zone ? 1 : 0
+
+  name          = var.domain_name
+  comment       = "Hosted zone for ${var.domain_name} (${var.project})"
+  force_destroy = var.force_destroy
+
+  # Private zone toggle requires at least one VPC association.
+  dynamic "vpc" {
+    for_each = var.private_zone ? toset(var.vpc_ids) : toset([])
+    content {
+      vpc_id = vpc.value
+    }
+  }
+
+  tags = merge(module.name.tags, var.tags)
+}
+
+data "aws_route53_zone" "existing" {
+  count = var.create_zone ? 0 : 1
+
+  zone_id      = var.zone_id
+  private_zone = var.private_zone
+}
+
+locals {
+  zone_id   = var.create_zone ? aws_route53_zone.this[0].zone_id : data.aws_route53_zone.existing[0].zone_id
+  zone_name = var.create_zone ? aws_route53_zone.this[0].name : data.aws_route53_zone.existing[0].name
+
+  # Build a stable map for plain records keyed by "<name>-<type>" so a
+  # caller can safely add/remove entries mid-stream without churning every
+  # subsequent record. Empty name ("") is the apex.
+  records_map = {
+    for r in var.records :
+    "${r.name}-${r.type}" => r
+  }
+
+  # Aliases keyed by "<name>" — alias records are A or AAAA, and Route 53
+  # allows only one record set per (name, type) per zone, so the name alone
+  # is sufficient when the caller stays in alias-A territory. For dual-stack
+  # callers, append "-${r.type}" if/when AAAA aliases are added.
+  aliases_map = {
+    for a in var.aliases :
+    "${a.name}-${try(a.type, "A")}" => a
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Plain records (CNAME / A / TXT / MX / SRV / AAAA / NS / etc.)
+# -----------------------------------------------------------------------------
+resource "aws_route53_record" "records" {
+  for_each = local.records_map
+
+  zone_id = local.zone_id
+  # Empty name maps to the apex; otherwise it's a subdomain label that
+  # Route 53 concatenates with the zone name.
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = each.value.ttl
+  records = each.value.values
+
+  # aws_route53_record does not accept a tags attribute (Route 53 record
+  # sets are not taggable resources in AWS). Tagging happens at the zone.
+}
+
+# -----------------------------------------------------------------------------
+# Alias records (ALB / CloudFront / API Gateway / etc.)
+# -----------------------------------------------------------------------------
+# Alias records cannot carry a TTL — the target's TTL governs caching.
+# `evaluate_target_health` only meaningfully toggles for ALB / NLB targets;
+# CloudFront and API Gateway require it to be false.
+resource "aws_route53_record" "aliases" {
+  for_each = local.aliases_map
+
+  zone_id = local.zone_id
+  name    = each.value.name
+  type    = try(each.value.type, "A")
+
+  alias {
+    name                   = each.value.target_dns_name
+    zone_id                = each.value.target_zone_id
+    evaluate_target_health = try(each.value.evaluate_target_health, false)
+  }
+
+  # aws_route53_record is not taggable; see note above.
+}

--- a/aws/route53/outputs.tf
+++ b/aws/route53/outputs.tf
@@ -1,0 +1,35 @@
+output "zone_id" {
+  description = "Route 53 hosted zone ID (works for both create_zone=true and false). Wire into downstream modules that need to attach records or build alias targets."
+  value       = local.zone_id
+}
+
+output "zone_arn" {
+  description = "ARN of the hosted zone (null when create_zone=false; the data source does not expose the ARN). Use this for IAM policies targeting the zone."
+  value       = var.create_zone ? aws_route53_zone.this[0].arn : null
+}
+
+output "zone_name" {
+  description = "Fully-qualified hosted zone name (e.g. example.com.). Useful when callers need to build FQDNs without reparsing var.domain_name."
+  value       = local.zone_name
+}
+
+output "name_servers" {
+  description = "Authoritative name servers for the hosted zone. Required for delegating a domain to Route 53 when create_zone = true and the registrar lives elsewhere."
+  value       = var.create_zone ? aws_route53_zone.this[0].name_servers : []
+}
+
+output "record_fqdns" {
+  description = "Map of record-key (\"<name>-<type>\") -> resolved FQDN, covering both plain records and aliases. Lets downstream callers reference the record without rebuilding the FQDN."
+  value = merge(
+    { for k, r in aws_route53_record.records : k => r.fqdn },
+    { for k, r in aws_route53_record.aliases : k => r.fqdn },
+  )
+}
+
+output "record_names" {
+  description = "List of all record short-names managed by this module (across both plain and alias records). Useful for assertions / discovery."
+  value = sort(concat(
+    [for r in aws_route53_record.records : r.name],
+    [for r in aws_route53_record.aliases : r.name],
+  ))
+}

--- a/aws/route53/variables.tf
+++ b/aws/route53/variables.tf
@@ -1,0 +1,172 @@
+variable "region" {
+  description = "AWS region (e.g., us-east-1). Route 53 itself is a global service, but the region is required for the provider and for module-name composition."
+  type        = string
+}
+
+variable "project" {
+  description = "Project name prefix used for tagging and naming"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,61}[a-z0-9]$", var.project))
+    error_message = "project must be lowercase alphanumeric with hyphens, 3-63 characters."
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g. production, staging, sandbox)"
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.environment)) > 0
+    error_message = "environment must be a non-empty string."
+  }
+}
+
+variable "domain_name" {
+  description = "Apex domain (e.g. example.com) for the hosted zone."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.domain_name)) > 0
+    error_message = "domain_name must be a non-empty string."
+  }
+
+  # Public hosted zones (and most private ones) require a syntactically
+  # valid DNS name. Allows trailing dot per RFC 1035 § 5.1; Route 53
+  # accepts either.
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\\.?$", var.domain_name))
+    error_message = "domain_name must be a syntactically valid DNS domain (RFC 1035 labels separated by dots)."
+  }
+}
+
+variable "create_zone" {
+  description = "If true, create a new Route 53 hosted zone for var.domain_name. If false, look up an existing zone via var.zone_id."
+  type        = bool
+  default     = false
+}
+
+variable "zone_id" {
+  description = "Existing Route 53 hosted zone ID. Required when create_zone = false; ignored when create_zone = true."
+  type        = string
+  default     = null
+
+  # Null-safe per Terraform's lack of short-circuit on ||.
+  validation {
+    condition     = var.zone_id == null ? true : can(regex("^Z[A-Z0-9]{1,31}$", var.zone_id))
+    error_message = "zone_id must look like a Route 53 zone ID (e.g. Z2FDTNDATAQYW2)."
+  }
+}
+
+variable "private_zone" {
+  description = "If true, the (created or queried) hosted zone is private. Private zones must be associated with at least one VPC."
+  type        = bool
+  default     = false
+}
+
+variable "vpc_ids" {
+  description = "VPC IDs to associate with a private hosted zone. Required when private_zone = true and create_zone = true; ignored otherwise."
+  type        = list(string)
+  default     = []
+}
+
+variable "force_destroy" {
+  description = "Allow `terraform destroy` to delete a created hosted zone even when it still contains record sets. Has no effect when create_zone = false."
+  type        = bool
+  default     = false
+}
+
+variable "records" {
+  description = <<-EOT
+    Plain record sets — CNAME / A / AAAA / TXT / MX / SRV / NS / PTR / SPF.
+    Each entry creates one `aws_route53_record` with an explicit TTL. Use
+    an empty `name` ("") to target the apex.
+
+    Example:
+      records = [
+        { name = "www",  type = "CNAME", ttl = 300, values = ["target.example.com"] },
+        { name = "",     type = "TXT",   ttl = 300, values = ["\"v=spf1 -all\""] },
+        { name = "mail", type = "MX",    ttl = 300, values = ["10 inbound.example.com"] },
+      ]
+  EOT
+  type = list(object({
+    name   = string
+    type   = string
+    ttl    = number
+    values = list(string)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for r in var.records :
+      contains(["A", "AAAA", "CNAME", "MX", "NS", "PTR", "SOA", "SPF", "SRV", "TXT", "CAA", "DS", "NAPTR"], r.type)
+    ])
+    error_message = "Each record.type must be one of A, AAAA, CNAME, MX, NS, PTR, SOA, SPF, SRV, TXT, CAA, DS, NAPTR. Use the `aliases` variable for alias records."
+  }
+
+  validation {
+    condition     = alltrue([for r in var.records : r.ttl >= 0 && r.ttl <= 2147483647])
+    error_message = "Each record.ttl must be a non-negative 32-bit integer (Route 53 max TTL is 2147483647 seconds)."
+  }
+
+  validation {
+    condition     = alltrue([for r in var.records : length(r.values) > 0])
+    error_message = "Each record must have at least one entry in `values`."
+  }
+}
+
+variable "aliases" {
+  description = <<-EOT
+    Alias records pointing at an AWS service endpoint (ALB, CloudFront,
+    API Gateway, S3 website, etc.). Alias records have no TTL — caching
+    is governed by the target. `type` defaults to "A"; set to "AAAA" only
+    for IPv6 alias targets. `evaluate_target_health` defaults to false
+    and must remain false for CloudFront / API Gateway targets.
+
+    Example:
+      aliases = [
+        {
+          name                   = ""          # apex
+          target_dns_name        = module.alb.alb_dns_name
+          target_zone_id         = module.alb.alb_zone_id
+          evaluate_target_health = true
+        },
+        {
+          name                   = "cdn"
+          target_dns_name        = module.cloudfront.domain_name
+          target_zone_id         = "Z2FDTNDATAQYW2"  # CloudFront's static zone
+        },
+      ]
+  EOT
+  type = list(object({
+    name                   = string
+    target_dns_name        = string
+    target_zone_id         = string
+    type                   = optional(string, "A")
+    evaluate_target_health = optional(bool, false)
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for a in var.aliases : contains(["A", "AAAA"], a.type)])
+    error_message = "alias.type must be A or AAAA (Route 53 alias records are restricted to these two types)."
+  }
+
+  validation {
+    condition     = alltrue([for a in var.aliases : length(trimspace(a.target_dns_name)) > 0])
+    error_message = "Each alias must specify a non-empty target_dns_name."
+  }
+
+  validation {
+    condition     = alltrue([for a in var.aliases : can(regex("^Z[A-Z0-9]{1,31}$", a.target_zone_id))])
+    error_message = "Each alias.target_zone_id must look like a Route 53 hosted-zone ID (e.g. Z2FDTNDATAQYW2 for CloudFront)."
+  }
+}
+
+variable "tags" {
+  description = "Common resource tags. Applied to the hosted zone (the only taggable Route 53 resource in this module)."
+  type        = map(string)
+  default     = {}
+}

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -69,6 +69,7 @@ var untaggableAWS = map[string]struct{}{
 	"aws_msk_configuration":                              {},
 	"aws_opensearchserverless_access_policy":             {},
 	"aws_opensearchserverless_security_policy":           {},
+	"aws_route53_record":                                 {},
 	"aws_s3_bucket_lifecycle_configuration":              {},
 	"aws_s3_bucket_ownership_controls":                   {},
 	"aws_s3_bucket_policy":                               {},

--- a/tests/lint-project-tag.sh
+++ b/tests/lint-project-tag.sh
@@ -56,6 +56,7 @@ NON_TAGGABLE_AWS=(
   aws_msk_configuration
   aws_opensearchserverless_access_policy
   aws_opensearchserverless_security_policy
+  aws_route53_record
   aws_s3_bucket_lifecycle_configuration
   aws_s3_bucket_ownership_controls
   aws_s3_bucket_policy


### PR DESCRIPTION
## Summary

Adds an `aws/route53` Terraform preset that owns a Route 53 hosted zone (created in-stack or looked up by ID) plus plain record sets and alias records. This is the v1 of issue #140 — the AWS preset on disk. The composer wiring, GCP parallel module, example stack, and ACM stretch goal are split into follow-up issues.

## What's in v1

- **`aws/route53/main.tf`** — `aws_route53_zone` (create or `data` lookup), `aws_route53_record` for `var.records` (CNAME / A / AAAA / TXT / MX / SRV / NS / etc.), `aws_route53_record` for `var.aliases` (A/AAAA alias to ALB / CloudFront / API Gateway).
- **`aws/route53/variables.tf`** — Matches the shape proposed in #140: `domain_name`, `create_zone`, `zone_id`, `private_zone`, `vpc_ids`, `force_destroy`, `records`, `aliases`, `tags`. Null-safe validations throughout (ternary, not `||`).
- **`aws/route53/outputs.tf`** — `zone_id`, `zone_arn`, `zone_name`, `name_servers`, `record_fqdns`, `record_names` for cross-module wiring.
- **`tests/lint-project-tag.sh`** — Adds `aws_route53_record` to `NON_TAGGABLE_AWS` (Route 53 record sets are not taggable in AWS provider 6.x). The hosted zone (the only taggable Route 53 resource in this module) carries `tags = merge(module.name.tags, var.tags)`.
- **`pkg/composer/imported_provenance.go`** — Mirrors the same addition into the Go-side `untaggableAWS` map. `TestUntaggableAllowlistsMatchLintScripts` keeps the two in sync.

## What's deferred (follow-up issues)

| Item | Issue |
|---|---|
| `gcp/cloud_dns` parallel preset | #583 |
| Composer wiring (`KeyAWSRoute53`, `ImplicitDependencies`, ALB / CloudFront / API Gateway / Cognito alias wiring, mapper updates) | #584 |
| Example stack: ALB + Route 53 custom domain | #585 |
| `aws/acm` preset (or fold ACM DNS validation into route53) | #586 |

The original acceptance list in #140 spanned 8 bullets; shipping the preset alone keeps this PR focused. The follow-ups are pre-filed so nothing falls through.

## Test plan

- [x] `terraform fmt -check -recursive` (clean)
- [x] `aws/route53` — `terraform init -backend=false && terraform validate` passes
- [x] `tests/validate-as-child.sh aws/route53` passes (preset works wrapped as a child module)
- [x] All eight repo lint scripts pass: `lint-project-tag.sh`, `lint-project-label.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`, `lint-no-root-only-blocks.sh`, `lint-labelless-name-prefix.sh`, `lint-gcp-project-pin.sh`, `lint-shared-no-cloud-providers.sh`, `lint-phantom-computed-fields.sh`, `lint-enrichgen-override-citations.sh`
- [x] `go build ./...` succeeds
- [x] `go test ./pkg/composer/ -count=1` — 1336 passed (includes `TestPresetDefaultsSatisfyValidations`, `TestEveryPresetHasResourceOrModuleCall`, `TestUntaggableAllowlistsMatchLintScripts`)
- [x] `go test ./... -count=1` — 5184 passed across 36 packages
- [x] `make verify-supported-resources` passes
- [x] `make verify-gen` passes
- [x] `make verify-phantom-schema` passes

Closes #140