### PR TITLE
fix(awsdiscover): bundle — CloudControl enricher CFN-shape Attrs-drop fixes

### DIFF
--- a/cmd/insideout-import/awsdiscover/cloudcontrol_block_wrap.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_block_wrap.go
@@ -1,0 +1,175 @@
+package awsdiscover
+
+// cloudcontrol_block_wrap.go — generic CFN-object-on-block-slice
+// normalization (#640 follow-up; generalizes the per-type
+// wrapObjectAsList Normalizer PR #641 wired only for aws_lambda_function).
+//
+// The bug class
+// -------------
+// CloudFormation serializes a SINGLETON nested config (e.g.
+// AWS::Lambda::Function.Environment, AWS::EC2::VPCEndpoint.DnsOptions,
+// AWS::EKS::Cluster.ResourcesVpcConfig) as a plain JSON *object*. The
+// Terraform provider exposes the same config as a repeated nested
+// *block*, so the generated Layer-1 struct types the field as a Go
+// *slice* with a `tf:"<name>,blocks"` tag. An object landing on a
+// slice-typed field makes encoding/json hard-fail with "cannot
+// unmarshal object into Go struct field ... of type []...", which
+// aborts the *entire* generated.UnmarshalAttrs call — so one
+// un-normalized block field drops the whole resource's Attrs to nil,
+// not just the offending key (reliable #1620).
+//
+// Why generic instead of per-type
+// -------------------------------
+// PR #641 fixed this for aws_lambda_function with an explicit
+// wrapObjectAsList(...) chain naming each affected CFN property. An
+// audit of all 94 CloudControl-registered types found ~28 more block
+// fields across ~10 types with the identical mismatch (aws_eks_cluster
+// alone has ResourcesVpcConfig / AccessConfig / KubernetesNetworkConfig
+// / … ). Hand-registering each one is drift-prone — every newly
+// registered type, and every provider-schema regen that adds a block
+// field, would silently reintroduce the crash until someone remembers
+// to add a wrapObjectAsList line.
+//
+// The block-vs-attribute distinction is already encoded structurally:
+// the generated struct field carries `tf:"<name>,blocks"`. So a single
+// reflection pass over the registered struct type — wrapping any
+// object-valued key that lands on a `,blocks` field into a one-element
+// list — fixes every current and future type at one site. This pass
+// runs AFTER shapeCFNForLayer1 (keys already snake_case, matching the
+// struct tags) and BEFORE generated.UnmarshalAttrs.
+//
+// Relationship to the explicit Normalizer chain: wrapObjectAsList stays
+// in place for aws_lambda_function. It is now redundant with this pass
+// (both are idempotent — a value already a list passes through), but
+// harmless, and it keeps PR #641's reviewed tests and the per-type
+// verbatimMapField anchor untouched. New types need NO registration.
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// wrapObjectBlocksForType walks the shaped (post-shapeCFNForLayer1) CFN
+// payload for tfType and wraps every object-valued key that lands on a
+// `,blocks` slice field of the registered Layer-1 struct into a
+// one-element list, recursing through nested blocks. The shaped map is
+// mutated in place and also returned for call-site convenience.
+//
+// Fail-open: an unregistered tfType or a nil map passes through
+// unchanged — the downstream generated.UnmarshalAttrs already fails
+// loudly for a genuinely missing type, so no information is lost here.
+func wrapObjectBlocksForType(tfType string, shaped map[string]any) map[string]any {
+	if shaped == nil {
+		return shaped
+	}
+	goType, _, ok := generated.Lookup(tfType)
+	if !ok {
+		return shaped
+	}
+	wrapStructBlocks(goType, shaped)
+	return shaped
+}
+
+// wrapStructBlocks applies the object→one-element-list wrap for every
+// `,blocks` field of structType found in m, recursing into nested
+// block element structs. `,block` (single, pointer-backed) fields are
+// recursed into but never wrapped — encoding/json accepts an object on
+// a *struct field, so the singleton block shape is already correct;
+// the recursion only reaches any `,blocks` field nested inside it.
+//
+// Generated structs are acyclic, so the recursion always terminates.
+func wrapStructBlocks(structType reflect.Type, m map[string]any) {
+	for structType.Kind() == reflect.Pointer {
+		structType = structType.Elem()
+	}
+	if structType.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < structType.NumField(); i++ {
+		field := structType.Field(i)
+		name, kind := tfTagKind(field.Tag.Get("tf"))
+		if name == "" || kind == tfAttr {
+			continue
+		}
+		raw, ok := m[name]
+		if !ok || raw == nil {
+			continue
+		}
+		elemType := blockElemType(field.Type)
+		if elemType == nil {
+			continue
+		}
+		switch v := raw.(type) {
+		case map[string]any:
+			// Recurse first so nested `,blocks` are fixed regardless of
+			// whether this level needs the wrap.
+			wrapStructBlocks(elemType, v)
+			if kind == tfBlocks {
+				// Singleton CFN object on a repeated-block slice field —
+				// the crash case. Wrap into a one-element list.
+				m[name] = []any{v}
+			}
+		case []any:
+			// Already a list (CFN plural property, or a re-run) — recurse
+			// into each object element, leave the list shape alone.
+			for _, e := range v {
+				if em, ok := e.(map[string]any); ok {
+					wrapStructBlocks(elemType, em)
+				}
+			}
+		}
+		// A scalar / null value is left untouched: the downstream
+		// unmarshal surfaces the genuine shape error rather than this
+		// pass masking it.
+	}
+}
+
+// blockElemType resolves the nested struct type backing a `,block` or
+// `,blocks` field — unwrapping the slice and any pointer indirection.
+// Returns nil if the field is not ultimately struct-backed (defensive;
+// every generated block field is).
+func blockElemType(t reflect.Type) reflect.Type {
+	if t.Kind() == reflect.Slice {
+		t = t.Elem()
+	}
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+	return t
+}
+
+// tfKind classifies a generated struct field by its `tf:` struct tag
+// suffix. It mirrors the tagKind enum in
+// pkg/composer/imported/generated/hcl.go, re-declared here because that
+// type is package-private to generated.
+type tfKind int
+
+const (
+	tfAttr   tfKind = iota // plain attribute (no nested-block recursion)
+	tfBlock                // `tf:"name,block"`  — single nested block, *Struct
+	tfBlocks               // `tf:"name,blocks"` — repeated nested block, []Struct
+)
+
+// tfTagKind parses a `tf:` struct tag into its attribute name and kind.
+// An empty or "-" tag yields ("", tfAttr) so the caller skips the field.
+func tfTagKind(tag string) (name string, kind tfKind) {
+	if tag == "" || tag == "-" {
+		return "", tfAttr
+	}
+	parts := strings.Split(tag, ",")
+	name = parts[0]
+	if len(parts) > 1 {
+		switch parts[1] {
+		case "block":
+			kind = tfBlock
+		case "blocks":
+			kind = tfBlocks
+		}
+	}
+	return name, kind
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_block_wrap_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_block_wrap_test.go
@@ -1,0 +1,502 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// TestTFTagKind pins the `tf:` struct-tag parser. The block-vs-attr
+// classification is what drives wrapStructBlocks, so a misparse would
+// silently disable the whole generic fix.
+func TestTFTagKind(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		tag      string
+		wantName string
+		wantKind tfKind
+	}{
+		{"", "", tfAttr},
+		{"-", "", tfAttr},
+		{"function_name", "function_name", tfAttr},
+		{"timeouts,block", "timeouts", tfBlock},
+		{"environment,blocks", "environment", tfBlocks},
+		{"dns_options,blocks", "dns_options", tfBlocks},
+		// Unknown suffix is treated as a plain attribute, not a block.
+		{"weird,unknown", "weird", tfAttr},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tag, func(t *testing.T) {
+			t.Parallel()
+			name, kind := tfTagKind(tc.tag)
+			assert.Equal(t, tc.wantName, name)
+			assert.Equal(t, tc.wantKind, kind)
+		})
+	}
+}
+
+// TestBlockElemType resolves the nested struct type behind a block
+// field for both the slice-backed (`,blocks`) and pointer-backed
+// (`,block`) shapes. The helper is only ever invoked by wrapStructBlocks
+// on a field already classified as a block, so the cases here mirror
+// exactly those two shapes.
+func TestBlockElemType(t *testing.T) {
+	t.Parallel()
+	fnType := reflect.TypeFor[generated.AWSLambdaFunction]()
+
+	blocksField, ok := fnType.FieldByName("Environment") // []AWSLambdaFunctionEnvironment
+	require.True(t, ok)
+	got := blockElemType(blocksField.Type)
+	require.NotNil(t, got)
+	assert.Equal(t, "AWSLambdaFunctionEnvironment", got.Name())
+
+	blockField, ok := fnType.FieldByName("Timeouts") // *AWSLambdaFunctionTimeouts
+	require.True(t, ok)
+	got = blockElemType(blockField.Type)
+	require.NotNil(t, got)
+	assert.Equal(t, "AWSLambdaFunctionTimeouts", got.Name())
+}
+
+// TestWrapObjectBlocksForType_FailOpen pins the two fail-open paths: an
+// unregistered type and a nil map both pass through without panicking.
+func TestWrapObjectBlocksForType_FailOpen(t *testing.T) {
+	t.Parallel()
+
+	in := map[string]any{"dns_options": map[string]any{"x": 1}}
+	out := wrapObjectBlocksForType("aws_not_a_real_type", in)
+	assert.Equal(t, in, out, "unregistered type must pass through unchanged")
+	_, stillObject := out["dns_options"].(map[string]any)
+	assert.True(t, stillObject, "unregistered type must not wrap anything")
+
+	assert.Nil(t, wrapObjectBlocksForType("aws_vpc_endpoint", nil),
+		"nil map must pass through as nil")
+}
+
+// TestWrapObjectBlocksForType_WrapsSingletonObject is the core unit: a
+// CFN object landing on a `,blocks` slice field is wrapped into a
+// one-element list so the downstream typed unmarshal stops hard-failing.
+func TestWrapObjectBlocksForType_WrapsSingletonObject(t *testing.T) {
+	t.Parallel()
+	shaped := map[string]any{
+		"dns_options": map[string]any{
+			"dns_record_ip_type": map[string]any{"literal": "ipv4"},
+		},
+	}
+	wrapObjectBlocksForType("aws_vpc_endpoint", shaped)
+
+	list, ok := shaped["dns_options"].([]any)
+	require.Truef(t, ok, "dns_options must become a list, got %T", shaped["dns_options"])
+	require.Len(t, list, 1)
+	elem, ok := list[0].(map[string]any)
+	require.True(t, ok, "the wrapped element must be the original object")
+	assert.Contains(t, elem, "dns_record_ip_type", "the original object's contents must be preserved, not replaced with an empty map")
+}
+
+// TestWrapObjectBlocksForType_Idempotent pins that a value already in
+// list shape (CFN plural property, or a re-run after a per-type
+// wrapObjectAsList Normalizer) is left untouched — no double-wrapping.
+func TestWrapObjectBlocksForType_Idempotent(t *testing.T) {
+	t.Parallel()
+	shaped := map[string]any{
+		"dns_options": []any{
+			map[string]any{"dns_record_ip_type": map[string]any{"literal": "ipv4"}},
+		},
+	}
+	wrapObjectBlocksForType("aws_vpc_endpoint", shaped)
+
+	list, ok := shaped["dns_options"].([]any)
+	require.True(t, ok, "an already-list block field must stay a list")
+	require.Len(t, list, 1, "an already-list block field must not be re-wrapped")
+	elem, ok := list[0].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, elem, "dns_record_ip_type", "the existing element's contents must survive untouched")
+}
+
+// TestWrapObjectBlocksForType_ScalarLeftAlone pins the fail-open posture
+// for a genuinely wrong shape: a scalar on a block field is not wrapped,
+// so the downstream unmarshal surfaces the real shape error instead of
+// this pass masking it.
+func TestWrapObjectBlocksForType_ScalarLeftAlone(t *testing.T) {
+	t.Parallel()
+	shaped := map[string]any{"dns_options": "not-an-object"}
+	wrapObjectBlocksForType("aws_vpc_endpoint", shaped)
+	assert.Equal(t, "not-an-object", shaped["dns_options"])
+}
+
+// TestWrapObjectBlocksForType_NestedBlocks pins the recursion: a CFN
+// object nested inside another CFN object — both landing on `,blocks`
+// fields — is wrapped at every level. aws_eks_cluster's
+// KubernetesNetworkConfig (block) contains ElasticLoadBalancing (block).
+func TestWrapObjectBlocksForType_NestedBlocks(t *testing.T) {
+	t.Parallel()
+	shaped := map[string]any{
+		"kubernetes_network_config": map[string]any{
+			"ip_family": map[string]any{"literal": "ipv4"},
+			"elastic_load_balancing": map[string]any{
+				"enabled": map[string]any{"literal": true},
+			},
+		},
+	}
+	wrapObjectBlocksForType("aws_eks_cluster", shaped)
+
+	outer, ok := shaped["kubernetes_network_config"].([]any)
+	require.Truef(t, ok, "outer block must wrap to a list, got %T", shaped["kubernetes_network_config"])
+	require.Len(t, outer, 1)
+	elem, ok := outer[0].(map[string]any)
+	require.True(t, ok)
+	inner, ok := elem["elastic_load_balancing"].([]any)
+	require.Truef(t, ok, "nested block must also wrap to a list, got %T", elem["elastic_load_balancing"])
+	require.Len(t, inner, 1)
+}
+
+// TestWrapObjectBlocksForType_SingleBlockNotWrapped pins that a `,block`
+// (single, pointer-backed) field is recursed into but NOT wrapped —
+// encoding/json accepts an object on a *struct field, so wrapping it
+// would be wrong. aws_lambda_function.Timeouts is the `,block` case.
+func TestWrapObjectBlocksForType_SingleBlockNotWrapped(t *testing.T) {
+	t.Parallel()
+	shaped := map[string]any{
+		"timeouts": map[string]any{"create": map[string]any{"literal": "10m"}},
+	}
+	wrapObjectBlocksForType("aws_lambda_function", shaped)
+	_, stillObject := shaped["timeouts"].(map[string]any)
+	assert.True(t, stillObject, "a single `,block` field must stay an object, not be wrapped into a list")
+}
+
+// TestGeneratedUnmarshalAttrs_ObjectOnBlockSlice_Crashes is the
+// load-bearing reproduction: it proves the bug class still exists at the
+// generated.UnmarshalAttrs boundary and that wrapping is what fixes it.
+// An object on a `,blocks` slice field hard-fails encoding/json and
+// aborts the WHOLE unmarshal; the one-element-list shape decodes clean.
+func TestGeneratedUnmarshalAttrs_ObjectOnBlockSlice_Crashes(t *testing.T) {
+	t.Parallel()
+
+	// Object on the dns_options slice field — the crash shape.
+	_, err := generated.UnmarshalAttrs("aws_vpc_endpoint",
+		json.RawMessage(`{"dns_options":{}}`))
+	require.Error(t, err, "object on a `,blocks` slice field must fail the unmarshal")
+
+	// One-element list — the shape wrapObjectBlocksForType produces.
+	_, err = generated.UnmarshalAttrs("aws_vpc_endpoint",
+		json.RawMessage(`{"dns_options":[{}]}`))
+	require.NoError(t, err, "one-element-list block shape must decode cleanly")
+}
+
+// newCCEnricher builds the Cloud Control enricher for tfType wired
+// exactly as NewAWSDiscoverer wires it: the registered per-type
+// Normalizer chained with the generic stripComputedOnlyForType filter.
+// Keeps the end-to-end tests honest against the production path.
+func newCCEnricher(t *testing.T, tfType string, get cloudControlGetResourceFn) *cloudControlEnricher {
+	t.Helper()
+	for _, c := range cloudControlTypeConfigs {
+		if c.TFType == tfType {
+			norm := chain(c.Normalizer, stripComputedOnlyForType(c.TFType))
+			return newCloudControlEnricherWithNormalizer(c.TFType, c.CloudFormationType, get, norm)
+		}
+	}
+	t.Fatalf("no cloudControlTypeConfigs entry for %s", tfType)
+	return nil
+}
+
+// TestCloudControlEnricher_Enrich_VPCEndpoint_GenericBlockWrap is the
+// end-to-end regression for a type with NO per-type Normalizer: the
+// generic wrapObjectBlocksForType pass is the sole fix. Before it, the
+// CFN object-shaped DnsOptions aborted UnmarshalAttrs and the imported
+// aws_vpc_endpoint came back with Attrs=nil — the same reliable #1620
+// failure mode PR #641 fixed only for aws_lambda_function.
+func TestCloudControlEnricher_Enrich_VPCEndpoint_GenericBlockWrap(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{props: `{
+		"Id": "vpce-0abc123",
+		"VpcId": "vpc-0aaa",
+		"ServiceName": "com.amazonaws.us-east-1.s3",
+		"VpcEndpointType": "Interface",
+		"DnsOptions": {"DnsRecordIpType": "ipv4", "PrivateDnsOnlyForInboundResolverEndpoint": false}
+	}`}
+	enr := newCCEnricher(t, "aws_vpc_endpoint", fake.call)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_vpc_endpoint",
+			ImportID: "vpce-0abc123",
+			Address:  "aws_vpc_endpoint.imported",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+	require.NotEmpty(t, ir.Attrs, "Attrs must not be empty — the object-on-block-slice bug drops everything")
+
+	decoded, err := generated.UnmarshalAttrs("aws_vpc_endpoint", ir.Attrs)
+	require.NoError(t, err)
+	ep, ok := decoded.(*generated.AWSVPCEndpoint)
+	require.Truef(t, ok, "decoded type is %T, want *generated.AWSVPCEndpoint", decoded)
+
+	require.NotNil(t, ep.ServiceName)
+	require.NotNil(t, ep.ServiceName.Literal)
+	assert.Equal(t, "com.amazonaws.us-east-1.s3", *ep.ServiceName.Literal)
+
+	require.Lenf(t, ep.DNSOptions, 1, "DnsOptions object must wrap into a one-element block slice")
+	require.NotNil(t, ep.DNSOptions[0].DNSRecordIpType)
+	require.NotNil(t, ep.DNSOptions[0].DNSRecordIpType.Literal)
+	assert.Equal(t, "ipv4", *ep.DNSOptions[0].DNSRecordIpType.Literal)
+}
+
+// TestCloudControlEnricher_Enrich_EKSCluster_NestedBlockWrap exercises
+// the recursive case end-to-end: aws_eks_cluster has no per-type
+// Normalizer, and its KubernetesNetworkConfig CFN object contains a
+// further ElasticLoadBalancing CFN object — both must wrap for the
+// typed unmarshal to succeed.
+func TestCloudControlEnricher_Enrich_EKSCluster_NestedBlockWrap(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{props: `{
+		"Name": "io-prod-eks",
+		"RoleArn": "arn:aws:iam::031780745048:role/io-prod-eks",
+		"Version": "1.30",
+		"AccessConfig": {"AuthenticationMode": "API"},
+		"KubernetesNetworkConfig": {"IpFamily": "ipv4", "ElasticLoadBalancing": {"Enabled": true}}
+	}`}
+	enr := newCCEnricher(t, "aws_eks_cluster", fake.call)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_eks_cluster",
+			ImportID: "io-prod-eks",
+			Address:  "aws_eks_cluster.imported",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+	require.NotEmpty(t, ir.Attrs)
+
+	decoded, err := generated.UnmarshalAttrs("aws_eks_cluster", ir.Attrs)
+	require.NoError(t, err)
+	cl, ok := decoded.(*generated.AWSEKSCluster)
+	require.Truef(t, ok, "decoded type is %T, want *generated.AWSEKSCluster", decoded)
+
+	require.NotNil(t, cl.Name)
+	require.NotNil(t, cl.Name.Literal)
+	assert.Equal(t, "io-prod-eks", *cl.Name.Literal)
+
+	require.Lenf(t, cl.AccessConfig, 1, "AccessConfig object must wrap into a block slice")
+	require.NotNil(t, cl.AccessConfig[0].AuthenticationMode)
+	require.NotNil(t, cl.AccessConfig[0].AuthenticationMode.Literal)
+	assert.Equal(t, "API", *cl.AccessConfig[0].AuthenticationMode.Literal)
+
+	require.Lenf(t, cl.KubernetesNetworkConfig, 1, "KubernetesNetworkConfig object must wrap into a block slice")
+	knc := cl.KubernetesNetworkConfig[0]
+	require.NotNil(t, knc.IpFamily)
+	require.NotNil(t, knc.IpFamily.Literal)
+	assert.Equal(t, "ipv4", *knc.IpFamily.Literal)
+	require.Lenf(t, knc.ElasticLoadBalancing, 1, "nested ElasticLoadBalancing object must also wrap")
+	require.NotNil(t, knc.ElasticLoadBalancing[0].Enabled)
+	require.NotNil(t, knc.ElasticLoadBalancing[0].Enabled.Literal)
+	assert.True(t, *knc.ElasticLoadBalancing[0].Enabled.Literal)
+}
+
+// --- CFN array-shaped Tags → struct map (#640 follow-up, tags variant) ---
+
+// TestGeneratedUnmarshalAttrs_ArrayOnTagsMap_Crashes pins the tag-shape
+// sibling of the object-on-block-slice bug: CFN serializes Tags as a
+// list-of-{Key,Value}, but the generated struct types `tags` as a map.
+// A list on a map field hard-fails encoding/json and aborts the WHOLE
+// unmarshal; the flat-map shape flattenTagListsForType produces decodes
+// clean.
+func TestGeneratedUnmarshalAttrs_ArrayOnTagsMap_Crashes(t *testing.T) {
+	t.Parallel()
+	_, err := generated.UnmarshalAttrs("aws_lambda_function",
+		json.RawMessage(`{"tags":[{"Key":"Project","Value":"io"}]}`))
+	require.Error(t, err, "list on a map-typed `tags` field must fail the unmarshal")
+
+	_, err = generated.UnmarshalAttrs("aws_lambda_function",
+		json.RawMessage(`{"tags":{"Project":{"literal":"io"}}}`))
+	require.NoError(t, err, "flat-map `tags` shape must decode cleanly")
+}
+
+// TestFlattenTagListsForType_FlattensArrayTags is the core unit for the
+// generic tag-flatten: a CFN list-of-{Key,Value} Tags property is
+// collapsed into the verbatim-wrapped flat map the struct's `tags` field
+// expects, for a type (aws_security_group) with no per-type
+// flattenTagList Normalizer.
+func TestFlattenTagListsForType_FlattensArrayTags(t *testing.T) {
+	t.Parallel()
+	out, err := flattenTagListsForType("aws_security_group",
+		json.RawMessage(`{"GroupName":"sg-x","Tags":[{"Key":"Project","Value":"io"},{"Key":"Env","Value":"prod"}]}`))
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(out, &m))
+	tagsWrap, ok := m["Tags"].(map[string]any)
+	require.Truef(t, ok, "Tags must become an object, got %T", m["Tags"])
+	inner, ok := tagsWrap[verbatimMarkerKey].(map[string]any)
+	require.True(t, ok, "flattened tags must be wrapped under the verbatim marker so keys survive camelToSnake")
+	assert.Equal(t, "io", inner["Project"])
+	assert.Equal(t, "prod", inner["Env"])
+}
+
+// TestFlattenTagListsForType_Idempotent pins that an already-flattened
+// (map-shaped) tag set, an absent Tags key, and an unregistered type all
+// pass through without error or double-processing.
+func TestFlattenTagListsForType_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	mapShaped := json.RawMessage(`{"Tags":{"Project":"io"}}`)
+	out, err := flattenTagListsForType("aws_security_group", mapShaped)
+	require.NoError(t, err)
+	// flattenTagListsForType only rewrites a *list*-shaped tag set (the
+	// crash case). An already-map Tags value is not a list, so it passes
+	// through completely untouched — content intact, no double-wrap.
+	assert.JSONEq(t, `{"Tags":{"Project":"io"}}`, string(out),
+		"an already-map Tags value must pass through unchanged")
+
+	out, err = flattenTagListsForType("aws_security_group", json.RawMessage(`{"GroupName":"sg-x"}`))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"GroupName":"sg-x"}`, string(out), "absent Tags must pass through unchanged")
+
+	out, err = flattenTagListsForType("aws_not_a_real_type", json.RawMessage(`{"Tags":[{"Key":"k","Value":"v"}]}`))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"Tags":[{"Key":"k","Value":"v"}]}`, string(out),
+		"unregistered type must pass through unchanged")
+}
+
+// TestCloudControlEnricher_Enrich_ArrayTags is the end-to-end regression
+// for the tags variant: aws_lambda_function's CFN payload carries
+// array-shaped Tags, and the per-type Normalizer chain does NOT flatten
+// them — the generic flattenTagListsForType pass is the sole fix. Before
+// it, the array aborted UnmarshalAttrs and the imported function came
+// back with Attrs=nil.
+func TestCloudControlEnricher_Enrich_ArrayTags(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{props: `{
+		"FunctionName": "io-prod-lambda",
+		"Role": "arn:aws:iam::031780745048:role/io-prod-lambda-exec",
+		"Runtime": "python3.12",
+		"Handler": "index.handler",
+		"MemorySize": 256,
+		"Timeout": 30,
+		"Tags": [{"Key": "Project", "Value": "io-prod"}, {"Key": "ManagedBy", "Value": "insideout"}]
+	}`}
+	enr := newLambdaEnricher(t, fake.call)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_lambda_function",
+			ImportID: "io-prod-lambda",
+			Address:  "aws_lambda_function.io_prod_lambda",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+	require.NotEmpty(t, ir.Attrs, "array-shaped Tags must not abort the unmarshal and drop every attribute")
+
+	fn := decodeLambda(t, ir.Attrs)
+	require.NotNil(t, fn.FunctionName)
+	require.NotNil(t, fn.FunctionName.Literal)
+	assert.Equal(t, "io-prod-lambda", *fn.FunctionName.Literal)
+
+	// Tag keys are operator data — must survive verbatim, not snake-cased.
+	require.NotNil(t, fn.Tags["Project"])
+	require.NotNil(t, fn.Tags["Project"].Literal)
+	assert.Equal(t, "io-prod", *fn.Tags["Project"].Literal)
+	require.NotNil(t, fn.Tags["ManagedBy"])
+	require.NotNil(t, fn.Tags["ManagedBy"].Literal)
+	assert.Equal(t, "insideout", *fn.Tags["ManagedBy"].Literal)
+}
+
+// --- Cloud Control region threading (#640 follow-up) ---
+
+// TestCloudControlEnricher_Enrich_ThreadsResourceRegion pins that
+// fetchAndMap pins GetResource to the resource's own Identity.Region.
+// Cloud Control is a regional API; the enricher's default client is
+// pinned to the discoverer's primary region, so without the per-call
+// override a cross-region resource is queried in the wrong region and
+// comes back ResourceNotFound — dropping its Attrs.
+func TestCloudControlEnricher_Enrich_ThreadsResourceRegion(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{props: `{"Id":"vpce-0abc123","ServiceName":"com.amazonaws.us-east-1.s3"}`}
+	enr := newCCEnricher(t, "aws_vpc_endpoint", fake.call)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_vpc_endpoint",
+			ImportID: "vpce-0abc123",
+			Address:  "aws_vpc_endpoint.imported",
+			Region:   "us-east-1",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+	assert.Equal(t, "us-east-1", fake.optsRegion(),
+		"GetResource must be pinned to the resource's discovered region")
+}
+
+// TestCloudControlEnricher_Enrich_NoRegionNoOverride pins the
+// complement: a resource with no Identity.Region passes no per-call
+// override, leaving GetResource on the enricher's default-region client.
+func TestCloudControlEnricher_Enrich_NoRegionNoOverride(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{props: `{"Id":"vpce-0abc123","ServiceName":"com.amazonaws.us-east-1.s3"}`}
+	enr := newCCEnricher(t, "aws_vpc_endpoint", fake.call)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_vpc_endpoint",
+			ImportID: "vpce-0abc123",
+			Address:  "aws_vpc_endpoint.imported",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+	assert.Empty(t, fake.gotOpts,
+		"no Identity.Region must append no per-call override at all")
+	assert.Empty(t, fake.optsRegion(),
+		"no Identity.Region must leave GetResource on the default-region client")
+}
+
+// --- CFN string-encoded scalar coercion (#640 follow-up) ---
+
+// TestCloudControlEnricher_Enrich_VPCEndpoint_StringEncodedBool is the
+// end-to-end regression for the scalar-coercion variant: CloudFormation
+// returns aws_vpc_endpoint's PrivateDnsEnabled / RequesterManaged as the
+// JSON string "true", which the generated Value[bool] field rejected —
+// aborting UnmarshalAttrs and dropping every aws_vpc_endpoint's Attrs
+// (live-confirmed: 4/4 nil). The tolerant Value literal decode coerces
+// the stringified scalar.
+func TestCloudControlEnricher_Enrich_VPCEndpoint_StringEncodedBool(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{props: `{
+		"Id": "vpce-0abc123",
+		"VpcId": "vpc-0aaa",
+		"ServiceName": "com.amazonaws.us-east-1.s3",
+		"VpcEndpointType": "Interface",
+		"PrivateDnsEnabled": "true",
+		"RequesterManaged": "false"
+	}`}
+	enr := newCCEnricher(t, "aws_vpc_endpoint", fake.call)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_vpc_endpoint",
+			ImportID: "vpce-0abc123",
+			Address:  "aws_vpc_endpoint.imported",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+	require.NotEmpty(t, ir.Attrs, "a string-encoded bool must not abort the unmarshal and drop every attribute")
+
+	decoded, err := generated.UnmarshalAttrs("aws_vpc_endpoint", ir.Attrs)
+	require.NoError(t, err)
+	ep, ok := decoded.(*generated.AWSVPCEndpoint)
+	require.Truef(t, ok, "decoded type is %T, want *generated.AWSVPCEndpoint", decoded)
+
+	require.NotNil(t, ep.PrivateDNSEnabled)
+	require.NotNil(t, ep.PrivateDNSEnabled.Literal)
+	assert.True(t, *ep.PrivateDNSEnabled.Literal, `CFN string "true" must coerce to bool true`)
+
+	// requester_managed is Computed-only on the schema, so
+	// stripComputedOnlyForType elides it (decision #5) before the
+	// coercion path is even reached — asserting its absence pins that
+	// the string-encoded value didn't sneak past the strip filter.
+	assert.Nil(t, ep.RequesterManaged, "computed-only requester_managed must be stripped")
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_enricher.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_enricher.go
@@ -222,10 +222,22 @@ func (e *cloudControlEnricher) fetchAndMap(ctx context.Context, get cloudControl
 	if identifier == "" {
 		return nil, fmt.Errorf("cloudcontrol enricher: cannot derive identifier from Identity (Address=%q)", identity.Address)
 	}
+	// Cloud Control GetResource is a regional API. The enricher's
+	// default client is pinned to the discoverer's primary region, so a
+	// resource discovered in another region (multi-region scans stamp
+	// Identity.Region) must override the per-call region — otherwise
+	// GetResource queries the wrong region and returns ResourceNotFound,
+	// dropping the resource's Attrs entirely (#640 follow-up, live-
+	// confirmed against cross-region aws_lambda_function).
+	var getOpts []func(*cloudcontrol.Options)
+	if identity.Region != "" {
+		region := identity.Region
+		getOpts = append(getOpts, func(o *cloudcontrol.Options) { o.Region = region })
+	}
 	out, err := get(ctx, &cloudcontrol.GetResourceInput{
 		TypeName:   aws.String(e.cfnType),
 		Identifier: aws.String(identifier),
-	})
+	}, getOpts...)
 	if err != nil {
 		if isCloudControlNotFound(err) {
 			return nil, fmt.Errorf("cloudcontrol enricher: %s %q: %w", e.cfnType, identifier, ErrNotFound)
@@ -252,6 +264,18 @@ func (e *cloudControlEnricher) fetchAndMap(ctx context.Context, get cloudControl
 		}
 		rawProps = normalized
 	}
+	// #640 follow-up — generic CFN array-shaped tag fix. CFN serializes
+	// Tags as a list-of-{Key,Value} for most services, but the generated
+	// struct types `tags` as a map; a list on a map field hard-fails
+	// encoding/json and aborts the whole UnmarshalAttrs. flattenTagListsForType
+	// reflects the registered struct and flattens the list to a map.
+	// Idempotent with any per-type flattenTagList Normalizer (see
+	// cloudcontrol_normalizers.go).
+	flattened, err := flattenTagListsForType(e.resourceType, rawProps)
+	if err != nil {
+		return nil, fmt.Errorf("cloudcontrol enricher: flatten tags %s %q: %w", e.cfnType, identifier, err)
+	}
+	rawProps = flattened
 
 	// Convert CamelCase property keys to snake_case so the json tags on
 	// the registered Layer-1 struct can match. The unmarshal would
@@ -267,6 +291,16 @@ func (e *cloudControlEnricher) fetchAndMap(ctx context.Context, get cloudControl
 		return nil, fmt.Errorf("cloudcontrol enricher: parse properties for %s %q: %w", e.cfnType, identifier, err)
 	}
 	shaped := shapeCFNForLayer1(props)
+	// #640 follow-up — generic CFN-object-on-block-slice fix. CFN
+	// serializes singleton nested configs as plain objects, but the
+	// generated Layer-1 struct types repeated nested blocks as slices
+	// (`tf:"<name>,blocks"`). An object on a slice field hard-fails
+	// encoding/json and aborts the whole UnmarshalAttrs, dropping every
+	// attribute. wrapObjectBlocksForType reflects the registered struct
+	// and wraps each such object into a one-element list. Idempotent
+	// with any per-type wrapObjectAsList Normalizer (see
+	// cloudcontrol_block_wrap.go).
+	shaped = wrapObjectBlocksForType(e.resourceType, shaped)
 	shapedJSON, err := json.Marshal(shaped)
 	if err != nil {
 		return nil, fmt.Errorf("cloudcontrol enricher: re-marshal snake_case for %s %q: %w", e.cfnType, identifier, err)

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_enricher_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_enricher_test.go
@@ -106,12 +106,14 @@ func TestShapeCFNForLayer1Recursive(t *testing.T) {
 // TypeName / Identifier without an AWS account.
 type fakeCCGet struct {
 	gotInput *cloudcontrol.GetResourceInput
-	props    string // raw JSON for Properties; "" → nil Properties
+	gotOpts  []func(*cloudcontrol.Options) // per-call option overrides (region threading)
+	props    string                        // raw JSON for Properties; "" → nil Properties
 	err      error
 }
 
-func (f *fakeCCGet) call(_ context.Context, in *cloudcontrol.GetResourceInput, _ ...func(*cloudcontrol.Options)) (*cloudcontrol.GetResourceOutput, error) {
+func (f *fakeCCGet) call(_ context.Context, in *cloudcontrol.GetResourceInput, opts ...func(*cloudcontrol.Options)) (*cloudcontrol.GetResourceOutput, error) {
 	f.gotInput = in
+	f.gotOpts = opts
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -124,6 +126,18 @@ func (f *fakeCCGet) call(_ context.Context, in *cloudcontrol.GetResourceInput, _
 			Properties: aws.String(f.props),
 		},
 	}, nil
+}
+
+// optsRegion applies the captured per-call option overrides to a zero
+// cloudcontrol.Options and reports the resulting Region — "" when no
+// override was passed. Lets region-threading tests assert that
+// fetchAndMap pinned GetResource to the resource's own region.
+func (f *fakeCCGet) optsRegion() string {
+	var o cloudcontrol.Options
+	for _, fn := range f.gotOpts {
+		fn(&o)
+	}
+	return o.Region
 }
 
 // TestCloudControlEnricher_Enrich_LogGroup exercises the full Enrich

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_lambda_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_lambda_enrich_test.go
@@ -1,0 +1,278 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// lambdaCCConfig fetches the registered cloudControlTypeConfigs entry for
+// aws_lambda_function so the tests exercise the production Normalizer
+// chain (wrapObjectAsList(...) for every CFN object-shaped block field)
+// rather than a hand-built one. Fails the test if the entry is missing —
+// a registration regression would otherwise silently fall back to the
+// generic no-normalizer path that drops the whole payload.
+func lambdaCCConfig(t *testing.T) cloudControlConfig {
+	t.Helper()
+	for _, c := range cloudControlTypeConfigs {
+		if c.TFType == "aws_lambda_function" {
+			return c
+		}
+	}
+	t.Fatal("no cloudControlTypeConfigs entry for aws_lambda_function")
+	return cloudControlConfig{}
+}
+
+// newLambdaEnricher builds the aws_lambda_function Cloud Control enricher
+// wired exactly as NewAWSDiscoverer wires it: the per-type Normalizer
+// chained with the generic stripComputedOnlyForType filter (#582). get is
+// the GetResource fake. This keeps the tests honest against the real
+// registration path.
+func newLambdaEnricher(t *testing.T, get cloudControlGetResourceFn) *cloudControlEnricher {
+	t.Helper()
+	cfg := lambdaCCConfig(t)
+	norm := chain(cfg.Normalizer, stripComputedOnlyForType(cfg.TFType))
+	return newCloudControlEnricherWithNormalizer(cfg.TFType, cfg.CloudFormationType, get, norm)
+}
+
+// decodeLambda runs the enriched Attrs back through the typed registry so
+// the assertions read field values off the strongly-typed Layer-1 struct
+// instead of poking at raw JSON.
+func decodeLambda(t *testing.T, attrs json.RawMessage) *generated.AWSLambdaFunction {
+	t.Helper()
+	decoded, err := generated.UnmarshalAttrs("aws_lambda_function", attrs)
+	require.NoError(t, err, "enriched Attrs must round-trip through UnmarshalAttrs")
+	fn, ok := decoded.(*generated.AWSLambdaFunction)
+	require.Truef(t, ok, "decoded type is %T, want *generated.AWSLambdaFunction", decoded)
+	return fn
+}
+
+// TestCloudControlEnricher_Enrich_LambdaFunction is the load-bearing
+// regression for the discovery-side half of reliable #1620: the CFN
+// AWS::Lambda::Function model serializes each singleton nested config
+// (Environment / TracingConfig / VpcConfig / …) as a plain JSON object,
+// but the generated Layer-1 struct types each as a `,blocks` slice. An
+// object landing on a slice field made encoding/json hard-fail, aborting
+// the WHOLE generated.UnmarshalAttrs call — so the imported Lambda came
+// back with Attrs=nil and `terraform plan` then failed on the missing
+// required `function_name` / `role` arguments.
+//
+// The fix is the per-type wrapObjectAsList Normalizer chain registered
+// in cloudControlTypeConfigs. This test feeds a realistic full
+// AWS::Lambda::Function payload through the production enricher wiring
+// and asserts every required + user-meaningful attribute lands with the
+// correct snake_case TF key and value.
+func TestCloudControlEnricher_Enrich_LambdaFunction(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{props: `{
+		"FunctionName": "io-cnquj6nrjnlc-prod-lambda",
+		"Arn": "arn:aws:lambda:us-east-1:031780745048:function:io-cnquj6nrjnlc-prod-lambda",
+		"Role": "arn:aws:iam::031780745048:role/io-cnquj6nrjnlc-prod-lambda-exec",
+		"Runtime": "python3.12",
+		"Handler": "index.handler",
+		"MemorySize": 512,
+		"Timeout": 45,
+		"Description": "imported function",
+		"PackageType": "Zip",
+		"Architectures": ["arm64"],
+		"Code": {"S3Bucket": "deploy-bucket", "S3Key": "fn.zip"},
+		"Environment": {"Variables": {"LOG_LEVEL": "info"}},
+		"TracingConfig": {"Mode": "Active"},
+		"VpcConfig": {"SecurityGroupIds": ["sg-aaa"], "SubnetIds": ["subnet-bbb"]},
+		"EphemeralStorage": {"Size": 1024},
+		"DeadLetterConfig": {"TargetArn": "arn:aws:sqs:us-east-1:031780745048:dlq"},
+		"LoggingConfig": {"LogFormat": "JSON", "LogGroup": "/aws/lambda/io-prod"}
+	}`}
+	enr := newLambdaEnricher(t, fake.call)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_lambda_function",
+			ImportID: "io-cnquj6nrjnlc-prod-lambda",
+			Address:  "aws_lambda_function.io_prod_lambda",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+	require.NotEmpty(t, ir.Attrs, "Attrs must not be empty after enrichment")
+
+	require.NotNil(t, fake.gotInput)
+	assert.Equal(t, "AWS::Lambda::Function", *fake.gotInput.TypeName)
+	assert.Equal(t, "io-cnquj6nrjnlc-prod-lambda", *fake.gotInput.Identifier)
+
+	fn := decodeLambda(t, ir.Attrs)
+
+	// --- Terraform Required arguments (function_name, role). ---
+	require.NotNil(t, fn.FunctionName)
+	require.NotNil(t, fn.FunctionName.Literal)
+	assert.Equal(t, "io-cnquj6nrjnlc-prod-lambda", *fn.FunctionName.Literal)
+	require.NotNil(t, fn.Role)
+	require.NotNil(t, fn.Role.Literal)
+	assert.Equal(t, "arn:aws:iam::031780745048:role/io-cnquj6nrjnlc-prod-lambda-exec", *fn.Role.Literal)
+
+	// --- CONFIGURABLE-panel scalars (runtime / memory_size / timeout /
+	// handler) — the reliable #1620 "Not configured" symptom. ---
+	require.NotNil(t, fn.Runtime)
+	require.NotNil(t, fn.Runtime.Literal)
+	assert.Equal(t, "python3.12", *fn.Runtime.Literal)
+	require.NotNil(t, fn.MemorySize)
+	require.NotNil(t, fn.MemorySize.Literal)
+	assert.Equal(t, int64(512), *fn.MemorySize.Literal)
+	require.NotNil(t, fn.Timeout)
+	require.NotNil(t, fn.Timeout.Literal)
+	assert.Equal(t, int64(45), *fn.Timeout.Literal)
+	require.NotNil(t, fn.Handler)
+	require.NotNil(t, fn.Handler.Literal)
+	assert.Equal(t, "index.handler", *fn.Handler.Literal)
+
+	// --- Additional cleanly-mapped scalars. ---
+	require.NotNil(t, fn.Description)
+	require.NotNil(t, fn.Description.Literal)
+	assert.Equal(t, "imported function", *fn.Description.Literal)
+	require.NotNil(t, fn.PackageType)
+	require.NotNil(t, fn.PackageType.Literal)
+	assert.Equal(t, "Zip", *fn.PackageType.Literal)
+	require.Len(t, fn.Architectures, 1)
+	require.NotNil(t, fn.Architectures[0])
+	require.NotNil(t, fn.Architectures[0].Literal)
+	assert.Equal(t, "arm64", *fn.Architectures[0].Literal)
+
+	// --- CFN object-shaped fields wrapped into singleton TF blocks.
+	// The Environment.Variables key (`LOG_LEVEL`) is operator data and
+	// must survive verbatim — NOT camelToSnake-mangled to `log__level`. ---
+	require.Len(t, fn.Environment, 1, "Environment object must wrap into a one-element block slice")
+	require.NotContains(t, fn.Environment[0].Variables, "log__level",
+		"environment-variable keys must not be snake_case-mangled")
+	require.NotNil(t, fn.Environment[0].Variables["LOG_LEVEL"])
+	require.NotNil(t, fn.Environment[0].Variables["LOG_LEVEL"].Literal)
+	assert.Equal(t, "info", *fn.Environment[0].Variables["LOG_LEVEL"].Literal)
+
+	require.Len(t, fn.TracingConfig, 1)
+	require.NotNil(t, fn.TracingConfig[0].Mode)
+	require.NotNil(t, fn.TracingConfig[0].Mode.Literal)
+	assert.Equal(t, "Active", *fn.TracingConfig[0].Mode.Literal)
+
+	require.Len(t, fn.VPCConfig, 1)
+	require.Len(t, fn.VPCConfig[0].SecurityGroupIDS, 1)
+	require.NotNil(t, fn.VPCConfig[0].SecurityGroupIDS[0].Literal)
+	assert.Equal(t, "sg-aaa", *fn.VPCConfig[0].SecurityGroupIDS[0].Literal)
+	require.Len(t, fn.VPCConfig[0].SubnetIDS, 1)
+	require.NotNil(t, fn.VPCConfig[0].SubnetIDS[0].Literal)
+	assert.Equal(t, "subnet-bbb", *fn.VPCConfig[0].SubnetIDS[0].Literal)
+
+	require.Len(t, fn.EphemeralStorage, 1)
+	require.NotNil(t, fn.EphemeralStorage[0].Size)
+	require.NotNil(t, fn.EphemeralStorage[0].Size.Literal)
+	assert.Equal(t, float64(1024), *fn.EphemeralStorage[0].Size.Literal)
+
+	require.Len(t, fn.DeadLetterConfig, 1)
+	require.NotNil(t, fn.DeadLetterConfig[0].TargetARN)
+	require.NotNil(t, fn.DeadLetterConfig[0].TargetARN.Literal)
+	assert.Equal(t, "arn:aws:sqs:us-east-1:031780745048:dlq", *fn.DeadLetterConfig[0].TargetARN.Literal)
+
+	require.Len(t, fn.LoggingConfig, 1)
+	require.NotNil(t, fn.LoggingConfig[0].LogFormat)
+	require.NotNil(t, fn.LoggingConfig[0].LogFormat.Literal)
+	assert.Equal(t, "JSON", *fn.LoggingConfig[0].LogFormat.Literal)
+
+	// --- Computed-only fields are elided by stripComputedOnlyForType.
+	// `arn` is Computed && !Configurable on the aws_lambda_function
+	// schema, so it must NOT survive into the emit payload (decision
+	// #5). Asserting its absence guards the chain ordering: the
+	// wrapObjectAsList steps must not perturb the strip filter. ---
+	assert.Nil(t, fn.ARN, "computed-only `arn` must be stripped from enriched Attrs")
+}
+
+// TestCloudControlEnricher_Enrich_LambdaFunction_Minimal asserts the fix
+// holds for the minimal-shape payload too: a Lambda with no nested
+// config blocks at all. This is the pre-fix happy-ish case — it should
+// have always worked — and pins that the Normalizer chain is a no-op
+// when none of the wrapped keys are present (idempotent / absent-key
+// pass-through contract of wrapObjectAsList).
+func TestCloudControlEnricher_Enrich_LambdaFunction_Minimal(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{props: `{
+		"FunctionName": "minimal-fn",
+		"Role": "arn:aws:iam::123456789012:role/minimal",
+		"Runtime": "go1.x",
+		"Handler": "bootstrap",
+		"MemorySize": 128,
+		"Timeout": 3
+	}`}
+	enr := newLambdaEnricher(t, fake.call)
+
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_lambda_function",
+			ImportID: "minimal-fn",
+			Address:  "aws_lambda_function.minimal",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+
+	fn := decodeLambda(t, ir.Attrs)
+	require.NotNil(t, fn.FunctionName)
+	require.NotNil(t, fn.FunctionName.Literal)
+	assert.Equal(t, "minimal-fn", *fn.FunctionName.Literal)
+	require.NotNil(t, fn.Role)
+	require.NotNil(t, fn.Role.Literal)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/minimal", *fn.Role.Literal)
+	require.NotNil(t, fn.Runtime)
+	require.NotNil(t, fn.Runtime.Literal)
+	assert.Equal(t, "go1.x", *fn.Runtime.Literal)
+	require.NotNil(t, fn.MemorySize)
+	require.NotNil(t, fn.MemorySize.Literal)
+	assert.Equal(t, int64(128), *fn.MemorySize.Literal)
+	require.NotNil(t, fn.Timeout)
+	require.NotNil(t, fn.Timeout.Literal)
+	assert.Equal(t, int64(3), *fn.Timeout.Literal)
+	assert.Empty(t, fn.Environment, "absent Environment must not synthesize a block")
+	assert.Empty(t, fn.VPCConfig, "absent VpcConfig must not synthesize a block")
+}
+
+// TestCloudControlEnricher_Enrich_LambdaFunction_SatisfiesEmitReadiness
+// closes the loop end-to-end: it pipes a discovered + enriched
+// aws_lambda_function through pkg/composer.ValidateImportedEmitReadiness
+// (the #639 compose-time guard) and asserts the enriched Attrs no longer
+// trips the imported_resource_missing_required_attr issue. Before the
+// wrapObjectAsList fix the enricher returned Attrs=nil and this validator
+// flagged the missing `function_name` / `role` — the exact reliable
+// #1620 symptom. After the fix the validator is clean.
+func TestCloudControlEnricher_Enrich_LambdaFunction_SatisfiesEmitReadiness(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCCGet{props: `{
+		"FunctionName": "io-prod-lambda",
+		"Arn": "arn:aws:lambda:us-east-1:031780745048:function:io-prod-lambda",
+		"Role": "arn:aws:iam::031780745048:role/io-prod-lambda-exec",
+		"Runtime": "python3.12",
+		"Handler": "index.handler",
+		"MemorySize": 256,
+		"Timeout": 30,
+		"Environment": {"Variables": {"FOO": "bar"}},
+		"TracingConfig": {"Mode": "PassThrough"}
+	}`}
+	enr := newLambdaEnricher(t, fake.call)
+
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.io_prod_lambda",
+			ImportID: "io-prod-lambda",
+		},
+		Tier: imported.TierImportedFlat,
+	}
+	require.NoError(t, enr.Enrich(context.Background(), &ir, EnrichClients{}))
+
+	issues := composer.ValidateImportedEmitReadiness("aws", []imported.ImportedResource{ir})
+	for _, is := range issues {
+		assert.NotEqualf(t, "imported_resource_missing_required_attr", is.Code,
+			"enriched Lambda must satisfy emit-readiness, got issue: %s — %s", is.Code, is.Reason)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers.go
@@ -38,6 +38,7 @@ package awsdiscover
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
@@ -616,6 +617,89 @@ func verbatimMapField(outerKey, innerKey string) Normalizer {
 		outer[innerKey] = map[string]any{verbatimMarkerKey: inner}
 		return encodeObject(m)
 	}
+}
+
+// flattenTagListsForType is the generic, reflection-driven counterpart
+// of the per-type flattenTagList Normalizer (#640 follow-up). It runs on
+// the raw Cloud Control JSON for tfType and flattens a CFN
+// list-of-{Key,Value} tag set that lands on the struct's map-typed
+// `tags` field into the flat map shape that field expects.
+//
+// The bug it closes is the tag-shape sibling of the object-on-block-
+// slice crash: CloudFormation serializes Tags as `[{Key,Value},...]`
+// for most modern services, but the generated Layer-1 struct types
+// `tags` as map[string]*Value[string]. A list landing on a map-typed
+// field hard-fails encoding/json with "cannot unmarshal array into Go
+// struct field ....tags of type map[...]", which aborts the *entire*
+// generated.UnmarshalAttrs call — so the whole resource's Attrs drop to
+// nil (reliable #1620 tags variant; live-confirmed against ~16 AWS
+// types incl. aws_lambda_function, aws_security_group, aws_lb, aws_vpc).
+//
+// Why generic: per-type flattenTagList("Tags") registration is
+// drift-prone — every newly registered taggable type reintroduces the
+// crash until someone adds the line. The map-vs-block distinction is
+// already encoded structurally (the struct field's Go kind), so one
+// reflection check covers every current and future type.
+//
+// Runs pre-shape (raw CFN JSON), so the verbatim-marker wrapping
+// flattenTagList applies survives into shapeCFNForLayer1 and the
+// operator-chosen tag keys are not camelToSnake-mangled. Idempotent
+// with any per-type flattenTagList already in the chain: a tag set
+// already flattened to a map (or wrapped under the verbatim marker) is
+// not a JSON list, so the list-shape guard below skips it.
+//
+// Scoped to the field named `tags`: that is the universal Terraform tag
+// attribute, and restricting to it avoids mis-flattening an exotic
+// non-tag map field whose CFN value is legitimately a list. Services
+// that surface tags under a bespoke CFN key (BackupVaultTags,
+// BackupPlanTags) keep their per-type extractors.
+func flattenTagListsForType(tfType string, raw json.RawMessage) (json.RawMessage, error) {
+	goType, _, ok := generated.Lookup(tfType)
+	if !ok || !hasStringMapField(goType, "tags") {
+		return raw, nil
+	}
+	m, err := decodeObject(raw)
+	if err != nil {
+		return nil, fmt.Errorf("flattenTagListsForType(%q): %w", tfType, err)
+	}
+	if m == nil {
+		return raw, nil
+	}
+	cur := raw
+	for k, v := range m {
+		if _, isList := v.([]any); !isList {
+			continue
+		}
+		if camelToSnake(k) != "tags" {
+			continue
+		}
+		if cur, err = flattenTagList(k)(cur); err != nil {
+			return nil, err
+		}
+	}
+	return cur, nil
+}
+
+// hasStringMapField reports whether goType (a registered Layer-1 struct,
+// or a pointer to one) has a map-typed field whose `tf:` attribute name
+// is tfName — i.e. the resource carries a `tags`-style flat map field.
+func hasStringMapField(goType reflect.Type, tfName string) bool {
+	for goType != nil && goType.Kind() == reflect.Pointer {
+		goType = goType.Elem()
+	}
+	if goType == nil || goType.Kind() != reflect.Struct {
+		return false
+	}
+	for i := 0; i < goType.NumField(); i++ {
+		f := goType.Field(i)
+		if f.Type.Kind() != reflect.Map {
+			continue
+		}
+		if name, _ := tfTagKind(f.Tag.Get("tf")); name == tfName {
+			return true
+		}
+	}
+	return false
 }
 
 // decodeObject is the shared parse step. Returns (nil, nil) for an

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers.go
@@ -508,6 +508,116 @@ func jsonStringifyField(from, to string) Normalizer {
 	}
 }
 
+// wrapObjectAsList returns a Normalizer that wraps a top-level key whose
+// CloudFormation value is a single JSON *object* into a one-element JSON
+// *array* (`{...}` → `[{...}]`).
+//
+// This bridges a CloudFormation-vs-Terraform shape gap for nested
+// single-instance config blocks. CloudFormation models a singleton
+// nested config (e.g. `AWS::Lambda::Function.Environment`,
+// `.TracingConfig`, `.VpcConfig`) as a plain JSON object, but the
+// Terraform provider exposes the same config as a nested *block* — the
+// generated Layer-1 struct types it as a slice (`[]AWSLambdaFunctionEnvironment`,
+// `tf:"environment,blocks"`). An object landing on a slice-typed field
+// makes `encoding/json` hard-fail with "cannot unmarshal object into Go
+// struct field ... of type []...", which aborts the *entire*
+// generated.UnmarshalAttrs call — so a single un-normalized block field
+// drops the whole resource's Attrs to nil, not just the offending key
+// (reliable #1620: imported aws_lambda_function came back with empty
+// Attrs, and terraform plan then failed on the missing required
+// `function_name` / `role` args — presets #638/#639).
+//
+// Idempotent / fail-open:
+//   - absent key → pass through unchanged.
+//   - value already a list → pass through unchanged (re-run safe, and a
+//     CFN array-typed property such as a *plural* `FileSystemConfigs`
+//     stays untouched).
+//   - value is a scalar or null → pass through unchanged; the downstream
+//     unmarshal will surface the genuine shape error rather than this
+//     helper masking it.
+//
+// Operates only on the named top-level key. The wrapped object's inner
+// keys are NOT renamed here — shapeCFNForLayer1 still recurses into the
+// single list element and applies the camelToSnake projection, so CFN
+// `{"Variables": {...}}` reaches the generated struct as
+// `{"variables": {...}}`.
+func wrapObjectAsList(key string) Normalizer {
+	return func(in json.RawMessage) (json.RawMessage, error) {
+		if key == "" {
+			return in, nil
+		}
+		m, err := decodeObject(in)
+		if err != nil {
+			return nil, fmt.Errorf("wrapObjectAsList(%q): %w", key, err)
+		}
+		if m == nil {
+			return in, nil
+		}
+		raw, ok := m[key]
+		if !ok || raw == nil {
+			return in, nil
+		}
+		obj, ok := raw.(map[string]any)
+		if !ok {
+			// Already a list, or a scalar — leave it for the downstream
+			// unmarshal to accept (list) or reject (scalar).
+			return in, nil
+		}
+		m[key] = []any{obj}
+		return encodeObject(m)
+	}
+}
+
+// verbatimMapField returns a Normalizer that marks a nested
+// user-data map so its keys bypass the CFN-CamelCase → snake_case
+// projection — the same mechanism flattenTagList uses for tag keys.
+//
+// The path is `outerKey` (a top-level object) → `innerKey` (a map whose
+// keys are operator-chosen identifiers). The classic case is
+// `AWS::Lambda::Function.Environment.Variables`: the Variables keys are
+// environment-variable NAMES (`LOG_LEVEL`, `DB_HOST`), and the generic
+// shapeCFNForLayer1 recursion would camelToSnake-mangle them
+// (`LOG_LEVEL` → `log__level`), corrupting the emitted HCL. Wrapping the
+// inner map under verbatimMarkerKey opts that sub-tree out of renaming
+// while still applying the scalar-leaf {"literal": …} wrap the generated
+// `map[string]*Value[string]` field decodes.
+//
+// Order matters: run this BEFORE wrapObjectAsList for the same outer key
+// — it expects `outerKey` to still hold a plain object, and leaves the
+// object-vs-list wrapping to the later step.
+//
+// Idempotent / fail-open: an absent outer key, an outer value that is
+// not an object, an absent inner key, an inner value that is not an
+// object, or an inner value already wrapped under the verbatim marker
+// all pass through unchanged.
+func verbatimMapField(outerKey, innerKey string) Normalizer {
+	return func(in json.RawMessage) (json.RawMessage, error) {
+		if outerKey == "" || innerKey == "" {
+			return in, nil
+		}
+		m, err := decodeObject(in)
+		if err != nil {
+			return nil, fmt.Errorf("verbatimMapField(%q, %q): %w", outerKey, innerKey, err)
+		}
+		if m == nil {
+			return in, nil
+		}
+		outer, ok := m[outerKey].(map[string]any)
+		if !ok {
+			return in, nil
+		}
+		inner, ok := outer[innerKey].(map[string]any)
+		if !ok {
+			return in, nil
+		}
+		if _, wrapped := inner[verbatimMarkerKey]; wrapped && len(inner) == 1 {
+			return in, nil
+		}
+		outer[innerKey] = map[string]any{verbatimMarkerKey: inner}
+		return encodeObject(m)
+	}
+}
+
 // decodeObject is the shared parse step. Returns (nil, nil) for an
 // empty / null payload so helpers can pass-through cleanly without
 // special-casing.

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_normalizers_test.go
@@ -806,3 +806,215 @@ func TestJSONStringifyField(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// TestWrapObjectAsList pins the wrapObjectAsList contract: a single CFN
+// object value at the named key is rewrapped into a one-element list so
+// it decodes into a Terraform `,blocks` slice field. Without this the
+// generated.UnmarshalAttrs call hard-fails on the object-vs-slice
+// mismatch and drops the whole resource's Attrs (reliable #1620).
+func TestWrapObjectAsList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("object value is wrapped into a one-element list", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":{"FOO":"bar"}}}`)
+		out, err := wrapObjectAsList("Environment")(in)
+		require.NoError(t, err)
+		m := asMap(t, out)
+		list, ok := m["Environment"].([]any)
+		require.Truef(t, ok, "Environment must be a list, got %T", m["Environment"])
+		require.Len(t, list, 1)
+		elem, ok := list[0].(map[string]any)
+		require.True(t, ok)
+		vars, ok := elem["Variables"].(map[string]any)
+		require.True(t, ok, "inner keys must be preserved unchanged")
+		assert.Equal(t, "bar", vars["FOO"])
+	})
+
+	t.Run("absent key is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"FunctionName":"fn"}`)
+		out, err := wrapObjectAsList("Environment")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("value already a list passes through unchanged", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":[{"Variables":{"FOO":"bar"}}]}`)
+		out, err := wrapObjectAsList("Environment")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out),
+			"an already-list value (or a CFN plural array property) must not be re-wrapped")
+	})
+
+	t.Run("scalar value passes through for downstream to reject", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":"oops"}`)
+		out, err := wrapObjectAsList("Environment")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out),
+			"a scalar must not be masked — the typed unmarshal surfaces the real shape error")
+	})
+
+	t.Run("null value is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":null}`)
+		out, err := wrapObjectAsList("Environment")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("empty key is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":{}}}`)
+		out, err := wrapObjectAsList("")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("idempotent across a re-run", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"TracingConfig":{"Mode":"Active"}}`)
+		once, err := wrapObjectAsList("TracingConfig")(in)
+		require.NoError(t, err)
+		twice, err := wrapObjectAsList("TracingConfig")(once)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(once), string(twice),
+			"applying the wrapper to an already-wrapped payload must be stable")
+	})
+
+	t.Run("malformed JSON surfaces an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := wrapObjectAsList("Environment")(json.RawMessage(`{not json`))
+		require.Error(t, err)
+	})
+
+	t.Run("only the named key is wrapped", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":{}},"VpcConfig":{"SubnetIds":[]}}`)
+		out, err := wrapObjectAsList("Environment")(in)
+		require.NoError(t, err)
+		m := asMap(t, out)
+		_, envIsList := m["Environment"].([]any)
+		assert.True(t, envIsList, "named key must be wrapped")
+		_, vpcIsObj := m["VpcConfig"].(map[string]any)
+		assert.True(t, vpcIsObj, "un-named key must be left untouched")
+	})
+}
+
+// verbatimInner pulls the inner map out of a `outer.inner` path and
+// asserts it is wrapped under the verbatim marker, returning the
+// unwrapped user-data map for further assertions.
+func verbatimInner(t *testing.T, raw json.RawMessage, outerKey, innerKey string) map[string]any {
+	t.Helper()
+	m := asMap(t, raw)
+	outer, ok := m[outerKey].(map[string]any)
+	require.Truef(t, ok, "%s must remain an object, got %T", outerKey, m[outerKey])
+	wrapper, ok := outer[innerKey].(map[string]any)
+	require.Truef(t, ok, "%s.%s must be an object, got %T", outerKey, innerKey, outer[innerKey])
+	inner, ok := wrapper[verbatimMarkerKey].(map[string]any)
+	require.Truef(t, ok, "%s.%s must be wrapped under the verbatim marker", outerKey, innerKey)
+	require.Lenf(t, wrapper, 1, "verbatim wrapper must hold only the marker key")
+	return inner
+}
+
+// TestVerbatimMapField pins verbatimMapField: a nested user-data map
+// (Lambda's Environment.Variables) is marked verbatim so the downstream
+// shapeCFNForLayer1 recursion leaves its keys un-renamed.
+func TestVerbatimMapField(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inner map is wrapped under the verbatim marker", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":{"LOG_LEVEL":"info","DBHost":"x"}}}`)
+		out, err := verbatimMapField("Environment", "Variables")(in)
+		require.NoError(t, err)
+		inner := verbatimInner(t, out, "Environment", "Variables")
+		assert.Equal(t, "info", inner["LOG_LEVEL"], "operator key must survive verbatim")
+		assert.Equal(t, "x", inner["DBHost"], "CamelCase operator key must NOT be snake_cased")
+	})
+
+	t.Run("absent outer key is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"FunctionName":"fn"}`)
+		out, err := verbatimMapField("Environment", "Variables")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("absent inner key is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Other":"v"}}`)
+		out, err := verbatimMapField("Environment", "Variables")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("non-object outer value is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":"oops"}`)
+		out, err := verbatimMapField("Environment", "Variables")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("non-object inner value is a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":"oops"}}`)
+		out, err := verbatimMapField("Environment", "Variables")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("idempotent across a re-run", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":{"FOO":"bar"}}}`)
+		once, err := verbatimMapField("Environment", "Variables")(in)
+		require.NoError(t, err)
+		twice, err := verbatimMapField("Environment", "Variables")(once)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(once), string(twice),
+			"re-marking an already-verbatim sub-tree must be stable")
+	})
+
+	t.Run("empty keys are a no-op", func(t *testing.T) {
+		t.Parallel()
+		in := json.RawMessage(`{"Environment":{"Variables":{"FOO":"bar"}}}`)
+		out, err := verbatimMapField("", "Variables")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+		out, err = verbatimMapField("Environment", "")(in)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(in), string(out))
+	})
+
+	t.Run("malformed JSON surfaces an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := verbatimMapField("Environment", "Variables")(json.RawMessage(`{not json`))
+		require.Error(t, err)
+	})
+
+	t.Run("composes before wrapObjectAsList without corrupting keys", func(t *testing.T) {
+		t.Parallel()
+		// Replays the production Lambda chain ordering: mark verbatim,
+		// then wrap the object into a singleton list.
+		n := chain(
+			verbatimMapField("Environment", "Variables"),
+			wrapObjectAsList("Environment"),
+		)
+		out, err := n(json.RawMessage(`{"Environment":{"Variables":{"LOG_LEVEL":"info"}}}`))
+		require.NoError(t, err)
+		m := asMap(t, out)
+		list, ok := m["Environment"].([]any)
+		require.Truef(t, ok, "Environment must be a list, got %T", m["Environment"])
+		require.Len(t, list, 1)
+		elem, ok := list[0].(map[string]any)
+		require.True(t, ok)
+		wrapper, ok := elem["Variables"].(map[string]any)
+		require.True(t, ok)
+		inner, ok := wrapper[verbatimMarkerKey].(map[string]any)
+		require.True(t, ok, "verbatim marker must survive the list wrap")
+		assert.Equal(t, "info", inner["LOG_LEVEL"])
+	})
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -304,6 +304,37 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		NameHintFromProperties:  nameOrIdentifier("FunctionName"),
 		NativeIDsFromProperties: arnUnderKey("Arn"),
 		TagsFromProperties:      tagsFromKey("Tags"),
