### PR TITLE
feat(awsdiscover): parallelize DiscoverTypes service walk

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -13,7 +13,8 @@
 // Discoverers in this package own narrow client interfaces so unit tests
 // can mock the SDK boundary without depending on real AWS credentials.
 // The aggregator (AWSDiscoverer) wires real SDK clients in production and
-// fans out to the registered per-type discoverers.
+// fans out to the registered per-type discoverers concurrently under a
+// bounded errgroup (defaultDiscoverTypesConcurrency).
 package awsdiscover
 
 import (
@@ -24,10 +25,22 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
+
+// defaultDiscoverTypesConcurrency caps the number of per-service
+// discoverers DiscoverTypes runs concurrently. Each selected
+// Discoverer already has its own internal bounded fan-out for per-item
+// SDK calls (tag fetches, GetResource walks); this constant bounds the
+// service-level layer on top. 8 is conservative — the dominant
+// per-service discoverers (cloud-control, dynamodb, lambda) issue
+// hundreds of API calls each, so service-level fan-out gives wall-time
+// wins from overlapping the slow services without multiplying the
+// account-wide AWS API rate by the registered-type count.
+const defaultDiscoverTypesConcurrency = 8
 
 // ErrNotSupported signals that a discoverer cannot resolve a given ID
 // (e.g. an ARN whose service portion does not match this discoverer's
@@ -367,16 +380,22 @@ func (a *AWSDiscoverer) DiscoverByID(ctx context.Context, tfType, id, region, ac
 	return d.DiscoverByID(ctx, id, region, accountID)
 }
 
-// DiscoverTypes runs each named discoverer in series and concatenates the
-// results. Unknown type names are reported as a single error containing all
-// invalid names (not interleaved with partial results) so the operator sees
-// the full set of misspellings in one shot.
+// DiscoverTypes runs the selected per-service discoverers concurrently
+// under a bounded errgroup (default concurrency:
+// defaultDiscoverTypesConcurrency). Per-item concurrency already lives
+// inside each discoverer (tag-fanout, sub-resource walks); adding
+// service-level fan-out shortens wall time for multi-service imports
+// without changing per-service throttle behavior. Unknown type names
+// are still reported as a single error containing all invalid names
+// (not interleaved with partial results) so the operator sees the full
+// set of misspellings in one shot.
 //
-// The aggregator itself is sequential across resource types — concurrency
-// lives inside individual discoverers (DynamoDB, Lambda) where per-item
-// tag-fanout dominates wall time. Stage 2c2 (#270) bounded that fanout via
-// errgroup; the SDK retryer config in cmd/insideout-import/discover.go
-// raises maxAttempts so transient Throttling no longer aborts a run.
+// Selection order is preserved in the returned slice: each goroutine
+// writes into its own pre-allocated index, so a flatten-after-Wait
+// keeps results deterministic without a mutex. Errors propagate via
+// errgroup's fail-fast semantics — the first per-service error cancels
+// sibling goroutines and is returned wrapped as
+// "<ResourceType>: <err>", matching the pre-parallelization shape.
 //
 // Multi-region (#291): each per-service Discover loops args.Regions
 // internally and builds per-region SDK clients via the configured
@@ -427,13 +446,30 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	}
 
 	stageStart := time.Now()
