### PR TITLE
feat(metrics): register bindings for 5 codegen-only types

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -22,8 +22,8 @@ and is checked in lockstep with the runtime registries. See the
 
 ## Summary
 
-- **AWS:** 135 types · 81% Discoverable · 81% Enrichable · 100% DriftDetectable · 64% MetricsAvailable · 91% AgentEditable
-- **GCP:** 64 types · 84% Discoverable · 84% Enrichable · 100% DriftDetectable · 75% MetricsAvailable · 91% AgentEditable
+- **AWS:** 135 types · 81% Discoverable · 81% Enrichable · 100% DriftDetectable · 67% MetricsAvailable · 91% AgentEditable
+- **GCP:** 64 types · 84% Discoverable · 84% Enrichable · 100% DriftDetectable · 77% MetricsAvailable · 91% AgentEditable
 
 ## AWS
 
@@ -67,9 +67,9 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_cloudwatch_log_resource_policy` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_cloudwatch_log_stream` | ✓ | ✓ | ✓ | ✓ | – |
 | `aws_cloudwatch_metric_alarm` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `aws_codebuild_project` | – | – | ✓ | – | ✓ |
+| `aws_codebuild_project` | – | – | ✓ | ✓ | ✓ |
 | `aws_codedeploy_app` | – | – | ✓ | – | ✓ |
-| `aws_codepipeline` | – | – | ✓ | – | ✓ |
+| `aws_codepipeline` | – | – | ✓ | ✓ | ✓ |
 | `aws_cognito_identity_provider` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_cognito_resource_server` | ✓ | ✓ | ✓ | – | ✓ |
 | `aws_cognito_user_pool` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -98,7 +98,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_elasticache_replication_group` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_elasticache_subnet_group` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_glue_catalog_database` | – | – | ✓ | – | ✓ |
-| `aws_glue_job` | – | – | ✓ | – | ✓ |
+| `aws_glue_job` | – | – | ✓ | ✓ | ✓ |
 | `aws_iam_group` | ✓ | ✓ | ✓ | ✓ | – |
 | `aws_iam_instance_profile` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_iam_policy` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -151,7 +151,7 @@ and is checked in lockstep with the runtime registries. See the
 | `aws_secretsmanager_secret_rotation` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_security_group` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_service_discovery_private_dns_namespace` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `aws_sfn_state_machine` | – | – | ✓ | – | ✓ |
+| `aws_sfn_state_machine` | – | – | ✓ | ✓ | ✓ |
 | `aws_sns_topic` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_sns_topic_subscription` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `aws_sqs_queue` | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -200,7 +200,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_compute_url_map` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_container_cluster` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_container_node_pool` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `google_dns_managed_zone` | – | – | ✓ | – | ✓ |
+| `google_dns_managed_zone` | – | – | ✓ | ✓ | ✓ |
 | `google_dns_record_set` | – | – | ✓ | – | ✓ |
 | `google_firestore_database` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_iam_workload_identity_pool` | – | – | ✓ | – | ✓ |

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -140,6 +140,11 @@ var seededTypes = []string{
 	"aws_key_pair",
 	"google_service_networking_connection",
 	"google_secret_manager_secret_iam_member",
+	"aws_codebuild_project",
+	"aws_codepipeline",
+	"aws_glue_job",
+	"aws_sfn_state_machine",
+	"google_dns_managed_zone",
 }
 
 // seededBindings mirrors the registrations performed by init(). Used
@@ -1142,6 +1147,41 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		Action:        "timeseries-list",
 		DimensionKey:  "member",
 		DimensionFrom: "id",
+	},
+	"aws_codebuild_project": {
+		Service:        "codebuild",
+		Action:         "get-metrics",
+		DimensionKey:   "ProjectName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"Builds", "Duration", "FailedBuilds", "SucceededBuilds"},
+	},
+	"aws_codepipeline": {
+		Service:        "codepipeline",
+		Action:         "get-metrics",
+		DimensionKey:   "PipelineName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"SucceededPipelineExecutions", "FailedPipelineExecutions", "PipelineExecutionTime"},
+	},
+	"aws_glue_job": {
+		Service:        "glue",
+		Action:         "get-metrics",
+		DimensionKey:   "JobName",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"glue.driver.aggregate.numCompletedTasks", "glue.driver.aggregate.numFailedTasks", "glue.driver.aggregate.elapsedTime"},
+	},
+	"aws_sfn_state_machine": {
+		Service:        "states",
+		Action:         "get-metrics",
+		DimensionKey:   "StateMachineArn",
+		DimensionFrom:  "id",
+		DefaultMetrics: []string{"ExecutionsStarted", "ExecutionsSucceeded", "ExecutionsFailed", "ExecutionTime"},
+	},
+	"google_dns_managed_zone": {
+		Service:        "dns",
+		Action:         "timeseries-list",
+		DimensionKey:   "target_name",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"dns.googleapis.com/query/response_count"},
 	},
 }
 

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -1148,6 +1148,11 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:  "member",
 		DimensionFrom: "id",
 	},