+		// Normalizer: CFN AWS::Lambda::Function models each singleton
+		// nested config (Environment, TracingConfig, VpcConfig, …) as a
+		// plain JSON *object*, but the Terraform provider exposes them as
+		// nested *blocks* — the generated Layer-1 struct types each as a
+		// slice (`[]AWSLambdaFunctionEnvironment`, `tf:"environment,blocks"`).
+		// An object landing on a slice-typed field makes encoding/json
+		// hard-fail, which aborts the WHOLE generated.UnmarshalAttrs call
+		// and drops every attribute — so the imported aws_lambda_function
+		// came back with empty Attrs and `terraform plan` then failed on
+		// the missing required `function_name` / `role` args
+		// (reliable #1620, sibling of presets #638/#639). wrapObjectAsList
+		// rewrites each object into a one-element list so the typed
+		// unmarshal succeeds and every scalar argument is captured too.
+		//
+		// verbatimMapField runs FIRST for Environment.Variables: the
+		// Variables keys are environment-variable NAMES (operator data),
+		// and the generic camelToSnake recursion would mangle them
+		// (`LOG_LEVEL` → `log__level`). The verbatim marker opts that
+		// sub-tree out of key renaming — same mechanism flattenTagList
+		// uses for tag keys.
+		Normalizer: chain(
+			verbatimMapField("Environment", "Variables"),
+			wrapObjectAsList("DeadLetterConfig"),
+			wrapObjectAsList("Environment"),
+			wrapObjectAsList("EphemeralStorage"),
+			wrapObjectAsList("ImageConfig"),
+			wrapObjectAsList("LoggingConfig"),
+			wrapObjectAsList("SnapStart"),
+			wrapObjectAsList("TracingConfig"),
+			wrapObjectAsList("VpcConfig"),
+		),
 	},
 
 	// =====================================================================

