### PR TITLE
feat: add gcp/cloud_dns preset module (#583)

### DIFF
--- a/gcp/cloud_dns/main.tf
+++ b/gcp/cloud_dns/main.tf
@@ -1,0 +1,139 @@
+# -----------------------------------------------------------------------------
+# GCP Cloud DNS — managed zone + record sets
+# -----------------------------------------------------------------------------
+# Owns a Cloud DNS public or private managed zone (either created here or
+# looked up by name) plus record sets (A / AAAA / CNAME / TXT / MX / SRV /
+# NS / PTR / SOA / CAA).
+#
+# Scoping (issue #583 — GCP parallel of #140's aws/route53 v1):
+#   - DNSSEC, cross-project peering, forwarding zones, reverse-lookup
+#     zones, and Cloud-DNS routing policies (geo / WRR / failover) are out
+#     of scope for v1.
+#   - Google-managed certificate issuance (Certificate Manager DNS
+#     authorization, the ACM-equivalent) belongs in a future preset or a
+#     follow-up iteration of this module.
+#   - There is no native "alias" record in Cloud DNS — callers point at
+#     load-balancer IPs / Cloud Run service IPs / etc. with plain A / AAAA
+#     or CNAME entries via var.records.
+#
+# TODO(#583 follow-up): register google_dns_managed_zone and
+# google_dns_record_set in pkg/insideout-import/registry/registry.go
+# (gcpDiscoverTypes) and add a Cloud DNS inspector under
+# pkg/observability/discovery/gcp/. Until then, this module's resources
+# are not represented in the typed registry / drift inspector, so the
+# `labels = merge({ project = var.project }, var.labels)` block on the
+# managed zone below is NOT CI-enforced by tests/lint-project-label.sh
+# (the allowlist there gates on registry parity per
+# TestUntaggableAllowlistsMatchLintScripts). The label still propagates
+# the Project identity correctly at apply time, matching the convention
+# every other GCP preset follows.
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Enable Cloud DNS API
+# -----------------------------------------------------------------------------
+# Cloud DNS depends on the dns.googleapis.com service being enabled in the
+# project. Unconditional so the test gate
+# (TestEveryPresetHasUnconditionalResource) sees at least one default-input
+# resource, and so the API enable lands before the managed zone CREATE.
+resource "google_project_service" "dns" {
+  project = var.project_id
+  service = "dns.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+# -----------------------------------------------------------------------------
+# Managed zone — either create or look up
+# -----------------------------------------------------------------------------
+# Exactly one of these resolves at any time:
+#   - create_zone=true  -> google_dns_managed_zone.this is created
+#   - create_zone=false -> data.google_dns_managed_zone.existing is queried
+#
+# Downstream resources reference local.zone_name, which selects the right
+# source based on create_zone.
+
+resource "google_dns_managed_zone" "this" {
+  count = var.create_zone ? 1 : 0
+
+  project     = var.project_id
+  name        = "${var.project}-${var.zone_short_name}"
+  dns_name    = var.dns_name
+  description = "Managed zone for ${var.dns_name} (${var.project})"
+  visibility  = var.private_zone ? "private" : "public"
+
+  force_destroy = var.force_destroy
+
+  depends_on = [google_project_service.dns]
+
+  # Private zones require at least one VPC self-link. Public zones must
+  # NOT carry a private_visibility_config block, so the dynamic block
+  # collapses to zero when private_zone = false.
+  dynamic "private_visibility_config" {
+    for_each = var.private_zone ? [1] : []
+    content {
+      dynamic "networks" {
+        for_each = toset(var.network_self_links)
+        content {
+          network_url = networks.value
+        }
+      }
+    }
+  }
+
+  labels = merge({ project = var.project }, var.labels)
+}
+
+data "google_dns_managed_zone" "existing" {
+  count = var.create_zone ? 0 : 1
+
+  project = var.project_id
+  name    = var.zone_name
+}
+
+locals {
+  zone_name = var.create_zone ? google_dns_managed_zone.this[0].name : data.google_dns_managed_zone.existing[0].name
+  zone_id   = var.create_zone ? google_dns_managed_zone.this[0].id : data.google_dns_managed_zone.existing[0].id
+  dns_name  = var.create_zone ? google_dns_managed_zone.this[0].dns_name : data.google_dns_managed_zone.existing[0].dns_name
+
+  # Build a stable map for record sets keyed by "<name>-<type>". Cloud DNS
+  # rejects multiple record sets with the same (name, type) per zone, so
+  # the key collisions surface as deterministic plan errors. Empty `name`
+  # ("") targets the apex (resolved below to the zone's dns_name).
+  records_map = {
+    for r in var.records :
+    "${r.name}-${r.type}" => r
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Record sets (A / AAAA / CNAME / TXT / MX / SRV / NS / etc.)
+# -----------------------------------------------------------------------------
+# Cloud DNS requires fully-qualified record names ending with the zone's
+# dns_name (which itself ends with a trailing dot). For convenience, an
+# empty `name` ("") on the input targets the apex, and non-empty values
+# are interpreted as a left-hand label (e.g. "www") that we concatenate
+# with the zone's dns_name.
+resource "google_dns_record_set" "records" {
+  for_each = local.records_map
+
+  project = var.project_id
+  # google_dns_record_set has no `labels` attribute (Cloud DNS record
+  # sets are not labelable). It also has no `tags`. The zone carries the
+  # project label; record sets are scoped through the parent zone.
+
+  managed_zone = local.zone_name
+  name         = each.value.name == "" ? local.dns_name : "${each.value.name}.${local.dns_name}"
+  type         = each.value.type
+  ttl          = each.value.ttl
+  rrdatas      = each.value.values
+}

--- a/gcp/cloud_dns/outputs.tf
+++ b/gcp/cloud_dns/outputs.tf
@@ -1,0 +1,29 @@
+output "zone_id" {
+  description = "Cloud DNS managed zone fully-qualified ID (works for both create_zone=true and false). Wire into downstream modules that need to attach records out-of-band or build zone references."
+  value       = local.zone_id
+}
+
+output "zone_name" {
+  description = "Cloud DNS managed zone resource name (e.g. \"example-com\"). Useful as the `managed_zone` argument on out-of-band record sets and for cross-module wiring."
+  value       = local.zone_name
+}
+
+output "dns_name" {
+  description = "Fully-qualified DNS name for the zone (always trailing-dot, e.g. \"example.com.\"). Lets downstream callers reference the zone's apex without reparsing var.dns_name."
+  value       = local.dns_name
+}
+
+output "name_servers" {
+  description = "Authoritative name servers for the managed zone. Required for delegating a domain to Cloud DNS when create_zone = true and the registrar lives elsewhere. Empty list when create_zone = false (the data source exposes name_servers, but we keep parity with the AWS module's contract of \"set only on create\")."
+  value       = var.create_zone ? google_dns_managed_zone.this[0].name_servers : []
+}
+
+output "record_fqdns" {
+  description = "Map of record-key (\"<name>-<type>\") -> resolved FQDN, covering all record sets managed by this module. Lets downstream callers reference the record without rebuilding the FQDN."
+  value       = { for k, r in google_dns_record_set.records : k => r.name }
+}
+
+output "record_names" {
+  description = "Sorted list of all record short-names managed by this module. Useful for assertions / discovery."
+  value       = sort([for r in var.records : r.name])
+}

--- a/gcp/cloud_dns/variables.tf
+++ b/gcp/cloud_dns/variables.tf
@@ -1,0 +1,140 @@
+variable "project" {
+  description = "Naming/label prefix for stack resources (NOT a GCP project ID — see var.project_id)."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+}
+
+variable "project_id" {
+  description = "Real GCP project ID where the managed zone and record sets are created (e.g. \"my-prod-12345\"). Distinct from var.project, which is the naming/label prefix and need not be a valid GCP project ID."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "project_id must be a valid GCP project ID: 6–30 chars, lowercase letters/digits/hyphens, start with a letter, end alphanumeric."
+  }
+}
+
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate). Cloud DNS itself is global, but the composer namespacing convention requires region.
+variable "region" {
+  description = "GCP region. Cloud DNS is a global service, but the region is required for the provider and for composer namespacing parity with other modules."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "dns_name" {
+  description = "Apex DNS name for the managed zone (e.g. \"example.com.\"). Cloud DNS requires a trailing dot — a trailing dot is appended if missing in the create-zone path."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.dns_name)) > 0
+    error_message = "dns_name must be a non-empty string."
+  }
+
+  # Cloud DNS DNS names must be syntactically valid; allow optional
+  # trailing dot per RFC 1035 § 3.1. Cloud DNS itself requires the dot
+  # at apply time, but we accept it either way for caller ergonomics.
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\\.?$", var.dns_name))
+    error_message = "dns_name must be a syntactically valid DNS domain (RFC 1035 labels separated by dots, optional trailing dot)."
+  }
+}
+
+variable "create_zone" {
+  description = "If true, create a new Cloud DNS managed zone for var.dns_name. If false, look up an existing zone via var.zone_name."
+  type        = bool
+  default     = false
+}
+
+variable "zone_short_name" {
+  description = "Short zone identifier appended to var.project to form the managed zone resource name (e.g. \"primary\" -> \"<project>-primary\"). Only used when create_zone = true. Must satisfy Cloud DNS's zone-name format: lowercase letters, digits, hyphens; 1-63 chars; start with a letter."
+  type        = string
+  default     = "primary"
+
+  validation {
+    condition     = can(regex("^[a-z][-a-z0-9]{0,62}$", var.zone_short_name))
+    error_message = "zone_short_name must start with a lowercase letter and contain only lowercase letters, digits, and hyphens (1-63 chars)."
+  }
+}
+
+variable "zone_name" {
+  description = "Existing Cloud DNS managed zone name (Cloud DNS resource name, e.g. \"example-com\"). Required when create_zone = false; ignored when create_zone = true."
+  type        = string
+  default     = null
+
+  # Null-safe per Terraform's lack of short-circuit on ||.
+  validation {
+    condition     = var.zone_name == null ? true : can(regex("^[a-z][-a-z0-9]{0,62}$", var.zone_name))
+    error_message = "zone_name must look like a Cloud DNS managed zone name: lowercase letters/digits/hyphens, start with a letter, 1-63 chars."
+  }
+}
+
+variable "private_zone" {
+  description = "If true, the (created or queried) managed zone is private. Private zones must be associated with at least one VPC via var.network_self_links."
+  type        = bool
+  default     = false
+}
+
+variable "network_self_links" {
+  description = "VPC self-links to associate with a private managed zone (e.g. \"projects/<id>/global/networks/<name>\"). Required when private_zone = true and create_zone = true; ignored otherwise."
+  type        = list(string)
+  default     = []
+}
+
+variable "force_destroy" {
+  description = "Allow `terraform destroy` to delete a created managed zone even when it still contains record sets. Has no effect when create_zone = false."
+  type        = bool
+  default     = false
+}
+
+variable "records" {
+  description = <<-EOT
+    Record sets — A / AAAA / CNAME / TXT / MX / SRV / NS / PTR / SOA / CAA.
+    Each entry creates one `google_dns_record_set` with an explicit TTL. Use
+    an empty `name` ("") to target the apex; non-empty names are interpreted
+    as a left-hand label that this module concatenates with the zone's
+    dns_name (e.g. name = "www" + dns_name = "example.com." -> "www.example.com.").
+
+    Example:
+      records = [
+        { name = "www",  type = "CNAME", ttl = 300, values = ["target.example.com."] },
+        { name = "",     type = "TXT",   ttl = 300, values = ["\"v=spf1 -all\""] },
+        { name = "mail", type = "MX",    ttl = 300, values = ["10 inbound.example.com."] },
+        { name = "api",  type = "A",     ttl = 60,  values = ["203.0.113.10"] },
+      ]
+  EOT
+  type = list(object({
+    name   = string
+    type   = string
+    ttl    = number
+    values = list(string)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for r in var.records :
+      contains(["A", "AAAA", "CAA", "CNAME", "MX", "NS", "PTR", "SOA", "SRV", "TXT"], r.type)
+    ])
+    error_message = "Each record.type must be one of A, AAAA, CAA, CNAME, MX, NS, PTR, SOA, SRV, TXT. (Cloud DNS also supports DNSKEY/DS/IPSECKEY/NAPTR/SPF/SSHFP/TLSA but those are out of v1 scope — open a follow-up if needed.)"
+  }
+
+  validation {
+    condition     = alltrue([for r in var.records : r.ttl >= 0 && r.ttl <= 2147483647])
+    error_message = "Each record.ttl must be a non-negative 32-bit integer."
+  }
+
+  validation {
+    condition     = alltrue([for r in var.records : length(r.values) > 0])
+    error_message = "Each record must have at least one entry in `values`."
+  }
+}
+
+variable "labels" {
+  description = "Labels applied to the managed zone (the only labelable resource in this module). Merged with the canonical { project = var.project } baseline."
+  type        = map(string)
+  default     = {}
+}

