### PR TITLE
feat(awsdiscover): policy-document enricher sweep — iam_role, iam_role_policy, s3_bucket_policy, lambda

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -299,18 +299,27 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 		// cloudcontrol_types.go for the wiring).
 		"aws_dynamodb_contributor_insights": newDDBContributorInsightsEnricher(),
 		"aws_dynamodb_table":                newDynamoDBTableEnricher(),
-		// aws_iam_policy: hand-rolled override (#661). The generic
-		// Cloud Control enricher's jsonStringifyField("PolicyDocument",
-		// "Policy") normalizer assumes GetResource returns a nested
-		// PolicyDocument, which the CFN AWS::IAM::ManagedPolicy schema
-		// often omits — leaving the REQUIRED `policy` argument empty.
-		// This enricher reads the document via iam:GetPolicy +
-		// iam:GetPolicyVersion instead. See iam_policy_enrich.go.
+		// aws_iam_policy / aws_iam_role / aws_iam_role_policy: hand-
+		// rolled overrides (#661 + follow-up). The generic Cloud Control
+		// enricher leaves these resources' REQUIRED JSON-document
+		// arguments (`policy`, `assume_role_policy`) empty — the CFN
+		// schemas treat the policy document as create-time input, not a
+		// stably-readable property, so GetResource omits it. Each
+		// enricher reads the document via the matching IAM Get* API
+		// instead. See iam_policy_enrich.go / iam_role_enrich.go /
+		// iam_role_policy_enrich.go.
 		"aws_iam_policy":                 newIAMPolicyEnricher(),
+		"aws_iam_role":                   newIAMRoleEnricher(),
+		"aws_iam_role_policy":            newIAMRolePolicyEnricher(),
 		"aws_iam_role_policy_attachment": newIAMRolePolicyAttachmentEnricher(),
 		"aws_resourceexplorer2_index":    newResourceExplorer2IndexEnricher(),
 		"aws_resourceexplorer2_view":     newResourceExplorer2ViewEnricher(),
 		"aws_s3_bucket":                  newS3BucketEnricher(),
+		// aws_s3_bucket_policy: hand-rolled override (#661 follow-up) —
+		// the REQUIRED `policy` argument has the same CC-path gap; the
+		// enricher reads it via s3:GetBucketPolicy. See
+		// s3_bucket_policy_enrich.go.
+		"aws_s3_bucket_policy": newS3BucketPolicyEnricher(),
 		// S3 bucket sub-resource enrichers — all five share the
 		// EnrichClients.S3 client; the per-bucket GetBucket* SDK calls
 		// fan out one-at-a-time and produce the typed Layer-1 payload
@@ -355,6 +364,18 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 		byTypeEnricher[ccCfg.TFType] = newCloudControlEnricherWithNormalizer(
 			ccCfg.TFType, ccCfg.CloudFormationType, nil, normalizer,
 		)
