### PR TITLE
feat(composer): expose ProvidersUsed + split providers.tf into providers/providers-aliases/providers-imported

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -59,9 +59,23 @@ type Files map[string][]byte
 // the deduped list of pre-plan validator findings (missing required vars,
 // type mismatches, wiring drift, etc.) that callers like the InsideOut backend/interactive-agent
 // surface for same-turn correction.
+//
+// ProvidersUsed mirrors the providersUsed map returned by EmitImportedTF: it
+// lists the clouds (and the synthetic gcp-beta key) for which at least one
+// imported resource was emitted. Downstream consumers use it to gate
+// archive-side behaviour without re-running EmitImportedTF — e.g. reliable's
+// renderImportedAliasProviderArchiveFile (luthersystems/reliable#1588) only
+// needs to ship a sibling provider-alias file when ProvidersUsed is
+// non-empty.
+//
+// Keys are the same constants exported by imported_emit.go:
+// ProvidersUsedKeyAWS ("aws"), ProvidersUsedKeyGCP ("gcp"),
+// ProvidersUsedKeyGCPBeta ("gcp-beta"). The map is nil when no imported
+// resources were emitted (matching EmitImportedTF's zero-result contract).
 type ComposeStackResult struct {
-	Files  Files
-	Issues []ValidationIssue
+	Files         Files
+	Issues        []ValidationIssue
+	ProvidersUsed map[string]bool
 }
 
 // ComposeSingleResult mirrors ComposeStackResult for the single-module path.
@@ -687,7 +701,7 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 		files["/imported.tf"] = importedTF
 	}
 
