### PR TITLE
feat: add aws/acm preset module (#586)

### DIFF
--- a/aws/acm/main.tf
+++ b/aws/acm/main.tf
@@ -1,0 +1,114 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Module overview
+# -----------------------------------------------------------------------------
+# Owns an AWS Certificate Manager (ACM) certificate with DNS validation.
+#
+# Scope (issue #586 v1):
+#   - Single ACM certificate per module instance, `validation_method = "DNS"`.
+#   - Emits the DNS validation records as a structured output so the caller
+#     can wire them into `aws/route53.records` (or any external DNS source).
+#   - Optionally waits for validation to complete (`aws_acm_certificate_validation`),
+#     gated on `var.create_validation` and the FQDN list returned after the
+#     records are created downstream.
+#   - EMAIL validation and re-import flows are out of scope. Use the AWS
+#     console / cert-manager workflow if you need either.
+#
+# Region note:
+#   ACM certificates for CloudFront MUST live in us-east-1 (CloudFront is a
+#   global service that pins to the N. Virginia regional control plane). For
+#   regional consumers (ALB, API Gateway), the cert must live in the same
+#   region as the consumer.
+#
+#   This module does NOT declare a `configuration_aliases` provider alias —
+#   instead, callers pin `var.region` (and the composer pins the underlying
+#   provider region) per instance. Compose two ACM module instances when a
+#   stack needs both an us-east-1 CloudFront cert and a regional ALB cert.
+#
+# Composer wiring (follow-up issue):
+#   - `validation_records` output -> `aws/route53.records` input
+#   - `certificate_arn` output -> ALB / API Gateway / CloudFront cert input
+#   - `validation_record_fqdns` (caller-supplied) -> `aws_acm_certificate_validation.this`
+
+module "name" {
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
+  luther_project = var.project
+  aws_region     = var.region
+  luther_env     = var.environment
+  org_name       = "luthersystems"
+  component      = "insideout"
+  subcomponent   = "acm"
+  resource       = "cert"
+}
+
+# -----------------------------------------------------------------------------
+# Certificate
+# -----------------------------------------------------------------------------
+# `create_before_destroy = true` is mandatory for ACM certs that back live
+# listeners: replacing a cert (e.g. on SAN change) must provision the new one
+# before AWS detaches the old, otherwise ALB / CloudFront briefly serve no
+# cert and clients get TLS errors. AWS' own documentation calls this out.
+resource "aws_acm_certificate" "this" {
+  domain_name               = var.domain_name
+  subject_alternative_names = var.subject_alternative_names
+  validation_method         = "DNS"
+
+  # Optional: pin the cert's certificate transparency policy. Public certs
+  # default to ENABLED; only set DISABLED if the org has a CT logging
+  # exception (rare; mostly internal-only PKI use cases).
+  options {
+    certificate_transparency_logging_preference = var.certificate_transparency_logging
+  }
+
+  # Optional: pin the cert's key algorithm (defaults to RSA_2048). ECDSA
+  # certs (EC_prime256v1 / EC_secp384r1) trade broader client support for
+  # smaller handshake payloads. ALB and CloudFront both support ECDSA.
+  key_algorithm = var.key_algorithm
+
+  tags = merge(module.name.tags, var.tags)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Optional validation wait
+# -----------------------------------------------------------------------------
+# `aws_acm_certificate_validation` is a synchronous wait on AWS' side —
+# Terraform blocks until the cert moves to ISSUED status. This requires the
+# DNS validation records (from the `validation_records` output below) to
+# already exist in DNS, which is the caller's responsibility (typically by
+# wiring this module's output into `aws/route53.records`).
+#
+# Set `create_validation = false` when:
+#   - The caller is using an external DNS provider that Terraform doesn't
+#     manage (cert will eventually be ISSUED out-of-band).
+#   - The caller wants to apply this module before wiring records and accept
+#     a "PENDING_VALIDATION" cert in state on the first apply.
+#
+# `validation_record_fqdns` lets the caller pass back the exact FQDNs the
+# records were written under, which avoids a chicken-and-egg dependency
+# cycle between this module and the route53 module.
+resource "aws_acm_certificate_validation" "this" {
+  count = var.create_validation ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.this.arn
+  validation_record_fqdns = var.validation_record_fqdns
+
+  # aws_acm_certificate_validation is not a taggable resource (it represents
+  # a wait operation, not an AWS-side object).
+
+  timeouts {
+    create = var.validation_timeout
+  }
+}

--- a/aws/acm/outputs.tf
+++ b/aws/acm/outputs.tf
@@ -1,0 +1,53 @@
+output "certificate_arn" {
+  description = "ACM certificate ARN. Wire into ALB listener (`certificate_arn`), API Gateway domain name (`regional_certificate_arn` / `certificate_arn`), or CloudFront viewer certificate (`acm_certificate_arn`). When create_validation = true this resolves only after the cert is ISSUED."
+  value       = var.create_validation ? aws_acm_certificate_validation.this[0].certificate_arn : aws_acm_certificate.this.arn
+}
+
+output "certificate_id" {
+  description = "ACM certificate ID (the trailing UUID of the ARN). Useful for IAM resource references that don't accept ARNs."
+  value       = aws_acm_certificate.this.id
+}
+
+output "domain_name" {
+  description = "Primary domain name on the certificate. Echoed for downstream wiring convenience so callers don't need to repeat the input."
+  value       = aws_acm_certificate.this.domain_name
+}
+
+output "validation_records" {
+  description = <<-EOT
+    DNS validation records the caller must publish for ACM to issue the cert.
+    One entry per unique validation record (primary + SANs). Each entry is a
+    map with `name`, `type`, and `value` — ready to feed into
+    `aws/route53.records` (one record per entry, with `ttl = 60`
+    recommended). Deduplicated by `resource_record_name` so wildcard + apex
+    covering the same zone don't produce two identical records.
+  EOT
+  # ACM emits one domain_validation_options entry per requested domain
+  # (primary + each SAN). When a wildcard like *.example.com is paired with
+  # an apex example.com SAN, ACM returns the same _acme-challenge.example.com
+  # record for both — dedupe so the caller doesn't try to create the same
+  # Route 53 record twice.
+  value = values({
+    for opt in aws_acm_certificate.this.domain_validation_options :
+    opt.resource_record_name => {
+      name  = opt.resource_record_name
+      type  = opt.resource_record_type
+      value = opt.resource_record_value
+    }
+  })
+}
+
+output "validation_record_fqdns" {
+  description = "Plain list of FQDNs from `validation_records`, for callers that just need the names to pass back into `var.validation_record_fqdns` on a second-pass apply."
+  value       = distinct([for opt in aws_acm_certificate.this.domain_validation_options : opt.resource_record_name])
+}
+
+output "domain_validation_options" {
+  description = "Raw `domain_validation_options` set from `aws_acm_certificate`. Prefer `validation_records` for typical wiring; this raw output exists for callers that need extra fields (e.g. per-domain validation status)."
+  value       = aws_acm_certificate.this.domain_validation_options
+}
+
+output "status" {
+  description = "Current ACM certificate status (PENDING_VALIDATION, ISSUED, etc.). Useful for assertions / reporting; not load-bearing for wiring."
+  value       = aws_acm_certificate.this.status
+}

--- a/aws/acm/tests/shape.tftest.hcl
+++ b/aws/acm/tests/shape.tftest.hcl
@@ -1,0 +1,109 @@
+mock_provider "aws" {}
+
+# Issue #586: aws/acm preset shape tests. Verifies that the certificate is
+# always created with DNS validation, that create_validation gates the
+# aws_acm_certificate_validation resource, and that wildcard / SAN inputs
+# survive validation.
+
+run "acm_minimum_inputs_creates_dns_cert" {
+  command = plan
+
+  variables {
+    project     = "test"
+    region      = "us-east-1"
+    environment = "test"
+    domain_name = "example.com"
+  }
+
+  assert {
+    condition     = aws_acm_certificate.this.validation_method == "DNS"
+    error_message = "ACM cert must always use DNS validation in this preset (EMAIL is out of scope)."
+  }
+
+  assert {
+    condition     = aws_acm_certificate.this.domain_name == "example.com"
+    error_message = "domain_name input should pass through to the cert resource."
+  }
+
+  assert {
+    condition     = length(aws_acm_certificate_validation.this) == 0
+    error_message = "create_validation defaults to false, so aws_acm_certificate_validation must NOT be created on minimum inputs."
+  }
+}
+
+run "acm_wildcard_with_sans" {
+  command = plan
+
+  variables {
+    project                   = "test"
+    region                    = "us-east-1"
+    environment               = "test"
+    domain_name               = "*.example.com"
+    subject_alternative_names = ["example.com", "api.example.com"]
+  }
+
+  assert {
+    condition     = aws_acm_certificate.this.domain_name == "*.example.com"
+    error_message = "Wildcard domain_name should be accepted."
+  }
+
+  assert {
+    condition     = length(aws_acm_certificate.this.subject_alternative_names) == 2
+    error_message = "SAN list should pass through unchanged."
+  }
+}
+
+run "acm_create_validation_emits_validation_resource" {
+  command = plan
+
+  variables {
+    project                 = "test"
+    region                  = "us-east-1"
+    environment             = "test"
+    domain_name             = "example.com"
+    create_validation       = true
+    validation_record_fqdns = ["_acme-challenge.example.com"]
+  }
+
+  assert {
+    condition     = length(aws_acm_certificate_validation.this) == 1
+    error_message = "create_validation = true must emit exactly one aws_acm_certificate_validation."
+  }
+
+  assert {
+    condition     = aws_acm_certificate_validation.this[0].validation_record_fqdns == toset(["_acme-challenge.example.com"])
+    error_message = "validation_record_fqdns input must pass through to the validation resource (as a set; the provider normalizes list -> set)."
+  }
+}
+
+run "acm_default_key_algorithm_is_rsa_2048" {
+  command = plan
+
+  variables {
+    project     = "test"
+    region      = "us-east-1"
+    environment = "test"
+    domain_name = "example.com"
+  }
+
+  assert {
+    condition     = aws_acm_certificate.this.key_algorithm == "RSA_2048"
+    error_message = "Default key_algorithm should be RSA_2048 (broadest client compatibility)."
+  }
+}
+
+run "acm_ct_logging_defaults_enabled" {
+  command = plan
+
+  variables {
+    project     = "test"
+    region      = "us-east-1"
+    environment = "test"
+    domain_name = "example.com"
+  }
+
+  assert {
+    condition     = aws_acm_certificate.this.options[0].certificate_transparency_logging_preference == "ENABLED"
+    error_message = "Certificate Transparency logging should default to ENABLED (browser/CT-log requirement for public certs)."
+  }
+}

--- a/aws/acm/variables.tf
+++ b/aws/acm/variables.tf
@@ -1,0 +1,133 @@
+variable "region" {
+  description = "AWS region the certificate is provisioned in. For CloudFront use pin to us-east-1; for ALB / API Gateway match the consumer's region."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.region)) > 0
+    error_message = "region must be a non-empty string."
+  }
+}
+
+variable "project" {
+  description = "Project name prefix used for tagging and naming."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,61}[a-z0-9]$", var.project))
+    error_message = "project must be lowercase alphanumeric with hyphens, 3-63 characters."
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g. production, staging, sandbox)."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.environment)) > 0
+    error_message = "environment must be a non-empty string."
+  }
+}
+
+variable "domain_name" {
+  description = "Primary fully-qualified domain name the certificate is issued for (e.g. www.example.com or *.example.com)."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.domain_name)) > 0
+    error_message = "domain_name must be a non-empty string."
+  }
+
+  # Allows wildcards (leading "*.") and standard RFC-1035 labels.
+  validation {
+    condition     = can(regex("^(\\*\\.)?[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$", var.domain_name))
+    error_message = "domain_name must be a syntactically valid DNS name (RFC 1035 labels), optionally prefixed with '*.' for a wildcard."
+  }
+}
+
+variable "subject_alternative_names" {
+  description = "Additional FQDNs (SANs) the certificate covers. Each entry must be a syntactically valid DNS name; wildcards (leading '*.') are allowed."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for s in var.subject_alternative_names :
+      can(regex("^(\\*\\.)?[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$", s))
+    ])
+    error_message = "Each subject_alternative_names entry must be a syntactically valid DNS name (optionally wildcarded)."
+  }
+
+  # ACM caps a public cert at 10 SANs (including the primary domain). Reject
+  # over-spec at plan time rather than waiting for an AWS-side rejection.
+  validation {
+    condition     = length(var.subject_alternative_names) <= 9
+    error_message = "subject_alternative_names supports up to 9 entries (ACM caps a public cert at 10 names total including the primary domain_name)."
+  }
+}
+
+variable "key_algorithm" {
+  description = "Key algorithm for the certificate. RSA_2048 is the broadest-compatibility default; ECDSA variants trade compatibility for smaller TLS handshakes."
+  type        = string
+  default     = "RSA_2048"
+
+  validation {
+    condition     = contains(["RSA_2048", "EC_prime256v1", "EC_secp384r1"], var.key_algorithm)
+    error_message = "key_algorithm must be one of RSA_2048, EC_prime256v1, EC_secp384r1."
+  }
+}
+
+variable "certificate_transparency_logging" {
+  description = "Certificate Transparency logging preference. Public web certs should keep this ENABLED (browser/CT-log requirement); DISABLED is only meaningful for internal-only PKI use cases with a documented exception."
+  type        = string
+  default     = "ENABLED"
+
+  validation {
+    condition     = contains(["ENABLED", "DISABLED"], var.certificate_transparency_logging)
+    error_message = "certificate_transparency_logging must be ENABLED or DISABLED."
+  }
+}
+
+variable "create_validation" {
+  description = <<-EOT
+    If true, create an `aws_acm_certificate_validation` that blocks the apply
+    until AWS confirms the cert is ISSUED. Requires the DNS validation
+    records (see the `validation_records` output) to already be present in
+    DNS — typically by feeding `validation_records` into `aws/route53.records`
+    and `validation_record_fqdns` back into this module.
+
+    Set false when the DNS provider is external/unmanaged or when accepting a
+    PENDING_VALIDATION cert in state on first apply.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "validation_record_fqdns" {
+  description = "List of FQDNs that the DNS validation records were written under. Only consulted when create_validation = true. Caller supplies these after creating the records in DNS (typically derived from `aws/route53.record_fqdns`)."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for f in var.validation_record_fqdns : length(trimspace(f)) > 0
+    ])
+    error_message = "Each validation_record_fqdns entry must be a non-empty string."
+  }
+}
+
+variable "validation_timeout" {
+  description = "Maximum time to wait for AWS to mark the cert ISSUED when create_validation = true. ACM DNS validation typically completes in a few minutes but the published SLA is up to 72 hours; '45m' is a pragmatic ceiling for stack deploys."
+  type        = string
+  default     = "45m"
+
+  validation {
+    condition     = can(regex("^[0-9]+[smh]$", var.validation_timeout))
+    error_message = "validation_timeout must be a Go duration string (e.g. '30m', '1h', '90s')."
+  }
+}
+
+variable "tags" {
+  description = "Common resource tags. Applied to the ACM certificate (the only taggable resource in this module)."
+  type        = map(string)
+  default     = {}
+}

