### PR TITLE
perf(discover): parallelize EnrichAttributes + expose plannability signal

### DIFF
--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"sort"
 	"time"
 
@@ -33,9 +34,61 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/servicediscovery"
 	"github.com/aws/aws-sdk-go-v2/service/wafv2"
+	smithy "github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// defaultEnrichConcurrency bounds the per-resource cloud-API fan-out of
+// EnrichAttributes. Each enricher issues one or more AWS SDK round-trips
+// per resource; running them under a bounded worker pool turns the
+// previously serial ~1m30s pass on large accounts (~224 resources) into
+// a parallel one without unbounded fan-out hammering the AWS API rate
+// limits.
+//
+// Pinned to 4 to mirror awsdiscover.defaultDiscoverTypesConcurrency,
+// which was lowered from 8 to 4 in #632 after 8 simultaneous t=0
+// kickoffs tripped CloudControl's per-account rate budget with a
+// ThrottlingException. The enrich phase issues the same flavor of
+// per-account AWS calls, so it inherits the same ceiling. 4 still
+// delivers roughly a 4x wall-time saving over the old serial pass —
+// the marginal speedup from 8 isn't worth re-introducing the throttle
+// risk.
+const defaultEnrichConcurrency = 4
+
+// defaultEnrichStartupJitterMax bounds the random sleep applied before
+// the first defaultEnrichConcurrency enrich goroutines issue their
+// first AWS call. Mirrors awsdiscover.defaultDiscoverStartupJitterMax
+// (same value, same rationale): without jitter the first batch of
+// goroutines all kick off at t=0 and their opening Describe*/Get* calls
+// land in the same burst, lighting up the per-account rate limiter.
+// 500ms gives the SDK retryer's adaptive token bucket room to spread
+// the load without materially extending wall time. Only the initial
+// batch is jittered — goroutines beyond the first defaultEnrichConcurrency
+// are already naturally staggered by errgroup slot availability.
+const defaultEnrichStartupJitterMax = 500 * time.Millisecond
+
+// enrichRetryMaxAttempts caps how many times enrichWithRetry calls the
+// wrapped enricher when it keeps returning a throttle error. Mirrors
+// discoverRetryMaxAttempts (cmd/insideout-import/discover.go).
+const enrichRetryMaxAttempts = 8
+
+// enrichRetryBaseDelay and enrichRetryMaxDelay bound the exponential
+// backoff enrichWithRetry sleeps between throttled attempts: the delay
+// starts at enrichRetryBaseDelay and doubles each attempt, capped at
+// enrichRetryMaxDelay.
+//
+// These are declared as package-level vars (not consts) purely so the
+// test suite can shrink them via a defer-restore to keep retry tests
+// fast; production code never reassigns them. The retry path almost
+// never fires in production (see enrichWithRetry's doc comment), so the
+// observable behavior of the var-vs-const choice is test-only.
+var (
+	enrichRetryBaseDelay = 200 * time.Millisecond
+	enrichRetryMaxDelay  = 8 * time.Second
 )
 
 // enrichServiceSlug is the progress-event service slug for the SDK
@@ -209,10 +262,108 @@ type EnrichClients struct {
 // error. Mirrors gcpdiscover.ErrEnrichClientUnavailable.
 var ErrEnrichClientUnavailable = errors.New("enrich: required SDK client unavailable on EnrichClients")
 
+// isThrottleError reports whether err is an AWS rate-limit / throttling
+// signal. It unwraps to a smithy.APIError (the same pattern isAPIErrorCode
+// uses — see sdkonly_helpers.go) and matches the documented throttle
+// ErrorCode() values across services, and additionally treats an HTTP
+// 429 (Too Many Requests) or 503 (Slow Down / Service Unavailable) as a
+// throttle via *smithyhttp.ResponseError.
+//
+// nil err returns false; a non-AWS error returns false.
+func isThrottleError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "ThrottlingException",
+			"Throttling",
+			"ThrottledException",
+			"RequestThrottled",
+			"RequestThrottledException",
+			"RequestLimitExceeded",
+			"TooManyRequestsException",
+			"ProvisionedThroughputExceededException",
+			"TransactionInProgressException",
+			"SlowDown",
+			"EC2ThrottledException":
+			return true
+		}
+	}
+	var httpErr *smithyhttp.ResponseError
+	if errors.As(err, &httpErr) {
+		switch httpErr.HTTPStatusCode() {
+		case 429, 503:
+			return true
+		}
+	}
+	return false
+}
+
+// enrichWithRetry calls fn and, if it returns a throttle error (per
+// isThrottleError), retries it under an exponential backoff with jitter
+// — up to enrichRetryMaxAttempts total attempts. A nil result, a
+// non-throttle error, or exhausting the attempt budget returns
+// immediately. The backoff sleep is select-cancellable on ctx.Done();
+// on cancel the last error is returned.
+//
+// This is a BACKSTOP layered ON TOP of the AWS SDK adaptive retryer
+// (aws.RetryModeAdaptive, discoverRetryMaxAttempts — configured on the
+// aws.Config in cmd/insideout-import/discover.go). When the caller built
+// the EnrichClients SDK clients from a Config carrying that retryer, a
+// throttle is usually absorbed below this layer and this loop rarely
+// fires. It exists because EnrichClients are caller-supplied: a caller
+// may construct clients without the adaptive retryer, in which case this
+// loop is the only throttle protection. (The GCP sibling has no
+// client-level adaptive retryer at all, so there this loop is the
+// primary defense.)
+//
+// Re-running a soft-failed Enrich is safe: per-type enrichers marshal
+// ir.Attrs atomically, so a retried call simply overwrites the prior
+// (failed) attempt's partial state.
+func enrichWithRetry(ctx context.Context, fn func() error) error {
+	var err error
+	backoff := enrichRetryBaseDelay
+	for attempt := 1; ; attempt++ {
+		err = fn()
+		if err == nil || !isThrottleError(err) || attempt >= enrichRetryMaxAttempts {
+			return err
+		}
+		// Half-fixed + half-random of the current backoff window so
+		// retrying goroutines don't re-synchronize into a fresh burst.
+		sleep := backoff/2 + time.Duration(rand.Int63n(int64(backoff/2)+1))
+		t := time.NewTimer(sleep)
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			return err
+		case <-t.C:
+		}
+		if backoff < enrichRetryMaxDelay {
+			backoff *= 2
+			if backoff > enrichRetryMaxDelay {
+				backoff = enrichRetryMaxDelay
+			}
+		}
+	}
+}
+
 // EnrichAttributes populates ir.Attrs in place for every imported
 // resource whose Identity.Type has a registered enricher. Resources of
 // types without a registered enricher are left untouched; the caller
 // can detect this via len(ir.Attrs) == 0 on return.
+//
+// The per-resource enrichers run concurrently under a bounded
+// errgroup (defaultEnrichConcurrency workers) so a large account's
+// cloud-API round-trips overlap instead of running strictly serially.
+// Each goroutine writes a distinct irs[i] element, so the fan-out is
+// data-race-free; the group is used purely as a bounded worker pool and
+// never fails early. Progress emission and error aggregation happen in a
+// SECOND serial pass after the workers finish, walking idx in sorted
+// order — so emit order and error-join order remain exactly as
+// deterministic as the old serial implementation, regardless of which
+// worker completes first.
 //
 // Errors are accumulated per-resource and surfaced together at the end
 // so a single mid-batch failure doesn't lose results from earlier
@@ -258,10 +409,53 @@ func (a *AWSDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.Imp
 		return irs[ix].Identity.Address < irs[iy].Identity.Address
 	})
 