-	var all []imported.ImportedResource
-	for _, d := range selected {
-		entries, err := d.Discover(ctx, args)
-		if err != nil {
-			return nil, fmt.Errorf("%s: %w", d.ResourceType(), err)
-		}
-		all = append(all, entries...)
+	results := make([][]imported.ImportedResource, len(selected))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(defaultDiscoverTypesConcurrency)
+	for i, d := range selected {
+		i, d := i, d
+		g.Go(func() error {
+			entries, err := d.Discover(gctx, args)
+			if err != nil {
+				return fmt.Errorf("%s: %w", d.ResourceType(), err)
+			}
+			results[i] = entries
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	var total int
+	for _, r := range results {
+		total += len(r)
+	}
+	all := make([]imported.ImportedResource, 0, total)
+	for _, r := range results {
+		all = append(all, r...)
 	}
 	args.Emitter.StageFinish("discover", len(all), time.Since(stageStart))
 	return all, nil

--- a/cmd/insideout-import/awsdiscover/awsdiscover_parallel_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_parallel_test.go
@@ -1,0 +1,178 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// sleepDiscoverer is a Discoverer whose Discover blocks for sleep before
+// returning out. Used by the concurrency tests to assert that
+// DiscoverTypes runs services in parallel: two sleepers of D each should
+// finish in ~D total, not 2*D.
+type sleepDiscoverer struct {
+	t           string
+	out         []imported.ImportedResource
+	err         error
+	sleep       time.Duration
+	concurrent  *int32 // running count; max ever observed via atomic CAS
+	maxObserved *int32 // monotonic max of concurrent observations
+}
+
+func (s *sleepDiscoverer) ResourceType() string { return s.t }
+
+func (s *sleepDiscoverer) Discover(ctx context.Context, _ DiscoverArgs) ([]imported.ImportedResource, error) {
+	if s.concurrent != nil {
+		n := atomic.AddInt32(s.concurrent, 1)
+		defer atomic.AddInt32(s.concurrent, -1)
+		// Track high-water mark via CAS loop.
+		for {
+			cur := atomic.LoadInt32(s.maxObserved)
+			if n <= cur || atomic.CompareAndSwapInt32(s.maxObserved, cur, n) {
+				break
+			}
+		}
+	}
+	select {
+	case <-time.After(s.sleep):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.out, nil
+}
+
+func (s *sleepDiscoverer) DiscoverByID(_ context.Context, _, _, _ string) (imported.ImportedResource, error) {
+	return imported.ImportedResource{}, ErrNotSupported
+}
+
+// TestDiscoverTypes_RunsServicesConcurrently asserts that DiscoverTypes
+// fans out across registered services rather than running them
+// sequentially. Two 50ms sleepers should complete in well under the
+// sequential lower bound of 100ms.
+func TestDiscoverTypes_RunsServicesConcurrently(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive; skip in -short")
+	}
+	t.Parallel()
+
+	var concurrent, maxObserved int32
+	const per = 50 * time.Millisecond
+	a := &sleepDiscoverer{
+		t:           "type_a",
+		out:         []imported.ImportedResource{ir("a1")},
+		sleep:       per,
+		concurrent:  &concurrent,
+		maxObserved: &maxObserved,
+	}
+	b := &sleepDiscoverer{
+		t:           "type_b",
+		out:         []imported.ImportedResource{ir("b1")},
+		sleep:       per,
+		concurrent:  &concurrent,
+		maxObserved: &maxObserved,
+	}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a, "type_b": b}}
+
+	start := time.Now()
+	got, err := agg.DiscoverTypes(context.Background(), []string{"type_a", "type_b"}, argsBasic())
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Generous bound: sequential would be >=100ms; parallel should be ~50ms.
+	// 80ms gives plenty of headroom for slow CI without losing the signal.
+	if elapsed >= 80*time.Millisecond {
+		t.Errorf("DiscoverTypes elapsed=%v, want <80ms (parallel) — looks sequential", elapsed)
+	}
+	// At some point both goroutines must have been running simultaneously.
+	if atomic.LoadInt32(&maxObserved) < 2 {
+		t.Errorf("maxObserved=%d, want >=2 (services should run concurrently)", maxObserved)
+	}
+	if len(got) != 2 {
+		t.Errorf("len(got)=%d, want 2", len(got))
+	}
+	// Selection order is preserved: results for type_a precede type_b.
+	if got[0].Identity.Address != "a1" || got[1].Identity.Address != "b1" {
+		t.Errorf("result order not preserved: got %s, %s; want a1, b1",
+			got[0].Identity.Address, got[1].Identity.Address)
+	}
+}
+
+// TestDiscoverTypes_PreservesSelectionOrderWithFan_Out — even with
+// concurrent execution, the returned slice is in the order callers
+// passed types. This matters because dep-chase and downstream stages
+// rely on the deterministic per-type grouping in the manifest.
+func TestDiscoverTypes_PreservesSelectionOrderWithFan_Out(t *testing.T) {
+	t.Parallel()
+	// Three services with varying out lengths. Selection order is
+	// c, a, b — the returned slice should group [c-items..., a-items..., b-items...].
+	a := &fakeDiscoverer{t: "type_a", out: []imported.ImportedResource{ir("a1"), ir("a2")}}
+	b := &fakeDiscoverer{t: "type_b", out: []imported.ImportedResource{ir("b1")}}
+	c := &fakeDiscoverer{t: "type_c", out: []imported.ImportedResource{ir("c1"), ir("c2"), ir("c3")}}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a, "type_b": b, "type_c": c}}
+
+	got, err := agg.DiscoverTypes(context.Background(), []string{"type_c", "type_a", "type_b"}, argsBasic())
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotAddrs := make([]string, len(got))
+	for i, r := range got {
+		gotAddrs[i] = r.Identity.Address
+	}
+	want := []string{"c1", "c2", "c3", "a1", "a2", "b1"}
+	if !reflect.DeepEqual(gotAddrs, want) {
+		t.Errorf("result order = %v, want %v (selection order: c, a, b)", gotAddrs, want)
+	}
+}
+
+// TestDiscoverTypes_FailFastCancelsSiblings — when one per-service
+// discoverer returns an error, the errgroup context cancels its
+// siblings so they return promptly instead of running to completion.
+func TestDiscoverTypes_FailFastCancelsSiblings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive; skip in -short")
+	}
+	t.Parallel()
+	// type_a fails immediately; type_b would sleep 500ms but should
+	// observe ctx.Done() and bail out fast.
+	a := &sleepDiscoverer{t: "type_a", sleep: 0, err: errors.New("boom")}
+	b := &sleepDiscoverer{t: "type_b", sleep: 500 * time.Millisecond}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a, "type_b": b}}
+
+	start := time.Now()
+	_, err := agg.DiscoverTypes(context.Background(), []string{"type_a", "type_b"}, argsBasic())
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected error from failing discoverer")
+	}
+	// Sequential or non-cancelling parallel would wait the full 500ms;
+	// a properly-wired errgroup cancels the sibling well under that.
+	if elapsed >= 250*time.Millisecond {
+		t.Errorf("elapsed=%v, want <250ms — sibling should have been cancelled fast", elapsed)
+	}
+}
+
+// TestDiscoverTypes_ErrorWrapShapeMatchesPreParallel pins the error
+// shape so callers grepping for "<resource_type>: <cause>" keep working
+// post-parallelization.
+func TestDiscoverTypes_ErrorWrapShapeMatchesPreParallel(t *testing.T) {
+	t.Parallel()
+	a := &fakeDiscoverer{t: "type_a", err: errors.New("Throttling")}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a}}
+	_, err := agg.DiscoverTypes(context.Background(), nil, argsBasic())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	want := "type_a: Throttling"
+	if err.Error() != want {
+		t.Errorf("err=%q, want %q", err.Error(), want)
+	}
+}


