### PR TITLE
fix(composer): make Bedrock S3/OpenSearch optional, drop implicit dep

### DIFF
--- a/aws/bedrock/main.tf
+++ b/aws/bedrock/main.tf
@@ -60,42 +60,62 @@ resource "aws_iam_role" "bedrock_kb" {
   }
 }
 
+# The role's inline policy is assembled from one always-on statement plus
+# two optional ones. bedrock:InvokeModel is unconditional — it is the whole
+# point of the role for the plain model-invocation use case, and keeps the
+# policy non-empty (aws_iam_role_policy rejects an empty Statement list).
+# The S3 and AOSS statements are appended only when their ARN is supplied:
+# they are Knowledge Base concerns (an S3 data source to ingest from, an
+# AOSS collection to grant data-plane access on) and have no purpose for a
+# role that only invokes models.
+locals {
+  bedrock_invoke_statement = {
+    Action = [
+      "bedrock:InvokeModel"
+    ]
+    Effect = "Allow"
+    # KB ingestion calls the embedding model; downstream consumers
+    # of the KB typically invoke the chat model through the same role.
+    Resource = [
+      "arn:aws:bedrock:${var.region}::foundation-model/${var.model_id}",
+      "arn:aws:bedrock:${var.region}::foundation-model/${var.embedding_model_id}",
+    ]
+  }
+
+  bedrock_s3_statements = var.s3_bucket_arn == null ? [] : [
+    {
+      Action = [
+        "s3:ListBucket",
+        "s3:GetObject"
+      ]
+      Effect = "Allow"
+      Resource = [
+        var.s3_bucket_arn,
+        "${var.s3_bucket_arn}/*"
+      ]
+    }
+  ]
+
+  bedrock_aoss_statements = var.opensearch_collection_arn == null ? [] : [
+    {
+      Action   = ["aoss:APIAccessAll"]
+      Effect   = "Allow"
+      Resource = var.opensearch_collection_arn
+    }
+  ]
+}
+
 resource "aws_iam_role_policy" "bedrock_kb" {
   name = "${var.project}-bedrock-policy"
   role = aws_iam_role.bedrock_kb.id
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
-      {
-        Action = [
-          "bedrock:InvokeModel"
-        ]
-        Effect = "Allow"
-        # KB ingestion calls the embedding model; downstream consumers
-        # of the KB typically invoke the chat model through the same role.
-        Resource = [
-          "arn:aws:bedrock:${var.region}::foundation-model/${var.model_id}",
-          "arn:aws:bedrock:${var.region}::foundation-model/${var.embedding_model_id}",
-        ]
-      },
-      {
-        Action = [
-          "s3:ListBucket",
-          "s3:GetObject"
-        ]
-        Effect = "Allow"
-        Resource = [
-          var.s3_bucket_arn,
-          "${var.s3_bucket_arn}/*"
-        ]
-      },
-      {
-        Action   = ["aoss:APIAccessAll"]
-        Effect   = "Allow"
-        Resource = var.opensearch_collection_arn
-      }
-    ]
+    Statement = concat(
+      [local.bedrock_invoke_statement],
+      local.bedrock_s3_statements,
+      local.bedrock_aoss_statements,
+    )
   })
 }
 

