### PR TITLE
feat(gcp): add cloud_deploy delivery-pipeline preset (#613)

### DIFF
--- a/gcp/cloud_deploy/main.tf
+++ b/gcp/cloud_deploy/main.tf
@@ -43,7 +43,7 @@ locals {
   # gcp/cloud_build / gcp/github_actions). The downstream InsideOut
   # inspector filters Cloud Deploy resources on the project label for
   # drift attribution.
-  tags_or_labels = merge({ project = var.project }, var.labels)
+  labels = merge({ project = var.project }, var.labels)
 
   # Each target's Cloud Deploy identifier is the var.project-prefixed form
   # of the user-supplied short name. The prefix is load-bearing for the
@@ -82,8 +82,10 @@ resource "google_project_service" "this" {
 # Cloud Deploy executes render/deploy/verify jobs as a service account; the
 # default is the Compute Engine default SA, which is over-privileged and
 # typically locked-down in production projects. Provision a per-pipeline
-# runner SA with least-privilege bindings (releaser + operator below) so
-# Cloud Deploy has explicit, auditable identity for its execution.
+# runner SA with the single least-privilege binding (jobRunner below) so
+# Cloud Deploy has explicit, auditable identity for its execution. Callers
+# that create releases (CI, gcloud users) hold roles/clouddeploy.releaser
+# themselves — the runner SA is the executor, not the release-creator.
 #
 # account_id has a 6-30 char limit and `[a-z]([-a-z0-9]*[a-z0-9])` regex.
 # var.project (the stack naming prefix) can overflow when combined with a
@@ -133,7 +135,7 @@ resource "google_clouddeploy_delivery_pipeline" "this" {
     }
   }
 
-  labels = local.tags_or_labels
+  labels = local.labels
 
   depends_on = [
     google_project_service.this,
@@ -174,7 +176,7 @@ resource "google_clouddeploy_target" "this" {
 
   description = "Cloud Deploy target ${each.value.name} (runtime: ${each.value.runtime}) for pipeline ${var.project}-${var.pipeline_short_name}"
 
-  require_approval = lookup(each.value, "require_approval", false)
+  require_approval = each.value.require_approval
 
   dynamic "run" {
     for_each = each.value.runtime == "run" ? [1] : []
@@ -196,40 +198,36 @@ resource "google_clouddeploy_target" "this" {
     execution_timeout = "3600s"
   }
 
-  labels = local.tags_or_labels
+  labels = local.labels
 
   depends_on = [
     google_project_service.this,
-    google_project_iam_member.deploy_runner_releaser,
-    google_project_iam_member.deploy_runner_operator,
+    google_project_iam_member.deploy_runner_job_runner,
   ]
 }
 
 # -----------------------------------------------------------------------------
-# Project-level IAM bindings for the runner SA
+# Project-level IAM binding for the runner SA
 # -----------------------------------------------------------------------------
-# roles/clouddeploy.releaser  — create releases + promote between targets.
-# roles/clouddeploy.operator  — execute render/deploy/verify jobs as part
-#                               of release rollout.
+# roles/clouddeploy.jobRunner  — execute render/deploy/verify jobs as part of
+#                                release rollout. The runner SA is the *executor*
+#                                identity, not the release-creator. Callers that
+#                                cut releases (CI workflow SA, gcloud user)
+#                                grant themselves roles/clouddeploy.releaser
+#                                separately — binding it to the runner SA here
+#                                would be over-privileged (the runner does not
+#                                create releases).
 #
-# Both are project-scoped because Cloud Deploy's release / rollout APIs
-# operate at the project level. google_project_iam_member (additive) is used
-# rather than google_project_iam_binding (authoritative) to avoid stomping
-# pre-existing role grants on the project. Etag drifts on refresh but is
-# Computed-only — lifecycle.ignore_changes has no effect; drift suppression
-# happens at the inspector level (matches gcp/cloud_build:81 pattern).
+# Project-scoped because Cloud Deploy's release / rollout APIs operate at the
+# project level. google_project_iam_member (additive) is used rather than
+# google_project_iam_binding (authoritative) to avoid stomping pre-existing
+# role grants on the project. Etag drifts on refresh but is Computed-only —
+# lifecycle.ignore_changes has no effect; drift suppression happens at the
+# inspector level (matches gcp/cloud_build:81 pattern).
 #
 # depends_on pins binding-creation after API enable so first-apply doesn't
 # race the Cloud Deploy service-account-readiness check.
-resource "google_project_iam_member" "deploy_runner_releaser" {
-  project = var.project_id
-  role    = "roles/clouddeploy.releaser"
-  member  = "serviceAccount:${google_service_account.deploy_runner.email}"
-
-  depends_on = [google_project_service.this]
-}
-
-resource "google_project_iam_member" "deploy_runner_operator" {
+resource "google_project_iam_member" "deploy_runner_job_runner" {
   project = var.project_id
   role    = "roles/clouddeploy.jobRunner"
   member  = "serviceAccount:${google_service_account.deploy_runner.email}"

--- a/gcp/cloud_deploy/main.tf
+++ b/gcp/cloud_deploy/main.tf
@@ -1,0 +1,238 @@
+# -----------------------------------------------------------------------------
+# GCP Cloud Deploy — managed delivery-pipeline preset
+# -----------------------------------------------------------------------------
+# Mirrors the role aws/codepipeline plays for AWS stacks. Provisions a Cloud
+# Deploy delivery pipeline that promotes a single release through a serial
+# chain of targets (typical: staging -> prod) running on either Cloud Run or
+# GKE. Closes the GCP CD-pipeline parity gap (#597 row 2 follow-up, issue
+# #613).
+#
+# Idempotency contract (CLAUDE.md "Idempotency"):
+#   - google_clouddeploy_delivery_pipeline, ..._target, google_service_account
+#     are NOT singletons; they can be destroyed and recreated cleanly. No
+#     adoption / lifecycle.ignore_changes dance required.
+#   - google_project_service entries use disable_on_destroy = false so the
+#     API stays enabled across destroy/apply cycles (matches the cloud_build
+#     and github_actions conventions in this repo).
+#
+# IAM propagation: the deploy SA's project-level role bindings are consumed
+# by Cloud Deploy at release-promotion time (i.e. minutes-to-hours after
+# terraform apply when the caller cuts the first release), so no
+# time_sleep.wait_iam_propagation is needed at apply time. If a future
+# in-stack consumer wires execution at apply time, re-introduce the
+# time_sleep pattern from gcp/cloud_build/main.tf.
+#
+# Var split (#157):
+#   - var.project  : naming/label prefix (NOT a GCP project ID)
+#   - var.project_id : real GCP project ID (used on every google_* resource
+#     and module's `project = ...` argument)
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+locals {
+  # Label propagation: every label-capable resource merges var.labels onto
+  # { project = var.project } so the project label always lands (mirrors
+  # gcp/cloud_build / gcp/github_actions). The downstream InsideOut
+  # inspector filters Cloud Deploy resources on the project label for
+  # drift attribution.
+  tags_or_labels = merge({ project = var.project }, var.labels)
+
+  # Each target's Cloud Deploy identifier is the var.project-prefixed form
+  # of the user-supplied short name. The prefix is load-bearing for the
+  # inspector's name-prefix scoping (lint-labelless-name-prefix.sh) AND
+  # for ensuring two stacks in the same project don't collide on a target
+  # named "staging" or "prod". The same prefixed value MUST be used as
+  # the serial_pipeline.stages.target_id below — Cloud Deploy resolves
+  # stage references by exact name match.
+  target_full_names = { for t in var.targets : t.name => "${var.project}-${t.name}" }
+
+  # Re-key the target list by the user-supplied short name for stable
+  # for_each. The list-of-objects input var.targets retains author-supplied
+  # order (needed for the serial pipeline stage chain below); the map view
+  # is only used as the for_each key set on google_clouddeploy_target.
+  targets_by_name = { for t in var.targets : t.name => t }
+}
+
+# -----------------------------------------------------------------------------
+# Required API enables
+# -----------------------------------------------------------------------------
+# Only clouddeploy.googleapis.com is preset-specific — IAM is already enabled
+# by the always-required-services baseline (gcp_services.go). disable_on_destroy
+# is false so the API survives a terraform destroy / apply cycle (matches the
+# repo-wide convention for project_service activations on long-lived APIs).
+resource "google_project_service" "this" {
+  for_each = toset(["clouddeploy.googleapis.com"])
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+# -----------------------------------------------------------------------------
+# Cloud Deploy execution / runner service account
+# -----------------------------------------------------------------------------
+# Cloud Deploy executes render/deploy/verify jobs as a service account; the
+# default is the Compute Engine default SA, which is over-privileged and
+# typically locked-down in production projects. Provision a per-pipeline
+# runner SA with least-privilege bindings (releaser + operator below) so
+# Cloud Deploy has explicit, auditable identity for its execution.
+#
+# account_id has a 6-30 char limit and `[a-z]([-a-z0-9]*[a-z0-9])` regex.
+# var.project (the stack naming prefix) can overflow when combined with a
+# role suffix; the SA short_name default fits within the cap. display_name
+# carries var.project for human readability — the
+# lint-labelless-name-prefix.sh allowlist exempts google_service_account
+# from the var.project-in-name rule precisely because of this length cap.
+resource "google_service_account" "deploy_runner" {
+  project      = var.project_id
+  account_id   = var.service_account_short_name
+  display_name = "Cloud Deploy runner SA (${var.project})"
+  description  = "Service account Cloud Deploy executes render/deploy/verify jobs as for delivery pipeline ${var.project}-${var.pipeline_short_name}"
+
+  depends_on = [google_project_service.this]
+}
+
+# -----------------------------------------------------------------------------
+# Delivery pipeline
+# -----------------------------------------------------------------------------
+# A delivery pipeline pins the ordered serial chain of targets a release
+# promotes through. The stage list is built from var.targets in author order
+# (so the user controls promotion order). location is var.region — Cloud
+# Deploy is a regional service.
+#
+# The pipeline name is var.project-prefixed so it satisfies the
+# lint-labelless-name-prefix rule (labels are also set, but
+# google_clouddeploy_delivery_pipeline is not on LABEL_CAPABLE_GCP yet —
+# defensive on both axes is cheap insurance).
+resource "google_clouddeploy_delivery_pipeline" "this" {
+  project  = var.project_id
+  location = var.region
+  name     = "${var.project}-${var.pipeline_short_name}"
+
+  description = "Delivery pipeline for ${var.project} (managed by Terraform; do not edit in the GCP console)"
+
+  serial_pipeline {
+    dynamic "stages" {
+      for_each = var.targets
+      content {
+        # target_id MUST match the corresponding google_clouddeploy_target.name
+        # (the var.project-prefixed form built in local.target_full_names) or
+        # Cloud Deploy rejects the pipeline at apply with INVALID_ARGUMENT:
+        # "target <name> does not exist".
+        target_id = local.target_full_names[stages.value.name]
+        profiles  = []
+      }
+    }
+  }
+
+  labels = local.tags_or_labels
+
+  depends_on = [
+    google_project_service.this,
+    google_clouddeploy_target.this,
+  ]
+}
+
+# -----------------------------------------------------------------------------
+# Targets — one per entry in var.targets
+# -----------------------------------------------------------------------------
+# Each target represents a deployment destination (a Cloud Run region or a
+# GKE cluster). The serial_pipeline above chains them in order. The target
+# `name` is the pipeline-scoped identifier and must match exactly what the
+# stage block references — for_each is keyed by name to make that
+# correspondence explicit and to give terraform stable resource addresses
+# under target add/remove.
+#
+# Runtime dispatch:
+#   - runtime = "run" : Cloud Run target. runtime_target is the Cloud Run
+#     location (region) where the service is deployed.
+#   - runtime = "gke" : GKE target. runtime_target is the fully-qualified
+#     cluster ID `projects/<id>/locations/<loc>/clusters/<name>`.
+#
+# Both shapes set execution_configs to drive renders/deploys via the runner
+# SA we provisioned above; without an explicit execution_configs block Cloud
+# Deploy falls back to the Compute Engine default SA (the over-privileged
+# default we explicitly want to avoid).
+resource "google_clouddeploy_target" "this" {
+  for_each = local.targets_by_name
+
+  project  = var.project_id
+  location = var.region
+  # name carries var.project as a hard prefix so the InsideOut inspector
+  # can attribute the target to this stack via name-prefix scoping
+  # (lint-labelless-name-prefix.sh). Using local.target_full_names keeps
+  # the prefixing logic and the serial_pipeline stage reference in sync.
+  name = local.target_full_names[each.key]
+
+  description = "Cloud Deploy target ${each.value.name} (runtime: ${each.value.runtime}) for pipeline ${var.project}-${var.pipeline_short_name}"
+
+  require_approval = lookup(each.value, "require_approval", false)
+
+  dynamic "run" {
+    for_each = each.value.runtime == "run" ? [1] : []
+    content {
+      location = each.value.runtime_target
+    }
+  }
+
+  dynamic "gke" {
+    for_each = each.value.runtime == "gke" ? [1] : []
+    content {
+      cluster = each.value.runtime_target
+    }
+  }
+
+  execution_configs {
+    usages            = ["RENDER", "DEPLOY", "VERIFY"]
+    service_account   = google_service_account.deploy_runner.email
+    execution_timeout = "3600s"
+  }
+
+  labels = local.tags_or_labels
+
+  depends_on = [
+    google_project_service.this,
+    google_project_iam_member.deploy_runner_releaser,
+    google_project_iam_member.deploy_runner_operator,
+  ]
+}
+
+# -----------------------------------------------------------------------------
+# Project-level IAM bindings for the runner SA
+# -----------------------------------------------------------------------------
+# roles/clouddeploy.releaser  — create releases + promote between targets.
+# roles/clouddeploy.operator  — execute render/deploy/verify jobs as part
+#                               of release rollout.
+#
+# Both are project-scoped because Cloud Deploy's release / rollout APIs
+# operate at the project level. google_project_iam_member (additive) is used
+# rather than google_project_iam_binding (authoritative) to avoid stomping
+# pre-existing role grants on the project. Etag drifts on refresh but is
+# Computed-only — lifecycle.ignore_changes has no effect; drift suppression
+# happens at the inspector level (matches gcp/cloud_build:81 pattern).
+#
+# depends_on pins binding-creation after API enable so first-apply doesn't
+# race the Cloud Deploy service-account-readiness check.
+resource "google_project_iam_member" "deploy_runner_releaser" {
+  project = var.project_id
+  role    = "roles/clouddeploy.releaser"
+  member  = "serviceAccount:${google_service_account.deploy_runner.email}"
+
+  depends_on = [google_project_service.this]
+}
+
+resource "google_project_iam_member" "deploy_runner_operator" {
+  project = var.project_id
+  role    = "roles/clouddeploy.jobRunner"
+  member  = "serviceAccount:${google_service_account.deploy_runner.email}"
+
+  depends_on = [google_project_service.this]
+}

--- a/gcp/cloud_deploy/outputs.tf
+++ b/gcp/cloud_deploy/outputs.tf
@@ -14,7 +14,11 @@ output "service_account_email" {
 }
 
 output "target_names" {
-  value       = [for t in var.targets : "${var.project}-${t.name}"]
+  # Read straight from the resources rather than recomputing the prefix here —
+  # keeps main.tf's local.target_full_names the single source of truth for the
+  # prefixing rule. var.targets is iterated to preserve the author-supplied
+  # ordering that google_clouddeploy_target.this (a for_each map) does not.
+  value       = [for t in var.targets : google_clouddeploy_target.this[t.name].name]
   description = "Ordered list of var.project-prefixed Cloud Deploy target names the pipeline promotes through. Same order as var.targets — element [0] is the first promotion stage. Each element matches the corresponding google_clouddeploy_target.name (= local.target_full_names entry)."
 }
 

--- a/gcp/cloud_deploy/outputs.tf
+++ b/gcp/cloud_deploy/outputs.tf
@@ -1,0 +1,29 @@
+output "pipeline_name" {
+  value       = google_clouddeploy_delivery_pipeline.this.name
+  description = "Cloud Deploy delivery pipeline short name (var.project-prefixed). Pass to `gcloud deploy releases create --delivery-pipeline=<this>`."
+}
+
+output "pipeline_id" {
+  value       = google_clouddeploy_delivery_pipeline.this.id
+  description = "Fully-qualified delivery pipeline resource ID (projects/<id>/locations/<region>/deliveryPipelines/<name>)."
+}
+
+output "service_account_email" {
+  value       = google_service_account.deploy_runner.email
+  description = "Email of the runner SA Cloud Deploy executes render / deploy / verify jobs as. Grant additional roles here for downstream resources the pipeline's targets must touch (e.g. roles/run.developer for Cloud Run deploys, roles/container.developer for GKE deploys)."
+}
+
+output "target_names" {
+  value       = [for t in var.targets : "${var.project}-${t.name}"]
+  description = "Ordered list of var.project-prefixed Cloud Deploy target names the pipeline promotes through. Same order as var.targets — element [0] is the first promotion stage. Each element matches the corresponding google_clouddeploy_target.name (= local.target_full_names entry)."
+}
+
+output "target_short_names" {
+  value       = [for t in var.targets : t.name]
+  description = "Ordered list of caller-supplied short names (unprefixed). Useful when the consumer needs to reference targets by the same identifier the caller used in var.targets."
+}
+
+output "target_ids" {
+  value       = { for k, v in google_clouddeploy_target.this : k => v.id }
+  description = "Map from target short name to fully-qualified target resource ID. Keys are the caller-supplied short names (unprefixed); values are the projects/<id>/locations/<region>/targets/<full-name> resource IDs. Useful for downstream wiring that needs the Cloud Deploy target reference (e.g. cross-stack release-promotion automation)."
+}

--- a/gcp/cloud_deploy/tests/shape.tftest.hcl
+++ b/gcp/cloud_deploy/tests/shape.tftest.hcl
@@ -12,7 +12,14 @@ mock_provider "google" {}
 #     collapse pipeline stages).
 
 run "cloud_deploy_minimum_inputs" {
-  command = plan
+  # `command = apply` (not plan) so the assertions below can cross-reference
+  # google_service_account.deploy_runner.email — the email is Computed by
+  # the Google provider and is plan-time-unknown. The mock_provider above
+  # generates a deterministic mock value at apply, making the cross-ref
+  # evaluable. All assertions in this block are about static configuration
+  # (names, labels, structural counts), not real API behaviour, so the
+  # mock-provider apply is safe.
+  command = apply
 
   variables {
     project    = "test"

--- a/gcp/cloud_deploy/tests/shape.tftest.hcl
+++ b/gcp/cloud_deploy/tests/shape.tftest.hcl
@@ -1,0 +1,151 @@
+mock_provider "google" {}
+
+# Issue #613 (gcp/cloud_deploy delivery-pipeline preset) shape tests. Verifies
+# that:
+#   - Defaults compose cleanly (happy path, two-stage Cloud Run pipeline).
+#   - The target name regex / runtime enum / empty-list validations all reject
+#     the misconfigurations they're supposed to.
+#   - Caller-supplied target list flows through and gets var.project-prefixed
+#     before reaching google_clouddeploy_target.name (which the
+#     lint-labelless-name-prefix rule enforces).
+#   - Duplicate target names fail loudly (they would otherwise silently
+#     collapse pipeline stages).
+
+run "cloud_deploy_minimum_inputs" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+  }
+
+  assert {
+    condition     = google_clouddeploy_delivery_pipeline.this.name == "test-delivery"
+    error_message = "pipeline name should default to ${var.project}-${var.pipeline_short_name}."
+  }
+
+  # Default var.targets has two entries (staging, prod) -> two
+  # google_clouddeploy_target resources.
+  assert {
+    condition     = length(google_clouddeploy_target.this) == 2
+    error_message = "Default var.targets has two entries; expected two google_clouddeploy_target resources."
+  }
+
+  # Each target name carries var.project as a hard prefix (lint contract).
+  assert {
+    condition     = google_clouddeploy_target.this["staging"].name == "test-staging"
+    error_message = "Target name must be var.project-prefixed (lint-labelless-name-prefix contract)."
+  }
+
+  assert {
+    condition     = google_clouddeploy_target.this["prod"].name == "test-prod"
+    error_message = "Target name must be var.project-prefixed (lint-labelless-name-prefix contract)."
+  }
+}
+
+run "cloud_deploy_gke_target_dispatches_gke_block" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    targets = [
+      {
+        name             = "prod"
+        runtime          = "gke"
+        runtime_target   = "projects/p/locations/us-central1/clusters/c"
+        require_approval = true
+      },
+    ]
+  }
+
+  # The dynamic gke {} block fires for runtime="gke" (and run {} stays empty).
+  assert {
+    condition     = length(google_clouddeploy_target.this["prod"].gke) == 1
+    error_message = "runtime=\"gke\" must dispatch the dynamic gke {} block."
+  }
+
+  assert {
+    condition     = length(google_clouddeploy_target.this["prod"].run) == 0
+    error_message = "runtime=\"gke\" must NOT emit a run {} block."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases: validation blocks must reject obvious misconfigurations at
+# plan time so callers don't discover them at apply.
+# -----------------------------------------------------------------------------
+
+run "cloud_deploy_rejects_empty_targets" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    targets    = []
+  }
+
+  expect_failures = [var.targets]
+}
+
+run "cloud_deploy_rejects_invalid_runtime" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    targets = [
+      {
+        name           = "staging"
+        runtime        = "lambda" # not in the allowed enum
+        runtime_target = "us-central1"
+      },
+    ]
+  }
+
+  expect_failures = [var.targets]
+}
+
+run "cloud_deploy_rejects_duplicate_target_names" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    targets = [
+      { name = "prod", runtime = "run", runtime_target = "us-central1" },
+      { name = "prod", runtime = "run", runtime_target = "us-east1" }, # duplicate
+    ]
+  }
+
+  expect_failures = [var.targets]
+}
+
+run "cloud_deploy_rejects_invalid_target_name" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    targets = [
+      {
+        name           = "Prod" # uppercase rejected by Cloud Deploy regex
+        runtime        = "run"
+        runtime_target = "us-central1"
+      },
+    ]
+  }
+
+  expect_failures = [var.targets]
+}
+
+run "cloud_deploy_rejects_invalid_project_id" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "INVALID_UPPERCASE"
+  }
+
+  expect_failures = [var.project_id]
+}

