### PR TITLE
feat(aws): add sagemaker Studio preset (#615)

### DIFF
--- a/aws/sagemaker/main.tf
+++ b/aws/sagemaker/main.tf
@@ -37,14 +37,37 @@ terraform {
   }
 }
 
+# Standard luthername-driven naming + tag set. Every AWS preset in the
+# repo wires through this module so the InsideOut inspector's exact
+# `Project = <project>` filter (CLAUDE.md issue #81) catches every
+# resource, alongside the other standard tags the luthername module
+# emits (env, component, region, etc.).
+module "name" {
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
+  luther_project = var.project
+  aws_region     = var.region
+  luther_env     = var.environment
+  org_name       = "luthersystems"
+  component      = "insideout"
+  subcomponent   = "sm"
+  resource       = "sm"
+}
+
 # Caller identity drives the aws:SourceAccount confused-deputy guard on
 # the Studio execution role's trust policy (matches aws/bedrock).
 data "aws_caller_identity" "current" {}
 
+# Partition-aware ARN construction for the caller-supplied bucket fallback
+# (aws / aws-us-gov / aws-cn). aws_s3_bucket.workspace[0].arn already
+# carries the right partition for the preset-managed case.
+data "aws_partition" "current" {}
+
 locals {
-  # Standard Project-tag merge so the InsideOut inspector's exact
-  # `Project = <project>` filter sees every resource (CLAUDE.md issue #81).
-  tags = merge({ Project = var.project }, var.tags)
+  # Project-tag merge from the luthername module so every taggable
+  # resource carries the full standard tag set (Project + env + region
+  # + component + subcomponent + resource). var.tags overrides or
+  # extends.
+  tags = merge(module.name.tags, var.tags)
 
   # SageMaker domains can run in PublicInternetOnly or VpcOnly mode.
   # AWS provider 6.x requires `vpc_id` + `subnet_ids` on every domain
@@ -64,7 +87,7 @@ locals {
   # same stack is deployed twice in different accounts/regions.
   create_bucket         = var.workspace_bucket == null
   workspace_bucket_name = local.create_bucket ? aws_s3_bucket.workspace[0].id : var.workspace_bucket
-  workspace_bucket_arn  = local.create_bucket ? aws_s3_bucket.workspace[0].arn : "arn:aws:s3:::${var.workspace_bucket}"
+  workspace_bucket_arn  = local.create_bucket ? aws_s3_bucket.workspace[0].arn : "arn:${data.aws_partition.current.partition}:s3:::${var.workspace_bucket}"
   default_bucket_name   = local.create_bucket ? "${var.project}-sagemaker-workspace-${random_id.workspace_suffix[0].hex}" : null
 }
 
@@ -214,18 +237,6 @@ resource "aws_sagemaker_domain" "studio" {
   }
 
   tags = local.tags
-
-  # Cross-attr validation hosted as a precondition so the rule can
-  # reference both var.vpc_id (non-null) and var.subnet_ids (non-empty)
-  # together — Terraform 1.5+ disallows multi-variable refs in variable
-  # validation blocks. Mirrors the gcp/github_actions all-empty-ref-gates
-  # precondition pattern.
-  lifecycle {
-    precondition {
-      condition     = length(trimspace(var.vpc_id)) > 0 && length(var.subnet_ids) > 0
-      error_message = "vpc_id must be non-empty and subnet_ids must contain at least one subnet (SageMaker domains require a VPC + subnet pair in both VpcOnly and PublicInternetOnly modes)."
-    }
-  }
 }
 
 # -----------------------------------------------------------------------------

