### PR TITLE
fix(composer,awsdiscover): /variables-imported.tf + DiscoverTypes rate-limit

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -146,6 +146,15 @@ type AWSDiscoverer struct {
 	// tests override to 0 (disable) or a tiny value to keep wall time
 	// short while still asserting jitter is applied.
 	startupJitter time.Duration
+	// jitterSample produces the per-goroutine startup delay. The
+	// production constructor wires a closure that draws a uniform
+	// sample in [0, startupJitter); tests inject a deterministic
+	// sequence so jitter assertions don't depend on global rand's
+	// seeding policy (math/rand auto-seeds since Go 1.20, but a
+	// future move to math/rand/v2 or an explicit seed would break a
+	// statistical assertion). A nil sampler defaults inside
+	// DiscoverTypes to the same closure shape.
+	jitterSample func() time.Duration
 	// jitterSleep is the seam DiscoverTypes calls before each
 	// goroutine's first per-service Discover. Defaults to
 	// time.Sleep; tests inject a fake that records the per-goroutine
@@ -153,6 +162,17 @@ type AWSDiscoverer struct {
 	// spinning real wall time. Each call receives the sampled
 	// duration for that goroutine.
 	jitterSleep func(time.Duration)
+}
+
+// defaultJitterSample returns a uniformly-random delay in
+// [0, a.startupJitter). Returns 0 when startupJitter <= 0, so callers
+// don't have to guard rand.Int63n against a zero/negative bound (it
+// panics on n <= 0). Used as the default for AWSDiscoverer.jitterSample.
+func (a *AWSDiscoverer) defaultJitterSample() time.Duration {
+	if a.startupJitter <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(a.startupJitter)))
 }
 
 // NewAWSDiscoverer wires up the production set of AWS discoverers with the
@@ -322,7 +342,7 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 			ccCfg.TFType, ccCfg.CloudFormationType, nil, normalizer,
 		)
 	}
-	return &AWSDiscoverer{
+	disc := &AWSDiscoverer{
 		defaultRegion:  cfg.Region,
 		byType:         byType,
 		rgtPrefetcher:  newRealRGTPrefetcher(cfg),
@@ -330,6 +350,8 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 		startupJitter:  defaultDiscoverStartupJitterMax,
 		jitterSleep:    time.Sleep,
 	}
+	disc.jitterSample = disc.defaultJitterSample
+	return disc
 }
 
 // serviceSlugByTFType maps a Terraform resource type to the short,
@@ -488,21 +510,20 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	// [0, a.startupJitter) before its first AWS call, spreading the
 	// initial wave so per-service requests don't all align at t=0.
 	//
-	// The sample is drawn here (deterministic-per-goroutine via the
-	// goroutine's index into the rand stream) and the actual sleep is
-	// performed via a.jitterSleep so tests can record the requested
-	// durations without spinning real wall time.
+	// Sampling is delegated to a.jitterSample (defaults to a uniform
+	// draw in [0, a.startupJitter)) and the actual sleep is performed
+	// via a.jitterSleep so tests can inject a deterministic sample
+	// sequence + recorder without spinning real wall time.
 	jitterSleep := a.jitterSleep
 	if jitterSleep == nil {
 		jitterSleep = time.Sleep
 	}
