### PR TITLE
feat(presets): add aws/codebuild standalone preset (#619)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-InsideOut Terraform Presets — a library of standardized, composable Terraform module presets for AWS (35 modules) and GCP (25 modules). Used standalone or composed by the InsideOut engine to generate cloud infrastructure stacks. Currently in beta.
+InsideOut Terraform Presets — a library of standardized, composable Terraform module presets for AWS (36 modules) and GCP (25 modules). Used standalone or composed by the InsideOut engine to generate cloud infrastructure stacks. Currently in beta.
 
 The Go module (`zz_embed.go`) embeds all `.tf` and `.tmpl` files via `embed.FS` for use by the InsideOut composition engine.
 
@@ -28,7 +28,7 @@ terraform fmt -recursive
 ## Architecture
 
 ```
-aws/<module>/          # AWS Terraform modules (35 modules)
+aws/<module>/          # AWS Terraform modules (36 modules)
 gcp/<module>/          # GCP Terraform modules (25 modules)
 zz_embed.go            # Go embed directive exposing FS for all .tf/.tmpl files
 go.mod                 # Go module: github.com/luthersystems/insideout-terraform-presets

--- a/aws/codebuild/main.tf
+++ b/aws/codebuild/main.tf
@@ -1,0 +1,357 @@
+# AWS CodeBuild project preset (#619, deferred row 3 of #598).
+#
+# Mirrors the role gcp/cloud_build plays for GCP stacks: a single-call
+# entry point for a managed build/CI runner on AWS. The preset
+# provisions:
+#
+#   - A CodeBuild project (`aws_codebuild_project`) named
+#     `${var.project}-${var.codebuild_project_name}` so the InsideOut
+#     inspector can attribute it to the stack via name-prefix scoping
+#     (CLAUDE.md "name-prefix scoping" rule).
+#   - A service IAM role (`aws_iam_role.service`) the CodeBuild control
+#     plane assumes to run builds. Trusts `codebuild.amazonaws.com` and
+#     carries the `aws:SourceAccount` confused-deputy guard
+#     (matches aws/apprunner + aws/sagemaker + aws/bedrock).
+#   - An inline IAM role policy (`aws_iam_role_policy.service`) granting
+#     the minimal permissions a build needs: CloudWatch Logs creation /
+#     write for build logs, ECR pull for the runtime image, and — when
+#     the optional VPC config is on — the EC2 ENI lifecycle calls
+#     CodeBuild makes per-build to wire its build container into the
+#     customer VPC. Inline (not attached managed policy) so the role's
+#     permission lifecycle tracks 1:1 with the role; mirrors
+#     aws/sagemaker's inline studio_workspace_access policy.
+#   - Optional S3 logs bucket
+#     (`aws_s3_bucket.logs` + versioning + AES256 + public-access block)
+#     when `enable_s3_logs = true`. The bucket carries the standard
+#     hardening trio matching aws/sagemaker's workspace bucket.
+#   - Optional `vpc_config` block on the project, gated on a non-empty
+#     `subnet_ids` list. The caller supplies `vpc_id`, `subnet_ids`, and
+#     `security_group_ids` — the composer wires `vpc_id` + `subnet_ids`
+#     from `module.aws_vpc` automatically when KeyAWSVPC is selected
+#     (and is the ImplicitDependencies default for KeyAWSCodeBuild).
+#
+# Scope ceiling: matches gcp/cloud_build simplicity. CodeBuild batch
+# build configurations, source-credential management
+# (`aws_codebuild_source_credential`), report groups, fleet (compute
+# pool) management, and webhook auto-trigger setup are exposed only as
+# the AWS provider defaults — advanced consumers wrap or fork.
+#
+# Discovery inspector: deferred per #619 (issue explicitly marks the
+# discovery inspector as out-of-scope / follow-up — mirrors the
+# apprunner + sagemaker deferral pattern). See
+# `pkg/observability/extractors/extractors_drift_test.go` allowlist.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
+  }
+}
+
+# Standard luthername-driven naming + tag set. Every AWS preset in the
+# repo wires through this module so the InsideOut inspector's exact
+# `Project = <project>` filter (CLAUDE.md issue #81) catches every
+# resource.
+module "name" {
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
+  luther_project = var.project
+  aws_region     = var.region
+  luther_env     = var.environment
+  org_name       = "luthersystems"
+  component      = "insideout"
+  subcomponent   = "cb"
+  resource       = "cb"
+}
+
+# Caller identity drives the aws:SourceAccount confused-deputy guard on
+# the CodeBuild service-role trust policy (matches aws/apprunner +
+# aws/sagemaker + aws/bedrock).
+data "aws_caller_identity" "current" {}
+
+locals {
+  # Project-tag merge from the luthername module so every taggable
+  # resource carries the full standard tag set.
+  tags = merge(module.name.tags, var.tags)
+
+  project_name = "${var.project}-${var.codebuild_project_name}"
+
+  create_logs_bucket = var.enable_s3_logs
+  # VPC config is opt-in via subnet_ids — leaving subnet_ids empty
+  # leaves the dynamic block off so the project runs in the CodeBuild
+  # public network plane (matches the default behaviour the AWS
+  # console offers).
+  needs_vpc_config = length(var.subnet_ids) > 0
+}
+
+# -----------------------------------------------------------------------------
+# Optional S3 logs bucket.
+#
+# Standard hardening trio: versioning + AES256 + public-access block.
+# Bucket name is suffixed with a random_id so distinct stacks don't
+# collide on the global S3 namespace. Pattern mirrors aws/sagemaker's
+# workspace bucket.
+# -----------------------------------------------------------------------------
+
+resource "random_id" "logs_suffix" {
+  count       = local.create_logs_bucket ? 1 : 0
+  byte_length = 3
+}
+
+resource "aws_s3_bucket" "logs" {
+  count = local.create_logs_bucket ? 1 : 0
+
+  bucket        = "${var.project}-codebuild-logs-${random_id.logs_suffix[0].hex}"
+  force_destroy = true
+
+  tags = merge(local.tags, {
+    Name = "${var.project}-codebuild-logs"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "logs" {
+  count = local.create_logs_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.logs[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
+  count = local.create_logs_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.logs[0].id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "logs" {
+  count = local.create_logs_bucket ? 1 : 0
+
+  bucket                  = aws_s3_bucket.logs[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# -----------------------------------------------------------------------------
+# IAM service role — assumed by the CodeBuild control plane per build.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "service" {
+  name = "${var.project}-codebuild"
+  path = "/service-role/"
+
+  # codebuild.amazonaws.com is the CodeBuild service principal. Scoped
+  # to the deploying account via aws:SourceAccount so a hostile cross-
+  # account caller can't trick CodeBuild into using this role on their
+  # behalf.
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "codebuild.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+        }
+      }
+    }]
+  })
+
+  tags = local.tags
+
+  lifecycle {
+    ignore_changes = [managed_policy_arns]
+  }
+}
+
+# Inline base policy: CloudWatch Logs (always on — every build emits
+# log streams) + ECR pull (covers the default standard image on public
+# ECR + any private image the caller swaps in). Inline (not attached
+# managed policy) so the role's permission lifecycle tracks 1:1 with
+# the role — mirrors aws/sagemaker's studio_workspace_access.
+#
+# The optional S3 logs + VPC ENI permission statements live on
+# separate count-gated aws_iam_role_policy resources below so the
+# policy doc itself stays a single-shape object literal and the
+# permission set adapts cleanly to the enable_s3_logs / VPC toggles.
+resource "aws_iam_role_policy" "service" {
+  name = "${var.project}-codebuild"
+  role = aws_iam_role.service.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # CloudWatch Logs — every build emits a log stream.
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/codebuild/${local.project_name}:*"
+      },
+      # ECR pull — the standard build image lives on a public ECR;
+      # private images need ECR auth + pull.
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer",
+        ]
+        Resource = "*"
+      },
+      # GetAuthorizationToken only accepts Resource "*" per the IAM
+      # contract — kept on its own statement so the linter sees a
+      # narrow Resource on the other ECR actions.
+      {
+        Effect   = "Allow"
+        Action   = "ecr:GetAuthorizationToken"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+# Optional S3 logs access — only attached when enable_s3_logs = true so
+# the role doesn't carry unused S3 permissions on builds that emit
+# CloudWatch-only logs.
+resource "aws_iam_role_policy" "service_s3_logs" {
+  count = local.create_logs_bucket ? 1 : 0
+
+  name = "${var.project}-codebuild-s3-logs"
+  role = aws_iam_role.service.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:PutObject",
+        "s3:ListBucket",
+      ]
+      Resource = [
+        aws_s3_bucket.logs[0].arn,
+        "${aws_s3_bucket.logs[0].arn}/*",
+      ]
+    }]
+  })
+}
+
+# Optional VPC ENI lifecycle — only attached when the project runs in
+# a VPC (subnet_ids non-empty). CodeBuild creates an ENI per build in
+# the provided subnets and deletes it when the build finishes;
+# DescribeDhcpOptions is read by CodeBuild during VPC config
+# validation. The ec2:CreateNetworkInterfacePermission action is
+# scoped to the supplied subnets via the ec2:Subnet condition so the
+# role can't attach ENIs in arbitrary subnets of the account.
+resource "aws_iam_role_policy" "service_vpc" {
+  count = local.needs_vpc_config ? 1 : 0
+
+  name = "${var.project}-codebuild-vpc"
+  role = aws_iam_role.service.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateNetworkInterface",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeDhcpOptions",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVpcs",
+        ]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "ec2:CreateNetworkInterfacePermission"
+        Resource = "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:network-interface/*"
+        Condition = {
+          StringEquals = {
+            "ec2:AuthorizedService" = "codebuild.amazonaws.com"
+          }
+          ArnEquals = {
+            "ec2:Subnet" = [for s in var.subnet_ids : "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:subnet/${s}"]
+          }
+        }
+      },
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# CodeBuild project.
+# -----------------------------------------------------------------------------
+
+resource "aws_codebuild_project" "main" {
+  name         = local.project_name
+  service_role = aws_iam_role.service.arn
+
+  source {
+    type      = var.source_type
+    location  = var.source_type == "NO_SOURCE" ? null : var.source_location
+    buildspec = var.buildspec
+  }
+
+  artifacts {
+    type     = var.artifacts_type
+    location = var.artifacts_type == "NO_ARTIFACTS" ? null : var.artifacts_location
+  }
+
+  environment {
+    compute_type                = var.compute_type
+    image                       = var.build_image
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = false
+  }
+
+  dynamic "vpc_config" {
+    for_each = local.needs_vpc_config ? [1] : []
+    content {
+      vpc_id             = var.vpc_id
+      subnets            = var.subnet_ids
+      security_group_ids = var.security_group_ids
+    }
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      status = "ENABLED"
+    }
+
+    dynamic "s3_logs" {
+      for_each = local.create_logs_bucket ? [1] : []
+      content {
+        status   = "ENABLED"
+        location = "${aws_s3_bucket.logs[0].bucket}/build-logs/"
+      }
+    }
+  }
+
+  tags = local.tags
+}

--- a/aws/codebuild/outputs.tf
+++ b/aws/codebuild/outputs.tf
@@ -1,0 +1,34 @@
+output "project_arn" {
+  description = "ARN of the CodeBuild project. Wire this into IAM policies, EventBridge rules that target the project, or CodePipeline build stages that need exact-match ARN references."
+  value       = aws_codebuild_project.main.arn
+}
+
+output "project_name" {
+  description = "Name of the CodeBuild project (`<project>-<codebuild_project_name>`). Use this when invoking the project via the AWS CLI / SDK (`aws codebuild start-build --project-name ...`) or wiring it to a CodePipeline source."
+  value       = aws_codebuild_project.main.name
+}
+
+output "service_role_arn" {
+  description = "ARN of the IAM role CodeBuild assumes per build. Caller-attached managed-policy attachments on this role extend what builds can call in AWS beyond the preset's inline policy (CloudWatch Logs + ECR pull + optional S3 logs + optional VPC ENI lifecycle)."
+  value       = aws_iam_role.service.arn
+}
+
+output "service_role_name" {
+  description = "Name of the service IAM role. Useful for attaching additional managed-policy attachments from sibling modules (e.g. a stack that wants the build to deploy to ECS attaches `AmazonEC2ContainerRegistryPowerUser` here)."
+  value       = aws_iam_role.service.name
+}
+
+output "logs_bucket_name" {
+  description = "Name of the S3 bucket the preset provisioned for build logs (null when enable_s3_logs = false). The bucket is hardened with versioning + AES256 + public-access-block."
+  value       = local.create_logs_bucket ? aws_s3_bucket.logs[0].bucket : null
+}
+
+output "logs_bucket_arn" {
+  description = "ARN of the S3 bucket the preset provisioned for build logs (null when enable_s3_logs = false). Useful for sibling modules that need to read build logs out-of-stack."
+  value       = local.create_logs_bucket ? aws_s3_bucket.logs[0].arn : null
+}
+
+output "tags" {
+  description = "The Project-tagged map applied to every taggable resource in this preset. Other presets composing on top can `merge(module.aws_codebuild.tags, ...)` to inherit the same Project attribution."
+  value       = local.tags
+}

--- a/aws/codebuild/tests/shape.tftest.hcl
+++ b/aws/codebuild/tests/shape.tftest.hcl
@@ -1,0 +1,439 @@
+mock_provider "aws" {}
+mock_provider "random" {}
+
+# Issue #619 (aws/codebuild standalone preset) shape tests. Verifies:
+#   - Defaults compose cleanly (minimum inputs happy path).
+#   - Project name carries the var.project prefix (inspector attribution).
+#   - Project tag is on every taggable resource (defense-in-depth alongside
+#     the prefix, CLAUDE.md issue #81).
+#   - Service role's trust policy is correctly scoped:
+#       - allows codebuild.amazonaws.com
+#       - carries the aws:SourceAccount confused-deputy guard
+#       - never wildcards SourceAccount
+#   - Optional S3 logs bucket toggles between off (no bucket / no S3
+#     hardening trio) and on (bucket + versioning + AES256 + public-
+#     access block ALL on, with `logs_config.s3_logs.location` wired).
+#   - Optional VPC config dynamic block toggles on a non-empty
+#     subnet_ids list (vpc_id / subnets / security_group_ids propagate).
+#   - source_type / artifacts_type / buildspec propagate to the project.
+#   - Validation rejects every misconfiguration axis, AND a positive
+#     companion run pins that the negatives fire on the right rule
+#     (rejection-axis triangulation per #614).
+#
+# Every run uses `command = plan`. The assertions below reference
+# attributes the preset sets explicitly (names, tags, IAM trust-policy
+# JSON, dynamic-block cardinality) — all plan-time-known. The
+# mock_provider emits random strings for arn-shaped Computed fields
+# which would fail apply-time validation on resources that demand
+# ARN-shaped inputs (e.g. service_role on aws_codebuild_project) — same
+# trade-off as aws/apprunner + aws/sagemaker shape tests. Every wiring
+# cross-ref we care about is also pinned end-to-end in
+# `TestComposeStack_AWSCodeBuild_Forward` in the Go composer wiring
+# test.
+
+# -----------------------------------------------------------------------------
+# Positive: minimum inputs plan cleanly.
+# -----------------------------------------------------------------------------
+
+run "codebuild_minimum_inputs" {
+  command = plan
+
+  variables {
+    project         = "test"
+    source_location = "https://github.com/example/repo.git"
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.name == "test-build"
+    error_message = "project name must be `<project>-<codebuild_project_name>` so InsideOut name-prefix scoping attributes it to the stack."
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.tags["Project"] == "test"
+    error_message = "Project tag must be set on the CodeBuild project so the InsideOut inspector's exact-match filter sees it (CLAUDE.md issue #81)."
+  }
+
+  # Defaults propagate.
+  assert {
+    condition     = aws_codebuild_project.main.environment[0].compute_type == "BUILD_GENERAL1_SMALL"
+    error_message = "Default compute_type must be BUILD_GENERAL1_SMALL."
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.environment[0].image == "aws/codebuild/standard:7.0"
+    error_message = "Default build_image must be aws/codebuild/standard:7.0."
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.source[0].type == "GITHUB"
+    error_message = "Default source_type must be GITHUB."
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.artifacts[0].type == "NO_ARTIFACTS"
+    error_message = "Default artifacts_type must be NO_ARTIFACTS."
+  }
+
+  # Service role exists, is project-prefixed.
+  assert {
+    condition     = aws_iam_role.service.name == "test-codebuild"
+    error_message = "Service role must be project-prefixed."
+  }
+
+  assert {
+    condition     = strcontains(aws_iam_role.service.assume_role_policy, "codebuild.amazonaws.com")
+    error_message = "Service role assume_role_policy must trust codebuild.amazonaws.com."
+  }
+
+  assert {
+    condition     = strcontains(aws_iam_role.service.assume_role_policy, "aws:SourceAccount")
+    error_message = "Service role assume_role_policy must carry the aws:SourceAccount confused-deputy guard."
+  }
+
+  # Reject the wildcard-value form of the SourceAccount guard — a
+  # mutation that hard-coded `"aws:SourceAccount": "*"` would still
+  # satisfy the strcontains check above but effectively disable the
+  # confused-deputy protection.
+  assert {
+    condition     = !strcontains(aws_iam_role.service.assume_role_policy, "\"aws:SourceAccount\":\"*\"")
+    error_message = "SourceAccount guard must not be wildcarded (\"*\")."
+  }
+
+  # No logs bucket by default.
+  assert {
+    condition     = length(aws_s3_bucket.logs) == 0
+    error_message = "Logs bucket must NOT be created when enable_s3_logs is unset (the default)."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_versioning.logs) == 0
+    error_message = "Logs bucket versioning must NOT be created when enable_s3_logs is unset."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_server_side_encryption_configuration.logs) == 0
+    error_message = "Logs bucket SSE configuration must NOT be created when enable_s3_logs is unset."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_public_access_block.logs) == 0
+    error_message = "Logs bucket public-access block must NOT be created when enable_s3_logs is unset."
+  }
+
+  # No VPC config by default (empty subnet_ids list).
+  assert {
+    condition     = length(aws_codebuild_project.main.vpc_config) == 0
+    error_message = "vpc_config dynamic block must be empty when subnet_ids is empty (the default)."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Positive: enable_s3_logs creates the bucket with full hardening.
+# -----------------------------------------------------------------------------
+
+run "codebuild_enable_s3_logs_creates_bucket" {
+  command = plan
+
+  variables {
+    project         = "test"
+    source_location = "https://github.com/example/repo.git"
+    enable_s3_logs  = true
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket.logs) == 1
+    error_message = "Logs bucket must be created when enable_s3_logs = true."
+  }
+
+  # Pins the project-prefix on the bucket name.
+  assert {
+    condition     = startswith(aws_s3_bucket.logs[0].bucket, "test-codebuild-logs-")
+    error_message = "Logs bucket name must start with `<project>-codebuild-logs-` for inspector attribution + global uniqueness."
+  }
+
+  # Hardening trio: versioning + encryption + public-access block all on.
+  assert {
+    condition     = length(aws_s3_bucket_versioning.logs) == 1
+    error_message = "Logs bucket versioning resource must be created when enable_s3_logs = true."
+  }
+
+  assert {
+    condition     = aws_s3_bucket_versioning.logs[0].versioning_configuration[0].status == "Enabled"
+    error_message = "Logs bucket versioning must be Enabled."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_server_side_encryption_configuration.logs) == 1
+    error_message = "Logs bucket SSE configuration must be created when enable_s3_logs = true."
+  }
+
+  # The `rule` block is a set, not a list — can't index with [0].
+  # Iterate via a for-expression instead to assert AES256 is present.
+  assert {
+    condition     = anytrue([for r in aws_s3_bucket_server_side_encryption_configuration.logs[0].rule : r.apply_server_side_encryption_by_default[0].sse_algorithm == "AES256"])
+    error_message = "Logs bucket SSE algorithm must be AES256."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_public_access_block.logs) == 1
+    error_message = "Logs bucket public-access block must be created when enable_s3_logs = true."
+  }
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.logs[0].block_public_acls == true && aws_s3_bucket_public_access_block.logs[0].block_public_policy == true && aws_s3_bucket_public_access_block.logs[0].ignore_public_acls == true && aws_s3_bucket_public_access_block.logs[0].restrict_public_buckets == true
+    error_message = "All four public-access block flags must be true (no partial public exposure)."
+  }
+
+  # s3_logs dynamic block on the project flips on.
+  assert {
+    condition     = length(aws_codebuild_project.main.logs_config[0].s3_logs) == 1
+    error_message = "Project's logs_config.s3_logs dynamic block must be present when enable_s3_logs = true."
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.logs_config[0].s3_logs[0].status == "ENABLED"
+    error_message = "Project's logs_config.s3_logs.status must be ENABLED when enable_s3_logs = true."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Positive: subnet_ids non-empty toggles vpc_config block on.
+# -----------------------------------------------------------------------------
+
+run "codebuild_vpc_config_threads_inputs" {
+  command = plan
+
+  variables {
+    project            = "test"
+    source_location    = "https://github.com/example/repo.git"
+    vpc_id             = "vpc-12345"
+    subnet_ids         = ["subnet-aaa", "subnet-bbb"]
+    security_group_ids = ["sg-12345"]
+  }
+
+  assert {
+    condition     = length(aws_codebuild_project.main.vpc_config) == 1
+    error_message = "vpc_config dynamic block must be present when subnet_ids is non-empty."
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.vpc_config[0].vpc_id == "vpc-12345"
+    error_message = "vpc_config.vpc_id must propagate var.vpc_id."
+  }
+
+  assert {
+    condition     = length(aws_codebuild_project.main.vpc_config[0].subnets) == 2
+    error_message = "vpc_config.subnets must propagate var.subnet_ids."
+  }
+
+  assert {
+    condition     = length(aws_codebuild_project.main.vpc_config[0].security_group_ids) == 1
+    error_message = "vpc_config.security_group_ids must propagate var.security_group_ids."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Positive: inline buildspec propagates to the project source block.
+# -----------------------------------------------------------------------------
+
+run "codebuild_buildspec_override_propagates" {
+  command = plan
+
+  variables {
+    project         = "test"
+    source_type     = "NO_SOURCE"
+    source_location = ""
+    buildspec       = "version: 0.2\nphases:\n  build:\n    commands:\n      - echo hello\n"
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.source[0].buildspec == "version: 0.2\nphases:\n  build:\n    commands:\n      - echo hello\n"
+    error_message = "Inline buildspec must propagate to aws_codebuild_project.source.buildspec verbatim."
+  }
+
+  # NO_SOURCE: source.location must be null (the preset coerces it).
+  assert {
+    condition     = aws_codebuild_project.main.source[0].location == null
+    error_message = "source.location must be null when source_type = NO_SOURCE."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Positive: S3 artifacts toggle propagates location.
+# -----------------------------------------------------------------------------
+
+run "codebuild_artifacts_s3_propagates" {
+  command = plan
+
+  variables {
+    project            = "test"
+    source_location    = "https://github.com/example/repo.git"
+    artifacts_type     = "S3"
+    artifacts_location = "my-artifacts-bucket"
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.artifacts[0].type == "S3"
+    error_message = "artifacts.type must propagate var.artifacts_type."
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.artifacts[0].location == "my-artifacts-bucket"
+    error_message = "artifacts.location must propagate var.artifacts_location when artifacts_type = S3."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Positive triangulation companions for the rejection-axis negatives below.
+# Pattern from #614 — pins that the negatives fire on the right validation
+# rule, not a no-op short-circuit.
+# -----------------------------------------------------------------------------
+
+run "codebuild_valid_compute_type_plans_cleanly" {
+  command = plan
+
+  variables {
+    project         = "test"
+    source_location = "https://github.com/example/repo.git"
+    compute_type    = "BUILD_GENERAL1_LARGE"
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.environment[0].compute_type == "BUILD_GENERAL1_LARGE"
+    error_message = "A valid compute_type must plan cleanly and propagate (companion to rejects_bad_compute_type)."
+  }
+}
+
+run "codebuild_valid_source_type_plans_cleanly" {
+  command = plan
+
+  variables {
+    project         = "test"
+    source_type     = "CODECOMMIT"
+    source_location = "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/myrepo"
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.source[0].type == "CODECOMMIT"
+    error_message = "A valid source_type must plan cleanly and propagate (companion to rejects_bad_source_type)."
+  }
+}
+
+run "codebuild_valid_artifacts_type_plans_cleanly" {
+  command = plan
+
+  variables {
+    project            = "test"
+    source_location    = "https://github.com/example/repo.git"
+    artifacts_type     = "CODEPIPELINE"
+    artifacts_location = ""
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.artifacts[0].type == "CODEPIPELINE"
+    error_message = "A valid artifacts_type must plan cleanly and propagate (companion to rejects_bad_artifacts_type)."
+  }
+}
+
+run "codebuild_valid_project_name_plans_cleanly" {
+  command = plan
+
+  variables {
+    project                = "test"
+    codebuild_project_name = "my-build"
+    source_location        = "https://github.com/example/repo.git"
+  }
+
+  assert {
+    condition     = aws_codebuild_project.main.name == "test-my-build"
+    error_message = "A regex-valid codebuild_project_name must plan cleanly (companion to rejects_bad_project_name)."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases — validation rejects obvious misconfigurations at plan
+# time so callers don't discover them at apply. Each axis paired with a
+# positive companion above.
+# -----------------------------------------------------------------------------
+
+run "codebuild_rejects_bad_compute_type" {
+  command = plan
+
+  variables {
+    project         = "test"
+    source_location = "https://github.com/example/repo.git"
+    compute_type    = "BUILD_GENERAL1_HUGE"
+  }
+
+  expect_failures = [var.compute_type]
+}
+
+run "codebuild_rejects_bad_source_type" {
+  command = plan
+
+  variables {
+    project         = "test"
+    source_type     = "BITBUCKET"
+    source_location = "https://bitbucket.org/example/repo.git"
+  }
+
+  expect_failures = [var.source_type]
+}
+
+run "codebuild_rejects_bad_artifacts_type" {
+  command = plan
+
+  variables {
+    project         = "test"
+    source_location = "https://github.com/example/repo.git"
+    artifacts_type  = "GCS"
+  }
+
+  expect_failures = [var.artifacts_type]
+}
+
+run "codebuild_rejects_bad_project_name" {
+  command = plan
+
+  variables {
+    project                = "test"
+    codebuild_project_name = "has spaces"
+    source_location        = "https://github.com/example/repo.git"
+  }
+
+  expect_failures = [var.codebuild_project_name]
+}
+
+run "codebuild_rejects_empty_project" {
+  command = plan
+
+  variables {
+    project         = "   "
+    source_location = "https://github.com/example/repo.git"
+  }
+
+  expect_failures = [var.project]
+}
+
+# Pins the 40-char project cap.
+run "codebuild_rejects_oversized_project" {
+  command = plan
+
+  variables {
+    # 41 chars — one over the limit. The trimspace-non-empty validation
+    # passes; only the length validation should fire.
+    project         = "abcdefghijklmnopqrstuvwxyz1234567890abcde"
+    source_location = "https://github.com/example/repo.git"
+  }
+
+  expect_failures = [var.project]
+}
+
+# source_location + artifacts_location cross-variable validations
+# (required-when-set) live at the AWS API layer rather than in
+# variable validation, because Terraform variable validation evaluates
+# each variable in isolation (the test framework rejects cross-`var.`
+# references in a single rule). CodeBuild's apply-time validator
+# rejects an empty source_location for any source_type other than
+# NO_SOURCE, and an empty artifacts_location for artifacts_type = S3 —
+# so the misconfiguration still surfaces, just at apply not at plan.

--- a/aws/codebuild/variables.tf
+++ b/aws/codebuild/variables.tf
@@ -1,0 +1,163 @@
+variable "project" {
+  description = "Naming / Project-tag prefix for stack resources. The InsideOut inspector filters AWS resources by exact `Project = <project>` match — this value also seeds the CodeBuild project name (`<project>-<codebuild_project_name>`), the IAM role name (`<project>-codebuild`), and the optional logs bucket name. Capped at 40 chars so the longest derived name (`<project>-codebuild-logs-<6hex>`) stays inside AWS's 63-char S3 bucket / 64-char IAM identifier limits."
+  type        = string
+  default     = "demo"
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+
+  validation {
+    condition     = length(var.project) <= 40
+    error_message = "project must be 40 chars or fewer so derived CodeBuild project / IAM role / S3 bucket names fit inside AWS's 63/64-char identifier limits."
+  }
+}
+
+variable "region" {
+  description = "AWS region. Passed into the luthername module so the standard tag set carries the region and into the inline IAM policy ARNs (logs:CreateLogGroup resource scope, ec2:CreateNetworkInterfacePermission subnet ARNs). The AWS provider itself picks the region up from provider config."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g. production, staging, sandbox). Feeds the luthername module's standard tag set; not used elsewhere in the preset."
+  type        = string
+  default     = "sandbox"
+
+  validation {
+    condition     = length(trimspace(var.environment)) > 0
+    error_message = "environment must be a non-empty string."
+  }
+}
+
+variable "tags" {
+  description = "Extra tags merged onto every taggable resource. The preset always sets the standard luthername tag set (including `Project = var.project`); entries here override or extend that base set."
+  type        = map(string)
+  default     = {}
+}
+
+# -----------------------------------------------------------------------------
+# Project shape
+# -----------------------------------------------------------------------------
+
+variable "codebuild_project_name" {
+  description = "CodeBuild project name component. The composed project name is `<project>-<codebuild_project_name>` (matches the gcp/cloud_build pattern of project-prefixed naming for inspector attribution)."
+  type        = string
+  default     = "build"
+
+  validation {
+    condition     = can(regex("^[A-Za-z][A-Za-z0-9_-]{1,38}[A-Za-z0-9]$", var.codebuild_project_name))
+    error_message = "codebuild_project_name must be 3-40 chars, start with a letter, end alphanumeric, contain only letters/digits/underscores/hyphens (CodeBuild naming rule)."
+  }
+}
+
+variable "build_image" {
+  description = "Container image the build runs inside. Defaults to AWS's standard managed image (`aws/codebuild/standard:7.0`, Ubuntu 22.04 with the standard runtime matrix preinstalled). For private ECR images use `<account>.dkr.ecr.<region>.amazonaws.com/<repo>:<tag>` — the preset's service role grants ECR pull permissions."
+  type        = string
+  default     = "aws/codebuild/standard:7.0"
+
+  validation {
+    condition     = length(trimspace(var.build_image)) > 0
+    error_message = "build_image must be a non-empty string."
+  }
+}
+
+variable "compute_type" {
+  description = "CodeBuild compute class. Determines vCPU / memory / disk for each build container. AWS accepts BUILD_GENERAL1_SMALL (3 GB RAM, 2 vCPU), MEDIUM (7 GB / 4 vCPU), LARGE (15 GB / 8 vCPU), or 2XLARGE (145 GB / 72 vCPU). https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html"
+  type        = string
+  default     = "BUILD_GENERAL1_SMALL"
+
+  validation {
+    condition     = contains(["BUILD_GENERAL1_SMALL", "BUILD_GENERAL1_MEDIUM", "BUILD_GENERAL1_LARGE", "BUILD_GENERAL1_2XLARGE"], var.compute_type)
+    error_message = "compute_type must be one of: BUILD_GENERAL1_SMALL, BUILD_GENERAL1_MEDIUM, BUILD_GENERAL1_LARGE, BUILD_GENERAL1_2XLARGE."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Source
+# -----------------------------------------------------------------------------
+
+variable "source_type" {
+  description = "CodeBuild source provider. CODECOMMIT pulls from AWS CodeCommit, GITHUB from a public/private GitHub repo (private repos need an `aws_codebuild_source_credential` set up out-of-stack), S3 from a versioned object, and NO_SOURCE runs a buildspec-only build with no checkout. https://docs.aws.amazon.com/codebuild/latest/APIReference/API_ProjectSource.html"
+  type        = string
+  default     = "GITHUB"
+
+  validation {
+    condition     = contains(["CODECOMMIT", "GITHUB", "S3", "NO_SOURCE"], var.source_type)
+    error_message = "source_type must be one of: CODECOMMIT, GITHUB, S3, NO_SOURCE."
+  }
+}
+
+variable "source_location" {
+  description = "Source location for `source_type`. For GITHUB the HTTPS clone URL (e.g. `https://github.com/owner/repo.git`); for CODECOMMIT the repository HTTPS URL; for S3 the `<bucket>/<key>` path to a zipped source archive. Ignored (and the preset sets it to null) when source_type = NO_SOURCE — provide an inline `buildspec` instead. Empty default keeps the variable optional so a NO_SOURCE single-module preview composes cleanly; CodeBuild's own apply-time validator rejects an empty location for any other source_type."
+  type        = string
+  default     = ""
+}
+
+variable "buildspec" {
+  description = "Inline buildspec.yml contents OR a relative path to a buildspec file inside the source. Null defers to a `buildspec.yml` at the source root (CodeBuild's default behaviour). For NO_SOURCE builds an inline string is the only option since there's no source tree to read from."
+  type        = string
+  default     = null
+}
+
+# -----------------------------------------------------------------------------
+# Artifacts
+# -----------------------------------------------------------------------------
+
+variable "artifacts_type" {
+  description = "Where CodeBuild publishes build artifacts. NO_ARTIFACTS skips publication (the default for test-only or deploy-via-pipeline builds), S3 uploads to a bucket the caller owns, and CODEPIPELINE hands the artifact back to an upstream CodePipeline stage. https://docs.aws.amazon.com/codebuild/latest/APIReference/API_ProjectArtifacts.html"
+  type        = string
+  default     = "NO_ARTIFACTS"
+
+  validation {
+    condition     = contains(["NO_ARTIFACTS", "S3", "CODEPIPELINE"], var.artifacts_type)
+    error_message = "artifacts_type must be one of: NO_ARTIFACTS, S3, CODEPIPELINE."
+  }
+}
+
+variable "artifacts_location" {
+  description = "Bucket name (without leading s3:// or trailing slash) when `artifacts_type = S3`. Ignored otherwise (the preset sets it to null for NO_ARTIFACTS / CODEPIPELINE). The caller owns the bucket — the preset does NOT provision it. Empty default keeps the variable optional for the NO_ARTIFACTS / CODEPIPELINE common cases; CodeBuild's own apply-time validator rejects an empty location when artifacts_type = S3."
+  type        = string
+  default     = ""
+}
+
+# -----------------------------------------------------------------------------
+# Optional S3 logs bucket
+# -----------------------------------------------------------------------------
+
+variable "enable_s3_logs" {
+  description = "Whether to provision a project-scoped S3 bucket for build logs in addition to the always-on CloudWatch Logs stream. When true, the preset creates the bucket with versioning + AES256 encryption + public-access block, grants the service role read/write to it, and wires `logs_config.s3_logs.location` to `<bucket>/build-logs/`."
+  type        = bool
+  default     = false
+}
+
+# -----------------------------------------------------------------------------
+# Optional VPC config
+#
+# vpc_id + subnet_ids are normally wired by the composer's DefaultWiring
+# from module.aws_vpc when KeyAWSVPC is selected. They're consumed only
+# when subnet_ids is non-empty (the preset gates the vpc_config block on
+# `length(var.subnet_ids) > 0`), so leaving them empty on a
+# public-network build is fine. security_group_ids is caller-supplied —
+# the preset doesn't create one; callers can reuse a VPC SG or
+# provision one out-of-stack.
+# -----------------------------------------------------------------------------
+
+variable "vpc_id" {
+  description = "VPC ID for the CodeBuild project's VPC config. Only consulted when subnet_ids is non-empty (the preset gates the vpc_config block on subnet_ids length). Composer wires this from `module.aws_vpc.vpc_id` automatically when KeyAWSVPC is selected (which is the ImplicitDependencies default for KeyAWSCodeBuild)."
+  type        = string
+  default     = ""
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs the CodeBuild project's build ENIs land in. Non-empty turns the project's vpc_config block on (private builds with access to RDS / ElastiCache / internal endpoints); empty leaves it off (builds run in CodeBuild's public network plane). Use private subnets for actual private build access. Composer wires this from `module.aws_vpc.private_subnet_ids` automatically when KeyAWSVPC is selected."
+  type        = list(string)
+  default     = []
+}
+
+variable "security_group_ids" {
+  description = "Security group IDs attached to the build ENIs. Required by AWS provider when subnet_ids is non-empty (the vpc_config block needs at least one SG). The preset does NOT provision an SG — callers reuse a VPC default SG or create one out-of-stack for egress rules."
+  type        = list(string)
+  default     = []
+}

--- a/pkg/composer/codebuild_aws_wiring_test.go
+++ b/pkg/composer/codebuild_aws_wiring_test.go
@@ -1,0 +1,352 @@
+package composer
+
+// codebuild_aws_wiring_test.go covers the issue #619 composer wiring
+// for the aws/codebuild preset (AWS analog of gcp/cloud_build for
+// managed CI/build runners):
+//
+//   - ComponentKey + PresetKeyMap + ModulePath + AllComponentKeys +
+//     ComposeOrder registry entries are exercised by
+//     TestAllComponentKeysCoversPresetKeyMap and
+//     TestMapperKeysSubsetOfModuleVariables (both in sibling files).
+//   - Default mapper provides every required variable — exercised by
+//     TestEveryRequiredVariableIsMappedOrWired.
+//
+// The tests below pin:
+//   - Forward wiring: selecting KeyAWSCodeBuild causes the composer to
+//     emit `module "aws_codebuild"` in the composed root, and threads
+//     `module.aws_vpc.vpc_id` / private subnets into the module block.
+//   - Mapper default: caller-empty cfg.AWSCodeBuild emits no overrides
+//     (the preset's variables.tf defaults must win).
+//   - Mapper caller-supplied: cfg.AWSCodeBuild fields flow through to
+//     the namespaced module variables.
+//   - Mapper partial-config: only fields the caller actually populated
+//     are emitted.
+//   - Mapper empty-strings-ignored: whitespace-only scalar fields are
+//     treated as not-set.
+//   - End-to-end ComposeStack with AWS + KeyAWSCodeBuild succeeds.
+//   - ComponentSelected + AWSIAMActions coverage.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// requireTfvarAssignment / requireNoTfvarAssignment are shared with
+// cloud_deploy_gcp_wiring_test.go + apprunner_aws_wiring_test.go +
+// sagemaker_aws_wiring_test.go.
+
+// -----------------------------------------------------------------------------
+// Mapper tests
+// -----------------------------------------------------------------------------
+
+// TestMapper_AWSCodeBuild_DefaultConfig pins the no-config path. When
+// cfg.AWSCodeBuild is nil the mapper MUST emit no CodeBuild-specific
+// tfvars — the preset's variables.tf defaults
+// (BUILD_GENERAL1_SMALL / aws/codebuild/standard:7.0 / GITHUB source /
+// NO_ARTIFACTS / no S3 logs / no VPC config) are the source of truth.
+func TestMapper_AWSCodeBuild_DefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSCodeBuild, &Components{}, &Config{}, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	// The mapper should NOT emit any of the optional CodeBuild fields
+	// when the caller hasn't set them. The preset's variables.tf default
+	// is the source of truth for every unset key.
+	for _, k := range []string{
+		"codebuild_project_name", "build_image", "compute_type",
+		"source_type", "source_location", "buildspec",
+		"artifacts_type", "artifacts_location",
+		"enable_s3_logs",
+		"vpc_id", "subnet_ids", "security_group_ids",
+	} {
+		_, has := vals[k]
+		require.Falsef(t, has,
+			"mapper must NOT emit %q when caller left cfg.AWSCodeBuild nil — module variables.tf default must win",
+			k)
+	}
+}
+
+func TestMapper_AWSCodeBuild_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	enableS3 := true
+
+	cfg := &Config{
+		AWSCodeBuild: &AWSCodeBuildConfig{
+			ProjectName:       "ci",
+			BuildImage:        "123456789012.dkr.ecr.us-east-1.amazonaws.com/myimage:latest",
+			ComputeType:       "BUILD_GENERAL1_LARGE",
+			SourceType:        "CODECOMMIT",
+			SourceLocation:    "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/myrepo",
+			Buildspec:         "version: 0.2",
+			ArtifactsType:     "S3",
+			ArtifactsLocation: "my-artifacts-bucket",
+			EnableS3Logs:      &enableS3,
+			VPCID:             "vpc-real",
+			SubnetIDs:         []string{"subnet-a", "subnet-b"},
+			SecurityGroupIDs:  []string{"sg-real"},
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSCodeBuild, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	require.Equal(t, "ci", vals["codebuild_project_name"])
+	require.Equal(t, "123456789012.dkr.ecr.us-east-1.amazonaws.com/myimage:latest", vals["build_image"])
+	require.Equal(t, "BUILD_GENERAL1_LARGE", vals["compute_type"])
+	require.Equal(t, "CODECOMMIT", vals["source_type"])
+	require.Equal(t, "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/myrepo", vals["source_location"])
+	require.Equal(t, "version: 0.2", vals["buildspec"])
+	require.Equal(t, "S3", vals["artifacts_type"])
+	require.Equal(t, "my-artifacts-bucket", vals["artifacts_location"])
+	require.Equal(t, true, vals["enable_s3_logs"])
+	require.Equal(t, "vpc-real", vals["vpc_id"])
+	require.Equal(t, []any{"subnet-a", "subnet-b"}, vals["subnet_ids"])
+	require.Equal(t, []any{"sg-real"}, vals["security_group_ids"])
+}
+
+// TestMapper_AWSCodeBuild_PartialConfig confirms that when only a
+// subset of fields is set the mapper emits only those fields — the
+// preset's variables.tf defaults must apply to the rest. Catches a
+// class of bug where the mapper would unconditionally emit empty
+// slices / false bools that override module defaults.
+func TestMapper_AWSCodeBuild_PartialConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSCodeBuild: &AWSCodeBuildConfig{
+			ComputeType: "BUILD_GENERAL1_LARGE",
+			BuildImage:  "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
+			// Every other field intentionally left at zero values.
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSCodeBuild, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	require.Equal(t, "BUILD_GENERAL1_LARGE", vals["compute_type"])
+	require.Equal(t, "aws/codebuild/amazonlinux2-x86_64-standard:5.0", vals["build_image"])
+
+	for _, k := range []string{
+		"codebuild_project_name", "source_type", "source_location",
+		"buildspec", "artifacts_type", "artifacts_location",
+		"enable_s3_logs",
+		"vpc_id", "subnet_ids", "security_group_ids",
+	} {
+		_, has := vals[k]
+		require.Falsef(t, has,
+			"mapper must NOT emit %q when caller left it zero — module default must win",
+			k)
+	}
+}
+
+// TestMapper_AWSCodeBuild_EmptyStringsIgnored pins the trimspace
+// gates. Whitespace-only string fields (e.g. an unset form field that
+// arrived as "   ") must be treated as not-set so the preset defaults
+// kick in instead of being overridden with garbage. Sibling pattern of
+// TestMapper_AWSAppRunner_EmptyStringsIgnored.
+func TestMapper_AWSCodeBuild_EmptyStringsIgnored(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		AWSCodeBuild: &AWSCodeBuildConfig{
+			ProjectName:       "   ",
+			BuildImage:        "  ",
+			ComputeType:       "",
+			SourceType:        " ",
+			SourceLocation:    "  ",
+			Buildspec:         "   ",
+			ArtifactsType:     "",
+			ArtifactsLocation: " ",
+			VPCID:             "  ",
+			SubnetIDs:         []string{"", "  ", "subnet-real"},
+			SecurityGroupIDs:  []string{"  ", "sg-real", ""},
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSCodeBuild, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	// Slices: whitespace/empty entries dropped, real ones kept.
+	require.Equal(t, []any{"subnet-real"}, vals["subnet_ids"])
+	require.Equal(t, []any{"sg-real"}, vals["security_group_ids"])
+
+	for _, k := range []string{
+		"codebuild_project_name", "build_image", "compute_type",
+		"source_type", "source_location", "buildspec",
+		"artifacts_type", "artifacts_location",
+		"vpc_id",
+	} {
+		_, has := vals[k]
+		require.Falsef(t, has,
+			"mapper must NOT emit %q when caller supplied a whitespace-only string",
+			k)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// End-to-end ComposeStack tests
+// -----------------------------------------------------------------------------
+
+func TestComposeStack_AWSCodeBuild_Forward(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSCodeBuild},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{Region: "us-east-1"},
+		Project:      "test",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	root, ok := out["/main.tf"]
+	require.True(t, ok, "composed root must contain main.tf")
+	rootStr := string(root)
+
+	require.Contains(t, rootStr, `module "aws_codebuild"`,
+		"composed root must declare module aws_codebuild when KeyAWSCodeBuild is selected")
+	// AWS modules use the legacy `modules/<x>` ModulePath (not `aws/<x>`)
+	// — kept for backwards compatibility with the in-account deployer
+	// service that already resolves that path.
+	require.Contains(t, rootStr, `"./modules/codebuild"`,
+		"module source path must resolve to modules/codebuild per ModulePath")
+
+	// KeyAWSCodeBuild → KeyAWSVPC implicit dep: aws_vpc must also appear.
+	require.Contains(t, rootStr, `module "aws_vpc"`,
+		"composer must auto-add KeyAWSVPC when KeyAWSCodeBuild is selected (ImplicitDependencies)")
+
+	// Wiring assertion: aws_codebuild's vpc_id argument must literally
+	// reference module.aws_vpc.vpc_id. Without this, the previous check
+	// only pins that aws_vpc is emitted — it doesn't pin that the value
+	// actually flows into aws_codebuild.
+	require.Contains(t, rootStr, `module.aws_vpc.vpc_id`,
+		"DefaultWiring must thread module.aws_vpc.vpc_id into the aws_codebuild module block")
+	// Symmetric subnet wiring — DefaultWiring threads private subnets on
+	// non-public VPCs. The default Components shape (no AWSVPC string set)
+	// is treated as non-public by isPublicVPC, so the wiring code falls
+	// into the private-subnet branch.
+	require.Contains(t, rootStr, `module.aws_vpc.private_subnet_ids`,
+		"DefaultWiring must thread module.aws_vpc.private_subnet_ids into aws_codebuild.subnet_ids (symmetric with the vpc_id wiring above)")
+
+	// Confirm the tfvars file landed and carries the always-required
+	// project / region mappings.
+	tfvars, ok := out["/aws_codebuild.auto.tfvars"]
+	require.True(t, ok, "expected aws_codebuild.auto.tfvars")
+	tfvarsStr := string(tfvars)
+	requireTfvarAssignment(t, tfvarsStr, "aws_codebuild_project", `"test"`,
+		"composer must emit aws_codebuild_project tfvar from the always-required project mapping")
+	requireTfvarAssignment(t, tfvarsStr, "aws_codebuild_region", `"us-east-1"`,
+		"composer must emit aws_codebuild_region tfvar from the always-required region mapping")
+}
+
+func TestComposeStack_AWSCodeBuild_CallerSuppliedConfig(t *testing.T) {
+	t.Parallel()
+
+	enableS3 := true
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSCodeBuild},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg: &Config{
+			Region: "us-east-1",
+			AWSCodeBuild: &AWSCodeBuildConfig{
+				ProjectName:    "ci",
+				BuildImage:     "aws/codebuild/standard:7.0",
+				ComputeType:    "BUILD_GENERAL1_MEDIUM",
+				SourceType:     "GITHUB",
+				SourceLocation: "https://github.com/example/repo.git",
+				EnableS3Logs:   &enableS3,
+			},
+		},
+		Project: "test",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err)
+
+	tfvars, ok := out["/aws_codebuild.auto.tfvars"]
+	require.True(t, ok)
+	tfvarsStr := string(tfvars)
+
+	requireTfvarAssignment(t, tfvarsStr, "aws_codebuild_codebuild_project_name", `"ci"`,
+		"caller-supplied ProjectName must flow through to the namespaced tfvar")
+	requireTfvarAssignment(t, tfvarsStr, "aws_codebuild_build_image", `"aws/codebuild/standard:7.0"`,
+		"caller-supplied BuildImage must flow through to the namespaced tfvar")
+	requireTfvarAssignment(t, tfvarsStr, "aws_codebuild_compute_type", `"BUILD_GENERAL1_MEDIUM"`,
+		"caller-supplied ComputeType must flow through to the namespaced tfvar")
+	requireTfvarAssignment(t, tfvarsStr, "aws_codebuild_source_type", `"GITHUB"`,
+		"caller-supplied SourceType must flow through to the namespaced tfvar")
+	requireTfvarAssignment(t, tfvarsStr, "aws_codebuild_source_location", `"https://github.com/example/repo.git"`,
+		"caller-supplied SourceLocation must flow through to the namespaced tfvar")
+	requireTfvarAssignment(t, tfvarsStr, "aws_codebuild_enable_s3_logs", `true`,
+		"caller-supplied EnableS3Logs must flow through to the namespaced tfvar")
+
+	// Partial-config contract: the unset Buildspec field must NOT
+	// appear in the tfvars (leaving Buildspec "" means the preset's
+	// variables.tf default of null wins). Same robust-anchored check
+	// as the apprunner port assertion.
+	requireNoTfvarAssignment(t, tfvarsStr, "aws_codebuild_buildspec",
+		"unset Buildspec must NOT be emitted in tfvars (the preset's null default must win)")
+	requireNoTfvarAssignment(t, tfvarsStr, "aws_codebuild_artifacts_type",
+		"unset ArtifactsType must NOT be emitted in tfvars (the preset's NO_ARTIFACTS default must win)")
+}
+
+// -----------------------------------------------------------------------------
+// Coherence / IAM permission coverage
+// -----------------------------------------------------------------------------
+
+// TestComponentSelected_AWSCodeBuild pins the coherence.go entry —
+// without it ComponentSelected returns false for KeyAWSCodeBuild and
+// the orphan-strip pass silently clears cfg.AWSCodeBuild even when
+// comps.AWSCodeBuild = &true.
+func TestComponentSelected_AWSCodeBuild(t *testing.T) {
+	t.Parallel()
+
+	tr := true
+	c := &Components{AWSCodeBuild: &tr}
+	require.True(t, ComponentSelected(c, KeyAWSCodeBuild),
+		"ComponentSelected must return true when comps.AWSCodeBuild=&true")
+
+	fa := false
+	c2 := &Components{AWSCodeBuild: &fa}
+	require.False(t, ComponentSelected(c2, KeyAWSCodeBuild),
+		"ComponentSelected must return false when comps.AWSCodeBuild=&false (explicit deselect)")
+
+	c3 := &Components{}
+	require.False(t, ComponentSelected(c3, KeyAWSCodeBuild),
+		"ComponentSelected must return false when comps.AWSCodeBuild is nil")
+}
+
+// TestAWSIAMPermissions_CodeBuildCovered pins the iam_actions.go
+// entry. Without it RequiredAWSIAMActions silently omits the
+// CodeBuild / IAM / S3 / EC2 permissions a real deploy needs —
+// surfacing as a 403 at apply time instead of at
+// SimulatePrincipalPolicy pre-deploy check (ui-core #192).
+func TestAWSIAMPermissions_CodeBuildCovered(t *testing.T) {
+	t.Parallel()
+
+	actions, ok := AWSIAMActions[KeyAWSCodeBuild]
+	require.True(t, ok, "AWSIAMActions must have an entry for KeyAWSCodeBuild")
+	require.NotEmpty(t, actions, "AWSIAMActions[KeyAWSCodeBuild] must list at least one action — project create + IAM role create + optional S3/VPC perms all require explicit perms beyond the always-required set")
+
+	required := RequiredAWSIAMActions([]ComponentKey{KeyAWSCodeBuild})
+	require.Contains(t, required, "codebuild:CreateProject",
+		"CodeBuild project create permission must be in the required set")
+	require.Contains(t, required, "iam:PassRole",
+		"PassRole permission must be in the required set (the CodeBuild control plane needs to assume the service role we create)")
+	require.Contains(t, required, "iam:PutRolePolicy",
+		"PutRolePolicy permission must be in the required set (the preset attaches inline policies to the service role)")
+	require.Contains(t, required, "logs:CreateLogGroup",
+		"CloudWatch Logs CreateLogGroup permission must be in the required set (every build emits a log stream)")
+	require.Contains(t, required, "s3:CreateBucket",
+		"S3 CreateBucket permission must be in the required set (covers the optional enable_s3_logs path)")
+	require.Contains(t, required, "ec2:CreateNetworkInterface",
+		"EC2 CreateNetworkInterface permission must be in the required set (covers the optional VPC config path)")
+}

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -95,6 +95,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.AWSCognito)
 	case KeyAWSGitHubActions:
 		return boolPtrTrue(c.AWSGitHubActions)
