### PR TITLE
fix(composer): never emit `id` arg + flag missing-required imported attrs

### DIFF
--- a/cmd/insideout-import/awsdiscover/cloudcontrol_enricher_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_enricher_test.go
@@ -685,3 +685,58 @@ func TestCloudControlEnricher_Enrich_RawAttrs_IsValidJSONWithSnakeKeys(t *testin
 		assert.Equalf(t, strings.ToLower(k), k, "expected lowercase top-level key, got %q", k)
 	}
 }
+
+// TestCloudControlEnricher_IAMPolicyDocumentToPolicy is the end-to-end
+// pin for reliable #1621 bug 2: a CloudFormation AWS::IAM::ManagedPolicy
+// payload surfaces the policy as a nested `PolicyDocument` object, but
+// Terraform's required `aws_iam_policy.policy` argument is a
+// JSON-encoded string. The jsonStringifyField normalizer wired into
+// cloudControlTypeConfigs must bridge the gap so the enriched typed
+// Attrs carry a non-empty `policy` string. Pre-fix the enriched
+// AWSIAMPolicy.Policy was nil and the composed resource block omitted
+// the required argument, failing terraform plan.
+func TestCloudControlEnricher_IAMPolicyDocumentToPolicy(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{
+		props: `{
+			"PolicyArn": "arn:aws:iam::123456789012:policy/example",
+			"Path": "/",
+			"Description": "example policy",
+			"PolicyDocument": {
+				"Version": "2012-10-17",
+				"Statement": [
+					{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"}
+				]
+			}
+		}`,
+	}
+	// Pull the Normalizer from the production config so a registration
+	// drift (someone dropping the normalizer) fails this test.
+	n := normalizerForCFNType(t, "AWS::IAM::ManagedPolicy")
+	enr := newCloudControlEnricherWithNormalizer("aws_iam_policy", "AWS::IAM::ManagedPolicy", fake.call, n)
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_iam_policy",
+			ImportID: "arn:aws:iam::123456789012:policy/example",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+
+	decoded, err := generated.UnmarshalAttrs("aws_iam_policy", ir.Attrs)
+	require.NoError(t, err)
+	pol, ok := decoded.(*generated.AWSIAMPolicy)
+	require.True(t, ok, "decoded type is %T", decoded)
+
+	// The required `policy` argument must be populated as a JSON string.
+	require.NotNil(t, pol.Policy, "policy must be populated post-normalize")
+	require.NotNil(t, pol.Policy.Literal)
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal([]byte(*pol.Policy.Literal), &doc),
+		"policy attribute must hold a valid JSON string")
+	assert.Equal(t, "2012-10-17", doc["Version"])
+
+	// Sibling fields still flow through the generic renamer.
+	require.NotNil(t, pol.Path)
+	require.NotNil(t, pol.Path.Literal)
+	assert.Equal(t, "/", *pol.Path.Literal)
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers.go
@@ -440,6 +440,74 @@ func stripComputedOnlyForType(tfType string) Normalizer {
 	}
 }
 
+// jsonStringifyField returns a Normalizer that takes the top-level
+// `from` key — whose CloudFormation value is a JSON *object* (or array)
+// — JSON-encodes it into a *string*, and stores that string at the new
+// top-level `to` key. The original `from` key is removed.
+//
+// This bridges the CloudFormation-vs-Terraform shape gap for
+// policy-document attributes. CloudFormation surfaces e.g.
+// `AWS::IAM::ManagedPolicy.PolicyDocument` as a nested JSON object, but
+// the Terraform `aws_iam_policy.policy` attribute is a JSON-encoded
+// *string* (`*Value[string]` on the generated Layer-1 struct). A plain
+// renameField would land an object on a string field and the
+// downstream UnmarshalAttrs would either drop it or error; without the
+// stringify the required `policy` argument is missing entirely and
+// `terraform plan` fails with "Missing required argument:
+// policy" (reliable #1621). renameField alone can't bridge it —
+// an object landing on a `*Value[string]` field is dropped.
+//
+// The post-camelToSnake projection turns `to` into its snake_case form
+// (e.g. `Policy` → `policy`), and shapeCFNForLayer1 wraps the string
+// scalar in the `{"literal": …}` envelope the generated `Value[string]`
+// field decodes. `to` is therefore passed PascalCase by callers so the
+// projection and scalar-wrap both fire.
+//
+// Idempotent / fail-open: if `from` is absent the payload passes
+// through unchanged; if `to` is already present the existing value
+// wins (the stringify is a no-op rather than an overwrite — matches the
+// renameField convention). A `from` value that is already a string is
+// moved to `to` verbatim (no double-encoding) so a re-run, or a CFN
+// payload that already returns the document as a string, stays stable.
+func jsonStringifyField(from, to string) Normalizer {
+	return func(in json.RawMessage) (json.RawMessage, error) {
+		if from == "" || to == "" {
+			return in, nil
+		}
+		m, err := decodeObject(in)
+		if err != nil {
+			return nil, fmt.Errorf("jsonStringifyField(%q, %q): %w", from, to, err)
+		}
+		if m == nil {
+			return in, nil
+		}
+		raw, ok := m[from]
+		if !ok || raw == nil {
+			return in, nil
+		}
+		if _, exists := m[to]; exists {
+			// Target already populated — leave it; don't guess which is
+			// authoritative. Still drop `from` so a stray object doesn't
+			// reach the Layer-1 unmarshal.
+			delete(m, from)
+			return encodeObject(m)
+		}
+		switch v := raw.(type) {
+		case string:
+			// Already a string — move verbatim, no double-encoding.
+			m[to] = v
+		default:
+			encoded, err := json.Marshal(v)
+			if err != nil {
+				return nil, fmt.Errorf("jsonStringifyField(%q, %q): encode value: %w", from, to, err)
+			}
+			m[to] = string(encoded)
+		}
+		delete(m, from)
+		return encodeObject(m)
+	}
+}
+
 // decodeObject is the shared parse step. Returns (nil, nil) for an
 // empty / null payload so helpers can pass-through cleanly without
 // special-casing.

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers_test.go
@@ -733,3 +733,76 @@ func TestStripComputedOnlyForType_ComposesAfterRenameAndSynth(t *testing.T) {
 	assert.NotContains(t, m, "Arn")
 	assert.NotContains(t, m, "LogGroupName")
 }