-	var errs []error
-	for _, i := range idx {
+	// Fan the per-resource enrichers out across a bounded worker pool.
+	// results[pos] holds the error (or nil) for idx[pos]; each worker
+	// writes exactly one distinct results slot and one distinct irs
+	// element, so no synchronization beyond errgroup is needed. The
+	// closure always returns nil — the group is a bounded pool, never
+	// an early-cancel mechanism — because the documented contract is
+	// "a partial result is more useful than no result": every resource
+	// must be attempted regardless of sibling failures. ctx is the
+	// caller's context (not a derived errgroup context) since we never
+	// cancel early.
+	results := make([]error, len(idx))
+	var g errgroup.Group
+	g.SetLimit(defaultEnrichConcurrency)
+	for pos, i := range idx {
 		enr := a.byTypeEnricher[irs[i].Identity.Type]
-		err := enr.Enrich(ctx, &irs[i], clients)
+		g.Go(func() error {
+			// Jitter only the initial burst: the first
+			// defaultEnrichConcurrency goroutines start simultaneously
+			// at t=0, so their opening AWS calls would otherwise land
+			// together. Goroutines beyond that batch are already
+			// staggered by errgroup slot availability — jittering all
+			// of them would add tens of seconds of dead wall time.
+			if pos < defaultEnrichConcurrency {
+				sleep := time.Duration(rand.Int63n(int64(defaultEnrichStartupJitterMax)))
+				t := time.NewTimer(sleep)
+				select {
+				case <-ctx.Done():
+					t.Stop()
+				case <-t.C:
+				}
+			}
+			results[pos] = enrichWithRetry(ctx, func() error {
+				return enr.Enrich(ctx, &irs[i], clients)
+			})
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	// Second pass: walk idx in sorted order to inspect results,
+	// emit progress events, and aggregate errors. Doing this serially
+	// — and outside the goroutines — keeps emit order and error-join
+	// order deterministic (progress.Emitter is not documented as
+	// concurrency-safe) and identical to the old serial behaviour.
+	var errs []error
+	for pos, i := range idx {
+		err := results[pos]
 		switch {
 		case err == nil:
 			emitter.ItemFound(enrichServiceSlug, irs[i].Identity.Region, irs[i].Identity.Type, irs[i].Identity.ImportID)

--- a/cmd/insideout-import/awsdiscover/enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/enrich_test.go
@@ -4,29 +4,59 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithy "github.com/aws/smithy-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
+// shrinkEnrichRetryDelays lowers the package-level retry backoff bounds
+// to sub-millisecond values for the duration of a test and restores
+// them on cleanup, so retry tests don't pay the production 200ms base /
+// 8s ceiling. enrichRetryBaseDelay/enrichRetryMaxDelay are vars (not
+// consts) precisely to allow this — see their doc comment in enrich.go.
+func shrinkEnrichRetryDelays(t *testing.T) {
+	t.Helper()
+	origBase, origMax := enrichRetryBaseDelay, enrichRetryMaxDelay
+	enrichRetryBaseDelay = 100 * time.Microsecond
+	enrichRetryMaxDelay = 1 * time.Millisecond
+	t.Cleanup(func() {
+		enrichRetryBaseDelay, enrichRetryMaxDelay = origBase, origMax
+	})
+}
+
 // fakeEnricher is a minimal AttributeEnricher that records its calls and
 // returns a configurable result. Used to exercise EnrichAttributes
 // dispatch / ordering / error-accumulation semantics without standing
 // up real SDK clients. Mirrors gcpdiscover.fakeEnricher.
+//
+// Since EnrichAttributes now fans the per-resource Enrich calls out
+// across a bounded worker pool (#655), the calls slice is mutex-guarded
+// so the recording is data-race-free under -race. The recorded order
+// reflects goroutine completion order, NOT dispatch order — tests that
+// need deterministic dispatch order assert on emitted progress events
+// (which EnrichAttributes emits from its serial post-Wait pass).
 type fakeEnricher struct {
 	tfType string
-	calls  []string                               // bucket-of-Identity.ImportID per call
+	mu     sync.Mutex
+	calls  []string                               // Identity.ImportID per call, completion order
 	result func(*imported.ImportedResource) error // per-call result
 }
 
 func (f *fakeEnricher) ResourceType() string { return f.tfType }
 func (f *fakeEnricher) Enrich(_ context.Context, ir *imported.ImportedResource, _ EnrichClients) error {
+	f.mu.Lock()
 	f.calls = append(f.calls, ir.Identity.ImportID)
+	f.mu.Unlock()
 	if f.result == nil {
 		ir.Attrs = json.RawMessage(`{}`)
 		return nil
@@ -59,14 +89,204 @@ func TestEnrichAttributes_DeterministicOrder(t *testing.T) {
 
 	// Intentionally out-of-order Addresses; aggregator must sort
 	// (type, address) so progress events are stable across runs.
+	// Since enrichers now run concurrently (#655), call-completion
+	// order is non-deterministic — the deterministic-order contract is
+	// proven instead by the post-Wait serial emit pass: ItemFound
+	// events must arrive in sorted (type, address) order.
+	rec := &recordingEmitter{}
 	irs := []imported.ImportedResource{
 		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "z", Address: "aws_dynamodb_table.z"}},
 		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "a", Address: "aws_dynamodb_table.a"}},
 		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "m", Address: "aws_dynamodb_table.m"}},
 	}
-	require.NoError(t, a.EnrichAttributes(context.Background(), irs, EnrichClients{DynamoDB: &dynamodb.Client{}}, nil))
-	assert.Equal(t, []string{"a", "m", "z"}, enr.calls,
-		"enrich must dispatch in sorted (type, address) order regardless of input order")
+	require.NoError(t, a.EnrichAttributes(context.Background(), irs, EnrichClients{DynamoDB: &dynamodb.Client{}}, rec))
+	items := filterEvents(rec.snapshot(), "item_found")
+	got := make([]string, len(items))
+	for i, e := range items {
+		got[i] = e.ImportID
+	}
+	assert.Equal(t, []string{"a", "m", "z"}, got,
+		"enrich must emit ItemFound in sorted (type, address) order regardless of input order")
+}
+
+// TestEnrichAttributes_RunsConcurrently proves the per-resource
+// enrichers run in parallel AND that the fan-out is bounded by the
+// worker pool (#655). It dispatches more resources than
+// defaultEnrichConcurrency: a barrier enricher blocks until exactly
+// defaultEnrichConcurrency goroutines are simultaneously in-flight
+// (the pool cap), then releases everyone. It asserts BOTH bounds —
+// maxInFlight >= 2 (concurrency happens) and maxInFlight <=
+// defaultEnrichConcurrency (the pool is bounded). A regression that
+// dropped g.SetLimit (unbounded fan-out) would push maxInFlight to n
+// and fail the upper bound.
+func TestEnrichAttributes_RunsConcurrently(t *testing.T) {
+	t.Parallel()
+
+	// More resources than the pool cap: the extra ones can only be
+	// enriched after the first batch is released.
+	const n = defaultEnrichConcurrency + 3
+	var inFlight atomic.Int64
+	var maxInFlight atomic.Int64
+	barrier := make(chan struct{})
+	allArrived := make(chan struct{})
+	var arrivedOnce sync.Once
+
+	enr := &fakeEnricher{
+		tfType: "aws_dynamodb_table",
+		result: func(ir *imported.ImportedResource) error {
+			cur := inFlight.Add(1)
+			for {
+				m := maxInFlight.Load()
+				if cur <= m || maxInFlight.CompareAndSwap(m, cur) {
+					break
+				}
+			}
+			// The barrier releases once exactly defaultEnrichConcurrency
+			// goroutines (the pool cap) are simultaneously in-flight. A
+			// bounded pool can never exceed that, so this fires exactly
+			// when the pool is saturated.
+			if cur == int64(defaultEnrichConcurrency) {
+				arrivedOnce.Do(func() { close(allArrived) })
+			}
+			<-barrier // block until the test releases everyone
+			inFlight.Add(-1)
+			ir.Attrs = json.RawMessage(`{}`)
+			return nil
+		},
+	}
+	a := &AWSDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"aws_dynamodb_table": enr}}
+
+	irs := make([]imported.ImportedResource, n)
+	for i := range irs {
+		irs[i] = imported.ImportedResource{Identity: imported.ResourceIdentity{
+			Type: "aws_dynamodb_table", ImportID: string(rune('a' + i)),
+			Address: "aws_dynamodb_table." + string(rune('a'+i)),
+		}}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.EnrichAttributes(context.Background(), irs, EnrichClients{DynamoDB: &dynamodb.Client{}}, nil)
+	}()
+
+	// If the pool regressed to serial, only one goroutine would ever be
+	// in-flight and allArrived would never close — guard the receive so
+	// the test fails fast instead of hanging until the package timeout.
+	select {
+	case <-allArrived:
+	case <-time.After(5 * time.Second):
+		t.Fatal("enrichers never reached expected concurrency — worker pool likely serial")
+	}
+	close(barrier)
+	require.NoError(t, <-done)
+
+	got := maxInFlight.Load()
+	assert.GreaterOrEqual(t, got, int64(2),
+		"enrichers must run concurrently, observed max in-flight %d", got)
+	assert.LessOrEqual(t, got, int64(defaultEnrichConcurrency),
+		"fan-out must be bounded by the worker pool, observed max in-flight %d", got)
+
+	// Every resource — including the ones beyond the pool cap — must
+	// still get enriched.
+	for i := range irs {
+		assert.NotEmpty(t, irs[i].Attrs,
+			"irs[%d] (ImportID=%q) must be enriched even though it dispatched after the pool cap", i, irs[i].Identity.ImportID)
+	}
+}
+
+// TestEnrichAttributes_OutOfOrderCompletionStillDeterministic proves
+// that even when enrichers finish in an order unrelated to the sorted
+// dispatch order, EnrichAttributes still emits ItemFound and aggregates
+// errors in sorted (type, address) order — because emit/aggregate runs
+// in the serial post-Wait pass (#655).
+func TestEnrichAttributes_OutOfOrderCompletionStillDeterministic(t *testing.T) {
+	t.Parallel()
+
+	// "a" finishes last, "z" finishes first — gated by per-ImportID
+	// release channels so completion order is the reverse of sorted
+	// order.
+	release := map[string]chan struct{}{
+		"a": make(chan struct{}),
+		"m": make(chan struct{}),
+		"z": make(chan struct{}),
+	}
+	enr := &fakeEnricher{
+		tfType: "aws_dynamodb_table",
+		result: func(ir *imported.ImportedResource) error {
+			<-release[ir.Identity.ImportID]
+			ir.Attrs = json.RawMessage(`{}`)
+			return nil
+		},
+	}
+	a := &AWSDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"aws_dynamodb_table": enr}}
+
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "z", Address: "aws_dynamodb_table.z"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "a", Address: "aws_dynamodb_table.a"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "m", Address: "aws_dynamodb_table.m"}},
+	}
+
+	rec := &recordingEmitter{}
+	done := make(chan error, 1)
+	go func() {
+		done <- a.EnrichAttributes(context.Background(), irs, EnrichClients{DynamoDB: &dynamodb.Client{}}, rec)
+	}()
+
+	// Release in reverse-sorted order.
+	close(release["z"])
+	close(release["m"])
+	close(release["a"])
+	require.NoError(t, <-done)
+
+	items := filterEvents(rec.snapshot(), "item_found")
+	got := make([]string, len(items))
+	for i, e := range items {
+		got[i] = e.ImportID
+	}
+	assert.Equal(t, []string{"a", "m", "z"}, got,
+		"ItemFound order must follow sorted idx, not completion order")
+}
+
+// TestEnrichAttributes_ErrorAggregationOrder proves the joined error's
+// per-resource order follows sorted idx, not goroutine completion order
+// (#655). Each enricher fails after a release gate; gates fire in
+// reverse-sorted order, yet the joined error must list a before b.
+func TestEnrichAttributes_ErrorAggregationOrder(t *testing.T) {
+	t.Parallel()
+
+	release := map[string]chan struct{}{
+		"a": make(chan struct{}),
+		"b": make(chan struct{}),
+	}
+	enr := &fakeEnricher{
+		tfType: "aws_dynamodb_table",
+		result: func(ir *imported.ImportedResource) error {
+			<-release[ir.Identity.ImportID]
+			return errors.New("403: " + ir.Identity.ImportID)
+		},
+	}
+	a := &AWSDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"aws_dynamodb_table": enr}}
+
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "a", Address: "aws_dynamodb_table.a"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "b", Address: "aws_dynamodb_table.b"}},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.EnrichAttributes(context.Background(), irs, EnrichClients{DynamoDB: &dynamodb.Client{}}, nil)
+	}()
+	// b completes before a — joined error must still list a first.
+	close(release["b"])
+	close(release["a"])
+	err := <-done
+	require.Error(t, err)
+	idxA := strings.Index(err.Error(), "aws_dynamodb_table.a")
+	idxB := strings.Index(err.Error(), "aws_dynamodb_table.b")
+	require.GreaterOrEqual(t, idxA, 0)
+	require.GreaterOrEqual(t, idxB, 0)
+	assert.Less(t, idxA, idxB,
+		"joined error must list resources in sorted idx order regardless of completion order")
 }
 
 func TestEnrichAttributes_AccumulatesErrors(t *testing.T) {
@@ -159,6 +379,107 @@ func TestEnrichAttributes_S3ClientUnused(t *testing.T) {
 	}
 	require.NoError(t, a.EnrichAttributes(context.Background(), irs, clients, nil))
 	require.NotEmpty(t, irs[0].Attrs)
+}
+
+// throttleErr returns a real AWS throttle-shaped error: a
+// smithy.GenericAPIError carrying the ThrottlingException code that
+// isThrottleError classifies as a throttle.
+func throttleErr() error {
+	return &smithy.GenericAPIError{Code: "ThrottlingException", Message: "rate exceeded"}
+}
+
+// TestEnrichWithRetry_RetriesThrottleThenSucceeds proves enrichWithRetry
+// retries a throttle error and the resource ends up enriched with no
+// error surfaced. The enricher returns a throttle for the first K calls
+// then nil.
+func TestEnrichWithRetry_RetriesThrottleThenSucceeds(t *testing.T) {
+	shrinkEnrichRetryDelays(t)
+
+	const failFirst = 3
+	// Distinctive payload written only on the successful (final) attempt
+	// so the assertion pins that the retried call's result actually
+	// landed — a constant `{}` would pass even if a stale write leaked.
+	const successAttrs = `{"retried":true,"table":"t1"}`
+	var calls atomic.Int64
+	enr := &fakeEnricher{
+		tfType: "aws_dynamodb_table",
+		result: func(ir *imported.ImportedResource) error {
+			if calls.Add(1) <= failFirst {
+				return throttleErr()
+			}
+			ir.Attrs = json.RawMessage(successAttrs)
+			return nil
+		},
+	}
+	a := &AWSDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"aws_dynamodb_table": enr}}
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "t1", Address: "aws_dynamodb_table.t1"}},
+	}
+	require.NoError(t, a.EnrichAttributes(context.Background(), irs, EnrichClients{DynamoDB: &dynamodb.Client{}}, nil),
+		"a throttle that eventually clears must not surface as an error")
+	assert.JSONEq(t, successAttrs, string(irs[0].Attrs),
+		"resource must end up enriched with the retried call's exact payload")
+	assert.Equal(t, int64(failFirst+1), calls.Load(),
+		"enricher must be retried exactly failFirst times then succeed")
+}
+
+// TestEnrichWithRetry_NonThrottleNotRetried proves a non-throttle error
+// is surfaced immediately without retry — the enricher is called once.
+func TestEnrichWithRetry_NonThrottleNotRetried(t *testing.T) {
+	shrinkEnrichRetryDelays(t)
+
+	var calls atomic.Int64
+	enr := &fakeEnricher{
+		tfType: "aws_dynamodb_table",
+		result: func(ir *imported.ImportedResource) error {
+			calls.Add(1)
+			return errors.New("403: access denied")
+		},
+	}
+	a := &AWSDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"aws_dynamodb_table": enr}}
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "t1", Address: "aws_dynamodb_table.t1"}},
+	}
+	err := a.EnrichAttributes(context.Background(), irs, EnrichClients{DynamoDB: &dynamodb.Client{}}, nil)
+	require.Error(t, err, "a non-throttle error must surface as a per-resource error")
+	assert.Equal(t, int64(1), calls.Load(), "a non-throttle error must not be retried")
+}
+
+// TestEnrichWithRetry_GivesUpAfterMaxAttempts proves the retry loop
+// gives up after enrichRetryMaxAttempts and surfaces the throttle error.
+func TestEnrichWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
+	shrinkEnrichRetryDelays(t)
+
+	var calls atomic.Int64
+	enr := &fakeEnricher{
+		tfType: "aws_dynamodb_table",
+		result: func(ir *imported.ImportedResource) error {
+			calls.Add(1)
+			return throttleErr()
+		},
+	}
+	a := &AWSDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"aws_dynamodb_table": enr}}
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "t1", Address: "aws_dynamodb_table.t1"}},
+	}
+	err := a.EnrichAttributes(context.Background(), irs, EnrichClients{DynamoDB: &dynamodb.Client{}}, nil)
+	require.Error(t, err, "an unrelenting throttle must eventually surface as an error")
+	assert.Contains(t, err.Error(), "ThrottlingException")
+	assert.Equal(t, int64(enrichRetryMaxAttempts), calls.Load(),
+		"retry loop must attempt exactly enrichRetryMaxAttempts times before giving up")
+}
+
+// TestIsThrottleError covers the AWS throttle classifier across the
+// smithy.APIError code set and the HTTP-status path.
+func TestIsThrottleError(t *testing.T) {
+	t.Parallel()
+	assert.False(t, isThrottleError(nil), "nil err must not be a throttle")
+	assert.False(t, isThrottleError(errors.New("plain")), "non-AWS error must not be a throttle")
+	assert.True(t, isThrottleError(&smithy.GenericAPIError{Code: "ThrottlingException"}))
+	assert.True(t, isThrottleError(&smithy.GenericAPIError{Code: "SlowDown"}))
+	assert.True(t, isThrottleError(&smithy.GenericAPIError{Code: "RequestLimitExceeded"}))
+	assert.False(t, isThrottleError(&smithy.GenericAPIError{Code: "AccessDenied"}),
+		"a non-throttle API error code must not classify as a throttle")
 }
 
 // filterEvents returns the subset of recorded events whose Kind matches

