### PR TITLE
feat(gcp): add github_actions preset for Workload Identity Federation (#597)

### DIFF
--- a/gcp/github_actions/main.tf
+++ b/gcp/github_actions/main.tf
@@ -1,0 +1,275 @@
+# -----------------------------------------------------------------------------
+# GCP GitHub Actions — Workload Identity Federation (WIF) for keyless deploys
+# -----------------------------------------------------------------------------
+# Mirrors aws/githubactions's OIDC role UX on the GCP side. Creates a
+# Workload Identity Pool + GitHub OIDC provider + deploy service account
+# bound such that GitHub Actions workflows in the configured repository can
+# impersonate the SA via short-lived federated credentials — eliminating
+# the need to mint and rotate long-lived SA JSON keys (the GCP equivalent
+# of leaking an AWS access key).
+#
+# Issue #597 row 1 (GCP GitHub Actions WIF). Follow-up scope (separate
+# tickets, filed at PR-merge time):
+#   - Cloud Deploy / Cloud Build delivery pipeline preset (gcp/cloud_deploy)
+#   - gcp/datadog and gcp/splunk log-router presets
+#   - inspector + drift-policy + insideout-import registry entries
+#
+# Idempotency contract (CLAUDE.md "Idempotency"):
+#   - google_iam_workload_identity_pool, ..._provider, google_service_account
+#     are NOT singletons — they can be created and destroyed cleanly. No
+#     adoption / lifecycle.ignore_changes dance required.
+#   - google_project_service entries use disable_on_destroy = false so the
+#     APIs stay enabled across destroy/apply cycles (matches the cloud_build
+#     and identity_platform conventions in this repo).
+#
+# IAM propagation: no time_sleep needed. The consumer of these bindings
+# is an external GitHub Actions workflow that runs minutes / hours / days
+# after terraform apply — IAM has propagated long before then. See the
+# trailing comment block in this file for the rule that governs adding
+# time_sleep if a future in-stack consumer is wired in.
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Required API enables
+# -----------------------------------------------------------------------------
+# WIF needs both iam.googleapis.com (for service-account + WIF resource
+# CRUD) and iamcredentials.googleapis.com (the token-minting STS endpoint
+# the GitHub Action calls to exchange its OIDC token for an SA access
+# token). Without the latter, the workflow succeeds at terraform-apply
+# time but fails at first deploy with `PERMISSION_DENIED: IAM Service
+# Account Credentials API has not been used`.
+resource "google_project_service" "iam" {
+  project            = var.project_id
+  service            = "iam.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "iamcredentials" {
+  project            = var.project_id
+  service            = "iamcredentials.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "sts" {
+  project            = var.project_id
+  service            = "sts.googleapis.com"
+  disable_on_destroy = false
+}
+
+# -----------------------------------------------------------------------------
+# Workload Identity Pool — the container that holds the GitHub OIDC provider
+# -----------------------------------------------------------------------------
+# pool_id has a 4-32 char limit and a `[a-z]([a-z0-9-]*[a-z0-9])` regex.
+# `${var.project}-${var.pool_short_name}` keeps the inspector name-prefix
+# scoping rule satisfied (lint-labelless-name-prefix.sh) while staying
+# within the length cap for typical project prefixes (`io-<13chars>` ≈
+# 16 chars + a short suffix). If a caller hits the cap, drop pool_short_name.
+resource "google_iam_workload_identity_pool" "github" {
+  project                   = var.project_id
+  workload_identity_pool_id = "${var.project}-${var.pool_short_name}"
+  display_name              = "GitHub Actions (${var.project})"
+  description               = "WIF pool for GitHub Actions OIDC federation — repo ${var.github_repository}"
+
+  depends_on = [google_project_service.iam]
+}
+
+# -----------------------------------------------------------------------------
+# GitHub OIDC provider on the pool
+# -----------------------------------------------------------------------------
+# `oidc.issuer_uri = https://token.actions.githubusercontent.com` is the
+# documented GitHub Actions OIDC issuer. The provider exposes the standard
+# GitHub claims (`sub`, `repository`, `actor`, `workflow`, `ref`, ...) which
+# we map 1:1 to `attribute.*` so the attribute_condition CEL expression
+# below can gate on them.
+#
+# attribute_condition (load-bearing security control):
+#   - Restrict to the configured `var.github_repository` so a workflow in a
+#     different repo on the same GitHub OIDC issuer cannot mint credentials.
+#   - Restrict to the caller-configured ref patterns (branches, tags,
+#     pull_request workflows) so unprivileged contributors can't simply
+#     push a branch to gain deploy creds.
+# Failing both gates fails the token exchange with `PERMISSION_DENIED:
+# The principal ... is not allowed to impersonate ...` — which is the
+# correct fail-loud surface.
+#
+# A missing condition would accept ANY GitHub workflow on the public OIDC
+# issuer (i.e. literally the entire world running on github.com). The
+# variables.tf validation block rejects the all-empty configuration to
+# prevent this misconfiguration from shipping.
+resource "google_iam_workload_identity_pool_provider" "github" {
+  project                            = var.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "${var.project}-${var.provider_short_name}"
+  display_name                       = "GitHub OIDC (${var.project})"
+  description                        = "GitHub Actions OIDC provider for ${var.github_repository}"
+
+  attribute_mapping = {
+    "google.subject"             = "assertion.sub"
+    "attribute.actor"            = "assertion.actor"
+    "attribute.aud"              = "assertion.aud"
+    "attribute.repository"       = "assertion.repository"
+    "attribute.repository_owner" = "assertion.repository_owner"
+    "attribute.ref"              = "assertion.ref"
+    "attribute.ref_type"         = "assertion.ref_type"
+    "attribute.event_name"       = "assertion.event_name"
+  }
+
+  # CEL condition: repository must match AND at least one of the
+  # ref-pattern gates must allow the token. local.attribute_condition is
+  # composed from var.allowed_branches / var.allowed_tags /
+  # var.allowed_pull_request below.
+  attribute_condition = local.attribute_condition
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+    # allowed_audiences left empty -> Google accepts the default audience
+    # of `https://iam.googleapis.com/projects/<num>/locations/global/
+    # workloadIdentityPools/<id>/providers/<provider_id>`, which is what
+    # google-github-actions/auth@v2 emits by default. Setting an explicit
+    # audience requires the workflow to set `audience:` in the action
+    # input — out of scope for the v1 preset UX.
+  }
+
+  # Cross-variable validation. Terraform 1.5+ variable validation blocks
+  # must reference their own variable, so a multi-variable rule fits
+  # cleanly only as a resource precondition. An all-empty ref-pattern
+  # configuration would build a WIF provider whose attribute_condition
+  # is `attribute.repository == "<repo>" && false` — which rejects every
+  # token (the local.ref_group fallback). That's safe-by-default, but
+  # the caller's intent is obviously wrong: they configured a deploy
+  # provider that can never deploy. Fail loudly at plan instead.
+  lifecycle {
+    precondition {
+      condition = (
+        length(var.allowed_branches) > 0 ||
+        length(var.allowed_tags) > 0 ||
+        var.allowed_pull_request
+      )
+      error_message = "At least one of allowed_branches, allowed_tags, allowed_pull_request must be non-empty. An all-empty configuration would build a WIF provider that rejects every workflow token (no ref-pattern matches). Pin allowed_branches to [\"main\"] for the standard branch-only deploy workflow, or override the other gates as needed."
+    }
+  }
+}
+
+locals {
+  # repository gate: exact match. assertion.repository is "OWNER/REPO".
+  repo_clause = "attribute.repository == \"${var.github_repository}\""
+
+  # ref gates: any of the following may match.
+  branch_clauses = [
+    for b in var.allowed_branches : "attribute.ref == \"refs/heads/${b}\""
+  ]
+  tag_clauses = [
+    for t in var.allowed_tags : "attribute.ref == \"refs/tags/${t}\""
+  ]
+  pr_clauses = var.allowed_pull_request ? ["attribute.event_name == \"pull_request\""] : []
+
+  ref_clauses = concat(local.branch_clauses, local.tag_clauses, local.pr_clauses)
+
+  # CEL grouping: repo AND (any-ref-clause). When ref_clauses is empty,
+  # variables.tf validation already failed plan — but the join would emit
+  # an empty parenthetical, so the guard short-circuits to a never-true
+  # expression as belt-and-suspenders.
+  ref_group = length(local.ref_clauses) > 0 ? "(${join(" || ", local.ref_clauses)})" : "false"
+
+  attribute_condition = "${local.repo_clause} && ${local.ref_group}"
+}
+
+# -----------------------------------------------------------------------------
+# Deploy service account — the identity the GitHub workflow impersonates
+# -----------------------------------------------------------------------------
+# account_id has a 4-30 char regex `[a-z]([-a-z0-9]*[a-z0-9])`. The
+# var.project prefix can overrun the cap; the short_name default keeps
+# typical names under the limit. The display_name carries var.project for
+# human readability — the lint-labelless-name-prefix.sh allowlist
+# exempts google_service_account from the var.project-in-name rule
+# precisely because of this length cap.
+resource "google_service_account" "deploy" {
+  project      = var.project_id
+  account_id   = var.service_account_short_name
+  display_name = "GitHub Actions deploy SA (${var.project})"
+  description  = "Service account impersonated by GitHub Actions WIF for repo ${var.github_repository}"
+
+  depends_on = [google_project_service.iam]
+}
+
+# -----------------------------------------------------------------------------
+# Grant the GitHub federated principal permission to impersonate the SA
+# -----------------------------------------------------------------------------
+# `principalSet://iam.googleapis.com/projects/<NUM>/locations/global/
+# workloadIdentityPools/<POOL_ID>/attribute.repository/<OWNER>/<REPO>`
+# is the canonical principal-set shape Google publishes for GitHub
+# Actions WIF. Combined with the provider's attribute_condition above,
+# this allows EXACTLY workflows from `var.github_repository` on the
+# allowed refs to mint tokens as this SA.
+#
+# We resolve the project number via data.google_project rather than
+# accepting it as a variable — keeps the caller's contract simple
+# (just project_id) and the number is stable per project.
+data "google_project" "this" {
+  project_id = var.project_id
+
+  # depends_on pins the read until after the API enable lands. Without
+  # it data.google_project may race the project_service activation in
+  # cold-account deploys and report `number = 0`, which produces an
+  # invalid principalSet that 404s at apply.
+  depends_on = [google_project_service.iam]
+}
+
+resource "google_service_account_iam_binding" "wif_user" {
+  service_account_id = google_service_account.deploy.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "principalSet://iam.googleapis.com/projects/${data.google_project.this.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github.workload_identity_pool_id}/attribute.repository/${var.github_repository}",
+  ]
+
+  depends_on = [google_iam_workload_identity_pool_provider.github]
+}
+
+# -----------------------------------------------------------------------------
+# Project-level role bindings for the deploy SA
+# -----------------------------------------------------------------------------
+# The SA needs whatever roles the caller's deploy pipeline actually uses.
+# Default = roles/run.admin + roles/iam.serviceAccountUser, which is the
+# minimal set for a Cloud Run deploy (run.admin to update services,
+# serviceAccountUser to attach the runtime SA to the new revision). Callers
+# can override via var.deploy_roles for other deploy targets (GKE, Cloud
+# Functions, BigQuery jobs, etc.).
+#
+# google_project_iam_member (additive, per-(role, member) pair) rather
+# than google_project_iam_binding (authoritative, owns the whole role
+# membership list) to avoid stomping pre-existing role grants in the
+# project. Etag drifts on refresh but is Computed-only —
+# lifecycle.ignore_changes has no effect; drift-check suppression
+# happens at the inspector level (matches gcp/cloud_build:81 pattern).
+resource "google_project_iam_member" "deploy_roles" {
+  for_each = toset(var.deploy_roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.deploy.email}"
+}
+
+# -----------------------------------------------------------------------------
+# IAM propagation note
+# -----------------------------------------------------------------------------
+# GCP IAM is eventually consistent — a downstream resource that consumes
+# bindings can race the propagation and 403 on the first apply. We do NOT
+# emit a time_sleep here because the consumer of these bindings is an
+# external GitHub Actions workflow that hits the WIF endpoint minutes /
+# hours / days after terraform apply completes — IAM will absolutely have
+# propagated by then. Compare gcp/cloud_build/main.tf, which historically
+# carried a time_sleep but had it removed (#201) once the real cause —
+# missing service_account, not propagation — was found. If a future
+# in-stack GCP consumer is wired to depend on these bindings at apply
+# time, this is the right spot to re-introduce time_sleep.wait_iam_propagation
+# (and re-declare the hashicorp/time required_provider above).

