### PR TITLE
fix: composer/discovery hardening for importable stacks (#652)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ verify-supported-resources: ## Fail if SUPPORTED_RESOURCES.md is stale (CI gate,
 test: ## Run go test -race for the whole module.
 	$(GO) test -race ./...
 
+.PHONY: test-roundtrip
+test-roundtrip: ## Live AWS discover->emit->plan round-trip for the import flow (#652). Needs real AWS creds (aws_jump first) and terraform; creates and destroys real resources.
+	RUN_LIVE_ROUNDTRIP=1 $(GO) test -tags=integration -run TestLiveRoundTrip ./cmd/insideout-import/... -v -timeout 20m
+
 .PHONY: go-fmt-check
 go-fmt-check: ## Fail if any tracked Go file is not gofmt-clean (CI gate, #647).
 	@unformatted=$$(gofmt -l $$(git ls-files '*.go')); \

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
@@ -130,6 +130,17 @@ type cloudControlConfig struct {
 	TagsFromProperties      func(props map[string]any) map[string]string
 	ParentLister            func(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error)
 	SDKLister               func(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error)
+	// SkipIdentifier, when non-nil, is consulted for every identifier
+	// returned by ListResources / SDKLister: returning true drops that
+	// identifier before the GetResource fan-out (and short-circuits
+	// DiscoverByID with ErrNotSupported). Use it to exclude resources
+	// that the Cloud Control list surfaces but that must never enter
+	// customer Terraform state — e.g. AWS-managed IAM policies, whose
+	// ARN account field is literally "aws" (#652). The customer cannot
+	// manage such a resource's lifecycle, so importing it would surface
+	// permanent drift. Filtering at the identifier stage also avoids a
+	// wasted GetResource call per skipped item.
+	SkipIdentifier func(identifier string) bool
 	// Normalizer, when non-nil, transforms the Cloud Control raw JSON
 	// response before the generic CC→TF mapping step. Use for per-type
 	// shape adjustments that CloudFormation does differently from
@@ -364,6 +375,21 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 			}
 		}
 
