### PR TITLE
feat(composer): wire aws/route53 with cross-module alias automation (#584)

### DIFF
--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -93,6 +93,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.AWSGitHubActions)
 	case KeyAWSCodePipeline:
 		return boolPtrTrue(c.AWSCodePipeline)
+	case KeyAWSRoute53:
+		return boolPtrTrue(c.AWSRoute53)
 	case KeyAWSBackups:
 		return c.AWSBackups != nil
 	// GCP pointer-typed selections.
@@ -283,7 +285,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
 		KeyAWSCognito, KeyAWSLambda, KeyAWSAPIGateway,
 		KeyAWSKMS, KeyAWSSecretsManager, KeyAWSOpenSearch,
-		KeyAWSBedrock, KeyAWSBackups,
+		KeyAWSBedrock, KeyAWSBackups, KeyAWSRoute53,
 		KeyGCPCompute, KeyGCPGKE, KeyGCPCloudRun,
 		KeyGCPCloudFunctions, KeyGCPLoadbalancer,
 		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -68,6 +68,7 @@ const (
 	KeyAWSBackups              ComponentKey = "aws_backups"
 	KeyAWSGitHubActions        ComponentKey = "aws_github_actions"
 	KeyAWSCodePipeline         ComponentKey = "aws_codepipeline"
+	KeyAWSRoute53              ComponentKey = "aws_route53"
 
 	// GCP components
 	KeyGCPVPC              ComponentKey = "gcp_vpc"
@@ -137,6 +138,9 @@ var ComposeOrder = []ComponentKey{
 	KeyGCPIdentityPlatform,
 	KeyAWSAPIGateway,
 	KeyGCPAPIGateway,
+	// Route 53 last so DefaultWiring can read ALB / CloudFront / API Gateway /
+	// Cognito siblings and auto-derive the matching alias records (#584).
+	KeyAWSRoute53,
 	KeyAWSKMS,
 	KeyGCPCloudKMS,
 	KeyAWSSecretsManager,
@@ -193,6 +197,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyAWSBastion:              "modules/bastion",
 	KeyAWSGitHubActions:        "modules/githubactions",
 	KeyAWSCodePipeline:         "modules/codepipeline",
+	KeyAWSRoute53:              "modules/route53",
 
 	// GCP
 	KeyGCPVPC:              "gcp/vpc",
@@ -359,6 +364,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyAWSBackups:              "backups",
 	KeyAWSGitHubActions:        "githubactions",
 	KeyAWSCodePipeline:         "codepipeline",
+	KeyAWSRoute53:              "route53",
 	KeyGCPVPC:                  "vpc",
 	KeyGCPCompute:              "compute",
 	KeyGCPGKE:                  "gke",
@@ -471,6 +477,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyAWSMSK,
 	KeyAWSOpenSearch,
 	KeyAWSRDS,
+	KeyAWSRoute53,
 	KeyAWSS3,
 	KeyAWSSQS,
 	KeyAWSSecretsManager,
@@ -716,6 +723,66 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		wi.RawHCL["scope"] = `"CLOUDFRONT"`
 		wi.RawHCL["region"] = `"us-east-1"`
 		wi.Names = append(wi.Names, "scope", "region")
+
+	case KeyAWSRoute53:
+		// Auto-emit alias records for in-stack endpoints (issue #584).
+		//
+		// Today's auto-aliases cover the two consumers whose presets already
+		// expose the (dns_name, zone_id) pair the alias-target shape needs:
+		//
+		//   - ALB:        module.aws_alb.alb_dns_name + .alb_zone_id, alias
+		//                 at the apex ("") with evaluate_target_health=true.
+		//   - CloudFront: module.aws_cloudfront.domain_name; CloudFront's
+		//                 hosted zone is the documented global static
+		//                 Z2FDTNDATAQYW2; alias at "cdn".
+		//                 evaluate_target_health must be false (CloudFront
+		//                 contract — no Route 53 health-check semantics on
+		//                 the global edge).
+		//
+		// Deferred (no preset outputs yet — TODO(#584-followup)):
+		//   - API Gateway: needs aws/apigateway to expose
+		//     aws_apigatewayv2_domain_name.api[0].domain_name_configuration[0]
+		//     {target_domain_name,hosted_zone_id} as outputs. Today they are
+		//     internal to the preset and the count=var.domain_name!=null gate
+		//     makes the outputs themselves nullable, so even after adding
+		//     them the wiring needs to gate on the user supplying a domain
+		//     to apigateway. Filed as a follow-up.
+		//   - Cognito: needs aws/cognito to manage an actual custom domain
+		//     (aws_cognito_user_pool_domain with `domain` instead of
+		//     `domain_prefix`) and surface its cloudfront_distribution_arn.
+		//     The current preset only manages the hosted UI prefix.
+		//
+		// The aliases HCL is emitted as a list literal of objects. Only
+		// emitted when at least one consumer is selected — leaving
+		// var.aliases at its preset default of `[]` when route53 is
+		// composed standalone (test contract: wiring stays inert when only
+		// one side is selected).
+		var aliasEntries []string
+		if hasALB {
+			aliasEntries = append(aliasEntries, `    {
+      name                   = ""
+      target_dns_name        = `+albRef(selected)+`.alb_dns_name
+      target_zone_id         = `+albRef(selected)+`.alb_zone_id
+      type                   = "A"
+      evaluate_target_health = true
+    }`)
+		}
+		if selected[KeyAWSCloudfront] {
+			// Z2FDTNDATAQYW2 is the documented global hosted-zone ID for
+			// every CloudFront distribution. evaluate_target_health must
+			// remain false for CloudFront alias targets.
+			aliasEntries = append(aliasEntries, `    {
+      name                   = "cdn"
+      target_dns_name        = `+WireRef(KeyAWSCloudfront, "domain_name")+`
+      target_zone_id         = "Z2FDTNDATAQYW2"
+      type                   = "A"
+      evaluate_target_health = false
+    }`)
+		}
+		if len(aliasEntries) > 0 {
+			wi.RawHCL["aliases"] = "[\n" + strings.Join(aliasEntries, ",\n") + ",\n  ]"
+			wi.Names = append(wi.Names, "aliases")
+		}
 
 	case KeyAWSCloudWatchMonitoring:
 		// When any per-component observability consumer is in the stack

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -66,6 +66,11 @@ var AWSIAMActions = map[ComponentKey][]string{
 	KeyAWSBackups:              {"backup:CreateBackupPlan", "backup:CreateBackupVault"},
 	KeyAWSGitHubActions:        {"iam:CreateOpenIDConnectProvider"},
 	KeyAWSCodePipeline:         {"codepipeline:CreatePipeline"},
+	// route53:CreateHostedZone covers the create_zone=true path; the data-
+	// lookup path (create_zone=false) needs only route53:GetHostedZone, which
+	// is implied by the create capability. Record-set CRUD is covered by
+	// ChangeResourceRecordSets (issued via change batches by the provider).
+	KeyAWSRoute53: {"route53:ChangeResourceRecordSets", "route53:CreateHostedZone"},
 }
 
 // RequiredAWSIAMActions returns the deduplicated, sorted list of IAM

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -573,6 +573,42 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+	case KeyAWSRoute53:
+		// Route 53 (#584). domain_name is required by the preset (no
+		// default); supply a preview-safe placeholder so single-module
+		// previews and validation runs succeed when the caller hasn't yet
+		// provided cfg.AWSRoute53.DomainName. The placeholder is a
+		// syntactically valid DNS name that obviously isn't a real domain
+		// — it'll fail the registrar/Route 53 check at apply time, which
+		// is the correct fail-loud surface (rather than a silent
+		// validation-time miss).
+		domain := "example.invalid"
+		if cfg != nil && cfg.AWSRoute53 != nil && strings.TrimSpace(cfg.AWSRoute53.DomainName) != "" {
+			domain = strings.TrimSpace(cfg.AWSRoute53.DomainName)
+		}
+		vals["domain_name"] = domain
+		if cfg != nil && cfg.AWSRoute53 != nil {
+			if cfg.AWSRoute53.CreateZone != nil {
+				vals["create_zone"] = *cfg.AWSRoute53.CreateZone
+			}
+			if cfg.AWSRoute53.ZoneID != "" {
+				vals["zone_id"] = cfg.AWSRoute53.ZoneID
+			}
+			if cfg.AWSRoute53.PrivateZone != nil {
+				vals["private_zone"] = *cfg.AWSRoute53.PrivateZone
+			}
+			if len(cfg.AWSRoute53.VPCIDs) > 0 {
+				vpcIDs := make([]any, len(cfg.AWSRoute53.VPCIDs))
+				for i, id := range cfg.AWSRoute53.VPCIDs {
+					vpcIDs[i] = id
+				}
+				vals["vpc_ids"] = vpcIDs
+			}
+			if cfg.AWSRoute53.ForceDestroy != nil {
+				vals["force_destroy"] = *cfg.AWSRoute53.ForceDestroy
+			}
+		}
+
 	case KeyAWSKMS:
 		if cfg != nil && cfg.AWSKMS != nil && cfg.AWSKMS.NumKeys != "" {
 			n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSKMS.NumKeys))

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -166,6 +166,14 @@ func kitchenSinkConfig() *Config {
 		ModelID           string `json:"modelId,omitempty"`
 		EmbeddingModelID  string `json:"embeddingModelId,omitempty"`
 	}{KnowledgeBaseName: "kb", ModelID: "anthropic.claude-3", EmbeddingModelID: "amazon.titan-embed"}
+	cfg.AWSRoute53 = &struct {
+		DomainName   string   `json:"domainName,omitempty"`
+		CreateZone   *bool    `json:"createZone,omitempty"`
+		ZoneID       string   `json:"zoneId,omitempty"`
+		PrivateZone  *bool    `json:"privateZone,omitempty"`
+		VPCIDs       []string `json:"vpcIds,omitempty"`
+		ForceDestroy *bool    `json:"forceDestroy,omitempty"`
+	}{DomainName: "example.com", CreateZone: &t, ZoneID: "Z1234567890ABC", VPCIDs: []string{"vpc-aaa"}, ForceDestroy: &t}
 
 	// GCP
 	cfg.GCPCompute = &struct {

--- a/pkg/composer/mapper_required_test.go
+++ b/pkg/composer/mapper_required_test.go
@@ -139,6 +139,7 @@ func kitchenSinkComponents() *Components {
 		AWSCognito:              &t,
 		AWSGitHubActions:        &t,
 		AWSCodePipeline:         &t,
+		AWSRoute53:              &t,
 		// GCP
 		GCPVPC:              &t,
 		GCPBastion:          &t,

--- a/pkg/composer/route53_wiring_test.go
+++ b/pkg/composer/route53_wiring_test.go
@@ -1,0 +1,290 @@
+package composer
+
+// route53_wiring_test.go covers the issue #584 composer wiring for the
+// aws/route53 preset:
+//
+//   - ComponentKey + PresetKeyMap + ModulePath + AllComponentKeys + ComposeOrder
+//     registry entries are exercised by TestAllComponentKeysCoversPresetKeyMap
+//     and TestMapperKeysSubsetOfModuleVariables (both in sibling files).
+//   - Default mapper provides every required variable — exercised by
+//     TestEveryRequiredVariableIsMappedOrWired.
+//
+// The tests below pin the cross-module alias auto-wiring contract:
+//   - When ALB / CloudFront is selected alongside Route 53, the composer
+//     auto-derives the matching aws_route53_record alias entry on the
+//     route53 module's `aliases` variable.
+//   - When neither ALB nor CloudFront is selected, the wiring stays inert
+//     and var.aliases falls back to its preset default ([]).
+//   - API Gateway and Cognito wiring are deferred — those presets don't yet
+//     expose target_dns_name / target_zone_id outputs. The tests below
+//     assert no `aliases` HCL is emitted for those keys today so a future
+//     PR adding the outputs has a single place to update.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultWiring_Route53_ALBAlias(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53: true,
+		KeyAWSALB:     true,
+		KeyAWSVPC:     true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	aliases, ok := wi.RawHCL["aliases"]
+	require.True(t, ok, "aliases must be wired when ALB is in the stack with Route 53")
+	require.Contains(t, aliases, "module.aws_alb.alb_dns_name",
+		"ALB alias must target module.aws_alb.alb_dns_name")
+	require.Contains(t, aliases, "module.aws_alb.alb_zone_id",
+		"ALB alias must use module.aws_alb.alb_zone_id (not a hardcoded zone)")
+	require.Contains(t, aliases, `evaluate_target_health = true`,
+		"ALB alias should set evaluate_target_health=true (ALB targets support health checks)")
+	require.Contains(t, aliases, `name                   = ""`,
+		"ALB alias should target the apex by default")
+	// The names slice tracks which inputs DefaultWiring claims responsibility for.
+	require.Contains(t, wi.Names, "aliases")
+}
+
+func TestDefaultWiring_Route53_CloudFrontAlias(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53:    true,
+		KeyAWSCloudfront: true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	aliases, ok := wi.RawHCL["aliases"]
+	require.True(t, ok, "aliases must be wired when CloudFront is in the stack with Route 53")
+	require.Contains(t, aliases, "module.aws_cloudfront.domain_name",
+		"CloudFront alias must target module.aws_cloudfront.domain_name")
+	require.Contains(t, aliases, `"Z2FDTNDATAQYW2"`,
+		"CloudFront alias must use the documented global hosted-zone ID Z2FDTNDATAQYW2")
+	require.Contains(t, aliases, `evaluate_target_health = false`,
+		"CloudFront alias must set evaluate_target_health=false (CloudFront contract)")
+	require.Contains(t, aliases, `name                   = "cdn"`,
+		"CloudFront alias should default to the `cdn` subdomain")
+}
+
+func TestDefaultWiring_Route53_ALBAndCloudFront(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53:    true,
+		KeyAWSALB:        true,
+		KeyAWSCloudfront: true,
+		KeyAWSVPC:        true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	aliases, ok := wi.RawHCL["aliases"]
+	require.True(t, ok, "aliases must be wired when both ALB and CloudFront are present")
+	require.Contains(t, aliases, "module.aws_alb.alb_dns_name", "ALB entry must be present")
+	require.Contains(t, aliases, "module.aws_cloudfront.domain_name", "CloudFront entry must be present")
+	// Both entries must be expressed in the same list literal.
+	entries := strings.Count(aliases, "target_dns_name")
+	require.Equal(t, 2, entries, "expected two alias entries (ALB + CloudFront), got %d", entries)
+}
+
+func TestDefaultWiring_Route53_InertWhenNoConsumers(t *testing.T) {
+	t.Parallel()
+
+	// Route 53 alone (no ALB / CloudFront / API Gateway / Cognito).
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53: true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	_, ok := wi.RawHCL["aliases"]
+	require.False(t, ok, "aliases must NOT be wired when no alias-target consumer is in the stack; var.aliases should fall back to the preset default []")
+	require.NotContains(t, wi.Names, "aliases", "Names should not advertise aliases when wiring is inert")
+}
+
+func TestDefaultWiring_Route53_APIGatewayDeferred(t *testing.T) {
+	t.Parallel()
+
+	// API Gateway wiring is deferred until aws/apigateway exposes
+	// target_domain_name / hosted_zone_id outputs. Until then, selecting
+	// API Gateway + Route 53 must NOT emit a stray alias entry referencing
+	// a non-existent output (which would surface as `unwired_output` from
+	// ValidateModuleWiring at compose time).
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53:    true,
+		KeyAWSAPIGateway: true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	if aliases, ok := wi.RawHCL["aliases"]; ok {
+		require.NotContains(t, aliases, "aws_apigateway",
+			"API Gateway alias wiring is deferred (#584 follow-up: aws/apigateway needs domain_name_configuration outputs)")
+	}
+}
+
+func TestDefaultWiring_Route53_CognitoDeferred(t *testing.T) {
+	t.Parallel()
+
+	// Cognito wiring is deferred until aws/cognito grows true custom-domain
+	// support (aws_cognito_user_pool_domain with `domain` + cloudfront
+	// distribution outputs).
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53: true,
+		KeyAWSCognito: true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	if aliases, ok := wi.RawHCL["aliases"]; ok {
+		require.NotContains(t, aliases, "aws_cognito",
+			"Cognito alias wiring is deferred (#584 follow-up: aws/cognito needs custom-domain support)")
+	}
+}
+
+// TestDefaultWiring_Route53_OtherKeysUntouched verifies the Route 53 case in
+// DefaultWiring doesn't accidentally fire for non-Route-53 component keys.
+// Without this guard a stray switch fall-through could pollute every
+// composed module with a stray `aliases` input.
+func TestDefaultWiring_Route53_OtherKeysUntouched(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53:    true,
+		KeyAWSALB:        true,
+		KeyAWSCloudfront: true,
+		KeyAWSVPC:        true,
+	}
+	for _, k := range []ComponentKey{KeyAWSALB, KeyAWSCloudfront, KeyAWSVPC, KeyAWSCognito, KeyAWSAPIGateway} {
+		wi := DefaultWiring(selected, k, &Components{})
+		_, ok := wi.RawHCL["aliases"]
+		require.False(t, ok, "DefaultWiring(%s) must not emit aliases — that's only on KeyAWSRoute53", k)
+	}
+}
+
+// TestMapper_Route53_DefaultDomainName verifies the mapper supplies a
+// placeholder domain_name when the caller hasn't provided one. domain_name is
+// required by the preset (no default in variables.tf), so without a mapper
+// fallback every single-module preview / kitchen-sink test would fail with
+// `missing_required_variable`.
+func TestMapper_Route53_DefaultDomainName(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSRoute53, &Components{}, &Config{}, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	domain, ok := vals["domain_name"]
+	require.True(t, ok, "mapper must always set domain_name (preset has no default)")
+	require.Equal(t, "example.invalid", domain,
+		"mapper should fall back to example.invalid when cfg.AWSRoute53.DomainName is unset; .invalid is the IANA-reserved TLD for testing")
+}
+
+// TestComposeStack_Route53WithALB drives a full ComposeStack pass with
+// Route 53 + ALB + VPC selected and verifies the composed root main.tf
+// renders a `module "aws_route53"` block whose `aliases = [...]` attribute
+// references the ALB. This pins the end-to-end wiring path that
+// DefaultWiring's per-key tests above can't directly exercise (the
+// composer's preset-inspection layer drops wiring whose name doesn't match
+// a declared variable; this test proves `aliases` survives that filter).
+func TestComposeStack_Route53WithALB(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud: "aws",
+		SelectedKeys: []ComponentKey{
+			KeyAWSVPC,
+			KeyAWSALB,
+			KeyAWSRoute53,
+		},
+		Comps:   &Components{},
+		Cfg:     &Config{Region: "us-east-1"},
+		Project: "test",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok, "composed root must contain main.tf")
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, `module "aws_route53"`,
+		"composed root must declare module aws_route53")
+	require.Contains(t, rootStr, "module.aws_alb.alb_dns_name",
+		"composed root must wire the ALB alias target into route53.aliases")
+	require.Contains(t, rootStr, "module.aws_alb.alb_zone_id",
+		"composed root must wire the ALB alias zone_id into route53.aliases")
+	require.Contains(t, rootStr, "aliases", "composed root must emit the aliases input")
+}
+
+// TestComposeStack_Route53Standalone confirms ComposeStack succeeds when
+// Route 53 is the only component — the mapper must supply a placeholder
+// domain_name (preset's variable has no default), and the composed root
+// must NOT emit a stray `aliases` input.
+func TestComposeStack_Route53Standalone(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSRoute53},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok)
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, `module "aws_route53"`)
+	require.NotContains(t, rootStr, "module.aws_alb",
+		"route53-only stack must not reference any ALB outputs")
+	require.NotContains(t, rootStr, "module.aws_cloudfront",
+		"route53-only stack must not reference any CloudFront outputs")
+
+	// Confirm a tfvars file landed and the placeholder domain made it in.
+	tfvars, ok := out["/aws_route53.auto.tfvars"]
+	require.True(t, ok, "expected aws_route53.auto.tfvars")
+	require.Contains(t, string(tfvars), "example.invalid",
+		"standalone route53 should land the placeholder domain so terraform plan can compile")
+}
+
+// TestMapper_Route53_CallerSuppliedConfig pins the per-field mapper plumbing.
+func TestMapper_Route53_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	tr, fa := true, false
+	cfg := &Config{
+		AWSRoute53: &struct {
+			DomainName   string   `json:"domainName,omitempty"`
+			CreateZone   *bool    `json:"createZone,omitempty"`
+			ZoneID       string   `json:"zoneId,omitempty"`
+			PrivateZone  *bool    `json:"privateZone,omitempty"`
+			VPCIDs       []string `json:"vpcIds,omitempty"`
+			ForceDestroy *bool    `json:"forceDestroy,omitempty"`
+		}{
+			DomainName:   "example.com",
+			CreateZone:   &tr,
+			ZoneID:       "Z1234567890ABC",
+			PrivateZone:  &fa,
+			VPCIDs:       []string{"vpc-aaa", "vpc-bbb"},
+			ForceDestroy: &tr,
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSRoute53, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	require.Equal(t, "example.com", vals["domain_name"])
+	require.Equal(t, true, vals["create_zone"])
+	require.Equal(t, "Z1234567890ABC", vals["zone_id"])
+	require.Equal(t, false, vals["private_zone"])
+	require.Equal(t, []any{"vpc-aaa", "vpc-bbb"}, vals["vpc_ids"])
+	require.Equal(t, true, vals["force_destroy"])
+}

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -43,6 +43,7 @@ type Components struct {
 	AWSCognito              *bool  `json:"aws_cognito,omitempty"`
 	AWSGitHubActions        *bool  `json:"aws_github_actions,omitempty"`
 	AWSCodePipeline         *bool  `json:"aws_codepipeline,omitempty"`
+	AWSRoute53              *bool  `json:"aws_route53,omitempty"`
 	AWSBackups              *struct {
 		EC2         *bool `json:"aws_ec2,omitempty"`
 		RDS         *bool `json:"aws_rds,omitempty"`
@@ -201,6 +202,24 @@ type Config struct {
 		DomainName     string `json:"domainName,omitempty"`
 		CertificateArn string `json:"certificateArn,omitempty"`
 	} `json:"aws_api_gateway,omitempty"`
+
+	// AWSRoute53 carries the caller-supplied Route 53 configuration. DomainName
+	// is the apex (e.g. "example.com") and is required when KeyAWSRoute53 is
+	// selected. CreateZone toggles between creating a hosted zone in-stack
+	// (true) and looking up an existing one by ZoneID (false). PrivateZone +
+	// VPCIDs are only consulted when CreateZone is true and the zone is
+	// intended to be private. Plain records and aliases (in addition to the
+	// auto-derived aliases the composer wires from ALB / CloudFront — see
+	// DefaultWiring at KeyAWSRoute53) flow through the same-named module
+	// variables.
+	AWSRoute53 *struct {
+		DomainName   string `json:"domainName,omitempty"`
+		CreateZone   *bool  `json:"createZone,omitempty"`
+		ZoneID       string `json:"zoneId,omitempty"`
+		PrivateZone  *bool  `json:"privateZone,omitempty"`
+		VPCIDs       []string `json:"vpcIds,omitempty"`
+		ForceDestroy *bool  `json:"forceDestroy,omitempty"`
+	} `json:"aws_route53,omitempty"`
 
 	AWSKMS *struct {
 		NumKeys string `json:"numKeys,omitempty"`
@@ -401,6 +420,7 @@ func (c *Components) Normalize() {
 		c.AWSCognito = nil
 		c.AWSGitHubActions = nil
 		c.AWSCodePipeline = nil
+		c.AWSRoute53 = nil
 		c.AWSBackups = nil
 	}
 }
@@ -506,6 +526,7 @@ func (c *Config) Normalize() {
 		c.AWSSecretsManager = nil
 		c.AWSOpenSearch = nil
 		c.AWSBedrock = nil
+		c.AWSRoute53 = nil
 		c.AWSBackups = nil
 	}
 }

--- a/pkg/observability/display.go
+++ b/pkg/observability/display.go
@@ -131,6 +131,8 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "AWS Backups"
 	case composer.KeyAWSGitHubActions:
 		return "AWS GitHub Actions OIDC"
+	case composer.KeyAWSRoute53:
+		return "AWS Route 53"
 	case composer.KeyGCPCompute:
 		return "GCP Compute Engine"
 	case composer.KeyGCPGKE:

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -59,6 +59,7 @@ var configExtractorAllowlist = map[string]string{
 	"aws_codepipeline":   "[placeholder] mapped to ec2.describe-instances, no dedicated shape (#204)",
 	"aws_backups":        "[no-inspector] AWS Backup vaults aren't inspected; covered via tag-based discovery (#204)",
 	"aws_github_actions": "[no-inspector] GitHub Actions IAM roles only — no SDK shape to extract (#204)",
+	"aws_route53":        "[no-inspector] Route 53 hosted zones / records not yet covered by the discovery pipeline (#584 follow-up)",
 
 	// Polymorphic EKS sub-keys: the ComponentKey string values are
 	// "ec2" (KeyAWSEKSNodeGroup) and "resource" (KeyAWSEKSControlPlane)


### PR DESCRIPTION
## Summary

Wires the `aws/route53` preset (added in #587 / closes #140) into the composer Go code so callers can compose it into stacks. Stacks on top of #587.

Closes #584.

## What changed

**Registry plumbing** (`pkg/composer/contracts.go`, `types.go`, `coherence.go`, `iam_actions.go`)
- New `KeyAWSRoute53 = "aws_route53"` component key wired into `ComposeOrder`, `ModulePath`, `PresetKeyMap`, `AllComponentKeys`, `ComponentSelected`, `isOrphanStrippableKey`, and `AWSIAMActions`.
- `Components.AWSRoute53` (`*bool`) selection field + `Config.AWSRoute53` sub-struct (`DomainName`, `CreateZone`, `ZoneID`, `PrivateZone`, `VPCIDs`, `ForceDestroy`) with `Normalize()` cleanup on the GCP branch.

**Mapper** (`pkg/composer/mapper.go`)
- `domain_name` defaults to a placeholder (`example.invalid`, IANA-reserved testing TLD) when the caller hasn't supplied one — the preset has no default and single-module previews need it.
- Caller-supplied `cfg.AWSRoute53.*` fields flow through to the matching module variables.

**Cross-module alias automation** (`pkg/composer/contracts.go::DefaultWiring`)
- When the stack includes Route 53 + ALB, the composer auto-emits an apex (`""`) alias to `module.aws_alb.alb_dns_name` / `.alb_zone_id` with `evaluate_target_health = true`.
- When the stack includes Route 53 + CloudFront, the composer auto-emits a `cdn` alias to `module.aws_cloudfront.domain_name` with the documented global zone `Z2FDTNDATAQYW2` and `evaluate_target_health = false` (CloudFront contract).
- Wiring stays inert when no alias-target consumer is selected — `var.aliases` falls back to the preset default `[]`.

**Observability plumbing** (`pkg/observability/display.go`, `extractors/extractors_drift_test.go`)
- `ComponentDisplayName(KeyAWSRoute53) → "AWS Route 53"`.
- Allowlist entry for `aws_route53` with `[no-inspector]` rationale until the discovery pipeline gains Route 53 coverage.

**Tests** (`pkg/composer/route53_wiring_test.go`)
- 11 new tests covering ALB / CloudFront alias derivation, inert standalone wiring, API Gateway / Cognito deferral pins, mapper default + caller-supplied config paths, and two end-to-end `ComposeStack` integration assertions (route53 + ALB + VPC, and route53 standalone).
- `kitchenSinkConfig` + `kitchenSinkComponents` updated so existing drift gates (`TestMapperKeysSubsetOfModuleVariables`, `TestEveryRequiredVariableIsMappedOrWired`) exercise the new mapper branch and wiring path.

## Per-consumer wiring status

| Consumer       | Status   | Notes |
|----------------|----------|-------|
| ALB            | Done     | `alb_dns_name` + `alb_zone_id` outputs already exist on the preset. |
| CloudFront     | Done     | `domain_name` output exists; uses documented global zone `Z2FDTNDATAQYW2`. |
| API Gateway    | Deferred | `aws/apigateway` does not yet expose `target_domain_name` / `hosted_zone_id` from its conditional custom-domain resource. Adding the outputs is a one-line preset change; gated on a #584 follow-up so a future PR has one place to plumb the wiring. Pinned by a dedicated test (`TestDefaultWiring_Route53_APIGatewayDeferred`). |
| Cognito        | Deferred | `aws/cognito` only manages the hosted UI prefix (`aws_cognito_user_pool_domain` with `domain_prefix`); a true custom-domain alias needs the preset to gain `domain` + cloudfront-distribution outputs. Pinned by `TestDefaultWiring_Route53_CognitoDeferred`. |

## Scope decisions

- **No `ImplicitDependencies` for Route 53.** Route 53 doesn't have a mandatory upstream dep — public zones need no VPC, and private zones need callers to supply `vpc_ids` (no canonical default). Added `nil` rather than guessing a hard edge.
- **Mapper placeholder is `example.invalid`.** IANA-reserved TLD makes it obvious in logs / `.auto.tfvars` that this is a stub; will fail at the Route 53 API on apply (which is the right loud surface) rather than silently producing a real-looking record.
- **API Gateway / Cognito alias auto-wiring deferred.** Both presets need preset-level output additions before wiring is possible; rather than land partial / brittle wiring, ship Done/Done for ALB+CloudFront and pin the deferrals with tests so the follow-up is one localized change.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` clean
- [x] `go test ./pkg/composer/... -count=1` — 1336 passed (skipping the 6 pre-existing terraform-CLI integration tests that hang on the provider-registry network call locally — they run in CI)
- [x] `go test ./... -count=1` — 5188 passed across 36 packages (same skip list)
- [x] `terraform fmt -check -recursive` clean
- [x] All ten repo lint scripts pass (`lint-project-tag.sh`, `lint-project-label.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`, `lint-no-root-only-blocks.sh`, `lint-labelless-name-prefix.sh`, `lint-gcp-project-pin.sh`, `lint-shared-no-cloud-providers.sh`, `lint-phantom-computed-fields.sh`, `lint-enrichgen-override-citations.sh`)
- [x] `make verify-gen` passes
- [x] `make verify-supported-resources` passes
- [x] `aws/route53` standalone — `terraform init -backend=false && terraform validate` passes
- [x] New `TestComposeStack_Route53WithALB` integration test asserts the composed root `main.tf` emits `module.aws_alb.alb_dns_name` + `module.aws_alb.alb_zone_id` inside the route53 module's `aliases =` input

## Stacks on

This PR targets `feat/add-route53-module` (PR #587). Merge #587 first, then this PR retargets to `main`.