### PR TITLE
fix(composer): co-emit bootstrap_role_arn / external_id as /variables-imported.tf (#630)

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -716,12 +716,21 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// sandbox-infrastructure-template wrapper) keep their own
 	// /providers.tf via PRESERVE_PATTERNS while the alias declarations
 	// slip through as sibling files — see luthersystems/reliable#1588.
+	//
+	// /variables-imported.tf carries the variable declarations that the
+	// AWS branch's assume_role dynamic block references
+	// (`bootstrap_role_arn`, `external_id`). They live in a sibling file
+	// rather than /providers.tf for the same PRESERVE_PATTERNS reason —
+	// see issue #630.
 	files["/providers.tf"] = providersFiles.Main
 	if len(providersFiles.Aliases) > 0 {
 		files["/providers-aliases.tf"] = providersFiles.Aliases
 	}
 	if len(providersFiles.Imported) > 0 {
 		files["/providers-imported.tf"] = providersFiles.Imported
+	}
+	if len(providersFiles.Variables) > 0 {
+		files["/variables-imported.tf"] = providersFiles.Variables
 	}
 
 	// Validator dispatcher — runs after the stack is fully composed, before
@@ -809,15 +818,27 @@ type providersTFInput struct {
 // doesn't produce — but keep the nil contract so callers can rely on a
 // non-nil slice meaning "write this file").
 //
+// Variables carries the `variable "bootstrap_role_arn" {}` and
+// `variable "external_id" {}` declarations consumed by the assume_role
+// dynamic block that the AWS branch threads through Main / Aliases /
+// Imported. Co-located in this sibling file (rather than left in Main)
+// because the runtime wrapper's PRESERVE_PATTERNS filter drops the
+// composer's Main while keeping the wrapper's own /providers.tf stub —
+// the Imported / Aliases siblings reference these vars, so the
+// declarations must live in a sibling file that survives the filter.
+// Nil when the cloud branch doesn't reference these vars (today: GCP).
+// See issue #630 for the production bug this split fixes.
+//
 // The split lets archive packagers (e.g. reliable's
 // sandbox-infrastructure-template wrapper) preserve the wrapper's own
 // providers.tf while still receiving the alias declarations as sibling
 // files that don't collide with the wrapper's PRESERVE_PATTERNS filter.
 // See luthersystems/reliable#1588 for the production bug this split fixes.
 type providersTFFiles struct {
-	Main     []byte
-	Aliases  []byte
-	Imported []byte
+	Main      []byte
+	Aliases   []byte
+	Imported  []byte
+	Variables []byte
 }
 
 // generateProvidersTF generates cloud-specific provider configuration.
@@ -834,6 +855,13 @@ type providersTFFiles struct {
 func generateProvidersTF(in providersTFInput) []byte {
 	pf := generateProvidersFiles(in)
 	var b []byte
+	// Variables must come before the provider blocks that reference them —
+	// terraform tolerates declaration order within a module, but the
+	// concatenated single-file form is read by humans (and a few legacy
+	// substring tests) where declaration-first is conventional.
+	if len(pf.Variables) > 0 {
+		b = append(b, pf.Variables...)
+	}
 	b = append(b, pf.Main...)
 	if len(pf.Aliases) > 0 {
 		b = append(b, pf.Aliases...)
@@ -983,7 +1011,14 @@ variable "external_id" {
 		maps.Copy(required, discovered)
 
 		var main strings.Builder
-		main.WriteString(awsVarDecls)
+		// NOTE: awsVarDecls is emitted into the Variables slot (→
+		// /variables-imported.tf) so it survives the runtime wrapper's
+		// PRESERVE_PATTERNS rsync filter, which drops the composer-emitted
+		// /providers.tf while keeping the wrapper's own stub. Both Aliases
+		// (us_east_1) and Imported (aws.imported) reference these vars via
+		// awsDynamicAssumeRole, and they're the sibling files that DO
+		// survive the filter — co-locating the declarations there keeps
+		// terraform plan resolvable on the deployed module. See issue #630.
 		main.WriteString("terraform {\n  required_providers {\n")
 		main.WriteString(renderRequiredProviders(required))
 		main.WriteString("  }\n}\n\n")
@@ -1022,9 +1057,10 @@ variable "external_id" {
 		fmt.Fprintf(&imp, "provider \"aws\" {\n  alias  = \"imported\"\n  region = %q%s\n}\n", region, awsDynamicAssumeRole)
 
 		return providersTFFiles{
-			Main:     []byte(main.String()),
-			Aliases:  aliases,
-			Imported: []byte(imp.String()),
+			Main:      []byte(main.String()),
+			Aliases:   aliases,
+			Imported:  []byte(imp.String()),
+			Variables: []byte(awsVarDecls),
 		}
 	}
 }

--- a/pkg/composer/providers_split_test.go
+++ b/pkg/composer/providers_split_test.go
@@ -201,6 +201,92 @@ func TestGenerateProvidersTF_WithImportedGCP(t *testing.T) {
 		"ProvidersUsed[aws] must be false on a GCP-only compose: %v", res.ProvidersUsed)
 }
 
+// TestGenerateProvidersTF_AWSVariablesImportedDeclared locks in the issue-#630
+// regression: on every AWS compose, the `bootstrap_role_arn` and `external_id`
+// variable declarations must land in /variables-imported.tf (a sibling file),
+// NOT in /providers.tf — because the runtime wrapper's PRESERVE_PATTERNS rsync
+// filter drops the composer's /providers.tf while preserving the wrapper's own
+// stub. The sibling alias files (/providers-aliases.tf, /providers-imported.tf)
+// reference these vars via the assume_role dynamic block, so the declarations
+// must survive the same filter or `terraform plan` fails with:
+//
+//	Error: Reference to undeclared input variable
+//	  on providers-imported.tf line 7, in provider "aws":
+//	   7:     for_each = var.bootstrap_role_arn != "" ? [1] : []
+//
+// See:
+//   - luthersystems/insideout-terraform-presets#630 (this fix)
+//   - luthersystems/sandbox-infrastructure-template#111 (the PRESERVE_PATTERNS contract)
+//   - luthersystems/reliable#1588 (the original archive-packager split)
+func TestGenerateProvidersTF_AWSVariablesImportedDeclared(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS", AWSVPC: "Private VPC"},
+		Cfg:          &Config{},
+		Project:      "p",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// The declarations live in /variables-imported.tf — a sibling that
+	// survives the wrapper's PRESERVE_PATTERNS rsync filter.
+	require.Contains(t, res.Files, "/variables-imported.tf",
+		"every AWS compose must emit /variables-imported.tf for the assume_role dynamic block's vars")
+	vars := string(res.Files["/variables-imported.tf"])
+	assert.Contains(t, vars, `variable "bootstrap_role_arn"`,
+		"/variables-imported.tf must declare bootstrap_role_arn")
+	assert.Contains(t, vars, `variable "external_id"`,
+		"/variables-imported.tf must declare external_id")
+
+	// They must NOT live in /providers.tf — that file is dropped by the
+	// wrapper's PRESERVE_PATTERNS filter. Putting them here would let
+	// non-wrapper direct-archive paths see them but leave wrapper-mode
+	// terraform plan broken (the original #630 bug).
+	prov := string(res.Files["/providers.tf"])
+	assert.NotContains(t, prov, `variable "bootstrap_role_arn"`,
+		"bootstrap_role_arn declaration must NOT live in /providers.tf — that file is dropped by the wrapper's PRESERVE_PATTERNS filter (#630)")
+	assert.NotContains(t, prov, `variable "external_id"`,
+		"external_id declaration must NOT live in /providers.tf — that file is dropped by the wrapper's PRESERVE_PATTERNS filter (#630)")
+
+	// And the surviving sibling alias files reference these vars — confirm
+	// the resolution graph is complete: declarations in a surviving sibling,
+	// references in surviving siblings.
+	importedTF := string(res.Files["/providers-imported.tf"])
+	assert.Contains(t, importedTF, `var.bootstrap_role_arn`,
+		"sanity: /providers-imported.tf must reference var.bootstrap_role_arn (else this regression test is meaningless)")
+}
+
+// TestGenerateProvidersTF_GCPNoVariablesImported pins the symmetric invariant
+// for GCP: the imported alias for google / google-beta does NOT use an
+// assume_role dynamic block (GCP doesn't use AWS-style cross-account role
+// assumption), so /variables-imported.tf must not emit. Guards against an
+// accidental "always emit on every cloud" refactor.
+func TestGenerateProvidersTF_GCPNoVariablesImported(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPVPC},
+		Comps:        &Components{Cloud: "GCP"},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-central1",
+		GCPProjectID: "demo-project-12345",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	_, has := res.Files["/variables-imported.tf"]
+	assert.False(t, has,
+		"GCP composes don't reference bootstrap_role_arn/external_id — /variables-imported.tf must not emit")
+}
+
 // TestComposeStackResult_ProvidersUsed_BackwardCompat pins that the new
 // ProvidersUsed field is additive: callers that ignore it still see the
 // same Files map and Issues list they always saw. This guards against an


### PR DESCRIPTION
## Summary

Splits the `variable "bootstrap_role_arn" {}` and `variable "external_id" {}` declarations out of the composer's `/providers.tf` (Main) and into a new sibling `/variables-imported.tf` so they survive the runtime wrapper's `PRESERVE_PATTERNS` rsync filter — which drops the composer-emitted `/providers.tf` while preserving the wrapper's own stub.

Closes #630.

## Why

Production bug on staging — `/import` plan fails at `custom-stack-provision`:

```
Error: Reference to undeclared input variable

  on providers-imported.tf line 7, in provider "aws":
   7:     for_each = var.bootstrap_role_arn != "" ? [1] : []
```

PR #627 split the monolithic `/providers.tf` into three files so the wrapper's PRESERVE_PATTERNS filter could drop the composer's Main file while letting `/providers-aliases.tf` and `/providers-imported.tf` slip through. But the AWS-branch `awsVarDecls` constant — which declares `bootstrap_role_arn` and `external_id` — stayed in the Main file via `main.WriteString(awsVarDecls)`. Both surviving siblings reference those vars via the shared `awsDynamicAssumeRole` constant, so the deployed module ends up with references to undeclared variables.

## Fix

| File | Before | After |
|---|---|---|
| `/providers.tf` | `awsVarDecls` + `terraform{}` + default provider | `terraform{}` + default provider |
| `/providers-aliases.tf` | (unchanged — `us_east_1` alias) | (unchanged) |
| `/providers-imported.tf` | (unchanged — `aws.imported` alias) | (unchanged) |
| `/variables-imported.tf` | **— new —** | `variable "bootstrap_role_arn" {}` + `variable "external_id" {}` |

`generateProvidersFiles` gains a fourth output slot (`Variables`), populated only on the AWS branch (GCP doesn't use `assume_role`). `composeStackImpl` writes it to `/variables-imported.tf` when non-empty.

The legacy `generateProvidersTF()` concatenation entry point now emits all four pieces in declaration-first order (Variables → Main → Aliases → Imported) so existing substring tests against the monolithic shape stay green.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/composer/... -count=1` — 2143 passed (existing) + 2 new regression tests
- [x] `go test ./... -count=1` — 5099 passed across 36 packages
- [x] `golangci-lint run ./pkg/composer/...` — no new issues introduced (6 pre-existing issues in untouched files: same set noted in PR #627)
- [x] Manual: `TestGenerateProvidersTF_AWSVariablesImportedDeclared` and `TestGenerateProvidersTF_GCPNoVariablesImported` both pass

New test coverage:

- **`TestGenerateProvidersTF_AWSVariablesImportedDeclared`** — every AWS compose emits `/variables-imported.tf` declaring both vars; neither var declaration appears in `/providers.tf` (the dropped-by-wrapper file); `/providers-imported.tf` still references `var.bootstrap_role_arn` (sanity check that the test isn't trivially passing).
- **`TestGenerateProvidersTF_GCPNoVariablesImported`** — GCP composes do NOT emit `/variables-imported.tf` (no `assume_role` dynamic block, no reference to those vars).

## Backward-compat

Additive: the legacy `generateProvidersTF` byte slice still contains the var declarations (just emitted before the `terraform{}` block now instead of nowhere). Callers reading `Files` as a map see one new entry on AWS composes. The only known consumer (reliable's `composeTFArchiveDirect`) iterates `Files` verbatim, so the new file naturally lands in the archive alongside its siblings.

## Cross-repo follow-up

After this merges + a new pseudo-version is tagged: bump reliable's `go.mod` (same pattern as PR #1598).

## References

- luthersystems/insideout-terraform-presets#630 (this issue)
- #627 — the original providers.tf split that left the var declarations behind
- luthersystems/sandbox-infrastructure-template#111 — the PRESERVE_PATTERNS literal-match contract
- luthersystems/reliable#1588 — the original archive-packager bug that motivated the split