--- a/aws/bedrock/variables.tf
+++ b/aws/bedrock/variables.tf
@@ -35,15 +35,17 @@ variable "embedding_model_id" {
 
 variable "s3_bucket_arn" {
   type        = string
-  description = "ARN of the S3 bucket the role is granted s3:ListBucket and s3:GetObject on. Required — the Bedrock KB role has no meaningful purpose without an S3 data source."
+  description = "ARN of the S3 bucket the role is granted s3:ListBucket and s3:GetObject on. Optional — set it for the Knowledge Base use case (the role needs an S3 data source to ingest from). Leave null for plain model-invocation use, where the role only needs bedrock:InvokeModel; the S3 policy statement is then omitted entirely."
+  default     = null
 }
 
 variable "opensearch_collection_arn" {
   type        = string
-  description = "ARN of the OpenSearch Serverless (AOSS) collection that backs the Bedrock Knowledge Base vector store. Managed-domain ARNs are not supported by Bedrock. Required — this role exists specifically to grant aoss:APIAccessAll on this collection."
+  description = "ARN of the OpenSearch Serverless (AOSS) collection that backs the Bedrock Knowledge Base vector store. Managed-domain ARNs are not supported by Bedrock. Optional — set it for the Knowledge Base use case (the role grants aoss:APIAccessAll on this collection). Leave null for plain model-invocation use; the AOSS policy statement is then omitted entirely."
+  default     = null
   validation {
-    condition     = can(regex("^arn:aws[a-z-]*:aoss:[a-z0-9-]+:[0-9]{12}:collection/[a-z0-9]+$", var.opensearch_collection_arn))
-    error_message = "opensearch_collection_arn must be an AOSS collection ARN matching arn:aws:aoss:<region>:<account>:collection/<id>."
+    condition     = var.opensearch_collection_arn == null ? true : can(regex("^arn:aws[a-z-]*:aoss:[a-z0-9-]+:[0-9]{12}:collection/[a-z0-9]+$", var.opensearch_collection_arn))
+    error_message = "opensearch_collection_arn must be null or an AOSS collection ARN matching arn:aws:aoss:<region>:<account>:collection/<id>."
   }
 }
 

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -1,19 +1,11 @@
 package composer
 
 import (
-	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	"github.com/stretchr/testify/require"
-)
-
-// awsBedrockCollectionArnRegex mirrors the validation regex baked into
-// aws/bedrock/variables.tf in this repo (landed in #69). If that regex
-// tightens, the preview stub below must also tighten.
-var awsBedrockCollectionArnRegex = regexp.MustCompile(
-	`^arn:aws[a-z-]*:aoss:[a-z0-9-]+:[0-9]{12}:collection/[a-z0-9]+$`,
 )
 
 // These tests cover composer-side wiring for the AOSS/Bedrock preset
@@ -108,54 +100,100 @@ func TestMapper_OpenSearchDeploymentTypeOverride(t *testing.T) {
 	// serverless override).
 }
 
-// TestMapper_BedrockPreviewStub locks in the preview-safe AOSS ARN stub
-// the mapper supplies so ComposeSingle can satisfy the preset's AOSS regex
-// validation and validateRequired.
-func TestMapper_BedrockPreviewStub(t *testing.T) {
+// TestMapper_BedrockNoKBStub confirms the mapper does NOT inject the
+// Knowledge Base inputs (s3_bucket_arn / opensearch_collection_arn) for a
+// Bedrock-only preview. Both preset inputs are optional (default null) since
+// the Bedrock→{S3,OpenSearch} implicit dependency was removed — a plain
+// model-invocation role needs neither. The mapper used to inject a stub
+// AOSS ARN because the inputs were required + regex-validated; that stub is
+// gone.
+func TestMapper_BedrockNoKBStub(t *testing.T) {
 	m := DefaultMapper{}
 
-	t.Run("stub emitted when absent", func(t *testing.T) {
-		vals, err := m.BuildModuleValues(
-			KeyAWSBedrock,
-			&Components{AWSBedrock: ptrBool(true)},
-			&Config{},
-			"demo", "us-east-1",
-		)
-		require.NoError(t, err)
+	vals, err := m.BuildModuleValues(
+		KeyAWSBedrock,
+		&Components{AWSBedrock: ptrBool(true)},
+		&Config{},
+		"demo", "us-east-1",
+	)
+	require.NoError(t, err)
 
-		stub, ok := vals["opensearch_collection_arn"]
-		require.True(t, ok, "mapper must supply opensearch_collection_arn stub for preview")
-		stubStr, isStr := stub.(string)
-		require.True(t, isStr, "stub must be a string")
-		require.True(t, strings.HasPrefix(stubStr, "arn:aws:aoss:"),
-			"stub must be AOSS-shaped (got %q)", stubStr)
-		require.Contains(t, stubStr, ":collection/",
-			"stub must include :collection/ segment required by the preset regex")
-		require.Regexp(t, awsBedrockCollectionArnRegex, stubStr,
-			"stub must satisfy the preset's AOSS-collection-ARN regex exactly")
-
-		// AWS's documentation-placeholder account ID. Pinned to
-		// 123456789012 specifically so a careless refactor to a random
-		// 12-digit value doesn't silently pass the shape regex.
-		require.Contains(t, stubStr, ":123456789012:",
-			"stub account ID must be AWS's documentation placeholder 123456789012")
-	})
+	_, hasOS := vals["opensearch_collection_arn"]
+	require.False(t, hasOS,
+		"mapper must not inject opensearch_collection_arn — it is an optional KB input")
+	_, hasS3 := vals["s3_bucket_arn"]
+	require.False(t, hasS3,
+		"mapper must not inject s3_bucket_arn — it is an optional KB input")
 }
 
-// TestMapper_BedrockPreviewStub_DoesNotOverwrite confirms that in a full
-// stack compose — where DefaultWiring populates `opensearch_collection_arn`
-// with a real `module.aws_opensearch.collection_arn` reference — the mapper
-// does NOT clobber it with the preview stub. `BuildModuleValues` runs
-// before wiring is applied and shares the same `vals` map, so the guard
-// `if _, ok := vals["opensearch_collection_arn"]; !ok { … }` is the
-// invariant to protect. A regression here would put a bogus hardcoded ARN
-// into every deployed Bedrock stack.
-func TestMapper_BedrockPreviewStub_DoesNotOverwrite(t *testing.T) {
-	// Directly exercise the mapper contract: if the key is already
-	// present, don't replace it. We can't easily seed `vals` from outside
-	// BuildModuleValues today, but ComposeStack's wiring does it via
-	// `block.Raw` — so the equivalent test is end-to-end: verify the
-	// composed main.tf has the real reference (not the stub).
+// TestComposeSingle_BedrockOnly_NoKBDepsRequired locks the core fix: a
+// standalone Bedrock module composes without S3 or OpenSearch. Before the
+// inputs were made optional, ComposeSingle(Bedrock) failed validateRequired
+// on the two missing KB ARNs (which is why the mapper stub existed).
+func TestComposeSingle_BedrockOnly_NoKBDepsRequired(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeSingle(ComposeSingleOpts{
+		Cloud:   "aws",
+		Key:     KeyAWSBedrock,
+		Comps:   &Components{AWSBedrock: ptrBool(true)},
+		Cfg:     &Config{},
+		Project: "demo",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err,
+		"ComposeSingle(Bedrock) must succeed with no S3/OpenSearch — KB inputs are optional")
+
+	bedrockTfvars := string(out["/aws_bedrock.auto.tfvars"])
+	// The optional KB inputs must not be set to a fabricated value — the
+	// preset defaults them to null and the role composes as invoke-only.
+	require.NotContains(t, bedrockTfvars, "composerpreview",
+		"no fabricated preview ARN may appear in a Bedrock-only compose")
+	require.NotContains(t, bedrockTfvars, "opensearch_collection_arn",
+		"opensearch_collection_arn must be left unset (null default) for a Bedrock-only compose")
+}
+
+// TestComposeStack_BedrockOnly_NoImplicitKBDeps verifies that selecting
+// Bedrock in a stack no longer drags S3 + OpenSearch in via
+// ImplicitDependencies. The user explicitly removing OpenSearch from a
+// Bedrock stack was being silently undone by the implicit-dependency
+// resolver — this is the regression guard for that bug.
+func TestComposeStack_BedrockOnly_NoImplicitKBDeps(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSBedrock},
+		Comps:        &Components{AWSBedrock: ptrBool(true)},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	mainTF := string(out["/main.tf"])
+	// No S3 or OpenSearch module should have been pulled into the stack.
+	require.NotContains(t, mainTF, `module "aws_s3"`,
+		"Bedrock alone must not implicitly pull in the S3 module")
+	require.NotContains(t, mainTF, `module "aws_opensearch"`,
+		"Bedrock alone must not implicitly pull in the OpenSearch module")
+	// And therefore no KB wiring.
+	require.NotContains(t, mainTF, "opensearch_collection_arn",
+		"a Bedrock-only stack must not wire opensearch_collection_arn")
+	require.NotContains(t, mainTF, "s3_bucket_arn",
+		"a Bedrock-only stack must not wire s3_bucket_arn")
+}
+
+// TestComposeStack_BedrockWiresRealAOSSArn confirms that when the user DOES
+// select OpenSearch + S3 alongside Bedrock (the Knowledge Base use case),
+// the composed stack wires the real module outputs — no stub, no fabricated
+// ARN. This is the KB-path counterpart to
+// TestComposeStack_BedrockOnly_NoImplicitKBDeps.
+func TestComposeStack_BedrockWiresRealAOSSArn(t *testing.T) {
+	t.Parallel()
+
 	c := newTestClient()
 	out, err := c.ComposeStack(ComposeStackOpts{
 		Cloud: "aws",
@@ -178,18 +216,16 @@ func TestMapper_BedrockPreviewStub_DoesNotOverwrite(t *testing.T) {
 	mainTF := string(out["/main.tf"])
 	bedrockTfvars := string(out["/aws_bedrock.auto.tfvars"])
 
-	// The composed module block must carry the real wiring, not the stub.
+	// The composed module block must carry the real wiring.
 	require.Contains(t, mainTF,
 		`opensearch_collection_arn = module.aws_opensearch.collection_arn`,
-		"stack composition must wire the real AOSS collection_arn, not the stub")
+		"KB-path stack composition must wire the real AOSS collection_arn")
 
-	// The preview-stub value must not appear anywhere — neither in the
-	// module block nor in .auto.tfvars for Bedrock. `block.Raw` wins over
-	// mapper vals in ComposeStack, so the stub should never reach the tfvars.
+	// No fabricated preview ARN may appear anywhere.
 	require.NotContains(t, mainTF, "composerpreview",
-		"preview stub must not leak into a composed stack's main.tf")
+		"no fabricated preview ARN may leak into a composed stack's main.tf")
 	require.NotContains(t, bedrockTfvars, "composerpreview",
-		"preview stub must not leak into a composed stack's tfvars")
+		"no fabricated preview ARN may leak into a composed stack's tfvars")
 }
 
 // TestGenerateProvidersTF_DiscoveryUnion verifies that discovered child

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -260,6 +260,21 @@ var ModulePath = map[ComponentKey]string{
 
 // ImplicitDependencies defines components that must be automatically added
 // if a certain component is selected.
+//
+// Entries here are HARD dependencies only: the selected component's preset
+// literally will not compose without the dependency (a required input with
+// no source, a module reference that resolves to nothing). "Commonly used
+// together" is NOT a dependency — that is a recommendation and belongs in
+// the conversational layer, not here. Registering a soft pairing as a hard
+// dep silently re-selects a component the user explicitly removed (see the
+// Bedrock→OpenSearch removal below).
+//
+// Bedrock is deliberately absent: the aws/bedrock preset's s3_bucket_arn
+// and opensearch_collection_arn inputs are optional (default null). A
+// Bedrock-only stack composes to a model-invocation role + guardrails;
+// S3 and OpenSearch join only when the user selects them for the
+// Knowledge Base use case, and DefaultWiring already wires them
+// conditionally on that selection.
 var ImplicitDependencies = map[ComponentKey][]ComponentKey{
 	KeyAWSALB:          {KeyAWSVPC},
 	KeyGCPLoadbalancer: {KeyGCPVPC},
@@ -269,7 +284,6 @@ var ImplicitDependencies = map[ComponentKey][]ComponentKey{
 	KeyAWSElastiCache:  {KeyAWSVPC},
 	KeyGCPMemorystore:  {KeyGCPVPC},
 	KeyAWSOpenSearch:   {KeyAWSVPC},
-	KeyAWSBedrock:      {KeyAWSS3, KeyAWSOpenSearch},
 	KeyAWSCloudfront:   {KeyAWSALB},
 	KeyAWSEKS:          {KeyAWSVPC},
 	KeyAWSECS:          {KeyAWSVPC},

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -726,19 +726,12 @@ func (m DefaultMapper) BuildModuleValues(
 				vals["embedding_model_id"] = cfg.AWSBedrock.EmbeddingModelID
 			}
 		}
-		// In stacks, wiring supplies s3_bucket_arn and opensearch_collection_arn.
-		// For single-module preview compose there is no opensearch module in
-		// the bundle, and the preset's regex validation rejects anything that
-		// isn't an AOSS collection ARN. Provide a well-formed stub that never
-		// reaches a live account — account ID 123456789012 is AWS's
-		// documentation placeholder, and the "composer-preview" collection
-		// name makes it obvious in logs / generated tfvars that this is not
-		// a real ARN.
-		if _, ok := vals["opensearch_collection_arn"]; !ok {
-			// The preset's regex requires [a-z0-9]+ with no hyphens for the
-			// collection name segment.
-			vals["opensearch_collection_arn"] = "arn:aws:aoss:us-east-1:123456789012:collection/composerpreview"
-		}
+		// s3_bucket_arn and opensearch_collection_arn are optional (default
+		// null) Knowledge Base inputs. In a full stack DefaultWiring supplies
+		// them from module.aws_s3 / module.aws_opensearch when those
+		// components are selected. For single-module preview compose they are
+		// simply left unset — the preset defaults them to null and the role
+		// composes as a plain model-invocation role. No stub needed.
 
 	case KeyAWSLambda:
 		vals["runtime"] = "nodejs20.x" // Default to nodejs

--- a/pkg/composer/validate_test.go
+++ b/pkg/composer/validate_test.go
@@ -217,11 +217,14 @@ func TestValidateRemovals(t *testing.T) {
 			wantKeys:  []string{"aws_alb", "aws_cloudfront"},
 		},
 		{
-			name:      "remove S3 and OpenSearch breaks Bedrock",
+			// S3 and OpenSearch are optional Knowledge Base inputs for
+			// Bedrock, not hard dependencies — a Bedrock role works for
+			// plain model invocation without either. Removing them from a
+			// Bedrock stack is therefore a safe removal, no warning.
+			name:      "remove S3 and OpenSearch from Bedrock stack — safe",
 			removed:   []ComponentKey{KeyAWSS3, KeyAWSOpenSearch},
 			remaining: []ComponentKey{KeyAWSVPC, KeyAWSBedrock},
-			wantWarn:  2,
-			wantKeys:  []string{"aws_s3", "aws_opensearch", "aws_bedrock"},
+			wantWarn:  0,
 		},
 		{
 			name:      "GCP: remove VPC breaks CloudSQL and GKE",


### PR DESCRIPTION
## Summary
- The `aws/bedrock` preset required `s3_bucket_arn` and `opensearch_collection_arn` with no defaults, so `ImplicitDependencies` declared `KeyAWSBedrock: {KeyAWSS3, KeyAWSOpenSearch}` to keep stacks composable. That turned the pairing into a **hard** dependency — a user who removed OpenSearch from a Bedrock stack had it silently re-added by `ResolveDependencies`.
- But S3 + OpenSearch are only needed for the Bedrock **Knowledge Base** use case. Plain model invocation needs neither. The compose layer already treated the pairing as optional (the `DependsOn` guard only fires `if selected[KeyAWSOpenSearch]`).
- This makes the two KB inputs optional (`default = null`), assembles the role's IAM policy conditionally, and removes the implicit dep. A Bedrock-only stack now composes to a model-invocation role + guardrails; S3/OpenSearch join only when explicitly selected.

## Changes
- `aws/bedrock/variables.tf` — `s3_bucket_arn` + `opensearch_collection_arn` default to `null`; the AOSS-ARN regex validation accepts `null`.
- `aws/bedrock/main.tf` — the inline IAM policy is `concat()`'d from an always-on `bedrock:InvokeModel` statement plus S3 and AOSS statements appended only when their ARN is non-null. Policy is never empty.
- `pkg/composer/contracts.go` — removed `KeyAWSBedrock` from `ImplicitDependencies`; added a doc comment that the map is for **hard** (compose-blocking) deps only — "commonly used together" is a recommendation, not a dependency.
- `pkg/composer/mapper.go` — removed the preview-stub AOSS ARN injection (no longer needed now the input is optional).

## Test plan
- [x] `go test ./...` — 5089 pass
- [x] `go vet ./pkg/composer/` — clean
- [x] `terraform validate` on `aws/bedrock/` — valid
- [x] `terraform fmt -check` — clean
- New tests in `compose_bedrock_aoss_test.go`: Bedrock-only `ComposeSingle` succeeds with no KB deps; Bedrock-only `ComposeStack` pulls in no S3/OpenSearch module; the KB path (Bedrock + S3 + OpenSearch explicitly selected) still wires the real AOSS `collection_arn`.

## Downstream
After merge, the `insideout-terraform-presets` pin in `luthersystems/reliable` go.mod will be bumped — reliable's `enableImplicitDependencies` adapter calls `composer.ResolveDependencies`, so dropping the map entry fixes the bug where an explicitly-removed OpenSearch reappeared on a Bedrock stack (reliable production session repro). No reliable-side logic change needed.