### PR TITLE
fix(awsdiscover): rate-limit parallel DiscoverTypes walk to avoid CloudControl throttle

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"sort"
 	"time"
 
@@ -35,12 +36,27 @@ import (
 // discoverers DiscoverTypes runs concurrently. Each selected
 // Discoverer already has its own internal bounded fan-out for per-item
 // SDK calls (tag fetches, GetResource walks); this constant bounds the
-// service-level layer on top. 8 is conservative — the dominant
-// per-service discoverers (cloud-control, dynamodb, lambda) issue
-// hundreds of API calls each, so service-level fan-out gives wall-time
-// wins from overlapping the slow services without multiplying the
-// account-wide AWS API rate by the registered-type count.
-const defaultDiscoverTypesConcurrency = 8
+// service-level layer on top.
+//
+// Originally 8 (#629); lowered to 4 (#632) after staging hit a
+// ThrottlingException from CloudControl ListResources during the
+// broad scan. 8 simultaneous t=0 kickoffs, each with internal
+// per-service fan-out, exceeded CloudControl's per-account rate
+// budget. 4 still gives ~4× wall-time savings over sequential
+// without multiplying account-wide QPS by the registered-type count.
+// See also: defaultDiscoverStartupJitterMax for the per-goroutine
+// jitter applied before the first AWS call.
+const defaultDiscoverTypesConcurrency = 4
+
+// defaultDiscoverStartupJitterMax bounds the random sleep applied
+// before each per-service goroutine's first AWS call. Without
+// jitter, all N goroutines kick off at t=0 and their first
+// ListResources / Describe* calls land in the same burst, lighting
+// up the per-region CloudControl rate-limiter (#632). 500ms gives
+// the SDK retryer's adaptive token bucket room to spread the load
+// without materially extending wall time (a typical broad scan
+// takes tens of seconds).
+const defaultDiscoverStartupJitterMax = 500 * time.Millisecond
 
 // ErrNotSupported signals that a discoverer cannot resolve a given ID
 // (e.g. an ARN whose service portion does not match this discoverer's
@@ -124,6 +140,19 @@ type AWSDiscoverer struct {
 	// existing per-type ordering one PR at a time. Mirrors
 	// gcpdiscover.GCPDiscoverer.byTypeEnricher (presets#403).
 	byTypeEnricher map[string]AttributeEnricher
+	// startupJitter caps the random per-goroutine sleep applied
+	// before the first AWS call inside DiscoverTypes (#632). Set to
+	// defaultDiscoverStartupJitterMax by the production constructors;
+	// tests override to 0 (disable) or a tiny value to keep wall time
+	// short while still asserting jitter is applied.
+	startupJitter time.Duration
+	// jitterSleep is the seam DiscoverTypes calls before each
+	// goroutine's first per-service Discover. Defaults to
+	// time.Sleep; tests inject a fake that records the per-goroutine
+	// sleep durations so jitter behavior can be asserted without
+	// spinning real wall time. Each call receives the sampled
+	// duration for that goroutine.
+	jitterSleep func(time.Duration)
 }
 
 // NewAWSDiscoverer wires up the production set of AWS discoverers with the
@@ -298,6 +327,8 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 		byType:         byType,
 		rgtPrefetcher:  newRealRGTPrefetcher(cfg),
 		byTypeEnricher: byTypeEnricher,
+		startupJitter:  defaultDiscoverStartupJitterMax,
+		jitterSleep:    time.Sleep,
 	}
 }
 