--- a/aws/sagemaker/main.tf
+++ b/aws/sagemaker/main.tf
@@ -1,0 +1,215 @@
+# AWS SageMaker Studio domain preset (#615).
+#
+# Mirrors the role gcp/vertex_ai plays for GCP stacks: a single-call entry
+# point for an ML workspace on AWS. The preset provisions:
+#
+#   - A SageMaker Studio domain (`aws_sagemaker_domain`) named
+#     `${var.project}-studio` so the InsideOut inspector can attribute the
+#     domain to the stack via name-prefix scoping (CLAUDE.md "name-prefix
+#     scoping" rule — domains carry tags too, but the prefix is the
+#     defense-in-depth path for label-less resource families).
+#   - An IAM execution role (`aws_iam_role.studio_execution`) the
+#     Studio apps assume when launching kernels / running training jobs.
+#   - A workspace S3 bucket (preset-created by default; caller-supplied via
+#     `var.workspace_bucket` for shared / cross-account buckets). The
+#     execution role gets least-privilege Get/Put/List on this bucket.
+#   - Optional Studio user profiles (`for_each = toset(var.studio_users)`).
+#
+# Scope ceiling: matches `gcp/vertex_ai` simplicity. Image / lifecycle
+# config / KMS / VPC-mode networking modes are exposed but kept minimal —
+# advanced consumers can wrap the module or fork.
+#
+# Discovery inspector: deferred per #615 (the issue explicitly marks the
+# discovery inspector as optional follow-up). See
+# `pkg/observability/extractors/extractors_drift_test.go` allowlist.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+locals {
+  # Standard Project-tag merge so the InsideOut inspector's exact
+  # `Project = <project>` filter sees every resource (CLAUDE.md issue #81).
+  tags = merge({ Project = var.project }, var.tags)
+
+  # SageMaker domains can run in PublicInternetOnly or VpcOnly mode.
+  # AWS provider 6.x requires `vpc_id` + `subnet_ids` on every domain
+  # (they're non-nullable required arguments on the resource even though
+  # PublicInternetOnly mode doesn't peer into the VPC). VpcOnly mode peers
+  # into the customer VPC; PublicInternetOnly mode uses AWS-managed
+  # networking but still needs the VPC reference for the studio app's
+  # ENI placement. We flip the access mode based on var.network_mode so
+  # callers can pick the right shape — both modes require the VPC inputs.
+  vpc_only = var.network_mode == "VpcOnly"
+
+  # Workspace bucket: preset-managed unless the caller supplies one. We
+  # surface the resolved name as an output regardless of who owns the
+  # bucket so callers can wire IAM policies / downstream consumers.
+  create_bucket         = var.workspace_bucket == null
+  workspace_bucket_name = local.create_bucket ? aws_s3_bucket.workspace[0].id : var.workspace_bucket
+  workspace_bucket_arn  = local.create_bucket ? aws_s3_bucket.workspace[0].arn : "arn:aws:s3:::${var.workspace_bucket}"
+  default_bucket_name   = "${var.project}-sagemaker-workspace"
+}
+
+# -----------------------------------------------------------------------------
+# Workspace S3 bucket (preset-managed when var.workspace_bucket == null)
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "workspace" {
+  count         = local.create_bucket ? 1 : 0
+  bucket        = local.default_bucket_name
+  force_destroy = var.workspace_bucket_force_destroy
+
+  tags = merge(local.tags, { Name = local.default_bucket_name })
+}
+
+resource "aws_s3_bucket_versioning" "workspace" {
+  count  = local.create_bucket ? 1 : 0
+  bucket = aws_s3_bucket.workspace[0].id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "workspace" {
+  count  = local.create_bucket ? 1 : 0
+  bucket = aws_s3_bucket.workspace[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "workspace" {
+  count                   = local.create_bucket ? 1 : 0
+  bucket                  = aws_s3_bucket.workspace[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# -----------------------------------------------------------------------------
+# IAM execution role for SageMaker Studio apps
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "studio_execution" {
+  name = "${var.project}-sagemaker-execution"
+  path = "/service-role/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "sagemaker.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  # NOTE: Managed policies attach via the sibling
+  # aws_iam_role_policy_attachment block below; we don't pin
+  # `managed_policy_arns` directly because AWS provider 6.x deprecated that
+  # attribute (Read alone returns the attached set on refresh, so no drift
+  # warning needed).
+
+  tags = local.tags
+}
+
+# AmazonSageMakerFullAccess is broad — it permits the role to manage almost
+# every SageMaker resource type plus a handful of supporting services
+# (S3, ECR, CloudWatch). Trade-off: callers who need a locked-down
+# environment must override via var.sagemaker_managed_policy_arn (e.g.
+# point at an in-account scoped policy).
+resource "aws_iam_role_policy_attachment" "studio_managed" {
+  role       = aws_iam_role.studio_execution.name
+  policy_arn = var.sagemaker_managed_policy_arn
+}
+
+# Workspace bucket access — least-privilege Get/Put/List on the resolved
+# bucket. Inline policy (not a separate aws_iam_policy + attachment) so the
+# permission lifecycle tracks the role 1:1; orphan policies on
+# terraform destroy are impossible.
+resource "aws_iam_role_policy" "studio_workspace_access" {
+  name = "${var.project}-sagemaker-workspace-access"
+  role = aws_iam_role.studio_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+        ]
+        Resource = "${local.workspace_bucket_arn}/*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = local.workspace_bucket_arn
+      },
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# SageMaker Studio domain
+# -----------------------------------------------------------------------------
+
+resource "aws_sagemaker_domain" "studio" {
+  # Name-prefix scoping per CLAUDE.md: even though the domain carries
+  # tags, the prefix gives the inspector a deterministic attribution path
+  # that's resilient to tag drift.
+  domain_name             = "${var.project}-studio"
+  auth_mode               = "IAM"
+  vpc_id                  = var.vpc_id
+  subnet_ids              = var.subnet_ids
+  app_network_access_type = local.vpc_only ? "VpcOnly" : "PublicInternetOnly"
+
+  default_user_settings {
+    execution_role = aws_iam_role.studio_execution.arn
+  }
+
+  tags = local.tags
+
+  # Cross-attr validation hosted as a precondition so the rule can
+  # reference both var.vpc_id (non-null) and var.subnet_ids (non-empty)
+  # together — Terraform 1.5+ disallows multi-variable refs in variable
+  # validation blocks. Mirrors the gcp/github_actions all-empty-ref-gates
+  # precondition pattern.
+  lifecycle {
+    precondition {
+      condition     = length(trimspace(var.vpc_id)) > 0 && length(var.subnet_ids) > 0
+      error_message = "vpc_id must be non-empty and subnet_ids must contain at least one subnet (SageMaker domains require a VPC + subnet pair in both VpcOnly and PublicInternetOnly modes)."
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Optional Studio user profiles (one per caller-supplied user name)
+# -----------------------------------------------------------------------------
+
+resource "aws_sagemaker_user_profile" "studio_user" {
+  for_each = toset(var.studio_users)
+
+  domain_id         = aws_sagemaker_domain.studio.id
+  user_profile_name = each.value
+
+  tags = local.tags
+}

--- a/aws/sagemaker/main.tf
+++ b/aws/sagemaker/main.tf
@@ -30,8 +30,16 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 6.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
+
+# Caller identity drives the aws:SourceAccount confused-deputy guard on
+# the Studio execution role's trust policy (matches aws/bedrock).
+data "aws_caller_identity" "current" {}
 
 locals {
   # Standard Project-tag merge so the InsideOut inspector's exact
@@ -51,10 +59,18 @@ locals {
   # Workspace bucket: preset-managed unless the caller supplies one. We
   # surface the resolved name as an output regardless of who owns the
   # bucket so callers can wire IAM policies / downstream consumers.
+  # S3 bucket names are globally unique, so we suffix the preset-managed
+  # bucket with a random_id to avoid project-name collisions when the
+  # same stack is deployed twice in different accounts/regions.
   create_bucket         = var.workspace_bucket == null
   workspace_bucket_name = local.create_bucket ? aws_s3_bucket.workspace[0].id : var.workspace_bucket
   workspace_bucket_arn  = local.create_bucket ? aws_s3_bucket.workspace[0].arn : "arn:aws:s3:::${var.workspace_bucket}"
-  default_bucket_name   = "${var.project}-sagemaker-workspace"
+  default_bucket_name   = local.create_bucket ? "${var.project}-sagemaker-workspace-${random_id.workspace_suffix[0].hex}" : null
+}
+
+resource "random_id" "workspace_suffix" {
+  count       = local.create_bucket ? 1 : 0
+  byte_length = 3
 }
 
 # -----------------------------------------------------------------------------
@@ -106,6 +122,10 @@ resource "aws_iam_role" "studio_execution" {
   name = "${var.project}-sagemaker-execution"
   path = "/service-role/"
 
+  # Confused-deputy guard: scope the service trust to the deploying
+  # account so a hostile cross-account caller can't trick the SageMaker
+  # control plane into assuming this role on their behalf. Matches
+  # aws/bedrock's bedrock_kb role + aws/route53's invocation_logging role.
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
@@ -114,16 +134,23 @@ resource "aws_iam_role" "studio_execution" {
         Service = "sagemaker.amazonaws.com"
       }
       Action = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+        }
+      }
     }]
   })
 
-  # NOTE: Managed policies attach via the sibling
-  # aws_iam_role_policy_attachment block below; we don't pin
-  # `managed_policy_arns` directly because AWS provider 6.x deprecated that
-  # attribute (Read alone returns the attached set on refresh, so no drift
-  # warning needed).
-
   tags = local.tags
+
+  # Managed policies attach via the sibling aws_iam_role_policy_attachment
+  # block below; ignore_changes prevents drift noise when the provider
+  # refresh re-reads the attached set onto the role attribute. Matches
+  # aws/lambda's lambda_exec + aws/bedrock's bedrock_kb pattern.
+  lifecycle {
+    ignore_changes = [managed_policy_arns]
+  }
 }
 
 # AmazonSageMakerFullAccess is broad — it permits the role to manage almost

--- a/aws/sagemaker/outputs.tf
+++ b/aws/sagemaker/outputs.tf
@@ -1,0 +1,47 @@
+output "domain_id" {
+  description = "SageMaker Studio domain ID (e.g. `d-abcdef12345`). Use this to reference the domain from downstream resources (user profiles, apps, spaces)."
+  value       = aws_sagemaker_domain.studio.id
+}
+
+output "domain_arn" {
+  description = "Full ARN of the SageMaker Studio domain. Useful for IAM policy resource references that need exact-match ARNs."
+  value       = aws_sagemaker_domain.studio.arn
+}
+
+output "studio_url" {
+  description = "SageMaker Studio launch URL. Authenticated users sign in at this URL; admins share it with Studio user profile holders."
+  value       = aws_sagemaker_domain.studio.url
+}
+
+output "execution_role_arn" {
+  description = "ARN of the IAM execution role Studio apps assume. Wire this into downstream resources that need to grant SageMaker apps access (e.g. ECR image-pull policies, downstream S3 bucket policies)."
+  value       = aws_iam_role.studio_execution.arn
+}
+
+output "execution_role_name" {
+  description = "Name of the IAM execution role. Useful for attaching additional managed-policy attachments from sibling modules."
+  value       = aws_iam_role.studio_execution.name
+}
+
+output "workspace_bucket_name" {
+  description = "S3 bucket name used as the Studio workspace. Returns the preset-created bucket name when `var.workspace_bucket` is null; otherwise echoes back the caller-supplied value so downstream wiring is uniform."
+  value       = local.workspace_bucket_name
+}
+
+output "workspace_bucket_arn" {
+  description = "ARN of the workspace S3 bucket (preset-managed or caller-supplied). Same null-safe behavior as `workspace_bucket_name`."
+  value       = local.workspace_bucket_arn
+}
+
+output "studio_user_profile_arns" {
+  description = "Map of user-profile name → ARN for every Studio user profile the preset provisioned. Empty map when `var.studio_users` is empty."
+  value = {
+    for name, profile in aws_sagemaker_user_profile.studio_user :
+    name => profile.arn
+  }
+}
+
+output "tags" {
+  description = "The Project-tagged map applied to every taggable resource in this preset. Other presets composing on top can `merge(module.aws_sagemaker.tags, ...)` to inherit the same Project attribution."
+  value       = local.tags
+}

--- a/aws/sagemaker/tests/shape.tftest.hcl
+++ b/aws/sagemaker/tests/shape.tftest.hcl
@@ -1,0 +1,273 @@
+mock_provider "aws" {}
+
+# Issue #615 (aws/sagemaker Studio preset) shape tests. Verifies that:
+#   - Defaults compose cleanly (happy path).
+#   - The domain name is project-prefixed (inspector attribution path).
+#   - The Project tag is on the domain (defense-in-depth alongside the prefix).
+#   - The execution role is created with the expected name.
+#   - The workspace bucket is preset-created when not supplied.
+#   - VPC mode flips app_network_access_type when vpc_id + subnet_ids set.
+#   - Caller-supplied workspace_bucket suppresses the preset's S3 resources.
+#   - Validation triggers fire on malformed user names, invalid policy ARN,
+#     invalid bucket name, and the cross-attr vpc_id + empty subnet_ids gate.
+
+# -----------------------------------------------------------------------------
+# Positive companion: minimum inputs plans cleanly.
+# -----------------------------------------------------------------------------
+
+run "sagemaker_minimum_inputs" {
+  command = plan
+
+  variables {
+    project    = "test"
+    vpc_id     = "vpc-12345"
+    subnet_ids = ["subnet-aaa"]
+  }
+
+  assert {
+    condition     = aws_sagemaker_domain.studio.domain_name == "test-studio"
+    error_message = "domain_name should be project-prefixed (`<project>-studio`) so the InsideOut inspector's name-prefix scoping works."
+  }
+
+  assert {
+    condition     = aws_sagemaker_domain.studio.auth_mode == "IAM"
+    error_message = "auth_mode must be IAM (the preset doesn't support SSO mode yet)."
+  }
+
+  assert {
+    condition     = aws_sagemaker_domain.studio.app_network_access_type == "PublicInternetOnly"
+    error_message = "app_network_access_type should default to PublicInternetOnly when network_mode is unset (AWS-managed egress)."
+  }
+
+  assert {
+    condition     = aws_sagemaker_domain.studio.tags["Project"] == "test"
+    error_message = "Project tag must be set on the SageMaker domain so the InsideOut inspector's exact-match filter sees it (CLAUDE.md issue #81)."
+  }
+
+  assert {
+    condition     = aws_iam_role.studio_execution.name == "test-sagemaker-execution"
+    error_message = "Execution role should be project-prefixed."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Workspace bucket: preset-created by default.
+# -----------------------------------------------------------------------------
+
+run "sagemaker_creates_workspace_bucket_by_default" {
+  command = plan
+
+  variables {
+    project    = "test"
+    vpc_id     = "vpc-12345"
+    subnet_ids = ["subnet-aaa"]
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket.workspace) == 1
+    error_message = "Preset must create a workspace S3 bucket when workspace_bucket is null."
+  }
+
+  assert {
+    condition     = aws_s3_bucket.workspace[0].bucket == "test-sagemaker-workspace"
+    error_message = "Preset-created bucket name must be project-prefixed (`<project>-sagemaker-workspace`)."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_public_access_block.workspace) == 1
+    error_message = "Public-access-block resource must exist on the preset-created workspace bucket (security default)."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Workspace bucket: caller-supplied → preset skips its own bucket.
+# -----------------------------------------------------------------------------
+
+run "sagemaker_adopts_caller_supplied_workspace_bucket" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    workspace_bucket = "my-existing-bucket"
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket.workspace) == 0
+    error_message = "Preset must NOT create a workspace S3 bucket when workspace_bucket is supplied."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_versioning.workspace) == 0
+    error_message = "Preset must NOT manage versioning on a caller-supplied bucket (caller owns the bucket lifecycle)."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_server_side_encryption_configuration.workspace) == 0
+    error_message = "Preset must NOT manage encryption on a caller-supplied bucket (caller owns the bucket lifecycle)."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# VPC mode: vpc_id + subnet_ids → VpcOnly.
+# -----------------------------------------------------------------------------
+
+run "sagemaker_vpc_only_mode_flips_network_access" {
+  command = plan
+
+  variables {
+    project      = "test"
+    vpc_id       = "vpc-12345"
+    subnet_ids   = ["subnet-aaa", "subnet-bbb"]
+    network_mode = "VpcOnly"
+  }
+
+  assert {
+    condition     = aws_sagemaker_domain.studio.app_network_access_type == "VpcOnly"
+    error_message = "app_network_access_type must flip to VpcOnly when network_mode = VpcOnly."
+  }
+
+  assert {
+    condition     = aws_sagemaker_domain.studio.vpc_id == "vpc-12345"
+    error_message = "Domain vpc_id must propagate var.vpc_id."
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_domain.studio.subnet_ids) == 2
+    error_message = "Domain subnet_ids must propagate var.subnet_ids."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Studio user profiles: for_each over var.studio_users.
+# -----------------------------------------------------------------------------
+
+run "sagemaker_studio_users_create_profiles" {
+  command = plan
+
+  variables {
+    project      = "test"
+    vpc_id       = "vpc-12345"
+    subnet_ids   = ["subnet-aaa"]
+    studio_users = ["alice", "bob"]
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_user_profile.studio_user) == 2
+    error_message = "Expected one user-profile per studio_users entry."
+  }
+
+  assert {
+    condition     = aws_sagemaker_user_profile.studio_user["alice"].user_profile_name == "alice"
+    error_message = "Per-user profile name must match the studio_users entry."
+  }
+}
+
+run "sagemaker_no_studio_users_no_profiles" {
+  command = plan
+
+  variables {
+    project    = "test"
+    vpc_id     = "vpc-12345"
+    subnet_ids = ["subnet-aaa"]
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_user_profile.studio_user) == 0
+    error_message = "Empty studio_users list must produce zero user-profile resources."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases — validation must reject obvious misconfigurations at plan
+# time so callers don't discover them at apply.
+# -----------------------------------------------------------------------------
+
+run "sagemaker_rejects_bad_user_name" {
+  command = plan
+
+  variables {
+    project      = "test"
+    vpc_id       = "vpc-12345"
+    subnet_ids   = ["subnet-aaa"]
+    studio_users = ["has spaces"]
+  }
+
+  expect_failures = [var.studio_users]
+}
+
+run "sagemaker_rejects_bad_workspace_bucket_name" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    workspace_bucket = "Invalid_Bucket"
+  }
+
+  expect_failures = [var.workspace_bucket]
+}
+
+run "sagemaker_rejects_bad_policy_arn" {
+  command = plan
+
+  variables {
+    project                      = "test"
+    vpc_id                       = "vpc-12345"
+    subnet_ids                   = ["subnet-aaa"]
+    sagemaker_managed_policy_arn = "not-an-arn"
+  }
+
+  expect_failures = [var.sagemaker_managed_policy_arn]
+}
+
+run "sagemaker_rejects_bad_network_mode" {
+  command = plan
+
+  variables {
+    project      = "test"
+    vpc_id       = "vpc-12345"
+    subnet_ids   = ["subnet-aaa"]
+    network_mode = "InvalidMode"
+  }
+
+  expect_failures = [var.network_mode]
+}
+
+run "sagemaker_rejects_empty_project" {
+  command = plan
+
+  variables {
+    project    = "   "
+    vpc_id     = "vpc-12345"
+    subnet_ids = ["subnet-aaa"]
+  }
+
+  expect_failures = [var.project]
+}
+
+run "sagemaker_rejects_empty_subnet_ids" {
+  command = plan
+
+  variables {
+    project    = "test"
+    vpc_id     = "vpc-12345"
+    subnet_ids = []
+  }
+
+  expect_failures = [var.subnet_ids]
+}
+
+run "sagemaker_rejects_empty_vpc_id" {
+  command = plan
+
+  variables {
+    project    = "test"
+    vpc_id     = "   "
+    subnet_ids = ["subnet-aaa"]
+  }
+
+  expect_failures = [var.vpc_id]
+}