### PR DESCRIPTION
## Summary

- Wrap the top-level service loop in `(*AWSDiscoverer).DiscoverTypes` in a bounded `errgroup.WithContext` (limit 8, `defaultDiscoverTypesConcurrency`). Per-item concurrency already lived inside each discoverer; service-level parallelism is what was missing.
- Preserve selection order in the returned slice by giving each goroutine a pre-allocated result slot — no mutex on the result aggregation.
- Keep error semantics identical (`"<resource_type>: <err>"` wrap shape; fail-fast cancels siblings via the errgroup context).
- Refresh the doc comment to drop the "sequential across resource types" claim and explain the new contract.

## Why

The aggregator's serial walk was a known limitation called out in the package doc. For a 12-AWS-service import, wall time was sum-of-services instead of max-of-services, even though the heavy services (cloud-control fan-out, DynamoDB, Lambda) all have their own internal concurrency. Reliable's importer wizard UI already advertises "Walking 12 AWS service APIs in parallel" — this brings the implementation in line.

## Safety audit

- Per-service `Discover` implementations build their own SDK clients per call and own their internal mutex/errgroup state — verified across the cloud-control discoverer, apigatewayv2_stage, bedrock_guardrail. No package-level mutable state shared across discoverers.
- `progress.JSONEmitter` is already `sync.Mutex`-guarded (per the package doc + `write` method). Concurrent `ServiceStart/ServiceFinish/ItemFound` from parallel discoverer goroutines is safe; no emitter changes needed.

## Test plan

- [x] `go test ./cmd/insideout-import/awsdiscover/... -count=1 -race` — 956 tests pass
- [x] `go test -race ./...` (full module) — 5112 tests pass across 34 packages
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./cmd/insideout-import/awsdiscover/...` — no new issues in changed files
- [x] New tests cover: concurrent execution (50ms sleepers complete in <80ms), result-order preservation across fan-out, fail-fast sibling cancellation on per-service error, unchanged error-wrap shape

## Follow-up

Downstream bump of the `insideout-terraform-presets` pin in `luthersystems/reliable`'s `go.mod` is a separate PR after this lands + a tag is published.

Closes #628