--- a/cmd/insideout-import/gcpdiscover/api_errors.go
+++ b/cmd/insideout-import/gcpdiscover/api_errors.go
@@ -31,3 +31,32 @@ func isGoogleAPINotFound(err error) bool {
 	}
 	return false
 }
+
+// isGoogleAPIRateLimited reports whether err is a *googleapi.Error that
+// signals a rate-limit / quota-exhaustion condition. It matches an HTTP
+// 429 (Too Many Requests) or 503 (Service Unavailable) status, and also
+// scans the structured per-error Reason fields for the documented
+// rate-limit reasons (`rateLimitExceeded`, `userRateLimitExceeded`,
+// `quotaExceeded`) — Google APIs sometimes return the throttle reason in
+// the error detail with a non-429 top-level Code.
+//
+// Used by gcpdiscover.enrichWithRetry as the throttle classifier for the
+// enrich-phase backoff loop — the GCP-side parallel to awsdiscover's
+// isThrottleError. nil err returns false; a non-Google error returns
+// false.
+func isGoogleAPIRateLimited(err error) bool {
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		return false
+	}
+	if gerr.Code == http.StatusTooManyRequests || gerr.Code == http.StatusServiceUnavailable {
+		return true
+	}
+	for _, e := range gerr.Errors {
+		switch e.Reason {
+		case "rateLimitExceeded", "userRateLimitExceeded", "quotaExceeded":
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"sort"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/cloudkms/v1"
 	computev1 "google.golang.org/api/compute/v1"
 	iamv1 "google.golang.org/api/iam/v1"
@@ -24,6 +26,53 @@ import (
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// defaultEnrichConcurrency bounds the per-resource cloud-API fan-out of
+// EnrichAttributes. Each enricher issues one or more GCP SDK round-trips
+// per resource; running them under a bounded worker pool turns the
+// previously serial ~1m30s pass on large accounts (~224 resources) into
+// a parallel one without unbounded fan-out hammering the GCP API rate
+// limits.
+//
+// Pinned to 4 to mirror awsdiscover.defaultDiscoverTypesConcurrency,
+// which was lowered from 8 to 4 in #632 after 8 simultaneous t=0
+// kickoffs tripped CloudControl's per-account rate budget with a
+// ThrottlingException. GCP's per-project quotas are likewise burst-
+// sensitive, so the enrich phase inherits the same ceiling. 4 still
+// delivers roughly a 4x wall-time saving over the old serial pass —
+// the marginal speedup from 8 isn't worth re-introducing the throttle
+// risk.
+const defaultEnrichConcurrency = 4
+
+// defaultEnrichStartupJitterMax bounds the random sleep applied before
+// the first defaultEnrichConcurrency enrich goroutines issue their
+// first GCP call. Mirrors awsdiscover.defaultDiscoverStartupJitterMax
+// (same value, same rationale): without jitter the first batch of
+// goroutines all kick off at t=0 and their opening Get/List calls land
+// in the same burst, lighting up the per-project rate limiter. 500ms
+// spreads the load without materially extending wall time. Only the
+// initial batch is jittered — goroutines beyond the first
+// defaultEnrichConcurrency are already naturally staggered by errgroup
+// slot availability.
+const defaultEnrichStartupJitterMax = 500 * time.Millisecond
+
+// enrichRetryMaxAttempts caps how many times enrichWithRetry calls the
+// wrapped enricher when it keeps returning a rate-limit error. Mirrors
+// awsdiscover.enrichRetryMaxAttempts / discoverRetryMaxAttempts.
+const enrichRetryMaxAttempts = 8
+
+// enrichRetryBaseDelay and enrichRetryMaxDelay bound the exponential
+// backoff enrichWithRetry sleeps between throttled attempts: the delay
+// starts at enrichRetryBaseDelay and doubles each attempt, capped at
+// enrichRetryMaxDelay.
+//
+// These are declared as package-level vars (not consts) purely so the
+// test suite can shrink them via a defer-restore to keep retry tests
+// fast; production code never reassigns them.
+var (
+	enrichRetryBaseDelay = 200 * time.Millisecond
+	enrichRetryMaxDelay  = 8 * time.Second
 )
 
 // enrichServiceSlug is the progress-event service slug for the SDK
@@ -210,10 +259,64 @@ type EnrichClients struct {
 // path in DiscoverTypes (gcpdiscover.go:430).
 var ErrEnrichClientUnavailable = errors.New("enrich: required SDK client unavailable on EnrichClients")
 
+// enrichWithRetry calls fn and, if it returns a rate-limit error (per
+// isGoogleAPIRateLimited), retries it under an exponential backoff with
+// jitter — up to enrichRetryMaxAttempts total attempts. A nil result, a
+// non-throttle error, or exhausting the attempt budget returns
+// immediately. The backoff sleep is select-cancellable on ctx.Done();
+// on cancel the last error is returned.
+//
+// This is a BACKSTOP retry loop. The AWS sibling layers this ON TOP of
+// the AWS SDK adaptive retryer; GCP has no equivalent client-level
+// adaptive retryer, so on the GCP side this loop is the PRIMARY throttle
+// defense — every rate-limit hit during enrichment is absorbed here
+// rather than surfacing as a per-resource error.
+//
+// Re-running a soft-failed Enrich is safe: per-type enrichers marshal
+// ir.Attrs atomically, so a retried call simply overwrites the prior
+// (failed) attempt's partial state.
+func enrichWithRetry(ctx context.Context, fn func() error) error {
+	var err error
+	backoff := enrichRetryBaseDelay
+	for attempt := 1; ; attempt++ {
+		err = fn()
+		if err == nil || !isGoogleAPIRateLimited(err) || attempt >= enrichRetryMaxAttempts {
+			return err
+		}
+		// Half-fixed + half-random of the current backoff window so
+		// retrying goroutines don't re-synchronize into a fresh burst.
+		sleep := backoff/2 + time.Duration(rand.Int63n(int64(backoff/2)+1))
+		t := time.NewTimer(sleep)
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			return err
+		case <-t.C:
+		}
+		if backoff < enrichRetryMaxDelay {
+			backoff *= 2
+			if backoff > enrichRetryMaxDelay {
+				backoff = enrichRetryMaxDelay
+			}
+		}
+	}
+}
+
 // EnrichAttributes populates ir.Attrs in place for every imported
 // resource whose Identity.Type has a registered enricher. Resources
 // of types without a registered enricher are left untouched; the
 // caller can detect this via len(ir.Attrs) == 0 on return.
+//
+// The per-resource enrichers run concurrently under a bounded
+// errgroup (defaultEnrichConcurrency workers) so a large account's
+// cloud-API round-trips overlap instead of running strictly serially.
+// Each goroutine writes a distinct irs[i] element, so the fan-out is
+// data-race-free; the group is used purely as a bounded worker pool and
+// never fails early. Progress emission, EnrichmentStatus/EnrichErrors
+// stamping, and error aggregation happen in a SECOND serial pass after
+// the workers finish, walking idx in sorted order — so emit order and
+// error-join order remain exactly as deterministic as the old serial
+// implementation, regardless of which worker completes first.
 //
 // Errors are accumulated per-resource and surfaced together at the
 // end so a single mid-batch failure doesn't lose results from earlier
@@ -252,10 +355,54 @@ func (g *GCPDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.Imp
 		return irs[ia].Identity.Address < irs[ib].Identity.Address
 	})
 
-	var errs []error
-	for _, i := range idx {
+	// Fan the per-resource enrichers out across a bounded worker pool.
+	// results[pos] holds the error (or nil) for idx[pos]; each worker
+	// writes exactly one distinct results slot and one distinct irs
+	// element, so no synchronization beyond errgroup is needed. The
+	// closure always returns nil — the group is a bounded pool, never
+	// an early-cancel mechanism — because the documented contract is
+	// "a partial result is more useful than no result": every resource
+	// must be attempted regardless of sibling failures. ctx is the
+	// caller's context (not a derived errgroup context) since we never
+	// cancel early.
+	results := make([]error, len(idx))
+	var grp errgroup.Group
+	grp.SetLimit(defaultEnrichConcurrency)
+	for pos, i := range idx {
 		enr := g.byTypeEnricher[irs[i].Identity.Type]
-		err := enr.Enrich(ctx, &irs[i], clients)
+		grp.Go(func() error {
+			// Jitter only the initial burst: the first
+			// defaultEnrichConcurrency goroutines start simultaneously
+			// at t=0, so their opening GCP calls would otherwise land
+			// together. Goroutines beyond that batch are already
+			// staggered by errgroup slot availability — jittering all
+			// of them would add tens of seconds of dead wall time.
+			if pos < defaultEnrichConcurrency {
+				sleep := time.Duration(rand.Int63n(int64(defaultEnrichStartupJitterMax)))
+				t := time.NewTimer(sleep)
+				select {
+				case <-ctx.Done():
+					t.Stop()
+				case <-t.C:
+				}
+			}
+			results[pos] = enrichWithRetry(ctx, func() error {
+				return enr.Enrich(ctx, &irs[i], clients)
+			})
+			return nil
+		})
+	}
+	_ = grp.Wait()
+
+	// Second pass: walk idx in sorted order to inspect results, stamp
+	// the per-IR EnrichmentStatus/EnrichErrors, emit progress events,
+	// and aggregate errors. Doing this serially — and outside the
+	// goroutines — keeps emit order and error-join order deterministic
+	// (progress.Emitter is not documented as concurrency-safe) and
+	// identical to the old serial behaviour.
+	var errs []error
+	for pos, i := range idx {
+		err := results[pos]
 		switch {
 		case err == nil:
 			// Per-type enrichers marshal Attrs atomically today, so

--- a/cmd/insideout-import/gcpdiscover/enrich_test.go
+++ b/cmd/insideout-import/gcpdiscover/enrich_test.go
@@ -5,28 +5,57 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
 	storagev1 "google.golang.org/api/storage/v1"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
+// shrinkEnrichRetryDelays lowers the package-level retry backoff bounds
+// to sub-millisecond values for the duration of a test and restores
+// them on cleanup, so retry tests don't pay the production 200ms base /
+// 8s ceiling. enrichRetryBaseDelay/enrichRetryMaxDelay are vars (not
+// consts) precisely to allow this — see their doc comment in enrich.go.
+func shrinkEnrichRetryDelays(t *testing.T) {
+	t.Helper()
+	origBase, origMax := enrichRetryBaseDelay, enrichRetryMaxDelay
+	enrichRetryBaseDelay = 100 * time.Microsecond
+	enrichRetryMaxDelay = 1 * time.Millisecond
+	t.Cleanup(func() {
+		enrichRetryBaseDelay, enrichRetryMaxDelay = origBase, origMax
+	})
+}
+
 // fakeEnricher is a minimal AttributeEnricher that records its calls
 // and returns a configurable result. Used to exercise EnrichAttributes
 // dispatch / ordering / error-accumulation semantics without standing
 // up real SDK clients.
+//
+// Since EnrichAttributes now fans the per-resource Enrich calls out
+// across a bounded worker pool (#655), the calls slice is mutex-guarded
+// so the recording is data-race-free under -race. The recorded order
+// reflects goroutine completion order, NOT dispatch order — tests that
+// need deterministic dispatch order assert on emitted progress events
+// (which EnrichAttributes emits from its serial post-Wait pass).
 type fakeEnricher struct {
 	tfType string
-	calls  []string                               // bucket-of-Identity.ImportID per call
+	mu     sync.Mutex
+	calls  []string                               // Identity.ImportID per call, completion order
 	result func(*imported.ImportedResource) error // per-call result
 }
 
 func (f *fakeEnricher) ResourceType() string { return f.tfType }
 func (f *fakeEnricher) Enrich(_ context.Context, ir *imported.ImportedResource, _ EnrichClients) error {
+	f.mu.Lock()
 	f.calls = append(f.calls, ir.Identity.ImportID)
+	f.mu.Unlock()
 	if f.result == nil {
 		ir.Attrs = json.RawMessage(`{}`)
 		return nil
@@ -74,19 +103,210 @@ func TestEnrichAttributes_DeterministicOrder(t *testing.T) {
 		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "a", Address: "google_storage_bucket.a"}},
 		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "m", Address: "google_storage_bucket.m"}},
 	}
-	require.NoError(t, g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, nil))
-	assert.Equal(t, []string{"a", "m", "z"}, enr.calls,
-		"enrich must dispatch in sorted (type, address) order regardless of input order")
+	// Since enrichers now run concurrently (#655), call-completion
+	// order is non-deterministic — the deterministic-order contract is
+	// proven instead by the post-Wait serial emit pass: ItemFound
+	// events must arrive in sorted (type, address) order.
+	rec := &recordingEmitter{}
+	require.NoError(t, g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, rec))
+	items := filterEvents(rec.snapshot(), "item_found")
+	got := make([]string, len(items))
+	for i, e := range items {
+		got[i] = e.ImportID
+	}
+	assert.Equal(t, []string{"a", "m", "z"}, got,
+		"enrich must emit ItemFound in sorted (type, address) order regardless of input order")
 
 	// Guard against an idx-vs-i writeback bug: each IR must be marked
 	// Full at its original input position, not at the sorted-dispatch
 	// position. A regression here (e.g. `for i := range irs` instead
-	// of `for _, i := range idx`) would still pass the dispatch-order
+	// of `for _, i := range idx`) would still pass the emit-order
 	// assertion above but corrupt the per-IR EnrichmentStatus.
 	for i, ir := range irs {
 		assert.Equal(t, imported.EnrichmentStatusFull, ir.Identity.EnrichmentStatus,
 			"irs[%d] (ImportID=%q) must be Full at its original input position", i, ir.Identity.ImportID)
 	}
+}
+
+// TestEnrichAttributes_RunsConcurrently proves the per-resource
+// enrichers run in parallel AND that the fan-out is bounded by the
+// worker pool (#655). It dispatches more resources than
+// defaultEnrichConcurrency: a barrier enricher blocks until exactly
+// defaultEnrichConcurrency goroutines are simultaneously in-flight
+// (the pool cap), then releases everyone. It asserts BOTH bounds —
+// maxInFlight >= 2 (concurrency happens) and maxInFlight <=
+// defaultEnrichConcurrency (the pool is bounded). A regression that
+// dropped grp.SetLimit (unbounded fan-out) would push maxInFlight to n
+// and fail the upper bound.
+func TestEnrichAttributes_RunsConcurrently(t *testing.T) {
+	t.Parallel()
+
+	// More resources than the pool cap: the extra ones can only be
+	// enriched after the first batch is released.
+	const n = defaultEnrichConcurrency + 3
+	var inFlight atomic.Int64
+	var maxInFlight atomic.Int64
+	barrier := make(chan struct{})
+	allArrived := make(chan struct{})
+	var arrivedOnce sync.Once
+
+	enr := &fakeEnricher{
+		tfType: "google_storage_bucket",
+		result: func(ir *imported.ImportedResource) error {
+			cur := inFlight.Add(1)
+			for {
+				m := maxInFlight.Load()
+				if cur <= m || maxInFlight.CompareAndSwap(m, cur) {
+					break
+				}
+			}
+			// The barrier releases once exactly defaultEnrichConcurrency
+			// goroutines (the pool cap) are simultaneously in-flight. A
+			// bounded pool can never exceed that, so this fires exactly
+			// when the pool is saturated.
+			if cur == int64(defaultEnrichConcurrency) {
+				arrivedOnce.Do(func() { close(allArrived) })
+			}
+			<-barrier // block until the test releases everyone
+			inFlight.Add(-1)
+			ir.Attrs = json.RawMessage(`{}`)
+			return nil
+		},
+	}
+	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"google_storage_bucket": enr}}
+
+	irs := make([]imported.ImportedResource, n)
+	for i := range irs {
+		irs[i] = imported.ImportedResource{Identity: imported.ResourceIdentity{
+			Type: "google_storage_bucket", ImportID: string(rune('a' + i)),
+			Address: "google_storage_bucket." + string(rune('a'+i)),
+		}}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, nil)
+	}()
+
+	// If the pool regressed to serial, only one goroutine would ever be
+	// in-flight and allArrived would never close — guard the receive so
+	// the test fails fast instead of hanging until the package timeout.
+	select {
+	case <-allArrived:
+	case <-time.After(5 * time.Second):
+		t.Fatal("enrichers never reached expected concurrency — worker pool likely serial")
+	}
+	close(barrier)
+	require.NoError(t, <-done)
+
+	got := maxInFlight.Load()
+	assert.GreaterOrEqual(t, got, int64(2),
+		"enrichers must run concurrently, observed max in-flight %d", got)
+	assert.LessOrEqual(t, got, int64(defaultEnrichConcurrency),
+		"fan-out must be bounded by the worker pool, observed max in-flight %d", got)
+
+	// Every resource — including the ones beyond the pool cap — must
+	// still get enriched.
+	for i := range irs {
+		assert.NotEmpty(t, irs[i].Attrs,
+			"irs[%d] (ImportID=%q) must be enriched even though it dispatched after the pool cap", i, irs[i].Identity.ImportID)
+	}
+}
+
+// TestEnrichAttributes_OutOfOrderCompletionStillDeterministic proves
+// that even when enrichers finish in an order unrelated to the sorted
+// dispatch order, EnrichAttributes still emits ItemFound, stamps
+// EnrichmentStatus, and aggregates errors in sorted (type, address)
+// order — because emit/stamp/aggregate runs in the serial post-Wait
+// pass (#655).
+func TestEnrichAttributes_OutOfOrderCompletionStillDeterministic(t *testing.T) {
+	t.Parallel()
+
+	release := map[string]chan struct{}{
+		"a": make(chan struct{}),
+		"m": make(chan struct{}),
+		"z": make(chan struct{}),
+	}
+	enr := &fakeEnricher{
+		tfType: "google_storage_bucket",
+		result: func(ir *imported.ImportedResource) error {
+			<-release[ir.Identity.ImportID]
+			ir.Attrs = json.RawMessage(`{}`)
+			return nil
+		},
+	}
+	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"google_storage_bucket": enr}}
+
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "z", Address: "google_storage_bucket.z"}},
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "a", Address: "google_storage_bucket.a"}},
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "m", Address: "google_storage_bucket.m"}},
+	}
+
+	rec := &recordingEmitter{}
+	done := make(chan error, 1)
+	go func() {
+		done <- g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, rec)
+	}()
+	// Release in reverse-sorted order.
+	close(release["z"])
+	close(release["m"])
+	close(release["a"])
+	require.NoError(t, <-done)
+
+	items := filterEvents(rec.snapshot(), "item_found")
+	got := make([]string, len(items))
+	for i, e := range items {
+		got[i] = e.ImportID
+	}
+	assert.Equal(t, []string{"a", "m", "z"}, got,
+		"ItemFound order must follow sorted idx, not completion order")
+	for i, ir := range irs {
+		assert.Equal(t, imported.EnrichmentStatusFull, ir.Identity.EnrichmentStatus,
+			"irs[%d] must be Full regardless of completion order", i)
+	}
+}
+
+// TestEnrichAttributes_ErrorAggregationOrder proves the joined error's
+// per-resource order follows sorted idx, not goroutine completion order
+// (#655). Each enricher fails after a release gate; gates fire in
+// reverse-sorted order, yet the joined error must list a before b.
+func TestEnrichAttributes_ErrorAggregationOrder(t *testing.T) {
+	t.Parallel()
+
+	release := map[string]chan struct{}{
+		"a": make(chan struct{}),
+		"b": make(chan struct{}),
+	}
+	enr := &fakeEnricher{
+		tfType: "google_storage_bucket",
+		result: func(ir *imported.ImportedResource) error {
+			<-release[ir.Identity.ImportID]
+			return errors.New("403: " + ir.Identity.ImportID)
+		},
+	}
+	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"google_storage_bucket": enr}}
+
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "a", Address: "google_storage_bucket.a"}},
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "b", Address: "google_storage_bucket.b"}},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, nil)
+	}()
+	// b completes before a — joined error must still list a first.
+	close(release["b"])
+	close(release["a"])
+	err := <-done
+	require.Error(t, err)
+	idxA := strings.Index(err.Error(), "google_storage_bucket.a")
+	idxB := strings.Index(err.Error(), "google_storage_bucket.b")
+	require.GreaterOrEqual(t, idxA, 0)
+	require.GreaterOrEqual(t, idxB, 0)
+	assert.Less(t, idxA, idxB,
+		"joined error must list resources in sorted idx order regardless of completion order")
 }
 
 func TestEnrichAttributes_AccumulatesErrors(t *testing.T) {
@@ -203,6 +423,115 @@ func TestEnrichAttributes_EmitsItemFoundOnSuccess(t *testing.T) {
 		"successful enrich must overwrite a prior Failed status")
 	assert.Nil(t, irs[0].Identity.EnrichErrors,
 		"successful enrich must clear stale EnrichErrors")
+}
+
+// rateLimitErr returns a real GCP rate-limit-shaped error: a
+// *googleapi.Error with HTTP 429 that isGoogleAPIRateLimited classifies
+// as a throttle.
+func rateLimitErr() error {
+	return &googleapi.Error{Code: 429, Message: "rate limit exceeded"}
+}
+
+// TestEnrichWithRetry_RetriesThrottleThenSucceeds proves enrichWithRetry
+// retries a rate-limit error and the resource ends up enriched with no
+// error surfaced. The enricher returns a 429 for the first K calls then
+// nil.
+func TestEnrichWithRetry_RetriesThrottleThenSucceeds(t *testing.T) {
+	shrinkEnrichRetryDelays(t)
+
+	const failFirst = 3
+	// Distinctive payload written only on the successful (final) attempt
+	// so the assertion pins that the retried call's result actually
+	// landed — a constant `{}` would pass even if a stale write leaked.
+	const successAttrs = `{"retried":true,"bucket":"b1"}`
+	var calls atomic.Int64
+	enr := &fakeEnricher{
+		tfType: "google_storage_bucket",
+		result: func(ir *imported.ImportedResource) error {
+			if calls.Add(1) <= failFirst {
+				return rateLimitErr()
+			}
+			ir.Attrs = json.RawMessage(successAttrs)
+			return nil
+		},
+	}
+	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"google_storage_bucket": enr}}
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "b1", Address: "google_storage_bucket.b1"}},
+	}
+	require.NoError(t, g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, nil),
+		"a rate-limit that eventually clears must not surface as an error")
+	assert.JSONEq(t, successAttrs, string(irs[0].Attrs),
+		"resource must end up enriched with the retried call's exact payload")
+	assert.Equal(t, imported.EnrichmentStatusFull, irs[0].Identity.EnrichmentStatus,
+		"retried-to-success IR must be marked Full")
+	assert.Equal(t, int64(failFirst+1), calls.Load(),
+		"enricher must be retried exactly failFirst times then succeed")
+}
+
+// TestEnrichWithRetry_NonThrottleNotRetried proves a non-rate-limit
+// error is surfaced immediately without retry — the enricher is called
+// once.
+func TestEnrichWithRetry_NonThrottleNotRetried(t *testing.T) {
+	shrinkEnrichRetryDelays(t)
+
+	var calls atomic.Int64
+	enr := &fakeEnricher{
+		tfType: "google_storage_bucket",
+		result: func(ir *imported.ImportedResource) error {
+			calls.Add(1)
+			return errors.New("403: permission denied")
+		},
+	}
+	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"google_storage_bucket": enr}}
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "b1", Address: "google_storage_bucket.b1"}},
+	}
+	err := g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, nil)
+	require.Error(t, err, "a non-rate-limit error must surface as a per-resource error")
+	assert.Equal(t, int64(1), calls.Load(), "a non-rate-limit error must not be retried")
+}
+
+// TestEnrichWithRetry_GivesUpAfterMaxAttempts proves the retry loop
+// gives up after enrichRetryMaxAttempts and surfaces the rate-limit
+// error.
+func TestEnrichWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
+	shrinkEnrichRetryDelays(t)
+
+	var calls atomic.Int64
+	enr := &fakeEnricher{
+		tfType: "google_storage_bucket",
+		result: func(ir *imported.ImportedResource) error {
+			calls.Add(1)
+			return rateLimitErr()
+		},
+	}
+	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"google_storage_bucket": enr}}
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", ImportID: "b1", Address: "google_storage_bucket.b1"}},
+	}
+	err := g.EnrichAttributes(context.Background(), irs, EnrichClients{Storage: &storagev1.Service{}}, nil)
+	require.Error(t, err, "an unrelenting rate-limit must eventually surface as an error")
+	assert.Equal(t, int64(enrichRetryMaxAttempts), calls.Load(),
+		"retry loop must attempt exactly enrichRetryMaxAttempts times before giving up")
+	assert.Equal(t, imported.EnrichmentStatusFailed, irs[0].Identity.EnrichmentStatus,
+		"a give-up after max attempts must mark the IR Failed")
+}
+
+// TestIsGoogleAPIRateLimited covers the GCP rate-limit classifier
+// across the HTTP-status path and the per-error Reason scan.
+func TestIsGoogleAPIRateLimited(t *testing.T) {
+	t.Parallel()
+	assert.False(t, isGoogleAPIRateLimited(nil), "nil err must not be rate-limited")
+	assert.False(t, isGoogleAPIRateLimited(errors.New("plain")), "non-Google error must not be rate-limited")
+	assert.True(t, isGoogleAPIRateLimited(&googleapi.Error{Code: 429}))
+	assert.True(t, isGoogleAPIRateLimited(&googleapi.Error{Code: 503}))
+	assert.False(t, isGoogleAPIRateLimited(&googleapi.Error{Code: 404}),
+		"a 404 must not classify as a rate-limit")
+	reasoned := &googleapi.Error{Code: 403}
+	reasoned.Errors = []googleapi.ErrorItem{{Reason: "userRateLimitExceeded"}}
+	assert.True(t, isGoogleAPIRateLimited(reasoned),
+		"a non-429 error carrying a rate-limit Reason must classify as a rate-limit")
 }
 
 // filterEvents returns the subset of recorded events whose Kind matches

