### PR TITLE
feat(composer): wire aws/acm + gcp/cloud_dns into composer

### DIFF
--- a/pkg/composer/acm_wiring_test.go
+++ b/pkg/composer/acm_wiring_test.go
@@ -1,0 +1,266 @@
+package composer
+
+// acm_wiring_test.go covers the issue #593 composer wiring for the
+// aws/acm preset:
+//
+//   - ComponentKey + PresetKeyMap + ModulePath + AllComponentKeys +
+//     ComposeOrder registry entries are exercised by
+//     TestAllComponentKeysCoversPresetKeyMap and
+//     TestMapperKeysSubsetOfModuleVariables (both in sibling files).
+//   - Default mapper provides every required variable — exercised by
+//     TestEveryRequiredVariableIsMappedOrWired.
+//
+// The tests below pin the cross-module wiring contract:
+//   - When KeyAWSACM is selected alongside KeyAWSRoute53, the composer
+//     auto-derives `aws_route53.records` from `aws_acm.validation_records`,
+//     transforming the {name,type,value} ACM shape into the {name,type,
+//     ttl,values} route53 shape (TTL=60).
+//   - When KeyAWSACM is selected without KeyAWSRoute53, no records wiring
+//     is emitted (route53 is the consumer; without it the producer is
+//     inert).
+//   - When KeyAWSRoute53 is selected without KeyAWSACM, the records
+//     wiring stays inert and var.records falls back to its preset
+//     default ([]).
+//
+// Back-edge wiring (route53.record_fqdns → acm.validation_record_fqdns +
+// auto-flip acm.create_validation=true) is deferred — closing that loop
+// creates an acm ↔ route53 2-cycle that ValidateNoModuleCycles flags
+// before terraform plan ever runs. Tracked in #601; see TODO(#601) at
+// the KeyAWSRoute53 case in DefaultWiring.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultWiring_ACMValidationRecordsIntoRoute53(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSACM:     true,
+		KeyAWSRoute53: true,
+	}
+	// The producer key (KeyAWSACM) has no cross-module inputs of its own
+	// today — verified separately. We test the route53 consumer here.
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	records, ok := wi.RawHCL["records"]
+	require.True(t, ok, "records must be wired when ACM is in the stack with Route 53")
+	require.Contains(t, records, "module.aws_acm.validation_records",
+		"records must source from module.aws_acm.validation_records")
+	require.Contains(t, records, "ttl    = 60",
+		"records should pin TTL=60 — ACM polls validation every 60s")
+	require.Contains(t, records, "values = [r.value]",
+		"records should wrap each ACM value (singular) in a list (plural) for route53.records shape")
+	require.Contains(t, records, "name   = r.name",
+		"records should pass through the ACM record name (already an FQDN)")
+	require.Contains(t, records, "type   = r.type",
+		"records should pass through the ACM record type (CNAME)")
+	require.Contains(t, wi.Names, "records")
+}
+
+func TestDefaultWiring_ACM_InertWhenRoute53Absent(t *testing.T) {
+	t.Parallel()
+
+	// ACM alone (no route53). The KeyAWSACM case in DefaultWiring has
+	// no cross-module wiring of its own — its outputs flow into other
+	// modules, not the other way around.
+	selected := map[ComponentKey]bool{
+		KeyAWSACM: true,
+	}
+	wi := DefaultWiring(selected, KeyAWSACM, &Components{})
+
+	require.Empty(t, wi.Names,
+		"ACM has no cross-module inputs today; DefaultWiring should be inert when only ACM is selected (got Names=%v)",
+		wi.Names)
+	require.Empty(t, wi.RawHCL,
+		"ACM has no cross-module inputs today; DefaultWiring should not emit any RawHCL when only ACM is selected (got %v)",
+		wi.RawHCL)
+}
+
+func TestDefaultWiring_Route53_RecordsInertWithoutACM(t *testing.T) {
+	t.Parallel()
+
+	// Route53 alone (no ACM). The records wiring must NOT fire — the
+	// preset's var.records default is []. Aliases wiring is also off
+	// because no consumer (ALB / CloudFront) is selected.
+	selected := map[ComponentKey]bool{
+		KeyAWSRoute53: true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	_, ok := wi.RawHCL["records"]
+	require.False(t, ok, "records must NOT be wired when ACM is not in the stack; var.records should fall back to []")
+	require.NotContains(t, wi.Names, "records",
+		"Names should not advertise records when wiring is inert")
+}
+
+func TestDefaultWiring_Route53_RecordsAndAliasesCanCoexist(t *testing.T) {
+	t.Parallel()
+
+	// ACM + ALB + route53: route53 should get BOTH `records` (from ACM
+	// validation records) AND `aliases` (from ALB).
+	selected := map[ComponentKey]bool{
+		KeyAWSACM:     true,
+		KeyAWSALB:     true,
+		KeyAWSRoute53: true,
+		KeyAWSVPC:     true,
+	}
+	wi := DefaultWiring(selected, KeyAWSRoute53, &Components{})
+
+	records, ok := wi.RawHCL["records"]
+	require.True(t, ok, "records must be wired (ACM is in the stack)")
+	require.Contains(t, records, "module.aws_acm.validation_records")
+
+	aliases, ok := wi.RawHCL["aliases"]
+	require.True(t, ok, "aliases must be wired (ALB is in the stack)")
+	require.Contains(t, aliases, "module.aws_alb.alb_dns_name")
+
+	// Both keys should be advertised in Names.
+	require.Contains(t, wi.Names, "records")
+	require.Contains(t, wi.Names, "aliases")
+}
+
+// TestDefaultWiring_ACM_OtherKeysUntouched verifies the records wiring
+// in the KeyAWSRoute53 case doesn't accidentally leak onto other keys.
+func TestDefaultWiring_ACM_OtherKeysUntouched(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSACM:     true,
+		KeyAWSRoute53: true,
+		KeyAWSALB:     true,
+		KeyAWSVPC:     true,
+	}
+	for _, k := range []ComponentKey{KeyAWSACM, KeyAWSALB, KeyAWSVPC, KeyAWSCloudfront} {
+		wi := DefaultWiring(selected, k, &Components{})
+		_, ok := wi.RawHCL["records"]
+		require.False(t, ok, "DefaultWiring(%s) must not emit records — that's only on KeyAWSRoute53", k)
+	}
+}
+
+// TestMapper_ACM_DefaultDomainName verifies the mapper supplies a
+// placeholder domain_name when the caller hasn't provided one.
+// domain_name is required by the preset (no default in variables.tf),
+// so without a mapper fallback every single-module preview / kitchen-
+// sink test would fail with `missing_required_variable`.
+func TestMapper_ACM_DefaultDomainName(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSACM, &Components{}, &Config{}, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	domain, ok := vals["domain_name"]
+	require.True(t, ok, "mapper must always set domain_name (preset has no default)")
+	require.Equal(t, "example.invalid", domain,
+		"mapper should fall back to example.invalid when cfg.AWSACM.DomainName is unset; .invalid is the IANA-reserved TLD for testing")
+}
+
+// TestMapper_ACM_CallerSuppliedConfig pins the per-field mapper plumbing.
+func TestMapper_ACM_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	tr := true
+	cfg := &Config{
+		AWSACM: &struct {
+			DomainName                     string   `json:"domainName,omitempty"`
+			SubjectAlternativeNames        []string `json:"subjectAlternativeNames,omitempty"`
+			KeyAlgorithm                   string   `json:"keyAlgorithm,omitempty"`
+			CertificateTransparencyLogging string   `json:"certificateTransparencyLogging,omitempty"`
+			CreateValidation               *bool    `json:"createValidation,omitempty"`
+			ValidationTimeout              string   `json:"validationTimeout,omitempty"`
+		}{
+			DomainName:                     "www.example.com",
+			SubjectAlternativeNames:        []string{"api.example.com", "*.example.com"},
+			KeyAlgorithm:                   "EC_prime256v1",
+			CertificateTransparencyLogging: "DISABLED",
+			CreateValidation:               &tr,
+			ValidationTimeout:              "1h",
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSACM, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	require.Equal(t, "www.example.com", vals["domain_name"])
+	require.Equal(t, []any{"api.example.com", "*.example.com"}, vals["subject_alternative_names"])
+	require.Equal(t, "EC_prime256v1", vals["key_algorithm"])
+	require.Equal(t, "DISABLED", vals["certificate_transparency_logging"])
+	require.Equal(t, true, vals["create_validation"])
+	require.Equal(t, "1h", vals["validation_timeout"])
+}
+
+// TestComposeStack_ACMWithRoute53 drives a full ComposeStack pass with
+// ACM + Route 53 selected and verifies the composed root main.tf
+// renders a `module "aws_route53"` block whose `records = [...]`
+// attribute references ACM's validation_records output. This pins the
+// end-to-end wiring path that DefaultWiring's per-key tests above
+// can't directly exercise (the composer's preset-inspection layer
+// drops wiring whose name doesn't match a declared variable; this
+// test proves `records` survives that filter).
+func TestComposeStack_ACMWithRoute53(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud: "aws",
+		SelectedKeys: []ComponentKey{
+			KeyAWSACM,
+			KeyAWSRoute53,
+		},
+		Comps:   &Components{},
+		Cfg:     &Config{Region: "us-east-1"},
+		Project: "test",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok, "composed root must contain main.tf")
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, `module "aws_acm"`,
+		"composed root must declare module aws_acm")
+	require.Contains(t, rootStr, `module "aws_route53"`,
+		"composed root must declare module aws_route53")
+	require.Contains(t, rootStr, "module.aws_acm.validation_records",
+		"composed root must wire ACM's validation_records into route53.records")
+	require.True(t, strings.Contains(rootStr, "records ="),
+		"composed root must emit a records assignment on the route53 module block")
+}
+
+// TestComposeStack_ACMStandalone confirms ComposeStack succeeds when
+// ACM is the only component — the mapper must supply a placeholder
+// domain_name (preset's variable has no default), and the composed
+// root must NOT emit a stray records-into-route53 reference.
+func TestComposeStack_ACMStandalone(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSACM},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok)
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, `module "aws_acm"`)
+	require.NotContains(t, rootStr, "module.aws_route53",
+		"acm-only stack must not reference any Route 53 outputs")
+
+	// Confirm the tfvars file landed with the placeholder domain.
+	tfvars, ok := out["/aws_acm.auto.tfvars"]
+	require.True(t, ok, "expected aws_acm.auto.tfvars")
+	require.Contains(t, string(tfvars), "example.invalid",
+		"standalone ACM should land the placeholder domain so terraform plan can compile")
+}

