### PR TITLE
feat(discovery): resolve parent VPC for internet gateways and DHCP options (#651)

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
@@ -122,6 +123,11 @@ const DefaultMaxConcurrency = 10
 type AWSDiscoverer struct {
 	byType        map[string]Discoverer
 	defaultRegion string
+	// cfg is the construction-time aws.Config. DiscoverTypes uses it to
+	// build per-region EC2 clients for the resolveVPCChildVPCIDs
+	// augmentation pass (#651), which needs live Describe* calls the
+	// per-type discoverers do not make.
+	cfg aws.Config
 	// rgtPrefetcher is the optional RGT (Resource Groups Tagging API)
 	// pre-pass run once per DiscoverTypes call. Defaults to a real
 	// prefetcher constructed from the aws.Config; tests can swap in a
@@ -344,6 +350,7 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 	}
 	disc := &AWSDiscoverer{
 		defaultRegion:  cfg.Region,
+		cfg:            cfg,
 		byType:         byType,
 		rgtPrefetcher:  newRealRGTPrefetcher(cfg),
 		byTypeEnricher: byTypeEnricher,
@@ -552,6 +559,24 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	all := make([]imported.ImportedResource, 0, total)
 	for _, r := range results {
 		all = append(all, r...)
+	}
+	// VPC-child VPC augmentation (#651): aws_internet_gateway and
+	// aws_vpc_dhcp_options carry no VpcId in their Cloud Control model,
+	// so the #650 in-memory join cannot find their parent aws_vpc. This
+	// SDK-backed pass issues EC2 Describe* calls to recover the link and
+	// stamps NativeIDs["vpc_id"] onto the matching resources, after which
+	// resolveParentAddresses handles them as ordinary forward-edge FK
+	// rules. A failure here must not abort an otherwise-successful
+	// discovery run — the parent links are best-effort enrichment — so a
+	// non-nil error is downgraded to a service warning.
+	if err := resolveVPCChildVPCIDs(ctx, all, args.Regions, func(region string) ec2VPCChildAPI {
+		return ec2.NewFromConfig(a.cfg, func(o *ec2.Options) {
+			if region != "" {
+				o.Region = region
+			}
+		})
+	}); err != nil {
+		args.Emitter.ServiceWarn("vpc_parent_resolve", "", err.Error())
 	}
 	// Parent-instance resolution (#650): now that the full cross-
 	// discoverer set is assembled, join each discovered child to the

--- a/cmd/insideout-import/awsdiscover/parent_resolve.go
+++ b/cmd/insideout-import/awsdiscover/parent_resolve.go
@@ -69,9 +69,15 @@ var parentFKByChildType = map[string]parentFK{
 	// CloudFormation model's VpcId into NativeIDs["vpc_id"] (see
 	// vpcIDNativeIDs); it matches the parent aws_vpc's ImportID
 	// (vpc-…). aws_internet_gateway and aws_vpc_dhcp_options carry no
-	// VPC reference in their own model — see unresolvableChildTypes.
-	"aws_route_table": {parentType: "aws_vpc", childKey: "vpc_id"},
-	"aws_subnet":      {parentType: "aws_vpc", childKey: "vpc_id"},
+	// VPC reference in their own Cloud Control model — their
+	// NativeIDs["vpc_id"] is instead stamped by the resolveVPCChildVPCIDs
+	// SDK augmentation pass (vpc_child_vpc_resolve.go, #651), which runs
+	// just before resolveParentAddresses. Once stamped they join their
+	// parent aws_vpc as ordinary forward edges.
+	"aws_route_table":      {parentType: "aws_vpc", childKey: "vpc_id"},
+	"aws_subnet":           {parentType: "aws_vpc", childKey: "vpc_id"},
+	"aws_internet_gateway": {parentType: "aws_vpc", childKey: "vpc_id"},
+	"aws_vpc_dhcp_options": {parentType: "aws_vpc", childKey: "vpc_id"},
 
 	// Split security-group rules. The ingress/egress Cloud Control
 	// entries lift the model's GroupId into NativeIDs["security_group_id"],
@@ -112,15 +118,19 @@ var parentFKByChildType = map[string]parentFK{
 // unresolvableChildTypes are labels-registry child types for which the
 // AWS resource model the discoverer reads carries no usable parent
 // reference, so no parent-instance link can be emitted without
-// discovering an additional association resource (a new AWS API call,
-// out of scope for #650 which is "emit what you already know"). They are
-// listed explicitly — rather than simply omitted — so
+// discovering an additional association resource. They are listed
+// explicitly — rather than simply omitted — so
 // TestParentFK_CoversLabelsRegistry can tell a deliberate, documented
-// omission from an accidental gap. Tracked for follow-up in #651.
-var unresolvableChildTypes = map[string]string{
-	"aws_internet_gateway": "AWS::EC2::InternetGateway has no VpcId; the IGW↔VPC link is a separate AWS::EC2::VPCGatewayAttachment resource (#651)",
-	"aws_vpc_dhcp_options": "AWS::EC2::DHCPOptions has no VpcId; the link is a separate AWS::EC2::VPCDHCPOptionsAssociation resource (#651)",
-}
+// omission from an accidental gap.
+//
+// This map is currently empty: as of #651 all 18 labels-registry child
+// edges are resolvable — the last two holdouts (aws_internet_gateway and
+// aws_vpc_dhcp_options) now resolve via the resolveVPCChildVPCIDs SDK
+// augmentation pass (vpc_child_vpc_resolve.go). The variable is retained
+// (not deleted) as the documented-omission mechanism for any future
+// labels edge whose parent link genuinely cannot be recovered, and
+// because several tests reference it.
+var unresolvableChildTypes = map[string]string{}
 
 // parentIndexKey identifies a candidate parent by its Terraform type and
 // one of the identifier values it exposes.

--- a/cmd/insideout-import/awsdiscover/parent_resolve_test.go
+++ b/cmd/insideout-import/awsdiscover/parent_resolve_test.go
@@ -172,7 +172,12 @@ func TestResolveParentAddresses(t *testing.T) {
 			},
 		},
 		{
-			name: "unresolvable type — internet gateway has no FK rule, stays unlinked",
+			// IGW and DHCP options now have forward-edge FK rules
+			// (#651), but their vpc_id NativeID is stamped by the
+			// resolveVPCChildVPCIDs SDK pass, not the in-memory
+			// resolver. With no vpc_id present a forward edge with an
+			// empty FK value stays unlinked.
+			name: "child with FK rule but missing vpc_id NativeID stays unlinked",
 			in: []imported.ImportedResource{
 				res("aws_vpc", "aws_vpc.main", "vpc-0abc", map[string]string{"name": "vpc-0abc"}),
 				res("aws_internet_gateway", "aws_internet_gateway.igw", "igw-01", map[string]string{"name": "igw-01"}),
@@ -181,6 +186,21 @@ func TestResolveParentAddresses(t *testing.T) {
 			want: map[string]string{
 				"aws_internet_gateway.igw": "",
 				"aws_vpc_dhcp_options.d":   "",
+			},
+		},
+		{
+			// With vpc_id stamped (as the resolveVPCChildVPCIDs SDK
+			// pass would), the IGW and DHCP options forward-resolve to
+			// their parent aws_vpc like any other VPC child (#651).
+			name: "forward edge — IGW and DHCP options resolve via stamped vpc_id",
+			in: []imported.ImportedResource{
+				res("aws_vpc", "aws_vpc.main", "vpc-0abc", map[string]string{"name": "vpc-0abc"}),
+				res("aws_internet_gateway", "aws_internet_gateway.igw", "igw-01", map[string]string{"name": "igw-01", "vpc_id": "vpc-0abc"}),
+				res("aws_vpc_dhcp_options", "aws_vpc_dhcp_options.d", "dopt-01", map[string]string{"name": "dopt-01", "vpc_id": "vpc-0abc"}),
+			},
+			want: map[string]string{
+				"aws_internet_gateway.igw": "aws_vpc.main",
+				"aws_vpc_dhcp_options.d":   "aws_vpc.main",
 			},
 		},
 		{
@@ -281,15 +301,28 @@ var fkContractFixtures = map[string]fkContractFixture{
 	"aws_elasticache_replication_group": {identifier: "redis-rg", props: map[string]any{"CacheParameterGroupName": "redis-pg"}},
 }
 
-// sdkOnlyFKChildren are forward-edge child types discovered by the
-// SDK-only sub-resource pipeline rather than Cloud Control. Their
-// foreign-key NativeIDs entry cannot be driven through a
-// cloudControlConfig closure (the fetch funcs need a live/fake SDK
-// client), so the discoverer↔resolver contract for these is pinned by
-// their own discoverer tests (sdkonly_s3_test.go asserts NativeIDs
-// ["bucket"]; the IAM role-policy-attachment test asserts NativeIDs
-// ["role"]). They are listed here so TestParentFK_DiscovererEmitsForeignKey
-// can account for every forward edge and skip exactly these.
+// sdkOnlyFKChildren are forward-edge child types whose foreign-key
+// NativeIDs entry is NOT produced by a Cloud Control
+// NativeIDsFromProperties closure, so the
+// TestParentFK_DiscovererEmitsForeignKey contract test cannot drive it
+// through a cloudControlConfig closure and must skip them. Two distinct
+// reasons land a type here:
+//
+//   - SDK-only sub-resource pipeline: the S3 sub-resource and IAM
+//     role-policy-attachment children are discovered by the SDK-only
+//     sub-resource pipeline; their FK is pinned by the discoverer's own
+//     tests (sdkonly_s3_test.go asserts NativeIDs["bucket"]; the IAM
+//     role-policy-attachment test asserts NativeIDs["role"]).
+//
+//   - SDK augmentation pass (#651): aws_internet_gateway and
+//     aws_vpc_dhcp_options have no VpcId in their Cloud Control model at
+//     all — NativeIDs["vpc_id"] is stamped after discovery by the
+//     resolveVPCChildVPCIDs SDK pass (vpc_child_vpc_resolve.go), not by
+//     any per-type discoverer. The discoverer↔resolver contract for
+//     these two is pinned by vpc_child_vpc_resolve_test.go instead.
+//
+// They are listed here so TestParentFK_DiscovererEmitsForeignKey can
+// account for every forward edge and skip exactly these.
 var sdkOnlyFKChildren = map[string]struct{}{
 	"aws_s3_bucket_versioning":                           {},
 	"aws_s3_bucket_lifecycle_configuration":              {},
@@ -297,6 +330,9 @@ var sdkOnlyFKChildren = map[string]struct{}{
 	"aws_s3_bucket_public_access_block":                  {},
 	"aws_s3_bucket_server_side_encryption_configuration": {},
 	"aws_iam_role_policy_attachment":                     {},
+	// #651 — vpc_id stamped by the resolveVPCChildVPCIDs SDK pass.
+	"aws_internet_gateway": {},
+	"aws_vpc_dhcp_options": {},
 }
 
 // TestParentFK_DiscovererEmitsForeignKey pins the discoverer↔resolver

--- a/cmd/insideout-import/awsdiscover/vpc_child_vpc_resolve.go
+++ b/cmd/insideout-import/awsdiscover/vpc_child_vpc_resolve.go
@@ -1,0 +1,201 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// vpc_child_vpc_resolve.go is the SDK-backed augmentation half of the
+// parent/child discovery model for two VPC-children that #650 could not
+// resolve from discovery data alone: aws_internet_gateway and
+// aws_vpc_dhcp_options (issue #651).
+//
+// Why a separate pass is needed. The route-table and subnet discoverers
+// resolve to their parent aws_vpc purely in-memory: the Cloud Control
+// models AWS::EC2::RouteTable and AWS::EC2::Subnet both carry a VpcId
+// property, which the discoverer lifts into NativeIDs["vpc_id"] and the
+// #650 resolver joins against the parent aws_vpc's ImportID. The two
+// types handled here have NO such property:
+//
+//   - AWS::EC2::InternetGateway carries no VpcId. An IGW exists
+//     independently of any VPC; the IGW↔VPC link is a separate
+//     attachment (modeled as AWS::EC2::VPCGatewayAttachment, and exposed
+//     on the SDK as the IGW's Attachments[] list).
+//   - AWS::EC2::DHCPOptions carries no VpcId. A DHCP options set exists
+//     independently of any VPC; the association lives on the VPC side
+//     (each VPC has a DhcpOptionsId pointing at the set it uses).
+//
+// Because the link lives elsewhere, no in-memory join over the discovery
+// result can recover it — the data simply is not there. #650 therefore
+// parked both types in parent_resolve.go's unresolvableChildTypes.
+// resolveVPCChildVPCIDs closes that gap with the minimum extra AWS API
+// surface: a DescribeInternetGateways call (whose Attachments[] carry the
+// IGW→VPC edge) and a DescribeVpcs call (whose DhcpOptionsId carries the
+// VPC→DHCP-options edge). It stamps NativeIDs["vpc_id"] onto the matching
+// discovered resources, after which the two types become ordinary
+// forward-edge FK rules in parentFKByChildType and the existing
+// resolveParentAddresses join handles them like any other VPC child.
+//
+// The exactly-one-VPC rule for DHCP options. An internet gateway has at
+// most one VPC attachment, so its vpc_id is unambiguous. A DHCP options
+// set is the opposite: a single set can be associated with many VPCs —
+// the account-default `dopt-` set is associated with every VPC that has
+// not been given a custom one. A shared options set therefore has no
+// single parent. resolveVPCChildVPCIDs only stamps vpc_id on a DHCP
+// options resource when the set maps to exactly one distinct VPC; a
+// shared set is left unstamped and stays unlinked. This mirrors the
+// "parameter group shared by several instances has no single parent and
+// stays unlinked" rule in parent_resolve.go.
+//
+// The pass runs once over the fully assembled cross-discoverer set inside
+// AWSDiscoverer.DiscoverTypes, immediately before resolveParentAddresses.
+// igw / dopt / vpc IDs are globally unique within an account, so the
+// per-region Describe results merge into account-wide maps with no risk
+// of cross-region collision, and resource-to-data matching is purely by
+// ID.
+
+// ec2VPCChildAPI is the narrow slice of the EC2 SDK that
+// resolveVPCChildVPCIDs depends on. *ec2.Client satisfies it; tests
+// inject a fake.
+type ec2VPCChildAPI interface {
+	DescribeInternetGateways(context.Context, *ec2.DescribeInternetGatewaysInput, ...func(*ec2.Options)) (*ec2.DescribeInternetGatewaysOutput, error)
+	DescribeVpcs(context.Context, *ec2.DescribeVpcsInput, ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error)
+}
+
+// resolveVPCChildVPCIDs stamps NativeIDs["vpc_id"] onto discovered
+// aws_internet_gateway and aws_vpc_dhcp_options resources by joining them
+// against fresh EC2 Describe calls (issue #651). It mutates resources in
+// place.
+//
+// It issues no API calls when there is nothing to augment: if resources
+// contains zero IGW and zero DHCP-options entries it returns nil
+// immediately, and within a region it skips DescribeInternetGateways when
+// there are no IGW resources and DescribeVpcs when there are no
+// DHCP-options resources.
+//
+// An IGW is stamped with the VpcId of its first VPC attachment (an IGW
+// has at most one). A DHCP options set is stamped only when it maps to
+// exactly one distinct VPC — a set shared across VPCs has no single
+// parent and is left unstamped. A non-empty existing vpc_id is never
+// overwritten.
+//
+// The first SDK error encountered is returned wrapped with context; the
+// caller decides whether to fail the run or downgrade to a warning.
+func resolveVPCChildVPCIDs(ctx context.Context, resources []imported.ImportedResource, regions []string, clientFor func(region string) ec2VPCChildAPI) error {
+	var haveIGW, haveDHCP bool
+	for i := range resources {
+		switch resources[i].Identity.Type {
+		case "aws_internet_gateway":
+			haveIGW = true
+		case "aws_vpc_dhcp_options":
+			haveDHCP = true
+		}
+	}
+	if !haveIGW && !haveDHCP {
+		// Nothing to augment — issue no API calls.
+		return nil
+	}
+
+	// Account-wide merged maps. igw / dopt / vpc IDs are unique per
+	// account so merging per-region results is collision-free.
+	igwToVPC := make(map[string]string)
+	doptToVPCs := make(map[string]map[string]struct{})
+
+	for _, region := range regions {
+		client := clientFor(region)
+
+		if haveIGW {
+			igwPager := ec2.NewDescribeInternetGatewaysPaginator(client, &ec2.DescribeInternetGatewaysInput{})
+			for igwPager.HasMorePages() {
+				page, err := igwPager.NextPage(ctx)
+				if err != nil {
+					return fmt.Errorf("ec2:DescribeInternetGateways in %q: %w", region, err)
+				}
+				for _, igw := range page.InternetGateways {
+					id := aws.ToString(igw.InternetGatewayId)
+					if id == "" {
+						continue
+					}
+					// An IGW has at most one VPC attachment; take
+					// the first attachment with a non-empty VpcId.
+					for _, att := range igw.Attachments {
+						vpcID := aws.ToString(att.VpcId)
+						if vpcID != "" {
+							igwToVPC[id] = vpcID
+							break
+						}
+					}
+				}
+			}
+		}
+
+		if haveDHCP {
+			vpcPager := ec2.NewDescribeVpcsPaginator(client, &ec2.DescribeVpcsInput{})
+			for vpcPager.HasMorePages() {
+				page, err := vpcPager.NextPage(ctx)
+				if err != nil {
+					return fmt.Errorf("ec2:DescribeVpcs in %q: %w", region, err)
+				}
+				for _, vpc := range page.Vpcs {
+					vpcID := aws.ToString(vpc.VpcId)
+					doptID := aws.ToString(vpc.DhcpOptionsId)
+					if vpcID == "" || doptID == "" {
+						continue
+					}
+					set := doptToVPCs[doptID]
+					if set == nil {
+						set = make(map[string]struct{})
+						doptToVPCs[doptID] = set
+					}
+					set[vpcID] = struct{}{}
+				}
+			}
+		}
+	}
+
+	for i := range resources {
+		id := &resources[i].Identity
+		switch id.Type {
+		case "aws_internet_gateway":
+			if id.NativeIDs["vpc_id"] != "" {
+				continue
+			}
+			vpcID, ok := igwToVPC[id.ImportID]
+			if !ok || vpcID == "" {
+				continue
+			}
+			if id.NativeIDs == nil {
+				id.NativeIDs = map[string]string{}
+			}
+			id.NativeIDs["vpc_id"] = vpcID
+		case "aws_vpc_dhcp_options":
+			if id.NativeIDs["vpc_id"] != "" {
+				continue
+			}
+			vpcs := doptToVPCs[id.ImportID]
+			// A DHCP options set shared by multiple VPCs has no
+			// single parent — leave it unstamped.
+			if len(vpcs) != 1 {
+				continue
+			}
+			var vpcID string
+			for v := range vpcs {
+				vpcID = v
+			}
+			if vpcID == "" {
+				continue
+			}
+			if id.NativeIDs == nil {
+				id.NativeIDs = map[string]string{}
+			}
+			id.NativeIDs["vpc_id"] = vpcID
+		}
+	}
+
+	return nil
+}

--- a/cmd/insideout-import/awsdiscover/vpc_child_vpc_resolve_test.go
+++ b/cmd/insideout-import/awsdiscover/vpc_child_vpc_resolve_test.go
@@ -1,0 +1,463 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// fakeEC2VPCChildAPI is an injectable ec2VPCChildAPI for the
+// resolveVPCChildVPCIDs tests. It is pagination-aware: igwPages and
+// vpcPages hold an ordered queue of responses drained one per call,
+// with NextToken set on every page but the last so the production
+// HasMorePages() loop iterates through all of them. The convenience
+// fields igws / vpcs seed a single-page queue. A per-call counter is
+// recorded per method so a test can assert the "issue no API calls
+// when there is nothing to augment" contract.
+//
+// One fake instance backs one region; cross-region tests give clientFor
+// a region->*fakeEC2VPCChildAPI map so each region serves its own data.
+type fakeEC2VPCChildAPI struct {
+	igws []ec2types.InternetGateway
+	vpcs []ec2types.Vpc
+
+	// igwPages / vpcPages, when non-nil, take precedence over the
+	// single-page igws / vpcs fields and are served one entry per
+	// call, oldest first.
+	igwPages [][]ec2types.InternetGateway
+	vpcPages [][]ec2types.Vpc
+
+	err error
+
+	igwCalls int
+	vpcCalls int
+}
+
+func (f *fakeEC2VPCChildAPI) DescribeInternetGateways(_ context.Context, _ *ec2.DescribeInternetGatewaysInput, _ ...func(*ec2.Options)) (*ec2.DescribeInternetGatewaysOutput, error) {
+	f.igwCalls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	pages := f.igwPages
+	if pages == nil {
+		pages = [][]ec2types.InternetGateway{f.igws}
+	}
+	// igwCalls has already been incremented, so it is 1-based.
+	idx := f.igwCalls - 1
+	if idx >= len(pages) {
+		idx = len(pages) - 1
+	}
+	out := &ec2.DescribeInternetGatewaysOutput{InternetGateways: pages[idx]}
+	if idx < len(pages)-1 {
+		out.NextToken = aws.String("page")
+	}
+	return out, nil
+}
+
+func (f *fakeEC2VPCChildAPI) DescribeVpcs(_ context.Context, _ *ec2.DescribeVpcsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+	f.vpcCalls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	pages := f.vpcPages
+	if pages == nil {
+		pages = [][]ec2types.Vpc{f.vpcs}
+	}
+	idx := f.vpcCalls - 1
+	if idx >= len(pages) {
+		idx = len(pages) - 1
+	}
+	out := &ec2.DescribeVpcsOutput{Vpcs: pages[idx]}
+	if idx < len(pages)-1 {
+		out.NextToken = aws.String("page")
+	}
+	return out, nil
+}
+
+// igw builds an InternetGateway with an optional single VPC attachment.
+func igw(id, vpcID string) ec2types.InternetGateway {
+	g := ec2types.InternetGateway{InternetGatewayId: aws.String(id)}
+	if vpcID != "" {
+		g.Attachments = []ec2types.InternetGatewayAttachment{{VpcId: aws.String(vpcID)}}
+	}
+	return g
+}
+
+// igwMultiAttach builds an InternetGateway carrying multiple
+// attachments. Each vpcID is mapped to an InternetGatewayAttachment; an
+// empty-string vpcID yields an attachment with a nil VpcId, exercising
+// the production loop's "take the first attachment with a non-empty
+// VpcId" branch.
+func igwMultiAttach(id string, vpcIDs ...string) ec2types.InternetGateway {
+	g := ec2types.InternetGateway{InternetGatewayId: aws.String(id)}
+	for _, v := range vpcIDs {
+		att := ec2types.InternetGatewayAttachment{}
+		if v != "" {
+			att.VpcId = aws.String(v)
+		}
+		g.Attachments = append(g.Attachments, att)
+	}
+	return g
+}
+
+// vpc builds a Vpc carrying a DhcpOptionsId.
+func vpc(id, doptID string) ec2types.Vpc {
+	return ec2types.Vpc{VpcId: aws.String(id), DhcpOptionsId: aws.String(doptID)}
+}
+
+// nativeID returns the NativeIDs["vpc_id"] of the resource with the
+// given Address, or "" when absent.
+func nativeVPCID(rs []imported.ImportedResource, addr string) string {
+	for _, r := range rs {
+		if r.Identity.Address == addr {
+			return r.Identity.NativeIDs["vpc_id"]
+		}
+	}
+	return ""
+}
+
+func TestResolveVPCChildVPCIDs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// in is the discovery set; resolveVPCChildVPCIDs mutates it.
+		in []imported.ImportedResource
+		// fake is the EC2 API double serving the Describe* responses.
+		fake *fakeEC2VPCChildAPI
+		// wantErr pins an expected wrapped SDK error.
+		wantErr bool
+		// wantErrMsg lists substrings the wrapped error must contain
+		// (inner cause, the failing API name, and the region).
+		wantErrMsg []string
+		// wantVPCID maps a resource Address to the NativeIDs["vpc_id"]
+		// expected after the pass ("" = stays unstamped).
+		wantVPCID map[string]string
+		// wantIGWCalls / wantVPCCalls pin the API-call counters.
+		wantIGWCalls int
+		wantVPCCalls int
+	}{
+		{
+			name: "IGW gets vpc_id stamped from its attachment",
+			in: []imported.ImportedResource{
+				res("aws_internet_gateway", "aws_internet_gateway.igw", "igw-01", nil),
+			},
+			fake: &fakeEC2VPCChildAPI{igws: []ec2types.InternetGateway{igw("igw-01", "vpc-0abc")}},
+			wantVPCID: map[string]string{
+				"aws_internet_gateway.igw": "vpc-0abc",
+			},
+			wantIGWCalls: 1,
+			wantVPCCalls: 0,
+		},
+		{
+			name: "DHCP options set used by exactly one VPC gets vpc_id stamped",
+			in: []imported.ImportedResource{
+				res("aws_vpc_dhcp_options", "aws_vpc_dhcp_options.d", "dopt-01", nil),
+			},
+			fake: &fakeEC2VPCChildAPI{vpcs: []ec2types.Vpc{vpc("vpc-0abc", "dopt-01")}},
+			wantVPCID: map[string]string{
+				"aws_vpc_dhcp_options.d": "vpc-0abc",
+			},
+			wantIGWCalls: 0,
+			wantVPCCalls: 1,
+		},
+		{
+			name: "DHCP options set shared by two VPCs stays unstamped",
+			in: []imported.ImportedResource{
+				res("aws_vpc_dhcp_options", "aws_vpc_dhcp_options.d", "dopt-shared", nil),
+			},
+			fake: &fakeEC2VPCChildAPI{vpcs: []ec2types.Vpc{
+				vpc("vpc-0abc", "dopt-shared"),
+				vpc("vpc-0def", "dopt-shared"),
+			}},
+			wantVPCID: map[string]string{
+				"aws_vpc_dhcp_options.d": "",
+			},
+			wantIGWCalls: 0,
+			wantVPCCalls: 1,
+		},
+		{
+			name: "zero IGW/DHCP resources — no API calls made",
+			in: []imported.ImportedResource{
+				res("aws_vpc", "aws_vpc.main", "vpc-0abc", map[string]string{"name": "vpc-0abc"}),
+				res("aws_subnet", "aws_subnet.web", "subnet-01", map[string]string{"vpc_id": "vpc-0abc"}),
+			},
+			fake:         &fakeEC2VPCChildAPI{},
+			wantVPCID:    map[string]string{},
+			wantIGWCalls: 0,
+			wantVPCCalls: 0,
+		},
+		{
+			name: "only IGW present — DescribeVpcs not called",
+			in: []imported.ImportedResource{
+				res("aws_internet_gateway", "aws_internet_gateway.igw", "igw-01", nil),
+			},
+			fake: &fakeEC2VPCChildAPI{igws: []ec2types.InternetGateway{igw("igw-01", "vpc-0abc")}},
+			wantVPCID: map[string]string{
+				"aws_internet_gateway.igw": "vpc-0abc",
+			},
+			wantIGWCalls: 1,
+			wantVPCCalls: 0,
+		},
+		{
+			name: "only DHCP present — DescribeInternetGateways not called",
+			in: []imported.ImportedResource{
+				res("aws_vpc_dhcp_options", "aws_vpc_dhcp_options.d", "dopt-01", nil),
+			},
+			fake: &fakeEC2VPCChildAPI{vpcs: []ec2types.Vpc{vpc("vpc-0abc", "dopt-01")}},
+			wantVPCID: map[string]string{
+				"aws_vpc_dhcp_options.d": "vpc-0abc",
+			},
+			wantIGWCalls: 0,
+			wantVPCCalls: 1,
+		},
+		{
+			name: "IGW paginated across two pages — attachment on page 2 still stamps",
+			in: []imported.ImportedResource{
+				res("aws_internet_gateway", "aws_internet_gateway.igw", "igw-01", nil),
+			},
+			fake: &fakeEC2VPCChildAPI{igwPages: [][]ec2types.InternetGateway{
+				{igw("igw-noise", "vpc-noise")},
+				{igw("igw-01", "vpc-0abc")},
+			}},
+			wantVPCID: map[string]string{
+				"aws_internet_gateway.igw": "vpc-0abc",
+			},
+			wantIGWCalls: 2,
+		},
+		{
+			name: "DHCP/VPC paginated across two pages — VPC on page 2 still stamps",
+			in: []imported.ImportedResource{
+				res("aws_vpc_dhcp_options", "aws_vpc_dhcp_options.d", "dopt-01", nil),
+			},
+			fake: &fakeEC2VPCChildAPI{vpcPages: [][]ec2types.Vpc{
+				{vpc("vpc-noise", "dopt-noise")},
+				{vpc("vpc-0abc", "dopt-01")},
+			}},
+			wantVPCID: map[string]string{
+				"aws_vpc_dhcp_options.d": "vpc-0abc",
+			},
+			wantVPCCalls: 2,
+		},
+		{
+			name: "IGW with multiple attachments — first non-empty VpcId wins",
+			in: []imported.ImportedResource{
+				res("aws_internet_gateway", "aws_internet_gateway.igw", "igw-01", nil),
+			},
+			fake: &fakeEC2VPCChildAPI{igws: []ec2types.InternetGateway{
+				igwMultiAttach("igw-01", "", "vpc-real"),
+			}},
+			wantVPCID: map[string]string{
+				"aws_internet_gateway.igw": "vpc-real",
+			},
+			wantIGWCalls: 1,
+		},
+		{
+			name: "DHCP set with the same VPC id repeated still stamps (set dedup)",
+			in: []imported.ImportedResource{
+				res("aws_vpc_dhcp_options", "aws_vpc_dhcp_options.d", "dopt-01", nil),
+			},
+			// The same vpc id appears twice across two pages; a set
+			// collapses it to len 1, so the resource is still stamped.
+			// A naive counter would see 2 and leave it unstamped.
+			fake: &fakeEC2VPCChildAPI{vpcPages: [][]ec2types.Vpc{
+				{vpc("vpc-0abc", "dopt-01")},
+				{vpc("vpc-0abc", "dopt-01")},
+			}},
+			wantVPCID: map[string]string{
+				"aws_vpc_dhcp_options.d": "vpc-0abc",
+			},
+			wantVPCCalls: 2,
+		},
+		{
+			name: "SDK error from DescribeInternetGateways is returned wrapped",
+			in: []imported.ImportedResource{
+				res("aws_internet_gateway", "aws_internet_gateway.igw", "igw-01", nil),
+			},
+			fake:         &fakeEC2VPCChildAPI{err: errors.New("boom")},
+			wantErr:      true,
+			wantErrMsg:   []string{"boom", "DescribeInternetGateways", "us-east-1"},
+			wantIGWCalls: 1,
+		},
+		{
+			name: "SDK error from DescribeVpcs is returned wrapped",
+			in: []imported.ImportedResource{
+				res("aws_vpc_dhcp_options", "aws_vpc_dhcp_options.d", "dopt-01", nil),
+			},
+			fake:         &fakeEC2VPCChildAPI{err: errors.New("boom")},
+			wantErr:      true,
+			wantErrMsg:   []string{"boom", "DescribeVpcs", "us-east-1"},
+			wantVPCCalls: 1,
+		},
+		{
+			name: "IGW with no attachment stays unstamped",
+			in: []imported.ImportedResource{
+				res("aws_internet_gateway", "aws_internet_gateway.igw", "igw-detached", nil),
+			},
+			fake: &fakeEC2VPCChildAPI{igws: []ec2types.InternetGateway{igw("igw-detached", "")}},
+			wantVPCID: map[string]string{
+				"aws_internet_gateway.igw": "",
+			},
+			wantIGWCalls: 1,
+		},
+		{
+			name: "existing non-empty vpc_id is not overwritten",
+			in: []imported.ImportedResource{
+				res("aws_internet_gateway", "aws_internet_gateway.igw", "igw-01", map[string]string{"vpc_id": "vpc-preexisting"}),
+			},
+			fake: &fakeEC2VPCChildAPI{igws: []ec2types.InternetGateway{igw("igw-01", "vpc-0abc")}},
+			wantVPCID: map[string]string{
+				"aws_internet_gateway.igw": "vpc-preexisting",
+			},
+			wantIGWCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := resolveVPCChildVPCIDs(context.Background(), tt.in, []string{"us-east-1"},
+				func(string) ec2VPCChildAPI { return tt.fake })
+			if tt.wantErr {
+				require.Error(t, err)
+				for _, sub := range tt.wantErrMsg {
+					assert.Containsf(t, err.Error(), sub,
+						"wrapped SDK error must contain %q", sub)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+			for addr, want := range tt.wantVPCID {
+				assert.Equalf(t, want, nativeVPCID(tt.in, addr), "NativeIDs[vpc_id] of %s", addr)
+			}
+			assert.Equal(t, tt.wantIGWCalls, tt.fake.igwCalls, "DescribeInternetGateways call count")
+			assert.Equal(t, tt.wantVPCCalls, tt.fake.vpcCalls, "DescribeVpcs call count")
+		})
+	}
+}
+
+// TestResolveVPCChildVPCIDs_NoCallsWhenNothingToAugment pins the
+// hard-zero-API-calls contract: with no IGW and no DHCP-options resource
+// in the set, resolveVPCChildVPCIDs must short-circuit before touching
+// the client at all.
+func TestResolveVPCChildVPCIDs_NoCallsWhenNothingToAugment(t *testing.T) {
+	t.Parallel()
+	fake := &fakeEC2VPCChildAPI{}
+	clientCalls := 0
+	in := []imported.ImportedResource{
+		res("aws_vpc", "aws_vpc.main", "vpc-0abc", map[string]string{"name": "vpc-0abc"}),
+	}
+	err := resolveVPCChildVPCIDs(context.Background(), in, []string{"us-east-1", "us-west-2"},
+		func(string) ec2VPCChildAPI {
+			clientCalls++
+			return fake
+		})
+	require.NoError(t, err)
+	assert.Zero(t, clientCalls, "clientFor must not be invoked when there is nothing to augment")
+	assert.Zero(t, fake.igwCalls)
+	assert.Zero(t, fake.vpcCalls)
+}
+
+// TestResolveVPCChildVPCIDs_CrossRegionMerge pins the account-wide
+// merge contract: resolveVPCChildVPCIDs queries every region and merges
+// the per-region Describe results into account-wide maps. A resource
+// discovered in any region is stamped from whichever region's API call
+// surfaced its IGW / VPC.
+func TestResolveVPCChildVPCIDs_CrossRegionMerge(t *testing.T) {
+	t.Parallel()
+
+	// Each region returns disjoint IGWs / VPCs.
+	east := &fakeEC2VPCChildAPI{
+		igws: []ec2types.InternetGateway{igw("igw-east", "vpc-east")},
+		vpcs: []ec2types.Vpc{vpc("vpc-east", "dopt-east")},
+	}
+	west := &fakeEC2VPCChildAPI{
+		igws: []ec2types.InternetGateway{igw("igw-west", "vpc-west")},
+		vpcs: []ec2types.Vpc{vpc("vpc-west", "dopt-west")},
+	}
+	byRegion := map[string]*fakeEC2VPCChildAPI{
+		"us-east-1": east,
+		"us-west-2": west,
+	}
+
+	in := []imported.ImportedResource{
+		res("aws_internet_gateway", "aws_internet_gateway.e", "igw-east", nil),
+		res("aws_internet_gateway", "aws_internet_gateway.w", "igw-west", nil),
+		res("aws_vpc_dhcp_options", "aws_vpc_dhcp_options.e", "dopt-east", nil),
+		res("aws_vpc_dhcp_options", "aws_vpc_dhcp_options.w", "dopt-west", nil),
+	}
+	err := resolveVPCChildVPCIDs(context.Background(), in,
+		[]string{"us-east-1", "us-west-2"},
+		func(region string) ec2VPCChildAPI { return byRegion[region] })
+	require.NoError(t, err)
+
+	// Resources from both regions are stamped from the merged maps.
+	assert.Equal(t, "vpc-east", nativeVPCID(in, "aws_internet_gateway.e"))
+	assert.Equal(t, "vpc-west", nativeVPCID(in, "aws_internet_gateway.w"))
+	assert.Equal(t, "vpc-east", nativeVPCID(in, "aws_vpc_dhcp_options.e"))
+	assert.Equal(t, "vpc-west", nativeVPCID(in, "aws_vpc_dhcp_options.w"))
+
+	// Every region was queried for both resource families.
+	assert.Equal(t, 1, east.igwCalls, "us-east-1 DescribeInternetGateways")
+	assert.Equal(t, 1, east.vpcCalls, "us-east-1 DescribeVpcs")
+	assert.Equal(t, 1, west.igwCalls, "us-west-2 DescribeInternetGateways")
+	assert.Equal(t, 1, west.vpcCalls, "us-west-2 DescribeVpcs")
+}
+
+// TestResolveVPCChildVPCIDs_CrossRegionDHCPDedup pins the set-dedup
+// contract across regions: when the SAME vpc id is surfaced for one
+// DHCP options set by two different regions, the doptToVPCs set
+// collapses it to a single distinct VPC and the resource is still
+// stamped. A naive counter would see two and leave it unstamped.
+func TestResolveVPCChildVPCIDs_CrossRegionDHCPDedup(t *testing.T) {
+	t.Parallel()
+
+	// Both regions report the same (vpc-0abc -> dopt-01) edge.
+	byRegion := map[string]*fakeEC2VPCChildAPI{
+		"us-east-1": {vpcs: []ec2types.Vpc{vpc("vpc-0abc", "dopt-01")}},
+		"us-west-2": {vpcs: []ec2types.Vpc{vpc("vpc-0abc", "dopt-01")}},
+	}
+	in := []imported.ImportedResource{
+		res("aws_vpc_dhcp_options", "aws_vpc_dhcp_options.d", "dopt-01", nil),
+	}
+	err := resolveVPCChildVPCIDs(context.Background(), in,
+		[]string{"us-east-1", "us-west-2"},
+		func(region string) ec2VPCChildAPI { return byRegion[region] })
+	require.NoError(t, err)
+
+	assert.Equal(t, "vpc-0abc", nativeVPCID(in, "aws_vpc_dhcp_options.d"),
+		"duplicated vpc id must dedup to one distinct VPC and still stamp")
+}
+
+// TestResolveVPCChildVPCIDs_ThenParentAddresses is the end-to-end
+// contract: resolveVPCChildVPCIDs stamps NativeIDs["vpc_id"], then
+// resolveParentAddresses joins the IGW / DHCP-options children to their
+// parent aws_vpc via the new forward-edge FK rules (#651).
+func TestResolveVPCChildVPCIDs_ThenParentAddresses(t *testing.T) {
+	t.Parallel()
+	in := []imported.ImportedResource{
+		res("aws_vpc", "aws_vpc.main", "vpc-0abc", map[string]string{"name": "vpc-0abc"}),
+		res("aws_internet_gateway", "aws_internet_gateway.igw", "igw-01", nil),
+		res("aws_vpc_dhcp_options", "aws_vpc_dhcp_options.d", "dopt-01", nil),
+	}
+	fake := &fakeEC2VPCChildAPI{
+		igws: []ec2types.InternetGateway{igw("igw-01", "vpc-0abc")},
+		vpcs: []ec2types.Vpc{vpc("vpc-0abc", "dopt-01")},
+	}
+	err := resolveVPCChildVPCIDs(context.Background(), in, []string{"us-east-1"},
+		func(string) ec2VPCChildAPI { return fake })
+	require.NoError(t, err)
+
+	resolveParentAddresses(in)
+	got := parentAddrByAddress(in)
+	assert.Equal(t, "aws_vpc.main", got["aws_internet_gateway.igw"], "IGW parent")
+	assert.Equal(t, "aws_vpc.main", got["aws_vpc_dhcp_options.d"], "DHCP options parent")
+}


### PR DESCRIPTION
## Summary

Closes the last two `parentTfType` edges #650 could not resolve. `aws_internet_gateway` and `aws_vpc_dhcp_options` carry no VpcId in their Cloud Control models, so the #650 in-memory join left their `ParentAddress` empty — they were parked in `unresolvableChildTypes`.

- New `resolveVPCChildVPCIDs` SDK pass (`vpc_child_vpc_resolve.go`): runs once over the assembled discovery set, just before `resolveParentAddresses`. Issues `ec2:DescribeInternetGateways` (whose `Attachments[].VpcId` carries the IGW→VPC edge) and `ec2:DescribeVpcs` (whose `DhcpOptionsId` carries the VPC→DHCP-options edge), and stamps `NativeIDs["vpc_id"]` onto the matching resources. Issues no API calls when there is nothing to augment.
- A DHCP options set shared by multiple VPCs (e.g. the account-default `dopt-`) has no single parent and is left unstamped — mirrors the parameter-group "shared stays unlinked" rule.
- Both types become ordinary forward-edge FK rules (`childKey: "vpc_id"`) in `parentFKByChildType`; `unresolvableChildTypes` is now empty (all 18 edges resolvable) but retained as the documented-omission mechanism.
- A non-nil error from the pass is downgraded to a `ServiceWarn` — the parent links are best-effort and must not abort an otherwise-successful discovery run.

## Test plan
- [x] `go test ./cmd/insideout-import/awsdiscover/...` — 1090 pass
- [x] `gofmt -l` clean, `go vet` clean
- New table tests cover: pagination across pages, cross-region merge, multi-attachment IGW, DHCP set-dedup, no-API-calls short-circuit, wrapped SDK errors (both APIs), detached IGW, overwrite-protection, and an end-to-end stamp→`resolveParentAddresses` join.

## Review notes
- /review: no P0/P1/P2 findings. One P3 (first-region SDK error aborts remaining regions) — accepted as fail-fast-with-warn.
- qa-professor: initial review flagged untested pagination / cross-region merge / multi-attachment / set-dedup — all closed before this PR was opened.