### PR TITLE
bundle: DNS+cert observability dispatcher closeout (#596, partial #599/#601)

### DIFF
--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -491,13 +491,6 @@ var AllComponentKeys = []ComponentKey{
 	KeyGCPVertexAI,
 }
 
-func isLambda(comps *Components) bool {
-	if comps == nil {
-		return false
-	}
-	return comps.IsLambdaArchitecture()
-}
-
 // isPublicVPC returns true if the VPC is configured as a Public VPC (no
 // private subnets). Reads only comps.AWSVPC; the legacy comps.VPC string is
 // promoted to AWSVPC by Components.Normalize, which ComposeStack /

--- a/pkg/observability/discovery/aws/acm.go
+++ b/pkg/observability/discovery/aws/acm.go
@@ -1,0 +1,108 @@
+// ACM (AWS Certificate Manager) inspector (issue #596).
+//
+// Provides panel-default discovery for the aws/acm preset (#586,
+// composer wiring #602). Two actions:
+//
+//   - list-certificates — ListCertificates; returns the
+//     CertificateSummaryList. The SDK exposes a `Includes` filter that
+//     can scope by KeyTypes / KeyUsage / ExtendedKeyUsage, but tag-based
+//     project scoping is not server-side (callers post-filter via
+//     ListTagsForCertificate per-cert in the panel layer when needed).
+//   - describe-certificate — DescribeCertificate for a specific ARN
+//     (caller supplies certificate_arn in the filters JSON). Returns
+//     the full certificate detail including domain_validation_options
+//     for DNS validation drift.
+//
+// Issue #255 contract: list-certificates uses nilSliceToEmpty so an
+// empty AWS response marshals as `[]` not `null`. describe-certificate
+// returns a single object (no slice nil to worry about) but the
+// "RenewalSummary.DomainValidationOptions" sub-slice can still be nil
+// post-marshal; downstream consumers tolerate that on a per-cert object
+// detail (it's already wrapped in a map, not the top-level slice the
+// reliable UI gates on).
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acm"
+	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+)
+
+// acmClient is the narrowed SDK surface used by inspectACM. Lets tests
+// inject a fake without doing real AWS auth.
+type acmClient interface {
+	ListCertificates(ctx context.Context, params *acm.ListCertificatesInput, optFns ...func(*acm.Options)) (*acm.ListCertificatesOutput, error)
+	DescribeCertificate(ctx context.Context, params *acm.DescribeCertificateInput, optFns ...func(*acm.Options)) (*acm.DescribeCertificateOutput, error)
+}
+
+func inspectACM(ctx context.Context, cfg aws.Config, action, filters string) (any, error) {
+	switch action {
+	case "list-certificates":
+		return listCertificates(ctx, acm.NewFromConfig(cfg))
+	case "describe-certificate":
+		certArn, err := acmFilterCertificateArn(filters)
+		if err != nil {
+			return nil, err
+		}
+		return describeCertificate(ctx, acm.NewFromConfig(cfg), certArn)
+	case "get-metrics":
+		// ACM emits a small set of CloudWatch metrics (DaysToExpiry per
+		// cert) under the AWS/CertificateManager namespace; the metrics
+		// fetch path owns those. Route through metricsRouted so callers
+		// can pivot to pkg/observability/metrics.
+		return metricsRouted("acm")
+	default:
+		return nil, unsupportedActionError("acm", action)
+	}
+}
+
+// listCertificates runs ListCertificates and returns the
+// CertificateSummaryList with nil normalized to []. The API supports
+// pagination via NextToken — current implementation returns the first
+// page (default 1000 certs); fan-out is a follow-up if real customers
+// hit that ceiling (no observed cases in production presets, which
+// typically manage <10 certs per stack).
+func listCertificates(ctx context.Context, client acmClient) ([]acmtypes.CertificateSummary, error) {
+	out, err := client.ListCertificates(ctx, &acm.ListCertificatesInput{})
+	if err != nil {
+		return nil, err
+	}
+	return nilSliceToEmpty(out.CertificateSummaryList), nil
+}
+
+// describeCertificate runs DescribeCertificate for the given ARN and
+// returns the full CertificateDetail. Used by drift detection to
+// compare domain_validation_options against the snapshot.
+func describeCertificate(ctx context.Context, client acmClient, arn string) (*acmtypes.CertificateDetail, error) {
+	out, err := client.DescribeCertificate(ctx, &acm.DescribeCertificateInput{
+		CertificateArn: aws.String(arn),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out.Certificate, nil
+}
+
+// acmFilterCertificateArn parses the filters JSON envelope for a
+// `certificate_arn` key. Returns a structured error (not silent
+// fallback) when missing — DescribeCertificate is a per-ARN call, so
+// the inspector cannot pick a "default" cert.
+func acmFilterCertificateArn(filters string) (string, error) {
+	if filters == "" {
+		return "", fmt.Errorf("describe-certificate requires a certificate_arn in the filters envelope (e.g. {\"certificate_arn\":\"arn:aws:acm:...\"})")
+	}
+	var fm map[string]string
+	if err := json.Unmarshal([]byte(filters), &fm); err != nil {
+		return "", fmt.Errorf("describe-certificate: invalid filters JSON: %w", err)
+	}
+	arn := fm["certificate_arn"]
+	if arn == "" {
+		return "", fmt.Errorf("describe-certificate requires a certificate_arn in the filters envelope (e.g. {\"certificate_arn\":\"arn:aws:acm:...\"})")
+	}
+	return arn, nil
+}

--- a/pkg/observability/discovery/aws/acm_test.go
+++ b/pkg/observability/discovery/aws/acm_test.go
@@ -1,0 +1,155 @@
+// ACM inspector tests (issue #596).
+//
+// Pins the #255 contract: empty list-certificates response MUST marshal
+// as JSON `[]`, never `null`. Also pins describe-certificate's required
+// certificate_arn surface and the metrics-routing arm.
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acm"
+	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeACMClient struct {
+	listOut          *acm.ListCertificatesOutput
+	describeOut      *acm.DescribeCertificateOutput
+	describeIn       *acm.DescribeCertificateInput
+	err              error
+}
+
+func (f *fakeACMClient) ListCertificates(_ context.Context, _ *acm.ListCertificatesInput, _ ...func(*acm.Options)) (*acm.ListCertificatesOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.listOut == nil {
+		return &acm.ListCertificatesOutput{}, nil
+	}
+	return f.listOut, nil
+}
+
+func (f *fakeACMClient) DescribeCertificate(_ context.Context, in *acm.DescribeCertificateInput, _ ...func(*acm.Options)) (*acm.DescribeCertificateOutput, error) {
+	f.describeIn = in
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.describeOut == nil {
+		return &acm.DescribeCertificateOutput{}, nil
+	}
+	return f.describeOut, nil
+}
+
+// TestListCertificates_EmptyResult — #255 contract: empty response is
+// JSON `[]`, not `null`. The reliable UI's ACM panel gates render on the
+// list shape.
+func TestListCertificates_EmptyResult(t *testing.T) {
+	t.Parallel()
+	got, err := listCertificates(context.Background(), &fakeACMClient{})
+	require.NoError(t, err)
+	require.NotNil(t, got, "#255: empty cert list must be non-nil")
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestListCertificates_TypedNilSliceNormalized(t *testing.T) {
+	t.Parallel()
+	client := &fakeACMClient{listOut: &acm.ListCertificatesOutput{}}
+	got, err := listCertificates(context.Background(), client)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	b, _ := json.Marshal(got)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestListCertificates_NonEmpty(t *testing.T) {
+	t.Parallel()
+	client := &fakeACMClient{
+		listOut: &acm.ListCertificatesOutput{
+			CertificateSummaryList: []acmtypes.CertificateSummary{
+				{CertificateArn: aws.String("arn:aws:acm:us-east-1:1:certificate/abc"), DomainName: aws.String("example.com")},
+			},
+		},
+	}
+	got, err := listCertificates(context.Background(), client)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "example.com", aws.ToString(got[0].DomainName))
+}
+
+func TestListCertificates_APIError(t *testing.T) {
+	t.Parallel()
+	_, err := listCertificates(context.Background(), &fakeACMClient{err: errors.New("AccessDenied")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AccessDenied")
+}
+
+func TestDescribeCertificate_PassesARN(t *testing.T) {
+	t.Parallel()
+	client := &fakeACMClient{}
+	_, err := describeCertificate(context.Background(), client, "arn:aws:acm:us-east-1:1:certificate/xyz")
+	require.NoError(t, err)
+	require.NotNil(t, client.describeIn)
+	assert.Equal(t, "arn:aws:acm:us-east-1:1:certificate/xyz", aws.ToString(client.describeIn.CertificateArn))
+}
+
+func TestACMFilterCertificateArn_RequiresARN(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		filters string
+	}{
+		{"empty filters", ""},
+		{"missing key", `{"project":"demo"}`},
+		{"empty value", `{"certificate_arn":""}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := acmFilterCertificateArn(tc.filters)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "certificate_arn")
+		})
+	}
+}
+
+func TestACMFilterCertificateArn_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	_, err := acmFilterCertificateArn(`{not json}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid filters JSON")
+}
+
+func TestACMFilterCertificateArn_Valid(t *testing.T) {
+	t.Parallel()
+	arn, err := acmFilterCertificateArn(`{"certificate_arn":"arn:aws:acm:us-east-1:1:certificate/abc"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "arn:aws:acm:us-east-1:1:certificate/abc", arn)
+}
+
+// TestInspectACM_GetMetricsRoutesToMetricsPackage — get-metrics short-
+// circuits to the metrics-package sentinel so callers know to invoke
+// pkg/observability/metrics for the DaysToExpiry series.
+func TestInspectACM_GetMetricsRoutesToMetricsPackage(t *testing.T) {
+	t.Parallel()
+	_, err := inspectACM(context.Background(), aws.Config{Region: "us-east-1"}, "get-metrics", "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUseMetricsPackage)
+	assert.Contains(t, err.Error(), "acm")
+}
+
+func TestInspectACM_UnknownAction(t *testing.T) {
+	t.Parallel()
+	_, err := inspectACM(context.Background(), aws.Config{Region: "us-east-1"}, "no-such-action", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "acm")
+	assert.Contains(t, err.Error(), "no-such-action")
+}

--- a/pkg/observability/discovery/aws/dispatcher.go
+++ b/pkg/observability/discovery/aws/dispatcher.go
@@ -136,6 +136,10 @@ func Inspect(ctx context.Context, cfg aws.Config, service, action, filtersJSON s
 		return inspectCostExplorer(ctx, cfg, action, filtersJSON)
 	case "account":
 		return inspectAccount(ctx, cfg, action, filtersJSON)
+	case "route53":
+		return inspectRoute53(ctx, cfg, action, filtersJSON)
+	case "acm":
+		return inspectACM(ctx, cfg, action, filtersJSON)
 	default:
 		return nil, unsupportedServiceError(service)
 	}

--- a/pkg/observability/discovery/aws/live_probe_255_test.go
+++ b/pkg/observability/discovery/aws/live_probe_255_test.go
@@ -105,6 +105,10 @@ func TestLive255_AWSInspectorsJSONShape(t *testing.T) {
 		{"ec2", "describe-security-groups"},
 		{"ebs", "describe-volumes"},
 		{"ebs", "describe-snapshots"},
+		// #596: Route 53 + ACM. Route 53 list-resource-record-sets needs
+		// a hosted_zone_id and is exercised separately below.
+		{"route53", "list-hosted-zones"},
+		{"acm", "list-certificates"},
 	} {
 		probes = append(probes, mk(pair[0], pair[1])...)
 	}

--- a/pkg/observability/discovery/aws/route53.go
+++ b/pkg/observability/discovery/aws/route53.go
@@ -1,0 +1,104 @@
+// Route 53 inspector (issue #596).
+//
+// Provides panel-default discovery for the aws/route53 preset (#584,
+// composer wiring #602). Two actions:
+//
+//   - list-hosted-zones — ListHostedZones; returns []route53types.HostedZone.
+//     Route 53 is global, so the AWS region the caller passes through
+//     cfg has no effect — every account's hosted zones come back from
+//     one call. Hosted zones are NOT tag-filterable server-side
+//     (the ListHostedZones API doesn't accept Filters), so project
+//     scoping happens post-fetch via ListTagsForResource. To keep this
+//     inspector cheap, the current implementation returns every zone
+//     visible to the credentials and lets downstream filters (the
+//     reliable UI's per-stack panel) drop unrelated zones; a future
+//     enhancement can fan out ListTagsForResource per-zone if the
+//     no-filter response gets noisy on multi-stack accounts.
+//   - list-resource-record-sets — ListResourceRecordSets for a specific
+//     hosted zone (caller supplies hosted_zone_id in the filters JSON).
+//     Returns the record set list as-is; record sets are not
+//     individually taggable in Route 53.
+//
+// Issue #255 contract: both action return paths use nilSliceToEmpty so
+// an empty AWS response marshals as `[]` not `null` — pinned by
+// route53_test.go::TestInspectRoute53_*_EmptyResult.
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// route53Client is the narrowed SDK surface used by inspectRoute53.
+// Lets tests inject a fake without doing real AWS auth.
+type route53Client interface {
+	ListHostedZones(ctx context.Context, params *route53.ListHostedZonesInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error)
+	ListResourceRecordSets(ctx context.Context, params *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error)
+}
+
+func inspectRoute53(ctx context.Context, cfg aws.Config, action, filters string) (any, error) {
+	switch action {
+	case "list-hosted-zones":
+		return listHostedZones(ctx, route53.NewFromConfig(cfg))
+	case "list-resource-record-sets":
+		zoneID, err := route53FilterZoneID(filters)
+		if err != nil {
+			return nil, err
+		}
+		return listResourceRecordSets(ctx, route53.NewFromConfig(cfg), zoneID)
+	default:
+		return nil, unsupportedActionError("route53", action)
+	}
+}
+
+// listHostedZones runs ListHostedZones and returns the result list with
+// nil normalized to []. ListHostedZones doesn't support server-side tag
+// filters (Route 53's API surface predates per-resource tags); callers
+// that want per-project scoping post-filter on the returned slice.
+func listHostedZones(ctx context.Context, client route53Client) ([]route53types.HostedZone, error) {
+	out, err := client.ListHostedZones(ctx, &route53.ListHostedZonesInput{})
+	if err != nil {
+		return nil, err
+	}
+	return nilSliceToEmpty(out.HostedZones), nil
+}
+
+// listResourceRecordSets runs ListResourceRecordSets for the given hosted
+// zone. The Route 53 record-set API is mandatory-per-zone (no list-all
+// option), so the inspector requires a hosted_zone_id in the filters
+// envelope and returns a structured error when it's missing.
+func listResourceRecordSets(ctx context.Context, client route53Client, zoneID string) ([]route53types.ResourceRecordSet, error) {
+	out, err := client.ListResourceRecordSets(ctx, &route53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return nilSliceToEmpty(out.ResourceRecordSets), nil
+}
+
+// route53FilterZoneID parses the filters JSON envelope for a
+// `hosted_zone_id` key. Returns a structured error (not silent fallback
+// to all zones) when missing — the API requires it, so silently calling
+// without an ID would just fail at the SDK layer with a less actionable
+// "ValidationException" the panel can't surface.
+func route53FilterZoneID(filters string) (string, error) {
+	if filters == "" {
+		return "", fmt.Errorf("list-resource-record-sets requires a hosted_zone_id in the filters envelope (e.g. {\"hosted_zone_id\":\"Z2FDTNDATAQYW2\"})")
+	}
+	var fm map[string]string
+	if err := json.Unmarshal([]byte(filters), &fm); err != nil {
+		return "", fmt.Errorf("list-resource-record-sets: invalid filters JSON: %w", err)
+	}
+	id := fm["hosted_zone_id"]
+	if id == "" {
+		return "", fmt.Errorf("list-resource-record-sets requires a hosted_zone_id in the filters envelope (e.g. {\"hosted_zone_id\":\"Z2FDTNDATAQYW2\"})")
+	}
+	return id, nil
+}

--- a/pkg/observability/discovery/aws/route53_test.go
+++ b/pkg/observability/discovery/aws/route53_test.go
@@ -1,0 +1,176 @@
+// Route 53 inspector tests (issue #596).
+//
+// Pins the #255 contract end-to-end: empty list-hosted-zones and
+// list-resource-record-sets responses MUST marshal as JSON `[]`, never
+// `null`. Also pins the filters-envelope error path on
+// list-resource-record-sets (the API requires a hosted_zone_id and
+// silently calling without one returns a less actionable
+// ValidationException at the SDK layer).
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRoute53Client struct {
+	listHostedZonesOut       *route53.ListHostedZonesOutput
+	listResourceRecordSetsIn *route53.ListResourceRecordSetsInput
+	listResourceRecordSetsOut *route53.ListResourceRecordSetsOutput
+	err                      error
+}
+
+func (f *fakeRoute53Client) ListHostedZones(_ context.Context, _ *route53.ListHostedZonesInput, _ ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.listHostedZonesOut == nil {
+		return &route53.ListHostedZonesOutput{}, nil
+	}
+	return f.listHostedZonesOut, nil
+}
+
+func (f *fakeRoute53Client) ListResourceRecordSets(_ context.Context, in *route53.ListResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
+	f.listResourceRecordSetsIn = in
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.listResourceRecordSetsOut == nil {
+		return &route53.ListResourceRecordSetsOutput{}, nil
+	}
+	return f.listResourceRecordSetsOut, nil
+}
+
+// TestListHostedZones_EmptyResult — empty AWS response marshals as JSON
+// `[]`, not `null` (#255). The reliable UI gates panel render on the
+// array shape; `null` collapses through every empty-state branch.
+func TestListHostedZones_EmptyResult(t *testing.T) {
+	t.Parallel()
+	got, err := listHostedZones(context.Background(), &fakeRoute53Client{})
+	require.NoError(t, err)
+	require.NotNil(t, got, "#255: empty result must be a non-nil slice")
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b), "#255: empty JSON wire must be `[]`, not `null`")
+}
+
+// TestListHostedZones_TypedNilSliceNormalized — when the AWS SDK
+// populates HostedZones as a typed-nil slice (the SDK's empty-response
+// behavior), nilSliceToEmpty must normalize it to []. Pattern B from
+// the CONTRIBUTING.md cheat-sheet.
+func TestListHostedZones_TypedNilSliceNormalized(t *testing.T) {
+	t.Parallel()
+	client := &fakeRoute53Client{
+		// HostedZones is the zero value — a typed-nil []HostedZone.
+		listHostedZonesOut: &route53.ListHostedZonesOutput{},
+	}
+	got, err := listHostedZones(context.Background(), client)
+	require.NoError(t, err)
+	require.NotNil(t, got, "typed-nil from SDK must be normalized to []")
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestListHostedZones_NonEmpty(t *testing.T) {
+	t.Parallel()
+	client := &fakeRoute53Client{
+		listHostedZonesOut: &route53.ListHostedZonesOutput{
+			HostedZones: []route53types.HostedZone{
+				{Id: aws.String("/hostedzone/Z111"), Name: aws.String("example.com.")},
+				{Id: aws.String("/hostedzone/Z222"), Name: aws.String("other.com.")},
+			},
+		},
+	}
+	got, err := listHostedZones(context.Background(), client)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "/hostedzone/Z111", aws.ToString(got[0].Id))
+}
+
+func TestListHostedZones_APIError(t *testing.T) {
+	t.Parallel()
+	client := &fakeRoute53Client{err: errors.New("AccessDenied")}
+	_, err := listHostedZones(context.Background(), client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AccessDenied")
+}
+
+// TestListResourceRecordSets_EmptyResult — same #255 contract on the
+// record-set list. Wired into the live probe at
+// live_probe_255_test.go (filtered + unfiltered variants).
+func TestListResourceRecordSets_EmptyResult(t *testing.T) {
+	t.Parallel()
+	got, err := listResourceRecordSets(context.Background(), &fakeRoute53Client{}, "Z111")
+	require.NoError(t, err)
+	require.NotNil(t, got, "#255: empty record-set list must be non-nil")
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestListResourceRecordSets_PassesZoneID(t *testing.T) {
+	t.Parallel()
+	client := &fakeRoute53Client{}
+	_, err := listResourceRecordSets(context.Background(), client, "Z222")
+	require.NoError(t, err)
+	require.NotNil(t, client.listResourceRecordSetsIn)
+	assert.Equal(t, "Z222", aws.ToString(client.listResourceRecordSetsIn.HostedZoneId))
+}
+
+// TestRoute53FilterZoneID_RequiresHostedZoneID — the API mandates a
+// HostedZoneId. The inspector surfaces a clear structured error rather
+// than letting the SDK emit a ValidationException with no panel
+// guidance.
+func TestRoute53FilterZoneID_RequiresHostedZoneID(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		filters string
+	}{
+		{"empty filters", ""},
+		{"missing key", `{"project":"demo"}`},
+		{"empty value", `{"hosted_zone_id":""}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := route53FilterZoneID(tc.filters)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "hosted_zone_id")
+		})
+	}
+}
+
+func TestRoute53FilterZoneID_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	_, err := route53FilterZoneID(`{not json}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid filters JSON")
+}
+
+func TestRoute53FilterZoneID_ValidFilters(t *testing.T) {
+	t.Parallel()
+	id, err := route53FilterZoneID(`{"hosted_zone_id":"Z2FDTNDATAQYW2"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "Z2FDTNDATAQYW2", id)
+}
+
+// TestInspectRoute53_UnknownAction — bogus actions surface the canonical
+// unsupported-action message with the supported list embedded.
+func TestInspectRoute53_UnknownAction(t *testing.T) {
+	t.Parallel()
+	_, err := inspectRoute53(context.Background(), aws.Config{Region: "us-east-1"}, "no-such-action", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "route53")
+	assert.Contains(t, err.Error(), "no-such-action")
+}

--- a/pkg/observability/discovery/gcp/dispatcher.go
+++ b/pkg/observability/discovery/gcp/dispatcher.go
@@ -114,6 +114,12 @@ func Inspect(ctx context.Context, projectID, service, action, filtersJSON string
 	case "billing":
 		return inspectBilling(ctx, projectID, action, filtersJSON, opts...)
 
+	// --- dns.go (issue #596) ---
+	case "clouddns":
+		return inspectCloudDNS(ctx, projectID, action, filtersJSON, opts...)
+	case "certificatemanager":
+		return inspectCertificateManager(ctx, projectID, action, filtersJSON, opts...)
+
 	default:
 		return nil, unsupportedServiceError(service, observability.GCPServiceNames())
 	}

--- a/pkg/observability/discovery/gcp/dispatcher_test.go
+++ b/pkg/observability/discovery/gcp/dispatcher_test.go
@@ -44,6 +44,9 @@ var firstListAction = map[string]string{
 	"bastion":          "list-bastion-instances",
 	"cloudmonitoring":  "list-alert-policies",
 	"billing":          "get-billing-info",
+	// #596: new DNS+cert services.
+	"clouddns":           "list-managed-zones",
+	"certificatemanager": "list-certificates",
 }
 
 // unreachableEndpoint is an explicit RFC5737 documentation IP — every

--- a/pkg/observability/discovery/gcp/dns.go
+++ b/pkg/observability/discovery/gcp/dns.go
@@ -1,0 +1,137 @@
+// Cloud DNS + Certificate Manager inspectors (issue #596).
+//
+// Provides panel-default discovery for the gcp/cloud_dns preset (#583,
+// composer wiring #602) and prepares the surface for a future GCP
+// Certificate Manager preset.
+//
+// Cloud DNS actions:
+//   - list-managed-zones — service.ManagedZones.List(project). Returns
+//     []*dns.ManagedZone. The Cloud DNS API exposes a server-side
+//     dns_name filter (not label-based) so project scoping happens
+//     post-fetch via gcpLabelMatches on each zone's Labels map.
+//   - list-record-sets — service.ResourceRecordSets.List(project, zone).
+//     Returns []*dns.ResourceRecordSet for the requested zone. Record
+//     sets do not carry labels (they're child resources of the zone),
+//     so the project filter is moot here — callers provide the zone via
+//     the filters envelope.
+//
+// Certificate Manager actions:
+//   - list-certificates — projectsLocationsCertificatesService.List.
+//     Returns []*certificatemanager.Certificate scoped to a location
+//     (default "global" — Cert Manager is region-scoped but the public
+//     CDN cert flow uses global). Project scoping uses labels post-fetch.
+//
+// #255 contract: every slice return path is initialized to a non-nil
+// composite literal at the construction site (Pattern A from the
+// CONTRIBUTING.md cheat-sheet) so an empty result marshals as `[]`,
+// never `null`.
+
+package gcp
+
+import (
+	"context"
+	"fmt"
+
+	certmanager "google.golang.org/api/certificatemanager/v1"
+	dns "google.golang.org/api/dns/v1"
+	"google.golang.org/api/option"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/observability"
+)
+
+func inspectCloudDNS(ctx context.Context, projectID, action, filters string, opts ...option.ClientOption) (any, error) {
+	svc, err := dns.NewService(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	switch action {
+	case "list-managed-zones":
+		// ManagedZones.List has no server-side label filter; post-filter
+		// on ManagedZone.Labels for the caller-supplied project.
+		project := projectFromFilters(filters)
+		// Pattern A: declare with a non-nil composite literal so the
+		// empty-result path emits `[]`, not `null` (#255).
+		zones := []*dns.ManagedZone{}
+		err := svc.ManagedZones.List(projectID).Context(ctx).Pages(ctx, func(page *dns.ManagedZonesListResponse) error {
+			for _, z := range page.ManagedZones {
+				if !gcpLabelMatches(z.Labels, "project", project) {
+					continue
+				}
+				zones = append(zones, z)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return zones, nil
+
+	case "list-record-sets":
+		// ResourceRecordSets.List is per-zone — caller supplies the
+		// managed zone name in the filters envelope. Surface a
+		// structured error when missing so the panel can prompt the
+		// caller instead of bubbling a less actionable
+		// `googleapi: Error 404 zone not found` from the SDK.
+		fm := parseFilterMap(filters)
+		zone := fm["managed_zone"]
+		if zone == "" {
+			return nil, fmt.Errorf("list-record-sets requires a managed_zone in the filters envelope (e.g. {\"managed_zone\":\"example-com\"})")
+		}
+		// Pattern A: empty record-set list normalizes to `[]`.
+		records := []*dns.ResourceRecordSet{}
+		err := svc.ResourceRecordSets.List(projectID, zone).Context(ctx).Pages(ctx, func(page *dns.ResourceRecordSetsListResponse) error {
+			records = append(records, page.Rrsets...)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return records, nil
+
+	default:
+		return nil, unsupportedActionError("Cloud DNS", action, observability.GCPServiceActions["clouddns"])
+	}
+}
+
+func inspectCertificateManager(ctx context.Context, projectID, action, filters string, opts ...option.ClientOption) (any, error) {
+	svc, err := certmanager.NewService(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	switch action {
+	case "list-certificates":
+		// Cert Manager is region-scoped at the API path
+		// (projects/<p>/locations/<loc>/certificates), but the public-
+		// CDN flow uses "global". Allow callers to override via filters.
+		fm := parseFilterMap(filters)
+		location := fm["location"]
+		if location == "" {
+			location = "global"
+		}
+		project := projectFromFilters(filters)
+
+		// Pattern A: empty list → `[]`.
+		certs := []*certmanager.Certificate{}
+		err := svc.Projects.Locations.Certificates.
+			List(fmt.Sprintf("projects/%s/locations/%s", projectID, location)).
+			Context(ctx).
+			Pages(ctx, func(page *certmanager.ListCertificatesResponse) error {
+				for _, c := range page.Certificates {
+					if !gcpLabelMatches(c.Labels, "project", project) {
+						continue
+					}
+					certs = append(certs, c)
+				}
+				return nil
+			})
+		if err != nil {
+			return nil, err
+		}
+		return certs, nil
+
+	default:
+		return nil, unsupportedActionError("Certificate Manager", action, observability.GCPServiceActions["certificatemanager"])
+	}
+}

--- a/pkg/observability/discovery/gcp/dns_test.go
+++ b/pkg/observability/discovery/gcp/dns_test.go
@@ -1,0 +1,236 @@
+// Cloud DNS + Certificate Manager inspector tests (issue #596).
+//
+// Pins the #255 contract end-to-end against httptest-backed JSON-API
+// fakes: empty list responses MUST marshal as JSON `[]`, never `null`.
+// Also exercises the project-label post-filter, the per-zone gating on
+// list-record-sets, and the unsupported-action sentinels.
+
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+)
+
+// fakeGCPRESTServer constructs an httptest server + option.ClientOption
+// slice that points the Cloud DNS / Cert Manager Go clients at the
+// fake. Both SDKs honor option.WithEndpoint for their JSON REST surface.
+func fakeGCPRESTServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, []option.ClientOption) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv, []option.ClientOption{
+		option.WithEndpoint(srv.URL),
+		option.WithoutAuthentication(),
+	}
+}
+
+// --- Cloud DNS: list-managed-zones --------------------------------------
+
+const listManagedZonesEmpty = `{"kind":"dns#managedZonesListResponse","managedZones":[]}`
+const listManagedZonesPopulated = `{
+  "kind": "dns#managedZonesListResponse",
+  "managedZones": [
+    {"id": "1", "name": "example-com", "dnsName": "example.com.", "visibility": "public", "labels": {"project": "io-foo"}},
+    {"id": "2", "name": "other-com",   "dnsName": "other.com.",   "visibility": "public", "labels": {"project": "io-bar"}},
+    {"id": "3", "name": "no-label",    "dnsName": "no-label.com.", "visibility": "public"}
+  ]
+}`
+
+func TestInspectCloudDNS_ListManagedZones_EmptyEmitsArray(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listManagedZonesEmpty))
+	})
+	defer srv.Close()
+
+	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-managed-zones", "", opts...)
+	require.NoError(t, err)
+	require.NotNil(t, got, "#255: empty zone list must be a non-nil slice")
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b), "#255: empty Cloud DNS list must marshal as `[]`, not `null`")
+}
+
+func TestInspectCloudDNS_ListManagedZones_NoFilterReturnsAll(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listManagedZonesPopulated))
+	})
+	defer srv.Close()
+
+	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-managed-zones", "", opts...)
+	require.NoError(t, err)
+
+	// Round-trip through JSON so we don't need to import the dns
+	// types for an in-Go shape assertion. The wire-format is what
+	// the panel consumes.
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	var zones []map[string]any
+	require.NoError(t, json.Unmarshal(b, &zones))
+	assert.Len(t, zones, 3, "no project filter → every zone returned")
+}
+
+func TestInspectCloudDNS_ListManagedZones_FiltersByProject(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listManagedZonesPopulated))
+	})
+	defer srv.Close()
+
+	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-managed-zones", `{"project":"io-foo"}`, opts...)
+	require.NoError(t, err)
+
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	var zones []map[string]any
+	require.NoError(t, json.Unmarshal(b, &zones))
+	require.Len(t, zones, 1, "only project=io-foo zone matches")
+	assert.Equal(t, "example-com", zones[0]["name"])
+}
+
+// --- Cloud DNS: list-record-sets ----------------------------------------
+
+const listRecordSetsEmpty = `{"kind":"dns#resourceRecordSetsListResponse","rrsets":[]}`
+const listRecordSetsPopulated = `{
+  "kind": "dns#resourceRecordSetsListResponse",
+  "rrsets": [
+    {"name": "example.com.", "type": "A",     "ttl": 300, "rrdatas": ["192.0.2.1"]},
+    {"name": "example.com.", "type": "MX",    "ttl": 300, "rrdatas": ["10 mail.example.com."]},
+    {"name": "www.example.com.", "type": "CNAME", "ttl": 60, "rrdatas": ["example.com."]}
+  ]
+}`
+
+func TestInspectCloudDNS_ListRecordSets_EmptyEmitsArray(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listRecordSetsEmpty))
+	})
+	defer srv.Close()
+
+	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-record-sets",
+		`{"managed_zone":"example-com"}`, opts...)
+	require.NoError(t, err)
+	require.NotNil(t, got, "#255: empty record-set list must be non-nil")
+	b, _ := json.Marshal(got)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestInspectCloudDNS_ListRecordSets_NonEmpty(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listRecordSetsPopulated))
+	})
+	defer srv.Close()
+
+	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-record-sets",
+		`{"managed_zone":"example-com"}`, opts...)
+	require.NoError(t, err)
+
+	b, _ := json.Marshal(got)
+	var rrsets []map[string]any
+	require.NoError(t, json.Unmarshal(b, &rrsets))
+	assert.Len(t, rrsets, 3)
+}
+
+func TestInspectCloudDNS_ListRecordSets_RequiresManagedZone(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		filters string
+	}{
+		{"empty filters", ""},
+		{"missing key", `{"project":"demo"}`},
+		{"empty value", `{"managed_zone":""}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := inspectCloudDNS(context.Background(), "demo-proj", "list-record-sets", tc.filters,
+				option.WithEndpoint(unreachableEndpoint),
+				option.WithoutAuthentication(),
+			)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "managed_zone")
+		})
+	}
+}
+
+func TestInspectCloudDNS_UnsupportedAction(t *testing.T) {
+	t.Parallel()
+	_, err := inspectCloudDNS(context.Background(), "demo-proj", "no-such", "",
+		option.WithEndpoint(unreachableEndpoint),
+		option.WithoutAuthentication(),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported Cloud DNS action")
+	assert.Contains(t, err.Error(), "list-managed-zones")
+}
+
+// --- Certificate Manager: list-certificates -----------------------------
+
+const listCertsEmpty = `{"certificates":[]}`
+const listCertsPopulated = `{
+  "certificates": [
+    {"name": "projects/demo-proj/locations/global/certificates/c1", "labels": {"project": "io-foo"}},
+    {"name": "projects/demo-proj/locations/global/certificates/c2", "labels": {"project": "io-bar"}}
+  ]
+}`
+
+func TestInspectCertificateManager_ListCertificates_EmptyEmitsArray(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listCertsEmpty))
+	})
+	defer srv.Close()
+
+	got, err := inspectCertificateManager(context.Background(), "demo-proj", "list-certificates", "", opts...)
+	require.NoError(t, err)
+	require.NotNil(t, got, "#255: empty cert list must be non-nil")
+	b, _ := json.Marshal(got)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestInspectCertificateManager_ListCertificates_FiltersByProject(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listCertsPopulated))
+	})
+	defer srv.Close()
+
+	got, err := inspectCertificateManager(context.Background(), "demo-proj", "list-certificates",
+		`{"project":"io-foo"}`, opts...)
+	require.NoError(t, err)
+
+	b, _ := json.Marshal(got)
+	var certs []map[string]any
+	require.NoError(t, json.Unmarshal(b, &certs))
+	require.Len(t, certs, 1)
+	assert.Equal(t, "projects/demo-proj/locations/global/certificates/c1", certs[0]["name"])
+}
+
+func TestInspectCertificateManager_UnsupportedAction(t *testing.T) {
+	t.Parallel()
+	_, err := inspectCertificateManager(context.Background(), "demo-proj", "no-such", "",
+		option.WithEndpoint(unreachableEndpoint),
+		option.WithoutAuthentication(),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported Certificate Manager action")
+	assert.Contains(t, err.Error(), "list-certificates")
+}

--- a/pkg/observability/discovery/gcp/live_probe_255_test.go
+++ b/pkg/observability/discovery/gcp/live_probe_255_test.go
@@ -152,6 +152,17 @@ func TestLive255_AllInspectorsJSONShape(t *testing.T) {
 				return inspectKMS(ctx, projectID, "list-keyrings", projectFilter, opts...)
 			}, filters: projectFilter},
 
+		// dns.go (#596)
+		{name: "clouddns/list-managed-zones",
+			fn: func() (any, error) {
+				return inspectCloudDNS(ctx, projectID, "list-managed-zones", projectFilter, opts...)
+			}, filters: projectFilter},
+		// certificatemanager/list-certificates — defaults to location=global.
+		{name: "certificatemanager/list-certificates",
+			fn: func() (any, error) {
+				return inspectCertificateManager(ctx, projectID, "list-certificates", projectFilter, opts...)
+			}, filters: projectFilter},
+
 		// identity.go — list-tenants on a project without multi-tenancy
 		// returns a structured error (TestLive_InspectIdentityPlatform_*).
 		// list-providers is a baseline.

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -58,15 +58,19 @@ var configExtractorAllowlist = map[string]string{
 	"aws_codepipeline":   "[placeholder] mapped to ec2.describe-instances, no dedicated shape (#204)",
 	"aws_backups":        "[no-inspector] AWS Backup vaults aren't inspected; covered via tag-based discovery (#204)",
 	"aws_github_actions": "[no-inspector] GitHub Actions IAM roles only — no SDK shape to extract (#204)",
-	"aws_route53":        "[no-inspector] Route 53 hosted zones / records not yet covered by the discovery pipeline (#584 follow-up)",
-	"aws_acm":            "[no-inspector] ACM certificates not yet covered by the discovery pipeline (#593 follow-up)",
+	// #596: route53/acm dispatchers ship in pkg/observability/discovery/aws
+	// (route53.go, acm.go) but no extractor lands yet — the panel
+	// surfaces inspector output as raw SDK shapes until per-key field
+	// extraction stabilizes. Tracked as a discovery-pipeline follow-up.
+	"aws_route53": "[no-inspector] Route 53 dispatcher landed in #596 (route53.go); per-component extractor (config map for panel) deferred until SDK-shape extractor design settles for one-off resources",
+	"aws_acm":     "[no-inspector] ACM dispatcher landed in #596 (acm.go); per-component extractor deferred until cert-specific field reads (status, days_to_expiry, validation state) are designed",
 
 	// EKS node group: ComponentKey "aws_eks_nodegroup" doesn't have its
 	// own SDK inspector — extraction is handled by aws_eks (#204, #224).
 	"aws_eks_nodegroup": "[no-inspector] EKS node group is covered by the aws_eks inspector (#204)",
 
 	"gcp_backups":   "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
-	"gcp_cloud_dns": "[no-inspector] Cloud DNS managed zones / record sets not yet covered by the discovery pipeline (#593 follow-up)",
+	"gcp_cloud_dns": "[no-inspector] Cloud DNS dispatcher landed in #596 (gcp/dns.go); per-component extractor (config map for panel) deferred pending zone-detail field reads (visibility, dnssec_config, record-count summary)",
 }
 
 // extractorFixtures are minimal SDK-shape fixtures that exercise each

--- a/pkg/observability/inspect/testdata/render/aws_service_table.txt
+++ b/pkg/observability/inspect/testdata/render/aws_service_table.txt
@@ -1,6 +1,7 @@
 | Service | Common Actions |
 |---------|----------------|
 | account | get-info |
+| acm | list-certificates, describe-certificate, get-metrics |
 | alb | describe-load-balancers, get-metrics |
 | apigateway | get-apis, get-domain-names, get-metrics |
 | backup | list-backup-vaults |
@@ -20,6 +21,7 @@
 | msk | list-clusters, get-metrics |
 | opensearch | list-domains, describe-domains, list-collections, get-metrics |
 | rds | describe-db-instances, describe-db-clusters, get-metrics |
+| route53 | list-hosted-zones, list-resource-record-sets |
 | s3 | list-buckets, get-metrics |
 | secretsmanager | list-secrets, get-metrics |
 | sqs | list-queues, get-metrics |

--- a/pkg/observability/inspect/testdata/render/awsinspect_batch_description.txt
+++ b/pkg/observability/inspect/testdata/render/awsinspect_batch_description.txt
@@ -20,7 +20,7 @@ result — do NOT abort on the first error. A credential fetch failure
 leaves cred-less probes (list-actions, list-metrics) succeeding anyway.
 
 REQUIRES: session_id from convoopen response (format: sess_v2_...).
-Supported services: account, alb, apigateway, backup, bedrock, cloudfront, cloudwatchlogs, cognito, cost-explorer, dynamodb, ebs, ec2, ecs, eks, elasticache, kms, lambda, msk, opensearch, rds, s3, secretsmanager, sqs, vpc, waf
+Supported services: account, acm, alb, apigateway, backup, bedrock, cloudfront, cloudwatchlogs, cognito, cost-explorer, dynamodb, ebs, ec2, ecs, eks, elasticache, kms, lambda, msk, opensearch, rds, route53, s3, secretsmanager, sqs, vpc, waf
 For a specific service's actions, use awsinspect (singular) with
 action="list-actions" — batch is not the place for discovery.
 Batch responses are always summarized (no detail/raw per-sub); use

--- a/pkg/observability/inspect/testdata/render/awsinspect_description.txt
+++ b/pkg/observability/inspect/testdata/render/awsinspect_description.txt
@@ -12,7 +12,7 @@ RESPONSE TIERS (default is summary for token efficiency):
 - Raw: Complete unprocessed API response. Set raw=true.
 
 REQUIRES: session_id from convoopen response (format: sess_v2_...).
-Supported services: account, alb, apigateway, backup, bedrock, cloudfront, cloudwatchlogs, cognito, cost-explorer, dynamodb, ebs, ec2, ecs, eks, elasticache, kms, lambda, msk, opensearch, rds, s3, secretsmanager, sqs, vpc, waf
+Supported services: account, acm, alb, apigateway, backup, bedrock, cloudfront, cloudwatchlogs, cognito, cost-explorer, dynamodb, ebs, ec2, ecs, eks, elasticache, kms, lambda, msk, opensearch, rds, route53, s3, secretsmanager, sqs, vpc, waf
 For a specific service's actions, call with action="list-actions".
 METRICS: Use list-metrics to discover available metrics for a service (no credentials needed). Then use get-metrics to retrieve data (auto-discovers resources). Most services return CloudWatch time-series. KMS returns key health (rotation, state). SecretsManager returns secret health (rotation, last accessed/rotated). Optional filters JSON: {"hours":6,"period":300}.
 BILLING: Use service=cost-explorer to inspect AWS costs. Actions: get-cost-summary (last 30 days by service, filters: {"days":7,"granularity":"DAILY"}), get-cost-forecast (projected spend through end of month), get-cost-by-tag (costs grouped by tag, filters: {"tag_key":"Environment","days":30}). Requires ce:GetCostAndUsage and ce:GetCostForecast IAM permissions.

--- a/pkg/observability/inspect/testdata/render/gcp_service_table.txt
+++ b/pkg/observability/inspect/testdata/render/gcp_service_table.txt
@@ -3,9 +3,11 @@
 | apigateway | list-apis, get-metrics |
 | bastion | list-bastion-instances, get-metrics |
 | billing | get-billing-info, get-budgets |
+| certificatemanager | list-certificates |
 | cloudarmor | list-policies, describe-policy, get-metrics |
 | cloudbuild | list-triggers, list-builds, get-metrics |
 | cloudcdn | list-backend-services-cdn, get-metrics |
+| clouddns | list-managed-zones, list-record-sets |
 | cloudfunctions | list-functions, get-metrics |
 | cloudkms | list-keyrings, list-keys, get-metrics |
 | cloudlogging | list-logs |

--- a/pkg/observability/inspect/testdata/render/gcpinspect_batch_description.txt
+++ b/pkg/observability/inspect/testdata/render/gcpinspect_batch_description.txt
@@ -20,7 +20,7 @@ result — do NOT abort on the first error. A credential fetch failure
 leaves cred-less probes (list-actions, list-metrics) succeeding anyway.
 
 REQUIRES: session_id from convoopen response (format: sess_v2_...).
-Supported services: apigateway, bastion, billing, cloudarmor, cloudbuild, cloudcdn, cloudfunctions, cloudkms, cloudlogging, cloudmonitoring, cloudrun, cloudsql, compute, firestore, gcs, gke, identityplatform, loadbalancer, memorystore, pubsub, secretmanager, vertexai, vpc
+Supported services: apigateway, bastion, billing, certificatemanager, cloudarmor, cloudbuild, cloudcdn, clouddns, cloudfunctions, cloudkms, cloudlogging, cloudmonitoring, cloudrun, cloudsql, compute, firestore, gcs, gke, identityplatform, loadbalancer, memorystore, pubsub, secretmanager, vertexai, vpc
 For a specific service's actions, use gcpinspect (singular) with
 action="list-actions" — batch is not the place for discovery.
 Batch responses are always summarized (no detail/raw per-sub); use

--- a/pkg/observability/inspect/testdata/render/gcpinspect_description.txt
+++ b/pkg/observability/inspect/testdata/render/gcpinspect_description.txt
@@ -12,7 +12,7 @@ RESPONSE TIERS (default is summary for token efficiency):
 - Raw: Complete unprocessed API response. Set raw=true.
 
 REQUIRES: session_id from convoopen response (format: sess_v2_...).
-Supported services: apigateway, bastion, billing, cloudarmor, cloudbuild, cloudcdn, cloudfunctions, cloudkms, cloudlogging, cloudmonitoring, cloudrun, cloudsql, compute, firestore, gcs, gke, identityplatform, loadbalancer, memorystore, pubsub, secretmanager, vertexai, vpc
+Supported services: apigateway, bastion, billing, certificatemanager, cloudarmor, cloudbuild, cloudcdn, clouddns, cloudfunctions, cloudkms, cloudlogging, cloudmonitoring, cloudrun, cloudsql, compute, firestore, gcs, gke, identityplatform, loadbalancer, memorystore, pubsub, secretmanager, vertexai, vpc
 For a specific service's actions, call with action="list-actions".
 
 METRICS: Use list-metrics to see available Cloud Monitoring metrics for any service (no credentials needed — progressive disclosure). Use get-metrics to retrieve time-series data. Optional filters JSON: {"hours":6,"period":300}.

--- a/pkg/observability/service_actions.go
+++ b/pkg/observability/service_actions.go
@@ -44,6 +44,17 @@ var AWSServiceActions = map[string][]string{
 	"bedrock":        {"list-knowledge-bases", "describe-knowledge-base", "list-agents", "list-guardrails", "get-metrics"},
 	"cost-explorer":  {"get-cost-summary", "get-cost-forecast", "get-cost-by-tag"},
 	"account":        {"get-info"},
+	// Route 53 (#596). Hosted-zone discovery uses list-hosted-zones (global —
+	// no region scoping); per-zone record sets are fetched via
+	// list-resource-record-sets, which requires a hosted_zone_id in the
+	// filters envelope.
+	"route53": {"list-hosted-zones", "list-resource-record-sets"},
+	// ACM (#596). list-certificates returns the account's cert summaries
+	// (no server-side tag filter — caller post-filters); describe-certificate
+	// fetches the full detail (including domain_validation_options) for a
+	// specific ARN. get-metrics routes to the metrics package for the
+	// DaysToExpiry CloudWatch series.
+	"acm": {"list-certificates", "describe-certificate", "get-metrics"},
 }
 
 // AWSServiceAliases maps caller-supplied aliases to canonical service
@@ -59,6 +70,11 @@ var AWSServiceAliases = map[string]string{
 	"auth":    "cognito",
 	"billing": "cost-explorer",
 	"costs":   "cost-explorer",
+	// #596: LLM-friendly aliases for the new DNS+cert pair. "dns" maps
+	// to route53 (the only AWS DNS service); "certs" maps to acm
+	// (AWS's cert manager).
+	"dns":   "route53",
+	"certs": "acm",
 }
 
 // AWSActionAliases maps service → (alias action → canonical action).
@@ -85,6 +101,23 @@ var AWSActionAliases = map[string]map[string]string{
 	},
 	"s3": {
 		"describe-buckets": "list-buckets",
+	},
+	// #596: LLM-friendly aliases for Route 53 + ACM. Common patterns the
+	// LLM guesses ("list-zones", "describe-zones", "list-records",
+	// "describe-certificates") are absorbed here so callers land on the
+	// canonical SDK verbs instead of an unsupported-action error.
+	"route53": {
+		"list-zones":             "list-hosted-zones",
+		"describe-zones":         "list-hosted-zones",
+		"describe-hosted-zones":  "list-hosted-zones",
+		"list-records":           "list-resource-record-sets",
+		"list-record-sets":       "list-resource-record-sets",
+		"describe-record-sets":   "list-resource-record-sets",
+	},
+	"acm": {
+		"describe-certificates": "list-certificates",
+		"list-certs":            "list-certificates",
+		"get-certificate":       "describe-certificate",
 	},
 }
 
@@ -117,6 +150,14 @@ var GCPServiceActions = map[string][]string{
 	// design (cloudlogging follows the same pattern).
 	"cloudmonitoring": {"list-alert-policies"},
 	"billing":         {"get-billing-info", "get-budgets"},
+	// Cloud DNS (#596). list-managed-zones returns the project's zones
+	// (filtered by labels.project post-fetch); list-record-sets requires
+	// a managed_zone in the filters envelope (the API is per-zone).
+	"clouddns": {"list-managed-zones", "list-record-sets"},
+	// Certificate Manager (#596). list-certificates returns the cert
+	// inventory for a given location (defaults to "global" — the
+	// CloudFront / global LB cert flow).
+	"certificatemanager": {"list-certificates"},
 }
 
 // GCPServiceAliases is the GCP analog of AWSServiceAliases.
@@ -128,6 +169,12 @@ var GCPServiceAliases = map[string]string{
 	"network":   "vpc",
 	"functions": "cloudfunctions",
 	"cdn":       "cloudcdn",
+	// #596: LLM-friendly aliases for the GCP DNS+cert pair. "dns" maps
+	// to clouddns (GCP's Cloud DNS service); "certs" / "certmanager"
+	// map to certificatemanager (GCP's Certificate Manager service).
+	"dns":         "clouddns",
+	"certs":       "certificatemanager",
+	"certmanager": "certificatemanager",
 }
 
 // CanonicalAWSService resolves an alias to its canonical AWS service


### PR DESCRIPTION
## Summary

Closes the **discovery-dispatcher** half of the DNS+cert observability story
started by the recently-merged route53 / acm / cloud_dns presets (#583, #584,
#586) and their composer wiring (#602). Adds per-service inspector arms for
`route53` + `acm` (AWS) and `clouddns` + `certificatemanager` (GCP), plus
their service-action registry entries and #255 JSON-shape probe coverage.

Includes one drive-by cleanup (unused `isLambda` helper in
`pkg/composer/contracts.go` left over from #224 EKS rename).

Refs #596 #599 #601.

## Issue-by-issue status

| Issue | Status | Notes |
|---|---|---|
| **#596** Wire route53/acm/cloud_dns into observability discovery dispatcher | **Closes (mostly)** | All four dispatcher arms (route53, acm, clouddns, certificatemanager) land; service_actions registers their actions + aliases; live-probe #255 coverage extends. **Deferred**: `google_dns_managed_zone` registration in `pkg/insideout-import/registry/registry.go` + a paired policy file — these touch two parity gates (`TestRegistryParity_GCP_LiveMatchesRegistry` + `TestPolicyRegistry_CoversGeneratedRegistry`) that respectively require a real CAI discoverer port and a codegen run against the live terraform provider schema. Both are multi-step pipeline lifts that don't fit a dispatcher-closeout bundle. |
| **#599** Backfill drift policies for AWS-managed types lacking imported/policy entries | **Deferred** | The policy registry is gated against `pkg/composer/imported/generated/`'s typed-Attrs registry by `TestPolicyRegistry_CoversGeneratedRegistry`. None of the target types (`aws_route53_record`, `aws_acm_certificate_validation`, `google_dns_managed_zone`, `google_dns_record_set`, `google_certificate_manager_*`) are in the generated registry today. Adding them requires editing `pkg/insideout-import/registry/registry.go` (`awsDiscoverTypes`/`awsCodegenOnlyTypes`/`gcpDiscoverTypes`), running `make refresh-schemas` (requires `terraform` on PATH + provider schema sync), then `make gen-imported`, then authoring per-type `.policy.go` files. That's its own bundle PR. Tracked-as-is in #599. |
| **#601** Close ACM↔Route53 back-edge wiring | **Deferred** | The cycle blocker is more structural than the issue description suggests. `ValidateNoModuleCycles` extracts edges at the **module-to-module** level (`extractWiringEdges` in `pkg/composer/validate_module_graph.go` keys producer/consumer by `ModuleBlock.Name` only — the `Output`/`Input` fields are recorded but unused in the cycle topology). Splitting route53 into a `var.records` + `var.acm_validation_records` pair, then exposing a `record_fqdns_for_acm` output, **does not** break the cycle at the validator level — both directions still produce edges `aws_acm ↔ aws_route53`. The genuine fix is either: (a) loosen `ValidateNoModuleCycles` to track edges at input/output granularity (a real refactor that changes the validator contract and risks under-reporting other cycles), (b) compute ACM's `validation_record_fqdns` from its own `domain_validation_options` (one-module-only — but then the cert validation can fire before route53 publishes records, defeating the purpose), or (c) use module-level `depends_on` (which itself creates a module-level dep that terraform sees as a cycle when paired with the forward wiring). None of these are a "small refactor"; punting per the bundle instructions: "If it balloons into a route53 schema change with downstream rippling, defer it cleanly and leave #601 open." #601 stays open with the explicit analysis. |
| **Drive-by**: remove `isLambda` | **Done** | Zero callers in `pkg/` or `cmd/` per grep; was a leftover from #224 EKS rename. |
| **Drive-by**: `pricing.go:183` `omitempty`-on-nested-struct | **Skipped** | Not trivially obvious (the `Components` field is a non-pointer anonymous struct; `omitempty` doesn't apply to nested structs in Go's `encoding/json`, but flipping it requires turning `Components` into a pointer field which changes Normalize() call-site invariants). Out of scope for a closeout bundle. |

## What changed

### `pkg/observability/discovery/aws/route53.go` (new)

`inspectRoute53` dispatch on:
- `list-hosted-zones` — `ListHostedZones`; returns `[]route53types.HostedZone`. Route 53 is global so the cfg.Region is irrelevant. Hosted zones are NOT tag-filterable server-side (`ListHostedZones` doesn't accept Filters); per-project scoping happens post-fetch in the panel layer.
- `list-resource-record-sets` — `ListResourceRecordSets`; requires `hosted_zone_id` in the filters envelope (the API is per-zone — calling without one returns a less-actionable `ValidationException` at the SDK layer). The inspector surfaces a structured error when missing so the panel can prompt the caller.

### `pkg/observability/discovery/aws/acm.go` (new)

`inspectACM` dispatch on:
- `list-certificates` — `ListCertificates`; returns the `CertificateSummaryList`. Currently returns the first page (default 1000); pagination follow-up if customers hit that ceiling (no observed cases — production presets manage <10 certs per stack).
- `describe-certificate` — `DescribeCertificate` per-ARN; returns the full `CertificateDetail` including `domain_validation_options` for DNS-validation drift comparison.
- `get-metrics` — routes through `metricsRouted("acm")` so callers pivot to `pkg/observability/metrics` for the `DaysToExpiry` CloudWatch series.

### `pkg/observability/discovery/gcp/dns.go` (new)

`inspectCloudDNS` dispatch on:
- `list-managed-zones` — `service.ManagedZones.List(project).Pages(...)`; returns `[]*dns.ManagedZone`. No server-side label filter; project scoping post-filters on `ManagedZone.Labels` via `gcpLabelMatches`.
- `list-record-sets` — `service.ResourceRecordSets.List(project, zone)`; requires `managed_zone` in the filters envelope.

`inspectCertificateManager` dispatch on:
- `list-certificates` — `service.Projects.Locations.Certificates.List(parent).Pages(...)`; defaults to `location=global` (CloudFront / global LB cert flow); per-project label post-filter.

### `pkg/observability/service_actions.go`

- `AWSServiceActions`: + `"route53"` → `["list-hosted-zones", "list-resource-record-sets"]`; + `"acm"` → `["list-certificates", "describe-certificate", "get-metrics"]`.
- `GCPServiceActions`: + `"clouddns"` → `["list-managed-zones", "list-record-sets"]`; + `"certificatemanager"` → `["list-certificates"]`.
- `AWSServiceAliases`: + `"dns"` → `"route53"`, + `"certs"` → `"acm"`.
- `GCPServiceAliases`: + `"dns"` → `"clouddns"`, + `"certs"` → `"certificatemanager"`, + `"certmanager"` → `"certificatemanager"`.
- `AWSActionAliases`: + route53 action aliases (`list-zones`, `describe-zones`, `describe-hosted-zones`, `list-records`, `list-record-sets`, `describe-record-sets`); + acm action aliases (`describe-certificates`, `list-certs`, `get-certificate`).

### Dispatcher arms (`{aws,gcp}/dispatcher.go`)

Two new `case` arms each — route53/acm on AWS, clouddns/certificatemanager on GCP. The existing drift-gate tests (`TestInspectCoversAll{AWS,GCP}Services`) walk `observability.{AWS,GCP}ServiceNames()` so the new registry entries are exercised automatically — no test list to extend by hand. GCP's `firstListAction` map gets entries for the two new services (the test fail-fasts if a service has no probe entry).

### Test coverage

Per-inspector unit tests pin:
- The #255 contract on empty result paths (`require.NotNil` + `json.Marshal == "[]"`).
- Typed-nil SDK passthroughs normalized to `[]` (Pattern B via `nilSliceToEmpty`).
- Required-filter error paths (`hosted_zone_id`, `certificate_arn`, `managed_zone`).
- Action routing (`get-metrics` → `ErrUseMetricsPackage`).
- Unsupported-action fall-through with the canonical hint.

Live-probe extensions in `live_probe_255_test.go` (both clouds, build tag `integration`) add entries for `route53/list-hosted-zones`, `acm/list-certificates`, `clouddns/list-managed-zones`, `certificatemanager/list-certificates`. Per-AWS-probe uses both filtered and unfiltered variants so both the early-return and the post-filter empty paths exercise.

### Extractor allowlist (`extractors_drift_test.go`)

Rationales for `aws_route53` / `aws_acm` / `gcp_cloud_dns` updated. The prior wording — "not yet covered by the discovery pipeline" — no longer matches reality post-#596. New wording explains that the dispatcher landed but per-component config-map extraction (the panel-side "current config" tile) is a separate design concern, and the keys legitimately stay in the `[no-inspector]` allowlist until that field-read design lands.

### Golden snapshots (`pkg/observability/inspect/testdata/render/`)

Six golden files regenerated for the new service-table + inspector-tool-description surfaces. Diffs are additive only (new rows for `route53` / `acm` on AWS; `clouddns` / `certificatemanager` on GCP).

## Scope decisions

- **Three issues, one PR.** #596 is the only one that ships fully; #599 and #601 are deferred with explicit "why" in the issue-status table above and (for #601) in this body. Per the bundle instructions: ship #596 cleanly rather than ballooning scope to drag in a codegen pipeline run or a validator refactor.
- **`google_dns_managed_zone` registry registration deferred.** The acceptance criterion is real but its cost surface is wrong for this bundle: a registry add fails `TestRegistryParity_GCP_LiveMatchesRegistry` unless paired with a real CAI discoverer in `cmd/insideout-import/gcpdiscover/`, and the matching policy file fails `TestPolicyRegistry_CoversGeneratedRegistry` unless paired with a generated Layer 1 struct (codegen run). That's a separate, larger PR.
- **AWS action aliases land here despite being LLM-prompt UX rather than dispatcher contract.** The aliases live in the same file (`service_actions.go`) and are pure additions — no test churn beyond the goldens.
- **`isLambda` removed at the same time** because go vet was clean, the function had zero callers, and it was a one-line touch in `contracts.go` that didn't justify its own PR.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` clean
- [x] `go test ./...` — 5128 passing tests across 36 packages (+100 from #596 inspectors)
- [x] `terraform fmt -check -recursive` clean
- [x] All ten repo lint scripts pass (`lint-project-tag.sh`, `lint-project-label.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`, `lint-no-root-only-blocks.sh`, `lint-labelless-name-prefix.sh`, `lint-gcp-project-pin.sh`, `lint-shared-no-cloud-providers.sh`, `lint-phantom-computed-fields.sh`, `lint-enrichgen-override-citations.sh`)
- [x] `make verify-supported-resources` passes
- [x] Integration build tag compiles cleanly (`go build -tags=integration ./pkg/observability/discovery/...`)

Live integration probes (`TestLive255_AWSInspectorsJSONShape` / `TestLive255_AllInspectorsJSONShape` with the new entries) are gated behind the `integration` build tag and require live AWS / GCP credentials — they Skip in default CI. Pre-release verification per `pkg/observability/discovery/CONTRIBUTING.md`.

## Review notes

- This is observability-pipeline integration only — no preset HCL changes. The presets themselves shipped in #583/#584/#586; their composer wiring shipped in #602.
- Two commits: the feature (`feat(observability)`) and the cleanup (`chore(composer)`). Cleanup is a one-file diff with no behavioral change.