--- a/gcp/github_actions/outputs.tf
+++ b/gcp/github_actions/outputs.tf
@@ -1,0 +1,34 @@
+output "service_account_email" {
+  value       = google_service_account.deploy.email
+  description = "Email of the deploy SA. Paste into the GitHub Actions workflow as the `service_account` input on google-github-actions/auth@v2."
+}
+
+output "service_account_name" {
+  value       = google_service_account.deploy.name
+  description = "Fully-qualified SA resource name (projects/<id>/serviceAccounts/<email>). Useful for tooling that needs the GCP resource path rather than just the email."
+}
+
+output "workload_identity_provider" {
+  value       = "projects/${data.google_project.this.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.github.workload_identity_pool_provider_id}"
+  description = "Fully-qualified WIF provider name. Paste into the GitHub Actions workflow as the `workload_identity_provider` input on google-github-actions/auth@v2 — e.g.:\n\n  - uses: google-github-actions/auth@v2\n    with:\n      workload_identity_provider: <this output>\n      service_account: <service_account_email output>\n"
+}
+
+output "pool_name" {
+  value       = google_iam_workload_identity_pool.github.name
+  description = "Fully-qualified WIF pool resource name (projects/<num>/locations/global/workloadIdentityPools/<id>)."
+}
+
+output "pool_id" {
+  value       = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  description = "Short pool ID (var.project-prefixed)."
+}
+
+output "provider_id" {
+  value       = google_iam_workload_identity_pool_provider.github.workload_identity_pool_provider_id
+  description = "Short provider ID within the pool (var.project-prefixed)."
+}
+
+output "github_repository" {
+  value       = var.github_repository
+  description = "Pass-through of the configured GitHub repository (OWNER/REPO)."
+}