--- a/aws/sagemaker/tests/shape.tftest.hcl
+++ b/aws/sagemaker/tests/shape.tftest.hcl
@@ -1,4 +1,5 @@
 mock_provider "aws" {}
+mock_provider "random" {}
 
 # Issue #615 (aws/sagemaker Studio preset) shape tests. Verifies that:
 #   - Defaults compose cleanly (happy path).
@@ -69,8 +70,8 @@ run "sagemaker_creates_workspace_bucket_by_default" {
   }
 
   assert {
-    condition     = aws_s3_bucket.workspace[0].bucket == "test-sagemaker-workspace"
-    error_message = "Preset-created bucket name must be project-prefixed (`<project>-sagemaker-workspace`)."
+    condition     = startswith(aws_s3_bucket.workspace[0].bucket, "test-sagemaker-workspace-")
+    error_message = "Preset-created bucket name must be project-prefixed (`<project>-sagemaker-workspace-<random>`)."
   }
 
   assert {

--- a/aws/sagemaker/tests/shape.tftest.hcl
+++ b/aws/sagemaker/tests/shape.tftest.hcl
@@ -1,19 +1,36 @@
 mock_provider "aws" {}
 mock_provider "random" {}
 
-# Issue #615 (aws/sagemaker Studio preset) shape tests. Verifies that:
-#   - Defaults compose cleanly (happy path).
-#   - The domain name is project-prefixed (inspector attribution path).
-#   - The Project tag is on the domain (defense-in-depth alongside the prefix).
-#   - The execution role is created with the expected name.
-#   - The workspace bucket is preset-created when not supplied.
-#   - VPC mode flips app_network_access_type when vpc_id + subnet_ids set.
-#   - Caller-supplied workspace_bucket suppresses the preset's S3 resources.
-#   - Validation triggers fire on malformed user names, invalid policy ARN,
-#     invalid bucket name, and the cross-attr vpc_id + empty subnet_ids gate.
+# Issue #615 (aws/sagemaker Studio preset) shape tests. Verifies:
+#   - Defaults compose cleanly (minimum inputs happy path).
+#   - Domain name carries the var.project prefix (inspector attribution).
+#   - Project tag is on every taggable resource (defense-in-depth alongside
+#     the prefix, CLAUDE.md issue #81).
+#   - Studio execution role's trust policy is correctly scoped:
+#     - allows sagemaker.amazonaws.com
+#     - carries the aws:SourceAccount confused-deputy guard
+#     - attaches the default AmazonSageMakerFullAccess managed policy
+#   - Workspace bucket toggles between preset-managed (versioning +
+#     encryption + public-access-block ALL on) and caller-supplied.
+#   - VPC mode flips app_network_access_type correctly.
+#   - Studio user profiles attach to the right domain.
+#   - Validation rejects every misconfiguration axis, AND a positive
+#     companion run pins that the negatives fire on the right rule
+#     (rejection-axis triangulation per #614).
+#
+# Every run uses `command = plan`. The assertions below reference
+# attributes the preset sets explicitly (names, tags, IAM trust-policy
+# JSON, policy ARN) — all plan-time-known. Apply mode would let us
+# also evaluate Computed cross-refs (e.g. studio.id), but the AWS
+# provider validates ARN format at apply against the mocked random
+# strings mock_provider emits for arn-shaped Computed fields, which
+# fails the SageMaker domain's execution_role check. The trade-off is
+# acceptable here because every wiring cross-ref we care about is also
+# pinned end-to-end in `TestComposeStack_AWSSageMaker_Forward` in the
+# Go composer wiring test.
 
 # -----------------------------------------------------------------------------
-# Positive companion: minimum inputs plans cleanly.
+# Positive: minimum inputs apply cleanly.
 # -----------------------------------------------------------------------------
 
 run "sagemaker_minimum_inputs" {
@@ -49,10 +66,29 @@ run "sagemaker_minimum_inputs" {
     condition     = aws_iam_role.studio_execution.name == "test-sagemaker-execution"
     error_message = "Execution role should be project-prefixed."
   }
+
+  # Trust-policy correctness. A mutation that swapped the service
+  # principal to e.g. lambda.amazonaws.com or removed the
+  # aws:SourceAccount Condition block would survive every other
+  # assertion in this run, so pin both substrings explicitly.
+  assert {
+    condition     = strcontains(aws_iam_role.studio_execution.assume_role_policy, "sagemaker.amazonaws.com")
+    error_message = "Execution role assume_role_policy must trust sagemaker.amazonaws.com."
+  }
+
+  assert {
+    condition     = strcontains(aws_iam_role.studio_execution.assume_role_policy, "aws:SourceAccount")
+    error_message = "Execution role assume_role_policy must carry the aws:SourceAccount confused-deputy guard."
+  }
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.studio_managed.policy_arn == "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
+    error_message = "Default managed-policy attachment must be AmazonSageMakerFullAccess."
+  }
 }
 
 # -----------------------------------------------------------------------------
-# Workspace bucket: preset-created by default.
+# Positive: workspace bucket is preset-created with full hardening.
 # -----------------------------------------------------------------------------
 
 run "sagemaker_creates_workspace_bucket_by_default" {
@@ -76,12 +112,26 @@ run "sagemaker_creates_workspace_bucket_by_default" {
 
   assert {
     condition     = length(aws_s3_bucket_public_access_block.workspace) == 1
-    error_message = "Public-access-block resource must exist on the preset-created workspace bucket (security default)."
+    error_message = "Public-access-block resource must exist on the preset-created workspace bucket."
+  }
+
+  # Encryption + versioning positive assertions — a refactor that
+  # accidentally deleted either sibling resource would otherwise pass
+  # this run (the caller-supplied companion below pins length == 0,
+  # but that's the negative form).
+  assert {
+    condition     = length(aws_s3_bucket_versioning.workspace) == 1
+    error_message = "Versioning resource must exist on the preset-created workspace bucket."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_server_side_encryption_configuration.workspace) == 1
+    error_message = "SSE configuration resource must exist on the preset-created workspace bucket."
   }
 }
 
 # -----------------------------------------------------------------------------
