### PR TITLE
feat(awsdiscover): hand-rolled attribute enricher for aws_iam_policy

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -299,10 +299,18 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 		// cloudcontrol_types.go for the wiring).
 		"aws_dynamodb_contributor_insights": newDDBContributorInsightsEnricher(),
 		"aws_dynamodb_table":                newDynamoDBTableEnricher(),
-		"aws_iam_role_policy_attachment":    newIAMRolePolicyAttachmentEnricher(),
-		"aws_resourceexplorer2_index":       newResourceExplorer2IndexEnricher(),
-		"aws_resourceexplorer2_view":        newResourceExplorer2ViewEnricher(),
-		"aws_s3_bucket":                     newS3BucketEnricher(),
+		// aws_iam_policy: hand-rolled override (#661). The generic
+		// Cloud Control enricher's jsonStringifyField("PolicyDocument",
+		// "Policy") normalizer assumes GetResource returns a nested
+		// PolicyDocument, which the CFN AWS::IAM::ManagedPolicy schema
+		// often omits — leaving the REQUIRED `policy` argument empty.
+		// This enricher reads the document via iam:GetPolicy +
+		// iam:GetPolicyVersion instead. See iam_policy_enrich.go.
+		"aws_iam_policy":                 newIAMPolicyEnricher(),
+		"aws_iam_role_policy_attachment": newIAMRolePolicyAttachmentEnricher(),
+		"aws_resourceexplorer2_index":    newResourceExplorer2IndexEnricher(),
+		"aws_resourceexplorer2_view":     newResourceExplorer2ViewEnricher(),
+		"aws_s3_bucket":                  newS3BucketEnricher(),
 		// S3 bucket sub-resource enrichers — all five share the
 		// EnrichClients.S3 client; the per-bucket GetBucket* SDK calls
 		// fan out one-at-a-time and produce the typed Layer-1 payload