+	// --- Codegen-only types (not in registry.SupportedDiscoverTypes; see
+	// awsCodegenOnlyTypes / gcpCodegenOnlyTypes in pkg/insideout-import/registry).
+	// These bindings are dormant until a per-type SDKLister / CAI mapping
+	// promotes the type into the live discoverer — wired here so the
+	// metrics surface lights up automatically when discovery lands. ---
 	"aws_codebuild_project": {
 		Service:        "codebuild",
 		Action:         "get-metrics",
@@ -1163,6 +1168,10 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DefaultMetrics: []string{"SucceededPipelineExecutions", "FailedPipelineExecutions", "PipelineExecutionTime"},
 	},
 	"aws_glue_job": {
+		// CloudWatch Glue metrics are typically compound-dimensioned
+		// (JobName + JobRunId + Type); JobName alone aggregates across
+		// runs and metric types. Acceptable as a default surface — the
+		// downstream consumer can fan out per-run / per-type if needed.
 		Service:        "glue",
 		Action:         "get-metrics",
 		DimensionKey:   "JobName",
@@ -1170,6 +1179,9 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DefaultMetrics: []string{"glue.driver.aggregate.numCompletedTasks", "glue.driver.aggregate.numFailedTasks", "glue.driver.aggregate.elapsedTime"},
 	},
 	"aws_sfn_state_machine": {
+		// DimensionFrom="id" because the AWS/States CloudWatch
+		// dimension is StateMachineArn, and the TF resource ID for
+		// aws_sfn_state_machine IS the ARN (not the name).
 		Service:        "states",
 		Action:         "get-metrics",
 		DimensionKey:   "StateMachineArn",


### PR DESCRIPTION
## Summary
- Adds opportunistic CloudWatch / Cloud Monitoring metrics bindings for 5 tfTypes that previously had `MetricsAvailable = –` in `SUPPORTED_RESOURCES.md`: `aws_codebuild_project`, `aws_codepipeline`, `aws_glue_job`, `aws_sfn_state_machine`, `google_dns_managed_zone`.
- All five sit on `awsCodegenOnlyTypes` / `gcpCodegenOnlyTypes`, so they remain `Discoverable = –` / `Enrichable = –` — the bindings are **dormant** (future-proof) until a hand-rolled SDKLister / CAI mapping promotes the type into the live discoverer. Annotated inline.
- Regenerates `SUPPORTED_RESOURCES.md` via `make regen-supported-resources`. Summary line shifts:
  - AWS MetricsAvailable: **64% → 67%**
  - GCP MetricsAvailable: **75% → 77%**

## Validation against canonical metric docs
| TF type | Namespace | Dimension | Default metrics |
|---|---|---|---|
| `aws_codebuild_project` | `AWS/CodeBuild` | `ProjectName` ← `name` | `Builds`, `Duration`, `FailedBuilds`, `SucceededBuilds` |
| `aws_codepipeline` | `AWS/CodePipeline` | `PipelineName` ← `name` | `SucceededPipelineExecutions`, `FailedPipelineExecutions`, `PipelineExecutionTime` |
| `aws_glue_job` | `Glue` | `JobName` ← `name` | `glue.driver.aggregate.{numCompletedTasks, numFailedTasks, elapsedTime}` |
| `aws_sfn_state_machine` | `AWS/States` | `StateMachineArn` ← `id` (TF id IS the ARN) | `Executions{Started, Succeeded, Failed}`, `ExecutionTime` |
| `google_dns_managed_zone` | Cloud Monitoring `dns_query` | `target_name` ← `name` | `dns.googleapis.com/query/response_count` |

## Test plan
- [x] `go test ./pkg/imported/bindings/... -count=1` — 151 passing locally (incl. `TestSeededBindings` covering the new types)
- [x] `go test ./...` — 5092 passing across all packages
- [x] `make regen-supported-resources && make verify-supported-resources` — generated doc matches committed file
- [ ] CI green (full suite + lints)

## Review notes
- `/review` findings: 0 P0 / 0 P1; 2 P2 drive-bys addressed (codegen-only cluster comment + `DimensionFrom="id"` rationale on `aws_sfn_state_machine`); 2 P3 nits skipped (no tracker issue cited — no open issue exists for opportunistic bindings)
- qa-professor: no test changes — skipped
- Deferred: 5+ more bindings exist for actively-discovered types that sit on `metricsBindingExempt` with `"binding shape deferred"` curator notes (`aws_instance`, `aws_msk_cluster`, `aws_opensearch_domain`, `google_compute_instance`, `google_cloudfunctions2_function`). Left for separate scoped PRs so the curators can weigh in on dimension shape.