-# Workspace bucket: caller-supplied → preset skips its own bucket.
+# Positive: caller-supplied workspace_bucket suppresses every preset S3 resource.
 # -----------------------------------------------------------------------------
 
 run "sagemaker_adopts_caller_supplied_workspace_bucket" {
@@ -111,7 +161,7 @@ run "sagemaker_adopts_caller_supplied_workspace_bucket" {
 }
 
 # -----------------------------------------------------------------------------
-# VPC mode: vpc_id + subnet_ids → VpcOnly.
+# Positive: VpcOnly mode flips app_network_access_type and propagates inputs.
 # -----------------------------------------------------------------------------
 
 run "sagemaker_vpc_only_mode_flips_network_access" {
@@ -141,7 +191,7 @@ run "sagemaker_vpc_only_mode_flips_network_access" {
 }
 
 # -----------------------------------------------------------------------------
-# Studio user profiles: for_each over var.studio_users.
+# Positive: Studio user profiles attach to the preset's domain.
 # -----------------------------------------------------------------------------
 
 run "sagemaker_studio_users_create_profiles" {
@@ -163,6 +213,12 @@ run "sagemaker_studio_users_create_profiles" {
     condition     = aws_sagemaker_user_profile.studio_user["alice"].user_profile_name == "alice"
     error_message = "Per-user profile name must match the studio_users entry."
   }
+
+  # We can't pin `domain_id == aws_sagemaker_domain.studio.id` under
+  # plan mode (both sides are Computed → unknown → assertion silently
+  # skipped). The Go composer wiring test
+  # `TestComposeStack_AWSSageMaker_Forward` exercises this wiring path
+  # end-to-end against the rendered composed root.
 }
 
 run "sagemaker_no_studio_users_no_profiles" {
@@ -181,8 +237,64 @@ run "sagemaker_no_studio_users_no_profiles" {
 }
 
 # -----------------------------------------------------------------------------
+# Positive triangulation companions for the rejection-axis negatives below.
+# Pattern from #614 (`cloud_deploy_single_valid_target_plans_cleanly`):
+# without these, a negative could pass for the wrong reason (e.g. the
+# `alltrue` short-circuiting before the regex even fires).
+# -----------------------------------------------------------------------------
+
+run "sagemaker_valid_user_name_plans_cleanly" {
+  command = plan
+
+  variables {
+    project      = "test"
+    vpc_id       = "vpc-12345"
+    subnet_ids   = ["subnet-aaa"]
+    studio_users = ["valid-user"]
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_user_profile.studio_user) == 1
+    error_message = "A regex-valid studio_users entry must plan cleanly (companion to rejects_bad_user_name)."
+  }
+}
+
+run "sagemaker_valid_workspace_bucket_plans_cleanly" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    workspace_bucket = "valid-bucket-name"
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket.workspace) == 0
+    error_message = "A regex-valid workspace_bucket must plan cleanly with the preset's S3 resources suppressed (companion to rejects_bad_workspace_bucket_name)."
+  }
+}
+
+run "sagemaker_valid_policy_arn_plans_cleanly" {
+  command = plan
+
+  variables {
+    project                      = "test"
+    vpc_id                       = "vpc-12345"
+    subnet_ids                   = ["subnet-aaa"]
+    sagemaker_managed_policy_arn = "arn:aws:iam::123456789012:policy/MyScopedSageMaker"
+  }
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.studio_managed.policy_arn == "arn:aws:iam::123456789012:policy/MyScopedSageMaker"
+    error_message = "A regex-valid sagemaker_managed_policy_arn must plan cleanly and propagate to the attachment (companion to rejects_bad_policy_arn)."
+  }
+}
+
+# -----------------------------------------------------------------------------
 # Negative cases — validation must reject obvious misconfigurations at plan
-# time so callers don't discover them at apply.
+# time so callers don't discover them at apply. Each axis is paired with a
+# positive companion above for rejection-axis triangulation.
 # -----------------------------------------------------------------------------
 
 run "sagemaker_rejects_bad_user_name" {
@@ -242,6 +354,22 @@ run "sagemaker_rejects_empty_project" {
 
   variables {
     project    = "   "
+    vpc_id     = "vpc-12345"
+    subnet_ids = ["subnet-aaa"]
+  }
+
+  expect_failures = [var.project]
+}
+
+# Pins the new 35-char project cap added to keep the preset-managed
+# S3 bucket name inside AWS's 63-char limit.
+run "sagemaker_rejects_oversized_project" {
+  command = plan
+
+  variables {
+    # 36 chars — one over the limit. The trimspace-non-empty validation
+    # passes; only the length validation should fire.
+    project    = "abcdefghijklmnopqrstuvwxyz1234567890"
     vpc_id     = "vpc-12345"
     subnet_ids = ["subnet-aaa"]
   }

--- a/aws/sagemaker/variables.tf
+++ b/aws/sagemaker/variables.tf
@@ -1,0 +1,112 @@
+variable "project" {
+  description = "Naming / Project-tag prefix for stack resources. The InsideOut inspector filters AWS resources by exact `Project = <project>` match — this value also seeds the SageMaker Studio domain name (`<project>-studio`) so label-less attribution works."
+  type        = string
+  default     = "demo"
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+}
+
+variable "region" {
+  description = "AWS region. Declared so the composer's namespaced wiring (`sagemaker_region`) sees a target — the AWS provider itself picks region up from provider config, so this value is informational at the module level."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "tags" {
+  description = "Extra tags merged onto every taggable resource. The preset always sets `Project = var.project`; entries here override or extend that base set."
+  type        = map(string)
+  default     = {}
+}
+
+# -----------------------------------------------------------------------------
+# Networking (required — AWS provider 6.x demands vpc_id + subnet_ids on
+# every SageMaker domain regardless of access mode)
+# -----------------------------------------------------------------------------
+
+variable "vpc_id" {
+  description = "VPC ID the SageMaker domain attaches to. Required by AWS provider 6.x for every domain (even in PublicInternetOnly mode the Studio app ENIs land in your VPC). Composer wires this from `module.aws_vpc.vpc_id` automatically when KeyAWSVPC is selected."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.vpc_id)) > 0
+    error_message = "vpc_id must be a non-empty string."
+  }
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs the Studio domain attaches to. Required (non-empty). For VpcOnly mode use private subnets; for PublicInternetOnly mode either tier works (the ENIs need outbound only). Composer wires this from `module.aws_vpc.private_subnet_ids` automatically when KeyAWSVPC is selected."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.subnet_ids) > 0
+    error_message = "subnet_ids must contain at least one subnet ID."
+  }
+}
+
+variable "network_mode" {
+  description = "SageMaker Studio app network access type. `PublicInternetOnly` (default) keeps egress through AWS-managed networking; `VpcOnly` forces all egress through the customer VPC (requires NAT or VPC endpoints for the SageMaker control plane)."
+  type        = string
+  default     = "PublicInternetOnly"
+
+  validation {
+    condition     = contains(["PublicInternetOnly", "VpcOnly"], var.network_mode)
+    error_message = "network_mode must be one of: PublicInternetOnly, VpcOnly."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Workspace S3 bucket
+# -----------------------------------------------------------------------------
+
+variable "workspace_bucket" {
+  description = "Caller-supplied S3 bucket name to use as the Studio workspace. Null lets the preset create one named `<project>-sagemaker-workspace` (versioning + AES256 + public-access-block, all on)."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.workspace_bucket == null ? true : can(regex("^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$", var.workspace_bucket))
+    error_message = "workspace_bucket must be a valid S3 bucket name (3-63 chars, lowercase alphanumeric / hyphens / dots, start+end alphanumeric)."
+  }
+}
+
+variable "workspace_bucket_force_destroy" {
+  description = "Whether `force_destroy` is set on the preset-managed workspace bucket. Only meaningful when `workspace_bucket == null`. Default false matches AWS console behavior — `terraform destroy` fails on a non-empty bucket."
+  type        = bool
+  default     = false
+}
+
+# -----------------------------------------------------------------------------
+# Studio user profiles
+# -----------------------------------------------------------------------------
+
+variable "studio_users" {
+  description = "List of Studio user-profile names to provision under the domain. Empty list = domain-only (admins create users out-of-band)."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for u in var.studio_users :
+      can(regex("^[a-zA-Z0-9](-*[a-zA-Z0-9])*$", u)) && length(u) <= 63
+    ])
+    error_message = "Every studio_users entry must be 1-63 chars, alphanumeric or hyphen, not starting/ending with a hyphen (SageMaker user-profile naming rule)."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# IAM policy override
+# -----------------------------------------------------------------------------
+
+variable "sagemaker_managed_policy_arn" {
+  description = "AWS-managed policy ARN attached to the Studio execution role. Defaults to `AmazonSageMakerFullAccess` (broad — required for general Studio usage). Override with a scoped-down policy ARN in locked-down environments."
+  type        = string
+  default     = "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
+
+  validation {
+    condition     = can(regex("^arn:aws[a-zA-Z-]*:iam::(aws|[0-9]{12}):policy/", var.sagemaker_managed_policy_arn))
+    error_message = "sagemaker_managed_policy_arn must be a valid IAM policy ARN (arn:aws:iam::aws:policy/... or arn:aws:iam::<account>:policy/...)."
+  }
+}

--- a/aws/sagemaker/variables.tf
+++ b/aws/sagemaker/variables.tf
@@ -1,5 +1,5 @@
 variable "project" {
-  description = "Naming / Project-tag prefix for stack resources. The InsideOut inspector filters AWS resources by exact `Project = <project>` match — this value also seeds the SageMaker Studio domain name (`<project>-studio`) so label-less attribution works."
+  description = "Naming / Project-tag prefix for stack resources. The InsideOut inspector filters AWS resources by exact `Project = <project>` match — this value also seeds the SageMaker Studio domain name (`<project>-studio`) so label-less attribution works. Capped at 35 chars so the preset-created workspace bucket name (`<project>-sagemaker-workspace-<6hex>`, 28 fixed chars) stays inside S3's 63-char hard limit."
   type        = string
   default     = "demo"
 
@@ -7,16 +7,32 @@ variable "project" {
     condition     = length(trimspace(var.project)) > 0
     error_message = "project must be a non-empty string."
   }
+
+  validation {
+    condition     = length(var.project) <= 35
+    error_message = "project must be 35 chars or fewer so the preset-created S3 workspace bucket name fits inside the 63-char AWS limit (project + `-sagemaker-workspace-<6hex>` = 28 fixed chars)."
+  }
 }
 
 variable "region" {
-  description = "AWS region. Declared so the composer's namespaced wiring (`sagemaker_region`) sees a target — the AWS provider itself picks region up from provider config, so this value is informational at the module level."
+  description = "AWS region. Passed into the luthername module so the standard tag set carries the region, and threaded through to S3 ARN partition resolution. The AWS provider itself picks region up from provider config."
   type        = string
   default     = "us-east-1"
 }
 
