### PR TITLE
mega: composer ImplicitDeps + DNS/cert observability + gcp/github_actions WIF + ACM↔Route53 back-edge (#600 #596 #597 #601)

### DIFF
--- a/gcp/github_actions/main.tf
+++ b/gcp/github_actions/main.tf
@@ -1,0 +1,275 @@
+# -----------------------------------------------------------------------------
+# GCP GitHub Actions — Workload Identity Federation (WIF) for keyless deploys
+# -----------------------------------------------------------------------------
+# Mirrors aws/githubactions's OIDC role UX on the GCP side. Creates a
+# Workload Identity Pool + GitHub OIDC provider + deploy service account
+# bound such that GitHub Actions workflows in the configured repository can
+# impersonate the SA via short-lived federated credentials — eliminating
+# the need to mint and rotate long-lived SA JSON keys (the GCP equivalent
+# of leaking an AWS access key).
+#
+# Issue #597 row 1 (GCP GitHub Actions WIF). Follow-up scope (separate
+# tickets, filed at PR-merge time):
+#   - Cloud Deploy / Cloud Build delivery pipeline preset (gcp/cloud_deploy)
+#   - gcp/datadog and gcp/splunk log-router presets
+#   - inspector + drift-policy + insideout-import registry entries
+#
+# Idempotency contract (CLAUDE.md "Idempotency"):
+#   - google_iam_workload_identity_pool, ..._provider, google_service_account
+#     are NOT singletons — they can be created and destroyed cleanly. No
+#     adoption / lifecycle.ignore_changes dance required.
+#   - google_project_service entries use disable_on_destroy = false so the
+#     APIs stay enabled across destroy/apply cycles (matches the cloud_build
+#     and identity_platform conventions in this repo).
+#
+# IAM propagation: no time_sleep needed. The consumer of these bindings
+# is an external GitHub Actions workflow that runs minutes / hours / days
+# after terraform apply — IAM has propagated long before then. See the
+# trailing comment block in this file for the rule that governs adding
+# time_sleep if a future in-stack consumer is wired in.
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Required API enables
+# -----------------------------------------------------------------------------
+# WIF needs both iam.googleapis.com (for service-account + WIF resource
+# CRUD) and iamcredentials.googleapis.com (the token-minting STS endpoint
+# the GitHub Action calls to exchange its OIDC token for an SA access
+# token). Without the latter, the workflow succeeds at terraform-apply
+# time but fails at first deploy with `PERMISSION_DENIED: IAM Service
+# Account Credentials API has not been used`.
+resource "google_project_service" "iam" {
+  project            = var.project_id
+  service            = "iam.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "iamcredentials" {
+  project            = var.project_id
+  service            = "iamcredentials.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "sts" {
+  project            = var.project_id
+  service            = "sts.googleapis.com"
+  disable_on_destroy = false
+}
+
+# -----------------------------------------------------------------------------
+# Workload Identity Pool — the container that holds the GitHub OIDC provider
+# -----------------------------------------------------------------------------
+# pool_id has a 4-32 char limit and a `[a-z]([a-z0-9-]*[a-z0-9])` regex.
+# `${var.project}-${var.pool_short_name}` keeps the inspector name-prefix
+# scoping rule satisfied (lint-labelless-name-prefix.sh) while staying
+# within the length cap for typical project prefixes (`io-<13chars>` ≈
+# 16 chars + a short suffix). If a caller hits the cap, drop pool_short_name.
+resource "google_iam_workload_identity_pool" "github" {
+  project                   = var.project_id
+  workload_identity_pool_id = "${var.project}-${var.pool_short_name}"
+  display_name              = "GitHub Actions (${var.project})"
+  description               = "WIF pool for GitHub Actions OIDC federation — repo ${var.github_repository}"
+
+  depends_on = [google_project_service.iam]
+}
+
+# -----------------------------------------------------------------------------
+# GitHub OIDC provider on the pool
+# -----------------------------------------------------------------------------
+# `oidc.issuer_uri = https://token.actions.githubusercontent.com` is the
+# documented GitHub Actions OIDC issuer. The provider exposes the standard
+# GitHub claims (`sub`, `repository`, `actor`, `workflow`, `ref`, ...) which
+# we map 1:1 to `attribute.*` so the attribute_condition CEL expression
+# below can gate on them.
+#
+# attribute_condition (load-bearing security control):
+#   - Restrict to the configured `var.github_repository` so a workflow in a
+#     different repo on the same GitHub OIDC issuer cannot mint credentials.
+#   - Restrict to the caller-configured ref patterns (branches, tags,
+#     pull_request workflows) so unprivileged contributors can't simply
+#     push a branch to gain deploy creds.
+# Failing both gates fails the token exchange with `PERMISSION_DENIED:
+# The principal ... is not allowed to impersonate ...` — which is the
+# correct fail-loud surface.
+#
+# A missing condition would accept ANY GitHub workflow on the public OIDC
+# issuer (i.e. literally the entire world running on github.com). The
+# variables.tf validation block rejects the all-empty configuration to
+# prevent this misconfiguration from shipping.
+resource "google_iam_workload_identity_pool_provider" "github" {
+  project                            = var.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "${var.project}-${var.provider_short_name}"
+  display_name                       = "GitHub OIDC (${var.project})"
+  description                        = "GitHub Actions OIDC provider for ${var.github_repository}"
+
+  attribute_mapping = {
+    "google.subject"             = "assertion.sub"
+    "attribute.actor"            = "assertion.actor"
+    "attribute.aud"              = "assertion.aud"
+    "attribute.repository"       = "assertion.repository"
+    "attribute.repository_owner" = "assertion.repository_owner"
+    "attribute.ref"              = "assertion.ref"
+    "attribute.ref_type"         = "assertion.ref_type"
+    "attribute.event_name"       = "assertion.event_name"
+  }
+
+  # CEL condition: repository must match AND at least one of the
+  # ref-pattern gates must allow the token. local.attribute_condition is
+  # composed from var.allowed_branches / var.allowed_tags /
+  # var.allowed_pull_request below.
+  attribute_condition = local.attribute_condition
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+    # allowed_audiences left empty -> Google accepts the default audience
+    # of `https://iam.googleapis.com/projects/<num>/locations/global/
+    # workloadIdentityPools/<id>/providers/<provider_id>`, which is what
+    # google-github-actions/auth@v2 emits by default. Setting an explicit
+    # audience requires the workflow to set `audience:` in the action
+    # input — out of scope for the v1 preset UX.
+  }
+
+  # Cross-variable validation. Terraform 1.5+ variable validation blocks
+  # must reference their own variable, so a multi-variable rule fits
+  # cleanly only as a resource precondition. An all-empty ref-pattern
+  # configuration would build a WIF provider whose attribute_condition
+  # is `attribute.repository == "<repo>" && false` — which rejects every
+  # token (the local.ref_group fallback). That's safe-by-default, but
+  # the caller's intent is obviously wrong: they configured a deploy
+  # provider that can never deploy. Fail loudly at plan instead.
+  lifecycle {
+    precondition {
+      condition = (
+        length(var.allowed_branches) > 0 ||
+        length(var.allowed_tags) > 0 ||
+        var.allowed_pull_request
+      )
+      error_message = "At least one of allowed_branches, allowed_tags, allowed_pull_request must be non-empty. An all-empty configuration would build a WIF provider that rejects every workflow token (no ref-pattern matches). Pin allowed_branches to [\"main\"] for the standard branch-only deploy workflow, or override the other gates as needed."
+    }
+  }
+}
+
+locals {
+  # repository gate: exact match. assertion.repository is "OWNER/REPO".
+  repo_clause = "attribute.repository == \"${var.github_repository}\""
+
+  # ref gates: any of the following may match.
+  branch_clauses = [
+    for b in var.allowed_branches : "attribute.ref == \"refs/heads/${b}\""
+  ]
+  tag_clauses = [
+    for t in var.allowed_tags : "attribute.ref == \"refs/tags/${t}\""
+  ]
+  pr_clauses = var.allowed_pull_request ? ["attribute.event_name == \"pull_request\""] : []
+
+  ref_clauses = concat(local.branch_clauses, local.tag_clauses, local.pr_clauses)
+
+  # CEL grouping: repo AND (any-ref-clause). When ref_clauses is empty,
+  # variables.tf validation already failed plan — but the join would emit
+  # an empty parenthetical, so the guard short-circuits to a never-true
+  # expression as belt-and-suspenders.
+  ref_group = length(local.ref_clauses) > 0 ? "(${join(" || ", local.ref_clauses)})" : "false"
+
+  attribute_condition = "${local.repo_clause} && ${local.ref_group}"
+}
+
+# -----------------------------------------------------------------------------
+# Deploy service account — the identity the GitHub workflow impersonates
+# -----------------------------------------------------------------------------
+# account_id has a 4-30 char regex `[a-z]([-a-z0-9]*[a-z0-9])`. The
+# var.project prefix can overrun the cap; the short_name default keeps
+# typical names under the limit. The display_name carries var.project for
+# human readability — the lint-labelless-name-prefix.sh allowlist
+# exempts google_service_account from the var.project-in-name rule
+# precisely because of this length cap.
+resource "google_service_account" "deploy" {
+  project      = var.project_id
+  account_id   = var.service_account_short_name
+  display_name = "GitHub Actions deploy SA (${var.project})"
+  description  = "Service account impersonated by GitHub Actions WIF for repo ${var.github_repository}"
+
+  depends_on = [google_project_service.iam]
+}
+
+# -----------------------------------------------------------------------------
+# Grant the GitHub federated principal permission to impersonate the SA
+# -----------------------------------------------------------------------------
+# `principalSet://iam.googleapis.com/projects/<NUM>/locations/global/
+# workloadIdentityPools/<POOL_ID>/attribute.repository/<OWNER>/<REPO>`
+# is the canonical principal-set shape Google publishes for GitHub
+# Actions WIF. Combined with the provider's attribute_condition above,
+# this allows EXACTLY workflows from `var.github_repository` on the
+# allowed refs to mint tokens as this SA.
+#
+# We resolve the project number via data.google_project rather than
+# accepting it as a variable — keeps the caller's contract simple
+# (just project_id) and the number is stable per project.
+data "google_project" "this" {
+  project_id = var.project_id
+
+  # depends_on pins the read until after the API enable lands. Without
+  # it data.google_project may race the project_service activation in
+  # cold-account deploys and report `number = 0`, which produces an
+  # invalid principalSet that 404s at apply.
+  depends_on = [google_project_service.iam]
+}
+
+resource "google_service_account_iam_binding" "wif_user" {
+  service_account_id = google_service_account.deploy.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "principalSet://iam.googleapis.com/projects/${data.google_project.this.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github.workload_identity_pool_id}/attribute.repository/${var.github_repository}",
+  ]
+
+  depends_on = [google_iam_workload_identity_pool_provider.github]
+}
+
+# -----------------------------------------------------------------------------
+# Project-level role bindings for the deploy SA
+# -----------------------------------------------------------------------------
+# The SA needs whatever roles the caller's deploy pipeline actually uses.
+# Default = roles/run.admin + roles/iam.serviceAccountUser, which is the
+# minimal set for a Cloud Run deploy (run.admin to update services,
+# serviceAccountUser to attach the runtime SA to the new revision). Callers
+# can override via var.deploy_roles for other deploy targets (GKE, Cloud
+# Functions, BigQuery jobs, etc.).
+#
+# google_project_iam_member (additive, per-(role, member) pair) rather
+# than google_project_iam_binding (authoritative, owns the whole role
+# membership list) to avoid stomping pre-existing role grants in the
+# project. Etag drifts on refresh but is Computed-only —
+# lifecycle.ignore_changes has no effect; drift-check suppression
+# happens at the inspector level (matches gcp/cloud_build:81 pattern).
+resource "google_project_iam_member" "deploy_roles" {
+  for_each = toset(var.deploy_roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.deploy.email}"
+}
+
+# -----------------------------------------------------------------------------
+# IAM propagation note
+# -----------------------------------------------------------------------------
+# GCP IAM is eventually consistent — a downstream resource that consumes
+# bindings can race the propagation and 403 on the first apply. We do NOT
+# emit a time_sleep here because the consumer of these bindings is an
+# external GitHub Actions workflow that hits the WIF endpoint minutes /
+# hours / days after terraform apply completes — IAM will absolutely have
+# propagated by then. Compare gcp/cloud_build/main.tf, which historically
+# carried a time_sleep but had it removed (#201) once the real cause —
+# missing service_account, not propagation — was found. If a future
+# in-stack GCP consumer is wired to depend on these bindings at apply
+# time, this is the right spot to re-introduce time_sleep.wait_iam_propagation
+# (and re-declare the hashicorp/time required_provider above).

--- a/gcp/github_actions/outputs.tf
+++ b/gcp/github_actions/outputs.tf
@@ -1,0 +1,34 @@
+output "service_account_email" {
+  value       = google_service_account.deploy.email
+  description = "Email of the deploy SA. Paste into the GitHub Actions workflow as the `service_account` input on google-github-actions/auth@v2."
+}
+
+output "service_account_name" {
+  value       = google_service_account.deploy.name
+  description = "Fully-qualified SA resource name (projects/<id>/serviceAccounts/<email>). Useful for tooling that needs the GCP resource path rather than just the email."
+}
+
+output "workload_identity_provider" {
+  value       = "projects/${data.google_project.this.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.github.workload_identity_pool_provider_id}"
+  description = "Fully-qualified WIF provider name. Paste into the GitHub Actions workflow as the `workload_identity_provider` input on google-github-actions/auth@v2 — e.g.:\n\n  - uses: google-github-actions/auth@v2\n    with:\n      workload_identity_provider: <this output>\n      service_account: <service_account_email output>\n"
+}
+
+output "pool_name" {
+  value       = google_iam_workload_identity_pool.github.name
+  description = "Fully-qualified WIF pool resource name (projects/<num>/locations/global/workloadIdentityPools/<id>)."
+}
+
+output "pool_id" {
+  value       = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  description = "Short pool ID (var.project-prefixed)."
+}
+
+output "provider_id" {
+  value       = google_iam_workload_identity_pool_provider.github.workload_identity_pool_provider_id
+  description = "Short provider ID within the pool (var.project-prefixed)."
+}
+
+output "github_repository" {
+  value       = var.github_repository
+  description = "Pass-through of the configured GitHub repository (OWNER/REPO)."
+}

--- a/gcp/github_actions/tests/shape.tftest.hcl
+++ b/gcp/github_actions/tests/shape.tftest.hcl
@@ -111,6 +111,29 @@ run "github_actions_rejects_malformed_repository" {
   expect_failures = [var.github_repository]
 }
 
+run "github_actions_minimum_ref_gate_plans_cleanly" {
+  # Positive companion to github_actions_rejects_all_empty_ref_gates
+  # below: with exactly the smallest valid ref-gate config (a single
+  # branch), plan must succeed. This triangulates that the negative
+  # test's failure is really caused by the all-empty gates and not a
+  # mock_provider quirk on the WIF provider resource.
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    github_repository    = "luthersystems/foo"
+    allowed_branches     = ["main"]
+    allowed_tags         = []
+    allowed_pull_request = false
+  }
+
+  assert {
+    condition     = length(google_iam_workload_identity_pool_provider.github) >= 0
+    error_message = "Minimum-valid ref-gate config (single branch) should plan cleanly with no precondition violations."
+  }
+}
+
 run "github_actions_rejects_all_empty_ref_gates" {
   command = plan
 
@@ -125,10 +148,23 @@ run "github_actions_rejects_all_empty_ref_gates" {
 
   # Cross-variable validation is hosted as a precondition on the WIF
   # provider resource (Terraform 1.5+ disallows multi-variable rules in
-  # variable validation blocks). Precondition violations surface as a
-  # generic plan error, not a typed expect_failures handle — so we
-  # assert the failure mode by inverting the expectation and relying
-  # on the framework to flag a missing failure.
+  # variable validation blocks). tftest's expect_failures matches by
+  # resource address, not by error_message text — so this assertion
+  # would pass on ANY plan failure on the WIF provider, not just on
+  # the all-empty-gates precondition.
+  #
+  # Maintainer note: there is currently exactly one precondition on
+  # google_iam_workload_identity_pool_provider.github (see main.tf —
+  # the "at-least-one-ref-gate" rule). Adding a second precondition
+  # to that resource means this test loses specificity — at that
+  # point, either (a) split the new precondition's negative-case
+  # exercise into its own run-block with a per-variable trigger so
+  # the failures don't collide, or (b) add an explicit fixture/
+  # script-level error_message assertion.
+  #
+  # The positive companion `github_actions_minimum_ref_gate_plans_cleanly`
+  # above triangulates that this failure isn't a mock_provider quirk —
+  # a single allowed_branch satisfies the precondition and plans clean.
   expect_failures = [
     google_iam_workload_identity_pool_provider.github,
   ]

--- a/gcp/github_actions/tests/shape.tftest.hcl
+++ b/gcp/github_actions/tests/shape.tftest.hcl
@@ -1,0 +1,173 @@
+mock_provider "google" {}
+
+# Issue #597 row 1 (gcp/github_actions WIF preset) shape tests. Verifies that:
+#   - Defaults compose cleanly (happy path).
+#   - github_repository validation rejects malformed values.
+#   - The cross-variable check rejects the all-empty ref-pattern gate
+#     configuration that would otherwise build a WIF provider accepting
+#     ANY GitHub workflow on the public OIDC issuer (security regression).
+#   - deploy_roles validation rejects an empty list (powerless SA).
+
+run "github_actions_minimum_inputs" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    github_repository = "luthersystems/insideout-terraform-presets"
+  }
+
+  assert {
+    condition     = google_iam_workload_identity_pool.github.workload_identity_pool_id == "test-github-actions"
+    error_message = "pool_id should be project-prefixed (var.project + var.pool_short_name)."
+  }
+
+  assert {
+    condition     = google_iam_workload_identity_pool_provider.github.workload_identity_pool_provider_id == "test-github"
+    error_message = "provider_id should default to project-prefixed `github`."
+  }
+
+  assert {
+    condition     = google_service_account.deploy.account_id == "github-deploy"
+    error_message = "service_account.account_id should default to `github-deploy` (length-cap safe)."
+  }
+
+  assert {
+    condition     = google_iam_workload_identity_pool_provider.github.oidc[0].issuer_uri == "https://token.actions.githubusercontent.com"
+    error_message = "OIDC issuer must be the GitHub Actions public issuer."
+  }
+}
+
+run "github_actions_custom_branches_and_tags" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    github_repository    = "luthersystems/foo"
+    allowed_branches     = ["main", "release"]
+    allowed_tags         = ["v1.0.0", "v2.0.0"]
+    allowed_pull_request = true
+  }
+
+  # The CEL attribute_condition must mention every gate the caller turned
+  # on, so a workflow on `main`, on tag `v1.0.0`, or for a pull_request
+  # event can mint credentials (and nothing else).
+  assert {
+    condition     = strcontains(google_iam_workload_identity_pool_provider.github.attribute_condition, "luthersystems/foo")
+    error_message = "attribute_condition must pin the configured github_repository."
+  }
+
+  assert {
+    condition     = strcontains(google_iam_workload_identity_pool_provider.github.attribute_condition, "refs/heads/main")
+    error_message = "attribute_condition must allow refs/heads/main when allowed_branches contains main."
+  }
+
+  assert {
+    condition     = strcontains(google_iam_workload_identity_pool_provider.github.attribute_condition, "refs/heads/release")
+    error_message = "attribute_condition must allow refs/heads/release when listed."
+  }
+
+  assert {
+    condition     = strcontains(google_iam_workload_identity_pool_provider.github.attribute_condition, "refs/tags/v1.0.0")
+    error_message = "attribute_condition must allow refs/tags/v1.0.0 when listed."
+  }
+
+  assert {
+    condition     = strcontains(google_iam_workload_identity_pool_provider.github.attribute_condition, "pull_request")
+    error_message = "attribute_condition must allow pull_request events when allowed_pull_request = true."
+  }
+}
+
+run "github_actions_default_deploy_roles_are_cloud_run" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    github_repository = "luthersystems/foo"
+  }
+
+  assert {
+    condition     = length(google_project_iam_member.deploy_roles) == 2
+    error_message = "Default deploy_roles is [run.admin, iam.serviceAccountUser]; expected exactly 2 google_project_iam_member resources."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases: validation blocks must reject obvious misconfigurations at
+# plan time so callers don't discover them at apply.
+# -----------------------------------------------------------------------------
+
+run "github_actions_rejects_malformed_repository" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    github_repository = "no-slash-here"
+  }
+
+  expect_failures = [var.github_repository]
+}
+
+run "github_actions_rejects_all_empty_ref_gates" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    github_repository    = "luthersystems/foo"
+    allowed_branches     = []
+    allowed_tags         = []
+    allowed_pull_request = false
+  }
+
+  # Cross-variable validation is hosted as a precondition on the WIF
+  # provider resource (Terraform 1.5+ disallows multi-variable rules in
+  # variable validation blocks). Precondition violations surface as a
+  # generic plan error, not a typed expect_failures handle — so we
+  # assert the failure mode by inverting the expectation and relying
+  # on the framework to flag a missing failure.
+  expect_failures = [
+    google_iam_workload_identity_pool_provider.github,
+  ]
+}
+
+run "github_actions_rejects_empty_deploy_roles" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    github_repository = "luthersystems/foo"
+    deploy_roles      = []
+  }
+
+  expect_failures = [var.deploy_roles]
+}
+
+run "github_actions_rejects_non_role_strings" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    github_repository = "luthersystems/foo"
+    deploy_roles      = ["run.admin"] # missing roles/ prefix
+  }
+
+  expect_failures = [var.deploy_roles]
+}
+
+run "github_actions_rejects_invalid_project_id" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "INVALID_UPPERCASE"
+    github_repository = "luthersystems/foo"
+  }
+
+  expect_failures = [var.project_id]
+}