--- a/pkg/composer/imported/generated/plannable.go
+++ b/pkg/composer/imported/generated/plannable.go
@@ -1,0 +1,152 @@
+package generated
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// MissingRequiredAttrs reports the schema-Required Terraform argument names
+// for tfType that `raw` (a marshaled Attrs payload) does not carry a value
+// for. The returned slice is sorted and empty when every Required argument
+// is present. An error is returned ONLY when tfType is not in the registry
+// (the caller genuinely cannot assess plannability). An undecodable `raw`
+// is NOT an error — it returns every Required name (nothing was captured).
+//
+// This is the durable, Tier-independent plannability signal behind issue
+// #656: a discovered resource is plannable iff every provider-Required
+// argument survived discovery into ir.Attrs. EmitImportedTF renders a plain
+// `resource {}` block and the deploy wrapper runs `terraform plan` with no
+// `-generate-config-out`, so Terraform never backfills Required arguments
+// from imported state — a Required argument absent here is a Required
+// argument that fails `plan` with an opaque "Missing required argument".
+//
+// "Present" is decided by reflecting over the decoded struct rather than by
+// JSON-object key inspection: a generated Required field is a `*Value[T]`
+// pointer with `json:",omitempty"`, so an absent attribute decodes to a nil
+// pointer. A field counts as present iff, after decode, it is a non-nil
+// pointer/interface, a non-empty map/slice, or an otherwise non-zero value.
+//
+// The decode is intentionally forgiving: a `raw` payload that fails to
+// unmarshal at all is treated as "discovery captured nothing", matching the
+// issue's framing — every Required name is returned, with a nil error, so
+// the resource is reported un-plannable rather than the failure being
+// surfaced as a registry error.
+func MissingRequiredAttrs(tfType string, raw json.RawMessage) ([]string, error) {
+	goType, schema, ok := Lookup(tfType)
+	if !ok {
+		return nil, fmt.Errorf("generated: no registered type for %q", tfType)
+	}
+
+	// Collect the sorted set of schema-Required argument names. A type with
+	// no Required arguments is always plannable regardless of `raw`.
+	var required []string
+	for name, fs := range schema {
+		if fs.Required {
+			required = append(required, name)
+		}
+	}
+	if len(required) == 0 {
+		return nil, nil
+	}
+	sort.Strings(required)
+
+	// No payload at all — discovery captured nothing; every Required
+	// argument is missing.
+	if len(raw) == 0 {
+		return required, nil
+	}
+
+	// Decode into a fresh typed value. An undecodable payload is NOT a
+	// registry error: per the issue, treat it as "discovery did not capture
+	// them" and report every Required argument as missing.
+	ptr := reflect.New(goType) // *<T>
+	if err := json.Unmarshal(raw, ptr.Interface()); err != nil {
+		return required, nil
+	}
+
+	present := presentTFNames(ptr.Elem())
+
+	var missing []string
+	for _, name := range required {
+		if !present[name] {
+			missing = append(missing, name)
+		}
+	}
+	// `required` is already sorted, so the filtered subset preserves order.
+	return missing, nil
+}
+
+// presentTFNames reflects over a decoded generated-struct value and returns
+// the set of `tf:"..."` argument names whose field carries a value. v must
+// be a struct Value (the dereferenced result of reflect.New(goType)).
+//
+// A field counts as present iff:
+//   - non-nil *Value[T]    → the value is in the literal or expr state
+//     (an explicit-null or absent state does NOT count — Terraform treats
+//     a required argument set to null the same as one omitted entirely)
+//   - other pointer / interface → non-nil
+//   - map / slice          → len > 0
+//   - any other kind       → non-zero
+//
+// Required generated fields are `*Value[T]` pointers in practice, so a nil
+// pointer (the JSON-omitempty representation of an absent attribute) is the
+// dominant "absent" case. Fields with no `tf` tag, or `tf:"-"`, are skipped
+// — they are not Terraform arguments.
+func presentTFNames(v reflect.Value) map[string]bool {
+	present := map[string]bool{}
+	if v.Kind() != reflect.Struct {
+		return present
+	}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+		tag := sf.Tag.Get("tf")
+		if tag == "" {
+			continue
+		}
+		// Strip any `,omitempty`-style options from the tag value.
+		name := tag
+		if comma := strings.IndexByte(name, ','); comma >= 0 {
+			name = name[:comma]
+		}
+		if name == "" || name == "-" {
+			continue
+		}
+		if fieldHasValue(v.Field(i)) {
+			present[name] = true
+		}
+	}
+	return present
+}
+
+// fieldHasValue reports whether a decoded struct field carries a value, per
+// the presence rule documented on presentTFNames.
+func fieldHasValue(fv reflect.Value) bool {
+	switch fv.Kind() {
+	case reflect.Pointer:
+		if fv.IsNil() {
+			return false
+		}
+		// A *Value[T] carries an explicit tri-state (absent / null /
+		// literal / expr). Only a literal or a Terraform expression is a
+		// captured value; an explicit-null required argument fails
+		// `terraform plan` exactly like an omitted one. State() is
+		// declared on *Value[T] for every T, so this reflects uniformly
+		// across the generated structs without naming the type param.
+		if m := fv.MethodByName("State"); m.IsValid() {
+			if st, ok := m.Call(nil)[0].Interface().(ValueState); ok {
+				return st == StateLiteral || st == StateExpr
+			}
+		}
+		return true
+	case reflect.Interface:
+		return !fv.IsNil()
+	case reflect.Map, reflect.Slice:
+		return fv.Len() > 0
+	default:
+		return !fv.IsZero()
+	}
+}