+		// Drop identifiers the per-type config marks as not customer-
+		// owned (e.g. AWS-managed IAM policies — #652). Filtering here,
+		// before the GetResource fan-out, also avoids a wasted
+		// GetResource call per skipped item.
+		if d.cfg.SkipIdentifier != nil {
+			kept := refs[:0]
+			for _, ref := range refs {
+				if d.cfg.SkipIdentifier(ref.identifier) {
+					continue
+				}
+				kept = append(kept, ref)
+			}
+			refs = kept
+		}
+
 		// Per-identifier GetResource fan-out under bounded errgroup.
 		type fetched struct {
 			identifier  string
@@ -488,6 +514,14 @@ func (d *cloudControlDiscoverer) DiscoverByID(ctx context.Context, id, region, a
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return imported.ImportedResource{}, fmt.Errorf("%s: empty id: %w", d.cfg.TFType, ErrNotSupported)
+	}
+	// Identifiers the per-type config excludes (e.g. AWS-managed IAM
+	// policies — #652) must not be imported even when dep-chase reaches
+	// them via a cross-reference. ErrNotSupported tells the dep-chase
+	// loop to drop the reference rather than retry with another
+	// discoverer.
+	if d.cfg.SkipIdentifier != nil && d.cfg.SkipIdentifier(id) {
+		return imported.ImportedResource{}, fmt.Errorf("%s %q: not customer-owned: %w", d.cfg.TFType, id, ErrNotSupported)
 	}
 	client := d.new(region)
 	resp, err := client.GetResource(ctx, &cloudcontrol.GetResourceInput{

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_skip_identifier_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_skip_identifier_test.go
@@ -1,0 +1,170 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+)
+
+// TestIsAWSManagedPolicyARN pins the AWS-managed vs customer-owned IAM
+// policy distinction (#652): an AWS-managed policy's ARN account field
+// is the literal string "aws", across all three partitions.
+func TestIsAWSManagedPolicyARN(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		arn  string
+		want bool
+	}{
+		{"aws partition managed", "arn:aws:iam::aws:policy/AWSAccountUsageReportAccess", true},
+		{"govcloud managed", "arn:aws-us-gov:iam::aws:policy/AdministratorAccess", true},
+		{"china managed", "arn:aws-cn:iam::aws:policy/ReadOnlyAccess", true},
+		{"aws managed job-function path", "arn:aws:iam::aws:policy/job-function/Billing", true},
+		{"customer-owned policy", "arn:aws:iam::123456789012:policy/my-app-policy", false},
+		{"customer-owned govcloud", "arn:aws-us-gov:iam::123456789012:policy/my-policy", false},
+		{"non-policy ARN", "arn:aws:s3:::my-bucket", false},
+		{"empty", "", false},
+		{"bare name", "AWSAccountUsageReportAccess", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isAWSManagedPolicyARN(tt.arn); got != tt.want {
+				t.Errorf("isAWSManagedPolicyARN(%q)=%v, want %v", tt.arn, got, tt.want)
+			}
+		})
+	}
+}
+
+// skipManagedConfig is testConfig with the production AWS-managed-policy
+// SkipIdentifier hook wired in, matching the aws_iam_policy config.
+func skipManagedConfig() cloudControlConfig {
+	cfg := testConfig()
+	cfg.SkipIdentifier = isAWSManagedPolicyARN
+	return cfg
+}
+
+// TestCloudControlDiscover_LeaksAWSManagedPolicyWithoutSkipIdentifier is
+// the contrast case for TestCloudControlDiscover_SkipsAWSManagedPolicies:
+// it documents that a config with no SkipIdentifier hook emits every
+// identifier ListResources returns — including AWS-managed IAM policies
+// (the #652 leak). It pins that the filtering is driven entirely by the
+// SkipIdentifier hook and nothing else, so the Skips… test's pass is
+// attributable to the hook.
+func TestCloudControlDiscover_LeaksAWSManagedPolicyWithoutSkipIdentifier(t *testing.T) {
+	t.Parallel()
+	const managed = "arn:aws:iam::aws:policy/AWSAccountUsageReportAccess"
+	fake := &fakeCloudControlClient{
+		listPages: []cloudcontrol.ListResourcesOutput{listPage("", managed)},
+		propsByIdentifier: map[string]map[string]any{
+			managed: {"ManagedPolicyName": "AWSAccountUsageReportAccess"},
+		},
+	}
+	d := &cloudControlDiscoverer{
+		cfg:            testConfig(), // no SkipIdentifier — the buggy config
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Regions: []string{"us-east-1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Identity.ImportID != managed {
+		t.Fatalf("expected the unfiltered discoverer to leak the AWS-managed policy; got %d resource(s): %+v", len(got), got)
+	}
+}
+
+// TestCloudControlDiscover_SkipsAWSManagedPolicies pins that the
+// SkipIdentifier hook drops AWS-managed IAM policies before the
+// GetResource fan-out: they never reach the emitted set, and — proving
+// the filter runs at the identifier stage, not post-fetch — GetResource
+// is never even called for them (#652).
+func TestCloudControlDiscover_SkipsAWSManagedPolicies(t *testing.T) {
+	t.Parallel()
+	const (
+		customer = "arn:aws:iam::123456789012:policy/my-app-policy"
+		managedA = "arn:aws:iam::aws:policy/AWSAccountUsageReportAccess"
+		managedB = "arn:aws:iam::aws:policy/AdministratorAccess"
+	)
+	fake := &fakeCloudControlClient{
+		listPages: []cloudcontrol.ListResourcesOutput{
+			listPage("", customer, managedA, managedB),
+		},
+		propsByIdentifier: map[string]map[string]any{
+			// Only the customer-owned policy should ever be fetched.
+			customer: {"ManagedPolicyName": "my-app-policy"},
+		},
+	}
+	d := &cloudControlDiscoverer{
+		cfg:            skipManagedConfig(),
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123456789012",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("emitted %d resources, want 1 (only the customer-owned policy)", len(got))
+	}
+	if got[0].Identity.ImportID != customer {
+		t.Errorf("emitted ImportID=%q, want %q", got[0].Identity.ImportID, customer)
+	}
+	for _, called := range fake.getResourceCalls {
+		if called == managedA || called == managedB {
+			t.Errorf("GetResource was called for AWS-managed policy %q; SkipIdentifier must drop it before the fan-out", called)
+		}
+	}
+}
+
+// TestCloudControlDiscoverByID_SkipsAWSManagedPolicy pins that a
+// dep-chase reaching an AWS-managed policy ARN gets ErrNotSupported
+// (so the loop drops the reference) and that no GetResource call is
+// issued for it.
+func TestCloudControlDiscoverByID_SkipsAWSManagedPolicy(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{}
+	d := &cloudControlDiscoverer{
+		cfg:            skipManagedConfig(),
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	_, err := d.DiscoverByID(context.Background(),
+		"arn:aws:iam::aws:policy/AWSAccountUsageReportAccess", "us-east-1", "123456789012")
+	if !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("err=%v, want ErrNotSupported", err)
+	}
+	if len(fake.getResourceCalls) != 0 {
+		t.Errorf("GetResource called %v; an AWS-managed policy must be skipped before any API call", fake.getResourceCalls)
+	}
+}
+
+// TestCloudControlDiscoverByID_CustomerPolicyNotSkipped pins the
+// negative: a customer-owned policy ARN is NOT skipped by the hook —
+// DiscoverByID proceeds to the GetResource call.
+func TestCloudControlDiscoverByID_CustomerPolicyNotSkipped(t *testing.T) {
+	t.Parallel()
+	const customer = "arn:aws:iam::123456789012:policy/my-app-policy"
+	fake := &fakeCloudControlClient{
+		propsByIdentifier: map[string]map[string]any{
+			customer: {"ManagedPolicyName": "my-app-policy"},
+		},
+	}
+	d := &cloudControlDiscoverer{
+		cfg:            skipManagedConfig(),
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	ir, err := d.DiscoverByID(context.Background(), customer, "us-east-1", "123456789012")
+	if err != nil {
+		t.Fatalf("customer-owned policy must not be skipped: %v", err)
+	}
+	if ir.Identity.ImportID != customer {
+		t.Errorf("ImportID=%q, want %q", ir.Identity.ImportID, customer)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -267,6 +267,12 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 			return map[string]string{"arn": identifier}
 		},
 		TagsFromProperties: tagsFromKey("Tags"),
+		// CC ListResources for AWS::IAM::ManagedPolicy returns both
+		// customer-managed AND AWS-managed policies. AWS-managed
+		// policies (ARN account field literally "aws") are not
+		// customer-owned and must never be imported into customer
+		// state — see isAWSManagedPolicyARN and #652.
+		SkipIdentifier: isAWSManagedPolicyARN,
 		// Normalizer: CFN AWS::IAM::ManagedPolicy surfaces the policy
 		// document as a nested JSON object under `PolicyDocument`, but
 		// Terraform's `aws_iam_policy.policy` is a REQUIRED JSON-encoded
@@ -2717,6 +2723,31 @@ func arnUnderKey(key string) func(identifier string, props map[string]any) map[s
 		}
 		return map[string]string{"arn": arn}
 	}
+}
+
+// awsManagedPolicyARNPrefixes are the IAM-managed-policy ARN prefixes
+// across the standard, GovCloud, and China partitions. An AWS-managed
+// policy ARN carries the literal account field "aws" (e.g.
+// arn:aws:iam::aws:policy/AWSAccountUsageReportAccess); a customer-owned
+// policy carries a real 12-digit account ID.
+var awsManagedPolicyARNPrefixes = []string{
+	"arn:aws:iam::aws:policy/",
+	"arn:aws-us-gov:iam::aws:policy/",
+	"arn:aws-cn:iam::aws:policy/",
+}
+
+// isAWSManagedPolicyARN reports whether arn is an AWS-managed IAM policy
+// ARN. AWS-managed policies are not customer-owned — their lifecycle
+// belongs to AWS — so importing one into customer Terraform state would
+// surface permanent, unfixable drift (#652). The aws_iam_policy
+// discoverer drops them via the SkipIdentifier hook.
+func isAWSManagedPolicyARN(arn string) bool {
+	for _, p := range awsManagedPolicyARNPrefixes {
+		if strings.HasPrefix(arn, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // tagsFromKey returns a TagsFromProperties extractor that reads tags

--- a/cmd/insideout-import/genconfig/attributes.go
+++ b/cmd/insideout-import/genconfig/attributes.go
@@ -8,10 +8,32 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
+
+// genconfigEvalContext is the evaluation context for decodeAttribute. It
+// registers the pure HCL functions that `terraform plan -generate-config-out`
+// emits into generated.tf — chiefly jsonencode, used for JSON-string
+// attributes such as aws_iam_policy.policy and
+// aws_iam_role.assume_role_policy. generate-config-out renders live cloud
+// state, so these calls carry only literal arguments (no variables or
+// resource refs) and evaluate cleanly with no variables in scope.
+//
+// Without this, jsonencode({...}) fails evaluation and decodeAttribute
+// captures the literal source text "jsonencode({...})" as a plain string;
+// the composer then re-quotes it into `policy = "jsonencode({...})"`, which
+// terraform plan rejects with `"policy" contains an invalid JSON policy`
+// (#652).
+var genconfigEvalContext = &hcl.EvalContext{
+	Functions: map[string]function.Function{
+		"jsonencode": stdlib.JSONEncodeFunc,
+		"jsondecode": stdlib.JSONDecodeFunc,
+	},
+}
 
 // extractAttributes parses the cleaned generated.tf and returns a copy of
 // the input slice with each ImportedResource.Attributes populated from its
@@ -97,11 +119,13 @@ func decodeAttribute(attr *hclwrite.Attribute) (any, error) {
 	if diags.HasErrors() {
 		return src, nil // unparseable: fall back to raw source
 	}
-	val, diags := parsedExpr.Value(nil)
+	val, diags := parsedExpr.Value(genconfigEvalContext)
 	if diags.HasErrors() {
-		// Has variables / refs / funcs we can't evaluate without context.
-		// Return the source text — Stage 2c can teach consumers to
-		// re-resolve it.
+		// Still unresolvable — a reference to another resource, or a
+		// function we don't register. generate-config-out emits only
+		// literals and jsonencode, so in practice this is a bare ref
+		// like aws_kms_key.foo.arn. Return the source text — Stage 2c
+		// can teach consumers to re-resolve it.
 		return src, nil
 	}
 

--- a/cmd/insideout-import/genconfig/attributes_test.go
+++ b/cmd/insideout-import/genconfig/attributes_test.go
@@ -1,10 +1,95 @@
 package genconfig
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
+
+// TestExtractAttributes_JSONEncodePolicyEvaluates pins the #652 fix: a
+// JSON-string attribute that `terraform plan -generate-config-out`
+// renders as a jsonencode({...}) call must be captured as a valid JSON
+// string, not as the literal source text "jsonencode({...})". Capturing
+// the text made the composer re-quote it into `policy =
+// "jsonencode({...})"`, which terraform plan rejects with `"policy"
+// contains an invalid JSON policy: not a JSON object`.
+func TestExtractAttributes_JSONEncodePolicyEvaluates(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_iam_policy" "x" {
+  name = "alpha"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:GetObject"]
+      Resource = "arn:aws:s3:::example-bucket/*"
+    }]
+  })
+}
+`)
+	out, err := extractAttributes(in, []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Address: "aws_iam_policy.x"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy, ok := out[0].Attributes["policy"].(string)
+	if !ok {
+		t.Fatalf("policy should be a string; got %T = %v", out[0].Attributes["policy"], out[0].Attributes["policy"])
+	}
+	if strings.Contains(policy, "jsonencode") {
+		t.Fatalf("policy still carries the jsonencode() source text; the expression was not evaluated:\n%s", policy)
+	}
+	// The captured value must be a valid JSON object.
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(policy), &doc); err != nil {
+		t.Fatalf("captured policy is not valid JSON: %v\n%s", err, policy)
+	}
+	if doc["Version"] != "2012-10-17" {
+		t.Errorf("policy JSON Version = %v, want 2012-10-17", doc["Version"])
+	}
+}
+
+// TestExtractAttributes_JSONEncodeAssumeRolePolicy is the sibling of
+// TestExtractAttributes_JSONEncodePolicyEvaluates for a different type
+// and attribute — aws_iam_role.assume_role_policy. terraform plan
+// -generate-config-out renders every IAM JSON-string attribute as a
+// jsonencode({...}) call, so the #652 fix must be generic across all of
+// them, not special-cased to aws_iam_policy.policy.
+func TestExtractAttributes_JSONEncodeAssumeRolePolicy(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_iam_role" "x" {
+  name = "alpha"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+`)
+	out, err := extractAttributes(in, []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Address: "aws_iam_role.x"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy, ok := out[0].Attributes["assume_role_policy"].(string)
+	if !ok {
+		t.Fatalf("assume_role_policy should be a string; got %T", out[0].Attributes["assume_role_policy"])
+	}
+	if strings.Contains(policy, "jsonencode") {
+		t.Fatalf("assume_role_policy still carries jsonencode() source text:\n%s", policy)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(policy), &doc); err != nil {
+		t.Fatalf("captured assume_role_policy is not valid JSON: %v\n%s", err, policy)
+	}
+}
 
 func TestExtractAttributes_ScalarTypes(t *testing.T) {
 	t.Parallel()

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
 // applyResourceTypeFixups runs after schema cleanup. It plugs the gaps
@@ -77,15 +79,9 @@ const lambdaPlaceholderFile = "lambda_placeholder.zip"
 // lambdaIgnoreChanges is the set of attributes lifecycle.ignore_changes
 // must cover so a real `terraform apply` against this stack will not try
 // to re-upload code or churn checksum-derived attrs the operator never
-// edits.
-var lambdaIgnoreChanges = []string{
-	"filename",
-	"image_uri",
-	"s3_bucket",
-	"s3_key",
-	"s3_object_version",
-	"source_code_hash",
-}
+// edits. It is the shared canonical list — the composer's imported.tf
+// emitter pins the identical set (see imported.LambdaCodeAttrs).
+var lambdaIgnoreChanges = imported.LambdaCodeAttrs
 
 // fixupLambdaSource is the per-block implementation of the Lambda
 // post-cleanup contract documented on applyResourceTypeFixups. The block

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -1,10 +1,27 @@
 package genconfig
 
 import (
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
+
+// TestLambdaIgnoreChangesUsesCanonicalList pins imported.LambdaCodeAttrs'
+// contract: the genconfig fixup and the composer's imported.tf emitter
+// must pin the identical lifecycle.ignore_changes set, or a Lambda
+// import breaks (#652). They cannot drift only because both read the
+// one shared list — a future edit re-introducing a local override here
+// is caught by this test.
+func TestLambdaIgnoreChangesUsesCanonicalList(t *testing.T) {
+	t.Parallel()
+	if !reflect.DeepEqual(lambdaIgnoreChanges, imported.LambdaCodeAttrs) {
+		t.Errorf("genconfig lambdaIgnoreChanges %v must equal the shared imported.LambdaCodeAttrs %v",
+			lambdaIgnoreChanges, imported.LambdaCodeAttrs)
+	}
+}
 
 // TestFixupLambda_NullSourceAttrsTreatedAsMissing pins the real-world
 // shape live AWS produces: terraform plan -generate-config-out emits

--- a/cmd/insideout-import/roundtrip_live_test.go
+++ b/cmd/insideout-import/roundtrip_live_test.go
@@ -1,0 +1,267 @@
+//go:build integration
+
+// roundtrip_live_test.go is the local live-AWS round-trip harness for the
+// import flow (issue #652). It exercises the whole cycle that previously
+// could only be tested on prod (Reliable + Argo): create real AWS
+// resources, discover them, re-emit imported.tf via the composer, and
+// assert `terraform plan` on that imported.tf is clean — then tear the
+// fixture down.
+//
+// It is gated three ways so it never runs in normal `go test ./...` or
+// CI: the `integration` build tag, the RUN_LIVE_ROUNDTRIP=1 env guard,
+// and a credential probe that skips cleanly when no AWS creds are
+// loaded. Run it with real creds (e.g. after `aws_jump <acct> <role>`):
+//
+//	make test-roundtrip
+//
+// or directly:
+//
+//	RUN_LIVE_ROUNDTRIP=1 go test -tags=integration -run TestLiveRoundTrip \
+//	    ./cmd/insideout-import/... -v -timeout 20m
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+)
+
+// roundtripRegion is the region the fixture and the plan workspace use.
+const roundtripRegion = "us-east-1"
+
+// roundtripTypes is the resource-type subset the discover run scans —
+// exactly the four #652-implicated types plus the IAM role the Lambda
+// depends on. Narrowing the scan keeps the run fast.
+const roundtripTypes = "aws_s3_bucket,aws_cloudwatch_log_group,aws_lambda_function,aws_iam_role,aws_iam_policy"
+
+// TestLiveRoundTrip applies the roundtrip fixture, discovers it, re-emits
+// imported.tf through the composer, and asserts `terraform plan` on the
+// emitted file completes without error — the #652 failure mode. It does
+// not apply the import; a clean plan is sufficient proof.
+func TestLiveRoundTrip(t *testing.T) {
+	if os.Getenv("RUN_LIVE_ROUNDTRIP") == "" {
+		t.Skip("live round-trip test: set RUN_LIVE_ROUNDTRIP=1 to run (creates real AWS resources)")
+	}
+	requireTerraform(t)
+	requireAWSCredentials(t)
+
+	project := "iort" + randomSuffix(t)
+	t.Logf("round-trip project prefix: %s", project)
+
+	// --- Stage 1: apply the fixture (real AWS resources) ---------------
+	fixtureWS := t.TempDir()
+	copyFile(t, filepath.Join("testdata", "roundtrip-fixture", "main.tf"),
+		filepath.Join(fixtureWS, "main.tf"))
+
+	tfVars := []string{"-var", "project=" + project, "-var", "region=" + roundtripRegion}
+	runTF(t, fixtureWS, "fixture init", "init", "-input=false", "-no-color")
+	// Destroy is registered before apply so a partial apply still cleans up.
+	t.Cleanup(func() {
+		out, err := tryTF(fixtureWS, append([]string{"destroy", "-auto-approve", "-input=false", "-no-color"}, tfVars...)...)
+		if err != nil {
+			t.Errorf("fixture destroy failed — manual cleanup of project %q may be needed:\n%s", project, out)
+		}
+	})
+	runTF(t, fixtureWS, "fixture apply",
+		append([]string{"apply", "-auto-approve", "-input=false", "-no-color"}, tfVars...)...)
+
+	// --- Stage 2: discover the fixture resources -----------------------
+	outDir := t.TempDir()
+	t.Logf("running insideout-import discover --project %s", project)
+	if code := runDiscover([]string{
+		"--provider", "aws",
+		"--project", project,
+		"--regions", roundtripRegion,
+		"--resource-types", roundtripTypes,
+		"--output-dir", outDir,
+	}); code != 0 {
+		t.Fatalf("discover exited %d, want 0", code)
+	}
+
+	irs, err := readManifest(filepath.Join(outDir, "imported.json"), "aws")
+	if err != nil {
+		t.Fatalf("read discovered manifest: %v", err)
+	}
+	if len(irs) == 0 {
+		t.Fatal("discover found zero resources; the fixture apply or the project-tag filter is broken")
+	}
+	t.Logf("discovered %d resource(s)", len(irs))
+
+	// No AWS-managed IAM policy may enter the discovered set (#652) — the
+	// discover project-tag scope plus the SkipIdentifier filter guarantee
+	// this; pin it so a regression on either is caught here.
+	for _, ir := range irs {
+		if strings.Contains(ir.Identity.ImportID, ":iam::aws:policy/") {
+			t.Errorf("discovered an AWS-managed IAM policy %q; it must never enter customer state", ir.Identity.ImportID)
+		}
+	}
+
+	// --- Stage 3: re-emit imported.tf via the composer -----------------
+	importedTF, used := composer.EmitImportedTF("aws", irs, composer.EmitImportedOpts{
+		ImportProjectID: project,
+		ImportSessionID: "roundtrip-live-test",
+		ImportedAt:      time.Now().UTC(),
+	})
+	if len(importedTF) == 0 {
+		t.Fatal("EmitImportedTF produced no output for a non-empty discovered set")
+	}
+	if !used["aws"] {
+		t.Fatal("EmitImportedTF did not flag the aws provider as used")
+	}
+
+	// --- Stage 4: terraform plan the emitted imported.tf ---------------
+	planWS := t.TempDir()
+	writeFile(t, filepath.Join(planWS, "imported.tf"), importedTF)
+	writeFile(t, filepath.Join(planWS, "providers.tf"), []byte(roundtripProvidersTF))
+
+	runTF(t, planWS, "imported.tf init", "init", "-input=false", "-no-color")
+	planOut, planErr := tryTF(planWS, "plan", "-input=false", "-no-color")
+	t.Logf("terraform plan output:\n%s", planOut)
+	if planErr != nil {
+		t.Fatalf("terraform plan on the composed imported.tf FAILED — this is the #652 regression:\n%s", planOut)
+	}
+	// Defense in depth: a zero exit with `Error:` diagnostics in the body
+	// would still be the #652 failure mode.
+	if strings.Contains(planOut, "\nError:") || strings.HasPrefix(planOut, "Error:") {
+		t.Fatalf("terraform plan emitted error diagnostics on the composed imported.tf (#652):\n%s", planOut)
+	}
+
+	// --- Stage 5: terraform apply — the real import --------------------
+	// Applying the import {} blocks adopts the four live resources into
+	// the plan workspace's (ephemeral) state. Once that succeeds the
+	// plan workspace owns them, so its destroy — registered here, and
+	// therefore run BEFORE the fixture destroy (t.Cleanup is LIFO) — is
+	// the real teardown; the fixture destroy then refreshes, finds the
+	// resources already gone, and no-ops.
+	t.Cleanup(func() {
+		out, err := tryTF(planWS, "destroy", "-auto-approve", "-input=false", "-no-color")
+		if err != nil {
+			t.Errorf("plan-workspace destroy failed — manual cleanup of project %q may be needed:\n%s", project, out)
+		}
+	})
+	applyOut, applyErr := tryTF(planWS, "apply", "-auto-approve", "-input=false", "-no-color")
+	t.Logf("terraform apply (import) output:\n%s", applyOut)
+	if applyErr != nil {
+		t.Fatalf("terraform apply on the composed imported.tf FAILED — the import does not work end to end:\n%s", applyOut)
+	}
+
+	// --- Stage 6: verify every resource landed in Terraform state ------
+	stateOut, err := tryTF(planWS, "state", "list")
+	if err != nil {
+		t.Fatalf("terraform state list failed after import: %v\n%s", err, stateOut)
+	}
+	for _, want := range []string{
+		"aws_lambda_function.",
+		"aws_s3_bucket.",
+		"aws_cloudwatch_log_group.",
+		"aws_iam_policy.",
+	} {
+		if !strings.Contains(stateOut, want) {
+			t.Errorf("imported Terraform state is missing a %s resource:\n%s", want, stateOut)
+		}
+	}
+	t.Logf("round-trip OK: %d resource(s) discovered, composed, and imported into Terraform state for project %s",
+		len(irs), project)
+}
+
+// roundtripProvidersTF is the providers.tf for the plan workspace. The
+// imported resources all carry `provider = aws.imported`, so the aliased
+// provider must be declared; the default provider satisfies init.
+const roundtripProvidersTF = `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "` + roundtripRegion + `"
+}
+
+provider "aws" {
+  alias  = "imported"
+  region = "` + roundtripRegion + `"
+}
+`
+
+// requireTerraform skips the test when the terraform binary is absent.
+func requireTerraform(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("live round-trip test: terraform not found on PATH")
+	}
+}
+
+// requireAWSCredentials skips the test when no usable AWS credentials are
+// loaded, rather than failing — the harness is opt-in and an unprivileged
+// environment should not turn red.
+func requireAWSCredentials(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(roundtripRegion))
+	if err != nil {
+		t.Skipf("live round-trip test: cannot load AWS config: %v", err)
+	}
+	if _, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}); err != nil {
+		t.Skipf("live round-trip test: no usable AWS credentials (run aws_jump first): %v", err)
+	}
+}
+
+// randomSuffix returns 8 lowercase hex chars for unique resource naming.
+func randomSuffix(t *testing.T) string {
+	t.Helper()
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return hex.EncodeToString(b)
+}
+
+// runTF runs terraform in dir and fails the test on a non-zero exit.
+func runTF(t *testing.T, dir, label string, args ...string) {
+	t.Helper()
+	out, err := tryTF(dir, args...)
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", label, err, out)
+	}
+}
+
+// tryTF runs terraform in dir and returns the combined output and error
+// without failing the test — callers decide how to react.
+func tryTF(dir string, args ...string) (string, error) {
+	cmd := exec.Command("terraform", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	writeFile(t, dst, data)
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/cmd/insideout-import/testdata/roundtrip-fixture/main.tf
+++ b/cmd/insideout-import/testdata/roundtrip-fixture/main.tf
@@ -1,0 +1,119 @@
+# roundtrip-fixture is a tiny, self-contained Terraform stack that creates
+# the four AWS resource types implicated in issue #652 — an S3 bucket, a
+# CloudWatch log group, a customer-managed IAM policy, and a Lambda
+# function (plus the IAM role the Lambda needs). The live round-trip test
+# (roundtrip_live_test.go) applies this stack, runs `insideout-import
+# discover` against it, re-emits imported.tf via the composer, and
+# asserts `terraform plan` on that imported.tf is clean.
+#
+# Every resource carries `Project = var.project` so the discover
+# project-tag filter scopes to exactly this fixture and nothing else in
+# the account. var.project is a unique random prefix supplied per run.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.4"
+    }
+  }
+}
+
+variable "project" {
+  type        = string
+  description = "Unique stack-naming / Project-tag prefix for this run."
+}
+
+variable "region" {
+  type        = string
+  default     = "us-east-1"
+  description = "AWS region to create the fixture resources in."
+}
+
+provider "aws" {
+  region = var.region
+}
+
+locals {
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_s3_bucket" "fixture" {
+  bucket        = "${var.project}-bucket"
+  force_destroy = true
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_log_group" "fixture" {
+  name              = "/insideout-roundtrip/${var.project}"
+  retention_in_days = 14
+  tags              = local.tags
+}
+
+resource "aws_iam_policy" "fixture" {
+  name = "${var.project}-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:GetObject"]
+      Resource = "${aws_s3_bucket.fixture.arn}/*"
+    }]
+  })
+  tags = local.tags
+}
+
+resource "aws_iam_role" "fixture" {
+  name = "${var.project}-lambda-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+  tags = local.tags
+}
+
+data "archive_file" "lambda" {
+  type        = "zip"
+  output_path = "${path.module}/lambda.zip"
+  source {
+    content  = "exports.handler = async () => ({ statusCode: 200 });"
+    filename = "index.js"
+  }
+}
+
+resource "aws_lambda_function" "fixture" {
+  function_name    = "${var.project}-fn"
+  role             = aws_iam_role.fixture.arn
+  runtime          = "nodejs20.x"
+  handler          = "index.handler"
+  filename         = data.archive_file.lambda.output_path
+  source_code_hash = data.archive_file.lambda.output_base64sha256
+  tags             = local.tags
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.fixture.id
+}
+
+output "log_group_name" {
+  value = aws_cloudwatch_log_group.fixture.name
+}
+
+output "iam_policy_arn" {
+  value = aws_iam_policy.fixture.arn
+}
+
+output "lambda_function_name" {
+  value = aws_lambda_function.fixture.function_name
+}

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -692,7 +692,8 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// at compose time, on the final ready-to-emit resource set — not in
 	// the discovery manifest writer, which validates a still-enriching
 	// intermediate snapshot. See ValidateImportedEmitReadiness.