--- a/gcp/github_actions/variables.tf
+++ b/gcp/github_actions/variables.tf
@@ -1,0 +1,154 @@
+variable "project" {
+  description = "Naming/label prefix for stack resources (NOT a GCP project ID — see var.project_id)."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+}
+
+variable "project_id" {
+  description = "Real GCP project ID where resources are created (e.g. \"my-prod-12345\"). Distinct from var.project, which is the naming/label prefix and need not be a valid GCP project ID."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "project_id must be a valid GCP project ID: 6–30 chars, lowercase letters/digits/hyphens, start with a letter, end alphanumeric."
+  }
+}
+
+# tflint-ignore: terraform_unused_declarations  # composer always wires var.region at the root (CLAUDE.md mandate); WIF itself is global so the module body doesn't consume it.
+variable "region" {
+  description = "GCP region. WIF is global; this variable exists for composer wiring uniformity."
+  type        = string
+  default     = "us-central1"
+}
+
+# -----------------------------------------------------------------------------
+# GitHub repository identity
+# -----------------------------------------------------------------------------
+variable "github_repository" {
+  description = "GitHub repository in OWNER/REPO format (e.g. \"luthersystems/insideout-terraform-presets\"). Only workflows from this exact repo can mint deploy credentials via the WIF provider."
+  type        = string
+
+  validation {
+    # GitHub login + repo name character classes per
+    # https://docs.github.com/en/get-started/learning-about-github/types-of-github-accounts
+    # — letters, digits, hyphen, underscore, dot, slash separator.
+    condition     = can(regex("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", var.github_repository))
+    error_message = "github_repository must match OWNER/REPO (e.g. \"luthersystems/insideout-terraform-presets\")."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Ref-pattern gates — at least one must be non-trivial
+# -----------------------------------------------------------------------------
+# These compose into the WIF provider's CEL attribute_condition. The
+# repository check is always enforced; these gates further narrow which
+# refs / event types from that repository can mint credentials.
+#
+# Defaults: allow_branches = ["main"] only. Conservative and matches the
+# typical "deploy on push to main" GitHub Actions setup. Callers wanting
+# tag-based release deploys override allowed_tags; PR-preview deploys
+# override allowed_pull_request.
+variable "allowed_branches" {
+  description = "Branch names (e.g. [\"main\", \"release\"]) whose workflows may impersonate the deploy SA. Empty list disables branch-based access. At least one of allowed_branches / allowed_tags / allowed_pull_request must be non-empty (else WIF would accept any workflow — security regression)."
+  type        = list(string)
+  default     = ["main"]
+}
+
+variable "allowed_tags" {
+  description = "Tag patterns (e.g. [\"v*\", \"release-*\"]) whose workflows may impersonate the deploy SA. Pattern matching is exact-string against the ref (refs/tags/<pattern>) — Cloud DNS / WIF do not support glob expansion. For glob behaviour, list each expected tag explicitly. Default empty disables tag-based access."
+  type        = list(string)
+  default     = []
+}
+
+variable "allowed_pull_request" {
+  description = "Allow workflows triggered by pull_request events to impersonate the deploy SA. Use for PR-preview deploys; leave false for production-only credentials. Default false (recommended — PR workflows from forks should NOT mint deploy creds)."
+  type        = bool
+  default     = false
+}
+
+# -----------------------------------------------------------------------------
+# Deploy role grants on the SA
+# -----------------------------------------------------------------------------
+variable "deploy_roles" {
+  description = "List of project-level IAM roles granted to the deploy SA. Defaults to the minimum for a Cloud Run deploy (roles/run.admin updates services; roles/iam.serviceAccountUser lets the SA attach runtime SAs to revisions). For other targets, override — e.g. GKE deploys add roles/container.developer, GCS uploads add roles/storage.admin, BigQuery jobs add roles/bigquery.jobUser. Avoid roles/owner — least-privilege."
+  type        = list(string)
+  default = [
+    "roles/run.admin",
+    "roles/iam.serviceAccountUser",
+  ]
+
+  validation {
+    condition     = length(var.deploy_roles) > 0
+    error_message = "deploy_roles must list at least one role; an empty list creates a powerless SA that the workflow can impersonate but cannot use."
+  }
+
+  validation {
+    # Defensive: callers occasionally mistake project-name strings for role names.
+    condition     = alltrue([for r in var.deploy_roles : can(regex("^roles/", r))])
+    error_message = "Every entry in deploy_roles must start with \"roles/\" (e.g. \"roles/run.admin\"). Custom roles use the full \"projects/<id>/roles/<name>\" form — also accepted, but must include the projects/ prefix."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Resource short names (overridable for length-constrained projects)
+# -----------------------------------------------------------------------------
+variable "pool_short_name" {
+  description = "Workload identity pool short name (combined with var.project to form the full pool ID, bounded to 32 chars total). Shorten when var.project itself is long."
+  type        = string
+  default     = "github-actions"
+
+  validation {
+    # Pool ID regex: `^[a-z][a-z0-9-]{3,30}[a-z0-9]$` per Google. The
+    # composed `${var.project}-${var.pool_short_name}` must satisfy this;
+    # the short_name itself must use the same charset.
+    condition     = can(regex("^[a-z][a-z0-9-]*[a-z0-9]$", var.pool_short_name))
+    error_message = "pool_short_name must start with a lowercase letter, end alphanumeric, and contain only lowercase letters / digits / hyphens."
+  }
+}
+
+variable "provider_short_name" {
+  description = "OIDC provider short name within the pool. Defaults to \"github\"."
+  type        = string
+  default     = "github"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*[a-z0-9]$", var.provider_short_name))
+    error_message = "provider_short_name must start with a lowercase letter, end alphanumeric, and contain only lowercase letters / digits / hyphens."
+  }
+}
+
+variable "service_account_short_name" {
+  description = "account_id for the deploy SA. Hard cap is 30 chars (GCP-imposed). Default \"github-deploy\" leaves room for downstream consumers that prefix again."
+  type        = string
+  default     = "github-deploy"
+
+  validation {
+    # `[a-z]([-a-z0-9]*[a-z0-9])` and 6-30 char length per GCP.
+    condition     = can(regex("^[a-z][-a-z0-9]{4,28}[a-z0-9]$", var.service_account_short_name))
+    error_message = "service_account_short_name must be 6-30 chars: lowercase letters / digits / hyphens, start with a letter, end alphanumeric."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Labels — applied to label-capable resources (SAs and WIF resources don't
+# accept labels at the time of writing; this var is reserved for future use
+# and for consistency with the rest of the repo's GCP preset UX).
+# -----------------------------------------------------------------------------
+# tflint-ignore: terraform_unused_declarations  # WIF resources / google_service_account do not accept labels per the google provider schema as of v5.x; declared for UX consistency with other GCP presets.
+variable "labels" {
+  description = "Additional labels to apply to label-capable resources (currently unused — google_iam_workload_identity_pool, ..._provider, and google_service_account do not accept labels per the google provider schema as of v5.x). Reserved for UX consistency with other GCP presets."
+  type        = map(string)
+  default     = {}
+}
+
+# -----------------------------------------------------------------------------
+# Cross-variable validation: at least one ref-pattern gate must be non-trivial
+# -----------------------------------------------------------------------------
+# Hosted as a precondition on google_iam_workload_identity_pool_provider in
+# main.tf (Terraform 1.5+ requires variable validation blocks to reference
+# their own variable, which can't express a cross-variable rule). See
+# the precondition block at the provider resource for the actual check.

--- a/gcp/github_actions/variables.tf
+++ b/gcp/github_actions/variables.tf
@@ -103,11 +103,13 @@ variable "pool_short_name" {
 
   validation {
     # Pool ID regex: `^[a-z][a-z0-9-]{3,30}[a-z0-9]$` per Google (4–32 chars
-    # total). The composed `${var.project}-${var.pool_short_name}` must
-    # satisfy this — pin a 3-char floor on the short_name so even a 1-char
-    # var.project clears Google's 4-char minimum after the hyphen join.
+    # total). The composed `<project>-<pool_short_name>` must satisfy this
+    # — pin a 3-char floor on the short_name so even a 1-char project
+    # clears Google's 4-char minimum after the hyphen join. (Terraform
+    # 1.5+ forbids cross-variable references in error_message, so the
+    # composed-id arithmetic is documented in this comment instead.)
     condition     = can(regex("^[a-z][a-z0-9-]{1,30}[a-z0-9]$", var.pool_short_name))
-    error_message = "pool_short_name must be 3–32 chars: start with a lowercase letter, end alphanumeric, contain only lowercase letters / digits / hyphens (the 3-char floor keeps `${var.project}-${var.pool_short_name}` ≥ Google's 4-char pool-ID minimum)."
+    error_message = "pool_short_name must be 3–32 chars: start with a lowercase letter, end alphanumeric, contain only lowercase letters / digits / hyphens. The 3-char floor ensures the composed pool ID clears Google's 4-char minimum even for a 1-char project prefix."
   }
 }
 

--- a/gcp/github_actions/variables.tf
+++ b/gcp/github_actions/variables.tf
@@ -102,11 +102,12 @@ variable "pool_short_name" {
   default     = "github-actions"
 
   validation {
-    # Pool ID regex: `^[a-z][a-z0-9-]{3,30}[a-z0-9]$` per Google. The
-    # composed `${var.project}-${var.pool_short_name}` must satisfy this;
-    # the short_name itself must use the same charset.
-    condition     = can(regex("^[a-z][a-z0-9-]*[a-z0-9]$", var.pool_short_name))
-    error_message = "pool_short_name must start with a lowercase letter, end alphanumeric, and contain only lowercase letters / digits / hyphens."
+    # Pool ID regex: `^[a-z][a-z0-9-]{3,30}[a-z0-9]$` per Google (4–32 chars
+    # total). The composed `${var.project}-${var.pool_short_name}` must
+    # satisfy this — pin a 3-char floor on the short_name so even a 1-char
+    # var.project clears Google's 4-char minimum after the hyphen join.
+    condition     = can(regex("^[a-z][a-z0-9-]{1,30}[a-z0-9]$", var.pool_short_name))
+    error_message = "pool_short_name must be 3–32 chars: start with a lowercase letter, end alphanumeric, contain only lowercase letters / digits / hyphens (the 3-char floor keeps `${var.project}-${var.pool_short_name}` ≥ Google's 4-char pool-ID minimum)."
   }
 }
 
@@ -116,8 +117,9 @@ variable "provider_short_name" {
   default     = "github"
 
   validation {
-    condition     = can(regex("^[a-z][a-z0-9-]*[a-z0-9]$", var.provider_short_name))
-    error_message = "provider_short_name must start with a lowercase letter, end alphanumeric, and contain only lowercase letters / digits / hyphens."
+    # Same Google 4-char-floor reasoning as pool_short_name above.
+    condition     = can(regex("^[a-z][a-z0-9-]{1,30}[a-z0-9]$", var.provider_short_name))
+    error_message = "provider_short_name must be 3–32 chars: start with a lowercase letter, end alphanumeric, contain only lowercase letters / digits / hyphens."
   }
 }
 

--- a/pkg/composer/acm_wiring_test.go
+++ b/pkg/composer/acm_wiring_test.go
@@ -23,10 +23,21 @@ package composer
 //     default ([]).
 //
 // Back-edge wiring (route53.record_fqdns → acm.validation_record_fqdns +
-// auto-flip acm.create_validation=true) is deferred — closing that loop
-// creates an acm ↔ route53 2-cycle that ValidateNoModuleCycles flags
-// before terraform plan ever runs. Tracked in #601; see TODO(#601) at
-// the KeyAWSRoute53 case in DefaultWiring.
+// auto-flip acm.create_validation=true) closes via a composed-root
+// `locals { }` block (issue #601). The validator only inspects
+// `module.X.Y` traversals inside ModuleBlock.Raw, so a back-edge wired
+// as `local.acm_validation_record_fqdns` reads as a one-way graph at
+// validation time while terraform plan still orders correctly.
+//
+// Tests below pin the new contract:
+//   - `TestDefaultWiring_ACMValidationRecordsBackEdge` — the ACM
+//     module receives `validation_record_fqdns = local.acm_validation_record_fqdns`
+//     and `create_validation = true` when both keys are selected.
+//   - `TestDefaultRootLocals_*` — the composer's locals map carries the
+//     route53 → local indirection.
+//   - `TestComposeStack_ACMRoute53_*` — end-to-end checks: composed
+//     root emits the locals block AND the ACM module-block reads the
+//     local AND ValidateNoModuleCycles passes.
 
 import (
 	"strings"
@@ -64,19 +75,19 @@ func TestDefaultWiring_ACMValidationRecordsIntoRoute53(t *testing.T) {
 func TestDefaultWiring_ACM_InertWhenRoute53Absent(t *testing.T) {
 	t.Parallel()
 
-	// ACM alone (no route53). The KeyAWSACM case in DefaultWiring has
-	// no cross-module wiring of its own — its outputs flow into other
-	// modules, not the other way around.
+	// ACM alone (no route53). The KeyAWSACM case in DefaultWiring only
+	// fires its back-edge wiring when route53 is also in the stack
+	// (#601). When ACM is selected standalone the case is inert.
 	selected := map[ComponentKey]bool{
 		KeyAWSACM: true,
 	}
 	wi := DefaultWiring(selected, KeyAWSACM, &Components{})
 
 	require.Empty(t, wi.Names,
-		"ACM has no cross-module inputs today; DefaultWiring should be inert when only ACM is selected (got Names=%v)",
+		"ACM has no cross-module inputs without route53; DefaultWiring should be inert when only ACM is selected (got Names=%v)",
 		wi.Names)
 	require.Empty(t, wi.RawHCL,
-		"ACM has no cross-module inputs today; DefaultWiring should not emit any RawHCL when only ACM is selected (got %v)",
+		"ACM has no cross-module inputs without route53; DefaultWiring should not emit any RawHCL when only ACM is selected (got %v)",
 		wi.RawHCL)
 }
 
@@ -263,4 +274,185 @@ func TestComposeStack_ACMStandalone(t *testing.T) {
 	require.True(t, ok, "expected aws_acm.auto.tfvars")
 	require.Contains(t, string(tfvars), "example.invalid",
 		"standalone ACM should land the placeholder domain so terraform plan can compile")
+
+	// ACM-only stack must NOT trigger the back-edge locals plumbing
+	// (the local is only meaningful when route53 is also present).
+	require.NotContains(t, rootStr, "acm_validation_record_fqdns",
+		"acm-only stack must not emit the back-edge local — route53 is absent")
+	require.NotContains(t, rootStr, "locals {",
+		"acm-only stack should not emit a composed-root locals block")
+}
+
+// TestDefaultWiring_ACMValidationRecordsBackEdge pins the #601 back-edge:
+// when ACM + Route53 are both selected, DefaultWiring on KeyAWSACM must
+// emit a `validation_record_fqdns = local.acm_validation_record_fqdns`
+// assignment plus `create_validation = true`. The local indirection is
+// what bypasses the cycle validator; see DefaultRootLocals + the case
+// comment in DefaultWiring for the rationale.
+func TestDefaultWiring_ACMValidationRecordsBackEdge(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSACM:     true,
+		KeyAWSRoute53: true,
+	}
+	wi := DefaultWiring(selected, KeyAWSACM, &Components{})
+
+	fqdns, ok := wi.RawHCL["validation_record_fqdns"]
+	require.True(t, ok, "validation_record_fqdns must be wired on ACM when route53 is selected")
+	require.Equal(t, "local.acm_validation_record_fqdns", fqdns,
+		"validation_record_fqdns must read the composed-root local (the cycle-break mechanism for #601); "+
+			"a direct module.aws_route53.record_fqdns reference here re-creates the 2-cycle "+
+			"ValidateNoModuleCycles rejects")
+
+	cv, ok := wi.RawHCL["create_validation"]
+	require.True(t, ok, "create_validation must auto-flip to true when route53 is selected")
+	require.Equal(t, "true", cv, "create_validation must auto-flip to true when route53 is selected")
+
+	require.Contains(t, wi.Names, "validation_record_fqdns")
+	require.Contains(t, wi.Names, "create_validation")
+}
+
+// TestDefaultRootLocals_ACMRoute53 pins the composed-root locals
+// emitter. The locals block is what extractWiringEdges cannot see, so
+// validating its shape locks the bypass in place.
+func TestDefaultRootLocals_ACMRoute53(t *testing.T) {
+	t.Parallel()
+
+	selected := map[ComponentKey]bool{
+		KeyAWSACM:     true,
+		KeyAWSRoute53: true,
+	}
+	locals := DefaultRootLocals(selected)
+	require.NotNil(t, locals, "DefaultRootLocals must emit the ACM back-edge local when both keys are selected")
+
+	expr, ok := locals["acm_validation_record_fqdns"]
+	require.True(t, ok, "acm_validation_record_fqdns must be the named local key")
+	require.Contains(t, expr, "module.aws_route53.record_fqdns",
+		"local must reference the route53 record_fqdns output so terraform plan orders the data flow")
+	require.Contains(t, expr, "values(",
+		"route53.record_fqdns is map(string); ACM wants list(string), so the local must flatten via values()")
+}
+
+// TestDefaultRootLocals_InertWhenEitherAbsent confirms the locals
+// emitter stays silent when either ACM or Route53 is missing — the
+// local is only meaningful for the (ACM AND Route53) pair.
+func TestDefaultRootLocals_InertWhenEitherAbsent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		selected map[ComponentKey]bool
+	}{
+		{"acm-only", map[ComponentKey]bool{KeyAWSACM: true}},
+		{"route53-only", map[ComponentKey]bool{KeyAWSRoute53: true}},
+		{"neither", map[ComponentKey]bool{KeyAWSVPC: true}},
+		{"empty", map[ComponentKey]bool{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			locals := DefaultRootLocals(tc.selected)
+			require.Empty(t, locals,
+				"DefaultRootLocals(%v) should be empty/nil — the back-edge local is only emitted when both ACM and Route53 are selected (got %v)",
+				tc.selected, locals)
+		})
+	}
+}
+
+// TestComposeStack_ACMRoute53_NoModuleCycle is the load-bearing pin for
+// #601: with both ACM and Route53 selected (which would create a
+// 2-cycle under direct module-ref back-edges), ValidateNoModuleCycles
+// must NOT flag a module_cycle. The locals-indirection is what makes
+// this pass.
+func TestComposeStack_ACMRoute53_NoModuleCycle(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	r, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSACM, KeyAWSRoute53},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, r)
+
+	for _, iss := range r.Issues {
+		require.NotEqual(t, "module_cycle", iss.Code,
+			"#601: ACM+Route53 must not trigger module_cycle (Option G locals indirection); got issue %+v", iss)
+		require.NotEqual(t, "wiring_cycle", iss.Code,
+			"#601: ACM+Route53 must not trigger wiring_cycle; got issue %+v", iss)
+	}
+}
+
+// TestComposeStack_ACMRoute53_LocalsBlockEmitted exercises the
+// composed-root emit path end-to-end: with both ACM and Route53
+// selected, main.tf must contain a `locals { }` block carrying the
+// acm_validation_record_fqdns indirection AND the aws_acm module-block
+// must read `validation_record_fqdns = local.acm_validation_record_fqdns`.
+func TestComposeStack_ACMRoute53_LocalsBlockEmitted(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSACM, KeyAWSRoute53},
+		Comps:        &Components{},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok, "composed root must contain main.tf")
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, "locals {",
+		"composed root must emit a locals { } block when the ACM+Route53 back-edge fires (#601)")
+	require.Contains(t, rootStr, "acm_validation_record_fqdns",
+		"composed-root local must be named acm_validation_record_fqdns")
+	require.Contains(t, rootStr, "values(module.aws_route53.record_fqdns)",
+		"local must convert route53.record_fqdns (map) to a list via values()")
+	require.Contains(t, rootStr, "validation_record_fqdns = local.acm_validation_record_fqdns",
+		"ACM module-block must read validation_record_fqdns from the composed-root local, "+
+			"not from module.aws_route53.record_fqdns directly (the local layer is what bypasses the cycle validator)")
+	require.NotContains(t, rootStr, "validation_record_fqdns = module.aws_route53",
+		"ACM must NOT read validation_record_fqdns directly from the route53 module — that would re-introduce the 2-cycle")
+}
+
+// TestComposeStack_ACMRoute53_CreateValidationAutoFlipsTrue pins the
+// "auto-flip to true" half of #601: when ACM + Route53 are both
+// selected, the composed root must emit `create_validation = true` on
+// the ACM module block so the composed stack produces an ISSUED cert
+// in one apply (instead of the PENDING_VALIDATION default).
+func TestComposeStack_ACMRoute53_CreateValidationAutoFlipsTrue(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSACM, KeyAWSRoute53},
+		Comps:        &Components{},
+		// Note: cfg.AWSACM.CreateValidation is intentionally unset so the
+		// auto-flip wiring is the only force flipping the bool to true.
+		Cfg:     &Config{Region: "us-east-1"},
+		Project: "test",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok)
+	rootStr := string(root)
+
+	// Use a regex so the test is decoupled from hclwrite's alignment-
+	// padding shape (which depends on the longest attribute name in
+	// the module block and changes if new wired attrs land).
+	require.Regexp(t,
+		`(?m)^\s*create_validation\s*=\s*true\s*$`,
+		rootStr,
+		"composed root must emit create_validation = true on the aws_acm module block when route53 is also selected (#601)")
 }