--- a/pkg/composer/imported/generated/plannable_test.go
+++ b/pkg/composer/imported/generated/plannable_test.go
@@ -1,0 +1,130 @@
+package generated
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMissingRequiredAttrs_AllPresent covers the plannable case: an
+// aws_iam_policy Attrs payload that carries its single Required argument
+// (`policy`) reports no missing arguments.
+func TestMissingRequiredAttrs_AllPresent(t *testing.T) {
+	t.Parallel()
+
+	attrs := AWSIAMPolicy{
+		Name:   LiteralOf("io-policy"),
+		Policy: LiteralOf(`{"Version":"2012-10-17"}`),
+	}
+	raw, err := json.Marshal(attrs)
+	require.NoError(t, err)
+
+	missing, err := MissingRequiredAttrs("aws_iam_policy", raw)
+	require.NoError(t, err)
+	assert.Empty(t, missing, "every Required argument is present")
+}
+
+// TestMissingRequiredAttrs_MissingPolicy covers the un-plannable case from
+// the issue: an aws_iam_policy whose Attrs omit the Required `policy`
+// argument is reported as missing exactly `policy`.
+func TestMissingRequiredAttrs_MissingPolicy(t *testing.T) {
+	t.Parallel()
+
+	// Optional fields are present; the Required `policy` is omitted.
+	raw := json.RawMessage(`{"name":{"literal":"io-policy"}}`)
+
+	missing, err := MissingRequiredAttrs("aws_iam_policy", raw)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"policy"}, missing)
+}
+
+// TestMissingRequiredAttrs_ExplicitNullIsMissing covers the tri-state edge:
+// a Required argument decoded to an explicit-null *Value (`{"null":true}`)
+// is reported missing — `terraform plan` rejects a required argument set to
+// null exactly like an omitted one, so a non-nil-but-null pointer must NOT
+// count as captured.
+func TestMissingRequiredAttrs_ExplicitNullIsMissing(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"name":{"literal":"io-policy"},"policy":{"null":true}}`)
+
+	missing, err := MissingRequiredAttrs("aws_iam_policy", raw)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"policy"}, missing, "explicit-null Required arg is not captured")
+}
+
+// TestMissingRequiredAttrs_ExprCounts confirms a Required argument carrying
+// a Terraform expression (a wiring edge, not a literal) counts as captured —
+// an expression resolves to a value at plan time.
+func TestMissingRequiredAttrs_ExprCounts(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"policy":{"expr":"data.aws_iam_policy_document.x.json"}}`)
+
+	missing, err := MissingRequiredAttrs("aws_iam_policy", raw)
+	require.NoError(t, err)
+	assert.Empty(t, missing, "an expression-valued Required arg is plannable")
+}
+
+// TestMissingRequiredAttrs_EmptyRaw covers the "discovery captured nothing"
+// case: an empty Attrs payload reports every Required argument as missing.
+func TestMissingRequiredAttrs_EmptyRaw(t *testing.T) {
+	t.Parallel()
+
+	missing, err := MissingRequiredAttrs("aws_iam_policy", nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"policy"}, missing)
+
+	missing, err = MissingRequiredAttrs("aws_iam_policy", json.RawMessage(``))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"policy"}, missing)
+}
+
+// TestMissingRequiredAttrs_UndecodableRaw covers the malformed-payload case:
+// a `raw` that cannot decode into the registered struct is treated as
+// "discovery did not capture them" — every Required argument is reported
+// missing, with a nil error (NOT a registry error).
+func TestMissingRequiredAttrs_UndecodableRaw(t *testing.T) {
+	t.Parallel()
+
+	// A JSON array cannot decode into the struct.
+	missing, err := MissingRequiredAttrs("aws_iam_policy", json.RawMessage(`[1,2,3]`))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"policy"}, missing)
+}
+
+// TestMissingRequiredAttrs_UnregisteredType covers the only error path: a
+// type absent from the registry returns an error so the caller knows
+// plannability genuinely cannot be assessed.
+func TestMissingRequiredAttrs_UnregisteredType(t *testing.T) {
+	t.Parallel()
+
+	missing, err := MissingRequiredAttrs("_definitely_not_registered", json.RawMessage(`{}`))
+	require.Error(t, err)
+	assert.Nil(t, missing)
+	assert.Contains(t, err.Error(), "no registered type")
+}
+
+// TestMissingRequiredAttrs_ZeroRequiredFields covers a registered type with
+// no Required arguments at all: it is always plannable, so the result is
+// (nil, nil) regardless of the payload.
+func TestMissingRequiredAttrs_ZeroRequiredFields(t *testing.T) {
+	// The shared package-level registry is mutated here via Register;
+	// t.Parallel is avoided so tests using Register don't interleave.
+	const tfType = "_test_plannable_no_required"
+	t.Cleanup(func() { unregisterForTest(tfType) })
+
+	// regTestType's only field `name` is Optional — no Required arguments.
+	Register(tfType, reflect.TypeFor[regTestType](), regTestTypeSchema, AWSProviderSource)
+
+	missing, err := MissingRequiredAttrs(tfType, json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.Nil(t, missing)
+
+	missing, err = MissingRequiredAttrs(tfType, nil)
+	require.NoError(t, err)
+	assert.Nil(t, missing)
+}

--- a/pkg/composer/imported_plannable.go
+++ b/pkg/composer/imported_plannable.go
@@ -1,0 +1,59 @@
+package composer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// MissingRequiredAttrs reports the schema-Required Terraform arguments that
+// discovery failed to capture in ir.Attrs. An empty result means the
+// resource is plannable. Unlike ValidateImportedResources, this does NOT
+// require ir.Tier to be stamped — it works directly against raw discovery
+// output (issue #656). When ir.Identity.Type is not a registered imported
+// type, plannability cannot be assessed and an empty slice is returned (so
+// callers do not disable rows on an absent signal).
+//
+// This is the public, durable contract that replaces downstream
+// (luthersystems/reliable) reaching into emit-mode classification or
+// stamping a synthetic Tier to detect un-plannable resources. The detection
+// runs entirely off ir.Identity.Type + ir.Attrs; see
+// generated.MissingRequiredAttrs for the per-attribute presence rule.
+func MissingRequiredAttrs(ir imported.ImportedResource) []string {
+	missing, err := generated.MissingRequiredAttrs(ir.Identity.Type, ir.Attrs)
+	if err != nil {
+		// Unregistered type: plannability cannot be assessed. Return an
+		// empty slice rather than an error so callers treat it as an
+		// absent signal — not as "un-plannable" — and do not disable the
+		// resource's row on the strength of a missing schema.
+		return nil
+	}
+	return missing
+}
+
+// Plannable reports whether every schema-Required Terraform argument for ir
+// was captured by discovery. See MissingRequiredAttrs — like it, Plannable
+// does NOT require ir.Tier to be stamped. A resource whose type is not a
+// registered imported type is reported plannable (the signal is absent, not
+// negative).
+func Plannable(ir imported.ImportedResource) bool {
+	return len(MissingRequiredAttrs(ir)) == 0
+}
+
+// UnplannableReason returns a human-readable explanation when ir is not
+// plannable, or "" when it is. The wording matches the
+// imported_resource_missing_required_attr validation message
+// (ValidateImportedEmitReadiness) so downstream UI copy stays consistent
+// whether it is sourced from a ValidationIssue or from this Tier-independent
+// helper.
+func UnplannableReason(ir imported.ImportedResource) string {
+	missing := MissingRequiredAttrs(ir)
+	if len(missing) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"imported %s %q is missing required argument(s) %s; discovery did not capture them and Terraform plan will fail — the resource block is not plannable",
+		ir.Identity.Type, ir.Identity.Address, strings.Join(missing, ", "))
+}

