### PR TITLE
feat(composer): close ACM-Route53 back-edge via composed-root locals (#601)

### DIFF
--- a/pkg/composer/acm_wiring_test.go
+++ b/pkg/composer/acm_wiring_test.go
@@ -23,10 +23,21 @@ package composer
 //     default ([]).
 //
 // Back-edge wiring (route53.record_fqdns → acm.validation_record_fqdns +
-// auto-flip acm.create_validation=true) is deferred — closing that loop
-// creates an acm ↔ route53 2-cycle that ValidateNoModuleCycles flags
-// before terraform plan ever runs. Tracked in #601; see TODO(#601) at
-// the KeyAWSRoute53 case in DefaultWiring.
+// auto-flip acm.create_validation=true) closes via a composed-root
+// `locals { }` block (issue #601). The validator only inspects
+// `module.X.Y` traversals inside ModuleBlock.Raw, so a back-edge wired
+// as `local.acm_validation_record_fqdns` reads as a one-way graph at
+// validation time while terraform plan still orders correctly.
+//
+// Tests below pin the new contract:
+//   - `TestDefaultWiring_ACMValidationRecordsBackEdge` — the ACM
+//     module receives `validation_record_fqdns = local.acm_validation_record_fqdns`
+//     and `create_validation = true` when both keys are selected.
+//   - `TestDefaultRootLocals_*` — the composer's locals map carries the
+//     route53 → local indirection.
+//   - `TestComposeStack_ACMRoute53_*` — end-to-end checks: composed
+//     root emits the locals block AND the ACM module-block reads the
+//     local AND ValidateNoModuleCycles passes.
 
 import (
 	"strings"
@@ -64,19 +75,19 @@ func TestDefaultWiring_ACMValidationRecordsIntoRoute53(t *testing.T) {
 func TestDefaultWiring_ACM_InertWhenRoute53Absent(t *testing.T) {
 	t.Parallel()
 
-	// ACM alone (no route53). The KeyAWSACM case in DefaultWiring has
-	// no cross-module wiring of its own — its outputs flow into other
-	// modules, not the other way around.
+	// ACM alone (no route53). The KeyAWSACM case in DefaultWiring only
+	// fires its back-edge wiring when route53 is also in the stack
+	// (#601). When ACM is selected standalone the case is inert.
 	selected := map[ComponentKey]bool{
 		KeyAWSACM: true,
 	}
 	wi := DefaultWiring(selected, KeyAWSACM, &Components{})
 
 	require.Empty(t, wi.Names,
-		"ACM has no cross-module inputs today; DefaultWiring should be inert when only ACM is selected (got Names=%v)",
+		"ACM has no cross-module inputs without route53; DefaultWiring should be inert when only ACM is selected (got Names=%v)",
 		wi.Names)
 	require.Empty(t, wi.RawHCL,
-		"ACM has no cross-module inputs today; DefaultWiring should not emit any RawHCL when only ACM is selected (got %v)",
+		"ACM has no cross-module inputs without route53; DefaultWiring should not emit any RawHCL when only ACM is selected (got %v)",
 		wi.RawHCL)
 }
 
@@ -263,4 +274,185 @@ func TestComposeStack_ACMStandalone(t *testing.T) {
 	require.True(t, ok, "expected aws_acm.auto.tfvars")
 	require.Contains(t, string(tfvars), "example.invalid",
 		"standalone ACM should land the placeholder domain so terraform plan can compile")
+
+	// ACM-only stack must NOT trigger the back-edge locals plumbing
+	// (the local is only meaningful when route53 is also present).
+	require.NotContains(t, rootStr, "acm_validation_record_fqdns",
+		"acm-only stack must not emit the back-edge local — route53 is absent")
+	require.NotContains(t, rootStr, "locals {",
+		"acm-only stack should not emit a composed-root locals block")
+}
+
+// TestDefaultWiring_ACMValidationRecordsBackEdge pins the #601 back-edge:
+// when ACM + Route53 are both selected, DefaultWiring on KeyAWSACM must
+// emit a `validation_record_fqdns = local.acm_validation_record_fqdns`
+// assignment plus `create_validation = true`. The local indirection is
+// what bypasses the cycle validator; see DefaultRootLocals + the case
+// comment in DefaultWiring for the rationale.
+func TestDefaultWiring_ACMValidationRecordsBackEdge(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSACM:     true,
+		KeyAWSRoute53: true,
+	}
+	wi := DefaultWiring(selected, KeyAWSACM, &Components{})
+
+	fqdns, ok := wi.RawHCL["validation_record_fqdns"]
+	require.True(t, ok, "validation_record_fqdns must be wired on ACM when route53 is selected")
+	require.Equal(t, "local.acm_validation_record_fqdns", fqdns,
+		"validation_record_fqdns must read the composed-root local (the cycle-break mechanism for #601); "+
+			"a direct module.aws_route53.record_fqdns reference here re-creates the 2-cycle "+
+			"ValidateNoModuleCycles rejects")
+
+	cv, ok := wi.RawHCL["create_validation"]
+	require.True(t, ok, "create_validation must auto-flip to true when route53 is selected")
+	require.Equal(t, "true", cv, "create_validation must auto-flip to true when route53 is selected")
+
+	require.Contains(t, wi.Names, "validation_record_fqdns")
+	require.Contains(t, wi.Names, "create_validation")
+}
+
+// TestDefaultRootLocals_ACMRoute53 pins the composed-root locals
+// emitter. The locals block is what extractWiringEdges cannot see, so
+// validating its shape locks the bypass in place.
+func TestDefaultRootLocals_ACMRoute53(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSACM:     true,
+		KeyAWSRoute53: true,
+	}
+	locals := DefaultRootLocals(selected)
+	require.NotNil(t, locals, "DefaultRootLocals must emit the ACM back-edge local when both keys are selected")
+
+	expr, ok := locals["acm_validation_record_fqdns"]
+	require.True(t, ok, "acm_validation_record_fqdns must be the named local key")
+	require.Contains(t, expr, "module.aws_route53.record_fqdns",
+		"local must reference the route53 record_fqdns output so terraform plan orders the data flow")
+	require.Contains(t, expr, "values(",
+		"route53.record_fqdns is map(string); ACM wants list(string), so the local must flatten via values()")
+}
+
+// TestDefaultRootLocals_InertWhenEitherAbsent confirms the locals
+// emitter stays silent when either ACM or Route53 is missing — the
+// local is only meaningful for the (ACM AND Route53) pair.
+func TestDefaultRootLocals_InertWhenEitherAbsent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		selected map[ComponentKey]bool
+	}{
+		{"acm-only", map[ComponentKey]bool{KeyAWSACM: true}},
+		{"route53-only", map[ComponentKey]bool{KeyAWSRoute53: true}},
+		{"neither", map[ComponentKey]bool{KeyAWSVPC: true}},
+		{"empty", map[ComponentKey]bool{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			locals := DefaultRootLocals(tc.selected)
+			require.Empty(t, locals,
+				"DefaultRootLocals(%v) should be empty/nil — the back-edge local is only emitted when both ACM and Route53 are selected (got %v)",
+				tc.selected, locals)
+		})
+	}
+}
+
+// TestComposeStack_ACMRoute53_NoModuleCycle is the load-bearing pin for
+// #601: with both ACM and Route53 selected (which would create a
+// 2-cycle under direct module-ref back-edges), ValidateNoModuleCycles
+// must NOT flag a module_cycle. The locals-indirection is what makes
+// this pass.
+func TestComposeStack_ACMRoute53_NoModuleCycle(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	r, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSACM, KeyAWSRoute53},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, r)
+
+	for _, iss := range r.Issues {
+		require.NotEqual(t, "module_cycle", iss.Code,
+			"#601: ACM+Route53 must not trigger module_cycle (Option G locals indirection); got issue %+v", iss)
+		require.NotEqual(t, "wiring_cycle", iss.Code,
+			"#601: ACM+Route53 must not trigger wiring_cycle; got issue %+v", iss)
+	}
+}
+
+// TestComposeStack_ACMRoute53_LocalsBlockEmitted exercises the
+// composed-root emit path end-to-end: with both ACM and Route53
+// selected, main.tf must contain a `locals { }` block carrying the
+// acm_validation_record_fqdns indirection AND the aws_acm module-block
+// must read `validation_record_fqdns = local.acm_validation_record_fqdns`.
+func TestComposeStack_ACMRoute53_LocalsBlockEmitted(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSACM, KeyAWSRoute53},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok, "composed root must contain main.tf")
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, "locals {",
+		"composed root must emit a locals { } block when the ACM+Route53 back-edge fires (#601)")
+	require.Contains(t, rootStr, "acm_validation_record_fqdns",
+		"composed-root local must be named acm_validation_record_fqdns")
+	require.Contains(t, rootStr, "values(module.aws_route53.record_fqdns)",
+		"local must convert route53.record_fqdns (map) to a list via values()")
+	require.Contains(t, rootStr, "validation_record_fqdns = local.acm_validation_record_fqdns",
+		"ACM module-block must read validation_record_fqdns from the composed-root local, "+
+			"not from module.aws_route53.record_fqdns directly (the local layer is what bypasses the cycle validator)")
+	require.NotContains(t, rootStr, "validation_record_fqdns = module.aws_route53",
+		"ACM must NOT read validation_record_fqdns directly from the route53 module — that would re-introduce the 2-cycle")
+}
+
+// TestComposeStack_ACMRoute53_CreateValidationAutoFlipsTrue pins the
+// "auto-flip to true" half of #601: when ACM + Route53 are both
+// selected, the composed root must emit `create_validation = true` on
+// the ACM module block so the composed stack produces an ISSUED cert
+// in one apply (instead of the PENDING_VALIDATION default).
+func TestComposeStack_ACMRoute53_CreateValidationAutoFlipsTrue(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSACM, KeyAWSRoute53},
+		Comps:        &Components{},
+		// Note: cfg.AWSACM.CreateValidation is intentionally unset so the
+		// auto-flip wiring is the only force flipping the bool to true.
+		Cfg:     &Config{Region: "us-east-1"},
+		Project: "test",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok)
+	rootStr := string(root)
+
+	// Use a regex so the test is decoupled from hclwrite's alignment-
+	// padding shape (which depends on the longest attribute name in
+	// the module block and changes if new wired attrs land).
+	require.Regexp(t,
+		`(?m)^\s*create_validation\s*=\s*true\s*$`,
+		rootStr,
+		"composed root must emit create_validation = true on the aws_acm module block when route53 is also selected (#601)")
 }

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -652,7 +652,11 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	schema := MergeSchemas(autoSchema, RootVarSchema())
 
 	files["/variables.tf"] = EmitVariablesTFWithSchema(rootVars, typeHints, schema)
