### PR TITLE
feat(discovery): emit per-instance parent reference on child resources

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -553,6 +553,12 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	for _, r := range results {
 		all = append(all, r...)
 	}
+	// Parent-instance resolution (#650): now that the full cross-
+	// discoverer set is assembled, join each discovered child to the
+	// specific parent instance it belongs to and stamp the parent's
+	// Terraform Address onto Identity.ParentAddress. Pure in-memory join
+	// — no AWS calls.
+	resolveParentAddresses(all)
 	args.Emitter.StageFinish("discover", len(all), time.Since(stageStart))
 	return all, nil
 }

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -406,12 +406,13 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		TagsFromProperties:     tagsFromKey("Tags"),
 	},
 	{
-		TFType:                 "aws_subnet",
-		CloudFormationType:     "AWS::EC2::Subnet",
-		Slug:                   "subnet",
-		ImportIDFromIdentifier: passthroughImportID,
-		NameHintFromProperties: passthroughIdentifierName,
-		TagsFromProperties:     tagsFromKey("Tags"),
+		TFType:                  "aws_subnet",
+		CloudFormationType:      "AWS::EC2::Subnet",
+		Slug:                    "subnet",
+		ImportIDFromIdentifier:  passthroughImportID,
+		NameHintFromProperties:  passthroughIdentifierName,
+		NativeIDsFromProperties: vpcIDNativeIDs,
+		TagsFromProperties:      tagsFromKey("Tags"),
 	},
 	{
 		TFType:                 "aws_security_group",
@@ -527,12 +528,13 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		TagsFromProperties: tagsFromKey("Tags"),
 	},
 	{
-		TFType:                 "aws_route_table",
-		CloudFormationType:     "AWS::EC2::RouteTable",
-		Slug:                   "route_table",
-		ImportIDFromIdentifier: passthroughImportID,
-		NameHintFromProperties: passthroughIdentifierName,
-		TagsFromProperties:     tagsFromKey("Tags"),
+		TFType:                  "aws_route_table",
+		CloudFormationType:      "AWS::EC2::RouteTable",
+		Slug:                    "route_table",
+		ImportIDFromIdentifier:  passthroughImportID,
+		NameHintFromProperties:  passthroughIdentifierName,
+		NativeIDsFromProperties: vpcIDNativeIDs,
+		TagsFromProperties:      tagsFromKey("Tags"),
 	},
 	{
 		TFType:                 "aws_network_acl",
@@ -663,12 +665,16 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 	// RDS
 	// =====================================================================
 	{
-		TFType:                  "aws_db_instance",
-		CloudFormationType:      "AWS::RDS::DBInstance",
-		Slug:                    "db_instance",
-		ImportIDFromIdentifier:  passthroughImportID,
-		NameHintFromProperties:  nameOrIdentifier("DBInstanceIdentifier"),
-		NativeIDsFromProperties: arnUnderKey("DBInstanceArn"),
+		TFType:                 "aws_db_instance",
+		CloudFormationType:     "AWS::RDS::DBInstance",
+		Slug:                   "db_instance",
+		ImportIDFromIdentifier: passthroughImportID,
+		NameHintFromProperties: nameOrIdentifier("DBInstanceIdentifier"),
+		// Also carries DBParameterGroupName as a reverse foreign key so
+		// the #650 parent-instance resolver can link an
+		// aws_db_parameter_group child back to the instance that uses
+		// it (the parameter group's own model has no instance back-ref).
+		NativeIDsFromProperties: arnAndKey("DBInstanceArn", "DBParameterGroupName", "db_parameter_group"),
 		TagsFromProperties:      tagsFromKey("Tags"),
 	},
 	{
@@ -1899,12 +1905,17 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		// aws_elasticache_replication_group matches — passthrough.
 		// Verified against terraform-provider-aws v6.x docs and live
 		// CC probe.
-		TFType:                  "aws_elasticache_replication_group",
-		CloudFormationType:      "AWS::ElastiCache::ReplicationGroup",
-		Slug:                    "elasticache_replication_group",
-		ImportIDFromIdentifier:  passthroughImportID,
-		NameHintFromProperties:  nameOrIdentifier("ReplicationGroupId"),
-		NativeIDsFromProperties: arnUnderKey("Arn"),
+		TFType:                 "aws_elasticache_replication_group",
+		CloudFormationType:     "AWS::ElastiCache::ReplicationGroup",
+		Slug:                   "elasticache_replication_group",
+		ImportIDFromIdentifier: passthroughImportID,
+		NameHintFromProperties: nameOrIdentifier("ReplicationGroupId"),
+		// Also carries CacheParameterGroupName as a reverse foreign key
+		// so the #650 parent-instance resolver can link an
+		// aws_elasticache_parameter_group child back to the replication
+		// group that uses it (the parameter group's own model has no
+		// replication-group back-ref).
+		NativeIDsFromProperties: arnAndKey("Arn", "CacheParameterGroupName", "cache_parameter_group"),
 		TagsFromProperties:      tagsFromKey("Tags"),
 	},
 
@@ -2748,6 +2759,41 @@ func isAWSManagedPolicyARN(arn string) bool {
 		}
 	}
 	return false