-	issues = append(issues, ValidateImportedEmitReadiness(cloud, opts.Imported)...)
+	emitReadiness := ValidateImportedEmitReadiness(cloud, opts.Imported)
+	issues = append(issues, emitReadiness...)
 	issues = append(issues, ValidateImportedResourceAuthorization(cloud, opts.Imported)...)
 	provOpts := ProvenanceOpts{ImportProjectID: opts.ImportProjectID}
 	issues = append(issues, ValidateProvenanceConflicts(cloud, opts.Imported, provOpts)...)
@@ -701,7 +702,15 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 		ImportSessionID: opts.ImportSessionID,
 		ImportedAt:      nowFn(),
 	}
-	importedTF, importedClouds := EmitImportedTF(cloud, opts.Imported, emitOpts)
+	// Refuse to emit resources flagged un-composable — a resource block
+	// missing required arguments fails `terraform plan` with "Missing
+	// required argument", which aborts planning for the WHOLE stack
+	// (#652). The imported_resource_missing_required_attr issue is
+	// already recorded above, so the caller still learns which resource
+	// was dropped and why; emitting it anyway would turn a one-resource
+	// gap into a stack-wide planning failure.
+	composable := dropUncomposable(opts.Imported, emitReadiness)
+	importedTF, importedClouds := EmitImportedTF(cloud, composable, emitOpts)
 	if len(importedTF) > 0 {
 		files["/imported.tf"] = importedTF
 	}