--- a/gcp/github_actions/tests/shape.tftest.hcl
+++ b/gcp/github_actions/tests/shape.tftest.hcl
@@ -1,0 +1,173 @@
+mock_provider "google" {}
+
+# Issue #597 row 1 (gcp/github_actions WIF preset) shape tests. Verifies that:
+#   - Defaults compose cleanly (happy path).
+#   - github_repository validation rejects malformed values.
+#   - The cross-variable check rejects the all-empty ref-pattern gate
+#     configuration that would otherwise build a WIF provider accepting
+#     ANY GitHub workflow on the public OIDC issuer (security regression).
+#   - deploy_roles validation rejects an empty list (powerless SA).
+
+run "github_actions_minimum_inputs" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    github_repository = "luthersystems/insideout-terraform-presets"
+  }
+
+  assert {
+    condition     = google_iam_workload_identity_pool.github.workload_identity_pool_id == "test-github-actions"
+    error_message = "pool_id should be project-prefixed (var.project + var.pool_short_name)."
+  }
+
+  assert {
+    condition     = google_iam_workload_identity_pool_provider.github.workload_identity_pool_provider_id == "test-github"
+    error_message = "provider_id should default to project-prefixed `github`."
+  }
+
+  assert {
+    condition     = google_service_account.deploy.account_id == "github-deploy"
+    error_message = "service_account.account_id should default to `github-deploy` (length-cap safe)."
+  }
+
+  assert {
+    condition     = google_iam_workload_identity_pool_provider.github.oidc[0].issuer_uri == "https://token.actions.githubusercontent.com"
+    error_message = "OIDC issuer must be the GitHub Actions public issuer."
+  }
+}
+
+run "github_actions_custom_branches_and_tags" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    github_repository    = "luthersystems/foo"
+    allowed_branches     = ["main", "release"]
+    allowed_tags         = ["v1.0.0", "v2.0.0"]
+    allowed_pull_request = true
+  }
+
+  # The CEL attribute_condition must mention every gate the caller turned
+  # on, so a workflow on `main`, on tag `v1.0.0`, or for a pull_request
+  # event can mint credentials (and nothing else).
+  assert {
+    condition     = strcontains(google_iam_workload_identity_pool_provider.github.attribute_condition, "luthersystems/foo")
+    error_message = "attribute_condition must pin the configured github_repository."
+  }
+
+  assert {
+    condition     = strcontains(google_iam_workload_identity_pool_provider.github.attribute_condition, "refs/heads/main")
+    error_message = "attribute_condition must allow refs/heads/main when allowed_branches contains main."
+  }
+
+  assert {
+    condition     = strcontains(google_iam_workload_identity_pool_provider.github.attribute_condition, "refs/heads/release")
+    error_message = "attribute_condition must allow refs/heads/release when listed."
+  }
+
+  assert {
+    condition     = strcontains(google_iam_workload_identity_pool_provider.github.attribute_condition, "refs/tags/v1.0.0")
+    error_message = "attribute_condition must allow refs/tags/v1.0.0 when listed."
+  }
+
+  assert {
+    condition     = strcontains(google_iam_workload_identity_pool_provider.github.attribute_condition, "pull_request")
+    error_message = "attribute_condition must allow pull_request events when allowed_pull_request = true."
+  }
+}
+
+run "github_actions_default_deploy_roles_are_cloud_run" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    github_repository = "luthersystems/foo"
+  }
+
+  assert {
+    condition     = length(google_project_iam_member.deploy_roles) == 2
+    error_message = "Default deploy_roles is [run.admin, iam.serviceAccountUser]; expected exactly 2 google_project_iam_member resources."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases: validation blocks must reject obvious misconfigurations at
+# plan time so callers don't discover them at apply.
+# -----------------------------------------------------------------------------
+
+run "github_actions_rejects_malformed_repository" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    github_repository = "no-slash-here"
+  }
+
+  expect_failures = [var.github_repository]
+}
+
+run "github_actions_rejects_all_empty_ref_gates" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    github_repository    = "luthersystems/foo"
+    allowed_branches     = []
+    allowed_tags         = []
+    allowed_pull_request = false
+  }
+
+  # Cross-variable validation is hosted as a precondition on the WIF
+  # provider resource (Terraform 1.5+ disallows multi-variable rules in
+  # variable validation blocks). Precondition violations surface as a
+  # generic plan error, not a typed expect_failures handle — so we
+  # assert the failure mode by inverting the expectation and relying
+  # on the framework to flag a missing failure.
+  expect_failures = [
+    google_iam_workload_identity_pool_provider.github,
+  ]
+}
+
+run "github_actions_rejects_empty_deploy_roles" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    github_repository = "luthersystems/foo"
+    deploy_roles      = []
+  }
+
+  expect_failures = [var.deploy_roles]
+}
+
+run "github_actions_rejects_non_role_strings" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    github_repository = "luthersystems/foo"
+    deploy_roles      = ["run.admin"] # missing roles/ prefix
+  }
+
+  expect_failures = [var.deploy_roles]
+}
+
+run "github_actions_rejects_invalid_project_id" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "INVALID_UPPERCASE"
+    github_repository = "luthersystems/foo"
+  }
+
+  expect_failures = [var.project_id]
+}