-	files["/providers.tf"] = generateProvidersTF(providersTFInput{
+	providersFiles := generateProvidersFiles(providersTFInput{
 		Cloud:          cloud,
 		Region:         reg,
 		GCPProjectID:   opts.GCPProjectID,
@@ -695,6 +709,20 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 		Discovered:     discoveredProviders,
 		ImportedClouds: importedClouds,
 	})
+	// /providers.tf holds only the terraform{} required_providers block and
+	// the default provider. /providers-aliases.tf and /providers-imported.tf
+	// carry the selection-dependent and `*.imported` alias blocks. The
+	// split lets archive packagers (notably reliable's
+	// sandbox-infrastructure-template wrapper) keep their own
+	// /providers.tf via PRESERVE_PATTERNS while the alias declarations
+	// slip through as sibling files — see luthersystems/reliable#1588.
+	files["/providers.tf"] = providersFiles.Main
+	if len(providersFiles.Aliases) > 0 {
+		files["/providers-aliases.tf"] = providersFiles.Aliases
+	}
+	if len(providersFiles.Imported) > 0 {
+		files["/providers-imported.tf"] = providersFiles.Imported
+	}
 
 	// Validator dispatcher — runs after the stack is fully composed, before
 	// returning. Each validator appends to issues. The missing-required check
@@ -710,7 +738,11 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	issues = append(issues, ValidateGCPProjectID(cloud, opts.GCPProjectID)...)
 	issues = append(issues, ValidateAWSVPCNATConsistency(cloud, opts.Comps, opts.Cfg)...)
 
-	return &ComposeStackResult{Files: files, Issues: issues}, nil
+	return &ComposeStackResult{
+		Files:         files,
+		Issues:        issues,
+		ProvidersUsed: importedClouds,
+	}, nil
 }
 
 // providersTFInput bundles every input needed to render the composed
@@ -758,11 +790,66 @@ type providersTFInput struct {
 	ImportedClouds map[string]bool
 }
 
+// providersTFFiles is the split-up output of generateProvidersFiles.
+//
+// Main carries the `terraform { required_providers { … } }` block and the
+// default `provider "<cloud>" {}` block — anything a baseline stack needs to
+// `terraform init` regardless of whether it has cross-region or imported
+// resources.
+//
+// Aliases carries non-imported provider aliases that depend on which
+// components are selected — today that means the AWS `us_east_1` alias used
+// by CloudFront / WAF cert validation. Nil when no such alias is needed
+// (e.g. GCP stacks, AWS stacks without WAF).
+//
+// Imported carries the `aws.imported` / `google.imported` /
+// `google-beta.imported` alias blocks emitted unconditionally for the
+// matching cloud (issue #562). Nil when neither AWS nor GCP would emit an
+// imported alias (i.e. an empty-cloud compose, which the current pipeline
+// doesn't produce — but keep the nil contract so callers can rely on a
+// non-nil slice meaning "write this file").
+//
+// The split lets archive packagers (e.g. reliable's
+// sandbox-infrastructure-template wrapper) preserve the wrapper's own
+// providers.tf while still receiving the alias declarations as sibling
+// files that don't collide with the wrapper's PRESERVE_PATTERNS filter.
+// See luthersystems/reliable#1588 for the production bug this split fixes.
+type providersTFFiles struct {
+	Main     []byte
+	Aliases  []byte
+	Imported []byte
+}
+
 // generateProvidersTF generates cloud-specific provider configuration.
 // For AWS it includes assume_role blocks with bootstrap_role_arn and
 // external_id variables so Oracle can deploy into the customer's account
 // using cross-account role assumption with confused-deputy protection.
+//
+// Deprecated for internal callers: prefer generateProvidersFiles, which
+// returns the three logical pieces (main / aliases / imported) as separate
+// files so archive packagers can sidestep PRESERVE_PATTERNS-style filters
+// that protect a wrapper's own /providers.tf. This wrapper concatenates the
+// three pieces back into a single byte slice for backwards compatibility
+// with tests that assert against the full document.
 func generateProvidersTF(in providersTFInput) []byte {
+	pf := generateProvidersFiles(in)
+	var b []byte
+	b = append(b, pf.Main...)
+	if len(pf.Aliases) > 0 {
+		b = append(b, pf.Aliases...)
+	}
+	if len(pf.Imported) > 0 {
+		b = append(b, pf.Imported...)
+	}
+	return b
+}
+
+// generateProvidersFiles renders provider configuration as three logical
+// files: the always-present terraform{} + default provider block (Main),
+// non-imported aliases keyed off in.Selected (Aliases), and the
+// unconditional `*.imported` alias blocks for the active cloud
+// (Imported). See providersTFFiles for the file-level contract.
+func generateProvidersFiles(in providersTFInput) providersTFFiles {
 	cloud := in.Cloud
 	region := in.Region
 	gcpProjectID := in.GCPProjectID
@@ -810,38 +897,45 @@ func generateProvidersTF(in providersTFInput) []byte {
     managed-by = %q
   }`, insideoutManagedByValue)
 
-		var b strings.Builder
-		b.WriteString("terraform {\n  required_providers {\n")
-		b.WriteString(renderRequiredProviders(required))
-		b.WriteString("  }\n}\n\n")
-		fmt.Fprintf(&b, "provider \"google\" {\n  region = %q%s\n}\n", region, gcpDefaultLabels)
-		b.WriteString("\n")
-		// google.imported drives Terraform's import {} for previously
-		// existing GCP resources. project is rendered as a literal —
-		// the root stack does not declare var.gcp_project_id, and the
-		// project ID is known at compose time. No default_labels:
-		// imported resources keep any pre-existing labels untouched.
-		// An empty gcpProjectID still emits an empty literal: the
-		// gcp_project_id_required ValidationIssue surfaces the real
-		// fix to the caller before apply.
+		var main strings.Builder
+		main.WriteString("terraform {\n  required_providers {\n")
+		main.WriteString(renderRequiredProviders(required))
+		main.WriteString("  }\n}\n\n")
+		fmt.Fprintf(&main, "provider \"google\" {\n  region = %q%s\n}\n", region, gcpDefaultLabels)
+
+		// GCP composes never declare additional non-imported aliases at
+		// the root today, so Aliases stays nil. Keep the slot for parity
+		// with the AWS branch and to give future GCP cross-region
+		// aliases a place to land without breaking the file layout.
+		var aliases []byte
+
+		// imported: google.imported drives Terraform's import {} for
+		// previously existing GCP resources, plus the google-beta.imported
+		// sibling for API-Gateway-family resources whose schema lives in
+		// hashicorp/google-beta. project is rendered as a literal — the
+		// root stack does not declare var.gcp_project_id, and the project
+		// ID is known at compose time. No default_labels: imported
+		// resources keep any pre-existing labels untouched. An empty
+		// gcpProjectID still emits an empty literal: the
+		// gcp_project_id_required ValidationIssue surfaces the real fix
+		// to the caller before apply.
 		//
-		// Emitted unconditionally for every GCP stack (issue #562):
-		// terraform state from a prior compose may still reference
-		// `google.imported` even when the current compose's Imported
-		// list is empty (drift-correction recompose, re-import flow,
-		// etc.). Omitting the alias block then crashes `terraform
-		// plan` with "Provider configuration not present".
-		fmt.Fprintf(&b, "provider \"google\" {\n  alias   = \"imported\"\n  region  = %q\n  project = %q\n}\n", region, gcpProjectID)
-		b.WriteString("\n")
-		// google-beta.imported is the alias used by imported
-		// resources whose schema lives in hashicorp/google-beta —
-		// most notably the API Gateway family. Mirrors the
-		// google.imported alias above (no default_labels) so the
-		// imported resources don't inherit the session's
-		// project label. Emitted unconditionally for the same
-		// reason as google.imported above (issue #562).
-		fmt.Fprintf(&b, "provider \"google-beta\" {\n  alias   = \"imported\"\n  region  = %q\n  project = %q\n}\n", region, gcpProjectID)
-		return []byte(b.String())
+		// Both blocks are emitted unconditionally for every GCP stack
+		// (issue #562): terraform state from a prior compose may still
+		// reference `google.imported` even when the current compose's
+		// Imported list is empty (drift-correction recompose, re-import
+		// flow, etc.). Omitting the alias block then crashes
+		// `terraform plan` with "Provider configuration not present".
+		var imp strings.Builder
+		imp.WriteString("\n")
+		fmt.Fprintf(&imp, "provider \"google\" {\n  alias   = \"imported\"\n  region  = %q\n  project = %q\n}\n", region, gcpProjectID)
+		imp.WriteString("\n")
+		fmt.Fprintf(&imp, "provider \"google-beta\" {\n  alias   = \"imported\"\n  region  = %q\n  project = %q\n}\n", region, gcpProjectID)
+		return providersTFFiles{
+			Main:     []byte(main.String()),
+			Aliases:  aliases,
+			Imported: []byte(imp.String()),
+		}
 
 	default: // aws
 		if region == "" {
@@ -888,19 +982,25 @@ variable "external_id" {
 		required["aws"] = &tfconfig.ProviderRequirement{Source: "hashicorp/aws", VersionConstraints: []string{">= 6.0"}}
 		maps.Copy(required, discovered)
 
-		var b strings.Builder
-		b.WriteString(awsVarDecls)
-		b.WriteString("terraform {\n  required_providers {\n")
-		b.WriteString(renderRequiredProviders(required))
-		b.WriteString("  }\n}\n\n")
-		fmt.Fprintf(&b, "provider \"aws\" {\n  region = %q%s%s\n}\n", region, awsDefaultTags, awsDynamicAssumeRole)
+		var main strings.Builder
+		main.WriteString(awsVarDecls)
+		main.WriteString("terraform {\n  required_providers {\n")
+		main.WriteString(renderRequiredProviders(required))
+		main.WriteString("  }\n}\n\n")
+		fmt.Fprintf(&main, "provider \"aws\" {\n  region = %q%s%s\n}\n", region, awsDefaultTags, awsDynamicAssumeRole)
 
 		// WAF requires an additional us_east_1 provider alias for CloudFront
 		// certificate validation. This is a root-configuration concern, not a
-		// child-module concern, so it stays cloud-aware here.
+		// child-module concern, so it stays cloud-aware here. The block
+		// lives in the Aliases slot so archive packagers can preserve the
+		// wrapper's own /providers.tf without dropping this alias
+		// (luthersystems/reliable#1588).
+		var aliases []byte
 		if selected[KeyAWSWAF] {
-			b.WriteString("\n")
-			fmt.Fprintf(&b, "provider \"aws\" {\n  alias  = \"us_east_1\"\n  region = \"us-east-1\"%s%s\n}\n", awsDefaultTags, awsDynamicAssumeRole)
+			var ab strings.Builder
+			ab.WriteString("\n")
+			fmt.Fprintf(&ab, "provider \"aws\" {\n  alias  = \"us_east_1\"\n  region = \"us-east-1\"%s%s\n}\n", awsDefaultTags, awsDynamicAssumeRole)
+			aliases = []byte(ab.String())
 		}
 
 		// aws.imported is the dedicated alias for resources discovered via
@@ -917,10 +1017,15 @@ variable "external_id" {
 		// empty (drift-correction recompose, re-import flow, etc.).
 		// Omitting the alias block then crashes `terraform plan` with
 		// "Provider configuration not present".
-		b.WriteString("\n")
-		fmt.Fprintf(&b, "provider \"aws\" {\n  alias  = \"imported\"\n  region = %q%s\n}\n", region, awsDynamicAssumeRole)
+		var imp strings.Builder
+		imp.WriteString("\n")
+		fmt.Fprintf(&imp, "provider \"aws\" {\n  alias  = \"imported\"\n  region = %q%s\n}\n", region, awsDynamicAssumeRole)
 
-		return []byte(b.String())
+		return providersTFFiles{
+			Main:     []byte(main.String()),
+			Aliases:  aliases,
+			Imported: []byte(imp.String()),
+		}
 	}
 }
 

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -464,19 +464,30 @@ func TestComposeStack_V2KitchenSink(t *testing.T) {
 	require.Contains(t, mainTF, "aws = aws")
 	require.Contains(t, mainTF, "aws.us_east_1 = aws.us_east_1")
 
-	// Providers file should declare default + us_east_1 alias
+	// Providers files: /providers.tf carries terraform{} + default block;
+	// /providers-aliases.tf carries the WAF us_east_1 alias post-split
+	// (luthersystems/reliable#1588). Both files must independently carry
+	// their own default_tags safety net (#1112).
 	require.Contains(t, out, "/providers.tf")
 	prov := string(out["/providers.tf"])
 	require.Contains(t, prov, `terraform {`)
 	require.Contains(t, prov, `required_providers`)
 	require.Contains(t, prov, `provider "aws" {`)
-	require.Contains(t, prov, `alias  = "us_east_1"`)
-	require.Contains(t, prov, `region = "us-east-1"`)
+	require.NotContains(t, prov, `alias  = "us_east_1"`,
+		"us_east_1 alias must live in /providers-aliases.tf, not /providers.tf")
+
+	require.Contains(t, out, "/providers-aliases.tf")
+	aliases := string(out["/providers-aliases.tf"])
+	require.Contains(t, aliases, `alias  = "us_east_1"`)
+	require.Contains(t, aliases, `region = "us-east-1"`)
+
 	// Verify each provider block independently carries default_tags with
 	// Project = var.project — the #1112 safety net. Split-per-block proves
 	// placement (a regression dropping default_tags from just one block
-	// would otherwise pass a global substring count).
-	assertProviderBlocksHaveDefaultTags(t, prov, 2)
+	// would otherwise pass a global substring count). One in /providers.tf
+	// (the default block) and one in /providers-aliases.tf (the us_east_1
+	// block) — total of 2 across the pair.
+	assertProviderBlocksHaveDefaultTags(t, prov+aliases, 2)
 
 	// Monitoring: per-component observability is active (consumers selected
 	// alongside cwm), so the legacy aggregator-side back-edges are dropped
@@ -691,16 +702,25 @@ func TestComposeStack_KitchenSink(t *testing.T) {
 	})
 
 	t.Run("providers_tf", func(t *testing.T) {
+		// Post-split (luthersystems/reliable#1588): /providers.tf only
+		// carries terraform{} + default provider; /providers-aliases.tf
+		// holds selection-dependent aliases (here: WAF's us_east_1).
 		require.Contains(t, out, "/providers.tf")
 		prov := string(out["/providers.tf"])
 		require.Contains(t, prov, `terraform {`)
 		require.Contains(t, prov, `required_providers`)
 		require.Contains(t, prov, `provider "aws" {`)
-		require.Contains(t, prov, `alias  = "us_east_1"`)
-		require.Contains(t, prov, `region = "us-east-1"`)
+		require.NotContains(t, prov, `alias  = "us_east_1"`,
+			"us_east_1 alias must live in /providers-aliases.tf, not /providers.tf")
+
+		require.Contains(t, out, "/providers-aliases.tf")
+		aliases := string(out["/providers-aliases.tf"])
+		require.Contains(t, aliases, `alias  = "us_east_1"`)
+		require.Contains(t, aliases, `region = "us-east-1"`)
+
 		// WAF is selected here so both default + us_east_1 blocks render;
 		// each must independently carry the #1112 default_tags safety net.
-		assertProviderBlocksHaveDefaultTags(t, prov, 2)
+		assertProviderBlocksHaveDefaultTags(t, prov+aliases, 2)
 	})
 }
 

--- a/pkg/composer/imported_compose_test.go
+++ b/pkg/composer/imported_compose_test.go
@@ -316,9 +316,16 @@ func TestComposeStackWithIssues_Imported_AWS(t *testing.T) {
 		pairs,
 		"every imported resource must have a paired import block with the matching id")
 
-	providersTF := string(res.Files["/providers.tf"])
-	assertImportedAliasDeclared(t, providersTF, "aws")
-	assertImportedProviderHasNoDefaultTags(t, providersTF, "aws")
+	// Imported alias blocks moved out of /providers.tf into
+	// /providers-imported.tf (luthersystems/reliable#1588) so archive
+	// packagers can ship them as a sibling file that slips through
+	// PRESERVE_PATTERNS-style filters. Assert against the imported file
+	// directly; the no-default-tags property still holds.
+	importedProvidersTF := string(res.Files["/providers-imported.tf"])
+	assertImportedAliasDeclared(t, importedProvidersTF, "aws")
+	assertImportedProviderHasNoDefaultTags(t, importedProvidersTF, "aws")
+	assert.NotContains(t, string(res.Files["/providers.tf"]), `alias  = "imported"`,
+		"/providers.tf must no longer carry the imported alias — it moved to /providers-imported.tf")
 
 	// Composed root must parse cleanly — ValidateComposedRoot is the
 	// terminal gate. No HCL parse issues should appear in res.Issues.
@@ -366,12 +373,14 @@ func TestComposeStackWithIssues_Imported_GCP(t *testing.T) {
 		parseImportPairs(t, importedTF),
 		"imported google resource must have a paired import block")
 
-	providersTF := string(res.Files["/providers.tf"])
-	assertImportedAliasDeclared(t, providersTF, "gcp")
-	assert.True(t, hasProviderAttr(providersTF, "gcp", "project", `"demo-project-12345"`),
+	// Imported alias blocks live in /providers-imported.tf as of the
+	// providers.tf split (luthersystems/reliable#1588).
+	importedProvidersTF := string(res.Files["/providers-imported.tf"])
+	assertImportedAliasDeclared(t, importedProvidersTF, "gcp")
+	assert.True(t, hasProviderAttr(importedProvidersTF, "gcp", "project", `"demo-project-12345"`),
 		"google.imported must carry project as a literal (root vars do not declare gcp_project_id):\n%s",
-		providersTF)
-	assertImportedProviderHasNoDefaultTags(t, providersTF, "gcp")
+		importedProvidersTF)
+	assertImportedProviderHasNoDefaultTags(t, importedProvidersTF, "gcp")
 
 	for _, iss := range res.Issues {
 		require.NotEqualf(t, "hcl_parse_error", iss.Code,
@@ -428,8 +437,11 @@ func TestComposeStackWithIssues_Imported_MissingBlocksApply(t *testing.T) {
 	assert.False(t, hasImportedTF,
 		"no imported.tf should be emitted when only blocked records are present")
 
-	providersTF := string(res.Files["/providers.tf"])
-	assertImportedAliasDeclared(t, providersTF, "aws")
+	// Imported alias still emits unconditionally for every AWS stack
+	// (#562), but it now lives in /providers-imported.tf
+	// (luthersystems/reliable#1588).
+	importedProvidersTF := string(res.Files["/providers-imported.tf"])
+	assertImportedAliasDeclared(t, importedProvidersTF, "aws")
 }
 
 // TestComposeStackWithIssues_Imported_StrictValidateEscalates pins that
@@ -501,8 +513,14 @@ func TestComposeStack_NoImportedKeepsExistingBehavior(t *testing.T) {
 	_, hasImportedTF := files["/imported.tf"]
 	assert.False(t, hasImportedTF,
 		"composes without Imported must not produce imported.tf")
-	providers := string(files["/providers.tf"])
-	assertImportedAliasDeclared(t, providers, "aws")
+	// The imported alias still emits unconditionally for every AWS stack
+	// (#562), but it now lives in /providers-imported.tf
+	// (luthersystems/reliable#1588). /providers.tf itself no longer
+	// carries any alias block.
+	importedProviders := string(files["/providers-imported.tf"])
+	assertImportedAliasDeclared(t, importedProviders, "aws")
+	assert.NotContains(t, string(files["/providers.tf"]), `alias  = "imported"`,
+		"/providers.tf must not carry the imported alias post-split")
 }
 
 // TestImportedResource_EveryTierBranchExercised acts as a CI gate ensuring

--- a/pkg/composer/providers_split_test.go
+++ b/pkg/composer/providers_split_test.go
@@ -1,0 +1,240 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests in this file lock the providers.tf split (luthersystems/reliable#1588):
+//
+//   - /providers.tf — terraform{} block + default provider only.
+//   - /providers-aliases.tf — selection-dependent aliases (today: WAF's
+//     us_east_1 alias). Absent when no such alias is needed.
+//   - /providers-imported.tf — `*.imported` alias blocks for the active
+//     cloud. Present whenever the cloud branch declares an imported alias
+//     (today: every AWS and GCP compose, per issue #562).
+//
+// The split lets archive packagers preserve a wrapper's own /providers.tf
+// (via filename-exact PRESERVE_PATTERNS filters) while still receiving the
+// alias declarations as sibling files. ComposeStackResult.ProvidersUsed
+// mirrors the providersUsed map EmitImportedTF returns so callers don't
+// have to re-run EmitImportedTF to recover the signal.
+
+// TestGenerateProvidersTF_DefaultOnly pins the no-WAF, no-imported AWS
+// stack: /providers.tf carries the default provider, /providers-aliases.tf
+// is absent, /providers-imported.tf still emits because issue #562 made
+// the aws.imported alias unconditional.
+func TestGenerateProvidersTF_DefaultOnly(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS", AWSVPC: "Private VPC"},
+		Cfg:          &Config{},
+		Project:      "p",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	require.Contains(t, res.Files, "/providers.tf",
+		"the main providers file must always be present")
+	prov := string(res.Files["/providers.tf"])
+	assert.Contains(t, prov, `terraform {`)
+	assert.Contains(t, prov, `required_providers`)
+	assert.Contains(t, prov, `provider "aws" {`)
+	assert.NotContains(t, prov, `alias  = "us_east_1"`,
+		"no WAF selected → no us_east_1 alias anywhere")
+	assert.NotContains(t, prov, `alias  = "imported"`,
+		"imported alias must live in /providers-imported.tf, not /providers.tf")
+
+	_, hasAliases := res.Files["/providers-aliases.tf"]
+	assert.False(t, hasAliases,
+		"no non-imported aliases are needed when WAF is not selected — /providers-aliases.tf must not emit")
+
+	// /providers-imported.tf is still emitted because issue #562 makes the
+	// aws.imported alias unconditional for every AWS stack.
+	require.Contains(t, res.Files, "/providers-imported.tf",
+		"every AWS stack emits the unconditional aws.imported alias (#562)")
+	assert.Contains(t, string(res.Files["/providers-imported.tf"]), `alias  = "imported"`)
+
+	// No Imported list → ProvidersUsed is nil (matches EmitImportedTF's
+	// zero-result contract).
+	assert.Empty(t, res.ProvidersUsed,
+		"no imported resources → ProvidersUsed must be empty")
+}
+
+// TestGenerateProvidersTF_WithUSEast1Alias pins that selecting WAF lifts
+// the us_east_1 alias into /providers-aliases.tf and leaves /providers.tf
+// clean of aliases.
+func TestGenerateProvidersTF_WithUSEast1Alias(t *testing.T) {
+	t.Parallel()
+
+	out := generateProvidersFiles(providersTFInput{
+		Cloud:    "aws",
+		Region:   "us-east-1",
+		Selected: map[ComponentKey]bool{KeyAWSWAF: true},
+	})
+
+	// Main: no alias blocks at all.
+	main := string(out.Main)
+	assert.Contains(t, main, `terraform {`)
+	assert.Contains(t, main, `provider "aws" {`)
+	assert.NotContains(t, main, `alias  = "us_east_1"`,
+		"us_east_1 alias must NOT appear in /providers.tf")
+	assert.NotContains(t, main, `alias  = "imported"`,
+		"imported alias must NOT appear in /providers.tf")
+
+	// Aliases: us_east_1 block only.
+	require.NotEmpty(t, out.Aliases,
+		"WAF selected → /providers-aliases.tf must emit")
+	aliases := string(out.Aliases)
+	assert.Contains(t, aliases, `alias  = "us_east_1"`)
+	assert.Contains(t, aliases, `region = "us-east-1"`)
+	assert.NotContains(t, aliases, `alias  = "imported"`,
+		"imported alias belongs in /providers-imported.tf")
+
+	// Imported: unconditional aws.imported.
+	require.NotEmpty(t, out.Imported)
+	assert.Contains(t, string(out.Imported), `alias  = "imported"`)
+}
+
+// TestGenerateProvidersTF_WithImported drives an AWS compose with an
+// imported resource and asserts:
+//   - /providers-imported.tf carries `alias = "imported"`
+//   - ProvidersUsed records ["aws"] so callers can gate archive-side
+//     behaviour without re-running EmitImportedTF.
+func TestGenerateProvidersTF_WithImported(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-east-1",
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_sqs_queue",
+					Address:  "aws_sqs_queue.orders_dlq",
+					ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders-DLQ",
+				},
+				Tier:  imported.TierImportedFlat,
+				Attrs: []byte(`{"name":{"literal":"orders-DLQ"}}`),
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	require.Contains(t, res.Files, "/providers-imported.tf")
+	importedTF := string(res.Files["/providers-imported.tf"])
+	assertImportedAliasDeclared(t, importedTF, "aws")
+
+	// The split must not silently lose the imported alias from /providers.tf
+	// without re-homing it — assert it does NOT appear in the main file.
+	assert.NotContains(t, string(res.Files["/providers.tf"]), `alias  = "imported"`,
+		"imported alias must NOT appear in /providers.tf post-split")
+
+	require.NotNil(t, res.ProvidersUsed, "ProvidersUsed must be set when imported resources emit")
+	assert.True(t, res.ProvidersUsed[ProvidersUsedKeyAWS],
+		"ProvidersUsed[aws] must be true: %v", res.ProvidersUsed)
+	assert.False(t, res.ProvidersUsed[ProvidersUsedKeyGCP],
+		"ProvidersUsed[gcp] must be false on an AWS-only compose: %v", res.ProvidersUsed)
+}
+
+// TestGenerateProvidersTF_WithImportedGCP mirrors the AWS case for GCP and
+// asserts ProvidersUsed records the gcp key. The google-beta.imported
+// block is emitted unconditionally for every GCP compose (#562), so its
+// presence in /providers-imported.tf is independent of whether the
+// current Imported list contains a google-beta-sourced resource.
+func TestGenerateProvidersTF_WithImportedGCP(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPVPC},
+		Comps:        &Components{Cloud: "GCP"},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-central1",
+		GCPProjectID: "demo-project-12345",
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "gcp",
+					Type:     "google_pubsub_topic",
+					Address:  "google_pubsub_topic.events",
+					ImportID: "projects/demo-project-12345/topics/events",
+				},
+				Tier:  imported.TierImportedFlat,
+				Attrs: []byte(`{"name":{"literal":"events"}}`),
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	require.Contains(t, res.Files, "/providers-imported.tf")
+	importedTF := string(res.Files["/providers-imported.tf"])
+	// Both google.imported and google-beta.imported emit unconditionally
+	// for every GCP stack (#562).
+	assert.Contains(t, importedTF, `provider "google" {`)
+	assert.Contains(t, importedTF, `provider "google-beta" {`)
+	assert.Contains(t, importedTF, `alias   = "imported"`)
+	assert.Contains(t, importedTF, `project = "demo-project-12345"`)
+
+	require.NotNil(t, res.ProvidersUsed)
+	assert.True(t, res.ProvidersUsed[ProvidersUsedKeyGCP],
+		"ProvidersUsed[gcp] must be true: %v", res.ProvidersUsed)
+	assert.False(t, res.ProvidersUsed[ProvidersUsedKeyAWS],
+		"ProvidersUsed[aws] must be false on a GCP-only compose: %v", res.ProvidersUsed)
+}
+
+// TestComposeStackResult_ProvidersUsed_BackwardCompat pins that the new
+// ProvidersUsed field is additive: callers that ignore it still see the
+// same Files map and Issues list they always saw. This guards against an
+// accidental restructure of Files / Issues during the refactor.
+func TestComposeStackResult_ProvidersUsed_BackwardCompat(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS", AWSVPC: "Private VPC"},
+		Cfg:          &Config{},
+		Project:      "p",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// Files-side invariants the pre-#1588 callers (e.g. reliable's
+	// composeTFArchiveDirect, which iterates res.Files verbatim) relied on.
+	require.Contains(t, res.Files, "/main.tf")
+	require.Contains(t, res.Files, "/variables.tf")
+	require.Contains(t, res.Files, "/providers.tf")
+	require.NotEmpty(t, res.Files["/providers.tf"],
+		"/providers.tf must remain non-empty post-split (callers may assert size)")
+
+	// Green-path stack: no validation issues. Mirrors the existing
+	// TestComposeStackWithIssues_GreenPath contract.
+	assert.Empty(t, res.Issues)
+
+	// ProvidersUsed is the additive surface — nil on a no-import compose
+	// is fine and what callers should expect. No imported resources →
+	// no imported clouds.
+	assert.Empty(t, res.ProvidersUsed,
+		"compose with no Imported list → ProvidersUsed must be empty")
+}


### PR DESCRIPTION
## Summary

Two related composer changes, both motivated by a production bug in the downstream consumer (luthersystems/reliable#1588) where the `provider \"aws\" { alias = \"imported\" }` block was lost between composer emission and the deployed module because the runtime wrapper's `PRESERVE_PATTERNS` rsync filter drops the entire composer-emitted `/providers.tf`.

### 1. Expose `ProvidersUsed` on `ComposeStackResult`

`EmitImportedTF` already returns a `providersUsed map[string]bool` keyed by cloud, but `ComposeStackWithIssues` consumed it internally and threw it away. Reliable's Shape-B workaround (`renderImportedAliasProviderArchiveFile`) had to re-run `EmitImportedTF` solely to recover that signal. The field now rides on the existing compose result.

Keys reuse the existing `ProvidersUsedKey{AWS,GCP,GCPBeta}` constants exported by `imported_emit.go` so the `EmitImportedTF` ↔ `ComposeStackResult` wire format stays single-sourced.

The field is additive — callers that only read `Files` / `Issues` see zero behaviour change.

### 2. Split monolithic `/providers.tf`

`/providers.tf` previously emitted one document containing four concerns (terraform{} required_providers + default provider + non-imported aliases + imported aliases). The wrapper's `PRESERVE_PATTERNS` rsync filter matches the filename exactly, so the entire file was dropped from the archive — taking the imported alias with it.

The composer now splits into three files:

| File | Contents | When emitted |
|---|---|---|
| `/providers.tf` | `terraform { required_providers { … } }` + default `provider \"<cloud>\"` block | Always |
| `/providers-aliases.tf` | Selection-dependent aliases (today: WAF's `us_east_1`) | Only when at least one such alias is needed |
| `/providers-imported.tf` | `*.imported` alias blocks for the active cloud | Whenever the cloud branch declares an imported alias (every AWS / GCP compose per #562) |

The `providers-` prefix slips through reliable's existing filename-exact `PRESERVE_PATTERNS` filter — the same observation that drove the Shape-B workaround in reliable#1588. With this split, that workaround can be retired entirely; reliable's archive packager just copies every entry in `Files` verbatim, no extra re-emission.

The legacy `generateProvidersTF(in) []byte` entry point survives as a concatenation of the three pieces so existing string-substring tests keep working. Internally `composeStackImpl` now calls `generateProvidersFiles`, which returns the pieces separately.

## Why

- **luthersystems/reliable#1588** — Shape-B workaround for the lost imported alias. With this PR, reliable can read `ProvidersUsed` off the compose result and let the alias file flow through the archive naturally rather than re-emitting it on the consumer side.
- **luthersystems/reliable#1577 / #1582** — same root cause, same fix line.

## Backward-compat note

Existing callers reading `Files[\"/providers.tf\"]` now get a smaller file that no longer contains alias blocks. If any caller depends on the old monolithic shape, they need to switch to reading the new `/providers-aliases.tf` / `/providers-imported.tf` sibling files.

The only known consumer (reliable) reads `Files` as a map and copies every entry verbatim into the archive, so the split is transparent there — the additional files just land in the archive alongside the existing ones.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/composer/... -count=1` — 2143 passed (was 2138; +5 new tests)
- [x] `golangci-lint run ./pkg/composer/...` — no new issues introduced (6 pre-existing issues in untouched files: `defaults.go`, `address.go`, `registry_test.go`, `imported_provenance_test.go`)
- [x] New `providers_split_test.go` covers: default-only emission, `us_east_1` landing in aliases, AWS+GCP imported flows surfacing the correct `ProvidersUsed` keys, and the backward-compat invariant for callers that ignore the new field
- [x] Existing tests in `imported_compose_test.go` and `compose_stack_test.go` updated to assert against the new file layout (including `NotContains` guards so a regression putting aliases back into `/providers.tf` fails loudly)
- [ ] Smoke-test on reliable side by bumping `go.mod` to this commit (follow-up PR)