--- a/tests/lint-labelless-name-prefix.sh
+++ b/tests/lint-labelless-name-prefix.sh
@@ -100,6 +100,11 @@ EXEMPT_LABELLESS_GCP=(
   google_secret_manager_secret_version
   google_storage_bucket_object
   google_service_networking_connection
+  # google_dns_record_set — Cloud DNS record sets have semantic DNS
+  # names (e.g. "www.example.com.") and cannot legally carry var.project
+  # in the name field. Attribution flows through the parent managed_zone
+  # whose name does carry var.project.
+  google_dns_record_set
   # Compute network-plane sub-resources scoped to a project-prefixed
   # parent network. The network/subnet/router/firewall NAME does carry
   # var.project where authored; the rule below only checks resource


### PR DESCRIPTION
## Summary

Adds a `gcp/cloud_dns` Terraform preset that owns a Cloud DNS public or private managed zone (created in-stack or looked up by name) plus record sets. This is the GCP parallel of `aws/route53` (#140 / PR #587), tracked in #583.

## What's in v1

- **`gcp/cloud_dns/main.tf`** — `google_project_service.dns` (unconditional API enable), `google_dns_managed_zone` (create or `data` lookup, public or private), `google_dns_record_set` for `var.records` (A / AAAA / CNAME / TXT / MX / SRV / NS / PTR / SOA / CAA).
- **`gcp/cloud_dns/variables.tf`** — Mirrors the aws/route53 variable shape with GCP idioms: `project` (label/naming prefix) + `project_id` (real GCP project ID, per #157), `dns_name` (with trailing-dot accommodation), `create_zone`, `zone_short_name` / `zone_name` (create-vs-lookup split), `private_zone`, `network_self_links` (parallel of AWS `vpc_ids`), `force_destroy`, `records`, `labels`. Null-safe validations throughout (ternary, not `||`).
- **`gcp/cloud_dns/outputs.tf`** — `zone_id`, `zone_name`, `dns_name`, `name_servers`, `record_fqdns`, `record_names` for cross-module wiring.
- **`tests/lint-labelless-name-prefix.sh`** — Adds `google_dns_record_set` to `EXEMPT_LABELLESS_GCP` (Cloud DNS record sets carry semantic DNS names like `www.example.com.` and can't legally embed `var.project`; attribution flows through the parent `managed_zone` whose `name` does carry `var.project`).

## What's deferred (open follow-ups if needed)

- **Composer wiring** for `KeyGCPCloudDNS` (analogous to #584 for aws/route53) — mapper updates, ImplicitDependencies, GLB / Cloud Run / API Gateway endpoint wiring.
- **Example stack** (GLB + Cloud DNS custom domain — analogous to PR #585).
- **Discovery inspector + typed-registry entries** for `google_dns_managed_zone` and `google_dns_record_set` (`pkg/insideout-import/registry/registry.go::gcpDiscoverTypes` + a Cloud DNS inspector under `pkg/observability/discovery/gcp/`). Until those land, the `labels = merge({ project = var.project }, var.labels)` block on the managed zone is **not** CI-enforced by `tests/lint-project-label.sh` (the allowlist there gates on registry parity per `TestUntaggableAllowlistsMatchLintScripts`). The label still propagates Project identity correctly at apply time, matching every other GCP preset. A `TODO(#583 follow-up)` in `main.tf` explains.
- **DNSSEC, cross-project peering, forwarding zones, reverse-lookup zones, Cloud-DNS routing policies (geo / WRR / failover)**.
- **Certificate Manager DNS authorization** (the ACM-equivalent).
- **Native alias records** — Cloud DNS has none. Callers point at GLB IPs / Cloud Run service IPs / etc. with plain A / AAAA / CNAME entries via `var.records`. If a future use-case demands alias-routing semantics it goes here as a Cloud-DNS routing policy.

## Test plan

- [x] `terraform fmt -check -recursive` (clean across the whole repo)
- [x] `gcp/cloud_dns` — `terraform init -backend=false && terraform validate` passes
- [x] `tests/validate-as-child.sh gcp/cloud_dns` passes (preset works wrapped as a child module)
- [x] All ten repo lint scripts pass: `lint-project-tag.sh`, `lint-project-label.sh`, `lint-gcp-project-pin.sh`, `lint-labelless-name-prefix.sh`, `lint-no-root-only-blocks.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`, `lint-shared-no-cloud-providers.sh`, `lint-phantom-computed-fields.sh`, `lint-enrichgen-override-citations.sh`
- [x] `go build ./...` succeeds
- [x] `go test ./pkg/composer/ -count=1` — 1334 passed (includes `TestEveryPresetHasUnconditionalResource`, `TestPresetDefaultsSatisfyValidations`, `TestEveryPresetHasResourceOrModuleCall`, `TestUntaggableAllowlistsMatchLintScripts`)
- [x] `go test ./... -count=1` — 5194 passed across 36 packages

Closes #583