### PR TITLE
fix(awsdiscover): capture full aws_lambda_function attrs via Cloud Control

### DIFF
--- a/cmd/insideout-import/awsdiscover/cloudcontrol_lambda_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_lambda_enrich_test.go
@@ -1,0 +1,278 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// lambdaCCConfig fetches the registered cloudControlTypeConfigs entry for
+// aws_lambda_function so the tests exercise the production Normalizer
+// chain (wrapObjectAsList(...) for every CFN object-shaped block field)
+// rather than a hand-built one. Fails the test if the entry is missing —
+// a registration regression would otherwise silently fall back to the
+// generic no-normalizer path that drops the whole payload.
+func lambdaCCConfig(t *testing.T) cloudControlConfig {
+	t.Helper()
+	for _, c := range cloudControlTypeConfigs {
+		if c.TFType == "aws_lambda_function" {
+			return c
+		}
+	}
+	t.Fatal("no cloudControlTypeConfigs entry for aws_lambda_function")
+	return cloudControlConfig{}
+}
+
+// newLambdaEnricher builds the aws_lambda_function Cloud Control enricher
+// wired exactly as NewAWSDiscoverer wires it: the per-type Normalizer
+// chained with the generic stripComputedOnlyForType filter (#582). get is
+// the GetResource fake. This keeps the tests honest against the real
+// registration path.
+func newLambdaEnricher(t *testing.T, get cloudControlGetResourceFn) *cloudControlEnricher {
+	t.Helper()
+	cfg := lambdaCCConfig(t)
+	norm := chain(cfg.Normalizer, stripComputedOnlyForType(cfg.TFType))
+	return newCloudControlEnricherWithNormalizer(cfg.TFType, cfg.CloudFormationType, get, norm)
+}
+
+// decodeLambda runs the enriched Attrs back through the typed registry so
+// the assertions read field values off the strongly-typed Layer-1 struct
+// instead of poking at raw JSON.
+func decodeLambda(t *testing.T, attrs json.RawMessage) *generated.AWSLambdaFunction {
+	t.Helper()
+	decoded, err := generated.UnmarshalAttrs("aws_lambda_function", attrs)
+	require.NoError(t, err, "enriched Attrs must round-trip through UnmarshalAttrs")
+	fn, ok := decoded.(*generated.AWSLambdaFunction)
+	require.Truef(t, ok, "decoded type is %T, want *generated.AWSLambdaFunction", decoded)
+	return fn
+}
+
+// TestCloudControlEnricher_Enrich_LambdaFunction is the load-bearing
+// regression for the discovery-side half of reliable #1620: the CFN
+// AWS::Lambda::Function model serializes each singleton nested config
+// (Environment / TracingConfig / VpcConfig / …) as a plain JSON object,
+// but the generated Layer-1 struct types each as a `,blocks` slice. An
+// object landing on a slice field made encoding/json hard-fail, aborting
+// the WHOLE generated.UnmarshalAttrs call — so the imported Lambda came
+// back with Attrs=nil and `terraform plan` then failed on the missing
+// required `function_name` / `role` arguments.
+//
+// The fix is the per-type wrapObjectAsList Normalizer chain registered
+// in cloudControlTypeConfigs. This test feeds a realistic full
+// AWS::Lambda::Function payload through the production enricher wiring
+// and asserts every required + user-meaningful attribute lands with the
+// correct snake_case TF key and value.
+func TestCloudControlEnricher_Enrich_LambdaFunction(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{props: `{
+		"FunctionName": "io-cnquj6nrjnlc-prod-lambda",
+		"Arn": "arn:aws:lambda:us-east-1:031780745048:function:io-cnquj6nrjnlc-prod-lambda",
+		"Role": "arn:aws:iam::031780745048:role/io-cnquj6nrjnlc-prod-lambda-exec",
+		"Runtime": "python3.12",
+		"Handler": "index.handler",
+		"MemorySize": 512,
+		"Timeout": 45,
+		"Description": "imported function",
+		"PackageType": "Zip",
+		"Architectures": ["arm64"],
+		"Code": {"S3Bucket": "deploy-bucket", "S3Key": "fn.zip"},
+		"Environment": {"Variables": {"LOG_LEVEL": "info"}},
+		"TracingConfig": {"Mode": "Active"},
+		"VpcConfig": {"SecurityGroupIds": ["sg-aaa"], "SubnetIds": ["subnet-bbb"]},
+		"EphemeralStorage": {"Size": 1024},
+		"DeadLetterConfig": {"TargetArn": "arn:aws:sqs:us-east-1:031780745048:dlq"},
+		"LoggingConfig": {"LogFormat": "JSON", "LogGroup": "/aws/lambda/io-prod"}
+	}`}
+	enr := newLambdaEnricher(t, fake.call)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_lambda_function",
+			ImportID: "io-cnquj6nrjnlc-prod-lambda",
+			Address:  "aws_lambda_function.io_prod_lambda",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+	require.NotEmpty(t, ir.Attrs, "Attrs must not be empty after enrichment")
+
+	require.NotNil(t, fake.gotInput)
+	assert.Equal(t, "AWS::Lambda::Function", *fake.gotInput.TypeName)
+	assert.Equal(t, "io-cnquj6nrjnlc-prod-lambda", *fake.gotInput.Identifier)
+
+	fn := decodeLambda(t, ir.Attrs)
+
+	// --- Terraform Required arguments (function_name, role). ---
+	require.NotNil(t, fn.FunctionName)
+	require.NotNil(t, fn.FunctionName.Literal)
+	assert.Equal(t, "io-cnquj6nrjnlc-prod-lambda", *fn.FunctionName.Literal)
+	require.NotNil(t, fn.Role)
+	require.NotNil(t, fn.Role.Literal)
+	assert.Equal(t, "arn:aws:iam::031780745048:role/io-cnquj6nrjnlc-prod-lambda-exec", *fn.Role.Literal)
+
+	// --- CONFIGURABLE-panel scalars (runtime / memory_size / timeout /
+	// handler) — the reliable #1620 "Not configured" symptom. ---
+	require.NotNil(t, fn.Runtime)
+	require.NotNil(t, fn.Runtime.Literal)
+	assert.Equal(t, "python3.12", *fn.Runtime.Literal)
+	require.NotNil(t, fn.MemorySize)
+	require.NotNil(t, fn.MemorySize.Literal)
+	assert.Equal(t, int64(512), *fn.MemorySize.Literal)
+	require.NotNil(t, fn.Timeout)
+	require.NotNil(t, fn.Timeout.Literal)
+	assert.Equal(t, int64(45), *fn.Timeout.Literal)
+	require.NotNil(t, fn.Handler)
+	require.NotNil(t, fn.Handler.Literal)
+	assert.Equal(t, "index.handler", *fn.Handler.Literal)
+
+	// --- Additional cleanly-mapped scalars. ---
+	require.NotNil(t, fn.Description)
+	require.NotNil(t, fn.Description.Literal)
+	assert.Equal(t, "imported function", *fn.Description.Literal)
+	require.NotNil(t, fn.PackageType)
+	require.NotNil(t, fn.PackageType.Literal)
+	assert.Equal(t, "Zip", *fn.PackageType.Literal)
+	require.Len(t, fn.Architectures, 1)
+	require.NotNil(t, fn.Architectures[0])
+	require.NotNil(t, fn.Architectures[0].Literal)
+	assert.Equal(t, "arm64", *fn.Architectures[0].Literal)
+
+	// --- CFN object-shaped fields wrapped into singleton TF blocks.
+	// The Environment.Variables key (`LOG_LEVEL`) is operator data and
+	// must survive verbatim — NOT camelToSnake-mangled to `log__level`. ---
+	require.Len(t, fn.Environment, 1, "Environment object must wrap into a one-element block slice")
+	require.NotContains(t, fn.Environment[0].Variables, "log__level",
+		"environment-variable keys must not be snake_case-mangled")
+	require.NotNil(t, fn.Environment[0].Variables["LOG_LEVEL"])
+	require.NotNil(t, fn.Environment[0].Variables["LOG_LEVEL"].Literal)
+	assert.Equal(t, "info", *fn.Environment[0].Variables["LOG_LEVEL"].Literal)
+
+	require.Len(t, fn.TracingConfig, 1)
+	require.NotNil(t, fn.TracingConfig[0].Mode)
+	require.NotNil(t, fn.TracingConfig[0].Mode.Literal)
+	assert.Equal(t, "Active", *fn.TracingConfig[0].Mode.Literal)
+
+	require.Len(t, fn.VPCConfig, 1)
+	require.Len(t, fn.VPCConfig[0].SecurityGroupIDS, 1)
+	require.NotNil(t, fn.VPCConfig[0].SecurityGroupIDS[0].Literal)
+	assert.Equal(t, "sg-aaa", *fn.VPCConfig[0].SecurityGroupIDS[0].Literal)
+	require.Len(t, fn.VPCConfig[0].SubnetIDS, 1)
+	require.NotNil(t, fn.VPCConfig[0].SubnetIDS[0].Literal)
+	assert.Equal(t, "subnet-bbb", *fn.VPCConfig[0].SubnetIDS[0].Literal)
+
+	require.Len(t, fn.EphemeralStorage, 1)
+	require.NotNil(t, fn.EphemeralStorage[0].Size)
+	require.NotNil(t, fn.EphemeralStorage[0].Size.Literal)
+	assert.Equal(t, float64(1024), *fn.EphemeralStorage[0].Size.Literal)
+
+	require.Len(t, fn.DeadLetterConfig, 1)
+	require.NotNil(t, fn.DeadLetterConfig[0].TargetARN)
+	require.NotNil(t, fn.DeadLetterConfig[0].TargetARN.Literal)
+	assert.Equal(t, "arn:aws:sqs:us-east-1:031780745048:dlq", *fn.DeadLetterConfig[0].TargetARN.Literal)
+
+	require.Len(t, fn.LoggingConfig, 1)
+	require.NotNil(t, fn.LoggingConfig[0].LogFormat)
+	require.NotNil(t, fn.LoggingConfig[0].LogFormat.Literal)
+	assert.Equal(t, "JSON", *fn.LoggingConfig[0].LogFormat.Literal)
+
+	// --- Computed-only fields are elided by stripComputedOnlyForType.
+	// `arn` is Computed && !Configurable on the aws_lambda_function
+	// schema, so it must NOT survive into the emit payload (decision
+	// #5). Asserting its absence guards the chain ordering: the
+	// wrapObjectAsList steps must not perturb the strip filter. ---
+	assert.Nil(t, fn.ARN, "computed-only `arn` must be stripped from enriched Attrs")
+}
+
+// TestCloudControlEnricher_Enrich_LambdaFunction_Minimal asserts the fix
+// holds for the minimal-shape payload too: a Lambda with no nested
+// config blocks at all. This is the pre-fix happy-ish case — it should
+// have always worked — and pins that the Normalizer chain is a no-op
+// when none of the wrapped keys are present (idempotent / absent-key
+// pass-through contract of wrapObjectAsList).
+func TestCloudControlEnricher_Enrich_LambdaFunction_Minimal(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{props: `{
+		"FunctionName": "minimal-fn",
+		"Role": "arn:aws:iam::123456789012:role/minimal",
+		"Runtime": "go1.x",
+		"Handler": "bootstrap",
+		"MemorySize": 128,
+		"Timeout": 3
+	}`}
+	enr := newLambdaEnricher(t, fake.call)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_lambda_function",
+			ImportID: "minimal-fn",
+			Address:  "aws_lambda_function.minimal",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+
+	fn := decodeLambda(t, ir.Attrs)
+	require.NotNil(t, fn.FunctionName)
+	require.NotNil(t, fn.FunctionName.Literal)
+	assert.Equal(t, "minimal-fn", *fn.FunctionName.Literal)
+	require.NotNil(t, fn.Role)
+	require.NotNil(t, fn.Role.Literal)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/minimal", *fn.Role.Literal)
+	require.NotNil(t, fn.Runtime)
+	require.NotNil(t, fn.Runtime.Literal)
+	assert.Equal(t, "go1.x", *fn.Runtime.Literal)
+	require.NotNil(t, fn.MemorySize)
+	require.NotNil(t, fn.MemorySize.Literal)
+	assert.Equal(t, int64(128), *fn.MemorySize.Literal)
+	require.NotNil(t, fn.Timeout)
+	require.NotNil(t, fn.Timeout.Literal)
+	assert.Equal(t, int64(3), *fn.Timeout.Literal)
+	assert.Empty(t, fn.Environment, "absent Environment must not synthesize a block")
+	assert.Empty(t, fn.VPCConfig, "absent VpcConfig must not synthesize a block")
+}
+
+// TestCloudControlEnricher_Enrich_LambdaFunction_SatisfiesEmitReadiness
+// closes the loop end-to-end: it pipes a discovered + enriched
+// aws_lambda_function through pkg/composer.ValidateImportedEmitReadiness
+// (the #639 compose-time guard) and asserts the enriched Attrs no longer
+// trips the imported_resource_missing_required_attr issue. Before the
+// wrapObjectAsList fix the enricher returned Attrs=nil and this validator
+// flagged the missing `function_name` / `role` — the exact reliable
+// #1620 symptom. After the fix the validator is clean.
+func TestCloudControlEnricher_Enrich_LambdaFunction_SatisfiesEmitReadiness(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{props: `{
+		"FunctionName": "io-prod-lambda",
+		"Arn": "arn:aws:lambda:us-east-1:031780745048:function:io-prod-lambda",
+		"Role": "arn:aws:iam::031780745048:role/io-prod-lambda-exec",
+		"Runtime": "python3.12",
+		"Handler": "index.handler",
+		"MemorySize": 256,
+		"Timeout": 30,
+		"Environment": {"Variables": {"FOO": "bar"}},
+		"TracingConfig": {"Mode": "PassThrough"}
+	}`}
+	enr := newLambdaEnricher(t, fake.call)
+
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.io_prod_lambda",
+			ImportID: "io-prod-lambda",
+		},
+		Tier: imported.TierImportedFlat,
+	}
+	require.NoError(t, enr.Enrich(context.Background(), &ir, EnrichClients{}))
+
+	issues := composer.ValidateImportedEmitReadiness("aws", []imported.ImportedResource{ir})
+	for _, is := range issues {
+		assert.NotEqualf(t, "imported_resource_missing_required_attr", is.Code,
+			"enriched Lambda must satisfy emit-readiness, got issue: %s — %s", is.Code, is.Reason)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers.go
@@ -508,6 +508,116 @@ func jsonStringifyField(from, to string) Normalizer {
 	}
 }
 
