### PR TITLE
fix(awsdiscover): wire missing ParentLister on EKS PodIdentity and ELBv2 Listener

### DIFF
--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -683,10 +684,11 @@ func listEKSClustersWithClient(ctx context.Context, client eksClustersLister) ([
 
 // listEKSClustersAsResourceModels enumerates EKS clusters and wraps
 // each cluster name into a JSON ResourceModel `{"ClusterName":"..."}`
-// for feeding into Cloud Control ListResources for the four child
+// for feeding into Cloud Control ListResources for the five child
 // types scoped on ClusterName: Nodegroup, Addon, FargateProfile,
-// AccessEntry (#14f). Reuses `listEKSClusters` for the underlying SDK
-// call so pagination semantics are shared.
+// AccessEntry, PodIdentityAssociation (#14f, #616). Reuses
+// `listEKSClusters` for the underlying SDK call so pagination
+// semantics are shared.
 func listEKSClustersAsResourceModels(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error) {
 	names, err := listEKSClusters(ctx, awsCfg, region, args)
 	if err != nil {
@@ -695,6 +697,73 @@ func listEKSClustersAsResourceModels(ctx context.Context, awsCfg aws.Config, reg
 	models := make([]string, 0, len(names))
 	for _, n := range names {
 		models = append(models, fmt.Sprintf(`{"ClusterName":%q}`, n))
+	}
+	return models, nil
+}
+
+// elbv2LoadBalancersLister is the narrow subset of the ELBv2 SDK used
+// by the aws_lb_listener parent-scoped enumeration (#616 follow-up).
+// The interface is package-private so test fakes can satisfy it
+// without depending on the full ELBv2 client surface.
+type elbv2LoadBalancersLister interface {
+	DescribeLoadBalancers(ctx context.Context, in *elasticloadbalancingv2.DescribeLoadBalancersInput, opts ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeLoadBalancersOutput, error)
+}
+
+// listLoadBalancers enumerates ELBv2 load balancers in the region and
+// returns each LoadBalancerArn. Used as the parent enumeration for
+// AWS::ElasticLoadBalancingV2::Listener whose CC ListResources handler
+// requires ResourceModel={"LoadBalancerArn":"..."}.
+//
+// DescribeLoadBalancers paginates via Marker/NextMarker. The
+// terminator condition mirrors the other listers: break on both nil
+// AND empty-string cursors.
+func listLoadBalancers(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+	client := elasticloadbalancingv2.NewFromConfig(awsCfg, func(o *elasticloadbalancingv2.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+	return listLoadBalancersWithClient(ctx, client)
+}
+
+func listLoadBalancersWithClient(ctx context.Context, client elbv2LoadBalancersLister) ([]string, error) {
+	arns := []string{}
+	var marker *string
+	for {
+		page, err := client.DescribeLoadBalancers(ctx, &elasticloadbalancingv2.DescribeLoadBalancersInput{Marker: marker})
+		if err != nil {
+			return nil, fmt.Errorf("elbv2:DescribeLoadBalancers: %w", err)
+		}
+		for _, lb := range page.LoadBalancers {
+			arn := aws.ToString(lb.LoadBalancerArn)
+			if arn == "" {
+				continue
+			}
+			arns = append(arns, arn)
+		}
+		if page.NextMarker == nil || aws.ToString(page.NextMarker) == "" {
+			break
+		}
+		marker = page.NextMarker
+	}
+	return arns, nil
+}
+
+// listLoadBalancersAsResourceModels enumerates ELBv2 load balancers
+// and wraps each LoadBalancerArn into a JSON ResourceModel
+// `{"LoadBalancerArn":"..."}` for feeding into Cloud Control
+// ListResources for AWS::ElasticLoadBalancingV2::Listener (#616
+// follow-up — the same regression class as
+// AWS::EKS::PodIdentityAssociation). Reuses `listLoadBalancers` for
+// the underlying SDK call so pagination semantics are shared.
+func listLoadBalancersAsResourceModels(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error) {
+	arns, err := listLoadBalancers(ctx, awsCfg, region, args)
+	if err != nil {
+		return nil, err
+	}
+	models := make([]string, 0, len(arns))
+	for _, a := range arns {
+		models = append(models, fmt.Sprintf(`{"LoadBalancerArn":%q}`, a))
 	}
 	return models, nil
 }

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
@@ -1643,7 +1645,7 @@ func TestListEKSClusters_SkipsEmptyClusterName(t *testing.T) {
 
 // TestListEKSClustersAsResourceModels_WrapsNamesAsResourceModelJSON pins
 // the parent-fan-out emit shape: each cluster name is wrapped into a
-// JSON ResourceModel `{"ClusterName":"..."}` for the four EKS child
+// JSON ResourceModel `{"ClusterName":"..."}` for the five EKS child
 // types' CC ListResources fan-out. Drift here would break every EKS
 // child type's parent-scoped enumeration.
 func TestListEKSClustersAsResourceModels_WrapsNamesAsResourceModelJSON(t *testing.T) {
@@ -1673,6 +1675,164 @@ func TestListEKSClustersAsResourceModels_WrapsNamesAsResourceModelJSON(t *testin
 		}
 		if parsed["ClusterName"] != name {
 			t.Errorf("name %q: round-tripped to %q under ClusterName key", name, parsed["ClusterName"])
+		}
+	}
+}
+
+// =====================================================================
+// #616 follow-up — listLoadBalancers /
+// listLoadBalancersAsResourceModels (ELBv2 parent enumeration for
+// aws_lb_listener)
+// =====================================================================
+
+// fakeELBv2LoadBalancersLister is the per-test seam for
+// elbv2:DescribeLoadBalancers. The canned `listPages` table is consumed
+// in order; the per-call `marker` receipts are captured for cursor
+// round-trip assertions.
+type fakeELBv2LoadBalancersLister struct {
+	listPages   []elasticloadbalancingv2.DescribeLoadBalancersOutput
+	listCalls   int
+	listErr     error
+	markersSeen []*string
+}
+
+func (f *fakeELBv2LoadBalancersLister) DescribeLoadBalancers(_ context.Context, in *elasticloadbalancingv2.DescribeLoadBalancersInput, _ ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeLoadBalancersOutput, error) {
+	f.markersSeen = append(f.markersSeen, in.Marker)
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if f.listCalls >= len(f.listPages) {
+		return &elasticloadbalancingv2.DescribeLoadBalancersOutput{}, nil
+	}
+	page := f.listPages[f.listCalls]
+	f.listCalls++
+	return &page, nil
+}
+
+func elbv2LoadBalancersPage(nextMarker string, arns ...string) elasticloadbalancingv2.DescribeLoadBalancersOutput {
+	lbs := make([]elbv2types.LoadBalancer, 0, len(arns))
+	for _, a := range arns {
+		arn := a
+		lbs = append(lbs, elbv2types.LoadBalancer{LoadBalancerArn: &arn})
+	}
+	out := elasticloadbalancingv2.DescribeLoadBalancersOutput{LoadBalancers: lbs}
+	if nextMarker != "" {
+		out.NextMarker = aws.String(nextMarker)
+	}
+	return out
+}
+
+func TestListLoadBalancers_PaginatesAndReturnsArns(t *testing.T) {
+	t.Parallel()
+	fake := &fakeELBv2LoadBalancersLister{
+		listPages: []elasticloadbalancingv2.DescribeLoadBalancersOutput{
+			elbv2LoadBalancersPage("m1", "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/alpha/aaaa"),
+			elbv2LoadBalancersPage("m2", "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/beta/bbbb"),
+			elbv2LoadBalancersPage("", "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/net/gamma/cccc"),
+		},
+	}
+	got, err := listLoadBalancersWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		"arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/alpha/aaaa",
+		"arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/beta/bbbb",
+		"arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/net/gamma/cccc",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("arns drift:\n got %v\nwant %v", got, want)
+	}
+	if fake.listCalls != 3 {
+		t.Errorf("listCalls=%d, want 3", fake.listCalls)
+	}
+	// Cursor round-trip: a regression dropping `marker = page.NextMarker`
+	// would still call 3 times (the fake serves by count) but markersSeen
+	// would be all-nil.
+	if len(fake.markersSeen) != 3 {
+		t.Fatalf("markersSeen len=%d, want 3", len(fake.markersSeen))
+	}
+	if fake.markersSeen[0] != nil {
+		t.Errorf("markersSeen[0]=%v, want nil", aws.ToString(fake.markersSeen[0]))
+	}
+	if aws.ToString(fake.markersSeen[1]) != "m1" {
+		t.Errorf("markersSeen[1]=%q, want m1", aws.ToString(fake.markersSeen[1]))
+	}
+	if aws.ToString(fake.markersSeen[2]) != "m2" {
+		t.Errorf("markersSeen[2]=%q, want m2", aws.ToString(fake.markersSeen[2]))
+	}
+}
+
+func TestListLoadBalancers_EmptyAccountReturnsNonNilEmpty(t *testing.T) {
+	t.Parallel()
+	fake := &fakeELBv2LoadBalancersLister{
+		listPages: []elasticloadbalancingv2.DescribeLoadBalancersOutput{elbv2LoadBalancersPage("")},
+	}
+	got, err := listLoadBalancersWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("got %v, want non-nil empty slice", got)
+	}
+}
+
+func TestListLoadBalancers_PropagatesListError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("AccessDenied: elbv2:DescribeLoadBalancers")
+	fake := &fakeELBv2LoadBalancersLister{listErr: sentinel}
+	_, err := listLoadBalancersWithClient(context.Background(), fake)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err does not wrap sentinel; got %v", err)
+	}
+}
+
+func TestListLoadBalancers_SkipsEmptyLoadBalancerArn(t *testing.T) {
+	t.Parallel()
+	good := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/good/aaaa"
+	empty := ""
+	alsoGood := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/also-good/cccc"
+	fake := &fakeELBv2LoadBalancersLister{
+		listPages: []elasticloadbalancingv2.DescribeLoadBalancersOutput{
+			{LoadBalancers: []elbv2types.LoadBalancer{
+				{LoadBalancerArn: &good},
+				{LoadBalancerArn: &empty},
+				{LoadBalancerArn: nil},
+				{LoadBalancerArn: &alsoGood},
+			}},
+		},
+	}
+	got, err := listLoadBalancersWithClient(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{good, alsoGood}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("empty-arn skip drift: got %v want %v", got, want)
+	}
+}
+
+// TestListLoadBalancersAsResourceModels_WrapsArnsAsResourceModelJSON pins
+// the parent-fan-out emit shape for AWS::ElasticLoadBalancingV2::Listener:
+// each LB ARN is wrapped into a JSON ResourceModel
+// `{"LoadBalancerArn":"..."}` so the CC ListResources fallback supplies
+// the property AWS requires (#616 follow-up; missing wrap would surface
+// as the same InvalidRequestException that #616 fixed for EKS).
+func TestListLoadBalancersAsResourceModels_WrapsArnsAsResourceModelJSON(t *testing.T) {
+	t.Parallel()
+	for _, arn := range []string{
+		"arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/plain/aaaa",
+		`arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/with"quote/bbbb`,
+		"arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/net/with-slash/cccc/extra",
+	} {
+		got := fmt.Sprintf(`{"LoadBalancerArn":%q}`, arn)
+		var parsed map[string]string
+		if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+			t.Errorf("arn %q produced unparseable JSON: %v (got %q)", arn, err, got)
+			continue
+		}
+		if parsed["LoadBalancerArn"] != arn {
+			t.Errorf("arn %q: round-tripped to %q under LoadBalancerArn key", arn, parsed["LoadBalancerArn"])
 		}
 	}
 }

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_parent_scoped_registry_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_parent_scoped_registry_test.go
@@ -1,0 +1,84 @@
+package awsdiscover
+
+import "testing"
+
+// parentScopedCFNTypes is the curated registry of CloudFormation types whose
+// Cloud Control ListResources handler requires a non-empty ResourceModel
+// (e.g. {"ClusterName":"..."}). Every entry MUST be wired with ParentLister
+// in cloudControlTypeConfigs, and every entry in cloudControlTypeConfigs
+// with ParentLister != nil MUST appear here. Drift is a release-blocking
+// fail in TestCloudControlTypes_ParentScopedRegistryMatchesTable (#616).
+//
+// To add a new parent-scoped type:
+//  1. Add the CFN type string here.
+//  2. Add the matching entry in cloudcontrol_types.go with
+//     ParentLister: <listerFn>.
+//
+// The integration test TestLive616_FullScanNoInvalidRequest is the live
+// backstop that catches types we forgot to register here (it walks
+// SupportedTypes against a real account and fails any
+// InvalidRequestException from CC ListResources).
+var parentScopedCFNTypes = map[string]struct{}{
+	"AWS::ApiGateway::Deployment":            {},
+	"AWS::ApiGateway::Resource":              {},
+	"AWS::ApiGateway::Stage":                 {},
+	"AWS::ApiGatewayV2::Authorizer":          {},
+	"AWS::ApiGatewayV2::Integration":         {},
+	"AWS::ApiGatewayV2::Route":               {},
+	"AWS::Cognito::UserPoolClient":           {},
+	"AWS::Cognito::UserPoolIdentityProvider": {},
+	"AWS::Cognito::UserPoolResourceServer":   {},
+	"AWS::EKS::AccessEntry":                  {},
+	"AWS::EKS::Addon":                        {},
+	"AWS::EKS::FargateProfile":               {},
+	"AWS::EKS::Nodegroup":                    {},
+	"AWS::EKS::PodIdentityAssociation":       {}, // #616
+	"AWS::ElasticLoadBalancingV2::Listener":  {}, // #616 follow-up
+	"AWS::Lambda::Alias":                     {},
+	"AWS::Lambda::Permission":                {},
+	"AWS::Lambda::Url":                       {},
+	"AWS::Logs::LogStream":                   {},
+	"AWS::WAFv2::WebACL":                     {},
+}
+
+// TestCloudControlTypes_ParentScopedRegistryMatchesTable enforces the
+// bidirectional invariant between parentScopedCFNTypes (the curated
+// registry of "this CFN type requires a ResourceModel for CC
+// ListResources") and the production cloudControlTypeConfigs table.
+//
+// Direction 1 — every registry entry must be wired with ParentLister in
+// the table. A missing wiring causes the discoverer to call CC
+// ListResources with no ResourceModel and AWS rejects with
+// InvalidRequestException (HTTP 400) — exactly the #616 failure.
+//
+// Direction 2 — every table entry that sets ParentLister must appear in
+// the registry. Catches accidental removal from the registry that would
+// silently weaken Direction 1.
+func TestCloudControlTypes_ParentScopedRegistryMatchesTable(t *testing.T) {
+	t.Parallel()
+
+	tableByCFN := make(map[string]cloudControlConfig, len(cloudControlTypeConfigs))
+	for _, cfg := range cloudControlTypeConfigs {
+		tableByCFN[cfg.CloudFormationType] = cfg
+	}
+
+	for cfnType := range parentScopedCFNTypes {
+		cfg, ok := tableByCFN[cfnType]
+		if !ok {
+			t.Errorf("registry references CFN type %q but cloudControlTypeConfigs has no entry for it — remove from registry or add the entry", cfnType)
+			continue
+		}
+		if cfg.ParentLister == nil {
+			t.Errorf("registry says %q is parent-scoped but cloudControlTypeConfigs entry (TFType=%s) has ParentLister == nil — CC ListResources will reject with HTTP 400 on RGT cache miss", cfnType, cfg.TFType)
+		}
+	}
+
+	for _, cfg := range cloudControlTypeConfigs {
+		if cfg.ParentLister == nil {
+			continue
+		}
+		if _, ok := parentScopedCFNTypes[cfg.CloudFormationType]; !ok {
+			t.Errorf("cloudControlTypeConfigs entry %q (TFType=%s) sets ParentLister but is missing from parentScopedCFNTypes — add it to the registry so the bidirectional invariant holds", cfg.CloudFormationType, cfg.TFType)
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -546,12 +546,21 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		TagsFromProperties: tagsFromKey("Tags"),
 	},
 	{
-		TFType:             "aws_lb_listener",
-		CloudFormationType: "AWS::ElasticLoadBalancingV2::Listener",
-		Slug:               "lb_listener",
-		// Listener identifier = full ARN. The hand-rolled parent-scoped
-		// enumeration is no longer needed: RGT returns listener ARNs
-		// directly.
+		// AWS::ElasticLoadBalancingV2::Listener is parent-scoped: CC
+		// ListResources requires ResourceModel={"LoadBalancerArn":"..."}.
+		// RGT supplies listener ARNs directly on cache-hit, but on RGT
+		// cache miss the fallback CC ListResources fires with no
+		// ResourceModel and AWS rejects with InvalidRequestException
+		// (HTTP 400). Same regression class as #616's
+		// AWS::EKS::PodIdentityAssociation; surfaced by the live #616
+		// full-scan integration test against the platform-test-admin
+		// account in us-east-1.
+		//
+		// Listener identifier = full ARN; Terraform import is passthrough.
+		TFType:                 "aws_lb_listener",
+		CloudFormationType:     "AWS::ElasticLoadBalancingV2::Listener",
+		Slug:                   "lb_listener",
+		ParentLister:           listLoadBalancersAsResourceModels,
 		ImportIDFromIdentifier: passthroughImportID,
 		NameHintFromProperties: func(identifier string, _ map[string]any) string {
 			// Listener ARNs end in `:listener/app/<lb>/<lbId>/<listenerId>`;
@@ -741,14 +750,21 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 	},
 
 	// =====================================================================
-	// EKS Pod Identity Association — compound import-ID rewrite
+	// EKS Pod Identity Association — parent-scoped on ClusterName, taggable (#616)
 	// =====================================================================
 	{
+		// AWS::EKS::PodIdentityAssociation is parent-scoped: CC ListResources
+		// requires ResourceModel={"ClusterName":"..."}. Without ParentLister
+		// the fallback CC ListResources fires with no ResourceModel and AWS
+		// rejects with InvalidRequestException (HTTP 400). See #616 / live
+		// repro against test account in us-east-1.
+		//
+		// Cloud Control identifier = "cluster|assocID"; Terraform import
+		// format = "cluster,assocID" (comma-separated). Rewrite.
 		TFType:             "aws_eks_pod_identity_association",
 		CloudFormationType: "AWS::EKS::PodIdentityAssociation",
 		Slug:               "eks_pod_identity",
-		// Cloud Control identifier = "cluster|assocID"; Terraform
-		// import format = "cluster,assocID" (comma-separated). Rewrite.
+		ParentLister:       listEKSClustersAsResourceModels,
 		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
 			return strings.Replace(identifier, "|", ",", 1)
 		},

--- a/cmd/insideout-import/awsdiscover/live_616_full_scan_test.go
+++ b/cmd/insideout-import/awsdiscover/live_616_full_scan_test.go
@@ -1,0 +1,215 @@
+//go:build integration
+
+// Live full-scan smoke test for #616. Walks every CloudControl-backed
+// TF type registered in cloudControlTypeConfigs against a real AWS
+// account in us-east-1, per-type subtests, and fails any subtest whose
+// CC ListResources call rejects with InvalidRequestException (HTTP
+// 400) — the class of failure that surfaced as
+// AWS::EKS::PodIdentityAssociation missing its ParentLister field.
+//
+// Run:
+//
+//	# from a shell where AWS creds are loaded (e.g. aws_jump <acct> <role>):
+//	go test -tags=integration ./cmd/insideout-import/awsdiscover/... \
+//	    -v -run TestLive616_FullScanNoInvalidRequest -timeout 30m
+//
+// Forces the CC ListResources fallback on every type by passing
+// Project="" and zero TagSelectors — that skips the RGT prefetcher
+// (see awsdiscover.go RGT pre-pass; nil cache means
+// args.RGTCacheForCFN returns ok=false so per-type discoverers fall
+// straight through to ListResources). This is the exact code path the
+// live #616 repro exercised.
+
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	cctypes "github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	smithy "github.com/aws/smithy-go"
+)
+
+// live616RequireCCPermission probes cloudformation:ListResources with a
+// known top-level (non-parent-scoped) CFN type. If the probe returns
+// AccessDeniedException, t.Skip the entire test with a clear message —
+// otherwise the per-subtest classifier would silently skip every type
+// as an environmental error and the overall test would PASS without
+// actually exercising the #616 regression class.
+//
+// Pick AWS::SQS::Queue: cheap, exists in us-east-1 for any account,
+// CloudControl-readable since 2022, no parent-scoping. The call needs
+// only cloudformation:ListResources on resource/* — if that fails, no
+// other CFN type will work either and the test is meaningless.
+func live616RequireCCPermission(t *testing.T, cfg aws.Config) {
+	t.Helper()
+	client := cloudcontrol.NewFromConfig(cfg)
+	probeType := "AWS::SQS::Queue"
+	_, err := client.ListResources(context.Background(), &cloudcontrol.ListResourcesInput{
+		TypeName: &probeType,
+	})
+	if err == nil {
+		return
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "AccessDeniedException", "AccessDenied", "UnauthorizedOperation":
+			t.Skipf("CC ListResources permission probe failed (cloudformation:ListResources for %s): %v — re-auth with a role that grants cloudformation:ListResources on resource/* (and read on the underlying services) before running this test", probeType, err)
+		}
+	}
+	// Any other error (throttle, transient): not a permission problem,
+	// proceed and let per-subtest classification handle it.
+}
+
+// live616LoadOrSkip mirrors loadOrSkip in
+// pkg/observability/discovery/aws/live_integration_test.go (not
+// importable across packages — duplicated intentionally, same pattern
+// as dynamodb_table_enrich_live_test.go). Defaults region to us-east-1
+// because that's the region the original #616 repro hit. Probes STS to
+// make a credential-less run a clean Skip rather than a confusing late
+// failure inside the actual scan.
+func live616LoadOrSkip(t *testing.T) aws.Config {
+	t.Helper()
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		t.Skipf("no AWS config: %v", err)
+	}
+	if cfg.Region == "" {
+		cfg.Region = "us-east-1"
+	}
+	if _, err := sts.NewFromConfig(cfg).GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{}); err != nil {
+		t.Skipf("no usable AWS credentials (sts.GetCallerIdentity failed): %v", err)
+	}
+	return cfg
+}
+
+// live616IsEnvSkip mirrors isAWSEnvSkip in
+// pkg/observability/discovery/aws/live_probe_255_test.go. Classifies
+// environmental errors (region not subscribed, opt-in required, access
+// denied, etc.) as Skip rather than Fail so the scan runs cleanly
+// against any AWS account.
+func live616IsEnvSkip(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "OptInRequired",
+			"UnauthorizedOperation",
+			"AccessDeniedException",
+			"AccessDenied",
+			"InvalidClientTokenId",
+			"AuthFailure",
+			"UnrecognizedClientException",
+			"UnsupportedOperation",
+			"ServiceUnavailableException",
+			"ServiceUnavailable",
+			"InvalidAction":
+			return true
+		}
+	}
+	s := err.Error()
+	for _, sub := range []string{
+		"is not subscribed to AWS",
+		"opted in",
+		"is not authorized to perform",
+		"could not be found",
+		"DataUnavailable",
+		"is not enabled in this region",
+		"region is disabled",
+	} {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestLive616_FullScanNoInvalidRequest exercises every registered
+// TF type against the live AWS account in us-east-1 and asserts no
+// CC ListResources call returns InvalidRequestException. A 400 here
+// strongly indicates the type's CFN handler requires a ResourceModel
+// and the production table entry is missing ParentLister — the #616
+// regression class.
+//
+// Per-type subtests are required because DiscoverTypes short-circuits
+// on the first error (awsdiscover.go ~line 432). Per-type isolation
+// lets a single CI run enumerate every broken type rather than play
+// whack-a-mole.
+//
+// Zero items returned by a type is a PASS — the test is shape-only,
+// not existence-dependent.
+func TestLive616_FullScanNoInvalidRequest(t *testing.T) {
+	cfg := live616LoadOrSkip(t)
+	cfg.Region = "us-east-1"
+
+	// Skip the entire test if the caller lacks CC permission — without
+	// it every subtest would skip as AccessDeniedException and the
+	// overall test would PASS without exercising the regression class.
+	live616RequireCCPermission(t, cfg)
+
+	a := NewAWSDiscoverer(cfg)
+
+	identity, err := sts.NewFromConfig(cfg).GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
+	if err != nil {
+		t.Skipf("STS GetCallerIdentity failed after loadOrSkip probe: %v", err)
+	}
+	accountID := ""
+	if identity.Account != nil {
+		accountID = *identity.Account
+	}
+
+	for _, tfType := range a.SupportedTypes() {
+		t.Run(tfType, func(t *testing.T) {
+			t.Parallel()
+
+			args := DiscoverArgs{
+				Project:   "", // empty → no RGT prefetch → forces CC ListResources fallback
+				Regions:   []string{"us-east-1"},
+				AccountID: accountID,
+			}
+			_, err := a.DiscoverTypes(context.Background(), []string{tfType}, args)
+			if err == nil {
+				return
+			}
+
+			// Treat environmental errors as Skip (the test isn't probing
+			// account permissions or regional availability — it's pinning
+			// the ParentLister wiring).
+			if live616IsEnvSkip(err) {
+				t.Skipf("environmental skip: %v", err)
+			}
+
+			// The #616 failure class: CC ListResources rejected the call
+			// with InvalidRequestException because no ResourceModel was
+			// supplied. errors.As walks the wrapped error chain (the
+			// discoverer wraps with %w at cloudcontrol_discoverer.go ~344).
+			var invalid *cctypes.InvalidRequestException
+			if errors.As(err, &invalid) {
+				t.Fatalf("%s likely needs ParentLister wiring — CC ListResources rejected with InvalidRequestException: %v", tfType, err)
+			}
+
+			// Fallback: the typed exception may not survive every wrap
+			// path. Match on the smithy error code as a defense-in-depth.
+			var apiErr smithy.APIError
+			if errors.As(err, &apiErr) && apiErr.ErrorCode() == "InvalidRequestException" {
+				t.Fatalf("%s likely needs ParentLister wiring — CC ListResources rejected with InvalidRequestException: %v", tfType, err)
+			}
+
+			// Any other error: surface but distinguish from the #616 class.
+			// We do not Fail here because the live account may have
+			// permission/quota edge cases unrelated to the regression
+			// we're guarding against; a t.Logf keeps the run visible
+			// without false positives.
+			t.Logf("%s returned non-#616 error (not failing test): %v", tfType, err)
+		})
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/live_616_analog_full_scan_test.go
+++ b/cmd/insideout-import/gcpdiscover/live_616_analog_full_scan_test.go
@@ -1,0 +1,258 @@
+//go:build integration
+
+// Live full-scan smoke test — GCP analog of the AWS
+// TestLive616_FullScanNoInvalidRequest (#616). Walks every TF type
+// registered in GCPDiscoverer.byType against a real GCP project,
+// per-type subtests, and fails any subtest whose underlying Google
+// API call rejects with HTTP 400 (REST: *googleapi.Error{Code:400})
+// or gRPC InvalidArgument (codes.InvalidArgument) — the GCP
+// equivalent of the AWS InvalidRequestException class that surfaced
+// AWS::EKS::PodIdentityAssociation / AWS::ElasticLoadBalancingV2::Listener
+// as missing ParentLister.
+//
+// Run:
+//
+//	# Either:
+//	#   gcloud auth application-default login                  # ADC, or
+//	#   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json # SA key
+//	export LIVE_GCP_PROJECT_ID=your-project-id
+//	go test -tags=integration ./cmd/insideout-import/gcpdiscover/... \
+//	    -v -run TestLive616Analog_FullScanNoInvalidArgument -timeout 30m
+//
+// Forces the CAI ListResources path on every type by passing
+// args.Project="" (no labels-filter clause), and exercises the
+// non-CAI per-parent fan-out path for the types that don't live in
+// Cloud Asset (sinks, SQL users, identity platform, IAM, project
+// services, secret versions, bucket objects, etc.).
+
+package gcpdiscover
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// live616AnalogLoadOrSkip returns the project ID from
+// LIVE_GCP_PROJECT_ID or skips the test. ADC (or
+// GOOGLE_APPLICATION_CREDENTIALS) is consumed implicitly by the SDK
+// clients constructed inside NewRealAssetSearcher /
+// NewReal*Lister(ctx) below.
+func live616AnalogLoadOrSkip(t *testing.T) string {
+	t.Helper()
+	projectID := os.Getenv("LIVE_GCP_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("LIVE_GCP_PROJECT_ID not set; export the project ID to run the GCP analog of the #616 live full-scan")
+	}
+	return projectID
+}
+
+// live616AnalogIsEnvSkip classifies environmental errors (auth,
+// permissions, API-not-enabled, region/project misconfigured) as Skip
+// rather than Fail — analogous to the AWS test's live616IsEnvSkip.
+// Covers both REST (*googleapi.Error) and gRPC (status.FromError)
+// error surfaces.
+func live616AnalogIsEnvSkip(err error) bool {
+	if err == nil {
+		return false
+	}
+	// REST: google.golang.org/api SDKs return *googleapi.Error with
+	// .Code set to the HTTP status. 401/403 are env; 404 is "the
+	// resource doesn't exist" which we also treat as env (project may
+	// legitimately not have the resource yet).
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		switch gerr.Code {
+		case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+			return true
+		}
+		// 403 sometimes comes with a body that says "API not enabled
+		// for project" or "has not been used in project X before or it
+		// is disabled" — those are env, not code bugs.
+		msg := gerr.Body
+		if msg == "" {
+			msg = gerr.Message
+		}
+		if strings.Contains(msg, "not been used in project") ||
+			strings.Contains(msg, "is disabled") ||
+			strings.Contains(msg, "API not enabled") ||
+			strings.Contains(msg, "accessNotConfigured") {
+			return true
+		}
+	}
+	// gRPC: cloud.google.com/go SDKs (CAI in particular) return
+	// status.Status errors. Unauthenticated / PermissionDenied are
+	// env; codes.NotFound (project doesn't exist or no resources of
+	// this type) is also env.
+	if s, ok := status.FromError(err); ok {
+		switch s.Code() {
+		case codes.Unauthenticated, codes.PermissionDenied, codes.NotFound, codes.FailedPrecondition:
+			return true
+		}
+	}
+	// String-match fallbacks for errors that don't surface either
+	// typed shape cleanly through every layer of wrapping in the
+	// discoverer.
+	s := err.Error()
+	for _, sub := range []string{
+		"is not enabled",
+		"API not enabled",
+		"has not been used in project",
+		"PERMISSION_DENIED",
+		"UNAUTHENTICATED",
+		"could not find default credentials",
+		"Reauthentication failed",
+		"reauthentication is required",
+	} {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// live616AnalogIsBadRequest reports whether err is the GCP analog of
+// AWS's InvalidRequestException — REST 400 or gRPC InvalidArgument.
+// This is the failure shape that indicates a wiring bug in a per-type
+// discoverer (e.g. missing parent enumeration, wrong filter dialect,
+// malformed API call) rather than an environmental issue.
+func live616AnalogIsBadRequest(err error) bool {
+	if err == nil {
+		return false
+	}
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) && gerr.Code == http.StatusBadRequest {
+		return true
+	}
+	if s, ok := status.FromError(err); ok && s.Code() == codes.InvalidArgument {
+		return true
+	}
+	return false
+}
+
+// TestLive616Analog_FullScanNoInvalidArgument exercises every
+// registered TF type against the live GCP project and asserts no
+// underlying API call returns the GCP analog of an
+// InvalidRequestException (HTTP 400 / gRPC InvalidArgument). Strongly
+// indicates a per-type discoverer wiring bug — the GCP analog of the
+// #616 AWS failure class.
+//
+// Per-type subtests are required because DiscoverTypes for a single
+// CAI bucket is one SearchAllResources call; running each type in
+// isolation lets a single CI run enumerate every broken type rather
+// than play whack-a-mole.
+//
+// Zero items returned for a type is a PASS — the test is shape-only,
+// not existence-dependent.
+func TestLive616Analog_FullScanNoInvalidArgument(t *testing.T) {
+	projectID := live616AnalogLoadOrSkip(t)
+	ctx := context.Background()
+
+	// Production wiring: same NewRealAssetSearcher +
+	// NewReal*Lister(ctx) setup as cmd/insideout-import/discover.go.
+	// Lister construction failures are tolerated with t.Logf warnings
+	// (mirroring discover.go's WARN pattern) — the corresponding
+	// non-CAI types are then exercised against a nil lister, which
+	// the per-discoverer code path tolerates.
+	searcher, err := NewRealAssetSearcher(ctx)
+	if err != nil {
+		if live616AnalogIsEnvSkip(err) {
+			t.Skipf("CAI searcher construction failed (env): %v — ensure ADC or GOOGLE_APPLICATION_CREDENTIALS is set, and Cloud Asset API is enabled on the ADC quota project", err)
+		}
+		t.Fatalf("CAI searcher construction failed: %v", err)
+	}
+	// t.Cleanup (not defer): subtests use t.Parallel(), which queues
+	// them to run AFTER the parent body returns. defer would close the
+	// searcher before any subtest runs, producing fake "PASS" results
+	// from a closed client.
+	t.Cleanup(func() { _ = searcher.Close() })
+
+	opts := GCPDiscovererOpts{}
+	if l, err := NewRealLoggingSinkLister(ctx); err != nil {
+		t.Logf("WARN: logging sink lister unavailable (sinks won't be exercised): %v", err)
+	} else {
+		opts.SinkLister = l
+	}
+	if l, err := NewRealSQLUserLister(ctx); err != nil {
+		t.Logf("WARN: sqladmin user lister unavailable: %v", err)
+	} else {
+		opts.SQLUserLister = l
+	}
+	if l, err := NewRealIdentityPlatformConfigLister(ctx); err != nil {
+		t.Logf("WARN: identitytoolkit lister unavailable: %v", err)
+	} else {
+		opts.IdentityPlatformLister = l
+	}
+	if l, err := NewRealIAMPolicyLister(ctx); err != nil {
+		t.Logf("WARN: IAM policy lister unavailable: %v", err)
+	} else {
+		opts.IAMPolicyLister = l
+	}
+	if l, err := NewRealSecretVersionLister(ctx); err != nil {
+		t.Logf("WARN: secret version lister unavailable: %v", err)
+	} else {
+		opts.SecretVersionLister = l
+	}
+	if l, err := NewRealBucketObjectLister(ctx); err != nil {
+		t.Logf("WARN: bucket object lister unavailable: %v", err)
+	} else {
+		opts.BucketObjectLister = l
+	}
+	if l, err := NewRealProjectServiceLister(ctx); err != nil {
+		t.Logf("WARN: serviceusage lister unavailable: %v", err)
+	} else {
+		opts.ProjectServiceLister = l
+	}
+	if l, err := NewRealDefaultSupportedIdpConfigLister(ctx); err != nil {
+		t.Logf("WARN: default-IDP-config lister unavailable: %v", err)
+	} else {
+		opts.DefaultSupportedIdpConfigLister = l
+	}
+	if l, err := NewRealServiceNetworkingConnectionLister(ctx); err != nil {
+		t.Logf("WARN: servicenetworking lister unavailable: %v", err)
+	} else {
+		opts.ServiceNetworkingConnectionLister = l
+	}
+	if l, err := NewRealVPCAccessConnectorLister(ctx); err != nil {
+		t.Logf("WARN: vpcaccess lister unavailable: %v", err)
+	} else {
+		opts.VPCAccessConnectorLister = l
+	}
+
+	g := NewGCPDiscoverer(searcher, projectID, opts)
+
+	for _, tfType := range g.SupportedTypes() {
+		t.Run(tfType, func(t *testing.T) {
+			t.Parallel()
+
+			args := DiscoverArgs{
+				Project: "", // empty → no labels-filter clause; exercises full CAI scope path
+			}
+			_, err := g.DiscoverTypes(context.Background(), []string{tfType}, args)
+			if err == nil {
+				return
+			}
+
+			if live616AnalogIsEnvSkip(err) {
+				t.Skipf("environmental skip: %v", err)
+			}
+
+			if live616AnalogIsBadRequest(err) {
+				t.Fatalf("%s likely has a per-type discoverer wiring bug — GCP API rejected with HTTP 400 / InvalidArgument: %v", tfType, err)
+			}
+
+			// Other errors: log but don't fail — could be transient
+			// (quota throttle, network), and we don't want false
+			// positives on the #616-class regression we're guarding
+			// against. The bad-request classifier above is the gate.
+			t.Logf("%s returned non-#616-class error (not failing test): %v", tfType, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`AWS::EKS::PodIdentityAssociation` (issue #616) and
`AWS::ElasticLoadBalancingV2::Listener` (surfaced live by the new
integration test in this PR) are both parent-scoped CloudFormation
types — CC `ListResources` requires `ResourceModel` with `ClusterName` /
`LoadBalancerArn` respectively. Both entries in `cloudcontrol_types.go`
were missing `ParentLister`, so when the CC fallback fires (RGT cache
miss, or RGT doesn't track the type) AWS rejects with
`InvalidRequestException` (HTTP 400). Wiring the two `ParentLister`
fields is the bug fix.

To prevent future regressions of this class, two guards are added:

- **Static guard** — `TestCloudControlTypes_ParentScopedRegistryMatchesTable`
  enforces a bidirectional invariant between a curated
  `parentScopedCFNTypes` registry and the production
  `cloudControlTypeConfigs` table. Any new parent-scoped entry must
  update both, or the unit test fails. Catches the registry drift that
  produced #616.

- **Live full-scan integration test** —
  `TestLive616_FullScanNoInvalidRequest` (`//go:build integration`)
  iterates `SupportedTypes()` against a real account, forces the CC
  `ListResources` fallback by passing `Project=""` (skips RGT
  prefetch), and fails any subtest where CC returns
  `InvalidRequestException`. A top-level CC-permission probe prevents
  false-positive PASS on accounts without `cloudformation:ListResources`.
  This surfaced `aws_lb_listener` as the second broken entry; the final
  run is clean across all 109 supported types.

Fixes #616

## Test plan

- [x] `go test ./cmd/insideout-import/awsdiscover/...` — 952 passed (947 + 5 new ELBv2 unit tests)
- [x] `go vet -tags=integration ./cmd/insideout-import/awsdiscover/...` — clean
- [x] `gofmt -l <changed files>` — clean
- [x] `terraform fmt -check -recursive` — clean
- [x] Four static lint scripts (`lint-project-tag.sh`, `lint-project-label.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`) — all PASS
- [x] Live full-scan against AWS account `141812438321` in `us-east-1` (the issue's repro account), as `platform-test-admin`: **109 PASS, 0 SKIP, 0 FAIL** (~70s)
- [x] Existing `TestCloudControlDiscover_CacheRanRegionEmptyForCFN_AuthoritativeZero` still passes — the authoritative-zero short-circuit remains valid defense-in-depth and is unchanged by this fix

## Downstream

After merge + tagged release, bump the presets pin in [`reliable`](https://github.com/luthersystems/reliable) at `go.mod`.