### PR TITLE
feat(examples): add ALB + Route 53 custom domain example (#585)

### DIFF
--- a/aws/route53/main.tf
+++ b/aws/route53/main.tf
@@ -1,0 +1,136 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Module overview
+# -----------------------------------------------------------------------------
+# Owns a Route 53 public or private hosted zone (either created here or
+# looked up by ID) plus two flavours of records:
+#
+#   - `var.records`  — plain CNAME / A / AAAA / TXT / MX / SRV / NS / etc.
+#                      records with explicit TTL and values.
+#   - `var.aliases`  — A/AAAA alias records that point at an AWS service
+#                      endpoint (ALB, CloudFront, API Gateway, etc.). Alias
+#                      records have no TTL and require the target's hosted
+#                      zone ID.
+#
+# Scoping (issue #140 v1):
+#   - DNSSEC, cross-account delegation, vanity domain registration, and
+#     full ACM-cert issuance flows are out of scope for v1. ACM DNS-validation
+#     plumbing belongs in a future `aws/acm` preset (or a follow-up
+#     iteration of this module).
+
+module "name" {
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
+  luther_project = var.project
+  aws_region     = var.region
+  luther_env     = var.environment
+  org_name       = "luthersystems"
+  component      = "insideout"
+  subcomponent   = "dns"
+  resource       = "dns"
+}
+
+# -----------------------------------------------------------------------------
+# Hosted zone — either create or look up
+# -----------------------------------------------------------------------------
+# Exactly one of these resolves at any time:
+#   - create_zone=true  -> aws_route53_zone.this is created
+#   - create_zone=false -> data.aws_route53_zone.existing is queried
+#
+# Downstream resources reference local.zone_id, which selects the right
+# source based on create_zone.
+
+resource "aws_route53_zone" "this" {
+  count = var.create_zone ? 1 : 0
+
+  name          = var.domain_name
+  comment       = "Hosted zone for ${var.domain_name} (${var.project})"
+  force_destroy = var.force_destroy
+
+  # Private zone toggle requires at least one VPC association.
+  dynamic "vpc" {
+    for_each = var.private_zone ? toset(var.vpc_ids) : toset([])
+    content {
+      vpc_id = vpc.value
+    }
+  }
+
+  tags = merge(module.name.tags, var.tags)
+}
+
+data "aws_route53_zone" "existing" {
+  count = var.create_zone ? 0 : 1
+
+  zone_id      = var.zone_id
+  private_zone = var.private_zone
+}
+
+locals {
+  zone_id   = var.create_zone ? aws_route53_zone.this[0].zone_id : data.aws_route53_zone.existing[0].zone_id
+  zone_name = var.create_zone ? aws_route53_zone.this[0].name : data.aws_route53_zone.existing[0].name
+
+  # Build a stable map for plain records keyed by "<name>-<type>" so a
+  # caller can safely add/remove entries mid-stream without churning every
+  # subsequent record. Empty name ("") is the apex.
+  records_map = {
+    for r in var.records :
+    "${r.name}-${r.type}" => r
+  }
+
+  # Aliases keyed by "<name>" — alias records are A or AAAA, and Route 53
+  # allows only one record set per (name, type) per zone, so the name alone
+  # is sufficient when the caller stays in alias-A territory. For dual-stack
+  # callers, append "-${r.type}" if/when AAAA aliases are added.
+  aliases_map = {
+    for a in var.aliases :
+    "${a.name}-${try(a.type, "A")}" => a
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Plain records (CNAME / A / TXT / MX / SRV / AAAA / NS / etc.)
+# -----------------------------------------------------------------------------
+resource "aws_route53_record" "records" {
+  for_each = local.records_map
+
+  zone_id = local.zone_id
+  # Empty name maps to the apex; otherwise it's a subdomain label that
+  # Route 53 concatenates with the zone name.
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = each.value.ttl
+  records = each.value.values
+
+  # aws_route53_record does not accept a tags attribute (Route 53 record
+  # sets are not taggable resources in AWS). Tagging happens at the zone.
+}
+
+# -----------------------------------------------------------------------------
+# Alias records (ALB / CloudFront / API Gateway / etc.)
+# -----------------------------------------------------------------------------
+# Alias records cannot carry a TTL — the target's TTL governs caching.
+# `evaluate_target_health` only meaningfully toggles for ALB / NLB targets;
+# CloudFront and API Gateway require it to be false.
+resource "aws_route53_record" "aliases" {
+  for_each = local.aliases_map
+
+  zone_id = local.zone_id
+  name    = each.value.name
+  type    = try(each.value.type, "A")
+
+  alias {
+    name                   = each.value.target_dns_name
+    zone_id                = each.value.target_zone_id
+    evaluate_target_health = try(each.value.evaluate_target_health, false)
+  }
+
+  # aws_route53_record is not taggable; see note above.
+}

--- a/aws/route53/outputs.tf
+++ b/aws/route53/outputs.tf
@@ -1,0 +1,35 @@
+output "zone_id" {
+  description = "Route 53 hosted zone ID (works for both create_zone=true and false). Wire into downstream modules that need to attach records or build alias targets."
+  value       = local.zone_id
+}
+
+output "zone_arn" {
+  description = "ARN of the hosted zone (null when create_zone=false; the data source does not expose the ARN). Use this for IAM policies targeting the zone."
+  value       = var.create_zone ? aws_route53_zone.this[0].arn : null
+}
+
+output "zone_name" {
+  description = "Fully-qualified hosted zone name (e.g. example.com.). Useful when callers need to build FQDNs without reparsing var.domain_name."
+  value       = local.zone_name
+}
+
+output "name_servers" {
+  description = "Authoritative name servers for the hosted zone. Required for delegating a domain to Route 53 when create_zone = true and the registrar lives elsewhere."
+  value       = var.create_zone ? aws_route53_zone.this[0].name_servers : []
+}
+
+output "record_fqdns" {
+  description = "Map of record-key (\"<name>-<type>\") -> resolved FQDN, covering both plain records and aliases. Lets downstream callers reference the record without rebuilding the FQDN."
+  value = merge(
+    { for k, r in aws_route53_record.records : k => r.fqdn },
+    { for k, r in aws_route53_record.aliases : k => r.fqdn },
+  )
+}
+
+output "record_names" {
+  description = "List of all record short-names managed by this module (across both plain and alias records). Useful for assertions / discovery."
+  value = sort(concat(
+    [for r in aws_route53_record.records : r.name],
+    [for r in aws_route53_record.aliases : r.name],
+  ))
+}

--- a/aws/route53/variables.tf
+++ b/aws/route53/variables.tf
@@ -1,0 +1,172 @@
+variable "region" {
+  description = "AWS region (e.g., us-east-1). Route 53 itself is a global service, but the region is required for the provider and for module-name composition."
+  type        = string
+}
+
+variable "project" {
+  description = "Project name prefix used for tagging and naming"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,61}[a-z0-9]$", var.project))
+    error_message = "project must be lowercase alphanumeric with hyphens, 3-63 characters."
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g. production, staging, sandbox)"
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.environment)) > 0
+    error_message = "environment must be a non-empty string."
+  }
+}
+
+variable "domain_name" {
+  description = "Apex domain (e.g. example.com) for the hosted zone."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.domain_name)) > 0
+    error_message = "domain_name must be a non-empty string."
+  }
+
+  # Public hosted zones (and most private ones) require a syntactically
+  # valid DNS name. Allows trailing dot per RFC 1035 § 5.1; Route 53
+  # accepts either.
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\\.?$", var.domain_name))
+    error_message = "domain_name must be a syntactically valid DNS domain (RFC 1035 labels separated by dots)."
+  }
+}
+
+variable "create_zone" {
+  description = "If true, create a new Route 53 hosted zone for var.domain_name. If false, look up an existing zone via var.zone_id."
+  type        = bool
+  default     = false
+}
+
+variable "zone_id" {
+  description = "Existing Route 53 hosted zone ID. Required when create_zone = false; ignored when create_zone = true."
+  type        = string
+  default     = null
+
+  # Null-safe per Terraform's lack of short-circuit on ||.
+  validation {
+    condition     = var.zone_id == null ? true : can(regex("^Z[A-Z0-9]{1,31}$", var.zone_id))
+    error_message = "zone_id must look like a Route 53 zone ID (e.g. Z2FDTNDATAQYW2)."
+  }
+}
+
+variable "private_zone" {
+  description = "If true, the (created or queried) hosted zone is private. Private zones must be associated with at least one VPC."
+  type        = bool
+  default     = false
+}
+
+variable "vpc_ids" {
+  description = "VPC IDs to associate with a private hosted zone. Required when private_zone = true and create_zone = true; ignored otherwise."
+  type        = list(string)
+  default     = []
+}
+
+variable "force_destroy" {
+  description = "Allow `terraform destroy` to delete a created hosted zone even when it still contains record sets. Has no effect when create_zone = false."
+  type        = bool
+  default     = false
+}
+
+variable "records" {
+  description = <<-EOT
+    Plain record sets — CNAME / A / AAAA / TXT / MX / SRV / NS / PTR / SPF.
+    Each entry creates one `aws_route53_record` with an explicit TTL. Use
+    an empty `name` ("") to target the apex.
+
+    Example:
+      records = [
+        { name = "www",  type = "CNAME", ttl = 300, values = ["target.example.com"] },
+        { name = "",     type = "TXT",   ttl = 300, values = ["\"v=spf1 -all\""] },
+        { name = "mail", type = "MX",    ttl = 300, values = ["10 inbound.example.com"] },
+      ]
+  EOT
+  type = list(object({
+    name   = string
+    type   = string
+    ttl    = number
+    values = list(string)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for r in var.records :
+      contains(["A", "AAAA", "CNAME", "MX", "NS", "PTR", "SOA", "SPF", "SRV", "TXT", "CAA", "DS", "NAPTR"], r.type)
+    ])
+    error_message = "Each record.type must be one of A, AAAA, CNAME, MX, NS, PTR, SOA, SPF, SRV, TXT, CAA, DS, NAPTR. Use the `aliases` variable for alias records."
+  }
+
+  validation {
+    condition     = alltrue([for r in var.records : r.ttl >= 0 && r.ttl <= 2147483647])
+    error_message = "Each record.ttl must be a non-negative 32-bit integer (Route 53 max TTL is 2147483647 seconds)."
+  }
+
+  validation {
+    condition     = alltrue([for r in var.records : length(r.values) > 0])
+    error_message = "Each record must have at least one entry in `values`."
+  }
+}
+
+variable "aliases" {
+  description = <<-EOT
+    Alias records pointing at an AWS service endpoint (ALB, CloudFront,
+    API Gateway, S3 website, etc.). Alias records have no TTL — caching
+    is governed by the target. `type` defaults to "A"; set to "AAAA" only
+    for IPv6 alias targets. `evaluate_target_health` defaults to false
+    and must remain false for CloudFront / API Gateway targets.
+
+    Example:
+      aliases = [
+        {
+          name                   = ""          # apex
+          target_dns_name        = module.alb.alb_dns_name
+          target_zone_id         = module.alb.alb_zone_id
+          evaluate_target_health = true
+        },
+        {
+          name                   = "cdn"
+          target_dns_name        = module.cloudfront.domain_name
+          target_zone_id         = "Z2FDTNDATAQYW2"  # CloudFront's static zone
+        },
+      ]
+  EOT
+  type = list(object({
+    name                   = string
+    target_dns_name        = string
+    target_zone_id         = string
+    type                   = optional(string, "A")
+    evaluate_target_health = optional(bool, false)
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for a in var.aliases : contains(["A", "AAAA"], a.type)])
+    error_message = "alias.type must be A or AAAA (Route 53 alias records are restricted to these two types)."
+  }
+
+  validation {
+    condition     = alltrue([for a in var.aliases : length(trimspace(a.target_dns_name)) > 0])
+    error_message = "Each alias must specify a non-empty target_dns_name."
+  }
+
+  validation {
+    condition     = alltrue([for a in var.aliases : can(regex("^Z[A-Z0-9]{1,31}$", a.target_zone_id))])
+    error_message = "Each alias.target_zone_id must look like a Route 53 hosted-zone ID (e.g. Z2FDTNDATAQYW2 for CloudFront)."
+  }
+}
+
+variable "tags" {
+  description = "Common resource tags. Applied to the hosted zone (the only taggable Route 53 resource in this module)."
+  type        = map(string)
+  default     = {}
+}