+}
+
+// vpcIDNativeIDs is a NativeIDsFromProperties extractor that lifts the
+// CloudFormation model's VpcId into NativeIDs["vpc_id"] — the foreign
+// key the #650 parent-instance resolver joins against an aws_vpc's
+// ImportID. Returns nil when VpcId is absent so callers see "no native
+// IDs" rather than an empty map.
+func vpcIDNativeIDs(_ string, props map[string]any) map[string]string {
+	if vpc := extractString(props, "VpcId"); vpc != "" {
+		return map[string]string{"vpc_id": vpc}
+	}
+	return nil
+}
+
+// arnAndKey returns a NativeIDsFromProperties extractor that stamps the
+// arnKey property under "arn" and, when present, the extraKey property
+// under extraNativeKey. It is used by parent resources that also need to
+// carry a reverse foreign key for the #650 parent-instance resolver —
+// e.g. an aws_db_instance carrying its DBParameterGroupName so an
+// aws_db_parameter_group child can be linked back to the instance that
+// references it. Returns nil when neither property is present.
+func arnAndKey(arnKey, extraKey, extraNativeKey string) func(string, map[string]any) map[string]string {
+	return func(_ string, props map[string]any) map[string]string {
+		out := map[string]string{}
+		if arn := extractString(props, arnKey); arn != "" {
+			out["arn"] = arn
+		}
+		if extra := extractString(props, extraKey); extra != "" {
+			out[extraNativeKey] = extra
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	}
 }
 
 // tagsFromKey returns a TagsFromProperties extractor that reads tags

--- a/cmd/insideout-import/awsdiscover/parent_resolve.go
+++ b/cmd/insideout-import/awsdiscover/parent_resolve.go
@@ -1,0 +1,221 @@
+package awsdiscover
+
+import (
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// parent_resolve.go is the instance-level half of the parent/child
+// discovery model (issue #650). pkg/imported/labels' parentTfType
+// registry answers the *type*-level question — "aws_s3_bucket_versioning
+// is scoped to aws_s3_bucket". This file answers the *instance*-level
+// question — "this specific versioning row belongs to that specific
+// bucket row" — by joining each discovered child against the rest of the
+// discovery result and stamping the parent's Terraform Address onto
+// ResourceIdentity.ParentAddress.
+//
+// The resolver runs once over the fully assembled cross-discoverer set
+// (see AWSDiscoverer.DiscoverTypes) so it can see every parent regardless
+// of which discoverer produced it. It is purely a join over identifiers
+// the discoverers already capture — no new AWS API calls.
+
+// parentFK describes how a discovered child resource of a given Terraform
+// type links to its parent instance. Exactly one of childKey / parentKey
+// is set, distinguishing the two join directions:
+//
+//   - Forward edge (childKey set): the child carries a foreign-key
+//     identifier of its parent — e.g. an aws_s3_bucket_versioning row
+//     carries NativeIDs["bucket"], the bucket name, which is the parent
+//     aws_s3_bucket's ImportID. This is the common case.
+//
+//   - Reverse edge (parentKey set): the child carries no reference to
+//     its parent; the parent carries a reference to the child instead.
+//     The two parameter-group types are like this — an
+//     aws_db_parameter_group is referenced *by* the aws_db_instance that
+//     uses it (the instance's DBParameterGroupName), not the other way
+//     round. Reverse edges resolve only on an unambiguous 1:1 match.
+type parentFK struct {
+	// parentType is the Terraform type of the parent resource. It must
+	// agree with pkg/imported/labels' type-level parentTfType registry;
+	// TestParentFK_AgreesWithLabelsRegistry pins that invariant.
+	parentType string
+	// childKey, for a forward edge, is the NativeIDs key on the CHILD
+	// whose value identifies the parent (matched against the parent's
+	// ImportID or any of its NativeIDs values).
+	childKey string
+	// parentKey, for a reverse edge, is the NativeIDs key on the PARENT
+	// whose value equals this child's ImportID.
+	parentKey string
+}
+
+// parentFKByChildType is the AWS foreign-key registry: child Terraform
+// type → how to find its parent instance. Every key here is a member of
+// the labels parentTfType registry; the inverse (a labels child with no
+// entry here) is allowed only for the types in unresolvableChildTypes.
+// Both invariants are enforced by tests so the type-level and
+// instance-level halves cannot silently drift apart.
+var parentFKByChildType = map[string]parentFK{
+	// S3 bucket sub-configuration. Every S3 sub-resource discoverer
+	// (sdkonly_s3.go) and the aws_s3_bucket_policy Cloud Control entry
+	// stamp NativeIDs["bucket"] with the bucket name, which is the
+	// parent aws_s3_bucket's ImportID.
+	"aws_s3_bucket_versioning":                           {parentType: "aws_s3_bucket", childKey: "bucket"},
+	"aws_s3_bucket_lifecycle_configuration":              {parentType: "aws_s3_bucket", childKey: "bucket"},
+	"aws_s3_bucket_ownership_controls":                   {parentType: "aws_s3_bucket", childKey: "bucket"},
+	"aws_s3_bucket_public_access_block":                  {parentType: "aws_s3_bucket", childKey: "bucket"},
+	"aws_s3_bucket_server_side_encryption_configuration": {parentType: "aws_s3_bucket", childKey: "bucket"},
+	"aws_s3_bucket_policy":                               {parentType: "aws_s3_bucket", childKey: "bucket"},
+
+	// VPC children. The route table and subnet discoverers lift the
+	// CloudFormation model's VpcId into NativeIDs["vpc_id"] (see
+	// vpcIDNativeIDs); it matches the parent aws_vpc's ImportID
+	// (vpc-…). aws_internet_gateway and aws_vpc_dhcp_options carry no
+	// VPC reference in their own model — see unresolvableChildTypes.
+	"aws_route_table": {parentType: "aws_vpc", childKey: "vpc_id"},
+	"aws_subnet":      {parentType: "aws_vpc", childKey: "vpc_id"},
+
+	// Split security-group rules. The ingress/egress Cloud Control
+	// entries lift the model's GroupId into NativeIDs["security_group_id"],
+	// which matches the parent aws_security_group's ImportID (sg-…).
+	"aws_vpc_security_group_ingress_rule": {parentType: "aws_security_group", childKey: "security_group_id"},
+	"aws_vpc_security_group_egress_rule":  {parentType: "aws_security_group", childKey: "security_group_id"},
+
+	// CloudWatch Logs. The log-stream discoverer splits the Cloud
+	// Control compound id into NativeIDs["log_group_name"], which
+	// matches the parent aws_cloudwatch_log_group's ImportID.
+	"aws_cloudwatch_log_stream": {parentType: "aws_cloudwatch_log_group", childKey: "log_group_name"},
+
+	// KMS. The alias discoverer lifts TargetKeyId into
+	// NativeIDs["target_key_id"]. AWS allows that value to be either a
+	// key id or a key ARN; the resolver indexes the parent aws_kms_key
+	// by both its ImportID (key id) and NativeIDs (arn), so either form
+	// joins.
+	"aws_kms_alias": {parentType: "aws_kms_key", childKey: "target_key_id"},
+
+	// IAM. The role-policy-attachment discoverer stamps
+	// NativeIDs["role"]; the inline-role-policy discoverer stamps
+	// NativeIDs["role_name"]. Both equal the parent aws_iam_role's
+	// ImportID (the role name).
+	"aws_iam_role_policy_attachment": {parentType: "aws_iam_role", childKey: "role"},
+	"aws_iam_role_policy":            {parentType: "aws_iam_role", childKey: "role_name"},
+
+	// Parameter groups — reverse edges. A parameter group's own model
+	// has no back-reference to the instance that uses it, so the
+	// resolver scans for the parent instead: the aws_db_instance /
+	// aws_elasticache_replication_group discoverers carry the parameter
+	// group name (see arnAndKey) and the resolver matches it against
+	// this child's ImportID. A parameter group shared by several
+	// instances has no single parent and stays unlinked.
+	"aws_db_parameter_group":          {parentType: "aws_db_instance", parentKey: "db_parameter_group"},
+	"aws_elasticache_parameter_group": {parentType: "aws_elasticache_replication_group", parentKey: "cache_parameter_group"},
+}
+
+// unresolvableChildTypes are labels-registry child types for which the
+// AWS resource model the discoverer reads carries no usable parent
+// reference, so no parent-instance link can be emitted without
+// discovering an additional association resource (a new AWS API call,
+// out of scope for #650 which is "emit what you already know"). They are
+// listed explicitly — rather than simply omitted — so
+// TestParentFK_CoversLabelsRegistry can tell a deliberate, documented
+// omission from an accidental gap. Tracked for follow-up in #651.
+var unresolvableChildTypes = map[string]string{
+	"aws_internet_gateway": "AWS::EC2::InternetGateway has no VpcId; the IGW↔VPC link is a separate AWS::EC2::VPCGatewayAttachment resource (#651)",
+	"aws_vpc_dhcp_options": "AWS::EC2::DHCPOptions has no VpcId; the link is a separate AWS::EC2::VPCDHCPOptionsAssociation resource (#651)",
+}
+
+// parentIndexKey identifies a candidate parent by its Terraform type and
+// one of the identifier values it exposes.
+type parentIndexKey struct {
+	typ string
+	id  string
+}
+
+// resolveParentAddresses populates Identity.ParentAddress on every
+// discovered child resource whose parent instance is present in
+// resources. It mutates the slice in place and is safe to call on any
+// discovery result — resources with no parent, and children whose parent
+// was not discovered, are left with an empty ParentAddress (no dangling
+// reference).
+//
+// resources is the fully assembled cross-discoverer set; the resolver is
+// a pure in-memory join and issues no AWS calls.
+func resolveParentAddresses(resources []imported.ImportedResource) {
+	if len(resources) < 2 {
+		return
+	}
+
+	// Forward index: every identifier a resource exposes — its ImportID
+	// and each NativeIDs value — mapped to its Terraform Address, keyed
+	// by (type, identifier). A (type, identifier) pair that resolves to
+	// more than one distinct address is marked ambiguous and dropped, so
+	// a child is never linked to an arbitrarily chosen parent.
+	fwd := make(map[parentIndexKey]string)
+	ambiguous := make(map[parentIndexKey]struct{})
+	index := func(typ, id, addr string) {
+		if id == "" || addr == "" {
+			return
+		}
+		k := parentIndexKey{typ, id}
+		if _, bad := ambiguous[k]; bad {
+			return
+		}
+		if prev, ok := fwd[k]; ok && prev != addr {
+			ambiguous[k] = struct{}{}
+			delete(fwd, k)
+			return
+		}
+		fwd[k] = addr
+	}
+	for i := range resources {
+		id := resources[i].Identity
+		index(id.Type, id.ImportID, id.Address)
+		for _, v := range id.NativeIDs {
+			index(id.Type, v, id.Address)
+		}
+	}
+
+	for i := range resources {
+		child := &resources[i]
+		fk, ok := parentFKByChildType[child.Identity.Type]
+		if !ok {
+			continue
+		}
+		if fk.parentKey == "" {
+			// Forward edge: the child carries the parent's identifier.
+			fkVal := child.Identity.NativeIDs[fk.childKey]
+			if fkVal == "" {
+				continue
+			}
+			k := parentIndexKey{fk.parentType, fkVal}
+			if _, bad := ambiguous[k]; bad {
+				continue
+			}
+			if addr := fwd[k]; addr != "" {
+				child.Identity.ParentAddress = addr
+			}
+			continue
+		}
+		// Reverse edge: the parent carries the child's identifier. Scan
+		// for parents of fk.parentType whose NativeIDs[fk.parentKey]
+		// equals this child's ImportID. Only an unambiguous 1:1 match
+		// yields a link.
+		childID := child.Identity.ImportID
+		if childID == "" {
+			continue
+		}
+		var match string
+		matches := 0
+		for j := range resources {
+			p := resources[j].Identity
+			if p.Type != fk.parentType || p.Address == "" {
+				continue
+			}
+			if p.NativeIDs[fk.parentKey] == childID {
+				match = p.Address
+				matches++
+			}
+		}
+		if matches == 1 {
+			child.Identity.ParentAddress = match
+		}
+	}
+}

--- a/cmd/insideout-import/awsdiscover/parent_resolve_test.go
+++ b/cmd/insideout-import/awsdiscover/parent_resolve_test.go
@@ -1,0 +1,274 @@
+package awsdiscover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/labels"
+)
+
+// res builds a minimal discovered resource for the resolver tests. The
+// resolver only reads Identity.{Type,Address,ImportID,NativeIDs}.
+func res(typ, addr, importID string, native map[string]string) imported.ImportedResource {
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:     "aws",
+			Type:      typ,
+			Address:   addr,
+			ImportID:  importID,
+			NativeIDs: native,
+		},
+		Tier:   imported.TierImportedFlat,
+		Source: imported.SourceImporter,
+	}
+}
+
+// parentAddrByAddress indexes the resolved ParentAddress of every
+// resource by its own Address, so a table test can assert the join
+// outcome without depending on slice order.
+func parentAddrByAddress(rs []imported.ImportedResource) map[string]string {
+	out := make(map[string]string, len(rs))
+	for _, r := range rs {
+		out[r.Identity.Address] = r.Identity.ParentAddress
+	}
+	return out
+}
+
+func TestResolveParentAddresses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// in is the discovery set; resolveParentAddresses mutates it.
+		in []imported.ImportedResource
+		// want maps a resource Address to its expected ParentAddress
+		// after resolution. An entry of "" pins "deliberately unlinked".
+		want map[string]string
+	}{
+		{
+			name: "forward edge — S3 sub-config links to its bucket",
+			in: []imported.ImportedResource{
+				res("aws_s3_bucket", "aws_s3_bucket.logs", "my-logs-bucket", map[string]string{"name": "my-logs-bucket"}),
+				res("aws_s3_bucket_versioning", "aws_s3_bucket_versioning.logs", "my-logs-bucket", map[string]string{"bucket": "my-logs-bucket"}),
+				res("aws_s3_bucket_public_access_block", "aws_s3_bucket_public_access_block.logs", "my-logs-bucket", map[string]string{"bucket": "my-logs-bucket"}),
+			},
+			want: map[string]string{
+				"aws_s3_bucket.logs":                     "",
+				"aws_s3_bucket_versioning.logs":          "aws_s3_bucket.logs",
+				"aws_s3_bucket_public_access_block.logs": "aws_s3_bucket.logs",
+			},
+		},
+		{
+			name: "forward edge — multiple buckets, each child joins its own",
+			in: []imported.ImportedResource{
+				res("aws_s3_bucket", "aws_s3_bucket.a", "bucket-a", map[string]string{"name": "bucket-a"}),
+				res("aws_s3_bucket", "aws_s3_bucket.b", "bucket-b", map[string]string{"name": "bucket-b"}),
+				res("aws_s3_bucket_versioning", "aws_s3_bucket_versioning.a", "bucket-a", map[string]string{"bucket": "bucket-a"}),
+				res("aws_s3_bucket_versioning", "aws_s3_bucket_versioning.b", "bucket-b", map[string]string{"bucket": "bucket-b"}),
+			},
+			want: map[string]string{
+				"aws_s3_bucket_versioning.a": "aws_s3_bucket.a",
+				"aws_s3_bucket_versioning.b": "aws_s3_bucket.b",
+			},
+		},
+		{
+			name: "forward edge — VPC child resolves via NativeIDs vpc_id",
+			in: []imported.ImportedResource{
+				res("aws_vpc", "aws_vpc.main", "vpc-0abc", map[string]string{"name": "vpc-0abc"}),
+				res("aws_subnet", "aws_subnet.web", "subnet-01", map[string]string{"name": "subnet-01", "vpc_id": "vpc-0abc"}),
+				res("aws_route_table", "aws_route_table.rt", "rtb-09", map[string]string{"name": "rtb-09", "vpc_id": "vpc-0abc"}),
+			},
+			want: map[string]string{
+				"aws_subnet.web":     "aws_vpc.main",
+				"aws_route_table.rt": "aws_vpc.main",
+			},
+		},
+		{
+			name: "forward edge — KMS alias matches key by ARN-form target_key_id",
+			in: []imported.ImportedResource{
+				res("aws_kms_key", "aws_kms_key.k", "1234abcd-key-id", map[string]string{
+					"name": "1234abcd-key-id",
+					"arn":  "arn:aws:kms:us-east-1:111:key/1234abcd-key-id",
+				}),
+				// alias points at the key by ARN, not the bare key id.
+				res("aws_kms_alias", "aws_kms_alias.a", "alias/app", map[string]string{
+					"name":          "alias/app",
+					"target_key_id": "arn:aws:kms:us-east-1:111:key/1234abcd-key-id",
+				}),
+			},
+			want: map[string]string{
+				"aws_kms_alias.a": "aws_kms_key.k",
+			},
+		},
+		{
+			name: "missing parent — child whose bucket was not discovered stays unlinked",
+			in: []imported.ImportedResource{
+				res("aws_s3_bucket_versioning", "aws_s3_bucket_versioning.orphan", "gone-bucket", map[string]string{"bucket": "gone-bucket"}),
+			},
+			want: map[string]string{
+				"aws_s3_bucket_versioning.orphan": "",
+			},
+		},
+		{
+			name: "ambiguous forward — two parents share the identifier, child unlinked",
+			in: []imported.ImportedResource{
+				res("aws_iam_role", "aws_iam_role.one", "shared-role", map[string]string{"name": "shared-role"}),
+				res("aws_iam_role", "aws_iam_role.two", "shared-role", map[string]string{"name": "shared-role"}),
+				res("aws_iam_role_policy", "aws_iam_role_policy.p", "shared-role:inline", map[string]string{"role_name": "shared-role"}),
+			},
+			want: map[string]string{
+				"aws_iam_role_policy.p": "",
+			},
+		},
+		{
+			name: "reverse edge — parameter group links to its sole instance",
+			in: []imported.ImportedResource{
+				res("aws_db_instance", "aws_db_instance.prod", "prod-db", map[string]string{
+					"name":               "prod-db",
+					"arn":                "arn:aws:rds:us-east-1:111:db:prod-db",
+					"db_parameter_group": "prod-pg",
+				}),
+				res("aws_db_parameter_group", "aws_db_parameter_group.pg", "prod-pg", map[string]string{"name": "prod-pg"}),
+			},
+			want: map[string]string{
+				"aws_db_parameter_group.pg": "aws_db_instance.prod",
+			},
+		},
+		{
+			name: "reverse edge — ElastiCache parameter group links to its replication group",
+			in: []imported.ImportedResource{
+				res("aws_elasticache_replication_group", "aws_elasticache_replication_group.redis", "redis-rg", map[string]string{
+					"name":                  "redis-rg",
+					"cache_parameter_group": "redis-pg",
+				}),
+				res("aws_elasticache_parameter_group", "aws_elasticache_parameter_group.pg", "redis-pg", map[string]string{"name": "redis-pg"}),
+			},
+			want: map[string]string{
+				"aws_elasticache_parameter_group.pg": "aws_elasticache_replication_group.redis",
+			},
+		},
+		{
+			name: "reverse edge — parameter group shared by two instances stays unlinked",
+			in: []imported.ImportedResource{
+				res("aws_db_instance", "aws_db_instance.a", "db-a", map[string]string{"name": "db-a", "db_parameter_group": "shared-pg"}),
+				res("aws_db_instance", "aws_db_instance.b", "db-b", map[string]string{"name": "db-b", "db_parameter_group": "shared-pg"}),
+				res("aws_db_parameter_group", "aws_db_parameter_group.pg", "shared-pg", map[string]string{"name": "shared-pg"}),
+			},
+			want: map[string]string{
+				"aws_db_parameter_group.pg": "",
+			},
+		},
+		{
+			name: "reverse edge — parameter group with no referencing instance stays unlinked",
+			in: []imported.ImportedResource{
+				res("aws_db_instance", "aws_db_instance.a", "db-a", map[string]string{"name": "db-a", "db_parameter_group": "other-pg"}),
+				res("aws_db_parameter_group", "aws_db_parameter_group.pg", "lonely-pg", map[string]string{"name": "lonely-pg"}),
+			},
+			want: map[string]string{
+				"aws_db_parameter_group.pg": "",
+			},
+		},
+		{
+			name: "unresolvable type — internet gateway has no FK rule, stays unlinked",
+			in: []imported.ImportedResource{
+				res("aws_vpc", "aws_vpc.main", "vpc-0abc", map[string]string{"name": "vpc-0abc"}),
+				res("aws_internet_gateway", "aws_internet_gateway.igw", "igw-01", map[string]string{"name": "igw-01"}),
+				res("aws_vpc_dhcp_options", "aws_vpc_dhcp_options.d", "dopt-01", map[string]string{"name": "dopt-01"}),
+			},
+			want: map[string]string{
+				"aws_internet_gateway.igw": "",
+				"aws_vpc_dhcp_options.d":   "",
+			},
+		},
+		{
+			name: "non-child resource — a plain parent type carries no ParentAddress",
+			in: []imported.ImportedResource{
+				res("aws_vpc", "aws_vpc.main", "vpc-0abc", map[string]string{"name": "vpc-0abc"}),
+				res("aws_sqs_queue", "aws_sqs_queue.q", "https://sqs/q", map[string]string{"name": "q"}),
+			},
+			want: map[string]string{
+				"aws_vpc.main":    "",
+				"aws_sqs_queue.q": "",
+			},
+		},
+		{
+			name: "child with empty FK value stays unlinked",
+			in: []imported.ImportedResource{
+				res("aws_s3_bucket", "aws_s3_bucket.b", "b", map[string]string{"name": "b"}),
+				// versioning row whose discoverer failed to capture the bucket.
+				res("aws_s3_bucket_versioning", "aws_s3_bucket_versioning.b", "b", map[string]string{"name": "b"}),
+			},
+			want: map[string]string{
+				"aws_s3_bucket_versioning.b": "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			resolveParentAddresses(tt.in)
+			got := parentAddrByAddress(tt.in)
+			for addr, wantParent := range tt.want {
+				assert.Equal(t, wantParent, got[addr], "ParentAddress of %s", addr)
+			}
+		})
+	}
+}
+
+// TestResolveParentAddresses_NoPanicOnTrivialInput pins that the
+// resolver tolerates empty and single-element sets (the < 2 short
+// circuit) without panicking.
+func TestResolveParentAddresses_NoPanicOnTrivialInput(t *testing.T) {
+	t.Parallel()
+	resolveParentAddresses(nil)
+	resolveParentAddresses([]imported.ImportedResource{})
+	one := []imported.ImportedResource{res("aws_s3_bucket_versioning", "aws_s3_bucket_versioning.x", "x", map[string]string{"bucket": "x"})}
+	resolveParentAddresses(one)
+	assert.Equal(t, "", one[0].Identity.ParentAddress, "a lone child cannot resolve a parent")
+}
+
+// TestParentFK_AgreesWithLabelsRegistry pins that every instance-level
+// foreign-key edge names the same parent type as the type-level
+// pkg/imported/labels parentTfType registry. Without this the two halves
+// of the parent/child model could silently disagree.
+func TestParentFK_AgreesWithLabelsRegistry(t *testing.T) {
+	t.Parallel()
+	for child, fk := range parentFKByChildType {
+		parent, ok := labels.ParentTfType(child)
+		require.Truef(t, ok, "%q has an FK rule but is not in the labels parentTfType registry", child)
+		assert.Equalf(t, parent, fk.parentType,
+			"%q FK rule names parent %q; labels registry says %q", child, fk.parentType, parent)
+		// Exactly one join direction must be set.
+		hasChildKey := fk.childKey != ""
+		hasParentKey := fk.parentKey != ""
+		assert.Truef(t, hasChildKey != hasParentKey,
+			"%q must set exactly one of childKey/parentKey (got childKey=%q parentKey=%q)", child, fk.childKey, fk.parentKey)
+	}
+}
+
+// TestParentFK_CoversLabelsRegistry pins that every child type in the
+// labels parentTfType registry is accounted for here — either with a
+// resolvable FK rule or as a documented, deliberate omission in
+// unresolvableChildTypes. A new labels edge with no entry in either map
+// fails this test loudly instead of silently shipping children with no
+// parent reference.
+func TestParentFK_CoversLabelsRegistry(t *testing.T) {
+	t.Parallel()
+	for _, child := range labels.ChildTfTypes() {
+		_, resolvable := parentFKByChildType[child]
+		_, unresolvable := unresolvableChildTypes[child]
+		assert.Truef(t, resolvable || unresolvable,
+			"labels child %q has neither an FK rule nor an unresolvableChildTypes entry", child)
+		assert.Falsef(t, resolvable && unresolvable,
+			"labels child %q is in both parentFKByChildType and unresolvableChildTypes", child)
+	}
+	// Every unresolvable entry must itself be a real labels child.
+	for child := range unresolvableChildTypes {
+		assert.Truef(t, labels.HasParent(child),
+			"unresolvableChildTypes lists %q which is not a labels child type", child)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/parent_resolve_test.go
+++ b/cmd/insideout-import/awsdiscover/parent_resolve_test.go
@@ -250,6 +250,93 @@ func TestParentFK_AgreesWithLabelsRegistry(t *testing.T) {
 	}
 }
 
+// fkContractFixture is a representative discovery payload for one
+// resource type, used to drive the production Cloud Control config
+// closure in TestParentFK_DiscovererEmitsForeignKey.
+type fkContractFixture struct {
+	identifier string
+	props      map[string]any
+}
+
+// fkContractFixtures supplies, per Cloud Control resource type the #650
+// resolver depends on, an identifier + properties payload shaped like
+// what the AWS API returns. The contract test feeds these through the
+// production NativeIDsFromProperties closure and asserts the
+// foreign-key NativeIDs entry comes out — so a config refactor that
+// drops a parent-reference extractor fails CI here instead of silently
+// emptying ParentAddress at customer deploy time.
+var fkContractFixtures = map[string]fkContractFixture{
+	// Forward-edge children: the child's own config carries the FK.
+	"aws_route_table":                     {identifier: "rtb-1", props: map[string]any{"VpcId": "vpc-1"}},
+	"aws_subnet":                          {identifier: "subnet-1", props: map[string]any{"VpcId": "vpc-1"}},
+	"aws_vpc_security_group_ingress_rule": {identifier: "sgr-1", props: map[string]any{"GroupId": "sg-1"}},
+	"aws_vpc_security_group_egress_rule":  {identifier: "sgr-2", props: map[string]any{"GroupId": "sg-1"}},
+	"aws_kms_alias":                       {identifier: "alias/app", props: map[string]any{"TargetKeyId": "key-1"}},
+	"aws_cloudwatch_log_stream":           {identifier: "log-group|log-stream", props: nil},
+	"aws_iam_role_policy":                 {identifier: "policy-name|role-name", props: nil},
+	"aws_s3_bucket_policy":                {identifier: "my-bucket", props: nil},
+	// Reverse-edge parents: the parent's config carries the FK that
+	// points back at the parameter-group child.
+	"aws_db_instance":                   {identifier: "prod-db", props: map[string]any{"DBParameterGroupName": "prod-pg"}},
+	"aws_elasticache_replication_group": {identifier: "redis-rg", props: map[string]any{"CacheParameterGroupName": "redis-pg"}},
+}
+
+// sdkOnlyFKChildren are forward-edge child types discovered by the
+// SDK-only sub-resource pipeline rather than Cloud Control. Their
+// foreign-key NativeIDs entry cannot be driven through a
+// cloudControlConfig closure (the fetch funcs need a live/fake SDK
+// client), so the discoverer↔resolver contract for these is pinned by
+// their own discoverer tests (sdkonly_s3_test.go asserts NativeIDs
+// ["bucket"]; the IAM role-policy-attachment test asserts NativeIDs
+// ["role"]). They are listed here so TestParentFK_DiscovererEmitsForeignKey
+// can account for every forward edge and skip exactly these.
+var sdkOnlyFKChildren = map[string]struct{}{
+	"aws_s3_bucket_versioning":                           {},
+	"aws_s3_bucket_lifecycle_configuration":              {},
+	"aws_s3_bucket_ownership_controls":                   {},
+	"aws_s3_bucket_public_access_block":                  {},
+	"aws_s3_bucket_server_side_encryption_configuration": {},
+	"aws_iam_role_policy_attachment":                     {},
+}
+
+// TestParentFK_DiscovererEmitsForeignKey pins the discoverer↔resolver
+// contract: for every parent/child edge, the resource type that is
+// supposed to carry the foreign key actually emits it through its
+// production discoverer config. Without this, a refactor that drops a
+// NativeIDsFromProperties extractor would leave the FK registry pointing
+// at a key the discoverer no longer produces — ParentAddress would go
+// silently empty and only the resolver's synthetic-input unit tests
+// (which never exercise the real config) would still pass.
+func TestParentFK_DiscovererEmitsForeignKey(t *testing.T) {
+	t.Parallel()
+	for child, fk := range parentFKByChildType {
+		// The type whose config carries the FK, and the NativeIDs key
+		// it must emit: the child itself for a forward edge, the parent
+		// for a reverse edge.
+		typ, key := child, fk.childKey
+		if fk.parentKey != "" {
+			typ, key = fk.parentType, fk.parentKey
+		}
+		if _, sdkOnly := sdkOnlyFKChildren[child]; sdkOnly {
+			// Forward child discovered by the SDK-only pipeline; its
+			// FK is pinned by the discoverer's own test (see comment
+			// on sdkOnlyFKChildren).
+			continue
+		}
+		t.Run(child, func(t *testing.T) {
+			t.Parallel()
+			fx, ok := fkContractFixtures[typ]
+			require.Truef(t, ok, "no fkContractFixtures entry for %q (needed to verify the %q edge)", typ, child)
+			cfg := configByTFType(t, typ)
+			require.NotNilf(t, cfg.NativeIDsFromProperties,
+				"%q has no NativeIDsFromProperties extractor; the #650 resolver expects NativeIDs[%q]", typ, key)
+			native := cfg.NativeIDsFromProperties(fx.identifier, fx.props)
+			assert.NotEmptyf(t, native[key],
+				"%q discoverer must emit NativeIDs[%q] for the %q parent-instance edge; got %+v", typ, key, child, native)
+		})
+	}
+}
+
 // TestParentFK_CoversLabelsRegistry pins that every child type in the
 // labels parentTfType registry is accounted for here — either with a
 // resolvable FK rule or as a documented, deliberate omission in

--- a/cmd/insideout-import/manifest_test.go
+++ b/cmd/insideout-import/manifest_test.go
@@ -172,6 +172,50 @@ func TestReadManifest_HappyPath(t *testing.T) {
 	}
 }
 