+	}
+	// aws_lambda_function: composite enricher (#661 follow-up). Unlike
+	// the policy-document enrichers above, lambda is NOT a full hand-
+	// rolled override — the Cloud Control path already maps the large
+	// AWS::Lambda::Function surface well. The composite delegates the
+	// bulk to the CC enricher the loop just registered, then issues one
+	// lambda:GetFunction call to recover the code attributes CC cannot
+	// read back (`image_uri` / `package_type` for container-image
+	// functions). Wrapping the already-built CC enricher keeps the
+	// composite in lockstep with any future CC lambda normalizer change.
+	if cc, ok := byTypeEnricher["aws_lambda_function"]; ok {
+		byTypeEnricher["aws_lambda_function"] = newLambdaFunctionEnricher(cc)
 	}
 	disc := &AWSDiscoverer{
 		defaultRegion:  cfg.Region,

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
@@ -234,10 +235,18 @@ type EnrichClients struct {
 	// ErrEnrichClientUnavailable.
 	APIGatewayV2 *apigatewayv2.Client
 	// IAM is the shared client for IAM hand-rolled enrichers
-	// (aws_iam_role_policy_attachment). IAM is a global service, so
-	// no per-region override is needed. Nil is tolerated and surfaces
-	// as ErrEnrichClientUnavailable.
+	// (aws_iam_role_policy_attachment, aws_iam_policy, aws_iam_role,
+	// aws_iam_role_policy). IAM is a global service, so no per-region
+	// override is needed. Nil is tolerated and surfaces as
+	// ErrEnrichClientUnavailable.
 	IAM *iam.Client
+	// Lambda is the shared client for the aws_lambda_function code
+	// enricher (#661 follow-up). Lambda is regional; the enricher
+	// applies a per-call region override via an Options closure so a
+	// single client serves every region in the run. Nil is tolerated:
+	// the lambda enricher still delegates to the Cloud Control path
+	// and simply skips the GetFunction-sourced code attributes.
+	Lambda *lambda.Client
 	// AutoScaling is the shared client for the
 	// aws_autoscaling_group_tag enricher (#482 final-2 push). Auto
 	// Scaling is regional, so the enricher's fetch closure pins the

--- a/cmd/insideout-import/awsdiscover/enrich_policy_e2e_test.go
+++ b/cmd/insideout-import/awsdiscover/enrich_policy_e2e_test.go
@@ -1,0 +1,373 @@
+//go:build integration
+
+// End-to-end confirmation for the policy-document attribute enrichers
+// (#661 + follow-up): aws_iam_policy, aws_iam_role, aws_iam_role_policy,
+// aws_s3_bucket_policy and the aws_lambda_function code overlay.
+//
+// Self-contained harness: the test provisions throwaway IAM / S3 /
+// Lambda resources in the live account via the AWS SDK, runs the real
+// registered enrichers through AWSDiscoverer.EnrichAttributes (the same
+// dispatch the discover command uses), asserts every required policy-
+// document attribute is populated with valid JSON, then tears every
+// resource down via t.Cleanup — so a passing run leaves no residue and
+// a mid-run failure still cleans up.
+//
+// Provisioning uses the AWS SDK rather than a terraform-exec wrapper:
+// it needs no `terraform` binary or provider download inside the test,
+// gives deterministic Cleanup-based teardown, and exercises exactly
+// what #661 is about — real cloud resources fed through the real
+// enrichers. The decision-#34 `terraform plan` zero-diff assertion
+// stays in the downstream reliable integration suite (which owns the
+// composer.EmitImportedTF + terraform rig), as noted in
+// dynamodb_table_enrich_live_test.go.
+//
+// Run (from a shell with AWS creds loaded, e.g. aws_jump <acct> <role>):
+//
+//	go test -tags=integration ./cmd/insideout-import/awsdiscover/... \
+//	    -v -run TestE2E661_PolicyDocumentEnrichers -timeout 15m
+//
+// Skips (not fails) when AWS credentials cannot be resolved so a
+// no-creds CI invocation is a no-op.
+
+package awsdiscover
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// e2eTrustPolicy is the role trust policy (lambda service principal so
+// the same role can back the test Lambda function).
+const e2eTrustPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}`
+
+// e2ePermissionPolicy is the document used for both the managed policy
+// and the inline role policy.
+const e2ePermissionPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["logs:CreateLogStream","logs:PutLogEvents"],"Resource":"*"}]}`
+
+// TestE2E661_PolicyDocumentEnrichers is the end-to-end confirmation.
+func TestE2E661_PolicyDocumentEnrichers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+	defer cancel()
+
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		t.Skipf("AWS config not resolvable, skipping: %v", err)
+	}
+	if cfg.Region == "" {
+		cfg.Region = "us-east-1"
+	}
+	region := cfg.Region
+
+	// Credentials precondition — skip (not fail) when creds are absent.
+	if _, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}); err != nil {
+		t.Skipf("STS GetCallerIdentity failed (no usable AWS creds), skipping: %v", err)
+	}
+
+	iamc := iam.NewFromConfig(cfg)
+	s3c := s3.NewFromConfig(cfg)
+	lambdac := lambda.NewFromConfig(cfg)
+
+	// Unique, collision-proof naming for this run.
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	roleName := "io-e2e661-role-" + suffix
+	inlineName := "io-e2e661-inline-" + suffix
+	managedName := "io-e2e661-managed-" + suffix
+	bucketName := "io-e2e661-bucket-" + suffix
+	fnName := "io-e2e661-fn-" + suffix
+
+	// ---- Provision: IAM role -------------------------------------------
+	createRoleOut, err := iamc.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(e2eTrustPolicy),
+		Description:              aws.String("insideout 661 e2e - safe to delete"),
+		MaxSessionDuration:       aws.Int32(3600),
+		Tags:                     []iamtypes.Tag{{Key: aws.String("Project"), Value: aws.String("io-e2e661")}},
+	})
+	require.NoError(t, err, "CreateRole")
+	roleARN := aws.ToString(createRoleOut.Role.Arn)
+	t.Cleanup(func() {
+		if _, err := iamc.DeleteRole(context.Background(), &iam.DeleteRoleInput{RoleName: aws.String(roleName)}); err != nil {
+			t.Logf("cleanup DeleteRole(%s): %v", roleName, err)
+		}
+	})
+
+	// ---- Provision: inline role policy ---------------------------------
+	_, err = iamc.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		RoleName:       aws.String(roleName),
+		PolicyName:     aws.String(inlineName),
+		PolicyDocument: aws.String(e2ePermissionPolicy),
+	})
+	require.NoError(t, err, "PutRolePolicy")
+	t.Cleanup(func() {
+		if _, err := iamc.DeleteRolePolicy(context.Background(), &iam.DeleteRolePolicyInput{
+			RoleName: aws.String(roleName), PolicyName: aws.String(inlineName),
+		}); err != nil {
+			t.Logf("cleanup DeleteRolePolicy(%s): %v", inlineName, err)
+		}
+	})
+
+	// ---- Provision: managed policy -------------------------------------
+	createPolicyOut, err := iamc.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String(managedName),
+		PolicyDocument: aws.String(e2ePermissionPolicy),
+		Description:    aws.String("insideout 661 e2e - safe to delete"),
+		Tags:           []iamtypes.Tag{{Key: aws.String("Project"), Value: aws.String("io-e2e661")}},
+	})
+	require.NoError(t, err, "CreatePolicy")
+	managedARN := aws.ToString(createPolicyOut.Policy.Arn)
+	t.Cleanup(func() {
+		if _, err := iamc.DeletePolicy(context.Background(), &iam.DeletePolicyInput{PolicyArn: aws.String(managedARN)}); err != nil {
+			t.Logf("cleanup DeletePolicy(%s): %v", managedARN, err)
+		}
+	})
+
+	// ---- Provision: S3 bucket + bucket policy --------------------------
+	require.NoError(t, e2eCreateBucket(ctx, s3c, bucketName, region), "CreateBucket")
+	t.Cleanup(func() {
+		if _, err := s3c.DeleteBucket(context.Background(), &s3.DeleteBucketInput{Bucket: aws.String(bucketName)}); err != nil {
+			t.Logf("cleanup DeleteBucket(%s): %v", bucketName, err)
+		}
+	})
+	bucketPolicy := fmt.Sprintf(
+		`{"Version":"2012-10-17","Statement":[{"Sid":"DenyInsecureTransport","Effect":"Deny","Principal":"*","Action":"s3:*","Resource":["arn:aws:s3:::%s","arn:aws:s3:::%s/*"],"Condition":{"Bool":{"aws:SecureTransport":"false"}}}]}`,
+		bucketName, bucketName)
+	_, err = s3c.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{
+		Bucket: aws.String(bucketName),
+		Policy: aws.String(bucketPolicy),
+	})
+	require.NoError(t, err, "PutBucketPolicy")
+	// DeleteBucketPolicy is implied by DeleteBucket, but delete it
+	// explicitly first so a DeleteBucket retry isn't blocked by it.
+	t.Cleanup(func() {
+		if _, err := s3c.DeleteBucketPolicy(context.Background(), &s3.DeleteBucketPolicyInput{Bucket: aws.String(bucketName)}); err != nil {
+			t.Logf("cleanup DeleteBucketPolicy(%s): %v", bucketName, err)
+		}
+	})
+
+	// ---- Provision: Lambda function (zip package) ----------------------
+	// IAM role propagation is eventually consistent; CreateFunction
+	// rejects an as-yet-unpropagated role with InvalidParameterValue.
+	fnARN := e2eCreateLambda(ctx, t, lambdac, fnName, roleARN)
+	if fnARN != "" {
+		t.Cleanup(func() {
+			if _, err := lambdac.DeleteFunction(context.Background(), &lambda.DeleteFunctionInput{FunctionName: aws.String(fnName)}); err != nil {
+				t.Logf("cleanup DeleteFunction(%s): %v", fnName, err)
+			}
+		})
+	}
+
+	// ---- Enrich: run the real registered enrichers ---------------------
+	clients := EnrichClients{
+		IAM:          iamc,
+		S3:           s3c,
+		Lambda:       lambdac,
+		CloudControl: cloudcontrol.NewFromConfig(cfg),
+	}
+	disc := NewAWSDiscoverer(cfg)
+
+	// Identities shaped exactly as the Cloud Control discoverers stamp
+	// them (see cloudControlTypeConfigs).
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{
+			Type: "aws_iam_policy", Address: "aws_iam_policy.e2e",
+			ImportID: managedARN, NameHint: managedName, Region: region,
+			NativeIDs: map[string]string{"arn": managedARN},
+		}},
+		{Identity: imported.ResourceIdentity{
+			Type: "aws_iam_role", Address: "aws_iam_role.e2e",
+			ImportID: roleName, NameHint: roleName, Region: region,
+		}},
+		{Identity: imported.ResourceIdentity{
+			Type: "aws_iam_role_policy", Address: "aws_iam_role_policy.e2e",
+			ImportID: roleName + ":" + inlineName, NameHint: inlineName, Region: region,
+			NativeIDs: map[string]string{"role_name": roleName, "policy_name": inlineName},
+		}},
+		{Identity: imported.ResourceIdentity{
+			Type: "aws_s3_bucket_policy", Address: "aws_s3_bucket_policy.e2e",
+			ImportID: bucketName, NameHint: bucketName, Region: region,
+			NativeIDs: map[string]string{"bucket": bucketName},
+		}},
+	}
+	if fnARN != "" {
+		irs = append(irs, imported.ImportedResource{Identity: imported.ResourceIdentity{
+			Type: "aws_lambda_function", Address: "aws_lambda_function.e2e",
+			ImportID: fnName, NameHint: fnName, Region: region,
+			NativeIDs: map[string]string{"arn": fnARN},
+		}})
+	}
+
+	if err := disc.EnrichAttributes(ctx, irs, clients, nil); err != nil {
+		t.Fatalf("EnrichAttributes returned error: %v", err)
+	}
+
+	byType := map[string]*imported.ImportedResource{}
+	for i := range irs {
+		byType[irs[i].Identity.Type] = &irs[i]
+	}
+
+	t.Run("aws_iam_policy/policy populated", func(t *testing.T) {
+		ir := byType["aws_iam_policy"]
+		requireEnrichedFull(t, ir)
+		var got generated.AWSIAMPolicy
+		require.NoError(t, json.Unmarshal(ir.Attrs, &got))
+		requireJSONLiteral(t, got.Policy, "policy")
+		require.NotNil(t, got.Name)
+		assert.Equal(t, managedName, *got.Name.Literal)
+	})
+
+	t.Run("aws_iam_role/assume_role_policy populated", func(t *testing.T) {
+		ir := byType["aws_iam_role"]
+		requireEnrichedFull(t, ir)
+		var got generated.AWSIAMRole
+		require.NoError(t, json.Unmarshal(ir.Attrs, &got))
+		requireJSONLiteral(t, got.AssumeRolePolicy, "assume_role_policy")
+		require.NotNil(t, got.Name)
+		assert.Equal(t, roleName, *got.Name.Literal)
+	})
+
+	t.Run("aws_iam_role_policy/policy populated", func(t *testing.T) {
+		ir := byType["aws_iam_role_policy"]
+		requireEnrichedFull(t, ir)
+		var got generated.AWSIAMRolePolicy
+		require.NoError(t, json.Unmarshal(ir.Attrs, &got))
+		requireJSONLiteral(t, got.Policy, "policy")
+		require.NotNil(t, got.Role)
+		assert.Equal(t, roleName, *got.Role.Literal)
+	})
+
+	t.Run("aws_s3_bucket_policy/policy populated", func(t *testing.T) {
+		ir := byType["aws_s3_bucket_policy"]
+		requireEnrichedFull(t, ir)
+		var got generated.AWSS3BucketPolicy
+		require.NoError(t, json.Unmarshal(ir.Attrs, &got))
+		requireJSONLiteral(t, got.Policy, "policy")
+		require.NotNil(t, got.Bucket)
+		assert.Equal(t, bucketName, *got.Bucket.Literal)
+	})
+
+	t.Run("aws_lambda_function/package_type populated", func(t *testing.T) {
+		ir := byType["aws_lambda_function"]
+		if ir == nil {
+			t.Skip("lambda function was not provisioned (see provisioning log)")
+		}
+		requireEnrichedFull(t, ir)
+		var got generated.AWSLambdaFunction
+		require.NoError(t, json.Unmarshal(ir.Attrs, &got))
+		// The composite enricher stamps the authoritative package_type
+		// from lambda:GetFunction. Our test function is a zip package.
+		require.NotNil(t, got.PackageType, "package_type must be set by the code overlay")
+		assert.Equal(t, "Zip", *got.PackageType.Literal)
+		// CC still mapped the bulk of the function.
+		require.NotNil(t, got.FunctionName)
+		assert.Equal(t, fnName, *got.FunctionName.Literal)
+	})
+}
+
+// requireEnrichedFull asserts the enricher succeeded for ir.
+func requireEnrichedFull(t *testing.T, ir *imported.ImportedResource) {
+	t.Helper()
+	require.NotNil(t, ir, "resource missing from enriched set")
+	require.Equalf(t, imported.EnrichmentStatusFull, ir.Identity.EnrichmentStatus,
+		"%s enrichment not Full: status=%v errors=%v", ir.Identity.Type, ir.Identity.EnrichmentStatus, ir.Identity.EnrichErrors)
+	require.NotEmpty(t, ir.Attrs, "%s Attrs empty", ir.Identity.Type)
+}
+
+// requireJSONLiteral asserts v holds a non-empty, valid-JSON literal.
+func requireJSONLiteral(t *testing.T, v *generated.Value[string], field string) {
+	t.Helper()
+	require.NotNilf(t, v, "%s must be populated", field)
+	require.NotNilf(t, v.Literal, "%s literal must be set", field)
+	require.NotEmptyf(t, *v.Literal, "%s must be non-empty", field)
+	require.Truef(t, json.Valid([]byte(*v.Literal)), "%s must be valid JSON, got %q", field, *v.Literal)
+}
+
+// e2eCreateBucket creates a bucket, handling the us-east-1 special case
+// (no LocationConstraint allowed there).
+func e2eCreateBucket(ctx context.Context, c *s3.Client, name, region string) error {
+	in := &s3.CreateBucketInput{Bucket: aws.String(name)}
+	if region != "us-east-1" {
+		in.CreateBucketConfiguration = &s3types.CreateBucketConfiguration{
+			LocationConstraint: s3types.BucketLocationConstraint(region),
+		}
+	}
+	_, err := c.CreateBucket(ctx, in)
+	return err
+}
+
+// e2eCreateLambda creates a zip-package Lambda, retrying CreateFunction
+// while the freshly-created IAM role is still propagating. Returns the
+// function ARN, or "" (with a logged reason) if provisioning could not
+// complete — the caller skips the lambda subtest in that case rather
+// than failing the IAM/S3 confirmation.
+func e2eCreateLambda(ctx context.Context, t *testing.T, c *lambda.Client, name, roleARN string) string {
+	t.Helper()
+	zipBytes, err := e2eLambdaZip()
+	if err != nil {
+		t.Logf("lambda provisioning skipped: build zip: %v", err)
+		return ""
+	}
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		out, err := c.CreateFunction(ctx, &lambda.CreateFunctionInput{
+			FunctionName: aws.String(name),
+			Role:         aws.String(roleARN),
+			Runtime:      lambdatypes.RuntimePython312,
+			Handler:      aws.String("index.handler"),
+			PackageType:  lambdatypes.PackageTypeZip,
+			Code:         &lambdatypes.FunctionCode{ZipFile: zipBytes},
+			Description:  aws.String("insideout 661 e2e - safe to delete"),
+		})
+		if err == nil {
+			return aws.ToString(out.FunctionArn)
+		}
+		// InvalidParameterValueException: the role cannot yet be
+		// assumed by Lambda (IAM eventual consistency). Retry.
+		var apiErr interface{ ErrorCode() string }
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "InvalidParameterValueException" && time.Now().Before(deadline) {
+			time.Sleep(8 * time.Second)
+			continue
+		}
+		t.Logf("lambda provisioning skipped: CreateFunction: %v", err)
+		return ""
+	}
+}
+
+// e2eLambdaZip builds a minimal in-memory zip deployment package with a
+// no-op python handler.
+func e2eLambdaZip() ([]byte, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("index.py")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := w.Write([]byte("def handler(event, context):\n    return {}\n")); err != nil {
+		return nil, err
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/cmd/insideout-import/awsdiscover/enrich_policy_e2e_test.go
+++ b/cmd/insideout-import/awsdiscover/enrich_policy_e2e_test.go
@@ -38,6 +38,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -54,6 +57,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
 )
@@ -189,30 +193,33 @@ func TestE2E661_PolicyDocumentEnrichers(t *testing.T) {
 
 	// Identities shaped exactly as the Cloud Control discoverers stamp
 	// them (see cloudControlTypeConfigs).
+	// Cloud + Tier are set so the same slice composes via EmitImportedTF
+	// in the terraform-plan subtest below (the discoverer normally
+	// stamps these; here the resources are hand-built).
 	irs := []imported.ImportedResource{
-		{Identity: imported.ResourceIdentity{
-			Type: "aws_iam_policy", Address: "aws_iam_policy.e2e",
+		{Tier: imported.TierImportedFlat, Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_iam_policy", Address: "aws_iam_policy.e2e",
 			ImportID: managedARN, NameHint: managedName, Region: region,
 			NativeIDs: map[string]string{"arn": managedARN},
 		}},
-		{Identity: imported.ResourceIdentity{
-			Type: "aws_iam_role", Address: "aws_iam_role.e2e",
+		{Tier: imported.TierImportedFlat, Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_iam_role", Address: "aws_iam_role.e2e",
 			ImportID: roleName, NameHint: roleName, Region: region,
 		}},
-		{Identity: imported.ResourceIdentity{
-			Type: "aws_iam_role_policy", Address: "aws_iam_role_policy.e2e",
+		{Tier: imported.TierImportedFlat, Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_iam_role_policy", Address: "aws_iam_role_policy.e2e",
 			ImportID: roleName + ":" + inlineName, NameHint: inlineName, Region: region,
 			NativeIDs: map[string]string{"role_name": roleName, "policy_name": inlineName},
 		}},
-		{Identity: imported.ResourceIdentity{
-			Type: "aws_s3_bucket_policy", Address: "aws_s3_bucket_policy.e2e",
+		{Tier: imported.TierImportedFlat, Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_s3_bucket_policy", Address: "aws_s3_bucket_policy.e2e",
 			ImportID: bucketName, NameHint: bucketName, Region: region,
 			NativeIDs: map[string]string{"bucket": bucketName},
 		}},
 	}
 	if fnARN != "" {
-		irs = append(irs, imported.ImportedResource{Identity: imported.ResourceIdentity{
-			Type: "aws_lambda_function", Address: "aws_lambda_function.e2e",
+		irs = append(irs, imported.ImportedResource{Tier: imported.TierImportedFlat, Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_lambda_function", Address: "aws_lambda_function.e2e",
 			ImportID: fnName, NameHint: fnName, Region: region,
 			NativeIDs: map[string]string{"arn": fnARN},
 		}})
@@ -282,6 +289,70 @@ func TestE2E661_PolicyDocumentEnrichers(t *testing.T) {
 		// CC still mapped the bulk of the function.
 		require.NotNil(t, got.FunctionName)
 		assert.Equal(t, fnName, *got.FunctionName.Literal)
+	})
+
+	// The load-bearing confirmation: compose the enriched IRs to HCL and
+	// run `terraform plan` against the live account. This is what would
+	// "blow up on the next plan" if a required policy-document argument
+	// were empty or the lambda block lacked a code source — a plan-time
+	// error, not a compose-time one. A non-empty diff is expected and
+	// fine; a plan *error* is the regression this guards against.
+	t.Run("terraform plan accepts the composed imported.tf", func(t *testing.T) {
+		tfBin, lookErr := exec.LookPath("terraform")
+		if lookErr != nil {
+			t.Skip("terraform binary not on PATH")
+		}
+		out, _ := composer.EmitImportedTF("aws", irs, composer.EmitImportedOpts{})
+		require.NotEmpty(t, out, "EmitImportedTF produced no HCL")
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "imported.tf"), out, 0o600))
+		providers := fmt.Sprintf(`terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+provider "aws" {
+  region = %q
+}
+provider "aws" {
+  alias  = "imported"
+  region = %q
+}
+`, region, region)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "providers.tf"), []byte(providers), 0o600))
+		// terraform plan never opens the lambda placeholder file, but
+		// write a real zip anyway so the directory is self-consistent.
+		if zipBytes, zerr := e2eLambdaZip(); zerr == nil {
+			_ = os.WriteFile(filepath.Join(dir, imported.LambdaPlaceholderFilename), zipBytes, 0o600)
+		}
+
+		runTF := func(args ...string) (string, error) {
+			cmd := exec.CommandContext(ctx, tfBin, args...)
+			cmd.Dir = dir
+			cmd.Env = append(os.Environ(), "TF_IN_AUTOMATION=1")
+			b, err := cmd.CombinedOutput()
+			return string(b), err
+		}
+		if o, err := runTF("init", "-input=false", "-no-color"); err != nil {
+			t.Fatalf("terraform init failed: %v\n%s", err, o)
+		}
+		// -detailed-exitcode: 0 = no diff, 2 = non-empty diff, 1 = error.
+		// A diff is expected (imported config rarely matches the live
+		// resource byte-for-byte); an error is the #663 regression.
+		o, err := runTF("plan", "-input=false", "-no-color", "-detailed-exitcode")
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && exitErr.ExitCode() == 2 {
+				t.Logf("terraform plan clean (exit 2 = non-empty diff, expected for import)")
+				return
+			}
+			t.Fatalf("terraform plan ERRORED — the composed imported.tf is not plan-clean:\n%s", o)
+		}
+		t.Logf("terraform plan clean (exit 0 = no diff)")
 	})
 }
 