--- a/tests/lint-project-tag.sh
+++ b/tests/lint-project-tag.sh
@@ -24,6 +24,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # Resource types that do NOT accept a tags attribute in AWS provider 6.x.
 # Keep sorted alphabetically.
 NON_TAGGABLE_AWS=(
+  aws_acm_certificate_validation
   aws_api_gateway_deployment
   aws_api_gateway_resource
   aws_apigatewayv2_api_mapping


### PR DESCRIPTION
Closes #586.

## Summary

Adds a standalone `aws/acm` preset that issues a DNS-validated ACM
certificate and emits structured DNS validation records so callers can
wire them into `aws/route53` (or any external DNS source).

## Decision: Option A (standalone `aws/acm`) over Option B (fold into `aws/route53`)

Posted in [issue thread](https://github.com/luthersystems/insideout-terraform-presets/issues/586#issuecomment-4468519328):

- ACM has real standalone value (external DNS provider, cross-account
  hosted zones, manual validation).
- Matches the modular preset philosophy (e.g. `aws/waf` is not folded
  into `aws/cloudfront`).
- The `aws/route53` header comment in PR #587 pre-anticipates this split.
- Keeps `aws/route53` focused on DNS records; ACM stays focused on cert
  lifecycle.

## What's in the module

- `aws_acm_certificate` with `validation_method = "DNS"` and
  `lifecycle.create_before_destroy = true` (mandatory so replacing a cert
  backing a live listener doesn't drop TLS).
- Optional `aws_acm_certificate_validation` gated on `var.create_validation`.
  `var.validation_record_fqdns` lets the caller pass back the FQDNs after
  writing records, breaking the chicken-and-egg dependency cycle with
  `aws/route53`.
- `validation_records` output: deduped by `resource_record_name` so
  wildcard + apex SAN pairs don't produce duplicate Route 53 records.
- Header documents the region rule and the composer-driven approach.

## Region / provider-alias handling

ACM certs for CloudFront MUST live in `us-east-1`; regional consumers
(ALB, API Gateway) need the cert in their own region. Rather than declare
a `configuration_aliases` provider alias (which would require
`.validate-skip` and complicate standalone validation), the module relies
on the composer pinning `var.region` per ACM module instance. Stacks
that need both a CloudFront cert and a regional ALB cert compose two ACM
instances.

## Composer wiring (follow-up)

Wiring `validation_records` -> `aws/route53.records` and
`certificate_arn` -> ALB / API Gateway / CloudFront is a composer-side
change, mirroring the route53 wiring pattern in #584. Tracking that as a
follow-up issue rather than coupling it to this preset PR.

## Files

- `aws/acm/main.tf` — provider + resources
- `aws/acm/variables.tf` — `project`, `region`, `environment`,
  `domain_name`, `subject_alternative_names`, `key_algorithm`,
  `certificate_transparency_logging`, `create_validation`,
  `validation_record_fqdns`, `validation_timeout`, `tags`
- `aws/acm/outputs.tf` — `certificate_arn`, `certificate_id`,
  `domain_name`, `validation_records`, `validation_record_fqdns`,
  `domain_validation_options`, `status`
- `aws/acm/tests/shape.tftest.hcl` — 5 plan-mode shape tests
  (`mock_provider "aws" {}`)
- `tests/lint-project-tag.sh` — adds `aws_acm_certificate_validation` to
  `NON_TAGGABLE_AWS` (it's a wait pseudo-resource, not an AWS object)

## Test plan

- [x] `terraform fmt -check -recursive` clean
- [x] `cd aws/acm && terraform init -backend=false && terraform validate` passes
- [x] `cd aws/acm && terraform test` -- 5/5 pass
- [x] `bash tests/lint-project-tag.sh` passes
- [x] `bash tests/lint-no-root-only-blocks.sh` passes
- [x] `bash tests/lint-sensitive-for-each.sh` passes
- [x] `bash tests/lint-foreach-unknown-keys.sh` passes
- [x] `bash tests/lint-project-label.sh` / `lint-labelless-name-prefix.sh` / `lint-shared-no-cloud-providers.sh` pass
- [x] `bash tests/validate-as-child.sh aws/acm` passes (no root-only block leakage)
- [x] `go build ./...` clean (`zz_embed.go`'s `aws/*/*.tf` glob covers the new module)
- [x] `go test ./...` -- 5195 tests pass in 36 packages