--- a/pkg/composer/imported/lambda.go
+++ b/pkg/composer/imported/lambda.go
@@ -1,0 +1,26 @@
+package imported
+
+// LambdaCodeAttrs are the aws_lambda_function deployment-package
+// attributes that an imported function cannot reproduce locally — the
+// code lives in AWS, not on disk.
+//
+// The provider schema requires exactly one of filename / image_uri /
+// s3_bucket, so the genconfig fixup injects a placeholder `filename` to
+// make the generated block valid. Both that fixup and the composer's
+// imported.tf emitter then pin every attribute below under
+// `lifecycle { ignore_changes }` so `terraform apply` never (a) reads
+// the nonexistent placeholder file, nor (b) re-uploads a placeholder
+// over the live function's real code. Without the pin, importing a
+// Lambda either fails the apply or destroys its code (#652).
+//
+// Declared here, in the shared IR package, so the genconfig fixup and
+// the composer emitter pin the identical set — a drift between the two
+// would reintroduce the bug.
+var LambdaCodeAttrs = []string{
+	"filename",
+	"image_uri",
+	"s3_bucket",
+	"s3_key",
+	"s3_object_version",
+	"source_code_hash",
+}

--- a/pkg/composer/imported_652_repro_test.go
+++ b/pkg/composer/imported_652_repro_test.go
@@ -1,0 +1,146 @@
+package composer
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// TestImported652Repro pins the composer's handling of the exact
+// discovery manifest that produced the malformed imported.tf in #652
+// (Reliable session sess_v2_CnqUJ6NRJnLC). testdata/imported_652_repro.json
+// is a faithful reduction of stack_versions.imported for that session,
+// carrying the three defect-bearing resources:
+//
+//   - aws_cloudwatch_log_group whose typed Attrs include the computed
+//     `id` attribute — EmitImportedTF must NOT render it into the
+//     resource body, or terraform plan fails "Invalid or unknown key".
+//   - aws_iam_policy with no `policy` attribute (a required argument).
+//   - aws_lambda_function with null Attrs — no `role`/`function_name`.
+//
+// The composer must (a) strip `id` from every emitted resource body and
+// (b) surface the missing required arguments as
+// imported_resource_missing_required_attr at compose time, rather than
+// letting terraform plan fail later with an opaque error.
+func TestImported652Repro(t *testing.T) {
+	t.Parallel()
+	raw, err := os.ReadFile("testdata/imported_652_repro.json")
+	require.NoError(t, err)
+	var irs []imported.ImportedResource
+	require.NoError(t, json.Unmarshal(raw, &irs))
+	require.Len(t, irs, 4)
+
+	out, used := EmitImportedTF("aws", irs, EmitImportedOpts{
+		ImportProjectID: "io-cnquj6nrjnlc",
+		ImportSessionID: "sess_v2_CnqUJ6NRJnLC",
+		ImportedAt:      time.Date(2026, 5, 20, 3, 52, 35, 0, time.UTC),
+	})
+	require.NotNil(t, out)
+	assert.True(t, used["aws"])
+
+	file, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.Falsef(t, diags.HasErrors(), "imported.tf must parse: %s\n%s", diags.Error(), out)
+
+	// Bug 1: no `resource {}` body may carry the computed `id` attribute.
+	// Terraform rejects `id = "..."` inside a resource block. import {}
+	// blocks legitimately carry id — only resource blocks are checked.
+	body := file.Body.(*hclsyntax.Body)
+	resourceBlocks := 0
+	for _, blk := range body.Blocks {
+		if blk.Type != "resource" {
+			continue
+		}
+		resourceBlocks++
+		_, hasID := blk.Body.Attributes["id"]
+		assert.Falsef(t, hasID,
+			"resource %v emits the computed `id` attribute; #652 — EmitImportedTF must strip it", blk.Labels)
+	}
+	assert.Equal(t, 4, resourceBlocks, "expected one resource block per imported resource")
+
+	// Bugs 2 & 3: the missing required arguments must be surfaced at
+	// compose time. aws_iam_policy lacks `policy`; aws_lambda_function
+	// has null Attrs (lacks `role` and `function_name`).
+	issues := ValidateImportedEmitReadiness("aws", irs)
+	flagged := map[string]bool{}
+	for _, is := range issues {
+		if is.Code == "imported_resource_missing_required_attr" {
+			flagged[is.Field] = true
+		}
+	}
+	// Expected field keys are derived from the loaded manifest rather
+	// than hard-coded, so a change to address derivation can't silently
+	// turn these assertions vacuous.
+	wantFlagged := map[string]string{} // tfType -> imported.<address>
+	for _, ir := range irs {
+		switch ir.Identity.Type {
+		case "aws_iam_policy", "aws_lambda_function":
+			wantFlagged[ir.Identity.Type] = "imported." + ir.Identity.Address
+		}
+	}
+	require.Len(t, wantFlagged, 2, "fixture must contain the iam_policy and lambda records")
+	assert.Truef(t, flagged[wantFlagged["aws_iam_policy"]],
+		"aws_iam_policy missing required `policy` not flagged at compose time; issues=%+v", issues)
+	assert.Truef(t, flagged[wantFlagged["aws_lambda_function"]],
+		"aws_lambda_function missing required args not flagged at compose time; issues=%+v", issues)
+}
+
+// TestImported652Repro_ComposeRefusesUncomposable is the end-to-end
+// composer-side reproduction of #652: it runs the exact #652 discovery
+// manifest through the public ComposeStackWithIssues path and asserts
+// the composer refuses the un-composable resources. Against main —
+// before the dropUncomposable hardening — the aws_iam_policy (no
+// `policy`) and aws_lambda_function (null Attrs) are emitted as partial
+// resource blocks and `terraform plan` aborts the entire stack with
+// "Missing required argument". The composable aws_cloudwatch_log_group
+// and aws_s3_bucket must survive so the rest of the stack still plans.
+func TestImported652Repro_ComposeRefusesUncomposable(t *testing.T) {
+	t.Parallel()
+	raw, err := os.ReadFile("testdata/imported_652_repro.json")
+	require.NoError(t, err)
+	var irs []imported.ImportedResource
+	require.NoError(t, json.Unmarshal(raw, &irs))
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "io-cnquj6nrjnlc",
+		Region:       "us-east-1",
+		Imported:     irs,
+	})
+	require.NoError(t, err)
+	tf := string(res.Files["/imported.tf"])
+
+	// Composable resources survive into the emitted stack.
+	assert.Contains(t, tf, `resource "aws_cloudwatch_log_group"`,
+		"the composable log group must be emitted")
+	assert.Contains(t, tf, `resource "aws_s3_bucket"`,
+		"the composable bucket must be emitted")
+
+	// Un-composable resources are refused — emitting their partial
+	// blocks would abort `terraform plan` for the whole stack (#652).
+	assert.NotContains(t, tf, `resource "aws_iam_policy"`,
+		"the iam_policy with no `policy` argument must be refused")
+	assert.NotContains(t, tf, `resource "aws_lambda_function"`,
+		"the lambda with null Attrs must be refused")
+
+	// The refusal is explained, not silent.
+	missingReqd := 0
+	for _, is := range res.Issues {
+		if is.Code == "imported_resource_missing_required_attr" {
+			missingReqd++
+		}
+	}
+	assert.GreaterOrEqualf(t, missingReqd, 2,
+		"compose must report imported_resource_missing_required_attr for each refused resource; issues=%+v", res.Issues)
+}

