### PR TITLE
feat(import): declarative parent/child Terraform-type registry

### DIFF
--- a/cmd/imported-codegen/emit_labels.go
+++ b/cmd/imported-codegen/emit_labels.go
@@ -14,9 +14,19 @@ import (
 // tags are lowerCamelCase so the emitted JSON matches the shape
 // downstream consumers (TS UIs) expect verbatim — no per-consumer
 // rename pass required.
+//
+// ParentTfType carries the parent/child relationship from the labels
+// package's parent registry (parent.go). It is the Terraform type of
+// the resource a child is scoped to (e.g. "aws_s3_bucket" for
+// "aws_s3_bucket_versioning"). It is empty — and omitted from the JSON
+// via omitempty — for every standalone, independently-importable type,
+// which is the vast majority. reliable's `/import` wizard reads this to
+// fold child types into their parent's tile instead of rendering them
+// as standalone import tiles (reliable#1617).
 type labelEntry struct {
-	Label   string `json:"label"`
-	IconKey string `json:"iconKey"`
+	Label        string `json:"label"`
+	IconKey      string `json:"iconKey"`
+	ParentTfType string `json:"parentTfType,omitempty"`
 }
 
 // runLabels is the `labels` subcommand: emit a deterministic JSON
@@ -43,9 +53,13 @@ func buildLabelsMap() map[string]labelEntry {
 	types := unionDiscoverTypes()
 	m := make(map[string]labelEntry, len(types))
 	for _, t := range types {
+		// ParentTfType returns ("", false) for standalone types; the
+		// zero string then drops out of the JSON via omitempty.
+		parent, _ := labels.ParentTfType(t)
 		m[t] = labelEntry{
-			Label:   labels.Label(t),
-			IconKey: labels.IconKey(t),
+			Label:        labels.Label(t),
+			IconKey:      labels.IconKey(t),
+			ParentTfType: parent,
 		}
 	}
 	return m

--- a/cmd/imported-codegen/emit_labels_test.go
+++ b/cmd/imported-codegen/emit_labels_test.go
@@ -109,6 +109,101 @@ func TestBuildLabelsMap_KnownEntries(t *testing.T) {
 	}
 }
 
+// TestBuildLabelsMap_CarriesParentTfType pins that the emitted labels
+// artifact carries the parentTfType field for child resource types and
+// leaves it empty for standalone types. This is the contract reliable's
+// `/import` wizard depends on (reliable#1617) — without the field in the
+// generated JSON the UI has no way to fold child tiles into their
+// parent.
+func TestBuildLabelsMap_CarriesParentTfType(t *testing.T) {
+	t.Parallel()
+	got := buildLabelsMap()
+
+	cases := []struct {
+		tfType     string
+		wantParent string // "" => must be a standalone type
+	}{
+		// Child types — parentTfType must be populated.
+		{tfType: "aws_s3_bucket_versioning", wantParent: "aws_s3_bucket"},
+		{tfType: "aws_s3_bucket_public_access_block", wantParent: "aws_s3_bucket"},
+		{tfType: "aws_route_table", wantParent: "aws_vpc"},
+		{tfType: "aws_vpc_security_group_ingress_rule", wantParent: "aws_security_group"},
+		{tfType: "aws_kms_alias", wantParent: "aws_kms_key"},
+		{tfType: "aws_cloudwatch_log_stream", wantParent: "aws_cloudwatch_log_group"},
+		{tfType: "aws_iam_role_policy_attachment", wantParent: "aws_iam_role"},
+		{tfType: "aws_db_parameter_group", wantParent: "aws_db_instance"},
+		// Standalone types — parentTfType must be the zero string.
+		{tfType: "aws_s3_bucket", wantParent: ""},
+		{tfType: "aws_vpc", wantParent: ""},
+		{tfType: "aws_dynamodb_table", wantParent: ""},
+	}
+	for _, tc := range cases {
+		entry, ok := got[tc.tfType]
+		if !ok {
+			t.Errorf("%s: missing from emitted labels map", tc.tfType)
+			continue
+		}
+		if entry.ParentTfType != tc.wantParent {
+			t.Errorf("%s: ParentTfType = %q, want %q", tc.tfType, entry.ParentTfType, tc.wantParent)
+		}
+	}
+}
+
+// TestRunLabels_OmitsEmptyParentTfType pins that the JSON-on-disk drops
+// the parentTfType key for standalone types (omitempty) but emits it for
+// child types. This locks the wire shape downstream consumers parse — a
+// standalone entry stays a two-key object, a child entry gains the third
+// key.
+func TestRunLabels_OmitsEmptyParentTfType(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "labels.json")
+	if code := runLabels([]string{"--output", out}); code != 0 {
+		t.Fatalf("runLabels exit code = %d, want 0", code)
+	}
+	buf, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	// Decode into raw maps so we can assert key presence/absence rather
+	// than the struct's zero-value default.
+	var raw map[string]map[string]any
+	if err := json.Unmarshal(buf, &raw); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+
+	child, ok := raw["aws_s3_bucket_versioning"]
+	if !ok {
+		t.Fatal("aws_s3_bucket_versioning missing from emitted JSON")
+	}
+	if got := child["parentTfType"]; got != "aws_s3_bucket" {
+		t.Errorf("aws_s3_bucket_versioning: parentTfType key = %v, want %q", got, "aws_s3_bucket")
+	}
+
+	// A child entry keeps the existing two keys plus the new one.
+	if _, present := child["label"]; !present {
+		t.Error("aws_s3_bucket_versioning: label key missing")
+	}
+	if _, present := child["iconKey"]; !present {
+		t.Error("aws_s3_bucket_versioning: iconKey key missing")
+	}
+
+	standalone, ok := raw["aws_s3_bucket"]
+	if !ok {
+		t.Fatal("aws_s3_bucket missing from emitted JSON")
+	}
+	if _, present := standalone["parentTfType"]; present {
+		t.Errorf("aws_s3_bucket: parentTfType key present, want omitted (omitempty)")
+	}
+	// omitempty must drop only parentTfType — the other two keys stay.
+	if _, present := standalone["label"]; !present {
+		t.Error("aws_s3_bucket: label key missing")
+	}
+	if _, present := standalone["iconKey"]; !present {
+		t.Error("aws_s3_bucket: iconKey key missing")
+	}
+}
+
 // TestUnionDiscoverTypes_SortedAndDeduped pins the shared helper's
 // guarantee that the union slice is sorted and contains no duplicates.
 // Downstream subcommands depend on this for deterministic output.

