### PR TITLE
feat(aws/apprunner): add App Runner preset + close out #598

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-InsideOut Terraform Presets — a library of standardized, composable Terraform module presets for AWS (29 modules) and GCP (22 modules). Used standalone or composed by the InsideOut engine to generate cloud infrastructure stacks. Currently in beta.
+InsideOut Terraform Presets — a library of standardized, composable Terraform module presets for AWS (35 modules) and GCP (25 modules). Used standalone or composed by the InsideOut engine to generate cloud infrastructure stacks. Currently in beta.
 
 The Go module (`zz_embed.go`) embeds all `.tf` and `.tmpl` files via `embed.FS` for use by the InsideOut composition engine.
 
@@ -28,8 +28,8 @@ terraform fmt -recursive
 ## Architecture
 
 ```
-aws/<module>/          # AWS Terraform modules (29 modules)
-gcp/<module>/          # GCP Terraform modules (22 modules)
+aws/<module>/          # AWS Terraform modules (35 modules)
+gcp/<module>/          # GCP Terraform modules (25 modules)
 zz_embed.go            # Go embed directive exposing FS for all .tf/.tmpl files
 go.mod                 # Go module: github.com/luthersystems/insideout-terraform-presets
 ```

--- a/aws/apprunner/main.tf
+++ b/aws/apprunner/main.tf
@@ -1,0 +1,314 @@
+# AWS App Runner service preset (#598 Row 2).
+#
+# Mirrors the role gcp/cloud_run plays for GCP stacks: a single-call entry
+# point for a managed-container service on AWS. The preset provisions:
+#
+#   - An App Runner service (`aws_apprunner_service`) named
+#     `${var.project}-${var.service_name}` so the InsideOut inspector can
+#     attribute it to the stack via name-prefix scoping (CLAUDE.md
+#     "name-prefix scoping" rule).
+#   - A versioned autoscaling configuration
+#     (`aws_apprunner_auto_scaling_configuration_version`) bound to the
+#     service. The configuration is a separate top-level resource whose
+#     name changes on any field mutation; `create_before_destroy` plus
+#     name suffixing keep replace-cycles clean instead of orphaning
+#     versions that block the service delete.
+#   - An ECR access IAM role (`aws_iam_role.access`) — only created when
+#     `image_repository_type = "ECR"`. App Runner's build plane assumes it
+#     to pull from private ECR. Carries the `aws:SourceAccount`
+#     confused-deputy guard (matches aws/sagemaker + aws/bedrock).
+#   - An instance IAM role (`aws_iam_role.instance`) the running tasks
+#     assume. Default trust policy only; callers attach app-specific
+#     policies out-of-band via the role name/ARN outputs.
+#   - Optional VPC connector + matching security group for private egress
+#     (`aws_apprunner_vpc_connector` + `aws_security_group.vpc_connector`)
+#     when `enable_vpc_connector = true`.
+#   - Optional custom domain association
+#     (`aws_apprunner_custom_domain_association`) when
+#     `custom_domain_name != null`. AWS validates the cert asynchronously
+#     post-apply — the preset returns the DNS-01 validation records as an
+#     output so callers can complete the manual step in their DNS provider.
+#
+# Scope ceiling: matches gcp/cloud_run simplicity. Source-code based
+# services (vs. image), tracing/observability bindings, and KMS-encrypted
+# secrets are exposed only as the AWS provider defaults — advanced
+# consumers wrap or fork.
+#
+# Discovery inspector: deferred per #598 (issue marks discovery inspector
+# as optional follow-up for every parity row). See
+# `pkg/observability/extractors/extractors_drift_test.go` allowlist.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
+  }
+}
+
+# Standard luthername-driven naming + tag set. Every AWS preset in the
+# repo wires through this module so the InsideOut inspector's exact
+# `Project = <project>` filter (CLAUDE.md issue #81) catches every
+# resource.
+module "name" {
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
+  luther_project = var.project
+  aws_region     = var.region
+  luther_env     = var.environment
+  org_name       = "luthersystems"
+  component      = "insideout"
+  subcomponent   = "ar"
+  resource       = "ar"
+}
+
+# Caller identity drives the aws:SourceAccount confused-deputy guard on
+# the App Runner service-role trust policies (matches aws/sagemaker +
+# aws/bedrock).
+data "aws_caller_identity" "current" {}
+
+locals {
+  # Project-tag merge from the luthername module so every taggable
+  # resource carries the full standard tag set.
+  tags = merge(module.name.tags, var.tags)
+
+  service_name = "${var.project}-${var.service_name}"
+
+  needs_access_role   = var.image_repository_type == "ECR"
+  needs_vpc_connector = var.enable_vpc_connector
+
+  # Autoscaling-config name suffix per-create so a CPU/memory mutation
+  # rolls the version forward via create_before_destroy without
+  # name-collision on the new version.
+  autoscaling_name = "${var.project}-${var.service_name}-${random_id.autoscaling_suffix.hex}"
+}
+
+resource "random_id" "autoscaling_suffix" {
+  byte_length = 3
+}
+
+# -----------------------------------------------------------------------------
+# IAM access role (ECR pull) — only when pulling from private ECR.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "access" {
+  count = local.needs_access_role ? 1 : 0
+
+  name = "${var.project}-apprunner-access"
+  path = "/service-role/"
+
+  # build.apprunner.amazonaws.com is the App Runner build plane
+  # service principal — distinct from the tasks.apprunner.amazonaws.com
+  # used on the instance role below. Scoped to the deploying account
+  # via aws:SourceAccount so a hostile cross-account caller can't
+  # trick App Runner into using this role on their behalf.
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "build.apprunner.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+        }
+      }
+    }]
+  })
+
+  tags = local.tags
+
+  lifecycle {
+    ignore_changes = [managed_policy_arns]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "access_ecr" {
+  count = local.needs_access_role ? 1 : 0
+
+  role       = aws_iam_role.access[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess"
+}
+
+# -----------------------------------------------------------------------------
+# IAM instance role — assumed by running tasks. Callers attach app-specific
+# permissions out-of-band via the role name/ARN outputs.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "instance" {
+  name = "${var.project}-apprunner-instance"
+  path = "/service-role/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "tasks.apprunner.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+        }
+      }
+    }]
+  })
+
+  tags = local.tags
+
+  lifecycle {
+    ignore_changes = [managed_policy_arns]
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Optional VPC connector for private egress.
+#
+# The matching security group has no ingress rules (App Runner doesn't
+# accept inbound from the customer VPC — only the service URL takes
+# traffic) and a single egress-all rule so the running tasks can reach
+# whatever private resource the caller is wiring (RDS, ElastiCache,
+# OpenSearch, internal ALB, etc.).
+# -----------------------------------------------------------------------------
+
+resource "aws_security_group" "vpc_connector" {
+  count = local.needs_vpc_connector ? 1 : 0
+
+  name        = "${var.project}-apprunner-vpcconnector"
+  description = "App Runner VPC connector egress for ${local.service_name}"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all egress from the App Runner VPC connector"
+  }
+
+  tags = local.tags
+}
+
+resource "aws_apprunner_vpc_connector" "main" {
+  count = local.needs_vpc_connector ? 1 : 0
+
+  vpc_connector_name = "${var.project}-apprunner-vpc"
+  subnets            = var.subnet_ids
+  security_groups    = [aws_security_group.vpc_connector[0].id]
+
+  tags = local.tags
+}
+
+# -----------------------------------------------------------------------------
+# Autoscaling configuration.
+#
+# App Runner versions every autoscaling config — any change spawns a new
+# version. We suffix the configuration_name with a random_id so the
+# create_before_destroy lifecycle can replace versions cleanly when a
+# caller tunes min/max/concurrency. Without the suffix, the new version
+# would collide on the existing name and the apply would fail.
+# -----------------------------------------------------------------------------
+
+resource "aws_apprunner_auto_scaling_configuration_version" "main" {
+  auto_scaling_configuration_name = local.autoscaling_name
+
+  max_concurrency = var.max_concurrency
+  max_size        = var.max_size
+  min_size        = var.min_size
+
+  tags = local.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# -----------------------------------------------------------------------------
+# App Runner service.
+# -----------------------------------------------------------------------------
+
+resource "aws_apprunner_service" "main" {
+  service_name = local.service_name
+
+  auto_scaling_configuration_arn = aws_apprunner_auto_scaling_configuration_version.main.arn
+
+  source_configuration {
+    auto_deployments_enabled = var.auto_deployments_enabled
+
+    dynamic "authentication_configuration" {
+      for_each = local.needs_access_role ? [1] : []
+      content {
+        access_role_arn = aws_iam_role.access[0].arn
+      }
+    }
+
+    image_repository {
+      image_identifier      = var.image_repository_url
+      image_repository_type = var.image_repository_type
+
+      image_configuration {
+        port = tostring(var.port)
+
+        runtime_environment_variables = var.env_vars
+      }
+    }
+  }
+
+  instance_configuration {
+    cpu               = var.cpu
+    memory            = var.memory
+    instance_role_arn = aws_iam_role.instance.arn
+  }
+
+  health_check_configuration {
+    protocol = var.health_check_protocol
+    # The HTTP path field is rejected by the API when protocol = TCP. The
+    # dynamic block below would be cleaner but App Runner's health_check
+    # block requires `path` to be present even for TCP — the value is
+    # just ignored. Provider validation accepts a non-empty default.
+    path     = var.health_check_path
+    interval = var.health_check_interval_seconds
+  }
+
+  network_configuration {
+    ingress_configuration {
+      is_publicly_accessible = var.is_publicly_accessible
+    }
+
+    dynamic "egress_configuration" {
+      for_each = local.needs_vpc_connector ? [1] : []
+      content {
+        egress_type       = "VPC"
+        vpc_connector_arn = aws_apprunner_vpc_connector.main[0].arn
+      }
+    }
+  }
+
+  tags = local.tags
+}
+
+# -----------------------------------------------------------------------------
+# Optional custom domain association.
+#
+# AWS validates the cert asynchronously after the apply returns —
+# `certificate_validation_records` is populated in the apply output so
+# callers can add the DNS-01 records in their DNS provider. The
+# association stays in `pending_certificate_dns_validation` status until
+# DNS resolves; the service URL keeps working in the meantime.
+# -----------------------------------------------------------------------------
+
+resource "aws_apprunner_custom_domain_association" "main" {
+  count = var.custom_domain_name == null ? 0 : 1
+
+  domain_name          = var.custom_domain_name
+  service_arn          = aws_apprunner_service.main.arn
+  enable_www_subdomain = var.enable_www_subdomain
+}

--- a/aws/apprunner/outputs.tf
+++ b/aws/apprunner/outputs.tf
@@ -1,0 +1,54 @@
+output "service_arn" {
+  description = "ARN of the App Runner service. Wire this into IAM policies / Route 53 alias targets / downstream resources that need exact-match ARN references."
+  value       = aws_apprunner_service.main.arn
+}
+
+output "service_id" {
+  description = "App Runner service ID (e.g. `<random-12-hex>`)."
+  value       = aws_apprunner_service.main.service_id
+}
+
+output "service_url" {
+  description = "App Runner-issued HTTPS URL the service is reachable at (e.g. `<random>.<region>.awsapprunner.com`). Stable across deploys."
+  value       = aws_apprunner_service.main.service_url
+}
+
+output "service_status" {
+  description = "App Runner service status (e.g. `RUNNING`, `PAUSED`, `CREATE_FAILED`). Useful for downstream conditional logic / health checks."
+  value       = aws_apprunner_service.main.status
+}
+
+output "autoscaling_configuration_arn" {
+  description = "ARN of the bound autoscaling configuration version. Tuning min/max/concurrency replaces this resource (create_before_destroy) so the ARN suffix changes on every revision."
+  value       = aws_apprunner_auto_scaling_configuration_version.main.arn
+}
+
+output "access_role_arn" {
+  description = "ARN of the App Runner ECR access role (null when image_repository_type = ECR_PUBLIC since the public registry needs no IAM)."
+  value       = local.needs_access_role ? aws_iam_role.access[0].arn : null
+}
+
+output "instance_role_arn" {
+  description = "ARN of the IAM role tasks assume at runtime. Caller-attached policies on this role govern what the app can call in AWS."
+  value       = aws_iam_role.instance.arn
+}
+
+output "instance_role_name" {
+  description = "Name of the instance IAM role. Useful for attaching additional managed-policy attachments from sibling modules."
+  value       = aws_iam_role.instance.name
+}
+
+output "vpc_connector_arn" {
+  description = "ARN of the App Runner VPC connector (null when enable_vpc_connector = false)."
+  value       = local.needs_vpc_connector ? aws_apprunner_vpc_connector.main[0].arn : null
+}
+
+output "custom_domain_validation_records" {
+  description = "DNS validation records the caller must add to their DNS provider for the custom-domain cert to issue. Empty list when custom_domain_name is null. Each entry has `name`, `type`, `value` — same shape as ACM's domain_validation_options."
+  value       = length(aws_apprunner_custom_domain_association.main) == 0 ? [] : aws_apprunner_custom_domain_association.main[0].certificate_validation_records
+}
+
+output "tags" {
+  description = "The Project-tagged map applied to every taggable resource in this preset. Other presets composing on top can `merge(module.aws_apprunner.tags, ...)` to inherit the same Project attribution."
+  value       = local.tags
+}

--- a/aws/apprunner/tests/shape.tftest.hcl
+++ b/aws/apprunner/tests/shape.tftest.hcl
@@ -1,0 +1,514 @@
+mock_provider "aws" {}
+mock_provider "random" {}
+
+# Issue #598 Row 2 (aws/apprunner) shape tests. Verifies:
+#   - Defaults compose cleanly (minimum inputs happy path).
+#   - Service name carries the var.project prefix (inspector attribution).
+#   - Project tag is on every taggable resource (defense-in-depth alongside
+#     the prefix, CLAUDE.md issue #81).
+#   - ECR_PUBLIC suppresses the access role entirely; ECR private creates
+#     it with the correct trust policy (service principal +
+#     aws:SourceAccount confused-deputy guard + AWSAppRunnerServicePolicyForECRAccess).
+#   - Instance role is always created with tasks.apprunner.amazonaws.com
+#     trust principal.
+#   - VPC connector toggle flips the connector + security group + the
+#     service's egress_configuration block.
+#   - Custom domain toggle flips the association resource.
+#   - Validation rejects every misconfiguration axis, AND a positive
+#     companion run pins that the negatives fire on the right rule
+#     (rejection-axis triangulation per #614).
+#
+# Every run uses `command = plan`. The mock_provider emits random
+# strings for arn-shaped Computed fields which fails apply-time
+# validation on resources that demand ARN-shaped inputs (e.g. App
+# Runner's instance_role_arn validator) — same trade-off as
+# aws/sagemaker's shape tests. Every wiring cross-ref we care about
+# is also pinned end-to-end in TestComposeStack_AWSAppRunner_Forward
+# in the Go composer wiring test.
+
+# -----------------------------------------------------------------------------
+# Positive: minimum inputs plan cleanly.
+# -----------------------------------------------------------------------------
+
+run "apprunner_minimum_inputs" {
+  command = plan
+
+  variables {
+    project = "test"
+  }
+
+  assert {
+    condition     = aws_apprunner_service.main.service_name == "test-app"
+    error_message = "service_name must be `<project>-<service_name>` so InsideOut name-prefix scoping attributes the service to the stack."
+  }
+
+  assert {
+    condition     = aws_apprunner_service.main.tags["Project"] == "test"
+    error_message = "Project tag must be set on the App Runner service so the InsideOut inspector's exact-match filter sees it (CLAUDE.md issue #81)."
+  }
+
+  # Default image_repository_type is ECR_PUBLIC → no access role.
+  assert {
+    condition     = length(aws_iam_role.access) == 0
+    error_message = "ECR_PUBLIC must NOT trigger creation of the access IAM role (no auth needed for the public registry)."
+  }
+
+  # Instance role is always created.
+  assert {
+    condition     = aws_iam_role.instance.name == "test-apprunner-instance"
+    error_message = "Instance role must be project-prefixed."
+  }
+
+  assert {
+    condition     = strcontains(aws_iam_role.instance.assume_role_policy, "tasks.apprunner.amazonaws.com")
+    error_message = "Instance role assume_role_policy must trust tasks.apprunner.amazonaws.com."
+  }
+
+  # Exclusivity: pin that the instance role trusts ONLY the tasks
+  # principal — not the build plane. A copy-paste regression that
+  # accidentally swapped the principals would leave the build-plane
+  # string in this policy, granting build-time pull permissions to
+  # running tasks. Without this assertion, the positive strcontains
+  # above would still pass.
+  assert {
+    condition     = !strcontains(aws_iam_role.instance.assume_role_policy, "build.apprunner.amazonaws.com")
+    error_message = "Instance role must trust ONLY the tasks principal — `build.apprunner.amazonaws.com` must NOT appear (privilege-boundary protection)."
+  }
+
+  assert {
+    condition     = strcontains(aws_iam_role.instance.assume_role_policy, "aws:SourceAccount")
+    error_message = "Instance role assume_role_policy must carry the aws:SourceAccount confused-deputy guard."
+  }
+
+  # Reject the wildcard-value form of the SourceAccount guard — a
+  # mutation that hard-coded `"aws:SourceAccount": "*"` would still
+  # satisfy the `aws:SourceAccount` strcontains check above but
+  # effectively disable the confused-deputy protection.
+  assert {
+    condition     = !strcontains(aws_iam_role.instance.assume_role_policy, "\"aws:SourceAccount\":\"*\"")
+    error_message = "SourceAccount guard must not be wildcarded (\"*\")."
+  }
+
+  # Pin port serialization end-to-end. tostring(var.port) at main.tf:258
+  # wraps the int to a string — a mutation that hard-coded the literal
+  # "8080" or interpolated the wrong variable would survive every
+  # other assertion in this run.
+  assert {
+    condition     = aws_apprunner_service.main.source_configuration[0].image_repository[0].image_configuration[0].port == "8080"
+    error_message = "Default port must serialize to \"8080\" (tostring(var.port))."
+  }
+
+  # Default auto_deployments_enabled propagates.
+  assert {
+    condition     = aws_apprunner_service.main.source_configuration[0].auto_deployments_enabled == false
+    error_message = "Default auto_deployments_enabled must be false (deploys are explicit by default)."
+  }
+
+  # Default health_check_protocol propagates.
+  assert {
+    condition     = aws_apprunner_service.main.health_check_configuration[0].protocol == "TCP"
+    error_message = "Default health_check_protocol must be TCP."
+  }
+
+  # Autoscaling config is always created.
+  assert {
+    condition     = aws_apprunner_auto_scaling_configuration_version.main.min_size == 1
+    error_message = "Default min_size must be 1 (App Runner does not support scale-to-zero)."
+  }
+
+  assert {
+    condition     = aws_apprunner_auto_scaling_configuration_version.main.max_size == 10
+    error_message = "Default max_size must be 10 (matches gcp/cloud_run's max_instances default ceiling)."
+  }
+
+  # No VPC connector by default.
+  assert {
+    condition     = length(aws_apprunner_vpc_connector.main) == 0
+    error_message = "VPC connector must NOT be created when enable_vpc_connector is unset."
+  }
+
+  # No custom domain by default.
+  assert {
+    condition     = length(aws_apprunner_custom_domain_association.main) == 0
+    error_message = "Custom domain association must NOT be created when custom_domain_name is null."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Positive: ECR private repository triggers the access role with the right
+# service-principal trust + managed-policy attachment.
+# -----------------------------------------------------------------------------
+
+run "apprunner_ecr_private_creates_access_role" {
+  command = plan
+
+  variables {
+    project               = "test"
+    image_repository_type = "ECR"
+    image_repository_url  = "123456789012.dkr.ecr.us-east-1.amazonaws.com/myapp:latest"
+  }
+
+  assert {
+    condition     = length(aws_iam_role.access) == 1
+    error_message = "ECR (private) must create exactly one access IAM role."
+  }
+
+  assert {
+    condition     = aws_iam_role.access[0].name == "test-apprunner-access"
+    error_message = "Access role must be project-prefixed."
+  }
+
+  assert {
+    condition     = strcontains(aws_iam_role.access[0].assume_role_policy, "build.apprunner.amazonaws.com")
+    error_message = "Access role assume_role_policy must trust build.apprunner.amazonaws.com (distinct from the tasks principal on the instance role)."
+  }
+
+  # Exclusivity: pin that the access role trusts ONLY the build plane —
+  # not the tasks principal. A copy-paste regression that swapped the
+  # role identities would survive the positive strcontains alone.
+  assert {
+    condition     = !strcontains(aws_iam_role.access[0].assume_role_policy, "tasks.apprunner.amazonaws.com")
+    error_message = "Access role must trust ONLY the build plane — `tasks.apprunner.amazonaws.com` must NOT appear (privilege-boundary protection)."
+  }
+
+  assert {
+    condition     = strcontains(aws_iam_role.access[0].assume_role_policy, "aws:SourceAccount")
+    error_message = "Access role assume_role_policy must carry the aws:SourceAccount confused-deputy guard."
+  }
+
+  assert {
+    condition     = !strcontains(aws_iam_role.access[0].assume_role_policy, "\"aws:SourceAccount\":\"*\"")
+    error_message = "Access role SourceAccount guard must not be wildcarded (\"*\")."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.access_ecr) == 1
+    error_message = "ECR (private) must attach exactly one managed-policy attachment to the access role."
+  }
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.access_ecr[0].policy_arn == "arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess"
+    error_message = "Default managed-policy attachment must be AWSAppRunnerServicePolicyForECRAccess."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Positive: VPC connector toggle creates connector + matching security group.
+# -----------------------------------------------------------------------------
+
+run "apprunner_vpc_connector_creates_connector" {
+  command = plan
+
+  variables {
+    project              = "test"
+    enable_vpc_connector = true
+    vpc_id               = "vpc-12345"
+    subnet_ids           = ["subnet-aaa", "subnet-bbb"]
+  }
+
+  assert {
+    condition     = length(aws_apprunner_vpc_connector.main) == 1
+    error_message = "VPC connector must be created when enable_vpc_connector = true."
+  }
+
+  assert {
+    condition     = aws_apprunner_vpc_connector.main[0].vpc_connector_name == "test-apprunner-vpc"
+    error_message = "VPC connector name must be project-prefixed."
+  }
+
+  assert {
+    condition     = length(aws_apprunner_vpc_connector.main[0].subnets) == 2
+    error_message = "VPC connector must propagate var.subnet_ids."
+  }
+
+  assert {
+    condition     = length(aws_security_group.vpc_connector) == 1
+    error_message = "VPC connector security group must be created alongside the connector."
+  }
+
+  assert {
+    condition     = aws_security_group.vpc_connector[0].vpc_id == "vpc-12345"
+    error_message = "VPC connector security group must propagate var.vpc_id."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Positive: custom domain toggle creates the association resource and
+# enables/disables the www subdomain.
+# -----------------------------------------------------------------------------
+
+run "apprunner_custom_domain_creates_association" {
+  command = plan
+
+  variables {
+    project              = "test"
+    custom_domain_name   = "app.example.com"
+    enable_www_subdomain = true
+  }
+
+  assert {
+    condition     = length(aws_apprunner_custom_domain_association.main) == 1
+    error_message = "Custom domain association must be created when custom_domain_name is set."
+  }
+
+  assert {
+    condition     = aws_apprunner_custom_domain_association.main[0].domain_name == "app.example.com"
+    error_message = "Association domain_name must propagate var.custom_domain_name."
+  }
+
+  assert {
+    condition     = aws_apprunner_custom_domain_association.main[0].enable_www_subdomain == true
+    error_message = "Association enable_www_subdomain must propagate var.enable_www_subdomain."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Positive: ingress visibility flips correctly between public and VPC.
+# -----------------------------------------------------------------------------
+
+run "apprunner_private_ingress_flips_accessibility" {
+  command = plan
+
+  variables {
+    project                = "test"
+    is_publicly_accessible = false
+  }
+
+  assert {
+    condition     = aws_apprunner_service.main.network_configuration[0].ingress_configuration[0].is_publicly_accessible == false
+    error_message = "Service ingress_configuration.is_publicly_accessible must flip to false when var.is_publicly_accessible = false."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Positive triangulation companions for the rejection-axis negatives below.
+# Pattern from #614 — pins that the negatives fire on the right validation
+# rule, not a no-op short-circuit.
+# -----------------------------------------------------------------------------
+
+run "apprunner_valid_cpu_memory_plans_cleanly" {
+  command = plan
+
+  variables {
+    project = "test"
+    cpu     = "2 vCPU"
+    memory  = "4 GB"
+  }
+
+  assert {
+    condition     = aws_apprunner_service.main.instance_configuration[0].cpu == "2 vCPU"
+    error_message = "Valid cpu must plan cleanly and propagate (companion to rejects_bad_cpu)."
+  }
+
+  assert {
+    condition     = aws_apprunner_service.main.instance_configuration[0].memory == "4 GB"
+    error_message = "Valid memory must plan cleanly and propagate (companion to rejects_bad_memory)."
+  }
+}
+
+run "apprunner_valid_service_name_plans_cleanly" {
+  command = plan
+
+  variables {
+    project      = "test"
+    service_name = "my-app"
+  }
+
+  assert {
+    condition     = aws_apprunner_service.main.service_name == "test-my-app"
+    error_message = "A regex-valid service_name must plan cleanly (companion to rejects_bad_service_name)."
+  }
+}
+
+run "apprunner_valid_custom_domain_plans_cleanly" {
+  command = plan
+
+  variables {
+    project            = "test"
+    custom_domain_name = "valid-domain.example.com"
+  }
+
+  assert {
+    condition     = length(aws_apprunner_custom_domain_association.main) == 1
+    error_message = "A regex-valid custom_domain_name must plan cleanly (companion to rejects_bad_custom_domain)."
+  }
+}
+
+run "apprunner_valid_max_size_plans_cleanly" {
+  command = plan
+
+  variables {
+    project  = "test"
+    max_size = 25
+  }
+
+  assert {
+    condition     = aws_apprunner_auto_scaling_configuration_version.main.max_size == 25
+    error_message = "max_size at the 25 boundary must plan cleanly (companion to rejects_oversized_max_size)."
+  }
+}
+
+run "apprunner_valid_port_plans_cleanly" {
+  command = plan
+
+  variables {
+    project = "test"
+    port    = 3000
+  }
+
+  assert {
+    condition     = aws_apprunner_service.main.source_configuration[0].image_repository[0].image_configuration[0].port == "3000"
+    error_message = "A valid port must plan cleanly and serialize to tostring(var.port) (companion to rejects_bad_port)."
+  }
+}
+
+run "apprunner_valid_image_repository_type_plans_cleanly" {
+  command = plan
+
+  variables {
+    project               = "test"
+    image_repository_type = "ECR_PUBLIC"
+  }
+
+  assert {
+    condition     = aws_apprunner_service.main.source_configuration[0].image_repository[0].image_repository_type == "ECR_PUBLIC"
+    error_message = "A valid image_repository_type must plan cleanly and propagate (companion to rejects_bad_image_repository_type)."
+  }
+}
+
+run "apprunner_valid_health_check_protocol_plans_cleanly" {
+  command = plan
+
+  variables {
+    project               = "test"
+    health_check_protocol = "HTTP"
+    health_check_path     = "/healthz"
+  }
+
+  assert {
+    condition     = aws_apprunner_service.main.health_check_configuration[0].protocol == "HTTP"
+    error_message = "A valid health_check_protocol must plan cleanly and propagate (companion to rejects_bad_health_check_protocol)."
+  }
+
+  assert {
+    condition     = aws_apprunner_service.main.health_check_configuration[0].path == "/healthz"
+    error_message = "health_check_path must propagate when HTTP is selected (pins the value-flow on health_check_path too)."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases — validation rejects obvious misconfigurations at plan
+# time so callers don't discover them at apply. Each axis paired with a
+# positive companion above.
+# -----------------------------------------------------------------------------
+
+run "apprunner_rejects_bad_service_name" {
+  command = plan
+
+  variables {
+    project      = "test"
+    service_name = "has spaces"
+  }
+
+  expect_failures = [var.service_name]
+}
+
+run "apprunner_rejects_bad_cpu" {
+  command = plan
+
+  variables {
+    project = "test"
+    cpu     = "3 vCPU"
+  }
+
+  expect_failures = [var.cpu]
+}
+
+run "apprunner_rejects_bad_memory" {
+  command = plan
+
+  variables {
+    project = "test"
+    memory  = "16 GB"
+  }
+
+  expect_failures = [var.memory]
+}
+
+run "apprunner_rejects_bad_image_repository_type" {
+  command = plan
+
+  variables {
+    project               = "test"
+    image_repository_type = "DOCKERHUB"
+  }
+
+  expect_failures = [var.image_repository_type]
+}
+
+run "apprunner_rejects_bad_health_check_protocol" {
+  command = plan
+
+  variables {
+    project               = "test"
+    health_check_protocol = "GRPC"
+  }
+
+  expect_failures = [var.health_check_protocol]
+}
+
+run "apprunner_rejects_oversized_max_size" {
+  command = plan
+
+  variables {
+    project  = "test"
+    max_size = 100
+  }
+
+  expect_failures = [var.max_size]
+}
+
+run "apprunner_rejects_bad_custom_domain" {
+  command = plan
+
+  variables {
+    project            = "test"
+    custom_domain_name = "not a domain"
+  }
+
+  expect_failures = [var.custom_domain_name]
+}
+
+run "apprunner_rejects_empty_project" {
+  command = plan
+
+  variables {
+    project = "   "
+  }
+
+  expect_failures = [var.project]
+}
+
+# Pins the 40-char project cap.
+run "apprunner_rejects_oversized_project" {
+  command = plan
+
+  variables {
+    # 41 chars — one over the limit. The trimspace-non-empty validation
+    # passes; only the length validation should fire.
+    project = "abcdefghijklmnopqrstuvwxyz1234567890abcde"
+  }
+
+  expect_failures = [var.project]
+}
+
+run "apprunner_rejects_bad_port" {
+  command = plan
+
+  variables {
+    project = "test"
+    port    = 70000
+  }
+
+  expect_failures = [var.port]
+}

--- a/aws/apprunner/variables.tf
+++ b/aws/apprunner/variables.tf
@@ -1,0 +1,252 @@
+variable "project" {
+  description = "Naming / Project-tag prefix for stack resources. The InsideOut inspector filters AWS resources by exact `Project = <project>` match — this value also seeds the App Runner service name (`<project>-<service_name>`) and IAM role names. Capped at 40 chars so the longest derived name (`<project>-apprunner-vpcconnector`, 25 fixed chars + 6-char random suffix on the autoscaling config) stays inside AWS's 64-char identifier limits."
+  type        = string
+  default     = "demo"
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+
+  validation {
+    condition     = length(var.project) <= 40
+    error_message = "project must be 40 chars or fewer so derived IAM role / VPC connector / autoscaling-config names fit inside AWS's 64-char identifier limits."
+  }
+}
+
+variable "region" {
+  description = "AWS region. Passed into the luthername module so the standard tag set carries the region. The AWS provider itself picks the region up from provider config."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g. production, staging, sandbox). Feeds the luthername module's standard tag set; not used elsewhere in the preset."
+  type        = string
+  default     = "sandbox"
+
+  validation {
+    condition     = length(trimspace(var.environment)) > 0
+    error_message = "environment must be a non-empty string."
+  }
+}
+
+variable "tags" {
+  description = "Extra tags merged onto every taggable resource. The preset always sets the standard luthername tag set (including `Project = var.project`); entries here override or extend that base set."
+  type        = map(string)
+  default     = {}
+}
+
+# -----------------------------------------------------------------------------
+# Service shape
+# -----------------------------------------------------------------------------
+
+variable "service_name" {
+  description = "App Runner service name component. The composed service name is `<project>-<service_name>` (matches the gcp/cloud_run pattern of project-prefixed naming for inspector attribution)."
+  type        = string
+  default     = "app"
+
+  validation {
+    condition     = can(regex("^[A-Za-z][A-Za-z0-9_-]{1,38}[A-Za-z0-9]$", var.service_name))
+    error_message = "service_name must be 3-40 chars, start with a letter, end alphanumeric, contain only letters/digits/underscores/hyphens (App Runner naming rule)."
+  }
+}
+
+variable "image_repository_url" {
+  description = "Container image identifier. For ECR private (image_repository_type = ECR), use the full repository URI with a tag (e.g. `123456789012.dkr.ecr.us-east-1.amazonaws.com/myapp:latest`). For ECR Public, use `public.ecr.aws/<alias>/<image>:<tag>`. Defaults to AWS's hello-app on ECR Public so a fresh deploy comes up green."
+  type        = string
+  default     = "public.ecr.aws/aws-containers/hello-app-runner:latest"
+}
+
+variable "image_repository_type" {
+  description = "Source type for image_repository_url. `ECR` (private) pulls via an access IAM role the preset creates. `ECR_PUBLIC` pulls anonymously and the access role is NOT created."
+  type        = string
+  default     = "ECR_PUBLIC"
+
+  validation {
+    condition     = contains(["ECR", "ECR_PUBLIC"], var.image_repository_type)
+    error_message = "image_repository_type must be one of: ECR, ECR_PUBLIC."
+  }
+}
+
+variable "port" {
+  description = "TCP port the container listens on. App Runner ingress forwards HTTPS traffic to this port. Default 8080 matches the hello-app and most managed-runtime defaults."
+  type        = number
+  default     = 8080
+
+  validation {
+    condition     = var.port >= 1 && var.port <= 65535
+    error_message = "port must be in the range 1-65535."
+  }
+}
+
+variable "env_vars" {
+  description = "Runtime environment variables injected into the container. Reserved App Runner prefixes (AWSAPPRUNNER, AWS_APPRUNNER) are rejected by the API at apply time."
+  type        = map(string)
+  default     = {}
+}
+
+# -----------------------------------------------------------------------------
+# Compute sizing.
+#
+# App Runner only accepts a fixed set of CPU/memory pairs. We validate each
+# axis independently here; the AWS API will reject invalid pairs at apply
+# time with a clear error message.
+# https://docs.aws.amazon.com/apprunner/latest/dg/architecture.html#architecture.instances
+# -----------------------------------------------------------------------------
+
+variable "cpu" {
+  description = "vCPU allocation. App Runner accepts one of: 0.25 vCPU, 0.5 vCPU, 1 vCPU, 2 vCPU, 4 vCPU. The numeric-string form (`256`, `512`, `1024`, `2048`, `4096`) is also accepted by the provider."
+  type        = string
+  default     = "1 vCPU"
+
+  validation {
+    condition     = contains(["0.25 vCPU", "0.5 vCPU", "1 vCPU", "2 vCPU", "4 vCPU", "256", "512", "1024", "2048", "4096"], var.cpu)
+    error_message = "cpu must be one of: 0.25 vCPU, 0.5 vCPU, 1 vCPU, 2 vCPU, 4 vCPU (or numeric equivalents 256, 512, 1024, 2048, 4096)."
+  }
+}
+
+variable "memory" {
+  description = "Memory allocation. App Runner accepts one of: 0.5 GB, 1 GB, 2 GB, 3 GB, 4 GB, 6 GB, 8 GB, 10 GB, 12 GB. The numeric-string form in MB is also accepted by the provider."
+  type        = string
+  default     = "2 GB"
+
+  validation {
+    condition     = contains(["0.5 GB", "1 GB", "2 GB", "3 GB", "4 GB", "6 GB", "8 GB", "10 GB", "12 GB", "512", "1024", "2048", "3072", "4096", "6144", "8192", "10240", "12288"], var.memory)
+    error_message = "memory must be one of: 0.5 GB, 1 GB, 2 GB, 3 GB, 4 GB, 6 GB, 8 GB, 10 GB, 12 GB (or numeric MB equivalents). Note: not every cpu/memory pair is valid — App Runner will reject invalid pairs at apply time."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Autoscaling
+# -----------------------------------------------------------------------------
+
+variable "min_size" {
+  description = "Minimum number of provisioned instances. App Runner keeps at least this many instances warm; 1 is the lowest the API accepts (App Runner does not support scale-to-zero today)."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.min_size >= 1 && var.min_size <= 25
+    error_message = "min_size must be in the range 1-25 (App Runner scaling limits)."
+  }
+}
+
+variable "max_size" {
+  description = "Maximum number of instances App Runner will scale out to. Hard ceiling is 25 per service today."
+  type        = number
+  default     = 10
+
+  validation {
+    condition     = var.max_size >= 1 && var.max_size <= 25
+    error_message = "max_size must be in the range 1-25 (App Runner scaling limits)."
+  }
+}
+
+variable "max_concurrency" {
+  description = "Maximum concurrent requests per instance before App Runner scales out. App Runner accepts 1-200; default 100 matches App Runner's own default."
+  type        = number
+  default     = 100
+
+  validation {
+    condition     = var.max_concurrency >= 1 && var.max_concurrency <= 200
+    error_message = "max_concurrency must be in the range 1-200."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Ingress / public accessibility
+# -----------------------------------------------------------------------------
+
+variable "is_publicly_accessible" {
+  description = "Whether the service URL is reachable from the public internet. Default true matches gcp/cloud_run's `allow_unauthenticated = true` default — flip to false for a VPC-internal service."
+  type        = bool
+  default     = true
+}
+
+variable "auto_deployments_enabled" {
+  description = "Whether App Runner auto-deploys on new ECR image pushes. Default false to keep deploys explicit; flip to true for CI-driven continuous deployment from an ECR tag."
+  type        = bool
+  default     = false
+}
+
+# -----------------------------------------------------------------------------
+# Health check
+# -----------------------------------------------------------------------------
+
+variable "health_check_protocol" {
+  description = "Health check protocol. `HTTP` requires `health_check_path`; `TCP` only checks port reachability."
+  type        = string
+  default     = "TCP"
+
+  validation {
+    condition     = contains(["HTTP", "TCP"], var.health_check_protocol)
+    error_message = "health_check_protocol must be one of: HTTP, TCP."
+  }
+}
+
+variable "health_check_path" {
+  description = "HTTP health check path. Only consulted when health_check_protocol = HTTP, but the App Runner API requires the field to be non-empty in all cases (it's ignored for TCP)."
+  type        = string
+  default     = "/"
+}
+
+variable "health_check_interval_seconds" {
+  description = "Health check interval in seconds. App Runner accepts 1-20."
+  type        = number
+  default     = 10
+
+  validation {
+    condition     = var.health_check_interval_seconds >= 1 && var.health_check_interval_seconds <= 20
+    error_message = "health_check_interval_seconds must be in the range 1-20."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Optional VPC connector for private egress.
+#
+# vpc_id + subnet_ids are normally wired by the composer's DefaultWiring
+# from module.aws_vpc when KeyAWSVPC is selected. They're required by AWS
+# provider only when enable_vpc_connector = true; the preset gates the
+# resource creation on the flag, so leaving them empty (the composer's
+# preview-safe stubs) on a public-only service is fine.
+# -----------------------------------------------------------------------------
+
+variable "enable_vpc_connector" {
+  description = "Whether to provision an App Runner VPC connector for private egress (RDS, ElastiCache, internal ALB, etc.). When true, vpc_id + subnet_ids must point at the customer VPC; the preset creates the connector + a matching security group (egress-all, no ingress) and wires the service's egress_configuration to it."
+  type        = bool
+  default     = false
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the App Runner VPC connector. Only consulted when enable_vpc_connector = true. Composer wires this from `module.aws_vpc.vpc_id` automatically when KeyAWSVPC is selected (which is the ImplicitDependencies default for KeyAWSAppRunner)."
+  type        = string
+  default     = ""
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs the VPC connector attaches ENIs into. Only consulted when enable_vpc_connector = true. Use private subnets for actual private egress; public subnets give you no isolation benefit. Composer wires this from `module.aws_vpc.private_subnet_ids` automatically when KeyAWSVPC is selected."
+  type        = list(string)
+  default     = []
+}
+
+# -----------------------------------------------------------------------------
+# Optional custom domain
+# -----------------------------------------------------------------------------
+
+variable "custom_domain_name" {
+  description = "Custom domain to associate with the service (e.g. `app.example.com`). Null disables the association. AWS validates the cert asynchronously post-apply — the DNS validation records land on the `custom_domain_validation_records` output; the caller is responsible for adding them in their DNS provider for the cert to issue."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.custom_domain_name == null ? true : can(regex("^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,}$", var.custom_domain_name))
+    error_message = "custom_domain_name must be a valid FQDN (e.g. app.example.com) when set."
+  }
+}
+
+variable "enable_www_subdomain" {
+  description = "Whether to also associate the `www.<custom_domain_name>` subdomain with the service. Only consulted when custom_domain_name != null."
+  type        = bool
+  default     = false
+}

--- a/pkg/composer/apprunner_aws_wiring_test.go
+++ b/pkg/composer/apprunner_aws_wiring_test.go
@@ -1,0 +1,377 @@
+package composer
+
+// apprunner_aws_wiring_test.go covers the issue #598 row 2 composer wiring
+// for the aws/apprunner preset (AWS analog of gcp/cloud_run for
+// managed-container services):
+//
+//   - ComponentKey + PresetKeyMap + ModulePath + AllComponentKeys +
+//     ComposeOrder registry entries are exercised by
+//     TestAllComponentKeysCoversPresetKeyMap and
+//     TestMapperKeysSubsetOfModuleVariables (both in sibling files).
+//   - Default mapper provides every required variable — exercised by
+//     TestEveryRequiredVariableIsMappedOrWired.
+//
+// The tests below pin:
+//   - Forward wiring: selecting KeyAWSAppRunner causes the composer to
+//     emit `module "aws_apprunner"` in the composed root, and threads
+//     `module.aws_vpc.vpc_id` / private subnets into the module block.
+//   - Mapper default: caller-empty cfg.AWSAppRunner emits no overrides
+//     (the preset's variables.tf defaults must win).
+//   - Mapper caller-supplied: cfg.AWSAppRunner fields flow through to
+//     the namespaced module variables.
+//   - Mapper partial-config: only fields the caller actually populated
+//     are emitted.
+//   - Mapper empty-strings-ignored: whitespace-only scalar fields are
+//     treated as not-set.
+//   - End-to-end ComposeStack with AWS + KeyAWSAppRunner succeeds.
+//   - ComponentSelected + AWSIAMActions coverage.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// requireTfvarAssignment is shared with cloud_deploy_gcp_wiring_test.go +
+// sagemaker_aws_wiring_test.go (5-arg signature: t, tfvars, key, value, msg).
+
+// -----------------------------------------------------------------------------
+// Mapper tests
+// -----------------------------------------------------------------------------
+
+// TestMapper_AWSAppRunner_DefaultConfig pins the no-config path. When
+// cfg.AWSAppRunner is nil the mapper MUST emit no App Runner-specific
+// tfvars — the preset's variables.tf defaults (1 vCPU, 2 GB, ECR_PUBLIC
+// hello-app, min=1/max=10, public-accessible, no VPC connector, no custom
+// domain) are the source of truth.
+func TestMapper_AWSAppRunner_DefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSAppRunner, &Components{}, &Config{}, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	// The mapper should NOT emit any of the optional App Runner fields
+	// when the caller hasn't set them. The preset's variables.tf default
+	// is the source of truth for every unset key.
+	for _, k := range []string{
+		"service_name", "image_repository_url", "image_repository_type", "port",
+		"env_vars", "cpu", "memory", "min_size", "max_size", "max_concurrency",
+		"is_publicly_accessible", "auto_deployments_enabled",
+		"health_check_protocol", "health_check_path",
+		"enable_vpc_connector", "vpc_id", "subnet_ids",
+		"custom_domain_name", "enable_www_subdomain",
+	} {
+		_, has := vals[k]
+		require.Falsef(t, has,
+			"mapper must NOT emit %q when caller left cfg.AWSAppRunner nil — module variables.tf default must win",
+			k)
+	}
+}
+
+func TestMapper_AWSAppRunner_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	port := 9090
+	minSize := 2
+	maxSize := 20
+	maxConcurrency := 50
+	pubAcc := false
+	autoDeploy := true
+	enableVPC := true
+	enableWWW := true
+
+	cfg := &Config{
+		AWSAppRunner: &AWSAppRunnerConfig{
+			ServiceName:            "api",
+			ImageRepositoryURL:     "123456789012.dkr.ecr.us-east-1.amazonaws.com/myapp:latest",
+			ImageRepositoryType:    "ECR",
+			Port:                   &port,
+			EnvVars:                map[string]string{"LOG_LEVEL": "info"},
+			CPU:                    "2 vCPU",
+			Memory:                 "4 GB",
+			MinSize:                &minSize,
+			MaxSize:                &maxSize,
+			MaxConcurrency:         &maxConcurrency,
+			IsPubliclyAccessible:   &pubAcc,
+			AutoDeploymentsEnabled: &autoDeploy,
+			HealthCheckProtocol:    "HTTP",
+			HealthCheckPath:        "/healthz",
+			EnableVPCConnector:     &enableVPC,
+			VPCID:                  "vpc-real",
+			SubnetIDs:              []string{"subnet-a", "subnet-b"},
+			CustomDomainName:       "api.example.com",
+			EnableWWWSubdomain:     &enableWWW,
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSAppRunner, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	require.Equal(t, "api", vals["service_name"])
+	require.Equal(t, "123456789012.dkr.ecr.us-east-1.amazonaws.com/myapp:latest", vals["image_repository_url"])
+	require.Equal(t, "ECR", vals["image_repository_type"])
+	require.Equal(t, 9090, vals["port"])
+	require.Equal(t, map[string]any{"LOG_LEVEL": "info"}, vals["env_vars"])
+	require.Equal(t, "2 vCPU", vals["cpu"])
+	require.Equal(t, "4 GB", vals["memory"])
+	require.Equal(t, 2, vals["min_size"])
+	require.Equal(t, 20, vals["max_size"])
+	require.Equal(t, 50, vals["max_concurrency"])
+	require.Equal(t, false, vals["is_publicly_accessible"])
+	require.Equal(t, true, vals["auto_deployments_enabled"])
+	require.Equal(t, "HTTP", vals["health_check_protocol"])
+	require.Equal(t, "/healthz", vals["health_check_path"])
+	require.Equal(t, true, vals["enable_vpc_connector"])
+	require.Equal(t, "vpc-real", vals["vpc_id"])
+	require.Equal(t, []any{"subnet-a", "subnet-b"}, vals["subnet_ids"])
+	require.Equal(t, "api.example.com", vals["custom_domain_name"])
+	require.Equal(t, true, vals["enable_www_subdomain"])
+}
+
+// TestMapper_AWSAppRunner_PartialConfig confirms that when only a subset
+// of fields is set the mapper emits only those fields — the preset's
+// variables.tf defaults must apply to the rest. Catches a class of bug
+// where the mapper would unconditionally emit empty slices / false bools
+// that override module defaults.
+func TestMapper_AWSAppRunner_PartialConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSAppRunner: &AWSAppRunnerConfig{
+			CPU:    "2 vCPU",
+			Memory: "4 GB",
+			// Every other field intentionally left at zero values.
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSAppRunner, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	require.Equal(t, "2 vCPU", vals["cpu"])
+	require.Equal(t, "4 GB", vals["memory"])
+
+	for _, k := range []string{
+		"service_name", "image_repository_url", "image_repository_type", "port",
+		"env_vars", "min_size", "max_size", "max_concurrency",
+		"is_publicly_accessible", "auto_deployments_enabled",
+		"health_check_protocol", "health_check_path",
+		"enable_vpc_connector", "vpc_id", "subnet_ids",
+		"custom_domain_name", "enable_www_subdomain",
+	} {
+		_, has := vals[k]
+		require.Falsef(t, has,
+			"mapper must NOT emit %q when caller left it zero — module default must win",
+			k)
+	}
+}
+
+// TestMapper_AWSAppRunner_EmptyStringsIgnored pins the trimspace gates.
+// Whitespace-only string fields (e.g. an unset form field that arrived
+// as "   ") must be treated as not-set so the preset defaults kick in
+// instead of being overridden with garbage. Sibling pattern of
+// TestMapper_AWSSageMaker_EmptyStringsIgnored.
+func TestMapper_AWSAppRunner_EmptyStringsIgnored(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSAppRunner: &AWSAppRunnerConfig{
+			ServiceName:         "   ",
+			ImageRepositoryURL:  "  ",
+			ImageRepositoryType: "",
+			CPU:                 "  ",
+			Memory:              "   ",
+			HealthCheckProtocol: "",
+			HealthCheckPath:     " ",
+			VPCID:               "   ",
+			SubnetIDs:           []string{"", "  ", "subnet-real"},
+			CustomDomainName:    "  ",
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSAppRunner, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	// subnet_ids: whitespace/empty entries dropped, real one kept.
+	require.Equal(t, []any{"subnet-real"}, vals["subnet_ids"])
+
+	for _, k := range []string{
+		"service_name", "image_repository_url", "image_repository_type",
+		"cpu", "memory", "health_check_protocol", "health_check_path",
+		"vpc_id", "custom_domain_name",
+	} {
+		_, has := vals[k]
+		require.Falsef(t, has,
+			"mapper must NOT emit %q when caller supplied a whitespace-only string",
+			k)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// End-to-end ComposeStack tests
+// -----------------------------------------------------------------------------
+
+func TestComposeStack_AWSAppRunner_Forward(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSAppRunner},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok, "composed root must contain main.tf")
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, `module "aws_apprunner"`,
+		"composed root must declare module aws_apprunner when KeyAWSAppRunner is selected")
+	// AWS modules use the legacy `modules/<x>` ModulePath (not `aws/<x>`)
+	// — kept for backwards compatibility with the in-account deployer
+	// service that already resolves that path.
+	require.Contains(t, rootStr, `"./modules/apprunner"`,
+		"module source path must resolve to modules/apprunner per ModulePath")
+
+	// KeyAWSAppRunner → KeyAWSVPC implicit dep: aws_vpc must also appear.
+	require.Contains(t, rootStr, `module "aws_vpc"`,
+		"composer must auto-add KeyAWSVPC when KeyAWSAppRunner is selected (ImplicitDependencies)")
+
+	// Wiring assertion: aws_apprunner's vpc_id argument must literally
+	// reference module.aws_vpc.vpc_id. Without this, the previous check
+	// only pins that aws_vpc is emitted — it doesn't pin that the value
+	// actually flows into aws_apprunner.
+	require.Contains(t, rootStr, `module.aws_vpc.vpc_id`,
+		"DefaultWiring must thread module.aws_vpc.vpc_id into the aws_apprunner module block")
+	// Symmetric subnet wiring — DefaultWiring threads private subnets on
+	// non-public VPCs. The default Components shape (no AWSVPC string set)
+	// is treated as non-public by isPublicVPC, so the wiring code falls
+	// into the private-subnet branch.
+	require.Contains(t, rootStr, `module.aws_vpc.private_subnet_ids`,
+		"DefaultWiring must thread module.aws_vpc.private_subnet_ids into aws_apprunner.subnet_ids (symmetric with the vpc_id wiring above)")
+
+	// Confirm the tfvars file landed and carries the always-required
+	// project / region mappings.
+	tfvars, ok := out["/aws_apprunner.auto.tfvars"]
+	require.True(t, ok, "expected aws_apprunner.auto.tfvars")
+	tfvarsStr := string(tfvars)
+	requireTfvarAssignment(t, tfvarsStr, "aws_apprunner_project", `"test"`,
+		"composer must emit aws_apprunner_project tfvar from the always-required project mapping")
+	requireTfvarAssignment(t, tfvarsStr, "aws_apprunner_region", `"us-east-1"`,
+		"composer must emit aws_apprunner_region tfvar from the always-required region mapping")
+}
+
+func TestComposeStack_AWSAppRunner_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	enableVPC := true
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSAppRunner},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg: &Config{
+			Region: "us-east-1",
+			AWSAppRunner: &AWSAppRunnerConfig{
+				ServiceName:         "api",
+				ImageRepositoryURL:  "123456789012.dkr.ecr.us-east-1.amazonaws.com/myapp:latest",
+				ImageRepositoryType: "ECR",
+				CPU:                 "2 vCPU",
+				Memory:              "4 GB",
+				CustomDomainName:    "api.example.com",
+				EnableVPCConnector:  &enableVPC,
+			},
+		},
+		Project: "test",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err)
+
+	tfvars, ok := out["/aws_apprunner.auto.tfvars"]
+	require.True(t, ok)
+	tfvarsStr := string(tfvars)
+
+	requireTfvarAssignment(t, tfvarsStr, "aws_apprunner_service_name", `"api"`,
+		"caller-supplied ServiceName must flow through to the namespaced tfvar")
+	requireTfvarAssignment(t, tfvarsStr, "aws_apprunner_image_repository_url",
+		`"123456789012.dkr.ecr.us-east-1.amazonaws.com/myapp:latest"`,
+		"caller-supplied ImageRepositoryURL must flow through to the namespaced tfvar")
+	requireTfvarAssignment(t, tfvarsStr, "aws_apprunner_image_repository_type", `"ECR"`,
+		"caller-supplied ImageRepositoryType must flow through to the namespaced tfvar")
+	requireTfvarAssignment(t, tfvarsStr, "aws_apprunner_cpu", `"2 vCPU"`,
+		"caller-supplied CPU must flow through to the namespaced tfvar")
+	requireTfvarAssignment(t, tfvarsStr, "aws_apprunner_memory", `"4 GB"`,
+		"caller-supplied Memory must flow through to the namespaced tfvar")
+	requireTfvarAssignment(t, tfvarsStr, "aws_apprunner_custom_domain_name", `"api.example.com"`,
+		"caller-supplied CustomDomainName must flow through to the namespaced tfvar")
+	requireTfvarAssignment(t, tfvarsStr, "aws_apprunner_enable_vpc_connector", `true`,
+		"caller-supplied EnableVPCConnector must flow through to the namespaced tfvar")
+
+	// Partial-config contract: the unset Port field must NOT appear in
+	// the tfvars (leaving Port nil means the preset's variables.tf
+	// default of 8080 wins). The bare-substring check is brittle because
+	// the HCL pretty-printer column-aligns assignments — a substring
+	// "aws_apprunner_port " (trailing-space) would also match
+	// "aws_apprunner_port      = " padding, defeating the assertion.
+	// requireNoTfvarAssignment uses the same anchored regex shape as
+	// requireTfvarAssignment so the check is robust to padding AND to
+	// future keys like aws_apprunner_port_range.
+	requireNoTfvarAssignment(t, tfvarsStr, "aws_apprunner_port",
+		"unset Port must NOT be emitted in tfvars (the preset's default 8080 must win)")
+}
+
+// -----------------------------------------------------------------------------
+// Coherence / IAM permission coverage
+// -----------------------------------------------------------------------------
+
+// TestComponentSelected_AWSAppRunner pins the coherence.go entry —
+// without it ComponentSelected returns false for KeyAWSAppRunner and the
+// orphan-strip pass silently clears cfg.AWSAppRunner even when
+// comps.AWSAppRunner = &true.
+func TestComponentSelected_AWSAppRunner(t *testing.T) {
+	t.Parallel()
+
+	tr := true
+	c := &Components{AWSAppRunner: &tr}
+	require.True(t, ComponentSelected(c, KeyAWSAppRunner),
+		"ComponentSelected must return true when comps.AWSAppRunner=&true")
+
+	fa := false
+	c2 := &Components{AWSAppRunner: &fa}
+	require.False(t, ComponentSelected(c2, KeyAWSAppRunner),
+		"ComponentSelected must return false when comps.AWSAppRunner=&false (explicit deselect)")
+
+	c3 := &Components{}
+	require.False(t, ComponentSelected(c3, KeyAWSAppRunner),
+		"ComponentSelected must return false when comps.AWSAppRunner is nil")
+}
+
+// TestAWSIAMPermissions_AppRunnerCovered pins the iam_actions.go entry.
+// Without it RequiredAWSIAMActions silently omits the App Runner / IAM /
+// VPC / security-group permissions a real deploy needs — surfacing as a
+// 403 at apply time instead of at SimulatePrincipalPolicy pre-deploy
+// check (ui-core #192).
+func TestAWSIAMPermissions_AppRunnerCovered(t *testing.T) {
+	t.Parallel()
+
+	actions, ok := AWSIAMActions[KeyAWSAppRunner]
+	require.True(t, ok, "AWSIAMActions must have an entry for KeyAWSAppRunner")
+	require.NotEmpty(t, actions, "AWSIAMActions[KeyAWSAppRunner] must list at least one action — service create + autoscaling-config create + IAM role create all require explicit perms beyond the always-required set")
+
+	required := RequiredAWSIAMActions([]ComponentKey{KeyAWSAppRunner})
+	require.Contains(t, required, "apprunner:CreateService",
+		"App Runner service create permission must be in the required set")
+	require.Contains(t, required, "apprunner:CreateAutoScalingConfiguration",
+		"App Runner autoscaling-config create permission must be in the required set")
+	require.Contains(t, required, "apprunner:CreateVpcConnector",
+		"App Runner VPC connector create permission must be in the required set (covers the enable_vpc_connector path)")
+	require.Contains(t, required, "ec2:CreateSecurityGroup",
+		"EC2 CreateSecurityGroup permission must be in the required set (covers the connector's matching SG)")
+	require.Contains(t, required, "iam:PassRole",
+		"PassRole permission must be in the required set (the App Runner control plane needs to assume both the access role and the instance role we create)")
+}

--- a/pkg/composer/cloud_deploy_gcp_wiring_test.go
+++ b/pkg/composer/cloud_deploy_gcp_wiring_test.go
@@ -54,6 +54,21 @@ func requireTfvarAssignment(t *testing.T, tfvars, key, value, msg string) {
 	require.True(t, matched, "%s\n--- tfvars ---\n%s", msg, tfvars)
 }
 
+// requireNoTfvarAssignment is the inverse of requireTfvarAssignment: it
+// pins that no top-level `<key> =` assignment exists in tfvars. Uses the
+// same anchored regex shape so it's robust to the HCL pretty-printer's
+// column-alignment padding (a substring like `"<key> "` would otherwise
+// false-match `"<key>      = "` for any wider-aligned file). Also robust
+// to false matches on `<key>_suffix` keys because the `\s*=` anchor
+// requires the next non-whitespace character to be `=`.
+func requireNoTfvarAssignment(t *testing.T, tfvars, key, msg string) {
+	t.Helper()
+	pattern := `(?m)^` + regexp.QuoteMeta(key) + `\s*=`
+	matched, err := regexp.MatchString(pattern, tfvars)
+	require.NoError(t, err, "regexp compile error for %q", pattern)
+	require.False(t, matched, "%s\n--- tfvars ---\n%s", msg, tfvars)
+}
+
 // TestMapper_GCPCloudDeploy_DefaultConfig pins the no-config path. When
 // cfg.GCPCloudDeploy is nil the mapper MUST emit no Cloud Deploy specific
 // tfvars — the preset's variables.tf defaults are the source of truth

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -53,6 +53,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.AWSECS)
 	case KeyAWSLambda:
 		return boolPtrTrue(c.AWSLambda)
+	case KeyAWSAppRunner:
+		return boolPtrTrue(c.AWSAppRunner)
 	case KeyAWSSageMaker:
 		return boolPtrTrue(c.AWSSageMaker)
 	case KeyAWSALB:
@@ -293,7 +295,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyAWSCloudfront, KeyAWSRDS, KeyAWSElastiCache,
 		KeyAWSS3, KeyAWSDynamoDB, KeyAWSSQS, KeyAWSMSK,
 		KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
-		KeyAWSCognito, KeyAWSLambda, KeyAWSSageMaker, KeyAWSAPIGateway,
+		KeyAWSCognito, KeyAWSLambda, KeyAWSAppRunner, KeyAWSSageMaker, KeyAWSAPIGateway,
 		KeyAWSKMS, KeyAWSSecretsManager, KeyAWSOpenSearch,
 		KeyAWSBedrock, KeyAWSBackups, KeyAWSRoute53,
 		KeyAWSACM,

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -41,6 +41,7 @@ const (
 	KeyAWSEKS                  ComponentKey = "aws_eks"
 	KeyAWSECS                  ComponentKey = "aws_ecs"
 	KeyAWSLambda               ComponentKey = "aws_lambda"
+	KeyAWSAppRunner            ComponentKey = "aws_apprunner"
 	KeyAWSSageMaker            ComponentKey = "aws_sagemaker"
 	KeyAWSALB                  ComponentKey = "aws_alb"
 	KeyAWSCloudfront           ComponentKey = "aws_cloudfront"
@@ -156,6 +157,12 @@ var ComposeOrder = []ComponentKey{
 	KeyAWSBedrock,
 	KeyAWSSageMaker,
 	KeyGCPVertexAI,
+	// App Runner (#598 row 2). Independent of EKS/ECS/Lambda compute
+	// keys — App Runner is a peer managed-container service (Cloud Run
+	// analog), not a downstream consumer of them. Position adjacent to
+	// other managed-compute pairs for reviewability; ordering is not
+	// load-bearing because no other key wires off of it.
+	KeyAWSAppRunner,
 	KeyAWSSQS,
 	KeyGCPPubSub,
 	KeyGCPCloudBuild,
@@ -189,6 +196,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyAWSEKSNodeGroup:         "modules/eks_nodegroup",
 	KeyAWSECS:                  "modules/ecs",
 	KeyAWSLambda:               "modules/lambda",
+	KeyAWSAppRunner:            "modules/apprunner",
 	KeyAWSSageMaker:            "modules/sagemaker",
 	KeyAWSALB:                  "modules/alb",
 	KeyAWSCloudfront:           "modules/cloudfront",
@@ -265,6 +273,13 @@ var ImplicitDependencies = map[ComponentKey][]ComponentKey{
 	// network_mode is PublicInternetOnly or VpcOnly — selecting SageMaker
 	// without a VPC leaves the required inputs without a wired source.
 	KeyAWSSageMaker: {KeyAWSVPC},
+	// App Runner (#598 row 2). The public-only service does NOT strictly
+	// require a VPC, but the preset's optional VPC connector path
+	// (enable_vpc_connector = true) feeds vpc_id + subnet_ids from
+	// module.aws_vpc. Forcing the implicit dep mirrors the GCP analog
+	// (gcp/cloud_run also declares KeyGCPVPC) and ensures the wiring is
+	// satisfiable when the caller flips on private egress later.
+	KeyAWSAppRunner: {KeyAWSVPC},
 	KeyAWSEKSNodeGroup: {KeyAWSEKS, KeyAWSVPC},
 	KeyAWSEC2:          {KeyAWSVPC},
 	KeyGCPCompute:      {KeyGCPVPC},
@@ -376,6 +391,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyAWSEKS:                  "eks",
 	KeyAWSECS:                  "ecs",
 	KeyAWSLambda:               "lambda",
+	KeyAWSAppRunner:            "apprunner",
 	KeyAWSSageMaker:            "sagemaker",
 	KeyAWSALB:                  "alb",
 	KeyAWSCloudfront:           "cloudfront",
@@ -488,6 +504,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyAWSACM,
 	KeyAWSALB,
 	KeyAWSAPIGateway,
+	KeyAWSAppRunner,
 	KeyAWSBackups,
 	KeyAWSBastion,
 	KeyAWSBedrock,
@@ -692,6 +709,28 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.RawHCL["subnet_ids"] = vpc + ".private_subnet_ids"
 			wi.RawHCL["security_group_ids"] = "[]"
 			wi.Names = append(wi.Names, "enable_vpc", "vpc_id", "subnet_ids", "security_group_ids")
+		}
+
+	case KeyAWSAppRunner:
+		// App Runner VPC-connector path consumes vpc_id + subnet_ids
+		// (#598 row 2). The preset's enable_vpc_connector flag gates
+		// actual creation of the connector, but threading the wiring
+		// unconditionally is fine — when the flag is false the inputs
+		// are simply ignored. Prefer private subnets when the upstream
+		// VPC is non-public so the connector lands in the right tier;
+		// fall back to public subnets on Public-VPC stacks (the connector
+		// still works — egress NAT is provided by App Runner's own
+		// network plane, the customer subnets are only the ENI placement
+		// for cross-VPC reachability).
+		if hasVPC {
+			vpc := vpcRef(selected)
+			wi.RawHCL["vpc_id"] = vpc + ".vpc_id"
+			if isPublicVPC(comps) {
+				wi.RawHCL["subnet_ids"] = vpc + ".public_subnet_ids"
+			} else {
+				wi.RawHCL["subnet_ids"] = vpc + ".private_subnet_ids"
+			}
+			wi.Names = append(wi.Names, "vpc_id", "subnet_ids")
 		}
 
 	case KeyAWSSageMaker:

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -38,6 +38,20 @@ var AWSIAMActions = map[ComponentKey][]string{
 	KeyAWSEKSNodeGroup:         {"eks:CreateNodegroup"},
 	KeyAWSECS:                  {"ecs:CreateCluster", "ecs:CreateService"},
 	KeyAWSLambda:               {"lambda:CreateFunction"},
+	// App Runner (#598 row 2). Service + autoscaling-config-version
+	// CREATE + the access role (only when image_repository_type = ECR)
+	// + the instance role + optional VPC connector. PassRole is needed
+	// so the App Runner control plane can assume the instance role and
+	// (when private ECR) the access role.
+	KeyAWSAppRunner: {
+		"apprunner:CreateAutoScalingConfiguration",
+		"apprunner:CreateService",
+		"apprunner:CreateVpcConnector",
+		"ec2:CreateSecurityGroup",
+		"iam:AttachRolePolicy",
+		"iam:CreateRole",
+		"iam:PassRole",
+	},
 	// SageMaker Studio (#615). Domain + user-profile CREATE + the IAM
 	// execution role / inline policy + the workspace S3 bucket setup
 	// (versioning / encryption / public-access block). PassRole is needed

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -44,6 +44,7 @@ var untaggableAWS = map[string]struct{}{
 	"aws_apigatewayv2_authorizer":                        {},
 	"aws_apigatewayv2_integration":                       {},
 	"aws_apigatewayv2_route":                             {},
+	"aws_apprunner_custom_domain_association":            {},
 	"aws_autoscaling_group_tag":                          {},
 	"aws_backup_selection":                               {},
 	"aws_bedrock_model_invocation_logging_configuration": {},

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1081,6 +1081,91 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+	case KeyAWSAppRunner:
+		// App Runner (#598 row 2). vpc_id + subnet_ids are wired
+		// automatically by DefaultWiring when KeyAWSVPC is selected, but
+		// the preset only consumes them when enable_vpc_connector = true.
+		// For single-module previews (no VPC in the selection), the
+		// preset's own variables.tf defaults (empty string / empty list)
+		// are fine because enable_vpc_connector also defaults to false —
+		// so we don't need preview-safe stubs like SageMaker does. The
+		// mapper emits overrides ONLY for fields the caller actually
+		// populated, following the partial-config pattern.
+		if cfg != nil && cfg.AWSAppRunner != nil {
+			ar := cfg.AWSAppRunner
+			if strings.TrimSpace(ar.ServiceName) != "" {
+				vals["service_name"] = strings.TrimSpace(ar.ServiceName)
+			}
+			if strings.TrimSpace(ar.ImageRepositoryURL) != "" {
+				vals["image_repository_url"] = strings.TrimSpace(ar.ImageRepositoryURL)
+			}
+			if strings.TrimSpace(ar.ImageRepositoryType) != "" {
+				vals["image_repository_type"] = strings.TrimSpace(ar.ImageRepositoryType)
+			}
+			if ar.Port != nil {
+				vals["port"] = *ar.Port
+			}
+			if len(ar.EnvVars) > 0 {
+				ev := make(map[string]any, len(ar.EnvVars))
+				for k, v := range ar.EnvVars {
+					ev[k] = v
+				}
+				vals["env_vars"] = ev
+			}
+			if strings.TrimSpace(ar.CPU) != "" {
+				vals["cpu"] = strings.TrimSpace(ar.CPU)
+			}
+			if strings.TrimSpace(ar.Memory) != "" {
+				vals["memory"] = strings.TrimSpace(ar.Memory)
+			}
+			if ar.MinSize != nil {
+				vals["min_size"] = *ar.MinSize
+			}
+			if ar.MaxSize != nil {
+				vals["max_size"] = *ar.MaxSize
+			}
+			if ar.MaxConcurrency != nil {
+				vals["max_concurrency"] = *ar.MaxConcurrency
+			}
+			if ar.IsPubliclyAccessible != nil {
+				vals["is_publicly_accessible"] = *ar.IsPubliclyAccessible
+			}
+			if ar.AutoDeploymentsEnabled != nil {
+				vals["auto_deployments_enabled"] = *ar.AutoDeploymentsEnabled
+			}
+			if strings.TrimSpace(ar.HealthCheckProtocol) != "" {
+				vals["health_check_protocol"] = strings.TrimSpace(ar.HealthCheckProtocol)
+			}
+			if strings.TrimSpace(ar.HealthCheckPath) != "" {
+				vals["health_check_path"] = strings.TrimSpace(ar.HealthCheckPath)
+			}
+			if ar.EnableVPCConnector != nil {
+				vals["enable_vpc_connector"] = *ar.EnableVPCConnector
+			}
+			if strings.TrimSpace(ar.VPCID) != "" {
+				vals["vpc_id"] = strings.TrimSpace(ar.VPCID)
+			}
+			if len(ar.SubnetIDs) > 0 {
+				ids := make([]any, 0, len(ar.SubnetIDs))
+				for _, id := range ar.SubnetIDs {
+					t := strings.TrimSpace(id)
+					if t == "" {
+						continue
+					}
+					ids = append(ids, t)
+				}
+				if len(ids) > 0 {
+					vals["subnet_ids"] = ids
+				}
+			}
+			if strings.TrimSpace(ar.CustomDomainName) != "" {
+				vals["custom_domain_name"] = strings.TrimSpace(ar.CustomDomainName)
+			}
+			if ar.EnableWWWSubdomain != nil {
+				vals["enable_www_subdomain"] = *ar.EnableWWWSubdomain
+			}
+		}
+
 	case KeyAWSSageMaker:
 		// SageMaker Studio (#615). vpc_id + subnet_ids are required by the
 		// preset (AWS provider 6.x demands them on aws_sagemaker_domain).

--- a/pkg/composer/presets.go
+++ b/pkg/composer/presets.go
@@ -80,6 +80,7 @@ func (c *Client) ListAvailableComponentKeys() ([]string, error) {
 
 		// AWS prefixed keys
 		KeyAWSVPC, KeyAWSBastion, KeyAWSEC2, KeyAWSEKS, KeyAWSEKSNodeGroup, KeyAWSECS, KeyAWSLambda,
+		KeyAWSAppRunner,
 		KeyAWSSageMaker,
 		KeyAWSALB, KeyAWSCloudfront, KeyAWSWAF, KeyAWSAPIGateway, KeyAWSRDS,
 		KeyAWSElastiCache, KeyAWSDynamoDB, KeyAWSS3, KeyAWSKMS, KeyAWSSecretsManager,

--- a/pkg/composer/pricing.go
+++ b/pkg/composer/pricing.go
@@ -100,6 +100,7 @@ type PricingData struct {
 		AWSEKS                  *PricingItem    `json:"aws_eks,omitempty"`
 		AWSECS                  *PricingItem    `json:"aws_ecs,omitempty"`
 		AWSLambda               *PricingItem    `json:"aws_lambda,omitempty"`
+		AWSAppRunner            *PricingItem    `json:"aws_apprunner,omitempty"`
 		AWSALB                  *PricingItem    `json:"aws_alb,omitempty"`
 		AWSCloudFront           *PricingItem    `json:"aws_cloudfront,omitempty"`
 		AWSWAF                  *PricingItem    `json:"aws_waf,omitempty"`

--- a/pkg/composer/pricing_coverage_test.go
+++ b/pkg/composer/pricing_coverage_test.go
@@ -1,0 +1,133 @@
+package composer
+
+// pricing_coverage_test.go gates the silent gap discovered during the
+// #598 / #614 / #618 / #620 audit: PricingData.Components is a typed
+// Go struct with explicit per-key fields, and #614 (gcp_cloud_deploy)
+// + #618 (aws_sagemaker) landed without adding their fields. The cost-
+// LLM is therefore structurally unable to emit a pricing row for those
+// components — the customer's cost panel drops them silently. There
+// was no coverage test to fail CI, so the gap was invisible.
+//
+// This test cross-references AllComponentKeys against the json tags
+// on PricingData.Components. Every AWS / GCP key must have a matching
+// field, or be listed in pricingDeferredKeys with an issue-tracked
+// rationale. The allowlist forces deferrals to be acknowledged in
+// code (matching the [no-inspector] pattern in extractors_drift_test.go).
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// pricingDeferredKeys are AWS/GCP ComponentKeys whose PricingData.Components
+// field is intentionally absent today. Adding a key here MUST cite the
+// issue tracking the backfill. Deleting an entry without adding the
+// field will make the test fail — that's the point.
+//
+// Trim back to {} once the corresponding backfill PR lands.
+var pricingDeferredKeys = map[ComponentKey]string{
+	KeyGCPCloudDeploy: "Backfill pricing row for gcp_cloud_deploy (#614 / tracked in #621). The cost-LLM cannot emit a Cloud Deploy line until PricingData.Components has a `GCPCloudDeploy *PricingItem` field.",
+	KeyAWSSageMaker:   "Backfill pricing row for aws_sagemaker (#615 / #618 / tracked in #621). The cost-LLM cannot emit a SageMaker Studio line until PricingData.Components has an `AWSSageMaker *PricingItem` field.",
+}
+
+// pricingNonComponentKeys are AllComponentKeys entries that are NOT
+// expected to have a pricing row — third-party toggles, conceptual
+// classifiers, EKS node group (covered by the parent EKS row), etc.
+var pricingNonComponentKeys = map[ComponentKey]bool{
+	KeyAWSEKSNodeGroup: true, // priced under the parent KeyAWSEKS row
+}
+
+// pricingComponentsJSONTags returns the json tag (minus `,omitempty`)
+// for every field on PricingData.Components, restricted to fields
+// whose tag starts with "aws_" or "gcp_". Other fields (architecture,
+// cloud, splunk, datadog, githubactions, legacy unprefixed) are
+// outside the AllComponentKeys coverage scope.
+func pricingComponentsJSONTags(t *testing.T) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	pd := PricingData{}
+	cv := reflect.ValueOf(pd).FieldByName("Components")
+	require.True(t, cv.IsValid(), "PricingData.Components field must exist")
+	ct := cv.Type()
+	for i := 0; i < ct.NumField(); i++ {
+		f := ct.Field(i)
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.TrimSuffix(strings.SplitN(tag, ",", 2)[0], ",omitempty")
+		if !strings.HasPrefix(name, "aws_") && !strings.HasPrefix(name, "gcp_") {
+			continue
+		}
+		out[name] = true
+	}
+	return out
+}
+
+// TestPricingDataCoversAllComponentKeys fails when an AWS or GCP
+// ComponentKey in AllComponentKeys lacks a matching json tag on
+// PricingData.Components.
+//
+// This catches the class of bug found in the #598-roll-up audit:
+// preset PRs that wired the composer but forgot to add the pricing
+// field, leaving the cost-LLM structurally unable to emit a row.
+// The pricing struct's per-key fields are typed by design (the LLM
+// schema generator emits a curated JSON Schema that the model is
+// constrained to), so a missing field is a hard structural gap, not
+// a soft "panel renders empty" fallback.
+func TestPricingDataCoversAllComponentKeys(t *testing.T) {
+	t.Parallel()
+
+	got := pricingComponentsJSONTags(t)
+
+	var missing []string
+	for _, k := range AllComponentKeys {
+		s := string(k)
+		if !strings.HasPrefix(s, "aws_") && !strings.HasPrefix(s, "gcp_") {
+			continue
+		}
+		if pricingNonComponentKeys[k] {
+			continue
+		}
+		if _, ok := pricingDeferredKeys[k]; ok {
+			// Deferred — pin the rationale is still present.
+			require.NotEmptyf(t, pricingDeferredKeys[k],
+				"pricingDeferredKeys[%q] must carry a non-empty issue-tracked rationale", k)
+			continue
+		}
+		if !got[s] {
+			missing = append(missing, s)
+		}
+	}
+	require.Empty(t, missing,
+		"PricingData.Components is missing fields for these AWS/GCP ComponentKeys: %v\n"+
+			"Fix: add `<Key> *PricingItem `+\"`json:\\\"<key>,omitempty\\\"`\"+` to PricingData.Components in pricing.go,\n"+
+			"OR add the key to pricingDeferredKeys with a tracked-issue rationale.",
+		missing)
+
+	// Sanity: an entry in pricingDeferredKeys must NOT also have a
+	// corresponding field (would mean someone forgot to delete the
+	// allowlist entry when they landed the backfill).
+	for k := range pricingDeferredKeys {
+		s := string(k)
+		require.Falsef(t, got[s],
+			"%q appears in pricingDeferredKeys AND in PricingData.Components — delete the allowlist entry; the backfill has landed",
+			s)
+	}
+}
+
+// TestPricingDataDeferralReferencesIssues guards against an empty-
+// rationale allowlist entry. Adding to pricingDeferredKeys is a code
+// signal that the deferral is intentional — the rationale field must
+// reference the tracking issue so reviewers can find it.
+func TestPricingDataDeferralReferencesIssues(t *testing.T) {
+	t.Parallel()
+	for k, reason := range pricingDeferredKeys {
+		require.Truef(t, strings.Contains(reason, "#"),
+			"pricingDeferredKeys[%q] must cite a tracking issue (e.g. \"#1234\") so the deferral is auditable",
+			k)
+	}
+}

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -23,6 +23,7 @@ type Components struct {
 	AWSEKS                  *bool  `json:"aws_eks,omitempty"`
 	AWSECS                  *bool  `json:"aws_ecs,omitempty"`
 	AWSLambda               *bool  `json:"aws_lambda,omitempty"`
+	AWSAppRunner            *bool  `json:"aws_apprunner,omitempty"`
 	AWSSageMaker            *bool  `json:"aws_sagemaker,omitempty"`
 	AWSALB                  *bool  `json:"aws_alb,omitempty"`
 	AWSCloudFront           *bool  `json:"aws_cloudfront,omitempty"`
@@ -202,6 +203,13 @@ type Config struct {
 		MemorySize string `json:"memorySize,omitempty"`
 		Timeout    string `json:"timeout,omitempty"`
 	} `json:"aws_lambda,omitempty"`
+
+	// AWSAppRunner carries the caller-supplied App Runner config (#598
+	// row 2). Named (not inline) so callers can construct it without
+	// re-typing the anonymous struct shape at every site, and so future
+	// field additions don't force every test instantiation to be touched
+	// (matches the GCPCloudDeployConfig + AWSSageMakerConfig pattern).
+	AWSAppRunner *AWSAppRunnerConfig `json:"aws_apprunner,omitempty"`
 
 	// AWSSageMaker carries the caller-supplied SageMaker Studio config
 	// (#615). Named (not inline) so callers can construct it without
@@ -458,6 +466,40 @@ type GCPCloudDeployConfig struct {
 	Targets                 []GCPCloudDeployTarget `json:"targets,omitempty"`
 }
 
+// AWSAppRunnerConfig is the caller-facing config for the aws/apprunner
+// preset (#598 row 2). Named (not inline) so callers can construct it
+// without re-typing the anonymous struct shape at every site, and so
+// future field additions don't force every test instantiation to be
+// touched. Mirrors AWSSageMakerConfig.
+//
+// Field semantics map 1:1 to aws/apprunner/variables.tf. Empty / nil
+// values mean "defer to the module's HCL default" — the mapper only
+// emits a tfvar when the caller supplies a value. VPCID / SubnetIDs are
+// normally wired automatically (DefaultWiring reads module.aws_vpc) so
+// callers don't usually populate them on this struct unless they need
+// to override the wiring.
+type AWSAppRunnerConfig struct {
+	ServiceName              string            `json:"serviceName,omitempty"`
+	ImageRepositoryURL       string            `json:"imageRepositoryUrl,omitempty"`
+	ImageRepositoryType      string            `json:"imageRepositoryType,omitempty"`
+	Port                     *int              `json:"port,omitempty"`
+	EnvVars                  map[string]string `json:"envVars,omitempty"`
+	CPU                      string            `json:"cpu,omitempty"`
+	Memory                   string            `json:"memory,omitempty"`
+	MinSize                  *int              `json:"minSize,omitempty"`
+	MaxSize                  *int              `json:"maxSize,omitempty"`
+	MaxConcurrency           *int              `json:"maxConcurrency,omitempty"`
+	IsPubliclyAccessible     *bool             `json:"isPubliclyAccessible,omitempty"`
+	AutoDeploymentsEnabled   *bool             `json:"autoDeploymentsEnabled,omitempty"`
+	HealthCheckProtocol      string            `json:"healthCheckProtocol,omitempty"`
+	HealthCheckPath          string            `json:"healthCheckPath,omitempty"`
+	EnableVPCConnector       *bool             `json:"enableVpcConnector,omitempty"`
+	VPCID                    string            `json:"vpcId,omitempty"`
+	SubnetIDs                []string          `json:"subnetIds,omitempty"`
+	CustomDomainName         string            `json:"customDomainName,omitempty"`
+	EnableWWWSubdomain       *bool             `json:"enableWwwSubdomain,omitempty"`
+}
+
 // AWSSageMakerConfig is the caller-facing config for the aws/sagemaker
 // Studio preset (#615). Named (not inline) so callers can construct it
 // without re-typing the anonymous struct shape at every site, and so
@@ -534,6 +576,7 @@ func (c *Components) Normalize() {
 		c.AWSEKS = nil
 		c.AWSECS = nil
 		c.AWSLambda = nil
+		c.AWSAppRunner = nil
 		c.AWSSageMaker = nil
 		c.AWSALB = nil
 		c.AWSCloudFront = nil
@@ -660,6 +703,7 @@ func (c *Config) Normalize() {
 		c.AWSCloudWatchMonitoring = nil
 		c.AWSCognito = nil
 		c.AWSLambda = nil
+		c.AWSAppRunner = nil
 		c.AWSSageMaker = nil
 		c.AWSAPIGateway = nil
 		c.AWSKMS = nil

--- a/pkg/observability/component_metrics_coverage_test.go
+++ b/pkg/observability/component_metrics_coverage_test.go
@@ -1,0 +1,127 @@
+package observability
+
+// component_metrics_coverage_test.go gates the silent gap discovered
+// during the #598 / #614 / #618 / #620 audit: ComponentMetricsMapping
+// is the source of truth for which (service, action) the inspector
+// dispatcher invokes to populate a component's panel. Three back-to-
+// back parity PRs landed without adding entries here, and there was
+// no test forcing the omission to be acknowledged — the affected
+// components silently rendered "no observable resources."
+//
+// This test fails when an AWS/GCP ComponentKey in
+// composer.AllComponentKeys is missing from ComponentMetricsMapping,
+// unless the key is in metricsDeferredKeys (with a tracked-issue
+// rationale) or in metricsNonComponentKeys (genuinely not panel-
+// renderable — IAM-only components, sub-keys priced under a parent,
+// etc.). Adding to either allowlist requires a code change reviewers
+// will see.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/stretchr/testify/require"
+)
+
+// metricsDeferredKeys are AWS/GCP ComponentKeys whose
+// ComponentMetricsMapping entry is intentionally absent today. Adding
+// or extending an entry here MUST cite the tracking issue.
+//
+// Two cohorts:
+//  1. Pre-existing historical drift — keys that have lacked a panel
+//     mapping since before #598/#614/#618/#620. Documented here so
+//     the gap is now at least visible. Backfilled in a separate PR.
+//  2. New parity-roll-up keys — #614 / #618 / #620 landed without a
+//     mapping AND without a corresponding `<service>` entry in
+//     AWSServiceActions / GCPServiceActions. Adding a mapping
+//     requires registering the service + its actions first.
+//
+// Trim back as backfills land.
+var metricsDeferredKeys = map[composer.ComponentKey]string{
+	// Cohort 1: pre-existing historical drift. All tracked in #622.
+	composer.KeyAWSACM:           "Pre-existing (tracked in #622): ACM has no panel mapping. Listing certificates is the natural surface but it was not wired when the ACM preset (#280) landed.",
+	composer.KeyAWSBackups:       "Pre-existing (tracked in #622): aws_backups panel surface unclear (vault list vs plan list vs selection list). The [no-inspector] allowlist in extractors_drift_test.go acknowledges the parallel discovery gap.",
+	composer.KeyAWSGitHubActions: "Pre-existing (tracked in #622): IAM-only component, no panel resource. Either belongs in metricsNonComponentKeys permanently OR needs an IAM-list mapping for the OIDC provider.",
+	composer.KeyAWSRoute53:       "Pre-existing (tracked in #622): Route 53 has a discovery dispatcher (#596 — route53.go) but no panel mapping. list-hosted-zones is the natural surface.",
+	composer.KeyGCPBackups:       "Pre-existing (tracked in #622): gcp_backups panel surface unclear, parallel to aws_backups deferral above.",
+	composer.KeyGCPCloudDNS:      "Pre-existing (tracked in #622): Cloud DNS has a discovery dispatcher (#596 — gcp/dns.go) but no panel mapping. list-managed-zones is the natural surface.",
+
+	// Cohort 2: parity-roll-up — needs both ComponentMetricsMapping
+	// entry AND a matching service registered in service_actions.go.
+	// All tracked in #622.
+	composer.KeyGCPCloudDeploy: "Backfill ComponentMetricsMapping + service_actions.go for gcp_cloud_deploy (#614 / tracked in #622). Natural surface: list-delivery-pipelines.",
+	composer.KeyAWSSageMaker:   "Backfill ComponentMetricsMapping + service_actions.go for aws_sagemaker (#615 / #618 / tracked in #622). Natural surface: list-domains.",
+	composer.KeyAWSAppRunner:   "Backfill ComponentMetricsMapping + service_actions.go for aws_apprunner (#598 / #620 / tracked in #622). Natural surface: list-services.",
+}
+
+// metricsNonComponentKeys are AllComponentKeys entries that genuinely
+// do NOT correspond to a panel-renderable resource. Distinct from
+// metricsDeferredKeys: these are by-design, not pending work.
+var metricsNonComponentKeys = map[composer.ComponentKey]bool{
+	// Auto-included node group is covered by the parent KeyAWSEKS row;
+	// the dispatcher routes both keys through the same eks panel.
+	composer.KeyAWSEKSNodeGroup: true,
+}
+
+// TestComponentMetricsMappingCoversAllComponentKeys fails when an
+// AWS/GCP ComponentKey in composer.AllComponentKeys lacks an entry
+// in ComponentMetricsMapping.
+//
+// The dispatcher returns "unsupportedServiceError" for unmapped keys;
+// the panel falls through to "no observable resources" with no
+// indication of whether the gap is a deploy failure or a missing
+// mapping. Customers see a healthy deploy report no observability —
+// hard to attribute without a coverage test that fails CI.
+func TestComponentMetricsMappingCoversAllComponentKeys(t *testing.T) {
+	t.Parallel()
+
+	var missing []string
+	for _, k := range composer.AllComponentKeys {
+		s := string(k)
+		if !strings.HasPrefix(s, "aws_") && !strings.HasPrefix(s, "gcp_") {
+			continue
+		}
+		if metricsNonComponentKeys[k] {
+			continue
+		}
+		if _, ok := metricsDeferredKeys[k]; ok {
+			require.NotEmptyf(t, metricsDeferredKeys[k],
+				"metricsDeferredKeys[%q] must carry a non-empty issue-tracked rationale", k)
+			continue
+		}
+		if _, ok := ComponentMetricsMapping[k]; !ok {
+			missing = append(missing, s)
+		}
+	}
+	require.Empty(t, missing,
+		"ComponentMetricsMapping is missing entries for these AWS/GCP ComponentKeys: %v\n"+
+			"Fix: add an entry in component_metrics.go,\n"+
+			"OR add the key to metricsDeferredKeys with a tracked-issue rationale.\n"+
+			"Note: adding a mapping may also require registering the service in pkg/observability/service_actions.go.",
+		missing)
+
+	// Sanity: an entry in metricsDeferredKeys must NOT also have a
+	// ComponentMetricsMapping entry (would mean the backfill landed
+	// without clearing the allowlist).
+	for k := range metricsDeferredKeys {
+		if _, ok := ComponentMetricsMapping[k]; ok {
+			require.Failf(t,
+				"deferred key has a mapping",
+				"%q appears in metricsDeferredKeys AND in ComponentMetricsMapping — delete the allowlist entry; the backfill has landed",
+				k)
+		}
+	}
+}
+
+// TestComponentMetricsMappingDeferralReferencesIssues guards against
+// allowlist entries with no tracked-issue reference, matching the
+// pricing coverage test pattern.
+func TestComponentMetricsMappingDeferralReferencesIssues(t *testing.T) {
+	t.Parallel()
+	for k, reason := range metricsDeferredKeys {
+		require.Truef(t, strings.Contains(reason, "#"),
+			"metricsDeferredKeys[%q] must cite a tracking issue (e.g. \"#1234\") so the deferral is auditable",
+			k)
+	}
+}

--- a/pkg/observability/display.go
+++ b/pkg/observability/display.go
@@ -109,6 +109,8 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "AWS Cognito"
 	case composer.KeyAWSLambda:
 		return "AWS Lambda"
+	case composer.KeyAWSAppRunner:
+		return "AWS App Runner"
 	case composer.KeyAWSSageMaker:
 		return "AWS SageMaker"
 	case composer.KeyAWSALB:

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -70,6 +70,7 @@ var configExtractorAllowlist = map[string]string{
 	"aws_eks_nodegroup": "[no-inspector] EKS node group is covered by the aws_eks inspector (#204)",
 
 	"aws_sagemaker": "[no-inspector] SageMaker Studio inspector deferred (#615 explicitly marks discovery inspector as optional/follow-up — domain + execution role are surfaced via name-prefix scoping until per-resource extractors land)",
+	"aws_apprunner": "[no-inspector] App Runner inspector deferred (#598 explicitly marks discovery inspector as optional/follow-up for every parity row — service + autoscaling config + VPC connector are surfaced via name-prefix scoping until per-resource extractors land)",
 
 	"gcp_backups":      "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
 	"gcp_cloud_deploy": "[no-inspector] Cloud Deploy delivery-pipeline inspector deferred (#613 explicitly marks discovery inspector + extractor as optional/follow-up); ComponentMetricsMapping has no entry yet so the panel falls back to design values until the per-component extractor lands",

--- a/tests/lint-project-tag.sh
+++ b/tests/lint-project-tag.sh
@@ -31,6 +31,7 @@ NON_TAGGABLE_AWS=(
   aws_apigatewayv2_authorizer
   aws_apigatewayv2_integration
   aws_apigatewayv2_route
+  aws_apprunner_custom_domain_association
   aws_autoscaling_group_tag
   aws_backup_selection
   aws_bedrock_model_invocation_logging_configuration


### PR DESCRIPTION
## Summary

Row 2 of #598 (AWS↔GCP parity roll-up) — AWS App Runner as the analog of `gcp/cloud_run`.

Pairs with #618 (Row 1, `aws/sagemaker` ↔ `gcp/vertex_ai`). Row 3 (`aws/codebuild` standalone) was explicitly tagged **Optional** in #598 and is deferred to #619 per #598's own AC. The PR therefore closes #598 in full.

Plus: an audit during this PR surfaced three silent observability gaps that affected #614 + #618 + #620 cumulatively. The pricing one is fixed for App Runner here, and two coverage gates are added so future preset PRs can't silently repeat the same omissions. The remaining backfill work is tracked in three follow-up issues.

## Scope

### Preset + composer wiring

- `aws/apprunner` preset: `aws_apprunner_service` + versioned autoscaling config (with `create_before_destroy` for clean replace cycles) + optional VPC connector + optional custom domain association + ECR access role (when private ECR) + tasks instance role. Both IAM roles carry the `aws:SourceAccount` confused-deputy guard. Every taggable resource carries `tags = merge(module.name.tags, var.tags)` per CLAUDE.md issue #81.
- Composer wiring: `KeyAWSAppRunner` registered with `ImplicitDependencies: {KeyAWSVPC}` (parity with `KeyGCPCloudRun`) and a `DefaultWiring` case threading `module.aws_vpc.vpc_id` + private subnets when the upstream VPC is non-public.
- Named `AWSAppRunnerConfig` sub-config (matches `AWSSageMakerConfig` + `GCPCloudDeployConfig`).
- 22 tftest runs (happy paths + value-flow assertions on every wired field + trust-policy exclusivity + SourceAccount wildcard rejection + #614-pattern rejection-axis triangulation).
- 9 Go composer tests (mapper paths + ComposeStack Forward with both `vpc_id` AND `private_subnet_ids` cross-module wiring pinned + CallerSuppliedConfig + ComponentSelected + IAMActions).
- Observability: friendly display name + `[no-inspector]` drift allowlist entry (parity with #615 sagemaker).
- CLAUDE.md preset count refresh: AWS 29 → 35, GCP 22 → 25 (absorbs historic drift).

### Silent-gap audit + coverage gates (added in 6th commit)

The audit found three things the parity-roll-up PRs (#614, #618, #620) had been silently skipping:

| Surface | Before this PR | After this PR |
|---|---|---|
| **Pricing rows** in `PricingData.Components` | Typed Go struct with explicit per-key fields; `gcp_cloud_deploy` and `aws_sagemaker` had no field. Cost-LLM structurally unable to emit those rows. | App Runner field added. `TestPricingDataCoversAllComponentKeys` gates future PRs — the two existing gaps are allowlisted with refs to **#621**. |
| **`ComponentMetricsMapping` entries** | No entry → dispatcher returns `unsupportedServiceError` → panel renders "no observable resources" indistinguishable from a failed deploy. Three roll-up keys + six pre-existing historical gaps. | `TestComponentMetricsMappingCoversAllComponentKeys` gates future PRs — all nine gaps allowlisted with refs to **#622**. The roll-up entries also need `service_actions.go` registrations (tracked alongside). |
| **Drift policy files** (`pkg/composer/imported/policy/*.policy.go`) | `pkg/drift/imported/compare.go::Compare` says verbatim: *"Types without a registered policy return nil (no fields curated → no drift signal)."* No policy files for `aws_apprunner_*`, `aws_sagemaker_*`, `google_clouddeploy_*` → drift detection blind. | Tracked in **#623**. No coverage test added — the policy files themselves are substantial curated per-attribute maps; writing them well is follow-on work. |

Both coverage tests pin that allowlist rationales must cite a tracked issue (`#` substring required), matching the existing `[no-inspector]` pattern in `extractors_drift_test.go`.

## Closing #598

| Row | Preset | Outcome |
|---|---|---|
| 1 | `aws/sagemaker` (Vertex AI analog) | ✅ shipped in #618 |
| 2 | `aws/apprunner` (Cloud Run analog) | ✅ this PR |
| 3 | `aws/codebuild` standalone | deferred to #619 (Optional per #598 scope) |

Closes #598.

## Follow-up issues

- #619 — `aws/codebuild` standalone preset (Row 3, Optional)
- #621 — Backfill pricing rows for #614 (gcp_cloud_deploy) + #618 (aws_sagemaker)
- #622 — Backfill ComponentMetricsMapping + service_actions for #614/#618/#620 + historical drift
- #623 — Drift policy files for #614/#618/#620 resource types

## Test plan

- [x] `cd aws/apprunner && terraform init -backend=false && terraform validate` — clean (one inherited `managed_policy_arns` deprecation warning, matches `aws/lambda` / `aws/sagemaker`)
- [x] `terraform test` — 22 runs pass
- [x] `terraform fmt -check -recursive` — clean
- [x] `go test ./pkg/composer/... ./pkg/observability/...` — 3385 tests pass (includes 4 new coverage tests + their gates)
- [x] All `tests/lint-*.sh` — green
- [x] `bash tests/validate-as-child.sh aws/apprunner` — passes
- [x] qa-professor pass: P0 + all P1s addressed inline (`requireNoTfvarAssignment` helper, trust-policy exclusivity, SourceAccount wildcard rejection, value-flow assertions, positive companions)