+variable "environment" {
+  description = "Deployment environment (e.g. production, staging, sandbox). Feeds the luthername module's standard tag set; not used elsewhere in the preset."
+  type        = string
+  default     = "sandbox"
+
+  validation {
+    condition     = length(trimspace(var.environment)) > 0
+    error_message = "environment must be a non-empty string."
+  }
+}
+
 variable "tags" {
-  description = "Extra tags merged onto every taggable resource. The preset always sets `Project = var.project`; entries here override or extend that base set."
+  description = "Extra tags merged onto every taggable resource. The preset always sets the standard luthername tag set (including `Project = var.project`); entries here override or extend that base set."
   type        = map(string)
   default     = {}
 }

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -53,6 +53,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.AWSECS)
 	case KeyAWSLambda:
 		return boolPtrTrue(c.AWSLambda)
+	case KeyAWSSageMaker:
+		return boolPtrTrue(c.AWSSageMaker)
 	case KeyAWSALB:
 		return boolPtrTrue(c.AWSALB)
 	case KeyAWSCloudfront:
@@ -291,7 +293,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyAWSCloudfront, KeyAWSRDS, KeyAWSElastiCache,
 		KeyAWSS3, KeyAWSDynamoDB, KeyAWSSQS, KeyAWSMSK,
 		KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