--- a/pkg/composer/imported_plannable_test.go
+++ b/pkg/composer/imported_plannable_test.go
@@ -1,0 +1,89 @@
+package composer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// plannableIAMPolicyIR builds an aws_iam_policy ImportedResource whose Attrs
+// carry the Required `policy` argument. It deliberately leaves ir.Tier
+// unset — the issue #656 contract is that plannability is assessable
+// directly off raw discovery output, with no Tier stamped.
+func plannableIAMPolicyIR(t *testing.T) imported.ImportedResource {
+	t.Helper()
+	raw := json.RawMessage(`{"name":{"literal":"io-policy"},"policy":{"literal":"{\"Version\":\"2012-10-17\"}"}}`)
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "aws",
+			Type:    "aws_iam_policy",
+			Address: "aws_iam_policy.app",
+		},
+		Attrs: raw,
+	}
+}
+
+// unplannableIAMPolicyIR builds the live repro from issue #656: an
+// aws_iam_policy whose Attrs omit the Required `policy` argument. Tier is
+// left unset on purpose.
+func unplannableIAMPolicyIR(t *testing.T) imported.ImportedResource {
+	t.Helper()
+	raw := json.RawMessage(`{"name":{"literal":"io-policy"}}`)
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "aws",
+			Type:    "aws_iam_policy",
+			Address: "aws_iam_policy.app",
+		},
+		Attrs: raw,
+	}
+}
+
+func TestMissingRequiredAttrs_Plannable(t *testing.T) {
+	t.Parallel()
+	ir := plannableIAMPolicyIR(t)
+	require.Empty(t, ir.Tier, "contract: plannability is assessed without a stamped Tier")
+
+	assert.Empty(t, MissingRequiredAttrs(ir))
+	assert.True(t, Plannable(ir))
+	assert.Equal(t, "", UnplannableReason(ir))
+}
+
+func TestMissingRequiredAttrs_Unplannable(t *testing.T) {
+	t.Parallel()
+	ir := unplannableIAMPolicyIR(t)
+	require.Empty(t, ir.Tier, "contract: plannability is assessed without a stamped Tier")
+
+	missing := MissingRequiredAttrs(ir)
+	assert.Equal(t, []string{"policy"}, missing)
+	assert.False(t, Plannable(ir))
+
+	reason := UnplannableReason(ir)
+	assert.Contains(t, reason, "policy")
+	assert.Contains(t, reason, "not plannable")
+	assert.Contains(t, reason, "aws_iam_policy.app")
+}
+
+// TestMissingRequiredAttrs_UnregisteredTypeIsPlannable asserts that a
+// resource whose Terraform type is not a registered imported type is
+// treated as an absent signal — plannable, with no missing arguments and no
+// reason — so downstream callers do not disable its row.
+func TestMissingRequiredAttrs_UnregisteredTypeIsPlannable(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "aws",
+			Type:    "aws_not_a_real_imported_type",
+			Address: "aws_not_a_real_imported_type.x",
+		},
+		Attrs: json.RawMessage(`{}`),
+	}
+	require.Empty(t, ir.Tier)
+
+	assert.Nil(t, MissingRequiredAttrs(ir))
+	assert.True(t, Plannable(ir))
+	assert.Equal(t, "", UnplannableReason(ir))
+}