--- a/pkg/imported/labels/parent.go
+++ b/pkg/imported/labels/parent.go
@@ -1,0 +1,120 @@
+// parent.go is the declarative parent/child registry for imported
+// Terraform resource types.
+//
+// Why this exists: luthersystems/reliable's reverse-Terraform `/import`
+// wizard (reliable#1617) discovers existing cloud resources and renders
+// them as importable tiles grouped by category. Many discovered types
+// are *child / sub-configuration* resources that have no independent
+// lifecycle — they only make sense imported together with their parent.
+// `aws_s3_bucket_versioning` is meaningless without the
+// `aws_s3_bucket` it configures; `aws_route_table` is scoped to an
+// `aws_vpc`; `aws_kms_alias` points at an `aws_kms_key`. The product
+// decision is that children must NOT appear as standalone import tiles —
+// the parent is the importable unit and importing it pulls the children
+// along.
+//
+// The relationship knowledge belongs upstream here, not duplicated in
+// reliable, for the same reason the display-label registry does: this
+// repo already owns the discovery machinery (the awsdiscover
+// `ParentLister` / `ImportIDFromParent` parent-scoped discoverers). Those
+// tell the discoverer how to *enumerate* children via parent-scoped AWS
+// APIs but never emit a declarative `childTfType → parentTfType` map —
+// they key the parent by CloudFormation type, not Terraform type, and
+// only cover the SDK-only sub-resource families. This registry
+// fills that gap with a single Terraform-typed map, and the parent field
+// rides along in the same generated labels artifact reliable already
+// consumes (see cmd/imported-codegen/emit_labels.go) so the UI gets it
+// for free with no second data path.
+//
+// Authoring rule: only add an entry for a child that genuinely requires
+// a *named parent of a specific type* to be addressable. A resource that
+// has a parent-ish relationship but is still independently importable
+// (e.g. `aws_lb_target_group` — usable without a load balancer) does NOT
+// belong here. A type with no parent is simply absent from the map;
+// ParentTfType returns ("", false) for it.
+package labels
+
+// parentTfTypes is the declarative childTfType → parentTfType registry.
+//
+// Each key is a Terraform resource type that the discovery pipeline can
+// surface, and the value is the Terraform type of the parent resource it
+// is scoped to. Every key and value here is a member of
+// pkg/insideout-import/registry's KnownTypes set — the
+// TestParentTfTypes_AllTypesAreKnown test enforces that so a typo or a
+// renamed-upstream type fails loudly instead of silently producing a
+// dangling edge.
+//
+// Grouped by parent family for readability; map iteration order is
+// irrelevant — every consumer (the accessor, the codegen emitter) reads
+// it by key.
+var parentTfTypes = map[string]string{
+	// S3 bucket sub-configuration family. Each of these is a distinct
+	// Terraform resource type that AWS models as inline bucket
+	// properties — they are addressed solely by the parent bucket name
+	// and have no lifecycle of their own. Mirrors awsdiscover's
+	// sdkOnlySubresourceTypeConfigs entries whose ParentCFNType is
+	// "AWS::S3::Bucket".
+	"aws_s3_bucket_versioning":                           "aws_s3_bucket",
+	"aws_s3_bucket_lifecycle_configuration":              "aws_s3_bucket",
+	"aws_s3_bucket_ownership_controls":                   "aws_s3_bucket",
+	"aws_s3_bucket_public_access_block":                  "aws_s3_bucket",
+	"aws_s3_bucket_server_side_encryption_configuration": "aws_s3_bucket",
+	"aws_s3_bucket_policy":                               "aws_s3_bucket",
+
+	// VPC children. A route table, internet gateway, subnet, and the
+	// modern split security-group rule resources are all scoped to a
+	// specific VPC and are not meaningful to import on their own.
+	"aws_route_table":      "aws_vpc",
+	"aws_internet_gateway": "aws_vpc",
+	"aws_subnet":           "aws_vpc",
+	"aws_vpc_dhcp_options": "aws_vpc",
+
+	// Split security-group rule resources (the aws_vpc_security_group_*
+	// resources that replaced the legacy aws_security_group_rule). Each
+	// rule is addressed by, and only exists within, its security group.
+	"aws_vpc_security_group_ingress_rule": "aws_security_group",
+	"aws_vpc_security_group_egress_rule":  "aws_security_group",
+
+	// CloudWatch Logs. A log stream is created inside a log group and is
+	// addressed as "<log-group>:<stream>"; it has no standalone tile.
+	"aws_cloudwatch_log_stream": "aws_cloudwatch_log_group",
+
+	// KMS. An alias is a pointer to a key; importing the key is the unit
+	// of work, the alias rides along.
+	"aws_kms_alias": "aws_kms_key",
+
+	// IAM. A role-policy attachment is the edge between a role and a
+	// managed policy — its import ID is "<role>/<policy-arn>", so it is
+	// scoped to the role. (Reliable groups it under the role tile.)
+	"aws_iam_role_policy_attachment": "aws_iam_role",
+	"aws_iam_role_policy":            "aws_iam_role",
+
+	// Database parameter groups. A DB parameter group is attached to and
+	// configures a specific database instance; an ElastiCache parameter
+	// group likewise configures a replication group. Neither is a
+	// standalone importable unit in the wizard.
+	"aws_db_parameter_group":          "aws_db_instance",
+	"aws_elasticache_parameter_group": "aws_elasticache_replication_group",
+}
+
+// ParentTfType returns the Terraform type of the parent resource that
+// childTfType is scoped to, and true, when childTfType is a registered
+// child. For any type with no parent — every importable, standalone
+// resource — it returns ("", false).
+//
+// Consumers (e.g. reliable's import wizard) use this to decide which
+// discovered types deserve a standalone tile: a type for which this
+// returns true is folded into its parent's tile rather than shown on its
+// own.
+func ParentTfType(childTfType string) (string, bool) {
+	parent, ok := parentTfTypes[childTfType]
+	return parent, ok
+}
+
+// HasParent reports whether childTfType is a registered child type. It
+// is the boolean-only convenience form of ParentTfType for call sites
+// that only need the predicate.
+func HasParent(childTfType string) bool {
+	_, ok := parentTfTypes[childTfType]
+	return ok
+}