--- a/examples/alb_route53_custom_domain/alb.auto.tfvars
+++ b/examples/alb_route53_custom_domain/alb.auto.tfvars
@@ -1,0 +1,2 @@
+alb_project = "demo"
+alb_region  = "us-east-1"

--- a/examples/alb_route53_custom_domain/main.tf
+++ b/examples/alb_route53_custom_domain/main.tf
@@ -1,0 +1,61 @@
+# -----------------------------------------------------------------------------
+# Example: ALB + Route 53 custom domain (issue #585, follow-up to #140)
+# -----------------------------------------------------------------------------
+# Demonstrates the end-to-end wiring requested by the Route 53 v1 acceptance
+# criteria:
+#
+#   VPC  ->  ALB (public)  ->  Route 53 alias record at the apex
+#
+# The Route 53 module owns the hosted zone (create_zone = true here so the
+# example is self-contained) and an apex A-alias record pointing at the ALB
+# via `module.alb.alb_dns_name` / `module.alb.alb_zone_id`. That is the same
+# alias wiring the InsideOut composer emits automatically when both presets
+# are selected together (PR #589, issue #584).
+#
+# Prerequisites for a real deploy (not enforced by `terraform validate`):
+#   - Delegate `var.route53_domain_name` to the hosted zone's name servers
+#     (output `module.route53.name_servers`) at your registrar.
+#   - HTTPS is out of scope here — the ALB listens on HTTP only. Add an ACM
+#     certificate ARN to `module.alb.certificate_arn` and an extra DNS-validation
+#     record to enable HTTPS. ACM is tracked separately (see route53 module
+#     header in aws/route53/main.tf).
+# -----------------------------------------------------------------------------
+
+module "vpc" {
+  source      = "../../aws/vpc"
+  project     = var.vpc_project
+  environment = var.environment
+  region      = var.vpc_region
+}
+
+module "alb" {
+  source            = "../../aws/alb"
+  vpc_id            = module.vpc.vpc_id
+  public_subnet_ids = module.vpc.public_subnet_ids
+  project           = var.alb_project
+  environment       = var.environment
+  region            = var.alb_region
+}
+
+module "route53" {
+  source = "../../aws/route53"
+
+  project     = var.route53_project
+  environment = var.environment
+  region      = var.route53_region
+
+  domain_name = var.route53_domain_name
+  create_zone = var.route53_create_zone
+
+  # Apex A-alias pointing at the ALB. evaluate_target_health = true is the
+  # recommended setting for ALB targets (health-checked failover); CloudFront
+  # / API Gateway targets must keep it false.
+  aliases = [
+    {
+      name                   = "" # apex
+      target_dns_name        = module.alb.alb_dns_name
+      target_zone_id         = module.alb.alb_zone_id
+      evaluate_target_health = true
+    },
+  ]
+}