+
+// TestJSONStringifyField covers the normalizer that bridges
+// CloudFormation's nested PolicyDocument object onto Terraform's
+// JSON-string `policy` attribute (reliable #1621 bug 2).
+func TestJSONStringifyField(t *testing.T) {
+	t.Parallel()
+
+	t.Run("object value is JSON-stringified onto the target key", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"PolicyDocument":{"Version":"2012-10-17","Statement":[{"Effect":"Allow"}]},"Path":"/"}`)
+		out, err := jsonStringifyField("PolicyDocument", "Policy")(in)
+		require.NoError(t, err)
+		m := asMap(t, out)
+		// Source key is removed.
+		_, hasFrom := m["PolicyDocument"]
+		assert.False(t, hasFrom, "source key must be removed")
+		// Target key holds a STRING, not an object.
+		s, ok := m["Policy"].(string)
+		require.True(t, ok, "target key must hold a string, got %T", m["Policy"])
+		// The string must be valid JSON round-tripping to the original.
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal([]byte(s), &doc))
+		assert.Equal(t, "2012-10-17", doc["Version"])
+		// Unrelated keys are untouched.
+		assert.Equal(t, "/", m["Path"])
+	})
+
+	t.Run("string value is moved verbatim, not double-encoded", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"PolicyDocument":"{\"Version\":\"2012-10-17\"}"}`)
+		out, err := jsonStringifyField("PolicyDocument", "Policy")(in)
+		require.NoError(t, err)
+		m := asMap(t, out)
+		assert.Equal(t, `{"Version":"2012-10-17"}`, m["Policy"],
+			"already-string value must move verbatim without double-encoding")
+	})
+
+	t.Run("absent source key is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Path":"/"}`)
+		out, err := jsonStringifyField("PolicyDocument", "Policy")(in)
+		require.NoError(t, err)
+		m := asMap(t, out)
+		assert.Equal(t, "/", m["Path"])
+		_, hasTarget := m["Policy"]
+		assert.False(t, hasTarget)
+	})
+
+	t.Run("pre-populated target wins, source dropped", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"PolicyDocument":{"a":1},"Policy":"existing"}`)
+		out, err := jsonStringifyField("PolicyDocument", "Policy")(in)
+		require.NoError(t, err)
+		m := asMap(t, out)
+		assert.Equal(t, "existing", m["Policy"], "existing target value must win")
+		_, hasFrom := m["PolicyDocument"]
+		assert.False(t, hasFrom, "stray source object must still be dropped")
+	})
+
+	t.Run("empty from/to is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"PolicyDocument":{"a":1}}`)
+		out, err := jsonStringifyField("", "Policy")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("malformed JSON surfaces an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := jsonStringifyField("PolicyDocument", "Policy")(json.RawMessage(`{not json`))
+		require.Error(t, err)
+	})
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -267,6 +267,17 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 			return map[string]string{"arn": identifier}
 		},
 		TagsFromProperties: tagsFromKey("Tags"),
+		// Normalizer: CFN AWS::IAM::ManagedPolicy surfaces the policy
+		// document as a nested JSON object under `PolicyDocument`, but
+		// Terraform's `aws_iam_policy.policy` is a REQUIRED JSON-encoded
+		// *string*. Without the stringify+rename the required `policy`
+		// argument is absent from the composed resource block and
+		// `terraform plan` fails with "Missing required argument:
+		// policy" (reliable #1621). renameField alone can't bridge it —
+		// an object landing on a `*Value[string]` field is dropped.
+		Normalizer: chain(
+			jsonStringifyField("PolicyDocument", "Policy"),
+		),
 	},
 
 	// =====================================================================

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -688,6 +688,11 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// (issue #148). This must happen before generateProvidersTF so that
 	// importedClouds tells the provider emitter which alias to declare.
 	issues = append(issues, ValidateImportedResources(cloud, opts.Imported)...)
+	// Emit-readiness checks (required-argument completeness) run here —
+	// at compose time, on the final ready-to-emit resource set — not in
+	// the discovery manifest writer, which validates a still-enriching
+	// intermediate snapshot. See ValidateImportedEmitReadiness.
+	issues = append(issues, ValidateImportedEmitReadiness(cloud, opts.Imported)...)
 	issues = append(issues, ValidateImportedResourceAuthorization(cloud, opts.Imported)...)
 	provOpts := ProvenanceOpts{ImportProjectID: opts.ImportProjectID}
 	issues = append(issues, ValidateProvenanceConflicts(cloud, opts.Imported, provOpts)...)

--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -212,12 +213,34 @@ func classifyEmitMode(ir imported.ImportedResource) emitMode {
 	return emitModeSkip
 }
 
+// computedResourceIDAttr is Terraform's synthetic per-resource
+// identifier attribute. It is exported by every provider's resource
+// schema as Optional+Computed (the historical "id == name" quirk on
+// some types means the provider technically marks it Optional), but it
+// is NEVER valid as an argument inside a `resource {}` block — supplying
+// it makes `terraform plan` fail with "Invalid or unknown key". The
+// discovered import id belongs in the sibling `import {}` block
+// (renderImportBlock), not in the resource body. EmitImportedTF strips
+// this key from every emitted resource body regardless of what the
+// discovery payload or the generated schema says — see stripResourceIDAttr.
+const computedResourceIDAttr = "id"
+
 // emitImportedResourceBody returns the HCL body bytes (no surrounding
 // `resource "..." "..." { ... }` wrapper) for ir. Branches on whether the
 // carrier carries typed Attrs or only opaque Attributes.