### PR DESCRIPTION
## Summary

Two related discovery-path improvements (bundled per request).

**#655 — parallelize the serial `EnrichAttributes` loop.** The reverse-import enrichment phase ran one cloud-API round-trip per resource serially — ~1m30s on a ~224-resource AWS account. It now runs the per-resource enrichers under a bounded `errgroup` worker pool, carrying the same rate-limit protection as the discover phase:
- Concurrency capped at `defaultEnrichConcurrency` (4), mirroring `defaultDiscoverTypesConcurrency` (#632 lowered it from 8 after a CloudControl throttle).
- Startup jitter on the initial burst so the first batch's calls don't all land at t=0.
- Throttle-aware backoff+retry (`enrichWithRetry`) absorbs an accidental rate-limit hit — exponential backoff with jitter, ctx-cancellable; a backstop atop the AWS SDK adaptive retryer and the primary defense for GCP (no client-level retryer).
- Progress emission, `EnrichmentStatus` stamping, and error aggregation run in a serial post-`Wait` pass over the sorted `idx`, so emit/error order stays byte-identical to the old serial behaviour.

**#656 — expose a per-resource plannability signal.** Discovery output did not say, per resource, whether every schema-`Required` Terraform argument was captured — so a discovered resource missing a required arg (e.g. `aws_iam_policy` without `policy`) only failed much later as a stack-wide `compose_failed`. New Tier-independent contract:
- `generated.MissingRequiredAttrs(tfType, raw)` — reflects over the registered typed model; an absent or explicit-null required `*Value` counts as not-captured.
- `composer.MissingRequiredAttrs(ir)` / `Plannable(ir)` / `UnplannableReason(ir)` — the public contract over an `imported.ImportedResource`, no `ir.Tier` needed. Lets `reliable` retire its fragile synthetic-Tier workaround.

Closes #655
Closes #656

## Test plan
- [x] `go test -race ./cmd/insideout-import/awsdiscover/... ./cmd/insideout-import/gcpdiscover/... ./pkg/composer/... ./pkg/composer/imported/generated/...` — 3680 pass under `-race`
- [x] New tests: bounded-concurrency (lower + upper bound), out-of-order-completion determinism, error-aggregation order, throttle retry/give-up, throttle classifiers, plannability (omitted / explicit-null / expr / unregistered / no-Tier)
- [x] `go build ./...`, `go vet ./cmd/insideout-import/... ./pkg/composer/...`

## Review notes
- /review findings: 1 P2 (explicit-null required arg counted as present) resolved.
- qa-professor findings: all addressed — concurrency upper-bound assertion added, hang-instead-of-fail barrier guarded with `time.After`, weak `NotEmpty` assertion tightened, hand-rolled helper removed, registry-mutation note added.

Downstream: `reliable#1664` (bump presets pin), `reliable#1661` (drop synthetic-Tier workaround).