@@ -449,9 +480,39 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	results := make([][]imported.ImportedResource, len(selected))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(defaultDiscoverTypesConcurrency)
+	// Per-goroutine startup jitter (#632). Without this, all N
+	// service goroutines unblock at t=0 and their first
+	// ListResources / Describe* calls land in the same burst,
+	// lighting up the per-region CloudControl rate-limiter. Each
+	// goroutine sleeps a uniformly-random duration in
+	// [0, a.startupJitter) before its first AWS call, spreading the
+	// initial wave so per-service requests don't all align at t=0.
+	//
+	// The sample is drawn here (deterministic-per-goroutine via the
+	// goroutine's index into the rand stream) and the actual sleep is
+	// performed via a.jitterSleep so tests can record the requested
+	// durations without spinning real wall time.
+	jitterSleep := a.jitterSleep
+	if jitterSleep == nil {
+		jitterSleep = time.Sleep
+	}
+	jitterMax := a.startupJitter
 	for i, d := range selected {
 		i, d := i, d
+		var delay time.Duration
+		if jitterMax > 0 {
+			delay = time.Duration(rand.Int63n(int64(jitterMax)))
+		}
 		g.Go(func() error {
+			if delay > 0 {
+				jitterSleep(delay)
+			}
+			// Cancellation check after jitter so a fail-fast sibling
+			// can short-circuit the slowest-jittered goroutines
+			// before they fire any AWS calls.
+			if err := gctx.Err(); err != nil {
+				return err
+			}
 			entries, err := d.Discover(gctx, args)
 			if err != nil {
 				return fmt.Errorf("%s: %w", d.ResourceType(), err)

--- a/cmd/insideout-import/awsdiscover/awsdiscover_parallel_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_parallel_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
@@ -55,13 +58,21 @@ func (s *sleepDiscoverer) DiscoverByID(_ context.Context, _, _, _ string) (impor
 
 // TestDiscoverTypes_RunsServicesConcurrently asserts that DiscoverTypes
 // fans out across registered services rather than running them
-// sequentially. Two 50ms sleepers should complete in well under the
-// sequential lower bound of 100ms.
+// sequentially. Concurrency was lowered from 8 → 4 in #632 to avoid
+// CloudControl throttling; with two 50ms sleepers and limit≥2 the
+// parallel wall time stays well under the sequential lower bound of
+// 100ms. Jitter is left at the zero-value default for this bare
+// &AWSDiscoverer{} (no NewAWSDiscoverer call), so it can't widen the
+// wall-time window.
 func TestDiscoverTypes_RunsServicesConcurrently(t *testing.T) {
 	if testing.Short() {
 		t.Skip("timing-sensitive; skip in -short")
 	}
 	t.Parallel()
+
+	if defaultDiscoverTypesConcurrency < 2 {
+		t.Fatalf("defaultDiscoverTypesConcurrency=%d; this test requires >=2 to assert parallel execution", defaultDiscoverTypesConcurrency)
+	}
 
 	var concurrent, maxObserved int32
 	const per = 50 * time.Millisecond
@@ -174,5 +185,168 @@ func TestDiscoverTypes_ErrorWrapShapeMatchesPreParallel(t *testing.T) {
 	want := "type_a: Throttling"
 	if err.Error() != want {
 		t.Errorf("err=%q, want %q", err.Error(), want)
+	}
+}
+
+// TestDiscoverTypes_ConcurrencyCappedAtDefault pins
+// defaultDiscoverTypesConcurrency (= 4 per #632, lowered from 8 in
+// #629) by registering more services than the cap and asserting the
+// observed-concurrent max never exceeds the limit. Catches an
+// accidental g.SetLimit() drop or a future bump that re-introduces
+// the CloudControl throttle observed in #632.
+func TestDiscoverTypes_ConcurrencyCappedAtDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive; skip in -short")
+	}
+	t.Parallel()
+
+	// Pin the expected cap. If the constant changes intentionally,
+	// update the literal here so the failure mode is obvious.
+	const wantCap = 4
+	if defaultDiscoverTypesConcurrency != wantCap {
+		t.Fatalf("defaultDiscoverTypesConcurrency=%d, want %d — if you intentionally changed the cap, update this test and TestProductionLoadConfig retry pins to match (#632)", defaultDiscoverTypesConcurrency, wantCap)
+	}
+
+	const services = wantCap * 2 // 8: enough to expose any cap > wantCap
+	var concurrent, maxObserved int32
+	byType := make(map[string]Discoverer, services)
+	types := make([]string, 0, services)
+	for i := 0; i < services; i++ {
+		name := "type_" + string(rune('a'+i))
+		byType[name] = &sleepDiscoverer{
+			t:           name,
+			out:         []imported.ImportedResource{ir(name + "1")},
+			sleep:       30 * time.Millisecond,
+			concurrent:  &concurrent,
+			maxObserved: &maxObserved,
+		}
+		types = append(types, name)
+	}
+	agg := &AWSDiscoverer{byType: byType}
+
+	if _, err := agg.DiscoverTypes(context.Background(), types, argsBasic()); err != nil {
+		t.Fatal(err)
+	}
+	got := atomic.LoadInt32(&maxObserved)
+	if int(got) > wantCap {
+		t.Errorf("maxObserved=%d, want <=%d (cap exceeded — g.SetLimit(defaultDiscoverTypesConcurrency) regressed)", got, wantCap)
+	}
+	// And it must have actually saturated the cap — otherwise the
+	// test isn't asserting anything (e.g. accidental serialization
+	// would also satisfy <=cap).
+	if int(got) < wantCap {
+		t.Errorf("maxObserved=%d, want ==%d (services should saturate the cap; if not, fan-out is broken)", got, wantCap)
+	}
+}
+
+// TestDiscoverTypes_StartupJitterApplied asserts that DiscoverTypes
+// stagger-starts its per-service goroutines via the jitterSleep seam
+// (#632). Without jitter all N goroutines fire their first AWS calls
+// at t=0, which is what triggered the CloudControl ThrottlingException
+// observed in staging. We assert:
+//
+//   - jitterSleep is called once per goroutine
+//   - the sampled durations span a non-trivial fraction of the jitter
+//     window (i.e. they aren't all zero — Int63n(0) panics so the
+//     production code guards on startupJitter > 0)
+//   - every sampled duration is within [0, startupJitter)
+func TestDiscoverTypes_StartupJitterApplied(t *testing.T) {
+	t.Parallel()
+
+	const services = 8
+	const jitterWindow = 100 * time.Millisecond
+
+	var mu sync.Mutex
+	var slept []time.Duration
+	recorder := func(d time.Duration) {
+		mu.Lock()
+		slept = append(slept, d)
+		mu.Unlock()
+	}
+
+	byType := make(map[string]Discoverer, services)
+	types := make([]string, 0, services)
+	for i := 0; i < services; i++ {
+		name := "type_" + string(rune('a'+i))
+		byType[name] = &fakeDiscoverer{t: name, out: []imported.ImportedResource{ir(name + "1")}}
+		types = append(types, name)
+	}
+	agg := &AWSDiscoverer{
+		byType:        byType,
+		startupJitter: jitterWindow,
+		jitterSleep:   recorder,
+	}
+
+	if _, err := agg.DiscoverTypes(context.Background(), types, argsBasic()); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	got := append([]time.Duration(nil), slept...)
+	mu.Unlock()
+
+	// Production samples a non-zero delay per goroutine; the recorder is
+	// only invoked when delay > 0. Across 8 goroutines drawing from a
+	// 100ms window, the probability of all 8 sampling exactly 0 is
+	// effectively zero (sampling resolution is nanoseconds), so we
+	// expect ~services entries. Allow for the rare zero by requiring at
+	// least services/2 + 1 recorded sleeps — comfortably above noise.
+	if len(got) < services/2+1 {
+		t.Errorf("jitterSleep called %d times across %d goroutines, want >=%d — jitter likely not applied (all delays 0?)", len(got), services, services/2+1)
+	}
+	// Every recorded duration must lie in [0, jitterWindow). Anything
+	// outside means rand.Int63n was called with a different bound or
+	// the duration arithmetic regressed.
+	for _, d := range got {
+		if d < 0 || d >= jitterWindow {
+			t.Errorf("recorded jitter delay=%v out of [0, %v)", d, jitterWindow)
+		}
+	}
+}
+
+// TestDiscoverTypes_StartupJitterDisabledWhenZero is the inverse
+// guard: setting startupJitter=0 must skip the rand.Int63n call (it
+// panics on 0) AND must not call jitterSleep. This is the shape every
+// existing test in the suite gets by default — they construct a bare
+// &AWSDiscoverer{} with the zero-value startupJitter, and the previous
+// (#629) parallel wall-time bound depends on no jitter being inserted.
+func TestDiscoverTypes_StartupJitterDisabledWhenZero(t *testing.T) {
+	t.Parallel()
+
+	var sleeps int32
+	recorder := func(time.Duration) { atomic.AddInt32(&sleeps, 1) }
+
+	a := &fakeDiscoverer{t: "type_a", out: []imported.ImportedResource{ir("a1")}}
+	b := &fakeDiscoverer{t: "type_b", out: []imported.ImportedResource{ir("b1")}}
+	agg := &AWSDiscoverer{
+		byType:        map[string]Discoverer{"type_a": a, "type_b": b},
+		startupJitter: 0,
+		jitterSleep:   recorder,
+	}
+
+	if _, err := agg.DiscoverTypes(context.Background(), []string{"type_a", "type_b"}, argsBasic()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := atomic.LoadInt32(&sleeps); got != 0 {
+		t.Errorf("jitterSleep called %d times with startupJitter=0, want 0", got)
+	}
+}
+
+// TestNewAWSDiscoverer_DefaultsJitterFields pins that the production
+// constructor wires both jitter fields. Without this, a future refactor
+// of NewAWSDiscovererWithConcurrency that drops the startupJitter /
+// jitterSleep assignments would silently disable the throttle
+// mitigation — every production call would skip the jitter sample
+// because startupJitter == 0.
+func TestNewAWSDiscoverer_DefaultsJitterFields(t *testing.T) {
+	t.Parallel()
+
+	d := NewAWSDiscovererWithConcurrency(aws.Config{}, 1)
+	if d.startupJitter != defaultDiscoverStartupJitterMax {
+		t.Errorf("startupJitter=%v, want %v", d.startupJitter, defaultDiscoverStartupJitterMax)
+	}
+	if d.jitterSleep == nil {
+		t.Errorf("jitterSleep is nil; constructor must wire time.Sleep")
 	}
 }

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -70,6 +70,16 @@ var (
 // stage budgets above can absorb.
 const discoverRetryMaxAttempts = 8
 
+// discoverRetryMode pins the SDK retryer to v2's adaptive mode (#632).
+// The default `standard` mode uses exponential backoff + jitter, which
+// reacts to ThrottlingException after the fact. Adaptive mode adds a
+// client-side token bucket that *proactively* slows the send rate when
+// the server signals throttling, which is the right shape for the
+// parallel DiscoverTypes walk (#629): per-service goroutines share the
+// same per-region CloudControl rate budget, so a feedback signal from
+// one goroutine's 400 should slow the others' first calls too.
+const discoverRetryMode = aws.RetryModeAdaptive
+
 // discoveryAggregator is the small subset of awsdiscover.AWSDiscoverer
 // (and gcpdiscover.GCPDiscoverer) the orchestrator needs. Defining the
 // interface in main lets tests inject a fake aggregator without standing
@@ -247,6 +257,7 @@ func productionDiscoverDeps() discoverDeps {
 			opts := []func(*config.LoadOptions) error{
 				config.WithRegion(region),
 				config.WithRetryMaxAttempts(discoverRetryMaxAttempts),
+				config.WithRetryMode(discoverRetryMode),
 			}
 			if endpointURL != "" {
 				opts = append(opts, config.WithBaseEndpoint(endpointURL))

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -1466,6 +1466,30 @@ func TestProductionDiscoverDeps_LoadConfigSetsRetryMaxAttempts(t *testing.T) {
 	}
 }
 
+// TestProductionDiscoverDeps_LoadConfigSetsRetryModeAdaptive pins that
+// the production loadConfig path threads aws.RetryModeAdaptive onto
+// the resulting aws.Config (#632). The default RetryMode is "standard"
+// (post-hoc exponential+jitter); adaptive adds a client-side token
+// bucket that slows the send rate proactively when the server signals
+// throttling, which is the right behavior for the parallel
+// DiscoverTypes walk (#629) where per-service goroutines share the
+// same per-region CloudControl rate budget.
+//
+// Pinning the literal "adaptive" (not the constant) is intentional —
+// a mutation that re-points discoverRetryMode to RetryModeStandard
+// must fail this test.
+func TestProductionDiscoverDeps_LoadConfigSetsRetryModeAdaptive(t *testing.T) {
+	t.Parallel()
+	deps := productionDiscoverDeps()
+	cfg, err := deps.loadConfig(context.Background(), "us-east-1", "")
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.RetryMode != aws.RetryModeAdaptive {
+		t.Errorf("aws.Config.RetryMode=%q, want %q (constant discoverRetryMode must be threaded through productionDiscoverDeps.loadConfig — see #632)", cfg.RetryMode, aws.RetryModeAdaptive)
+	}
+}
+
 // TestProductionDiscoverDeps_LoadConfigBaseEndpoint pins how the
 // endpointURL parameter reaches aws.Config.BaseEndpoint across the
 // flag/env precedence matrix that the orchestrator-level table test


### PR DESCRIPTION
## Summary

Staging hit `ThrottlingException` from AWS CloudControl `ListResources` during the parallel `DiscoverTypes` walk introduced in #629. Concurrency 8 + simultaneous t=0 kickoff + per-service internal fan-out exceeded CloudControl's per-account rate budget on the broad-scan path.

Three coordinated mitigations:

- **Lower concurrency** — `defaultDiscoverTypesConcurrency` `8` → `4`. Each per-service discoverer already has its own internal bounded fan-out for per-item SDK calls; the service-level layer on top doesn't need to be as wide. Still ~4× wall-time savings vs sequential without multiplying account-wide QPS by the registered-type count.
- **Startup jitter** — new `jitterSleep` / `startupJitter` seam on `AWSDiscoverer` (default 500ms window, `time.Sleep`). Each per-service goroutine sleeps a uniformly-random duration in `[0, startupJitter)` before its first AWS call so the initial fan-out wave doesn't align at t=0. Cancellation is re-checked after the jitter so a fail-fast sibling can short-circuit the slowest-jittered goroutines before they fire any SDK calls.
- **Adaptive retry** — pin SDK retryer to `aws.RetryModeAdaptive` in `productionDiscoverDeps.loadConfig`. The default `standard` mode reacts to throttling post-hoc via exponential+jitter; adaptive adds a client-side token bucket that proactively slows the send rate, which is the right shape for the parallel walk where goroutines share the same per-region CloudControl budget. Keeps `WithRetryMaxAttempts(8)`.

## Tests

- `TestDiscoverTypes_ConcurrencyCappedAtDefault` — registers 2× services, asserts max-observed concurrency == `defaultDiscoverTypesConcurrency`.
- `TestDiscoverTypes_StartupJitterApplied` — recorder `jitterSleep`, asserts per-goroutine delays drawn from `[0, jitterWindow)` without burning real wall time.
- `TestDiscoverTypes_StartupJitterDisabledWhenZero` — confirms the zero-value path (used by every existing test) skips the sample.
- `TestNewAWSDiscoverer_DefaultsJitterFields` — pins that the production constructor wires both fields, so a future refactor can't silently disable the mitigation.
- `TestProductionDiscoverDeps_LoadConfigSetsRetryModeAdaptive` — sibling to the existing `RetryMaxAttempts` pin.
- Existing wall-time bound in `TestDiscoverTypes_RunsServicesConcurrently` preserved.

## Test plan

- [x] `go test -race ./cmd/insideout-import/awsdiscover/... -count=1` (960 tests, clean)
- [x] `go test -race ./cmd/insideout-import/ -count=1` (204 tests, clean)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] CI green

## Follow-up

After this merges + tags, `reliable` needs a `go.mod` bump on `insideout-terraform-presets` to pick this up. Cross-repo, not in scope here.

Closes #632