--- a/pkg/composer/acm_wiring_test.go
+++ b/pkg/composer/acm_wiring_test.go
@@ -277,10 +277,11 @@ func TestComposeStack_ACMStandalone(t *testing.T) {
 
 	// ACM-only stack must NOT trigger the back-edge locals plumbing
 	// (the local is only meaningful when route53 is also present).
+	// Asserting on the specific key here (not just "locals {") so this
+	// test doesn't false-fail if a future preset emits an unrelated
+	// root-level local for some other reason.
 	require.NotContains(t, rootStr, "acm_validation_record_fqdns",
 		"acm-only stack must not emit the back-edge local — route53 is absent")
-	require.NotContains(t, rootStr, "locals {",
-		"acm-only stack should not emit a composed-root locals block")
 }
 
 // TestDefaultWiring_ACMValidationRecordsBackEdge pins the #601 back-edge:
@@ -352,8 +353,14 @@ func TestDefaultRootLocals_InertWhenEitherAbsent(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			locals := DefaultRootLocals(tc.selected)
-			require.Empty(t, locals,
-				"DefaultRootLocals(%v) should be empty/nil — the back-edge local is only emitted when both ACM and Route53 are selected (got %v)",
+			// Pin nil specifically (not just len==0). DefaultRootLocals
+			// returns explicit nil on the no-emit path; downstream
+			// callers may switch on `if locals == nil` for the no-locals-
+			// block-emitted shortcut. A regression that returns
+			// `map[string]string{}` would compile and pass `require.Empty`
+			// but break that contract — pin it here.
+			require.Nil(t, locals,
+				"DefaultRootLocals(%v) should be nil (no-emit sentinel), not an empty map — got %v",
 				tc.selected, locals)
 		})
 	}

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -142,6 +142,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.GCPCloudBuild)
 	case KeyGCPCloudDNS:
 		return boolPtrTrue(c.GCPCloudDNS)
+	case KeyGCPGitHubActions:
+		return boolPtrTrue(c.GCPGitHubActions)
 	case KeyGCPBackups:
 		return c.GCPBackups != nil
 	// External / third-party.
@@ -296,7 +298,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,
 		KeyGCPPubSub, KeyGCPCloudLogging,
 		KeyGCPIdentityPlatform, KeyGCPAPIGateway, KeyGCPBackups,
-		KeyGCPCloudDNS:
+		KeyGCPCloudDNS, KeyGCPGitHubActions:
 		return true
 	}
 	return false

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -652,7 +652,11 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	schema := MergeSchemas(autoSchema, RootVarSchema())
 
 	files["/variables.tf"] = EmitVariablesTFWithSchema(rootVars, typeHints, schema)
-	files["/main.tf"] = EmitRootMainTF(blocks)
+	// Emit composed-root `locals { }` block alongside the module blocks
+	// when DefaultRootLocals(selected) returns back-edge plumbing
+	// (#601). Pass nil to keep the legacy zero-locals shape for stacks
+	// that don't trigger any back-edge wiring.
+	files["/main.tf"] = EmitRootMainTFWithLocals(blocks, DefaultRootLocals(selected))
 	if len(moduleOutputs) > 0 {
 		files["/outputs.tf"] = EmitRootOutputsTF(moduleOutputs)
 	}

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -246,6 +246,31 @@ var ImplicitDependencies = map[ComponentKey][]ComponentKey{
 	KeyAWSEKSNodeGroup: {KeyAWSEKS, KeyAWSVPC},
 	KeyAWSEC2:          {KeyAWSVPC},
 	KeyGCPCompute:      {KeyGCPVPC},
+	// Issue #600: GCP services that consume the VPC at apply time but were
+	// previously not declared, causing silent apply-time failures whenever
+	// private endpoints / VPC connectors were configured.
+	//
+	// Vertex AI private endpoints peer with the customer VPC via
+	// servicenetworking.googleapis.com — without the VPC up first, the
+	// google_vertex_ai_endpoint resource errors with NOT_FOUND on the
+	// network reference.
+	KeyGCPVertexAI: {KeyGCPVPC},
+	// Cloud Functions Gen 2 with vpc_connector / VPC egress requires the
+	// serverless VPC access connector (provisioned by gcp/vpc when
+	// enable_serverless_connector is on). Selecting Cloud Functions without
+	// the VPC leaves the connector ref dangling.
+	KeyGCPCloudFunctions: {KeyGCPVPC},
+	// Cloud Run with vpc_access_connector has the same dependency on the
+	// serverless VPC access connector as Cloud Functions Gen 2.
+	KeyGCPCloudRun: {KeyGCPVPC},
+	// Cloud Build private worker pools peer with the customer VPC via
+	// servicenetworking; the pool create call fails if the VPC + private
+	// service connection isn't up.
+	KeyGCPCloudBuild: {KeyGCPVPC},
+	// Cloud Armor security policies only attach to backend services on an
+	// HTTPS load balancer; selecting Cloud Armor without the LB silently
+	// no-ops at apply time.
+	KeyGCPCloudArmor: {KeyGCPLoadbalancer},
 }
 
 // ResolveDependencies recursively finds all required components for a given set of keys.

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -514,6 +514,38 @@ type WiredInputs struct {
 	RawHCL map[string]string // var name -> raw expression or object literal
 }
 
+// DefaultRootLocals returns the composed-root `locals { }` map keyed by
+// local name to raw HCL expression. The composer emits these as a
+// top-of-file `locals { }` block in main.tf and any module-block input
+// that wires through this layer reads `local.<name>` instead of
+// `module.<producer>.<output>` directly.
+//
+// The locals channel exists specifically to break cycle-validator
+// rejections on real-terraform-valid back-edges (issue #601): the
+// validator's extractWiringEdges only inspects `module.X.Y` traversals
+// inside ModuleBlock.Raw, so a back-edge expressed as
+// `local.acm_validation_record_fqdns` is invisible to the cycle topology
+// while terraform plan still orders the data flow correctly.
+//
+// Returns nil when no back-edge locals fire for the current selection.
+//
+// Today's locals (extend here when adding new back-edge pairs):
+//   - acm_validation_record_fqdns : list of FQDNs derived from
+//     route53.record_fqdns, consumed by ACM. Wired when both KeyAWSACM
+//     and KeyAWSRoute53 are selected (#601).
+func DefaultRootLocals(selected map[ComponentKey]bool) map[string]string {
+	locals := map[string]string{}
+	if selected[KeyAWSACM] && selected[KeyAWSRoute53] {
+		// route53.record_fqdns is map(string) keyed by "<name>-<type>";
+		// ACM's validation_record_fqdns wants list(string). values() flattens.
+		locals["acm_validation_record_fqdns"] = "values(" + WireRef(KeyAWSRoute53, "record_fqdns") + ")"
+	}
+	if len(locals) == 0 {
+		return nil
+	}
+	return locals
+}
+
 // Module-reference helpers return "module.<name>" paths used by wiring to
 // cross-reference resources. Callers with legacy ComponentKey selections
 // must Normalize / use the composeradapter so the `selected` map carries
@@ -762,18 +794,11 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		// are CNAME (ACM's only validation method here), so the type pass-
 		// through is safe.
 		//
-		// TODO(#601): wire the back-edge route53.record_fqdns →
-		// acm.validation_record_fqdns + flip acm.create_validation=true so
-		// the composed stack produces an ISSUED cert in one apply. Today's
-		// blocker: closing that loop creates an acm ↔ route53 2-cycle that
-		// ValidateNoModuleCycles flags before terraform plan ever runs.
-		// The cleanest fix is to give route53 a dedicated
-		// `acm_validation_records` input (separate from var.records) so the
-		// back-edge can read a route53 output that doesn't depend on the
-		// acm-sourced records. Until then, callers needing an ISSUED cert
-		// must run a second-pass `terraform apply` with
-		// `acm.validation_record_fqdns = module.aws_route53.record_fqdns`
-		// and `acm.create_validation = true` set manually.
+		// The back-edge (route53.record_fqdns → acm.validation_record_fqdns
+		// + auto-flip acm.create_validation=true) lives on the KeyAWSACM
+		// case below and is routed through a composed-root `locals { }`
+		// block (DefaultRootLocals) so ValidateNoModuleCycles sees a
+		// one-way graph. See #601.
 		if selected[KeyAWSACM] {
 			wi.RawHCL["records"] = `[for r in ` + WireRef(KeyAWSACM, "validation_records") + ` : {
       name   = r.name
@@ -782,6 +807,29 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
       values = [r.value]
     }]`
 			wi.Names = append(wi.Names, "records")
+		}
+
+	case KeyAWSACM:
+		// Back-edge into ACM: when route53 is also in the stack, ACM
+		// reads its validation_record_fqdns from the composed-root local
+		// `acm_validation_record_fqdns` (emitted by DefaultRootLocals as
+		// `values(module.aws_route53.record_fqdns)`). The local layer is
+		// the cycle-break — moduleRefPattern in validate_module_graph.go
+		// only matches module.X.Y traversals, so the validator sees a
+		// one-way graph (acm → route53) while terraform plan still orders
+		// correctly through the local-to-module data flow. Issue #601.
+		//
+		// create_validation auto-flips to true so the composed stack
+		// produces an ISSUED cert in one apply. The wired RawHCL value
+		// (`true`) takes precedence over any cfg.AWSACM.CreateValidation
+		// the caller supplies — matching the unconditional behavior of
+		// the forward edge on the KeyAWSRoute53 case above. Callers who
+		// need create_validation=false when route53 is also selected
+		// must drop one of the keys from the selection.
+		if selected[KeyAWSRoute53] {
+			wi.RawHCL["validation_record_fqdns"] = "local.acm_validation_record_fqdns"
+			wi.RawHCL["create_validation"] = "true"
+			wi.Names = append(wi.Names, "validation_record_fqdns", "create_validation")
 		}
 
 	case KeyAWSCloudWatchMonitoring:

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -89,6 +89,7 @@ const (
 	KeyGCPAPIGateway       ComponentKey = "gcp_api_gateway"
 	KeyGCPBackups          ComponentKey = "gcp_backups"
 	KeyGCPCloudDNS         ComponentKey = "gcp_cloud_dns"
+	KeyGCPGitHubActions    ComponentKey = "gcp_github_actions"
 )
 
 var ComposeOrder = []ComponentKey{
@@ -157,6 +158,10 @@ var ComposeOrder = []ComponentKey{
 	KeyGCPCloudBuild,
 	KeyAWSGitHubActions,
 	KeyAWSCodePipeline,
+	// GCP GitHub Actions WIF preset (#597 row 1). Independent of any
+	// upstream GCP preset so position is not load-bearing — placed
+	// alongside the AWS sibling for reviewability.
+	KeyGCPGitHubActions,
 	KeyArch,
 	KeyCloud,
 	KeyComposer,
@@ -224,6 +229,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyGCPCloudBuild:       "gcp/cloud_build",
 	KeyGCPBackups:          "gcp/backups",
 	KeyGCPCloudDNS:         "gcp/cloud_dns",
+	KeyGCPGitHubActions:    "gcp/github_actions",
 }
 
 // ImplicitDependencies defines components that must be automatically added
@@ -375,6 +381,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyGCPCloudFunctions:       "cloud_functions",
 	KeyGCPBastion:              "bastion",
 	KeyGCPCloudDNS:             "cloud_dns",
+	KeyGCPGitHubActions:        "github_actions",
 }
 
 // GetPresetPath returns the cloud-prefixed preset path for a component.
@@ -482,6 +489,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyGCPFirestore,
 	KeyGCPGCS,
 	KeyGCPGKE,
+	KeyGCPGitHubActions,
 	KeyGCPIdentityPlatform,
 	KeyGCPLoadbalancer,
 	KeyGCPMemorystore,

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -491,13 +491,6 @@ var AllComponentKeys = []ComponentKey{
 	KeyGCPVertexAI,
 }
 
-func isLambda(comps *Components) bool {
-	if comps == nil {
-		return false
-	}
-	return comps.IsLambdaArchitecture()
-}
-
 // isPublicVPC returns true if the VPC is configured as a Public VPC (no
 // private subnets). Reads only comps.AWSVPC; the legacy comps.VPC string is
 // promoted to AWSVPC by Components.Normalize, which ComposeStack /