--- a/gcp/github_actions/variables.tf
+++ b/gcp/github_actions/variables.tf
@@ -1,0 +1,154 @@
+variable "project" {
+  description = "Naming/label prefix for stack resources (NOT a GCP project ID — see var.project_id)."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+}
+
+variable "project_id" {
+  description = "Real GCP project ID where resources are created (e.g. \"my-prod-12345\"). Distinct from var.project, which is the naming/label prefix and need not be a valid GCP project ID."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "project_id must be a valid GCP project ID: 6–30 chars, lowercase letters/digits/hyphens, start with a letter, end alphanumeric."
+  }
+}
+
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate); WIF itself is global so the module body doesn't consume it.
+variable "region" {
+  description = "GCP region. WIF is global; this variable exists for composer wiring uniformity."
+  type        = string
+  default     = "us-central1"
+}
+
+# -----------------------------------------------------------------------------
+# GitHub repository identity
+# -----------------------------------------------------------------------------
+variable "github_repository" {
+  description = "GitHub repository in OWNER/REPO format (e.g. \"luthersystems/insideout-terraform-presets\"). Only workflows from this exact repo can mint deploy credentials via the WIF provider."
+  type        = string
+
+  validation {
+    # GitHub login + repo name character classes per
+    # https://docs.github.com/en/get-started/learning-about-github/types-of-github-accounts
+    # — letters, digits, hyphen, underscore, dot, slash separator.
+    condition     = can(regex("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", var.github_repository))
+    error_message = "github_repository must match OWNER/REPO (e.g. \"luthersystems/insideout-terraform-presets\")."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Ref-pattern gates — at least one must be non-trivial
+# -----------------------------------------------------------------------------
+# These compose into the WIF provider's CEL attribute_condition. The
+# repository check is always enforced; these gates further narrow which
+# refs / event types from that repository can mint credentials.
+#
+# Defaults: allow_branches = ["main"] only. Conservative and matches the
+# typical "deploy on push to main" GitHub Actions setup. Callers wanting
+# tag-based release deploys override allowed_tags; PR-preview deploys
+# override allowed_pull_request.
+variable "allowed_branches" {
+  description = "Branch names (e.g. [\"main\", \"release\"]) whose workflows may impersonate the deploy SA. Empty list disables branch-based access. At least one of allowed_branches / allowed_tags / allowed_pull_request must be non-empty (else WIF would accept any workflow — security regression)."
+  type        = list(string)
+  default     = ["main"]
+}
+
+variable "allowed_tags" {
+  description = "Tag patterns (e.g. [\"v*\", \"release-*\"]) whose workflows may impersonate the deploy SA. Pattern matching is exact-string against the ref (refs/tags/<pattern>) — Cloud DNS / WIF do not support glob expansion. For glob behaviour, list each expected tag explicitly. Default empty disables tag-based access."
+  type        = list(string)
+  default     = []
+}
+
+variable "allowed_pull_request" {
+  description = "Allow workflows triggered by pull_request events to impersonate the deploy SA. Use for PR-preview deploys; leave false for production-only credentials. Default false (recommended — PR workflows from forks should NOT mint deploy creds)."
+  type        = bool
+  default     = false
+}
+
+# -----------------------------------------------------------------------------
+# Deploy role grants on the SA
+# -----------------------------------------------------------------------------
+variable "deploy_roles" {
+  description = "List of project-level IAM roles granted to the deploy SA. Defaults to the minimum for a Cloud Run deploy (roles/run.admin updates services; roles/iam.serviceAccountUser lets the SA attach runtime SAs to revisions). For other targets, override — e.g. GKE deploys add roles/container.developer, GCS uploads add roles/storage.admin, BigQuery jobs add roles/bigquery.jobUser. Avoid roles/owner — least-privilege."
+  type        = list(string)
+  default = [
+    "roles/run.admin",
+    "roles/iam.serviceAccountUser",
+  ]
+
+  validation {
+    condition     = length(var.deploy_roles) > 0
+    error_message = "deploy_roles must list at least one role; an empty list creates a powerless SA that the workflow can impersonate but cannot use."
+  }
+
+  validation {
+    # Defensive: callers occasionally mistake project-name strings for role names.
+    condition     = alltrue([for r in var.deploy_roles : can(regex("^roles/", r))])
+    error_message = "Every entry in deploy_roles must start with \"roles/\" (e.g. \"roles/run.admin\"). Custom roles use the full \"projects/<id>/roles/<name>\" form — also accepted, but must include the projects/ prefix."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Resource short names (overridable for length-constrained projects)
+# -----------------------------------------------------------------------------
+variable "pool_short_name" {
+  description = "Workload identity pool short name (combined with var.project to form the full pool ID, bounded to 32 chars total). Shorten when var.project itself is long."
+  type        = string
+  default     = "github-actions"
+
+  validation {
+    # Pool ID regex: `^[a-z][a-z0-9-]{3,30}[a-z0-9]$` per Google. The
+    # composed `${var.project}-${var.pool_short_name}` must satisfy this;
+    # the short_name itself must use the same charset.
+    condition     = can(regex("^[a-z][a-z0-9-]*[a-z0-9]$", var.pool_short_name))
+    error_message = "pool_short_name must start with a lowercase letter, end alphanumeric, and contain only lowercase letters / digits / hyphens."
+  }
+}
+
+variable "provider_short_name" {
+  description = "OIDC provider short name within the pool. Defaults to \"github\"."
+  type        = string
+  default     = "github"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*[a-z0-9]$", var.provider_short_name))
+    error_message = "provider_short_name must start with a lowercase letter, end alphanumeric, and contain only lowercase letters / digits / hyphens."
+  }
+}
+
+variable "service_account_short_name" {
+  description = "account_id for the deploy SA. Hard cap is 30 chars (GCP-imposed). Default \"github-deploy\" leaves room for downstream consumers that prefix again."
+  type        = string
+  default     = "github-deploy"
+
+  validation {
+    # `[a-z]([-a-z0-9]*[a-z0-9])` and 6-30 char length per GCP.
+    condition     = can(regex("^[a-z][-a-z0-9]{4,28}[a-z0-9]$", var.service_account_short_name))
+    error_message = "service_account_short_name must be 6-30 chars: lowercase letters / digits / hyphens, start with a letter, end alphanumeric."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Labels — applied to label-capable resources (SAs and WIF resources don't
+# accept labels at the time of writing; this var is reserved for future use
+# and for consistency with the rest of the repo's GCP preset UX).
+# -----------------------------------------------------------------------------
+# tflint-ignore: terraform_unused_declarations  # WIF resources / google_service_account do not accept labels per the google provider schema as of v5.x; declared for UX consistency with other GCP presets.
+variable "labels" {
+  description = "Additional labels to apply to label-capable resources (currently unused — google_iam_workload_identity_pool, ..._provider, and google_service_account do not accept labels per the google provider schema as of v5.x). Reserved for UX consistency with other GCP presets."
+  type        = map(string)
+  default     = {}
+}
+
+# -----------------------------------------------------------------------------
+# Cross-variable validation: at least one ref-pattern gate must be non-trivial
+# -----------------------------------------------------------------------------
+# Hosted as a precondition on google_iam_workload_identity_pool_provider in
+# main.tf (Terraform 1.5+ requires variable validation blocks to reference
+# their own variable, which can't express a cross-variable rule). See
+# the precondition block at the provider resource for the actual check.

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -142,6 +142,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.GCPCloudBuild)
 	case KeyGCPCloudDNS:
 		return boolPtrTrue(c.GCPCloudDNS)
+	case KeyGCPGitHubActions:
+		return boolPtrTrue(c.GCPGitHubActions)
 	case KeyGCPBackups:
 		return c.GCPBackups != nil
 	// External / third-party.
@@ -296,7 +298,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,
 		KeyGCPPubSub, KeyGCPCloudLogging,
 		KeyGCPIdentityPlatform, KeyGCPAPIGateway, KeyGCPBackups,
-		KeyGCPCloudDNS:
+		KeyGCPCloudDNS, KeyGCPGitHubActions:
 		return true
 	}
 	return false

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -89,6 +89,7 @@ const (
 	KeyGCPAPIGateway       ComponentKey = "gcp_api_gateway"
 	KeyGCPBackups          ComponentKey = "gcp_backups"
 	KeyGCPCloudDNS         ComponentKey = "gcp_cloud_dns"
+	KeyGCPGitHubActions    ComponentKey = "gcp_github_actions"
 )
 
 var ComposeOrder = []ComponentKey{
@@ -157,6 +158,10 @@ var ComposeOrder = []ComponentKey{
 	KeyGCPCloudBuild,
 	KeyAWSGitHubActions,
 	KeyAWSCodePipeline,
+	// GCP GitHub Actions WIF preset (#597 row 1). Independent of any
+	// upstream GCP preset so position is not load-bearing — placed
+	// alongside the AWS sibling for reviewability.
+	KeyGCPGitHubActions,
 	KeyArch,
 	KeyCloud,
 	KeyComposer,
@@ -224,6 +229,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyGCPCloudBuild:       "gcp/cloud_build",
 	KeyGCPBackups:          "gcp/backups",
 	KeyGCPCloudDNS:         "gcp/cloud_dns",
+	KeyGCPGitHubActions:    "gcp/github_actions",
 }
 
 // ImplicitDependencies defines components that must be automatically added
@@ -375,6 +381,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyGCPCloudFunctions:       "cloud_functions",
 	KeyGCPBastion:              "bastion",
 	KeyGCPCloudDNS:             "cloud_dns",
+	KeyGCPGitHubActions:        "github_actions",
 }
 
 // GetPresetPath returns the cloud-prefixed preset path for a component.
@@ -482,6 +489,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyGCPFirestore,
 	KeyGCPGCS,
 	KeyGCPGKE,
+	KeyGCPGitHubActions,
 	KeyGCPIdentityPlatform,
 	KeyGCPLoadbalancer,
 	KeyGCPMemorystore,

--- a/pkg/composer/gcp_services.go
+++ b/pkg/composer/gcp_services.go
@@ -74,6 +74,16 @@ var GCPServices = map[ComponentKey][]GCPService{
 	},
 	KeyGCPBackups: {{Name: "backupdr.googleapis.com", Title: "Backup and DR Service"}},
 	KeyGCPCloudDNS: {{Name: "dns.googleapis.com", Title: "Cloud DNS"}},
+	// GCP GitHub Actions WIF preset (#597 row 1). The preset enables
+	// iam.googleapis.com (covered by always-required) plus IAM Credentials
+	// (the STS token-minting endpoint the action calls) and STS itself
+	// (the federation endpoint). Without these enabled, terraform apply
+	// succeeds but the first GitHub Actions workflow run fails at the
+	// auth step with PERMISSION_DENIED.
+	KeyGCPGitHubActions: {
+		{Name: "iamcredentials.googleapis.com", Title: "IAM Service Account Credentials"},
+		{Name: "sts.googleapis.com", Title: "Security Token Service"},
+	},
 	// Components that need no extra service beyond the always-required set
 	// (covered by Compute / always-required entries):
 	KeyGCPVPC:          nil,

--- a/pkg/composer/github_actions_gcp_wiring_test.go
+++ b/pkg/composer/github_actions_gcp_wiring_test.go
@@ -1,0 +1,218 @@
+package composer
+
+// github_actions_gcp_wiring_test.go covers the issue #597 row 1 composer
+// wiring for the gcp/github_actions preset (GitHub Actions Workload
+// Identity Federation):
+//
+//   - ComponentKey + PresetKeyMap + ModulePath + AllComponentKeys +
+//     ComposeOrder registry entries are exercised by
+//     TestAllComponentKeysCoversPresetKeyMap and
+//     TestMapperKeysSubsetOfModuleVariables (both in sibling files).
+//   - Default mapper provides every required variable — exercised by
+//     TestEveryRequiredVariableIsMappedOrWired.
+//
+// The tests below pin:
+//   - Forward wiring: selecting KeyGCPGitHubActions causes the composer to
+//     emit `module "gcp_github_actions"` in the composed root.
+//   - Mapper default: caller-empty cfg.GCPGitHubActions produces the
+//     placeholder.invalid/placeholder repo (preset's variable has no
+//     default, so without this the single-module preview fails).
+//   - Mapper caller-supplied: cfg.GCPGitHubActions.GitHubRepository
+//     flows through unchanged to the github_repository module variable.
+//   - End-to-end ComposeStack with GCP + KeyGCPGitHubActions succeeds and
+//     produces a valid composed root.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapper_GCPGitHubActions_DefaultRepository(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyGCPGitHubActions, &Components{}, &Config{}, "demo", "us-central1")
+	require.NoError(t, err)
+
+	repo, ok := vals["github_repository"]
+	require.True(t, ok, "mapper must always set github_repository (preset has no default)")
+	require.Equal(t, "placeholder.invalid/placeholder", repo,
+		"mapper should fall back to placeholder.invalid/placeholder when cfg.GCPGitHubActions.GitHubRepository is unset; the placeholder is shaped to satisfy the OWNER/REPO regex without colliding with any real GitHub identity")
+}
+
+func TestMapper_GCPGitHubActions_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	tr := true
+	cfg := &Config{
+		GCPGitHubActions: &struct {
+			GitHubRepository   string   `json:"githubRepository,omitempty"`
+			AllowedBranches    []string `json:"allowedBranches,omitempty"`
+			AllowedTags        []string `json:"allowedTags,omitempty"`
+			AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
+			DeployRoles        []string `json:"deployRoles,omitempty"`
+		}{
+			GitHubRepository:   "luthersystems/foo",
+			AllowedBranches:    []string{"main", "release"},
+			AllowedTags:        []string{"v1.0.0"},
+			AllowedPullRequest: &tr,
+			DeployRoles:        []string{"roles/run.admin", "roles/container.developer"},
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyGCPGitHubActions, &Components{}, cfg, "demo", "us-central1")
+	require.NoError(t, err)
+
+	require.Equal(t, "luthersystems/foo", vals["github_repository"])
+	require.Equal(t, []any{"main", "release"}, vals["allowed_branches"])
+	require.Equal(t, []any{"v1.0.0"}, vals["allowed_tags"])
+	require.Equal(t, true, vals["allowed_pull_request"])
+	require.Equal(t, []any{"roles/run.admin", "roles/container.developer"}, vals["deploy_roles"])
+}
+
+// TestMapper_GCPGitHubActions_PartialConfig confirms that when only one
+// optional sub-field is set the mapper emits only that sub-field — the
+// preset's variables.tf defaults must apply to the rest. Catches a class
+// of bug where the mapper would unconditionally emit empty slices /
+// false bools that override the module's defaults.
+func TestMapper_GCPGitHubActions_PartialConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		GCPGitHubActions: &struct {
+			GitHubRepository   string   `json:"githubRepository,omitempty"`
+			AllowedBranches    []string `json:"allowedBranches,omitempty"`
+			AllowedTags        []string `json:"allowedTags,omitempty"`
+			AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
+			DeployRoles        []string `json:"deployRoles,omitempty"`
+		}{
+			GitHubRepository: "luthersystems/foo",
+			// AllowedBranches, AllowedTags, AllowedPullRequest, DeployRoles
+			// intentionally left at zero values.
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyGCPGitHubActions, &Components{}, cfg, "demo", "us-central1")
+	require.NoError(t, err)
+
+	require.Equal(t, "luthersystems/foo", vals["github_repository"])
+	_, hasBranches := vals["allowed_branches"]
+	require.False(t, hasBranches, "mapper must NOT emit allowed_branches when caller left the slice nil — module default [\"main\"] must win")
+	_, hasTags := vals["allowed_tags"]
+	require.False(t, hasTags, "mapper must NOT emit allowed_tags when caller left the slice nil")
+	_, hasPR := vals["allowed_pull_request"]
+	require.False(t, hasPR, "mapper must NOT emit allowed_pull_request when caller left the *bool nil")
+	_, hasRoles := vals["deploy_roles"]
+	require.False(t, hasRoles, "mapper must NOT emit deploy_roles when caller left the slice nil — module default [run.admin, iam.serviceAccountUser] must win")
+}
+
+func TestComposeStack_GCPGitHubActions_Forward(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPGitHubActions},
+		Comps:        &Components{Cloud: "GCP"},
+		Cfg:          &Config{Region: "us-central1"},
+		Project:      "test",
+		Region:       "us-central1",
+		GCPProjectID: "test-project-12345",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok, "composed root must contain main.tf")
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, `module "gcp_github_actions"`,
+		"composed root must declare module gcp_github_actions when KeyGCPGitHubActions is selected")
+	require.Contains(t, rootStr, `"./gcp/github_actions"`,
+		"module source path must resolve to gcp/github_actions per ModulePath (composer formats with variable padding around =)")
+
+	// Confirm the tfvars file landed with the placeholder repo.
+	tfvars, ok := out["/gcp_github_actions.auto.tfvars"]
+	require.True(t, ok, "expected gcp_github_actions.auto.tfvars")
+	require.Contains(t, string(tfvars), "placeholder.invalid/placeholder",
+		"standalone GitHub Actions module should land the placeholder repo so terraform plan can compile; callers MUST override before terraform apply")
+}
+
+func TestComposeStack_GCPGitHubActions_CallerSuppliedRepo(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPGitHubActions},
+		Comps:        &Components{Cloud: "GCP"},
+		Cfg: &Config{
+			Region: "us-central1",
+			GCPGitHubActions: &struct {
+				GitHubRepository   string   `json:"githubRepository,omitempty"`
+				AllowedBranches    []string `json:"allowedBranches,omitempty"`
+				AllowedTags        []string `json:"allowedTags,omitempty"`
+				AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
+				DeployRoles        []string `json:"deployRoles,omitempty"`
+			}{
+				GitHubRepository: "luthersystems/insideout-terraform-presets",
+			},
+		},
+		Project:      "test",
+		Region:       "us-central1",
+		GCPProjectID: "test-project-12345",
+	})
+	require.NoError(t, err)
+
+	tfvars, ok := out["/gcp_github_actions.auto.tfvars"]
+	require.True(t, ok)
+	require.Contains(t, string(tfvars), "luthersystems/insideout-terraform-presets",
+		"caller-supplied github_repository must flow through to the tfvars file")
+	require.NotContains(t, string(tfvars), "placeholder.invalid",
+		"caller-supplied github_repository must override the placeholder default")
+}
+
+// TestComponentSelected_GCPGitHubActions pins the coherence.go entry —
+// without it ComponentSelected returns false for KeyGCPGitHubActions
+// and the orphan-strip pass silently clears cfg.GCPGitHubActions even
+// when comps.GCPGitHubActions=&true.
+func TestComponentSelected_GCPGitHubActions(t *testing.T) {
+	t.Parallel()
+
+	tr := true
+	c := &Components{GCPGitHubActions: &tr}
+	require.True(t, ComponentSelected(c, KeyGCPGitHubActions),
+		"ComponentSelected must return true when comps.GCPGitHubActions=&true")
+
+	fa := false
+	c2 := &Components{GCPGitHubActions: &fa}
+	require.False(t, ComponentSelected(c2, KeyGCPGitHubActions),
+		"ComponentSelected must return false when comps.GCPGitHubActions=&false (explicit deselect)")
+
+	c3 := &Components{}
+	require.False(t, ComponentSelected(c3, KeyGCPGitHubActions),
+		"ComponentSelected must return false when comps.GCPGitHubActions is nil")
+}
+
+// TestGCPIAMPermissions_GitHubActionsCovered pins the iam_actions.go
+// entry. Without it RequiredGCPIAMPermissions silently omits the WIF /
+// SA-creation permissions a real deploy needs — surfacing as a 403 at
+// apply time instead of at the SimulatePrincipalPolicy / testIamPermissions
+// pre-deploy check (ui-core #192).
+func TestGCPIAMPermissions_GitHubActionsCovered(t *testing.T) {
+	t.Parallel()
+
+	perms, ok := GCPIAMPermissions[KeyGCPGitHubActions]
+	require.True(t, ok, "GCPIAMPermissions must have an entry for KeyGCPGitHubActions")
+	require.NotEmpty(t, perms, "GCPIAMPermissions[KeyGCPGitHubActions] must list at least one permission — WIF + SA + IAM-binding all require explicit perms beyond the always-required set")
+
+	required := RequiredGCPIAMPermissions([]ComponentKey{KeyGCPGitHubActions})
+	require.Contains(t, required, "iam.workloadIdentityPools.create",
+		"WIF pool create permission must be in the required set")
+	require.Contains(t, required, "iam.workloadIdentityPoolProviders.create",
+		"WIF provider create permission must be in the required set")
+	require.Contains(t, required, "iam.serviceAccounts.create",
+		"SA create permission must be in the required set")
+	require.Contains(t, required, "resourcemanager.projects.setIamPolicy",
+		"Project IAM-binding permission must be in the required set (the deploy SA needs roles bound at the project level)")
+}

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -162,6 +162,18 @@ var GCPIAMPermissions = map[ComponentKey][]string{
 		"dns.managedZones.create",
 		"dns.resourceRecordSets.create",
 	},