--- a/gcp/cloud_deploy/tests/shape.tftest.hcl
+++ b/gcp/cloud_deploy/tests/shape.tftest.hcl
@@ -41,6 +41,23 @@ run "cloud_deploy_minimum_inputs" {
     condition     = google_clouddeploy_target.this["prod"].name == "test-prod"
     error_message = "Target name must be var.project-prefixed (lint-labelless-name-prefix contract)."
   }
+
+  # serial_pipeline.stages[*].target_id must equal the var.project-prefixed
+  # target name (= local.target_full_names entry). Cloud Deploy resolves
+  # stages to targets by exact name match — a drift here would compose a
+  # plan that apply-time rejects with INVALID_ARGUMENT "target X does not
+  # exist". Pinning the correspondence in a tftest keeps the
+  # local.target_full_names indirection from accidentally diverging from
+  # the stage target_id reference.
+  assert {
+    condition     = tolist(google_clouddeploy_delivery_pipeline.this.serial_pipeline[0].stages)[0].target_id == "test-staging"
+    error_message = "serial_pipeline.stages[0].target_id must be the var.project-prefixed first target name."
+  }
+
+  assert {
+    condition     = tolist(google_clouddeploy_delivery_pipeline.this.serial_pipeline[0].stages)[1].target_id == "test-prod"
+    error_message = "serial_pipeline.stages[1].target_id must be the var.project-prefixed second target name."
+  }
 }
 
 run "cloud_deploy_gke_target_dispatches_gke_block" {

--- a/gcp/cloud_deploy/tests/shape.tftest.hcl
+++ b/gcp/cloud_deploy/tests/shape.tftest.hcl
@@ -58,6 +58,60 @@ run "cloud_deploy_minimum_inputs" {
     condition     = tolist(google_clouddeploy_delivery_pipeline.this.serial_pipeline[0].stages)[1].target_id == "test-prod"
     error_message = "serial_pipeline.stages[1].target_id must be the var.project-prefixed second target name."
   }
+
+  # Runner SA's account_id must hit the variables.tf default. A rename
+  # that slipped under the SA's 30-char cap would not trip the validation
+  # block but WOULD change a stack-stable identifier consumers might
+  # already grant cross-project access to — surface the default
+  # explicitly so a default-flip is a deliberate test break.
+  assert {
+    condition     = google_service_account.deploy_runner.account_id == "clouddeploy-runner"
+    error_message = "Runner SA account_id should default to `clouddeploy-runner` (length-safe at 18 chars)."
+  }
+
+  # execution_configs.service_account MUST point at the per-pipeline
+  # runner SA, not the default Compute Engine SA. The entire reason this
+  # preset provisions a runner SA is to avoid the over-privileged CE
+  # default — a mutation that dropped execution_configs (or pointed it
+  # at the wrong reference) would silently regress that security promise.
+  assert {
+    condition     = google_clouddeploy_target.this["staging"].execution_configs[0].service_account == google_service_account.deploy_runner.email
+    error_message = "Cloud Deploy targets must execute as the per-pipeline runner SA, not the default Compute Engine SA (over-privileged)."
+  }
+
+  assert {
+    condition     = contains(google_clouddeploy_target.this["staging"].execution_configs[0].usages, "DEPLOY")
+    error_message = "execution_configs.usages must include DEPLOY so render/deploy/verify all route through the runner SA."
+  }
+}
+
+# Positive companion to the cloud_deploy_rejects_* triad below. With a
+# valid single-entry targets list (same SHAPE the negatives use, just
+# with valid values), plan must succeed. This triangulates that the
+# negatives' expect_failures on var.targets is the right validation
+# firing (the field under test), not e.g. the empty-list check
+# unexpectedly tripping on a single-entry list, or the name regex
+# tripping on the targets we use in the duplicate-names case.
+run "cloud_deploy_single_valid_target_plans_cleanly" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    targets = [
+      { name = "prod", runtime = "run", runtime_target = "us-central1" },
+    ]
+  }
+
+  assert {
+    condition     = length(google_clouddeploy_target.this) == 1
+    error_message = "Valid single-target list must plan cleanly with exactly one target resource."
+  }
+
+  assert {
+    condition     = google_clouddeploy_target.this["prod"].name == "test-prod"
+    error_message = "Single target must still get the var.project name-prefix."
+  }
 }
 
 run "cloud_deploy_gke_target_dispatches_gke_block" {

--- a/gcp/cloud_deploy/variables.tf
+++ b/gcp/cloud_deploy/variables.tf
@@ -1,0 +1,134 @@
+variable "project" {
+  description = "Naming/label prefix for stack resources (NOT a GCP project ID — see var.project_id)."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+}
+
+variable "project_id" {
+  description = "Real GCP project ID where resources are created (e.g. \"my-prod-12345\"). Distinct from var.project, which is the naming/label prefix and need not be a valid GCP project ID."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "project_id must be a valid GCP project ID: 6–30 chars, lowercase letters/digits/hyphens, start with a letter, end alphanumeric."
+  }
+}
+
+variable "region" {
+  description = "GCP region for the Cloud Deploy delivery pipeline and its targets. Cloud Deploy is a regional service; targets that deploy to Cloud Run / GKE in a DIFFERENT region than the pipeline are supported, but the pipeline resource itself lives in this region."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "labels" {
+  description = "Additional labels to apply to label-capable resources (the project label is always merged in)."
+  type        = map(string)
+  default     = {}
+}
+
+# -----------------------------------------------------------------------------
+# Pipeline targets — the ordered serial chain of deployment destinations
+# -----------------------------------------------------------------------------
+# Each entry defines a deployment destination Cloud Deploy promotes a release
+# through. The list order IS the promotion order — element [0] is the first
+# stage, [n-1] is the last. The typical CD shape is two entries
+# (staging -> prod) which is the default below.
+#
+# Per-entry fields:
+#   - name             : pipeline-scoped target identifier. Lowercase letters,
+#                        digits, hyphens; must satisfy Cloud Deploy's name
+#                        regex `^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$`.
+#   - runtime          : "run" (Cloud Run) or "gke" (GKE). The preset's
+#                        google_clouddeploy_target dispatches on this value
+#                        to emit either a `run {}` or `gke {}` block.
+#   - runtime_target   : runtime-dispatched destination identifier.
+#                        For runtime="run": Cloud Run location (region),
+#                        e.g. "us-central1". May differ from var.region.
+#                        For runtime="gke": fully-qualified cluster ID,
+#                        e.g. "projects/<id>/locations/<loc>/clusters/<name>".
+#   - require_approval : optional bool, default false. When true, Cloud
+#                        Deploy halts the promotion to this target and
+#                        waits for an `gcloud deploy releases promote
+#                        --to-target` operator action. Typically only
+#                        flipped on for prod.
+variable "targets" {
+  description = "Ordered list of Cloud Deploy targets the pipeline promotes through (element [0] = first stage). Each target picks a runtime (run | gke) and a runtime-specific destination. Default is a staging -> prod Cloud Run pair in var.region; override for GKE-backed pipelines or multi-region rollouts."
+  type = list(object({
+    name             = string
+    runtime          = string
+    runtime_target   = string
+    require_approval = optional(bool, false)
+  }))
+  default = [
+    {
+      name             = "staging"
+      runtime          = "run"
+      runtime_target   = "us-central1"
+      require_approval = false
+    },
+    {
+      name             = "prod"
+      runtime          = "run"
+      runtime_target   = "us-central1"
+      require_approval = true
+    },
+  ]
+
+  validation {
+    condition     = length(var.targets) > 0
+    error_message = "targets must list at least one entry; an empty list creates a delivery pipeline with no promotion stages, which Cloud Deploy rejects at apply with INVALID_ARGUMENT."
+  }
+
+  validation {
+    condition     = alltrue([for t in var.targets : can(regex("^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$", t.name))])
+    error_message = "Every targets[*].name must satisfy Cloud Deploy's identifier regex: start with a lowercase letter, 1-63 chars, contain only lowercase letters / digits / hyphens, and end alphanumeric."
+  }
+
+  validation {
+    condition     = alltrue([for t in var.targets : contains(["run", "gke"], t.runtime)])
+    error_message = "Every targets[*].runtime must be one of: \"run\" (Cloud Run) or \"gke\" (GKE). Other runtimes (Cloud Build custom targets, multi-target deploys) are out of scope for the v1 preset."
+  }
+
+  validation {
+    condition     = alltrue([for t in var.targets : length(trimspace(t.runtime_target)) > 0])
+    error_message = "Every targets[*].runtime_target must be non-empty (Cloud Run location for runtime=\"run\"; fully-qualified GKE cluster ID for runtime=\"gke\")."
+  }
+
+  validation {
+    # Distinct names: Cloud Deploy's serial_pipeline.stages references
+    # targets by name, so duplicate names would silently collapse stages.
+    condition     = length(distinct([for t in var.targets : t.name])) == length(var.targets)
+    error_message = "Every targets[*].name must be unique within the list — Cloud Deploy promotion stages reference targets by name and duplicates would silently collapse pipeline stages."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Resource short names (overridable for length-constrained projects)
+# -----------------------------------------------------------------------------
+variable "service_account_short_name" {
+  description = "account_id for the Cloud Deploy runner SA. Hard cap is 30 chars (GCP-imposed). Default \"clouddeploy-runner\" (18 chars) leaves room for downstream consumers."
+  type        = string
+  default     = "clouddeploy-runner"
+
+  validation {
+    # `[a-z]([-a-z0-9]*[a-z0-9])` and 6-30 char length per GCP.
+    condition     = can(regex("^[a-z][-a-z0-9]{4,28}[a-z0-9]$", var.service_account_short_name))
+    error_message = "service_account_short_name must be 6-30 chars: lowercase letters / digits / hyphens, start with a letter, end alphanumeric."
+  }
+}
+
+variable "pipeline_short_name" {
+  description = "Cloud Deploy delivery-pipeline short name (combined with var.project to form the full pipeline name, bounded by Cloud Deploy's 63-char identifier cap). Default \"delivery\"."
+  type        = string
+  default     = "delivery"
+
+  validation {
+    # Cloud Deploy identifier regex (same as targets[*].name).
+    condition     = can(regex("^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$", var.pipeline_short_name))
+    error_message = "pipeline_short_name must satisfy Cloud Deploy's identifier regex: start with a lowercase letter, 1-63 chars, lowercase letters / digits / hyphens, end alphanumeric."
+  }
+}

--- a/pkg/composer/cloud_deploy_gcp_wiring_test.go
+++ b/pkg/composer/cloud_deploy_gcp_wiring_test.go
@@ -29,11 +29,30 @@ package composer
 //     check fires on the right surface (ui-core #192).
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// requireTfvarAssignment asserts that tfvars (the raw bytes of an
+// .auto.tfvars file) contains a top-level assignment of the form
+//
+//	<key> = <value>
+//
+// where the `=` may be preceded by any whitespace (the composer's
+// HCL pretty-printer column-aligns assignments and the gap width
+// changes whenever the longest key in the file changes). Anchored
+// to start-of-line so substrings appearing inside nested objects
+// or comments cannot satisfy the check.
+func requireTfvarAssignment(t *testing.T, tfvars, key, value, msg string) {
+	t.Helper()
+	pattern := `(?m)^` + regexp.QuoteMeta(key) + `\s*= ` + regexp.QuoteMeta(value) + `$`
+	matched, err := regexp.MatchString(pattern, tfvars)
+	require.NoError(t, err, "regexp compile error for %q", pattern)
+	require.True(t, matched, "%s\n--- tfvars ---\n%s", msg, tfvars)
+}
 
 // TestMapper_GCPCloudDeploy_DefaultConfig pins the no-config path. When
 // cfg.GCPCloudDeploy is nil the mapper MUST emit no Cloud Deploy specific
@@ -75,6 +94,13 @@ func TestMapper_GCPCloudDeploy_CallerSuppliedConfig(t *testing.T) {
 			ServiceAccountShortName: &saShort,
 			PipelineShortName:       &pipeShort,
 			Targets: []GCPCloudDeployTarget{
+				// targets[0]: RequireApproval intentionally nil — pins the
+				// per-element "leave it to the preset's optional(bool, false)
+				// default" path. A mapper bug that emitted require_approval=false
+				// unconditionally for nil pointers would silently couple the
+				// on-the-wire shape to a hard-coded default and break that
+				// invariant — this assertion catches it.
+				{Name: "qa", Runtime: "run", RuntimeTarget: "us-west1"},
 				{Name: "staging", Runtime: "run", RuntimeTarget: "us-east1", RequireApproval: &noApprove},
 				{Name: "prod", Runtime: "gke", RuntimeTarget: "projects/p/locations/us-central1/clusters/c", RequireApproval: &approve},
 			},
@@ -90,17 +116,26 @@ func TestMapper_GCPCloudDeploy_CallerSuppliedConfig(t *testing.T) {
 
 	targets, ok := vals["targets"].([]any)
 	require.True(t, ok, "targets must be a []any (each entry is a map per the preset's list-of-objects schema)")
-	require.Len(t, targets, 2)
+	require.Len(t, targets, 3)
 
-	first, ok := targets[0].(map[string]any)
+	zeroth, ok := targets[0].(map[string]any)
 	require.True(t, ok, "targets[0] must be a map")
+	require.Equal(t, "qa", zeroth["name"])
+	require.Equal(t, "run", zeroth["runtime"])
+	require.Equal(t, "us-west1", zeroth["runtime_target"])
+	_, hasApproval := zeroth["require_approval"]
+	require.False(t, hasApproval,
+		"mapper must NOT emit require_approval when caller left the per-element *bool nil — preset's optional(bool, false) default must apply per element")
+
+	first, ok := targets[1].(map[string]any)
+	require.True(t, ok, "targets[1] must be a map")
 	require.Equal(t, "staging", first["name"])
 	require.Equal(t, "run", first["runtime"])
 	require.Equal(t, "us-east1", first["runtime_target"])
 	require.Equal(t, false, first["require_approval"])
 
-	second, ok := targets[1].(map[string]any)
-	require.True(t, ok, "targets[1] must be a map")
+	second, ok := targets[2].(map[string]any)
+	require.True(t, ok, "targets[2] must be a map")
 	require.Equal(t, "prod", second["name"])
 	require.Equal(t, "gke", second["runtime"])
 	require.Equal(t, "projects/p/locations/us-central1/clusters/c", second["runtime_target"])
@@ -209,6 +244,7 @@ func TestComposeStack_GCPCloudDeploy_CallerSuppliedConfig(t *testing.T) {
 	t.Parallel()
 
 	pipeShort := "release"
+	saShort := "deployer-sa"
 	c := newTestClient()
 	out, err := c.ComposeStack(ComposeStackOpts{
 		Cloud:        "gcp",
@@ -217,7 +253,8 @@ func TestComposeStack_GCPCloudDeploy_CallerSuppliedConfig(t *testing.T) {
 		Cfg: &Config{
 			Region: "us-central1",
 			GCPCloudDeploy: &GCPCloudDeployConfig{
-				PipelineShortName: &pipeShort,
+				ServiceAccountShortName: &saShort,
+				PipelineShortName:       &pipeShort,
 				Targets: []GCPCloudDeployTarget{
 					{Name: "qa", Runtime: "run", RuntimeTarget: "us-west2"},
 					{Name: "prod", Runtime: "run", RuntimeTarget: "us-east1"},
@@ -234,14 +271,23 @@ func TestComposeStack_GCPCloudDeploy_CallerSuppliedConfig(t *testing.T) {
 	require.True(t, ok)
 	tfvarsStr := string(tfvars)
 
-	// Top-level scalar: pin the full assignment so a future composer change
-	// that re-keys / re-formats the line breaks the test instead of
-	// silently passing. The composer namespaces variables with
+	// Top-level scalars: pin the full assignments so a future composer
+	// change that re-keys / re-formats the line breaks the test instead
+	// of silently passing. The composer namespaces variables with
 	// `<component>_` prefix to avoid collisions across modules in the
 	// composed root (CLAUDE.md "Downstream Composition"), so the tfvars
-	// key is gcp_cloud_deploy_<var>.
-	require.Contains(t, tfvarsStr, `gcp_cloud_deploy_pipeline_short_name = "release"`,
+	// keys are gcp_cloud_deploy_<var>. The HCL pretty-printer column-
+	// aligns `=` across the file so we use a multiline-anchored regex
+	// with flexible whitespace before `=` rather than a fixed-width
+	// substring match. Every caller-controllable mapper output is end-
+	// to-end-pinned here (mapper -> tfvars file) so a bug emitting a
+	// value under the wrong namespaced key would fail this test, not
+	// just the lower-level TestMapperKeysSubsetOfModuleVariables
+	// invariant.
+	requireTfvarAssignment(t, tfvarsStr, "gcp_cloud_deploy_pipeline_short_name", `"release"`,
 		"caller-supplied pipeline_short_name must flow through to tfvars under the namespaced key")
+	requireTfvarAssignment(t, tfvarsStr, "gcp_cloud_deploy_service_account_short_name", `"deployer-sa"`,
+		"caller-supplied service_account_short_name must flow through to tfvars under the namespaced key")
 	// Nested object values inside the targets list have column-aligned `=`
 	// (whitespace width is a function of the longest field name in the
 	// block — `runtime_target` here), so we can't pin a single-space
@@ -250,7 +296,13 @@ func TestComposeStack_GCPCloudDeploy_CallerSuppliedConfig(t *testing.T) {
 	// a comment / unrelated key elsewhere in the file cannot satisfy it.
 	targetsIdx := strings.Index(tfvarsStr, "gcp_cloud_deploy_targets = [")
 	require.NotEqual(t, -1, targetsIdx, "gcp_cloud_deploy_targets list block must be emitted in tfvars")
-	targetsSection := tfvarsStr[targetsIdx:]
+	// Bound the section to the matching `}]` so values from later tfvars
+	// can't satisfy the per-target substring checks below. The list
+	// contains nested `{}` blocks but no nested `[]`, so the first `}]`
+	// after targetsIdx closes the targets list.
+	closeOffset := strings.Index(tfvarsStr[targetsIdx:], "}]")
+	require.NotEqual(t, -1, closeOffset, "targets list block must close with `}]`\n--- tfvars ---\n"+tfvarsStr)
+	targetsSection := tfvarsStr[targetsIdx : targetsIdx+closeOffset+2]
 	require.Contains(t, targetsSection, `"qa"`,
 		"caller-supplied target name \"qa\" must land inside the targets list")
 	require.Contains(t, targetsSection, `"us-west2"`,
@@ -303,7 +355,9 @@ func TestGCPIAMPermissions_CloudDeployCovered(t *testing.T) {
 	require.Contains(t, required, "iam.serviceAccounts.create",
 		"runner SA create permission must be in the required set")
 	require.Contains(t, required, "resourcemanager.projects.setIamPolicy",
-		"project IAM binding permission must be in the required set (the runner SA needs roles/clouddeploy.* bound at the project level)")
+		"project IAM binding permission must be in the required set (the runner SA needs roles/clouddeploy.jobRunner bound at the project level — releaser is held out-of-stack by the release-creator, not the runner)")
+	require.Contains(t, required, "serviceusage.services.enable",
+		"service-enable permission must be in the required set — the preset's google_project_service activates clouddeploy.googleapis.com, and without this perm the first apply fails with SERVICE_DISABLED 403 on a fresh project")
 }
 
 // TestGCPServices_CloudDeployCovered pins the gcp_services.go entry. The

--- a/pkg/composer/cloud_deploy_gcp_wiring_test.go
+++ b/pkg/composer/cloud_deploy_gcp_wiring_test.go
@@ -29,6 +29,7 @@ package composer
 //     check fires on the right surface (ui-core #192).
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -233,14 +234,31 @@ func TestComposeStack_GCPCloudDeploy_CallerSuppliedConfig(t *testing.T) {
 	require.True(t, ok)
 	tfvarsStr := string(tfvars)
 
-	// caller-supplied PipelineShortName must override default.
-	require.Contains(t, tfvarsStr, "release",
-		"caller-supplied pipeline_short_name must flow through to tfvars")
-	// caller-supplied target identifiers must be present.
-	require.Contains(t, tfvarsStr, "qa",
-		"caller-supplied target name \"qa\" must flow through to tfvars")
-	require.Contains(t, tfvarsStr, "us-west2",
-		"caller-supplied runtime_target must flow through to tfvars")
+	// Top-level scalar: pin the full assignment so a future composer change
+	// that re-keys / re-formats the line breaks the test instead of
+	// silently passing. The composer namespaces variables with
+	// `<component>_` prefix to avoid collisions across modules in the
+	// composed root (CLAUDE.md "Downstream Composition"), so the tfvars
+	// key is gcp_cloud_deploy_<var>.
+	require.Contains(t, tfvarsStr, `gcp_cloud_deploy_pipeline_short_name = "release"`,
+		"caller-supplied pipeline_short_name must flow through to tfvars under the namespaced key")
+	// Nested object values inside the targets list have column-aligned `=`
+	// (whitespace width is a function of the longest field name in the
+	// block — `runtime_target` here), so we can't pin a single-space
+	// `key = value` form. Scope the substring check to the
+	// `gcp_cloud_deploy_targets = [...]` section so a value appearing in
+	// a comment / unrelated key elsewhere in the file cannot satisfy it.
+	targetsIdx := strings.Index(tfvarsStr, "gcp_cloud_deploy_targets = [")
+	require.NotEqual(t, -1, targetsIdx, "gcp_cloud_deploy_targets list block must be emitted in tfvars")
+	targetsSection := tfvarsStr[targetsIdx:]
+	require.Contains(t, targetsSection, `"qa"`,
+		"caller-supplied target name \"qa\" must land inside the targets list")
+	require.Contains(t, targetsSection, `"us-west2"`,
+		"caller-supplied runtime_target \"us-west2\" must land inside the targets list")
+	require.Contains(t, targetsSection, `"prod"`,
+		"caller-supplied target name \"prod\" must land inside the targets list")
+	require.Contains(t, targetsSection, `"us-east1"`,
+		"caller-supplied runtime_target \"us-east1\" must land inside the targets list")
 }
 
 // TestComponentSelected_GCPCloudDeploy pins the coherence.go entry. Without

--- a/pkg/composer/cloud_deploy_gcp_wiring_test.go
+++ b/pkg/composer/cloud_deploy_gcp_wiring_test.go
@@ -1,0 +1,309 @@
+package composer
+
+// cloud_deploy_gcp_wiring_test.go covers the issue #613 composer wiring for
+// the gcp/cloud_deploy preset (Cloud Deploy managed delivery pipeline):
+//
+//   - ComponentKey + PresetKeyMap + ModulePath + AllComponentKeys +
+//     ComposeOrder registry entries are exercised by
+//     TestAllComponentKeysCoversPresetKeyMap and
+//     TestMapperKeysSubsetOfModuleVariables (both in sibling files).
+//   - Default mapper provides every required variable — exercised by
+//     TestEveryRequiredVariableIsMappedOrWired.
+//
+// The tests below pin:
+//   - Mapper default (cfg.GCPCloudDeploy == nil) emits nothing — the preset's
+//     variables.tf defaults (staging->prod Cloud Run pair) must apply.
+//   - Mapper caller-supplied (full config) flows through verbatim.
+//   - Mapper partial-config emits ONLY the supplied sub-field — catches the
+//     class of bug where the mapper would unconditionally emit empty
+//     slices / false bools that override module defaults.
+//   - Forward wiring: selecting KeyGCPCloudDeploy emits
+//     `module "gcp_cloud_deploy"` in the composed root + the auto.tfvars
+//     file.
+//   - End-to-end ComposeStack with caller-supplied targets carries those
+//     targets into the tfvars file.
+//   - ComponentSelected pins the coherence.go entry (mirrors
+//     TestComponentSelected_GCPGitHubActions — without it the orphan-strip
+//     pass silently clears cfg.GCPCloudDeploy).
+//   - GCPIAMPermissions pins the iam_actions.go entry so the SA pre-flight
+//     check fires on the right surface (ui-core #192).
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMapper_GCPCloudDeploy_DefaultConfig pins the no-config path. When
+// cfg.GCPCloudDeploy is nil the mapper MUST emit no Cloud Deploy specific
+// tfvars — the preset's variables.tf defaults are the source of truth
+// (staging->prod Cloud Run pair, "delivery" pipeline short name,
+// "clouddeploy-runner" SA short name). Emitting an empty list or empty
+// string here would override those defaults and break the single-module
+// preview UX.
+func TestMapper_GCPCloudDeploy_DefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyGCPCloudDeploy, &Components{}, &Config{}, "demo", "us-central1")
+	require.NoError(t, err)
+
+	// The mapper should NOT emit any of the optional Cloud Deploy fields
+	// when the caller hasn't set them. The composer's preset-inspection
+	// layer will fall back to variables.tf defaults for every unset key.
+	for _, k := range []string{"service_account_short_name", "pipeline_short_name", "targets"} {
+		_, has := vals[k]
+		require.False(t, has,
+			"mapper must NOT emit %q when cfg.GCPCloudDeploy is nil — module variables.tf default must win", k)
+	}
+}
+
+// TestMapper_GCPCloudDeploy_CallerSuppliedConfig pins the full caller-
+// supplied path. Every sub-field flows through to its module variable
+// unchanged.
+func TestMapper_GCPCloudDeploy_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	saShort := "deployer"
+	pipeShort := "main-pipeline"
+	approve := true
+	noApprove := false
+
+	cfg := &Config{
+		GCPCloudDeploy: &GCPCloudDeployConfig{
+			ServiceAccountShortName: &saShort,
+			PipelineShortName:       &pipeShort,
+			Targets: []GCPCloudDeployTarget{
+				{Name: "staging", Runtime: "run", RuntimeTarget: "us-east1", RequireApproval: &noApprove},
+				{Name: "prod", Runtime: "gke", RuntimeTarget: "projects/p/locations/us-central1/clusters/c", RequireApproval: &approve},
+			},
+		},
+	}
+
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyGCPCloudDeploy, &Components{}, cfg, "demo", "us-central1")
+	require.NoError(t, err)
+
+	require.Equal(t, "deployer", vals["service_account_short_name"])
+	require.Equal(t, "main-pipeline", vals["pipeline_short_name"])
+
+	targets, ok := vals["targets"].([]any)
+	require.True(t, ok, "targets must be a []any (each entry is a map per the preset's list-of-objects schema)")
+	require.Len(t, targets, 2)
+
+	first, ok := targets[0].(map[string]any)
+	require.True(t, ok, "targets[0] must be a map")
+	require.Equal(t, "staging", first["name"])
+	require.Equal(t, "run", first["runtime"])
+	require.Equal(t, "us-east1", first["runtime_target"])
+	require.Equal(t, false, first["require_approval"])
+
+	second, ok := targets[1].(map[string]any)
+	require.True(t, ok, "targets[1] must be a map")
+	require.Equal(t, "prod", second["name"])
+	require.Equal(t, "gke", second["runtime"])
+	require.Equal(t, "projects/p/locations/us-central1/clusters/c", second["runtime_target"])
+	require.Equal(t, true, second["require_approval"])
+}
+
+// TestMapper_GCPCloudDeploy_PartialConfig pins the partial-config rule.
+// When only one optional sub-field is set the mapper MUST emit only that
+// sub-field; the preset's variables.tf defaults must apply to the rest.
+// Without this rule the mapper would emit empty slices / strings /
+// false-bools that override the preset's defaults, regressing the
+// single-module preview UX.
+func TestMapper_GCPCloudDeploy_PartialConfig(t *testing.T) {
+	t.Parallel()
+
+	pipeShort := "release-pipeline"
+	cfg := &Config{
+		GCPCloudDeploy: &GCPCloudDeployConfig{
+			PipelineShortName: &pipeShort,
+			// ServiceAccountShortName, Targets intentionally left zero.
+		},
+	}
+
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyGCPCloudDeploy, &Components{}, cfg, "demo", "us-central1")
+	require.NoError(t, err)
+
+	require.Equal(t, "release-pipeline", vals["pipeline_short_name"])
+
+	_, hasSA := vals["service_account_short_name"]
+	require.False(t, hasSA,
+		"mapper must NOT emit service_account_short_name when caller left the *string nil — module default \"clouddeploy-runner\" must win")
+	_, hasTargets := vals["targets"]
+	require.False(t, hasTargets,
+		"mapper must NOT emit targets when caller left the slice nil — module default (staging->prod Cloud Run pair) must win")
+}
+
+// TestMapper_GCPCloudDeploy_EmptyStringShortNameIsIgnored confirms the
+// trimspace gate inside the mapper: a caller-supplied *string pointer to
+// an empty / whitespace-only value is treated as "not supplied" rather
+// than emitted as an empty string (which the preset's regex validation
+// would reject at plan-time with a noisy error).
+func TestMapper_GCPCloudDeploy_EmptyStringShortNameIsIgnored(t *testing.T) {
+	t.Parallel()
+
+	empty := ""
+	whitespace := "   "
+
+	cfg := &Config{
+		GCPCloudDeploy: &GCPCloudDeployConfig{
+			ServiceAccountShortName: &empty,
+			PipelineShortName:       &whitespace,
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyGCPCloudDeploy, &Components{}, cfg, "demo", "us-central1")
+	require.NoError(t, err)
+
+	_, hasSA := vals["service_account_short_name"]
+	require.False(t, hasSA,
+		"empty-string ServiceAccountShortName must be treated as not supplied — module default wins")
+	_, hasPipe := vals["pipeline_short_name"]
+	require.False(t, hasPipe,
+		"whitespace-only PipelineShortName must be treated as not supplied — module default wins")
+}
+
+// TestComposeStack_GCPCloudDeploy_Forward exercises the end-to-end
+// composer: selecting KeyGCPCloudDeploy must emit the
+// `module "gcp_cloud_deploy"` block in the composed root and produce the
+// corresponding auto.tfvars file.
+func TestComposeStack_GCPCloudDeploy_Forward(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPCloudDeploy},
+		Comps:        &Components{Cloud: "GCP"},
+		Cfg:          &Config{Region: "us-central1"},
+		Project:      "test",
+		Region:       "us-central1",
+		GCPProjectID: "test-project-12345",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok, "composed root must contain main.tf")
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, `module "gcp_cloud_deploy"`,
+		"composed root must declare module gcp_cloud_deploy when KeyGCPCloudDeploy is selected")
+	require.Contains(t, rootStr, `"./gcp/cloud_deploy"`,
+		"module source path must resolve to gcp/cloud_deploy per ModulePath")
+
+	// The tfvars file lands as gcp_cloud_deploy.auto.tfvars; with default
+	// config (no overrides) it should be present even if it carries only
+	// the always-emitted project / region / environment trio.
+	_, ok = out["/gcp_cloud_deploy.auto.tfvars"]
+	require.True(t, ok, "expected gcp_cloud_deploy.auto.tfvars")
+}
+
+// TestComposeStack_GCPCloudDeploy_CallerSuppliedConfig exercises the end-
+// to-end composer with caller-supplied targets. The custom target list
+// must flow through to the tfvars file.
+func TestComposeStack_GCPCloudDeploy_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	pipeShort := "release"
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPCloudDeploy},
+		Comps:        &Components{Cloud: "GCP"},
+		Cfg: &Config{
+			Region: "us-central1",
+			GCPCloudDeploy: &GCPCloudDeployConfig{
+				PipelineShortName: &pipeShort,
+				Targets: []GCPCloudDeployTarget{
+					{Name: "qa", Runtime: "run", RuntimeTarget: "us-west2"},
+					{Name: "prod", Runtime: "run", RuntimeTarget: "us-east1"},
+				},
+			},
+		},
+		Project:      "test",
+		Region:       "us-central1",
+		GCPProjectID: "test-project-12345",
+	})
+	require.NoError(t, err)
+
+	tfvars, ok := out["/gcp_cloud_deploy.auto.tfvars"]
+	require.True(t, ok)
+	tfvarsStr := string(tfvars)
+
+	// caller-supplied PipelineShortName must override default.
+	require.Contains(t, tfvarsStr, "release",
+		"caller-supplied pipeline_short_name must flow through to tfvars")
+	// caller-supplied target identifiers must be present.
+	require.Contains(t, tfvarsStr, "qa",
+		"caller-supplied target name \"qa\" must flow through to tfvars")
+	require.Contains(t, tfvarsStr, "us-west2",
+		"caller-supplied runtime_target must flow through to tfvars")
+}
+
+// TestComponentSelected_GCPCloudDeploy pins the coherence.go entry. Without
+// it ComponentSelected returns false for KeyGCPCloudDeploy and the orphan-
+// strip pass silently clears cfg.GCPCloudDeploy even when
+// comps.GCPCloudDeploy=&true.
+func TestComponentSelected_GCPCloudDeploy(t *testing.T) {
+	t.Parallel()
+
+	tr := true
+	c := &Components{GCPCloudDeploy: &tr}
+	require.True(t, ComponentSelected(c, KeyGCPCloudDeploy),
+		"ComponentSelected must return true when comps.GCPCloudDeploy=&true")
+
+	fa := false
+	c2 := &Components{GCPCloudDeploy: &fa}
+	require.False(t, ComponentSelected(c2, KeyGCPCloudDeploy),
+		"ComponentSelected must return false when comps.GCPCloudDeploy=&false (explicit deselect)")
+
+	c3 := &Components{}
+	require.False(t, ComponentSelected(c3, KeyGCPCloudDeploy),
+		"ComponentSelected must return false when comps.GCPCloudDeploy is nil")
+}
+
+// TestGCPIAMPermissions_CloudDeployCovered pins the iam_actions.go entry.
+// Without it RequiredGCPIAMPermissions silently omits the Cloud Deploy
+// permissions a real deploy needs — surfacing as a 403 at apply time
+// instead of at the SimulatePrincipalPolicy / testIamPermissions
+// pre-deploy check (ui-core #192).
+func TestGCPIAMPermissions_CloudDeployCovered(t *testing.T) {
+	t.Parallel()
+
+	perms, ok := GCPIAMPermissions[KeyGCPCloudDeploy]
+	require.True(t, ok, "GCPIAMPermissions must have an entry for KeyGCPCloudDeploy")
+	require.NotEmpty(t, perms, "GCPIAMPermissions[KeyGCPCloudDeploy] must list at least one permission")
+
+	required := RequiredGCPIAMPermissions([]ComponentKey{KeyGCPCloudDeploy})
+	require.Contains(t, required, "clouddeploy.deliveryPipelines.create",
+		"delivery pipeline create permission must be in the required set")
+	require.Contains(t, required, "clouddeploy.targets.create",
+		"target create permission must be in the required set")
+	require.Contains(t, required, "iam.serviceAccounts.create",
+		"runner SA create permission must be in the required set")
+	require.Contains(t, required, "resourcemanager.projects.setIamPolicy",
+		"project IAM binding permission must be in the required set (the runner SA needs roles/clouddeploy.* bound at the project level)")
+}
+
+// TestGCPServices_CloudDeployCovered pins the gcp_services.go entry. The
+// preset's google_project_service activates clouddeploy.googleapis.com,
+// but the pre-deploy serviceusage.batchGet check needs an entry here to
+// surface a missing-API error on a fresh project before terraform apply.
+func TestGCPServices_CloudDeployCovered(t *testing.T) {
+	t.Parallel()
+
+	services, ok := GCPServices[KeyGCPCloudDeploy]
+	require.True(t, ok, "GCPServices must have an entry for KeyGCPCloudDeploy")
+	require.NotEmpty(t, services, "GCPServices[KeyGCPCloudDeploy] must list at least one service")
+
+	required := RequiredGCPServices([]ComponentKey{KeyGCPCloudDeploy})
+	names := make([]string, 0, len(required))
+	for _, s := range required {
+		names = append(names, s.Name)
+	}
+	require.Contains(t, names, "clouddeploy.googleapis.com",
+		"Cloud Deploy service must be in the required set so a fresh project's missing-API check catches it pre-deploy")
+}

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -140,6 +140,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.GCPIdentityPlatform)
 	case KeyGCPCloudBuild:
 		return boolPtrTrue(c.GCPCloudBuild)
+	case KeyGCPCloudDeploy:
+		return boolPtrTrue(c.GCPCloudDeploy)
 	case KeyGCPCloudDNS:
 		return boolPtrTrue(c.GCPCloudDNS)
 	case KeyGCPGitHubActions:
@@ -298,7 +300,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,
 		KeyGCPPubSub, KeyGCPCloudLogging,
 		KeyGCPIdentityPlatform, KeyGCPAPIGateway, KeyGCPBackups,
-		KeyGCPCloudDNS, KeyGCPGitHubActions:
+		KeyGCPCloudDNS, KeyGCPGitHubActions, KeyGCPCloudDeploy:
 		return true
 	}
 	return false

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -83,6 +83,7 @@ const (
 	KeyGCPCloudMonitoring  ComponentKey = "gcp_cloud_monitoring"
 	KeyGCPIdentityPlatform ComponentKey = "gcp_identity_platform"
 	KeyGCPCloudBuild       ComponentKey = "gcp_cloud_build"
+	KeyGCPCloudDeploy      ComponentKey = "gcp_cloud_deploy"
 	KeyGCPFirestore        ComponentKey = "gcp_firestore"
 	KeyGCPVertexAI         ComponentKey = "gcp_vertex_ai"
 	KeyGCPCloudArmor       ComponentKey = "gcp_cloud_armor"
@@ -162,6 +163,12 @@ var ComposeOrder = []ComponentKey{
 	// upstream GCP preset so position is not load-bearing — placed
 	// alongside the AWS sibling for reviewability.
 	KeyGCPGitHubActions,
+	// GCP Cloud Deploy delivery-pipeline preset (#613). The pipeline is
+	// independent of any upstream GCP preset in this repo (its targets
+	// reference Cloud Run regions / GKE cluster IDs the caller supplies
+	// out-of-stack), so position is not load-bearing — placed alongside
+	// the AWS CodePipeline sibling for reviewability.
+	KeyGCPCloudDeploy,
 	KeyArch,
 	KeyCloud,
 	KeyComposer,
@@ -227,6 +234,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyGCPCloudMonitoring:  "gcp/cloud_monitoring",
 	KeyGCPIdentityPlatform: "gcp/identity_platform",
 	KeyGCPCloudBuild:       "gcp/cloud_build",
+	KeyGCPCloudDeploy:      "gcp/cloud_deploy",
 	KeyGCPBackups:          "gcp/backups",
 	KeyGCPCloudDNS:         "gcp/cloud_dns",
 	KeyGCPGitHubActions:    "gcp/github_actions",
@@ -407,6 +415,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyGCPBastion:              "bastion",
 	KeyGCPCloudDNS:             "cloud_dns",
 	KeyGCPGitHubActions:        "github_actions",
+	KeyGCPCloudDeploy:          "cloud_deploy",
 }
 
 // GetPresetPath returns the cloud-prefixed preset path for a component.
@@ -503,6 +512,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyGCPBastion,
 	KeyGCPCloudArmor,
 	KeyGCPCloudBuild,
+	KeyGCPCloudDeploy,
 	KeyGCPCloudDNS,
 	KeyGCPCloudFunctions,
 	KeyGCPCloudKMS,

--- a/pkg/composer/gcp_services.go
+++ b/pkg/composer/gcp_services.go
@@ -84,6 +84,16 @@ var GCPServices = map[ComponentKey][]GCPService{
 		{Name: "iamcredentials.googleapis.com", Title: "IAM Service Account Credentials"},
 		{Name: "sts.googleapis.com", Title: "Security Token Service"},
 	},
+	// GCP Cloud Deploy delivery-pipeline preset (#613). The preset enables
+	// clouddeploy.googleapis.com itself via google_project_service; the
+	// always-required IAM activation covers the runner SA + role bindings.
+	// Without this entry, the pre-deploy serviceusage.batchGet check
+	// would silently omit Cloud Deploy and the first
+	// google_clouddeploy_delivery_pipeline create fails with a
+	// SERVICE_DISABLED 403.
+	KeyGCPCloudDeploy: {
+		{Name: "clouddeploy.googleapis.com", Title: "Cloud Deploy"},
+	},
 	// Components that need no extra service beyond the always-required set
 	// (covered by Compute / always-required entries):
 	KeyGCPVPC:          nil,

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -178,8 +178,9 @@ var GCPIAMPermissions = map[ComponentKey][]string{
 	// needs delivery-pipeline + target create capability (the two Cloud
 	// Deploy resource types this preset manages), service-account create
 	// (for the runner SA), and project-level IAM binding capability (for
-	// the two roles/clouddeploy.* grants on that SA), plus the API enable
-	// for clouddeploy.googleapis.com.
+	// the single roles/clouddeploy.jobRunner grant on that SA — releaser
+	// is granted out-of-stack to the principal that cuts releases), plus
+	// the API enable for clouddeploy.googleapis.com.
 	KeyGCPCloudDeploy: {
 		"clouddeploy.deliveryPipelines.create",
 		"clouddeploy.targets.create",

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -174,6 +174,19 @@ var GCPIAMPermissions = map[ComponentKey][]string{
 		"resourcemanager.projects.setIamPolicy",
 		"serviceusage.services.enable",
 	},
+	// GCP Cloud Deploy delivery-pipeline preset (#613). Deploying SA
+	// needs delivery-pipeline + target create capability (the two Cloud
+	// Deploy resource types this preset manages), service-account create
+	// (for the runner SA), and project-level IAM binding capability (for
+	// the two roles/clouddeploy.* grants on that SA), plus the API enable
+	// for clouddeploy.googleapis.com.
+	KeyGCPCloudDeploy: {
+		"clouddeploy.deliveryPipelines.create",
+		"clouddeploy.targets.create",
+		"iam.serviceAccounts.create",
+		"resourcemanager.projects.setIamPolicy",
+		"serviceusage.services.enable",
+	},
 	// Components that need no extra permission beyond the always-required set:
 	KeyGCPVPC:          nil,
 	KeyGCPCompute:      nil,

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1124,6 +1124,48 @@ func (m DefaultMapper) BuildModuleValues(
 				vals["deploy_roles"] = rs
 			}
 		}
+
+	case KeyGCPCloudDeploy:
+		// GCP Cloud Deploy delivery pipeline (#613). Every field is optional —
+		// only emit the tfvar when the caller set a value, so the preset's
+		// variables.tf defaults (staging->prod Cloud Run pair in var.region;
+		// "delivery" pipeline short name; "clouddeploy-runner" SA short name)
+		// stay in force when the caller doesn't override. The partial-config
+		// pattern catches a class of bug where the mapper would
+		// unconditionally emit empty slices / false bools that override
+		// the module's defaults — see
+		// TestMapper_GCPCloudDeploy_PartialConfig.
+		if cfg != nil && cfg.GCPCloudDeploy != nil {
+			cd := cfg.GCPCloudDeploy
+			if cd.ServiceAccountShortName != nil && strings.TrimSpace(*cd.ServiceAccountShortName) != "" {
+				vals["service_account_short_name"] = strings.TrimSpace(*cd.ServiceAccountShortName)
+			}
+			if cd.PipelineShortName != nil && strings.TrimSpace(*cd.PipelineShortName) != "" {
+				vals["pipeline_short_name"] = strings.TrimSpace(*cd.PipelineShortName)
+			}
+			if len(cd.Targets) > 0 {
+				targets := make([]any, len(cd.Targets))
+				for i, t := range cd.Targets {
+					entry := map[string]any{
+						"name":           t.Name,
+						"runtime":        t.Runtime,
+						"runtime_target": t.RuntimeTarget,
+					}
+					// require_approval is an optional object attribute on
+					// the preset's var.targets schema (default false). Only
+					// emit it when the caller set the *bool — leaving it
+					// out lets the preset's `optional(bool, false)` default
+					// apply per element. Emitting `false` explicitly would
+					// be equivalent but couples the on-the-wire shape to
+					// every caller's mental model of the default.
+					if t.RequireApproval != nil {
+						entry["require_approval"] = *t.RequireApproval
+					}
+					targets[i] = entry
+				}
+				vals["targets"] = targets
+			}
+		}
 	}
 
 	return vals, nil

--- a/pkg/composer/presets.go
+++ b/pkg/composer/presets.go
@@ -92,7 +92,7 @@ func (c *Client) ListAvailableComponentKeys() ([]string, error) {
 		KeyGCPGCS, KeyGCPCloudKMS, KeyGCPSecretManager, KeyGCPVertexAI,
 		KeyGCPPubSub, KeyGCPCloudLogging, KeyGCPCloudMonitoring,
 		KeyGCPIdentityPlatform, KeyGCPCloudBuild, KeyGCPBackups,
-		KeyGCPCloudDNS, KeyGCPGitHubActions,
+		KeyGCPCloudDNS, KeyGCPGitHubActions, KeyGCPCloudDeploy,
 	}
 
 	for _, cloud := range clouds {

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -75,6 +75,7 @@ type Components struct {
 	GCPCloudMonitoring  *bool  `json:"gcp_cloud_monitoring,omitempty"`
 	GCPIdentityPlatform *bool  `json:"gcp_identity_platform,omitempty"`
 	GCPCloudBuild       *bool  `json:"gcp_cloud_build,omitempty"`
+	GCPCloudDeploy      *bool  `json:"gcp_cloud_deploy,omitempty"`
 	GCPCloudDNS         *bool  `json:"gcp_cloud_dns,omitempty"`
 	GCPGitHubActions    *bool  `json:"gcp_github_actions,omitempty"`
 	GCPBackups          *struct {
@@ -382,6 +383,16 @@ type Config struct {
 	// on the deploy SA.
 	GCPGitHubActions *GCPGitHubActionsConfig `json:"gcp_github_actions,omitempty"`
 
+	// GCPCloudDeploy carries the caller-supplied Cloud Deploy delivery-
+	// pipeline configuration (#613). Every field is optional; the mapper
+	// only emits its tfvar when set so the preset's variables.tf defaults
+	// (staging->prod Cloud Run pair in var.region) apply when callers
+	// don't override. Targets is the ordered promotion chain — element [0]
+	// is the first stage. ServiceAccountShortName / PipelineShortName let
+	// callers rename the runner SA / pipeline when the var.project prefix
+	// alone would collide with downstream consumers.
+	GCPCloudDeploy *GCPCloudDeployConfig `json:"gcp_cloud_deploy,omitempty"`
+
 	GCPBackups *struct {
 		Compute *struct {
 			FrequencyHours int `json:"frequencyHours,omitempty"`
@@ -407,6 +418,36 @@ type GCPGitHubActionsConfig struct {
 	AllowedTags        []string `json:"allowedTags,omitempty"`
 	AllowedPullRequest *bool    `json:"allowedPullRequest,omitempty"`
 	DeployRoles        []string `json:"deployRoles,omitempty"`
+}
+
+// GCPCloudDeployTarget is a single entry in GCPCloudDeployConfig.Targets.
+// Mirrors the gcp/cloud_deploy preset's var.targets list-of-objects shape:
+//   - Name: pipeline-scoped target identifier (short form; the preset prefixes
+//     it with var.project before sending to Cloud Deploy).
+//   - Runtime: "run" (Cloud Run) | "gke" (GKE).
+//   - RuntimeTarget: runtime-dispatched destination. For runtime="run", a
+//     Cloud Run region (e.g. "us-central1"). For runtime="gke", a fully-
+//     qualified cluster ID ("projects/<id>/locations/<loc>/clusters/<name>").
+//   - RequireApproval: optional, default false. When true, Cloud Deploy halts
+//     promotion to this target and waits for a manual operator step.
+//
+// Named (not inline) for the same UX reasons as GCPGitHubActionsConfig.
+type GCPCloudDeployTarget struct {
+	Name            string `json:"name"`
+	Runtime         string `json:"runtime"`
+	RuntimeTarget   string `json:"runtimeTarget"`
+	RequireApproval *bool  `json:"requireApproval,omitempty"`
+}
+
+// GCPCloudDeployConfig is the caller-facing config for the gcp/cloud_deploy
+// preset (#613). Every field is optional — the mapper only emits its tfvar
+// when set, so the preset's variables.tf defaults (staging->prod Cloud Run
+// pair in var.region; "delivery" pipeline short name; "clouddeploy-runner"
+// SA short name) apply when callers don't override.
+type GCPCloudDeployConfig struct {
+	ServiceAccountShortName *string                `json:"serviceAccountShortName,omitempty"`
+	PipelineShortName       *string                `json:"pipelineShortName,omitempty"`
+	Targets                 []GCPCloudDeployTarget `json:"targets,omitempty"`
 }
 
 // VarEntry holds a module variable name and a value (or nil). RawExpr can be used for expressions.
@@ -452,6 +493,7 @@ func (c *Components) Normalize() {
 		c.GCPCloudMonitoring = nil
 		c.GCPIdentityPlatform = nil
 		c.GCPCloudBuild = nil
+		c.GCPCloudDeploy = nil
 		c.GCPCloudDNS = nil
 		c.GCPGitHubActions = nil
 		c.GCPBackups = nil
@@ -559,6 +601,7 @@ func (c *Config) Normalize() {
 		c.GCPLoadbalancer = nil
 		c.GCPCloudDNS = nil
 		c.GCPGitHubActions = nil
+		c.GCPCloudDeploy = nil
 		c.GCPBackups = nil
 		// AWSCloudfront.CachePaths is a within-prefixed deprecated sub-field;
 		// migrate to OriginPath and clear. Distinct from the legacy Cloudfront

--- a/pkg/observability/display.go
+++ b/pkg/observability/display.go
@@ -161,6 +161,8 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "GCP Cloud Armor"
 	case composer.KeyGCPCloudBuild:
 		return "GCP Cloud Build"
+	case composer.KeyGCPCloudDeploy:
+		return "GCP Cloud Deploy"
 	case composer.KeyGCPCloudFunctions:
 		return "GCP Cloud Functions"
 	case composer.KeyGCPIdentityPlatform:

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -69,8 +69,9 @@ var configExtractorAllowlist = map[string]string{
 	// own SDK inspector — extraction is handled by aws_eks (#204, #224).
 	"aws_eks_nodegroup": "[no-inspector] EKS node group is covered by the aws_eks inspector (#204)",
 
-	"gcp_backups":   "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
-	"gcp_cloud_dns": "[no-inspector] Cloud DNS dispatcher landed in #596 (gcp/dns.go); per-component extractor (config map for panel) deferred pending zone-detail field reads (visibility, dnssec_config, record-count summary)",
+	"gcp_backups":      "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
+	"gcp_cloud_deploy": "[no-inspector] Cloud Deploy delivery-pipeline inspector deferred (#613 explicitly marks discovery inspector + extractor as optional/follow-up); ComponentMetricsMapping has no entry yet so the panel falls back to design values until the per-component extractor lands",
+	"gcp_cloud_dns":    "[no-inspector] Cloud DNS dispatcher landed in #596 (gcp/dns.go); per-component extractor (config map for panel) deferred pending zone-detail field reads (visibility, dnssec_config, record-count summary)",
 }
 
 // extractorFixtures are minimal SDK-shape fixtures that exercise each


### PR DESCRIPTION
## Summary

Closes #613 — adds a `gcp/cloud_deploy` preset mirroring the role `aws/codepipeline` plays for AWS stacks. Closes the GCP CD-pipeline parity gap (#597 row 2 follow-up).

- **Preset** (`gcp/cloud_deploy/`): a managed Cloud Deploy delivery pipeline that promotes a single release through an ordered serial chain of targets (default: staging → prod) on Cloud Run or GKE. Provisions a per-pipeline runner SA with the minimum `roles/clouddeploy.jobRunner` binding — release-creation (`roles/clouddeploy.releaser`) is held out-of-stack by the CI workflow SA / gcloud user that cuts releases.
- **Composer wiring**: `KeyGCPCloudDeploy`, `Components.GCPCloudDeploy *bool`, `Config.GCPCloudDeploy *GCPCloudDeployConfig` + named `GCPCloudDeployTarget` sub-type, full registry coverage (`AllComponentKeys`, `ComposeOrder`, `ModulePath`, `PresetKeyMap`, `ComponentSelected`, `GCPIAMPermissions`, `GCPServices`).
- **Mapper**: every config field is optional. Partial-config callers fall back to the preset's `variables.tf` defaults rather than getting empty slices / false bools overridden onto them.
- **Tests**: 9 composer wiring tests + 8 tftest plan-time cases (positive companion + 4 rejection-axis triangulators).

Discovery inspector + per-component extractor are explicitly deferred per the issue scope; the `[no-inspector]` rationale on `configExtractorAllowlist[\"gcp_cloud_deploy\"]` references #613 so the next person picking that up has the breadcrumb.

## Test plan
- [x] `terraform fmt -check -recursive` — clean
- [x] 7 static lints PASS (`project-tag`, `project-label`, `gcp-project-pin`, `labelless-name-prefix`, `no-root-only-blocks`, `sensitive-for-each`, `foreach-unknown-keys`)
- [x] `terraform validate gcp/cloud_deploy/` — clean
- [x] `go test ./pkg/composer/...` — 2088 pass
- [x] `go vet ./...` / `go build ./...` — clean
- [ ] CI green

## Review notes

**/review findings** (all addressed pre-PR):
- P0: 0
- P1: 1 — *over-privileged runner SA carrying `roles/clouddeploy.releaser`*; dropped the binding (release-creation belongs to the principal that calls `gcloud deploy releases create`, not the executor SA). `GCPIAMPermissions` entry, design comments, and tests all updated to reflect the single-binding scope.
- P2: 7 — all addressed as drive-bys: renamed misleading `deploy_runner_operator` → `deploy_runner_job_runner` (the role bound is `jobRunner`, not the non-existent `operator`); dropped redundant `lookup(each.value, \"require_approval\", false)` (the `optional(bool, false)` schema already supplies the default); renamed `local.tags_or_labels` → `local.labels` (GCP module shouldn't reference \"tags\"); `target_names` output now reads from the resources / `local.target_full_names` to keep the prefix logic single-sourced; tightened composer test substring assertions; tftest happy-path now pins `serial_pipeline.stages[*].target_id` correspondence to `local.target_full_names`; comment fixes.
- P3: 1 — comment update, subsumed.

**qa-professor findings** (all addressed pre-PR):
- P1-1: rejection-axis triangulation — `cloud_deploy_rejects_*` tftests now have a positive companion (`cloud_deploy_single_valid_target_plans_cleanly`) that uses the same single-target shape with valid values to prove the negatives' `expect_failures = [var.targets]` fires on the right validation rule.
- P1-2: `TestComposeStack_GCPCloudDeploy_CallerSuppliedConfig`'s targets-section substring check now bounds the slice to the matching `}]` rather than running to EOF, so a value appearing in a later tfvars line cannot satisfy a per-target check by accident.
- P1-3: `TestGCPIAMPermissions_CloudDeployCovered` now asserts `serviceusage.services.enable` (the perm that gates the preset's `google_project_service` activation — without it first apply fails with `SERVICE_DISABLED 403` on a fresh project) and the assertion message reflects the post-P1-fix single-binding shape.
- P2: `TestMapper_GCPCloudDeploy_CallerSuppliedConfig` now exercises the per-element `RequireApproval: nil` branch; end-to-end test pins `service_account_short_name` flow-through; tftest happy path pins runner SA `account_id` default + `execution_configs.service_account` wiring + `execution_configs.usages` includes DEPLOY.

**Cross-references**
- Parent rollup: #597 (closed) row 2 follow-up.
- Sister CI preset: `gcp/cloud_build` (#283).
- AWS counterpart: `aws/codepipeline` (`KeyAWSCodePipeline`).
- Project-pin convention: #287.

## Deferred follow-ups
- Discovery inspector + per-component extractor for `gcp_cloud_deploy` (`[no-inspector]` rationale referenced from `configExtractorAllowlist`, opens a clean breadcrumb for the next pickup).