--- a/pkg/composer/cloud_dns_wiring_test.go
+++ b/pkg/composer/cloud_dns_wiring_test.go
@@ -1,0 +1,147 @@
+package composer
+
+// cloud_dns_wiring_test.go covers the issue #593 composer wiring for
+// the gcp/cloud_dns preset:
+//
+//   - ComponentKey + PresetKeyMap + ModulePath + AllComponentKeys +
+//     ComposeOrder registry entries are exercised by
+//     TestAllComponentKeysCoversPresetKeyMap and
+//     TestMapperKeysSubsetOfModuleVariables (both in sibling files).
+//   - Default mapper provides every required variable — exercised by
+//     TestEveryRequiredVariableIsMappedOrWired.
+//
+// Cloud DNS has no cross-module wiring today (no GCP-side equivalent
+// of ACM auto-feed, no LB alias auto-derivation), so the wiring
+// contract is "DefaultWiring is inert for KeyGCPCloudDNS." The tests
+// below pin that contract so a future PR adding wiring (e.g. feeding
+// gcp_loadbalancer's address into cloud_dns.records) lands deliberately
+// rather than by silent regression.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultWiring_GCPCloudDNS_InertStandalone(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyGCPCloudDNS: true,
+	}
+	wi := DefaultWiring(selected, KeyGCPCloudDNS, &Components{})
+
+	require.Empty(t, wi.Names,
+		"GCP Cloud DNS has no cross-module wiring today; DefaultWiring should be inert (got Names=%v)",
+		wi.Names)
+	require.Empty(t, wi.RawHCL,
+		"GCP Cloud DNS has no cross-module wiring today; DefaultWiring should not emit any RawHCL (got %v)",
+		wi.RawHCL)
+}
+
+func TestDefaultWiring_GCPCloudDNS_InertWithSiblings(t *testing.T) {
+	t.Parallel()
+
+	// Even with the full GCP catalog selected, Cloud DNS must stay
+	// inert until a follow-up PR explicitly wires it.
+	selected := map[ComponentKey]bool{
+		KeyGCPCloudDNS:     true,
+		KeyGCPVPC:          true,
+		KeyGCPLoadbalancer: true,
+		KeyGCPCloudRun:     true,
+		KeyGCPCompute:      true,
+	}
+	wi := DefaultWiring(selected, KeyGCPCloudDNS, &Components{})
+
+	require.Empty(t, wi.Names,
+		"Cloud DNS should remain inert until a follow-up PR adds wiring (got Names=%v)",
+		wi.Names)
+}
+
+// TestMapper_GCPCloudDNS_DefaultDNSName verifies the mapper supplies a
+// placeholder dns_name when the caller hasn't provided one. dns_name
+// is required by the preset (no default), so without a mapper fallback
+// every single-module preview / kitchen-sink test would fail with
+// `missing_required_variable`.
+func TestMapper_GCPCloudDNS_DefaultDNSName(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyGCPCloudDNS, &Components{}, &Config{}, "demo", "us-central1")
+	require.NoError(t, err)
+
+	dns, ok := vals["dns_name"]
+	require.True(t, ok, "mapper must always set dns_name (preset has no default)")
+	require.Equal(t, "example.invalid.", dns,
+		"mapper should fall back to example.invalid. (with trailing dot) when cfg.GCPCloudDNS.DNSName is unset; .invalid is the IANA-reserved TLD for testing")
+}
+
+// TestMapper_GCPCloudDNS_CallerSuppliedConfig pins the per-field
+// mapper plumbing.
+func TestMapper_GCPCloudDNS_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	tr, fa := true, false
+	cfg := &Config{
+		GCPCloudDNS: &struct {
+			DNSName          string   `json:"dnsName,omitempty"`
+			CreateZone       *bool    `json:"createZone,omitempty"`
+			ZoneShortName    string   `json:"zoneShortName,omitempty"`
+			ZoneName         string   `json:"zoneName,omitempty"`
+			PrivateZone      *bool    `json:"privateZone,omitempty"`
+			NetworkSelfLinks []string `json:"networkSelfLinks,omitempty"`
+			ForceDestroy     *bool    `json:"forceDestroy,omitempty"`
+		}{
+			DNSName:          "example.com.",
+			CreateZone:       &tr,
+			ZoneShortName:    "primary",
+			ZoneName:         "example-com",
+			PrivateZone:      &fa,
+			NetworkSelfLinks: []string{"projects/p/global/networks/n"},
+			ForceDestroy:     &tr,
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyGCPCloudDNS, &Components{}, cfg, "demo", "us-central1")
+	require.NoError(t, err)
+
+	require.Equal(t, "example.com.", vals["dns_name"])
+	require.Equal(t, true, vals["create_zone"])
+	require.Equal(t, "primary", vals["zone_short_name"])
+	require.Equal(t, "example-com", vals["zone_name"])
+	require.Equal(t, false, vals["private_zone"])
+	require.Equal(t, []any{"projects/p/global/networks/n"}, vals["network_self_links"])
+	require.Equal(t, true, vals["force_destroy"])
+}
+
+// TestComposeStack_GCPCloudDNSStandalone confirms ComposeStack succeeds
+// when Cloud DNS is the only component — the mapper must supply a
+// placeholder dns_name (preset's variable has no default).
+func TestComposeStack_GCPCloudDNSStandalone(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPCloudDNS},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-central1"},
+		Project:      "test",
+		Region:       "us-central1",
+		GCPProjectID: "test-project-12345",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok, "composed root must contain main.tf")
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, `module "gcp_cloud_dns"`,
+		"composed root must declare module gcp_cloud_dns")
+
+	// Confirm the tfvars file landed with the placeholder dns_name.
+	tfvars, ok := out["/gcp_cloud_dns.auto.tfvars"]
+	require.True(t, ok, "expected gcp_cloud_dns.auto.tfvars")
+	require.Contains(t, string(tfvars), "example.invalid.",
+		"standalone Cloud DNS should land the placeholder dns_name so terraform plan can compile")
+}

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -95,6 +95,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.AWSCodePipeline)
 	case KeyAWSRoute53:
 		return boolPtrTrue(c.AWSRoute53)