--- a/pkg/composer/imported_compose_test.go
+++ b/pkg/composer/imported_compose_test.go
@@ -727,6 +727,7 @@ func TestComposeStackWithIssues_CrossTierWiring_RoundTrip(t *testing.T) {
 				Tier: imported.TierImportedFlat,
 				Attributes: map[string]any{
 					"function_name": "api",
+					"role":          "arn:aws:iam::123456789012:role/api",
 					// Cross-tier reference: api Lambda reads users table ARN.
 					"description": RawExpr{Expr: "aws_dynamodb_table.users.arn"},
 				},
@@ -777,6 +778,7 @@ func TestComposeStackWithIssues_CrossTierWiring_DanglingFlagged(t *testing.T) {
 				Tier: imported.TierImportedFlat,
 				Attributes: map[string]any{
 					"function_name": "api",
+					"role":          "arn:aws:iam::123456789012:role/api",
 					"description":   RawExpr{Expr: "aws_dynamodb_table.absent.arn"},
 				},
 			},

--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -134,6 +134,7 @@ func EmitImportedTF(cloud string, irs []imported.ImportedResource, opts EmitImpo
 					continue
 				}
 			}
+			body = appendImportedLifecycle(body, ir.Identity.Type)
 			alias := providerAliasForResource(got, ir.Identity)
 			e.resource = wrapResourceBlock(ir.Identity.Type, addressLabel(addr), alias, body)
 			if mode == emitModeResourceImport {
@@ -346,6 +347,44 @@ func writeOpaqueAttr(body *hclwrite.Body, name string, v any) error {
 // <body> }` as a byte slice for downstream concatenation. Body bytes are
 // inserted verbatim; the outer hclwrite.ParseConfig pass canonicalises
 // formatting.
+// importedLifecycleIgnoreChanges maps a Terraform type to the attributes
+// an imported instance of it must pin under `lifecycle.ignore_changes`.
+//
+// aws_lambda_function: the discovery pipeline injects a placeholder
+// `filename` so the block satisfies the provider's "one of filename /
+// image_uri / s3_bucket" schema rule (an imported function's code lives
+// in AWS, not on disk). Without pinning the code attributes, the first
+// `terraform apply` after import either fails reading the nonexistent
+// placeholder file or re-uploads the placeholder over the live
+// function's real code (#652). The genconfig fixup adds the same pin to
+// generated.tf, but the composer re-emits imported.tf from the IR — and
+// the IR does not carry meta-blocks — so the emitter must re-add it.
+var importedLifecycleIgnoreChanges = map[string][]string{
+	"aws_lambda_function": imported.LambdaCodeAttrs,
+}
+
+// appendImportedLifecycle appends a `lifecycle { ignore_changes = [...] }`
+// block to an imported resource body when tfType is in
+// importedLifecycleIgnoreChanges. body is hclwrite-emitted attribute
+// text; the block is appended as raw HCL (ignore_changes items are bare
+// attribute references, not strings) and re-formatted by the caller's
+// outer parse. Types with no entry are returned unchanged.
+func appendImportedLifecycle(body []byte, tfType string) []byte {
+	attrs, ok := importedLifecycleIgnoreChanges[tfType]
+	if !ok || len(attrs) == 0 {
+		return body
+	}
+	var b bytes.Buffer
+	b.Write(body)
+	if len(body) > 0 && !bytes.HasSuffix(body, []byte("\n")) {
+		b.WriteByte('\n')
+	}
+	b.WriteString("\nlifecycle {\n  ignore_changes = [")
+	b.WriteString(strings.Join(attrs, ", "))
+	b.WriteString("]\n}\n")
+	return b.Bytes()
+}
+
 func wrapResourceBlock(tfType, label, providerAlias string, body []byte) []byte {
 	var b bytes.Buffer
 	fmt.Fprintf(&b, "resource %q %q {\n", tfType, label)

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -96,6 +96,68 @@ func TestEmitImportedTF_TypedGCP(t *testing.T) {
 //
 // Without this gate, Bundle 9's stated purpose — promoting 20 GCP
 // types from opaque-emit to typed-emit — has no end-to-end assertion.
+// TestEmitImportedTF_LambdaIgnoreChanges pins #652: an imported
+// aws_lambda_function carries a placeholder `filename` (its real code
+// lives in AWS, not on disk; the provider schema still demands one of
+// filename / image_uri / s3_bucket). The emitter must pin the code
+// attributes under lifecycle.ignore_changes — otherwise the first
+// `terraform apply` after import reads the nonexistent placeholder file
+// (apply fails) or re-uploads it over the live function's real code.
+func TestEmitImportedTF_LambdaIgnoreChanges(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.fn",
+			ImportID: "fn",
+		},
+		Tier: imported.TierImportedFlat,
+		Attributes: map[string]any{
+			"function_name": "fn",
+			"role":          "arn:aws:iam::123456789012:role/fn",
+			"filename":      "lambda_placeholder.zip",
+		},
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+	file, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.Falsef(t, diags.HasErrors(), "imported.tf must parse: %s\n%s", diags.Error(), s)
+
+	var lifecycle *hclsyntax.Body
+	for _, blk := range file.Body.(*hclsyntax.Body).Blocks {
+		if blk.Type != "resource" {
+			continue
+		}
+		for _, sub := range blk.Body.Blocks {
+			if sub.Type == "lifecycle" {
+				lifecycle = sub.Body
+			}
+		}
+	}
+	require.NotNilf(t, lifecycle, "imported aws_lambda_function must emit a lifecycle block:\n%s", s)
+	ic := lifecycle.Attributes["ignore_changes"]
+	require.NotNil(t, ic, "lifecycle must set ignore_changes")
+	tuple, ok := ic.Expr.(*hclsyntax.TupleConsExpr)
+	require.True(t, ok, "ignore_changes must be a list")
+	// Assert the exact attribute identities against a literal — not
+	// against imported.LambdaCodeAttrs, which the production emitter
+	// also reads (that would be tautological). Pinning the wrong six
+	// attributes re-introduces the #652 "apply overwrites real code"
+	// failure while keeping the count correct.
+	var got []string
+	for _, e := range tuple.Exprs {
+		trav, isTrav := e.(*hclsyntax.ScopeTraversalExpr)
+		require.Truef(t, isTrav, "ignore_changes entry must be an attribute reference, got %T", e)
+		got = append(got, trav.Traversal.RootName())
+	}
+	sort.Strings(got)
+	want := []string{"filename", "image_uri", "s3_bucket", "s3_key", "s3_object_version", "source_code_hash"}
+	sort.Strings(want)
+	assert.Equal(t, want, got, "ignore_changes must pin exactly the Lambda code-source attributes")
+}
+
 func TestEmitImportedTF_TypedRoutingForAllGCPTypes(t *testing.T) {
 	t.Parallel()
 	for _, tfType := range generated.RegisteredTypes() {

--- a/pkg/composer/imported_validate.go
+++ b/pkg/composer/imported_validate.go
@@ -216,6 +216,40 @@ func ValidateImportedEmitReadiness(cloud string, irs []imported.ImportedResource
 	return issues
 }
 
+// dropUncomposable returns irs with every resource flagged
+// imported_resource_missing_required_attr removed. emitReadiness is the
+// ValidationIssue slice from ValidateImportedEmitReadiness for the same
+// resource set.
+//
+// A resource missing required arguments cannot be rendered as a
+// plannable `resource {}` block — `terraform plan` rejects the partial
+// body with "Missing required argument" and aborts planning for the
+// entire stack (#652). Refusing the single un-composable resource keeps
+// the rest of the stack composable; the issue is already recorded so the
+// caller still sees which resource was dropped and why.
+//
+// The input slice is returned unchanged (no allocation) when nothing is
+// flagged — the common case.
+func dropUncomposable(irs []imported.ImportedResource, emitReadiness []ValidationIssue) []imported.ImportedResource {
+	refused := map[string]bool{}
+	for _, is := range emitReadiness {
+		if is.Code == "imported_resource_missing_required_attr" {
+			refused[strings.TrimPrefix(is.Field, "imported.")] = true
+		}
+	}
+	if len(refused) == 0 {
+		return irs
+	}
+	out := make([]imported.ImportedResource, 0, len(irs))
+	for _, ir := range irs {
+		if refused[ir.Identity.Address] {
+			continue
+		}
+		out = append(out, ir)
+	}
+	return out
+}
+
 // ProvenanceOpts carries the per-compose context needed by
 // ValidateProvenanceConflicts. ImportProjectID is the logical claim/owner ID
 // used cross-cloud (decision #46 in docs/managed-resource-tiers.md). The

--- a/pkg/composer/imported_validate_test.go
+++ b/pkg/composer/imported_validate_test.go
@@ -210,6 +210,41 @@ func TestValidateImportedResources_FieldFormat(t *testing.T) {
 	assert.Contains(t, fields, "imported.[1]")
 }
 
+// TestDropUncomposable pins the #652 "refuse uncomposable resources"
+// hardening: a resource flagged imported_resource_missing_required_attr
+// is dropped from the emit set so its partial resource block never
+// reaches terraform plan (where it would abort the whole stack with
+// "Missing required argument"), while every composable resource is kept.
+func TestDropUncomposable(t *testing.T) {
+	t.Parallel()
+	// aws_sqs_queue has no required arguments — composable with no Attrs.
+	good := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.ok", ImportID: "ok"},
+		Tier:     imported.TierImportedFlat,
+	}
+	// aws_lambda_function requires role + function_name — with no Attrs
+	// it is un-composable.
+	bad := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_lambda_function", Address: "aws_lambda_function.bad", ImportID: "bad"},
+		Tier:     imported.TierImportedFlat,
+	}
+	irs := []imported.ImportedResource{good, bad}
+
+	issues := ValidateImportedEmitReadiness("aws", irs)
+	require.NotEmpty(t, issues, "the attr-less lambda must be flagged un-composable")
+
+	kept := dropUncomposable(irs, issues)
+	keptAddr := map[string]bool{}
+	for _, ir := range kept {
+		keptAddr[ir.Identity.Address] = true
+	}
+	assert.True(t, keptAddr["aws_sqs_queue.ok"], "composable resource must be kept")
+	assert.False(t, keptAddr["aws_lambda_function.bad"], "un-composable resource must be refused")
+
+	// No flagged resources -> the input slice is returned unchanged.
+	assert.Len(t, dropUncomposable([]imported.ImportedResource{good}, nil), 1)
+}
+
 func TestValidateProvenanceConflicts_Empty(t *testing.T) {
 	t.Parallel()
 	assert.Nil(t, ValidateProvenanceConflicts("aws", nil, ProvenanceOpts{ImportProjectID: "io-1"}))

--- a/pkg/composer/testdata/imported_652_repro.json
+++ b/pkg/composer/testdata/imported_652_repro.json
@@ -1,0 +1,145 @@
+[
+  {
+    "tier": "ImportedFlat",
+    "attrs": {
+      "id": { "literal": "/aws/lambda/io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca" },
+      "name": { "literal": "/aws/lambda/io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca" },
+      "tags": {
+        "ID": { "literal": "lambdaa0ca" },
+        "Name": { "literal": "io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca" },
+        "Project": { "literal": "io-cnquj6nrjnlc" },
+        "Resource": { "literal": "lambda" },
+        "Component": { "literal": "insideout" },
+        "Environment": { "literal": "prod" },
+        "Organization": { "literal": "luthersystems" },
+        "Subcomponent": { "literal": "lambda" }
+      },
+      "log_group_class": { "literal": "STANDARD" },
+      "retention_in_days": { "literal": 14 }
+    },
+    "source": "importer",
+    "identity": {
+      "tags": {
+        "ID": "lambdaa0ca",
+        "Name": "io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca",
+        "Project": "io-cnquj6nrjnlc",
+        "Resource": "lambda",
+        "Component": "insideout",
+        "Environment": "prod",
+        "Organization": "luthersystems",
+        "Subcomponent": "lambda"
+      },
+      "type": "aws_cloudwatch_log_group",
+      "cloud": "aws",
+      "region": "us-east-1",
+      "address": "aws_cloudwatch_log_group.aws_lambda_io_cnquj6nrjnlc_prod_luthersystems_insideout_lambda_lambdaa0ca",
+      "import_id": "/aws/lambda/io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca",
+      "name_hint": "/aws/lambda/io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca",
+      "account_id": "031780745048",
+      "native_ids": {
+        "arn": "arn:aws:logs:us-east-1:031780745048:log-group:/aws/lambda/io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca:*",
+        "name": "/aws/lambda/io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca"
+      },
+      "provider_config": "aws.imported",
+      "provider_source": "registry.terraform.io/hashicorp/aws",
+      "provider_version": "5.40.0"
+    }
+  },
+  {
+    "tier": "ImportedFlat",
+    "attrs": {
+      "path": { "literal": "/" },
+      "description": { "literal": "Allows users to access the Account Usage Report page." }
+    },
+    "source": "importer",
+    "identity": {
+      "type": "aws_iam_policy",
+      "cloud": "aws",
+      "address": "aws_iam_policy.awsaccountusagereportaccess",
+      "import_id": "arn:aws:iam::aws:policy/AWSAccountUsageReportAccess",
+      "name_hint": "AWSAccountUsageReportAccess",
+      "account_id": "031780745048",
+      "native_ids": {
+        "arn": "arn:aws:iam::aws:policy/AWSAccountUsageReportAccess",
+        "name": "AWSAccountUsageReportAccess"
+      },
+      "provider_config": "aws.imported",
+      "provider_source": "registry.terraform.io/hashicorp/aws",
+      "provider_version": "5.40.0"
+    }
+  },
+  {
+    "tier": "ImportedFlat",
+    "source": "importer",
+    "identity": {
+      "tags": {
+        "ID": "lambdaa0ca",
+        "Name": "io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca",
+        "Project": "io-cnquj6nrjnlc",
+        "Resource": "lambda",
+        "Component": "insideout",
+        "Environment": "prod",
+        "Organization": "luthersystems",
+        "Subcomponent": "lambda"
+      },
+      "type": "aws_lambda_function",
+      "cloud": "aws",
+      "region": "us-east-1",
+      "address": "aws_lambda_function.io_cnquj6nrjnlc_prod_luthersystems_insideout_lambda_lambdaa0ca",
+      "import_id": "io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca",
+      "name_hint": "io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca",
+      "account_id": "031780745048",
+      "native_ids": {
+        "arn": "arn:aws:lambda:us-east-1:031780745048:function:io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca",
+        "name": "io-cnquj6nrjnlc-prod-luthersystems-insideout-lambda-lambdaa0ca"
+      },
+      "provider_config": "aws.imported",
+      "provider_source": "registry.terraform.io/hashicorp/aws",
+      "provider_version": "5.40.0"
+    }
+  },
+  {
+    "tier": "ImportedFlat",
+    "attrs": {
+      "tags": {
+        "ID": { "literal": "s30" },
+        "Name": { "literal": "io-cnquj6nrjnlc-prod-luthersystems-insideout-s3-s30" },
+        "Project": { "literal": "io-cnquj6nrjnlc" },
+        "Resource": { "literal": "s3" },
+        "Component": { "literal": "insideout" },
+        "Environment": { "literal": "prod" },
+        "Organization": { "literal": "luthersystems" },
+        "Subcomponent": { "literal": "s3" }
+      },
+      "bucket": { "literal": "io-cnquj6nrjnlc-93ce72" },
+      "region": { "literal": "us-east-1" }
+    },
+    "source": "importer",
+    "identity": {
+      "tags": {
+        "ID": "s30",
+        "Name": "io-cnquj6nrjnlc-prod-luthersystems-insideout-s3-s30",
+        "Project": "io-cnquj6nrjnlc",
+        "Resource": "s3",
+        "Component": "insideout",
+        "Environment": "prod",
+        "Organization": "luthersystems",
+        "Subcomponent": "s3"
+      },
+      "type": "aws_s3_bucket",
+      "cloud": "aws",
+      "region": "us-east-1",
+      "address": "aws_s3_bucket.io_cnquj6nrjnlc_93ce72",
+      "import_id": "io-cnquj6nrjnlc-93ce72",
+      "name_hint": "io-cnquj6nrjnlc-93ce72",
+      "account_id": "031780745048",
+      "native_ids": {
+        "arn": "arn:aws:s3:::io-cnquj6nrjnlc-93ce72",
+        "name": "io-cnquj6nrjnlc-93ce72"
+      },
+      "provider_config": "aws.imported",
+      "provider_source": "registry.terraform.io/hashicorp/aws",
+      "provider_version": "5.40.0"
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Fixes the malformed `imported.tf` that made `terraform plan`/`apply` fail on every imported stack (#652). The discover → compose → plan → apply flow now works end to end against live AWS.

Five fixes, one commit each:

- **Skip AWS-managed IAM policies during discovery** — Cloud Control surfaces `arn:aws:iam::aws:policy/*` policies that are not customer-owned; importing one is permanent drift. New `SkipIdentifier` hook drops them in `Discover` and `DiscoverByID`.
- **Evaluate `jsonencode()` when capturing generated attrs** — `terraform plan -generate-config-out` renders every JSON-string attribute (`aws_iam_policy.policy`, `aws_iam_role.assume_role_policy`, …) as a `jsonencode({...})` call. genconfig captured the literal source text, so the composer emitted `policy = "jsonencode({...})"` — an invalid policy string. genconfig now evaluates the expression to real JSON.
- **Refuse to emit un-composable imported resources** — a resource missing required arguments was emitted as a partial `resource {}` block, and `terraform plan` aborted the *whole* stack with "Missing required argument". ComposeStack now drops such resources (still reporting the issue) so the rest of the stack plans.
- **Pin Lambda code attrs under `lifecycle.ignore_changes`** — an imported `aws_lambda_function` carries a placeholder `filename`; without the ignore-changes pin (which the composer was dropping) `terraform apply` read the nonexistent placeholder zip — or would overwrite the live function's real code.
- **Drop computed `id`** — already on `main` (`bddcc83`); pinned here against the real #652 manifest.

## How it was found / verified

A new live-AWS round-trip harness (`TestLiveRoundTrip`, `//go:build integration`) runs the full flow against a real account — apply fixture → discover → emit `imported.tf` → `terraform plan` → `terraform apply` (real import) → destroy. It surfaced the jsonencode and Lambda-lifecycle bugs above. Verified green end to end:

```
Apply complete! Resources: 4 imported, 0 added, 4 changed, 0 destroyed.
round-trip OK: 4 resource(s) discovered, composed, and imported into Terraform state
--- PASS: TestLiveRoundTrip
```

## Test plan

- [x] `go test ./cmd/insideout-import/... ./pkg/composer/...` — green
- [x] `make test-roundtrip` — live discover→emit→plan→apply→destroy, green on a real account
- [x] Composer-side reproduction (`TestImported652Repro_ComposeRefusesUncomposable`) and genconfig reproduction (`TestExtractAttributes_JSONEncode*`) both verified to fail against pre-fix code
- [x] CI

## Review notes

- `/review`: no P0/P1.
- qa-professor: addressed all findings — added a genuine composer-side reproduction through the public `ComposeStackWithIssues` path (fails against `main`); replaced a tautological `assert.Len` with an exact attribute-identity check against a hard-coded literal; de-magic'd manifest-derived field keys; added a drift guard for the shared `LambdaCodeAttrs` list; relabelled the managed-policy contrast test.
- The round-trip harness is opt-in (integration tag + `RUN_LIVE_ROUNDTRIP` + credential probe), mirroring the existing `TestLive255` pre-release probes — it does not run in normal CI.

## Related

- #654 — broken/empty enrichers (the upstream half; separate work). The "refuse un-composable" fix here is the composer-side backstop for it.

Closes #652