--- a/pkg/composer/imported/generated/value.go
+++ b/pkg/composer/imported/generated/value.go
@@ -173,9 +173,45 @@ func (v *Value[T]) UnmarshalJSON(b []byte) error {
 	default:
 		var lit T
 		if err := json.Unmarshal(raw.Literal, &lit); err != nil {
+			// CloudFormation / Cloud Control routinely serialize bool and
+			// numeric scalars as JSON *strings* — "true", "false", "443",
+			// "1.5" — even where the Terraform provider schema (and so
+			// the generated Value[bool] / Value[int64] / Value[float64]
+			// field) expects a native scalar. The strict decode above
+			// then hard-fails, and because UnmarshalAttrs decodes the
+			// whole resource in one pass, ONE such field drops every
+			// attribute of the resource to nil (live-confirmed: every
+			// aws_vpc_endpoint, whose PrivateDnsEnabled comes back as
+			// "true"). When the literal is a quoted string, retry the
+			// decode against the unquoted bytes so a stringified scalar
+			// still lands on its typed field. Purely additive: a literal
+			// that already decoded strictly never reaches this branch,
+			// and a string that is not a valid T (e.g. "hello" for a
+			// bool) still surfaces the original error.
+			if unquoted, ok := unquoteJSONString(raw.Literal); ok {
+				if err2 := json.Unmarshal(unquoted, &lit); err2 == nil {
+					v.Literal = &lit
+					return nil
+				}
+			}
 			return fmt.Errorf("Value: decoding literal: %w", err)
 		}
 		v.Literal = &lit
 	}
 	return nil
