### PR TITLE
fix(composer): backfill missing GCP ImplicitDependencies (#600)

### DIFF
--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -246,6 +246,31 @@ var ImplicitDependencies = map[ComponentKey][]ComponentKey{
 	KeyAWSEKSNodeGroup: {KeyAWSEKS, KeyAWSVPC},
 	KeyAWSEC2:          {KeyAWSVPC},
 	KeyGCPCompute:      {KeyGCPVPC},
+	// Issue #600: GCP services that consume the VPC at apply time but were
+	// previously not declared, causing silent apply-time failures whenever
+	// private endpoints / VPC connectors were configured.
+	//
+	// Vertex AI private endpoints peer with the customer VPC via
+	// servicenetworking.googleapis.com — without the VPC up first, the
+	// google_vertex_ai_endpoint resource errors with NOT_FOUND on the
+	// network reference.
+	KeyGCPVertexAI: {KeyGCPVPC},
+	// Cloud Functions Gen 2 with vpc_connector / VPC egress requires the
+	// serverless VPC access connector (provisioned by gcp/vpc when
+	// enable_serverless_connector is on). Selecting Cloud Functions without
+	// the VPC leaves the connector ref dangling.
+	KeyGCPCloudFunctions: {KeyGCPVPC},
+	// Cloud Run with vpc_access_connector has the same dependency on the
+	// serverless VPC access connector as Cloud Functions Gen 2.
+	KeyGCPCloudRun: {KeyGCPVPC},
+	// Cloud Build private worker pools peer with the customer VPC via
+	// servicenetworking; the pool create call fails if the VPC + private
+	// service connection isn't up.
+	KeyGCPCloudBuild: {KeyGCPVPC},
+	// Cloud Armor security policies only attach to backend services on an
+	// HTTPS load balancer; selecting Cloud Armor without the LB silently
+	// no-ops at apply time.
+	KeyGCPCloudArmor: {KeyGCPLoadbalancer},
 }
 
 // ResolveDependencies recursively finds all required components for a given set of keys.

--- a/pkg/composer/implicit_deps_test.go
+++ b/pkg/composer/implicit_deps_test.go
@@ -1,0 +1,99 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestImplicitDependencies_GCPCompute_AutoWiresVPC pins the GCP services
+// that consume the VPC at apply time. Each entry below was a silent
+// apply-time failure before issue #600: selecting the service without
+// also selecting gcp/vpc left dangling network references that only
+// surfaced once terraform reached the cloud API.
+//
+// KeyGCPGKE → KeyGCPVPC was the existing template; the rest were
+// backfilled in #600. KeyGCPCloudArmor → KeyGCPLoadbalancer is the
+// parallel for the LB-only attachment point.
+func TestImplicitDependencies_GCPCompute_AutoWiresVPC(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		consumer ComponentKey
+		need     ComponentKey
+		reason   string
+	}{
+		// Template (pre-existing) — pinned here so the table reads as a
+		// complete contract, not just the new rows.
+		{KeyGCPGKE, KeyGCPVPC, "GKE clusters require a VPC for the cluster network"},
+
+		// Issue #600 backfill.
+		{KeyGCPVertexAI, KeyGCPVPC, "Vertex AI private endpoints peer with the VPC via servicenetworking"},
+		{KeyGCPCloudFunctions, KeyGCPVPC, "Cloud Functions Gen 2 with VPC egress needs the serverless VPC connector"},
+		{KeyGCPCloudRun, KeyGCPVPC, "Cloud Run with vpc_access_connector needs the serverless VPC connector"},
+		{KeyGCPCloudBuild, KeyGCPVPC, "Cloud Build private worker pools peer with the customer VPC"},
+		{KeyGCPCloudArmor, KeyGCPLoadbalancer, "Cloud Armor only attaches to backend services on an HTTPS LB"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(string(tc.consumer)+"_needs_"+string(tc.need), func(t *testing.T) {
+			t.Parallel()
+
+			deps, ok := ImplicitDependencies[tc.consumer]
+			require.True(t, ok,
+				"ImplicitDependencies[%s] must be declared (%s)", tc.consumer, tc.reason)
+			assert.Contains(t, deps, tc.need,
+				"%s must implicitly depend on %s — %s", tc.consumer, tc.need, tc.reason)
+
+			// ResolveDependencies must hand back tc.need alongside tc.consumer
+			// when only the consumer is selected — this is the user-visible
+			// contract.
+			resolved := ResolveDependencies([]ComponentKey{tc.consumer})
+			assert.Contains(t, resolved, tc.need,
+				"ResolveDependencies([%s]) must auto-include %s", tc.consumer, tc.need)
+			assert.Contains(t, resolved, tc.consumer,
+				"ResolveDependencies([%s]) must preserve the original consumer", tc.consumer)
+		})
+	}
+}
+
+// TestImplicitDependencies_ComposeOrderRespected verifies that for every
+// (consumer → dependency) entry, the dependency appears before the
+// consumer in ComposeOrder. Terraform composes modules in declared
+// order; if a dependency landed after its consumer, the consumer's
+// module block would reference a not-yet-declared module.
+//
+// This is the structural invariant that backstops the new #600 entries —
+// any future addition to ImplicitDependencies that violates ordering
+// fails this test instead of failing silently at apply time.
+func TestImplicitDependencies_ComposeOrderRespected(t *testing.T) {
+	t.Parallel()
+
+	position := make(map[ComponentKey]int, len(ComposeOrder))
+	for i, k := range ComposeOrder {
+		position[k] = i
+	}
+
+	for consumer, deps := range ImplicitDependencies {
+		consumerPos, consumerInOrder := position[consumer]
+		if !consumerInOrder {
+			// Not every ComponentKey participates in ComposeOrder (e.g. the
+			// pseudo-components Arch/Cloud/Composer). Skip — ordering is
+			// only meaningful for keys the composer actually emits.
+			continue
+		}
+		for _, dep := range deps {
+			depPos, depInOrder := position[dep]
+			if !depInOrder {
+				t.Errorf("ImplicitDependencies[%s] references %s which is missing from ComposeOrder",
+					consumer, dep)
+				continue
+			}
+			assert.Less(t, depPos, consumerPos,
+				"ComposeOrder violation: %s (pos=%d) must precede consumer %s (pos=%d) — implicit deps must compose first",
+				dep, depPos, consumer, consumerPos)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`ImplicitDependencies` declares which preset modules need other modules auto-wired when selected. Five GCP keys were missing their implicit dependency, silently causing apply-time failures when private endpoints / VPC connectors / LB attachments were configured but the upstream module wasn't explicitly selected.

## Added rows

| Consumer | Implicit dep | Why |
|---|---|---|
| `KeyGCPVertexAI` | `KeyGCPVPC` | Vertex AI private endpoints peer with the VPC via `servicenetworking.googleapis.com`; the `google_vertex_ai_endpoint` resource errors `NOT_FOUND` on the network reference without the VPC up first |
| `KeyGCPCloudFunctions` | `KeyGCPVPC` | Cloud Functions Gen 2 with `vpc_connector` / VPC egress requires the serverless VPC access connector (provisioned by `gcp/vpc` when `enable_serverless_connector` is on) |
| `KeyGCPCloudRun` | `KeyGCPVPC` | Same serverless VPC access connector dependency as Cloud Functions Gen 2 |
| `KeyGCPCloudBuild` | `KeyGCPVPC` | Cloud Build private worker pools peer with the customer VPC via servicenetworking |
| `KeyGCPCloudArmor` | `KeyGCPLoadbalancer` | Cloud Armor security policies only attach to backend services on an HTTPS load balancer; selecting Cloud Armor without the LB silently no-ops at apply time |

`KeyGCPGKE → KeyGCPVPC` was the existing template; the others are direct parallels.

## Tests

- `TestImplicitDependencies_GCPCompute_AutoWiresVPC` (new, table-driven) pins each row end-to-end: declared in `ImplicitDependencies` AND surfaced by `ResolveDependencies`.
- `TestImplicitDependencies_ComposeOrderRespected` (new) is a structural invariant that any dep must precede its consumer in `ComposeOrder` — any future addition that violates ordering fails this test instead of failing silently at apply time.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/composer/ -run TestImplicitDependencies -count=1` — 8/8 pass
- [x] `go vet ./...` clean
- [ ] CI: full sweep

Closes #600.