--- a/examples/alb_route53_custom_domain/providers.tf
+++ b/examples/alb_route53_custom_domain/providers.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.vpc_region
+  default_tags {
+    tags = {
+      Project    = var.project
+      managed-by = "insideout"
+    }
+  }
+}

--- a/examples/alb_route53_custom_domain/route53.auto.tfvars
+++ b/examples/alb_route53_custom_domain/route53.auto.tfvars
@@ -1,0 +1,8 @@
+route53_project = "demo"
+route53_region  = "us-east-1"
+
+# Reserved RFC 6761 TLD — never resolvable, never registrable. Keeps a stray
+# `terraform apply` in CI or a sandbox from creating a hosted zone for a real
+# domain. Override at deploy time with the customer's actual apex.
+route53_domain_name = "example.invalid"
+route53_create_zone = true

--- a/examples/alb_route53_custom_domain/variables.tf
+++ b/examples/alb_route53_custom_domain/variables.tf
@@ -1,0 +1,59 @@
+variable "environment" {
+  description = "Deployment environment (e.g. production, staging, sandbox)"
+  type        = string
+  default     = "sandbox"
+}
+
+variable "project" {
+  description = "Project name prefix (always wired by the composer at the root)"
+  type        = string
+  default     = ""
+}
+
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate)
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+# --- VPC -------------------------------------------------------------------
+
+variable "vpc_project" {
+  type = string
+}
+
+variable "vpc_region" {
+  type = string
+}
+
+# --- ALB -------------------------------------------------------------------
+
+variable "alb_project" {
+  type = string
+}
+
+variable "alb_region" {
+  type = string
+}
+
+# --- Route 53 --------------------------------------------------------------
+
+variable "route53_project" {
+  type = string
+}
+
+variable "route53_region" {
+  type = string
+}
+
+variable "route53_domain_name" {
+  description = "Apex domain for the hosted zone. Use a reserved test-only TLD (example.invalid / .test) in CI so a stray apply cannot collide with a registered domain."
+  type        = string
+}
+
+variable "route53_create_zone" {
+  description = "If true, create a brand new hosted zone for var.route53_domain_name. If false, supply an existing zone_id directly in main.tf via module.route53.zone_id."
+  type        = bool
+  default     = true
+}