+//
+// The `id` attribute is stripped from both paths: discovery (e.g. the
+// Cloud Control enricher) can land the computed `id` into the typed
+// Attrs / opaque Attributes bag, but `id` is never a legal resource
+// argument — it must only ever appear in the `import {}` block. Emitting
+// it produces the malformed-HCL "Invalid or unknown key" plan failure.
 func emitImportedResourceBody(ir imported.ImportedResource) ([]byte, error) {
 	if len(ir.Attrs) > 0 {
-		typed, err := generated.UnmarshalAttrs(ir.Identity.Type, ir.Attrs)
+		attrs, err := stripResourceIDAttr(ir.Attrs)
+		if err != nil {
+			return nil, fmt.Errorf("strip id from typed Attrs for %q: %w", ir.Identity.Type, err)
+		}
+		typed, err := generated.UnmarshalAttrs(ir.Identity.Type, attrs)
 		if err != nil {
 			return nil, fmt.Errorf("decode typed Attrs for %q: %w", ir.Identity.Type, err)
 		}
@@ -228,6 +251,33 @@ func emitImportedResourceBody(ir imported.ImportedResource) ([]byte, error) {
 		return body, nil
 	}
 	return emitOpaqueAttrsBody(ir)
+}
+
+// stripResourceIDAttr removes the top-level `id` key from a typed-Attrs
+// JSON object before it is unmarshalled into a generated Layer-1 struct.
+// Returns the input unchanged when `id` is absent or the payload is not a
+// JSON object (defensive — UnmarshalAttrs will surface a non-object
+// payload as its own error). Operates only on the top level: a nested
+// block legitimately named `id` (none exist in the current schemas, but
+// the carve-out keeps the transform conservative) is untouched.
+func stripResourceIDAttr(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return raw, nil
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		// Not a JSON object — leave it for UnmarshalAttrs to reject.
+		return raw, nil //nolint:nilerr // intentional passthrough
+	}
+	if _, ok := obj[computedResourceIDAttr]; !ok {
+		return raw, nil
+	}
+	delete(obj, computedResourceIDAttr)
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // emitOpaqueAttrsBody renders ir.Attributes as HCL body. Skips computed-only
@@ -249,6 +299,13 @@ func emitOpaqueAttrsBody(ir imported.ImportedResource) ([]byte, error) {
 	body := f.Body()
 
 	for _, k := range keys {
+		// `id` is never a legal resource argument — it belongs in the
+		// `import {}` block only. Skip it in the opaque path too: the
+		// generated schema marks `id` Optional+Computed, so the
+		// Configurable() gate below would otherwise let it through.
+		if k == computedResourceIDAttr {
+			continue
+		}
 		if hasSchema {
 			if fs, ok := schema[k]; ok && !fs.Configurable() {
 				continue

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -705,3 +705,121 @@ func extractResourceBlock(t *testing.T, hcl, tfType, label string) string {
 	t.Fatalf("unterminated resource block for %s.%s", tfType, label)
 	return ""
 }
+
+// TestEmitImportedTF_NoIDArgInResourceBlock locks the fix for the
+// malformed-HCL bug from reliable #1621 / staging session
+// sess_v2_CnqUJ6NRJnLC: discovery (the Cloud Control enricher's
+// synthIDFromField step) lands the computed `id` attribute into the
+// typed Attrs bag. `id` is Terraform's synthetic resource identifier —
+// emitting it inside a `resource {}` block makes `terraform plan` fail
+// with "Invalid or unknown key". The discovered import id belongs in
+// the sibling `import {}` block ONLY. This test asserts the emitted
+// resource body never carries an `id = ...` argument while the import
+// block still carries the id.
+func TestEmitImportedTF_NoIDArgInResourceBlock(t *testing.T) {
+	t.Parallel()
+	// Verbatim shape of the aws_cloudwatch_log_group entry persisted for
+	// session sess_v2_CnqUJ6NRJnLC — note the `id` key in Attrs.
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_cloudwatch_log_group",
+			Address:  "aws_cloudwatch_log_group.aws_lambda_io_lambdaa0ca",
+			ImportID: "/aws/lambda/io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca",
+		},
+		Tier: imported.TierImportedFlat,
+		Attrs: []byte(`{
+			"id":{"literal":"/aws/lambda/io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca"},
+			"name":{"literal":"/aws/lambda/io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca"},
+			"retention_in_days":{"literal":14},
+			"log_group_class":{"literal":"STANDARD"}
+		}`),
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+
+	block := extractResourceBlock(t, s, "aws_cloudwatch_log_group", "aws_lambda_io_lambdaa0ca")
+	// The resource body must NOT contain an `id = ...` argument.
+	idArg := regexp.MustCompile(`(?m)^\s*id\s*=`)
+	assert.False(t, idArg.MatchString(block),
+		"resource block must not emit an `id` argument (computed-only):\n%s", block)
+	// Non-id configurable attributes must survive the strip.
+	assert.True(t, hasAttr(t, block, "name", `"/aws/lambda/io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca"`),
+		"name attr must survive id-strip:\n%s", block)
+	assert.True(t, hasAttr(t, block, "retention_in_days", "14"),
+		"retention_in_days attr must survive id-strip:\n%s", block)
+
+	// The import block (not the resource block) carries the id.
+	assert.Contains(t, s, "import {")
+	assert.Contains(t, s, "to = aws_cloudwatch_log_group.aws_lambda_io_lambdaa0ca")
+	assert.Contains(t, s, `id = "/aws/lambda/io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca"`)
+
+	// Whole document must parse as valid HCL.
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "imported.tf must parse: %s", diags.Error())
+}
+
+// TestEmitImportedTF_NoIDArgOpaquePath asserts the opaque-attr fallback
+// path (ir.Attributes instead of typed ir.Attrs) also strips `id`. The
+// generated schema marks `id` Optional+Computed, so the
+// FieldSchema.Configurable() gate alone would let it through.
+func TestEmitImportedTF_NoIDArgOpaquePath(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_cloudwatch_log_group",
+			Address:  "aws_cloudwatch_log_group.opaque",
+			ImportID: "/aws/lambda/opaque",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"id":                "/aws/lambda/opaque",
+			"name":              "/aws/lambda/opaque",
+			"retention_in_days": 14,
+		},
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+	block := extractResourceBlock(t, s, "aws_cloudwatch_log_group", "opaque")
+	idArg := regexp.MustCompile(`(?m)^\s*id\s*=`)
+	assert.False(t, idArg.MatchString(block),
+		"opaque path must not emit an `id` argument:\n%s", block)
+	assert.True(t, hasAttr(t, block, "name", `"/aws/lambda/opaque"`),
+		"name must survive in opaque path:\n%s", block)
+}
+
+// TestEmitImportedTF_IAMPolicyCarriesPolicy locks bug 2: the composed
+// aws_iam_policy resource block must carry the required `policy`
+// argument. Discovery (with the new jsonStringifyField normalizer)
+// lands the policy document as a JSON-encoded string on the `policy`
+// key; EmitImportedTF must propagate it into the resource body.
+func TestEmitImportedTF_IAMPolicyCarriesPolicy(t *testing.T) {
+	t.Parallel()
+	policyJSON := `{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"s3:GetObject\",\"Resource\":\"*\"}]}`
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_iam_policy",
+			Address:  "aws_iam_policy.example",
+			ImportID: "arn:aws:iam::123456789012:policy/example",
+		},
+		Tier: imported.TierImportedFlat,
+		Attrs: []byte(`{
+			"path":{"literal":"/"},
+			"description":{"literal":"example policy"},
+			"policy":{"literal":"` + policyJSON + `"}
+		}`),
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+	block := extractResourceBlock(t, s, "aws_iam_policy", "example")
+	policyArg := regexp.MustCompile(`(?m)^\s*policy\s*=`)
+	assert.True(t, policyArg.MatchString(block),
+		"aws_iam_policy resource block must carry the required `policy` argument:\n%s", block)
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "imported.tf must parse: %s", diags.Error())
+}