+	// GCP GitHub Actions WIF preset (#597 row 1). The deploying SA needs
+	// permissions to create the WIF pool + provider, the deploy SA, and
+	// project-level IAM bindings on that SA — plus enable the IAM /
+	// IAM Credentials / STS APIs.
+	KeyGCPGitHubActions: {
+		"iam.workloadIdentityPools.create",
+		"iam.workloadIdentityPoolProviders.create",
+		"iam.serviceAccounts.create",
+		"iam.serviceAccounts.setIamPolicy",
+		"resourcemanager.projects.setIamPolicy",
+		"serviceusage.services.enable",
+	},
 	// Components that need no extra permission beyond the always-required set:
 	KeyGCPVPC:          nil,
 	KeyGCPCompute:      nil,

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1080,6 +1080,50 @@ func (m DefaultMapper) BuildModuleValues(
 				vals["force_destroy"] = *cfg.GCPCloudDNS.ForceDestroy
 			}
 		}
+
+	case KeyGCPGitHubActions:
+		// GCP GitHub Actions WIF (#597 row 1). github_repository is required
+		// by the preset (no default); supply a preview-safe placeholder
+		// matching the OWNER/REPO regex so single-module previews and
+		// validation runs succeed when the caller hasn't yet provided
+		// cfg.GCPGitHubActions.GitHubRepository. The placeholder is shaped
+		// to obviously not match any real GitHub repo — callers MUST
+		// override before terraform apply or the WIF condition will reject
+		// every workflow token at exchange time. .invalid is the IANA-
+		// reserved TLD for testing; the slash separator satisfies the
+		// preset's OWNER/REPO regex without colliding with any real
+		// GitHub identity (slash characters are illegal in GitHub logins).
+		repo := "placeholder.invalid/placeholder"
+		if cfg != nil && cfg.GCPGitHubActions != nil && strings.TrimSpace(cfg.GCPGitHubActions.GitHubRepository) != "" {
+			repo = strings.TrimSpace(cfg.GCPGitHubActions.GitHubRepository)
+		}
+		vals["github_repository"] = repo
+		if cfg != nil && cfg.GCPGitHubActions != nil {
+			if len(cfg.GCPGitHubActions.AllowedBranches) > 0 {
+				bs := make([]any, len(cfg.GCPGitHubActions.AllowedBranches))
+				for i, b := range cfg.GCPGitHubActions.AllowedBranches {
+					bs[i] = b
+				}
+				vals["allowed_branches"] = bs
+			}
+			if len(cfg.GCPGitHubActions.AllowedTags) > 0 {
+				ts := make([]any, len(cfg.GCPGitHubActions.AllowedTags))
+				for i, t := range cfg.GCPGitHubActions.AllowedTags {
+					ts[i] = t
+				}
+				vals["allowed_tags"] = ts
+			}
+			if cfg.GCPGitHubActions.AllowedPullRequest != nil {
+				vals["allowed_pull_request"] = *cfg.GCPGitHubActions.AllowedPullRequest
+			}
+			if len(cfg.GCPGitHubActions.DeployRoles) > 0 {
+				rs := make([]any, len(cfg.GCPGitHubActions.DeployRoles))
+				for i, r := range cfg.GCPGitHubActions.DeployRoles {
+					rs[i] = r
+				}
+				vals["deploy_roles"] = rs
+			}
+		}
 	}
 
 	return vals, nil