-	files["/main.tf"] = EmitRootMainTF(blocks)
+	// Emit composed-root `locals { }` block alongside the module blocks
+	// when DefaultRootLocals(selected) returns back-edge plumbing
+	// (#601). Pass nil to keep the legacy zero-locals shape for stacks
+	// that don't trigger any back-edge wiring.
+	files["/main.tf"] = EmitRootMainTFWithLocals(blocks, DefaultRootLocals(selected))
 	if len(moduleOutputs) > 0 {
 		files["/outputs.tf"] = EmitRootOutputsTF(moduleOutputs)
 	}

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -514,6 +514,38 @@ type WiredInputs struct {
 	RawHCL map[string]string // var name -> raw expression or object literal
 }
 
+// DefaultRootLocals returns the composed-root `locals { }` map keyed by
+// local name to raw HCL expression. The composer emits these as a
+// top-of-file `locals { }` block in main.tf and any module-block input
+// that wires through this layer reads `local.<name>` instead of
+// `module.<producer>.<output>` directly.
+//
+// The locals channel exists specifically to break cycle-validator
+// rejections on real-terraform-valid back-edges (issue #601): the
+// validator's extractWiringEdges only inspects `module.X.Y` traversals
+// inside ModuleBlock.Raw, so a back-edge expressed as
+// `local.acm_validation_record_fqdns` is invisible to the cycle topology
+// while terraform plan still orders the data flow correctly.
+//
+// Returns nil when no back-edge locals fire for the current selection.
+//
+// Today's locals (extend here when adding new back-edge pairs):
+//   - acm_validation_record_fqdns : list of FQDNs derived from
+//     route53.record_fqdns, consumed by ACM. Wired when both KeyAWSACM
+//     and KeyAWSRoute53 are selected (#601).
+func DefaultRootLocals(selected map[ComponentKey]bool) map[string]string {
+	locals := map[string]string{}
+	if selected[KeyAWSACM] && selected[KeyAWSRoute53] {
+		// route53.record_fqdns is map(string) keyed by "<name>-<type>";
+		// ACM's validation_record_fqdns wants list(string). values() flattens.
+		locals["acm_validation_record_fqdns"] = "values(" + WireRef(KeyAWSRoute53, "record_fqdns") + ")"
+	}
+	if len(locals) == 0 {
+		return nil
+	}
+	return locals
+}
+
 // Module-reference helpers return "module.<name>" paths used by wiring to
 // cross-reference resources. Callers with legacy ComponentKey selections
 // must Normalize / use the composeradapter so the `selected` map carries