--- a/pkg/imported/labels/parent_test.go
+++ b/pkg/imported/labels/parent_test.go
@@ -1,0 +1,184 @@
+package labels
+
+import (
+	"testing"
+
+	typeregistry "github.com/luthersystems/insideout-terraform-presets/pkg/insideout-import/registry"
+)
+
+// TestParentTfType_ChildResolvesToParent pins the core contract: every
+// known child type resolves to exactly the expected parent. The cases
+// are exact-match and mutation-fragile — a change to any value in the
+// parentTfTypes map (or an accidental deletion of a key) fails a
+// specific row here rather than slipping through a presence-only check.
+func TestParentTfType_ChildResolvesToParent(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		child      string
+		wantParent string
+	}{
+		// S3 bucket sub-configuration family.
+		{"aws_s3_bucket_versioning", "aws_s3_bucket"},
+		{"aws_s3_bucket_lifecycle_configuration", "aws_s3_bucket"},
+		{"aws_s3_bucket_ownership_controls", "aws_s3_bucket"},
+		{"aws_s3_bucket_public_access_block", "aws_s3_bucket"},
+		{"aws_s3_bucket_server_side_encryption_configuration", "aws_s3_bucket"},
+		{"aws_s3_bucket_policy", "aws_s3_bucket"},
+		// VPC children.
+		{"aws_route_table", "aws_vpc"},
+		{"aws_internet_gateway", "aws_vpc"},
+		{"aws_subnet", "aws_vpc"},
+		{"aws_vpc_dhcp_options", "aws_vpc"},
+		// Split security-group rules.
+		{"aws_vpc_security_group_ingress_rule", "aws_security_group"},
+		{"aws_vpc_security_group_egress_rule", "aws_security_group"},
+		// CloudWatch Logs.
+		{"aws_cloudwatch_log_stream", "aws_cloudwatch_log_group"},
+		// KMS.
+		{"aws_kms_alias", "aws_kms_key"},
+		// IAM.
+		{"aws_iam_role_policy_attachment", "aws_iam_role"},
+		{"aws_iam_role_policy", "aws_iam_role"},
+		// Database parameter groups.
+		{"aws_db_parameter_group", "aws_db_instance"},
+		{"aws_elasticache_parameter_group", "aws_elasticache_replication_group"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.child, func(t *testing.T) {
+			t.Parallel()
+			gotParent, ok := ParentTfType(tc.child)
+			if !ok {
+				t.Fatalf("ParentTfType(%q): ok = false, want true", tc.child)
+			}
+			if gotParent != tc.wantParent {
+				t.Errorf("ParentTfType(%q) = %q, want %q", tc.child, gotParent, tc.wantParent)
+			}
+		})
+	}
+}
+
+// TestParentTfType_StandaloneTypesHaveNoParent pins the negative half of
+// the contract: a resource type that is independently importable — a
+// parent itself, or a plain standalone resource — must NOT be in the
+// registry. ParentTfType returns ("", false) so reliable's wizard keeps
+// rendering it as its own tile.
+func TestParentTfType_StandaloneTypesHaveNoParent(t *testing.T) {
+	t.Parallel()
+	standalone := []string{
+		// Parents must not themselves be children.
+		"aws_s3_bucket",
+		"aws_vpc",
+		"aws_security_group",
+		"aws_cloudwatch_log_group",
+		"aws_kms_key",
+		"aws_iam_role",
+		"aws_db_instance",
+		"aws_elasticache_replication_group",
+		// Plain standalone resources.
+		"aws_dynamodb_table",
+		"aws_sqs_queue",
+		"aws_lambda_function",
+		"aws_lb_target_group",
+		"google_storage_bucket",
+		// Unknown type — defensive.
+		"not_a_real_type",
+	}
+	for _, tt := range standalone {
+		t.Run(tt, func(t *testing.T) {
+			t.Parallel()
+			gotParent, ok := ParentTfType(tt)
+			if ok {
+				t.Errorf("ParentTfType(%q): ok = true (parent=%q), want false", tt, gotParent)
+			}
+			if gotParent != "" {
+				t.Errorf("ParentTfType(%q) = %q, want \"\"", tt, gotParent)
+			}
+		})
+	}
+}
+
+// TestHasParent pins the boolean convenience accessor against the same
+// child / standalone split, so a divergence between HasParent and
+// ParentTfType fails loudly.
+func TestHasParent(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		tfType string
+		want   bool
+	}{
+		{"aws_s3_bucket_versioning", true},
+		{"aws_kms_alias", true},
+		{"aws_vpc_security_group_egress_rule", true},
+		{"aws_s3_bucket", false},
+		{"aws_kms_key", false},
+		{"not_a_real_type", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tfType, func(t *testing.T) {
+			t.Parallel()
+			if got := HasParent(tc.tfType); got != tc.want {
+				t.Errorf("HasParent(%q) = %v, want %v", tc.tfType, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParentTfTypes_AllTypesAreKnown enforces that every key and every
+// value in the registry is a member of registry.KnownTypes. A dangling
+// edge — a child or parent that no longer exists upstream because a type
+// was renamed or removed — is a release-blocking bug: reliable's wizard
+// would either fold a tile into a parent that has no tile, or hide a
+// child of a type the discoverer never emits.
+func TestParentTfTypes_AllTypesAreKnown(t *testing.T) {
+	t.Parallel()
+	known := knownTypeSet(t)
+	for child, parent := range parentTfTypes {
+		if _, ok := known[child]; !ok {
+			t.Errorf("child %q is not in registry.KnownTypes — typo or removed-upstream type", child)
+		}
+		if _, ok := known[parent]; !ok {
+			t.Errorf("parent %q (of child %q) is not in registry.KnownTypes — typo or removed-upstream type", parent, child)
+		}
+	}
+}
+
+// TestParentTfTypes_NoSelfReference pins that no type is its own parent —
+// a self-edge would make the wizard fold a tile into itself and hide it
+// entirely.
+func TestParentTfTypes_NoSelfReference(t *testing.T) {
+	t.Parallel()
+	for child, parent := range parentTfTypes {
+		if child == parent {
+			t.Errorf("type %q is registered as its own parent", child)
+		}
+	}
+}
+
+// TestParentTfTypes_ParentsAreNotChildren pins that the registry is a
+// flat one-level tree: a registered parent must not itself appear as a
+// child key. The wizard folds children one level into their parent's
+// tile; a parent that is also a child would need recursive folding,
+// which the consumer does not implement.
+func TestParentTfTypes_ParentsAreNotChildren(t *testing.T) {
+	t.Parallel()
+	for child, parent := range parentTfTypes {
+		if grandparent, ok := parentTfTypes[parent]; ok {
+			t.Errorf("parent %q (of child %q) is itself a child of %q — registry must be a flat one-level tree", parent, child, grandparent)
+		}
+	}
+}
+
+// knownTypeSet returns registry.KnownTypes as a set for O(1) membership
+// checks.
+func knownTypeSet(t *testing.T) map[string]struct{} {
+	t.Helper()
+	types := typeregistry.KnownTypes()
+	if len(types) == 0 {
+		t.Fatal("typeregistry.KnownTypes() returned nothing — cannot validate the parent registry")
+	}
+	set := make(map[string]struct{}, len(types))
+	for _, ty := range types {
+		set[ty] = struct{}{}
+	}
+	return set
+}


### PR DESCRIPTION
## Summary

- Adds a declarative `childTfType -> parentTfType` registry in `pkg/imported/labels/parent.go` so luthersystems/reliable's reverse-Terraform `/import` wizard can fold child/sub-configuration resources into their parent's tile instead of rendering them as standalone import tiles (reliable#1617).
- Child types — S3 bucket sub-configs, VPC children, split SG rules, log streams, KMS aliases, IAM role-policy attachments, DB parameter groups — have no independent lifecycle; the parent is the importable unit and importing it pulls the children along. The relationship belongs upstream alongside the existing parent-scoped discovery machinery (`awsdiscover`'s `ParentLister` / `ImportIDFromParent`), which only enumerates children via parent-scoped APIs and never emitted a declarative TF-typed map.
- Wires the `parentTfType` field into the generated labels artifact (`imported-codegen labels` subcommand) so the field rides along in the same per-tfType JSON reliable already consumes — no second data path. `omitempty` keeps standalone entries byte-identical to today.

## Accessors

- `ParentTfType(child) (string, bool)` — parent type + ok; `("", false)` for any standalone type.
- `HasParent(child) bool` — boolean convenience form.

## Test plan

- [x] `go test ./pkg/imported/labels/... -run 'TestParent|TestHasParent' -count=1` — exact child->parent pairs, standalone types resolve to `("", false)`, flat one-level tree (no self-reference, no parent-that-is-also-a-child), every key/value is a member of `registry.KnownTypes`.
- [x] `go test ./cmd/imported-codegen/... -run 'Labels|Parent' -count=1` — emitted artifact carries `parentTfType` for child entries and omits it (omitempty) for standalone entries, with `label`/`iconKey` preserved.
- [x] `go build ./...`, `go vet`, `golangci-lint` on the touched packages — clean (2 pre-existing staticcheck nits in untouched `typemap*.go` are out of scope).

## Review notes

- /review findings: 0 P0, 0 P1; 1 P3 (doc-comment type count) fixed as drive-by; 1 P2 left (raw-`any` JSON comparison form is correct as written).
- qa-professor pass: strengthened `TestRunLabels_OmitsEmptyParentTfType` to also assert the non-omitted `label`/`iconKey` keys survive, so a whole-entry-shape regression can't slip through the omitempty check.

## Consumer / follow-up

luthersystems/reliable's `/import` wizard. A follow-up reliable PR will bump the presets `go.mod` pin, regenerate `lib/generated/imported-labels.json`, and fold child tiles into their parent in the discovery grid. No reliable changes in this PR.

Closes #636