-	jitterMax := a.startupJitter
+	jitterSample := a.jitterSample
+	if jitterSample == nil {
+		jitterSample = a.defaultJitterSample
+	}
 	for i, d := range selected {
-		i, d := i, d
-		var delay time.Duration
-		if jitterMax > 0 {
-			delay = time.Duration(rand.Int63n(int64(jitterMax)))
-		}
+		delay := jitterSample()
 		g.Go(func() error {
 			if delay > 0 {
 				jitterSleep(delay)

--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"sort"
 	"time"
 
@@ -35,12 +36,27 @@ import (
 // discoverers DiscoverTypes runs concurrently. Each selected
 // Discoverer already has its own internal bounded fan-out for per-item
 // SDK calls (tag fetches, GetResource walks); this constant bounds the
-// service-level layer on top. 8 is conservative — the dominant
-// per-service discoverers (cloud-control, dynamodb, lambda) issue
-// hundreds of API calls each, so service-level fan-out gives wall-time
-// wins from overlapping the slow services without multiplying the
-// account-wide AWS API rate by the registered-type count.
-const defaultDiscoverTypesConcurrency = 8
+// service-level layer on top.
+//
+// Originally 8 (#629); lowered to 4 (#632) after staging hit a
+// ThrottlingException from CloudControl ListResources during the
+// broad scan. 8 simultaneous t=0 kickoffs, each with internal
+// per-service fan-out, exceeded CloudControl's per-account rate
+// budget. 4 still gives ~4× wall-time savings over sequential
+// without multiplying account-wide QPS by the registered-type count.
+// See also: defaultDiscoverStartupJitterMax for the per-goroutine
+// jitter applied before the first AWS call.
+const defaultDiscoverTypesConcurrency = 4
+
+// defaultDiscoverStartupJitterMax bounds the random sleep applied
+// before each per-service goroutine's first AWS call. Without
+// jitter, all N goroutines kick off at t=0 and their first
+// ListResources / Describe* calls land in the same burst, lighting
+// up the per-region CloudControl rate-limiter (#632). 500ms gives
+// the SDK retryer's adaptive token bucket room to spread the load
+// without materially extending wall time (a typical broad scan
+// takes tens of seconds).
+const defaultDiscoverStartupJitterMax = 500 * time.Millisecond
 
 // ErrNotSupported signals that a discoverer cannot resolve a given ID
 // (e.g. an ARN whose service portion does not match this discoverer's
@@ -124,6 +140,19 @@ type AWSDiscoverer struct {
 	// existing per-type ordering one PR at a time. Mirrors
 	// gcpdiscover.GCPDiscoverer.byTypeEnricher (presets#403).
 	byTypeEnricher map[string]AttributeEnricher
+	// startupJitter caps the random per-goroutine sleep applied
+	// before the first AWS call inside DiscoverTypes (#632). Set to
+	// defaultDiscoverStartupJitterMax by the production constructors;
+	// tests override to 0 (disable) or a tiny value to keep wall time
+	// short while still asserting jitter is applied.
+	startupJitter time.Duration
+	// jitterSleep is the seam DiscoverTypes calls before each
+	// goroutine's first per-service Discover. Defaults to
+	// time.Sleep; tests inject a fake that records the per-goroutine
+	// sleep durations so jitter behavior can be asserted without
+	// spinning real wall time. Each call receives the sampled
+	// duration for that goroutine.
+	jitterSleep func(time.Duration)
 }
 
 // NewAWSDiscoverer wires up the production set of AWS discoverers with the
@@ -298,6 +327,8 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 		byType:         byType,
 		rgtPrefetcher:  newRealRGTPrefetcher(cfg),
 		byTypeEnricher: byTypeEnricher,
+		startupJitter:  defaultDiscoverStartupJitterMax,
+		jitterSleep:    time.Sleep,
 	}
 }
 
@@ -449,9 +480,39 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	results := make([][]imported.ImportedResource, len(selected))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(defaultDiscoverTypesConcurrency)
+	// Per-goroutine startup jitter (#632). Without this, all N
+	// service goroutines unblock at t=0 and their first
+	// ListResources / Describe* calls land in the same burst,
+	// lighting up the per-region CloudControl rate-limiter. Each
+	// goroutine sleeps a uniformly-random duration in
+	// [0, a.startupJitter) before its first AWS call, spreading the
+	// initial wave so per-service requests don't all align at t=0.
+	//
+	// The sample is drawn here (deterministic-per-goroutine via the
+	// goroutine's index into the rand stream) and the actual sleep is
+	// performed via a.jitterSleep so tests can record the requested
+	// durations without spinning real wall time.
+	jitterSleep := a.jitterSleep
+	if jitterSleep == nil {
+		jitterSleep = time.Sleep
+	}
+	jitterMax := a.startupJitter
 	for i, d := range selected {
 		i, d := i, d
+		var delay time.Duration
+		if jitterMax > 0 {
+			delay = time.Duration(rand.Int63n(int64(jitterMax)))
+		}
 		g.Go(func() error {
+			if delay > 0 {
+				jitterSleep(delay)
+			}
+			// Cancellation check after jitter so a fail-fast sibling
+			// can short-circuit the slowest-jittered goroutines
+			// before they fire any AWS calls.
+			if err := gctx.Err(); err != nil {
+				return err
+			}
 			entries, err := d.Discover(gctx, args)
 			if err != nil {
 				return fmt.Errorf("%s: %w", d.ResourceType(), err)

--- a/cmd/insideout-import/awsdiscover/awsdiscover_parallel_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_parallel_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
@@ -55,13 +58,21 @@ func (s *sleepDiscoverer) DiscoverByID(_ context.Context, _, _, _ string) (impor
 
 // TestDiscoverTypes_RunsServicesConcurrently asserts that DiscoverTypes
 // fans out across registered services rather than running them
-// sequentially. Two 50ms sleepers should complete in well under the
-// sequential lower bound of 100ms.
+// sequentially. Concurrency was lowered from 8 → 4 in #632 to avoid
+// CloudControl throttling; with two 50ms sleepers and limit≥2 the
+// parallel wall time stays well under the sequential lower bound of
+// 100ms. Jitter is left at the zero-value default for this bare
+// &AWSDiscoverer{} (no NewAWSDiscoverer call), so it can't widen the
+// wall-time window.
 func TestDiscoverTypes_RunsServicesConcurrently(t *testing.T) {
 	if testing.Short() {
 		t.Skip("timing-sensitive; skip in -short")
 	}
 	t.Parallel()
+
+	if defaultDiscoverTypesConcurrency < 2 {
+		t.Fatalf("defaultDiscoverTypesConcurrency=%d; this test requires >=2 to assert parallel execution", defaultDiscoverTypesConcurrency)
+	}
 
 	var concurrent, maxObserved int32
 	const per = 50 * time.Millisecond
@@ -174,5 +185,168 @@ func TestDiscoverTypes_ErrorWrapShapeMatchesPreParallel(t *testing.T) {
 	want := "type_a: Throttling"
 	if err.Error() != want {
 		t.Errorf("err=%q, want %q", err.Error(), want)
+	}
+}
+
+// TestDiscoverTypes_ConcurrencyCappedAtDefault pins
+// defaultDiscoverTypesConcurrency (= 4 per #632, lowered from 8 in
+// #629) by registering more services than the cap and asserting the
+// observed-concurrent max never exceeds the limit. Catches an
+// accidental g.SetLimit() drop or a future bump that re-introduces
+// the CloudControl throttle observed in #632.
+func TestDiscoverTypes_ConcurrencyCappedAtDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive; skip in -short")
+	}
+	t.Parallel()
+
+	// Pin the expected cap. If the constant changes intentionally,
+	// update the literal here so the failure mode is obvious.
+	const wantCap = 4
+	if defaultDiscoverTypesConcurrency != wantCap {
+		t.Fatalf("defaultDiscoverTypesConcurrency=%d, want %d — if you intentionally changed the cap, update this test and TestProductionLoadConfig retry pins to match (#632)", defaultDiscoverTypesConcurrency, wantCap)
+	}
+
+	const services = wantCap * 2 // 8: enough to expose any cap > wantCap
+	var concurrent, maxObserved int32
+	byType := make(map[string]Discoverer, services)
+	types := make([]string, 0, services)
+	for i := 0; i < services; i++ {
+		name := "type_" + string(rune('a'+i))
+		byType[name] = &sleepDiscoverer{
+			t:           name,
+			out:         []imported.ImportedResource{ir(name + "1")},
+			sleep:       30 * time.Millisecond,
+			concurrent:  &concurrent,
+			maxObserved: &maxObserved,
+		}
+		types = append(types, name)
+	}
+	agg := &AWSDiscoverer{byType: byType}
+
+	if _, err := agg.DiscoverTypes(context.Background(), types, argsBasic()); err != nil {
+		t.Fatal(err)
+	}
+	got := atomic.LoadInt32(&maxObserved)
+	if int(got) > wantCap {
+		t.Errorf("maxObserved=%d, want <=%d (cap exceeded — g.SetLimit(defaultDiscoverTypesConcurrency) regressed)", got, wantCap)
+	}
+	// And it must have actually saturated the cap — otherwise the
+	// test isn't asserting anything (e.g. accidental serialization
+	// would also satisfy <=cap).
+	if int(got) < wantCap {
+		t.Errorf("maxObserved=%d, want ==%d (services should saturate the cap; if not, fan-out is broken)", got, wantCap)
+	}
+}
+
+// TestDiscoverTypes_StartupJitterApplied asserts that DiscoverTypes
+// stagger-starts its per-service goroutines via the jitterSleep seam
+// (#632). Without jitter all N goroutines fire their first AWS calls
+// at t=0, which is what triggered the CloudControl ThrottlingException
+// observed in staging. We assert:
+//
+//   - jitterSleep is called once per goroutine
+//   - the sampled durations span a non-trivial fraction of the jitter
+//     window (i.e. they aren't all zero — Int63n(0) panics so the
+//     production code guards on startupJitter > 0)
+//   - every sampled duration is within [0, startupJitter)
+func TestDiscoverTypes_StartupJitterApplied(t *testing.T) {
+	t.Parallel()
+
+	const services = 8
+	const jitterWindow = 100 * time.Millisecond
+
+	var mu sync.Mutex
+	var slept []time.Duration
+	recorder := func(d time.Duration) {
+		mu.Lock()
+		slept = append(slept, d)
+		mu.Unlock()
+	}
+
+	byType := make(map[string]Discoverer, services)
+	types := make([]string, 0, services)
+	for i := 0; i < services; i++ {
+		name := "type_" + string(rune('a'+i))
+		byType[name] = &fakeDiscoverer{t: name, out: []imported.ImportedResource{ir(name + "1")}}
+		types = append(types, name)
+	}
+	agg := &AWSDiscoverer{
+		byType:        byType,
+		startupJitter: jitterWindow,
+		jitterSleep:   recorder,
+	}
+
+	if _, err := agg.DiscoverTypes(context.Background(), types, argsBasic()); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	got := append([]time.Duration(nil), slept...)
+	mu.Unlock()
+
+	// Production samples a non-zero delay per goroutine; the recorder is
+	// only invoked when delay > 0. Across 8 goroutines drawing from a
+	// 100ms window, the probability of all 8 sampling exactly 0 is
+	// effectively zero (sampling resolution is nanoseconds), so we
+	// expect ~services entries. Allow for the rare zero by requiring at
+	// least services/2 + 1 recorded sleeps — comfortably above noise.
+	if len(got) < services/2+1 {
+		t.Errorf("jitterSleep called %d times across %d goroutines, want >=%d — jitter likely not applied (all delays 0?)", len(got), services, services/2+1)
+	}
+	// Every recorded duration must lie in [0, jitterWindow). Anything
+	// outside means rand.Int63n was called with a different bound or
+	// the duration arithmetic regressed.
+	for _, d := range got {
+		if d < 0 || d >= jitterWindow {
+			t.Errorf("recorded jitter delay=%v out of [0, %v)", d, jitterWindow)
+		}
+	}
+}
+
+// TestDiscoverTypes_StartupJitterDisabledWhenZero is the inverse
+// guard: setting startupJitter=0 must skip the rand.Int63n call (it
+// panics on 0) AND must not call jitterSleep. This is the shape every
+// existing test in the suite gets by default — they construct a bare
+// &AWSDiscoverer{} with the zero-value startupJitter, and the previous
+// (#629) parallel wall-time bound depends on no jitter being inserted.
+func TestDiscoverTypes_StartupJitterDisabledWhenZero(t *testing.T) {
+	t.Parallel()
+
+	var sleeps int32
+	recorder := func(time.Duration) { atomic.AddInt32(&sleeps, 1) }
+
+	a := &fakeDiscoverer{t: "type_a", out: []imported.ImportedResource{ir("a1")}}
+	b := &fakeDiscoverer{t: "type_b", out: []imported.ImportedResource{ir("b1")}}
+	agg := &AWSDiscoverer{
+		byType:        map[string]Discoverer{"type_a": a, "type_b": b},
+		startupJitter: 0,
+		jitterSleep:   recorder,
+	}
+
+	if _, err := agg.DiscoverTypes(context.Background(), []string{"type_a", "type_b"}, argsBasic()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := atomic.LoadInt32(&sleeps); got != 0 {
+		t.Errorf("jitterSleep called %d times with startupJitter=0, want 0", got)
+	}
+}
+
+// TestNewAWSDiscoverer_DefaultsJitterFields pins that the production
+// constructor wires both jitter fields. Without this, a future refactor
+// of NewAWSDiscovererWithConcurrency that drops the startupJitter /
+// jitterSleep assignments would silently disable the throttle
+// mitigation — every production call would skip the jitter sample
+// because startupJitter == 0.
+func TestNewAWSDiscoverer_DefaultsJitterFields(t *testing.T) {
+	t.Parallel()
+
+	d := NewAWSDiscovererWithConcurrency(aws.Config{}, 1)
+	if d.startupJitter != defaultDiscoverStartupJitterMax {
+		t.Errorf("startupJitter=%v, want %v", d.startupJitter, defaultDiscoverStartupJitterMax)
+	}
+	if d.jitterSleep == nil {
+		t.Errorf("jitterSleep is nil; constructor must wire time.Sleep")
 	}
 }

--- a/cmd/insideout-import/awsdiscover/awsdiscover_parallel_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_parallel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -211,7 +212,7 @@ func TestDiscoverTypes_ConcurrencyCappedAtDefault(t *testing.T) {
 	var concurrent, maxObserved int32
 	byType := make(map[string]Discoverer, services)
 	types := make([]string, 0, services)
-	for i := 0; i < services; i++ {
+	for i := range services {
 		name := "type_" + string(rune('a'+i))
 		byType[name] = &sleepDiscoverer{
 			t:           name,
@@ -223,6 +224,13 @@ func TestDiscoverTypes_ConcurrencyCappedAtDefault(t *testing.T) {
 		types = append(types, name)
 	}
 	agg := &AWSDiscoverer{byType: byType}
+	// This test depends on the bare &AWSDiscoverer{} zero-value
+	// startupJitter so no [0, 500ms) sleep widens the parallel-saturation
+	// window. If a future refactor moves jitter to a struct-default, the
+	// 30ms sleep budget here is no longer enough to guarantee saturation.
+	if agg.startupJitter != 0 {
+		t.Fatalf("agg.startupJitter=%v, want 0 (test depends on zero-value default)", agg.startupJitter)
+	}
 
 	if _, err := agg.DiscoverTypes(context.Background(), types, argsBasic()); err != nil {
 		t.Fatal(err)
@@ -239,22 +247,50 @@ func TestDiscoverTypes_ConcurrencyCappedAtDefault(t *testing.T) {
 	}
 }
 
-// TestDiscoverTypes_StartupJitterApplied asserts that DiscoverTypes
-// stagger-starts its per-service goroutines via the jitterSleep seam
-// (#632). Without jitter all N goroutines fire their first AWS calls
-// at t=0, which is what triggered the CloudControl ThrottlingException
-// observed in staging. We assert:
+// TestDiscoverTypes_StartupJitterApplied asserts DiscoverTypes
+// stagger-starts its per-service goroutines via the jitterSample +
+// jitterSleep seams (#632). Without jitter all N goroutines fire
+// their first AWS calls at t=0, which is what triggered the
+// CloudControl ThrottlingException observed in staging.
 //
-//   - jitterSleep is called once per goroutine
-//   - the sampled durations span a non-trivial fraction of the jitter
-//     window (i.e. they aren't all zero — Int63n(0) panics so the
-//     production code guards on startupJitter > 0)
-//   - every sampled duration is within [0, startupJitter)
+// We inject a deterministic sample sequence so the count and value
+// assertions are exact (no statistical lower bound, no dependency on
+// math/rand's seeding policy). The sequence includes one zero entry
+// to pin the production code's `if delay > 0 { jitterSleep(...) }`
+// guard, one near-zero, one near-window-max, and a mid-range — so a
+// mutation that shrinks the window or skips the sleep is loud.
 func TestDiscoverTypes_StartupJitterApplied(t *testing.T) {
 	t.Parallel()
 
-	const services = 8
 	const jitterWindow = 100 * time.Millisecond
+	// One sample per service. Order matches the alphabetic byType
+	// iteration order DiscoverTypes uses via its `selected` slice
+	// (DiscoverTypes sorts internally), so the recorder sees the
+	// non-zero entries in this order regardless of goroutine
+	// scheduling.
+	sequence := []time.Duration{
+		0,                        // pins the `if delay > 0` guard — must NOT be recorded
+		1 * time.Microsecond,     // near-zero, MUST be recorded
+		50 * time.Millisecond,    // mid-range, MUST be recorded
+		99 * time.Millisecond,    // near-window-max — catches a shrunk-window mutation
+		25 * time.Millisecond,    // mid-range
+		75 * time.Millisecond,    // mid-range
+		10 * time.Millisecond,    // near-zero+, MUST be recorded
+		jitterWindow - time.Nanosecond, // [0, window) boundary
+	}
+	services := len(sequence)
+	wantSlept := make([]time.Duration, 0, services)
+	for _, d := range sequence {
+		if d > 0 {
+			wantSlept = append(wantSlept, d)
+		}
+	}
+
+	var sampleIdx int32
+	sampler := func() time.Duration {
+		i := atomic.AddInt32(&sampleIdx, 1) - 1
+		return sequence[i]
+	}
 
 	var mu sync.Mutex
 	var slept []time.Duration
@@ -266,7 +302,7 @@ func TestDiscoverTypes_StartupJitterApplied(t *testing.T) {
 
 	byType := make(map[string]Discoverer, services)
 	types := make([]string, 0, services)
-	for i := 0; i < services; i++ {
+	for i := range services {
 		name := "type_" + string(rune('a'+i))
 		byType[name] = &fakeDiscoverer{t: name, out: []imported.ImportedResource{ir(name + "1")}}
 		types = append(types, name)
@@ -274,6 +310,7 @@ func TestDiscoverTypes_StartupJitterApplied(t *testing.T) {
 	agg := &AWSDiscoverer{
 		byType:        byType,
 		startupJitter: jitterWindow,
+		jitterSample:  sampler,
 		jitterSleep:   recorder,
 	}
 
@@ -281,50 +318,81 @@ func TestDiscoverTypes_StartupJitterApplied(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Sampler called exactly once per service (in the parent loop
+	// before each g.Go) — pin the count to catch a mutation that
+	// drops the sample or moves it inside a conditional.
+	if got := atomic.LoadInt32(&sampleIdx); int(got) != services {
+		t.Errorf("jitterSample called %d times, want %d (once per service)", got, services)
+	}
+
 	mu.Lock()
 	got := append([]time.Duration(nil), slept...)
 	mu.Unlock()
 
-	// Production samples a non-zero delay per goroutine; the recorder is
-	// only invoked when delay > 0. Across 8 goroutines drawing from a
-	// 100ms window, the probability of all 8 sampling exactly 0 is
-	// effectively zero (sampling resolution is nanoseconds), so we
-	// expect ~services entries. Allow for the rare zero by requiring at
-	// least services/2 + 1 recorded sleeps — comfortably above noise.
-	if len(got) < services/2+1 {
-		t.Errorf("jitterSleep called %d times across %d goroutines, want >=%d — jitter likely not applied (all delays 0?)", len(got), services, services/2+1)
+	// Recorder receives exactly the non-zero samples — proves both
+	// (a) the `delay > 0` guard skips the zero entry (catches a
+	// mutation that always sleeps, slowing the broad scan by
+	// median-of-window per goroutine) and (b) every non-zero sample
+	// is faithfully forwarded (catches a mutation that drops the
+	// sleep entirely, re-introducing the aligned t=0 burst).
+	if len(got) != len(wantSlept) {
+		t.Fatalf("jitterSleep called %d times, want %d (one per non-zero sample)", len(got), len(wantSlept))
 	}
-	// Every recorded duration must lie in [0, jitterWindow). Anything
-	// outside means rand.Int63n was called with a different bound or
-	// the duration arithmetic regressed.
-	for _, d := range got {
-		if d < 0 || d >= jitterWindow {
-			t.Errorf("recorded jitter delay=%v out of [0, %v)", d, jitterWindow)
+	// Order isn't goroutine-deterministic, so compare as multisets.
+	slices.Sort(got)
+	slices.Sort(wantSlept)
+	for i, d := range got {
+		if d != wantSlept[i] {
+			t.Errorf("jitterSleep[%d]=%v, want %v (slept=%v, wantSlept=%v)", i, d, wantSlept[i], got, wantSlept)
 		}
 	}
 }
 
-// TestDiscoverTypes_StartupJitterDisabledWhenZero is the inverse
-// guard: setting startupJitter=0 must skip the rand.Int63n call (it
-// panics on 0) AND must not call jitterSleep. This is the shape every
-// existing test in the suite gets by default — they construct a bare
-// &AWSDiscoverer{} with the zero-value startupJitter, and the previous
-// (#629) parallel wall-time bound depends on no jitter being inserted.
+// TestDiscoverTypes_StartupJitterDisabledWhenZero pins two coupled
+// invariants for the startupJitter=0 path — the shape every existing
+// test in the suite gets by default (bare &AWSDiscoverer{} with the
+// zero-value startupJitter, on which the #629 parallel wall-time
+// bound depends):
+//
+//  1. defaultJitterSample MUST return 0 (not call rand.Int63n with
+//     a zero/negative bound — that panics).
+//  2. With the default sampler returning 0, jitterSleep is never
+//     called.
+//
+// The recover() block proves the panic-guard is real; the recorder
+// count proves the `if delay > 0` guard skips the sleep. Both
+// together catch a mutation that drops either guard.
 func TestDiscoverTypes_StartupJitterDisabledWhenZero(t *testing.T) {
 	t.Parallel()
 
+	// Invariant 1: the default sampler must not panic when
+	// startupJitter is zero. A naive `rand.Int63n(0)` would.
+	agg := &AWSDiscoverer{startupJitter: 0}
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("defaultJitterSample panicked at startupJitter=0: %v — production code must guard rand.Int63n against n<=0", r)
+			}
+		}()
+		if d := agg.defaultJitterSample(); d != 0 {
+			t.Errorf("defaultJitterSample()=%v at startupJitter=0, want 0", d)
+		}
+	}()
+
+	// Invariant 2: with the default sampler returning 0, no
+	// jitterSleep call is issued.
 	var sleeps int32
 	recorder := func(time.Duration) { atomic.AddInt32(&sleeps, 1) }
 
 	a := &fakeDiscoverer{t: "type_a", out: []imported.ImportedResource{ir("a1")}}
 	b := &fakeDiscoverer{t: "type_b", out: []imported.ImportedResource{ir("b1")}}
-	agg := &AWSDiscoverer{
+	agg2 := &AWSDiscoverer{
 		byType:        map[string]Discoverer{"type_a": a, "type_b": b},
 		startupJitter: 0,
 		jitterSleep:   recorder,
 	}
 
-	if _, err := agg.DiscoverTypes(context.Background(), []string{"type_a", "type_b"}, argsBasic()); err != nil {
+	if _, err := agg2.DiscoverTypes(context.Background(), []string{"type_a", "type_b"}, argsBasic()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -334,11 +402,18 @@ func TestDiscoverTypes_StartupJitterDisabledWhenZero(t *testing.T) {
 }
 
 // TestNewAWSDiscoverer_DefaultsJitterFields pins that the production
-// constructor wires both jitter fields. Without this, a future refactor
-// of NewAWSDiscovererWithConcurrency that drops the startupJitter /
-// jitterSleep assignments would silently disable the throttle
-// mitigation — every production call would skip the jitter sample
-// because startupJitter == 0.
+// constructor wires all three jitter fields to their throttle-
+// mitigation defaults. Without this, a future refactor of
+// NewAWSDiscovererWithConcurrency that drops the startupJitter /
+// jitterSleep / jitterSample assignments would silently disable the
+// mitigation — every production call would either skip the jitter
+// sample (startupJitter == 0) or skip the sleep (jitterSleep == nil
+// is recovered to time.Sleep, but a non-nil no-op wiring would not be).
+//
+// The function-identity assertion via reflect.ValueOf().Pointer()
+// catches a mutation that wires a no-op (e.g. jitterSleep = func(time.Duration){})
+// — a plain nil-check would happily accept that and silently disable
+// the production jitter.
 func TestNewAWSDiscoverer_DefaultsJitterFields(t *testing.T) {
 	t.Parallel()
 
@@ -347,6 +422,24 @@ func TestNewAWSDiscoverer_DefaultsJitterFields(t *testing.T) {
 		t.Errorf("startupJitter=%v, want %v", d.startupJitter, defaultDiscoverStartupJitterMax)
 	}
 	if d.jitterSleep == nil {
-		t.Errorf("jitterSleep is nil; constructor must wire time.Sleep")
+		t.Fatalf("jitterSleep is nil; constructor must wire time.Sleep")
+	}
+	// Function-identity check: confirm the constructor wired the
+	// real time.Sleep, not a no-op stub that would silently disable
+	// the per-goroutine startup delay. reflect-comparing the code
+	// pointer is the standard idiom for this (Go funcs aren't ==
+	// comparable in source).
+	wantSleep := reflect.ValueOf(time.Sleep).Pointer()
+	gotSleep := reflect.ValueOf(d.jitterSleep).Pointer()
+	if gotSleep != wantSleep {
+		t.Errorf("jitterSleep is not time.Sleep (got pointer=%x, want %x) — a no-op stub would silently disable the #632 mitigation", gotSleep, wantSleep)
+	}
+	if d.jitterSample == nil {
+		t.Fatalf("jitterSample is nil; constructor must wire defaultJitterSample")
+	}
+	wantSample := reflect.ValueOf(d.defaultJitterSample).Pointer()
+	gotSample := reflect.ValueOf(d.jitterSample).Pointer()
+	if gotSample != wantSample {
+		t.Errorf("jitterSample is not d.defaultJitterSample (got pointer=%x, want %x)", gotSample, wantSample)
 	}
 }

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -70,6 +70,16 @@ var (
 // stage budgets above can absorb.
 const discoverRetryMaxAttempts = 8
 
+// discoverRetryMode pins the SDK retryer to v2's adaptive mode (#632).
+// The default `standard` mode uses exponential backoff + jitter, which
+// reacts to ThrottlingException after the fact. Adaptive mode adds a
+// client-side token bucket that *proactively* slows the send rate when
+// the server signals throttling, which is the right shape for the
+// parallel DiscoverTypes walk (#629): per-service goroutines share the
+// same per-region CloudControl rate budget, so a feedback signal from
+// one goroutine's 400 should slow the others' first calls too.
+const discoverRetryMode = aws.RetryModeAdaptive
+
 // discoveryAggregator is the small subset of awsdiscover.AWSDiscoverer
 // (and gcpdiscover.GCPDiscoverer) the orchestrator needs. Defining the
 // interface in main lets tests inject a fake aggregator without standing
@@ -247,6 +257,7 @@ func productionDiscoverDeps() discoverDeps {
 			opts := []func(*config.LoadOptions) error{
 				config.WithRegion(region),
 				config.WithRetryMaxAttempts(discoverRetryMaxAttempts),
+				config.WithRetryMode(discoverRetryMode),
 			}
 			if endpointURL != "" {
 				opts = append(opts, config.WithBaseEndpoint(endpointURL))

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -1475,9 +1475,12 @@ func TestProductionDiscoverDeps_LoadConfigSetsRetryMaxAttempts(t *testing.T) {
 // DiscoverTypes walk (#629) where per-service goroutines share the
 // same per-region CloudControl rate budget.
 //
-// Pinning the literal "adaptive" (not the constant) is intentional —
-// a mutation that re-points discoverRetryMode to RetryModeStandard
-// must fail this test.
+// Pinning against `aws.RetryModeAdaptive` (the SDK constant, imported
+// independently of the production `discoverRetryMode` constant) is
+// intentional — re-reading the production constant would make this
+// test tautological. A mutation that re-points discoverRetryMode to
+// RetryModeStandard fails here because the SDK-imported expectation
+// stays "adaptive".
 func TestProductionDiscoverDeps_LoadConfigSetsRetryModeAdaptive(t *testing.T) {
 	t.Parallel()
 	deps := productionDiscoverDeps()

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -1466,6 +1466,30 @@ func TestProductionDiscoverDeps_LoadConfigSetsRetryMaxAttempts(t *testing.T) {
 	}
 }
 
+// TestProductionDiscoverDeps_LoadConfigSetsRetryModeAdaptive pins that
+// the production loadConfig path threads aws.RetryModeAdaptive onto
+// the resulting aws.Config (#632). The default RetryMode is "standard"
+// (post-hoc exponential+jitter); adaptive adds a client-side token
+// bucket that slows the send rate proactively when the server signals
+// throttling, which is the right behavior for the parallel
+// DiscoverTypes walk (#629) where per-service goroutines share the
+// same per-region CloudControl rate budget.
+//
+// Pinning the literal "adaptive" (not the constant) is intentional —
+// a mutation that re-points discoverRetryMode to RetryModeStandard
+// must fail this test.
+func TestProductionDiscoverDeps_LoadConfigSetsRetryModeAdaptive(t *testing.T) {
+	t.Parallel()
+	deps := productionDiscoverDeps()
+	cfg, err := deps.loadConfig(context.Background(), "us-east-1", "")
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.RetryMode != aws.RetryModeAdaptive {
+		t.Errorf("aws.Config.RetryMode=%q, want %q (constant discoverRetryMode must be threaded through productionDiscoverDeps.loadConfig — see #632)", cfg.RetryMode, aws.RetryModeAdaptive)
+	}
+}
+
 // TestProductionDiscoverDeps_LoadConfigBaseEndpoint pins how the
 // endpointURL parameter reaches aws.Config.BaseEndpoint across the
 // flag/env precedence matrix that the orchestrator-level table test

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -716,12 +716,21 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// sandbox-infrastructure-template wrapper) keep their own
 	// /providers.tf via PRESERVE_PATTERNS while the alias declarations
 	// slip through as sibling files — see luthersystems/reliable#1588.
+	//
+	// /variables-imported.tf carries the variable declarations that the
+	// AWS branch's assume_role dynamic block references
+	// (`bootstrap_role_arn`, `external_id`). They live in a sibling file
+	// rather than /providers.tf for the same PRESERVE_PATTERNS reason —
+	// see issue #630.
 	files["/providers.tf"] = providersFiles.Main
 	if len(providersFiles.Aliases) > 0 {
 		files["/providers-aliases.tf"] = providersFiles.Aliases
 	}
 	if len(providersFiles.Imported) > 0 {
 		files["/providers-imported.tf"] = providersFiles.Imported
+	}
+	if len(providersFiles.Variables) > 0 {
+		files["/variables-imported.tf"] = providersFiles.Variables
 	}
 
 	// Validator dispatcher — runs after the stack is fully composed, before
@@ -809,15 +818,27 @@ type providersTFInput struct {
 // doesn't produce — but keep the nil contract so callers can rely on a
 // non-nil slice meaning "write this file").
 //
+// Variables carries the `variable "bootstrap_role_arn" {}` and
+// `variable "external_id" {}` declarations consumed by the assume_role
+// dynamic block that the AWS branch threads through Main / Aliases /
+// Imported. Co-located in this sibling file (rather than left in Main)
+// because the runtime wrapper's PRESERVE_PATTERNS filter drops the
+// composer's Main while keeping the wrapper's own /providers.tf stub —
+// the Imported / Aliases siblings reference these vars, so the
+// declarations must live in a sibling file that survives the filter.
+// Nil when the cloud branch doesn't reference these vars (today: GCP).
+// See issue #630 for the production bug this split fixes.
+//
 // The split lets archive packagers (e.g. reliable's
 // sandbox-infrastructure-template wrapper) preserve the wrapper's own
 // providers.tf while still receiving the alias declarations as sibling
 // files that don't collide with the wrapper's PRESERVE_PATTERNS filter.
 // See luthersystems/reliable#1588 for the production bug this split fixes.
 type providersTFFiles struct {
-	Main     []byte
-	Aliases  []byte
-	Imported []byte
+	Main      []byte
+	Aliases   []byte
+	Imported  []byte
+	Variables []byte
 }
 
 // generateProvidersTF generates cloud-specific provider configuration.
@@ -834,6 +855,13 @@ type providersTFFiles struct {
 func generateProvidersTF(in providersTFInput) []byte {
 	pf := generateProvidersFiles(in)
 	var b []byte
+	// Variables must come before the provider blocks that reference them —
+	// terraform tolerates declaration order within a module, but the
+	// concatenated single-file form is read by humans (and a few legacy
+	// substring tests) where declaration-first is conventional.
+	if len(pf.Variables) > 0 {
+		b = append(b, pf.Variables...)
+	}
 	b = append(b, pf.Main...)
 	if len(pf.Aliases) > 0 {
 		b = append(b, pf.Aliases...)
@@ -983,7 +1011,14 @@ variable "external_id" {
 		maps.Copy(required, discovered)
 
 		var main strings.Builder
-		main.WriteString(awsVarDecls)
+		// NOTE: awsVarDecls is emitted into the Variables slot (→
+		// /variables-imported.tf) so it survives the runtime wrapper's
+		// PRESERVE_PATTERNS rsync filter, which drops the composer-emitted
+		// /providers.tf while keeping the wrapper's own stub. Both Aliases
+		// (us_east_1) and Imported (aws.imported) reference these vars via
+		// awsDynamicAssumeRole, and they're the sibling files that DO
+		// survive the filter — co-locating the declarations there keeps
+		// terraform plan resolvable on the deployed module. See issue #630.
 		main.WriteString("terraform {\n  required_providers {\n")
 		main.WriteString(renderRequiredProviders(required))
 		main.WriteString("  }\n}\n\n")
@@ -1022,9 +1057,10 @@ variable "external_id" {
 		fmt.Fprintf(&imp, "provider \"aws\" {\n  alias  = \"imported\"\n  region = %q%s\n}\n", region, awsDynamicAssumeRole)
 
 		return providersTFFiles{
-			Main:     []byte(main.String()),
-			Aliases:  aliases,
-			Imported: []byte(imp.String()),
+			Main:      []byte(main.String()),
+			Aliases:   aliases,
+			Imported:  []byte(imp.String()),
+			Variables: []byte(awsVarDecls),
 		}
 	}
 }

--- a/pkg/composer/providers_split_test.go
+++ b/pkg/composer/providers_split_test.go
@@ -201,6 +201,92 @@ func TestGenerateProvidersTF_WithImportedGCP(t *testing.T) {
 		"ProvidersUsed[aws] must be false on a GCP-only compose: %v", res.ProvidersUsed)
 }
 
+// TestGenerateProvidersTF_AWSVariablesImportedDeclared locks in the issue-#630
+// regression: on every AWS compose, the `bootstrap_role_arn` and `external_id`
+// variable declarations must land in /variables-imported.tf (a sibling file),
+// NOT in /providers.tf — because the runtime wrapper's PRESERVE_PATTERNS rsync
+// filter drops the composer's /providers.tf while preserving the wrapper's own
+// stub. The sibling alias files (/providers-aliases.tf, /providers-imported.tf)
+// reference these vars via the assume_role dynamic block, so the declarations
+// must survive the same filter or `terraform plan` fails with:
+//
+//	Error: Reference to undeclared input variable
+//	  on providers-imported.tf line 7, in provider "aws":
+//	   7:     for_each = var.bootstrap_role_arn != "" ? [1] : []
+//
+// See:
+//   - luthersystems/insideout-terraform-presets#630 (this fix)
+//   - luthersystems/sandbox-infrastructure-template#111 (the PRESERVE_PATTERNS contract)
+//   - luthersystems/reliable#1588 (the original archive-packager split)
+func TestGenerateProvidersTF_AWSVariablesImportedDeclared(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS", AWSVPC: "Private VPC"},
+		Cfg:          &Config{},
+		Project:      "p",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// The declarations live in /variables-imported.tf — a sibling that
+	// survives the wrapper's PRESERVE_PATTERNS rsync filter.
+	require.Contains(t, res.Files, "/variables-imported.tf",
+		"every AWS compose must emit /variables-imported.tf for the assume_role dynamic block's vars")
+	vars := string(res.Files["/variables-imported.tf"])
+	assert.Contains(t, vars, `variable "bootstrap_role_arn"`,
+		"/variables-imported.tf must declare bootstrap_role_arn")
+	assert.Contains(t, vars, `variable "external_id"`,
+		"/variables-imported.tf must declare external_id")
+
+	// They must NOT live in /providers.tf — that file is dropped by the
+	// wrapper's PRESERVE_PATTERNS filter. Putting them here would let
+	// non-wrapper direct-archive paths see them but leave wrapper-mode
+	// terraform plan broken (the original #630 bug).
+	prov := string(res.Files["/providers.tf"])
+	assert.NotContains(t, prov, `variable "bootstrap_role_arn"`,
+		"bootstrap_role_arn declaration must NOT live in /providers.tf — that file is dropped by the wrapper's PRESERVE_PATTERNS filter (#630)")
+	assert.NotContains(t, prov, `variable "external_id"`,
+		"external_id declaration must NOT live in /providers.tf — that file is dropped by the wrapper's PRESERVE_PATTERNS filter (#630)")
+
+	// And the surviving sibling alias files reference these vars — confirm
+	// the resolution graph is complete: declarations in a surviving sibling,
+	// references in surviving siblings.
+	importedTF := string(res.Files["/providers-imported.tf"])
+	assert.Contains(t, importedTF, `var.bootstrap_role_arn`,
+		"sanity: /providers-imported.tf must reference var.bootstrap_role_arn (else this regression test is meaningless)")
+}
+
+// TestGenerateProvidersTF_GCPNoVariablesImported pins the symmetric invariant
+// for GCP: the imported alias for google / google-beta does NOT use an
+// assume_role dynamic block (GCP doesn't use AWS-style cross-account role
+// assumption), so /variables-imported.tf must not emit. Guards against an
+// accidental "always emit on every cloud" refactor.
+func TestGenerateProvidersTF_GCPNoVariablesImported(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "gcp",
+		SelectedKeys: []ComponentKey{KeyGCPVPC},
+		Comps:        &Components{Cloud: "GCP"},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-central1",
+		GCPProjectID: "demo-project-12345",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	_, has := res.Files["/variables-imported.tf"]
+	assert.False(t, has,
+		"GCP composes don't reference bootstrap_role_arn/external_id — /variables-imported.tf must not emit")
+}
+
 // TestComposeStackResult_ProvidersUsed_BackwardCompat pins that the new
 // ProvidersUsed field is additive: callers that ignore it still see the
 // same Files map and Issues list they always saw. This guards against an

--- a/pkg/composer/providers_split_test.go
+++ b/pkg/composer/providers_split_test.go
@@ -285,6 +285,12 @@ func TestGenerateProvidersTF_GCPNoVariablesImported(t *testing.T) {
 	_, has := res.Files["/variables-imported.tf"]
 	assert.False(t, has,
 		"GCP composes don't reference bootstrap_role_arn/external_id — /variables-imported.tf must not emit")
+	// Sanity: GCP compose still produces /providers.tf. Without this,
+	// a mutation that broke GCP provider generation entirely (so Files
+	// was missing both files) would pass the negative assertion above
+	// for the wrong reason.
+	assert.Contains(t, res.Files, "/providers.tf",
+		"GCP compose must still emit /providers.tf — the absence-of-variables-imported assertion above is meaningless if all provider files are missing")
 }
 
 // TestComposeStackResult_ProvidersUsed_BackwardCompat pins that the new


### PR DESCRIPTION
## Summary

Bundles two staging-blocking fixes plus tightened tests:

- **fix(composer): co-emit `bootstrap_role_arn` / `external_id` as `/variables-imported.tf`** (closes #630) — splits the AWS var declarations out of `/providers.tf` (which the runtime wrapper's `PRESERVE_PATTERNS` rsync filter drops) into a sibling file alongside `/providers-aliases.tf` and `/providers-imported.tf` (which the filter preserves). Production reproducer was a `Reference to undeclared input variable` failure on `/import` plan after PR #627.
- **fix(awsdiscover): rate-limit parallel `DiscoverTypes` walk** (closes #632) — staging hit a `ThrottlingException` from CloudControl `ListResources` during the parallel walk added in #629. Three coordinated mitigations: concurrency cap 8 → 4, per-goroutine startup jitter ([0, 500ms) via an injectable `jitterSample` seam), and `aws.RetryModeAdaptive` (client-side token bucket on top of the existing 8-attempt retry budget).
- **test(awsdiscover): tighten jitter tests with deterministic sample seam** — addresses qa-professor review of the #632 tests by replacing the statistical lower-bound on jitter sleep counts with a deterministic sample sequence injected through the new `jitterSample` seam. The sequence pins the `if delay > 0` guard, the near-window-max boundary, and the [0, window) edge so a shrunk-window mutation or a dropped-sleep mutation both fail loudly. Wiring test uses `reflect.ValueOf().Pointer()` identity checks so a no-op-stub mutation is caught.

## Test plan

- [x] `go test ./pkg/composer/... -count=1` — 2145 passed
- [x] `go test -race ./cmd/insideout-import/awsdiscover/... -count=1` — 960 passed
- [x] `go test -race ./cmd/insideout-import/ -count=1` — 204 passed
- [x] `go vet ./...` clean
- [x] `go build ./...` clean

## Review notes

- /review findings: 0 P0/P1 from the initial pass.
- qa-professor findings: 1 P1 + 4 P2 + 2 P3 all addressed in the third commit (`7d9d666`). The P1 was the probabilistic lower-bound on the jitter test; the P2s were the missing panic-guard assertion, the weak nil-check on the constructor wiring test, the missing zero-jitter precondition on the cap test, the misleading "literal" comment on the retry-mode test, and the GCP test's missing positive assertion that `/providers.tf` is still produced.

## Cross-repo follow-up

After this merges + a new pseudo-version is tagged, `reliable` needs a `go.mod` bump on `insideout-terraform-presets` to pick both fixes up (same pattern as PR luthersystems/reliable#1598).

## References

- #630 — bootstrap_role_arn declaration bug
- #632 — CloudControl throttling
- #627 — original providers.tf split that left the var decls behind
- #629 — original parallel DiscoverTypes walk
- luthersystems/sandbox-infrastructure-template#111 — PRESERVE_PATTERNS literal-match contract
- luthersystems/reliable#1588 — original archive-packager bug