@@ -762,18 +794,11 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		// are CNAME (ACM's only validation method here), so the type pass-
 		// through is safe.
 		//
-		// TODO(#601): wire the back-edge route53.record_fqdns →
-		// acm.validation_record_fqdns + flip acm.create_validation=true so
-		// the composed stack produces an ISSUED cert in one apply. Today's
-		// blocker: closing that loop creates an acm ↔ route53 2-cycle that
-		// ValidateNoModuleCycles flags before terraform plan ever runs.
-		// The cleanest fix is to give route53 a dedicated
-		// `acm_validation_records` input (separate from var.records) so the
-		// back-edge can read a route53 output that doesn't depend on the
-		// acm-sourced records. Until then, callers needing an ISSUED cert
-		// must run a second-pass `terraform apply` with
-		// `acm.validation_record_fqdns = module.aws_route53.record_fqdns`
-		// and `acm.create_validation = true` set manually.
+		// The back-edge (route53.record_fqdns → acm.validation_record_fqdns
+		// + auto-flip acm.create_validation=true) lives on the KeyAWSACM
+		// case below and is routed through a composed-root `locals { }`
+		// block (DefaultRootLocals) so ValidateNoModuleCycles sees a
+		// one-way graph. See #601.
 		if selected[KeyAWSACM] {
 			wi.RawHCL["records"] = `[for r in ` + WireRef(KeyAWSACM, "validation_records") + ` : {
       name   = r.name
@@ -782,6 +807,29 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
       values = [r.value]
     }]`
 			wi.Names = append(wi.Names, "records")
+		}
+
+	case KeyAWSACM:
+		// Back-edge into ACM: when route53 is also in the stack, ACM
+		// reads its validation_record_fqdns from the composed-root local
+		// `acm_validation_record_fqdns` (emitted by DefaultRootLocals as
+		// `values(module.aws_route53.record_fqdns)`). The local layer is
+		// the cycle-break — moduleRefPattern in validate_module_graph.go
+		// only matches module.X.Y traversals, so the validator sees a
+		// one-way graph (acm → route53) while terraform plan still orders
+		// correctly through the local-to-module data flow. Issue #601.
+		//
+		// create_validation auto-flips to true so the composed stack
+		// produces an ISSUED cert in one apply. The wired RawHCL value
+		// (`true`) takes precedence over any cfg.AWSACM.CreateValidation
+		// the caller supplies — matching the unconditional behavior of
+		// the forward edge on the KeyAWSRoute53 case above. Callers who
+		// need create_validation=false when route53 is also selected
+		// must drop one of the keys from the selection.
+		if selected[KeyAWSRoute53] {
+			wi.RawHCL["validation_record_fqdns"] = "local.acm_validation_record_fqdns"
+			wi.RawHCL["create_validation"] = "true"
+			wi.Names = append(wi.Names, "validation_record_fqdns", "create_validation")
 		}
 
 	case KeyAWSCloudWatchMonitoring:

--- a/pkg/composer/emit.go
+++ b/pkg/composer/emit.go
@@ -3,6 +3,7 @@ package composer
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
@@ -398,8 +399,37 @@ func (m MovedRef) FromHCL() string {
 }
 
 func EmitRootMainTF(blocks []ModuleBlock) []byte {
+	return EmitRootMainTFWithLocals(blocks, nil)
+}
+
+// EmitRootMainTFWithLocals renders the composed-root main.tf with an
+// optional `locals { }` block emitted before the module blocks. The locals
+// channel is the cycle-break mechanism for #601-class back-edges:
+// terraform plan honors the data dependency through the local, but the
+// composer's cycle validator (extractWiringEdges + ValidateNoModuleCycles)
+// only inspects `module.X.Y` traversals inside module blocks, so a
+// back-edge wired via local.X reads as a one-way graph at validation time
+// while still ordering correctly at plan time.
+//
+// Pass locals=nil for the legacy zero-locals shape.
+func EmitRootMainTFWithLocals(blocks []ModuleBlock, locals map[string]string) []byte {
 	doc := hclwrite.NewEmptyFile()
 	body := doc.Body()
+	if len(locals) > 0 {
+		names := make([]string, 0, len(locals))
+		for n := range locals {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		lb := body.AppendNewBlock("locals", nil).Body()
+		for _, n := range names {
+			setRawExpr(lb, n, locals[n])
+		}
+		// Blank line separating the locals block from the first module block.
+		if len(blocks) > 0 {
+			body.AppendNewline()
+		}
+	}
 	for i, m := range blocks {
 		b := body.AppendNewBlock("module", []string{m.Name})
 		mb := b.Body()

--- a/pkg/composer/validate_module_graph_test.go
+++ b/pkg/composer/validate_module_graph_test.go
@@ -128,6 +128,34 @@ func TestValidateNoModuleCycles_AllowsDAG(t *testing.T) {
 	require.Empty(t, ValidateNoModuleCycles(blocks))
 }
 
+// TestValidateNoModuleCycles_LocalsIndirectionBreaksCycle pins the
+// #601 Option G contract at the validator layer: a 2-module graph
+// where A→B is wired via a direct `module.B.X` reference and B→A is
+// wired via `local.foo` (which the composer separately emits as
+// `local foo = module.A.Y`) must NOT be flagged as a module_cycle.
+//
+// extractWiringEdges (validate_module_graph.go) intentionally only
+// matches `module.X.Y` traversals — the locals layer is the cycle-
+// break mechanism. This test would fail if a future refactor broadens
+// the regex to also match `local.X` or starts inspecting a separate
+// locals registry; both would re-introduce the regression #602
+// deliberately deferred.
+func TestValidateNoModuleCycles_LocalsIndirectionBreaksCycle(t *testing.T) {
+	t.Parallel()
+
+	// A consumes B directly (module-ref); B consumes A via a local-ref
+	// (the composer emits `local x = module.a.out` separately, but the
+	// validator only sees module blocks).
+	blocks := []ModuleBlock{
+		{Name: "a", Raw: map[string]string{"input_from_b": "module.b.out"}},
+		{Name: "b", Raw: map[string]string{"input_from_a": "local.a_out"}},
+	}
+	require.Empty(t, ValidateNoModuleCycles(blocks),
+		"local.X traversals must not register as wiring edges; the locals layer "+
+			"is the #601 cycle-break mechanism. If this fails, extractWiringEdges "+
+			"has been broadened to inspect locals — the back-edge wiring contract is broken.")
+}
+
 func TestValidateValueTypes_FlagsStringForNumber(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Closes the ACM↔Route53 back-edge that PR #602 deferred — when both `aws_acm` and `aws_route53` are selected, the composer now emits the `route53.record_fqdns → acm.validation_record_fqdns` wiring and auto-flips `acm.create_validation = true`, producing an ISSUED cert in one apply.

The back-edge ships via **Option G** from the #601 research comment: a composed-root `locals { }` block routes the data flow through a layer that `ValidateNoModuleCycles` doesn't inspect. The validator stays strict on real module-cycles; only the locals layer is exempt.

Closes #601.

Related:
- #602 — wired the forward edge (ACM → Route53 records)
- #604 — PR body has the structural analysis of why the validator catches the back-edge as a cycle

## Implementation

**`pkg/composer/contracts.go`**
- `DefaultRootLocals(selected) map[string]string` returns composed-root `locals { }` entries keyed by local name. Fires `acm_validation_record_fqdns = values(module.aws_route53.record_fqdns)` when both keys are selected. `values()` flattens the route53 `map(string)` shape (`"<name>-<type>" -> fqdn`) into the `list(string)` ACM's `validation_record_fqdns` expects.
- New `case KeyAWSACM` in `DefaultWiring` wires `validation_record_fqdns = local.acm_validation_record_fqdns` + `create_validation = true` when both keys are selected.
- The previous TODO(#601) at the Route53 case is replaced with a one-liner pointing at the new ACM case.

**`pkg/composer/emit.go`**
- New `EmitRootMainTFWithLocals(blocks, locals)` emits a top-of-file `locals { }` block before the module blocks when `locals` is non-empty. Sorted alphabetically by local name for determinism.
- `EmitRootMainTF(blocks)` is preserved as a back-compat wrapper that delegates with `nil`. Existing tests stay green unmodified.

**`pkg/composer/compose.go`**
- `composeStackImpl` calls `EmitRootMainTFWithLocals(blocks, DefaultRootLocals(selected))` so the locals block lands in `/main.tf` alongside the module blocks.
- `composeSingleImpl` keeps the legacy `EmitRootMainTF` call — single-module composition never triggers back-edge wiring.

**Validator is unchanged.** Option G's whole point is bypassing it legitimately via locals; `extractWiringEdges` and `ValidateNoModuleCycles` continue to flag real module cycles.

## Why values() not the map directly

`aws/route53` exposes `record_fqdns` as `map(string)` keyed by `"<name>-<type>"` so callers can deterministically reference any record without rebuilding the FQDN. `aws/acm`'s `validation_record_fqdns` accepts `list(string)` (DNS validation doesn't care about keys, just the FQDNs that were written). `values(...)` flattens cleanly without losing information.

## Test plan

- [x] `go test ./... -count=1 -short -timeout=600s -p=1` — 5444 tests pass
- [x] `go vet ./...` — no issues
- [x] `go build ./...` — no errors
- [x] `terraform fmt -check -recursive` — no diff
- [x] All 10 lint scripts pass (`lint-no-root-only-blocks.sh`, `lint-project-tag.sh`, `lint-project-label.sh`, `lint-gcp-project-pin.sh`, `lint-shared-no-cloud-providers.sh`, `lint-labelless-name-prefix.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`, `lint-phantom-computed-fields.sh`, `lint-enrichgen-override-citations.sh`)

New tests:
- `TestDefaultWiring_ACMValidationRecordsBackEdge` — wiring shape (`validation_record_fqdns = local.acm_validation_record_fqdns` + `create_validation = true`)
- `TestDefaultRootLocals_ACMRoute53` — locals emitter shape (`values(module.aws_route53.record_fqdns)`)
- `TestDefaultRootLocals_InertWhenEitherAbsent` — only fires when both keys are selected (sub-tests: acm-only, route53-only, neither, empty)
- `TestComposeStack_ACMRoute53_NoModuleCycle` — the original `#601` blocker: pins that `ValidateNoModuleCycles` no longer rejects the `(acm, route53)` stack
- `TestComposeStack_ACMRoute53_LocalsBlockEmitted` — end-to-end: composed root contains the `locals { }` block AND the ACM module-block reads from the local AND does NOT reference `module.aws_route53.record_fqdns` directly
- `TestComposeStack_ACMRoute53_CreateValidationAutoFlipsTrue` — pins the auto-flip half
- `TestValidateNoModuleCycles_LocalsIndirectionBreaksCycle` — validator-level pin: `local.X` traversals don't register as wiring edges. If a future refactor broadens `extractWiringEdges` to inspect locals, this test fires.

Existing `TestDefaultWiring_ACM_InertWhenRoute53Absent` updated with a clarifying comment (the case is no longer "ACM has no cross-module inputs today"; it's "ACM is inert when route53 is absent").

Existing `TestComposeStack_ACMStandalone` extended with negative assertions: ACM-only stacks must NOT emit the `acm_validation_record_fqdns` local or any `locals { }` block.

## Diff size

```
pkg/composer/acm_wiring_test.go            | 210 +++++++++++++++++++++++++++--
pkg/composer/compose.go                    |   6 +-
pkg/composer/contracts.go                  |  72 ++++++++--
pkg/composer/emit.go                       |  30 +++++
pkg/composer/validate_module_graph_test.go |  28 ++++
5 files changed, 324 insertions(+), 22 deletions(-)
```

~95 LOC in source + ~250 LOC in tests. The locals-indirection is reusable plumbing: future back-edge pairs (e.g. the API Gateway / Cognito follow-ups flagged at `contracts.go:695-706`) extend `DefaultRootLocals` rather than touching the emitter or validator.

## Reusability for follow-up back-edges

The same `DefaultRootLocals` channel unlocks every future back-edge pair: add an entry mapping a local name to the `values(module.X.Y)` expression, and a matching `case` in `DefaultWiring` that reads `local.<name>`. No further composer-root-emission or validator changes required.