+// wrapObjectAsList returns a Normalizer that wraps a top-level key whose
+// CloudFormation value is a single JSON *object* into a one-element JSON
+// *array* (`{...}` → `[{...}]`).
+//
+// This bridges a CloudFormation-vs-Terraform shape gap for nested
+// single-instance config blocks. CloudFormation models a singleton
+// nested config (e.g. `AWS::Lambda::Function.Environment`,
+// `.TracingConfig`, `.VpcConfig`) as a plain JSON object, but the
+// Terraform provider exposes the same config as a nested *block* — the
+// generated Layer-1 struct types it as a slice (`[]AWSLambdaFunctionEnvironment`,
+// `tf:"environment,blocks"`). An object landing on a slice-typed field
+// makes `encoding/json` hard-fail with "cannot unmarshal object into Go
+// struct field ... of type []...", which aborts the *entire*
+// generated.UnmarshalAttrs call — so a single un-normalized block field
+// drops the whole resource's Attrs to nil, not just the offending key
+// (reliable #1620: imported aws_lambda_function came back with empty
+// Attrs, and terraform plan then failed on the missing required
+// `function_name` / `role` args — presets #638/#639).
+//
+// Idempotent / fail-open:
+//   - absent key → pass through unchanged.
+//   - value already a list → pass through unchanged (re-run safe, and a
+//     CFN array-typed property such as a *plural* `FileSystemConfigs`
+//     stays untouched).
+//   - value is a scalar or null → pass through unchanged; the downstream
+//     unmarshal will surface the genuine shape error rather than this
+//     helper masking it.
+//
+// Operates only on the named top-level key. The wrapped object's inner
+// keys are NOT renamed here — shapeCFNForLayer1 still recurses into the
+// single list element and applies the camelToSnake projection, so CFN
+// `{"Variables": {...}}` reaches the generated struct as
+// `{"variables": {...}}`.
+func wrapObjectAsList(key string) Normalizer {
+	return func(in json.RawMessage) (json.RawMessage, error) {
+		if key == "" {
+			return in, nil
+		}
+		m, err := decodeObject(in)
+		if err != nil {
+			return nil, fmt.Errorf("wrapObjectAsList(%q): %w", key, err)
+		}
+		if m == nil {
+			return in, nil
+		}
+		raw, ok := m[key]
+		if !ok || raw == nil {
+			return in, nil
+		}
+		obj, ok := raw.(map[string]any)
+		if !ok {
+			// Already a list, or a scalar — leave it for the downstream
+			// unmarshal to accept (list) or reject (scalar).
+			return in, nil
+		}
+		m[key] = []any{obj}
+		return encodeObject(m)
+	}
+}
+
+// verbatimMapField returns a Normalizer that marks a nested
+// user-data map so its keys bypass the CFN-CamelCase → snake_case
+// projection — the same mechanism flattenTagList uses for tag keys.
+//
+// The path is `outerKey` (a top-level object) → `innerKey` (a map whose
+// keys are operator-chosen identifiers). The classic case is
+// `AWS::Lambda::Function.Environment.Variables`: the Variables keys are
+// environment-variable NAMES (`LOG_LEVEL`, `DB_HOST`), and the generic
+// shapeCFNForLayer1 recursion would camelToSnake-mangle them
+// (`LOG_LEVEL` → `log__level`), corrupting the emitted HCL. Wrapping the
+// inner map under verbatimMarkerKey opts that sub-tree out of renaming
+// while still applying the scalar-leaf {"literal": …} wrap the generated
+// `map[string]*Value[string]` field decodes.
+//
+// Order matters: run this BEFORE wrapObjectAsList for the same outer key
+// — it expects `outerKey` to still hold a plain object, and leaves the
+// object-vs-list wrapping to the later step.
+//
+// Idempotent / fail-open: an absent outer key, an outer value that is
+// not an object, an absent inner key, an inner value that is not an
+// object, or an inner value already wrapped under the verbatim marker
+// all pass through unchanged.
+func verbatimMapField(outerKey, innerKey string) Normalizer {
+	return func(in json.RawMessage) (json.RawMessage, error) {
+		if outerKey == "" || innerKey == "" {
+			return in, nil
+		}
+		m, err := decodeObject(in)
+		if err != nil {
+			return nil, fmt.Errorf("verbatimMapField(%q, %q): %w", outerKey, innerKey, err)
+		}
+		if m == nil {
+			return in, nil
+		}
+		outer, ok := m[outerKey].(map[string]any)
+		if !ok {
+			return in, nil
+		}
+		inner, ok := outer[innerKey].(map[string]any)
+		if !ok {
+			return in, nil
+		}
+		if _, wrapped := inner[verbatimMarkerKey]; wrapped && len(inner) == 1 {
+			return in, nil
+		}
+		outer[innerKey] = map[string]any{verbatimMarkerKey: inner}
+		return encodeObject(m)
+	}
+}
+
 // decodeObject is the shared parse step. Returns (nil, nil) for an
 // empty / null payload so helpers can pass-through cleanly without
 // special-casing.

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers_test.go
@@ -806,3 +806,215 @@ func TestJSONStringifyField(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// TestWrapObjectAsList pins the wrapObjectAsList contract: a single CFN
+// object value at the named key is rewrapped into a one-element list so
+// it decodes into a Terraform `,blocks` slice field. Without this the
+// generated.UnmarshalAttrs call hard-fails on the object-vs-slice
+// mismatch and drops the whole resource's Attrs (reliable #1620).
+func TestWrapObjectAsList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("object value is wrapped into a one-element list", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":{"FOO":"bar"}}}`)
+		out, err := wrapObjectAsList("Environment")(in)
+		require.NoError(t, err)
+		m := asMap(t, out)
+		list, ok := m["Environment"].([]any)
+		require.Truef(t, ok, "Environment must be a list, got %T", m["Environment"])
+		require.Len(t, list, 1)
+		elem, ok := list[0].(map[string]any)
+		require.True(t, ok)
+		vars, ok := elem["Variables"].(map[string]any)
+		require.True(t, ok, "inner keys must be preserved unchanged")
+		assert.Equal(t, "bar", vars["FOO"])
+	})
+
+	t.Run("absent key is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"FunctionName":"fn"}`)
+		out, err := wrapObjectAsList("Environment")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("value already a list passes through unchanged", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":[{"Variables":{"FOO":"bar"}}]}`)
+		out, err := wrapObjectAsList("Environment")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out),
+			"an already-list value (or a CFN plural array property) must not be re-wrapped")
+	})
+
+	t.Run("scalar value passes through for downstream to reject", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":"oops"}`)
+		out, err := wrapObjectAsList("Environment")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out),
+			"a scalar must not be masked — the typed unmarshal surfaces the real shape error")
+	})
+
+	t.Run("null value is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":null}`)
+		out, err := wrapObjectAsList("Environment")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("empty key is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":{}}}`)
+		out, err := wrapObjectAsList("")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("idempotent across a re-run", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"TracingConfig":{"Mode":"Active"}}`)
+		once, err := wrapObjectAsList("TracingConfig")(in)
+		require.NoError(t, err)
+		twice, err := wrapObjectAsList("TracingConfig")(once)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(once), string(twice),
+			"applying the wrapper to an already-wrapped payload must be stable")
+	})
+
+	t.Run("malformed JSON surfaces an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := wrapObjectAsList("Environment")(json.RawMessage(`{not json`))
+		require.Error(t, err)
+	})
+
+	t.Run("only the named key is wrapped", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":{}},"VpcConfig":{"SubnetIds":[]}}`)
+		out, err := wrapObjectAsList("Environment")(in)
+		require.NoError(t, err)
+		m := asMap(t, out)
+		_, envIsList := m["Environment"].([]any)
+		assert.True(t, envIsList, "named key must be wrapped")
+		_, vpcIsObj := m["VpcConfig"].(map[string]any)
+		assert.True(t, vpcIsObj, "un-named key must be left untouched")
+	})
+}
+
+// verbatimInner pulls the inner map out of a `outer.inner` path and
+// asserts it is wrapped under the verbatim marker, returning the
+// unwrapped user-data map for further assertions.
+func verbatimInner(t *testing.T, raw json.RawMessage, outerKey, innerKey string) map[string]any {
+	t.Helper()
+	m := asMap(t, raw)
+	outer, ok := m[outerKey].(map[string]any)
+	require.Truef(t, ok, "%s must remain an object, got %T", outerKey, m[outerKey])
+	wrapper, ok := outer[innerKey].(map[string]any)
+	require.Truef(t, ok, "%s.%s must be an object, got %T", outerKey, innerKey, outer[innerKey])
+	inner, ok := wrapper[verbatimMarkerKey].(map[string]any)
+	require.Truef(t, ok, "%s.%s must be wrapped under the verbatim marker", outerKey, innerKey)
+	require.Lenf(t, wrapper, 1, "verbatim wrapper must hold only the marker key")
+	return inner
+}
+
+// TestVerbatimMapField pins verbatimMapField: a nested user-data map
+// (Lambda's Environment.Variables) is marked verbatim so the downstream
+// shapeCFNForLayer1 recursion leaves its keys un-renamed.
+func TestVerbatimMapField(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inner map is wrapped under the verbatim marker", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":{"LOG_LEVEL":"info","DBHost":"x"}}}`)
+		out, err := verbatimMapField("Environment", "Variables")(in)
+		require.NoError(t, err)
+		inner := verbatimInner(t, out, "Environment", "Variables")
+		assert.Equal(t, "info", inner["LOG_LEVEL"], "operator key must survive verbatim")
+		assert.Equal(t, "x", inner["DBHost"], "CamelCase operator key must NOT be snake_cased")
+	})
+
+	t.Run("absent outer key is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"FunctionName":"fn"}`)
+		out, err := verbatimMapField("Environment", "Variables")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("absent inner key is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Other":"v"}}`)
+		out, err := verbatimMapField("Environment", "Variables")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("non-object outer value is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":"oops"}`)
+		out, err := verbatimMapField("Environment", "Variables")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("non-object inner value is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":"oops"}}`)
+		out, err := verbatimMapField("Environment", "Variables")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("idempotent across a re-run", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":{"FOO":"bar"}}}`)
+		once, err := verbatimMapField("Environment", "Variables")(in)
+		require.NoError(t, err)
+		twice, err := verbatimMapField("Environment", "Variables")(once)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(once), string(twice),
+			"re-marking an already-verbatim sub-tree must be stable")
+	})
+
+	t.Run("empty keys are a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":{"FOO":"bar"}}}`)
+		out, err := verbatimMapField("", "Variables")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+		out, err = verbatimMapField("Environment", "")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("malformed JSON surfaces an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := verbatimMapField("Environment", "Variables")(json.RawMessage(`{not json`))
+		require.Error(t, err)
+	})
+
+	t.Run("composes before wrapObjectAsList without corrupting keys", func(t *testing.T) {
+		t.Parallel()
+		// Replays the production Lambda chain ordering: mark verbatim,
+		// then wrap the object into a singleton list.
+		n := chain(
+			verbatimMapField("Environment", "Variables"),
+			wrapObjectAsList("Environment"),
+		)
+		out, err := n(json.RawMessage(`{"Environment":{"Variables":{"LOG_LEVEL":"info"}}}`))
+		require.NoError(t, err)
+		m := asMap(t, out)
+		list, ok := m["Environment"].([]any)
+		require.Truef(t, ok, "Environment must be a list, got %T", m["Environment"])
+		require.Len(t, list, 1)
+		elem, ok := list[0].(map[string]any)
+		require.True(t, ok)
+		wrapper, ok := elem["Variables"].(map[string]any)
+		require.True(t, ok)
+		inner, ok := wrapper[verbatimMarkerKey].(map[string]any)
+		require.True(t, ok, "verbatim marker must survive the list wrap")
+		assert.Equal(t, "info", inner["LOG_LEVEL"])
+	})
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -304,6 +304,37 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		NameHintFromProperties:  nameOrIdentifier("FunctionName"),
 		NativeIDsFromProperties: arnUnderKey("Arn"),
 		TagsFromProperties:      tagsFromKey("Tags"),
+		// Normalizer: CFN AWS::Lambda::Function models each singleton
+		// nested config (Environment, TracingConfig, VpcConfig, …) as a
+		// plain JSON *object*, but the Terraform provider exposes them as
+		// nested *blocks* — the generated Layer-1 struct types each as a
+		// slice (`[]AWSLambdaFunctionEnvironment`, `tf:"environment,blocks"`).
+		// An object landing on a slice-typed field makes encoding/json
+		// hard-fail, which aborts the WHOLE generated.UnmarshalAttrs call
+		// and drops every attribute — so the imported aws_lambda_function
+		// came back with empty Attrs and `terraform plan` then failed on
+		// the missing required `function_name` / `role` args
+		// (reliable #1620, sibling of presets #638/#639). wrapObjectAsList
+		// rewrites each object into a one-element list so the typed
+		// unmarshal succeeds and every scalar argument is captured too.
+		//
+		// verbatimMapField runs FIRST for Environment.Variables: the
+		// Variables keys are environment-variable NAMES (operator data),
+		// and the generic camelToSnake recursion would mangle them
+		// (`LOG_LEVEL` → `log__level`). The verbatim marker opts that
+		// sub-tree out of key renaming — same mechanism flattenTagList
+		// uses for tag keys.
+		Normalizer: chain(
+			verbatimMapField("Environment", "Variables"),
+			wrapObjectAsList("DeadLetterConfig"),
+			wrapObjectAsList("Environment"),
+			wrapObjectAsList("EphemeralStorage"),
+			wrapObjectAsList("ImageConfig"),
+			wrapObjectAsList("LoggingConfig"),
+			wrapObjectAsList("SnapStart"),
+			wrapObjectAsList("TracingConfig"),
+			wrapObjectAsList("VpcConfig"),
+		),
 	},
 
 	// =====================================================================


### PR DESCRIPTION
## Summary

- The CFN `AWS::Lambda::Function` model serializes each singleton nested config (`Environment`, `TracingConfig`, `VpcConfig`, `DeadLetterConfig`, `EphemeralStorage`, `ImageConfig`, `LoggingConfig`, `SnapStart`) as a plain JSON **object**, but the generated Terraform Layer-1 struct types each as a `,blocks` **slice**. An object landing on a slice-typed field made `encoding/json` hard-fail, which aborted the *entire* `generated.UnmarshalAttrs` call in `cloudControlEnricher.fetchAndMap` — so the discovered `aws_lambda_function` came back with `Attrs=nil`, every attribute dropped.
- Downstream: the composer emitted a resource block missing the provider-Required `function_name` / `role` args (`terraform plan` failed), and reliable's CONFIGURABLE panel showed runtime/memory/timeout as "Not configured" (reliable#1620).
- Fix: a per-type Cloud Control `Normalizer` chain for `aws_lambda_function`. `wrapObjectAsList` rewrites each CFN object-shaped block property into a one-element list so the typed unmarshal succeeds and every top-level scalar is captured. `verbatimMapField` marks `Environment.Variables` so the operator-chosen env-var keys bypass the `camelToSnake` projection (same mechanism `flattenTagList` uses for tag keys).
- Confirmed against staging session `sess_v2_CnqUJ6NRJnLC` (v18): the imported Lambda row had no `attrs` field at all.

Stacks logically after #639 (emit-readiness validator + `aws_iam_policy` `jsonStringifyField`) — no overlap with its changes. The enriched Lambda now satisfies `ValidateImportedEmitReadiness`, locked by a regression test.

## Test plan

- [x] `go test ./cmd/insideout-import/awsdiscover/ -run 'TestWrapObjectAsList|TestVerbatimMapField|TestCloudControlEnricher_Enrich_LambdaFunction' -count=1` — 23 pass
- [x] Full `./cmd/insideout-import/awsdiscover/...` + `./pkg/composer/...` suites — 3147 pass
- [x] `go vet` clean; `gofmt` clean; new code lint-clean (pre-existing lint issues in untouched files only)
- [x] Reproduced the pre-fix `Attrs=nil` failure, then verified the fix captures `function_name`, `role`, `runtime`, `memory_size`, `timeout`, `handler` + nested blocks
- [x] Regression test: enriched Lambda passes `pkg/composer.ValidateImportedEmitReadiness` with no `imported_resource_missing_required_attr` issue

## Review notes

- /review findings: no P0/P1. One P2 deferred (below).
- qa-professor: the agent subagent tool was unavailable in this environment; the qa rubric was applied manually — assertions are exact-match and mutation-fragile, helpers use `t.Helper()`, all tests `t.Parallel()` with no shared state, normalizer tests cover absent/list/scalar/null/malformed/idempotent branches.

## Deferred follow-up

- **[P2]** The CFN `AWS::Lambda::Function` `Tags` map keys are still `camelToSnake`-mangled by the generic projection in the enriched `Attrs.tags` (same class of bug as `Environment.Variables`, but `Tags` is Optional and resource tags are managed independently by the provenance tag injector). Fixing it cleanly needs a top-level verbatim-map variant — out of scope here to keep the PR focused on the required-arg / CONFIGURABLE-panel fix.

Closes #640