+// TestManifest_ParentAddressRoundTrips pins that the #650 per-instance
+// parent reference survives a writeManifest → readManifest cycle: the
+// child carries its resolved ParentAddress, and a resource with no
+// parent has it absent (the omitempty JSON tag) rather than serialized
+// as an empty string.
+func TestManifest_ParentAddressRoundTrips(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bucket := validIR("aws_s3_bucket", "aws_s3_bucket.b", "b")
+	child := validIR("aws_s3_bucket_versioning", "aws_s3_bucket_versioning.b", "b")
+	child.Identity.ParentAddress = "aws_s3_bucket.b"
+
+	path, _, err := writeManifest(dir, "aws", []imported.ImportedResource{bucket, child})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := readManifest(path, "aws")
+	if err != nil {
+		t.Fatal(err)
+	}
+	byAddr := map[string]imported.ImportedResource{}
+	for _, r := range got {
+		byAddr[r.Identity.Address] = r
+	}
+	if pa := byAddr["aws_s3_bucket_versioning.b"].Identity.ParentAddress; pa != "aws_s3_bucket.b" {
+		t.Errorf("child ParentAddress=%q, want aws_s3_bucket.b", pa)
+	}
+	if pa := byAddr["aws_s3_bucket.b"].Identity.ParentAddress; pa != "" {
+		t.Errorf("parent-less resource ParentAddress=%q, want empty", pa)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"parent_address": "aws_s3_bucket.b"`) {
+		t.Errorf("manifest JSON missing parent_address key:\n%s", raw)
+	}
+	// The parent-less bucket must not serialize an empty parent_address.
+	if strings.Count(string(raw), `"parent_address"`) != 1 {
+		t.Errorf("expected exactly one parent_address key (omitempty); got:\n%s", raw)
+	}
+}
+
 // TestReadManifest_MalformedJSONIncludesOffset pins that a syntactically
 // invalid manifest surfaces a json.SyntaxError offset in the error message.
 // Operators editing the file by hand need a position pointer; without it

--- a/pkg/composer/imported/identity.go
+++ b/pkg/composer/imported/identity.go
@@ -66,6 +66,20 @@ type ResourceIdentity struct {
 	// sanitized form. See the Address field comment for the
 	// relationship.
 	NameHint string `json:"name_hint,omitempty"`
+	// ParentAddress is the Terraform Address of the parent resource
+	// instance this resource is a child of, when that parent is present
+	// in the same discovery result. It is the per-instance counterpart of
+	// the type-level pkg/imported/labels parentTfType registry: that map
+	// answers "aws_s3_bucket_versioning is scoped to aws_s3_bucket"; this
+	// field answers "this versioning instance belongs to that specific
+	// bucket". Empty for resources with no parent, and for children whose
+	// parent instance was not discovered in this run (no dangling
+	// reference). Resolved post-discovery by joining the child's
+	// foreign-key identifier against the discovered set — see
+	// cmd/insideout-import/awsdiscover's parent resolver. Downstream
+	// consumers (reliable's reverse-Terraform import wizard, reliable#1617)
+	// use it to collapse child instance rows under their parent instance.
+	ParentAddress string `json:"parent_address,omitempty"`
 	// ProviderConfig identifies the provider alias used by emitted HCL,
 	// e.g. "aws.imported" or "google.imported".
 	ProviderConfig string `json:"provider_config,omitempty"`

--- a/pkg/composer/imported_validate.go
+++ b/pkg/composer/imported_validate.go
@@ -29,6 +29,10 @@ import (
 //   - imported_resource_decode_failed — Attrs is non-empty but
 //     generated.UnmarshalAttrs(Identity.Type, Attrs) returns an error or the
 //     type is not in the registry.
+//   - imported_resource_dangling_parent — Identity.ParentAddress is set but
+//     no resource in the set carries that Address. The per-instance parent
+//     reference (#650) must point at a discovered resource; a dangling
+//     reference means the resolver linked to a parent that is not present.
 //
 // External tiers (ExternalByPolicy, ExternalUnsupported) and ComposerNative /
 // ComposerGraduated are out of scope here — they are not emitted as flat
@@ -40,6 +44,10 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 	want := strings.ToLower(strings.TrimSpace(cloud))
 	var issues []ValidationIssue
 	addressIndex := map[string][]int{}
+	// parentRefs records, per resource index, a non-empty
+	// Identity.ParentAddress so the dangling-parent check can run after
+	// every Address in the set is known.
+	parentRefs := map[int]string{}
 
 	for i, ir := range irs {
 		field := importedField(ir, i)
@@ -96,6 +104,10 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 			addressIndex[addr] = append(addressIndex[addr], i)
 		}
 
+		if parent := strings.TrimSpace(ir.Identity.ParentAddress); parent != "" {
+			parentRefs[i] = parent
+		}
+
 		if strings.TrimSpace(ir.Identity.ImportID) == "" {
 			issues = append(issues, ValidationIssue{
 				Field:  field,
@@ -145,6 +157,27 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 			Value:  fmt.Sprintf("%d resources", len(idxs)),
 			Code:   "imported_resource_address_collision",
 			Reason: fmt.Sprintf("Terraform address %q is claimed by %d imported resources; addresses must be unique within a stack", addr, len(idxs)),
+		})
+	}
+
+	// Dangling parent-instance reference (#650): every non-empty
+	// ParentAddress must resolve to a resource Address present in the
+	// set. Sorted by index for deterministic issue ordering.
+	danglingIdxs := make([]int, 0, len(parentRefs))
+	for i := range parentRefs {
+		danglingIdxs = append(danglingIdxs, i)
+	}
+	sort.Ints(danglingIdxs)
+	for _, i := range danglingIdxs {
+		parent := parentRefs[i]
+		if _, ok := addressIndex[parent]; ok {
+			continue
+		}
+		issues = append(issues, ValidationIssue{
+			Field:  importedField(irs[i], i),
+			Value:  parent,
+			Code:   "imported_resource_dangling_parent",
+			Reason: fmt.Sprintf("Identity.ParentAddress %q does not match any imported resource Address in the set; the per-instance parent reference must point at a discovered resource", parent),
 		})
 	}
 

--- a/pkg/composer/imported_validate_test.go
+++ b/pkg/composer/imported_validate_test.go
@@ -166,6 +166,45 @@ func TestValidateImportedResources_Codes(t *testing.T) {
 			},
 			wantCodes: []string{"imported_resource_decode_failed"},
 		},
+		{
+			name:  "dangling parent reference",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{
+					Identity: imported.ResourceIdentity{
+						Cloud:         "aws",
+						Type:          "aws_s3_bucket_versioning",
+						Address:       "aws_s3_bucket_versioning.x",
+						ImportID:      "x",
+						ParentAddress: "aws_s3_bucket.gone",
+					},
+					Tier: imported.TierImportedFlat,
+				},
+			},
+			wantCodes: []string{"imported_resource_dangling_parent"},
+		},
+		{
+			name:  "valid parent reference passes",
+			cloud: "aws",
+			irs: []imported.ImportedResource{
+				{
+					Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_s3_bucket", Address: "aws_s3_bucket.b", ImportID: "b"},
+					Tier:     imported.TierImportedFlat,
+				},
+				{
+					Identity: imported.ResourceIdentity{
+						Cloud:         "aws",
+						Type:          "aws_s3_bucket_versioning",
+						Address:       "aws_s3_bucket_versioning.b",
+						ImportID:      "b",
+						ParentAddress: "aws_s3_bucket.b",
+					},
+					Tier: imported.TierImportedFlat,
+				},
+			},
+			wantCodes: nil,
+			denyCodes: []string{"imported_resource_dangling_parent"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/imported/labels/parent.go
+++ b/pkg/imported/labels/parent.go
@@ -34,6 +34,8 @@
 // ParentTfType returns ("", false) for it.
 package labels
 
+import "sort"
+
 // parentTfTypes is the declarative childTfType → parentTfType registry.
 //
 // Each key is a Terraform resource type that the discovery pipeline can
@@ -117,4 +119,19 @@ func ParentTfType(childTfType string) (string, bool) {
 func HasParent(childTfType string) bool {
 	_, ok := parentTfTypes[childTfType]
 	return ok
+}
+
+// ChildTfTypes returns the sorted list of every registered child type —
+// the keys of the parentTfType registry. It exists so consumers in other
+// packages (notably the awsdiscover parent-instance resolver) can pin a
+// cross-package consistency invariant: every type-level child edge must
+// have a corresponding instance-level foreign-key resolution rule, or be
+// explicitly exempted. Returns a fresh slice; callers may mutate it.
+func ChildTfTypes() []string {
+	out := make([]string, 0, len(parentTfTypes))
+	for child := range parentTfTypes {
+		out = append(out, child)
+	}
+	sort.Strings(out)
+	return out
 }


### PR DESCRIPTION
## Summary

Discovery now resolves a **per-instance parent link** on each discovered child resource, so downstream consumers can group/collapse child instances under the specific parent instance they belong to.

The type-level `parentTfType` registry (#637) already answers *"`aws_s3_bucket_versioning` is scoped to `aws_s3_bucket`"*. This PR adds the instance-level answer: *"this specific versioning row belongs to that specific bucket row."*

## What changed

- **Model** — `ResourceIdentity` gains `ParentAddress`, the Terraform address of the parent resource instance. Round-trips through the discovery manifest schema (`parent_address`, `omitempty`). Empty for resources with no parent and for children whose parent instance was not discovered (no dangling reference).
- **Resolver** — new `awsdiscover.resolveParentAddresses`: a post-discovery, in-memory join over the fully assembled cross-discoverer set, wired into `DiscoverTypes`. No new AWS API calls.
  - **Forward edges** match a child's foreign-key identifier (`bucket`, `vpc_id`, `security_group_id`, `role`, …) against a parent's `ImportID` / `NativeIDs`.
  - **Reverse edges** (parameter groups, which carry no forward FK) scan for the sole referencing parent instance; a shared parameter group stays unlinked.
- **18-edge audit** — every `parentTfType` edge is accounted for:
  - 13 already captured their parent identifier.
  - `aws_route_table` / `aws_subnet` now lift `VpcId` into `NativeIDs`.
  - `aws_db_instance` / `aws_elasticache_replication_group` now carry their parameter-group name as a reverse FK.
  - `aws_internet_gateway` / `aws_vpc_dhcp_options` carry **no** VPC reference in their own AWS resource model — listed in `unresolvableChildTypes` with a documented rationale, follow-up tracked in #651.
- **Validation** — `ValidateImportedResources` rejects a dangling `ParentAddress` (`imported_resource_dangling_parent`).
- **Drift guard** — cross-package tests pin that every `labels` child type has either an FK rule or a documented unresolvable entry, so the type-level and instance-level halves cannot silently diverge.

## Tests

- Table-driven `TestResolveParentAddresses`: forward path, reverse path, NativeIDs-form match, ambiguous parents, missing parent, unresolvable types — all covered.
- `TestParentFK_AgreesWithLabelsRegistry` / `TestParentFK_CoversLabelsRegistry`: registry-consistency invariants.
- `TestManifest_ParentAddressRoundTrips`: manifest write→read round-trip + `omitempty` shape.
- `imported_resource_dangling_parent` validation cases.

Closes #650