### PR TITLE
fix(discovery): downgrade ErrNotFound enrich failures + stamp EnrichmentStatus (#654)

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_test.go
@@ -220,6 +220,40 @@ func TestNewAWSDiscoverer_RegistersAllSupportedTypes(t *testing.T) {
 	}
 }
 
+// TestEnricherCoverage_EverySupportedTypeHasEnricher pins issue #654's
+// "the static capability list must reflect reality" contract: every type
+// the discoverer offers via SupportedTypes() must have a registered
+// AttributeEnricher. Without this a type can be discoverable — and so
+// offered as importable — while silently lacking an enricher, which
+// yields empty Attrs and an uncomposable resource block.
+//
+// A type may be listed in enricherExemptTypes only with a documented
+// reason. The set is empty today: every supported AWS type has an
+// enricher, either hand-rolled or the generic Cloud Control fallback
+// registered for every cloudControlTypeConfigs entry. Per-type Attrs
+// population on the happy path is pinned by the individual
+// *_enrich_test.go suites and cloudcontrol_enricher_test.go; this test
+// guards the registration so a newly-added discoverer cannot ship
+// without a matching enricher.
+func TestEnricherCoverage_EverySupportedTypeHasEnricher(t *testing.T) {
+	t.Parallel()
+	// enricherExemptTypes lists supported types intentionally shipped
+	// without an enricher. Each entry needs a one-line rationale. Empty
+	// today — retained as the documented-exemption mechanism.
+	enricherExemptTypes := map[string]string{}
+
+	agg := NewAWSDiscoverer(awsDummyConfig())
+	for _, typ := range agg.SupportedTypes() {
+		if reason, exempt := enricherExemptTypes[typ]; exempt {
+			t.Logf("%s: enricher-exempt (%s)", typ, reason)
+			continue
+		}
+		if _, ok := agg.byTypeEnricher[typ]; !ok {
+			t.Errorf("supported type %q has no registered AttributeEnricher — it would discover with empty Attrs and an uncomposable resource block (#654); add an enricher or list it in enricherExemptTypes with a reason", typ)
+		}
+	}
+}
+
 // TestNewAWSDiscoverer_DiscoverByID_DispatchesAndPropagatesErrNotSupported
 // pins the aggregator's per-type dispatch contract: registered types
 // route to the matching discoverer; unregistered types return

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -368,11 +368,22 @@ func enrichWithRetry(ctx context.Context, fn func() error) error {
 // Errors are accumulated per-resource and surfaced together at the end
 // so a single mid-batch failure doesn't lose results from earlier
 // successful enrichments — a partial result is more useful than no
-// result. ErrEnrichClientUnavailable failures are downgraded to
-// progress.ServiceWarn events (and not included in the returned error)
-// since they reflect caller-side configuration, not API failures. The
-// returned error wraps the joined per-resource errors; callers may
-// inspect via errors.Is / errors.As.
+// result. Two error kinds are downgraded to progress.ServiceWarn events
+// (and not included in the returned error): ErrEnrichClientUnavailable,
+// which reflects caller-side configuration rather than an API failure,
+// and ErrNotFound, which is the expected per-resource outcome when the
+// resource (or a sub-resource the enricher reads) genuinely does not
+// exist — an S3 sub-resource that is unconfigured on its bucket, a Cloud
+// Control GetResource that 404s (issue #654). The returned error wraps
+// the joined per-resource errors for the remaining real failures;
+// callers may inspect via errors.Is / errors.As.
+//
+// Every enriched resource has its Identity.EnrichmentStatus /
+// EnrichErrors stamped: EnrichmentStatusFull on success,
+// EnrichmentStatusFailed (with the error text in EnrichErrors) on any
+// failure including the two downgraded kinds. This gives callers a
+// machine-readable per-resource signal that does not depend on
+// inspecting the returned joined error or on the absence of Attrs.
 //
 // emitter receives ItemFound per successfully enriched resource and
 // ServiceWarn per ErrEnrichClientUnavailable. The standard
@@ -458,14 +469,39 @@ func (a *AWSDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.Imp
 		err := results[pos]
 		switch {
 		case err == nil:
+			// Per-type enrichers marshal Attrs atomically today, so a
+			// nil return means Full. The Partial state is reserved for
+			// a future multi-call enricher (see issue #471).
+			irs[i].Identity.EnrichmentStatus = imported.EnrichmentStatusFull
+			irs[i].Identity.EnrichErrors = nil
 			emitter.ItemFound(enrichServiceSlug, irs[i].Identity.Region, irs[i].Identity.Type, irs[i].Identity.ImportID)
 		case errors.Is(err, ErrEnrichClientUnavailable):
 			// Client-side configuration failure — surface as a warn
 			// but don't accumulate as an error. Mirrors the GCP-side
-			// downgrade semantics.
+			// downgrade semantics. The typed signal on Identity lets
+			// downstream consumers distinguish this from a happy
+			// Identity-only IR (issue #471).
+			irs[i].Identity.EnrichmentStatus = imported.EnrichmentStatusFailed
+			irs[i].Identity.EnrichErrors = append(irs[i].Identity.EnrichErrors, err.Error())
+			emitter.ServiceWarn(enrichServiceSlug, "", fmt.Sprintf("%s/%s: %v", irs[i].Identity.Type, irs[i].Identity.Address, err))
+		case errors.Is(err, ErrNotFound):
+			// The resource ID parsed but the cloud-side resource — or a
+			// sub-resource the enricher reads — does not exist: an S3
+			// sub-resource genuinely unconfigured on its bucket, a Cloud
+			// Control GetResource that 404s, and so on. This is an
+			// expected per-resource outcome, not a batch failure, so it
+			// is downgraded to a warn and NOT accumulated into errs
+			// (issue #654). The typed EnrichmentStatusFailed marker lets
+			// the composer's drop-uncomposable filter elide the resource
+			// and lets callers flag it without inspecting Attrs.
+			irs[i].Identity.EnrichmentStatus = imported.EnrichmentStatusFailed
+			irs[i].Identity.EnrichErrors = append(irs[i].Identity.EnrichErrors, err.Error())
 			emitter.ServiceWarn(enrichServiceSlug, "", fmt.Sprintf("%s/%s: %v", irs[i].Identity.Type, irs[i].Identity.Address, err))
 		default:
-			errs = append(errs, fmt.Errorf("enrich %s/%s: %w", irs[i].Identity.Type, irs[i].Identity.Address, err))
+			wrapped := fmt.Errorf("enrich %s/%s: %w", irs[i].Identity.Type, irs[i].Identity.Address, err)
+			irs[i].Identity.EnrichmentStatus = imported.EnrichmentStatusFailed
+			irs[i].Identity.EnrichErrors = append(irs[i].Identity.EnrichErrors, wrapped.Error())
+			errs = append(errs, wrapped)
 		}
 	}
 	if len(errs) > 0 {

--- a/cmd/insideout-import/awsdiscover/enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/enrich_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -310,6 +311,14 @@ func TestEnrichAttributes_AccumulatesErrors(t *testing.T) {
 	// whack-a-mole.
 	assert.Contains(t, err.Error(), "a")
 	assert.Contains(t, err.Error(), "b")
+	// Each failed resource also carries the typed failure marker with
+	// the wrapped error text (#654).
+	assert.Equal(t, imported.EnrichmentStatusFailed, irs[0].Identity.EnrichmentStatus)
+	assert.Equal(t, imported.EnrichmentStatusFailed, irs[1].Identity.EnrichmentStatus)
+	require.NotEmpty(t, irs[0].Identity.EnrichErrors)
+	require.NotEmpty(t, irs[1].Identity.EnrichErrors)
+	assert.Contains(t, irs[0].Identity.EnrichErrors[0], "a")
+	assert.Contains(t, irs[1].Identity.EnrichErrors[0], "b")
 }
 
 func TestEnrichAttributes_DowngradesClientUnavailable(t *testing.T) {
@@ -332,6 +341,111 @@ func TestEnrichAttributes_DowngradesClientUnavailable(t *testing.T) {
 	require.Len(t, warns, 1, "exactly one ServiceWarn must be emitted for the unavailable client")
 	assert.Contains(t, warns[0].Message, "aws_dynamodb_table")
 	assert.Contains(t, warns[0].Message, "client unavailable")
+	// The downgrade still stamps the typed failure marker so a caller
+	// can distinguish this from a happy Identity-only IR (#654).
+	assert.Equal(t, imported.EnrichmentStatusFailed, irs[0].Identity.EnrichmentStatus)
+	assert.NotEmpty(t, irs[0].Identity.EnrichErrors)
+}
+
+// TestEnrichAttributes_DowngradesNotFound pins the #654 contract: an
+// enricher returning ErrNotFound — the resource, or a sub-resource it
+// reads, genuinely does not exist — is downgraded to a ServiceWarn and
+// NOT accumulated into the returned batch error, while still stamping
+// the typed EnrichmentStatusFailed marker so callers (and the composer's
+// drop-uncomposable filter) can flag the resource.
+func TestEnrichAttributes_DowngradesNotFound(t *testing.T) {
+	t.Parallel()
+	enr := &fakeEnricher{
+		tfType: "aws_dynamodb_table",
+		result: func(ir *imported.ImportedResource) error {
+			return fmt.Errorf("table %q: %w", ir.Identity.ImportID, ErrNotFound)
+		},
+	}
+	a := &AWSDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"aws_dynamodb_table": enr}}
+
+	rec := &recordingEmitter{}
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "t1", Address: "aws_dynamodb_table.t1"}},
+	}
+	err := a.EnrichAttributes(context.Background(), irs, EnrichClients{DynamoDB: &dynamodb.Client{}}, rec)
+	require.NoError(t, err, "ErrNotFound must downgrade to a warn, not a returned batch error")
+
+	warns := filterEvents(rec.snapshot(), "service_warn")
+	require.Len(t, warns, 1, "exactly one ServiceWarn must be emitted for the not-found resource")
+	assert.Contains(t, warns[0].Message, "aws_dynamodb_table")
+	assert.Contains(t, warns[0].Message, "t1",
+		"the warn message must carry the per-resource failure detail")
+
+	// A not-found resource is not a discovered item — ItemFound must
+	// not fire for it.
+	assert.Empty(t, filterEvents(rec.snapshot(), "item_found"),
+		"a not-found resource must not be reported as ItemFound")
+
+	assert.Equal(t, imported.EnrichmentStatusFailed, irs[0].Identity.EnrichmentStatus,
+		"a not-found resource must be stamped EnrichmentStatusFailed")
+	require.NotEmpty(t, irs[0].Identity.EnrichErrors, "EnrichErrors must carry the failure text")
+	assert.Contains(t, irs[0].Identity.EnrichErrors[0], "t1")
+}
+
+// TestEnrichAttributes_NotFoundDowngradedAlongsideRealError pins the
+// headline #654 interaction: in a heterogeneous batch an ErrNotFound
+// resource is downgraded (warn, no entry in the returned error) while a
+// genuine failure in the same pass is still accumulated — and both
+// resources are stamped EnrichmentStatusFailed.
+func TestEnrichAttributes_NotFoundDowngradedAlongsideRealError(t *testing.T) {
+	t.Parallel()
+	enr := &fakeEnricher{
+		tfType: "aws_dynamodb_table",
+		result: func(ir *imported.ImportedResource) error {
+			if ir.Identity.ImportID == "missing" {
+				return fmt.Errorf("table %q: %w", ir.Identity.ImportID, ErrNotFound)
+			}
+			return errors.New("403: " + ir.Identity.ImportID)
+		},
+	}
+	a := &AWSDiscoverer{byTypeEnricher: map[string]AttributeEnricher{"aws_dynamodb_table": enr}}
+
+	rec := &recordingEmitter{}
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "missing", Address: "aws_dynamodb_table.missing"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "denied", Address: "aws_dynamodb_table.denied"}},
+	}
+	err := a.EnrichAttributes(context.Background(), irs, EnrichClients{DynamoDB: &dynamodb.Client{}}, rec)
+
+	// The genuine 403 is still surfaced; the ErrNotFound resource is not.
+	require.Error(t, err, "a genuine failure must still be returned")
+	assert.Contains(t, err.Error(), "denied", "the real failure must be in the joined error")
+	assert.NotContains(t, err.Error(), "missing",
+		"the downgraded ErrNotFound resource must not appear in the joined error")
+
+	// Exactly one warn — for the downgraded ErrNotFound resource.
+	warns := filterEvents(rec.snapshot(), "service_warn")
+	require.Len(t, warns, 1)
+	assert.Contains(t, warns[0].Message, "missing")
+
+	// Both resources carry the typed failure marker regardless of which
+	// arm handled them.
+	assert.Equal(t, imported.EnrichmentStatusFailed, irs[0].Identity.EnrichmentStatus)
+	assert.Equal(t, imported.EnrichmentStatusFailed, irs[1].Identity.EnrichmentStatus)
+	assert.NotEmpty(t, irs[0].Identity.EnrichErrors)
+	assert.NotEmpty(t, irs[1].Identity.EnrichErrors)
+}
+
+// TestEnrichAttributes_StampsEnrichmentStatusFull pins that a successful
+// enrich stamps EnrichmentStatusFull and leaves EnrichErrors empty — the
+// machine-readable per-resource signal callers use instead of inspecting
+// Attrs or the joined batch error (#654).
+func TestEnrichAttributes_StampsEnrichmentStatusFull(t *testing.T) {
+	t.Parallel()
+	a := &AWSDiscoverer{byTypeEnricher: map[string]AttributeEnricher{
+		"aws_dynamodb_table": &fakeEnricher{tfType: "aws_dynamodb_table"},
+	}}
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", ImportID: "t1", Address: "aws_dynamodb_table.t1"}},
+	}
+	require.NoError(t, a.EnrichAttributes(context.Background(), irs, EnrichClients{DynamoDB: &dynamodb.Client{}}, nil))
+	assert.Equal(t, imported.EnrichmentStatusFull, irs[0].Identity.EnrichmentStatus)
+	assert.Empty(t, irs[0].Identity.EnrichErrors)
 }
 
 func TestEnrichAttributes_EmitsItemFoundOnSuccess(t *testing.T) {


### PR DESCRIPTION
## Summary

`EnrichAttributes` (AWS) had no `ErrNotFound` case — every enricher that soft-failed with `ErrNotFound` (S3 sub-resources unconfigured on their bucket, Cloud Control `GetResource` 404s, resourceexplorer/IAM lookups that miss) fell into the `default` arm: accumulated as a batch-fatal error and left with `Attrs` nil. That is the enrichment gap behind the uncomposable `imported.tf` failures in #654.

- **`ErrNotFound` downgrade** — treated like `ErrEnrichClientUnavailable`: surfaced as a `ServiceWarn`, **not** accumulated into the returned batch error. A not-configured sub-resource is an expected per-resource outcome, not a run failure. Genuine failures in the same batch are still returned.
- **`EnrichmentStatus`/`EnrichErrors` stamping (AC2)** — every enriched resource now gets `Identity.EnrichmentStatus` (`full`/`failed`) + `EnrichErrors` stamped. The AWS orchestrator previously never wrote these; this ports the stamping the GCP sibling already does, making the `identity.go` field doc ("Set by the EnrichAttributes orchestrator") true for AWS too.
- **Coverage test (AC3)** — `TestEnricherCoverage_EverySupportedTypeHasEnricher` enumerates `SupportedTypes()` and asserts each has a registered `AttributeEnricher`, with a documented (empty) exemption allowlist — a discoverable type can never silently ship without an enricher.

### Note on AC1

The issue's premise — "10 types have no working enricher" — was **inaccurate**. Investigation confirmed all 10 have real enrichers that populate `Attrs` on the happy path. The single root cause was the missing `ErrNotFound` arm in the orchestrator. No type needs removal from `SupportedTypes()`; the new coverage test verifies every supported type has an enricher today.

The stack-breaking symptom in the issue title was separately mitigated by #652/#657 (composer's `dropUncomposable`); this PR closes the upstream enrichment gap that fed it.

## Test plan
- [x] `go test ./cmd/insideout-import/...` — 2705 pass
- [x] `gofmt -l` clean, `go vet` clean
- New tests: `ErrNotFound` downgrade (single + mixed-batch alongside a genuine error), `EnrichmentStatus` stamping on success/failure/client-unavailable, ItemFound suppression on the downgrade path, and the `SupportedTypes()` enricher-coverage guard.

## Review notes
- /review + qa-professor run pre-PR. qa-professor flagged a missing mixed-batch interaction test, ItemFound-suppression assertion, and weak `EnrichErrors` content checks — all addressed before this PR opened.

Closes #654