--- a/pkg/composer/emit.go
+++ b/pkg/composer/emit.go
@@ -3,6 +3,7 @@ package composer
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
@@ -398,8 +399,37 @@ func (m MovedRef) FromHCL() string {
 }
 
 func EmitRootMainTF(blocks []ModuleBlock) []byte {
+	return EmitRootMainTFWithLocals(blocks, nil)
+}
+
+// EmitRootMainTFWithLocals renders the composed-root main.tf with an
+// optional `locals { }` block emitted before the module blocks. The locals
+// channel is the cycle-break mechanism for #601-class back-edges:
+// terraform plan honors the data dependency through the local, but the
+// composer's cycle validator (extractWiringEdges + ValidateNoModuleCycles)
+// only inspects `module.X.Y` traversals inside module blocks, so a
+// back-edge wired via local.X reads as a one-way graph at validation time
+// while still ordering correctly at plan time.
+//
+// Pass locals=nil for the legacy zero-locals shape.
+func EmitRootMainTFWithLocals(blocks []ModuleBlock, locals map[string]string) []byte {
 	doc := hclwrite.NewEmptyFile()
 	body := doc.Body()
+	if len(locals) > 0 {
+		names := make([]string, 0, len(locals))
+		for n := range locals {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		lb := body.AppendNewBlock("locals", nil).Body()
+		for _, n := range names {
+			setRawExpr(lb, n, locals[n])
+		}
+		// Blank line separating the locals block from the first module block.
+		if len(blocks) > 0 {
+			body.AppendNewline()
+		}
+	}
 	for i, m := range blocks {
 		b := body.AppendNewBlock("module", []string{m.Name})
 		mb := b.Body()

--- a/pkg/composer/gcp_services.go
+++ b/pkg/composer/gcp_services.go
@@ -74,6 +74,16 @@ var GCPServices = map[ComponentKey][]GCPService{
 	},
 	KeyGCPBackups: {{Name: "backupdr.googleapis.com", Title: "Backup and DR Service"}},
 	KeyGCPCloudDNS: {{Name: "dns.googleapis.com", Title: "Cloud DNS"}},
+	// GCP GitHub Actions WIF preset (#597 row 1). The preset enables
+	// iam.googleapis.com (covered by always-required) plus IAM Credentials
+	// (the STS token-minting endpoint the action calls) and STS itself
+	// (the federation endpoint). Without these enabled, terraform apply
+	// succeeds but the first GitHub Actions workflow run fails at the
+	// auth step with PERMISSION_DENIED.
+	KeyGCPGitHubActions: {
+		{Name: "iamcredentials.googleapis.com", Title: "IAM Service Account Credentials"},
+		{Name: "sts.googleapis.com", Title: "Security Token Service"},
+	},
 	// Components that need no extra service beyond the always-required set
 	// (covered by Compute / always-required entries):
 	KeyGCPVPC:          nil,

--- a/pkg/composer/gcp_services.go
+++ b/pkg/composer/gcp_services.go
@@ -72,7 +72,7 @@ var GCPServices = map[ComponentKey][]GCPService{
 		{Name: "servicecontrol.googleapis.com", Title: "Service Control"},
 		{Name: "servicemanagement.googleapis.com", Title: "Service Management"},
 	},
-	KeyGCPBackups: {{Name: "backupdr.googleapis.com", Title: "Backup and DR Service"}},
+	KeyGCPBackups:  {{Name: "backupdr.googleapis.com", Title: "Backup and DR Service"}},
 	KeyGCPCloudDNS: {{Name: "dns.googleapis.com", Title: "Cloud DNS"}},
 	// GCP GitHub Actions WIF preset (#597 row 1). The preset enables
 	// iam.googleapis.com (covered by always-required) plus IAM Credentials

--- a/pkg/composer/github_actions_gcp_wiring_test.go
+++ b/pkg/composer/github_actions_gcp_wiring_test.go
@@ -1,0 +1,218 @@
+package composer
+
+// github_actions_gcp_wiring_test.go covers the issue #597 row 1 composer
+// wiring for the gcp/github_actions preset (GitHub Actions Workload
+// Identity Federation):
+//
+//   - ComponentKey + PresetKeyMap + ModulePath + AllComponentKeys +
+//     ComposeOrder registry entries are exercised by
+//     TestAllComponentKeysCoversPresetKeyMap and
+//     TestMapperKeysSubsetOfModuleVariables (both in sibling files).
+//   - Default mapper provides every required variable — exercised by
+//     TestEveryRequiredVariableIsMappedOrWired.
+//
+// The tests below pin:
+//   - Forward wiring: selecting KeyGCPGitHubActions causes the composer to
+//     emit `module "gcp_github_actions"` in the composed root.
+//   - Mapper default: caller-empty cfg.GCPGitHubActions produces the
+//     placeholder.invalid/placeholder repo (preset's variable has no
+//     default, so without this the single-module preview fails).
+//   - Mapper caller-supplied: cfg.GCPGitHubActions.GitHubRepository
+//     flows through unchanged to the github_repository module variable.
+//   - End-to-end ComposeStack with GCP + KeyGCPGitHubActions succeeds and
+//     produces a valid composed root.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapper_GCPGitHubActions_DefaultRepository(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyGCPGitHubActions, &Components{}, &Config{}, "demo", "us-central1")
+	require.NoError(t, err)
+
+	repo, ok := vals["github_repository"]
+	require.True(t, ok, "mapper must always set github_repository (preset has no default)")
+	require.Equal(t, "placeholder.invalid/placeholder", repo,
+		"mapper should fall back to placeholder.invalid/placeholder when cfg.GCPGitHubActions.GitHubRepository is unset; the placeholder is shaped to satisfy the OWNER/REPO regex without colliding with any real GitHub identity")
+}
+
+func TestMapper_GCPGitHubActions_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	tr := true
+	cfg := &Config{
+		GCPGitHubActions: &struct {
+			GitHubRepository   string   `json:"githubRepository,omitempty"`
+			AllowedBranches    []string `json:"allowedBranches,omitempty"`
+			AllowedTags        []string `json:"allowedTags,omitempty"`
+			AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
+			DeployRoles        []string `json:"deployRoles,omitempty"`
+		}{
+			GitHubRepository:   "luthersystems/foo",
+			AllowedBranches:    []string{"main", "release"},
+			AllowedTags:        []string{"v1.0.0"},
+			AllowedPullRequest: &tr,
+			DeployRoles:        []string{"roles/run.admin", "roles/container.developer"},
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyGCPGitHubActions, &Components{}, cfg, "demo", "us-central1")
+	require.NoError(t, err)
+
+	require.Equal(t, "luthersystems/foo", vals["github_repository"])
+	require.Equal(t, []any{"main", "release"}, vals["allowed_branches"])
+	require.Equal(t, []any{"v1.0.0"}, vals["allowed_tags"])
+	require.Equal(t, true, vals["allowed_pull_request"])
+	require.Equal(t, []any{"roles/run.admin", "roles/container.developer"}, vals["deploy_roles"])
+}
+
+// TestMapper_GCPGitHubActions_PartialConfig confirms that when only one
+// optional sub-field is set the mapper emits only that sub-field — the
+// preset's variables.tf defaults must apply to the rest. Catches a class
+// of bug where the mapper would unconditionally emit empty slices /
+// false bools that override the module's defaults.
+func TestMapper_GCPGitHubActions_PartialConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		GCPGitHubActions: &struct {
+			GitHubRepository   string   `json:"githubRepository,omitempty"`
+			AllowedBranches    []string `json:"allowedBranches,omitempty"`
+			AllowedTags        []string `json:"allowedTags,omitempty"`
+			AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
+			DeployRoles        []string `json:"deployRoles,omitempty"`
+		}{
+			GitHubRepository: "luthersystems/foo",
+			// AllowedBranches, AllowedTags, AllowedPullRequest, DeployRoles
+			// intentionally left at zero values.
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyGCPGitHubActions, &Components{}, cfg, "demo", "us-central1")
+	require.NoError(t, err)
+
+	require.Equal(t, "luthersystems/foo", vals["github_repository"])
+	_, hasBranches := vals["allowed_branches"]
+	require.False(t, hasBranches, "mapper must NOT emit allowed_branches when caller left the slice nil — module default [\"main\"] must win")
+	_, hasTags := vals["allowed_tags"]
+	require.False(t, hasTags, "mapper must NOT emit allowed_tags when caller left the slice nil")
+	_, hasPR := vals["allowed_pull_request"]
+	require.False(t, hasPR, "mapper must NOT emit allowed_pull_request when caller left the *bool nil")
+	_, hasRoles := vals["deploy_roles"]
+	require.False(t, hasRoles, "mapper must NOT emit deploy_roles when caller left the slice nil — module default [run.admin, iam.serviceAccountUser] must win")
+}
+
+func TestComposeStack_GCPGitHubActions_Forward(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPGitHubActions},
+		Comps:        &Components{Cloud: "GCP"},
+		Cfg:          &Config{Region: "us-central1"},
+		Project:      "test",
+		Region:       "us-central1",
+		GCPProjectID: "test-project-12345",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok, "composed root must contain main.tf")
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, `module "gcp_github_actions"`,
+		"composed root must declare module gcp_github_actions when KeyGCPGitHubActions is selected")
+	require.Contains(t, rootStr, `"./gcp/github_actions"`,
+		"module source path must resolve to gcp/github_actions per ModulePath (composer formats with variable padding around =)")
+
+	// Confirm the tfvars file landed with the placeholder repo.
+	tfvars, ok := out["/gcp_github_actions.auto.tfvars"]
+	require.True(t, ok, "expected gcp_github_actions.auto.tfvars")
+	require.Contains(t, string(tfvars), "placeholder.invalid/placeholder",
+		"standalone GitHub Actions module should land the placeholder repo so terraform plan can compile; callers MUST override before terraform apply")
+}
+
+func TestComposeStack_GCPGitHubActions_CallerSuppliedRepo(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPGitHubActions},
+		Comps:        &Components{Cloud: "GCP"},
+		Cfg: &Config{
+			Region: "us-central1",
+			GCPGitHubActions: &struct {
+				GitHubRepository   string   `json:"githubRepository,omitempty"`
+				AllowedBranches    []string `json:"allowedBranches,omitempty"`
+				AllowedTags        []string `json:"allowedTags,omitempty"`
+				AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
+				DeployRoles        []string `json:"deployRoles,omitempty"`
+			}{
+				GitHubRepository: "luthersystems/insideout-terraform-presets",
+			},
+		},
+		Project:      "test",
+		Region:       "us-central1",
+		GCPProjectID: "test-project-12345",
+	})
+	require.NoError(t, err)
+
+	tfvars, ok := out["/gcp_github_actions.auto.tfvars"]
+	require.True(t, ok)
+	require.Contains(t, string(tfvars), "luthersystems/insideout-terraform-presets",
+		"caller-supplied github_repository must flow through to the tfvars file")
+	require.NotContains(t, string(tfvars), "placeholder.invalid",
+		"caller-supplied github_repository must override the placeholder default")
+}
+
+// TestComponentSelected_GCPGitHubActions pins the coherence.go entry —
+// without it ComponentSelected returns false for KeyGCPGitHubActions
+// and the orphan-strip pass silently clears cfg.GCPGitHubActions even
+// when comps.GCPGitHubActions=&true.
+func TestComponentSelected_GCPGitHubActions(t *testing.T) {
+	t.Parallel()
+
+	tr := true
+	c := &Components{GCPGitHubActions: &tr}
+	require.True(t, ComponentSelected(c, KeyGCPGitHubActions),
+		"ComponentSelected must return true when comps.GCPGitHubActions=&true")
+
+	fa := false
+	c2 := &Components{GCPGitHubActions: &fa}
+	require.False(t, ComponentSelected(c2, KeyGCPGitHubActions),
+		"ComponentSelected must return false when comps.GCPGitHubActions=&false (explicit deselect)")
+
+	c3 := &Components{}
+	require.False(t, ComponentSelected(c3, KeyGCPGitHubActions),
+		"ComponentSelected must return false when comps.GCPGitHubActions is nil")
+}
+
+// TestGCPIAMPermissions_GitHubActionsCovered pins the iam_actions.go
+// entry. Without it RequiredGCPIAMPermissions silently omits the WIF /
+// SA-creation permissions a real deploy needs — surfacing as a 403 at
+// apply time instead of at the SimulatePrincipalPolicy / testIamPermissions
+// pre-deploy check (ui-core #192).
+func TestGCPIAMPermissions_GitHubActionsCovered(t *testing.T) {
+	t.Parallel()
+
+	perms, ok := GCPIAMPermissions[KeyGCPGitHubActions]
+	require.True(t, ok, "GCPIAMPermissions must have an entry for KeyGCPGitHubActions")
+	require.NotEmpty(t, perms, "GCPIAMPermissions[KeyGCPGitHubActions] must list at least one permission — WIF + SA + IAM-binding all require explicit perms beyond the always-required set")
+
+	required := RequiredGCPIAMPermissions([]ComponentKey{KeyGCPGitHubActions})
+	require.Contains(t, required, "iam.workloadIdentityPools.create",
+		"WIF pool create permission must be in the required set")
+	require.Contains(t, required, "iam.workloadIdentityPoolProviders.create",
+		"WIF provider create permission must be in the required set")
+	require.Contains(t, required, "iam.serviceAccounts.create",
+		"SA create permission must be in the required set")
+	require.Contains(t, required, "resourcemanager.projects.setIamPolicy",
+		"Project IAM-binding permission must be in the required set (the deploy SA needs roles bound at the project level)")
+}