--- a/pkg/composer/imported_required_attr_test.go
+++ b/pkg/composer/imported_required_attr_test.go
@@ -1,0 +1,176 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateImportedResources_MissingRequiredAttr_Lambda locks the
+// fix for bugs 2 & 3 from reliable #1621 / staging session
+// sess_v2_CnqUJ6NRJnLC: the imported aws_lambda_function had Attrs=null
+// (Cloud Control enrichment captured nothing), so the composed resource
+// block was missing the REQUIRED `role` and `function_name` arguments
+// and `terraform plan` failed with "Missing required arguments". The
+// validator must surface this as a blocking
+// imported_resource_missing_required_attr issue at compose time, naming
+// the exact missing keys, rather than letting the malformed HCL reach
+// terraform plan.
+func TestValidateImportedResources_MissingRequiredAttr_Lambda(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.io_lambdaa0ca",
+			ImportID: "io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca",
+		},
+		Tier: imported.TierImportedFlat,
+		// Attrs deliberately nil — mirrors the production payload where
+		// discovery returned nothing for the Lambda.
+	}
+	issues := ValidateImportedResources("aws", []imported.ImportedResource{ir})
+	require.Equal(t, 1, countCode(issues, "imported_resource_missing_required_attr"),
+		"expected exactly one missing-required-attr issue, got: %v", issueCodes(issues))
+
+	var found ValidationIssue
+	for _, i := range issues {
+		if i.Code == "imported_resource_missing_required_attr" {
+			found = i
+		}
+	}
+	// The reason must name BOTH missing required arguments so the
+	// operator/agent gets an actionable error.
+	assert.Contains(t, found.Reason, "function_name")
+	assert.Contains(t, found.Reason, "role")
+	assert.Equal(t, "imported.aws_lambda_function.io_lambdaa0ca", found.Field)
+}
+
+// TestValidateImportedResources_MissingRequiredAttr_IAMPolicy locks bug
+// 2: an aws_iam_policy whose discovery payload omits the required
+// `policy` argument (the pre-fix behavior — CFN's PolicyDocument was
+// never renamed to `policy`) must be flagged.
+func TestValidateImportedResources_MissingRequiredAttr_IAMPolicy(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_iam_policy",
+			Address:  "aws_iam_policy.example",
+			ImportID: "arn:aws:iam::123456789012:policy/example",
+		},
+		Tier: imported.TierImportedFlat,
+		// Only path + description — `policy` (Required) absent. Verbatim
+		// shape of the broken production payload.
+		Attrs: []byte(`{"path":{"literal":"/"},"description":{"literal":"x"}}`),
+	}
+	issues := ValidateImportedResources("aws", []imported.ImportedResource{ir})
+	require.Equal(t, 1, countCode(issues, "imported_resource_missing_required_attr"),
+		"expected one missing-required-attr issue, got: %v", issueCodes(issues))
+	for _, i := range issues {
+		if i.Code == "imported_resource_missing_required_attr" {
+			assert.Contains(t, i.Reason, "policy")
+		}
+	}
+}
+
+// TestValidateImportedResources_RequiredAttrPresent asserts NO
+// missing-required issue is raised when the discovery payload carries
+// every required argument — the post-fix happy path.
+func TestValidateImportedResources_RequiredAttrPresent(t *testing.T) {
+	t.Parallel()
+	lambda := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.ok",
+			ImportID: "ok-fn",
+		},
+		Tier: imported.TierImportedFlat,
+		Attrs: []byte(`{
+			"function_name":{"literal":"ok-fn"},
+			"role":{"literal":"arn:aws:iam::123456789012:role/ok"},
+			"runtime":{"literal":"go1.x"}
+		}`),
+	}
+	policy := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_iam_policy",
+			Address:  "aws_iam_policy.ok",
+			ImportID: "arn:aws:iam::123456789012:policy/ok",
+		},
+		Tier: imported.TierImportedFlat,
+		Attrs: []byte(`{
+			"path":{"literal":"/"},
+			"policy":{"literal":"{}"}
+		}`),
+	}
+	issues := ValidateImportedResources("aws", []imported.ImportedResource{lambda, policy})
+	assert.Equal(t, 0, countCode(issues, "imported_resource_missing_required_attr"),
+		"no missing-required issue expected, got: %v", issueCodes(issues))
+}
+
+// TestValidateImportedResources_RequiredAttrViaOpaqueBag asserts the
+// required-attr presence check also reads ir.Attributes (the opaque
+// fallback bag), not just typed Attrs.
+func TestValidateImportedResources_RequiredAttrViaOpaqueBag(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.opaque",
+			ImportID: "opaque-fn",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"function_name": "opaque-fn",
+			"role":          "arn:aws:iam::123456789012:role/opaque",
+		},
+	}
+	issues := ValidateImportedResources("aws", []imported.ImportedResource{ir})
+	assert.Equal(t, 0, countCode(issues, "imported_resource_missing_required_attr"),
+		"opaque-bag required attrs must satisfy the check, got: %v", issueCodes(issues))
+}
+
+// TestValidateImportedResources_RemovedBlockExemptFromRequired asserts a
+// removal-pending resource (emitted as a `removed {}` block, no resource
+// body) is NOT subjected to the required-argument check — a removed
+// block carries no arguments to be missing.
+func TestValidateImportedResources_RemovedBlockExemptFromRequired(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.gone",
+			ImportID: "gone-fn",
+		},
+		Tier:        imported.TierImportedMissing,
+		Remediation: imported.ActionRemoveFromInsideOut,
+	}
+	issues := ValidateImportedResources("aws", []imported.ImportedResource{ir})
+	assert.Equal(t, 0, countCode(issues, "imported_resource_missing_required_attr"),
+		"removed-block resources are exempt, got: %v", issueCodes(issues))
+}
+
+// TestMissingRequiredAttrs_UnregisteredTypeFailOpen asserts the helper
+// is fail-open for types with no registered generated schema — the long
+// tail running the opaque-attr fallback must not trip the check.
+func TestMissingRequiredAttrs_UnregisteredTypeFailOpen(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_totally_made_up_type",
+			Address:  "aws_totally_made_up_type.x",
+			ImportID: "x",
+		},
+		Tier: imported.TierImportedFlat,
+	}
+	assert.Nil(t, missingRequiredAttrs(ir),
+		"unregistered type must fail-open (nil missing list)")
+}