+	case KeyAWSCodeBuild:
+		return boolPtrTrue(c.AWSCodeBuild)
 	case KeyAWSCodePipeline:
 		return boolPtrTrue(c.AWSCodePipeline)
 	case KeyAWSRoute53:
@@ -295,7 +297,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyAWSCloudfront, KeyAWSRDS, KeyAWSElastiCache,
 		KeyAWSS3, KeyAWSDynamoDB, KeyAWSSQS, KeyAWSMSK,
 		KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
-		KeyAWSCognito, KeyAWSLambda, KeyAWSAppRunner, KeyAWSSageMaker, KeyAWSAPIGateway,
+		KeyAWSCognito, KeyAWSLambda, KeyAWSAppRunner, KeyAWSSageMaker, KeyAWSCodeBuild, KeyAWSAPIGateway,
 		KeyAWSKMS, KeyAWSSecretsManager, KeyAWSOpenSearch,
 		KeyAWSBedrock, KeyAWSBackups, KeyAWSRoute53,
 		KeyAWSACM,

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -63,6 +63,7 @@ const (
 	KeyAWSCognito              ComponentKey = "aws_cognito"
 	KeyAWSBackups              ComponentKey = "aws_backups"
 	KeyAWSGitHubActions        ComponentKey = "aws_github_actions"
+	KeyAWSCodeBuild            ComponentKey = "aws_codebuild"
 	KeyAWSCodePipeline         ComponentKey = "aws_codepipeline"
 	KeyAWSRoute53              ComponentKey = "aws_route53"
 	KeyAWSACM                  ComponentKey = "aws_acm"
@@ -166,6 +167,11 @@ var ComposeOrder = []ComponentKey{
 	KeyAWSSQS,
 	KeyGCPPubSub,
 	KeyGCPCloudBuild,
+	// CodeBuild standalone preset (#619, deferred row 3 of #598). Peer
+	// of gcp/cloud_build; no other key wires off of it today (CodePipeline
+	// integration is a future PR). Placed alongside the GCP analog +
+	// CodePipeline sibling for reviewability; ordering is not load-bearing.
+	KeyAWSCodeBuild,
 	KeyAWSGitHubActions,
 	KeyAWSCodePipeline,
 	// GCP GitHub Actions WIF preset (#597 row 1). Independent of any
@@ -219,6 +225,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyAWSBackups:              "modules/backups",
 	KeyAWSBastion:              "modules/bastion",
 	KeyAWSGitHubActions:        "modules/githubactions",
+	KeyAWSCodeBuild:            "modules/codebuild",
 	KeyAWSCodePipeline:         "modules/codepipeline",
 	KeyAWSRoute53:              "modules/route53",
 	KeyAWSACM:                  "modules/acm",
@@ -280,6 +287,13 @@ var ImplicitDependencies = map[ComponentKey][]ComponentKey{
 	// (gcp/cloud_run also declares KeyGCPVPC) and ensures the wiring is
 	// satisfiable when the caller flips on private egress later.
 	KeyAWSAppRunner: {KeyAWSVPC},
+	// CodeBuild (#619). Public-network builds do not strictly require
+	// a VPC, but the preset's optional vpc_config path (subnet_ids
+	// non-empty) feeds vpc_id + subnet_ids from module.aws_vpc. Forcing
+	// the implicit dep mirrors the GCP analog (gcp/cloud_build also
+	// declares KeyGCPVPC) and keeps the wiring satisfiable when the
+	// caller flips on private builds later.
+	KeyAWSCodeBuild:    {KeyAWSVPC},
 	KeyAWSEKSNodeGroup: {KeyAWSEKS, KeyAWSVPC},
 	KeyAWSEC2:          {KeyAWSVPC},
 	KeyGCPCompute:      {KeyGCPVPC},
@@ -413,6 +427,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyAWSCognito:              "cognito",
 	KeyAWSBackups:              "backups",
 	KeyAWSGitHubActions:        "githubactions",
+	KeyAWSCodeBuild:            "codebuild",
 	KeyAWSCodePipeline:         "codepipeline",
 	KeyAWSRoute53:              "route53",
 	KeyAWSACM:                  "acm",
@@ -511,6 +526,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyAWSCloudWatchLogs,
 	KeyAWSCloudWatchMonitoring,
 	KeyAWSCloudfront,
+	KeyAWSCodeBuild,
 	KeyAWSCodePipeline,
 	KeyAWSCognito,
 	KeyAWSDynamoDB,
@@ -722,6 +738,28 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		// still works — egress NAT is provided by App Runner's own
 		// network plane, the customer subnets are only the ENI placement
 		// for cross-VPC reachability).
+		if hasVPC {
+			vpc := vpcRef(selected)
+			wi.RawHCL["vpc_id"] = vpc + ".vpc_id"
+			if isPublicVPC(comps) {
+				wi.RawHCL["subnet_ids"] = vpc + ".public_subnet_ids"
+			} else {
+				wi.RawHCL["subnet_ids"] = vpc + ".private_subnet_ids"
+			}
+			wi.Names = append(wi.Names, "vpc_id", "subnet_ids")
+		}
+
+	case KeyAWSCodeBuild:
+		// CodeBuild VPC-config path consumes vpc_id + subnet_ids
+		// (#619). The preset gates vpc_config creation on a non-empty
+		// subnet_ids list, but threading the wiring unconditionally is
+		// fine — when subnet_ids is empty (e.g. on a single-module
+		// preview) the preset simply leaves the vpc_config dynamic
+		// block off. Prefer private subnets when the upstream VPC is
+		// non-public so the build ENIs land in the right tier; fall
+		// back to public subnets on Public-VPC stacks so callers still
+		// get a non-empty list when they later opt-in by populating
+		// subnet_ids out-of-stack.
 		if hasVPC {
 			vpc := vpcRef(selected)
 			wi.RawHCL["vpc_id"] = vpc + ".vpc_id"

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -31,13 +31,13 @@ var AlwaysRequiredAWSIAMActions = []string{
 // drift-guard test (TestAWSIAMActions_CoverAllAWSKeys) fails the package
 // build otherwise. nil values are permitted for forward-compat.
 var AWSIAMActions = map[ComponentKey][]string{
-	KeyAWSVPC:                  {"ec2:AllocateAddress", "ec2:CreateInternetGateway", "ec2:CreateNatGateway", "ec2:CreateRouteTable", "ec2:CreateSubnet", "ec2:CreateVpc"},
-	KeyAWSBastion:              {"ec2:RunInstances"},
-	KeyAWSEC2:                  {"ec2:RunInstances"},
-	KeyAWSEKS:                  {"eks:CreateCluster", "eks:CreateNodegroup"},
-	KeyAWSEKSNodeGroup:         {"eks:CreateNodegroup"},
-	KeyAWSECS:                  {"ecs:CreateCluster", "ecs:CreateService"},
-	KeyAWSLambda:               {"lambda:CreateFunction"},
+	KeyAWSVPC:          {"ec2:AllocateAddress", "ec2:CreateInternetGateway", "ec2:CreateNatGateway", "ec2:CreateRouteTable", "ec2:CreateSubnet", "ec2:CreateVpc"},
+	KeyAWSBastion:      {"ec2:RunInstances"},
+	KeyAWSEC2:          {"ec2:RunInstances"},
+	KeyAWSEKS:          {"eks:CreateCluster", "eks:CreateNodegroup"},
+	KeyAWSEKSNodeGroup: {"eks:CreateNodegroup"},
+	KeyAWSECS:          {"ecs:CreateCluster", "ecs:CreateService"},
+	KeyAWSLambda:       {"lambda:CreateFunction"},
 	// App Runner (#598 row 2). Service + autoscaling-config-version
 	// CREATE + the access role (only when image_repository_type = ECR)
 	// + the instance role + optional VPC connector. PassRole is needed
@@ -90,7 +90,26 @@ var AWSIAMActions = map[ComponentKey][]string{
 	KeyAWSCognito:              {"cognito-idp:CreateUserPool"},
 	KeyAWSBackups:              {"backup:CreateBackupPlan", "backup:CreateBackupVault"},
 	KeyAWSGitHubActions:        {"iam:CreateOpenIDConnectProvider"},
-	KeyAWSCodePipeline:         {"codepipeline:CreatePipeline"},
+	// CodeBuild (#619). Project CREATE + the inline service-role
+	// policies the preset attaches (logs:CreateLogGroup for the build's
+	// CloudWatch Logs group, optional S3 bucket setup when enable_s3_logs
+	// is on, EC2 ENI lifecycle perms when the optional VPC config kicks
+	// in). PassRole is needed so the CodeBuild control plane can assume
+	// the service role we create.
+	KeyAWSCodeBuild: {
+		"codebuild:CreateProject",
+		"ec2:CreateNetworkInterface",
+		"iam:AttachRolePolicy",
+		"iam:CreateRole",
+		"iam:PassRole",
+		"iam:PutRolePolicy",
+		"logs:CreateLogGroup",
+		"s3:CreateBucket",
+		"s3:PutBucketPublicAccessBlock",
+		"s3:PutBucketVersioning",
+		"s3:PutEncryptionConfiguration",
+	},
+	KeyAWSCodePipeline: {"codepipeline:CreatePipeline"},
 	// route53:CreateHostedZone covers the create_zone=true path; the data-
 	// lookup path (create_zone=false) needs only route53:GetHostedZone, which
 	// is implied by the create capability. Record-set CRUD is covered by

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1232,6 +1232,76 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+	case KeyAWSCodeBuild:
+		// CodeBuild (#619). vpc_id + subnet_ids are wired automatically
+		// by DefaultWiring when KeyAWSVPC is selected, but the preset
+		// only consumes them when subnet_ids is non-empty. For single-
+		// module previews (no VPC in the selection), the preset's own
+		// variables.tf defaults (empty string / empty list) leave the
+		// vpc_config block off — so we don't need preview-safe stubs
+		// like SageMaker does. The mapper emits overrides ONLY for
+		// fields the caller actually populated, following the partial-
+		// config pattern.
+		if cfg != nil && cfg.AWSCodeBuild != nil {
+			cb := cfg.AWSCodeBuild
+			if strings.TrimSpace(cb.ProjectName) != "" {
+				vals["codebuild_project_name"] = strings.TrimSpace(cb.ProjectName)
+			}
+			if strings.TrimSpace(cb.BuildImage) != "" {
+				vals["build_image"] = strings.TrimSpace(cb.BuildImage)
+			}
+			if strings.TrimSpace(cb.ComputeType) != "" {
+				vals["compute_type"] = strings.TrimSpace(cb.ComputeType)
+			}
+			if strings.TrimSpace(cb.SourceType) != "" {
+				vals["source_type"] = strings.TrimSpace(cb.SourceType)
+			}
+			if strings.TrimSpace(cb.SourceLocation) != "" {
+				vals["source_location"] = strings.TrimSpace(cb.SourceLocation)
+			}
+			if strings.TrimSpace(cb.Buildspec) != "" {
+				vals["buildspec"] = strings.TrimSpace(cb.Buildspec)
+			}
+			if strings.TrimSpace(cb.ArtifactsType) != "" {
+				vals["artifacts_type"] = strings.TrimSpace(cb.ArtifactsType)
+			}
+			if strings.TrimSpace(cb.ArtifactsLocation) != "" {
+				vals["artifacts_location"] = strings.TrimSpace(cb.ArtifactsLocation)
+			}
+			if cb.EnableS3Logs != nil {
+				vals["enable_s3_logs"] = *cb.EnableS3Logs
+			}
+			if strings.TrimSpace(cb.VPCID) != "" {
+				vals["vpc_id"] = strings.TrimSpace(cb.VPCID)
+			}
+			if len(cb.SubnetIDs) > 0 {
+				ids := make([]any, 0, len(cb.SubnetIDs))
+				for _, id := range cb.SubnetIDs {
+					t := strings.TrimSpace(id)
+					if t == "" {
+						continue
+					}
+					ids = append(ids, t)
+				}
+				if len(ids) > 0 {
+					vals["subnet_ids"] = ids
+				}
+			}
+			if len(cb.SecurityGroupIDs) > 0 {
+				ids := make([]any, 0, len(cb.SecurityGroupIDs))
+				for _, id := range cb.SecurityGroupIDs {
+					t := strings.TrimSpace(id)
+					if t == "" {
+						continue
+					}
+					ids = append(ids, t)
+				}
+				if len(ids) > 0 {
+					vals["security_group_ids"] = ids
+				}
+			}
+		}
+
 	case KeyGCPGitHubActions:
 		// GCP GitHub Actions WIF (#597 row 1). github_repository is required
 		// by the preset (no default); supply a preview-safe placeholder

--- a/pkg/composer/presets.go
+++ b/pkg/composer/presets.go
@@ -85,7 +85,7 @@ func (c *Client) ListAvailableComponentKeys() ([]string, error) {
 		KeyAWSALB, KeyAWSCloudfront, KeyAWSWAF, KeyAWSAPIGateway, KeyAWSRDS,
 		KeyAWSElastiCache, KeyAWSDynamoDB, KeyAWSS3, KeyAWSKMS, KeyAWSSecretsManager,
 		KeyAWSOpenSearch, KeyAWSBedrock, KeyAWSSQS, KeyAWSMSK, KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
-		KeyAWSGrafana, KeyAWSCognito, KeyAWSBackups, KeyAWSGitHubActions, KeyAWSCodePipeline,
+		KeyAWSGrafana, KeyAWSCognito, KeyAWSBackups, KeyAWSGitHubActions, KeyAWSCodeBuild, KeyAWSCodePipeline,
 
 		// GCP keys
 		KeyGCPVPC, KeyGCPBastion, KeyGCPCompute, KeyGCPGKE, KeyGCPCloudRun,

--- a/pkg/composer/pricing.go
+++ b/pkg/composer/pricing.go
@@ -121,6 +121,7 @@ type PricingData struct {
 		AWSGrafana              *PricingItem    `json:"aws_grafana,omitempty"`
 		AWSCognito              *PricingItem    `json:"aws_cognito,omitempty"`
 		AWSGitHubActions        *PricingItem    `json:"aws_github_actions,omitempty"`
+		AWSCodeBuild            *PricingItem    `json:"aws_codebuild,omitempty"`
 		AWSCodePipeline         *PricingItem    `json:"aws_codepipeline,omitempty"`
 		AWSRoute53              *PricingItem    `json:"aws_route53,omitempty"`
 		AWSACM                  *PricingItem    `json:"aws_acm,omitempty"`
@@ -233,6 +234,7 @@ func (p *PricingData) Normalize() {
 		c.AWSGrafana = nil
 		c.AWSCognito = nil
 		c.AWSGitHubActions = nil
+		c.AWSCodeBuild = nil
 		c.AWSCodePipeline = nil
 		c.AWSRoute53 = nil
 		c.AWSACM = nil

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -44,6 +44,7 @@ type Components struct {
 	AWSGrafana              *bool  `json:"aws_grafana,omitempty"`
 	AWSCognito              *bool  `json:"aws_cognito,omitempty"`
 	AWSGitHubActions        *bool  `json:"aws_github_actions,omitempty"`
+	AWSCodeBuild            *bool  `json:"aws_codebuild,omitempty"`
 	AWSCodePipeline         *bool  `json:"aws_codepipeline,omitempty"`
 	AWSRoute53              *bool  `json:"aws_route53,omitempty"`
 	AWSACM                  *bool  `json:"aws_acm,omitempty"`
@@ -217,6 +218,13 @@ type Config struct {
 	// field additions don't force every test instantiation to be touched
 	// (matches the GCPGitHubActionsConfig pattern set in #597).
 	AWSSageMaker *AWSSageMakerConfig `json:"aws_sagemaker,omitempty"`
+
+	// AWSCodeBuild carries the caller-supplied CodeBuild project config
+	// (#619). Named (not inline) so callers can construct it without
+	// re-typing the anonymous struct shape at every site, and so future
+	// field additions don't force every test instantiation to be touched
+	// (matches the AWSAppRunnerConfig + AWSSageMakerConfig pattern).
+	AWSCodeBuild *AWSCodeBuildConfig `json:"aws_codebuild,omitempty"`
 
 	AWSAPIGateway *struct {
 		DomainName     string `json:"domainName,omitempty"`
@@ -479,25 +487,25 @@ type GCPCloudDeployConfig struct {
 // callers don't usually populate them on this struct unless they need
 // to override the wiring.
 type AWSAppRunnerConfig struct {
-	ServiceName              string            `json:"serviceName,omitempty"`
-	ImageRepositoryURL       string            `json:"imageRepositoryUrl,omitempty"`
-	ImageRepositoryType      string            `json:"imageRepositoryType,omitempty"`
-	Port                     *int              `json:"port,omitempty"`
-	EnvVars                  map[string]string `json:"envVars,omitempty"`
-	CPU                      string            `json:"cpu,omitempty"`
-	Memory                   string            `json:"memory,omitempty"`
-	MinSize                  *int              `json:"minSize,omitempty"`
-	MaxSize                  *int              `json:"maxSize,omitempty"`
-	MaxConcurrency           *int              `json:"maxConcurrency,omitempty"`
-	IsPubliclyAccessible     *bool             `json:"isPubliclyAccessible,omitempty"`
-	AutoDeploymentsEnabled   *bool             `json:"autoDeploymentsEnabled,omitempty"`
-	HealthCheckProtocol      string            `json:"healthCheckProtocol,omitempty"`
-	HealthCheckPath          string            `json:"healthCheckPath,omitempty"`
-	EnableVPCConnector       *bool             `json:"enableVpcConnector,omitempty"`
-	VPCID                    string            `json:"vpcId,omitempty"`
-	SubnetIDs                []string          `json:"subnetIds,omitempty"`
-	CustomDomainName         string            `json:"customDomainName,omitempty"`
-	EnableWWWSubdomain       *bool             `json:"enableWwwSubdomain,omitempty"`
+	ServiceName            string            `json:"serviceName,omitempty"`
+	ImageRepositoryURL     string            `json:"imageRepositoryUrl,omitempty"`
+	ImageRepositoryType    string            `json:"imageRepositoryType,omitempty"`
+	Port                   *int              `json:"port,omitempty"`
+	EnvVars                map[string]string `json:"envVars,omitempty"`
+	CPU                    string            `json:"cpu,omitempty"`
+	Memory                 string            `json:"memory,omitempty"`
+	MinSize                *int              `json:"minSize,omitempty"`
+	MaxSize                *int              `json:"maxSize,omitempty"`
+	MaxConcurrency         *int              `json:"maxConcurrency,omitempty"`
+	IsPubliclyAccessible   *bool             `json:"isPubliclyAccessible,omitempty"`
+	AutoDeploymentsEnabled *bool             `json:"autoDeploymentsEnabled,omitempty"`
+	HealthCheckProtocol    string            `json:"healthCheckProtocol,omitempty"`
+	HealthCheckPath        string            `json:"healthCheckPath,omitempty"`
+	EnableVPCConnector     *bool             `json:"enableVpcConnector,omitempty"`
+	VPCID                  string            `json:"vpcId,omitempty"`
+	SubnetIDs              []string          `json:"subnetIds,omitempty"`
+	CustomDomainName       string            `json:"customDomainName,omitempty"`
+	EnableWWWSubdomain     *bool             `json:"enableWwwSubdomain,omitempty"`
 }
 
 // AWSSageMakerConfig is the caller-facing config for the aws/sagemaker
@@ -519,6 +527,34 @@ type AWSSageMakerConfig struct {
 	WorkspaceBucketForceDestroy *bool    `json:"workspaceBucketForceDestroy,omitempty"`
 	StudioUsers                 []string `json:"studioUsers,omitempty"`
 	SageMakerManagedPolicyARN   string   `json:"sagemakerManagedPolicyArn,omitempty"`
+}
+
+// AWSCodeBuildConfig is the caller-facing config for the aws/codebuild
+// preset (#619). Named (not inline) so callers can construct it
+// without re-typing the anonymous struct shape at every site, and so
+// future field additions don't force every test instantiation to be
+// touched. Mirrors AWSAppRunnerConfig + AWSSageMakerConfig.
+//
+// Field semantics map 1:1 to aws/codebuild/variables.tf. Empty / nil
+// values mean "defer to the module's HCL default" — the mapper only
+// emits a tfvar when the caller supplies a value. VPCID / SubnetIDs are
+// normally wired automatically (DefaultWiring reads module.aws_vpc) so
+// callers don't usually populate them on this struct unless they need
+// to override the wiring. SecurityGroupIDs is always caller-supplied —
+// the preset doesn't create an SG.
+type AWSCodeBuildConfig struct {
+	ProjectName       string   `json:"projectName,omitempty"`
+	BuildImage        string   `json:"buildImage,omitempty"`
+	ComputeType       string   `json:"computeType,omitempty"`
+	SourceType        string   `json:"sourceType,omitempty"`
+	SourceLocation    string   `json:"sourceLocation,omitempty"`
+	Buildspec         string   `json:"buildspec,omitempty"`
+	ArtifactsType     string   `json:"artifactsType,omitempty"`
+	ArtifactsLocation string   `json:"artifactsLocation,omitempty"`
+	EnableS3Logs      *bool    `json:"enableS3Logs,omitempty"`
+	VPCID             string   `json:"vpcId,omitempty"`
+	SubnetIDs         []string `json:"subnetIds,omitempty"`
+	SecurityGroupIDs  []string `json:"securityGroupIds,omitempty"`
 }
 
 // VarEntry holds a module variable name and a value (or nil). RawExpr can be used for expressions.
@@ -597,6 +633,7 @@ func (c *Components) Normalize() {
 		c.AWSGrafana = nil
 		c.AWSCognito = nil
 		c.AWSGitHubActions = nil
+		c.AWSCodeBuild = nil
 		c.AWSCodePipeline = nil
 		c.AWSRoute53 = nil
 		c.AWSACM = nil
@@ -705,6 +742,7 @@ func (c *Config) Normalize() {
 		c.AWSLambda = nil
 		c.AWSAppRunner = nil
 		c.AWSSageMaker = nil
+		c.AWSCodeBuild = nil
 		c.AWSAPIGateway = nil
 		c.AWSKMS = nil
 		c.AWSSecretsManager = nil

--- a/pkg/observability/component_metrics_coverage_test.go
+++ b/pkg/observability/component_metrics_coverage_test.go
@@ -40,7 +40,16 @@ import (
 // All #622 entries cleared. The two by-design omissions
 // (aws_github_actions, gcp_backups) live in metricsNonComponentKeys
 // below with rationale.
-var metricsDeferredKeys = map[composer.ComponentKey]string{}
+var metricsDeferredKeys = map[composer.ComponentKey]string{
+	// CodeBuild (#619). The issue explicitly defers the discovery
+	// inspector — service + actions are not yet registered in
+	// AWSServiceActions, so a ComponentMetricsMapping entry pointing at
+	// codebuild.list-projects would dispatch to an unregistered service
+	// and surface "unsupported service" at runtime instead of the panel.
+	// Backfill alongside the inspector landing (mirrors the #622 backfill
+	// of apprunner + sagemaker after #618 / #620 added their inspectors).
+	composer.KeyAWSCodeBuild: "[#619] discovery inspector deferred; ComponentMetricsMapping entry pending the codebuild.list-projects handler registration alongside the inspector backfill PR",
+}
 
 // metricsNonComponentKeys are AllComponentKeys entries that genuinely
 // do NOT correspond to a panel-renderable resource. Distinct from

--- a/pkg/observability/display.go
+++ b/pkg/observability/display.go
@@ -127,6 +127,8 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "AWS Bastion"
 	case composer.KeyAWSGrafana:
 		return "AWS Grafana"
+	case composer.KeyAWSCodeBuild:
+		return "AWS CodeBuild"
 	case composer.KeyAWSCodePipeline:
 		return "AWS CodePipeline"
 	case composer.KeyAWSBackups:

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -71,6 +71,7 @@ var configExtractorAllowlist = map[string]string{
 
 	"aws_sagemaker": "[no-inspector] SageMaker Studio inspector deferred (#615 explicitly marks discovery inspector as optional/follow-up — domain + execution role are surfaced via name-prefix scoping until per-resource extractors land)",
 	"aws_apprunner": "[no-inspector] App Runner inspector deferred (#598 explicitly marks discovery inspector as optional/follow-up for every parity row — service + autoscaling config + VPC connector are surfaced via name-prefix scoping until per-resource extractors land)",
+	"aws_codebuild": "[no-inspector] CodeBuild inspector deferred (#619 explicitly marks discovery inspector as optional/follow-up — project + service role + optional logs bucket are surfaced via name-prefix scoping until per-resource extractors land)",
 
 	"gcp_backups":      "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
 	"gcp_cloud_deploy": "[no-inspector] Cloud Deploy delivery-pipeline inspector deferred (#613 explicitly marks discovery inspector + extractor as optional/follow-up); ComponentMetricsMapping has no entry yet so the panel falls back to design values until the per-component extractor lands",


### PR DESCRIPTION
## Summary

- New `aws/codebuild/` preset — a single-call entry point for a managed AWS CodeBuild project, mirroring the role `gcp/cloud_build` plays for GCP stacks. Deferred row 3 of the #598 AWS↔GCP parity roll-up.
- Composer wiring (additive, mirrors `aws/apprunner` + `aws/sagemaker` precedent): `KeyAWSCodeBuild` + `AWSCodeBuildConfig` + mapper partial-config + IAM action allowlist + pricing field + observability display-name + `[no-inspector]` allowlist entry.
- Inspector deferred per #619's explicit non-goal; entry added to `metricsDeferredKeys` to surface the gap for backfill alongside the inspector PR (same pattern as `apprunner` / `sagemaker` pre-#622).

## Files

**Greenfield preset:**
- `aws/codebuild/main.tf` — `aws_codebuild_project` + IAM service role with `codebuild.amazonaws.com` trust principal and `aws:SourceAccount` confused-deputy guard + inline base policy (CloudWatch Logs + ECR pull) + count-gated S3 logs bucket with the standard hardening trio (versioning + AES256 + public-access block) + count-gated VPC config dynamic block.
- `aws/codebuild/variables.tf` — standard quartet (`project`/`region`/`environment`/`tags`) + `codebuild_project_name`/`build_image`/`compute_type` (enum) / `source_type` (enum) / `source_location` / `buildspec` / `artifacts_type` (enum) / `artifacts_location` / `enable_s3_logs` / `vpc_id` / `subnet_ids` / `security_group_ids`.
- `aws/codebuild/outputs.tf` — `project_arn`/`project_name`/`service_role_{arn,name}`/`logs_bucket_{name,arn}` + the canonical `tags` output.
- `aws/codebuild/tests/shape.tftest.hcl` — 15 plan-time tests: minimum inputs, optional S3 logs (hardening-trio cardinality), VPC config threading, buildspec/artifacts propagation, positive triangulation companions + rejection-axis negatives for every enum validation (#614 pattern).

**Composer wiring (mirrors apprunner/sagemaker):**
- `pkg/composer/contracts.go` — `KeyAWSCodeBuild` const + `ComposeOrder` / `ModulePath` / `PresetKeyMap` / `AllComponentKeys` / `ImplicitDependencies({KeyAWSVPC})` / `DefaultWiring` (public/private subnet chooser).
- `pkg/composer/types.go` — `AWSCodeBuild *bool` on `Components` + `AWSCodeBuild *AWSCodeBuildConfig` on `Config` + named `AWSCodeBuildConfig` struct + GCP-branch nil-outs on both `Normalize`s.
- `pkg/composer/coherence.go` — `ComponentSelected` case + `isOrphanStrippable` entry.
- `pkg/composer/mapper.go` — partial-config block with `strings.TrimSpace` gates on every string field, `!= nil` on pointers, slice trimming (no preview-safe stubs — every variable has a default).
- `pkg/composer/iam_actions.go` — `codebuild:CreateProject` + IAM + S3 + EC2 ENI + logs actions.
- `pkg/composer/presets.go` — `allKeys` entry.
- `pkg/composer/pricing.go` — `AWSCodeBuild *PricingItem` field + GCP-branch nil-out.
- `pkg/composer/codebuild_aws_wiring_test.go` (new) — 8 tests: `Mapper_{DefaultConfig,CallerSuppliedConfig,PartialConfig,EmptyStringsIgnored}`, `ComposeStack_{Forward,CallerSuppliedConfig}`, `ComponentSelected`, `IAMPermissionsCovered`.

**Observability:**
- `pkg/observability/display.go` — `"AWS CodeBuild"` display name.
- `pkg/observability/extractors/extractors_drift_test.go` — `[no-inspector]` allowlist entry citing #619.
- `pkg/observability/component_metrics_coverage_test.go` — `metricsDeferredKeys` entry citing #619 (panel-mapping backfill blocked on the codebuild service registration in `AWSServiceActions` that ships with the inspector PR).

**Docs:**
- `CLAUDE.md` — AWS preset count 35 → 36 (project overview + architecture diagram).

## Acceptance criteria

- [x] Preset + composer wiring + tests landed.
- [x] `terraform fmt -check -recursive aws/codebuild/` clean.
- [x] `cd aws/codebuild && terraform init -backend=false && terraform validate` passes.
- [x] `cd aws/codebuild && terraform test -test-directory tests` — **15 passed, 0 failed**.
- [x] All seven `tests/lint-*.sh` scripts PASS on the new preset (project-tag, sensitive-for-each, foreach-unknown-keys, no-root-only-blocks, shared-no-cloud-providers, labelless-name-prefix, gcp-project-pin, project-label).
- [x] `bash tests/validate-as-child.sh aws/codebuild` PASS (preset bundles cleanly as a composer-emitted child module).
- [x] `go build ./...` succeeds — `zz_embed.go` picks up the new module automatically.
- [x] `go test ./pkg/composer/... ./pkg/observability/... -count=1` — **3460 passed, 0 failed** (includes the 8 new wiring tests, drift gates for pricing / display-name / metrics mapping / extractors, and the preset-defaults validation).
- [x] `go test ./... -count=1` — **5092 passed, 0 failed** across the whole repo.
- [x] PR body uses `Closes #619`.

## Non-goals / out-of-scope follow-ups

- **Observability inspector** — deferred via the `[no-inspector]` extractor allowlist + `metricsDeferredKeys` entry, both citing #619. A future inspector PR will register `codebuild` in `pkg/observability/service_actions.go` (with `list-projects` + `batch-get-projects` + `get-metrics`), wire the dispatcher, clear both allowlist entries, and add a `ComponentMetricsMapping[KeyAWSCodeBuild]` row pointing at `codebuild.list-projects`. Mirrors how #622 backfilled `apprunner` + `sagemaker` after #618 / #620 added their inspectors.
- **CodePipeline integration** — `aws/codepipeline/main.tf` is still a placeholder. A future PR that fills it in can wire `aws/codebuild` outputs (`project_arn`/`project_name`) into the pipeline's build stage.
- **Cross-variable validation** — `source_location` is required when `source_type != NO_SOURCE` and `artifacts_location` is required when `artifacts_type = S3`. Both are enforced at apply time by the AWS CodeBuild API; Terraform variable validation rules cannot cross-reference other variables in the eval framework, so these checks live there rather than in `variables.tf`.

Closes #619