+}
+
+// unquoteJSONString reports whether raw is a JSON string literal and, if
+// so, returns its contents as raw bytes suitable for a retry decode:
+// `"true"` → `true`, `"443"` → `443`. Returns ok=false for any
+// non-string JSON, so a genuine bool/number literal is never disturbed.
+// An empty or otherwise non-scalar string is still returned ok=true —
+// the caller's retry json.Unmarshal rejects it and surfaces the
+// original error, so no separate guard is needed here.
+func unquoteJSONString(raw json.RawMessage) (json.RawMessage, bool) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, false
+	}
+	return json.RawMessage(s), true
 }

--- a/pkg/composer/imported/generated/value_test.go
+++ b/pkg/composer/imported/generated/value_test.go
@@ -45,6 +45,74 @@ func TestValueJSON_Literal(t *testing.T) {
 	assert.False(t, got.Null)
 }
 
+// TestValueJSON_CoercesStringEncodedScalars pins the tolerant literal
+// decode: CloudFormation / Cloud Control serialize bool and numeric
+// scalars as JSON strings ("true", "443", "1.5"), and a strict decode
+// onto a Value[bool] / Value[int64] / Value[float64] field would
+// hard-fail and abort the whole resource unmarshal. The retry against
+// the unquoted bytes must land the value.
+func TestValueJSON_CoercesStringEncodedScalars(t *testing.T) {
+	t.Parallel()
+
+	var b Value[bool]
+	require.NoError(t, json.Unmarshal([]byte(`{"literal":"true"}`), &b),
+		"string-encoded bool literal must coerce")
+	require.NotNil(t, b.Literal)
+	assert.True(t, *b.Literal)
+
+	var bf Value[bool]
+	require.NoError(t, json.Unmarshal([]byte(`{"literal":"false"}`), &bf))
+	require.NotNil(t, bf.Literal)
+	assert.False(t, *bf.Literal)
+
+	var i Value[int64]
+	require.NoError(t, json.Unmarshal([]byte(`{"literal":"443"}`), &i),
+		"string-encoded int literal must coerce")
+	require.NotNil(t, i.Literal)
+	assert.Equal(t, int64(443), *i.Literal)
+
+	var f Value[float64]
+	require.NoError(t, json.Unmarshal([]byte(`{"literal":"1.5"}`), &f),
+		"string-encoded float literal must coerce")
+	require.NotNil(t, f.Literal)
+	assert.InEpsilon(t, 1.5, *f.Literal, 1e-9)
+}
+
+// TestValueJSON_NativeScalarsUnaffected pins that the coercion is purely
+// additive: a literal that already decodes strictly is never routed
+// through the retry, and a native string literal is unchanged.
+func TestValueJSON_NativeScalarsUnaffected(t *testing.T) {
+	t.Parallel()
+
+	var b Value[bool]
+	require.NoError(t, json.Unmarshal([]byte(`{"literal":true}`), &b))
+	require.NotNil(t, b.Literal)
+	assert.True(t, *b.Literal)
+
+	// A native string literal that happens to read like a bool must stay
+	// the string "true", not be coerced.
+	var s Value[string]
+	require.NoError(t, json.Unmarshal([]byte(`{"literal":"true"}`), &s))
+	require.NotNil(t, s.Literal)
+	assert.Equal(t, "true", *s.Literal)
+}
+
+// TestValueJSON_UncoercibleStringStillErrors pins that a quoted string
+// that is not a valid scalar of the target type still surfaces the
+// original decode error rather than being silently swallowed.
+func TestValueJSON_UncoercibleStringStillErrors(t *testing.T) {
+	t.Parallel()
+
+	var b Value[bool]
+	err := json.Unmarshal([]byte(`{"literal":"hello"}`), &b)
+	require.Error(t, err, `"hello" is not a bool — must still fail`)
+	assert.Contains(t, err.Error(), "decoding literal")
+
+	var i Value[int64]
+	err = json.Unmarshal([]byte(`{"literal":""}`), &i)
+	require.Error(t, err, "empty string is not an int — must still fail")
+}
+
 func TestValueJSON_Null(t *testing.T) {
 	t.Parallel()
 	v := NullOf[int64]()


### PR DESCRIPTION
## Summary

A bundle of fixes for a family of bugs where the AWS Cloud Control enricher silently drops a discovered resource's **entire** `Attrs` to `nil`. Root cause is shared: a CloudFormation-vs-generated-struct shape mismatch makes `encoding/json` hard-fail, which aborts the whole `generated.UnmarshalAttrs` call — so one un-normalized field loses every attribute, `terraform plan` then fails on missing required args, and reliable's CONFIGURABLE panel shows "Not configured".

PR #641 fixed **one** variant for **one** type (`aws_lambda_function`). Live-testing #641 against AWS uncovered three more variants affecting ~30 resource types. This bundle generalizes the fix so it covers all 94 CloudControl-registered types — and every future one — with no per-type registration.

This PR **supersedes and includes #641** (its commit is the first of the three here). #641 should be closed once this merges.

### The four fixes

1. **Object-on-block-slice → generic wrap (#642).** CFN serializes a singleton nested config as a JSON object, but the generated struct types repeated nested blocks as slices (`tf:"…,blocks"`). `wrapObjectBlocksForType` reflects the registered struct and wraps any object landing on a `,blocks` field into a one-element list, recursively. Replaces #641's per-type `wrapObjectAsList` allowlist (kept, idempotent) with one drift-proof pass.
2. **Tags array-vs-map → generic flatten (#643).** CFN serializes `Tags` as a `[{Key,Value}]` array; the struct types `tags` as a map. `flattenTagListsForType` flattens it, verbatim-wrapping the keys so operator tag names survive the `camelToSnake` projection. Affected ~16 types incl. `aws_lambda_function`, `aws_security_group`, `aws_lb`, `aws_vpc`.
3. **Region threading (#644).** Cloud Control `GetResource` is regional; `fetchAndMap` never threaded the resource's own region, so cross-region resources returned `ResourceNotFound`. Now pinned to `Identity.Region` via a per-call `cloudcontrol.Options` override.
4. **CFN string-encoded scalars (#645).** CFN serializes bool/numeric scalars as JSON strings (`"true"`, `"443"`). `Value[T].UnmarshalJSON` now retries a failed literal decode against the unquoted bytes — purely additive (a strict-decoding literal is untouched; an uncoercible string still errors). Fixes every `aws_vpc_endpoint` (`PrivateDnsEnabled` returns as `"true"`).

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt` clean on all touched files
- [x] Full suite green — `go test ./...` (5057 tests, 36 packages)
- [x] New unit + end-to-end tests: each crash class is reproduced directly (`require.Error` on the raw shape, `require.NoError` on the fixed shape); QA-reviewed (mutation-tested: reverting any one fix fails a named test)
- [x] **Live-verified against AWS** (account `141812438321`, regions `eu-west-2` + `us-east-1`): all 4 `aws_lambda_function` (incl. 3 cross-region + array-shaped Tags), 16 `aws_security_group`, 4 `aws_lb`, 7 `aws_vpc`, `aws_eks_cluster`, `aws_vpc_endpoint` all enrich with full non-nil `Attrs`

## Follow-ups (filed, not in this PR)

- **#646** — `aws_sqs_queue` enrichment fails a separate `Value` decode (`at least one of null/literal/expr`); distinct root cause.
- **#647** — pre-existing repo hygiene: gofmt drift on 6 files + unused package symbols.

Closes #642
Closes #643
Closes #644
Closes #645