--- a/pkg/composer/imported_required_attr_test.go
+++ b/pkg/composer/imported_required_attr_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestValidateImportedResources_MissingRequiredAttr_Lambda locks the
+// TestValidateImportedEmitReadiness_MissingRequiredAttr_Lambda locks the
 // fix for bugs 2 & 3 from reliable #1621 / staging session
 // sess_v2_CnqUJ6NRJnLC: the imported aws_lambda_function had Attrs=null
 // (Cloud Control enrichment captured nothing), so the composed resource
@@ -18,7 +18,7 @@ import (
 // imported_resource_missing_required_attr issue at compose time, naming
 // the exact missing keys, rather than letting the malformed HCL reach
 // terraform plan.
-func TestValidateImportedResources_MissingRequiredAttr_Lambda(t *testing.T) {
+func TestValidateImportedEmitReadiness_MissingRequiredAttr_Lambda(t *testing.T) {
 	t.Parallel()
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{
@@ -31,7 +31,7 @@ func TestValidateImportedResources_MissingRequiredAttr_Lambda(t *testing.T) {
 		// Attrs deliberately nil — mirrors the production payload where
 		// discovery returned nothing for the Lambda.
 	}
-	issues := ValidateImportedResources("aws", []imported.ImportedResource{ir})
+	issues := ValidateImportedEmitReadiness("aws", []imported.ImportedResource{ir})
 	require.Equal(t, 1, countCode(issues, "imported_resource_missing_required_attr"),
 		"expected exactly one missing-required-attr issue, got: %v", issueCodes(issues))
 
@@ -48,11 +48,11 @@ func TestValidateImportedResources_MissingRequiredAttr_Lambda(t *testing.T) {
 	assert.Equal(t, "imported.aws_lambda_function.io_lambdaa0ca", found.Field)
 }
 
-// TestValidateImportedResources_MissingRequiredAttr_IAMPolicy locks bug
+// TestValidateImportedEmitReadiness_MissingRequiredAttr_IAMPolicy locks bug
 // 2: an aws_iam_policy whose discovery payload omits the required
 // `policy` argument (the pre-fix behavior — CFN's PolicyDocument was
 // never renamed to `policy`) must be flagged.
-func TestValidateImportedResources_MissingRequiredAttr_IAMPolicy(t *testing.T) {
+func TestValidateImportedEmitReadiness_MissingRequiredAttr_IAMPolicy(t *testing.T) {
 	t.Parallel()
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{
@@ -66,7 +66,7 @@ func TestValidateImportedResources_MissingRequiredAttr_IAMPolicy(t *testing.T) {
 		// shape of the broken production payload.
 		Attrs: []byte(`{"path":{"literal":"/"},"description":{"literal":"x"}}`),
 	}
-	issues := ValidateImportedResources("aws", []imported.ImportedResource{ir})
+	issues := ValidateImportedEmitReadiness("aws", []imported.ImportedResource{ir})
 	require.Equal(t, 1, countCode(issues, "imported_resource_missing_required_attr"),
 		"expected one missing-required-attr issue, got: %v", issueCodes(issues))
 	for _, i := range issues {
@@ -76,10 +76,10 @@ func TestValidateImportedResources_MissingRequiredAttr_IAMPolicy(t *testing.T) {
 	}
 }
 
-// TestValidateImportedResources_RequiredAttrPresent asserts NO
+// TestValidateImportedEmitReadiness_RequiredAttrPresent asserts NO
 // missing-required issue is raised when the discovery payload carries
 // every required argument — the post-fix happy path.
-func TestValidateImportedResources_RequiredAttrPresent(t *testing.T) {
+func TestValidateImportedEmitReadiness_RequiredAttrPresent(t *testing.T) {
 	t.Parallel()
 	lambda := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{
@@ -108,15 +108,15 @@ func TestValidateImportedResources_RequiredAttrPresent(t *testing.T) {
 			"policy":{"literal":"{}"}
 		}`),
 	}
-	issues := ValidateImportedResources("aws", []imported.ImportedResource{lambda, policy})
+	issues := ValidateImportedEmitReadiness("aws", []imported.ImportedResource{lambda, policy})
 	assert.Equal(t, 0, countCode(issues, "imported_resource_missing_required_attr"),
 		"no missing-required issue expected, got: %v", issueCodes(issues))
 }
 
-// TestValidateImportedResources_RequiredAttrViaOpaqueBag asserts the
+// TestValidateImportedEmitReadiness_RequiredAttrViaOpaqueBag asserts the
 // required-attr presence check also reads ir.Attributes (the opaque
 // fallback bag), not just typed Attrs.
-func TestValidateImportedResources_RequiredAttrViaOpaqueBag(t *testing.T) {
+func TestValidateImportedEmitReadiness_RequiredAttrViaOpaqueBag(t *testing.T) {
 	t.Parallel()
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{
@@ -131,16 +131,16 @@ func TestValidateImportedResources_RequiredAttrViaOpaqueBag(t *testing.T) {
 			"role":          "arn:aws:iam::123456789012:role/opaque",
 		},
 	}
-	issues := ValidateImportedResources("aws", []imported.ImportedResource{ir})
+	issues := ValidateImportedEmitReadiness("aws", []imported.ImportedResource{ir})
 	assert.Equal(t, 0, countCode(issues, "imported_resource_missing_required_attr"),
 		"opaque-bag required attrs must satisfy the check, got: %v", issueCodes(issues))
 }
 
-// TestValidateImportedResources_RemovedBlockExemptFromRequired asserts a
+// TestValidateImportedEmitReadiness_RemovedBlockExempt asserts a
 // removal-pending resource (emitted as a `removed {}` block, no resource
 // body) is NOT subjected to the required-argument check — a removed
 // block carries no arguments to be missing.
-func TestValidateImportedResources_RemovedBlockExemptFromRequired(t *testing.T) {
+func TestValidateImportedEmitReadiness_RemovedBlockExempt(t *testing.T) {
 	t.Parallel()
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{
@@ -152,9 +152,35 @@ func TestValidateImportedResources_RemovedBlockExemptFromRequired(t *testing.T) 
 		Tier:        imported.TierImportedMissing,
 		Remediation: imported.ActionRemoveFromInsideOut,
 	}
-	issues := ValidateImportedResources("aws", []imported.ImportedResource{ir})
+	issues := ValidateImportedEmitReadiness("aws", []imported.ImportedResource{ir})
 	assert.Equal(t, 0, countCode(issues, "imported_resource_missing_required_attr"),
 		"removed-block resources are exempt, got: %v", issueCodes(issues))
+}
+
+// TestValidateImportedResources_DoesNotFlagMissingRequired locks the
+// separation of concerns the discovery pipeline depends on: the
+// structural validator ValidateImportedResources runs on the
+// INTERMEDIATE discovery manifest (resources still being enriched by
+// dep-chase / drift-fix / Cloud Control passes), so it must NOT raise
+// imported_resource_missing_required_attr — that emit-readiness check
+// belongs to ValidateImportedEmitReadiness. Regressing this conflates
+// "manifest snapshot" with "ready to emit" and breaks the
+// cmd/insideout-import manifest writer.
+func TestValidateImportedResources_DoesNotFlagMissingRequired(t *testing.T) {
+	t.Parallel()
+	// A perfectly valid mid-pipeline snapshot: no typed Attrs yet.
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.midpipeline",
+			ImportID: "midpipeline-fn",
+		},
+		Tier: imported.TierImportedFlat,
+	}
+	issues := ValidateImportedResources("aws", []imported.ImportedResource{ir})
+	assert.Equal(t, 0, countCode(issues, "imported_resource_missing_required_attr"),
+		"manifest-path validator must not flag missing-required, got: %v", issueCodes(issues))
 }
 
 // TestMissingRequiredAttrs_UnregisteredTypeFailOpen asserts the helper

--- a/pkg/composer/imported_validate.go
+++ b/pkg/composer/imported_validate.go
@@ -61,21 +61,14 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 		}
 
 		got := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
-		// cloudOK gates the deeper per-record checks (decode, required-
-		// argument completeness) — a resource flagged for the wrong /
-		// unsupported cloud is not emitted into THIS compose, so layering
-		// additional issues on it is noise.
-		cloudOK := true
 		switch {
 		case got == "":
-			cloudOK = false
 			issues = append(issues, ValidationIssue{
 				Field:  field,
 				Code:   "imported_resource_unsupported_cloud",
 				Reason: "imported resource has empty Identity.Cloud; expected \"aws\" or \"gcp\"",
 			})
 		case got != "aws" && got != "gcp":
-			cloudOK = false
 			issues = append(issues, ValidationIssue{
 				Field:   field,
 				Value:   ir.Identity.Cloud,
@@ -84,7 +77,6 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 				Reason:  fmt.Sprintf("imported resource has unsupported Identity.Cloud %q; expected \"aws\" or \"gcp\"", ir.Identity.Cloud),
 			})
 		case want != "" && got != want:
-			cloudOK = false
 			issues = append(issues, ValidationIssue{
 				Field:  field,
 				Value:  ir.Identity.Cloud,
@@ -134,36 +126,14 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 			}
 		}
 
-		// Required-argument completeness. EmitImportedTF renders a
-		// `resource {}` block per emit-eligible resource; the wrapper
-		// runs a plain `terraform plan` against it (no
-		// `-generate-config-out`), so Terraform does NOT backfill
-		// required arguments from the imported state — the resource
-		// block must already carry every Required attribute. A sparse
-		// discovery payload (e.g. an `aws_lambda_function` whose Cloud
-		// Control enrichment soft-failed, leaving Attrs empty) would
-		// otherwise emit a partial block that fails plan with "Missing
-		// required argument". Surface it here as a blocking issue with
-		// the exact missing keys so the operator/agent gets an
-		// actionable error at compose time instead of an opaque
-		// terraform-plan failure. ResourceRecreate-mode missing
-		// resources are exempt — they emit a resource-only block whose
-		// purpose is to re-create from scratch and the same rule
-		// applies, so they are checked too; only the removed-block mode
-		// (which emits no resource body) is skipped.
-		if mode := classifyEmitMode(ir); cloudOK && (mode == emitModeResourceImport || mode == emitModeResourceOnly) {
-			if missing := missingRequiredAttrs(ir); len(missing) > 0 {
-				issues = append(issues, ValidationIssue{
-					Field: field,
-					Value: ir.Identity.Type,
-					Code:  "imported_resource_missing_required_attr",
-					Reason: fmt.Sprintf(
-						"imported %s %q is missing required argument(s) %s; discovery did not capture them and Terraform plan will fail — the resource block is not plannable",
-						ir.Identity.Type, ir.Identity.Address, strings.Join(missing, ", ")),
-					Suggestion: "re-run discovery for this resource, or verify the cloud-credential scope can read the resource's full configuration",
-				})
-			}
-		}
+		// Required-argument completeness is intentionally NOT checked
+		// here — see ValidateImportedEmitReadiness. ValidateImportedResources
+		// runs on the discovery manifest, an INTERMEDIATE artifact whose
+		// resources are still being enriched (dep-chase appends resources,
+		// drift-fix converges, the Cloud Control enricher lands typed
+		// Attrs in a later pass). Required args are guaranteed only at
+		// compose/emit time; gating the manifest writer on them would
+		// reject a perfectly valid mid-pipeline snapshot.
 	}
 
 	for addr, idxs := range addressIndex {
@@ -178,6 +148,71 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 		})
 	}
 
+	return issues
+}
+
+// ValidateImportedEmitReadiness runs the emit-time-only checks on irs:
+// checks that are meaningful only once discovery has finished and the
+// composer is about to render `/imported.tf`. Unlike
+// ValidateImportedResources (which validates the INTERMEDIATE discovery
+// manifest — a snapshot whose resources are still being enriched by
+// dep-chase / drift-fix / Cloud Control passes), this function assumes a
+// final, ready-to-emit resource set.
+//
+// Issue codes:
+//
+//   - imported_resource_missing_required_attr — an emit-eligible resource
+//     is missing one or more schema-Required arguments. EmitImportedTF
+//     renders a `resource {}` block per emit-eligible resource and the
+//     deploy wrapper runs a plain `terraform plan` (no
+//     `-generate-config-out`), so Terraform does NOT backfill required
+//     arguments from the imported state — the resource block must already
+//     carry every Required attribute. A sparse discovery payload (e.g. an
+//     `aws_lambda_function` whose Cloud Control enrichment soft-failed,
+//     leaving Attrs empty) would otherwise emit a partial block that
+//     fails plan with an opaque "Missing required argument". This surfaces
+//     it with the exact missing keys at compose time instead.
+//
+// The check is skipped for resources flagged by ValidateImportedResources
+// for the wrong / unsupported cloud (they are not emitted into this
+// compose) and for removed-block-mode resources (which emit no resource
+// body). compose.go runs this alongside ValidateImportedResources before
+// EmitImportedTF; the discovery manifest writer deliberately does not.
+func ValidateImportedEmitReadiness(cloud string, irs []imported.ImportedResource) []ValidationIssue {
+	if len(irs) == 0 {
+		return nil
+	}
+	want := strings.ToLower(strings.TrimSpace(cloud))
+	var issues []ValidationIssue
+	for i, ir := range irs {
+		if !isImportedTier(ir.Tier) {
+			continue
+		}
+		got := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
+		// Wrong / unsupported cloud — not emitted into this compose;
+		// ValidateImportedResources already reports the cloud issue.
+		if got != "aws" && got != "gcp" {
+			continue
+		}
+		if want != "" && got != want {
+			continue
+		}
+		mode := classifyEmitMode(ir)
+		if mode != emitModeResourceImport && mode != emitModeResourceOnly {
+			continue
+		}
+		if missing := missingRequiredAttrs(ir); len(missing) > 0 {
+			issues = append(issues, ValidationIssue{
+				Field: importedField(ir, i),
+				Value: ir.Identity.Type,
+				Code:  "imported_resource_missing_required_attr",
+				Reason: fmt.Sprintf(
+					"imported %s %q is missing required argument(s) %s; discovery did not capture them and Terraform plan will fail — the resource block is not plannable",
+					ir.Identity.Type, ir.Identity.Address, strings.Join(missing, ", ")),
+				Suggestion: "re-run discovery for this resource, or verify the cloud-credential scope can read the resource's full configuration",
+			})
+		}
+	}
 	return issues
 }
 

--- a/pkg/composer/imported_validate.go
+++ b/pkg/composer/imported_validate.go
@@ -1,6 +1,7 @@
 package composer
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -60,14 +61,21 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 		}
 
 		got := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
+		// cloudOK gates the deeper per-record checks (decode, required-
+		// argument completeness) — a resource flagged for the wrong /
+		// unsupported cloud is not emitted into THIS compose, so layering
+		// additional issues on it is noise.
+		cloudOK := true
 		switch {
 		case got == "":
+			cloudOK = false
 			issues = append(issues, ValidationIssue{
 				Field:  field,
 				Code:   "imported_resource_unsupported_cloud",
 				Reason: "imported resource has empty Identity.Cloud; expected \"aws\" or \"gcp\"",
 			})
 		case got != "aws" && got != "gcp":
+			cloudOK = false
 			issues = append(issues, ValidationIssue{
 				Field:   field,
 				Value:   ir.Identity.Cloud,
@@ -76,6 +84,7 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 				Reason:  fmt.Sprintf("imported resource has unsupported Identity.Cloud %q; expected \"aws\" or \"gcp\"", ir.Identity.Cloud),
 			})
 		case want != "" && got != want:
+			cloudOK = false
 			issues = append(issues, ValidationIssue{
 				Field:  field,
 				Value:  ir.Identity.Cloud,
@@ -121,6 +130,37 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 					Value:  ir.Identity.Type,
 					Code:   "imported_resource_decode_failed",
 					Reason: fmt.Sprintf("decode typed Attrs for %q failed: %s", ir.Identity.Type, err.Error()),
+				})
+			}
+		}
+
+		// Required-argument completeness. EmitImportedTF renders a
+		// `resource {}` block per emit-eligible resource; the wrapper
+		// runs a plain `terraform plan` against it (no
+		// `-generate-config-out`), so Terraform does NOT backfill
+		// required arguments from the imported state — the resource
+		// block must already carry every Required attribute. A sparse
+		// discovery payload (e.g. an `aws_lambda_function` whose Cloud
+		// Control enrichment soft-failed, leaving Attrs empty) would
+		// otherwise emit a partial block that fails plan with "Missing
+		// required argument". Surface it here as a blocking issue with
+		// the exact missing keys so the operator/agent gets an
+		// actionable error at compose time instead of an opaque
+		// terraform-plan failure. ResourceRecreate-mode missing
+		// resources are exempt — they emit a resource-only block whose
+		// purpose is to re-create from scratch and the same rule
+		// applies, so they are checked too; only the removed-block mode
+		// (which emits no resource body) is skipped.
+		if mode := classifyEmitMode(ir); cloudOK && (mode == emitModeResourceImport || mode == emitModeResourceOnly) {
+			if missing := missingRequiredAttrs(ir); len(missing) > 0 {
+				issues = append(issues, ValidationIssue{
+					Field: field,
+					Value: ir.Identity.Type,
+					Code:  "imported_resource_missing_required_attr",
+					Reason: fmt.Sprintf(
+						"imported %s %q is missing required argument(s) %s; discovery did not capture them and Terraform plan will fail — the resource block is not plannable",
+						ir.Identity.Type, ir.Identity.Address, strings.Join(missing, ", ")),
+					Suggestion: "re-run discovery for this resource, or verify the cloud-credential scope can read the resource's full configuration",
 				})
 			}
 		}
@@ -264,6 +304,57 @@ func ValidateProvenanceConflicts(cloud string, irs []imported.ImportedResource, 
 	}
 
 	return issues
+}
+
+// missingRequiredAttrs returns the sorted snake_case names of the
+// schema-Required attributes that are absent from ir's discovered
+// attribute bag. Returns nil when the type has no registered schema
+// (fail-open: the long tail of unregistered types runs the opaque-attr
+// fallback and the composer can't reason about their required set), when
+// the type has no Required fields, or when every Required field is
+// present.
+//
+// "Present" means the key appears in the typed Attrs JSON object (the
+// post-discovery payload) OR — for the opaque-attr fallback path — in
+// ir.Attributes. A key whose value is JSON null still counts as present:
+// the composer emits `attr = null`, which Terraform accepts as an
+// explicit value; the un-plannable case this guards against is the key
+// being absent entirely.
+//
+// The synthetic `id` attribute is never treated as required even if a
+// provider schema marks it so — it is stripped from emission by
+// stripResourceIDAttr and belongs only in the `import {}` block.
+func missingRequiredAttrs(ir imported.ImportedResource) []string {
+	_, schema, ok := generated.Lookup(ir.Identity.Type)
+	if !ok {
+		return nil
+	}
+	present := map[string]bool{}
+	if len(ir.Attrs) > 0 {
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(ir.Attrs, &obj); err == nil {
+			for k := range obj {
+				present[k] = true
+			}
+		}
+	}
+	for k := range ir.Attributes {
+		present[k] = true
+	}
+	var missing []string
+	for name, fs := range schema {
+		if !fs.Required {
+			continue
+		}
+		if name == computedResourceIDAttr {
+			continue
+		}
+		if !present[name] {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(missing)
+	return missing
 }
 
 // isImportedTier reports whether t is a tier that the composer emits as flat


### PR DESCRIPTION
## Summary

The `/import` reverse-Terraform wizard composed a malformed `imported.tf` that failed `terraform plan` three ways (repro: reliable staging session `sess_v2_CnqUJ6NRJnLC`, AWS account `031780745048`). Root-causes and fixes:

- **Bug 1 — `id` emitted as a resource argument.** Discovery's `synthIDFromField` normalizer lands the computed `id` into the typed `Attrs` bag, and `aws_cloudwatch_log_group`'s generated schema marks `id` as `Optional+Computed` so `MarshalHCL` emitted it. `id` is never a legal `resource {}` argument (`terraform plan` → "Invalid or unknown key") — it belongs only in the `import {}` block. `imported_emit.go` now strips `id` from both the typed-`Attrs` and opaque-`Attributes` emission paths.

- **Bug 2 — `aws_iam_policy` missing the required `policy` argument.** CloudFormation `AWS::IAM::ManagedPolicy` surfaces the policy as a nested `PolicyDocument` *object*; Terraform's `policy` is a JSON-encoded *string*. The Cloud Control enricher's generic CamelCase→snake_case projection turns it into `policy_document` (no matching json tag) and silently drops it. New `jsonStringifyField` normalizer, wired into the `aws_iam_policy` config, JSON-stringifies `PolicyDocument` → `policy`.

- **Bug 3 — `aws_lambda_function` missing required `role` + `function_name`.** The discovered attribute bag was empty (`Attrs = null`). New `imported_resource_missing_required_attr` validation flags any emit-eligible imported resource whose discovery payload omits a schema-`Required` argument, surfacing un-plannable HCL as a blocking, actionable compose-time error (naming the exact missing keys) instead of an opaque `terraform plan` failure.

## Coordination

Bug 3's empty Lambda attribute bag is the **same root cause** as reliable #1620's "CONFIGURABLE shows RUNTIME/MEMORY/TIMEOUT as Not configured" — both surfaces read the same sparse discovery payload. That reliable PR (`fix/imported-lambda-observable-config`) only touches `imported_metrics.go` (the OBSERVABLE creds-broker symptom); no file overlap. The discovery-side fix here is upstream of both surfaces.

## Test plan

- [x] `go test ./pkg/composer/ ./cmd/insideout-import/awsdiscover/` — 2420 pass
- [x] `go vet` clean on changed packages
- [x] `golangci-lint` — no new issues in changed files
- [x] Mutation-fragile HCL string-assertion tests: no `id =` in any `resource {}` block (typed + opaque paths), `aws_iam_policy` carries `policy`, whole doc parses as valid HCL
- [x] Validator tests: `imported_resource_missing_required_attr` raised for the empty Lambda (names `role` + `function_name`) and missing-`policy` IAM policy; not raised on the happy path or wrong-cloud resources
- [x] End-to-end `PolicyDocument` → `policy` Cloud Control enricher pin

Closes #638