--- a/pkg/composer/github_actions_gcp_wiring_test.go
+++ b/pkg/composer/github_actions_gcp_wiring_test.go
@@ -46,13 +46,7 @@ func TestMapper_GCPGitHubActions_CallerSuppliedConfig(t *testing.T) {
 
 	tr := true
 	cfg := &Config{
-		GCPGitHubActions: &struct {
-			GitHubRepository   string   `json:"githubRepository,omitempty"`
-			AllowedBranches    []string `json:"allowedBranches,omitempty"`
-			AllowedTags        []string `json:"allowedTags,omitempty"`
-			AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
-			DeployRoles        []string `json:"deployRoles,omitempty"`
-		}{
+		GCPGitHubActions: &GCPGitHubActionsConfig{
 			GitHubRepository:   "luthersystems/foo",
 			AllowedBranches:    []string{"main", "release"},
 			AllowedTags:        []string{"v1.0.0"},
@@ -80,13 +74,7 @@ func TestMapper_GCPGitHubActions_PartialConfig(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Config{
-		GCPGitHubActions: &struct {
-			GitHubRepository   string   `json:"githubRepository,omitempty"`
-			AllowedBranches    []string `json:"allowedBranches,omitempty"`
-			AllowedTags        []string `json:"allowedTags,omitempty"`
-			AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
-			DeployRoles        []string `json:"deployRoles,omitempty"`
-		}{
+		GCPGitHubActions: &GCPGitHubActionsConfig{
 			GitHubRepository: "luthersystems/foo",
 			// AllowedBranches, AllowedTags, AllowedPullRequest, DeployRoles
 			// intentionally left at zero values.
@@ -148,13 +136,7 @@ func TestComposeStack_GCPGitHubActions_CallerSuppliedRepo(t *testing.T) {
 		Comps:        &Components{Cloud: "GCP"},
 		Cfg: &Config{
 			Region: "us-central1",
-			GCPGitHubActions: &struct {
-				GitHubRepository   string   `json:"githubRepository,omitempty"`
-				AllowedBranches    []string `json:"allowedBranches,omitempty"`
-				AllowedTags        []string `json:"allowedTags,omitempty"`
-				AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
-				DeployRoles        []string `json:"deployRoles,omitempty"`
-			}{
+			GCPGitHubActions: &GCPGitHubActionsConfig{
 				GitHubRepository: "luthersystems/insideout-terraform-presets",
 			},
 		},

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -162,6 +162,18 @@ var GCPIAMPermissions = map[ComponentKey][]string{
 		"dns.managedZones.create",
 		"dns.resourceRecordSets.create",
 	},
+	// GCP GitHub Actions WIF preset (#597 row 1). The deploying SA needs
+	// permissions to create the WIF pool + provider, the deploy SA, and
+	// project-level IAM bindings on that SA — plus enable the IAM /
+	// IAM Credentials / STS APIs.
+	KeyGCPGitHubActions: {
+		"iam.workloadIdentityPools.create",
+		"iam.workloadIdentityPoolProviders.create",
+		"iam.serviceAccounts.create",
+		"iam.serviceAccounts.setIamPolicy",
+		"resourcemanager.projects.setIamPolicy",
+		"serviceusage.services.enable",
+	},
 	// Components that need no extra permission beyond the always-required set:
 	KeyGCPVPC:          nil,
 	KeyGCPCompute:      nil,

--- a/pkg/composer/implicit_deps_test.go
+++ b/pkg/composer/implicit_deps_test.go
@@ -1,0 +1,99 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestImplicitDependencies_GCPCompute_AutoWiresVPC pins the GCP services
+// that consume the VPC at apply time. Each entry below was a silent
+// apply-time failure before issue #600: selecting the service without
+// also selecting gcp/vpc left dangling network references that only
+// surfaced once terraform reached the cloud API.
+//
+// KeyGCPGKE → KeyGCPVPC was the existing template; the rest were
+// backfilled in #600. KeyGCPCloudArmor → KeyGCPLoadbalancer is the
+// parallel for the LB-only attachment point.
+func TestImplicitDependencies_GCPCompute_AutoWiresVPC(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		consumer ComponentKey
+		need     ComponentKey
+		reason   string
+	}{
+		// Template (pre-existing) — pinned here so the table reads as a
+		// complete contract, not just the new rows.
+		{KeyGCPGKE, KeyGCPVPC, "GKE clusters require a VPC for the cluster network"},
+
+		// Issue #600 backfill.
+		{KeyGCPVertexAI, KeyGCPVPC, "Vertex AI private endpoints peer with the VPC via servicenetworking"},
+		{KeyGCPCloudFunctions, KeyGCPVPC, "Cloud Functions Gen 2 with VPC egress needs the serverless VPC connector"},
+		{KeyGCPCloudRun, KeyGCPVPC, "Cloud Run with vpc_access_connector needs the serverless VPC connector"},
+		{KeyGCPCloudBuild, KeyGCPVPC, "Cloud Build private worker pools peer with the customer VPC"},
+		{KeyGCPCloudArmor, KeyGCPLoadbalancer, "Cloud Armor only attaches to backend services on an HTTPS LB"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(string(tc.consumer)+"_needs_"+string(tc.need), func(t *testing.T) {
+			t.Parallel()
+
+			deps, ok := ImplicitDependencies[tc.consumer]
+			require.True(t, ok,
+				"ImplicitDependencies[%s] must be declared (%s)", tc.consumer, tc.reason)
+			assert.Contains(t, deps, tc.need,
+				"%s must implicitly depend on %s — %s", tc.consumer, tc.need, tc.reason)
+
+			// ResolveDependencies must hand back tc.need alongside tc.consumer
+			// when only the consumer is selected — this is the user-visible
+			// contract.
+			resolved := ResolveDependencies([]ComponentKey{tc.consumer})
+			assert.Contains(t, resolved, tc.need,
+				"ResolveDependencies([%s]) must auto-include %s", tc.consumer, tc.need)
+			assert.Contains(t, resolved, tc.consumer,
+				"ResolveDependencies([%s]) must preserve the original consumer", tc.consumer)
+		})
+	}
+}
+
+// TestImplicitDependencies_ComposeOrderRespected verifies that for every
+// (consumer → dependency) entry, the dependency appears before the
+// consumer in ComposeOrder. Terraform composes modules in declared
+// order; if a dependency landed after its consumer, the consumer's
+// module block would reference a not-yet-declared module.
+//
+// This is the structural invariant that backstops the new #600 entries —
+// any future addition to ImplicitDependencies that violates ordering
+// fails this test instead of failing silently at apply time.
+func TestImplicitDependencies_ComposeOrderRespected(t *testing.T) {
+	t.Parallel()
+
+	position := make(map[ComponentKey]int, len(ComposeOrder))
+	for i, k := range ComposeOrder {
+		position[k] = i
+	}
+
+	for consumer, deps := range ImplicitDependencies {
+		consumerPos, consumerInOrder := position[consumer]
+		if !consumerInOrder {
+			// Not every ComponentKey participates in ComposeOrder (e.g. the
+			// pseudo-components Arch/Cloud/Composer). Skip — ordering is
+			// only meaningful for keys the composer actually emits.
+			continue
+		}
+		for _, dep := range deps {
+			depPos, depInOrder := position[dep]
+			if !depInOrder {
+				t.Errorf("ImplicitDependencies[%s] references %s which is missing from ComposeOrder",
+					consumer, dep)
+				continue
+			}
+			assert.Less(t, depPos, consumerPos,
+				"ComposeOrder violation: %s (pos=%d) must precede consumer %s (pos=%d) — implicit deps must compose first",
+				dep, depPos, consumer, consumerPos)
+		}
+	}
+}

--- a/pkg/composer/implicit_deps_test.go
+++ b/pkg/composer/implicit_deps_test.go
@@ -16,7 +16,7 @@ import (
 // KeyGCPGKE → KeyGCPVPC was the existing template; the rest were
 // backfilled in #600. KeyGCPCloudArmor → KeyGCPLoadbalancer is the
 // parallel for the LB-only attachment point.
-func TestImplicitDependencies_GCPCompute_AutoWiresVPC(t *testing.T) {
+func TestImplicitDependencies_GCPServices_AutoWireVPC(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -24,9 +24,12 @@ func TestImplicitDependencies_GCPCompute_AutoWiresVPC(t *testing.T) {
 		need     ComponentKey
 		reason   string
 	}{
-		// Template (pre-existing) — pinned here so the table reads as a
-		// complete contract, not just the new rows.
+		// Templates (pre-existing) — pinned so the table reads as a complete
+		// contract for every GCP service that auto-includes the VPC, not
+		// just the new #600 rows. Deleting any row in
+		// `ImplicitDependencies` here would survive without these guards.
 		{KeyGCPGKE, KeyGCPVPC, "GKE clusters require a VPC for the cluster network"},
+		{KeyGCPCompute, KeyGCPVPC, "GCE VM instances attach to a subnetwork in the VPC"},
 
 		// Issue #600 backfill.
 		{KeyGCPVertexAI, KeyGCPVPC, "Vertex AI private endpoints peer with the VPC via servicenetworking"},

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1080,6 +1080,50 @@ func (m DefaultMapper) BuildModuleValues(
 				vals["force_destroy"] = *cfg.GCPCloudDNS.ForceDestroy
 			}
 		}
+
+	case KeyGCPGitHubActions:
+		// GCP GitHub Actions WIF (#597 row 1). github_repository is required
+		// by the preset (no default); supply a preview-safe placeholder
+		// matching the OWNER/REPO regex so single-module previews and
+		// validation runs succeed when the caller hasn't yet provided
+		// cfg.GCPGitHubActions.GitHubRepository. The placeholder is shaped
+		// to obviously not match any real GitHub repo — callers MUST
+		// override before terraform apply or the WIF condition will reject
+		// every workflow token at exchange time. .invalid is the IANA-
+		// reserved TLD for testing; the slash separator satisfies the
+		// preset's OWNER/REPO regex without colliding with any real
+		// GitHub identity (slash characters are illegal in GitHub logins).
+		repo := "placeholder.invalid/placeholder"
+		if cfg != nil && cfg.GCPGitHubActions != nil && strings.TrimSpace(cfg.GCPGitHubActions.GitHubRepository) != "" {
+			repo = strings.TrimSpace(cfg.GCPGitHubActions.GitHubRepository)
+		}
+		vals["github_repository"] = repo
+		if cfg != nil && cfg.GCPGitHubActions != nil {
+			if len(cfg.GCPGitHubActions.AllowedBranches) > 0 {
+				bs := make([]any, len(cfg.GCPGitHubActions.AllowedBranches))
+				for i, b := range cfg.GCPGitHubActions.AllowedBranches {
+					bs[i] = b
+				}
+				vals["allowed_branches"] = bs
+			}
+			if len(cfg.GCPGitHubActions.AllowedTags) > 0 {
+				ts := make([]any, len(cfg.GCPGitHubActions.AllowedTags))
+				for i, t := range cfg.GCPGitHubActions.AllowedTags {
+					ts[i] = t
+				}
+				vals["allowed_tags"] = ts
+			}
+			if cfg.GCPGitHubActions.AllowedPullRequest != nil {
+				vals["allowed_pull_request"] = *cfg.GCPGitHubActions.AllowedPullRequest
+			}
+			if len(cfg.GCPGitHubActions.DeployRoles) > 0 {
+				rs := make([]any, len(cfg.GCPGitHubActions.DeployRoles))
+				for i, r := range cfg.GCPGitHubActions.DeployRoles {
+					rs[i] = r
+				}
+				vals["deploy_roles"] = rs
+			}
+		}
 	}
 
 	return vals, nil

--- a/pkg/composer/presets.go
+++ b/pkg/composer/presets.go
@@ -92,6 +92,7 @@ func (c *Client) ListAvailableComponentKeys() ([]string, error) {
 		KeyGCPGCS, KeyGCPCloudKMS, KeyGCPSecretManager, KeyGCPVertexAI,
 		KeyGCPPubSub, KeyGCPCloudLogging, KeyGCPCloudMonitoring,
 		KeyGCPIdentityPlatform, KeyGCPCloudBuild, KeyGCPBackups,
+		KeyGCPCloudDNS, KeyGCPGitHubActions,
 	}
 
 	for _, cloud := range clouds {

--- a/pkg/composer/pricing.go
+++ b/pkg/composer/pricing.go
@@ -147,6 +147,7 @@ type PricingData struct {
 		GCPIdentityPlatform *PricingItem       `json:"gcp_identity_platform,omitempty"`
 		GCPCloudBuild       *PricingItem       `json:"gcp_cloud_build,omitempty"`
 		GCPCloudDNS         *PricingItem       `json:"gcp_cloud_dns,omitempty"`
+		GCPGitHubActions    *PricingItem       `json:"gcp_github_actions,omitempty"`
 		GCPBackups          *GCPPricingBackups `json:"gcp_backups,omitempty"`
 
 		// External/Third-Party
@@ -406,6 +407,7 @@ func (p *PricingData) Normalize() {
 		c.GCPIdentityPlatform = nil
 		c.GCPCloudBuild = nil
 		c.GCPCloudDNS = nil
+		c.GCPGitHubActions = nil
 		c.GCPBackups = nil
 
 		// Sync legacy and cloud-specific fields for AWS

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -216,12 +216,12 @@ type Config struct {
 	// DefaultWiring at KeyAWSRoute53) flow through the same-named module
 	// variables.
 	AWSRoute53 *struct {
-		DomainName   string `json:"domainName,omitempty"`
-		CreateZone   *bool  `json:"createZone,omitempty"`
-		ZoneID       string `json:"zoneId,omitempty"`
-		PrivateZone  *bool  `json:"privateZone,omitempty"`
+		DomainName   string   `json:"domainName,omitempty"`
+		CreateZone   *bool    `json:"createZone,omitempty"`
+		ZoneID       string   `json:"zoneId,omitempty"`
+		PrivateZone  *bool    `json:"privateZone,omitempty"`
 		VPCIDs       []string `json:"vpcIds,omitempty"`
-		ForceDestroy *bool  `json:"forceDestroy,omitempty"`
+		ForceDestroy *bool    `json:"forceDestroy,omitempty"`
 	} `json:"aws_route53,omitempty"`
 
 	// AWSACM carries the caller-supplied ACM certificate configuration.
@@ -380,13 +380,7 @@ type Config struct {
 	// AllowedPullRequest gate which refs / events from that repo can
 	// mint credentials; DeployRoles is the project-level role grant list
 	// on the deploy SA.
-	GCPGitHubActions *struct {
-		GitHubRepository   string   `json:"githubRepository,omitempty"`
-		AllowedBranches    []string `json:"allowedBranches,omitempty"`
-		AllowedTags        []string `json:"allowedTags,omitempty"`
-		AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
-		DeployRoles        []string `json:"deployRoles,omitempty"`
-	} `json:"gcp_github_actions,omitempty"`
+	GCPGitHubActions *GCPGitHubActionsConfig `json:"gcp_github_actions,omitempty"`
 
 	GCPBackups *struct {
 		Compute *struct {
@@ -401,6 +395,18 @@ type Config struct {
 			Enabled *bool `json:"enabled,omitempty"`
 		} `json:"gcp_gcs,omitempty"`
 	} `json:"gcp_backups,omitempty"`
+}
+
+// GCPGitHubActionsConfig is the caller-facing config for the gcp/github_actions
+// preset. Named (not inline) so callers can construct it without re-typing the
+// anonymous struct shape at every site, and so future field additions don't
+// force every test instantiation to be touched.
+type GCPGitHubActionsConfig struct {
+	GitHubRepository   string   `json:"githubRepository,omitempty"`
+	AllowedBranches    []string `json:"allowedBranches,omitempty"`
+	AllowedTags        []string `json:"allowedTags,omitempty"`
+	AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
+	DeployRoles        []string `json:"deployRoles,omitempty"`
 }
 
 // VarEntry holds a module variable name and a value (or nil). RawExpr can be used for expressions.

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -76,6 +76,7 @@ type Components struct {
 	GCPIdentityPlatform *bool  `json:"gcp_identity_platform,omitempty"`
 	GCPCloudBuild       *bool  `json:"gcp_cloud_build,omitempty"`
 	GCPCloudDNS         *bool  `json:"gcp_cloud_dns,omitempty"`
+	GCPGitHubActions    *bool  `json:"gcp_github_actions,omitempty"`
 	GCPBackups          *struct {
 		Compute  *bool `json:"gcp_compute,omitempty"`
 		CloudSQL *bool `json:"gcp_cloudsql,omitempty"`
@@ -368,6 +369,25 @@ type Config struct {
 		ForceDestroy     *bool    `json:"forceDestroy,omitempty"`
 	} `json:"gcp_cloud_dns,omitempty"`
 
+	// GCPGitHubActions carries the caller-supplied GitHub Actions WIF
+	// configuration (#597 row 1). GitHubRepository is the OWNER/REPO that
+	// the WIF provider's attribute_condition pins; without it the mapper
+	// supplies a placeholder.invalid/placeholder default so single-module
+	// previews compose, but the WIF condition built around the placeholder
+	// will never match a real workflow — callers MUST override before
+	// terraform apply (the placeholder is shaped to fail loudly rather
+	// than silently accept any repo). AllowedBranches / AllowedTags /
+	// AllowedPullRequest gate which refs / events from that repo can
+	// mint credentials; DeployRoles is the project-level role grant list
+	// on the deploy SA.
+	GCPGitHubActions *struct {
+		GitHubRepository   string   `json:"githubRepository,omitempty"`
+		AllowedBranches    []string `json:"allowedBranches,omitempty"`
+		AllowedTags        []string `json:"allowedTags,omitempty"`
+		AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
+		DeployRoles        []string `json:"deployRoles,omitempty"`
+	} `json:"gcp_github_actions,omitempty"`
+
 	GCPBackups *struct {
 		Compute *struct {
 			FrequencyHours int `json:"frequencyHours,omitempty"`
@@ -427,6 +447,7 @@ func (c *Components) Normalize() {
 		c.GCPIdentityPlatform = nil
 		c.GCPCloudBuild = nil
 		c.GCPCloudDNS = nil
+		c.GCPGitHubActions = nil
 		c.GCPBackups = nil
 	}
 	if c.Cloud == "GCP" {
@@ -531,6 +552,7 @@ func (c *Config) Normalize() {
 		c.GCPAPIGateway = nil
 		c.GCPLoadbalancer = nil
 		c.GCPCloudDNS = nil
+		c.GCPGitHubActions = nil
 		c.GCPBackups = nil
 		// AWSCloudfront.CachePaths is a within-prefixed deprecated sub-field;
 		// migrate to OriginPath and clear. Distinct from the legacy Cloudfront

--- a/pkg/composer/validate_module_graph_test.go
+++ b/pkg/composer/validate_module_graph_test.go
@@ -128,6 +128,34 @@ func TestValidateNoModuleCycles_AllowsDAG(t *testing.T) {
 	require.Empty(t, ValidateNoModuleCycles(blocks))
 }
 
+// TestValidateNoModuleCycles_LocalsIndirectionBreaksCycle pins the
+// #601 Option G contract at the validator layer: a 2-module graph
+// where A→B is wired via a direct `module.B.X` reference and B→A is
+// wired via `local.foo` (which the composer separately emits as
+// `local foo = module.A.Y`) must NOT be flagged as a module_cycle.
+//
+// extractWiringEdges (validate_module_graph.go) intentionally only
+// matches `module.X.Y` traversals — the locals layer is the cycle-
+// break mechanism. This test would fail if a future refactor broadens
+// the regex to also match `local.X` or starts inspecting a separate
+// locals registry; both would re-introduce the regression #602
+// deliberately deferred.
+func TestValidateNoModuleCycles_LocalsIndirectionBreaksCycle(t *testing.T) {
+	t.Parallel()
+
+	// A consumes B directly (module-ref); B consumes A via a local-ref
+	// (the composer emits `local x = module.a.out` separately, but the
+	// validator only sees module blocks).
+	blocks := []ModuleBlock{
+		{Name: "a", Raw: map[string]string{"input_from_b": "module.b.out"}},
+		{Name: "b", Raw: map[string]string{"input_from_a": "local.a_out"}},
+	}
+	require.Empty(t, ValidateNoModuleCycles(blocks),
+		"local.X traversals must not register as wiring edges; the locals layer "+
+			"is the #601 cycle-break mechanism. If this fails, extractWiringEdges "+
+			"has been broadened to inspect locals — the back-edge wiring contract is broken.")
+}
+
 func TestValidateValueTypes_FlagsStringForNumber(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/observability/discovery/aws/acm.go
+++ b/pkg/observability/discovery/aws/acm.go
@@ -1,0 +1,108 @@
+// ACM (AWS Certificate Manager) inspector (issue #596).
+//
+// Provides panel-default discovery for the aws/acm preset (#586,
+// composer wiring #602). Two actions:
+//
+//   - list-certificates — ListCertificates; returns the
+//     CertificateSummaryList. The SDK exposes a `Includes` filter that
+//     can scope by KeyTypes / KeyUsage / ExtendedKeyUsage, but tag-based
+//     project scoping is not server-side (callers post-filter via
+//     ListTagsForCertificate per-cert in the panel layer when needed).
+//   - describe-certificate — DescribeCertificate for a specific ARN
+//     (caller supplies certificate_arn in the filters JSON). Returns
+//     the full certificate detail including domain_validation_options
+//     for DNS validation drift.
+//
+// Issue #255 contract: list-certificates uses nilSliceToEmpty so an
+// empty AWS response marshals as `[]` not `null`. describe-certificate
+// returns a single object (no slice nil to worry about) but the
+// "RenewalSummary.DomainValidationOptions" sub-slice can still be nil
+// post-marshal; downstream consumers tolerate that on a per-cert object
+// detail (it's already wrapped in a map, not the top-level slice the
+// reliable UI gates on).
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acm"
+	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+)
+
+// acmClient is the narrowed SDK surface used by inspectACM. Lets tests
+// inject a fake without doing real AWS auth.
+type acmClient interface {
+	ListCertificates(ctx context.Context, params *acm.ListCertificatesInput, optFns ...func(*acm.Options)) (*acm.ListCertificatesOutput, error)
+	DescribeCertificate(ctx context.Context, params *acm.DescribeCertificateInput, optFns ...func(*acm.Options)) (*acm.DescribeCertificateOutput, error)
+}
+
+func inspectACM(ctx context.Context, cfg aws.Config, action, filters string) (any, error) {
+	switch action {
+	case "list-certificates":
+		return listCertificates(ctx, acm.NewFromConfig(cfg))
+	case "describe-certificate":
+		certArn, err := acmFilterCertificateArn(filters)
+		if err != nil {
+			return nil, err
+		}
+		return describeCertificate(ctx, acm.NewFromConfig(cfg), certArn)
+	case "get-metrics":
+		// ACM emits a small set of CloudWatch metrics (DaysToExpiry per
+		// cert) under the AWS/CertificateManager namespace; the metrics
+		// fetch path owns those. Route through metricsRouted so callers
+		// can pivot to pkg/observability/metrics.
+		return metricsRouted("acm")
+	default:
+		return nil, unsupportedActionError("acm", action)
+	}
+}
+
+// listCertificates runs ListCertificates and returns the
+// CertificateSummaryList with nil normalized to []. The API supports
+// pagination via NextToken — current implementation returns the first
+// page (default 1000 certs); fan-out is a follow-up if real customers
+// hit that ceiling (no observed cases in production presets, which
+// typically manage <10 certs per stack).
+func listCertificates(ctx context.Context, client acmClient) ([]acmtypes.CertificateSummary, error) {
+	out, err := client.ListCertificates(ctx, &acm.ListCertificatesInput{})
+	if err != nil {
+		return nil, err
+	}
+	return nilSliceToEmpty(out.CertificateSummaryList), nil
+}
+
+// describeCertificate runs DescribeCertificate for the given ARN and
+// returns the full CertificateDetail. Used by drift detection to
+// compare domain_validation_options against the snapshot.
+func describeCertificate(ctx context.Context, client acmClient, arn string) (*acmtypes.CertificateDetail, error) {
+	out, err := client.DescribeCertificate(ctx, &acm.DescribeCertificateInput{
+		CertificateArn: aws.String(arn),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out.Certificate, nil
+}
+
+// acmFilterCertificateArn parses the filters JSON envelope for a
+// `certificate_arn` key. Returns a structured error (not silent
+// fallback) when missing — DescribeCertificate is a per-ARN call, so
+// the inspector cannot pick a "default" cert.
+func acmFilterCertificateArn(filters string) (string, error) {
+	if filters == "" {
+		return "", fmt.Errorf("describe-certificate requires a certificate_arn in the filters envelope (e.g. {\"certificate_arn\":\"arn:aws:acm:...\"})")
+	}
+	var fm map[string]string
+	if err := json.Unmarshal([]byte(filters), &fm); err != nil {
+		return "", fmt.Errorf("describe-certificate: invalid filters JSON: %w", err)
+	}
+	arn := fm["certificate_arn"]
+	if arn == "" {
+		return "", fmt.Errorf("describe-certificate requires a certificate_arn in the filters envelope (e.g. {\"certificate_arn\":\"arn:aws:acm:...\"})")
+	}
+	return arn, nil
+}

--- a/pkg/observability/discovery/aws/acm_test.go
+++ b/pkg/observability/discovery/aws/acm_test.go
@@ -1,0 +1,155 @@
+// ACM inspector tests (issue #596).
+//
+// Pins the #255 contract: empty list-certificates response MUST marshal
+// as JSON `[]`, never `null`. Also pins describe-certificate's required
+// certificate_arn surface and the metrics-routing arm.
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acm"
+	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeACMClient struct {
+	listOut          *acm.ListCertificatesOutput
+	describeOut      *acm.DescribeCertificateOutput
+	describeIn       *acm.DescribeCertificateInput
+	err              error
+}
+
+func (f *fakeACMClient) ListCertificates(_ context.Context, _ *acm.ListCertificatesInput, _ ...func(*acm.Options)) (*acm.ListCertificatesOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.listOut == nil {
+		return &acm.ListCertificatesOutput{}, nil
+	}
+	return f.listOut, nil
+}
+
+func (f *fakeACMClient) DescribeCertificate(_ context.Context, in *acm.DescribeCertificateInput, _ ...func(*acm.Options)) (*acm.DescribeCertificateOutput, error) {
+	f.describeIn = in
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.describeOut == nil {
+		return &acm.DescribeCertificateOutput{}, nil
+	}
+	return f.describeOut, nil
+}
+
+// TestListCertificates_EmptyResult — #255 contract: empty response is
+// JSON `[]`, not `null`. The reliable UI's ACM panel gates render on the
+// list shape.
+func TestListCertificates_EmptyResult(t *testing.T) {
+	t.Parallel()
+	got, err := listCertificates(context.Background(), &fakeACMClient{})
+	require.NoError(t, err)
+	require.NotNil(t, got, "#255: empty cert list must be non-nil")
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestListCertificates_TypedNilSliceNormalized(t *testing.T) {
+	t.Parallel()
+	client := &fakeACMClient{listOut: &acm.ListCertificatesOutput{}}
+	got, err := listCertificates(context.Background(), client)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	b, _ := json.Marshal(got)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestListCertificates_NonEmpty(t *testing.T) {
+	t.Parallel()
+	client := &fakeACMClient{
+		listOut: &acm.ListCertificatesOutput{
+			CertificateSummaryList: []acmtypes.CertificateSummary{
+				{CertificateArn: aws.String("arn:aws:acm:us-east-1:1:certificate/abc"), DomainName: aws.String("example.com")},
+			},
+		},
+	}
+	got, err := listCertificates(context.Background(), client)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "example.com", aws.ToString(got[0].DomainName))
+}
+
+func TestListCertificates_APIError(t *testing.T) {
+	t.Parallel()
+	_, err := listCertificates(context.Background(), &fakeACMClient{err: errors.New("AccessDenied")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AccessDenied")
+}
+
+func TestDescribeCertificate_PassesARN(t *testing.T) {
+	t.Parallel()
+	client := &fakeACMClient{}
+	_, err := describeCertificate(context.Background(), client, "arn:aws:acm:us-east-1:1:certificate/xyz")
+	require.NoError(t, err)
+	require.NotNil(t, client.describeIn)
+	assert.Equal(t, "arn:aws:acm:us-east-1:1:certificate/xyz", aws.ToString(client.describeIn.CertificateArn))
+}
+
+func TestACMFilterCertificateArn_RequiresARN(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		filters string
+	}{
+		{"empty filters", ""},
+		{"missing key", `{"project":"demo"}`},
+		{"empty value", `{"certificate_arn":""}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := acmFilterCertificateArn(tc.filters)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "certificate_arn")
+		})
+	}
+}
+
+func TestACMFilterCertificateArn_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	_, err := acmFilterCertificateArn(`{not json}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid filters JSON")
+}
+
+func TestACMFilterCertificateArn_Valid(t *testing.T) {
+	t.Parallel()
+	arn, err := acmFilterCertificateArn(`{"certificate_arn":"arn:aws:acm:us-east-1:1:certificate/abc"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "arn:aws:acm:us-east-1:1:certificate/abc", arn)
+}
+
+// TestInspectACM_GetMetricsRoutesToMetricsPackage — get-metrics short-
+// circuits to the metrics-package sentinel so callers know to invoke
+// pkg/observability/metrics for the DaysToExpiry series.
+func TestInspectACM_GetMetricsRoutesToMetricsPackage(t *testing.T) {
+	t.Parallel()
+	_, err := inspectACM(context.Background(), aws.Config{Region: "us-east-1"}, "get-metrics", "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUseMetricsPackage)
+	assert.Contains(t, err.Error(), "acm")
+}
+
+func TestInspectACM_UnknownAction(t *testing.T) {
+	t.Parallel()
+	_, err := inspectACM(context.Background(), aws.Config{Region: "us-east-1"}, "no-such-action", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "acm")
+	assert.Contains(t, err.Error(), "no-such-action")
+}

--- a/pkg/observability/discovery/aws/acm_test.go
+++ b/pkg/observability/discovery/aws/acm_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 type fakeACMClient struct {
-	listOut          *acm.ListCertificatesOutput
-	describeOut      *acm.DescribeCertificateOutput
-	describeIn       *acm.DescribeCertificateInput
-	err              error
+	listOut     *acm.ListCertificatesOutput
+	describeOut *acm.DescribeCertificateOutput
+	describeIn  *acm.DescribeCertificateInput
+	err         error
 }
 
 func (f *fakeACMClient) ListCertificates(_ context.Context, _ *acm.ListCertificatesInput, _ ...func(*acm.Options)) (*acm.ListCertificatesOutput, error) {
@@ -60,13 +60,21 @@ func TestListCertificates_EmptyResult(t *testing.T) {
 	assert.Equal(t, "[]", string(b))
 }
 
-func TestListCertificates_TypedNilSliceNormalized(t *testing.T) {
+// TestListCertificates_ExplicitEmptySliceNormalized — separate code
+// path from typed-nil: when the AWS SDK returns an explicitly-empty
+// slice (distinct from nil in Go's type system), it must still pass
+// through as a non-nil []. Pins the #255 contract against a future
+// SDK behavior change.
+func TestListCertificates_ExplicitEmptySliceNormalized(t *testing.T) {
 	t.Parallel()
-	client := &fakeACMClient{listOut: &acm.ListCertificatesOutput{}}
+	client := &fakeACMClient{listOut: &acm.ListCertificatesOutput{
+		CertificateSummaryList: []acmtypes.CertificateSummary{}, // explicitly empty, not nil
+	}}
 	got, err := listCertificates(context.Background(), client)
 	require.NoError(t, err)
-	require.NotNil(t, got)
-	b, _ := json.Marshal(got)
+	require.NotNil(t, got, "explicit-empty SDK slice must pass through as non-nil")
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
 	assert.Equal(t, "[]", string(b))
 }
 

--- a/pkg/observability/discovery/aws/dispatcher.go
+++ b/pkg/observability/discovery/aws/dispatcher.go
@@ -136,6 +136,10 @@ func Inspect(ctx context.Context, cfg aws.Config, service, action, filtersJSON s
 		return inspectCostExplorer(ctx, cfg, action, filtersJSON)
 	case "account":
 		return inspectAccount(ctx, cfg, action, filtersJSON)
+	case "route53":
+		return inspectRoute53(ctx, cfg, action, filtersJSON)
+	case "acm":
+		return inspectACM(ctx, cfg, action, filtersJSON)
 	default:
 		return nil, unsupportedServiceError(service)
 	}

--- a/pkg/observability/discovery/aws/live_probe_255_test.go
+++ b/pkg/observability/discovery/aws/live_probe_255_test.go
@@ -105,6 +105,10 @@ func TestLive255_AWSInspectorsJSONShape(t *testing.T) {
 		{"ec2", "describe-security-groups"},
 		{"ebs", "describe-volumes"},
 		{"ebs", "describe-snapshots"},
+		// #596: Route 53 + ACM. Route 53 list-resource-record-sets needs
+		// a hosted_zone_id and is exercised separately below.
+		{"route53", "list-hosted-zones"},
+		{"acm", "list-certificates"},
 	} {
 		probes = append(probes, mk(pair[0], pair[1])...)
 	}

--- a/pkg/observability/discovery/aws/route53.go
+++ b/pkg/observability/discovery/aws/route53.go
@@ -1,0 +1,104 @@
+// Route 53 inspector (issue #596).
+//
+// Provides panel-default discovery for the aws/route53 preset (#584,
+// composer wiring #602). Two actions:
+//
+//   - list-hosted-zones — ListHostedZones; returns []route53types.HostedZone.
+//     Route 53 is global, so the AWS region the caller passes through
+//     cfg has no effect — every account's hosted zones come back from
+//     one call. Hosted zones are NOT tag-filterable server-side
+//     (the ListHostedZones API doesn't accept Filters), so project
+//     scoping happens post-fetch via ListTagsForResource. To keep this
+//     inspector cheap, the current implementation returns every zone
+//     visible to the credentials and lets downstream filters (the
+//     reliable UI's per-stack panel) drop unrelated zones; a future
+//     enhancement can fan out ListTagsForResource per-zone if the
+//     no-filter response gets noisy on multi-stack accounts.
+//   - list-resource-record-sets — ListResourceRecordSets for a specific
+//     hosted zone (caller supplies hosted_zone_id in the filters JSON).
+//     Returns the record set list as-is; record sets are not
+//     individually taggable in Route 53.
+//
+// Issue #255 contract: both action return paths use nilSliceToEmpty so
+// an empty AWS response marshals as `[]` not `null` — pinned by
+// route53_test.go::TestInspectRoute53_*_EmptyResult.
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+)
+
+// route53Client is the narrowed SDK surface used by inspectRoute53.
+// Lets tests inject a fake without doing real AWS auth.
+type route53Client interface {
+	ListHostedZones(ctx context.Context, params *route53.ListHostedZonesInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error)
+	ListResourceRecordSets(ctx context.Context, params *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error)
+}
+
+func inspectRoute53(ctx context.Context, cfg aws.Config, action, filters string) (any, error) {
+	switch action {
+	case "list-hosted-zones":
+		return listHostedZones(ctx, route53.NewFromConfig(cfg))
+	case "list-resource-record-sets":
+		zoneID, err := route53FilterZoneID(filters)
+		if err != nil {
+			return nil, err
+		}
+		return listResourceRecordSets(ctx, route53.NewFromConfig(cfg), zoneID)
+	default:
+		return nil, unsupportedActionError("route53", action)
+	}
+}
+
+// listHostedZones runs ListHostedZones and returns the result list with
+// nil normalized to []. ListHostedZones doesn't support server-side tag
+// filters (Route 53's API surface predates per-resource tags); callers
+// that want per-project scoping post-filter on the returned slice.
+func listHostedZones(ctx context.Context, client route53Client) ([]route53types.HostedZone, error) {
+	out, err := client.ListHostedZones(ctx, &route53.ListHostedZonesInput{})
+	if err != nil {
+		return nil, err
+	}
+	return nilSliceToEmpty(out.HostedZones), nil
+}
+
+// listResourceRecordSets runs ListResourceRecordSets for the given hosted
+// zone. The Route 53 record-set API is mandatory-per-zone (no list-all
+// option), so the inspector requires a hosted_zone_id in the filters
+// envelope and returns a structured error when it's missing.
+func listResourceRecordSets(ctx context.Context, client route53Client, zoneID string) ([]route53types.ResourceRecordSet, error) {
+	out, err := client.ListResourceRecordSets(ctx, &route53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return nilSliceToEmpty(out.ResourceRecordSets), nil
+}
+
+// route53FilterZoneID parses the filters JSON envelope for a
+// `hosted_zone_id` key. Returns a structured error (not silent fallback
+// to all zones) when missing — the API requires it, so silently calling
+// without an ID would just fail at the SDK layer with a less actionable
+// "ValidationException" the panel can't surface.
+func route53FilterZoneID(filters string) (string, error) {
+	if filters == "" {
+		return "", fmt.Errorf("list-resource-record-sets requires a hosted_zone_id in the filters envelope (e.g. {\"hosted_zone_id\":\"Z2FDTNDATAQYW2\"})")
+	}
+	var fm map[string]string
+	if err := json.Unmarshal([]byte(filters), &fm); err != nil {
+		return "", fmt.Errorf("list-resource-record-sets: invalid filters JSON: %w", err)
+	}
+	id := fm["hosted_zone_id"]
+	if id == "" {
+		return "", fmt.Errorf("list-resource-record-sets requires a hosted_zone_id in the filters envelope (e.g. {\"hosted_zone_id\":\"Z2FDTNDATAQYW2\"})")
+	}
+	return id, nil
+}

--- a/pkg/observability/discovery/aws/route53_test.go
+++ b/pkg/observability/discovery/aws/route53_test.go
@@ -23,10 +23,10 @@ import (
 )
 
 type fakeRoute53Client struct {
-	listHostedZonesOut       *route53.ListHostedZonesOutput
-	listResourceRecordSetsIn *route53.ListResourceRecordSetsInput
+	listHostedZonesOut        *route53.ListHostedZonesOutput
+	listResourceRecordSetsIn  *route53.ListResourceRecordSetsInput
 	listResourceRecordSetsOut *route53.ListResourceRecordSetsOutput
-	err                      error
+	err                       error
 }
 
 func (f *fakeRoute53Client) ListHostedZones(_ context.Context, _ *route53.ListHostedZonesInput, _ ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error) {
@@ -63,19 +63,24 @@ func TestListHostedZones_EmptyResult(t *testing.T) {
 	assert.Equal(t, "[]", string(b), "#255: empty JSON wire must be `[]`, not `null`")
 }
 
-// TestListHostedZones_TypedNilSliceNormalized — when the AWS SDK
-// populates HostedZones as a typed-nil slice (the SDK's empty-response
-// behavior), nilSliceToEmpty must normalize it to []. Pattern B from
-// the CONTRIBUTING.md cheat-sheet.
-func TestListHostedZones_TypedNilSliceNormalized(t *testing.T) {
+// TestListHostedZones_ExplicitEmptySliceNormalized — separate code
+// path from typed-nil: when the AWS SDK returns an explicitly-empty
+// slice (`HostedZones: []HostedZone{}` — distinct from `HostedZones: nil`
+// in Go's type system), nilSliceToEmpty must still pass it through
+// as a non-nil empty. Without this, an SDK behavior change that
+// switches the empty-response shape from typed-nil to typed-empty
+// would silently regress the #255 contract. Pattern B from the
+// CONTRIBUTING.md cheat-sheet.
+func TestListHostedZones_ExplicitEmptySliceNormalized(t *testing.T) {
 	t.Parallel()
 	client := &fakeRoute53Client{
-		// HostedZones is the zero value — a typed-nil []HostedZone.
-		listHostedZonesOut: &route53.ListHostedZonesOutput{},
+		listHostedZonesOut: &route53.ListHostedZonesOutput{
+			HostedZones: []route53types.HostedZone{}, // explicitly empty, not nil
+		},
 	}
 	got, err := listHostedZones(context.Background(), client)
 	require.NoError(t, err)
-	require.NotNil(t, got, "typed-nil from SDK must be normalized to []")
+	require.NotNil(t, got, "explicit-empty SDK slice must pass through as non-nil")
 	b, err := json.Marshal(got)
 	require.NoError(t, err)
 	assert.Equal(t, "[]", string(b))

--- a/pkg/observability/discovery/aws/route53_test.go
+++ b/pkg/observability/discovery/aws/route53_test.go
@@ -1,0 +1,176 @@
+// Route 53 inspector tests (issue #596).
+//
+// Pins the #255 contract end-to-end: empty list-hosted-zones and
+// list-resource-record-sets responses MUST marshal as JSON `[]`, never
+// `null`. Also pins the filters-envelope error path on
+// list-resource-record-sets (the API requires a hosted_zone_id and
+// silently calling without one returns a less actionable
+// ValidationException at the SDK layer).
+
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRoute53Client struct {
+	listHostedZonesOut       *route53.ListHostedZonesOutput
+	listResourceRecordSetsIn *route53.ListResourceRecordSetsInput
+	listResourceRecordSetsOut *route53.ListResourceRecordSetsOutput
+	err                      error
+}
+
+func (f *fakeRoute53Client) ListHostedZones(_ context.Context, _ *route53.ListHostedZonesInput, _ ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.listHostedZonesOut == nil {
+		return &route53.ListHostedZonesOutput{}, nil
+	}
+	return f.listHostedZonesOut, nil
+}
+
+func (f *fakeRoute53Client) ListResourceRecordSets(_ context.Context, in *route53.ListResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
+	f.listResourceRecordSetsIn = in
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.listResourceRecordSetsOut == nil {
+		return &route53.ListResourceRecordSetsOutput{}, nil
+	}
+	return f.listResourceRecordSetsOut, nil
+}
+
+// TestListHostedZones_EmptyResult — empty AWS response marshals as JSON
+// `[]`, not `null` (#255). The reliable UI gates panel render on the
+// array shape; `null` collapses through every empty-state branch.
+func TestListHostedZones_EmptyResult(t *testing.T) {
+	t.Parallel()
+	got, err := listHostedZones(context.Background(), &fakeRoute53Client{})
+	require.NoError(t, err)
+	require.NotNil(t, got, "#255: empty result must be a non-nil slice")
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b), "#255: empty JSON wire must be `[]`, not `null`")
+}
+
+// TestListHostedZones_TypedNilSliceNormalized — when the AWS SDK
+// populates HostedZones as a typed-nil slice (the SDK's empty-response
+// behavior), nilSliceToEmpty must normalize it to []. Pattern B from
+// the CONTRIBUTING.md cheat-sheet.
+func TestListHostedZones_TypedNilSliceNormalized(t *testing.T) {
+	t.Parallel()
+	client := &fakeRoute53Client{
+		// HostedZones is the zero value — a typed-nil []HostedZone.
+		listHostedZonesOut: &route53.ListHostedZonesOutput{},
+	}
+	got, err := listHostedZones(context.Background(), client)
+	require.NoError(t, err)
+	require.NotNil(t, got, "typed-nil from SDK must be normalized to []")
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestListHostedZones_NonEmpty(t *testing.T) {
+	t.Parallel()
+	client := &fakeRoute53Client{
+		listHostedZonesOut: &route53.ListHostedZonesOutput{
+			HostedZones: []route53types.HostedZone{
+				{Id: aws.String("/hostedzone/Z111"), Name: aws.String("example.com.")},
+				{Id: aws.String("/hostedzone/Z222"), Name: aws.String("other.com.")},
+			},
+		},
+	}
+	got, err := listHostedZones(context.Background(), client)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "/hostedzone/Z111", aws.ToString(got[0].Id))
+}
+
+func TestListHostedZones_APIError(t *testing.T) {
+	t.Parallel()
+	client := &fakeRoute53Client{err: errors.New("AccessDenied")}
+	_, err := listHostedZones(context.Background(), client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AccessDenied")
+}
+
+// TestListResourceRecordSets_EmptyResult — same #255 contract on the
+// record-set list. Wired into the live probe at
+// live_probe_255_test.go (filtered + unfiltered variants).
+func TestListResourceRecordSets_EmptyResult(t *testing.T) {
+	t.Parallel()
+	got, err := listResourceRecordSets(context.Background(), &fakeRoute53Client{}, "Z111")
+	require.NoError(t, err)
+	require.NotNil(t, got, "#255: empty record-set list must be non-nil")
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestListResourceRecordSets_PassesZoneID(t *testing.T) {
+	t.Parallel()
+	client := &fakeRoute53Client{}
+	_, err := listResourceRecordSets(context.Background(), client, "Z222")
+	require.NoError(t, err)
+	require.NotNil(t, client.listResourceRecordSetsIn)
+	assert.Equal(t, "Z222", aws.ToString(client.listResourceRecordSetsIn.HostedZoneId))
+}
+
+// TestRoute53FilterZoneID_RequiresHostedZoneID — the API mandates a
+// HostedZoneId. The inspector surfaces a clear structured error rather
+// than letting the SDK emit a ValidationException with no panel
+// guidance.
+func TestRoute53FilterZoneID_RequiresHostedZoneID(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		filters string
+	}{
+		{"empty filters", ""},
+		{"missing key", `{"project":"demo"}`},
+		{"empty value", `{"hosted_zone_id":""}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := route53FilterZoneID(tc.filters)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "hosted_zone_id")
+		})
+	}
+}
+
+func TestRoute53FilterZoneID_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	_, err := route53FilterZoneID(`{not json}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid filters JSON")
+}
+
+func TestRoute53FilterZoneID_ValidFilters(t *testing.T) {
+	t.Parallel()
+	id, err := route53FilterZoneID(`{"hosted_zone_id":"Z2FDTNDATAQYW2"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "Z2FDTNDATAQYW2", id)
+}
+
+// TestInspectRoute53_UnknownAction — bogus actions surface the canonical
+// unsupported-action message with the supported list embedded.
+func TestInspectRoute53_UnknownAction(t *testing.T) {
+	t.Parallel()
+	_, err := inspectRoute53(context.Background(), aws.Config{Region: "us-east-1"}, "no-such-action", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "route53")
+	assert.Contains(t, err.Error(), "no-such-action")
+}

--- a/pkg/observability/discovery/gcp/dispatcher.go
+++ b/pkg/observability/discovery/gcp/dispatcher.go
@@ -114,6 +114,12 @@ func Inspect(ctx context.Context, projectID, service, action, filtersJSON string
 	case "billing":
 		return inspectBilling(ctx, projectID, action, filtersJSON, opts...)
 
+	// --- dns.go (issue #596) ---
+	case "clouddns":
+		return inspectCloudDNS(ctx, projectID, action, filtersJSON, opts...)
+	case "certificatemanager":
+		return inspectCertificateManager(ctx, projectID, action, filtersJSON, opts...)
+
 	default:
 		return nil, unsupportedServiceError(service, observability.GCPServiceNames())
 	}

--- a/pkg/observability/discovery/gcp/dispatcher_test.go
+++ b/pkg/observability/discovery/gcp/dispatcher_test.go
@@ -44,6 +44,9 @@ var firstListAction = map[string]string{
 	"bastion":          "list-bastion-instances",
 	"cloudmonitoring":  "list-alert-policies",
 	"billing":          "get-billing-info",
+	// #596: new DNS+cert services.
+	"clouddns":           "list-managed-zones",
+	"certificatemanager": "list-certificates",
 }
 
 // unreachableEndpoint is an explicit RFC5737 documentation IP — every

--- a/pkg/observability/discovery/gcp/dns.go
+++ b/pkg/observability/discovery/gcp/dns.go
@@ -1,0 +1,137 @@
+// Cloud DNS + Certificate Manager inspectors (issue #596).
+//
+// Provides panel-default discovery for the gcp/cloud_dns preset (#583,
+// composer wiring #602) and prepares the surface for a future GCP
+// Certificate Manager preset.
+//
+// Cloud DNS actions:
+//   - list-managed-zones — service.ManagedZones.List(project). Returns
+//     []*dns.ManagedZone. The Cloud DNS API exposes a server-side
+//     dns_name filter (not label-based) so project scoping happens
+//     post-fetch via gcpLabelMatches on each zone's Labels map.
+//   - list-record-sets — service.ResourceRecordSets.List(project, zone).
+//     Returns []*dns.ResourceRecordSet for the requested zone. Record
+//     sets do not carry labels (they're child resources of the zone),
+//     so the project filter is moot here — callers provide the zone via
+//     the filters envelope.
+//
+// Certificate Manager actions:
+//   - list-certificates — projectsLocationsCertificatesService.List.
+//     Returns []*certificatemanager.Certificate scoped to a location
+//     (default "global" — Cert Manager is region-scoped but the public
+//     CDN cert flow uses global). Project scoping uses labels post-fetch.
+//
+// #255 contract: every slice return path is initialized to a non-nil
+// composite literal at the construction site (Pattern A from the
+// CONTRIBUTING.md cheat-sheet) so an empty result marshals as `[]`,
+// never `null`.
+
+package gcp
+
+import (
+	"context"
+	"fmt"
+
+	certmanager "google.golang.org/api/certificatemanager/v1"
+	dns "google.golang.org/api/dns/v1"
+	"google.golang.org/api/option"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/observability"
+)
+
+func inspectCloudDNS(ctx context.Context, projectID, action, filters string, opts ...option.ClientOption) (any, error) {
+	svc, err := dns.NewService(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	switch action {
+	case "list-managed-zones":
+		// ManagedZones.List has no server-side label filter; post-filter
+		// on ManagedZone.Labels for the caller-supplied project.
+		project := projectFromFilters(filters)
+		// Pattern A: declare with a non-nil composite literal so the
+		// empty-result path emits `[]`, not `null` (#255).
+		zones := []*dns.ManagedZone{}
+		err := svc.ManagedZones.List(projectID).Context(ctx).Pages(ctx, func(page *dns.ManagedZonesListResponse) error {
+			for _, z := range page.ManagedZones {
+				if !gcpLabelMatches(z.Labels, "project", project) {
+					continue
+				}
+				zones = append(zones, z)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return zones, nil
+
+	case "list-record-sets":
+		// ResourceRecordSets.List is per-zone — caller supplies the
+		// managed zone name in the filters envelope. Surface a
+		// structured error when missing so the panel can prompt the
+		// caller instead of bubbling a less actionable
+		// `googleapi: Error 404 zone not found` from the SDK.
+		fm := parseFilterMap(filters)
+		zone := fm["managed_zone"]
+		if zone == "" {
+			return nil, fmt.Errorf("list-record-sets requires a managed_zone in the filters envelope (e.g. {\"managed_zone\":\"example-com\"})")
+		}
+		// Pattern A: empty record-set list normalizes to `[]`.
+		records := []*dns.ResourceRecordSet{}
+		err := svc.ResourceRecordSets.List(projectID, zone).Context(ctx).Pages(ctx, func(page *dns.ResourceRecordSetsListResponse) error {
+			records = append(records, page.Rrsets...)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return records, nil
+
+	default:
+		return nil, unsupportedActionError("Cloud DNS", action, observability.GCPServiceActions["clouddns"])
+	}
+}
+
+func inspectCertificateManager(ctx context.Context, projectID, action, filters string, opts ...option.ClientOption) (any, error) {
+	svc, err := certmanager.NewService(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	switch action {
+	case "list-certificates":
+		// Cert Manager is region-scoped at the API path
+		// (projects/<p>/locations/<loc>/certificates), but the public-
+		// CDN flow uses "global". Allow callers to override via filters.
+		fm := parseFilterMap(filters)
+		location := fm["location"]
+		if location == "" {
+			location = "global"
+		}
+		project := projectFromFilters(filters)
+
+		// Pattern A: empty list → `[]`.
+		certs := []*certmanager.Certificate{}
+		err := svc.Projects.Locations.Certificates.
+			List(fmt.Sprintf("projects/%s/locations/%s", projectID, location)).
+			Context(ctx).
+			Pages(ctx, func(page *certmanager.ListCertificatesResponse) error {
+				for _, c := range page.Certificates {
+					if !gcpLabelMatches(c.Labels, "project", project) {
+						continue
+					}
+					certs = append(certs, c)
+				}
+				return nil
+			})
+		if err != nil {
+			return nil, err
+		}
+		return certs, nil
+
+	default:
+		return nil, unsupportedActionError("Certificate Manager", action, observability.GCPServiceActions["certificatemanager"])
+	}
+}

--- a/pkg/observability/discovery/gcp/dns_test.go
+++ b/pkg/observability/discovery/gcp/dns_test.go
@@ -46,11 +46,10 @@ const listManagedZonesPopulated = `{
 
 func TestInspectCloudDNS_ListManagedZones_EmptyEmitsArray(t *testing.T) {
 	t.Parallel()
-	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	_, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(listManagedZonesEmpty))
 	})
-	defer srv.Close()
 
 	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-managed-zones", "", opts...)
 	require.NoError(t, err)
@@ -62,11 +61,10 @@ func TestInspectCloudDNS_ListManagedZones_EmptyEmitsArray(t *testing.T) {
 
 func TestInspectCloudDNS_ListManagedZones_NoFilterReturnsAll(t *testing.T) {
 	t.Parallel()
-	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	_, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(listManagedZonesPopulated))
 	})
-	defer srv.Close()
 
 	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-managed-zones", "", opts...)
 	require.NoError(t, err)
@@ -83,11 +81,10 @@ func TestInspectCloudDNS_ListManagedZones_NoFilterReturnsAll(t *testing.T) {
 
 func TestInspectCloudDNS_ListManagedZones_FiltersByProject(t *testing.T) {
 	t.Parallel()
-	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	_, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(listManagedZonesPopulated))
 	})
-	defer srv.Close()
 
 	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-managed-zones", `{"project":"io-foo"}`, opts...)
 	require.NoError(t, err)
@@ -114,11 +111,10 @@ const listRecordSetsPopulated = `{
 
 func TestInspectCloudDNS_ListRecordSets_EmptyEmitsArray(t *testing.T) {
 	t.Parallel()
-	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	_, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(listRecordSetsEmpty))
 	})
-	defer srv.Close()
 
 	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-record-sets",
 		`{"managed_zone":"example-com"}`, opts...)
@@ -130,11 +126,10 @@ func TestInspectCloudDNS_ListRecordSets_EmptyEmitsArray(t *testing.T) {
 
 func TestInspectCloudDNS_ListRecordSets_NonEmpty(t *testing.T) {
 	t.Parallel()
-	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	_, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(listRecordSetsPopulated))
 	})
-	defer srv.Close()
 
 	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-record-sets",
 		`{"managed_zone":"example-com"}`, opts...)
@@ -192,11 +187,10 @@ const listCertsPopulated = `{
 
 func TestInspectCertificateManager_ListCertificates_EmptyEmitsArray(t *testing.T) {
 	t.Parallel()
-	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	_, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(listCertsEmpty))
 	})
-	defer srv.Close()
 
 	got, err := inspectCertificateManager(context.Background(), "demo-proj", "list-certificates", "", opts...)
 	require.NoError(t, err)
@@ -207,11 +201,10 @@ func TestInspectCertificateManager_ListCertificates_EmptyEmitsArray(t *testing.T
 
 func TestInspectCertificateManager_ListCertificates_FiltersByProject(t *testing.T) {
 	t.Parallel()
-	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	_, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(listCertsPopulated))
 	})
-	defer srv.Close()
 
 	got, err := inspectCertificateManager(context.Background(), "demo-proj", "list-certificates",
 		`{"project":"io-foo"}`, opts...)

--- a/pkg/observability/discovery/gcp/dns_test.go
+++ b/pkg/observability/discovery/gcp/dns_test.go
@@ -1,0 +1,236 @@
+// Cloud DNS + Certificate Manager inspector tests (issue #596).
+//
+// Pins the #255 contract end-to-end against httptest-backed JSON-API
+// fakes: empty list responses MUST marshal as JSON `[]`, never `null`.
+// Also exercises the project-label post-filter, the per-zone gating on
+// list-record-sets, and the unsupported-action sentinels.
+
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+)
+
+// fakeGCPRESTServer constructs an httptest server + option.ClientOption
+// slice that points the Cloud DNS / Cert Manager Go clients at the
+// fake. Both SDKs honor option.WithEndpoint for their JSON REST surface.
+func fakeGCPRESTServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, []option.ClientOption) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv, []option.ClientOption{
+		option.WithEndpoint(srv.URL),
+		option.WithoutAuthentication(),
+	}
+}
+
+// --- Cloud DNS: list-managed-zones --------------------------------------
+
+const listManagedZonesEmpty = `{"kind":"dns#managedZonesListResponse","managedZones":[]}`
+const listManagedZonesPopulated = `{
+  "kind": "dns#managedZonesListResponse",
+  "managedZones": [
+    {"id": "1", "name": "example-com", "dnsName": "example.com.", "visibility": "public", "labels": {"project": "io-foo"}},
+    {"id": "2", "name": "other-com",   "dnsName": "other.com.",   "visibility": "public", "labels": {"project": "io-bar"}},
+    {"id": "3", "name": "no-label",    "dnsName": "no-label.com.", "visibility": "public"}
+  ]
+}`
+
+func TestInspectCloudDNS_ListManagedZones_EmptyEmitsArray(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listManagedZonesEmpty))
+	})
+	defer srv.Close()
+
+	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-managed-zones", "", opts...)
+	require.NoError(t, err)
+	require.NotNil(t, got, "#255: empty zone list must be a non-nil slice")
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b), "#255: empty Cloud DNS list must marshal as `[]`, not `null`")
+}
+
+func TestInspectCloudDNS_ListManagedZones_NoFilterReturnsAll(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listManagedZonesPopulated))
+	})
+	defer srv.Close()
+
+	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-managed-zones", "", opts...)
+	require.NoError(t, err)
+
+	// Round-trip through JSON so we don't need to import the dns
+	// types for an in-Go shape assertion. The wire-format is what
+	// the panel consumes.
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	var zones []map[string]any
+	require.NoError(t, json.Unmarshal(b, &zones))
+	assert.Len(t, zones, 3, "no project filter → every zone returned")
+}
+
+func TestInspectCloudDNS_ListManagedZones_FiltersByProject(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listManagedZonesPopulated))
+	})
+	defer srv.Close()
+
+	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-managed-zones", `{"project":"io-foo"}`, opts...)
+	require.NoError(t, err)
+
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	var zones []map[string]any
+	require.NoError(t, json.Unmarshal(b, &zones))
+	require.Len(t, zones, 1, "only project=io-foo zone matches")
+	assert.Equal(t, "example-com", zones[0]["name"])
+}
+
+// --- Cloud DNS: list-record-sets ----------------------------------------
+
+const listRecordSetsEmpty = `{"kind":"dns#resourceRecordSetsListResponse","rrsets":[]}`
+const listRecordSetsPopulated = `{
+  "kind": "dns#resourceRecordSetsListResponse",
+  "rrsets": [
+    {"name": "example.com.", "type": "A",     "ttl": 300, "rrdatas": ["192.0.2.1"]},
+    {"name": "example.com.", "type": "MX",    "ttl": 300, "rrdatas": ["10 mail.example.com."]},
+    {"name": "www.example.com.", "type": "CNAME", "ttl": 60, "rrdatas": ["example.com."]}
+  ]
+}`
+
+func TestInspectCloudDNS_ListRecordSets_EmptyEmitsArray(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listRecordSetsEmpty))
+	})
+	defer srv.Close()
+
+	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-record-sets",
+		`{"managed_zone":"example-com"}`, opts...)
+	require.NoError(t, err)
+	require.NotNil(t, got, "#255: empty record-set list must be non-nil")
+	b, _ := json.Marshal(got)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestInspectCloudDNS_ListRecordSets_NonEmpty(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listRecordSetsPopulated))
+	})
+	defer srv.Close()
+
+	got, err := inspectCloudDNS(context.Background(), "demo-proj", "list-record-sets",
+		`{"managed_zone":"example-com"}`, opts...)
+	require.NoError(t, err)
+
+	b, _ := json.Marshal(got)
+	var rrsets []map[string]any
+	require.NoError(t, json.Unmarshal(b, &rrsets))
+	assert.Len(t, rrsets, 3)
+}
+
+func TestInspectCloudDNS_ListRecordSets_RequiresManagedZone(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		filters string
+	}{
+		{"empty filters", ""},
+		{"missing key", `{"project":"demo"}`},
+		{"empty value", `{"managed_zone":""}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := inspectCloudDNS(context.Background(), "demo-proj", "list-record-sets", tc.filters,
+				option.WithEndpoint(unreachableEndpoint),
+				option.WithoutAuthentication(),
+			)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "managed_zone")
+		})
+	}
+}
+
+func TestInspectCloudDNS_UnsupportedAction(t *testing.T) {
+	t.Parallel()
+	_, err := inspectCloudDNS(context.Background(), "demo-proj", "no-such", "",
+		option.WithEndpoint(unreachableEndpoint),
+		option.WithoutAuthentication(),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported Cloud DNS action")
+	assert.Contains(t, err.Error(), "list-managed-zones")
+}
+
+// --- Certificate Manager: list-certificates -----------------------------
+
+const listCertsEmpty = `{"certificates":[]}`
+const listCertsPopulated = `{
+  "certificates": [
+    {"name": "projects/demo-proj/locations/global/certificates/c1", "labels": {"project": "io-foo"}},
+    {"name": "projects/demo-proj/locations/global/certificates/c2", "labels": {"project": "io-bar"}}
+  ]
+}`
+
+func TestInspectCertificateManager_ListCertificates_EmptyEmitsArray(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listCertsEmpty))
+	})
+	defer srv.Close()
+
+	got, err := inspectCertificateManager(context.Background(), "demo-proj", "list-certificates", "", opts...)
+	require.NoError(t, err)
+	require.NotNil(t, got, "#255: empty cert list must be non-nil")
+	b, _ := json.Marshal(got)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestInspectCertificateManager_ListCertificates_FiltersByProject(t *testing.T) {
+	t.Parallel()
+	srv, opts := fakeGCPRESTServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(listCertsPopulated))
+	})
+	defer srv.Close()
+
+	got, err := inspectCertificateManager(context.Background(), "demo-proj", "list-certificates",
+		`{"project":"io-foo"}`, opts...)
+	require.NoError(t, err)
+
+	b, _ := json.Marshal(got)
+	var certs []map[string]any
+	require.NoError(t, json.Unmarshal(b, &certs))
+	require.Len(t, certs, 1)
+	assert.Equal(t, "projects/demo-proj/locations/global/certificates/c1", certs[0]["name"])
+}
+
+func TestInspectCertificateManager_UnsupportedAction(t *testing.T) {
+	t.Parallel()
+	_, err := inspectCertificateManager(context.Background(), "demo-proj", "no-such", "",
+		option.WithEndpoint(unreachableEndpoint),
+		option.WithoutAuthentication(),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported Certificate Manager action")
+	assert.Contains(t, err.Error(), "list-certificates")
+}

--- a/pkg/observability/discovery/gcp/live_probe_255_test.go
+++ b/pkg/observability/discovery/gcp/live_probe_255_test.go
@@ -152,6 +152,17 @@ func TestLive255_AllInspectorsJSONShape(t *testing.T) {
 				return inspectKMS(ctx, projectID, "list-keyrings", projectFilter, opts...)
 			}, filters: projectFilter},
 
+		// dns.go (#596)
+		{name: "clouddns/list-managed-zones",
+			fn: func() (any, error) {
+				return inspectCloudDNS(ctx, projectID, "list-managed-zones", projectFilter, opts...)
+			}, filters: projectFilter},
+		// certificatemanager/list-certificates — defaults to location=global.
+		{name: "certificatemanager/list-certificates",
+			fn: func() (any, error) {
+				return inspectCertificateManager(ctx, projectID, "list-certificates", projectFilter, opts...)
+			}, filters: projectFilter},
+
 		// identity.go — list-tenants on a project without multi-tenancy
 		// returns a structured error (TestLive_InspectIdentityPlatform_*).
 		// list-providers is a baseline.

--- a/pkg/observability/display.go
+++ b/pkg/observability/display.go
@@ -177,6 +177,8 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "GCP Cloud Monitoring"
 	case composer.KeyGCPCloudDNS:
 		return "GCP Cloud DNS"
+	case composer.KeyGCPGitHubActions:
+		return "GCP GitHub Actions WIF"
 	case composer.KeyGCPBackups:
 		return "GCP Backups"
 	default:

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -58,15 +58,19 @@ var configExtractorAllowlist = map[string]string{
 	"aws_codepipeline":   "[placeholder] mapped to ec2.describe-instances, no dedicated shape (#204)",
 	"aws_backups":        "[no-inspector] AWS Backup vaults aren't inspected; covered via tag-based discovery (#204)",
 	"aws_github_actions": "[no-inspector] GitHub Actions IAM roles only — no SDK shape to extract (#204)",
-	"aws_route53":        "[no-inspector] Route 53 hosted zones / records not yet covered by the discovery pipeline (#584 follow-up)",
-	"aws_acm":            "[no-inspector] ACM certificates not yet covered by the discovery pipeline (#593 follow-up)",
+	// #596: route53/acm dispatchers ship in pkg/observability/discovery/aws
+	// (route53.go, acm.go) but no extractor lands yet — the panel
+	// surfaces inspector output as raw SDK shapes until per-key field
+	// extraction stabilizes. Tracked as a discovery-pipeline follow-up.
+	"aws_route53": "[no-inspector] Route 53 dispatcher landed in #596 (route53.go); per-component extractor (config map for panel) deferred until SDK-shape extractor design settles for one-off resources",
+	"aws_acm":     "[no-inspector] ACM dispatcher landed in #596 (acm.go); per-component extractor deferred until cert-specific field reads (status, days_to_expiry, validation state) are designed",
 
 	// EKS node group: ComponentKey "aws_eks_nodegroup" doesn't have its
 	// own SDK inspector — extraction is handled by aws_eks (#204, #224).
 	"aws_eks_nodegroup": "[no-inspector] EKS node group is covered by the aws_eks inspector (#204)",
 
 	"gcp_backups":   "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
-	"gcp_cloud_dns": "[no-inspector] Cloud DNS managed zones / record sets not yet covered by the discovery pipeline (#593 follow-up)",
+	"gcp_cloud_dns": "[no-inspector] Cloud DNS dispatcher landed in #596 (gcp/dns.go); per-component extractor (config map for panel) deferred pending zone-detail field reads (visibility, dnssec_config, record-count summary)",
 }
 
 // extractorFixtures are minimal SDK-shape fixtures that exercise each

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -65,8 +65,9 @@ var configExtractorAllowlist = map[string]string{
 	// own SDK inspector — extraction is handled by aws_eks (#204, #224).
 	"aws_eks_nodegroup": "[no-inspector] EKS node group is covered by the aws_eks inspector (#204)",
 
-	"gcp_backups":   "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
-	"gcp_cloud_dns": "[no-inspector] Cloud DNS managed zones / record sets not yet covered by the discovery pipeline (#593 follow-up)",
+	"gcp_backups":         "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
+	"gcp_cloud_dns":       "[no-inspector] Cloud DNS managed zones / record sets not yet covered by the discovery pipeline (#593 follow-up)",
+	"gcp_github_actions":  "[no-inspector] GitHub Actions WIF pool/provider/SA not yet covered by the discovery pipeline (#597 follow-up)",
 }
 
 // extractorFixtures are minimal SDK-shape fixtures that exercise each

--- a/pkg/observability/inspect/testdata/render/aws_service_table.txt
+++ b/pkg/observability/inspect/testdata/render/aws_service_table.txt
@@ -1,6 +1,7 @@
 | Service | Common Actions |
 |---------|----------------|
 | account | get-info |
+| acm | list-certificates, describe-certificate, get-metrics |
 | alb | describe-load-balancers, get-metrics |
 | apigateway | get-apis, get-domain-names, get-metrics |
 | backup | list-backup-vaults |
@@ -20,6 +21,7 @@
 | msk | list-clusters, get-metrics |
 | opensearch | list-domains, describe-domains, list-collections, get-metrics |
 | rds | describe-db-instances, describe-db-clusters, get-metrics |
+| route53 | list-hosted-zones, list-resource-record-sets |
 | s3 | list-buckets, get-metrics |
 | secretsmanager | list-secrets, get-metrics |
 | sqs | list-queues, get-metrics |

--- a/pkg/observability/inspect/testdata/render/awsinspect_batch_description.txt
+++ b/pkg/observability/inspect/testdata/render/awsinspect_batch_description.txt
@@ -20,7 +20,7 @@ result — do NOT abort on the first error. A credential fetch failure
 leaves cred-less probes (list-actions, list-metrics) succeeding anyway.
 
 REQUIRES: session_id from convoopen response (format: sess_v2_...).
-Supported services: account, alb, apigateway, backup, bedrock, cloudfront, cloudwatchlogs, cognito, cost-explorer, dynamodb, ebs, ec2, ecs, eks, elasticache, kms, lambda, msk, opensearch, rds, s3, secretsmanager, sqs, vpc, waf
+Supported services: account, acm, alb, apigateway, backup, bedrock, cloudfront, cloudwatchlogs, cognito, cost-explorer, dynamodb, ebs, ec2, ecs, eks, elasticache, kms, lambda, msk, opensearch, rds, route53, s3, secretsmanager, sqs, vpc, waf
 For a specific service's actions, use awsinspect (singular) with
 action="list-actions" — batch is not the place for discovery.
 Batch responses are always summarized (no detail/raw per-sub); use

--- a/pkg/observability/inspect/testdata/render/awsinspect_description.txt
+++ b/pkg/observability/inspect/testdata/render/awsinspect_description.txt
@@ -12,7 +12,7 @@ RESPONSE TIERS (default is summary for token efficiency):
 - Raw: Complete unprocessed API response. Set raw=true.
 
 REQUIRES: session_id from convoopen response (format: sess_v2_...).
-Supported services: account, alb, apigateway, backup, bedrock, cloudfront, cloudwatchlogs, cognito, cost-explorer, dynamodb, ebs, ec2, ecs, eks, elasticache, kms, lambda, msk, opensearch, rds, s3, secretsmanager, sqs, vpc, waf
+Supported services: account, acm, alb, apigateway, backup, bedrock, cloudfront, cloudwatchlogs, cognito, cost-explorer, dynamodb, ebs, ec2, ecs, eks, elasticache, kms, lambda, msk, opensearch, rds, route53, s3, secretsmanager, sqs, vpc, waf
 For a specific service's actions, call with action="list-actions".
 METRICS: Use list-metrics to discover available metrics for a service (no credentials needed). Then use get-metrics to retrieve data (auto-discovers resources). Most services return CloudWatch time-series. KMS returns key health (rotation, state). SecretsManager returns secret health (rotation, last accessed/rotated). Optional filters JSON: {"hours":6,"period":300}.
 BILLING: Use service=cost-explorer to inspect AWS costs. Actions: get-cost-summary (last 30 days by service, filters: {"days":7,"granularity":"DAILY"}), get-cost-forecast (projected spend through end of month), get-cost-by-tag (costs grouped by tag, filters: {"tag_key":"Environment","days":30}). Requires ce:GetCostAndUsage and ce:GetCostForecast IAM permissions.

--- a/pkg/observability/inspect/testdata/render/gcp_service_table.txt
+++ b/pkg/observability/inspect/testdata/render/gcp_service_table.txt
@@ -3,9 +3,11 @@
 | apigateway | list-apis, get-metrics |
 | bastion | list-bastion-instances, get-metrics |
 | billing | get-billing-info, get-budgets |
+| certificatemanager | list-certificates |
 | cloudarmor | list-policies, describe-policy, get-metrics |
 | cloudbuild | list-triggers, list-builds, get-metrics |
 | cloudcdn | list-backend-services-cdn, get-metrics |
+| clouddns | list-managed-zones, list-record-sets |
 | cloudfunctions | list-functions, get-metrics |
 | cloudkms | list-keyrings, list-keys, get-metrics |
 | cloudlogging | list-logs |

--- a/pkg/observability/inspect/testdata/render/gcpinspect_batch_description.txt
+++ b/pkg/observability/inspect/testdata/render/gcpinspect_batch_description.txt
@@ -20,7 +20,7 @@ result — do NOT abort on the first error. A credential fetch failure
 leaves cred-less probes (list-actions, list-metrics) succeeding anyway.
 
 REQUIRES: session_id from convoopen response (format: sess_v2_...).
-Supported services: apigateway, bastion, billing, cloudarmor, cloudbuild, cloudcdn, cloudfunctions, cloudkms, cloudlogging, cloudmonitoring, cloudrun, cloudsql, compute, firestore, gcs, gke, identityplatform, loadbalancer, memorystore, pubsub, secretmanager, vertexai, vpc
+Supported services: apigateway, bastion, billing, certificatemanager, cloudarmor, cloudbuild, cloudcdn, clouddns, cloudfunctions, cloudkms, cloudlogging, cloudmonitoring, cloudrun, cloudsql, compute, firestore, gcs, gke, identityplatform, loadbalancer, memorystore, pubsub, secretmanager, vertexai, vpc
 For a specific service's actions, use gcpinspect (singular) with
 action="list-actions" — batch is not the place for discovery.
 Batch responses are always summarized (no detail/raw per-sub); use

--- a/pkg/observability/inspect/testdata/render/gcpinspect_description.txt
+++ b/pkg/observability/inspect/testdata/render/gcpinspect_description.txt
@@ -12,7 +12,7 @@ RESPONSE TIERS (default is summary for token efficiency):
 - Raw: Complete unprocessed API response. Set raw=true.
 
 REQUIRES: session_id from convoopen response (format: sess_v2_...).
-Supported services: apigateway, bastion, billing, cloudarmor, cloudbuild, cloudcdn, cloudfunctions, cloudkms, cloudlogging, cloudmonitoring, cloudrun, cloudsql, compute, firestore, gcs, gke, identityplatform, loadbalancer, memorystore, pubsub, secretmanager, vertexai, vpc
+Supported services: apigateway, bastion, billing, certificatemanager, cloudarmor, cloudbuild, cloudcdn, clouddns, cloudfunctions, cloudkms, cloudlogging, cloudmonitoring, cloudrun, cloudsql, compute, firestore, gcs, gke, identityplatform, loadbalancer, memorystore, pubsub, secretmanager, vertexai, vpc
 For a specific service's actions, call with action="list-actions".
 
 METRICS: Use list-metrics to see available Cloud Monitoring metrics for any service (no credentials needed — progressive disclosure). Use get-metrics to retrieve time-series data. Optional filters JSON: {"hours":6,"period":300}.

--- a/pkg/observability/service_actions.go
+++ b/pkg/observability/service_actions.go
@@ -44,6 +44,17 @@ var AWSServiceActions = map[string][]string{
 	"bedrock":        {"list-knowledge-bases", "describe-knowledge-base", "list-agents", "list-guardrails", "get-metrics"},
 	"cost-explorer":  {"get-cost-summary", "get-cost-forecast", "get-cost-by-tag"},
 	"account":        {"get-info"},
+	// Route 53 (#596). Hosted-zone discovery uses list-hosted-zones (global —
+	// no region scoping); per-zone record sets are fetched via
+	// list-resource-record-sets, which requires a hosted_zone_id in the
+	// filters envelope.
+	"route53": {"list-hosted-zones", "list-resource-record-sets"},
+	// ACM (#596). list-certificates returns the account's cert summaries
+	// (no server-side tag filter — caller post-filters); describe-certificate
+	// fetches the full detail (including domain_validation_options) for a
+	// specific ARN. get-metrics routes to the metrics package for the
+	// DaysToExpiry CloudWatch series.
+	"acm": {"list-certificates", "describe-certificate", "get-metrics"},
 }
 
 // AWSServiceAliases maps caller-supplied aliases to canonical service
@@ -59,6 +70,11 @@ var AWSServiceAliases = map[string]string{
 	"auth":    "cognito",
 	"billing": "cost-explorer",
 	"costs":   "cost-explorer",
+	// #596: LLM-friendly aliases for the new DNS+cert pair. "dns" maps
+	// to route53 (the only AWS DNS service); "certs" maps to acm
+	// (AWS's cert manager).
+	"dns":   "route53",
+	"certs": "acm",
 }
 
 // AWSActionAliases maps service → (alias action → canonical action).
@@ -85,6 +101,23 @@ var AWSActionAliases = map[string]map[string]string{
 	},
 	"s3": {
 		"describe-buckets": "list-buckets",
+	},
+	// #596: LLM-friendly aliases for Route 53 + ACM. Common patterns the
+	// LLM guesses ("list-zones", "describe-zones", "list-records",
+	// "describe-certificates") are absorbed here so callers land on the
+	// canonical SDK verbs instead of an unsupported-action error.
+	"route53": {
+		"list-zones":             "list-hosted-zones",
+		"describe-zones":         "list-hosted-zones",
+		"describe-hosted-zones":  "list-hosted-zones",
+		"list-records":           "list-resource-record-sets",
+		"list-record-sets":       "list-resource-record-sets",
+		"describe-record-sets":   "list-resource-record-sets",
+	},
+	"acm": {
+		"describe-certificates": "list-certificates",
+		"list-certs":            "list-certificates",
+		"get-certificate":       "describe-certificate",
 	},
 }
 
@@ -117,6 +150,14 @@ var GCPServiceActions = map[string][]string{
 	// design (cloudlogging follows the same pattern).
 	"cloudmonitoring": {"list-alert-policies"},
 	"billing":         {"get-billing-info", "get-budgets"},
+	// Cloud DNS (#596). list-managed-zones returns the project's zones
+	// (filtered by labels.project post-fetch); list-record-sets requires
+	// a managed_zone in the filters envelope (the API is per-zone).
+	"clouddns": {"list-managed-zones", "list-record-sets"},
+	// Certificate Manager (#596). list-certificates returns the cert
+	// inventory for a given location (defaults to "global" — the
+	// CloudFront / global LB cert flow).
+	"certificatemanager": {"list-certificates"},
 }
 
 // GCPServiceAliases is the GCP analog of AWSServiceAliases.
@@ -128,6 +169,12 @@ var GCPServiceAliases = map[string]string{
 	"network":   "vpc",
 	"functions": "cloudfunctions",
 	"cdn":       "cloudcdn",
+	// #596: LLM-friendly aliases for the GCP DNS+cert pair. "dns" maps
+	// to clouddns (GCP's Cloud DNS service); "certs" / "certmanager"
+	// map to certificatemanager (GCP's Certificate Manager service).
+	"dns":         "clouddns",
+	"certs":       "certificatemanager",
+	"certmanager": "certificatemanager",
 }
 
 // CanonicalAWSService resolves an alias to its canonical AWS service

--- a/pkg/observability/service_actions.go
+++ b/pkg/observability/service_actions.go
@@ -106,13 +106,20 @@ var AWSActionAliases = map[string]map[string]string{
 	// LLM guesses ("list-zones", "describe-zones", "list-records",
 	// "describe-certificates") are absorbed here so callers land on the
 	// canonical SDK verbs instead of an unsupported-action error.
+	// Note: "list-record-sets" is also the canonical GCP Cloud DNS action
+	// name (see GCPServiceActions["clouddns"] below). A cross-cloud caller
+	// using --service=route53 --action=list-record-sets lands on
+	// route53.list-resource-record-sets here; --service=clouddns
+	// --action=list-record-sets lands on clouddns.list-record-sets there.
+	// The two SDK verbs differ; the user-facing alias intentionally
+	// converges so cross-cloud tooling can use a single action name.
 	"route53": {
-		"list-zones":             "list-hosted-zones",
-		"describe-zones":         "list-hosted-zones",
-		"describe-hosted-zones":  "list-hosted-zones",
-		"list-records":           "list-resource-record-sets",
-		"list-record-sets":       "list-resource-record-sets",
-		"describe-record-sets":   "list-resource-record-sets",
+		"list-zones":            "list-hosted-zones",
+		"describe-zones":        "list-hosted-zones",
+		"describe-hosted-zones": "list-hosted-zones",
+		"list-records":          "list-resource-record-sets",
+		"list-record-sets":      "list-resource-record-sets",
+		"describe-record-sets":  "list-resource-record-sets",
 	},
 	"acm": {
 		"describe-certificates": "list-certificates",

--- a/tests/lint-gcp-project-pin.sh
+++ b/tests/lint-gcp-project-pin.sh
@@ -69,6 +69,7 @@ EXEMPT_PROJECT_PIN_GCP=(
   google_kms_crypto_key                 # parent: key_ring (gcp/kms/main.tf:82,103)
   google_kms_crypto_key_iam_binding     # parent: crypto_key_id (gcp/kms/main.tf:126)
   google_secret_manager_secret_version  # parent: secret (gcp/cloud_build, gcp/secretmanager)
+  google_service_account_iam_binding    # parent: service_account_id (gcp/github_actions/main.tf, #597)
   google_service_networking_connection  # parent: network (gcp/cloudsql/main.tf:41)
   google_storage_bucket_iam_member      # parent: bucket (gcp/cloud_logging/main.tf:60)
   google_storage_bucket_object          # parent: bucket (gcp/cloud_functions/main.tf:56)


### PR DESCRIPTION
## Summary

Mega bundle PR combining 4 standalone PRs from this grind session plus 2 review-driven fixup commits. Single review surface for everything DNS/cert + composer-wiring landed in round 3.

### Source PRs (superseded by this bundle)

- **#603** — `fix(composer): backfill missing GCP ImplicitDependencies (#600)`
- **#604** — `bundle: DNS+cert observability dispatcher closeout (#596)` + drive-by `isLambda` removal from `contracts.go`
- **#605** — `feat(gcp): add github_actions preset for Workload Identity Federation (#597 row 1)`
- **#609** — `feat(composer): close ACM↔Route53 back-edge via composed-root locals indirection (#601)`

### Per-issue scope

**#600 — GCP ImplicitDependencies backfill (PR #603 surface)**
Five GCP keys were missing their implicit dependency, silently causing apply-time failures when private endpoints / VPC connectors / LB attachments were configured but the upstream module wasn't explicitly selected:
- `KeyGCPVertexAI → KeyGCPVPC` (private endpoints via servicenetworking)
- `KeyGCPCloudFunctions → KeyGCPVPC` (Gen 2 serverless VPC connector)
- `KeyGCPCloudRun → KeyGCPVPC` (vpc_access_connector)
- `KeyGCPCloudBuild → KeyGCPVPC` (private worker pools)
- `KeyGCPCloudArmor → KeyGCPLoadbalancer` (policies attach to backend services)

New tests: `TestImplicitDependencies_GCPServices_AutoWireVPC` (table-driven, 7 rows including KeyGCPGKE + KeyGCPCompute templates) and `TestImplicitDependencies_ComposeOrderRespected` (structural invariant that any dep must precede its consumer in `ComposeOrder`).

**#596 — DNS+cert observability dispatcher closeout (PR #604 surface)**
All four dispatcher arms wired: AWS route53 (`list-hosted-zones`, `list-resource-record-sets`), AWS acm (`list-certificates`, `describe-certificate`, `get-metrics`), GCP clouddns (`list-managed-zones`, `list-record-sets`), GCP certificatemanager (`list-certificates`). LLM aliases registered (`dns`→route53/clouddns, `certs`→acm/certificatemanager). Live-probe #255 coverage extended. Drive-by: removed unused `isLambda` helper from `contracts.go` after the #224 EKS rename. *Deferred*: `google_dns_managed_zone` registry+policy backfill (tracked in #599; needs a real CAI discoverer port + the `make refresh-schemas` pipeline; see #599 research comment).

**#597 row 1 — gcp/github_actions WIF preset (PR #605 surface)**
New `gcp/github_actions/{main,variables,outputs}.tf` preset providing Workload Identity Federation for GitHub Actions deploys into GCP. Mirrors `aws/githubactions`'s OIDC role UX on the GCP side. Closes the highest-leverage GCP UX gap vs. AWS — until now, every GCP customer who wants GitHub Actions deploys had to hand-wire WIF.

Full composer wiring: `KeyGCPGitHubActions` + ComposeOrder + ModulePath + PresetKeyMap + AllComponentKeys + IAM permissions + GCPServices entries + pricing slot + mapper. Mapper placeholder `placeholder.invalid/placeholder` is shaped to fail the CEL gate by design (slash characters illegal in GitHub logins) — fail-loud default. Follow-up tickets filed: #606 (inspector), #607 (drift policy), #608 (registry entry).

**#601 — ACM↔Route53 back-edge via composed-root locals indirection (PR #609 surface)**
PR #602 wired ACM→Route53 forward but left the back-edge as #601 because direct module→module back-edges re-create a 2-cycle that `ValidateNoModuleCycles` rejects. PR #604 then identified that the originally-proposed fix (split route53 inputs) doesn't work because `extractWiringEdges` keys cycle topology by `ModuleBlock.Name` only.

The research comment posted to #601 recommended **Option G**: emit the back-edge through a composed-root `locals { }` block. The composer generates:

```hcl
locals {
  acm_validation_record_fqdns = values(module.aws_route53.record_fqdns)
}
```

alongside the module blocks, and ACM reads `validation_record_fqdns = local.acm_validation_record_fqdns`. `moduleRefPattern` only matches `module.X.Y` traversals (not `local.X`), and `extractWiringEdges` only iterates `[]ModuleBlock` (not locals), so the validator sees a one-way graph while terraform plan still orders correctly. The locals plumbing is reusable for the API Gateway / Cognito back-edge follow-ups flagged at `contracts.go:695-706`. `acm.create_validation` auto-flips to `true` when both keys selected.

### Review-driven fixup commit

The last commit `f6215a5` addresses every finding from `/review` (5 P2) and `qa-professor` (3 P1, 2 P2):

- **P1 — TestImplicitDependencies name vs coverage mismatch**: renamed to `TestImplicitDependencies_GCPServices_AutoWireVPC` and added the missing `KeyGCPCompute` row so the table actually pins what the function claims
- **P1 — TestDefaultRootLocals_InertWhenEitherAbsent**: changed `require.Empty` → `require.Nil` to pin the explicit nil-sentinel contract (callers may switch on `if locals == nil`)
- **P1 — tftest negative case may pass for wrong reason**: added positive companion `github_actions_minimum_ref_gate_plans_cleanly` to triangulate; expanded maintainer note about the single-precondition assumption
- **P2 — TestComposeStack_ACMStandalone over-asserts on `"locals {"`**: dropped the broader check; specific-key check is sufficient
- **P2 — TypedNilSliceNormalized duplicates EmptyResult**: distinguished by passing explicitly-empty slice (different code path than typed-nil); added `require.NoError` on `json.Marshal`
- **P2 — gofmt-dirty files (5)**: ran `gofmt -w` on the 5 files this bundle introduced
- **P2 — anonymous struct in `Config.GCPGitHubActions`**: promoted to named type `GCPGitHubActionsConfig` (matches Go-guidance named-type rule; future field additions won't force every test instantiation to be touched)
- **P2 — pool/provider short-name underflow risk**: tightened regex floor to 3 chars so composed pool ID clears Google's 4-char minimum even with a 1-char `var.project`
- **P2 — redundant `defer srv.Close()`**: dropped 7 instances in `dns_test.go` (`fakeGCPRESTServer` already registers `t.Cleanup`)
- **P2 — cross-cloud verb-shape divergence on `list-record-sets`**: added note in `service_actions.go` explaining the convergence

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` — **5146 tests pass** across 36 packages
- [x] `terraform fmt -check -recursive` clean
- [x] All 10 lint scripts pass (`lint-project-tag`, `lint-project-label`, `lint-sensitive-for-each`, `lint-foreach-unknown-keys`, `lint-no-root-only-blocks`, `lint-labelless-name-prefix`, `lint-gcp-project-pin`, `lint-shared-no-cloud-providers`, `lint-phantom-computed-fields`, `lint-enrichgen-override-citations`)
- [x] `terraform test gcp/github_actions/` — 9/9 pass
- [ ] CI: full sweep

## Review notes

- **`/review` findings:** 0 P0; 0 P1; 5 P2 (all addressed inline); 2 P3 (informational, skipped)
- **`qa-professor` verdict:** NEEDS WORK → 3 P1 + 2 P2 — **all addressed inline** in commit `f6215a5`
- **Security pass:** WIF preset attribute_condition is load-bearing with a precondition that rejects the all-empty ref-gate config (dangerous "any repo, any ref" misconfiguration is plan-time-rejected). `deploy_roles` default `[run.admin, iam.serviceAccountUser]` is minimum-privilege. Inspectors validate filters JSON via typed unmarshal, no injection surface. `data.google_project.this` correctly depends on the IAM service-enable to avoid the `number = 0` race that would produce an invalid principalSet.

## Closes

Closes #600
Closes #596
Closes #597 (row 1 — `gcp/github_actions` WIF; remaining rows tracked separately)
Closes #601

Supersedes PRs #603, #604, #605, #609 (closed as part of merging this bundle).

Refs #599 (drift policy backfill — research-comment posted, deferred as own bundle per CI parity gate).
Refs #606, #607, #608 (gcp/github_actions inspector / drift policy / registry — filed during #605 implementation).