--- a/cmd/insideout-import/awsdiscover/iam_policy_enrich.go
+++ b/cmd/insideout-import/awsdiscover/iam_policy_enrich.go
@@ -1,0 +1,317 @@
+// Package awsdiscover — IAM customer-managed policy attribute enricher
+// (#661).
+//
+// Pairs with the Cloud-Control-routed `aws_iam_policy` discoverer
+// registered in cloudControlTypeConfigs ("AWS::IAM::ManagedPolicy").
+//
+// **Why a hand-rolled override**: `aws_iam_policy.policy` is a REQUIRED
+// JSON-encoded string. The generic Cloud Control enricher relies on the
+// `jsonStringifyField("PolicyDocument", "Policy")` normalizer (#1621),
+// which assumes Cloud Control's GetResource returns a nested
+// `PolicyDocument` property. The CFN AWS::IAM::ManagedPolicy schema
+// treats `PolicyDocument` as create-time *input*, not a stably-readable
+// property — GetResource frequently omits it. The normalizer is
+// fail-open, so the required `policy` argument is silently left empty
+// and the composer flags the resource `imported_resource_missing_
+// required_attr`.
+//
+// This enricher does the two standard IAM read calls instead:
+//
+//  1. iam:GetPolicy(PolicyArn)            → Policy.DefaultVersionId
+//     (plus Name / Path / Description / Tags metadata).
+//  2. iam:GetPolicyVersion(PolicyArn, V)  → PolicyVersion.Document,
+//     a URL-encoded (RFC 3986) JSON string that is URL-decoded and
+//     re-compacted into the `policy` argument.
+//
+// Soft-fails NoSuchEntity onto ErrNotFound so a policy deleted between
+// discovery and enrichment downgrades to a per-resource warn rather
+// than failing the batch (issue #654 semantics).
+//
+// **Computed-only / TF-input-only fields skipped per decision #5:**
+//   - `arn` (Computed) — stamped on ir.Identity.NativeIDs["arn"]
+//     instead, matching the secretsmanager_secret pattern.
+//   - `attachment_count`, `policy_id` (Computed).
+//   - `id` (Optional+Computed alias for ARN).
+//   - `name_prefix` (Optional+Computed; provider derives Name from it).
+//   - `tags_all` (Computed; provider merges defaults at plan time).
+//   - `delay_after_policy_creation_in_ms` (TF-input only; no API
+//     source).
+package awsdiscover
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// iamPolicyTFType is the registered Terraform type for the IAM policy
+// enricher. Kept as a constant so the registry / ResourceType() stay
+// in lockstep.
+const iamPolicyTFType = "aws_iam_policy"
+
+// iamPolicyData is the combined result of the two IAM read calls the
+// enricher issues. Policy carries the GetPolicy metadata; Document is
+// the URL-decoded + JSON-compacted policy document from the default
+// policy version.
+type iamPolicyData struct {
+	Policy   *iamtypes.Policy
+	Document string
+}
+
+// iamPolicyEnricher implements both AttributeEnricher and ByIDEnricher
+// for aws_iam_policy.
+type iamPolicyEnricher struct {
+	// fetch is overridable for tests. Defaults to the real two-call
+	// GetPolicy + GetPolicyVersion path against the iam.Client in
+	// EnrichClients. Tests inject a fake by constructing the enricher
+	// with a custom fetch — keeps the enricher hermetically testable
+	// without spinning up an HTTP server for the SDK client.
+	fetch func(ctx context.Context, c *iam.Client, policyARN string) (*iamPolicyData, error)
+}
+
+// newIAMPolicyEnricher returns the production-wired enricher.
+// AWSDiscoverer's byTypeEnricher map registers this under
+// "aws_iam_policy", overriding the generic Cloud Control fallback.
+func newIAMPolicyEnricher() *iamPolicyEnricher {
+	return &iamPolicyEnricher{fetch: defaultIAMPolicyFetch}
+}
+
+func (iamPolicyEnricher) ResourceType() string { return iamPolicyTFType }
+
+// Enrich populates ir.Attrs with a typed AWSIAMPolicy payload for the
+// policy identified by ir.Identity. Returns ErrEnrichClientUnavailable
+// if EnrichClients.IAM is nil, ErrNotFound if the policy no longer
+// exists, and any other error reflects a real IAM API failure.
+func (e iamPolicyEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if c.IAM == nil {
+		return ErrEnrichClientUnavailable
+	}
+	arn := iamPolicyARNForEnrich(&ir.Identity)
+	if arn == "" {
+		return fmt.Errorf("%s: cannot derive policy ARN from Identity (Address=%q ImportID=%q)",
+			iamPolicyTFType, ir.Identity.Address, ir.Identity.ImportID)
+	}
+	data, err := e.fetch(ctx, c.IAM, arn)
+	if err != nil {
+		if isAPIErrorCode(err, "NoSuchEntity", "NoSuchEntityException") {
+			return fmt.Errorf("%s %q: %w", iamPolicyTFType, arn, ErrNotFound)
+		}
+		return fmt.Errorf("%s: fetch %q: %w", iamPolicyTFType, arn, err)
+	}
+	if data == nil {
+		return fmt.Errorf("%s: fetch %q: empty response", iamPolicyTFType, arn)
+	}
+
+	// Stamp ARN on Identity.NativeIDs so downstream consumers don't
+	// have to round-trip back to the SDK for the ARN. The pure-mapping
+	// helper does NOT touch ir.Identity per the AttributeEnricher
+	// contract; this is the only place Enrich writes to it. Prefer the
+	// API-returned ARN, falling back to the ARN the lookup used.
+	stampARN := arn
+	if data.Policy != nil {
+		if a := aws.ToString(data.Policy.Arn); a != "" {
+			stampARN = a
+		}
+	}
+	if ir.Identity.NativeIDs == nil {
+		ir.Identity.NativeIDs = map[string]string{}
+	}
+	ir.Identity.NativeIDs["arn"] = stampARN
+
+	raw, err := json.Marshal(mapIAMPolicy(data))
+	if err != nil {
+		return fmt.Errorf("%s: marshal Attrs: %w", iamPolicyTFType, err)
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID fetches the typed AWSIAMPolicy payload for the policy
+// named by identity and returns it as the json.RawMessage shape that
+// would land in ImportedResource.Attrs. Shares the SDK calls + mapping
+// with Enrich via the private fetch hook + mapIAMPolicy helper so the
+// two paths cannot drift out of sync. Does not mutate identity.
+func (e iamPolicyEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.IAM == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if identity == nil {
+		return nil, errors.New(iamPolicyTFType + ": identity is nil")
+	}
+	arn := iamPolicyARNForEnrich(identity)
+	if arn == "" {
+		return nil, fmt.Errorf("%s: cannot derive policy ARN from Identity (Address=%q ImportID=%q)",
+			iamPolicyTFType, identity.Address, identity.ImportID)
+	}
+	data, err := e.fetch(ctx, c.IAM, arn)
+	if err != nil {
+		if isAPIErrorCode(err, "NoSuchEntity", "NoSuchEntityException") {
+			return nil, fmt.Errorf("%s %q: %w", iamPolicyTFType, arn, ErrNotFound)
+		}
+		return nil, fmt.Errorf("%s: fetch %q: %w", iamPolicyTFType, arn, err)
+	}
+	if data == nil {
+		return nil, fmt.Errorf("%s: fetch %q: empty response", iamPolicyTFType, arn)
+	}
+	raw, err := json.Marshal(mapIAMPolicy(data))
+	if err != nil {
+		return nil, fmt.Errorf("%s: marshal Attrs: %w", iamPolicyTFType, err)
+	}
+	return raw, nil
+}
+
+// iamPolicyARNForEnrich derives the PolicyArn argument for GetPolicy.
+// Both iam:GetPolicy and iam:GetPolicyVersion require the full ARN —
+// the bare policy name is not accepted — so NameHint (the policy name)
+// is intentionally NOT a fallback here.
+//
+// Preference order:
+//
+//  1. Identity.NativeIDs["arn"] — the Cloud Control discoverer's
+//     NativeIDsFromProperties stamps the policy ARN here.
+//  2. Identity.ImportID — the discoverer's passthroughImportID emits
+//     the policy ARN as the import ID for aws_iam_policy.
+func iamPolicyARNForEnrich(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if s := strings.TrimSpace(id.NativeIDs["arn"]); s != "" {
+		return s
+	}
+	return strings.TrimSpace(id.ImportID)
+}
+
+// iamPolicyAPI is the narrow subset of the IAM API the aws_iam_policy
+// enricher's fetch path issues. The real *iam.Client and in-test fakes
+// both satisfy it, so the two-call orchestration in
+// fetchIAMPolicyWithClient is unit-testable without a stubbed HTTP
+// transport. Mirrors the narrow-client-interface convention in
+// sdkonly_iam.go.
+type iamPolicyAPI interface {
+	GetPolicy(ctx context.Context, in *iam.GetPolicyInput, opts ...func(*iam.Options)) (*iam.GetPolicyOutput, error)
+	GetPolicyVersion(ctx context.Context, in *iam.GetPolicyVersionInput, opts ...func(*iam.Options)) (*iam.GetPolicyVersionOutput, error)
+}
+
+// defaultIAMPolicyFetch is the production fetch path: it wires the real
+// *iam.Client into fetchIAMPolicyWithClient, which holds the two-call
+// orchestration logic behind the narrow iamPolicyAPI interface.
+func defaultIAMPolicyFetch(ctx context.Context, c *iam.Client, policyARN string) (*iamPolicyData, error) {
+	if c == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	return fetchIAMPolicyWithClient(ctx, c, policyARN)
+}
+
+// fetchIAMPolicyWithClient calls GetPolicy to resolve the default
+// version ID and metadata, then GetPolicyVersion to retrieve the policy
+// document. The document is URL-encoded (RFC 3986) and is decoded +
+// compacted by decodeIAMPolicyDocument.
+func fetchIAMPolicyWithClient(ctx context.Context, c iamPolicyAPI, policyARN string) (*iamPolicyData, error) {
+	gp, err := c.GetPolicy(ctx, &iam.GetPolicyInput{PolicyArn: aws.String(policyARN)})
+	if err != nil {
+		return nil, fmt.Errorf("iam:GetPolicy: %w", err)
+	}
+	if gp == nil || gp.Policy == nil {
+		return nil, errors.New("iam:GetPolicy: nil policy in response")
+	}
+	versionID := aws.ToString(gp.Policy.DefaultVersionId)
+	if versionID == "" {
+		return nil, errors.New("iam:GetPolicy: response carries no DefaultVersionId")
+	}
+	gpv, err := c.GetPolicyVersion(ctx, &iam.GetPolicyVersionInput{
+		PolicyArn: aws.String(policyARN),
+		VersionId: aws.String(versionID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("iam:GetPolicyVersion: %w", err)
+	}
+	if gpv == nil || gpv.PolicyVersion == nil {
+		return nil, errors.New("iam:GetPolicyVersion: nil policy version in response")
+	}
+	doc, err := decodeIAMPolicyDocument(aws.ToString(gpv.PolicyVersion.Document))
+	if err != nil {
+		return nil, fmt.Errorf("iam:GetPolicyVersion: decode document: %w", err)
+	}
+	return &iamPolicyData{Policy: gp.Policy, Document: doc}, nil
+}
+
+// decodeIAMPolicyDocument turns the raw GetPolicyVersion document into
+// the compact JSON string that lands in `aws_iam_policy.policy`.
+//
+// The IAM API returns the document URL-encoded compliant with RFC 3986;
+// url.QueryUnescape reverses that. If unescaping fails the raw value is
+// used as-is (some callers / fakes pass an already-decoded document).
+// The result is then re-compacted via json.Compact so the emitted
+// `policy` string is stable regardless of the API's whitespace — a
+// non-JSON document is a hard error since `policy` must be valid JSON.
+//
+// An empty document yields an empty string (the caller omits the
+// `policy` field entirely in that case).
+func decodeIAMPolicyDocument(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	decoded, err := url.QueryUnescape(raw)
+	if err != nil {
+		decoded = raw
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, []byte(decoded)); err != nil {
+		return "", fmt.Errorf("policy document is not valid JSON: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// mapIAMPolicy is the pure-mapping helper shared by Enrich and
+// EnrichByID. Every field is emitted only when present on the API
+// response so the resulting HCL stays decision-#34 clean (no
+// "field = null" noise).
+func mapIAMPolicy(d *iamPolicyData) *generated.AWSIAMPolicy {
+	typed := &generated.AWSIAMPolicy{}
+	if d == nil {
+		return typed
+	}
+	if p := d.Policy; p != nil {
+		if name := aws.ToString(p.PolicyName); name != "" {
+			typed.Name = generated.LiteralOf(name)
+		}
+		if path := aws.ToString(p.Path); path != "" {
+			typed.Path = generated.LiteralOf(path)
+		}
+		if desc := aws.ToString(p.Description); desc != "" {
+			typed.Description = generated.LiteralOf(desc)
+		}
+		if len(p.Tags) > 0 {
+			m := map[string]*generated.Value[string]{}
+			for _, t := range p.Tags {
+				if t.Key != nil {
+					m[*t.Key] = generated.LiteralOf(aws.ToString(t.Value))
+				}
+			}
+			if len(m) > 0 {
+				typed.Tags = m
+			}
+		}
+	}
+	if d.Document != "" {
+		typed.Policy = generated.LiteralOf(d.Document)
+	}
+	return typed
+}
+
+// Compile-time assertions.
+var (
+	_ AttributeEnricher = (*iamPolicyEnricher)(nil)
+	_ ByIDEnricher      = (*iamPolicyEnricher)(nil)
+)

--- a/cmd/insideout-import/awsdiscover/iam_policy_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/iam_policy_enrich_test.go
@@ -1,0 +1,509 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// samplePolicyDocument is a minimal valid IAM policy document used
+// across the tests below.
+const samplePolicyDocument = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`
+
+// fakeIAMPolicyAPI is a hand-rolled iamPolicyAPI fake: each method
+// returns the canned output/error stored on the struct and records the
+// argument it was called with so tests can assert call wiring.
+type fakeIAMPolicyAPI struct {
+	getPolicyOut *iam.GetPolicyOutput
+	getPolicyErr error
+
+	getVersionOut *iam.GetPolicyVersionOutput
+	getVersionErr error
+
+	gotPolicyARN     string // PolicyArn passed to GetPolicy
+	gotVersionARN    string // PolicyArn passed to GetPolicyVersion
+	gotVersionID     string // VersionId passed to GetPolicyVersion
+	getVersionCalled bool
+}
+
+func (f *fakeIAMPolicyAPI) GetPolicy(_ context.Context, in *iam.GetPolicyInput, _ ...func(*iam.Options)) (*iam.GetPolicyOutput, error) {
+	f.gotPolicyARN = aws.ToString(in.PolicyArn)
+	return f.getPolicyOut, f.getPolicyErr
+}
+
+func (f *fakeIAMPolicyAPI) GetPolicyVersion(_ context.Context, in *iam.GetPolicyVersionInput, _ ...func(*iam.Options)) (*iam.GetPolicyVersionOutput, error) {
+	f.getVersionCalled = true
+	f.gotVersionARN = aws.ToString(in.PolicyArn)
+	f.gotVersionID = aws.ToString(in.VersionId)
+	return f.getVersionOut, f.getVersionErr
+}
+
+var _ iamPolicyAPI = (*fakeIAMPolicyAPI)(nil)
+
+func TestIAMPolicyEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "aws_iam_policy", newIAMPolicyEnricher().ResourceType())
+}
+
+func TestIAMPolicyEnricher_NilClient(t *testing.T) {
+	t.Parallel()
+	enr := iamPolicyEnricher{}
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			NativeIDs: map[string]string{"arn": "arn:aws:iam::123456789012:policy/MyPolicy"},
+		},
+	}, EnrichClients{})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestIAMPolicyEnricher_CannotResolveARN(t *testing.T) {
+	t.Parallel()
+	enr := iamPolicyEnricher{}
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{},
+	}, EnrichClients{IAM: &iam.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive policy ARN")
+}
+
+func TestIAMPolicyEnricher_HappyPath(t *testing.T) {
+	t.Parallel()
+	const lookupARN = "arn:aws:iam::123456789012:policy/MyPolicy"
+	// The API-returned ARN differs from the lookup ARN so the test can
+	// prove the stamp prefers the API value.
+	const apiARN = "arn:aws:iam::123456789012:policy/some/path/MyPolicy"
+	enr := iamPolicyEnricher{fetch: func(_ context.Context, _ *iam.Client, gotARN string) (*iamPolicyData, error) {
+		assert.Equal(t, lookupARN, gotARN)
+		return &iamPolicyData{
+			Policy: &iamtypes.Policy{
+				Arn:         aws.String(apiARN),
+				PolicyName:  aws.String("MyPolicy"),
+				Path:        aws.String("/some/path/"),
+				Description: aws.String("my managed policy"),
+				Tags: []iamtypes.Tag{
+					{Key: aws.String("Project"), Value: aws.String("io-abc")},
+				},
+			},
+			Document: samplePolicyDocument,
+		}, nil
+	}}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{
+		ImportID: lookupARN,
+	}}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{IAM: &iam.Client{}}))
+
+	// The API-returned ARN wins over the lookup ARN when stamping.
+	assert.Equal(t, apiARN, ir.Identity.NativeIDs["arn"])
+
+	var got generated.AWSIAMPolicy
+	require.NoError(t, json.Unmarshal(ir.Attrs, &got))
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "MyPolicy", *got.Name.Literal)
+	require.NotNil(t, got.Path)
+	assert.Equal(t, "/some/path/", *got.Path.Literal)
+	require.NotNil(t, got.Description)
+	assert.Equal(t, "my managed policy", *got.Description.Literal)
+	require.NotNil(t, got.Policy)
+	assert.JSONEq(t, samplePolicyDocument, *got.Policy.Literal)
+	require.NotNil(t, got.Tags["Project"])
+	assert.Equal(t, "io-abc", *got.Tags["Project"].Literal)
+
+	// Computed-only fields are NOT populated (decision #5).
+	assert.Nil(t, got.ARN)
+	assert.Nil(t, got.AttachmentCount)
+	assert.Nil(t, got.PolicyID)
+	assert.Nil(t, got.ID)
+}
+
+func TestIAMPolicyEnricher_StampFallsBackToLookupARN(t *testing.T) {
+	t.Parallel()
+	const lookupARN = "arn:aws:iam::123456789012:policy/MyPolicy"
+	// Policy.Arn is nil — the stamp must fall back to the lookup ARN.
+	enr := iamPolicyEnricher{fetch: func(context.Context, *iam.Client, string) (*iamPolicyData, error) {
+		return &iamPolicyData{
+			Policy:   &iamtypes.Policy{PolicyName: aws.String("MyPolicy")},
+			Document: samplePolicyDocument,
+		}, nil
+	}}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: lookupARN}}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{IAM: &iam.Client{}}))
+	assert.Equal(t, lookupARN, ir.Identity.NativeIDs["arn"])
+}
+
+func TestIAMPolicyEnricher_NoSuchEntityMapsToNotFound(t *testing.T) {
+	t.Parallel()
+	for _, code := range []string{"NoSuchEntity", "NoSuchEntityException"} {
+		t.Run(code, func(t *testing.T) {
+			t.Parallel()
+			enr := iamPolicyEnricher{fetch: func(context.Context, *iam.Client, string) (*iamPolicyData, error) {
+				return nil, &fakeIAMSmithyErr{code: code}
+			}}
+			err := enr.Enrich(context.Background(), &imported.ImportedResource{
+				Identity: imported.ResourceIdentity{ImportID: "arn:aws:iam::123456789012:policy/Gone"},
+			}, EnrichClients{IAM: &iam.Client{}})
+			require.ErrorIs(t, err, ErrNotFound)
+		})
+	}
+}
+
+func TestIAMPolicyEnricher_AccessDeniedIsNotNotFound(t *testing.T) {
+	t.Parallel()
+	// A non-NoSuchEntity smithy error must NOT be downgraded to
+	// ErrNotFound — it is a real failure the batch should surface.
+	enr := iamPolicyEnricher{fetch: func(context.Context, *iam.Client, string) (*iamPolicyData, error) {
+		return nil, &fakeIAMSmithyErr{code: "AccessDenied"}
+	}}
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{ImportID: "arn:aws:iam::123456789012:policy/Denied"},
+	}, EnrichClients{IAM: &iam.Client{}})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound)
+	// The ARN is wrapped into the error context.
+	assert.Contains(t, err.Error(), "arn:aws:iam::123456789012:policy/Denied")
+}
+
+func TestIAMPolicyEnricher_UnexpectedErrorPropagates(t *testing.T) {
+	t.Parallel()
+	want := errors.New("boom")
+	enr := iamPolicyEnricher{fetch: func(context.Context, *iam.Client, string) (*iamPolicyData, error) {
+		return nil, want
+	}}
+	err := enr.Enrich(context.Background(), &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{ImportID: "arn:aws:iam::123456789012:policy/X"},
+	}, EnrichClients{IAM: &iam.Client{}})
+	require.ErrorIs(t, err, want)
+	assert.Contains(t, err.Error(), "arn:aws:iam::123456789012:policy/X")
+}
+
+func TestIAMPolicyEnricher_EmptyResponseIsError(t *testing.T) {
+	t.Parallel()
+	// fetch returning (nil, nil) must surface as an explicit error,
+	// not a silently-empty Attrs payload.
+	enr := iamPolicyEnricher{fetch: func(context.Context, *iam.Client, string) (*iamPolicyData, error) {
+		return nil, nil
+	}}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{ImportID: "arn:aws:iam::123456789012:policy/X"},
+	}
+	err := enr.Enrich(context.Background(), ir, EnrichClients{IAM: &iam.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+	assert.Nil(t, ir.Attrs)
+}
+
+func TestIAMPolicyEnricher_EnrichByID(t *testing.T) {
+	t.Parallel()
+	const arn = "arn:aws:iam::123456789012:policy/MyPolicy"
+	enr := iamPolicyEnricher{fetch: func(context.Context, *iam.Client, string) (*iamPolicyData, error) {
+		return &iamPolicyData{
+			Policy:   &iamtypes.Policy{Arn: aws.String(arn), PolicyName: aws.String("MyPolicy")},
+			Document: samplePolicyDocument,
+		}, nil
+	}}
+	identity := &imported.ResourceIdentity{NativeIDs: map[string]string{"arn": arn}}
+	raw, err := enr.EnrichByID(context.Background(), identity, EnrichClients{IAM: &iam.Client{}})
+	require.NoError(t, err)
+
+	// EnrichByID must not mutate identity — unlike Enrich, it does not
+	// stamp the ARN or any other field. NativeIDs is left exactly as
+	// the caller passed it.
+	assert.Equal(t, map[string]string{"arn": arn}, identity.NativeIDs)
+	assert.Empty(t, identity.Address)
+
+	var got generated.AWSIAMPolicy
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.NotNil(t, got.Policy)
+	assert.JSONEq(t, samplePolicyDocument, *got.Policy.Literal)
+}
+
+func TestIAMPolicyEnricher_EnrichByID_NilClient(t *testing.T) {
+	t.Parallel()
+	enr := iamPolicyEnricher{}
+	_, err := enr.EnrichByID(context.Background(),
+		&imported.ResourceIdentity{NativeIDs: map[string]string{"arn": "arn:x"}}, EnrichClients{})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestIAMPolicyEnricher_EnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	enr := iamPolicyEnricher{}
+	_, err := enr.EnrichByID(context.Background(), nil, EnrichClients{IAM: &iam.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity is nil")
+}
+
+func TestIAMPolicyEnricher_EnrichByID_NotFound(t *testing.T) {
+	t.Parallel()
+	enr := iamPolicyEnricher{fetch: func(context.Context, *iam.Client, string) (*iamPolicyData, error) {
+		return nil, &fakeIAMSmithyErr{code: "NoSuchEntityException"}
+	}}
+	_, err := enr.EnrichByID(context.Background(),
+		&imported.ResourceIdentity{ImportID: "arn:aws:iam::123456789012:policy/Gone"},
+		EnrichClients{IAM: &iam.Client{}})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestIAMPolicyEnricher_EnrichByID_EmptyResponseIsError(t *testing.T) {
+	t.Parallel()
+	enr := iamPolicyEnricher{fetch: func(context.Context, *iam.Client, string) (*iamPolicyData, error) {
+		return nil, nil
+	}}
+	_, err := enr.EnrichByID(context.Background(),
+		&imported.ResourceIdentity{ImportID: "arn:aws:iam::123456789012:policy/X"},
+		EnrichClients{IAM: &iam.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+}
+
+func TestIAMPolicyARNForEnrich(t *testing.T) {
+	t.Parallel()
+	t.Run("NativeIDs wins", func(t *testing.T) {
+		t.Parallel()
+		got := iamPolicyARNForEnrich(&imported.ResourceIdentity{
+			NativeIDs: map[string]string{"arn": "arn:native"},
+			ImportID:  "arn:import",
+		})
+		assert.Equal(t, "arn:native", got)
+	})
+	t.Run("ImportID fallback", func(t *testing.T) {
+		t.Parallel()
+		got := iamPolicyARNForEnrich(&imported.ResourceIdentity{ImportID: "arn:import"})
+		assert.Equal(t, "arn:import", got)
+	})
+	t.Run("nil identity", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "", iamPolicyARNForEnrich(nil))
+	})
+	t.Run("NameHint is not a fallback", func(t *testing.T) {
+		t.Parallel()
+		// GetPolicy requires a full ARN; the bare policy name in
+		// NameHint must not be used.
+		got := iamPolicyARNForEnrich(&imported.ResourceIdentity{NameHint: "MyPolicy"})
+		assert.Equal(t, "", got)
+	})
+	t.Run("whitespace is trimmed", func(t *testing.T) {
+		t.Parallel()
+		got := iamPolicyARNForEnrich(&imported.ResourceIdentity{NativeIDs: map[string]string{"arn": "  arn:x  "}})
+		assert.Equal(t, "arn:x", got)
+	})
+}
+
+func TestDecodeIAMPolicyDocument(t *testing.T) {
+	t.Parallel()
+	t.Run("URL-encoded document is decoded", func(t *testing.T) {
+		t.Parallel()
+		// The IAM API returns the document URL-encoded (RFC 3986).
+		encoded := url.QueryEscape(samplePolicyDocument)
+		got, err := decodeIAMPolicyDocument(encoded)
+		require.NoError(t, err)
+		assert.JSONEq(t, samplePolicyDocument, got)
+	})
+	t.Run("already-decoded document is compacted", func(t *testing.T) {
+		t.Parallel()
+		pretty := "{\n  \"Version\": \"2012-10-17\"\n}"
+		got, err := decodeIAMPolicyDocument(pretty)
+		require.NoError(t, err)
+		assert.Equal(t, `{"Version":"2012-10-17"}`, got)
+	})
+	t.Run("malformed escape falls back to raw", func(t *testing.T) {
+		t.Parallel()
+		// A bare "%" is not a valid escape; url.QueryUnescape errors,
+		// the raw value is used as-is and then compacted.
+		got, err := decodeIAMPolicyDocument(`{"k": "100% done"}`)
+		require.NoError(t, err)
+		assert.Equal(t, `{"k":"100% done"}`, got)
+	})
+	t.Run("empty document yields empty string", func(t *testing.T) {
+		t.Parallel()
+		got, err := decodeIAMPolicyDocument("")
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
+	t.Run("non-JSON document is an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := decodeIAMPolicyDocument("not json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not valid JSON")
+	})
+}
+
+func TestMapIAMPolicy(t *testing.T) {
+	t.Parallel()
+	t.Run("nil input yields empty struct", func(t *testing.T) {
+		t.Parallel()
+		got := mapIAMPolicy(nil)
+		require.NotNil(t, got)
+		assert.Nil(t, got.Name)
+		assert.Nil(t, got.Policy)
+	})
+	t.Run("empty document omits policy field", func(t *testing.T) {
+		t.Parallel()
+		got := mapIAMPolicy(&iamPolicyData{
+			Policy:   &iamtypes.Policy{PolicyName: aws.String("P")},
+			Document: "",
+		})
+		assert.Nil(t, got.Policy, "empty document must leave policy unset")
+		require.NotNil(t, got.Name)
+	})
+	t.Run("empty-string metadata fields are omitted", func(t *testing.T) {
+		t.Parallel()
+		got := mapIAMPolicy(&iamPolicyData{
+			Policy: &iamtypes.Policy{
+				PolicyName:  aws.String(""),
+				Path:        aws.String(""),
+				Description: aws.String(""),
+			},
+			Document: samplePolicyDocument,
+		})
+		assert.Nil(t, got.Name)
+		assert.Nil(t, got.Path)
+		assert.Nil(t, got.Description)
+	})
+	t.Run("nil-key tag is skipped without panic", func(t *testing.T) {
+		t.Parallel()
+		got := mapIAMPolicy(&iamPolicyData{
+			Policy: &iamtypes.Policy{
+				Tags: []iamtypes.Tag{
+					{Key: nil, Value: aws.String("orphan")},
+					{Key: aws.String("Project"), Value: aws.String("io-abc")},
+				},
+			},
+		})
+		require.Len(t, got.Tags, 1)
+		require.NotNil(t, got.Tags["Project"])
+		assert.Equal(t, "io-abc", *got.Tags["Project"].Literal)
+	})
+	t.Run("all-nil-key tags yield nil map", func(t *testing.T) {
+		t.Parallel()
+		got := mapIAMPolicy(&iamPolicyData{
+			Policy: &iamtypes.Policy{
+				Tags: []iamtypes.Tag{{Key: nil, Value: aws.String("orphan")}},
+			},
+		})
+		assert.Nil(t, got.Tags, "a tag map with no usable keys must stay nil, not {}")
+	})
+}
+
+func TestFetchIAMPolicyWithClient(t *testing.T) {
+	t.Parallel()
+	const arn = "arn:aws:iam::123456789012:policy/MyPolicy"
+
+	t.Run("happy path wires DefaultVersionId into GetPolicyVersion", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeIAMPolicyAPI{
+			getPolicyOut: &iam.GetPolicyOutput{Policy: &iamtypes.Policy{
+				Arn:              aws.String(arn),
+				PolicyName:       aws.String("MyPolicy"),
+				DefaultVersionId: aws.String("v3"),
+			}},
+			getVersionOut: &iam.GetPolicyVersionOutput{PolicyVersion: &iamtypes.PolicyVersion{
+				Document: aws.String(url.QueryEscape(samplePolicyDocument)),
+			}},
+		}
+		data, err := fetchIAMPolicyWithClient(context.Background(), f, arn)
+		require.NoError(t, err)
+		require.NotNil(t, data)
+		// GetPolicy and GetPolicyVersion both received the ARN.
+		assert.Equal(t, arn, f.gotPolicyARN)
+		assert.Equal(t, arn, f.gotVersionARN)
+		// GetPolicyVersion was called with the version id GetPolicy
+		// reported as the default — not a hard-coded value.
+		assert.Equal(t, "v3", f.gotVersionID)
+		assert.JSONEq(t, samplePolicyDocument, data.Document)
+	})
+
+	t.Run("GetPolicy error is wrapped", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeIAMPolicyAPI{getPolicyErr: errors.New("boom")}
+		_, err := fetchIAMPolicyWithClient(context.Background(), f, arn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "iam:GetPolicy")
+		assert.False(t, f.getVersionCalled, "GetPolicyVersion must not run after GetPolicy fails")
+	})
+
+	t.Run("nil Policy in GetPolicy response is an error", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeIAMPolicyAPI{getPolicyOut: &iam.GetPolicyOutput{Policy: nil}}
+		_, err := fetchIAMPolicyWithClient(context.Background(), f, arn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil policy")
+		assert.False(t, f.getVersionCalled)
+	})
+
+	t.Run("missing DefaultVersionId is an error", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeIAMPolicyAPI{getPolicyOut: &iam.GetPolicyOutput{Policy: &iamtypes.Policy{
+			Arn: aws.String(arn),
+		}}}
+		_, err := fetchIAMPolicyWithClient(context.Background(), f, arn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "DefaultVersionId")
+		assert.False(t, f.getVersionCalled)
+	})
+
+	t.Run("GetPolicyVersion error is wrapped", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeIAMPolicyAPI{
+			getPolicyOut: &iam.GetPolicyOutput{Policy: &iamtypes.Policy{
+				DefaultVersionId: aws.String("v1"),
+			}},
+			getVersionErr: errors.New("boom"),
+		}
+		_, err := fetchIAMPolicyWithClient(context.Background(), f, arn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "iam:GetPolicyVersion")
+	})
+
+	t.Run("nil PolicyVersion in response is an error", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeIAMPolicyAPI{
+			getPolicyOut: &iam.GetPolicyOutput{Policy: &iamtypes.Policy{
+				DefaultVersionId: aws.String("v1"),
+			}},
+			getVersionOut: &iam.GetPolicyVersionOutput{PolicyVersion: nil},
+		}
+		_, err := fetchIAMPolicyWithClient(context.Background(), f, arn)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil policy version")
+	})
+
+	t.Run("NoSuchEntity from GetPolicy surfaces and maps to NotFound", func(t *testing.T) {
+		t.Parallel()
+		// fetchIAMPolicyWithClient wraps the smithy error; the enricher
+		// then maps it to ErrNotFound via isAPIErrorCode (errors.As
+		// unwraps through the fmt.Errorf %w chain).
+		f := &fakeIAMPolicyAPI{getPolicyErr: &fakeIAMSmithyErr{code: "NoSuchEntity"}}
+		_, err := fetchIAMPolicyWithClient(context.Background(), f, arn)
+		require.Error(t, err)
+		assert.True(t, isAPIErrorCode(err, "NoSuchEntity"),
+			"wrapped smithy error must remain inspectable through the wrap chain")
+	})
+}
+
+func TestDefaultIAMPolicyFetch_NilClient(t *testing.T) {
+	t.Parallel()
+	_, err := defaultIAMPolicyFetch(context.Background(), nil, "arn:x")
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestIAMPolicyEnricher_RegisteredAsOverride(t *testing.T) {
+	t.Parallel()
+	// The hand-rolled enricher must win over the generic Cloud Control
+	// fallback for aws_iam_policy (#661).
+	d := NewAWSDiscoverer(aws.Config{Region: "us-east-1"})
+	enr, ok := d.byTypeEnricher["aws_iam_policy"]
+	require.True(t, ok, "aws_iam_policy must have a registered enricher")
+	_, isHandRolled := enr.(*iamPolicyEnricher)
+	assert.True(t, isHandRolled, "aws_iam_policy enricher must be the hand-rolled override, got %T", enr)
+}


### PR DESCRIPTION
## Summary
- `aws_iam_policy` rode the generic Cloud Control enricher path, whose `jsonStringifyField("PolicyDocument", "Policy")` normalizer assumes `GetResource` returns a nested `PolicyDocument`. The CFN `AWS::IAM::ManagedPolicy` schema treats `PolicyDocument` as create-time *input*, not a stably-readable property, so `GetResource` frequently omits it — the fail-open normalizer then leaves the **REQUIRED** `policy` argument empty and the composer flags `imported_resource_missing_required_attr`.
- Adds a hand-rolled `AttributeEnricher` / `ByIDEnricher` for `aws_iam_policy`, registered in `byTypeEnricher` so it overrides the Cloud Control fallback (same mechanism `aws_dynamodb_table` / `aws_secretsmanager_secret` use).
- The enricher does the two standard IAM read calls — `iam:GetPolicy` for the default version id + metadata, `iam:GetPolicyVersion` for the URL-encoded policy document — then URL-decodes and JSON-compacts the document into `policy`. `NoSuchEntity` soft-fails onto `ErrNotFound`.

## Test plan
- [x] `go test ./cmd/insideout-import/awsdiscover/ -count=1` — 1126 pass
- [x] `go vet ./cmd/insideout-import/awsdiscover/` — clean
- [x] New tests cover `Enrich`, `EnrichByID`, the two-call orchestration (`fetchIAMPolicyWithClient` via a narrow `iamPolicyAPI` fake), `mapIAMPolicy` edge cases, `decodeIAMPolicyDocument`, and the registry override

## Review notes
- /review findings: no P0/P1/P2 in production code
- qa-professor findings: all addressed — added a narrow `iamPolicyAPI` interface + `fetchIAMPolicyWithClient` seam so the production fetch orchestration is unit-tested (was 0%), plus direct `mapIAMPolicy` table tests (nil input, empty document, empty-string fields, nil-key tags), distinct API-vs-lookup ARN stamping, empty-response guards, `AccessDenied`-is-not-`NotFound`, and the malformed-escape fallback

## Related / follow-up
- The same two-call gap exists for `aws_lambda_function` code, `aws_iam_role` inline/assume-role policies, and remaining `aws_s3_bucket` sub-resources — a sweep is worth a separate ticket (noted in #661).
- Downstream: luthersystems/reliable#1694 (compose no longer hard-fails on the un-composable resource — complementary).

Closes #661