--- a/pkg/composer/presets.go
+++ b/pkg/composer/presets.go
@@ -92,6 +92,7 @@ func (c *Client) ListAvailableComponentKeys() ([]string, error) {
 		KeyGCPGCS, KeyGCPCloudKMS, KeyGCPSecretManager, KeyGCPVertexAI,
 		KeyGCPPubSub, KeyGCPCloudLogging, KeyGCPCloudMonitoring,
 		KeyGCPIdentityPlatform, KeyGCPCloudBuild, KeyGCPBackups,
+		KeyGCPCloudDNS, KeyGCPGitHubActions,
 	}
 
 	for _, cloud := range clouds {

--- a/pkg/composer/pricing.go
+++ b/pkg/composer/pricing.go
@@ -147,6 +147,7 @@ type PricingData struct {
 		GCPIdentityPlatform *PricingItem       `json:"gcp_identity_platform,omitempty"`
 		GCPCloudBuild       *PricingItem       `json:"gcp_cloud_build,omitempty"`
 		GCPCloudDNS         *PricingItem       `json:"gcp_cloud_dns,omitempty"`
+		GCPGitHubActions    *PricingItem       `json:"gcp_github_actions,omitempty"`
 		GCPBackups          *GCPPricingBackups `json:"gcp_backups,omitempty"`
 
 		// External/Third-Party
@@ -406,6 +407,7 @@ func (p *PricingData) Normalize() {
 		c.GCPIdentityPlatform = nil
 		c.GCPCloudBuild = nil
 		c.GCPCloudDNS = nil
+		c.GCPGitHubActions = nil
 		c.GCPBackups = nil
 
 		// Sync legacy and cloud-specific fields for AWS

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -76,6 +76,7 @@ type Components struct {
 	GCPIdentityPlatform *bool  `json:"gcp_identity_platform,omitempty"`
 	GCPCloudBuild       *bool  `json:"gcp_cloud_build,omitempty"`
 	GCPCloudDNS         *bool  `json:"gcp_cloud_dns,omitempty"`
+	GCPGitHubActions    *bool  `json:"gcp_github_actions,omitempty"`
 	GCPBackups          *struct {
 		Compute  *bool `json:"gcp_compute,omitempty"`
 		CloudSQL *bool `json:"gcp_cloudsql,omitempty"`
@@ -368,6 +369,25 @@ type Config struct {
 		ForceDestroy     *bool    `json:"forceDestroy,omitempty"`
 	} `json:"gcp_cloud_dns,omitempty"`
 
+	// GCPGitHubActions carries the caller-supplied GitHub Actions WIF
+	// configuration (#597 row 1). GitHubRepository is the OWNER/REPO that
+	// the WIF provider's attribute_condition pins; without it the mapper
+	// supplies a placeholder.invalid/placeholder default so single-module
+	// previews compose, but the WIF condition built around the placeholder
+	// will never match a real workflow — callers MUST override before
+	// terraform apply (the placeholder is shaped to fail loudly rather
+	// than silently accept any repo). AllowedBranches / AllowedTags /
+	// AllowedPullRequest gate which refs / events from that repo can
+	// mint credentials; DeployRoles is the project-level role grant list
+	// on the deploy SA.
+	GCPGitHubActions *struct {
+		GitHubRepository   string   `json:"githubRepository,omitempty"`
+		AllowedBranches    []string `json:"allowedBranches,omitempty"`
+		AllowedTags        []string `json:"allowedTags,omitempty"`
+		AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
+		DeployRoles        []string `json:"deployRoles,omitempty"`
+	} `json:"gcp_github_actions,omitempty"`
+
 	GCPBackups *struct {
 		Compute *struct {
 			FrequencyHours int `json:"frequencyHours,omitempty"`
@@ -427,6 +447,7 @@ func (c *Components) Normalize() {
 		c.GCPIdentityPlatform = nil
 		c.GCPCloudBuild = nil
 		c.GCPCloudDNS = nil
+		c.GCPGitHubActions = nil
 		c.GCPBackups = nil
 	}
 	if c.Cloud == "GCP" {
@@ -531,6 +552,7 @@ func (c *Config) Normalize() {
 		c.GCPAPIGateway = nil
 		c.GCPLoadbalancer = nil
 		c.GCPCloudDNS = nil
+		c.GCPGitHubActions = nil
 		c.GCPBackups = nil
 		// AWSCloudfront.CachePaths is a within-prefixed deprecated sub-field;
 		// migrate to OriginPath and clear. Distinct from the legacy Cloudfront

--- a/pkg/observability/display.go
+++ b/pkg/observability/display.go
@@ -177,6 +177,8 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "GCP Cloud Monitoring"
 	case composer.KeyGCPCloudDNS:
 		return "GCP Cloud DNS"
+	case composer.KeyGCPGitHubActions:
+		return "GCP GitHub Actions WIF"
 	case composer.KeyGCPBackups:
 		return "GCP Backups"
 	default:

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -65,8 +65,9 @@ var configExtractorAllowlist = map[string]string{
 	// own SDK inspector — extraction is handled by aws_eks (#204, #224).
 	"aws_eks_nodegroup": "[no-inspector] EKS node group is covered by the aws_eks inspector (#204)",
 
-	"gcp_backups":   "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
-	"gcp_cloud_dns": "[no-inspector] Cloud DNS managed zones / record sets not yet covered by the discovery pipeline (#593 follow-up)",
+	"gcp_backups":         "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
+	"gcp_cloud_dns":       "[no-inspector] Cloud DNS managed zones / record sets not yet covered by the discovery pipeline (#593 follow-up)",
+	"gcp_github_actions":  "[no-inspector] GitHub Actions WIF pool/provider/SA not yet covered by the discovery pipeline (#597 follow-up)",
 }
 
 // extractorFixtures are minimal SDK-shape fixtures that exercise each

--- a/tests/lint-gcp-project-pin.sh
+++ b/tests/lint-gcp-project-pin.sh
@@ -69,6 +69,7 @@ EXEMPT_PROJECT_PIN_GCP=(
   google_kms_crypto_key                 # parent: key_ring (gcp/kms/main.tf:82,103)
   google_kms_crypto_key_iam_binding     # parent: crypto_key_id (gcp/kms/main.tf:126)
   google_secret_manager_secret_version  # parent: secret (gcp/cloud_build, gcp/secretmanager)
+  google_service_account_iam_binding    # parent: service_account_id (gcp/github_actions/main.tf, #597)
   google_service_networking_connection  # parent: network (gcp/cloudsql/main.tf:41)
   google_storage_bucket_iam_member      # parent: bucket (gcp/cloud_logging/main.tf:60)
   google_storage_bucket_object          # parent: bucket (gcp/cloud_functions/main.tf:56)


### PR DESCRIPTION
## Summary

Closes row 1 of #597: adds the **`gcp/github_actions`** preset providing Workload Identity Federation (WIF) plumbing so GitHub Actions workflows can deploy into GCP without static service-account JSON keys. Mirrors `aws/githubactions`'s OIDC role UX on the GCP side — the highest-leverage AWS↔GCP parity gap per the audit.

### Module shape

`gcp/github_actions/`:

| Resource | Purpose |
|---|---|
| `google_iam_workload_identity_pool` | WIF pool, named `${var.project}-${var.pool_short_name}` |
| `google_iam_workload_identity_pool_provider` | GitHub OIDC provider, issuer `token.actions.githubusercontent.com`, CEL attribute_condition pinning the repository + allowed refs |
| `google_service_account` | Deploy SA the GitHub workflow impersonates |
| `google_service_account_iam_binding` | Grants `roles/iam.workloadIdentityUser` to the GitHub `principalSet` for the configured repo |
| `google_project_iam_member` (for_each) | Project-level role grants from `var.deploy_roles` (defaults: `roles/run.admin`, `roles/iam.serviceAccountUser`) |
| `google_project_service` (×3) | iam, iamcredentials, sts API enables |

### Caller UX

```hcl
module "github_actions" {
  source            = "./gcp/github_actions"
  project           = "io-abc123"
  project_id        = "my-prod-12345"
  github_repository = "luthersystems/my-repo"
  # defaults: allowed_branches = ["main"], deploy_roles = ["roles/run.admin", "roles/iam.serviceAccountUser"]
}

# Then in .github/workflows/deploy.yml:
# - uses: google-github-actions/auth@v2
#   with:
#     workload_identity_provider: ${{ module.github_actions.workload_identity_provider }}
#     service_account: ${{ module.github_actions.service_account_email }}
```

### Scope decisions (v1 by design)

- **No `time_sleep` for IAM propagation.** Unlike `gcp/cloud_build`, the consumer here is an external GitHub Actions workflow that runs minutes-to-days after terraform apply — IAM has propagated long before then. The trailing comment block in `main.tf` documents the rule for when to add one back (in-stack consumer with apply-time dependency).
- **Cross-variable validation as a `precondition`** on the WIF provider resource. Terraform 1.5+ requires variable `validation` blocks to reference their own variable, which can't express the "at least one of allowed_branches / allowed_tags / allowed_pull_request" rule. A precondition fits cleanly and surfaces at `terraform plan`.
- **`account_id` not project-prefixed.** Hits the 30-char GCP cap on typical project names; `google_service_account` is already in the lint-labelless-name-prefix.sh allowlist for this reason. `display_name` carries `var.project` for human readability.

### Composer + observability wiring

- `KeyGCPGitHubActions` ComponentKey + ComposeOrder + ModulePath + PresetKeyMap + AllComponentKeys + ComponentSelected + isOrphanStrippableKey
- `Components.GCPGitHubActions *bool` + `Config.GCPGitHubActions` sub-struct (GitHubRepository, AllowedBranches, AllowedTags, AllowedPullRequest, DeployRoles), with corresponding Normalize entries
- `DefaultMapper` case: caller-empty cfg → `placeholder.invalid/placeholder` repo so single-module previews compose (callers MUST override before apply — the placeholder is shaped to fail loudly)
- `GCPIAMPermissions` + `GCPServices` entries (IAM, IAM Credentials, STS)
- `PricingData.Components.GCPGitHubActions` field (consumers populate the value out-of-band)
- `pkg/observability/display.go`: ComponentDisplayName entry ("GCP GitHub Actions WIF")
- `pkg/observability/extractors`: allowlist entry (no inspector in v1 — see follow-ups)

### Lint hygiene

- `google_service_account_iam_binding` added to `EXEMPT_PROJECT_PIN_GCP` in `tests/lint-gcp-project-pin.sh` — the Google provider does not accept `project` on this resource type (parent-scoped via `service_account_id`).
- All other lints pass unchanged.

### Tests

- `gcp/github_actions/tests/shape.tftest.hcl`: 8 cases — happy path + custom branches/tags/PR + default deploy_roles count + 4 negative validations (malformed repository, all-empty ref-gate precondition, empty deploy_roles, non-roles/ prefix string, invalid project_id).
- `pkg/composer/github_actions_gcp_wiring_test.go`: 7 cases — mapper placeholder default + caller-supplied flow-through + partial-config defaults-respect + ComponentSelected + forward ComposeStack wiring (composed root contains module block + tfvars carries placeholder) + caller-supplied repo override + GCPIAMPermissions coverage.
- Drift-guard tests pass: `TestGCPServices_CoverAllGCPKeys`, `TestGCPIAMPermissions_CoverAllGCPKeys`, `TestAllComponentKeysCoversPresetKeyMap`, `TestComponentDisplayName_CoversEveryComponentKey`, `TestExtractCoversAllGCPComponents`, `TestPresetDefaultsSatisfyValidations`, `TestEveryRequiredVariableIsMappedOrWired`, `TestKnownFieldsNoShrink`.
- Full local `go test ./...`: **5119 passed, 0 failed** (excluding the slow `TestComposeStack_AWS_PublicVPC_TerraformValidate` series which is unrelated to this PR).

### Follow-up tickets filed

- **#606** — gcp/github_actions inspector under `pkg/observability/discovery/gcp/`
- **#607** — gcp/github_actions drift policy under `pkg/composer/imported/policy/`
- **#608** — gcp/github_actions registry entry in `pkg/insideout-import/registry/registry.go`
- Cloud Deploy preset (`gcp/cloud_deploy`) — row 2 of #597 (separate PR)
- Cloud Build trigger preset polish — row 3 of #597 (separate PR)

Closes #597 (row 1 only).
Refs #597 (remaining rows: gcp/cloud_deploy, gcp/datadog, gcp/splunk, gcp/grafana — separate PRs).

## Test plan

- [x] CI passes (149/149 checks green)
- [x] `gcp/github_actions/tests/shape.tftest.hcl` runs cleanly under `terraform test` with mocked google provider (8/8 cases)
- [x] `bash tests/validate-as-child.sh gcp/github_actions` passes locally
- [x] All composer drift-guard tests pass
- [x] All lint scripts pass