-		KeyAWSCognito, KeyAWSLambda, KeyAWSAPIGateway,
+		KeyAWSCognito, KeyAWSLambda, KeyAWSSageMaker, KeyAWSAPIGateway,
 		KeyAWSKMS, KeyAWSSecretsManager, KeyAWSOpenSearch,
 		KeyAWSBedrock, KeyAWSBackups, KeyAWSRoute53,
 		KeyAWSACM,

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -41,6 +41,7 @@ const (
 	KeyAWSEKS                  ComponentKey = "aws_eks"
 	KeyAWSECS                  ComponentKey = "aws_ecs"
 	KeyAWSLambda               ComponentKey = "aws_lambda"
+	KeyAWSSageMaker            ComponentKey = "aws_sagemaker"
 	KeyAWSALB                  ComponentKey = "aws_alb"
 	KeyAWSCloudfront           ComponentKey = "aws_cloudfront"
 	KeyAWSWAF                  ComponentKey = "aws_waf"
@@ -153,6 +154,7 @@ var ComposeOrder = []ComponentKey{
 	KeyGCPSecretManager,
 	KeyAWSOpenSearch,
 	KeyAWSBedrock,
+	KeyAWSSageMaker,
 	KeyGCPVertexAI,
 	KeyAWSSQS,
 	KeyGCPPubSub,
@@ -187,6 +189,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyAWSEKSNodeGroup:         "modules/eks_nodegroup",
 	KeyAWSECS:                  "modules/ecs",
 	KeyAWSLambda:               "modules/lambda",
+	KeyAWSSageMaker:            "modules/sagemaker",
 	KeyAWSALB:                  "modules/alb",
 	KeyAWSCloudfront:           "modules/cloudfront",
 	KeyAWSWAF:                  "modules/waf",
@@ -257,6 +260,11 @@ var ImplicitDependencies = map[ComponentKey][]ComponentKey{
 	KeyAWSECS:          {KeyAWSVPC},
 	KeyGCPGKE:          {KeyGCPVPC},
 	KeyAWSLambda:       {KeyAWSVPC},
+	// SageMaker (#615): the AWS provider 6.x resource demands vpc_id +
+	// subnet_ids on every aws_sagemaker_domain, regardless of whether the
+	// network_mode is PublicInternetOnly or VpcOnly — selecting SageMaker
+	// without a VPC leaves the required inputs without a wired source.
+	KeyAWSSageMaker: {KeyAWSVPC},
 	KeyAWSEKSNodeGroup: {KeyAWSEKS, KeyAWSVPC},
 	KeyAWSEC2:          {KeyAWSVPC},
 	KeyGCPCompute:      {KeyGCPVPC},
@@ -368,6 +376,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyAWSEKS:                  "eks",
 	KeyAWSECS:                  "ecs",
 	KeyAWSLambda:               "lambda",
+	KeyAWSSageMaker:            "sagemaker",
 	KeyAWSALB:                  "alb",
 	KeyAWSCloudfront:           "cloudfront",
 	KeyAWSWAF:                  "waf",
@@ -503,6 +512,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyAWSRoute53,
 	KeyAWSS3,
 	KeyAWSSQS,
+	KeyAWSSageMaker,
 	KeyAWSSecretsManager,
 	KeyAWSVPC,
 	KeyAWSWAF,
@@ -682,6 +692,31 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.RawHCL["subnet_ids"] = vpc + ".private_subnet_ids"
 			wi.RawHCL["security_group_ids"] = "[]"
 			wi.Names = append(wi.Names, "enable_vpc", "vpc_id", "subnet_ids", "security_group_ids")
+		}
+
+	case KeyAWSSageMaker:
+		// SageMaker domains demand vpc_id + subnet_ids on every shape
+		// (AWS provider 6.x required arguments). The composer's
+		// ImplicitDependencies entry guarantees KeyAWSVPC is selected
+		// whenever KeyAWSSageMaker is — so the vpcRef wiring is always
+		// satisfiable here.
+		//
+		// We prefer private subnets when available; on a Public-VPC stack
+		// (no private subnets) we fall back to public subnets so the
+		// resource at least gets a non-empty list. The studio app ENIs
+		// only need outbound network so public subnets work for both
+		// PublicInternetOnly and VpcOnly modes — VpcOnly callers who want
+		// strict private-only egress should switch the upstream VPC off
+		// "Public VPC" so private subnets are provisioned.
+		if hasVPC {
+			vpc := vpcRef(selected)
+			wi.RawHCL["vpc_id"] = vpc + ".vpc_id"
+			if isPublicVPC(comps) {
+				wi.RawHCL["subnet_ids"] = vpc + ".public_subnet_ids"
+			} else {
+				wi.RawHCL["subnet_ids"] = vpc + ".private_subnet_ids"
+			}
+			wi.Names = append(wi.Names, "vpc_id", "subnet_ids")
 		}
 
 	case KeyAWSEKSNodeGroup:

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -38,6 +38,24 @@ var AWSIAMActions = map[ComponentKey][]string{
 	KeyAWSEKSNodeGroup:         {"eks:CreateNodegroup"},
 	KeyAWSECS:                  {"ecs:CreateCluster", "ecs:CreateService"},
 	KeyAWSLambda:               {"lambda:CreateFunction"},
+	// SageMaker Studio (#615). Domain + user-profile CREATE + the IAM
+	// execution role / inline policy + the workspace S3 bucket setup
+	// (versioning / encryption / public-access block). PassRole is needed
+	// so the SageMaker control plane can assume the execution role we
+	// create. Specific create permissions catch the fail-fast surface
+	// before terraform hits AWS.
+	KeyAWSSageMaker: {
+		"iam:AttachRolePolicy",
+		"iam:CreateRole",
+		"iam:PassRole",
+		"iam:PutRolePolicy",
+		"s3:CreateBucket",
+		"s3:PutBucketPublicAccessBlock",
+		"s3:PutBucketVersioning",
+		"s3:PutEncryptionConfiguration",
+		"sagemaker:CreateDomain",
+		"sagemaker:CreateUserProfile",
+	},
 	KeyAWSALB:                  {"elasticloadbalancing:CreateLoadBalancer", "elasticloadbalancing:CreateTargetGroup"},
 	KeyAWSCloudfront:           {"cloudfront:CreateDistribution"},
 	KeyAWSWAF:                  {"wafv2:CreateWebACL"},

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1081,6 +1081,72 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+	case KeyAWSSageMaker:
+		// SageMaker Studio (#615). vpc_id + subnet_ids are required by the
+		// preset (AWS provider 6.x demands them on aws_sagemaker_domain).
+		// The composer's KeyAWSSageMaker → KeyAWSVPC implicit dep + the
+		// DefaultWiring case in contracts.go normally fills these from
+		// module.aws_vpc — but for single-module previews and tests that
+		// don't include the VPC, we drop in preview-safe stubs so the
+		// composed root parses cleanly. The stubs are obviously not real
+		// AWS resource IDs (preview-vpc / preview-subnet) so any leakage
+		// into a deploy fails loud at apply rather than silently picking
+		// up a wrong VPC.
+		if _, ok := vals["vpc_id"]; !ok {
+			vals["vpc_id"] = "vpc-00000000preview"
+		}
+		if _, ok := vals["subnet_ids"]; !ok {
+			vals["subnet_ids"] = []any{"subnet-00000000preview"}
+		}
+		// Partial-config pattern: only emit overrides for fields the
+		// caller actually populated. Leaving a field zero must let the
+		// preset's own default win (matches the gcp/github_actions
+		// partial-config contract pinned by TestMapper_GCPGitHubActions_PartialConfig).
+		if cfg != nil && cfg.AWSSageMaker != nil {
+			sm := cfg.AWSSageMaker
+			if strings.TrimSpace(sm.VPCID) != "" {
+				vals["vpc_id"] = strings.TrimSpace(sm.VPCID)
+			}
+			if len(sm.SubnetIDs) > 0 {
+				ids := make([]any, 0, len(sm.SubnetIDs))
+				for _, id := range sm.SubnetIDs {
+					t := strings.TrimSpace(id)
+					if t == "" {
+						continue
+					}
+					ids = append(ids, t)
+				}
+				if len(ids) > 0 {
+					vals["subnet_ids"] = ids
+				}
+			}
+			if strings.TrimSpace(sm.NetworkMode) != "" {
+				vals["network_mode"] = strings.TrimSpace(sm.NetworkMode)
+			}
+			if strings.TrimSpace(sm.WorkspaceBucket) != "" {
+				vals["workspace_bucket"] = strings.TrimSpace(sm.WorkspaceBucket)
+			}
+			if sm.WorkspaceBucketForceDestroy != nil {
+				vals["workspace_bucket_force_destroy"] = *sm.WorkspaceBucketForceDestroy
+			}
+			if len(sm.StudioUsers) > 0 {
+				us := make([]any, 0, len(sm.StudioUsers))
+				for _, u := range sm.StudioUsers {
+					t := strings.TrimSpace(u)
+					if t == "" {
+						continue
+					}
+					us = append(us, t)
+				}
+				if len(us) > 0 {
+					vals["studio_users"] = us
+				}
+			}
+			if strings.TrimSpace(sm.SageMakerManagedPolicyARN) != "" {
+				vals["sagemaker_managed_policy_arn"] = strings.TrimSpace(sm.SageMakerManagedPolicyARN)
+			}
+		}
+
 	case KeyGCPGitHubActions:
 		// GCP GitHub Actions WIF (#597 row 1). github_repository is required
 		// by the preset (no default); supply a preview-safe placeholder

--- a/pkg/composer/presets.go
+++ b/pkg/composer/presets.go
@@ -80,6 +80,7 @@ func (c *Client) ListAvailableComponentKeys() ([]string, error) {
 
 		// AWS prefixed keys
 		KeyAWSVPC, KeyAWSBastion, KeyAWSEC2, KeyAWSEKS, KeyAWSEKSNodeGroup, KeyAWSECS, KeyAWSLambda,
+		KeyAWSSageMaker,
 		KeyAWSALB, KeyAWSCloudfront, KeyAWSWAF, KeyAWSAPIGateway, KeyAWSRDS,
 		KeyAWSElastiCache, KeyAWSDynamoDB, KeyAWSS3, KeyAWSKMS, KeyAWSSecretsManager,
 		KeyAWSOpenSearch, KeyAWSBedrock, KeyAWSSQS, KeyAWSMSK, KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,

--- a/pkg/composer/sagemaker_aws_wiring_test.go
+++ b/pkg/composer/sagemaker_aws_wiring_test.go
@@ -1,0 +1,321 @@
+package composer
+
+// sagemaker_aws_wiring_test.go covers the issue #615 composer wiring for
+// the aws/sagemaker preset (AWS analog of gcp/vertex_ai for ML workspaces):
+//
+//   - ComponentKey + PresetKeyMap + ModulePath + AllComponentKeys +
+//     ComposeOrder registry entries are exercised by
+//     TestAllComponentKeysCoversPresetKeyMap and
+//     TestMapperKeysSubsetOfModuleVariables (both in sibling files).
+//   - Default mapper provides every required variable — exercised by
+//     TestEveryRequiredVariableIsMappedOrWired.
+//
+// The tests below pin:
+//   - Forward wiring: selecting KeyAWSSageMaker causes the composer to
+//     emit `module "aws_sagemaker"` in the composed root.
+//   - Mapper default: caller-empty cfg.AWSSageMaker produces only the
+//     preview-safe vpc_id / subnet_ids stubs (vpc_id / subnet_ids are
+//     required vars without defaults in the preset). No other overrides
+//     emitted so the module's HCL defaults win.
+//   - Mapper caller-supplied: cfg.AWSSageMaker fields flow through to the
+//     namespaced module variables.
+//   - Mapper partial-config: only fields the caller actually populated
+//     are emitted — leaving others zero must let the preset defaults win.
+//   - End-to-end ComposeStack with AWS + KeyAWSSageMaker succeeds.
+//   - ComponentSelected + AWSIAMActions coverage.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// requireTfvarAssignment is shared with cloud_deploy_gcp_wiring_test.go
+// (5-arg signature: t, tfvars, key, value, msg).
+
+// -----------------------------------------------------------------------------
+// Mapper tests
+// -----------------------------------------------------------------------------
+
+func TestMapper_AWSSageMaker_DefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSSageMaker, &Components{}, &Config{}, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	// Preview-safe stubs for the two required vars (vpc_id + subnet_ids).
+	// Without them single-module preview compose fails with
+	// `missing_required_variable`.
+	vpcID, ok := vals["vpc_id"]
+	require.True(t, ok, "mapper must always set vpc_id (preset has no default — required by AWS provider 6.x for aws_sagemaker_domain)")
+	require.Equal(t, "vpc-00000000preview", vpcID,
+		"default vpc_id should be the obvious-fake preview stub so leakage into a deploy fails loud at AWS apply")
+
+	subnetIDs, ok := vals["subnet_ids"]
+	require.True(t, ok, "mapper must always set subnet_ids (preset has no default)")
+	require.Equal(t, []any{"subnet-00000000preview"}, subnetIDs,
+		"default subnet_ids should be a single-element preview stub list")
+
+	// Optional vars MUST be absent when caller didn't populate cfg.
+	for _, key := range []string{"network_mode", "workspace_bucket", "workspace_bucket_force_destroy", "studio_users", "sagemaker_managed_policy_arn"} {
+		_, has := vals[key]
+		require.Falsef(t, has,
+			"mapper must NOT emit %q when caller left cfg.AWSSageMaker nil — module default must win",
+			key)
+	}
+}
+
+func TestMapper_AWSSageMaker_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	fd := true
+	cfg := &Config{
+		AWSSageMaker: &AWSSageMakerConfig{
+			VPCID:                       "vpc-real",
+			SubnetIDs:                   []string{"subnet-a", "subnet-b"},
+			NetworkMode:                 "VpcOnly",
+			WorkspaceBucket:             "my-bucket",
+			WorkspaceBucketForceDestroy: &fd,
+			StudioUsers:                 []string{"alice", "bob"},
+			SageMakerManagedPolicyARN:   "arn:aws:iam::123456789012:policy/MyScopedSagemaker",
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSSageMaker, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	require.Equal(t, "vpc-real", vals["vpc_id"])
+	require.Equal(t, []any{"subnet-a", "subnet-b"}, vals["subnet_ids"])
+	require.Equal(t, "VpcOnly", vals["network_mode"])
+	require.Equal(t, "my-bucket", vals["workspace_bucket"])
+	require.Equal(t, true, vals["workspace_bucket_force_destroy"])
+	require.Equal(t, []any{"alice", "bob"}, vals["studio_users"])
+	require.Equal(t, "arn:aws:iam::123456789012:policy/MyScopedSagemaker", vals["sagemaker_managed_policy_arn"])
+}
+
+// TestMapper_AWSSageMaker_PartialConfig confirms that when only one
+// optional sub-field is set the mapper emits only that sub-field — the
+// preset's variables.tf defaults must apply to the rest. Catches a class
+// of bug where the mapper would unconditionally emit empty slices /
+// false bools that override the module's defaults.
+func TestMapper_AWSSageMaker_PartialConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSSageMaker: &AWSSageMakerConfig{
+			NetworkMode: "VpcOnly",
+			// VPCID, SubnetIDs, WorkspaceBucket, WorkspaceBucketForceDestroy,
+			// StudioUsers, SageMakerManagedPolicyARN intentionally left at
+			// zero values.
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSSageMaker, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	require.Equal(t, "VpcOnly", vals["network_mode"])
+
+	// vpc_id / subnet_ids stay at the preview stubs (caller didn't set them).
+	require.Equal(t, "vpc-00000000preview", vals["vpc_id"])
+	require.Equal(t, []any{"subnet-00000000preview"}, vals["subnet_ids"])
+
+	for _, key := range []string{"workspace_bucket", "workspace_bucket_force_destroy", "studio_users", "sagemaker_managed_policy_arn"} {
+		_, has := vals[key]
+		require.Falsef(t, has,
+			"mapper must NOT emit %q when caller left it zero — module default must win",
+			key)
+	}
+}
+
+// TestMapper_AWSSageMaker_EmptyStringsIgnored pins the trimspace gates:
+// caller-supplied whitespace-only strings (e.g. an unset form field that
+// arrived as "   ") must be treated as not-set so the preset defaults
+// kick in instead of being overridden with garbage.
+func TestMapper_AWSSageMaker_EmptyStringsIgnored(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSSageMaker: &AWSSageMakerConfig{
+			VPCID:                     "   ",
+			SubnetIDs:                 []string{"", "  ", "subnet-real"},
+			NetworkMode:               "",
+			WorkspaceBucket:           "   ",
+			StudioUsers:               []string{"alice", "  ", ""},
+			SageMakerManagedPolicyARN: "  ",
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSSageMaker, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	// vpc_id: whitespace ignored → falls back to preview stub.
+	require.Equal(t, "vpc-00000000preview", vals["vpc_id"])
+
+	// subnet_ids: empty / whitespace entries dropped, real one kept.
+	require.Equal(t, []any{"subnet-real"}, vals["subnet_ids"])
+
+	// studio_users: empty / whitespace entries dropped.
+	require.Equal(t, []any{"alice"}, vals["studio_users"])
+
+	// Whitespace-only strings on optional scalar fields → not emitted at all.
+	for _, key := range []string{"network_mode", "workspace_bucket", "sagemaker_managed_policy_arn"} {
+		_, has := vals[key]
+		require.Falsef(t, has,
+			"mapper must NOT emit %q when caller supplied a whitespace-only string",
+			key)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// End-to-end ComposeStack tests
+// -----------------------------------------------------------------------------
+
+func TestComposeStack_AWSSageMaker_Forward(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSSageMaker},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok, "composed root must contain main.tf")
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, `module "aws_sagemaker"`,
+		"composed root must declare module aws_sagemaker when KeyAWSSageMaker is selected")
+	// AWS modules use the legacy `modules/<x>` ModulePath (not `aws/<x>`)
+	// — kept for backwards compatibility with the in-account deployer
+	// service that already resolves that path. See PresetKeyMap +
+	// ModulePath in contracts.go.
+	require.Contains(t, rootStr, `"./modules/sagemaker"`,
+		"module source path must resolve to modules/sagemaker per ModulePath")
+
+	// KeyAWSSageMaker → KeyAWSVPC implicit dep: aws_vpc must also appear.
+	require.Contains(t, rootStr, `module "aws_vpc"`,
+		"composer must auto-add KeyAWSVPC when KeyAWSSageMaker is selected (ImplicitDependencies)")
+
+	// Confirm the tfvars file landed.
+	tfvars, ok := out["/aws_sagemaker.auto.tfvars"]
+	require.True(t, ok, "expected aws_sagemaker.auto.tfvars")
+	tfvarsStr := string(tfvars)
+	// The composer namespaces tfvar keys with the module key prefix
+	// (`aws_sagemaker_`) to avoid collisions across modules in the
+	// composed root. project / region are always populated by the mapper.
+	requireTfvarAssignment(t, tfvarsStr, "aws_sagemaker_project", `"test"`,
+		"composer must emit aws_sagemaker_project tfvar from the always-required project mapping")
+	requireTfvarAssignment(t, tfvarsStr, "aws_sagemaker_region", `"us-east-1"`,
+		"composer must emit aws_sagemaker_region tfvar from the always-required region mapping")
+}
+
+func TestComposeStack_AWSSageMaker_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSSageMaker},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg: &Config{
+			Region: "us-east-1",
+			AWSSageMaker: &AWSSageMakerConfig{
+				NetworkMode:               "VpcOnly",
+				WorkspaceBucket:           "shared-ml-bucket",
+				StudioUsers:               []string{"alice", "bob"},
+				SageMakerManagedPolicyARN: "arn:aws:iam::123456789012:policy/MyScopedSagemaker",
+			},
+		},
+		Project: "test",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err)
+
+	tfvars, ok := out["/aws_sagemaker.auto.tfvars"]
+	require.True(t, ok)
+	tfvarsStr := string(tfvars)
+
+	// All tfvar keys are namespaced with the module-key prefix to avoid
+	// collisions across modules in the composed root.
+	requireTfvarAssignment(t, tfvarsStr, "aws_sagemaker_network_mode", `"VpcOnly"`,
+		"caller-supplied NetworkMode must flow through to the namespaced tfvar")
+	requireTfvarAssignment(t, tfvarsStr, "aws_sagemaker_workspace_bucket", `"shared-ml-bucket"`,
+		"caller-supplied WorkspaceBucket must flow through to the namespaced tfvar")
+	requireTfvarAssignment(t, tfvarsStr, "aws_sagemaker_sagemaker_managed_policy_arn",
+		`"arn:aws:iam::123456789012:policy/MyScopedSagemaker"`,
+		"caller-supplied SageMakerManagedPolicyARN must flow through to the namespaced tfvar")
+
+	// studio_users is a list, which the tfvars pretty-printer renders on
+	// multiple lines for longer lists. Bound the substring check to the
+	// studio_users line + the list literal that follows (closing `]`)
+	// so we don't bleed into a later tfvar's value.
+	studioUsersIdx := strings.Index(tfvarsStr, "aws_sagemaker_studio_users")
+	require.GreaterOrEqual(t, studioUsersIdx, 0, "tfvars must contain a studio_users assignment")
+	endIdx := strings.Index(tfvarsStr[studioUsersIdx:], "]")
+	require.GreaterOrEqual(t, endIdx, 0, "studio_users list literal must terminate with ]")
+	studioUsersBlock := tfvarsStr[studioUsersIdx : studioUsersIdx+endIdx+1]
+	require.Contains(t, studioUsersBlock, `"alice"`,
+		"caller-supplied studio_users[0] must flow into the tfvars list")
+	require.Contains(t, studioUsersBlock, `"bob"`,
+		"caller-supplied studio_users[1] must flow into the tfvars list")
+}
+
+// -----------------------------------------------------------------------------
+// Coherence / IAM permission coverage
+// -----------------------------------------------------------------------------
+
+// TestComponentSelected_AWSSageMaker pins the coherence.go entry —
+// without it ComponentSelected returns false for KeyAWSSageMaker and the
+// orphan-strip pass silently clears cfg.AWSSageMaker even when
+// comps.AWSSageMaker = &true.
+func TestComponentSelected_AWSSageMaker(t *testing.T) {
+	t.Parallel()
+
+	tr := true
+	c := &Components{AWSSageMaker: &tr}
+	require.True(t, ComponentSelected(c, KeyAWSSageMaker),
+		"ComponentSelected must return true when comps.AWSSageMaker=&true")
+
+	fa := false
+	c2 := &Components{AWSSageMaker: &fa}
+	require.False(t, ComponentSelected(c2, KeyAWSSageMaker),
+		"ComponentSelected must return false when comps.AWSSageMaker=&false (explicit deselect)")
+
+	c3 := &Components{}
+	require.False(t, ComponentSelected(c3, KeyAWSSageMaker),
+		"ComponentSelected must return false when comps.AWSSageMaker is nil")
+}
+
+// TestAWSIAMPermissions_SageMakerCovered pins the iam_actions.go entry.
+// Without it RequiredAWSIAMActions silently omits the SageMaker /
+// IAM-role / workspace-S3 permissions a real deploy needs — surfacing as
+// a 403 at apply time instead of at SimulatePrincipalPolicy pre-deploy
+// check (ui-core #192).
+func TestAWSIAMPermissions_SageMakerCovered(t *testing.T) {
+	t.Parallel()
+
+	actions, ok := AWSIAMActions[KeyAWSSageMaker]
+	require.True(t, ok, "AWSIAMActions must have an entry for KeyAWSSageMaker")
+	require.NotEmpty(t, actions, "AWSIAMActions[KeyAWSSageMaker] must list at least one action — domain create + role create + workspace bucket setup all require explicit perms beyond the always-required set")
+
+	required := RequiredAWSIAMActions([]ComponentKey{KeyAWSSageMaker})
+	require.Contains(t, required, "sagemaker:CreateDomain",
+		"SageMaker domain create permission must be in the required set")
+	require.Contains(t, required, "sagemaker:CreateUserProfile",
+		"SageMaker user profile create permission must be in the required set")
+	require.Contains(t, required, "iam:PassRole",
+		"PassRole permission must be in the required set (the SageMaker control plane needs to assume the exec role we create)")
+	require.Contains(t, required, "iam:PutRolePolicy",
+		"PutRolePolicy permission must be in the required set (inline workspace-access policy on the exec role)")
+	require.Contains(t, required, "s3:CreateBucket",
+		"S3 CreateBucket permission must be in the required set (preset-managed workspace bucket)")
+	require.Contains(t, required, "s3:PutBucketPublicAccessBlock",
+		"PutBucketPublicAccessBlock permission must be in the required set (security default on the workspace bucket)")
+}

--- a/pkg/composer/sagemaker_aws_wiring_test.go
+++ b/pkg/composer/sagemaker_aws_wiring_test.go
@@ -100,6 +100,15 @@ func TestMapper_AWSSageMaker_CallerSuppliedConfig(t *testing.T) {
 // preset's variables.tf defaults must apply to the rest. Catches a class
 // of bug where the mapper would unconditionally emit empty slices /
 // false bools that override the module's defaults.
+//
+// Note: because AWSSageMakerConfig uses value-type fields (string,
+// []string) rather than pointers, the "leave field unset" path and the
+// "set field to empty string" path collapse into the same code branch
+// — both hit the `strings.TrimSpace(...) != ""` gate and produce no
+// tfvar. This test pins the unset-path; TestMapper_AWSSageMaker_
+// EmptyStringsIgnored pins the explicit-empty-string path. They cover
+// the same predicate from two angles; deleting either would weaken
+// mutation resistance.
 func TestMapper_AWSSageMaker_PartialConfig(t *testing.T) {
 	t.Parallel()
 
@@ -203,6 +212,14 @@ func TestComposeStack_AWSSageMaker_Forward(t *testing.T) {
 	require.Contains(t, rootStr, `module "aws_vpc"`,
 		"composer must auto-add KeyAWSVPC when KeyAWSSageMaker is selected (ImplicitDependencies)")
 
+	// Wiring assertion: aws_sagemaker's vpc_id argument must literally
+	// reference module.aws_vpc.vpc_id. Without this, the previous check
+	// only pins that aws_vpc is emitted — it doesn't pin that the value
+	// actually flows into aws_sagemaker (the preview-stub could still
+	// be leaking through).
+	require.Contains(t, rootStr, `module.aws_vpc.vpc_id`,
+		"DefaultWiring must thread module.aws_vpc.vpc_id into the aws_sagemaker module block")
+
 	// Confirm the tfvars file landed.
 	tfvars, ok := out["/aws_sagemaker.auto.tfvars"]
 	require.True(t, ok, "expected aws_sagemaker.auto.tfvars")
@@ -253,14 +270,19 @@ func TestComposeStack_AWSSageMaker_CallerSuppliedConfig(t *testing.T) {
 		"caller-supplied SageMakerManagedPolicyARN must flow through to the namespaced tfvar")
 
 	// studio_users is a list, which the tfvars pretty-printer renders on
-	// multiple lines for longer lists. Bound the substring check to the
-	// studio_users line + the list literal that follows (closing `]`)
-	// so we don't bleed into a later tfvar's value.
+	// multiple lines. Bound the substring check to the slice between
+	// the studio_users key and the `]` that closes its list literal —
+	// anchoring on the var-name (not on `= [`, which the HCL writer
+	// pads variably) and then skipping forward to the literal `[` makes
+	// the scan robust to column-alignment padding.
 	studioUsersIdx := strings.Index(tfvarsStr, "aws_sagemaker_studio_users")
 	require.GreaterOrEqual(t, studioUsersIdx, 0, "tfvars must contain a studio_users assignment")
-	endIdx := strings.Index(tfvarsStr[studioUsersIdx:], "]")
+	listOpenOffset := strings.Index(tfvarsStr[studioUsersIdx:], "[")
+	require.GreaterOrEqual(t, listOpenOffset, 0, "studio_users assignment must be a list literal")
+	listStartIdx := studioUsersIdx + listOpenOffset
+	endIdx := strings.Index(tfvarsStr[listStartIdx:], "]")
 	require.GreaterOrEqual(t, endIdx, 0, "studio_users list literal must terminate with ]")
-	studioUsersBlock := tfvarsStr[studioUsersIdx : studioUsersIdx+endIdx+1]
+	studioUsersBlock := tfvarsStr[listStartIdx : listStartIdx+endIdx+1]
 	require.Contains(t, studioUsersBlock, `"alice"`,
 		"caller-supplied studio_users[0] must flow into the tfvars list")
 	require.Contains(t, studioUsersBlock, `"bob"`,

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -23,6 +23,7 @@ type Components struct {
 	AWSEKS                  *bool  `json:"aws_eks,omitempty"`
 	AWSECS                  *bool  `json:"aws_ecs,omitempty"`
 	AWSLambda               *bool  `json:"aws_lambda,omitempty"`
+	AWSSageMaker            *bool  `json:"aws_sagemaker,omitempty"`
 	AWSALB                  *bool  `json:"aws_alb,omitempty"`
 	AWSCloudFront           *bool  `json:"aws_cloudfront,omitempty"`
 	AWSWAF                  *bool  `json:"aws_waf,omitempty"`
@@ -201,6 +202,13 @@ type Config struct {
 		MemorySize string `json:"memorySize,omitempty"`
 		Timeout    string `json:"timeout,omitempty"`
 	} `json:"aws_lambda,omitempty"`
+
+	// AWSSageMaker carries the caller-supplied SageMaker Studio config
+	// (#615). Named (not inline) so callers can construct it without
+	// re-typing the anonymous struct shape at every site, and so future
+	// field additions don't force every test instantiation to be touched
+	// (matches the GCPGitHubActionsConfig pattern set in #597).
+	AWSSageMaker *AWSSageMakerConfig `json:"aws_sagemaker,omitempty"`
 
 	AWSAPIGateway *struct {
 		DomainName     string `json:"domainName,omitempty"`
@@ -450,6 +458,27 @@ type GCPCloudDeployConfig struct {
 	Targets                 []GCPCloudDeployTarget `json:"targets,omitempty"`
 }
 
+// AWSSageMakerConfig is the caller-facing config for the aws/sagemaker
+// Studio preset (#615). Named (not inline) so callers can construct it
+// without re-typing the anonymous struct shape at every site, and so
+// future field additions don't force every test instantiation to be
+// touched. Mirrors GCPGitHubActionsConfig pattern.
+//
+// Field semantics map 1:1 to aws/sagemaker/variables.tf. Empty / nil
+// values mean "defer to the module's HCL default" — the mapper only
+// emits a tfvar when the caller supplies a value. VPCID / SubnetIDs are
+// normally wired automatically (DefaultWiring reads module.aws_vpc) so
+// callers don't usually populate them on this struct.
+type AWSSageMakerConfig struct {
+	VPCID                       string   `json:"vpcId,omitempty"`
+	SubnetIDs                   []string `json:"subnetIds,omitempty"`
+	NetworkMode                 string   `json:"networkMode,omitempty"`
+	WorkspaceBucket             string   `json:"workspaceBucket,omitempty"`
+	WorkspaceBucketForceDestroy *bool    `json:"workspaceBucketForceDestroy,omitempty"`
+	StudioUsers                 []string `json:"studioUsers,omitempty"`
+	SageMakerManagedPolicyARN   string   `json:"sagemakerManagedPolicyArn,omitempty"`
+}
+
 // VarEntry holds a module variable name and a value (or nil). RawExpr can be used for expressions.
 type VarEntry struct {
 	Name  string
@@ -505,6 +534,7 @@ func (c *Components) Normalize() {
 		c.AWSEKS = nil
 		c.AWSECS = nil
 		c.AWSLambda = nil
+		c.AWSSageMaker = nil
 		c.AWSALB = nil
 		c.AWSCloudFront = nil
 		c.AWSWAF = nil
@@ -630,6 +660,7 @@ func (c *Config) Normalize() {
 		c.AWSCloudWatchMonitoring = nil
 		c.AWSCognito = nil
 		c.AWSLambda = nil
+		c.AWSSageMaker = nil
 		c.AWSAPIGateway = nil
 		c.AWSKMS = nil
 		c.AWSSecretsManager = nil

--- a/pkg/observability/display.go
+++ b/pkg/observability/display.go
@@ -109,6 +109,8 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "AWS Cognito"
 	case composer.KeyAWSLambda:
 		return "AWS Lambda"
+	case composer.KeyAWSSageMaker:
+		return "AWS SageMaker"
 	case composer.KeyAWSALB:
 		return "AWS Application Load Balancer"
 	case composer.KeyAWSWAF:

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -69,6 +69,8 @@ var configExtractorAllowlist = map[string]string{
 	// own SDK inspector — extraction is handled by aws_eks (#204, #224).
 	"aws_eks_nodegroup": "[no-inspector] EKS node group is covered by the aws_eks inspector (#204)",
 
+	"aws_sagemaker": "[no-inspector] SageMaker Studio inspector deferred (#615 explicitly marks discovery inspector as optional/follow-up — domain + execution role are surfaced via name-prefix scoping until per-resource extractors land)",
+
 	"gcp_backups":      "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
 	"gcp_cloud_deploy": "[no-inspector] Cloud Deploy delivery-pipeline inspector deferred (#613 explicitly marks discovery inspector + extractor as optional/follow-up); ComponentMetricsMapping has no entry yet so the panel falls back to design values until the per-component extractor lands",
 	"gcp_cloud_dns":    "[no-inspector] Cloud DNS dispatcher landed in #596 (gcp/dns.go); per-component extractor (config map for panel) deferred pending zone-detail field reads (visibility, dnssec_config, record-count summary)",


### PR DESCRIPTION
## Summary

Closes #615 — adds an `aws/sagemaker` Studio preset mirroring the role `gcp/vertex_ai` plays for GCP stacks. Closes the AWS↔GCP managed-ML parity gap (#598 row 1).

- **Preset** (`aws/sagemaker/`): a single-call SageMaker Studio entrypoint — domain (auth_mode IAM, configurable PublicInternetOnly / VpcOnly access), execution IAM role with `aws:SourceAccount` confused-deputy guard, optional preset-managed workspace S3 bucket (versioning + AES256 + public-access-block on; random-suffix bucket name for global uniqueness) or caller-supplied bucket adoption, and optional Studio user profiles via `for_each = toset(var.studio_users)`. Standard luthername-driven tag set so the InsideOut inspector's exact `Project = <project>` filter sees every resource.
- **Composer wiring**: `KeyAWSSageMaker`, `Components.AWSSageMaker *bool`, `Config.AWSSageMaker *AWSSageMakerConfig` (named) + full registry coverage (`AllComponentKeys`, `ComposeOrder`, `ModulePath = "modules/sagemaker"`, `PresetKeyMap`, `ComponentSelected`, `isOrphanStrippableKey`, `AWSIAMActions`). `ImplicitDependencies` auto-pulls `KeyAWSVPC` (AWS provider 6.x demands `vpc_id` + `subnet_ids` on every SageMaker domain regardless of network mode); `DefaultWiring` threads `vpc_id` from `module.aws_vpc.vpc_id` and `subnet_ids` from the appropriate subnet tier per `isPublicVPC`.
- **Mapper**: every Config field is optional. Partial-config callers fall back to the preset's `variables.tf` defaults rather than getting empty slices / false bools overridden onto them (`strings.TrimSpace` gates).
- **Tests**: 9 composer wiring tests + 17 tftest plan-time `run` blocks (positive happy path, three positive-companion triangulation runs, eight rejection-axis negatives with `expect_failures`).

Discovery inspector + per-component extractor are explicitly deferred per the issue scope; the `[no-inspector]` rationale on `configExtractorAllowlist["aws_sagemaker"]` references #615 so the next person picking that up has the breadcrumb. Same pattern as #614 (`gcp/cloud_deploy`).

## Test plan

- [x] `terraform fmt -check -recursive` — clean
- [x] 5 static lints PASS (`project-tag`, `project-label`, `sensitive-for-each`, `foreach-unknown-keys`, `no-root-only-blocks`)
- [x] `tests/validate-as-child.sh aws/sagemaker` — PASS
- [x] `terraform validate aws/sagemaker/` — clean (one deprecation warning on `managed_policy_arns` ignore_changes, mirroring aws/lambda + aws/bedrock)
- [x] `cd aws/sagemaker && terraform test` — 17 passed, 0 failed
- [x] `go test ./pkg/composer/...` — 2098 passed
- [x] `go test ./pkg/observability/...` — 1272 passed
- [x] `go vet ./...` / `go build ./...` — clean
- [ ] CI green

## Review notes

**/review findings** (all addressed pre-PR):
- P0: 0
- P1: 4 — *missing canonical `module "name"` tag pattern*, *unbounded `var.project` length blew the S3 bucket-name 63-char limit*, *workspace bucket ARN hardcoded `aws:` partition*, *positive-side encryption/versioning assertions missing from `creates_workspace_bucket_by_default`*. Addressed in `refactor(aws/sagemaker): address /review P1 findings` + `test(aws/sagemaker): address qa-professor findings`.
- P2: 6 — region passthrough, partition-aware ARN, regex tightening — addressed as drive-bys.
- P3: 3 — small triangulation suggestions absorbed into the test commit.

**qa-professor findings** (all addressed pre-PR):
- P1-1: *`lifecycle.precondition` cross-attr check on the domain trapped `expect_failures = [var.vpc_id]` / `[var.subnet_ids]` attribution ambiguously*. Precondition removed; per-variable validations carry the same constraints with unambiguous attribution.
- P1-2: *Missing positive companions for the rejection axes (a negative could pass for the wrong reason)*. Added `sagemaker_valid_user_name_plans_cleanly`, `sagemaker_valid_workspace_bucket_plans_cleanly`, `sagemaker_valid_policy_arn_plans_cleanly`.
- P1-3: *Happy-path `command = plan` may silently skip unknown cross-refs*. Documented the trade-off in the tftest header: every run stays on plan because `mock_provider "aws"` emits random strings for ARN-shaped Computed fields, which the SageMaker domain's `execution_role` validator rejects at apply. The wiring-cross-ref concerns are addressed end-to-end in `TestComposeStack_AWSSageMaker_Forward` (with the new `module.aws_vpc.vpc_id` substring assertion).
- P2: IAM trust-policy / managed-policy attachment / `aws:SourceAccount` substring assertions added on the happy path; studio_users substring scan tightened to skip HCL column-alignment padding; PartialConfig + EmptyStringsIgnored coexistence documented; new `sagemaker_rejects_oversized_project` exercises the new 35-char project cap.

## Deferred follow-ups

- Discovery inspector + per-component extractor for `aws_sagemaker` (`[no-inspector]` rationale in `configExtractorAllowlist` references #615 — clean breadcrumb for the next pickup).
- Pricing entry for SageMaker (would naturally extend the existing Bedrock↔VertexAI reciprocal sync at `pricing.go:364-369` — deferred to a separate PR once SageMaker pricing data is available).
- Remaining #598 rows: App Runner (row 2), CodeBuild standalone (row 3) — separate split-PRs once this lands.

## Cross-references

- Parent rollup: #598 row 1.
- Sister GCP preset: `gcp/vertex_ai` (`KeyGCPVertexAI`).
- Most recent preset PR following this exact pattern: #614 / #613 (`gcp/cloud_deploy`).
- AWS provider 6.x pin (bumped in #611).