+	case KeyAWSACM:
+		return boolPtrTrue(c.AWSACM)
 	case KeyAWSBackups:
 		return c.AWSBackups != nil
 	// GCP pointer-typed selections.
@@ -138,6 +140,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.GCPIdentityPlatform)
 	case KeyGCPCloudBuild:
 		return boolPtrTrue(c.GCPCloudBuild)
+	case KeyGCPCloudDNS:
+		return boolPtrTrue(c.GCPCloudDNS)
 	case KeyGCPBackups:
 		return c.GCPBackups != nil
 	// External / third-party.
@@ -286,11 +290,13 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyAWSCognito, KeyAWSLambda, KeyAWSAPIGateway,
 		KeyAWSKMS, KeyAWSSecretsManager, KeyAWSOpenSearch,
 		KeyAWSBedrock, KeyAWSBackups, KeyAWSRoute53,
+		KeyAWSACM,
 		KeyGCPCompute, KeyGCPGKE, KeyGCPCloudRun,
 		KeyGCPCloudFunctions, KeyGCPLoadbalancer,
 		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,
 		KeyGCPPubSub, KeyGCPCloudLogging,
-		KeyGCPIdentityPlatform, KeyGCPAPIGateway, KeyGCPBackups:
+		KeyGCPIdentityPlatform, KeyGCPAPIGateway, KeyGCPBackups,
+		KeyGCPCloudDNS:
 		return true
 	}
 	return false

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -63,6 +63,7 @@ const (
 	KeyAWSGitHubActions        ComponentKey = "aws_github_actions"
 	KeyAWSCodePipeline         ComponentKey = "aws_codepipeline"
 	KeyAWSRoute53              ComponentKey = "aws_route53"
+	KeyAWSACM                  ComponentKey = "aws_acm"
 
 	// GCP components
 	KeyGCPVPC              ComponentKey = "gcp_vpc"
@@ -87,6 +88,7 @@ const (
 	KeyGCPCloudArmor       ComponentKey = "gcp_cloud_armor"
 	KeyGCPAPIGateway       ComponentKey = "gcp_api_gateway"
 	KeyGCPBackups          ComponentKey = "gcp_backups"
+	KeyGCPCloudDNS         ComponentKey = "gcp_cloud_dns"
 )
 
 var ComposeOrder = []ComponentKey{
@@ -131,8 +133,17 @@ var ComposeOrder = []ComponentKey{
 	KeyGCPIdentityPlatform,
 	KeyAWSAPIGateway,
 	KeyGCPAPIGateway,
+	// ACM before Route 53 so DefaultWiring for KeyAWSRoute53 can read ACM's
+	// validation_records output and inject it into route53.records (#593).
+	KeyAWSACM,
+	// Cloud DNS — GCP analog of Route 53. No back-edges from other GCP
+	// presets today (no Cloud Armor / load-balancer alias auto-wiring), so
+	// position is not load-bearing relative to other GCP keys (#593).
+	KeyGCPCloudDNS,
 	// Route 53 last so DefaultWiring can read ALB / CloudFront / API Gateway /
-	// Cognito siblings and auto-derive the matching alias records (#584).
+	// Cognito siblings and auto-derive the matching alias records (#584),
+	// AND read ACM's validation_records output to wire DNS-01 challenges
+	// without manual caller plumbing (#593).
 	KeyAWSRoute53,
 	KeyAWSKMS,
 	KeyGCPCloudKMS,
@@ -187,6 +198,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyAWSGitHubActions:        "modules/githubactions",
 	KeyAWSCodePipeline:         "modules/codepipeline",
 	KeyAWSRoute53:              "modules/route53",
+	KeyAWSACM:                  "modules/acm",
 
 	// GCP
 	KeyGCPVPC:              "gcp/vpc",
@@ -211,6 +223,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyGCPIdentityPlatform: "gcp/identity_platform",
 	KeyGCPCloudBuild:       "gcp/cloud_build",
 	KeyGCPBackups:          "gcp/backups",
+	KeyGCPCloudDNS:         "gcp/cloud_dns",
 }
 
 // ImplicitDependencies defines components that must be automatically added
@@ -338,6 +351,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyAWSGitHubActions:        "githubactions",
 	KeyAWSCodePipeline:         "codepipeline",
 	KeyAWSRoute53:              "route53",
+	KeyAWSACM:                  "acm",
 	KeyGCPVPC:                  "vpc",
 	KeyGCPCompute:              "compute",
 	KeyGCPGKE:                  "gke",
@@ -360,6 +374,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyGCPCloudRun:             "cloud_run",
 	KeyGCPCloudFunctions:       "cloud_functions",
 	KeyGCPBastion:              "bastion",
+	KeyGCPCloudDNS:             "cloud_dns",
 }
 
 // GetPresetPath returns the cloud-prefixed preset path for a component.
@@ -420,6 +435,7 @@ func CloudFromKeys(keys []string) string {
 //     (consumed directly by the InsideOut backend's composeradapter).
 var AllComponentKeys = []ComponentKey{
 	// AWS (alphabetical for reviewability)
+	KeyAWSACM,
 	KeyAWSALB,
 	KeyAWSAPIGateway,
 	KeyAWSBackups,
@@ -455,6 +471,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyGCPBastion,
 	KeyGCPCloudArmor,
 	KeyGCPCloudBuild,
+	KeyGCPCloudDNS,
 	KeyGCPCloudFunctions,
 	KeyGCPCloudKMS,
 	KeyGCPCloudLogging,
@@ -735,6 +752,36 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		if len(aliasEntries) > 0 {
 			wi.RawHCL["aliases"] = "[\n" + strings.Join(aliasEntries, ",\n") + ",\n  ]"
 			wi.Names = append(wi.Names, "aliases")
+		}
+		// Auto-inject ACM DNS-01 validation records when aws/acm is in the
+		// stack (issue #593). ACM's validation_records output is a list of
+		// {name, type, value} maps; route53.records expects a list of
+		// {name, type, ttl, values} objects. The for-expression reshapes
+		// the data and pins TTL to 60s — ACM's DNS validation polls every
+		// 60s, so anything higher wastes time on first apply. The records
+		// are CNAME (ACM's only validation method here), so the type pass-
+		// through is safe.
+		//
+		// TODO(#601): wire the back-edge route53.record_fqdns →
+		// acm.validation_record_fqdns + flip acm.create_validation=true so
+		// the composed stack produces an ISSUED cert in one apply. Today's
+		// blocker: closing that loop creates an acm ↔ route53 2-cycle that
+		// ValidateNoModuleCycles flags before terraform plan ever runs.
+		// The cleanest fix is to give route53 a dedicated
+		// `acm_validation_records` input (separate from var.records) so the
+		// back-edge can read a route53 output that doesn't depend on the
+		// acm-sourced records. Until then, callers needing an ISSUED cert
+		// must run a second-pass `terraform apply` with
+		// `acm.validation_record_fqdns = module.aws_route53.record_fqdns`
+		// and `acm.create_validation = true` set manually.
+		if selected[KeyAWSACM] {
+			wi.RawHCL["records"] = `[for r in ` + WireRef(KeyAWSACM, "validation_records") + ` : {
+      name   = r.name
+      type   = r.type
+      ttl    = 60
+      values = [r.value]
+    }]`
+			wi.Names = append(wi.Names, "records")
 		}
 
 	case KeyAWSCloudWatchMonitoring:

--- a/pkg/composer/gcp_services.go
+++ b/pkg/composer/gcp_services.go
@@ -73,6 +73,7 @@ var GCPServices = map[ComponentKey][]GCPService{
 		{Name: "servicemanagement.googleapis.com", Title: "Service Management"},
 	},
 	KeyGCPBackups: {{Name: "backupdr.googleapis.com", Title: "Backup and DR Service"}},
+	KeyGCPCloudDNS: {{Name: "dns.googleapis.com", Title: "Cloud DNS"}},
 	// Components that need no extra service beyond the always-required set
 	// (covered by Compute / always-required entries):
 	KeyGCPVPC:          nil,

--- a/pkg/composer/hcl_validation.go
+++ b/pkg/composer/hcl_validation.go
@@ -223,6 +223,7 @@ func validationFunctions() map[string]function.Function {
 		validationFunctionsMap = map[string]function.Function{
 			"can":         tryfunc.CanFunc,
 			"contains":    stdlib.ContainsFunc,
+			"distinct":    stdlib.DistinctFunc,
 			"length":      lengthFunc(),
 			"lower":       stdlib.LowerFunc,
 			"regex":       stdlib.RegexFunc,

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -64,6 +64,20 @@ var AWSIAMActions = map[ComponentKey][]string{
 	// is implied by the create capability. Record-set CRUD is covered by
 	// ChangeResourceRecordSets (issued via change batches by the provider).
 	KeyAWSRoute53: {"route53:ChangeResourceRecordSets", "route53:CreateHostedZone"},
+	// ACM (#593). acm:RequestCertificate covers the cert CREATE; the
+	// surrounding tag / option / describe operations cover the lifecycle
+	// the provider exercises during plan/apply/destroy. Public certs
+	// require no extra permission for issuance — DNS validation runs
+	// asynchronously inside AWS once the validation records exist.
+	KeyAWSACM: {
+		"acm:AddTagsToCertificate",
+		"acm:DeleteCertificate",
+		"acm:DescribeCertificate",
+		"acm:ListCertificates",
+		"acm:ListTagsForCertificate",
+		"acm:RequestCertificate",
+		"acm:UpdateCertificateOptions",
+	},
 }
 
 // RequiredAWSIAMActions returns the deduplicated, sorted list of IAM
@@ -138,6 +152,16 @@ var GCPIAMPermissions = map[ComponentKey][]string{
 	KeyGCPVertexAI:         {"aiplatform.endpoints.create"},
 	KeyGCPAPIGateway:       {"apigateway.gateways.create"},
 	KeyGCPBackups:          {"backupdr.managementServers.create"},
+	// Cloud DNS (#593). managedZones.create + resourceRecordSets.create
+	// cover zone + record CRUD; changes.create covers the underlying
+	// change-batch API the provider uses. SA needs dns.googleapis.com
+	// enabled but the API-enable lives in always-required
+	// (serviceusage.services.enable is implicit in resourcemanager.projects.get).
+	KeyGCPCloudDNS: {
+		"dns.changes.create",
+		"dns.managedZones.create",
+		"dns.resourceRecordSets.create",
+	},
 	// Components that need no extra permission beyond the always-required set:
 	KeyGCPVPC:          nil,
 	KeyGCPCompute:      nil,

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -606,6 +606,39 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+	case KeyAWSACM:
+		// ACM (#593). domain_name is required by the preset (no default);
+		// supply a preview-safe placeholder so single-module previews and
+		// validation runs succeed when the caller hasn't yet provided
+		// cfg.AWSACM.DomainName. Same .invalid TLD strategy as route53:
+		// fails loud at apply time against the real ACM API.
+		domain := "example.invalid"
+		if cfg != nil && cfg.AWSACM != nil && strings.TrimSpace(cfg.AWSACM.DomainName) != "" {
+			domain = strings.TrimSpace(cfg.AWSACM.DomainName)
+		}
+		vals["domain_name"] = domain
+		if cfg != nil && cfg.AWSACM != nil {
+			if len(cfg.AWSACM.SubjectAlternativeNames) > 0 {
+				sans := make([]any, len(cfg.AWSACM.SubjectAlternativeNames))
+				for i, s := range cfg.AWSACM.SubjectAlternativeNames {
+					sans[i] = s
+				}
+				vals["subject_alternative_names"] = sans
+			}
+			if cfg.AWSACM.KeyAlgorithm != "" {
+				vals["key_algorithm"] = cfg.AWSACM.KeyAlgorithm
+			}
+			if cfg.AWSACM.CertificateTransparencyLogging != "" {
+				vals["certificate_transparency_logging"] = cfg.AWSACM.CertificateTransparencyLogging
+			}
+			if cfg.AWSACM.CreateValidation != nil {
+				vals["create_validation"] = *cfg.AWSACM.CreateValidation
+			}
+			if cfg.AWSACM.ValidationTimeout != "" {
+				vals["validation_timeout"] = cfg.AWSACM.ValidationTimeout
+			}
+		}
+
 	case KeyAWSKMS:
 		if cfg != nil && cfg.AWSKMS != nil && cfg.AWSKMS.NumKeys != "" {
 			n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSKMS.NumKeys))
@@ -1010,6 +1043,41 @@ func (m DefaultMapper) BuildModuleValues(
 		if cfg != nil && cfg.GCPBackups != nil {
 			if cfg.GCPBackups.Compute != nil && cfg.GCPBackups.Compute.RetentionDays > 0 {
 				vals["snapshot_retention_days"] = cfg.GCPBackups.Compute.RetentionDays
+			}
+		}
+
+	case KeyGCPCloudDNS:
+		// Cloud DNS (#593). dns_name is required by the preset (no
+		// default); supply a preview-safe placeholder with the trailing
+		// dot Cloud DNS expects. Same .invalid TLD strategy as
+		// route53 / acm.
+		dns := "example.invalid."
+		if cfg != nil && cfg.GCPCloudDNS != nil && strings.TrimSpace(cfg.GCPCloudDNS.DNSName) != "" {
+			dns = strings.TrimSpace(cfg.GCPCloudDNS.DNSName)
+		}
+		vals["dns_name"] = dns
+		if cfg != nil && cfg.GCPCloudDNS != nil {
+			if cfg.GCPCloudDNS.CreateZone != nil {
+				vals["create_zone"] = *cfg.GCPCloudDNS.CreateZone
+			}
+			if cfg.GCPCloudDNS.ZoneShortName != "" {
+				vals["zone_short_name"] = cfg.GCPCloudDNS.ZoneShortName
+			}
+			if cfg.GCPCloudDNS.ZoneName != "" {
+				vals["zone_name"] = cfg.GCPCloudDNS.ZoneName
+			}
+			if cfg.GCPCloudDNS.PrivateZone != nil {
+				vals["private_zone"] = *cfg.GCPCloudDNS.PrivateZone
+			}
+			if len(cfg.GCPCloudDNS.NetworkSelfLinks) > 0 {
+				links := make([]any, len(cfg.GCPCloudDNS.NetworkSelfLinks))
+				for i, l := range cfg.GCPCloudDNS.NetworkSelfLinks {
+					links[i] = l
+				}
+				vals["network_self_links"] = links
+			}
+			if cfg.GCPCloudDNS.ForceDestroy != nil {
+				vals["force_destroy"] = *cfg.GCPCloudDNS.ForceDestroy
 			}
 		}
 	}

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -174,6 +174,14 @@ func kitchenSinkConfig() *Config {
 		VPCIDs       []string `json:"vpcIds,omitempty"`
 		ForceDestroy *bool    `json:"forceDestroy,omitempty"`
 	}{DomainName: "example.com", CreateZone: &t, ZoneID: "Z1234567890ABC", VPCIDs: []string{"vpc-aaa"}, ForceDestroy: &t}
+	cfg.AWSACM = &struct {
+		DomainName                     string   `json:"domainName,omitempty"`
+		SubjectAlternativeNames        []string `json:"subjectAlternativeNames,omitempty"`
+		KeyAlgorithm                   string   `json:"keyAlgorithm,omitempty"`
+		CertificateTransparencyLogging string   `json:"certificateTransparencyLogging,omitempty"`
+		CreateValidation               *bool    `json:"createValidation,omitempty"`
+		ValidationTimeout              string   `json:"validationTimeout,omitempty"`
+	}{DomainName: "example.com", SubjectAlternativeNames: []string{"www.example.com"}, KeyAlgorithm: "RSA_2048", CertificateTransparencyLogging: "ENABLED", CreateValidation: &t, ValidationTimeout: "45m"}
 
 	// GCP
 	cfg.GCPCompute = &struct {
@@ -226,6 +234,15 @@ func kitchenSinkConfig() *Config {
 	cfg.GCPLoadbalancer = &struct {
 		EnableCDN *bool `json:"enable_cdn,omitempty"`
 	}{EnableCDN: &t}
+	cfg.GCPCloudDNS = &struct {
+		DNSName          string   `json:"dnsName,omitempty"`
+		CreateZone       *bool    `json:"createZone,omitempty"`
+		ZoneShortName    string   `json:"zoneShortName,omitempty"`
+		ZoneName         string   `json:"zoneName,omitempty"`
+		PrivateZone      *bool    `json:"privateZone,omitempty"`
+		NetworkSelfLinks []string `json:"networkSelfLinks,omitempty"`
+		ForceDestroy     *bool    `json:"forceDestroy,omitempty"`
+	}{DNSName: "example.com.", CreateZone: &t, ZoneShortName: "primary", ZoneName: "example-com", NetworkSelfLinks: []string{"projects/p/global/networks/n"}, ForceDestroy: &t}
 
 	return cfg
 }

--- a/pkg/composer/mapper_required_test.go
+++ b/pkg/composer/mapper_required_test.go
@@ -130,6 +130,7 @@ func kitchenSinkComponents() *Components {
 		AWSGitHubActions:        &t,
 		AWSCodePipeline:         &t,
 		AWSRoute53:              &t,
+		AWSACM:                  &t,
 		// GCP
 		GCPVPC:              &t,
 		GCPBastion:          &t,
@@ -152,6 +153,7 @@ func kitchenSinkComponents() *Components {
 		GCPCloudMonitoring:  &t,
 		GCPIdentityPlatform: &t,
 		GCPCloudBuild:       &t,
+		GCPCloudDNS:         &t,
 	}
 }
 

--- a/pkg/composer/pricing.go
+++ b/pkg/composer/pricing.go
@@ -120,6 +120,8 @@ type PricingData struct {
 		AWSCognito              *PricingItem    `json:"aws_cognito,omitempty"`
 		AWSGitHubActions        *PricingItem    `json:"aws_github_actions,omitempty"`
 		AWSCodePipeline         *PricingItem    `json:"aws_codepipeline,omitempty"`
+		AWSRoute53              *PricingItem    `json:"aws_route53,omitempty"`
+		AWSACM                  *PricingItem    `json:"aws_acm,omitempty"`
 		AWSBackups              *PricingBackups `json:"aws_backups,omitempty"`
 
 		// GCP Components
@@ -144,6 +146,7 @@ type PricingData struct {
 		GCPCloudMonitoring  *PricingItem       `json:"gcp_cloud_monitoring,omitempty"`
 		GCPIdentityPlatform *PricingItem       `json:"gcp_identity_platform,omitempty"`
 		GCPCloudBuild       *PricingItem       `json:"gcp_cloud_build,omitempty"`
+		GCPCloudDNS         *PricingItem       `json:"gcp_cloud_dns,omitempty"`
 		GCPBackups          *GCPPricingBackups `json:"gcp_backups,omitempty"`
 
 		// External/Third-Party
@@ -226,6 +229,8 @@ func (p *PricingData) Normalize() {
 		c.AWSCognito = nil
 		c.AWSGitHubActions = nil
 		c.AWSCodePipeline = nil
+		c.AWSRoute53 = nil
+		c.AWSACM = nil
 		c.AWSBackups = nil
 
 		// Sync legacy and cloud-specific fields for GCP
@@ -400,6 +405,7 @@ func (p *PricingData) Normalize() {
 		c.GCPCloudMonitoring = nil
 		c.GCPIdentityPlatform = nil
 		c.GCPCloudBuild = nil
+		c.GCPCloudDNS = nil
 		c.GCPBackups = nil
 
 		// Sync legacy and cloud-specific fields for AWS

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -44,6 +44,7 @@ type Components struct {
 	AWSGitHubActions        *bool  `json:"aws_github_actions,omitempty"`
 	AWSCodePipeline         *bool  `json:"aws_codepipeline,omitempty"`
 	AWSRoute53              *bool  `json:"aws_route53,omitempty"`
+	AWSACM                  *bool  `json:"aws_acm,omitempty"`
 	AWSBackups              *struct {
 		EC2         *bool `json:"aws_ec2,omitempty"`
 		RDS         *bool `json:"aws_rds,omitempty"`
@@ -74,6 +75,7 @@ type Components struct {
 	GCPCloudMonitoring  *bool  `json:"gcp_cloud_monitoring,omitempty"`
 	GCPIdentityPlatform *bool  `json:"gcp_identity_platform,omitempty"`
 	GCPCloudBuild       *bool  `json:"gcp_cloud_build,omitempty"`
+	GCPCloudDNS         *bool  `json:"gcp_cloud_dns,omitempty"`
 	GCPBackups          *struct {
 		Compute  *bool `json:"gcp_compute,omitempty"`
 		CloudSQL *bool `json:"gcp_cloudsql,omitempty"`
@@ -221,6 +223,23 @@ type Config struct {
 		ForceDestroy *bool  `json:"forceDestroy,omitempty"`
 	} `json:"aws_route53,omitempty"`
 
+	// AWSACM carries the caller-supplied ACM certificate configuration.
+	// DomainName is the primary FQDN; SubjectAlternativeNames adds SANs.
+	// CreateValidation toggles the synchronous `aws_acm_certificate_validation`
+	// wait — the composer leaves this at the module's default (false) today,
+	// but a future #593-followup PR will flip it to true automatically when
+	// aws/route53 is in the stack (once the back-edge wiring is unblocked).
+	// KeyAlgorithm pins RSA_2048 (default) vs EC_prime256v1 / EC_secp384r1.
+	// ValidationTimeout caps the validation wait when CreateValidation=true.
+	AWSACM *struct {
+		DomainName                     string   `json:"domainName,omitempty"`
+		SubjectAlternativeNames        []string `json:"subjectAlternativeNames,omitempty"`
+		KeyAlgorithm                   string   `json:"keyAlgorithm,omitempty"`
+		CertificateTransparencyLogging string   `json:"certificateTransparencyLogging,omitempty"`
+		CreateValidation               *bool    `json:"createValidation,omitempty"`
+		ValidationTimeout              string   `json:"validationTimeout,omitempty"`
+	} `json:"aws_acm,omitempty"`
+
 	AWSKMS *struct {
 		NumKeys string `json:"numKeys,omitempty"`
 	} `json:"aws_kms,omitempty"`
@@ -333,6 +352,22 @@ type Config struct {
 		EnableCDN *bool `json:"enable_cdn,omitempty"`
 	} `json:"gcp_loadbalancer,omitempty"`
 
+	// GCPCloudDNS carries the caller-supplied Cloud DNS configuration.
+	// DNSName is the apex (e.g. "example.com.") and is required when
+	// KeyGCPCloudDNS is selected. CreateZone toggles between creating a
+	// managed zone in-stack (true) and looking up an existing one by
+	// ZoneName (false). PrivateZone + NetworkSelfLinks are only consulted
+	// when CreateZone is true and the zone is intended to be private.
+	GCPCloudDNS *struct {
+		DNSName          string   `json:"dnsName,omitempty"`
+		CreateZone       *bool    `json:"createZone,omitempty"`
+		ZoneShortName    string   `json:"zoneShortName,omitempty"`
+		ZoneName         string   `json:"zoneName,omitempty"`
+		PrivateZone      *bool    `json:"privateZone,omitempty"`
+		NetworkSelfLinks []string `json:"networkSelfLinks,omitempty"`
+		ForceDestroy     *bool    `json:"forceDestroy,omitempty"`
+	} `json:"gcp_cloud_dns,omitempty"`
+
 	GCPBackups *struct {
 		Compute *struct {
 			FrequencyHours int `json:"frequencyHours,omitempty"`
@@ -391,6 +426,7 @@ func (c *Components) Normalize() {
 		c.GCPCloudMonitoring = nil
 		c.GCPIdentityPlatform = nil
 		c.GCPCloudBuild = nil
+		c.GCPCloudDNS = nil
 		c.GCPBackups = nil
 	}
 	if c.Cloud == "GCP" {
@@ -421,6 +457,7 @@ func (c *Components) Normalize() {
 		c.AWSGitHubActions = nil
 		c.AWSCodePipeline = nil
 		c.AWSRoute53 = nil
+		c.AWSACM = nil
 		c.AWSBackups = nil
 	}
 }
@@ -493,6 +530,7 @@ func (c *Config) Normalize() {
 		c.GCPIdentityPlatform = nil
 		c.GCPAPIGateway = nil
 		c.GCPLoadbalancer = nil
+		c.GCPCloudDNS = nil
 		c.GCPBackups = nil
 		// AWSCloudfront.CachePaths is a within-prefixed deprecated sub-field;
 		// migrate to OriginPath and clear. Distinct from the legacy Cloudfront
@@ -527,6 +565,7 @@ func (c *Config) Normalize() {
 		c.AWSOpenSearch = nil
 		c.AWSBedrock = nil
 		c.AWSRoute53 = nil
+		c.AWSACM = nil
 		c.AWSBackups = nil
 	}
 }

--- a/pkg/observability/display.go
+++ b/pkg/observability/display.go
@@ -131,6 +131,8 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "AWS GitHub Actions OIDC"
 	case composer.KeyAWSRoute53:
 		return "AWS Route 53"
+	case composer.KeyAWSACM:
+		return "AWS Certificate Manager"
 	case composer.KeyGCPCompute:
 		return "GCP Compute Engine"
 	case composer.KeyGCPGKE:
@@ -173,6 +175,8 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "GCP Cloud Logging"
 	case composer.KeyGCPCloudMonitoring:
 		return "GCP Cloud Monitoring"
+	case composer.KeyGCPCloudDNS:
+		return "GCP Cloud DNS"
 	case composer.KeyGCPBackups:
 		return "GCP Backups"
 	default:

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -59,12 +59,14 @@ var configExtractorAllowlist = map[string]string{
 	"aws_backups":        "[no-inspector] AWS Backup vaults aren't inspected; covered via tag-based discovery (#204)",
 	"aws_github_actions": "[no-inspector] GitHub Actions IAM roles only — no SDK shape to extract (#204)",
 	"aws_route53":        "[no-inspector] Route 53 hosted zones / records not yet covered by the discovery pipeline (#584 follow-up)",
+	"aws_acm":            "[no-inspector] ACM certificates not yet covered by the discovery pipeline (#593 follow-up)",
 
 	// EKS node group: ComponentKey "aws_eks_nodegroup" doesn't have its
 	// own SDK inspector — extraction is handled by aws_eks (#204, #224).
 	"aws_eks_nodegroup": "[no-inspector] EKS node group is covered by the aws_eks inspector (#204)",
 
-	"gcp_backups": "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
+	"gcp_backups":   "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
+	"gcp_cloud_dns": "[no-inspector] Cloud DNS managed zones / record sets not yet covered by the discovery pipeline (#593 follow-up)",
 }
 
 // extractorFixtures are minimal SDK-shape fixtures that exercise each


### PR DESCRIPTION
## Summary

Wires the `aws/acm` (#586) and `gcp/cloud_dns` (#583) presets into the composer Go code so callers can compose them into stacks. Until this lands, both presets ship as standalone modules in the bundle PR but are not selectable via `composer.ComposeStack`.

Closes #593.
Follow-ups filed: #596 (inspectors), #601 (back-edge wiring).

## What changed

**Registry plumbing** (`pkg/composer/contracts.go`, `types.go`, `coherence.go`, `iam_actions.go`, `gcp_services.go`, `pricing.go`)
- New `KeyAWSACM = \"aws_acm\"` + `KeyGCPCloudDNS = \"gcp_cloud_dns\"` component keys wired into `ComposeOrder`, `ModulePath`, `PresetKeyMap`, `AllComponentKeys`, `ComponentSelected`, `isOrphanStrippableKey`, `AWSIAMActions`, `GCPIAMPermissions`, `GCPServices`, and `PricingData.Components`.
- `Components.AWSACM` (`*bool`) + `Components.GCPCloudDNS` (`*bool`) selection fields.
- `Config.AWSACM` sub-struct (DomainName, SubjectAlternativeNames, KeyAlgorithm, CertificateTransparencyLogging, CreateValidation, ValidationTimeout).
- `Config.GCPCloudDNS` sub-struct (DNSName, CreateZone, ZoneShortName, ZoneName, PrivateZone, NetworkSelfLinks, ForceDestroy).
- IAM coverage: ACM gets RequestCertificate / DescribeCertificate / DeleteCertificate / Add+ListTags / ListCertificates / UpdateCertificateOptions; Cloud DNS gets managedZones.create / resourceRecordSets.create / changes.create plus the `dns.googleapis.com` service entry.

**Cross-module wiring** (`pkg/composer/contracts.go::DefaultWiring`)
- When the stack includes Route 53 + ACM, the composer auto-emits a `records = [for r in module.aws_acm.validation_records : { name = r.name, type = r.type, ttl = 60, values = [r.value] }]` block on the route53 module, reshaping ACM's `{name,type,value}` output into route53's `{name,type,ttl,values}` input. TTL pinned to 60s — ACM polls validation every 60s, so anything higher just wastes time on first apply.
- Back-edge wiring (`route53.record_fqdns` → `acm.validation_record_fqdns` + auto-flip `acm.create_validation = true`) is deferred to #601. Closing that loop creates an `acm ↔ route53` 2-cycle that `ValidateNoModuleCycles` flags before terraform plan ever runs. The cleanest fix is to give route53 a dedicated input separate from `var.records` so the back-edge can read a route53 output that doesn't depend on the ACM-sourced records.

**Mapper** (`pkg/composer/mapper.go`)
- `domain_name` (ACM) and `dns_name` (Cloud DNS) default to `example.invalid` / `example.invalid.` (IANA-reserved testing TLD) when the caller hasn't supplied one — both presets have no default and single-module previews need it. Fails loud at apply time against the real API, which is the right surface (not silent validation-time miss).
- Caller-supplied `cfg.AWSACM.*` / `cfg.GCPCloudDNS.*` fields flow through to the matching module variables.

**HCL validation surface** (`pkg/composer/hcl_validation.go`)
- Added `stdlib.DistinctFunc` to the validation function map so the cloud_dns preset's `distinct([...])` rule (uniqueness check on records) evaluates against its default at `TestPresetDefaultsSatisfyValidations` time.

**Observability plumbing** (`pkg/observability/display.go`, `extractors/extractors_drift_test.go`)
- `ComponentDisplayName(KeyAWSACM) → \"AWS Certificate Manager\"`, `ComponentDisplayName(KeyGCPCloudDNS) → \"GCP Cloud DNS\"`.
- Allowlist entries for `aws_acm` and `gcp_cloud_dns` with `[no-inspector]` rationale until the discovery pipeline gains coverage. Tracked in #596.

**Tests** (`pkg/composer/acm_wiring_test.go`, `cloud_dns_wiring_test.go`)
- 13 new tests covering: forward wiring (ACM → route53.records), inert producer (ACM alone), inert consumer (route53 alone), records+aliases coexistence (ACM + ALB + route53), mapper defaults, mapper caller-supplied config, end-to-end `ComposeStack` integration (ACM + route53 / standalone, Cloud DNS standalone).
- `kitchenSinkConfig` + `kitchenSinkComponents` updated so existing drift gates (`TestMapperKeysSubsetOfModuleVariables`, `TestEveryRequiredVariableIsMappedOrWired`) exercise the new mapper branches.

## Per-consumer wiring status

| Direction | Status | Notes |
|---|---|---|
| ACM `validation_records` → route53 `records` | Done | Pinned by `TestDefaultWiring_ACMValidationRecordsIntoRoute53` + `TestComposeStack_ACMWithRoute53` |
| route53 `record_fqdns` → ACM `validation_record_fqdns` | Deferred (#601) | Cycle blocker; needs route53 to expose a separate input to break the loop |
| Auto-flip `acm.create_validation = true` | Deferred (#601) | Paired with the back-edge wiring |
| Cloud DNS cross-module wiring | Deferred | No GCP-side consumer needs Cloud DNS today; tracked as a follow-up when a real wiring use-case lands |

## Scope decisions

- **Forward-only ACM wiring.** The back-edge would create a module cycle that the composer's own `ValidateNoModuleCycles` would reject. Rather than land partial wiring that fails composer-validation when both keys are selected, the forward direction ships and the back-edge is a clean follow-up (#601) with a documented fix path.
- **Mapper placeholders use `example.invalid` / `example.invalid.`** — IANA-reserved TLD makes it obvious in logs / `.auto.tfvars` that this is a stub; will fail loudly at the ACM / Cloud DNS API on apply rather than silently producing a real-looking cert / record. Cloud DNS variant carries the trailing dot Cloud DNS expects.
- **Pricing rows added as plain `*PricingItem` slots.** The LLM pricing pipeline will fill in actual values; the spec called for $0 (ACM public) / $400 (ACM private CA) / $0.50/zone-mo (Cloud DNS), but those are pricing-prompt concerns, not composer-side constants. Adding the slots is enough — the LLM populates them at price-compute time and the merge layer carries them forward.
- **Inspectors deferred to #596.** That issue already exists and covers route53 + ACM + cloud_dns together; matching `[no-inspector]` allowlist entries here.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` clean
- [x] `go test ./pkg/composer/... -count=1` — 2018 passed
- [x] `go test ./... -count=1` — 5121 passed across 36 packages
- [x] `terraform fmt -check -recursive` clean
- [x] All ten repo lint scripts pass (`lint-project-tag.sh`, `lint-project-label.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`, `lint-no-root-only-blocks.sh`, `lint-labelless-name-prefix.sh`, `lint-gcp-project-pin.sh`, `lint-shared-no-cloud-providers.sh`, `lint-phantom-computed-fields.sh`, `lint-enrichgen-override-citations.sh`)
- [x] `make verify-gen` passes
- [x] `make verify-supported-resources` passes
- [x] `aws/acm` and `gcp/cloud_dns` pass `tests/validate-as-child.sh` (wrapped as child modules)
- [x] New `TestComposeStack_ACMWithRoute53` integration test asserts the composed root `main.tf` emits `module.aws_acm.validation_records` inside the route53 module's `records =` input

## Review notes

- This is engine integration only — no preset HCL changes. The presets themselves landed in #583 (cloud_dns) and #586 (acm) and were validated there.
- Issue #594 referenced in the task description corresponds to the bundle PR that landed these presets together; the standalone preset commits were #583 and #586.
- Test counts: +13 new tests (8 in acm_wiring_test.go, 5 in cloud_dns_wiring_test.go). The kitchen-sink updates indirectly add coverage to `TestMapperKeysSubsetOfModuleVariables` and `TestEveryRequiredVariableIsMappedOrWired` for the two new keys via their `t.Run` per-key subtests.