--- a/cmd/insideout-import/awsdiscover/iam_policy_enrich.go
+++ b/cmd/insideout-import/awsdiscover/iam_policy_enrich.go
@@ -252,12 +252,17 @@ func fetchIAMPolicyWithClient(ctx context.Context, c iamPolicyAPI, policyARN str
 // The IAM API returns the document URL-encoded compliant with RFC 3986;
 // url.QueryUnescape reverses that. If unescaping fails the raw value is
 // used as-is (some callers / fakes pass an already-decoded document).
-// The result is then re-compacted via json.Compact so the emitted
-// `policy` string is stable regardless of the API's whitespace — a
-// non-JSON document is a hard error since `policy` must be valid JSON.
+// The result is then re-compacted via compactPolicyJSON so the emitted
+// `policy` string is stable regardless of the API's whitespace.
 //
 // An empty document yields an empty string (the caller omits the
 // `policy` field entirely in that case).
+//
+// Shared by the IAM-family enrichers (aws_iam_policy, aws_iam_role's
+// assume_role_policy, aws_iam_role_policy) — every IAM read API returns
+// policy documents URL-encoded. The S3 bucket-policy enricher uses
+// compactPolicyJSON directly because s3:GetBucketPolicy returns the
+// document already decoded.
 func decodeIAMPolicyDocument(raw string) (string, error) {
 	if raw == "" {
 		return "", nil
@@ -266,8 +271,20 @@ func decodeIAMPolicyDocument(raw string) (string, error) {
 	if err != nil {
 		decoded = raw
 	}
+	return compactPolicyJSON(decoded)
+}
+
+// compactPolicyJSON validates raw as JSON and returns it whitespace-
+// compacted so the emitted `policy` / `assume_role_policy` string is
+// stable regardless of the source API's formatting. An empty input
+// yields an empty string; a non-JSON input is a hard error since these
+// Terraform attributes must hold valid JSON.
+func compactPolicyJSON(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
 	var buf bytes.Buffer
-	if err := json.Compact(&buf, []byte(decoded)); err != nil {
+	if err := json.Compact(&buf, []byte(raw)); err != nil {
 		return "", fmt.Errorf("policy document is not valid JSON: %w", err)
 	}
 	return buf.String(), nil

--- a/cmd/insideout-import/awsdiscover/iam_role_enrich.go
+++ b/cmd/insideout-import/awsdiscover/iam_role_enrich.go
@@ -1,0 +1,248 @@
+// Package awsdiscover — IAM role attribute enricher (#661 follow-up).
+//
+// Pairs with the Cloud-Control-routed `aws_iam_role` discoverer
+// registered in cloudControlTypeConfigs ("AWS::IAM::Role").
+//
+// **Why a hand-rolled override**: `aws_iam_role.assume_role_policy` is
+// a REQUIRED JSON-encoded string. The generic Cloud Control enricher
+// reads `AWS::IAM::Role.AssumeRolePolicyDocument` as create-time input,
+// not a stably-readable property — GetResource frequently omits it,
+// leaving the required `assume_role_policy` argument empty and tripping
+// the composer's `imported_resource_missing_required_attr`. Same gap as
+// aws_iam_policy (#661); same fix shape.
+//
+// One iam:GetRole call returns every field the Layer-1 model needs —
+// the trust policy (AssumeRolePolicyDocument, URL-encoded), the
+// metadata (Name / Path / Description / MaxSessionDuration /
+// PermissionsBoundary) and inline Tags — so no second call is needed.
+//
+// **Computed-only / TF-input-only / separate-resource fields skipped:**
+//   - `arn` (Computed) — stamped on ir.Identity.NativeIDs["arn"].
+//   - `id`, `unique_id`, `create_date` (Computed).
+//   - `name_prefix` (Optional+Computed), `tags_all` (Computed).
+//   - `force_detach_policies` (TF-input only; no API source).
+//   - `inline_policy` / `managed_policy_arns` blocks — these duplicate
+//     the standalone aws_iam_role_policy / aws_iam_role_policy_attachment
+//     resources and the provider docs mark the in-role forms as
+//     exclusive alternatives; the discoverer emits the standalone
+//     resources, so populating the blocks here would double-count.
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// iamRoleTFType is the registered Terraform type for the IAM role
+// enricher.
+const iamRoleTFType = "aws_iam_role"
+
+// iamRoleAPI is the narrow subset of the IAM API the aws_iam_role
+// enricher's fetch path issues. The real *iam.Client and in-test fakes
+// both satisfy it, so fetchIAMRoleWithClient is unit-testable without a
+// stubbed HTTP transport. Mirrors iamPolicyAPI.
+type iamRoleAPI interface {
+	GetRole(ctx context.Context, in *iam.GetRoleInput, opts ...func(*iam.Options)) (*iam.GetRoleOutput, error)
+}
+
+// iamRoleEnricher implements both AttributeEnricher and ByIDEnricher
+// for aws_iam_role.
+type iamRoleEnricher struct {
+	// fetch is overridable for tests. Defaults to the real GetRole
+	// path against the iam.Client in EnrichClients.
+	fetch func(ctx context.Context, c *iam.Client, roleName string) (*iamtypes.Role, error)
+}
+
+// newIAMRoleEnricher returns the production-wired enricher.
+func newIAMRoleEnricher() *iamRoleEnricher {
+	return &iamRoleEnricher{fetch: defaultIAMRoleFetch}
+}
+
+func (iamRoleEnricher) ResourceType() string { return iamRoleTFType }
+
+// Enrich populates ir.Attrs with a typed AWSIAMRole payload for the
+// role identified by ir.Identity. Returns ErrEnrichClientUnavailable if
+// EnrichClients.IAM is nil, ErrNotFound if the role no longer exists,
+// and any other error reflects a real IAM API failure.
+func (e iamRoleEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if c.IAM == nil {
+		return ErrEnrichClientUnavailable
+	}
+	name := iamRoleNameForEnrich(&ir.Identity)
+	if name == "" {
+		return fmt.Errorf("%s: cannot derive role name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			iamRoleTFType, ir.Identity.Address, ir.Identity.ImportID, ir.Identity.NameHint)
+	}
+	role, err := e.fetch(ctx, c.IAM, name)
+	if err != nil {
+		if isAPIErrorCode(err, "NoSuchEntity", "NoSuchEntityException") {
+			return fmt.Errorf("%s %q: %w", iamRoleTFType, name, ErrNotFound)
+		}
+		return fmt.Errorf("%s: fetch %q: %w", iamRoleTFType, name, err)
+	}
+	if role == nil {
+		return fmt.Errorf("%s: fetch %q: empty response", iamRoleTFType, name)
+	}
+
+	// Stamp ARN on Identity.NativeIDs so downstream consumers don't
+	// have to round-trip back to the SDK. The pure-mapping helper does
+	// NOT touch ir.Identity per the AttributeEnricher contract.
+	if arn := aws.ToString(role.Arn); arn != "" {
+		if ir.Identity.NativeIDs == nil {
+			ir.Identity.NativeIDs = map[string]string{}
+		}
+		ir.Identity.NativeIDs["arn"] = arn
+	}
+
+	typed, err := mapIAMRole(role)
+	if err != nil {
+		return fmt.Errorf("%s %q: %w", iamRoleTFType, name, err)
+	}
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return fmt.Errorf("%s: marshal Attrs: %w", iamRoleTFType, err)
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID fetches the typed AWSIAMRole payload for the role named by
+// identity. Shares the SDK call + mapping with Enrich. Does not mutate
+// identity.
+func (e iamRoleEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.IAM == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if identity == nil {
+		return nil, errors.New(iamRoleTFType + ": identity is nil")
+	}
+	name := iamRoleNameForEnrich(identity)
+	if name == "" {
+		return nil, fmt.Errorf("%s: cannot derive role name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			iamRoleTFType, identity.Address, identity.ImportID, identity.NameHint)
+	}
+	role, err := e.fetch(ctx, c.IAM, name)
+	if err != nil {
+		if isAPIErrorCode(err, "NoSuchEntity", "NoSuchEntityException") {
+			return nil, fmt.Errorf("%s %q: %w", iamRoleTFType, name, ErrNotFound)
+		}
+		return nil, fmt.Errorf("%s: fetch %q: %w", iamRoleTFType, name, err)
+	}
+	if role == nil {
+		return nil, fmt.Errorf("%s: fetch %q: empty response", iamRoleTFType, name)
+	}
+	typed, err := mapIAMRole(role)
+	if err != nil {
+		return nil, fmt.Errorf("%s %q: %w", iamRoleTFType, name, err)
+	}
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("%s: marshal Attrs: %w", iamRoleTFType, err)
+	}
+	return raw, nil
+}
+
+// iamRoleNameForEnrich derives the RoleName argument for GetRole.
+// iam:GetRole takes the bare role name (not the ARN), and the Cloud
+// Control discoverer's passthroughImportID emits the role name as the
+// import ID for aws_iam_role.
+//
+// Preference order:
+//
+//  1. Identity.ImportID — the discoverer's import ID (the role name).
+//  2. Identity.NameHint — the RoleName surfaced from CFN properties.
+func iamRoleNameForEnrich(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if s := strings.TrimSpace(id.ImportID); s != "" {
+		return s
+	}
+	return strings.TrimSpace(id.NameHint)
+}
+
+// defaultIAMRoleFetch is the production fetch path: it wires the real
+// *iam.Client into fetchIAMRoleWithClient.
+func defaultIAMRoleFetch(ctx context.Context, c *iam.Client, roleName string) (*iamtypes.Role, error) {
+	if c == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	return fetchIAMRoleWithClient(ctx, c, roleName)
+}
+
+// fetchIAMRoleWithClient issues the single GetRole call behind the
+// narrow iamRoleAPI interface so the orchestration is unit-testable.
+func fetchIAMRoleWithClient(ctx context.Context, c iamRoleAPI, roleName string) (*iamtypes.Role, error) {
+	out, err := c.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String(roleName)})
+	if err != nil {
+		return nil, fmt.Errorf("iam:GetRole: %w", err)
+	}
+	if out == nil || out.Role == nil {
+		return nil, errors.New("iam:GetRole: nil role in response")
+	}
+	return out.Role, nil
+}
+
+// mapIAMRole projects an iamtypes.Role into the typed AWSIAMRole
+// struct. Every field is emitted only when present so the resulting
+// HCL stays decision-#34 clean. The trust policy is URL-decoded +
+// JSON-compacted; a non-JSON trust policy is a hard error (the
+// required `assume_role_policy` argument must hold valid JSON).
+func mapIAMRole(role *iamtypes.Role) (*generated.AWSIAMRole, error) {
+	typed := &generated.AWSIAMRole{}
+	if role == nil {
+		return typed, nil
+	}
+	if name := aws.ToString(role.RoleName); name != "" {
+		typed.Name = generated.LiteralOf(name)
+	}
+	if path := aws.ToString(role.Path); path != "" {
+		typed.Path = generated.LiteralOf(path)
+	}
+	if desc := aws.ToString(role.Description); desc != "" {
+		typed.Description = generated.LiteralOf(desc)
+	}
+	if role.MaxSessionDuration != nil {
+		typed.MaxSessionDuration = generated.LiteralOf(int64(*role.MaxSessionDuration))
+	}
+	if role.PermissionsBoundary != nil {
+		if pb := aws.ToString(role.PermissionsBoundary.PermissionsBoundaryArn); pb != "" {
+			typed.PermissionsBoundary = generated.LiteralOf(pb)
+		}
+	}
+	if len(role.Tags) > 0 {
+		m := map[string]*generated.Value[string]{}
+		for _, t := range role.Tags {
+			if t.Key != nil {
+				m[*t.Key] = generated.LiteralOf(aws.ToString(t.Value))
+			}
+		}
+		if len(m) > 0 {
+			typed.Tags = m
+		}
+	}
+	doc, err := decodeIAMPolicyDocument(aws.ToString(role.AssumeRolePolicyDocument))
+	if err != nil {
+		return nil, fmt.Errorf("decode assume_role_policy: %w", err)
+	}
+	if doc != "" {
+		typed.AssumeRolePolicy = generated.LiteralOf(doc)
+	}
+	return typed, nil
+}
+
+// Compile-time assertions.
+var (
+	_ AttributeEnricher = (*iamRoleEnricher)(nil)
+	_ ByIDEnricher      = (*iamRoleEnricher)(nil)
+)

--- a/cmd/insideout-import/awsdiscover/iam_role_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/iam_role_enrich_test.go
@@ -1,0 +1,255 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// sampleTrustPolicy is a minimal valid IAM trust policy.
+const sampleTrustPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}`
+
+// fakeIAMRoleAPI is an iamRoleAPI fake.
+type fakeIAMRoleAPI struct {
+	out      *iam.GetRoleOutput
+	err      error
+	gotName  string
+	gotCalls int
+}
+
+func (f *fakeIAMRoleAPI) GetRole(_ context.Context, in *iam.GetRoleInput, _ ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
+	f.gotCalls++
+	f.gotName = aws.ToString(in.RoleName)
+	return f.out, f.err
+}
+
+var _ iamRoleAPI = (*fakeIAMRoleAPI)(nil)
+
+func TestIAMRoleEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "aws_iam_role", newIAMRoleEnricher().ResourceType())
+}
+
+func TestIAMRoleEnricher_NilClient(t *testing.T) {
+	t.Parallel()
+	err := iamRoleEnricher{}.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "r"}}, EnrichClients{})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestIAMRoleEnricher_CannotResolveName(t *testing.T) {
+	t.Parallel()
+	err := iamRoleEnricher{}.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{}}, EnrichClients{IAM: &iam.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive role name")
+}
+
+func TestIAMRoleEnricher_HappyPath(t *testing.T) {
+	t.Parallel()
+	const arn = "arn:aws:iam::123456789012:role/my-role"
+	enr := iamRoleEnricher{fetch: func(_ context.Context, _ *iam.Client, name string) (*iamtypes.Role, error) {
+		assert.Equal(t, "my-role", name)
+		return &iamtypes.Role{
+			RoleName:                 aws.String("my-role"),
+			Arn:                      aws.String(arn),
+			Path:                     aws.String("/service-role/"),
+			Description:              aws.String("a role"),
+			MaxSessionDuration:       aws.Int32(7200),
+			AssumeRolePolicyDocument: aws.String(url.QueryEscape(sampleTrustPolicy)),
+			PermissionsBoundary: &iamtypes.AttachedPermissionsBoundary{
+				PermissionsBoundaryArn: aws.String("arn:aws:iam::123456789012:policy/boundary"),
+			},
+			Tags: []iamtypes.Tag{{Key: aws.String("Project"), Value: aws.String("io-x")}},
+		}, nil
+	}}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "my-role"}}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{IAM: &iam.Client{}}))
+
+	assert.Equal(t, arn, ir.Identity.NativeIDs["arn"])
+
+	var got generated.AWSIAMRole
+	require.NoError(t, json.Unmarshal(ir.Attrs, &got))
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "my-role", *got.Name.Literal)
+	require.NotNil(t, got.AssumeRolePolicy)
+	assert.JSONEq(t, sampleTrustPolicy, *got.AssumeRolePolicy.Literal)
+	require.NotNil(t, got.MaxSessionDuration)
+	assert.Equal(t, int64(7200), *got.MaxSessionDuration.Literal)
+	require.NotNil(t, got.PermissionsBoundary)
+	assert.Equal(t, "arn:aws:iam::123456789012:policy/boundary", *got.PermissionsBoundary.Literal)
+	require.NotNil(t, got.Path)
+	assert.Equal(t, "/service-role/", *got.Path.Literal)
+	require.NotNil(t, got.Tags["Project"])
+	assert.Equal(t, "io-x", *got.Tags["Project"].Literal)
+	// Computed / separate-resource fields not populated.
+	assert.Nil(t, got.ARN)
+	assert.Nil(t, got.ID)
+	assert.Nil(t, got.UniqueID)
+	assert.Nil(t, got.InlinePolicy)
+	assert.Nil(t, got.ManagedPolicyArns)
+}
+
+func TestIAMRoleEnricher_NoSuchEntityMapsToNotFound(t *testing.T) {
+	t.Parallel()
+	enr := iamRoleEnricher{fetch: func(context.Context, *iam.Client, string) (*iamtypes.Role, error) {
+		return nil, &fakeIAMSmithyErr{code: "NoSuchEntity"}
+	}}
+	err := enr.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "gone"}}, EnrichClients{IAM: &iam.Client{}})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestIAMRoleEnricher_AccessDeniedIsNotNotFound(t *testing.T) {
+	t.Parallel()
+	enr := iamRoleEnricher{fetch: func(context.Context, *iam.Client, string) (*iamtypes.Role, error) {
+		return nil, &fakeIAMSmithyErr{code: "AccessDenied"}
+	}}
+	err := enr.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "r"}}, EnrichClients{IAM: &iam.Client{}})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound)
+}
+
+func TestIAMRoleEnricher_EnrichByID(t *testing.T) {
+	t.Parallel()
+	enr := iamRoleEnricher{fetch: func(context.Context, *iam.Client, string) (*iamtypes.Role, error) {
+		return &iamtypes.Role{
+			RoleName:                 aws.String("my-role"),
+			Arn:                      aws.String("arn:aws:iam::1:role/my-role"),
+			AssumeRolePolicyDocument: aws.String(url.QueryEscape(sampleTrustPolicy)),
+		}, nil
+	}}
+	identity := &imported.ResourceIdentity{NameHint: "my-role"}
+	raw, err := enr.EnrichByID(context.Background(), identity, EnrichClients{IAM: &iam.Client{}})
+	require.NoError(t, err)
+	// EnrichByID must not mutate identity.
+	assert.Nil(t, identity.NativeIDs)
+
+	var got generated.AWSIAMRole
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.NotNil(t, got.AssumeRolePolicy)
+	assert.JSONEq(t, sampleTrustPolicy, *got.AssumeRolePolicy.Literal)
+}
+
+func TestIAMRoleEnricher_EnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	_, err := iamRoleEnricher{}.EnrichByID(context.Background(), nil, EnrichClients{IAM: &iam.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity is nil")
+}
+
+func TestIAMRoleEnricher_EnrichByID_NilClient(t *testing.T) {
+	t.Parallel()
+	_, err := iamRoleEnricher{}.EnrichByID(context.Background(),
+		&imported.ResourceIdentity{ImportID: "r"}, EnrichClients{})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestIAMRoleEnricher_EmptyARNNotStamped(t *testing.T) {
+	t.Parallel()
+	// A role whose Arn is empty must not stamp NativeIDs (and must not
+	// allocate the NativeIDs map just to hold an empty value).
+	enr := iamRoleEnricher{fetch: func(context.Context, *iam.Client, string) (*iamtypes.Role, error) {
+		return &iamtypes.Role{
+			RoleName:                 aws.String("my-role"),
+			AssumeRolePolicyDocument: aws.String(url.QueryEscape(sampleTrustPolicy)),
+		}, nil
+	}}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "my-role"}}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{IAM: &iam.Client{}}))
+	assert.Nil(t, ir.Identity.NativeIDs, "no ARN means NativeIDs stays nil")
+}
+
+func TestIAMRoleNameForEnrich(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "from-import",
+		iamRoleNameForEnrich(&imported.ResourceIdentity{ImportID: "from-import", NameHint: "from-hint"}))
+	assert.Equal(t, "from-hint",
+		iamRoleNameForEnrich(&imported.ResourceIdentity{NameHint: "from-hint"}))
+	assert.Equal(t, "", iamRoleNameForEnrich(nil))
+}
+
+func TestFetchIAMRoleWithClient(t *testing.T) {
+	t.Parallel()
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeIAMRoleAPI{out: &iam.GetRoleOutput{Role: &iamtypes.Role{RoleName: aws.String("r")}}}
+		role, err := fetchIAMRoleWithClient(context.Background(), f, "r")
+		require.NoError(t, err)
+		assert.Equal(t, "r", aws.ToString(role.RoleName))
+		assert.Equal(t, "r", f.gotName)
+	})
+	t.Run("error is wrapped", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeIAMRoleAPI{err: errors.New("boom")}
+		_, err := fetchIAMRoleWithClient(context.Background(), f, "r")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "iam:GetRole")
+	})
+	t.Run("nil role is an error", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeIAMRoleAPI{out: &iam.GetRoleOutput{Role: nil}}
+		_, err := fetchIAMRoleWithClient(context.Background(), f, "r")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil role")
+	})
+}
+
+func TestMapIAMRole(t *testing.T) {
+	t.Parallel()
+	t.Run("nil input", func(t *testing.T) {
+		t.Parallel()
+		got, err := mapIAMRole(nil)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Nil(t, got.AssumeRolePolicy)
+	})
+	t.Run("empty-string fields omitted", func(t *testing.T) {
+		t.Parallel()
+		got, err := mapIAMRole(&iamtypes.Role{
+			RoleName:    aws.String(""),
+			Path:        aws.String(""),
+			Description: aws.String(""),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.Name)
+		assert.Nil(t, got.Path)
+		assert.Nil(t, got.Description)
+		assert.Nil(t, got.AssumeRolePolicy)
+	})
+	t.Run("nil-key tag skipped", func(t *testing.T) {
+		t.Parallel()
+		got, err := mapIAMRole(&iamtypes.Role{
+			Tags: []iamtypes.Tag{{Key: nil, Value: aws.String("x")}},
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.Tags)
+	})
+	t.Run("invalid trust policy is an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := mapIAMRole(&iamtypes.Role{AssumeRolePolicyDocument: aws.String("not json")})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "assume_role_policy")
+	})
+}
+
+func TestIAMRoleEnricher_RegisteredAsOverride(t *testing.T) {
+	t.Parallel()
+	d := NewAWSDiscoverer(aws.Config{Region: "us-east-1"})
+	enr, ok := d.byTypeEnricher["aws_iam_role"]
+	require.True(t, ok)
+	_, isHandRolled := enr.(*iamRoleEnricher)
+	assert.True(t, isHandRolled, "got %T", enr)
+}

--- a/cmd/insideout-import/awsdiscover/iam_role_policy_enrich.go
+++ b/cmd/insideout-import/awsdiscover/iam_role_policy_enrich.go
@@ -1,0 +1,224 @@
+// Package awsdiscover — IAM inline role-policy attribute enricher
+// (#661 follow-up).
+//
+// Pairs with the Cloud-Control-routed `aws_iam_role_policy` discoverer
+// registered in cloudControlTypeConfigs ("AWS::IAM::RolePolicy").
+//
+// **Why a hand-rolled override**: `aws_iam_role_policy.policy` is a
+// REQUIRED JSON-encoded string with the same Cloud-Control read-back
+// gap as aws_iam_policy (#661) — the CFN schema treats the inline
+// policy document as create-time input. One iam:GetRolePolicy call
+// returns the document (URL-encoded) plus the role/policy names.
+//
+// Distinct from aws_iam_role_policy_attachment: that resource binds a
+// *managed* policy ARN to a role; this resource is an *inline* policy
+// document embedded in the role. They share neither the API nor the
+// import-ID shape.
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// iamRolePolicyTFType is the registered Terraform type for the inline
+// role-policy enricher.
+const iamRolePolicyTFType = "aws_iam_role_policy"
+
+// iamRolePolicyData is the result of the GetRolePolicy call: the
+// resolved role/policy names and the URL-decoded + compacted policy
+// document.
+type iamRolePolicyData struct {
+	RoleName   string
+	PolicyName string
+	Document   string
+}
+
+// iamRolePolicyAPI is the narrow subset of the IAM API the
+// aws_iam_role_policy enricher's fetch path issues.
+type iamRolePolicyAPI interface {
+	GetRolePolicy(ctx context.Context, in *iam.GetRolePolicyInput, opts ...func(*iam.Options)) (*iam.GetRolePolicyOutput, error)
+}
+
+// iamRolePolicyEnricher implements both AttributeEnricher and
+// ByIDEnricher for aws_iam_role_policy.
+type iamRolePolicyEnricher struct {
+	// fetch is overridable for tests. Defaults to the real
+	// GetRolePolicy path against the iam.Client in EnrichClients.
+	fetch func(ctx context.Context, c *iam.Client, roleName, policyName string) (*iamRolePolicyData, error)
+}
+
+// newIAMRolePolicyEnricher returns the production-wired enricher.
+func newIAMRolePolicyEnricher() *iamRolePolicyEnricher {
+	return &iamRolePolicyEnricher{fetch: defaultIAMRolePolicyFetch}
+}
+
+func (iamRolePolicyEnricher) ResourceType() string { return iamRolePolicyTFType }
+
+// Enrich populates ir.Attrs with a typed AWSIAMRolePolicy payload.
+// Returns ErrEnrichClientUnavailable if EnrichClients.IAM is nil,
+// ErrNotFound if the role or inline policy no longer exists, and any
+// other error reflects a real IAM API failure.
+func (e iamRolePolicyEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if c.IAM == nil {
+		return ErrEnrichClientUnavailable
+	}
+	role, policy, err := iamRolePolicyParts(&ir.Identity)
+	if err != nil {
+		return err
+	}
+	data, ferr := e.fetch(ctx, c.IAM, role, policy)
+	if ferr != nil {
+		if isAPIErrorCode(ferr, "NoSuchEntity", "NoSuchEntityException") {
+			return fmt.Errorf("%s (role=%s, policy=%s): %w", iamRolePolicyTFType, role, policy, ErrNotFound)
+		}
+		return fmt.Errorf("%s: fetch (role=%s, policy=%s): %w", iamRolePolicyTFType, role, policy, ferr)
+	}
+	if data == nil {
+		return fmt.Errorf("%s: fetch (role=%s, policy=%s): empty response", iamRolePolicyTFType, role, policy)
+	}
+	raw, err := json.Marshal(mapIAMRolePolicy(data))
+	if err != nil {
+		return fmt.Errorf("%s: marshal Attrs: %w", iamRolePolicyTFType, err)
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID fetches the typed AWSIAMRolePolicy payload for the inline
+// policy named by identity. Shares the SDK call + mapping with Enrich.
+func (e iamRolePolicyEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.IAM == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if identity == nil {
+		return nil, errors.New(iamRolePolicyTFType + ": identity is nil")
+	}
+	role, policy, err := iamRolePolicyParts(identity)
+	if err != nil {
+		return nil, err
+	}
+	data, ferr := e.fetch(ctx, c.IAM, role, policy)
+	if ferr != nil {
+		if isAPIErrorCode(ferr, "NoSuchEntity", "NoSuchEntityException") {
+			return nil, fmt.Errorf("%s (role=%s, policy=%s): %w", iamRolePolicyTFType, role, policy, ErrNotFound)
+		}
+		return nil, fmt.Errorf("%s: fetch (role=%s, policy=%s): %w", iamRolePolicyTFType, role, policy, ferr)
+	}
+	if data == nil {
+		return nil, fmt.Errorf("%s: fetch (role=%s, policy=%s): empty response", iamRolePolicyTFType, role, policy)
+	}
+	raw, err := json.Marshal(mapIAMRolePolicy(data))
+	if err != nil {
+		return nil, fmt.Errorf("%s: marshal Attrs: %w", iamRolePolicyTFType, err)
+	}
+	return raw, nil
+}
+
+// iamRolePolicyParts resolves (roleName, policyName) from the
+// discoverer-populated Identity. Preference order:
+//
+//  1. Identity.NativeIDs["role_name"] + ["policy_name"] — the Cloud
+//     Control discoverer's NativeIDsFromProperties stamps both.
+//  2. Identity.ImportID parsed as "<RoleName>:<PolicyName>" — the
+//     discoverer rewrites the CC identifier into the Terraform import
+//     form. IAM role and policy names cannot contain ":" (the allowed
+//     set is [\w+=,.@-]), so a single SplitN(2) is unambiguous.
+func iamRolePolicyParts(id *imported.ResourceIdentity) (string, string, error) {
+	if id == nil {
+		return "", "", errors.New(iamRolePolicyTFType + ": identity is nil")
+	}
+	role := strings.TrimSpace(id.NativeIDs["role_name"])
+	policy := strings.TrimSpace(id.NativeIDs["policy_name"])
+	if role != "" && policy != "" {
+		return role, policy, nil
+	}
+	if imp := strings.TrimSpace(id.ImportID); imp != "" {
+		parts := strings.SplitN(imp, ":", 2)
+		if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+			return parts[0], parts[1], nil
+		}
+	}
+	return "", "", fmt.Errorf("%s: cannot resolve (role, policy) from Identity (Address=%q ImportID=%q)",
+		iamRolePolicyTFType, id.Address, id.ImportID)
+}
+
+// defaultIAMRolePolicyFetch is the production fetch path.
+func defaultIAMRolePolicyFetch(ctx context.Context, c *iam.Client, roleName, policyName string) (*iamRolePolicyData, error) {
+	if c == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	return fetchIAMRolePolicyWithClient(ctx, c, roleName, policyName)
+}
+
+// fetchIAMRolePolicyWithClient issues GetRolePolicy behind the narrow
+// iamRolePolicyAPI interface so the orchestration is unit-testable.
+// The returned PolicyDocument is URL-encoded (RFC 3986) and is decoded
+// + compacted by decodeIAMPolicyDocument.
+func fetchIAMRolePolicyWithClient(ctx context.Context, c iamRolePolicyAPI, roleName, policyName string) (*iamRolePolicyData, error) {
+	out, err := c.GetRolePolicy(ctx, &iam.GetRolePolicyInput{
+		RoleName:   aws.String(roleName),
+		PolicyName: aws.String(policyName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("iam:GetRolePolicy: %w", err)
+	}
+	if out == nil {
+		return nil, errors.New("iam:GetRolePolicy: nil response")
+	}
+	doc, err := decodeIAMPolicyDocument(aws.ToString(out.PolicyDocument))
+	if err != nil {
+		return nil, fmt.Errorf("iam:GetRolePolicy: decode document: %w", err)
+	}
+	// Prefer the API-echoed names; fall back to the request arguments
+	// (GetRolePolicy always echoes them, but a defensive fallback keeps
+	// the mapping correct if a future SDK shape changes).
+	role := aws.ToString(out.RoleName)
+	if role == "" {
+		role = roleName
+	}
+	policy := aws.ToString(out.PolicyName)
+	if policy == "" {
+		policy = policyName
+	}
+	return &iamRolePolicyData{RoleName: role, PolicyName: policy, Document: doc}, nil
+}
+
+// mapIAMRolePolicy projects the fetched data into the typed
+// AWSIAMRolePolicy struct. The Terraform resource id is the
+// "<role>:<policy>" import form; downstream consumers don't have to
+// reconstruct it.
+func mapIAMRolePolicy(d *iamRolePolicyData) *generated.AWSIAMRolePolicy {
+	typed := &generated.AWSIAMRolePolicy{}
+	if d == nil {
+		return typed
+	}
+	if d.RoleName != "" {
+		typed.Role = generated.LiteralOf(d.RoleName)
+	}
+	if d.PolicyName != "" {
+		typed.Name = generated.LiteralOf(d.PolicyName)
+	}
+	if d.RoleName != "" && d.PolicyName != "" {
+		typed.ID = generated.LiteralOf(d.RoleName + ":" + d.PolicyName)
+	}
+	if d.Document != "" {
+		typed.Policy = generated.LiteralOf(d.Document)
+	}
+	return typed
+}
+
+// Compile-time assertions.
+var (
+	_ AttributeEnricher = (*iamRolePolicyEnricher)(nil)
+	_ ByIDEnricher      = (*iamRolePolicyEnricher)(nil)
+)

--- a/cmd/insideout-import/awsdiscover/iam_role_policy_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/iam_role_policy_enrich_test.go
@@ -1,0 +1,231 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// fakeIAMRolePolicyAPI is an iamRolePolicyAPI fake.
+type fakeIAMRolePolicyAPI struct {
+	out       *iam.GetRolePolicyOutput
+	err       error
+	gotRole   string
+	gotPolicy string
+}
+
+func (f *fakeIAMRolePolicyAPI) GetRolePolicy(_ context.Context, in *iam.GetRolePolicyInput, _ ...func(*iam.Options)) (*iam.GetRolePolicyOutput, error) {
+	f.gotRole = aws.ToString(in.RoleName)
+	f.gotPolicy = aws.ToString(in.PolicyName)
+	return f.out, f.err
+}
+
+var _ iamRolePolicyAPI = (*fakeIAMRolePolicyAPI)(nil)
+
+func TestIAMRolePolicyEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "aws_iam_role_policy", newIAMRolePolicyEnricher().ResourceType())
+}
+
+func TestIAMRolePolicyEnricher_NilClient(t *testing.T) {
+	t.Parallel()
+	err := iamRolePolicyEnricher{}.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "r:p"}}, EnrichClients{})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestIAMRolePolicyEnricher_CannotResolve(t *testing.T) {
+	t.Parallel()
+	err := iamRolePolicyEnricher{}.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{}}, EnrichClients{IAM: &iam.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot resolve")
+}
+
+func TestIAMRolePolicyEnricher_HappyPath(t *testing.T) {
+	t.Parallel()
+	enr := iamRolePolicyEnricher{fetch: func(_ context.Context, _ *iam.Client, role, policy string) (*iamRolePolicyData, error) {
+		assert.Equal(t, "my-role", role)
+		assert.Equal(t, "my-inline", policy)
+		return &iamRolePolicyData{RoleName: role, PolicyName: policy, Document: samplePolicyDocument}, nil
+	}}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{
+		NativeIDs: map[string]string{"role_name": "my-role", "policy_name": "my-inline"},
+	}}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{IAM: &iam.Client{}}))
+
+	var got generated.AWSIAMRolePolicy
+	require.NoError(t, json.Unmarshal(ir.Attrs, &got))
+	require.NotNil(t, got.Role)
+	assert.Equal(t, "my-role", *got.Role.Literal)
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "my-inline", *got.Name.Literal)
+	require.NotNil(t, got.ID)
+	assert.Equal(t, "my-role:my-inline", *got.ID.Literal)
+	require.NotNil(t, got.Policy)
+	assert.JSONEq(t, samplePolicyDocument, *got.Policy.Literal)
+}
+
+func TestIAMRolePolicyEnricher_NoSuchEntityMapsToNotFound(t *testing.T) {
+	t.Parallel()
+	enr := iamRolePolicyEnricher{fetch: func(context.Context, *iam.Client, string, string) (*iamRolePolicyData, error) {
+		return nil, &fakeIAMSmithyErr{code: "NoSuchEntity"}
+	}}
+	err := enr.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "r:p"}}, EnrichClients{IAM: &iam.Client{}})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestIAMRolePolicyEnricher_EmptyResponseIsError(t *testing.T) {
+	t.Parallel()
+	enr := iamRolePolicyEnricher{fetch: func(context.Context, *iam.Client, string, string) (*iamRolePolicyData, error) {
+		return nil, nil
+	}}
+	err := enr.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "r:p"}}, EnrichClients{IAM: &iam.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+}
+
+func TestIAMRolePolicyEnricher_EnrichByID(t *testing.T) {
+	t.Parallel()
+	enr := iamRolePolicyEnricher{fetch: func(context.Context, *iam.Client, string, string) (*iamRolePolicyData, error) {
+		return &iamRolePolicyData{RoleName: "r", PolicyName: "p", Document: samplePolicyDocument}, nil
+	}}
+	raw, err := enr.EnrichByID(context.Background(),
+		&imported.ResourceIdentity{ImportID: "r:p"}, EnrichClients{IAM: &iam.Client{}})
+	require.NoError(t, err)
+	var got generated.AWSIAMRolePolicy
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.JSONEq(t, samplePolicyDocument, *got.Policy.Literal)
+}
+
+func TestIAMRolePolicyEnricher_EnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	_, err := iamRolePolicyEnricher{}.EnrichByID(context.Background(), nil, EnrichClients{IAM: &iam.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity is nil")
+}
+
+func TestIAMRolePolicyEnricher_EnrichByID_NilClient(t *testing.T) {
+	t.Parallel()
+	_, err := iamRolePolicyEnricher{}.EnrichByID(context.Background(),
+		&imported.ResourceIdentity{ImportID: "r:p"}, EnrichClients{})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestIAMRolePolicyParts(t *testing.T) {
+	t.Parallel()
+	t.Run("NativeIDs win", func(t *testing.T) {
+		t.Parallel()
+		role, policy, err := iamRolePolicyParts(&imported.ResourceIdentity{
+			NativeIDs: map[string]string{"role_name": "nr", "policy_name": "np"},
+			ImportID:  "ir:ip",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "nr", role)
+		assert.Equal(t, "np", policy)
+	})
+	t.Run("ImportID fallback", func(t *testing.T) {
+		t.Parallel()
+		role, policy, err := iamRolePolicyParts(&imported.ResourceIdentity{ImportID: "my-role:my-policy"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-role", role)
+		assert.Equal(t, "my-policy", policy)
+	})
+	t.Run("malformed ImportID is an error", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := iamRolePolicyParts(&imported.ResourceIdentity{ImportID: "no-colon"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot resolve")
+	})
+	t.Run("ImportID with an empty half is an error", func(t *testing.T) {
+		t.Parallel()
+		for _, bad := range []string{":policy", "role:"} {
+			_, _, err := iamRolePolicyParts(&imported.ResourceIdentity{ImportID: bad})
+			require.Errorf(t, err, "ImportID %q must not resolve", bad)
+		}
+	})
+	t.Run("nil identity", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := iamRolePolicyParts(nil)
+		require.Error(t, err)
+	})
+}
+
+func TestFetchIAMRolePolicyWithClient(t *testing.T) {
+	t.Parallel()
+	t.Run("happy path decodes document and passes args", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeIAMRolePolicyAPI{out: &iam.GetRolePolicyOutput{
+			RoleName:       aws.String("r"),
+			PolicyName:     aws.String("p"),
+			PolicyDocument: aws.String(url.QueryEscape(samplePolicyDocument)),
+		}}
+		data, err := fetchIAMRolePolicyWithClient(context.Background(), f, "r", "p")
+		require.NoError(t, err)
+		assert.Equal(t, "r", f.gotRole)
+		assert.Equal(t, "p", f.gotPolicy)
+		assert.JSONEq(t, samplePolicyDocument, data.Document)
+		assert.Equal(t, "r", data.RoleName)
+		assert.Equal(t, "p", data.PolicyName)
+	})
+	t.Run("falls back to request args when response omits names", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeIAMRolePolicyAPI{out: &iam.GetRolePolicyOutput{
+			PolicyDocument: aws.String(samplePolicyDocument),
+		}}
+		data, err := fetchIAMRolePolicyWithClient(context.Background(), f, "req-role", "req-policy")
+		require.NoError(t, err)
+		assert.Equal(t, "req-role", data.RoleName)
+		assert.Equal(t, "req-policy", data.PolicyName)
+	})
+	t.Run("error is wrapped", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeIAMRolePolicyAPI{err: errors.New("boom")}
+		_, err := fetchIAMRolePolicyWithClient(context.Background(), f, "r", "p")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "iam:GetRolePolicy")
+	})
+}
+
+func TestMapIAMRolePolicy(t *testing.T) {
+	t.Parallel()
+	t.Run("nil input", func(t *testing.T) {
+		t.Parallel()
+		got := mapIAMRolePolicy(nil)
+		require.NotNil(t, got)
+		assert.Nil(t, got.Policy)
+	})
+	t.Run("empty document omits policy", func(t *testing.T) {
+		t.Parallel()
+		got := mapIAMRolePolicy(&iamRolePolicyData{RoleName: "r", PolicyName: "p", Document: ""})
+		assert.Nil(t, got.Policy)
+		require.NotNil(t, got.ID)
+		assert.Equal(t, "r:p", *got.ID.Literal)
+	})
+	t.Run("id omitted when a name is missing", func(t *testing.T) {
+		t.Parallel()
+		got := mapIAMRolePolicy(&iamRolePolicyData{RoleName: "r", Document: samplePolicyDocument})
+		assert.Nil(t, got.ID)
+	})
+}
+
+func TestIAMRolePolicyEnricher_RegisteredAsOverride(t *testing.T) {
+	t.Parallel()
+	d := NewAWSDiscoverer(aws.Config{Region: "us-east-1"})
+	enr, ok := d.byTypeEnricher["aws_iam_role_policy"]
+	require.True(t, ok)
+	_, isHandRolled := enr.(*iamRolePolicyEnricher)
+	assert.True(t, isHandRolled, "got %T", enr)
+}

--- a/cmd/insideout-import/awsdiscover/lambda_function_enrich.go
+++ b/cmd/insideout-import/awsdiscover/lambda_function_enrich.go
@@ -1,0 +1,222 @@
+// Package awsdiscover — aws_lambda_function code enricher (#661
+// follow-up).
+//
+// Unlike the policy-document enrichers (iam_policy / iam_role /
+// iam_role_policy / s3_bucket_policy), this is NOT a full hand-rolled
+// override. The Cloud Control path already maps the large
+// AWS::Lambda::Function surface (runtime, handler, memory, environment
+// blocks, VPC config, …) well. What it CANNOT recover is the code
+// source: the CFN `Code` property is create-time input, so GetResource
+// returns nothing for `image_uri` / `s3_bucket` / `filename`.
+//
+// **What is and isn't recoverable.** For container-image functions the
+// image URI is readable via lambda:GetFunction → Code.ImageUri, so this
+// enricher recovers `image_uri` + `package_type = "Image"`. For
+// zip-package functions the original `filename` / `s3_bucket` / `s3_key`
+// are genuinely unrecoverable — GetFunction returns only a short-lived
+// presigned download URL (Code.Location), not the operator's source
+// location. Those functions get `package_type = "Zip"` stamped and the
+// composer's un-composable-resource handling (reliable#1694) takes over
+// for the missing code argument.
+//
+// **Composite, not replacement.** lambdaFunctionEnricher wraps the
+// Cloud Control enricher: Enrich delegates the bulk mapping to it, then
+// issues one GetFunction call and patches the code attributes into the
+// resulting payload. Wrapping the already-built CC enricher keeps this
+// in lockstep with any future CC lambda normalizer change.
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// lambdaFunctionTFType is the registered Terraform type for the lambda
+// function enricher.
+const lambdaFunctionTFType = "aws_lambda_function"
+
+// lambdaCodeInfo carries the code attributes lambda:GetFunction can
+// recover. PackageType is "Zip" or "Image"; ImageURI is set only for
+// Image-package functions.
+type lambdaCodeInfo struct {
+	PackageType string
+	ImageURI    string
+}
+
+// lambdaFunctionAPI is the narrow subset of the Lambda API the code
+// enricher's fetch path issues.
+type lambdaFunctionAPI interface {
+	GetFunction(ctx context.Context, in *lambda.GetFunctionInput, opts ...func(*lambda.Options)) (*lambda.GetFunctionOutput, error)
+}
+
+// lambdaFunctionEnricher implements AttributeEnricher and ByIDEnricher,
+// composing the Cloud Control enricher with a GetFunction-sourced code
+// overlay. EnrichByID is always defined; it returns an error at call
+// time when the wrapped inner enricher does not itself implement
+// ByIDEnricher (the production Cloud Control enricher does).
+type lambdaFunctionEnricher struct {
+	// inner is the Cloud Control enricher that does the bulk mapping.
+	inner AttributeEnricher
+	// fetch is overridable for tests. Defaults to a real GetFunction
+	// call against the lambda.Client in EnrichClients.
+	fetch func(ctx context.Context, c *lambda.Client, region, functionName string) (*lambdaCodeInfo, error)
+}
+
+// newLambdaFunctionEnricher wraps inner (the Cloud Control enricher
+// registered for aws_lambda_function) with the code overlay.
+func newLambdaFunctionEnricher(inner AttributeEnricher) *lambdaFunctionEnricher {
+	return &lambdaFunctionEnricher{inner: inner, fetch: defaultLambdaFunctionFetch}
+}
+
+func (lambdaFunctionEnricher) ResourceType() string { return lambdaFunctionTFType }
+
+// Enrich runs the inner Cloud Control enricher, then overlays the code
+// attributes from lambda:GetFunction. A nil EnrichClients.Lambda is
+// tolerated: the CC payload still lands and only the code overlay is
+// skipped (image_uri is best-effort, not load-bearing for the schema).
+// A GetFunction failure is likewise non-fatal — the CC payload is kept
+// and the overlay skipped — because the resource is already enriched.
+func (e lambdaFunctionEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if err := e.inner.Enrich(ctx, ir, c); err != nil {
+		return err
+	}
+	patched, err := e.overlayCode(ctx, &ir.Identity, ir.Attrs, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = patched
+	return nil
+}
+
+// EnrichByID delegates to the inner enricher's ByIDEnricher
+// implementation (the Cloud Control enricher satisfies it), then
+// overlays the code attributes. If the inner enricher does not
+// implement ByIDEnricher the call returns an error rather than
+// silently producing an un-overlaid payload.
+func (e lambdaFunctionEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, errors.New(lambdaFunctionTFType + ": identity is nil")
+	}
+	byID, ok := e.inner.(ByIDEnricher)
+	if !ok {
+		return nil, fmt.Errorf("%s: inner enricher %T does not support EnrichByID", lambdaFunctionTFType, e.inner)
+	}
+	raw, err := byID.EnrichByID(ctx, identity, c)
+	if err != nil {
+		return nil, err
+	}
+	return e.overlayCode(ctx, identity, raw, c)
+}
+
+// overlayCode patches the GetFunction-sourced code attributes into
+// attrs. It is a no-op (returns attrs unchanged) when the Lambda client
+// is unavailable, when attrs is empty, or when GetFunction fails — the
+// overlay is best-effort and must never discard the CC payload.
+func (e lambdaFunctionEnricher) overlayCode(ctx context.Context, id *imported.ResourceIdentity, attrs json.RawMessage, c EnrichClients) (json.RawMessage, error) {
+	if c.Lambda == nil || len(attrs) == 0 {
+		return attrs, nil
+	}
+	name := lambdaFunctionNameForEnrich(id)
+	if name == "" {
+		return attrs, nil
+	}
+	info, err := e.fetch(ctx, c.Lambda, id.Region, name)
+	if err != nil {
+		// Best-effort: a GetFunction failure leaves the CC payload
+		// intact. ErrNotFound here would be surprising (the CC enricher
+		// already resolved the function) so it is treated like any
+		// other transient failure — skipped, not propagated.
+		return attrs, nil
+	}
+	if info == nil {
+		return attrs, nil
+	}
+	return patchLambdaCodeAttrs(attrs, info)
+}
+
+// lambdaFunctionNameForEnrich derives the FunctionName argument for
+// GetFunction. lambda:GetFunction accepts the bare name, the full ARN,
+// or a partial ARN; the Cloud Control discoverer's passthroughImportID
+// emits the function name as the import ID.
+func lambdaFunctionNameForEnrich(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if s := strings.TrimSpace(id.ImportID); s != "" {
+		return s
+	}
+	return strings.TrimSpace(id.NameHint)
+}
+
+// defaultLambdaFunctionFetch is the production fetch path: it wires the
+// real *lambda.Client into fetchLambdaFunctionWithClient, applying the
+// per-call region override (Lambda is a regional service).
+func defaultLambdaFunctionFetch(ctx context.Context, c *lambda.Client, region, functionName string) (*lambdaCodeInfo, error) {
+	if c == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	var opts []func(*lambda.Options)
+	if region != "" {
+		opts = append(opts, func(o *lambda.Options) { o.Region = region })
+	}
+	return fetchLambdaFunctionWithClient(ctx, c, functionName, opts...)
+}
+
+// fetchLambdaFunctionWithClient issues the GetFunction call behind the
+// narrow lambdaFunctionAPI interface so the overlay is unit-testable.
+func fetchLambdaFunctionWithClient(ctx context.Context, c lambdaFunctionAPI, functionName string, opts ...func(*lambda.Options)) (*lambdaCodeInfo, error) {
+	out, err := c.GetFunction(ctx, &lambda.GetFunctionInput{FunctionName: aws.String(functionName)}, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("lambda:GetFunction: %w", err)
+	}
+	if out == nil || out.Configuration == nil {
+		return nil, errors.New("lambda:GetFunction: nil configuration in response")
+	}
+	info := &lambdaCodeInfo{PackageType: string(out.Configuration.PackageType)}
+	if out.Code != nil {
+		info.ImageURI = aws.ToString(out.Code.ImageUri)
+	}
+	return info, nil
+}
+
+// patchLambdaCodeAttrs unmarshals the Cloud Control payload back into
+// the typed struct, overlays the code attributes, and re-marshals.
+// Round-trips cleanly because the CC enricher produced attrs by
+// marshaling the same generated.AWSLambdaFunction type.
+//
+// `package_type` is stamped from the authoritative GetFunction value.
+// `image_uri` is set only for Image-package functions with a non-empty
+// URI; zip-package functions get no code argument here (unrecoverable
+// — see the package doc comment).
+func patchLambdaCodeAttrs(attrs json.RawMessage, info *lambdaCodeInfo) (json.RawMessage, error) {
+	var typed generated.AWSLambdaFunction
+	if err := json.Unmarshal(attrs, &typed); err != nil {
+		return nil, fmt.Errorf("%s: unmarshal CC payload for code overlay: %w", lambdaFunctionTFType, err)
+	}
+	if info.PackageType != "" {
+		typed.PackageType = generated.LiteralOf(info.PackageType)
+	}
+	if strings.EqualFold(info.PackageType, "Image") && info.ImageURI != "" {
+		typed.ImageURI = generated.LiteralOf(info.ImageURI)
+	}
+	raw, err := json.Marshal(&typed)
+	if err != nil {
+		return nil, fmt.Errorf("%s: re-marshal code overlay: %w", lambdaFunctionTFType, err)
+	}
+	return raw, nil
+}
+
+// Compile-time assertions.
+var (
+	_ AttributeEnricher = (*lambdaFunctionEnricher)(nil)
+	_ ByIDEnricher      = (*lambdaFunctionEnricher)(nil)
+)

--- a/cmd/insideout-import/awsdiscover/lambda_function_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/lambda_function_enrich_test.go
@@ -1,0 +1,286 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// fakeInnerEnricher is a stand-in for the Cloud Control enricher the
+// lambda composite wraps. It writes a canned payload (or returns a
+// canned error) and optionally satisfies ByIDEnricher.
+type fakeInnerEnricher struct {
+	attrs       json.RawMessage
+	err         error
+	supportByID bool
+}
+
+func (f *fakeInnerEnricher) ResourceType() string { return "aws_lambda_function" }
+
+func (f *fakeInnerEnricher) Enrich(_ context.Context, ir *imported.ImportedResource, _ EnrichClients) error {
+	if f.err != nil {
+		return f.err
+	}
+	ir.Attrs = f.attrs
+	return nil
+}
+
+func (f *fakeInnerEnricher) EnrichByID(_ context.Context, _ *imported.ResourceIdentity, _ EnrichClients) (json.RawMessage, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.attrs, nil
+}
+
+// innerNoByID satisfies AttributeEnricher only (no EnrichByID).
+type innerNoByID struct{ attrs json.RawMessage }
+
+func (innerNoByID) ResourceType() string { return "aws_lambda_function" }
+func (i innerNoByID) Enrich(_ context.Context, ir *imported.ImportedResource, _ EnrichClients) error {
+	ir.Attrs = i.attrs
+	return nil
+}
+
+// fakeLambdaAPI is a lambdaFunctionAPI fake.
+type fakeLambdaAPI struct {
+	out     *lambda.GetFunctionOutput
+	err     error
+	gotName string
+}
+
+func (f *fakeLambdaAPI) GetFunction(_ context.Context, in *lambda.GetFunctionInput, _ ...func(*lambda.Options)) (*lambda.GetFunctionOutput, error) {
+	f.gotName = aws.ToString(in.FunctionName)
+	return f.out, f.err
+}
+
+var _ lambdaFunctionAPI = (*fakeLambdaAPI)(nil)
+
+// ccPayload is a minimal Cloud-Control-shaped aws_lambda_function
+// payload (what the inner enricher would produce).
+func ccPayload(t *testing.T) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(&generated.AWSLambdaFunction{
+		FunctionName: generated.LiteralOf("my-fn"),
+		Role:         generated.LiteralOf("arn:aws:iam::1:role/r"),
+	})
+	require.NoError(t, err)
+	return raw
+}
+
+func TestLambdaFunctionEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "aws_lambda_function", newLambdaFunctionEnricher(&fakeInnerEnricher{}).ResourceType())
+}
+
+func TestLambdaFunctionEnricher_ImagePackagePatched(t *testing.T) {
+	t.Parallel()
+	enr := lambdaFunctionEnricher{
+		inner: &fakeInnerEnricher{attrs: ccPayload(t)},
+		fetch: func(_ context.Context, _ *lambda.Client, _, name string) (*lambdaCodeInfo, error) {
+			assert.Equal(t, "my-fn", name)
+			return &lambdaCodeInfo{PackageType: "Image", ImageURI: "123.dkr.ecr.us-east-1.amazonaws.com/app:latest"}, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "my-fn"}}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{Lambda: &lambda.Client{}}))
+
+	var got generated.AWSLambdaFunction
+	require.NoError(t, json.Unmarshal(ir.Attrs, &got))
+	require.NotNil(t, got.PackageType)
+	assert.Equal(t, "Image", *got.PackageType.Literal)
+	require.NotNil(t, got.ImageURI)
+	assert.Equal(t, "123.dkr.ecr.us-east-1.amazonaws.com/app:latest", *got.ImageURI.Literal)
+	// CC-mapped fields survive the overlay round-trip.
+	require.NotNil(t, got.FunctionName)
+	assert.Equal(t, "my-fn", *got.FunctionName.Literal)
+}
+
+func TestLambdaFunctionEnricher_ZipPackageNoImageURI(t *testing.T) {
+	t.Parallel()
+	enr := lambdaFunctionEnricher{
+		inner: &fakeInnerEnricher{attrs: ccPayload(t)},
+		fetch: func(context.Context, *lambda.Client, string, string) (*lambdaCodeInfo, error) {
+			// A zip function may still report a stale ImageURI-shaped
+			// value; the overlay must NOT set image_uri for Zip.
+			return &lambdaCodeInfo{PackageType: "Zip"}, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "my-fn"}}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{Lambda: &lambda.Client{}}))
+
+	var got generated.AWSLambdaFunction
+	require.NoError(t, json.Unmarshal(ir.Attrs, &got))
+	require.NotNil(t, got.PackageType)
+	assert.Equal(t, "Zip", *got.PackageType.Literal)
+	assert.Nil(t, got.ImageURI, "zip functions must not get image_uri")
+}
+
+func TestLambdaFunctionEnricher_InnerErrorPropagates(t *testing.T) {
+	t.Parallel()
+	want := errors.New("cc boom")
+	fetched := false
+	enr := lambdaFunctionEnricher{
+		inner: &fakeInnerEnricher{err: want},
+		fetch: func(context.Context, *lambda.Client, string, string) (*lambdaCodeInfo, error) {
+			fetched = true
+			return nil, nil
+		},
+	}
+	err := enr.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "my-fn"}},
+		EnrichClients{Lambda: &lambda.Client{}})
+	require.ErrorIs(t, err, want)
+	assert.False(t, fetched, "GetFunction must not run after the inner enricher fails")
+}
+
+func TestLambdaFunctionEnricher_NilLambdaClientKeepsCCPayload(t *testing.T) {
+	t.Parallel()
+	cc := ccPayload(t)
+	enr := lambdaFunctionEnricher{
+		inner: &fakeInnerEnricher{attrs: cc},
+		fetch: func(context.Context, *lambda.Client, string, string) (*lambdaCodeInfo, error) {
+			t.Fatal("fetch must not run when Lambda client is nil")
+			return nil, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "my-fn"}}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{}))
+	assert.JSONEq(t, string(cc), string(ir.Attrs), "CC payload must survive unchanged")
+}
+
+func TestLambdaFunctionEnricher_FetchFailureKeepsCCPayload(t *testing.T) {
+	t.Parallel()
+	cc := ccPayload(t)
+	enr := lambdaFunctionEnricher{
+		inner: &fakeInnerEnricher{attrs: cc},
+		fetch: func(context.Context, *lambda.Client, string, string) (*lambdaCodeInfo, error) {
+			return nil, errors.New("GetFunction throttled")
+		},
+	}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "my-fn"}}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{Lambda: &lambda.Client{}}))
+	assert.JSONEq(t, string(cc), string(ir.Attrs), "a GetFunction failure must not discard the CC payload")
+}
+
+func TestLambdaFunctionEnricher_EnrichByID(t *testing.T) {
+	t.Parallel()
+	enr := lambdaFunctionEnricher{
+		inner: &fakeInnerEnricher{attrs: ccPayload(t), supportByID: true},
+		fetch: func(context.Context, *lambda.Client, string, string) (*lambdaCodeInfo, error) {
+			return &lambdaCodeInfo{PackageType: "Image", ImageURI: "repo/app:v1"}, nil
+		},
+	}
+	raw, err := enr.EnrichByID(context.Background(),
+		&imported.ResourceIdentity{ImportID: "my-fn"}, EnrichClients{Lambda: &lambda.Client{}})
+	require.NoError(t, err)
+	var got generated.AWSLambdaFunction
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.NotNil(t, got.ImageURI)
+	assert.Equal(t, "repo/app:v1", *got.ImageURI.Literal)
+}
+
+func TestLambdaFunctionEnricher_EnrichByID_InnerLacksByID(t *testing.T) {
+	t.Parallel()
+	enr := lambdaFunctionEnricher{inner: innerNoByID{attrs: ccPayload(t)}}
+	_, err := enr.EnrichByID(context.Background(),
+		&imported.ResourceIdentity{ImportID: "my-fn"}, EnrichClients{Lambda: &lambda.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support EnrichByID")
+}
+
+func TestLambdaFunctionEnricher_EnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	enr := lambdaFunctionEnricher{inner: &fakeInnerEnricher{}}
+	_, err := enr.EnrichByID(context.Background(), nil, EnrichClients{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity is nil")
+}
+
+func TestFetchLambdaFunctionWithClient(t *testing.T) {
+	t.Parallel()
+	t.Run("image package", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeLambdaAPI{out: &lambda.GetFunctionOutput{
+			Configuration: &lambdatypes.FunctionConfiguration{PackageType: lambdatypes.PackageTypeImage},
+			Code:          &lambdatypes.FunctionCodeLocation{ImageUri: aws.String("repo/app:v2")},
+		}}
+		info, err := fetchLambdaFunctionWithClient(context.Background(), f, "fn")
+		require.NoError(t, err)
+		assert.Equal(t, "fn", f.gotName)
+		assert.Equal(t, "Image", info.PackageType)
+		assert.Equal(t, "repo/app:v2", info.ImageURI)
+	})
+	t.Run("zip package", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeLambdaAPI{out: &lambda.GetFunctionOutput{
+			Configuration: &lambdatypes.FunctionConfiguration{PackageType: lambdatypes.PackageTypeZip},
+			Code:          &lambdatypes.FunctionCodeLocation{Location: aws.String("https://presigned")},
+		}}
+		info, err := fetchLambdaFunctionWithClient(context.Background(), f, "fn")
+		require.NoError(t, err)
+		assert.Equal(t, "Zip", info.PackageType)
+		assert.Empty(t, info.ImageURI)
+	})
+	t.Run("error is wrapped", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeLambdaAPI{err: errors.New("boom")}
+		_, err := fetchLambdaFunctionWithClient(context.Background(), f, "fn")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "lambda:GetFunction")
+	})
+	t.Run("nil configuration is an error", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeLambdaAPI{out: &lambda.GetFunctionOutput{Configuration: nil}}
+		_, err := fetchLambdaFunctionWithClient(context.Background(), f, "fn")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil configuration")
+	})
+}
+
+func TestPatchLambdaCodeAttrs(t *testing.T) {
+	t.Parallel()
+	t.Run("invalid attrs JSON is an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := patchLambdaCodeAttrs([]byte("not json"), &lambdaCodeInfo{PackageType: "Zip"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unmarshal CC payload")
+	})
+	t.Run("empty package type leaves package_type unset", func(t *testing.T) {
+		t.Parallel()
+		raw, err := patchLambdaCodeAttrs(ccPayload(t), &lambdaCodeInfo{})
+		require.NoError(t, err)
+		var got generated.AWSLambdaFunction
+		require.NoError(t, json.Unmarshal(raw, &got))
+		assert.Nil(t, got.PackageType)
+	})
+}
+
+func TestLambdaFunctionNameForEnrich(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "imp", lambdaFunctionNameForEnrich(&imported.ResourceIdentity{ImportID: "imp", NameHint: "hint"}))
+	assert.Equal(t, "hint", lambdaFunctionNameForEnrich(&imported.ResourceIdentity{NameHint: "hint"}))
+	assert.Equal(t, "", lambdaFunctionNameForEnrich(nil))
+}
+
+func TestLambdaFunctionEnricher_RegisteredAsComposite(t *testing.T) {
+	t.Parallel()
+	d := NewAWSDiscoverer(aws.Config{Region: "us-east-1"})
+	enr, ok := d.byTypeEnricher["aws_lambda_function"]
+	require.True(t, ok)
+	composite, isComposite := enr.(*lambdaFunctionEnricher)
+	require.True(t, isComposite, "got %T", enr)
+	// The composite must wrap the Cloud Control enricher, not nil.
+	require.NotNil(t, composite.inner)
+	_, innerIsCC := composite.inner.(*cloudControlEnricher)
+	assert.True(t, innerIsCC, "inner must be the Cloud Control enricher, got %T", composite.inner)
+}

--- a/cmd/insideout-import/awsdiscover/s3_bucket_policy_enrich.go
+++ b/cmd/insideout-import/awsdiscover/s3_bucket_policy_enrich.go
@@ -1,0 +1,157 @@
+// Package awsdiscover — S3 bucket-policy attribute enricher (#661
+// follow-up).
+//
+// Pairs with the Cloud-Control-routed `aws_s3_bucket_policy` discoverer
+// registered in cloudControlTypeConfigs ("AWS::S3::BucketPolicy").
+//
+// **Why a hand-rolled override**: `aws_s3_bucket_policy.policy` is a
+// REQUIRED JSON-encoded string with the same Cloud-Control read-back
+// gap as aws_iam_policy (#661) — the CFN AWS::S3::BucketPolicy
+// `PolicyDocument` is create-time input, so GetResource leaves the
+// required `policy` argument empty. One s3:GetBucketPolicy call returns
+// the document.
+//
+// Unlike the IAM-family enrichers, s3:GetBucketPolicy returns the
+// document already URL-decoded, so the mapping uses compactPolicyJSON
+// directly rather than decodeIAMPolicyDocument.
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// s3BucketPolicyTFType is the registered Terraform type for the S3
+// bucket-policy enricher.
+const s3BucketPolicyTFType = "aws_s3_bucket_policy"
+
+// s3BucketPolicyEnricher implements both AttributeEnricher and
+// ByIDEnricher for aws_s3_bucket_policy.
+type s3BucketPolicyEnricher struct {
+	// fetch is overridable for tests. Defaults to a real
+	// GetBucketPolicy call against the s3.Client in EnrichClients.
+	fetch func(ctx context.Context, c *s3.Client, bucket string) (*s3.GetBucketPolicyOutput, error)
+}
+
+// newS3BucketPolicyEnricher returns the production-wired enricher.
+func newS3BucketPolicyEnricher() *s3BucketPolicyEnricher {
+	return &s3BucketPolicyEnricher{fetch: defaultS3BucketPolicyFetch}
+}
+
+func (s3BucketPolicyEnricher) ResourceType() string { return s3BucketPolicyTFType }
+
+// Enrich populates ir.Attrs with a typed AWSS3BucketPolicy payload.
+// Returns ErrEnrichClientUnavailable if EnrichClients.S3 is nil,
+// ErrNotFound if the bucket has no policy (or no longer exists), and
+// any other error reflects a real S3 API failure.
+func (e s3BucketPolicyEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if c.S3 == nil {
+		return ErrEnrichClientUnavailable
+	}
+	bucket := s3BucketNameForEnrich(&ir.Identity)
+	if bucket == "" {
+		return fmt.Errorf("%s: cannot derive bucket name from Identity (Address=%q ImportID=%q)",
+			s3BucketPolicyTFType, ir.Identity.Address, ir.Identity.ImportID)
+	}
+	typed, err := e.fetchAndMap(ctx, c.S3, bucket)
+	if err != nil {
+		return err
+	}
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return fmt.Errorf("%s: marshal Attrs: %w", s3BucketPolicyTFType, err)
+	}
+	ir.Attrs = raw
+	return nil
+}
+
+// EnrichByID fetches the typed AWSS3BucketPolicy payload for the bucket
+// named by identity. Shares the SDK call + mapping with Enrich.
+func (e s3BucketPolicyEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if c.S3 == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if identity == nil {
+		return nil, errors.New(s3BucketPolicyTFType + ": identity is nil")
+	}
+	bucket := s3BucketNameForEnrich(identity)
+	if bucket == "" {
+		return nil, fmt.Errorf("%s: cannot derive bucket name from Identity (Address=%q ImportID=%q)",
+			s3BucketPolicyTFType, identity.Address, identity.ImportID)
+	}
+	typed, err := e.fetchAndMap(ctx, c.S3, bucket)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return nil, fmt.Errorf("%s: marshal Attrs: %w", s3BucketPolicyTFType, err)
+	}
+	return raw, nil
+}
+
+// fetchAndMap issues GetBucketPolicy and projects the result.
+// NoSuchBucketPolicy (the bucket exists but carries no policy) and
+// NoSuchBucket (the bucket is gone) both map to ErrNotFound, which
+// EnrichAttributes downgrades to a per-resource warning rather than a
+// batch-fatal error.
+func (e s3BucketPolicyEnricher) fetchAndMap(ctx context.Context, c *s3.Client, bucket string) (*generated.AWSS3BucketPolicy, error) {
+	out, err := e.fetch(ctx, c, bucket)
+	if err != nil {
+		if isS3NotSetError(err, "NoSuchBucketPolicy", "NoSuchBucket") {
+			return nil, fmt.Errorf("%s (bucket=%s): %w", s3BucketPolicyTFType, bucket, ErrNotFound)
+		}
+		return nil, fmt.Errorf("%s: get bucket policy (bucket=%s): %w", s3BucketPolicyTFType, bucket, err)
+	}
+	typed, err := mapS3BucketPolicy(bucket, out)
+	if err != nil {
+		return nil, fmt.Errorf("%s (bucket=%s): %w", s3BucketPolicyTFType, bucket, err)
+	}
+	return typed, nil
+}
+
+// defaultS3BucketPolicyFetch is the production fetch path: a single
+// GetBucketPolicy call.
+func defaultS3BucketPolicyFetch(ctx context.Context, c *s3.Client, bucket string) (*s3.GetBucketPolicyOutput, error) {
+	if c == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	return c.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: aws.String(bucket)})
+}
+
+// mapS3BucketPolicy projects the GetBucketPolicy response into the
+// typed AWSS3BucketPolicy struct. The document is JSON-compacted for a
+// stable `policy` string; a non-JSON document is a hard error (the
+// required `policy` argument must hold valid JSON). The `region`
+// attribute is Computed and intentionally not populated (decision #5).
+func mapS3BucketPolicy(bucket string, out *s3.GetBucketPolicyOutput) (*generated.AWSS3BucketPolicy, error) {
+	typed := &generated.AWSS3BucketPolicy{
+		Bucket: generated.LiteralOf(bucket),
+		ID:     generated.LiteralOf(bucket),
+	}
+	if out == nil {
+		return typed, nil
+	}
+	doc, err := compactPolicyJSON(aws.ToString(out.Policy))
+	if err != nil {
+		return nil, fmt.Errorf("decode policy: %w", err)
+	}
+	if doc != "" {
+		typed.Policy = generated.LiteralOf(doc)
+	}
+	return typed, nil
+}
+
+// Compile-time assertions.
+var (
+	_ AttributeEnricher = (*s3BucketPolicyEnricher)(nil)
+	_ ByIDEnricher      = (*s3BucketPolicyEnricher)(nil)
+)

--- a/cmd/insideout-import/awsdiscover/s3_bucket_policy_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/s3_bucket_policy_enrich_test.go
@@ -1,0 +1,165 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// sampleBucketPolicy is a minimal valid S3 bucket policy.
+const sampleBucketPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Principal":"*","Action":"s3:*","Resource":"arn:aws:s3:::b/*","Condition":{"Bool":{"aws:SecureTransport":"false"}}}]}`
+
+func TestS3BucketPolicyEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "aws_s3_bucket_policy", newS3BucketPolicyEnricher().ResourceType())
+}
+
+func TestS3BucketPolicyEnricher_NilClient(t *testing.T) {
+	t.Parallel()
+	err := s3BucketPolicyEnricher{}.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{NameHint: "b"}}, EnrichClients{})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestS3BucketPolicyEnricher_CannotResolveBucket(t *testing.T) {
+	t.Parallel()
+	err := s3BucketPolicyEnricher{}.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{}}, EnrichClients{S3: &s3.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive bucket name")
+}
+
+func TestS3BucketPolicyEnricher_HappyPath(t *testing.T) {
+	t.Parallel()
+	enr := s3BucketPolicyEnricher{fetch: func(_ context.Context, _ *s3.Client, bucket string) (*s3.GetBucketPolicyOutput, error) {
+		assert.Equal(t, "my-bucket", bucket)
+		return &s3.GetBucketPolicyOutput{Policy: aws.String(sampleBucketPolicy)}, nil
+	}}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{NameHint: "my-bucket"}}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+
+	var got generated.AWSS3BucketPolicy
+	require.NoError(t, json.Unmarshal(ir.Attrs, &got))
+	require.NotNil(t, got.Bucket)
+	assert.Equal(t, "my-bucket", *got.Bucket.Literal)
+	require.NotNil(t, got.ID)
+	assert.Equal(t, "my-bucket", *got.ID.Literal)
+	require.NotNil(t, got.Policy)
+	assert.JSONEq(t, sampleBucketPolicy, *got.Policy.Literal)
+	// region is Computed — not populated (decision #5).
+	assert.Nil(t, got.Region)
+}
+
+func TestS3BucketPolicyEnricher_NoSuchBucketPolicyMapsToNotFound(t *testing.T) {
+	t.Parallel()
+	for _, code := range []string{"NoSuchBucketPolicy", "NoSuchBucket"} {
+		t.Run(code, func(t *testing.T) {
+			t.Parallel()
+			enr := s3BucketPolicyEnricher{fetch: func(context.Context, *s3.Client, string) (*s3.GetBucketPolicyOutput, error) {
+				return nil, &fakeS3SmithyErr{code: code}
+			}}
+			err := enr.Enrich(context.Background(),
+				&imported.ImportedResource{Identity: imported.ResourceIdentity{NameHint: "b"}}, EnrichClients{S3: &s3.Client{}})
+			require.ErrorIs(t, err, ErrNotFound)
+		})
+	}
+}
+
+func TestS3BucketPolicyEnricher_UnexpectedErrorPropagates(t *testing.T) {
+	t.Parallel()
+	// A real s3:GetBucketPolicy AccessDenied arrives as a smithy
+	// APIError. It must NOT be downgraded to ErrNotFound — only the
+	// "no policy / no bucket" codes are. Using the smithy-shaped error
+	// (not a plain errors.New) exercises the code-list discrimination
+	// in isS3NotSetError.
+	want := &fakeS3SmithyErr{code: "AccessDenied"}
+	enr := s3BucketPolicyEnricher{fetch: func(context.Context, *s3.Client, string) (*s3.GetBucketPolicyOutput, error) {
+		return nil, want
+	}}
+	err := enr.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{NameHint: "b"}}, EnrichClients{S3: &s3.Client{}})
+	require.ErrorIs(t, err, want)
+	assert.NotErrorIs(t, err, ErrNotFound)
+}
+
+func TestS3BucketPolicyEnricher_EnrichByID_NilClient(t *testing.T) {
+	t.Parallel()
+	_, err := s3BucketPolicyEnricher{}.EnrichByID(context.Background(),
+		&imported.ResourceIdentity{NameHint: "b"}, EnrichClients{})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestS3BucketPolicyEnricher_InvalidJSONPolicyIsError(t *testing.T) {
+	t.Parallel()
+	enr := s3BucketPolicyEnricher{fetch: func(context.Context, *s3.Client, string) (*s3.GetBucketPolicyOutput, error) {
+		return &s3.GetBucketPolicyOutput{Policy: aws.String("not json")}, nil
+	}}
+	err := enr.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{NameHint: "b"}}, EnrichClients{S3: &s3.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not valid JSON")
+}
+
+func TestS3BucketPolicyEnricher_EnrichByID(t *testing.T) {
+	t.Parallel()
+	enr := s3BucketPolicyEnricher{fetch: func(context.Context, *s3.Client, string) (*s3.GetBucketPolicyOutput, error) {
+		return &s3.GetBucketPolicyOutput{Policy: aws.String(sampleBucketPolicy)}, nil
+	}}
+	raw, err := enr.EnrichByID(context.Background(),
+		&imported.ResourceIdentity{NameHint: "my-bucket"}, EnrichClients{S3: &s3.Client{}})
+	require.NoError(t, err)
+	var got generated.AWSS3BucketPolicy
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.JSONEq(t, sampleBucketPolicy, *got.Policy.Literal)
+}
+
+func TestS3BucketPolicyEnricher_EnrichByID_NilIdentity(t *testing.T) {
+	t.Parallel()
+	_, err := s3BucketPolicyEnricher{}.EnrichByID(context.Background(), nil, EnrichClients{S3: &s3.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity is nil")
+}
+
+func TestMapS3BucketPolicy(t *testing.T) {
+	t.Parallel()
+	t.Run("nil output yields bucket+id only", func(t *testing.T) {
+		t.Parallel()
+		got, err := mapS3BucketPolicy("b", nil)
+		require.NoError(t, err)
+		require.NotNil(t, got.Bucket)
+		assert.Equal(t, "b", *got.Bucket.Literal)
+		assert.Nil(t, got.Policy)
+	})
+	t.Run("empty policy string omits policy field", func(t *testing.T) {
+		t.Parallel()
+		got, err := mapS3BucketPolicy("b", &s3.GetBucketPolicyOutput{Policy: aws.String("")})
+		require.NoError(t, err)
+		assert.Nil(t, got.Policy)
+	})
+	t.Run("policy is JSON-compacted", func(t *testing.T) {
+		t.Parallel()
+		got, err := mapS3BucketPolicy("b", &s3.GetBucketPolicyOutput{
+			Policy: aws.String("{\n  \"Version\": \"2012-10-17\"\n}"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.Policy)
+		assert.Equal(t, `{"Version":"2012-10-17"}`, *got.Policy.Literal)
+	})
+}
+
+func TestS3BucketPolicyEnricher_RegisteredAsOverride(t *testing.T) {
+	t.Parallel()
+	d := NewAWSDiscoverer(aws.Config{Region: "us-east-1"})
+	enr, ok := d.byTypeEnricher["aws_s3_bucket_policy"]
+	require.True(t, ok)
+	_, isHandRolled := enr.(*s3BucketPolicyEnricher)
+	assert.True(t, isHandRolled, "got %T", enr)
+}

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -70,11 +70,10 @@ var resourceTypeFixups = map[string]func(*hclwrite.Block){
 }
 
 // lambdaPlaceholderFile is what we set `filename` to so the block
-// validates without holding actual code. terraform validate doesn't open
-// the file (that happens at apply / build time), so the path can point
-// at a nonexistent file. A neutral, unmistakable name keeps the
-// generated.tf self-documenting.
-const lambdaPlaceholderFile = "lambda_placeholder.zip"
+// validates without holding actual code. It is the shared canonical
+// value — the composer's imported.tf emitter injects the identical
+// placeholder on the SDK-enrich path (see imported.LambdaPlaceholderFilename).
+const lambdaPlaceholderFile = imported.LambdaPlaceholderFilename
 
 // lambdaIgnoreChanges is the set of attributes lifecycle.ignore_changes
 // must cover so a real `terraform apply` against this stack will not try

--- a/pkg/composer/imported/lambda.go
+++ b/pkg/composer/imported/lambda.go
@@ -24,3 +24,26 @@ var LambdaCodeAttrs = []string{
 	"s3_object_version",
 	"source_code_hash",
 }
+
+// LambdaPlaceholderFilename is the value pinned on
+// `aws_lambda_function.filename` for an imported zip-package function
+// whose deployment package cannot be reproduced locally (the code lives
+// in AWS, not on disk, and lambda:GetFunction returns only a short-lived
+// presigned URL — not the operator's original source).
+//
+// The provider's schema rule requires exactly one of filename /
+// image_uri / s3_bucket; an imported zip function has none, so both the
+// genconfig fixup (terraform-driven path) and the composer's imported.tf
+// emitter (SDK-enrich path) inject this placeholder to satisfy the rule.
+// It is always paired with `lifecycle { ignore_changes = LambdaCodeAttrs }`
+// so `terraform apply` never reads the nonexistent file nor re-uploads
+// the placeholder over the live function's real code (#652).
+//
+// terraform validate / plan does not open the file — that happens only
+// at apply/build time, which the ignore_changes pin prevents — so the
+// path may point at a file that does not exist. A neutral, unmistakable
+// name keeps the generated stack self-documenting.
+//
+// Declared here, in the shared IR package, so the genconfig fixup and
+// the composer emitter inject the identical value.
+const LambdaPlaceholderFilename = "lambda_placeholder.zip"

--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -245,6 +245,7 @@ func emitImportedResourceBody(ir imported.ImportedResource) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("decode typed Attrs for %q: %w", ir.Identity.Type, err)
 		}
+		ensureLambdaPlaceholderSource(typed)
 		body, err := generated.MarshalHCL(typed)
 		if err != nil {
 			return nil, fmt.Errorf("marshal typed body for %q: %w", ir.Identity.Type, err)
@@ -383,6 +384,45 @@ func appendImportedLifecycle(body []byte, tfType string) []byte {
 	b.WriteString(strings.Join(attrs, ", "))
 	b.WriteString("]\n}\n")
 	return b.Bytes()
+}
+
+// ensureLambdaPlaceholderSource injects a placeholder `filename` onto an
+// imported aws_lambda_function whose typed payload carries no usable
+// code source.
+//
+// The provider's schema rule requires exactly one of filename /
+// image_uri / s3_bucket. The SDK attribute enricher recovers image_uri
+// for container-image functions (lambda:GetFunction → Code.ImageUri),
+// but a zip-package function's filename / s3_bucket are genuinely
+// unrecoverable from the API — so without this injection the emitted
+// block fails `terraform plan` provider-side validation. The genconfig
+// fixup (fixupLambdaSource) does the equivalent on the terraform-driven
+// path; this is the SDK-enrich-path parity.
+//
+// The placeholder is always paired with the
+// `lifecycle { ignore_changes = LambdaCodeAttrs }` block that
+// appendImportedLifecycle adds for aws_lambda_function, so terraform
+// never reads the nonexistent file nor re-uploads it over the live
+// function's code (#652).
+//
+// A container-image function (package_type == "Image") never gets a
+// placeholder filename — filename and image_uri are mutually exclusive,
+// so injecting one would itself break the plan. A non-pointer / wrong
+// type is a no-op (defensive: only *generated.AWSLambdaFunction is
+// touched).
+func ensureLambdaPlaceholderSource(typed any) {
+	lf, ok := typed.(*generated.AWSLambdaFunction)
+	if !ok {
+		return
+	}
+	if lf.PackageType != nil && lf.PackageType.Literal != nil &&
+		strings.EqualFold(*lf.PackageType.Literal, "Image") {
+		return
+	}
+	if lf.Filename != nil || lf.ImageURI != nil || lf.S3Bucket != nil {
+		return
+	}
+	lf.Filename = generated.LiteralOf(imported.LambdaPlaceholderFilename)
 }
 
 func wrapResourceBlock(tfType, label, providerAlias string, body []byte) []byte {

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -1,6 +1,7 @@
 package composer
 
 import (
+	"encoding/json"
 	"regexp"
 	"sort"
 	"strings"
@@ -156,6 +157,75 @@ func TestEmitImportedTF_LambdaIgnoreChanges(t *testing.T) {
 	want := []string{"filename", "image_uri", "s3_bucket", "s3_key", "s3_object_version", "source_code_hash"}
 	sort.Strings(want)
 	assert.Equal(t, want, got, "ignore_changes must pin exactly the Lambda code-source attributes")
+}
+
+// TestEmitImportedTF_LambdaTypedAttrsInjectsPlaceholderFilename pins the
+// SDK-enrich-path half of #663: a zip-package aws_lambda_function
+// enriched into typed Attrs has no recoverable code source (filename /
+// s3_bucket are unrecoverable from the API). The emitter must inject the
+// placeholder `filename` so the block satisfies the provider's
+// one-of-filename/image_uri/s3_bucket rule — the genconfig fixup does
+// the equivalent on the terraform-driven path.
+func TestEmitImportedTF_LambdaTypedAttrsInjectsPlaceholderFilename(t *testing.T) {
+	t.Parallel()
+	attrs, err := json.Marshal(&generated.AWSLambdaFunction{
+		FunctionName: generated.LiteralOf("fn"),
+		Role:         generated.LiteralOf("arn:aws:iam::123456789012:role/fn"),
+		PackageType:  generated.LiteralOf("Zip"),
+	})
+	require.NoError(t, err)
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.fn",
+			ImportID: "fn",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: attrs,
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+	assert.Truef(t, hasAttr(t, s, "filename", `"lambda_placeholder.zip"`),
+		"zip-package lambda must get a placeholder filename:\n%s", s)
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.Falsef(t, diags.HasErrors(), "imported.tf must parse: %s\n%s", diags.Error(), s)
+	assert.Contains(t, s, "ignore_changes", "placeholder filename must still be pinned under ignore_changes")
+}
+
+// TestEmitImportedTF_LambdaImagePackageNoPlaceholderFilename is the
+// negative: a container-image function carries image_uri (recovered by
+// the enricher) and must NOT get a placeholder filename — filename and
+// image_uri are mutually exclusive, so injecting one would itself break
+// the plan.
+func TestEmitImportedTF_LambdaImagePackageNoPlaceholderFilename(t *testing.T) {
+	t.Parallel()
+	const imageURI = "123456789012.dkr.ecr.us-east-1.amazonaws.com/app:latest"
+	attrs, err := json.Marshal(&generated.AWSLambdaFunction{
+		FunctionName: generated.LiteralOf("fn"),
+		Role:         generated.LiteralOf("arn:aws:iam::123456789012:role/fn"),
+		PackageType:  generated.LiteralOf("Image"),
+		ImageURI:     generated.LiteralOf(imageURI),
+	})
+	require.NoError(t, err)
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_lambda_function",
+			Address:  "aws_lambda_function.fn",
+			ImportID: "fn",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: attrs,
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+	assert.Falsef(t, hasAttr(t, s, "filename", `"lambda_placeholder.zip"`),
+		"image-package lambda must NOT get a placeholder filename:\n%s", s)
+	assert.Truef(t, hasAttr(t, s, "image_uri", `"`+imageURI+`"`),
+		"image-package lambda must keep its image_uri:\n%s", s)
 }
 
 func TestEmitImportedTF_TypedRoutingForAllGCPTypes(t *testing.T) {


### PR DESCRIPTION
## Summary
Follow-up to [#662](https://github.com/luthersystems/insideout-terraform-presets/pull/662). Three more resource types hit the same Cloud Control read-back gap as `aws_iam_policy` — a **required JSON-document argument** the CC `GetResource` path leaves empty because the CFN schema treats the document as create-time input, tripping the composer's `imported_resource_missing_required_attr`.

- **`aws_iam_role`** — hand-rolled enricher reads `assume_role_policy` via `iam:GetRole`.
- **`aws_iam_role_policy`** — hand-rolled enricher reads the inline `policy` via `iam:GetRolePolicy`.
- **`aws_s3_bucket_policy`** — hand-rolled enricher reads `policy` via `s3:GetBucketPolicy`.
- **`aws_lambda_function`** — *composite* enricher: delegates the bulk mapping to the Cloud Control enricher, then overlays `image_uri` / `package_type` from `lambda:GetFunction`.

### Lambda code payload
Zip-package code (`filename` / `s3_bucket`) is genuinely unrecoverable from the API. The provider schema still requires one of `filename` / `image_uri` / `s3_bucket`, so an imported zip lambda would fail `terraform plan` provider-side. Fix: the composer's `imported.tf` emitter now injects a **placeholder `filename`** (`ensureLambdaPlaceholderSource`), paired with the existing `lifecycle { ignore_changes = LambdaCodeAttrs }` block — terraform never reads the placeholder nor re-uploads it over the live code (#652 pattern). This is the SDK-enrich-path parity for the genconfig fixup that already did this on the terraform-driven path.

## Test plan
- [x] `go test ./...` — green; `go vet` (incl. `-tags=integration`) — clean
- [x] **Live e2e** — `TestE2E661_PolicyDocumentEnrichers` provisions real IAM/S3/Lambda resources, runs the enrichers, **composes the result to HCL and runs `terraform plan` against the live account**, then tears down. Ran green against a live account (`141812438321`): all five resource types `plan` with **no errors** (exit 2 = expected non-empty import diff); zero residual resources after teardown.

## Review notes
- /review: no P0/P1/P2 in production code
- qa-professor: PASS — all actionable findings addressed (EnrichByID nil-client parity tests, smithy-shaped error discrimination, edge cases)

Closes #663