--- a/examples/alb_route53_custom_domain/vpc.auto.tfvars
+++ b/examples/alb_route53_custom_domain/vpc.auto.tfvars
@@ -1,0 +1,2 @@
+vpc_project = "demo"
+vpc_region  = "us-east-1"

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -93,6 +93,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.AWSGitHubActions)
 	case KeyAWSCodePipeline:
 		return boolPtrTrue(c.AWSCodePipeline)
+	case KeyAWSRoute53:
+		return boolPtrTrue(c.AWSRoute53)
 	case KeyAWSBackups:
 		return c.AWSBackups != nil
 	// GCP pointer-typed selections.
@@ -283,7 +285,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
 		KeyAWSCognito, KeyAWSLambda, KeyAWSAPIGateway,
 		KeyAWSKMS, KeyAWSSecretsManager, KeyAWSOpenSearch,
-		KeyAWSBedrock, KeyAWSBackups,
+		KeyAWSBedrock, KeyAWSBackups, KeyAWSRoute53,
 		KeyGCPCompute, KeyGCPGKE, KeyGCPCloudRun,
 		KeyGCPCloudFunctions, KeyGCPLoadbalancer,
 		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -68,6 +68,7 @@ const (
 	KeyAWSBackups              ComponentKey = "aws_backups"
 	KeyAWSGitHubActions        ComponentKey = "aws_github_actions"
 	KeyAWSCodePipeline         ComponentKey = "aws_codepipeline"
+	KeyAWSRoute53              ComponentKey = "aws_route53"
 
 	// GCP components
 	KeyGCPVPC              ComponentKey = "gcp_vpc"
@@ -137,6 +138,9 @@ var ComposeOrder = []ComponentKey{
 	KeyGCPIdentityPlatform,
 	KeyAWSAPIGateway,
 	KeyGCPAPIGateway,
+	// Route 53 last so DefaultWiring can read ALB / CloudFront / API Gateway /
+	// Cognito siblings and auto-derive the matching alias records (#584).
+	KeyAWSRoute53,
 	KeyAWSKMS,
 	KeyGCPCloudKMS,
 	KeyAWSSecretsManager,
@@ -193,6 +197,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyAWSBastion:              "modules/bastion",
 	KeyAWSGitHubActions:        "modules/githubactions",
 	KeyAWSCodePipeline:         "modules/codepipeline",
+	KeyAWSRoute53:              "modules/route53",
 
 	// GCP
 	KeyGCPVPC:              "gcp/vpc",
@@ -359,6 +364,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyAWSBackups:              "backups",
 	KeyAWSGitHubActions:        "githubactions",
 	KeyAWSCodePipeline:         "codepipeline",
+	KeyAWSRoute53:              "route53",
 	KeyGCPVPC:                  "vpc",
 	KeyGCPCompute:              "compute",
 	KeyGCPGKE:                  "gke",
@@ -471,6 +477,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyAWSMSK,
 	KeyAWSOpenSearch,
 	KeyAWSRDS,
+	KeyAWSRoute53,
 	KeyAWSS3,
 	KeyAWSSQS,
 	KeyAWSSecretsManager,
@@ -716,6 +723,66 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		wi.RawHCL["scope"] = `"CLOUDFRONT"`
 		wi.RawHCL["region"] = `"us-east-1"`
 		wi.Names = append(wi.Names, "scope", "region")
+
+	case KeyAWSRoute53:
+		// Auto-emit alias records for in-stack endpoints (issue #584).
+		//
+		// Today's auto-aliases cover the two consumers whose presets already
+		// expose the (dns_name, zone_id) pair the alias-target shape needs:
+		//
+		//   - ALB:        module.aws_alb.alb_dns_name + .alb_zone_id, alias
+		//                 at the apex ("") with evaluate_target_health=true.
+		//   - CloudFront: module.aws_cloudfront.domain_name; CloudFront's
+		//                 hosted zone is the documented global static
+		//                 Z2FDTNDATAQYW2; alias at "cdn".
+		//                 evaluate_target_health must be false (CloudFront
+		//                 contract — no Route 53 health-check semantics on
+		//                 the global edge).
+		//
+		// Deferred (no preset outputs yet — TODO(#584-followup)):
+		//   - API Gateway: needs aws/apigateway to expose
+		//     aws_apigatewayv2_domain_name.api[0].domain_name_configuration[0]
+		//     {target_domain_name,hosted_zone_id} as outputs. Today they are
+		//     internal to the preset and the count=var.domain_name!=null gate
+		//     makes the outputs themselves nullable, so even after adding
+		//     them the wiring needs to gate on the user supplying a domain
+		//     to apigateway. Filed as a follow-up.
+		//   - Cognito: needs aws/cognito to manage an actual custom domain
+		//     (aws_cognito_user_pool_domain with `domain` instead of
+		//     `domain_prefix`) and surface its cloudfront_distribution_arn.
+		//     The current preset only manages the hosted UI prefix.
+		//
+		// The aliases HCL is emitted as a list literal of objects. Only
+		// emitted when at least one consumer is selected — leaving
+		// var.aliases at its preset default of `[]` when route53 is
+		// composed standalone (test contract: wiring stays inert when only
+		// one side is selected).
+		var aliasEntries []string
+		if hasALB {
+			aliasEntries = append(aliasEntries, `    {
+      name                   = ""
+      target_dns_name        = `+albRef(selected)+`.alb_dns_name
+      target_zone_id         = `+albRef(selected)+`.alb_zone_id
+      type                   = "A"
+      evaluate_target_health = true
+    }`)
+		}
+		if selected[KeyAWSCloudfront] {
+			// Z2FDTNDATAQYW2 is the documented global hosted-zone ID for
+			// every CloudFront distribution. evaluate_target_health must
+			// remain false for CloudFront alias targets.
+			aliasEntries = append(aliasEntries, `    {
+      name                   = "cdn"
+      target_dns_name        = `+WireRef(KeyAWSCloudfront, "domain_name")+`
+      target_zone_id         = "Z2FDTNDATAQYW2"
+      type                   = "A"
+      evaluate_target_health = false
+    }`)
+		}
+		if len(aliasEntries) > 0 {
+			wi.RawHCL["aliases"] = "[\n" + strings.Join(aliasEntries, ",\n") + ",\n  ]"
+			wi.Names = append(wi.Names, "aliases")
+		}
 
 	case KeyAWSCloudWatchMonitoring:
 		// When any per-component observability consumer is in the stack

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -66,6 +66,11 @@ var AWSIAMActions = map[ComponentKey][]string{
 	KeyAWSBackups:              {"backup:CreateBackupPlan", "backup:CreateBackupVault"},
 	KeyAWSGitHubActions:        {"iam:CreateOpenIDConnectProvider"},
 	KeyAWSCodePipeline:         {"codepipeline:CreatePipeline"},
+	// route53:CreateHostedZone covers the create_zone=true path; the data-
+	// lookup path (create_zone=false) needs only route53:GetHostedZone, which
+	// is implied by the create capability. Record-set CRUD is covered by
+	// ChangeResourceRecordSets (issued via change batches by the provider).
+	KeyAWSRoute53: {"route53:ChangeResourceRecordSets", "route53:CreateHostedZone"},
 }
 
 // RequiredAWSIAMActions returns the deduplicated, sorted list of IAM

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -69,6 +69,7 @@ var untaggableAWS = map[string]struct{}{
 	"aws_msk_configuration":                              {},
 	"aws_opensearchserverless_access_policy":             {},
 	"aws_opensearchserverless_security_policy":           {},
+	"aws_route53_record":                                 {},
 	"aws_s3_bucket_lifecycle_configuration":              {},
 	"aws_s3_bucket_ownership_controls":                   {},
 	"aws_s3_bucket_policy":                               {},

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -573,6 +573,42 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+	case KeyAWSRoute53:
+		// Route 53 (#584). domain_name is required by the preset (no
+		// default); supply a preview-safe placeholder so single-module
+		// previews and validation runs succeed when the caller hasn't yet
+		// provided cfg.AWSRoute53.DomainName. The placeholder is a
+		// syntactically valid DNS name that obviously isn't a real domain
+		// — it'll fail the registrar/Route 53 check at apply time, which
+		// is the correct fail-loud surface (rather than a silent
+		// validation-time miss).
+		domain := "example.invalid"
+		if cfg != nil && cfg.AWSRoute53 != nil && strings.TrimSpace(cfg.AWSRoute53.DomainName) != "" {
+			domain = strings.TrimSpace(cfg.AWSRoute53.DomainName)
+		}
+		vals["domain_name"] = domain
+		if cfg != nil && cfg.AWSRoute53 != nil {
+			if cfg.AWSRoute53.CreateZone != nil {
+				vals["create_zone"] = *cfg.AWSRoute53.CreateZone
+			}
+			if cfg.AWSRoute53.ZoneID != "" {
+				vals["zone_id"] = cfg.AWSRoute53.ZoneID
+			}
+			if cfg.AWSRoute53.PrivateZone != nil {
+				vals["private_zone"] = *cfg.AWSRoute53.PrivateZone
+			}
+			if len(cfg.AWSRoute53.VPCIDs) > 0 {
+				vpcIDs := make([]any, len(cfg.AWSRoute53.VPCIDs))
+				for i, id := range cfg.AWSRoute53.VPCIDs {
+					vpcIDs[i] = id
+				}
+				vals["vpc_ids"] = vpcIDs
+			}
+			if cfg.AWSRoute53.ForceDestroy != nil {
+				vals["force_destroy"] = *cfg.AWSRoute53.ForceDestroy
+			}
+		}
+
 	case KeyAWSKMS:
 		if cfg != nil && cfg.AWSKMS != nil && cfg.AWSKMS.NumKeys != "" {
 			n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSKMS.NumKeys))

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -166,6 +166,14 @@ func kitchenSinkConfig() *Config {
 		ModelID           string `json:"modelId,omitempty"`
 		EmbeddingModelID  string `json:"embeddingModelId,omitempty"`
 	}{KnowledgeBaseName: "kb", ModelID: "anthropic.claude-3", EmbeddingModelID: "amazon.titan-embed"}
+	cfg.AWSRoute53 = &struct {
+		DomainName   string   `json:"domainName,omitempty"`
+		CreateZone   *bool    `json:"createZone,omitempty"`
+		ZoneID       string   `json:"zoneId,omitempty"`
+		PrivateZone  *bool    `json:"privateZone,omitempty"`
+		VPCIDs       []string `json:"vpcIds,omitempty"`
+		ForceDestroy *bool    `json:"forceDestroy,omitempty"`
+	}{DomainName: "example.com", CreateZone: &t, ZoneID: "Z1234567890ABC", VPCIDs: []string{"vpc-aaa"}, ForceDestroy: &t}
 
 	// GCP
 	cfg.GCPCompute = &struct {

--- a/pkg/composer/mapper_required_test.go
+++ b/pkg/composer/mapper_required_test.go
@@ -139,6 +139,7 @@ func kitchenSinkComponents() *Components {
 		AWSCognito:              &t,
 		AWSGitHubActions:        &t,
 		AWSCodePipeline:         &t,
+		AWSRoute53:              &t,
 		// GCP
 		GCPVPC:              &t,
 		GCPBastion:          &t,

--- a/pkg/composer/route53_wiring_test.go
+++ b/pkg/composer/route53_wiring_test.go
@@ -1,0 +1,290 @@
+package composer
+
+// route53_wiring_test.go covers the issue #584 composer wiring for the
+// aws/route53 preset:
+//
+//   - ComponentKey + PresetKeyMap + ModulePath + AllComponentKeys + ComposeOrder
+//     registry entries are exercised by TestAllComponentKeysCoversPresetKeyMap
+//     and TestMapperKeysSubsetOfModuleVariables (both in sibling files).
+//   - Default mapper provides every required variable — exercised by
+//     TestEveryRequiredVariableIsMappedOrWired.
+//
+// The tests below pin the cross-module alias auto-wiring contract:
+//   - When ALB / CloudFront is selected alongside Route 53, the composer
+//     auto-derives the matching aws_route53_record alias entry on the
+//     route53 module's `aliases` variable.
+//   - When neither ALB nor CloudFront is selected, the wiring stays inert
+//     and var.aliases falls back to its preset default ([]).
+//   - API Gateway and Cognito wiring are deferred — those presets don't yet
+//     expose target_dns_name / target_zone_id outputs. The tests below
+//     assert no `aliases` HCL is emitted for those keys today so a future
+//     PR adding the outputs has a single place to update.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultWiring_Route53_ALBAlias(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53: true,
+		KeyAWSALB:     true,
+		KeyAWSVPC:     true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	aliases, ok := wi.RawHCL["aliases"]
+	require.True(t, ok, "aliases must be wired when ALB is in the stack with Route 53")
+	require.Contains(t, aliases, "module.aws_alb.alb_dns_name",
+		"ALB alias must target module.aws_alb.alb_dns_name")
+	require.Contains(t, aliases, "module.aws_alb.alb_zone_id",
+		"ALB alias must use module.aws_alb.alb_zone_id (not a hardcoded zone)")
+	require.Contains(t, aliases, `evaluate_target_health = true`,
+		"ALB alias should set evaluate_target_health=true (ALB targets support health checks)")
+	require.Contains(t, aliases, `name                   = ""`,
+		"ALB alias should target the apex by default")
+	// The names slice tracks which inputs DefaultWiring claims responsibility for.
+	require.Contains(t, wi.Names, "aliases")
+}
+
+func TestDefaultWiring_Route53_CloudFrontAlias(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53:    true,
+		KeyAWSCloudfront: true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	aliases, ok := wi.RawHCL["aliases"]
+	require.True(t, ok, "aliases must be wired when CloudFront is in the stack with Route 53")
+	require.Contains(t, aliases, "module.aws_cloudfront.domain_name",
+		"CloudFront alias must target module.aws_cloudfront.domain_name")
+	require.Contains(t, aliases, `"Z2FDTNDATAQYW2"`,
+		"CloudFront alias must use the documented global hosted-zone ID Z2FDTNDATAQYW2")
+	require.Contains(t, aliases, `evaluate_target_health = false`,
+		"CloudFront alias must set evaluate_target_health=false (CloudFront contract)")
+	require.Contains(t, aliases, `name                   = "cdn"`,
+		"CloudFront alias should default to the `cdn` subdomain")
+}
+
+func TestDefaultWiring_Route53_ALBAndCloudFront(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53:    true,
+		KeyAWSALB:        true,
+		KeyAWSCloudfront: true,
+		KeyAWSVPC:        true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	aliases, ok := wi.RawHCL["aliases"]
+	require.True(t, ok, "aliases must be wired when both ALB and CloudFront are present")
+	require.Contains(t, aliases, "module.aws_alb.alb_dns_name", "ALB entry must be present")
+	require.Contains(t, aliases, "module.aws_cloudfront.domain_name", "CloudFront entry must be present")
+	// Both entries must be expressed in the same list literal.
+	entries := strings.Count(aliases, "target_dns_name")
+	require.Equal(t, 2, entries, "expected two alias entries (ALB + CloudFront), got %d", entries)
+}
+
+func TestDefaultWiring_Route53_InertWhenNoConsumers(t *testing.T) {
+	t.Parallel()
+
+	// Route 53 alone (no ALB / CloudFront / API Gateway / Cognito).
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53: true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	_, ok := wi.RawHCL["aliases"]
+	require.False(t, ok, "aliases must NOT be wired when no alias-target consumer is in the stack; var.aliases should fall back to the preset default []")
+	require.NotContains(t, wi.Names, "aliases", "Names should not advertise aliases when wiring is inert")
+}
+
+func TestDefaultWiring_Route53_APIGatewayDeferred(t *testing.T) {
+	t.Parallel()
+
+	// API Gateway wiring is deferred until aws/apigateway exposes
+	// target_domain_name / hosted_zone_id outputs. Until then, selecting
+	// API Gateway + Route 53 must NOT emit a stray alias entry referencing
+	// a non-existent output (which would surface as `unwired_output` from
+	// ValidateModuleWiring at compose time).
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53:    true,
+		KeyAWSAPIGateway: true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	if aliases, ok := wi.RawHCL["aliases"]; ok {
+		require.NotContains(t, aliases, "aws_apigateway",
+			"API Gateway alias wiring is deferred (#584 follow-up: aws/apigateway needs domain_name_configuration outputs)")
+	}
+}
+
+func TestDefaultWiring_Route53_CognitoDeferred(t *testing.T) {
+	t.Parallel()
+
+	// Cognito wiring is deferred until aws/cognito grows true custom-domain
+	// support (aws_cognito_user_pool_domain with `domain` + cloudfront
+	// distribution outputs).
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53: true,
+		KeyAWSCognito: true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	if aliases, ok := wi.RawHCL["aliases"]; ok {
+		require.NotContains(t, aliases, "aws_cognito",
+			"Cognito alias wiring is deferred (#584 follow-up: aws/cognito needs custom-domain support)")
+	}
+}
+
+// TestDefaultWiring_Route53_OtherKeysUntouched verifies the Route 53 case in
+// DefaultWiring doesn't accidentally fire for non-Route-53 component keys.
+// Without this guard a stray switch fall-through could pollute every
+// composed module with a stray `aliases` input.
+func TestDefaultWiring_Route53_OtherKeysUntouched(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53:    true,
+		KeyAWSALB:        true,
+		KeyAWSCloudfront: true,
+		KeyAWSVPC:        true,
+	}
+	for _, k := range []ComponentKey{KeyAWSALB, KeyAWSCloudfront, KeyAWSVPC, KeyAWSCognito, KeyAWSAPIGateway} {
+		wi := DefaultWiring(selected, k, &Components{})
+		_, ok := wi.RawHCL["aliases"]
+		require.False(t, ok, "DefaultWiring(%s) must not emit aliases — that's only on KeyAWSRoute53", k)
+	}
+}
+
+// TestMapper_Route53_DefaultDomainName verifies the mapper supplies a
+// placeholder domain_name when the caller hasn't provided one. domain_name is
+// required by the preset (no default in variables.tf), so without a mapper
+// fallback every single-module preview / kitchen-sink test would fail with
+// `missing_required_variable`.
+func TestMapper_Route53_DefaultDomainName(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSRoute53, &Components{}, &Config{}, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	domain, ok := vals["domain_name"]
+	require.True(t, ok, "mapper must always set domain_name (preset has no default)")
+	require.Equal(t, "example.invalid", domain,
+		"mapper should fall back to example.invalid when cfg.AWSRoute53.DomainName is unset; .invalid is the IANA-reserved TLD for testing")
+}
+
+// TestComposeStack_Route53WithALB drives a full ComposeStack pass with
+// Route 53 + ALB + VPC selected and verifies the composed root main.tf
+// renders a `module "aws_route53"` block whose `aliases = [...]` attribute
+// references the ALB. This pins the end-to-end wiring path that
+// DefaultWiring's per-key tests above can't directly exercise (the
+// composer's preset-inspection layer drops wiring whose name doesn't match
+// a declared variable; this test proves `aliases` survives that filter).
+func TestComposeStack_Route53WithALB(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud: "aws",
+		SelectedKeys: []ComponentKey{
+			KeyAWSVPC,
+			KeyAWSALB,
+			KeyAWSRoute53,
+		},
+		Comps:   &Components{},
+		Cfg:     &Config{Region: "us-east-1"},
+		Project: "test",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok, "composed root must contain main.tf")
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, `module "aws_route53"`,
+		"composed root must declare module aws_route53")
+	require.Contains(t, rootStr, "module.aws_alb.alb_dns_name",
+		"composed root must wire the ALB alias target into route53.aliases")
+	require.Contains(t, rootStr, "module.aws_alb.alb_zone_id",
+		"composed root must wire the ALB alias zone_id into route53.aliases")
+	require.Contains(t, rootStr, "aliases", "composed root must emit the aliases input")
+}
+
+// TestComposeStack_Route53Standalone confirms ComposeStack succeeds when
+// Route 53 is the only component — the mapper must supply a placeholder
+// domain_name (preset's variable has no default), and the composed root
+// must NOT emit a stray `aliases` input.
+func TestComposeStack_Route53Standalone(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSRoute53},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok)
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, `module "aws_route53"`)
+	require.NotContains(t, rootStr, "module.aws_alb",
+		"route53-only stack must not reference any ALB outputs")
+	require.NotContains(t, rootStr, "module.aws_cloudfront",
+		"route53-only stack must not reference any CloudFront outputs")
+
+	// Confirm a tfvars file landed and the placeholder domain made it in.
+	tfvars, ok := out["/aws_route53.auto.tfvars"]
+	require.True(t, ok, "expected aws_route53.auto.tfvars")
+	require.Contains(t, string(tfvars), "example.invalid",
+		"standalone route53 should land the placeholder domain so terraform plan can compile")
+}
+
+// TestMapper_Route53_CallerSuppliedConfig pins the per-field mapper plumbing.
+func TestMapper_Route53_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	tr, fa := true, false
+	cfg := &Config{
+		AWSRoute53: &struct {
+			DomainName   string   `json:"domainName,omitempty"`
+			CreateZone   *bool    `json:"createZone,omitempty"`
+			ZoneID       string   `json:"zoneId,omitempty"`
+			PrivateZone  *bool    `json:"privateZone,omitempty"`
+			VPCIDs       []string `json:"vpcIds,omitempty"`
+			ForceDestroy *bool    `json:"forceDestroy,omitempty"`
+		}{
+			DomainName:   "example.com",
+			CreateZone:   &tr,
+			ZoneID:       "Z1234567890ABC",
+			PrivateZone:  &fa,
+			VPCIDs:       []string{"vpc-aaa", "vpc-bbb"},
+			ForceDestroy: &tr,
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSRoute53, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	require.Equal(t, "example.com", vals["domain_name"])
+	require.Equal(t, true, vals["create_zone"])
+	require.Equal(t, "Z1234567890ABC", vals["zone_id"])
+	require.Equal(t, false, vals["private_zone"])
+	require.Equal(t, []any{"vpc-aaa", "vpc-bbb"}, vals["vpc_ids"])
+	require.Equal(t, true, vals["force_destroy"])
+}

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -43,6 +43,7 @@ type Components struct {
 	AWSCognito              *bool  `json:"aws_cognito,omitempty"`
 	AWSGitHubActions        *bool  `json:"aws_github_actions,omitempty"`
 	AWSCodePipeline         *bool  `json:"aws_codepipeline,omitempty"`
+	AWSRoute53              *bool  `json:"aws_route53,omitempty"`
 	AWSBackups              *struct {
 		EC2         *bool `json:"aws_ec2,omitempty"`
 		RDS         *bool `json:"aws_rds,omitempty"`
@@ -201,6 +202,24 @@ type Config struct {
 		DomainName     string `json:"domainName,omitempty"`
 		CertificateArn string `json:"certificateArn,omitempty"`
 	} `json:"aws_api_gateway,omitempty"`
+
+	// AWSRoute53 carries the caller-supplied Route 53 configuration. DomainName
+	// is the apex (e.g. "example.com") and is required when KeyAWSRoute53 is
+	// selected. CreateZone toggles between creating a hosted zone in-stack
+	// (true) and looking up an existing one by ZoneID (false). PrivateZone +
+	// VPCIDs are only consulted when CreateZone is true and the zone is
+	// intended to be private. Plain records and aliases (in addition to the
+	// auto-derived aliases the composer wires from ALB / CloudFront — see
+	// DefaultWiring at KeyAWSRoute53) flow through the same-named module
+	// variables.
+	AWSRoute53 *struct {
+		DomainName   string `json:"domainName,omitempty"`
+		CreateZone   *bool  `json:"createZone,omitempty"`
+		ZoneID       string `json:"zoneId,omitempty"`
+		PrivateZone  *bool  `json:"privateZone,omitempty"`
+		VPCIDs       []string `json:"vpcIds,omitempty"`
+		ForceDestroy *bool  `json:"forceDestroy,omitempty"`
+	} `json:"aws_route53,omitempty"`
 
 	AWSKMS *struct {
 		NumKeys string `json:"numKeys,omitempty"`
@@ -401,6 +420,7 @@ func (c *Components) Normalize() {
 		c.AWSCognito = nil
 		c.AWSGitHubActions = nil
 		c.AWSCodePipeline = nil
+		c.AWSRoute53 = nil
 		c.AWSBackups = nil
 	}
 }
@@ -506,6 +526,7 @@ func (c *Config) Normalize() {
 		c.AWSSecretsManager = nil
 		c.AWSOpenSearch = nil
 		c.AWSBedrock = nil
+		c.AWSRoute53 = nil
 		c.AWSBackups = nil
 	}
 }

--- a/pkg/observability/display.go
+++ b/pkg/observability/display.go
@@ -131,6 +131,8 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "AWS Backups"
 	case composer.KeyAWSGitHubActions:
 		return "AWS GitHub Actions OIDC"
+	case composer.KeyAWSRoute53:
+		return "AWS Route 53"
 	case composer.KeyGCPCompute:
 		return "GCP Compute Engine"
 	case composer.KeyGCPGKE:

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -59,6 +59,7 @@ var configExtractorAllowlist = map[string]string{
 	"aws_codepipeline":   "[placeholder] mapped to ec2.describe-instances, no dedicated shape (#204)",
 	"aws_backups":        "[no-inspector] AWS Backup vaults aren't inspected; covered via tag-based discovery (#204)",
 	"aws_github_actions": "[no-inspector] GitHub Actions IAM roles only — no SDK shape to extract (#204)",
+	"aws_route53":        "[no-inspector] Route 53 hosted zones / records not yet covered by the discovery pipeline (#584 follow-up)",
 
 	// Polymorphic EKS sub-keys: the ComponentKey string values are
 	// "ec2" (KeyAWSEKSNodeGroup) and "resource" (KeyAWSEKSControlPlane)

--- a/tests/lint-project-tag.sh
+++ b/tests/lint-project-tag.sh
@@ -56,6 +56,7 @@ NON_TAGGABLE_AWS=(
   aws_msk_configuration
   aws_opensearchserverless_access_policy
   aws_opensearchserverless_security_policy
+  aws_route53_record
   aws_s3_bucket_lifecycle_configuration
   aws_s3_bucket_ownership_controls
   aws_s3_bucket_policy


### PR DESCRIPTION
## Summary

- Adds `examples/alb_route53_custom_domain/` composing **VPC + ALB + Route 53** to demonstrate the end-to-end alias wiring requested by issue #140's acceptance criteria.
- Apex A-alias record (`name = ""`) points at the ALB via `module.alb.alb_dns_name` / `module.alb.alb_zone_id`, with `evaluate_target_health = true` (recommended for ALB targets).
- Uses the reserved RFC 6761 TLD `example.invalid` as the default `route53_domain_name` so a stray `terraform apply` cannot collide with a real registered domain. Override at deploy time.
- Picks up CI coverage automatically via the `validate-examples` matrix job in `.github/workflows/terraform-validate.yml` (matches the second acceptance bullet).

## Stacking

Stacked on #589 (`feat/issue-584-composer-wiring-route53`) — the example itself only needs the `aws/route53` preset from #587, but the PR sequence keeps composer wiring + first-class example in lockstep. Rebase onto `main` once #587 and #589 land.

## Test plan

- [x] `terraform init -backend=false -input=false` succeeds in the example dir
- [x] `terraform validate` reports `Success!` (deprecation warnings are pre-existing in `aws/alb`'s `aws_s3_bucket`)
- [x] `terraform fmt -check -recursive` clean across the repo
- [x] `tests/lint-project-tag.sh`, `lint-project-label.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh` all PASS
- [ ] CI `validate-examples` job picks up the new directory

Closes #585